### PR TITLE
CBG-1808: convert empty sync function to nil

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -4100,7 +4100,7 @@ func TestEmptyStringJavascriptFunctions(t *testing.T) {
 			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 		),
 	)
-	_ = resp.Body.Close()
+	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
 	// db config put with empty sync func and import filter
@@ -4110,7 +4110,7 @@ func TestEmptyStringJavascriptFunctions(t *testing.T) {
 			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 		),
 	)
-	_ = resp.Body.Close()
+	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
 	// db config post, with empty sync func and import filter
@@ -4120,6 +4120,6 @@ func TestEmptyStringJavascriptFunctions(t *testing.T) {
 			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 		),
 	)
-	_ = resp.Body.Close()
+	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 }

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -4100,7 +4100,7 @@ func TestEmptyStringJavascriptFunctions(t *testing.T) {
 			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 		),
 	)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
 	// db config put with empty sync func and import filter
@@ -4110,7 +4110,7 @@ func TestEmptyStringJavascriptFunctions(t *testing.T) {
 			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 		),
 	)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
 	// db config post, with empty sync func and import filter
@@ -4120,6 +4120,6 @@ func TestEmptyStringJavascriptFunctions(t *testing.T) {
 			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 		),
 	)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 }

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -4093,61 +4093,33 @@ func TestEmptyStringJavascriptFunctions(t *testing.T) {
 		tb.Close()
 	}()
 
+	// db put with empty sync func and import filter
 	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/",
 		fmt.Sprintf(
-			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t, "import_filter": ""}`,
+			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t, "sync": "", "import_filter": ""}`,
 			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 		),
 	)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	respBody, err := ioutil.ReadAll(resp.Body)
-	assert.NoError(t, err)
-	_ = resp.Body.Close()
-	assert.Contains(t, string(respBody), "import filter function cannot be empty string")
-
-	resp = bootstrapAdminRequest(t, http.MethodPut, "/db/",
-		fmt.Sprintf(
-			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t, "sync": ""}`,
-			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
-		),
-	)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	respBody, err = ioutil.ReadAll(resp.Body)
-	assert.NoError(t, err)
-	_ = resp.Body.Close()
-	assert.Contains(t, string(respBody), "sync function cannot be empty string")
-
-	resp = bootstrapAdminRequest(t, http.MethodPut, "/db/",
-		fmt.Sprintf(
-			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,
-			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
-		),
-	)
+	resp.Body.Close()
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
+	// db config put with empty sync func and import filter
 	resp = bootstrapAdminRequest(t, http.MethodPut, "/db/_config",
 		fmt.Sprintf(
 			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t, "sync": "", "import_filter": ""}`,
 			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 		),
 	)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	respBody, err = ioutil.ReadAll(resp.Body)
-	assert.NoError(t, err)
-	_ = resp.Body.Close()
-	assert.Contains(t, string(respBody), "sync function cannot be empty string")
-	assert.Contains(t, string(respBody), "import filter function cannot be empty string")
+	resp.Body.Close()
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
+	// db config post, with empty sync func and import filter
 	resp = bootstrapAdminRequest(t, http.MethodPost, "/db/_config",
 		fmt.Sprintf(
 			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t, "sync": "", "import_filter": ""}`,
 			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 		),
 	)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	respBody, err = ioutil.ReadAll(resp.Body)
-	assert.NoError(t, err)
-	_ = resp.Body.Close()
-	assert.Contains(t, string(respBody), "sync function cannot be empty string")
-	assert.Contains(t, string(respBody), "import filter function cannot be empty string")
+	resp.Body.Close()
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 }

--- a/rest/config.go
+++ b/rest/config.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -625,7 +626,9 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) (errorMessag
 	}
 
 	if dbConfig.Sync != nil {
-		if strings.TrimSpace(*dbConfig.Sync) != "" {
+		var decodedSync string
+		err = json.Unmarshal([]byte(*dbConfig.Sync), &decodedSync)
+		if (err != nil && strings.TrimSpace(*dbConfig.Sync) != "") || (err == nil && strings.TrimSpace(decodedSync) != "") {
 			_, err = sgbucket.NewJSRunner(*dbConfig.Sync)
 			if err != nil {
 				errorMessages = multierror.Append(errorMessages, fmt.Errorf("sync function contains invalid javascript syntax: %v", err))
@@ -640,7 +643,9 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) (errorMessag
 	}
 
 	if dbConfig.ImportFilter != nil {
-		if strings.TrimSpace(*dbConfig.ImportFilter) != "" {
+		var decodedFilter string
+		err = json.Unmarshal([]byte(*dbConfig.ImportFilter), &decodedFilter)
+		if (err != nil && strings.TrimSpace(*dbConfig.ImportFilter) != "") || (err == nil && strings.TrimSpace(decodedFilter) != "") {
 			_, err = sgbucket.NewJSRunner(*dbConfig.ImportFilter)
 			if err != nil {
 				errorMessages = multierror.Append(errorMessages, fmt.Errorf("import filter function contains invalid javascript syntax: %v", err))

--- a/rest/config.go
+++ b/rest/config.go
@@ -12,7 +12,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -626,9 +625,7 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) (errorMessag
 	}
 
 	if dbConfig.Sync != nil {
-		var decodedSync string
-		err = json.Unmarshal([]byte(*dbConfig.Sync), &decodedSync)
-		if (err != nil && strings.TrimSpace(*dbConfig.Sync) != "") || (err == nil && strings.TrimSpace(decodedSync) != "") {
+		if strings.TrimSpace(*dbConfig.Sync) != "" {
 			_, err = sgbucket.NewJSRunner(*dbConfig.Sync)
 			if err != nil {
 				errorMessages = multierror.Append(errorMessages, fmt.Errorf("sync function contains invalid javascript syntax: %v", err))
@@ -636,16 +633,10 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) (errorMessag
 		} else {
 			dbConfig.Sync = nil
 		}
-
-		// if *dbConfig.Sync == "" {
-		// 	errorMessages = multierror.Append(errorMessages, fmt.Errorf("sync function cannot be empty string"))
-		// }
 	}
 
 	if dbConfig.ImportFilter != nil {
-		var decodedFilter string
-		err = json.Unmarshal([]byte(*dbConfig.ImportFilter), &decodedFilter)
-		if (err != nil && strings.TrimSpace(*dbConfig.ImportFilter) != "") || (err == nil && strings.TrimSpace(decodedFilter) != "") {
+		if strings.TrimSpace(*dbConfig.ImportFilter) != "" {
 			_, err = sgbucket.NewJSRunner(*dbConfig.ImportFilter)
 			if err != nil {
 				errorMessages = multierror.Append(errorMessages, fmt.Errorf("import filter function contains invalid javascript syntax: %v", err))
@@ -653,10 +644,6 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) (errorMessag
 		} else {
 			dbConfig.ImportFilter = nil
 		}
-
-		// if *dbConfig.ImportFilter == "" {
-		// 	errorMessages = multierror.Append(errorMessages, fmt.Errorf("import filter function cannot be empty string"))
-		// }
 	}
 
 	return errorMessages

--- a/rest/config.go
+++ b/rest/config.go
@@ -625,25 +625,33 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) (errorMessag
 	}
 
 	if dbConfig.Sync != nil {
-		_, err = sgbucket.NewJSRunner(*dbConfig.Sync)
-		if err != nil {
-			errorMessages = multierror.Append(errorMessages, fmt.Errorf("sync function contains invalid javascript syntax: %v", err))
+		if strings.TrimSpace(*dbConfig.Sync) != "" {
+			_, err = sgbucket.NewJSRunner(*dbConfig.Sync)
+			if err != nil {
+				errorMessages = multierror.Append(errorMessages, fmt.Errorf("sync function contains invalid javascript syntax: %v", err))
+			}
+		} else {
+			dbConfig.Sync = nil
 		}
 
-		if *dbConfig.Sync == "" {
-			errorMessages = multierror.Append(errorMessages, fmt.Errorf("sync function cannot be empty string"))
-		}
+		// if *dbConfig.Sync == "" {
+		// 	errorMessages = multierror.Append(errorMessages, fmt.Errorf("sync function cannot be empty string"))
+		// }
 	}
 
 	if dbConfig.ImportFilter != nil {
-		_, err = sgbucket.NewJSRunner(*dbConfig.ImportFilter)
-		if err != nil {
-			errorMessages = multierror.Append(errorMessages, fmt.Errorf("import filter function contains invalid javascript syntax: %v", err))
+		if strings.TrimSpace(*dbConfig.ImportFilter) != "" {
+			_, err = sgbucket.NewJSRunner(*dbConfig.ImportFilter)
+			if err != nil {
+				errorMessages = multierror.Append(errorMessages, fmt.Errorf("import filter function contains invalid javascript syntax: %v", err))
+			}
+		} else {
+			dbConfig.ImportFilter = nil
 		}
 
-		if *dbConfig.ImportFilter == "" {
-			errorMessages = multierror.Append(errorMessages, fmt.Errorf("import filter function cannot be empty string"))
-		}
+		// if *dbConfig.ImportFilter == "" {
+		// 	errorMessages = multierror.Append(errorMessages, fmt.Errorf("import filter function cannot be empty string"))
+		// }
 	}
 
 	return errorMessages

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2050,34 +2050,60 @@ func TestUseXattrs(t *testing.T) {
 
 func TestInvalidJavascriptFunctions(t *testing.T) {
 	testCases := []struct {
-		Name             string
-		SyncFunction     *string
-		ImportFilter     *string
-		ExpectErrorCount int
+		Name               string
+		SyncFunction       *string
+		ImportFilter       *string
+		ExpectErrorCount   int
+		ExpectSyncFunction *string
+		ExpectImportFilter *string
 	}{
 		{
 			"Both nil",
 			nil,
 			nil,
 			0,
+			nil,
+			nil,
 		},
 		{
 			"Valid Sync Fn No Import",
 			base.StringPtr(`function(){}`),
 			nil,
 			0,
+			base.StringPtr(`function(){}`),
+			nil,
 		},
 		{
 			"Valid Import Fn No Sync",
 			nil,
 			base.StringPtr(`function(){}`),
 			0,
+			nil,
+			base.StringPtr(`function(){}`),
+		},
+		{
+			"Both empty",
+			base.StringPtr(``),
+			base.StringPtr(``),
+			0,
+			nil,
+			nil,
+		},
+		{
+			"Both blank",
+			base.StringPtr(` `),
+			base.StringPtr(` `),
+			0,
+			nil,
+			nil,
 		},
 		{
 			"Invalid Sync Fn No Import",
 			base.StringPtr(`function(){`),
 			nil,
 			1,
+			nil,
+			nil,
 		},
 		{
 			"Invalid Sync Fn No Import #2",
@@ -2086,18 +2112,24 @@ func TestInvalidJavascriptFunctions(t *testing.T) {
 			}`),
 			nil,
 			1,
+			nil,
+			nil,
 		},
 		{
 			"Invalid Import Fn No Sync",
 			nil,
 			base.StringPtr(`function(){`),
 			1,
+			nil,
+			nil,
 		},
 		{
 			"Both invalid",
 			base.StringPtr(`function(){`),
 			base.StringPtr(`function(){`),
 			2,
+			nil,
+			nil,
 		},
 	}
 
@@ -2119,6 +2151,8 @@ func TestInvalidJavascriptFunctions(t *testing.T) {
 
 			if testCase.ExpectErrorCount == 0 {
 				assert.NoError(t, err)
+				assert.Equal(t, testCase.ExpectSyncFunction, dbConfig.Sync)
+				assert.Equal(t, testCase.ExpectImportFilter, dbConfig.ImportFilter)
 			} else {
 				assert.Error(t, err)
 				errorMessages, ok := err.(*multierror.Error)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2098,6 +2098,14 @@ func TestInvalidJavascriptFunctions(t *testing.T) {
 			nil,
 		},
 		{
+			"Both blank encoded",
+			base.StringPtr("\" \""),
+			base.StringPtr("\" \""),
+			0,
+			nil,
+			nil,
+		},
+		{
 			"Invalid Sync Fn No Import",
 			base.StringPtr(`function(){`),
 			nil,

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2098,14 +2098,6 @@ func TestInvalidJavascriptFunctions(t *testing.T) {
 			nil,
 		},
 		{
-			"Both blank encoded",
-			base.StringPtr("\" \""),
-			base.StringPtr("\" \""),
-			0,
-			nil,
-			nil,
-		},
-		{
 			"Invalid Sync Fn No Import",
 			base.StringPtr(`function(){`),
 			nil,

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -319,12 +319,12 @@ func TestImportFilterEndpoint(t *testing.T) {
 			tb.GetName(), base.TestsDisableGSI(),
 		),
 	)
-	_ = resp.Body.Close()
+	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
 	// Ensure we won't fail with an empty import filter
 	resp = bootstrapAdminRequest(t, http.MethodPut, "/db1/_config/import_filter", "")
-	_ = resp.Body.Close()
+	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Add a document
@@ -333,12 +333,12 @@ func TestImportFilterEndpoint(t *testing.T) {
 
 	// Ensure document is imported based on default import filter
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/importDoc1", "")
-	_ = resp.Body.Close()
+	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Modify the import filter to always reject import
 	resp = bootstrapAdminRequest(t, http.MethodPut, "/db1/_config/import_filter", `function(){return false}`)
-	_ = resp.Body.Close()
+	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Add a document
@@ -348,13 +348,13 @@ func TestImportFilterEndpoint(t *testing.T) {
 	// Ensure document is not imported and is rejected based on updated filter
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/importDoc2", "")
 	responseBody, err := ioutil.ReadAll(resp.Body)
-	_ = resp.Body.Close()
+	assert.NoError(t, resp.Body.Close())
 	assert.NoError(t, err)
 	assert.Contains(t, string(responseBody), "Not imported")
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 
 	resp = bootstrapAdminRequest(t, http.MethodDelete, "/db1/_config/import_filter", "")
-	_ = resp.Body.Close()
+	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Add a document
@@ -363,6 +363,6 @@ func TestImportFilterEndpoint(t *testing.T) {
 
 	// Ensure document is imported based on default import filter
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/importDoc3", "")
-	_ = resp.Body.Close()
+	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -321,12 +321,10 @@ func TestImportFilterEndpoint(t *testing.T) {
 	)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
-	// Ensure we cannot set an empty import filter
+	// Ensure we won't fail with an empty import filter
 	resp = bootstrapAdminRequest(t, http.MethodPut, "/db1/_config/import_filter", "")
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	responseBody, err := ioutil.ReadAll(resp.Body)
-	assert.NoError(t, err)
-	assert.Contains(t, string(responseBody), "import filter function cannot be empty string")
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Add a document
 	err = tb.Bucket.Set("importDoc1", 0, []byte("{}"))
@@ -347,7 +345,7 @@ func TestImportFilterEndpoint(t *testing.T) {
 	// Ensure document is not imported and is rejected based on updated filter
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/importDoc2", "")
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
-	responseBody, err = ioutil.ReadAll(resp.Body)
+	responseBody, err := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.Contains(t, string(responseBody), "Not imported")
 

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -319,11 +319,12 @@ func TestImportFilterEndpoint(t *testing.T) {
 			tb.GetName(), base.TestsDisableGSI(),
 		),
 	)
+	_ = resp.Body.Close()
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
 	// Ensure we won't fail with an empty import filter
 	resp = bootstrapAdminRequest(t, http.MethodPut, "/db1/_config/import_filter", "")
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Add a document
@@ -332,10 +333,12 @@ func TestImportFilterEndpoint(t *testing.T) {
 
 	// Ensure document is imported based on default import filter
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/importDoc1", "")
+	_ = resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Modify the import filter to always reject import
 	resp = bootstrapAdminRequest(t, http.MethodPut, "/db1/_config/import_filter", `function(){return false}`)
+	_ = resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Add a document
@@ -344,12 +347,14 @@ func TestImportFilterEndpoint(t *testing.T) {
 
 	// Ensure document is not imported and is rejected based on updated filter
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/importDoc2", "")
-	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	responseBody, err := ioutil.ReadAll(resp.Body)
+	_ = resp.Body.Close()
 	assert.NoError(t, err)
 	assert.Contains(t, string(responseBody), "Not imported")
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 
 	resp = bootstrapAdminRequest(t, http.MethodDelete, "/db1/_config/import_filter", "")
+	_ = resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Add a document
@@ -358,5 +363,6 @@ func TestImportFilterEndpoint(t *testing.T) {
 
 	// Ensure document is imported based on default import filter
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/importDoc3", "")
+	_ = resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }


### PR DESCRIPTION
CBG-1808

- converts sync func to nil if it is empty or blanks
- same for import filter
- done on validateVersion to work legacy or v3 configs
- added check in existing `TestInvalidJavascriptFunctions`

## Integration Test
http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1416/
