### PR TITLE
CBG-1770: Enable TestLogFilePathWritable

### DIFF
--- a/base/logging_config_test.go
+++ b/base/logging_config_test.go
@@ -34,9 +34,6 @@ func TestValidateLogFileOutput(t *testing.T) {
 
 // CBG-1760: Error upfront when the configured logFilePath is not writable
 func TestLogFilePathWritable(t *testing.T) {
-	// FIXME: CBG-1770
-	t.Skip("CBG-1770 Test not working on Jenkins (is it to do with umask in /tmp??)")
-
 	if runtime.GOOS == "windows" {
 		// Cannot make folder inaccessible to writes or make read-only: https://github.com/golang/go/issues/35042
 		t.Skip("Test not compatible with Windows")


### PR DESCRIPTION
CBG-1770

- Removed skip from TestLogFilePathWritable

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1419
