### PR TITLE
CBG-1831: Create TLSRootCAProvider for dcp client

### DIFF
--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -159,11 +159,17 @@ func (dc *DCPClient) initAgent(spec BucketSpec) error {
 		return fmt.Errorf("Unable to start DCP Client - error creating authenticator: %w", authErr)
 	}
 
+	tlsRootCAProvider, err := GoCBCoreTLSRootCAProvider(&spec.TLSSkipVerify, spec.CACertPath)
+	if err != nil {
+		return err
+	}
+
 	// Force poolsize to 1, multiple clients results in DCP naming collision
 	agentConfig.KVConfig.PoolSize = 1
 	agentConfig.BucketName = spec.BucketName
 	agentConfig.DCPConfig.AgentPriority = gocbcore.DcpAgentPriorityLow
 	agentConfig.SecurityConfig.Auth = auth
+	agentConfig.SecurityConfig.TLSRootCAProvider = tlsRootCAProvider
 	agentConfig.UserAgent = "SyncGatewayDCP"
 
 	flags := memd.DcpOpenFlagProducer

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1190,7 +1190,7 @@ func initClusterAgent(clusterAddress, clusterUser, clusterPass, certPath, keyPat
 	}
 
 	if err := <-agentReadyErr; err != nil {
-		if _, ok := err.(x509.UnknownAuthorityError); ok {
+		if _, ok := errors.Unwrap(err).(x509.UnknownAuthorityError); ok {
 			err = fmt.Errorf("%w - Provide a CA cert, or set tls_skip_verify to true in config", err)
 		}
 


### PR DESCRIPTION
CBG-1831

Creates a TLSRootCAProvider and passed in the cert provider to the DCP client agent config.

Added an X509 test to validate this fixed behaviour and also added an unwrap fix to an existing test.

Not running an integration test for this as X509 tests aren't ran on integration anyway. Validated x509 tests locally though.