### PR TITLE
Disable sequence batching for TestOneShotChangesWithExplicitDocIds 

### DIFF
--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -1737,6 +1737,8 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyNone)()
 
+	defer db.SuspendSequenceBatching()()
+
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channels)}`}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()


### PR DESCRIPTION
... due to requiring sequential sequences for changes since value

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1439/
