### PR TITLE
CBG-1819: Add duplicate database check in handleCreateDB prior to loading in-memory

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -76,6 +76,11 @@ func (h *handler) handleCreateDB() error {
 		h.server.lock.Lock()
 		defer h.server.lock.Unlock()
 
+		if _, exists := h.server.databases_[dbName]; exists {
+			return base.HTTPErrorf(http.StatusPreconditionFailed, // what CouchDB returns
+				"Duplicate database name %q", dbName)
+		}
+
 		_, err = h.server._applyConfig(loadedConfig, true)
 		if err != nil {
 			if errors.Is(err, base.ErrAuthError) {


### PR DESCRIPTION
CBG-1819

Checks to see if a database already exists with the given name, and returns the error that Sync Gateway used to return in this case.
The new test also checks that stats aren't reset to zero in this case, as a proxy to determine if the database has been reloaded or not.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1443/

