### PR TITLE
CBG-1547: Fix test race and changes termination during deferred backfill

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -1043,10 +1043,9 @@ func (db *Database) waitForCacheUpdate(terminator chan bool, currentCachedSequen
 		case <-terminator:
 			return true
 		case <-ticker.C:
-			// Continue after ticker completed
-		}
-		if db.changeCache.getChannelCache().GetHighCacheSequence() != currentCachedSequence {
-			return false
+			if db.changeCache.getChannelCache().GetHighCacheSequence() != currentCachedSequence {
+				return false
+			}
 		}
 	}
 	return false

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -3672,6 +3672,7 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "", errorCode, "resp: %s", respBody)
 
+	base.WaitForStat(pullStats.NumPullReplTotalOneShot.Value, 1)
 	// Might need to expect 0 after CBG-1824 depending on fix implementation
 	assert.EqualValues(t, 1, pullStats.NumPullReplActiveOneShot.Value())
 
@@ -3690,6 +3691,7 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "", errorCode, "resp: %s", respBody)
 
+	base.WaitForStat(pullStats.NumPullReplTotalContinuous.Value, 1)
 	assert.EqualValues(t, 1, pullStats.NumPullReplActiveContinuous.Value())
 
 	// Send a second continuous subchanges request, expect an error


### PR DESCRIPTION
CBG-1547

- Removed terminator checking before fetching databases changes
- replaced time.sleep with ticker for waiting for caches changes for optimisation and added terminator check there
- fixed race condition in  test by waiting for stat to update
- moved waiting for caches changes to its own function

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1448/
