### PR TITLE
CBG-1837 Add failOnRollback option to DCP client

### DIFF
--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"sync"
@@ -145,4 +146,105 @@ func TestTerminateDCPFeed(t *testing.T) {
 	log.Printf("Waiting for docs generation goroutine to exit")
 	additionalDocsWg.Wait()
 	log.Printf("additionalDocs wait completed")
+}
+
+// TestDCPClientMultiFeedConsistency tests for DCP rollback between execution of two DCP feeds, based on
+// changes in the vbUUID
+func TestDCPClientMultiFeedConsistency(t *testing.T) {
+
+	if UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
+
+	// create callback
+	mutationCount := uint64(0)
+	vbucketZeroCount := uint64(0)
+	counterCallback := func(event sgbucket.FeedEvent) bool {
+		if bytes.HasPrefix(event.Key, []byte(t.Name())) {
+			atomic.AddUint64(&mutationCount, 1)
+			if event.VbNo == 0 {
+				atomic.AddUint64(&vbucketZeroCount, 1)
+			}
+		}
+		return false
+	}
+
+	store, ok := AsCouchbaseStore(bucket)
+	assert.True(t, ok)
+	feedID := t.Name()
+
+	// Add documents
+	updatedBody := map[string]interface{}{"foo": "bar"}
+	for i := 0; i < 10000; i++ {
+		key := fmt.Sprintf("%s_%d", t.Name(), i)
+		err := bucket.Set(key, 0, updatedBody)
+		assert.NoError(t, err)
+	}
+
+	// Perform first one-shot DCP feed - normal one-shot
+	dcpClientOpts := DCPClientOptions{
+		OneShot:        true,
+		FailOnRollback: true,
+	}
+	dcpClient, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, store)
+	assert.NoError(t, err)
+
+	doneChan, startErr := dcpClient.Start()
+	assert.NoError(t, startErr)
+
+	// Wait for first feed to complete
+	timeout := time.After(3 * time.Second)
+	select {
+	case <-doneChan:
+		mutationCount := atomic.LoadUint64(&mutationCount)
+		assert.Equal(t, uint64(10000), mutationCount)
+	case <-timeout:
+		t.Errorf("timeout waiting for first one-shot feed to complete")
+	}
+
+	// store the number of mutations from vbucket zero for validating rollback on the third feed
+	vbucketZeroExpected := atomic.LoadUint64(&vbucketZeroCount)
+
+	// Perform second one-shot DCP feed - vbUUID mismatch, failOnRollback=true
+	// Retrieve metadata from first DCP feed, and modify vbUUID to simulate rollback on server
+	uuidMismatchMetadata := dcpClient.GetMetadata()
+	uuidMismatchMetadata[0].vbUUID = 1234
+
+	dcpClientOpts = DCPClientOptions{
+		InitialMetadata: uuidMismatchMetadata,
+		FailOnRollback:  true,
+		OneShot:         true,
+	}
+	dcpClient2, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, store)
+	assert.NoError(t, err)
+
+	_, startErr2 := dcpClient2.Start()
+	assert.Error(t, startErr2)
+
+	// Perform a third DCP feed - mismatched vbUUID, failOnRollback=false
+	atomic.StoreUint64(&mutationCount, 0)
+	dcpClientOpts = DCPClientOptions{
+		InitialMetadata: uuidMismatchMetadata,
+		FailOnRollback:  false,
+		OneShot:         true,
+	}
+	dcpClient3, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, store)
+	assert.NoError(t, err)
+
+	doneChan3, startErr3 := dcpClient3.Start()
+	assert.NoError(t, startErr3)
+
+	// Wait for third feed to complete
+	timeout = time.After(3 * time.Second)
+	select {
+	case <-doneChan3:
+		// only vbucket 0 should have rolled back, expect mutation count to be only vbucketZero
+		mutationCount := atomic.LoadUint64(&mutationCount)
+		assert.Equal(t, vbucketZeroExpected, mutationCount)
+	case <-timeout:
+		t.Errorf("timeout waiting for first one-shot feed to complete")
+	}
 }


### PR DESCRIPTION
When failOnRollback is set, DCP client will close with error if rollback is detected.  This includes rollback on startup for mismatched vbUUIDs.

CBG-1837

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1446/
