### PR TITLE
Enable TestImportZeroValueDecimalPlacesScientificNotation after server-side fix

### DIFF
--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1697,9 +1697,6 @@ func TestImportZeroValueDecimalPlaces(t *testing.T) {
 // TestImportZeroValueDecimalPlacesScientificNotation tests that docs containing numbers of the form 0e10 are imported correctly.
 func TestImportZeroValueDecimalPlacesScientificNotation(t *testing.T) {
 
-	// FIXME: Fails because of MB-38034
-	t.Skipf("Fails because of MB-38034")
-
 	SkipImportTestsIfNotEnabled(t)
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport)()


### PR DESCRIPTION
This failing test was written for MB-38034 (via #4509) which was fixed on the server side back in 6.5.1 - enable test for regression purposes.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1450/

