### PR TITLE
CBG-1837: Handle rollback during DCP for attachment cleanup

### DIFF
--- a/base/bucket_xattr.go
+++ b/base/bucket_xattr.go
@@ -166,7 +166,7 @@ func (bucket *CouchbaseBucketGoCB) SubdocGetRaw(k string, subdocKey string) ([]b
 		err = pkgerrors.Wrapf(err, "SubdocGetRaw with key %s and subdocKey %s", UD(k).Redact(), UD(subdocKey).Redact())
 	}
 
-	return rawValue, casOut, nil
+	return rawValue, casOut, err
 }
 
 // Retrieve a document and it's associated named xattr

--- a/base/bucket_xattr.go
+++ b/base/bucket_xattr.go
@@ -146,7 +146,7 @@ func (bucket *CouchbaseBucketGoCB) SubdocGetRaw(k string, subdocKey string) ([]b
 			Execute()
 
 		if lookupErr != nil {
-			isRecoverable := bucket.isRecoverableWriteError(lookupErr)
+			isRecoverable := bucket.isRecoverableReadError(lookupErr)
 			if isRecoverable {
 				return isRecoverable, lookupErr, 0
 			}

--- a/base/bucket_xattr.go
+++ b/base/bucket_xattr.go
@@ -31,8 +31,8 @@ func (bucket *CouchbaseBucketGoCB) GetSubDocRaw(k string, subdocKey string) ([]b
 	return bucket.SubdocGetRaw(k, subdocKey)
 }
 
-func (bucket *CouchbaseBucketGoCB) WriteSubDoc(k string, subdocKey string, value []byte) (uint64, error) {
-	return bucket.SubdocWrite(k, subdocKey, value)
+func (bucket *CouchbaseBucketGoCB) WriteSubDoc(k string, subdocKey string, cas uint64, value []byte) (uint64, error) {
+	return bucket.SubdocWrite(k, subdocKey, cas, value)
 }
 
 func (bucket *CouchbaseBucketGoCB) GetWithXattr(k string, xattrKey string, userXattrKey string, rv interface{}, xv interface{}, uxv interface{}) (cas uint64, err error) {
@@ -112,8 +112,8 @@ func (bucket *CouchbaseBucketGoCB) SubdocGetXattr(k string, xattrKey string, xv 
 	return cas, err
 }
 
-func (bucket *CouchbaseBucketGoCB) SubdocWrite(k string, subdocKey string, value []byte) (uint64, error) {
-	mutateInBuilder := bucket.Bucket.MutateInEx(k, gocb.SubdocDocFlagMkDoc, 0, 0).
+func (bucket *CouchbaseBucketGoCB) SubdocWrite(k string, subdocKey string, cas uint64, value []byte) (uint64, error) {
+	mutateInBuilder := bucket.Bucket.MutateInEx(k, gocb.SubdocDocFlagMkDoc, gocb.Cas(cas), 0).
 		UpsertEx(subdocKey, value, gocb.SubdocFlagNone)
 	docFragment, err := mutateInBuilder.Execute()
 	if err != nil {

--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -125,6 +125,11 @@ func (c *Collection) SubdocGetRaw(k string, subdocKey string) ([]byte, uint64, e
 			if isRecoverable {
 				return isRecoverable, lookupErr, 0
 			}
+
+			if isKVError(lookupErr, memd.StatusKeyNotFound) {
+				return false, ErrNotFound, 0
+			}
+
 			return false, lookupErr, 0
 		}
 
@@ -141,7 +146,7 @@ func (c *Collection) SubdocGetRaw(k string, subdocKey string) ([]byte, uint64, e
 		err = pkgerrors.Wrapf(err, "SubdocGetRaw with key %s and subdocKey %s", UD(k).Redact(), UD(subdocKey).Redact())
 	}
 
-	return rawValue, casOut, nil
+	return rawValue, casOut, err
 }
 
 func (c *Collection) SubdocWrite(k string, subdocKey string, cas uint64, value []byte) (uint64, error) {

--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -121,7 +121,7 @@ func (c *Collection) SubdocGetRaw(k string, subdocKey string) ([]byte, uint64, e
 
 		res, lookupErr := c.LookupIn(k, ops, &gocb.LookupInOptions{})
 		if lookupErr != nil {
-			isRecoverable := c.isRecoverableWriteError(lookupErr)
+			isRecoverable := c.isRecoverableReadError(lookupErr)
 			if isRecoverable {
 				return isRecoverable, lookupErr, 0
 			}

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -15,7 +15,7 @@ const (
 
 // SubdocXattrStore interface defines the set of operations Sync Gateway uses to manage and interact with xattrs
 type SubdocXattrStore interface {
-	SubdocGetXattr(k string, xattrKey string, xv interface{}) (casOut uint64, err error)
+	SubdocGetXattr(k string, subdocKey string, xv interface{}) (casOut uint64, err error)
 	SubdocGetBodyAndXattr(k string, xattrKey string, userXattrKey string, rv interface{}, xv interface{}, uxv interface{}) (cas uint64, err error)
 	SubdocInsertXattr(k string, xattrKey string, exp uint32, cas uint64, xv interface{}) (casOut uint64, err error)
 	SubdocInsertBodyAndXattr(k string, xattrKey string, exp uint32, v interface{}, xv interface{}) (casOut uint64, err error)
@@ -27,6 +27,8 @@ type SubdocXattrStore interface {
 	SubdocDeleteXattrs(k string, xattrKeys ...string) error
 	SubdocDeleteBodyAndXattr(k string, xattrKey string) error
 	SubdocDeleteBody(k string, xattrKey string, exp uint32, cas uint64) (casOut uint64, err error)
+	SubdocGetRaw(k string, xattrKey string) (value []byte, casOut uint64, err error)
+	WriteSubDoc(k string, subdocKey string, value []byte) (uint64, error)
 	GetSpec() BucketSpec
 	IsSupported(feature sgbucket.DataStoreFeature) bool
 	isRecoverableReadError(err error) bool

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -15,7 +15,7 @@ const (
 
 // SubdocXattrStore interface defines the set of operations Sync Gateway uses to manage and interact with xattrs
 type SubdocXattrStore interface {
-	SubdocGetXattr(k string, subdocKey string, xv interface{}) (casOut uint64, err error)
+	SubdocGetXattr(k string, xattrKey string, xv interface{}) (casOut uint64, err error)
 	SubdocGetBodyAndXattr(k string, xattrKey string, userXattrKey string, rv interface{}, xv interface{}, uxv interface{}) (cas uint64, err error)
 	SubdocInsertXattr(k string, xattrKey string, exp uint32, cas uint64, xv interface{}) (casOut uint64, err error)
 	SubdocInsertBodyAndXattr(k string, xattrKey string, exp uint32, v interface{}, xv interface{}) (casOut uint64, err error)
@@ -27,8 +27,6 @@ type SubdocXattrStore interface {
 	SubdocDeleteXattrs(k string, xattrKeys ...string) error
 	SubdocDeleteBodyAndXattr(k string, xattrKey string) error
 	SubdocDeleteBody(k string, xattrKey string, exp uint32, cas uint64) (casOut uint64, err error)
-	SubdocGetRaw(k string, xattrKey string) (value []byte, casOut uint64, err error)
-	WriteSubDoc(k string, subdocKey string, cas uint64, value []byte) (uint64, error)
 	GetSpec() BucketSpec
 	IsSupported(feature sgbucket.DataStoreFeature) bool
 	isRecoverableReadError(err error) bool

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -28,7 +28,7 @@ type SubdocXattrStore interface {
 	SubdocDeleteBodyAndXattr(k string, xattrKey string) error
 	SubdocDeleteBody(k string, xattrKey string, exp uint32, cas uint64) (casOut uint64, err error)
 	SubdocGetRaw(k string, xattrKey string) (value []byte, casOut uint64, err error)
-	WriteSubDoc(k string, subdocKey string, value []byte) (uint64, error)
+	WriteSubDoc(k string, subdocKey string, cas uint64, value []byte) (uint64, error)
 	GetSpec() BucketSpec
 	IsSupported(feature sgbucket.DataStoreFeature) bool
 	isRecoverableReadError(err error) bool

--- a/base/dcp_client_metadata.go
+++ b/base/dcp_client_metadata.go
@@ -96,3 +96,21 @@ func (md *DCPMetadata) Reset() {
 	md.startSeqNo = 0
 	md.endSeqNo = 0
 }
+
+func GetVBUUIDs(metadata []DCPMetadata) []uint64 {
+	uuids := make([]uint64, 0, len(metadata))
+	for _, meta := range metadata {
+		uuids = append(uuids, uint64(meta.vbUUID))
+	}
+	return uuids
+}
+
+func BuildDCPMetadataSliceFromVBUUIDs(vbUUIDS []uint64) []DCPMetadata {
+	metadata := make([]DCPMetadata, 0, len(vbUUIDS))
+	for _, vbUUID := range vbUUIDS {
+		metadata = append(metadata, DCPMetadata{
+			vbUUID: gocbcore.VbUUID(vbUUID),
+		})
+	}
+	return metadata
+}

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -282,6 +282,14 @@ func (b *LeakyBucket) GetXattr(k string, xattr string, xv interface{}) (cas uint
 	return b.bucket.GetXattr(k, xattr, xv)
 }
 
+func (b *LeakyBucket) GetSubDocRaw(k string, subdocKey string) ([]byte, uint64, error) {
+	return b.bucket.GetSubDocRaw(k, subdocKey)
+}
+
+func (b *LeakyBucket) WriteSubDoc(k string, subdocKey string, value []byte) (uint64, error) {
+	return b.bucket.WriteSubDoc(k, subdocKey, value)
+}
+
 func (b *LeakyBucket) StartTapFeed(args sgbucket.FeedArguments, dbStats *expvar.Map) (sgbucket.MutationFeed, error) {
 
 	if b.config.TapFeedDeDuplication {

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -286,8 +286,8 @@ func (b *LeakyBucket) GetSubDocRaw(k string, subdocKey string) ([]byte, uint64, 
 	return b.bucket.GetSubDocRaw(k, subdocKey)
 }
 
-func (b *LeakyBucket) WriteSubDoc(k string, subdocKey string, value []byte) (uint64, error) {
-	return b.bucket.WriteSubDoc(k, subdocKey, value)
+func (b *LeakyBucket) WriteSubDoc(k string, subdocKey string, cas uint64, value []byte) (uint64, error) {
+	return b.bucket.WriteSubDoc(k, subdocKey, cas, value)
 }
 
 func (b *LeakyBucket) StartTapFeed(args sgbucket.FeedArguments, dbStats *expvar.Map) (sgbucket.MutationFeed, error) {

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -144,6 +144,16 @@ func (b *LoggingBucket) GetXattr(k string, xattr string, xv interface{}) (cas ui
 	return b.bucket.GetXattr(k, xattr, xv)
 }
 
+func (b *LoggingBucket) GetSubDocRaw(k string, subdocKey string) ([]byte, uint64, error) {
+	defer b.log(time.Now(), k, subdocKey)
+	return b.bucket.GetSubDocRaw(k, subdocKey)
+}
+
+func (b *LoggingBucket) WriteSubDoc(k string, subdocKey string, value []byte) (uint64, error) {
+	defer b.log(time.Now(), k, subdocKey)
+	return b.bucket.WriteSubDoc(k, subdocKey, value)
+}
+
 func (b *LoggingBucket) GetDDocs() (map[string]sgbucket.DesignDoc, error) {
 	defer b.log(time.Now())
 	return b.bucket.GetDDocs()

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -149,9 +149,9 @@ func (b *LoggingBucket) GetSubDocRaw(k string, subdocKey string) ([]byte, uint64
 	return b.bucket.GetSubDocRaw(k, subdocKey)
 }
 
-func (b *LoggingBucket) WriteSubDoc(k string, subdocKey string, value []byte) (uint64, error) {
+func (b *LoggingBucket) WriteSubDoc(k string, subdocKey string, cas uint64, value []byte) (uint64, error) {
 	defer b.log(time.Now(), k, subdocKey)
-	return b.bucket.WriteSubDoc(k, subdocKey, value)
+	return b.bucket.WriteSubDoc(k, subdocKey, cas, value)
 }
 
 func (b *LoggingBucket) GetDDocs() (map[string]sgbucket.DesignDoc, error) {

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -15,7 +15,7 @@ import (
 
 const CompactionIDKey = "compactID"
 
-func Mark(db *Database, compactionID string, terminator *base.SafeTerminator, markedAttachmentCount *base.AtomicInt) (int64, []uint64, error) {
+func Mark(db *Database, compactionID string, terminator *base.SafeTerminator, markedAttachmentCount *base.AtomicInt) (count int64, vbUUIDs []uint64, err error) {
 	base.InfofCtx(db.Ctx, base.KeyAll, "Starting first phase of attachment compaction (mark phase) with compactionID: %q", compactionID)
 	compactionLoggingID := "Compaction Mark: " + compactionID
 

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -15,7 +15,7 @@ import (
 
 const CompactionIDKey = "compactID"
 
-func Mark(db *Database, compactionID string, terminator *base.SafeTerminator, markedAttachmentCount *base.AtomicInt) (int64, error) {
+func Mark(db *Database, compactionID string, terminator *base.SafeTerminator, markedAttachmentCount *base.AtomicInt) (int64, []uint64, error) {
 	base.InfofCtx(db.Ctx, base.KeyAll, "Starting first phase of attachment compaction (mark phase) with compactionID: %q", compactionID)
 	compactionLoggingID := "Compaction Mark: " + compactionID
 
@@ -117,24 +117,25 @@ func Mark(db *Database, compactionID string, terminator *base.SafeTerminator, ma
 
 	cbStore, ok := base.AsCouchbaseStore(db.Bucket)
 	if !ok {
-		return 0, fmt.Errorf("bucket is not a Couchbase Store")
+		return 0, nil, fmt.Errorf("bucket is not a Couchbase Store")
 	}
 
 	clientOptions := base.DCPClientOptions{
-		OneShot: true,
+		OneShot:        true,
+		FailOnRollback: true,
 	}
 
 	base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Starting DCP feed for mark phase of attachment compaction", compactionLoggingID)
 	dcpFeedKey := compactionID + "_mark"
 	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, cbStore)
 	if err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 
 	doneChan, err := dcpClient.Start()
 	if err != nil {
 		_ = dcpClient.Close()
-		return 0, err
+		return 0, nil, err
 	}
 
 	select {
@@ -146,10 +147,10 @@ func Mark(db *Database, compactionID string, terminator *base.SafeTerminator, ma
 
 	if markProcessFailureErr != nil {
 		_ = dcpClient.Close()
-		return markedAttachmentCount.Value(), markProcessFailureErr
+		return markedAttachmentCount.Value(), nil, markProcessFailureErr
 	}
 
-	return markedAttachmentCount.Value(), dcpClient.Close()
+	return markedAttachmentCount.Value(), base.GetVBUUIDs(dcpClient.GetMetadata()), dcpClient.Close()
 }
 
 // AttachmentsMetaMap struct is a very minimal struct to unmarshal into when getting attachments from bodies
@@ -258,7 +259,7 @@ func handleAttachments(attachmentKeyMap map[string]string, docKey string, attach
 	}
 }
 
-func Sweep(db *Database, compactionID string, dryRun bool, terminator *base.SafeTerminator, purgedAttachmentCount *base.AtomicInt) (int64, error) {
+func Sweep(db *Database, compactionID string, vbUUIDs []uint64, dryRun bool, terminator *base.SafeTerminator, purgedAttachmentCount *base.AtomicInt) (int64, error) {
 	base.InfofCtx(db.Ctx, base.KeyAll, "Starting second phase of attachment compaction (sweep phase) with compactionID: %q", compactionID)
 	compactionLoggingID := "Compaction Sweep: " + compactionID
 
@@ -325,7 +326,9 @@ func Sweep(db *Database, compactionID string, dryRun bool, terminator *base.Safe
 	}
 
 	clientOptions := base.DCPClientOptions{
-		OneShot: true,
+		OneShot:         true,
+		FailOnRollback:  true,
+		InitialMetadata: base.BuildDCPMetadataSliceFromVBUUIDs(vbUUIDs),
 	}
 
 	base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Starting DCP feed for sweep phase of attachment compaction", compactionLoggingID)
@@ -351,7 +354,7 @@ func Sweep(db *Database, compactionID string, dryRun bool, terminator *base.Safe
 	return purgedAttachmentCount.Value(), dcpClient.Close()
 }
 
-func Cleanup(db *Database, compactionID string, terminator *base.SafeTerminator) error {
+func Cleanup(db *Database, compactionID string, vbUUIDs []uint64, terminator *base.SafeTerminator) error {
 	base.InfofCtx(db.Ctx, base.KeyAll, "Starting third phase of attachment compaction (cleanup phase) with compactionID: %q", compactionID)
 	compactionLoggingID := "Compaction Cleanup: " + compactionID
 
@@ -442,7 +445,9 @@ func Cleanup(db *Database, compactionID string, terminator *base.SafeTerminator)
 	}
 
 	clientOptions := base.DCPClientOptions{
-		OneShot: true,
+		OneShot:         true,
+		FailOnRollback:  true,
+		InitialMetadata: base.BuildDCPMetadataSliceFromVBUUIDs(vbUUIDs),
 	}
 
 	base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Starting DCP feed for cleanup phase of attachment compaction", compactionLoggingID)

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -46,7 +46,7 @@ func TestAttachmentMark(t *testing.T) {
 	attKeys = append(attKeys, createDocWithInBodyAttachment(t, "inBodyDoc", []byte(`{}`), "attForInBodyRef", []byte(`{"val": "inBodyAtt"}`), testDb))
 
 	terminator := base.NewSafeTerminator()
-	attachmentsMarked, err := Mark(testDb, t.Name(), terminator, &base.AtomicInt{})
+	attachmentsMarked, _, err := Mark(testDb, t.Name(), terminator, &base.AtomicInt{})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(13), attachmentsMarked)
 
@@ -102,7 +102,7 @@ func TestAttachmentSweep(t *testing.T) {
 	}
 
 	terminator := base.NewSafeTerminator()
-	purged, err := Sweep(testDb, t.Name(), false, terminator, &base.AtomicInt{})
+	purged, err := Sweep(testDb, t.Name(), nil, false, terminator, &base.AtomicInt{})
 	assert.NoError(t, err)
 
 	assert.Equal(t, int64(11), purged)
@@ -173,7 +173,7 @@ func TestAttachmentCleanup(t *testing.T) {
 	}
 
 	terminator := base.NewSafeTerminator()
-	err := Cleanup(testDb, t.Name(), terminator)
+	err := Cleanup(testDb, t.Name(), nil, terminator)
 	assert.NoError(t, err)
 
 	for _, docID := range singleMarkedAttIDs {
@@ -242,11 +242,11 @@ func TestAttachmentMarkAndSweepAndCleanup(t *testing.T) {
 	}
 
 	terminator := base.NewSafeTerminator()
-	attachmentsMarked, err := Mark(testDb, t.Name(), terminator, &base.AtomicInt{})
+	attachmentsMarked, vbUUIDS, err := Mark(testDb, t.Name(), terminator, &base.AtomicInt{})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(10), attachmentsMarked)
 
-	attachmentsPurged, err := Sweep(testDb, t.Name(), false, terminator, &base.AtomicInt{})
+	attachmentsPurged, err := Sweep(testDb, t.Name(), vbUUIDS, false, terminator, &base.AtomicInt{})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(5), attachmentsPurged)
 
@@ -264,7 +264,7 @@ func TestAttachmentMarkAndSweepAndCleanup(t *testing.T) {
 		}
 	}
 
-	err = Cleanup(testDb, t.Name(), terminator)
+	err = Cleanup(testDb, t.Name(), vbUUIDS, terminator)
 	assert.NoError(t, err)
 
 	for _, attDocKey := range attKeys {

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -9,7 +9,6 @@
 package db
 
 import (
-	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -301,9 +300,7 @@ func (b *BackgroundManager) getStatusFromCluster() ([]byte, error) {
 				// avoid this unmarshal / marshal work from having to happen again, next time GET is called.
 				// If there is an error we can just ignore it as worst case we run this unmarshal / marshal again on
 				// next request
-				_, err := b.clusterAwareOptions.bucket.WriteSubDoc(b.clusterAwareOptions.StatusDocID(), "status", statusCas, status)
-				fmt.Println(err)
-				// _, _ = b.clusterAwareOptions.bucket.WriteCas(b.clusterAwareOptions.StatusDocID()+".status", 0, 0, statusCas, status, sgbucket.Raw)
+				_, _ = b.clusterAwareOptions.bucket.WriteSubDoc(b.clusterAwareOptions.StatusDocID(), "status", statusCas, status)
 			}
 		}
 	}
@@ -410,7 +407,6 @@ func (b *BackgroundManager) UpdateStatusClusterAware() error {
 			return true, err, nil
 		}
 
-		// TODO: Handle two operations occurring here, maybe two retries for each op?
 		_, err = b.clusterAwareOptions.bucket.WriteSubDoc(b.clusterAwareOptions.StatusDocID(), "status", 0, status)
 		if err != nil {
 			return true, err, nil

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -85,7 +85,7 @@ type BackgroundManagerStatus struct {
 type BackgroundManagerProcessI interface {
 	Init(options map[string]interface{}, clusterStatus []byte) error
 	Run(options map[string]interface{}, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error
-	GetProcessStatus(status BackgroundManagerStatus) ([]byte, []byte, error)
+	GetProcessStatus(status BackgroundManagerStatus) (statusOut []byte, meta []byte, err error)
 	ResetStatus()
 }
 

--- a/db/background_mgr_attachment_compaction.go
+++ b/db/background_mgr_attachment_compaction.go
@@ -25,6 +25,7 @@ type AttachmentCompactionManager struct {
 	PurgedAttachments base.AtomicInt
 	CompactID         string
 	Phase             string
+	VBUUIDs           []string
 	dryRun            bool
 	lock              sync.Mutex
 }
@@ -43,7 +44,6 @@ func NewAttachmentCompactionManager(bucket base.Bucket) *BackgroundManager {
 }
 
 func (a *AttachmentCompactionManager) Init(options map[string]interface{}, clusterStatus []byte) error {
-
 	database := options["database"].(*Database)
 	database.DbStats.Database().CompactionAttachmentStartTime.Set(time.Now().UTC().Unix())
 
@@ -65,8 +65,8 @@ func (a *AttachmentCompactionManager) Init(options map[string]interface{}, clust
 	}
 
 	if clusterStatus != nil {
-		var attachmentResponseStatus AttachmentManagerResponse
-		err := base.JSONUnmarshal(clusterStatus, &attachmentResponseStatus)
+		var statusDoc AttachmentManagerStatusDoc
+		err := base.JSONUnmarshal(clusterStatus, &statusDoc)
 
 		reset, ok := options["reset"].(bool)
 		if reset && ok {
@@ -77,14 +77,15 @@ func (a *AttachmentCompactionManager) Init(options map[string]interface{}, clust
 		// If the previous run completed, or there was an error during unmarshalling the status we will start the
 		// process from scratch with a new compaction ID. Otherwise, we should resume with the compact ID, phase and
 		// stats specified in the doc.
-		if attachmentResponseStatus.State == BackgroundProcessStateCompleted || err != nil || (reset && ok) {
+		if statusDoc.State == BackgroundProcessStateCompleted || err != nil || (reset && ok) {
 			return newRunInit()
 		} else {
-			a.CompactID = attachmentResponseStatus.CompactID
-			a.Phase = attachmentResponseStatus.Phase
-			a.dryRun = attachmentResponseStatus.DryRun
-			a.MarkedAttachments.Set(attachmentResponseStatus.MarkedAttachments)
-			a.PurgedAttachments.Set(attachmentResponseStatus.PurgedAttachments)
+			a.CompactID = statusDoc.CompactID
+			a.Phase = statusDoc.Phase
+			a.dryRun = statusDoc.DryRun
+			a.MarkedAttachments.Set(statusDoc.MarkedAttachments)
+			a.PurgedAttachments.Set(statusDoc.PurgedAttachments)
+			a.VBUUIDs = statusDoc.VBUUIDs
 
 			base.Infof(base.KeyAll, "Attachment Compaction: Attempting to resume compaction with compact ID: %q phase %q", a.CompactID, a.Phase)
 		}
@@ -107,6 +108,8 @@ func (a *AttachmentCompactionManager) Run(options map[string]interface{}, persis
 	}
 
 	defer persistClusterStatus()
+
+	a.VBUUIDs = []string{"x", "y", "z"}
 
 	// Need to check the current phase in the event we are resuming - No need to run mark again if we got as far as
 	// cleanup last time...
@@ -156,11 +159,20 @@ type AttachmentManagerResponse struct {
 	DryRun            bool   `json:"dry_run,omitempty"`
 }
 
-func (a *AttachmentCompactionManager) GetProcessStatus(status BackgroundManagerStatus) ([]byte, error) {
+type AttachmentManagerMeta struct {
+	VBUUIDs []string `json:"vbuuids"`
+}
+
+type AttachmentManagerStatusDoc struct {
+	AttachmentManagerResponse `json:"status"`
+	AttachmentManagerMeta     `json:"meta"`
+}
+
+func (a *AttachmentCompactionManager) GetProcessStatus(status BackgroundManagerStatus) ([]byte, []byte, error) {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
-	retStatus := AttachmentManagerResponse{
+	response := AttachmentManagerResponse{
 		BackgroundManagerStatus: status,
 		MarkedAttachments:       a.MarkedAttachments.Value(),
 		PurgedAttachments:       a.PurgedAttachments.Value(),
@@ -169,7 +181,21 @@ func (a *AttachmentCompactionManager) GetProcessStatus(status BackgroundManagerS
 		DryRun:                  a.dryRun,
 	}
 
-	return base.JSONMarshal(retStatus)
+	meta := AttachmentManagerMeta{
+		VBUUIDs: a.VBUUIDs,
+	}
+
+	statusJSON, err := base.JSONMarshal(response)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	metaJSON, err := base.JSONMarshal(meta)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return statusJSON, metaJSON, err
 }
 
 func (a *AttachmentCompactionManager) ResetStatus() {

--- a/db/background_mgr_resync.go
+++ b/db/background_mgr_resync.go
@@ -72,7 +72,7 @@ type ResyncManagerResponse struct {
 	DocsProcessed int `json:"docs_processed"`
 }
 
-func (r *ResyncManager) GetProcessStatus(backgroundManagerStatus BackgroundManagerStatus) ([]byte, error) {
+func (r *ResyncManager) GetProcessStatus(backgroundManagerStatus BackgroundManagerStatus) ([]byte, []byte, error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
@@ -82,5 +82,6 @@ func (r *ResyncManager) GetProcessStatus(backgroundManagerStatus BackgroundManag
 		DocsProcessed:           r.DocsProcessed,
 	}
 
-	return base.JSONMarshal(retStatus)
+	statusJSON, err := base.JSONMarshal(retStatus)
+	return statusJSON, nil, err
 }

--- a/db/background_mgr_tombstone_compaction.go
+++ b/db/background_mgr_tombstone_compaction.go
@@ -60,13 +60,14 @@ type TombstoneManagerResponse struct {
 	DocsPurged int64 `json:"docs_purged"`
 }
 
-func (t *TombstoneCompactionManager) GetProcessStatus(backgroundManagerStatus BackgroundManagerStatus) ([]byte, error) {
+func (t *TombstoneCompactionManager) GetProcessStatus(backgroundManagerStatus BackgroundManagerStatus) ([]byte, []byte, error) {
 	retStatus := TombstoneManagerResponse{
 		BackgroundManagerStatus: backgroundManagerStatus,
 		DocsPurged:              atomic.LoadInt64(&t.PurgedDocCount),
 	}
 
-	return base.JSONMarshal(retStatus)
+	statusJSON, err := base.JSONMarshal(retStatus)
+	return statusJSON, nil, err
 }
 
 func (t *TombstoneCompactionManager) ResetStatus() {

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -40,7 +40,7 @@ licenses/APL2.txt.
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="6db8e07afd1fb977cddc87ff7ff1d16587a4626e"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="CBG-1837"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
@@ -59,7 +59,7 @@ licenses/APL2.txt.
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="de3fe8f77a83ac70786a33e5b69e1d6a4f1e3bc4"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="CBG-1837"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -40,7 +40,7 @@ licenses/APL2.txt.
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="CBG-1837"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="fc018ef7de83003867f1111968f2add63145c39c"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
@@ -59,7 +59,7 @@ licenses/APL2.txt.
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="CBG-1837"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 


### PR DESCRIPTION
CBG-1837

PR aims to utilize the DCP features added in [CBG-1837-DCP](https://github.com/couchbase/sync_gateway/pull/5357). 
Main complication of this is the fact that we have to do this in the resumption case too meaning we need to store the 'metadata' somewhere in the bucket, but without it showing up in a GET status response. 
To do this I opted to 'split' the status document into a status object and a 'meta' object. This results in `GetProcessState` returning two byte slices, one for the status and one for the meta. This makes it fairly extensible, allowing each process to create its own meta if required.
To save these items to the bucket without interfering with each other we have added subdoc operations to perform the write and get.

Written a test to ensure process fails if a vb uuid mismatch occurs.
Other, existing tests should be sufficient to ensure that the splitting out of the status doc doesn't interfere with / break anything else.

## Dependencies (if applicable)
- [x] https://github.com/couchbase/sg-bucket/pull/69
- [x] https://github.com/couchbaselabs/walrus/pull/61
- [x] Bump manifest

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1456/
- [x] `xattrs=false` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1457/