### PR TITLE
Move Sync Function stats from CBLPush stats to database stats

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -245,8 +245,6 @@ type CBLReplicationPushStats struct {
 	DocPushCount        *SgwIntStat `json:"doc_push_count"`
 	ProposeChangeCount  *SgwIntStat `json:"propose_change_count"`
 	ProposeChangeTime   *SgwIntStat `json:"propose_change_time"`
-	SyncFunctionCount   *SgwIntStat `json:"sync_function_count"`
-	SyncFunctionTime    *SgwIntStat `json:"sync_function_time"`
 	WriteProcessingTime *SgwIntStat `json:"write_processing_time"`
 }
 
@@ -280,6 +278,8 @@ type DatabaseStats struct {
 	WarnChannelsPerDocCount       *SgwIntStat `json:"warn_channels_per_doc_count"`
 	WarnGrantsPerDocCount         *SgwIntStat `json:"warn_grants_per_doc_count"`
 	WarnXattrSizeCount            *SgwIntStat `json:"warn_xattr_size_count"`
+	SyncFunctionCount             *SgwIntStat `json:"sync_function_count"`
+	SyncFunctionTime              *SgwIntStat `json:"sync_function_time"`
 
 	// These can be cleaned up in future versions of SGW, implemented as maps to reduce amount of potential risk
 	// prior to Hydrogen release. These are not exported as part of prometheus and only exposed through expvars
@@ -796,8 +796,6 @@ func (d *DbStats) initCBLReplicationPushStats() {
 		DocPushCount:        NewIntStat(SubsystemReplicationPush, "doc_push_count", labelKeys, labelVals, prometheus.GaugeValue, 0),
 		ProposeChangeCount:  NewIntStat(SubsystemReplicationPush, "propose_change_count", labelKeys, labelVals, prometheus.CounterValue, 0),
 		ProposeChangeTime:   NewIntStat(SubsystemReplicationPush, "propose_change_time", labelKeys, labelVals, prometheus.CounterValue, 0),
-		SyncFunctionCount:   NewIntStat(SubsystemReplicationPush, "sync_function_count", labelKeys, labelVals, prometheus.CounterValue, 0),
-		SyncFunctionTime:    NewIntStat(SubsystemReplicationPush, "sync_function_time", labelKeys, labelVals, prometheus.CounterValue, 0),
 		WriteProcessingTime: NewIntStat(SubsystemReplicationPush, "write_processing_time", labelKeys, labelVals, prometheus.GaugeValue, 0),
 	}
 }
@@ -808,8 +806,6 @@ func (d *DbStats) unregisterCBLReplicationPushStats() {
 	prometheus.Unregister(d.CBLReplicationPushStats.DocPushCount)
 	prometheus.Unregister(d.CBLReplicationPushStats.ProposeChangeCount)
 	prometheus.Unregister(d.CBLReplicationPushStats.ProposeChangeTime)
-	prometheus.Unregister(d.CBLReplicationPushStats.SyncFunctionCount)
-	prometheus.Unregister(d.CBLReplicationPushStats.SyncFunctionTime)
 	prometheus.Unregister(d.CBLReplicationPushStats.WriteProcessingTime)
 }
 
@@ -850,6 +846,8 @@ func (d *DbStats) initDatabaseStats() {
 		WarnChannelsPerDocCount:       NewIntStat(SubsystemDatabaseKey, "warn_channels_per_doc_count", labelKeys, labelVals, prometheus.CounterValue, 0),
 		WarnGrantsPerDocCount:         NewIntStat(SubsystemDatabaseKey, "warn_grants_per_doc_count", labelKeys, labelVals, prometheus.CounterValue, 0),
 		WarnXattrSizeCount:            NewIntStat(SubsystemDatabaseKey, "warn_xattr_size_count", labelKeys, labelVals, prometheus.CounterValue, 0),
+		SyncFunctionCount:             NewIntStat(SubsystemDatabaseKey, "sync_function_count", labelKeys, labelVals, prometheus.CounterValue, 0),
+		SyncFunctionTime:              NewIntStat(SubsystemDatabaseKey, "sync_function_time", labelKeys, labelVals, prometheus.CounterValue, 0),
 		ImportFeedMapStats:            &ExpVarMapWrapper{new(expvar.Map).Init()},
 		CacheFeedMapStats:             &ExpVarMapWrapper{new(expvar.Map).Init()},
 	}
@@ -885,6 +883,8 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.WarnChannelsPerDocCount)
 	prometheus.Unregister(d.DatabaseStats.WarnGrantsPerDocCount)
 	prometheus.Unregister(d.DatabaseStats.WarnXattrSizeCount)
+	prometheus.Unregister(d.DatabaseStats.SyncFunctionCount)
+	prometheus.Unregister(d.DatabaseStats.SyncFunctionTime)
 }
 
 func (d *DbStats) Database() *DatabaseStats {

--- a/db/crud.go
+++ b/db/crud.go
@@ -2184,13 +2184,13 @@ func (db *Database) getChannelsAndAccess(doc *Document, body Body, metaMap map[s
 	if db.ChannelMapper != nil {
 		// Call the ChannelMapper:
 		startTime := time.Now()
-		db.DbStats.CBLReplicationPush().SyncFunctionCount.Add(1)
+		db.DbStats.Database().SyncFunctionCount.Add(1)
 
 		var output *channels.ChannelMapperOutput
 		output, err = db.ChannelMapper.MapToChannelsAndAccess(body, oldJson, metaMap,
 			makeUserCtx(db.user))
 
-		db.DbStats.CBLReplicationPush().SyncFunctionTime.Add(time.Since(startTime).Nanoseconds())
+		db.DbStats.Database().SyncFunctionTime.Add(time.Since(startTime).Nanoseconds())
 
 		if err == nil {
 			result = output.Channels

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2428,7 +2428,7 @@ func TestResyncUpdateAllDocChannels(t *testing.T) {
 	_, err = db.UpdateAllDocChannels(false, func(docsProcessed, docsChanged *int) {}, base.NewSafeTerminator())
 	assert.NoError(t, err)
 
-	syncFnCount := int(db.DbStats.CBLReplicationPush().SyncFunctionCount.Value())
+	syncFnCount := int(db.DbStats.Database().SyncFunctionCount.Value())
 	assert.Equal(t, 20, syncFnCount)
 }
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1255,7 +1255,7 @@ func TestDBOfflineSingleResync(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		rt.createDoc(t, fmt.Sprintf("doc%v", i))
 	}
-	assert.Equal(t, int64(1000), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
+	assert.Equal(t, int64(1000), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 
 	log.Printf("Taking DB offline")
 	response := rt.SendAdminRequest("GET", "/db/", "")
@@ -1286,7 +1286,7 @@ func TestDBOfflineSingleResync(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	assert.Equal(t, int64(2000), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
+	assert.Equal(t, int64(2000), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 }
 
 func TestResync(t *testing.T) {
@@ -1366,7 +1366,7 @@ func TestResync(t *testing.T) {
 			})
 			assert.NoError(t, err)
 
-			assert.Equal(t, testCase.expectedSyncFnRuns, int(rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value()))
+			assert.Equal(t, testCase.expectedSyncFnRuns, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
 
 			var queryName string
 			if base.TestsDisableGSI() {
@@ -1547,7 +1547,7 @@ func TestResyncStop(t *testing.T) {
 	}
 
 	err := rt.WaitForCondition(func() bool {
-		return int(rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value()) == 1000
+		return int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()) == 1000
 	})
 	assert.NoError(t, err)
 
@@ -1577,7 +1577,7 @@ func TestResyncStop(t *testing.T) {
 
 	assert.True(t, callbackFired, "expecting callback to be fired")
 
-	syncFnCount := int(rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
+	syncFnCount := int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 	assert.True(t, syncFnCount < 2000, "Expected syncFnCount < 2000 but syncFnCount=%d", syncFnCount)
 }
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5758,7 +5758,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Ensure sync function has ran twice (once for PUT and once for xattr addition)
-	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
+	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 
 	// Get Xattr and ensure channel value set correctly
 	var syncData db.SyncData
@@ -5784,7 +5784,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 
 	assert.Equal(t, syncData.Crc32c, syncData2.Crc32c)
 	assert.Equal(t, syncData.Crc32cUserXattr, syncData2.Crc32cUserXattr)
-	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
+	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
 
 	// Update body but same value and ensure it isn't imported again (crc32 hash should match)
@@ -5802,7 +5802,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 
 	assert.Equal(t, syncData2.Crc32c, syncData3.Crc32c)
 	assert.Equal(t, syncData2.Crc32cUserXattr, syncData3.Crc32cUserXattr)
-	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
+	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
 
 	// Update body and ensure import occurs
@@ -5815,7 +5815,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	assert.Equal(t, int64(3), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
+	assert.Equal(t, int64(3), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 
 	var syncData4 db.SyncData
 	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData4)
@@ -5882,7 +5882,7 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Ensure sync function has been ran on import
-	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
+	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 
 	// Write user xattr
 	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, channelName)
@@ -5899,7 +5899,7 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Ensure sync function has ran on import
-	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
+	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 
 	// Get sync data for doc and ensure user xattr has been used correctly to set channel
 	var syncData db.SyncData
@@ -5922,7 +5922,7 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 
 	assert.Equal(t, syncData.Crc32c, syncData2.Crc32c)
 	assert.Equal(t, syncData.Crc32cUserXattr, syncData2.Crc32cUserXattr)
-	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
+	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 }
 
 func TestUserXattrOnDemandImportWrite(t *testing.T) {
@@ -5984,7 +5984,7 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Ensure sync function has ran on import
-	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
+	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 
 	// Write user xattr
 	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, channelName)
@@ -6001,7 +6001,7 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Ensure sync function has ran on import
-	assert.Equal(t, int64(3), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
+	assert.Equal(t, int64(3), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 
 	subdocXattrStore, ok := base.AsSubdocXattrStore(rt.Bucket())
 	require.True(t, ok)


### PR DESCRIPTION
SyncFunctionCount and SyncFunctionTime stats aren't CBL-specific, move to database.

CBG-1838

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1462/
