### PR TITLE
CBG-1720: added mutex, concurrent calls in test

### DIFF
--- a/base/logger.go
+++ b/base/logger.go
@@ -19,9 +19,13 @@ import (
 )
 
 var flushLogBuffersWaitGroup sync.WaitGroup
+var flushLogMutex sync.Mutex
 
 // FlushLogBuffers will cause all log collation buffers to be flushed to the output before returning.
 func FlushLogBuffers() {
+	flushLogMutex.Lock()
+	defer flushLogMutex.Unlock()
+
 	loggers := []*FileLogger{
 		traceLogger,
 		debugLogger,

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -634,18 +634,16 @@ func TestLogFlush(t *testing.T) {
 			base.FlushLoggerBuffers()
 
 			// Concurrent calls to FlushLogBuffers should not cause data race or wait group reuse issues
-			// Wait for concurrent calls so they don't cause issues with SetupAndValidateLogging of next t.Run
+			// Wait for concurrent calls so they don't cause issues with SetupAndValidateLogging from next t.Run
 			var flushCallsWg = sync.WaitGroup{}
-			for i := 0; i < 5; i++ {
+			for i := 0; i < 10; i++ {
 				flushCallsWg.Add(1)
 				go func() {
+					// Flush collation buffers to ensure the files that will be built do get written
 					base.FlushLogBuffers()
 					flushCallsWg.Done()
 				}()
 			}
-
-			// Flush collation buffers to ensure the files that will be built do get written
-			base.FlushLogBuffers()
 			flushCallsWg.Wait()
 
 			// Check that the expected number of log files are created


### PR DESCRIPTION
CBG-1720

- added Mutex so concurrent calls to FlushLogBuffers do not cause data race or wait group reuse issues.
- added concurrent calls to FlushLogBuffers in the test.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1​46​6/


