### PR TITLE
CBG-1790 Define cbgt index types per config group, use indexParams to retrieve dest implementations

### DIFF
--- a/base/dcp_feed_type.go
+++ b/base/dcp_feed_type.go
@@ -52,6 +52,11 @@ type SGFeedSourceParams struct {
 	DbName string `json:"sg_dbname,omitempty"`
 }
 
+type SGFeedIndexParams struct {
+	// Used to retrieve the dest implementation (importListener))
+	DestKey string `json:"destKey,omitempty"`
+}
+
 // cbgtFeedParams returns marshalled cbgt.DCPFeedParams as string, to be passed as feedparams during cbgt.Manager init.
 // Used to pass basic auth credentials and xattr flag to cbgt.
 func cbgtFeedParams(spec BucketSpec, dbName string) (string, error) {
@@ -63,6 +68,19 @@ func cbgtFeedParams(spec BucketSpec, dbName string) (string, error) {
 	}
 
 	paramBytes, err := JSONMarshal(feedParams)
+	if err != nil {
+		return "", err
+	}
+	return string(paramBytes), nil
+}
+
+// cbgtIndexParams returns marshalled indexParams as string, to be passed as indexParams during cbgt index creation.
+// Used to retrieve the dest implementation for a given feed
+func cbgtIndexParams(destKey string) (string, error) {
+	indexParams := &SGFeedIndexParams{}
+	indexParams.DestKey = destKey
+
+	paramBytes, err := JSONMarshal(indexParams)
 	if err != nil {
 		return "", err
 	}

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -98,6 +98,9 @@ func createCBGTIndex(c *CbgtContext, dbName string, configGroupID string, bucket
 	}
 
 	indexParams, err := cbgtIndexParams(ImportDestKey(dbName))
+	if err != nil {
+		return err
+	}
 
 	vbNo, err := bucket.GetMaxVbno()
 	if err != nil {
@@ -560,6 +563,12 @@ var cbgtDestFactoriesLock sync.Mutex
 
 func StoreDestFactory(destKey string, dest CbgtDestFactoryFunc) {
 	cbgtDestFactoriesLock.Lock()
+	_, ok := cbgtDestFactories[destKey]
+
+	// We don't expect duplicate destKey registration - log a warning if it already exists
+	if ok {
+		Warnf("destKey %s already exists in cbgtDestFactories - new value will replace the existing dest")
+	}
 	cbgtDestFactories[destKey] = dest
 	cbgtDestFactoriesLock.Unlock()
 }

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -37,7 +37,7 @@ type CbgtContext struct {
 
 // StartShardedDCPFeed initializes and starts a CBGT Manager targeting the provided bucket.
 // dbName is used to define a unique path name for local file storage of pindex files
-func StartShardedDCPFeed(dbName string, uuid string, heartbeater Heartbeater, bucket Bucket, spec BucketSpec, numPartitions uint16, cfg cbgt.Cfg) (*CbgtContext, error) {
+func StartShardedDCPFeed(dbName string, configGroup string, uuid string, heartbeater Heartbeater, bucket Bucket, spec BucketSpec, numPartitions uint16, cfg cbgt.Cfg) (*CbgtContext, error) {
 
 	cbgtContext, err := initCBGTManager(bucket, spec, cfg, uuid, dbName)
 	if err != nil {
@@ -50,7 +50,7 @@ func StartShardedDCPFeed(dbName string, uuid string, heartbeater Heartbeater, bu
 	)
 
 	// Start Manager.  Registers this node in the cfg
-	err = cbgtContext.StartManager(dbName, bucket, spec, numPartitions)
+	err = cbgtContext.StartManager(dbName, configGroup, bucket, spec, numPartitions)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func GenerateLegacyIndexName(dbName string) string {
 // to the manager's cbgt cfg.  Nodes that have registered for this indexType with the manager via
 // RegisterPIndexImplType (see importListener.RegisterImportPindexImpl)
 // will receive PIndexImpl callbacks (New, Open) for assigned PIndex to initiate DCP processing.
-func createCBGTIndex(c *CbgtContext, dbName string, bucket Bucket, spec BucketSpec, numPartitions uint16) error {
+func createCBGTIndex(c *CbgtContext, dbName string, configGroupID string, bucket Bucket, spec BucketSpec, numPartitions uint16) error {
 
 	sourceType := SOURCE_GOCOUCHBASE_DCP_SG
 
@@ -96,6 +96,8 @@ func createCBGTIndex(c *CbgtContext, dbName string, bucket Bucket, spec BucketSp
 	if err != nil {
 		return err
 	}
+
+	indexParams, err := cbgtIndexParams(ImportDestKey(dbName))
 
 	vbNo, err := bucket.GetMaxVbno()
 	if err != nil {
@@ -113,10 +115,6 @@ func createCBGTIndex(c *CbgtContext, dbName string, bucket Bucket, spec BucketSp
 		MaxPartitionsPerPIndex: int(partitionsPerPIndex), // num vbuckets per Pindex.  Multiple Pindexes could be assigned per node.
 		NumReplicas:            0,                        // No replicas required for SG sharded feed
 	}
-
-	// TODO: If this isn't well-formed JSON, cbgt emits errors when opening locally persisted pindex files.  Review
-	//       how this can be optimized if we're not actually using it in the indexImpl
-	indexParams := `{"name": "` + dbName + `"}`
 
 	// Required for initial pools request, before BucketDataSourceOptions kick in.
 	// go-couchbase doesn't support handling x509 auth and root ca verification as separate concerns.
@@ -156,7 +154,9 @@ func createCBGTIndex(c *CbgtContext, dbName string, bucket Bucket, spec BucketSp
 		return options
 	})
 
-	indexType := CBGTIndexTypeSyncGatewayImport + dbName
+	// Index types are namespaced by configGroupID to support delete and create of a database targeting the
+	// same bucket in a config group
+	indexType := CBGTIndexTypeSyncGatewayImport + configGroupID
 	err = c.Manager.CreateIndex(
 		sourceType,        // sourceType
 		bucket.GetName(),  // sourceName
@@ -329,7 +329,7 @@ func initCBGTManager(bucket Bucket, spec BucketSpec, cfgSG cbgt.Cfg, dbUUID stri
 }
 
 // StartManager registers this node with cbgt, and the janitor will start feeds on this node.
-func (c *CbgtContext) StartManager(dbName string, bucket Bucket, spec BucketSpec, numPartitions uint16) (err error) {
+func (c *CbgtContext) StartManager(dbName string, configGroup string, bucket Bucket, spec BucketSpec, numPartitions uint16) (err error) {
 
 	// TODO: Clarify the functional difference between registering the manager as 'wanted' vs 'known'.
 	registerType := cbgt.NODE_DEFS_WANTED
@@ -339,7 +339,7 @@ func (c *CbgtContext) StartManager(dbName string, bucket Bucket, spec BucketSpec
 	}
 
 	// Add the index definition for this feed to the cbgt cfg, in case it's not already present.
-	err = createCBGTIndex(c, dbName, bucket, spec, numPartitions)
+	err = createCBGTIndex(c, dbName, configGroup, bucket, spec, numPartitions)
 	if err != nil {
 		if strings.Contains(err.Error(), "an index with the same name already exists") {
 			Infof(KeyCluster, "Duplicate cbgt index detected during index creation (concurrent creation), using existing")
@@ -365,6 +365,11 @@ func (c *CbgtContext) StopHeartbeatListener() {
 
 func (c *CbgtContext) RemoveFeedCredentials(dbName string) {
 	removeCbgtCredentials(dbName)
+}
+
+// Format of dest key for retrieval of import dest from cbgtDestFactories
+func ImportDestKey(dbName string) string {
+	return dbName + "_import"
 }
 
 func initCfgCB(bucket Bucket, spec BucketSpec) (*cbgt.CfgCB, error) {
@@ -543,4 +548,34 @@ func (l *importHeartbeatListener) GetNodes() ([]string, error) {
 
 func (l *importHeartbeatListener) Stop() {
 	close(l.terminator)
+}
+
+// cbgtDestFactories map DCP feed keys (destKey) to a function that will generate cbgt.Dest.  Need to be stored in a
+// global map to avoid races between db creation and db addition to the server context database set
+
+type CbgtDestFactoryFunc = func() (cbgt.Dest, error)
+
+var cbgtDestFactories = make(map[string]CbgtDestFactoryFunc)
+var cbgtDestFactoriesLock sync.Mutex
+
+func StoreDestFactory(destKey string, dest CbgtDestFactoryFunc) {
+	cbgtDestFactoriesLock.Lock()
+	cbgtDestFactories[destKey] = dest
+	cbgtDestFactoriesLock.Unlock()
+}
+
+func FetchDestFactory(destKey string) (CbgtDestFactoryFunc, error) {
+	cbgtDestFactoriesLock.Lock()
+	defer cbgtDestFactoriesLock.Unlock()
+	listener, ok := cbgtDestFactories[destKey]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return listener, nil
+}
+
+func RemoveDestFactory(destKey string) {
+	cbgtDestFactoriesLock.Lock()
+	delete(cbgtDestFactories, destKey)
+	cbgtDestFactoriesLock.Unlock()
 }

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -161,7 +161,8 @@ func TestCBGTIndexCreation(t *testing.T) {
 			require.NoError(t, err)
 
 			// Define index type
-			indexType := CBGTIndexTypeSyncGatewayImport + tc.dbName
+			configGroup := "configGroup" + t.Name()
+			indexType := CBGTIndexTypeSyncGatewayImport + configGroup
 			cbgt.RegisterPIndexImplType(indexType,
 				&cbgt.PIndexImplType{})
 
@@ -219,7 +220,7 @@ func TestCBGTIndexCreation(t *testing.T) {
 			}
 
 			// Create cbgt index via SG handling
-			err = createCBGTIndex(context, tc.dbName, bucket, spec, 16)
+			err = createCBGTIndex(context, tc.dbName, configGroup, bucket, spec, 16)
 			require.NoError(t, err)
 
 			// Verify single index exists, and matches expected naming
@@ -259,7 +260,8 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 	require.NoError(t, err)
 
 	// Define index type
-	indexType := CBGTIndexTypeSyncGatewayImport + testDbName
+	configGroup := "configGroup" + t.Name()
+	indexType := CBGTIndexTypeSyncGatewayImport + configGroup
 	cbgt.RegisterPIndexImplType(indexType,
 		&cbgt.PIndexImplType{})
 
@@ -288,7 +290,7 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 	require.NoError(t, err, "Unable to create legacy-style index")
 
 	// Create cbgt index
-	err = createCBGTIndex(context, testDbName, bucket, spec, 16)
+	err = createCBGTIndex(context, testDbName, configGroup, bucket, spec, 16)
 	require.NoError(t, err)
 
 	// Verify single index created
@@ -297,7 +299,7 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 	assert.Equal(t, 1, len(indexDefsMap))
 
 	// Attempt to recreate index
-	err = createCBGTIndex(context, testDbName, bucket, spec, 16)
+	err = createCBGTIndex(context, testDbName, configGroup, bucket, spec, 16)
 	require.NoError(t, err)
 
 	// Verify single index defined (acts as upsert to existing)
@@ -334,7 +336,8 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 	require.NoError(t, err)
 
 	// Define index type
-	indexType := CBGTIndexTypeSyncGatewayImport + unsafeTestDBName
+	configGroup := "configGroup" + t.Name()
+	indexType := CBGTIndexTypeSyncGatewayImport + configGroup
 	cbgt.RegisterPIndexImplType(indexType,
 		&cbgt.PIndexImplType{})
 
@@ -363,7 +366,7 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 	require.NoError(t, err, "Unable to create legacy-style index")
 
 	// Create cbgt index
-	err = createCBGTIndex(context, unsafeTestDBName, bucket, spec, 16)
+	err = createCBGTIndex(context, unsafeTestDBName, configGroup, bucket, spec, 16)
 	require.NoError(t, err)
 
 	// Verify single index created
@@ -372,7 +375,7 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 	assert.Equal(t, 1, len(indexDefsMap))
 
 	// Attempt to recreate index
-	err = createCBGTIndex(context, unsafeTestDBName, bucket, spec, 16)
+	err = createCBGTIndex(context, unsafeTestDBName, configGroup, bucket, spec, 16)
 	require.NoError(t, err)
 
 	// Verify single index defined (acts as upsert to existing)
@@ -401,7 +404,8 @@ func TestConcurrentCBGTIndexCreation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Define index type for db name
-	indexType := CBGTIndexTypeSyncGatewayImport + testDBName
+	configGroup := "configGroup" + t.Name()
+	indexType := CBGTIndexTypeSyncGatewayImport + configGroup
 	cbgt.RegisterPIndexImplType(indexType,
 		&cbgt.PIndexImplType{})
 
@@ -424,7 +428,7 @@ func TestConcurrentCBGTIndexCreation(t *testing.T) {
 
 			// StartManager starts the manager and creates the index
 			log.Printf("Starting manager for %s", managerUUID)
-			startErr := context.StartManager(testDBName, bucket, spec, DefaultImportPartitions)
+			startErr := context.StartManager(testDBName, configGroup, bucket, spec, DefaultImportPartitions)
 			assert.NoError(t, startErr)
 
 			managerWg.Done()

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -161,9 +161,13 @@ func newTestClusterV2(server string, logger clusterLogFunc) *tbpClusterV2 {
 
 // getCluster makes cluster connection.  Callers must close.
 func getCluster(server string) *gocb.Cluster {
+
+	testClusterTimeout := 10 * time.Second
 	spec := BucketSpec{
-		Server:        server,
-		TLSSkipVerify: true,
+		Server:          server,
+		TLSSkipVerify:   true,
+		BucketOpTimeout: &testClusterTimeout,
+		CouchbaseDriver: TestClusterDriver(),
 	}
 
 	connStr, err := spec.GetGoCBConnString()
@@ -234,7 +238,11 @@ func (c *tbpClusterV2) insertBucket(name string, quotaMB int) error {
 			NumReplicas:  0,
 		},
 	}
-	return cluster.Buckets().CreateBucket(settings, nil)
+
+	options := &gocb.CreateBucketOptions{
+		Timeout: 10 * time.Second,
+	}
+	return cluster.Buckets().CreateBucket(settings, options)
 }
 
 func (c *tbpClusterV2) removeBucket(name string) error {

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -55,8 +55,11 @@ func (il *importListener) StartImportFeed(bucket base.Bucket, dbStats *base.DbSt
 
 	importFeedStatsMap := dbContext.DbStats.Database().ImportFeedMapStats
 
-	// Register cbgt PIndex to support sharded import.
-	il.RegisterImportPindexImpl()
+	// Store the listener in global map for dbname-based retrieval by cbgt prior to index registration
+	base.StoreDestFactory(base.ImportDestKey(il.database.Name), il.NewImportDest)
+
+	// Register cbgt PIndex to support sharded import, if not already defined
+	//il.RegisterImportPindexImpl()
 
 	// Start DCP mutation feed
 	base.Infof(base.KeyDCP, "Starting DCP import feed for bucket: %q ", base.UD(bucket.GetName()))
@@ -67,7 +70,7 @@ func (il *importListener) StartImportFeed(bucket base.Bucket, dbStats *base.DbSt
 		// Non-couchbase bucket or CE, start a non-sharded feed
 		return bucket.StartDCPFeed(feedArgs, il.ProcessFeedEvent, importFeedStatsMap.Map)
 	} else {
-		il.cbgtContext, err = base.StartShardedDCPFeed(dbContext.Name, dbContext.UUID, dbContext.Heartbeater, bucket, cbStore.GetSpec(), dbContext.Options.ImportOptions.ImportPartitions, dbContext.CfgSG)
+		il.cbgtContext, err = base.StartShardedDCPFeed(dbContext.Name, dbContext.Options.GroupID, dbContext.UUID, dbContext.Heartbeater, bucket, cbStore.GetSpec(), dbContext.Options.ImportOptions.ImportPartitions, dbContext.CfgSG)
 		return err
 	}
 
@@ -174,6 +177,9 @@ func (il *importListener) Stop() {
 			// ClosePIndex calls are synchronous, so can stop manager once they've completed
 			il.cbgtContext.Manager.Stop()
 			il.cbgtContext.RemoveFeedCredentials(il.database.Name)
+
+			// Remove entry from global listener directory
+			base.RemoveDestFactory(base.ImportDestKey(il.database.Name))
 
 			// TODO: Shut down the cfg (when cfg supports)
 		}

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -58,9 +58,6 @@ func (il *importListener) StartImportFeed(bucket base.Bucket, dbStats *base.DbSt
 	// Store the listener in global map for dbname-based retrieval by cbgt prior to index registration
 	base.StoreDestFactory(base.ImportDestKey(il.database.Name), il.NewImportDest)
 
-	// Register cbgt PIndex to support sharded import, if not already defined
-	//il.RegisterImportPindexImpl()
-
 	// Start DCP mutation feed
 	base.Infof(base.KeyDCP, "Starting DCP import feed for bucket: %q ", base.UD(bucket.GetName()))
 

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -11,52 +11,68 @@ licenses/APL2.txt.
 package db
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/couchbase/cbgt"
 	"github.com/couchbase/sync_gateway/base"
 )
 
-// init registers the PIndex type definition.  This is invoked by cbgt when a Pindex (collection of
+// RegisterImportPindexImpl registers the PIndex type definition.  This is invoked by cbgt when a Pindex (collection of
 // vbuckets) is assigned to this node.
-func (il *importListener) RegisterImportPindexImpl() {
 
-	// Since RegisterPIndexImplType is a global var, index type needs to be database-scoped to support
-	// running multiple databases.  This avoids requiring a database lookup based in indexParams at PIndex creation
-	// time, which introduces deadlock potential
+func RegisterImportPindexImpl(configGroup string) {
 
-	pIndexType := base.CBGTIndexTypeSyncGatewayImport + il.database.Name
+	// Since RegisterPIndexImplType is a global var without synchronization, index type needs to be
+	// config group scoped.  The associated importListener within the context is retrieved based on the
+	// dbname in the index params
+	pIndexType := base.CBGTIndexTypeSyncGatewayImport + configGroup
 	base.Infof(base.KeyDCP, "Registering PindexImplType for %s", pIndexType)
 	cbgt.RegisterPIndexImplType(pIndexType,
 		&cbgt.PIndexImplType{
-			New:       il.NewImportPIndexImpl,
-			Open:      il.OpenImportPIndexImpl,
-			OpenUsing: il.OpenImportPIndexImplUsing,
+			New:       NewImportPIndexImpl,
+			Open:      OpenImportPIndexImpl,
+			OpenUsing: OpenImportPIndexImplUsing,
 			Description: "general/syncGateway-import " +
 				" - import processing for shared bucket access",
 		})
 }
 
-// NewImportPIndexImpl is called when the node is first added to the cbgt cfg.  On a node restart,
-// OpenImportPindexImpl is called, and indexParams aren't included.
-func (il *importListener) NewImportPIndexImpl(indexType, indexParams, path string, restart func()) (cbgt.PIndexImpl, cbgt.Dest, error) {
+// getListenerForIndex looks up the importListener for the dbName specified in the index params
+func getListenerImportDest(indexParams string) (cbgt.Dest, error) {
 
-	importDest, err := il.NewImportDest()
+	var sgIndexParams base.SGFeedIndexParams
+	err := base.JSONUnmarshal([]byte(indexParams), &sgIndexParams)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling dbname from cbgt index params: %w", err)
+	}
+
+	destFactory, fetchErr := base.FetchDestFactory(sgIndexParams.DestKey)
+	if fetchErr != nil {
+		return nil, fmt.Errorf("error retrieving listener for indexParams %v: %v", indexParams, fetchErr)
+	}
+	return destFactory()
+}
+
+// NewImportPIndexImpl is called when the node is first added to the cbgt cfg.  On a node restart,
+// OpenImportPindexImplUsing is called.
+func NewImportPIndexImpl(indexType, indexParams, path string, restart func()) (cbgt.PIndexImpl, cbgt.Dest, error) {
+	defer base.FatalPanicHandler()
+
+	importDest, err := getListenerImportDest(indexParams)
 	if err != nil {
 		base.Errorf("Error creating NewImportDest during NewImportPIndexImpl: %v", err)
 	}
 	return nil, importDest, err
 }
 
-func (il *importListener) OpenImportPIndexImpl(indexType, path string, restart func()) (cbgt.PIndexImpl, cbgt.Dest, error) {
-
-	importDest, err := il.NewImportDest()
-	if err != nil {
-		base.Errorf("Error creating NewImportDest during OpenImportPIndexImpl: %v", err)
-	}
-	return nil, importDest, err
+func OpenImportPIndexImpl(indexType, path string, restart func()) (cbgt.PIndexImpl, cbgt.Dest, error) {
+	return nil, nil, errors.New("Open PIndexImpl not supported for SG 3.0 databases - must provide index params")
 }
 
-func (il *importListener) OpenImportPIndexImplUsing(indexType, path, indexParams string, restart func()) (cbgt.PIndexImpl, cbgt.Dest, error) {
-	return il.OpenImportPIndexImpl(indexType, path, restart)
+func OpenImportPIndexImplUsing(indexType, path, indexParams string, restart func()) (cbgt.PIndexImpl, cbgt.Dest, error) {
+	importDest, err := getListenerImportDest(indexParams)
+	return nil, importDest, err
 }
 
 // Returns a cbgt.Dest targeting the importListener's ProcessFeedEvent

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -4231,3 +4231,71 @@ func TestGroupIDReplications(t *testing.T) {
 		}
 	}
 }
+
+// CBG-1790: Deleting a database that targets the same bucket as another causes a panic in legacy
+func TestDeleteDatabasePointingAtSameBucket(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() || !base.TestUseXattrs() {
+		t.Skip("This test only works against Couchbase Server with xattrs")
+	}
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	tb := base.GetTestBucket(t)
+	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb})
+	defer rt.Close()
+	resp := rt.SendAdminRequest(http.MethodDelete, "/db/", "")
+	assertStatus(t, resp, http.StatusOK)
+	// Make another database that uses import in-order to trigger the panic instantly instead of having to time.Sleep
+	resp = rt.SendAdminRequest(http.MethodPut, "/db1/", fmt.Sprintf(`{
+		"bucket": "%s",
+		"username": "%s",
+		"password": "%s",
+		"use_views": %t,
+		"num_index_replicas": 0
+	}`, tb.GetName(), base.TestClusterUsername(), base.TestClusterPassword(), base.TestsDisableGSI()))
+}
+
+func TestDeleteDatabasePointingAtSameBucketPersistent(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	// Start SG with no databases in bucket(s)
+	config := bootstrapStartupConfigForTest(t)
+	sc, err := setupServerContext(&config, true)
+	require.NoError(t, err)
+	defer sc.Close()
+	serverErr := make(chan error, 0)
+	go func() {
+		serverErr <- startServer(&config, sc)
+	}()
+	require.NoError(t, sc.waitForRESTAPIs())
+	// Get a test bucket, and use it to create the database.
+	tb := base.GetTestBucket(t)
+	defer func() {
+		fmt.Println("closing test bucket")
+		tb.Close()
+	}()
+
+	dbConfig := `{
+   "bucket": "` + tb.GetName() + `",
+   "name": "%s",
+   "import_docs": true,
+   "enable_shared_bucket_access": ` + strconv.FormatBool(base.TestUseXattrs()) + `,
+   "use_views": ` + strconv.FormatBool(base.TestsDisableGSI()) + `,
+   "num_index_replicas": 0 }`
+
+	resp := bootstrapAdminRequest(t, http.MethodPut, "/db1/", fmt.Sprintf(dbConfig, "db1"))
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	resp = bootstrapAdminRequest(t, http.MethodDelete, "/db1/", "")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Make another database that uses import in-order to trigger the panic instantly instead of having to time.Sleep
+	resp = bootstrapAdminRequest(t, http.MethodPut, "/db2/", fmt.Sprintf(dbConfig, "db2"))
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	// Validate that deleted database is no longer in dest factory set
+	_, fetchDb1DestErr := base.FetchDestFactory(base.ImportDestKey("db1"))
+	assert.Equal(t, base.ErrNotFound, fetchDb1DestErr)
+	_, fetchDb2DestErr := base.FetchDestFactory(base.ImportDestKey("db2"))
+	assert.NoError(t, fetchDb2DestErr)
+}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -765,10 +765,13 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		slowQueryWarningThreshold = time.Duration(*config.SlowQueryWarningThresholdMs) * time.Millisecond
 	}
 
-	groupID := sc.config.Bootstrap.ConfigGroupID
-	if groupID == persistentConfigDefaultGroupID {
-		groupID = ""
+	groupID := ""
+	if sc.config.Bootstrap.ConfigGroupID != persistentConfigDefaultGroupID {
+		groupID = sc.config.Bootstrap.ConfigGroupID
 	}
+
+	// Register the cbgt pindex type for the configGroup
+	db.RegisterImportPindexImpl(groupID)
 
 	contextOptions := db.DatabaseContextOptions{
 		CacheOptions:              &cacheOptions,


### PR DESCRIPTION
CBG-1790

Previously SG defined an cbgt index type definition per db, and the index type definition callbacks referenced that database's import listener directly. This introduces race conditions in cbgt, which expects type definitions to be registered in memory once at process start, and not removed.

An index type for the config group is now created on server context initialization, and databases register indexes of that type. In order for the config group's index callbacks to properly target specific database contexts (specifically the cbgt.Dest implementation that will be working the feed), databases register their dests into a synchronized global map on startup (and remove from the map on database stop). The dest map key is stored with the per-databases cbgt index registration (stored in cbgt's bucket cfg per database).

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1469/
