### PR TITLE
CBG-1715: SkipPrometheusStatsRegistration with GSI enabled duplicate prometheus stats panic fixed

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1872,14 +1872,10 @@ func mockOIDCOptionsWithBadName() *auth.OIDCOptions {
 
 func TestNewDatabaseContextWithOIDCProviderOptionErrors(t *testing.T) {
 	// Enable prometheus stats. Ensures that we recover / cleanup stats if we fail to initialize a DatabaseContext
-	// TODO: Currently disabled this Prometheus check when running with GSI. No idea why it fails but it hits the
-	// duplicate registration panic.
-	if base.TestsDisableGSI() {
-		base.SkipPrometheusStatsRegistration = false
-		defer func() {
-			base.SkipPrometheusStatsRegistration = true
-		}()
-	}
+	base.SkipPrometheusStatsRegistration = false
+	defer func() {
+		base.SkipPrometheusStatsRegistration = true
+	}()
 
 	testBucket := base.GetTestBucket(t)
 	tests := []struct {

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -177,7 +177,7 @@ func emptyAllDocsIndex(ctx context.Context, b base.Bucket, tbp *base.TestBucketP
 	purgedDocCount := 0
 	purgeBody := Body{"_purged": true}
 
-	dbCtx, err := NewDatabaseContext("db", base.NoCloseClone(b), false, DatabaseContextOptions{
+	dbCtx, err := NewDatabaseContext(b.GetName(), base.NoCloseClone(b), false, DatabaseContextOptions{
 		UseViews:    base.TestsDisableGSI(),
 		EnableXattr: base.TestUseXattrs(),
 	})

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -7431,12 +7431,6 @@ func TestRevocationResumeSameRoleAndLowSeqCheck(t *testing.T) {
 }
 
 func TestMetricsHandler(t *testing.T) {
-	// TODO: Currently disabled this Prometheus check when running with GSI. No idea why it fails but it hits the
-	// duplicate registration panic.
-	if !base.TestsDisableGSI() {
-		t.Skip("Temporary error")
-	}
-
 	base.SkipPrometheusStatsRegistration = false
 	defer func() {
 		base.SkipPrometheusStatsRegistration = true


### PR DESCRIPTION
CBG-1715

- Removed skips from tests
- When a database is made to clean the past buckets, the database is called what the bucket name is instead of "db". This avoids duplicate prometheus stats being registered (causing a panic) when `SkipPrometheusStatsRegistration == true`. Also allows the test to use the db name "db" freely without it colliding with the clean up db prometheus stats.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true gsi=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1473
- [x] `^(TestNewDatabaseContextWithOIDCProviderOptionErrors|TestMetricsHandler) count=25 gsi=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1471
