### PR TITLE
CBG-1621: Added WaitForPendingChanges in putNewEditsFalse

### DIFF
--- a/rest/api_test_helpers_test.go
+++ b/rest/api_test_helpers_test.go
@@ -109,6 +109,8 @@ func (rt *RestTester) putNewEditsFalse(docID string, newRevID string, parentRevI
 	require.True(rt.tb, response.Ok)
 	require.NotEmpty(rt.tb, response.Rev)
 
+	require.NoError(rt.tb, rt.WaitForPendingChanges())
+
 	return response
 }
 

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -4705,7 +4705,7 @@ func TestLocalWinsConflictResolution(t *testing.T) {
 			if base.GTestBucketPool.NumUsableBuckets() < 2 {
 				t.Skipf("test requires at least 2 usable test buckets")
 			}
-			defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+			defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 
 			activeRT, remoteRT, remoteURLString, teardown := setupSGRPeers(t)
 			defer teardown()


### PR DESCRIPTION
CBG-1621

Added a wait for changes every time a new document is created (using `putNewEditsFalse`) so the bucket has a chance to cache the changes. 

Issue caused by starting the replication on line 4789 before the remoteRT has had a chance to finish fully storing the new documents that where created. A `WaitForPendingChanges` could have been added on line 4782 instead and had the same effect, but this does no harm and will help avoid other flaky tests in the future.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1481
- [x] `xattrs=true target=^TestLocalWinsConflictResolution count=25` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1475
