### PR TITLE
Increase log level in flaky TestDocEtag (CBG 1734)

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -117,6 +117,8 @@ func TestDocLifecycle(t *testing.T) {
 
 //Validate that Etag header value is surrounded with double quotes, see issue #808
 func TestDocEtag(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAccess)()
+
 	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -117,7 +117,7 @@ func TestDocLifecycle(t *testing.T) {
 
 //Validate that Etag header value is surrounded with double quotes, see issue #808
 func TestDocEtag(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAccess)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()


### PR DESCRIPTION
CBG-1734

- failure seems rare and there is not enough info to try to repro.
- added logging setup to collect more data on next failure.
- set debug level to reduce logging noise.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` (http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1478/)
