### PR TITLE
Include current revID in proposeChanges response when requested

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -621,6 +621,12 @@ func seqStr(seq interface{}) string {
 
 // Handles a "proposeChanges" request, similar to "changes" but in no-conflicts mode
 func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
+
+	includeConflictRev := false
+	if val := rq.Properties[ProposeChangesConflictsIncludeRev]; val != "" {
+		includeConflictRev = val == "true"
+	}
+
 	var changeList [][]interface{}
 	if err := rq.ReadJSONBody(&changeList); err != nil {
 		return err
@@ -647,7 +653,7 @@ func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 		if len(change) > 2 {
 			parentRevID = change[2].(string)
 		}
-		status := bh.db.CheckProposedRev(docID, revID, parentRevID)
+		status, currentRev := bh.db.CheckProposedRev(docID, revID, parentRevID)
 		if status != 0 {
 			// Skip writing trailing zeroes; but if we write a number afterwards we have to catch up
 			if nWritten > 0 {
@@ -656,7 +662,18 @@ func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 			for ; nWritten < i; nWritten++ {
 				output.Write([]byte("0,"))
 			}
-			output.Write([]byte(strconv.FormatInt(int64(status), 10)))
+			if includeConflictRev && status == ProposedRev_Conflict {
+				revEntry := IncludeConflictRevEntry{Status: status, Rev: currentRev}
+				entryBytes, marshalErr := base.JSONMarshal(revEntry)
+				if marshalErr != nil {
+					base.Warnf("Unable to marshal proposeChangesEntry as includeConflictRev - falling back to status-only entry.  Error: %v", marshalErr)
+					output.Write([]byte(strconv.FormatInt(int64(status), 10)))
+				}
+				output.Write(entryBytes)
+
+			} else {
+				output.Write([]byte(strconv.FormatInt(int64(status), 10)))
+			}
 			nWritten++
 		}
 	}

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -86,6 +86,9 @@ const (
 	ChangesResponseDeltas     = "deltas"
 
 	// proposeChanges message properties
+	ProposeChangesConflictsIncludeRev = "conflictIncludesRev"
+
+	// proposeChanges response message properties
 	ProposeChangesResponseDeltas = "deltas"
 
 	// getAttachment message properties
@@ -450,4 +453,9 @@ func (g *getAttachmentParams) docID() string {
 
 func (g *getAttachmentParams) String() string {
 	return fmt.Sprintf("Digest:%v, DocID: %v ", g.digest(), base.UD(g.docID()))
+}
+
+type IncludeConflictRevEntry struct {
+	Status ProposedRevStatus `json:"status"`
+	Rev    string            `json:"rev"`
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -2433,26 +2433,26 @@ const (
 
 // Given a docID/revID to be pushed by a client, check whether it can be added _without conflict_.
 // This is used by the BLIP replication code in "allow_conflicts=false" mode.
-func (db *Database) CheckProposedRev(docid string, revid string, parentRevID string) ProposedRevStatus {
+func (db *Database) CheckProposedRev(docid string, revid string, parentRevID string) (status ProposedRevStatus, currentRev string) {
 	doc, err := db.GetDocument(docid, DocUnmarshalAll)
 	if err != nil {
 		if !base.IsDocNotFoundError(err) {
 			base.WarnfCtx(db.Ctx, "CheckProposedRev(%q) --> %T %v", base.UD(docid), err, err)
-			return ProposedRev_Error
+			return ProposedRev_Error, ""
 		}
 		// Doc doesn't exist locally; adding it is OK (even if it has a history)
-		return ProposedRev_OK
+		return ProposedRev_OK, ""
 	} else if doc.CurrentRev == revid {
 		// Proposed rev already exists here:
-		return ProposedRev_Exists
+		return ProposedRev_Exists, ""
 	} else if doc.CurrentRev == parentRevID {
 		// Proposed rev's parent is my current revision; OK to add:
-		return ProposedRev_OK
+		return ProposedRev_OK, ""
 	} else if parentRevID == "" && doc.History[doc.CurrentRev].Deleted {
 		// Proposed rev has no parent and doc is currently deleted; OK to add:
-		return ProposedRev_OK
+		return ProposedRev_OK, ""
 	} else {
 		// Parent revision mismatch, so this is a conflict:
-		return ProposedRev_Conflict
+		return ProposedRev_Conflict, doc.CurrentRev
 	}
 }

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -639,6 +639,123 @@ func TestProposedChangesNoConflictsMode(t *testing.T) {
 
 }
 
+// Validate SG sends conflicting rev when requested
+func TestProposedChangesIncludeConflictingRev(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+
+	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+		noConflictsMode: true,
+		guestEnabled:    true,
+	})
+	assert.NoError(t, err, "Error creating BlipTester")
+	defer bt.Close()
+
+	// Write existing docs to server directly (not via blip)
+	rt := bt.restTester
+	resp := rt.putDoc("conflictingInsert", `{"version":1}`)
+	conflictingInsertRev := resp.Rev
+
+	resp = rt.putDoc("matchingInsert", `{"version":1}`)
+	matchingInsertRev := resp.Rev
+
+	resp = rt.putDoc("conflictingUpdate", `{"version":1}`)
+	conflictingUpdateRev1 := resp.Rev
+	resp = rt.updateDoc("conflictingUpdate", resp.Rev, `{"version":2}`)
+	conflictingUpdateRev2 := resp.Rev
+
+	resp = rt.putDoc("matchingUpdate", `{"version":1}`)
+	matchingUpdateRev1 := resp.Rev
+	resp = rt.updateDoc("matchingUpdate", resp.Rev, `{"version":2}`)
+	matchingUpdateRev2 := resp.Rev
+
+	resp = rt.putDoc("newUpdate", `{"version":1}`)
+	newUpdateRev1 := resp.Rev
+
+	type proposeChangesCase struct {
+		key           string
+		revID         string
+		parentRevID   string
+		expectedValue interface{}
+	}
+
+	proposeChangesCases := []proposeChangesCase{
+		proposeChangesCase{
+			key:           "conflictingInsert",
+			revID:         "1-abc",
+			parentRevID:   "",
+			expectedValue: map[string]interface{}{"status": float64(db.ProposedRev_Conflict), "rev": conflictingInsertRev},
+		},
+		proposeChangesCase{
+			key:           "newInsert",
+			revID:         "1-abc",
+			parentRevID:   "",
+			expectedValue: float64(db.ProposedRev_OK),
+		},
+		proposeChangesCase{
+			key:           "matchingInsert",
+			revID:         matchingInsertRev,
+			parentRevID:   "",
+			expectedValue: float64(db.ProposedRev_Exists),
+		},
+		proposeChangesCase{
+			key:           "conflictingUpdate",
+			revID:         "2-abc",
+			parentRevID:   conflictingUpdateRev1,
+			expectedValue: map[string]interface{}{"status": float64(db.ProposedRev_Conflict), "rev": conflictingUpdateRev2},
+		},
+		proposeChangesCase{
+			key:           "newUpdate",
+			revID:         "2-abc",
+			parentRevID:   newUpdateRev1,
+			expectedValue: float64(db.ProposedRev_OK),
+		},
+		proposeChangesCase{
+			key:           "matchingUpdate",
+			revID:         matchingUpdateRev2,
+			parentRevID:   matchingUpdateRev1,
+			expectedValue: float64(db.ProposedRev_Exists),
+		},
+	}
+
+	proposeChangesRequest := blip.NewRequest()
+	proposeChangesRequest.SetProfile("proposeChanges")
+	proposeChangesRequest.SetCompressed(true)
+	proposeChangesRequest.Properties[db.ProposeChangesConflictsIncludeRev] = "true"
+
+	// proposedChanges entries are of the form: [docID, revID, parentRevID], where parentRevID is optional
+	proposedChanges := make([][]interface{}, 0)
+	for _, c := range proposeChangesCases {
+		changeEntry := []interface{}{
+			c.key,
+			c.revID,
+		}
+		if c.parentRevID != "" {
+			changeEntry = append(changeEntry, c.parentRevID)
+		}
+		proposedChanges = append(proposedChanges, changeEntry)
+	}
+	proposeChangesBody, marshalErr := json.Marshal(proposedChanges)
+	require.NoError(t, marshalErr)
+
+	proposeChangesRequest.SetBody(proposeChangesBody)
+	sent := bt.sender.Send(proposeChangesRequest)
+	goassert.True(t, sent)
+	proposeChangesResponse := proposeChangesRequest.Response()
+	bodyReader, err := proposeChangesResponse.BodyReader()
+	assert.NoError(t, err, "Error getting changes response body reader")
+
+	var changeList []interface{}
+	decoder := base.JSONDecoder(bodyReader)
+	decodeErr := decoder.Decode(&changeList)
+	require.NoError(t, decodeErr)
+
+	for i, entry := range changeList {
+		assert.Equal(t, proposeChangesCases[i].expectedValue, entry)
+	}
+
+}
+
 // Connect to public port with authentication
 func TestPublicPortAuthentication(t *testing.T) {
 


### PR DESCRIPTION
CBG-1845

For proposeChanges requests that set the property conflictIncludesRev to true, conflicting changes will include the current rev ID in the response, in the format `{“status” : 409, “rev”: “”}`.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1477/
