### PR TITLE
CBG-1824: NumPullReplActiveOneShot decrements on sub changes feed completion

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -222,14 +222,12 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 			bh.replicationStats.SubChangesContinuousTotal.Add(1)
 		} else {
 			bh.replicationStats.SubChangesOneShotActive.Add(1)
+			defer bh.replicationStats.SubChangesOneShotActive.Add(-1)
 			bh.replicationStats.SubChangesOneShotTotal.Add(1)
 		}
 
 		defer func() {
 			bh.activeSubChanges.Set(false)
-			if !bh.continuous {
-				bh.replicationStats.SubChangesOneShotActive.Add(-1)
-			}
 		}()
 		// sendChanges runs until blip context closes, or fails due to error
 		startTime := time.Now()

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -216,7 +216,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 	bh.continuous = continuous
 	// Start asynchronous changes goroutine
 	go func() {
-		// Pull replication stats by type - Active stats decremented in Close()
+		// Pull replication stats by type - Active continuous stats decremented in Close(), one shot after changes sent
 		if bh.continuous {
 			bh.replicationStats.SubChangesContinuousActive.Add(1)
 			bh.replicationStats.SubChangesContinuousTotal.Add(1)
@@ -227,6 +227,9 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 
 		defer func() {
 			bh.activeSubChanges.Set(false)
+			if !bh.continuous {
+				bh.replicationStats.SubChangesOneShotActive.Add(-1)
+			}
 		}()
 		// sendChanges runs until blip context closes, or fails due to error
 		startTime := time.Now()

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -216,7 +216,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 	bh.continuous = continuous
 	// Start asynchronous changes goroutine
 	go func() {
-		// Pull replication stats by type - Active continuous stats decremented in Close(), one shot after changes sent
+		// Pull replication stats by type
 		if bh.continuous {
 			bh.replicationStats.SubChangesContinuousActive.Add(1)
 			defer bh.replicationStats.SubChangesContinuousActive.Add(-1)

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -219,6 +219,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 		// Pull replication stats by type - Active continuous stats decremented in Close(), one shot after changes sent
 		if bh.continuous {
 			bh.replicationStats.SubChangesContinuousActive.Add(1)
+			defer bh.replicationStats.SubChangesContinuousActive.Add(-1)
 			bh.replicationStats.SubChangesContinuousTotal.Add(1)
 		} else {
 			bh.replicationStats.SubChangesOneShotActive.Add(1)

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -195,12 +195,8 @@ func (bsc *BlipSyncContext) register(profile string, handlerFn func(*blipHandler
 }
 
 func (bsc *BlipSyncContext) Close() {
-	if bsc.gotSubChanges {
-		if bsc.continuous {
-			bsc.replicationStats.SubChangesContinuousActive.Add(-1)
-		} else {
-			bsc.replicationStats.SubChangesOneShotActive.Add(-1)
-		}
+	if bsc.gotSubChanges && bsc.continuous {
+		bsc.replicationStats.SubChangesContinuousActive.Add(-1)
 	}
 
 	bsc.terminatorOnce.Do(func() {

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -195,10 +195,6 @@ func (bsc *BlipSyncContext) register(profile string, handlerFn func(*blipHandler
 }
 
 func (bsc *BlipSyncContext) Close() {
-	if bsc.gotSubChanges && bsc.continuous {
-		bsc.replicationStats.SubChangesContinuousActive.Add(-1)
-	}
-
 	bsc.terminatorOnce.Do(func() {
 		close(bsc.terminator)
 	})

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -3748,11 +3748,13 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 }
 
 // Make sure that a client cannot open multiple subChanges subscriptions on a single blip context (SG #3222)
-//
 // - Open a one-off subChanges request, ensure it works.
 // - Open a subsequent continuous request, and ensure it works.
 // - Open another continuous subChanges, and asserts that it gets an error on the 2nd one, because the first is still running.
 // - Open another one-off subChanges request, assert we still get an error.
+//
+// Asserts on stats to test for regression of CBG-1824: Make sure SubChangesOneShotActive gets decremented when one shot
+// sub changes request has completed
 func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 
@@ -3772,8 +3774,9 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	}
 
 	pullStats := bt.restTester.GetDatabase().DbStats.CBLReplicationPull()
-	assert.EqualValues(t, 0, pullStats.NumPullReplActiveContinuous.Value())
-	assert.EqualValues(t, 0, pullStats.NumPullReplActiveOneShot.Value())
+	require.EqualValues(t, 0, pullStats.NumPullReplActiveContinuous.Value())
+	require.EqualValues(t, 0, pullStats.NumPullReplActiveOneShot.Value())
+	require.EqualValues(t, 0, pullStats.NumPullReplSinceZero.Value())
 
 	// Open an initial continuous = false subChanges request, which we'd expect to release the lock after it's "caught up".
 	subChangesRequest := blip.NewRequest()
@@ -3781,18 +3784,19 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	subChangesRequest.Properties["continuous"] = "false"
 	subChangesRequest.SetCompressed(false)
 	sent := bt.sender.Send(subChangesRequest)
-	goassert.True(t, sent)
+	require.True(t, sent)
 	subChangesResponse := subChangesRequest.Response()
-	goassert.Equals(t, subChangesResponse.SerialNumber(), subChangesRequest.SerialNumber())
+	require.Equal(t, subChangesResponse.SerialNumber(), subChangesRequest.SerialNumber())
 	errorCode := subChangesResponse.Properties["Error-Code"]
 	log.Printf("errorCode: %v", errorCode)
 	respBody, err := subChangesResponse.Body()
 	require.NoError(t, err)
-	assert.Equal(t, "", errorCode, "resp: %s", respBody)
+	require.Equal(t, "", errorCode, "resp: %s", respBody)
 
 	base.WaitForStat(pullStats.NumPullReplTotalOneShot.Value, 1)
-	// Might need to expect 0 after CBG-1824 depending on fix implementation
-	assert.EqualValues(t, 1, pullStats.NumPullReplActiveOneShot.Value())
+	value, _ := base.WaitForStat(pullStats.NumPullReplActiveOneShot.Value, 0)
+	require.EqualValues(t, 0, value)
+	require.EqualValues(t, 1, pullStats.NumPullReplSinceZero.Value())
 
 	// Send continous subChanges to subscribe to changes, which will cause the "changes" profile handler above to be called back
 	subChangesRequest = blip.NewRequest()
@@ -3800,17 +3804,20 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	subChangesRequest.Properties["continuous"] = "true"
 	subChangesRequest.SetCompressed(false)
 	sent = bt.sender.Send(subChangesRequest)
-	goassert.True(t, sent)
+	require.True(t, sent)
 	subChangesResponse = subChangesRequest.Response()
-	goassert.Equals(t, subChangesResponse.SerialNumber(), subChangesRequest.SerialNumber())
+	require.Equal(t, subChangesResponse.SerialNumber(), subChangesRequest.SerialNumber())
 	errorCode = subChangesResponse.Properties["Error-Code"]
 	log.Printf("errorCode: %v", errorCode)
 	respBody, err = subChangesResponse.Body()
 	require.NoError(t, err)
-	assert.Equal(t, "", errorCode, "resp: %s", respBody)
+	require.Equal(t, "", errorCode, "resp: %s", respBody)
 
-	base.WaitForStat(pullStats.NumPullReplTotalContinuous.Value, 1)
-	assert.EqualValues(t, 1, pullStats.NumPullReplActiveContinuous.Value())
+	value, _ = base.WaitForStat(pullStats.NumPullReplTotalContinuous.Value, 1)
+	require.EqualValues(t, 1, value)
+	require.EqualValues(t, 1, pullStats.NumPullReplActiveContinuous.Value())
+	require.EqualValues(t, 0, pullStats.NumPullReplActiveOneShot.Value())
+	require.EqualValues(t, 2, pullStats.NumPullReplSinceZero.Value())
 
 	// Send a second continuous subchanges request, expect an error
 	subChangesRequest = blip.NewRequest()
@@ -3818,14 +3825,16 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	subChangesRequest.Properties["continuous"] = "true"
 	subChangesRequest.SetCompressed(false)
 	sent = bt.sender.Send(subChangesRequest)
-	goassert.True(t, sent)
+	require.True(t, sent)
 	subChangesResponse = subChangesRequest.Response()
-	goassert.Equals(t, subChangesResponse.SerialNumber(), subChangesRequest.SerialNumber())
+	require.Equal(t, subChangesResponse.SerialNumber(), subChangesRequest.SerialNumber())
 	errorCode = subChangesResponse.Properties["Error-Code"]
 	log.Printf("errorCode2: %v", errorCode)
 	assert.Equal(t, "500", errorCode)
 
+	assert.EqualValues(t, 1, pullStats.NumPullReplTotalContinuous.Value())
 	assert.EqualValues(t, 1, pullStats.NumPullReplActiveContinuous.Value())
+	assert.EqualValues(t, 2, pullStats.NumPullReplSinceZero.Value())
 
 	// Even a subsequent continuous = false subChanges request should return an error. This isn't restricted to only continuous changes.
 	subChangesRequest = blip.NewRequest()
@@ -3833,23 +3842,24 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	subChangesRequest.Properties["continuous"] = "false"
 	subChangesRequest.SetCompressed(false)
 	sent = bt.sender.Send(subChangesRequest)
-	goassert.True(t, sent)
+	require.True(t, sent)
 	subChangesResponse = subChangesRequest.Response()
-	goassert.Equals(t, subChangesResponse.SerialNumber(), subChangesRequest.SerialNumber())
+	require.Equal(t, subChangesResponse.SerialNumber(), subChangesRequest.SerialNumber())
 	errorCode = subChangesResponse.Properties["Error-Code"]
 	log.Printf("errorCode: %v", errorCode)
 	respBody, err = subChangesResponse.Body()
 	require.NoError(t, err)
 	assert.Equal(t, "500", errorCode, "resp: %s", respBody)
 
-	assert.EqualValues(t, 1, pullStats.NumPullReplActiveOneShot.Value())
+	assert.EqualValues(t, 0, pullStats.NumPullReplActiveOneShot.Value())
+	assert.EqualValues(t, 1, pullStats.NumPullReplTotalOneShot.Value())
+	assert.EqualValues(t, 2, pullStats.NumPullReplSinceZero.Value())
 
 	bt.sender.Close() // Close continuous sub changes feed
 
-	activeContStat, activeContStatIsExpected := base.WaitForStat(pullStats.NumPullReplActiveContinuous.Value, 0)
-	assert.True(t, activeContStatIsExpected, "NumPullReplActiveContinuous=%d instead of expected value of 0", activeContStat)
+	value, _ = base.WaitForStat(pullStats.NumPullReplActiveContinuous.Value, 0)
+	assert.EqualValues(t, 0, value)
 
-	// Skipping assertions on one shot stat due to stat not being decremented after one shot has completed - CBG-1824
-	// activeOneShotStat, activeOneShotStatIsExpected := base.WaitForStat(pullStats.NumPullReplActiveOneShot.Value, 0)
-	// assert.True(t, activeOneShotStatIsExpected, "NumPullReplActiveOneShot=%d instead of expected value of 0", activeOneShotStat)
+	value, _ = base.WaitForStat(pullStats.NumPullReplActiveOneShot.Value, 0)
+	assert.EqualValues(t, 0, value)
 }


### PR DESCRIPTION
CBG-1824

- `SubChangesOneShotActive` is decremented after the sub changes feed has finished which therefore decrements `NumPullReplActiveOneShot`
- Modified `TestMultipleOutstandingChangesSubscriptions` to also test the pull stats work as intended
- Modified `TestMultipleOutstandingChangesSubscriptions` to have require where appropriate 

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1535