### PR TITLE
CBG-1502 Checkpoint persistence for one-shot DCP feeds

### DIFF
--- a/base/dcp_client_metadata.go
+++ b/base/dcp_client_metadata.go
@@ -1,28 +1,49 @@
 package base
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/couchbase/gocbcore/v10"
 )
 
 type DCPMetadata struct {
-	vbUUID          gocbcore.VbUUID
-	startSeqNo      gocbcore.SeqNo
-	endSeqNo        gocbcore.SeqNo
-	snapStartSeqNo  gocbcore.SeqNo
-	snapEndSeqNo    gocbcore.SeqNo
-	failoverEntries []gocbcore.FailoverEntry
+	VbUUID          gocbcore.VbUUID
+	StartSeqNo      gocbcore.SeqNo
+	EndSeqNo        gocbcore.SeqNo
+	SnapStartSeqNo  gocbcore.SeqNo
+	SnapEndSeqNo    gocbcore.SeqNo
+	FailoverEntries []gocbcore.FailoverEntry
 }
 
 type DCPMetadataStore interface {
+	// Rollback resets vbucket metadata, but preserves endSeqNo
 	Rollback(vbID uint16)
+
+	// SetMeta updates the DCPMetadata for a vbucket
 	SetMeta(vbID uint16, meta DCPMetadata)
+
+	// GetMeta retrieves DCPMetadata for a vbucket
 	GetMeta(vbID uint16) DCPMetadata
+
+	// SetEndSeqNos sets the end sequence numbers for all specified vbuckets
 	SetEndSeqNos(map[uint16]uint64)
+
+	// SetSnapshot updates the metadata based on a DCP snapshotEvent
 	SetSnapshot(e snapshotEvent)
+
+	// UpdateSeq updates the last sequence processed for a vbucket
 	UpdateSeq(vbID uint16, seq uint64)
+
+	// SetFailoverEntries sets the failover history (vbuUUID, seq) for a vbucket
 	SetFailoverEntries(vbID uint16, entries []gocbcore.FailoverEntry)
+
+	// Persist writes the metadata for the specified workerID and vbucket IDs to the backing store
+	Persist(workerID int, vbIDs []uint16)
+
+	// Purge removes all metadata associated with the metadata store from the bucket.  It does not remove the
+	// in-memory metadata.
+	Purge(numWorkers int)
 }
 
 type DCPMetadataMem struct {
@@ -37,22 +58,22 @@ func NewDCPMetadataMem(numVbuckets uint16) *DCPMetadataMem {
 	}
 	for vbNo := uint16(0); vbNo < numVbuckets; vbNo++ {
 		m.metadata[vbNo] = DCPMetadata{
-			failoverEntries: make([]gocbcore.FailoverEntry, 0),
-			endSeqNo:        math.MaxUint64,
+			FailoverEntries: make([]gocbcore.FailoverEntry, 0),
+			EndSeqNo:        math.MaxUint64,
 		}
 	}
 	return m
 }
 
-// Rollback resets the metadata, preserving endSeqNo if set
+// Rollback resets the metadata, preserving EndSeqNo if set
 func (m *DCPMetadataMem) Rollback(vbID uint16) {
 	m.metadata[vbID] = DCPMetadata{
-		vbUUID:          0,
-		startSeqNo:      0,
-		endSeqNo:        m.endSeqNos[vbID],
-		snapStartSeqNo:  0,
-		snapEndSeqNo:    0,
-		failoverEntries: make([]gocbcore.FailoverEntry, 0),
+		VbUUID:          0,
+		StartSeqNo:      0,
+		EndSeqNo:        m.endSeqNos[vbID],
+		SnapStartSeqNo:  0,
+		SnapEndSeqNo:    0,
+		FailoverEntries: make([]gocbcore.FailoverEntry, 0),
 	}
 }
 
@@ -65,42 +86,52 @@ func (m *DCPMetadataMem) GetMeta(vbID uint16) DCPMetadata {
 }
 
 func (m *DCPMetadataMem) SetSnapshot(e snapshotEvent) {
-	m.metadata[e.vbID].snapStartSeqNo = gocbcore.SeqNo(e.startSeq)
-	m.metadata[e.vbID].snapEndSeqNo = gocbcore.SeqNo(e.endSeq)
+	m.metadata[e.vbID].SnapStartSeqNo = gocbcore.SeqNo(e.startSeq)
+	m.metadata[e.vbID].SnapEndSeqNo = gocbcore.SeqNo(e.endSeq)
 }
 
 func (m *DCPMetadataMem) UpdateSeq(vbID uint16, seq uint64) {
-	m.metadata[vbID].startSeqNo = gocbcore.SeqNo(seq)
+	m.metadata[vbID].StartSeqNo = gocbcore.SeqNo(seq)
 }
 
 func (m *DCPMetadataMem) SetFailoverEntries(vbID uint16, fe []gocbcore.FailoverEntry) {
-	m.metadata[vbID].failoverEntries = fe
-	m.metadata[vbID].vbUUID = getVbUUID(fe, m.metadata[vbID].startSeqNo)
+	m.metadata[vbID].FailoverEntries = fe
+	m.metadata[vbID].VbUUID = getVbUUID(fe, m.metadata[vbID].StartSeqNo)
 }
 
 // SetEndSeqNos will update the metadata endSeqNos to the values provided.  Vbuckets not
-// present in the endSeqNos map will have their endSeqNo set to zero.
+// present in the endSeqNos map will have their EndSeqNo set to zero.
 func (m *DCPMetadataMem) SetEndSeqNos(endSeqNos map[uint16]uint64) {
 	for i := 0; i < len(m.metadata); i++ {
 		endSeqNo, _ := endSeqNos[uint16(i)]
-		m.metadata[i].endSeqNo = gocbcore.SeqNo(endSeqNo)
+		m.metadata[i].EndSeqNo = gocbcore.SeqNo(endSeqNo)
 		m.endSeqNos[i] = gocbcore.SeqNo(endSeqNo)
 	}
+}
+
+// Persist is no-op for in-memory metadata store
+func (md *DCPMetadataMem) Persist(workerID int, vbIDs []uint16) {
+	return
+}
+
+// Purge is no-op for in-memory metadata store
+func (md *DCPMetadataMem) Purge(numWorkers int) {
+	return
 }
 
 // Reset sets metadata sequences to zero, but maintains vbucket UUID and failover entries.  Used for scenarios
 // that want to restart a feed from zero, but detect failover
 func (md *DCPMetadata) Reset() {
-	md.snapStartSeqNo = 0
-	md.snapEndSeqNo = 0
-	md.startSeqNo = 0
-	md.endSeqNo = 0
+	md.SnapStartSeqNo = 0
+	md.SnapEndSeqNo = 0
+	md.StartSeqNo = 0
+	md.EndSeqNo = 0
 }
 
 func GetVBUUIDs(metadata []DCPMetadata) []uint64 {
 	uuids := make([]uint64, 0, len(metadata))
 	for _, meta := range metadata {
-		uuids = append(uuids, uint64(meta.vbUUID))
+		uuids = append(uuids, uint64(meta.VbUUID))
 	}
 	return uuids
 }
@@ -109,8 +140,139 @@ func BuildDCPMetadataSliceFromVBUUIDs(vbUUIDS []uint64) []DCPMetadata {
 	metadata := make([]DCPMetadata, 0, len(vbUUIDS))
 	for _, vbUUID := range vbUUIDS {
 		metadata = append(metadata, DCPMetadata{
-			vbUUID: gocbcore.VbUUID(vbUUID),
+			VbUUID: gocbcore.VbUUID(vbUUID),
 		})
 	}
 	return metadata
+}
+
+// DCPMetadataCS stores DCP metadata in the specified CouchbaseStore.  It does not require that the store is the
+// same one being streamed over DCP.
+type DCPMetadataCS struct {
+	bucket    Bucket
+	keyPrefix string
+	metadata  []DCPMetadata
+	endSeqNos []gocbcore.SeqNo
+}
+
+func NewDCPMetadataCS(store Bucket, numVbuckets uint16, numWorkers int, keyPrefix string) *DCPMetadataCS {
+
+	m := &DCPMetadataCS{
+		bucket:    store,
+		keyPrefix: keyPrefix,
+		metadata:  make([]DCPMetadata, numVbuckets),
+		endSeqNos: make([]gocbcore.SeqNo, numVbuckets),
+	}
+	for vbNo := uint16(0); vbNo < numVbuckets; vbNo++ {
+		m.metadata[vbNo] = DCPMetadata{
+			FailoverEntries: make([]gocbcore.FailoverEntry, 0),
+			EndSeqNo:        math.MaxUint64,
+		}
+	}
+
+	// Initialize any persisted metadata
+	for i := 0; i < numWorkers; i++ {
+		m.load(i)
+	}
+
+	return m
+}
+
+func (m *DCPMetadataCS) Rollback(vbID uint16) {
+	// Preserve endSeqNo on rollback
+	endSeqNo := m.metadata[vbID].EndSeqNo
+	m.metadata[vbID] = DCPMetadata{
+		VbUUID:          0,
+		StartSeqNo:      0,
+		EndSeqNo:        endSeqNo,
+		SnapStartSeqNo:  0,
+		SnapEndSeqNo:    0,
+		FailoverEntries: make([]gocbcore.FailoverEntry, 0),
+	}
+}
+
+func (m *DCPMetadataCS) SetMeta(vbNo uint16, metadata DCPMetadata) {
+	m.metadata[vbNo] = metadata
+}
+
+func (m *DCPMetadataCS) GetMeta(vbNo uint16) DCPMetadata {
+	return m.metadata[vbNo]
+}
+
+func (m *DCPMetadataCS) SetSnapshot(e snapshotEvent) {
+	m.metadata[e.vbID].SnapStartSeqNo = gocbcore.SeqNo(e.startSeq)
+	m.metadata[e.vbID].SnapEndSeqNo = gocbcore.SeqNo(e.endSeq)
+}
+
+func (m *DCPMetadataCS) UpdateSeq(vbNo uint16, seq uint64) {
+	m.metadata[vbNo].StartSeqNo = gocbcore.SeqNo(seq)
+}
+
+func (m *DCPMetadataCS) SetFailoverEntries(vbID uint16, fe []gocbcore.FailoverEntry) {
+	m.metadata[vbID].FailoverEntries = fe
+	m.metadata[vbID].VbUUID = getVbUUID(fe, m.metadata[vbID].StartSeqNo)
+}
+
+// SetEndSeqNos will update the metadata endSeqNos to the values provided.  Vbuckets not
+// present in the endSeqNos map will have their EndSeqNo set to zero.
+func (m *DCPMetadataCS) SetEndSeqNos(endSeqNos map[uint16]uint64) {
+	for i := 0; i < len(m.metadata); i++ {
+		endSeqNo, _ := endSeqNos[uint16(i)]
+		m.metadata[i].EndSeqNo = gocbcore.SeqNo(endSeqNo)
+	}
+}
+
+// Persist is called by worker.  Triggers persistence of metadata for all listed vbuckets.  This set must be the same
+// set that has been assigned to the worker.  There's no synchronization on m.metadata - relies on DCP worker to
+// avoid read/write races on vbucket data.  Calls to persist must be blocking on the worker goroutine, and vbuckets are
+// only assigned to a single worker
+func (m *DCPMetadataCS) Persist(workerID int, vbIDs []uint16) {
+
+	meta := WorkerMetadata{}
+	meta.DCPMeta = make(map[uint16]DCPMetadata)
+	for _, vbID := range vbIDs {
+		meta.DCPMeta[vbID] = m.metadata[vbID]
+	}
+	err := m.bucket.Set(m.getMetadataKey(workerID), 0, meta)
+	if err != nil {
+		Infof(KeyDCP, "Unable to persist DCP metadata: %v", err)
+	} else {
+		Tracef(KeyDCP, "Persisted metadata for worker %d: %v", workerID, meta)
+		//log.Printf("Persisted metadata for worker %d (%s): %v", workerID, m.getMetadataKey(workerID), meta)
+	}
+	return
+}
+
+func (m *DCPMetadataCS) load(workerID int) {
+	var meta WorkerMetadata
+	_, err := m.bucket.Get(m.getMetadataKey(workerID), &meta)
+	if err != nil {
+		if IsKeyNotFoundError(m.bucket, err) {
+			return
+		}
+		Infof(KeyDCP, "Error loading persisted metadata - metadata will be reset for worker %d: %s", workerID, err)
+	}
+
+	Tracef(KeyDCP, "Loaded metadata for worker %d: %v", workerID, meta)
+	//log.Printf("Loaded metadata for worker %d (%s): %v", workerID, m.getMetadataKey(workerID), meta)
+	for vbID, metadata := range meta.DCPMeta {
+		m.metadata[vbID] = metadata
+	}
+}
+
+func (m *DCPMetadataCS) Purge(numWorkers int) {
+	for i := 0; i < numWorkers; i++ {
+		err := m.bucket.Delete(m.getMetadataKey(i))
+		if err != nil && !IsKeyNotFoundError(m.bucket, err) {
+			Infof(KeyDCP, "Unable to remove DCP checkpoint for key %s: %v", m.getMetadataKey(i), err)
+		}
+	}
+}
+
+func (m *DCPMetadataCS) getMetadataKey(workerID int) string {
+	return fmt.Sprintf("%s%d", m.keyPrefix, workerID)
+}
+
+type WorkerMetadata struct {
+	DCPMeta map[uint16]DCPMetadata
 }

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -260,8 +260,7 @@ func TestResumeStoppedFeed(t *testing.T) {
 	mutationCount := uint64(0)
 	counterCallback := func(event sgbucket.FeedEvent) bool {
 		if bytes.HasPrefix(event.Key, []byte(t.Name())) {
-			atomic.AddUint64(&mutationCount, 1)
-			count := atomic.LoadUint64(&mutationCount)
+			count := atomic.AddUint64(&mutationCount, 1)
 			if count > 5000 {
 				err := dcpClient.Close()
 				assert.NoError(t, err)

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -40,14 +40,12 @@ func TestOneShotDCP(t *testing.T) {
 	}
 
 	// start one shot feed
-	store, ok := AsCouchbaseStore(bucket)
-	assert.True(t, ok)
 	feedID := t.Name()
 	clientOptions := DCPClientOptions{
 		OneShot: true,
 	}
 
-	dcpClient, err := NewDCPClient(feedID, counterCallback, clientOptions, store, "")
+	dcpClient, err := NewDCPClient(feedID, counterCallback, clientOptions, bucket, "")
 	assert.NoError(t, err)
 
 	// Add additional documents in a separate goroutine, to verify afterEndSeq handling
@@ -100,11 +98,9 @@ func TestTerminateDCPFeed(t *testing.T) {
 	}
 
 	// start continuous feed with terminator
-	store, ok := AsCouchbaseStore(bucket)
-	assert.True(t, ok)
 	feedID := t.Name()
 
-	dcpClient, err := NewDCPClient(feedID, counterCallback, DCPClientOptions{}, store, "")
+	dcpClient, err := NewDCPClient(feedID, counterCallback, DCPClientOptions{}, bucket, "")
 	assert.NoError(t, err)
 
 	// Add documents in a separate goroutine
@@ -149,7 +145,7 @@ func TestTerminateDCPFeed(t *testing.T) {
 }
 
 // TestDCPClientMultiFeedConsistency tests for DCP rollback between execution of two DCP feeds, based on
-// changes in the vbUUID
+// changes in the VbUUID
 func TestDCPClientMultiFeedConsistency(t *testing.T) {
 
 	if UnitTestUrlIsWalrus() {
@@ -172,8 +168,6 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 		return false
 	}
 
-	store, ok := AsCouchbaseStore(bucket)
-	assert.True(t, ok)
 	feedID := t.Name()
 
 	// Add documents
@@ -189,7 +183,7 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 		OneShot:        true,
 		FailOnRollback: true,
 	}
-	dcpClient, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, store, "")
+	dcpClient, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, bucket, "")
 	assert.NoError(t, err)
 
 	doneChan, startErr := dcpClient.Start()
@@ -208,30 +202,31 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 	// store the number of mutations from vbucket zero for validating rollback on the third feed
 	vbucketZeroExpected := atomic.LoadUint64(&vbucketZeroCount)
 
-	// Perform second one-shot DCP feed - vbUUID mismatch, failOnRollback=true
-	// Retrieve metadata from first DCP feed, and modify vbUUID to simulate rollback on server
+	// Perform second one-shot DCP feed - VbUUID mismatch, failOnRollback=true
+	// Retrieve metadata from first DCP feed, and modify VbUUID to simulate rollback on server
 	uuidMismatchMetadata := dcpClient.GetMetadata()
-	uuidMismatchMetadata[0].vbUUID = 1234
+	uuidMismatchMetadata[0].VbUUID = 1234
 
 	dcpClientOpts = DCPClientOptions{
 		InitialMetadata: uuidMismatchMetadata,
 		FailOnRollback:  true,
 		OneShot:         true,
 	}
-	dcpClient2, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, store, "")
+	dcpClient2, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, bucket, "")
 	assert.NoError(t, err)
 
 	_, startErr2 := dcpClient2.Start()
 	assert.Error(t, startErr2)
 
-	// Perform a third DCP feed - mismatched vbUUID, failOnRollback=false
+	log.Printf("Starting third feed")
+	// Perform a third DCP feed - mismatched VbUUID, failOnRollback=false
 	atomic.StoreUint64(&mutationCount, 0)
 	dcpClientOpts = DCPClientOptions{
 		InitialMetadata: uuidMismatchMetadata,
 		FailOnRollback:  false,
 		OneShot:         true,
 	}
-	dcpClient3, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, store, "")
+	dcpClient3, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, bucket, "")
 	assert.NoError(t, err)
 
 	doneChan3, startErr3 := dcpClient3.Start()
@@ -243,8 +238,108 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 	case <-doneChan3:
 		// only vbucket 0 should have rolled back, expect mutation count to be only vbucketZero
 		mutationCount := atomic.LoadUint64(&mutationCount)
-		assert.Equal(t, vbucketZeroExpected, mutationCount)
+		assert.Equal(t, int(vbucketZeroExpected), int(mutationCount))
 	case <-timeout:
 		t.Errorf("timeout waiting for first one-shot feed to complete")
 	}
+}
+
+// TestResumeInterruptedFeed uses persisted metadata to resume the feed
+func TestResumeStoppedFeed(t *testing.T) {
+
+	if UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
+
+	var dcpClient *DCPClient
+
+	// create callback
+	mutationCount := uint64(0)
+	counterCallback := func(event sgbucket.FeedEvent) bool {
+		if bytes.HasPrefix(event.Key, []byte(t.Name())) {
+			atomic.AddUint64(&mutationCount, 1)
+			count := atomic.LoadUint64(&mutationCount)
+			if count > 5000 {
+				err := dcpClient.Close()
+				assert.NoError(t, err)
+			}
+		}
+		return false
+	}
+
+	feedID := t.Name()
+
+	// Add documents
+	updatedBody := map[string]interface{}{"foo": "bar"}
+	for i := 0; i < 10000; i++ {
+		key := fmt.Sprintf("%s_%d", t.Name(), i)
+		err := bucket.Set(key, 0, updatedBody)
+		assert.NoError(t, err)
+	}
+
+	// Start first one-shot DCP feed, will be stopped by callback after processing 5000 records
+	// Set metadata persistence frequency to zero to force persistence on every mutation
+	highFrequency := 0 * time.Second
+	dcpClientOpts := DCPClientOptions{
+		OneShot:                    true,
+		FailOnRollback:             false,
+		CheckpointPersistFrequency: &highFrequency,
+	}
+	var err error
+	dcpClient, err = NewDCPClient(feedID, counterCallback, dcpClientOpts, bucket, "")
+	assert.NoError(t, err)
+
+	doneChan, startErr := dcpClient.Start()
+	assert.NoError(t, startErr)
+
+	// Wait for first feed to complete
+	timeout := time.After(3 * time.Second)
+	time.Sleep(1 * time.Second)
+	select {
+	case <-doneChan:
+		mutationCount := atomic.LoadUint64(&mutationCount)
+		assert.True(t, int(mutationCount) > 5000)
+		log.Printf("Total processed first feed: %v", mutationCount)
+	case <-timeout:
+		t.Errorf("timeout waiting for first one-shot feed to complete")
+	}
+
+	var secondFeedCount uint64
+	secondCallback := func(event sgbucket.FeedEvent) bool {
+		if bytes.HasPrefix(event.Key, []byte(t.Name())) {
+			atomic.AddUint64(&mutationCount, 1)
+			atomic.AddUint64(&secondFeedCount, 1)
+		}
+		return false
+	}
+
+	// Perform second one-shot DCP feed with the same ID, verify it resumes and completes
+	dcpClientOpts = DCPClientOptions{
+		FailOnRollback: false,
+		OneShot:        true,
+	}
+	dcpClient2, err := NewDCPClient(feedID, secondCallback, dcpClientOpts, bucket, "")
+	assert.NoError(t, err)
+
+	doneChan2, startErr2 := dcpClient2.Start()
+	assert.NoError(t, startErr2)
+
+	// Wait for second feed to complete
+	timeout = time.After(3 * time.Second)
+	time.Sleep(1 * time.Second)
+	select {
+	case <-doneChan2:
+		// validate the total count exceeds 10000, and the second feed didn't just reprocess everything
+		mutationCount := atomic.LoadUint64(&mutationCount)
+		assert.True(t, int(mutationCount) >= 10000)
+		secondFeedCount := atomic.LoadUint64(&secondFeedCount)
+		assert.True(t, int(secondFeedCount) < 10000)
+		log.Printf("Total processed: %v, second feed: %v", mutationCount, secondFeedCount)
+	case <-timeout:
+		t.Errorf("timeout waiting for second one-shot feed to complete")
+	}
+
 }

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -3,7 +3,6 @@ package db
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -115,11 +114,6 @@ func Mark(db *Database, compactionID string, terminator *base.SafeTerminator, ma
 		return true
 	}
 
-	cbStore, ok := base.AsCouchbaseStore(db.Bucket)
-	if !ok {
-		return 0, nil, fmt.Errorf("bucket is not a Couchbase Store")
-	}
-
 	clientOptions := base.DCPClientOptions{
 		OneShot:        true,
 		FailOnRollback: true,
@@ -127,7 +121,7 @@ func Mark(db *Database, compactionID string, terminator *base.SafeTerminator, ma
 
 	base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Starting DCP feed for mark phase of attachment compaction", compactionLoggingID)
 	dcpFeedKey := compactionID + "_mark"
-	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, cbStore, db.Options.GroupID)
+	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, db.Bucket, db.Options.GroupID)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -320,11 +314,6 @@ func Sweep(db *Database, compactionID string, vbUUIDs []uint64, dryRun bool, ter
 		return true
 	}
 
-	cbStore, ok := base.AsCouchbaseStore(db.Bucket)
-	if !ok {
-		return 0, fmt.Errorf("bucket is not a Couchbase Store")
-	}
-
 	clientOptions := base.DCPClientOptions{
 		OneShot:         true,
 		FailOnRollback:  true,
@@ -333,7 +322,7 @@ func Sweep(db *Database, compactionID string, vbUUIDs []uint64, dryRun bool, ter
 
 	base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Starting DCP feed for sweep phase of attachment compaction", compactionLoggingID)
 	dcpFeedKey := compactionID + "_sweep"
-	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, cbStore, db.Options.GroupID)
+	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, db.Bucket, db.Options.GroupID)
 	if err != nil {
 		return 0, err
 	}
@@ -439,11 +428,6 @@ func Cleanup(db *Database, compactionID string, vbUUIDs []uint64, terminator *ba
 		return true
 	}
 
-	cbStore, ok := base.AsCouchbaseStore(db.Bucket)
-	if !ok {
-		return fmt.Errorf("bucket is not a Couchbase Store")
-	}
-
 	clientOptions := base.DCPClientOptions{
 		OneShot:         true,
 		FailOnRollback:  true,
@@ -452,7 +436,7 @@ func Cleanup(db *Database, compactionID string, vbUUIDs []uint64, terminator *ba
 
 	base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Starting DCP feed for cleanup phase of attachment compaction", compactionLoggingID)
 	dcpFeedKey := compactionID + "_cleanup"
-	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, cbStore, db.Options.GroupID)
+	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, db.Bucket, db.Options.GroupID)
 	if err != nil {
 		return err
 	}

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -523,8 +523,6 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 		err = testDB2.AttachmentCompactionManager.Start(map[string]interface{}{"database": testDB2})
 		assert.NotContains(t, err.Error(), "Process already running")
 	}
-	assert.NoError(t, err)
-
 }
 
 func TestAttachmentProcessError(t *testing.T) {
@@ -583,7 +581,7 @@ func TestAttachmentDifferentVBUUIDsBetweenPhases(t *testing.T) {
 
 	_, err = Sweep(testDB, t.Name(), vbUUIDs, false, terminator, &base.AtomicInt{})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "error opening stream for vb 0: vbUUID mismatch when failOnRollback set")
+	assert.Contains(t, err.Error(), "error opening stream for vb 0: VbUUID mismatch when failOnRollback set")
 }
 
 func WaitForConditionWithOptions(successFunc func() bool, maxNumAttempts, timeToSleepMs int) error {


### PR DESCRIPTION
CBG-1502

Switches one-shot DCP feed to persist checkpoint metadata to the bucket, to support resumption after node failure.  Metadata is persisted per DCP worker, to avoid contention on in-memory metadata at persistence time.  Workers schedule persistence for their metadata based on their metaPersistFrequency.  This defaults to 1 minute, but can be adjusted for unit testing.

On successful one-shot feed completion, checkpoints are purged from the bucket.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1488/
