### PR TITLE
CBG-1846: Load database on /db/_config update prior to writing config

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3795,7 +3795,7 @@ func TestLegacyCredentialInheritance(t *testing.T) {
 }
 
 func TestDbOfflineConfigLegacy(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{persistentConfig: false})
+	rt := NewRestTester(t, nil)
 	bucket := rt.Bucket()
 	defer rt.Close()
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -1086,12 +1086,6 @@ func (sc *ServerContext) _fetchAndLoadDatabase(dbName string) (found bool, err e
 }
 
 func (sc *ServerContext) fetchDatabase(dbName string) (found bool, dbConfig *DatabaseConfig, err error) {
-	select {
-	case <-sc.bootstrapContext.terminator:
-		return false, nil, fmt.Errorf("bootstrapContext closed")
-	default:
-	}
-
 	buckets, err := sc.bootstrapContext.connection.GetConfigBuckets()
 	if err != nil {
 		return false, nil, fmt.Errorf("couldn't get buckets from cluster: %w", err)

--- a/rest/config.go
+++ b/rest/config.go
@@ -680,19 +680,18 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) (errorMessag
 		}
 	}
 
-	// TODO: Add upfront validation of RevsLimit after proving TestPersistentDbConfigWithInvalidUpsert correctly rolls back database.
-	// revsLimit := dbConfig.RevsLimit
-	// if revsLimit != nil {
-	// 	if *dbConfig.ConflictsAllowed() {
-	// 		if *revsLimit < 20 {
-	// 			errorMessages = multierror.Append(errorMessages, fmt.Errorf("The revs_limit (%v) value in your Sync Gateway configuration cannot be set lower than 20.", *revsLimit))
-	// 		}
-	// 	} else {
-	// 		if *revsLimit <= 0 {
-	// 			errorMessages = multierror.Append(errorMessages, fmt.Errorf("The revs_limit (%v) value in your Sync Gateway configuration must be greater than zero.", *revsLimit))
-	// 		}
-	// 	}
-	// }
+	revsLimit := dbConfig.RevsLimit
+	if revsLimit != nil {
+		if *dbConfig.ConflictsAllowed() {
+			if *revsLimit < 20 {
+				errorMessages = multierror.Append(errorMessages, fmt.Errorf("The revs_limit (%v) value in your Sync Gateway configuration cannot be set lower than 20.", *revsLimit))
+			}
+		} else {
+			if *revsLimit <= 0 {
+				errorMessages = multierror.Append(errorMessages, fmt.Errorf("The revs_limit (%v) value in your Sync Gateway configuration must be greater than zero.", *revsLimit))
+			}
+		}
+	}
 
 	return errorMessages
 }

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -395,7 +395,7 @@ func setupAndValidateDatabases(databases DbConfigMap) error {
 		if err := dbConfig.setup(name, BootstrapConfig{}, nil); err != nil {
 			return err
 		}
-		if err := dbConfig.validateSgDbConfig(); err != nil {
+		if err := dbConfig.validate(); err != nil {
 			return err
 		}
 	}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2107,7 +2107,7 @@ func TestInvalidJavascriptFunctions(t *testing.T) {
 			nil,
 		},
 		{
-			"Invalid Sync Fn No Import #2",
+			"Invalid Sync Fn No Import 2",
 			base.StringPtr(`function(doc){
 				if (t )){}
 			}`),
@@ -2136,8 +2136,9 @@ func TestInvalidJavascriptFunctions(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
+			safeDbName := strings.ToLower(strings.ReplaceAll(testCase.Name, " ", "-"))
 			dbConfig := DbConfig{
-				Name: testCase.Name,
+				Name: safeDbName,
 			}
 
 			if testCase.SyncFunction != nil {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1257,10 +1257,11 @@ func TestConfigGroupIDValidation(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			if test.eeMode && !base.IsEnterpriseEdition() {
+			isEnterpriseEdition := base.IsEnterpriseEdition()
+			if test.eeMode && !isEnterpriseEdition {
 				t.Skip("EE mode only test case")
 			}
-			if !test.eeMode && base.IsEnterpriseEdition() {
+			if !test.eeMode && isEnterpriseEdition {
 				t.Skip("CE mode only test case")
 			}
 
@@ -1271,7 +1272,7 @@ func TestConfigGroupIDValidation(t *testing.T) {
 					UseTLSServer:  base.BoolPtr(base.ServerIsTLS(base.UnitTestUrl())),
 				},
 			}
-			err := sc.validate()
+			err := sc.validate(isEnterpriseEdition)
 			if test.expectedError != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), test.expectedError)
@@ -1322,7 +1323,7 @@ func TestClientTLSMissing(t *testing.T) {
 			if test.tlsCert {
 				config.API.HTTPS.TLSCertPath = "test.cert"
 			}
-			err := config.validate()
+			err := config.validate(false)
 			if test.expectError {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), errorTLSOneMissing)
@@ -2216,7 +2217,7 @@ func TestStartupConfigBcryptCostValidation(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			sc := StartupConfig{Auth: AuthConfig{BcryptCost: test.cost}}
-			err := sc.validate()
+			err := sc.validate(false)
 			if test.expectError {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), errContains)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1323,7 +1323,7 @@ func TestClientTLSMissing(t *testing.T) {
 			if test.tlsCert {
 				config.API.HTTPS.TLSCertPath = "test.cert"
 			}
-			err := config.validate(false)
+			err := config.validate(base.IsEnterpriseEdition())
 			if test.expectError {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), errorTLSOneMissing)
@@ -2218,7 +2218,7 @@ func TestStartupConfigBcryptCostValidation(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			sc := StartupConfig{Auth: AuthConfig{BcryptCost: test.cost}}
-			err := sc.validate(false)
+			err := sc.validate(base.IsEnterpriseEdition())
 			if test.expectError {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), errContains)

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -1,0 +1,194 @@
+package rest
+
+import (
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// RestTesterCluster can be used to simulate a multi-node Sync Gateway cluster.
+type RestTesterCluster struct {
+	testBucket      *base.TestBucket
+	restTesters     []*RestTester
+	roundRobinCount int64
+}
+
+// RefreshClusterDbConfigs will synchronously fetch the latest db configs from each bucket for each RestTester.
+func (rtc *RestTesterCluster) RefreshClusterDbConfigs() (count int, err error) {
+	for _, rt := range rtc.restTesters {
+		c, err := rt.ServerContext().fetchAndLoadConfigs()
+		if err != nil {
+			return 0, err
+		}
+		count += c
+	}
+	return count, nil
+}
+
+func (rtc *RestTesterCluster) NumNodes() int {
+	return len(rtc.restTesters)
+}
+
+// ForEachNode runs the given function on each RestTester node.
+func (rtc *RestTesterCluster) ForEachNode(fn func(rt *RestTester)) {
+	for _, rt := range rtc.restTesters {
+		fn(rt)
+	}
+}
+
+// RoundRobin returns the next RestTester instance, cycling through all of them sequentially.
+func (rtc *RestTesterCluster) RoundRobin() *RestTester {
+	requestNum := atomic.AddInt64(&rtc.roundRobinCount, 1) % int64(len(rtc.restTesters))
+	node := requestNum % int64(len(rtc.restTesters))
+	return rtc.restTesters[node]
+}
+
+// Node returns a specific RestTester instance.
+func (rtc *RestTesterCluster) Node(i int) *RestTester {
+	return rtc.restTesters[i]
+}
+
+// Close closes all of RestTester nodes and the shared TestBucket.
+func (rtc *RestTesterCluster) Close() {
+	for _, rt := range rtc.restTesters {
+		rt.Close()
+	}
+	rtc.testBucket.Close()
+}
+
+// var _ base.BootstrapConnection = &testBootstrapConnection{}
+
+type RestTesterClusterConfig struct {
+	numNodes   uint8
+	groupID    *string
+	rtConfig   *RestTesterConfig
+	testBucket *base.TestBucket
+}
+
+func defaultRestTesterClusterConfig(t *testing.T) *RestTesterClusterConfig {
+	return &RestTesterClusterConfig{
+		numNodes:   3,
+		groupID:    base.StringPtr(t.Name()),
+		rtConfig:   nil,
+		testBucket: nil,
+	}
+}
+
+func NewRestTesterCluster(t *testing.T, config *RestTesterClusterConfig) *RestTesterCluster {
+	if base.UnitTestUrlIsWalrus() {
+		// TODO: implementing a single bucket/mock base.BootstrapConnection might work here
+		t.Skip("Walrus not supported for RestTesterCluster")
+	}
+
+	if config == nil {
+		config = defaultRestTesterClusterConfig(t)
+	}
+
+	// Set group ID for each RestTester from cluster
+	if config.rtConfig == nil {
+		config.rtConfig = &RestTesterConfig{groupID: config.groupID}
+	} else {
+		config.rtConfig.groupID = config.groupID
+	}
+	// only persistent mode is supported for a RestTesterCluster
+	config.rtConfig.persistentConfig = true
+
+	// Make all RestTesters share the same unclosable TestBucket
+	tb := config.testBucket
+	if tb == nil {
+		tb = base.GetTestBucket(t)
+	}
+	config.rtConfig.TestBucket = tb.NoCloseClone()
+
+	// Start up all rest testers in parallel
+	wg := sync.WaitGroup{}
+	restTesters := make([]*RestTester, 0, config.numNodes)
+	for i := 0; i < int(config.numNodes); i++ {
+		wg.Add(1)
+		go func() {
+			rt := NewRestTester(t, config.rtConfig)
+			// initialize the RestTester before we attempt to use it
+			_ = rt.ServerContext()
+			restTesters = append(restTesters, rt)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	return &RestTesterCluster{
+		testBucket:  tb,
+		restTesters: restTesters,
+	}
+}
+
+// dbConfigForTestBucket returns a barebones DbConfig for the given TestBucket.
+func dbConfigForTestBucket(tb *base.TestBucket) DbConfig {
+	return DbConfig{
+		BucketConfig: BucketConfig{
+			Bucket: base.StringPtr(tb.GetName()),
+		},
+		NumIndexReplicas: base.UintPtr(0),
+		UseViews:         base.BoolPtr(base.TestsDisableGSI()),
+		EnableXattrs:     base.BoolPtr(base.TestUseXattrs()),
+	}
+}
+
+func TestPersistentDbConfigWithInvalidUpsert(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+
+	rtc := NewRestTesterCluster(t, nil)
+	defer rtc.Close()
+
+	const db = "db"
+
+	dbConfig := dbConfigForTestBucket(rtc.testBucket)
+
+	// Create database on a random node.
+	resp, err := rtc.RoundRobin().CreateDatabase(db, dbConfig)
+	require.NoError(t, err)
+	assertStatus(t, resp, http.StatusCreated)
+
+	// A duplicate create shouldn't work, even if this were a node that doesn't have the database loaded yet.
+	// But this _will_ trigger an on-demand load on this node. So now we have 2 nodes running the database.
+	resp, err = rtc.RoundRobin().CreateDatabase(db, dbConfig)
+	require.NoError(t, err)
+	// CouchDB returns this status and body in this scenario
+	assertStatus(t, resp, http.StatusPreconditionFailed)
+	assert.Contains(t, string(resp.BodyBytes()), "Duplicate database name")
+
+	// The remaining nodes will get the config via polling.
+	count, err := rtc.RefreshClusterDbConfigs()
+	require.NoError(t, err)
+	assert.Equal(t, rtc.NumNodes()-2, count)
+
+	// Sanity-check they have all loaded after the forced update.
+	rtc.ForEachNode(func(rt *RestTester) {
+		resp := rt.SendAdminRequest(http.MethodGet, "/"+db+"/", "")
+		assertStatus(t, resp, http.StatusOK)
+	})
+
+	// Now we'll attempt to write an invalid database to a single node.
+	// Ensure it doesn't get unloaded and is rolled back to the original database config.
+	rtNode := rtc.RoundRobin()
+
+	// upsert with an invalid config option
+	resp, err = rtNode.UpsertDbConfig(db, DbConfig{RevsLimit: base.Uint32Ptr(0)})
+	require.NoError(t, err)
+	// If this is being caught by upfront validation, it should be 400
+	// assertStatus(t, resp, http.StatusBadRequest)
+	assertStatus(t, resp, http.StatusInternalServerError)
+
+	// On the same node, make sure the database is still running.
+	resp = rtNode.SendAdminRequest(http.MethodGet, "/"+db+"/", "")
+	assertStatus(t, resp, http.StatusOK)
+
+	// and make sure we roll back the database to the previous version (without revs_limit set)
+	resp = rtNode.SendAdminRequest(http.MethodGet, "/"+db+"/_config", "")
+	assertStatus(t, resp, http.StatusOK)
+	assert.NotContains(t, string(resp.BodyBytes()), `"revs_limit":`)
+}

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -179,9 +179,7 @@ func TestPersistentDbConfigWithInvalidUpsert(t *testing.T) {
 	// upsert with an invalid config option
 	resp, err = rtNode.UpsertDbConfig(db, DbConfig{RevsLimit: base.Uint32Ptr(0)})
 	require.NoError(t, err)
-	// If this is being caught by upfront validation, it should be 400
-	// assertStatus(t, resp, http.StatusBadRequest)
-	assertStatus(t, resp, http.StatusInternalServerError)
+	assertStatus(t, resp, http.StatusBadRequest)
 
 	// On the same node, make sure the database is still running.
 	resp = rtNode.SendAdminRequest(http.MethodGet, "/"+db+"/", "")

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -418,7 +418,7 @@ func TestTLSSkipVerifyCombinations(t *testing.T) {
 				},
 			}
 
-			err := startupConfig.validate(false)
+			err := startupConfig.validate(base.IsEnterpriseEdition())
 			if test.expectError {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), errorText)
@@ -541,7 +541,7 @@ func TestUseTLSServer(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			sc := StartupConfig{Bootstrap: BootstrapConfig{Server: test.server, UseTLSServer: &test.useTLSServer}}
 
-			err := sc.validate(false)
+			err := sc.validate(base.IsEnterpriseEdition())
 
 			if test.expectedError != nil {
 				require.Error(t, err)

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -418,7 +418,7 @@ func TestTLSSkipVerifyCombinations(t *testing.T) {
 				},
 			}
 
-			err := startupConfig.validate()
+			err := startupConfig.validate(false)
 			if test.expectError {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), errorText)
@@ -541,7 +541,7 @@ func TestUseTLSServer(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			sc := StartupConfig{Bootstrap: BootstrapConfig{Server: test.server, UseTLSServer: &test.useTLSServer}}
 
-			err := sc.validate()
+			err := sc.validate(false)
 
 			if test.expectedError != nil {
 				require.Error(t, err)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -58,6 +58,7 @@ type RestTesterConfig struct {
 	enableAdminAuthPermissionsCheck bool
 	useTLSServer                    bool // If true, TLS will be required for communications with CBS. Default: false
 	persistentConfig                bool
+	groupID                         *string
 }
 
 type RestTester struct {
@@ -133,6 +134,10 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 	username, password, _ := testBucket.BucketSpec.Auth.GetCredentials()
 
+	// Disable config polling to avoid test flakiness and increase control of timing.
+	// Rely on on-demand config fetching for consistency.
+	sc.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0)
+
 	sc.Bootstrap.Server = testBucket.BucketSpec.Server
 	sc.Bootstrap.Username = username
 	sc.Bootstrap.Password = password
@@ -145,8 +150,22 @@ func (rt *RestTester) Bucket() base.Bucket {
 	sc.API.EnableAdminAuthenticationPermissionsCheck = &rt.enableAdminAuthPermissionsCheck
 	sc.Bootstrap.UseTLSServer = &rt.RestTesterConfig.useTLSServer
 	sc.Bootstrap.ServerTLSSkipVerify = base.BoolPtr(base.TestTLSSkipVerify())
+	if rt.RestTesterConfig.groupID != nil {
+		sc.Bootstrap.ConfigGroupID = *rt.RestTesterConfig.groupID
+	}
 
-	rt.RestTesterServerContext = NewServerContext(&sc, false)
+	// Allow EE-only config even in CE for testing.
+	if err := sc.validate(true); err != nil {
+		panic("invalid RestTester StartupConfig: " + err.Error())
+	}
+
+	rt.RestTesterServerContext = NewServerContext(&sc, rt.RestTesterConfig.persistentConfig)
+
+	if !base.ServerIsWalrus(sc.Bootstrap.Server) {
+		if err := rt.RestTesterServerContext.initializeCouchbaseServerConnections(); err != nil {
+			panic("Couldn't initialize Couchbase Server connection: " + err.Error())
+		}
+	}
 
 	if !base.UnitTestUrlIsWalrus() {
 		// Copy any testbucket cert info into boostrap server config
@@ -169,49 +188,52 @@ func (rt *RestTester) Bucket() base.Bucket {
 		rt.tb.Fatalf("Unable to copy initial startup config: %v", err)
 	}
 
-	useXattrs := base.TestUseXattrs()
+	// tests must create their own databases in persistent mode
+	if !rt.persistentConfig {
+		useXattrs := base.TestUseXattrs()
 
-	if rt.DatabaseConfig == nil {
-		// If no db config was passed in, create one
-		rt.DatabaseConfig = &DatabaseConfig{}
-	}
+		if rt.DatabaseConfig == nil {
+			// If no db config was passed in, create one
+			rt.DatabaseConfig = &DatabaseConfig{}
+		}
 
-	if base.TestsDisableGSI() {
-		rt.DatabaseConfig.UseViews = base.BoolPtr(true)
-	}
+		if base.TestsDisableGSI() {
+			rt.DatabaseConfig.UseViews = base.BoolPtr(true)
+		}
 
-	// numReplicas set to 0 for test buckets, since it should assume that there may only be one indexing node.
-	numReplicas := uint(0)
-	rt.DatabaseConfig.NumIndexReplicas = &numReplicas
+		// numReplicas set to 0 for test buckets, since it should assume that there may only be one indexing node.
+		numReplicas := uint(0)
+		rt.DatabaseConfig.NumIndexReplicas = &numReplicas
 
-	rt.DatabaseConfig.Bucket = &testBucket.BucketSpec.BucketName
-	rt.DatabaseConfig.Username = username
-	rt.DatabaseConfig.Password = password
-	rt.DatabaseConfig.CACertPath = testBucket.BucketSpec.CACertPath
-	rt.DatabaseConfig.CertPath = testBucket.BucketSpec.Certpath
-	rt.DatabaseConfig.KeyPath = testBucket.BucketSpec.Keypath
-	rt.DatabaseConfig.Name = "db"
-	rt.DatabaseConfig.Sync = &rt.SyncFn
-	rt.DatabaseConfig.EnableXattrs = &useXattrs
-	if rt.EnableNoConflictsMode {
-		boolVal := false
-		rt.DatabaseConfig.AllowConflicts = &boolVal
-	}
+		rt.DatabaseConfig.Bucket = &testBucket.BucketSpec.BucketName
+		rt.DatabaseConfig.Username = username
+		rt.DatabaseConfig.Password = password
+		rt.DatabaseConfig.CACertPath = testBucket.BucketSpec.CACertPath
+		rt.DatabaseConfig.CertPath = testBucket.BucketSpec.Certpath
+		rt.DatabaseConfig.KeyPath = testBucket.BucketSpec.Keypath
+		rt.DatabaseConfig.Name = "db"
+		rt.DatabaseConfig.Sync = &rt.SyncFn
+		rt.DatabaseConfig.EnableXattrs = &useXattrs
+		if rt.EnableNoConflictsMode {
+			boolVal := false
+			rt.DatabaseConfig.AllowConflicts = &boolVal
+		}
 
-	rt.DatabaseConfig.SGReplicateEnabled = base.BoolPtr(rt.RestTesterConfig.sgReplicateEnabled)
+		rt.DatabaseConfig.SGReplicateEnabled = base.BoolPtr(rt.RestTesterConfig.sgReplicateEnabled)
 
-	_, err = rt.RestTesterServerContext.AddDatabaseFromConfig(*rt.DatabaseConfig)
-	if err != nil {
-		rt.tb.Fatalf("Error from AddDatabaseFromConfig: %v", err)
-	}
+		_, err = rt.RestTesterServerContext.AddDatabaseFromConfig(*rt.DatabaseConfig)
+		if err != nil {
+			rt.tb.Fatalf("Error from AddDatabaseFromConfig: %v", err)
+		}
 
-	// Update the testBucket Bucket to the one associated with the database context.  The new (dbContext) bucket
-	// will be closed when the rest tester closes the server context. The original bucket will be closed using the
-	// testBucket's closeFn
-	rt.testBucket.Bucket = rt.RestTesterServerContext.Database("db").Bucket
+		// Update the testBucket Bucket to the one associated with the database context.  The new (dbContext) bucket
+		// will be closed when the rest tester closes the server context. The original bucket will be closed using the
+		// testBucket's closeFn
+		rt.testBucket.Bucket = rt.RestTesterServerContext.Database("db").Bucket
 
-	if err := rt.SetAdminParty(rt.guestEnabled); err != nil {
-		rt.tb.Fatalf("Error from SetAdminParty %v", err)
+		if err := rt.SetAdminParty(rt.guestEnabled); err != nil {
+			rt.tb.Fatalf("Error from SetAdminParty %v", err)
+		}
 	}
 
 	return rt.testBucket.Bucket
@@ -220,6 +242,36 @@ func (rt *RestTester) Bucket() base.Bucket {
 func (rt *RestTester) ServerContext() *ServerContext {
 	rt.Bucket()
 	return rt.RestTesterServerContext
+}
+
+// CreateDatabase is a utility function to create a database through the REST API
+func (rt *RestTester) CreateDatabase(dbName string, config DbConfig) (*TestResponse, error) {
+	dbcJSON, err := base.JSONMarshal(config)
+	if err != nil {
+		return nil, err
+	}
+	resp := rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/", dbName), string(dbcJSON))
+	return resp, nil
+}
+
+// ReplaceDbConfig is a utility function to replace a database config through the REST API
+func (rt *RestTester) ReplaceDbConfig(dbName string, config DbConfig) (*TestResponse, error) {
+	dbcJSON, err := base.JSONMarshal(config)
+	if err != nil {
+		return nil, err
+	}
+	resp := rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/_config", dbName), string(dbcJSON))
+	return resp, nil
+}
+
+// UpsertDbConfig is a utility function to upsert a database through the REST API
+func (rt *RestTester) UpsertDbConfig(dbName string, config DbConfig) (*TestResponse, error) {
+	dbcJSON, err := base.JSONMarshal(config)
+	if err != nil {
+		return nil, err
+	}
+	resp := rt.SendAdminRequest(http.MethodPost, fmt.Sprintf("/%s/_config", dbName), string(dbcJSON))
+	return resp, nil
 }
 
 // Returns first database found for server context.

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -154,7 +154,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 		sc.Bootstrap.ConfigGroupID = *rt.RestTesterConfig.groupID
 	}
 
-	// Allow EE-only config even in CE for testing.
+	// Allow EE-only config even in CE for testing using group IDs.
 	if err := sc.validate(true); err != nil {
 		panic("invalid RestTester StartupConfig: " + err.Error())
 	}


### PR DESCRIPTION
CBG-1846

- On a failed load during `/db/_config` update, the database is rolled back to the version in the bucket.
- Add more upfront `dbConfig` validation to avoid rollback churn in most cases.
- Add `RestTesterCluster` and use it in `TestPersistentDbConfigWithInvalidUpsert` to reproduce issue.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1487/
  - `TestAttachmentCompactionStopImmediateStart` Race assertion fixed in #5371 
