### PR TITLE
CBG-1857 Implement error set handler

### DIFF
--- a/base/error_test.go
+++ b/base/error_test.go
@@ -13,6 +13,7 @@ package base
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"reflect"
 	"testing"
@@ -181,4 +182,28 @@ func TestIsDocNotFoundError(t *testing.T) {
 
 	fakeSyntaxError := &json.SyntaxError{}
 	assert.False(t, IsDocNotFoundError(fakeSyntaxError))
+}
+
+func TestMultiError(t *testing.T) {
+	var m *MultiError
+	m = m.Append(fmt.Errorf("first error"))
+	m = m.Append(fmt.Errorf("second error"))
+	assert.Equal(t, 2, m.Len())
+	assert.NotNil(t, m.ErrorOrNil())
+
+	var moreErrors *MultiError
+	moreErrors = moreErrors.Append(m)
+	assert.Equal(t, 2, moreErrors.Len())
+	assert.NotNil(t, moreErrors.ErrorOrNil())
+
+	var moreNonEmptyErrors *MultiError
+	moreNonEmptyErrors = moreNonEmptyErrors.Append(fmt.Errorf("another error"))
+	moreNonEmptyErrors = moreNonEmptyErrors.Append(moreErrors)
+	assert.Equal(t, 3, moreNonEmptyErrors.Len())
+	assert.NotNil(t, moreNonEmptyErrors.ErrorOrNil())
+	log.Printf("%s", moreNonEmptyErrors)
+
+	var nilError *MultiError
+	assert.Nil(t, nilError.ErrorOrNil())
+
 }

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -109,9 +109,6 @@ licenses/APL2.txt.
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 
-  <project name="go-multierror" path="godeps/src/github.com/hashicorp/go-multierror" remote="couchbasedeps" revision="0d28cf682dbe774898e42a3db11b7ce24b36751a"/>
-  <project name="errwrap" path="godeps/src/github.com/hashicorp/errwrap" remote="couchbasedeps" revision="7b00e5db719c64d14dd0caaacbd13e76254d02c0"/>
-
   <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
 
   <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>

--- a/rest/sgcollect_test.go
+++ b/rest/sgcollect_test.go
@@ -17,8 +17,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/couchbase/sync_gateway/base"
+
 	goassert "github.com/couchbaselabs/go.assert"
-	"github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -129,7 +130,7 @@ func TestSgcollectOptionsValidateInvalid(t *testing.T) {
 		t.Run(test.name, func(ts *testing.T) {
 			errs := test.options.Validate()
 			require.NotNil(t, errs)
-			multiError, ok := errs.(*multierror.Error)
+			multiError, ok := errs.(*base.MultiError)
 			require.True(t, ok)
 
 			// make sure we get at least one error for the given invalid options.


### PR DESCRIPTION
CBG-1857

Implementation of error that manages a slice of errors.  Callers must use ErrorOrNil() once error set has been built for nil handling.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1491/
  - test server OOM issues
- [x] verified locally