### PR TITLE
Fix logging in StoreDestFactory warning with missing destKey value

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -567,7 +567,7 @@ func StoreDestFactory(destKey string, dest CbgtDestFactoryFunc) {
 
 	// We don't expect duplicate destKey registration - log a warning if it already exists
 	if ok {
-		Warnf("destKey %s already exists in cbgtDestFactories - new value will replace the existing dest")
+		Warnf("destKey %s already exists in cbgtDestFactories - new value will replace the existing dest", destKey)
 	}
 	cbgtDestFactories[destKey] = dest
 	cbgtDestFactoriesLock.Unlock()


### PR DESCRIPTION
Fixes incorrect logging seen in integration tests:

```
2021-12-14T07:15:42.726-08:00 [WRN] destKey %!s(MISSING) already exists in cbgtDestFactories - new value will replace the existing dest -- base.StoreDestFactory() at dcp_sharded.go:570
```

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- n/a