### PR TITLE
CBG-1848: Create 3.0.0 manifest and move master to 3.1.0

### DIFF
--- a/base/version.go
+++ b/base/version.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	ProductName          = "Couchbase Sync Gateway"
-	ProductVersionNumber = "3.0" // API/feature level
+	ProductVersionNumber = "3.1" // API/feature level
 )
 
 var (

--- a/manifest/2.8.xml
+++ b/manifest/2.8.xml
@@ -24,7 +24,7 @@ licenses/APL2.txt.
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
-    <project name="build" path="cbbuild" remote="couchbase">
+    <project name="build" path="cbbuild" remote="couchbase" revision="0fc38ccd909e027412260c1d5905cfcd50c268d4">
         <annotation name="VERSION" value="2.8.3"     keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>

--- a/manifest/2.8.xml
+++ b/manifest/2.8.xml
@@ -32,7 +32,7 @@ licenses/APL2.txt.
 
 
     <!-- Sync Gateway -->
-    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/2.8.3"/>
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
     <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
 

--- a/manifest/3.0.xml
+++ b/manifest/3.0.xml
@@ -25,14 +25,14 @@ licenses/APL2.txt.
   <!-- Build Scripts (required on CI servers) -->
   <project name="product-texts" path="product-texts" remote="couchbase"/>
   <project name="build" path="cbbuild" remote="couchbase">
-    <annotation name="VERSION" value="3.1.0"     keep="true"/>
+    <annotation name="VERSION" value="3.0.0"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
   </project>
 
 
   <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase"/>
+  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/3.0.0"/>
 
   <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
 

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -2,7 +2,7 @@
     "product": "sync_gateway",
     "manifests": {
         "manifest/default.xml": {
-            "release": "3.0.0",
+            "release": "3.1.0",
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,
@@ -271,6 +271,15 @@
             "go_version": "1.13.4",
             "trigger_blackduck": true,
             "start_build": 1
+        },
+        "manifest/3.0.xml": {
+            "release": "3.0.0",
+            "release_name": "Couchbase Sync Gateway 3.0.0",
+            "production": true,
+            "interval": 120,
+            "go_version": "1.16.6",
+            "trigger_blackduck": true,
+            "start_build": 529
         },
         "manifest/dev.xml": {
             "release": "dev",

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -264,10 +264,11 @@
             "start_build": 10
         },
         "manifest/2.8.xml": {
+            "do-build": false,
             "release": "2.8.3",
             "release_name": "Couchbase Sync Gateway 2.8.3",
             "production": true,
-            "interval": 120,
+            "interval": 1440,
             "go_version": "1.13.4",
             "trigger_blackduck": true,
             "start_build": 1


### PR DESCRIPTION
CBG-1848

- Master branch now 3.1.0
- 3.0.0 built from 3.0.xml manifest pointing to `release/3.0.0` branch
- Set `do_build=false` on GA'd 2.8.3

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- n/a