### PR TITLE
CBG-1046: Added ability to specify user for active peer in ISGR

### DIFF
--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -61,6 +61,8 @@ type ActiveReplicatorConfig struct {
 	Continuous bool
 	// RemoteDBURL represents the full Sync Gateway URL, including database path, and basic auth credentials of the target.
 	RemoteDBURL *url.URL
+	// RunAs is the user to run the replication under
+	RunAs string
 	// PurgeOnRemoval will purge the document on the active side if we pull a removal from the remote.
 	PurgeOnRemoval bool
 	// ActiveDB is a reference to the active database context.
@@ -130,6 +132,9 @@ func (arc ActiveReplicatorConfig) CheckpointHash() (string, error) {
 		return "", err
 	}
 	if _, err := hash.Write([]byte(arc.RemoteDBURL.String())); err != nil {
+		return "", err
+	}
+	if _, err := hash.Write([]byte(arc.RunAs)); err != nil {
 		return "", err
 	}
 	bucketUUID, err := arc.ActiveDB.Bucket.UUID()

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -251,7 +251,7 @@ func (rc *ReplicationConfig) Upsert(c *ReplicationUpsertConfig) {
 		rc.Username = *c.Username
 	}
 
-	if c.Username != nil && c.Password != nil {
+	if c.Username != nil {
 		rc.Password = *c.Password
 	}
 
@@ -501,7 +501,7 @@ func (m *sgReplicateManager) NewActiveReplicatorConfig(config *ReplicationCfg) (
 	rc = &ActiveReplicatorConfig{
 		ID:                 config.ID,
 		Continuous:         config.Continuous,
-		ActiveDB:           activeDB, // sg-replicate interacts with local as admin
+		ActiveDB:           activeDB,
 		PurgeOnRemoval:     config.PurgeOnRemoval,
 		DeltasEnabled:      config.DeltaSyncEnabled,
 		InsecureSkipVerify: insecureSkipVerify,

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -50,7 +50,7 @@ const (
 	ConfigErrorMissingQueryParams               = "Replication specifies sync_gateway/bychannel filter but is missing query_params"
 	ConfigErrorMissingRemote                    = "Replication remote must be specified"
 	ConfigErrorMissingDirection                 = "Replication direction must be specified"
-	ConfigErrorDuplicateCredentials             = "Auth credentials can be specified using username/password config properties or remote URL, but not both"
+	ConfigErrorDuplicateCredentials             = "Auth credentials can be specified using remote_username/remote_password config properties or remote URL, but not both"
 	ConfigErrorConfigBasedAdhoc                 = "adhoc=true is invalid for replication in Sync Gateway configuration"
 	ConfigErrorConfigBasedCancel                = "cancel=true is invalid for replication in Sync Gateway configuration"
 	ConfigErrorInvalidConflictResolutionTypeFmt = "Conflict resolution type is invalid, valid values are %s/%s/%s/%s"
@@ -212,7 +212,7 @@ func (rc *ReplicationConfig) ValidateReplication(fromConfig bool) (err error) {
 		return base.HTTPErrorf(http.StatusBadRequest, "Replication remote URL is invalid")
 	}
 
-	if (remoteURL != nil && remoteURL.User.Username() != "") && rc.RemoteUsername != "" {
+	if (remoteURL != nil && remoteURL.User.Username() != "") && (rc.RemoteUsername != "" || rc.Username != "") {
 		return base.HTTPErrorf(http.StatusBadRequest,
 			ConfigErrorDuplicateCredentials)
 	}
@@ -520,6 +520,7 @@ func (m *sgReplicateManager) NewActiveReplicatorConfig(config *ReplicationCfg) (
 		DeltasEnabled:      config.DeltaSyncEnabled,
 		InsecureSkipVerify: insecureSkipVerify,
 		CheckpointInterval: m.CheckpointInterval,
+		RunAs:              config.RunAs,
 	}
 
 	rc.MaxReconnectInterval = defaultMaxReconnectInterval

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -212,6 +212,11 @@ func (rc *ReplicationConfig) ValidateReplication(fromConfig bool) (err error) {
 		return base.HTTPErrorf(http.StatusBadRequest, "Replication remote URL is invalid")
 	}
 
+	if rc.RemoteUsername != "" && rc.Username != "" {
+		return base.HTTPErrorf(http.StatusBadRequest,
+			"Cannot set both remote_username and username config options. Please only use the remote_username and remote_password config options")
+	}
+
 	if (remoteURL != nil && remoteURL.User.Username() != "") && (rc.RemoteUsername != "" || rc.Username != "") {
 		return base.HTTPErrorf(http.StatusBadRequest,
 			ConfigErrorDuplicateCredentials)

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -555,6 +555,7 @@ func TestIsCfgChanged(t *testing.T) {
 				Filter:                 "a",
 				QueryParams:            []interface{}{"ABC"},
 				Cancel:                 true,
+				RunAsAdminUser:         true,
 			},
 		}
 	}

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -555,7 +555,6 @@ func TestIsCfgChanged(t *testing.T) {
 				Filter:                 "a",
 				QueryParams:            []interface{}{"ABC"},
 				Cancel:                 true,
-				RunAsAdminUser:         true,
 			},
 		}
 	}

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -4291,9 +4291,7 @@ func TestDeleteDatabasePointingAtSameBucketPersistent(t *testing.T) {
 
 // CBG-1046: Add ability to specify user for active peer in sg-replicate2
 func TestSpecifyUserDocsToReplicate(t *testing.T) {
-	if base.GTestBucketPool.NumUsableBuckets() < 2 {
-		t.Skipf("test requires at least 2 usable test buckets")
-	}
+	base.RequireNumTestBuckets(t, 2)
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 
 	testCases := []struct {

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -4289,6 +4289,156 @@ func TestDeleteDatabasePointingAtSameBucketPersistent(t *testing.T) {
 	assert.NoError(t, fetchDb2DestErr)
 }
 
+// CBG-1046: Add ability to specify user for active peer in sg-replicate2
+func TestSpecifyUserDocsToReplicate(t *testing.T) {
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+
+	testCases := []struct {
+		direction string
+	}{
+		{
+			direction: "push",
+		},
+		{
+			direction: "pull",
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.direction, func(t *testing.T) {
+			replName := test.direction
+			syncFunc := `
+function (doc) {
+	if (doc.owner) {
+		requireUser(doc.owner);
+	}
+	channel(doc.channels);
+	requireAccess(doc.channels);
+}`
+			rtConfig := &RestTesterConfig{
+				SyncFn: syncFunc,
+				DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+					Users: map[string]*db.PrincipalConfig{
+						"alice": {
+							Password:         base.StringPtr("pass"),
+							ExplicitChannels: base.SetOf("chanAlpha", "chanBeta", "chanCharlie", "chanHotel", "chanIndia"),
+						},
+						"bob": {
+							Password:         base.StringPtr("pass"),
+							ExplicitChannels: base.SetOf("chanDelta", "chanEcho"),
+						},
+					},
+				}},
+			}
+			// Set up buckets, rest testers, and set up servers
+			passiveRT := NewRestTester(t, rtConfig)
+			defer passiveRT.Close()
+
+			activeRT := NewRestTester(t, rtConfig)
+			defer activeRT.Close()
+
+			publicSrv := httptest.NewServer(passiveRT.TestPublicHandler())
+			defer publicSrv.Close()
+
+			adminSrv := httptest.NewServer(passiveRT.TestAdminHandler())
+			defer adminSrv.Close()
+
+			// Change RT depending on direction
+			var senderRT *RestTester   // RT that has the initial docs that get replicated to the other bucket
+			var receiverRT *RestTester // RT that gets the docs replicated to it
+			if test.direction == "push" {
+				senderRT = activeRT
+				receiverRT = passiveRT
+			} else if test.direction == "pull" {
+				senderRT = passiveRT
+				receiverRT = activeRT
+			}
+
+			// Create docs to replicate
+			bulkDocsBody := `
+{
+  "docs": [
+  	{"channels":["chanAlpha"], "access":"alice"},
+  	{"channels":["chanBeta","chanFoxtrot"], "access":"alice"},
+  	{"channels":["chanCharlie","chanEcho"], "access":"alice,bob"},
+  	{"channels":["chanDelta"], "access":"bob"},
+  	{"channels":["chanGolf"], "access":""},
+  	{"channels":["!"], "access":"alice,bob"},
+  	{"channels":["!"], "access":"bob", "owner":"bob"},
+  	{"channels":["!"], "access":"alice", "owner":"alice"},
+	{"channels":["chanHotel"], "access":"", "owner":"mike"},
+	{"channels":["chanIndia"], "access":"alice", "owner":"alice"}
+  ]
+}
+`
+			resp := senderRT.SendAdminRequest("POST", "/db/_bulk_docs", bulkDocsBody)
+			assertStatus(t, resp, http.StatusCreated)
+
+			err := senderRT.WaitForPendingChanges()
+			require.NoError(t, err)
+
+			// Replicate just alices docs
+			replConf := `
+				{
+					"replication_id": "` + replName + `",
+					"remote": "` + publicSrv.URL + `/db",
+					"direction": "` + test.direction + `",
+					"continuous": true,
+					"batch": 200,
+					"run_as_admin_user": false,
+					"username": "alice",
+					"password": "pass"
+				}`
+
+			resp = activeRT.SendAdminRequest("PUT", "/db/_replication/"+replName, replConf)
+			assertStatus(t, resp, http.StatusCreated)
+
+			err = activeRT.GetDatabase().SGReplicateMgr.StartReplications()
+			require.NoError(t, err)
+			activeRT.waitForReplicationStatus(replName, db.ReplicationStateRunning)
+
+			value, _ := base.WaitForStat(receiverRT.GetDatabase().DbStats.Database().NumDocWrites.Value, 6)
+			assert.EqualValues(t, 6, value)
+
+			changesResults, err := receiverRT.WaitForChanges(6, "/db/_changes?since=0&include_docs=true", "", true)
+			assert.NoError(t, err)
+			assert.Len(t, changesResults.Results, 6)
+			// Check the docs are alices docs
+			for _, result := range changesResults.Results {
+				body, err := result.Doc.MarshalJSON()
+				require.NoError(t, err)
+				assert.Contains(t, string(body), "alice")
+			}
+
+			// Replicate all docs
+			// Run as admin should default to true
+			replConf = `
+					{
+						"replication_id": "` + replName + `",
+						"remote": "` + adminSrv.URL + `/db",
+						"direction": "` + test.direction + `",
+						"continuous": true,
+						"batch": 200
+					}`
+
+			err = activeRT.GetDatabase().SGReplicateMgr.DeleteReplication(replName)
+			require.NoError(t, err)
+
+			resp = activeRT.SendAdminRequest("PUT", "/db/_replication/"+replName, replConf)
+			assertStatus(t, resp, http.StatusCreated)
+
+			err = activeRT.GetDatabase().SGReplicateMgr.StartReplications()
+			require.NoError(t, err)
+			activeRT.waitForReplicationStatus(replName, db.ReplicationStateRunning)
+
+			value, _ = base.WaitForStat(receiverRT.GetDatabase().DbStats.Database().NumDocWrites.Value, 10)
+			assert.EqualValues(t, 10, value)
+		})
+	}
+}
+
 // CBG-1581: Ensure activeReplicatorCommon does final checkpoint on stop/disconnect
 func TestReplicatorCheckpointOnStop(t *testing.T) {
 	passiveRT := NewRestTester(t, nil)

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -1164,12 +1164,12 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 
 	// Create replication with explicitly defined auth credentials in replication config
 	replication1Config := db.ReplicationConfig{
-		ID:        "replication1",
-		Remote:    "http://remote:4984/db",
-		Username:  "alice",
-		Password:  "pass",
-		Direction: db.ActiveReplicatorTypePull,
-		Adhoc:     true,
+		ID:             "replication1",
+		Remote:         "http://remote:4984/db",
+		RemoteUsername: "alice",
+		RemotePassword: "pass",
+		Direction:      db.ActiveReplicatorTypePull,
+		Adhoc:          true,
 	}
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_replication/replication1", marshalConfig(t, replication1Config))
 	assertStatus(t, response, http.StatusCreated)
@@ -1188,10 +1188,10 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 		assert.Equal(t, expected.Adhoc, actual.Adhoc, "Replication type mismatch")
 		assert.Equal(t, expected.Direction, actual.Direction, "Replication direction mismatch")
 		assert.Equal(t, expected.Remote, actual.Remote, "Couldn't redact auth credentials")
-		assert.Equal(t, expected.Username, actual.Username, "Couldn't redact username")
-		assert.Equal(t, expected.Password, actual.Password, "Couldn't redact password")
+		assert.Equal(t, expected.RemoteUsername, actual.RemoteUsername, "Couldn't redact username")
+		assert.Equal(t, expected.RemotePassword, actual.RemotePassword, "Couldn't redact password")
 	}
-	replication1Config.Password = base.RedactedStr
+	replication1Config.RemotePassword = base.RedactedStr
 	checkReplicationConfig(&replication1Config, &configResponse)
 
 	// Create another replication with auth credentials defined in Remote URL
@@ -1292,21 +1292,21 @@ func TestValidateReplication(t *testing.T) {
 		{
 			name: "auth credentials specified in both replication config and remote URL",
 			replicationConfig: db.ReplicationConfig{
-				Remote:   "http://bob:pass@remote:4984/db",
-				Username: "alice",
-				Password: "pass",
+				Remote:         "http://bob:pass@remote:4984/db",
+				RemoteUsername: "alice",
+				RemotePassword: "pass",
 			},
 			expectedErrorMsg: db.ConfigErrorDuplicateCredentials,
 		},
 		{
 			name: "auth credentials specified in replication config",
 			replicationConfig: db.ReplicationConfig{
-				Remote:      "http://remote:4984/db",
-				Username:    "alice",
-				Password:    "pass",
-				Filter:      base.ByChannelFilter,
-				QueryParams: map[string]interface{}{"channels": []interface{}{"E", "A", "D", "G", "B", "e"}},
-				Direction:   db.ActiveReplicatorTypePull,
+				Remote:         "http://remote:4984/db",
+				RemoteUsername: "alice",
+				RemotePassword: "pass",
+				Filter:         base.ByChannelFilter,
+				QueryParams:    map[string]interface{}{"channels": []interface{}{"E", "A", "D", "G", "B", "e"}},
+				Direction:      db.ActiveReplicatorTypePull,
 			},
 		},
 		{
@@ -1452,12 +1452,12 @@ func TestGetStatusWithReplication(t *testing.T) {
 
 	// Create a replication
 	config1 := db.ReplicationConfig{
-		ID:        "replication1",
-		Remote:    "http://remote:4984/db",
-		Username:  "alice",
-		Password:  "pass",
-		Direction: db.ActiveReplicatorTypePull,
-		Adhoc:     true,
+		ID:             "replication1",
+		Remote:         "http://remote:4984/db",
+		RemoteUsername: "alice",
+		RemotePassword: "pass",
+		Direction:      db.ActiveReplicatorTypePull,
+		Adhoc:          true,
 	}
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_replication/replication1", marshalConfig(t, config1))
 	assertStatus(t, response, http.StatusCreated)
@@ -1495,8 +1495,8 @@ func TestGetStatusWithReplication(t *testing.T) {
 	assertReplication := func(expected db.ReplicationConfig, actual *db.ReplicationCfg) {
 		assert.Equal(t, expected.ID, actual.ID)
 		assert.Equal(t, expected.Remote, actual.Remote)
-		assert.Equal(t, expected.Username, actual.Username)
-		assert.Equal(t, expected.Password, actual.Password)
+		assert.Equal(t, expected.RemoteUsername, actual.RemoteUsername)
+		assert.Equal(t, expected.RemotePassword, actual.RemotePassword)
 		assert.Equal(t, expected.Direction, actual.Direction)
 		assert.Equal(t, expected.Adhoc, actual.Adhoc)
 	}
@@ -1504,7 +1504,7 @@ func TestGetStatusWithReplication(t *testing.T) {
 	// Check replication1 details in cluster response
 	repl, ok := database.SGRCluster.Replications[config1.ID]
 	assert.True(t, ok, "Error getting replication")
-	config1.Password = base.RedactedStr
+	config1.RemotePassword = base.RedactedStr
 	assertReplication(config1, repl)
 
 	// Check replication2 details in cluster response


### PR DESCRIPTION
CBG-1046

- Added new replicator config option `run_as` which will run the replication as the user defined. If left blank, the replication is ran as an admin user
- Added test to test sync function is being ran by correct user, and only the docs the user has access to is being replicated
- Deprecated replication config options `username` and `password` which have been replaced by `remote_username` and `remote_password`. This will log a deprecation warning every time the fields are modified
- Added a test to test that `username` and `password` is mapped on to `remote_username` and `remote_password` respectively and ensures the password redaction is working correctly

# Dependencies
- [x] Merge #5383 in to fix race condition in test

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1503
