### PR TITLE
3.1.0: Bump Go version to 1.17.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           key: sgw-bootstrap-cache-${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16.6
+          go-version: 1.17.5
       - name: Set GOPATH
         run: echo "GOPATH=$GITHUB_WORKSPACE/godeps" >> $GITHUB_ENV
       - name: build
@@ -75,7 +75,7 @@ jobs:
           key: sgw-bootstrap-cache-${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16.6
+          go-version: 1.17.5
       - name: Set GOPATH
         run: ${{ matrix.set-gopath }}
       - name: 'test'
@@ -93,7 +93,7 @@ jobs:
           key: sgw-bootstrap-cache-${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16.6
+          go-version: 1.17.5
       - name: Set GOPATH
         run: echo "GOPATH=$GITHUB_WORKSPACE/godeps" >> $GITHUB_ENV
       - name: 'test -race'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     agent { label 'sync-gateway-pipeline-builder' }
 
     environment {
-        GO_VERSION = 'go1.16.6'
+        GO_VERSION = 'go1.17.5'
         GVM = "/root/.gvm/bin/gvm"
         GO = "/root/.gvm/gos/${GO_VERSION}/bin"
         GOPATH = "${WORKSPACE}/godeps"

--- a/auth/auth_time_sensitive_test.go
+++ b/auth/auth_time_sensitive_test.go
@@ -1,3 +1,4 @@
+//go:build !race
 // +build !race
 
 /*

--- a/base/constants_ce.go
+++ b/base/constants_ce.go
@@ -1,3 +1,4 @@
+//go:build !cb_sg_enterprise
 // +build !cb_sg_enterprise
 
 /*

--- a/base/constants_ee.go
+++ b/base/constants_ee.go
@@ -1,3 +1,4 @@
+//go:build cb_sg_enterprise
 // +build cb_sg_enterprise
 
 /*

--- a/base/rlimit.go
+++ b/base/rlimit.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/base/rlimit_test.go
+++ b/base/rlimit_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/base/util_ce.go
+++ b/base/util_ce.go
@@ -1,3 +1,4 @@
+//go:build !cb_sg_enterprise
 // +build !cb_sg_enterprise
 
 /*

--- a/base/util_ee.go
+++ b/base/util_ee.go
@@ -1,3 +1,4 @@
+//go:build cb_sg_enterprise
 // +build cb_sg_enterprise
 
 /*

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -6,7 +6,7 @@
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,
-            "go_version": "1.16.6",
+            "go_version": "1.17.5",
             "trigger_blackduck": true,
             "start_build": 1
         },

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -9,6 +9,7 @@
 // This file contains tests which depend on the race detector being disabled.  Contains changes tests
 // that have unpredictable timing when running w/ race detector due to longpoll/continuous changes request
 // processing.
+//go:build !race
 // +build !race
 
 package rest

--- a/service/sg-windows/sg-accel-service/sg-accel-service.go
+++ b/service/sg-windows/sg-accel-service/sg-accel-service.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/service/sg-windows/sg-service/sg-service.go
+++ b/service/sg-windows/sg-service/sg-service.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*


### PR DESCRIPTION
Proactively bump Go to latest version as early as possible for SG 3.1.0

- Updated build tag format to match 1.17's gofmt

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1504/
