### PR TITLE
CBG-1849: Flaky TestSGR2TombstoneConflictHandling/RemoteLongResurrectRemote

### DIFF
--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -3996,17 +3996,10 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 	}
 
 	compareDocRev := func(docRev, cmpRev string) (shouldRetry bool, err error, value interface{}) {
-		var gen, hash bool
-		docArr := strings.Split(docRev, "-")
-		cmpArr := strings.Split(cmpRev, "-")
-		if len(docArr) > 0 && len(cmpArr) > 0 {
-			gen = (docArr[0] == cmpArr[0])
-		}
-		if len(docArr) > 1 && len(cmpArr) > 1 {
-			hash = (docArr[1] == cmpArr[1])
-		}
-		if gen {
-			if !hash {
+		docGen, docHash := db.ParseRevID(docRev)
+		cmpGen, cmpHash := db.ParseRevID(docRev)
+		if docGen ==  cmpGen {
+			if docHash != cmpHash {
 				return false, fmt.Errorf("rev generations match but hashes are different: %v, %v", docRev, cmpRev), nil
 			}
 			return false, nil, docRev

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -3997,8 +3997,8 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 
 	compareDocRev := func(docRev, cmpRev string) (shouldRetry bool, err error, value interface{}) {
 		docGen, docHash := db.ParseRevID(docRev)
-		cmpGen, cmpHash := db.ParseRevID(docRev)
-		if docGen ==  cmpGen {
+		cmpGen, cmpHash := db.ParseRevID(cmpRev)
+		if docGen == cmpGen {
 			if docHash != cmpHash {
 				return false, fmt.Errorf("rev generations match but hashes are different: %v, %v", docRev, cmpRev), nil
 			}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -510,6 +510,16 @@ func (rt *RestTester) WaitForConditionWithOptions(successFunc func() bool, maxNu
 	return nil
 }
 
+func (rt *RestTester) WaitForConditionShouldRetry(conditionFunc func() (shouldRetry bool, err error, value interface{}), maxNumAttempts, timeToSleepMs int) error {
+	sleeper := base.CreateSleeperFunc(maxNumAttempts, timeToSleepMs)
+	err, _ := base.RetryLoop("Wait for condition options", conditionFunc, sleeper)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (rt *RestTester) SendAdminRequest(method, resource string, body string) *TestResponse {
 	input := bytes.NewBufferString(body)
 	request, err := http.NewRequest(method, "http://localhost"+resource, input)


### PR DESCRIPTION
CBG-1849

- Test seems to have failed waiting for specific rev hash (generations seemed to match).
- No reliable way to repro and no race condition was found.
- Added comparison and logging to post full expected and actual revs.
- Added a "should retry" wait for when rev hashes don't match, and not retry 200 times.
- Eval errors from get doc calls, reduce possible red herring msgs.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1508/
