### PR TITLE
CBG-1864: Fixed race condition caused when getting user roles

### DIFF
--- a/auth/principal.go
+++ b/auth/principal.go
@@ -123,6 +123,8 @@ type User interface {
 
 	RoleHistory() TimedSetHistory
 
+	PreloadRoles()
+
 	RevokedChannels(since uint64, lowSeq uint64, triggeredBy uint64) RevokedChannels
 
 	// Obtains the period over which the user had access to the given channel. Either directly or via a role.

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -123,7 +123,7 @@ type User interface {
 
 	RoleHistory() TimedSetHistory
 
-	PreloadRoles()
+	InitializeRoles()
 
 	RevokedChannels(since uint64, lowSeq uint64, triggeredBy uint64) RevokedChannels
 

--- a/auth/user.go
+++ b/auth/user.go
@@ -471,7 +471,7 @@ func (user *userImpl) GetRoles() []Role {
 	return user.roles
 }
 
-func (user *userImpl) PreloadRoles() {
+func (user *userImpl) InitializeRoles() {
 	_ = user.GetRoles()
 }
 

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -105,7 +105,7 @@ func (bh *blipHandler) refreshUser() error {
 				bc.dbUserLock.Unlock()
 				return err
 			}
-			newUser.PreloadRoles()
+			newUser.InitializeRoles()
 			bc.userChangeWaiter.RefreshUserKeys(newUser)
 			bc.blipContextDb.SetUser(newUser)
 

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -105,6 +105,7 @@ func (bh *blipHandler) refreshUser() error {
 				bc.dbUserLock.Unlock()
 				return err
 			}
+			newUser.PreloadRoles()
 			bc.userChangeWaiter.RefreshUserKeys(newUser)
 			bc.blipContextDb.SetUser(newUser)
 

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -66,7 +66,7 @@ func NewBlipSyncContext(bc *blip.Context, db *Database, contextID string, replic
 
 	if u := db.User(); u != nil {
 		bsc.userName = u.Name()
-		u.PreloadRoles()
+		u.InitializeRoles()
 	}
 
 	// Register default handlers

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -66,6 +66,7 @@ func NewBlipSyncContext(bc *blip.Context, db *Database, contextID string, replic
 
 	if u := db.User(); u != nil {
 		bsc.userName = u.Name()
+		u.PreloadRoles()
 	}
 
 	// Register default handlers


### PR DESCRIPTION
CBG-1864

GetRoles is now preloaded when creating a new blip context or refreshing the user of the database

Tested locally with race detection for `TestSpecifyUserDocsToReplicate` from CBG-1046 https://github.com/couchbase/sync_gateway/pull/5379

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1549 failing test `TestBlipPusherUpdateDatabase` is skipped on master rebase