### PR TITLE
CBG-1513: Review intermittent test failure in TestDBOnlineWithDelayAndImmediate

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1884,14 +1884,11 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
 	assertStatus(t, response, 200)
 
-	require.Equal(t, "Offline", rt.GetDBState())
-
 	//Bring DB online with delay of two seconds
 	response = rt.SendAdminRequest("POST", "/db/_online", "{\"delay\":1}")
 	assertStatus(t, response, 200)
 
-	errDBState = rt.WaitForDBOffline()
-	assert.NoError(t, errDBState)
+	require.Equal(t, "Offline", rt.GetDBState())
 
 	// Bring DB online immediately
 	response = rt.SendAdminRequest("POST", "/db/_online", "")

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1872,12 +1872,6 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	assertNow := func(t *testing.T, expected interface{}, actual interface{}) {
-		if !assert.Equal(t, expected, actual) {
-			t.FailNow()
-		}
-	}
-
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
@@ -1885,12 +1879,12 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 	var errDBState error
 
 	log.Printf("Taking DB offline")
-	assertNow(t, "Online", rt.GetDBState())
+	require.Equal(t, "Online", rt.GetDBState())
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
 	assertStatus(t, response, 200)
 
-	assertNow(t, "Offline", rt.GetDBState())
+	require.Equal(t, "Offline", rt.GetDBState())
 
 	//Bring DB online with delay of two seconds
 	response = rt.SendAdminRequest("POST", "/db/_online", "{\"delay\":1}")

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -630,10 +630,6 @@ func (rt *RestTester) WaitForDBOnline() (err error) {
 	return rt.waitForDBState("Online")
 }
 
-func (rt *RestTester) WaitForDBOffline() (err error) {
-	return rt.waitForDBState("Offline")
-}
-
 func (rt *RestTester) waitForDBState(stateWant string) (err error) {
 	var stateCurr string
 	maxTries := 20


### PR DESCRIPTION
CBG-1513

- Not able to repro, but noticed that responses from the _offline posts where not being checked, instead there were a couple of misleading asserts on previous response.
- Fixed the _offline post response checks.
- Added wait for db offline.
- Removed redundant check for db online.
- Added helpers for get and wait for db state, in RestTester.


## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1514/
- [x] `count=100` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1524/
