### PR TITLE
Add function caller and line numbers to trace logging

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -245,8 +245,8 @@ func logTo(ctx context.Context, logLevel LogLevel, logKey LogKey, format string,
 	// Prepend timestamp, level, log key.
 	format = addPrefixes(format, ctx, logLevel, logKey)
 
-	// Warn and error logs also append caller name/line numbers.
-	if logLevel <= LevelWarn && logLevel > LevelNone {
+	// Error, warn and trace logs also append caller name/line numbers.
+	if logLevel <= LevelWarn || logLevel == LevelTrace {
 		format += " -- " + GetCallersName(2, true)
 	}
 


### PR DESCRIPTION
Makes for easier code navigation via logs. The performance cost of `GetCallerName` is expensive so limited to dev-time only trace logging.

![Screenshot 2021-12-23 at 11 51 49](https://user-images.githubusercontent.com/1525809/147236734-e22d84ac-3a57-4851-babc-4d86eea4f912.png)

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- n/a