### PR TITLE
CBG-1827: stop auto import before purge

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5564,6 +5564,7 @@ func TestTombstonedBulkDocsWithPriorPurge(t *testing.T) {
 			console.log("doc:"+JSON.stringify(doc))
 			console.log("oldDoc:"+JSON.stringify(oldDoc))
 		}`,
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{AutoImport: false}}, // prevent importing the doc before the purge
 	})
 	defer rt.Close()
 


### PR DESCRIPTION
CBG-1827

- Not able to repro, but by comparing the logs with a successful run, it seems the import happened right after the doc was added to the bucket, before the test issued the purge.
- Added db configuration to disable the import and allow the tested scenario to happen.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1516/
- [x] `count=25`  http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1520/