### PR TITLE
CBG-1826: flaky TestTombstonedBulkDocsWithExistingTombstone

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5602,6 +5602,7 @@ func TestTombstonedBulkDocsWithExistingTombstone(t *testing.T) {
 			console.log("doc:"+JSON.stringify(doc))
 			console.log("oldDoc:"+JSON.stringify(oldDoc))
 		}`,
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{AutoImport: false}}, // prevent importing the doc before the delete
 	})
 	defer rt.Close()
 


### PR DESCRIPTION
CBG-1826

- Very similar to CBG-1827 and caught in the same Jenkins run.
- Not able to repro, but by comparing the logs with a successful run, it seems the import happened right after the WriteCas/Remove to the bucket, and before /db/_bulk_docs.
- Added db configuration to disable the import and allow the tested scenario to happen.


## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1517/

