### PR TITLE
3.0 RC2: CBG-1860: Pass through admin authentication for sgcollect_info

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1132,6 +1132,9 @@ func (h *handler) handleSGCollect() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Invalid options used for sgcollect_info: %v", multiError)
 	}
 
+	// Populate username and password used by sgcollect_info script for talking to Sync Gateway.
+	params.syncGatewayUsername, params.syncGatewayPassword = h.getBasicAuth()
+
 	zipFilename := sgcollectFilename()
 
 	logFilePath := h.server.config.Logging.LogFilePath

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -184,6 +184,11 @@ type sgCollectOptions struct {
 	UploadProxy     string `json:"upload_proxy,omitempty"`
 	Customer        string `json:"customer,omitempty"`
 	Ticket          string `json:"ticket,omitempty"`
+
+	// Unexported - Don't allow these to be set via the JSON body.
+	// We'll set them from the request's basic auth.
+	syncGatewayUsername string
+	syncGatewayPassword string
 }
 
 // validateOutputDirectory will check that the given path exists, and is a directory.
@@ -278,6 +283,14 @@ func (c *sgCollectOptions) Args() []string {
 
 	if c.RedactSalt != "" {
 		args = append(args, "--log-redaction-salt", c.RedactSalt)
+	}
+
+	if c.syncGatewayUsername != "" {
+		args = append(args, "--sync-gateway-username", c.syncGatewayUsername)
+	}
+
+	if c.syncGatewayPassword != "" {
+		args = append(args, "--sync-gateway-password", c.syncGatewayPassword)
 	}
 
 	return args


### PR DESCRIPTION
CBG-1860

Passes `/_sgcollect_info` request credentials through to the `sgcollect_info` binary for the loopback requests with admin authentication enabled.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1518/
  - 2 unrelated failures due to transient errors