### PR TITLE
3.0 RC2: CBG-1865: Change default value of enable_advanced_auth_dp

### DIFF
--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -36,12 +36,11 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 			HTTPS: HTTPSConfig{
 				TLSMinimumVersion: "tlsv1.2",
 			},
-			ReadHeaderTimeout:              base.NewConfigDuration(base.DefaultReadHeaderTimeout),
-			IdleTimeout:                    base.NewConfigDuration(base.DefaultIdleTimeout),
-			AdminInterfaceAuthentication:   base.BoolPtr(true),
-			MetricsInterfaceAuthentication: base.BoolPtr(true),
-			// Post-DP this should be set to base.IsEnterpriseEdition as default
-			EnableAdminAuthenticationPermissionsCheck: base.BoolPtr(false),
+			ReadHeaderTimeout:                         base.NewConfigDuration(base.DefaultReadHeaderTimeout),
+			IdleTimeout:                               base.NewConfigDuration(base.DefaultIdleTimeout),
+			AdminInterfaceAuthentication:              base.BoolPtr(true),
+			MetricsInterfaceAuthentication:            base.BoolPtr(true),
+			EnableAdminAuthenticationPermissionsCheck: base.BoolPtr(base.IsEnterpriseEdition()),
 		},
 		Logging: base.LoggingConfig{
 			LogFilePath:    defaultLogFilePath,


### PR DESCRIPTION
CBG-1865

This just switches the default value of `enable_advanced_auth_dp` to be `true` now. 
Have tested manually to ensure the change works and to ensure attempting to set it as a CE user still errors properly.

Once this is merged / approved I'll open the same PR for master.
