### PR TITLE
Rename Attachment Compact functions and make private

### DIFF
--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -14,7 +14,7 @@ import (
 
 const CompactionIDKey = "compactID"
 
-func Mark(db *Database, compactionID string, terminator *base.SafeTerminator, markedAttachmentCount *base.AtomicInt) (count int64, vbUUIDs []uint64, err error) {
+func attachmentCompactMarkPhase(db *Database, compactionID string, terminator *base.SafeTerminator, markedAttachmentCount *base.AtomicInt) (count int64, vbUUIDs []uint64, err error) {
 	base.InfofCtx(db.Ctx, base.KeyAll, "Starting first phase of attachment compaction (mark phase) with compactionID: %q", compactionID)
 	compactionLoggingID := "Compaction Mark: " + compactionID
 
@@ -253,7 +253,7 @@ func handleAttachments(attachmentKeyMap map[string]string, docKey string, attach
 	}
 }
 
-func Sweep(db *Database, compactionID string, vbUUIDs []uint64, dryRun bool, terminator *base.SafeTerminator, purgedAttachmentCount *base.AtomicInt) (int64, error) {
+func attachmentCompactSweepPhase(db *Database, compactionID string, vbUUIDs []uint64, dryRun bool, terminator *base.SafeTerminator, purgedAttachmentCount *base.AtomicInt) (int64, error) {
 	base.InfofCtx(db.Ctx, base.KeyAll, "Starting second phase of attachment compaction (sweep phase) with compactionID: %q", compactionID)
 	compactionLoggingID := "Compaction Sweep: " + compactionID
 
@@ -343,7 +343,7 @@ func Sweep(db *Database, compactionID string, vbUUIDs []uint64, dryRun bool, ter
 	return purgedAttachmentCount.Value(), dcpClient.Close()
 }
 
-func Cleanup(db *Database, compactionID string, vbUUIDs []uint64, terminator *base.SafeTerminator) error {
+func attachmentCompactCleanupPhase(db *Database, compactionID string, vbUUIDs []uint64, terminator *base.SafeTerminator) error {
 	base.InfofCtx(db.Ctx, base.KeyAll, "Starting third phase of attachment compaction (cleanup phase) with compactionID: %q", compactionID)
 	compactionLoggingID := "Compaction Cleanup: " + compactionID
 

--- a/db/background_mgr_attachment_compaction.go
+++ b/db/background_mgr_attachment_compaction.go
@@ -116,7 +116,7 @@ func (a *AttachmentCompactionManager) Run(options map[string]interface{}, persis
 	case "mark", "":
 		a.SetPhase("mark")
 		persistClusterStatus()
-		_, a.VBUUIDs, err = Mark(database, a.CompactID, terminator, &a.MarkedAttachments)
+		_, a.VBUUIDs, err = attachmentCompactMarkPhase(database, a.CompactID, terminator, &a.MarkedAttachments)
 		if err != nil || terminator.IsClosed() {
 			return err
 		}
@@ -124,7 +124,7 @@ func (a *AttachmentCompactionManager) Run(options map[string]interface{}, persis
 	case "sweep":
 		a.SetPhase("sweep")
 		persistClusterStatus()
-		_, err := Sweep(database, a.CompactID, a.VBUUIDs, a.dryRun, terminator, &a.PurgedAttachments)
+		_, err := attachmentCompactSweepPhase(database, a.CompactID, a.VBUUIDs, a.dryRun, terminator, &a.PurgedAttachments)
 		if err != nil || terminator.IsClosed() {
 			return err
 		}
@@ -132,7 +132,7 @@ func (a *AttachmentCompactionManager) Run(options map[string]interface{}, persis
 	case "cleanup":
 		a.SetPhase("cleanup")
 		persistClusterStatus()
-		err := Cleanup(database, a.CompactID, a.VBUUIDs, terminator)
+		err := attachmentCompactCleanupPhase(database, a.CompactID, a.VBUUIDs, terminator)
 		if err != nil || terminator.IsClosed() {
 			return err
 		}


### PR DESCRIPTION
Small PR to just rename the Mark, Sweep and Cleanup functions for attachment compaction. This is to make it more clear what these functions are as 'Mark' etc are a little ambiguous. Also made the functions private as there is no reason that these need to be accessed outside of the db package.