### PR TITLE
Wait for pending changes after writing grantDoc in TestContinuousChangesDynamicGrant

### DIFF
--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -991,6 +991,7 @@ function(doc, oldDoc) {
 	revsFinishedWg.Add(1)
 	response := rt.SendAdminRequest("PUT", "/db/grantDoc", `{"accessUser":"user1", "accessChannel":"ABC", "channels":["ABC"]}`)
 	assertStatus(t, response, 201)
+	require.NoError(t, rt.WaitForPendingChanges())
 
 	// Wait until all expected changes are received by change handler
 	// receivedChangesWg.Wait()


### PR DESCRIPTION
The 5 second timeout seems like a reasonable amount of time to wait for the waitgroups below to be decremented via replication messages, but only after we've heard back from DCP about the grantDoc we just wrote.

Seen fail here: http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1526

```
2022-01-06T05:46:33.475-08:00 [INF] HTTP:  #9206: PUT http://localhost/db/<ud>grantDoc</ud> (as ADMIN)
2022-01-06T05:46:33.804-08:00 [INF] Cache:     Got no rows from query for channel:"<ud>!</ud>"
2022-01-06T05:46:33.804-08:00 [INF] Cache: c:[2565dd03] GetChangesInChannel("<ud>!</ud>") --> 0 rows
2022-01-06T05:46:33.804-08:00 [INF] Cache:     Got no rows from query for channel:"<ud>user1</ud>"
2022-01-06T05:46:33.804-08:00 [INF] Cache: c:[2565dd03] GetChangesInChannel("<ud>user1</ud>") --> 0 rows
2022-01-06T05:46:33.804-08:00 [INF] Sync: c:[2565dd03] Sent all changes to client
2022-01-06T05:46:34.146-08:00 [INF] Design docs for current view version (2.1) do not exist - creating...
2022-01-06T05:46:34.337-08:00 [INF] Cache:   Querying 'channels' for "<ud>ABC</ud>" (start=#1, end=#3, limit=5000)
2022-01-06T05:46:34.758-08:00 [INF] Design docs successfully created for view version 2.1.
2022-01-06T05:46:34.758-08:00 [INF] Verifying view availability for bucket <ud>sg_int_0_1641475791183581004</ud>...
2022-01-06T05:46:34.808-08:00 [INF] Views ready for bucket <ud>sg_int_0_1641475791183581004</ud>.
2022-01-06T05:46:34.978-08:00 [INF] Cache: Received #3 (unused sequence)
2022-01-06T05:46:36.106-08:00 [INF] Design docs for current view version (2.1) do not exist - creating...
2022-01-06T05:46:36.566-08:00 [INF] Design docs successfully created for view version 2.1.
2022-01-06T05:46:36.566-08:00 [INF] Verifying view availability for bucket <ud>sg_int_1_1641475791183581004</ud>...
2022-01-06T05:46:36.626-08:00 [INF] Views ready for bucket <ud>sg_int_1_1641475791183581004</ud>.
    blip_api_test.go:998: 
        	Error Trace:	blip_api_test.go:998
        	Error:      	Received unexpected error:
        	            	Timed out waiting after 5s
        	Test:       	TestContinuousChangesDynamicGrant
        	Messages:   	Timed out waiting for all changes.
2022/01/06 05:46:39 got rev message: map[accessChannel:ABC accessUser:user1 channels:[ABC]]
2022-01-06T05:46:39.678-08:00 [INF] Cache:     Got 1 rows from query for "<ud>ABC</ud>": #2 ... #2
2022-01-06T05:46:39.678-08:00 [INF] Channel query took 5.340433021s to return 1 rows.  Channel: <ud>ABC</ud> StartSeq: 1 EndSeq: 3 Limit: 5000
2022-01-06T05:46:39.678-08:00 [INF] Cache:   Initialized cache of "<ud>ABC</ud>" with 1 entries from query (#2--#2)
2022-01-06T05:46:39.678-08:00 [INF] Cache: c:[2565dd03] GetChangesInChannel("<ud>ABC</ud>") --> 1 rows
2022-01-06T05:46:39.678-08:00 [INF] Sync: c:[2565dd03] Sent 1 changes to client, from seq 2
```

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `count=25` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1528/