### PR TITLE
CBG-1875: Improve redaction for base.Set

### DIFF
--- a/base/redactor.go
+++ b/base/redactor.go
@@ -76,6 +76,44 @@ func (redactorSlice RedactorSlice) String() string {
 	return "[ " + string(tmp) + "]"
 }
 
+func (set Set) buildRedactorSet(function func(interface{}) RedactorFunc) RedactorSet {
+	return RedactorSet{
+		set:          set,
+		redactorFunc: function,
+	}
+}
+
+type RedactorSet struct {
+	set          Set
+	redactorFunc func(interface{}) RedactorFunc
+}
+
+func (redactorSet RedactorSet) Redact() string {
+	return redactorSet.GetRedactionString(true)
+}
+
+func (redactorSet RedactorSet) String() string {
+	return redactorSet.GetRedactionString(false)
+}
+
+func (redactorSet RedactorSet) GetRedactionString(shouldRedact bool) string {
+	tmp := []byte("{")
+	iterationCount := 0
+	for setItem, _ := range redactorSet.set {
+		if shouldRedact {
+			tmp = append(tmp, redactorSet.redactorFunc(setItem).Redact()...)
+		} else {
+			tmp = append(tmp, redactorSet.redactorFunc(setItem).String()...)
+		}
+		iterationCount++
+		if iterationCount != len(redactorSet.set) {
+			tmp = append(tmp, ", "...)
+		}
+	}
+
+	return string(append(tmp, "}"...))
+}
+
 func buildRedactorFuncSlice(valueOf reflect.Value, function func(interface{}) RedactorFunc) RedactorSlice {
 	length := valueOf.Len()
 	retVal := make([]Redactor, 0, length)

--- a/base/redactor_metadata.go
+++ b/base/redactor_metadata.go
@@ -58,6 +58,10 @@ func MD(i interface{}) RedactorFunc {
 		return func() Redactor {
 			return Metadata(v)
 		}
+	case Set:
+		return func() Redactor {
+			return v.buildRedactorSet(MD)
+		}
 	case fmt.Stringer:
 		return func() Redactor {
 			return Metadata(v.String())

--- a/base/redactor_metadata_test.go
+++ b/base/redactor_metadata_test.go
@@ -32,19 +32,28 @@ func TestMD(t *testing.T) {
 	RedactMetadata = true
 	defer func() { RedactMetadata = false }()
 
-	//Base string test
+	// Base string test
 	md := MD("hello world")
 	assert.Equal(t, metaDataPrefix+"hello world"+metaDataSuffix, md.Redact())
 
-	//Big Int
+	// Big Int
 	md = MD(big.NewInt(1234))
 	assert.Equal(t, metaDataPrefix+"1234"+metaDataSuffix, md.Redact())
 
-	//Struct
+	// Struct
 	md = MD(struct{}{})
 	assert.Equal(t, metaDataPrefix+"{}"+metaDataSuffix, md.Redact())
 
-	//String slict
+	// String slice
 	md = MD([]string{"hello", "world", "o/"})
 	assert.Equal(t, "[ "+metaDataPrefix+"hello"+metaDataSuffix+" "+metaDataPrefix+"world"+metaDataSuffix+" "+metaDataPrefix+"o/"+metaDataSuffix+" ]", md.Redact())
+
+	// Set
+	md = MD(SetOf("hello", "world"))
+	// As a set comes from a map we can't be sure which order it'll end up with so should check both permutations
+	redactedPerm1 := "{" + metaDataPrefix + "hello" + metaDataSuffix + ", " + metaDataPrefix + "world" + metaDataSuffix + "}"
+	redactedPerm2 := "{" + metaDataPrefix + "world" + metaDataSuffix + ", " + metaDataPrefix + "hello" + metaDataSuffix + "}"
+	redactedSet := md.Redact()
+	redactedCorrectly := redactedPerm1 == redactedSet || redactedPerm2 == redactedSet
+	assert.True(t, redactedCorrectly, "Unexpected redact got %v", redactedSet)
 }

--- a/base/redactor_systemdata.go
+++ b/base/redactor_systemdata.go
@@ -55,6 +55,10 @@ func SD(i interface{}) RedactorFunc {
 		return func() Redactor {
 			return SystemData(v)
 		}
+	case Set:
+		return func() Redactor {
+			return v.buildRedactorSet(SD)
+		}
 	case fmt.Stringer:
 		return func() Redactor {
 			return SystemData(v.String())

--- a/base/redactor_systemdata_test.go
+++ b/base/redactor_systemdata_test.go
@@ -32,19 +32,28 @@ func TestSD(t *testing.T) {
 	RedactSystemData = true
 	defer func() { RedactSystemData = false }()
 
-	//Base string test
+	// Base string test
 	sd := SD("hello world")
 	assert.Equal(t, systemDataPrefix+"hello world"+systemDataSuffix, sd.Redact())
 
-	//Big Int
+	// Big Int
 	sd = SD(big.NewInt(1234))
 	assert.Equal(t, systemDataPrefix+"1234"+systemDataSuffix, sd.Redact())
 
-	//Struct
+	// Struct
 	sd = SD(struct{}{})
 	assert.Equal(t, systemDataPrefix+"{}"+systemDataSuffix, sd.Redact())
 
-	//String slict
+	// String slice
 	sd = SD([]string{"hello", "world", "o/"})
 	assert.Equal(t, "[ "+systemDataPrefix+"hello"+systemDataSuffix+" "+systemDataPrefix+"world"+systemDataSuffix+" "+systemDataPrefix+"o/"+systemDataSuffix+" ]", sd.Redact())
+
+	// Set
+	sd = SD(SetOf("hello", "world"))
+	// As a set comes from a map we can't be sure which order it'll end up with so should check both permutations
+	redactedPerm1 := "{" + systemDataPrefix + "hello" + systemDataSuffix + ", " + systemDataPrefix + "world" + systemDataSuffix + "}"
+	redactedPerm2 := "{" + systemDataPrefix + "world" + systemDataSuffix + ", " + systemDataPrefix + "hello" + systemDataSuffix + "}"
+	redactedSet := sd.Redact()
+	redactedCorrectly := redactedPerm1 == redactedSet || redactedPerm2 == redactedSet
+	assert.True(t, redactedCorrectly, "Unexpected redact got %v", redactedSet)
 }

--- a/base/redactor_userdata.go
+++ b/base/redactor_userdata.go
@@ -56,6 +56,10 @@ func UD(i interface{}) RedactorFunc {
 		return func() Redactor {
 			return UserData(v)
 		}
+	case Set:
+		return func() Redactor {
+			return v.buildRedactorSet(UD)
+		}
 	case fmt.Stringer:
 		return func() Redactor {
 			return UserData(v.String())

--- a/base/redactor_userdata_test.go
+++ b/base/redactor_userdata_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUserDataRedact(t *testing.T) {
@@ -48,6 +49,15 @@ func TestUD(t *testing.T) {
 	// String slice test.
 	ud = UD([]string{"hello", "world", "o/"})
 	goassert.Equals(t, ud.Redact(), "[ "+userDataPrefix+"hello"+userDataSuffix+" "+userDataPrefix+"world"+userDataSuffix+" "+userDataPrefix+"o/"+userDataSuffix+" ]")
+
+	// Set
+	ud = UD(SetOf("hello", "world"))
+	// As a set comes from a map we can't be sure which order it'll end up with so should check both permutations
+	redactedPerm1 := "{" + userDataPrefix + "hello" + userDataSuffix + ", " + userDataPrefix + "world" + userDataSuffix + "}"
+	redactedPerm2 := "{" + userDataPrefix + "world" + userDataSuffix + ", " + userDataPrefix + "hello" + userDataSuffix + "}"
+	redactedSet := ud.Redact()
+	redactedCorrectly := redactedPerm1 == redactedSet || redactedPerm2 == redactedSet
+	assert.True(t, redactedCorrectly, "Unexpected redact got %v", redactedSet)
 }
 
 func BenchmarkUserDataRedact(b *testing.B) {


### PR DESCRIPTION
CBG-1875

Added redaction for base.Set. Added a new struct `RedactorSet` which stores the set itself and also the 'type' of redaction we want to perform (UD, MD, SD).  Then when either Redact() or String() is called the set can be processed and either returned as a regular string, or as a redacted string. This requires only 1 iteration of the set at redact time.

This is covered by expanding unit tests.
