### PR TITLE
CBG-1872: Return 503 on failed auth when server unavailable

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -590,12 +590,16 @@ func (auth *Authenticator) DeleteRole(role Role, purge bool, deleteSeq uint64) e
 
 // Authenticates a user given the username and password.
 // If the username and password are both "", it will return a default empty User object, not nil.
-func (auth *Authenticator) AuthenticateUser(username string, password string) User {
-	user, _ := auth.GetUser(username)
-	if user == nil || !user.Authenticate(password) {
-		return nil
+func (auth *Authenticator) AuthenticateUser(username string, password string) (User, error) {
+	user, err := auth.GetUser(username)
+	if err != nil && !base.IsDocNotFoundError(err) {
+		return nil, err
 	}
-	return user
+
+	if user == nil || !user.Authenticate(password) {
+		return nil, nil
+	}
+	return user, nil
 }
 
 // Authenticates a user based on a JWT token string and a set of providers.  Attempts to match the

--- a/base/error.go
+++ b/base/error.go
@@ -117,6 +117,9 @@ func ErrorAsHTTPStatus(err error) (int, string) {
 	if errors.Is(unwrappedErr, gocb.ErrDocumentExists) {
 		return http.StatusConflict, "Conflict"
 	}
+	if errors.Is(unwrappedErr, gocb.ErrTimeout) {
+		return http.StatusServiceUnavailable, "Database timeout error (gocb.ErrTimeout)"
+	}
 	if isKVError(unwrappedErr, memd.StatusTooBig) {
 		return http.StatusRequestEntityTooLarge, "Document too large!"
 	}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -454,7 +454,10 @@ func (h *handler) checkAuth(context *db.DatabaseContext) (err error) {
 
 	// Check basic auth first
 	if userName, password := h.getBasicAuth(); userName != "" {
-		h.user = context.Authenticator().AuthenticateUser(userName, password)
+		h.user, err = context.Authenticator().AuthenticateUser(userName, password)
+		if err != nil {
+			return err
+		}
 		if h.user == nil {
 			base.Infof(base.KeyAll, "HTTP auth failed for username=%q", base.UD(userName))
 			if context.Options.SendWWWAuthenticateHeader == nil || *context.Options.SendWWWAuthenticateHeader {


### PR DESCRIPTION
CBG-1872

Previously `AuthenticateUser` was ignoring any error from `GetUser` and if no user was returned ended up returning a 401. We now return the error from GetUser (unless its a doc not found) and return the error up to the response. 

The 503 response will be as follows.
```
{
    "error": "Service Unavailable",
    "reason": "Database timeout error (gocb.ErrTimeout)"
}
```

Note that this will also affect other errors returned by `GetUser` which I think should work well.

Manually tested by shutting down a Couchbase Server.