### PR TITLE
Wait on all stats inside TestMultipleOutstandingChangesSubscriptions to avoid races

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -529,6 +529,13 @@ func WaitForStat(getStatFunc func() int64, expected int64) (int64, bool) {
 	return valInt64, err == nil && ok
 }
 
+// RequireWaitForStat will retry for up to 20 seconds until the result of getStatFunc is equal to the expected value.
+func RequireWaitForStat(t testing.TB, getStatFunc func() int64, expected int64) {
+	val, ok := WaitForStat(getStatFunc, expected)
+	require.True(t, ok)
+	require.Equal(t, expected, val)
+}
+
 type dataStore struct {
 	name   string
 	driver CouchbaseDriver

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -3774,10 +3774,10 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	}
 
 	pullStats := bt.restTester.GetDatabase().DbStats.CBLReplicationPull()
-	require.EqualValues(t, 0, pullStats.NumPullReplActiveContinuous.Value())
 	require.EqualValues(t, 0, pullStats.NumPullReplTotalContinuous.Value())
-	require.EqualValues(t, 0, pullStats.NumPullReplActiveOneShot.Value())
+	require.EqualValues(t, 0, pullStats.NumPullReplActiveContinuous.Value())
 	require.EqualValues(t, 0, pullStats.NumPullReplTotalOneShot.Value())
+	require.EqualValues(t, 0, pullStats.NumPullReplActiveOneShot.Value())
 	require.EqualValues(t, 0, pullStats.NumPullReplSinceZero.Value())
 
 	// Open an initial continuous = false subChanges request, which we'd expect to release the lock after it's "caught up".
@@ -3795,10 +3795,10 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "", errorCode, "resp: %s", respBody)
 
-	base.RequireWaitForStat(t, pullStats.NumPullReplActiveOneShot.Value, 0)
 	base.RequireWaitForStat(t, pullStats.NumPullReplTotalOneShot.Value, 1)
-	base.RequireWaitForStat(t, pullStats.NumPullReplActiveContinuous.Value, 0)
+	base.RequireWaitForStat(t, pullStats.NumPullReplActiveOneShot.Value, 0)
 	base.RequireWaitForStat(t, pullStats.NumPullReplTotalContinuous.Value, 0)
+	base.RequireWaitForStat(t, pullStats.NumPullReplActiveContinuous.Value, 0)
 	base.RequireWaitForStat(t, pullStats.NumPullReplSinceZero.Value, 1)
 
 	// Send continous subChanges to subscribe to changes, which will cause the "changes" profile handler above to be called back
@@ -3816,10 +3816,10 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "", errorCode, "resp: %s", respBody)
 
-	base.RequireWaitForStat(t, pullStats.NumPullReplActiveOneShot.Value, 0)
 	base.RequireWaitForStat(t, pullStats.NumPullReplTotalOneShot.Value, 1)
-	base.RequireWaitForStat(t, pullStats.NumPullReplActiveContinuous.Value, 1)
+	base.RequireWaitForStat(t, pullStats.NumPullReplActiveOneShot.Value, 0)
 	base.RequireWaitForStat(t, pullStats.NumPullReplTotalContinuous.Value, 1)
+	base.RequireWaitForStat(t, pullStats.NumPullReplActiveContinuous.Value, 1)
 	base.RequireWaitForStat(t, pullStats.NumPullReplSinceZero.Value, 2)
 
 	// Send a second continuous subchanges request, expect an error
@@ -3835,10 +3835,10 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	log.Printf("errorCode2: %v", errorCode)
 	assert.Equal(t, "500", errorCode)
 
-	base.RequireWaitForStat(t, pullStats.NumPullReplActiveOneShot.Value, 0)
 	base.RequireWaitForStat(t, pullStats.NumPullReplTotalOneShot.Value, 1)
-	base.RequireWaitForStat(t, pullStats.NumPullReplActiveContinuous.Value, 1)
+	base.RequireWaitForStat(t, pullStats.NumPullReplActiveOneShot.Value, 0)
 	base.RequireWaitForStat(t, pullStats.NumPullReplTotalContinuous.Value, 1)
+	base.RequireWaitForStat(t, pullStats.NumPullReplActiveContinuous.Value, 1)
 	base.RequireWaitForStat(t, pullStats.NumPullReplSinceZero.Value, 2)
 
 	// Even a subsequent continuous = false subChanges request should return an error. This isn't restricted to only continuous changes.
@@ -3856,14 +3856,14 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "500", errorCode, "resp: %s", respBody)
 
-	base.RequireWaitForStat(t, pullStats.NumPullReplActiveOneShot.Value, 0)
 	base.RequireWaitForStat(t, pullStats.NumPullReplTotalOneShot.Value, 1)
-	base.RequireWaitForStat(t, pullStats.NumPullReplActiveContinuous.Value, 1)
+	base.RequireWaitForStat(t, pullStats.NumPullReplActiveOneShot.Value, 0)
 	base.RequireWaitForStat(t, pullStats.NumPullReplTotalContinuous.Value, 1)
+	base.RequireWaitForStat(t, pullStats.NumPullReplActiveContinuous.Value, 1)
 	base.RequireWaitForStat(t, pullStats.NumPullReplSinceZero.Value, 2)
 
 	bt.sender.Close() // Close continuous sub changes feed
 
-	base.RequireWaitForStat(t, pullStats.NumPullReplActiveContinuous.Value, 0)
 	base.RequireWaitForStat(t, pullStats.NumPullReplActiveOneShot.Value, 0)
+	base.RequireWaitForStat(t, pullStats.NumPullReplActiveContinuous.Value, 0)
 }


### PR DESCRIPTION
Assert on the same set of stats for consistency - but have each of them do a retry loop until they've met the condition.

http://mobile.jenkins.couchbase.com/job/sgw-unix-build/19149/consoleFull#-1538788267db2b220c-562c-42fc-9783-a473165a58a0

```
00:08:31 2022-01-18T16:05:35.670-08:00 [INF] Sync: c:[426b671c] Sent all changes to client
00:08:31 2022-01-18T16:05:35.771-08:00 [INF] SyncMsg: c:[426b671c] #2: Type:subChanges Since:0 Continuous:true 
00:08:31 2022-01-18T16:05:35.771-08:00 [INF] Sync: c:[426b671c] Sending changes since 0
00:08:31 2022/01/18 16:05:35 errorCode: 
00:08:31 2022-01-18T16:05:35.774-08:00 [INF] WS: Error: receiveLoop exiting with WebSocket error: read tcp 127.0.0.1:58584->127.0.0.1:42407: use of closed network connection
00:08:31 2022-01-18T16:05:35.774-08:00 [INF] WS: BLIP/Websocket receiveLoop exited: read tcp 127.0.0.1:58584->127.0.0.1:42407: use of closed network connection
00:08:31 2022-01-18T16:05:35.777-08:00 [INF] Changes: c:[426b671c] MultiChangesFeed(channels: {<ud>*</ud>}, options: {Since: 0, Limit: 0, Conflicts: false, IncludeDocs: false, Wait: true, Continuous: true, HeartbeatMs: 0, TimeoutMs: 0, ActiveOnly: false}) ... <ud></ud>
00:08:31 2022-01-18T16:05:35.825-08:00 [INF] HTTP: c:[426b671c] #10827:    --> BLIP+WebSocket connection closed
00:08:31 2022-01-18T16:05:35.825-08:00 [INF] Changes: c:[426b671c] MultiChangesFeed done <ud></ud>
00:08:31 2022-01-18T16:05:35.825-08:00 [INF] rest.TestMultipleOutstandingChangesSubscriptions: Reset logging
00:08:31 
--- FAIL: TestMultipleOutstandingChangesSubscriptions (0.16s)
00:08:31     require.go:201: 
00:08:31         	Error Trace:	blip_api_test.go:3820
00:08:31         	Error:      	Not equal: 
00:08:31         	            	expected: int(2)
00:08:31         	            	actual  : int64(1)
00:08:31         	Test:       	TestMultipleOutstandingChangesSubscriptions
```