### PR TITLE
CBG-1926: Run StartReplications() when a new databaseContext is loaded

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -403,6 +403,14 @@ func (ar *ActiveReplicator) alignState(targetState string) error {
 
 }
 
+func (dbc *DatabaseContext) StartReplications() {
+	base.Infof(base.KeyReplicate, "Starting Inter-Sync Gateway Replications for database %q", dbc.Name)
+	err := dbc.SGReplicateMgr.StartReplications()
+	if err != nil {
+		base.Errorf("Error starting %q Inter-Sync Gateway Replications: %v", dbc.Name, err)
+	}
+}
+
 func NewSGReplicateManager(dbContext *DatabaseContext, cfg cbgt.Cfg) (*sgReplicateManager, error) {
 	if cfg == nil {
 		return nil, errors.New("Cfg must be provided for SGReplicateManager")

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -146,12 +146,8 @@ func (sc *ServerContext) PostStartup() {
 	time.Sleep(5 * time.Second)
 
 	sc.lock.RLock()
-	for dbName, dbContext := range sc.databases_ {
-		base.Infof(base.KeyReplicate, "Starting Inter-Sync Gateway Replications for database %q", dbName)
-		err := dbContext.SGReplicateMgr.StartReplications()
-		if err != nil {
-			base.Errorf("Error starting sg-replicate replications: %v", err)
-		}
+	for _, dbContext := range sc.databases_ {
+		dbContext.StartReplications()
 	}
 	sc.lock.RUnlock()
 
@@ -591,6 +587,8 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config DatabaseConfig, useE
 		atomic.StoreUint32(&dbcontext.State, db.DBOnline)
 		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "online", "DB loaded from config", &sc.config.API.AdminInterface)
 	}
+
+	dbcontext.StartReplications()
 
 	return dbcontext, nil
 }


### PR DESCRIPTION
CBG-1926

- Run StartReplications() when a new databaseContext is loaded (from a new database, or a database config update)
  - Fixes issue where assigned replications we not being started on nodes where a database was dynamically loaded

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1555/