### PR TITLE
CBG-1926: Run StartReplications() when a new databaseContext is loaded

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -83,43 +83,43 @@ const BGTCompletionMaxWait = 30 * time.Second
 // Basic description of a database. Shared between all Database objects on the same database.
 // This object is thread-safe so it can be shared between HTTP handlers.
 type DatabaseContext struct {
-	Name                        string                  // Database name
-	UUID                        string                  // UUID for this database instance. Used by cbgt and sgr
-	Bucket                      base.Bucket             // Storage
-	BucketSpec                  base.BucketSpec         // The BucketSpec
-	BucketLock                  sync.RWMutex            // Control Access to the underlying bucket object
-	mutationListener            changeListener          // Caching feed listener
-	ImportListener              *importListener         // Import feed listener
-	sequences                   *sequenceAllocator      // Source of new sequence numbers
-	ChannelMapper               *channels.ChannelMapper // Runs JS 'sync' function
-	StartTime                   time.Time               // Timestamp when context was instantiated
-	RevsLimit                   uint32                  // Max depth a document's revision tree can grow to
-	autoImport                  bool                    // Add sync data to new untracked couchbase server docs?  (Xattr mode specific)
-	revisionCache               RevisionCache           // Cache of recently-accessed doc revisions
-	changeCache                 *changeCache            // Cache of recently-access channels
-	EventMgr                    *EventManager           // Manages notification events
-	AllowEmptyPassword          bool                    // Allow empty passwords?  Defaults to false
-	Options                     DatabaseContextOptions  // Database Context Options
-	AccessLock                  sync.RWMutex            // Allows DB offline to block until synchronous calls have completed
-	State                       uint32                  // The runtime state of the DB from a service perspective
-	ResyncManager               *BackgroundManager
-	TombstoneCompactionManager  *BackgroundManager
-	AttachmentCompactionManager *BackgroundManager
-	ExitChanges                 chan struct{}            // Active _changes feeds on the DB will close when this channel is closed
-	OIDCProviders               auth.OIDCProviderMap     // OIDC clients
-	PurgeInterval               time.Duration            // Metadata purge interval
-	serverUUID                  string                   // UUID of the server, if available
-	DbStats                     *base.DbStats            // stats that correspond to this database context
-	CompactState                uint32                   // Status of database compaction
-	terminator                  chan bool                // Signal termination of background goroutines
-	backgroundTasks             []BackgroundTask         // List of background tasks that are initiated.
-	activeChannels              *channels.ActiveChannels // Tracks active replications by channel
-	CfgSG                       cbgt.Cfg                 // Sync Gateway cluster shared config
-	//CfgSG                        *base.CfgSG              // Sync Gateway cluster shared config
-	SGReplicateMgr               *sgReplicateManager // Manages interactions with sg-replicate replications
-	Heartbeater                  base.Heartbeater    // Node heartbeater for SG cluster awareness
-	ServeInsecureAttachmentTypes bool                // Attachment content type will bypass the content-disposition handling, default false
-	GoCBHttpClient               *http.Client
+	Name                         string                  // Database name
+	UUID                         string                  // UUID for this database instance. Used by cbgt and sgr
+	Bucket                       base.Bucket             // Storage
+	BucketSpec                   base.BucketSpec         // The BucketSpec
+	BucketLock                   sync.RWMutex            // Control Access to the underlying bucket object
+	mutationListener             changeListener          // Caching feed listener
+	ImportListener               *importListener         // Import feed listener
+	sequences                    *sequenceAllocator      // Source of new sequence numbers
+	ChannelMapper                *channels.ChannelMapper // Runs JS 'sync' function
+	StartTime                    time.Time               // Timestamp when context was instantiated
+	RevsLimit                    uint32                  // Max depth a document's revision tree can grow to
+	autoImport                   bool                    // Add sync data to new untracked couchbase server docs?  (Xattr mode specific)
+	revisionCache                RevisionCache           // Cache of recently-accessed doc revisions
+	changeCache                  *changeCache            // Cache of recently-access channels
+	EventMgr                     *EventManager           // Manages notification events
+	AllowEmptyPassword           bool                    // Allow empty passwords?  Defaults to false
+	Options                      DatabaseContextOptions  // Database Context Options
+	AccessLock                   sync.RWMutex            // Allows DB offline to block until synchronous calls have completed
+	State                        uint32                  // The runtime state of the DB from a service perspective
+	ResyncManager                *BackgroundManager
+	TombstoneCompactionManager   *BackgroundManager
+	AttachmentCompactionManager  *BackgroundManager
+	ExitChanges                  chan struct{}            // Active _changes feeds on the DB will close when this channel is closed
+	OIDCProviders                auth.OIDCProviderMap     // OIDC clients
+	PurgeInterval                time.Duration            // Metadata purge interval
+	serverUUID                   string                   // UUID of the server, if available
+	DbStats                      *base.DbStats            // stats that correspond to this database context
+	CompactState                 uint32                   // Status of database compaction
+	terminator                   chan bool                // Signal termination of background goroutines
+	backgroundTasks              []BackgroundTask         // List of background tasks that are initiated.
+	activeChannels               *channels.ActiveChannels // Tracks active replications by channel
+	CfgSG                        cbgt.Cfg                 // Sync Gateway cluster shared config
+	SGReplicateMgr               *sgReplicateManager      // Manages interactions with sg-replicate replications
+	Heartbeater                  base.Heartbeater         // Node heartbeater for SG cluster awareness
+	ServeInsecureAttachmentTypes bool                     // Attachment content type will bypass the content-disposition handling, default false
+	GoCBHttpClient               *http.Client             // A HTTP Client from gocb to use the management endpoints
+	ServerContextHasStarted      chan struct{}            // Closed via PostStartup once the server has fully started
 }
 
 type DatabaseContextOptions struct {

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -403,6 +403,33 @@ func (ar *ActiveReplicator) alignState(targetState string) error {
 
 }
 
+func (dbc *DatabaseContext) StartReplications() {
+	if dbc.Options.SGReplicateOptions.Enabled {
+		base.Debugf(base.KeyReplicate, "Will start Inter-Sync Gateway Replications for database %q", dbc.Name)
+		go func() {
+			// Wait for the server context to be started
+			t := time.NewTimer(time.Second * 10)
+			defer t.Stop()
+			select {
+			case <-dbc.ServerContextHasStarted:
+				base.Debugf(base.KeyReplicate, "Server context started, starting ISGR replications %q", dbc.Name)
+			case <-t.C:
+				base.Infof(base.KeyReplicate, "Timed out waiting for server context startup... starting ISGR replications for %q anyway", dbc.Name)
+			case <-dbc.terminator:
+				base.Debugf(base.KeyReplicate, "Database context for %q closed before starting ISGR replications - aborting...", dbc.Name)
+				return
+			}
+
+			err := dbc.SGReplicateMgr.StartReplications()
+			if err != nil {
+				base.Errorf("Error starting %q Inter-Sync Gateway Replications: %v", dbc.Name, err)
+			}
+		}()
+	} else {
+		base.Debugf(base.KeyReplicate, "Not starting Inter-Sync Gateway Replications for database %q - is disabled", dbc.Name)
+	}
+}
+
 func NewSGReplicateManager(dbContext *DatabaseContext, cfg cbgt.Cfg) (*sgReplicateManager, error) {
 	if cfg == nil {
 		return nil, errors.New("Cfg must be provided for SGReplicateManager")

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -406,7 +406,10 @@ func (ar *ActiveReplicator) alignState(targetState string) error {
 func (dbc *DatabaseContext) StartReplications() {
 	if dbc.Options.SGReplicateOptions.Enabled {
 		base.Debugf(base.KeyReplicate, "Will start Inter-Sync Gateway Replications for database %q", dbc.Name)
+		dbc.SGReplicateMgr.closeWg.Add(1)
 		go func() {
+			defer dbc.SGReplicateMgr.closeWg.Done()
+
 			// Wait for the server context to be started
 			t := time.NewTimer(time.Second * 10)
 			defer t.Stop()

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2630,7 +2630,7 @@ func TestConfigRedaction(t *testing.T) {
 // Reproduces panic seen in CBG-1053
 func TestAdhocReplicationStatus(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll, base.KeyReplicate)()
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{sgReplicateEnabled: true})
 	defer rt.Close()
 
 	srv := httptest.NewServer(rt.TestAdminHandler())
@@ -2646,9 +2646,6 @@ func TestAdhocReplicationStatus(t *testing.T) {
 
 	resp := rt.SendAdminRequest("PUT", "/db/_replication/pushandpull-with-target-oneshot-adhoc", replConf)
 	assertStatus(t, resp, http.StatusCreated)
-
-	err := rt.GetDatabase().SGReplicateMgr.StartReplications()
-	require.NoError(t, err)
 
 	// With the error hitting the replicationStatus endpoint will either return running, if not completed, and once
 	// completed panics. With the fix after running it'll return a 404 as replication no longer exists.

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4059,6 +4059,9 @@ func TestUnsupportedConfig(t *testing.T) {
 	testProviderOnlyJSON := `{"name": "test_provider_only",
         			"server": "walrus:",
         			"bucket": "test_provider_only",
+					"sgreplicate": {
+						"enabled": false
+					},
 			        "unsupported": {
 			          "oidc_test_provider": {
 			            "enabled":true,
@@ -4077,6 +4080,9 @@ func TestUnsupportedConfig(t *testing.T) {
 	viewsOnlyJSON := `{"name": "views_only",
         			"server": "walrus:",
         			"bucket": "views_only",
+					"sgreplicate": {
+						"enabled": false
+					},
 			        "unsupported": {
 			          "user_views": {
 			            "enabled":true
@@ -4094,6 +4100,9 @@ func TestUnsupportedConfig(t *testing.T) {
 	viewsAndTestJSON := `{"name": "views_and_test",
         			"server": "walrus:",
         			"bucket": "views_and_test",
+					"sgreplicate": {
+						"enabled": false
+					},
 			        "unsupported": {
 			          "oidc_test_provider": {
 			            "enabled":true,

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -749,9 +749,6 @@ func TestReplicationRebalancePull(t *testing.T) {
 	// Increase checkpoint persistence frequency for cross-node status verification
 	activeRT2.GetDatabase().SGReplicateMgr.CheckpointInterval = 50 * time.Millisecond
 
-	err := activeRT2.GetDatabase().SGReplicateMgr.StartReplications()
-	require.NoError(t, err)
-
 	// Wait for replication to be rebalanced to activeRT2
 	activeRT.waitForAssignedReplications(1)
 	activeRT2.waitForAssignedReplications(1)
@@ -843,9 +840,6 @@ func TestReplicationRebalancePush(t *testing.T) {
 
 	// Increase checkpoint persistence frequency for cross-node status verification
 	activeRT2.GetDatabase().SGReplicateMgr.CheckpointInterval = 50 * time.Millisecond
-
-	err := activeRT2.GetDatabase().SGReplicateMgr.StartReplications()
-	require.NoError(t, err)
 
 	// Wait for replication to be rebalanced to activeRT2
 	activeRT.waitForAssignedReplications(1)
@@ -1017,7 +1011,7 @@ func TestReplicationConcurrentPush(t *testing.T) {
 // setupSGRPeers sets up two rest testers to be used for sg-replicate testing with the following configuration:
 //   activeRT:
 //     - backed by test bucket
-//     - SGReplicationMgr.StartReplications() has been called
+//     - has sgreplicate enabled
 //   passiveRT:
 //     - backed by different test bucket
 //     - user 'alice' created with star channel access
@@ -1707,9 +1701,6 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 	// Increase checkpoint persistence frequency for cross-node status verification
 	activeRT2.GetDatabase().SGReplicateMgr.CheckpointInterval = 50 * time.Millisecond
 
-	err := activeRT2.GetDatabase().SGReplicateMgr.StartReplications()
-	require.NoError(t, err)
-
 	// Wait for replication to be rebalanced to activeRT2
 	activeRT.waitForAssignedReplications(1)
 	activeRT2.waitForAssignedReplications(1)
@@ -1740,7 +1731,7 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 	assert.NoError(t, activeRT2Mgr.RemoveNode(activeRTUUID))
 
 	// Wait for nodes to add themselves back to cluster
-	err = activeRT.WaitForCondition(func() bool {
+	err := activeRT.WaitForCondition(func() bool {
 		clusterDef, err := activeRTMgr.GetSGRCluster()
 		if err != nil {
 			return false

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -1052,10 +1052,6 @@ func setupSGRPeers(t *testing.T) (activeRT *RestTester, passiveRT *RestTester, r
 		sgReplicateEnabled: true,
 	})
 
-	// Start replication manager on rt1
-	err := activeRT.GetDatabase().SGReplicateMgr.StartReplications()
-	require.NoError(t, err)
-
 	teardown = func() {
 		activeRT.Close()
 		activeTestBucket.Close()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -230,6 +230,9 @@ func (rt *RestTester) Bucket() base.Bucket {
 		}
 	}
 
+	// PostStartup (without actually waiting 5 seconds)
+	close(rt.RestTesterServerContext.hasStarted)
+
 	return rt.testBucket.Bucket
 }
 


### PR DESCRIPTION
CBG-1926

Changes the approach to PostStartup now that databases are rarely present or up to date on the node at startup time. Fixes issue where assigned replications we not being started on nodes where a database was dynamically loaded.

- Run StartReplications() when a new databaseContext is loaded (from a new database, or a database config update)
  - StartReplications tries to wait until the parent ServerContext has run through PostStartup.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1557/
- [x] `xattrs=true` local run passes