### PR TITLE
Avoid test modification of defaultCheckpointInterval after replicate manager initialization

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -27,12 +27,13 @@ import (
 )
 
 const (
-	cfgKeySGRCluster          = "sgrCluster"    // key used for sgrCluster information in a cbgt.Cfg-based key value store
-	maxSGRClusterCasRetries   = 100             // Maximum number of CAS retries when attempting to update the sgr cluster configuration
-	sgrClusterMgrContextID    = "sgr-mgr-"      // logging context ID prefix for sgreplicate manager
-	defaultChangesBatchSize   = 200             // default changes batch size if replication batch_size is unset
-	defaultCheckpointInterval = time.Second * 5 // default value used for time-based checkpointing
+	cfgKeySGRCluster        = "sgrCluster" // key used for sgrCluster information in a cbgt.Cfg-based key value store
+	maxSGRClusterCasRetries = 100          // Maximum number of CAS retries when attempting to update the sgr cluster configuration
+	sgrClusterMgrContextID  = "sgr-mgr-"   // logging context ID prefix for sgreplicate manager
+	defaultChangesBatchSize = 200          // default changes batch size if replication batch_size is unset
 )
+
+var DefaultCheckpointInterval = time.Second * 5 // default value used for time-based checkpointing
 
 const (
 	ReplicationStateStopped      = "stopped"
@@ -446,7 +447,7 @@ func NewSGReplicateManager(dbContext *DatabaseContext, cfg cbgt.Cfg) (*sgReplica
 		clusterSubscribeTerminator: make(chan struct{}),
 		dbContext:                  dbContext,
 		activeReplicators:          make(map[string]*ActiveReplicator),
-		CheckpointInterval:         defaultCheckpointInterval,
+		CheckpointInterval:         DefaultCheckpointInterval,
 	}, nil
 
 }

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -426,6 +426,9 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 
 			defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
+			// Increase checkpoint persistence frequency for cross-node status verification
+			defer reduceTestCheckpointInterval(50 * time.Millisecond)()
+
 			// Disable sequence batching for multi-RT tests (pending CBG-1000)
 			defer db.SuspendSequenceBatching()()
 
@@ -486,9 +489,6 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 				sgReplicateEnabled: true,
 			})
 			defer rt1.Close()
-
-			// Increase checkpoint persistence frequency for cross-node status verification
-			rt1.GetDatabase().SGReplicateMgr.CheckpointInterval = 50 * time.Millisecond
 
 			rt1.waitForAssignedReplications(1)
 


### PR DESCRIPTION
Moves to var, modifies on test setup.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1560/
  - unrelated (DCP) failures