### PR TITLE
CBG-1905: Include log context for many user-triggered processes

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -9,6 +9,7 @@
 package auth
 
 import (
+	"context"
 	"encoding/base64"
 	"errors"
 	"log"
@@ -296,7 +297,7 @@ type mockComputer struct {
 	err          error
 }
 
-func (self *mockComputer) ComputeChannelsForPrincipal(p Principal) (ch.TimedSet, error) {
+func (self *mockComputer) ComputeChannelsForPrincipal(ctx context.Context, p Principal) (ch.TimedSet, error) {
 	switch p.(type) {
 	case User:
 		return self.channels, self.err
@@ -307,7 +308,7 @@ func (self *mockComputer) ComputeChannelsForPrincipal(p Principal) (ch.TimedSet,
 	}
 }
 
-func (self *mockComputer) ComputeRolesForUser(User) (ch.TimedSet, error) {
+func (self *mockComputer) ComputeRolesForUser(context.Context, User) (ch.TimedSet, error) {
 	return self.roles, self.err
 }
 
@@ -676,6 +677,8 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 	defer testBucket.Close()
 	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
+	ctx := base.TestCtx(t)
+
 	var callbackURLFunc OIDCCallbackURLFunc
 	callbackURL := base.StringPtr("http://comcast:4984/_callback")
 	providerGoogle := &OIDCProvider{
@@ -734,7 +737,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			ClientID:                    "aud1",
 			AllowUnsignedProviderTokens: true,
 		}
-		err = provider.InitUserPrefix()
+		err = provider.InitUserPrefix(ctx)
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -763,7 +766,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud1",
 		}
-		err = provider.InitUserPrefix()
+		err = provider.InitUserPrefix(ctx)
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -790,7 +793,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud4",
 		}
-		err = provider.InitUserPrefix()
+		err = provider.InitUserPrefix(ctx)
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -817,7 +820,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud4",
 		}
-		err = provider.InitUserPrefix()
+		err = provider.InitUserPrefix(ctx)
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -843,7 +846,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud1",
 		}
-		err = provider.InitUserPrefix()
+		err = provider.InitUserPrefix(ctx)
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -871,7 +874,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			ClientID:                    "aud1",
 			AllowUnsignedProviderTokens: true,
 		}
-		err = provider.InitUserPrefix()
+		err = provider.InitUserPrefix(ctx)
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:        "id0123456789",
@@ -901,7 +904,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud1",
 		}
-		err = provider.InitUserPrefix()
+		err = provider.InitUserPrefix(ctx)
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:        "id0123456789",
@@ -929,7 +932,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud1",
 		}
-		err = provider.InitUserPrefix()
+		err = provider.InitUserPrefix(ctx)
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -964,7 +967,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			UserPrefix:                  strings.ToLower(providerGoogle.Name),
 			AllowUnsignedProviderTokens: true,
 		}
-		err = provider.InitUserPrefix()
+		err = provider.InitUserPrefix(ctx)
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -1003,7 +1006,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			UserPrefix:                  strings.ToLower(providerGoogle.Name),
 			AllowUnsignedProviderTokens: true,
 		}
-		err = provider.InitUserPrefix()
+		err = provider.InitUserPrefix(ctx)
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -1042,7 +1045,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			UserPrefix:                  strings.ToLower(providerGoogle.Name),
 			AllowUnsignedProviderTokens: true,
 		}
-		err = provider.InitUserPrefix()
+		err = provider.InitUserPrefix(ctx)
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -1075,7 +1078,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			UserPrefix:                  strings.ToLower(providerGoogle.Name),
 			AllowUnsignedProviderTokens: true,
 		}
-		err = provider.InitUserPrefix()
+		err = provider.InitUserPrefix(ctx)
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -1300,7 +1303,7 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 			ClientID:    "aud1",
 		}
 		providers := OIDCProviderMap{providerGoogle.Name: providerGoogle, providerFacebook.Name: providerFacebook}
-		err = providerGoogle.InitUserPrefix()
+		err = providerGoogle.InitUserPrefix(base.TestCtx(t))
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -1326,7 +1329,7 @@ type mockComputerV2 struct {
 	err          error
 }
 
-func (m mockComputerV2) ComputeChannelsForPrincipal(principal Principal) (ch.TimedSet, error) {
+func (m mockComputerV2) ComputeChannelsForPrincipal(ctx context.Context, principal Principal) (ch.TimedSet, error) {
 	if user, ok := principal.(User); ok {
 		return m.channels[user.Name()].Copy(), nil
 	} else {
@@ -1334,7 +1337,7 @@ func (m mockComputerV2) ComputeChannelsForPrincipal(principal Principal) (ch.Tim
 	}
 }
 
-func (m mockComputerV2) ComputeRolesForUser(user User) (ch.TimedSet, error) {
+func (m mockComputerV2) ComputeRolesForUser(ctx context.Context, user User) (ch.TimedSet, error) {
 	return m.roles[user.Name()].Copy(), nil
 }
 

--- a/auth/password_hash.go
+++ b/auth/password_hash.go
@@ -61,7 +61,7 @@ func compareHashAndPassword(cache Cache, hash []byte, password []byte) bool {
 func (auth *Authenticator) SetBcryptCost(cost int) error {
 	if cost <= 0 {
 		auth.BcryptCost = DefaultBcryptCost
-		base.Debugf(base.KeyAuth, "bcrypt cost set to default: %d", cost)
+		base.DebugfCtx(auth.LogCtx, base.KeyAuth, "bcrypt cost set to default: %d", cost)
 		return nil
 	}
 
@@ -71,7 +71,7 @@ func (auth *Authenticator) SetBcryptCost(cost int) error {
 			cost, DefaultBcryptCost, bcrypt.MaxCost)
 	}
 
-	base.Infof(base.KeyAuth, "bcrypt cost set to: %d", cost)
+	base.InfofCtx(auth.LogCtx, base.KeyAuth, "bcrypt cost set to: %d", cost)
 	auth.BcryptCost = cost
 	auth.bcryptCostChanged = true
 

--- a/auth/session.go
+++ b/auth/session.go
@@ -43,9 +43,9 @@ func (auth *Authenticator) AuthenticateCookie(rq *http.Request, response http.Re
 		return nil, err
 	}
 	// Don't need to check session.Expiration, because Couchbase will have nuked the document.
-	//update the session Expiration if 10% or more of the current expiration time has elapsed
-	//if the session does not contain a Ttl (probably created prior to upgrading SG), use
-	//default value of 24Hours
+	// update the session Expiration if 10% or more of the current expiration time has elapsed
+	// if the session does not contain a Ttl (probably created prior to upgrading SG), use
+	// default value of 24Hours
 	if session.Ttl == 0 {
 		session.Ttl = kDefaultSessionTTL
 	}
@@ -121,7 +121,7 @@ func (auth Authenticator) DeleteSessionForCookie(rq *http.Request) *http.Cookie 
 	}
 
 	if err := auth.bucket.Delete(DocIDForSession(cookie.Value)); err != nil {
-		base.Debugf(base.KeyAuth, "Error while deleting session for cookie %s, Error: %v", base.UD(cookie.Value), err)
+		base.DebugfCtx(auth.LogCtx, base.KeyAuth, "Error while deleting session for cookie %s, Error: %v", base.UD(cookie.Value), err)
 	}
 
 	newCookie := *cookie

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -410,9 +411,9 @@ func isTransientIndexerError(err error) bool {
 	return false
 }
 
-func SlowQueryLog(startTime time.Time, threshold time.Duration, messageFormat string, args ...interface{}) {
+func SlowQueryLog(ctx context.Context, startTime time.Time, threshold time.Duration, messageFormat string, args ...interface{}) {
 	if elapsed := time.Now().Sub(startTime); elapsed > threshold {
-		Infof(KeyQuery, messageFormat+" took "+elapsed.String(), args...)
+		InfofCtx(ctx, KeyQuery, messageFormat+" took "+elapsed.String(), args...)
 	}
 }
 

--- a/base/logging.go
+++ b/base/logging.go
@@ -282,7 +282,7 @@ func Consolef(logLevel LogLevel, logKey LogKey, format string, args ...interface
 
 	// If the above logTo didn't already log to stderr, do it directly here
 	if !consoleLogger.isStderr || !consoleLogger.shouldLog(logLevel, logKey) {
-		format = color(addPrefixes(format, context.Background(), logLevel, logKey), logLevel)
+		format = color(addPrefixes(format, nil, logLevel, logKey), logLevel)
 		_, _ = fmt.Fprintf(consoleFOutput, format+"\n", args...)
 	}
 }
@@ -295,7 +295,7 @@ func LogSyncGatewayVersion() {
 	Consolef(LevelNone, KeyNone, msg)
 
 	// Log the startup indicator to ALL log files too.
-	msg = addPrefixes(msg, context.Background(), LevelNone, KeyNone)
+	msg = addPrefixes(msg, nil, LevelNone, KeyNone)
 	if errorLogger.shouldLog(LevelNone) {
 		errorLogger.logger.Printf(msg)
 	}

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -62,8 +62,8 @@ func NewTaskID(contextID string, taskName string) string {
 	return contextID + "-" + taskName + "-" + strconv.Itoa(rand.Intn(65536))
 }
 
-// testCtx creates a log context for the given test.
-func testCtx(t testing.TB) context.Context {
+// TestCtx creates a log context for the given test.
+func TestCtx(t testing.TB) context.Context {
 	return context.WithValue(context.Background(), LogContextKey{}, LogContext{TestName: t.Name()})
 }
 

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -181,7 +181,7 @@ func (tbp *TestBucketPool) markBucketClosed(t testing.TB, b Bucket) {
 	defer tbp.unclosedBucketsLock.Unlock()
 
 	// Check for unclosed view query operations. A fatal error will occur if queue is not cleared
-	testCtx := testCtx(t)
+	testCtx := TestCtx(t)
 	switch typedBucket := b.(type) {
 	case *Collection:
 		tbp.checkForViewOpsQueueEmptied(testCtx, b.GetName(), typedBucket.queryOps)
@@ -209,7 +209,7 @@ func (tbp *TestBucketPool) checkForViewOpsQueueEmptied(ctx context.Context, buck
 }
 
 func (tbp *TestBucketPool) GetWalrusTestBucket(t testing.TB, url string) (b Bucket, s BucketSpec, teardown func()) {
-	testCtx := testCtx(t)
+	testCtx := TestCtx(t)
 	if !UnitTestUrlIsWalrus() {
 		FatalfCtx(testCtx, "nil TestBucketPool, but not using a Walrus test URL")
 	}
@@ -260,7 +260,7 @@ func (tbp *TestBucketPool) GetWalrusTestBucket(t testing.TB, url string) (b Buck
 // which closes the bucket, readies it for a new test, and releases back into the pool.
 func (tbp *TestBucketPool) GetTestBucketAndSpec(t testing.TB) (b Bucket, s BucketSpec, teardownFn func()) {
 
-	ctx := testCtx(t)
+	ctx := TestCtx(t)
 
 	// Return a new Walrus bucket when tbp has not been initialized
 	if !tbp.integrationMode {

--- a/db/active_replicator_test.go
+++ b/db/active_replicator_test.go
@@ -11,12 +11,12 @@ licenses/APL2.txt.
 package db
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 
+	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -65,7 +65,7 @@ func TestBlipSyncErrorUserinfo(t *testing.T) {
 			srvURL.Path = "/db1"
 			t.Logf("srvURL: %v", srvURL.String())
 
-			blipContext, err := NewSGBlipContext(context.Background(), t.Name())
+			blipContext, err := NewSGBlipContext(base.TestCtx(t), t.Name())
 			require.NoError(t, err)
 
 			_, err = blipSync(*srvURL, blipContext, false)

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -100,7 +100,7 @@ func (bh *blipHandler) refreshUser() error {
 		// If changed, refresh the user and db while holding the lock
 		if userChanged {
 			// Refresh the BlipSyncContext database
-			newUser, err := bc.blipContextDb.Authenticator().GetUser(bc.userName)
+			newUser, err := bc.blipContextDb.Authenticator(bh.loggingCtx).GetUser(bc.userName)
 			if err != nil {
 				bc.dbUserLock.Unlock()
 				return err
@@ -117,7 +117,7 @@ func (bh *blipHandler) refreshUser() error {
 	return nil
 }
 
-//////// CHECKPOINTS
+// ////// CHECKPOINTS
 
 // Received a "getCheckpoint" request
 func (bh *blipHandler) handleGetCheckpoint(rq *blip.Message) error {
@@ -169,7 +169,7 @@ func (bh *blipHandler) handleSetCheckpoint(rq *blip.Message) error {
 	return nil
 }
 
-//////// CHANGES
+// ////// CHANGES
 
 // Received a "subChanges" subscription request
 func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
@@ -695,7 +695,7 @@ func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 	return nil
 }
 
-//////// DOCUMENTS:
+// ////// DOCUMENTS:
 
 func (bsc *BlipSyncContext) sendRevAsDelta(sender *blip.Sender, docID, revID, deltaSrcRevID string, seq SequenceID, knownRevs map[string]bool, maxHistory int, handleChangesResponseDb *Database) error {
 
@@ -779,7 +779,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 		}
 	}()
 
-	//addRevisionParams := newAddRevisionParams(rq)
+	// addRevisionParams := newAddRevisionParams(rq)
 	revMessage := RevMessage{Message: rq}
 
 	base.DebugfCtx(bh.loggingCtx, base.KeySyncMsg, "#%d: Type:%s %s", bh.serialNumber, rq.Profile(), revMessage.String())
@@ -909,7 +909,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 	// Look at attachments with revpos > the last common ancestor's
 	minRevpos := 1
 	if len(history) > 0 {
-		currentDoc, rawDoc, err := bh.db.GetDocumentWithRaw(docID, DocUnmarshalSync)
+		currentDoc, rawDoc, err := bh.db.GetDocumentWithRaw(bh.loggingCtx, docID, DocUnmarshalSync)
 		// If we're able to obtain current doc data then we should use the common ancestor generation++ for min revpos
 		// as we will already have any attachments on the common ancestor so don't need to ask for them.
 		// Otherwise we'll have to go as far back as we can in the doc history and choose the last entry in there.
@@ -960,7 +960,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 	return nil
 }
 
-//////// ATTACHMENTS:
+// ////// ATTACHMENTS:
 
 func (bh *blipHandler) handleProveAttachment(rq *blip.Message) error {
 	nonce, err := rq.Body()

--- a/db/blip_sync_context_test.go
+++ b/db/blip_sync_context_test.go
@@ -11,7 +11,6 @@ licenses/APL2.txt.
 package db
 
 import (
-	"context"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -47,7 +46,7 @@ func TestBlipSyncContextSetUseDeltas(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := &BlipSyncContext{
-				blipContextDb:    &Database{Ctx: context.TODO()},
+				blipContextDb:    &Database{Ctx: base.TestCtx(t)},
 				useDeltas:        tt.startingCtxDeltas,
 				sgCanUseDeltas:   tt.sgCanUseDeltas,
 				replicationStats: NewBlipSyncStats(),
@@ -88,7 +87,7 @@ func BenchmarkBlipSyncContextSetUseDeltas(b *testing.B) {
 	for _, tt := range tests {
 		b.Run(tt.name, func(b *testing.B) {
 			ctx := &BlipSyncContext{
-				blipContextDb:    &Database{Ctx: context.TODO()},
+				blipContextDb:    &Database{Ctx: base.TestCtx(b)},
 				replicationStats: NewBlipSyncStats(),
 			}
 			b.ResetTimer()

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -149,7 +149,7 @@ func DefaultCacheOptions() CacheOptions {
 	}
 }
 
-//////// HOUSEKEEPING:
+// ////// HOUSEKEEPING:
 
 // Initializes a new changeCache.
 // lastSequence is the last known database sequence assigned.
@@ -368,7 +368,7 @@ func (c *changeCache) CleanSkippedSequenceQueue(ctx context.Context) error {
 		entry.Skipped = true
 		// Need to populate the actual channels for this entry - the entry returned from the * channel
 		// view will only have the * channel
-		doc, err := c.context.GetDocument(entry.DocID, DocUnmarshalNoHistory)
+		doc, err := c.context.GetDocument(ctx, entry.DocID, DocUnmarshalNoHistory)
 		if err != nil {
 			base.WarnfCtx(ctx, "Unable to retrieve doc when processing skipped document %q: abandoning sequence %d", base.UD(entry.DocID), entry.Sequence)
 			continue
@@ -393,7 +393,7 @@ func (c *changeCache) CleanSkippedSequenceQueue(ctx context.Context) error {
 	return nil
 }
 
-//////// ADDING CHANGES:
+// ////// ADDING CHANGES:
 
 // Note that DocChanged may be executed concurrently for multiple events (in the DCP case, DCP events
 // originating from multiple vbuckets).  Only processEntry is locking - all other functionality needs to support
@@ -532,7 +532,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 					TimeReceived: event.TimeReceived,
 				}
 
-				//if the doc was removed from one or more channels at this sequence
+				// if the doc was removed from one or more channels at this sequence
 				// Set the removed flag and removed channel set on the LogEntry
 				if channelRemovals, atRevId := syncData.Channels.ChannelsRemovedAtSequence(seq); len(channelRemovals) > 0 {
 					change.DocID = docID
@@ -827,7 +827,7 @@ func (c *changeCache) getChannelCache() ChannelCache {
 	return c.channelCache
 }
 
-//////// CHANGE ACCESS:
+// ////// CHANGE ACCESS:
 
 func (c *changeCache) GetChanges(channelName string, options ChangesOptions) ([]*LogEntry, error) {
 
@@ -874,7 +874,7 @@ func (c *changeCache) getInitialSequence() (initialSequence uint64) {
 	return initialSequence
 }
 
-//////// LOG PRIORITY QUEUE -- container/heap callbacks that should not be called directly.   Use heap.Init/Push/etc()
+// ////// LOG PRIORITY QUEUE -- container/heap callbacks that should not be called directly.   Use heap.Init/Push/etc()
 
 func (h LogPriorityQueue) Len() int           { return len(h) }
 func (h LogPriorityQueue) Less(i, j int) bool { return h[i].Sequence < h[j].Sequence }
@@ -892,7 +892,7 @@ func (h *LogPriorityQueue) Pop() interface{} {
 	return x
 }
 
-//////// SKIPPED SEQUENCE QUEUE
+// ////// SKIPPED SEQUENCE QUEUE
 
 func (c *changeCache) RemoveSkipped(x uint64) error {
 	err := c.skippedSeqs.Remove(x)

--- a/db/change_listener_test.go
+++ b/db/change_listener_test.go
@@ -27,10 +27,12 @@ func TestUserWaiter(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
+	ctx := base.TestCtx(t)
+
 	// Create user
 	username := "bob"
-	authenticator := db.Authenticator()
-	require.NotNil(t, authenticator, "db.Authenticator() returned nil")
+	authenticator := db.Authenticator(ctx)
+	require.NotNil(t, authenticator, "db.Authenticator(base.TestCtx(t)) returned nil")
 	user, err := authenticator.NewUser(username, "letmein", channels.SetOf(t, "ABC"))
 	require.NoError(t, err, "Error creating new user")
 
@@ -55,7 +57,7 @@ func TestUserWaiter(t *testing.T) {
 		Name:     &username,
 		Channels: base.SetFromArray([]string{"ABC", "DEF"}),
 	}
-	_, err = db.UpdatePrincipal(updatedUser, true, true)
+	_, err = db.UpdatePrincipal(ctx, updatedUser, true, true)
 	require.NoError(t, err, "Error updating user")
 
 	// Wait for notification from grant
@@ -70,17 +72,19 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
+	ctx := base.TestCtx(t)
+
 	// Create role
 	roleName := "good_egg"
-	authenticator := db.Authenticator()
-	require.NotNil(t, authenticator, "db.Authenticator() returned nil")
+	authenticator := db.Authenticator(ctx)
+	require.NotNil(t, authenticator, "db.Authenticator(base.TestCtx(t)) returned nil")
 	role, err := authenticator.NewRole(roleName, channels.SetOf(t, "ABC"))
 	require.NoError(t, err, "Error creating new role")
 	require.NoError(t, authenticator.Save(role))
 
 	// Create user
 	username := "bob"
-	require.NotNil(t, authenticator, "db.Authenticator() returned nil")
+	require.NotNil(t, authenticator, "db.Authenticator(base.TestCtx(t)) returned nil")
 	user, err := authenticator.NewUser(username, "letmein", nil)
 	require.NoError(t, err, "Error creating new user")
 
@@ -105,7 +109,7 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 		Name:              &username,
 		ExplicitRoleNames: []string{roleName},
 	}
-	_, err = db.UpdatePrincipal(updatedUser, true, true)
+	_, err = db.UpdatePrincipal(ctx, updatedUser, true, true)
 	require.NoError(t, err, "Error updating user")
 
 	// Wait for notify from updated user
@@ -126,7 +130,7 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 		Name:     &roleName,
 		Channels: base.SetFromArray([]string{"ABC"}),
 	}
-	_, err = db.UpdatePrincipal(updatedRole, false, true)
+	_, err = db.UpdatePrincipal(ctx, updatedRole, false, true)
 	require.NoError(t, err, "Error updating role")
 
 	// Wait for user notification of updated role

--- a/db/changes.go
+++ b/db/changes.go
@@ -106,7 +106,7 @@ func (db *Database) addDocToChangeEntry(entry *ChangeEntry, options ChangesOptio
 
 	if options.IncludeDocs && includeConflicts {
 		// Load doc body + metadata
-		doc, err := db.GetDocument(entry.ID, DocUnmarshalAll)
+		doc, err := db.GetDocument(db.Ctx, entry.ID, DocUnmarshalAll)
 		if err != nil {
 			base.WarnfCtx(db.Ctx, "Changes feed: error getting doc %q: %v", base.UD(entry.ID), err)
 			return
@@ -117,7 +117,7 @@ func (db *Database) addDocToChangeEntry(entry *ChangeEntry, options ChangesOptio
 		// Load doc metadata only
 		doc := &Document{}
 		var err error
-		doc.SyncData, err = db.GetDocSyncData(entry.ID)
+		doc.SyncData, err = db.GetDocSyncData(db.Ctx, entry.ID)
 		if err != nil {
 			base.WarnfCtx(db.Ctx, "Changes feed: error getting doc sync data %q: %v", base.UD(entry.ID), err)
 			return
@@ -303,7 +303,7 @@ func (db *Database) buildRevokedFeed(channelName string, options ChangesOptions,
 }
 
 func UserHasDocAccess(db *Database, docID, revID string) (bool, error) {
-	rev, err := db.revisionCache.Get(docID, revID, false, false)
+	rev, err := db.revisionCache.Get(db.Ctx, docID, revID, false, false)
 	if err != nil {
 		if base.IsDocNotFoundError(err) {
 			return false, nil
@@ -322,7 +322,7 @@ func UserHasDocAccess(db *Database, docID, revID string) (bool, error) {
 // Checks if a document needs to be revoked. This is used in the case where the since < doc sequence
 func (db *Database) wasDocInChannelPriorToRevocation(docID, chanName string, since uint64) (bool, error) {
 	// Get doc sync data so we can verify the docs grant history
-	syncData, err := db.GetDocSyncData(docID)
+	syncData, err := db.GetDocSyncData(db.Ctx, docID)
 	if err != nil {
 		return false, err
 	}
@@ -1231,7 +1231,7 @@ func (db *Database) DocIDChangesFeed(userChannels base.Set, explicitDocIds []str
 func createChangesEntry(docid string, db *Database, options ChangesOptions) *ChangeEntry {
 	row := &ChangeEntry{ID: docid}
 
-	populatedDoc, err := db.GetDocument(docid, DocUnmarshalSync)
+	populatedDoc, err := db.GetDocument(db.Ctx, docid, DocUnmarshalSync)
 	if err != nil {
 		base.InfofCtx(db.Ctx, base.KeyChanges, "Unable to get changes for docID %v, caused by %v", base.UD(docid), err)
 		return nil

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -57,7 +57,7 @@ type ChannelCache interface {
 	Clear()
 
 	// Size of the the largest individual channel cache, invoked for stats reporting
-	//// TODO: let the cache manage its own stats internally (maybe take an updateStats call)
+	// // TODO: let the cache manage its own stats internally (maybe take an updateStats call)
 	MaxCacheSize() int
 
 	// Returns the highest cached sequence, used for changes synchronization
@@ -75,7 +75,7 @@ type ChannelCache interface {
 
 // ChannelQueryHandler interface is implemented by databaseContext.
 type ChannelQueryHandler interface {
-	getChangesInChannelFromQuery(channelName string, startSeq, endSeq uint64, limit int, activeOnly bool) (LogEntries, error)
+	getChangesInChannelFromQuery(ctx context.Context, channelName string, startSeq, endSeq uint64, limit int, activeOnly bool) (LogEntries, error)
 }
 
 type StableSequenceCallbackFunc func() uint64

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -318,9 +318,9 @@ func (c *singleChannelCacheImpl) GetCachedChanges(options ChangesOptions) (valid
 	sinceSeq := options.Since.SafeSequence()
 	limit := options.Limit
 
-	//If the activeOnly option is set, then do not limit the number of entries returned
-	//we don't know how many non active entries will be discarded from the entry set
-	//by the caller, so the additional entries may be needed to return up to the limit requested
+	// If the activeOnly option is set, then do not limit the number of entries returned
+	// we don't know how many non active entries will be discarded from the entry set
+	// by the caller, so the additional entries may be needed to return up to the limit requested
 	if options.ActiveOnly {
 		limit = 0
 	}
@@ -383,7 +383,7 @@ func (c *singleChannelCacheImpl) GetChanges(options ChangesOptions) ([]*LogEntry
 	}
 
 	// Nope, we're going to have to backfill from the view.
-	//** First acquire the _query_ lock (not the regular lock!)
+	// ** First acquire the _query_ lock (not the regular lock!)
 	// Track pending queries via StatKeyChannelCachePendingQueries expvar
 	c.cacheStats.ChannelCachePendingQueries.Add(1)
 	c.queryLock.Lock()
@@ -415,7 +415,7 @@ func (c *singleChannelCacheImpl) GetChanges(options ChangesOptions) ([]*LogEntry
 	// overlap, which helps confirm that we've got everything.
 	c.cacheStats.ChannelCacheMisses.Add(1)
 	endSeq := cacheValidFrom
-	resultFromQuery, err := c.queryHandler.getChangesInChannelFromQuery(c.channelName, startSeq, endSeq, options.Limit, options.ActiveOnly)
+	resultFromQuery, err := c.queryHandler.getChangesInChannelFromQuery(options.Ctx, c.channelName, startSeq, endSeq, options.Limit, options.ActiveOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -452,7 +452,7 @@ func (c *singleChannelCacheImpl) GetChanges(options ChangesOptions) ([]*LogEntry
 	return result, nil
 }
 
-//////// LOGENTRIES:
+// ////// LOGENTRIES:
 
 func (c *singleChannelCacheImpl) _adjustFirstSeq(change *LogEntry) {
 	if change.Sequence < c.validFrom {
@@ -837,7 +837,7 @@ type bypassChannelCache struct {
 func (b *bypassChannelCache) GetChanges(options ChangesOptions) ([]*LogEntry, error) {
 	startSeq := options.Since.SafeSequence() + 1
 	endSeq := uint64(math.MaxUint64)
-	return b.queryHandler.getChangesInChannelFromQuery(b.channelName, startSeq, endSeq, options.Limit, options.ActiveOnly)
+	return b.queryHandler.getChangesInChannelFromQuery(options.Ctx, b.channelName, startSeq, endSeq, options.Limit, options.ActiveOnly)
 }
 
 // No cached changes for bypassChannelCache

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -9,6 +9,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math/rand"
@@ -457,7 +458,7 @@ type testQueryHandler struct {
 	lock       sync.RWMutex
 }
 
-func (qh *testQueryHandler) getChangesInChannelFromQuery(channelName string, startSeq, endSeq uint64, limit int, activeOnly bool) (LogEntries, error) {
+func (qh *testQueryHandler) getChangesInChannelFromQuery(ctx context.Context, channelName string, startSeq, endSeq uint64, limit int, activeOnly bool) (LogEntries, error) {
 	queryEntries := make(LogEntries, 0)
 	qh.lock.RLock()
 	for _, entry := range qh.entries {

--- a/db/crud.go
+++ b/db/crud.go
@@ -334,7 +334,7 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta *RevisionD
 	if fromRevision.Delta != nil {
 		if fromRevision.Delta.ToRevID == toRevID {
 
-			isAuthorized, redactedBody := db.authorizeUserForChannels(docID, toRevID, fromRevision.Delta.ToChannels, fromRevision.Delta.ToDeleted, encodeRevisions(db.Ctx, fromRevision.Delta.RevisionHistory))
+			isAuthorized, redactedBody := db.authorizeUserForChannels(docID, toRevID, fromRevision.Delta.ToChannels, fromRevision.Delta.ToDeleted, encodeRevisions(docID, fromRevision.Delta.RevisionHistory))
 			if !isAuthorized {
 				return nil, &redactedBody, nil
 			}
@@ -683,7 +683,7 @@ func (db *Database) get1xRevFromDoc(doc *Document, revid string, listRevisions b
 		if getHistoryErr != nil {
 			return nil, removed, getHistoryErr
 		}
-		kvPairs = append(kvPairs, base.KVPair{Key: BodyRevisions, Val: encodeRevisions(db.Ctx, validatedHistory)})
+		kvPairs = append(kvPairs, base.KVPair{Key: BodyRevisions, Val: encodeRevisions(doc.ID, validatedHistory)})
 	}
 
 	bodyBytes, err = base.InjectJSONProperties(bodyBytes, kvPairs...)
@@ -1911,7 +1911,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			DocID:            docid,
 			RevID:            newRevID,
 			BodyBytes:        storedDocBytes,
-			History:          encodeRevisions(db.Ctx, history),
+			History:          encodeRevisions(docid, history),
 			Channels:         revChannels,
 			Attachments:      doc.Attachments,
 			Expiry:           doc.Expiry,

--- a/db/crud.go
+++ b/db/crud.go
@@ -10,6 +10,7 @@ package db
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math"
 	"net/http"
@@ -32,7 +33,7 @@ const (
 // this is different from a client specifically requesting a revision they know about, which are treated as a _removal.
 var ErrForbidden = base.HTTPErrorf(403, "forbidden")
 
-//////// READING DOCUMENTS:
+// ////// READING DOCUMENTS:
 
 func realDocID(docid string) string {
 	if len(docid) > 250 {
@@ -44,13 +45,13 @@ func realDocID(docid string) string {
 	return docid
 }
 
-func (db *DatabaseContext) GetDocument(docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
-	doc, _, err = db.GetDocumentWithRaw(docid, unmarshalLevel)
+func (db *DatabaseContext) GetDocument(ctx context.Context, docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
+	doc, _, err = db.GetDocumentWithRaw(ctx, docid, unmarshalLevel)
 	return doc, err
 }
 
 // Lowest-level method that reads a document from the bucket
-func (db *DatabaseContext) GetDocumentWithRaw(docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, rawBucketDoc *sgbucket.BucketDocument, err error) {
+func (db *DatabaseContext) GetDocumentWithRaw(ctx context.Context, docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, rawBucketDoc *sgbucket.BucketDocument, err error) {
 	key := realDocID(docid)
 	if key == "" {
 		return nil, nil, base.HTTPErrorf(400, "Invalid doc ID")
@@ -61,7 +62,7 @@ func (db *DatabaseContext) GetDocumentWithRaw(docid string, unmarshalLevel Docum
 			return nil, nil, err
 		}
 
-		isSgWrite, crc32Match, _ := doc.IsSGWrite(rawBucketDoc.Body)
+		isSgWrite, crc32Match, _ := doc.IsSGWrite(ctx, rawBucketDoc.Body)
 		if crc32Match {
 			db.DbStats.Database().Crc32MatchCount.Add(1)
 		}
@@ -69,7 +70,7 @@ func (db *DatabaseContext) GetDocumentWithRaw(docid string, unmarshalLevel Docum
 		// If existing doc wasn't an SG Write, import the doc.
 		if !isSgWrite {
 			var importErr error
-			doc, importErr = db.OnDemandImportForGet(docid, rawBucketDoc.Body, rawBucketDoc.Xattr, rawBucketDoc.UserXattr, rawBucketDoc.Cas)
+			doc, importErr = db.OnDemandImportForGet(ctx, docid, rawBucketDoc.Body, rawBucketDoc.Xattr, rawBucketDoc.UserXattr, rawBucketDoc.Cas)
 			if importErr != nil {
 				return nil, nil, importErr
 			}
@@ -124,7 +125,7 @@ func (db *DatabaseContext) GetDocWithXattr(key string, unmarshalLevel DocumentUn
 }
 
 // This gets *just* the Sync Metadata (_sync field) rather than the entire doc, for efficiency reasons.
-func (db *DatabaseContext) GetDocSyncData(docid string) (SyncData, error) {
+func (db *DatabaseContext) GetDocSyncData(ctx context.Context, docid string) (SyncData, error) {
 
 	emptySyncData := SyncData{}
 	key := realDocID(docid)
@@ -147,7 +148,7 @@ func (db *DatabaseContext) GetDocSyncData(docid string) (SyncData, error) {
 			return emptySyncData, unmarshalErr
 		}
 
-		isSgWrite, crc32Match, _ := doc.IsSGWrite(rawDoc)
+		isSgWrite, crc32Match, _ := doc.IsSGWrite(ctx, rawDoc)
 		if crc32Match {
 			db.DbStats.Database().Crc32MatchCount.Add(1)
 		}
@@ -156,7 +157,7 @@ func (db *DatabaseContext) GetDocSyncData(docid string) (SyncData, error) {
 		if !isSgWrite {
 			var importErr error
 
-			doc, importErr = db.OnDemandImportForGet(docid, rawDoc, rawXattr, rawUserXattr, cas)
+			doc, importErr = db.OnDemandImportForGet(ctx, docid, rawDoc, rawXattr, rawUserXattr, cas)
 			if importErr != nil {
 				return emptySyncData, importErr
 			}
@@ -185,9 +186,9 @@ func (db *DatabaseContext) GetDocSyncData(docid string) (SyncData, error) {
 
 // OnDemandImportForGet.  Attempts to import the doc based on the provided id, contents and cas.  ImportDocRaw does cas retry handling
 // if the document gets updated after the initial retrieval attempt that triggered this.
-func (db *DatabaseContext) OnDemandImportForGet(docid string, rawDoc []byte, rawXattr []byte, rawUserXattr []byte, cas uint64) (docOut *Document, err error) {
+func (db *DatabaseContext) OnDemandImportForGet(ctx context.Context, docid string, rawDoc []byte, rawXattr []byte, rawUserXattr []byte, cas uint64) (docOut *Document, err error) {
 	isDelete := rawDoc == nil
-	importDb := Database{DatabaseContext: db, user: nil}
+	importDb := Database{DatabaseContext: db, user: nil, Ctx: ctx}
 	var importErr error
 
 	docOut, importErr = importDb.ImportDocRaw(docid, rawDoc, rawXattr, rawUserXattr, isDelete, cas, nil, ImportOnDemand)
@@ -257,10 +258,10 @@ func (db *Database) getRev(docid, revid string, maxHistory int, historyFrom []st
 	if revid != "" {
 		// Get a specific revision body and history from the revision cache
 		// (which will load them if necessary, by calling revCacheLoader, above)
-		revision, err = db.revisionCache.Get(docid, revid, includeBody, RevCacheOmitDelta)
+		revision, err = db.revisionCache.Get(db.Ctx, docid, revid, includeBody, RevCacheOmitDelta)
 	} else {
 		// No rev ID given, so load active revision
-		revision, err = db.revisionCache.GetActive(docid, includeBody)
+		revision, err = db.revisionCache.GetActive(db.Ctx, docid, includeBody)
 	}
 
 	if err != nil {
@@ -310,7 +311,7 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta *RevisionD
 		return nil, nil, nil
 	}
 
-	fromRevision, err := db.revisionCache.Get(docID, fromRevID, RevCacheOmitBody, RevCacheIncludeDelta)
+	fromRevision, err := db.revisionCache.Get(db.Ctx, docID, fromRevID, RevCacheOmitBody, RevCacheIncludeDelta)
 
 	// If the fromRevision is a removal cache entry (no body), but the user has access to that removal, then just
 	// return 404 missing to indicate that the body of the revision is no longer available.
@@ -333,7 +334,7 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta *RevisionD
 	if fromRevision.Delta != nil {
 		if fromRevision.Delta.ToRevID == toRevID {
 
-			isAuthorized, redactedBody := db.authorizeUserForChannels(docID, toRevID, fromRevision.Delta.ToChannels, fromRevision.Delta.ToDeleted, encodeRevisions(fromRevision.Delta.RevisionHistory))
+			isAuthorized, redactedBody := db.authorizeUserForChannels(docID, toRevID, fromRevision.Delta.ToChannels, fromRevision.Delta.ToDeleted, encodeRevisions(db.Ctx, fromRevision.Delta.RevisionHistory))
 			if !isAuthorized {
 				return nil, &redactedBody, nil
 			}
@@ -353,7 +354,7 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta *RevisionD
 
 		// db.DbStats.StatsDeltaSync().Add(base.StatKeyDeltaCacheMisses, 1)
 		db.DbStats.DeltaSync().DeltaCacheMiss.Add(1)
-		toRevision, err := db.revisionCache.Get(docID, toRevID, RevCacheOmitBody, RevCacheIncludeDelta)
+		toRevision, err := db.revisionCache.Get(db.Ctx, docID, toRevID, RevCacheOmitBody, RevCacheIncludeDelta)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -371,7 +372,7 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta *RevisionD
 		// If the revision we're generating a delta to is a tombstone, mark it as such and don't bother generating a delta
 		if deleted {
 			revCacheDelta := newRevCacheDelta([]byte(base.EmptyDocument), fromRevID, toRevision, deleted, nil)
-			db.revisionCache.UpdateDelta(docID, fromRevID, revCacheDelta)
+			db.revisionCache.UpdateDelta(db.Ctx, docID, fromRevID, revCacheDelta)
 			return &revCacheDelta, nil, nil
 		}
 
@@ -411,7 +412,7 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta *RevisionD
 		revCacheDelta := newRevCacheDelta(deltaBytes, fromRevID, toRevision, deleted, toRevAttStorageMeta)
 
 		// Write the newly calculated delta back into the cache before returning
-		db.revisionCache.UpdateDelta(docID, fromRevID, revCacheDelta)
+		db.revisionCache.UpdateDelta(db.Ctx, docID, fromRevID, revCacheDelta)
 		return &revCacheDelta, nil, nil
 	}
 
@@ -447,7 +448,7 @@ func (db *Database) authorizeUserForChannels(docID, revID string, channels base.
 // Returns the body of a revision of a document, as well as the document's current channels
 // and the user/roles it grants channel access to.
 func (db *Database) Get1xRevAndChannels(docID string, revID string, listRevisions bool) (bodyBytes []byte, channels channels.ChannelMap, access UserAccessMap, roleAccess UserAccessMap, flags uint8, sequence uint64, gotRevID string, removed bool, err error) {
-	doc, err := db.GetDocument(docID, DocUnmarshalAll)
+	doc, err := db.GetDocument(db.Ctx, docID, DocUnmarshalAll)
 	if doc == nil {
 		return
 	}
@@ -488,8 +489,8 @@ func (db *Database) authorizeDoc(doc *Document, revid string) error {
 
 // Gets a revision of a document. If it's obsolete it will be loaded from the database if possible.
 // inline "_attachments" properties in the body will be extracted and returned separately if present (pre-2.5 metadata, or backup revisions)
-func (db *DatabaseContext) getRevision(doc *Document, revid string) (bodyBytes []byte, body Body, attachments AttachmentsMeta, err error) {
-	bodyBytes = doc.getRevisionBodyJSON(revid, db.RevisionBodyLoader)
+func (db *DatabaseContext) getRevision(ctx context.Context, doc *Document, revid string) (bodyBytes []byte, body Body, attachments AttachmentsMeta, err error) {
+	bodyBytes = doc.getRevisionBodyJSON(ctx, revid, db.RevisionBodyLoader)
 
 	// No inline body, so look for separate doc:
 	if bodyBytes == nil {
@@ -497,7 +498,7 @@ func (db *DatabaseContext) getRevision(doc *Document, revid string) (bodyBytes [
 			return nil, nil, nil, base.HTTPErrorf(404, "missing")
 		}
 
-		bodyBytes, err = db.getOldRevisionJSON(doc.ID, revid)
+		bodyBytes, err = db.getOldRevisionJSON(ctx, doc.ID, revid)
 		if err != nil || bodyBytes == nil {
 			return nil, nil, nil, err
 		}
@@ -608,12 +609,12 @@ func extractInlineAttachments(bodyBytes []byte) (attachments AttachmentsMeta, cl
 // If it's obsolete it will be loaded from the database if possible.
 // Does not add _id or _rev properties.
 func (db *Database) getRevisionBodyJSON(doc *Document, revid string) ([]byte, error) {
-	if body := doc.getRevisionBodyJSON(revid, db.RevisionBodyLoader); body != nil {
+	if body := doc.getRevisionBodyJSON(db.Ctx, revid, db.RevisionBodyLoader); body != nil {
 		return body, nil
 	} else if !doc.History.contains(revid) {
 		return nil, base.HTTPErrorf(404, "missing")
 	} else {
-		return db.getOldRevisionJSON(doc.ID, revid)
+		return db.getOldRevisionJSON(db.Ctx, doc.ID, revid)
 	}
 }
 
@@ -659,7 +660,7 @@ func (db *Database) get1xRevFromDoc(doc *Document, revid string, listRevisions b
 				return nil, false, base.HTTPErrorf(404, "deleted")
 			}
 		}
-		if bodyBytes, _, attachments, err = db.getRevision(doc, revid); err != nil {
+		if bodyBytes, _, attachments, err = db.getRevision(db.Ctx, doc, revid); err != nil {
 			return nil, false, err
 		}
 	}
@@ -682,7 +683,7 @@ func (db *Database) get1xRevFromDoc(doc *Document, revid string, listRevisions b
 		if getHistoryErr != nil {
 			return nil, removed, getHistoryErr
 		}
-		kvPairs = append(kvPairs, base.KVPair{Key: BodyRevisions, Val: encodeRevisions(validatedHistory)})
+		kvPairs = append(kvPairs, base.KVPair{Key: BodyRevisions, Val: encodeRevisions(db.Ctx, validatedHistory)})
 	}
 
 	bodyBytes, err = base.InjectJSONProperties(bodyBytes, kvPairs...)
@@ -696,7 +697,7 @@ func (db *Database) get1xRevFromDoc(doc *Document, revid string, listRevisions b
 // Returns the body and rev ID of the asked-for revision or the most recent available ancestor.
 func (db *Database) getAvailableRev(doc *Document, revid string) ([]byte, string, AttachmentsMeta, error) {
 	for ; revid != ""; revid = doc.History[revid].Parent {
-		if bodyBytes, _, attachments, _ := db.getRevision(doc, revid); bodyBytes != nil {
+		if bodyBytes, _, attachments, _ := db.getRevision(db.Ctx, doc, revid); bodyBytes != nil {
 			return bodyBytes, revid, attachments, nil
 		}
 	}
@@ -758,7 +759,7 @@ func (db *Database) backupAncestorRevs(doc *Document, newDoc *Document) {
 			// No ancestors with JSON found.  Check if we need to back up current rev for delta sync, then return
 			db.backupRevisionJSON(doc.ID, newDoc.RevID, "", newBodyBytes, nil, doc.Attachments)
 			return
-		} else if json = doc.getRevisionBodyJSON(ancestorRevId, db.RevisionBodyLoader); json != nil {
+		} else if json = doc.getRevisionBodyJSON(db.Ctx, ancestorRevId, db.RevisionBodyLoader); json != nil {
 			break
 		}
 	}
@@ -774,7 +775,7 @@ func (db *Database) backupAncestorRevs(doc *Document, newDoc *Document) {
 	}
 }
 
-//////// UPDATING DOCUMENTS:
+// ////// UPDATING DOCUMENTS:
 
 func (db *Database) OnDemandImportForWrite(docid string, doc *Document, deleted bool) error {
 
@@ -843,7 +844,7 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 
 		// Is this doc an sgWrite?
 		if doc != nil {
-			isSgWrite, crc32Match, _ = doc.IsSGWrite(nil)
+			isSgWrite, crc32Match, _ = doc.IsSGWrite(db.Ctx, nil)
 			if crc32Match {
 				db.DbStats.Database().Crc32MatchCount.Add(1)
 			}
@@ -944,7 +945,7 @@ func (db *Database) PutExistingRevWithConflictResolution(newDoc *Document, docHi
 
 		// Is this doc an sgWrite?
 		if doc != nil {
-			isSgWrite, crc32Match, _ = doc.IsSGWrite(nil)
+			isSgWrite, crc32Match, _ = doc.IsSGWrite(db.Ctx, nil)
 			if crc32Match {
 				db.DbStats.Database().Crc32MatchCount.Add(1)
 			}
@@ -1693,7 +1694,7 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 		if newRevID != doc.CurrentRev {
 			channelSet, access, roles, syncExpiry, oldBodyJSON, err = db.recalculateSyncFnForActiveRev(doc, metaMap, newRevID)
 		}
-		_, err = doc.updateChannels(channelSet)
+		_, err = doc.updateChannels(db.Ctx, channelSet)
 		if err != nil {
 			return
 		}
@@ -1843,7 +1844,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 
 			// Prior to saving doc invalidate the revision in cache
 			if createNewRevIDSkipped {
-				db.revisionCache.Invalidate(doc.ID, doc.CurrentRev)
+				db.revisionCache.Invalidate(db.Ctx, doc.ID, doc.CurrentRev)
 			}
 
 			base.DebugfCtx(db.Ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.CurrentRev)
@@ -1910,7 +1911,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			DocID:            docid,
 			RevID:            newRevID,
 			BodyBytes:        storedDocBytes,
-			History:          encodeRevisions(history),
+			History:          encodeRevisions(db.Ctx, history),
 			Channels:         revChannels,
 			Attachments:      doc.Attachments,
 			Expiry:           doc.Expiry,
@@ -1919,9 +1920,9 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 		}
 
 		if createNewRevIDSkipped {
-			db.revisionCache.Upsert(documentRevision)
+			db.revisionCache.Upsert(db.Ctx, documentRevision)
 		} else {
-			db.revisionCache.Put(documentRevision)
+			db.revisionCache.Put(db.Ctx, documentRevision)
 		}
 
 		if db.EventMgr.HasHandlerForEvent(DocumentChange) {
@@ -1937,7 +1938,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			}
 		}
 	} else {
-		//Revision has been pruned away so won't be added to cache
+		// Revision has been pruned away so won't be added to cache
 		base.InfofCtx(db.Ctx, base.KeyCRUD, "doc %q / %q, has been pruned, it has not been inserted into the revision cache", base.UD(docid), newRevID)
 	}
 
@@ -2000,7 +2001,7 @@ func getAttachmentIDsForLeafRevisions(db *Database, doc *Document, newRevID stri
 	})
 
 	for _, leafRevision := range documentLeafRevisions {
-		_, _, attachmentMeta, err := db.getRevision(doc, leafRevision)
+		_, _, attachmentMeta, err := db.getRevision(db.Ctx, doc, leafRevision)
 		if err != nil {
 			return nil, err
 		}
@@ -2089,7 +2090,7 @@ func (db *Database) MarkPrincipalsChanged(docid string, newRevID string, changed
 		base.InfofCtx(db.Ctx, base.KeyAccess, "Rev %q / %q invalidates roles of %s", base.UD(docid), newRevID, base.UD(changedRoleUsers))
 		for _, name := range changedRoleUsers {
 			db.invalUserRoles(name, invalSeq)
-			//If this is the current in memory db.user, reload to generate updated roles
+			// If this is the current in memory db.user, reload to generate updated roles
 			if db.user != nil && db.user.Name() == name {
 				base.DebugfCtx(db.Ctx, base.KeyAccess, "Role set for active user has been modified - user %q will be reloaded.", base.UD(db.user.Name()))
 				reloadActiveUser = true
@@ -2099,7 +2100,7 @@ func (db *Database) MarkPrincipalsChanged(docid string, newRevID string, changed
 	}
 
 	if reloadActiveUser {
-		user, err := db.Authenticator().GetUser(db.user.Name())
+		user, err := db.Authenticator(db.Ctx).GetUser(db.user.Name())
 		if err != nil {
 			base.WarnfCtx(db.Ctx, "Error reloading active db.user[%s], security information will not be recalculated until next authentication --> %+v", base.UD(db.user.Name()), err)
 		} else {
@@ -2137,7 +2138,7 @@ func (db *Database) DeleteDoc(docid string, revid string) (string, error) {
 
 // Purges a document from the bucket (no tombstone)
 func (db *Database) Purge(key string) error {
-	doc, err := db.GetDocument(key, DocUnmarshalAll)
+	doc, err := db.GetDocument(db.Ctx, key, DocUnmarshalAll)
 	if err != nil {
 		return err
 	}
@@ -2161,7 +2162,7 @@ func (db *Database) Purge(key string) error {
 	}
 }
 
-//////// CHANNELS:
+// ////// CHANNELS:
 
 // Calls the JS sync function to assign the doc to channels, grant users
 // access to channels, and reject invalid documents.
@@ -2273,22 +2274,15 @@ func isAccessError(err error) bool {
 
 // Recomputes the set of channels a User/Role has been granted access to by sync() functions.
 // This is part of the ChannelComputer interface defined by the Authenticator.
-func (context *DatabaseContext) ComputeChannelsForPrincipal(princ auth.Principal) (channels.TimedSet, error) {
-	return context.ComputeSequenceChannelsForPrincipal(princ)
-}
-
-// Recomputes the set of channels a User/Role has been granted access to by sync() functions.
-// This is part of the ChannelComputer interface defined by the Authenticator.
-func (context *DatabaseContext) ComputeSequenceChannelsForPrincipal(princ auth.Principal) (channels.TimedSet, error) {
-
+func (context *DatabaseContext) ComputeChannelsForPrincipal(ctx context.Context, princ auth.Principal) (channels.TimedSet, error) {
 	key := princ.Name()
 	if _, ok := princ.(auth.User); !ok {
 		key = channels.RoleAccessPrefix + key // Roles are identified in access view by a "role:" prefix
 	}
 
-	results, err := context.QueryAccess(key)
+	results, err := context.QueryAccess(ctx, key)
 	if err != nil {
-		base.Warnf("QueryAccess returned error: %v", err)
+		base.WarnfCtx(ctx, "QueryAccess returned error: %v", err)
 		return nil, err
 	}
 
@@ -2308,14 +2302,8 @@ func (context *DatabaseContext) ComputeSequenceChannelsForPrincipal(princ auth.P
 
 // Recomputes the set of channels a User/Role has been granted access to by sync() functions.
 // This is part of the ChannelComputer interface defined by the Authenticator.
-func (context *DatabaseContext) ComputeRolesForUser(user auth.User) (channels.TimedSet, error) {
-	return context.ComputeSequenceRolesForUser(user)
-}
-
-// Recomputes the set of roles a User has been granted access to by sync() functions.
-// This is part of the ChannelComputer interface defined by the Authenticator.
-func (context *DatabaseContext) ComputeSequenceRolesForUser(user auth.User) (channels.TimedSet, error) {
-	results, err := context.QueryRoleAccess(user.Name())
+func (context *DatabaseContext) ComputeRolesForUser(ctx context.Context, user auth.User) (channels.TimedSet, error) {
+	results, err := context.QueryRoleAccess(ctx, user.Name())
 	if err != nil {
 		return nil, err
 	}
@@ -2348,7 +2336,7 @@ func (context *DatabaseContext) checkForUpgrade(key string, unmarshalLevel Docum
 	return doc, rawDocument
 }
 
-//////// REVS_DIFF:
+// ////// REVS_DIFF:
 
 // Given a document ID and a set of revision IDs, looks up which ones are not known. Returns an
 // array of the unknown revisions, and an array of known revisions that might be recent ancestors.
@@ -2376,7 +2364,7 @@ func (db *Database) RevDiff(docid string, revids []string) (missing, possible []
 		}
 		history = doc.History
 	} else {
-		doc, err := db.GetDocument(docid, DocUnmarshalSync)
+		doc, err := db.GetDocument(db.Ctx, docid, DocUnmarshalSync)
 		if err != nil {
 			if !base.IsDocNotFoundError(err) {
 				base.WarnfCtx(db.Ctx, "RevDiff(%q) --> %T %v", base.UD(docid), err, err)
@@ -2434,7 +2422,7 @@ const (
 // Given a docID/revID to be pushed by a client, check whether it can be added _without conflict_.
 // This is used by the BLIP replication code in "allow_conflicts=false" mode.
 func (db *Database) CheckProposedRev(docid string, revid string, parentRevID string) (status ProposedRevStatus, currentRev string) {
-	doc, err := db.GetDocument(docid, DocUnmarshalAll)
+	doc, err := db.GetDocument(db.Ctx, docid, DocUnmarshalAll)
 	if err != nil {
 		if !base.IsDocNotFoundError(err) {
 			base.WarnfCtx(db.Ctx, "CheckProposedRev(%q) --> %T %v", base.UD(docid), err, err)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -131,7 +131,7 @@ func TestHasAttachmentsFlag(t *testing.T) {
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 2-a...")
-	gotDoc, err := db.GetDocument("doc1", DocUnmarshalSync)
+	gotDoc, err := db.GetDocument(base.TestCtx(t), "doc1", DocUnmarshalSync)
 	assert.NoError(t, err)
 	require.Contains(t, gotDoc.Attachments, "hello.txt")
 	attachmentData, ok := gotDoc.Attachments["hello.txt"].(map[string]interface{})
@@ -157,7 +157,7 @@ func TestHasAttachmentsFlag(t *testing.T) {
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify rev 2-b")
-	gotDoc, err = db.GetDocument("doc1", DocUnmarshalSync)
+	gotDoc, err = db.GetDocument(base.TestCtx(t), "doc1", DocUnmarshalSync)
 	assert.NoError(t, err)
 	require.Contains(t, gotDoc.Attachments, "hello.txt")
 	attachmentData, ok = gotDoc.Attachments["hello.txt"].(map[string]interface{})
@@ -942,7 +942,7 @@ func TestLargeSequence(t *testing.T) {
 	_, _, err := db.PutExistingRevWithBody("largeSeqDoc", body, []string{"1-a"}, false)
 	assert.NoError(t, err, "add largeSeqDoc")
 
-	syncData, err := db.GetDocSyncData("largeSeqDoc")
+	syncData, err := db.GetDocSyncData(base.TestCtx(t), "largeSeqDoc")
 	assert.NoError(t, err, "Error retrieving document sync data")
 	goassert.Equals(t, syncData.Sequence, uint64(9223372036854775808))
 }

--- a/db/database.go
+++ b/db/database.go
@@ -252,7 +252,7 @@ func ConnectToBucketFailFast(spec base.BucketSpec) (bucket base.Bucket, err erro
 // ConnectToBucket opens a Couchbase connection and return a specific bucket.
 func ConnectToBucket(spec base.BucketSpec) (base.Bucket, error) {
 
-	//start a retry loop to connect to the bucket backing off double the delay each time
+	// start a retry loop to connect to the bucket backing off double the delay each time
 	worker := func() (bool, error, interface{}) {
 		bucket, err := base.GetBucket(spec)
 
@@ -264,8 +264,8 @@ func ConnectToBucket(spec base.BucketSpec) (base.Bucket, error) {
 	}
 
 	sleeper := base.CreateDoublingSleeperFunc(
-		13, //MaxNumRetries approx 40 seconds total retry duration
-		5,  //InitialRetrySleepTimeMS
+		13, // MaxNumRetries approx 40 seconds total retry duration
+		5,  // InitialRetrySleepTimeMS
 	)
 
 	description := fmt.Sprintf("Attempt to connect to bucket : %v", spec.BucketName)
@@ -745,16 +745,16 @@ func (context *DatabaseContext) NotifyTerminatedChanges(username string) {
 func (dc *DatabaseContext) TakeDbOffline(reason string) error {
 
 	if atomic.CompareAndSwapUint32(&dc.State, DBOnline, DBStopping) {
-		//notify all active _changes feeds to close
+		// notify all active _changes feeds to close
 		close(dc.ExitChanges)
 
-		//Block until all current calls have returned, including _changes feeds
+		// Block until all current calls have returned, including _changes feeds
 		dc.AccessLock.Lock()
 		defer dc.AccessLock.Unlock()
 
 		dc.changeCache.Stop()
 
-		//set DB state to Offline
+		// set DB state to Offline
 		atomic.StoreUint32(&dc.State, DBOffline)
 
 		if err := dc.EventMgr.RaiseDBStateChangeEvent(dc.Name, "offline", reason, dc.Options.AdminInterface); err != nil {
@@ -779,7 +779,7 @@ func (dc *DatabaseContext) TakeDbOffline(reason string) error {
 	}
 }
 
-func (context *DatabaseContext) Authenticator() *auth.Authenticator {
+func (context *DatabaseContext) Authenticator(ctx context.Context) *auth.Authenticator {
 	context.BucketLock.RLock()
 	defer context.BucketLock.RUnlock()
 
@@ -799,6 +799,7 @@ func (context *DatabaseContext) Authenticator() *auth.Authenticator {
 		ChannelsWarningThreshold: channelsWarningThreshold,
 		SessionCookieName:        sessionCookieName,
 		BcryptCost:               context.Options.BcryptCost,
+		LogCtx:                   ctx,
 	})
 
 	return authenticator
@@ -835,7 +836,7 @@ func (db *Database) ReloadUser() error {
 	if db.user == nil {
 		return nil
 	}
-	user, err := db.Authenticator().GetUser(db.user.Name())
+	user, err := db.Authenticator(db.Ctx).GetUser(db.user.Name())
 	if err != nil {
 		return err
 	}
@@ -847,7 +848,7 @@ func (db *Database) ReloadUser() error {
 	}
 }
 
-//////// ALL DOCUMENTS:
+// ////// ALL DOCUMENTS:
 
 type IDRevAndSequence struct {
 	DocID    string
@@ -867,7 +868,7 @@ type ForEachDocIDFunc func(id IDRevAndSequence, channels []string) (bool, error)
 // Iterates over all documents in the database, calling the callback function on each
 func (db *Database) ForEachDocID(callback ForEachDocIDFunc, resultsOpts ForEachDocIDOptions) error {
 
-	results, err := db.QueryAllDocs(resultsOpts.Startkey, resultsOpts.Endkey)
+	results, err := db.QueryAllDocs(db.Ctx, resultsOpts.Startkey, resultsOpts.Endkey)
 	if err != nil {
 		return err
 	}
@@ -922,8 +923,8 @@ func (db *Database) processForEachDocIDResults(callback ForEachDocIDFunc, limit 
 		} else if err != nil {
 			return err
 		}
-		//We have to apply limit check after callback has been called
-		//to account for rows that are not in the current users channels
+		// We have to apply limit check after callback has been called
+		// to account for rows that are not in the current users channels
 		if limit > 0 && count == limit {
 			break
 		}
@@ -938,7 +939,7 @@ type principalsViewRow struct {
 }
 
 // Returns the IDs of all users and roles
-func (db *DatabaseContext) AllPrincipalIDs() (users, roles []string, err error) {
+func (db *DatabaseContext) AllPrincipalIDs(ctx context.Context) (users, roles []string, err error) {
 
 	startKey := ""
 	limit := db.Options.QueryPaginationLimit
@@ -948,7 +949,7 @@ func (db *DatabaseContext) AllPrincipalIDs() (users, roles []string, err error) 
 
 outerLoop:
 	for {
-		results, err := db.QueryPrincipals(startKey, limit)
+		results, err := db.QueryPrincipals(ctx, startKey, limit)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1013,21 +1014,21 @@ outerLoop:
 	return users, roles, nil
 }
 
-//////// HOUSEKEEPING:
+// ////// HOUSEKEEPING:
 
 // Deletes all session documents for a user
-func (db *DatabaseContext) DeleteUserSessions(userName string) error {
+func (db *DatabaseContext) DeleteUserSessions(ctx context.Context, userName string) error {
 
-	results, err := db.QuerySessions(userName)
+	results, err := db.QuerySessions(ctx, userName)
 	if err != nil {
 		return err
 	}
 
 	var sessionsRow QueryIdRow
 	for results.Next(&sessionsRow) {
-		base.Infof(base.KeyCRUD, "\tDeleting %q", sessionsRow.Id)
+		base.InfofCtx(ctx, base.KeyCRUD, "\tDeleting %q", sessionsRow.Id)
 		if err := db.Bucket.Delete(sessionsRow.Id); err != nil {
-			base.Warnf("Error deleting %q: %v", sessionsRow.Id, err)
+			base.WarnfCtx(ctx, "Error deleting %q: %v", sessionsRow.Id, err)
 		}
 	}
 	return results.Close()
@@ -1069,7 +1070,7 @@ func (db *Database) Compact(skipRunningStateCheck bool, callback compactCallback
 	purgeBody := Body{"_purged": true}
 	for {
 		purgedDocs := make([]string, 0)
-		results, err := db.QueryTombstones(purgeOlderThan, QueryTombstoneBatch)
+		results, err := db.QueryTombstones(ctx, purgeOlderThan, QueryTombstoneBatch)
 		if err != nil {
 			return 0, err
 		}
@@ -1138,7 +1139,7 @@ func (db *Database) Compact(skipRunningStateCheck bool, callback compactCallback
 	return purgedDocCount, nil
 }
 
-//////// SYNC FUNCTION:
+// ////// SYNC FUNCTION:
 
 // Sets the database context's sync function based on the JS code from config.
 // Returns a boolean indicating whether the function is different from the saved one.
@@ -1190,8 +1191,8 @@ func (context *DatabaseContext) UpdateSyncFun(syncFun string) (changed bool, err
 type updateAllDocChannelsCallbackFunc func(docsProcessed, docsChanged *int)
 
 func (db *Database) UpdateAllDocChannels(regenerateSequences bool, callback updateAllDocChannelsCallbackFunc, terminator *base.SafeTerminator) (int, error) {
-	base.Infof(base.KeyAll, "Recomputing document channels...")
-	base.Infof(base.KeyAll, "Re-running sync function on all documents...")
+	base.InfofCtx(db.Ctx, base.KeyAll, "Recomputing document channels...")
+	base.InfofCtx(db.Ctx, base.KeyAll, "Re-running sync function on all documents...")
 
 	queryLimit := db.Options.QueryPaginationLimit
 	startSeq := uint64(0)
@@ -1210,7 +1211,7 @@ func (db *Database) UpdateAllDocChannels(regenerateSequences bool, callback upda
 	var unusedSequences []uint64
 
 	for {
-		results, err := db.QueryResync(queryLimit, startSeq, endSeq)
+		results, err := db.QueryResync(db.Ctx, queryLimit, startSeq, endSeq)
 		if err != nil {
 			return 0, err
 		}
@@ -1222,7 +1223,7 @@ func (db *Database) UpdateAllDocChannels(regenerateSequences bool, callback upda
 		for results.Next(&importRow) {
 			select {
 			case <-terminator.Done():
-				base.Infof(base.KeyAll, "Resync was stopped before the operation could be completed. System "+
+				base.InfofCtx(db.Ctx, base.KeyAll, "Resync was stopped before the operation could be completed. System "+
 					"may be in an inconsistent state. Docs changed: %d Docs Processed: %d", docsChanged, docsProcessed)
 				closeErr := results.Close()
 				if closeErr != nil {
@@ -1243,7 +1244,7 @@ func (db *Database) UpdateAllDocChannels(regenerateSequences bool, callback upda
 					// This is a document not known to the sync gateway. Ignore it:
 					return nil, false, nil, base.ErrUpdateCancel
 				} else {
-					base.Debugf(base.KeyCRUD, "\tRe-syncing document %q", base.UD(docid))
+					base.DebugfCtx(db.Ctx, base.KeyCRUD, "\tRe-syncing document %q", base.UD(docid))
 				}
 
 				// Run the sync fn over each current/leaf revision, in case there are conflicts:
@@ -1251,11 +1252,11 @@ func (db *Database) UpdateAllDocChannels(regenerateSequences bool, callback upda
 				doc.History.forEachLeaf(func(rev *RevInfo) {
 					bodyBytes, _, err := db.get1xRevFromDoc(doc, rev.ID, false)
 					if err != nil {
-						base.Warnf("Error getting rev from doc %s/%s %s", base.UD(docid), rev.ID, err)
+						base.WarnfCtx(db.Ctx, "Error getting rev from doc %s/%s %s", base.UD(docid), rev.ID, err)
 					}
 					var body Body
 					if err := body.Unmarshal(bodyBytes); err != nil {
-						base.Warnf("Error unmarshalling body %s/%s for sync function %s", base.UD(docid), rev.ID, err)
+						base.WarnfCtx(db.Ctx, "Error unmarshalling body %s/%s for sync function %s", base.UD(docid), rev.ID, err)
 						return
 					}
 					metaMap, err := doc.GetMetaMap(db.Options.UserXattrKey)
@@ -1265,7 +1266,7 @@ func (db *Database) UpdateAllDocChannels(regenerateSequences bool, callback upda
 					channels, access, roles, syncExpiry, _, err := db.getChannelsAndAccess(doc, body, metaMap, rev.ID)
 					if err != nil {
 						// Probably the validator rejected the doc
-						base.Warnf("Error calling sync() on doc %q: %v", base.UD(docid), err)
+						base.WarnfCtx(db.Ctx, "Error calling sync() on doc %q: %v", base.UD(docid), err)
 						access = nil
 						channels = nil
 					}
@@ -1276,12 +1277,12 @@ func (db *Database) UpdateAllDocChannels(regenerateSequences bool, callback upda
 						if regenerateSequences {
 							unusedSequences, err = db.assignSequence(0, doc, unusedSequences)
 							if err != nil {
-								base.Warnf("Unable to assign a sequence number: %v", err)
+								base.WarnfCtx(db.Ctx, "Unable to assign a sequence number: %v", err)
 							}
 							forceUpdate = true
 						}
 
-						changedChannels, err := doc.updateChannels(channels)
+						changedChannels, err := doc.updateChannels(db.Ctx, channels)
 						changed = len(doc.Access.updateAccess(doc, access)) +
 							len(doc.RoleAccess.updateAccess(doc, roles)) +
 							len(changedChannels)
@@ -1316,7 +1317,7 @@ func (db *Database) UpdateAllDocChannels(regenerateSequences bool, callback upda
 						return nil, nil, deleteDoc, nil, err
 					}
 					if shouldUpdate {
-						base.Infof(base.KeyAccess, "Saving updated channels and access grants of %q", base.UD(docid))
+						base.InfofCtx(db.Ctx, base.KeyAccess, "Saving updated channels and access grants of %q", base.UD(docid))
 						if updatedExpiry != nil {
 							updatedDoc.UpdateExpiry(*updatedExpiry)
 						}
@@ -1344,7 +1345,7 @@ func (db *Database) UpdateAllDocChannels(regenerateSequences bool, callback upda
 						return nil, nil, false, err
 					}
 					if shouldUpdate {
-						base.Infof(base.KeyAccess, "Saving updated channels and access grants of %q", base.UD(docid))
+						base.InfofCtx(db.Ctx, base.KeyAccess, "Saving updated channels and access grants of %q", base.UD(docid))
 						if updatedExpiry != nil {
 							updatedDoc.UpdateExpiry(*updatedExpiry)
 						}
@@ -1359,7 +1360,7 @@ func (db *Database) UpdateAllDocChannels(regenerateSequences bool, callback upda
 			if err == nil {
 				docsChanged++
 			} else if err != base.ErrUpdateCancel {
-				base.Warnf("Error updating doc %q: %v", base.UD(docid), err)
+				base.WarnfCtx(db.Ctx, "Error updating doc %q: %v", base.UD(docid), err)
 			}
 		}
 
@@ -1380,17 +1381,17 @@ func (db *Database) UpdateAllDocChannels(regenerateSequences bool, callback upda
 	for _, sequence := range unusedSequences {
 		err := db.sequences.releaseSequence(sequence)
 		if err != nil {
-			base.Warnf("Error attempting to release sequence %d. Error %v", sequence, err)
+			base.WarnfCtx(db.Ctx, "Error attempting to release sequence %d. Error %v", sequence, err)
 		}
 	}
 
 	if regenerateSequences {
-		users, roles, err := db.AllPrincipalIDs()
+		users, roles, err := db.AllPrincipalIDs(db.Ctx)
 		if err != nil {
 			return docsChanged, err
 		}
 
-		authr := db.Authenticator()
+		authr := db.Authenticator(db.Ctx)
 		regeneratePrincipalSequences := func(princ auth.Principal) error {
 			nextSeq, err := db.DatabaseContext.sequences.nextSequence()
 			if err != nil {
@@ -1429,12 +1430,12 @@ func (db *Database) UpdateAllDocChannels(regenerateSequences bool, callback upda
 
 	}
 
-	base.Infof(base.KeyAll, "Finished re-running sync function; %d/%d docs changed", docsChanged, docsProcessed)
+	base.InfofCtx(db.Ctx, base.KeyAll, "Finished re-running sync function; %d/%d docs changed", docsChanged, docsProcessed)
 
 	if docsChanged > 0 {
 		// Now invalidate channel cache of all users/roles:
-		base.Infof(base.KeyAll, "Invalidating channel caches of users/roles...")
-		users, roles, _ := db.AllPrincipalIDs()
+		base.InfofCtx(db.Ctx, base.KeyAll, "Invalidating channel caches of users/roles...")
+		users, roles, _ := db.AllPrincipalIDs(db.Ctx)
 		for _, name := range users {
 			db.invalUserChannels(name, endSeq)
 		}
@@ -1446,23 +1447,23 @@ func (db *Database) UpdateAllDocChannels(regenerateSequences bool, callback upda
 }
 
 func (db *Database) invalUserRoles(username string, invalSeq uint64) {
-	authr := db.Authenticator()
+	authr := db.Authenticator(db.Ctx)
 	if err := authr.InvalidateRoles(username, invalSeq); err != nil {
-		base.Warnf("Error invalidating roles for user %s: %v", base.UD(username), err)
+		base.WarnfCtx(db.Ctx, "Error invalidating roles for user %s: %v", base.UD(username), err)
 	}
 }
 
 func (db *Database) invalUserChannels(username string, invalSeq uint64) {
-	authr := db.Authenticator()
+	authr := db.Authenticator(db.Ctx)
 	if err := authr.InvalidateChannels(username, true, invalSeq); err != nil {
-		base.Warnf("Error invalidating channels for user %s: %v", base.UD(username), err)
+		base.WarnfCtx(db.Ctx, "Error invalidating channels for user %s: %v", base.UD(username), err)
 	}
 }
 
 func (db *Database) invalRoleChannels(rolename string, invalSeq uint64) {
-	authr := db.Authenticator()
+	authr := db.Authenticator(db.Ctx)
 	if err := authr.InvalidateChannels(rolename, false, invalSeq); err != nil {
-		base.Warnf("Error invalidating channels for role %s: %v", base.UD(rolename), err)
+		base.WarnfCtx(db.Ctx, "Error invalidating channels for role %s: %v", base.UD(rolename), err)
 	}
 }
 
@@ -1623,7 +1624,7 @@ func (context *DatabaseContext) AllowFlushNonCouchbaseBuckets() bool {
 	return false
 }
 
-//////// SEQUENCE ALLOCATION:
+// ////// SEQUENCE ALLOCATION:
 
 func (context *DatabaseContext) LastSequence() (uint64, error) {
 	return context.sequences.lastSequence()

--- a/db/document.go
+++ b/db/document.go
@@ -982,7 +982,7 @@ func (doc *Document) updateChannels(ctx context.Context, newChannels base.Set) (
 // Determine whether the specified revision was a channel removal, based on doc.Channels.  If so, construct the standard document body for a
 // removal notification (_removed=true)
 // Set of channels returned from IsChannelRemoval are "Active" channels and NOT "Removed".
-func (doc *Document) IsChannelRemoval(ctx context.Context, revID string) (bodyBytes []byte, history Revisions, channels base.Set, isRemoval bool, isDelete bool, err error) {
+func (doc *Document) IsChannelRemoval(revID string) (bodyBytes []byte, history Revisions, channels base.Set, isRemoval bool, isDelete bool, err error) {
 
 	removedChannels := make(base.Set)
 
@@ -1022,7 +1022,7 @@ func (doc *Document) IsChannelRemoval(ctx context.Context, revID string) (bodyBy
 	if len(revHistory) == 0 {
 		revHistory = []string{revID}
 	}
-	history = encodeRevisions(ctx, revHistory)
+	history = encodeRevisions(doc.ID, revHistory)
 
 	return bodyBytes, history, activeChannels, true, isDelete, nil
 }

--- a/db/document.go
+++ b/db/document.go
@@ -10,6 +10,7 @@ package db
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/binary"
@@ -592,14 +593,14 @@ func (s *SyncData) IsSGWrite(cas uint64, rawBody []byte, rawUserXattr []byte) (i
 
 // doc.IsSGWrite - used during on-demand import.  Doesn't invoke SyncData.IsSGWrite so that we
 // can complete the inexpensive cas check before the (potential) doc marshalling.
-func (doc *Document) IsSGWrite(rawBody []byte) (isSGWrite bool, crc32Match bool, bodyChanged bool) {
+func (doc *Document) IsSGWrite(ctx context.Context, rawBody []byte) (isSGWrite bool, crc32Match bool, bodyChanged bool) {
 
 	// If the raw body is available, use SyncData.IsSGWrite
 	if rawBody != nil && len(rawBody) > 0 {
 
 		isSgWriteFeed, crc32MatchFeed, bodyChangedFeed := doc.SyncData.IsSGWrite(doc.Cas, rawBody, doc.rawUserXattr)
 		if !isSgWriteFeed {
-			base.Debugf(base.KeyCRUD, "Doc %s is not an SG write, based on cas and body hash. cas:%x syncCas:%q", base.UD(doc.ID), doc.Cas, doc.SyncData.Cas)
+			base.DebugfCtx(ctx, base.KeyCRUD, "Doc %s is not an SG write, based on cas and body hash. cas:%x syncCas:%q", base.UD(doc.ID), doc.Cas, doc.SyncData.Cas)
 		}
 
 		return isSgWriteFeed, crc32MatchFeed, bodyChangedFeed
@@ -613,7 +614,7 @@ func (doc *Document) IsSGWrite(rawBody []byte) (isSGWrite bool, crc32Match bool,
 	// Since raw body isn't available, marshal from the document to perform body hash comparison
 	bodyBytes, err := doc.BodyBytes()
 	if err != nil {
-		base.Warnf("Unable to marshal doc body during SG write check for doc %s. Error: %v", base.UD(doc.ID), err)
+		base.WarnfCtx(ctx, "Unable to marshal doc body during SG write check for doc %s. Error: %v", base.UD(doc.ID), err)
 		return false, false, false
 	}
 	// The bodyBytes would be replaced with "{}" if the document is a "Delete" and it can’t be used for
@@ -626,12 +627,12 @@ func (doc *Document) IsSGWrite(rawBody []byte) (isSGWrite bool, crc32Match bool,
 
 	// If the current body crc32c matches the one in doc.SyncData, this was an SG write (i.e. has already been imported)
 	if currentBodyCrc32c != doc.SyncData.Crc32c {
-		base.Debugf(base.KeyCRUD, "Doc %s is not an SG write, based on cas and body hash. cas:%x syncCas:%q", base.UD(doc.ID), doc.Cas, doc.SyncData.Cas)
+		base.DebugfCtx(ctx, base.KeyCRUD, "Doc %s is not an SG write, based on cas and body hash. cas:%x syncCas:%q", base.UD(doc.ID), doc.Cas, doc.SyncData.Cas)
 		return false, false, true
 	}
 
 	if HasUserXattrChanged(doc.rawUserXattr, doc.Crc32cUserXattr) {
-		base.Debugf(base.KeyCRUD, "Doc %s is not an SG write, based on user xattr hash", base.UD(doc.ID))
+		base.DebugfCtx(ctx, base.KeyCRUD, "Doc %s is not an SG write, based on user xattr hash", base.UD(doc.ID))
 		return false, false, false
 	}
 
@@ -694,13 +695,13 @@ func (doc *Document) getNonWinningRevisionBody(revid string, loader RevLoaderFun
 }
 
 // Fetches the body of a revision as JSON, or nil if it's not available.
-func (doc *Document) getRevisionBodyJSON(revid string, loader RevLoaderFunc) []byte {
+func (doc *Document) getRevisionBodyJSON(ctx context.Context, revid string, loader RevLoaderFunc) []byte {
 	var bodyJSON []byte
 	if revid == doc.CurrentRev {
 		var marshalErr error
 		bodyJSON, marshalErr = doc.BodyBytes()
 		if marshalErr != nil {
-			base.Warnf("Marshal error when retrieving active current revision body: %v", marshalErr)
+			base.WarnfCtx(ctx, "Marshal error when retrieving active current revision body: %v", marshalErr)
 		}
 	} else {
 		bodyJSON, _ = doc.History.getRevisionBody(revid, loader)
@@ -850,7 +851,7 @@ func (doc *Document) UpdateExpiry(expiry uint32) {
 	}
 }
 
-//////// CHANNELS & ACCESS:
+// ////// CHANNELS & ACCESS:
 
 func (doc *Document) updateChannelHistory(channelName string, seq uint64, addition bool) {
 	// Check if we already have an entry for this channel
@@ -942,7 +943,7 @@ func (doc *Document) addToChannelSetHistory(channelName string, historyEntry Cha
 
 // Updates the Channels property of a document object with current & past channels.
 // Returns the set of channels that have changed (document joined or left in this revision)
-func (doc *Document) updateChannels(newChannels base.Set) (changedChannels base.Set, err error) {
+func (doc *Document) updateChannels(ctx context.Context, newChannels base.Set) (changedChannels base.Set, err error) {
 	var changed []string
 	oldChannels := doc.Channels
 	if oldChannels == nil {
@@ -972,7 +973,7 @@ func (doc *Document) updateChannels(newChannels base.Set) (changedChannels base.
 		}
 	}
 	if changed != nil {
-		base.Infof(base.KeyCRUD, "\tDoc %q / %q in channels %q", base.UD(doc.ID), doc.CurrentRev, base.UD(newChannels))
+		base.InfofCtx(ctx, base.KeyCRUD, "\tDoc %q / %q in channels %q", base.UD(doc.ID), doc.CurrentRev, base.UD(newChannels))
 		changedChannels, err = channels.SetFromArray(changed, channels.KeepStar)
 	}
 	return
@@ -981,7 +982,7 @@ func (doc *Document) updateChannels(newChannels base.Set) (changedChannels base.
 // Determine whether the specified revision was a channel removal, based on doc.Channels.  If so, construct the standard document body for a
 // removal notification (_removed=true)
 // Set of channels returned from IsChannelRemoval are "Active" channels and NOT "Removed".
-func (doc *Document) IsChannelRemoval(revID string) (bodyBytes []byte, history Revisions, channels base.Set, isRemoval bool, isDelete bool, err error) {
+func (doc *Document) IsChannelRemoval(ctx context.Context, revID string) (bodyBytes []byte, history Revisions, channels base.Set, isRemoval bool, isDelete bool, err error) {
 
 	removedChannels := make(base.Set)
 
@@ -1021,7 +1022,7 @@ func (doc *Document) IsChannelRemoval(revID string) (bodyBytes []byte, history R
 	if len(revHistory) == 0 {
 		revHistory = []string{revID}
 	}
-	history = encodeRevisions(revHistory)
+	history = encodeRevisions(ctx, revHistory)
 
 	return bodyBytes, history, activeChannels, true, isDelete, nil
 }
@@ -1058,7 +1059,7 @@ func (accessMap *UserAccessMap) updateAccess(doc *Document, newAccess channels.A
 	return changedUsers
 }
 
-//////// MARSHALING ////////
+// ////// MARSHALING ////////
 
 type documentRoot struct {
 	SyncData *SyncData `json:"_sync"`

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -430,7 +430,7 @@ func TestEvaluateFunction(t *testing.T) {
 	body := Body{"key": "value", "version": "1a"}
 	source := "illegal function(doc) {}"
 	importFilterFunc := NewImportFilterFunction(source)
-	result, err := importFilterFunc.EvaluateFunction(body)
+	result, err := importFilterFunc.EvaluateFunction(base.TestCtx(t), body)
 	assert.Error(t, err, "Unexpected token function error")
 	assert.False(t, result, "Function evaluation result should be false")
 
@@ -438,7 +438,7 @@ func TestEvaluateFunction(t *testing.T) {
 	body = Body{"key": "value", "version": "2a"}
 	source = `function(doc) { if (doc.version == "2a") { return true; } else { return false; }}`
 	importFilterFunc = NewImportFilterFunction(source)
-	result, err = importFilterFunc.EvaluateFunction(body)
+	result, err = importFilterFunc.EvaluateFunction(base.TestCtx(t), body)
 	assert.NoError(t, err, "Import filter function shouldn't throw any error")
 	assert.True(t, result, "Import filter function should return boolean value true")
 
@@ -446,7 +446,7 @@ func TestEvaluateFunction(t *testing.T) {
 	body = Body{"key": "value", "version": "2b"}
 	source = `function(doc) { if (doc.version == "2b") { return 1.01; } else { return 0.01; }}`
 	importFilterFunc = NewImportFilterFunction(source)
-	result, err = importFilterFunc.EvaluateFunction(body)
+	result, err = importFilterFunc.EvaluateFunction(base.TestCtx(t), body)
 	assert.Error(t, err, "Import filter function returned non-boolean value")
 	assert.False(t, result, "Import filter function evaluation result should be false")
 
@@ -454,7 +454,7 @@ func TestEvaluateFunction(t *testing.T) {
 	body = Body{"key": "value", "version": "1a"}
 	source = `function(doc) { if (doc.version == "1a") { return "true"; } else { return "false"; }}`
 	importFilterFunc = NewImportFilterFunction(source)
-	result, err = importFilterFunc.EvaluateFunction(body)
+	result, err = importFilterFunc.EvaluateFunction(base.TestCtx(t), body)
 	assert.NoError(t, err, "Import filter function shouldn't throw any error")
 	assert.True(t, result, "Import filter function should return true")
 
@@ -462,7 +462,7 @@ func TestEvaluateFunction(t *testing.T) {
 	body = Body{"key": "value", "version": "2a"}
 	source = `function(doc) { if (doc.version == "1a") { return "true"; } else { return "false"; }}`
 	importFilterFunc = NewImportFilterFunction(source)
-	result, err = importFilterFunc.EvaluateFunction(body)
+	result, err = importFilterFunc.EvaluateFunction(base.TestCtx(t), body)
 	assert.NoError(t, err, "Import filter function shouldn't throw any error")
 	assert.False(t, result, "Import filter function should return false")
 
@@ -470,7 +470,7 @@ func TestEvaluateFunction(t *testing.T) {
 	body = Body{"key": "value", "version": "1a"}
 	source = `function(doc) { if (doc.version == "1a") { return "TruE"; } else { return "FaLsE"; }}`
 	importFilterFunc = NewImportFilterFunction(source)
-	result, err = importFilterFunc.EvaluateFunction(body)
+	result, err = importFilterFunc.EvaluateFunction(base.TestCtx(t), body)
 	assert.Error(t, err, `strconv.ParseBool: parsing "TruE": invalid syntax`)
 	assert.False(t, result, "Import filter function should return true")
 }

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -54,7 +54,7 @@ func TestQueryChannelsStatsView(t *testing.T) {
 	channelQueryErrorCountBefore := db.DbStats.Query(queryExpvar).QueryErrorCount.Value()
 
 	// Issue channels query
-	results, queryErr := db.QueryChannels("ABC", docSeqMap["queryTestDoc1"], docSeqMap["queryTestDoc3"], 100, false)
+	results, queryErr := db.QueryChannels(base.TestCtx(t), "ABC", docSeqMap["queryTestDoc1"], docSeqMap["queryTestDoc3"], 100, false)
 	assert.NoError(t, queryErr, "Query error")
 
 	assert.Equal(t, 3, countQueryResults(results))
@@ -101,7 +101,7 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 	channelQueryErrorCountBefore := db.DbStats.Query(QueryTypeChannels).QueryErrorCount.Value()
 
 	// Issue channels query
-	results, queryErr := db.QueryChannels("ABC", docSeqMap["queryTestDoc1"], docSeqMap["queryTestDoc3"], 100, false)
+	results, queryErr := db.QueryChannels(base.TestCtx(t), "ABC", docSeqMap["queryTestDoc1"], docSeqMap["queryTestDoc3"], 100, false)
 	assert.NoError(t, queryErr, "Query error")
 
 	assert.Equal(t, 3, countQueryResults(results))
@@ -143,7 +143,7 @@ func TestQuerySequencesStatsView(t *testing.T) {
 	channelQueryErrorCountBefore := db.DbStats.Query(queryExpvar).QueryErrorCount.Value()
 
 	// Issue channels query
-	results, queryErr := db.QuerySequences([]uint64{
+	results, queryErr := db.QuerySequences(base.TestCtx(t), []uint64{
 		docSeqMap["queryTestDoc3"], docSeqMap["queryTestDoc4"],
 		docSeqMap["queryTestDoc6"], docSeqMap["queryTestDoc8"],
 	})
@@ -153,21 +153,21 @@ func TestQuerySequencesStatsView(t *testing.T) {
 	assert.NoError(t, closeErr, "Close error")
 
 	// Issue query with single key
-	results, queryErr = db.QuerySequences([]uint64{docSeqMap["queryTestDoc2"]})
+	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{docSeqMap["queryTestDoc2"]})
 	assert.NoError(t, queryErr, "Query error")
 	goassert.Equals(t, countQueryResults(results), 1)
 	closeErr = results.Close()
 	assert.NoError(t, closeErr, "Close error")
 
 	// Issue query with key outside keyset range
-	results, queryErr = db.QuerySequences([]uint64{100})
+	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{100})
 	assert.NoError(t, queryErr, "Query error")
 	goassert.Equals(t, countQueryResults(results), 0)
 	closeErr = results.Close()
 	assert.NoError(t, closeErr, "Close error")
 
 	// Issue query with empty keys
-	results, queryErr = db.QuerySequences([]uint64{})
+	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{})
 	assert.Error(t, queryErr, "Expect empty sequence error")
 
 	channelQueryCountAfter := db.DbStats.Query(queryExpvar).QueryCount.Value()
@@ -184,7 +184,7 @@ func TestQuerySequencesStatsView(t *testing.T) {
 		docSeqMap[docID] = doc.Sequence
 	}
 	// Issue channels query
-	results, queryErr = db.QuerySequences([]uint64{
+	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{
 		docSeqMap["queryTestDoc3"], docSeqMap["queryTestDoc4"],
 		docSeqMap["queryTestDoc6"], docSeqMap["queryTestDoc8"],
 		docSeqMap["queryTestDocChanneled5"],
@@ -195,7 +195,7 @@ func TestQuerySequencesStatsView(t *testing.T) {
 	assert.NoError(t, closeErr, "Close error")
 
 	// Issue query with single key
-	results, queryErr = db.QuerySequences([]uint64{docSeqMap["queryTestDoc2"]})
+	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{docSeqMap["queryTestDoc2"]})
 	assert.NoError(t, queryErr, "Query error")
 	goassert.Equals(t, countQueryResults(results), 1)
 	closeErr = results.Close()
@@ -203,7 +203,7 @@ func TestQuerySequencesStatsView(t *testing.T) {
 
 	// Issue query with key outside sequence range.  Note that this isn't outside the entire view key range, as
 	// [*, 25] is sorted before ["ABC1", 11]
-	results, queryErr = db.QuerySequences([]uint64{100})
+	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{100})
 	assert.NoError(t, queryErr, "Query error")
 	goassert.Equals(t, countQueryResults(results), 0)
 	closeErr = results.Close()
@@ -236,7 +236,7 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 	channelQueryErrorCountBefore := db.DbStats.Query(QueryTypeSequences).QueryErrorCount.Value()
 
 	// Issue channels query
-	results, queryErr := db.QuerySequences([]uint64{
+	results, queryErr := db.QuerySequences(base.TestCtx(t), []uint64{
 		docSeqMap["queryTestDoc3"], docSeqMap["queryTestDoc4"],
 		docSeqMap["queryTestDoc6"], docSeqMap["queryTestDoc8"],
 	})
@@ -246,21 +246,21 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 	assert.NoError(t, closeErr, "Close error")
 
 	// Issue query with single key
-	results, queryErr = db.QuerySequences([]uint64{docSeqMap["queryTestDoc2"]})
+	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{docSeqMap["queryTestDoc2"]})
 	assert.NoError(t, queryErr, "Query error")
 	goassert.Equals(t, countQueryResults(results), 1)
 	closeErr = results.Close()
 	assert.NoError(t, closeErr, "Close error")
 
 	// Issue query with key outside keyset range
-	results, queryErr = db.QuerySequences([]uint64{100})
+	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{100})
 	assert.NoError(t, queryErr, "Query error")
 	goassert.Equals(t, countQueryResults(results), 0)
 	closeErr = results.Close()
 	assert.NoError(t, closeErr, "Close error")
 
 	// Issue query with empty keys
-	results, queryErr = db.QuerySequences([]uint64{})
+	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{})
 	assert.Error(t, queryErr, "Expect empty sequence error")
 
 	channelQueryCountAfter := db.DbStats.Query(QueryTypeSequences).QueryCount.Value()
@@ -278,7 +278,7 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 	}
 
 	// Issue channels query
-	results, queryErr = db.QuerySequences([]uint64{
+	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{
 		docSeqMap["queryTestDoc3"], docSeqMap["queryTestDoc4"],
 		docSeqMap["queryTestDoc6"], docSeqMap["queryTestDoc8"],
 		docSeqMap["queryTestDocChanneled5"],
@@ -289,7 +289,7 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 	assert.NoError(t, closeErr, "Close error")
 
 	// Issue query with single key
-	results, queryErr = db.QuerySequences([]uint64{docSeqMap["queryTestDoc2"]})
+	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{docSeqMap["queryTestDoc2"]})
 	assert.NoError(t, queryErr, "Query error")
 	goassert.Equals(t, countQueryResults(results), 1)
 	closeErr = results.Close()
@@ -297,7 +297,7 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 
 	// Issue query with key outside sequence range.  Note that this isn't outside the entire view key range, as
 	// [*, 25] is sorted before ["ABC1", 11]
-	results, queryErr = db.QuerySequences([]uint64{100})
+	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{100})
 	assert.NoError(t, queryErr, "Query error")
 	goassert.Equals(t, countQueryResults(results), 0)
 	closeErr = results.Close()
@@ -345,7 +345,7 @@ func TestCoveringQueries(t *testing.T) {
 	covered = isCovered(plan)
 	planJSON, err = base.JSONMarshal(plan)
 	assert.NoError(t, err)
-	//assert.True(t, covered, "Access query isn't covered by index: %s", planJSON)
+	// assert.True(t, covered, "Access query isn't covered by index: %s", planJSON)
 
 	// roleAccess
 	roleAccessStatement := db.buildRoleAccessQuery("user1")
@@ -354,7 +354,7 @@ func TestCoveringQueries(t *testing.T) {
 	covered = isCovered(plan)
 	planJSON, err = base.JSONMarshal(plan)
 	assert.NoError(t, err)
-	//assert.True(t, !covered, "RoleAccess query isn't covered by index: %s", planJSON)
+	// assert.True(t, !covered, "RoleAccess query isn't covered by index: %s", planJSON)
 
 }
 
@@ -376,7 +376,7 @@ func TestAllDocsQuery(t *testing.T) {
 	// Standard query
 	startKey := "a"
 	endKey := ""
-	results, queryErr := db.QueryAllDocs(startKey, endKey)
+	results, queryErr := db.QueryAllDocs(base.TestCtx(t), startKey, endKey)
 	assert.NoError(t, queryErr, "Query error")
 	var row map[string]interface{}
 	rowCount := 0
@@ -389,7 +389,7 @@ func TestAllDocsQuery(t *testing.T) {
 	// Attempt to invalidate standard query
 	startKey = "a' AND 1=0\x00"
 	endKey = ""
-	results, queryErr = db.QueryAllDocs(startKey, endKey)
+	results, queryErr = db.QueryAllDocs(base.TestCtx(t), startKey, endKey)
 	assert.NoError(t, queryErr, "Query error")
 	rowCount = 0
 	for results.Next(&row) {
@@ -401,7 +401,7 @@ func TestAllDocsQuery(t *testing.T) {
 	// Attempt to invalidate statement to add row to resultset
 	startKey = `a' UNION ALL SELECT TOSTRING(BASE64_DECODE("SW52YWxpZERhdGE=")) as id;` + "\x00"
 	endKey = ""
-	results, queryErr = db.QueryAllDocs(startKey, endKey)
+	results, queryErr = db.QueryAllDocs(base.TestCtx(t), startKey, endKey)
 	assert.NoError(t, queryErr, "Query error")
 	rowCount = 0
 	for results.Next(&row) {
@@ -414,7 +414,7 @@ func TestAllDocsQuery(t *testing.T) {
 	// Attempt to create syntax error
 	startKey = `a'1`
 	endKey = ""
-	results, queryErr = db.QueryAllDocs(startKey, endKey)
+	results, queryErr = db.QueryAllDocs(base.TestCtx(t), startKey, endKey)
 	assert.NoError(t, queryErr, "Query error")
 	rowCount = 0
 	for results.Next(&row) {
@@ -444,7 +444,7 @@ func TestAccessQuery(t *testing.T) {
 
 	// Standard query
 	username := "user1"
-	results, queryErr := db.QueryAccess(username)
+	results, queryErr := db.QueryAccess(base.TestCtx(t), username)
 	assert.NoError(t, queryErr, "Query error")
 	var row map[string]interface{}
 	rowCount := 0
@@ -456,7 +456,7 @@ func TestAccessQuery(t *testing.T) {
 
 	// Attempt to introduce syntax error.  Should return zero rows for user `user1'`, and not return error
 	username = "user1'"
-	results, queryErr = db.QueryAccess(username)
+	results, queryErr = db.QueryAccess(base.TestCtx(t), username)
 	assert.NoError(t, queryErr, "Query error")
 	rowCount = 0
 	for results.Next(&row) {
@@ -468,7 +468,7 @@ func TestAccessQuery(t *testing.T) {
 	// Attempt to introduce syntax error.  Should return zero rows for user `user1`AND`, and not return error.
 	// Validates select clause protection
 	username = "user1`AND"
-	results, queryErr = db.QueryAccess(username)
+	results, queryErr = db.QueryAccess(base.TestCtx(t), username)
 	assert.NoError(t, queryErr, "Query error")
 	rowCount = 0
 	for results.Next(&row) {
@@ -497,7 +497,7 @@ func TestRoleAccessQuery(t *testing.T) {
 
 	// Standard query
 	username := "user1"
-	results, queryErr := db.QueryRoleAccess(username)
+	results, queryErr := db.QueryRoleAccess(base.TestCtx(t), username)
 	assert.NoError(t, queryErr, "Query error")
 	var row map[string]interface{}
 	rowCount := 0
@@ -509,7 +509,7 @@ func TestRoleAccessQuery(t *testing.T) {
 
 	// Attempt to introduce syntax error.  Should return zero rows for user `user1'`, and not return error
 	username = "user1'"
-	results, queryErr = db.QueryRoleAccess(username)
+	results, queryErr = db.QueryRoleAccess(base.TestCtx(t), username)
 	assert.NoError(t, queryErr, "Query error")
 	rowCount = 0
 	for results.Next(&row) {
@@ -521,7 +521,7 @@ func TestRoleAccessQuery(t *testing.T) {
 	// Attempt to introduce syntax error.  Should return zero rows for user `user1`AND`, and not return error
 	// Validates select clause protection
 	username = "user1`AND"
-	results, queryErr = db.QueryRoleAccess(username)
+	results, queryErr = db.QueryRoleAccess(base.TestCtx(t), username)
 	assert.NoError(t, queryErr, "Query error")
 	rowCount = 0
 	for results.Next(&row) {
@@ -706,49 +706,49 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	// 20 Deleted documents (10 deleted + 10 branched|deleted)
 
 	// Get changes from channel "ABC" with limit and activeOnly true
-	entries, err := db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 25, true)
+	entries, err := db.getChangesInChannelFromQuery(base.TestCtx(t), "ABC", startSeq, endSeq, 25, true)
 	require.NoError(t, err, "Couldn't query active docs from channel ABC with limit")
 	require.Len(t, entries, 25)
 	checkFlags(entries)
 
 	// Get changes from channel "*" with limit and activeOnly true
-	entries, err = db.getChangesInChannelFromQuery("*", startSeq, endSeq, 25, true)
+	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), "*", startSeq, endSeq, 25, true)
 	require.NoError(t, err, "Couldn't query active docs from channel * with limit")
 	require.Len(t, entries, 25)
 	checkFlags(entries)
 
 	// Get changes from channel "ABC" without limit and activeOnly true
-	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 0, true)
+	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), "ABC", startSeq, endSeq, 0, true)
 	require.NoError(t, err, "Couldn't query active docs from channel ABC with limit")
 	require.Len(t, entries, 30)
 	checkFlags(entries)
 
 	// Get changes from channel "*" without limit and activeOnly true
-	entries, err = db.getChangesInChannelFromQuery("*", startSeq, endSeq, 0, true)
+	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), "*", startSeq, endSeq, 0, true)
 	require.NoError(t, err, "Couldn't query active docs from channel * with limit")
 	require.Len(t, entries, 30)
 	checkFlags(entries)
 
 	// Get changes from channel "ABC" with limit and activeOnly false
-	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 45, false)
+	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), "ABC", startSeq, endSeq, 45, false)
 	require.NoError(t, err, "Couldn't query active docs from channel ABC with limit")
 	require.Len(t, entries, 45)
 	checkFlags(entries)
 
 	// Get changes from channel "*" with limit and activeOnly false
-	entries, err = db.getChangesInChannelFromQuery("*", startSeq, endSeq, 45, false)
+	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), "*", startSeq, endSeq, 45, false)
 	require.NoError(t, err, "Couldn't query active docs from channel * with limit")
 	require.Len(t, entries, 45)
 	checkFlags(entries)
 
 	// Get changes from channel "ABC" without limit and activeOnly false
-	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 0, false)
+	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), "ABC", startSeq, endSeq, 0, false)
 	require.NoError(t, err, "Couldn't query active docs from channel ABC with limit")
 	require.Len(t, entries, 50)
 	checkFlags(entries)
 
 	// Get changes from channel "*" without limit and activeOnly true
-	entries, err = db.getChangesInChannelFromQuery("*", startSeq, endSeq, 0, false)
+	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), "*", startSeq, endSeq, 0, false)
 	require.NoError(t, err, "Couldn't query active docs from channel * with limit")
 	require.Len(t, entries, 50)
 	checkFlags(entries)

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -12,7 +12,6 @@ package db
 
 import (
 	"fmt"
-	"log"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -75,7 +74,6 @@ func TestRepairBucket(t *testing.T) {
 	defer bucket.Close()
 
 	repairJob := func(docId string, originalCBDoc []byte) (transformedCBDoc []byte, transformed bool, err error) {
-		log.Printf("repairJob called back")
 		return nil, true, nil
 	}
 	repairBucket := NewRepairBucket(bucket).

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -11,6 +11,8 @@ licenses/APL2.txt.
 package db
 
 import (
+	"context"
+
 	"github.com/couchbase/sync_gateway/base"
 )
 
@@ -29,13 +31,13 @@ func NewBypassRevisionCache(backingStore RevisionCacheBackingStore, bypassStat *
 }
 
 // Get fetches the revision for the given docID and revID immediately from the bucket.
-func (rc *BypassRevisionCache) Get(docID, revID string, includeBody bool, includeDelta bool) (docRev DocumentRevision, err error) {
+func (rc *BypassRevisionCache) Get(ctx context.Context, docID, revID string, includeBody bool, includeDelta bool) (docRev DocumentRevision, err error) {
 
 	unmarshalLevel := DocUnmarshalSync
 	if includeBody {
 		unmarshalLevel = DocUnmarshalAll
 	}
-	doc, err := rc.backingStore.GetDocument(docID, unmarshalLevel)
+	doc, err := rc.backingStore.GetDocument(ctx, docID, unmarshalLevel)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
@@ -43,7 +45,7 @@ func (rc *BypassRevisionCache) Get(docID, revID string, includeBody bool, includ
 	docRev = DocumentRevision{
 		RevID: revID,
 	}
-	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(rc.backingStore, doc, revID)
+	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, revID)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
@@ -54,13 +56,13 @@ func (rc *BypassRevisionCache) Get(docID, revID string, includeBody bool, includ
 }
 
 // GetActive fetches the active revision for the given docID immediately from the bucket.
-func (rc *BypassRevisionCache) GetActive(docID string, includeBody bool) (docRev DocumentRevision, err error) {
+func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, includeBody bool) (docRev DocumentRevision, err error) {
 
 	unmarshalLevel := DocUnmarshalSync
 	if includeBody {
 		unmarshalLevel = DocUnmarshalAll
 	}
-	doc, err := rc.backingStore.GetDocument(docID, unmarshalLevel)
+	doc, err := rc.backingStore.GetDocument(ctx, docID, unmarshalLevel)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
@@ -69,7 +71,7 @@ func (rc *BypassRevisionCache) GetActive(docID string, includeBody bool) (docRev
 		RevID: doc.CurrentRev,
 	}
 
-	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(rc.backingStore, doc, doc.SyncData.CurrentRev)
+	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, doc.SyncData.CurrentRev)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
@@ -80,25 +82,25 @@ func (rc *BypassRevisionCache) GetActive(docID string, includeBody bool) (docRev
 }
 
 // Peek is a no-op for a BypassRevisionCache, and always returns a false 'found' value.
-func (rc *BypassRevisionCache) Peek(docID, revID string) (docRev DocumentRevision, found bool) {
+func (rc *BypassRevisionCache) Peek(ctx context.Context, docID, revID string) (docRev DocumentRevision, found bool) {
 	return DocumentRevision{}, false
 }
 
 // Put is a no-op for a BypassRevisionCache
-func (rc *BypassRevisionCache) Put(docRev DocumentRevision) {
+func (rc *BypassRevisionCache) Put(ctx context.Context, docRev DocumentRevision) {
 	// no-op
 }
 
 // Update is a no-op for a BypassRevisionCache
-func (rc *BypassRevisionCache) Upsert(docRev DocumentRevision) {
+func (rc *BypassRevisionCache) Upsert(ctx context.Context, docRev DocumentRevision) {
 	// no-op
 }
 
-func (rc *BypassRevisionCache) Invalidate(docID, revID string) {
+func (rc *BypassRevisionCache) Invalidate(ctx context.Context, docID, revID string) {
 	// nop
 }
 
 // UpdateDelta is a no-op for a BypassRevisionCache
-func (rc *BypassRevisionCache) UpdateDelta(docID, revID string, toDelta RevisionDelta) {
+func (rc *BypassRevisionCache) UpdateDelta(ctx context.Context, docID, revID string, toDelta RevisionDelta) {
 	// no-op
 }

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -264,7 +264,7 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 	if bodyBytes, body, attachments, err = backingStore.getRevision(ctx, doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether
 		// the revision was a channel removal. If so, we want to store as removal in the revision cache
-		removalBodyBytes, removalHistory, activeChannels, isRemoval, isDelete, isRemovalErr := doc.IsChannelRemoval(ctx, revid)
+		removalBodyBytes, removalHistory, activeChannels, isRemoval, isDelete, isRemovalErr := doc.IsChannelRemoval(revid)
 		if isRemovalErr != nil {
 			return bodyBytes, body, history, channels, isRemoval, nil, isDelete, nil, isRemovalErr
 		}
@@ -283,7 +283,7 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 	if getHistoryErr != nil {
 		return bodyBytes, body, history, channels, removed, nil, deleted, nil, getHistoryErr
 	}
-	history = encodeRevisions(ctx, validatedHistory)
+	history = encodeRevisions(doc.ID, validatedHistory)
 	channels = doc.History[revid].Channels
 
 	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, err

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -30,28 +31,28 @@ type RevisionCache interface {
 	// Get returns the given revision, and stores if not already cached.
 	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
 	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
-	Get(docID, revID string, includeBody bool, includeDelta bool) (DocumentRevision, error)
+	Get(ctx context.Context, docID, revID string, includeBody bool, includeDelta bool) (DocumentRevision, error)
 
 	// GetActive returns the current revision for the given doc ID, and stores if not already cached.
 	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
-	GetActive(docID string, includeBody bool) (docRev DocumentRevision, err error)
+	GetActive(ctx context.Context, docID string, includeBody bool) (docRev DocumentRevision, err error)
 
 	// Peek returns the given revision if present in the cache
-	Peek(docID, revID string) (docRev DocumentRevision, found bool)
+	Peek(ctx context.Context, docID, revID string) (docRev DocumentRevision, found bool)
 
 	// Put will store the given docRev in the cache
-	Put(docRev DocumentRevision)
+	Put(ctx context.Context, docRev DocumentRevision)
 
 	// Update will remove existing value and re-create new one
-	Upsert(docRev DocumentRevision)
+	Upsert(ctx context.Context, docRev DocumentRevision)
 
 	// Invalidate marks a revision in the cache as invalid. This is used to call into LoadInvalidRevFromBackingStore in LRU.
 	// Marked revision denotes that this value should not be used and should be replaced. Used in the event of an user
 	// xattr only update where there is no revision change.
-	Invalidate(docID, revID string)
+	Invalidate(ctx context.Context, docID, revID string)
 
 	// UpdateDelta stores the given toDelta value in the given rev if cached
-	UpdateDelta(docID, revID string, toDelta RevisionDelta)
+	UpdateDelta(ctx context.Context, docID, revID string, toDelta RevisionDelta)
 }
 
 const (
@@ -103,8 +104,8 @@ func DefaultRevisionCacheOptions() *RevisionCacheOptions {
 
 // RevisionCacheBackingStore is the interface required to be passed into a RevisionCache constructor to provide a backing store for loading documents.
 type RevisionCacheBackingStore interface {
-	GetDocument(docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error)
-	getRevision(doc *Document, revid string) ([]byte, Body, AttachmentsMeta, error)
+	GetDocument(ctx context.Context, docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error)
+	getRevision(ctx context.Context, doc *Document, revid string) ([]byte, Body, AttachmentsMeta, error)
 }
 
 // DocumentRevision stored and returned by the rev cache
@@ -245,25 +246,25 @@ func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRe
 
 // This is the RevisionCacheLoaderFunc callback for the context's RevisionCache.
 // Its job is to load a revision from the bucket when there's a cache miss.
-func revCacheLoader(backingStore RevisionCacheBackingStore, id IDAndRev, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
+func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore, id IDAndRev, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
 	var doc *Document
 	unmarshalLevel := DocUnmarshalSync
 	if unmarshalBody {
 		unmarshalLevel = DocUnmarshalAll
 	}
-	if doc, err = backingStore.GetDocument(id.DocID, unmarshalLevel); doc == nil {
+	if doc, err = backingStore.GetDocument(ctx, id.DocID, unmarshalLevel); doc == nil {
 		return bodyBytes, body, history, channels, removed, attachments, deleted, expiry, err
 	}
 
-	return revCacheLoaderForDocument(backingStore, doc, id.RevID)
+	return revCacheLoaderForDocument(ctx, backingStore, doc, id.RevID)
 }
 
 // Common revCacheLoader functionality used either during a cache miss (from revCacheLoader), or directly when retrieving current rev from cache
-func revCacheLoaderForDocument(backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
-	if bodyBytes, body, attachments, err = backingStore.getRevision(doc, revid); err != nil {
+func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
+	if bodyBytes, body, attachments, err = backingStore.getRevision(ctx, doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether
 		// the revision was a channel removal. If so, we want to store as removal in the revision cache
-		removalBodyBytes, removalHistory, activeChannels, isRemoval, isDelete, isRemovalErr := doc.IsChannelRemoval(revid)
+		removalBodyBytes, removalHistory, activeChannels, isRemoval, isDelete, isRemovalErr := doc.IsChannelRemoval(ctx, revid)
 		if isRemovalErr != nil {
 			return bodyBytes, body, history, channels, isRemoval, nil, isDelete, nil, isRemovalErr
 		}
@@ -282,7 +283,7 @@ func revCacheLoaderForDocument(backingStore RevisionCacheBackingStore, doc *Docu
 	if getHistoryErr != nil {
 		return bodyBytes, body, history, channels, removed, nil, deleted, nil, getHistoryErr
 	}
-	history = encodeRevisions(validatedHistory)
+	history = encodeRevisions(ctx, validatedHistory)
 	channels = doc.History[revid].Channels
 
 	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, err

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -115,12 +115,12 @@ func TestBackupOldRevision(t *testing.T) {
 	require.NoError(t, err)
 
 	// make sure we didn't accidentally store an empty old revision
-	_, err = db.getOldRevisionJSON(docID, "")
+	_, err = db.getOldRevisionJSON(base.TestCtx(t), docID, "")
 	assert.Error(t, err)
 	assert.Equal(t, "404 missing", err.Error())
 
 	// check for current rev backup in xattr+delta case (to support deltas by sdk imports)
-	_, err = db.getOldRevisionJSON(docID, rev1ID)
+	_, err = db.getOldRevisionJSON(base.TestCtx(t), docID, rev1ID)
 	if deltasEnabled && xattrsEnabled {
 		require.NoError(t, err)
 	} else {
@@ -134,11 +134,11 @@ func TestBackupOldRevision(t *testing.T) {
 	require.NoError(t, err)
 
 	// now in all cases we'll have rev 1 backed up (for at least 5 minutes)
-	_, err = db.getOldRevisionJSON(docID, rev1ID)
+	_, err = db.getOldRevisionJSON(base.TestCtx(t), docID, rev1ID)
 	require.NoError(t, err)
 
 	// check for current rev backup in xattr+delta case (to support deltas by sdk imports)
-	_, err = db.getOldRevisionJSON(docID, rev2ID)
+	_, err = db.getOldRevisionJSON(base.TestCtx(t), docID, rev2ID)
 	if deltasEnabled && xattrsEnabled {
 		require.NoError(t, err)
 	} else {

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -10,7 +10,6 @@ package db
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -775,7 +774,8 @@ func splitRevisionList(revisions Revisions) (int, []string) {
 
 // Standard CouchDB encoding of a revision list: digests without numeric generation prefixes go in
 // the "ids" property, and the first (largest) generation number in the "start" property.
-func encodeRevisions(ctx context.Context, revs []string) Revisions {
+// The docID parameter is informational only - and used when logging edge cases.
+func encodeRevisions(docID string, revs []string) Revisions {
 	ids := make([]string, len(revs))
 	var start int
 	for i, revid := range revs {
@@ -784,7 +784,7 @@ func encodeRevisions(ctx context.Context, revs []string) Revisions {
 		if i == 0 {
 			start = gen
 		} else if gen != start-i {
-			base.WarnfCtx(ctx, "Found gap in revision list. Expecting gen %v but got %v in %v", start-i, gen, revs)
+			base.Warnf("Found gap in revision list for doc %q. Expecting gen %v but got %v in %v", base.UD(docID), start-i, gen, revs)
 		}
 	}
 	return Revisions{RevisionsStart: start, RevisionsIds: ids}

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -754,35 +754,34 @@ func BenchmarkEncodeRevisions(b *testing.B) {
 		},
 	}
 
-	ctx := base.TestCtx(b)
-
 	for _, test := range tests {
+		docID := b.Name() + "-" + test.name
 		b.Run(test.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_ = encodeRevisions(ctx, test.input)
+				_ = encodeRevisions(docID, test.input)
 			}
 		})
 	}
 }
 
 func TestEncodeRevisions(t *testing.T) {
-	encoded := encodeRevisions(base.TestCtx(t), []string{"5-huey", "4-dewey", "3-louie"})
+	encoded := encodeRevisions(t.Name(), []string{"5-huey", "4-dewey", "3-louie"})
 	assert.Equal(t, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie"}}, encoded)
 }
 
 func TestEncodeRevisionsGap(t *testing.T) {
-	encoded := encodeRevisions(base.TestCtx(t), []string{"5-huey", "3-louie"})
+	encoded := encodeRevisions(t.Name(), []string{"5-huey", "3-louie"})
 	assert.Equal(t, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "louie"}}, encoded)
 }
 
 func TestEncodeRevisionsZero(t *testing.T) {
-	encoded := encodeRevisions(base.TestCtx(t), []string{"1-foo", "0-bar"})
+	encoded := encodeRevisions(t.Name(), []string{"1-foo", "0-bar"})
 	assert.Equal(t, Revisions{RevisionsStart: 1, RevisionsIds: []string{"foo", ""}}, encoded)
 }
 
 func TestTrimEncodedRevisionsToAncestor(t *testing.T) {
 
-	encoded := encodeRevisions(base.TestCtx(t), []string{"5-huey", "4-dewey", "3-louie", "2-screwy"})
+	encoded := encodeRevisions(t.Name(), []string{"5-huey", "4-dewey", "3-louie", "2-screwy"})
 
 	result, trimmedRevs := trimEncodedRevisionsToAncestor(encoded, []string{"3-walter", "17-gretchen", "1-fooey"}, 1000)
 	goassert.True(t, result)
@@ -801,7 +800,7 @@ func TestTrimEncodedRevisionsToAncestor(t *testing.T) {
 	goassert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey"}})
 
 	// Check maxLength with no ancestors:
-	encoded = encodeRevisions(base.TestCtx(t), []string{"5-huey", "4-dewey", "3-louie", "2-screwy"})
+	encoded = encodeRevisions(t.Name(), []string{"5-huey", "4-dewey", "3-louie", "2-screwy"})
 
 	result, trimmedRevs = trimEncodedRevisionsToAncestor(encoded, nil, 6)
 	goassert.True(t, result)

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -754,33 +754,35 @@ func BenchmarkEncodeRevisions(b *testing.B) {
 		},
 	}
 
+	ctx := base.TestCtx(b)
+
 	for _, test := range tests {
 		b.Run(test.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_ = encodeRevisions(test.input)
+				_ = encodeRevisions(ctx, test.input)
 			}
 		})
 	}
 }
 
 func TestEncodeRevisions(t *testing.T) {
-	encoded := encodeRevisions([]string{"5-huey", "4-dewey", "3-louie"})
+	encoded := encodeRevisions(base.TestCtx(t), []string{"5-huey", "4-dewey", "3-louie"})
 	assert.Equal(t, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie"}}, encoded)
 }
 
 func TestEncodeRevisionsGap(t *testing.T) {
-	encoded := encodeRevisions([]string{"5-huey", "3-louie"})
+	encoded := encodeRevisions(base.TestCtx(t), []string{"5-huey", "3-louie"})
 	assert.Equal(t, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "louie"}}, encoded)
 }
 
 func TestEncodeRevisionsZero(t *testing.T) {
-	encoded := encodeRevisions([]string{"1-foo", "0-bar"})
+	encoded := encodeRevisions(base.TestCtx(t), []string{"1-foo", "0-bar"})
 	assert.Equal(t, Revisions{RevisionsStart: 1, RevisionsIds: []string{"foo", ""}}, encoded)
 }
 
 func TestTrimEncodedRevisionsToAncestor(t *testing.T) {
 
-	encoded := encodeRevisions([]string{"5-huey", "4-dewey", "3-louie", "2-screwy"})
+	encoded := encodeRevisions(base.TestCtx(t), []string{"5-huey", "4-dewey", "3-louie", "2-screwy"})
 
 	result, trimmedRevs := trimEncodedRevisionsToAncestor(encoded, []string{"3-walter", "17-gretchen", "1-fooey"}, 1000)
 	goassert.True(t, result)
@@ -799,7 +801,7 @@ func TestTrimEncodedRevisionsToAncestor(t *testing.T) {
 	goassert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey"}})
 
 	// Check maxLength with no ancestors:
-	encoded = encodeRevisions([]string{"5-huey", "4-dewey", "3-louie", "2-screwy"})
+	encoded = encodeRevisions(base.TestCtx(t), []string{"5-huey", "4-dewey", "3-louie", "2-screwy"})
 
 	result, trimmedRevs = trimEncodedRevisionsToAncestor(encoded, nil, 6)
 	goassert.True(t, result)
@@ -1036,7 +1038,7 @@ func getHistoryWithTimeout(rawDoc *Document, revId string, timeout time.Duration
 
 }
 
-//////// BENCHMARK:
+// ////// BENCHMARK:
 
 func BenchmarkRevTreePruning(b *testing.B) {
 

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -541,7 +541,7 @@ func (m *sgReplicateManager) NewActiveReplicatorConfig(config *ReplicationCfg) (
 
 	activeDB := &Database{DatabaseContext: m.dbContext}
 	if config.RunAs != "" {
-		user, err := m.dbContext.Authenticator().GetUser(config.RunAs)
+		user, err := m.dbContext.Authenticator(m.loggingCtx).GetUser(config.RunAs)
 		if err != nil {
 			return nil, err
 		}

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -390,7 +390,7 @@ func TestRebalanceReplications(t *testing.T) {
 		t.Run(fmt.Sprintf("%s", testCase.name), func(t *testing.T) {
 
 			cluster := NewSGRCluster()
-			cluster.loggingCtx = context.WithValue(context.Background(), base.LogContextKey{},
+			cluster.loggingCtx = context.WithValue(base.TestCtx(t), base.LogContextKey{},
 				base.LogContext{CorrelationID: sgrClusterMgrContextID + "test"})
 			cluster.Nodes = testCase.nodes
 			cluster.Replications = testCase.replications

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -28,10 +28,11 @@ import (
 
 const kDefaultDBOnlineDelay = 0
 
-//////// DATABASE MAINTENANCE:
+// ////// DATABASE MAINTENANCE:
 
 // "Create" a database (actually just register an existing bucket)
 func (h *handler) handleCreateDB() error {
+	base.WarnfCtx(h.rq.Context(), "bbrks context test")
 	h.assertAdminOnly()
 	dbName := h.PathVar("newdb")
 	config, err := h.readSanitizeDbConfigJSON()
@@ -150,12 +151,12 @@ func getAuthScopeHandleCreateDB(bodyJSON []byte) (string, error) {
 func (h *handler) handleDbOnline() error {
 	h.assertAdminOnly()
 	dbState := atomic.LoadUint32(&h.db.State)
-	//If the DB is already transitioning to: online or is online silently return
+	// If the DB is already transitioning to: online or is online silently return
 	if dbState == db.DBOnline || dbState == db.DBStarting {
 		return nil
 	}
 
-	//If the DB is currently re-syncing return an error asking the user to retry later
+	// If the DB is currently re-syncing return an error asking the user to retry later
 	if dbState == db.DBResyncing {
 		return base.HTTPErrorf(http.StatusServiceUnavailable, "Database _resync is in progress, this may take some time, try again later")
 	}
@@ -182,7 +183,7 @@ func (h *handler) handleDbOnline() error {
 	return nil
 }
 
-//Take a DB offline
+// Take a DB offline
 func (h *handler) handleDbOffline() error {
 	h.assertAdminOnly()
 	var err error
@@ -913,7 +914,7 @@ func (h *handler) handleGetRawDoc() error {
 		includeDoc = false
 	}
 
-	doc, err := h.db.GetDocument(docid, db.DocUnmarshalSync)
+	doc, err := h.db.GetDocument(h.db.Ctx, docid, db.DocUnmarshalSync)
 	if err != nil {
 		return err
 	}
@@ -964,7 +965,7 @@ func (h *handler) handleGetRawDoc() error {
 func (h *handler) handleGetRevTree() error {
 	h.assertAdminOnly()
 	docid := h.PathVar("docid")
-	doc, err := h.db.GetDocument(docid, db.DocUnmarshalAll)
+	doc, err := h.db.GetDocument(h.db.Ctx, docid, db.DocUnmarshalAll)
 
 	if doc != nil {
 		h.writeText([]byte(doc.History.RenderGraphvizDot()))
@@ -1148,7 +1149,7 @@ func (h *handler) handleSGCollect() error {
 	return nil
 }
 
-//////// USERS & ROLES:
+// ////// USERS & ROLES:
 
 func internalUserName(name string) string {
 	if name == base.GuestUsername {
@@ -1213,13 +1214,13 @@ func (h *handler) updatePrincipal(name string, isUser bool) error {
 
 	internalName := internalUserName(*newInfo.Name)
 	newInfo.Name = &internalName
-	replaced, err := h.db.UpdatePrincipal(newInfo, isUser, h.rq.Method != "POST")
+	replaced, err := h.db.UpdatePrincipal(h.db.Ctx, newInfo, isUser, h.rq.Method != "POST")
 	if err != nil {
 		return err
 	} else if replaced {
 		// on update with a new password, remove previous user sessions
 		if newInfo.Password != nil {
-			err = h.db.DeleteUserSessions(*newInfo.Name)
+			err = h.db.DeleteUserSessions(h.db.Ctx, *newInfo.Name)
 			if err != nil {
 				return err
 			}
@@ -1253,26 +1254,26 @@ func (h *handler) deleteUser() error {
 			"The %s user cannot be deleted. Only disabled via an update.", base.GuestUsername)
 	}
 
-	user, err := h.db.Authenticator().GetUser(username)
+	user, err := h.db.Authenticator(h.db.Ctx).GetUser(username)
 	if user == nil {
 		if err == nil {
 			err = kNotFoundError
 		}
 		return err
 	}
-	return h.db.Authenticator().DeleteUser(user)
+	return h.db.Authenticator(h.db.Ctx).DeleteUser(user)
 }
 
 func (h *handler) deleteRole() error {
 	h.assertAdminOnly()
 	purge := h.getBoolQuery("purge")
-	return h.db.DeleteRole(mux.Vars(h.rq)["name"], purge)
+	return h.db.DeleteRole(h.ctx(), mux.Vars(h.rq)["name"], purge)
 
 }
 
 func (h *handler) getUserInfo() error {
 	h.assertAdminOnly()
-	user, err := h.db.Authenticator().GetUser(internalUserName(mux.Vars(h.rq)["name"]))
+	user, err := h.db.Authenticator(h.db.Ctx).GetUser(internalUserName(mux.Vars(h.rq)["name"]))
 	if user == nil {
 		if err == nil {
 			err = kNotFoundError
@@ -1288,7 +1289,7 @@ func (h *handler) getUserInfo() error {
 
 func (h *handler) getRoleInfo() error {
 	h.assertAdminOnly()
-	role, err := h.db.Authenticator().GetRole(mux.Vars(h.rq)["name"])
+	role, err := h.db.Authenticator(h.db.Ctx).GetRole(mux.Vars(h.rq)["name"])
 	if role == nil {
 		if err == nil {
 			err = kNotFoundError
@@ -1303,7 +1304,7 @@ func (h *handler) getRoleInfo() error {
 }
 
 func (h *handler) getUsers() error {
-	users, _, err := h.db.AllPrincipalIDs()
+	users, _, err := h.db.AllPrincipalIDs(h.db.Ctx)
 	if err != nil {
 		return err
 	}
@@ -1313,7 +1314,7 @@ func (h *handler) getUsers() error {
 }
 
 func (h *handler) getRoles() error {
-	_, roles, err := h.db.AllPrincipalIDs()
+	_, roles, err := h.db.AllPrincipalIDs(h.db.Ctx)
 	if err != nil {
 		return err
 	}
@@ -1327,7 +1328,7 @@ func (h *handler) handlePurge() error {
 
 	message := "OK"
 
-	//Get the list of docs to purge
+	// Get the list of docs to purge
 
 	input, err := h.readJSON()
 	if err != nil {
@@ -1343,23 +1344,23 @@ func (h *handler) handlePurge() error {
 	var first bool = true
 
 	for key, value := range input {
-		//For each one validate that the revision list is set to ["*"], otherwise skip doc and log warning
-		base.Infof(base.KeyCRUD, "purging document = %v", base.UD(key))
+		// For each one validate that the revision list is set to ["*"], otherwise skip doc and log warning
+		base.InfofCtx(h.db.Ctx, base.KeyCRUD, "purging document = %v", base.UD(key))
 
 		if revisionList, ok := value.([]interface{}); ok {
 
-			//There should only be a single revision entry of "*"
+			// There should only be a single revision entry of "*"
 			if len(revisionList) != 1 {
-				base.Infof(base.KeyCRUD, "Revision list for doc ID %v, should contain exactly one entry", base.UD(key))
-				continue //skip this entry its not valid
+				base.InfofCtx(h.db.Ctx, base.KeyCRUD, "Revision list for doc ID %v, should contain exactly one entry", base.UD(key))
+				continue // skip this entry its not valid
 			}
 
 			if revisionList[0] != "*" {
-				base.Infof(base.KeyCRUD, "Revision entry for doc ID %v, should be the '*' revison", base.UD(key))
-				continue //skip this entry its not valid
+				base.InfofCtx(h.db.Ctx, base.KeyCRUD, "Revision entry for doc ID %v, should be the '*' revison", base.UD(key))
+				continue // skip this entry its not valid
 			}
 
-			//Attempt to delete document, if successful add to response, otherwise log warning
+			// Attempt to delete document, if successful add to response, otherwise log warning
 			err = h.db.Purge(key)
 			if err == nil {
 
@@ -1375,19 +1376,19 @@ func (h *handler) handlePurge() error {
 				_, _ = h.response.Write([]byte(s))
 
 			} else {
-				base.Infof(base.KeyCRUD, "Failed to purge document %v, err = %v", base.UD(key), err)
-				continue //skip this entry its not valid
+				base.InfofCtx(h.db.Ctx, base.KeyCRUD, "Failed to purge document %v, err = %v", base.UD(key), err)
+				continue // skip this entry its not valid
 			}
 
 		} else {
-			base.Infof(base.KeyCRUD, "Revision list for doc ID %v, is not an array, ", base.UD(key))
-			continue //skip this entry its not valid
+			base.InfofCtx(h.db.Ctx, base.KeyCRUD, "Revision list for doc ID %v, is not an array, ", base.UD(key))
+			continue // skip this entry its not valid
 		}
 	}
 
 	if len(docIDs) > 0 {
 		count := h.db.GetChangeCache().Remove(docIDs, startTime)
-		base.Debugf(base.KeyCache, "Purged %d items from caches", count)
+		base.DebugfCtx(h.db.Ctx, base.KeyCache, "Purged %d items from caches", count)
 	}
 
 	_, _ = h.response.Write([]byte("}\n}\n"))

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -47,9 +47,9 @@ func init() {
 	underscore.Disable() // It really slows down unit tests (by making otto.New take a lot longer)
 }
 
-//////// REST TESTER HELPER CLASS:
+// ////// REST TESTER HELPER CLASS:
 
-//////// AND NOW THE TESTS:
+// ////// AND NOW THE TESTS:
 
 func TestRoot(t *testing.T) {
 	rt := NewRestTester(t, nil)
@@ -115,7 +115,7 @@ func TestDocLifecycle(t *testing.T) {
 	assertStatus(t, response, 200)
 }
 
-//Validate that Etag header value is surrounded with double quotes, see issue #808
+// Validate that Etag header value is surrounded with double quotes, see issue #808
 func TestDocEtag(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
@@ -132,16 +132,16 @@ func TestDocEtag(t *testing.T) {
 		t.Fatalf("No revid in response for PUT doc")
 	}
 
-	//Validate Etag returned on doc creation
+	// Validate Etag returned on doc creation
 	goassert.Equals(t, response.Header().Get("Etag"), strconv.Quote(revid))
 
 	response = rt.SendRequest("GET", "/db/doc", "")
 	assertStatus(t, response, 200)
 
-	//Validate Etag returned when retrieving doc
+	// Validate Etag returned when retrieving doc
 	goassert.Equals(t, response.Header().Get("Etag"), strconv.Quote(revid))
 
-	//Validate Etag returned when updating doc
+	// Validate Etag returned when updating doc
 	response = rt.SendRequest("PUT", "/db/doc?rev="+revid, `{"prop":false}`)
 	revid = body["rev"].(string)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
@@ -153,7 +153,7 @@ func TestDocEtag(t *testing.T) {
 
 	goassert.Equals(t, response.Header().Get("Etag"), strconv.Quote(revid))
 
-	//Test Attachments
+	// Test Attachments
 	attachmentBody := "this is the body of attachment"
 	attachmentContentType := "content/type"
 	reqHeaders := map[string]string{
@@ -172,7 +172,7 @@ func TestDocEtag(t *testing.T) {
 	}
 	goassert.True(t, revIdAfterAttachment != revid)
 
-	//validate Etag returned from adding an attachment
+	// validate Etag returned from adding an attachment
 	goassert.Equals(t, response.Header().Get("Etag"), strconv.Quote(revIdAfterAttachment))
 
 	// retrieve attachment
@@ -182,7 +182,7 @@ func TestDocEtag(t *testing.T) {
 	goassert.Equals(t, response.Header().Get("Content-Disposition"), "")
 	goassert.Equals(t, response.Header().Get("Content-Type"), attachmentContentType)
 
-	//Validate Etag returned from retrieving an attachment
+	// Validate Etag returned from retrieving an attachment
 	goassert.Equals(t, response.Header().Get("Etag"), "\"sha1-nq0xWBV2IEkkpY3ng+PEtFnCcVY=\"")
 
 }
@@ -307,14 +307,14 @@ func TestDocAttachmentOnRemovedRev(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	a := rt.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
 	user, err := a.GetUser("")
 	assert.NoError(t, err)
 	user.SetDisabled(true)
 	err = a.Save(user)
 	assert.NoError(t, err)
 
-	//Create a test user
+	// Create a test user
 	user, err = a.NewUser("user1", "letmein", channels.SetOf(t, "foo"))
 	assert.NoError(t, a.Save(user))
 
@@ -324,7 +324,7 @@ func TestDocAttachmentOnRemovedRev(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revid := body["rev"].(string)
 
-	//Put new revision removing document from users channel set
+	// Put new revision removing document from users channel set
 	response = rt.Send(requestByUser("PUT", "/db/doc?rev="+revid, `{"prop":true}`, "user1"))
 	assertStatus(t, response, 201)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
@@ -345,24 +345,24 @@ func TestDocumentUpdateWithNullBody(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	a := rt.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
 	user, err := a.GetUser("")
 	assert.NoError(t, err)
 	user.SetDisabled(true)
 	err = a.Save(user)
 	assert.NoError(t, err)
 
-	//Create a test user
+	// Create a test user
 	user, err = a.NewUser("user1", "letmein", channels.SetOf(t, "foo"))
 	assert.NoError(t, a.Save(user))
-	//Create document
+	// Create document
 	response := rt.Send(requestByUser("PUT", "/db/doc", `{"prop":true, "channels":["foo"]}`, "user1"))
 	assertStatus(t, response, 201)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revid := body["rev"].(string)
 
-	//Put new revision with null body
+	// Put new revision with null body
 	response = rt.Send(requestByUser("PUT", "/db/doc?rev="+revid, "", "user1"))
 	assertStatus(t, response, 400)
 }
@@ -1346,14 +1346,14 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	a := rt.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
 	user, err := a.GetUser("")
 	assert.NoError(t, err)
 	user.SetDisabled(true)
 	err = a.Save(user)
 	assert.NoError(t, err)
 
-	//Create a test user
+	// Create a test user
 	user, err = a.NewUser("user1", "letmein", nil)
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(user))
@@ -1389,7 +1389,7 @@ func TestBulkDocsChangeToRoleAccess(t *testing.T) {
 	defer rt.Close()
 
 	// Create a role with no channels assigned to it
-	authenticator := rt.ServerContext().Database("db").Authenticator()
+	authenticator := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
 	role, err := authenticator.NewRole("role1", nil)
 	assert.NoError(t, authenticator.Save(role))
 
@@ -1920,7 +1920,7 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 
 // Test _all_docs API call under different security scenarios
 func TestAllDocsAccessControl(t *testing.T) {
-	//restTester := initRestTester(db.IntSequenceType, `function(doc) {channel(doc.channels);}`)
+	// restTester := initRestTester(db.IntSequenceType, `function(doc) {channel(doc.channels);}`)
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 	type allDocsRow struct {
@@ -1992,7 +1992,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	goassert.Equals(t, allDocsResult.Rows[2].ID, "doc5")
 	goassert.DeepEquals(t, allDocsResult.Rows[2].Value.Channels, []string{"Cinemax"})
 
-	//Check all docs limit option
+	// Check all docs limit option
 	request, _ = http.NewRequest("GET", "/db/_all_docs?limit=1&channels=true", nil)
 	request.SetBasicAuth("alice", "letmein")
 	response = rt.Send(request)
@@ -2006,7 +2006,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
 
-	//Check all docs startkey option
+	// Check all docs startkey option
 	request, _ = http.NewRequest("GET", "/db/_all_docs?startkey=doc5&channels=true", nil)
 	request.SetBasicAuth("alice", "letmein")
 	response = rt.Send(request)
@@ -2020,7 +2020,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc5")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
 
-	//Check all docs startkey option with double quote
+	// Check all docs startkey option with double quote
 	request, _ = http.NewRequest("GET", `/db/_all_docs?startkey="doc5"&channels=true`, nil)
 	request.SetBasicAuth("alice", "letmein")
 	response = rt.Send(request)
@@ -2034,7 +2034,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc5")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
 
-	//Check all docs endkey option
+	// Check all docs endkey option
 	request, _ = http.NewRequest("GET", "/db/_all_docs?endkey=doc3&channels=true", nil)
 	request.SetBasicAuth("alice", "letmein")
 	response = rt.Send(request)
@@ -2048,7 +2048,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
 
-	//Check all docs endkey option
+	// Check all docs endkey option
 	request, _ = http.NewRequest("GET", `/db/_all_docs?endkey="doc3"&channels=true`, nil)
 	request.SetBasicAuth("alice", "letmein")
 	response = rt.Send(request)
@@ -2161,7 +2161,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	a := rt.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
 	guest, err := a.GetUser("")
 	assert.NoError(t, err)
 	guest.SetDisabled(false)
@@ -2348,7 +2348,7 @@ func TestAccessOnTombstone(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	a := rt.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
 	guest, err := a.GetUser("")
 	assert.NoError(t, err)
 	guest.SetDisabled(false)
@@ -2442,7 +2442,7 @@ func TestSyncFnBodyProperties(t *testing.T) {
 	response := rt.SendAdminRequest("PUT", "/db/"+testDocID, `{"`+testdataKey+`":true}`)
 	assertStatus(t, response, 201)
 
-	syncData, err := rt.GetDatabase().GetDocSyncData(testDocID)
+	syncData, err := rt.GetDatabase().GetDocSyncData(base.TestCtx(t), testDocID)
 	assert.NoError(t, err)
 
 	actualProperties := syncData.Channels.KeySet()
@@ -2491,7 +2491,7 @@ func TestSyncFnBodyPropertiesTombstone(t *testing.T) {
 	response = rt.SendAdminRequest("DELETE", "/db/"+testDocID+"?rev="+revID, `{}`)
 	assertStatus(t, response, 200)
 
-	syncData, err := rt.GetDatabase().GetDocSyncData(testDocID)
+	syncData, err := rt.GetDatabase().GetDocSyncData(base.TestCtx(t), testDocID)
 	assert.NoError(t, err)
 
 	actualProperties := syncData.Channels.KeySet()
@@ -2539,7 +2539,7 @@ func TestSyncFnOldDocBodyProperties(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/db/"+testDocID+"?rev="+revID, `{"`+testdataKey+`":true,"update":2}`)
 	assertStatus(t, response, 201)
 
-	syncData, err := rt.GetDatabase().GetDocSyncData(testDocID)
+	syncData, err := rt.GetDatabase().GetDocSyncData(base.TestCtx(t), testDocID)
 	assert.NoError(t, err)
 
 	actualProperties := syncData.Channels.KeySet()
@@ -2595,7 +2595,7 @@ func TestSyncFnOldDocBodyPropertiesTombstoneResurrect(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/db/"+testDocID+"?rev="+revID, `{"`+testdataKey+`":true}`)
 	assertStatus(t, response, 201)
 
-	syncData, err := rt.GetDatabase().GetDocSyncData(testDocID)
+	syncData, err := rt.GetDatabase().GetDocSyncData(base.TestCtx(t), testDocID)
 	assert.NoError(t, err)
 
 	actualProperties := syncData.Channels.KeySet()
@@ -2678,7 +2678,7 @@ func TestSyncFnDocBodyPropertiesSwitchActiveTombstone(t *testing.T) {
 	assert.Equal(t, 1, numErrorsAfter-numErrorsBefore, "expecting to see only only 1 error logged")
 }
 
-//Test for wrong _changes entries for user joining a populated channel
+// Test for wrong _changes entries for user joining a populated channel
 func TestUserJoiningPopulatedChannel(t *testing.T) {
 
 	if testing.Short() {
@@ -2691,7 +2691,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	a := rt.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
 	guest, err := a.GetUser("")
 	assert.NoError(t, err)
 	guest.SetDisabled(false)
@@ -2714,7 +2714,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	since := changesResults.Results[49].Seq
 	assert.Equal(t, "doc48", changesResults.Results[49].ID)
 
-	//// Check the _changes feed with  since and limit, to get second half of feed
+	// // Check the _changes feed with  since and limit, to get second half of feed
 	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?since=\"%s\"&limit=%d", since, limit), "user1", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 50)
@@ -2725,7 +2725,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/db/_user/user2", `{"email":"user2@couchbase.com", "password":"letmein", "admin_channels":["alpha"]}`)
 	assertStatus(t, response, 201)
 
-	//Retrieve all changes for user2 with no limits
+	// Retrieve all changes for user2 with no limits
 	changesResults, err = rt.WaitForChanges(101, fmt.Sprintf("/db/_changes"), "user2", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 101)
@@ -2740,10 +2740,10 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	log.Printf("create user response: %s", getUserResponse.Body.Bytes())
 
 	// Get the sequence from the user doc to validate against the triggered by value in the changes results
-	user3, _ := rt.GetDatabase().Authenticator().GetUser("user3")
+	user3, _ := rt.GetDatabase().Authenticator(base.TestCtx(t)).GetUser("user3")
 	userSequence := user3.Sequence()
 
-	//Get first 50 document changes.
+	// Get first 50 document changes.
 	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user3", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 50)
@@ -2751,7 +2751,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, "doc49", changesResults.Results[49].ID)
 	assert.Equal(t, userSequence, since.TriggeredBy)
 
-	//// Get remainder of changes i.e. no limit parameter
+	// // Get remainder of changes i.e. no limit parameter
 	changesResults, err = rt.WaitForChanges(51, fmt.Sprintf("/db/_changes?since=\"%s\"", since), "user3", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 51)
@@ -2761,7 +2761,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/db/_user/user4", `{"email":"user4@couchbase.com", "password":"letmein", "admin_channels":["alpha"]}`)
 	assertStatus(t, response, 201)
 	// Get the sequence from the user doc to validate against the triggered by value in the changes results
-	user4, _ := rt.GetDatabase().Authenticator().GetUser("user4")
+	user4, _ := rt.GetDatabase().Authenticator(base.TestCtx(t)).GetUser("user4")
 	user4Sequence := user4.Sequence()
 
 	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user4", false)
@@ -2771,7 +2771,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, "doc49", changesResults.Results[49].ID)
 	assert.Equal(t, user4Sequence, since.TriggeredBy)
 
-	//// Check the _changes feed with  since and limit, to get second half of feed
+	// // Check the _changes feed with  since and limit, to get second half of feed
 	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?since=%s&limit=%d", since, limit), "user4", false)
 	assert.Equal(t, nil, err)
 	require.Len(t, changesResults.Results, 50)
@@ -2787,7 +2787,7 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	a := rt.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
 	guest, err := a.GetUser("")
 	assert.NoError(t, err)
 	guest.SetDisabled(false)
@@ -2803,7 +2803,7 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, "role1", body["name"])
 
-	//Put document to trigger sync function
+	// Put document to trigger sync function
 	response = rt.Send(request("PUT", "/db/doc1", `{"user":"user1", "role":"role:role1", "channel":"chan1"}`)) // seq=1
 	assertStatus(t, response, 201)
 	body = nil
@@ -2821,8 +2821,8 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 	goassert.DeepEquals(t, body["roles"], []interface{}{"role1"})
 	goassert.DeepEquals(t, body["all_channels"], []interface{}{"!", "chan1"})
 
-	//goassert.DeepEquals(t, body["admin_roles"], []interface{}{"hipster"})
-	//goassert.DeepEquals(t, body["all_channels"], []interface{}{"bar", "fedoras", "fixies", "foo"})
+	// goassert.DeepEquals(t, body["admin_roles"], []interface{}{"hipster"})
+	// goassert.DeepEquals(t, body["all_channels"], []interface{}{"bar", "fedoras", "fixies", "foo"})
 }
 
 func TestRoleAccessChanges(t *testing.T) {
@@ -2833,7 +2833,7 @@ func TestRoleAccessChanges(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	a := rt.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
 	guest, err := a.GetUser("")
 	require.NoError(t, err)
 
@@ -3000,7 +3000,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	a := rt.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
 	guest, err := a.GetUser("")
 	assert.NoError(t, err)
 	guest.SetDisabled(false)
@@ -3038,7 +3038,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
 	goassert.Equals(t, allDocsResult.Rows[0].Value.Channels[0], "ch1")
 
-	//Commit rev 2 that maps to a differenet channel
+	// Commit rev 2 that maps to a differenet channel
 	str := fmt.Sprintf(`{"foo":"bar", "channels":["ch2"], "_rev":%q}`, doc1RevID)
 	assertStatus(t, rt.Send(request("PUT", "/db/doc1", str)), 201)
 
@@ -3068,7 +3068,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 	goassert.Equals(t, allDocsResult.Rows[0].Value.Channels[0], "ch2")
 }
 
-//Test for regression of issue #447
+// Test for regression of issue #447
 func TestAttachmentsNoCrossTalk(t *testing.T) {
 
 	rt := NewRestTester(t, nil)
@@ -3101,7 +3101,7 @@ func TestAttachmentsNoCrossTalk(t *testing.T) {
 	log.Printf("/db/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", revIdAfterAttachment, doc1revId)
 	response = rt.SendAdminRequestWithHeaders("GET", fmt.Sprintf("/db/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", revIdAfterAttachment, doc1revId), "", reqHeaders)
 	goassert.Equals(t, response.Code, 200)
-	//validate attachment has data property
+	// validate attachment has data property
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	log.Printf("response body revid1 = %s", body)
 	attachments := body["_attachments"].(map[string]interface{})
@@ -3161,16 +3161,16 @@ func TestAddingAttachment(t *testing.T) {
 				"Content-Type": attachmentContentType,
 			}
 
-			//Set attachment
+			// Set attachment
 			response := rt.SendAdminRequestWithHeaders("PUT", "/db/"+testCase.docName+"/attach1?rev="+docrevId,
 				attachmentBody, reqHeaders)
 			assertStatus(tt, response, testCase.expectedPut)
 
-			//Get attachment back
+			// Get attachment back
 			response = rt.SendAdminRequestWithHeaders("GET", "/db/"+testCase.docName+"/attach1", "", reqHeaders)
 			assertStatus(tt, response, testCase.expectedGet)
 
-			//If able to retrieve document check it is same as original
+			// If able to retrieve document check it is same as original
 			if response.Code == 200 {
 				assert.Equal(tt, response.Body.String(), attachmentBody)
 			}
@@ -3213,7 +3213,7 @@ func TestOldDocHandling(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	a := rt.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
 	guest, err := a.GetUser("")
 	assert.NoError(t, err)
 	guest.SetDisabled(false)
@@ -3456,10 +3456,10 @@ func TestCreateTarget(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	//Attempt to create existing target DB on public API
+	// Attempt to create existing target DB on public API
 	response := rt.SendRequest("PUT", "/db/", "")
 	assertStatus(t, response, 412)
-	//Attempt to create new target DB on public API
+	// Attempt to create new target DB on public API
 	response = rt.SendRequest("PUT", "/foo/", "")
 	assertStatus(t, response, 403)
 }
@@ -4013,7 +4013,7 @@ func TestLongpollWithWildcard(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	a := rt.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
 
 	// Create user:
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS"))
@@ -4165,32 +4165,32 @@ func TestDocIDFilterResurrection(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	//Create User
-	a := rt.ServerContext().Database("db").Authenticator()
+	// Create User
+	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
 	jacques, err := a.NewUser("jacques", "letmein", channels.SetOf(t, "A", "B"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(jacques))
 
-	//Create Doc
+	// Create Doc
 	response := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": ["A"]}`)
 	assert.Equal(t, http.StatusCreated, response.Code)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevID := body["rev"].(string)
 
-	//Delete Doc
+	// Delete Doc
 	response = rt.SendAdminRequest("DELETE", "/db/doc1?rev="+docRevID, "")
 	assert.Equal(t, http.StatusOK, response.Code)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevID2 := body["rev"].(string)
 
-	//Update / Revive Doc
+	// Update / Revive Doc
 	response = rt.SendAdminRequest("PUT", "/db/doc1?rev="+docRevID2, `{"channels": ["B"]}`)
 	assert.Equal(t, http.StatusCreated, response.Code)
 
 	require.NoError(t, rt.WaitForPendingChanges())
 
-	//Changes call
+	// Changes call
 	request, _ := http.NewRequest("GET", "/db/_changes", nil)
 	request.SetBasicAuth("jacques", "letmein")
 	response = rt.Send(request)
@@ -4235,43 +4235,43 @@ func TestConflictWithInvalidAttachment(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	//Create Doc
+	// Create Doc
 	docrevId := rt.createDoc(t, "doc1")
 
 	docRevDigest := strings.Split(docrevId, "-")[1]
 
-	//Setup Attachment
+	// Setup Attachment
 	attachmentContentType := "content/type"
 	reqHeaders := map[string]string{
 		"Content-Type": attachmentContentType,
 	}
 
-	//Set attachment
-	attachmentBody := "aGVsbG8gd29ybGQ=" //hello.txt
+	// Set attachment
+	attachmentBody := "aGVsbG8gd29ybGQ=" // hello.txt
 	response := rt.SendAdminRequestWithHeaders("PUT", "/db/doc1/attach1?rev="+docrevId, attachmentBody, reqHeaders)
 	assertStatus(t, response, http.StatusCreated)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docrevId2 := body["rev"].(string)
 
-	//Update Doc
+	// Update Doc
 	rev3Input := `{"_attachments":{"attach1":{"content-type": "content/type", "digest":"sha1-b7fDq/pHG8Nf5F3fe0K2nu0xcw0=", "length": 16, "revpos": 2, "stub": true}}, "_id": "doc1", "_rev": "` + docrevId2 + `", "prop":true}`
 	response = rt.SendAdminRequest("PUT", "/db/doc1", rev3Input)
 	assertStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docrevId3 := body["rev"].(string)
 
-	//Get Existing Doc & Update rev
+	// Get Existing Doc & Update rev
 	rev4Input := `{"_attachments":{"attach1":{"content-type": "content/type", "digest":"sha1-b7fDq/pHG8Nf5F3fe0K2nu0xcw0=", "length": 16, "revpos": 2, "stub": true}}, "_id": "doc1", "_rev": "` + docrevId3 + `", "prop":true}`
 	response = rt.SendAdminRequest("PUT", "/db/doc1", rev4Input)
 	assertStatus(t, response, http.StatusCreated)
 
-	//Get Existing Doc to Modify
+	// Get Existing Doc to Modify
 	response = rt.SendAdminRequest("GET", "/db/doc1?revs=true", "")
 	assertStatus(t, response, http.StatusOK)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 
-	//Modify Doc
+	// Modify Doc
 	parentRevList := [3]string{"foo3", "foo2", docRevDigest}
 	body["_rev"] = "3-foo3"
 	body["rev"] = "3-foo3"
@@ -4279,12 +4279,12 @@ func TestConflictWithInvalidAttachment(t *testing.T) {
 	body["_revisions"].(map[string]interface{})["start"] = 3
 	delete(body["_attachments"].(map[string]interface{})["attach1"].(map[string]interface{}), "digest")
 
-	//Prepare changed doc
+	// Prepare changed doc
 	temp, err := base.JSONMarshal(body)
 	assert.NoError(t, err)
 	newBody := string(temp)
 
-	//Send changed / conflict doc
+	// Send changed / conflict doc
 	response = rt.SendAdminRequest("PUT", "/db/doc1?new_edits=false", newBody)
 	assertStatus(t, response, http.StatusBadRequest)
 }
@@ -4333,11 +4333,11 @@ func TestConflictingBranchAttachments(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	//Create a document
+	// Create a document
 	docRevId := rt.createDoc(t, "doc1")
 	docRevDigest := strings.Split(docRevId, "-")[1]
 
-	////Create diverging tree
+	// //Create diverging tree
 	var body db.Body
 
 	reqBodyRev2 := `{"_rev": "2-two", "_revisions": {"ids": ["two", "` + docRevDigest + `"], "start": 2}}`
@@ -4355,41 +4355,41 @@ func TestConflictingBranchAttachments(t *testing.T) {
 	docRevId2a := body["rev"].(string)
 	assert.Equal(t, "2-twoa", docRevId2a)
 
-	//Create an attachment
+	// Create an attachment
 	attachmentContentType := "content/type"
 	reqHeaders := map[string]string{
 		"Content-Type": attachmentContentType,
 	}
 
-	//Put attachment on doc1 rev 2
-	rev3Attachment := `aGVsbG8gd29ybGQ=` //hello.txt
+	// Put attachment on doc1 rev 2
+	rev3Attachment := `aGVsbG8gd29ybGQ=` // hello.txt
 	response = rt.SendAdminRequestWithHeaders("PUT", "/db/doc1/attach1?rev=2-two", rev3Attachment, reqHeaders)
 	assertStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId3 := body["rev"].(string)
 
-	//Put attachment on doc1 conflicting rev 2a
-	rev3aAttachment := `Z29vZGJ5ZSBjcnVlbCB3b3JsZA==` //bye.txt
+	// Put attachment on doc1 conflicting rev 2a
+	rev3aAttachment := `Z29vZGJ5ZSBjcnVlbCB3b3JsZA==` // bye.txt
 	response = rt.SendAdminRequestWithHeaders("PUT", "/db/doc1/attach1a?rev=2-twoa", rev3aAttachment, reqHeaders)
 	assertStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId3a := body["rev"].(string)
 
-	//Perform small update on doc3
+	// Perform small update on doc3
 	rev4Body := `{"_id": "doc1", "_attachments": {"attach1": {"content_type": "content/type", "digest": "sha1-b7fDq/pHG8Nf5F3fe0K2nu0xcw0=", "length": 16, "revpos": 3, "stub":true}}}`
 	response = rt.SendAdminRequest("PUT", "/db/doc1?rev="+docRevId3, rev4Body)
 	assertStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId4 := body["rev"].(string)
 
-	//Perform small update on doc3a
+	// Perform small update on doc3a
 	rev4aBody := `{"_id": "doc1", "_attachments": {"attach1a": {"content_type": "content/type", "digest": "sha1-rdfKyt3ssqPHnWBUxl/xauXXcUs=", "length": 28, "revpos": 3, "stub": true}}}`
 	response = rt.SendAdminRequest("PUT", "/db/doc1?rev="+docRevId3a, rev4aBody)
 	assertStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId4a := body["rev"].(string)
 
-	//Ensure the two attachments are different
+	// Ensure the two attachments are different
 	response1 := rt.SendAdminRequest("GET", "/db/doc1?atts_since=[\""+docRevId+"\"]&rev="+docRevId4, "")
 	response2 := rt.SendAdminRequest("GET", "/db/doc1?rev="+docRevId4a, "")
 
@@ -4407,11 +4407,11 @@ func TestAttachmentsWithTombstonedConflict(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	//Create a document
+	// Create a document
 	docRevId := rt.createDoc(t, "doc1")
-	//docRevDigest := strings.Split(docRevId, "-")[1]
+	// docRevDigest := strings.Split(docRevId, "-")[1]
 
-	//Create an attachment
+	// Create an attachment
 	attachmentContentType := "content/type"
 	reqHeaders := map[string]string{
 		"Content-Type": attachmentContentType,
@@ -4419,7 +4419,7 @@ func TestAttachmentsWithTombstonedConflict(t *testing.T) {
 
 	// Add an attachment at rev 2
 	var body db.Body
-	rev2Attachment := `aGVsbG8gd29ybGQ=` //hello.txt
+	rev2Attachment := `aGVsbG8gd29ybGQ=` // hello.txt
 	response := rt.SendAdminRequestWithHeaders("PUT", "/db/doc1/attach1?rev="+docRevId, rev2Attachment, reqHeaders)
 	assertStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
@@ -4433,7 +4433,7 @@ func TestAttachmentsWithTombstonedConflict(t *testing.T) {
 	docRevId3 := body["rev"].(string)
 
 	// Add another attachment at rev 4
-	rev4Attachment := `Z29vZGJ5ZSBjcnVlbCB3b3JsZA==` //bye.txt
+	rev4Attachment := `Z29vZGJ5ZSBjcnVlbCB3b3JsZA==` // bye.txt
 	response = rt.SendAdminRequestWithHeaders("PUT", "/db/doc1/attach2?rev="+docRevId3, rev4Attachment, reqHeaders)
 	assertStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
@@ -4461,7 +4461,7 @@ func TestAttachmentsWithTombstonedConflict(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/db/doc1?rev="+docRevId5, rev6Body)
 	assertStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
-	//docRevId6 := body["rev"].(string)
+	// docRevId6 := body["rev"].(string)
 
 	response = rt.SendAdminRequest("GET", "/db/doc1?atts_since=[\""+docRevId+"\"]", "")
 	log.Printf("Rev6 GET: %s", response.Body.Bytes())
@@ -4504,9 +4504,9 @@ func TestNumAccessErrors(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	a := rt.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
 
-	//Create a test user
+	// Create a test user
 	user, err := a.NewUser("user", "letmein", channels.SetOf(t, "A"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(user))
@@ -5000,13 +5000,13 @@ func Benchmark_RestApiGetDocPerformance(b *testing.B) {
 	prt := NewRestTester(b, nil)
 	defer prt.Close()
 
-	//Create test document
+	// Create test document
 	prt.SendRequest("PUT", "/db/doc", `{"prop":true}`)
 
 	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
-		//GET the document until test run has completed
+		// GET the document until test run has completed
 		for pb.Next() {
 			prt.SendRequest("GET", "/db/doc", "")
 		}
@@ -5024,7 +5024,7 @@ func Benchmark_RestApiPutDocPerformanceDefaultSyncFunc(b *testing.B) {
 	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
-		//PUT a new document until test run has completed
+		// PUT a new document until test run has completed
 		for pb.Next() {
 			prt.SendRequest("PUT", fmt.Sprintf("/db/doc-%v", base.GenerateRandomID()), threekdoc)
 		}
@@ -5042,7 +5042,7 @@ func Benchmark_RestApiPutDocPerformanceExplicitSyncFunc(b *testing.B) {
 	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
-		//PUT a new document until test run has completed
+		// PUT a new document until test run has completed
 		for pb.Next() {
 			qrt.SendRequest("PUT", fmt.Sprintf("/db/doc-%v", base.GenerateRandomID()), threekdoc)
 		}
@@ -5051,7 +5051,7 @@ func Benchmark_RestApiPutDocPerformanceExplicitSyncFunc(b *testing.B) {
 
 func Benchmark_RestApiGetDocPerformanceFullRevCache(b *testing.B) {
 	defer base.SetUpBenchmarkLogging(base.LevelWarn, base.KeyHTTP)()
-	//Create test documents
+	// Create test documents
 	rt := NewRestTester(b, nil)
 	defer rt.Close()
 	keys := make([]string, 5000)
@@ -5064,7 +5064,7 @@ func Benchmark_RestApiGetDocPerformanceFullRevCache(b *testing.B) {
 	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
-		//GET the document until test run has completed
+		// GET the document until test run has completed
 		for pb.Next() {
 			key := keys[rand.Intn(5000)]
 			rt.SendRequest("GET", "/db/"+key+"?rev=1-45ca73d819d5b1c9b8eea95290e79004", "")
@@ -6198,7 +6198,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
 	assert.NoError(t, err)
 
-	docRev, err := rt.GetDatabase().GetRevisionCacheForTest().Get(docKey, syncData.CurrentRev, true, false)
+	docRev, err := rt.GetDatabase().GetRevisionCacheForTest().Get(base.TestCtx(t), docKey, syncData.CurrentRev, true, false)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(docRev.Channels.ToArray()))
 	assert.Equal(t, syncData.CurrentRev, docRev.RevID)
@@ -6218,7 +6218,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
 	assert.NoError(t, err)
 
-	docRev2, err := rt.GetDatabase().GetRevisionCacheForTest().Get(docKey, syncData.CurrentRev, true, false)
+	docRev2, err := rt.GetDatabase().GetRevisionCacheForTest().Get(base.TestCtx(t), docKey, syncData.CurrentRev, true, false)
 	assert.NoError(t, err)
 	assert.Equal(t, syncData2.CurrentRev, docRev2.RevID)
 
@@ -6257,7 +6257,7 @@ func TestDocumentChannelHistory(t *testing.T) {
 	assertStatus(t, resp, http.StatusCreated)
 	err := json.Unmarshal(resp.BodyBytes(), &body)
 	assert.NoError(t, err)
-	syncData, err := rt.GetDatabase().GetDocSyncData("doc")
+	syncData, err := rt.GetDatabase().GetDocSyncData(base.TestCtx(t), "doc")
 	assert.NoError(t, err)
 
 	require.Len(t, syncData.ChannelSet, 1)
@@ -6270,7 +6270,7 @@ func TestDocumentChannelHistory(t *testing.T) {
 	assertStatus(t, resp, http.StatusCreated)
 	err = json.Unmarshal(resp.BodyBytes(), &body)
 	assert.NoError(t, err)
-	syncData, err = rt.GetDatabase().GetDocSyncData("doc")
+	syncData, err = rt.GetDatabase().GetDocSyncData(base.TestCtx(t), "doc")
 	assert.NoError(t, err)
 
 	require.Len(t, syncData.ChannelSet, 1)
@@ -6283,7 +6283,7 @@ func TestDocumentChannelHistory(t *testing.T) {
 	assertStatus(t, resp, http.StatusCreated)
 	err = json.Unmarshal(resp.BodyBytes(), &body)
 	assert.NoError(t, err)
-	syncData, err = rt.GetDatabase().GetDocSyncData("doc")
+	syncData, err = rt.GetDatabase().GetDocSyncData(base.TestCtx(t), "doc")
 	assert.NoError(t, err)
 
 	require.Len(t, syncData.ChannelSet, 2)
@@ -6348,7 +6348,7 @@ func TestChannelHistoryLegacyDoc(t *testing.T) {
 	assertStatus(t, resp, http.StatusCreated)
 	err = json.Unmarshal(resp.BodyBytes(), &body)
 	assert.NoError(t, err)
-	syncData, err := rt.GetDatabase().GetDocSyncData("doc1")
+	syncData, err := rt.GetDatabase().GetDocSyncData(base.TestCtx(t), "doc1")
 	assert.NoError(t, err)
 	require.Len(t, syncData.ChannelSet, 1)
 	assert.Contains(t, syncData.ChannelSet, db.ChannelSetEntry{
@@ -7784,7 +7784,7 @@ func TestChannelHistoryPruning(t *testing.T) {
 	}
 
 	// Validate history is pruned properly with first entry merged to span a wider period
-	authenticator := rt.GetDatabase().Authenticator()
+	authenticator := rt.GetDatabase().Authenticator(base.TestCtx(t))
 	role, err := authenticator.GetRole("foo")
 	assert.NoError(t, err)
 	require.Contains(t, role.ChannelHistory(), "a")
@@ -7933,7 +7933,7 @@ func TestDocChannelSetPruning(t *testing.T) {
 		revID = rt.createDocReturnRev(t, "doc", revID, map[string]interface{}{"channels": []string{"a"}})
 	}
 
-	syncData, err := rt.GetDatabase().GetDocSyncData("doc")
+	syncData, err := rt.GetDatabase().GetDocSyncData(base.TestCtx(t), "doc")
 	assert.NoError(t, err)
 
 	require.Len(t, syncData.ChannelSetHistory, db.DocumentHistoryMaxEntriesPerChannel)

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -39,7 +39,7 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 	defer rt.Close()
 
 	// Create user:
-	a := rt.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
@@ -103,7 +103,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 	assertStatus(t, userResponse, 200)
 
 	/*
-		a := it.ServerContext().Database("db").Authenticator()
+		a := it.ServerContext().Database("db").Authenticator(base.TestCtx(t))
 		bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t,"ABC"))
 		goassert.True(t, err == nil)
 		a.Save(bernard)

--- a/rest/blip_sync_messages_test.go
+++ b/rest/blip_sync_messages_test.go
@@ -11,10 +11,10 @@ licenses/APL2.txt.
 package rest
 
 import (
-	"context"
 	"testing"
 
 	"github.com/couchbase/go-blip"
+	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -82,7 +82,7 @@ func TestSubChangesSince(t *testing.T) {
 	rq := blip.NewRequest()
 	rq.Properties["since"] = `"1"`
 
-	subChangesParams, err := db.NewSubChangesParams(context.TODO(), rq, db.SequenceID{}, testDb.ParseSequenceID)
+	subChangesParams, err := db.NewSubChangesParams(base.TestCtx(t), rq, db.SequenceID{}, testDb.ParseSequenceID)
 	require.NoError(t, err)
 
 	seqID := subChangesParams.Since()

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -96,7 +96,7 @@ func (h *handler) handleGetDoc() error {
 
 		if openRevs == "all" {
 			// open_revs=all
-			doc, err := h.db.GetDocument(docid, db.DocUnmarshalSync)
+			doc, err := h.db.GetDocument(h.db.Ctx, docid, db.DocUnmarshalSync)
 			if err != nil {
 				return err
 			}
@@ -117,7 +117,7 @@ func (h *handler) handleGetDoc() error {
 				for _, revid := range revids {
 					revBody, err := h.db.Get1xRevBodyWithHistory(docid, revid, revsLimit, revsFrom, attachmentsSince, showExp)
 					if err != nil {
-						revBody = db.Body{"missing": revid} //TODO: More specific error
+						revBody = db.Body{"missing": revid} // TODO: More specific error
 					}
 					_ = WriteRevisionAsPart(h.rq.Context(), h.db.DatabaseContext.DbStats.CBLReplicationPull(), revBody, err != nil, false, writer)
 					h.db.DbStats.Database().NumDocReadsRest.Add(1)
@@ -133,7 +133,7 @@ func (h *handler) handleGetDoc() error {
 			for _, revid := range revids {
 				revBody, err := h.db.Get1xRevBodyWithHistory(docid, revid, revsLimit, revsFrom, attachmentsSince, showExp)
 				if err != nil {
-					revBody = db.Body{"missing": revid} //TODO: More specific error
+					revBody = db.Body{"missing": revid} // TODO: More specific error
 				} else {
 					revBody = db.Body{"ok": revBody}
 				}
@@ -324,7 +324,7 @@ func (h *handler) handlePutAttachment() error {
 	attachment["data"] = attachmentData
 	attachment["content_type"] = attachmentContentType
 
-	//attach it
+	// attach it
 	attachments[attachmentName] = attachment
 	body[db.BodyAttachments] = attachments
 
@@ -513,7 +513,7 @@ func (h *handler) handleDeleteDoc() error {
 	return err
 }
 
-//////// LOCAL DOCS:
+// ////// LOCAL DOCS:
 
 // HTTP handler for a GET of a _local document
 func (h *handler) handleGetLocalDoc() error {

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -469,7 +469,7 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 
 	// Attempt to retrieve via view.  Above operations were all synchronous (on-demand import of SDK delete, SG delete), so
 	// stale=false view results should be immediately updated.
-	results, err := rt.GetDatabase().ChannelViewTest("ABC", 0, 1000)
+	results, err := rt.GetDatabase().ChannelViewForTest(t, "ABC", 0, 1000)
 	assert.NoError(t, err, "Error issuing channel view query")
 	for _, entry := range results {
 		log.Printf("Got view result: %v", entry)
@@ -544,7 +544,7 @@ func TestImportFilterLogging(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	//Add document to bucket
+	// Add document to bucket
 	key := "ValidImport"
 	body := make(map[string]interface{})
 	body["type"] = "mobile"
@@ -553,19 +553,19 @@ func TestImportFilterLogging(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, ok)
 
-	//Get number of errors before
+	// Get number of errors before
 	numErrors, err := strconv.Atoi(base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().ErrorCount.String())
 	assert.NoError(t, err)
 
-	//Attempt to get doc will trigger import
+	// Attempt to get doc will trigger import
 	response := rt.SendAdminRequest("GET", "/db/"+key, "")
 	assert.Equal(t, http.StatusOK, response.Code)
 
-	//Get number of errors after
+	// Get number of errors after
 	numErrorsAfter, err := strconv.Atoi(base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().ErrorCount.String())
 	assert.NoError(t, err)
 
-	//Make sure an error was logged
+	// Make sure an error was logged
 	assert.Equal(t, numErrors+1, numErrorsAfter)
 
 }

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -95,7 +95,7 @@ func (h *handler) handleOIDCCommon() (redirectURLString string, err error) {
 		return redirectURLString, err
 	}
 
-	client, err := provider.GetClient(h.getOIDCCallbackURL)
+	client, err := provider.GetClient(h.db.Ctx, h.getOIDCCallbackURL)
 	if err != nil {
 		return redirectURLString, base.HTTPErrorf(
 			http.StatusInternalServerError, fmt.Sprintf("Unable to obtain client for provider: %s - %v", providerName, err))
@@ -168,7 +168,7 @@ func (h *handler) handleOIDCCallback() error {
 		http.SetCookie(h.response, stateCookie)
 	}
 
-	client, err := provider.GetClient(h.getOIDCCallbackURL)
+	client, err := provider.GetClient(h.db.Ctx, h.getOIDCCallbackURL)
 	if err != nil {
 		return fmt.Errorf("OIDC initialization error: %w", err)
 	}
@@ -221,7 +221,7 @@ func (h *handler) handleOIDCRefresh() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Unable to identify provider for callback request")
 	}
 
-	client, err := provider.GetClient(h.getOIDCCallbackURL)
+	client, err := provider.GetClient(h.db.Ctx, h.getOIDCCallbackURL)
 	if err != nil {
 		return fmt.Errorf("OIDC initialization error: %w", err)
 	}
@@ -261,7 +261,7 @@ func (h *handler) handleOIDCRefresh() error {
 }
 
 func (h *handler) createSessionForTrustedIdToken(rawIDToken string, provider *auth.OIDCProvider) (username string, sessionID string, err error) {
-	user, tokenExpiryTime, err := h.db.Authenticator().AuthenticateTrustedJWT(rawIDToken, provider, h.getOIDCCallbackURL)
+	user, tokenExpiryTime, err := h.db.Authenticator(h.db.Ctx).AuthenticateTrustedJWT(rawIDToken, provider, h.getOIDCCallbackURL)
 	if err != nil {
 		return "", "", err
 	}

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -1168,7 +1168,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 	mockSyncGateway := httptest.NewServer(restTester.TestPublicHandler())
 	defer mockSyncGateway.Close()
 	mockSyncGatewayURL := mockSyncGateway.URL
-	authenticator := restTester.ServerContext().Database("db").Authenticator()
+	authenticator := restTester.ServerContext().Database("db").Authenticator(base.TestCtx(t))
 
 	sendAuthRequest := func(claimSet claimSet) (*http.Response, error) {
 		token, err := mockAuthServer.makeToken(claimSet)
@@ -1243,7 +1243,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		runGoodAuthTest(claimSet, username)
 
 		// Bad email shouldn't not be saved on successful authentication.
-		user, err := restTester.ServerContext().Database("db").Authenticator().GetUser("foo_noah")
+		user, err := restTester.ServerContext().Database("db").Authenticator(base.TestCtx(t)).GetUser("foo_noah")
 		require.NoError(t, err, "Error getting user from db")
 		assert.Equal(t, username, user.Name())
 		assert.Empty(t, user.Email(), "Bad email shouldn't be saved")
@@ -1257,7 +1257,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		runGoodAuthTest(claimSet, username)
 
 		// Bad email shouldn't not be saved on successful authentication.
-		user, err := restTester.ServerContext().Database("db").Authenticator().GetUser(username)
+		user, err := restTester.ServerContext().Database("db").Authenticator(base.TestCtx(t)).GetUser(username)
 		require.NoError(t, err, "Error getting user from db")
 		assert.Equal(t, username, user.Name())
 		assert.Equal(t, "foo_noah@couchbase.com", user.Email(), "Bad email shouldn't be saved")
@@ -1271,7 +1271,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		runGoodAuthTest(claimSet, username)
 
 		// Good email should be updated on successful authentication.
-		user, err := restTester.ServerContext().Database("db").Authenticator().GetUser(username)
+		user, err := restTester.ServerContext().Database("db").Authenticator(base.TestCtx(t)).GetUser(username)
 		require.NoError(t, err, "Error getting user from db")
 		assert.Equal(t, username, user.Name())
 		assert.Equal(t, "foo_noah@example.com", user.Email(), "Email is not updated")
@@ -1346,7 +1346,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		oldUserPrefix := provider.UserPrefix
 		provider.UsernameClaim = usernameClaim
 		provider.UserPrefix = ""
-		require.NoError(t, provider.InitUserPrefix(), "Error initializing user_prefix")
+		require.NoError(t, provider.InitUserPrefix(base.TestCtx(t)), "Error initializing user_prefix")
 		defer func() {
 			provider.UsernameClaim = oldUsernameClaim
 			provider.UserPrefix = oldUserPrefix
@@ -1371,7 +1371,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		oldUserPrefix := provider.UserPrefix
 		provider.UsernameClaim = usernameClaim
 		provider.UserPrefix = ""
-		require.NoError(t, provider.InitUserPrefix(), "Error initializing user_prefix")
+		require.NoError(t, provider.InitUserPrefix(base.TestCtx(t)), "Error initializing user_prefix")
 		defer func() {
 			provider.UsernameClaim = oldUsernameClaim
 			provider.UserPrefix = oldUserPrefix
@@ -1398,7 +1398,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		oldUserPrefix := provider.UserPrefix
 		provider.UsernameClaim = usernameClaim
 		provider.UserPrefix = "foo"
-		require.NoError(t, provider.InitUserPrefix(), "Error initializing user_prefix")
+		require.NoError(t, provider.InitUserPrefix(base.TestCtx(t)), "Error initializing user_prefix")
 		usernameExpected := provider.UserPrefix + "_" + username
 		defer func() {
 			provider.UsernameClaim = oldUsernameClaim
@@ -1424,7 +1424,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		oldUserPrefix := provider.UserPrefix
 		provider.UsernameClaim = usernameClaim
 		provider.UserPrefix = "foo"
-		require.NoError(t, provider.InitUserPrefix(), "Error initializing user_prefix")
+		require.NoError(t, provider.InitUserPrefix(base.TestCtx(t)), "Error initializing user_prefix")
 		usernameExpected := provider.UserPrefix + "_" + username
 		defer func() {
 			provider.UsernameClaim = oldUsernameClaim
@@ -1451,7 +1451,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		provider := restTester.DatabaseConfig.OIDCConfig.Providers.GetDefaultProvider()
 		oldUserPrefix := provider.UserPrefix
 		provider.UserPrefix = "foo"
-		require.NoError(t, provider.InitUserPrefix(), "Error initializing user_prefix")
+		require.NoError(t, provider.InitUserPrefix(base.TestCtx(t)), "Error initializing user_prefix")
 		defer func() { provider.UserPrefix = oldUserPrefix }()
 		claimSet := claimsAuthentic()
 		claimSet.secondaryClaims[emailClaim] = email
@@ -1472,7 +1472,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		provider := restTester.DatabaseConfig.OIDCConfig.Providers.GetDefaultProvider()
 		oldUserPrefix := provider.UserPrefix
 		provider.UserPrefix = "foo"
-		require.NoError(t, provider.InitUserPrefix(), "Error initializing user_prefix")
+		require.NoError(t, provider.InitUserPrefix(base.TestCtx(t)), "Error initializing user_prefix")
 		defer func() { provider.UserPrefix = oldUserPrefix }()
 		claimSet := claimsAuthentic()
 		claimSet.secondaryClaims[emailClaim] = email
@@ -1496,7 +1496,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		provider := restTester.DatabaseConfig.OIDCConfig.Providers.GetDefaultProvider()
 		oldUserPrefix := provider.UserPrefix
 		provider.UserPrefix = ""
-		require.NoError(t, provider.InitUserPrefix(), "Error initializing user_prefix")
+		require.NoError(t, provider.InitUserPrefix(base.TestCtx(t)), "Error initializing user_prefix")
 		defer func() { provider.UserPrefix = oldUserPrefix }()
 		claimSet := claimsAuthentic()
 		claimSet.secondaryClaims[emailClaim] = email
@@ -1519,7 +1519,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		provider := restTester.DatabaseConfig.OIDCConfig.Providers.GetDefaultProvider()
 		oldUserPrefix := provider.UserPrefix
 		provider.UserPrefix = ""
-		require.NoError(t, provider.InitUserPrefix(), "Error initializing user_prefix")
+		require.NoError(t, provider.InitUserPrefix(base.TestCtx(t)), "Error initializing user_prefix")
 		defer func() { provider.UserPrefix = oldUserPrefix }()
 		claimSet := claimsAuthentic()
 		claimSet.secondaryClaims[emailClaim] = email
@@ -1548,7 +1548,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		oldUserPrefix := provider.UserPrefix
 		provider.UsernameClaim = usernameClaim
 		provider.UserPrefix = ""
-		require.NoError(t, provider.InitUserPrefix(), "Error initializing user_prefix")
+		require.NoError(t, provider.InitUserPrefix(base.TestCtx(t)), "Error initializing user_prefix")
 		defer func() {
 			provider.UsernameClaim = oldUsernameClaim
 			provider.UserPrefix = oldUserPrefix
@@ -1567,7 +1567,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		oldUserPrefix := provider.UserPrefix
 		provider.UsernameClaim = usernameClaim
 		provider.UserPrefix = ""
-		require.NoError(t, provider.InitUserPrefix(), "Error initializing user_prefix")
+		require.NoError(t, provider.InitUserPrefix(base.TestCtx(t)), "Error initializing user_prefix")
 		defer func() {
 			provider.UsernameClaim = oldUsernameClaim
 			provider.UserPrefix = oldUserPrefix
@@ -1592,7 +1592,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		provider.UsernameClaim = usernameClaim
 		provider.UserPrefix = ""
 		provider.Register = true
-		require.NoError(t, provider.InitUserPrefix(), "Error initializing user_prefix")
+		require.NoError(t, provider.InitUserPrefix(base.TestCtx(t)), "Error initializing user_prefix")
 		defer func() {
 			provider.UsernameClaim = oldUsernameClaim
 			provider.UserPrefix = oldUserPrefix
@@ -1620,7 +1620,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		provider.UsernameClaim = usernameClaim
 		provider.UserPrefix = ""
 		provider.Register = false
-		require.NoError(t, provider.InitUserPrefix(), "Error initializing user_prefix")
+		require.NoError(t, provider.InitUserPrefix(base.TestCtx(t)), "Error initializing user_prefix")
 		defer func() {
 			provider.UsernameClaim = oldUsernameClaim
 			provider.UserPrefix = oldUserPrefix
@@ -1643,7 +1643,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 			oldUserPrefix := provider.UserPrefix
 			provider.UsernameClaim = usernameClaim
 			provider.UserPrefix = ""
-			require.NoError(t, provider.InitUserPrefix(), "Error initializing user_prefix")
+			require.NoError(t, provider.InitUserPrefix(base.TestCtx(t)), "Error initializing user_prefix")
 			defer func() {
 				provider.UsernameClaim = oldUsernameClaim
 				provider.UserPrefix = oldUserPrefix
@@ -1663,7 +1663,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		oldUserPrefix := provider.UserPrefix
 		provider.UsernameClaim = usernameClaim
 		provider.UserPrefix = ""
-		require.NoError(t, provider.InitUserPrefix(), "Error initializing user_prefix")
+		require.NoError(t, provider.InitUserPrefix(base.TestCtx(t)), "Error initializing user_prefix")
 		defer func() {
 			provider.UsernameClaim = oldUsernameClaim
 			provider.UserPrefix = oldUserPrefix
@@ -1686,7 +1686,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		provider.UsernameClaim = usernameClaim
 		provider.UserPrefix = ""
 		provider.Register = true
-		require.NoError(t, provider.InitUserPrefix(), "Error initializing user_prefix")
+		require.NoError(t, provider.InitUserPrefix(base.TestCtx(t)), "Error initializing user_prefix")
 		defer func() {
 			provider.UsernameClaim = oldUsernameClaim
 			provider.UserPrefix = oldUserPrefix
@@ -1712,7 +1712,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 			oldUserPrefix := provider.UserPrefix
 			provider.UsernameClaim = usernameClaim
 			provider.UserPrefix = ""
-			require.NoError(t, provider.InitUserPrefix(), "Error initializing user_prefix")
+			require.NoError(t, provider.InitUserPrefix(base.TestCtx(t)), "Error initializing user_prefix")
 			defer func() {
 				provider.UsernameClaim = oldUsernameClaim
 				provider.UserPrefix = oldUserPrefix
@@ -1739,7 +1739,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		provider.UsernameClaim = usernameClaim
 		provider.UserPrefix = ""
 		provider.Register = true
-		require.NoError(t, provider.InitUserPrefix(), "Error initializing user_prefix")
+		require.NoError(t, provider.InitUserPrefix(base.TestCtx(t)), "Error initializing user_prefix")
 		defer func() {
 			provider.UsernameClaim = oldUsernameClaim
 			provider.UserPrefix = oldUserPrefix
@@ -1765,7 +1765,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		provider.UsernameClaim = usernameClaim
 		provider.UserPrefix = ""
 		provider.Register = true
-		require.NoError(t, provider.InitUserPrefix(), "Error initializing user_prefix")
+		require.NoError(t, provider.InitUserPrefix(base.TestCtx(t)), "Error initializing user_prefix")
 		defer func() {
 			provider.UsernameClaim = oldUsernameClaim
 			provider.UserPrefix = oldUserPrefix

--- a/rest/replication_api_no_race_test.go
+++ b/rest/replication_api_no_race_test.go
@@ -95,7 +95,7 @@ func TestPushReplicationAPIUpdateDatabase(t *testing.T) {
 
 	// wait for the last document written to rt1 to arrive at rt2
 	waitAndAssertCondition(t, func() bool {
-		_, err := rt2.GetDatabase().GetDocument(lastDocIDString, db.DocUnmarshalNone)
+		_, err := rt2.GetDatabase().GetDocument(base.TestCtx(t), lastDocIDString, db.DocUnmarshalNone)
 		return err == nil
 	})
 }

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -180,7 +180,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	assertStatus(t, resp, http.StatusCreated)
 	revID := respRevID(t, resp)
 
-	remoteDoc, err := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	remoteDoc, err := rt2.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
@@ -224,7 +224,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
-	doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
@@ -313,7 +313,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
-	doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
@@ -334,7 +334,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	require.Len(t, changesResults.Results, 2)
 	assert.Equal(t, docID, changesResults.Results[1].ID)
 
-	doc2, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc2, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc2.SyncData.CurrentRev)
@@ -532,7 +532,7 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 			assert.Equal(t, docID, changesResults.Results[0].ID)
 			lastSeq = changesResults.Last_Seq.(string)
 
-			doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+			doc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 			require.NoError(t, err)
 			revGen, _ := db.ParseRevID(doc.SyncData.CurrentRev)
 
@@ -640,7 +640,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 		docID := fmt.Sprintf("%s%d", docIDPrefix, i)
 		assert.True(t, docIDsSeen[docID])
 
-		doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+		doc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 		assert.NoError(t, err)
 
 		body, err := doc.GetDeepMutableBody()
@@ -693,7 +693,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 		docID := fmt.Sprintf("%s%d", docIDPrefix, i)
 		assert.True(t, docIDsSeen[docID])
 
-		doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+		doc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 		assert.NoError(t, err)
 
 		body, err := doc.GetDeepMutableBody()
@@ -814,7 +814,7 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 		docID := fmt.Sprintf("%s%d", docIDPrefix, i)
 		assert.True(t, docIDsSeen[docID])
 
-		_, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+		_, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 		assert.NoError(t, err)
 	}
 
@@ -909,7 +909,7 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 	assertStatus(t, resp, http.StatusCreated)
 	revID := respRevID(t, resp)
 
-	remoteDoc, err := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	remoteDoc, err := rt2.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
@@ -959,7 +959,7 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 	}
 	assert.True(t, replicationStopped, "One-shot replication status should go to stopped on completion")
 
-	doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
@@ -1010,7 +1010,7 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 	assertStatus(t, resp, http.StatusCreated)
 	revID := respRevID(t, resp)
 
-	localDoc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	localDoc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
@@ -1046,7 +1046,7 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
-	doc, err := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err := rt2.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
@@ -1133,7 +1133,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
-	doc, err := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err := rt2.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
@@ -1155,7 +1155,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 	require.Len(t, changesResults.Results, 2)
 	assert.Equal(t, docID, changesResults.Results[1].ID)
 
-	doc2, err := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc2, err := rt2.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc2.SyncData.CurrentRev)
@@ -1259,7 +1259,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 		docID := fmt.Sprintf("%s%d", docIDPrefix, i)
 		assert.True(t, docIDsSeen[docID])
 
-		doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+		doc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 		assert.NoError(t, err)
 
 		body, err := doc.GetDeepMutableBody()
@@ -1310,7 +1310,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 		docID := fmt.Sprintf("%s%d", docIDPrefix, i)
 		assert.True(t, docIDsSeen[docID])
 
-		doc, err := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+		doc, err := rt2.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 		assert.NoError(t, err)
 
 		body, err := doc.GetDeepMutableBody()
@@ -1516,7 +1516,7 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 	assertStatus(t, resp, http.StatusCreated)
 	revID := respRevID(t, resp)
 
-	localDoc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	localDoc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
@@ -1558,7 +1558,7 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 	}
 	assert.True(t, replicationStopped, "One-shot replication status should go to stopped on completion")
 
-	doc, err := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err := rt2.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
@@ -1643,7 +1643,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
-	doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
@@ -1663,7 +1663,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
-	doc, err = rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err = rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	assert.True(t, doc.IsDeleted())
@@ -1744,7 +1744,7 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
-	doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
@@ -1762,7 +1762,7 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 		return stats.DocsPurged
 	}, 1)
 
-	doc, err = rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err = rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.Error(t, err)
 	assert.True(t, base.IsDocNotFoundError(err), "Error returned wasn't a DocNotFound error")
 	assert.Nil(t, doc)
@@ -1955,7 +1955,7 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			assert.Equal(t, test.expectedLocalRevID, changesResults.Results[0].Changes[0]["rev"])
 			log.Printf("Changes response is %+v", changesResults)
 
-			doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+			doc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 			require.NoError(t, err)
 			assert.Equal(t, test.expectedLocalRevID, doc.SyncData.CurrentRev)
 
@@ -2105,7 +2105,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			rt2revID := respRevID(t, resp)
 			assert.Equal(t, test.remoteRevID, rt2revID)
 
-			remoteDoc, err := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalSync)
+			remoteDoc, err := rt2.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalSync)
 			require.NoError(t, err)
 
 			// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
@@ -2139,7 +2139,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			rt1revID := respRevID(t, resp)
 			assert.Equal(t, test.localRevID, rt1revID)
 
-			localDoc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalSync)
+			localDoc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalSync)
 			require.NoError(t, err)
 
 			customConflictResolver, err := db.NewCustomConflictResolver(test.conflictResolver)
@@ -2180,7 +2180,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			docResponse := rt1.SendAdminRequest(http.MethodGet, "/db/"+docID, "")
 			log.Printf("Non-raw response: %s", docResponse.Body.Bytes())
 
-			doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+			doc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 			require.NoError(t, err)
 			assert.Equal(t, test.expectedRevID, doc.SyncData.CurrentRev)
 			assert.Equal(t, expectedLocalBody, doc.Body())
@@ -2220,7 +2220,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			assert.Equal(t, test.expectedRevID, changesResults.Results[0].Changes[0]["rev"])
 			log.Printf("Changes response is %+v", changesResults)
 
-			doc, err = rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+			doc, err = rt2.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 			require.NoError(t, err)
 			assert.Equal(t, test.expectedRevID, doc.SyncData.CurrentRev)
 			assert.Equal(t, expectedLocalBody, doc.Body())
@@ -2317,7 +2317,7 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
-	doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
@@ -2461,7 +2461,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
-	doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	body, err := doc.GetDeepMutableBody()
@@ -2516,7 +2516,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
-	doc, err = rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err = rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	require.NoError(t, err)
 
 	body, err = doc.GetDeepMutableBody()
@@ -2607,7 +2607,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	require.NoError(t, err)
 
 	startNumChangesRequestedFromZeroTotal := rt1.GetDatabase().DbStats.CBLReplicationPull().NumPullReplSinceZero.Value()
-	//startNumRevsSentTotal := ar.Pull.GetStats().SendRevCount.Value()
+	// startNumRevsSentTotal := ar.Pull.GetStats().SendRevCount.Value()
 	startNumRevsSentTotal := ar.Push.GetStats().SendRevCount.Value()
 
 	assert.NoError(t, ar.Start())
@@ -2618,7 +2618,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
-	doc, err := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err := rt2.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	body, err := doc.GetDeepMutableBody()
@@ -2686,7 +2686,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
-	doc, err = rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err = rt2.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	require.NoError(t, err)
 
 	body, err = doc.GetDeepMutableBody()
@@ -2791,7 +2791,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 	lastSeq := changesResults.Last_Seq.(string)
 
-	doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	body, err := doc.GetDeepMutableBody()
@@ -2826,7 +2826,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID+"2", changesResults.Results[0].ID)
 
-	doc, err = rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err = rt2.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	require.NoError(t, err)
 
 	body, err = doc.GetDeepMutableBody()
@@ -2859,7 +2859,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID+"2", changesResults.Results[0].ID)
 
-	doc, err = rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err = rt2.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	require.NoError(t, err)
 
 	body, err = doc.GetDeepMutableBody()
@@ -3045,7 +3045,7 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, rt1docID, changesResults.Results[0].ID)
 
-	doc, err := rt2.GetDatabase().GetDocument(rt1docID, db.DocUnmarshalAll)
+	doc, err := rt2.GetDatabase().GetDocument(base.TestCtx(t), rt1docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	assert.Equal(t, rt1revID, doc.SyncData.CurrentRev)
@@ -3067,7 +3067,7 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	assert.Equal(t, rt1docID, changesResults.Results[0].ID)
 	assert.Equal(t, rt2docID, changesResults.Results[1].ID)
 
-	doc, err = rt1.GetDatabase().GetDocument(rt2docID, db.DocUnmarshalAll)
+	doc, err = rt1.GetDatabase().GetDocument(base.TestCtx(t), rt2docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	assert.Equal(t, rt2revID, doc.SyncData.CurrentRev)
@@ -3220,7 +3220,7 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 		docID := fmt.Sprintf("%s_%s_%d", docIDPrefix, "chan2", i)
 		assert.True(t, docIDsSeen[docID])
 
-		doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+		doc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 		assert.NoError(t, err)
 
 		body, err := doc.GetDeepMutableBody()
@@ -3889,7 +3889,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 			assert.Equal(t, test.expectedLocalRevID, changesResults.Results[0].Changes[0]["rev"])
 			log.Printf("Changes response is %+v", changesResults)
 
-			doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+			doc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 			require.NoError(t, err)
 			assert.Equal(t, test.expectedLocalRevID, doc.SyncData.CurrentRev)
 			log.Printf("doc.Body(): %v", doc.Body())
@@ -4070,7 +4070,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 
 			// Wait for document to arrive on the doc is was put on
 			err := localActiveRT.WaitForConditionShouldRetry(func() (shouldRetry bool, err error, value interface{}) {
-				doc, _ := localActiveRT.GetDatabase().GetDocument("docid2", db.DocUnmarshalSync)
+				doc, _ := localActiveRT.GetDatabase().GetDocument(base.TestCtx(t), "docid2", db.DocUnmarshalSync)
 				if doc != nil {
 					return compareDocRev(doc.SyncData.CurrentRev, "3-abc")
 				}
@@ -4080,7 +4080,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 
 			// Wait for document to be replicated
 			err = remotePassiveRT.WaitForConditionShouldRetry(func() (shouldRetry bool, err error, value interface{}) {
-				doc, _ := remotePassiveRT.GetDatabase().GetDocument("docid2", db.DocUnmarshalSync)
+				doc, _ := remotePassiveRT.GetDatabase().GetDocument(base.TestCtx(t), "docid2", db.DocUnmarshalSync)
 				if doc != nil {
 					return compareDocRev(doc.SyncData.CurrentRev, "3-abc")
 				}
@@ -4100,7 +4100,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 
 				// Validate document revision created to prevent race conditions
 				err = remotePassiveRT.WaitForConditionShouldRetry(func() (shouldRetry bool, err error, value interface{}) {
-					doc, docErr := remotePassiveRT.GetDatabase().GetDocument("docid2", db.DocUnmarshalSync)
+					doc, docErr := remotePassiveRT.GetDatabase().GetDocument(base.TestCtx(t), "docid2", db.DocUnmarshalSync)
 					if assert.NoError(t, docErr) {
 						if shouldRetry, err, value = compareDocRev(doc.SyncData.CurrentRev, "4-cc0337d9d38c8e5fc930ae3deda62bf8"); value != nil {
 							requireTombstone(t, passiveBucket, "docid2")
@@ -4126,7 +4126,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 
 				// Validate document revision created to prevent race conditions
 				err = localActiveRT.WaitForConditionShouldRetry(func() (shouldRetry bool, err error, value interface{}) {
-					doc, docErr := localActiveRT.GetDatabase().GetDocument("docid2", db.DocUnmarshalSync)
+					doc, docErr := localActiveRT.GetDatabase().GetDocument(base.TestCtx(t), "docid2", db.DocUnmarshalSync)
 					if assert.NoError(t, docErr) {
 						if shouldRetry, err, value = compareDocRev(doc.SyncData.CurrentRev, "4-cc0337d9d38c8e5fc930ae3deda62bf8"); value != nil {
 							requireTombstone(t, activeBucket, "docid2")
@@ -4152,7 +4152,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 
 			// Wait for the recently longest branch to show up on both sides
 			err = localActiveRT.WaitForConditionShouldRetry(func() (shouldRetry bool, err error, value interface{}) {
-				doc, docErr := localActiveRT.GetDatabase().GetDocument("docid2", db.DocUnmarshalSync)
+				doc, docErr := localActiveRT.GetDatabase().GetDocument(base.TestCtx(t), "docid2", db.DocUnmarshalSync)
 				if assert.NoError(t, docErr) {
 					if shouldRetry, err, value = compareDocRev(doc.SyncData.CurrentRev, "5-4a5f5a35196c37c117737afd5be1fc9b"); value != nil {
 						// Validate local is CBS tombstone, expect not found error
@@ -4166,7 +4166,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 			assert.NoError(t, err)
 
 			err = remotePassiveRT.WaitForConditionShouldRetry(func() (shouldRetry bool, err error, value interface{}) {
-				doc, docErr := remotePassiveRT.GetDatabase().GetDocument("docid2", db.DocUnmarshalSync)
+				doc, docErr := remotePassiveRT.GetDatabase().GetDocument(base.TestCtx(t), "docid2", db.DocUnmarshalSync)
 				if assert.NoError(t, docErr) {
 					if shouldRetry, err, value = compareDocRev(doc.SyncData.CurrentRev, "5-4a5f5a35196c37c117737afd5be1fc9b"); value != nil {
 						// Validate remote is CBS tombstone
@@ -4192,7 +4192,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 					err = activeBucket.Set("docid2", 0, updatedBody)
 					assert.NoError(t, err, "Unable to resurrect doc docid2")
 					// force on-demand import
-					_, getErr := localActiveRT.GetDatabase().GetDocument("docid2", db.DocUnmarshalSync)
+					_, getErr := localActiveRT.GetDatabase().GetDocument(base.TestCtx(t), "docid2", db.DocUnmarshalSync)
 					assert.NoError(t, getErr, "Unable to retrieve resurrected doc docid2")
 				} else {
 					resp = localActiveRT.SendAdminRequest("PUT", "/db/docid2", `{"resurrection": true}`)
@@ -4204,7 +4204,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 					err = passiveBucket.Set("docid2", 0, updatedBody)
 					assert.NoError(t, err, "Unable to resurrect doc docid2")
 					// force on-demand import
-					_, getErr := remotePassiveRT.GetDatabase().GetDocument("docid2", db.DocUnmarshalSync)
+					_, getErr := remotePassiveRT.GetDatabase().GetDocument(base.TestCtx(t), "docid2", db.DocUnmarshalSync)
 					assert.NoError(t, getErr, "Unable to retrieve resurrected doc docid2")
 				} else {
 					resp = remotePassiveRT.SendAdminRequest("PUT", "/db/docid2", `{"resurrection": true}`)
@@ -4349,7 +4349,7 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 			// Wait for the original document revision written to rt1 to arrive at rt2.
 			rt2RevIDCreated := rt1RevIDCreated
 			require.NoError(t, rt2.WaitForCondition(func() bool {
-				doc, _ := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+				doc, _ := rt2.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 				return doc != nil && len(doc.Body()) > 0
 			}))
 			requireRevID(t, rt2, docID, rt2RevIDCreated)
@@ -4501,7 +4501,7 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 			// Wait for the original document revision written to rt2 to arrive at rt1.
 			rt1RevIDCreated := rt2RevIDCreated
 			require.NoError(t, rt1.WaitForCondition(func() bool {
-				doc, _ := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+				doc, _ := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 				return doc != nil && len(doc.Body()) > 0
 			}))
 			requireRevID(t, rt1, docID, rt1RevIDCreated)
@@ -4540,7 +4540,7 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 			// Wait for conflict resolved doc (tombstone) to be pulled to passive bucket
 			// Then require it is the expected rev
 			require.NoError(t, rt2.WaitForCondition(func() bool {
-				doc, _ := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+				doc, _ := rt2.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 				return doc != nil && doc.SyncData.CurrentRev == test.expectedRevID
 			}))
 
@@ -5764,12 +5764,12 @@ func TestUnprocessableDeltas(t *testing.T) {
 	err = activeRT.WaitForPendingChanges()
 	require.NoError(t, err)
 
-	rev, err := passiveRT.GetDatabase().GetRevisionCacheForTest().GetActive("test", true)
+	rev, err := passiveRT.GetDatabase().GetRevisionCacheForTest().GetActive(base.TestCtx(t), "test", true)
 	require.NoError(t, err)
 	// Making body invalid to trigger log "Unable to unmarshal mutable body for doc" in handleRev
 	// Which should give a HTTP 422
 	rev.BodyBytes = []byte("{invalid}")
-	passiveRT.GetDatabase().GetRevisionCacheForTest().Upsert(rev)
+	passiveRT.GetDatabase().GetRevisionCacheForTest().Upsert(base.TestCtx(t), rev)
 
 	assert.NoError(t, ar.Start())
 	// Check if it replicated
@@ -5889,7 +5889,7 @@ func createOrUpdateDoc(t *testing.T, rt *RestTester, docID, revID, bodyValue str
 func waitForTombstone(t *testing.T, rt *RestTester, docID string) {
 	require.NoError(t, rt.WaitForPendingChanges())
 	require.NoError(t, rt.WaitForCondition(func() bool {
-		doc, _ := rt.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+		doc, _ := rt.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 		return doc.IsDeleted() && len(doc.Body()) == 0
 	}))
 }
@@ -5906,7 +5906,7 @@ func requireErrorKeyNotFound(t *testing.T, rt *RestTester, docID string) {
 // requireRevID asserts that the specified document revision is written to the
 // underlying bucket backed by the given RestTester instance.
 func requireRevID(t *testing.T, rt *RestTester, docID, revID string) {
-	doc, err := rt.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err := rt.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	require.NoError(t, err, "Error reading document from bucket")
 	require.Equal(t, revID, doc.SyncData.CurrentRev)
 }

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -123,7 +123,7 @@ func CreatePublicHandler(sc *ServerContext) http.Handler {
 	return wrapRouter(sc, regularPrivs, r)
 }
 
-//////// ADMIN API:
+// ////// ADMIN API:
 
 // CreateAdminHandler Creates the HTTP handler for the PRIVATE admin API of a gateway server.
 func CreateAdminHandler(sc *ServerContext) http.Handler {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -12,7 +12,6 @@ package rest
 
 import (
 	"bytes"
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -299,7 +298,7 @@ func (rt *RestTester) SequenceForDoc(docid string) (seq uint64, err error) {
 	if database == nil {
 		return 0, fmt.Errorf("No database found")
 	}
-	doc, err := database.GetDocument(docid, db.DocUnmarshalAll)
+	doc, err := database.GetDocument(base.TestCtx(rt.tb), docid, db.DocUnmarshalAll)
 	if err != nil {
 		return 0, err
 	}
@@ -312,7 +311,7 @@ func (rt *RestTester) WaitForSequence(seq uint64) error {
 	if database == nil {
 		return fmt.Errorf("No database found")
 	}
-	return database.WaitForSequence(context.TODO(), seq)
+	return database.WaitForSequence(base.TestCtx(rt.tb), seq)
 }
 
 func (rt *RestTester) WaitForPendingChanges() error {
@@ -320,11 +319,11 @@ func (rt *RestTester) WaitForPendingChanges() error {
 	if database == nil {
 		return fmt.Errorf("No database found")
 	}
-	return database.WaitForPendingChanges(context.TODO())
+	return database.WaitForPendingChanges(base.TestCtx(rt.tb))
 }
 
 func (rt *RestTester) SetAdminParty(partyTime bool) error {
-	a := rt.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(rt.tb))
 	guest, err := a.GetUser("")
 	if err != nil {
 		return err
@@ -978,7 +977,7 @@ func createBlipTesterWithSpec(tb testing.TB, spec BlipTesterSpec, rt *RestTester
 	}
 
 	// Make BLIP/Websocket connection
-	bt.blipContext, err = db.NewSGBlipContextWithProtocols(context.Background(), "", protocols...)
+	bt.blipContext, err = db.NewSGBlipContextWithProtocols(base.TestCtx(tb), "", protocols...)
 	if err != nil {
 		return nil, err
 	}
@@ -1565,9 +1564,9 @@ func (e ExpectedChange) Equals(change []interface{}) error {
 	}
 
 	// TODO: commented due to reasons given above
-	//if e.sequence != "*" && changeSequence != e.sequence {
+	// if e.sequence != "*" && changeSequence != e.sequence {
 	//	return fmt.Errorf("changeSequence (%s) != expectedChangeSequence (%s)", changeSequence, e.sequence)
-	//}
+	// }
 
 	if changeDeleted != nil && e.deleted != nil && *changeDeleted != *e.deleted {
 		return fmt.Errorf("changeDeleted (%v) != expectedChangeDeleted (%v)", *changeDeleted, *e.deleted)


### PR DESCRIPTION
CBG-1905

- Earlier creation of HTTP request context, which is now created lazily via `h.ctx()`
	- Passed down via `Database.Ctx` for user-scoped operations that fall outside of a handler's scope
	- `Database.Ctx` is used to supply context to standalone components:
	  - Authenticator
	  - Changes feeds
	  - ChannelComputer/Views/Queries
	  - CRUD ops
	  - On-demand import
 - Exported `base.TestCtx(testing.TB)` to generate test-specific contexts for the above

## TODO/Future work
- Remove non-context log functions (CBG-1925)
- Pass context into Bucket APIs? gocb can take a context for per-op cancellation
  - Decided to postpone changes here until bucket API is revisited

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1562/
