### PR TITLE
CBG-1621: Added trace logging only

### DIFF
--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -4661,7 +4661,7 @@ func TestLocalWinsConflictResolution(t *testing.T) {
 	for _, test := range conflictResolutionTests {
 		t.Run(test.name, func(t *testing.T) {
 			base.RequireNumTestBuckets(t, 2)
-			defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+			defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 
 			activeRT, remoteRT, remoteURLString, teardown := setupSGRPeers(t)
 			defer teardown()


### PR DESCRIPTION
CBG-1621

Added trace logging to `TestLocalWinsConflictResolution`

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- `xattrs=true TestLocalWinsConflictResolution detect-races` Attempt to trigger fail again - http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1565

