### PR TITLE
TestResumeStoppedFeed debug log level for flaky test diagnosis

### DIFF
--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -251,6 +251,8 @@ func TestResumeStoppedFeed(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
+	defer SetUpTestLogging(LevelDebug, KeyAll)()
+
 	bucket := GetTestBucket(t)
 	defer bucket.Close()
 


### PR DESCRIPTION
Filed issue (CBG-1930) for flaky test - bumping log level for future diagnosis.

```
=== RUN   TestResumeStoppedFeed
2022-02-02T05:17:38.031-08:00 [INF] Setting max_concurrent_query_ops to 256 based on query node count (1)
2022-02-02T05:17:38.513-08:00 [WRN] gocb: memdClient read failure on conn `a6a4490c9d6de606/7a6967a269d8373d` : EOF -- base.GoCBCoreLogger.Log() at logger_external.go:79
2022-02-02T05:17:40.648-08:00 [WRN] Error opening stream for vbID 1004: EOF | {"bucket":"sg_int_2_1643807764994150764","last_dispatched_to":"127.0.0.1:11210","last_dispatched_from":"127.0.0.1:52863","last_connection_id":"e92001317271ec82/461271c831ac6174"} -- base.(*DCPClient).openStream() at dcp_client.go:306
    dcp_client_test.go:295: 
        	Error Trace:	dcp_client_test.go:295
        	Error:      	Received unexpected error:
        	            	Unable to start DCP client, error opening stream for vb 1004: EOF | {"bucket":"sg_int_2_1643807764994150764","last_dispatched_to":"127.0.0.1:11210","last_dispatched_from":"127.0.0.1:52863","last_connection_id":"e92001317271ec82/461271c831ac6174"}
        	Test:       	TestResumeStoppedFeed
    dcp_client_test.go:306: timeout waiting for first one-shot feed to complete
2022/02/02 05:17:45 Total processed: 10000, second feed: 4998
--- FAIL: TestResumeStoppedFeed (8.38s)
```