### PR TITLE
CBG-1901: Update ISGR/Blip to nhooyr.io/websocket

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -105,7 +105,7 @@ licenses/APL2.txt.
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="nhooyr-websocket"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="746a6c2c23026766d1a3ace9cca85c5a01f11408"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -17,7 +17,7 @@ licenses/APL2.txt.
   <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
 
   <!-- FIXME: Temporary for CI until couchbasedeps is updated -->
-  <remote fetch="https://github.com/nhooyr/" name="nhooyr"/>
+  <remote fetch="https://github.com/klauspost/" name="klauspost"/>
 
   <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
@@ -159,6 +159,7 @@ licenses/APL2.txt.
 
   <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
 
-  <project name="websocket" path="nhooyr.io/websocket" remote="nhooyr" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
+  <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
+  <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="klauspost" revision="a1a9cfc821f00faf2f5231beaa96244344d50391"/>
 
 </manifest>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -16,9 +16,6 @@ licenses/APL2.txt.
   <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
   <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
 
-  <!-- FIXME: Temporary for CI until couchbasedeps is updated -->
-  <remote fetch="https://github.com/klauspost/" name="klauspost"/>
-
   <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
   <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
@@ -160,6 +157,6 @@ licenses/APL2.txt.
   <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
 
   <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
-  <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="klauspost" revision="a1a9cfc821f00faf2f5231beaa96244344d50391"/>
+  <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="a1a9cfc821f00faf2f5231beaa96244344d50391"/>
 
 </manifest>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -16,6 +16,9 @@ licenses/APL2.txt.
   <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
   <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
 
+  <!-- FIXME: Temporary for CI until couchbasedeps is updated -->
+  <remote fetch="https://github.com/nhooyr/" name="nhooyr"/>
+
   <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
   <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
@@ -105,7 +108,7 @@ licenses/APL2.txt.
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="3c4edeb16c47cdb3bcd1eeab3b3c5c87832d4923"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="nhooyr-websocket"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 
@@ -155,5 +158,7 @@ licenses/APL2.txt.
   <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="1ecb1f411c1f2ce65a2db6ea4a8ae927182d342e"/>
 
   <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
+
+  <project name="websocket" path="nhooyr.io/websocket" remote="nhooyr" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
 
 </manifest>

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -35,7 +35,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
-	"golang.org/x/net/websocket"
 )
 
 // Testing utilities that have been included in the rest package so that they
@@ -986,20 +985,17 @@ func createBlipTesterWithSpec(tb testing.TB, spec BlipTesterSpec, rt *RestTester
 		return nil, err
 	}
 
-	origin := "http://localhost" // TODO: what should be used here?
-
-	config, err := websocket.NewConfig(u.String(), origin)
-	if err != nil {
-		return nil, err
+	config := blip.DialOptions{
+		URL: u.String(),
 	}
 
 	if len(spec.connectingUsername) > 0 {
-		config.Header = http.Header{
+		config.HTTPHeader = http.Header{
 			"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte(spec.connectingUsername+":"+spec.connectingPassword))},
 		}
 	}
 
-	bt.sender, err = bt.blipContext.DialConfig(config)
+	bt.sender, err = bt.blipContext.DialConfig(&config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
CBG-1901

Replaces go-blip and ISGR `x/net/websocket` implementations with `nhooyr.io/websocket`

## TODO
- [x] More testing of mixed websocket client/server implementations.

## Dependencies (if applicable)
- [x] https://github.com/couchbase/go-blip/pull/53
- [x] Change manifest once `couchbasedeps` is updated

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1576/
  - Failures related to bucket flush timeouts - full integration test run works locally.