### PR TITLE
CBG-1910 Avoid retrieval of temporary revision backups during ancestor lookup

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2627,7 +2627,7 @@ func TestSyncFnDocBodyPropertiesSwitchActiveTombstone(t *testing.T) {
 		console.log("full doc: "+JSON.stringify(doc));
 		console.log("full oldDoc: "+JSON.stringify(oldDoc));
 
-		if (oldDoc == null || !oldDoc.syncOldDocBodyCheck) {
+		if (doc.testdata == 1 || (oldDoc != null && !oldDoc.syncOldDocBodyCheck)) {
 			console.log("skipping oldDoc property checks for this rev")
 			return
 		}


### PR DESCRIPTION
When attempting to retrieve an ancestor for use as oldDoc in the sync function, we shouldn't check for temporary revision body backups.  These aren't intended for use by the sync function (as they would provide different results depending on whether they have expired), and the check adds unnecessary performance overhead at write time when the ancestor is unavailable or not the immediate parent.

CBG-1910

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1574/
