### PR TITLE
Reduce RestTester bcrypt cost

### DIFF
--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -159,7 +159,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 		panic("invalid RestTester StartupConfig: " + err.Error())
 	}
 
-	// Post-validation, we can lower the bcrypt cost to reduce test runtime.
+	// Post-validation, we can lower the bcrypt cost beyond SG limits to reduce test runtime.
 	sc.Auth.BcryptCost = bcrypt.MinCost
 
 	rt.RestTesterServerContext = NewServerContext(&sc, rt.RestTesterConfig.persistentConfig)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -34,6 +34,7 @@ import (
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/net/websocket"
 )
 
@@ -157,6 +158,9 @@ func (rt *RestTester) Bucket() base.Bucket {
 	if err := sc.validate(true); err != nil {
 		panic("invalid RestTester StartupConfig: " + err.Error())
 	}
+
+	// Post-validation, we can lower the bcrypt cost to reduce test runtime.
+	sc.Auth.BcryptCost = bcrypt.MinCost
 
 	rt.RestTesterServerContext = NewServerContext(&sc, rt.RestTesterConfig.persistentConfig)
 


### PR DESCRIPTION
Minor (~100ms per test) speedup of `RestTester` tests by reducing the cost of bcrypt hashing