### PR TITLE
CBG-1874: Deprecated 'allow-conflicts=true'

### DIFF
--- a/docs/api/api_docs.yaml
+++ b/docs/api/api_docs.yaml
@@ -5646,6 +5646,7 @@ components:
         allow_conflicts:
           type: boolean
           default: true
+          deprecated: true
           description: This controls whether to allow conflicting document revisions.
         num_index_replicas:
           type: number

--- a/rest/config.go
+++ b/rest/config.go
@@ -694,10 +694,6 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) error {
 		}
 	}
 
-	if dbConfig.AllowConflicts != nil && *dbConfig.AllowConflicts {
-		base.Warnf(`Deprecation notice: Setting the database configuration option "allow_conflicts" to true is due to be removed. In the future, conflicts will not be allowed.`)
-	}
-
 	return multiError.ErrorOrNil()
 }
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -136,7 +136,7 @@ type DbConfig struct {
 	SecureCookieOverride             *bool                            `json:"session_cookie_secure,omitempty"`                // Override cookie secure flag
 	SessionCookieName                string                           `json:"session_cookie_name,omitempty"`                  // Custom per-database session cookie name
 	SessionCookieHTTPOnly            *bool                            `json:"session_cookie_http_only,omitempty"`             // HTTP only cookies
-	AllowConflicts                   *bool                            `json:"allow_conflicts,omitempty"`                      // False forbids creating conflicts
+	AllowConflicts                   *bool                            `json:"allow_conflicts,omitempty"`                      // Deprecated: False forbids creating conflicts
 	NumIndexReplicas                 *uint                            `json:"num_index_replicas,omitempty"`                   // Number of GSI index replicas used for core indexes
 	UseViews                         *bool                            `json:"use_views,omitempty"`                            // Force use of views instead of GSI
 	SendWWWAuthenticateHeader        *bool                            `json:"send_www_authenticate_header,omitempty"`         // If false, disables setting of 'WWW-Authenticate' header in 401 responses
@@ -692,6 +692,10 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) error {
 				multiError = multiError.Append(fmt.Errorf("The revs_limit (%v) value in your Sync Gateway configuration must be greater than zero.", *revsLimit))
 			}
 		}
+	}
+
+	if dbConfig.AllowConflicts != nil && *dbConfig.AllowConflicts {
+		base.Warnf(`Deprecation notice: Setting the database configuration option "allow_conflicts" to true is due to be removed. In the future, conflicts will not be allowed.`)
 	}
 
 	return multiError.ErrorOrNil()

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -771,6 +771,10 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		groupID = sc.config.Bootstrap.ConfigGroupID
 	}
 
+	if config.AllowConflicts != nil && *config.AllowConflicts {
+		base.Warnf(`Deprecation notice: setting database configuration option "allow_conflicts" to true is due to be removed. In the future, conflicts will not be allowed.`)
+	}
+
 	// Register the cbgt pindex type for the configGroup
 	db.RegisterImportPindexImpl(groupID)
 


### PR DESCRIPTION
CBG-1874

Deprecated the `allow-conflicts=true` database option. Tested manually.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1585
