### PR TITLE
Replace some WaitForChanges with WaitForPendingChanges for improved reliability

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2676,10 +2676,9 @@ func TestUserXattrsRawGet(t *testing.T) {
 
 	resp := rt.SendAdminRequest("PUT", "/db/"+docKey, "{}")
 	assertStatus(t, resp, http.StatusCreated)
-	_, err := rt.WaitForChanges(1, "/db/_changes", "", true)
-	assert.NoError(t, err)
+	require.NoError(t, rt.WaitForPendingChanges())
 
-	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, "val")
+	_, err := userXattrStore.WriteUserXattr(docKey, xattrKey, "val")
 	assert.NoError(t, err)
 
 	err = rt.WaitForCondition(func() bool {

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -3417,6 +3417,7 @@ func TestRevocationNoRev(t *testing.T) {
 	revID := rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"channels": "A"})
 
 	require.NoError(t, rt.WaitForPendingChanges())
+	firstOneShotSinceSeq := rt.GetDocumentSequence("doc")
 
 	// OneShot pull to grab doc
 	err = btc.StartOneshotPull()
@@ -3432,10 +3433,9 @@ func TestRevocationNoRev(t *testing.T) {
 
 	waitRevID := rt.createDocReturnRev(t, "docmarker", "", map[string]interface{}{"channels": "!"})
 	require.NoError(t, rt.WaitForPendingChanges())
-	lastSeq, err := rt.SequenceForDoc("docmarker")
-	require.NoError(t, err)
 
-	err = btc.StartPullSince("false", strconv.FormatUint(lastSeq, 10), "false")
+	lastSeqStr := strconv.FormatUint(firstOneShotSinceSeq, 10)
+	err = btc.StartPullSince("false", lastSeqStr, "false")
 	assert.NoError(t, err)
 
 	_, ok = btc.WaitForRev("docmarker", waitRevID)

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -949,8 +949,7 @@ func TestChangeWaiterExitOnChangesTermination(t *testing.T) {
 			if test.manualNotify {
 				resp = sendRequestFn(rt, test.username, http.MethodPut, "/db/doc2", `{"foo":"bar"}`)
 				assertStatus(t, resp, http.StatusCreated)
-				_, err := rt.WaitForChanges(1, "/db/_changes?since="+lastSeq, "", true)
-				assert.NoError(t, err)
+				require.NoError(t, rt.WaitForPendingChanges())
 			}
 
 			// wait for zero


### PR DESCRIPTION
Some calls to `WaitForChanges` don't use the changes feed result, and just rely on the given count for writes to come back over DCP.

In some cases (e.g `TestRevocationMessage`), the given count wasn't correct, but happened to work most of the time. Replaced with WaitForPendingChanges for easier/less error-prone waiting and remove source of flakyness.