### PR TITLE
Bump logging in TestDBOnlineWithDelayAndImmediate for flaky test diagnosis

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1872,6 +1872,8 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 


### PR DESCRIPTION
https://issues.couchbase.com/browse/CBG-1513 