### PR TITLE
Uptake fix for MB-43553 by using the GetBucket helper method

### DIFF
--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -725,12 +725,12 @@ func alternateAddressShims(loggingCtx context.Context, bucketSpecTLS bool, connS
 			}
 		}
 
-		pool, err := client.GetPool(poolName)
-		if err != nil {
-			return nil, err
+		var bucket *couchbase.Bucket
+		if auth != nil {
+			bucket, err = couchbase.ConnectWithAuthAndGetBucket(serverURL, poolName, bucketName, auth)
+		} else {
+			bucket, err = couchbase.GetBucket(serverURL, poolName, bucketName)
 		}
-
-		bucket, err := pool.GetBucket(bucketName)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The original code here didn't utilise the fix made in MB-43553 to close the pool refence once the bucket is closed.

We can't make use of the same code in the fix due to use of private methods, so we'll have to instead switch to the `GetBucket` helpers, despite already having a `couchbase.Client` available earlier to retrieve alternate addresses.

The additional cost of calling Connect twice is just one additional HTTP request, but nothing persistent. (Only `Pools` spawn background connection/processes)

- [x] https://jenkins.sgwdev.com/job/SyncGateway-Integration/78