### PR TITLE
Improve test synchronisation in some replicator tests

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -4545,8 +4545,6 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 	_, err = activeRT.GetDatabase().SGReplicateMgr.PutReplicationStatus(t.Name(), "stop")
 	require.NoError(t, err)
 	activeRT.waitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
-	err = activeRT.GetDatabase().SGReplicateMgr.DeleteReplication(t.Name())
-	require.NoError(t, err)
 
 	// Check checkpoint document was wrote to bucket with correct status
 	// _sync:local:checkpoint/sgr2cp:push:TestReplicatorCheckpointOnStop
@@ -4559,4 +4557,7 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 	err = json.Unmarshal(val, &config)
 	require.NoError(t, err)
 	assert.Equal(t, seq, config.LastSeq)
+
+	err = activeRT.GetDatabase().SGReplicateMgr.DeleteReplication(t.Name())
+	require.NoError(t, err)
 }

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -3536,10 +3536,13 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 	}, "Expecting NumConnectAttempts > 3")
 
 	assert.NoError(t, ar.Stop())
-	reconnectAttempts := ar.Pull.GetStats().NumConnectAttempts.Value()
+	waitAndRequireCondition(t, func() bool {
+		return ar.GetStatus().Status == db.ReplicationStateStopped
+	})
 
 	// wait for a bit to see if the reconnect loop has stopped
-	time.Sleep(time.Millisecond * 100)
+	reconnectAttempts := ar.Pull.GetStats().NumConnectAttempts.Value()
+	time.Sleep(time.Millisecond * 250)
 	assert.Equal(t, reconnectAttempts, ar.Pull.GetStats().NumConnectAttempts.Value())
 
 	assert.NoError(t, ar.Reset())


### PR DESCRIPTION
These failed in some unit test runs.

- `TestActiveReplicatorReconnectSendActions`: Ensure replication is stopped before calling Reset
- `TestReplicatorCheckpointOnStop`: Delete replication (which purges checkpoints) _after_ checking for checkpoint... this was racy but happened to pass most of the time

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- n/a (These tests run under Walrus)