### PR TITLE
Run inuse high-watermark check for tests

### DIFF
--- a/auth/main_test.go
+++ b/auth/main_test.go
@@ -22,7 +22,7 @@ func TestMain(m *testing.M) {
 	teardownFuncs := make([]func(), 0)
 	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestLogging(m))
 	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestProfiling(m))
-	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestMemoryWatermark(m, 2048))
+	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestMemoryWatermark(m, 512))
 
 	base.SkipPrometheusStatsRegistration = true
 

--- a/auth/main_test.go
+++ b/auth/main_test.go
@@ -18,16 +18,23 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	defer base.SetUpGlobalTestLogging(m)()
-	defer base.SetUpGlobalTestProfiling(m)()
+	// can't use defer because of os.Exit
+	teardownFuncs := make([]func(), 0)
+	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestLogging(m))
+	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestProfiling(m))
+	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestMemoryWatermark(m, 2048))
 
 	base.SkipPrometheusStatsRegistration = true
 
 	base.GTestBucketPool = base.NewTestBucketPool(base.FlushBucketEmptierFunc, base.NoopInitFunc)
+	teardownFuncs = append(teardownFuncs, base.GTestBucketPool.Close)
 
+	// Run the test suite
 	status := m.Run()
 
-	base.GTestBucketPool.Close()
+	for _, fn := range teardownFuncs {
+		fn()
+	}
 
 	os.Exit(status)
 }

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -349,9 +349,9 @@ func SetUpGlobalTestMemoryWatermark(m *testing.M, memWatermarkThresholdMB uint64
 
 		if inuseHighWatermarkMB > float64(memWatermarkThresholdMB) {
 			// Exit during teardown to fail the suite if they exceeded the threshold
-			log.Fatalf("FATAL - Test: memory watermark %.2f MB exceeded threshold (%d MB)", inuseHighWatermarkMB, memWatermarkThresholdMB)
+			log.Fatalf("FATAL - TEST: Memory watermark %.2f MB exceeded threshold (%d MB)", inuseHighWatermarkMB, memWatermarkThresholdMB)
 		} else {
-			log.Printf("Test: memory watermark %.2f MB", inuseHighWatermarkMB)
+			log.Printf("TEST: Memory watermark %.2f MB", inuseHighWatermarkMB)
 		}
 	}
 }

--- a/channels/main_test.go
+++ b/channels/main_test.go
@@ -22,7 +22,7 @@ func TestMain(m *testing.M) {
 	teardownFuncs := make([]func(), 0)
 	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestLogging(m))
 	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestProfiling(m))
-	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestMemoryWatermark(m, 2048))
+	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestMemoryWatermark(m, 128))
 
 	base.SkipPrometheusStatsRegistration = true
 

--- a/channels/main_test.go
+++ b/channels/main_test.go
@@ -18,12 +18,20 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	defer base.SetUpGlobalTestLogging(m)()
-	defer base.SetUpGlobalTestProfiling(m)()
+	// can't use defer because of os.Exit
+	teardownFuncs := make([]func(), 0)
+	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestLogging(m))
+	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestProfiling(m))
+	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestMemoryWatermark(m, 2048))
 
 	base.SkipPrometheusStatsRegistration = true
 
+	// Run the test suite
 	status := m.Run()
+
+	for _, fn := range teardownFuncs {
+		fn()
+	}
 
 	os.Exit(status)
 }

--- a/db/main_test.go
+++ b/db/main_test.go
@@ -18,16 +18,23 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	defer base.SetUpGlobalTestLogging(m)()
-	defer base.SetUpGlobalTestProfiling(m)()
+	// can't use defer because of os.Exit
+	teardownFuncs := make([]func(), 0)
+	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestLogging(m))
+	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestProfiling(m))
+	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestMemoryWatermark(m, 2048))
 
 	base.SkipPrometheusStatsRegistration = true
 
 	base.GTestBucketPool = base.NewTestBucketPool(ViewsAndGSIBucketReadier, ViewsAndGSIBucketInit)
+	teardownFuncs = append(teardownFuncs, base.GTestBucketPool.Close)
 
+	// Run the test suite
 	status := m.Run()
 
-	base.GTestBucketPool.Close()
+	for _, fn := range teardownFuncs {
+		fn()
+	}
 
 	os.Exit(status)
 }

--- a/rest/main_test.go
+++ b/rest/main_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 	teardownFuncs := make([]func(), 0)
 	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestLogging(m))
 	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestProfiling(m))
-	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestMemoryWatermark(m, 2048))
+	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestMemoryWatermark(m, 8192))
 
 	base.SkipPrometheusStatsRegistration = true
 

--- a/rest/main_test.go
+++ b/rest/main_test.go
@@ -21,16 +21,23 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	defer base.SetUpGlobalTestLogging(m)()
-	defer base.SetUpGlobalTestProfiling(m)()
+	// can't use defer because of os.Exit
+	teardownFuncs := make([]func(), 0)
+	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestLogging(m))
+	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestProfiling(m))
+	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestMemoryWatermark(m, 2048))
 
 	base.SkipPrometheusStatsRegistration = true
 
 	base.GTestBucketPool = base.NewTestBucketPool(db.ViewsAndGSIBucketReadier, db.ViewsAndGSIBucketInit)
+	teardownFuncs = append(teardownFuncs, base.GTestBucketPool.Close)
 
+	// Run the test suite
 	status := m.Run()
 
-	base.GTestBucketPool.Close()
+	for _, fn := range teardownFuncs {
+		fn()
+	}
 
 	os.Exit(status)
 }


### PR DESCRIPTION
- Periodically records inuse water mark and ensures it does not exceed a threshold after the given package's tests have finished.
- Threshold values are defined per-package, and are set to allow the current integration test high water mark (plus breathing room) but should immediately catch any obvious regressions.
- Sampling rate can be controlled with the existing `SG_TEST_PROFILE_FREQUENCY` environment variable, which will also emit heap profiles at the given frequency.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/83/
