### PR TITLE
CBD-4566, pin older SGW to SHA in build repo.  Build script in the

### DIFF
--- a/manifest/3.0.xml
+++ b/manifest/3.0.xml
@@ -24,7 +24,7 @@ licenses/APL2.txt.
 
   <!-- Build Scripts (required on CI servers) -->
   <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase">
+  <project name="build" path="cbbuild" remote="couchbase" revision="a5d50edde6a7525bdff32f8ba3127a47ac2b291e">
     <annotation name="VERSION" value="3.0.0"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>


### PR DESCRIPTION
CBD-4566

Build script in the repo will be changed to perform gomod builds starting in 3.1.0.  If we ever need to
change the build script for older releases, we can branch from this SHA.

-Ming Ho
