### PR TITLE
Clean up 'TEST: ' logging (to capture more test bucket pool logging)

### DIFF
--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -662,7 +662,7 @@ func (btc *BlipTesterClient) PushRevWithHistory(docID, parentRev string, body []
 	revRequest.Properties[db.RevMessageHistory] = strings.Join(revisionHistory, ",")
 
 	if btc.ClientDeltas && proposeChangesResponse.Properties[db.ProposeChangesResponseDeltas] == "true" {
-		base.Debugf(base.KeySync, "TEST: sending deltas from test client")
+		base.Debugf(base.KeySync, "Sending deltas from test client")
 		var parentDocJSON, newDocJSON db.Body
 		err := parentDocJSON.Unmarshal(parentDocBody)
 		if err != nil {
@@ -681,7 +681,7 @@ func (btc *BlipTesterClient) PushRevWithHistory(docID, parentRev string, body []
 		revRequest.Properties[db.RevMessageDeltaSrc] = parentRev
 		body = delta
 	} else {
-		base.Debugf(base.KeySync, "TEST: not sending deltas from client")
+		base.Debugf(base.KeySync, "Not sending deltas from test client")
 	}
 
 	revRequest.SetBody(body)


### PR DESCRIPTION
- Include the `TEST: ` log prefix in most test bucket pool fatalf logging so it's captured in the filtered integration test output.
- Remove spurious `TEST: ` logging elsewhere.