### PR TITLE
CBG-1942: Review and update REST API spec

### DIFF
--- a/docs/api/api_docs.yaml
+++ b/docs/api/api_docs.yaml
@@ -61,11 +61,11 @@ paths:
                     type: boolean
                     example: true
                   couchdb:
-                    description: ''
+                    description: 'CouchDB welcome'
                     type: string
                     example: Welcome
                   vendor:
-                    description: ''
+                    description: 'Product vendor'
                     type: object
                     properties:
                       name:
@@ -900,7 +900,7 @@ paths:
       description: This endpoint is non-functional but is present for CouchDB compatibility.
       responses:
         '201':
-          description: ''
+          description: 'OK'
           content:
             application/json:
               schema:

--- a/docs/api/api_docs.yaml
+++ b/docs/api/api_docs.yaml
@@ -1,20 +1,53 @@
-openapi: 3.0.0
+openapi: 3.0.3
 info:
-  title: Sync Gateway API
-  version: '3.0'
+  title: Sync Gateway
+  description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
+  version: 3.1.0
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'
 servers:
-  - url: 'http://localhost:4984'
+  - url: '{protocol}://{hostname}:4984'
     description: Public API
-  - url: 'http://localhost:4985'
+    variables:
+      protocol:
+        description: The protocol to use (HTTP or HTTPS)
+        default: http
+        enum:
+          - http
+          - https
+      hostname:
+        description: The hostname to use
+        default: localhost
+  - url: '{protocol}://{hostname}:4985'
     description: Admin API
-  - url: 'http://localhost:4986'
-    description: Metric API
+    variables:
+      protocol:
+        description: The protocol to use (HTTP or HTTPS)
+        default: http
+        enum:
+          - http
+          - https
+      hostname:
+        description: The hostname to use
+        default: localhost
+  - url: '{protocol}://{hostname}:4986'
+    description: Metrics API
+    variables:
+      protocol:
+        description: The protocol to use (HTTP or HTTPS)
+        default: http
+        enum:
+          - http
+          - https
+      hostname:
+        description: The hostname to use
+        default: localhost
 paths:
   /:
     get:
+      summary: Get server information
+      description: Returns information about the Sync Gateway node.
       responses:
         '200':
           description: Returned server information
@@ -24,28 +57,41 @@ paths:
                 type: object
                 properties:
                   ADMIN:
+                    description: '`true` if the request is from the Admin API - otherwise omitted.'
                     type: boolean
-                    description: Whether the request is from the Admin API (`true`) or the Public API (`false`).
+                    example: true
                   couchdb:
+                    description: ''
                     type: string
-                    default: Welcome
+                    example: Welcome
                   vendor:
-                    $ref: '#/components/schemas/Vendor'
+                    description: ''
+                    type: object
+                    properties:
+                      name:
+                        description: Product name
+                        type: string
+                        example: Couchbase Sync Gateway
+                      version:
+                        description: |-
+                          API version.
+                          Omitted if `api.hide_product_version=true`
+                        type: string
+                        example: 3.1
+                    required:
+                      - name
                   version:
-                    type: string
                     description: |-
-                      The product version including the build number and edition (ie. `EE` or `CE`).
-
-                      Blank if `api.hide_product_version=true` in the startup configuration.
+                      Product version, including the build number and edition (i.e. `EE` or `CE`)
+                      Omitted if `api.hide_product_version=true`
+                    type: string
+                    example: Couchbase Sync Gateway/3.1.0(1;a765231) EE
                 required:
-                  - ADMIN
                   - couchdb
                   - vendor
       tags:
         - Admin
         - Public
-      summary: Get server information
-      description: This will return information about the server.
     head:
       responses:
         '200':
@@ -59,6 +105,8 @@ paths:
     parameters:
       - $ref: '#/components/parameters/db'
     get:
+      summary: Get database information
+      description: Retrieve information about the database.
       responses:
         '200':
           description: Successfully returned database information
@@ -68,62 +116,71 @@ paths:
                 type: object
                 properties:
                   db_name:
-                    type: string
                     description: Database name
+                    type: string
+                    example: db
                   update_seq:
-                    type: number
                     description: |-
-                      The last sequence number that was committed to the database. This is the number of updates to the database.
+                      The last sequence number that was committed to the database.
 
                       Will return 0 if the database is offline.
-                  committed_update_seq:
-                    type: number
-                    description: |-
-                      The last sequence number that was committed to the database. This is the number of updates to the database.
-
-                      Will return 0 if the database is offline.
-                  instance_start_time:
                     type: integer
-                    description: Date and time the database was opened in microseconds since 1st January 1970.
+                    example: 123456
+                  committed_update_seq:
+                    description: |-
+                      The last sequence number that was committed to the database.
+
+                      Will return 0 if the database is offline.
+                    type: integer
+                    example: 123456
+                  instance_start_time:
+                    description: 'Timestamp of when the database opened, in microseconds since the Unix epoch.'
+                    type: integer
+                    example: 1644600082279583
                   compact_running:
-                    type: boolean
                     description: Indicates whether database compaction is currently taking place or not.
+                    type: boolean
                   purge_seq:
-                    type: number
                     description: Unused field.
+                    type: number
                     default: 0
                   disk_format_version:
-                    type: number
                     description: Unused field.
+                    type: number
                     default: 0
                   state:
+                    description: 'The database state. Change using the `/{db}/_offline` and `/{db}/_online` endpoints.'
                     type: string
                     enum:
                       - Online
                       - Offline
-                    description: |-
-                      Whether the database is in an offline or online state.
-
-                      The database state can be changed by using the `/{db}/_offline` and `/{db}/_online` endpoints.
                   server_uuid:
+                    description: Unique server identifier.
                     type: string
-                    description: Unique server identifier. This is the same for all databases on the Sync Gateway node.
-              examples: {}
+                    example: 995618a6a6cc9ac79731bd13240e19b5
         '404':
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
         - Public
-      description: Retrieve information about the database.
-      summary: Get database information
     post:
+      summary: Create a new document
+      description: |-
+        Create a new document in the database.
+
+        This will generate a random document ID unless specified in the body.
+
+        A document can have a maximum size of 20MB.
+      parameters:
+        - $ref: '#/components/parameters/roundtrip'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Document'
       responses:
         '200':
-          description: New revision created sucessfully.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/New-revision'
+          description: New document revision created successfully.
           headers:
             Etag:
               schema:
@@ -133,6 +190,10 @@ paths:
               schema:
                 type: string
               description: The document ID of the newly created document.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/New-revision'
         '400':
           $ref: '#/components/responses/request-problem'
         '404':
@@ -144,21 +205,12 @@ paths:
       tags:
         - Admin
         - Public
-      summary: Create a new document
-      description: |-
-        Create a new document in the database.
-
-        This will generate a random document ID unless specified in the body.
-
-        A document can have a maximum size of 20MB.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Document'
-      parameters:
-        - $ref: '#/components/parameters/roundtrip'
     delete:
+      summary: Remove a database
+      description: |-
+        Removes a database from the Sync Gateway cluster
+
+        **Note:** If running in legacy mode, this will only delete the database from the current node.
       responses:
         '200':
           description: Successfully removed the database
@@ -177,12 +229,9 @@ paths:
                 $ref: '#/components/schemas/HTTP-Error'
       tags:
         - Admin
-      description: |-
-        Delete a database configuration from the bucket and remove it from the current node.
-
-        **Note:** If running in legacy mode, this will only delete the database from the current node.
-      summary: Remove a database
     head:
+      summary: Check if database exists
+      description: Check if a database exists by using the response status code.
       responses:
         '200':
           description: Database exists
@@ -191,9 +240,22 @@ paths:
       tags:
         - Admin
         - Public
-      summary: Check if database exists
-      description: Check if a database exists by using the response status code.
     put:
+      summary: Create a new Sync Gateway database
+      description: |-
+        This is to create a new database for Sync Gateway.
+
+        The new database name will be the name specified in the URL, not what is specified in the request body database configuration.
+
+        If the bucket is not provided in the database configuration, Sync Gateway will attempt to find and use the database name as the bucket.
+
+        By default, the new database will be brought online immediately. This can be avoided by including `"offline": true` in the configuration in the request body.
+      requestBody:
+        description: The configuration to use for the new database
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Database'
       responses:
         '201':
           description: Database created successfully
@@ -225,35 +287,12 @@ paths:
                 $ref: '#/components/schemas/HTTP-Error'
       tags:
         - Admin
-      summary: Create a new Sync Gateway database
-      description: |-
-        This is to create a new database for Sync Gateway. 
-
-        The new database name will be the name specified in the URL, not what is specified in the request body database configuration.
-
-        If the bucket is not provided in the database configuration, Sync Gateway will attempt to find and use the database name as the bucket.
-
-        By default, the new database will be brought online immediately. This can be avoided by including `"offline": true` in the configuration in the request body.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Database'
-        description: The configuration to use for the new database
   '/{db}/_all_docs':
     parameters:
       - $ref: '#/components/parameters/db'
     get:
-      responses:
-        '200':
-          $ref: '#/components/responses/all-docs'
-        '400':
-          $ref: '#/components/responses/request-problem'
-        '404':
-          $ref: '#/components/responses/Not-found'
-      tags:
-        - Admin
-        - Public
+      summary: Gets all the documents in the database with the given parameters
+      description: Returns all documents in the databased based on the specified parameters.
       parameters:
         - $ref: '#/components/parameters/include_docs'
         - $ref: '#/components/parameters/Include-channels'
@@ -264,9 +303,6 @@ paths:
         - $ref: '#/components/parameters/startkey'
         - $ref: '#/components/parameters/endkey'
         - $ref: '#/components/parameters/limit'
-      summary: Gets all the documents in the database with the given parameters
-      description: Returns all documents in the databased based on the specified parameters.
-    post:
       responses:
         '200':
           $ref: '#/components/responses/all-docs'
@@ -277,7 +313,9 @@ paths:
       tags:
         - Admin
         - Public
+    post:
       summary: Get all the documents in the database using a built-in view
+      description: Get a built-in view of all the documents in the database.
       parameters:
         - $ref: '#/components/parameters/include_docs'
         - $ref: '#/components/parameters/Include-channels'
@@ -300,7 +338,16 @@ paths:
                     type: string
               required:
                 - keys
-      description: Get a built-in view of all the documents in the database.
+      responses:
+        '200':
+          $ref: '#/components/responses/all-docs'
+        '400':
+          $ref: '#/components/responses/request-problem'
+        '404':
+          $ref: '#/components/responses/Not-found'
+      tags:
+        - Admin
+        - Public
     head:
       responses:
         '200':
@@ -326,6 +373,42 @@ paths:
     parameters:
       - $ref: '#/components/parameters/db'
     post:
+      summary: Bulk document operations
+      description: |-
+        This will allow multiple documented to be created, updated or deleted in bulk.
+
+        To create a new document, simply add the body in an object under `docs`. A doc ID will be generated by Sync Gateway unless `_id` is specified.
+
+        To update an existing document, provide the document ID (`_id`) and revision ID (`_rev`) as well as the new body values.
+
+        To delete an existing document, provide the document ID (`_id`), revision ID (`_rev`), and set the deletion flag (`_deleted`) to true.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                new_edits:
+                  description: This controls whether to assign new revision identifiers to new edits (`true`) or use the existing ones (`false`).
+                  type: boolean
+                  default: true
+                docs:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Document'
+              required:
+                - docs
+            example:
+              new_edits: true
+              docs:
+                - _id: FooBar
+                  foo: bar
+                - _id: AliceSettings
+                  _rev: 5-832a6db48ed130adadede928aee54576
+                  FailedLoginAttempts: 7
+                - _id: BobSettings
+                  _rev: 1-fa76ba41ee5fdfee1b91fc478ed09e59
+                  _deleted: true
       responses:
         '201':
           description: |-
@@ -336,27 +419,27 @@ paths:
             application/json:
               schema:
                 type: array
-                uniqueItems: true
                 items:
                   type: object
                   properties:
                     id:
-                      type: string
                       description: The ID of the document that the operation was performed on.
+                      type: string
                     rev:
-                      type: string
                       description: The new revision of the document if the operation was a success.
+                      type: string
                     error:
-                      type: string
                       description: The error type if the operation of the document failed.
+                      type: string
                     reason:
-                      type: string
                       description: The reason the operation failed.
-                    status:
                       type: string
+                    status:
                       description: The HTTP status code for why the operation failed.
+                      type: string
                   required:
                     - id
+                uniqueItems: true
               examples:
                 Success:
                   value:
@@ -385,81 +468,42 @@ paths:
       tags:
         - Admin
         - Public
-      summary: Bulk document operations
-      description: |-
-        This will allow multiple documented to be created, updated or deleted in bulk.
-
-        To create a new document, simply add the body in an object under `docs`. A doc ID will be generated by Sync Gateway unless `_id` is specified.
-
-        To update an existing document, provide the document ID (`_id`) and revision ID (`_rev`) as well as the new body values.
-
-        To delete an existing document, provide the document ID (`_id`), revision ID (`_rev`), and set the deletion flag (`_deleted`) to true.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                new_edits:
-                  default: true
-                  type: boolean
-                  description: This controls whether to assign new revision identifiers to new edits (`true`) or use the existing ones (`false`).
-                docs:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/Document'
-              required:
-                - docs
-            examples:
-              Example:
-                value:
-                  new_edits: true
-                  docs:
-                    - _id: FooBar
-                      foo: bar
-                    - _id: AliceSettings
-                      _rev: 5-832a6db48ed130adadede928aee54576
-                      FailedLoginAttempts: 7
-                    - _id: BobSettings
-                      _rev: 1-fa76ba41ee5fdfee1b91fc478ed09e59
-                      _deleted: true
   '/{db}/_bulk_get':
     parameters:
       - $ref: '#/components/parameters/db'
     post:
-      responses:
-        '200':
-          description: Returned the requested docs as `multipart/mixed` response type
-        '400':
-          description: Bad Request
-        '404':
-          $ref: '#/components/responses/Not-found'
-      tags:
-        - Admin
-        - Public
+      summary: Get multiple documents in a MIME multipart response
+      description: |
+        This request returns any number of documents, as individual bodies in a MIME multipart response.
+
+        Each enclosed body contains one requested document. The bodies appear in the same order as in the request, but can also be identified by their `X-Doc-ID` and `X-Rev-ID` headers (if the `attachments` query is `true`).
+
+        A body for a document with no attachments will have content type `application/json` and contain the document itself.
+
+        A body for a document that has attachments will be written as a nested `multipart/related` body.
       parameters:
         - name: attachments
           in: query
+          description: This is for whether to include attachments in each of the documents returned or not.
           schema:
             type: boolean
             default: 'false'
-          description: This is for whether to include attachments in each of the documents returned or not.
         - $ref: '#/components/parameters/include-revs'
         - name: revs_limit
-          schema:
-            type: integer
           in: query
           description: The number of revisions to include in the response from the document history. This parameter only makes a different if the `revs` query parameter is set to `true`. The full revision history will be returned if `revs` is set but this is not.
-        - name: X-Accept-Part-Encoding
           schema:
-            type: string
+            type: integer
+        - name: X-Accept-Part-Encoding
           in: header
           description: If this header includes `gzip` then the part HTTP compression encoding will be done.
-        - name: Accept-Encoding
           schema:
             type: string
+        - name: Accept-Encoding
           in: header
           description: If this header includes `gzip` then the the HTTP response will be compressed. This takes priority over `X-Accept-Part-Encoding`. Only part compression will be done if `X-Accept-Part-Encoding=gzip` and the `User-Agent` is below 1.2 due to clients not being able to handle full compression.
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -472,110 +516,106 @@ paths:
                     type: object
                     properties:
                       id:
-                        type: string
                         description: ID of the document to retrieve.
+                        type: string
                     required:
                       - id
               required:
                 - docs
-            examples:
-              Example:
-                value:
-                  docs:
-                    - id: FooBar
-                    - id: attachment
-                    - id: AliceSettings
-      description: |
-        This request returns any number of documents, as individual bodies in a MIME multipart response.
-
-        Each enclosed body contains one requested document. The bodies appear in the same order as in the request, but can also be identified by their `X-Doc-ID` and `X-Rev-ID` headers (if the `attachments` query is `true`).
-
-        A body for a document with no attachments will have content type `application/json` and contain the document itself.
-
-        A body for a document that has attachments will be written as a nested `multipart/related` body.
-      summary: Get multiple documents in a MIME multipart response
-  '/{db}/_changes':
-    parameters:
-      - $ref: '#/components/parameters/db'
-    get:
+            example:
+              docs:
+                - id: FooBar
+                - id: attachment
+                - id: AliceSettings
       responses:
         '200':
-          $ref: '#/components/responses/changes-feed'
+          description: Returned the requested docs as `multipart/mixed` response type
         '400':
-          $ref: '#/components/responses/request-problem'
+          description: Bad Request
         '404':
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
         - Public
+  '/{db}/_changes':
+    parameters:
+      - $ref: '#/components/parameters/db'
+    get:
       summary: Get changes list
       description: |-
-        This request retrieves a sorted list of changes made to documents in the database, in time order of application. Each document appears at most once, ordered by its most recent change, regardless of how many times it’s been changed.
+        This request retrieves a sorted list of changes made to documents in the database, in time order of application. Each document appears at most once, ordered by its most recent change, regardless of how many times it has been changed.
 
         This request can be used to listen for update and modifications to the database for post processing or synchronization. A continuously connected changes feed is a reasonable approach for generating a real-time log for most applications.
       parameters:
         - name: limit
           in: query
+          description: Maximum number of changes to return.
           schema:
             type: integer
-          description: Maximum number of changes to return.
+        - name: since
+          in: query
+          description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
+          schema:
+            type: string
         - name: style
+          in: query
+          description: Controls whether to return the current winning revision (`main_only`) or all the leaf revision including conflicts and deleted former conflicts (`all_docs`).
           schema:
             type: string
             default: main_only
             enum:
               - main_only
               - all_docs
-          in: query
-          description: Controls whether to return the current winning revision (`main_only`) or all the leaf revision including conflicts and deleted former conflicts (`all_docs`).
         - name: active_only
+          in: query
+          description: Set true to exclude deleted documents and notifications for documents the user no longer has access to from the changes feed.
           schema:
             type: boolean
             default: 'false'
-          in: query
-          description: Set true to exclude deleted documents and notifications for documents the user no longer has access to from the changes feed.
         - $ref: '#/components/parameters/include_docs'
         - name: revocations
-          schema:
-            type: boolean
           in: query
           description: 'If true, revocation messages will be sent on the changes feed.'
+          schema:
+            type: boolean
         - name: filter
+          in: query
+          description: Set a filter to either filter by channels or document IDs.
           schema:
             type: string
             enum:
               - sync_gateway/bychannel
               - _doc_ids
-          in: query
-          description: Set a filter to either filter by channels or document IDs.
         - name: channels
-          schema:
-            type: string
           in: query
           description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannels`.'
+          schema:
+            type: string
         - name: doc_ids
+          in: query
+          description: 'A valid JSON array of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`. Also accepts a comma separated list of document IDs instead.'
           schema:
             type: array
             items:
               type: string
-          in: query
-          description: 'A valid JSON array of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`. Also accepts a comma separated list of document IDs instead.'
         - name: heartbeat
+          in: query
+          description: The interval (in milliseconds) to send an empty line (CRLF) in the response. This is to help prevent gateways from deciding the socket is idle and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`. This will override any timeouts to keep the feed alive indefinitely. Setting to 0 results in no heartbeat. The maximum heartbeat can be set in the server replication configuration.
           schema:
             type: integer
             default: 0
             minimum: 25000
-          in: query
-          description: The interval (in milliseconds) to send an empty line (CRLF) in the response. This is to help prevent gateways from deciding the socket is idle and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`. This will override any timeouts to keep the feed alive indefinitely. Setting to 0 results in no heartbeat. The maximum heartbeat can be set in the server replication configuration.
         - name: timeout
+          in: query
+          description: 'This is the maximum period (in milliseconds) to wait for a change before the response is sent, even if there are no results. This is only applicable for `feed=longpoll` or `feed=continuous` changes feeds. Setting to 0 results in no timeout.'
           schema:
             type: integer
             default: 300000
             maximum: 900000
             minimum: 0
-          in: query
-          description: 'This is the maximum period (in milliseconds) to wait for a change before the response is sent, even if there are no results. This is only applicable for `feed=longpoll` or `feed=continuous` changes feeds. Setting to 0 results in no timeout.'
         - name: feed
+          in: query
+          description: 'The type of changes feed to use. '
           schema:
             type: string
             default: normal
@@ -584,9 +624,6 @@ paths:
               - longpoll
               - continuous
               - websocket
-          in: query
-          description: 'The type of changes feed to use. '
-    post:
       responses:
         '200':
           $ref: '#/components/responses/changes-feed'
@@ -597,9 +634,10 @@ paths:
       tags:
         - Admin
         - Public
+    post:
       summary: Get changes list
       description: |-
-        This request retrieves a sorted list of changes made to documents in the database, in time order of application. Each document appears at most once, ordered by its most recent change, regardless of how many times it’s been changed.
+        This request retrieves a sorted list of changes made to documents in the database, in time order of application. Each document appears at most once, ordered by its most recent change, regardless of how many times it has been changed.
 
         This request can be used to listen for update and modifications to the database for post processing or synchronization. A continuously connected changes feed is a reasonable approach for generating a real-time log for most applications.
       requestBody:
@@ -609,38 +647,48 @@ paths:
               type: object
               properties:
                 limit:
-                  type: string
                   description: Maximum number of changes to return.
+                  type: string
                 style:
-                  type: string
                   description: Controls whether to return the current winning revision (`main_only`) or all the leaf revision including conflicts and deleted former conflicts (`all_docs`).
+                  type: string
                 active_only:
-                  type: string
                   description: Set true to exclude deleted documents and notifications for documents the user no longer has access to from the changes feed.
+                  type: string
                 include_docs:
-                  type: string
                   description: Include the body associated with each document.
+                  type: string
                 revocations:
-                  type: string
                   description: 'If true, revocation messages will be sent on the changes feed.'
+                  type: string
                 filter:
-                  type: string
                   description: Set a filter to either filter by channels or document IDs.
+                  type: string
                 channels:
-                  type: string
                   description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannels`.'
+                  type: string
                 doc_ids:
-                  type: string
                   description: 'A valid JSON array of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`.'
+                  type: string
                 heartbeat:
-                  type: string
                   description: The interval (in milliseconds) to send an empty line (CRLF) in the response. This is to help prevent gateways from deciding the socket is idle and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`. This will override any timeouts to keep the feed alive indefinitely. Setting to 0 results in no heartbeat. The maximum heartbeat can be set in the server replication configuration.
+                  type: string
                 timeout:
-                  type: string
                   description: 'This is the maximum period (in milliseconds) to wait for a change before the response is sent, even if there are no results. This is only applicable for `feed=longpoll` or `feed=continuous` changes feeds. Setting to 0 results in no timeout.'
-                feed:
                   type: string
+                feed:
                   description: 'The type of changes feed to use. '
+                  type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/changes-feed'
+        '400':
+          $ref: '#/components/responses/request-problem'
+        '404':
+          $ref: '#/components/responses/Not-found'
+      tags:
+        - Admin
+        - Public
     head:
       responses:
         '200':
@@ -657,6 +705,10 @@ paths:
       - $ref: '#/components/parameters/db'
       - $ref: '#/components/parameters/ddoc'
     get:
+      summary: Get views of a design document | Unsupported
+      description: |-
+        **This is unsupported**
+        Query a design document.
       responses:
         '200':
           description: Successfully returned design document.
@@ -671,11 +723,16 @@ paths:
       tags:
         - Admin
         - Public
-      summary: Get views of a design document | Unsupported
+    put:
+      summary: Update views of a design document | Unsupported
       description: |-
         **This is unsupported**
-        Query a design document.
-    put:
+        Update the views of a design document.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Design-doc'
       responses:
         '200':
           description: Design document changes successfully
@@ -686,16 +743,11 @@ paths:
       tags:
         - Admin
         - Public
-      summary: Update views of a design document | Unsupported
+    delete:
+      summary: Delete a design document | Unsupported
       description: |-
         **This is unsupported**
-        Update the views of a design document.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Design-doc'
-    delete:
+        Delete a design document.
       responses:
         '200':
           description: Design document deleted successfully
@@ -706,10 +758,6 @@ paths:
       tags:
         - Admin
         - Public
-      description: |-
-        **This is unsupported**
-        Delete a design document.
-      summary: Delete a design document | Unsupported
     head:
       responses:
         '200':
@@ -731,6 +779,77 @@ paths:
       - $ref: '#/components/parameters/ddoc'
       - $ref: '#/components/parameters/view'
     get:
+      summary: Query a view on a design document | Unsupported
+      description: |-
+        **This is unsupported**
+        Query a view on a design document.
+      parameters:
+        - name: inclusive_end
+          in: query
+          description: Indicates whether the specified end key should be included in the result.
+          schema:
+            type: boolean
+        - name: descending
+          in: query
+          description: Return documents in descending order.
+          schema:
+            type: boolean
+        - name: include_docs
+          in: query
+          description: Only works when using Couchbase Server 3.0 and earlier. Indicates whether to include the full content of the documents in the response.
+          schema:
+            type: boolean
+        - name: reduce
+          in: query
+          description: Whether to execute a reduce function on the response or not.
+          schema:
+            type: boolean
+        - name: group
+          in: query
+          description: Group the results using the reduce function to a group or single row.
+          schema:
+            type: boolean
+        - name: skip
+          in: query
+          description: Skip the specified number of documents before starting to return results.
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: Return only the specified number of documents
+          schema:
+            type: integer
+        - name: group_level
+          in: query
+          description: Specify the group level to be used.
+          schema:
+            type: integer
+        - name: startkey_docid
+          in: query
+          description: Return documents starting with the specified document identifier.
+          schema:
+            type: string
+        - name: endkey_docid
+          in: query
+          description: Stop returning records when the specified document identifier is reached.
+          schema:
+            type: string
+        - name: stale
+          in: query
+          description: 'Allow the results from a stale view to be used, without triggering a rebuild of all views within the encompassing design document.'
+          schema:
+            type: string
+            enum:
+              - ok
+              - update_after
+        - $ref: '#/components/parameters/startkey'
+        - $ref: '#/components/parameters/endkey'
+        - name: key
+          in: query
+          description: Return only the document that matches the specified key.
+          schema:
+            type: string
+        - $ref: '#/components/parameters/keys'
       responses:
         '200':
           description: Returned view successfully
@@ -773,81 +892,12 @@ paths:
       tags:
         - Admin
         - Public
-      parameters:
-        - name: inclusive_end
-          schema:
-            type: boolean
-          in: query
-          description: Indicates whether the specified end key should be included in the result.
-        - name: descending
-          schema:
-            type: boolean
-          in: query
-          description: Return documents in descending order.
-        - name: include_docs
-          in: query
-          schema:
-            type: boolean
-          description: Only works when using Couchbase Server 3.0 and earlier. Indicates whether to include the full content of the documents in the response.
-        - name: reduce
-          schema:
-            type: boolean
-          in: query
-          description: Whether to execute a reduce function on the response or not.
-        - name: group
-          schema:
-            type: boolean
-          in: query
-          description: Group the results using the reduce function to a group or single row.
-        - name: skip
-          schema:
-            type: integer
-          in: query
-          description: Skip the specified number of documents before starting to return results.
-        - name: limit
-          in: query
-          schema:
-            type: integer
-          description: Return only the specified number of documents
-        - name: group_level
-          schema:
-            type: integer
-          in: query
-          description: Specify the group level to be used.
-        - name: startkey_docid
-          schema:
-            type: string
-          in: query
-          description: Return documents starting with the specified document identifier.
-        - name: endkey_docid
-          schema:
-            type: string
-          in: query
-          description: Stop returning records when the specified document identifier is reached.
-        - name: stale
-          schema:
-            type: string
-            enum:
-              - ok
-              - update_after
-          in: query
-          description: 'Allow the results from a stale view to be used, without triggering a rebuild of all views within the encompassing design document.'
-        - $ref: '#/components/parameters/startkey'
-        - $ref: '#/components/parameters/endkey'
-        - name: key
-          schema:
-            type: string
-          in: query
-          description: Return only the document that matches the specified key.
-        - $ref: '#/components/parameters/keys'
-      description: |-
-        **This is unsupported**
-        Query a view on a design document.
-      summary: Query a view on a design document | Unsupported
   '/{db}/_ensure_full_commit':
     parameters:
       - $ref: '#/components/parameters/db'
     post:
+      summary: ''
+      description: This endpoint is non-functional but is present for CouchDB compatibility.
       responses:
         '201':
           description: ''
@@ -857,9 +907,13 @@ paths:
                 type: object
                 properties:
                   instance_start_time:
+                    description: 'Timestamp of when the database opened, in microseconds since the Unix epoch.'
                     type: integer
+                    example: 1644600082279583
                   ok:
                     type: boolean
+                    example: true
+                    default: true
       tags:
         - Admin
         - Public
@@ -867,6 +921,19 @@ paths:
     parameters:
       - $ref: '#/components/parameters/db'
     post:
+      summary: Compare revisions to what is in the database
+      description: 'Takes a set of document IDs, each with a set of revision IDs. For each document, an array of unknown revisions are returned with an array of known revisions that may be recent ancestors.'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                docid:
+                  description: The document ID with an array of revisions to use for the comparison.
+                  type: array
+                  items:
+                    type: string
       responses:
         '200':
           description: Comparisons successful
@@ -876,17 +943,17 @@ paths:
                 type: object
                 properties:
                   docid:
-                    type: object
                     description: The document ID.
+                    type: object
                     properties:
                       missing:
-                        type: array
                         description: The revisions that are not in the database (and therefore `missing`).
+                        type: array
                         items:
                           type: string
                       possible_ancestors:
-                        type: array
                         description: An array of known revisions that might be the recent ancestors.
+                        type: array
                         items:
                           type: string
         '404':
@@ -894,32 +961,21 @@ paths:
       tags:
         - Admin
         - Public
-      summary: Compare revisions to whats in the database
-      description: |-
-        This is used by the replicator to detect which revisions Sync Gateway does not have. 
-
-        This takes the document IDs with each having set of revision IDs, then this is used to look up which revisions do not corrospond to what's in the database. An array of the unknown revisions are returned, and an array of known revisions that might be recent ancestors for each of the documents.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                docid:
-                  type: array
-                  description: The document ID with an array of revisions to use for the comparison.
-                  items:
-                    type: string
   '/{db}/_local/{docid}':
     parameters:
       - $ref: '#/components/parameters/db'
-      - schema:
-          type: string
-        name: docid
+      - name: docid
         in: path
-        required: true
         description: The name of the local document ID excluding the `_local/` prefix.
+        required: true
+        schema:
+          type: string
     get:
+      summary: Get local document
+      description: |-
+        This request retrieves a local document.
+
+        Local document IDs begin with `_local/`. Local documents are not replicated or indexed, don't support attachments, and don't save revision histories. In practice they are almost only used by Couchbase Lite's replicator, as a place to store replication checkpoint data.
       responses:
         '200':
           description: Successfully found local document
@@ -930,15 +986,25 @@ paths:
       tags:
         - Admin
         - Public
-      description: |-
-        This request retrieves a local document. 
-
-        Local document IDs begin with `_local/`. Local documents are not replicated or indexed, don’t support attachments, and don’t save revision histories. In practice they are almost only used by Couchbase Lite’s replicator, as a place to store replication checkpoint data.
-      summary: Get local document
     put:
+      summary: Upsert a local document
+      description: |-
+        This request creates or updates a local document. Updating a local document requires that the revision ID be put in the body under `_rev`.
+
+        Local document IDs are given a `_local/` prefix. Local documents are not replicated or indexed, don't support attachments, and don't save revision histories. In practice they are almost only used by the client's replicator, as a place to store replication checkpoint data.
+      requestBody:
+        description: The body of the document
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                _rev:
+                  description: Revision to replace. Required if updating existing local document.
+                  type: string
       responses:
         '201':
-          description: Document successfully upserted. The document ID will be prefixed with `_local/`.
+          description: Document successfully written. The document ID will be prefixed with `_local/`.
           content:
             application/json:
               schema:
@@ -952,22 +1018,18 @@ paths:
       tags:
         - Admin
         - Public
-      description: |-
-        This request creates or updates a local document. Updating a local document requires that the revision ID be put in the body under `_rev`.
-
-        Local document IDs are given a `_local/` prefix. Local documents are not replicated or indexed, don’t support attachments, and don’t save revision histories. In practice they are almost only used by the client’s replicator, as a place to store replication checkpoint data.
-      summary: Upsert a local document
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                _rev:
-                  type: string
-                  description: Revision to replace. Required if updating existing local document.
-        description: The body of the document
     delete:
+      description: |-
+        This request deletes a local document.
+
+        Local document IDs begin with `_local/`. Local documents are not replicated or indexed, don't support attachments, and don't save revision histories. In practice they are almost only used by Couchbase Lite's replicator, as a place to store replication checkpoint data.
+      parameters:
+        - name: rev
+          in: query
+          description: The revision ID of the revision to delete.
+          required: true
+          schema:
+            type: string
       responses:
         '200':
           description: Successfully removed the local document.
@@ -980,17 +1042,6 @@ paths:
       tags:
         - Admin
         - Public
-      description: |-
-        This request deletes a local document.
-
-        Local document IDs begin with `_local/`. Local documents are not replicated or indexed, don’t support attachments, and don’t save revision histories. In practice they are almost only used by Couchbase Lite’s replicator, as a place to store replication checkpoint data.
-      parameters:
-        - schema:
-            type: string
-          in: query
-          name: rev
-          description: The revision ID of the revision to delete.
-          required: true
     head:
       responses:
         '200':
@@ -1006,12 +1057,23 @@ paths:
       description: |-
         This request checks if a local document exists. 
 
-        Local document IDs begin with `_local/`. Local documents are not replicated or indexed, don’t support attachments, and don’t save revision histories. In practice they are almost only used by Couchbase Lite’s replicator, as a place to store replication checkpoint data.
+        Local document IDs begin with `_local/`. Local documents are not replicated or indexed, don't support attachments, and don't save revision histories. In practice they are almost only used by Couchbase Lite's replicator, as a place to store replication checkpoint data.
   '/{db}/{docid}':
     parameters:
       - $ref: '#/components/parameters/db'
       - $ref: '#/components/parameters/docid'
     get:
+      summary: Get a document
+      description: Retrieve a document from the database by its doc ID.
+      parameters:
+        - $ref: '#/components/parameters/rev'
+        - $ref: '#/components/parameters/open_revs'
+        - $ref: '#/components/parameters/show_exp'
+        - $ref: '#/components/parameters/revs_from'
+        - $ref: '#/components/parameters/atts_since'
+        - $ref: '#/components/parameters/revs_limit'
+        - $ref: '#/components/parameters/includeAttachments'
+        - $ref: '#/components/parameters/replicator2'
       responses:
         '200':
           description: Document found and returned successfully
@@ -1026,19 +1088,17 @@ paths:
                 type: object
                 properties:
                   _id:
-                    type: string
                     description: The ID of the document.
-                  _rev:
                     type: string
+                  _rev:
                     description: The revision ID of the document.
-              examples:
-                Example with no optional fields filled:
-                  value:
-                    FailedLoginAttempts: 5
-                    Friends:
-                      - Bob
-                    _id: AliceSettings
-                    _rev: 1-64d4a1f179db5c1848fe52967b47c166
+                    type: string
+              example:
+                FailedLoginAttempts: 5
+                Friends:
+                  - Bob
+                _id: AliceSettings
+                _rev: 1-64d4a1f179db5c1848fe52967b47c166
         '400':
           $ref: '#/components/responses/invalid-doc-id'
         '404':
@@ -1052,41 +1112,8 @@ paths:
       tags:
         - Admin
         - Public
-      summary: Get a document
-      parameters:
-        - $ref: '#/components/parameters/rev'
-        - $ref: '#/components/parameters/open_revs'
-        - $ref: '#/components/parameters/show_exp'
-        - $ref: '#/components/parameters/revs_from'
-        - $ref: '#/components/parameters/atts_since'
-        - $ref: '#/components/parameters/revs_limit'
-        - $ref: '#/components/parameters/includeAttachments'
-        - $ref: '#/components/parameters/replicator2'
-      description: Retrieve a document from the database by it's doc ID.
     put:
-      responses:
-        '201':
-          description: Created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/New-revision'
-          headers:
-            Etag:
-              schema:
-                type: string
-              description: The revision of the upserted document. Not set if query option `new_edits` is true.
-        '400':
-          $ref: '#/components/responses/request-problem'
-        '404':
-          $ref: '#/components/responses/Not-found'
-        '409':
-          $ref: '#/components/responses/Conflict'
-        '415':
-          $ref: '#/components/responses/Invalid-content-type'
-      tags:
-        - Admin
-        - Public
+      summary: Upsert a document
       description: |-
         This will upsert a document meaning if it does not exist, then it will be created. Otherwise a new revision will be made for the existing document. A revision ID must be provided if targetting an existing document.
 
@@ -1101,13 +1128,43 @@ paths:
         - $ref: '#/components/parameters/new_edits'
         - $ref: '#/components/parameters/rev'
         - $ref: '#/components/parameters/If-Match'
-      summary: Upsert a document
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/Document'
+      responses:
+        '201':
+          description: Created
+          headers:
+            Etag:
+              schema:
+                type: string
+              description: The revision of the written document. Not set if query option `new_edits` is true.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/New-revision'
+        '400':
+          $ref: '#/components/responses/request-problem'
+        '404':
+          $ref: '#/components/responses/Not-found'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '415':
+          $ref: '#/components/responses/Invalid-content-type'
+      tags:
+        - Admin
+        - Public
     delete:
+      summary: Delete a document
+      description: |-
+        Delete a document from the database. A new revision is created so the database can track the deletion in synchronized copies.
+
+        A revision ID either in the header or on the query parameters is required.
+      parameters:
+        - $ref: '#/components/parameters/rev'
+        - $ref: '#/components/parameters/If-Match'
       responses:
         '200':
           $ref: '#/components/responses/New-revision'
@@ -1118,14 +1175,6 @@ paths:
       tags:
         - Admin
         - Public
-      summary: Delete a document
-      description: |-
-        Delete a document from the database. A new revision is created so the database can track the deletion in synchronized copies.
-
-        A revision ID either in the header or on the query parameters is required.
-      parameters:
-        - $ref: '#/components/parameters/rev'
-        - $ref: '#/components/parameters/If-Match'
     head:
       responses:
         '200':
@@ -1153,12 +1202,39 @@ paths:
       - $ref: '#/components/parameters/db'
       - $ref: '#/components/parameters/docid'
       - name: attach
+        in: path
+        description: 'The attachment name. This value must be URL encoded. For example, if the attachment name is `blob_/avatar`, the path component passed to the URL should be `blob_%2Favatar` (tested with [URLEncoder](https://www.urlencoder.org/)).'
+        required: true
         schema:
           type: string
-        in: path
-        required: true
-        description: 'The attachment name. This value must be URL encoded. For example, if the attachment name is `blob_/avatar`, the path component passed to the URL should be `blob_%2Favatar` (tested with [URLEncoder](https://www.urlencoder.org/)).'
     get:
+      summary: Get an attachment from a document
+      description: |-
+        This request retrieves a file attachment associated with the document. 
+
+        The raw data of the associated attachment is returned (just as if you were accessing a static file). The `Content-Type` response header is the same content type set when the document attachment was added to the database. The `Content-Disposition` response header will be set if the content type is considered unsafe to display in a browser (unless overridden by by database config option `serve_insecure_attachment_types`) which will force the attachment to be downloaded.
+
+        If the `meta` query parameter is set then the response will be in JSON with the additional metadata tags.
+      parameters:
+        - $ref: '#/components/parameters/rev'
+        - name: content_encoding
+          in: query
+          description: Set to false to disable the `Content-Encoding` response header.
+          schema:
+            type: boolean
+            default: 'true'
+        - name: Range
+          in: header
+          description: RFC-2616 bytes range header.
+          schema:
+            type: string
+          example: bytes=123-456
+        - name: meta
+          in: query
+          description: Return only the metadata of the attachment in the response body.
+          schema:
+            type: boolean
+            default: 'false'
       responses:
         '200':
           description: Found attachment successfully.
@@ -1180,53 +1256,7 @@ paths:
       tags:
         - Admin
         - Public
-      summary: Get an attachment from a document
-      description: |-
-        This request retrieves a file attachment associated with the document. 
-
-        The raw data of the associated attachment is returned (just as if you were accessing a static file). The `Content-Type` response header is the same content type set when the document attachment was added to the database. The `Content-Disposition` response header will be set if the content type is considered unsafe to display in a browser (unless overriden by by database config option `serve_insecure_attachment_types`) which will force the attachment to be downloaded.
-
-        If the `meta` query parameter is set then the response will be in JSON with the additional metadata tags.
-      parameters:
-        - $ref: '#/components/parameters/rev'
-        - name: content_encoding
-          schema:
-            type: boolean
-            default: 'true'
-          in: query
-          description: Set to false to disable the `Content-Encoding` response header.
-        - name: Range
-          schema:
-            type: string
-          in: header
-          description: RFC-2616 bytes range header.
-          example: bytes=123-456
-        - name: meta
-          schema:
-            type: boolean
-            default: 'false'
-          in: query
-          description: Return only the metadata of the attachment in the response body.
     put:
-      responses:
-        '201':
-          description: Attachment added to new or existing document successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/New-revision'
-          headers:
-            Etag:
-              schema:
-                type: string
-              description: The ID of the new revision.
-        '404':
-          $ref: '#/components/responses/Not-found'
-        '409':
-          $ref: '#/components/responses/Conflict'
-      tags:
-        - Admin
-        - Public
       summary: Create or update an attachment on a document
       description: |-
         This request adds or updates an attachment associated with the document. If the document does not exist, it will be created and the attachment will be added to it.
@@ -1238,28 +1268,47 @@ paths:
         To remove an attachment from a document, omit the attachment in the `_attachments` object of the document in the `PUT /{db}/{docid}` request.
       parameters:
         - name: Content-Type
+          in: header
+          description: The content type of the attachment.
           schema:
             type: string
             default: application/octet-stream
-          in: header
-          description: The content type of the attachment.
         - name: rev
-          schema:
-            type: string
           in: query
           description: The existing document revision ID to modify. Required only when modifying an existing document.
-        - name: If-Match
           schema:
             type: string
+        - name: If-Match
           in: header
           description: An alternative way of specifying the document revision ID.
+          schema:
+            type: string
       requestBody:
+        description: The attachment data
         content:
           Attachment content type:
             schema:
               description: The content to store in the body
               type: string
-        description: The attachment data
+      responses:
+        '201':
+          description: Attachment added to new or existing document successfully
+          headers:
+            Etag:
+              schema:
+                type: string
+              description: The ID of the new revision.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/New-revision'
+        '404':
+          $ref: '#/components/responses/Not-found'
+        '409':
+          $ref: '#/components/responses/Conflict'
+      tags:
+        - Admin
+        - Public
     head:
       responses:
         '200':
@@ -1267,8 +1316,8 @@ paths:
           headers:
             Content-Length:
               schema:
-                type: number
                 description: Length of the attachment in bytes
+                type: number
             Etag:
               schema:
                 type: string
@@ -1286,6 +1335,8 @@ paths:
     parameters:
       - $ref: '#/components/parameters/db'
     get:
+      summary: Get information about the current user
+      description: This will get the information about the current user.
       responses:
         '200':
           $ref: '#/components/responses/User-session-information'
@@ -1294,9 +1345,34 @@ paths:
       tags:
         - Admin
         - Public
-      summary: Get information about the current user
-      description: This will get the information about the current user.
     post:
+      summary: Create a new user session
+      description: |-
+        # Admin API
+        Generates a login session for a user and returns the session ID and cookie name for that session. If no TTL is provided, then the default of 24 hours will be used.
+
+        A session cannot be generated for an non-existent user or the `GUEST` user.
+
+        # Public API
+        Generates a login session for the user based on the credentials provided in the request body or if that fails (due to invalid credentials or none provided at all), generates the new session for the currently authenticated user instead. On a successful session creation, a session cookie is stored to keep the user authenticated for future API calls.
+
+        If CORS is enabled, the origin must match an allowed login origin otherwise an error will be returned.
+      requestBody:
+        description: The body can depend on if using the Public or Admin APIs.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: User name to generate the session for.
+                  type: string
+                ttl:
+                  description: '**Admin API only**: Time until the session expires. Uses default value of 24 hours if left blank.'
+                  type: integer
+                password:
+                  description: '**Public API only**: Password of the user to generate the session for.'
+                  type: string
       responses:
         '200':
           description: Session created successfully. Returned body is dependant on if using Public or Admin APIs
@@ -1306,14 +1382,14 @@ paths:
                 type: object
                 properties:
                   session_id:
-                    type: string
                     description: '**Admin API only**: The ID of the session. This is the value that would be put in to the cookie to keep the user authenticated.'
+                    type: string
                   expires:
-                    type: string
                     description: '**Admin API only**: The date and time the cookie expires.'
-                  cookie_name:
                     type: string
+                  cookie_name:
                     description: '**Admin API only**: The name of the cookie that would be used to store the users session.'
+                    type: string
               examples:
                 Admin API response:
                   value:
@@ -1337,34 +1413,12 @@ paths:
       tags:
         - Admin
         - Public
-      summary: Create a new user session
+    delete:
+      summary: Log out
       description: |-
-        # Admin API
-        Generates a login session for a user and returns the session ID and cookie name for that session. If no TTL is provided, then the default of 24 hours will be used.
-
-        A session cannot be generated for an non-existent user or the `GUEST` user.
-
-        # Public API
-        Generates a login session for the user based on the credentials provided in the request body or if that fails (due to invalid credentials or none provided at all), generates the new session for the currently authenticated user instead. On a successful session creation, a session cookie is stored to keep the user authenticated for future API calls.
+        Invalidates the session for the currently authenticated user and removes their session cookie.
 
         If CORS is enabled, the origin must match an allowed login origin otherwise an error will be returned.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                  description: User name to generate the session for.
-                ttl:
-                  type: integer
-                  description: '**Admin API only**: Time until the session expires. Uses default value of 24 hours if left blank.'
-                password:
-                  type: string
-                  description: '**Public API only**: Password of the user to generate the session for.'
-        description: The body can depend on if using the Public or Admin APIs.
-    delete:
       responses:
         '200':
           description: Successfully removed session (logged out)
@@ -1374,11 +1428,6 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Public
-      description: |-
-        Invalidates the session for the currently authenticated user and removes their session cookie.
-
-        If CORS is enabled, the origin must match an allowed login origin otherwise an error will be returned.
-      summary: Log out
     head:
       responses:
         '200':
@@ -1392,14 +1441,29 @@ paths:
     parameters:
       - $ref: '#/components/parameters/db'
     post:
-      deprecated: true
+      summary: Create a new Facebook-based session
+      description: |-
+        Creates a new session based on a Facebook user. On a successful session creation, a session cookie is stored to keep the user authenticated for future API calls.
+
+        If CORS is enabled, the origin must match an allowed login origin otherwise an error will be returned.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                access_token:
+                  description: Facebook access token to base the new session on.
+                  type: string
+              required:
+                - access_token
       responses:
         '200':
           description: Session created successfully
         '400':
           $ref: '#/components/responses/Invalid-CORS'
         '401':
-          description: Recieved error from Facebook verifier
+          description: Received error from Facebook verifier
           content:
             application/json:
               schema:
@@ -1412,7 +1476,7 @@ paths:
         '404':
           $ref: '#/components/responses/Not-found'
         '502':
-          description: Recieved invalid response from the Facebook verifier
+          description: Received invalid response from the Facebook verifier
           content:
             application/json:
               schema:
@@ -1433,64 +1497,14 @@ paths:
                     type: string
                   reason:
                     type: string
+      deprecated: true
       tags:
         - Admin
         - Public
-      summary: Create a new Facebook-based session
-      description: |-
-        Creates a new session based on a Facebook user. On a successful session creation, a session cookie is stored to keep the user authenticated for future API calls.
-
-        If CORS is enabled, the origin must match an allowed login origin otherwise an error will be returned.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                access_token:
-                  type: string
-                  description: Facebook access token to base the new session on.
-              required:
-                - access_token
   '/{db}/_google':
     parameters:
       - $ref: '#/components/parameters/db'
     post:
-      deprecated: true
-      responses:
-        '200':
-          description: Session created successfully
-        '400':
-          $ref: '#/components/responses/Invalid-CORS'
-        '401':
-          description: Recieved error from Google token verifier or invalid application ID in the config
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                  reason:
-                    type: string
-        '404':
-          $ref: '#/components/responses/Not-found'
-        '502':
-          description: Recieved invalid response from the Google token verifier
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                  reason:
-                    type: string
-        '504':
-          description: Unable to send request to the Google token verifier
-      tags:
-        - Admin
-        - Public
       summary: Create a new Google-based session
       description: |-
         Creates a new session based on a Google user. On a successful session creation, a session cookie is stored to keep the user authenticated for future API calls.
@@ -1503,14 +1517,54 @@ paths:
               type: object
               properties:
                 id_token:
-                  type: string
                   description: Google ID token to base the new session on.
+                  type: string
               required:
                 - id_token
+      responses:
+        '200':
+          description: Session created successfully
+        '400':
+          $ref: '#/components/responses/Invalid-CORS'
+        '401':
+          description: Received error from Google token verifier or invalid application ID in the config
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  reason:
+                    type: string
+        '404':
+          $ref: '#/components/responses/Not-found'
+        '502':
+          description: Received invalid response from the Google token verifier
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  reason:
+                    type: string
+        '504':
+          description: Unable to send request to the Google token verifier
+      deprecated: true
+      tags:
+        - Admin
+        - Public
   '/{db}/_oidc':
     parameters:
       - $ref: '#/components/parameters/db'
     get:
+      summary: OpenID Connect authentication initiation via Location header redirect
+      description: 'Called by clients to initiate the OpenID Connect Authorization Code Flow. Redirects to the OpenID Connect provider if successful. '
+      parameters:
+        - $ref: '#/components/parameters/provider'
+        - $ref: '#/components/parameters/offline'
       responses:
         '302':
           description: Successfully connected with the OpenID Connect provider so now redirecting to the requested OIDC provider for authentication.
@@ -1528,15 +1582,15 @@ paths:
       tags:
         - Admin
         - Public
-      summary: OpenID Connect authentication initiation via Location header redirect
-      description: 'Called by clients to initiate the OpenID Connect Authorization Code Flow. Redirects to the OpenID Connect provider if successful. '
-      parameters:
-        - $ref: '#/components/parameters/provider'
-        - $ref: '#/components/parameters/offline'
   '/{db}/_oidc_challenge':
     parameters:
       - $ref: '#/components/parameters/db'
     get:
+      summary: OpenID Connect authentication initiation via WWW-Authenticate header
+      description: 'Called by clients to initiate the OpenID Connect Authorization Code Flow. This will establish a connection with the provider, then put the redirect URL in the `WWW-Authenticate` header.'
+      parameters:
+        - $ref: '#/components/parameters/provider'
+        - $ref: '#/components/parameters/offline'
       responses:
         '400':
           description: 'The provider provided is not defined in the Sync Gateway config. If no provided was specified then there is no default provider set. '
@@ -1554,22 +1608,28 @@ paths:
       tags:
         - Admin
         - Public
-      summary: OpenID Connect authentication initiation via WWW-Authenticate header
-      description: 'Called by clients to initiate the OpenID Connect Authorization Code Flow. This will establish a connection with the provider, then put the redirect URL in the `WWW-Authenticate` header.'
-      parameters:
-        - $ref: '#/components/parameters/provider'
-        - $ref: '#/components/parameters/offline'
   '/{db}/_oidc_callback':
     parameters:
       - $ref: '#/components/parameters/db'
     get:
+      summary: OpenID Connect authentication callback
+      description: The callback URL that the client is redirected to after authenticating with the OpenID Connect provider.
+      parameters:
+        - name: error
+          in: query
+          description: 'The OpenID Connect error, if any occurred.'
+          schema:
+            type: string
+        - $ref: '#/components/parameters/oidc-code'
+        - $ref: '#/components/parameters/provider'
+        - $ref: '#/components/parameters/oidc-state'
       responses:
         '200':
           $ref: '#/components/responses/OIDC-callback'
         '400':
           description: A problem occurred when reading the callback request body
         '401':
-          description: An error was receieved from the OpenID Connect provider. This means the error query parameter was filled.
+          description: An error was received from the OpenID Connect provider. This means the error query parameter was filled.
         '404':
           $ref: '#/components/responses/Not-found'
         '500':
@@ -1586,21 +1646,20 @@ paths:
       tags:
         - Admin
         - Public
-      summary: OpenID Connect authentication callback
-      parameters:
-        - name: error
-          schema:
-            type: string
-          in: query
-          description: 'The OpenID Connect error, if any occurred.'
-        - $ref: '#/components/parameters/oidc-code'
-        - $ref: '#/components/parameters/provider'
-        - $ref: '#/components/parameters/oidc-state'
-      description: The callback URL that the client is redirected to after authenticating with the OpenID Connect provider.
   '/{db}/_oidc_refresh':
     parameters:
       - $ref: '#/components/parameters/db'
     get:
+      summary: OpenID Connect token refresh
+      description: Refresh the OpenID Connect token based on the provided refresh token.
+      parameters:
+        - name: refresh_token
+          in: query
+          description: The OpenID Connect refresh token.
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/provider'
       responses:
         '200':
           $ref: '#/components/responses/OIDC-callback'
@@ -1613,23 +1672,20 @@ paths:
       tags:
         - Admin
         - Public
-      summary: OpenID Connect token refresh
-      parameters:
-        - name: refresh_token
-          schema:
-            type: string
-          in: query
-          description: The OpenID Connect refresh token.
-          required: true
-        - $ref: '#/components/parameters/provider'
-      description: Refresh the OpenID Connect token based on the provided refresh token.
   '/{db}/_oidc_testing/.well-known/openid-configuration':
     parameters:
       - $ref: '#/components/parameters/db'
     get:
+      summary: OpenID Connect mock provider
+      description: Mock an OpenID Connect provider response for testing purposes. This returns a response that is the same structure as what Sync Gateway expects from an OIDC provider after initiating OIDC authentication.
       responses:
         '200':
-          description: 'Sucessfully generated OpenID Connect provider mock response. '
+          description: 'Successfully generated OpenID Connect provider mock response. '
+          headers:
+            Expiry:
+              schema:
+                type: string
+              description: the time until the response expires.
           content:
             application/json:
               schema:
@@ -1657,11 +1713,6 @@ paths:
                     type: string
                   token_endpoint_auth_methods_supported:
                     type: string
-          headers:
-            Expiry:
-              schema:
-                type: string
-              description: the time until the response expires.
         '403':
           $ref: '#/components/responses/OIDC-test-provider-disabled'
         '404':
@@ -1669,12 +1720,14 @@ paths:
       tags:
         - Admin
         - Public
-      summary: OpenID Connect mock provider
-      description: Mock an OpenID Connect provider response for testing purposes. This returns a response that is the same structure as what Sync Gateway expects from an OIDC provider after initiating OIDC authentication.
   '/{db}/_oidc_testing/authorize':
     parameters:
       - $ref: '#/components/parameters/db'
     get:
+      summary: OpenID Connect mock login page
+      description: Show a mock OpenID Connect login page for the client to log in to.
+      parameters:
+        - $ref: '#/components/parameters/oidc-scope'
       responses:
         '200':
           description: OK
@@ -1689,11 +1742,11 @@ paths:
       tags:
         - Admin
         - Public
-      summary: OpenID Connect mock login page
-      description: Show a mock OpenID Connect login page for the client to log in to.
-      parameters:
-        - $ref: '#/components/parameters/oidc-scope'
     post:
+      summary: OpenID Connect mock login page
+      description: Show a mock OpenID Connect login page for the client to log in to.
+      parameters:
+        - $ref: '#/components/parameters/oidc-scope'
       responses:
         '200':
           description: OK
@@ -1708,14 +1761,29 @@ paths:
       tags:
         - Admin
         - Public
-      summary: OpenID Connect mock login page
-      description: Show a mock OpenID Connect login page for the client to log in to.
-      parameters:
-        - $ref: '#/components/parameters/oidc-scope'
   '/{db}/_oidc_testing/token':
     parameters:
       - $ref: '#/components/parameters/db'
     post:
+      summary: OpenID Connect mock token
+      description: Return a mock OpenID Connect token for the OIDC authentication flow.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                grant_type:
+                  description: The grant type of the token to request. Can either be an `authorization_code` or `refresh_token`.
+                  type: string
+                code:
+                  description: '**`grant_type=authorization_code` only**: The OpenID Connect authentication token.'
+                  type: string
+                refresh_token:
+                  description: '**`grant_type=refresh_token` only**: The OpenID Connect refresh token.'
+                  type: string
+              required:
+                - grant_type
       responses:
         '200':
           $ref: '#/components/responses/OIDC-token'
@@ -1728,32 +1796,15 @@ paths:
       tags:
         - Admin
         - Public
-      summary: OpenID Connect mock token
-      description: Return a mock OpenID Connect token for the OIDC authentication flow.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                grant_type:
-                  type: string
-                  description: The grant type of the token to request. Can either be an `authorization_code` or `refresh_token`.
-                code:
-                  type: string
-                  description: '**`grant_type=authorization_code` only**: The OpenID Connect authentication token.'
-                refresh_token:
-                  type: string
-                  description: '**`grant_type=refresh_token` only**: The OpenID Connect refresh token.'
-              required:
-                - grant_type
   '/{db}/_oidc_testing/certs':
     parameters:
       - $ref: '#/components/parameters/db'
     get:
+      summary: OpenID Connect public certificates for signing keys
+      description: Return a mock OpenID Connect public key to be used as signing keys.
       responses:
         '200':
-          description: Returned public key sucessfully
+          description: Returned public key successfully
           content:
             application/json:
               schema:
@@ -1800,48 +1851,35 @@ paths:
       tags:
         - Admin
         - Public
-      summary: OpenID Connect public certificates for signing keys
-      description: Return a mock OpenID Connect public key to be used as signing keys.
   '/{db}/_oidc_testing/authenticate':
     parameters:
       - $ref: '#/components/parameters/db'
     get:
-      responses:
-        '302':
-          $ref: '#/components/responses/OIDC-testing-redirect'
-        '403':
-          $ref: '#/components/responses/OIDC-test-provider-disabled'
-        '404':
-          $ref: '#/components/responses/Not-found'
-      tags:
-        - Admin
-        - Public
+      summary: OpenID Connect mock login page handler
+      description: 'Used to handle the login page displayed for the `GET /{db}/_oidc_testing/authorize` endpoint.'
       parameters:
         - $ref: '#/components/parameters/oidc-redirect_uri'
         - $ref: '#/components/parameters/oidc-scope'
         - name: username
           in: query
+          required: true
           schema:
             type: string
-          required: true
         - name: tokenttl
           in: query
+          required: true
           schema:
             type: integer
-          required: true
         - name: identity-token-formats
           in: query
+          required: true
           schema:
             type: string
-          required: true
         - name: authenticated
           in: query
+          required: true
           schema:
             type: string
-          required: true
-      description: 'Used to handle the login page displayed for the `GET /{db}/_oidc_testing/authorize` endpoint.'
-      summary: OpenID Connect mock login page handler
-    post:
       responses:
         '302':
           $ref: '#/components/responses/OIDC-testing-redirect'
@@ -1852,17 +1890,40 @@ paths:
       tags:
         - Admin
         - Public
+    post:
+      summary: OpenID Connect mock login page handler
       description: 'Used to handle the login page displayed for the `GET /{db}/_oidc_testing/authorize` endpoint.'
       parameters:
         - $ref: '#/components/parameters/oidc-redirect_uri'
         - $ref: '#/components/parameters/oidc-scope'
-      summary: OpenID Connect mock login page handler
       requestBody:
         $ref: '#/components/requestBodies/OIDC-login-page-handler'
+      responses:
+        '302':
+          $ref: '#/components/responses/OIDC-testing-redirect'
+        '403':
+          $ref: '#/components/responses/OIDC-test-provider-disabled'
+        '404':
+          $ref: '#/components/responses/Not-found'
+      tags:
+        - Admin
+        - Public
   '/{db}/_blipsync':
     parameters:
       - $ref: '#/components/parameters/db'
     get:
+      summary: Handle incoming BLIP Sync web socket request
+      description: This handles incoming BLIP Sync requests from either Couchbase Lite or another Sync Gateway node. The connection has to be upgradable to a websocket connection or else the request will fail.
+      parameters:
+        - name: client
+          in: query
+          description: This is the client type that is making the BLIP Sync request. Used to control client-type specific replication behaviour.
+          schema:
+            type: string
+            default: cbl2
+            enum:
+              - cbl2
+              - sgr2
       responses:
         '101':
           description: Upgraded to a web socket connection
@@ -1870,30 +1931,27 @@ paths:
           $ref: '#/components/responses/Not-found'
         '426':
           description: Cannot upgrade connection to a web socket connection
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTP-Error'
+              example:
+                error: Upgrade Required
+                reason: Can't upgrade this request to websocket connection
       tags:
         - Admin
         - Public
-      summary: Handle incoming BLIP Sync web socket request
-      description: This handles incoming BLIP Sync requests from either Couchbase Lite or another Sync Gateway node. The connection has to be upgradable to a websocket connection or else the request will fail.
-      parameters:
-        - name: client
-          schema:
-            type: string
-            default: cbl2
-            enum:
-              - cbl2
-              - sgr2
-          in: query
-          description: This is the client type that is making the BLIP Sync request. Used to control client-type specific replication behaviour.
   '/{targetdb}/':
     parameters:
       - name: targetdb
+        in: path
+        description: The database name to target.
+        required: true
         schema:
           type: string
-        in: path
-        required: true
-        description: The database name to target.
     put:
+      summary: Create DB public API stub
+      description: 'A stub that always returns an error on the Public API, for createTarget/CouchDB compatibility.'
       responses:
         '403':
           description: Database does not exist and cannot be created over the public API
@@ -1906,6 +1964,8 @@ paths:
       - $ref: '#/components/parameters/db'
       - $ref: '#/components/parameters/sessionid'
     get:
+      summary: Get session information
+      description: Retrieve session information such as the user the session belongs too and what channels that user can access.
       responses:
         '200':
           $ref: '#/components/responses/User-session-information'
@@ -1913,9 +1973,9 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      summary: Get session information
-      description: Retrieve session information such as the user the session belongs too and what channels that user can access.
     delete:
+      summary: Remove session
+      description: Invalidates the session provided so that anyone using it is logged out and is prevented from future use.
       responses:
         '200':
           description: Successfully removed the user session
@@ -1923,16 +1983,26 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      summary: Remove session
-      description: Invalidates the session provided so that anyone using it is logged out and is prevented from future use.
   '/{db}/_raw/{docid}':
     parameters:
       - $ref: '#/components/parameters/db'
       - $ref: '#/components/parameters/docid'
     get:
+      summary: Get a document with the corresponding metadata
+      description: |-
+        Returns the a documents latest revision with its metadata.
+
+        Note: The direct use of this endpoint is unsupported. The sync metadata is maintained internally by Sync Gateway and its structure can change. It should not be used to drive business logic of applications since the response to the `/{db}/_raw/{id}` endpoint can change at any time.
+      parameters:
+        - $ref: '#/components/parameters/include_doc'
+        - name: redact
+          in: query
+          description: This redacts sensitive parts of the response. Cannot be used when `include_docs=true`
+          schema:
+            type: boolean
       responses:
         '200':
-          description: Document found sucessfully
+          description: Document found successfully
           content:
             application/json:
               schema:
@@ -1942,22 +2012,22 @@ paths:
                     type: object
                     properties:
                       rev:
-                        type: string
                         description: The current document revision ID.
+                        type: string
                       sequence:
-                        type: number
                         description: The most recent sequence number of the document.
+                        type: number
                       recent_sequences:
-                        type: array
                         description: The previous sequence numbers of the document.
+                        type: array
                         items:
                           type: number
                       history:
                         type: object
                         properties:
                           revs:
-                            type: array
                             description: The past revision IDs.
+                            type: array
                             items:
                               type: string
                           parents:
@@ -1973,30 +2043,29 @@ paths:
                                 type: string
                               nullable: true
                       cas:
-                        type: string
                         description: The document CAS (Concurrent Document Mutations) number used for document locking.
-                      value_crc32c:
                         type: string
+                      value_crc32c:
                         description: The documents CRC32 number.
+                        type: string
                       channel_set:
-                        type: array
                         description: The channels the document has been in.
-                        nullable: true
+                        type: array
                         items:
                           type: object
                           properties:
                             name:
-                              type: string
                               description: The name of the channel.
+                              type: string
                             start:
-                              type: string
                               description: The sequence number that document was added to the channel.
-                            end:
                               type: string
+                            end:
                               description: The sequence number the document was removed from the channel. Omitted if not removed.
+                              type: string
+                        nullable: true
                       channel_set_history:
                         type: array
-                        nullable: true
                         items:
                           type: object
                           properties:
@@ -2006,27 +2075,16 @@ paths:
                               type: string
                             end:
                               type: string
+                        nullable: true
                       time_saved:
-                        type: string
                         description: The time and date the document was most recently changed.
+                        type: string
         '400':
           $ref: '#/components/responses/request-problem'
         '404':
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      summary: Get a document with the corresponding metadata
-      description: |-
-        Returns the a documents latest revision with it's metadata.
-
-        Note: The direct use of this endpoint is unsupported. The sync metadata is maintained internally by Sync Gateway and its structure can change. It should not be used to drive business logic of applications since the response to the `/{db}/_raw/{id}` endpoint can change at any time.
-      parameters:
-        - $ref: '#/components/parameters/include_doc'
-        - schema:
-            type: boolean
-          in: query
-          name: redact
-          description: This redacts sensitive parts of the sync data. Cannot be used when `include_docs=true`
     head:
       responses:
         '200':
@@ -2042,20 +2100,6 @@ paths:
       - $ref: '#/components/parameters/db'
       - $ref: '#/components/parameters/docid'
     get:
-      responses:
-        '200':
-          description: Found document
-          content:
-            application/json:
-              schema:
-                type: string
-              examples:
-                Example:
-                  value: 'digraph graphname{"1-d4d949b7feafc8c31215684baa45b6cd" -> "2-4f3f24143ea43d85a9a340ac016fdfc4"; }'
-        '404':
-          $ref: '#/components/responses/Not-found'
-      tags:
-        - Admin
       summary: Revision tree structure in Graphviz Dot format | Unsupported
       description: |-
         This returns the Dot syntax of the revision tree for the document so that it can be rendered in to a PNG image using the [Graphviz CLI tool](http://www.graphviz.org/).
@@ -2067,32 +2111,46 @@ paths:
 
 
         **Note: This endpoint is useful for debugging purposes only. It is not officially supported.**
+      responses:
+        '200':
+          description: Found document
+          content:
+            application/json:
+              schema:
+                type: string
+              example: 'digraph graphname{"1-d4d949b7feafc8c31215684baa45b6cd" -> "2-4f3f24143ea43d85a9a340ac016fdfc4"; }'
+        '404':
+          $ref: '#/components/responses/Not-found'
+      tags:
+        - Admin
   '/{db}/_user/':
     parameters:
       - $ref: '#/components/parameters/db'
     get:
+      summary: Get all the names of the users
+      description: Retrieves all the names of the users that are in the database.
       responses:
         '200':
           description: Users retrieved successfully
           content:
             application/json:
               schema:
-                type: array
                 description: List of all user names
+                type: array
                 items:
                   type: string
-              examples:
-                Example:
-                  value:
-                    - Alice
-                    - Bob
+              example:
+                - Alice
+                - Bob
         '404':
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      summary: Get all the names of the users
-      description: Retrieves all the names of the users that are in the database.
     post:
+      summary: Create a new user
+      description: Create a new user using the request body to specify the properties on the user.
+      requestBody:
+        $ref: '#/components/requestBodies/User'
       responses:
         '201':
           description: New user created successfully
@@ -2102,10 +2160,6 @@ paths:
           $ref: '#/components/responses/Conflict'
       tags:
         - Admin
-      summary: Create a new user
-      requestBody:
-        $ref: '#/components/requestBodies/User'
-      description: Create a new user using the request body to specify the properties on the user.
     head:
       responses:
         '200':
@@ -2119,6 +2173,8 @@ paths:
       - $ref: '#/components/parameters/db'
       - $ref: '#/components/parameters/user-name'
     get:
+      summary: Get a user
+      description: Retrieve a single users information.
       responses:
         '200':
           $ref: '#/components/responses/User'
@@ -2126,9 +2182,11 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      summary: Get a user
-      description: Retrieve a single users information.
     put:
+      summary: Upsert a user
+      description: 'If the user does not exist, create a new user otherwise update the existing user.'
+      requestBody:
+        $ref: '#/components/requestBodies/User'
       responses:
         '200':
           description: Existing user modified successfully
@@ -2138,11 +2196,9 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      description: 'If the user does not exist, create a new user otherwise update the existing user.'
-      summary: Upsert a user
-      requestBody:
-        $ref: '#/components/requestBodies/User'
     delete:
+      summary: Delete a user
+      description: Delete a user from the database.
       responses:
         '200':
           description: User deleted successfully
@@ -2150,8 +2206,6 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      description: Delete a user from the database.
-      summary: Delete a user
     head:
       responses:
         '200':
@@ -2167,6 +2221,11 @@ paths:
       - $ref: '#/components/parameters/db'
       - $ref: '#/components/parameters/user-name'
     delete:
+      summary: Remove all of a users sessions
+      description: |-
+        Invalidates all the sessions that a user has.
+
+        Will still return a `200` status code if the user has no sessions.
       responses:
         '200':
           description: User now has no sessions
@@ -2174,54 +2233,51 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      summary: Remove all of a users sessions
-      description: |-
-        Invalidates all the sessions that a user has.
-
-        Will still return a `200` status code if the user has no sessions.
   '/{db}/_user/{name}/_session/{sessionid}':
     parameters:
       - $ref: '#/components/parameters/db'
       - $ref: '#/components/parameters/user-name'
       - $ref: '#/components/parameters/sessionid'
     delete:
+      summary: Remove session with user validation
+      description: Invalidates the session only if it belongs to the user.
       responses:
         '200':
-          description: Session has been sucessfully removed as the user was associated with the session
+          description: Session has been successfully removed as the user was associated with the session
         '404':
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      summary: Remove session with user validation
-      description: Invalidates the session only if it belongs to the user.
   '/{db}/_role/':
     parameters:
       - $ref: '#/components/parameters/db'
     get:
+      summary: Get all names of the roles
+      description: Retrieves all the roles that are in the database.
       responses:
         '200':
           description: Roles retrieved successfully
           content:
             application/json:
               schema:
-                type: array
-                minItems: 0
-                uniqueItems: true
                 description: List of all role names
+                type: array
                 items:
                   type: string
-              examples:
-                Example:
-                  value:
-                    - Administrator
-                    - Moderator
+                minItems: 0
+                uniqueItems: true
+              example:
+                - Administrator
+                - Moderator
         '404':
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      summary: Get all names of the roles
-      description: Retrieves all the roles that are in the database.
     post:
+      summary: Create a new role
+      description: Create a new role using the request body to specify the properties on the role.
+      requestBody:
+        $ref: '#/components/requestBodies/Role'
       responses:
         '201':
           description: New role created successfully
@@ -2231,10 +2287,6 @@ paths:
           $ref: '#/components/responses/Conflict'
       tags:
         - Admin
-      summary: Create a new role
-      description: Create a new role using the request body to specify the properties on the role.
-      requestBody:
-        $ref: '#/components/requestBodies/Role'
     head:
       responses:
         '200':
@@ -2248,6 +2300,8 @@ paths:
       - $ref: '#/components/parameters/db'
       - $ref: '#/components/parameters/role-name'
     get:
+      summary: Get a role
+      description: Retrieve a single roles properties.
       responses:
         '200':
           $ref: '#/components/responses/Role'
@@ -2255,9 +2309,11 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      summary: Get a role
-      description: Retrieve a single roles properties.
     put:
+      summary: Upsert a role
+      description: 'If the role does not exist, create a new role otherwise update the existing role.'
+      requestBody:
+        $ref: '#/components/requestBodies/Role'
       responses:
         '200':
           description: OK
@@ -2267,11 +2323,9 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      summary: Upsert a role
-      description: 'If the role does not exist, create a new role otherwise update the existing role.'
-      requestBody:
-        $ref: '#/components/requestBodies/Role'
     delete:
+      summary: Delete a role
+      description: Delete a role from the database.
       responses:
         '200':
           description: OK
@@ -2279,8 +2333,6 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      description: Delete a role from the database.
-      summary: Delete a role
     head:
       responses:
         '200':
@@ -2295,6 +2347,8 @@ paths:
     parameters:
       - $ref: '#/components/parameters/db'
     get:
+      summary: Get all replication configurations
+      description: This will retrieve all database replication definitions.
       responses:
         '200':
           description: |-
@@ -2308,9 +2362,14 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      summary: Get all replication configurations
-      description: This will retrieve all database replication definitions.
     post:
+      summary: Upsert a replication
+      description: |-
+        Create or update a replication in the database.
+
+        If an existing replication is being updated, that replication must be stopped first.
+      requestBody:
+        $ref: '#/components/requestBodies/Replication-upsert'
       responses:
         '200':
           $ref: '#/components/responses/Replicator-updated'
@@ -2322,13 +2381,6 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      summary: Upsert a replication
-      description: |-
-        Create or update a replication in the database.
-
-        If an existing replication is being updated, that replication must be stopped first.
-      requestBody:
-        $ref: '#/components/requestBodies/Replication-upsert'
     head:
       responses:
         '200':
@@ -2342,6 +2394,8 @@ paths:
       - $ref: '#/components/parameters/db'
       - $ref: '#/components/parameters/replicationid'
     get:
+      summary: Get a replication configuration
+      description: Retrieve a replication configuration from the database.
       responses:
         '200':
           description: Successfully retrieved the replication configuration
@@ -2353,9 +2407,16 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      summary: Get a replication configuration
-      description: Retrieve a replication configuration from the database.
     put:
+      summary: Upsert a replication
+      description: |-
+        Create or update a replication in the database.
+
+        The replication ID does **not** need to be set in the request body.
+
+        If an existing replication is being updated, that replication must be stopped first and, if the `replication_id` is specified in the request body, it must match the replication ID in the URI.
+      requestBody:
+        $ref: '#/components/requestBodies/Replication-upsert'
       responses:
         '200':
           $ref: '#/components/responses/Replicator-updated'
@@ -2367,16 +2428,9 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      summary: Upsert a replication
-      description: |-
-        Create or update a replication in the database.
-
-        The replication ID does **not** need to be set in the request body.
-
-        If an existing replication is being updated, that replication must be stopped first and, if the `replication_id` is specified in the request body, it must match the replication ID in the URI.
-      requestBody:
-        $ref: '#/components/requestBodies/Replication-upsert'
     delete:
+      summary: Stop and delete a replication
+      description: This will delete a replication causing it to stop and no longer exist.
       responses:
         '200':
           description: Replication successfully deleted
@@ -2386,8 +2440,6 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      summary: Stop and delete a replication
-      description: This will delete a replication causing it to stop and no longer exist.
     head:
       responses:
         '200':
@@ -2398,8 +2450,17 @@ paths:
         - Admin
       summary: Check if a replication exists
       description: Check if a replication exists.
-  /_replicationStatus/:
+  '/{db}/_replicationStatus/':
+    parameters:
+      - $ref: '#/components/parameters/db'
     get:
+      summary: Get all replication statuses
+      description: Retrieve all the replication statuses in the Sync Gateway node.
+      parameters:
+        - $ref: '#/components/parameters/replication-active-only'
+        - $ref: '#/components/parameters/replication-local-only'
+        - $ref: '#/components/parameters/replication-include-error'
+        - $ref: '#/components/parameters/replication-include-config'
       responses:
         '200':
           description: Successfully retrieved all replication statuses.
@@ -2413,13 +2474,6 @@ paths:
           $ref: '#/components/responses/request-problem'
       tags:
         - Admin
-      summary: Get all replication statuses
-      description: Retrieve all the replication statuses in the Sync Gateway node.
-      parameters:
-        - $ref: '#/components/parameters/replication-active-only'
-        - $ref: '#/components/parameters/replication-local-only'
-        - $ref: '#/components/parameters/replication-include-error'
-        - $ref: '#/components/parameters/replication-include-config'
     head:
       responses:
         '200':
@@ -2428,10 +2482,18 @@ paths:
           description: Bad Request
       tags:
         - Admin
-  '/_replicationStatus/{replicationid}':
+  '/{db}/_replicationStatus/{replicationid}':
     parameters:
+      - $ref: '#/components/parameters/db'
       - $ref: '#/components/parameters/replicationid'
     get:
+      summary: Get replication status
+      description: Retrieve the status of a replication.
+      parameters:
+        - $ref: '#/components/parameters/replication-active-only'
+        - $ref: '#/components/parameters/replication-local-only'
+        - $ref: '#/components/parameters/replication-include-error'
+        - $ref: '#/components/parameters/replication-include-config'
       responses:
         '200':
           description: Successfully retrieved replication status
@@ -2449,14 +2511,26 @@ paths:
                 $ref: '#/components/schemas/HTTP-Error'
       tags:
         - Admin
-      summary: Get replication status
-      description: Retrieve the status of a replication.
-      parameters:
-        - $ref: '#/components/parameters/replication-active-only'
-        - $ref: '#/components/parameters/replication-local-only'
-        - $ref: '#/components/parameters/replication-include-error'
-        - $ref: '#/components/parameters/replication-include-config'
     put:
+      summary: Control a replication state
+      description: |-
+        Control the replication by changing its state.
+
+        This is done through the action query parameter, which has 3 valid values:
+        * `start` - starts a stopped replication
+        * `stop` - stops an active replication
+        * `reset` - resets the replication checkpoint to 0. For bidirectional replication, both push and pull checkpoints are reset to 0. The replication must be stopped to use this.
+      parameters:
+        - name: action
+          in: query
+          description: The target state to put the replicator into.
+          required: true
+          schema:
+            type: string
+            enum:
+              - start
+              - stop
+              - reset
       responses:
         '200':
           description: Successfully changed target state of replicator
@@ -2465,34 +2539,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/Replication-status'
         '400':
-          $ref: '#/components/responses/request-problem'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTP-Error'
+          $ref: '#/components/responses/request-problem'
         '404':
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      description: |-
-        Change the replication state to target. 
-
-        This is done through the action query parameter, which has 3 valid values:
-        * `start` - starts a stopped replication
-        * `stop` - stops an active replication
-        * `reset` - resets the replication checkpoint to 0. For bidirectional replication, both push and pull checkpoints are reset to 0. The replication must be stopped to use this.
-      summary: Modify a replication status
-      parameters:
-        - name: action
-          schema:
-            type: string
-            enum:
-              - start
-              - stop
-              - reset
-          in: query
-          description: The target state to put the replicator into.
-          required: true
     head:
       responses:
         '200':
@@ -2512,84 +2567,70 @@ paths:
       description: Check if a replication exists
   /_logging:
     get:
+      summary: Get console logging settings
+      description: |-
+        **Deprecated in favour of `GET /_config`**
+        This will return a map of the log keys being used for the console logging.
       responses:
         '200':
           description: Returned map of console log keys
           content:
             application/json:
               schema:
-                type: object
-                description: Map of console log keys
-                properties:
-                  log_key:
-                    type: boolean
-                    default: true
-                    description: This is the console log keys currently in use (therefore all the values will be `true`).
-                required:
-                  - log_key
+                $ref: '#/components/schemas/DeprecatedLogKeyMap'
+      deprecated: true
       tags:
         - Admin
-      description: |-
-        **Deprecated in favour of `GET /_config`**
-        This will return a map of the log keys being used for the console. This will include the runtime log keys.
-      summary: Get the console log keys
-      deprecated: true
     put:
-      responses:
-        '200':
-          description: Log keys successfully replace
-        '400':
-          $ref: '#/components/responses/request-problem'
-      tags:
-        - Admin
-      deprecated: true
+      summary: Set console logging settings
       description: |-
         **Deprecated in favour of `PUT /_config`**
-        This is for replacing all the log keys and optionally changing the console log level.
-      summary: Replace console log keys and change log level
+        Enable or disable console log keys and optionally change the console log level.
+      parameters:
+        - $ref: '#/components/parameters/log-level'
+        - $ref: '#/components/parameters/log-level-int'
       requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              description: A map of the console log keys to replace all the current log keys with.
-              properties:
-                log_key:
-                  type: boolean
-                  description: The name of the log key and the value `true` to use it.
         description: The map of log keys to use for console logging.
-      parameters:
-        - $ref: '#/components/parameters/log-level'
-        - $ref: '#/components/parameters/log-level-int'
-    post:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeprecatedLogKeyMap'
       responses:
         '200':
-          description: Log keys successfully upserted.
+          description: Log keys successfully replaced.
         '400':
           $ref: '#/components/responses/request-problem'
+      deprecated: true
       tags:
         - Admin
-      deprecated: true
-      summary: Update console log keys and change log level
+    post:
+      summary: Update console logging settings
       description: |-
         **Deprecated in favour of `PUT /_config`**
-        This is for upserting the log keys provided and optionally changing the console log level.
+        This is for enabling the log keys provided and optionally changing the console log level.
       parameters:
         - $ref: '#/components/parameters/log-level'
         - $ref: '#/components/parameters/log-level-int'
       requestBody:
+        description: The console log keys to upsert.
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                log_key:
-                  type: boolean
-                  description: 'The console log key to upsert along with the value. If the value is `false` then the log key will not be used, or else if `true` than the log key will be used.'
-        description: The console log keys to upsert.
+              $ref: '#/components/schemas/DeprecatedLogKeyMap'
+      responses:
+        '200':
+          description: Log keys successfully updated.
+        '400':
+          $ref: '#/components/responses/request-problem'
+      deprecated: true
+      tags:
+        - Admin
   '/_profile/{profilename}':
     parameters:
       - name: profilename
+        in: path
+        description: The handler to use for profiling.
+        required: true
         schema:
           type: string
           enum:
@@ -2598,42 +2639,44 @@ paths:
             - threadcreate
             - mutex
             - goroutine
-        in: path
-        required: true
-        description: The handler to use for profiling.
     post:
+      summary: Create point-in-time profile
+      description: This endpoint allows you to create a pprof snapshot of the given type.
+      requestBody:
+        $ref: '#/components/requestBodies/Profile'
       responses:
         '200':
-          description: Successfully started profiling
+          description: Successfully created profile
         '400':
           $ref: '#/components/responses/request-problem'
         '404':
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      description: |-
-        This endpoint allows you to start profiling Sync Gateway. Profiling outputs a Go pprof file so performance can be analysed.
-
-        To start profiling, call this endpoint with the handler to use for profiling and supply a file to output the pprof file to.
-      summary: Start profiling
   /_profile:
     post:
+      summary: Start or Stop continuous CPU profiling
+      description: |-
+        This endpoint allows you to start and stop continuous CPU profiling.
+
+        To start profiling the CPU, call this endpoint and supply a file to output the pprof file to.
+
+        To stop profiling, call this endpoint but don't supply the `file` in the body.
+      requestBody:
+        $ref: '#/components/requestBodies/Profile'
       responses:
         '200':
-          description: Sucessfully started or stopped CPU profiling
+          description: Successfully started or stopped CPU profiling
         '400':
           $ref: '#/components/responses/request-problem'
       tags:
         - Admin
-      description: |-
-        This endpoint allows you to start or stop CPU profiling for Sync Gateway. Profiling outputs a Go pprof file so performance can be analysed.
-
-        To start profiling the CPU, call this endpoint and supply a file to output the pprof file to. To stop profiling, call this endpoint but don't supply the `file` in the body.
-      summary: Start or stop CPU profiling
-      requestBody:
-        $ref: '#/components/requestBodies/Profile'
   /_heap:
     post:
+      summary: Dump heap profile
+      description: This endpoint will dump a pprof heap profile.
+      requestBody:
+        $ref: '#/components/requestBodies/Profile'
       responses:
         '200':
           description: Successfully dumped heap profile
@@ -2641,21 +2684,35 @@ paths:
           $ref: '#/components/responses/request-problem'
       tags:
         - Admin
-      summary: Dump heap profile
-      description: This endpoint will dump a pprof heap profile.
-      requestBody:
-        $ref: '#/components/requestBodies/Profile'
   /_stats:
     get:
+      summary: Get memory statistics
+      description: This will return the current Sync Gateway nodes memory statistics such as current memory usage.
       responses:
         '200':
           description: Returned memory usage statistics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  memstats:
+                    description: A set of Go runtime memory statistics.
+                    additionalProperties: true
       tags:
         - Admin
-      description: This will return the current Sync Gateway nodes memory statistics such as current memory usage.
-      summary: Get memory statistics
   /_config:
     get:
+      summary: Get server configuration
+      description: This will return the configuration that the Sync Gateway node is running with.
+      parameters:
+        - $ref: '#/components/parameters/deprecated-redact'
+        - name: include_runtime
+          in: query
+          description: 'Whether to include the values set at runtime, default values, and all loaded databases.'
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           description: Successfully returned server configuration
@@ -2667,97 +2724,30 @@ paths:
           $ref: '#/components/responses/request-problem'
       tags:
         - Admin
-      description: This will return the configuration that the Sync Gateway node is running with.
-      parameters:
-        - $ref: '#/components/parameters/redact'
-        - name: include_runtime
-          in: query
-          description: Include the default values that Sync Gateway is running with (known as the runtime configuration) and include all the databases under the `databases` key.
-          schema:
-            type: boolean
-            default: 'false'
-      summary: Get the server configuration
     put:
-      responses:
-        '200':
-          description: Successfully updated logging options
-        '400':
-          $ref: '#/components/responses/request-problem'
-      tags:
-        - Admin
-      summary: Update the server logging options
-      description: This endpoint is used to update the server logging options without needing a restart.
+      summary: Set runtime configuration
+      description: |-
+        This endpoint is used to dynamically set runtime options, like logging without needing a restart.
+
+        These options are not persisted, and will not survive a restart of Sync Gateway.
+
+        The endpoint only accepts a limited number of options that can be changed at runtime. See request body schema for allowable options.
       requestBody:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                logging:
-                  type: object
-                  properties:
-                    console:
-                      type: object
-                      description: Options for outputting the logs to the console.
-                      properties:
-                        log_level:
-                          type: string
-                          enum:
-                            - none
-                            - error
-                            - warn
-                            - info
-                            - debug
-                            - trace
-                          description: The minimum log level to output to console.
-                        log_keys:
-                          type: array
-                          description: |-
-                            The log keys to use to filter the outputted log messages.
-
-                            **If set, this will replace any existing logging keys.**
-                          items:
-                            type: string
-                            enum:
-                              - '*'
-                              - Admin
-                              - Access
-                              - Auth
-                              - Bucket
-                              - Cache
-                              - Changes
-                              - SGCluster
-                              - Config
-                              - CRUD
-                              - DCP
-                              - Events
-                              - gocb
-                              - HTTP
-                              - HTTP+
-                              - Import
-                              - Javascript
-                              - Migrate
-                              - Query
-                              - Replicate
-                              - Sync
-                              - SyncMsg
-                              - WS
-                              - WSFrame
-                              - TEST
-                    error:
-                      $ref: '#/components/schemas/Log-update-enabled'
-                    warn:
-                      $ref: '#/components/schemas/Log-update-enabled'
-                    info:
-                      $ref: '#/components/schemas/Log-update-enabled'
-                    debug:
-                      $ref: '#/components/schemas/Log-update-enabled'
-                    trace:
-                      $ref: '#/components/schemas/Log-update-enabled'
-                    stats:
-                      $ref: '#/components/schemas/Log-update-enabled'
+              $ref: '#/components/schemas/Startup-config'
+      responses:
+        '200':
+          description: Successfully set runtime options
+        '400':
+          $ref: '#/components/responses/request-problem'
+      tags:
+        - Admin
   /_status:
     get:
+      summary: Get the server status
+      description: This will retrieve the status of each database and the overall server status.
       responses:
         '200':
           description: Returned the status successfully
@@ -2769,10 +2759,10 @@ paths:
           $ref: '#/components/responses/request-problem'
       tags:
         - Admin
-      summary: Get the server status
-      description: This will retrieve the status of each database and the overall server status.
   /_sgcollect_info:
     get:
+      summary: Get the status of the Sync Gateway Collect Info
+      description: This will return the status of whether Sync Gateway Collect Info (sgcollect_info) is currently running or not.
       responses:
         '200':
           description: Returned sgcollect_info status
@@ -2782,18 +2772,63 @@ paths:
                 type: object
                 properties:
                   status:
+                    description: The status of sgcollect_info.
                     type: string
                     enum:
                       - stopped
                       - running
-                    description: The status of sgcollect_info.
                 required:
                   - status
       tags:
         - Admin
-      summary: Get the status of the Sync Gateway Collect Info
-      description: This will return the status of whether Sync Gateway Collect Info (sgcollect_info) is currently running or not.
     post:
+      summary: Start Sync Gateway Collect Info
+      description: This endpoint is used to start a Sync Gateway Collect Info (sgcollect_info) job so that Sync Gateway diagnostic data can be outputted to a file.
+      requestBody:
+        description: sgcollect_info options
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                redact_level:
+                  description: The redaction level to use for redacting the collected logs.
+                  type: string
+                  default: partial
+                  enum:
+                    - partial
+                    - none
+                redact_salt:
+                  description: The salt to use for the log redactions.
+                  type: string
+                output_dir:
+                  description: |-
+                    The directory to output the collected logs zip file at.
+
+                    This overrides the configured default output directory configured in the startup config `logging.log_file_path`.
+                  type: string
+                  default: The configured path set in the startup config `logging.log_file_path`
+                upload:
+                  description: |-
+                    If set, upload the logs to Couchbase Support.
+
+                    A customer name must be set if this is set.
+                  type: boolean
+                upload_host:
+                  description: The host to send the logs too.
+                  type: string
+                  default: 'https://uploads.couchbase.com'
+                upload_proxy:
+                  description: The proxy to use while uploading the logs.
+                  type: string
+                customer:
+                  description: The customer name to use when uploading the logs.
+                  type: string
+                ticket:
+                  description: The Zendesk ticket number to use when uploading logs.
+                  type: string
+                  maxLength: 7
+                  minLength: 1
       responses:
         '200':
           description: Successfully started sgcollect_info
@@ -2803,9 +2838,9 @@ paths:
                 type: object
                 properties:
                   status:
+                    description: The new sgcollect_info status.
                     type: string
                     default: started
-                    description: The new sgcollect_info status.
         '400':
           $ref: '#/components/responses/request-problem'
         '500':
@@ -2816,54 +2851,9 @@ paths:
                 $ref: '#/components/schemas/HTTP-Error'
       tags:
         - Admin
-      summary: Start Sync Gateway Collect Info
-      description: This endpoint is used to start a Sync Gateway Collect Info (sgcollect_info) job so that Sync Gateway diagnostic data can be outputted to a file.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                redact_level:
-                  type: string
-                  default: partial
-                  enum:
-                    - partial
-                    - none
-                  description: The redaction level to use for redacting the collected logs.
-                redact_salt:
-                  type: string
-                  description: The salt to use for the log redactions.
-                output_dir:
-                  type: string
-                  description: |-
-                    The directory to output the collected logs zip file at.
-
-                    This overrides the configured default output directory configured in the startup config `logging.log_file_path`.
-                  default: The configured path set in the startup config `logging.log_file_path`
-                upload:
-                  type: boolean
-                  description: |-
-                    If set, upload the logs to Couchbase Support.
-
-                    A customer name must be set if this is set.
-                upload_host:
-                  type: string
-                  default: 'https://uploads.couchbase.com'
-                  description: The host to send the logs too.
-                upload_proxy:
-                  type: string
-                  description: The proxy to use while uploading the logs.
-                customer:
-                  type: string
-                  description: The customer name to use when uploading the logs.
-                ticket:
-                  type: string
-                  description: The Zendesk ticket number to use when uploading logs.
-                  minLength: 1
-                  maxLength: 7
-        description: sgcollect_info options
     delete:
+      summary: Cancel the Sync Gateway Collect Info job
+      description: 'This endpoint is used to cancel a current Sync Gateway Collect Info (sgcollect_info) job that is running. '
       responses:
         '200':
           description: Job cancelled successfully
@@ -2873,40 +2863,38 @@ paths:
                 type: object
                 properties:
                   status:
+                    description: The new status of sgcollect_info.
                     type: string
                     default: cancelled
-                    description: The new status of sgcollect_info.
         '400':
           $ref: '#/components/responses/request-problem'
       tags:
         - Admin
-      summary: Cancel the Sync Gateway Collect Info job
-      description: 'This endpoint is used to cancel a current Sync Gateway Collect Info (sgcollect_info) job that is running. '
   /_debug/pprof/goroutine:
     get:
+      summary: Get goroutine profile
+      description: Stack traces of all current goroutines.
+      parameters:
+        - $ref: '#/components/parameters/pprof-seconds'
       responses:
         '200':
-          description: OK
-          content:
-            application/octet-stream:
-              schema:
-                type: string
+          $ref: '#/components/responses/pprof-binary'
       tags:
         - Admin
-      summary: Get the goroutine pprof debug file
     post:
+      summary: Get goroutine profile
+      description: Stack traces of all current goroutines.
+      parameters:
+        - $ref: '#/components/parameters/pprof-seconds'
       responses:
         '200':
-          description: OK
-          content:
-            application/octet-stream:
-              schema:
-                type: string
+          $ref: '#/components/responses/pprof-binary'
       tags:
         - Admin
-      summary: Get the goroutine pprof debug file
   /_debug/pprof/cmdline:
     get:
+      summary: Get passed in command line parameters
+      description: 'Gets the command line parameters that was passed in to Sync Gateway which will include the binary, flags (if any) and startup configuration.'
       responses:
         '200':
           description: OK
@@ -2916,9 +2904,9 @@ paths:
                 type: string
       tags:
         - Admin
-      summary: Get passed in command line parameters
-      description: 'Gets the command line parameters that was passed in to Sync Gateway which will include the binary, flags (if any) and startup configuration.'
     post:
+      summary: Get passed in command line parameters
+      description: 'Gets the command line parameters that was passed in to Sync Gateway which will include the binary, flags (if any) and startup configuration.'
       responses:
         '200':
           description: OK
@@ -2926,12 +2914,11 @@ paths:
             text/plain:
               schema:
                 type: string
-      description: 'Gets the command line parameters that was passed in to Sync Gateway which will include the binary, flags (if any) and startup configuration.'
       tags:
         - Admin
-      summary: Get passed in command line parameters
   /_debug/pprof/symbol:
     get:
+      summary: Get symbol pprof debug information
       responses:
         '200':
           description: OK
@@ -2941,8 +2928,8 @@ paths:
                 type: string
       tags:
         - Admin
-      summary: Get symbol pprof debug information
     post:
+      summary: Get symbol pprof debug information
       responses:
         '200':
           description: OK
@@ -2952,179 +2939,172 @@ paths:
                 type: string
       tags:
         - Admin
-      summary: Get symbol pprof debug information
   /_debug/pprof/heap:
     get:
+      summary: Get the heap pprof debug file
+      parameters:
+        - $ref: '#/components/parameters/pprof-seconds'
       responses:
         '200':
-          description: OK
-          content:
-            application/octet-stream:
-              schema:
-                type: string
+          $ref: '#/components/responses/pprof-binary'
       tags:
         - Admin
-      summary: Get the heap pprof debug file
     post:
+      summary: Get the heap pprof debug file
+      parameters:
+        - $ref: '#/components/parameters/pprof-seconds'
       responses:
         '200':
-          description: OK
-          content:
-            application/octet-stream:
-              schema:
-                type: string
+          $ref: '#/components/responses/pprof-binary'
       tags:
         - Admin
-      summary: Get the heap pprof debug file
   /_debug/pprof/profile:
     get:
+      summary: Get the profile pprof debug file
+      parameters:
+        - $ref: '#/components/parameters/pprof-seconds'
       responses:
         '200':
-          description: OK
-          content:
-            application/octet-stream:
-              schema:
-                type: string
+          $ref: '#/components/responses/pprof-binary'
       tags:
         - Admin
-      summary: Get the profile pprof debug file
     post:
+      summary: Get the profile pprof debug file
+      parameters:
+        - $ref: '#/components/parameters/pprof-seconds'
       responses:
         '200':
-          description: OK
-          content:
-            application/octet-stream:
-              schema:
-                type: string
+          $ref: '#/components/responses/pprof-binary'
       tags:
         - Admin
-      summary: Get the profile pprof debug file
   /_debug/pprof/block:
     get:
+      summary: Get block profile
+      description: Returns stack traces that led to blocking on synchronization primitives
+      parameters:
+        - $ref: '#/components/parameters/debug-profile-seconds'
       responses:
         '200':
-          description: OK
-          content:
-            application/octet-stream:
-              schema:
-                type: string
+          $ref: '#/components/responses/pprof-binary'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTP-Error'
+              example:
+                error: forbidden
+                reason: Can only run one mutex profile at a time
       tags:
         - Admin
-      summary: Get the block pprof debug file
-      parameters:
-        - $ref: '#/components/parameters/debug-profile-seconds'
     post:
+      summary: Get block profile
+      description: Returns stack traces that led to blocking on synchronization primitives
+      parameters:
+        - $ref: '#/components/parameters/debug-profile-seconds'
       responses:
         '200':
-          description: OK
-          content:
-            application/octet-stream:
-              schema:
-                type: string
+          $ref: '#/components/responses/pprof-binary'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTP-Error'
+              example:
+                error: forbidden
+                reason: Can only run one mutex profile at a time
       tags:
         - Admin
-      summary: Get the block pprof debug file
-      parameters:
-        - $ref: '#/components/parameters/debug-profile-seconds'
   /_debug/pprof/threadcreate:
     get:
+      summary: Get the threadcreate pprof debug file
       responses:
         '200':
-          description: OK
-          content:
-            application/octet-stream:
-              schema:
-                type: string
+          $ref: '#/components/responses/pprof-binary'
       tags:
         - Admin
-      summary: Get the threadcreate pprof debug file
     post:
+      summary: Get the threadcreate pprof debug file
       responses:
         '200':
-          description: OK
-          content:
-            application/octet-stream:
-              schema:
-                type: string
+          $ref: '#/components/responses/pprof-binary'
       tags:
         - Admin
-      summary: Get the threadcreate pprof debug file
   /_debug/pprof/mutex:
     get:
+      summary: Get mutex profile
+      description: Returns stack traces of holders of contended mutexes
+      parameters:
+        - $ref: '#/components/parameters/debug-profile-seconds'
       responses:
         '200':
-          description: OK
-          content:
-            application/octet-stream:
-              schema:
-                type: string
+          $ref: '#/components/responses/pprof-binary'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTP-Error'
+              example:
+                error: forbidden
+                reason: Can only run one mutex profile at a time
       tags:
         - Admin
-      summary: Get the mutex pprof debug file
-      parameters:
-        - $ref: '#/components/parameters/debug-profile-seconds'
     post:
+      summary: Get mutex profile
+      description: Returns stack traces of holders of contended mutexes
+      parameters:
+        - $ref: '#/components/parameters/debug-profile-seconds'
       responses:
         '200':
-          description: OK
-          content:
-            application/octet-stream:
-              schema:
-                type: string
+          $ref: '#/components/responses/pprof-binary'
         '403':
           description: Forbidden
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTP-Error'
+              example:
+                error: forbidden
+                reason: Can only run one mutex profile at a time
       tags:
         - Admin
-      summary: Get the mutex pprof debug file
-      parameters:
-        - $ref: '#/components/parameters/debug-profile-seconds'
   /_debug/pprof/trace:
     get:
+      summary: Get trace profile
+      description: Responds with the execution trace in binary form
+      parameters:
+        - name: seconds
+          in: query
+          schema:
+            type: integer
+            default: 1
       responses:
         '200':
-          description: OK
-          content:
-            application/octet-stream:
-              schema:
-                type: string
+          $ref: '#/components/responses/pprof-binary'
       tags:
         - Admin
-      summary: Get the trace pprof debug file
     post:
+      summary: Get trace profile
+      description: Responds with the execution trace in binary form
+      parameters:
+        - name: seconds
+          in: query
+          schema:
+            type: integer
+            default: 1
       responses:
         '200':
-          description: OK
-          content:
-            application/octet-stream:
-              schema:
-                type: string
+          $ref: '#/components/responses/pprof-binary'
       tags:
         - Admin
-      summary: Get the trace pprof debug file
   /_debug/fgprof:
     get:
+      summary: Get fgprof profile
+      description: 'A sampling Go profiler that allows you to analyze On-CPU as well as [Off-CPU](http://www.brendangregg.com/offcpuanalysis.html) (e.g. I/O) time together.'
+      parameters:
+        - $ref: '#/components/parameters/debug-profile-seconds'
       responses:
         '200':
           description: OK
@@ -3134,8 +3114,11 @@ paths:
                 type: string
       tags:
         - Admin
-      summary: Get the fgprof debug profile
     post:
+      summary: Get fgprof profile
+      description: 'A sampling Go profiler that allows you to analyze On-CPU as well as [Off-CPU](http://www.brendangregg.com/offcpuanalysis.html) (e.g. I/O) time together.'
+      parameters:
+        - $ref: '#/components/parameters/debug-profile-seconds'
       responses:
         '200':
           description: OK
@@ -3145,9 +3128,17 @@ paths:
                 type: string
       tags:
         - Admin
-      summary: Get the fgprof debug profile
   /_post_upgrade:
     post:
+      summary: Run the post upgrade process on all databases
+      description: The post upgrade process involves removing obsolete design documents and indexes when they are no longer needed.
+      parameters:
+        - name: preview
+          in: query
+          description: 'If set, a dry-run will be done to return what would be removed.'
+          schema:
+            type: string
+            default: 'false'
       responses:
         '200':
           description: Returned results
@@ -3157,16 +3148,16 @@ paths:
                 type: object
                 properties:
                   post_upgrade_results:
-                    type: object
                     description: A map of databases.
+                    type: object
                     properties:
                       database_name:
-                        type: object
                         description: The database name that was targetted.
+                        type: object
                         properties:
                           removed_design_docs:
-                            type: array
                             description: The design documents that have or will be removed.
+                            type: array
                             items:
                               type: string
                           removed_indexes:
@@ -3178,57 +3169,61 @@ paths:
                           - removed_design_docs
                           - removed_indexes
                   preview:
-                    type: boolean
                     description: 'If set, nothing in the database was changed as this was a dry-run. This can be controlled by the `preview` query parameter in the request.'
+                    type: boolean
                 required:
                   - post_upgrade_results
       tags:
         - Admin
-      summary: Run the post upgrade process on all databases
-      parameters:
-        - schema:
-            type: string
-            default: 'false'
-          in: query
-          name: preview
-          description: 'If set, a dry-run will be done to return what would be removed.'
-      description: The post upgrade process involves removing obsolete design documents and indexes when they are no longer needed.
   '/{db}/_config':
     get:
+      summary: Get database configuration
+      description: Retrieve the full configuration for the database specified.
+      parameters:
+        - $ref: '#/components/parameters/deprecated-redact'
+        - name: include_javascript
+          in: query
+          description: 'Include the fields that have Javascript functions in the response. E.g. sync function, import filter, and event handlers.'
+          schema:
+            type: boolean
+            default: true
+        - $ref: '#/components/parameters/include_runtime'
+        - name: refresh_config
+          in: query
+          description: Forces the configuration to be reloaded on the Sync Gateway node.
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           description: Successfully retrieved database configuration
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Database'
           headers:
             Etag:
               schema:
                 type: string
-              description: The database configuration revision.
+              description: The database configuration version. Use with If-Match for optimistic concurrency control.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Database'
         '404':
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      summary: Get an existing database configuration
-      parameters:
-        - $ref: '#/components/parameters/redact'
-        - name: include_javascript
-          schema:
-            type: boolean
-            default: 'true'
-          in: query
-          description: 'Include the fields that have Javascript functions in the response. This is the sync function, import filter, document changed event, and database state changed event.'
-        - $ref: '#/components/parameters/include_runtime'
-        - name: refresh_config
-          schema:
-            type: boolean
-            default: 'false'
-          in: query
-          description: Forces the configuration to be loaded out the bucket and applied on the Sync Gateway node..
-      description: Retrieve the full configuration for the database specified.
     put:
+      summary: Replace database configuration
+      description: |-
+        Replaces the database configuration with the one sent in the request.
+
+        The bucket and database name cannot be changed. If these need to be changed, the database will need to be deleted then recreated with the new settings.
+      parameters:
+        - $ref: '#/components/parameters/DB-config-If-Match'
+      requestBody:
+        description: The new database configuration to use
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Database'
       responses:
         '201':
           $ref: '#/components/responses/DB-config-updated'
@@ -3237,32 +3232,23 @@ paths:
         '404':
           $ref: '#/components/responses/Not-found'
         '412':
-          description: Precondition Failed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTP-Error'
+          $ref: '#/components/responses/DB-config-precondition-failed'
       tags:
         - Admin
-      summary: Replace an existing database configuration
+    post:
+      summary: Update database configuration
       description: |-
-        This is used to replace the whole database configuration with a new one. 
+        This is used to update the database configuration fields specified. Only the fields specified in the request will have their values replaced.
 
         The bucket and database name cannot be changed. If these need to be changed, the database will need to be deleted then recreated with the new settings.
+      parameters:
+        - $ref: '#/components/parameters/DB-config-If-Match'
       requestBody:
+        description: The database configuration fields to update
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/Database'
-        description: The new database configuration to use
-      parameters:
-        - name: If-Match
-          schema:
-            type: string
-          in: header
-          description: Database revision to replace. This will cause a HTTP 412 response if it does not match the latest database configuration revision.
-    post:
-      summary: Update an existing database configuration
       responses:
         '201':
           $ref: '#/components/responses/DB-config-updated'
@@ -3271,23 +3257,7 @@ paths:
         '404':
           description: Not Found
         '412':
-          description: Precondition Failed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTP-Error'
-      description: |-
-        This is used to update the database configuration fields specified. This means that only the fields specified in the request will have their values replaced.
-
-        The bucket and database name cannot be changed. If these need to be changed, the database will need to be deleted then recreated with the new settings.
-      parameters:
-        - $ref: '#/components/parameters/DB-config-If-Match'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Database'
-        description: The database configuration fields to update
+          $ref: '#/components/responses/DB-config-precondition-failed'
       tags:
         - Admin
     parameters:
@@ -3296,6 +3266,11 @@ paths:
     parameters:
       - $ref: '#/components/parameters/db'
     get:
+      summary: Get database sync function
+      description: |-
+        This returns the database's sync function.
+
+        Response will be blank if there has been no sync function set.
       responses:
         '200':
           description: Successfully retrieved the sync function
@@ -3308,16 +3283,29 @@ paths:
             application/javascript:
               schema:
                 type: string
+              example: |-
+                function (doc, oldDoc) {
+                  channel(doc.channels);
+                }
         '404':
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      summary: Get the database sync function
-      description: |-
-        This returns the database's sync function that documents are ran through when created.
-
-        Response will be blank if there has been no sync function set.
     put:
+      summary: Set database sync function
+      description: This will allow you to update the sync function.
+      parameters:
+        - $ref: '#/components/parameters/DB-config-If-Match'
+      requestBody:
+        description: The new sync function to use
+        content:
+          application/javascript:
+            schema:
+              type: string
+            example: |-
+              function (doc, oldDoc) {
+                channel(doc.channels);
+              }
       responses:
         '200':
           description: Updated sync function successfully
@@ -3326,51 +3314,40 @@ paths:
         '404':
           $ref: '#/components/responses/Not-found'
         '412':
-          description: Precondition Failed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTP-Error'
+          $ref: '#/components/responses/DB-config-precondition-failed'
       tags:
         - Admin
-      summary: Replace the database sync function
-      description: This will allow you to update the sync function that documents are ran through on creation.
-      parameters:
-        - $ref: '#/components/parameters/DB-config-If-Match'
-      requestBody:
-        content:
-          application/javascript:
-            schema:
-              type: string
-            examples:
-              Example:
-                value: 'function(doc, oldDoc) { channel(doc.channels); }'
-        description: The new sync function to use
     delete:
+      summary: Remove custom sync function
+      description: |-
+        This will remove the custom sync function from the database configuration.
+
+        The default sync function is equivalent to:
+        ```javascript
+        function (doc) {
+          channel(doc.channels);
+        }
+        ```
+      parameters:
+        - $ref: '#/components/parameters/If-Match'
       responses:
         '200':
           description: Successfully reset the sync function
         '404':
           $ref: '#/components/responses/Not-found'
         '412':
-          description: Precondition Failed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTP-Error'
+          $ref: '#/components/responses/DB-config-precondition-failed'
       tags:
         - Admin
-      summary: Reset the sync function back to it's default
-      description: |-
-        This will delete the current sync function from the database configuration so that Sync Gateway will instead use the default function.
-
-        The default sync function is: `function(doc){channel(doc.channels);}`.
-      parameters:
-        - $ref: '#/components/parameters/If-Match'
   '/{db}/_config/import_filter':
     parameters:
       - $ref: '#/components/parameters/db'
     get:
+      summary: Get database import filter
+      description: |-
+        This returns the database's import filter that documents are ran through when importing.
+
+        Response will be blank if there has been no import filter set.
       responses:
         '200':
           description: Successfully retrieved the import filter
@@ -3387,12 +3364,17 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      summary: Get the database import filter
-      description: |-
-        This returns the database's import filter that documents are ran through when importing.
-
-        Response will be blank if there has been no import filter set.
     put:
+      summary: Set database import filter
+      description: This will allow you to update the database's import filter.
+      parameters:
+        - $ref: '#/components/parameters/DB-config-If-Match'
+      requestBody:
+        description: The import filter to use
+        content:
+          application/javascript:
+            schema:
+              type: string
       responses:
         '200':
           description: Updated import filter successfully
@@ -3401,48 +3383,32 @@ paths:
         '404':
           $ref: '#/components/responses/Not-found'
         '412':
-          description: Precondition Failed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTP-Error'
+          $ref: '#/components/responses/DB-config-precondition-failed'
       tags:
         - Admin
-      summary: Replace the database import filter
-      description: This will allow you to update the import filter that documents are ran through when importing.
+    delete:
+      summary: Delete import filter
+      description: This will remove the custom import filter function from the database configuration so that Sync Gateway will not filter any documents during import.
       parameters:
         - $ref: '#/components/parameters/DB-config-If-Match'
-      requestBody:
-        content:
-          application/javascript:
-            schema:
-              type: string
-        description: The import filter to use
-    delete:
       responses:
         '200':
           description: Successfully deleted the import filter
         '404':
           $ref: '#/components/responses/Not-found'
         '412':
-          description: Precondition Failed
-          content:
-            application/json:
-              schema:
-                type: object
+          $ref: '#/components/responses/DB-config-precondition-failed'
       tags:
         - Admin
-      summary: Delete the import filter
-      description: This will delete the current import filter from the database configuration so that Sync Gateway will not filter any documents during import.
-      parameters:
-        - $ref: '#/components/parameters/DB-config-If-Match'
   '/{db}/_resync':
     parameters:
       - $ref: '#/components/parameters/db'
     get:
+      summary: Get resync status
+      description: This will retrieve the status of last resync operation (whether it is running or not).
       responses:
         '200':
-          description: Sucessfully retrieved the most recent resync operation status
+          description: successfully retrieved the most recent resync operation status
           content:
             application/json:
               schema:
@@ -3451,12 +3417,39 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      summary: Get the most recent resync operation details
-      description: This will retrieve the status of last resync operation (whether it is running or not).
     post:
+      summary: Start or stop Resync
+      description: |
+        This can be used to start or stop a resync operation. A resync operation will cause all documents in the database to be reprocessed through the database sync function. 
+
+        Generally, a resync operation might be wanted when the sync function has been modified in such a way that the channel or access mappings for any existing documents would change as a result.
+
+        A resync operation cannot be run if the database is online. The database can be taken offline by calling the `POST /{db}/_offline` endpoint.
+
+        In a multi-node cluster, the resync operation *must* be run on only a single node. Therefore, users should bring other nodes offline before initiating this action. Undefined system behaviour will happen if running resync on more than 1 node.
+
+        The `requireUser()` and `requireRole()` calls in the sync function will always return `true`. 
+
+        - **action=start** - This is an asynchronous operation, and will start resync in the background.
+        - **action=stop** - This will stop the currently running resync operation.
+      parameters:
+        - name: action
+          in: query
+          description: This is whether to start a new resync job or stop an existing one.
+          schema:
+            type: string
+            default: start
+            enum:
+              - start
+              - stop
+        - name: regenerate_sequences
+          in: query
+          description: '**Use this only when requested to do so by the Couchbase support team** This request will regenerate the sequence numbers for each document processed.'
+          schema:
+            type: boolean
       responses:
         '200':
-          description: Sucessfully changed the status of the resync operation
+          description: successfully changed the status of the resync operation
           content:
             application/json:
               schema:
@@ -3469,40 +3462,43 @@ paths:
                 $ref: '#/components/schemas/HTTP-Error'
       tags:
         - Admin
-      description: |
-        This can be used to start or stop a resync operation. A resync operation will cause all documents in the database to be reprocessed through the database sync function. 
-
-        Generally, a resync operation might be wanted when the sync function has been modified in such a way that the channel or access mappings for any existing documents would change as a result.
-
-        **action=start**
-        This is an asynchronous operation.
-
-        The `requireUser()` and `requireRole()` calls in the sync function will always return `true`. 
-
-        A resync operation cannot be done if the database is online. The database can be taken offline by calling the `POST /{db}/_offline` endpoint.
-
-        **action=stop**
-        This will stop the currently running resync operation.
-      summary: Reprocess all documents through the sync function
-      parameters:
-        - name: action
-          schema:
-            type: string
-            enum:
-              - start
-              - stop
-            default: start
-          in: query
-          description: This is whether to start a new resync job or stop an existing one.
-        - name: regenerate_sequences
-          schema:
-            type: boolean
-          in: query
-          description: '**Use this only when requested to do so by the Couchbase support team** This request will regenerate the sequence numbers for each document processed. It is only carried out on this node. It is not cross-node aware. In a multi-node cluster, the resync operation must only be ran on one node therefore, users should bring other nodes offline before initiating this action. Undefined system behaviour will happen if running resync on more than 1 node.'
   '/{db}/_purge':
     parameters:
       - $ref: '#/components/parameters/db'
     post:
+      summary: Purge a document
+      description: |-
+        The purge command provides a way to remove a document from the database. The operation removes *all* revisions (active and tombstones) for the specified document(s). A common usage of this endpoint is to remove tombstone documents that are no longer needed, thus recovering storage space and reducing data replicated to clients. Other clients are not notified when a revision has been purged; so in order to purge a revision from the system it must be done from all databases (on Couchbase Lite and Sync Gateway).
+
+        When `enable_shared_bucket_access` is enabled, this endpoint removes the document and its associated extended attributes.
+      requestBody:
+        description: Purge request body
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                doc_id:
+                  description: |-
+                    The document ID to purge. The array must only be 1 element which is `*`.
+
+                    All revisions will be permanently removed for that document.
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                      - '*'
+            examples:
+              Example:
+                value:
+                  doc_id:
+                    - '*'
+              Multiple purges example:
+                value:
+                  doc_id_1:
+                    - '*'
+                  doc_id_2:
+                    - '*'
       responses:
         '200':
           description: 'Attempted documents purge. Check output to verify the documents that were purged. The document IDs will not be listed if they have not been purged (for example, due to no existing).'
@@ -3543,43 +3539,17 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      description: |-
-        The purge command provides a way to remove a document from the bucket itself. The operation removes all the revisions (active and tombstones) for the specified document(s). A common usage of this endpoint is to remove tombstone documents that are no longer needed, thus recovering storage space and reducing data replicated to clients. Other clients are not notified when a revision has been purged; so in order to purge a revision from the system it must be done from all databases (on Couchbase Lite and Sync Gateway).
-
-        When convergence is enabled, this endpoint removes the document and its associated extended attributes.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                doc_id:
-                  type: array
-                  description: |-
-                    The document ID to purge. The array must only be 1 element which is `*`.
-
-                    All revisions will be permanently removed for that document.
-                  items:
-                    type: string
-                    enum:
-                      - '*'
-            examples:
-              Example:
-                value:
-                  doc_id:
-                    - '*'
-              Multiple purges example:
-                value:
-                  doc_id_1:
-                    - '*'
-                  doc_id_2:
-                    - '*'
-        description: Purge request body
-      summary: Remove a document from the bucket
   '/{db}/_flush':
     parameters:
       - $ref: '#/components/parameters/db'
     post:
+      summary: Flush the entire database bucket | Unsupported
+      description: |-
+        **This is unsupported**
+
+        This will purge ***all*** documents.
+
+        The bucket will only be flushed if the unsupported database configuration option `enable_couchbase_bucket_flush` is set.
       responses:
         '200':
           description: Successfully flushed the bucket
@@ -3593,29 +3563,10 @@ paths:
                 $ref: '#/components/schemas/HTTP-Error'
       tags:
         - Admin
-      summary: Flush the entire database bucket | Unsupported
-      description: |-
-        **This is unsupported**
-        This will remove all documents in the entire bucket that the database uses.
-
-        The bucket will only be flushed if the unsupported database configuration option `enable_couchbase_bucket_flush` is set.
   '/{db}/_online':
     parameters:
       - $ref: '#/components/parameters/db'
     post:
-      responses:
-        '200':
-          description: Database will be brought online immediately or with the specified delay
-        '404':
-          $ref: '#/components/responses/Not-found'
-        '503':
-          description: An error occurred
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTP-Error'
-      tags:
-        - Admin
       summary: Bring the database online
       description: |-
         This will bring the database online so the Public and full Admin REST API requests can be served.
@@ -3629,20 +3580,46 @@ paths:
         * Make the database available for Couchbase Lite clients at a specific time.
         * Make the databases on several Sync Gateway instances available at the same time.
       requestBody:
+        description: Add an optional delay to wait before bringing the database online
         content:
           application/json:
             schema:
               type: object
               properties:
                 delay:
-                  type: integer
                   description: The amount of seconds to delay bringing the database online.
+                  type: integer
                   default: 0
-        description: Add an optional delay to wait before bringing the database online
+      responses:
+        '200':
+          description: Database will be brought online immediately or with the specified delay
+        '404':
+          $ref: '#/components/responses/Not-found'
+        '503':
+          description: An error occurred
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTP-Error'
+      tags:
+        - Admin
   '/{db}/_offline':
     parameters:
       - $ref: '#/components/parameters/db'
     post:
+      summary: Take the database offline
+      description: |
+        This will take the database offline meaning actions can be taken without disrupting current operations ungracefully or having the restart the Sync Gateway instance.
+
+        This will not take the backing Couchbase Server bucket offline. 
+
+        Taking a database offline that is in the progress of coming online will take the database offline after it comes online.
+
+        Taking the database offline will:
+        * Close all active `_changes` feeds for the database.
+        * Reject all access to the database via the Public REST API (returning a 503 Service Unavailable code).
+        * Reject most Admin API requests (by returning a 503 Service Unavailable code). The only endpoints to be available are: the resync endpoints, the configuration endpoints, `DELETE, GET, HEAD /{db}/`, `POST /{db}/_offline`, and `POST /{db}/_online`. 
+        * Stops webhook event handlers.
       responses:
         '200':
           description: Database has been taken offline successfully
@@ -3656,24 +3633,15 @@ paths:
                 $ref: '#/components/schemas/HTTP-Error'
       tags:
         - Admin
-      summary: Take the database offline
-      description: |
-        This will take the database offline meaning actions can be taken without distrupting current operations ungracefully or having the restart the Sync Gateway instance. 
-
-        This will not take the backing Couchbase Server bucket offline. 
-
-        Taking a database offline that is in the progress of coming online will take the database offline after it comes online.
-
-        Taking the database offline will:
-        * Close all active `_changes` feeds for the database.
-        * Reject all access to the database via the Public REST API (returning a 503 Service Unavailable code).
-        * Reject most Admin API requests (by returning a 503 Service Unavailable code). The only endpoints to be available are: the resync endpoints, the configuration endpoints, `DELETE, GET, HEAD /{db}/`, `POST /{db}/_offline`, and `POST /{db}/_online`. 
-        * Stops webhook event handlers.
   '/{db}/_dump/{view}':
     parameters:
       - $ref: '#/components/parameters/db'
       - $ref: '#/components/parameters/view'
     get:
+      summary: Dump a view | Unsupported
+      description: |-
+        **This is unsupported**
+        This queries the view and outputs it as HTML.
       responses:
         '200':
           description: Retrieved view successfully
@@ -3691,15 +3659,82 @@ paths:
                 $ref: '#/components/schemas/HTTP-Error'
       tags:
         - Admin
-      description: |-
-        **This is unsupported**
-        This queries the view and outputs it as HTML.
-      summary: Dump a view | Unsupported
   '/{db}/_view/{view}':
     parameters:
       - $ref: '#/components/parameters/db'
       - $ref: '#/components/parameters/view'
     get:
+      summary: Query a view on the default design document | Unsupported
+      description: |-
+        **This is unsupported**
+        Query a view on the default Sync Gateway design document.
+      parameters:
+        - name: inclusive_end
+          in: query
+          description: Indicates whether the specified end key should be included in the result.
+          schema:
+            type: boolean
+        - name: descending
+          in: query
+          description: Return documents in descending order.
+          schema:
+            type: boolean
+        - name: include_docs
+          in: query
+          description: Only works when using Couchbase Server 3.0 and earlier. Indicates whether to include the full content of the documents in the response.
+          schema:
+            type: boolean
+        - name: reduce
+          in: query
+          description: Whether to execute a reduce function on the response or not.
+          schema:
+            type: boolean
+        - name: group
+          in: query
+          description: Group the results using the reduce function to a group or single row.
+          schema:
+            type: boolean
+        - name: skip
+          in: query
+          description: Skip the specified number of documents before starting to return results.
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: Return only the specified number of documents
+          schema:
+            type: integer
+        - name: group_level
+          in: query
+          description: Specify the group level to be used.
+          schema:
+            type: integer
+        - name: startkey_docid
+          in: query
+          description: Return documents starting with the specified document identifier.
+          schema:
+            type: string
+        - name: endkey_docid
+          in: query
+          description: Stop returning records when the specified document identifier is reached.
+          schema:
+            type: string
+        - name: stale
+          in: query
+          description: 'Allow the results from a stale view to be used, without triggering a rebuild of all views within the encompassing design document.'
+          schema:
+            type: string
+            enum:
+              - ok
+              - update_after
+        - $ref: '#/components/parameters/startkey'
+        - $ref: '#/components/parameters/endkey'
+        - name: key
+          in: query
+          description: Return only the document that matches the specified key.
+          schema:
+            type: string
+        - $ref: '#/components/parameters/keys'
       responses:
         '200':
           description: Returned view successfully
@@ -3742,87 +3777,26 @@ paths:
       tags:
         - Admin
         - Public
-      parameters:
-        - name: inclusive_end
-          schema:
-            type: boolean
-          in: query
-          description: Indicates whether the specified end key should be included in the result.
-        - name: descending
-          schema:
-            type: boolean
-          in: query
-          description: Return documents in descending order.
-        - name: include_docs
-          in: query
-          schema:
-            type: boolean
-          description: Only works when using Couchbase Server 3.0 and earlier. Indicates whether to include the full content of the documents in the response.
-        - name: reduce
-          schema:
-            type: boolean
-          in: query
-          description: Whether to execute a reduce function on the response or not.
-        - name: group
-          schema:
-            type: boolean
-          in: query
-          description: Group the results using the reduce function to a group or single row.
-        - name: skip
-          schema:
-            type: integer
-          in: query
-          description: Skip the specified number of documents before starting to return results.
-        - name: limit
-          in: query
-          schema:
-            type: integer
-          description: Return only the specified number of documents
-        - name: group_level
-          schema:
-            type: integer
-          in: query
-          description: Specify the group level to be used.
-        - name: startkey_docid
-          schema:
-            type: string
-          in: query
-          description: Return documents starting with the specified document identifier.
-        - name: endkey_docid
-          schema:
-            type: string
-          in: query
-          description: Stop returning records when the specified document identifier is reached.
-        - name: stale
-          schema:
-            type: string
-            enum:
-              - ok
-              - update_after
-          in: query
-          description: 'Allow the results from a stale view to be used, without triggering a rebuild of all views within the encompassing design document.'
-        - $ref: '#/components/parameters/startkey'
-        - $ref: '#/components/parameters/endkey'
-        - name: key
-          schema:
-            type: string
-          in: query
-          description: Return only the document that matches the specified key.
-        - $ref: '#/components/parameters/keys'
-      description: |-
-        **This is unsupported**
-        Query a view on the default Sync Gateway design document.
-      summary: Query a view on the default design document | Unsupported
   '/{db}/_dumpchannel/{channel}':
     parameters:
       - $ref: '#/components/parameters/db'
       - name: channel
+        in: path
+        description: The channel to dump all the documents from.
+        required: true
         schema:
           type: string
-        in: path
-        required: true
-        description: The channel to dump all the documents from.
     get:
+      summary: Dump all the documents in a channel | Unsupported
+      description: |-
+        **This is unsupported**
+        This queries a channel and displays all the document IDs and revisions that are in that channel.
+      parameters:
+        - name: since
+          in: query
+          description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
+          schema:
+            type: string
       responses:
         '200':
           description: Successfully got all documents in the channel
@@ -3834,29 +3808,21 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      description: |-
-        **This is unsupported**
-        This queries a channel and displays all the document IDs and revisions that are in that channel.
-      summary: Dump all the documents in a channel | Unsupported
-      parameters:
-        - in: query
-          name: since
-          description: The minimum sequence number to retrieve the documents from.
-          schema:
-            type: integer
   '/{db}/_repair':
     parameters:
       - $ref: '#/components/parameters/db'
     post:
+      summary: ''
+      description: This endpoint is disabled.
       responses:
         '500':
           description: This endpoint is disabled
       tags:
         - Admin
-      description: This endpoint is disabled.
-      summary: ''
   /_all_dbs:
     get:
+      summary: Get a list of all the databases
+      description: This retrieves all the database's names that are in the current Sync Gateway node.
       responses:
         '200':
           description: Successfully retrieved all database names
@@ -3868,8 +3834,6 @@ paths:
                   type: string
       tags:
         - Admin
-      description: This retrieves all the database's names that are in the current Sync Gateway node.
-      summary: Get a list of all the databases
     head:
       responses:
         '200':
@@ -3880,6 +3844,36 @@ paths:
     parameters:
       - $ref: '#/components/parameters/db'
     post:
+      summary: Manage a compact operation
+      description: |-
+        This allows a new compact operation to be done on the database, or to stop an existing running compact operation. 
+
+        The type of compaction that is done depends on what the `type` query parameter is set to. The 2 options will:
+        * `tombstone` - purge the JSON bodies of non-leaf revisions. This is known as database compaction. Database compaction is done periodically automatically by the system. JSON bodies of leaf nodes (conflicting branches) are not removed therefore it is important to resolve conflicts in order to re-claim disk space.
+        * `attachment` - purge all unlinked/unused legacy (pre 3.0) attachments. If the previous attachment compact operation failed, this will attempt to restart the `compact_id` at the appropriate phase (if possible).
+
+        Both types can each have a maximum of 1 compact operation running at any one point. This means that an attachment compaction can be running at the same time as a tombstone compaction but not 2 tombstone compactions.
+      parameters:
+        - $ref: '#/components/parameters/compact-type'
+        - name: action
+          in: query
+          description: Defines whether the a compact operation is being started or stopped.
+          schema:
+            type: string
+            default: start
+            enum:
+              - start
+              - stop
+        - name: reset
+          in: query
+          description: '**Attachment compaction only**: This forces a fresh compact start instead of trying to resume the previous failed compact operation.'
+          schema:
+            type: boolean
+        - name: dry_run
+          in: query
+          description: '**Attachment compaction only**: This will run through all 3 stages of attachment compact but will not purge any attachments. This can be used to check how many attachments will be purged.'
+          schema:
+            type: boolean
       responses:
         '200':
           description: Started or stopped compact operation successfully
@@ -3895,37 +3889,11 @@ paths:
                 $ref: '#/components/schemas/HTTP-Error'
       tags:
         - Admin
+    get:
+      summary: Get the status of the most recent compact operation
+      description: This will retrieve the current status of the most recent compact operation.
       parameters:
         - $ref: '#/components/parameters/compact-type'
-        - schema:
-            type: string
-            default: start
-            enum:
-              - start
-              - stop
-          in: query
-          name: action
-          description: Defines whether the a compact operation is being started or stopped.
-        - schema:
-            type: boolean
-          in: query
-          name: reset
-          description: '**Attachment compaction only**: This forces a fresh compact start instead of trying to resume the previous failed compact operation.'
-        - schema:
-            type: boolean
-          in: query
-          name: dry_run
-          description: '**Attachment compaction only**: This will run through all 3 stages of attachment compact but will not purge any attachments. This can be used to check how many attachments will be purged.'
-      summary: Manage a compact operation
-      description: |-
-        This allows a new compact operation to be done on the database, or to stop an existing running compact operation. 
-
-        The type of compaction that is done depends on what the `type` query parameter is set to. The 2 options will:
-        * `tombstone` - purge the JSON bodies of non-leaf revisions. This is known as database compaction. Database compaction is done periodically automatically by the system. JSON bodies of leaf nodes (conflicting branches) are not removed therefore it is imporant to resolve conflicts in order to re-claim disk space.
-        * `attachment` - purge all unlinked/unused legacy (pre 3.0) attachments. If the previous attachment compact operation failed, this will attempt to restart the `compact_id` at the appropiate phase (if possible).
-
-        Both types can each have a maximum of 1 compact operation running at any one point. This means that an attachment compaction can be running at the same time as a tombstone compaction but not 2 tombstone compactions.
-    get:
       responses:
         '200':
           description: Compaction status retrieved successfully
@@ -3939,12 +3907,10 @@ paths:
           $ref: '#/components/responses/Not-found'
       tags:
         - Admin
-      parameters:
-        - $ref: '#/components/parameters/compact-type'
-      summary: Get the status of the most recent compact operation
-      description: This will retrieve the current status of the most recent compact operation.
   /_metrics:
     get:
+      summary: Debugging/monitoring runtime stats in Prometheus Exposition format
+      description: Returns Sync Gateway statistics and other runtime variables in Prometheus Exposition format.
       responses:
         '200':
           description: Successfully returned stats
@@ -3953,69 +3919,40 @@ paths:
               schema:
                 type: string
       tags:
-        - Metric
-      summary: Get monitoring statistics in Prometheus format
-      description: |-
-        This returns Sync Gateway statistics and other runtime variables in Prometheus format. 
-
-        Generally, this is used for debugging or performance monitoring purposes.
+        - Metrics
   /_expvar:
     get:
+      summary: Get all Sync Gateway statistics
+      description: |-
+        This returns a snapshot of all metrics in Sync Gateway for debugging and monitoring purposes.
+
+        This includes per database stats, replication stats, and server stats.
       responses:
         '200':
           description: Returned statistics
+          content:
+            application/javascript:
+              schema:
+                $ref: '#/components/schemas/ExpVars'
       tags:
         - Admin
-        - Metric
-      summary: Get all Sync Gateway debug statistics
-      description: |-
-        This returns all the statistics of Sync Gateway for debugging purposes.
-
-        This includes per database stats, replication stats, and server stats.
+        - Metrics
 components:
   parameters:
-    db:
-      name: db
-      in: path
-      required: true
-      schema:
-        type: string
-      description: The name of the database to run the operation against.
-    newdb:
-      name: newdb
-      in: path
-      required: true
-      schema:
-        type: string
-      description: The name of the new database.
-    docid:
-      name: docid
-      in: path
-      required: true
-      schema:
-        type: string
-      description: The document ID to run the operation against.
-    user-name:
-      name: name
-      in: path
-      required: true
-      schema:
-        type: string
-      description: The name of the user.
-    role-name:
-      name: name
-      in: path
-      required: true
-      schema:
-        type: string
-      description: The name of the role.
-    include_docs:
-      name: include_docs
-      in: query
+    DB-config-If-Match:
+      name: If-Match
+      in: header
       required: false
       schema:
         type: string
-      description: Include the body associated with each document.
+      description: 'If set to a configuration''s Etag value, enables optimistic concurrency control for the request. Returns HTTP 412 if another update happened underneath this one.'
+    If-Match:
+      name: If-Match
+      in: header
+      required: false
+      schema:
+        type: string
+      description: The revision ID to target.
     Include-channels:
       name: channels
       in: query
@@ -4023,6 +3960,72 @@ components:
       schema:
         type: string
       description: Include the channels each document is part of that the calling user also has access too.
+    atts_since:
+      name: atts_since
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+      description: Include attachments only since specified revisions. Excludes the attachments for the specified revisions. Only gets used if `attachments=true`.
+    compact-type:
+      name: type
+      in: query
+      required: false
+      schema:
+        type: string
+        default: tombstone
+        enum:
+          - attachment
+          - tombstone
+      description: 'This is the type of compaction to use. The type must be either: `attachment` for cleaning up legacy (pre-3.0) attachments, or `tombstone` for purging the JSON bodies of non-leaf revisions.'
+    db:
+      name: db
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The name of the database to run the operation against.
+    ddoc:
+      name: ddoc
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The design document name.
+    debug-profile-seconds:
+      name: seconds
+      in: query
+      required: false
+      schema:
+        type: integer
+        default: 30
+        minimum: 0
+      description: The amount of seconds to run the profiler for.
+    deprecated-redact:
+      name: redact
+      in: query
+      deprecated: true
+      required: false
+      schema:
+        type: boolean
+        default: 'true'
+      description: No longer supported field.
+    docid:
+      name: docid
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The document ID to run the operation against.
+    endkey:
+      name: endkey
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Stop returning records when this key is reached.
     include-access:
       name: access
       in: query
@@ -4044,6 +4047,35 @@ components:
       schema:
         type: string
       description: Include the document sequence number `update_seq` property for each document.
+    includeAttachments:
+      name: attachments
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Include attachment bodies in response.
+    include_doc:
+      name: include_doc
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Include the body associated with the document.
+    include_docs:
+      name: include_docs
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Include the body associated with each document.
+    include_runtime:
+      name: include_runtime
+      in: query
+      required: false
+      schema:
+        type: boolean
+        default: false
+      description: 'Whether to include the values set at runtime, and default values.'
     keys:
       name: keys
       in: query
@@ -4053,144 +4085,6 @@ components:
         items:
           type: string
       description: An array of document ID strings to filter by.
-    provider:
-      name: provider
-      in: query
-      required: false
-      schema:
-        type: string
-      description: 'The OpenID Connect provider to use for authentication.  The list of providers are defined in the Sync Gateway config. If left empty, the default provider will be used.'
-    offline:
-      name: offline
-      in: query
-      required: false
-      schema:
-        type: string
-      description: 'If true, the OpenID Connect provider is requested to confirm with the user the permissions requested and refresh the OIDC token. To do this, access_type=offline and prompt=consent is set on the redirection link.'
-    oidc-code:
-      name: code
-      in: query
-      required: true
-      schema:
-        type: string
-      description: The OpenID Connect authentication code.
-    oidc-state:
-      name: state
-      in: query
-      required: false
-      schema:
-        type: string
-      description: The OpenID Connect state to verify against the state cookie. This is used to prevent cross-site request forgery (CSRF). This is not required if `disable_callback_state=true` for the provider config (NOT recommended).
-    oidc-scope:
-      name: scope
-      in: query
-      required: true
-      schema:
-        type: string
-      description: The OpenID Connect authentication scope.
-    oidc-redirect_uri:
-      name: redirect_uri
-      in: query
-      required: false
-      schema:
-        type: string
-      description: The Sync Gateway OpenID Connect callback URL.
-    rev:
-      name: rev
-      in: query
-      required: false
-      schema:
-        type: string
-      description: The document revision to target.
-    show_exp:
-      name: show_exp
-      in: query
-      required: false
-      schema:
-        type: string
-      description: Whether to show the expiry property (`_exp`) in the response.
-    revs_from:
-      name: revs_from
-      in: query
-      required: false
-      schema:
-        type: array
-        items:
-          type: string
-      description: 'Trim the revision history to stop at the first revision in the provided list. If no match is found, the revisions will be trimmed to the `revs_limit`.'
-    atts_since:
-      name: atts_since
-      in: query
-      required: false
-      schema:
-        type: array
-        items:
-          type: string
-      description: Include attachments only since specified revisions. Excludes the attachments for the specified revisions. Only gets used if `attachments=true`.
-    revs_limit:
-      name: revs_limit
-      in: query
-      required: false
-      schema:
-        type: integer
-      description: Maximum amount of revisions to return for each document.
-    includeAttachments:
-      name: attachments
-      in: query
-      required: false
-      schema:
-        type: string
-      description: Include attachment bodies in response.
-    replicator2:
-      name: replicator2
-      in: query
-      required: false
-      schema:
-        type: boolean
-      description: Returns the document with the required properties for replication. This is an enterprise-edition only feature.
-    roundtrip:
-      name: roundtrip
-      in: query
-      required: false
-      schema:
-        type: boolean
-      description: Block until document has been received by change cache
-    new_edits:
-      name: new_edits
-      in: query
-      required: false
-      schema:
-        type: boolean
-        default: 'true'
-      description: 'Setting this to false indicates that the request body is an already-existing revision that should be directly inserted into the database, instead of a modification to apply to the current document. This mode is used for replication.  This option must be used in conjunction with the `_revisions` property in the request body.'
-    If-Match:
-      name: If-Match
-      in: header
-      required: false
-      schema:
-        type: string
-      description: The revision ID to target.
-    include_doc:
-      name: include_doc
-      in: query
-      required: false
-      schema:
-        type: string
-      description: Include the body associated with the document.
-    startkey:
-      name: startkey
-      in: query
-      required: false
-      schema:
-        type: string
-      description: Return records starting with the specified key.
-    endkey:
-      name: endkey
-      in: query
-      required: false
-      schema:
-        type: string
-      description: Stop returning records when this key is reached.
     limit:
       name: limit
       in: query
@@ -4198,103 +4092,6 @@ components:
       schema:
         type: number
       description: This limits the number of result rows returned. Using a value of `0` has the same effect as the value `1`.
-    ddoc:
-      name: ddoc
-      in: path
-      required: true
-      schema:
-        type: string
-      description: The design document name.
-    open_revs:
-      name: open_revs
-      in: query
-      required: false
-      schema:
-        type: array
-        items:
-          type: string
-      description: 'Option to fetch specified revisions of the document. The value can be all to fetch all leaf revisions or an array of revision numbers (i.e. open_revs=["rev1", “rev2”]). Only leaf revision bodies that haven’t been pruned are guaranteed to be returned. If this option is specified the response will be in multipart format. Use the `Accept: application/json` request header to get the result as a JSON object.'
-    replicationid:
-      name: replicationid
-      in: path
-      required: true
-      schema:
-        type: string
-      description: What replication to target based on it's replication ID.
-    replication-active-only:
-      name: activeOnly
-      in: query
-      required: false
-      schema:
-        type: boolean
-        default: 'false'
-      description: Only return replications that are actively running (`state=running`).
-    replication-local-only:
-      name: localOnly
-      in: query
-      required: false
-      schema:
-        type: boolean
-        default: 'false'
-      description: Only return replications that were started on the current Sync Gateway node.
-    replication-include-error:
-      name: includeError
-      in: query
-      required: false
-      schema:
-        type: boolean
-        default: 'true'
-      description: Include replications that have stopped due to an error (`state=error`).
-    replication-include-config:
-      name: includeConfig
-      in: query
-      required: false
-      schema:
-        type: boolean
-        default: 'false'
-      description: Include the replication configuration with each replicator status in the response.
-    redact:
-      name: redact
-      in: query
-      required: false
-      schema:
-        type: boolean
-        default: 'true'
-      description: No longer supported field.
-    include_runtime:
-      name: include_runtime
-      in: query
-      required: false
-      schema:
-        type: boolean
-        default: 'false'
-      description: Include the default values that Sync Gateway is running with (known as the runtime configuration).
-    DB-config-If-Match:
-      name: If-Match
-      in: header
-      required: false
-      schema:
-        type: string
-        default: The current revision
-      description: Database revision to replace. This will cause a HTTP 412 response if it does not match the latest database configuration revision.
-    compact-type:
-      name: type
-      in: query
-      required: false
-      schema:
-        type: string
-        default: tombstone
-        enum:
-          - attachment
-          - tombstone
-      description: 'This is the type of compaction to use. The type must be either: `attachment` for cleaning up legacy (pre-3.0) attachments, or `tombstone` for purging the JSON bodies of non-leaf revisions.'
-    view:
-      name: view
-      in: path
-      required: true
-      schema:
-        type: string
-      description: The view to target.
     log-level:
       name: logLevel
       in: query
@@ -4315,19 +4112,158 @@ components:
       required: false
       schema:
         type: integer
-        minimum: 1
         maximum: 3
+        minimum: 1
       deprecated: true
       description: '**Deprecated: use log level instead.** This sets the console log level depending on the value provide. 1 sets to `info`, 2 sets to `warn`, and 3 sets to `error`.'
-    debug-profile-seconds:
+    new_edits:
+      name: new_edits
+      in: query
+      required: false
+      schema:
+        type: boolean
+        default: 'true'
+      description: 'Setting this to false indicates that the request body is an already-existing revision that should be directly inserted into the database, instead of a modification to apply to the current document. This mode is used for replication.  This option must be used in conjunction with the `_revisions` property in the request body.'
+    offline:
+      name: offline
+      in: query
+      required: false
+      schema:
+        type: string
+      description: 'If true, the OpenID Connect provider is requested to confirm with the user the permissions requested and refresh the OIDC token. To do this, access_type=offline and prompt=consent is set on the redirection link.'
+    oidc-code:
+      name: code
+      in: query
+      required: true
+      schema:
+        type: string
+      description: The OpenID Connect authentication code.
+    oidc-redirect_uri:
+      name: redirect_uri
+      in: query
+      required: false
+      schema:
+        type: string
+      description: The Sync Gateway OpenID Connect callback URL.
+    oidc-scope:
+      name: scope
+      in: query
+      required: true
+      schema:
+        type: string
+      description: The OpenID Connect authentication scope.
+    oidc-state:
+      name: state
+      in: query
+      required: false
+      schema:
+        type: string
+      description: The OpenID Connect state to verify against the state cookie. This is used to prevent cross-site request forgery (CSRF). This is not required if `disable_callback_state=true` for the provider config (NOT recommended).
+    open_revs:
+      name: open_revs
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+      description: 'Option to fetch specified revisions of the document. The value can be all to fetch all leaf revisions or an array of revision numbers (i.e. open_revs=["rev1", "rev2"]). Only leaf revision bodies that haven''t been pruned are guaranteed to be returned. If this option is specified the response will be in multipart format. Use the `Accept: application/json` request header to get the result as a JSON object.'
+    pprof-seconds:
       name: seconds
+      in: query
+      description: 'If set, collect a delta profile for the given duration, instead of a snapshot.'
+      schema:
+        type: integer
+    provider:
+      name: provider
+      in: query
+      required: false
+      schema:
+        type: string
+      description: 'The OpenID Connect provider to use for authentication.  The list of providers are defined in the Sync Gateway config. If left empty, the default provider will be used.'
+    replication-active-only:
+      name: activeOnly
+      in: query
+      required: false
+      schema:
+        type: boolean
+        default: 'false'
+      description: Only return replications that are actively running (`state=running`).
+    replication-include-config:
+      name: includeConfig
+      in: query
+      required: false
+      schema:
+        type: boolean
+        default: 'false'
+      description: Include the replication configuration with each replicator status in the response.
+    replication-include-error:
+      name: includeError
+      in: query
+      required: false
+      schema:
+        type: boolean
+        default: 'true'
+      description: Include replications that have stopped due to an error (`state=error`).
+    replication-local-only:
+      name: localOnly
+      in: query
+      required: false
+      schema:
+        type: boolean
+        default: 'false'
+      description: Only return replications that were started on the current Sync Gateway node.
+    replicationid:
+      name: replicationid
+      in: path
+      required: true
+      schema:
+        type: string
+      description: What replication to target based on its replication ID.
+    replicator2:
+      name: replicator2
+      in: query
+      required: false
+      schema:
+        type: boolean
+      description: Returns the document with the required properties for replication. This is an enterprise-edition only feature.
+    rev:
+      name: rev
+      in: query
+      required: false
+      schema:
+        type: string
+      description: The document revision to target.
+    revs_from:
+      name: revs_from
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+      description: 'Trim the revision history to stop at the first revision in the provided list. If no match is found, the revisions will be trimmed to the `revs_limit`.'
+    revs_limit:
+      name: revs_limit
       in: query
       required: false
       schema:
         type: integer
-        minimum: 0
-        default: 30
-      description: The amount of seconds to run the profiler for.
+      description: Maximum amount of revisions to return for each document.
+    role-name:
+      name: name
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The name of the role.
+    roundtrip:
+      name: roundtrip
+      in: query
+      required: false
+      schema:
+        type: boolean
+      description: Block until document has been received by change cache
     sessionid:
       name: sessionid
       in: path
@@ -4335,6 +4271,2040 @@ components:
       schema:
         type: string
       description: The ID of the session to target.
+    show_exp:
+      name: show_exp
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Whether to show the expiry property (`_exp`) in the response.
+    startkey:
+      name: startkey
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Return records starting with the specified key.
+    user-name:
+      name: name
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The name of the user.
+    view:
+      name: view
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The view to target.
+  schemas:
+    ExpVars:
+      type: object
+      properties:
+        cmdline:
+          description: 'Built-in variables from the Go runtime, lists the command-line arguments'
+          type: object
+        memstats:
+          description: Dumps a large amount of information about the memory heap and garbage collector
+          type: object
+        cb:
+          description: Variables reported by the Couchbase SDK (go_couchbase package)
+          type: object
+        mc:
+          description: Variables reported by the low-level memcached API (gomemcached package)
+          type: object
+        syncGateway_changeCache:
+          type: object
+          properties:
+            maxPending:
+              description: Max number of sequences waiting on a missing earlier sequence number
+              type: object
+            lag-tap-0000ms:
+              description: Histogram of delay from doc save till it shows up in Tap feed
+              type: object
+            lag-queue-0000ms:
+              description: Histogram of delay from Tap feed till doc is posted to changes feed
+              type: object
+            lag-total-0000ms:
+              description: Histogram of total delay from doc save till posted to changes feed
+              type: object
+            outOfOrder:
+              description: Number of out-of-order sequences posted
+              type: object
+            view_queries:
+              description: Number of queries to channels view
+              type: object
+        syncGateway_db:
+          type: object
+          properties:
+            channelChangesFeeds:
+              description: 'Number of calls to db.changesFeed, i.e. generating a changes feed for a single channel.'
+              type: object
+            channelLogAdds:
+              description: Number of entries added to channel logs
+              type: object
+            channelLogAppends:
+              description: Number of times entries were written to channel logs using an APPEND operation
+              type: object
+            channelLogCacheHits:
+              description: Number of requests for channel-logs that were fulfilled from the in-memory cache
+              type: object
+            channelLogRewrites:
+              description: Number of times entries were written to channel logs using a SET operation (rewriting the entire log)
+              type: object
+            channelLogRewriteCollisions:
+              description: Number of collisions while attempting to rewrite channel logs using SET
+              type: object
+            document_gets:
+              description: Number of times a document was read from the database
+              type: object
+            revisionCache_adds:
+              description: Number of revisions added to the revision cache
+              type: object
+            revisionCache_hits:
+              description: Number of times a revision-cache lookup succeeded
+              type: object
+            revisionCache_misses:
+              description: Number of times a revision-cache lookup failed
+              type: object
+            revs_added:
+              description: Number of revisions added to the database (including deletions)
+              type: object
+            sequence_gets:
+              description: Number of times the database's lastSequence was read
+              type: object
+            sequence_reserves:
+              description: Number of times the database's lastSequence was incremented
+              type: object
+        syncgateway:
+          description: Monitoring stats
+          type: object
+          properties:
+            global:
+              description: Global Sync Gateway stats
+              type: object
+              properties:
+                resource_utilization:
+                  description: Resource utilization stats
+                  type: object
+                  properties:
+                    admin_net_bytes_recv:
+                      type: integer
+                    admin_net_bytes_sent:
+                      type: integer
+                    error_count:
+                      type: integer
+                    go_memstats_heapalloc:
+                      type: integer
+                    go_memstats_heapidle:
+                      type: integer
+                    go_memstats_heapinuse:
+                      type: integer
+                    go_memstats_heapreleased:
+                      type: integer
+                    go_memstats_pausetotalns:
+                      type: integer
+                    go_memstats_stackinuse:
+                      type: integer
+                    go_memstats_stacksys:
+                      type: integer
+                    go_memstats_sys:
+                      type: integer
+                    goroutines_high_watermark:
+                      type: integer
+                    num_goroutines:
+                      type: integer
+                    process_cpu_percent_utilization:
+                      type: integer
+                    process_memory_resident:
+                      type: integer
+                    pub_net_bytes_recv:
+                      type: integer
+                    pub_net_bytes_sent:
+                      type: integer
+                    system_memory_total:
+                      type: integer
+                    warn_count:
+                      type: integer
+            per_db:
+              description: |-
+                This array contains stats for all databases declared in the config file -- see the [Sync Gateway Statistics Schema](./../stats-monitoring.html) for more details on the metrics collected and reported by Sync Gateway.
+                The statistics for each {$db_name} database are grouped into:
+                - cache related statistics
+                - cbl_replication_push
+                - cbl_replication_pull
+                - database_related_statistics
+                - delta_sync
+                - gsi_views
+                - security_related_statistics
+                - shared_bucket_import
+                - per_replication statistics for each `replication_id`
+              type: array
+              items:
+                type: object
+                properties:
+                  cache:
+                    type: object
+                  database:
+                    type: object
+                  per_replication:
+                    type: array
+                  security:
+                    type: object
+            per_replication:
+              description: |-
+                An array of stats for each replication declared in the config file
+                **Deprecated @ 2.8**: used only by inter-sync-gateway replications version 1.
+              type: array
+              items:
+                type: object
+                description: Stats for a given replication_id
+                properties:
+                  $replication_id:
+                    type: object
+                    properties:
+                      sgr_active:
+                        description: |-
+                          Whether the replication is active at this time.
+                          **Deprecated @ 2.8**: used only by inter-sync-gateway replications version 1.
+                        type: boolean
+                      sgr_docs_checked_sent:
+                        description: |-
+                          The total number of documents checked for changes since replication started.
+                          This represents the number of potential change notifications pushed by Sync Gateway.
+                          **Constraints**
+                            This is not necessarily the number of documents pushed, as a given target might already have the change.
+                            Used by versions 1 and 2.
+                        type: integer
+                      sgr_num_attachments_transferred:
+                        description: |-
+                          The total number of attachments transferred since replication started.
+                          **Deprecated @ 2.8**: used only by inter-sync-gateway replications version 1.
+                        type: integer
+                      sgr_num_attachment_bytes_transferred:
+                        description: |-
+                          The total number of attachment bytes transferred since replication started.
+                          **Deprecated @ 2.8**: used only by inter-sync-gateway replications version 1.
+                        type: integer
+                      sgr_num_docs_failed_to_push:
+                        description: |-
+                          The total number of documents that failed to be pushed since replication started.
+                          Used by versions 1 and 2.
+                        type: integer
+                      sgr_num_docs_pushed:
+                        description: |-
+                          The total number of documents that were pushed since replication started.
+                          Used by versions 1 and 2.
+                        type: integer
+              deprecated: true
+    User:
+      description: Properties associated with a user
+      type: object
+      properties:
+        name:
+          description: |-
+            The name of the user.
+
+            User names can only have alphanumeric ASCII characters and underscores.
+          type: string
+        password:
+          description: |-
+            The password of the user.
+
+            Mandatory. unless `allow_empty_password` is `true` in the database configs.
+          type: string
+        admin_channels:
+          description: A list of channels to explicitly grant to the user.
+          type: array
+          items:
+            type: string
+        all_channels:
+          description: |-
+            All the channels that the user has been granted access to.
+
+            Access could have been granted through the sync function, roles, or explicitly on the user under the `admin_channels` property.
+          type: array
+          items:
+            type: string
+          readOnly: true
+        email:
+          description: The email address of the user.
+          type: string
+        disabled:
+          description: 'If true, the user will not be able to login to the account as it is disabled.'
+          type: boolean
+        admin_roles:
+          description: A list of roles to explicitly grant to the user.
+          type: array
+          items:
+            type: string
+        roles:
+          description: |-
+            All the roles that the user has been granted access to.
+
+            Access could have been granted through the sync function, or explicitly on the user under the `admin_roles` property.
+          type: array
+          items:
+            type: string
+          readOnly: true
+      title: User
+    Role:
+      description: Properties associated with a role
+      type: object
+      properties:
+        name:
+          description: |-
+            The name of the role.
+
+            Role names can only have alphanumeric ASCII characters and underscores.
+          type: string
+        admin_channels:
+          description: The channels that users in the role are able to access.
+          type: array
+          items:
+            type: string
+        all_channels:
+          description: |-
+            The channels that the role grants access to.
+
+            These channels could have been assigned by the Sync function or using the `admin_channels` property.
+          type: array
+          items:
+            type: string
+          readOnly: true
+      title: Role
+    User-session-information:
+      type: object
+      properties:
+        authentication_handlers:
+          description: The ways authentication can be established to authenticate as the user.
+          type: array
+          items:
+            type: string
+        ok:
+          type: boolean
+        userCtx:
+          type: object
+          properties:
+            channels:
+              description: |
+                A map of the channels the user has access to and the sequence number each channel was created at.
+
+                The key is the channel name and the value is the sequence number.
+              type: object
+            name:
+              description: The name of the user.
+              type: string
+              nullable: true
+      title: User Session Information
+    OIDC-callback:
+      type: object
+      properties:
+        id_token:
+          description: The OpenID Connect ID token
+          type: string
+        refresh_token:
+          description: The OpenID Connect ID refresh token
+          type: string
+        session_id:
+          description: The Sync Gateway session token
+          type: string
+        name:
+          description: The Sync Gateway user
+          type: string
+        access_token:
+          description: The OpenID Connect access token
+          type: string
+        token_type:
+          description: The OpenID Connect ID token type
+          type: string
+        expires_in:
+          description: The time until the id_token expires (TTL).
+          type: number
+      title: OpenID Connect callback properties
+    OIDC-token:
+      description: Properties expected back from an OpenID Connect provider after successful authentication
+      type: object
+      properties:
+        access_token:
+          type: string
+        token_type:
+          type: string
+        refresh_token:
+          type: string
+        expires_in:
+          type: string
+        id_token:
+          type: string
+      title: OIDC-token
+    OIDC-login-page-handler:
+      description: Properties passed from the OpenID Connect mock login page to the handler
+      type: object
+      properties:
+        username:
+          type: string
+        tokenttl:
+          type: string
+        identity-token-formats:
+          type: string
+        authenticated:
+          type: string
+      required:
+        - username
+        - tokenttl
+        - identity-token-formats
+        - authenticated
+    Document:
+      description: The configurable Sync Gateway properties of a document.
+      type: object
+      properties:
+        _id:
+          description: The ID of the document.
+          type: string
+        _rev:
+          description: The revision of the document.
+          type: string
+        _exp:
+          description: |-
+            Expiry time after which the document will be purged. The expiration time is set and managed on the Couchbase Server document. The value can be specified in two ways; in ISO-8601 format, for example the 6th of July 2022 at 17:00 in the BST timezone would be `2016-07-06T17:00:00+01:00`; it can also be specified as a numeric Couchbase Server expiry value. Couchbase Server expiries are specified as Unix time, and if the desired TTL is below 30 days then it can also represent an interval in seconds from the current time (for example, a value of 5 will remove the document 5 seconds after it is written to Couchbase Server). The document expiration time is returned in the response of `GET /{db}/{doc} ` when `show_exp=true` is included in the query.
+
+            As with the existing explicit purge mechanism, this applies only to the local database; it has nothing to do with replication. This expiration time is not propagated when the document is replicated. The purge of the document does not cause it to be deleted on any other database.
+          type: string
+        _deleted:
+          description: 'Whether the document is a tombstone or not. If true, it is a tombstone.'
+          type: boolean
+        _revisions:
+          type: object
+          properties:
+            start:
+              description: Prefix number for the latest revision.
+              type: number
+            ids:
+              description: 'Array of valid revision IDs, in reverse order (latest first).'
+              type: array
+              items:
+                type: string
+        _attachments:
+          type: object
+          properties:
+            attachment_name:
+              description: The name of the attachment.
+              type: object
+              properties:
+                content_type:
+                  description: Content type of the attachment.
+                  type: string
+                data:
+                  description: The data in the attachment in base64.
+                  type: string
+    New-revision:
+      description: Properties returned when a new document revision is created
+      type: object
+      properties:
+        id:
+          description: The ID of the document.
+          type: string
+        ok:
+          description: Wheather the request completed successfully.
+          type: boolean
+        rev:
+          description: The revision of the document.
+          type: string
+      required:
+        - id
+        - ok
+        - rev
+      title: New-revision
+    Changes-feed:
+      description: Properties of a changes feed
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            type: object
+            properties:
+              seq:
+                description: The change sequence number.
+                type: number
+              id:
+                description: The document ID the change happened on.
+                type: string
+              changes:
+                description: List of document leafs with each leaf containing only a `rev` field.
+                type: array
+                items:
+                  type: object
+                  properties:
+                    rev:
+                      description: The new revision that was caused by that change.
+                      type: string
+                uniqueItems: true
+          uniqueItems: true
+        last_seq:
+          description: The last change sequence number.
+          type: string
+    Design-doc:
+      description: Properties of a design document
+      type: object
+      properties:
+        language:
+          type: string
+        views:
+          type: object
+          properties:
+            view_name:
+              type: object
+              properties:
+                map:
+                  type: string
+                reduce:
+                  type: string
+        options:
+          type: object
+          properties:
+            local_seq:
+              type: string
+            include_design:
+              type: string
+            raw:
+              type: string
+            index_xattr_on_deleted_docs:
+              type: string
+    HTTP-Error:
+      type: object
+      properties:
+        error:
+          description: The error name.
+          type: string
+        reason:
+          description: The error description.
+          type: string
+      required:
+        - error
+        - reason
+      title: HTTP-Error
+    Retrieved-replication:
+      description: Properties of a replication
+      type: object
+      properties:
+        replication_id:
+          description: |-
+            This is the ID of the replication.
+
+            When creating a new replication using a POST request, this will be set to a random UUID if not explicitly set. 
+
+            When the replication ID is specified in the URL, this must be set to the same replication ID if specifying it at all.
+          type: string
+        remote:
+          description: |-
+            This is the endpoint of the database for the remote Sync Gateway that is the subject of this replication's `push`, `pull`, or `pushAndPull` action.
+
+            Typically this would include the URI, port, and database name. For example, `http://localhost:4985/db`.
+
+            How this remote is used depends on the `direction` of the replication:
+            * `pull` - this replicator _pulls_ changes from the `remote`
+            * `push` - this replicator _pushes_ changes to this `remote`
+            * `pushAndPull` - this replicator _pushes_ changes to this `remote`, while also pulling receiving changes
+          type: string
+        username:
+          description: |-
+            **This has been deprecated in favour of `remote_username`.**
+
+            This is the username to use to authenticate with the remote.
+
+            This can only be used for a pull replication.
+          type: string
+          deprecated: true
+        password:
+          description: |-
+            **This has been deprecated in favour of `remote_password`.**
+
+            This is the password to use to authenticate with the remote.
+
+            This password will be redacted in the replication config.
+
+            This can only be used for a pull replication.
+          type: string
+          deprecated: true
+        remote_username:
+          description: |-
+            The username to use to authenticate with the remote.
+
+            This can only be used for a pull replication.
+          type: string
+        remote_password:
+          description: |-
+            The password to use to authenticate with the remote.
+
+            This password will be redacted in the replication config.
+
+            This can only be used for a pull replication.
+          type: string
+        direction:
+          description: |-
+            This specifies which direction the replication will be replicating with the `remote` replicator.
+
+            The directions are:
+            * `pull` - changes are pulled from the remote database
+            * `push` - changes are pushed to the remote database
+            * `pushAndPull` - changes are both push-to and pulled-from the remote database
+
+            Replications created prior to Sync Gateway 2.8 derive their `direction` from the source/target URL of the replication.
+          type: string
+          enum:
+            - push
+            - pull
+            - pushAndPull
+        conflict_resolution_type:
+          description: |-
+            This defines what conflict resolution policy Sync Gateway should use to apply when resolving conflicting revisions.
+
+            Changing this is an enterprise-edition only feature.
+
+            **Behaviour**
+            * *default* - In priority order, this will cause
+              - Deletes to always win (the delete with the logest revision history wins if both revisions are deletes)
+              - The revision with the longest revision history to win. This means the the revision with the most changes and therefore the highest revision ID will win.
+            * *localWins* - This will result in local revisions always being the winner in any conflict.
+            * *remoteWins* - This will result in remote revisions always being the winner in any conflict.
+            * *custom* - This will result in conflicts going through your own custom conflict resolver. You must provide this logic as a Javascript function in the `custom_conflict_resolver` parameter. This is an enterprise-edition only feature.
+
+
+            Note: replications created prior to Sync Gateway 2.8 will default to `default`.
+          type: string
+          default: default
+          enum:
+            - default
+            - remoteWins
+            - localWins
+            - custom
+        custom_conflict_resolver:
+          description: "This specifies the Javascript function to use to resolve conflicts between conflicting revisions.\n \nThis **must** be used when `conflict_resolution_type=custom`. This property will be ignored when `conflict_resolution_type` is not `custom`.\n\nThe Javascript function to provide this property should be in backticks (like the sync function). The function takes 1 parameter which is a struct that represents the conflict. This struct has 2 properties:\n* `LocalDocument` - The local document. This contains the document ID under the `_id` key.\n* `RemoteDocument` - The remote document\nThe function should return the new documents body. This can be the winning revision (for example, `return conflict.LocalDocument`), a new body, or `nil` to resolve as a delete.\n\nExample:\n```\n\"custom_conflict_resolver\":\\`\n\tfunction(conflict) {\n\t\tconsole.log(\"Doc ID: \"+conflict.LocalDocument._id);\n\t\tconsole.log(\"Full remote doc: \"+JSON.stringify(conflict.RemoteDocument));\n\t\treturn conflict.RemoteDocument;\n\t}\n\\`\n```\n\nUsing complex `custom_conflict_resolver` functions can noticeably degrade performance. Use a built-in resolver whenever possible.\n\nThis is an enterprise-edition only feature.\n"
+          type: string
+          default: none
+        purge_on_removal:
+          description: |-
+            Specifies whether to purge a document if the remote user loses access to all of the channels on the document when attempting to pull it from the remote.
+
+            If false, documents will not be replicated and not be purged when the user loses access.
+          type: boolean
+          default: false
+        enable_delta_sync:
+          description: |-
+            This will turn on delta- sync for the replication. This works in conjunction with the database level setting `delta_sync.enabled`
+
+            If set to true, delta-sync will be used as long as both databases involved in the replication have delta-sync enabled. If a database does not have delta-sync enabled, then the replication will run without delta-sync.
+
+            Replications created prior to Sync Gateway 2.8 must have delta-sync disabled.
+
+            Enabling this is an enterprise-edition only feature.
+          type: boolean
+          default: false
+        max_backoff_time:
+          description: |-
+            Specifies the maximum time-period (in minutes) that Sync Gateway will attempt to reconnect to a lost or unreachable remote.
+
+            When a disconnection happens, Sync Gateway will do an exponential backoff up to this specified value. When this value is met, it will attempt to reconnect indefinitely every `max_backoff_time` minutes.
+
+            If this is set to 0, Sync Gateway will do the normal exponential backoff after the disconnect happens but then attempting 10 minutes and stop the replication.
+
+            Note: this defaults to 5 minutes for replications created prior to Sync Gateway 2.8.
+          type: integer
+          default: 5
+        initial_state:
+          description: |-
+            This is what state to start the replication in when creating a new replication.
+
+            This allows you to control if the replication starts in a `stopped` start or `running` state.
+
+            Replications prior to Sync Gateway 2.8 will run in the default state `running`.
+          type: string
+          default: running
+          enum:
+            - running
+            - stopped
+        continuous:
+          description: |-
+            If true, changes will be immediately synced when they happen. This is known as a continuous replication.
+
+            If false, all changes will be synced until they have been processed. The replication will then cease and not process any future changes (unless started again by the user). This is known as a one-shot replication.
+          type: boolean
+          default: false
+        filter:
+          description: |-
+            This defines whether to filter documents by their channels or not.
+
+            If set to `sync_gateway/bychannel` then a **pull** replication will be limited to a specific set of channels specified by the `query_params.channels` property. 
+
+            This only can be used with pull replications.
+          type: string
+          enum:
+            - sync_gateway/bychannel
+        query_params:
+          description: |-
+            This is a set of key/value pairs used in the query string of the replication.
+
+            If `filters=sync_gateway/bychannel` then this can be used to set the channels to filter by in a pull replication. To do this, set the `channels` key to a string array of the channels to filter by. For example:
+            ```
+            "filter":"sync_gateway/bychannel",
+            "query_params": {
+              "channels":["chanUser1"]
+            },
+            ```
+          type: array
+          items:
+            type: string
+        cancel:
+          description: Unused field
+          type: boolean
+        adhoc:
+          description: |-
+            Set to true to run the replication as an adhoc replication instead of a persistent one. 
+
+            This means that the replication will only last the period of the replication until the status is changed to `stopped` and then it will be removed automatically. It will also be removed if Sync Gateway restarts or if removed due to user action.
+          type: boolean
+          default: false
+        batch_size:
+          description: The amount of changes to be sent in one batch of replications. Changing this is an enterprise-edition only feature.
+          type: integer
+          default: 200
+        run_as:
+          description: This is used if you want to specify a user to run the replication as. This means that the replication will only be able to replicate what the user  access to what the user has access to.
+          type: string
+        assigned_node:
+          description: The unique ID of the node assigned to the replication.
+          type: string
+        target_state:
+          description: This is the state that the replicator is in or that trying to transition in to.
+          type: string
+          enum:
+            - running
+            - stopped
+            - resetting
+            - error
+            - starting
+            - reconnecting
+      title: Replication
+    Replication:
+      description: Properties of a replication
+      type: object
+      properties:
+        replication_id:
+          description: |-
+            This is the ID of the replication.
+
+            When creating a new replication using a POST request, this will be set to a random UUID if not explicitly set. 
+
+            When the replication ID is specified in the URL, this must be set to the same replication ID if specifying it at all.
+          type: string
+        remote:
+          description: |-
+            This is the endpoint of the database for the remote Sync Gateway that is the subject of this replication's `push`, `pull`, or `pushAndPull` action.
+
+            Typically this would include the URI, port, and database name. For example, `http://localhost:4985/db`.
+
+            How this remote is used depends on the `direction` of the replication:
+            * `pull` - this replicator _pulls_ changes from the `remote`
+            * `push` - this replicator _pushes_ changes to this `remote`
+            * `pushAndPull` - this replicator _pushes_ changes to this `remote`, while also pulling receiving changes
+          type: string
+        username:
+          description: |-
+            **This has been deprecated in favour of `remote_username`.**
+
+            This is the username to use to authenticate with the remote.
+
+            This can only be used for a pull replication.
+          type: string
+          deprecated: true
+        password:
+          description: |-
+            **This has been deprecated in favour of `remote_password`.**
+
+            This is the password to use to authenticate with the remote.
+
+            This password will be redacted in the replication config.
+
+            This can only be used for a pull replication.
+          type: string
+          deprecated: true
+        remote_username:
+          description: |-
+            The username to use to authenticate with the remote.
+
+            This can only be used for a pull replication.
+          type: string
+        remote_password:
+          description: |-
+            The password to use to authenticate with the remote.
+
+            This password will be redacted in the replication config.
+
+            This can only be used for a pull replication.
+          type: string
+        direction:
+          description: |-
+            This specifies which direction the replication will be replicating with the `remote` replicator.
+
+            The directions are:
+            * `pull` - changes are pulled from the remote database
+            * `push` - changes are pushed to the remote database
+            * `pushAndPull` - changes are both push-to and pulled-from the remote database
+
+            Replications created prior to Sync Gateway 2.8 derive their `direction` from the source/target URL of the replication.
+          type: string
+          enum:
+            - push
+            - pull
+            - pushAndPull
+        conflict_resolution_type:
+          description: |-
+            This defines what conflict resolution policy Sync Gateway should use to apply when resolving conflicting revisions.
+
+            Changing this is an enterprise-edition only feature.
+
+            **Behaviour**
+            * *default* - In priority order, this will cause
+              - Deletes to always win (the delete with the logest revision history wins if both revisions are deletes)
+              - The revision with the longest revision history to win. This means the the revision with the most changes and therefore the highest revision ID will win.
+            * *localWins* - This will result in local revisions always being the winner in any conflict.
+            * *remoteWins* - This will result in remote revisions always being the winner in any conflict.
+            * *custom* - This will result in conflicts going through your own custom conflict resolver. You must provide this logic as a Javascript function in the `custom_conflict_resolver` parameter. This is an enterprise-edition only feature.
+
+
+            Note: replications created prior to Sync Gateway 2.8 will default to `default`.
+          type: string
+          default: default
+          enum:
+            - default
+            - remoteWins
+            - localWins
+            - custom
+        custom_conflict_resolver:
+          description: "This specifies the Javascript function to use to resolve conflicts between conflicting revisions.\n \nThis **must** be used when `conflict_resolution_type=custom`. This property will be ignored when `conflict_resolution_type` is not `custom`.\n\nThe Javascript function to provide this property should be in backticks (like the sync function). The function takes 1 parameter which is a struct that represents the conflict. This struct has 2 properties:\n* `LocalDocument` - The local document. This contains the document ID under the `_id` key.\n* `RemoteDocument` - The remote document\nThe function should return the new documents body. This can be the winning revision (for example, `return conflict.LocalDocument`), a new body, or `nil` to resolve as a delete.\n\nExample:\n```\n\"custom_conflict_resolver\":\\`\n\tfunction(conflict) {\n\t\tconsole.log(\"Doc ID: \"+conflict.LocalDocument._id);\n\t\tconsole.log(\"Full remote doc: \"+JSON.stringify(conflict.RemoteDocument));\n\t\treturn conflict.RemoteDocument;\n\t}\n\\`\n```\n\nUsing complex `custom_conflict_resolver` functions can noticeably degrade performance. Use a built-in resolver whenever possible.\n\nThis is an enterprise-edition only feature.\n"
+          type: string
+          default: none
+        purge_on_removal:
+          description: |-
+            Specifies whether to purge a document if the remote user loses access to all of the channels on the document when attempting to pull it from the remote.
+
+            If false, documents will not be replicated and not be purged when the user loses access.
+          type: boolean
+          default: false
+        enable_delta_sync:
+          description: |-
+            This will turn on delta- sync for the replication. This works in conjunction with the database level setting `delta_sync.enabled`
+
+            If set to true, delta-sync will be used as long as both databases involved in the replication have delta-sync enabled. If a database does not have delta-sync enabled, then the replication will run without delta-sync.
+
+            Replications created prior to Sync Gateway 2.8 must have delta-sync disabled.
+
+            Enabling this is an enterprise-edition only feature.
+          type: boolean
+          default: false
+        max_backoff_time:
+          description: |-
+            Specifies the maximum time-period (in minutes) that Sync Gateway will attempt to reconnect to a lost or unreachable remote.
+
+            When a disconnection happens, Sync Gateway will do an exponential backoff up to this specified value. When this value is met, it will attempt to reconnect indefinitely every `max_backoff_time` minutes.
+
+            If this is set to 0, Sync Gateway will do the normal exponential backoff after the disconnect happens but then attempting 10 minutes and stop the replication.
+
+            Note: this defaults to 5 minutes for replications created prior to Sync Gateway 2.8.
+          type: integer
+          default: 5
+        initial_state:
+          description: |-
+            This is what state to start the replication in when creating a new replication.
+
+            This allows you to control if the replication starts in a `stopped` start or `running` state.
+
+            Replications prior to Sync Gateway 2.8 will run in the default state `running`.
+          type: string
+          default: running
+          enum:
+            - running
+            - stopped
+        continuous:
+          description: |-
+            If true, changes will be immediately synced when they happen. This is known as a continuous replication.
+
+            If false, all changes will be synced until they have been processed. The replication will then cease and not process any future changes (unless started again by the user). This is known as a one-shot replication.
+          type: boolean
+          default: false
+        filter:
+          description: |-
+            This defines whether to filter documents by their channels or not.
+
+            If set to `sync_gateway/bychannel` then a **pull** replication will be limited to a specific set of channels specified by the `query_params.channels` property. 
+
+            This only can be used with pull replications.
+          type: string
+          enum:
+            - sync_gateway/bychannel
+        query_params:
+          description: |-
+            This is a set of key/value pairs used in the query string of the replication.
+
+            If `filters=sync_gateway/bychannel` then this can be used to set the channels to filter by in a pull replication. To do this, set the `channels` key to a string array of the channels to filter by. For example:
+            ```
+            "filter":"sync_gateway/bychannel",
+            "query_params": {
+              "channels":["chanUser1"]
+            },
+            ```
+          type: array
+          items:
+            type: string
+        cancel:
+          description: Unused field
+          type: boolean
+        adhoc:
+          description: |-
+            Set to true to run the replication as an adhoc replication instead of a persistent one. 
+
+            This means that the replication will only last the period of the replication until the status is changed to `stopped` and then it will be removed automatically. It will also be removed if Sync Gateway restarts or if removed due to user action.
+          type: boolean
+          default: false
+        batch_size:
+          description: The amount of changes to be sent in one batch of replications. Changing this is an enterprise-edition only feature.
+          type: integer
+          default: 200
+        run_as:
+          description: This is used if you want to specify a user to run the replication as. This means that the replication will only be able to replicate what the user  access to what the user has access to.
+          type: string
+      required:
+        - direction
+      title: User configurable replication properties
+    All-replications:
+      description: Contains all the replication IDs with their corresponding replication configurations
+      type: object
+      properties:
+        replication_id:
+          $ref: '#/components/schemas/Retrieved-replication'
+      title: All-replications
+    Replication-status:
+      type: object
+      properties:
+        replication_id:
+          description: The ID of the replication.
+          type: string
+        config:
+          $ref: '#/components/schemas/Replication'
+        status:
+          description: The status of the replication.
+          type: string
+          enum:
+            - stopped
+            - running
+            - reconnecting
+            - resetting
+            - error
+            - starting
+        error_message:
+          description: The error message of the replication if an error has occurred.
+          type: string
+        docs_read:
+          description: The number of documents that have been read (fetched) from the source database.
+          type: integer
+        docs_checked_pull:
+          type: integer
+        docs_purged:
+          description: The number of documents that have been purged.
+          type: integer
+        rejected_by_local:
+          description: The number of documents that were received by the local but did not get replicated due to getting rejected by the sync function on the local.
+          type: integer
+        last_seq_pull:
+          description: The last changes sequence number that was pulled from the remote.
+          type: string
+        deltas_recv:
+          description: The number of deltas that have been received from the remote.
+          type: integer
+        deltas_requested:
+          type: integer
+        docs_written:
+          description: The number of documents that have been wrote (pushed) to the target database.
+          type: integer
+        docs_checked_push:
+          type: integer
+        docs_write_failures:
+          description: The number of documents that have failed to be wrote (pushed) to the target database. There will be no attempt to try to push these docs again.
+          type: integer
+        docs_write_conflicts:
+          description: The number of documents that had a conflict.
+          type: integer
+        rejected_by_remote:
+          description: The number of documents that were received by the remote but did not get replicated due to getting rejected by the sync function on the remote.
+          type: integer
+        last_seq_push:
+          description: The last changes sequence number that was pushed to the remote.
+          type: string
+        deltas_sent:
+          description: 'The number of deltas that have been sent to the remote. '
+          type: integer
+      required:
+        - replication_id
+      title: Replication-status
+    Database:
+      description: The properties of a database configuration.
+      type: object
+      properties:
+        server:
+          description: 'This is the Couchbase Server address or addresses that the database connect to. '
+          type: string
+        pool:
+          description: This field is unsupported and ignored.
+          type: string
+          default: default
+          deprecated: true
+        bucket:
+          description: The Couchbase Server backing bucket for the database.
+          type: string
+          default: The database name
+        username:
+          description: The username for authenticating to the server.
+          type: string
+        password:
+          description: The password for authenticating to the server.
+          type: string
+        certpath:
+          description: The cert path (public key) for X.509 bucket auth.
+          type: string
+        keypath:
+          description: The key path (private key) for X.509 bucket auth
+          type: string
+        cacertpath:
+          description: The root CA cert path for X.509 bucket authentication.
+          type: string
+        kv_tls_port:
+          description: The Memcached TLS port.
+          type: integer
+          default: 11207
+        max_concurrent_query_ops:
+          description: The maximum amount of query operations that can be running at any one point.
+          type: integer
+          default: 1000
+        name:
+          description: The name of the database.
+          type: string
+        sync:
+          description: The Javascript function that newly created documents are ran through.
+          type: string
+          default: 'function(doc){channel(doc.channels);}'
+        users:
+          $ref: '#/components/schemas/User'
+        roles:
+          $ref: '#/components/schemas/Role'
+        revs_limit:
+          description: |-
+            The maximum depth a document's revision tree can grow too.
+
+            The minimum is `20` if conflicts are allowed and 0 if not. It is not recommended to go below `100` when conflicts are allowed.
+          type: number
+          default: 100 if conflict allowed and 50 if not
+          minimum: 0
+        import_docs:
+          description: |-
+            If true, documents will be imported in to Sync Gateway from the bucket when requested. Documents will be ran through the set `import_filter` if any is set.
+
+            The default value depends on the edition of Sync Gateway being used. If the edition is the community-edition, then this will default to `false` or else in the enterprise-edition, it will default to `true`.
+
+            This can also be set to the string `continuous` which maps to true.
+          type: boolean
+        import_partitions:
+          description: |-
+            ** This is an enterprise-edition feature only**
+            This is how many import partitions should be used for import sharding. 
+
+            Partitions are distributed among all Sync Gateway nodes participating in import processing (`import_docs=true`), and each process a subset of the server's vbuckets.
+
+            Each partition is processed by an independent function that runs simultaneously to others, so `import_partitions` can be used to tune concurrency based on the number of Sync Gateway nodes, and the number of cores per node.
+          type: number
+          default: 16
+        import_filter:
+          description: |-
+            This is the function that all imported documents are ran through in order to filter out what to import and what not to import. This allows you to control what is made available to Couchbase Mobile clients. If it is not set, then no documents are filtered when imported.
+
+            `import_docs` must be true to make this field applicable.
+          type: string
+          example: 'function(doc) { if (doc.type != ''mobile'') { return false; } return true; }'
+        import_backup_old_rev:
+          description: This controls whether import should attempt to create a temporary backup of the previous revision body (if available) when the document is modified in the bucket.
+          type: boolean
+          default: false
+        event_handlers:
+          description: These are the settings for webhooks.
+          type: object
+          properties:
+            max_processes:
+              description: The maximum amount of concurrent event handling independent functions that can be running at the same time.
+              type: string
+            wait_for_process:
+              description: The maximum amount of time (in milliseconds) to wait when the even queue is full.
+              type: string
+            document_changed:
+              $ref: '#/components/schemas/Event-config'
+            db_state_changed:
+              $ref: '#/components/schemas/Event-config'
+        feed_type:
+          description: The type of feed to use to communicate with Couchbase Server.
+          type: string
+          default: DCP
+          enum:
+            - TAP
+            - DCP
+          deprecated: true
+        allow_empty_password:
+          description: This controls whether users that are created can have an empty password or not.
+          type: boolean
+          default: false
+        cache:
+          type: object
+          properties:
+            rev_cache:
+              description: The revision cache config settings.
+              type: object
+              properties:
+                size:
+                  description: The maximum number of revisions that can be stored in the revision cache.
+                  type: string
+                  default: 5000
+                shard_count:
+                  description: The number of shards the revision cache should be split into.
+                  type: string
+                  default: 16
+            channel_cache:
+              description: The channel cache config settings.
+              type: object
+              properties:
+                max_number:
+                  description: The maximum number of channel caches which can exist at any one point.
+                  type: integer
+                  default: 50000
+                compact_high_watermark_pct:
+                  description: |-
+                    The trigger value for starting the channel cache eviction process. 
+
+                    Specify this as a percentage which will be the percentage used on `max_number).
+
+                    When the cache size, determined by `max_number`, reaches the high watermark, the eviction process iterates through the cache, removing inactive channels.
+                  type: integer
+                  default: 80
+                compact_low_watermark_pct:
+                  description: |-
+                    The trigger value for stopping the channel cache eviction process. 
+
+                    Specify this as a percentage which will be the percentage used on `max_number).
+
+                    When the cache size, determined by `max_number` returns to a value lower than the percentage of it set here, the cache eviction process is stopped.
+                  type: integer
+                  default: 60
+                max_wait_pending:
+                  description: The maximum time (in milliseconds) for waiting for a pending sequence before skipping it.
+                  type: number
+                  default: 5000
+                max_num_pending:
+                  description: The maximum number of pending sequences before skipping sequences.
+                  type: integer
+                  default: 10000
+                max_wait_skipped:
+                  description: The maximum amount of time (in milliseconds) to wait for a skipped sequence before abandoning it.
+                  type: number
+                  default: 3600000
+                enable_star_channel:
+                  description: Used to control whether Sync Gateway should use the all documents (*) channel.
+                  type: boolean
+                  default: false
+                max_length:
+                  description: The maximum number of entries to maintain in the cache per channel.
+                  type: integer
+                  default: 500
+                min_length:
+                  description: The minimum number of entries to maintain in the cache per channel.
+                  type: integer
+                  default: 50
+                expiry_seconds:
+                  description: The amount of time (in seconds) to keep entries in the cache beyond the minimum retained.
+                  type: integer
+                  default: 60
+                query_limit:
+                  description: |-
+                    **Deprecated in favour of the database setting `query_pagination_limit`**
+                    The limit used for channel queries.
+                  type: integer
+                  default: 5000
+                  deprecated: true
+            max_wait_pending:
+              description: |-
+                **Deprecated, please use the database setting `cache.channel_cache.max_wait_pending` instead**
+                The maximum time (in milliseconds) for waiting for a pending sequence before skipping it.
+              type: number
+              deprecated: true
+            max_wait_skipped:
+              description: |-
+                **Deprecated, please use the database setting `cache.channel_cache.max_wait_skipped` instead**
+                The maximum time (in milliseconds) for waiting for pending sequences before skipping.
+              type: number
+              deprecated: true
+            enable_star_channel:
+              description: |-
+                **Deprecated, please use the database setting `cache.channel_cache.enable_star_channel` instead**
+                Used to control whether Sync Gateway should use the all documents (*) channel.
+              type: boolean
+              deprecated: true
+            channel_cache_max_length:
+              description: |-
+                **Deprecated, please use the database setting `cache.channel_cache.max_length` instead**
+                The maximum number of entries maintained in cache per channel.
+              type: number
+              deprecated: true
+            channel_cache_min_length:
+              description: |-
+                **Deprecated, please use the database setting `cache.channel_cache.min_length` instead**
+                The minimum number of entries maintained in cache per channel.
+              type: integer
+              deprecated: true
+            channel_cache_expiry:
+              description: |-
+                **Deprecated, please use the database setting `cache.channel_cache.expiry_seconds` instead**
+                The time (seconds) to keep entries in cache beyond the minimum retained.
+              type: integer
+              deprecated: true
+            max_num_pending:
+              description: |-
+                **Deprecated, please use the database setting `cache.channel_cache.max_num_pending` instead**
+                The max number of pending sequences before skipping.
+              type: integer
+              deprecated: true
+        rev_cache_size:
+          description: |-
+            **Deprecated, please use the database setting `cache.rev_cache.size` instead**
+            The maximum number of revisions to store in the revision cache.
+          type: number
+          deprecated: true
+        offline:
+          description: Start the database in an offline state.
+          type: boolean
+          default: false
+        unsupported:
+          description: These are unsupported options and therefore it is not recommended to use them.
+          type: object
+          properties:
+            user_views:
+              type: object
+              properties:
+                enabled:
+                  description: Whether pass-through view query is supported through public API.
+                  type: boolean
+            oidc_test_provider:
+              type: object
+              properties:
+                enabled:
+                  description: Whether the `oidc_test_provider` endpoints should be exposed on the public API.
+                  type: boolean
+            api_endpoints:
+              type: object
+              properties:
+                enable_couchbase_bucket_flush:
+                  description: |-
+                    **Setting for test purposes only**
+                    Whether Couchbase buckets can be flushed via Admin REST API.
+                  type: boolean
+            warning_thresholds:
+              type: object
+              properties:
+                xattr_size_bytes:
+                  description: The number of bytes to be used as a threshold for xattr size limit warnings.
+                  type: number
+                channels_per_doc:
+                  description: The number of channels per document to be used as a threshold for the channel count warnings.
+                  type: number
+                access_and_role_grants_per_doc:
+                  description: The number of access and role grants per document to be used as a threshold for grant count warnings.
+                  type: number
+                channels_per_user:
+                  description: The number of channels per user to be used as a threshold for channel count warnings.
+                  type: number
+                channel_name_size:
+                  description: The number of channel name characters to be used as a threshold for channel name warnings.
+                  type: number
+            disable_clean_skipped_query:
+              description: Whether to clean skipped sequence processing to bypass final checks.
+              type: boolean
+            oidc_tls_skip_verify:
+              description: Enable self-signed certificates for OIDC testing.
+              type: boolean
+            sgr_tls_skip_verify:
+              description: Enable self-signed certificates for SG-replicate testing.
+              type: boolean
+            remote_config_tls_skip_verify:
+              description: Enable self-signed certificates for external JavaScript load.
+              type: boolean
+        oidc:
+          description: Configuration for OpenID Connect authentication.
+          type: object
+          properties:
+            providers:
+              description: List of OpenID Connect issuers.
+              type: object
+              properties:
+                provider_name:
+                  description: The providers name.
+                  type: object
+                  properties:
+                    issuer:
+                      description: The URL for the OpenID Connect issuer.
+                      type: string
+                    register:
+                      description: If to register a new Sync Gateway user account when a user logs in with OpenID Connect.
+                      type: boolean
+                    client_id:
+                      description: The OpenID Connect provider client ID.
+                      type: string
+                    validation_key:
+                      description: The OpenID Connect provider client secret.
+                      type: string
+                    callback_url:
+                      description: |-
+                        The URL that the OpenID Connect will redirect to after authentication.
+
+                        If not provided, a callback URL will be generated.
+                      type: string
+                    disable_session:
+                      description: Disable Sync Gateway session creation on successful OpenID Connect authentication.
+                      type: boolean
+                    scope:
+                      description: The scope sent for the OpenID Connect request.
+                      type: array
+                      items:
+                        type: string
+                    include_access:
+                      description: 'This is whether the `_oidc_callback` response should include the OpenID Connect access token and associated fields (such as `token_type`, and `expires_in`).'
+                      type: boolean
+                    user_prefix:
+                      description: This is the username prefix for all users created through this provider.
+                      type: string
+                    discovery_url:
+                      description: The non-standard discovery endpoint.
+                      type: string
+                    disable_cfg_validation:
+                      description: This bypasses the configuration validation based on the OpenID Connect specifications. This may be required for some OpenID providers that don't strictly adhere to the specifications.
+                      type: boolean
+                      default: false
+                    disable_callback_state:
+                      description: |-
+                        Controls whether to maintain state between the auth request and callback endpoints (`/_oidc` and `/_oidc_callback`).
+
+                        **This is not recommended as it would cause OpenID Connect authentication to be vulnerable to Cross-Site Request Forgery (CSRF, XSRF).**
+                      type: boolean
+                      default: false
+                    username_claim:
+                      description: |-
+                        Allows a different OpenID Connect field to be specified instead of the Subject (`sub`).
+
+                        The field name to use can be specified here.
+                      type: string
+                    allow_unsigned_provider_tokens:
+                      description: Allows users accept unsigned tokens from providers.
+                      type: boolean
+                    IsDefault:
+                      description: Indicates if this is the default OpenID Connect provider.
+                      type: boolean
+                    Name:
+                      description: The name of the OpenID Connect Provider.
+                      type: string
+                    InsecureSkipVerify:
+                      description: 'Determines whether the TLS certificate verification should be disabled for this provider. '
+                      type: boolean
+                      default: false
+            default_provider:
+              description: The default provider to use when the provider is not specified in the client.
+              type: string
+        old_rev_expiry_seconds:
+          description: The number of seconds before old revisions are removed from the Couchbase Server bucket.
+          type: number
+          default: 300
+        view_query_timeout_secs:
+          description: The number of seconds before a view query should timeout.
+          type: integer
+          default: 75
+        local_doc_expiry_secs:
+          description: The number of seconds before a `_local` document should expire.
+          type: integer
+          default: 7776000
+        enable_shared_bucket_access:
+          description: Whether to use extended attributes to store Sync Gateway document (`_sync`) metadata.
+          type: boolean
+          default: true
+        session_cookie_secure:
+          description: |-
+            Override the session cookie `secure` flag. If set, the cookie will have the `secure` flag.
+
+            This will default to `true` if startup config `api.https.tls_cert_path` is set otherwise it will default to `false`.
+          type: boolean
+        session_cookie_name:
+          description: This can be used to define a custom per-database session cookie name.
+          type: string
+        session_cookie_http_only:
+          description: Make all session cookies for the database set the `HttpOnly` flag so they are inaccessible to JavaScript.
+          type: boolean
+          default: false
+        allow_conflicts:
+          description: This controls whether to allow conflicting document revisions.
+          type: boolean
+          default: true
+          deprecated: true
+        num_index_replicas:
+          description: This is the number of Global Secondary Indexes (GSI) to use for core indexes.
+          type: number
+          default: 1
+        use_views:
+          description: Force the use of views instead of GSI.
+          type: boolean
+          default: false
+        send_www_authentice_header:
+          description: Controls whether to send a `WWW-Authenticate` header in `401 Unauthorized` HTTP responses.
+          type: boolean
+          default: true
+        bucket_op_timeout_ms:
+          description: 'This is the amount of milliseconds should pass before a bucket operation times out. An error will be returned if the bucket operation times out saying: `operation timed out`.'
+          type: number
+        slow_query_warning_threshold:
+          description: 'The amount of milliseconds a N1QL query should run before logging a warning. '
+          type: number
+          default: 500
+        delta_sync:
+          description: |-
+            Delta sync configuration settings.
+
+            **This is an enterprise-edition feature only**
+          type: object
+          properties:
+            enabled:
+              description: |-
+                Whether delta sync is enabled.
+
+                **This is an enterprise-edition feature only**
+              type: boolean
+              default: false
+            rev_max_age_seconds:
+              description: |-
+                The number of seconds deltas for old revisions are available for.
+
+                This defaults to 24 hours (in seconds).
+              type: number
+              default: 86400
+        compact_interval_days:
+          description: |-
+            The interval between scheduled tombstone compaction runs (in days). This can be a floating point number.
+
+            If set to 0, compaction will not run automatically.
+          type: number
+          default: 1
+        sgreplicate_enabled:
+          description: Whether the node should accept assign replications (`true`) or not (`false`).
+          type: boolean
+          default: true
+        sgreplicate_websocket_heartbeat_secs:
+          description: Use a custom heartbeat interval (in seconds) for websocket ping frames.
+          type: integer
+          default: 300
+        replications:
+          type: object
+          properties:
+            replication_id:
+              $ref: '#/components/schemas/Replication'
+        serve_insecure_attachment_types:
+          description: |
+            If set, always serve attachments with the `Content-Type` header set to the type of the attachment.
+
+            When serving an attachment, usually the `Content-Type` header is set to the type of the attachment but the `Content-Disposition` response header will be set instead if the content type is vulnerable to a phishing attack, causing the browser to download the file instead of display it. This option will override that behaviour and always set the `Content-Type` header.
+          type: boolean
+          default: false
+        query_pagination_limit:
+          description: The query limit to be used during pagination of large queries.
+          type: integer
+          default: 5000
+        user_xattr_key:
+          description: 'The key to use for the user xattr that will be accessible from the sync function. IF empty, the feature will be disabled.'
+          type: string
+        client_partition_window_secs:
+          description: |-
+            How long (in seconds) clients can remain offline for without losing replication metadata.
+
+            Defaults to 30 days (in seconds)
+          type: integer
+          default: 2592000
+        guest:
+          $ref: '#/components/schemas/User'
+      title: Database-config
+    Event-config:
+      type: object
+      properties:
+        handler:
+          description: The handler type.
+          type: string
+          enum:
+            - webhook
+        url:
+          description: The URL of the webhook.
+          type: string
+        filter:
+          description: The Javascript function to use to filter the webhook events.
+          type: string
+        timeout:
+          description: The amount of time (in seconds) to attempt connect to the webhook before giving up.
+          type: number
+        options:
+          description: The options for the event.
+          type: object
+          properties:
+            option_name:
+              description: The option key and value.
+      title: Event-config
+    Resync-status:
+      description: The status of a resync operation
+      type: object
+      properties:
+        status:
+          description: The status of the current operation.
+          type: string
+          enum:
+            - running
+            - completed
+            - stopping
+            - stopped
+            - error
+        start_time:
+          description: The ISO-8601 date and time the resync operation was started.
+          type: string
+        last_error:
+          description: The last error that occurred in the resync operation (if any).
+          type: string
+        docs_changed:
+          description: The amount of documents that have been changed as a result of the resync operation.
+          type: integer
+        docs_processed:
+          description: The amount of docs that have been processed so far in the resync operation.
+          type: integer
+      required:
+        - status
+        - start_time
+        - last_error
+        - docs_changed
+        - docs_processed
+      title: Resync-status
+    Compact-status:
+      description: The status returned from a compaction.
+      type: object
+      properties:
+        status:
+          description: The status of the current operation.
+          type: string
+        start_time:
+          description: The ISO-8601 date and time the compact operation was started.
+          type: string
+        last_error:
+          description: The last error that occurred in the compact operation (if any).
+          type: string
+        docs_purged:
+          description: |-
+            **Applicable to tombstone compaction only**
+            This is the amount of documents that have been purged so far.
+          type: string
+        marked_attachments:
+          description: |-
+            **Applicable to attachment compaction only**
+            This is the amount of attachments that have been marked to be purged.
+          type: string
+        purged_attachments:
+          description: |-
+            **Applicable to attachment compaction only**
+            This is the amount of attachments that have been purged so far.
+          type: string
+        compact_id:
+          description: |-
+            **Applicable to attachment compaction only**
+            This is the ID of the compaction.
+          type: string
+        phase:
+          description: |-
+            **Applicable to attachment compaction only**
+            This indicates the current phase of running attachment compact processes.
+
+            For failed processes, this indicates the phase at which a compact_id restart will commence (where relevant).
+          type: string
+        dry_run:
+          description: |
+            **Applicable to attachment compaction only**
+          type: string
+          enum:
+            - mark
+            - sweep
+            - cleanup
+      required:
+        - status
+        - start_time
+        - last_error
+      title: Compact-status
+    Startup-config:
+      type: object
+      properties:
+        bootstrap:
+          description: Configuration settings for interacting with Couchbase Server.
+          type: object
+          properties:
+            group_id:
+              description: The config group ID to use when discovering databases. Allows for non-homogenous configuration.
+              type: string
+              default: default
+            config_update_frequency:
+              description: |-
+                How often to poll Couchbase Server for new config changes.
+
+                This is a duration and therefore can be provided with units "h", "m", "s", "ms", "us", and "ns". For example, 5 hours, 20 minutes, and 30 seconds would be `5h20m30s`.
+              type: string
+              default: 10s
+            server:
+              description: Couchbase Server connection string/URL.
+              type: string
+            username:
+              description: Username for authenticating to server.
+              type: string
+            password:
+              description: Password for authenticating to server
+              type: string
+            ca_cert_path:
+              description: Root CA cert path for TLS connection
+              type: string
+            server_tls_skip_verify:
+              description: Allow empty server CA Cert Path without attempting to use system root pool
+              type: boolean
+              default: false
+            x509_cert_path:
+              description: Cert path (public key) for X.509 bucket auth
+              type: string
+            x509_key_path:
+              description: Key path (private key) for X.509 bucket auth
+              type: string
+            use_tls_server:
+              description: Enforces a secure or non-secure server scheme
+              type: boolean
+              default: true
+          readOnly: true
+          required:
+            - server
+            - username
+            - password
+        api:
+          description: Configuration settings for modifying how the REST API is interacted with.
+          type: object
+          properties:
+            public_interface:
+              description: Network interface to bind public API to
+              type: string
+              default: ':4984'
+            admin_interface:
+              description: |-
+                Network interface to bind admin API to.
+
+                By default, this will only be accessible to the localhost.
+              type: string
+              default: '127.0.0.1:4985'
+            metric_interface:
+              description: |-
+                Network interface to bind metrics API to.
+
+                By default, this will only be accessible to the localhost.
+              type: string
+              default: '127.0.0.1:4986'
+            profile_interface:
+              description: Network interface to bind profiling API to
+              type: string
+            admin_interface_authentication:
+              description: Whether the admin API requires authentication
+              type: boolean
+              default: true
+            metrics_interface_authentication:
+              description: Whether the metrics API requires authentication
+              type: boolean
+              default: true
+            enable_advanced_auth_dp:
+              description: |-
+                Whether to enable the DP permissions check feature of admin auth.
+
+                Defaults to `true` if using enterprise-edition or `false` if using community-edition.
+              type: boolean
+            server_read_timeout:
+              description: |-
+                Maximum duration.Second before timing out read of the HTTP(S) request.
+
+                This is a duration and therefore can be provided with units "h", "m", "s", "ms", "us", and "ns". For example, 5 hours, 20 minutes, and 30 seconds would be `5h20m30s`.
+              type: string
+            server_write_timeout:
+              description: |-
+                Maximum duration.Second before timing out write of the HTTP(S) response.
+
+                This is a duration and therefore can be provided with units "h", "m", "s", "ms", "us", and "ns". For example, 5 hours, 20 minutes, and 30 seconds would be `5h20m30s`.
+              type: string
+            read_header_timeout:
+              description: |-
+                The amount of time allowed to read request headers.
+
+                This is a duration and therefore can be provided with units "h", "m", "s", "ms", "us", and "ns". For example, 5 hours, 20 minutes, and 30 seconds would be `5h20m30s`.
+              type: string
+              default: 5s
+            idle_timeout:
+              description: |-
+                The maximum amount of time to wait for the next request when keep-alives are enabled.
+
+                This is a duration and therefore can be provided with units "h", "m", "s", "ms", "us", and "ns". For example, 5 hours, 20 minutes, and 30 seconds would be `5h20m30s`.
+              type: string
+              default: 90s
+            pretty:
+              description: Pretty-print JSON responses
+              type: boolean
+            max_connections:
+              description: Max of incoming HTTP connections to accept
+              type: number
+              default: 0
+            compress_responses:
+              description: 'If false, disables compression of HTTP responses'
+              type: boolean
+              default: true
+            hide_product_version:
+              description: Whether product versions removed from Server headers and REST API responses
+              type: boolean
+            https:
+              type: object
+              properties:
+                tls_minimum_version:
+                  description: The minimum allowable TLS version for the REST APIs
+                  type: string
+                  default: tlsv1.2
+                tls_cert_path:
+                  description: The TLS cert file to use for the REST APIs
+                  type: string
+                tls_key_path:
+                  description: The TLS key file to use for the REST APIs
+                  type: string
+            cors:
+              type: object
+              properties:
+                origin:
+                  description: 'List of allowed origins, use [''*''] to allow access from everywhere'
+                  type: array
+                  items:
+                    type: string
+                login_origin:
+                  description: List of allowed login origins
+                  type: array
+                  items:
+                    type: string
+                headers:
+                  description: List of allowed headers
+                  type: array
+                  items:
+                    type: string
+                max_age:
+                  description: Maximum age of the CORS Options request
+                  type: integer
+          readOnly: true
+        logging:
+          description: The configuration settings for modifying Sync Gateway logging.
+          type: object
+          properties:
+            log_file_path:
+              description: Absolute or relative path on the filesystem to the log file directory. A relative path is from the directory that contains the Sync Gateway executable file.
+              type: string
+              readOnly: true
+            redaction_level:
+              description: Redaction level to apply to log output.
+              type: string
+              default: partial
+              enum:
+                - none
+                - partial
+                - full
+                - unset
+              readOnly: true
+            console:
+              $ref: '#/components/schemas/Console-logging-config'
+            error:
+              $ref: '#/components/schemas/File-logging-config'
+            warn:
+              $ref: '#/components/schemas/File-logging-config'
+            info:
+              $ref: '#/components/schemas/File-logging-config'
+            debug:
+              $ref: '#/components/schemas/File-logging-config'
+            trace:
+              $ref: '#/components/schemas/File-logging-config'
+            stats:
+              $ref: '#/components/schemas/File-logging-config'
+        auth:
+          type: object
+          properties:
+            bcrypt_cost:
+              description: Cost to use for bcrypt password hashes
+              type: integer
+              default: 10
+              maximum: 31
+              minimum: 10
+          readOnly: true
+        replicator:
+          type: object
+          properties:
+            max_heartbeat:
+              description: |-
+                Max heartbeat value for `_changes` request.
+
+                This is a duration and therefore can be provided with units "h", "m", "s", "ms", "us", and "ns". For example, 5 hours, 20 minutes, and 30 seconds would be `5h20m30s`.
+              type: string
+            blip_compression:
+              description: BLIP data compression level (0-9)
+              type: integer
+              maximum: 9
+              minimum: 0
+          readOnly: true
+        unsupported:
+          description: Settings that are not officially supported. It is highly recommended these are **not** used.
+          type: object
+          properties:
+            stats_log_frequency:
+              description: |-
+                How often should stats be written to stats logs.
+
+                This is a duration and therefore can be provided with units "h", "m", "s", "ms", "us", and "ns". For example, 5 hours, 20 minutes, and 30 seconds would be `5h20m30s`.
+              type: string
+              default: 1m
+            use_stdlib_json:
+              description: Bypass the jsoniter package and use Go's stdlib instead
+              type: boolean
+            http2:
+              type: object
+              properties:
+                enabled:
+                  description: Whether HTTP2 support is enabled
+                  type: boolean
+          readOnly: true
+        database_credentials:
+          description: 'A map of database name to credentials, that can be used instead of the bootstrap ones.'
+          type: object
+          properties:
+            database_name:
+              type: object
+              properties:
+                username:
+                  description: Username for authenticating to the bucket
+                  type: string
+                password:
+                  description: Password for authenticating to the bucket. This value is always redacted.
+                  type: string
+                x509_cert_path:
+                  description: Cert path (public key) for X.509 bucket auth
+                  type: string
+                x509_key_path:
+                  description: Key path (private key) for X.509 bucket auth
+                  type: string
+          readOnly: true
+        max_file_descriptors:
+          description: Max of open file descriptors (RLIMIT_NOFILE)
+          type: number
+          default: 5000
+          minimum: 0
+          readOnly: true
+        couchbase_keepalive_interval:
+          description: TCP keep-alive interval between SG and Couchbase server
+          type: integer
+          readOnly: true
+      title: Startup-config
+    File-logging-config:
+      type: object
+      properties:
+        enabled:
+          description: Toggle for this log output
+          type: boolean
+        rotation:
+          $ref: '#/components/schemas/Log-rotation-config-readonly'
+        collation_buffer_size:
+          description: The size of the log collation buffer
+          type: integer
+          readOnly: true
+      title: File-logging-config
+    Log-rotation-config-readonly:
+      type: object
+      properties:
+        max_size:
+          description: The maximum size in MB of the log file before it gets rotated.
+          type: integer
+        max_age:
+          description: The maximum number of days to retain old log files.
+          type: integer
+        localtime:
+          description: 'If true, it uses the computer''s local time to format the backup timestamp.'
+          type: boolean
+        rotated_logs_size:
+          description: Max Size (in mb) of log files before deletion
+          type: integer
+      readOnly: true
+      title: Log-rotation-config
+    Console-logging-config:
+      type: object
+      properties:
+        log_level:
+          description: Log Level for the console output
+          type: string
+          default: none
+          enum:
+            - none
+            - error
+            - warn
+            - info
+            - debug
+            - trace
+        log_keys:
+          description: Log Keys for the console output
+          type: array
+          items:
+            type: string
+        color_enabled:
+          description: Log with color for the console output
+          type: boolean
+          readOnly: true
+        file_output:
+          description: 'Override the default stderr output, and write to the file specified instead'
+          type: string
+          readOnly: true
+        enabled:
+          description: Toggle for this log output
+          type: boolean
+          readOnly: true
+        rotation:
+          $ref: '#/components/schemas/Log-rotation-config-readonly'
+        collation_buffer_size:
+          description: The size of the log collation buffer.
+          type: integer
+          readOnly: true
+      title: Console-logging-config
+    Log-update-enabled:
+      type: object
+      properties:
+        enabled:
+          description: 'If set, this log level will be outputted.'
+          type: boolean
+      title: Log-update-enabled
+    DeprecatedLogKeyMap:
+      description: A map of log keys and whether they are enabled or not.
+      type: object
+      example:
+        HTTP: true
+        CRUD: false
+        Changes: true
+      additionalProperties:
+        description: The log key and whether it is enabled or not.
+        type: boolean
+    Status:
+      type: object
+      properties:
+        databases:
+          description: Map of the databases in the node.
+          type: object
+          properties:
+            database_name:
+              type: object
+              properties:
+                seq:
+                  description: The latest sequence number in the database.
+                  type: number
+                  minimum: 0
+                server_uuid:
+                  description: The server unique identifier.
+                  type: string
+                state:
+                  description: Whether the database is online or offline.
+                  type: string
+                  enum:
+                    - Online
+                    - Offline
+                replication_status:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Replication-status'
+                cluster:
+                  type: object
+                  properties:
+                    replication:
+                      description: Map of replication configs defined for the cluster.
+                      type: object
+                      properties:
+                        replication_id:
+                          $ref: '#/components/schemas/Retrieved-replication'
+                    nodes:
+                      description: Map of all Sync Gateway nodes in the cluster.
+                      type: object
+                      properties:
+                        node_uuid:
+                          description: The nodes unique identifier.
+                          type: object
+                          properties:
+                            uuid:
+                              description: The nodes unique identifier.
+                              type: string
+                            host:
+                              description: The nodes host name.
+                              type: string
+        version:
+          description: |-
+            The product version including the build number and edition (ie. `EE` or `CE`).
+
+            Blank if `api.hide_product_version=true` in the startup configuration.
+          type: string
+      title: Status
+  requestBodies:
+    User:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/User'
+      description: Properties associated with a user
+    Role:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Role'
+      description: Properties associated with a role
+    OIDC-login-page-handler:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/OIDC-login-page-handler'
+      description: Properties passed from the OpenID Connect mock login page to the handler
+    Doc-body:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Document'
+      description: Properties of a document
+    Replication-upsert:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Replication'
+      description: If the `replication_id` matches an existing replication then the existing configuration will be updated. Only the specified fields in the request will be used to update the existing configuration. Unspecified fields will remain untouched.
+    Profile:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              file:
+                description: This is the file to output the pprof profile at.
+                type: string
   responses:
     Not-found:
       description: Resource could not be found
@@ -4342,11 +6312,9 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/HTTP-Error'
-          examples:
-            Database not found:
-              value:
-                error: not_found
-                reason: no such database "invalid-db"
+          example:
+            error: not_found
+            reason: no such database "invalid-db"
     Conflict:
       description: Resource already exists under that name
       content:
@@ -4424,7 +6392,7 @@ components:
           schema:
             $ref: '#/components/schemas/HTTP-Error'
     New-revision:
-      description: New revision created sucessfully
+      description: New revision created successfully
       content:
         application/json:
           schema:
@@ -4441,6 +6409,14 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/HTTP-Error'
+    pprof-binary:
+      description: OK
+      content:
+        application/octet-stream:
+          schema:
+            description: pprof binary data
+            type: string
+            example: pprof binary data
     all-docs:
       description: Operation ran successfully
       content:
@@ -4450,7 +6426,6 @@ components:
             properties:
               rows:
                 type: array
-                uniqueItems: true
                 items:
                   type: object
                   properties:
@@ -4463,6 +6438,7 @@ components:
                       properties:
                         rev:
                           type: string
+                uniqueItems: true
               total_rows:
                 type: number
               update_seq:
@@ -4490,1797 +6466,27 @@ components:
           schema:
             type: string
           description: The new database configuration revision.
-  schemas:
-    User:
-      description: Properties associated with a user
-      type: object
-      title: User
-      properties:
-        name:
-          type: string
-          description: |-
-            The name of the user.
+    DB-config-precondition-failed:
+      description: |-
+        Precondition Failed
 
-            User names can only have alphanumeric ASCII characters and underscores.
-        password:
-          type: string
-          description: |-
-            The password of the user.
+        The supplied If-Match header did not match the current version of the configuration.
 
-            Mandatory. unless `allow_empty_password` is `true` in the database configs.
-        admin_channels:
-          type: array
-          description: The channels that user is able to access.
-          items:
-            type: string
-        all_channels:
-          type: array
-          description: |-
-            All the channels that the user has been granted access to.
-
-            Access could have been granted through the sync function, roles, or explicitly on the user under the `admin_channels` property.
-          items:
-            type: string
-            readOnly: true
-        email:
-          type: string
-          description: The email address of the user.
-        disabled:
-          type: boolean
-          description: 'If true, the user will not be able to login to the account as it is disabled.'
-        admin_roles:
-          type: array
-          description: The roles the user is assigned to.
-          items:
-            type: string
-        roles:
-          type: array
-          description: The roles that the user is assigned to by the Sync function.
-          items:
-            type: string
-          readOnly: true
-    Role:
-      description: Properties associated with a role
-      type: object
-      title: Role
-      properties:
-        name:
-          type: string
-          description: |-
-            The name of the role.
-
-            Role names can only have alphanumeric ASCII characters and underscores.
-        admin_channels:
-          type: array
-          description: The channels that users in the role are able to access.
-          items:
-            type: string
-        all_channels:
-          type: array
-          description: |-
-            The channels that the role grants access to.
-
-            These channels could have been assigned by the Sync function or using the `admin_channels` property.
-          items:
-            type: string
-            readOnly: true
-    User-session-information:
-      type: object
-      properties:
-        authentication_handlers:
-          type: array
-          description: The ways authentication can be established to authenticate as the user.
-          items:
-            type: string
-        ok:
-          type: boolean
-        userCtx:
-          type: object
-          properties:
-            channels:
-              type: object
-              description: |
-                A map of the channels the user has access to and the sequence number each channel was created at.
-
-                The key is the channel name and the value is the sequence number.
-            name:
-              type: string
-              description: The name of the user.
-              nullable: true
-      title: User Session Information
-    OIDC-callback:
-      type: object
-      title: OpenID Connect callback properties
-      properties:
-        id_token:
-          type: string
-          description: The OpenID Connect ID token
-        refresh_token:
-          type: string
-          description: The OpenID Connect ID refresh token
-        session_id:
-          type: string
-          description: The Sync Gateway session token
-        name:
-          type: string
-          description: The Sync Gateway user
-        access_token:
-          type: string
-          description: The OpenID Connect access token
-        token_type:
-          type: string
-          description: The OpenID Connect ID token type
-        expires_in:
-          type: number
-          description: The time until the id_token expires (TTL).
-    OIDC-token:
-      title: OIDC-token
-      type: object
-      description: Properties expected back from an OpenID Connect provider after successful authentication
-      properties:
-        access_token:
-          type: string
-        token_type:
-          type: string
-        refresh_token:
-          type: string
-        expires_in:
-          type: string
-        id_token:
-          type: string
-    OIDC-login-page-handler:
-      description: Properties passed from the OpenID Connect mock login page to the handler
-      type: object
-      properties:
-        username:
-          type: string
-        tokenttl:
-          type: string
-        identity-token-formats:
-          type: string
-        authenticated:
-          type: string
-      required:
-        - username
-        - tokenttl
-        - identity-token-formats
-        - authenticated
-    Document:
-      description: The configurable Sync Gateway properties of a document.
-      type: object
-      properties:
-        _id:
-          type: string
-          description: The ID of the document.
-        _rev:
-          type: string
-          description: The revision of the document.
-        _exp:
-          type: string
-          description: |-
-            Expiry time after which the document will be purged. The expiration time is set and managed on the Couchbase Server document. The value can be specified in two ways; in ISO-8601 format, for example the 6th of July 2022 at 17:00 in the BST timezone would be `2016-07-06T17:00:00+01:00`; it can also be specified as a numeric Couchbase Server expiry value. Couchbase Server expiries are specified as Unix time, and if the desired TTL is below 30 days then it can also represent an interval in seconds from the current time (for example, a value of 5 will remove the document 5 seconds after it is written to Couchbase Server). The document expiration time is returned in the response of `GET /{db}/{doc} ` when `show_exp=true` is included in the query.
-
-            As with the existing explicit purge mechanism, this applies only to the local database; it has nothing to do with replication. This expiration time is not propagated when the document is replicated. The purge of the document does not cause it to be deleted on any other database.
-        _deleted:
-          type: boolean
-          description: 'Whether the document is a tombstone or not. If true, it is a tombstone.'
-        _revisions:
-          type: object
-          properties:
-            start:
-              type: number
-              description: Prefix number for the latest revision.
-            ids:
-              type: array
-              description: 'Array of valid revision IDs, in reverse order (latest first).'
-              items:
-                type: string
-        _attachments:
-          type: object
-          properties:
-            attachment_name:
-              type: object
-              description: The name of the attachment.
-              properties:
-                content_type:
-                  type: string
-                  description: Content type of the attachment.
-                data:
-                  type: string
-                  description: The data in the attachment in base64.
-    New-revision:
-      title: New-revision
-      type: object
-      description: Properties returned when a new revision is created
-      properties:
-        id:
-          type: string
-          description: The ID of the document.
-        ok:
-          type: boolean
-          description: Wheather the request completed successfully.
-        rev:
-          type: string
-          description: The revision of the document.
-      required:
-        - id
-        - ok
-        - rev
-    Changes-feed:
-      description: Properties of a changes feed
-      type: object
-      properties:
-        results:
-          type: array
-          uniqueItems: true
-          items:
-            type: object
-            properties:
-              seq:
-                type: number
-                description: The change sequence number.
-              id:
-                type: string
-                description: The document ID the change happened on.
-              changes:
-                type: array
-                uniqueItems: true
-                description: List of document leafs with each leaf containing only a `rev` field.
-                items:
-                  type: object
-                  properties:
-                    rev:
-                      type: string
-                      description: The new revision that was caused by that change.
-        last_seq:
-          type: string
-          description: The last change sequence number.
-    Design-doc:
-      description: Properties of a design document
-      type: object
-      properties:
-        language:
-          type: string
-        views:
-          type: object
-          properties:
-            view_name:
-              type: object
-              properties:
-                map:
-                  type: string
-                reduce:
-                  type: string
-        options:
-          type: object
-          properties:
-            local_seq:
-              type: string
-            include_design:
-              type: string
-            raw:
-              type: string
-            index_xattr_on_deleted_docs:
-              type: string
-    HTTP-Error:
-      title: HTTP-Error
-      type: object
-      properties:
-        error:
-          type: string
-        reason:
-          type: string
-          description: The error description.
-      required:
-        - error
-        - reason
-    Retrieved-replication:
-      title: Replication
-      type: object
-      description: Properties of a replication
-      properties:
-        replication_id:
-          type: string
-          description: |-
-            This is the ID of the replication.
-
-            When creating a new replication using a POST request, this will be set to a random UUID if not explicitly set. 
-
-            When the replication ID is specified in the URL, this must be set to the same replication ID if specifying it at all.
-        remote:
-          type: string
-          description: |-
-            This is the endpoint of the database for the remote Sync Gateway that is the subject of this replication's `push`, `pull`, or `pushAndPull` action.
-
-            Typically this would include the URI, port, and database name. For example, `http://localhost:4985/db`.
-
-            How this remote is used depends on the `direction` of the replication:
-            * `pull` - this replicator _pulls_ changes from the `remote`
-            * `push` - this replicator _pushes_ changes to this `remote`
-            * `pushAndPull` - this replicator _pushes_ changes to this `remote`, while also pulling recieving changes
-        username:
-          type: string
-          deprecated: true
-          description: |-
-            **This has been deprecated in favour of `remote_username`.**
-
-            This is the username to use to authenticate with the remote.
-
-            This can only be used for a pull replication.
-        password:
-          type: string
-          deprecated: true
-          description: |-
-            **This has been deprecated in favour of `remote_password`.**
-
-            This is the password to use to authenticate with the remote.
-
-            This password will be redacted in the replication config.
-
-            This can only be used for a pull replication.
-        remote_username:
-          type: string
-          description: |-
-            The username to use to authenticate with the remote.
-
-            This can only be used for a pull replication.
-        remote_password:
-          type: string
-          description: |-
-            The password to use to authenticate with the remote.
-
-            This password will be redacted in the replication config.
-
-            This can only be used for a pull replication.
-        direction:
-          type: string
-          enum:
-            - push
-            - pull
-            - pushAndPull
-          description: |-
-            This specifies which direction the replication will be replicating with the `remote` replicator.
-
-            The directions are:
-            * `pull` - changes are pulled from the remote database
-            * `push` - changes are pushed to the remote database
-            * `pushAndPull` - changes are both push-to and pulled-from the remote database
-
-            Replications created prior to Sync Gateway 2.8 derive their `direction` from the source/target URL of the replication.
-        conflict_resolution_type:
-          type: string
-          default: default
-          enum:
-            - default
-            - remoteWins
-            - localWins
-            - custom
-          description: |-
-            This defines what conflict resolution policy Sync Gateway should use to apply when resolving conflicting revisions.
-
-            Changing this is an enterprise-edition only feature.
-
-            **Behavior**
-            * *default* - In priority order, this will cause
-              - Deletes to always win (the delete with the logest revision history wins if both revisions are deletes)
-              - The revision with the longest revision history to win. This means the the revision with the most changes and therefore the highest revision ID will win.
-            * *localWins* - This will result in local revisions always being the winner in any conflict.
-            * *remoteWins* - This will result in remote revisions always being the winner in any conflict.
-            * *custom* - This will result in conflicts going through your own custom conflict resolver. You must provide this logic as a Javascript function in the `custom_conflict_resolver` parameter. This is an enterprise-edition only feature.
-
-
-            Note: replications created prior to Sync Gateway 2.8 will default to `default`.
-        custom_conflict_resolver:
-          type: string
-          default: none
-          description: "This specifies the Javascript function to use to resolve conflicts between conflicting revisions.\n \nThis **must** be used when `conflict_resolution_type=custom`. This property will be ignored when `conflict_resolution_type` is not `custom`.\n\nThe Javascript function to provide this property should be in backticks (like the sync function). The function takes 1 parameter which is a struct that represents the conflict. This struct has 2 properties:\n* `LocalDocument` - The local document. This contains the document ID under the `_id` key.\n* `RemoteDocument` - The remote document\nThe function should return the new documents body. This can be the winning revision (for example, `return conflict.LocalDocument`), a new body, or `nil` to resolve as a delete.\n\nExample:\n```\n\"custom_conflict_resolver\":\\`\n\tfunction(conflict) {\n\t\tconsole.log(\"Doc ID: \"+conflict.LocalDocument._id);\n\t\tconsole.log(\"Full remote doc: \"+JSON.stringify(conflict.RemoteDocument));\n\t\treturn conflict.RemoteDocument;\n\t}\n\\`\n```\n\nUsing complex `custom_conflict_resolver` functions can noticeably degrade performance. Use a built-in resolver whenever possible.\n\nThis is an enterprise-edition only feature.\n"
-        purge_on_removal:
-          type: boolean
-          default: false
-          description: |-
-            Specifies whether to purge a document if the remote user loses access to all of the channels on the document when attempting to pull it from the remote.
-
-            If false, documents will not be replicated and not be purged when the user loses access.
-        enable_delta_sync:
-          type: boolean
-          default: false
-          description: |-
-            This will turn on delta- sync for the replication. This works in conjunction with the database level setting `delta_sync.enabled`
-
-            If set to true, delta-sync will be used as long as both databases involved in the replication have delta-sync enabled. If a database does not have delta-sync enabled, then the replication will run without delta-sync.
-
-            Replications created prior to Sync Gateway 2.8 must have delta-sync disabled.
-
-            Enabling this is an enterprise-edition only feature.
-        max_backoff_time:
-          type: integer
-          default: 5
-          description: |-
-            Specifies the maximum time-period (in minutes) that Sync Gateway will attempt to reconnect to a lost or unreachable remote.
-
-            When a disconnection happens, Sync Gateway will do an exponential backoff up to this specified value. When this value is met, it will attempt to reconnect indefnitely every `max_backoff_time` minutes.
-
-            If this is set to 0, Sync Gateway will do the normal exponential backoff after the disconnect happens but then attempting 10 minutes and stop the replication.
-
-            Note: this defaults to 5 minutes for replications created prior to Sync Gateway 2.8.
-        initial_state:
-          type: string
-          default: running
-          enum:
-            - running
-            - stopped
-          description: |-
-            This is what state to start the replication in when creating a new replication.
-
-            This allows you to control if the replication starts in a `stopped` start or `running` state.
-
-            Replications prior to Sync Gateway 2.8 will run in the default state `running`.
-        continuous:
-          type: boolean
-          default: false
-          description: |-
-            If true, changes will be immediately synced whewn they happen. This is known as a continuous replication.
-
-            If false, all changes will be synced until they have been processed. The replication will then cease and not process any future changes (unless started again by the user). This is known as a one-shot replication.
-        filter:
-          type: string
-          enum:
-            - sync_gateway/bychannel
-          description: |-
-            This defines whether to filter documents by their channels or not.
-
-            If set to `sync_gateway/bychannel` then a **pull** replication will be limited to a specific set of channels specified by the `query_params.channels` property. 
-
-            This only can be used with pull replications.
-        query_params:
-          type: array
-          description: |-
-            This is a set of key/value pairs used in the query string of the replication.
-
-            If `filters=sync_gateway/bychannel` then this can be used to set the channels to filter by in a pull replication. To do this, set the `channels` key to a string array of the channels to filter by. For example:
-            ```
-            "filter":"sync_gateway/bychannel",
-            "query_params": {
-              "channels":["chanUser1"]
-            },
-            ```
-          items:
-            type: string
-        cancel:
-          type: boolean
-          description: Unused field
-        adhoc:
-          type: boolean
-          default: false
-          description: |-
-            Set to true to run the replication as an adhoc replication instead of a persistent one. 
-
-            This means that the replication will only last the period of the replication until the status is changed to `stopped` and then it will be removed automatically. It will also be removed if Sync Gateway restarts or if removed due to user action.
-        batch_size:
-          type: integer
-          default: 200
-          description: The amount of changes to be sent in one batch of replications. Changing this is an enterprise-edition only feature.
-        run_as:
-          type: string
-          description: This is used if you want to specify a user to run the replication as. This means that the replication will only be able to replicate what the user  access to what the user has access to.
-        assigned_node:
-          type: string
-          description: The unique ID of the node assigned to the replication.
-        target_state:
-          type: string
-          enum:
-            - running
-            - stopped
-            - resetting
-            - error
-            - starting
-            - reconnecting
-          description: This is the state that the replicator is in or that trying to transition in to.
-    Replication:
-      title: User configurable replication properties
-      type: object
-      description: Properties of a replication
-      properties:
-        replication_id:
-          type: string
-          description: |-
-            This is the ID of the replication.
-
-            When creating a new replication using a POST request, this will be set to a random UUID if not explicitly set. 
-
-            When the replication ID is specified in the URL, this must be set to the same replication ID if specifying it at all.
-        remote:
-          type: string
-          description: |-
-            This is the endpoint of the database for the remote Sync Gateway that is the subject of this replication's `push`, `pull`, or `pushAndPull` action.
-
-            Typically this would include the URI, port, and database name. For example, `http://localhost:4985/db`.
-
-            How this remote is used depends on the `direction` of the replication:
-            * `pull` - this replicator _pulls_ changes from the `remote`
-            * `push` - this replicator _pushes_ changes to this `remote`
-            * `pushAndPull` - this replicator _pushes_ changes to this `remote`, while also pulling recieving changes
-        username:
-          type: string
-          deprecated: true
-          description: |-
-            **This has been deprecated in favour of `remote_username`.**
-
-            This is the username to use to authenticate with the remote.
-
-            This can only be used for a pull replication.
-        password:
-          type: string
-          deprecated: true
-          description: |-
-            **This has been deprecated in favour of `remote_password`.**
-
-            This is the password to use to authenticate with the remote.
-
-            This password will be redacted in the replication config.
-
-            This can only be used for a pull replication.
-        remote_username:
-          type: string
-          description: |-
-            The username to use to authenticate with the remote.
-
-            This can only be used for a pull replication.
-        remote_password:
-          type: string
-          description: |-
-            The password to use to authenticate with the remote.
-
-            This password will be redacted in the replication config.
-
-            This can only be used for a pull replication.
-        direction:
-          type: string
-          enum:
-            - push
-            - pull
-            - pushAndPull
-          description: |-
-            This specifies which direction the replication will be replicating with the `remote` replicator.
-
-            The directions are:
-            * `pull` - changes are pulled from the remote database
-            * `push` - changes are pushed to the remote database
-            * `pushAndPull` - changes are both push-to and pulled-from the remote database
-
-            Replications created prior to Sync Gateway 2.8 derive their `direction` from the source/target URL of the replication.
-        conflict_resolution_type:
-          type: string
-          default: default
-          enum:
-            - default
-            - remoteWins
-            - localWins
-            - custom
-          description: |-
-            This defines what conflict resolution policy Sync Gateway should use to apply when resolving conflicting revisions.
-
-            Changing this is an enterprise-edition only feature.
-
-            **Behavior**
-            * *default* - In priority order, this will cause
-              - Deletes to always win (the delete with the logest revision history wins if both revisions are deletes)
-              - The revision with the longest revision history to win. This means the the revision with the most changes and therefore the highest revision ID will win.
-            * *localWins* - This will result in local revisions always being the winner in any conflict.
-            * *remoteWins* - This will result in remote revisions always being the winner in any conflict.
-            * *custom* - This will result in conflicts going through your own custom conflict resolver. You must provide this logic as a Javascript function in the `custom_conflict_resolver` parameter. This is an enterprise-edition only feature.
-
-
-            Note: replications created prior to Sync Gateway 2.8 will default to `default`.
-        custom_conflict_resolver:
-          type: string
-          default: none
-          description: "This specifies the Javascript function to use to resolve conflicts between conflicting revisions.\n \nThis **must** be used when `conflict_resolution_type=custom`. This property will be ignored when `conflict_resolution_type` is not `custom`.\n\nThe Javascript function to provide this property should be in backticks (like the sync function). The function takes 1 parameter which is a struct that represents the conflict. This struct has 2 properties:\n* `LocalDocument` - The local document. This contains the document ID under the `_id` key.\n* `RemoteDocument` - The remote document\nThe function should return the new documents body. This can be the winning revision (for example, `return conflict.LocalDocument`), a new body, or `nil` to resolve as a delete.\n\nExample:\n```\n\"custom_conflict_resolver\":\\`\n\tfunction(conflict) {\n\t\tconsole.log(\"Doc ID: \"+conflict.LocalDocument._id);\n\t\tconsole.log(\"Full remote doc: \"+JSON.stringify(conflict.RemoteDocument));\n\t\treturn conflict.RemoteDocument;\n\t}\n\\`\n```\n\nUsing complex `custom_conflict_resolver` functions can noticeably degrade performance. Use a built-in resolver whenever possible.\n\nThis is an enterprise-edition only feature.\n"
-        purge_on_removal:
-          type: boolean
-          default: false
-          description: |-
-            Specifies whether to purge a document if the remote user loses access to all of the channels on the document when attempting to pull it from the remote.
-
-            If false, documents will not be replicated and not be purged when the user loses access.
-        enable_delta_sync:
-          type: boolean
-          default: false
-          description: |-
-            This will turn on delta- sync for the replication. This works in conjunction with the database level setting `delta_sync.enabled`
-
-            If set to true, delta-sync will be used as long as both databases involved in the replication have delta-sync enabled. If a database does not have delta-sync enabled, then the replication will run without delta-sync.
-
-            Replications created prior to Sync Gateway 2.8 must have delta-sync disabled.
-
-            Enabling this is an enterprise-edition only feature.
-        max_backoff_time:
-          type: integer
-          default: 5
-          description: |-
-            Specifies the maximum time-period (in minutes) that Sync Gateway will attempt to reconnect to a lost or unreachable remote.
-
-            When a disconnection happens, Sync Gateway will do an exponential backoff up to this specified value. When this value is met, it will attempt to reconnect indefnitely every `max_backoff_time` minutes.
-
-            If this is set to 0, Sync Gateway will do the normal exponential backoff after the disconnect happens but then attempting 10 minutes and stop the replication.
-
-            Note: this defaults to 5 minutes for replications created prior to Sync Gateway 2.8.
-        initial_state:
-          type: string
-          default: running
-          enum:
-            - running
-            - stopped
-          description: |-
-            This is what state to start the replication in when creating a new replication.
-
-            This allows you to control if the replication starts in a `stopped` start or `running` state.
-
-            Replications prior to Sync Gateway 2.8 will run in the default state `running`.
-        continuous:
-          type: boolean
-          default: false
-          description: |-
-            If true, changes will be immediately synced whewn they happen. This is known as a continuous replication.
-
-            If false, all changes will be synced until they have been processed. The replication will then cease and not process any future changes (unless started again by the user). This is known as a one-shot replication.
-        filter:
-          type: string
-          enum:
-            - sync_gateway/bychannel
-          description: |-
-            This defines whether to filter documents by their channels or not.
-
-            If set to `sync_gateway/bychannel` then a **pull** replication will be limited to a specific set of channels specified by the `query_params.channels` property. 
-
-            This only can be used with pull replications.
-        query_params:
-          type: array
-          description: |-
-            This is a set of key/value pairs used in the query string of the replication.
-
-            If `filters=sync_gateway/bychannel` then this can be used to set the channels to filter by in a pull replication. To do this, set the `channels` key to a string array of the channels to filter by. For example:
-            ```
-            "filter":"sync_gateway/bychannel",
-            "query_params": {
-              "channels":["chanUser1"]
-            },
-            ```
-          items:
-            type: string
-        cancel:
-          type: boolean
-          description: Unused field
-        adhoc:
-          type: boolean
-          default: false
-          description: |-
-            Set to true to run the replication as an adhoc replication instead of a persistent one. 
-
-            This means that the replication will only last the period of the replication until the status is changed to `stopped` and then it will be removed automatically. It will also be removed if Sync Gateway restarts or if removed due to user action.
-        batch_size:
-          type: integer
-          default: 200
-          description: The amount of changes to be sent in one batch of replications. Changing this is an enterprise-edition only feature.
-        run_as:
-          type: string
-          description: This is used if you want to specify a user to run the replication as. This means that the replication will only be able to replicate what the user  access to what the user has access to.
-      required:
-        - direction
-    All-replications:
-      title: All-replications
-      type: object
-      description: Contains all the replication IDs with their corresponding replication configurations
-      properties:
-        replication_id:
-          $ref: '#/components/schemas/Retrieved-replication'
-    Replication-status:
-      title: Replication-status
-      type: object
-      properties:
-        replication_id:
-          type: string
-          description: The ID of the replication.
-        config:
-          $ref: '#/components/schemas/Replication'
-        status:
-          type: string
-          description: The status of the replication.
-          enum:
-            - stopped
-            - running
-            - reconnecting
-            - resetting
-            - error
-            - starting
-        error_message:
-          type: string
-          description: The error message of the replication if an error has occurred.
-        docs_read:
-          type: integer
-          description: The number of documents that have been read (fetched) from the source database.
-        docs_checked_pull:
-          type: integer
-        docs_purged:
-          type: integer
-          description: The number of documents that have been purged.
-        rejected_by_local:
-          type: integer
-          description: The number of documents that were received by the local but did not get replicated due to getting rejected by the sync function on the local.
-        last_seq_pull:
-          type: string
-          description: The last changes sequence number that was pulled from the remote.
-        deltas_recv:
-          type: integer
-          description: The number of deltas that have been receieved from the remote.
-        deltas_requested:
-          type: integer
-        docs_written:
-          type: integer
-          description: The number of documents that have been wrote (pushed) to the target database.
-        docs_checked_push:
-          type: integer
-        docs_write_failures:
-          type: integer
-          description: The number of documents that have failed to be wrote (pushed) to the target database. There will be no attempt to try to push these docs again.
-        docs_write_conflicts:
-          type: integer
-          description: The number of documents that had a conflict.
-        rejected_by_remote:
-          type: integer
-          description: The number of documents that were received by the remote but did not get replicated due to getting rejected by the sync function on the remote.
-        last_seq_push:
-          type: string
-          description: The last changes sequence number that was pushed to the remote.
-        deltas_sent:
-          type: integer
-          description: 'The number of deltas that have been sent to the remote. '
-      required:
-        - replication_id
-    Database:
-      title: Database-config
-      type: object
-      description: The properties of a database configuration.
-      properties:
-        server:
-          type: string
-          description: 'This is the Couchbase Server address or addresses that the database connect to. '
-        pool:
-          type: string
-          deprecated: true
-          description: Couchbase pool name. Always forced to be `default` due to deprecation.
-        bucket:
-          type: string
-          description: The Couchbase Server backing bucket for the database.
-          default: The database name
-        username:
-          type: string
-          description: The username for authenticating to the server.
-        password:
-          type: string
-          description: The password for authenticating to the server.
-        certpath:
-          type: string
-          description: The cert path (public key) for X.509 bucket auth.
-        keypath:
-          type: string
-          description: The key path (private key) for X.509 bucket auth
-        cacertpath:
-          type: string
-          description: The root CA cert path for X.509 bucket authentication.
-        kv_tls_port:
-          type: integer
-          default: 11207
-          description: The Memcached TLS port.
-        max_concurrent_query_ops:
-          type: integer
-          description: The maximum amount of query operations that can be running at any one point.
-          default: 1000
-        name:
-          type: string
-          description: The name of the database.
-        sync:
-          type: string
-          description: The Javascript function that newly created documents are ran through.
-          default: 'function(doc){channel(doc.channels);}'
-        users:
-          $ref: '#/components/schemas/User'
-        roles:
-          $ref: '#/components/schemas/Role'
-        revs_limit:
-          type: number
-          description: |-
-            The maximum depth a document's revision tree can grow too.
-
-            The minimum is `20` if conflicts are allowed and 0 if not. It is not recommended to go below `100` when conflicts are allowed.
-          default: 100 if conflict allowed and 50 if not
-          minimum: 0
-        import_docs:
-          type: boolean
-          description: |-
-            If true, documents will be imported in to Sync Gateway from the bucket when requested. Documents will be ran through the set `import_filter` if any is set.
-
-            The default value depends on the edition of Sync Gateway being used. If the edition is the community-edition, then this will default to `false` or else in the enterprise-edition, it will default to `true`.
-
-            This can also be set to the string `continuous` which maps to true.
-        import_partitions:
-          type: number
-          description: |-
-            ** This is an enterprise-edition feature only**
-            This is how many import partitions should be used for import sharding. 
-
-            Partitions are distributed among all Sync Gateway nodes participating in import processing (`import_docs=true`), and each process a subset of the server’s vbuckets.
-
-            Each partition is processed by an independant function that runs simultaneously to others, so `import_partitions` can be used to tune concurrency based on the number of Sync Gateway nodes, and the number of cores per node.
-          default: 16
-        import_filter:
-          type: string
-          description: |-
-            This is the function that all imported documents are ran through in order to filter out what to import and what not to import. This allows you to control what is made available to Couchbase Mobile clients. If it is not set, then no documents are filtered when imported.
-
-            `import_docs` must be true to make this field applicable.
-          example: 'function(doc) { if (doc.type != ''mobile'') { return false; } return true; }'
-        import_backup_old_rev:
-          type: boolean
-          description: This controls whether import should attempt to create a temporary backup of the previous revision body (if available) when the document is modified in the bucket.
-          default: false
-        event_handlers:
-          type: object
-          description: These are the settings for webhooks.
-          properties:
-            max_processes:
-              type: string
-              description: The maximum amount of concurrent event handling independant functions that can be running at the same time.
-            wait_for_process:
-              type: string
-              description: The maximum amount of time (in milliseconds) to wait when the even queue is full.
-            document_changed:
-              $ref: '#/components/schemas/Event-config'
-            db_state_changed:
-              $ref: '#/components/schemas/Event-config'
-        feed_type:
-          type: string
-          description: |-
-            The type of feed to use to communicate with Couchbase Server.
-
-            Import cannot be used with a TAP feed.
-          default: Based on Couchbase Server version
-          enum:
-            - TAP
-            - DCP
-        allow_empty_password:
-          type: boolean
-          default: false
-          description: This controls whether users that are created can have an empty password or not.
-        cache:
-          type: object
-          properties:
-            rev_cache:
-              type: object
-              description: The revision cache config settings.
-              properties:
-                size:
-                  type: string
-                  description: The maximum number of revisions that can be stored in the revision cache.
-                  default: 5000
-                shard_count:
-                  type: string
-                  description: The number of shards the revision cache should be split into.
-                  default: 16
-            channel_cache:
-              type: object
-              description: The channel cache config settings.
-              properties:
-                max_number:
-                  type: integer
-                  description: The maximum number of channel caches which can exist at any one point.
-                  default: 50000
-                compact_high_watermark_pct:
-                  type: integer
-                  description: |-
-                    The trigger value for starting the channel cache eviction process. 
-
-                    Specify this as a percentage which will be the percentage used on `max_number).
-
-                    When the cache size, determined by `max_number`, reaches the high watermark, the eviction process iterates through the cache, removing inactive channels.
-                  default: 80
-                compact_low_watermark_pct:
-                  type: integer
-                  default: 60
-                  description: |-
-                    The trigger value for stopping the channel cache eviction process. 
-
-                    Specify this as a percentage which will be the percentage used on `max_number).
-
-                    When the cache size, determined by `max_number` returns to a value lower than the percentage of it set here, the cache eviction process is stopped.
-                max_wait_pending:
-                  type: number
-                  description: The maximum time (in milliseconds) for waiting for a pending sequence before skipping it.
-                  default: 5000
-                max_num_pending:
-                  type: integer
-                  description: The maximum number of pending sequences before skipping sequences.
-                  default: 10000
-                max_wait_skipped:
-                  type: number
-                  description: The maximum amount of time (in milliseconds) to wait for a skipped sequence before abandoning it.
-                  default: 3600000
-                enable_star_channel:
-                  type: boolean
-                  description: Used to control whether Sync Gateway should use the all documents (*) channel.
-                  default: false
-                max_length:
-                  type: integer
-                  description: The maximum number of entries to maintain in the cache per channel.
-                  default: 500
-                min_length:
-                  type: integer
-                  description: The minimum number of entries to maintain in the cache per channel.
-                  default: 50
-                expiry_seconds:
-                  type: integer
-                  description: The amount of time (in seconds) to keep entries in the cache beyond the minimum retained.
-                  default: 60
-                query_limit:
-                  type: integer
-                  description: |-
-                    **Deprecated in favour of the database setting `query_pagination_limit`**
-                    The limit used for channel queries.
-                  deprecated: true
-                  default: 5000
-            max_wait_pending:
-              type: number
-              deprecated: true
-              description: |-
-                **Deprecated, please use the database setting `cache.channel_cache.max_wait_pending` instead**
-                The maximum time (in milliseconds) for waiting for a pending sequence before skipping it.
-            max_wait_skipped:
-              type: number
-              deprecated: true
-              description: |-
-                **Deprecated, please use the database setting `cache.channel_cache.max_wait_skipped` instead**
-                The maximum time (in milliseconds) for waiting for pending sequences before skipping.
-            enable_star_channel:
-              type: boolean
-              deprecated: true
-              description: |-
-                **Deprecated, please use the database setting `cache.channel_cache.enable_star_channel` instead**
-                Used to control whether Sync Gateway should use the all documents (*) channel.
-            channel_cache_max_length:
-              type: number
-              deprecated: true
-              description: |-
-                **Deprecated, please use the database setting `cache.channel_cache.max_length` instead**
-                The maximum number of entries maintained in cache per channel.
-            channel_cache_min_length:
-              type: integer
-              deprecated: true
-              description: |-
-                **Deprecated, please use the database setting `cache.channel_cache.min_length` instead**
-                The minimum number of entries maintained in cache per channel.
-            channel_cache_expiry:
-              type: integer
-              deprecated: true
-              description: |-
-                **Deprecated, please use the database setting `cache.channel_cache.expiry_seconds` instead**
-                The time (seconds) to keep entries in cache beyond the minimum retained.
-            max_num_pending:
-              type: integer
-              deprecated: true
-              description: |-
-                **Deprecated, please use the database setting `cache.channel_cache.max_num_pending` instead**
-                The max number of pending sequences before skipping.
-        rev_cache_size:
-          type: number
-          deprecated: true
-          description: |-
-            **Deprecated, please use the database setting `cache.rev_cache.size` instead**
-            The maximum number of revisions to store in the revision cache.
-        offline:
-          type: boolean
-          default: false
-          description: Start the database in an offline state.
-        unsupported:
-          type: object
-          description: These are unsupported options and therfore it is not recommended to use them.
-          properties:
-            user_views:
-              type: object
-              properties:
-                enabled:
-                  type: boolean
-                  description: Whether pass-through view query is supported through public API.
-            oidc_test_provider:
-              type: object
-              properties:
-                enabled:
-                  type: boolean
-                  description: Whether the `oidc_test_provider` endpoints should be exposed on the public API.
-            api_endpoints:
-              type: object
-              properties:
-                enable_couchbase_bucket_flush:
-                  type: boolean
-                  description: |-
-                    **Setting for test purposes only**
-                    Whether Couchbase buckets can be flushed via Admin REST API.
-            warning_thresholds:
-              type: object
-              properties:
-                xattr_size_bytes:
-                  type: number
-                  description: The number of bytes to be used as a threshold for xattr size limit warnings.
-                channels_per_doc:
-                  type: number
-                  description: The number of channels per document to be used as a threshold for the channel count warnings.
-                access_and_role_grants_per_doc:
-                  type: number
-                  description: The number of access and role grants per document to be used as a threshold for grant count warnings.
-                channels_per_user:
-                  type: number
-                  description: The number of channels per user to be used as a threshold for channel count warnings.
-                channel_name_size:
-                  type: number
-                  description: The number of channel name characters to be used as a threshold for channel name warnings.
-            disable_clean_skipped_query:
-              type: boolean
-              description: Whether to clean skipped sequence processing to bypass final checks.
-            oidc_tls_skip_verify:
-              type: boolean
-              description: Enable self-signed certificates for OIDC testing.
-            sgr_tls_skip_verify:
-              type: boolean
-              description: Enable self-signed certificates for SG-replicate testing.
-            remote_config_tls_skip_verify:
-              type: boolean
-              description: Enable self-signed certificates for external JavaScript load.
-        oidc:
-          type: object
-          description: Configuration for OpenID Connect authentication.
-          properties:
-            providers:
-              type: object
-              description: List of OpenID Connect issuers.
-              properties:
-                provider_name:
-                  type: object
-                  description: The providers name.
-                  properties:
-                    issuer:
-                      type: string
-                      description: The URL for the OpenID Connect issuer.
-                    register:
-                      type: boolean
-                      description: If to register a new Sync Gateway user account when a user logs in with OpenID Connect.
-                    client_id:
-                      type: string
-                      description: The OpenID Connect provider client ID.
-                    validation_key:
-                      type: string
-                      description: The OpenID Connect provider client secret.
-                    callback_url:
-                      type: string
-                      description: |-
-                        The URL that the OpenID Connect will redirect to after authentication.
-
-                        If not provided, a callback URL will be generated.
-                    disable_session:
-                      type: boolean
-                      description: Disable Sync Gateway session creation on successful OpenID Connect authentication.
-                    scope:
-                      type: array
-                      description: The scope sent for the OpenID Connect request.
-                      items:
-                        type: string
-                    include_access:
-                      type: boolean
-                      description: 'This is whether the `_oidc_callback` response should include the OpenID Connect access token and associated fields (such as `token_type`, and `expires_in`).'
-                    user_prefix:
-                      type: string
-                      description: This is the username prefix for all users created through this provider.
-                    discovery_url:
-                      type: string
-                      description: The non-standard discovery endpoint.
-                    disable_cfg_validation:
-                      type: boolean
-                      description: This bypasses the configuration validation based on the OpenID Connect specifications. This may be required for some OpenID providers that don't strictly adhere to the specifications.
-                      default: false
-                    disable_callback_state:
-                      type: boolean
-                      description: |-
-                        Controls whether to maintain state between the auth request and callback endpoints (`/_oidc` and `/_oidc_callback`).
-
-                        **This is not recommended as it would cause OpenID Connect authentication to be vulnerable to Cross-Site Request Forgery (CSRF, XSRF).**
-                      default: false
-                    username_claim:
-                      type: string
-                      description: |-
-                        Allows a different OpenID Connect field to be specified instead of the Subject (`sub`).
-
-                        The field name to use can be specified here.
-                    allow_unsigned_provider_tokens:
-                      type: boolean
-                      description: Allows users accept unsigned tokens from providers.
-                    IsDefault:
-                      type: boolean
-                      description: Indicates if this is the default OpenID Connect provider.
-                    Name:
-                      type: string
-                      description: The name of the OpenID Connect Provider.
-                    InsecureSkipVerify:
-                      type: boolean
-                      description: 'Determines whether the TLS certificate verification should be disabled for this provider. '
-                      default: false
-            default_provider:
-              type: string
-              description: The default provider to use when the provider is not specified in the client.
-        old_rev_expiry_seconds:
-          type: number
-          description: The number of seconds before old revisions are removed from the Couchbase Server bucket.
-          default: 300
-        view_query_timeout_secs:
-          type: integer
-          description: The number of seconds before a view query should timeout.
-          default: 75
-        local_doc_expiry_secs:
-          type: integer
-          description: The number of seconds before a `_local` document should expire.
-          default: 7776000
-        enable_shared_bucket_access:
-          type: boolean
-          description: Whether to use extended attributes to store Sync Gateway document (`_sync`) metadata.
-          default: true
-        session_cookie_secure:
-          type: boolean
-          description: |-
-            Override the session cookie `secure` flag. If set, the cookie will have the `secure` flag.
-
-            This will default to `true` if startup config `api.https.tls_cert_path` is set otherwise it will default to `false`.
-        session_cookie_name:
-          type: string
-          description: This can be used to define a custom per-database session cookie name.
-        session_cookie_http_only:
-          type: boolean
-          description: Make all session cookies for the database set the `HttpOnly` flag so they are inaccessible to JavaScript.
-          default: false
-        allow_conflicts:
-          type: boolean
-          default: true
-          deprecated: true
-          description: This controls whether to allow conflicting document revisions.
-        num_index_replicas:
-          type: number
-          description: This is the number of Global Secondary Indexes (GSI) to use for core indexes.
-          default: 1
-        use_views:
-          type: boolean
-          description: Force the use of views instead of GSI.
-          default: false
-        send_www_authentice_header:
-          type: boolean
-          description: Controls whether to send a `WWW-Authenticate` header in `401 Unauthorized` HTTP responses.
-          default: true
-        bucket_op_timeout_ms:
-          type: number
-          description: 'This is the amount of milliseconds should pass before a bucket operation times out. An error will be returned if the bucket operation times out saying: `operation timed out`.'
-        slow_query_warning_threshold:
-          type: number
-          description: 'The amount of milliseconds a N1QL query should run before logging a warning. '
-          default: 500
-        delta_sync:
-          type: object
-          description: |-
-            Delta sync configuration settings.
-
-            **This is an enterprise-edition feature only**
-          properties:
-            enabled:
-              type: boolean
-              description: |-
-                Whether delta sync is enabled.
-
-                **This is an enterprise-edition feature only**
-              default: false
-            rev_max_age_seconds:
-              type: number
-              description: |-
-                The number of seconds deltas for old revisions are available for.
-
-                This defaults to 24 hours (in seconds).
-              default: 86400
-        compact_interval_days:
-          type: number
-          description: |-
-            The interval between scheduled tombstone compaction runs (in days). This can be a floating point number.
-
-            If set to 0, compaction will not run automatically.
-          default: 1
-        sgreplicate_enabled:
-          type: boolean
-          default: true
-          description: Whether the node should accept assign replications (`true`) or not (`false`).
-        sgreplicate_websocket_heartbeat_secs:
-          type: integer
-          description: Use a custom heartbeat interval (in seconds) for websocket ping frames.
-          default: 300
-        replications:
-          type: object
-          properties:
-            replication_id:
-              $ref: '#/components/schemas/Replication'
-        serve_insecure_attachment_types:
-          type: boolean
-          description: |
-            If set, always serve attachments with the `Content-Type` header set to the type of the attachment.
-
-            When serving an attachment, usually the `Content-Type` header is set to the type of the attachment but the `Content-Disposition` response header will be set instead if the content type is vulnerable to a phishing attack, causing the browser to download the file instead of display it. This option will override that behaviour and always set the `Content-Type` header.
-          default: false
-        query_pagination_limit:
-          type: integer
-          description: The query limit to be used during pagination of large queries.
-          default: 5000
-        user_xattr_key:
-          type: string
-          description: 'The key to use for the user xattr that will be accessible from the sync function. IF empty, the feature will be disabled.'
-        client_partition_window_secs:
-          type: integer
-          description: |-
-            How long (in seconds) clients can remain offline for without losing replication metadata.
-
-            Defaults to 30 days (in seconds)
-          default: 2592000
-        guest:
-          $ref: '#/components/schemas/User'
-    Event-config:
-      title: Event-config
-      type: object
-      properties:
-        handler:
-          type: string
-          description: The handler type.
-          enum:
-            - webhook
-        url:
-          type: string
-          description: The URL of the webhook.
-        filter:
-          type: string
-          description: The Javascript function to use to filter the webhook events.
-        timeout:
-          type: number
-          description: The amount of time (in seconds) to attempt connect to the webhook before giving up.
-        options:
-          type: object
-          description: The options for the event.
-          properties:
-            option_name:
-              description: The option key and value.
-    Resync-status:
-      title: Resync-status
-      type: object
-      properties:
-        status:
-          type: string
-          description: The status of the current operation.
-          enum:
-            - running
-            - completed
-            - stopping
-            - stopped
-            - error
-        start_time:
-          type: string
-          description: The ISO-8601 date and time the resync operation was started.
-        last_error:
-          type: string
-          description: The last error that occurred in the resync operation (if any).
-        docs_changed:
-          type: integer
-          description: The amount of documents that have been changed as a result of the resync operation.
-        docs_processed:
-          type: integer
-          description: The amount of docs that have been processed so far in the resync operation.
-      required:
-        - status
-        - start_time
-        - last_error
-        - docs_changed
-        - docs_processed
-      description: The status of a resync operation
-    Compact-status:
-      title: Compact-status
-      type: object
-      description: The status returned from a compaction.
-      properties:
-        status:
-          type: string
-          description: The status of the current operation.
-        start_time:
-          type: string
-          description: The ISO-8601 date and time the compact operation was started.
-        last_error:
-          type: string
-          description: The last error that occurred in the compact operation (if any).
-        docs_purged:
-          type: string
-          description: |-
-            **Applicable to tombstone compaction only**
-            This is the amount of documents that have been purged so far.
-        marked_attachments:
-          type: string
-          description: |-
-            **Applicable to attachment compaction only**
-            This is the amount of attachments that have been marked to be purged.
-        purged_attachments:
-          type: string
-          description: |-
-            **Applicable to attachment compaction only**
-            This is the amount of attachments that have been purged so far.
-        compact_id:
-          type: string
-          description: |-
-            **Applicable to attachment compaction only**
-            This is the ID of the compaction.
-        phase:
-          type: string
-          description: |-
-            **Applicable to attachment compaction only**
-            This indicates the current phase of running attachment compact processes.
-
-            For failed processes, this indicates the phase at which a compact_id restart will commence (where relevant).
-        dry_run:
-          type: string
-          description: |
-            **Applicable to attachment compaction only**
-          enum:
-            - mark
-            - sweep
-            - cleanup
-      required:
-        - status
-        - start_time
-        - last_error
-    Startup-config:
-      title: Startup-config
-      type: object
-      properties:
-        bootstrap:
-          type: object
-          description: Configuration settings for interacting with Couchbase Server.
-          properties:
-            group_id:
-              type: string
-              description: The config group ID to use when discovering databases. Allows for non-homogenous configuration.
-              default: default
-            config_update_frequency:
-              type: string
-              description: |-
-                How often to poll Couchbase Server for new config changes.
-
-                This is a duration and therefore can be provided with units "h", "m", "s", "ms", "us", and "ns". For example, 5 hours, 20 minutes, and 30 seconds would be `5h20m30s`.
-              default: 10s
-            server:
-              type: string
-              description: Couchbase Server connection string/URL.
-            username:
-              type: string
-              description: Username for authenticating to server.
-            password:
-              type: string
-              description: Password for authenticating to server
-            ca_cert_path:
-              type: string
-              description: Root CA cert path for TLS connection
-            server_tls_skip_verify:
-              type: boolean
-              description: Allow empty server CA Cert Path without attempting to use system root pool
-              default: false
-            x509_cert_path:
-              type: string
-              description: Cert path (public key) for X.509 bucket auth
-            x509_key_path:
-              type: string
-              description: Key path (private key) for X.509 bucket auth
-            use_tls_server:
-              type: boolean
-              description: Enforces a secure or non-secure server scheme
-              default: true
-          required:
-            - server
-            - username
-            - password
-        api:
-          type: object
-          description: Configuration settings for modifying how the REST API is interacted with.
-          properties:
-            public_interface:
-              type: string
-              description: Network interface to bind public API to
-              default: ':4984'
-            admin_interface:
-              type: string
-              description: |-
-                Network interface to bind admin API to.
-
-                By default, this will only be accessible to the localhost.
-              default: '127.0.0.1:4985'
-            metric_interface:
-              type: string
-              description: |-
-                Network interface to bind metrics API to.
-
-                By default, this will only be accessible to the localhost.
-              default: '127.0.0.1:4986'
-            profile_interface:
-              type: string
-              description: Network interface to bind profiling API to
-            admin_interface_authentication:
-              type: boolean
-              description: Whether the admin API requires authentication
-              default: true
-            metrics_interface_authentication:
-              type: boolean
-              description: Whether the metrics API requires authentication
-              default: true
-            enable_advanced_auth_dp:
-              type: boolean
-              description: |-
-                Whether to enable the DP permissions check feature of admin auth.
-
-                Defaults to `true` if using enterprise-edition or `false` if using community-edition.
-            server_read_timeout:
-              type: string
-              description: |-
-                Maximum duration.Second before timing out read of the HTTP(S) request.
-
-                This is a duration and therefore can be provided with units "h", "m", "s", "ms", "us", and "ns". For example, 5 hours, 20 minutes, and 30 seconds would be `5h20m30s`.
-            server_write_timeout:
-              type: string
-              description: |-
-                Maximum duration.Second before timing out write of the HTTP(S) response.
-
-                This is a duration and therefore can be provided with units "h", "m", "s", "ms", "us", and "ns". For example, 5 hours, 20 minutes, and 30 seconds would be `5h20m30s`.
-            read_header_timeout:
-              type: string
-              description: |-
-                The amount of time allowed to read request headers.
-
-                This is a duration and therefore can be provided with units "h", "m", "s", "ms", "us", and "ns". For example, 5 hours, 20 minutes, and 30 seconds would be `5h20m30s`.
-              default: 5s
-            idle_timeout:
-              type: string
-              description: |-
-                The maximum amount of time to wait for the next request when keep-alives are enabled.
-
-                This is a duration and therefore can be provided with units "h", "m", "s", "ms", "us", and "ns". For example, 5 hours, 20 minutes, and 30 seconds would be `5h20m30s`.
-              default: 90s
-            pretty:
-              type: boolean
-              description: Pretty-print JSON responses
-            max_connections:
-              type: number
-              description: 'Max # of incoming HTTP connections to accept'
-              default: 0
-            compress_responses:
-              type: boolean
-              description: 'If false, disables compression of HTTP responses'
-              default: true
-            hide_product_version:
-              type: boolean
-              description: Whether product versions removed from Server headers and REST API responses
-            https:
-              type: object
-              properties:
-                tls_minimum_version:
-                  type: string
-                  description: The minimum allowable TLS version for the REST APIs
-                  default: tlsv1.2
-                tls_cert_path:
-                  type: string
-                  description: The TLS cert file to use for the REST APIs
-                tls_key_path:
-                  type: string
-                  description: The TLS key file to use for the REST APIs
-            cors:
-              type: object
-              properties:
-                origin:
-                  type: array
-                  description: 'List of allowed origins, use [''*''] to allow access from everywhere'
-                  items:
-                    type: string
-                login_origin:
-                  type: array
-                  description: List of allowed login origins
-                  items:
-                    type: string
-                headers:
-                  type: array
-                  description: List of allowed headers
-                  items:
-                    type: string
-                max_age:
-                  type: integer
-                  description: Maximum age of the CORS Options request
-        logging:
-          type: object
-          description: The configuration settings for moddifying Sync Gateway logging.
-          properties:
-            log_file_path:
-              type: string
-              description: Absolute or relative path on the filesystem to the log file directory. A relative path is from the directory that contains the Sync Gateway executable file.
-            redaction_level:
-              type: string
-              description: Redaction level to apply to log output.
-              enum:
-                - none
-                - partial
-                - full
-                - unset
-              default: partial
-            console:
-              $ref: '#/components/schemas/Console-logging-config'
-            error:
-              $ref: '#/components/schemas/File-logging-config'
-            warn:
-              $ref: '#/components/schemas/File-logging-config'
-            info:
-              $ref: '#/components/schemas/File-logging-config'
-            debug:
-              $ref: '#/components/schemas/File-logging-config'
-            trace:
-              $ref: '#/components/schemas/File-logging-config'
-            stats:
-              $ref: '#/components/schemas/File-logging-config'
-        auth:
-          type: object
-          properties:
-            bcrypt_cost:
-              type: integer
-              default: 10
-              maximum: 31
-              minimum: 10
-              description: Cost to use for bcrypt password hashes
-        replicator:
-          type: object
-          properties:
-            max_heartbeat:
-              type: string
-              description: |-
-                Max heartbeat value for `_changes` request.
-
-                This is a duration and therefore can be provided with units "h", "m", "s", "ms", "us", and "ns". For example, 5 hours, 20 minutes, and 30 seconds would be `5h20m30s`.
-            blip_compression:
-              type: integer
-              description: BLIP data compression level (0-9)
-              minimum: 0
-              maximum: 9
-        unsupported:
-          type: object
-          description: Settings that are not officially supported. It is highly recommended these are **not** used.
-          properties:
-            stats_log_frequency:
-              type: string
-              description: |-
-                How often should stats be written to stats logs.
-
-                This is a duration and therefore can be provided with units "h", "m", "s", "ms", "us", and "ns". For example, 5 hours, 20 minutes, and 30 seconds would be `5h20m30s`.
-              default: 1m
-            use_stdlib_json:
-              type: boolean
-              description: Bypass the jsoniter package and use Go's stdlib instead
-            http2:
-              type: object
-              properties:
-                enabled:
-                  type: boolean
-                  description: Whether HTTP2 support is enabled
-        database_credentials:
-          description: 'A map of database name to credentials, that can be used instead of the bootstrap ones.'
-          type: object
-          properties:
-            database_name:
-              type: object
-              properties:
-                username:
-                  type: string
-                  description: Username for authenticating to the bucket
-                password:
-                  type: string
-                  description: Password for authenticating to the bucket
-                x509_cert_path:
-                  type: string
-                  description: Cert path (public key) for X.509 bucket auth
-                x509_key_path:
-                  type: string
-                  description: Key path (private key) for X.509 bucket auth
-        max_file_descriptors:
-          type: number
-          description: 'Max # of open file descriptors (RLIMIT_NOFILE)'
-          minimum: 0
-          default: 5000
-        couchbase_keepalive_interval:
-          description: TCP keep-alive interval between SG and Couchbase server
-          type: integer
-    File-logging-config:
-      title: File-logging-config
-      type: object
-      properties:
-        enabled:
-          type: boolean
-          description: Toggle for this log output
-        rotation:
-          $ref: '#/components/schemas/Log-rotation-config'
-        collation_buffer_size:
-          type: integer
-          description: The size of the log collation buffer
-    Log-rotation-config:
-      title: Log-rotation-config
-      type: object
-      properties:
-        max_size:
-          type: integer
-          description: The maximum size in MB of the log file before it gets rotated.
-        max_age:
-          type: integer
-          description: The maximum number of days to retain old log files.
-        localtime:
-          type: boolean
-          description: 'If true, it uses the computer''s local time to format the backup timestamp.'
-        rotated_logs_size:
-          type: integer
-          description: Max Size (in mb) of log files before deletion
-    Console-logging-config:
-      title: Console-logging-config
-      type: object
-      properties:
-        log_level:
-          type: string
-          description: Log Level for the console output
-          default: none
-          enum:
-            - none
-            - error
-            - warn
-            - info
-            - debug
-            - trace
-        log_keys:
-          type: array
-          description: Log Keys for the console output
-          items:
-            type: string
-        color_enabled:
-          type: boolean
-          description: Log with color for the console output
-        file_output:
-          type: string
-          description: 'Override the default stderr output, and write to the file specified instead'
-        enabled:
-          type: boolean
-          description: Toggle for this log output
-        rotation:
-          $ref: '#/components/schemas/Log-rotation-config'
-        collation_buffer_size:
-          type: integer
-          description: The size of the log collation buffer.
-    Log-update-enabled:
-      title: Log-update-enabled
-      type: object
-      properties:
-        enabled:
-          type: boolean
-          description: 'If set, this log level will be outputted.'
-    Status:
-      title: Status
-      type: object
-      properties:
-        databases:
-          type: object
-          description: Map of the databases in the node.
-          properties:
-            database_name:
-              type: object
-              properties:
-                seq:
-                  type: number
-                  minimum: 0
-                  description: The latest sequence number in the database.
-                server_uuid:
-                  type: string
-                  description: The server unique identifier.
-                state:
-                  type: string
-                  enum:
-                    - Online
-                    - Offline
-                  description: Whether the database is online or offline.
-                replication_status:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/Replication-status'
-                cluster:
-                  type: object
-                  properties:
-                    replication:
-                      type: object
-                      description: Map of replication configs defined for the cluster.
-                      properties:
-                        replication_id:
-                          $ref: '#/components/schemas/Retrieved-replication'
-                    nodes:
-                      type: object
-                      description: Map of all Sync Gateway nodes in the cluster.
-                      properties:
-                        node_uuid:
-                          type: object
-                          description: The nodes unique identifier.
-                          properties:
-                            uuid:
-                              type: string
-                              description: The nodes unique identifier.
-                            host:
-                              type: string
-                              description: The nodes host name.
-        version:
-          type: string
-          description: |-
-            The product version including the build number and edition (ie. `EE` or `CE`).
-
-            Blank if `api.hide_product_version=true` in the startup configuration.
-    Vendor:
-      title: Vendor
-      type: object
-      properties:
-        name:
-          type: string
-          default: Couchbase Sync Gateway
-          description: The product name.
-        version:
-          type: string
-          description: |-
-            The product version.
-
-            Blank if `api.hide_product_version=true` in the startup configuration.
-      required:
-        - name
-  requestBodies:
-    User:
+        Returned when optimistic concurrency control is used, and there has been an update to the configuration in between this update.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/User'
-      description: Properties associated with a user
-    Role:
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Role'
-      description: Properties associated with a role
-    OIDC-login-page-handler:
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/OIDC-login-page-handler'
-      description: Properties passed from the OpenID Connect mock login page to the handler
-    Doc-body:
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Document'
-      description: Properties of a document
-    Replication-upsert:
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Replication'
-      description: If the `replication_id` matches an existing replication then the existing configuration will be updated. Only the specified fields in the request will be used to update the existing configuration. Unspecified fields will remain untouched.
-    Profile:
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              file:
-                type: string
-                description: This is the file to output the pprof profile at.
+            $ref: '#/components/schemas/HTTP-Error'
+          example:
+            error: Precondition Failed
+            reason: Provided If-Match header does not match current config version
+tags:
+  - name: Public
+    description: Public API (port 4984)
+  - name: Admin
+    description: Admin API (port 4985)
+  - name: Metrics
+    description: Metrics API (port 4986)
+externalDocs:
+  description: Sync Gateway Quickstart | Couchbase Docs
+  url: 'https://docs.couchbase.com/sync-gateway/current/index.html'


### PR DESCRIPTION
Going to be largely unreviewable due to reordering of properties (via `openapi-format`)

## Changes:
* Run through spellcheck
* Run through openapi-format tool
* Remove implementation details
* Fix /_replicationStatus paths (to include /{db}/)
* Cleanup schema for /
* Improve schema for GET /{db}/
* Clarify non-functionality of /_ensure_full_commit
* Add expvar schema
* Update all pprof endpoints
* Update db config etag/ifmatch descriptions
* Fix incorrect 'value' nesting for single exmaples
* Extract 412 response for db config endpoints
* Fixes to sync, import, resync, purge, etc.