### PR TITLE
CBG-1951: Minor Jenkins script changes

### DIFF
--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -45,8 +45,8 @@ fi
 # Install tools to use after job has completed
 go get -u -v github.com/tebeka/go2xunit
 go install -v github.com/tebeka/go2xunit
-go get -v -u github.com/axw/gocov/...
-go install -v github.com/axw/gocov/...
+go get -v -u github.com/axw/gocov/gocov
+go install -v github.com/axw/gocov/gocov
 go get -v -u github.com/AlekSi/gocov-xml
 go install -v github.com/AlekSi/gocov-xml
 
@@ -90,9 +90,9 @@ fi
 
 if [ "${RUN_WALRUS}" == "true" ]; then
   # EE
-  go test -coverprofile=coverage_walrus_ee.out -coverpkg=github.com/couchbase/sync_gateway/${TARGET_PACKAGE} -tags cb_sg_enterprise $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} >verbose_unit_ee.out.raw 2>&1 | true
+  go test -coverprofile=coverage_walrus_ee.out -coverpkg=github.com/couchbase/sync_gateway/... -tags cb_sg_enterprise $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} >verbose_unit_ee.out.raw 2>&1 | true
   # CE
-  go test -coverprofile=coverage_walrus_ce.out -coverpkg=github.com/couchbase/sync_gateway/${TARGET_PACKAGE} $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} >verbose_unit_ce.out.raw 2>&1 | true
+  go test -coverprofile=coverage_walrus_ce.out -coverpkg=github.com/couchbase/sync_gateway/... $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} >verbose_unit_ce.out.raw 2>&1 | true
 fi
 
 # Start CBS
@@ -128,7 +128,7 @@ if [ "${SG_EDITION}" == "EE" ]; then
     GO_TEST_FLAGS="${GO_TEST_FLAGS} -tags cb_sg_enterprise"
 fi
 
-go test ${GO_TEST_FLAGS} -coverprofile=coverage_int.out -coverpkg=github.com/couchbase/sync_gateway/${TARGET_PACKAGE} github.com/couchbase/sync_gateway/${TARGET_PACKAGE} 2>&1 | tee "${INT_LOG_FILE_NAME}.out.raw" | grep -E '(--- (FAIL|PASS|SKIP):|github.com/couchbase/sync_gateway(/.+)?\t|TEST: |panic: )'
+go test ${GO_TEST_FLAGS} -coverprofile=coverage_int.out -coverpkg=github.com/couchbase/sync_gateway/... github.com/couchbase/sync_gateway/${TARGET_PACKAGE} 2>&1 | tee "${INT_LOG_FILE_NAME}.out.raw" | grep -E '(--- (FAIL|PASS|SKIP):|github.com/couchbase/sync_gateway(/.+)?\t|TEST: |panic: )'
 if [ "${PIPESTATUS[0]}" -ne "0" ]; then # If test exit code is not 0 (failed)
   echo "Go test failed! Parsing logs to find cause..."
   TEST_FAILED=true

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 DEFAULT_PACKAGE_TIMEOUT="45m"
 
-if [ $1 == "-m" ]; then
+if [ "$1" == "-m" ]; then
     echo "Running in automated master integration mode"
     # Set automated setting parameters
     SG_COMMIT="master"
@@ -49,7 +49,7 @@ go install -v github.com/AlekSi/gocov-xml@latest
 
 # Set environment vars
 GO_TEST_FLAGS="-v -p 1 -count=${RUN_COUNT}"
-INT_LOG_FILE_NAME="int_logs_${SG_EDITION}_${SG_COMMIT}_${TARGET_TEST}"
+INT_LOG_FILE_NAME="verbose_int"
 
 if [ -d "godeps" ]; then
   export GOPATH=`pwd`/godeps

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -43,12 +43,9 @@ if [ ${USE_GO_MODULES} == "false" ]; then
 fi
 
 # Install tools to use after job has completed
-go get -u -v github.com/tebeka/go2xunit
-go install -v github.com/tebeka/go2xunit
-go get -v -u github.com/axw/gocov/gocov
-go install -v github.com/axw/gocov/gocov
-go get -v -u github.com/AlekSi/gocov-xml
-go install -v github.com/AlekSi/gocov-xml
+go install -v github.com/tebeka/go2xunit@latest
+go install -v github.com/axw/gocov/gocov@latest
+go install -v github.com/AlekSi/gocov-xml@latest
 
 # Set environment vars
 GO_TEST_FLAGS="-v -p 1 -count=${RUN_COUNT}"


### PR DESCRIPTION
CBG-1951

- Cleanup
- Go Get is used for bootstrap, and Go install for modules
- Cover profile targets all packages

- Jenkins will now download the integration script if it does not exist
