### PR TITLE
CBG-1925: Remove non-context log functions

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -372,7 +372,7 @@ func (auth *Authenticator) InvalidateChannels(name string, isUser bool, invalSeq
 		docID = docIDForRole(name)
 	}
 
-	base.Infof(base.KeyAccess, "Invalidate access of %q", base.UD(name))
+	base.InfofCtx(auth.LogCtx, base.KeyAccess, "Invalidate access of %q", base.UD(name))
 
 	if auth.bucket.IsSupported(sgbucket.DataStoreFeatureSubdocOperations) {
 		err := auth.bucket.SubdocInsert(docID, "channel_inval_seq", 0, invalSeq)
@@ -544,7 +544,7 @@ func (auth *Authenticator) casUpdatePrincipal(p Principal, callback casUpdatePri
 			return err
 		}
 
-		base.Infof(base.KeyAuth, "CAS mismatch in casUpdatePrincipal, retrying.  Principal:%s", base.UD(p.Name()))
+		base.InfofCtx(auth.LogCtx, base.KeyAuth, "CAS mismatch in casUpdatePrincipal, retrying.  Principal:%s", base.UD(p.Name()))
 
 		switch p.(type) {
 		case User:

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -284,7 +284,7 @@ func (auth *Authenticator) rebuildRoles(user User) error {
 		var err error
 		roles, err = auth.channelComputer.ComputeRolesForUser(auth.LogCtx, user)
 		if err != nil {
-			base.Warnf("channelComputer.ComputeRolesForUser failed on user %s: %v", base.UD(user.Name()), err)
+			base.WarnfCtx(auth.LogCtx, "channelComputer.ComputeRolesForUser failed on user %s: %v", base.UD(user.Name()), err)
 			return err
 		}
 	}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -688,7 +688,7 @@ func verifyToken(ctx context.Context, token string, provider *OIDCProvider, call
 // creates the user when autoRegister=true.
 func (auth *Authenticator) AuthenticateTrustedJWT(token string, provider *OIDCProvider, callbackURLFunc OIDCCallbackURLFunc) (user User,
 	tokenExpiry time.Time, err error) {
-	base.Debugf(base.KeyAuth, "AuthenticateTrustedJWT called with token: %s", base.UD(token))
+	base.DebugfCtx(auth.LogCtx, base.KeyAuth, "AuthenticateTrustedJWT called with token: %s", base.UD(token))
 
 	var identity *Identity
 	if provider.AllowUnsignedProviderTokens {

--- a/auth/password_hash_test.go
+++ b/auth/password_hash_test.go
@@ -219,6 +219,7 @@ func TestCacheRace(t *testing.T) {
 		{"RandReplKeyCache", NewRandReplKeyCache(maxCacheSize), randReplKeyCache},
 		{"NoReplKeyCache", NewNoReplKeyCache(maxCacheSize), noReplKeyCache},
 	}
+	ctx := base.TestCtx(t)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -235,7 +236,7 @@ func TestCacheRace(t *testing.T) {
 					defer wg.Done()
 					key := fmt.Sprintf("k%d", i)
 					cache.Put(key)
-					base.Infof(base.KeyAuth, "Goroutine%v Put key: %v", i, key)
+					base.InfofCtx(ctx, base.KeyAuth, "Goroutine%v Put key: %v", i, key)
 				}(cache, i)
 
 				wg.Add(1)
@@ -243,7 +244,7 @@ func TestCacheRace(t *testing.T) {
 					defer wg.Done()
 					key := fmt.Sprintf("k%d", i)
 					ok := cache.Contains(key)
-					base.Infof(base.KeyAuth, "Goroutine%v Contains: %v, key: %v", i, ok, key)
+					base.InfofCtx(ctx, base.KeyAuth, "Goroutine%v Contains: %v, key: %v", i, ok, key)
 				}(cache, i)
 			}
 			wg.Wait()

--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"time"
@@ -243,7 +244,7 @@ func (cc *CouchbaseCluster) getBucket(bucketName string) (b *gocb.Bucket, teardo
 	teardownFn = func() {
 		err := connection.Close(&gocb.ClusterCloseOptions{})
 		if err != nil {
-			Warnf("Failed to close cluster connection: %v", err)
+			WarnfCtx(context.Background(), "Failed to close cluster connection: %v", err)
 		}
 	}
 

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -611,6 +611,6 @@ func retrievePurgeInterval(bucket CouchbaseStore, uri string) (time.Duration, er
 func ensureBodyClosed(body io.ReadCloser) {
 	err := body.Close()
 	if err != nil {
-		Debugf(KeyBucket, "Failed to close socket: %v", err)
+		DebugfCtx(context.TODO(), KeyBucket, "Failed to close socket: %v", err)
 	}
 }

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -380,7 +380,7 @@ func GetStatsVbSeqno(stats map[string]map[string]string, maxVbno uint16, useAbsH
 
 func GetBucket(spec BucketSpec) (bucket Bucket, err error) {
 	if spec.IsWalrusBucket() {
-		Infof(KeyAll, "Opening Walrus database %s on <%s>", MD(spec.BucketName), SD(spec.Server))
+		InfofCtx(context.TODO(), KeyAll, "Opening Walrus database %s on <%s>", MD(spec.BucketName), SD(spec.Server))
 		sgbucket.SetLogging(ConsoleLogKey().Enabled(KeyBucket))
 		bucket, err = walrus.GetBucket(spec.Server, DefaultPool, spec.BucketName)
 		// If feed type is not specified (defaults to DCP) or isn't TAP, wrap with pseudo-vbucket handling for walrus
@@ -393,7 +393,7 @@ func GetBucket(spec BucketSpec) (bucket Bucket, err error) {
 		if spec.Auth != nil {
 			username, _, _ = spec.Auth.GetCredentials()
 		}
-		Infof(KeyAll, "%v Opening Couchbase database %s on <%s> as user %q", spec.CouchbaseDriver, MD(spec.BucketName), SD(spec.Server), UD(username))
+		InfofCtx(context.TODO(), KeyAll, "%v Opening Couchbase database %s on <%s> as user %q", spec.CouchbaseDriver, MD(spec.BucketName), SD(spec.Server), UD(username))
 
 		switch spec.CouchbaseDriver {
 		case GoCB, GoCBCustomSGTranscoder:

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -107,7 +107,7 @@ func ChooseCouchbaseDriver(bucketType CouchbaseBucketType) CouchbaseDriver {
 		return GoCBv2
 	default:
 		// If a new bucket type is added and this method isn't updated, flag a warning (or, could panic)
-		Warnf("Unexpected bucket type: %v", bucketType)
+		WarnfCtx(context.Background(), "Unexpected bucket type: %v", bucketType)
 		return GoCBv2
 	}
 
@@ -416,7 +416,7 @@ func GetBucket(spec BucketSpec) (bucket Bucket, err error) {
 		// or later, otherwise refuse to connect to the bucket since pre 5.0 versions don't support XATTRs
 		if spec.UseXattrs {
 			if !bucket.IsSupported(sgbucket.DataStoreFeatureXattrs) {
-				Warnf("If using XATTRS, Couchbase Server version must be >= 5.0.")
+				WarnfCtx(context.Background(), "If using XATTRS, Couchbase Server version must be >= 5.0.")
 				return nil, ErrFatalBucketConnection
 			}
 		}
@@ -589,7 +589,7 @@ func retrievePurgeInterval(bucket CouchbaseStore, uri string) (time.Duration, er
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusForbidden {
-		Warnf("403 Forbidden attempting to access %s.  Bucket user must have Bucket Full Access and Bucket Admin roles to retrieve metadata purge interval.", UD(uri))
+		WarnfCtx(resp.Request.Context(), "403 Forbidden attempting to access %s.  Bucket user must have Bucket Full Access and Bucket Admin roles to retrieve metadata purge interval.", UD(uri))
 	} else if resp.StatusCode != http.StatusOK {
 		return 0, errors.New(resp.Status)
 	}

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -9,6 +9,7 @@
 package base
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -282,7 +283,7 @@ func (b BucketSpec) TLSConfig() *tls.Config {
 		var err error
 		certPool, err = getRootCAs(b.CACertPath)
 		if err != nil {
-			Errorf("Error creating tlsConfig for DCP processing: %v", err)
+			ErrorfCtx(context.Background(), "Error creating tlsConfig for DCP processing: %v", err)
 			return nil
 		}
 	}
@@ -296,7 +297,7 @@ func (b BucketSpec) TLSConfig() *tls.Config {
 	if b.Certpath != "" && b.Keypath != "" {
 		cert, err := tls.LoadX509KeyPair(b.Certpath, b.Keypath)
 		if err != nil {
-			Errorf("Error creating tlsConfig for DCP processing: %v", err)
+			ErrorfCtx(context.Background(), "Error creating tlsConfig for DCP processing: %v", err)
 			return nil
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1103,7 +1103,7 @@ func (bucket *CouchbaseBucketGoCB) Update(k string, exp uint32, callback sgbucke
 		}
 
 		retryAttempts++
-		Debugf(KeyCRUD, "CAS Update RetryLoop retrying for doc %q, attempt %d", UD(k), retryAttempts)
+		DebugfCtx(context.TODO(), KeyCRUD, "CAS Update RetryLoop retrying for doc %q, attempt %d", UD(k), retryAttempts)
 	}
 }
 

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -992,7 +992,7 @@ func (bucket *CouchbaseBucketGoCB) Remove(k string, cas uint64) (casOut uint64, 
 
 func (bucket *CouchbaseBucketGoCB) Write(k string, flags int, exp uint32, v interface{}, opt sgbucket.WriteOptions) error {
 	// TODO: CBG-1948
-	Panicf("Unimplemented method: Write()")
+	PanicfCtx(context.TODO(), "Unimplemented method: Write()")
 	return nil
 }
 
@@ -1006,13 +1006,13 @@ func (bucket *CouchbaseBucketGoCB) WriteCas(k string, flags int, exp uint32, cas
 	// we only support the sgbucket.Raw WriteOption at this point
 	if opt != 0 && opt != sgbucket.Raw {
 		// TODO: CBG-1948
-		Panicf("WriteOption must be empty or sgbucket.Raw")
+		PanicfCtx(context.TODO(), "WriteOption must be empty or sgbucket.Raw")
 	}
 
 	// also, flags must be 0, since that is not supported by gocb
 	if flags != 0 {
 		// TODO: CBG-1948
-		Panicf("flags must be 0")
+		PanicfCtx(context.TODO(), "flags must be 0")
 	}
 
 	worker := func() (shouldRetry bool, err error, value uint64) {

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -64,7 +64,7 @@ func (bucket *CouchbaseBucketGoCB) Query(statement string, params map[string]int
 	waitTime := 10 * time.Millisecond
 	for i := 1; i <= MaxQueryRetries; i++ {
 
-		Tracef(KeyQuery, "Executing N1QL query: %v", UD(n1qlQuery))
+		TracefCtx(logCtx, KeyQuery, "Executing N1QL query: %v", UD(n1qlQuery))
 		queryResults, queryErr := bucket.runQuery(n1qlQuery, params)
 
 		if queryErr == nil {

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -76,19 +77,19 @@ func (bucket *CouchbaseBucketGoCB) Query(statement string, params map[string]int
 
 		// Non-retry error - return
 		if !isTransientIndexerError(queryErr) {
-			Warnf("Error when querying index using statement: [%s] parameters: [%+v] error:%v", UD(bucketStatement), UD(params), queryErr)
+			WarnfCtx(context.TODO(), "Error when querying index using statement: [%s] parameters: [%+v] error:%v", UD(bucketStatement), UD(params), queryErr)
 			return queryResults, pkgerrors.WithStack(queryErr)
 		}
 
 		// Indexer error - wait then retry
 		err = queryErr
-		Warnf("Indexer error during query - retry %d/%d after %v.  Error: %v", i, MaxQueryRetries, waitTime, queryErr)
+		WarnfCtx(context.TODO(), "Indexer error during query - retry %d/%d after %v.  Error: %v", i, MaxQueryRetries, waitTime, queryErr)
 		time.Sleep(waitTime)
 
 		waitTime = time.Duration(waitTime * 2)
 	}
 
-	Warnf("Exceeded max retries for query when querying index using statement: [%s], err:%v", UD(bucketStatement), err)
+	WarnfCtx(context.TODO(), "Exceeded max retries for query when querying index using statement: [%s], err:%v", UD(bucketStatement), err)
 	return nil, err
 }
 

--- a/base/bucket_xattr.go
+++ b/base/bucket_xattr.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"context"
 	"errors"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -69,17 +70,17 @@ func (bucket *CouchbaseBucketGoCB) SubdocGetXattr(k string, xattrKey string, xv 
 		case nil:
 			xattrContErr := res.Content(xattrKey, xv)
 			if xattrContErr != nil {
-				Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContErr)
+				DebugfCtx(context.TODO(), KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContErr)
 			}
 			cas := uint64(res.Cas())
 			return false, err, cas
 		case gocbcore.ErrSubDocBadMulti:
 			xattrErr := res.Content(xattrKey, xv)
-			Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrErr)
+			DebugfCtx(context.TODO(), KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrErr)
 			cas := uint64(res.Cas())
 			return false, ErrXattrNotFound, cas
 		case gocbcore.ErrKeyNotFound:
-			Debugf(KeyCRUD, "No document found for key=%s", UD(k))
+			DebugfCtx(context.TODO(), KeyCRUD, "No document found for key=%s", UD(k))
 			return false, ErrNotFound, 0
 		case gocbcore.ErrSubDocMultiPathFailureDeleted, gocb.ErrSubDocSuccessDeleted:
 			xattrContentErr := res.Content(xattrKey, xv)
@@ -189,12 +190,12 @@ func (bucket *CouchbaseBucketGoCB) SubdocGetBodyAndXattr(k string, xattrKey stri
 			// Attempt to retrieve the document body, if present
 			docContentErr := res.Content("", rv)
 			if docContentErr != nil {
-				Debugf(KeyCRUD, "No document body found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), docContentErr)
+				DebugfCtx(context.TODO(), KeyCRUD, "No document body found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), docContentErr)
 			}
 			// Attempt to retrieve the xattr, if present
 			xattrContentErr := res.Content(xattrKey, xv)
 			if xattrContentErr != nil {
-				Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContentErr)
+				DebugfCtx(context.TODO(), KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContentErr)
 			}
 			cas = uint64(res.Cas())
 
@@ -204,7 +205,7 @@ func (bucket *CouchbaseBucketGoCB) SubdocGetBodyAndXattr(k string, xattrKey stri
 			cas = uint64(res.Cas())
 			if xattrContentErr != nil {
 				// No doc, no xattr can be treated as NotFound from Sync Gateway's perspective, even if it is a server tombstone
-				Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContentErr)
+				DebugfCtx(context.TODO(), KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContentErr)
 				return false, ErrNotFound, cas
 			}
 			return false, nil, cas
@@ -306,7 +307,7 @@ func (bucket *CouchbaseBucketGoCB) SubdocDeleteBodyAndXattr(k string, xattrKey s
 		Execute()
 
 	if mutateErr == nil || mutateErr == gocbcore.ErrSubDocSuccessDeleted {
-		Debugf(KeyCRUD, "No error or ErrSubDocSuccessDeleted.  We're done.")
+		DebugfCtx(context.TODO(), KeyCRUD, "No error or ErrSubDocSuccessDeleted.  We're done.")
 		return nil
 	}
 
@@ -337,7 +338,7 @@ func (bucket *CouchbaseBucketGoCB) SubdocDeleteBody(k string, xattrKey string, e
 		Execute()
 
 	if mutateErr == nil || mutateErr == gocbcore.ErrSubDocSuccessDeleted {
-		Debugf(KeyCRUD, "No error or ErrSubDocSuccessDeleted.  We're done.")
+		DebugfCtx(context.TODO(), KeyCRUD, "No error or ErrSubDocSuccessDeleted.  We're done.")
 		return uint64(docFragment.Cas()), nil
 	}
 
@@ -360,7 +361,7 @@ func (bucket *CouchbaseBucketGoCB) SubdocUpdateXattrDeleteBody(k, xattrKey strin
 		Execute()
 
 	if mutateErr == nil || mutateErr == gocbcore.ErrSubDocSuccessDeleted {
-		Debugf(KeyCRUD, "No error or ErrSubDocSuccessDeleted.  We're done.")
+		DebugfCtx(context.TODO(), KeyCRUD, "No error or ErrSubDocSuccessDeleted.  We're done.")
 		return uint64(docFragment.Cas()), nil
 	}
 

--- a/base/collection.go
+++ b/base/collection.go
@@ -32,9 +32,10 @@ var _ CouchbaseStore = &Collection{}
 // Connect to the default collection for the specified bucket
 func GetCouchbaseCollection(spec BucketSpec) (*Collection, error) {
 
+	logCtx := context.TODO()
 	connString, err := spec.GetGoCBConnString()
 	if err != nil {
-		WarnfCtx(context.TODO(), "Unable to parse server value: %s error: %v", SD(spec.Server), err)
+		WarnfCtx(logCtx, "Unable to parse server value: %s error: %v", SD(spec.Server), err)
 		return nil, err
 	}
 
@@ -49,13 +50,13 @@ func GetCouchbaseCollection(spec BucketSpec) (*Collection, error) {
 	}
 
 	if _, ok := authenticator.(gocb.CertificateAuthenticator); ok {
-		Infof(KeyAuth, "Using cert authentication for bucket %s on %s", MD(spec.BucketName), MD(spec.Server))
+		InfofCtx(logCtx, KeyAuth, "Using cert authentication for bucket %s on %s", MD(spec.BucketName), MD(spec.Server))
 	} else {
-		Infof(KeyAuth, "Using credential authentication for bucket %s on %s", MD(spec.BucketName), MD(spec.Server))
+		InfofCtx(logCtx, KeyAuth, "Using credential authentication for bucket %s on %s", MD(spec.BucketName), MD(spec.Server))
 	}
 
 	timeoutsConfig := GoCBv2TimeoutsConfig(spec.BucketOpTimeout, StdlibDurationPtr(spec.GetViewQueryTimeout()))
-	Infof(KeyAll, "Setting query timeouts for bucket %s to %v", spec.BucketName, timeoutsConfig.QueryTimeout)
+	InfofCtx(logCtx, KeyAll, "Setting query timeouts for bucket %s to %v", spec.BucketName, timeoutsConfig.QueryTimeout)
 
 	clusterOptions := gocb.ClusterOptions{
 		Authenticator:  authenticator,
@@ -70,7 +71,7 @@ func GetCouchbaseCollection(spec BucketSpec) (*Collection, error) {
 
 	cluster, err := gocb.Connect(connString, clusterOptions)
 	if err != nil {
-		Infof(KeyAuth, "Unable to connect to cluster: %v", err)
+		InfofCtx(logCtx, KeyAuth, "Unable to connect to cluster: %v", err)
 		return nil, err
 	}
 
@@ -125,7 +126,7 @@ func GetCollectionFromCluster(cluster *gocb.Cluster, spec BucketSpec, waitUntilR
 
 	if maxConcurrentQueryOps > DefaultHttpMaxIdleConnsPerHost*queryNodeCount {
 		maxConcurrentQueryOps = DefaultHttpMaxIdleConnsPerHost * queryNodeCount
-		Infof(KeyAll, "Setting max_concurrent_query_ops to %d based on query node count (%d)", maxConcurrentQueryOps, queryNodeCount)
+		InfofCtx(context.TODO(), KeyAll, "Setting max_concurrent_query_ops to %d based on query node count (%d)", maxConcurrentQueryOps, queryNodeCount)
 	}
 
 	collection.queryOps = make(chan struct{}, maxConcurrentQueryOps)

--- a/base/collection.go
+++ b/base/collection.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"errors"
 	"expvar"
 	"fmt"
@@ -33,7 +34,7 @@ func GetCouchbaseCollection(spec BucketSpec) (*Collection, error) {
 
 	connString, err := spec.GetGoCBConnString()
 	if err != nil {
-		Warnf("Unable to parse server value: %s error: %v", SD(spec.Server), err)
+		WarnfCtx(context.TODO(), "Unable to parse server value: %s error: %v", SD(spec.Server), err)
 		return nil, err
 	}
 
@@ -83,7 +84,7 @@ func GetCouchbaseCollection(spec BucketSpec) (*Collection, error) {
 		if errors.Is(err, gocb.ErrAuthenticationFailure) {
 			return nil, ErrAuthError
 		}
-		Warnf("Error waiting for cluster to be ready: %v", err)
+		WarnfCtx(context.TODO(), "Error waiting for cluster to be ready: %v", err)
 		return nil, err
 	}
 
@@ -101,7 +102,7 @@ func GetCollectionFromCluster(cluster *gocb.Cluster, spec BucketSpec, waitUntilR
 		if errors.Is(err, gocb.ErrAuthenticationFailure) {
 			return nil, ErrAuthError
 		}
-		Warnf("Error waiting for bucket to be ready: %v", err)
+		WarnfCtx(context.TODO(), "Error waiting for bucket to be ready: %v", err)
 		return nil, err
 	}
 
@@ -171,7 +172,7 @@ func (c *Collection) UUID() (string, error) {
 func (c *Collection) Close() {
 	if c.cluster != nil {
 		if err := c.cluster.Close(nil); err != nil {
-			Warnf("Error closing collection cluster: %v", err)
+			WarnfCtx(context.TODO(), "Error closing collection cluster: %v", err)
 		}
 	}
 	return
@@ -628,7 +629,7 @@ func (c *Collection) Flush() error {
 	workerFlush := func() (shouldRetry bool, err error, value interface{}) {
 		err = bucketManager.FlushBucket(c.Bucket().Name(), nil)
 		if err != nil {
-			Warnf("Error flushing bucket: %v  Will retry.", err)
+			WarnfCtx(context.TODO(), "Error flushing bucket: %v  Will retry.", err)
 			shouldRetry = true
 		}
 		return shouldRetry, err, nil
@@ -719,7 +720,7 @@ func (c *Collection) MaxTTL() (int, error) {
 func (c *Collection) HttpClient() *http.Client {
 	router, routerErr := c.Bucket().Internal().IORouter()
 	if routerErr != nil {
-		Warnf("Unable to obtain router while retrieving httpClient:%v", routerErr)
+		WarnfCtx(context.TODO(), "Unable to obtain router while retrieving httpClient:%v", routerErr)
 		return nil
 	}
 	return router.HTTPClient()
@@ -732,7 +733,7 @@ func (c *Collection) GetExpiry(k string) (expiry uint32, getMetaError error) {
 
 	router, routerErr := c.Bucket().Internal().IORouter()
 	if routerErr != nil {
-		Warnf("Unable to obtain router while retrieving expiry:%v", routerErr)
+		WarnfCtx(context.TODO(), "Unable to obtain router while retrieving expiry:%v", routerErr)
 		return 0, routerErr
 	}
 	getMetaOptions := gocbcore.GetMetaOptions{

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"time"
@@ -56,19 +57,19 @@ func (c *Collection) Query(statement string, params map[string]interface{}, cons
 
 		// Non-retry error - return
 		if !isTransientIndexerError(queryErr) {
-			Warnf("Error when querying index using statement: [%s] parameters: [%+v] error:%v", UD(bucketStatement), UD(params), queryErr)
+			WarnfCtx(context.TODO(), "Error when querying index using statement: [%s] parameters: [%+v] error:%v", UD(bucketStatement), UD(params), queryErr)
 			return resultsIterator, pkgerrors.WithStack(queryErr)
 		}
 
 		// Indexer error - wait then retry
 		err = queryErr
-		Warnf("Indexer error during query - retry %d/%d after %v.  Error: %v", i, MaxQueryRetries, waitTime, queryErr)
+		WarnfCtx(context.TODO(), "Indexer error during query - retry %d/%d after %v.  Error: %v", i, MaxQueryRetries, waitTime, queryErr)
 		time.Sleep(waitTime)
 
 		waitTime = waitTime * 2
 	}
 
-	Warnf("Exceeded max retries for query when querying index using statement: [%s] parameters: [%+v], err:%v", UD(bucketStatement), UD(params), err)
+	WarnfCtx(context.TODO(), "Exceeded max retries for query when querying index using statement: [%s] parameters: [%+v], err:%v", UD(bucketStatement), UD(params), err)
 	return nil, err
 }
 

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -41,7 +41,7 @@ func (c *Collection) Query(statement string, params map[string]interface{}, cons
 
 	waitTime := 10 * time.Millisecond
 	for i := 1; i <= MaxQueryRetries; i++ {
-		Tracef(KeyQuery, "Executing N1QL query: %v - %+v", UD(bucketStatement), UD(params))
+		TracefCtx(logCtx, KeyQuery, "Executing N1QL query: %v - %+v", UD(bucketStatement), UD(params))
 		queryResults, queryErr := c.runQuery(bucketStatement, n1qlOptions)
 		if queryErr == nil {
 			resultsIterator := &gocbRawIterator{

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -123,13 +123,13 @@ func createIndex(store N1QLStore, indexName string, createStatement string, opti
 	}
 
 	if IsIndexerRetryIndexError(err) {
-		Infof(KeyQuery, "Indexer error creating index - waiting for server background retry.  Error:%v", err)
+		InfofCtx(context.TODO(), KeyQuery, "Indexer error creating index - waiting for server background retry.  Error:%v", err)
 		// Wait for bucket to be created in background before returning
 		return waitForIndexExistence(store, indexName, true)
 	}
 
 	if IsCreateDuplicateIndexError(err) {
-		Infof(KeyQuery, "Duplicate index creation in progress - waiting for index readiness.  Error:%v", err)
+		InfofCtx(context.TODO(), KeyQuery, "Duplicate index creation in progress - waiting for index readiness.  Error:%v", err)
 		// Wait for bucket to be created in background before returning
 		return waitForIndexExistence(store, indexName, true)
 	}
@@ -203,7 +203,7 @@ func BuildDeferredIndexes(s N1QLStore, indexSet []string) error {
 		return nil
 	}
 
-	Infof(KeyQuery, "Building deferred indexes: %v", deferredIndexes)
+	InfofCtx(context.TODO(), KeyQuery, "Building deferred indexes: %v", deferredIndexes)
 	buildErr := buildIndexes(s, deferredIndexes)
 	return buildErr
 }
@@ -223,7 +223,7 @@ func buildIndexes(s N1QLStore, indexNames []string) error {
 
 	// If indexer reports build will be completed in the background, wait to validate build actually happens.
 	if IsIndexerRetryBuildError(err) {
-		Infof(KeyQuery, "Indexer error creating index - waiting for background build.  Error:%v", err)
+		InfofCtx(context.TODO(), KeyQuery, "Indexer error creating index - waiting for background build.  Error:%v", err)
 		// Wait for bucket to be created in background before returning
 		for _, indexName := range indexNames {
 			waitErr := s.WaitForIndexOnline(indexName)
@@ -328,7 +328,7 @@ func DropIndex(store N1QLStore, indexName string) error {
 	}
 
 	if IsIndexerRetryIndexError(err) {
-		Infof(KeyQuery, "Indexer error dropping index - waiting for server background retry.  Error:%v", err)
+		InfofCtx(context.TODO(), KeyQuery, "Indexer error dropping index - waiting for server background retry.  Error:%v", err)
 		// Wait for bucket to be dropped in background before returning
 		return waitForIndexExistence(store, indexName, false)
 	}

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -115,7 +115,7 @@ func createIndex(store N1QLStore, indexName string, createStatement string, opti
 		createStatement = fmt.Sprintf(`%s with %s`, createStatement, withClause)
 	}
 
-	Debugf(KeyQuery, "Attempting to create index using statement: [%s]", UD(createStatement))
+	DebugfCtx(context.TODO(), KeyQuery, "Attempting to create index using statement: [%s]", UD(createStatement))
 
 	err := store.executeStatement(createStatement)
 	if err == nil {

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -277,7 +277,7 @@ func GetIndexMeta(store N1QLStore, indexName string) (exists bool, meta *IndexMe
 		exists, meta, err := getIndexMetaWithoutRetry(store, indexName)
 		if err != nil {
 			// retry
-			Warnf("Error from GetIndexMeta for index %s: %v will retry", indexName, err)
+			WarnfCtx(context.TODO(), "Error from GetIndexMeta for index %s: %v will retry", indexName, err)
 			return true, err, nil
 		}
 		return false, nil, getIndexMetaRetryValues{
@@ -478,7 +478,7 @@ func (i *gocbRawIterator) Next(valuePtr interface{}) bool {
 
 	err := JSONUnmarshal(nextBytes, &valuePtr)
 	if err != nil {
-		Warnf("Unable to marshal view result row into value: %v", err)
+		WarnfCtx(context.TODO(), "Unable to marshal view result row into value: %v", err)
 		return false
 	}
 	return true

--- a/base/collection_view.go
+++ b/base/collection_view.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -193,7 +194,7 @@ func (c *Collection) View(ddoc, name string, params map[string]interface{}) (sgb
 
 		viewMeta, err := unmarshalViewMetadata(gocbViewResult)
 		if err != nil {
-			Warnf("Unable to type get metadata for gocb ViewResult - the total rows count will be missing.")
+			WarnfCtx(context.TODO(), "Unable to type get metadata for gocb ViewResult - the total rows count will be missing.")
 		} else {
 			viewResult.TotalRows = viewMeta.TotalRows
 		}
@@ -275,7 +276,7 @@ func createViewOptions(params map[string]interface{}) (viewOpts *gocb.ViewOption
 		case ViewQueryParamLimit:
 			uintVal, err := normalizeIntToUint(optionValue)
 			if err != nil {
-				Warnf("ViewQueryParamLimit error: %v", err)
+				WarnfCtx(context.Background(), "ViewQueryParamLimit error: %v", err)
 			}
 			viewOpts.Limit = uint32(uintVal)
 		case ViewQueryParamDescending:
@@ -285,7 +286,7 @@ func createViewOptions(params map[string]interface{}) (viewOpts *gocb.ViewOption
 		case ViewQueryParamSkip:
 			uintVal, err := normalizeIntToUint(optionValue)
 			if err != nil {
-				Warnf("ViewQueryParamSkip error: %v", err)
+				WarnfCtx(context.Background(), "ViewQueryParamSkip error: %v", err)
 			}
 			viewOpts.Skip = uint32(uintVal)
 		case ViewQueryParamGroup:
@@ -293,7 +294,7 @@ func createViewOptions(params map[string]interface{}) (viewOpts *gocb.ViewOption
 		case ViewQueryParamGroupLevel:
 			uintVal, err := normalizeIntToUint(optionValue)
 			if err != nil {
-				Warnf("ViewQueryParamGroupLevel error: %v", err)
+				WarnfCtx(context.Background(), "ViewQueryParamGroupLevel error: %v", err)
 			}
 			viewOpts.GroupLevel = uint32(uintVal)
 		case ViewQueryParamKey:
@@ -358,7 +359,7 @@ func asViewConsistency(value interface{}) gocb.ViewScanConsistency {
 		}
 		parsedVal, err := strconv.ParseBool(typeValue)
 		if err != nil {
-			Warnf("asStale called with unknown value: %v.  defaulting to stale=false", typeValue)
+			WarnfCtx(context.Background(), "asStale called with unknown value: %v.  defaulting to stale=false", typeValue)
 			return gocb.ViewScanConsistencyRequestPlus
 		}
 		if parsedVal {
@@ -373,7 +374,7 @@ func asViewConsistency(value interface{}) gocb.ViewScanConsistency {
 			return gocb.ViewScanConsistencyRequestPlus
 		}
 	default:
-		Warnf("asViewConsistency called with unknown type: %T.  defaulting to RequestPlus", typeValue)
+		WarnfCtx(context.Background(), "asViewConsistency called with unknown type: %T.  defaulting to RequestPlus", typeValue)
 		return gocb.ViewScanConsistencyRequestPlus
 	}
 

--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 
@@ -95,13 +96,13 @@ func (c *Collection) SubdocGetXattr(k string, xattrKey string, xv interface{}) (
 		xattrContErr := res.ContentAt(0, xv)
 		// On error here, treat as the xattr wasn't found
 		if xattrContErr != nil {
-			Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContErr)
+			DebugfCtx(context.TODO(), KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContErr)
 			return 0, ErrXattrNotFound
 		}
 		cas := uint64(res.Cas())
 		return cas, nil
 	} else if errors.Is(lookupErr, gocbcore.ErrDocumentNotFound) {
-		Debugf(KeyCRUD, "No document found for key=%s", UD(k))
+		DebugfCtx(context.TODO(), KeyCRUD, "No document found for key=%s", UD(k))
 		return 0, ErrNotFound
 	} else {
 		return 0, lookupErr
@@ -208,16 +209,16 @@ func (c *Collection) SubdocGetBodyAndXattr(k string, xattrKey string, userXattrK
 
 			if isKVError(docContentErr, memd.StatusSubDocMultiPathFailureDeleted) && isKVError(xattrContentErr, memd.StatusSubDocMultiPathFailureDeleted) {
 				// No doc, no xattr can be treated as NotFound from Sync Gateway's perspective, even if it is a server tombstone, but should return cas
-				Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContentErr)
+				DebugfCtx(context.TODO(), KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContentErr)
 				return false, ErrNotFound, cas
 			}
 
 			if docContentErr != nil {
-				Debugf(KeyCRUD, "No document body found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), docContentErr)
+				DebugfCtx(context.TODO(), KeyCRUD, "No document body found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), docContentErr)
 			}
 			// Attempt to retrieve the xattr, if present
 			if xattrContentErr != nil {
-				Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContentErr)
+				DebugfCtx(context.TODO(), KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContentErr)
 			}
 
 		case gocbcore.ErrMemdSubDocMultiPathFailureDeleted:
@@ -226,7 +227,7 @@ func (c *Collection) SubdocGetBodyAndXattr(k string, xattrKey string, userXattrK
 			cas = uint64(res.Cas())
 			if xattrContentErr != nil {
 				// No doc, no xattr means the doc isn't found
-				Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContentErr)
+				DebugfCtx(context.TODO(), KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContentErr)
 				return false, ErrNotFound, cas
 			}
 			return false, nil, cas

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -239,7 +240,7 @@ func WriteUpdateWithXattr(store SubdocXattrStore, k string, xattrKey string, use
 			// conflict/duplicate handling on retry.
 		} else {
 			// WriteWithXattr already handles retry on recoverable errors, so fail on any errors other than ErrKeyExists
-			Warnf("Failed to update doc with xattr for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), writeErr)
+			WarnfCtx(context.TODO(), "Failed to update doc with xattr for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), writeErr)
 			return emptyCas, writeErr
 		}
 

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -200,7 +200,7 @@ func WriteUpdateWithXattr(store SubdocXattrStore, k string, xattrKey string, use
 			if err != nil {
 				if pkgerrors.Cause(err) != ErrNotFound {
 					// Unexpected error, cancel writeupdate
-					Debugf(KeyCRUD, "Retrieval of existing doc failed during WriteUpdateWithXattr for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), err)
+					DebugfCtx(context.TODO(), KeyCRUD, "Retrieval of existing doc failed during WriteUpdateWithXattr for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), err)
 					return emptyCas, err
 				}
 				// Key not found - initialize values
@@ -351,7 +351,7 @@ type deleteWithXattrRaceInjection func(k string, xattrKey string)
 
 func deleteWithXattrInternal(store KvXattrStore, k string, xattrKey string, callback deleteWithXattrRaceInjection) error {
 
-	Debugf(KeyCRUD, "DeleteWithXattr called with key: %v xattrKey: %v", UD(k), UD(xattrKey))
+	DebugfCtx(context.TODO(), KeyCRUD, "DeleteWithXattr called with key: %v xattrKey: %v", UD(k), UD(xattrKey))
 
 	// Try to delete body and xattrs in single op
 	// NOTE: ongoing discussion w/ KV Engine team on whether this should handle cases where the body

--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -161,7 +162,7 @@ func (dc *DCPClient) close() {
 
 		agentErr := dc.agent.Close()
 		if agentErr != nil {
-			Warnf("Error closing DCP agent in client close: %v", agentErr)
+			WarnfCtx(context.Background(), "Error closing DCP agent in client close: %v", agentErr)
 		}
 	}
 	closeErr := dc.getCloseError()
@@ -298,12 +299,12 @@ func (dc *DCPClient) openStream(vbID uint16) (err error) {
 				return fmt.Errorf("metadata rollback failed for vb %d: %v", vbID, err)
 			}
 		case errors.Is(openStreamErr, gocbcore.ErrShutdown):
-			Warnf("Closing stream for vbID %d, agent has been shut down", vbID)
+			WarnfCtx(context.Background(), "Closing stream for vbID %d, agent has been shut down", vbID)
 			return openStreamErr
 		case errors.Is(openStreamErr, ErrTimeout):
 			Debugf(KeyDCP, "Timeout attempting to open stream for vb %d, will retry", vbID)
 		default:
-			Warnf("Error opening stream for vbID %d: %v", vbID, openStreamErr)
+			WarnfCtx(context.Background(), "Error opening stream for vbID %d: %v", vbID, openStreamErr)
 			return openStreamErr
 		}
 	}

--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -152,7 +152,7 @@ func (dc *DCPClient) close() {
 
 	// set dc.closing to true, avoid re-triggering close if it's already in progress
 	if !dc.closing.CompareAndSwap(false, true) {
-		Infof(KeyDCP, "DCP Client close called - client is already closing")
+		InfofCtx(context.TODO(), KeyDCP, "DCP Client close called - client is already closing")
 		return
 	}
 
@@ -162,7 +162,7 @@ func (dc *DCPClient) close() {
 
 		agentErr := dc.agent.Close()
 		if agentErr != nil {
-			WarnfCtx(context.Background(), "Error closing DCP agent in client close: %v", agentErr)
+			WarnfCtx(context.TODO(), "Error closing DCP agent in client close: %v", agentErr)
 		}
 	}
 	closeErr := dc.getCloseError()
@@ -273,6 +273,7 @@ func (dc *DCPClient) startWorkers() {
 
 func (dc *DCPClient) openStream(vbID uint16) (err error) {
 
+	logCtx := context.TODO()
 	var openStreamErr error
 	for i := 0; i < openRetryCount; i++ {
 		// Cancel open for stopped client
@@ -290,21 +291,21 @@ func (dc *DCPClient) openStream(vbID uint16) (err error) {
 		switch {
 		case (errors.Is(openStreamErr, gocbcore.ErrMemdRollback) || errors.Is(openStreamErr, gocbcore.ErrMemdRangeError)):
 			if dc.failOnRollback {
-				Infof(KeyDCP, "Open stream for vbID %d failed due to rollback or range error, closing client based on failOnRollback=true", vbID)
+				InfofCtx(logCtx, KeyDCP, "Open stream for vbID %d failed due to rollback or range error, closing client based on failOnRollback=true", vbID)
 				return fmt.Errorf("%s, failOnRollback requested", openStreamErr)
 			}
-			Infof(KeyDCP, "Open stream for vbID %d failed due to rollback or range error, will roll back metadata and retry: %v", vbID, openStreamErr)
+			InfofCtx(logCtx, KeyDCP, "Open stream for vbID %d failed due to rollback or range error, will roll back metadata and retry: %v", vbID, openStreamErr)
 			err := dc.rollback(vbID)
 			if err != nil {
 				return fmt.Errorf("metadata rollback failed for vb %d: %v", vbID, err)
 			}
 		case errors.Is(openStreamErr, gocbcore.ErrShutdown):
-			WarnfCtx(context.Background(), "Closing stream for vbID %d, agent has been shut down", vbID)
+			WarnfCtx(logCtx, "Closing stream for vbID %d, agent has been shut down", vbID)
 			return openStreamErr
 		case errors.Is(openStreamErr, ErrTimeout):
 			Debugf(KeyDCP, "Timeout attempting to open stream for vb %d, will retry", vbID)
 		default:
-			WarnfCtx(context.Background(), "Error opening stream for vbID %d: %v", vbID, openStreamErr)
+			WarnfCtx(logCtx, "Error opening stream for vbID %d: %v", vbID, openStreamErr)
 			return openStreamErr
 		}
 	}
@@ -407,7 +408,7 @@ func (dc *DCPClient) onStreamEnd(e endStreamEvent) {
 
 	if errors.Is(e.err, gocbcore.ErrDCPStreamStateChanged) || errors.Is(e.err, gocbcore.ErrDCPStreamTooSlow) ||
 		errors.Is(e.err, gocbcore.ErrDCPStreamDisconnected) {
-		Infof(KeyDCP, "Stream (vb:%d) closed by server, will reconnect.  Reason: %v", e.vbID, e.err)
+		InfofCtx(context.TODO(), KeyDCP, "Stream (vb:%d) closed by server, will reconnect.  Reason: %v", e.vbID, e.err)
 		err := dc.openStream(e.vbID)
 		if err != nil {
 			dc.fatalError(fmt.Errorf("Stream (vb:%d) failed to reopen: %w", e.vbID, err))

--- a/base/dcp_client_metadata.go
+++ b/base/dcp_client_metadata.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"context"
 	"fmt"
 	"math"
 
@@ -235,7 +236,7 @@ func (m *DCPMetadataCS) Persist(workerID int, vbIDs []uint16) {
 	}
 	err := m.bucket.Set(m.getMetadataKey(workerID), 0, meta)
 	if err != nil {
-		Infof(KeyDCP, "Unable to persist DCP metadata: %v", err)
+		InfofCtx(context.TODO(), KeyDCP, "Unable to persist DCP metadata: %v", err)
 	} else {
 		Tracef(KeyDCP, "Persisted metadata for worker %d: %v", workerID, meta)
 		//log.Printf("Persisted metadata for worker %d (%s): %v", workerID, m.getMetadataKey(workerID), meta)
@@ -250,7 +251,7 @@ func (m *DCPMetadataCS) load(workerID int) {
 		if IsKeyNotFoundError(m.bucket, err) {
 			return
 		}
-		Infof(KeyDCP, "Error loading persisted metadata - metadata will be reset for worker %d: %s", workerID, err)
+		InfofCtx(context.TODO(), KeyDCP, "Error loading persisted metadata - metadata will be reset for worker %d: %s", workerID, err)
 	}
 
 	Tracef(KeyDCP, "Loaded metadata for worker %d: %v", workerID, meta)
@@ -264,7 +265,7 @@ func (m *DCPMetadataCS) Purge(numWorkers int) {
 	for i := 0; i < numWorkers; i++ {
 		err := m.bucket.Delete(m.getMetadataKey(i))
 		if err != nil && !IsKeyNotFoundError(m.bucket, err) {
-			Infof(KeyDCP, "Unable to remove DCP checkpoint for key %s: %v", m.getMetadataKey(i), err)
+			InfofCtx(context.TODO(), KeyDCP, "Unable to remove DCP checkpoint for key %s: %v", m.getMetadataKey(i), err)
 		}
 	}
 }

--- a/base/dcp_client_metadata.go
+++ b/base/dcp_client_metadata.go
@@ -238,7 +238,7 @@ func (m *DCPMetadataCS) Persist(workerID int, vbIDs []uint16) {
 	if err != nil {
 		InfofCtx(context.TODO(), KeyDCP, "Unable to persist DCP metadata: %v", err)
 	} else {
-		Tracef(KeyDCP, "Persisted metadata for worker %d: %v", workerID, meta)
+		TracefCtx(context.TODO(), KeyDCP, "Persisted metadata for worker %d: %v", workerID, meta)
 		//log.Printf("Persisted metadata for worker %d (%s): %v", workerID, m.getMetadataKey(workerID), meta)
 	}
 	return
@@ -254,7 +254,7 @@ func (m *DCPMetadataCS) load(workerID int) {
 		InfofCtx(context.TODO(), KeyDCP, "Error loading persisted metadata - metadata will be reset for worker %d: %s", workerID, err)
 	}
 
-	Tracef(KeyDCP, "Loaded metadata for worker %d: %v", workerID, meta)
+	TracefCtx(context.TODO(), KeyDCP, "Loaded metadata for worker %d: %v", workerID, meta)
 	//log.Printf("Loaded metadata for worker %d (%s): %v", workerID, m.getMetadataKey(workerID), meta)
 	for vbID, metadata := range meta.DCPMeta {
 		m.metadata[vbID] = metadata

--- a/base/dcp_client_worker.go
+++ b/base/dcp_client_worker.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"bytes"
+	"context"
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -78,7 +79,7 @@ func (w *DCPWorker) Send(event streamEvent) {
 	select {
 	case w.eventFeed <- event:
 	case <-w.terminator:
-		Infof(KeyDCP, "Closing DCP worker, DCP Client was closed")
+		InfofCtx(context.TODO(), KeyDCP, "Closing DCP worker, DCP Client was closed")
 	}
 }
 

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -458,7 +458,7 @@ func (b *backfillStatus) updateStats(vbno uint16, previousVbSequence uint64, cur
 		b.lastPersistTime = time.Now()
 		err := b.persistBackfillSequences(bucket, currentSequences)
 		if err != nil {
-			Warnf("Error persisting back-fill sequences: %v", err)
+			WarnfCtx(context.Background(), "Error persisting back-fill sequences: %v", err)
 		}
 		b.logBackfillProgress()
 	}
@@ -469,7 +469,7 @@ func (b *backfillStatus) updateStats(vbno uint16, previousVbSequence uint64, cur
 		b.active = false
 		err := b.purgeBackfillSequences(bucket)
 		if err != nil {
-			Warnf("Error purging back-fill sequences: %v", err)
+			WarnfCtx(context.Background(), "Error purging back-fill sequences: %v", err)
 		}
 	}
 }
@@ -631,7 +631,7 @@ func getNetworkTypeFromConnSpec(spec gocbconnstr.ConnSpec) clusterNetworkType {
 	networkType := clusterNetworkAuto
 	if networkOpt, ok := spec.Options["network"]; ok && len(networkOpt) > 0 {
 		if len(networkOpt) > 1 {
-			Warnf("multiple 'network' options found in connection string - using first one: %q", networkOpt[0])
+			WarnfCtx(context.Background(), "multiple 'network' options found in connection string - using first one: %q", networkOpt[0])
 		}
 		networkType = clusterNetworkType(networkOpt[0])
 	}

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -332,14 +332,14 @@ func (c *DCPCommon) initFeed(backfillType uint64) (highSeqnos map[uint16]uint64,
 	switch backfillType {
 	case sgbucket.FeedNoBackfill:
 		// For non-backfill, use vbucket uuids, high sequence numbers
-		Debugf(KeyDCP, "Initializing DCP with no backfill - seeding seqnos: %v", highSeqnos)
+		DebugfCtx(c.loggingCtx, KeyDCP, "Initializing DCP with no backfill - seeding seqnos: %v", highSeqnos)
 		c.seedSeqnos(statsUuids, highSeqnos)
 	case sgbucket.FeedResume:
 		// For resume case, load previously persisted checkpoints from bucket
 		c.initMetadata(c.maxVbNo)
 		// Track backfill (from persisted checkpoints to current high seqno)
 		c.backfill.init(c.seqs, highSeqnos, c.maxVbNo, c.dbStatsExpvars)
-		Debugf(KeyDCP, "Initializing DCP feed based on persisted checkpoints")
+		DebugfCtx(c.loggingCtx, KeyDCP, "Initializing DCP feed based on persisted checkpoints")
 	default:
 		// Otherwise, start feed from zero
 		startSeqnos := make(map[uint16]uint64, c.maxVbNo)
@@ -347,7 +347,7 @@ func (c *DCPCommon) initFeed(backfillType uint64) (highSeqnos map[uint16]uint64,
 		c.seedSeqnos(vbuuids, startSeqnos)
 		// Track backfill (from zero to current high seqno)
 		c.backfill.init(c.seqs, highSeqnos, c.maxVbNo, c.dbStatsExpvars)
-		Debugf(KeyDCP, "Initializing DCP feed to start from zero")
+		DebugfCtx(c.loggingCtx, KeyDCP, "Initializing DCP feed to start from zero")
 	}
 
 	return highSeqnos, nil

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -242,7 +242,7 @@ func (d *DCPDest) Stats(io.Writer) error {
 func partitionToVbNo(partition string) uint16 {
 	vbNo, err := strconv.Atoi(partition)
 	if err != nil {
-		Errorf("Unexpected non-numeric partition value %s, ignoring: %v", partition, err)
+		ErrorfCtx(context.Background(), "Unexpected non-numeric partition value %s, ignoring: %v", partition, err)
 		return 0
 	}
 	return uint16(vbNo)

--- a/base/dcp_feed_type.go
+++ b/base/dcp_feed_type.go
@@ -145,14 +145,14 @@ func addCbgtAuthToDCPParams(dcpParams string) string {
 	}
 
 	if sgSourceParams.DbName == "" {
-		Infof(KeyImport, "Database name not specified in dcp params, feed credentials not added")
+		InfofCtx(context.Background(), KeyImport, "Database name not specified in dcp params, feed credentials not added")
 		return dcpParams
 	}
 
 	username, password, ok := getCbgtCredentials(sgSourceParams.DbName)
 	if !ok {
 		// no stored credentials includes the valid x.509 auth case
-		Infof(KeyImport, "No feed credentials stored for db from sourceParams: %s", MD(sgSourceParams.DbName))
+		InfofCtx(context.Background(), KeyImport, "No feed credentials stored for db from sourceParams: %s", MD(sgSourceParams.DbName))
 		return dcpParams
 	}
 

--- a/base/dcp_feed_type.go
+++ b/base/dcp_feed_type.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"context"
 	"sync"
 
 	"github.com/couchbase/cbgt"
@@ -139,7 +140,7 @@ func addCbgtAuthToDCPParams(dcpParams string) string {
 
 	unmarshalErr := JSONUnmarshal([]byte(dcpParams), &sgSourceParams)
 	if unmarshalErr != nil {
-		Warnf("Unable to unmarshal params provided by cbgt as sgSourceParams: %v", unmarshalErr)
+		WarnfCtx(context.Background(), "Unable to unmarshal params provided by cbgt as sgSourceParams: %v", unmarshalErr)
 		return dcpParams
 	}
 
@@ -158,7 +159,7 @@ func addCbgtAuthToDCPParams(dcpParams string) string {
 	var feedParamsWithAuth cbgt.DCPFeedParams
 	unmarshalDCPErr := JSONUnmarshal([]byte(dcpParams), &feedParamsWithAuth)
 	if unmarshalDCPErr != nil {
-		Warnf("Unable to unmarshal params provided by cbgt as dcpFeedParams: %v", unmarshalDCPErr)
+		WarnfCtx(context.Background(), "Unable to unmarshal params provided by cbgt as dcpFeedParams: %v", unmarshalDCPErr)
 	}
 
 	// Add creds to params
@@ -167,7 +168,7 @@ func addCbgtAuthToDCPParams(dcpParams string) string {
 
 	marshalledParamsWithAuth, marshalErr := JSONMarshal(feedParamsWithAuth)
 	if marshalErr != nil {
-		Warnf("Unable to marshal updated cbgt dcp params: %v", marshalErr)
+		WarnfCtx(context.Background(), "Unable to marshal updated cbgt dcp params: %v", marshalErr)
 		return dcpParams
 	}
 

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -328,7 +328,7 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 	if args.Terminator != nil {
 		go func() {
 			<-args.Terminator
-			Tracef(KeyDCP, "Closing DCP Feed [%s-%s] based on termination notification", MD(bucketName), feedID)
+			TracefCtx(loggingCtx, KeyDCP, "Closing DCP Feed [%s-%s] based on termination notification", MD(bucketName), feedID)
 			if err := bds.Close(); err != nil {
 				DebugfCtx(loggingCtx, KeyDCP, "Error closing DCP Feed [%s-%s] based on termination notification, Error: %v", MD(bucketName), feedID, err)
 			}

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -330,7 +330,7 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 			<-args.Terminator
 			Tracef(KeyDCP, "Closing DCP Feed [%s-%s] based on termination notification", MD(bucketName), feedID)
 			if err := bds.Close(); err != nil {
-				Debugf(KeyDCP, "Error closing DCP Feed [%s-%s] based on termination notification, Error: %v", MD(bucketName), feedID, err)
+				DebugfCtx(loggingCtx, KeyDCP, "Error closing DCP Feed [%s-%s] based on termination notification, Error: %v", MD(bucketName), feedID, err)
 			}
 			if args.DoneChan != nil {
 				close(args.DoneChan)

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -239,7 +239,7 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 
 	feedID := args.ID
 	if feedID == "" {
-		Infof(KeyDCP, "DCP feed started without feedID specified - defaulting to %s", DCPCachingFeedID)
+		InfofCtx(context.TODO(), KeyDCP, "DCP feed started without feedID specified - defaulting to %s", DCPCachingFeedID)
 		feedID = DCPCachingFeedID
 	}
 	receiver, loggingCtx := NewDCPReceiver(callback, bucket, maxVbno, persistCheckpoints, dbStats, feedID, args.CheckpointPrefix)
@@ -295,7 +295,7 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 	}
 
 	networkType := getNetworkTypeFromConnSpec(connSpec)
-	Infof(KeyDCP, "Using network type: %s", networkType)
+	InfofCtx(loggingCtx, KeyDCP, "Using network type: %s", networkType)
 
 	// default (aka internal) networking is handled by cbdatasource, so we can avoid the shims altogether in this case, for all other cases we need shims to remap hosts.
 	if networkType != clusterNetworkDefault {

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -478,16 +478,17 @@ func (l *importHeartbeatListener) StaleHeartbeatDetected(nodeUUID string) {
 // subscribeNodeChanges registers with the manager's cfg implementation for notifications on changes to the
 // NODE_DEFS_KNOWN key.  When notified, refreshes the handlers nodeIDs.
 func (l *importHeartbeatListener) subscribeNodeChanges() error {
+	logCtx := context.TODO()
 
 	cfgEvents := make(chan cbgt.CfgEvent)
 	err := l.cfg.Subscribe(cbgt.CfgNodeDefsKey(cbgt.NODE_DEFS_KNOWN), cfgEvents)
 	if err != nil {
-		Debugf(KeyCluster, "Error subscribing NODE_DEFS_KNOWN changes: %v", err)
+		DebugfCtx(logCtx, KeyCluster, "Error subscribing NODE_DEFS_KNOWN changes: %v", err)
 		return err
 	}
 	err = l.cfg.Subscribe(cbgt.CfgNodeDefsKey(cbgt.NODE_DEFS_WANTED), cfgEvents)
 	if err != nil {
-		Debugf(KeyCluster, "Error subscribing NODE_DEFS_WANTED changes: %v", err)
+		DebugfCtx(logCtx, KeyCluster, "Error subscribing NODE_DEFS_WANTED changes: %v", err)
 		return err
 	}
 	go func() {
@@ -497,12 +498,12 @@ func (l *importHeartbeatListener) subscribeNodeChanges() error {
 			case <-cfgEvents:
 				localNodeRegistered, err := l.reloadNodes()
 				if err != nil {
-					WarnfCtx(context.Background(), "Error while reloading heartbeat node definitions: %v", err)
+					WarnfCtx(logCtx, "Error while reloading heartbeat node definitions: %v", err)
 				}
 				if !localNodeRegistered {
 					registerErr := l.mgr.Register(cbgt.NODE_DEFS_WANTED)
 					if registerErr != nil {
-						WarnfCtx(context.Background(), "Error attempting to re-register node, node will not participate in import until restarted or cbgt cfg is next updated: %v", registerErr)
+						WarnfCtx(logCtx, "Error attempting to re-register node, node will not participate in import until restarted or cbgt cfg is next updated: %v", registerErr)
 					}
 				}
 

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -337,7 +337,7 @@ func (c *CbgtContext) StartManager(dbName string, configGroup string, bucket Buc
 	// TODO: Clarify the functional difference between registering the manager as 'wanted' vs 'known'.
 	registerType := cbgt.NODE_DEFS_WANTED
 	if err := c.Manager.Start(registerType); err != nil {
-		Errorf("cbgt Manager start failed: %v", err)
+		ErrorfCtx(c.loggingCtx, "cbgt Manager start failed: %v", err)
 		return err
 	}
 
@@ -349,7 +349,7 @@ func (c *CbgtContext) StartManager(dbName string, configGroup string, bucket Buc
 		} else if strings.Contains(err.Error(), "concurrent index definition update") {
 			Infof(KeyCluster, "Index update failed due to concurrent update, using existing")
 		} else {
-			Errorf("cbgt index creation failed: %v", err)
+			ErrorfCtx(c.loggingCtx, "cbgt index creation failed: %v", err)
 			return err
 		}
 	}

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -204,7 +204,7 @@ func dcpSafeIndexName(c *CbgtContext, dbName string) (safeIndexName, previousUUI
 	if legacyIndexUUID != "" {
 		deleteErr := c.Manager.DeleteIndexEx(legacyIndexName, "")
 		if deleteErr != nil {
-			Warnf("Error removing legacy import feed index: %v", deleteErr)
+			WarnfCtx(c.loggingCtx, "Error removing legacy import feed index: %v", deleteErr)
 		}
 	}
 	return indexName, indexUUID
@@ -471,7 +471,7 @@ func (l *importHeartbeatListener) StaleHeartbeatDetected(nodeUUID string) {
 	Infof(KeyCluster, "StaleHeartbeatDetected by import listener for node: %v", nodeUUID)
 	err := cbgt.UnregisterNodes(l.cfg, l.mgr.Version(), []string{nodeUUID})
 	if err != nil {
-		Warnf("Attempt to unregister %v from CBGT got error: %v", nodeUUID, err)
+		WarnfCtx(context.Background(), "Attempt to unregister %v from CBGT got error: %v", nodeUUID, err)
 	}
 }
 
@@ -497,12 +497,12 @@ func (l *importHeartbeatListener) subscribeNodeChanges() error {
 			case <-cfgEvents:
 				localNodeRegistered, err := l.reloadNodes()
 				if err != nil {
-					Warnf("Error while reloading heartbeat node definitions: %v", err)
+					WarnfCtx(context.Background(), "Error while reloading heartbeat node definitions: %v", err)
 				}
 				if !localNodeRegistered {
 					registerErr := l.mgr.Register(cbgt.NODE_DEFS_WANTED)
 					if registerErr != nil {
-						Warnf("Error attempting to re-register node, node will not participate in import until restarted or cbgt cfg is next updated: %v", registerErr)
+						WarnfCtx(context.Background(), "Error attempting to re-register node, node will not participate in import until restarted or cbgt cfg is next updated: %v", registerErr)
 					}
 				}
 
@@ -567,7 +567,7 @@ func StoreDestFactory(destKey string, dest CbgtDestFactoryFunc) {
 
 	// We don't expect duplicate destKey registration - log a warning if it already exists
 	if ok {
-		Warnf("destKey %s already exists in cbgtDestFactories - new value will replace the existing dest", destKey)
+		WarnfCtx(context.Background(), "destKey %s already exists in cbgtDestFactories - new value will replace the existing dest", destKey)
 	}
 	cbgtDestFactories[destKey] = dest
 	cbgtDestFactoriesLock.Unlock()

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -146,7 +146,7 @@ func createCBGTIndex(c *CbgtContext, dbName string, configGroupID string, bucket
 		}
 
 		networkType := getNetworkTypeFromConnSpec(connSpec)
-		Infof(KeyDCP, "Using network type: %s", networkType)
+		InfofCtx(c.loggingCtx, KeyDCP, "Using network type: %s", networkType)
 
 		// default (aka internal) networking is handled by cbdatasource, so we can avoid the shims altogether in this case, for all other cases we need shims to remap hosts.
 		if networkType != clusterNetworkDefault {
@@ -345,9 +345,9 @@ func (c *CbgtContext) StartManager(dbName string, configGroup string, bucket Buc
 	err = createCBGTIndex(c, dbName, configGroup, bucket, spec, numPartitions)
 	if err != nil {
 		if strings.Contains(err.Error(), "an index with the same name already exists") {
-			Infof(KeyCluster, "Duplicate cbgt index detected during index creation (concurrent creation), using existing")
+			InfofCtx(c.loggingCtx, KeyCluster, "Duplicate cbgt index detected during index creation (concurrent creation), using existing")
 		} else if strings.Contains(err.Error(), "concurrent index definition update") {
-			Infof(KeyCluster, "Index update failed due to concurrent update, using existing")
+			InfofCtx(c.loggingCtx, KeyCluster, "Index update failed due to concurrent update, using existing")
 		} else {
 			ErrorfCtx(c.loggingCtx, "cbgt index creation failed: %v", err)
 			return err
@@ -468,10 +468,10 @@ func (l *importHeartbeatListener) Name() string {
 // When we detect other nodes have stopped pushing heartbeats, use manager to remove from cfg
 func (l *importHeartbeatListener) StaleHeartbeatDetected(nodeUUID string) {
 
-	Infof(KeyCluster, "StaleHeartbeatDetected by import listener for node: %v", nodeUUID)
+	InfofCtx(context.TODO(), KeyCluster, "StaleHeartbeatDetected by import listener for node: %v", nodeUUID)
 	err := cbgt.UnregisterNodes(l.cfg, l.mgr.Version(), []string{nodeUUID})
 	if err != nil {
-		WarnfCtx(context.Background(), "Attempt to unregister %v from CBGT got error: %v", nodeUUID, err)
+		WarnfCtx(context.TODO(), "Attempt to unregister %v from CBGT got error: %v", nodeUUID, err)
 	}
 }
 

--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -148,7 +149,7 @@ func getRootCAs(caCertPath string) (*x509.CertPool, error) {
 	rootCAs, err := x509.SystemCertPool()
 	if err != nil {
 		rootCAs = x509.NewCertPool()
-		Warnf("Could not retrieve root CAs: %v", err)
+		WarnfCtx(context.Background(), "Could not retrieve root CAs: %v", err)
 	}
 	return rootCAs, nil
 }

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -134,7 +135,7 @@ func (h *couchbaseHeartBeater) Stop() {
 	for h.sendActive.IsTrue() || h.checkActive.IsTrue() {
 		waitTimeMs += 10
 		if waitTimeMs > maxWaitTimeMs {
-			Warnf("couchbaseHeartBeater didn't complete Stop() within expected elapsed time")
+			WarnfCtx(context.Background(), "couchbaseHeartBeater didn't complete Stop() within expected elapsed time")
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
@@ -161,7 +162,7 @@ func (h *couchbaseHeartBeater) StartSendingHeartbeats() error {
 				return
 			case <-ticker.C:
 				if err := h.sendHeartbeat(); err != nil {
-					Warnf("Unexpected error sending heartbeat - will be retried: %v", err)
+					WarnfCtx(context.Background(), "Unexpected error sending heartbeat - will be retried: %v", err)
 				}
 			}
 		}
@@ -174,7 +175,7 @@ func (h *couchbaseHeartBeater) StartSendingHeartbeats() error {
 func (h *couchbaseHeartBeater) StartCheckingHeartbeats() error {
 
 	if err := h.checkStaleHeartbeats(); err != nil {
-		Warnf("Error checking for stale heartbeats: %v", err)
+		WarnfCtx(context.Background(), "Error checking for stale heartbeats: %v", err)
 	}
 
 	ticker := time.NewTicker(h.heartbeatPollInterval)
@@ -188,7 +189,7 @@ func (h *couchbaseHeartBeater) StartCheckingHeartbeats() error {
 				return
 			case <-ticker.C:
 				if err := h.checkStaleHeartbeats(); err != nil {
-					Warnf("Error checking for stale heartbeats: %v", err)
+					WarnfCtx(context.Background(), "Error checking for stale heartbeats: %v", err)
 				}
 			}
 		}
@@ -252,7 +253,7 @@ func (h *couchbaseHeartBeater) getNodeListenerMap() ListenerMap {
 	for _, listener := range h.heartbeatListeners {
 		listenerNodes, err := listener.GetNodes()
 		if err != nil {
-			Warnf("Error obtaining node set for listener %s - will be omitted for this heartbeat iteration.  Error: %v", listener.Name(), err)
+			WarnfCtx(context.Background(), "Error obtaining node set for listener %s - will be omitted for this heartbeat iteration.  Error: %v", listener.Name(), err)
 		}
 		for _, nodeUUID := range listenerNodes {
 			_, ok := nodeToListenerMap[nodeUUID]

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -114,7 +114,7 @@ func (h *couchbaseHeartBeater) Start() error {
 		return err
 	}
 
-	Debugf(KeyCluster, "Sending node heartbeats at interval: %v", h.heartbeatSendInterval)
+	DebugfCtx(context.TODO(), KeyCluster, "Sending node heartbeats at interval: %v", h.heartbeatSendInterval)
 
 	return nil
 

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -446,7 +446,7 @@ func (dh *documentBackedListener) updateNodeList(nodeID string, remove bool) err
 			dh.nodeIDs = append(dh.nodeIDs, nodeID)
 		}
 
-		Infof(KeyCluster, "Updating nodeList document (%s) with node IDs: %v", dh.nodeListKey, dh.nodeIDs)
+		InfofCtx(context.TODO(), KeyCluster, "Updating nodeList document (%s) with node IDs: %v", dh.nodeListKey, dh.nodeIDs)
 
 		casOut, err := dh.bucket.WriteCas(dh.nodeListKey, 0, 0, dh.cas, dh.nodeIDs, 0)
 

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -271,7 +271,7 @@ func (h *couchbaseHeartBeater) checkStaleHeartbeats() error {
 
 	// Build set of all nodes
 	nodeListenerMap := h.getNodeListenerMap()
-	Tracef(KeyCluster, "Checking heartbeats for node set: %s", nodeListenerMap)
+	TracefCtx(context.Background(), KeyCluster, "Checking heartbeats for node set: %s", nodeListenerMap)
 
 	for heartbeatNodeUUID, listeners := range nodeListenerMap {
 		if heartbeatNodeUUID == h.nodeUUID {

--- a/base/http_listener.go
+++ b/base/http_listener.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"net"
@@ -45,7 +46,7 @@ func ListenAndServeHTTP(addr string, connLimit uint, certFile, keyFile string, h
 			protocolsEnabled = []string{"h2", "http/1.1"}
 		}
 		config.NextProtos = protocolsEnabled
-		Infof(KeyHTTP, "Protocols enabled: %v on %v", config.NextProtos, SD(addr))
+		InfofCtx(context.TODO(), KeyHTTP, "Protocols enabled: %v on %v", config.NextProtos, SD(addr))
 		config.Certificates = make([]tls.Certificate, 1)
 		var err error
 		config.Certificates[0], err = tls.LoadX509KeyPair(certFile, keyFile)

--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -206,14 +207,14 @@ func ToLogKey(keysStr []string) (logKeys LogKeyMask) {
 		// Strip a single "+" suffix in log keys and warn (for backwards compatibility)
 		if strings.HasSuffix(key, "+") {
 			newLogKey := strings.TrimSuffix(key, "+")
-			Warnf("Deprecated log key: %q found. Changing to: %q.", originalKey, newLogKey)
+			WarnfCtx(context.Background(), "Deprecated log key: %q found. Changing to: %q.", originalKey, newLogKey)
 			key = newLogKey
 		}
 
 		if logKey, ok := logKeyNamesInverse[key]; ok {
 			logKeys.Enable(logKey)
 		} else {
-			Warnf("Invalid log key: %v", originalKey)
+			WarnfCtx(context.Background(), "Invalid log key: %v", originalKey)
 		}
 	}
 

--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -199,5 +199,5 @@ func (l CBGoUtilsLogger) Severea(f func() string) { l.warnNotImplemented("Severe
 func (l CBGoUtilsLogger) Fatala(f func() string)  { l.warnNotImplemented("Fatala", f) }
 
 func (CBGoUtilsLogger) warnNotImplemented(name string, f func() string) {
-	Warnf(fmt.Sprintf("CBGoUtilsLogger: %s not implemented! %s", name, f()))
+	WarnfCtx(context.Background(), fmt.Sprintf("CBGoUtilsLogger: %s not implemented! %s", name, f()))
 }

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -209,7 +210,7 @@ func (lfc *FileLoggerConfig) init(level LogLevel, name string, logFilePath strin
 	go func() {
 		defer func() {
 			if panicked := recover(); panicked != nil {
-				Warnf("Panic when deleting rotated log files: \n %s", panicked, debug.Stack())
+				WarnfCtx(context.Background(), "Panic when deleting rotated log files: \n %s", panicked, debug.Stack())
 			}
 		}()
 		for {
@@ -217,7 +218,7 @@ func (lfc *FileLoggerConfig) init(level LogLevel, name string, logFilePath strin
 			case <-ticker.C:
 				err := runLogDeletion(logFilePath, level.String(), int(float64(*lfc.Rotation.RotatedLogsSizeLimit)*rotatedLogsLowWatermarkMultiplier), *lfc.Rotation.RotatedLogsSizeLimit)
 				if err != nil {
-					Warnf("%s", err)
+					WarnfCtx(context.Background(), "%s", err)
 				}
 			}
 		}

--- a/base/logging.go
+++ b/base/logging.go
@@ -44,7 +44,7 @@ func UpdateLogKeys(keys map[string]bool, replace bool) {
 		}
 	}
 
-	Infof(KeyAll, "Setting log keys to: %v", ConsoleLogKey().EnabledLogKeys())
+	InfofCtx(context.Background(), KeyAll, "Setting log keys to: %v", ConsoleLogKey().EnabledLogKeys())
 }
 
 // Returns a string identifying a function on the call stack.
@@ -91,7 +91,7 @@ var (
 
 // RotateLogfiles rotates all active log files.
 func RotateLogfiles() map[*FileLogger]error {
-	Infof(KeyAll, "Rotating log files...")
+	InfofCtx(context.Background(), KeyAll, "Rotating log files...")
 
 	loggers := map[*FileLogger]error{
 		traceLogger: nil,
@@ -194,9 +194,9 @@ func Fatalf(format string, args ...interface{}) {
 // }
 
 // Infof logs the given formatted string and args to the info log level and given log key.
-func Infof(logKey LogKey, format string, args ...interface{}) {
-	logTo(context.TODO(), LevelInfo, logKey, format, args...)
-}
+// func Infof(logKey LogKey, format string, args ...interface{}) {
+// 	logTo(context.TODO(), LevelInfo, logKey, format, args...)
+// }
 
 // Debugf logs the given formatted string and args to the debug log level with an optional log key.
 func Debugf(logKey LogKey, format string, args ...interface{}) {

--- a/base/logging.go
+++ b/base/logging.go
@@ -184,9 +184,9 @@ func Fatalf(format string, args ...interface{}) {
 }
 
 // Errorf logs the given formatted string and args to the error log level and given log key.
-func Errorf(format string, args ...interface{}) {
-	logTo(context.TODO(), LevelError, KeyAll, format, args...)
-}
+// func Errorf(format string, args ...interface{}) {
+// 	logTo(context.TODO(), LevelError, KeyAll, format, args...)
+// }
 
 // Warnf logs the given formatted string and args to the warn log level and given log key.
 func Warnf(format string, args ...interface{}) {

--- a/base/logging.go
+++ b/base/logging.go
@@ -199,9 +199,9 @@ func Fatalf(format string, args ...interface{}) {
 // }
 
 // Debugf logs the given formatted string and args to the debug log level with an optional log key.
-func Debugf(logKey LogKey, format string, args ...interface{}) {
-	logTo(context.TODO(), LevelDebug, logKey, format, args...)
-}
+// func Debugf(logKey LogKey, format string, args ...interface{}) {
+// 	logTo(context.TODO(), LevelDebug, logKey, format, args...)
+// }
 
 // Tracef logs the given formatted string and args to the trace log level with an optional log key.
 func Tracef(logKey LogKey, format string, args ...interface{}) {

--- a/base/logging.go
+++ b/base/logging.go
@@ -204,9 +204,9 @@ func Fatalf(format string, args ...interface{}) {
 // }
 
 // Tracef logs the given formatted string and args to the trace log level with an optional log key.
-func Tracef(logKey LogKey, format string, args ...interface{}) {
-	logTo(context.TODO(), LevelTrace, logKey, format, args...)
-}
+// func Tracef(logKey LogKey, format string, args ...interface{}) {
+// 	logTo(context.TODO(), LevelTrace, logKey, format, args...)
+// }
 
 // RecordStats writes the given stats JSON content to a stats log file, if enabled.
 // The content passed in is expected to be a JSON dictionary.

--- a/base/logging.go
+++ b/base/logging.go
@@ -282,7 +282,7 @@ func Consolef(logLevel LogLevel, logKey LogKey, format string, args ...interface
 
 	// If the above logTo didn't already log to stderr, do it directly here
 	if !consoleLogger.isStderr || !consoleLogger.shouldLog(logLevel, logKey) {
-		format = color(addPrefixes(format, nil, logLevel, logKey), logLevel)
+		format = color(addPrefixes(format, context.Background(), logLevel, logKey), logLevel)
 		_, _ = fmt.Fprintf(consoleFOutput, format+"\n", args...)
 	}
 }
@@ -295,7 +295,7 @@ func LogSyncGatewayVersion() {
 	Consolef(LevelNone, KeyNone, msg)
 
 	// Log the startup indicator to ALL log files too.
-	msg = addPrefixes(msg, nil, LevelNone, KeyNone)
+	msg = addPrefixes(msg, context.Background(), LevelNone, KeyNone)
 	if errorLogger.shouldLog(LevelNone) {
 		errorLogger.logger.Printf(msg)
 	}
@@ -333,8 +333,15 @@ func addPrefixes(format string, ctx context.Context, logLevel LogLevel, logKey L
 		logKeyPrefix = logKeyName + ": "
 	}
 
-	if ctx != nil {
-		if logCtx, ok := ctx.Value(LogContextKey{}).(LogContext); ok {
+	// if ctx != nil && ctx.Value(LogContextKey{}) != nil {
+	// 	if logCtx, ok := ctx.Value(LogContextKey{}).(LogContext); ok {
+	// 		format = logCtx.addContext(format)
+	// 	}
+	// }
+	if ctx == nil {
+		format = color("[CTX NIL] ", LevelWarn)
+	} else if ctxVal := ctx.Value(LogContextKey{}); ctxVal != nil {
+		if logCtx, ok := ctxVal.(LogContext); ok {
 			format = logCtx.addContext(format)
 		}
 	}

--- a/base/logging.go
+++ b/base/logging.go
@@ -124,6 +124,10 @@ func init() {
 
 // PanicfCtx logs the given formatted string and args to the error log level and given log key and then panics.
 func PanicfCtx(ctx context.Context, format string, args ...interface{}) {
+	// Fall back to stdlib's log.Panicf if SG loggers aren't set up.
+	if errorLogger == nil {
+		log.Panicf(format, args...)
+	}
 	logTo(ctx, LevelError, KeyAll, format, args...)
 	FlushLogBuffers()
 	panic(fmt.Sprintf(format, args...))
@@ -131,6 +135,10 @@ func PanicfCtx(ctx context.Context, format string, args ...interface{}) {
 
 // FatalfCtx logs the given formatted string and args to the error log level and given log key and then exits.
 func FatalfCtx(ctx context.Context, format string, args ...interface{}) {
+	// Fall back to stdlib's log.Panicf if SG loggers aren't set up.
+	if errorLogger == nil {
+		log.Fatalf(format, args...)
+	}
 	logTo(ctx, LevelError, KeyAll, format, args...)
 	FlushLogBuffers()
 	os.Exit(1)
@@ -162,26 +170,26 @@ func TracefCtx(ctx context.Context, logKey LogKey, format string, args ...interf
 }
 
 // Panicf logs the given formatted string and args to the error log level and given log key and then panics.
-func Panicf(format string, args ...interface{}) {
-	// Fall back to stdlib's log.Panicf if SG loggers aren't set up.
-	if errorLogger == nil {
-		log.Panicf(format, args...)
-	}
-	logTo(context.TODO(), LevelError, KeyAll, format, args...)
-	FlushLogBuffers()
-	panic(fmt.Sprintf(format, args...))
-}
+// func Panicf(format string, args ...interface{}) {
+// 	// Fall back to stdlib's log.Panicf if SG loggers aren't set up.
+// 	if errorLogger == nil {
+// 		log.Panicf(format, args...)
+// 	}
+// 	logTo(context.TODO(), LevelError, KeyAll, format, args...)
+// 	FlushLogBuffers()
+// 	panic(fmt.Sprintf(format, args...))
+// }
 
 // Fatalf logs the given formatted string and args to the error log level and given log key and then exits.
-func Fatalf(format string, args ...interface{}) {
-	// Fall back to stdlib's log.Fatalf if SG loggers aren't set up.
-	if errorLogger == nil {
-		log.Fatalf(format, args...)
-	}
-	logTo(context.TODO(), LevelError, KeyAll, format, args...)
-	FlushLogBuffers()
-	os.Exit(1)
-}
+// func Fatalf(format string, args ...interface{}) {
+// 	// Fall back to stdlib's log.Fatalf if SG loggers aren't set up.
+// 	if errorLogger == nil {
+// 		log.Fatalf(format, args...)
+// 	}
+// 	logTo(context.TODO(), LevelError, KeyAll, format, args...)
+// 	FlushLogBuffers()
+// 	os.Exit(1)
+// }
 
 // Errorf logs the given formatted string and args to the error log level and given log key.
 // func Errorf(format string, args ...interface{}) {

--- a/base/logging.go
+++ b/base/logging.go
@@ -169,53 +169,6 @@ func TracefCtx(ctx context.Context, logKey LogKey, format string, args ...interf
 	logTo(ctx, LevelTrace, logKey, format, args...)
 }
 
-// Panicf logs the given formatted string and args to the error log level and given log key and then panics.
-// func Panicf(format string, args ...interface{}) {
-// 	// Fall back to stdlib's log.Panicf if SG loggers aren't set up.
-// 	if errorLogger == nil {
-// 		log.Panicf(format, args...)
-// 	}
-// 	logTo(context.TODO(), LevelError, KeyAll, format, args...)
-// 	FlushLogBuffers()
-// 	panic(fmt.Sprintf(format, args...))
-// }
-
-// Fatalf logs the given formatted string and args to the error log level and given log key and then exits.
-// func Fatalf(format string, args ...interface{}) {
-// 	// Fall back to stdlib's log.Fatalf if SG loggers aren't set up.
-// 	if errorLogger == nil {
-// 		log.Fatalf(format, args...)
-// 	}
-// 	logTo(context.TODO(), LevelError, KeyAll, format, args...)
-// 	FlushLogBuffers()
-// 	os.Exit(1)
-// }
-
-// Errorf logs the given formatted string and args to the error log level and given log key.
-// func Errorf(format string, args ...interface{}) {
-// 	logTo(context.TODO(), LevelError, KeyAll, format, args...)
-// }
-
-// Warnf logs the given formatted string and args to the warn log level and given log key.
-// func Warnf(format string, args ...interface{}) {
-// 	logTo(context.TODO(), LevelWarn, KeyAll, format, args...)
-// }
-
-// Infof logs the given formatted string and args to the info log level and given log key.
-// func Infof(logKey LogKey, format string, args ...interface{}) {
-// 	logTo(context.TODO(), LevelInfo, logKey, format, args...)
-// }
-
-// Debugf logs the given formatted string and args to the debug log level with an optional log key.
-// func Debugf(logKey LogKey, format string, args ...interface{}) {
-// 	logTo(context.TODO(), LevelDebug, logKey, format, args...)
-// }
-
-// Tracef logs the given formatted string and args to the trace log level with an optional log key.
-// func Tracef(logKey LogKey, format string, args ...interface{}) {
-// 	logTo(context.TODO(), LevelTrace, logKey, format, args...)
-// }
-
 // RecordStats writes the given stats JSON content to a stats log file, if enabled.
 // The content passed in is expected to be a JSON dictionary.
 func RecordStats(statsJson string) {

--- a/base/logging.go
+++ b/base/logging.go
@@ -294,16 +294,11 @@ func addPrefixes(format string, ctx context.Context, logLevel LogLevel, logKey L
 		logKeyPrefix = logKeyName + ": "
 	}
 
-	// if ctx != nil && ctx.Value(LogContextKey{}) != nil {
-	// 	if logCtx, ok := ctx.Value(LogContextKey{}).(LogContext); ok {
-	// 		format = logCtx.addContext(format)
-	// 	}
-	// }
-	if ctx == nil {
-		format = color("[CTX NIL] ", LevelWarn)
-	} else if ctxVal := ctx.Value(LogContextKey{}); ctxVal != nil {
-		if logCtx, ok := ctxVal.(LogContext); ok {
-			format = logCtx.addContext(format)
+	if ctx != nil {
+		if ctxVal := ctx.Value(LogContextKey{}); ctxVal != nil {
+			if logCtx, ok := ctxVal.(LogContext); ok {
+				format = logCtx.addContext(format)
+			}
 		}
 	}
 

--- a/base/logging.go
+++ b/base/logging.go
@@ -189,9 +189,9 @@ func Fatalf(format string, args ...interface{}) {
 // }
 
 // Warnf logs the given formatted string and args to the warn log level and given log key.
-func Warnf(format string, args ...interface{}) {
-	logTo(context.TODO(), LevelWarn, KeyAll, format, args...)
-}
+// func Warnf(format string, args ...interface{}) {
+// 	logTo(context.TODO(), LevelWarn, KeyAll, format, args...)
+// }
 
 // Infof logs the given formatted string and args to the info log level and given log key.
 func Infof(logKey LogKey, format string, args ...interface{}) {

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -46,9 +46,9 @@ func TestRedactedLogFuncs(t *testing.T) {
 	defer func() { RedactUserData = false }()
 
 	RedactUserData = false
-	assertLogContains(t, "Username: alice", func() { Infof(KeyAll, "Username: %s", username) })
+	assertLogContains(t, "Username: alice", func() { InfofCtx(ctx, KeyAll, "Username: %s", username) })
 	RedactUserData = true
-	assertLogContains(t, "Username: <ud>alice</ud>", func() { Infof(KeyAll, "Username: %s", username) })
+	assertLogContains(t, "Username: <ud>alice</ud>", func() { InfofCtx(ctx, KeyAll, "Username: %s", username) })
 
 	RedactUserData = false
 	assertLogContains(t, "Username: alice", func() { WarnfCtx(ctx, "Username: %s", username) })
@@ -65,7 +65,7 @@ func Benchmark_LoggingPerformance(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		Debugf(KeyCRUD, "some crud'y message")
-		Infof(KeyCRUD, "some crud'y message")
+		InfofCtx(ctx, KeyCRUD, "some crud'y message")
 		WarnfCtx(ctx, "some crud'y message")
 		ErrorfCtx(ctx, "some crud'y message")
 	}

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -10,7 +10,6 @@ package base
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -42,6 +41,7 @@ func TestRedactedLogFuncs(t *testing.T) {
 	}
 
 	username := UD("alice")
+	ctx := TestCtx(t)
 
 	defer func() { RedactUserData = false }()
 
@@ -51,22 +51,23 @@ func TestRedactedLogFuncs(t *testing.T) {
 	assertLogContains(t, "Username: <ud>alice</ud>", func() { Infof(KeyAll, "Username: %s", username) })
 
 	RedactUserData = false
-	assertLogContains(t, "Username: alice", func() { WarnfCtx(context.Background(), "Username: %s", username) })
+	assertLogContains(t, "Username: alice", func() { WarnfCtx(ctx, "Username: %s", username) })
 	RedactUserData = true
-	assertLogContains(t, "Username: <ud>alice</ud>", func() { WarnfCtx(context.Background(), "Username: %s", username) })
+	assertLogContains(t, "Username: <ud>alice</ud>", func() { WarnfCtx(ctx, "Username: %s", username) })
 }
 
 func Benchmark_LoggingPerformance(b *testing.B) {
 
 	defer SetUpBenchmarkLogging(LevelInfo, KeyHTTP, KeyCRUD)()
 
+	ctx := TestCtx(b)
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
 		Debugf(KeyCRUD, "some crud'y message")
 		Infof(KeyCRUD, "some crud'y message")
-		WarnfCtx(context.Background(), "some crud'y message")
-		ErrorfCtx(context.Background(), "some crud'y message")
+		WarnfCtx(ctx, "some crud'y message")
+		ErrorfCtx(ctx, "some crud'y message")
 	}
 }
 

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -10,6 +10,7 @@ package base
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -65,7 +66,7 @@ func Benchmark_LoggingPerformance(b *testing.B) {
 		Debugf(KeyCRUD, "some crud'y message")
 		Infof(KeyCRUD, "some crud'y message")
 		Warnf("some crud'y message")
-		Errorf("some crud'y message")
+		ErrorfCtx(context.Background(), "some crud'y message")
 	}
 }
 

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -64,7 +64,7 @@ func Benchmark_LoggingPerformance(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		Debugf(KeyCRUD, "some crud'y message")
+		DebugfCtx(ctx, KeyCRUD, "some crud'y message")
 		InfofCtx(ctx, KeyCRUD, "some crud'y message")
 		WarnfCtx(ctx, "some crud'y message")
 		ErrorfCtx(ctx, "some crud'y message")

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -51,9 +51,9 @@ func TestRedactedLogFuncs(t *testing.T) {
 	assertLogContains(t, "Username: <ud>alice</ud>", func() { Infof(KeyAll, "Username: %s", username) })
 
 	RedactUserData = false
-	assertLogContains(t, "Username: alice", func() { Warnf("Username: %s", username) })
+	assertLogContains(t, "Username: alice", func() { WarnfCtx(context.Background(), "Username: %s", username) })
 	RedactUserData = true
-	assertLogContains(t, "Username: <ud>alice</ud>", func() { Warnf("Username: %s", username) })
+	assertLogContains(t, "Username: <ud>alice</ud>", func() { WarnfCtx(context.Background(), "Username: %s", username) })
 }
 
 func Benchmark_LoggingPerformance(b *testing.B) {
@@ -65,7 +65,7 @@ func Benchmark_LoggingPerformance(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Debugf(KeyCRUD, "some crud'y message")
 		Infof(KeyCRUD, "some crud'y message")
-		Warnf("some crud'y message")
+		WarnfCtx(context.Background(), "some crud'y message")
 		ErrorfCtx(context.Background(), "some crud'y message")
 	}
 }

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -104,7 +104,7 @@ func NewTestBucketPool(bucketReadierFunc TBPBucketReadierFunc, bucketInitFunc TB
 
 	_, err := SetMaxFileDescriptors(5000)
 	if err != nil {
-		Fatalf("couldn't set max file descriptors: %v", err)
+		FatalfCtx(context.TODO(), "couldn't set max file descriptors: %v", err)
 	}
 
 	numBuckets := tbpNumBuckets()
@@ -716,7 +716,7 @@ func tbpNumBuckets() int {
 		var err error
 		numBuckets, err = strconv.Atoi(envPoolSize)
 		if err != nil {
-			Fatalf("Couldn't parse %s: %v", tbpEnvPoolSize, err)
+			FatalfCtx(context.TODO(), "Couldn't parse %s: %v", tbpEnvPoolSize, err)
 		}
 	}
 	return numBuckets
@@ -729,7 +729,7 @@ func tbpBucketQuotaMB() int {
 		var err error
 		bucketQuota, err = strconv.Atoi(envBucketQuotaMB)
 		if err != nil {
-			Fatalf("Couldn't parse %s: %v", tbpEnvBucketQuotaMB, err)
+			FatalfCtx(context.TODO(), "Couldn't parse %s: %v", tbpEnvBucketQuotaMB, err)
 		}
 	}
 	return bucketQuota

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -57,12 +57,12 @@ func initV1Cluster(server string) *gocbv1.Cluster {
 
 	connStr, err := spec.GetGoCBConnString()
 	if err != nil {
-		Fatalf("error getting connection string: %v", err)
+		FatalfCtx(context.TODO(), "error getting connection string: %v", err)
 	}
 
 	cluster, err := gocbv1.Connect(connStr)
 	if err != nil {
-		Fatalf("Couldn't connect to %q: %v", server, err)
+		FatalfCtx(context.TODO(), "Couldn't connect to %q: %v", server, err)
 	}
 
 	err = cluster.Authenticate(gocbv1.PasswordAuthenticator{
@@ -70,7 +70,7 @@ func initV1Cluster(server string) *gocbv1.Cluster {
 		Password: TestClusterPassword(),
 	})
 	if err != nil {
-		Fatalf("Couldn't authenticate with %q: %v", server, err)
+		FatalfCtx(context.TODO(), "Couldn't authenticate with %q: %v", server, err)
 	}
 
 	return cluster
@@ -172,17 +172,17 @@ func getCluster(server string) *gocb.Cluster {
 
 	connStr, err := spec.GetGoCBConnString()
 	if err != nil {
-		Fatalf("error getting connection string: %v", err)
+		FatalfCtx(context.TODO(), "error getting connection string: %v", err)
 	}
 
 	securityConfig, err := GoCBv2SecurityConfig(&spec.TLSSkipVerify, spec.CACertPath)
 	if err != nil {
-		Fatalf("Couldn't initialize cluster security config: %v", err)
+		FatalfCtx(context.TODO(), "Couldn't initialize cluster security config: %v", err)
 	}
 
 	authenticatorConfig, authErr := GoCBv2Authenticator(TestClusterUsername(), TestClusterPassword(), spec.Certpath, spec.Keypath)
 	if authErr != nil {
-		Fatalf("Couldn't initialize cluster authenticator config: %v", authErr)
+		FatalfCtx(context.TODO(), "Couldn't initialize cluster authenticator config: %v", authErr)
 	}
 
 	timeoutsConfig := GoCBv2TimeoutsConfig(spec.BucketOpTimeout, StdlibDurationPtr(spec.GetViewQueryTimeout()))
@@ -195,11 +195,11 @@ func getCluster(server string) *gocb.Cluster {
 
 	cluster, err := gocb.Connect(connStr, clusterOptions)
 	if err != nil {
-		Fatalf("Couldn't connect to %q: %v", server, err)
+		FatalfCtx(context.TODO(), "Couldn't connect to %q: %v", server, err)
 	}
 	err = cluster.WaitUntilReady(15*time.Second, nil)
 	if err != nil {
-		Fatalf("Cluster not ready: %v", err)
+		FatalfCtx(context.TODO(), "Cluster not ready: %v", err)
 	}
 
 	return cluster

--- a/base/redactor_userdata_test.go
+++ b/base/redactor_userdata_test.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"math/big"
 	"testing"
 	"time"
@@ -102,35 +103,35 @@ func BenchmarkRedactOnLog(b *testing.B) {
 
 	b.Run("WarnPlain", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			Warnf("Log: %s", "Fixed String")
+			WarnfCtx(context.Background(), "Log: %s", "Fixed String")
 		}
 	})
 
 	b.Run("WarnRedactTrueNotUD", func(b *testing.B) {
 		RedactUserData = true
 		for i := 0; i < b.N; i++ {
-			Warnf("Log: %s", FakeLogger{})
+			WarnfCtx(context.Background(), "Log: %s", FakeLogger{})
 		}
 	})
 
 	b.Run("WarnRedactTrueUD", func(b *testing.B) {
 		RedactUserData = true
 		for i := 0; i < b.N; i++ {
-			Warnf("Log: %s", UD(FakeLogger{}))
+			WarnfCtx(context.Background(), "Log: %s", UD(FakeLogger{}))
 		}
 	})
 
 	b.Run("WarnRedactFalseNotUD", func(b *testing.B) {
 		RedactUserData = false
 		for i := 0; i < b.N; i++ {
-			Warnf("Log: %s", FakeLogger{})
+			WarnfCtx(context.Background(), "Log: %s", FakeLogger{})
 		}
 	})
 
 	b.Run("WarnRedactFalseUD", func(b *testing.B) {
 		RedactUserData = false
 		for i := 0; i < b.N; i++ {
-			Warnf("Log: %s", UD(FakeLogger{}))
+			WarnfCtx(context.Background(), "Log: %s", UD(FakeLogger{}))
 		}
 	})
 

--- a/base/redactor_userdata_test.go
+++ b/base/redactor_userdata_test.go
@@ -140,36 +140,41 @@ func BenchmarkRedactOnLog(b *testing.B) {
 	})
 
 	b.Run("DebugPlain", func(b *testing.B) {
+		ctx := TestCtx(b)
 		for i := 0; i < b.N; i++ {
-			Debugf(KeyAll, "Log: %s", "Fixed String")
+			DebugfCtx(ctx, KeyAll, "Log: %s", "Fixed String")
 		}
 	})
 
 	b.Run("DebugRedactTrueNotUD", func(b *testing.B) {
+		ctx := TestCtx(b)
 		RedactUserData = true
 		for i := 0; i < b.N; i++ {
-			Debugf(KeyAll, "Log: %s", FakeLogger{})
+			DebugfCtx(ctx, KeyAll, "Log: %s", FakeLogger{})
 		}
 	})
 
 	b.Run("DebugRedactTrueUD", func(b *testing.B) {
+		ctx := TestCtx(b)
 		RedactUserData = true
 		for i := 0; i < b.N; i++ {
-			Debugf(KeyAll, "Log: %s", UD(FakeLogger{}))
+			DebugfCtx(ctx, KeyAll, "Log: %s", UD(FakeLogger{}))
 		}
 	})
 
 	b.Run("DebugRedactFalseNotUD", func(b *testing.B) {
+		ctx := TestCtx(b)
 		RedactUserData = false
 		for i := 0; i < b.N; i++ {
-			Debugf(KeyAll, "Log: %s", FakeLogger{})
+			DebugfCtx(ctx, KeyAll, "Log: %s", FakeLogger{})
 		}
 	})
 
 	b.Run("DebugRedactFalseUD", func(b *testing.B) {
+		ctx := TestCtx(b)
 		RedactUserData = false
 		for i := 0; i < b.N; i++ {
-			Debugf(KeyAll, "Log: %s", UD(FakeLogger{}))
+			DebugfCtx(ctx, KeyAll, "Log: %s", UD(FakeLogger{}))
 		}
 	})
 }

--- a/base/redactor_userdata_test.go
+++ b/base/redactor_userdata_test.go
@@ -11,7 +11,6 @@ licenses/APL2.txt.
 package base
 
 import (
-	"context"
 	"math/big"
 	"testing"
 	"time"
@@ -102,36 +101,41 @@ func BenchmarkRedactOnLog(b *testing.B) {
 	defer SetUpBenchmarkLogging(LevelWarn, KeyAll)()
 
 	b.Run("WarnPlain", func(b *testing.B) {
+		ctx := TestCtx(b)
 		for i := 0; i < b.N; i++ {
-			WarnfCtx(context.Background(), "Log: %s", "Fixed String")
+			WarnfCtx(ctx, "Log: %s", "Fixed String")
 		}
 	})
 
 	b.Run("WarnRedactTrueNotUD", func(b *testing.B) {
+		ctx := TestCtx(b)
 		RedactUserData = true
 		for i := 0; i < b.N; i++ {
-			WarnfCtx(context.Background(), "Log: %s", FakeLogger{})
+			WarnfCtx(ctx, "Log: %s", FakeLogger{})
 		}
 	})
 
 	b.Run("WarnRedactTrueUD", func(b *testing.B) {
+		ctx := TestCtx(b)
 		RedactUserData = true
 		for i := 0; i < b.N; i++ {
-			WarnfCtx(context.Background(), "Log: %s", UD(FakeLogger{}))
+			WarnfCtx(ctx, "Log: %s", UD(FakeLogger{}))
 		}
 	})
 
 	b.Run("WarnRedactFalseNotUD", func(b *testing.B) {
+		ctx := TestCtx(b)
 		RedactUserData = false
 		for i := 0; i < b.N; i++ {
-			WarnfCtx(context.Background(), "Log: %s", FakeLogger{})
+			WarnfCtx(ctx, "Log: %s", FakeLogger{})
 		}
 	})
 
 	b.Run("WarnRedactFalseUD", func(b *testing.B) {
+		ctx := TestCtx(b)
 		RedactUserData = false
 		for i := 0; i < b.N; i++ {
-			WarnfCtx(context.Background(), "Log: %s", UD(FakeLogger{}))
+			WarnfCtx(ctx, "Log: %s", UD(FakeLogger{}))
 		}
 	})
 

--- a/base/rlimit.go
+++ b/base/rlimit.go
@@ -13,7 +13,10 @@ licenses/APL2.txt.
 
 package base
 
-import "syscall"
+import (
+	"context"
+	"syscall"
+)
 
 // Set Max File Descriptor limits
 //
@@ -49,7 +52,7 @@ func SetMaxFileDescriptors(requestedSoftFDLimit uint64) (uint64, error) {
 	err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limits)
 
 	if err == nil {
-		Infof(KeyAll, "Configured process to allow %d open file descriptors", recommendedSoftFDLimit)
+		InfofCtx(context.Background(), KeyAll, "Configured process to allow %d open file descriptors", recommendedSoftFDLimit)
 	}
 
 	return recommendedSoftFDLimit, err
@@ -88,7 +91,7 @@ func getSoftFDLimit(requestedSoftFDLimit uint64, limit syscall.Rlimit) (requires
 	// Is the user requesting something higher than the existing hard limit?
 	if requestedSoftFDLimit >= currentHardFdLimit {
 		// yes, so just use the hard limit
-		Infof(KeyAll, "requestedSoftFDLimit >= currentHardFdLimit (%v >= %v) capping at %v", requestedSoftFDLimit, currentHardFdLimit, currentHardFdLimit)
+		InfofCtx(context.Background(), KeyAll, "requestedSoftFDLimit >= currentHardFdLimit (%v >= %v) capping at %v", requestedSoftFDLimit, currentHardFdLimit, currentHardFdLimit)
 		return true, currentHardFdLimit
 	}
 

--- a/base/rlimit.go
+++ b/base/rlimit.go
@@ -84,7 +84,7 @@ func getSoftFDLimit(requestedSoftFDLimit uint64, limit syscall.Rlimit) (requires
 	// Is the user requesting something that is less than the existing soft limit?
 	if requestedSoftFDLimit <= currentSoftFdLimit {
 		// yep, and there is no point in doing so, so return false for requiresUpdate.
-		Debugf(KeyAll, "requestedSoftFDLimit < currentSoftFdLimit (%v <= %v) no action needed", requestedSoftFDLimit, currentSoftFdLimit)
+		DebugfCtx(context.Background(), KeyAll, "requestedSoftFDLimit < currentSoftFdLimit (%v <= %v) no action needed", requestedSoftFDLimit, currentSoftFdLimit)
 		return false, currentSoftFdLimit
 	}
 

--- a/base/stats.go
+++ b/base/stats.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"expvar"
 	"math"
 	"strconv"
@@ -105,7 +106,7 @@ func (s *SgwStats) String() string {
 	bytes, err := JSONMarshalCanonical(s)
 	s.dbStatsMapMutex.Unlock()
 	if err != nil {
-		Errorf("Unable to Marshal SgwStats: %v", err)
+		ErrorfCtx(context.Background(), "Unable to Marshal SgwStats: %v", err)
 		return "null"
 	}
 	return string(bytes)

--- a/base/util.go
+++ b/base/util.go
@@ -1473,7 +1473,7 @@ type JSONEncoderI interface {
 func FatalPanicHandler() {
 	// Log any panics using the built-in loggers so that the stacktraces end up in SG log files before exiting.
 	if r := recover(); r != nil {
-		Fatalf("Unexpected panic: %v - stopping process\n%v", r, string(debug.Stack()))
+		FatalfCtx(context.TODO(), "Unexpected panic: %v - stopping process\n%v", r, string(debug.Stack()))
 	}
 }
 

--- a/base/util.go
+++ b/base/util.go
@@ -441,7 +441,7 @@ func RetryLoopCtx(description string, worker RetryWorker, sleeper RetrySleeper, 
 			WarnfCtx(ctx, "RetryLoop for %v giving up after %v attempts", description, numAttempts)
 			return err, value
 		}
-		Debugf(KeyAll, "RetryLoop retrying %v after %v ms.", description, sleepMs)
+		DebugfCtx(ctx, KeyAll, "RetryLoop retrying %v after %v ms.", description, sleepMs)
 
 		select {
 		case <-ctx.Done():
@@ -476,7 +476,7 @@ func RetryLoopCas(description string, worker RetryCasWorker, sleeper RetrySleepe
 			WarnfCtx(context.Background(), "RetryLoopCas for %v giving up after %v attempts", description, numAttempts)
 			return err, value
 		}
-		Debugf(KeyAll, "RetryLoopCas retrying %v after %v ms.", description, sleepMs)
+		DebugfCtx(context.Background(), KeyAll, "RetryLoopCas retrying %v after %v ms.", description, sleepMs)
 
 		<-time.After(time.Millisecond * time.Duration(sleepMs))
 

--- a/base/util.go
+++ b/base/util.go
@@ -51,7 +51,7 @@ const (
 func RedactBasicAuthURLUserAndPassword(urlIn string) string {
 	redactedUrl, err := RedactBasicAuthURL(urlIn, false)
 	if err != nil {
-		Warnf("%v", err)
+		WarnfCtx(context.Background(), "%v", err)
 		return ""
 	}
 	return redactedUrl
@@ -61,7 +61,7 @@ func RedactBasicAuthURLUserAndPassword(urlIn string) string {
 func RedactBasicAuthURLPassword(urlIn string) string {
 	redactedUrl, err := RedactBasicAuthURL(urlIn, true)
 	if err != nil {
-		Warnf("%v", err)
+		WarnfCtx(context.Background(), "%v", err)
 		return ""
 	}
 	return redactedUrl
@@ -438,7 +438,7 @@ func RetryLoopCtx(description string, worker RetryWorker, sleeper RetrySleeper, 
 			if err == nil {
 				err = NewRetryTimeoutError(description, numAttempts)
 			}
-			Warnf("RetryLoop for %v giving up after %v attempts", description, numAttempts)
+			WarnfCtx(ctx, "RetryLoop for %v giving up after %v attempts", description, numAttempts)
 			return err, value
 		}
 		Debugf(KeyAll, "RetryLoop retrying %v after %v ms.", description, sleepMs)
@@ -473,7 +473,7 @@ func RetryLoopCas(description string, worker RetryCasWorker, sleeper RetrySleepe
 			if err == nil {
 				err = NewRetryTimeoutError(description, numAttempts)
 			}
-			Warnf("RetryLoopCas for %v giving up after %v attempts", description, numAttempts)
+			WarnfCtx(context.Background(), "RetryLoopCas for %v giving up after %v attempts", description, numAttempts)
 			return err, value
 		}
 		Debugf(KeyAll, "RetryLoopCas retrying %v after %v ms.", description, sleepMs)
@@ -1153,7 +1153,7 @@ func ExpvarVar2Int(expvarVar expvar.Var) int64 {
 	}
 	asInt, ok := expvarVar.(*expvar.Int)
 	if !ok {
-		Warnf("ExpvarVar2Int could not convert %v to *expvar.Int", expvarVar)
+		WarnfCtx(context.Background(), "ExpvarVar2Int could not convert %v to *expvar.Int", expvarVar)
 		return 0
 	}
 	return asInt.Value()

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -480,7 +480,7 @@ func SetUpGlobalTestLogging(m *testing.M) (teardownFn func()) {
 //     defer SetUpTestLogging(LevelDebug, KeyCache,KeyDCP,KeySync)()
 func SetUpTestLogging(logLevel LogLevel, logKeys ...LogKey) (teardownFn func()) {
 	caller := GetCallersName(1, false)
-	Infof(KeyAll, "%s: Setup logging: level: %v - keys: %v", caller, logLevel, logKeys)
+	InfofCtx(context.Background(), KeyAll, "%s: Setup logging: level: %v - keys: %v", caller, logLevel, logKeys)
 	return setTestLogging(logLevel, caller, logKeys...)
 }
 
@@ -514,7 +514,7 @@ func setTestLogging(logLevel LogLevel, caller string, logKeys ...LogKey) (teardo
 		// noop, test log level is already set globally
 		return func() {
 			if caller != "" {
-				Infof(KeyAll, "%v: Reset logging", caller)
+				InfofCtx(context.Background(), KeyAll, "%v: Reset logging", caller)
 			}
 		}
 	}
@@ -536,7 +536,7 @@ func setTestLogging(logLevel LogLevel, caller string, logKeys ...LogKey) (teardo
 		consoleLogger.LogLevel.Set(initialLogLevel)
 		consoleLogger.LogKeyMask.Set(initialLogKey)
 		if caller != "" {
-			Infof(KeyAll, "%v: Reset logging", caller)
+			InfofCtx(context.Background(), KeyAll, "%v: Reset logging", caller)
 		}
 	}
 }

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -451,7 +451,7 @@ func SetUpGlobalTestLogging(m *testing.M) (teardownFn func()) {
 		var l LogLevel
 		err := l.UnmarshalText([]byte(logLevel))
 		if err != nil {
-			Fatalf("TEST: Invalid log level used for %q: %s", TestEnvGlobalLogLevel, err)
+			FatalfCtx(context.TODO(), "TEST: Invalid log level used for %q: %s", TestEnvGlobalLogLevel, err)
 		}
 		teardown := SetUpTestLogging(l, KeyAll)
 		GlobalTestLoggingSet.Set(true)

--- a/channels/active_channels.go
+++ b/channels/active_channels.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package channels
 
 import (
+	"context"
 	"sync"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -98,7 +99,7 @@ func (ac *ActiveChannels) _incr(channelName string) {
 func (ac *ActiveChannels) _decr(channelName string) {
 	current, ok := ac.channelCounts[channelName]
 	if !ok {
-		base.Warnf("Attempt made to decrement inactive channel %s - will be ignored", base.UD(channelName))
+		base.WarnfCtx(context.Background(), "Attempt made to decrement inactive channel %s - will be ignored", base.UD(channelName))
 		return
 	}
 	if current <= 1 {

--- a/channels/sync_runner.go
+++ b/channels/sync_runner.go
@@ -176,7 +176,7 @@ func NewSyncRunner(funcSource string) (*SyncRunner, error) {
 
 			expiry, reflectErr := base.ReflectExpiry(rawExpiry)
 			if reflectErr != nil {
-				base.Warnf("SyncRunner: Invalid value passed to expiry().  Value:%+v ", call.Argument(0))
+				base.WarnfCtx(ctx, "SyncRunner: Invalid value passed to expiry().  Value:%+v ", call.Argument(0))
 				return otto.UndefinedValue()
 			}
 
@@ -264,7 +264,7 @@ func ottoValueToStringArray(value otto.Value) []string {
 	result, nonStrings := base.ValueToStringArray(nativeValue)
 
 	if !value.IsNull() && !value.IsUndefined() && nonStrings != nil {
-		base.Warnf("Channel names must be string values only. Ignoring non-string channels: %s", base.UD(nonStrings))
+		base.WarnfCtx(context.Background(), "Channel names must be string values only. Ignoring non-string channels: %s", base.UD(nonStrings))
 	}
 	return result
 }

--- a/channels/sync_runner.go
+++ b/channels/sync_runner.go
@@ -9,6 +9,7 @@
 package channels
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -115,11 +116,12 @@ type SyncRunner struct {
 }
 
 func NewSyncRunner(funcSource string) (*SyncRunner, error) {
+	ctx := context.Background()
 	funcSource = wrappedFuncSource(funcSource)
 	runner := &SyncRunner{}
 	err := runner.InitWithLogging(funcSource,
-		func(s string) { base.Errorf(base.KeyJavascript.String()+": Sync %s", base.UD(s)) },
-		func(s string) { base.Infof(base.KeyJavascript, "Sync %s", base.UD(s)) })
+		func(s string) { base.ErrorfCtx(ctx, base.KeyJavascript.String()+": Sync %s", base.UD(s)) },
+		func(s string) { base.InfofCtx(ctx, base.KeyJavascript, "Sync %s", base.UD(s)) })
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +165,7 @@ func NewSyncRunner(funcSource string) (*SyncRunner, error) {
 		if len(call.ArgumentList) > 0 {
 			rawExpiry, exportErr := call.Argument(0).Export()
 			if exportErr != nil {
-				base.Warnf("SyncRunner: Unable to export expiry parameter: %v Error: %s", call.Argument(0), exportErr)
+				base.WarnfCtx(ctx, "SyncRunner: Unable to export expiry parameter: %v Error: %s", call.Argument(0), exportErr)
 				return otto.UndefinedValue()
 			}
 

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -311,7 +311,7 @@ func combinedState(state1, state2 string) (combinedState string) {
 		return ReplicationStateReconnecting
 	}
 
-	base.Infof(base.KeyReplicate, "Unhandled combination of replication states (%s, %s), returning %s", state1, state2, state1)
+	base.InfofCtx(context.Background(), base.KeyReplicate, "Unhandled combination of replication states (%s, %s), returning %s", state1, state2, state1)
 	return state1
 }
 

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -668,7 +668,7 @@ func getLocalCheckpoint(db *DatabaseContext, clientID string) (*replicationCheck
 		if !base.IsKeyNotFoundError(db.Bucket, err) {
 			return nil, err
 		}
-		base.Debugf(base.KeyReplicate, "couldn't find existing local checkpoint for ID %q", clientID)
+		base.DebugfCtx(context.TODO(), base.KeyReplicate, "couldn't find existing local checkpoint for ID %q", clientID)
 		return nil, nil
 	}
 	var checkpoint *replicationCheckpoint

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -647,7 +647,7 @@ func (c *Checkpointer) setLocalCheckpointStatus(status string, errorMessage stri
 
 	checkpoint.Status.Status = status
 	checkpoint.Status.ErrorMessage = errorMessage
-	base.Tracef(base.KeyReplicate, "setLocalCheckpoint(%v)", checkpoint)
+	base.TracefCtx(c.ctx, base.KeyReplicate, "setLocalCheckpoint(%v)", checkpoint)
 	newRev, setErr := c.setLocalCheckpoint(checkpoint)
 	if setErr != nil {
 		base.WarnfCtx(c.ctx, "Unable to persist status in local checkpoint for %s, status not updated: %v", c.clientID, setErr)
@@ -661,7 +661,7 @@ func (c *Checkpointer) setLocalCheckpointStatus(status string, errorMessage stri
 }
 
 func getLocalCheckpoint(db *DatabaseContext, clientID string) (*replicationCheckpoint, error) {
-	base.Tracef(base.KeyReplicate, "getLocalCheckpoint for %s", clientID)
+	base.TracefCtx(context.TODO(), base.KeyReplicate, "getLocalCheckpoint for %s", clientID)
 
 	checkpointBytes, err := db.GetSpecialBytes(DocTypeLocal, checkpointDocIDPrefix+clientID)
 	if err != nil {
@@ -696,12 +696,12 @@ func setLocalCheckpointStatus(db *Database, clientID string, status string, erro
 
 	checkpoint.Status.Status = status
 	checkpoint.Status.ErrorMessage = errorMessage
-	base.Tracef(base.KeyReplicate, "setLocalCheckpoint(%v)", checkpoint)
+	base.TracefCtx(db.Ctx, base.KeyReplicate, "setLocalCheckpoint(%v)", checkpoint)
 	newRev, putErr := db.putSpecial(DocTypeLocal, checkpointDocIDPrefix+clientID, checkpoint.Rev, checkpoint.AsBody())
 	if putErr != nil {
 		base.WarnfCtx(db.Ctx, "Unable to persist status in local checkpoint for %s, status not updated: %v", clientID, putErr)
 	} else {
-		base.Tracef(base.KeyReplicate, "setLocalCheckpointStatus successful for %s, newRev: %s: %+v %+v", clientID, newRev, checkpoint, checkpoint.Status)
+		base.TracefCtx(db.Ctx, base.KeyReplicate, "setLocalCheckpointStatus successful for %s, newRev: %s: %+v %+v", clientID, newRev, checkpoint, checkpoint.Status)
 	}
 	return
 }

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -219,7 +219,7 @@ func (c *Checkpointer) CheckpointNow() {
 	base.InfofCtx(c.ctx, base.KeyReplicate, "checkpointer: calculated seq: %v", seq)
 	err := c._setCheckpoints(seq, status)
 	if err != nil {
-		base.Warnf("couldn't set checkpoints: %v", err)
+		base.WarnfCtx(c.ctx, "couldn't set checkpoints: %v", err)
 	}
 }
 
@@ -683,7 +683,7 @@ func setLocalCheckpointStatus(db *Database, clientID string, status string, erro
 	// getCheckpoint to obtain the current rev
 	checkpoint, err := getLocalCheckpoint(db.DatabaseContext, clientID)
 	if err != nil {
-		base.Warnf("Unable to retrieve local checkpoint for %s, status not updated", clientID)
+		base.WarnfCtx(db.Ctx, "Unable to retrieve local checkpoint for %s, status not updated", clientID)
 		return
 	}
 	if checkpoint == nil {
@@ -699,7 +699,7 @@ func setLocalCheckpointStatus(db *Database, clientID string, status string, erro
 	base.Tracef(base.KeyReplicate, "setLocalCheckpoint(%v)", checkpoint)
 	newRev, putErr := db.putSpecial(DocTypeLocal, checkpointDocIDPrefix+clientID, checkpoint.Rev, checkpoint.AsBody())
 	if putErr != nil {
-		base.Warnf("Unable to persist status in local checkpoint for %s, status not updated: %v", clientID, putErr)
+		base.WarnfCtx(db.Ctx, "Unable to persist status in local checkpoint for %s, status not updated: %v", clientID, putErr)
 	} else {
 		base.Tracef(base.KeyReplicate, "setLocalCheckpointStatus successful for %s, newRev: %s: %+v %+v", clientID, newRev, checkpoint, checkpoint.Status)
 	}

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -107,12 +107,12 @@ func (apr *ActivePushReplicator) _connect() error {
 			_ = apr.setError(PreHydrogenTargetAllowConflictsError)
 			err = apr.stopAndDisconnect()
 			if err != nil {
-				base.Errorf("Failed to stop and disconnect replication: %v", err)
+				base.ErrorfCtx(apr.ctx, "Failed to stop and disconnect replication: %v", err)
 			}
 		} else if strings.Contains(err.Error(), ErrDatabaseWentAway.Message) {
 			err = apr.reconnect()
 			if err != nil {
-				base.Errorf("Failed to reconnect replication: %v", err)
+				base.ErrorfCtx(apr.ctx, "Failed to reconnect replication: %v", err)
 			}
 		}
 		// No special handling for error

--- a/db/attachment.go
+++ b/db/attachment.go
@@ -9,6 +9,7 @@
 package db
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha1"
 	"crypto/sha256"
@@ -317,7 +318,7 @@ func GenerateProofOfAttachment(attachmentData []byte) (nonce []byte, proof strin
 		return nil, "", base.HTTPErrorf(http.StatusInternalServerError, fmt.Sprintf("Failed to generate random data: %s", err))
 	}
 	proof = ProveAttachment(attachmentData, nonce)
-	base.Tracef(base.KeyCRUD, "Generated nonce %v and proof %q for attachment: %v", nonce, proof, attachmentData)
+	base.TracefCtx(context.Background(), base.KeyCRUD, "Generated nonce %v and proof %q for attachment: %v", nonce, proof, attachmentData)
 	return nonce, proof, nil
 }
 
@@ -328,7 +329,7 @@ func ProveAttachment(attachmentData, nonce []byte) (proof string) {
 	d.Write(nonce)
 	d.Write(attachmentData)
 	proof = "sha1-" + base64.StdEncoding.EncodeToString(d.Sum(nil))
-	base.Tracef(base.KeyCRUD, "Generated proof %q using nonce %v for attachment: %v", proof, nonce, attachmentData)
+	base.TracefCtx(context.Background(), base.KeyCRUD, "Generated proof %q using nonce %v for attachment: %v", proof, nonce, attachmentData)
 	return proof
 }
 

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -98,6 +98,7 @@ func (b *BackgroundManager) Start(options map[string]interface{}) error {
 		return err
 	}
 
+	logCtx := context.TODO()
 	var processClusterStatus []byte
 	if b.isClusterAware() {
 		processClusterStatus, _, err = b.clusterAwareOptions.bucket.GetRaw(b.clusterAwareOptions.StatusDocID())
@@ -122,7 +123,7 @@ func (b *BackgroundManager) Start(options map[string]interface{}) error {
 				case <-ticker.C:
 					err = b.UpdateStatusClusterAware()
 					if err != nil {
-						base.WarnfCtx(context.TODO(), "Failed to update background manager status: %v", err)
+						base.WarnfCtx(logCtx, "Failed to update background manager status: %v", err)
 					}
 
 				case <-b.terminator.Done():
@@ -139,7 +140,7 @@ func (b *BackgroundManager) Start(options map[string]interface{}) error {
 		}
 		err := b.Process.Run(options, updateStatusClusterAwareCallback, b.terminator)
 		if err != nil {
-			base.ErrorfCtx(context.TODO(), "Error: %v", err)
+			base.ErrorfCtx(logCtx, "Error: %v", err)
 			b.SetError(err)
 		}
 
@@ -158,7 +159,7 @@ func (b *BackgroundManager) Start(options map[string]interface{}) error {
 		if b.isClusterAware() {
 			err = b.UpdateStatusClusterAware()
 			if err != nil {
-				base.WarnfCtx(context.TODO(), "Failed to update background manager status: %v", err)
+				base.WarnfCtx(logCtx, "Failed to update background manager status: %v", err)
 			}
 
 			// Delete the heartbeat doc to allow another process to run
@@ -170,7 +171,7 @@ func (b *BackgroundManager) Start(options map[string]interface{}) error {
 	if b.isClusterAware() {
 		err = b.UpdateStatusClusterAware()
 		if err != nil {
-			base.ErrorfCtx(context.TODO(), "Failed to update background manager status: %v", err)
+			base.ErrorfCtx(logCtx, "Failed to update background manager status: %v", err)
 		}
 	}
 

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -122,7 +122,7 @@ func (b *BackgroundManager) Start(options map[string]interface{}) error {
 				case <-ticker.C:
 					err = b.UpdateStatusClusterAware()
 					if err != nil {
-						base.Warnf("Failed to update background manager status: %v", err)
+						base.WarnfCtx(context.TODO(), "Failed to update background manager status: %v", err)
 					}
 
 				case <-b.terminator.Done():
@@ -158,7 +158,7 @@ func (b *BackgroundManager) Start(options map[string]interface{}) error {
 		if b.isClusterAware() {
 			err = b.UpdateStatusClusterAware()
 			if err != nil {
-				base.Warnf("Failed to update background manager status: %v", err)
+				base.WarnfCtx(context.TODO(), "Failed to update background manager status: %v", err)
 			}
 
 			// Delete the heartbeat doc to allow another process to run
@@ -465,7 +465,7 @@ func (b *BackgroundManager) UpdateHeartbeatDocClusterAware() error {
 	if status.ShouldStop {
 		err = b.Stop()
 		if err != nil {
-			base.Warnf("Failed to stop process %q: %v", b.clusterAwareOptions.processSuffix, err)
+			base.WarnfCtx(context.TODO(), "Failed to stop process %q: %v", b.clusterAwareOptions.processSuffix, err)
 		}
 	}
 

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -9,6 +9,7 @@
 package db
 
 import (
+	"context"
 	"net/http"
 	"sync"
 	"time"
@@ -138,7 +139,7 @@ func (b *BackgroundManager) Start(options map[string]interface{}) error {
 		}
 		err := b.Process.Run(options, updateStatusClusterAwareCallback, b.terminator)
 		if err != nil {
-			base.Errorf("Error: %v", err)
+			base.ErrorfCtx(context.TODO(), "Error: %v", err)
 			b.SetError(err)
 		}
 
@@ -169,7 +170,7 @@ func (b *BackgroundManager) Start(options map[string]interface{}) error {
 	if b.isClusterAware() {
 		err = b.UpdateStatusClusterAware()
 		if err != nil {
-			base.Errorf("Failed to update background manager status: %v", err)
+			base.ErrorfCtx(context.TODO(), "Failed to update background manager status: %v", err)
 		}
 	}
 
@@ -206,7 +207,7 @@ func (b *BackgroundManager) markStart() error {
 				case <-ticker.C:
 					err = b.UpdateHeartbeatDocClusterAware()
 					if err != nil {
-						base.Errorf("Failed to update expiry on heartbeat doc: %v", err)
+						base.ErrorfCtx(context.TODO(), "Failed to update expiry on heartbeat doc: %v", err)
 						b.SetError(err)
 					}
 				case <-b.terminator.Done():

--- a/db/background_mgr_attachment_compaction.go
+++ b/db/background_mgr_attachment_compaction.go
@@ -103,7 +103,7 @@ func (a *AttachmentCompactionManager) Run(options map[string]interface{}, persis
 	persistClusterStatus := func() {
 		err := persistClusterStatusCallback()
 		if err != nil {
-			base.Warnf("Failed to persist cluster status on-demand following completion of phase: %v", err)
+			base.WarnfCtx(database.Ctx, "Failed to persist cluster status on-demand following completion of phase: %v", err)
 		}
 	}
 

--- a/db/background_mgr_attachment_compaction.go
+++ b/db/background_mgr_attachment_compaction.go
@@ -55,12 +55,12 @@ func (a *AttachmentCompactionManager) Init(options map[string]interface{}, clust
 
 		dryRun, _ := options["dryRun"].(bool)
 		if dryRun {
-			base.Infof(base.KeyAll, "Attachment Compaction: Running as dry run. No attachments will be purged")
+			base.InfofCtx(database.Ctx, base.KeyAll, "Attachment Compaction: Running as dry run. No attachments will be purged")
 		}
 
 		a.dryRun = dryRun
 		a.CompactID = uniqueUUID.String()
-		base.Infof(base.KeyAll, "Attachment Compaction: Starting new compaction run with compact ID: %q", a.CompactID)
+		base.InfofCtx(database.Ctx, base.KeyAll, "Attachment Compaction: Starting new compaction run with compact ID: %q", a.CompactID)
 		return nil
 	}
 
@@ -70,7 +70,7 @@ func (a *AttachmentCompactionManager) Init(options map[string]interface{}, clust
 
 		reset, ok := options["reset"].(bool)
 		if reset && ok {
-			base.Infof(base.KeyAll, "Attachment Compaction: Resetting compaction process. Will not  resume any "+
+			base.InfofCtx(database.Ctx, base.KeyAll, "Attachment Compaction: Resetting compaction process. Will not  resume any "+
 				"partially completed process")
 		}
 
@@ -87,7 +87,7 @@ func (a *AttachmentCompactionManager) Init(options map[string]interface{}, clust
 			a.PurgedAttachments.Set(statusDoc.PurgedAttachments)
 			a.VBUUIDs = statusDoc.VBUUIDs
 
-			base.Infof(base.KeyAll, "Attachment Compaction: Attempting to resume compaction with compact ID: %q phase %q", a.CompactID, a.Phase)
+			base.InfofCtx(database.Ctx, base.KeyAll, "Attachment Compaction: Attempting to resume compaction with compact ID: %q phase %q", a.CompactID, a.Phase)
 		}
 
 		return nil

--- a/db/blip_messages.go
+++ b/db/blip_messages.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -66,7 +67,7 @@ func (rq *SubChangesRequest) marshalBLIPRequest() (*blip.Message, error) {
 		if err := msg.SetJSONBody(map[string]interface{}{
 			"docIDs": rq.DocIDs,
 		}); err != nil {
-			base.Errorf("error marshalling docIDs slice into subChanges request: %v", err)
+			base.ErrorfCtx(context.Background(), "error marshalling docIDs slice into subChanges request: %v", err)
 			return nil, err
 		}
 	}

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -559,7 +559,7 @@ func (bsc *BlipSyncContext) sendRevision(sender *blip.Sender, docID, revID strin
 		return bsc.sendNoRev(sender, docID, revID, seq, err)
 	}
 
-	base.Tracef(base.KeySync, "sendRevision, rev attachments for %s/%s are %v", base.UD(docID), revID, base.UD(rev.Attachments))
+	base.TracefCtx(bsc.loggingCtx, base.KeySync, "sendRevision, rev attachments for %s/%s are %v", base.UD(docID), revID, base.UD(rev.Attachments))
 	attachmentStorageMeta := ToAttachmentStorageMeta(rev.Attachments)
 	var bodyBytes []byte
 	if base.IsEnterpriseEdition() {

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -356,7 +356,7 @@ func (c *changeCache) CleanSkippedSequenceQueue(ctx context.Context) error {
 		// Add queried sequences not in the resultset to pendingRemovals
 		for _, skippedSeq := range skippedSeqBatch {
 			if _, ok := foundMap[skippedSeq]; !ok {
-				base.Warnf("Skipped Sequence %d didn't show up in MaxChannelLogMissingWaitTime, and isn't available from a * channel query.  If it's a valid sequence, it won't be replicated until Sync Gateway is restarted.", skippedSeq)
+				base.WarnfCtx(ctx, "Skipped Sequence %d didn't show up in MaxChannelLogMissingWaitTime, and isn't available from a * channel query.  If it's a valid sequence, it won't be replicated until Sync Gateway is restarted.", skippedSeq)
 				pendingRemovals = append(pendingRemovals, skippedSeq)
 			}
 		}
@@ -451,7 +451,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 			base.Debugf(base.KeyCache, "Unable to unmarshal sync metadata for feed document %q.  Will not be included in channel cache.  Error: %v", base.UD(docID), err)
 		}
 		if err == base.ErrEmptyMetadata {
-			base.Warnf("Unexpected empty metadata when processing feed event.  docid: %s opcode: %v datatype:%v", base.UD(event.Key), event.Opcode, event.DataType)
+			base.WarnfCtx(context.TODO(), "Unexpected empty metadata when processing feed event.  docid: %s opcode: %v datatype:%v", base.UD(event.Key), event.Opcode, event.DataType)
 		}
 		return
 	}
@@ -598,7 +598,7 @@ func (c *changeCache) processUnusedSequence(docID string, timeReceived time.Time
 	sequenceStr := strings.TrimPrefix(docID, base.UnusedSeqPrefix)
 	sequence, err := strconv.ParseUint(sequenceStr, 10, 64)
 	if err != nil {
-		base.Warnf("Unable to identify sequence number for unused sequence notification with key: %s, error: %v", base.UD(docID), err)
+		base.WarnfCtx(context.TODO(), "Unable to identify sequence number for unused sequence notification with key: %s, error: %v", base.UD(docID), err)
 		return
 	}
 	c.releaseUnusedSequence(sequence, timeReceived)
@@ -630,12 +630,12 @@ func (c *changeCache) processUnusedSequenceRange(docID string) {
 
 	fromSequence, err := strconv.ParseUint(sequences[2], 10, 64)
 	if err != nil {
-		base.Warnf("Unable to identify from sequence number for unused sequences notification with key: %s, error:", base.UD(docID), err)
+		base.WarnfCtx(context.TODO(), "Unable to identify from sequence number for unused sequences notification with key: %s, error:", base.UD(docID), err)
 		return
 	}
 	toSequence, err := strconv.ParseUint(sequences[3], 10, 64)
 	if err != nil {
-		base.Warnf("Unable to identify to sequence number for unused sequence notification with key: %s, error:", base.UD(docID), err)
+		base.WarnfCtx(context.TODO(), "Unable to identify to sequence number for unused sequence notification with key: %s, error:", base.UD(docID), err)
 		return
 	}
 
@@ -652,7 +652,7 @@ func (c *changeCache) processPrincipalDoc(docID string, docJSON []byte, isUser b
 	// have gaps in it, causing later sequences to get stuck in the queue.
 	princ, err := c.unmarshalCachePrincipal(docJSON)
 	if err != nil {
-		base.Warnf("changeCache: Error unmarshaling doc %q: %v", base.UD(docID), err)
+		base.WarnfCtx(context.TODO(), "changeCache: Error unmarshaling doc %q: %v", base.UD(docID), err)
 		return
 	}
 	sequence := princ.Sequence

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -434,7 +434,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 	// If this is a delete and there are no xattrs (no existing SG revision), we can ignore
 	if event.Opcode == sgbucket.FeedOpDeletion && len(docJSON) == 0 {
-		base.Debugf(base.KeyImport, "Ignoring delete mutation for %s - no existing Sync Gateway metadata.", base.UD(docID))
+		base.DebugfCtx(logCtx, base.KeyImport, "Ignoring delete mutation for %s - no existing Sync Gateway metadata.", base.UD(docID))
 		return
 	}
 
@@ -449,7 +449,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	if err != nil {
 		// Avoid log noise related to failed unmarshaling of binary documents.
 		if event.DataType != base.MemcachedDataTypeRaw {
-			base.Debugf(base.KeyCache, "Unable to unmarshal sync metadata for feed document %q.  Will not be included in channel cache.  Error: %v", base.UD(docID), err)
+			base.DebugfCtx(logCtx, base.KeyCache, "Unable to unmarshal sync metadata for feed document %q.  Will not be included in channel cache.  Error: %v", base.UD(docID), err)
 		}
 		if err == base.ErrEmptyMetadata {
 			base.WarnfCtx(logCtx, "Unexpected empty metadata when processing feed event.  docid: %s opcode: %v datatype:%v", base.UD(event.Key), event.Opcode, event.DataType)
@@ -564,7 +564,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	if millisecondLatency >= 60*1000 {
 		base.InfofCtx(logCtx, base.KeyDCP, "Received #%d after %3dms (%q / %q)", change.Sequence, millisecondLatency, base.UD(change.DocID), change.RevID)
 	} else {
-		base.Debugf(base.KeyDCP, "Received #%d after %3dms (%q / %q)", change.Sequence, millisecondLatency, base.UD(change.DocID), change.RevID)
+		base.DebugfCtx(logCtx, base.KeyDCP, "Received #%d after %3dms (%q / %q)", change.Sequence, millisecondLatency, base.UD(change.DocID), change.RevID)
 	}
 
 	changedChannels := c.processEntry(change)
@@ -690,6 +690,7 @@ func (c *changeCache) processEntry(change *LogEntry) base.Set {
 		return nil
 	}
 
+	logCtx := context.TODO()
 	sequence := change.Sequence
 	if change.Sequence > c.internalStats.highSeqFeed {
 		c.internalStats.highSeqFeed = change.Sequence
@@ -701,13 +702,13 @@ func (c *changeCache) processEntry(change *LogEntry) base.Set {
 	// We can cancel processing early in these scenarios.
 	// Check if this is a duplicate of an already processed sequence
 	if sequence < c.nextSequence && !c.WasSkipped(sequence) {
-		base.Debugf(base.KeyCache, "  Ignoring duplicate of #%d", sequence)
+		base.DebugfCtx(logCtx, base.KeyCache, "  Ignoring duplicate of #%d", sequence)
 		return nil
 	}
 
 	// Check if this is a duplicate of a pending sequence
 	if _, found := c.receivedSeqs[sequence]; found {
-		base.Debugf(base.KeyCache, "  Ignoring duplicate of #%d", sequence)
+		base.DebugfCtx(logCtx, base.KeyCache, "  Ignoring duplicate of #%d", sequence)
 		return nil
 	}
 	c.receivedSeqs[sequence] = struct{}{}
@@ -724,7 +725,7 @@ func (c *changeCache) processEntry(change *LogEntry) base.Set {
 		numPending := len(c.pendingLogs)
 		c.internalStats.pendingSeqLen = numPending
 		if base.LogDebugEnabled(base.KeyCache) {
-			base.Debugf(base.KeyCache, "  Deferring #%d (%d now waiting for #%d...#%d) doc %q / %q",
+			base.DebugfCtx(logCtx, base.KeyCache, "  Deferring #%d (%d now waiting for #%d...#%d) doc %q / %q",
 				sequence, numPending, c.nextSequence, c.pendingLogs[0].Sequence-1, base.UD(change.DocID), change.RevID)
 		}
 		// Update max pending high watermark stat
@@ -741,9 +742,9 @@ func (c *changeCache) processEntry(change *LogEntry) base.Set {
 		// Remove from skipped sequence queue
 		if !c.WasSkipped(sequence) {
 			// Error removing from skipped sequences
-			base.InfofCtx(context.TODO(), base.KeyCache, "  Received unexpected out-of-order change - not in skippedSeqs (seq %d, expecting %d) doc %q / %q", sequence, c.nextSequence, base.UD(change.DocID), change.RevID)
+			base.InfofCtx(logCtx, base.KeyCache, "  Received unexpected out-of-order change - not in skippedSeqs (seq %d, expecting %d) doc %q / %q", sequence, c.nextSequence, base.UD(change.DocID), change.RevID)
 		} else {
-			base.InfofCtx(context.TODO(), base.KeyCache, "  Received previously skipped out-of-order change (seq %d, expecting %d) doc %q / %q ", sequence, c.nextSequence, base.UD(change.DocID), change.RevID)
+			base.InfofCtx(logCtx, base.KeyCache, "  Received previously skipped out-of-order change (seq %d, expecting %d) doc %q / %q ", sequence, c.nextSequence, base.UD(change.DocID), change.RevID)
 			change.Skipped = true
 		}
 
@@ -752,7 +753,7 @@ func (c *changeCache) processEntry(change *LogEntry) base.Set {
 		// in cache
 		err := c.RemoveSkipped(sequence)
 		if err != nil {
-			base.Debugf(base.KeyCache, "Error removing skipped sequence: #%d from cache: %v", sequence, err)
+			base.DebugfCtx(logCtx, base.KeyCache, "Error removing skipped sequence: #%d from cache: %v", sequence, err)
 		}
 	}
 	return changedChannels
@@ -781,7 +782,7 @@ func (c *changeCache) _addToCache(change *LogEntry) []string {
 	// the change's active channels, as well as any channel removals for the active revision.
 	updatedChannels := c.channelCache.AddToCache(change)
 	if base.LogDebugEnabled(base.KeyDCP) {
-		base.Debugf(base.KeyDCP, " #%d ==> channels %v", change.Sequence, base.UD(updatedChannels))
+		base.DebugfCtx(context.TODO(), base.KeyDCP, " #%d ==> channels %v", change.Sequence, base.UD(updatedChannels))
 	}
 
 	if !change.TimeReceived.IsZero() {
@@ -848,7 +849,7 @@ func (c *changeCache) LastSequence() uint64 {
 func (c *changeCache) getOldestSkippedSequence() uint64 {
 	oldestSkippedSeq := c.skippedSeqs.getOldest()
 	if oldestSkippedSeq > 0 {
-		base.Debugf(base.KeyChanges, "Get oldest skipped, returning: %d", oldestSkippedSeq)
+		base.DebugfCtx(context.TODO(), base.KeyChanges, "Get oldest skipped, returning: %d", oldestSkippedSeq)
 	}
 	return oldestSkippedSeq
 }
@@ -931,7 +932,7 @@ func (c *changeCache) waitForSequence(ctx context.Context, sequence uint64, maxW
 
 	worker := func() (bool, error, interface{}) {
 		if c.getNextSequence() >= sequence+1 {
-			base.Debugf(base.KeyCache, "waitForSequence(%d) took %v", sequence, time.Since(startTime))
+			base.DebugfCtx(ctx, base.KeyCache, "waitForSequence(%d) took %v", sequence, time.Since(startTime))
 			return false, nil, nil
 		}
 		// retry
@@ -953,7 +954,7 @@ func (c *changeCache) waitForSequenceNotSkipped(ctx context.Context, sequence ui
 		if c.getNextSequence() >= sequence+1 {
 			foundInMissing := c.skippedSeqs.Contains(sequence)
 			if !foundInMissing {
-				base.Debugf(base.KeyCache, "waitForSequenceNotSkipped(%d) took %v", sequence, time.Since(startTime))
+				base.DebugfCtx(ctx, base.KeyCache, "waitForSequenceNotSkipped(%d) took %v", sequence, time.Since(startTime))
 				return false, nil, nil
 			}
 		}

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -98,7 +98,7 @@ func (listener *changeListener) StartMutationFeed(bucket base.Bucket, dbStats *e
 	default:
 		// DCP Feed
 		//    DCP receiver isn't go-channel based - DCPReceiver calls ProcessEvent directly.
-		base.Infof(base.KeyDCP, "Using DCP feed for bucket: %q (based on feed_type specified in config file)", base.MD(bucket.GetName()))
+		base.InfofCtx(context.TODO(), base.KeyDCP, "Using DCP feed for bucket: %q (based on feed_type specified in config file)", base.MD(bucket.GetName()))
 		return bucket.StartDCPFeed(listener.FeedArgs, listener.ProcessFeedEvent, dbStats)
 	}
 }

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"context"
 	"expvar"
 	"math"
 	"strings"
@@ -168,7 +169,7 @@ func (listener *changeListener) Stop() {
 	case <-listener.FeedArgs.DoneChan:
 		// Mutation feed worker goroutine is terminated and doneChan is already closed.
 	case <-time.After(waitTime):
-		base.Warnf("Timeout after %v of waiting for mutation feed worker to terminate", waitTime)
+		base.WarnfCtx(context.Background(), "Timeout after %v of waiting for mutation feed worker to terminate", waitTime)
 	}
 }
 

--- a/db/changes.go
+++ b/db/changes.go
@@ -1080,20 +1080,20 @@ func (db *Database) GetChangeLog(channelName string, afterSeq uint64) (entries [
 
 // WaitForSequenceNotSkipped blocks until the given sequence has been received or skipped by the change cache.
 func (dbc *DatabaseContext) WaitForSequence(ctx context.Context, sequence uint64) (err error) {
-	base.Debugf(base.KeyChanges, "Waiting for sequence: %d", sequence)
+	base.DebugfCtx(ctx, base.KeyChanges, "Waiting for sequence: %d", sequence)
 	return dbc.changeCache.waitForSequence(ctx, sequence, base.DefaultWaitForSequence)
 }
 
 // WaitForSequenceNotSkipped blocks until the given sequence has been received by the change cache without being skipped.
 func (dbc *DatabaseContext) WaitForSequenceNotSkipped(ctx context.Context, sequence uint64) (err error) {
-	base.Debugf(base.KeyChanges, "Waiting for sequence: %d", sequence)
+	base.DebugfCtx(ctx, base.KeyChanges, "Waiting for sequence: %d", sequence)
 	return dbc.changeCache.waitForSequenceNotSkipped(ctx, sequence, base.DefaultWaitForSequence)
 }
 
 // WaitForPendingChanges blocks until the change-cache has caught up with the latest writes to the database.
 func (dbc *DatabaseContext) WaitForPendingChanges(ctx context.Context) (err error) {
 	lastSequence, err := dbc.LastSequence()
-	base.Debugf(base.KeyChanges, "Waiting for sequence: %d", lastSequence)
+	base.DebugfCtx(ctx, base.KeyChanges, "Waiting for sequence: %d", lastSequence)
 	return dbc.changeCache.waitForSequence(ctx, lastSequence, base.DefaultWaitForSequence)
 }
 

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -418,8 +418,9 @@ func (c *channelCacheImpl) compactChannelCache() {
 	// Increment compact count on start, as timing is updated per loop iteration
 	c.cacheStats.ChannelCacheCompactCount.Add(1)
 
+	logCtx := context.TODO()
 	cacheSize := c.channelCaches.Length()
-	base.InfofCtx(context.TODO(), base.KeyCache, "Starting channel cache compaction, size %d", cacheSize)
+	base.InfofCtx(logCtx, base.KeyCache, "Starting channel cache compaction, size %d", cacheSize)
 	for {
 		// channelCache close handling
 		compactIterationStart := time.Now()
@@ -435,7 +436,7 @@ func (c *channelCacheImpl) compactChannelCache() {
 		// Maintain a target number of items to compact per iteration.  Break the list iteration when the target is reached
 		targetEvictCount := cacheSize - c.compactLowWatermark
 		if targetEvictCount <= 0 {
-			base.InfofCtx(context.TODO(), base.KeyCache, "Stopping channel cache compaction, size %d", cacheSize)
+			base.InfofCtx(logCtx, base.KeyCache, "Stopping channel cache compaction, size %d", cacheSize)
 			return
 		}
 		base.Tracef(base.KeyCache, "Target eviction count: %d (lwm:%d)", targetEvictCount, c.compactLowWatermark)
@@ -452,7 +453,7 @@ func (c *channelCacheImpl) compactChannelCache() {
 			elementCount++
 			singleChannelCache, ok := elem.Value.(*singleChannelCacheImpl)
 			if !ok {
-				base.WarnfCtx(context.Background(), "Non-cache entry (%T) found in channel cache during compaction - ignoring", elem.Value)
+				base.WarnfCtx(logCtx, "Non-cache entry (%T) found in channel cache during compaction - ignoring", elem.Value)
 				return true
 			}
 

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -327,7 +327,7 @@ func (c *channelCacheImpl) getBypassChannelCache(channelName string) SingleChann
 func AsSingleChannelCache(cacheValue interface{}) *singleChannelCacheImpl {
 	singleChannelCache, ok := cacheValue.(*singleChannelCacheImpl)
 	if !ok {
-		base.Warnf("Unexpected channel cache value type: %T", cacheValue)
+		base.WarnfCtx(context.Background(), "Unexpected channel cache value type: %T", cacheValue)
 		return nil
 	}
 	return singleChannelCache
@@ -452,7 +452,7 @@ func (c *channelCacheImpl) compactChannelCache() {
 			elementCount++
 			singleChannelCache, ok := elem.Value.(*singleChannelCacheImpl)
 			if !ok {
-				base.Warnf("Non-cache entry (%T) found in channel cache during compaction - ignoring", elem.Value)
+				base.WarnfCtx(context.Background(), "Non-cache entry (%T) found in channel cache during compaction - ignoring", elem.Value)
 				return true
 			}
 

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -123,7 +123,7 @@ func newChannelCache(dbName string, options ChannelCacheOptions, queryHandler Ch
 		return nil, err
 	}
 	channelCache.backgroundTasks = append(channelCache.backgroundTasks, bgt)
-	base.Debugf(base.KeyCache, "Initialized channel cache with maxChannels:%d, HWM: %d, LWM: %d",
+	base.DebugfCtx(context.Background(), base.KeyCache, "Initialized channel cache with maxChannels:%d, HWM: %d, LWM: %d",
 		channelCache.maxChannels, channelCache.compactHighWatermark, channelCache.compactLowWatermark)
 	return channelCache, nil
 }
@@ -427,7 +427,7 @@ func (c *channelCacheImpl) compactChannelCache() {
 
 		select {
 		case <-c.terminator:
-			base.Debugf(base.KeyCache, "Channel cache compaction stopped due to cache close.")
+			base.DebugfCtx(logCtx, base.KeyCache, "Channel cache compaction stopped due to cache close.")
 			return
 		default:
 			// continue

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -439,7 +439,7 @@ func (c *channelCacheImpl) compactChannelCache() {
 			base.InfofCtx(logCtx, base.KeyCache, "Stopping channel cache compaction, size %d", cacheSize)
 			return
 		}
-		base.Tracef(base.KeyCache, "Target eviction count: %d (lwm:%d)", targetEvictCount, c.compactLowWatermark)
+		base.TracefCtx(logCtx, base.KeyCache, "Target eviction count: %d (lwm:%d)", targetEvictCount, c.compactLowWatermark)
 
 		// Iterates through cache entries based on cache size at start of compaction iteration loop.  Intentionally
 		// ignores channels added during compaction iteration
@@ -466,16 +466,16 @@ func (c *channelCacheImpl) compactChannelCache() {
 			// Determine whether NRU channel is active, to establish eviction priority
 			isActive := c.activeChannels.IsActive(singleChannelCache.channelName)
 			if !isActive {
-				base.Tracef(base.KeyCache, "Marking inactive cache entry %q for eviction ", base.UD(singleChannelCache.channelName))
+				base.TracefCtx(logCtx, base.KeyCache, "Marking inactive cache entry %q for eviction ", base.UD(singleChannelCache.channelName))
 				inactiveEvictionCandidates = append(inactiveEvictionCandidates, elem)
 			} else {
-				base.Tracef(base.KeyCache, "Marking NRU cache entry %q for eviction", base.UD(singleChannelCache.channelName))
+				base.TracefCtx(logCtx, base.KeyCache, "Marking NRU cache entry %q for eviction", base.UD(singleChannelCache.channelName))
 				nruEvictionCandidates = append(nruEvictionCandidates, elem)
 			}
 
 			// If we have enough inactive channels to reach targetCount, terminate range
 			if len(inactiveEvictionCandidates) >= targetEvictCount {
-				base.Tracef(base.KeyCache, "Eviction count target (%d) reached with inactive channels, proceeding to removal", targetEvictCount)
+				base.TracefCtx(logCtx, base.KeyCache, "Eviction count target (%d) reached with inactive channels, proceeding to removal", targetEvictCount)
 				return false
 			}
 			return true
@@ -513,7 +513,7 @@ func (c *channelCacheImpl) compactChannelCache() {
 		// Update eviction stats
 		c.updateEvictionStats(inactiveEvictCount, len(evictionElements), compactIterationStart)
 
-		base.Tracef(base.KeyCache, "Compact iteration complete - eviction count: %d (lwm:%d)", len(evictionElements), c.compactLowWatermark)
+		base.TracefCtx(logCtx, base.KeyCache, "Compact iteration complete - eviction count: %d (lwm:%d)", len(evictionElements), c.compactLowWatermark)
 	}
 }
 

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -199,7 +199,7 @@ func (c *channelCacheImpl) AddToCache(change *LogEntry) (updatedChannels []strin
 	// twice)
 	if change.Skipped {
 		c.lateSeqLock.Lock()
-		base.Infof(base.KeyChanges, "Acquired late sequence lock in order to cache %d - doc %q / %q", change.Sequence, base.UD(change.DocID), change.RevID)
+		base.InfofCtx(context.TODO(), base.KeyChanges, "Acquired late sequence lock in order to cache %d - doc %q / %q", change.Sequence, base.UD(change.DocID), change.RevID)
 		defer c.lateSeqLock.Unlock()
 	}
 
@@ -419,7 +419,7 @@ func (c *channelCacheImpl) compactChannelCache() {
 	c.cacheStats.ChannelCacheCompactCount.Add(1)
 
 	cacheSize := c.channelCaches.Length()
-	base.Infof(base.KeyCache, "Starting channel cache compaction, size %d", cacheSize)
+	base.InfofCtx(context.TODO(), base.KeyCache, "Starting channel cache compaction, size %d", cacheSize)
 	for {
 		// channelCache close handling
 		compactIterationStart := time.Now()
@@ -435,7 +435,7 @@ func (c *channelCacheImpl) compactChannelCache() {
 		// Maintain a target number of items to compact per iteration.  Break the list iteration when the target is reached
 		targetEvictCount := cacheSize - c.compactLowWatermark
 		if targetEvictCount <= 0 {
-			base.Infof(base.KeyCache, "Stopping channel cache compaction, size %d", cacheSize)
+			base.InfofCtx(context.TODO(), base.KeyCache, "Stopping channel cache compaction, size %d", cacheSize)
 			return
 		}
 		base.Tracef(base.KeyCache, "Target eviction count: %d (lwm:%d)", targetEvictCount, c.compactLowWatermark)

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -154,7 +154,7 @@ func newChannelCacheWithOptions(queryHandler ChannelQueryHandler, channelName st
 		cache.options.MaxNumChannels = options.MaxNumChannels
 	}
 
-	base.Debugf(base.KeyCache, "Initialized cache for channel %q with min:%v max:%v age:%v, validFrom: %d",
+	base.DebugfCtx(context.Background(), base.KeyCache, "Initialized cache for channel %q with min:%v max:%v age:%v, validFrom: %d",
 		base.UD(cache.channelName), cache.options.ChannelCacheMinLength, cache.options.ChannelCacheMaxLength, cache.options.ChannelCacheAge, validFrom)
 
 	return cache
@@ -226,6 +226,7 @@ func (c *singleChannelCacheImpl) Remove(docIDs []string, startTime time.Time) (c
 
 	c.lock.Lock()
 	defer c.lock.Unlock()
+	logCtx := context.TODO()
 
 	// Build subset of docIDs that we know are present in the cache
 	foundDocs := make(map[string]struct{}, 0)
@@ -244,7 +245,7 @@ func (c *singleChannelCacheImpl) Remove(docIDs []string, startTime time.Time) (c
 			// Make sure the document we're about to remove is older than the start time of the purge
 			// This is to ensure that resurrected documents do not accidentally get removed.
 			if c.logs[i].TimeReceived.After(startTime) {
-				base.Debugf(base.KeyCache, "Skipping removal of doc %q from cache %q - received after purge",
+				base.DebugfCtx(logCtx, base.KeyCache, "Skipping removal of doc %q from cache %q - received after purge",
 					base.UD(docID), base.UD(c.channelName))
 				continue
 			}
@@ -280,7 +281,7 @@ func (c *singleChannelCacheImpl) _pruneCacheLength() (pruned int) {
 	}
 
 	if pruned > 0 {
-		base.Debugf(base.KeyCache, "Pruned %d entries from channel %q", pruned, base.UD(c.channelName))
+		base.DebugfCtx(context.TODO(), base.KeyCache, "Pruned %d entries from channel %q", pruned, base.UD(c.channelName))
 	}
 
 	return pruned
@@ -468,7 +469,7 @@ func (c *singleChannelCacheImpl) _appendChange(change *LogEntry) {
 	end := len(log) - 1
 	if end >= 0 {
 		if change.Sequence <= log[end].Sequence {
-			base.Debugf(base.KeyCache, "LogEntries.appendChange: out-of-order sequence #%d (last is #%d) - handling as insert",
+			base.DebugfCtx(context.TODO(), base.KeyCache, "LogEntries.appendChange: out-of-order sequence #%d (last is #%d) - handling as insert",
 				change.Sequence, log[end].Sequence)
 			// insert the change in the array, ensuring the docID isn't already present
 			c.insertChange(&c.logs, change)
@@ -578,11 +579,12 @@ func (c *singleChannelCacheImpl) insertChange(log *LogEntries, change *LogEntry)
 func (c *singleChannelCacheImpl) prependChanges(changes LogEntries, changesValidFrom uint64, changesValidTo uint64) int {
 	c.lock.Lock()
 	defer c.lock.Unlock()
+	logCtx := context.TODO()
 
 	// If set of changes to prepend is empty, check whether validFrom should be updated
 	if len(changes) == 0 {
 		if changesValidFrom < c.validFrom && changesValidTo >= c.validFrom {
-			base.Debugf(base.KeyCache, " changesValidFrom (%d) < c.validFrom < changesValidTo (%d), setting c.validFrom from %v -> %v for %q",
+			base.DebugfCtx(logCtx, base.KeyCache, " changesValidFrom (%d) < c.validFrom < changesValidTo (%d), setting c.validFrom from %v -> %v for %q",
 				changesValidFrom, changesValidTo, c.validFrom, changesValidFrom, base.UD(c.channelName))
 			c.validFrom = changesValidFrom
 		}
@@ -602,7 +604,7 @@ func (c *singleChannelCacheImpl) prependChanges(changes LogEntries, changesValid
 		}
 		c.logs = make(LogEntries, len(changes))
 		copy(c.logs, changes)
-		base.InfofCtx(context.TODO(), base.KeyCache, "  Initialized cache of %q with %d entries from query (#%d--#%d)",
+		base.InfofCtx(logCtx, base.KeyCache, "  Initialized cache of %q with %d entries from query (#%d--#%d)",
 			base.UD(c.channelName), len(changes), changes[0].Sequence, changes[len(changes)-1].Sequence)
 
 		for _, change := range changes {
@@ -657,10 +659,10 @@ func (c *singleChannelCacheImpl) prependChanges(changes LogEntries, changesValid
 	numToPrepend := len(entriesToPrepend)
 	if numToPrepend > 0 {
 		c.logs = append(entriesToPrepend, c.logs...)
-		base.InfofCtx(context.TODO(), base.KeyCache, "  Added %d entries from query (#%d--#%d) to cache of %q",
+		base.InfofCtx(logCtx, base.KeyCache, "  Added %d entries from query (#%d--#%d) to cache of %q",
 			numToPrepend, entriesToPrepend[0].Sequence, entriesToPrepend[numToPrepend-1].Sequence, base.UD(c.channelName))
 	}
-	base.Debugf(base.KeyCache, " Backfill cache from query c.validFrom from %v -> %v",
+	base.DebugfCtx(logCtx, base.KeyCache, " Backfill cache from query c.validFrom from %v -> %v",
 		c.validFrom, changesValidFrom)
 	c.validFrom = changesValidFrom
 	return numToPrepend

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -188,7 +188,7 @@ func (c *singleChannelCacheImpl) addToCache(change *LogEntry, isRemoval bool) {
 	defer c.lock.Unlock()
 
 	if c.wouldBeImmediatelyPruned(change) {
-		base.Infof(base.KeyCache, "Not adding change #%d doc %q / %q ==> channel %q, since it will be immediately pruned",
+		base.InfofCtx(context.TODO(), base.KeyCache, "Not adding change #%d doc %q / %q ==> channel %q, since it will be immediately pruned",
 			change.Sequence, base.UD(change.DocID), change.RevID, base.UD(c.channelName))
 		return
 	}
@@ -602,7 +602,7 @@ func (c *singleChannelCacheImpl) prependChanges(changes LogEntries, changesValid
 		}
 		c.logs = make(LogEntries, len(changes))
 		copy(c.logs, changes)
-		base.Infof(base.KeyCache, "  Initialized cache of %q with %d entries from query (#%d--#%d)",
+		base.InfofCtx(context.TODO(), base.KeyCache, "  Initialized cache of %q with %d entries from query (#%d--#%d)",
 			base.UD(c.channelName), len(changes), changes[0].Sequence, changes[len(changes)-1].Sequence)
 
 		for _, change := range changes {
@@ -657,7 +657,7 @@ func (c *singleChannelCacheImpl) prependChanges(changes LogEntries, changesValid
 	numToPrepend := len(entriesToPrepend)
 	if numToPrepend > 0 {
 		c.logs = append(entriesToPrepend, c.logs...)
-		base.Infof(base.KeyCache, "  Added %d entries from query (#%d--#%d) to cache of %q",
+		base.InfofCtx(context.TODO(), base.KeyCache, "  Added %d entries from query (#%d--#%d) to cache of %q",
 			numToPrepend, entriesToPrepend[0].Sequence, entriesToPrepend[numToPrepend-1].Sequence, base.UD(c.channelName))
 	}
 	base.Debugf(base.KeyCache, " Backfill cache from query c.validFrom from %v -> %v",

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -260,7 +260,7 @@ func (c *singleChannelCacheImpl) Remove(docIDs []string, startTime time.Time) (c
 			delete(c.cachedDocIDs, docID)
 			count++
 
-			base.Tracef(base.KeyCache, "Removed doc %q from cache %q", base.UD(docID), base.UD(c.channelName))
+			base.TracefCtx(logCtx, base.KeyCache, "Removed doc %q from cache %q", base.UD(docID), base.UD(c.channelName))
 		}
 	}
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -1098,7 +1098,7 @@ func (db *Database) resolveConflict(localDoc *Document, remoteDoc *Document, doc
 
 	resolvedBody, resolutionType, resolveFuncError := resolver.Resolve(conflict)
 	if resolveFuncError != nil {
-		base.Infof(base.KeyReplicate, "Error when running conflict resolution for doc %s: %v", base.UD(localDoc.ID), resolveFuncError)
+		base.InfofCtx(db.Ctx, base.KeyReplicate, "Error when running conflict resolution for doc %s: %v", base.UD(localDoc.ID), resolveFuncError)
 		return "", nil, resolveFuncError
 	}
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -1129,7 +1129,7 @@ func (db *Database) resolveDocRemoteWins(localDoc *Document, conflict Conflict) 
 		return "", tombstoneErr
 	}
 	remoteRevID := conflict.RemoteDocument.ExtractRev()
-	base.Debugf(base.KeyReplicate, "Resolved conflict for doc %s as remote wins - remote rev is %s, previous local rev %s tombstoned by %s, ", base.UD(localDoc.ID), remoteRevID, localRevID, tombstoneRevID)
+	base.DebugfCtx(db.Ctx, base.KeyReplicate, "Resolved conflict for doc %s as remote wins - remote rev is %s, previous local rev %s tombstoned by %s, ", base.UD(localDoc.ID), remoteRevID, localRevID, tombstoneRevID)
 	return remoteRevID, nil
 }
 
@@ -1220,7 +1220,7 @@ func (db *Database) resolveDocLocalWins(localDoc *Document, remoteDoc *Document,
 		return "", nil, tombstoneErr
 	}
 
-	base.Debugf(base.KeyReplicate, "Resolved conflict for doc %s as localWins - local rev %s moved to %s, and tombstoned with %s", base.UD(localDoc.ID), localRevID, newRevID, tombstoneRevID)
+	base.DebugfCtx(db.Ctx, base.KeyReplicate, "Resolved conflict for doc %s as localWins - local rev %s moved to %s, and tombstoned with %s", base.UD(localDoc.ID), localRevID, newRevID, tombstoneRevID)
 	return newRevID, docHistory, nil
 }
 
@@ -1262,7 +1262,7 @@ func (db *Database) resolveDocMerge(localDoc *Document, remoteDoc *Document, con
 	// Update the history for the remote doc to prepend the merged revID
 	docHistory = append([]string{mergedRevID}, docHistory...)
 
-	base.Debugf(base.KeyReplicate, "Resolved conflict for doc %s as merge - merged rev %s added as child of %s, previous local rev %s tombstoned by %s", base.UD(localDoc.ID), mergedRevID, remoteRevID, localRevID, tombstoneRevID)
+	base.DebugfCtx(db.Ctx, base.KeyReplicate, "Resolved conflict for doc %s as merge - merged rev %s added as child of %s, previous local rev %s tombstoned by %s", base.UD(localDoc.ID), mergedRevID, remoteRevID, localRevID, tombstoneRevID)
 	return mergedRevID, docHistory, nil
 }
 
@@ -1275,7 +1275,7 @@ func (db *Database) tombstoneActiveRevision(doc *Document, revID string) (tombst
 
 	// Don't tombstone an already deleted revision, return the incoming revID instead.
 	if doc.IsDeleted() {
-		base.Debugf(base.KeyReplicate, "Active revision %s/%s is already tombstoned.", base.UD(doc.ID), revID)
+		base.DebugfCtx(db.Ctx, base.KeyReplicate, "Active revision %s/%s is already tombstoned.", base.UD(doc.ID), revID)
 		return revID, nil
 	}
 
@@ -1918,7 +1918,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 				winningRevChange := prevCurrentRev != doc.CurrentRev
 				err = db.EventMgr.RaiseDocumentChangeEvent(webhookJSON, docid, oldBodyJSON, revChannels, winningRevChange)
 				if err != nil {
-					base.Debugf(base.KeyCRUD, "Error raising document change event: %v", err)
+					base.DebugfCtx(db.Ctx, base.KeyCRUD, "Error raising document change event: %v", err)
 				}
 			}
 		}

--- a/db/database.go
+++ b/db/database.go
@@ -363,7 +363,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 		options.CacheOptions,
 	)
 	if err != nil {
-		base.Debugf(base.KeyDCP, "Error initializing the change cache", err)
+		base.DebugfCtx(logCtx, base.KeyDCP, "Error initializing the change cache", err)
 	}
 
 	// Set the DB Context notifyChange callback to call back the changecache DocChanged callback
@@ -636,7 +636,7 @@ func (dbCtx *DatabaseContext) GetServerUUID() string {
 			return ""
 		}
 
-		base.Debugf(base.KeyAll, "Database %v: Got server UUID %v", base.MD(dbCtx.Name), base.MD(uuid))
+		base.DebugfCtx(context.TODO(), base.KeyAll, "Database %v: Got server UUID %v", base.MD(dbCtx.Name), base.MD(uuid))
 		dbCtx.serverUUID = uuid
 	}
 
@@ -759,7 +759,7 @@ func (dc *DatabaseContext) TakeDbOffline(reason string) error {
 		atomic.StoreUint32(&dc.State, DBOffline)
 
 		if err := dc.EventMgr.RaiseDBStateChangeEvent(dc.Name, "offline", reason, dc.Options.AdminInterface); err != nil {
-			base.Debugf(base.KeyCRUD, "Error raising database state change event: %v", err)
+			base.DebugfCtx(context.TODO(), base.KeyCRUD, "Error raising database state change event: %v", err)
 		}
 
 		return nil

--- a/db/database.go
+++ b/db/database.go
@@ -429,7 +429,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	}
 
 	// Start DCP feed
-	base.Infof(base.KeyDCP, "Starting mutation feed on bucket %v due to either channel cache mode or doc tracking (auto-import)", base.MD(bucket.GetName()))
+	base.InfofCtx(context.TODO(), base.KeyDCP, "Starting mutation feed on bucket %v due to either channel cache mode or doc tracking (auto-import)", base.MD(bucket.GetName()))
 	cacheFeedStatsMap := dbContext.DbStats.Database().CacheFeedMapStats
 	err = dbContext.mutationListener.Start(bucket, cacheFeedStatsMap.Map)
 
@@ -534,7 +534,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 				dbContext.PurgeInterval = serverPurgeInterval
 			}
 		}
-		base.Infof(base.KeyAll, "Using metadata purge interval of %.2f days for tombstone compaction.", dbContext.PurgeInterval.Hours()/24)
+		base.InfofCtx(context.TODO(), base.KeyAll, "Using metadata purge interval of %.2f days for tombstone compaction.", dbContext.PurgeInterval.Hours()/24)
 
 		if dbContext.Options.CompactInterval != 0 {
 			if autoImport {
@@ -684,7 +684,7 @@ func waitForBGTCompletion(waitTimeMax time.Duration, tasks []BackgroundTask, dbN
 		case <-time.After(waitTime):
 			// Timeout after waiting for background task to terminate.
 		}
-		base.Infof(base.KeyAll, "Timeout after %v of waiting for background task %q to "+
+		base.InfofCtx(context.TODO(), base.KeyAll, "Timeout after %v of waiting for background task %q to "+
 			"terminate, database: %s", waitTimeMax, t.taskName, dbName)
 	}
 }
@@ -709,9 +709,9 @@ func (context *DatabaseContext) RestartListener() error {
 }
 
 // Cache flush support.  Currently test-only - added for unit test access from rest package
-func (context *DatabaseContext) FlushChannelCache() error {
-	base.Infof(base.KeyCache, "Flushing channel cache")
-	return context.changeCache.Clear()
+func (dbCtx *DatabaseContext) FlushChannelCache() error {
+	base.InfofCtx(context.TODO(), base.KeyCache, "Flushing channel cache")
+	return dbCtx.changeCache.Clear()
 }
 
 // Removes previous versions of Sync Gateway's design docs found on the server
@@ -774,7 +774,7 @@ func (dc *DatabaseContext) TakeDbOffline(reason string) error {
 			msg = "Unable to take Database offline, another operation was already in progress. Please try again."
 		}
 
-		base.Infof(base.KeyCRUD, msg)
+		base.InfofCtx(context.TODO(), base.KeyCRUD, msg)
 		return base.HTTPErrorf(http.StatusServiceUnavailable, msg)
 	}
 }

--- a/db/database.go
+++ b/db/database.go
@@ -326,6 +326,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	)
 
 	dbContext.EventMgr = NewEventManager()
+	logCtx := context.TODO()
 
 	var err error
 	dbContext.sequences, err = newSequenceAllocator(bucket, dbContext.DbStats.Database())
@@ -429,7 +430,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	}
 
 	// Start DCP feed
-	base.InfofCtx(context.TODO(), base.KeyDCP, "Starting mutation feed on bucket %v due to either channel cache mode or doc tracking (auto-import)", base.MD(bucket.GetName()))
+	base.InfofCtx(logCtx, base.KeyDCP, "Starting mutation feed on bucket %v due to either channel cache mode or doc tracking (auto-import)", base.MD(bucket.GetName()))
 	cacheFeedStatsMap := dbContext.DbStats.Database().CacheFeedMapStats
 	err = dbContext.mutationListener.Start(bucket, cacheFeedStatsMap.Map)
 
@@ -477,12 +478,12 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 
 		for name, provider := range options.OIDCOptions.Providers {
 			if provider.Issuer == "" || provider.ClientID == "" {
-				base.WarnfCtx(context.TODO(), "Issuer and ClientID required for OIDC Provider - skipping provider %q", base.UD(name))
+				base.WarnfCtx(logCtx, "Issuer and ClientID required for OIDC Provider - skipping provider %q", base.UD(name))
 				continue
 			}
 
 			if provider.ValidationKey == nil {
-				base.WarnfCtx(context.TODO(), "Validation Key not defined in config for provider %q - auth code flow will not be supported for this provider", base.UD(name))
+				base.WarnfCtx(logCtx, "Validation Key not defined in config for provider %q - auth code flow will not be supported for this provider", base.UD(name))
 			}
 
 			if strings.Contains(name, "_") {
@@ -529,12 +530,12 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 		if ok {
 			serverPurgeInterval, err := cbStore.MetadataPurgeInterval()
 			if err != nil {
-				base.WarnfCtx(context.TODO(), "Unable to retrieve server's metadata purge interval - will use default value. %s", err)
+				base.WarnfCtx(logCtx, "Unable to retrieve server's metadata purge interval - will use default value. %s", err)
 			} else if serverPurgeInterval > 0 {
 				dbContext.PurgeInterval = serverPurgeInterval
 			}
 		}
-		base.InfofCtx(context.TODO(), base.KeyAll, "Using metadata purge interval of %.2f days for tombstone compaction.", dbContext.PurgeInterval.Hours()/24)
+		base.InfofCtx(logCtx, base.KeyAll, "Using metadata purge interval of %.2f days for tombstone compaction.", dbContext.PurgeInterval.Hours()/24)
 
 		if dbContext.Options.CompactInterval != 0 {
 			if autoImport {
@@ -551,7 +552,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 				}
 				db.backgroundTasks = append(db.backgroundTasks, bgt)
 			} else {
-				base.WarnfCtx(context.TODO(), "Automatic compaction can only be enabled on nodes running an Import process")
+				base.WarnfCtx(logCtx, "Automatic compaction can only be enabled on nodes running an Import process")
 			}
 		}
 

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -323,7 +323,7 @@ func InitializeViews(bucket base.Bucket) error {
 
 	// If not present, install design docs and views
 	if !ddocsExist {
-		base.Infof(base.KeyAll, "Design docs for current view version (%s) do not exist - creating...", DesignDocVersion)
+		base.InfofCtx(context.TODO(), base.KeyAll, "Design docs for current view version (%s) do not exist - creating...", DesignDocVersion)
 		if err := installViews(bucket); err != nil {
 			return err
 		}
@@ -343,7 +343,7 @@ func checkExistingDDocs(bucket base.Bucket) bool {
 	sgHousekeepingDDocExists := getDDocErr == nil
 
 	if sgDDocExists && sgHousekeepingDDocExists {
-		base.Infof(base.KeyAll, "Design docs for current SG view version (%s) found.", DesignDocVersion)
+		base.InfofCtx(context.TODO(), base.KeyAll, "Design docs for current SG view version (%s) found.", DesignDocVersion)
 		return true
 	}
 
@@ -581,7 +581,7 @@ func installViews(bucket base.Bucket) error {
 		}
 	}
 
-	base.Infof(base.KeyAll, "Design docs successfully created for view version %s.", DesignDocVersion)
+	base.InfofCtx(context.TODO(), base.KeyAll, "Design docs successfully created for view version %s.", DesignDocVersion)
 
 	return nil
 }
@@ -592,7 +592,7 @@ func WaitForViews(bucket base.Bucket) error {
 	views := []string{ViewChannels, ViewAccess, ViewRoleAccess}
 	viewErrors := make(chan error, len(views))
 
-	base.Infof(base.KeyAll, "Verifying view availability for bucket %s...", base.UD(bucket.GetName()))
+	base.InfofCtx(context.TODO(), base.KeyAll, "Verifying view availability for bucket %s...", base.UD(bucket.GetName()))
 
 	for _, viewName := range views {
 		viewsWg.Add(1)
@@ -612,7 +612,7 @@ func WaitForViews(bucket base.Bucket) error {
 		return err
 	}
 
-	base.Infof(base.KeyAll, "Views ready for bucket %s.", base.UD(bucket.GetName()))
+	base.InfofCtx(context.TODO(), base.KeyAll, "Views ready for bucket %s.", base.UD(bucket.GetName()))
 	return nil
 
 }
@@ -637,7 +637,7 @@ func waitForViewIndexing(bucket base.Bucket, ddocName string, viewName string) e
 
 		// Retry on timeout or undefined view errors , otherwise return the error
 		if err == base.ErrViewTimeoutError {
-			base.Infof(base.KeyAll, "Timeout waiting for view %q to be ready for bucket %q - retrying...", viewName, base.UD(bucket.GetName()))
+			base.InfofCtx(context.TODO(), base.KeyAll, "Timeout waiting for view %q to be ready for bucket %q - retrying...", viewName, base.UD(bucket.GetName()))
 		} else {
 			// For any other error, retry up to maxRetry, to wait for view initialization on the server
 			errRetryCount++

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -567,7 +568,7 @@ func installViews(bucket base.Bucket) error {
 		worker := func() (shouldRetry bool, err error, value interface{}) {
 			err = bucket.PutDDoc(designDocName, designDoc)
 			if err != nil {
-				base.Warnf("Error installing Couchbase design doc: %v", err)
+				base.WarnfCtx(context.TODO(), "Error installing Couchbase design doc: %v", err)
 			}
 			return err != nil, err, nil
 		}
@@ -643,7 +644,7 @@ func waitForViewIndexing(bucket base.Bucket, ddocName string, viewName string) e
 			if errRetryCount > maxRetry {
 				return err
 			}
-			base.Warnf("Error waiting for view %q to be ready for bucket %q - retrying...(%d/%d)", viewName, bucket.GetName(), errRetryCount, maxRetry)
+			base.WarnfCtx(context.TODO(), "Error waiting for view %q to be ready for bucket %q - retrying...(%d/%d)", viewName, bucket.GetName(), errRetryCount, maxRetry)
 			time.Sleep(time.Duration(retrySleep) * time.Millisecond)
 			retrySleep *= float64(1.5)
 		}
@@ -674,7 +675,7 @@ func removeObsoleteDesignDocs(bucket base.Bucket, previewOnly bool, useViews boo
 			if !previewOnly {
 				removeDDocErr := bucket.DeleteDDoc(ddocName)
 				if removeDDocErr != nil && !IsMissingDDocError(removeDDocErr) {
-					base.Warnf("Unexpected error when removing design doc %q: %s", ddocName, removeDDocErr)
+					base.WarnfCtx(context.TODO(), "Unexpected error when removing design doc %q: %s", ddocName, removeDDocErr)
 				}
 				// Only include in list of removedDesignDocs if it was actually removed
 				if removeDDocErr == nil {
@@ -683,7 +684,7 @@ func removeObsoleteDesignDocs(bucket base.Bucket, previewOnly bool, useViews boo
 			} else {
 				_, existsDDocErr := bucket.GetDDoc(ddocName)
 				if existsDDocErr != nil && !IsMissingDDocError(existsDDocErr) {
-					base.Warnf("Unexpected error when checking existence of design doc %q: %s", ddocName, existsDDocErr)
+					base.WarnfCtx(context.TODO(), "Unexpected error when checking existence of design doc %q: %s", ddocName, existsDDocErr)
 				}
 				// Only include in list of removedDesignDocs if it exists
 				if existsDDocErr == nil {

--- a/db/document.go
+++ b/db/document.go
@@ -256,14 +256,14 @@ func (doc *Document) Body() Body {
 	}
 
 	if doc._rawBody == nil {
-		base.Warnf("Null doc body/rawBody %s/%s from %s", base.UD(doc.ID), base.UD(doc.RevID), caller)
+		base.WarnfCtx(context.Background(), "Null doc body/rawBody %s/%s from %s", base.UD(doc.ID), base.UD(doc.RevID), caller)
 		return nil
 	}
 
 	base.Tracef(base.KeyAll, "        UNMARSHAL doc body %s/%s from %s", base.UD(doc.ID), base.UD(doc.RevID), caller)
 	err := doc._body.Unmarshal(doc._rawBody)
 	if err != nil {
-		base.Warnf("Unable to unmarshal document body from raw body : %s", err)
+		base.WarnfCtx(context.Background(), "Unable to unmarshal document body from raw body : %s", err)
 		return nil
 	}
 	return doc._body
@@ -313,7 +313,7 @@ func (doc *Document) BodyBytes() ([]byte, error) {
 	}
 
 	if doc._body == nil {
-		base.Warnf("Null doc body/rawBody %s/%s from %s", base.UD(doc.ID), base.UD(doc.RevID), caller)
+		base.WarnfCtx(context.Background(), "Null doc body/rawBody %s/%s from %s", base.UD(doc.ID), base.UD(doc.RevID), caller)
 		return nil, nil
 	}
 
@@ -688,7 +688,7 @@ func (doc *Document) getNonWinningRevisionBody(revid string, loader RevLoaderFun
 	}
 
 	if err := body.Unmarshal(bodyBytes); err != nil {
-		base.Warnf("Unexpected error parsing body of rev %q: %v", revid, err)
+		base.WarnfCtx(context.TODO(), "Unexpected error parsing body of rev %q: %v", revid, err)
 		return nil
 	}
 	return body
@@ -797,7 +797,7 @@ func (doc *Document) deleteRemovedRevisionBodies(bucket base.Bucket) {
 	for _, revBodyKey := range doc.removedRevisionBodyKeys {
 		deleteErr := bucket.Delete(revBodyKey)
 		if deleteErr != nil {
-			base.Warnf("Unable to delete old revision body using key %s - will not be deleted from bucket.", revBodyKey)
+			base.WarnfCtx(context.TODO(), "Unable to delete old revision body using key %s - will not be deleted from bucket.", revBodyKey)
 		}
 	}
 	doc.removedRevisionBodyKeys = map[string]string{}
@@ -820,7 +820,7 @@ func (doc *Document) migrateRevisionBodies(bucket base.Bucket) error {
 			bodyKey := generateRevBodyKey(doc.ID, revID)
 			persistErr := doc.persistRevisionBody(bucket, bodyKey, revInfo.Body)
 			if persistErr != nil {
-				base.Warnf("Unable to store revision body for doc %s, rev %s externally: %v", base.UD(doc.ID), revID, persistErr)
+				base.WarnfCtx(context.TODO(), "Unable to store revision body for doc %s, rev %s externally: %v", base.UD(doc.ID), revID, persistErr)
 				continue
 			}
 			revInfo.BodyKey = bodyKey
@@ -1118,7 +1118,7 @@ func (doc *Document) MarshalJSON() (data []byte, err error) {
 // lazy unmarshalling as needed.
 func (doc *Document) UnmarshalWithXattr(data []byte, xdata []byte, unmarshalLevel DocumentUnmarshalLevel) error {
 	if doc.ID == "" {
-		base.Warnf("Attempted to unmarshal document without ID set")
+		base.WarnfCtx(context.Background(), "Attempted to unmarshal document without ID set")
 		return errors.New("Document was unmarshalled without ID set")
 	}
 

--- a/db/document.go
+++ b/db/document.go
@@ -1054,7 +1054,7 @@ func (accessMap *UserAccessMap) updateAccess(doc *Document, newAccess channels.A
 		if accessMap == &doc.RoleAccess {
 			what = "role"
 		}
-		base.Infof(base.KeyAccess, "Doc %q grants %s access: %v", base.UD(doc.ID), what, base.UD(*accessMap))
+		base.InfofCtx(context.TODO(), base.KeyAccess, "Doc %q grants %s access: %v", base.UD(doc.ID), what, base.UD(*accessMap))
 	}
 	return changedUsers
 }

--- a/db/document.go
+++ b/db/document.go
@@ -251,7 +251,7 @@ func (doc *Document) Body() Body {
 	}
 
 	if doc._body != nil {
-		base.Tracef(base.KeyAll, "Already had doc body %s/%s from %s", base.UD(doc.ID), base.UD(doc.RevID), caller)
+		base.TracefCtx(context.Background(), base.KeyAll, "Already had doc body %s/%s from %s", base.UD(doc.ID), base.UD(doc.RevID), caller)
 		return doc._body
 	}
 
@@ -260,7 +260,7 @@ func (doc *Document) Body() Body {
 		return nil
 	}
 
-	base.Tracef(base.KeyAll, "        UNMARSHAL doc body %s/%s from %s", base.UD(doc.ID), base.UD(doc.RevID), caller)
+	base.TracefCtx(context.Background(), base.KeyAll, "        UNMARSHAL doc body %s/%s from %s", base.UD(doc.ID), base.UD(doc.RevID), caller)
 	err := doc._body.Unmarshal(doc._rawBody)
 	if err != nil {
 		base.WarnfCtx(context.Background(), "Unable to unmarshal document body from raw body : %s", err)

--- a/db/event.go
+++ b/db/event.go
@@ -177,12 +177,12 @@ func (ef *JSEventFunction) CallFunction(event Event) (interface{}, error) {
 	case *DBStateChangeEvent:
 		result, err = ef.Call(event.Doc)
 	default:
-		base.Warnf("unknown event %v tried to call function", event.EventType())
+		base.WarnfCtx(context.TODO(), "unknown event %v tried to call function", event.EventType())
 		return "", fmt.Errorf("unknown event %v tried to call function", event.EventType())
 	}
 
 	if err != nil {
-		base.Warnf("Error calling function - function processing aborted: %v", err)
+		base.WarnfCtx(context.TODO(), "Error calling function - function processing aborted: %v", err)
 		return "", err
 	}
 
@@ -207,7 +207,7 @@ func (ef *JSEventFunction) CallValidateFunction(event Event) (bool, error) {
 		}
 		return boolResult, nil
 	default:
-		base.Warnf("Event validate function returned non-boolean result %T %v", result, result)
+		base.WarnfCtx(context.TODO(), "Event validate function returned non-boolean result %T %v", result, result)
 		return false, errors.New("Validate function returned non-boolean value.")
 	}
 

--- a/db/event.go
+++ b/db/event.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -113,8 +114,10 @@ type jsEventTask struct {
 func newJsEventTask(funcSource string) (sgbucket.JSServerTask, error) {
 	eventTask := &jsEventTask{}
 	err := eventTask.InitWithLogging(funcSource,
-		func(s string) { base.Errorf(base.KeyJavascript.String()+": Webhook %s", base.UD(s)) },
-		func(s string) { base.Infof(base.KeyJavascript, "Webhook %s", base.UD(s)) })
+		func(s string) {
+			base.ErrorfCtx(context.Background(), base.KeyJavascript.String()+": Webhook %s", base.UD(s))
+		},
+		func(s string) { base.InfofCtx(context.Background(), base.KeyJavascript, "Webhook %s", base.UD(s)) })
 	if err != nil {
 		return nil, err
 	}

--- a/db/event.go
+++ b/db/event.go
@@ -154,7 +154,7 @@ type JSEventFunction struct {
 
 func NewJSEventFunction(fnSource string) *JSEventFunction {
 
-	base.Infof(base.KeyEvents, "Creating new JSEventFunction")
+	base.InfofCtx(context.Background(), base.KeyEvents, "Creating new JSEventFunction")
 	return &JSEventFunction{
 		JSServer: sgbucket.NewJSServer(fnSource, kTaskCacheSize,
 			func(fnSource string) (sgbucket.JSServerTask, error) {

--- a/db/event_handler.go
+++ b/db/event_handler.go
@@ -92,6 +92,7 @@ func (wh *Webhook) HandleEvent(event Event) bool {
 
 	const contentType = "application/json"
 	var payload []byte
+	logCtx := context.TODO()
 
 	// Different events post different content by default
 	switch event := event.(type) {
@@ -112,12 +113,12 @@ func (wh *Webhook) HandleEvent(event Event) bool {
 		//}
 		jsonOut, err := base.JSONMarshal(event.Doc)
 		if err != nil {
-			base.WarnfCtx(context.TODO(), "Error marshalling doc for webhook post")
+			base.WarnfCtx(logCtx, "Error marshalling doc for webhook post")
 			return false
 		}
 		payload = jsonOut
 	default:
-		base.WarnfCtx(context.TODO(), "Webhook invoked for unsupported event type.")
+		base.WarnfCtx(logCtx, "Webhook invoked for unsupported event type.")
 		return false
 	}
 
@@ -125,7 +126,7 @@ func (wh *Webhook) HandleEvent(event Event) bool {
 		// If filter function is defined, use it to determine whether to post
 		success, err := wh.filter.CallValidateFunction(event)
 		if err != nil {
-			base.WarnfCtx(context.TODO(), "Error calling webhook filter function: %v", err)
+			base.WarnfCtx(logCtx, "Error calling webhook filter function: %v", err)
 		}
 
 		// If filter returns false, cancel webhook post
@@ -141,23 +142,23 @@ func (wh *Webhook) HandleEvent(event Event) bool {
 			if resp != nil && resp.Body != nil {
 				_, err := io.Copy(ioutil.Discard, resp.Body)
 				if err != nil {
-					base.Debugf(base.KeyEvents, "Error copying response body: %v", err)
+					base.DebugfCtx(logCtx, base.KeyEvents, "Error copying response body: %v", err)
 				}
 				err = resp.Body.Close()
 				if err != nil {
-					base.Debugf(base.KeyEvents, "Error closing response body: %v", err)
+					base.DebugfCtx(logCtx, base.KeyEvents, "Error closing response body: %v", err)
 				}
 			}
 		}()
 
 		if err != nil {
-			base.WarnfCtx(context.TODO(), "Error attempting to post %s to url %s: %s", base.UD(event.String()), base.UD(wh.SanitizedUrl()), err)
+			base.WarnfCtx(logCtx, "Error attempting to post %s to url %s: %s", base.UD(event.String()), base.UD(wh.SanitizedUrl()), err)
 			return false
 		}
 
 		// Check Log Level first, as SanitizedUrl is expensive to evaluate.
 		if base.LogDebugEnabled(base.KeyEvents) {
-			base.Debugf(base.KeyEvents, "Webhook handler ran for event.  Payload %s posted to URL %s, got status %s",
+			base.DebugfCtx(logCtx, base.KeyEvents, "Webhook handler ran for event.  Payload %s posted to URL %s, got status %s",
 				base.UD(string(payload)), base.UD(wh.SanitizedUrl()), resp.Status)
 		}
 		return true

--- a/db/event_handler.go
+++ b/db/event_handler.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -111,12 +112,12 @@ func (wh *Webhook) HandleEvent(event Event) bool {
 		//}
 		jsonOut, err := base.JSONMarshal(event.Doc)
 		if err != nil {
-			base.Warnf("Error marshalling doc for webhook post")
+			base.WarnfCtx(context.TODO(), "Error marshalling doc for webhook post")
 			return false
 		}
 		payload = jsonOut
 	default:
-		base.Warnf("Webhook invoked for unsupported event type.")
+		base.WarnfCtx(context.TODO(), "Webhook invoked for unsupported event type.")
 		return false
 	}
 
@@ -124,7 +125,7 @@ func (wh *Webhook) HandleEvent(event Event) bool {
 		// If filter function is defined, use it to determine whether to post
 		success, err := wh.filter.CallValidateFunction(event)
 		if err != nil {
-			base.Warnf("Error calling webhook filter function: %v", err)
+			base.WarnfCtx(context.TODO(), "Error calling webhook filter function: %v", err)
 		}
 
 		// If filter returns false, cancel webhook post
@@ -150,7 +151,7 @@ func (wh *Webhook) HandleEvent(event Event) bool {
 		}()
 
 		if err != nil {
-			base.Warnf("Error attempting to post %s to url %s: %s", base.UD(event.String()), base.UD(wh.SanitizedUrl()), err)
+			base.WarnfCtx(context.TODO(), "Error attempting to post %s to url %s: %s", base.UD(event.String()), base.UD(wh.SanitizedUrl()), err)
 			return false
 		}
 

--- a/db/event_manager.go
+++ b/db/event_manager.go
@@ -112,7 +112,7 @@ func (em *EventManager) ProcessEvent(event Event) {
 			} else {
 				em.IncrementEventsProcessedFail(1)
 			}
-			base.Tracef(base.KeyAll, "Webhook event processed %s", event)
+			base.TracefCtx(logCtx, base.KeyAll, "Webhook event processed %s", event)
 
 		}(event, handler)
 	}
@@ -141,7 +141,7 @@ func (em *EventManager) raiseEvent(event Event) error {
 		defer timer.Stop()
 		select {
 		case em.asyncEventChannel <- event:
-			base.Tracef(base.KeyAll, "Event sent to channel %s", event.String())
+			base.TracefCtx(context.TODO(), base.KeyAll, "Event sent to channel %s", event.String())
 		case <-timer.C:
 			// Event queue channel is full - ignore event and log error
 			base.WarnfCtx(context.TODO(), "Event queue full - discarding event: %s", base.UD(event.String()))

--- a/db/event_manager.go
+++ b/db/event_manager.go
@@ -73,7 +73,7 @@ func (em *EventManager) Start(maxProcesses uint, waitTime int) {
 		em.waitTime = waitTime
 	}
 
-	base.Infof(base.KeyEvents, "Starting event manager with max processes:%d, wait time:%d ms", maxProcesses, em.waitTime)
+	base.InfofCtx(context.TODO(), base.KeyEvents, "Starting event manager with max processes:%d, wait time:%d ms", maxProcesses, em.waitTime)
 	// activeCountChannel limits the number of concurrent events being processed
 	em.activeCountChannel = make(chan bool, maxProcesses)
 
@@ -123,7 +123,7 @@ func (em *EventManager) ProcessEvent(event Event) {
 func (em *EventManager) RegisterEventHandler(handler EventHandler, eventType EventType) {
 	em.eventHandlers[eventType] = append(em.eventHandlers[eventType], handler)
 	em.activeEventTypes[eventType] = true
-	base.Infof(base.KeyEvents, "Registered event handler: %v, for event type %v", handler, eventType)
+	base.InfofCtx(context.Background(), base.KeyEvents, "Registered event handler: %v, for event type %v", handler, eventType)
 }
 
 // Checks whether a handler of the given type has been registered to the event manager.

--- a/db/event_manager.go
+++ b/db/event_manager.go
@@ -96,11 +96,12 @@ func (em *EventManager) Start(maxProcesses uint, waitTime int) {
 // Concurrent processing of all async event handlers registered for the event type
 func (em *EventManager) ProcessEvent(event Event) {
 	defer func() { <-em.activeCountChannel }()
+	logCtx := context.TODO()
 	// Send event to all registered handlers concurrently.  WaitGroup blocks
 	// until all are finished
 	var wg sync.WaitGroup
 	for _, handler := range em.eventHandlers[event.EventType()] {
-		base.Debugf(base.KeyEvents, "Event queue worker sending event %s to: %s", base.UD(event.String()), handler)
+		base.DebugfCtx(logCtx, base.KeyEvents, "Event queue worker sending event %s to: %s", base.UD(event.String()), handler)
 		wg.Add(1)
 		go func(event Event, handler EventHandler) {
 			defer wg.Done()

--- a/db/event_manager.go
+++ b/db/event_manager.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"sync/atomic"
@@ -142,7 +143,7 @@ func (em *EventManager) raiseEvent(event Event) error {
 			base.Tracef(base.KeyAll, "Event sent to channel %s", event.String())
 		case <-timer.C:
 			// Event queue channel is full - ignore event and log error
-			base.Warnf("Event queue full - discarding event: %s", base.UD(event.String()))
+			base.WarnfCtx(context.TODO(), "Event queue full - discarding event: %s", base.UD(event.String()))
 			return errors.New("Event queue full")
 		}
 	}

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -353,7 +353,7 @@ func (em *EventManager) waitForProcessedTotal(ctx context.Context, waitCount int
 	worker := func() (bool, error, interface{}) {
 		eventTotal := em.GetEventsProcessedSuccess() + em.GetEventsProcessedFail()
 		if eventTotal >= int64(waitCount) {
-			base.Debugf(base.KeyAll, "waitForProcessedTotal(%d) took %v", waitCount, time.Since(startTime))
+			base.DebugfCtx(ctx, base.KeyAll, "waitForProcessedTotal(%d) took %v", waitCount, time.Since(startTime))
 			return false, nil, nil
 		}
 

--- a/db/import.go
+++ b/db/import.go
@@ -460,8 +460,10 @@ type jsImportFilterRunner struct {
 func newImportFilterRunner(funcSource string) (sgbucket.JSServerTask, error) {
 	importFilterRunner := &jsEventTask{}
 	err := importFilterRunner.InitWithLogging(funcSource,
-		func(s string) { base.Errorf(base.KeyJavascript.String()+": Import %s", base.UD(s)) },
-		func(s string) { base.Infof(base.KeyJavascript, "Import %s", base.UD(s)) })
+		func(s string) {
+			base.ErrorfCtx(context.Background(), base.KeyJavascript.String()+": Import %s", base.UD(s))
+		},
+		func(s string) { base.InfofCtx(context.Background(), base.KeyJavascript, "Import %s", base.UD(s)) })
 	if err != nil {
 		return nil, err
 	}

--- a/db/import.go
+++ b/db/import.go
@@ -482,7 +482,7 @@ type ImportFilterFunction struct {
 
 func NewImportFilterFunction(fnSource string) *ImportFilterFunction {
 
-	base.Debugf(base.KeyImport, "Creating new ImportFilterFunction")
+	base.DebugfCtx(context.Background(), base.KeyImport, "Creating new ImportFilterFunction")
 	return &ImportFilterFunction{
 		JSServer: sgbucket.NewJSServer(fnSource, kTaskCacheSize,
 			func(fnSource string) (sgbucket.JSServerTask, error) {

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -41,7 +41,7 @@ func NewImportListener(groupID string) *importListener {
 // Writes DCP stats into the StatKeyImportDcpStats map
 func (il *importListener) StartImportFeed(bucket base.Bucket, dbStats *base.DbStats, dbContext *DatabaseContext) (err error) {
 
-	base.Infof(base.KeyDCP, "Attempting to start import DCP feed...")
+	base.InfofCtx(context.TODO(), base.KeyDCP, "Attempting to start import DCP feed...")
 
 	il.bucketName = bucket.GetName()
 	il.database = Database{DatabaseContext: dbContext, user: nil}
@@ -60,7 +60,7 @@ func (il *importListener) StartImportFeed(bucket base.Bucket, dbStats *base.DbSt
 	base.StoreDestFactory(base.ImportDestKey(il.database.Name), il.NewImportDest)
 
 	// Start DCP mutation feed
-	base.Infof(base.KeyDCP, "Starting DCP import feed for bucket: %q ", base.UD(bucket.GetName()))
+	base.InfofCtx(context.TODO(), base.KeyDCP, "Starting DCP import feed for bucket: %q ", base.UD(bucket.GetName()))
 
 	// TODO: need to clean up StartDCPFeed to push bucket dependencies down
 	cbStore, ok := base.AsCouchbaseStore(bucket)
@@ -141,7 +141,7 @@ func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
 		// last attempt to exit processing if the importListener has been closed before attempting to write to the bucket
 		select {
 		case <-il.terminator:
-			base.Infof(base.KeyImport, "Aborting import for doc %q - importListener.terminator was closed", base.UD(docID))
+			base.InfofCtx(context.TODO(), base.KeyImport, "Aborting import for doc %q - importListener.terminator was closed", base.UD(docID))
 			return
 		default:
 		}

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"context"
 	"strings"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -115,7 +116,7 @@ func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
 	if err != nil {
 		base.Debugf(base.KeyImport, "Found sync metadata, but unable to unmarshal for feed document %q.  Will not be imported.  Error: %v", base.UD(event.Key), err)
 		if err == base.ErrEmptyMetadata {
-			base.Warnf("Unexpected empty metadata when processing feed event.  docid: %s opcode: %v datatype:%v", base.UD(event.Key), event.Opcode, event.DataType)
+			base.WarnfCtx(context.TODO(), "Unexpected empty metadata when processing feed event.  docid: %s opcode: %v datatype:%v", base.UD(event.Key), event.Opcode, event.DataType)
 		}
 		return
 	}

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -96,7 +96,7 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) (shouldPers
 
 	// If this is a delete and there are no xattrs (no existing SG revision), we shouldn't import
 	if event.Opcode == sgbucket.FeedOpDeletion && len(event.Value) == 0 {
-		base.Debugf(base.KeyImport, "Ignoring delete mutation for %s - no existing Sync Gateway metadata.", base.UD(event.Key))
+		base.DebugfCtx(context.TODO(), base.KeyImport, "Ignoring delete mutation for %s - no existing Sync Gateway metadata.", base.UD(event.Key))
 		return true
 	}
 
@@ -110,13 +110,14 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) (shouldPers
 }
 
 func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
+	logCtx := context.TODO()
 
 	// Unmarshal the doc metadata (if present) to determine if this mutation requires import.
 	syncData, rawBody, rawXattr, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(event.Value, event.DataType, il.database.Options.UserXattrKey, false)
 	if err != nil {
-		base.Debugf(base.KeyImport, "Found sync metadata, but unable to unmarshal for feed document %q.  Will not be imported.  Error: %v", base.UD(event.Key), err)
+		base.DebugfCtx(logCtx, base.KeyImport, "Found sync metadata, but unable to unmarshal for feed document %q.  Will not be imported.  Error: %v", base.UD(event.Key), err)
 		if err == base.ErrEmptyMetadata {
-			base.WarnfCtx(context.TODO(), "Unexpected empty metadata when processing feed event.  docid: %s opcode: %v datatype:%v", base.UD(event.Key), event.Opcode, event.DataType)
+			base.WarnfCtx(logCtx, "Unexpected empty metadata when processing feed event.  docid: %s opcode: %v datatype:%v", base.UD(event.Key), event.Opcode, event.DataType)
 		}
 		return
 	}
@@ -141,7 +142,7 @@ func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
 		// last attempt to exit processing if the importListener has been closed before attempting to write to the bucket
 		select {
 		case <-il.terminator:
-			base.InfofCtx(context.TODO(), base.KeyImport, "Aborting import for doc %q - importListener.terminator was closed", base.UD(docID))
+			base.InfofCtx(logCtx, base.KeyImport, "Aborting import for doc %q - importListener.terminator was closed", base.UD(docID))
 			return
 		default:
 		}
@@ -149,11 +150,11 @@ func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
 		_, err := il.database.ImportDocRaw(docID, rawBody, rawXattr, rawUserXattr, isDelete, event.Cas, &event.Expiry, ImportFromFeed)
 		if err != nil {
 			if err == base.ErrImportCasFailure {
-				base.Debugf(base.KeyImport, "Not importing mutation - document %s has been subsequently updated and will be imported based on that mutation.", base.UD(docID))
+				base.DebugfCtx(logCtx, base.KeyImport, "Not importing mutation - document %s has been subsequently updated and will be imported based on that mutation.", base.UD(docID))
 			} else if err == base.ErrImportCancelledFilter {
 				// No logging required - filter info already logged during importDoc
 			} else {
-				base.Debugf(base.KeyImport, "Did not import doc %q - external update will not be accessible via Sync Gateway.  Reason: %v", base.UD(docID), err)
+				base.DebugfCtx(logCtx, base.KeyImport, "Did not import doc %q - external update will not be accessible via Sync Gateway.  Reason: %v", base.UD(docID), err)
 			}
 		}
 	}
@@ -169,7 +170,7 @@ func (il *importListener) Stop() {
 			for _, pIndex := range pindexes {
 				err := il.cbgtContext.Manager.ClosePIndex(pIndex)
 				if err != nil {
-					base.Debugf(base.KeyImport, "Error closing pindex: %v", err)
+					base.DebugfCtx(context.TODO(), base.KeyImport, "Error closing pindex: %v", err)
 				}
 			}
 			// ClosePIndex calls are synchronous, so can stop manager once they've completed

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -61,7 +62,7 @@ func NewImportPIndexImpl(indexType, indexParams, path string, restart func()) (c
 
 	importDest, err := getListenerImportDest(indexParams)
 	if err != nil {
-		base.Errorf("Error creating NewImportDest during NewImportPIndexImpl: %v", err)
+		base.ErrorfCtx(context.TODO(), "Error creating NewImportDest during NewImportPIndexImpl: %v", err)
 	}
 	return nil, importDest, err
 }

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -28,7 +28,7 @@ func RegisterImportPindexImpl(configGroup string) {
 	// config group scoped.  The associated importListener within the context is retrieved based on the
 	// dbname in the index params
 	pIndexType := base.CBGTIndexTypeSyncGatewayImport + configGroup
-	base.Infof(base.KeyDCP, "Registering PindexImplType for %s", pIndexType)
+	base.InfofCtx(context.TODO(), base.KeyDCP, "Registering PindexImplType for %s", pIndexType)
 	cbgt.RegisterPIndexImplType(pIndexType,
 		&cbgt.PIndexImplType{
 			New:       NewImportPIndexImpl,

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -331,7 +331,7 @@ func waitForIndexes(bucket base.N1QLStore, useXattrs bool) error {
 			indexesWg.Add(1)
 			go func(index SGIndex) {
 				defer indexesWg.Done()
-				base.Debugf(base.KeyQuery, "Verifying index availability for index %s...", base.MD(index.fullIndexName(useXattrs)))
+				base.DebugfCtx(logCtx, base.KeyQuery, "Verifying index availability for index %s...", base.MD(index.fullIndexName(useXattrs)))
 				queryStatement := index.readinessQuery
 				if index.simpleName == QueryTypeChannels {
 					queryStatement = replaceActiveOnlyFilter(queryStatement, false)
@@ -343,7 +343,7 @@ func waitForIndexes(bucket base.N1QLStore, useXattrs bool) error {
 					base.WarnfCtx(logCtx, "Query error for statement [%s], err:%v", queryStatement, queryErr)
 					indexErrors <- queryErr
 				}
-				base.Debugf(base.KeyQuery, "Index %s verified as ready", base.MD(index.fullIndexName(useXattrs)))
+				base.DebugfCtx(logCtx, base.KeyQuery, "Index %s verified as ready", base.MD(index.fullIndexName(useXattrs)))
 			}(sgIndex)
 		}
 	}

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -222,7 +222,7 @@ func (i *SGIndex) createIfNeeded(bucket base.N1QLStore, useXattrs bool, numRepli
 			//  2. SG previously crashed between index creation and index build.
 			// GSI doesn't like concurrent build requests, so wait and recheck index state before treating as option 2.
 			// (see known issue documented https://developer.couchbase.com/documentation/server/current/n1ql/n1ql-language-reference/build-index.html)
-			base.Infof(base.KeyQuery, "Index %s already in deferred state - waiting 10s to re-evaluate before issuing build to avoid concurrent build requests.", indexName)
+			base.InfofCtx(context.TODO(), base.KeyQuery, "Index %s already in deferred state - waiting 10s to re-evaluate before issuing build to avoid concurrent build requests.", indexName)
 			time.Sleep(10 * time.Second)
 			exists, indexMeta, metaErr = bucket.GetIndexMeta(indexName)
 			if metaErr != nil || indexMeta == nil {
@@ -235,8 +235,10 @@ func (i *SGIndex) createIfNeeded(bucket base.N1QLStore, useXattrs bool, numRepli
 		return false, nil
 	}
 
+	logCtx := context.TODO()
+
 	// Create index
-	base.Infof(base.KeyQuery, "Index %s doesn't exist, creating...", indexName)
+	base.InfofCtx(logCtx, base.KeyQuery, "Index %s doesn't exist, creating...", indexName)
 	isDeferred = true
 	indexExpression := replaceSyncTokensIndex(i.expression, useXattrs)
 	filterExpression := replaceSyncTokensIndex(i.filterExpression, useXattrs)
@@ -262,7 +264,7 @@ func (i *SGIndex) createIfNeeded(bucket base.N1QLStore, useXattrs bool, numRepli
 			if strings.Contains(err.Error(), "not enough indexer nodes") {
 				return false, fmt.Errorf("Unable to create indexes with the specified number of replicas (%d).  Increase the number of index nodes, or modify 'num_index_replicas' in your Sync Gateway database config.", numReplica), nil
 			}
-			base.WarnfCtx(context.TODO(), "Error creating index %s: %v - will retry.", indexName, err)
+			base.WarnfCtx(logCtx, "Error creating index %s: %v - will retry.", indexName, err)
 		}
 		return err != nil, err, nil
 	}
@@ -274,14 +276,14 @@ func (i *SGIndex) createIfNeeded(bucket base.N1QLStore, useXattrs bool, numRepli
 		return false, pkgerrors.Wrapf(err, "Error installing Couchbase index: %v", indexName)
 	}
 
-	base.Infof(base.KeyQuery, "Index %s created successfully", indexName)
+	base.InfofCtx(logCtx, base.KeyQuery, "Index %s created successfully", indexName)
 	return isDeferred, nil
 }
 
 // Initializes Sync Gateway indexes for bucket.  Creates required indexes if not found, then waits for index readiness.
 func InitializeIndexes(bucket base.N1QLStore, useXattrs bool, numReplicas uint) error {
 
-	base.Infof(base.KeyAll, "Initializing indexes with numReplicas: %d...", numReplicas)
+	base.InfofCtx(context.TODO(), base.KeyAll, "Initializing indexes with numReplicas: %d...", numReplicas)
 
 	// Create any indexes that aren't present
 	deferredIndexes := make([]string, 0)
@@ -303,7 +305,7 @@ func InitializeIndexes(bucket base.N1QLStore, useXattrs bool, numReplicas uint) 
 	if len(deferredIndexes) > 0 {
 		buildErr := bucket.BuildDeferredIndexes(deferredIndexes)
 		if buildErr != nil {
-			base.Infof(base.KeyQuery, "Error building deferred indexes.  Error: %v", buildErr)
+			base.InfofCtx(context.TODO(), base.KeyQuery, "Error building deferred indexes.  Error: %v", buildErr)
 			return buildErr
 		}
 	}
@@ -320,7 +322,8 @@ func InitializeIndexes(bucket base.N1QLStore, useXattrs bool, numReplicas uint) 
 // Issue a consistency=request_plus query against critical indexes to guarantee indexing is complete and indexes are ready.
 func waitForIndexes(bucket base.N1QLStore, useXattrs bool) error {
 	var indexesWg sync.WaitGroup
-	base.Infof(base.KeyAll, "Verifying index availability for bucket %s...", base.MD(bucket.GetName()))
+	logCtx := context.TODO()
+	base.InfofCtx(logCtx, base.KeyAll, "Verifying index availability for bucket %s...", base.MD(bucket.GetName()))
 	indexErrors := make(chan error, len(sgIndexes))
 
 	for _, sgIndex := range sgIndexes {
@@ -337,7 +340,7 @@ func waitForIndexes(bucket base.N1QLStore, useXattrs bool) error {
 				queryStatement = replaceIndexTokensQuery(queryStatement, index, useXattrs)
 				queryErr := waitForIndex(bucket, index.fullIndexName(useXattrs), queryStatement)
 				if queryErr != nil {
-					base.WarnfCtx(context.TODO(), "Query error for statement [%s], err:%v", queryStatement, queryErr)
+					base.WarnfCtx(logCtx, "Query error for statement [%s], err:%v", queryStatement, queryErr)
 					indexErrors <- queryErr
 				}
 				base.Debugf(base.KeyQuery, "Index %s verified as ready", base.MD(index.fullIndexName(useXattrs)))
@@ -352,13 +355,15 @@ func waitForIndexes(bucket base.N1QLStore, useXattrs bool) error {
 		return err
 	}
 
-	base.Infof(base.KeyAll, "Indexes ready for bucket %s.", base.MD(bucket.GetName()))
+	base.InfofCtx(logCtx, base.KeyAll, "Indexes ready for bucket %s.", base.MD(bucket.GetName()))
 	return nil
 }
 
 // Issues adhoc consistency=request_plus query to determine if specified index is ready.
 // Retries indefinitely on timeout, backoff retry on all other errors.
 func waitForIndex(bucket base.N1QLStore, indexName string, queryStatement string) error {
+
+	logCtx := context.TODO()
 
 	// For non-timeout errors, backoff retry up to ~15m, to handle large initial indexing times
 	retrySleeper := base.CreateMaxDoublingSleeperFunc(180, 100, 5000)
@@ -370,7 +375,7 @@ func waitForIndex(bucket base.N1QLStore, indexName string, queryStatement string
 		if resultSet != nil {
 			resultSetCloseError := resultSet.Close()
 			if resultSetCloseError != nil {
-				base.Infof(base.KeyAll, "Failed to close query results when verifying index %q availability for bucket %q", base.MD(indexName), base.MD(bucket.GetName()))
+				base.InfofCtx(logCtx, base.KeyAll, "Failed to close query results when verifying index %q availability for bucket %q", base.MD(indexName), base.MD(bucket.GetName()))
 			}
 		}
 
@@ -379,9 +384,9 @@ func waitForIndex(bucket base.N1QLStore, indexName string, queryStatement string
 		}
 
 		if resultsError == base.ErrViewTimeoutError {
-			base.Infof(base.KeyAll, "Timeout waiting for index %q to be ready for bucket %q - retrying...", base.MD(indexName), base.MD(bucket.GetName()))
+			base.InfofCtx(logCtx, base.KeyAll, "Timeout waiting for index %q to be ready for bucket %q - retrying...", base.MD(indexName), base.MD(bucket.GetName()))
 		} else {
-			base.Infof(base.KeyAll, "Error waiting for index %q to be ready for bucket %q - retrying...", base.MD(indexName), base.MD(bucket.GetName()))
+			base.InfofCtx(logCtx, base.KeyAll, "Error waiting for index %q to be ready for bucket %q - retrying...", base.MD(indexName), base.MD(bucket.GetName()))
 			retryCount++
 			shouldContinue, sleepMs := retrySleeper(retryCount)
 			if !shouldContinue {

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -261,7 +262,7 @@ func (i *SGIndex) createIfNeeded(bucket base.N1QLStore, useXattrs bool, numRepli
 			if strings.Contains(err.Error(), "not enough indexer nodes") {
 				return false, fmt.Errorf("Unable to create indexes with the specified number of replicas (%d).  Increase the number of index nodes, or modify 'num_index_replicas' in your Sync Gateway database config.", numReplica), nil
 			}
-			base.Warnf("Error creating index %s: %v - will retry.", indexName, err)
+			base.WarnfCtx(context.TODO(), "Error creating index %s: %v - will retry.", indexName, err)
 		}
 		return err != nil, err, nil
 	}
@@ -336,7 +337,7 @@ func waitForIndexes(bucket base.N1QLStore, useXattrs bool) error {
 				queryStatement = replaceIndexTokensQuery(queryStatement, index, useXattrs)
 				queryErr := waitForIndex(bucket, index.fullIndexName(useXattrs), queryStatement)
 				if queryErr != nil {
-					base.Warnf("Query error for statement [%s], err:%v", queryStatement, queryErr)
+					base.WarnfCtx(context.TODO(), "Query error for statement [%s], err:%v", queryStatement, queryErr)
 					indexErrors <- queryErr
 				}
 				base.Debugf(base.KeyQuery, "Index %s verified as ready", base.MD(index.fullIndexName(useXattrs)))
@@ -423,7 +424,7 @@ func removeObsoleteIndexes(bucket base.N1QLStore, previewOnly bool, useXattrs bo
 	for _, indexName := range removalCandidates {
 		removed, err := removeObsoleteIndex(bucket, indexName, previewOnly)
 		if err != nil {
-			base.Warnf("Unexpected error when removing index %q: %s", indexName, err)
+			base.WarnfCtx(context.TODO(), "Unexpected error when removing index %q: %s", indexName, err)
 		}
 		if removed {
 			removedIndexes = append(removedIndexes, indexName)

--- a/db/query.go
+++ b/db/query.go
@@ -324,7 +324,7 @@ func (context *DatabaseContext) QueryRoleAccess(ctx context.Context, username st
 
 	// N1QL Query
 	if username == "" {
-		base.Warnf("QueryRoleAccess called with empty username")
+		base.WarnfCtx(ctx, "QueryRoleAccess called with empty username")
 		return &EmptyResultIterator{}, nil
 	}
 

--- a/db/repair_bucket.go
+++ b/db/repair_bucket.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"context"
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -139,8 +140,9 @@ This is how the view is iterated:
 */
 func (r RepairBucket) RepairBucket() (results []RepairBucketResult, err error) {
 
-	base.Infof(base.KeyCRUD, "RepairBucket() invoked")
-	defer base.Infof(base.KeyCRUD, "RepairBucket() finished")
+	logCtx := context.TODO()
+	base.InfofCtx(logCtx, base.KeyCRUD, "RepairBucket() invoked")
+	defer base.InfofCtx(logCtx, base.KeyCRUD, "RepairBucket() finished")
 
 	startKey := ""
 	results = []RepairBucketResult{}
@@ -155,9 +157,9 @@ func (r RepairBucket) RepairBucket() (results []RepairBucketResult, err error) {
 		}
 		options["limit"] = r.ViewQueryPageSize
 
-		base.Infof(base.KeyCRUD, "RepairBucket() querying view with options: %+v", options)
+		base.InfofCtx(logCtx, base.KeyCRUD, "RepairBucket() querying view with options: %+v", options)
 		vres, err := r.Bucket.View(DesignDocSyncHousekeeping(), ViewImport, options)
-		base.Infof(base.KeyCRUD, "RepairBucket() queried view and got %d results", len(vres.Rows))
+		base.InfofCtx(logCtx, base.KeyCRUD, "RepairBucket() queried view and got %d results", len(vres.Rows))
 		if err != nil {
 			// TODO: Maybe we could retry if the view timed out (as seen in #3267)
 			return results, err
@@ -210,9 +212,9 @@ func (r RepairBucket) RepairBucket() (results []RepairBucketResult, err error) {
 
 					backupOrDryRunDocId, err = r.WriteRepairedDocsToBucket(key, currentValue, updatedDoc)
 					if err != nil {
-						base.Infof(base.KeyCRUD, "Repair Doc (dry_run=%v) Writing docs to bucket failed with error: %v.  Dumping raw contents.", r.DryRun, err)
-						base.Infof(base.KeyCRUD, "Original Doc before repair: %s", base.UD(currentValue))
-						base.Infof(base.KeyCRUD, "Updated doc after repair: %s", base.UD(updatedDoc))
+						base.InfofCtx(logCtx, base.KeyCRUD, "Repair Doc (dry_run=%v) Writing docs to bucket failed with error: %v.  Dumping raw contents.", r.DryRun, err)
+						base.InfofCtx(logCtx, base.KeyCRUD, "Original Doc before repair: %s", base.UD(currentValue))
+						base.InfofCtx(logCtx, base.KeyCRUD, "Updated doc after repair: %s", base.UD(updatedDoc))
 					}
 
 					result := RepairBucketResult{
@@ -244,9 +246,9 @@ func (r RepairBucket) RepairBucket() (results []RepairBucketResult, err error) {
 
 			if backupOrDryRunDocId != "" {
 				if r.DryRun {
-					base.Infof(base.KeyCRUD, "Repair Doc: dry run result available in Bucket Doc: %v (auto-deletes in 24 hours)", base.UD(backupOrDryRunDocId))
+					base.InfofCtx(logCtx, base.KeyCRUD, "Repair Doc: dry run result available in Bucket Doc: %v (auto-deletes in 24 hours)", base.UD(backupOrDryRunDocId))
 				} else {
-					base.Infof(base.KeyCRUD, "Repair Doc: Doc repaired, original doc backed up in Bucket Doc: %v (auto-deletes in 24 hours)", base.UD(backupOrDryRunDocId))
+					base.InfofCtx(logCtx, base.KeyCRUD, "Repair Doc: Doc repaired, original doc backed up in Bucket Doc: %v (auto-deletes in 24 hours)", base.UD(backupOrDryRunDocId))
 				}
 			}
 
@@ -254,7 +256,7 @@ func (r RepairBucket) RepairBucket() (results []RepairBucketResult, err error) {
 
 		numDocsProcessed += numResultsProcessed
 
-		base.Infof(base.KeyCRUD, "RepairBucket() processed %d / %d", numDocsProcessed, vres.TotalRows)
+		base.InfofCtx(logCtx, base.KeyCRUD, "RepairBucket() processed %d / %d", numDocsProcessed, vres.TotalRows)
 
 		if numResultsProcessed == 0 {
 			// No point in going to the next page, since this page had 0 results.  See method comments.
@@ -284,7 +286,7 @@ func (r RepairBucket) WriteRepairedDocsToBucket(docId string, originalDoc, updat
 
 	//If the RepairedFileTTL is explicitly set to 0 then don't write the doc at all
 	if int(r.RepairedFileTTL.Seconds()) == 0 {
-		base.Infof(base.KeyCRUD, "Repair Doc: Doc %v repaired, TTL set to 0, doc will not be written to bucket", base.UD(backupOrDryRunDocId))
+		base.InfofCtx(context.TODO(), base.KeyCRUD, "Repair Doc: Doc %v repaired, TTL set to 0, doc will not be written to bucket", base.UD(backupOrDryRunDocId))
 		return backupOrDryRunDocId, nil
 	}
 

--- a/db/repair_bucket.go
+++ b/db/repair_bucket.go
@@ -336,8 +336,8 @@ func (r RepairBucket) TransformBucketDoc(docId string, originalCBDoc []byte) (tr
 // Repairs rev tree cycles (see SG issue #2847)
 func RepairJobRevTreeCycles(docId string, originalCBDoc []byte) (transformedCBDoc []byte, transformed bool, err error) {
 
-	base.Debugf(base.KeyCRUD, "RepairJobRevTreeCycles() called with doc id: %v", base.UD(docId))
-	defer base.Debugf(base.KeyCRUD, "RepairJobRevTreeCycles() finished.  Doc id: %v.  transformed: %v.  err: %v", base.UD(docId), base.UD(transformed), err)
+	base.DebugfCtx(context.TODO(), base.KeyCRUD, "RepairJobRevTreeCycles() called with doc id: %v", base.UD(docId))
+	defer base.DebugfCtx(context.TODO(), base.KeyCRUD, "RepairJobRevTreeCycles() finished.  Doc id: %v.  transformed: %v.  err: %v", base.UD(docId), base.UD(transformed), err)
 
 	doc, errUnmarshal := unmarshalDocument(docId, originalCBDoc)
 	if errUnmarshal != nil {

--- a/db/revision.go
+++ b/db/revision.go
@@ -363,7 +363,7 @@ func genOfRevID(revid string) int {
 	var generation int
 	n, _ := fmt.Sscanf(revid, "%d-", &generation)
 	if n < 1 || generation < 1 {
-		base.Warnf("genOfRevID unsuccessful for %q", revid)
+		base.WarnfCtx(context.Background(), "genOfRevID unsuccessful for %q", revid)
 		return -1
 	}
 	return generation
@@ -377,16 +377,16 @@ func ParseRevID(revid string) (int, string) {
 
 	idx := strings.Index(revid, "-")
 	if idx == -1 {
-		base.Warnf("parseRevID found no separator in rev %q", revid)
+		base.WarnfCtx(context.Background(), "parseRevID found no separator in rev %q", revid)
 		return -1, ""
 	}
 
 	gen, err := strconv.Atoi(revid[:idx])
 	if err != nil {
-		base.Warnf("parseRevID unexpected generation in rev %q: %s", revid, err)
+		base.WarnfCtx(context.Background(), "parseRevID unexpected generation in rev %q: %s", revid, err)
 		return -1, ""
 	} else if gen < 1 {
-		base.Warnf("parseRevID unexpected generation in rev %q", revid)
+		base.WarnfCtx(context.Background(), "parseRevID unexpected generation in rev %q", revid)
 		return -1, ""
 	}
 

--- a/db/revision.go
+++ b/db/revision.go
@@ -79,7 +79,7 @@ func (body Body) Copy(copyType BodyCopyType) Body {
 	case BodyNoCopy:
 		return body
 	default:
-		base.Infof(base.KeyCRUD, "Unexpected copy type specified in body.Copy - defaulting to shallow copy.  copyType: %d", copyType)
+		base.InfofCtx(context.Background(), base.KeyCRUD, "Unexpected copy type specified in body.Copy - defaulting to shallow copy.  copyType: %d", copyType)
 		return body.ShallowCopy()
 	}
 }
@@ -99,7 +99,7 @@ func (body Body) DeepCopy() Body {
 	var copiedBody Body
 	err := base.DeepCopyInefficient(&copiedBody, body)
 	if err != nil {
-		base.Infof(base.KeyCRUD, "Error copying body: %v", err)
+		base.InfofCtx(context.Background(), base.KeyCRUD, "Error copying body: %v", err)
 	}
 	return copiedBody
 }

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -10,6 +10,7 @@ package db
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -423,7 +424,7 @@ func (tree RevTree) setRevisionBody(revid string, body []byte, bodyKey string, h
 func (tree RevTree) removeRevisionBody(revid string) (deletedBodyKey string) {
 	info, found := tree[revid]
 	if !found {
-		base.Errorf("RemoveRevisionBody called for revid not in tree: %v", revid)
+		base.ErrorfCtx(context.Background(), "RemoveRevisionBody called for revid not in tree: %v", revid)
 		return ""
 	}
 	deletedBodyKey = info.BodyKey

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -788,7 +788,7 @@ func encodeRevisions(docID string, revs []string) Revisions {
 		if i == 0 {
 			start = gen
 		} else if gen != start-i {
-			base.Warnf("Found gap in revision list for doc %q. Expecting gen %v but got %v in %v", base.UD(docID), start-i, gen, revs)
+			base.WarnfCtx(context.TODO(), "Found gap in revision list for doc %q. Expecting gen %v but got %v in %v", base.UD(docID), start-i, gen, revs)
 		}
 	}
 	return Revisions{RevisionsStart: start, RevisionsIds: ids}

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -201,7 +201,7 @@ func (tree RevTree) RepairCycles() (err error) {
 		for {
 
 			if node.ParentGenGTENodeGen() {
-				base.Infof(base.KeyCRUD, "Node %+v detected to have invalid parent rev (parent generation larger than node generation).  Repairing by designating as a root node.", base.UD(node))
+				base.InfofCtx(context.Background(), base.KeyCRUD, "Node %+v detected to have invalid parent rev (parent generation larger than node generation).  Repairing by designating as a root node.", base.UD(node))
 				node.Parent = ""
 				break
 			}

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -267,7 +267,7 @@ func (s *sequenceAllocator) waitForReleasedSequences(startTime time.Time) (waite
 	if requiredWait < 0 {
 		return 0
 	}
-	base.Infof(base.KeyCache, "Waiting %v for sequence allocation...", requiredWait)
+	base.InfofCtx(context.TODO(), base.KeyCache, "Waiting %v for sequence allocation...", requiredWait)
 	time.Sleep(requiredWait)
 	return requiredWait
 }

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -9,6 +9,7 @@
 package db
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -117,7 +118,7 @@ func (s *sequenceAllocator) releaseUnusedSequences() {
 	if s.last < s.max {
 		err := s.releaseSequenceRange(s.last+1, s.max)
 		if err != nil {
-			base.Warnf("Error returned when releasing sequence range [%d-%d]. Falling back to skipped sequence handling.  Error:%v", s.last+1, s.max, err)
+			base.WarnfCtx(context.TODO(), "Error returned when releasing sequence range [%d-%d]. Falling back to skipped sequence handling.  Error:%v", s.last+1, s.max, err)
 		}
 	}
 	// Reduce batch size for next incr by the unused amount
@@ -149,7 +150,7 @@ func (s *sequenceAllocator) lastSequence() (uint64, error) {
 	s.dbStats.SequenceGetCount.Add(1)
 	last, err := s.getSequence()
 	if err != nil {
-		base.Warnf("Error from Get in getSequence(): %v", err)
+		base.WarnfCtx(context.TODO(), "Error from Get in getSequence(): %v", err)
 	}
 	return last, err
 }
@@ -198,7 +199,7 @@ func (s *sequenceAllocator) _reserveSequenceRange() error {
 
 	max, err := s.incrementSequence(s.sequenceBatchSize)
 	if err != nil {
-		base.Warnf("Error from incrementSequence in _reserveSequences(%d): %v", s.sequenceBatchSize, err)
+		base.WarnfCtx(context.TODO(), "Error from incrementSequence in _reserveSequences(%d): %v", s.sequenceBatchSize, err)
 		return err
 	}
 

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -194,7 +194,7 @@ func (s *sequenceAllocator) _reserveSequenceRange() error {
 		if s.sequenceBatchSize > maxBatchSize {
 			s.sequenceBatchSize = maxBatchSize
 		}
-		base.Debugf(base.KeyCRUD, "Increased sequence batch to %d", s.sequenceBatchSize)
+		base.DebugfCtx(context.TODO(), base.KeyCRUD, "Increased sequence batch to %d", s.sequenceBatchSize)
 	}
 
 	max, err := s.incrementSequence(s.sequenceBatchSize)
@@ -238,7 +238,7 @@ func (s *sequenceAllocator) releaseSequence(sequence uint64) error {
 		return err
 	}
 	s.dbStats.SequenceReleasedCount.Add(1)
-	base.Debugf(base.KeyCRUD, "Released unused sequence #%d", sequence)
+	base.DebugfCtx(context.TODO(), base.KeyCRUD, "Released unused sequence #%d", sequence)
 	return nil
 }
 
@@ -255,7 +255,7 @@ func (s *sequenceAllocator) releaseSequenceRange(fromSequence, toSequence uint64
 		return err
 	}
 	s.dbStats.SequenceReleasedCount.Add(int64(toSequence - fromSequence + 1))
-	base.Debugf(base.KeyCRUD, "Released unused sequences #%d-#%d", fromSequence, toSequence)
+	base.DebugfCtx(context.TODO(), base.KeyCRUD, "Released unused sequences #%d-#%d", fromSequence, toSequence)
 	return nil
 }
 

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -441,7 +441,7 @@ func (dbc *DatabaseContext) StartReplications() {
 
 			err := dbc.SGReplicateMgr.StartReplications()
 			if err != nil {
-				base.Errorf("Error starting %q Inter-Sync Gateway Replications: %v", dbc.Name, err)
+				base.ErrorfCtx(dbc.SGReplicateMgr.loggingCtx, "Error starting %q Inter-Sync Gateway Replications: %v", dbc.Name, err)
 			}
 		}()
 	} else {

--- a/db/sg_replicate_conflict_resolver.go
+++ b/db/sg_replicate_conflict_resolver.go
@@ -210,7 +210,7 @@ func (i *ConflictResolverJSServer) EvaluateFunction(conflict Conflict) (Body, er
 	remoteRevID, _ := conflict.RemoteDocument[BodyRev].(string)
 	result, err := i.Call(conflict)
 	if err != nil {
-		base.Warnf("Unexpected error invoking conflict resolver for document %s, local/remote revisions %s/%s - processing aborted, document will not be replicated.  Error: %v",
+		base.WarnfCtx(context.Background(), "Unexpected error invoking conflict resolver for document %s, local/remote revisions %s/%s - processing aborted, document will not be replicated.  Error: %v",
 			base.UD(docID), base.UD(localRevID), base.UD(remoteRevID), err)
 		return nil, err
 	}
@@ -226,10 +226,10 @@ func (i *ConflictResolverJSServer) EvaluateFunction(conflict Conflict) (Body, er
 	case map[string]interface{}:
 		return result, nil
 	case error:
-		base.Warnf("conflictResolverRunner: " + result.Error())
+		base.WarnfCtx(context.Background(), "conflictResolverRunner: "+result.Error())
 		return nil, result
 	default:
-		base.Warnf("Custom conflict resolution function returned non-document result %v Type: %T", result, result)
+		base.WarnfCtx(context.Background(), "Custom conflict resolution function returned non-document result %v Type: %T", result, result)
 		return nil, errors.New("Custom conflict resolution function returned non-document value.")
 	}
 }
@@ -288,7 +288,7 @@ func newConflictResolverRunner(funcSource string) (sgbucket.JSServerTask, error)
 func ErrorToOttoValue(runner *sgbucket.JSRunner, err error) otto.Value {
 	errorValue, convertErr := runner.ToValue(err)
 	if convertErr != nil {
-		base.Warnf("Unable to convert error to otto value: %v", convertErr)
+		base.WarnfCtx(context.Background(), "Unable to convert error to otto value: %v", convertErr)
 	}
 	return errorValue
 }

--- a/db/sg_replicate_conflict_resolver.go
+++ b/db/sg_replicate_conflict_resolver.go
@@ -238,8 +238,12 @@ func (i *ConflictResolverJSServer) EvaluateFunction(conflict Conflict) (Body, er
 func newConflictResolverRunner(funcSource string) (sgbucket.JSServerTask, error) {
 	conflictResolverRunner := &sgbucket.JSRunner{}
 	err := conflictResolverRunner.InitWithLogging(funcSource,
-		func(s string) { base.ErrorfCtx(context.Background(), base.KeyJavascript.String()+": ConflictResolver %s", base.UD(s)) },
-		func(s string) { base.InfofCtx(context.Background(), base.KeyJavascript, "ConflictResolver %s", base.UD(s)) })
+		func(s string) {
+			base.ErrorfCtx(context.Background(), base.KeyJavascript.String()+": ConflictResolver %s", base.UD(s))
+		},
+		func(s string) {
+			base.InfofCtx(context.Background(), base.KeyJavascript, "ConflictResolver %s", base.UD(s))
+		})
 	if err != nil {
 		return nil, err
 	}

--- a/db/sg_replicate_conflict_resolver.go
+++ b/db/sg_replicate_conflict_resolver.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -237,8 +238,8 @@ func (i *ConflictResolverJSServer) EvaluateFunction(conflict Conflict) (Body, er
 func newConflictResolverRunner(funcSource string) (sgbucket.JSServerTask, error) {
 	conflictResolverRunner := &sgbucket.JSRunner{}
 	err := conflictResolverRunner.InitWithLogging(funcSource,
-		func(s string) { base.Errorf(base.KeyJavascript.String()+": ConflictResolver %s", base.UD(s)) },
-		func(s string) { base.Infof(base.KeyJavascript, "ConflictResolver %s", base.UD(s)) })
+		func(s string) { base.ErrorfCtx(context.Background(), base.KeyJavascript.String()+": ConflictResolver %s", base.UD(s)) },
+		func(s string) { base.InfofCtx(context.Background(), base.KeyJavascript, "ConflictResolver %s", base.UD(s)) })
 	if err != nil {
 		return nil, err
 	}

--- a/db/sg_replicate_conflict_resolver.go
+++ b/db/sg_replicate_conflict_resolver.go
@@ -197,7 +197,7 @@ type ConflictResolverJSServer struct {
 }
 
 func NewConflictResolverJSServer(fnSource string) *ConflictResolverJSServer {
-	base.Debugf(base.KeyReplicate, "Creating new ConflictResolverFunction")
+	base.DebugfCtx(context.Background(), base.KeyReplicate, "Creating new ConflictResolverFunction")
 	return &ConflictResolverJSServer{
 		JSServer: sgbucket.NewJSServer(fnSource, kTaskCacheSize, newConflictResolverRunner),
 	}

--- a/db/sg_replicate_conflict_resolver.go
+++ b/db/sg_replicate_conflict_resolver.go
@@ -131,7 +131,7 @@ func (c *ConflictResolver) Resolve(conflict Conflict) (winner Body, resolutionTy
 		return winner, ConflictResolutionRemote, nil
 	}
 
-	base.Infof(base.KeyReplicate, "Conflict resolver returned non-empty revID (%s) not matching local (%s) or remote (%s), treating result as merge.", winningRev, localRev, remoteRev)
+	base.InfofCtx(context.Background(), base.KeyReplicate, "Conflict resolver returned non-empty revID (%s) not matching local (%s) or remote (%s), treating result as merge.", winningRev, localRev, remoteRev)
 	c.stats.ConflictResultMergeCount.Add(1)
 	return winner, ConflictResolutionMerge, err
 }

--- a/db/utils.go
+++ b/db/utils.go
@@ -32,7 +32,7 @@ func NewBackgroundTask(taskName string, dbName string, task BackgroundTaskFunc, 
 		doneChan: make(chan struct{}),
 	}
 
-	base.Infof(base.KeyAll, "Created background task: %q with interval %v", taskName, interval)
+	base.InfofCtx(context.Background(), base.KeyAll, "Created background task: %q with interval %v", taskName, interval)
 	go func() {
 		defer close(bgt.doneChan)
 		defer base.FatalPanicHandler()

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -173,7 +173,7 @@ func (h *handler) handleDbOnline() error {
 
 	_ = base.JSONUnmarshal(body, &input)
 
-	base.Infof(base.KeyCRUD, "Taking Database : %v, online in %v seconds", base.MD(h.db.Name), input.Delay)
+	base.InfofCtx(h.ctx(), base.KeyCRUD, "Taking Database : %v, online in %v seconds", base.MD(h.db.Name), input.Delay)
 	go func() {
 		time.Sleep(time.Duration(input.Delay) * time.Second)
 		h.server.TakeDbOnline(h.db.DatabaseContext)
@@ -187,7 +187,7 @@ func (h *handler) handleDbOffline() error {
 	h.assertAdminOnly()
 	var err error
 	if err = h.db.TakeDbOffline("ADMIN Request"); err != nil {
-		base.Infof(base.KeyCRUD, "Unable to take Database : %v, offline", base.MD(h.db.Name))
+		base.InfofCtx(h.ctx(), base.KeyCRUD, "Unable to take Database : %v, offline", base.MD(h.db.Name))
 	}
 
 	return err
@@ -1070,7 +1070,7 @@ func (h *handler) handleSetLogging() error {
 	}
 
 	if setLogLevel {
-		base.Infof(base.KeyAll, "Setting log level to: %v", newLogLevel)
+		base.InfofCtx(h.ctx(), base.KeyAll, "Setting log level to: %v", newLogLevel)
 		base.ConsoleLogLevel().Set(newLogLevel)
 
 		// empty body is OK if request is just setting the log level

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -974,7 +974,7 @@ func (h *handler) handleGetRevTree() error {
 
 func (h *handler) handleGetLogging() error {
 	h.writeJSON(base.GetLogKeys())
-	base.Warnf("Deprecation notice: Current _logging endpoints are now deprecated. Using _config endpoints " +
+	base.WarnfCtx(h.ctx(), "Deprecation notice: Current _logging endpoints are now deprecated. Using _config endpoints "+
 		"instead")
 	return nil
 }
@@ -1041,7 +1041,7 @@ func (h *handler) handleGetStatus() error {
 }
 
 func (h *handler) handleSetLogging() error {
-	base.Warnf("Deprecation notice: Current _logging endpoints are now deprecated. Using _config endpoints " +
+	base.WarnfCtx(h.ctx(), "Deprecation notice: Current _logging endpoints are now deprecated. Using _config endpoints "+
 		"instead")
 
 	body, err := h.readBody()
@@ -1057,7 +1057,7 @@ func (h *handler) handleSetLogging() error {
 		}
 		setLogLevel = true
 	} else if level := h.getIntQuery("level", 0); level != 0 {
-		base.Warnf("Using deprecated query parameter: %q. Use %q instead.", "level", "logLevel")
+		base.WarnfCtx(h.ctx(), "Using deprecated query parameter: %q. Use %q instead.", "level", "logLevel")
 		switch base.GetRestrictedInt(&level, 0, 1, 3, false) {
 		case 1:
 			newLogLevel = base.LevelInfo

--- a/rest/api.go
+++ b/rest/api.go
@@ -468,7 +468,7 @@ func (h *handler) handleProfiling() error {
 	}
 
 	if fileCloseError := f.Close(); fileCloseError != nil {
-		base.Warnf("Error closing profile file: %v", fileCloseError)
+		base.WarnfCtx(h.ctx(), "Error closing profile file: %v", fileCloseError)
 	}
 
 	return err
@@ -495,7 +495,7 @@ func (h *handler) handleHeapProfiling() error {
 	err = pprof.WriteHeapProfile(f)
 
 	if fileCloseError := f.Close(); fileCloseError != nil {
-		base.Warnf("Error closing profile file: %v", fileCloseError)
+		base.WarnfCtx(h.ctx(), "Error closing profile file: %v", fileCloseError)
 	}
 
 	return err

--- a/rest/api.go
+++ b/rest/api.go
@@ -437,7 +437,7 @@ func (h *handler) handleProfiling() error {
 	// Handle no file
 	if params.File == "" {
 		if isCPUProfile {
-			base.Infof(base.KeyAll, "... ending CPU profile")
+			base.InfofCtx(h.ctx(), base.KeyAll, "... ending CPU profile")
 			pprof.StopCPUProfile()
 			h.server.CloseCpuPprofFile()
 			return nil
@@ -451,17 +451,17 @@ func (h *handler) handleProfiling() error {
 	}
 
 	if isCPUProfile {
-		base.Infof(base.KeyAll, "Starting CPU profile to %s ...", base.UD(params.File))
+		base.InfofCtx(h.ctx(), base.KeyAll, "Starting CPU profile to %s ...", base.UD(params.File))
 		if err = pprof.StartCPUProfile(f); err != nil {
 			if fileError := os.Remove(params.File); fileError != nil {
-				base.Infof(base.KeyAll, "Error removing file: %s", base.UD(params.File))
+				base.InfofCtx(h.ctx(), base.KeyAll, "Error removing file: %s", base.UD(params.File))
 			}
 			return err
 		}
 		h.server.SetCpuPprofFile(f)
 		return err
 	} else if profile := pprof.Lookup(profileName); profile != nil {
-		base.Infof(base.KeyAll, "Writing %q profile to %s ...", profileName, base.UD(params.File))
+		base.InfofCtx(h.ctx(), base.KeyAll, "Writing %q profile to %s ...", profileName, base.UD(params.File))
 		err = profile.WriteTo(f, 0)
 	} else {
 		err = base.HTTPErrorf(http.StatusNotFound, "No such profile %q", profileName)
@@ -487,7 +487,7 @@ func (h *handler) handleHeapProfiling() error {
 		return err
 	}
 
-	base.Infof(base.KeyAll, "Dumping heap profile to %s ...", base.UD(params.File))
+	base.InfofCtx(h.ctx(), base.KeyAll, "Dumping heap profile to %s ...", base.UD(params.File))
 	f, err := os.Create(params.File)
 	if err != nil {
 		return err

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -374,12 +374,12 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 
 		digest, ok := msg.Properties[db.GetAttachmentDigest]
 		if !ok {
-			base.Panicf("couldn't find digest in getAttachment message properties")
+			base.PanicfCtx(context.TODO(), "couldn't find digest in getAttachment message properties")
 		}
 
 		attachment, err := btc.getAttachment(digest)
 		if err != nil {
-			base.Panicf("couldn't find attachment for digest: %v", digest)
+			base.PanicfCtx(context.TODO(), "couldn't find attachment for digest: %v", digest)
 		}
 
 		response := msg.Response()
@@ -394,7 +394,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 
 	btr.bt.blipContext.DefaultHandler = func(msg *blip.Message) {
 		btr.storeMessage(msg)
-		base.Panicf("Unknown profile: %s caught by client DefaultHandler - msg: %#v", msg.Profile(), msg)
+		base.PanicfCtx(context.TODO(), "Unknown profile: %s caught by client DefaultHandler - msg: %#v", msg.Profile(), msg)
 	}
 }
 

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -12,6 +12,7 @@ package rest
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -662,7 +663,7 @@ func (btc *BlipTesterClient) PushRevWithHistory(docID, parentRev string, body []
 	revRequest.Properties[db.RevMessageHistory] = strings.Join(revisionHistory, ",")
 
 	if btc.ClientDeltas && proposeChangesResponse.Properties[db.ProposeChangesResponseDeltas] == "true" {
-		base.Debugf(base.KeySync, "Sending deltas from test client")
+		base.DebugfCtx(context.TODO(), base.KeySync, "Sending deltas from test client")
 		var parentDocJSON, newDocJSON db.Body
 		err := parentDocJSON.Unmarshal(parentDocBody)
 		if err != nil {
@@ -681,7 +682,7 @@ func (btc *BlipTesterClient) PushRevWithHistory(docID, parentRev string, body []
 		revRequest.Properties[db.RevMessageDeltaSrc] = parentRev
 		body = delta
 	} else {
-		base.Debugf(base.KeySync, "Not sending deltas from test client")
+		base.DebugfCtx(context.TODO(), base.KeySync, "Not sending deltas from test client")
 	}
 
 	revRequest.SetBody(body)

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -230,7 +230,7 @@ func (h *handler) handleAllDocs() error {
 // HTTP handler for _dump
 func (h *handler) handleDump() error {
 	viewName := h.PathVar("view")
-	base.Infof(base.KeyHTTP, "Dump view %q", base.MD(viewName))
+	base.InfofCtx(h.ctx(), base.KeyHTTP, "Dump view %q", base.MD(viewName))
 	opts := db.Body{"stale": false, "reduce": false}
 	result, err := h.db.Bucket.View(db.DesignDocSyncGateway(), viewName, opts)
 	if err != nil {
@@ -264,7 +264,7 @@ func (h *handler) handleRepair() error {
 		return errors.New("_repair endpoint disabled")
 	}
 
-	base.Infof(base.KeyHTTP, "Repair bucket")
+	base.InfofCtx(h.ctx(), base.KeyHTTP, "Repair bucket")
 
 	// Todo: is this actually needed or does something else in the handler do it?  I can't find that..
 	defer func() {
@@ -305,7 +305,7 @@ func (h *handler) handleRepair() error {
 func (h *handler) handleDumpChannel() error {
 	channelName := h.PathVar("channel")
 	since := h.getIntQuery("since", 0)
-	base.Infof(base.KeyHTTP, "Dump channel %q", base.UD(channelName))
+	base.InfofCtx(h.ctx(), base.KeyHTTP, "Dump channel %q", base.UD(channelName))
 
 	chanLog := h.db.GetChangeLog(channelName, since)
 	if chanLog == nil {
@@ -519,7 +519,7 @@ func (h *handler) handleBulkDocs() error {
 			status["status"] = code
 			status["error"] = base.CouchHTTPErrorName(code)
 			status["reason"] = msg
-			base.Infof(base.KeyAll, "\tBulkDocs: Doc %q --> %d %s (%v)", base.UD(docid), code, msg, err)
+			base.InfofCtx(h.ctx(), base.KeyAll, "\tBulkDocs: Doc %q --> %d %s (%v)", base.UD(docid), code, msg, err)
 			err = nil // wrote it to output already; not going to return it
 		} else {
 			status["rev"] = revid
@@ -545,7 +545,7 @@ func (h *handler) handleBulkDocs() error {
 			status["status"] = code
 			status["error"] = base.CouchHTTPErrorName(code)
 			status["reason"] = msg
-			base.Infof(base.KeyAll, "\tBulkDocs: Local Doc %q --> %d %s (%v)", base.UD(docid), code, msg, err)
+			base.InfofCtx(h.ctx(), base.KeyAll, "\tBulkDocs: Local Doc %q --> %d %s (%v)", base.UD(docid), code, msg, err)
 			err = nil
 		} else {
 			status["rev"] = revid

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -11,6 +11,7 @@ package rest
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -622,7 +623,7 @@ func readWebSocketMessage(conn *websocket.Conn) ([]byte, error) {
 	var message []byte
 	if err := websocket.Message.Receive(conn, &message); err != nil {
 		if err != io.EOF {
-			base.Warnf("Error reading initial websocket message: %v", err)
+			base.WarnfCtx(context.TODO(), "Error reading initial websocket message: %v", err)
 			return nil, err
 		}
 	}

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -10,6 +10,7 @@ package rest
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -3967,6 +3968,6 @@ func WriteDirectWithKey(testDb *db.DatabaseContext, key string, channelArray []s
 
 	_, err := testDb.Bucket.Add(key, 0, db.Body{base.SyncPropertyName: syncData, "key": key})
 	if err != nil {
-		base.Panicf("Error while add ket to bucket: %v", err)
+		base.PanicfCtx(context.TODO(), "Error while add ket to bucket: %v", err)
 	}
 }

--- a/rest/config.go
+++ b/rest/config.go
@@ -10,6 +10,7 @@ package rest
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -924,7 +925,7 @@ func SetMaxFileDescriptors(maxP *uint64) error {
 	}
 	_, err := base.SetMaxFileDescriptors(maxFDs)
 	if err != nil {
-		base.Errorf("Error setting MaxFileDescriptors to %d: %v", maxFDs, err)
+		base.ErrorfCtx(context.Background(), "Error setting MaxFileDescriptors to %d: %v", maxFDs, err)
 		return err
 	}
 	return nil
@@ -1203,7 +1204,7 @@ func (sc *ServerContext) _applyConfigs(dbNameConfigs map[string]DatabaseConfig) 
 	for dbName, cnf := range dbNameConfigs {
 		applied, err := sc._applyConfig(cnf, false)
 		if err != nil {
-			base.Errorf("Couldn't apply config for database %q: %v", base.MD(dbName), err)
+			base.ErrorfCtx(context.Background(), "Couldn't apply config for database %q: %v", base.MD(dbName), err)
 			continue
 		}
 		if applied {
@@ -1277,24 +1278,24 @@ func (sc *ServerContext) addLegacyPrincipals(legacyDbUsers, legacyDbRoles map[st
 	for dbName, dbUser := range legacyDbUsers {
 		dbCtx, err := sc.GetDatabase(dbName)
 		if err != nil {
-			base.Errorf("Couldn't get database context to install user principles: %v", err)
+			base.ErrorfCtx(context.Background(), "Couldn't get database context to install user principles: %v", err)
 			continue
 		}
 		err = sc.installPrincipals(dbCtx, dbUser, "user")
 		if err != nil {
-			base.Errorf("Couldn't install user principles: %v", err)
+			base.ErrorfCtx(context.Background(), "Couldn't install user principles: %v", err)
 		}
 	}
 
 	for dbName, dbRole := range legacyDbRoles {
 		dbCtx, err := sc.GetDatabase(dbName)
 		if err != nil {
-			base.Errorf("Couldn't get database context to install role principles: %v", err)
+			base.ErrorfCtx(context.Background(), "Couldn't get database context to install role principles: %v", err)
 			continue
 		}
 		err = sc.installPrincipals(dbCtx, dbRole, "role")
 		if err != nil {
-			base.Errorf("Couldn't install role principles: %v", err)
+			base.ErrorfCtx(context.Background(), "Couldn't install role principles: %v", err)
 		}
 	}
 }
@@ -1314,14 +1315,14 @@ func startServer(config *StartupConfig, sc *ServerContext) error {
 	base.Consolef(base.LevelInfo, base.KeyAll, "Starting metrics server on %s", config.API.MetricsInterface)
 	go func() {
 		if err := sc.Serve(config, config.API.MetricsInterface, CreateMetricHandler(sc)); err != nil {
-			base.Errorf("Error serving the Metrics API: %v", err)
+			base.ErrorfCtx(context.TODO(), "Error serving the Metrics API: %v", err)
 		}
 	}()
 
 	base.Consolef(base.LevelInfo, base.KeyAll, "Starting admin server on %s", config.API.AdminInterface)
 	go func() {
 		if err := sc.Serve(config, config.API.AdminInterface, CreateAdminHandler(sc)); err != nil {
-			base.Errorf("Error serving the Admin API: %v", err)
+			base.ErrorfCtx(context.TODO(), "Error serving the Admin API: %v", err)
 		}
 	}()
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -459,7 +459,7 @@ func (dbConfig *DbConfig) AutoImportEnabled() (bool, error) {
 
 	str, ok := dbConfig.AutoImport.(string)
 	if ok && str == "continuous" {
-		base.Warnf(`Using deprecated config value for "import_docs": "continuous". Use "import_docs": true instead.`)
+		base.WarnfCtx(context.Background(), `Using deprecated config value for "import_docs": "continuous". Use "import_docs": true instead.`)
 		return true, nil
 	}
 
@@ -519,15 +519,15 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) error {
 			// EE: channel cache
 			if !isEnterpriseEdition {
 				if val := dbConfig.CacheConfig.ChannelCacheConfig.MaxNumber; val != nil {
-					base.Warnf(eeOnlyWarningMsg, "cache.channel_cache.max_number", *val, db.DefaultChannelCacheMaxNumber)
+					base.WarnfCtx(context.Background(), eeOnlyWarningMsg, "cache.channel_cache.max_number", *val, db.DefaultChannelCacheMaxNumber)
 					dbConfig.CacheConfig.ChannelCacheConfig.MaxNumber = nil
 				}
 				if val := dbConfig.CacheConfig.ChannelCacheConfig.HighWatermarkPercent; val != nil {
-					base.Warnf(eeOnlyWarningMsg, "cache.channel_cache.compact_high_watermark_pct", *val, db.DefaultCompactHighWatermarkPercent)
+					base.WarnfCtx(context.Background(), eeOnlyWarningMsg, "cache.channel_cache.compact_high_watermark_pct", *val, db.DefaultCompactHighWatermarkPercent)
 					dbConfig.CacheConfig.ChannelCacheConfig.HighWatermarkPercent = nil
 				}
 				if val := dbConfig.CacheConfig.ChannelCacheConfig.LowWatermarkPercent; val != nil {
-					base.Warnf(eeOnlyWarningMsg, "cache.channel_cache.compact_low_watermark_pct", *val, db.DefaultCompactLowWatermarkPercent)
+					base.WarnfCtx(context.Background(), eeOnlyWarningMsg, "cache.channel_cache.compact_low_watermark_pct", *val, db.DefaultCompactLowWatermarkPercent)
 					dbConfig.CacheConfig.ChannelCacheConfig.LowWatermarkPercent = nil
 				}
 			}
@@ -579,7 +579,7 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) error {
 			// EE: disable revcache
 			revCacheSize := dbConfig.CacheConfig.RevCacheConfig.Size
 			if !isEnterpriseEdition && revCacheSize != nil && *revCacheSize == 0 {
-				base.Warnf(eeOnlyWarningMsg, "cache.rev_cache.size", *revCacheSize, db.DefaultRevisionCacheSize)
+				base.WarnfCtx(context.Background(), eeOnlyWarningMsg, "cache.rev_cache.size", *revCacheSize, db.DefaultRevisionCacheSize)
 				dbConfig.CacheConfig.RevCacheConfig.Size = nil
 			}
 
@@ -593,7 +593,7 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) error {
 
 	// EE: delta sync
 	if !isEnterpriseEdition && dbConfig.DeltaSync != nil && dbConfig.DeltaSync.Enabled != nil {
-		base.Warnf(eeOnlyWarningMsg, "delta_sync.enabled", *dbConfig.DeltaSync.Enabled, false)
+		base.WarnfCtx(context.Background(), eeOnlyWarningMsg, "delta_sync.enabled", *dbConfig.DeltaSync.Enabled, false)
 		dbConfig.DeltaSync.Enabled = nil
 	}
 
@@ -612,7 +612,7 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) error {
 
 	if dbConfig.ImportPartitions != nil {
 		if !isEnterpriseEdition {
-			base.Warnf(eeOnlyWarningMsg, "import_partitions", *dbConfig.ImportPartitions, nil)
+			base.WarnfCtx(context.Background(), eeOnlyWarningMsg, "import_partitions", *dbConfig.ImportPartitions, nil)
 			dbConfig.ImportPartitions = nil
 		} else if !dbConfig.UseXattrs() {
 			multiError = multiError.Append(fmt.Errorf("Invalid configuration - import_partitions set, but enable_shared_bucket_access not enabled"))
@@ -624,7 +624,7 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) error {
 	}
 
 	if dbConfig.DeprecatedPool != nil {
-		base.Warnf(`"pool" config option is not supported. The pool will be set to "default". The option should be removed from config file.`)
+		base.WarnfCtx(context.Background(), `"pool" config option is not supported. The pool will be set to "default". The option should be removed from config file.`)
 	}
 
 	if dbConfig.Sync != nil {
@@ -1345,7 +1345,7 @@ func sharedBucketDatabaseCheck(sc *ServerContext) (errors error) {
 		multiError = multiError.Append(sharedBucketError)
 		messageFormat := "Bucket %q is shared among databases %s. " +
 			"This may result in unexpected behaviour if security is not defined consistently."
-		base.Warnf(messageFormat, base.MD(sharedBucket.bucketName), base.MD(sharedBucket.dbNames))
+		base.WarnfCtx(context.Background(), messageFormat, base.MD(sharedBucket.bucketName), base.MD(sharedBucket.dbNames))
 	}
 	return multiError.ErrorOrNil()
 }
@@ -1386,7 +1386,7 @@ func sharedBuckets(dbContextMap map[string][]*db.DatabaseContext) (sharedBuckets
 func HandleSighup() {
 	for logger, err := range base.RotateLogfiles() {
 		if err != nil {
-			base.Warnf("Error rotating %v: %v", logger, err)
+			base.WarnfCtx(context.Background(), "Error rotating %v: %v", logger, err)
 		}
 	}
 }

--- a/rest/config.go
+++ b/rest/config.go
@@ -426,7 +426,7 @@ var ErrPathNotFound = errors.New("path not found")
 func readFromPath(path string, insecureSkipVerify bool) (rc io.ReadCloser, err error) {
 	messageFormat := "Loading content from [%s] ..."
 	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
-		base.Infof(base.KeyAll, messageFormat, path)
+		base.InfofCtx(context.Background(), base.KeyAll, messageFormat, path)
 		client := base.GetHttpClient(insecureSkipVerify)
 		resp, err := client.Get(path)
 		if err != nil {
@@ -437,7 +437,7 @@ func readFromPath(path string, insecureSkipVerify bool) (rc io.ReadCloser, err e
 		}
 		rc = resp.Body
 	} else if base.FileExists(path) {
-		base.Infof(base.KeyAll, messageFormat, path)
+		base.InfofCtx(context.Background(), base.KeyAll, messageFormat, path)
 		rc, err = os.Open(path)
 		if err != nil {
 			return nil, err
@@ -1029,9 +1029,9 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 
 	base.FlushLoggerBuffers()
 
-	base.Infof(base.KeyAll, "Logging: Console level: %v", base.ConsoleLogLevel())
-	base.Infof(base.KeyAll, "Logging: Console keys: %v", base.ConsoleLogKey().EnabledLogKeys())
-	base.Infof(base.KeyAll, "Logging: Redaction level: %s", config.Logging.RedactionLevel)
+	base.InfofCtx(context.Background(), base.KeyAll, "Logging: Console level: %v", base.ConsoleLogLevel())
+	base.InfofCtx(context.Background(), base.KeyAll, "Logging: Console keys: %v", base.ConsoleLogKey().EnabledLogKeys())
+	base.InfofCtx(context.Background(), base.KeyAll, "Logging: Redaction level: %s", config.Logging.RedactionLevel)
 
 	if err := setGlobalConfig(config); err != nil {
 		return nil, err
@@ -1064,7 +1064,7 @@ func (sc *ServerContext) fetchAndLoadConfigs() (count int, err error) {
 	for _, bucket := range bucketsNoConfig {
 		dbName, ok := sc.bucketDbName[bucket]
 		if ok {
-			base.Infof(base.KeyConfig, "database %q was running on this node, but config was not found on the server - removing database", base.MD(dbName))
+			base.InfofCtx(context.TODO(), base.KeyConfig, "database %q was running on this node, but config was not found on the server - removing database", base.MD(dbName))
 			sc._removeDatabase(dbName)
 		}
 	}
@@ -1233,13 +1233,13 @@ func (sc *ServerContext) _applyConfig(cnf DatabaseConfig, failFast bool) (applie
 
 		if cnf.cas == 0 {
 			// force an update when the new config's cas was set to zero prior to load
-			base.Infof(base.KeyConfig, "Forcing update of config for database %q bucket %q", cnf.Name, *cnf.Bucket)
+			base.InfofCtx(context.TODO(), base.KeyConfig, "Forcing update of config for database %q bucket %q", cnf.Name, *cnf.Bucket)
 		} else {
 			if sc.dbConfigs[foundDbName].cas >= cnf.cas {
 				base.Debugf(base.KeyConfig, "Database %q bucket %q config has not changed since last update", cnf.Name, *cnf.Bucket)
 				return false, nil
 			}
-			base.Infof(base.KeyConfig, "Updating database %q for bucket %q with new config from bucket", cnf.Name, *cnf.Bucket)
+			base.InfofCtx(context.TODO(), base.KeyConfig, "Updating database %q for bucket %q with new config from bucket", cnf.Name, *cnf.Bucket)
 		}
 	}
 
@@ -1304,7 +1304,7 @@ func (sc *ServerContext) addLegacyPrincipals(legacyDbUsers, legacyDbRoles map[st
 func startServer(config *StartupConfig, sc *ServerContext) error {
 	if config.API.ProfileInterface != "" {
 		//runtime.MemProfileRate = 10 * 1024
-		base.Infof(base.KeyAll, "Starting profile server on %s", base.UD(config.API.ProfileInterface))
+		base.InfofCtx(context.TODO(), base.KeyAll, "Starting profile server on %s", base.UD(config.API.ProfileInterface))
 		go func() {
 			_ = http.ListenAndServe(config.API.ProfileInterface, nil)
 		}()
@@ -1401,7 +1401,7 @@ func RegisterSignalHandler() {
 
 	go func() {
 		for sig := range signalChannel {
-			base.Infof(base.KeyAll, "Handling signal: %v", sig)
+			base.InfofCtx(context.TODO(), base.KeyAll, "Handling signal: %v", sig)
 			switch sig {
 			case syscall.SIGHUP:
 				HandleSighup()

--- a/rest/config.go
+++ b/rest/config.go
@@ -1121,7 +1121,7 @@ func (sc *ServerContext) fetchDatabase(dbName string) (found bool, dbConfig *Dat
 		}
 
 		if cnf.Name != dbName {
-			base.Tracef(base.KeyConfig, "%q did not contain config in group %q for db %q", bucket, sc.config.Bootstrap.ConfigGroupID, dbName)
+			base.TracefCtx(logCtx, base.KeyConfig, "%q did not contain config in group %q for db %q", bucket, sc.config.Bootstrap.ConfigGroupID, dbName)
 			continue
 		}
 
@@ -1142,7 +1142,7 @@ func (sc *ServerContext) fetchDatabase(dbName string) (found bool, dbConfig *Dat
 			cnf.CertPath = sc.config.Bootstrap.X509CertPath
 			cnf.KeyPath = sc.config.Bootstrap.X509KeyPath
 		}
-		base.Tracef(base.KeyConfig, "Got config for bucket %q with cas %d", bucket, cas)
+		base.TracefCtx(logCtx, base.KeyConfig, "Got config for bucket %q with cas %d", bucket, cas)
 		return true, &cnf, nil
 	}
 
@@ -1160,11 +1160,11 @@ func (sc *ServerContext) fetchConfigs() (dbNameConfigs map[string]DatabaseConfig
 	fetchedConfigs := make(map[string]DatabaseConfig, len(buckets))
 
 	for _, bucket := range buckets {
-		base.Tracef(base.KeyConfig, "Checking for config for group %q from bucket %q", sc.config.Bootstrap.ConfigGroupID, bucket)
+		base.TracefCtx(logCtx, base.KeyConfig, "Checking for config for group %q from bucket %q", sc.config.Bootstrap.ConfigGroupID, bucket)
 		var cnf DatabaseConfig
 		cas, err := sc.bootstrapContext.connection.GetConfig(bucket, sc.config.Bootstrap.ConfigGroupID, &cnf)
 		if err == base.ErrNotFound {
-			base.Tracef(base.KeyConfig, "bucket %q did not contain config for group %q", bucket, sc.config.Bootstrap.ConfigGroupID)
+			base.TracefCtx(logCtx, base.KeyConfig, "bucket %q did not contain config for group %q", bucket, sc.config.Bootstrap.ConfigGroupID)
 			bucketsNoConfig = append(bucketsNoConfig, bucket)
 			continue
 		}

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -130,7 +131,7 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 		server, username, password, err := legacyServerAddressUpgrade(*dbConfig.Server)
 		if err != nil {
 			server = *dbConfig.Server
-			base.Errorf("Error upgrading server address: %v", err)
+			base.ErrorfCtx(context.Background(), "Error upgrading server address: %v", err)
 		}
 
 		dbConfig.Server = base.StringPtr(server)
@@ -394,7 +395,7 @@ func setupServerConfig(args []string) (config *LegacyServerConfig, err error) {
 	multiError = multiError.Append(config.validate())
 	multiError = multiError.Append(config.setupAndValidateDatabases())
 	if multiError.ErrorOrNil() != nil {
-		base.Errorf("Error during config validation: %v", multiError)
+		base.ErrorfCtx(context.Background(), "Error during config validation: %v", multiError)
 		return nil, fmt.Errorf("error(s) during config validation: %v", multiError)
 	}
 

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -227,7 +227,7 @@ func setGlobalConfig(sc *StartupConfig) error {
 		cpus := runtime.NumCPU()
 		if cpus > 1 {
 			runtime.GOMAXPROCS(cpus)
-			base.Infof(base.KeyAll, "Configured Go to use all %d CPUs; setenv GOMAXPROCS to override this", cpus)
+			base.InfofCtx(context.Background(), base.KeyAll, "Configured Go to use all %d CPUs; setenv GOMAXPROCS to override this", cpus)
 		}
 	}
 
@@ -242,7 +242,7 @@ func setGlobalConfig(sc *StartupConfig) error {
 
 	// Given unscoped usage of base.JSON functions, this can't be scoped.
 	if base.BoolDefault(sc.Unsupported.UseStdlibJSON, false) {
-		base.Infof(base.KeyAll, "Using the stdlib JSON package")
+		base.InfofCtx(context.Background(), base.KeyAll, "Using the stdlib JSON package")
 		base.UseStdlibJSON = true
 	}
 

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"os"
 	"runtime"
 	"time"
@@ -231,7 +232,7 @@ func setGlobalConfig(sc *StartupConfig) error {
 	}
 
 	if _, err := base.SetMaxFileDescriptors(sc.MaxFileDescriptors); err != nil {
-		base.Errorf("Error setting MaxFileDescriptors to %d: %v", sc.MaxFileDescriptors, err)
+		base.ErrorfCtx(context.Background(), "Error setting MaxFileDescriptors to %d: %v", sc.MaxFileDescriptors, err)
 	}
 
 	// TODO: Remove with GoCB DCP switch

--- a/rest/debug.go
+++ b/rest/debug.go
@@ -96,7 +96,7 @@ func recordCBClientStat(opname, k string, start time.Time, err error) {
 }
 
 func (h *handler) handleExpvar() error {
-	base.Infof(base.KeyHTTP, "Recording snapshot of current debug variables.")
+	base.InfofCtx(h.ctx(), base.KeyHTTP, "Recording snapshot of current debug variables.")
 	h.rq.URL.Path = strings.Replace(h.rq.URL.Path, kDebugURLPathPrefix, "/debug/vars", 1)
 	http.DefaultServeMux.ServeHTTP(h.response, h.rq)
 	return nil

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -69,7 +69,7 @@ func (h *handler) handleGetDoc() error {
 		value, err := h.db.Get1xRevBodyWithHistory(docid, revid, revsLimit, revsFrom, attachmentsSince, showExp)
 		if err != nil {
 			if err == base.ErrImportCancelledPurged {
-				base.Debugf(base.KeyImport, fmt.Sprintf("Import cancelled as document %v is purged", base.UD(docid)))
+				base.DebugfCtx(h.ctx(), base.KeyImport, fmt.Sprintf("Import cancelled as document %v is purged", base.UD(docid)))
 				return nil
 			}
 			return err
@@ -126,7 +126,7 @@ func (h *handler) handleGetDoc() error {
 			})
 			return err
 		} else {
-			base.Debugf(base.KeyHTTP, "Fallback to non-multipart for open_revs")
+			base.DebugfCtx(h.ctx(), base.KeyHTTP, "Fallback to non-multipart for open_revs")
 			h.setHeader("Content-Type", "application/json")
 			_, _ = h.response.Write([]byte(`[` + "\n"))
 			separator := []byte(``)

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -392,7 +392,7 @@ func (h *handler) logDuration(realTime bool) {
 		logKey = base.KeyHTTP
 	}
 
-	base.Infof(logKey, "%s:     --> %d %s  (%.1f ms)",
+	base.InfofCtx(h.ctx(), logKey, "%s:     --> %d %s  (%.1f ms)",
 		h.formatSerialNumber(), h.status, h.statusMessage,
 		float64(duration)/float64(time.Millisecond),
 	)

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -983,7 +983,7 @@ func (h *handler) addJSON(value interface{}) error {
 		brokenPipeError := strings.Contains(err.Error(), "write: broken pipe")
 		connectionResetError := strings.Contains(err.Error(), "write: connection reset")
 		if brokenPipeError || connectionResetError {
-			base.Debugf(base.KeyCRUD, "Couldn't serialize document body, HTTP client closed connection")
+			base.DebugfCtx(h.ctx(), base.KeyCRUD, "Couldn't serialize document body, HTTP client closed connection")
 			return err
 		} else {
 			base.WarnfCtx(h.ctx(), "Couldn't serialize JSON for %s", err)

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -786,7 +786,7 @@ func (h *handler) readDocument() (db.Body, error) {
 			body, err := ReadMultipartDocument(reader)
 			if err != nil {
 				_ = ioutil.WriteFile("GatewayPUT.mime", raw, 0600)
-				base.Warnf("Error reading MIME data: copied to file GatewayPUT.mime")
+				base.WarnfCtx(h.ctx(), "Error reading MIME data: copied to file GatewayPUT.mime")
 			}
 			return body, err
 		} else {
@@ -906,14 +906,14 @@ func (h *handler) writeJSON(value interface{}) {
 // If status is nonzero, the header will be written with that status.
 func (h *handler) writeJSONStatus(status int, value interface{}) {
 	if !h.requestAccepts("application/json") {
-		base.Warnf("Client won't accept JSON, only %s", h.rq.Header.Get("Accept"))
+		base.WarnfCtx(h.ctx(), "Client won't accept JSON, only %s", h.rq.Header.Get("Accept"))
 		h.writeStatus(http.StatusNotAcceptable, "only application/json available")
 		return
 	}
 
 	jsonOut, err := base.JSONMarshalCanonical(value)
 	if err != nil {
-		base.Warnf("Couldn't serialize JSON for %v : %s", base.UD(value), err)
+		base.WarnfCtx(h.ctx(), "Couldn't serialize JSON for %v : %s", base.UD(value), err)
 		h.writeStatus(http.StatusInternalServerError, "JSON serialization failed")
 		return
 	}
@@ -935,7 +935,7 @@ func (h *handler) writeRawJSON(b []byte) {
 // If status is nonzero, the header will be written with that status.
 func (h *handler) writeRawJSONStatus(status int, b []byte) {
 	if !h.requestAccepts("application/json") {
-		base.Warnf("Client won't accept JSON, only %s", h.rq.Header.Get("Accept"))
+		base.WarnfCtx(h.ctx(), "Client won't accept JSON, only %s", h.rq.Header.Get("Accept"))
 		h.writeStatus(http.StatusNotAcceptable, "only application/json available")
 		return
 	}
@@ -962,7 +962,7 @@ func (h *handler) writeJavascript(js string) {
 // If status is nonzero, the header will be written with that status.
 func (h *handler) writeWithMimetypeStatus(status int, value []byte, mimetype string) {
 	if !h.requestAccepts(mimetype) {
-		base.Warnf("Client won't accept %s, only %s", mimetype, h.rq.Header.Get("Accept"))
+		base.WarnfCtx(h.ctx(), "Client won't accept %s, only %s", mimetype, h.rq.Header.Get("Accept"))
 		h.writeStatus(http.StatusNotAcceptable, fmt.Sprintf("only %s available", mimetype))
 		return
 	}
@@ -986,7 +986,7 @@ func (h *handler) addJSON(value interface{}) error {
 			base.Debugf(base.KeyCRUD, "Couldn't serialize document body, HTTP client closed connection")
 			return err
 		} else {
-			base.Warnf("Couldn't serialize JSON for %s", err)
+			base.WarnfCtx(h.ctx(), "Couldn't serialize JSON for %s", err)
 			h.writeStatus(http.StatusInternalServerError, "Couldn't serialize document body")
 		}
 	}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -1040,7 +1040,7 @@ func (h *handler) writeError(err error) {
 			if h.db != nil {
 				base.ErrorfCtx(h.db.Ctx, "%s: %v", h.formatSerialNumber(), err)
 			} else {
-				base.Errorf("%s: %v", h.formatSerialNumber(), err)
+				base.ErrorfCtx(h.ctx(), "%s: %v", h.formatSerialNumber(), err)
 			}
 		}
 	}

--- a/rest/main.go
+++ b/rest/main.go
@@ -23,7 +23,7 @@ import (
 // does the initial setup and finally starts the server.
 func ServerMain() {
 	if err := serverMain(context.Background(), os.Args); err != nil {
-		base.Fatalf("Couldn't start Sync Gateway: %v", err)
+		base.FatalfCtx(context.TODO(), "Couldn't start Sync Gateway: %v", err)
 	}
 }
 

--- a/rest/main.go
+++ b/rest/main.go
@@ -86,8 +86,8 @@ func serverMainPersistentConfig(fs *flag.FlagSet, flagStartupConfig *StartupConf
 				// the config is actually a 3.x config but with a genuine unknown field, therefore we should  return the
 				// original error from LoadStartupConfigFromPath.
 				if pkgerrors.Cause(upgradeError) == base.ErrUnknownField {
-					base.Warnf("Automatic upgrade attempt failed, %s not recognized as legacy config format: %v", base.MD(configPath[0]), upgradeError)
-					base.Warnf("Provided config %s not recognized as bootstrap config format: %v", base.MD(configPath[0]), err)
+					base.WarnfCtx(context.Background(), "Automatic upgrade attempt failed, %s not recognized as legacy config format: %v", base.MD(configPath[0]), upgradeError)
+					base.WarnfCtx(context.Background(), "Provided config %s not recognized as bootstrap config format: %v", base.MD(configPath[0]), err)
 					return false, fmt.Errorf("unknown config fields supplied. Unable to continue")
 				}
 
@@ -242,7 +242,7 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 	// Otherwise continue with startup but don't attempt to write migrated config and log warning
 	backupLocation, err := backupCurrentConfigFile(configPath)
 	if err != nil {
-		base.Warnf("Unable to write config file backup: %v. Won't write backup or updated config but will continue with startup.", err)
+		base.WarnfCtx(context.Background(), "Unable to write config file backup: %v. Won't write backup or updated config but will continue with startup.", err)
 		return startupConfig, false, users, roles, nil
 	}
 
@@ -259,7 +259,7 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 	// Otherwise continue with startup but log warning
 	err = ioutil.WriteFile(configPath, jsonStartupConfig, 0644)
 	if err != nil {
-		base.Warnf("Unable to write updated config file: %v -  but will continue with startup.", err)
+		base.WarnfCtx(context.Background(), "Unable to write updated config file: %v -  but will continue with startup.", err)
 		return startupConfig, false, users, roles, nil
 	}
 

--- a/rest/main.go
+++ b/rest/main.go
@@ -76,7 +76,7 @@ func serverMainPersistentConfig(fs *flag.FlagSet, flagStartupConfig *StartupConf
 			// If we have an unknown field error processing config its possible that the config is a 2.x config
 			// requiring automatic upgrade. We should attempt to perform this upgrade
 
-			base.Infof(base.KeyAll, "Found unknown fields in startup config. Attempting to read as legacy config.")
+			base.InfofCtx(context.Background(), base.KeyAll, "Found unknown fields in startup config. Attempting to read as legacy config.")
 
 			var upgradeError error
 			fileStartupConfig, disablePersistentConfigFallback, legacyDbUsers, legacyDbRoles, upgradeError = automaticConfigUpgrade(configPath[0])
@@ -134,7 +134,7 @@ func serverMainPersistentConfig(fs *flag.FlagSet, flagStartupConfig *StartupConf
 		return false, err
 	}
 
-	base.Infof(base.KeyAll, "Config: Starting in persistent mode using config group %q", sc.Bootstrap.ConfigGroupID)
+	base.InfofCtx(context.Background(), base.KeyAll, "Config: Starting in persistent mode using config group %q", sc.Bootstrap.ConfigGroupID)
 	ctx, err := setupServerContext(&sc, true)
 	if err != nil {
 		return false, err
@@ -185,7 +185,7 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 		return nil, true, users, roles, nil
 	}
 
-	base.Infof(base.KeyAll, "Config is a legacy config, and disable_persistent_config was not requested. Attempting automatic config upgrade.")
+	base.InfofCtx(context.Background(), base.KeyAll, "Config is a legacy config, and disable_persistent_config was not requested. Attempting automatic config upgrade.")
 
 	startupConfig, dbConfigs, err := legacyServerConfig.ToStartupConfig()
 	if err != nil {
@@ -229,12 +229,12 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 		if err != nil {
 			// If key already exists just continue
 			if errors.Is(err, base.ErrAlreadyExists) {
-				base.Infof(base.KeyAll, "Skipping Couchbase Server persistence for config group %q in %s. Already exists.", configGroupID, base.UD(dbc.Name))
+				base.InfofCtx(context.Background(), base.KeyAll, "Skipping Couchbase Server persistence for config group %q in %s. Already exists.", configGroupID, base.UD(dbc.Name))
 				continue
 			}
 			return nil, false, nil, nil, err
 		}
-		base.Infof(base.KeyAll, "Persisted database %s config for group %q to Couchbase Server bucket: %s", base.UD(dbc.Name), configGroupID, base.MD(*dbc.Bucket))
+		base.InfofCtx(context.Background(), base.KeyAll, "Persisted database %s config for group %q to Couchbase Server bucket: %s", base.UD(dbc.Name), configGroupID, base.MD(*dbc.Bucket))
 	}
 
 	// Attempt to backup current config
@@ -246,7 +246,7 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 		return startupConfig, false, users, roles, nil
 	}
 
-	base.Infof(base.KeyAll, "Current config backed up to %s", base.MD(backupLocation))
+	base.InfofCtx(context.Background(), base.KeyAll, "Current config backed up to %s", base.MD(backupLocation))
 
 	// Overwrite old config with new migrated startup config
 	jsonStartupConfig, err := json.MarshalIndent(startupConfig, "", "  ")
@@ -263,7 +263,7 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 		return startupConfig, false, users, roles, nil
 	}
 
-	base.Infof(base.KeyAll, "Current config file overwritten by upgraded config at %s", base.MD(configPath))
+	base.InfofCtx(context.Background(), base.KeyAll, "Current config file overwritten by upgraded config at %s", base.MD(configPath))
 	return startupConfig, false, users, roles, nil
 }
 
@@ -360,7 +360,7 @@ func createCouchbaseClusterFromStartupConfig(config *StartupConfig) (*base.Couch
 		config.Bootstrap.Password, config.Bootstrap.X509CertPath, config.Bootstrap.X509KeyPath,
 		config.Bootstrap.CACertPath, config.Bootstrap.ServerTLSSkipVerify)
 	if err != nil {
-		base.Infof(base.KeyConfig, "Couldn't create couchbase cluster instance: %v", err)
+		base.InfofCtx(context.Background(), base.KeyConfig, "Couldn't create couchbase cluster instance: %v", err)
 		return nil, err
 	}
 

--- a/rest/main_legacy.go
+++ b/rest/main_legacy.go
@@ -36,7 +36,7 @@ func legacyServerMain(osArgs []string, flagStartupConfig *StartupConfig) error {
 	}
 
 	if flagStartupConfig != nil {
-		base.Tracef(base.KeyAll, "got config from flags: %#v", flagStartupConfig)
+		base.TracefCtx(context.Background(), base.KeyAll, "got config from flags: %#v", flagStartupConfig)
 		err := sc.Merge(flagStartupConfig)
 		if err != nil {
 			return err

--- a/rest/main_legacy.go
+++ b/rest/main_legacy.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"reflect"
@@ -13,7 +14,7 @@ const flagDeprecated = `Flag "%s" is deprecated. Please use "%s" in future.`
 
 // legacyServerMain runs the pre-3.0 Sync Gateway server.
 func legacyServerMain(osArgs []string, flagStartupConfig *StartupConfig) error {
-	base.Warnf("Running in legacy config mode")
+	base.WarnfCtx(context.Background(), "Running in legacy config mode")
 
 	lc, err := setupServerConfig(osArgs)
 	if err != nil {
@@ -99,30 +100,30 @@ func fillConfigWithLegacyFlags(flags map[string]legacyConfigFlag, fs *flag.FlagS
 		switch f.Name {
 		case "interface", "adminInterface", "profileInterface", "url", "certpath", "keypath", "cacertpath", "logFilePath":
 			*cfgFlag.config.(*string) = *cfgFlag.flagValue.(*string)
-			base.Warnf(flagDeprecated, "-"+f.Name, "-"+cfgFlag.supersededFlag)
+			base.WarnfCtx(context.Background(), flagDeprecated, "-"+f.Name, "-"+cfgFlag.supersededFlag)
 		case "pretty":
 			rCfg := reflect.ValueOf(cfgFlag.config).Elem()
 			rFlag := reflect.ValueOf(cfgFlag.flagValue)
 			rCfg.Set(rFlag)
-			base.Warnf(flagDeprecated, "-"+f.Name, "-"+cfgFlag.supersededFlag)
+			base.WarnfCtx(context.Background(), flagDeprecated, "-"+f.Name, "-"+cfgFlag.supersededFlag)
 		case "verbose":
 			if *cfgFlag.flagValue.(*bool) {
 				if consoleLogLevelSet {
-					base.Warnf(`Cannot use deprecated flag "-verbose" with flag "-logging.console.log_level". To set Sync Gateway to be verbose, please use flag "-logging.console.log_level info". Ignoring flag...`)
+					base.WarnfCtx(context.Background(), `Cannot use deprecated flag "-verbose" with flag "-logging.console.log_level". To set Sync Gateway to be verbose, please use flag "-logging.console.log_level info". Ignoring flag...`)
 				} else {
 					*cfgFlag.config.(**base.LogLevel) = base.LogLevelPtr(base.LevelInfo)
-					base.Warnf(flagDeprecated, "-"+f.Name, "-logging.console.log_level info")
+					base.WarnfCtx(context.Background(), flagDeprecated, "-"+f.Name, "-logging.console.log_level info")
 				}
 			}
 		case "log":
 			list := strings.Split(*cfgFlag.flagValue.(*string), ",")
 			*cfgFlag.config.(*[]string) = list
-			base.Warnf(flagDeprecated, "-"+f.Name, "-"+cfgFlag.supersededFlag)
+			base.WarnfCtx(context.Background(), flagDeprecated, "-"+f.Name, "-"+cfgFlag.supersededFlag)
 		case "configServer":
 			err := fmt.Errorf(`flag "-%s" is no longer supported and has been removed`, f.Name)
 			errors = errors.Append(err)
 		case "dbname", "deploymentID":
-			base.Warnf(`Flag "-%s" is no longer supported and has been removed.`, f.Name)
+			base.WarnfCtx(context.Background(), `Flag "-%s" is no longer supported and has been removed.`, f.Name)
 		}
 	})
 	return errors.ErrorOrNil()

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -89,7 +89,7 @@ func (h *handler) handleOIDCChallenge() error {
 
 func (h *handler) handleOIDCCommon() (redirectURLString string, err error) {
 	providerName := h.getQuery(requestParamProvider)
-	base.Infof(base.KeyAuth, "Getting provider for name %v", base.UD(providerName))
+	base.InfofCtx(h.ctx(), base.KeyAuth, "Getting provider for name %v", base.UD(providerName))
 	provider, err := h.getOIDCProvider(providerName)
 	if err != nil || provider == nil {
 		return redirectURLString, err
@@ -187,7 +187,7 @@ func (h *handler) handleOIDCCallback() error {
 	if !ok {
 		return base.HTTPErrorf(http.StatusInternalServerError, "No id_token field in oauth2 token.")
 	}
-	base.Infof(base.KeyAuth, "Obtained token from Authorization Server: %v", rawIDToken)
+	base.InfofCtx(h.ctx(), base.KeyAuth, "Obtained token from Authorization Server: %v", rawIDToken)
 
 	// Create a Sync Gateway session
 	username, sessionID, err := h.createSessionForTrustedIdToken(rawIDToken, provider)
@@ -232,7 +232,7 @@ func (h *handler) handleOIDCRefresh() error {
 	context := auth.GetOIDCClientContext(provider.InsecureSkipVerify)
 	token, err := client.Config().TokenSource(context, &oauth2.Token{RefreshToken: refreshToken}).Token()
 	if err != nil {
-		base.Infof(base.KeyAuth, "Unsuccessful token refresh: %v", err)
+		base.InfofCtx(h.ctx(), base.KeyAuth, "Unsuccessful token refresh: %v", err)
 		return base.HTTPErrorf(http.StatusInternalServerError, "Unable to refresh token.")
 	}
 
@@ -240,7 +240,7 @@ func (h *handler) handleOIDCRefresh() error {
 	if !ok {
 		return base.HTTPErrorf(http.StatusInternalServerError, "No id_token field in oauth2 token.")
 	}
-	base.Infof(base.KeyAuth, "Obtained token from Authorization Server: %v", rawIDToken)
+	base.InfofCtx(h.ctx(), base.KeyAuth, "Obtained token from Authorization Server: %v", rawIDToken)
 
 	username, sessionID, err := h.createSessionForTrustedIdToken(rawIDToken, provider)
 	if err != nil {

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -157,7 +157,7 @@ func (h *handler) handleOIDCCallback() error {
 		}
 
 		if err != nil {
-			base.Warnf("Unexpected error attempting to read OIDC state cookie: %v", err)
+			base.WarnfCtx(h.ctx(), "Unexpected error attempting to read OIDC state cookie: %v", err)
 			return ErrReadStateCookie
 		}
 
@@ -294,7 +294,7 @@ func (h *handler) getOIDCProvider(providerName string) (*auth.OIDCProvider, erro
 func (h *handler) getOIDCCallbackURL(providerName string, isDefault bool) string {
 	dbName := h.PathVar("db")
 	if dbName == "" {
-		base.Warnf("Can't calculate OIDC callback URL without DB in path.")
+		base.WarnfCtx(h.ctx(), "Can't calculate OIDC callback URL without DB in path.")
 		return ""
 	}
 
@@ -310,7 +310,7 @@ func (h *handler) getOIDCCallbackURL(providerName string, isDefault bool) string
 
 	callbackURL, err := auth.SetURLQueryParam(callbackURL, auth.OIDCAuthProvider, providerName)
 	if err != nil {
-		base.Warnf("Failed to add provider %q to OIDC callback URL (%s): %v", base.UD(providerName), callbackURL, err)
+		base.WarnfCtx(h.ctx(), "Failed to add provider %q to OIDC callback URL (%s): %v", base.UD(providerName), callbackURL, err)
 	}
 	return callbackURL
 }

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package rest
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
@@ -236,7 +237,7 @@ func renderJSON(w http.ResponseWriter, r *http.Request, statusCode int, data int
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	if err := json.NewEncoder(w).Encode(data); err != nil {
-		base.Errorf("Error rendering JSON response: %s", err)
+		base.ErrorfCtx(r.Context(), "Error rendering JSON response: %s", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -253,7 +254,7 @@ func (s *mockAuthServer) authHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	redirect := r.URL.Query().Get(requestParamRedirectURI)
 	if redirect == "" {
-		base.Errorf("No redirect URL found in auth request")
+		base.ErrorfCtx(r.Context(), "No redirect URL found in auth request")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -278,7 +279,7 @@ func (s *mockAuthServer) authHandler(w http.ResponseWriter, r *http.Request) {
 	if s.options.forceError.errorType == untoldProviderErr {
 		uri, err := auth.SetURLQueryParam(redirectionURL, requestParamProvider, "untold")
 		if err != nil {
-			base.Errorf("error setting untold provider in mock callback URL")
+			base.ErrorfCtx(r.Context(), "error setting untold provider in mock callback URL")
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -335,7 +336,7 @@ func (s *mockAuthServer) makeToken(claimSet claimSet) (string, error) {
 	builder := jwt.Signed(s.signer).Claims(primaryClaims).Claims(secondaryClaims)
 	token, err := builder.CompactSerialize()
 	if err != nil {
-		base.Errorf("Error serializing token: %s", err)
+		base.ErrorfCtx(context.TODO(), "Error serializing token: %s", err)
 		return "", err
 	}
 	return token, nil

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -265,7 +265,7 @@ func (s *mockAuthServer) authHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	code, err := base.GenerateRandomSecret()
 	if err != nil {
-		base.Errorf(err.Error())
+		base.ErrorfCtx(r.Context(), err.Error())
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/rest/oidc_test_provider.go
+++ b/rest/oidc_test_provider.go
@@ -9,6 +9,7 @@
 package rest
 
 import (
+	"context"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
@@ -154,7 +155,7 @@ func (h *handler) handleOidcProviderConfiguration() error {
 	}
 
 	issuerUrl := issuerUrl(h)
-	base.Debugf(base.KeyAuth, "handleOidcProviderConfiguration issuerURL = %s", issuerUrl)
+	base.DebugfCtx(h.ctx(), base.KeyAuth, "handleOidcProviderConfiguration issuerURL = %s", issuerUrl)
 
 	config := &auth.ProviderMetadata{
 		Issuer:                            issuerUrl,
@@ -330,10 +331,10 @@ func (h *handler) handleOidcTestProviderAuthenticate() error {
 	tokenDuration := time.Duration(tokenTtl) * time.Second
 	authenticated := h.rq.FormValue(formKeyAuthenticated)
 	redirectURI := requestParams.Get(requestParamRedirectURI)
-	base.Debugf(base.KeyAuth, "handleOidcTestProviderAuthenticate() called.  username: %s authenticated: %s", username, authenticated)
+	base.DebugfCtx(h.ctx(), base.KeyAuth, "handleOidcTestProviderAuthenticate() called.  username: %s authenticated: %s", username, authenticated)
 
 	if username == "" || authenticated == "" {
-		base.Debugf(base.KeyAuth, "user did not enter valid credentials -- username or authenticated is empty")
+		base.DebugfCtx(h.ctx(), base.KeyAuth, "user did not enter valid credentials -- username or authenticated is empty")
 		error := "?error=invalid_request&error_description=User failed authentication"
 		h.setHeader(headerLocation, requestParams.Get(requestParamRedirectURI)+error)
 		h.response.WriteHeader(http.StatusFound)
@@ -542,13 +543,13 @@ func writeTokenResponse(h *handler, subject string, issuerUrl string, authState 
 func extractSubjectFromRefreshToken(refreshToken string) (string, error) {
 	decodedToken, err := base64.StdEncoding.DecodeString(refreshToken)
 	if err != nil {
-		base.Debugf(base.KeyAuth, "invalid refresh token provided, error: %v", err)
+		base.DebugfCtx(context.Background(), base.KeyAuth, "invalid refresh token provided, error: %v", err)
 		return "", base.HTTPErrorf(http.StatusBadRequest, "Invalid OIDC Refresh Token")
 	}
 
 	components := strings.Split(string(decodedToken), ":::")
 	subject := components[0]
-	base.Debugf(base.KeyAuth, "subject extracted from refresh token = %v", subject)
+	base.DebugfCtx(context.Background(), base.KeyAuth, "subject extracted from refresh token = %v", subject)
 
 	if len(components) != 2 || subject == "" {
 		return "", base.HTTPErrorf(http.StatusBadRequest, "OIDC Refresh Token does not contain subject")

--- a/rest/oidc_test_provider.go
+++ b/rest/oidc_test_provider.go
@@ -198,7 +198,7 @@ func (h *handler) handleOidcTestProviderAuthorize() error {
 
 	requestParams := h.rq.URL.RawQuery
 
-	base.Infof(base.KeyAuth, "handleOidcTestProviderAuthorize() raw authorize request raw query params = %v", requestParams)
+	base.InfofCtx(h.ctx(), base.KeyAuth, "handleOidcTestProviderAuthorize() raw authorize request raw query params = %v", requestParams)
 
 	scope := h.getQueryValues().Get(requestParamScope)
 	if scope == "" {
@@ -259,7 +259,7 @@ func (h *handler) handleOidcTestProviderToken() error {
 		return base.HTTPErrorf(http.StatusForbidden, "OIDC test provider is not enabled")
 	}
 
-	base.Infof(base.KeyAuth, "handleOidcTestProviderToken() called")
+	base.InfofCtx(h.ctx(), base.KeyAuth, "handleOidcTestProviderToken() called")
 
 	// determine the grant_type being requested
 	grantType := h.rq.FormValue("grant_type")
@@ -282,7 +282,7 @@ func (h *handler) handleOidcTestProviderCerts() error {
 		return base.HTTPErrorf(http.StatusForbidden, "OIDC test provider is not enabled")
 	}
 
-	base.Infof(base.KeyAuth, "handleOidcTestProviderCerts() called")
+	base.InfofCtx(h.ctx(), base.KeyAuth, "handleOidcTestProviderCerts() called")
 
 	privateKey, err := privateKey()
 	if err != nil {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1084,7 +1084,7 @@ func (sc *ServerContext) startStatsLogger() {
 					base.WarnfCtx(context.TODO(), "Error logging stats: %v", err)
 				}
 			case <-sc.statsContext.terminator:
-				base.Debugf(base.KeyAll, "Stopping stats logging goroutine")
+				base.DebugfCtx(context.TODO(), base.KeyAll, "Stopping stats logging goroutine")
 				sc.statsContext.statsLoggingTicker.Stop()
 				return
 			}
@@ -1438,7 +1438,7 @@ func (sc *ServerContext) initializeCouchbaseServerConnections() error {
 						t.Stop()
 						return
 					case <-t.C:
-						base.Debugf(base.KeyConfig, "Fetching configs from buckets in cluster for group %q", sc.config.Bootstrap.ConfigGroupID)
+						base.DebugfCtx(logCtx, base.KeyConfig, "Fetching configs from buckets in cluster for group %q", sc.config.Bootstrap.ConfigGroupID)
 						count, err := sc.fetchAndLoadConfigs()
 						if err != nil {
 							base.WarnfCtx(logCtx, "Couldn't load configs from bucket when polled: %v", err)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -822,7 +822,7 @@ func (sc *ServerContext) TakeDbOnline(database *db.DatabaseContext) {
 	if atomic.CompareAndSwapUint32(&database.State, db.DBOffline, db.DBStarting) {
 		reloadedDb, err := sc.ReloadDatabase(database.Name)
 		if err != nil {
-			base.Errorf("Error reloading database from config: %v", err)
+			base.ErrorfCtx(context.TODO(), "Error reloading database from config: %v", err)
 			return
 		}
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -10,7 +10,6 @@ package rest
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -616,7 +615,7 @@ func TestLogFlush(t *testing.T) {
 			testDirName := filepath.Base(tempPath)
 
 			// Log some stuff (which will go into the memory loggers)
-			ctx := context.Background()
+			ctx := base.TestCtx(t)
 			base.ErrorfCtx(ctx, "error: "+testDirName)
 			base.WarnfCtx(ctx, "warn: "+testDirName)
 			base.InfofCtx(ctx, base.KeyAll, "info: "+testDirName)

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -10,6 +10,7 @@ package rest
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -615,11 +616,12 @@ func TestLogFlush(t *testing.T) {
 			testDirName := filepath.Base(tempPath)
 
 			// Log some stuff (which will go into the memory loggers)
-			base.Errorf("error: " + testDirName)
-			base.Warnf("warn: " + testDirName)
-			base.Infof(base.KeyAll, "info: "+testDirName)
-			base.Debugf(base.KeyAll, "debug: "+testDirName)
-			base.Tracef(base.KeyAll, "trace: "+testDirName)
+			ctx := context.Background()
+			base.ErrorfCtx(ctx, "error: "+testDirName)
+			base.WarnfCtx(ctx, "warn: "+testDirName)
+			base.InfofCtx(ctx, base.KeyAll, "info: "+testDirName)
+			base.DebugfCtx(ctx, base.KeyAll, "debug: "+testDirName)
+			base.TracefCtx(ctx, base.KeyAll, "trace: "+testDirName)
 			base.RecordStats("{}")
 
 			config := DefaultStartupConfig(tempPath)

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -152,7 +152,7 @@ func (h *handler) makeSessionFromNameAndEmail(username, email string, createUser
 			if email != user.Email() {
 				if err = h.db.Authenticator(h.db.Ctx).UpdateUserEmail(user, email); err != nil {
 					// Failure to update email during session creation is non-critical, log and continue.
-					base.Infof(base.KeyAuth, "Unable to update email for user %s during session creation.  Session will still be created. Error:%v,", base.UD(username), err)
+					base.InfofCtx(h.ctx(), base.KeyAuth, "Unable to update email for user %s during session creation.  Session will still be created. Error:%v,", base.UD(username), err)
 				}
 			}
 		} else {

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -76,7 +76,7 @@ func (sg *sgCollect) Start(logFilePath string, ctxSerialNumber uint64, zipFilena
 		// If no output directory specified, default to the configured LogFilePath
 		if logFilePath != "" {
 			params.OutputDirectory = logFilePath
-			base.Debugf(base.KeyAdmin, "sgcollect_info: no output directory specified, using LogFilePath: %v", params.OutputDirectory)
+			base.DebugfCtx(sg.context, base.KeyAdmin, "sgcollect_info: no output directory specified, using LogFilePath: %v", params.OutputDirectory)
 		} else {
 			// If LogFilePath is not set, and DefaultLogFilePath is not set via a service script, error out.
 			return errors.New("no output directory or LogFilePath specified")
@@ -308,6 +308,7 @@ func sgCollectPaths() (sgBinary, sgCollectBinary string, err error) {
 		return "", "", err
 	}
 
+	logCtx := context.Background()
 	hasBinDir := true
 	sgCollectPath := filepath.Join("tools", "sgcollect_info")
 
@@ -325,7 +326,7 @@ func sgCollectPaths() (sgBinary, sgCollectBinary string, err error) {
 		}
 
 		// Check sgcollect_info exists at the path we guessed.
-		base.Debugf(base.KeyAdmin, "Checking sgcollect_info binary exists at: %v", sgCollectBinary)
+		base.DebugfCtx(logCtx, base.KeyAdmin, "Checking sgcollect_info binary exists at: %v", sgCollectBinary)
 		_, err = os.Stat(sgCollectBinary)
 		if err != nil {
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -562,7 +562,7 @@ func (rt *RestTester) WaitForNViewResults(numResultsExpected int, viewUrlPath st
 		// If the view is undefined, it might be a race condition where the view is still being created
 		// See https://github.com/couchbase/sync_gateway/issues/3570#issuecomment-390487982
 		if strings.Contains(response.Body.String(), "view_undefined") {
-			base.Infof(base.KeyAll, "view_undefined error: %v.  Retrying", response.Body.String())
+			base.InfofCtx(response.Req.Context(), base.KeyAll, "view_undefined error: %v.  Retrying", response.Body.String())
 			return true, nil, nil
 		}
 

--- a/rest/view_api.go
+++ b/rest/view_api.go
@@ -111,7 +111,7 @@ func (h *handler) handleView() error {
 		}
 	}
 
-	base.Infof(base.KeyHTTP, "JSON view %q/%q - opts %v", base.MD(ddocName), base.MD(viewName), base.MD(opts))
+	base.InfofCtx(h.ctx(), base.KeyHTTP, "JSON view %q/%q - opts %v", base.MD(ddocName), base.MD(viewName), base.MD(opts))
 
 	result, err := h.db.QueryDesignDoc(ddocName, viewName, opts)
 	if err != nil {

--- a/rest/view_api.go
+++ b/rest/view_api.go
@@ -24,7 +24,7 @@ import (
 // HTTP handler for GET _design/$ddoc
 func (h *handler) handleGetDesignDoc() error {
 	ddocID := h.PathVar("ddoc")
-	base.Debugf(base.KeyAll, "GetDesignDoc %v", base.MD(ddocID))
+	base.DebugfCtx(h.ctx(), base.KeyAll, "GetDesignDoc %v", base.MD(ddocID))
 	var result interface{}
 	if ddocID == db.DesignDocSyncGateway() {
 		// we serve this content here so that CouchDB 1.2 has something to


### PR DESCRIPTION
CBG-1925

- general idea with exceptions: 
- tried to use existing context, explicitly declared or from objects already available.
- if no ctx available, used ```context.Background()``` for logging from inside getter/setter/validation/util functions. 
- used ```context.TODO()``` in all other places: running processes, operations, etc., where it was not clear what info could be helpful to log. 
- in addition, and pending confirmation from devs, replaced fatalf and panicf, which were not mentioned in the ticket.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/142/
