### PR TITLE
CBG-1929: Legacy replication configs are now validated and removed replication `cancel` field

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -53,7 +53,6 @@ const (
 	ConfigErrorMissingDirection                 = "Replication direction must be specified"
 	ConfigErrorDuplicateCredentials             = "Auth credentials can be specified using remote_username/remote_password config properties or remote URL, but not both"
 	ConfigErrorConfigBasedAdhoc                 = "adhoc=true is invalid for replication in Sync Gateway configuration"
-	ConfigErrorConfigBasedCancel                = "cancel=true is invalid for replication in Sync Gateway configuration"
 	ConfigErrorInvalidConflictResolutionTypeFmt = "Conflict resolution type is invalid, valid values are %s/%s/%s/%s"
 	ConfigErrorInvalidDirectionFmt              = "Invalid replication direction %q, valid values are %s/%s/%s"
 	ConfigErrorBadChannelsArray                 = "Bad channels array in query_params for sync_gateway/bychannel filter"
@@ -107,7 +106,6 @@ type ReplicationConfig struct {
 	Continuous             bool                      `json:"continuous"`
 	Filter                 string                    `json:"filter,omitempty"`
 	QueryParams            interface{}               `json:"query_params,omitempty"`
-	Cancel                 bool                      `json:"cancel,omitempty"`
 	Adhoc                  bool                      `json:"adhoc,omitempty"`
 	BatchSize              int                       `json:"batch_size,omitempty"`
 	RunAs                  string                    `json:"run_as,omitempty"`
@@ -151,7 +149,6 @@ type ReplicationUpsertConfig struct {
 	Continuous             *bool       `json:"continuous"`
 	Filter                 *string     `json:"filter,omitempty"`
 	QueryParams            interface{} `json:"query_params,omitempty"`
-	Cancel                 *bool       `json:"cancel,omitempty"`
 	Adhoc                  *bool       `json:"adhoc,omitempty"`
 	BatchSize              *int        `json:"batch_size,omitempty"`
 	RunAs                  *string     `json:"run_as,omitempty"`
@@ -177,11 +174,6 @@ func (rc *ReplicationConfig) ValidateReplication(fromConfig bool) (err error) {
 	// key-related enhancements
 	if len(rc.ID) > 160 {
 		return base.HTTPErrorf(http.StatusBadRequest, ConfigErrorIDTooLong)
-	}
-
-	// Cancel is only supported via the REST API
-	if rc.Cancel && fromConfig {
-		return base.HTTPErrorf(http.StatusBadRequest, ConfigErrorConfigBasedCancel)
 	}
 
 	if rc.Adhoc {
@@ -300,9 +292,6 @@ func (rc *ReplicationConfig) Upsert(c *ReplicationUpsertConfig) {
 	}
 	if c.Filter != nil {
 		rc.Filter = *c.Filter
-	}
-	if c.Cancel != nil {
-		rc.Cancel = *c.Cancel
 	}
 	if c.Adhoc != nil {
 		rc.Adhoc = *c.Adhoc

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -493,7 +493,6 @@ func TestUpsertReplicationConfig(t *testing.T) {
 				Continuous:             true,
 				Filter:                 "a",
 				QueryParams:            []interface{}{"ABC"},
-				Cancel:                 true,
 			},
 			updatedConfig: &ReplicationUpsertConfig{
 				ID:                     "foo",
@@ -508,7 +507,6 @@ func TestUpsertReplicationConfig(t *testing.T) {
 				Continuous:             base.BoolPtr(false),
 				Filter:                 base.StringPtr("b"),
 				QueryParams:            []interface{}{"DEF"},
-				Cancel:                 base.BoolPtr(false),
 			},
 			expectedConfig: &ReplicationConfig{
 				ID:                     "foo",
@@ -523,7 +521,6 @@ func TestUpsertReplicationConfig(t *testing.T) {
 				Continuous:             false,
 				Filter:                 "b",
 				QueryParams:            []interface{}{"DEF"},
-				Cancel:                 false,
 			},
 		},
 	}
@@ -554,7 +551,6 @@ func TestIsCfgChanged(t *testing.T) {
 				Continuous:             true,
 				Filter:                 "a",
 				QueryParams:            []interface{}{"ABC"},
-				Cancel:                 true,
 				Username:               "alice",
 				Password:               "password",
 			},

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -655,9 +655,6 @@ Retrieved-replication:
       type: array
       items:
         type: string
-    cancel:
-      description: Unused field
-      type: boolean
     adhoc:
       description: |-
         Set to true to run the replication as an adhoc replication instead of a persistent one.
@@ -857,9 +854,6 @@ Replication:
       type: array
       items:
         type: string
-    cancel:
-      description: Unused field
-      type: boolean
     adhoc:
       description: |-
         Set to true to run the replication as an adhoc replication instead of a persistent one.

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -111,6 +111,18 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 			dbConfig.SlowQueryWarningThresholdMs = base.Uint32Ptr(uint32(*lc.SlowQueryWarningThreshold))
 		}
 
+		// Validate replication configs
+		for replicationID, replicationConfig := range dbConfig.Replications {
+			if replicationConfig.ID != "" && replicationConfig.ID != replicationID {
+				return nil, nil, fmt.Errorf("replication_id %q does not match replications key %q in replication config", replicationConfig.ID, replicationID)
+			}
+
+			err := replicationConfig.ValidateReplication(true)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+
 		if dbConfig.Server == nil || *dbConfig.Server == "" {
 			continue
 		}

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -1239,14 +1239,6 @@ func TestValidateReplication(t *testing.T) {
 		eeOnly            bool
 	}{
 		{
-			name: "replication config unsupported Cancel option",
-			replicationConfig: db.ReplicationConfig{
-				Cancel: true,
-			},
-			fromConfig:       true,
-			expectedErrorMsg: db.ConfigErrorConfigBasedCancel,
-		},
-		{
 			name: "replication config unsupported Adhoc option",
 			replicationConfig: db.ReplicationConfig{
 				Adhoc: true,


### PR DESCRIPTION
CBG-1929

- The replication configurations provided for each static database in a legacy configuration is now validated (along with the specific config only validations)
- Added validation when using a legacy config to make sure the replication key matches the replication ID (as was in 2.8.3)
- Removed the unused `cancel` field from a replication config
- Added unit test to confirm legacy config replication validation works, and tested manually as well

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/144/
