### PR TITLE
CBG-1972: Fixed flaky test TestAdminReduceSumQuery caused by race

### DIFF
--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -368,16 +368,18 @@ func TestAdminReduceSumQuery(t *testing.T) {
 		// Create docs:
 		response = rt.SendRequest(http.MethodPut, fmt.Sprintf("/db/doc%v", i), `{"key":"A", "value":1}`)
 		assertStatus(t, response, http.StatusCreated)
-
 	}
 	response = rt.SendRequest(http.MethodPut, fmt.Sprintf("/db/doc%v", 10), `{"key":"B", "value":99}`)
 	assertStatus(t, response, http.StatusCreated)
 
-	var result sgbucket.ViewResult
+	// Wait for all created documents to avoid race when using "reduce"
+	_, err := rt.WaitForNAdminViewResults(10, "/db/_design/foo/_view/bar?reduce=false")
+	require.NoError(t, err, "Unexpected error")
 
+	var result sgbucket.ViewResult
 	// Admin view query:
-	result, err := rt.WaitForNAdminViewResults(1, "/db/_design/foo/_view/bar?reduce=true")
-	assert.NoError(t, err, "Unexpected error")
+	result, err = rt.WaitForNAdminViewResults(1, "/db/_design/foo/_view/bar?reduce=true")
+	require.NoError(t, err, "Unexpected error")
 
 	// we should get 1 row with the reduce result
 	require.Len(t, result.Rows, 1)


### PR DESCRIPTION
CBG-1972

- Added extra wait for all the documents to be ran through the view before doing the reduce.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/147/
