### PR TITLE
CBG-1969: Override revpos when client erroneously doesn't update it

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -971,15 +971,10 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 					return base.HTTPErrorf(http.StatusInternalServerError, "Current attachment data is invalid")
 				}
 
-				currentAttachmentRevpos, ok := base.ToInt64(currentAttachmentMeta["revpos"])
-				if !ok {
-					return base.HTTPErrorf(http.StatusInternalServerError, "Current attachment data is invalid")
-				}
-
-				// Compare the revpos and attachment digest. If revpos is same but attachment digest is different we
-				// need to override the revpos and set it to the current revision as the incoming revpos must be invalid
-				// and we need to request it.
-				if currentAttachmentRevpos == incomingAttachmentRevpos && currentAttachmentDigest != incomingAttachmentDigest {
+				// Compare the revpos and attachment digest. If incoming revpos is less than or equal to minRevPos and
+				// digest is different we need to override the revpos and set it to the current revision as the incoming
+				// revpos must be invalid and we need to request it.
+				if int(incomingAttachmentRevpos) <= minRevpos && currentAttachmentDigest != incomingAttachmentDigest {
 					minRevpos, _ = ParseRevID(history[len(history)-1])
 					bodyAtts[name].(map[string]interface{})["revpos"], _ = ParseRevID(revID)
 				}

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -3859,3 +3859,43 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	base.RequireWaitForStat(t, pullStats.NumPullReplActiveOneShot.Value, 0)
 	base.RequireWaitForStat(t, pullStats.NumPullReplActiveContinuous.Value, 0)
 }
+
+func TestAttachmentWithErroneousRevPos(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		guestEnabled: true,
+	})
+	defer rt.Close()
+
+	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
+	require.NoError(t, err)
+	defer btc.Close()
+
+	// Create rev 1 with the hello.txt attachment
+	revid := rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"val": "val", "_attachments": map[string]interface{}{"hello.txt": map[string]interface{}{"data": "aGVsbG8gd29ybGQ="}}})
+	err = rt.WaitForPendingChanges()
+	assert.NoError(t, err)
+
+	// Pull rev and attachment down to client
+	err = btc.StartOneshotPull()
+	assert.NoError(t, err)
+	_, found := btc.WaitForRev("doc", revid)
+	assert.True(t, found)
+
+	// Add an attachment to client
+	btc.attachmentsLock.Lock()
+	btc.attachments["sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="] = []byte("goodbye cruel world")
+	btc.attachmentsLock.Unlock()
+
+	// Put doc with an erroneous revpos 1 but with a different digest, referring to the above attachment
+	revid, err = btc.PushRevWithHistory("doc", revid, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"length": 19,"digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="}}}`), 1, 0)
+	require.NoError(t, err)
+
+	// Ensure message and attachment is pushed up
+	_, ok := btc.pushReplication.WaitForMessage(2)
+	assert.True(t, ok)
+
+	// Get the attachment and ensure the data is updated
+	resp := rt.SendAdminRequest(http.MethodGet, "/db/doc/hello.txt", "")
+	assertStatus(t, resp, http.StatusOK)
+	assert.Equal(t, "goodbye cruel world", string(resp.BodyBytes()))
+}


### PR DESCRIPTION
CBG-1969

Prior versions of CBL can end up in a situation where, if an attachment is updated, the revpos is not incremented, meaning that it will remain the same as the prior version of the attachment. This means that Sync Gateway never gets or knows about the updated attachment and therefore the data is not stored on CBS or replicated to other clients.

This PR aims to work around this issue by checking for the erroneous revpos and overriding it. 
- Obtains current bucket doc to compare against (if available)
- Checks revpos and digest for the current and incoming document
- If revpos is same but digest is different update revpos to latest revpos so that we know to request the new data

(Also moved the len(history) > 1 check inside the attachment section as its the only place it was used anyway.

This is tested by a unit test. It creates an attachment on SGW and pulls the attachment down to the client. It then updates this attachment and pushes up purposfully incorrect attachment meta --> An updated digest but with the old name and with the old revpos. A GET to SGW is then issued to ensure that it does indeed have the updated attachment.

