### PR TITLE
Fixed flaky test TestAdminReduceViewQuery

### DIFF
--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -325,10 +325,13 @@ func TestAdminReduceViewQuery(t *testing.T) {
 	response = rt.SendRequest(http.MethodPut, fmt.Sprintf("/db/doc%v", 10), `{"key":1, "value":"0", "channel":"W"}`)
 	assertStatus(t, response, http.StatusCreated)
 
-	var result sgbucket.ViewResult
+	// Wait for all created documents to avoid race when using "reduce"
+	_, err := rt.WaitForNAdminViewResults(10, "/db/_design/foo/_view/bar?reduce=false")
+	require.NoError(t, err, "Unexpected error")
 
+	var result sgbucket.ViewResult
 	// Admin view query:
-	result, err := rt.WaitForNAdminViewResults(1, "/db/_design/foo/_view/bar?reduce=true")
+	result, err = rt.WaitForNAdminViewResults(1, "/db/_design/foo/_view/bar?reduce=true")
 	assert.NoError(t, err, "Unexpected error")
 
 	// we should get 1 row with the reduce result


### PR DESCRIPTION
- Applied fix from #5459 ([CBG-1972](https://issues.couchbase.com/browse/CBG-1972)) to `TestAdminReduceViewQuery`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true count=50 test=^TestAdminReduceViewQuery` https://jenkins.sgwdev.com/job/SyncGateway-Integration/148/
