### PR TITLE
Fixed description for "marked_attachment" on the Rest API specifications

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1524,7 +1524,7 @@ Compact-status:
       description: |-
         **Applicable to attachment compaction only**
 
-        This is the amount of attachments that have been marked to be kept.
+        This is the number of references there are to legacy attachments. 
       type: string
     purged_attachments:
       description: |-

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1524,7 +1524,7 @@ Compact-status:
       description: |-
         **Applicable to attachment compaction only**
 
-        This is the amount of attachments that have been marked to be purged.
+        This is the amount of attachments that have been marked to be kept.
       type: string
     purged_attachments:
       description: |-


### PR DESCRIPTION
Modified the compact endpoint `marked_attachments` description to show that it does not purge marked attachments.