### PR TITLE
CBG-1963: TestConcurrentRefreshUser sends all revs before starting changes timeout timer

### DIFF
--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1005,7 +1005,7 @@ function(doc, oldDoc) {
 }
 
 // Start subChanges w/ continuous=true, batchsize=20
-// Start goroutine sending rev messages for documents that grant access to themselves for the active replication's user
+// Start sending rev messages for documents that grant access to themselves for the active replication's user
 
 func TestConcurrentRefreshUser(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)()
@@ -1114,31 +1114,29 @@ function(doc, oldDoc) {
 	subChangesResponse := subChangesRequest.Response()
 	goassert.Equals(t, subChangesResponse.SerialNumber(), subChangesRequest.SerialNumber())
 
-	// Start goroutine to simulate sending docs from the client
-
+	// Start goroutines to simulate sending docs from the client
 	receivedChangesWg.Add(100)
 	revsFinishedWg.Add(100)
-	go func() {
-		for i := 0; i < 100; i++ {
-			docID := fmt.Sprintf("foo_%d", i)
-			_, _, _, sendErr := bt.SendRev(
-				docID,
-				"1-abc",
-				[]byte(`{"accessUser": "user1",
-				"accessChannel":"`+docID+`",
-				"channels":["`+docID+`"]}`),
-				blip.Properties{},
-			)
-			assert.NoError(t, sendErr)
-		}
-	}()
+	beforeChangesSent := time.Now().UnixMilli()
+	for i := 0; i < 100; i++ {
+		docID := fmt.Sprintf("foo_%d", i)
+		_, _, _, sendErr := bt.SendRev(
+			docID,
+			"1-abc",
+			[]byte(`{"accessUser": "user1",
+			"accessChannel":"`+docID+`",
+			"channels":["`+docID+`"]}`),
+			blip.Properties{},
+		)
+		assert.NoError(t, sendErr)
+	}
 
 	// Wait until all expected changes are received by change handler
-	// receivedChangesWg.Wait()
-	timeoutErr := WaitWithTimeout(&receivedChangesWg, time.Second*60)
+	timeoutErr := WaitWithTimeout(&receivedChangesWg, time.Second*30)
 	assert.NoError(t, timeoutErr, "Timed out waiting for all changes.")
+	fmt.Println("Revs sent and changes received in", time.Now().UnixMilli()-beforeChangesSent, "ms")
 
-	revTimeoutErr := WaitWithTimeout(&revsFinishedWg, time.Second*60)
+	revTimeoutErr := WaitWithTimeout(&revsFinishedWg, time.Second*30)
 	assert.NoError(t, revTimeoutErr, "Timed out waiting for all revs.")
 
 	assert.False(t, nonIntegerSequenceReceived, "Unexpected non-integer sequence seen.")

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1006,7 +1006,6 @@ function(doc, oldDoc) {
 
 // Start subChanges w/ continuous=true, batchsize=20
 // Start sending rev messages for documents that grant access to themselves for the active replication's user
-
 func TestConcurrentRefreshUser(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)()
 	// Initialize restTester here, so that we can use custom sync function, and later modify user
@@ -1114,10 +1113,13 @@ function(doc, oldDoc) {
 	subChangesResponse := subChangesRequest.Response()
 	goassert.Equals(t, subChangesResponse.SerialNumber(), subChangesRequest.SerialNumber())
 
-	// Start goroutines to simulate sending docs from the client
+	// Simulate sending docs from the client
 	receivedChangesWg.Add(100)
 	revsFinishedWg.Add(100)
 	beforeChangesSent := time.Now().UnixMilli()
+	// Sending revs may take a while if using views (GSI=false) due to the CBS views engine taking a while to execute the queries
+	// regarding rebuilding the users access grants (due to the constant invalidation of this).
+	// This blip tester is running as the user so the users access grants are rebuilt instantly when invalidated instead of the usual lazy-loading.
 	for i := 0; i < 100; i++ {
 		docID := fmt.Sprintf("foo_%d", i)
 		_, _, _, sendErr := bt.SendRev(


### PR DESCRIPTION
CBG-1963

The timeout seemed to be hit due to the `bt.SendRev` call calling `func (request *Message) Response() *Message` in the `go-blip` package taking a while to return. 
So instead of starting the changes timeout timer before all the revs have been sent, it now does it after by making it single-threaded.

- Removed goroutine use meaning the changes timeout starts counting when all the documents revs have been sent
- Dropped timeout back to 30 seconds
- Added log information for how long it took to receive all changes

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true count=20 test=^TestConcurrentRefreshUser` https://jenkins.sgwdev.com/job/SyncGateway-Integration/149/
