### PR TITLE
CBG-1971: Fixed TestReplicationConcurrentPush

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -501,7 +501,7 @@ func (m *sgReplicateManager) StartReplications() error {
 		return err
 	}
 	for replicationID, replicationCfg := range replications {
-		base.DebugfCtx(m.loggingCtx, base.KeyCluster, "Replication %s is assigned to node %s (local node is %s)", replicationID, replicationCfg.AssignedNode, m.localNodeUUID)
+		base.DebugfCtx(m.loggingCtx, base.KeyCluster, "Replication %s is assigned to node %s (local node is %s) on start up", replicationID, replicationCfg.AssignedNode, m.localNodeUUID)
 		if replicationCfg.AssignedNode == m.localNodeUUID {
 			activeReplicator, err := m.InitializeReplication(replicationCfg)
 			if err != nil {
@@ -1179,7 +1179,7 @@ func (c *SGRCluster) RebalanceReplications() {
 	for replicationID, replication := range unassignedReplications {
 		replication.AssignedNode = nodesByReplicationCount[0].host
 		nodesByReplicationCount[0].assignedReplicationIDs = append(nodesByReplicationCount[0].assignedReplicationIDs, replicationID)
-		base.DebugfCtx(c.loggingCtx, base.KeyReplicate, "Replication %s assigned to %s.", replicationID, nodesByReplicationCount[0].host)
+		base.DebugfCtx(c.loggingCtx, base.KeyReplicate, "Replication %s assigned to %s on update.", replicationID, nodesByReplicationCount[0].host)
 		sort.Sort(nodesByReplicationCount)
 	}
 
@@ -1202,7 +1202,7 @@ func (c *SGRCluster) RebalanceReplications() {
 		base.DebugfCtx(c.loggingCtx, base.KeyReplicate, "Replication %s unassigned from %s.", replicationToMove, highCountNode.host)
 		lowCountNode.assignedReplicationIDs = append(lowCountNode.assignedReplicationIDs, replicationToMove)
 		c.Replications[replicationToMove].AssignedNode = lowCountNode.host
-		base.DebugfCtx(c.loggingCtx, base.KeyReplicate, "Replication %s assigned to %s.", replicationToMove, lowCountNode.host)
+		base.DebugfCtx(c.loggingCtx, base.KeyReplicate, "Replication %s assigned to %s on update.", replicationToMove, lowCountNode.host)
 		sort.Sort(nodesByReplicationCount)
 	}
 

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -940,7 +940,7 @@ func TestPullOneshotReplicationAPI(t *testing.T) {
 func TestReplicationConcurrentPush(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 
 	// Disable sequence batching for multi-RT tests (pending CBG-1000)
 	defer db.SuspendSequenceBatching()()
@@ -1026,6 +1026,8 @@ func setupSGRPeers(t *testing.T) (activeRT *RestTester, passiveRT *RestTester, r
 			},
 		}},
 	})
+	// Initalize RT and bucket
+	_ = passiveRT.Bucket()
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
 	srv := httptest.NewServer(passiveRT.TestPublicHandler())
@@ -1040,6 +1042,8 @@ func setupSGRPeers(t *testing.T) (activeRT *RestTester, passiveRT *RestTester, r
 		TestBucket:         activeTestBucket.NoCloseClone(),
 		sgReplicateEnabled: true,
 	})
+	// Initalize RT and bucket
+	_ = activeRT.Bucket()
 
 	teardown = func() {
 		activeRT.Close()


### PR DESCRIPTION
CBG-1971

`rep_ABC` was causing the bucket to be initialised, and the replicator to (sometimes) be created before ISGR had been started. ISGR would start, pick up this replicator and start it. `rep_DEF` would then be made while ISGR was still starting `rep_ABC` and therefore was not subscribed to replication changes. 

- Bucket is initialised in `setupSGRPeers` for the active and passive rest testers so all replication changes are subscribed too
- Added additional logging to track if a replication was created due to an update or before ISGR start up
- Changed log level back to info

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/150/
