### PR TITLE
CBG-1959: Unset default console log level to restore dynamic level/key enabling

### DIFF
--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -46,9 +46,6 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 		Logging: base.LoggingConfig{
 			LogFilePath:    defaultLogFilePath,
 			RedactionLevel: base.DefaultRedactionLevel,
-			Console: &base.ConsoleLoggerConfig{
-				LogLevel: base.LogLevelPtr(base.LevelNone),
-			},
 		},
 		Auth: AuthConfig{
 			BcryptCost: auth.DefaultBcryptCost,


### PR DESCRIPTION
CBG-1959

- Unset default console log level to restore dynamic log level/key enabling
- Modify test to cover behaviour

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a