### PR TITLE
Set console logging ColorEnabled value even when logger is disabled

### DIFF
--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -30,7 +30,7 @@ type ConsoleLogger struct {
 	LogKeyMask   *LogKeyMask
 	ColorEnabled bool
 
-	// isStderr is true when the console logger is configured with no FileOutput
+	// isStderr is true when the console logger is enabled with no FileOutput
 	isStderr bool
 
 	// ConsoleLoggerConfig stores the initial config used to instantiate ConsoleLogger
@@ -60,18 +60,17 @@ func NewConsoleLogger(shouldLogLocation bool, config *ConsoleLoggerConfig) (*Con
 	}
 
 	logKey := ToLogKey(config.LogKeys)
-	isStderr := config.FileOutput == "" && *config.Enabled
 
 	logger := &ConsoleLogger{
 		LogLevel:     config.LogLevel,
 		LogKeyMask:   &logKey,
-		ColorEnabled: *config.ColorEnabled && isStderr,
+		ColorEnabled: *config.ColorEnabled,
 		FileLogger: FileLogger{
 			Enabled: AtomicBool{},
 			logger:  log.New(config.Output, "", 0),
 			config:  config.FileLoggerConfig,
 		},
-		isStderr: isStderr,
+		isStderr: config.FileOutput == "" && *config.Enabled,
 		config:   *config,
 	}
 	logger.Enabled.Set(*config.Enabled)


### PR DESCRIPTION
Allows color to be set, even if the output is disabled. This enables `Consolef(...)` (which bypasses the enabled checks) to use color.

## Testing - default log config (console disabled) with env var `SG_COLOR=true`

### Before
![Screenshot 2022-03-18 at 14 05 06](https://user-images.githubusercontent.com/1525809/159018703-e95a7b18-68fb-4c9b-aedb-f6f99c102edf.png)

### After
![Screenshot 2022-03-18 at 14 05 09](https://user-images.githubusercontent.com/1525809/159018710-aa207e18-84ae-4cf2-9c9b-b258dfe364ed.png)

## Dependencies
- [x] #5467 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a