### PR TITLE
Add GitHub action to validate OpenAPI specs

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: r7kamura/redocly-problem-matchers@v1
-      - uses: bbrks/redoc-lint-github-action@temp-fork-version-bump
+      - uses: mhiew/redoc-lint-github-action@v3
         with:
           args: '--format stylish'
         env:

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,0 +1,39 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included in
+# the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+# file, in accordance with the Business Source License, use of this software
+# will be governed by the Apache License, Version 2.0, included in the file
+# licenses/APL2.txt.
+
+name: openapi
+
+on:
+  push:
+    # Only run when we change an API spec
+    paths:
+      - 'docs/api/**'
+    branches: 
+      - 'master'
+      - 'release/*'
+      - 'CBG*'
+  pull_request:
+    # Only run when we change an API spec
+    paths:
+      - 'docs/api/**'
+    branches:
+      - 'master'
+      - 'release/*'
+
+jobs:
+  api_validation:
+    runs-on: ubuntu-latest
+    name: OpenAPI Validation
+    steps:
+      - uses: actions/checkout@v2
+      - uses: r7kamura/redocly-problem-matchers@v1
+      - uses: bbrks/redoc-lint-github-action@temp-fork-version-bump
+        with:
+          args: '--format stylish'
+        env:
+          NO_COLOR: '1'

--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -1,0 +1,26 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included in
+# the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+# file, in accordance with the Business Source License, use of this software
+# will be governed by the Apache License, Version 2.0, included in the file
+# licenses/APL2.txt.
+
+# This configuration file is read by the Redocly `openapi` CLI tool to validate/lint our specs (from GitHub Actions)
+
+apiDefinitions:
+  admin: ./docs/api/admin.yaml
+  public: ./docs/api/public.yaml
+  metric: ./docs/api/metric.yaml
+
+lint:
+  extends:
+    - minimal
+  rules:
+    # disable unnecessary/invalid warnings
+    operation-2xx-response: off # _blipsync 101 Upgrade ...
+    operation-operationId: off  # Optional (mostly used for generating code)
+    operation-summary: off      # Optional field
+    no-ambiguous-paths: off     # /{db}/{doc} != /_debug/expvar
+    no-identical-paths: off     # /{db} != /{targetdb}
+    no-path-trailing-slash: off # Some endpoints require a trailing slash

--- a/docs/api/metric.yaml
+++ b/docs/api/metric.yaml
@@ -29,7 +29,6 @@ paths:
 tags:
   - name: Prometheus
     description: Endpoints for use with Prometheus
-  - name: Standard Output
 externalDocs:
   description: Sync Gateway Quickstart | Couchbase Docs
   url: 'https://docs.couchbase.com/sync-gateway/current/index.html'

--- a/docs/api/paths/metric/_expvar.yaml
+++ b/docs/api/paths/metric/_expvar.yaml
@@ -16,5 +16,3 @@ get:
         application/javascript:
           schema:
             $ref: ../../components/schemas.yaml#/ExpVars
-  tags:
-  - Standard Output


### PR DESCRIPTION
Validates the OpenAPI specs when modified. Caught some existing failures, will leave those to be fixed separately.

- The configuration specified in `.redocly.yaml` determines what rules are run and which API specs exist, and is automatically found by the tools below:
  - GH Actions runs the Redocly OpenAPI lint tool whenever a file changes in `docs/api/**`
  - You can also run locally with `openapi lint` installable here: https://github.com/Redocly/openapi-cli#node

![Screenshot 2022-03-18 at 16 44 39](https://user-images.githubusercontent.com/1525809/159046192-3b66d77c-179f-417a-995a-5aa2c0047999.png)

## Dependencies
- [x] https://github.com/mhiew/redoc-lint-github-action/pull/2 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a