### PR TITLE
Re-add per-workspace GOCACHE path to avoid conflicts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
         SGW_REPO = "github.com/couchbase/sync_gateway"
         GH_ACCESS_TOKEN_CREDENTIAL = "github_cb-robot-sg_access_token"
         GO111MODULE = "on"
+        GOCACHE = "${WORKSPACE}/.gocache"
     }
 
     tools {


### PR DESCRIPTION
We used to have per-workspace GOCACHE paths set, so that concurrent builds would not conflict
Looks like this was unintentionally lost in #5430 

Caused a build to fail when another job ran `go clean -cache` underneath it:
```
15:35:50  # sync
15:35:50  ../../tools/org.jenkinsci.plugins.golang.GolangInstallation/1.17.5/src/sync/cond.go:8:2: could not import "sync/atomic": open /home/ec2-user/.cache/go-build/6c/6ca48af10324eb42980195e8fcebcfb786a8305981190e65240640b484268c8b-d: no such file or directory
15:35:50  # internal/reflectlite
15:35:50  ../../tools/org.jenkinsci.plugins.golang.GolangInstallation/1.17.5/src/internal/reflectlite/swapper.go:8:2: could not import "internal/unsafeheader": open /home/ec2-user/.cache/go-build/29/2974990b81ca84e6027db1ab6adeb2d50ee907a8af027a6b7837758d5a544d05-d: no such file or directory
```