### PR TITLE
Jenkins: Report flaky tests on pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -358,7 +358,7 @@ pipeline {
             cobertura autoUpdateHealth: false, onlyStable: false, autoUpdateStability: false, coberturaReportFile: 'reports/coverage-*.xml', conditionalCoverageTargets: '70, 0, 0', failNoReports: false, failUnhealthy: false, failUnstable: false, lineCoverageTargets: '80, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '80, 0, 0', sourceEncoding: 'ASCII', zoomCoverageChart: false
 
             // Publish the junit test reports
-            junit allowEmptyResults: true, testResults: 'reports/test-*.xml'
+            junit allowEmptyResults: true, testDataPublishers: [[$class: 'JUnitFlakyTestDataPublisher']], testResults: 'reports/test-*.xml'
 
             step([$class: 'WsCleanup'])
             sh "go clean -cache"


### PR DESCRIPTION
Records flaky test stats on the pipeline job (integration had this already enabled via the Job config UI)