### PR TITLE
Fix TestPersistentConfigConcurrency panicing log setup

### DIFF
--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -256,8 +256,11 @@ func TestBootstrapDuplicateDatabase(t *testing.T) {
 func bootstrapStartupConfigForTest(t *testing.T) StartupConfig {
 	config := DefaultStartupConfig("")
 
-	config.Logging.Console.LogLevel.Set(base.LevelInfo)
-	config.Logging.Console.LogKeys = []string{"*"}
+	config.Logging.Console = &base.ConsoleLoggerConfig{
+		LogLevel: base.LogLevelPtr(base.LevelInfo),
+		LogKeys:  []string{"*"},
+	}
+
 	config.API.AdminInterfaceAuthentication = base.BoolPtr(false)
 
 	config.API.PublicInterface = "127.0.0.1:" + strconv.FormatInt(4984+bootstrapTestPortOffset, 10)


### PR DESCRIPTION
Test was panicing due to `nil` `config.Logging.Console` value after changes in #5467 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `rest` `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/153/
  - flaky: `rest.TestSGR2TombstoneConflictHandling/RemoteLongSDKResurrectRemote`