### PR TITLE
CBG-1981: Removed password change from TestReplicatorRevocationsMultipleAlternateAccess

### DIFF
--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -5126,6 +5126,7 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 }
 
 func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 	base.RequireNumTestBuckets(t, 2)
 
 	// Passive
@@ -5160,10 +5161,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	})
 	require.NoError(t, ar.Start())
 
-	resp := rt2.SendAdminRequest("PUT", "/db/_user/user", `{"name": "user", "password": "letmein"}`)
-	assertStatus(t, resp, http.StatusOK)
-
-	resp = rt2.SendAdminRequest("PUT", "/db/_role/foo", `{"admin_channels": ["A", "B", "C"]}`)
+	resp := rt2.SendAdminRequest("PUT", "/db/_role/foo", `{"admin_channels": ["A", "B", "C"]}`)
 	assertStatus(t, resp, http.StatusOK)
 
 	revocationTester.addRole("user", "foo")

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -5126,7 +5126,7 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 }
 
 func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 	base.RequireNumTestBuckets(t, 2)
 
 	// Passive


### PR DESCRIPTION
CBG-1981

- ~~Added trace logging to `TestReplicatorRevocationsMultipleAlternateAccess`~~ Changed to info due to reproing with trace
- Removed unnecessary password change happening in test