### PR TITLE
CBG-2001: Prepared manifests for release 3.0.1

### DIFF
--- a/manifest/3.0/3.0.0.xml
+++ b/manifest/3.0/3.0.0.xml
@@ -25,14 +25,14 @@ licenses/APL2.txt.
   <!-- Build Scripts (required on CI servers) -->
   <project name="product-texts" path="product-texts" remote="couchbase"/>
   <project name="build" path="cbbuild" remote="couchbase" revision="a5d50edde6a7525bdff32f8ba3127a47ac2b291e">
-    <annotation name="VERSION" value="3.0.1"     keep="true"/>
+    <annotation name="VERSION" value="3.0.0"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
   </project>
 
 
   <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/3.0.1"/>
+  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="46803d1a55f989f8c203c717081200c0c2630d62"/>
 
   <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
 

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -274,13 +274,23 @@
             "start_build": 1
         },
         "manifest/3.0.xml": {
-            "release": "3.0.0",
-            "release_name": "Couchbase Sync Gateway 3.0.0",
+            "release": "3.0.1",
+            "release_name": "Couchbase Sync Gateway 3.0.1",
             "production": true,
             "interval": 120,
             "go_version": "1.16.6",
             "trigger_blackduck": true,
             "start_build": 529
+        },
+        "manifest/3.0/3.0.0.xml": {
+            "do-build": false,
+            "release": "3.0.0",
+            "release_name": "Couchbase Sync Gateway 3.0.0",
+            "production": true,
+            "interval": 1440,
+            "go_version": "1.16.6",
+            "trigger_blackduck": true,
+            "start_build": 544
         },
         "manifest/dev.xml": {
             "release": "dev",

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -280,7 +280,7 @@
             "interval": 120,
             "go_version": "1.16.6",
             "trigger_blackduck": true,
-            "start_build": 529
+            "start_build": 1
         },
         "manifest/3.0/3.0.0.xml": {
             "do-build": false,


### PR DESCRIPTION
CBG-2001

- Added 3.0.0 to product releases (check `start_build` number)
- Modified 3.0 release to be for 3.0.1 (check if the `start_build` number should be modified)
- Added 3.0.0 manifest
- Modified 3.0 manifest file to be for 3.0.1
