### PR TITLE
CBG-2001: Bumped version to 3.0.1

### DIFF
--- a/base/version.go
+++ b/base/version.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	ProductName          = "Couchbase Sync Gateway"
-	ProductVersionNumber = "3.0" // API/feature level
+	ProductVersionNumber = "3.0.1" // API/feature level
 )
 
 var (


### PR DESCRIPTION
CBG-2001

- Changed Sync Gateway version to the release version (`3.0.1`).