### PR TITLE
Flaky test fixes: Make createDocReturnRev wait for pending changes

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -6569,6 +6569,8 @@ func (rt *RestTester) createDocReturnRev(t *testing.T, docID string, revID strin
 	if revID == "" {
 		t.Fatalf("No revID in response for PUT doc")
 	}
+
+	require.NoError(t, rt.WaitForPendingChanges())
 	return revID
 }
 


### PR DESCRIPTION
Should improve reliability of the revocation tests that write documents then run active replicators (revocationTester.getChanges is already waiting)
A bit overkill to do this on _every_ doc write using this function, but slower doc writes vs. ordering guarantees without test changes seems like a good tradeoff to make.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/154/
  - [x] Known flaky test: `TestLogFlush`