### PR TITLE
[3.0.1 Backport] CBG-1953: Unset default console log level to restore dynamic level/key enabling

### DIFF
--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -30,7 +30,7 @@ type ConsoleLogger struct {
 	LogKeyMask   *LogKeyMask
 	ColorEnabled bool
 
-	// isStderr is true when the console logger is configured with no FileOutput
+	// isStderr is true when the console logger is enabled with no FileOutput
 	isStderr bool
 
 	// ConsoleLoggerConfig stores the initial config used to instantiate ConsoleLogger
@@ -60,18 +60,17 @@ func NewConsoleLogger(shouldLogLocation bool, config *ConsoleLoggerConfig) (*Con
 	}
 
 	logKey := ToLogKey(config.LogKeys)
-	isStderr := config.FileOutput == "" && *config.Enabled
 
 	logger := &ConsoleLogger{
 		LogLevel:     config.LogLevel,
 		LogKeyMask:   &logKey,
-		ColorEnabled: *config.ColorEnabled && isStderr,
+		ColorEnabled: *config.ColorEnabled,
 		FileLogger: FileLogger{
 			Enabled: AtomicBool{},
 			logger:  log.New(config.Output, "", 0),
 			config:  config.FileLoggerConfig,
 		},
-		isStderr: isStderr,
+		isStderr: config.FileOutput == "" && *config.Enabled,
 		config:   *config,
 	}
 	logger.Enabled.Set(*config.Enabled)

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -256,8 +256,11 @@ func TestBootstrapDuplicateDatabase(t *testing.T) {
 func bootstrapStartupConfigForTest(t *testing.T) StartupConfig {
 	config := DefaultStartupConfig("")
 
-	config.Logging.Console.LogLevel.Set(base.LevelInfo)
-	config.Logging.Console.LogKeys = []string{"*"}
+	config.Logging.Console = &base.ConsoleLoggerConfig{
+		LogLevel: base.LogLevelPtr(base.LevelInfo),
+		LogKeys:  []string{"*"},
+	}
+
 	config.API.AdminInterfaceAuthentication = base.BoolPtr(false)
 
 	config.API.PublicInterface = "127.0.0.1:" + strconv.FormatInt(4984+bootstrapTestPortOffset, 10)

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -45,9 +45,6 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 		Logging: base.LoggingConfig{
 			LogFilePath:    defaultLogFilePath,
 			RedactionLevel: base.DefaultRedactionLevel,
-			Console: &base.ConsoleLoggerConfig{
-				LogLevel: base.LogLevelPtr(base.LevelNone),
-			},
 		},
 		Auth: AuthConfig{
 			BcryptCost: auth.DefaultBcryptCost,


### PR DESCRIPTION
Cherry-picks #5467 and associated follow-up fixes #5468 #5474 into 3.0.1
