### PR TITLE
GitHub Action annotations to provide inline test assertion failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
       - 'master'
       - 'release/*'
       - 'CBG*'
+      - 'ci-*'
   pull_request:
     branches:
       - 'master'
@@ -23,12 +24,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: setup-go
-        uses: actions/setup-go@v2
+      - uses: actions/setup-go@v2
         with:
           go-version: 1.17.5
-      - name: checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - name: gofmt
         run: |
           gofmt -d -e . | tee gofmt.out
@@ -39,7 +38,6 @@ jobs:
         run: go build "./..."
 
   test:
-    needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -49,30 +47,35 @@ jobs:
       GOPRIVATE: github.com/couchbaselabs
       MallocNanoZone: 0
     steps:
-      - name: setup-go
-        uses: actions/setup-go@v2
+      - uses: actions/setup-go@v2
         with:
           go-version: 1.17.5
-      - name: checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - name: Build
         run: go build -v "./..."
-      - name: Test 
-        run: go test -timeout=30m -count=1 -v "./..."
+      - name: Run Tests
+        run: go test -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -jr '.Output | select (. != null )'
+        shell: bash
+      - name: Annotate Failures
+        if: always()
+        uses: guyarb/golang-test-annotations@v0.5.0
+        with:
+          test-results: test.json
 
   test-race:
-    needs: build
     runs-on: ubuntu-latest
     env:
       GOPRIVATE: github.com/couchbaselabs
     steps:
-      - name: setup-go
-        uses: actions/setup-go@v2
+      - uses: actions/setup-go@v2
         with:
           go-version: 1.17.5
-      - name: checkout
-        uses: actions/checkout@v2
-      - name: Build
-        run: go build -v "./..."
-      - name: Test 
-        run: go test -race -timeout=30m -count=1 -v "./..."
+      - uses: actions/checkout@v2
+      - name: Run Tests
+        run: go test -race -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -jr '.Output | select (. != null )'
+        shell: bash
+      - name: Annotate Failures
+        if: always()
+        uses: guyarb/golang-test-annotations@v0.5.0
+        with:
+          test-results: test.json


### PR DESCRIPTION
Show test failures inline (saves time looking through raw test output)

Example: 
![Screenshot 2022-03-23 at 13 24 21](https://user-images.githubusercontent.com/1525809/159709655-7be546cf-4c27-4c0b-a6aa-706ca7e993d6.png)

## Changes
- Runs branches starting with `ci-` for easier actions/jenkins testing before making PRs
- Runs unit tests with `-json` output
  - Json output run through `jq -jr '.Output | select (. != null )'` to print logs output as before
  - Action reads Json to leave inline comments for assertion failures (see screenshot above)