### PR TITLE
Test fix: TestActiveReplicatorHeartbeats waits longer before checking heatbeat ping counts

### DIFF
--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -129,14 +129,14 @@ func TestActiveReplicatorHeartbeats(t *testing.T) {
 
 	assert.NoError(t, ar.Start())
 
-	time.Sleep(time.Millisecond * 50)
+	// let some pings happen
+	time.Sleep(time.Millisecond * 500)
 
 	pingGoroutines := base.ExpvarVar2Int(expvar.Get("goblip").(*expvar.Map).Get("goroutines_sender_ping"))
 	assert.Equal(t, 1+pingGoroutinesStart, pingGoroutines, "Expected ping sender goroutine to be 1 more than start")
 
 	pingCount := base.ExpvarVar2Int(expvar.Get("goblip").(*expvar.Map).Get("sender_ping_count"))
-	assert.Truef(t, pingCount > pingCountStart, "Expected ping count to be > pingCountStart")
-
+	assert.Greaterf(t, pingCount, pingCountStart, "Expected ping count to increase since start")
 	assert.NoError(t, ar.Stop())
 
 	pingGoroutines = base.ExpvarVar2Int(expvar.Get("goblip").(*expvar.Map).Get("goroutines_sender_ping"))


### PR DESCRIPTION
It's possible for the ping goroutine to not be fully started and sending pings after just 50ms of the replication running.
Let the test wait for longer before checking that we've sent some heartbeat pings.

```
2022-03-23T13:32:00.251Z [INF] WS: c:#13931 Start BLIP/Websocket handler
2022-03-23T13:32:00.251Z [DBG] WSFrame+: c:#13931 Sender starting
...
    replicator_test.go:138: 
        	Error Trace:	replicator_test.go:138
        	Error:      	Should be true
        	Test:       	TestActiveReplicatorHeartbeats
        	Messages:   	Expected ping count to be > pingCountStart
2022-03-23T13:32:00.319Z [DBG] WSFrame+: c:TestActiveReplicatorHeartbeats-push Sender stopped
2022-03-23T13:32:00.319Z [INF] WS: c:TestActiveReplicatorHeartbeats-push Error: receiveLoop exiting with WebSocket error: failed to get reader: WebSocket closed: write timed out: context canceled
2022-03-23T13:32:00.319Z [INF] WS: c:TestActiveReplicatorHeartbeats-push BLIP/Websocket receiveLoop exited: failed to get reader: WebSocket closed: write timed out: context canceled
2022-03-23T13:32:00.319Z [DBG] WSFrame+: c:TestActiveReplicatorHeartbeats-push parseLoop stopped
2022-03-23T13:32:00.319Z [DBG] WSFrame+: c:TestActiveReplicatorHeartbeats-push Sender error sending ping frame. Error: failed to ping: failed to write control frame opPing: failed to write frame: context canceled
2022-03-23T13:32:00.319Z [DBG] WSFrame+: c:TestActiveReplicatorHeartbeats-push Sender sent ping frame
```