### PR TITLE
[Backport 3.0.1] CBG-1999: CBG-1858: Password can now be upserted for replication config independently of username

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -249,7 +249,7 @@ func (rc *ReplicationConfig) Upsert(c *ReplicationUpsertConfig) {
 		rc.Username = *c.Username
 	}
 
-	if c.Username != nil {
+	if c.Password != nil {
 		rc.Password = *c.Password
 	}
 

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -555,6 +555,8 @@ func TestIsCfgChanged(t *testing.T) {
 				Filter:                 "a",
 				QueryParams:            []interface{}{"ABC"},
 				Cancel:                 true,
+				Username:               "alice",
+				Password:               "password",
 			},
 		}
 	}
@@ -590,6 +592,13 @@ func TestIsCfgChanged(t *testing.T) {
 			name: "conflictResolverFnChange",
 			updatedConfig: &ReplicationUpsertConfig{
 				ConflictResolutionFn: base.StringPtr("b"),
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "passwordChanged", // Verify fix CBG-1858
+			updatedConfig: &ReplicationUpsertConfig{
+				Password: base.StringPtr("changed"),
 			},
 			expectedChanged: true,
 		},


### PR DESCRIPTION
CBG-1999

Cherry picked CBG-1858 so passwords can be upserted without changing the username as well for a replication config