### PR TITLE
[Backport 3.0.1] CBG-2000: CBG-1824: NumPullReplActiveOneShot decrements on sub changes feed completion

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -220,12 +220,14 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 	bh.continuous = continuous
 	// Start asynchronous changes goroutine
 	go func() {
-		// Pull replication stats by type - Active stats decremented in Close()
+		// Pull replication stats by type
 		if bh.continuous {
 			bh.replicationStats.SubChangesContinuousActive.Add(1)
+			defer bh.replicationStats.SubChangesContinuousActive.Add(-1)
 			bh.replicationStats.SubChangesContinuousTotal.Add(1)
 		} else {
 			bh.replicationStats.SubChangesOneShotActive.Add(1)
+			defer bh.replicationStats.SubChangesOneShotActive.Add(-1)
 			bh.replicationStats.SubChangesOneShotTotal.Add(1)
 		}
 

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -207,14 +207,6 @@ func (bsc *BlipSyncContext) register(profile string, handlerFn func(*blipHandler
 }
 
 func (bsc *BlipSyncContext) Close() {
-	if bsc.gotSubChanges {
-		if bsc.continuous {
-			bsc.replicationStats.SubChangesContinuousActive.Add(-1)
-		} else {
-			bsc.replicationStats.SubChangesOneShotActive.Add(-1)
-		}
-	}
-
 	bsc.terminatorOnce.Do(func() {
 		close(bsc.terminator)
 	})


### PR DESCRIPTION
CBG-2000

Cherry picked CBG-1824 which reliably decrements `NumPullReplActiveOneShot` when the sub changes feed has completed