### PR TITLE
CBG-2010 Avoid attachment fetch work for known attachments independent of revpos

### DIFF
--- a/db/attachment.go
+++ b/db/attachment.go
@@ -261,10 +261,11 @@ func (db *Database) setAttachments(attachments AttachmentData) error {
 type AttachmentCallback func(name string, digest string, knownData []byte, meta map[string]interface{}) ([]byte, error)
 
 // Given a document body, invokes the callback once for each attachment that doesn't include
-// its data. The callback is told whether the attachment body is known to the database, according
+// its data, and isn't present with a matching digest on the existing doc (existingDigests).
+// The callback is told whether the attachment body is known to the database, according
 // to its digest. If the attachment isn't known, the callback can return data for it, which will
 // be added to the metadata as a "data" property.
-func (db *Database) ForEachStubAttachment(body Body, minRevpos int, docID string, callback AttachmentCallback) error {
+func (db *Database) ForEachStubAttachment(body Body, minRevpos int, docID string, existingDigests map[string]string, callback AttachmentCallback) error {
 	atts := GetBodyAttachments(body)
 	if atts == nil && body[BodyAttachments] != nil {
 		return base.HTTPErrorf(http.StatusBadRequest, "Invalid _attachments")
@@ -283,7 +284,13 @@ func (db *Database) ForEachStubAttachment(body Body, minRevpos int, docID string
 				return base.HTTPErrorf(http.StatusBadRequest, "Invalid attachment")
 			}
 
-			// TODO: CBG-1590 to determine whether incoming attachment is AttVersion1 or AttVersion2
+			// If digest matches the one on existing doc, SG doesn't need to prove/get
+			existingDigest, existingOk := existingDigests[name]
+			if existingOk && existingDigest == digest {
+				// see CBG-2010 for discussion of potential existence check here
+				continue
+			}
+
 			// Assumes the attachment is always AttVersion2 while checking whether it has already been uploaded.
 			attachmentKey := MakeAttachmentKey(AttVersion2, docID, digest)
 			data, err := db.GetAttachment(attachmentKey)

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -931,15 +931,31 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 			}
 		}
 
+		// currentDigests is a map from attachment name to the current bucket doc digest,
+		// for any attachments on the incoming document that are also on the current bucket doc
+		var currentDigests map[string]string
+
 		// Do we have a previous doc? If not don't need to do this check
 		if currentBucketDoc != nil {
 			bodyAtts := GetBodyAttachments(body)
+			currentDigests = make(map[string]string, len(bodyAtts))
 			for name, value := range bodyAtts {
 				// Check if we have this attachment name already, if we do, continue check
 				currentAttachment, ok := currentBucketDoc.Attachments[name]
 				if !ok {
 					continue
 				}
+
+				currentAttachmentMeta, ok := currentAttachment.(map[string]interface{})
+				if !ok {
+					return base.HTTPErrorf(http.StatusInternalServerError, "Current attachment data is invalid")
+				}
+
+				currentAttachmentDigest, ok := currentAttachmentMeta["digest"].(string)
+				if !ok {
+					return base.HTTPErrorf(http.StatusInternalServerError, "Current attachment data is invalid")
+				}
+				currentDigests[name] = currentAttachmentDigest
 
 				incomingAttachmentMeta, ok := value.(map[string]interface{})
 				if !ok {
@@ -962,16 +978,6 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 					return base.HTTPErrorf(http.StatusBadRequest, "Invalid attachment")
 				}
 
-				currentAttachmentMeta, ok := currentAttachment.(map[string]interface{})
-				if !ok {
-					return base.HTTPErrorf(http.StatusInternalServerError, "Current attachment data is invalid")
-				}
-
-				currentAttachmentDigest, ok := currentAttachmentMeta["digest"].(string)
-				if !ok {
-					return base.HTTPErrorf(http.StatusInternalServerError, "Current attachment data is invalid")
-				}
-
 				// Compare the revpos and attachment digest. If incoming revpos is less than or equal to minRevPos and
 				// digest is different we need to override the revpos and set it to the current revision as the incoming
 				// revpos must be invalid and we need to request it.
@@ -984,8 +990,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 			body[BodyAttachments] = bodyAtts
 		}
 
-		// Check for any attachments I don't have yet, and request them:
-		if err := bh.downloadOrVerifyAttachments(rq.Sender, body, minRevpos, docID); err != nil {
+		if err := bh.downloadOrVerifyAttachments(rq.Sender, body, minRevpos, docID, currentDigests); err != nil {
 			base.ErrorfCtx(bh.loggingCtx, "Error during downloadOrVerifyAttachments for doc %s/%s: %v", base.UD(docID), revID, err)
 			return err
 		}
@@ -1192,8 +1197,8 @@ func (bh *blipHandler) sendProveAttachment(sender *blip.Sender, docID, name, dig
 
 // For each attachment in the revision, makes sure it's in the database, asking the client to
 // upload it if necessary. This method blocks until all the attachments have been processed.
-func (bh *blipHandler) downloadOrVerifyAttachments(sender *blip.Sender, body Body, minRevpos int, docID string) error {
-	return bh.db.ForEachStubAttachment(body, minRevpos, docID,
+func (bh *blipHandler) downloadOrVerifyAttachments(sender *blip.Sender, body Body, minRevpos int, docID string, currentDigests map[string]string) error {
+	return bh.db.ForEachStubAttachment(body, minRevpos, docID, currentDigests,
 		func(name string, digest string, knownData []byte, meta map[string]interface{}) ([]byte, error) {
 			// request attachment if we don't have it
 			if knownData == nil {


### PR DESCRIPTION
CBG-2010

For blip replication, we previously relied on revpos to identify that an attachment was already associated with the Sync Gateway version of the document.  However, in cases where revpos isn't specified correctly, SG can still avoid this work by checking existing attachments.

If an incoming attachment matches name and digest with an attachment on the active server revision of the document, we no longer perform prove/get work, even when revpos is greater than the common ancestor.

This also addresses an issue where we were checking against v2 attachment storage was always being used when revpos > minRevPos, under the assumption that this must be a new attachment to SG and should be stored in the new format. For clients using revpos incorrectly, this resulted in attachments being migrated from v1 to v2 storage unintentionally.


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/157/
