### PR TITLE
CBG-1995: Added support for top-level properties with an underscore prefix

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -868,8 +868,8 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 		}
 
 		// Make up a new _rev, and add it to the history:
-		bodyWithoutSpecialProps, wasStripped := stripSpecialProperties(body)
-		canonicalBytesForRevID, err := base.JSONMarshalCanonical(bodyWithoutSpecialProps)
+		bodyWithoutInternalProps, wasStripped := stripInternalProperties(body)
+		canonicalBytesForRevID, err := base.JSONMarshalCanonical(bodyWithoutInternalProps)
 		if err != nil {
 			return nil, nil, false, nil, err
 		}

--- a/db/crud.go
+++ b/db/crud.go
@@ -1316,9 +1316,9 @@ func validateNewBody(body Body) error {
 		return base.HTTPErrorf(http.StatusNotFound, "Document revision is not accessible")
 	}
 
-	// Reject bodies containing user special properties for compatibility with CouchDB
-	if containsUserSpecialProperties(body) {
-		return base.HTTPErrorf(400, "user defined top level properties beginning with '_' are not allowed in document body")
+	// Reject bodies that contains the "_purged" property.
+	if body[BodyPurged] != nil {
+		return base.HTTPErrorf(http.StatusBadRequest, "user defined top level property '_purged' is not allowed in document body")
 	}
 	return nil
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1562,6 +1562,7 @@ func TestPostWithUserSpecialProperty(t *testing.T) {
 	doc, err = db.GetDocument(base.TestCtx(t), docid, DocUnmarshalAll)
 	require.NotNil(t, doc)
 	assert.Equal(t, rev2id, doc.CurrentRev)
+	assert.Equal(t, "value", doc.Body()["_special"])
 	assert.NoError(t, err, "Unable to retrieve doc using generated uuid")
 }
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1517,22 +1517,6 @@ func TestPostWithExistingId(t *testing.T) {
 
 }
 
-// Unit test for issue #507
-func TestPutWithUserSpecialProperty(t *testing.T) {
-
-	db := setupTestDB(t)
-	defer db.Close()
-
-	// Test creating a document with existing id property:
-	customDocId := "customIdValue"
-	log.Printf("Create document with existing id...")
-	body := Body{BodyId: customDocId, "key1": "value1", "_key2": "existing"}
-	docid, rev1id, _, err := db.Post(body)
-	require.True(t, err.Error() == "400 user defined top level properties beginning with '_' are not allowed in document body")
-	goassert.True(t, rev1id == "")
-	goassert.True(t, docid == "")
-}
-
 // Unit test for issue #976
 func TestWithNullPropertyKey(t *testing.T) {
 
@@ -1549,9 +1533,8 @@ func TestWithNullPropertyKey(t *testing.T) {
 	goassert.True(t, docid != "")
 }
 
-// Unit test for issue #507
+// Unit test for issue #507, modified for CBG-1995 (allowing special properties)
 func TestPostWithUserSpecialProperty(t *testing.T) {
-
 	db := setupTestDB(t)
 	defer db.Close()
 
@@ -1561,27 +1544,25 @@ func TestPostWithUserSpecialProperty(t *testing.T) {
 	body := Body{BodyId: customDocId, "key1": "value1", "key2": "existing"}
 	docid, rev1id, _, err := db.Post(body)
 	require.NoError(t, err, "Couldn't create document")
-	goassert.True(t, rev1id != "")
-	goassert.True(t, docid == customDocId)
+	require.NotEqual(t, "", rev1id)
+	require.Equal(t, customDocId, docid)
 
 	// Test retrieval
 	doc, err := db.GetDocument(base.TestCtx(t), customDocId, DocUnmarshalAll)
-	goassert.True(t, doc != nil)
+	require.NotNil(t, doc)
 	assert.NoError(t, err, "Unable to retrieve doc using custom id")
 
-	// Test that posting an update with a user special property does not update the
-	// document
+	// Test that posting an update with a user special property does update the document
 	log.Printf("Update document with existing id...")
 	body = Body{BodyId: customDocId, BodyRev: rev1id, "_special": "value", "key1": "value1", "key2": "existing"}
-	_, _, err = db.Put(docid, body)
-	goassert.True(t, err.Error() == "400 user defined top level properties beginning with '_' are not allowed in document body")
+	rev2id, _, err := db.Put(docid, body)
+	assert.NoError(t, err)
 
-	// Test retrieval gets rev1
+	// Test retrieval gets rev2
 	doc, err = db.GetDocument(base.TestCtx(t), docid, DocUnmarshalAll)
-	goassert.True(t, doc != nil)
-	goassert.True(t, doc.CurrentRev == rev1id)
+	require.NotNil(t, doc)
+	assert.Equal(t, rev2id, doc.CurrentRev)
 	assert.NoError(t, err, "Unable to retrieve doc using generated uuid")
-
 }
 
 func TestRecentSequenceHistory(t *testing.T) {

--- a/db/import.go
+++ b/db/import.go
@@ -262,9 +262,9 @@ func (db *Database) importDoc(docid string, body Body, expiry *uint32, isDelete 
 		if len(existingDoc.Body) > 0 {
 			rawBodyForRevID = existingDoc.Body
 		} else {
-			var bodyWithoutSpecialProps Body
-			bodyWithoutSpecialProps, wasStripped = stripSpecialProperties(body)
-			rawBodyForRevID, err = base.JSONMarshalCanonical(bodyWithoutSpecialProps)
+			var bodyWithoutInternalProps Body
+			bodyWithoutInternalProps, wasStripped = stripInternalProperties(body)
+			rawBodyForRevID, err = base.JSONMarshalCanonical(bodyWithoutInternalProps)
 			if err != nil {
 				return nil, nil, false, nil, err
 			}

--- a/db/revision.go
+++ b/db/revision.go
@@ -444,25 +444,6 @@ func stripSpecialPropertiesExcept(b Body, exceptions ...string) (sb Body, foundS
 	}
 }
 
-// containsUserSpecialProperties returns true if the given body contains a non-SG special property (underscore prefixed)
-func containsUserSpecialProperties(b Body) bool {
-	for k := range b {
-		if k != "" && k[0] == '_' &&
-			!base.ContainsString([]string{
-				BodyId,
-				BodyRev,
-				BodyDeleted,
-				BodyAttachments,
-				BodyRevisions,
-				BodyExpiry,
-			}, k) {
-			// body contains special property that isn't one of the above... must be user's
-			return true
-		}
-	}
-	return false
-}
-
 func GetStringArrayProperty(body map[string]interface{}, property string) ([]string, error) {
 	if raw, exists := body[property]; !exists {
 		return nil, nil

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -183,10 +183,5 @@ func BenchmarkSpecialProperties(b *testing.B) {
 				stripAllSpecialProperties(t.body)
 			}
 		})
-		b.Run(t.name+"-containsUserSpecialProperties", func(bb *testing.B) {
-			for i := 0; i < bb.N; i++ {
-				containsUserSpecialProperties(t.body)
-			}
-		})
 	}
 }

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -147,6 +147,63 @@ func TestBackupOldRevision(t *testing.T) {
 	}
 }
 
+func TestStripSpecialProperties(t *testing.T) {
+	testCases := []struct {
+		name              string
+		input             Body
+		stripInternalOnly bool
+		stripped          bool // Should at least 1 property have been stripped
+		newBodyIfStripped *Body
+	}{
+		{
+			name:              "No special",
+			input:             Body{"test": 0, "bob": 0, "alice": 0},
+			stripInternalOnly: false,
+			stripped:          false,
+			newBodyIfStripped: nil,
+		},
+		{
+			name:              "No special internal only",
+			input:             Body{"test": 0, "bob": 0, "alice": 0},
+			stripInternalOnly: true,
+			stripped:          false,
+			newBodyIfStripped: nil,
+		},
+		{
+			name:              "Strip special props",
+			input:             Body{"_test": 0, "test": 0, "_attachments": 0, "_id": 0},
+			stripInternalOnly: false,
+			stripped:          true,
+			newBodyIfStripped: &Body{"test": 0},
+		},
+		{
+			name:              "Strip internal special props",
+			input:             Body{"_test": 0, "test": 0, "_rev": 0, "_exp": 0},
+			stripInternalOnly: true,
+			stripped:          true,
+			newBodyIfStripped: &Body{"_test": 0, "test": 0},
+		},
+		{
+			name:              "Confirm internal attachments and deleted skipped",
+			input:             Body{"_test": 0, "test": 0, "_attachments": 0, "_rev": 0, "_deleted": 0},
+			stripInternalOnly: true,
+			stripped:          true,
+			newBodyIfStripped: &Body{"_test": 0, "test": 0, "_attachments": 0, "_deleted": 0},
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			stripped, specialProps := stripSpecialProperties(test.input, test.stripInternalOnly)
+			assert.Equal(t, test.stripped, specialProps)
+			if test.stripped {
+				assert.Equal(t, *test.newBodyIfStripped, stripped)
+				return
+			}
+			assert.Equal(t, test.input, stripped)
+		})
+	}
+}
+
 func BenchmarkSpecialProperties(b *testing.B) {
 	noSpecialBody := Body{
 		"asdf": "qwerty", "a": true, "b": true, "c": true,
@@ -173,12 +230,12 @@ func BenchmarkSpecialProperties(b *testing.B) {
 	}
 
 	for _, t := range tests {
-		b.Run(t.name+"-stripSpecialProperties", func(bb *testing.B) {
+		b.Run(t.name+"-stripInternalProperties", func(bb *testing.B) {
 			for i := 0; i < bb.N; i++ {
-				stripSpecialProperties(t.body)
+				stripInternalProperties(t.body)
 			}
 		})
-		b.Run(t.name+"-stripAllSpecialProperties", func(bb *testing.B) {
+		b.Run(t.name+"-stripAllInternalProperties", func(bb *testing.B) {
 			for i := 0; i < bb.N; i++ {
 				stripAllSpecialProperties(t.body)
 			}

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -2241,3 +2241,30 @@ func TestDeletedDocumentImportWithImportFilter(t *testing.T) {
 	syncMeta = respBody[base.SyncPropertyName].(map[string]interface{})
 	assert.NotEmpty(t, syncMeta["rev"].(string))
 }
+
+// CBG-1995: Test the support for using an underscore prefix in the top-level body of a document
+func TestUnderscorePrefixSupportImport(t *testing.T) {
+	SkipImportTestsIfNotEnabled(t)
+
+	rt := NewRestTester(t, &RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{AutoImport: true}}})
+	defer rt.Close()
+	bucket := rt.Bucket()
+
+	docID := t.Name()
+	docBody := map[string]interface{}{
+		"_test": true,
+		"_exp":  120,
+		"true":  false,
+	}
+
+	added, err := bucket.Add(docID, 0, docBody)
+	require.True(t, added)
+	require.NoError(t, err)
+
+	resp := rt.getDoc(docID)
+
+	// Make sure doc values match inputted doc body
+	for key, val := range docBody {
+		assert.EqualValues(t, val, resp[key])
+	}
+}


### PR DESCRIPTION
CBG-1995

- Documents can now be created with properties that begin with an underscore.
- using the `_purged` property will continue to still return an error
- Modified existing tests to assert with the new behaviour
- Added 2 unit tests - one to test the Rest API and ISGR, and one to test importing a document that using an underscore prefix
- Rev ID that are generated now include user-set underscore parameters.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/166
