### PR TITLE
Fixed API specs linting warnings and errors

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -17,6 +17,8 @@ on:
       - 'master'
       - 'release/*'
       - 'CBG*'
+      - 'ci-*'
+      - 'api-ci-*'
   pull_request:
     # Only run when we change an API spec
     paths:

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -357,6 +357,7 @@ OIDC-login-page-handler:
 Document:
   description: The configurable Sync Gateway properties of a document.
   type: object
+  additionalProperties: true
   properties:
     _id:
       description: The ID of the document.

--- a/docs/api/paths/admin/{db}~_bulk_docs.yaml
+++ b/docs/api/paths/admin/{db}~_bulk_docs.yaml
@@ -71,7 +71,7 @@ post:
                   type: string
                 status:
                   description: The HTTP status code for why the operation failed.
-                  type: string
+                  type: integer
               required:
               - id
             uniqueItems: true

--- a/docs/api/paths/admin/{db}~_purge.yaml
+++ b/docs/api/paths/admin/{db}~_purge.yaml
@@ -16,6 +16,12 @@ post:
       application/json:
         schema:
           type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+              enum:
+                - '*'
           properties:
             doc_id:
               description: |-
@@ -50,11 +56,12 @@ post:
             properties:
               purged:
                 type: object
-                properties:
-                  doc_id:
-                    type: array
-                    items:
-                      type: string
+                additionalProperties:
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                      - '*'
             required:
             - purged
           examples:

--- a/docs/api/paths/admin/{db}~_revs_diff.yaml
+++ b/docs/api/paths/admin/{db}~_revs_diff.yaml
@@ -20,31 +20,31 @@ post:
               type: array
               items:
                 type: string
-    responses:
-      "200":
-        description: Comparisons successful
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                docid:
-                  description: The document ID.
-                  type: object
-                  properties:
-                    missing:
-                      description: The revisions that are not in the database (and therefore
-                        `missing`).
-                      type: array
-                      items:
-                        type: string
-                    possible_ancestors:
-                      description: An array of known revisions that might be the recent
-                        ancestors.
-                      type: array
-                      items:
-                        type: string
-      "404":
-        $ref: ../../components/responses.yaml#/Not-found
+  responses:
+    "200":
+      description: Comparisons successful
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              docid:
+                description: The document ID.
+                type: object
+                properties:
+                  missing:
+                    description: The revisions that are not in the database (and therefore
+                      `missing`).
+                    type: array
+                    items:
+                      type: string
+                  possible_ancestors:
+                    description: An array of known revisions that might be the recent
+                      ancestors.
+                    type: array
+                    items:
+                      type: string
+    "404":
+      $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Management

--- a/docs/api/paths/admin/{db}~{docid}.yaml
+++ b/docs/api/paths/admin/{db}~{docid}.yaml
@@ -31,6 +31,7 @@ get:
         application/json:
           schema:
             type: object
+            additionalProperties: true
             properties:
               _id:
                 description: The ID of the document.

--- a/docs/api/paths/public/{db}~_bulk_docs.yaml
+++ b/docs/api/paths/public/{db}~_bulk_docs.yaml
@@ -68,7 +68,7 @@ post:
                   type: string
                 status:
                   description: The HTTP status code for why the operation failed.
-                  type: string
+                  type: integer
               required:
               - id
             uniqueItems: true

--- a/docs/api/paths/public/{db}~_revs_diff.yaml
+++ b/docs/api/paths/public/{db}~_revs_diff.yaml
@@ -17,31 +17,31 @@ post:
               type: array
               items:
                 type: string
-    responses:
-      "200":
-        description: Comparisons successful
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                docid:
-                  description: The document ID.
-                  type: object
-                  properties:
-                    missing:
-                      description: The revisions that are not in the database (and therefore
-                        `missing`).
-                      type: array
-                      items:
-                        type: string
-                    possible_ancestors:
-                      description: An array of known revisions that might be the recent
-                        ancestors.
-                      type: array
-                      items:
-                        type: string
-      "404":
-        $ref: ../../components/responses.yaml#/Not-found
+  responses:
+    "200":
+      description: Comparisons successful
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              docid:
+                description: The document ID.
+                type: object
+                properties:
+                  missing:
+                    description: The revisions that are not in the database (and therefore
+                      `missing`).
+                    type: array
+                    items:
+                      type: string
+                  possible_ancestors:
+                    description: An array of known revisions that might be the recent
+                      ancestors.
+                    type: array
+                    items:
+                      type: string
+    "404":
+      $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Management

--- a/docs/api/paths/public/{db}~_session.yaml
+++ b/docs/api/paths/public/{db}~_session.yaml
@@ -59,15 +59,13 @@ post:
                 properties:
                   channels:
                     type: object
-                    required:
-                      - channel
                     description: A map of the channels the user is in along with the sequence number the user was granted access.
-                    properties:
-                      channel:
-                        type:
-                          - number
-                          - string
-                        description: The channel name (as the key) and the channel sequence number the user was granted access to that channel.
+                    additionalProperties:
+                      oneOf:
+                        - type: number
+                        - type: string
+                      minimum: 1
+                      description: The channel name (as the key) and the channel sequence number the user was granted access to that channel.
                   name:
                     type: string
                     minLength: 1

--- a/docs/api/paths/public/{db}~{docid}.yaml
+++ b/docs/api/paths/public/{db}~{docid}.yaml
@@ -27,6 +27,7 @@ get:
         application/json:
           schema:
             type: object
+            additionalProperties: true
             properties:
               _id:
                 description: The ID of the document.


### PR DESCRIPTION
- Fixed all warnings and errors the Redocly linter was reporting for the OpenAPI specs
- Branches prefixed with `ci-` or `api-ci-` now get ran through the Redocly OpenAPI linter on Github actions if the API docs have been changed
