### PR TITLE
[Backport 3.0.1] CBG-1997: CBG-1910 Avoid retrieval of temporary revision backups during ancestor lookup

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -604,29 +604,14 @@ func extractInlineAttachments(bodyBytes []byte) (attachments AttachmentsMeta, cl
 	return attsMap, bodyBytes, body, nil
 }
 
-// Gets a revision of a document as raw JSON.
-// If it's obsolete it will be loaded from the database if possible.
-// Does not add _id or _rev properties.
-func (db *Database) getRevisionBodyJSON(doc *Document, revid string) ([]byte, error) {
-	if body := doc.getRevisionBodyJSON(revid, db.RevisionBodyLoader); body != nil {
-		return body, nil
-	} else if !doc.History.contains(revid) {
-		return nil, base.HTTPErrorf(404, "missing")
-	} else {
-		return db.getOldRevisionJSON(doc.ID, revid)
-	}
-}
-
 // Gets the body of a revision's nearest ancestor, as raw JSON (without _id or _rev.)
 // If no ancestor has any JSON, returns nil but no error.
 func (db *Database) getAncestorJSON(doc *Document, revid string) ([]byte, error) {
 	for {
 		if revid = doc.History.getParent(revid); revid == "" {
 			return nil, nil
-		} else if body, err := db.getRevisionBodyJSON(doc, revid); body != nil {
+		} else if body := doc.getRevisionBodyJSON(revid, db.RevisionBodyLoader); body != nil {
 			return body, nil
-		} else if !base.IsDocNotFoundError(err) {
-			return nil, err
 		}
 	}
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2627,7 +2627,7 @@ func TestSyncFnDocBodyPropertiesSwitchActiveTombstone(t *testing.T) {
 		console.log("full doc: "+JSON.stringify(doc));
 		console.log("full oldDoc: "+JSON.stringify(oldDoc));
 
-		if (oldDoc == null || !oldDoc.syncOldDocBodyCheck) {
+		if (doc.testdata == 1 || (oldDoc != null && !oldDoc.syncOldDocBodyCheck)) {
 			console.log("skipping oldDoc property checks for this rev")
 			return
 		}


### PR DESCRIPTION
CBG-1997

Backported CBG-1910: Avoid retrieval of temporary revision backups during ancestor lookup