### PR TITLE
[3.0.1 Backport] Improvements to TestDBOnlineWithDelayAndImmediate

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1867,43 +1867,47 @@ func TestSingleDBOnlineWithDelay(t *testing.T) {
 // DB should should only be brought online once
 // there should be no errors
 func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
-
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
 
-	rt := NewRestTester(t, nil)
-	defer rt.Close()
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 
-	var response *TestResponse
-	var errDBState error
+	// CBG-1513: This test is prone to panicing when the walrus bucket was closed and still used
+	assert.NotPanicsf(t, func() {
+		rt := NewRestTester(t, nil)
+		defer rt.Close()
 
-	log.Printf("Taking DB offline")
-	require.Equal(t, "Online", rt.GetDBState())
+		var response *TestResponse
+		var errDBState error
 
-	response = rt.SendAdminRequest("POST", "/db/_offline", "")
-	assertStatus(t, response, 200)
+		log.Printf("Taking DB offline")
+		require.Equal(t, "Online", rt.GetDBState())
 
-	//Bring DB online with delay of two seconds
-	response = rt.SendAdminRequest("POST", "/db/_online", "{\"delay\":1}")
-	assertStatus(t, response, 200)
+		response = rt.SendAdminRequest("POST", "/db/_offline", "")
+		assertStatus(t, response, 200)
 
-	require.Equal(t, "Offline", rt.GetDBState())
+		// Bring DB online with delay of two seconds
+		response = rt.SendAdminRequest("POST", "/db/_online", "{\"delay\":1}")
+		assertStatus(t, response, 200)
 
-	// Bring DB online immediately
-	response = rt.SendAdminRequest("POST", "/db/_online", "")
-	assertStatus(t, response, 200)
+		require.Equal(t, "Offline", rt.GetDBState())
 
-	// Wait for DB to come online (retry loop)
-	errDBState = rt.WaitForDBOnline()
-	assert.NoError(t, errDBState)
+		// Bring DB online immediately
+		response = rt.SendAdminRequest("POST", "/db/_online", "")
+		assertStatus(t, response, 200)
 
-	// Wait until after the 1 second delay, since the online request explicitly asked for a delay
-	time.Sleep(1500 * time.Millisecond)
+		// Wait for DB to come online (retry loop)
+		errDBState = rt.WaitForDBOnline()
+		assert.NoError(t, errDBState)
 
-	// Wait for DB to come online (retry loop)
-	errDBState = rt.WaitForDBOnline()
-	assert.NoError(t, errDBState)
+		// Wait until after the 1 second delay, since the online request explicitly asked for a delay
+		time.Sleep(1500 * time.Millisecond)
+
+		// Wait for DB to come online (retry loop)
+		errDBState = rt.WaitForDBOnline()
+		assert.NoError(t, errDBState)
+	}, "CBG-1513: panicked when the walrus bucket was closed and still used")
 }
 
 // Test bring DB online concurrently with delay of 1 second

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1864,7 +1864,7 @@ func TestSingleDBOnlineWithDelay(t *testing.T) {
 
 // Test bring DB online with delay of 2 seconds
 // But bring DB online immediately in separate call
-// BD should should only be brought online once
+// DB should should only be brought online once
 // there should be no errors
 func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 
@@ -1875,44 +1875,35 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
+	var response *TestResponse
+	var errDBState error
+
 	log.Printf("Taking DB offline")
-	response := rt.SendAdminRequest("GET", "/db/", "")
-	var body db.Body
-	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
-	goassert.True(t, body["state"].(string) == "Online")
+	require.Equal(t, "Online", rt.GetDBState())
 
-	rt.SendAdminRequest("POST", "/db/_offline", "")
+	response = rt.SendAdminRequest("POST", "/db/_offline", "")
 	assertStatus(t, response, 200)
-
-	response = rt.SendAdminRequest("GET", "/db/", "")
-	body = nil
-	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
-	goassert.True(t, body["state"].(string) == "Offline")
 
 	//Bring DB online with delay of two seconds
-	rt.SendAdminRequest("POST", "/db/_online", "{\"delay\":1}")
+	response = rt.SendAdminRequest("POST", "/db/_online", "{\"delay\":1}")
 	assertStatus(t, response, 200)
 
+	require.Equal(t, "Offline", rt.GetDBState())
+
 	// Bring DB online immediately
-	rt.SendAdminRequest("POST", "/db/_online", "")
+	response = rt.SendAdminRequest("POST", "/db/_online", "")
 	assertStatus(t, response, 200)
 
 	// Wait for DB to come online (retry loop)
-	errDbOnline := rt.WaitForDBOnline()
-	assert.NoError(t, errDbOnline, "Error waiting for db to come online")
-
-	response = rt.SendAdminRequest("GET", "/db/", "")
-	body = nil
-	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
-	goassert.True(t, body["state"].(string) == "Online")
+	errDBState = rt.WaitForDBOnline()
+	assert.NoError(t, errDBState)
 
 	// Wait until after the 1 second delay, since the online request explicitly asked for a delay
 	time.Sleep(1500 * time.Millisecond)
 
 	// Wait for DB to come online (retry loop)
-	errDbOnline = rt.WaitForDBOnline()
-	assert.NoError(t, errDbOnline, "Error waiting for db to come online")
-
+	errDBState = rt.WaitForDBOnline()
+	assert.NoError(t, errDBState)
 }
 
 // Test bring DB online concurrently with delay of 1 second

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -625,30 +625,29 @@ func (rt *RestTester) WaitForViewAvailable(viewURLPath string) (err error) {
 
 }
 
-func (rt *RestTester) WaitForDBOnline() (err error) {
+func (rt *RestTester) GetDBState() string {
+	var body db.Body
+	resp := rt.SendAdminRequest("GET", "/db/", "")
+	assertStatus(rt.tb, resp, 200)
+	require.NoError(rt.tb, base.JSONUnmarshal(resp.Body.Bytes(), &body))
+	return body["state"].(string)
+}
 
+func (rt *RestTester) WaitForDBOnline() (err error) {
+	return rt.waitForDBState("Online")
+}
+
+func (rt *RestTester) waitForDBState(stateWant string) (err error) {
+	var stateCurr string
 	maxTries := 20
 
 	for i := 0; i < maxTries; i++ {
-
-		response := rt.SendAdminRequest("GET", "/db/", "")
-		var body db.Body
-		err := base.JSONUnmarshal(response.Body.Bytes(), &body)
-		if err != nil {
-			return err
-		}
-
-		if body["state"].(string) == "Online" {
+		if stateCurr = rt.GetDBState(); stateCurr == stateWant {
 			return nil
 		}
-
-		// Otherwise, sleep and try again
 		time.Sleep(500 * time.Millisecond)
-
 	}
-
-	return fmt.Errorf("Give up waiting for DB to come online after %d attempts", maxTries)
-
+	return fmt.Errorf("given up waiting for DB state, want: %s, current: %s, attempts: %d", stateWant, stateCurr, maxTries)
 }
 
 func (rt *RestTester) SendAdminRequestWithHeaders(method, resource string, body string, headers map[string]string) *TestResponse {


### PR DESCRIPTION
Pulls test improvements from #5385 and #5490 into 3.0.1 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/161/
