### PR TITLE
CBG-1914: Improved handling for some dbconfig updates during a rolling upgrade 

### DIFF
--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -580,7 +580,7 @@ func GenerateDcpStreamName(feedID string) (string, error) {
 	return fmt.Sprintf(
 		"%v-v-%v-commit-%v-uuid-%v",
 		feedID,
-		ProductVersionNumber,
+		ProductAPIVersion,
 		commitTruncated,
 		u.String(),
 	), nil

--- a/base/util.go
+++ b/base/util.go
@@ -1704,3 +1704,29 @@ func CoalesceBools(a, b *bool) *bool {
 	}
 	return nil
 }
+
+// stringsCut is a backport of the Go 1.18 strings.Cut function. This can be removed once we're running on Go 1.18
+func stringsCut(s, sep string) (before, after string, found bool) {
+	if i := strings.Index(s, sep); i >= 0 {
+		return s[:i], s[i+len(sep):], true
+	}
+	return s, "", false
+}
+
+// safeCutBefore returns the value up to the first instance of sep if it exists, and the remaining part of the string after sep.
+func safeCutBefore(s, sep string) (value, remainder string) {
+	val, after, ok := stringsCut(s, sep)
+	if !ok {
+		return "", s
+	}
+	return val, after
+}
+
+// safeCutAfter returns the value after the first instance of sep if it exists, and the remaining part of the string before sep.
+func safeCutAfter(s, sep string) (value, remainder string) {
+	before, val, ok := stringsCut(s, sep)
+	if !ok {
+		return "", s
+	}
+	return val, before
+}

--- a/base/version.go
+++ b/base/version.go
@@ -11,15 +11,20 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"fmt"
 	"strings"
 )
 
 const (
-	ProductName          = "Couchbase Sync Gateway"
-	ProductVersionNumber = "3.1" // API/feature level
+	ProductName = "Couchbase Sync Gateway"
+
+	ProductAPIVersionMajor = "3"
+	ProductAPIVersionMinor = "1"
+	ProductAPIVersion      = ProductAPIVersionMajor + "." + ProductAPIVersionMinor
 )
 
+// populated via init() below
 var (
 	// VersionString appears in the "Server:" header of HTTP responses.
 	// CBL 1.x parses the header to determine whether it's talking to Sync Gateway (vs. CouchDB) and what version.
@@ -29,40 +34,71 @@ var (
 	// LongVersionString includes build number; appears in the response of "GET /" and the initial log message
 	LongVersionString string
 
-	// ProductNameString comes from Gerrit (jenkins builds) or Git (dev builds)
+	// ProductNameString comes from Gerrit (jenkins builds) or Git (dev builds); is probably "Couchbase Sync Gateway"
 	ProductNameString string
 )
 
+// substituted by Jenkins build scripts
+const (
+	buildPlaceholderServerName               = "@PRODUCT_NAME@"    // e.g: Couchbase Sync Gateway
+	buildPlaceholderVersionBuildNumberString = "@PRODUCT_VERSION@" // e.g: 2.8.2-1
+	buildPlaceholderVersionCommitSHA         = "@COMMIT_SHA@"      // e.g: 4df7a2d
+)
+
 func init() {
-	// Placeholders substituted by Jenkins build
-	const (
-		buildPlaceholderServerName               = "@PRODUCT_NAME@"
-		buildPlaceholderVersionBuildNumberString = "@PRODUCT_VERSION@"
-		buildPlaceholderVersionCommitSHA         = "@COMMIT_SHA@"
+
+	var (
+		majorStr, minorStr, patchStr, otherStr, buildStr, editionStr string
 	)
 
 	// Use build info if available, otherwise use git info to populate instead.
 	if buildPlaceholderVersionBuildNumberString[0] != '@' {
 		// Split version number and build number (optional)
-		versionTokens := strings.Split(buildPlaceholderVersionBuildNumberString, "-")
-		BuildVersionString := versionTokens[0]
-		var BuildNumberString string
-		if len(versionTokens) > 1 {
-			BuildNumberString = fmt.Sprintf("%s;", versionTokens[1])
+		versionAndBuild := strings.Split(buildPlaceholderVersionBuildNumberString, "-")
+
+		versions := strings.Split(versionAndBuild[0], ".")
+		if len(versions) >= 0 {
+			majorStr = versions[0]
+		} else if len(versions) >= 1 {
+			minorStr = versions[1]
+		} else if len(versions) >= 2 {
+			patchStr = versions[2]
+		} else if len(versions) >= 3 {
+			otherStr = versions[3]
+		} else {
+			PanicfCtx(context.Background(), "unknown version format (expected major.minor.patch[.other]) got %v", versions)
 		}
-		LongVersionString = fmt.Sprintf("%s/%s(%s%.7s) %s", buildPlaceholderServerName, BuildVersionString, BuildNumberString, buildPlaceholderVersionCommitSHA, productEditionShortName)
-		VersionString = fmt.Sprintf("%s/%s %s", buildPlaceholderServerName, BuildVersionString, productEditionShortName)
-		ProductNameString = buildPlaceholderServerName
+
+		var formattedBuildStr string
+		if len(versionAndBuild) > 1 {
+			buildStr = versionAndBuild[1]
+			formattedBuildStr = ";" + buildStr
+		}
+
+		productName := buildPlaceholderServerName
+
+		// E.g: Couchbase Sync Gateway/2.8.2(1;4df7a2d) EE
+		LongVersionString = fmt.Sprintf("%s/%s(%s%.7s) %s", productName, versionString, formattedBuildStr, buildPlaceholderVersionCommitSHA, productEditionShortName)
+		VersionString = fmt.Sprintf("%s/%s %s", productName, versionString, productEditionShortName)
+		ProductNameString = productName
 	} else {
+		// no patch version available for git-based version info
+		majorStr = ProductAPIVersionMajor
+		minorStr = ProductAPIVersionMinor
+
 		// GitProductName is set via the build script, but may not be set when unit testing.
 		productName := GitProductName
 		if productName == "" {
 			productName = ProductName
 		}
+
+		// E.g: Couchbase Sync Gateway/CBG-1914(6282c1c+CHANGES) CE
 		LongVersionString = fmt.Sprintf("%s/%s(%.7s%s) %s", productName, GitBranch, GitCommit, GitDirty, productEditionShortName)
-		VersionString = fmt.Sprintf("%s/%s branch/%s commit/%.7s%s %s", productName, ProductVersionNumber, GitBranch, GitCommit, GitDirty, productEditionShortName)
+		VersionString = fmt.Sprintf("%s/%s branch/%s commit/%.7s%s %s", productName, ProductAPIVersion, GitBranch, GitCommit, GitDirty, productEditionShortName)
 		ProductNameString = productName
 	}
+
+	editionStr = productEditionShortName
 }
 
 // IsEnterpriseEdition returns true if this Sync Gateway node is enterprise edition.

--- a/base/version.go
+++ b/base/version.go
@@ -26,6 +26,9 @@ const (
 
 // populated via init() below
 var (
+	// ProductVersion describes the specific version information of the build.
+	ProductVersion *ComparableVersion
+
 	// VersionString appears in the "Server:" header of HTTP responses.
 	// CBL 1.x parses the header to determine whether it's talking to Sync Gateway (vs. CouchDB) and what version.
 	// This determines what replication API features it will use (E.g: bulk get and POST _changes that are CB-Mobile only features.)
@@ -99,6 +102,12 @@ func init() {
 	}
 
 	editionStr = productEditionShortName
+
+	var err error
+	ProductVersion, err = NewComparableVersion(majorStr, minorStr, patchStr, otherStr, buildStr, editionStr)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // IsEnterpriseEdition returns true if this Sync Gateway node is enterprise edition.

--- a/base/version_comparable.go
+++ b/base/version_comparable.go
@@ -1,0 +1,285 @@
+package base
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+)
+
+const (
+	// comparableVersionEpoch can be incremented when the versioning system or string format changes, whilst maintaining ordering.
+	// i.e. It's a version number version
+	// e.g: version system change from semver to dates: 0:30.2.1@45-EE < 1:22-3-25@33-EE
+	comparableVersionEpoch = 0
+)
+
+// ComparableVersion is an [epoch:]major.minor.patch[.other][@build][-edition] version that has methods to reliably extract information.
+type ComparableVersion struct {
+	epoch, major, minor, patch, other uint8
+	build                             uint16
+	edition                           productEdition
+	strOnce                           sync.Once
+	str                               string
+}
+
+// NewComparableVersionFromString parses a ComparableVersion from the given version string.
+// Expected format: `[epoch:]major.minor.patch[.other][@build][-edition]`
+func NewComparableVersionFromString(version string) (*ComparableVersion, error) {
+	epoch, major, minor, patch, other, build, edition, err := parseComparableVersion(version)
+	if err != nil {
+		return nil, err
+	}
+	return &ComparableVersion{
+		epoch:   epoch,
+		major:   major,
+		minor:   minor,
+		patch:   patch,
+		other:   other,
+		build:   build,
+		edition: edition,
+	}, nil
+}
+
+func NewComparableVersion(majorStr, minorStr, patchStr, otherStr, buildStr, editionStr string) (*ComparableVersion, error) {
+	_, major, minor, patch, other, build, edition, err := parseComparableVersionComponents("", majorStr, minorStr, patchStr, otherStr, buildStr, editionStr)
+	if err != nil {
+		return nil, err
+	}
+	return &ComparableVersion{
+		epoch:   comparableVersionEpoch,
+		major:   major,
+		minor:   minor,
+		patch:   patch,
+		other:   other,
+		build:   build,
+		edition: edition,
+	}, nil
+}
+
+// Equal returns true if pv is equal to b
+func (pv *ComparableVersion) Equal(b *ComparableVersion) bool {
+	return pv.epoch == b.epoch &&
+		pv.major == b.major &&
+		pv.minor == b.minor &&
+		pv.patch == b.patch &&
+		pv.other == b.other &&
+		pv.build == b.build &&
+		pv.edition == b.edition
+}
+
+// Less returns true if a is less than b
+func (a *ComparableVersion) Less(b *ComparableVersion) bool {
+	if a.epoch < b.epoch {
+		return true
+	} else if a.epoch > b.epoch {
+		return false
+	}
+	if a.major < b.major {
+		return true
+	} else if a.major > b.major {
+		return false
+	}
+	if a.minor < b.minor {
+		return true
+	} else if a.minor > b.minor {
+		return false
+	}
+	if a.patch < b.patch {
+		return true
+	} else if a.patch > b.patch {
+		return false
+	}
+	if a.other < b.other {
+		return true
+	} else if a.other > b.other {
+		return false
+	}
+	if a.build < b.build {
+		return true
+	} else if a.build > b.build {
+		return false
+	}
+	if a.edition < b.edition {
+		return true
+	} else if a.edition > b.edition {
+		return false
+	}
+
+	// versions are equal
+	return false
+}
+
+func (pv *ComparableVersion) String() string {
+	pv.strOnce.Do(func() {
+		pv.str = pv.formatComparableVersion()
+	})
+	return pv.str
+}
+
+const (
+	comparableVersionSep        = '.'
+	comparableVersionSepEpoch   = ':'
+	comparableVersionSepBuild   = '@'
+	comparableVersionSepEdition = '-'
+)
+
+// formatComparableVersion returns the string representation of the given version.
+// format: `[epoch:]major.minor.patch[.other][@build][-edition]`
+func (pv *ComparableVersion) formatComparableVersion() string {
+	if pv == nil {
+		return "0.0.0"
+	}
+
+	epochStr := ""
+	if pv.epoch > 0 {
+		epochStr = strconv.FormatUint(uint64(pv.epoch), 10) + string(comparableVersionSepEpoch)
+	}
+
+	semverStr := strconv.FormatUint(uint64(pv.major), 10) +
+		string(comparableVersionSep) +
+		strconv.FormatUint(uint64(pv.minor), 10) +
+		string(comparableVersionSep) +
+		strconv.FormatUint(uint64(pv.patch), 10)
+
+	otherStr := ""
+	if pv.other > 0 {
+		otherStr = string(comparableVersionSep) +
+			strconv.FormatUint(uint64(pv.other), 10)
+	}
+
+	buildStr := ""
+	if pv.build > 0 {
+		buildStr = string(comparableVersionSepBuild) + strconv.FormatUint(uint64(pv.build), 10)
+	}
+
+	editionStr := ""
+	if ed := pv.edition.String(); ed != "" {
+		editionStr = string(comparableVersionSepEdition) + ed
+	}
+
+	return epochStr + semverStr + otherStr + buildStr + editionStr
+}
+
+func parseComparableVersion(version string) (epoch, major, minor, patch, other uint8, build uint16, edition productEdition, err error) {
+	epochStr, majorStr, minorStr, patchStr, otherStr, buildStr, edtionStr, err := extractComparableVersionComponents(version)
+	if err != nil {
+		return 0, 0, 0, 0, 0, 0, "", err
+	}
+	return parseComparableVersionComponents(epochStr, majorStr, minorStr, patchStr, otherStr, buildStr, edtionStr)
+}
+
+func parseComparableVersionComponents(epochStr, majorStr, minorStr, patchStr, otherStr, buildStr, editionStr string) (epoch, major, minor, patch, other uint8, build uint16, edition productEdition, err error) {
+	if epochStr != "" {
+		tmp, err := strconv.ParseUint(epochStr, 10, 8)
+		if err != nil {
+			return 0, 0, 0, 0, 0, 0, "", fmt.Errorf("couldn't parse version epoch: %q: %w", epochStr, err)
+		}
+		epoch = uint8(tmp)
+	}
+
+	if majorStr != "" {
+		tmp, err := strconv.ParseUint(majorStr, 10, 8)
+		if err != nil {
+			return 0, 0, 0, 0, 0, 0, "", fmt.Errorf("couldn't parse version major: %q: %w", majorStr, err)
+		}
+		major = uint8(tmp)
+	}
+
+	if minorStr != "" {
+		tmp, err := strconv.ParseUint(minorStr, 10, 8)
+		if err != nil {
+			return 0, 0, 0, 0, 0, 0, "", fmt.Errorf("couldn't parse version minor: %q: %w", minorStr, err)
+		}
+		minor = uint8(tmp)
+	}
+
+	if patchStr != "" {
+		tmp, err := strconv.ParseUint(patchStr, 10, 8)
+		if err != nil {
+			return 0, 0, 0, 0, 0, 0, "", fmt.Errorf("couldn't parse version patch: %q: %w", patchStr, err)
+		}
+		patch = uint8(tmp)
+	}
+
+	if otherStr != "" {
+		tmp, err := strconv.ParseUint(otherStr, 10, 8)
+		if err != nil {
+			return 0, 0, 0, 0, 0, 0, "", fmt.Errorf("couldn't parse version other: %q: %w", otherStr, err)
+		}
+		other = uint8(tmp)
+	}
+
+	if buildStr != "" {
+		tmp, err := strconv.ParseUint(buildStr, 10, 16)
+		if err != nil {
+			return 0, 0, 0, 0, 0, 0, "", fmt.Errorf("couldn't parse version build: %q: %w", buildStr, err)
+		}
+		build = uint16(tmp)
+	}
+
+	if editionStr != "" {
+		if err := isValidProductEdition(editionStr); err != nil {
+			return 0, 0, 0, 0, 0, 0, "", fmt.Errorf("couldn't parse version edition: %q: %w", editionStr, err)
+		}
+		edition = productEdition(editionStr)
+	}
+
+	return epoch, major, minor, patch, other, build, edition, nil
+}
+
+// extractComparableVersionComponents takes a version string and returns each component as a string
+func extractComparableVersionComponents(version string) (epoch, major, minor, patch, other, build, edition string, err error) {
+
+	var remainder string
+
+	// The repeated Cuts look inefficient, but is faster and lower alloc than something like strings.Split,
+	// and still iterating over the entire string only once, albeit in small chunks.
+
+	// prefixes
+	epoch, remainder = safeCutBefore(version, string(comparableVersionSepEpoch))
+
+	// suffixes
+	edition, remainder = safeCutAfter(remainder, string(comparableVersionSepEdition))
+	build, remainder = safeCutAfter(remainder, string(comparableVersionSepBuild))
+
+	// major.minor.patch[.other]
+	major, remainder = safeCutBefore(remainder, string(comparableVersionSep))
+	minor, remainder = safeCutBefore(remainder, string(comparableVersionSep))
+
+	// handle optional [.other]
+	if before, after, ok := stringsCut(remainder, string(comparableVersionSep)); !ok {
+		patch = remainder
+	} else {
+		patch = before
+		other = after
+	}
+
+	if major == "" || minor == "" || patch == "" {
+		return "", "", "", "", "", "", "", errors.New("version requires at least major.minor.patch components")
+	}
+
+	return epoch, major, minor, patch, other, build, edition, nil
+}
+
+type productEdition string
+
+const (
+	ProductEditionEE = "EE" // Enterprise Edition
+	ProductEditionCE = "CE" // Community Edition
+)
+
+func isValidProductEdition(s string) error {
+	switch s {
+	case ProductEditionEE, ProductEditionCE:
+		return nil
+	}
+	return fmt.Errorf("unknown edition: %q", s)
+}
+
+func (pe *productEdition) String() string {
+	if pe == nil {
+		return ""
+	}
+	return string(*pe)
+}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1013,7 +1013,7 @@ func (h *handler) handleGetStatus() error {
 	// This handler is supposed to be admin-only anyway, but being defensive if this is opened up in the routes file.
 	if h.shouldShowProductVersion() {
 		status.Version = base.LongVersionString
-		status.Vendor.Version = base.ProductVersionNumber
+		status.Vendor.Version = base.ProductAPIVersion
 	}
 
 	for _, database := range h.server.databases_ {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -90,7 +90,7 @@ func (h *handler) handleCreateDB() error {
 				"Duplicate database name %q", dbName)
 		}
 
-		_, err = h.server._applyConfig(loadedConfig, true)
+		_, err = h.server._applyConfig(loadedConfig, true, false)
 		if err != nil {
 			if errors.Is(err, base.ErrAuthError) {
 				return base.HTTPErrorf(http.StatusForbidden, "auth failure accessing provided bucket: %s", bucket)

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -79,7 +79,8 @@ func (h *handler) handleCreateDB() error {
 		}
 
 		loadedConfig := DatabaseConfig{Version: version, DbConfig: *config}
-		persistedConfig := DatabaseConfig{Version: version, DbConfig: persistedDbConfig}
+
+		persistedConfig := DatabaseConfig{Version: version, DbConfig: persistedDbConfig, SGVersion: base.ProductVersion.String()}
 
 		h.server.lock.Lock()
 		defer h.server.lock.Unlock()
@@ -551,6 +552,8 @@ func (h *handler) handlePutDbConfig() (err error) {
 				return nil, err
 			}
 
+			bucketDbConfig.SGVersion = base.ProductVersion.String()
+
 			updatedDbConfig = &bucketDbConfig
 
 			// take a copy to stamp credentials and load before we persist
@@ -645,6 +648,8 @@ func (h *handler) handleDeleteDbConfigSync() error {
 				return nil, err
 			}
 
+			bucketDbConfig.SGVersion = base.ProductVersion.String()
+
 			updatedDbConfig = &bucketDbConfig
 			return base.JSONMarshal(bucketDbConfig)
 		})
@@ -705,10 +710,11 @@ func (h *handler) handlePutDbConfigSync() error {
 			}
 
 			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
-
 			if err != nil {
 				return nil, err
 			}
+
+			bucketDbConfig.SGVersion = base.ProductVersion.String()
 
 			updatedDbConfig = &bucketDbConfig
 			return base.JSONMarshal(bucketDbConfig)
@@ -792,6 +798,8 @@ func (h *handler) handleDeleteDbConfigImportFilter() error {
 				return nil, err
 			}
 
+			bucketDbConfig.SGVersion = base.ProductVersion.String()
+
 			updatedDbConfig = &bucketDbConfig
 			return base.JSONMarshal(bucketDbConfig)
 		})
@@ -856,6 +864,8 @@ func (h *handler) handlePutDbConfigImportFilter() error {
 			if err != nil {
 				return nil, err
 			}
+
+			bucketDbConfig.SGVersion = base.ProductVersion.String()
 
 			updatedDbConfig = &bucketDbConfig
 			return base.JSONMarshal(bucketDbConfig)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3924,6 +3924,10 @@ func TestDbConfigPersistentSGVersions(t *testing.T) {
 
 	// Start SG with no databases
 	config := bootstrapStartupConfigForTest(t)
+
+	// enable the background update worker for this test only
+	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(time.Millisecond * 250)
+
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
 	defer func() {

--- a/rest/api.go
+++ b/rest/api.go
@@ -58,7 +58,7 @@ func (h *handler) handleRoot() error {
 
 	if h.shouldShowProductVersion() {
 		resp.Version = base.LongVersionString
-		resp.Vendor.Version = base.ProductVersionNumber
+		resp.Vendor.Version = base.ProductAPIVersion
 	}
 
 	h.writeJSON(resp)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5593,7 +5593,7 @@ func TestHideProductInfo(t *testing.T) {
 				assert.Equal(t, base.VersionString, resp.Header().Get("Server"))
 
 				body := string(resp.BodyBytes())
-				assert.Contains(t, body, base.ProductVersionNumber)
+				assert.Contains(t, body, base.ProductAPIVersion)
 				return
 			}
 
@@ -5609,11 +5609,11 @@ func TestHideProductInfo(t *testing.T) {
 				assert.Contains(t, body, base.ProductNameString)
 				// no versions
 				assert.NotEqual(t, base.VersionString, serverHeader)
-				assert.NotContains(t, body, base.ProductVersionNumber)
+				assert.NotContains(t, body, base.ProductAPIVersion)
 			} else {
 				assert.Equal(t, base.VersionString, serverHeader)
 				assert.Contains(t, body, base.ProductNameString)
-				assert.Contains(t, body, base.ProductVersionNumber)
+				assert.Contains(t, body, base.ProductAPIVersion)
 			}
 		})
 	}

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
@@ -279,7 +278,6 @@ func bootstrapStartupConfigForTest(t *testing.T) StartupConfig {
 		t.Skipf("EE-ONLY: Skipping test %s due to requiring non-default Config Group ID", t.Name())
 	}
 	config.Bootstrap.ConfigGroupID = t.Name()
-	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(time.Millisecond * 250)
 
 	return config
 }

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
@@ -257,8 +258,8 @@ func bootstrapStartupConfigForTest(t *testing.T) StartupConfig {
 	config := DefaultStartupConfig("")
 
 	config.Logging.Console = &base.ConsoleLoggerConfig{
-		LogLevel: base.LogLevelPtr(base.LevelInfo),
-		LogKeys:  []string{"*"},
+		LogLevel: base.ConsoleLogLevel(),
+		LogKeys:  base.ConsoleLogKey().EnabledLogKeys(),
 	}
 
 	config.API.AdminInterfaceAuthentication = base.BoolPtr(false)
@@ -278,6 +279,7 @@ func bootstrapStartupConfigForTest(t *testing.T) StartupConfig {
 		t.Skipf("EE-ONLY: Skipping test %s due to requiring non-default Config Group ID", t.Name())
 	}
 	config.Bootstrap.ConfigGroupID = t.Name()
+	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(time.Millisecond * 250)
 
 	return config
 }

--- a/rest/config.go
+++ b/rest/config.go
@@ -1125,7 +1125,7 @@ func (sc *ServerContext) fetchAndLoadConfigs(isInitialStartup bool) (count int, 
 		}
 	}
 
-	return sc._applyConfigs(fetchedConfigs), nil
+	return sc._applyConfigs(fetchedConfigs, isInitialStartup), nil
 }
 
 func (sc *ServerContext) fetchAndLoadDatabase(dbName string) (found bool, err error) {
@@ -1141,7 +1141,7 @@ func (sc *ServerContext) _fetchAndLoadDatabase(dbName string) (found bool, err e
 	if err != nil || !found {
 		return false, err
 	}
-	sc._applyConfigs(map[string]DatabaseConfig{dbName: *dbConfig})
+	sc._applyConfigs(map[string]DatabaseConfig{dbName: *dbConfig}, false)
 
 	return true, nil
 }
@@ -1263,9 +1263,9 @@ func (sc *ServerContext) fetchConfigs(isInitialStartup bool) (dbNameConfigs map[
 }
 
 // _applyConfigs takes a map of dbName->DatabaseConfig and loads them into the ServerContext where necessary.
-func (sc *ServerContext) _applyConfigs(dbNameConfigs map[string]DatabaseConfig) (count int) {
+func (sc *ServerContext) _applyConfigs(dbNameConfigs map[string]DatabaseConfig, isInitialStartup bool) (count int) {
 	for dbName, cnf := range dbNameConfigs {
-		applied, err := sc._applyConfig(cnf, false)
+		applied, err := sc._applyConfig(cnf, false, isInitialStartup)
 		if err != nil {
 			base.ErrorfCtx(context.Background(), "Couldn't apply config for database %q: %v", base.MD(dbName), err)
 			continue
@@ -1281,11 +1281,11 @@ func (sc *ServerContext) _applyConfigs(dbNameConfigs map[string]DatabaseConfig) 
 func (sc *ServerContext) applyConfigs(dbNameConfigs map[string]DatabaseConfig) (count int) {
 	sc.lock.Lock()
 	defer sc.lock.Unlock()
-	return sc._applyConfigs(dbNameConfigs)
+	return sc._applyConfigs(dbNameConfigs, false)
 }
 
 // _applyConfig loads the given database, failFast=true will not attempt to retry connecting/loading
-func (sc *ServerContext) _applyConfig(cnf DatabaseConfig, failFast bool) (applied bool, err error) {
+func (sc *ServerContext) _applyConfig(cnf DatabaseConfig, failFast, isInitialStartup bool) (applied bool, err error) {
 	// 3.0.0 doesn't write a SGVersion, but everything else will
 	configSGVersionStr := "3.0.0"
 	if cnf.SGVersion != "" {
@@ -1297,11 +1297,13 @@ func (sc *ServerContext) _applyConfig(cnf DatabaseConfig, failFast bool) (applie
 		return false, err
 	}
 
-	// Skip applying if the config is from a newer SG version than this node
-	nodeSGVersion := base.ProductVersion
-	if nodeSGVersion.Less(configSGVersion) {
-		base.WarnfCtx(context.TODO(), "Cannot apply config update from server for db %q, this SG version is older than config's SG version (%s < %s)", cnf.Name, nodeSGVersion.String(), configSGVersion.String())
-		return false, nil
+	if !isInitialStartup {
+		// Skip applying if the config is from a newer SG version than this node and we're not just starting up
+		nodeSGVersion := base.ProductVersion
+		if nodeSGVersion.Less(configSGVersion) {
+			base.WarnfCtx(context.TODO(), "Cannot apply config update from server for db %q, this SG version is older than config's SG version (%s < %s)", cnf.Name, nodeSGVersion.String(), configSGVersion.String())
+			return false, nil
+		}
 	}
 
 	// skip if we already have this config loaded, and we've got a cas value to compare with
@@ -1343,13 +1345,6 @@ func (sc *ServerContext) _applyConfig(cnf DatabaseConfig, failFast bool) (applie
 	}
 
 	return true, nil
-}
-
-// applyConfigs takes a map of bucket->DatabaseConfig and loads them into the ServerContext where necessary.
-func (sc *ServerContext) applyConfig(cnf DatabaseConfig) (applied bool, err error) {
-	sc.lock.Lock()
-	defer sc.lock.Unlock()
-	return sc._applyConfig(cnf, false)
 }
 
 // addLegacyPrincipals takes a map of databases that each have a map of names with principle configs.

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -16,6 +16,9 @@ type DatabaseConfig struct {
 	// Version is a generated Rev ID used for optimistic concurrency control using ETags/If-Match headers.
 	Version string `json:"version,omitempty"`
 
+	// SGVersion is a base.ComparableVersion of the Sync Gateway node that wrote the config.
+	SGVersion string `json:"sg_version,omitempty"`
+
 	// DbConfig embeds database config properties
 	DbConfig
 }

--- a/rest/main.go
+++ b/rest/main.go
@@ -213,6 +213,8 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 			return nil, false, nil, nil, err
 		}
 
+		dbc.SGVersion = base.ProductVersion.String()
+
 		// Return users and roles separate from config
 		users = make(map[string]map[string]*auth.PrincipalConfig)
 		roles = make(map[string]map[string]*auth.PrincipalConfig)

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -3738,32 +3738,6 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 	require.NoError(t, ar.Stop())
 }
 
-func waitAndRequireCondition(t *testing.T, fn func() bool, failureMsgAndArgs ...interface{}) {
-	t.Log("starting waitAndRequireCondition")
-	for i := 0; i <= 20; i++ {
-		if i == 20 {
-			require.Fail(t, "Condition failed to be satisfied", failureMsgAndArgs...)
-		}
-		if fn() {
-			break
-		}
-		time.Sleep(time.Millisecond * 250)
-	}
-}
-
-func waitAndAssertCondition(t *testing.T, fn func() bool, failureMsgAndArgs ...interface{}) {
-	t.Log("starting waitAndAssertCondition")
-	for i := 0; i <= 20; i++ {
-		if i == 20 {
-			assert.Fail(t, "Condition failed to be satisfied", failureMsgAndArgs...)
-		}
-		if fn() {
-			break
-		}
-		time.Sleep(time.Millisecond * 250)
-	}
-}
-
 func TestBlipSyncNonUpgradableConnection(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyHTTPResp)
 	rt := NewRestTester(t, &RestTesterConfig{

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -154,8 +154,6 @@ func (sc *ServerContext) PostStartup() {
 const serverContextStopMaxWait = 30 * time.Second
 
 func (sc *ServerContext) Close() {
-	sc.lock.Lock()
-	defer sc.lock.Unlock()
 
 	logCtx := context.TODO()
 	err := base.TerminateAndWaitForClose(sc.statsContext.terminator, sc.statsContext.doneChan, serverContextStopMaxWait)
@@ -167,6 +165,9 @@ func (sc *ServerContext) Close() {
 	if err != nil {
 		base.InfofCtx(logCtx, base.KeyAll, "Couldn't stop background config update worker: %v", err)
 	}
+
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
 
 	for _, ctx := range sc.databases_ {
 		ctx.Close()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1700,3 +1700,43 @@ func NewHTTPTestServerOnListener(h http.Handler, l net.Listener) *httptest.Serve
 	s.Start()
 	return s
 }
+
+func waitAndRequireCondition(t *testing.T, fn func() bool, failureMsgAndArgs ...interface{}) {
+	t.Log("starting waitAndRequireCondition")
+	for i := 0; i <= 20; i++ {
+		if i == 20 {
+			require.Fail(t, "Condition failed to be satisfied", failureMsgAndArgs...)
+		}
+		if fn() {
+			break
+		}
+		time.Sleep(time.Millisecond * 250)
+	}
+}
+
+func waitAndAssertCondition(t *testing.T, fn func() bool, failureMsgAndArgs ...interface{}) {
+	t.Log("starting waitAndAssertCondition")
+	for i := 0; i <= 20; i++ {
+		if i == 20 {
+			assert.Fail(t, "Condition failed to be satisfied", failureMsgAndArgs...)
+		}
+		if fn() {
+			break
+		}
+		time.Sleep(time.Millisecond * 250)
+	}
+}
+
+func waitAndAssertConditionTimeout(t *testing.T, timeout time.Duration, fn func() bool, failureMsgAndArgs ...interface{}) {
+	start := time.Now()
+	tick := time.NewTicker(timeout / 20)
+	defer tick.Stop()
+	for range tick.C {
+		if time.Since(start) > timeout {
+			assert.Fail(t, "Condition failed to be satisfied", failureMsgAndArgs...)
+		}
+		if fn() {
+			return
+		}
+	}
+}


### PR DESCRIPTION
May be easier to review by commit.

CBG-1914 - Prevents issues in mixed-version deployments where a config with new fields from a new SG version are applied to an older SG node and fails to do so.

- Minor refactor of version information pulled from build scripts (nessesary in order to get patch version information)
- Added a `ComparableVersion` type, which can be parsed from a `major.minor.patch` string (along with finer-grained information) that provides methods to compare versions.
- Persisted database configs store SG node version information on write
- When a database config is being loaded from the bucket as part of the background config update process, SG will warn and skip the update if the SG version on the config is newer than the node that is trying to load it.
  - E.g: `[WRN] Cannot apply config update from server for db "foo", this SG version is older than config's SG version (3.0.0 < 3.1.0-EE)`
- If the database config is being loaded from the bucket on initiali startup, no version check is applied to support downgrade use-cases.
- Older SG nodes are still allowed to overwrite a config file from a newer SG version to further support downgrade.

## Depends on
- [x] #5545 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/258/
