### PR TITLE
Fixed Go test failure annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: IsaacLambat/golang-test-annotations@v0.6.0
+        uses: IsaacLambat/golang-test-annotations@v0.6.2
         with:
           test-results: test.json
 
@@ -76,6 +76,6 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: IsaacLambat/golang-test-annotations@v0.6.0
+        uses: IsaacLambat/golang-test-annotations@v0.6.2
         with:
           test-results: test.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.5.0
+        uses: IsaacLambat/golang-test-annotations@v0.6.0
         with:
           test-results: test.json
 
@@ -76,6 +76,6 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.5.0
+        uses: IsaacLambat/golang-test-annotations@v0.6.0
         with:
           test-results: test.json


### PR DESCRIPTION
Fixed `golang-test-annotations` to annotate go test failures on Github, even if their was logging prior to the failure.
