### PR TITLE
Test fix: Leaked goroutine in TestDeleteDatabasePointingAtSameBucketPersistent

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -4254,8 +4254,11 @@ func TestDeleteDatabasePointingAtSameBucketPersistent(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
-	defer sc.Close()
 	serverErr := make(chan error, 0)
+	defer func() {
+		sc.Close()
+		require.NoError(t, <-serverErr)
+	}()
 	go func() {
 		serverErr <- startServer(&config, sc)
 	}()


### PR DESCRIPTION
Not reading from an unbuffered `serverErr` means the send goroutine locks and leaks.