### PR TITLE
GH Actions: Sort test logs by package, timestamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
-        run: go test -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -jr '.Output | select (. != null )'
+        run: go test -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
       - name: Annotate Failures
         if: always()
@@ -72,7 +72,7 @@ jobs:
           go-version: 1.17.5
       - uses: actions/checkout@v2
       - name: Run Tests
-        run: go test -race -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -jr '.Output | select (. != null )'
+        run: go test -race -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
       - name: Annotate Failures
         if: always()


### PR DESCRIPTION
Copes `go test`'s behaviour of buffering and printing ordered package logs, even for parallel tests.
Avoids interleaved logs from paralell test packages.