### PR TITLE
Test fix: TestActiveReplicatorPullBasic one-shot replication misses pending sequence

### DIFF
--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -209,6 +209,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 			DatabaseContext: rt1.GetDatabase(),
 		},
 		ChangesBatchSize:    200,
+		Continuous:          true,
 		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()


### PR DESCRIPTION
If the document write hasn't been cached by the time the replicator starts, the one-shot replication will finish without actually sending it ("Found sequence later than stable sequence"). Instead of waiting for pending changes, we can run the replicator as a continuous one so that even a pending change is eventually replicated.

```
[DBG] CRUD+: c:#15696 Saving doc (seq: #2, id: <ud>TestActiveReplicatorPullBasicrt2doc1</ud> rev: 1-7a1aff6eb338ec3e7556b150cdd03660)
...
[DBG] Changes+: c:[6658de7d] MultiChangesFeed sending <ud>{Seq:1, ID:_user/AL_1c.e-@, Changes:[]}</ud> <ud>  (to AL_1c.e-@)</ud>
[DBG] Changes+: c:[6658de7d] Found sequence later than stable sequence: stable:[1] entry:[2] (<ud>TestActiveReplicatorPullBasicrt2doc1</ud>)
[INF] Changes: c:[6658de7d] MultiChangesFeed done <ud>  (to AL_1c.e-@)</ud>
```