### PR TITLE
CBG-2026: Add option to disable basic auth for the public API

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -123,32 +123,32 @@ type DatabaseContext struct {
 }
 
 type DatabaseContextOptions struct {
-	CacheOptions              *CacheOptions
-	RevisionCacheOptions      *RevisionCacheOptions
-	OldRevExpirySeconds       uint32
-	AdminInterface            *string
-	UnsupportedOptions        *UnsupportedOptions
-	OIDCOptions               *auth.OIDCOptions
-	DBOnlineCallback          DBOnlineCallback // Callback function to take the DB back online
-	ImportOptions             ImportOptions
-	EnableXattr               bool             // Use xattr for _sync
-	LocalDocExpirySecs        uint32           // The _local doc expiry time in seconds
-	SecureCookieOverride      bool             // Pass-through DBConfig.SecureCookieOverride
-	SessionCookieName         string           // Pass-through DbConfig.SessionCookieName
-	SessionCookieHttpOnly     bool             // Pass-through DbConfig.SessionCookieHTTPOnly
-	AllowConflicts            *bool            // False forbids creating conflicts
-	SendWWWAuthenticateHeader *bool            // False disables setting of 'WWW-Authenticate' header
-	DisablePublicBasicAuth    bool             // True enforces OIDC/guest only
-	UseViews                  bool             // Force use of views
-	DeltaSyncOptions          DeltaSyncOptions // Delta Sync Options
-	CompactInterval           uint32           // Interval in seconds between compaction is automatically ran - 0 means don't run
-	SGReplicateOptions        SGReplicateOptions
-	SlowQueryWarningThreshold time.Duration
-	QueryPaginationLimit      int    // Limit used for pagination of queries. If not set defaults to DefaultQueryPaginationLimit
-	UserXattrKey              string // Key of user xattr that will be accessible from the Sync Function. If empty the feature will be disabled.
-	ClientPartitionWindow     time.Duration
-	BcryptCost                int
-	GroupID                   string
+	CacheOptions                  *CacheOptions
+	RevisionCacheOptions          *RevisionCacheOptions
+	OldRevExpirySeconds           uint32
+	AdminInterface                *string
+	UnsupportedOptions            *UnsupportedOptions
+	OIDCOptions                   *auth.OIDCOptions
+	DBOnlineCallback              DBOnlineCallback // Callback function to take the DB back online
+	ImportOptions                 ImportOptions
+	EnableXattr                   bool             // Use xattr for _sync
+	LocalDocExpirySecs            uint32           // The _local doc expiry time in seconds
+	SecureCookieOverride          bool             // Pass-through DBConfig.SecureCookieOverride
+	SessionCookieName             string           // Pass-through DbConfig.SessionCookieName
+	SessionCookieHttpOnly         bool             // Pass-through DbConfig.SessionCookieHTTPOnly
+	AllowConflicts                *bool            // False forbids creating conflicts
+	SendWWWAuthenticateHeader     *bool            // False disables setting of 'WWW-Authenticate' header
+	DisablePasswordAuthentication bool             // True enforces OIDC/guest only
+	UseViews                      bool             // Force use of views
+	DeltaSyncOptions              DeltaSyncOptions // Delta Sync Options
+	CompactInterval               uint32           // Interval in seconds between compaction is automatically ran - 0 means don't run
+	SGReplicateOptions            SGReplicateOptions
+	SlowQueryWarningThreshold     time.Duration
+	QueryPaginationLimit          int    // Limit used for pagination of queries. If not set defaults to DefaultQueryPaginationLimit
+	UserXattrKey                  string // Key of user xattr that will be accessible from the Sync Function. If empty the feature will be disabled.
+	ClientPartitionWindow         time.Duration
+	BcryptCost                    int
+	GroupID                       string
 }
 
 type SGReplicateOptions struct {

--- a/db/database.go
+++ b/db/database.go
@@ -138,6 +138,7 @@ type DatabaseContextOptions struct {
 	SessionCookieHttpOnly     bool             // Pass-through DbConfig.SessionCookieHTTPOnly
 	AllowConflicts            *bool            // False forbids creating conflicts
 	SendWWWAuthenticateHeader *bool            // False disables setting of 'WWW-Authenticate' header
+	DisablePublicBasicAuth    bool             // True enforces OIDC/guest only
 	UseViews                  bool             // Force use of views
 	DeltaSyncOptions          DeltaSyncOptions // Delta Sync Options
 	CompactInterval           uint32           // Interval in seconds between compaction is automatically ran - 0 means don't run

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1374,6 +1374,10 @@ Database:
       description: Controls whether to send a `WWW-Authenticate` header in `401 Unauthorized` HTTP responses.
       type: boolean
       default: true
+    disable_public_basic_auth:
+      description: Whether to disable basic authentication and only allow OIDC and guest access.
+      type: boolean
+      default: false
     bucket_op_timeout_ms:
       description: 'This is the amount of milliseconds should pass before a bucket operation times out. An error will be returned if the bucket operation times out saying: `operation timed out`.'
       type: number

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1374,8 +1374,8 @@ Database:
       description: Controls whether to send a `WWW-Authenticate` header in `401 Unauthorized` HTTP responses.
       type: boolean
       default: true
-    disable_public_basic_auth:
-      description: Whether to disable basic authentication and only allow OIDC and guest access.
+    disable_password_auth:
+      description: Whether to disable username/password authentication and only allow OIDC and guest access.
       type: boolean
       default: false
     bucket_op_timeout_ms:

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -95,7 +95,7 @@ func TestDisablePublicBasicAuth(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
-				DisablePublicBasicAuth: true,
+				DisablePasswordAuth: true,
 				Guest: &db.PrincipalConfig{
 					Disabled: base.BoolPtr(true),
 				},
@@ -123,7 +123,7 @@ func TestDisablePublicBasicAuth(t *testing.T) {
 	assertStatus(t, response, http.StatusUnauthorized)
 
 	// As a sanity check, ensure it does work when the setting is disabled
-	rt.ServerContext().Database("db").Options.DisablePublicBasicAuth = false
+	rt.ServerContext().Database("db").Options.DisablePasswordAuthentication = false
 	response = rt.Send(requestByUser(http.MethodGet, "/db/", "", "user1"))
 	assertStatus(t, response, http.StatusOK)
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -117,6 +117,11 @@ func TestDisablePublicBasicAuth(t *testing.T) {
 	response = rt.Send(requestByUser(http.MethodGet, "/db/", "", "user1"))
 	assertStatus(t, response, http.StatusUnauthorized)
 	assert.NotContains(t, response.Header(), "WWW-Authenticate", "expected to not receive a WWW-Auth header when basic auth is disabled")
+
+	// As a sanity check, ensure it does work when the setting is disabled
+	rt.ServerContext().Database("db").Options.DisablePublicBasicAuth = false
+	response = rt.Send(requestByUser(http.MethodGet, "/db/", "", "user1"))
+	assertStatus(t, response, http.StatusOK)
 }
 
 func (rt *RestTester) createDoc(t *testing.T, docid string) string {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -118,9 +118,16 @@ func TestDisablePublicBasicAuth(t *testing.T) {
 	assertStatus(t, response, http.StatusUnauthorized)
 	assert.NotContains(t, response.Header(), "WWW-Authenticate", "expected to not receive a WWW-Auth header when basic auth is disabled")
 
+	// Also check that we can't create a session through POST /db/_session
+	response = rt.SendRequest(http.MethodPost, "/db/_session", `{"name":"user1","password":"letmein"}`)
+	assertStatus(t, response, http.StatusUnauthorized)
+
 	// As a sanity check, ensure it does work when the setting is disabled
 	rt.ServerContext().Database("db").Options.DisablePublicBasicAuth = false
 	response = rt.Send(requestByUser(http.MethodGet, "/db/", "", "user1"))
+	assertStatus(t, response, http.StatusOK)
+
+	response = rt.SendRequest(http.MethodPost, "/db/_session", `{"name":"user1","password":"letmein"}`)
 	assertStatus(t, response, http.StatusOK)
 }
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -106,7 +106,7 @@ func TestDisablePublicBasicAuth(t *testing.T) {
 
 	response := rt.SendRequest(http.MethodGet, "/db/", "")
 	assertStatus(t, response, http.StatusUnauthorized)
-	assert.NotContains(t, response.Header(), "WWW-Authenticate", "expected to not receive a WWW-Auth header when basic auth is disabled")
+	assert.NotContains(t, response.Header(), "WWW-Authenticate", "expected to not receive a WWW-Auth header when password auth is disabled")
 
 	// Double-check that even if we provide valid credentials we still won't be let in
 	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
@@ -116,7 +116,7 @@ func TestDisablePublicBasicAuth(t *testing.T) {
 
 	response = rt.Send(requestByUser(http.MethodGet, "/db/", "", "user1"))
 	assertStatus(t, response, http.StatusUnauthorized)
-	assert.NotContains(t, response.Header(), "WWW-Authenticate", "expected to not receive a WWW-Auth header when basic auth is disabled")
+	assert.NotContains(t, response.Header(), "WWW-Authenticate", "expected to not receive a WWW-Auth header when password auth is disabled")
 
 	// Also check that we can't create a session through POST /db/_session
 	response = rt.SendRequest(http.MethodPost, "/db/_session", `{"name":"user1","password":"letmein"}`)

--- a/rest/config.go
+++ b/rest/config.go
@@ -696,10 +696,10 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) error {
 		}
 	}
 
-	// Ensure that, if basic auth is disabled, there's another way to authenticate
+	// Ensure that, if password auth is disabled, there's another way to authenticate
 	if dbConfig.DisablePasswordAuth {
 		if dbConfig.OIDCConfig == nil && (dbConfig.Guest == nil || base.BoolDefault(dbConfig.Guest.Disabled, true)) {
-			multiError = multiError.Append(fmt.Errorf("basic authentication is disabled, but there is no alternative auth configuration (OIDC or guest access)"))
+			multiError = multiError.Append(fmt.Errorf("password authentication is disabled, but there is no alternative auth configuration (OIDC or guest access)"))
 		}
 	}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -140,8 +140,8 @@ type DbConfig struct {
 	AllowConflicts                   *bool                            `json:"allow_conflicts,omitempty"`                      // Deprecated: False forbids creating conflicts
 	NumIndexReplicas                 *uint                            `json:"num_index_replicas,omitempty"`                   // Number of GSI index replicas used for core indexes
 	UseViews                         *bool                            `json:"use_views,omitempty"`                            // Force use of views instead of GSI
-	SendWWWAuthenticateHeader        *bool                            `json:"send_www_authenticate_header,omitempty"`         // If false, disables setting of 'WWW-Authenticate' header in 401 responses. Implicitly false if disable_public_basic_auth is true.
-	DisablePublicBasicAuth           bool                             `json:"disable_public_basic_auth,omitempty"`            // If true, disables basic authentication, only permitting OIDC or guest access
+	SendWWWAuthenticateHeader        *bool                            `json:"send_www_authenticate_header,omitempty"`         // If false, disables setting of 'WWW-Authenticate' header in 401 responses. Implicitly false if disable_password_auth is true.
+	DisablePasswordAuth              bool                             `json:"disable_password_auth,omitempty"`                // If true, disables user/pass authentication, only permitting OIDC or guest access
 	BucketOpTimeoutMs                *uint32                          `json:"bucket_op_timeout_ms,omitempty"`                 // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
 	SlowQueryWarningThresholdMs      *uint32                          `json:"slow_query_warning_threshold,omitempty"`         // Log warnings if N1QL queries take this many ms
 	DeltaSync                        *DeltaSyncConfig                 `json:"delta_sync,omitempty"`                           // Config for delta sync
@@ -697,7 +697,7 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) error {
 	}
 
 	// Ensure that, if basic auth is disabled, there's another way to authenticate
-	if dbConfig.DisablePublicBasicAuth {
+	if dbConfig.DisablePasswordAuth {
 		if dbConfig.OIDCConfig == nil && (dbConfig.Guest == nil || base.BoolDefault(dbConfig.Guest.Disabled, true)) {
 			multiError = multiError.Append(fmt.Errorf("basic authentication is disabled, but there is no alternative auth configuration (OIDC or guest access)"))
 		}

--- a/rest/config.go
+++ b/rest/config.go
@@ -696,13 +696,6 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) error {
 		}
 	}
 
-	// Ensure that, if password auth is disabled, there's another way to authenticate
-	if dbConfig.DisablePasswordAuth {
-		if dbConfig.OIDCConfig == nil && (dbConfig.Guest == nil || base.BoolDefault(dbConfig.Guest.Disabled, true)) {
-			multiError = multiError.Append(fmt.Errorf("password authentication is disabled, but there is no alternative auth configuration (OIDC or guest access)"))
-		}
-	}
-
 	return multiError.ErrorOrNil()
 }
 

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -125,6 +125,15 @@ func TestConfigValidation(t *testing.T) {
 			name:   "Compact Interval just right",
 			config: `{"databases": {"db":{"compact_interval_days": 0.04}}}`,
 		},
+		{
+			name:   "Basic auth disabled with no alternative",
+			config: `{"databases": {"db":{"disable_public_basic_auth": true}}}`,
+			err:    "basic authentication is disabled, but there is no alternative auth configuration (OIDC or guest access)",
+		},
+		{
+			name:   "Basic auth disabled but OIDC configured",
+			config: `{"databases": {"db":{"disable_public_basic_auth": true, "oidc": {"providers":{"test":{}}}}}}`,
+		},
 	}
 
 	for _, test := range tests {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -127,12 +127,12 @@ func TestConfigValidation(t *testing.T) {
 		},
 		{
 			name:   "Basic auth disabled with no alternative",
-			config: `{"databases": {"db":{"disable_public_basic_auth": true}}}`,
+			config: `{"databases": {"db":{"disable_password_auth": true}}}`,
 			err:    "basic authentication is disabled, but there is no alternative auth configuration (OIDC or guest access)",
 		},
 		{
 			name:   "Basic auth disabled but OIDC configured",
-			config: `{"databases": {"db":{"disable_public_basic_auth": true, "oidc": {"providers":{"test":{}}}}}}`,
+			config: `{"databases": {"db":{"disable_password_auth": true, "oidc": {"providers":{"test":{}}}}}}`,
 		},
 	}
 

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -125,15 +125,6 @@ func TestConfigValidation(t *testing.T) {
 			name:   "Compact Interval just right",
 			config: `{"databases": {"db":{"compact_interval_days": 0.04}}}`,
 		},
-		{
-			name:   "Password auth disabled with no alternative",
-			config: `{"databases": {"db":{"disable_password_auth": true}}}`,
-			err:    "password authentication is disabled, but there is no alternative auth configuration (OIDC or guest access)",
-		},
-		{
-			name:   "Password auth disabled but OIDC configured",
-			config: `{"databases": {"db":{"disable_password_auth": true, "oidc": {"providers":{"test":{}}}}}}`,
-		},
 	}
 
 	for _, test := range tests {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -126,12 +126,12 @@ func TestConfigValidation(t *testing.T) {
 			config: `{"databases": {"db":{"compact_interval_days": 0.04}}}`,
 		},
 		{
-			name:   "Basic auth disabled with no alternative",
+			name:   "Password auth disabled with no alternative",
 			config: `{"databases": {"db":{"disable_password_auth": true}}}`,
-			err:    "basic authentication is disabled, but there is no alternative auth configuration (OIDC or guest access)",
+			err:    "password authentication is disabled, but there is no alternative auth configuration (OIDC or guest access)",
 		},
 		{
-			name:   "Basic auth disabled but OIDC configured",
+			name:   "Password auth disabled but OIDC configured",
 			config: `{"databases": {"db":{"disable_password_auth": true, "oidc": {"providers":{"test":{}}}}}}`,
 		},
 	}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -464,7 +464,7 @@ func (h *handler) checkAuth(dbCtx *db.DatabaseContext) (err error) {
 	}
 
 	// Check basic auth first
-	if !dbCtx.Options.DisablePublicBasicAuth {
+	if !dbCtx.Options.DisablePasswordAuthentication {
 		if userName, password := h.getBasicAuth(); userName != "" {
 			h.user, err = dbCtx.Authenticator(h.ctx()).AuthenticateUser(userName, password)
 			if err != nil {

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -399,7 +399,7 @@ func TestOIDCWithBasicAuthDisabled(t *testing.T) {
 					Enabled: true,
 				},
 			},
-			DisablePublicBasicAuth: true,
+			DisablePasswordAuth: true,
 		}}}
 	restTester := NewRestTester(t, &restTesterConfig)
 	require.NoError(t, restTester.SetAdminParty(false))

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -466,6 +466,7 @@ func TestOIDCWithBasicAuthDisabled(t *testing.T) {
 	response, err = client.Do(request)
 	require.NoError(t, err, "Error sending request")
 	require.Equal(t, http.StatusOK, response.StatusCode)
+	require.NoError(t, request.Body.Close(), "Error closing response body")
 
 	// Finally, forget the session and check that we're back to getting a 401, but with no WWW-Authenticate
 	client.Jar = nil
@@ -474,6 +475,7 @@ func TestOIDCWithBasicAuthDisabled(t *testing.T) {
 	response, err = client.Do(request)
 	require.NoError(t, err, "Error sending request")
 	require.Equal(t, http.StatusUnauthorized, response.StatusCode)
+	require.NoError(t, request.Body.Close(), "Error closing response body")
 }
 
 // parseAuthURL returns the authentication URL extracted from user consent form.

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -466,7 +466,7 @@ func TestOIDCWithBasicAuthDisabled(t *testing.T) {
 	response, err = client.Do(request)
 	require.NoError(t, err, "Error sending request")
 	require.Equal(t, http.StatusOK, response.StatusCode)
-	require.NoError(t, request.Body.Close(), "Error closing response body")
+	require.NoError(t, response.Body.Close(), "Error closing response body")
 
 	// Finally, forget the session and check that we're back to getting a 401, but with no WWW-Authenticate
 	client.Jar = nil
@@ -475,7 +475,7 @@ func TestOIDCWithBasicAuthDisabled(t *testing.T) {
 	response, err = client.Do(request)
 	require.NoError(t, err, "Error sending request")
 	require.Equal(t, http.StatusUnauthorized, response.StatusCode)
-	require.NoError(t, request.Body.Close(), "Error closing response body")
+	require.NoError(t, response.Body.Close(), "Error closing response body")
 }
 
 // parseAuthURL returns the authentication URL extracted from user consent form.

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -776,6 +776,12 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		base.WarnfCtx(context.TODO(), `Deprecation notice: setting database configuration option "allow_conflicts" to true is due to be removed. In the future, conflicts will not be allowed.`)
 	}
 
+	// If basic auth is disabled, it doesn't make sense to send WWW-Authenticate
+	sendWWWAuthenticate := config.SendWWWAuthenticateHeader
+	if config.DisablePublicBasicAuth {
+		sendWWWAuthenticate = base.BoolPtr(false)
+	}
+
 	// Register the cbgt pindex type for the configGroup
 	db.RegisterImportPindexImpl(groupID)
 
@@ -794,7 +800,8 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		SessionCookieName:         config.SessionCookieName,
 		SessionCookieHttpOnly:     base.BoolDefault(config.SessionCookieHTTPOnly, false),
 		AllowConflicts:            config.ConflictsAllowed(),
-		SendWWWAuthenticateHeader: config.SendWWWAuthenticateHeader,
+		SendWWWAuthenticateHeader: sendWWWAuthenticate,
+		DisablePublicBasicAuth:    config.DisablePublicBasicAuth,
 		DeltaSyncOptions:          deltaSyncOptions,
 		CompactInterval:           compactIntervalSecs,
 		QueryPaginationLimit:      queryPaginationLimit,

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -778,7 +778,7 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 
 	// If basic auth is disabled, it doesn't make sense to send WWW-Authenticate
 	sendWWWAuthenticate := config.SendWWWAuthenticateHeader
-	if config.DisablePublicBasicAuth {
+	if config.DisablePasswordAuth {
 		sendWWWAuthenticate = base.BoolPtr(false)
 	}
 
@@ -786,26 +786,26 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 	db.RegisterImportPindexImpl(groupID)
 
 	contextOptions := db.DatabaseContextOptions{
-		CacheOptions:              &cacheOptions,
-		RevisionCacheOptions:      revCacheOptions,
-		OldRevExpirySeconds:       oldRevExpirySeconds,
-		LocalDocExpirySecs:        localDocExpirySecs,
-		AdminInterface:            &sc.config.API.AdminInterface,
-		UnsupportedOptions:        config.Unsupported,
-		OIDCOptions:               config.OIDCConfig,
-		DBOnlineCallback:          dbOnlineCallback,
-		ImportOptions:             importOptions,
-		EnableXattr:               config.UseXattrs(),
-		SecureCookieOverride:      secureCookieOverride,
-		SessionCookieName:         config.SessionCookieName,
-		SessionCookieHttpOnly:     base.BoolDefault(config.SessionCookieHTTPOnly, false),
-		AllowConflicts:            config.ConflictsAllowed(),
-		SendWWWAuthenticateHeader: sendWWWAuthenticate,
-		DisablePublicBasicAuth:    config.DisablePublicBasicAuth,
-		DeltaSyncOptions:          deltaSyncOptions,
-		CompactInterval:           compactIntervalSecs,
-		QueryPaginationLimit:      queryPaginationLimit,
-		UserXattrKey:              config.UserXattrKey,
+		CacheOptions:                  &cacheOptions,
+		RevisionCacheOptions:          revCacheOptions,
+		OldRevExpirySeconds:           oldRevExpirySeconds,
+		LocalDocExpirySecs:            localDocExpirySecs,
+		AdminInterface:                &sc.config.API.AdminInterface,
+		UnsupportedOptions:            config.Unsupported,
+		OIDCOptions:                   config.OIDCConfig,
+		DBOnlineCallback:              dbOnlineCallback,
+		ImportOptions:                 importOptions,
+		EnableXattr:                   config.UseXattrs(),
+		SecureCookieOverride:          secureCookieOverride,
+		SessionCookieName:             config.SessionCookieName,
+		SessionCookieHttpOnly:         base.BoolDefault(config.SessionCookieHTTPOnly, false),
+		AllowConflicts:                config.ConflictsAllowed(),
+		SendWWWAuthenticateHeader:     sendWWWAuthenticate,
+		DisablePasswordAuthentication: config.DisablePasswordAuth,
+		DeltaSyncOptions:              deltaSyncOptions,
+		CompactInterval:               compactIntervalSecs,
+		QueryPaginationLimit:          queryPaginationLimit,
+		UserXattrKey:                  config.UserXattrKey,
 		SGReplicateOptions: db.SGReplicateOptions{
 			Enabled:               sgReplicateEnabled,
 			WebsocketPingInterval: sgReplicateWebsocketPingInterval,

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -48,6 +48,11 @@ func (h *handler) handleSessionPOST() error {
 		}
 	}
 
+	// NOTE: handleSessionPOST doesn't handle creating users from OIDC - checkAuth calls out into AuthenticateUntrustedJWT.
+	// Therefore, if by this point `h.user` is guest, this isn't creating a session from OIDC.
+	if h.db.Options.DisablePublicBasicAuth && (h.user == nil || h.user.Name() == "") {
+		return base.HTTPErrorf(http.StatusUnauthorized, "Password authentication is disabled")
+	}
 	user, err := h.getUserFromSessionRequestBody()
 
 	// If we fail to get a user from the body and we've got a non-GUEST authenticated user, create the session based on that user

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -50,7 +50,7 @@ func (h *handler) handleSessionPOST() error {
 
 	// NOTE: handleSessionPOST doesn't handle creating users from OIDC - checkAuth calls out into AuthenticateUntrustedJWT.
 	// Therefore, if by this point `h.user` is guest, this isn't creating a session from OIDC.
-	if h.db.Options.DisablePublicBasicAuth && (h.user == nil || h.user.Name() == "") {
+	if h.db.Options.DisablePasswordAuthentication && (h.user == nil || h.user.Name() == "") {
 		return base.HTTPErrorf(http.StatusUnauthorized, "Password authentication is disabled")
 	}
 	user, err := h.getUserFromSessionRequestBody()


### PR DESCRIPTION
CBG-2026

Adds a new config option, `disable_password_auth`, which enforces that only OIDC or guest authentication is used on the public interface.

Things to look out for when reviewing:
* Are there any other paths where authentication is performed that don't pass through `(*handler).checkAuth()`?
  * Cursory check suggests it should be all of them, as even things like `_blipsync` pass through `makeHandler`
* Have I updated all the documentation I should?
* Are there other things worth testing?

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/180/
