### PR TITLE
CBG-2023: Internal properties are now prevented from use

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -768,6 +768,25 @@ type removalDocument struct {
 	Removed bool `json:"_removed"`
 }
 
+func validateBlipBody(body Body) error {
+	if body[base.SyncPropertyName] != nil {
+		return base.HTTPErrorf(http.StatusBadRequest, "top level property '_sync' is a reserved internal property")
+	}
+	if body[BodyId] != nil {
+		return base.HTTPErrorf(http.StatusBadRequest, "top level property '_id' is a reserved internal property")
+	}
+	if body[BodyRev] != nil {
+		return base.HTTPErrorf(http.StatusBadRequest, "top level property '_rev' is a reserved internal property")
+	}
+	if body[BodyDeleted] != nil {
+		return base.HTTPErrorf(http.StatusBadRequest, "top level property '_deleted' is a reserved internal property")
+	}
+	if body[BodyRevisions] != nil {
+		return base.HTTPErrorf(http.StatusBadRequest, "top level property '_rev' is a reserved internal property")
+	}
+	return nil
+}
+
 // Received a "rev" request, i.e. client is pushing a revision body
 func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 	startTime := time.Now()
@@ -824,6 +843,10 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 		RevID: revID,
 	}
 	newDoc.UpdateBodyBytes(bodyBytes)
+	err = validateBlipBody(newDoc.Body())
+	if err != nil {
+		return err
+	}
 
 	injectedAttachmentsForDelta := false
 	if deltaSrcRevID, isDelta := revMessage.DeltaSrc(); isDelta {

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -773,7 +773,7 @@ func validateBlipBody(body Body) error {
 	disallowed := []string{base.SyncPropertyName, BodyId, BodyRev, BodyDeleted, BodyRevisions}
 	for _, prop := range disallowed {
 		if body[prop] != nil {
-			return base.HTTPErrorf(http.StatusBadRequest, "top level property '"+prop+"' is a reserved internal property")
+			return base.HTTPErrorf(http.StatusBadRequest, "top-level property '"+prop+"' is a reserved internal property")
 		}
 	}
 	return nil

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -769,20 +769,12 @@ type removalDocument struct {
 }
 
 func validateBlipBody(body Body) error {
-	if body[base.SyncPropertyName] != nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "top level property '_sync' is a reserved internal property")
-	}
-	if body[BodyId] != nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "top level property '_id' is a reserved internal property")
-	}
-	if body[BodyRev] != nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "top level property '_rev' is a reserved internal property")
-	}
-	if body[BodyDeleted] != nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "top level property '_deleted' is a reserved internal property")
-	}
-	if body[BodyRevisions] != nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "top level property '_rev' is a reserved internal property")
+	// Prevent disallowed internal properties from being used
+	disallowed := []string{base.SyncPropertyName, BodyId, BodyRev, BodyDeleted, BodyRevisions}
+	for _, prop := range disallowed {
+		if body[prop] != nil {
+			return base.HTTPErrorf(http.StatusBadRequest, "top level property '"+prop+"' is a reserved internal property")
+		}
 	}
 	return nil
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -1062,7 +1062,7 @@ func (db *Database) PutExistingRevWithBody(docid string, body Body, docHistory [
 
 func validateDocUpdate(body Body) error {
 	if body[base.SyncPropertyName] != nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "document top level property '_sync' is a reserved internal property")
+		return base.HTTPErrorf(http.StatusBadRequest, "document-top level property '_sync' is a reserved internal property")
 	}
 	return nil
 }
@@ -1336,10 +1336,14 @@ func validateNewBody(body Body) error {
 
 	// Reject bodies that contains the "_purged" property.
 	if body[BodyPurged] != nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "user defined top level property '_purged' is not allowed in document body")
+		return base.HTTPErrorf(http.StatusBadRequest, "user defined top-level property '_purged' is not allowed in document body")
 	}
 
-	// TODO: Add validation when the first property is added using the BodyInternalPrefix "_sync_"
+	for key := range body {
+		if strings.HasPrefix(key, BodyInternalPrefix) {
+			return base.HTTPErrorf(http.StatusBadRequest, "user defined top-level properties that start with '_sync_' are not allowed in document body")
+		}
+	}
 	return nil
 }
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -821,6 +821,11 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 
 	delete(body, BodyRevisions)
 
+	err = validateDocUpdate(body)
+	if err != nil {
+		return "", nil, err
+	}
+
 	allowImport := db.UseXattrs()
 	doc, newRevID, err = db.updateAndReturnDoc(newDoc.ID, allowImport, expiry, nil, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 
@@ -1040,6 +1045,11 @@ func (db *Database) PutExistingRevWithBody(docid string, body Body, docHistory [
 	delete(body, BodyAttachments)
 	newDoc.UpdateBody(body)
 
+	err = validateDocUpdate(body)
+	if err != nil {
+		return nil, "", err
+	}
+
 	doc, newRevID, putExistingRevErr := db.PutExistingRev(newDoc, docHistory, noConflicts, false, nil)
 
 	if putExistingRevErr != nil {
@@ -1048,6 +1058,13 @@ func (db *Database) PutExistingRevWithBody(docid string, body Body, docHistory [
 
 	return doc, newRevID, err
 
+}
+
+func validateDocUpdate(body Body) error {
+	if body[base.SyncPropertyName] != nil {
+		return base.HTTPErrorf(http.StatusBadRequest, "document top level property '_sync' is a reserved internal property")
+	}
+	return nil
 }
 
 // resolveConflict runs the conflictResolverFunction with doc and newDoc.  doc and newDoc's bodies and revision trees
@@ -1309,17 +1326,18 @@ func (db *Database) validateExistingDoc(doc *Document, importAllowed, docExists 
 	return nil
 }
 
+// validateNewBody validates any new body being received
 func validateNewBody(body Body) error {
 	// Reject a body that contains the "_removed" property, this means that the user
 	// is trying to update a document they do not have read access to.
 	if body[BodyRemoved] != nil {
 		return base.HTTPErrorf(http.StatusNotFound, "Document revision is not accessible")
 	}
-
 	// Reject bodies that contains the "_purged" property.
 	if body[BodyPurged] != nil {
 		return base.HTTPErrorf(http.StatusBadRequest, "user defined top level property '_purged' is not allowed in document body")
 	}
+	// TODO: Add validation when the first property is added using the BodyInternalPrefix "_sync_"
 	return nil
 }
 
@@ -1621,6 +1639,11 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 		return
 	}
 
+	err = validateNewBody(newDoc.Body())
+	if err != nil {
+		return
+	}
+
 	// Marshal raw user xattrs for use in Sync Fn. If this fails we can bail out so we should do early as possible.
 	metaMap, err := doc.GetMetaMap(db.Options.UserXattrKey)
 	if err != nil {
@@ -1628,12 +1651,6 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 	}
 
 	syncFnBody, err := newDoc.GetDeepMutableBody()
-	if err != nil {
-		return
-	}
-
-	// TODO: seems a bit late to do this. Could we move it earlier?
-	err = validateNewBody(syncFnBody)
 	if err != nil {
 		return
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -1333,10 +1333,12 @@ func validateNewBody(body Body) error {
 	if body[BodyRemoved] != nil {
 		return base.HTTPErrorf(http.StatusNotFound, "Document revision is not accessible")
 	}
+
 	// Reject bodies that contains the "_purged" property.
 	if body[BodyPurged] != nil {
 		return base.HTTPErrorf(http.StatusBadRequest, "user defined top level property '_purged' is not allowed in document body")
 	}
+
 	// TODO: Add validation when the first property is added using the BodyInternalPrefix "_sync_"
 	return nil
 }

--- a/db/import.go
+++ b/db/import.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"strconv"
 	"time"
 
@@ -440,27 +439,6 @@ func (db *Database) backupPreImportRevision(docid, revid string) error {
 		return fmt.Errorf("Persistence error: %v", setOldRevErr)
 	}
 
-	return nil
-}
-
-func validateImportBody(body Body) error {
-	// Prevent disallowed internal properties from being used
-	disallowed := []string{BodyId, BodyRev, BodyExpiry, BodyRevisions}
-	for _, prop := range disallowed {
-		if body[prop] != nil {
-			return base.HTTPErrorf(http.StatusBadRequest, "top-level property '"+prop+"' is a reserved internal property therefore cannot be imported")
-		}
-	}
-
-	if isPurged, ok := body[BodyPurged].(bool); ok && isPurged {
-		return base.ErrImportCancelledPurged
-	}
-
-	// TODO: Validate attachment data to ensure user is not setting invalid attachments
-
-	if body == nil {
-		return base.ErrEmptyDocument
-	}
 	return nil
 }
 

--- a/db/import.go
+++ b/db/import.go
@@ -444,26 +444,20 @@ func (db *Database) backupPreImportRevision(docid, revid string) error {
 }
 
 func validateImportBody(body Body) error {
-	if body[BodyId] != nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "top level property '_id' is a reserved internal property therefore cannot be imported")
-	}
-	if body[BodyRev] != nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "top level property '_rev' is a reserved internal property therefore cannot be imported")
-	}
-	if body[BodyDeleted] != nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "top level property '_deleted' is a reserved internal property therefore cannot be imported")
-	}
-	if body[BodyExpiry] != nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "top level property '_exp' is a reserved internal property therefore cannot be imported")
-	}
-	if body[BodyRevisions] != nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "top level property '_revisions' is a reserved internal property therefore cannot be imported")
+	// Prevent disallowed internal properties from being used
+	disallowed := []string{BodyId, BodyRev, BodyDeleted, BodyExpiry, BodyRevisions}
+	for _, prop := range disallowed {
+		if body[prop] != nil {
+			return base.HTTPErrorf(http.StatusBadRequest, "top level property '"+prop+"' is a reserved internal property therefore cannot be imported")
+		}
 	}
 
 	if isPurged, ok := body[BodyPurged].(bool); ok && isPurged {
 		return base.ErrImportCancelledPurged
 	}
+
 	// TODO: Validate attachment data to ensure user is not setting invalid attachments
+
 	if body == nil {
 		return base.ErrEmptyDocument
 	}

--- a/db/import.go
+++ b/db/import.go
@@ -445,10 +445,10 @@ func (db *Database) backupPreImportRevision(docid, revid string) error {
 
 func validateImportBody(body Body) error {
 	// Prevent disallowed internal properties from being used
-	disallowed := []string{BodyId, BodyRev, BodyDeleted, BodyExpiry, BodyRevisions}
+	disallowed := []string{BodyId, BodyRev, BodyExpiry, BodyRevisions}
 	for _, prop := range disallowed {
 		if body[prop] != nil {
-			return base.HTTPErrorf(http.StatusBadRequest, "top level property '"+prop+"' is a reserved internal property therefore cannot be imported")
+			return base.HTTPErrorf(http.StatusBadRequest, "top-level property '"+prop+"' is a reserved internal property therefore cannot be imported")
 		}
 	}
 

--- a/db/validation.go
+++ b/db/validation.go
@@ -1,0 +1,85 @@
+package db
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+
+	"github.com/couchbase/sync_gateway/base"
+)
+
+// validateNewBody validates any new body being received (i.e. through blip, import, and API)
+func validateNewBody(body Body) error {
+	// Reject a body that contains the "_removed" property, this means that the user
+	// is trying to update a document they do not have read access to.
+	if body[BodyRemoved] != nil {
+		return base.HTTPErrorf(http.StatusNotFound, "Document revision is not accessible")
+	}
+
+	// Reject bodies that contains the "_purged" property.
+	if body[BodyPurged] != nil {
+		return base.HTTPErrorf(http.StatusBadRequest, "user defined top-level property '_purged' is not allowed in document body")
+	}
+
+	for key := range body {
+		if strings.HasPrefix(key, BodyInternalPrefix) {
+			return base.HTTPErrorf(http.StatusBadRequest, "user defined top-level properties that start with '_sync_' are not allowed in document body")
+		}
+	}
+	return nil
+}
+
+// validateAPIDocUpdate finds disallowed document properties that are allowed in through blip and/or import but not through
+// the REST API
+func validateAPIDocUpdate(body Body) error {
+	// VaLidation for disallowed properties for blip and import should be done in validateNewBody
+	// _rev, _attachments, _id are validated before reaching this function (due to endpoint specific behaviour)
+	if body[base.SyncPropertyName] != nil {
+		return base.HTTPErrorf(http.StatusBadRequest, "document-top level property '_sync' is a reserved internal property")
+	}
+	return nil
+}
+
+// validateImportBody validates incoming import bodies
+func validateImportBody(body Body) error {
+	if body == nil {
+		return base.ErrEmptyDocument
+	}
+
+	if isPurged, ok := body[BodyPurged].(bool); ok && isPurged {
+		return base.ErrImportCancelledPurged
+	}
+
+	// Prevent disallowed internal properties from being used
+	disallowed := []string{BodyId, BodyRev, BodyExpiry, BodyRevisions}
+	for _, prop := range disallowed {
+		if body[prop] != nil {
+			return base.HTTPErrorf(http.StatusBadRequest, "top-level property '"+prop+"' is a reserved internal property therefore cannot be imported")
+		}
+	}
+	// TODO: Validate attachment data to ensure user is not setting invalid attachments
+
+	return nil
+}
+
+// validateBlipBody validates incoming blip rev bodies
+func validateBlipBody(rawBody []byte, doc *Document) error {
+	// Prevent disallowed internal properties from being used
+	disallowed := []string{base.SyncPropertyName, BodyId, BodyRev, BodyDeleted, BodyRevisions}
+	for _, prop := range disallowed {
+		// Only unmarshal if raw body contains the disallowed property
+		if bytes.Contains(rawBody, []byte(prop)) {
+			if doc.Body()[prop] != nil {
+				return base.HTTPErrorf(http.StatusBadRequest, "top-level property '"+prop+"' is a reserved internal property")
+			}
+		}
+	}
+	return nil
+}
+
+func (db *Database) validateExistingDoc(doc *Document, importAllowed, docExists bool) error {
+	if !importAllowed && docExists && !doc.HasValidSyncData() {
+		return base.HTTPErrorf(409, "Not imported")
+	}
+	return nil
+}

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -4607,11 +4607,10 @@ func TestApiInternalPropertiesHandling(t *testing.T) {
 			inputBody:    map[string]interface{}{"_removed": false},
 			expectReject: true,
 		},
-		// TODO: When first _sync_ (BodyInternalPrefix) prefixed internal property is added, this document should be expect to be rejected
 		{
 			name:         "_sync_cookies",
 			inputBody:    map[string]interface{}{"_sync_cookies": true},
-			expectReject: false,
+			expectReject: true,
 		},
 	}
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4302,14 +4302,6 @@ func TestImportingPurgedDocument(t *testing.T) {
 	assert.Equal(t, numErrors, numErrorsAfter)
 }
 
-func TestRestSettingPurged(t *testing.T) {
-	rt := NewRestTester(t, nil)
-	defer rt.Close()
-
-	response := rt.SendAdminRequest("PUT", "/db/doc1", `{"_purged": true, "foo": "bar"}`)
-	assert.Equal(t, http.StatusBadRequest, response.Code)
-}
-
 func TestDocIDFilterResurrection(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -4052,11 +4052,10 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 			inputBody:    map[string]interface{}{"_removed": false},
 			expectReject: true,
 		},
-		// TODO: When first _sync_ (BodyInternalPrefix) prefixed internal property is added, this document should be expect to be rejected
 		{
 			name:         "_sync_cookies",
 			inputBody:    map[string]interface{}{"_sync_cookies": true},
-			expectReject: false,
+			expectReject: true,
 		},
 	}
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -3974,3 +3974,132 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 	assertStatus(t, resp, http.StatusOK)
 	assert.Equal(t, "goodbye cruel world", string(resp.BodyBytes()))
 }
+
+func TestBlipInternalPropertiesHandling(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+
+	testCases := []struct {
+		name                        string
+		inputBody                   map[string]interface{}
+		expectReject                bool
+		skipDocContentsVerification *bool
+	}{
+		{
+			name:         "Valid document",
+			inputBody:    map[string]interface{}{"document": "is valid"},
+			expectReject: false,
+		},
+		{
+			name:         "Valid document with special prop",
+			inputBody:    map[string]interface{}{"_cookie": "is valid"},
+			expectReject: false,
+		},
+		{
+			name:         "Invalid _sync",
+			inputBody:    map[string]interface{}{"_sync": true},
+			expectReject: true,
+		},
+		{
+			name:         "Valid _id",
+			inputBody:    map[string]interface{}{"_id": "documentid"},
+			expectReject: true,
+		},
+		{
+			name:         "Valid _rev",
+			inputBody:    map[string]interface{}{"_rev": "1-abc"},
+			expectReject: true,
+		},
+		{
+			name:         "Valid _deleted",
+			inputBody:    map[string]interface{}{"_deleted": false},
+			expectReject: true,
+		},
+		{
+			name:         "Invalid _attachments",
+			inputBody:    map[string]interface{}{"_attachments": false},
+			expectReject: true,
+		},
+		{
+			name:                        "Valid _attachments",
+			inputBody:                   map[string]interface{}{"_attachments": map[string]interface{}{"attch": map[string]interface{}{"data": "c2d3IGZ0dw=="}}},
+			expectReject:                false,
+			skipDocContentsVerification: base.BoolPtr(true),
+		},
+		{
+			name:                        "_revisions",
+			inputBody:                   map[string]interface{}{"_revisions": false},
+			expectReject:                true,
+			skipDocContentsVerification: base.BoolPtr(true),
+		},
+		{
+			name:                        "Valid _exp",
+			inputBody:                   map[string]interface{}{"_exp": "123"},
+			expectReject:                false,
+			skipDocContentsVerification: base.BoolPtr(true),
+		},
+		{
+			name:         "Invalid _exp",
+			inputBody:    map[string]interface{}{"_exp": "abc"},
+			expectReject: true,
+		},
+		{
+			name:         "_purged",
+			inputBody:    map[string]interface{}{"_purged": false},
+			expectReject: true,
+		},
+		{
+			name:         "_removed",
+			inputBody:    map[string]interface{}{"_removed": false},
+			expectReject: true,
+		},
+		// TODO: When first _sync_ (BodyInternalPrefix) prefixed internal property is added, this document should be expect to be rejected
+		{
+			name:         "_sync_cookies",
+			inputBody:    map[string]interface{}{"_sync_cookies": true},
+			expectReject: false,
+		},
+	}
+
+	// Setup
+	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	defer rt.Close()
+
+	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
+	require.NoError(t, err)
+	defer client.Close()
+
+	// Track last sequence for next changes feed
+	var changes changesResults
+	changes.Last_Seq = "0"
+
+	for i, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			docID := fmt.Sprintf("test%d", i)
+			rawBody, err := json.Marshal(test.inputBody)
+			require.NoError(t, err)
+
+			_, err = client.PushRev(docID, "", rawBody)
+			if test.expectReject {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			// Wait for rev to be received on RT
+			err = rt.WaitForPendingChanges()
+			require.NoError(t, err)
+			changes, err = rt.WaitForChanges(1, fmt.Sprintf("/db/_changes?since=%s", changes.Last_Seq), "", true)
+			require.NoError(t, err)
+
+			var bucketDoc map[string]interface{}
+			_, err = rt.Bucket().Get(docID, &bucketDoc)
+			assert.NoError(t, err)
+			// Confirm input body is in the bucket doc
+			if test.skipDocContentsVerification == nil || !*test.skipDocContentsVerification {
+				for k, v := range test.inputBody {
+					assert.Equal(t, v, bucketDoc[k])
+				}
+			}
+		})
+	}
+}

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -3976,7 +3976,7 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 }
 
 func TestBlipInternalPropertiesHandling(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	testCases := []struct {
 		name                        string

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -2267,3 +2267,115 @@ func TestUnderscorePrefixSupportImport(t *testing.T) {
 		assert.EqualValues(t, val, resp[key])
 	}
 }
+
+func TestImportInternalPropertiesHandling(t *testing.T) {
+	SkipImportTestsIfNotEnabled(t)
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+
+	testCases := []struct {
+		name               string
+		importBody         map[string]interface{}
+		expectReject       bool
+		expectedStatusCode *int // Defaults to not 200 (for expectedReject=true) and 200 if expectedReject=false
+	}{
+		{
+			name:         "Valid document with special prop",
+			importBody:   map[string]interface{}{"_cookie": "is valid"},
+			expectReject: false,
+		},
+		{
+			name:               "Invalid _sync",
+			importBody:         map[string]interface{}{"_sync": true},
+			expectReject:       true,
+			expectedStatusCode: base.IntPtr(500), // Internal server error due to unmarshal error
+		},
+		{
+			name:               "Valid _id",
+			importBody:         map[string]interface{}{"_id": "documentid"},
+			expectReject:       true,
+			expectedStatusCode: base.IntPtr(400),
+		},
+		{
+			name:         "Valid _rev",
+			importBody:   map[string]interface{}{"_rev": "1-abc"},
+			expectReject: true,
+		},
+		{
+			name:         "Valid _deleted",
+			importBody:   map[string]interface{}{"_deleted": false},
+			expectReject: true,
+		},
+		{
+			name:         "Valid _revisions",
+			importBody:   map[string]interface{}{"_revisions": map[string]interface{}{"ids": "1-abc"}},
+			expectReject: true,
+		},
+		{
+			name:         "Valid _exp",
+			importBody:   map[string]interface{}{"_exp": "123"},
+			expectReject: true,
+		},
+		{
+			name:         "Invalid _attachments",
+			importBody:   map[string]interface{}{"_attachments": false},
+			expectReject: false,
+		},
+		{
+			name:         "Valid _attachments",
+			importBody:   map[string]interface{}{"_attachments": map[string]interface{}{"attch": map[string]interface{}{"data": "c2d3IGZ0dw=="}}},
+			expectReject: false,
+		},
+		{
+			name:         "_purged false",
+			importBody:   map[string]interface{}{"_purged": false},
+			expectReject: false, // Should only reject when _purged=true
+		},
+		{
+			name:               "_removed",
+			importBody:         map[string]interface{}{"_removed": false},
+			expectReject:       true,
+			expectedStatusCode: base.IntPtr(404),
+		},
+		// TODO: When first _sync_ (BodyInternalPrefix) prefixed internal property is added, this document should be expect to be rejected
+		{
+			name:         "_sync_cookies",
+			importBody:   map[string]interface{}{"_sync_cookies": true},
+			expectReject: false,
+		},
+	}
+
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+	bucket := rt.Bucket()
+
+	for i, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			docID := fmt.Sprintf("test%d", i)
+			added, err := bucket.Add(docID, 0, test.importBody)
+			require.True(t, added)
+			require.NoError(t, err)
+
+			// Perform on-demand import
+			resp := rt.SendAdminRequest("GET", "/db/"+docID, "")
+			if test.expectReject {
+				if test.expectedStatusCode != nil {
+					assert.Equal(t, *test.expectedStatusCode, resp.Code)
+				} else {
+					assert.NotEqual(t, 200, resp.Code)
+				}
+				return
+			}
+			if test.expectedStatusCode != nil {
+				assertStatus(rt.tb, resp, *test.expectedStatusCode)
+			} else {
+				assertStatus(rt.tb, resp, 200)
+			}
+			var body db.Body
+			require.NoError(rt.tb, base.JSONUnmarshal(resp.Body.Bytes(), &body))
+
+			for key, val := range body {
+				assert.EqualValues(t, val, body[key])
+			}
+		})
+	}
+}

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -2244,7 +2244,7 @@ func TestDeletedDocumentImportWithImportFilter(t *testing.T) {
 // CBG-2023: Test preventing underscore attachments
 func TestImportInternalPropertiesHandling(t *testing.T) {
 	SkipImportTestsIfNotEnabled(t)
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	testCases := []struct {
 		name               string
@@ -2310,9 +2310,10 @@ func TestImportInternalPropertiesHandling(t *testing.T) {
 			expectReject: true,
 		},
 		{
-			name:         "_purged true",
-			importBody:   map[string]interface{}{"_purged": true},
-			expectReject: true,
+			name:               "_purged true",
+			importBody:         map[string]interface{}{"_purged": true},
+			expectReject:       true,
+			expectedStatusCode: base.IntPtr(200), // Import gets cancelled and returns 200 and blank body
 		},
 		{
 			name:               "_removed",

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -2307,7 +2307,12 @@ func TestImportInternalPropertiesHandling(t *testing.T) {
 		{
 			name:         "_purged false",
 			importBody:   map[string]interface{}{"_purged": false},
-			expectReject: false, // Should only reject when _purged=true
+			expectReject: true,
+		},
+		{
+			name:         "_purged true",
+			importBody:   map[string]interface{}{"_purged": true},
+			expectReject: true,
 		},
 		{
 			name:               "_removed",

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1547,8 +1547,7 @@ func TestOnDemandMigrateWithExpiry(t *testing.T) {
 		assert.Equal(t, 200, response.Code)
 	}
 	triggerOnDemandViaWrite := func(rt *RestTester, key string) {
-		bodyString := rawDocWithSyncMeta()
-		rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", key), bodyString)
+		rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", key), "{}")
 	}
 
 	type testcase struct {

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -5889,7 +5889,7 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 
 	// Create the document
 	docID := t.Name()
-	rawDoc := `{"_id": "replaced", "_foo": true, "_exp": 120, "true": false, "_attachments": {"bar": {"data": "Zm9vYmFy"}}}`
+	rawDoc := `{"_foo": true, "_exp": 120, "true": false, "_attachments": {"bar": {"data": "Zm9vYmFy"}}}`
 	_ = activeRT.putDoc(docID, rawDoc)
 
 	// Set-up replicator
@@ -5925,7 +5925,6 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 
 	// Assert document was replicated successfully
 	doc := passiveRT.getDoc(docID)
-	assert.EqualValues(t, docID, doc["_id"])  // Confirm ID gets replaced with doc ID
 	assert.EqualValues(t, true, doc["_foo"])  // Confirm user defined value got created
 	assert.EqualValues(t, nil, doc["_exp"])   // Confirm expiry was consumed
 	assert.EqualValues(t, false, doc["true"]) // Sanity check normal keys
@@ -5936,7 +5935,7 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 	// Edit existing document
 	rev := doc["_rev"]
 	require.NotNil(t, rev)
-	rawDoc = fmt.Sprintf(`{"_id": "replaced", "_rev": "%s","_foo": false, "test": true}`, rev)
+	rawDoc = fmt.Sprintf(`{"_rev": "%s","_foo": false, "test": true}`, rev)
 	_ = activeRT.putDoc(docID, rawDoc)
 
 	// Replicate modified document
@@ -5953,7 +5952,6 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 	// Verify document replicated successfully
 	doc = passiveRT.getDoc(docID)
 	assert.NotEqualValues(t, doc["_rev"], rev) // Confirm rev got replaced with new rev
-	assert.EqualValues(t, docID, doc["_id"])   // Confirm ID gets replaced with doc ID
 	assert.EqualValues(t, false, doc["_foo"])  // Confirm user defined value got created
 	assert.EqualValues(t, true, doc["test"])
 	// Confirm attachment was removed successfully in latest revision

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1210,8 +1210,6 @@ func (bt *BlipTester) SendRevWithAttachment(input SendRevWithAttachmentInput) (s
 		}
 	}
 
-	doc.SetID(input.docId)
-	doc.SetRevID(input.revId)
 	doc.SetAttachments(db.AttachmentMap{
 		input.attachmentName: &myAttachment,
 	})


### PR DESCRIPTION
CBG-2023

- Internal properties are prevented depending on if using blip, import, or the REST API.
- Intentionally left todo in code for future use

`_deleted` is not rejected from import.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/219/ `1 failed test now fixed`
- [x] `just run failed test that has been fixed` https://jenkins.sgwdev.com/job/SyncGateway-Integration/220/
