### PR TITLE
CBG-1996: [Backport 3.0.1] CBG-1995: Implementation for supporting user-defined special properties 

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -867,8 +867,8 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 		}
 
 		// Make up a new _rev, and add it to the history:
-		bodyWithoutSpecialProps, wasStripped := stripSpecialProperties(body)
-		canonicalBytesForRevID, err := base.JSONMarshalCanonical(bodyWithoutSpecialProps)
+		bodyWithoutInternalProps, wasStripped := stripInternalProperties(body)
+		canonicalBytesForRevID, err := base.JSONMarshalCanonical(bodyWithoutInternalProps)
 		if err != nil {
 			return nil, nil, false, nil, err
 		}
@@ -1315,9 +1315,9 @@ func validateNewBody(body Body) error {
 		return base.HTTPErrorf(http.StatusNotFound, "Document revision is not accessible")
 	}
 
-	// Reject bodies containing user special properties for compatibility with CouchDB
-	if containsUserSpecialProperties(body) {
-		return base.HTTPErrorf(400, "user defined top level properties beginning with '_' are not allowed in document body")
+	// Reject bodies that contains the "_purged" property.
+	if body[BodyPurged] != nil {
+		return base.HTTPErrorf(http.StatusBadRequest, "user defined top level property '_purged' is not allowed in document body")
 	}
 	return nil
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1518,22 +1518,6 @@ func TestPostWithExistingId(t *testing.T) {
 
 }
 
-// Unit test for issue #507
-func TestPutWithUserSpecialProperty(t *testing.T) {
-
-	db := setupTestDB(t)
-	defer db.Close()
-
-	// Test creating a document with existing id property:
-	customDocId := "customIdValue"
-	log.Printf("Create document with existing id...")
-	body := Body{BodyId: customDocId, "key1": "value1", "_key2": "existing"}
-	docid, rev1id, _, err := db.Post(body)
-	goassert.True(t, rev1id == "")
-	goassert.True(t, docid == "")
-	goassert.True(t, err.Error() == "400 user defined top level properties beginning with '_' are not allowed in document body")
-}
-
 // Unit test for issue #976
 func TestWithNullPropertyKey(t *testing.T) {
 
@@ -1549,9 +1533,8 @@ func TestWithNullPropertyKey(t *testing.T) {
 	goassert.True(t, docid != "")
 }
 
-// Unit test for issue #507
+// Unit test for issue #507, modified for CBG-1995 (allowing special properties)
 func TestPostWithUserSpecialProperty(t *testing.T) {
-
 	db := setupTestDB(t)
 	defer db.Close()
 
@@ -1560,28 +1543,27 @@ func TestPostWithUserSpecialProperty(t *testing.T) {
 	log.Printf("Create document with existing id...")
 	body := Body{BodyId: customDocId, "key1": "value1", "key2": "existing"}
 	docid, rev1id, _, err := db.Post(body)
-	goassert.True(t, rev1id != "")
-	goassert.True(t, docid == customDocId)
-	assert.NoError(t, err, "Couldn't create document")
+	require.NoError(t, err, "Couldn't create document")
+	require.NotEqual(t, "", rev1id)
+	require.Equal(t, customDocId, docid)
 
 	// Test retrieval
 	doc, err := db.GetDocument(customDocId, DocUnmarshalAll)
-	goassert.True(t, doc != nil)
+	require.NotNil(t, doc)
 	assert.NoError(t, err, "Unable to retrieve doc using custom id")
 
-	// Test that posting an update with a user special property does not update the
-	//document
+	// Test that posting an update with a user special property does update the document
 	log.Printf("Update document with existing id...")
 	body = Body{BodyId: customDocId, BodyRev: rev1id, "_special": "value", "key1": "value1", "key2": "existing"}
-	_, _, err = db.Put(docid, body)
-	goassert.True(t, err.Error() == "400 user defined top level properties beginning with '_' are not allowed in document body")
+	rev2id, _, err := db.Put(docid, body)
+	assert.NoError(t, err)
 
-	// Test retrieval gets rev1
+	// Test retrieval gets rev2
 	doc, err = db.GetDocument(docid, DocUnmarshalAll)
-	goassert.True(t, doc != nil)
-	goassert.True(t, doc.CurrentRev == rev1id)
+	require.NotNil(t, doc)
+	assert.Equal(t, rev2id, doc.CurrentRev)
+	assert.Equal(t, "value", doc.Body()["_special"])
 	assert.NoError(t, err, "Unable to retrieve doc using generated uuid")
-
 }
 
 func TestRecentSequenceHistory(t *testing.T) {

--- a/db/import.go
+++ b/db/import.go
@@ -266,9 +266,9 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 		if len(existingDoc.Body) > 0 {
 			rawBodyForRevID = existingDoc.Body
 		} else {
-			var bodyWithoutSpecialProps Body
-			bodyWithoutSpecialProps, wasStripped = stripSpecialProperties(body)
-			rawBodyForRevID, err = base.JSONMarshalCanonical(bodyWithoutSpecialProps)
+			var bodyWithoutInternalProps Body
+			bodyWithoutInternalProps, wasStripped = stripInternalProperties(body)
+			rawBodyForRevID, err = base.JSONMarshalCanonical(bodyWithoutInternalProps)
 			if err != nil {
 				return nil, nil, false, nil, err
 			}

--- a/db/revision.go
+++ b/db/revision.go
@@ -24,14 +24,15 @@ import (
 type Body map[string]interface{}
 
 const (
-	BodyDeleted     = "_deleted"
-	BodyRev         = "_rev"
-	BodyId          = "_id"
-	BodyRevisions   = "_revisions"
-	BodyAttachments = "_attachments"
-	BodyPurged      = "_purged"
-	BodyExpiry      = "_exp"
-	BodyRemoved     = "_removed"
+	BodyDeleted        = "_deleted"
+	BodyRev            = "_rev"
+	BodyId             = "_id"
+	BodyRevisions      = "_revisions"
+	BodyAttachments    = "_attachments"
+	BodyPurged         = "_purged"
+	BodyExpiry         = "_exp"
+	BodyRemoved        = "_removed"
+	BodyInternalPrefix = "_sync_" // New internal properties prefix (CBG-1995)
 )
 
 // A revisions property found within a Body.  Expected to be of the form:
@@ -338,7 +339,7 @@ func (body Body) FixJSONNumbers() {
 
 func CreateRevID(generation int, parentRevID string, body Body) (string, error) {
 	// This should produce the same results as TouchDB.
-	strippedBody, _ := stripSpecialProperties(body)
+	strippedBody, _ := stripInternalProperties(body)
 	encoding, err := base.JSONMarshalCanonical(strippedBody)
 	if err != nil {
 		return "", err
@@ -412,54 +413,49 @@ func compareRevIDs(id1, id2 string) int {
 	return 0
 }
 
-// stripSpecialProperties returns a copy of the given body with all underscore-prefixed keys removed, except _attachments and _deleted.
-func stripSpecialProperties(b Body) (Body, bool) {
-	return stripSpecialPropertiesExcept(b, BodyAttachments, BodyDeleted)
+// stripInternalProperties returns a copy of the given body with all internal underscore-prefixed keys removed, except _attachments and _deleted.
+func stripInternalProperties(b Body) (Body, bool) {
+	return stripSpecialProperties(b, true)
 }
 
-// stripAllSpecialProperties returns a copy of the given body with all underscore-prefixed keys removed.
+// stripAllInternalProperties returns a copy of the given body with all underscore-prefixed keys removed.
 func stripAllSpecialProperties(b Body) (Body, bool) {
-	return stripSpecialPropertiesExcept(b)
+	return stripSpecialProperties(b, false)
 }
 
-// stripSpecialPropertiesExcept returns a copy of the given body with all underscore-prefixed keys removed, except those given.
-func stripSpecialPropertiesExcept(b Body, exceptions ...string) (sb Body, foundSpecialProps bool) {
+// stripSpecialPropertiesExcept returns a copy of the given body with underscore-prefixed keys removed.
+// Set internalOnly to only strip internal properties except _deleted and _attachments
+func stripSpecialProperties(b Body, internalOnly bool) (sb Body, foundSpecialProps bool) {
 	// Assume no properties removed for the initial capacity to reduce allocs on large docs.
 	stripped := make(Body, len(b))
 	for k, v := range b {
-		if k == "" || k[0] != '_' ||
-			base.StringSliceContains(exceptions, k) {
+		// Property is not stripped if:
+		// - It is blank
+		// - Does not start with an underscore ('_')
+		// - Is not an internal special property (this check is excluded when internalOnly = false)
+		if k == "" || k[0] != '_' || (internalOnly && (!strings.HasPrefix(k, BodyInternalPrefix) &&
+			!base.StringSliceContains([]string{
+				base.SyncPropertyName,
+				BodyId,
+				BodyRev,
+				BodyRevisions,
+				BodyExpiry,
+				BodyPurged,
+				BodyRemoved,
+			}, k))) {
 			// property is allowed
 			stripped[k] = v
 		} else {
 			foundSpecialProps = true
 		}
 	}
+
 	if foundSpecialProps {
 		return stripped, true
 	} else {
 		// Return original body if nothing was removed
 		return b, false
 	}
-}
-
-// containsUserSpecialProperties returns true if the given body contains a non-SG special property (underscore prefixed)
-func containsUserSpecialProperties(b Body) bool {
-	for k := range b {
-		if k != "" && k[0] == '_' &&
-			!base.ContainsString([]string{
-				BodyId,
-				BodyRev,
-				BodyDeleted,
-				BodyAttachments,
-				BodyRevisions,
-				BodyExpiry,
-			}, k) {
-			// body contains special property that isn't one of the above... must be user's
-			return true
-		}
-	}
-	return false
 }
 
 func GetStringArrayProperty(body map[string]interface{}, property string) ([]string, error) {

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -5864,6 +5864,107 @@ func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 	assert.Equal(t, docWriteFailuresBefore, ar.GetStatus().DocWriteFailures, "ISGR should ignore _remove:true bodies when purgeOnRemoval is disabled. CBG-1428 regression.")
 }
 
+// CBG-1995: Test the support for using an underscore prefix in the top-level body of a document
+// Tests replication and Rest API
+func TestUnderscorePrefixSupport(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+
+	// Passive //
+	passiveRT := NewRestTester(t, nil)
+	defer passiveRT.Close()
+
+	// Make passive RT listen on an actual HTTP port, so it can receive the blipsync request from the active replicator
+	srv := httptest.NewServer(passiveRT.TestAdminHandler())
+	defer srv.Close()
+
+	// Active //
+	activeRT := NewRestTester(t, nil)
+	defer activeRT.Close()
+
+	// Create the document
+	docID := t.Name()
+	rawDoc := `{"_id": "replaced", "_foo": true, "_exp": 120, "true": false, "_attachments": {"bar": {"data": "Zm9vYmFy"}}}`
+	_ = activeRT.putDoc(docID, rawDoc)
+
+	// Set-up replicator
+	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	require.NoError(t, err)
+
+	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePush,
+		RemoteDBURL: passiveDBURL,
+		ActiveDB: &db.Database{
+			DatabaseContext: activeRT.GetDatabase(),
+		},
+		Continuous:          true,
+		ChangesBatchSize:    200,
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		PurgeOnRemoval:      false,
+	})
+	defer func() { require.NoError(t, ar.Stop()) }()
+
+	require.NoError(t, ar.Start())
+	activeRT.waitForReplicationStatus(ar.ID, db.ReplicationStateRunning)
+
+	// Confirm document is replicated
+	changesResults, err := passiveRT.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	assert.NoError(t, err)
+	assert.Len(t, changesResults.Results, 1)
+
+	err = passiveRT.WaitForPendingChanges()
+	require.NoError(t, err)
+
+	require.NoError(t, ar.Stop())
+
+	// Assert document was replicated successfully
+	doc := passiveRT.getDoc(docID)
+	assert.EqualValues(t, docID, doc["_id"])  // Confirm ID gets replaced with doc ID
+	assert.EqualValues(t, true, doc["_foo"])  // Confirm user defined value got created
+	assert.EqualValues(t, nil, doc["_exp"])   // Confirm expiry was consumed
+	assert.EqualValues(t, false, doc["true"]) // Sanity check normal keys
+	// Confirm attachment was created successfully
+	resp := passiveRT.SendAdminRequest("GET", "/db/"+t.Name()+"/bar", "")
+	assertStatus(t, resp, 200)
+
+	// Edit existing document
+	rev := doc["_rev"]
+	require.NotNil(t, rev)
+	rawDoc = fmt.Sprintf(`{"_id": "replaced", "_rev": "%s","_foo": false, "test": true}`, rev)
+	_ = activeRT.putDoc(docID, rawDoc)
+
+	// Replicate modified document
+	require.NoError(t, ar.Start())
+	activeRT.waitForReplicationStatus(ar.ID, db.ReplicationStateRunning)
+
+	changesResults, err = passiveRT.WaitForChanges(1, fmt.Sprintf("/db/_changes?since=%v", changesResults.Last_Seq), "", true)
+	assert.NoError(t, err)
+	assert.Len(t, changesResults.Results, 1)
+
+	err = passiveRT.WaitForPendingChanges()
+	require.NoError(t, err)
+
+	// Verify document replicated successfully
+	doc = passiveRT.getDoc(docID)
+	assert.NotEqual(t, doc["_rev"], rev)      // Confirm rev got replaced with new rev
+	assert.EqualValues(t, docID, doc["_id"])  // Confirm ID gets replaced with doc ID
+	assert.EqualValues(t, false, doc["_foo"]) // Confirm user defined value got created
+	assert.EqualValues(t, true, doc["test"])
+	// Confirm attachment was removed successfully in latest revision
+	resp = passiveRT.SendAdminRequest("GET", "/db/"+docID+"/bar", "")
+	assertStatus(t, resp, 404)
+
+	// Add disallowed _removed tag in document
+	rawDoc = fmt.Sprintf(`{"_rev": "%s","_removed": false}`, doc["_rev"])
+	resp = activeRT.SendAdminRequest("PUT", "/db/"+docID, rawDoc)
+	assertStatus(t, resp, 404)
+
+	// Add disallowed _purged tag in document
+	rawDoc = fmt.Sprintf(`{"_rev": "%s","_purged": true}`, doc["_rev"])
+	resp = activeRT.SendAdminRequest("PUT", "/db/"+docID, rawDoc)
+	assertStatus(t, resp, 400)
+}
+
 func getTestRevpos(t *testing.T, doc db.Body, attachmentKey string) (revpos int) {
 	attachments := db.GetBodyAttachments(doc)
 	if attachments == nil {


### PR DESCRIPTION
CBG-1996

Backport of CBG-1995: Implementation for supporting top-level document properties with an underscore prefix 

- [x] https://jenkins.sgwdev.com/job/SyncGateway-Integration/181 1 flake
