### PR TITLE
Switched Go annotations to latest, non-forked version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: IsaacLambat/golang-test-annotations@v0.6.2
+        uses: guyarb/golang-test-annotations@v0.5.1
         with:
           test-results: test.json
 
@@ -76,6 +76,6 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: IsaacLambat/golang-test-annotations@v0.6.2
+        uses: guyarb/golang-test-annotations@v0.5.1
         with:
           test-results: test.json


### PR DESCRIPTION
Failures in the Github tests now get annotated with using the latest version of `guyarb/golang-test-annotations`rather than the forked version `IsaacLambat/golang-test-annotations`