### PR TITLE
CBG-2016: Relax principal name restrictions

### DIFF
--- a/auth/role.go
+++ b/auth/role.go
@@ -102,7 +102,7 @@ func (role *roleImpl) initRole(name string, channels base.Set) error {
 }
 
 // IsValidPrincipalName checks if the given user/role name would be valid. Valid names must be valid UTF-8, containing
-// at least one alphanumeric (except for the guest user), and no colons, commas, or slashes.
+// at least one alphanumeric (except for the guest user), and no colons, commas, backticks, or slashes.
 func IsValidPrincipalName(name string) bool {
 	if len(name) == 0 {
 		return true // guest user
@@ -116,7 +116,8 @@ func IsValidPrincipalName(name string) bool {
 		// colons: basic authentication uses them to separate usernames from passwords
 		// commas: fails channels.IsValidChannel, which channels.compileAccessMap uses via SetFromArray
 		// slashes: would need to make many (possibly breaking) changes to routing
-		if char == '/' || char == ':' || char == ',' {
+		// backticks: MB-50619
+		if char == '/' || char == ':' || char == ',' || char == '`' {
 			return false
 		}
 		if !seenAnAlphanum && (unicode.IsLetter(char) || unicode.IsNumber(char)) {

--- a/auth/role_test.go
+++ b/auth/role_test.go
@@ -30,9 +30,11 @@ func TestInitRole(t *testing.T) {
 
 	// Check initializing role with illegal role name.
 	role = &roleImpl{}
-	assert.Error(t, role.initRole("Mu$ic", channels.SetOf(t, "Spotify", "Youtube")))
-	assert.Error(t, role.initRole("Musi[", channels.SetOf(t, "Spotify", "Youtube")))
-	assert.Error(t, role.initRole("Music~", channels.SetOf(t, "Spotify", "Youtube")))
+	assert.Error(t, role.initRole("Music/", channels.SetOf(t, "Spotify", "Youtube")))
+	assert.Error(t, role.initRole("Music:", channels.SetOf(t, "Spotify", "Youtube")))
+	assert.Error(t, role.initRole("Music,", channels.SetOf(t, "Spotify", "Youtube")))
+	assert.Error(t, role.initRole(".", channels.SetOf(t, "Spotify", "Youtube")))
+	assert.Error(t, role.initRole("\xf7,", channels.SetOf(t, "Spotify", "Youtube")))
 }
 
 func TestAuthorizeChannelsRole(t *testing.T) {

--- a/auth/role_test.go
+++ b/auth/role_test.go
@@ -11,6 +11,8 @@ licenses/APL2.txt.
 package auth
 
 import (
+	"math/rand"
+	"strings"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -51,4 +53,17 @@ func TestAuthorizeChannelsRole(t *testing.T) {
 	assert.Error(t, role.AuthorizeAllChannels(channels.SetOf(t, "unknown")))
 	assert.NoError(t, role.AuthorizeAnyChannel(channels.SetOf(t, "superuser", "unknown")))
 	assert.Error(t, role.AuthorizeAllChannels(channels.SetOf(t, "unknown1", "unknown2")))
+}
+
+func BenchmarkIsValidPrincipalName(b *testing.B) {
+	const nameLength = 50
+	name := strings.Builder{}
+	for i := 0; i < nameLength; i++ {
+		name.WriteRune(rune(rand.Intn('z'-'a') + 'a'))
+	}
+	nameStr := name.String()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		IsValidPrincipalName(nameStr)
+	}
 }

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -212,6 +212,39 @@ func TestIsValidEmail(t *testing.T) {
 
 }
 
+func TestInvalidUsernamesRejected(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Username string
+	}{
+		{
+			Name:     "colons",
+			Username: "foo:bar",
+		},
+		{
+			Name:     "commas",
+			Username: "foo,bar",
+		},
+		{
+			Name:     "slashes",
+			Username: "foo/bar",
+		},
+		{
+			Name:     "no alphanumeric",
+			Username: "..",
+		},
+		{
+			Name:     "invalid UTF-8",
+			Username: "foo\xf9bar",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			require.False(t, IsValidPrincipalName(tc.Username), "expected '%s' to be rejected", tc.Username)
+		})
+	}
+}
+
 func TestCanSeeChannelSince(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
 	testBucket := base.GetTestBucket(t)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1364,12 +1364,20 @@ func TestAccessFunctionValidation(t *testing.T) {
 	_, _, err = db.Put("doc2", body)
 	assert.NoError(t, err, "")
 
-	body = Body{"users": []string{"roll:over"}, "userChannels": []string{"BBC1"}}
+	body = Body{"users": []string{"bad,username"}, "userChannels": []string{"BBC1"}}
 	_, _, err = db.Put("doc3", body)
 	assertHTTPError(t, err, 500)
 
-	body = Body{"users": []string{"username"}, "userChannels": []string{"bad,name"}}
+	body = Body{"users": []string{"role:bad:rolename"}, "userChannels": []string{"BBC1"}}
 	_, _, err = db.Put("doc4", body)
+	assertHTTPError(t, err, 500)
+
+	body = Body{"users": []string{",.,.,.,.,."}, "userChannels": []string{"BBC1"}}
+	_, _, err = db.Put("doc5", body)
+	assertHTTPError(t, err, 500)
+
+	body = Body{"users": []string{"username"}, "userChannels": []string{"bad,name"}}
+	_, _, err = db.Put("doc6", body)
 	assertHTTPError(t, err, 500)
 }
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1364,20 +1364,12 @@ func TestAccessFunctionValidation(t *testing.T) {
 	_, _, err = db.Put("doc2", body)
 	assert.NoError(t, err, "")
 
-	body = Body{"users": []string{"bad username"}, "userChannels": []string{"BBC1"}}
+	body = Body{"users": []string{"roll:over"}, "userChannels": []string{"BBC1"}}
 	_, _, err = db.Put("doc3", body)
 	assertHTTPError(t, err, 500)
 
-	body = Body{"users": []string{"role:bad rolename"}, "userChannels": []string{"BBC1"}}
-	_, _, err = db.Put("doc4", body)
-	assertHTTPError(t, err, 500)
-
-	body = Body{"users": []string{"roll:over"}, "userChannels": []string{"BBC1"}}
-	_, _, err = db.Put("doc5", body)
-	assertHTTPError(t, err, 500)
-
 	body = Body{"users": []string{"username"}, "userChannels": []string{"bad,name"}}
-	_, _, err = db.Put("doc6", body)
+	_, _, err = db.Put("doc4", body)
 	assertHTTPError(t, err, 500)
 }
 

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -454,28 +454,18 @@ func TestAccessQuery(t *testing.T) {
 	assert.Equal(t, 5, rowCount)
 	assert.NoError(t, results.Close())
 
-	// Attempt to introduce syntax error.  Should return zero rows for user `user1'`, and not return error
-	username = "user1'"
-	results, queryErr = db.QueryAccess(base.TestCtx(t), username)
-	assert.NoError(t, queryErr, "Query error")
-	rowCount = 0
-	for results.Next(&row) {
-		rowCount++
-	}
-	assert.Equal(t, 0, rowCount)
-	assert.NoError(t, results.Close())
-
-	// Attempt to introduce syntax error.  Should return zero rows for user `user1`AND`, and not return error.
+	// Attempt to introduce syntax errors. Each of these should return zero rows and no error.
 	// Validates select clause protection
-	username = "user1`AND"
-	results, queryErr = db.QueryAccess(base.TestCtx(t), username)
-	assert.NoError(t, queryErr, "Query error")
-	rowCount = 0
-	for results.Next(&row) {
-		rowCount++
+	for _, username := range []string{"user1'", "user1`AND", "user1?", "user1 ! user2$"} {
+		results, queryErr = db.QueryAccess(base.TestCtx(t), username)
+		assert.NoError(t, queryErr, "Query error")
+		rowCount = 0
+		for results.Next(&row) {
+			rowCount++
+		}
+		assert.Equal(t, 0, rowCount)
+		assert.NoError(t, results.Close())
 	}
-	assert.Equal(t, 0, rowCount)
-	assert.NoError(t, results.Close())
 }
 
 func TestRoleAccessQuery(t *testing.T) {
@@ -507,28 +497,18 @@ func TestRoleAccessQuery(t *testing.T) {
 	assert.Equal(t, 5, rowCount)
 	assert.NoError(t, results.Close())
 
-	// Attempt to introduce syntax error.  Should return zero rows for user `user1'`, and not return error
-	username = "user1'"
-	results, queryErr = db.QueryRoleAccess(base.TestCtx(t), username)
-	assert.NoError(t, queryErr, "Query error")
-	rowCount = 0
-	for results.Next(&row) {
-		rowCount++
-	}
-	assert.Equal(t, 0, rowCount)
-	assert.NoError(t, results.Close())
-
-	// Attempt to introduce syntax error.  Should return zero rows for user `user1`AND`, and not return error
+	// Attempt to introduce syntax errors. Each of these should return zero rows and no error.
 	// Validates select clause protection
-	username = "user1`AND"
-	results, queryErr = db.QueryRoleAccess(base.TestCtx(t), username)
-	assert.NoError(t, queryErr, "Query error")
-	rowCount = 0
-	for results.Next(&row) {
-		rowCount++
+	for _, username := range []string{"user1'", "user1`AND", "user1?", "user1 ! user2$"} {
+		results, queryErr = db.QueryRoleAccess(base.TestCtx(t), username)
+		assert.NoError(t, queryErr, "Query error")
+		rowCount = 0
+		for results.Next(&row) {
+			rowCount++
+		}
+		assert.Equal(t, 0, rowCount)
+		assert.NoError(t, results.Close())
 	}
-	assert.Equal(t, 0, rowCount)
-	assert.NoError(t, results.Close())
 }
 
 // Parse the plan looking for use of the fetch operation (appears as the key/value pair "#operator":"Fetch")

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -516,7 +516,6 @@ func TestFunkyRoleNames(t *testing.T) {
 			require.NoError(t, err)
 			const username = "user1"
 			syncFn := fmt.Sprintf(`function(doc) {channel(doc.channels); role("%s", %s);}`, username, string(roleNameJSON))
-			t.Logf("syncFn:\n%s", syncFn)
 			rt := NewRestTester(t, &RestTesterConfig{
 				SyncFn: syncFn,
 			})

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -460,7 +460,15 @@ func TestFunkyUsernames(t *testing.T) {
 		},
 		{
 			Name:     "spaces and punctuation",
-			UserName: "Foo And Bar!",
+			UserName: "Foo `And` Bar!",
+		},
+		{
+			Name:     "question mark",
+			UserName: "foo?bar",
+		},
+		{
+			Name:     "underscore prefix",
+			UserName: "_sync-foobar",
 		},
 	}
 	for _, tc := range cases {
@@ -506,7 +514,15 @@ func TestFunkyRoleNames(t *testing.T) {
 		},
 		{
 			Name:     "spaces and punctuation",
-			RoleName: "Foo And Bar!",
+			RoleName: "Foo `And` Bar!",
+		},
+		{
+			Name:     "question mark",
+			RoleName: "foo?bar",
+		},
+		{
+			Name:     "underscore prefix",
+			RoleName: "_sync-foobar",
 		},
 	}
 	for _, tc := range cases {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -459,12 +459,12 @@ func TestFunkyUsernames(t *testing.T) {
 			UserName: "foo#bar",
 		},
 		{
-			Name:     "spaces and punctuation",
-			UserName: "Foo `And` Bar!",
-		},
-		{
 			Name:     "question mark",
 			UserName: "foo?bar",
+		},
+		{
+			Name:     "dollars",
+			UserName: "$foo$bar",
 		},
 		{
 			Name:     "underscore prefix",
@@ -513,12 +513,12 @@ func TestFunkyRoleNames(t *testing.T) {
 			RoleName: "foo#bar",
 		},
 		{
-			Name:     "spaces and punctuation",
-			RoleName: "Foo `And` Bar!",
-		},
-		{
 			Name:     "question mark",
 			RoleName: "foo?bar",
+		},
+		{
+			Name:     "dollars",
+			RoleName: "$foo$bar",
 		},
 		{
 			Name:     "underscore prefix",


### PR DESCRIPTION
CBG-2016

Especially with OIDC, customers may want to e.g. namespace their usernames. Up until now we only permitted a select few characters (alphanumeric and any of "_-+.@") in principal names. Extend this to any character except for a few problematic cases:

- Invalid UTF-8
- Strings consisting only of punctuation (i.e. no alpha-numerics)
- Slashes, colons, backticks, and commas

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true,gsi=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/203/
- [x] `xattrs=true,gsi=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/204/
