### PR TITLE
Implement Connected Client BLIP API

### DIFF
--- a/db/blip_connected_client.go
+++ b/db/blip_connected_client.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2022-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package db
+
+import (
+	"net/http"
+
+	"github.com/couchbase/go-blip"
+	"github.com/couchbase/sync_gateway/base"
+)
+
+// Handles a Connected-Client "getRev" request.
+func (bh *blipHandler) handleGetRev(rq *blip.Message) error {
+	docID := rq.Properties[GetRevMessageId]
+	ifNotRev := rq.Properties[GetRevIfNotRev]
+
+	rev, err := bh.db.GetRev(docID, "", false, nil)
+	if err != nil {
+		status, reason := base.ErrorAsHTTPStatus(err)
+		return &base.HTTPError{Status: status, Message: reason}
+	} else if ifNotRev == rev.RevID {
+		return base.HTTPErrorf(http.StatusNotModified, "Not Modified")
+	} else if rev.Deleted {
+		return base.HTTPErrorf(http.StatusNotFound, "Deleted")
+	}
+
+	body, err := rev.Body()
+	if err != nil {
+		return base.HTTPErrorf(http.StatusInternalServerError, "Couldn't read document body: %s", err)
+	}
+
+	// Still need to stamp _attachments into BLIP messages
+	if len(rev.Attachments) > 0 {
+		DeleteAttachmentVersion(rev.Attachments)
+		body[BodyAttachments] = rev.Attachments
+	}
+
+	bodyBytes, err := base.JSONMarshalCanonical(body)
+	if err != nil {
+		return base.HTTPErrorf(http.StatusInternalServerError, "Couldn't encode document: %s", err)
+	}
+
+	response := rq.Response()
+	response.SetCompressed(true)
+	response.Properties[GetRevRevId] = rev.RevID
+	response.SetBody(bodyBytes)
+	bh.replicationStats.HandleGetRev.Add(1)
+	return nil
+}
+
+// Handles a Connected-Client "putRev" request.
+func (bh *blipHandler) handlePutRev(rq *blip.Message) error {
+	//FIXME: This should probably not just call into `handleRev`, which
+	// looks like it does some stuff specific to replication.
+	err := bh.handleRev(rq)
+	bh.replicationStats.HandlePutRev.Add(1)
+	return err
+}

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -39,6 +39,8 @@ var kHandlersByProfile = map[string]blipHandlerFunc{
 	MessageGetAttachment:   userBlipHandler((*blipHandler).handleGetAttachment),
 	MessageProveAttachment: userBlipHandler((*blipHandler).handleProveAttachment),
 	MessageProposeChanges:  (*blipHandler).handleProposeChanges,
+	MessageGetRev:          (*blipHandler).handleGetRev,
+	MessagePutRev:          (*blipHandler).handlePutRev,
 }
 
 // maxInFlightChangesBatches is the maximum number of in-flight changes batches a client is allowed to send without being throttled.

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -33,6 +33,9 @@ const (
 	MessageGetAttachment   = "getAttachment"
 	MessageProposeChanges  = "proposeChanges"
 	MessageProveAttachment = "proveAttachment"
+	MessageGetRev          = "getRev"       // Connected Client API
+	MessagePutRev          = "putRev"       // Connected Client API
+	MessageUnsubChanges    = "unsubChanges" // Connected Client API
 )
 
 // Message properties
@@ -77,6 +80,11 @@ const (
 	NorevMessageSequence = "sequence"
 	NorevMessageError    = "error"
 	NorevMessageReason   = "reason"
+
+	// getRev (Connected Client) message properties
+	GetRevMessageId = "id"
+	GetRevRevId     = "rev"
+	GetRevIfNotRev  = "ifNotRev"
 
 	// changes message properties
 	ChangesMessageIgnoreNoConflicts = "ignoreNoConflicts"

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -114,6 +114,9 @@ const (
 // Function signature for something that parses a sequence id from a string
 type SequenceIDParser func(since string) (SequenceID, error)
 
+// Function signature that returns the latest sequence
+type LatestSequenceFunc func() (SequenceID, error)
+
 // Helper for handling BLIP subChanges requests.  Supports Stringer() interface to log aspects of the request.
 type SubChangesParams struct {
 	rq      *blip.Message // The underlying BLIP message
@@ -126,7 +129,7 @@ type SubChangesBody struct {
 }
 
 // Create a new subChanges helper
-func NewSubChangesParams(logCtx context.Context, rq *blip.Message, zeroSeq SequenceID, sequenceIDParser SequenceIDParser) (*SubChangesParams, error) {
+func NewSubChangesParams(logCtx context.Context, rq *blip.Message, zeroSeq SequenceID, latestSeq LatestSequenceFunc, sequenceIDParser SequenceIDParser) (*SubChangesParams, error) {
 
 	params := &SubChangesParams{
 		rq: rq,
@@ -134,12 +137,16 @@ func NewSubChangesParams(logCtx context.Context, rq *blip.Message, zeroSeq Seque
 
 	// Determine incoming since and docIDs once, since there is some overhead associated with their calculation
 	sinceSequenceId := zeroSeq
-	if sinceStr, found := rq.Properties[SubChangesSince]; found {
-		var err error
+	var err error
+	if rq.Properties["future"] == "true" {
+		sinceSequenceId, err = latestSeq()
+	} else if sinceStr, found := rq.Properties[SubChangesSince]; found {
 		if sinceSequenceId, err = sequenceIDParser(base.ConvertJSONString(sinceStr)); err != nil {
 			base.InfofCtx(logCtx, base.KeySync, "%s: Invalid sequence ID in 'since': %s", rq, sinceStr)
-			return params, err
 		}
+	}
+	if err != nil {
+		return params, err
 	}
 	params._since = sinceSequenceId
 

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -24,6 +24,8 @@ type BlipSyncStats struct {
 	HandleRevBytes                   *base.SgwIntStat
 	HandleRevProcessingTime          *base.SgwIntStat
 	HandleRevDocsPurgedCount         *base.SgwIntStat
+	HandleGetRev                     *base.SgwIntStat // Connected Client API
+	HandlePutRev                     *base.SgwIntStat // Connected Client API
 	SendRevCount                     *base.SgwIntStat // sendRev
 	SendRevDeltaRequestedCount       *base.SgwIntStat
 	SendRevDeltaSentCount            *base.SgwIntStat
@@ -64,6 +66,8 @@ func NewBlipSyncStats() *BlipSyncStats {
 		HandleRevBytes:                   &base.SgwIntStat{},
 		HandleRevProcessingTime:          &base.SgwIntStat{},
 		HandleRevDocsPurgedCount:         &base.SgwIntStat{},
+		HandleGetRev:                     &base.SgwIntStat{},
+		HandlePutRev:                     &base.SgwIntStat{},
 		SendRevCount:                     &base.SgwIntStat{}, // sendRev
 		SendRevDeltaRequestedCount:       &base.SgwIntStat{},
 		SendRevDeltaSentCount:            &base.SgwIntStat{},

--- a/rest/blip_sync_messages_test.go
+++ b/rest/blip_sync_messages_test.go
@@ -82,10 +82,34 @@ func TestSubChangesSince(t *testing.T) {
 	rq := blip.NewRequest()
 	rq.Properties["since"] = `"1"`
 
-	subChangesParams, err := db.NewSubChangesParams(base.TestCtx(t), rq, db.SequenceID{}, testDb.ParseSequenceID)
+	subChangesParams, err := db.NewSubChangesParams(base.TestCtx(t), rq, db.SequenceID{}, nil, testDb.ParseSequenceID)
 	require.NoError(t, err)
 
 	seqID := subChangesParams.Since()
 	assert.Equal(t, uint64(1), seqID.Seq)
+
+}
+
+// Tests parsing the "future" mode of subChanges.
+func TestSubChangesFuture(t *testing.T) {
+
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	testDb := rt.GetDatabase()
+
+	latestSeq := func() (db.SequenceID, error) {
+		return db.SequenceID{Seq: 999}, nil
+	}
+
+	rq := blip.NewRequest()
+	rq.Properties["future"] = "true"
+	rq.Properties["since"] = `"1"`
+
+	subChangesParams, err := db.NewSubChangesParams(base.TestCtx(t), rq, db.SequenceID{}, latestSeq, testDb.ParseSequenceID)
+	require.NoError(t, err)
+
+	seqID := subChangesParams.Since()
+	assert.Equal(t, uint64(999), seqID.Seq)
 
 }


### PR DESCRIPTION
CBG-2038

The Connected Client API runs over the same BLIP connection as the replicator, but uses a few new request types and adds a new parameter to subChanges. [It's documented here](https://github.com/couchbase/couchbase-lite-core/blob/feature/connected-client/docs/overview/ConnectedClientProtocol.md).

This PR:
- Adds a `future` parameter to `subChanges`. If set to `true`, it effectively sets `since` to the latest sequence ID, so only future changes will be sent.
- Adds `getRev` which requests the current revision of a single document.
- Adds `putRev` which stores a single document. (This is basically identical to `rev`, but made a separate request for reasons explained in the spec.)

Not implemented yet:
- `unsubChanges` — I think I will need help with this, because the whole machinery of the BLIP changes feed is complex enough that couldn't figure out how to stop one.

Potential issues:
- I implemented `handlePutRev` by simply calling `handleRev`. This works, but `handleRev` does some logging and stats-incrementing that might not be appropriate outside a replication; I'll leave that for reviewers to decide.