### PR TITLE
CBG-2014: Check attachment size before sending to DB

### DIFF
--- a/db/attachment.go
+++ b/db/attachment.go
@@ -14,9 +14,11 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 
+	"github.com/couchbase/gomemcached"
 	"github.com/couchbase/sync_gateway/base"
 )
 
@@ -53,6 +55,9 @@ type DocAttachment struct {
 	Version     int    `json:"ver,omitempty"`
 	Data        []byte `json:"-"` // tell json marshal/unmarshal to ignore this field
 }
+
+// ErrAttachmentTooLarge is returned when an attempt to attach an oversize attachment is made.
+var ErrAttachmentTooLarge = errors.New("attachment too large")
 
 // Given Attachments Meta to be stored in the database, storeAttachments goes through the map, finds attachments with
 // inline bodies, copies the bodies into the Couchbase db, and replaces the bodies with the 'digest' attributes which
@@ -246,6 +251,9 @@ func (db *Database) setAttachment(key string, value []byte) error {
 func (db *Database) setAttachments(attachments AttachmentData) error {
 	for key, data := range attachments {
 		attachmentSize := int64(len(data))
+		if attachmentSize > int64(gomemcached.MaxBodyLen) {
+			return ErrAttachmentTooLarge
+		}
 		_, err := db.Bucket.AddRaw(key, 0, data)
 		if err == nil {
 			base.InfofCtx(db.Ctx, base.KeyCRUD, "\tAdded attachment %q", base.UD(key))

--- a/db/attachment.go
+++ b/db/attachment.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/couchbase/gomemcached"
 	"github.com/couchbase/sync_gateway/base"
 )
 
@@ -58,6 +57,8 @@ type DocAttachment struct {
 
 // ErrAttachmentTooLarge is returned when an attempt to attach an oversize attachment is made.
 var ErrAttachmentTooLarge = errors.New("attachment too large")
+
+const maxAttachmentSizeBytes = 20 * 1024 * 1024
 
 // Given Attachments Meta to be stored in the database, storeAttachments goes through the map, finds attachments with
 // inline bodies, copies the bodies into the Couchbase db, and replaces the bodies with the 'digest' attributes which
@@ -251,7 +252,7 @@ func (db *Database) setAttachment(key string, value []byte) error {
 func (db *Database) setAttachments(attachments AttachmentData) error {
 	for key, data := range attachments {
 		attachmentSize := int64(len(data))
-		if attachmentSize > int64(gomemcached.MaxBodyLen) {
+		if attachmentSize > int64(maxAttachmentSizeBytes) {
 			return ErrAttachmentTooLarge
 		}
 		_, err := db.Bucket.AddRaw(key, 0, data)

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -1580,7 +1580,9 @@ func TestLargeAttachments(t *testing.T) {
 			},
 		},
 	})
-	require.Error(t, err, "Created doc with oversize attachment")
+	var httpErr *base.HTTPError
+	require.ErrorAs(t, err, &httpErr, "Created doc with oversize attachment")
+	require.Equal(t, http.StatusRequestEntityTooLarge, httpErr.Status)
 
 	_, _, err = db.Put("hugedoc", Body{
 		"_attachments": AttachmentsMeta{
@@ -1589,5 +1591,6 @@ func TestLargeAttachments(t *testing.T) {
 			},
 		},
 	})
-	require.Error(t, err, "Created doc with huge attachment")
+	require.ErrorAs(t, err, &httpErr, "Created doc with huge attachment")
+	require.Equal(t, http.StatusRequestEntityTooLarge, httpErr.Status)
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -1449,7 +1449,7 @@ func (db *Database) addAttachments(newAttachments AttachmentData) error {
 	// Need to check and add attachments here to ensure the attachment is within size constraints
 	err := db.setAttachments(newAttachments)
 	if err != nil {
-		if err.Error() == "document value was too large" {
+		if errors.Is(err, ErrAttachmentTooLarge) || err.Error() == "document value was too large" {
 			err = base.HTTPErrorf(http.StatusRequestEntityTooLarge, "Attachment too large")
 		} else {
 			err = errors.Wrap(err, "Error adding attachment")


### PR DESCRIPTION
CBG-2014

Previously we would rely on CBS to tell SGW when an attachment is too big (>20MB). However, if an attachment exceeds 30MB, CBS will abruptly close the connection instead, which would manifest as a 500 error.

Instead, check the attachment size before we try sending the attachment to the server.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/194/