### PR TITLE
[Backport 3.0.1] CBG-2044: CBG-2026: Add option to disable basic auth for the public API

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -123,31 +123,32 @@ type DatabaseContext struct {
 }
 
 type DatabaseContextOptions struct {
-	CacheOptions              *CacheOptions
-	RevisionCacheOptions      *RevisionCacheOptions
-	OldRevExpirySeconds       uint32
-	AdminInterface            *string
-	UnsupportedOptions        *UnsupportedOptions
-	OIDCOptions               *auth.OIDCOptions
-	DBOnlineCallback          DBOnlineCallback // Callback function to take the DB back online
-	ImportOptions             ImportOptions
-	EnableXattr               bool             // Use xattr for _sync
-	LocalDocExpirySecs        uint32           // The _local doc expiry time in seconds
-	SecureCookieOverride      bool             // Pass-through DBConfig.SecureCookieOverride
-	SessionCookieName         string           // Pass-through DbConfig.SessionCookieName
-	SessionCookieHttpOnly     bool             // Pass-through DbConfig.SessionCookieHTTPOnly
-	AllowConflicts            *bool            // False forbids creating conflicts
-	SendWWWAuthenticateHeader *bool            // False disables setting of 'WWW-Authenticate' header
-	UseViews                  bool             // Force use of views
-	DeltaSyncOptions          DeltaSyncOptions // Delta Sync Options
-	CompactInterval           uint32           // Interval in seconds between compaction is automatically ran - 0 means don't run
-	SGReplicateOptions        SGReplicateOptions
-	SlowQueryWarningThreshold time.Duration
-	QueryPaginationLimit      int    // Limit used for pagination of queries. If not set defaults to DefaultQueryPaginationLimit
-	UserXattrKey              string // Key of user xattr that will be accessible from the Sync Function. If empty the feature will be disabled.
-	ClientPartitionWindow     time.Duration
-	BcryptCost                int
-	GroupID                   string
+	CacheOptions                  *CacheOptions
+	RevisionCacheOptions          *RevisionCacheOptions
+	OldRevExpirySeconds           uint32
+	AdminInterface                *string
+	UnsupportedOptions            *UnsupportedOptions
+	OIDCOptions                   *auth.OIDCOptions
+	DBOnlineCallback              DBOnlineCallback // Callback function to take the DB back online
+	ImportOptions                 ImportOptions
+	EnableXattr                   bool             // Use xattr for _sync
+	LocalDocExpirySecs            uint32           // The _local doc expiry time in seconds
+	SecureCookieOverride          bool             // Pass-through DBConfig.SecureCookieOverride
+	SessionCookieName             string           // Pass-through DbConfig.SessionCookieName
+	SessionCookieHttpOnly         bool             // Pass-through DbConfig.SessionCookieHTTPOnly
+	AllowConflicts                *bool            // False forbids creating conflicts
+	SendWWWAuthenticateHeader     *bool            // False disables setting of 'WWW-Authenticate' header
+	DisablePasswordAuthentication bool             // True enforces OIDC/guest only
+	UseViews                      bool             // Force use of views
+	DeltaSyncOptions              DeltaSyncOptions // Delta Sync Options
+	CompactInterval               uint32           // Interval in seconds between compaction is automatically ran - 0 means don't run
+	SGReplicateOptions            SGReplicateOptions
+	SlowQueryWarningThreshold     time.Duration
+	QueryPaginationLimit          int    // Limit used for pagination of queries. If not set defaults to DefaultQueryPaginationLimit
+	UserXattrKey                  string // Key of user xattr that will be accessible from the Sync Function. If empty the feature will be disabled.
+	ClientPartitionWindow         time.Duration
+	BcryptCost                    int
+	GroupID                       string
 }
 
 type SGReplicateOptions struct {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -91,6 +91,46 @@ func TestDBRoot(t *testing.T) {
 	goassert.Equals(t, response.Header().Get("Allow"), "GET, HEAD, POST, PUT")
 }
 
+func TestDisablePublicBasicAuth(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				DisablePasswordAuth: true,
+				Guest: &db.PrincipalConfig{
+					Disabled: base.BoolPtr(true),
+				},
+			},
+		},
+	})
+	defer rt.Close()
+
+	response := rt.SendRequest(http.MethodGet, "/db/", "")
+	assertStatus(t, response, http.StatusUnauthorized)
+	assert.NotContains(t, response.Header(), "WWW-Authenticate", "expected to not receive a WWW-Auth header when password auth is disabled")
+
+	// Double-check that even if we provide valid credentials we still won't be let in
+	a := rt.ServerContext().Database("db").Authenticator()
+	user, err := a.NewUser("user1", "letmein", channels.SetOf(t, "foo"))
+	assert.NoError(t, err)
+	assert.NoError(t, a.Save(user))
+
+	response = rt.Send(requestByUser(http.MethodGet, "/db/", "", "user1"))
+	assertStatus(t, response, http.StatusUnauthorized)
+	assert.NotContains(t, response.Header(), "WWW-Authenticate", "expected to not receive a WWW-Auth header when password auth is disabled")
+
+	// Also check that we can't create a session through POST /db/_session
+	response = rt.SendRequest(http.MethodPost, "/db/_session", `{"name":"user1","password":"letmein"}`)
+	assertStatus(t, response, http.StatusUnauthorized)
+
+	// As a sanity check, ensure it does work when the setting is disabled
+	rt.ServerContext().Database("db").Options.DisablePasswordAuthentication = false
+	response = rt.Send(requestByUser(http.MethodGet, "/db/", "", "user1"))
+	assertStatus(t, response, http.StatusOK)
+
+	response = rt.SendRequest(http.MethodPost, "/db/_session", `{"name":"user1","password":"letmein"}`)
+	assertStatus(t, response, http.StatusOK)
+}
+
 func (rt *RestTester) createDoc(t *testing.T, docid string) string {
 	response := rt.SendAdminRequest("PUT", "/db/"+docid, `{"prop":true}`)
 	assertStatus(t, response, 201)

--- a/rest/config.go
+++ b/rest/config.go
@@ -139,7 +139,8 @@ type DbConfig struct {
 	AllowConflicts                   *bool                            `json:"allow_conflicts,omitempty"`                      // False forbids creating conflicts
 	NumIndexReplicas                 *uint                            `json:"num_index_replicas,omitempty"`                   // Number of GSI index replicas used for core indexes
 	UseViews                         *bool                            `json:"use_views,omitempty"`                            // Force use of views instead of GSI
-	SendWWWAuthenticateHeader        *bool                            `json:"send_www_authenticate_header,omitempty"`         // If false, disables setting of 'WWW-Authenticate' header in 401 responses
+	SendWWWAuthenticateHeader        *bool                            `json:"send_www_authenticate_header,omitempty"`         // If false, disables setting of 'WWW-Authenticate' header in 401 responses. Implicitly false if disable_password_auth is true.
+	DisablePasswordAuth              bool                             `json:"disable_password_auth,omitempty"`                // If true, disables user/pass authentication, only permitting OIDC or guest access
 	BucketOpTimeoutMs                *uint32                          `json:"bucket_op_timeout_ms,omitempty"`                 // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
 	SlowQueryWarningThresholdMs      *uint32                          `json:"slow_query_warning_threshold,omitempty"`         // Log warnings if N1QL queries take this many ms
 	DeltaSync                        *DeltaSyncConfig                 `json:"delta_sync,omitempty"`                           // Config for delta sync

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -376,6 +376,108 @@ func TestOpenIDConnectTestProviderWithRealWorldToken(t *testing.T) {
 	}
 }
 
+func TestOIDCWithBasicAuthDisabled(t *testing.T) {
+	providers := auth.OIDCProviderMap{
+		"test": &auth.OIDCProvider{
+			Register:      true,
+			Issuer:        "${baseURL}/db/_oidc_testing",
+			Name:          "test",
+			ClientID:      "sync_gateway",
+			ValidationKey: base.StringPtr("qux"),
+			CallbackURL:   base.StringPtr("${baseURL}/db/_oidc_callback"),
+			UserPrefix:    "foo",
+		},
+	}
+	defaultProvider := "test"
+	opts := auth.OIDCOptions{Providers: providers, DefaultProvider: &defaultProvider}
+
+	restTesterConfig := RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			OIDCConfig: &opts,
+			Unsupported: &db.UnsupportedOptions{
+				OidcTestProvider: &db.OidcTestProviderOptions{
+					Enabled: true,
+				},
+			},
+			DisablePasswordAuth: true,
+		}}}
+	restTester := NewRestTester(t, &restTesterConfig)
+	require.NoError(t, restTester.SetAdminParty(false))
+	defer restTester.Close()
+
+	mockSyncGateway := httptest.NewServer(restTester.TestPublicHandler())
+	defer mockSyncGateway.Close()
+	mockSyncGatewayURL := mockSyncGateway.URL
+	provider := restTesterConfig.DatabaseConfig.OIDCConfig.Providers.GetDefaultProvider()
+	provider.Issuer = mockSyncGateway.URL + "/db/_oidc_testing"
+	provider.CallbackURL = base.StringPtr(mockSyncGateway.URL + "/db/_oidc_callback")
+	createUser(t, restTester, "foo_noah")
+
+	// Send OpenID Connect request
+	authURL := "/db/_oidc?provider=test&offline=true"
+	requestURL := mockSyncGatewayURL + authURL
+	request, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	require.NoError(t, err, "Error creating new request")
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err, "Error creating new cookie jar")
+	client := http.DefaultClient
+	client.Jar = jar
+	response, err := client.Do(request)
+	require.NoError(t, err, "Error sending request")
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	bodyBytes, err := ioutil.ReadAll(response.Body)
+	require.NoError(t, err, "Error reading response")
+	bodyString := string(bodyBytes)
+	require.NoError(t, response.Body.Close(), "Error closing response body")
+
+	// Send authentication request
+	requestURL = mockSyncGateway.URL + "/db/_oidc_testing/" + parseAuthURL(bodyString)
+	form := url.Values{}
+	form.Add(formKeyUsername, "noah")
+	form.Add(formKeyAuthenticated, "Return a valid authorization code for this user")
+	form.Add(formKeyIdTokenFormat, string(defaultFormat))
+	request, err = http.NewRequest(http.MethodPost, requestURL, bytes.NewBufferString(form.Encode()))
+	require.NoError(t, err, "Error creating new request")
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	response, err = client.Do(request)
+	require.NoError(t, err, "Error sending request")
+	require.Equal(t, http.StatusOK, response.StatusCode)
+
+	var authResponseActual OIDCTokenResponse
+	require.NoError(t, err, json.NewDecoder(response.Body).Decode(&authResponseActual))
+	require.NoError(t, response.Body.Close(), "Error closing response body")
+	assert.NotEmpty(t, authResponseActual.SessionID, "session_id doesn't exist")
+	assert.NotEmpty(t, authResponseActual.Username, "session_id doesn't exist")
+	assert.NotEmpty(t, authResponseActual.IDToken, "id_token mismatch")
+	assert.NotEmpty(t, authResponseActual.RefreshToken, "refresh_token mismatch")
+
+	// Obtain session with Bearer token
+	sessionEndpoint := mockSyncGatewayURL + "/" + restTester.DatabaseConfig.Name + "/_session"
+	request, err = http.NewRequest(http.MethodPost, sessionEndpoint, strings.NewReader(`{}`))
+	require.NoError(t, err, "Error creating new request")
+	request.Header.Add("Authorization", BearerToken+" "+authResponseActual.IDToken)
+	response, err = http.DefaultClient.Do(request)
+	require.NoError(t, err, "Error sending request with bearer token")
+	checkGoodAuthResponse(t, response, "foo_noah")
+
+	// Now verify that we can perform a trivial request
+	request, err = http.NewRequest(http.MethodGet, mockSyncGatewayURL+"/"+restTester.DatabaseConfig.Name, nil)
+	require.NoError(t, err, "Error creating new request")
+	response, err = client.Do(request)
+	require.NoError(t, err, "Error sending request")
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	require.NoError(t, response.Body.Close(), "Error closing response body")
+
+	// Finally, forget the session and check that we're back to getting a 401, but with no WWW-Authenticate
+	client.Jar = nil
+	request, err = http.NewRequest(http.MethodGet, mockSyncGatewayURL+"/"+restTester.DatabaseConfig.Name, nil)
+	require.NoError(t, err, "Error creating new request")
+	response, err = client.Do(request)
+	require.NoError(t, err, "Error sending request")
+	require.Equal(t, http.StatusUnauthorized, response.StatusCode)
+	require.NoError(t, response.Body.Close(), "Error closing response body")
+}
+
 // parseAuthURL returns the authentication URL extracted from user consent form.
 func parseAuthURL(html string) string {
 	re := regexp.MustCompile(`<form action="(.+)" method`)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -771,29 +771,36 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		groupID = sc.config.Bootstrap.ConfigGroupID
 	}
 
+	// If basic auth is disabled, it doesn't make sense to send WWW-Authenticate
+	sendWWWAuthenticate := config.SendWWWAuthenticateHeader
+	if config.DisablePasswordAuth {
+		sendWWWAuthenticate = base.BoolPtr(false)
+	}
+
 	// Register the cbgt pindex type for the configGroup
 	db.RegisterImportPindexImpl(groupID)
 
 	contextOptions := db.DatabaseContextOptions{
-		CacheOptions:              &cacheOptions,
-		RevisionCacheOptions:      revCacheOptions,
-		OldRevExpirySeconds:       oldRevExpirySeconds,
-		LocalDocExpirySecs:        localDocExpirySecs,
-		AdminInterface:            &sc.config.API.AdminInterface,
-		UnsupportedOptions:        config.Unsupported,
-		OIDCOptions:               config.OIDCConfig,
-		DBOnlineCallback:          dbOnlineCallback,
-		ImportOptions:             importOptions,
-		EnableXattr:               config.UseXattrs(),
-		SecureCookieOverride:      secureCookieOverride,
-		SessionCookieName:         config.SessionCookieName,
-		SessionCookieHttpOnly:     base.BoolDefault(config.SessionCookieHTTPOnly, false),
-		AllowConflicts:            config.ConflictsAllowed(),
-		SendWWWAuthenticateHeader: config.SendWWWAuthenticateHeader,
-		DeltaSyncOptions:          deltaSyncOptions,
-		CompactInterval:           compactIntervalSecs,
-		QueryPaginationLimit:      queryPaginationLimit,
-		UserXattrKey:              config.UserXattrKey,
+		CacheOptions:                  &cacheOptions,
+		RevisionCacheOptions:          revCacheOptions,
+		OldRevExpirySeconds:           oldRevExpirySeconds,
+		LocalDocExpirySecs:            localDocExpirySecs,
+		AdminInterface:                &sc.config.API.AdminInterface,
+		UnsupportedOptions:            config.Unsupported,
+		OIDCOptions:                   config.OIDCConfig,
+		DBOnlineCallback:              dbOnlineCallback,
+		ImportOptions:                 importOptions,
+		EnableXattr:                   config.UseXattrs(),
+		SecureCookieOverride:          secureCookieOverride,
+		SessionCookieName:             config.SessionCookieName,
+		SessionCookieHttpOnly:         base.BoolDefault(config.SessionCookieHTTPOnly, false),
+		AllowConflicts:                config.ConflictsAllowed(),
+		SendWWWAuthenticateHeader:     sendWWWAuthenticate,
+		DisablePasswordAuthentication: config.DisablePasswordAuth,
+		DeltaSyncOptions:              deltaSyncOptions,
+		CompactInterval:               compactIntervalSecs,
+		QueryPaginationLimit:          queryPaginationLimit,
+		UserXattrKey:                  config.UserXattrKey,
 		SGReplicateOptions: db.SGReplicateOptions{
 			Enabled:               sgReplicateEnabled,
 			WebsocketPingInterval: sgReplicateWebsocketPingInterval,

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -48,6 +48,11 @@ func (h *handler) handleSessionPOST() error {
 		}
 	}
 
+	// NOTE: handleSessionPOST doesn't handle creating users from OIDC - checkAuth calls out into AuthenticateUntrustedJWT.
+	// Therefore, if by this point `h.user` is guest, this isn't creating a session from OIDC.
+	if h.db.Options.DisablePasswordAuthentication && (h.user == nil || h.user.Name() == "") {
+		return base.HTTPErrorf(http.StatusUnauthorized, "Password authentication is disabled")
+	}
 	user, err := h.getUserFromSessionRequestBody()
 
 	// If we fail to get a user from the body and we've got a non-GUEST authenticated user, create the session based on that user


### PR DESCRIPTION
CBG-2044

Backport CBG-2026 to 3.0.1.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/196/
- [x] `rest` only https://jenkins.sgwdev.com/job/SyncGateway-Integration/197
```
--- PASS: TestOIDCWithBasicAuthDisabled (3.30s)
--- PASS: TestDisablePublicBasicAuth (3.18s)
```