### PR TITLE
[3.0.1 Backport] CBG-2035: Improved persistent config handling for dropped buckets

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -10,6 +10,7 @@ package rest
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -1055,15 +1056,14 @@ func (sc *ServerContext) fetchAndLoadConfigs() (count int, err error) {
 	sc.lock.Lock()
 	defer sc.lock.Unlock()
 
-	fetchedConfigs, bucketsNoConfig, err := sc.fetchConfigs()
+	fetchedConfigs, err := sc.fetchConfigs()
 	if err != nil {
 		return 0, err
 	}
 
-	for _, bucket := range bucketsNoConfig {
-		dbName, ok := sc.bucketDbName[bucket]
-		if ok {
-			base.Infof(base.KeyConfig, "database %q was running on this node, but config was not found on the server - removing database", base.MD(dbName))
+	for _, dbName := range sc.bucketDbName {
+		if _, foundMatchingDb := fetchedConfigs[dbName]; !foundMatchingDb {
+			base.InfofCtx(context.TODO(), base.KeyConfig, "Database %q was running on this node, but config was not found on the server - removing database", base.MD(dbName))
 			sc._removeDatabase(dbName)
 		}
 	}
@@ -1148,10 +1148,10 @@ func (sc *ServerContext) fetchDatabase(dbName string) (found bool, dbConfig *Dat
 }
 
 // fetchConfigs retrieves all database configs from the ServerContext's bootstrapConnection.
-func (sc *ServerContext) fetchConfigs() (dbNameConfigs map[string]DatabaseConfig, bucketsNoConfig []string, err error) {
+func (sc *ServerContext) fetchConfigs() (dbNameConfigs map[string]DatabaseConfig, err error) {
 	buckets, err := sc.bootstrapContext.connection.GetConfigBuckets()
 	if err != nil {
-		return nil, nil, fmt.Errorf("couldn't get buckets from cluster: %w", err)
+		return nil, fmt.Errorf("couldn't get buckets from cluster: %w", err)
 	}
 
 	fetchedConfigs := make(map[string]DatabaseConfig, len(buckets))
@@ -1161,12 +1161,13 @@ func (sc *ServerContext) fetchConfigs() (dbNameConfigs map[string]DatabaseConfig
 		var cnf DatabaseConfig
 		cas, err := sc.bootstrapContext.connection.GetConfig(bucket, sc.config.Bootstrap.ConfigGroupID, &cnf)
 		if err == base.ErrNotFound {
-			base.Tracef(base.KeyConfig, "bucket %q did not contain config for group %q", bucket, sc.config.Bootstrap.ConfigGroupID)
-			bucketsNoConfig = append(bucketsNoConfig, bucket)
+			base.DebugfCtx(context.TODO(), base.KeyConfig, "Bucket %q did not contain config for group %q", bucket, sc.config.Bootstrap.ConfigGroupID)
 			continue
 		}
 		if err != nil {
-			base.Debugf(base.KeyConfig, "unable to fetch config for group %q from bucket %q: %v", sc.config.Bootstrap.ConfigGroupID, bucket, err)
+			// Unexpected error fetching config - SDK has already performed retries, so we'll treat it as a database removal
+			// this could be due to invalid JSON or some other non-recoverable error.
+			base.WarnfCtx(context.TODO(), "Unable to fetch config for group %q from bucket %q: %v", sc.config.Bootstrap.ConfigGroupID, bucket, err)
 			continue
 		}
 
@@ -1195,7 +1196,7 @@ func (sc *ServerContext) fetchConfigs() (dbNameConfigs map[string]DatabaseConfig
 		fetchedConfigs[cnf.Name] = cnf
 	}
 
-	return fetchedConfigs, bucketsNoConfig, nil
+	return fetchedConfigs, nil
 }
 
 // _applyConfigs takes a map of dbName->DatabaseConfig and loads them into the ServerContext where necessary.


### PR DESCRIPTION
Backports #5497 to 3.0.1

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/199/
