### PR TITLE
CBG-1980: Fixed incorrect attachment stats being reported

### DIFF
--- a/base/dcp_client_worker.go
+++ b/base/dcp_client_worker.go
@@ -85,8 +85,8 @@ func (w *DCPWorker) Send(event streamEvent) {
 }
 
 func (w *DCPWorker) Start(wg *sync.WaitGroup) {
+	wg.Add(1)
 	go func() {
-		wg.Add(1)
 		defer wg.Done()
 		for {
 			select {

--- a/base/dcp_client_worker.go
+++ b/base/dcp_client_worker.go
@@ -3,6 +3,7 @@ package base
 import (
 	"bytes"
 	"context"
+	"sync"
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -83,9 +84,10 @@ func (w *DCPWorker) Send(event streamEvent) {
 	}
 }
 
-func (w *DCPWorker) Start() {
-
+func (w *DCPWorker) Start(wg *sync.WaitGroup) {
 	go func() {
+		wg.Add(1)
+		defer wg.Done()
 		for {
 			select {
 			case event := <-w.eventFeed:

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -802,3 +802,84 @@ func createDocWithInBodyAttachment(t *testing.T, docID string, docBody []byte, a
 
 	return attDocID
 }
+
+// Check for regression of CBG-1980 caused by DCP closing timing issue for the mark and sweep stage
+// May sometimes pass even if there is a regression of the timing issue
+func TestAttachmentCompactIncorrectStat(t *testing.T) {
+	const docsToCreate = 500
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Requires CBS")
+	}
+
+	testDb := setupTestDB(t)
+	defer testDb.Close()
+	// Create the docs that will be marked and swept
+	body := map[string]interface{}{"foo": "bar"}
+	for i := 0; i < docsToCreate; i++ {
+		key := fmt.Sprintf("%s_%d", t.Name(), i)
+		_, _, err := testDb.Put(key, body)
+		assert.NoError(t, err)
+	}
+
+	attKeys := make([]string, 0, 11)
+	for i := 0; i < docsToCreate; i++ {
+		docID := fmt.Sprintf("testDoc-%d", i)
+		attKey := fmt.Sprintf("att-%d", i)
+		attBody := map[string]interface{}{"value": strconv.Itoa(i)}
+		attJSONBody, err := base.JSONMarshal(attBody)
+		assert.NoError(t, err)
+		attKeys = append(attKeys, CreateLegacyAttachmentDoc(t, testDb, docID, []byte("{}"), attKey, attJSONBody))
+	}
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	// Start marking stage
+	terminator := base.NewSafeTerminator()
+	stat := &base.AtomicInt{}
+	count := int64(0)
+	var err error
+	go func() {
+		count, _, err = attachmentCompactMarkPhase(testDb, "mark", terminator, stat)
+		require.NoError(t, err)
+	}()
+
+	retryFunc := func() (shouldRetry bool, err error, value interface{}) {
+		if stat.Value() == 0 {
+			return true, nil, nil
+		}
+		return false, nil, nil
+	}
+
+	err, _ = base.RetryLoop("wait for marking to start", retryFunc, base.CreateSleeperFunc(1000, 1))
+	require.NoError(t, err)
+
+	terminator.Close() // Terminate mark function
+	// Allow time for timing issue to be hit where stat increments when it shouldn't
+	time.Sleep(time.Second * 1)
+
+	assert.Equal(t, count, stat.Value())
+	fmt.Println("Count:", count, "stat:", stat.Value())
+	if count == docsToCreate && stat.Value() == docsToCreate {
+		fmt.Println("Attachment compaction ran too fast, causing it to process all documents instead of terminating mid-way. Consider upping the docsToCreate")
+	}
+
+	// Start sweeping with different compact ID so all documents get sweeped
+	stat = &base.AtomicInt{}
+	terminator = base.NewSafeTerminator()
+	go func() {
+		count, err = attachmentCompactSweepPhase(testDb, "sweep", nil, false, terminator, stat)
+		require.NoError(t, err)
+	}()
+
+	err, _ = base.RetryLoop("wait for marking to start", retryFunc, base.CreateSleeperFunc(1000, 1))
+	require.NoError(t, err)
+
+	terminator.Close() // Terminate sweep function
+	// Allow time for timing issue to be hit where stat increments when it shouldn't
+	time.Sleep(time.Second * 1)
+
+	assert.Equal(t, count, stat.Value())
+	fmt.Println("Count:", count, "stat:", stat.Value())
+	if count == docsToCreate && stat.Value() == docsToCreate {
+		fmt.Println("Attachment compaction ran too fast, causing it to process all documents instead of terminating mid-way. Consider upping the docsToCreate")
+	}
+}

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -831,7 +831,7 @@ func TestAttachmentCompactIncorrectStat(t *testing.T) {
 		attKeys = append(attKeys, CreateLegacyAttachmentDoc(t, testDb, docID, []byte("{}"), attKey, attJSONBody))
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	// Start marking stage
 	terminator := base.NewSafeTerminator()
 	stat := &base.AtomicInt{}


### PR DESCRIPTION
CBG-1980

- All attachment compaction phases wait for the DCP client doneChannel to close before returning out the function causing a correct count to be returned that will not increment after the function has exited
- The DCP doneChannel is only closed after all the DCP workers have terminated
- Unit test to repro incorrect stats

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/207/
