### PR TITLE
CBG-2037: [3.0.1 Backport] CBG-2036: Validate OIDC issuer is reachable when validating config

### DIFF
--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -332,7 +332,7 @@ func (op *OIDCProvider) initOIDCClient() error {
 		return err
 	}
 
-	metadata, verifier, err := op.discoverConfig()
+	metadata, verifier, err := op.DiscoverConfig()
 	if err != nil {
 		return pkgerrors.Wrap(err, ErrMsgUnableToDiscoverConfig)
 	}
@@ -382,8 +382,8 @@ func GetStandardDiscoveryEndpoint(issuer string) string {
 	return strings.TrimSuffix(issuer, "/") + OIDCDiscoveryConfigPath
 }
 
-// discoverConfig initiates the initial metadata provider discovery while initializing the OpenID Connect client.
-func (op *OIDCProvider) discoverConfig() (metadata ProviderMetadata, verifier *oidc.IDTokenVerifier, err error) {
+// DiscoverConfig initiates the initial metadata provider discovery while initializing the OpenID Connect client.
+func (op *OIDCProvider) DiscoverConfig() (metadata ProviderMetadata, verifier *oidc.IDTokenVerifier, err error) {
 	discoveryURL := op.getDiscoveryEndpoint()
 	if !op.isStandardDiscovery() {
 		base.Infof(base.KeyAuth, "Fetching provider config from explicitly defined discovery endpoint: %s", base.UD(discoveryURL))

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -254,7 +254,7 @@ func TestConcurrentSetConfig(t *testing.T) {
 	}
 	err := provider.initOIDCClient()
 	require.NoError(t, err, "openid connect client initialization failure")
-	metadata, verifier, err := provider.discoverConfig()
+	metadata, verifier, err := provider.DiscoverConfig()
 	require.NoError(t, err, "error discovering provider metadata")
 
 	expectedAuthURL := []string{

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -28,6 +28,8 @@ import (
 
 const kDefaultDBOnlineDelay = 0
 
+const paramDisableOIDCValidation = "disable_oidc_validation"
+
 //////// DATABASE MAINTENANCE:
 
 // "Create" a database (actually just register an existing bucket)
@@ -45,7 +47,7 @@ func (h *handler) handleCreateDB() error {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
 
-		if err := config.validate(); err != nil {
+		if err := config.validate(!h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
 
@@ -488,9 +490,11 @@ func (h *handler) handlePutDbConfig() (err error) {
 		dbConfig.Name = dbName
 	}
 
+	validateOIDC := !h.getBoolQuery(paramDisableOIDCValidation)
+
 	if !h.server.persistentConfig {
 		updatedDbConfig := &DatabaseConfig{DbConfig: *dbConfig}
-		err = updatedDbConfig.validate()
+		err = updatedDbConfig.validate(validateOIDC)
 		if err != nil {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
@@ -532,7 +536,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 			if err := dbConfig.validatePersistentDbConfig(); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
-			if err := bucketDbConfig.validate(); err != nil {
+			if err := bucketDbConfig.validate(validateOIDC); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
 
@@ -690,7 +694,7 @@ func (h *handler) handlePutDbConfigSync() error {
 
 			bucketDbConfig.Sync = &js
 
-			if err := bucketDbConfig.validate(); err != nil {
+			if err := bucketDbConfig.validate(!h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
 
@@ -838,7 +842,7 @@ func (h *handler) handlePutDbConfigImportFilter() error {
 
 			bucketDbConfig.ImportFilter = &js
 
-			if err := bucketDbConfig.validate(); err != nil {
+			if err := bucketDbConfig.validate(!h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -498,11 +498,11 @@ func (dbConfig *DbConfig) validatePersistentDbConfig() (errorMessages error) {
 	return multiError.ErrorOrNil()
 }
 
-func (dbConfig *DbConfig) validate() error {
-	return dbConfig.validateVersion(base.IsEnterpriseEdition())
+func (dbConfig *DbConfig) validate(validateOIDCConfig bool) error {
+	return dbConfig.validateVersion(base.IsEnterpriseEdition(), validateOIDCConfig)
 }
 
-func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) error {
+func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition, validateOIDCConfig bool) error {
 
 	var multiError *base.MultiError
 	// Make sure a non-zero compact_interval_days config is within the valid range
@@ -691,6 +691,15 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) error {
 		} else {
 			if *revsLimit <= 0 {
 				multiError = multiError.Append(fmt.Errorf("The revs_limit (%v) value in your Sync Gateway configuration must be greater than zero.", *revsLimit))
+			}
+		}
+	}
+
+	if validateOIDCConfig && dbConfig.OIDCConfig != nil {
+		for name, provider := range dbConfig.OIDCConfig.Providers {
+			_, _, err := provider.DiscoverConfig()
+			if err != nil {
+				multiError = multiError.Append(fmt.Errorf("failed to validate OIDC configuration for %s: %w", name, err))
 			}
 		}
 	}

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -394,7 +394,7 @@ func setupAndValidateDatabases(databases DbConfigMap) error {
 		if err := dbConfig.setup(name, BootstrapConfig{}, nil); err != nil {
 			return err
 		}
-		if err := dbConfig.validate(); err != nil {
+		if err := dbConfig.validate(false); err != nil {
 			return err
 		}
 	}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2158,7 +2158,7 @@ func TestInvalidJavascriptFunctions(t *testing.T) {
 				dbConfig.ImportFilter = testCase.ImportFilter
 			}
 
-			err := dbConfig.validate()
+			err := dbConfig.validate(false)
 
 			if testCase.ExpectErrorCount == 0 {
 				assert.NoError(t, err)


### PR DESCRIPTION
CBG-2037

Backport #5513 to 3.0.1.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/212/
