### PR TITLE
CBG-860: Replace defer SetUpTestLogging() with tb.Cleanup()

### DIFF
--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestOIDCProviderMap_GetDefaultProvider(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAuth)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAuth)
 
 	cbProvider := OIDCProvider{
 		Name: "Couchbase",
@@ -106,7 +106,7 @@ func TestOIDCProviderMap_GetDefaultProvider(t *testing.T) {
 
 func TestOIDCProviderMap_GetProviderForIssuer(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAuth)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAuth)
 
 	clientID := "SGW-TEST"
 	cbProvider := OIDCProvider{

--- a/auth/password_hash_test.go
+++ b/auth/password_hash_test.go
@@ -158,7 +158,7 @@ const (
 )
 
 func TestCache(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAuth)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAuth)
 	var tests = []struct {
 		name      string
 		cache     Cache
@@ -209,7 +209,7 @@ func TestCache(t *testing.T) {
 }
 
 func TestCacheRace(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAuth)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAuth)
 	const maxCacheSize = 5
 	var tests = []struct {
 		name      string

--- a/auth/role_test.go
+++ b/auth/role_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestInitRole(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 	// Check initializing role with legal role name.
 	role := &roleImpl{}
 	assert.NoError(t, role.initRole("Music", channels.SetOf(t, "Spotify", "Youtube")))

--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -24,7 +24,7 @@ import (
 func TestCreateSession(t *testing.T) {
 	var username string = "Alice"
 	const invalidSessionTTLError = "400 Invalid session time-to-live"
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
@@ -63,7 +63,7 @@ func TestCreateSession(t *testing.T) {
 }
 
 func TestDeleteSession(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 	var username string = "Alice"
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -93,7 +93,7 @@ func TestDeleteSession(t *testing.T) {
 // using the sessionID, username, expiration and TTL from LoginSession provided.
 // If nil is provided instead of valid login session, nil must be returned.
 func TestMakeSessionCookie(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
@@ -154,7 +154,7 @@ func TestMakeSessionCookieProperties(t *testing.T) {
 // the request is unknown, Nil would be returned from DeleteSessionForCookie.
 func TestDeleteSessionForCookie(t *testing.T) {
 	const defaultEndpoint = "http://localhost/"
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -27,7 +27,7 @@ func TestUserAuthenticateDisabled(t *testing.T) {
 		oldPassword = "hunter2"
 	)
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
@@ -62,7 +62,7 @@ func TestUserAuthenticatePasswordHashUpgrade(t *testing.T) {
 		newBcryptCost = 12
 	)
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
@@ -246,7 +246,7 @@ func TestInvalidUsernamesRejected(t *testing.T) {
 }
 
 func TestCanSeeChannelSince(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
@@ -274,7 +274,7 @@ func TestCanSeeChannelSince(t *testing.T) {
 }
 
 func TestGetAddedChannels(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
@@ -313,7 +313,7 @@ func TestUserAuthenticateWithNilUserReference(t *testing.T) {
 
 // Must not authenticate if the user account is disabled.
 func TestUserAuthenticateWithDisabledUserAccount(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 	const (
 		username = "alice"
 		password = "hunter2"
@@ -335,7 +335,7 @@ func TestUserAuthenticateWithDisabledUserAccount(t *testing.T) {
 // Must not authenticate if old hash is present.
 // Password must be reset to use new (bcrypt) password hash.
 func TestUserAuthenticateWithOldPasswordHash(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 	const (
 		username = "alice"
 		password = "hunter2"
@@ -356,7 +356,7 @@ func TestUserAuthenticateWithOldPasswordHash(t *testing.T) {
 
 // Must not authenticate with bad password hash
 func TestUserAuthenticateWithBadPasswordHash(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 	const (
 		username = "alice"
 		password = "hunter2"
@@ -377,7 +377,7 @@ func TestUserAuthenticateWithBadPasswordHash(t *testing.T) {
 
 // Must not authenticate if No hash, but (incorrect) password provided.
 func TestUserAuthenticateWithNoHashAndBadPassword(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 	const (
 		username = "alice"
 		password = "hunter2"

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1278,7 +1278,7 @@ func TestXattrTombstoneDocAndUpdateXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	defer SetUpTestLogging(LevelDebug, KeyCRUD)()
+	SetUpTestLogging(t, LevelDebug, KeyCRUD)
 
 	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
@@ -1374,7 +1374,7 @@ func TestXattrDeleteDocAndXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	defer SetUpTestLogging(LevelDebug, KeyCRUD)()
+	SetUpTestLogging(t, LevelDebug, KeyCRUD)
 
 	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
@@ -1695,7 +1695,7 @@ func TestXattrMutateDocAndXattr(t *testing.T) {
 func TestGetXattr(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 
-	defer SetUpTestLogging(LevelDebug, KeyAll)()
+	SetUpTestLogging(t, LevelDebug, KeyAll)
 
 	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
@@ -1787,7 +1787,7 @@ func TestGetXattr(t *testing.T) {
 func TestGetXattrAndBody(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 
-	defer SetUpTestLogging(LevelDebug, KeyAll)()
+	SetUpTestLogging(t, LevelDebug, KeyAll)
 
 	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
@@ -2258,7 +2258,7 @@ func verifyDocDeletedXattrExists(store sgbucket.XattrStore, key, xattrName strin
 
 func TestUpdateXattrWithDeleteBodyAndIsDelete(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
-	defer SetUpTestLogging(LevelDebug, KeyCRUD)()
+	SetUpTestLogging(t, LevelDebug, KeyCRUD)
 
 	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
@@ -2301,7 +2301,7 @@ func TestUpdateXattrWithDeleteBodyAndIsDelete(t *testing.T) {
 
 func TestUserXattrGetWithXattr(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
-	defer SetUpTestLogging(LevelDebug, KeyCRUD)()
+	SetUpTestLogging(t, LevelDebug, KeyCRUD)
 
 	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
@@ -2334,7 +2334,7 @@ func TestUserXattrGetWithXattr(t *testing.T) {
 
 func TestUserXattrGetWithXattrNil(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
-	defer SetUpTestLogging(LevelDebug, KeyCRUD)()
+	SetUpTestLogging(t, LevelDebug, KeyCRUD)
 
 	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
@@ -2361,7 +2361,7 @@ func TestUserXattrGetWithXattrNil(t *testing.T) {
 
 func TestInsertTombstoneWithXattr(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
-	defer SetUpTestLogging(LevelDebug, KeyCRUD)()
+	SetUpTestLogging(t, LevelDebug, KeyCRUD)
 
 	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
@@ -2561,7 +2561,7 @@ func TestUpsertOptionPreserveExpiry(t *testing.T) {
 	if bucket.IsSupported(sgbucket.DataStoreFeaturePreserveExpiry) {
 		t.Skip("Preserve expiry is not supported with this CBS version. Skipping test...")
 	}
-	defer SetUpTestLogging(LevelInfo, KeyAll)()
+	SetUpTestLogging(t, LevelInfo, KeyAll)
 
 	testCases := []struct {
 		name          string

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -251,7 +251,7 @@ func TestResumeStoppedFeed(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	defer SetUpTestLogging(LevelDebug, KeyAll)()
+	SetUpTestLogging(t, LevelDebug, KeyAll)
 
 	bucket := GetTestBucket(t)
 	defer bucket.Close()

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -102,7 +102,7 @@ func TestCouchbaseHeartbeaters(t *testing.T) {
 		t.Skip("Skipping heartbeattest in short mode")
 	}
 
-	defer SetUpTestLogging(LevelDebug, KeyDCP)()
+	SetUpTestLogging(t, LevelDebug, KeyDCP)
 
 	keyprefix := SyncPrefix + t.Name()
 
@@ -281,7 +281,7 @@ func TestCouchbaseHeartbeatersMultipleListeners(t *testing.T) {
 // one second, so retry polling is required.
 func TestCBGTManagerHeartbeater(t *testing.T) {
 
-	defer SetUpTestLogging(LevelDebug, KeyDCP)()
+	SetUpTestLogging(t, LevelDebug, KeyDCP)
 
 	if UnitTestUrlIsWalrus() {
 		t.Skip("This test won't work under walrus - no expiry, required for heartbeats")

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -58,7 +58,7 @@ func TestRedactedLogFuncs(t *testing.T) {
 
 func Benchmark_LoggingPerformance(b *testing.B) {
 
-	defer SetUpBenchmarkLogging(LevelInfo, KeyHTTP, KeyCRUD)()
+	SetUpBenchmarkLogging(b, LevelInfo, KeyHTTP, KeyCRUD)
 
 	ctx := TestCtx(b)
 	b.ResetTimer()

--- a/base/redactor_userdata_test.go
+++ b/base/redactor_userdata_test.go
@@ -98,7 +98,7 @@ func (fakeLogger FakeLogger) String() string {
 
 func BenchmarkRedactOnLog(b *testing.B) {
 
-	defer SetUpBenchmarkLogging(LevelWarn, KeyAll)()
+	SetUpBenchmarkLogging(b, LevelWarn, KeyAll)
 
 	b.Run("WarnPlain", func(b *testing.B) {
 		ctx := TestCtx(b)

--- a/base/rlimit_test.go
+++ b/base/rlimit_test.go
@@ -49,7 +49,7 @@ func TestGetSoftFDLimitWithCurrent(t *testing.T) {
 }
 
 func TestSetMaxFileDescriptors(t *testing.T) {
-	defer SetUpTestLogging(LevelDebug, KeyAll)()
+	SetUpTestLogging(t, LevelDebug, KeyAll)
 
 	// grab current limits
 	var startLimits syscall.Rlimit

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -637,7 +637,7 @@ func (m *mockTB) Cleanup(fn func()) {
 	m.cleanupFn = fn
 }
 
-func TestSetUpTestLogging(t *testing.T) {
+func TestSetTestLogging(t *testing.T) {
 	if GlobalTestLoggingSet.IsTrue() {
 		t.Skip("Test does not work when a global test log level is set")
 	}
@@ -646,35 +646,31 @@ func TestSetUpTestLogging(t *testing.T) {
 	require.Equal(t, LevelInfo, *consoleLogger.LogLevel)
 	require.Equal(t, *logKeyMask(KeyHTTP), *consoleLogger.LogKeyMask)
 
-	mock := &mockTB{}
-
-	SetUpTestLogging(mock, LevelDebug, KeyDCP, KeySync)
+	cleanup := setTestLogging(LevelDebug, "", KeyDCP, KeySync)
 	assert.Equal(t, LevelDebug, *consoleLogger.LogLevel)
 	assert.Equal(t, *logKeyMask(KeyDCP, KeySync), *consoleLogger.LogKeyMask)
 
-	mock.cleanupFn()
+	cleanup()
 	assert.Equal(t, LevelInfo, *consoleLogger.LogLevel)
 	assert.Equal(t, *logKeyMask(KeyHTTP), *consoleLogger.LogKeyMask)
 
-	DisableTestLogging(mock)
+	cleanup = setTestLogging(LevelNone, "", KeyNone)
 	assert.Equal(t, LevelNone, *consoleLogger.LogLevel)
 	assert.Equal(t, *logKeyMask(KeyNone), *consoleLogger.LogKeyMask)
 
-	mock.cleanupFn()
+	cleanup()
 	assert.Equal(t, LevelInfo, *consoleLogger.LogLevel)
 	assert.Equal(t, *logKeyMask(KeyHTTP), *consoleLogger.LogKeyMask)
 
-	SetUpTestLogging(mock, LevelDebug, KeyDCP, KeySync)
+	cleanup = setTestLogging(LevelDebug, "", KeyDCP, KeySync)
 	assert.Equal(t, LevelDebug, *consoleLogger.LogLevel)
 	assert.Equal(t, *logKeyMask(KeyDCP, KeySync), *consoleLogger.LogKeyMask)
 
 	// Now we should panic because we forgot to call teardown!
-	// TODO: should no longer be necessary since the move to tb.Cleanup,
-	// as Go will take care of calling it
 	assert.Panics(t, func() {
-		SetUpTestLogging(mock, LevelError, KeyAuth, KeyCRUD)
+		setTestLogging(LevelDebug, "", KeyDCP, KeySync)
 	}, "Expected panic from multiple SetUpTestLogging calls")
-	mock.cleanupFn()
+	cleanup()
 }
 
 func TestEncodeDecodeCompatVersion(t *testing.T) {

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -629,14 +629,6 @@ func TestRedactBasicAuthURL(t *testing.T) {
 	}
 }
 
-type mockTB struct {
-	cleanupFn func()
-}
-
-func (m *mockTB) Cleanup(fn func()) {
-	m.cleanupFn = fn
-}
-
 func TestSetTestLogging(t *testing.T) {
 	if GlobalTestLoggingSet.IsTrue() {
 		t.Skip("Test does not work when a global test log level is set")

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -453,7 +453,9 @@ func SetUpGlobalTestLogging(m *testing.M) (teardownFn func()) {
 		if err != nil {
 			FatalfCtx(context.TODO(), "TEST: Invalid log level used for %q: %s", TestEnvGlobalLogLevel, err)
 		}
-		teardown := SetUpTestLogging(l, KeyAll)
+		caller := GetCallersName(1, false)
+		InfofCtx(context.Background(), KeyAll, "%s: Setup logging: level: %v - keys: %v", caller, logLevel, KeyAll)
+		teardown := setTestLogging(l, caller, KeyAll)
 		GlobalTestLoggingSet.Set(true)
 		return func() {
 			teardown()
@@ -464,41 +466,37 @@ func SetUpGlobalTestLogging(m *testing.M) (teardownFn func()) {
 	return func() { GlobalTestLoggingSet.Set(false) }
 }
 
-// SetUpTestLogging will set the given log level and log keys,
-// and return a function that can be deferred for teardown.
+// canCleanup is a subset of testing.TB used for testing the test logging.
+type canCleanup interface {
+	Cleanup(func())
+}
+
+// SetUpTestLogging will set the given log level and log keys, and revert the changes at the end of the current test.
 //
-// This function will panic if called multiple times without running the teardownFn.
-//
-// To set multiple log keys, append as variadic arguments
-// E.g. KeyCache,KeyDCP,KeySync
-//
-// Usage:
-//     teardownFn := SetUpTestLogging(LevelDebug, KeyCache,KeyDCP,KeySync)
-//     defer teardownFn()
-//
-// Shorthand style:
-//     defer SetUpTestLogging(LevelDebug, KeyCache,KeyDCP,KeySync)()
-func SetUpTestLogging(logLevel LogLevel, logKeys ...LogKey) (teardownFn func()) {
+// This function will panic if called multiple times in the same test.
+func SetUpTestLogging(tb canCleanup, logLevel LogLevel, logKeys ...LogKey) {
 	caller := GetCallersName(1, false)
 	InfofCtx(context.Background(), KeyAll, "%s: Setup logging: level: %v - keys: %v", caller, logLevel, logKeys)
-	return setTestLogging(logLevel, caller, logKeys...)
+	cleanup := setTestLogging(logLevel, caller, logKeys...)
+	tb.Cleanup(cleanup)
 }
 
 // DisableTestLogging is an alias for SetUpTestLogging(LevelNone, KeyNone)
-// This function will panic if called multiple times without running the teardownFn.
-func DisableTestLogging() (teardownFn func()) {
+// This function will panic if called multiple times in the same test.
+func DisableTestLogging(tb canCleanup) {
 	caller := ""
-	return setTestLogging(LevelNone, caller, KeyNone)
+	cleanup := setTestLogging(LevelNone, caller, KeyNone)
+	tb.Cleanup(cleanup)
 }
 
 // SetUpBenchmarkLogging will set the given log level and key, and do log processing for that configuration,
 // but discards the output, instead of writing it to console.
-func SetUpBenchmarkLogging(logLevel LogLevel, logKeys ...LogKey) (teardownFn func()) {
+func SetUpBenchmarkLogging(tb testing.TB, logLevel LogLevel, logKeys ...LogKey) {
 	teardownFnOrig := setTestLogging(logLevel, "", logKeys...)
 
 	// discard all logging output for benchmarking (but still execute logging as normal)
 	consoleLogger.logger.SetOutput(ioutil.Discard)
-	return func() {
+	tb.Cleanup(func() {
 		// revert back to original output
 		if consoleLogger != nil && consoleLogger.output != nil {
 			consoleLogger.logger.SetOutput(consoleLogger.output)
@@ -506,7 +504,7 @@ func SetUpBenchmarkLogging(logLevel LogLevel, logKeys ...LogKey) (teardownFn fun
 			consoleLogger.logger.SetOutput(os.Stderr)
 		}
 		teardownFnOrig()
-	}
+	})
 }
 
 func setTestLogging(logLevel LogLevel, caller string, logKeys ...LogKey) (teardownFn func()) {

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -466,15 +466,10 @@ func SetUpGlobalTestLogging(m *testing.M) (teardownFn func()) {
 	return func() { GlobalTestLoggingSet.Set(false) }
 }
 
-// canCleanup is a subset of testing.TB used for testing the test logging.
-type canCleanup interface {
-	Cleanup(func())
-}
-
 // SetUpTestLogging will set the given log level and log keys, and revert the changes at the end of the current test.
 //
 // This function will panic if called multiple times in the same test.
-func SetUpTestLogging(tb canCleanup, logLevel LogLevel, logKeys ...LogKey) {
+func SetUpTestLogging(tb testing.TB, logLevel LogLevel, logKeys ...LogKey) {
 	caller := GetCallersName(1, false)
 	InfofCtx(context.Background(), KeyAll, "%s: Setup logging: level: %v - keys: %v", caller, logLevel, logKeys)
 	cleanup := setTestLogging(logLevel, caller, logKeys...)
@@ -483,7 +478,7 @@ func SetUpTestLogging(tb canCleanup, logLevel LogLevel, logKeys ...LogKey) {
 
 // DisableTestLogging is an alias for SetUpTestLogging(LevelNone, KeyNone)
 // This function will panic if called multiple times in the same test.
-func DisableTestLogging(tb canCleanup) {
+func DisableTestLogging(tb testing.TB) {
 	caller := ""
 	cleanup := setTestLogging(LevelNone, caller, KeyNone)
 	tb.Cleanup(cleanup)

--- a/channels/channelmapper_test.go
+++ b/channels/channelmapper_test.go
@@ -527,7 +527,7 @@ func TestMetaMap(t *testing.T) {
 }
 
 func TestNilMetaMap(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	mapper := NewChannelMapper(`function(doc, oldDoc, meta) {channel(meta.xattrs.myxattr.val);}`)
 
 	metaMap := map[string]interface{}{

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -212,7 +212,7 @@ func TestAttachmentCleanup(t *testing.T) {
 }
 
 func TestAttachmentMarkAndSweepAndCleanup(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Requires CBS")
 	}

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -41,7 +41,7 @@ func tojson(obj interface{}) string {
 }
 
 func TestBackupOldRevisionWithAttachments(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	deltasEnabled := base.IsEnterpriseEdition()
 	xattrsEnabled := base.TestUseXattrs()
@@ -513,7 +513,7 @@ func TestForEachStubAttachmentErrors(t *testing.T) {
 }
 
 func TestGenerateProofOfAttachment(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	attData := []byte(`hello world`)
 
@@ -770,7 +770,7 @@ func TestMigrateBodyAttachments(t *testing.T) {
 		t.Skip("Test requires Couchbase Server bucket when using xattrs")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	const docKey = "TestAttachmentMigrate"
 
@@ -1050,7 +1050,7 @@ func TestMigrateBodyAttachmentsMerge(t *testing.T) {
 		t.Skip("Test requires Couchbase Server bucket when using xattrs")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	const docKey = "TestAttachmentMigrate"
 
@@ -1213,7 +1213,7 @@ func TestMigrateBodyAttachmentsMergeConflicting(t *testing.T) {
 		t.Skip("Test requires Couchbase Server bucket when using xattrs")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	const docKey = "TestAttachmentMigrate"
 
@@ -1385,7 +1385,7 @@ func TestMigrateBodyAttachmentsMergeConflicting(t *testing.T) {
 }
 
 func TestAllowedAttachments(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeySync)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeySync)
 
 	var tests = []struct {
 		name              string

--- a/db/blip_sync_context_test.go
+++ b/db/blip_sync_context_test.go
@@ -19,7 +19,7 @@ import (
 
 // TestBlipSyncContextSetUseDeltas verifies all permutations of setUseDeltas()
 func TestBlipSyncContextSetUseDeltas(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeySync)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeySync)
 
 	tests := []struct {
 		name string
@@ -60,7 +60,7 @@ func TestBlipSyncContextSetUseDeltas(t *testing.T) {
 
 // BenchmarkBlipSyncContextSetUseDeltas verifies all permutations of setUseDeltas()
 func BenchmarkBlipSyncContextSetUseDeltas(b *testing.B) {
-	defer base.SetUpBenchmarkLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpBenchmarkLogging(b, base.LevelInfo, base.KeyHTTP)
 
 	tests := []struct {
 		name string

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -246,7 +246,7 @@ func TestLateSequenceErrorRecovery(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
 
 	db := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close()
@@ -364,7 +364,7 @@ func TestLateSequenceHandlingDuringCompact(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
 
 	cacheOptions := shortWaitCache()
 	cacheOptions.ChannelCacheOptions.MaxNumChannels = 100
@@ -544,7 +544,7 @@ func TestChannelCacheBufferingWithUserDoc(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyDCP)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyDCP)
 
 	db := setupTestDB(t)
 	defer db.Close()
@@ -582,7 +582,7 @@ func TestChannelCacheBackfill(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 
 	db := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close()
@@ -647,7 +647,7 @@ func TestContinuousChangesBackfill(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache, base.KeyChanges, base.KeyDCP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache, base.KeyChanges, base.KeyDCP)
 
 	db := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close()
@@ -747,7 +747,7 @@ func TestLowSequenceHandling(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyQuery)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyQuery)
 
 	db := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close()
@@ -812,7 +812,7 @@ func TestLowSequenceHandlingAcrossChannels(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyQuery)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyQuery)
 
 	db := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close()
@@ -869,7 +869,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges, base.KeyQuery)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges, base.KeyQuery)
 
 	db := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close()
@@ -955,7 +955,7 @@ func TestChannelQueryCancellation(t *testing.T) {
 		t.Skip("Skip test with LeakyBucket dependency test when running in integration")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
 	// Set up PostQueryCallback on bucket - will be invoked when changes triggers the cache backfill view query
 
@@ -1070,7 +1070,7 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges, base.KeyCache)
 
 	db := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close()
@@ -1162,7 +1162,7 @@ func TestChannelRace(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges)
 
 	db := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close()
@@ -1255,7 +1255,7 @@ func TestSkippedViewRetrieval(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache)
 
 	originalBatchSize := SkippedSeqCleanViewBatch
 	SkippedSeqCleanViewBatch = 4
@@ -1325,7 +1325,7 @@ func TestStopChangeCache(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges, base.KeyDCP)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges, base.KeyDCP)
 
 	if base.TestUseXattrs() {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
@@ -1367,7 +1367,7 @@ func TestChannelCacheSize(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache)
 
 	options := DefaultCacheOptions()
 	options.ChannelCacheOptions.ChannelCacheMinLength = 600
@@ -1587,7 +1587,7 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 	}
 
 	// Enable relevant logging
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache, base.KeyChanges)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache, base.KeyChanges)
 
 	// Create a test db that uses channel cache
 	options := DefaultCacheOptions()
@@ -1672,7 +1672,7 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 // Trigger initialization of empty cache, then write and validate a subsequent changes request returns expected data.
 func TestInitializeEmptyCache(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges)
 
 	// Increase the cache max size
 	cacheOptions := DefaultCacheOptions()
@@ -1723,7 +1723,7 @@ func TestInitializeEmptyCache(t *testing.T) {
 // sets query/cache boundaries
 func TestInitializeCacheUnderLoad(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges)
 
 	// Increase the cache max size
 	cacheOptions := DefaultCacheOptions()
@@ -1781,7 +1781,7 @@ func TestInitializeCacheUnderLoad(t *testing.T) {
 func TestNotifyForInactiveChannel(t *testing.T) {
 
 	// Enable relevant logging
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache, base.KeyDCP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache, base.KeyDCP)
 
 	db := setupTestDB(t)
 	defer db.Close()
@@ -1843,7 +1843,7 @@ func TestChangeCache_InsertPendingEntries(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 
 	cacheOptions := DefaultCacheOptions()
 	cacheOptions.CachePendingSeqMaxWait = 100 * time.Millisecond
@@ -1934,7 +1934,7 @@ func (f *testProcessEntryFeed) Next() *LogEntry {
 //   - non-unique doc ids?
 
 func BenchmarkProcessEntry(b *testing.B) {
-	defer base.SetUpBenchmarkLogging(base.LevelError, base.KeyCache, base.KeyChanges)()
+	base.SetUpBenchmarkLogging(b, base.LevelError, base.KeyCache, base.KeyChanges)
 	processEntryBenchmarks := []struct {
 		name           string
 		feed           *testProcessEntryFeed
@@ -2160,7 +2160,7 @@ func (f *testDocChangedFeed) Next() sgbucket.FeedEvent {
 //   - non-unique doc ids?
 
 func BenchmarkDocChanged(b *testing.B) {
-	defer base.SetUpBenchmarkLogging(base.LevelError, base.KeyCache, base.KeyChanges)()
+	base.SetUpBenchmarkLogging(b, base.LevelError, base.KeyCache, base.KeyChanges)
 	processEntryBenchmarks := []struct {
 		name           string
 		feed           *testDocChangedFeed

--- a/db/change_listener_test.go
+++ b/db/change_listener_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestUserWaiter(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
 
 	db := setupTestDB(t)
 	defer db.Close()
@@ -67,7 +67,7 @@ func TestUserWaiter(t *testing.T) {
 
 func TestUserWaiterForRoleChange(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
 
 	db := setupTestDB(t)
 	defer db.Close()

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -50,7 +50,7 @@ func TestFilterToAvailableChannels(t *testing.T) {
 			expectedDocsReturned: []string{"doc1", "doc3"},
 		},
 	}
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges)
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			db := setupTestDB(t)
@@ -98,7 +98,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -196,7 +196,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 		t.Skip("This test is known to be failing against couchbase server with XATTRS enabled.  See https://gist.github.com/tleyden/a41632355fadde54f19e84ba68015512")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	db := setupTestDB(t)
 	defer db.Close()
@@ -357,7 +357,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
 	// Create 10 documents
 	revId := ""
 	var err error
@@ -416,7 +416,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 
 // Benchmark to validate fix for https://github.com/couchbase/sync_gateway/issues/2428
 func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
-	defer base.SetUpBenchmarkLogging(base.LevelWarn, base.KeyHTTP)()
+	base.SetUpBenchmarkLogging(b, base.LevelWarn, base.KeyHTTP)
 
 	db := setupTestDB(b)
 	defer db.Close()

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestDuplicateDocID(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
 	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
@@ -72,7 +72,7 @@ func TestDuplicateDocID(t *testing.T) {
 
 func TestLateArrivingSequence(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
 	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
@@ -105,7 +105,7 @@ func TestLateArrivingSequence(t *testing.T) {
 
 func TestLateSequenceAsFirst(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
 	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 
 func TestDuplicateLateArrivingSequence(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
 	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
@@ -212,7 +212,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 
 func TestPrependChanges(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
 	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
@@ -396,7 +396,7 @@ func TestPrependChanges(t *testing.T) {
 
 func TestChannelCacheRemove(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
 	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
@@ -435,7 +435,7 @@ func TestChannelCacheRemove(t *testing.T) {
 
 func TestChannelCacheStats(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
 	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
@@ -505,7 +505,7 @@ func TestChannelCacheStats(t *testing.T) {
 
 func TestChannelCacheStatsOnPrune(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
 	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
@@ -535,7 +535,7 @@ func TestChannelCacheStatsOnPrune(t *testing.T) {
 
 func TestChannelCacheStatsOnPrepend(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
 	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
@@ -595,7 +595,7 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 }
 
 func TestBypassSingleChannelCache(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
 	terminator := make(chan bool)
 	defer close(terminator)
@@ -624,7 +624,7 @@ func TestBypassSingleChannelCache(t *testing.T) {
 
 func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 
-	defer base.DisableTestLogging()()
+	base.DisableTestLogging(b)
 
 	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
@@ -643,7 +643,7 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 
 func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 
-	defer base.DisableTestLogging()()
+	base.DisableTestLogging(b)
 
 	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
@@ -660,7 +660,7 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 
 func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 
-	defer base.DisableTestLogging()()
+	base.DisableTestLogging(b)
 
 	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
@@ -677,7 +677,7 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 
 func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 
-	defer base.DisableTestLogging()()
+	base.DisableTestLogging(b)
 
 	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
@@ -694,7 +694,7 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 
 func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 
-	defer base.DisableTestLogging()()
+	base.DisableTestLogging(b)
 
 	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
@@ -711,7 +711,7 @@ func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 
 func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 
-	defer base.SetUpBenchmarkLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpBenchmarkLogging(b, base.LevelInfo, base.KeyHTTP)
 
 	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
@@ -728,7 +728,7 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 
 func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 
-	defer base.DisableTestLogging()()
+	base.DisableTestLogging(b)
 
 	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestChannelCacheMaxSize(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
 	bucket := base.GetTestBucket(t)
 
@@ -74,7 +74,7 @@ func getCacheUtilization(stats *base.CacheStats) (active, tombstones, removals i
 
 func TestChannelCacheSimpleCompact(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
 	// Define cache with max channels 20, hwm will be 16, low water mark will be 12
 	options := DefaultCacheOptions().ChannelCacheOptions
@@ -108,7 +108,7 @@ func TestChannelCacheSimpleCompact(t *testing.T) {
 
 func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
 	// Define cache with max channels 20, watermarks 50/90
 	options := DefaultCacheOptions().ChannelCacheOptions
@@ -163,7 +163,7 @@ func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 // between compact triggers.  In the second compact, NRU channels should have eviction priority.
 func TestChannelCacheCompactNRU(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
 	// Define cache with max channels 20, watermarks 50/90
 	options := DefaultCacheOptions().ChannelCacheOptions
@@ -256,7 +256,7 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 // or equal to the CompactHighWatermark
 func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelWarn, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelWarn, base.KeyCache)
 
 	// Define cache with max channels 20, watermarks 50/90
 	options := DefaultCacheOptions().ChannelCacheOptions
@@ -326,7 +326,7 @@ func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 // active.
 func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelWarn, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelWarn, base.KeyCache)
 
 	// Define cache with max channels 100, watermarks 90/70
 	options := DefaultCacheOptions().ChannelCacheOptions
@@ -391,7 +391,7 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 // TestChannelCacheBypass validates that the bypass 'cache' is used when the cache max_num_channels is reached.
 // To force this scenario, HWM is set to 100%, which effectively disables compaction.
 func TestChannelCacheBypass(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelWarn, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelWarn, base.KeyCache)
 
 	// Define cache with max channels 20, watermarks 50/100
 	options := DefaultCacheOptions().ChannelCacheOptions
@@ -488,7 +488,7 @@ func (qh *testQueryHandler) seedEntries(seededEntries LogEntries) {
 }
 
 func TestChannelCacheBackgroundTaskWithIllegalTimeInterval(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelWarn, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelWarn, base.KeyCache)
 	options := DefaultCacheOptions().ChannelCacheOptions
 
 	// Specify illegal time interval for background task. Time interval should be > 0

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -63,7 +63,7 @@ func getRevTreeList(bucket base.Bucket, key string, useXattrs bool) (revTreeList
 // Tests simple retrieval of rev not resident in the cache
 func TestRevisionCacheLoad(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	db := setupTestDBWithViewsEnabled(t)
 	defer db.Close()
@@ -103,7 +103,7 @@ func TestRevisionCacheLoad(t *testing.T) {
 }
 
 func TestHasAttachmentsFlag(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	db := setupTestDB(t)
 	defer db.Close()
 
@@ -181,7 +181,7 @@ func TestHasAttachmentsFlagForLegacyAttachments(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() || !base.TestUseXattrs() {
 		t.Skip("Test only works with a Couchbase server and Xattrs")
 	}
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	db := setupTestDB(t)
 	defer db.Close()
 
@@ -301,7 +301,7 @@ func TestHasAttachmentsFlagForLegacyAttachments(t *testing.T) {
 // Tests permutations of inline and external storage of conflicts and tombstones
 func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	db := setupTestDB(t)
 	defer db.Close()
@@ -1019,7 +1019,7 @@ func TestMalformedRevisionStorageRecovery(t *testing.T) {
 }
 
 func BenchmarkDatabaseGet1xRev(b *testing.B) {
-	defer base.DisableTestLogging()()
+	base.DisableTestLogging(b)
 
 	db := setupTestDB(b)
 	defer db.Close()
@@ -1075,7 +1075,7 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 }
 
 func BenchmarkDatabaseGetRev(b *testing.B) {
-	defer base.DisableTestLogging()()
+	base.DisableTestLogging(b)
 
 	db := setupTestDB(b)
 	defer db.Close()
@@ -1132,7 +1132,7 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 
 // Replicates delta patching work carried out by handleRev
 func BenchmarkHandleRevDelta(b *testing.B) {
-	defer base.DisableTestLogging()()
+	base.DisableTestLogging(b)
 
 	db := setupTestDB(b)
 	defer db.Close()

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -157,7 +157,7 @@ func assertHTTPError(t *testing.T, err error, status int) {
 
 func TestDatabase(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	db := setupTestDB(t)
 	defer db.Close()
@@ -764,7 +764,7 @@ func allDocIDs(db *Database) (docs []AllDocsEntry, err error) {
 
 func TestAllDocsOnly(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
 	// Lower the log max length so no more than 50 items will be kept.
 	cacheOptions := DefaultCacheOptions()
@@ -873,7 +873,7 @@ func TestAllDocsOnly(t *testing.T) {
 // Unit test for bug #673
 func TestUpdatePrincipal(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 
 	db := setupTestDB(t)
 	defer db.Close()
@@ -1686,7 +1686,7 @@ func TestConcurrentImport(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyImport)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyImport)
 
 	// Add doc to the underlying bucket:
 	_, err := db.Bucket.Add("directWrite", 0, Body{"value": "hi"})
@@ -1710,7 +1710,7 @@ func TestConcurrentImport(t *testing.T) {
 // ////// BENCHMARKS
 
 func BenchmarkDatabase(b *testing.B) {
-	defer base.DisableTestLogging()()
+	base.DisableTestLogging(b)
 
 	for i := 0; i < b.N; i++ {
 		bucket, _ := ConnectToBucket(base.BucketSpec{
@@ -1728,7 +1728,7 @@ func BenchmarkDatabase(b *testing.B) {
 }
 
 func BenchmarkPut(b *testing.B) {
-	defer base.DisableTestLogging()()
+	base.DisableTestLogging(b)
 
 	bucket, _ := ConnectToBucket(base.BucketSpec{
 		Server:          base.UnitTestUrl(),
@@ -2013,7 +2013,7 @@ func TestSyncFnMutateBody(t *testing.T) {
 // Multiple clients are attempting to push the same new revision concurrently; first writer should be successful,
 // subsequent writers should fail on CAS, and then identify that revision already exists on retry.
 func TestConcurrentPushSameNewRevision(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
 	var db *Database
 	var enableCallback bool
 	var revId string
@@ -2053,7 +2053,7 @@ func TestConcurrentPushSameNewRevision(t *testing.T) {
 // Multiple clients are attempting to push the same new, non-winning revision concurrently; non-winning is an
 // update to a non-winning branch that leaves the branch still non-winning (i.e. shorter) than the active branch
 func TestConcurrentPushSameNewNonWinningRevision(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
 	var db *Database
 	var enableCallback bool
 
@@ -2108,7 +2108,7 @@ func TestConcurrentPushSameNewNonWinningRevision(t *testing.T) {
 // Multiple clients are attempting to push the same tombstone of the winning revision for a branched document
 // First writer should be successful, subsequent writers should fail on CAS, then identify rev already exists
 func TestConcurrentPushSameTombstoneWinningRevision(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
 	var db *Database
 	var enableCallback bool
 
@@ -2163,7 +2163,7 @@ func TestConcurrentPushSameTombstoneWinningRevision(t *testing.T) {
 // Multiple clients are attempting to push conflicting non-winning revisions; multiple clients pushing different
 // updates to non-winning branches that leave the branch(es) non-winning.
 func TestConcurrentPushDifferentUpdateNonWinningRevision(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
 	var db *Database
 	var enableCallback bool
 

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -162,7 +162,7 @@ func TestDBStateChangeEvent(t *testing.T) {
 // the max concurrent goroutines
 func TestSlowExecutionProcessing(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyEvents)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyEvents)
 
 	em := NewEventManager()
 	em.Start(0, -1)
@@ -716,7 +716,7 @@ func TestWebhookTimeout(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	ts, wr := InitWebhookTest()
 	defer ts.Close()
 	url := ts.URL

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -40,7 +40,7 @@ func TestMigrateMetadata(t *testing.T) {
 		t.Skip("This test only works with XATTRS enabled")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyMigrate, base.KeyImport)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyMigrate, base.KeyImport)
 
 	db := setupTestDB(t)
 	defer db.Close()
@@ -110,7 +110,7 @@ func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 		t.Skip("This test only works with XATTRS enabled")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyMigrate, base.KeyImport)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyMigrate, base.KeyImport)
 
 	db := setupTestDB(t)
 	defer db.Close()
@@ -382,7 +382,7 @@ func TestImportNullDoc(t *testing.T) {
 		t.Skip("This test only works with XATTRS enabled and in integration mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyImport)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyImport)
 
 	db := setupTestDB(t)
 	defer db.Close()
@@ -399,7 +399,7 @@ func TestImportNullDoc(t *testing.T) {
 }
 
 func TestImportNullDocRaw(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyImport)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyImport)
 
 	db := setupTestDB(t)
 	defer db.Close()
@@ -424,7 +424,7 @@ func assertXattrSyncMetaRevGeneration(t *testing.T, bucket base.Bucket, key stri
 }
 
 func TestEvaluateFunction(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyImport)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyImport)
 	db := setupTestDB(t)
 	defer db.Close()
 

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -68,7 +68,7 @@ func TestRepairBucket(t *testing.T) {
 		t.Skip("This test only works against walrus (requires views)")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCRUD)
 
 	bucket, numDocs := testBucketWithViewsAndBrokenDoc(t)
 	defer bucket.Close()
@@ -98,7 +98,7 @@ func TestRepairBucketRevTreeCycles(t *testing.T) {
 		t.Skip("This test only works against walrus (requires views)")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCRUD)
 
 	bucket, _ := testBucketWithViewsAndBrokenDoc(t)
 	defer bucket.Close()
@@ -147,7 +147,7 @@ func TestRepairBucketDryRun(t *testing.T) {
 		t.Skip("This test only works against walrus (requires views)")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCRUD)
 
 	bucket, _ := testBucketWithViewsAndBrokenDoc(t)
 	defer bucket.Close()

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -225,7 +225,7 @@ func TestRevisionCacheInternalProperties(t *testing.T) {
 
 func TestBypassRevisionCache(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	db := setupTestDB(t)
 	defer db.Close()
@@ -286,7 +286,7 @@ func TestBypassRevisionCache(t *testing.T) {
 // Ensure attachment properties aren't being incorrectly stored in revision cache body when inserted via Put
 func TestPutRevisionCacheAttachmentProperty(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	db := setupTestDB(t)
 	defer db.Close()
@@ -327,7 +327,7 @@ func TestPutRevisionCacheAttachmentProperty(t *testing.T) {
 // Ensure attachment properties aren't being incorrectly stored in revision cache body when inserted via PutExistingRev
 func TestPutExistingRevRevisionCacheAttachmentProperty(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	db := setupTestDB(t)
 	defer db.Close()
@@ -480,7 +480,7 @@ func TestInvalidate(t *testing.T) {
 }
 
 func BenchmarkRevisionCacheRead(b *testing.B) {
-	defer base.SetUpBenchmarkLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpBenchmarkLogging(b, base.LevelDebug, base.KeyAll)
 
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(5000, &testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -98,7 +98,7 @@ func TestParseRevisionsToAncestor(t *testing.T) {
 
 // TestBackupOldRevision ensures that old revisions are kept around temporarily for in-flight requests and delta sync purposes.
 func TestBackupOldRevision(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	deltasEnabled := base.IsEnterpriseEdition()
 	xattrsEnabled := base.TestUseXattrs()

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -839,7 +839,7 @@ func TestRevsHistoryInfiniteLoop(t *testing.T) {
 // Repair tool for https://github.com/couchbase/sync_gateway/issues/2847
 func TestRepairRevsHistoryWithCycles(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCRUD)
 
 	for i, testdocProblematicRevTree := range testdocProblematicRevTrees {
 

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -230,7 +230,7 @@ func testReplicationCfg(id, assignedNode string) *ReplicationCfg {
 
 func TestRebalanceReplications(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyReplicate)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyReplicate)
 
 	type rebalanceTest struct {
 		name                  string                     // Test name
@@ -417,7 +417,7 @@ func TestRebalanceReplications(t *testing.T) {
 
 func TestUpsertReplicationConfig(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyReplicate)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyReplicate)
 
 	type rebalanceTest struct {
 		name           string                   // Test name
@@ -634,7 +634,7 @@ func TestIsCfgChanged(t *testing.T) {
 
 // Test replicators assigned nodes with different group IDs
 func TestReplicateGroupIDAssignedNodes(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
 

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -499,7 +499,7 @@ func TestAdminAuthWithX509(t *testing.T) {
 func TestAdminAPIAuth(t *testing.T) {
 
 	// Don't really care about the log level but this test hits the logging endpoint so this is used to reset the logging
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyNone)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyNone)
 
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -521,7 +521,7 @@ func TestLoggingKeys(t *testing.T) {
 	}
 
 	// Reset logging to initial state, in case any other tests forgot to clean up after themselves
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyNone)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyNone)
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -601,7 +601,7 @@ func TestLoggingLevels(t *testing.T) {
 	}
 
 	// Reset logging to initial state, in case any other tests forgot to clean up after themselves
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyNone)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyNone)
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -639,7 +639,7 @@ func TestLoggingCombined(t *testing.T) {
 	}
 
 	// Reset logging to initial state, in case any other tests forgot to clean up after themselves
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyNone)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyNone)
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -681,7 +681,7 @@ func TestGetStatus(t *testing.T) {
 // Test user delete while that user has an active changes feed (see issue 809)
 func TestUserDeleteDuringChangesWithAccess(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyCache, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache, base.KeyHTTP)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel); if(doc.type == "setaccess") { access(doc.owner, doc.channel);}}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -1293,7 +1293,7 @@ func TestDBOfflineSingleResync(t *testing.T) {
 }
 
 func TestResync(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	testCases := []struct {
 		name               string
@@ -1592,7 +1592,7 @@ func TestResyncRegenerateSequences(t *testing.T) {
 		}
 	}`
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	var testBucket *base.TestBucket
 
@@ -1874,7 +1874,7 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
 
 	// CBG-1513: This test is prone to panicing when the walrus bucket was closed and still used
 	assert.NotPanicsf(t, func() {
@@ -2627,7 +2627,7 @@ func TestConfigRedaction(t *testing.T) {
 
 // Reproduces panic seen in CBG-1053
 func TestAdhocReplicationStatus(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll, base.KeyReplicate)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll, base.KeyReplicate)
 	rt := NewRestTester(t, &RestTesterConfig{sgReplicateEnabled: true})
 	defer rt.Close()
 
@@ -3144,7 +3144,7 @@ func TestConfigEndpoint(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+			base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 			base.InitializeMemoryLoggers()
 			tempDir := os.TempDir()
@@ -3184,7 +3184,7 @@ func TestConfigEndpoint(t *testing.T) {
 }
 
 func TestLoggingDeprecationWarning(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -3210,7 +3210,7 @@ func TestLoggingDeprecationWarning(t *testing.T) {
 }
 
 func TestInitialStartupConfig(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -3245,7 +3245,7 @@ func TestInitialStartupConfig(t *testing.T) {
 }
 
 func TestIncludeRuntimeStartupConfig(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	base.InitializeMemoryLoggers()
 	tempDir := os.TempDir()
@@ -3346,7 +3346,7 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	serverErr := make(chan error, 0)
 
@@ -3407,7 +3407,7 @@ func TestDbConfigCredentials(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	serverErr := make(chan error, 0)
 
@@ -3479,7 +3479,7 @@ func TestInvalidDBConfig(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	serverErr := make(chan error, 0)
 
@@ -3538,7 +3538,7 @@ func TestCreateDbOnNonExistentBucket(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	serverErr := make(chan error, 0)
 
@@ -3576,7 +3576,7 @@ func TestPutDbConfigChangeName(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	serverErr := make(chan error, 0)
 
@@ -3617,7 +3617,7 @@ func TestPutDBConfigOIDC(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	serverErr := make(chan error, 0)
 
@@ -3733,7 +3733,7 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	serverErr := make(chan error, 0)
 
@@ -3830,7 +3830,7 @@ func TestLegacyCredentialInheritance(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	serverErr := make(chan error, 0)
 
@@ -3917,7 +3917,7 @@ func TestDbOfflineConfigPersistent(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	serverErr := make(chan error, 0)
 
@@ -3996,7 +3996,7 @@ func TestDeleteFunctionsWhileDbOffline(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	// Start SG with bootstrap credentials filled
 	config := bootstrapStartupConfigForTest(t)
@@ -4083,7 +4083,7 @@ func TestSetFunctionsWhileDbOffline(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	// Start SG with bootstrap credentials filled
 	config := bootstrapStartupConfigForTest(t)
@@ -4148,7 +4148,7 @@ func TestEmptyStringJavascriptFunctions(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	serverErr := make(chan error, 0)
 
@@ -4209,7 +4209,7 @@ func TestGroupIDReplications(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() || !base.TestUseXattrs() {
 		t.Skip("This test only works against Couchbase Server with xattrs enabled")
 	}
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	// Create test buckets to replicate between
 	passiveBucket := base.GetTestBucket(t)
@@ -4320,7 +4320,7 @@ func TestDeleteDatabasePointingAtSameBucket(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() || !base.TestUseXattrs() {
 		t.Skip("This test only works against Couchbase Server with xattrs")
 	}
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 	tb := base.GetTestBucket(t)
 	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb})
 	defer rt.Close()
@@ -4340,7 +4340,7 @@ func TestDeleteDatabasePointingAtSameBucketPersistent(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 	// Start SG with no databases in bucket(s)
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
@@ -4389,7 +4389,7 @@ func TestDeleteDatabasePointingAtSameBucketPersistent(t *testing.T) {
 // CBG-1046: Add ability to specify user for active peer in sg-replicate2
 func TestSpecifyUserDocsToReplicate(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	testCases := []struct {
 		direction string

--- a/rest/api_benchmark_test.go
+++ b/rest/api_benchmark_test.go
@@ -67,7 +67,7 @@ var doc_1k_format = `{%s
 
 func BenchmarkReadOps_Get(b *testing.B) {
 
-	defer base.DisableTestLogging()()
+	base.DisableTestLogging(b)
 
 	rt := NewRestTester(b, nil)
 	defer rt.Close()
@@ -118,7 +118,7 @@ func BenchmarkReadOps_Get(b *testing.B) {
 // Benchmark 100% rev cache miss scenario
 func BenchmarkReadOps_GetRevCacheMisses(b *testing.B) {
 
-	defer base.DisableTestLogging()()
+	base.DisableTestLogging(b)
 
 	rt := NewRestTester(b, nil)
 	defer rt.Close()
@@ -185,7 +185,7 @@ func BenchmarkReadOps_GetRevCacheMisses(b *testing.B) {
 
 func BenchmarkReadOps_Changes(b *testing.B) {
 
-	defer base.DisableTestLogging()()
+	base.DisableTestLogging(b)
 
 	rt := NewRestTester(b, nil)
 	defer rt.Close()
@@ -258,7 +258,7 @@ func BenchmarkReadOps_Changes(b *testing.B) {
 
 func BenchmarkReadOps_RevsDiff(b *testing.B) {
 
-	defer base.DisableTestLogging()()
+	base.DisableTestLogging(b)
 
 	rt := NewRestTester(b, nil)
 	defer rt.Close()

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -158,7 +158,7 @@ func TestDocLifecycle(t *testing.T) {
 
 // Validate that Etag header value is surrounded with double quotes, see issue #808
 func TestDocEtag(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
@@ -1491,7 +1491,7 @@ func TestBulkGetEmptyDocs(t *testing.T) {
 
 func TestBulkDocsChangeToAccess(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAccess)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAccess)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {if(doc.type == "setaccess") {channel(doc.channel); access(doc.owner, doc.channel);} else { requireAccess(doc.channel)}}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -1525,7 +1525,7 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 
 func TestBulkDocsChangeToRoleAccess(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAccess)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAccess)
 
 	rtConfig := RestTesterConfig{SyncFn: `
 		function(doc) {
@@ -2306,7 +2306,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 func TestChannelAccessChanges(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyCRUD)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {access(doc.owner, doc._id);channel(doc.channel)}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2485,7 +2485,7 @@ func TestChannelAccessChanges(t *testing.T) {
 
 func TestAccessOnTombstone(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyCRUD)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc,oldDoc) {
 			 if (doc.owner) {
@@ -2562,7 +2562,7 @@ func TestAccessOnTombstone(t *testing.T) {
 // This can be used to introspect what properties ended up in the body passed to the sync function.
 func TestSyncFnBodyProperties(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyJavascript)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyJavascript)
 
 	const (
 		testDocID   = "testdoc"
@@ -2604,7 +2604,7 @@ func TestSyncFnBodyProperties(t *testing.T) {
 // It creates a doc, and then tombstones it to see what properties are present in the body of the tombstone.
 func TestSyncFnBodyPropertiesTombstone(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyJavascript)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyJavascript)
 
 	const (
 		testDocID   = "testdoc"
@@ -2653,7 +2653,7 @@ func TestSyncFnBodyPropertiesTombstone(t *testing.T) {
 // It creates a doc, and updates it to inspect what properties are present on the oldDoc body.
 func TestSyncFnOldDocBodyProperties(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyJavascript)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyJavascript)
 
 	const (
 		testDocID   = "testdoc"
@@ -2701,7 +2701,7 @@ func TestSyncFnOldDocBodyProperties(t *testing.T) {
 // It creates a doc, tombstones it, and then resurrects it to inspect oldDoc properties on the tombstone.
 func TestSyncFnOldDocBodyPropertiesTombstoneResurrect(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyJavascript)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyJavascript)
 
 	const (
 		testDocID   = "testdoc"
@@ -2763,7 +2763,7 @@ func TestSyncFnOldDocBodyPropertiesTombstoneResurrect(t *testing.T) {
 //                   └────────────── (T) 3-b
 func TestSyncFnDocBodyPropertiesSwitchActiveTombstone(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyJavascript)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyJavascript)
 
 	const (
 		testDocID   = "testdoc"
@@ -2836,7 +2836,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache, base.KeyAccess, base.KeyCRUD, base.KeyChanges)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache, base.KeyAccess, base.KeyCRUD, base.KeyChanges)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channels)}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2932,7 +2932,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 
 func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAccess, base.KeyCRUD, base.KeyChanges)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAccess, base.KeyCRUD, base.KeyChanges)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {role(doc.user, doc.role);channel(doc.channel)}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2978,7 +2978,7 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 
 func TestRoleAccessChanges(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAccess, base.KeyCRUD, base.KeyChanges)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAccess, base.KeyCRUD, base.KeyChanges)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {role(doc.user, doc.role);channel(doc.channel)}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -3391,7 +3391,7 @@ func TestOldDocHandling(t *testing.T) {
 
 func TestStarAccess(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges)
 
 	type allDocsRow struct {
 		ID    string `json:"id"`
@@ -4154,7 +4154,7 @@ func TestLongpollWithWildcard(t *testing.T) {
 	// TODO: Test disabled because it fails with -race
 	t.Skip("WARNING: TEST DISABLED")
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
 	var changes struct {
 		Results  []db.ChangeEntry
@@ -4354,7 +4354,7 @@ func TestDocIDFilterResurrection(t *testing.T) {
 
 func TestSyncFunctionErrorLogging(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyJavascript)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyJavascript)
 
 	rtConfig := RestTesterConfig{SyncFn: `
 		function(doc) {
@@ -4689,7 +4689,7 @@ func TestNonImportedDuplicateID(t *testing.T) {
 
 func TestChanCacheActiveRevsStat(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -5055,7 +5055,7 @@ func TestWebhookPropsWithAttachments(t *testing.T) {
 // TestWebhookWinningRevChangedEvent ensures the winning_rev_changed event is only fired for a winning revision change, and checks that document_changed is always fired.
 func TestWebhookWinningRevChangedEvent(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeyEvents)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyEvents)
 
 	wg := sync.WaitGroup{}
 
@@ -5146,7 +5146,7 @@ func TestWebhookWinningRevChangedEvent(t *testing.T) {
 
 func Benchmark_RestApiGetDocPerformance(b *testing.B) {
 
-	defer base.SetUpBenchmarkLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpBenchmarkLogging(b, base.LevelInfo, base.KeyHTTP)
 
 	prt := NewRestTester(b, nil)
 	defer prt.Close()
@@ -5167,7 +5167,7 @@ func Benchmark_RestApiGetDocPerformance(b *testing.B) {
 var threekdoc = `{"cols":["Name","Address","Location","phone"],"data":[["MelyssaF.Stokes","Ap#166-9804ProinSt.","52.01352,-9.4151","(306)773-3853"],["RuthT.Richards","Ap#180-8417TemporRoad","8.07909,-118.55952","(662)733-8043"],["CedricN.Witt","Ap#575-4625NuncSt.","74.419,153.71285","(850)995-0417"],["ElianaF.Ashley","Ap#169-2030Nibh.St.","87.98632,97.47442","(903)272-5949"],["ChesterJ.Holland","2905ProinSt.","-43.14706,-64.25893","(911)435-9200"],["AleaT.Bishop","Ap#493-4894ConvallisRd.","42.54157,64.98534","(479)848-2988"],["HerrodT.Barron","Ap#822-1444EtAvenue","9.50706,-111.54064","(390)300-8534"],["YoshiP.Sanchez","Ap#796-4679Arcu.Avenue","-16.49557,-137.69","(913)606-8930"],["GrahamO.Velazquez","415EratRd.","-5.30634,171.81751","(691)700-3072"],["BryarF.Sargent","Ap#180-6507Lacus.St.","17.64959,-19.93008","(516)890-6469"],["XerxesM.Gaines","370-1967NislStreet","-39.28978,-23.74924","(461)907-9563"],["KayI.Jones","565-351ElitAve","25.58317,17.43545","(145)441-5007"],["ImaZ.Curry","Ap#143-8377MagnaAve","-86.72025,-161.94081","(484)924-8145"],["GiselleW.Macdonald","962AdipiscingRoad","-21.55826,-121.06657","(137)255-2241"],["TarikJ.Kane","P.O.Box447,5949PhasellusSt.","57.28914,-125.89595","(356)758-8271"],["ChristopherJ.Travis","5246InRd.","-69.12682,31.20181","(298)963-1855"],["QuinnT.Pace","P.O.Box935,212Laoreet,St.","-62.00241,1.31111","(157)419-0182"],["BrentK.Guy","156-417LoremSt.","26.67571,-29.35786","(125)687-6610"],["JocelynN.Cash","Ap#502-9209VehiculaSt.","-26.05925,160.61357","(782)351-4211"],["DaphneS.King","571-1485FringillaRoad","-76.33262,-142.5655","(356)476-4508"],["MicahJ.Eaton","3468ProinRd.","61.30187,-128.8584","(942)467-7558"],["ChaneyM.Gay","444-1647Pede.Rd.","84.32739,-43.59781","(386)231-0872"],["LacotaM.Guerra","9863NuncRoad","21.81253,-54.90423","(694)443-8520"],["KimberleyY.Jensen","6403PurusSt.","67.5704,65.90554","(181)309-7780"],["JenaY.Brennan","Ap#533-7088MalesuadaStreet","78.58624,-172.89351","(886)688-0617"],["CarterK.Dotson","Ap#828-1931IpsumAve","59.54845,53.30366","(203)546-8704"],["EllaU.Buckner","Ap#141-1401CrasSt.","78.34425,-172.24474","(214)243-6054"],["HamiltonE.Estrada","8676Iaculis,St.","11.67468,-130.12233","(913)624-2612"],["IanT.Saunders","P.O.Box519,3762DictumRd.","-10.97019,73.47059","(536)391-7018"],["CairoK.Craft","6619Sem.St.","9.28931,-5.69682","(476)804-7898"],["JohnB.Norman","Ap#865-7121CubiliaAve","50.96552,-126.5271","(309)323-6975"],["SawyerD.Hale","Ap#512-820EratRd.","-65.1931,166.14822","(180)527-8987"],["CiaranQ.Cole","P.O.Box262,9220SedAvenue","69.753,121.39921","(272)654-8755"],["BrandenJ.Thompson","Ap#846-5470MetusAv.","44.61386,-44.18375","(388)776-0689"]]}`
 
 func Benchmark_RestApiPutDocPerformanceDefaultSyncFunc(b *testing.B) {
-	defer base.SetUpBenchmarkLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpBenchmarkLogging(b, base.LevelInfo, base.KeyHTTP)
 
 	prt := NewRestTester(b, nil)
 	defer prt.Close()
@@ -5186,7 +5186,7 @@ func Benchmark_RestApiPutDocPerformanceDefaultSyncFunc(b *testing.B) {
 
 func Benchmark_RestApiPutDocPerformanceExplicitSyncFunc(b *testing.B) {
 
-	defer base.SetUpBenchmarkLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpBenchmarkLogging(b, base.LevelInfo, base.KeyHTTP)
 
 	qrtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	qrt := NewRestTester(b, &qrtConfig)
@@ -5205,7 +5205,7 @@ func Benchmark_RestApiPutDocPerformanceExplicitSyncFunc(b *testing.B) {
 }
 
 func Benchmark_RestApiGetDocPerformanceFullRevCache(b *testing.B) {
-	defer base.SetUpBenchmarkLogging(base.LevelWarn, base.KeyHTTP)()
+	base.SetUpBenchmarkLogging(b, base.LevelWarn, base.KeyHTTP)
 	// Create test documents
 	rt := NewRestTester(b, nil)
 	defer rt.Close()
@@ -5460,7 +5460,7 @@ func TestSessionFail(t *testing.T) {
 }
 
 func TestImportOnWriteMigration(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test doesn't work with Walrus")
 	}
@@ -5725,7 +5725,7 @@ func TestTombstonedBulkDocsWithPriorPurge(t *testing.T) {
 		t.Skip("Test requires xattrs to be enabled")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rt := NewRestTester(t, &RestTesterConfig{
 		SyncFn: `function(doc,oldDoc){
 			console.log("doc:"+JSON.stringify(doc))
@@ -5764,7 +5764,7 @@ func TestTombstonedBulkDocsWithExistingTombstone(t *testing.T) {
 		t.Skip("Test requires xattrs to be enabled")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rt := NewRestTester(t, &RestTesterConfig{
 		SyncFn: `function(doc,oldDoc){
 			console.log("doc:"+JSON.stringify(doc))
@@ -5887,7 +5887,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 		t.Skipf("test is EE only - user xattrs")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	docKey := t.Name()
 	xattrKey := "myXattr"
@@ -6009,7 +6009,7 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 		t.Skipf("test is EE only - user xattrs")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	docKey := t.Name()
 	xattrKey := "myXattr"
@@ -6109,7 +6109,7 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 		t.Skipf("test is EE only - user xattrs")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	docKey := t.Name()
 	xattrKey := "myXattr"
@@ -6196,7 +6196,7 @@ func TestRemovingUserXattr(t *testing.T) {
 		t.Skipf("test is EE only - user xattrs")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	testCases := []struct {
 		name          string
@@ -6313,7 +6313,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 		t.Skipf("test is EE only - user xattrs")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	docKey := t.Name()
 	xattrKey := "myXattr"
@@ -8031,7 +8031,7 @@ func TestRevocationWithUserXattrs(t *testing.T) {
 		t.Skipf("test is EE only - user xattrs")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	xattrKey := "channelInfo"
 
@@ -8100,7 +8100,7 @@ func TestDocChannelSetPruning(t *testing.T) {
 }
 
 func TestBasicAttachmentRemoval(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
 
@@ -9394,7 +9394,7 @@ func TestTombstoneCompactionAPI(t *testing.T) {
 }
 
 func TestAttachmentsMissing(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -9419,7 +9419,7 @@ func TestAttachmentsMissing(t *testing.T) {
 }
 
 func TestAttachmentsMissingNoBody(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -33,7 +33,7 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel);}`})
 	defer rt.Close()
@@ -88,7 +88,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
@@ -166,7 +166,7 @@ func TestSetupAndValidate(t *testing.T) {
 	if !base.UnitTestUrlIsWalrus() {
 		t.Skip("Skipping this test; it only works on Walrus bucket")
 	}
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	t.Run("Run setupAndValidate with valid config", func(t *testing.T) {
 		configFile := createTempFile(t, []byte(`{
           "databases": {

--- a/rest/blip_api_no_race_test.go
+++ b/rest/blip_api_no_race_test.go
@@ -33,7 +33,7 @@ func TestBlipPusherUpdateDatabase(t *testing.T) {
 
 	t.Skip("Skipping test - revisit in CBG-1908")
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeyHTTPResp, base.KeySync)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyHTTPResp, base.KeySync)
 
 	tb := base.GetTestBucket(t)
 	defer tb.Close()

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -46,7 +46,7 @@ import (
 // Replication Spec: https://github.com/couchbase/couchbase-lite-core/wiki/Replication-Protocol#proposechanges
 func TestBlipPushRevisionInspectChanges(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	bt, err := NewBlipTester(t)
 	assert.NoError(t, err, "Error creating BlipTester")
@@ -161,7 +161,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 // Wait until we get the expected updates
 func TestContinuousChangesSubscription(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)
 
 	bt, err := NewBlipTester(t)
 	assert.NoError(t, err, "Error creating BlipTester")
@@ -277,7 +277,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	bt, err := NewBlipTester(t)
 	assert.NoError(t, err, "Error creating BlipTester")
@@ -433,7 +433,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 // Test subChanges w/ docID filter
 func TestBlipSubChangesDocIDFilter(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	bt, err := NewBlipTester(t)
 	assert.NoError(t, err, "Error creating BlipTester")
@@ -601,7 +601,7 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 // 4. Make sure that the server responds to accept the changes (empty array)
 func TestProposedChangesNoConflictsMode(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		noConflictsMode: true,
@@ -641,7 +641,7 @@ func TestProposedChangesNoConflictsMode(t *testing.T) {
 // Validate SG sends conflicting rev when requested
 func TestProposedChangesIncludeConflictingRev(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		noConflictsMode: true,
@@ -758,7 +758,7 @@ func TestProposedChangesIncludeConflictingRev(t *testing.T) {
 // Connect to public port with authentication
 func TestPublicPortAuthentication(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	// Create bliptester that is connected as user1, with access to the user1 channel
 	btUser1, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
@@ -815,7 +815,7 @@ func TestPublicPortAuthentication(t *testing.T) {
 // Connect to public port with authentication, and validate user update during a replication
 func TestPublicPortAuthenticationUserUpdate(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	// Initialize restTester here, so that we can use custom sync function, and later modify user
 	syncFunction := `
@@ -880,7 +880,7 @@ function(doc, oldDoc) {
 // Write a doc that grants access to itself for the active replication's user
 func TestContinuousChangesDynamicGrant(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)
 	// Initialize restTester here, so that we can use custom sync function, and later modify user
 	syncFunction := `
 function(doc, oldDoc) {
@@ -1007,7 +1007,7 @@ function(doc, oldDoc) {
 // Start subChanges w/ continuous=true, batchsize=20
 // Start sending rev messages for documents that grant access to themselves for the active replication's user
 func TestConcurrentRefreshUser(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)
 	// Initialize restTester here, so that we can use custom sync function, and later modify user
 	syncFunction := `
 function(doc, oldDoc) {
@@ -1149,7 +1149,7 @@ function(doc, oldDoc) {
 //   Validate deleted handling (includes check for https://github.com/couchbase/sync_gateway/issues/3341)
 func TestBlipSendAndGetRev(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -1196,7 +1196,7 @@ func TestBlipSendAndGetRev(t *testing.T) {
 //   Validate deleted handling (includes check for https://github.com/couchbase/sync_gateway/issues/3341)
 func TestBlipSendAndGetLargeNumberRev(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -1252,7 +1252,7 @@ func TestMultiChannelContinousChangesSubscription(t *testing.T) {
 // Test setting and getting checkpoints
 func TestBlipSetCheckpoint(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -1302,7 +1302,7 @@ func TestNoConflictsModeReplication(t *testing.T) {
 // Reproduces https://github.com/couchbase/sync_gateway/issues/2717
 func TestReloadUser(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	syncFn := `
 		function(doc) {
@@ -1369,7 +1369,7 @@ func TestReloadUser(t *testing.T) {
 // it shows up in the user's changes feed
 func TestAccessGrantViaSyncFunction(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	// Setup
 	rtConfig := RestTesterConfig{
@@ -1415,7 +1415,7 @@ func TestAccessGrantViaSyncFunction(t *testing.T) {
 // it shows up in the user's changes feed
 func TestAccessGrantViaAdminApi(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
@@ -1453,7 +1453,7 @@ func TestAccessGrantViaAdminApi(t *testing.T) {
 
 func TestCheckpoint(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
@@ -1522,7 +1522,7 @@ func TestCheckpoint(t *testing.T) {
 // - Get attachment via REST and verifies it returns the correct content
 func TestPutAttachmentViaBlipGetViaRest(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
@@ -1568,7 +1568,7 @@ func TestPutAttachmentViaBlipGetViaRest(t *testing.T) {
 
 func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
@@ -1652,7 +1652,7 @@ func TestPutInvalidAttachment(t *testing.T) {
 		},
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
@@ -1696,7 +1696,7 @@ func TestPutInvalidAttachment(t *testing.T) {
 // returns an error code
 func TestPutInvalidRevSyncFnReject(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	syncFn := `
 		function(doc) {
@@ -1743,7 +1743,7 @@ func TestPutInvalidRevSyncFnReject(t *testing.T) {
 
 func TestPutInvalidRevMalformedBody(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
@@ -1781,7 +1781,7 @@ func TestPutInvalidRevMalformedBody(t *testing.T) {
 
 func TestPutRevNoConflictsMode(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
@@ -1811,7 +1811,7 @@ func TestPutRevNoConflictsMode(t *testing.T) {
 
 func TestPutRevConflictsMode(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
@@ -1854,7 +1854,7 @@ func TestPutRevConflictsMode(t *testing.T) {
 //
 func TestGetRemovedDoc(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -1996,7 +1996,7 @@ func TestMissingNoRev(t *testing.T) {
 // and checks that full body replication still happens in CE.
 func TestBlipDeltaSyncPull(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{
@@ -2077,7 +2077,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		t.Skip("Enterprise-only test for delta sync")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -2147,7 +2147,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 // TestBlipDeltaSyncPullRemoved tests a simple pull replication that drops a document out of the user's channel.
 func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
@@ -2202,7 +2202,7 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 // └──────────────┘ └───────────────────────────────────┘
 func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
@@ -2297,7 +2297,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 // └──────────────┘           └───────────┘          └───────────┘
 func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeyCache, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyCache, base.KeySync, base.KeySyncMsg)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
@@ -2430,7 +2430,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 // TestBlipPullRevMessageHistory tests that a simple pull replication contains history in the rev message.
 func TestBlipPullRevMessageHistory(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{
@@ -2481,7 +2481,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 		t.Skipf("Skipping enterprise-only delta sync test.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{
@@ -2574,7 +2574,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 // and checks that full body replication is still supported in CE.
 func TestBlipDeltaSyncPush(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -2685,7 +2685,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 // TestBlipNonDeltaSyncPush tests that a client that doesn't support deltas can push to a SG that supports deltas (either CE or EE)
 func TestBlipNonDeltaSyncPush(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -2739,7 +2739,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 // TestBlipDeltaSyncNewAttachmentPull tests that adding a new attachment in SG and replicated via delta sync adds the attachment
 // to the temporary "allowedAttachments" map.
 func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{
@@ -2839,7 +2839,7 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 // Reproduces CBG-617 (a client using activeOnly for the initial replication, and then still expecting to get subsequent tombstones afterwards)
 func TestActiveOnlyContinuous(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
@@ -2875,7 +2875,7 @@ func TestActiveOnlyContinuous(t *testing.T) {
 // Test that exercises Sync Gateway's norev handler
 func TestBlipNorev(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
@@ -2922,7 +2922,7 @@ func TestNoRevSetSeq(t *testing.T) {
 
 // TestBlipDeltaSyncPushAttachment tests updating a doc that has an attachment with a delta that doesn't modify the attachment.
 func TestBlipDeltaSyncPushAttachment(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta test requires EE")
@@ -2987,7 +2987,7 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 // 5. Update doc in the test client by adding another attachment
 // 6. Have that update pushed using delta sync via the continuous replication started in step 2
 func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta test requires EE")
 	}
@@ -3069,7 +3069,7 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 // 4. Update doc in the test client and keep the same attachment stub.
 // 5. Have that update pushed via the continuous replication started in step 2
 func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
@@ -3147,7 +3147,7 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 // 4. Update doc in the test client and keep the same attachment stub.
 // 5. Have that update pushed via the continuous replication started in step 2
 func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
@@ -3360,7 +3360,7 @@ func TestCBLRevposHandling(t *testing.T) {
 }
 
 func TestRevocationMessage(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	revocationTester, rt := initScenario(t, nil)
 	defer rt.Close()
@@ -3547,7 +3547,7 @@ func TestRevocationNoRev(t *testing.T) {
 
 func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -3642,7 +3642,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 }
 
 func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		guestEnabled: true,
 	}
@@ -3714,7 +3714,7 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 }
 
 func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		guestEnabled: true,
 	}
@@ -3774,7 +3774,7 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 }
 
 func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rt := NewRestTester(t, &RestTesterConfig{
 		guestEnabled: true,
 		DatabaseConfig: &DatabaseConfig{
@@ -3824,7 +3824,7 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 // Asserts on stats to test for regression of CBG-1824: Make sure SubChangesOneShotActive gets decremented when one shot
 // sub changes request has completed
 func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	bt, err := NewBlipTester(t)
 	require.NoError(t, err, "Error creating BlipTester")

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -28,7 +28,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 		t.Skip("Bootstrap works with Couchbase Server only")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	// Start SG with no databases
 	config := bootstrapStartupConfigForTest(t)
@@ -142,7 +142,7 @@ func TestBootstrapDuplicateBucket(t *testing.T) {
 		t.Skip("Bootstrap works with Couchbase Server only")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	serverErr := make(chan error, 0)
 
@@ -194,7 +194,7 @@ func TestBootstrapDuplicateDatabase(t *testing.T) {
 		t.Skip("Bootstrap works with Couchbase Server only")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	serverErr := make(chan error, 0)
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -36,7 +36,7 @@ func TestReproduce2383(t *testing.T) {
 		t.Skip("Skip LeakyBucket test when running in integration")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -190,7 +190,7 @@ func TestDocDeletionFromChannel(t *testing.T) {
 
 func TestPostChanges(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
@@ -223,7 +223,7 @@ func TestPostChangesUserTiming(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel)}`})
 	defer rt.Close()
@@ -284,7 +284,7 @@ func TestPostChangesSinceInteger(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
@@ -390,7 +390,7 @@ func postChangesSince(t *testing.T, rt *RestTester) {
 
 func TestPostChangesChannelFilterInteger(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
@@ -459,7 +459,7 @@ func TestPostChangesAdminChannelGrant(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
@@ -541,7 +541,7 @@ func TestPostChangesAdminChannelGrant(t *testing.T) {
 }
 
 func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
 	// Disable sequence batching for multi-RT tests (pending CBG-1000)
 	defer db.SuspendSequenceBatching()()
@@ -698,7 +698,7 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 }
 
 func TestPostChangesAdminChannelGrantRemovalWithLimit(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
@@ -760,7 +760,7 @@ func TestPostChangesAdminChannelGrantRemovalWithLimit(t *testing.T) {
 // TestChangesFromCompoundSinceViaDocGrant ensures that a changes feed with a compound since value returns the correct result after a dynamic channel grant.
 func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges, base.KeyHTTP)
 
 	// Disable sequence batching for multi-RT tests (pending CBG-1000)
 	defer db.SuspendSequenceBatching()()
@@ -907,7 +907,7 @@ func TestChangeWaiterExitOnChangesTermination(t *testing.T) {
 	for _, test := range tests {
 		testName := fmt.Sprintf("%v user:%v manualNotify:%t", test.feedType, test.username, test.manualNotify)
 		t.Run(testName, func(t *testing.T) {
-			defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+			base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 			rt := NewRestTester(t, nil)
 			defer rt.Close()
@@ -960,7 +960,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 		t.Skip("This test cannot run in xattr mode until WriteDirect() is updated.  See https://github.com/couchbase/sync_gateway/issues/2666#issuecomment-311183219")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges)
 
 	pendingMaxWait := uint32(5)
 	maxNum := 50
@@ -1052,7 +1052,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 		t.Skip("This test cannot run in xattr mode until WriteDirect() is updated.  See https://github.com/couchbase/sync_gateway/issues/2666#issuecomment-311183219")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges)
 	pendingMaxWait := uint32(5)
 	maxNum := 50
 	skippedMaxWait := uint32(120000)
@@ -1186,7 +1186,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 		t.Skip("This test cannot run in xattr mode until WriteDirect() is updated.  See https://github.com/couchbase/sync_gateway/issues/2666#issuecomment-311183219")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges)
 	pendingMaxWait := uint32(5)
 	maxNum := 50
 	skippedMaxWait := uint32(120000)
@@ -1316,7 +1316,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 		t.Skip("This test cannot run in xattr mode until WriteDirect() is updated.  See https://github.com/couchbase/sync_gateway/issues/2666#issuecomment-311183219")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges)
 
 	pendingMaxWait := uint32(5)
 	maxNum := 50
@@ -1426,7 +1426,7 @@ func TestUnusedSequences(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyCRUD, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyCRUD, base.KeyHTTP)
 
 	// Only do 10 iterations if running against walrus.  If against a live couchbase server,
 	// just do single iteration.  (Takes approx 30s)
@@ -1603,7 +1603,7 @@ func _testConcurrentNewEditsFalseDelete(t *testing.T) {
 }
 
 func TestChangesActiveOnlyInteger(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
@@ -1726,7 +1726,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyNone)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyNone)
 
 	defer db.SuspendSequenceBatching()()
 
@@ -1931,7 +1931,7 @@ func updateTestDoc(rt *RestTester, docid string, revid string, body string) (new
 // Validate retrieval of various document body types using include_docs.
 func TestChangesIncludeDocs(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyNone)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyNone)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channels)}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2160,7 +2160,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 // Tests view backfills into empty cache and validates that results are prepended to cache
 func TestChangesViewBackfillFromQueryOnly(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2232,7 +2232,7 @@ func TestChangesViewBackfillFromQueryOnly(t *testing.T) {
 // Validate that non-contiguous query results (due to limit) are not prepended to the cache
 func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2331,7 +2331,7 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 // Tests multiple view backfills and validates that results are prepended to cache
 func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2415,7 +2415,7 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 // Tests multiple view backfills and validates that results are prepended to cache
 func TestChangesViewBackfillNoOverlap(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2501,7 +2501,7 @@ func TestChangesViewBackfillNoOverlap(t *testing.T) {
 // Tests view backfill and validates that results are prepended to cache
 func TestChangesViewBackfill(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2572,7 +2572,7 @@ func TestChangesViewBackfill(t *testing.T) {
 // Tests view backfill and validates that results are prepended to cache
 func TestChangesViewBackfillStarChannel(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2648,7 +2648,7 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 // Tests query backfill with limit
 func TestChangesQueryBackfillWithLimit(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2812,7 +2812,7 @@ func TestChangesQueryBackfillWithLimit(t *testing.T) {
 // Tests query backfill with limit
 func TestMultichannelChangesQueryBackfillWithLimit(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2887,7 +2887,7 @@ func TestMultichannelChangesQueryBackfillWithLimit(t *testing.T) {
 // Tests star channel query backfill with limit
 func TestChangesQueryStarChannelBackfillLimit(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	queryLimit := 5
@@ -2940,7 +2940,7 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 		t.Skip("Skip test with LeakyBucket dependency test when running in integration")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -3046,7 +3046,7 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 
 func TestChangesActiveOnlyWithLimit(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges)
 
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
@@ -3228,7 +3228,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 // additional to general view handling.
 func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)
 
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
@@ -3417,7 +3417,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 
 func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)
 
 	cacheSize := 2
 	shortWaitConfig := &DatabaseConfig{DbConfig: DbConfig{
@@ -3574,7 +3574,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 // Test _changes returning conflicts
 func TestChangesIncludeConflicts(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyCRUD)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc,oldDoc) {
 			 channel(doc.channel)
@@ -3663,7 +3663,7 @@ func TestChangesLargeSequences(t *testing.T) {
 
 func TestIncludeDocsWithPrincipals(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -3717,7 +3717,7 @@ func TestIncludeDocsWithPrincipals(t *testing.T) {
 // Validate that an admin channel grant wakes up a waiting changes request
 func TestChangesAdminChannelGrantLongpollNotify(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -3772,7 +3772,7 @@ func TestChangesAdminChannelGrantLongpollNotify(t *testing.T) {
 // Validate handling when a single channel cache is compacted while changes request is in wait mode
 func TestCacheCompactDuringChangesWait(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache)
 
 	numIndexReplicas := uint(0)
 	smallCacheSize := 100
@@ -3846,7 +3846,7 @@ func TestCacheCompactDuringChangesWait(t *testing.T) {
 }
 
 func TestTombstoneCompaction(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Walrus does not support Xattrs")

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -474,7 +474,7 @@ func TestAutoImportEnabled(t *testing.T) {
 }
 
 func TestMergeWith(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	defaultInterface := "4984"
 	adminInterface := "127.0.0.1:4985"
 	profileInterface := "127.0.0.1:4985"
@@ -545,7 +545,7 @@ func TestMergeWith(t *testing.T) {
 
 func TestSetupAndValidateLogging(t *testing.T) {
 	t.Skip("Skipping TestSetupAndValidateLogging")
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	sc := &StartupConfig{}
 	err := sc.SetupAndValidateLogging()
 	assert.NoError(t, err, "Setup and validate logging should be successful")
@@ -554,7 +554,7 @@ func TestSetupAndValidateLogging(t *testing.T) {
 
 func TestSetupAndValidateLoggingWithLoggingConfig(t *testing.T) {
 	t.Skip("Skipping TestSetupAndValidateLoggingWithLoggingConfig")
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	logFilePath := "/var/log/sync_gateway"
 	sc := &StartupConfig{Logging: base.LoggingConfig{LogFilePath: logFilePath, RedactionLevel: base.RedactFull}}
 	err := sc.SetupAndValidateLogging()
@@ -563,7 +563,7 @@ func TestSetupAndValidateLoggingWithLoggingConfig(t *testing.T) {
 }
 
 func TestServerConfigValidate(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	// unsupported.stats_log_freq_secs
 	statsLogFrequencySecs := uint(9)
 	unsupported := &UnsupportedServerConfigLegacy{StatsLogFrequencySecs: &statsLogFrequencySecs}
@@ -806,7 +806,7 @@ func TestValidateServerContextSharedBuckets(t *testing.T) {
 		t.Skip("Skipping this test; requires Couchbase Bucket")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	tb1 := base.GetTestBucket(t)
 	defer tb1.Close()
@@ -1190,7 +1190,7 @@ func deleteTempFile(t *testing.T, file *os.File) {
 }
 
 func TestDefaultLogging(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	config := DefaultStartupConfig("")
 	assert.Equal(t, base.RedactPartial, config.Logging.RedactionLevel)
@@ -1208,7 +1208,7 @@ func TestDefaultLogging(t *testing.T) {
 }
 
 func TestSetupServerContext(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	t.Run("Create server context with a valid configuration", func(t *testing.T) {
 		config := DefaultStartupConfig("")
 		config.Bootstrap.Server = base.UnitTestUrl() // Valid config requires server to be explicitly defined
@@ -1294,7 +1294,7 @@ func TestConfigGroupIDValidation(t *testing.T) {
 
 // CBG-1599
 func TestClientTLSMissing(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	errorTLSOneMissing := "both TLS Key Path and TLS Cert Path must be provided when using client TLS. Disable client TLS by not providing either of these options"
 	testCases := []struct {
 		name        string

--- a/rest/doc_api_test.go
+++ b/rest/doc_api_test.go
@@ -101,7 +101,7 @@ func TestDocumentNumbers(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	for _, test := range tests {
 		t.Run(test.name, func(ts *testing.T) {

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -73,7 +73,7 @@ func TestXattrImportOldDoc(t *testing.T) {
 
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	// 1. Test oldDoc behaviour during SDK insert
 	key := "TestImportDelete"
@@ -155,7 +155,7 @@ func TestXattrImportOldDocRevHistory(t *testing.T) {
 	defer rt.Close()
 
 	bucket := rt.Bucket()
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	// 1. Create revision with history
 	docID := t.Name()
@@ -204,7 +204,7 @@ func TestXattrSGTombstone(t *testing.T) {
 
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	// 1. Create doc through SG
 	key := "TestXattrSGTombstone"
@@ -249,7 +249,7 @@ func TestXattrImportOnCasFailure(t *testing.T) {
 	defer rt.Close()
 
 	bucket := rt.Bucket()
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport)
 
 	// 1. SG Write
 	key := "TestCasFailureImport"
@@ -313,7 +313,7 @@ func TestXattrResurrectViaSG(t *testing.T) {
 
 	rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	// 1. Create and import doc
 	key := "TestResurrectViaSG"
@@ -362,7 +362,7 @@ func TestXattrResurrectViaSDK(t *testing.T) {
 
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport)
 
 	// 1. Create and import doc
 	key := "TestResurrectViaSDK"
@@ -427,7 +427,7 @@ func TestXattrDoubleDelete(t *testing.T) {
 
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	// 1. Create and import doc
 	key := "TestDoubleDelete"
@@ -476,7 +476,7 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport)
 
 	// 1. Create and import docs
 	key := "SG_delete"
@@ -551,7 +551,7 @@ func TestXattrImportFilterOptIn(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	// 1. Create two docs via the SDK, one matching filter
 	mobileKey := "TestImportFilterValid"
@@ -642,7 +642,7 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	// 1. Create doc via the SDK
 	mobileKey := "TestImportMultiActorUpdate"
@@ -698,7 +698,7 @@ func TestXattrImportMultipleActorOnDemandPut(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	// 1. Create doc via the SDK
 	mobileKey := "TestImportMultiActorUpdate"
@@ -756,7 +756,7 @@ func TestXattrImportMultipleActorOnDemandFeed(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	// Create doc via the SDK
 	mobileKey := "TestImportMultiActorFeed"
@@ -829,7 +829,7 @@ func TestXattrImportLargeNumbers(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	// 1. Create doc via the SDK
 	mobileKey := "TestImportLargeNumbers"
@@ -878,7 +878,7 @@ func TestMigrateLargeInlineRevisions(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	// Write doc in SG format directly to the bucket
 	key := "TestMigrateLargeInlineRevisions"
@@ -947,7 +947,7 @@ func TestMigrateTombstone(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	// Write doc in SG format directly to the bucket
 	key := "TestMigrateTombstone"
@@ -1016,7 +1016,7 @@ func TestMigrateWithExternalRevisions(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	// Write doc in SG format directly to the bucket
 	key := "TestMigrateWithExternalRevisions"
@@ -1092,7 +1092,7 @@ func TestCheckForUpgradeOnRead(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	// Write doc in SG format (doc + xattr) directly to the bucket
 	key := "TestCheckForUpgrade"
@@ -1171,7 +1171,7 @@ func TestCheckForUpgradeOnWrite(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD, base.KeyCache)
 
 	// Write doc in SG format (doc + xattr) directly to the bucket
 	key := "TestCheckForUpgrade"
@@ -1253,7 +1253,7 @@ func TestCheckForUpgradeFeed(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD, base.KeyCache)
 
 	// Write doc in SG format (doc + xattr) directly to the bucket
 	key := "TestCheckForUpgrade"
@@ -1316,7 +1316,7 @@ func TestXattrFeedBasedImportPreservesExpiry(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	// 1. Create docs via the SDK with expiry set
 	mobileKey := "TestXattrImportPreservesExpiry"
@@ -1378,7 +1378,7 @@ func TestFeedBasedMigrateWithExpiry(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	// Write doc in SG format directly to the bucket
 	key := "TestFeedBasedMigrateWithExpiry"
@@ -1428,7 +1428,7 @@ func TestOnDemandWriteImportReplacingNullDoc(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	key := "TestXattrOnDemandImportNullBody"
 
@@ -1500,7 +1500,7 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 			defer rt.Close()
 			bucket := rt.Bucket()
 
-			defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+			base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 			key := fmt.Sprintf("TestXattrOnDemandImportPreservesExpiry-%d", i)
 
@@ -1585,7 +1585,7 @@ func TestOnDemandMigrateWithExpiry(t *testing.T) {
 			defer rt.Close()
 			bucket := rt.Bucket()
 
-			defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+			base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 			// Create via the SDK with sync metadata intact
 			expirySeconds := time.Second * 30
@@ -1632,7 +1632,7 @@ func TestXattrSGWriteOfNonImportedDoc(t *testing.T) {
 
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	// 1. Create doc via SG
 	sgWriteKey := "TestImportFilterSGWrite"
@@ -1680,7 +1680,7 @@ func TestImportBinaryDoc(t *testing.T) {
 
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD, base.KeyCache)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD, base.KeyCache)
 
 	// 1. Write a binary doc through the SDK
 	rawBytes := []byte("some bytes")
@@ -1697,7 +1697,7 @@ func TestImportZeroValueDecimalPlaces(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport)
 
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -1759,7 +1759,7 @@ func TestImportZeroValueDecimalPlacesScientificNotation(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport)
 
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -1832,7 +1832,7 @@ func TestImportRevisionCopy(t *testing.T) {
 	defer rt.Close()
 
 	bucket := rt.Bucket()
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport)
 
 	key := "TestImportRevisionCopy"
 	docBody := make(map[string]interface{})
@@ -1893,7 +1893,7 @@ func TestImportRevisionCopyUnavailable(t *testing.T) {
 	}
 
 	bucket := rt.Bucket()
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport)
 
 	key := "TestImportRevisionCopy"
 	docBody := make(map[string]interface{})
@@ -1954,7 +1954,7 @@ func TestImportRevisionCopyDisabled(t *testing.T) {
 	}
 
 	bucket := rt.Bucket()
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport)
 
 	key := "TestImportRevisionCopy"
 	docBody := make(map[string]interface{})
@@ -2068,7 +2068,7 @@ func TestUnexpectedBodyOnTombstone(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	// 1. Create doc via the SDK
 	mobileKey := "TestTombstoneUpdate"
@@ -2162,7 +2162,7 @@ func assertXattrSyncMetaRevGeneration(t *testing.T, bucket base.Bucket, key stri
 
 func TestDeletedEmptyDocumentImport(t *testing.T) {
 	SkipImportTestsIfNotEnabled(t)
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport)
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 	bucket := rt.Bucket()
@@ -2211,7 +2211,7 @@ func TestDeletedDocumentImportWithImportFilter(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	bucket := rt.Bucket()
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD, base.KeyJavascript)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD, base.KeyJavascript)
 
 	// Create document via SDK
 	key := "doc1"

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -2106,7 +2106,7 @@ func TestOpenIDConnectAuthCodeFlowWithUsernameClaim(t *testing.T) {
 // at a later request
 func TestEventuallyReachableOIDCClient(t *testing.T) {
 	// Modified copy of TestOpenIDConnectImplicitFlow
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	unreachableAddr := "http://0.0.0.0"
 	tests := []struct {
 		name                string

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -106,7 +106,7 @@ func TestCreateJWTToken(t *testing.T) {
 }
 
 func TestExtractSubjectFromRefreshToken(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 	// Extract subject from invalid refresh token
 	sub, err := extractSubjectFromRefreshToken("invalid_refresh_token")
 	require.Error(t, err, "invalid refresh token error")

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -289,7 +289,7 @@ func TestImportFilterEndpoint(t *testing.T) {
 		t.Skip("Test requires xattrs")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	serverErr := make(chan error, 0)
 

--- a/rest/replication_api_no_race_test.go
+++ b/rest/replication_api_no_race_test.go
@@ -37,7 +37,7 @@ func TestPushReplicationAPIUpdateDatabase(t *testing.T) {
 	}
 
 	base.RequireNumTestBuckets(t, 2)
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	rt1, rt2, remoteURLString, teardown := setupSGRPeers(t)
 	defer teardown()

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -521,7 +521,7 @@ func TestReplicationsFromConfig(t *testing.T) {
 func TestPushReplicationAPI(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	rt1, rt2, remoteURLString, teardown := setupSGRPeers(t)
 	defer teardown()
@@ -564,7 +564,7 @@ func TestPushReplicationAPI(t *testing.T) {
 func TestPullReplicationAPI(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	rt1, rt2, remoteURLString, teardown := setupSGRPeers(t)
 	defer teardown()
@@ -606,7 +606,7 @@ func TestPullReplicationAPI(t *testing.T) {
 func TestReplicationStatusActions(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	rt1, rt2, remoteURLString, teardown := setupSGRPeers(t)
 	defer teardown()
@@ -708,7 +708,7 @@ func TestReplicationRebalancePull(t *testing.T) {
 	}
 
 	base.RequireNumTestBuckets(t, 2)
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	// Increase checkpoint persistence frequency for cross-node status verification
 	defer reduceTestCheckpointInterval(50 * time.Millisecond)()
@@ -798,7 +798,7 @@ func TestReplicationRebalancePush(t *testing.T) {
 	}
 
 	base.RequireNumTestBuckets(t, 2)
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	// Increase checkpoint persistence frequency for cross-node status verification
 	defer reduceTestCheckpointInterval(50 * time.Millisecond)()
@@ -885,7 +885,7 @@ func TestReplicationRebalancePush(t *testing.T) {
 func TestPullOneshotReplicationAPI(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	activeRT, remoteRT, remoteURLString, teardown := setupSGRPeers(t)
 	defer teardown()
@@ -940,7 +940,7 @@ func TestPullOneshotReplicationAPI(t *testing.T) {
 func TestReplicationConcurrentPush(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	// Disable sequence batching for multi-RT tests (pending CBG-1000)
 	defer db.SuspendSequenceBatching()()
@@ -1503,7 +1503,7 @@ func TestGetStatusWithReplication(t *testing.T) {
 }
 
 func TestRequireReplicatorStoppedBeforeUpsert(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyHTTPResp)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyHTTPResp)
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -1555,7 +1555,7 @@ func TestReplicationConfigChange(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	rt1, rt2, remoteURLString, teardown := setupSGRPeers(t)
 	defer teardown()
@@ -1654,7 +1654,7 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 	defer reduceTestCheckpointInterval(50 * time.Millisecond)()
 
 	base.RequireNumTestBuckets(t, 2)
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	// Disable sequence batching for multi-RT tests (pending CBG-1000)
 	defer db.SuspendSequenceBatching()()

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -33,7 +33,7 @@ import (
 
 // TestActiveReplicatorBlipsync uses an ActiveReplicator with another RestTester instance to connect and cleanly disconnect.
 func TestActiveReplicatorBlipsync(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyHTTPResp)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyHTTPResp)
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -93,7 +93,7 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 
 // TestActiveReplicatorHeartbeats uses an ActiveReplicator with another RestTester instance to connect, and waits for several websocket ping/pongs.
 func TestActiveReplicatorHeartbeats(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyWebSocket, base.KeyWebSocketFrame)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyWebSocket, base.KeyWebSocketFrame)
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -152,7 +152,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
@@ -247,7 +247,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
@@ -425,7 +425,7 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+			base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 			// Increase checkpoint persistence frequency for cross-node status verification
 			defer reduceTestCheckpointInterval(50 * time.Millisecond)()
@@ -563,7 +563,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	const (
 		changesBatchSize  = 10
@@ -728,7 +728,7 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	const (
 		changesBatchSize  = 10
@@ -887,7 +887,7 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyReplicate)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyReplicate)
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
@@ -980,7 +980,7 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
@@ -1069,7 +1069,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Active
 	tb1 := base.GetTestBucket(t)
@@ -1182,7 +1182,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	const (
 		changesBatchSize  = 10
@@ -1346,7 +1346,7 @@ func TestActiveReplicatorPushFromCheckpointIgnored(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	const (
 		changesBatchSize  = 10
@@ -1486,7 +1486,7 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
@@ -1581,7 +1581,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
@@ -1681,7 +1681,7 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyReplicate)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyReplicate)
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
@@ -1857,7 +1857,7 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 	for _, test := range conflictResolutionTests {
 		t.Run(test.name, func(t *testing.T) {
 			base.RequireNumTestBuckets(t, 2)
-			defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD)()
+			base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD)
 
 			// Passive
 			tb2 := base.GetTestBucket(t)
@@ -2064,7 +2064,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 	for _, test := range conflictResolutionTests {
 		t.Run(test.name, func(t *testing.T) {
 			base.RequireNumTestBuckets(t, 2)
-			defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD)()
+			base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD)
 
 			// Passive
 			rt2 := NewRestTester(t, &RestTesterConfig{
@@ -2258,7 +2258,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 //   - Uses an ActiveReplicator configured for push to start pushing changes to rt2.
 func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Passive
 	rt2 := NewRestTester(t, &RestTesterConfig{
@@ -2335,7 +2335,7 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 //   - Uses an ActiveReplicator configured for push to start pushing changes to rt2.
 func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Passive
 	rt2 := NewRestTester(t, &RestTesterConfig{
@@ -2399,7 +2399,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 3)
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	// Passive
 	rt2 := NewRestTester(t, &RestTesterConfig{
@@ -2553,7 +2553,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 3)
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
@@ -2726,7 +2726,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyBucket, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyBucket, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	// Passive
 	rt2 := NewRestTester(t, &RestTesterConfig{
@@ -2882,7 +2882,7 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyBucket, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyBucket, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	// Passive
 	rt2 := NewRestTester(t, &RestTesterConfig{
@@ -2981,7 +2981,7 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Passive
 	rt2 := NewRestTester(t, &RestTesterConfig{
@@ -3087,7 +3087,7 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	const (
 		changesBatchSize         = 10
@@ -3293,7 +3293,7 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 			for _, timeoutVal := range timeoutVals {
 				t.Run(test.name+" with timeout "+timeoutVal.String(), func(t *testing.T) {
 
-					defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+					base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 					// Passive
 					tb2 := base.GetTestBucket(t)
@@ -3396,7 +3396,7 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp)
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
@@ -3475,7 +3475,7 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp)
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
@@ -3596,7 +3596,7 @@ func waitAndAssertCondition(t *testing.T, fn func() bool, failureMsgAndArgs ...i
 }
 
 func TestBlipSyncNonUpgradableConnection(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyHTTPResp)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyHTTPResp)
 	rt := NewRestTester(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			Users: map[string]*db.PrincipalConfig{
@@ -3814,7 +3814,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 	for _, test := range conflictResolutionTests {
 		t.Run(test.name, func(t *testing.T) {
 			base.RequireNumTestBuckets(t, 2)
-			defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+			base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 			// Passive
 			tb2 := base.GetTestBucket(t)
@@ -4031,7 +4031,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 	for _, test := range tombstoneTests {
 
 		t.Run(test.name, func(t *testing.T) {
-			defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket, base.KeyReplicate)()
+			base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket, base.KeyReplicate)
 
 			if test.sdkResurrect && !base.TestUseXattrs() {
 				t.Skip("SDK resurrect test cases require xattrs to be enabled")
@@ -4264,7 +4264,7 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 	if !base.TestUseXattrs() {
 		t.Skip("This test only works with XATTRS enabled")
 	}
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	defaultConflictResolverWithTombstoneTests := []struct {
 		name             string   // A unique name to identify the unit test.
@@ -4416,7 +4416,7 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 	if !base.TestUseXattrs() {
 		t.Skip("This test only works with XATTRS enabled")
 	}
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	defaultConflictResolverWithTombstoneTests := []struct {
 		name            string   // A unique name to identify the unit test.
@@ -4671,7 +4671,7 @@ func TestLocalWinsConflictResolution(t *testing.T) {
 	for _, test := range conflictResolutionTests {
 		t.Run(test.name, func(t *testing.T) {
 			base.RequireNumTestBuckets(t, 2)
-			defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+			base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
 
 			activeRT, remoteRT, remoteURLString, teardown := setupSGRPeers(t)
 			defer teardown()
@@ -5230,7 +5230,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 }
 
 func TestConflictResolveMergeWithMutatedRev(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	base.RequireNumTestBuckets(t, 2)
 
@@ -5477,7 +5477,7 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 }
 
 func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	defer db.SuspendSequenceBatching()()
 
@@ -5607,7 +5607,7 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 		t.Skipf("Requires EE for delta sync")
 	}
 	defer db.SuspendSequenceBatching()()
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	// Passive //
 	passiveBucket := base.GetTestBucket(t)
@@ -5706,7 +5706,7 @@ func TestUnprocessableDeltas(t *testing.T) {
 	}
 
 	defer db.SuspendSequenceBatching()()
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	// Passive //
 	passiveBucket := base.GetTestBucket(t)
@@ -5798,7 +5798,7 @@ func TestUnprocessableDeltas(t *testing.T) {
 func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 	// Copies the behaviour of TestGetRemovedAsUser but with replication and no user
 	defer db.SuspendSequenceBatching()()
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	// Passive //
 	passiveBucket := base.GetTestBucket(t)

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -141,7 +141,7 @@ func dbConfigForTestBucket(tb *base.TestBucket) DbConfig {
 }
 
 func TestPersistentDbConfigWithInvalidUpsert(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	rtc := NewRestTesterCluster(t, nil)
 	defer rtc.Close()

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -222,7 +222,7 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 }
 
 func TestStatsLoggerStopped(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	sc := DefaultStartupConfig("")
 
@@ -324,7 +324,7 @@ outerLoop:
 }
 
 func TestStartAndStopHTTPServers(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
@@ -477,7 +477,7 @@ func TestTLSSkipVerifyGetBucketSpec(t *testing.T) {
 
 // CBG-1535 - test Bootstrap.UseTLSServer option
 func TestUseTLSServer(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	errorMustBeSecure := "Must use secure scheme in Couchbase Server URL, or opt out by setting bootstrap.use_tls_server to false. Current URL: %v"
 	errorAllowInsecureAndBeSecure := "Couchbase server URL cannot use secure protocol when bootstrap.use_tls_server is false. Current URL: %v"
 	testCases := []struct {
@@ -604,7 +604,7 @@ func TestLogFlush(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+			base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 			// Setup memory logging
 			base.InitializeMemoryLoggers()

--- a/rest/x509_test.go
+++ b/rest/x509_test.go
@@ -28,7 +28,7 @@ import (
 // TestX509RoundtripUsingIP is a happy-path roundtrip write test for SG connecting to CBS using valid X.509 certs for authentication.
 // The test enforces SG connects using an IP address which is also present in the node cert.
 func TestX509RoundtripUsingIP(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	tb, teardownFn, _, _, _ := setupX509Tests(t, true)
 	defer tb.Close()
@@ -49,7 +49,7 @@ func TestX509RoundtripUsingIP(t *testing.T) {
 // TestX509RoundtripUsingDomain is a happy-path roundtrip write test for SG connecting to CBS using valid X.509 certs for authentication.
 // The test enforces SG connects using a domain name which is also present in the node cert.
 func TestX509RoundtripUsingDomain(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	tb, teardownFn, _, _, _ := setupX509Tests(t, false)
 	defer tb.Close()
@@ -68,7 +68,7 @@ func TestX509RoundtripUsingDomain(t *testing.T) {
 }
 
 func TestX509UnknownAuthorityWrap(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	tb, teardownFn, _, _, _ := setupX509Tests(t, true)
 	defer tb.Close()


### PR DESCRIPTION
CBG-860

Replaces test functions of the kind `defer Foo()()` with `Foo(t)`, and makes them take advantage of `t.Cleanup()` to ensure they get run after the test. This ensures that it's impossible to forget the `defer` or the second `()`.

Because this changes almost every test, I've split the PR into two commits for ease of reviewing, one implementing the new signature and another updating them all to use it. This does mean that the first commit won't compile on its own.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/213/
