### PR TITLE
CBG-2027 Enhancements to GET /db/_user/

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -935,11 +935,6 @@ func (db *Database) processForEachDocIDResults(callback ForEachDocIDFunc, limit 
 	return nil
 }
 
-type principalsViewRow struct {
-	Key   string // principal name
-	Value bool   // 'isUser' flag
-}
-
 // Returns the IDs of all users and roles
 func (db *DatabaseContext) AllPrincipalIDs(ctx context.Context) (users, roles []string, err error) {
 
@@ -1014,6 +1009,86 @@ outerLoop:
 	}
 
 	return users, roles, nil
+}
+
+// Returns user information for all users (ID, disabled, email)
+func (db *DatabaseContext) GetUsers(ctx context.Context, limit int) (users []PrincipalConfig, err error) {
+
+	if db.Options.UseViews {
+		return nil, errors.New("GetUsers not supported when running with useViews=true")
+	}
+
+	// While using SyncDocs index, must set startKey to the user prefix to avoid unwanted interaction between
+	// limit handling and startKey (non-user _sync: prefixed documents being included in the query limit evaluation).
+	// This doesn't happen for AllPrincipalIDs, I believe because the role check forces query to not assume
+	// a contiguous set of results
+	startKey := base.UserPrefix
+	paginationLimit := db.Options.QueryPaginationLimit
+	if paginationLimit == 0 {
+		paginationLimit = DefaultQueryPaginationLimit
+	}
+
+	// If the requested limit is lower than the pagination limit, use requested limit as pagination limit
+	if limit > 0 && limit < paginationLimit {
+		paginationLimit = limit
+	}
+
+	users = []PrincipalConfig{}
+
+	totalCount := 0
+
+outerLoop:
+	for {
+		results, err := db.QueryUsers(ctx, startKey, paginationLimit)
+		if err != nil {
+			return nil, err
+		}
+
+		resultCount := 0
+		for {
+			// startKey is inclusive, so need to skip first result if using non-empty startKey, as this results in an overlapping result
+			var skipAddition bool
+			if resultCount == 0 && startKey != "" {
+				skipAddition = true
+			}
+
+			var queryRow QueryUsersRow
+			found := results.Next(&queryRow)
+			if !found {
+				break
+			}
+			startKey = base.UserPrefix + queryRow.Name
+			resultCount++
+			if queryRow.Name != "" && !skipAddition {
+				principal := PrincipalConfig{
+					Name:     &queryRow.Name,
+					Email:    queryRow.Email,
+					Disabled: &queryRow.Disabled,
+				}
+				users = append(users, principal)
+				totalCount++
+				if limit > 0 && totalCount >= limit {
+					break
+				}
+			}
+		}
+
+		closeErr := results.Close()
+		if closeErr != nil {
+			return nil, closeErr
+		}
+
+		if resultCount < paginationLimit {
+			break outerLoop
+		}
+
+		if limit > 0 && totalCount >= limit {
+			break outerLoop
+		}
+
+	}
+
+	return users, nil
 }
 
 // ////// HOUSEKEEPING:
@@ -1601,6 +1676,7 @@ func initDatabaseStats(dbName string, autoImport bool, options DatabaseContextOp
 			QueryTypeTombstones,
 			QueryTypeResync,
 			QueryTypeAllDocs,
+			QueryTypeUsers,
 		}
 	}
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2463,6 +2463,48 @@ func TestTombstoneCompactionStopWithManager(t *testing.T) {
 	assert.Equal(t, QueryTombstoneBatch, int(tombstoneCompactionStatus.DocsPurged))
 }
 
+func TestGetAllUsers(t *testing.T) {
+
+	if base.TestsDisableGSI() {
+		t.Skip("This test only works with Couchbase Server and UseViews=false")
+	}
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
+
+	db := setupTestDB(t)
+	db.Options.QueryPaginationLimit = 100
+	defer db.Close()
+
+	db.ChannelMapper = channels.NewDefaultChannelMapper()
+
+	log.Printf("Creating users...")
+	// Create users
+	authenticator := db.Authenticator(base.TestCtx(t))
+	user, _ := authenticator.NewUser("userA", "letmein", channels.SetOf(t, "ABC"))
+	_ = user.SetEmail("userA@test.org")
+	assert.NoError(t, authenticator.Save(user))
+	user, _ = authenticator.NewUser("userB", "letmein", channels.SetOf(t, "ABC"))
+	_ = user.SetEmail("userB@test.org")
+	assert.NoError(t, authenticator.Save(user))
+	user, _ = authenticator.NewUser("userC", "letmein", channels.SetOf(t, "ABC"))
+	user.SetDisabled(true)
+	assert.NoError(t, authenticator.Save(user))
+	user, _ = authenticator.NewUser("userD", "letmein", channels.SetOf(t, "ABC"))
+	assert.NoError(t, authenticator.Save(user))
+
+	log.Printf("Getting users...")
+	users, err := db.GetUsers(base.TestCtx(t), 0)
+	assert.NoError(t, err)
+	assert.Equal(t, 4, len(users))
+	log.Printf("THE USERS: %+v", users)
+	marshalled, err := json.Marshal(users)
+	log.Printf("THE USERS MARSHALLED: %s", marshalled)
+
+	limitedUsers, err := db.GetUsers(base.TestCtx(t), 2)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(limitedUsers))
+}
+
 func waitAndAssertConditionWithOptions(t *testing.T, fn func() bool, retryCount, msSleepTime int, failureMsgAndArgs ...interface{}) {
 	for i := 0; i <= retryCount; i++ {
 		if i == retryCount {

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -54,6 +54,12 @@ const (
 	ViewTombstones                  = "tombstones"
 )
 
+// Principals view result row
+type principalsViewRow struct {
+	Key   string // principal name
+	Value bool   // 'isUser' flag
+}
+
 func isInternalDDoc(ddocName string) bool {
 	return strings.HasPrefix(ddocName, "sync_")
 }

--- a/docs/api/components/parameters.yaml
+++ b/docs/api/components/parameters.yaml
@@ -459,3 +459,19 @@ disable_oidc_validation:
   schema:
     type: boolean
     default: false
+usersNameOnly:
+  name: name_only
+  in: query
+  required: false
+  schema:
+    type: boolean
+    default: true
+  description: Whether to return user names only, or more detailed information for each user.
+usersLimit:
+  name: limit
+  in: query
+  required: false
+  schema:
+    type: integer
+  description: How many results to return. Using a value of `0` results in no limit.
+

--- a/docs/api/paths/admin/{db}~_user~.yaml
+++ b/docs/api/paths/admin/{db}~_user~.yaml
@@ -10,13 +10,16 @@ get:
     * Sync Gateway Architect
     * Sync Gateway Application
     * Sync Gateway Application Read Only
+  parameters:
+    - $ref: ../../components/parameters.yaml#/usersNameOnly
+    - $ref: ../../components/parameters.yaml#/usersLimit
   responses:
     "200":
       description: Users retrieved successfully
       content:
         application/json:
           schema:
-            description: List of all user names
+            description: List of users
             type: array
             items:
               type: string

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1339,8 +1339,12 @@ func (h *handler) getUsers() error {
 		}
 		bytes, marshalErr = base.JSONMarshal(users)
 	}
+
+	if marshalErr != nil {
+		return marshalErr
+	}
 	h.writeRawJSON(bytes)
-	return marshalErr
+	return nil
 }
 
 func (h *handler) getRoles() error {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -30,6 +30,10 @@ const kDefaultDBOnlineDelay = 0
 
 const paramDisableOIDCValidation = "disable_oidc_validation"
 
+// GetUsers  - GET /{db}/_user/
+const paramNameOnly = "name_only"
+const paramLimit = "limit"
+
 // ////// DATABASE MAINTENANCE:
 
 // "Create" a database (actually just register an existing bucket)
@@ -1309,13 +1313,34 @@ func (h *handler) getRoleInfo() error {
 }
 
 func (h *handler) getUsers() error {
-	users, _, err := h.db.AllPrincipalIDs(h.db.Ctx)
-	if err != nil {
-		return err
+
+	limit := h.getIntQuery(paramLimit, 0)
+	nameOnly, _ := h.getOptBoolQuery(paramNameOnly, true)
+
+	if limit > 0 && nameOnly {
+		return base.HTTPErrorf(http.StatusBadRequest, fmt.Sprintf("Use of %s only supported when %s=false", paramLimit, paramNameOnly))
 	}
-	bytes, err := base.JSONMarshal(users)
+
+	var bytes []byte
+	var marshalErr error
+	if nameOnly {
+		users, _, err := h.db.AllPrincipalIDs(h.db.Ctx)
+		if err != nil {
+			return err
+		}
+		bytes, marshalErr = base.JSONMarshal(users)
+	} else {
+		if h.db.Options.UseViews {
+			return base.HTTPErrorf(http.StatusBadRequest, fmt.Sprintf("Use of %s=false not supported when database has use_views=true", paramNameOnly))
+		}
+		users, err := h.db.GetUsers(h.db.Ctx, int(limit))
+		if err != nil {
+			return err
+		}
+		bytes, marshalErr = base.JSONMarshal(users)
+	}
 	h.writeRawJSON(bytes)
-	return err
+	return marshalErr
 }
 
 func (h *handler) getRoles() error {


### PR DESCRIPTION
Adds the ability to include email and disabled values when retrieving all users via GET /db/_user/ by setting name_only=false.  Also supports specifying a limit on that REST API when name_only=false is being used.

Views support is not required (and not included, as it would require an update to view definitions).  For 3.1.0 we plan to support this functionality more generally with new indexes on the system collection, but putting this in master for the time being.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/222/ - full run with views
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/223/ - new test with GSI

