### PR TITLE
[3.0.1 Backport] CBG-2032: Backport CBG-2023: Prevent use of internal underscore properties

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -875,6 +875,11 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 		bh.replicationStats.HandleRevDeltaRecvCount.Add(1)
 	}
 
+	err = validateBlipBody(bodyBytes, newDoc)
+	if err != nil {
+		return err
+	}
+
 	// Handle and pull out expiry
 	if bytes.Contains(bodyBytes, []byte(BodyExpiry)) {
 		body := newDoc.Body()

--- a/db/crud.go
+++ b/db/crud.go
@@ -820,6 +820,11 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 
 	delete(body, BodyRevisions)
 
+	err = validateAPIDocUpdate(body)
+	if err != nil {
+		return "", nil, err
+	}
+
 	allowImport := db.UseXattrs()
 	doc, newRevID, err = db.updateAndReturnDoc(newDoc.ID, allowImport, expiry, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 
@@ -1021,6 +1026,11 @@ func (db *Database) PutExistingRevWithConflictResolution(newDoc *Document, docHi
 }
 
 func (db *Database) PutExistingRevWithBody(docid string, body Body, docHistory []string, noConflicts bool) (doc *Document, newRev string, err error) {
+	err = validateAPIDocUpdate(body)
+	if err != nil {
+		return nil, "", err
+	}
+
 	expiry, _ := body.ExtractExpiry()
 	deleted := body.ExtractDeleted()
 	revid := body.ExtractRev()
@@ -1037,6 +1047,7 @@ func (db *Database) PutExistingRevWithBody(docid string, body Body, docHistory [
 
 	newDoc.DocAttachments = GetBodyAttachments(body)
 	delete(body, BodyAttachments)
+
 	newDoc.UpdateBody(body)
 
 	doc, newRevID, putExistingRevErr := db.PutExistingRev(newDoc, docHistory, noConflicts, false, nil)
@@ -1299,27 +1310,6 @@ func (db *Database) tombstoneActiveRevision(doc *Document, revID string) (tombst
 	doc.RemoveBody()
 
 	return newRevID, nil
-}
-
-func (db *Database) validateExistingDoc(doc *Document, importAllowed, docExists bool) error {
-	if !importAllowed && docExists && !doc.HasValidSyncData() {
-		return base.HTTPErrorf(409, "Not imported")
-	}
-	return nil
-}
-
-func validateNewBody(body Body) error {
-	// Reject a body that contains the "_removed" property, this means that the user
-	// is trying to update a document they do not have read access to.
-	if body[BodyRemoved] != nil {
-		return base.HTTPErrorf(http.StatusNotFound, "Document revision is not accessible")
-	}
-
-	// Reject bodies that contains the "_purged" property.
-	if body[BodyPurged] != nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "user defined top level property '_purged' is not allowed in document body")
-	}
-	return nil
 }
 
 func (doc *Document) updateWinningRevAndSetDocFlags() {
@@ -1631,7 +1621,6 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 		return
 	}
 
-	// TODO: seems a bit late to do this. Could we move it earlier?
 	err = validateNewBody(syncFnBody)
 	if err != nil {
 		return

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2471,7 +2471,7 @@ func TestGetAllUsers(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges)()
 
 	db := setupTestDB(t)
 	db.Options.QueryPaginationLimit = 100

--- a/db/import.go
+++ b/db/import.go
@@ -42,13 +42,12 @@ func (db *Database) ImportDocRaw(docid string, value []byte, xattrValue []byte, 
 			base.Infof(base.KeyImport, "Unmarshal error during importDoc %v", err)
 			return nil, err
 		}
-		if body == nil {
-			return nil, base.ErrEmptyDocument
-		}
-	}
 
-	if isPurged, ok := body[BodyPurged].(bool); ok && isPurged {
-		return nil, base.ErrImportCancelledPurged
+		err = validateImportBody(body)
+		if err != nil {
+			return nil, err
+		}
+		delete(body, BodyPurged)
 	}
 
 	// Get the doc expiry if it wasn't passed in, and this isn't a server tombstone

--- a/db/validation.go
+++ b/db/validation.go
@@ -1,0 +1,85 @@
+package db
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+
+	"github.com/couchbase/sync_gateway/base"
+)
+
+// validateNewBody validates any new body being received (i.e. through blip, import, and API)
+func validateNewBody(body Body) error {
+	// Reject a body that contains the "_removed" property, this means that the user
+	// is trying to update a document they do not have read access to.
+	if body[BodyRemoved] != nil {
+		return base.HTTPErrorf(http.StatusNotFound, "Document revision is not accessible")
+	}
+
+	// Reject bodies that contains the "_purged" property.
+	if _, ok := body[BodyPurged]; ok {
+		return base.HTTPErrorf(http.StatusBadRequest, "user defined top-level property '_purged' is not allowed in document body")
+	}
+
+	for key := range body {
+		if strings.HasPrefix(key, BodyInternalPrefix) {
+			base.Warnf("user defined top-level properties that start with '_sync_' should not be in the document body")
+		}
+	}
+	return nil
+}
+
+// validateAPIDocUpdate finds disallowed document properties that are allowed in through blip and/or import but not through
+// the REST API
+func validateAPIDocUpdate(body Body) error {
+	// Validation for disallowed properties for blip and import should be done in validateNewBody
+	// _rev, _attachments, _id are validated before reaching this function (due to endpoint specific behaviour)
+	if _, ok := body[base.SyncPropertyName]; ok {
+		base.Warnf("document-top level property '_sync' is an internal property and should not be set")
+	}
+	return nil
+}
+
+// validateImportBody validates incoming import bodies
+func validateImportBody(body Body) error {
+	if body == nil {
+		return base.ErrEmptyDocument
+	}
+
+	if isPurged, ok := body[BodyPurged].(bool); ok && isPurged {
+		return base.ErrImportCancelledPurged
+	}
+
+	// Warn when an internal properties is used
+	disallowed := []string{BodyId, BodyRev, BodyExpiry, BodyRevisions}
+	for _, prop := range disallowed {
+		if _, ok := body[prop]; ok {
+			base.Warnf("top-level property '" + prop + "' is a reserved internal property and should not be set")
+		}
+	}
+
+	return nil
+}
+
+// validateBlipBody validates incoming blip rev bodies
+// Takes a rawBody to avoid an unnecessary call to doc.BodyBytes()
+func validateBlipBody(rawBody []byte, doc *Document) error {
+	// Warn when an internal properties is used
+	disallowed := []string{base.SyncPropertyName, BodyId, BodyRev, BodyDeleted, BodyRevisions}
+	for _, prop := range disallowed {
+		// Only unmarshal if raw body contains the disallowed property
+		if bytes.Contains(rawBody, []byte(`"`+prop+`"`)) {
+			if _, ok := doc.Body()[prop]; ok {
+				base.Warnf("top-level property '" + prop + "' is an internal property and should not be set")
+			}
+		}
+	}
+	return nil
+}
+
+func (db *Database) validateExistingDoc(doc *Document, importAllowed, docExists bool) error {
+	if !importAllowed && docExists && !doc.HasValidSyncData() {
+		return base.HTTPErrorf(409, "Not imported")
+	}
+	return nil
+}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4193,14 +4193,6 @@ func TestImportingPurgedDocument(t *testing.T) {
 	assert.Equal(t, numErrors, numErrorsAfter)
 }
 
-func TestRestSettingPurged(t *testing.T) {
-	rt := NewRestTester(t, nil)
-	defer rt.Close()
-
-	response := rt.SendAdminRequest("PUT", "/db/doc1", `{"_purged": true, "foo": "bar"}`)
-	assert.Equal(t, http.StatusBadRequest, response.Code)
-}
-
 func TestDocIDFilterResurrection(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -5883,7 +5883,7 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 
 	// Create the document
 	docID := t.Name()
-	rawDoc := `{"_id": "replaced", "_foo": true, "_exp": 120, "true": false, "_attachments": {"bar": {"data": "Zm9vYmFy"}}}`
+	rawDoc := `{"_foo": true, "_exp": 120, "true": false, "_attachments": {"bar": {"data": "Zm9vYmFy"}}}`
 	_ = activeRT.putDoc(docID, rawDoc)
 
 	// Set-up replicator
@@ -5919,7 +5919,6 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 
 	// Assert document was replicated successfully
 	doc := passiveRT.getDoc(docID)
-	assert.EqualValues(t, docID, doc["_id"])  // Confirm ID gets replaced with doc ID
 	assert.EqualValues(t, true, doc["_foo"])  // Confirm user defined value got created
 	assert.EqualValues(t, nil, doc["_exp"])   // Confirm expiry was consumed
 	assert.EqualValues(t, false, doc["true"]) // Sanity check normal keys
@@ -5930,7 +5929,7 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 	// Edit existing document
 	rev := doc["_rev"]
 	require.NotNil(t, rev)
-	rawDoc = fmt.Sprintf(`{"_id": "replaced", "_rev": "%s","_foo": false, "test": true}`, rev)
+	rawDoc = fmt.Sprintf(`{"_rev": "%s","_foo": false, "test": true}`, rev)
 	_ = activeRT.putDoc(docID, rawDoc)
 
 	// Replicate modified document
@@ -5947,7 +5946,6 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 	// Verify document replicated successfully
 	doc = passiveRT.getDoc(docID)
 	assert.NotEqual(t, doc["_rev"], rev)      // Confirm rev got replaced with new rev
-	assert.EqualValues(t, docID, doc["_id"])  // Confirm ID gets replaced with doc ID
 	assert.EqualValues(t, false, doc["_foo"]) // Confirm user defined value got created
 	assert.EqualValues(t, true, doc["test"])
 	// Confirm attachment was removed successfully in latest revision

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1217,8 +1217,6 @@ func (bt *BlipTester) SendRevWithAttachment(input SendRevWithAttachmentInput) (s
 		}
 	}
 
-	doc.SetID(input.docId)
-	doc.SetRevID(input.revId)
 	doc.SetAttachments(db.AttachmentMap{
 		input.attachmentName: &myAttachment,
 	})


### PR DESCRIPTION
CBG-2032

Backport of CBG-2023: Prevent use of internal underscore properties
- Replaced errors with warnings except for `_purged`, `_removed` and for checking ID and rev matches for REST API endpoints

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/239
