### PR TITLE
CBD-4731: Fix example file attributes

### DIFF
--- a/build/rpm.spec.tmpl
+++ b/build/rpm.spec.tmpl
@@ -211,7 +211,7 @@ exit 0
 
 %attr (0755, bin, bin) @@PREFIX@@/bin/*
 %attr (0755, bin, bin) @@PREFIX@@/tools/*
-%attr (0644, bin, bin) @@PREFIX@@/examples/*
+%attr (0755, bin, bin) @@PREFIX@@/examples/*
 %attr (0755, bin, bin) @@PREFIX@@/service/*
 %attr (0644, bin, bin) @@PREFIX@@/LICENSE.txt
 %attr (0644, bin, bin) @@PREFIX@@/manifest.txt


### PR DESCRIPTION
CBD-4731

This change corrects the permissions on the contents of the examples directory