### PR TITLE
Jenkins master integration runs with CBS 7.0.3 by default and various test fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -381,5 +381,13 @@ pipeline {
                 }
             }
         }
+        aborted {
+            archiveArtifacts excludes: 'verbose_*.out', artifacts: '*.out', fingerprint: false, allowEmptyArchive: true
+            script {
+                if ("${env.BRANCH_NAME}" == 'master') {
+                    slackSend color: "danger", message: "Master SGW pipeline build aborted: ${currentBuild.fullDisplayName}\nCould be due to build timeout: ${env.BUILD_URL}"
+                }
+            }
+        }
     }
 }

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -53,6 +53,7 @@ func TestFilterToAvailableChannels(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			db := setupTestDB(t)
+			defer db.Close()
 
 			auth := db.Authenticator(base.TestCtx(t))
 			user, err := auth.NewUser("test", "pass", testCase.userChans)
@@ -81,8 +82,6 @@ func TestFilterToAvailableChannels(t *testing.T) {
 				}
 			}
 			assert.True(t, match)
-
-			db.Close()
 		})
 	}
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1858,6 +1858,8 @@ func TestNewDatabaseContextWithOIDCProviderOptionErrors(t *testing.T) {
 	}()
 
 	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close()
+
 	tests := []struct {
 		name          string
 		inputOptions  *auth.OIDCOptions
@@ -1901,8 +1903,6 @@ func TestNewDatabaseContextWithOIDCProviderOptionErrors(t *testing.T) {
 			assert.Nil(t, context, "Database context shouldn't be created")
 		})
 	}
-
-	testBucket.Close()
 }
 
 func TestNewDatabaseContextWithOIDCProviderOptions(t *testing.T) {

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -15,7 +15,7 @@ if [ "$1" == "-m" ]; then
     RUN_COUNT="1"
     # CBS server settings
     COUCHBASE_SERVER_PROTOCOL="couchbase"
-    COUCHBASE_SERVER_VERSION="latest"
+    COUCHBASE_SERVER_VERSION="enterprise-7.0.3"
     SG_TEST_BUCKET_POOL_SIZE="3"
     SG_TEST_BUCKET_POOL_DEBUG="true"
     GSI="false"

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2133,8 +2133,8 @@ func TestAllDocsAccessControl(t *testing.T) {
 	allDocsResult := allDocsResponse{}
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.NoError(t, err)
-	assert.Equal(t, 3, len(allDocsResult.Rows))
+	require.NoError(t, err)
+	require.Equal(t, 3, len(allDocsResult.Rows))
 	assert.Equal(t, "doc3", allDocsResult.Rows[0].ID)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 	assert.Equal(t, "doc4", allDocsResult.Rows[1].ID)
@@ -2151,7 +2151,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	log.Printf("Response = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(allDocsResult.Rows))
 	assert.Equal(t, "doc3", allDocsResult.Rows[0].ID)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
@@ -2165,8 +2165,8 @@ func TestAllDocsAccessControl(t *testing.T) {
 	log.Printf("Response = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(allDocsResult.Rows))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(allDocsResult.Rows))
 	assert.Equal(t, "doc5", allDocsResult.Rows[0].ID)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 
@@ -2179,8 +2179,8 @@ func TestAllDocsAccessControl(t *testing.T) {
 	log.Printf("Response = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(allDocsResult.Rows))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(allDocsResult.Rows))
 	assert.Equal(t, "doc5", allDocsResult.Rows[0].ID)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 
@@ -2193,8 +2193,8 @@ func TestAllDocsAccessControl(t *testing.T) {
 	log.Printf("Response = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(allDocsResult.Rows))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(allDocsResult.Rows))
 	assert.Equal(t, "doc3", allDocsResult.Rows[0].ID)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 
@@ -2207,8 +2207,8 @@ func TestAllDocsAccessControl(t *testing.T) {
 	log.Printf("Response = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(allDocsResult.Rows))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(allDocsResult.Rows))
 	assert.Equal(t, "doc3", allDocsResult.Rows[0].ID)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 
@@ -2221,8 +2221,8 @@ func TestAllDocsAccessControl(t *testing.T) {
 	log.Printf("Response = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.NoError(t, err)
-	assert.Equal(t, 3, len(allDocsResult.Rows))
+	require.NoError(t, err)
+	require.Equal(t, 3, len(allDocsResult.Rows))
 	assert.Equal(t, "doc3", allDocsResult.Rows[0].ID)
 	assert.Equal(t, "doc4", allDocsResult.Rows[1].ID)
 	assert.Equal(t, "doc5", allDocsResult.Rows[2].ID)
@@ -2237,8 +2237,8 @@ func TestAllDocsAccessControl(t *testing.T) {
 	log.Printf("Response from POST _all_docs = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.NoError(t, err)
-	assert.Equal(t, 4, len(allDocsResult.Rows))
+	require.NoError(t, err)
+	require.Equal(t, 4, len(allDocsResult.Rows))
 	assert.Equal(t, "doc4", allDocsResult.Rows[0].Key)
 	assert.Equal(t, "doc4", allDocsResult.Rows[0].ID)
 	assert.Equal(t, "1-e0351a57554e023a77544d33dd21e56c", allDocsResult.Rows[0].Value.Rev)
@@ -2262,8 +2262,8 @@ func TestAllDocsAccessControl(t *testing.T) {
 	log.Printf("Response from GET _all_docs = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.NoError(t, err)
-	assert.Equal(t, 4, len(allDocsResult.Rows))
+	require.NoError(t, err)
+	require.Equal(t, 4, len(allDocsResult.Rows))
 	assert.Equal(t, "doc4", allDocsResult.Rows[0].Key)
 	assert.Equal(t, "doc4", allDocsResult.Rows[0].ID)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
@@ -2284,8 +2284,8 @@ func TestAllDocsAccessControl(t *testing.T) {
 	log.Printf("Response from POST _all_docs = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(allDocsResult.Rows))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(allDocsResult.Rows))
 	assert.Equal(t, "doc4", allDocsResult.Rows[0].Key)
 	assert.Equal(t, "doc4", allDocsResult.Rows[0].ID)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
@@ -2297,8 +2297,8 @@ func TestAllDocsAccessControl(t *testing.T) {
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.NoError(t, err)
-	assert.Equal(t, 5, len(allDocsResult.Rows))
+	require.NoError(t, err)
+	require.Equal(t, 5, len(allDocsResult.Rows))
 	assert.Equal(t, "doc1", allDocsResult.Rows[0].ID)
 	assert.Equal(t, "doc2", allDocsResult.Rows[1].ID)
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3664,6 +3664,7 @@ func TestEventConfigValidationSuccess(t *testing.T) {
 	}
 
 	sc := NewServerContext(&StartupConfig{}, false)
+	defer sc.Close()
 
 	// Valid config
 	configJSON := `{"name": "default",
@@ -3688,9 +3689,6 @@ func TestEventConfigValidationSuccess(t *testing.T) {
 
 	_, err = sc.AddDatabaseFromConfig(DatabaseConfig{DbConfig: dbConfig})
 	assert.True(t, err == nil)
-
-	sc.Close()
-
 }
 
 func TestEventConfigValidationInvalid(t *testing.T) {
@@ -4205,6 +4203,7 @@ func TestLongpollWithWildcard(t *testing.T) {
 func TestUnsupportedConfig(t *testing.T) {
 
 	sc := NewServerContext(&StartupConfig{}, false)
+	defer sc.Close()
 	testProviderOnlyJSON := `{"name": "test_provider_only",
         			"server": "walrus:",
         			"bucket": "test_provider_only",
@@ -4269,8 +4268,6 @@ func TestUnsupportedConfig(t *testing.T) {
 
 	_, err = sc.AddDatabaseFromConfig(DatabaseConfig{DbConfig: viewsAndTestConfig})
 	assert.NoError(t, err, "Error adding viewsAndTestConfig database.")
-
-	sc.Close()
 }
 
 func TestImportingPurgedDocument(t *testing.T) {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1217,9 +1217,9 @@ func TestSetupServerContext(t *testing.T) {
 		config.Bootstrap.Username = base.TestClusterUsername()
 		config.Bootstrap.Password = base.TestClusterPassword()
 		sc, err := setupServerContext(&config, false)
+		defer sc.Close()
 		require.NoError(t, err)
 		require.NotNil(t, sc)
-		sc.Close()
 	})
 }
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -350,6 +350,11 @@ func TestStartAndStopHTTPServers(t *testing.T) {
 		serveErr <- startServer(&config, sc)
 	}()
 
+	defer func() {
+		sc.Close()
+		require.NoError(t, <-serveErr)
+	}()
+
 	err, _ = base.RetryLoop("try http request", func() (shouldRetry bool, err error, value interface{}) {
 		resp, err := http.Get("http://" + config.API.PublicInterface)
 		if err != nil {
@@ -359,10 +364,6 @@ func TestStartAndStopHTTPServers(t *testing.T) {
 		return false, nil, nil
 	}, base.CreateMaxDoublingSleeperFunc(10, 10, 1000))
 	assert.NoError(t, err)
-
-	sc.Close()
-
-	assert.NoError(t, <-serveErr)
 }
 
 // CBG-1518 - Test CA Certificate behaviour with and with Bootstrap.ServerTLSSkipVerify


### PR DESCRIPTION
- Tests defer teardown functions (where possible). This is for server context creations, database creations, and rest tester creations.
- Jenkins pipeline runs will now send a Slack message if the master integration run is aborted. This is so a message is sent if the build times out (currently after 1h).
- Fixed a test causing panic when it fails
- Master integration runs use `couchbase/server:enterprise-7.0.3` image by default.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/235/ `known flaky test fail`
