### PR TITLE
CBG-2053: Added stat tracking for connected client putRev messages

### DIFF
--- a/db/blip_connected_client.go
+++ b/db/blip_connected_client.go
@@ -64,7 +64,7 @@ func (bh *blipHandler) handlePutRev(rq *blip.Message) error {
 		deltaRecvCount:  bh.replicationStats.HandlePutRevDeltaRecvCount,
 		bytes:           bh.replicationStats.HandlePutRevBytes,
 		processingTime:  bh.replicationStats.HandlePutRevProcessingTime,
-		docsPurgedCount: bh.replicationStats.HandlePutRevCount,
+		docsPurgedCount: bh.replicationStats.HandlePutRevDocsPurgedCount,
 	}
 	return bh.processRev(rq, stats)
 }

--- a/db/blip_connected_client.go
+++ b/db/blip_connected_client.go
@@ -66,5 +66,5 @@ func (bh *blipHandler) handlePutRev(rq *blip.Message) error {
 		processingTime:  bh.replicationStats.HandlePutRevProcessingTime,
 		docsPurgedCount: bh.replicationStats.HandlePutRevDocsPurgedCount,
 	}
-	return bh.processRev(rq, stats)
+	return bh.processRev(rq, &stats)
 }

--- a/db/blip_connected_client.go
+++ b/db/blip_connected_client.go
@@ -52,15 +52,19 @@ func (bh *blipHandler) handleGetRev(rq *blip.Message) error {
 	response.SetCompressed(true)
 	response.Properties[GetRevRevId] = rev.RevID
 	response.SetBody(bodyBytes)
-	bh.replicationStats.HandleGetRev.Add(1)
+	bh.replicationStats.HandleGetRevCount.Add(1)
 	return nil
 }
 
 // Handles a Connected-Client "putRev" request.
 func (bh *blipHandler) handlePutRev(rq *blip.Message) error {
-	//FIXME: This should probably not just call into `handleRev`, which
-	// looks like it does some stuff specific to replication.
-	err := bh.handleRev(rq)
-	bh.replicationStats.HandlePutRev.Add(1)
-	return err
+	stats := processRevStats{
+		count:           bh.replicationStats.HandlePutRevCount,
+		errorCount:      bh.replicationStats.HandlePutRevErrorCount,
+		deltaRecvCount:  bh.replicationStats.HandlePutRevDeltaRecvCount,
+		bytes:           bh.replicationStats.HandlePutRevBytes,
+		processingTime:  bh.replicationStats.HandlePutRevProcessingTime,
+		docsPurgedCount: bh.replicationStats.HandlePutRevCount,
+	}
+	return bh.processRev(rq, stats)
 }

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -790,7 +790,8 @@ type processRevStats struct {
 }
 
 // Processes a "rev" request, i.e. client is pushing a revision body
-func (bh *blipHandler) processRev(rq *blip.Message, stats processRevStats) (err error) {
+// stats must always be provided, along with all the fields filled with valid pointers
+func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err error) {
 	startTime := time.Now()
 	defer func() {
 		stats.processingTime.Add(time.Since(startTime).Nanoseconds())
@@ -1058,7 +1059,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 		processingTime:  bh.replicationStats.HandleRevProcessingTime,
 		docsPurgedCount: bh.replicationStats.HandleRevDocsPurgedCount,
 	}
-	return bh.processRev(rq, stats)
+	return bh.processRev(rq, &stats)
 }
 
 // ////// ATTACHMENTS:

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1056,7 +1056,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 		deltaRecvCount:  bh.replicationStats.HandleRevDeltaRecvCount,
 		bytes:           bh.replicationStats.HandleRevBytes,
 		processingTime:  bh.replicationStats.HandleRevProcessingTime,
-		docsPurgedCount: bh.replicationStats.HandleRevCount,
+		docsPurgedCount: bh.replicationStats.HandleRevDocsPurgedCount,
 	}
 	return bh.processRev(rq, stats)
 }

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -780,15 +780,24 @@ type removalDocument struct {
 	Removed bool `json:"_removed"`
 }
 
-// Received a "rev" request, i.e. client is pushing a revision body
-func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
+type processRevStats struct {
+	count           *base.SgwIntStat // Increments when rev processed successfully
+	errorCount      *base.SgwIntStat
+	deltaRecvCount  *base.SgwIntStat
+	bytes           *base.SgwIntStat
+	processingTime  *base.SgwIntStat
+	docsPurgedCount *base.SgwIntStat
+}
+
+// Processes a "rev" request, i.e. client is pushing a revision body
+func (bh *blipHandler) processRev(rq *blip.Message, stats processRevStats) (err error) {
 	startTime := time.Now()
 	defer func() {
-		bh.replicationStats.HandleRevProcessingTime.Add(time.Since(startTime).Nanoseconds())
+		stats.processingTime.Add(time.Since(startTime).Nanoseconds())
 		if err == nil {
-			bh.BlipSyncContext.replicationStats.HandleRevCount.Add(1)
+			stats.count.Add(1)
 		} else {
-			bh.BlipSyncContext.replicationStats.HandleRevErrorCount.Add(1)
+			stats.errorCount.Add(1)
 		}
 	}()
 
@@ -804,7 +813,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 
 	base.TracefCtx(bh.loggingCtx, base.KeySyncMsg, "#%d: Properties:%v  Body:%s", bh.serialNumber, base.UD(revMessage.Properties), base.UD(string(bodyBytes)))
 
-	bh.replicationStats.HandleRevBytes.Add(int64(len(bodyBytes)))
+	stats.bytes.Add(int64(len(bodyBytes)))
 
 	// Doc metadata comes from the BLIP message metadata, not magic document properties:
 	docID, found := revMessage.ID()
@@ -823,7 +832,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 			if err := bh.db.Purge(docID); err != nil {
 				return err
 			}
-			bh.replicationStats.HandleRevDocsPurgedCount.Add(1)
+			stats.docsPurgedCount.Add(1)
 			if bh.sgr2PullProcessedSeqCallback != nil {
 				bh.sgr2PullProcessedSeqCallback(rq.Properties[RevMessageSequence], IDAndRev{DocID: docID, RevID: revID})
 			}
@@ -885,7 +894,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 
 		newDoc.UpdateBody(deltaSrcMap)
 		base.TracefCtx(bh.loggingCtx, base.KeySync, "docID: %s - body after patching: %v", base.UD(docID), base.UD(deltaSrcMap))
-		bh.replicationStats.HandleRevDeltaRecvCount.Add(1)
+		stats.deltaRecvCount.Add(1)
 	}
 
 	err = validateBlipBody(bodyBytes, newDoc)
@@ -1037,6 +1046,19 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 	}
 
 	return nil
+}
+
+// Handler for when a rev is received from the client
+func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
+	stats := processRevStats{
+		count:           bh.replicationStats.HandleRevCount,
+		errorCount:      bh.replicationStats.HandleRevErrorCount,
+		deltaRecvCount:  bh.replicationStats.HandleRevDeltaRecvCount,
+		bytes:           bh.replicationStats.HandleRevBytes,
+		processingTime:  bh.replicationStats.HandleRevProcessingTime,
+		docsPurgedCount: bh.replicationStats.HandleRevCount,
+	}
+	return bh.processRev(rq, stats)
 }
 
 // ////// ATTACHMENTS:

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -24,8 +24,13 @@ type BlipSyncStats struct {
 	HandleRevBytes                   *base.SgwIntStat
 	HandleRevProcessingTime          *base.SgwIntStat
 	HandleRevDocsPurgedCount         *base.SgwIntStat
-	HandleGetRev                     *base.SgwIntStat // Connected Client API
-	HandlePutRev                     *base.SgwIntStat // Connected Client API
+	HandleGetRevCount                *base.SgwIntStat // Connected Client API
+	HandlePutRevCount                *base.SgwIntStat // Connected Client API
+	HandlePutRevErrorCount           *base.SgwIntStat // Connected Client API
+	HandlePutRevDeltaRecvCount       *base.SgwIntStat // Connected Client API
+	HandlePutRevBytes                *base.SgwIntStat // Connected Client API
+	HandlePutRevProcessingTime       *base.SgwIntStat // Connected Client API
+	HandlePutRevDocsPurgedCount      *base.SgwIntStat // Connected Client API
 	SendRevCount                     *base.SgwIntStat // sendRev
 	SendRevDeltaRequestedCount       *base.SgwIntStat
 	SendRevDeltaSentCount            *base.SgwIntStat
@@ -66,8 +71,13 @@ func NewBlipSyncStats() *BlipSyncStats {
 		HandleRevBytes:                   &base.SgwIntStat{},
 		HandleRevProcessingTime:          &base.SgwIntStat{},
 		HandleRevDocsPurgedCount:         &base.SgwIntStat{},
-		HandleGetRev:                     &base.SgwIntStat{},
-		HandlePutRev:                     &base.SgwIntStat{},
+		HandleGetRevCount:                &base.SgwIntStat{},
+		HandlePutRevCount:                &base.SgwIntStat{},
+		HandlePutRevErrorCount:           &base.SgwIntStat{},
+		HandlePutRevDeltaRecvCount:       &base.SgwIntStat{},
+		HandlePutRevBytes:                &base.SgwIntStat{},
+		HandlePutRevProcessingTime:       &base.SgwIntStat{},
+		HandlePutRevDocsPurgedCount:      &base.SgwIntStat{},
 		SendRevCount:                     &base.SgwIntStat{}, // sendRev
 		SendRevDeltaRequestedCount:       &base.SgwIntStat{},
 		SendRevDeltaSentCount:            &base.SgwIntStat{},

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -4181,7 +4181,6 @@ func TestProcessRevIncrementsStat(t *testing.T) {
 	pullStats := ar.Pull.GetStats()
 	require.EqualValues(t, 0, pullStats.HandleRevCount.Value())
 	require.EqualValues(t, 0, pullStats.HandleRevBytes.Value())
-	require.EqualValues(t, 0, pullStats.HandleRevProcessingTime.Value())
 	require.EqualValues(t, 0, pullStats.HandlePutRevCount.Value())
 
 	rev := remoteRT.createDoc(t, "doc")
@@ -4196,7 +4195,6 @@ func TestProcessRevIncrementsStat(t *testing.T) {
 
 	assert.EqualValues(t, 1, pullStats.HandleRevCount.Value())
 	assert.NotEqualValues(t, 0, pullStats.HandleRevBytes.Value())
-	assert.NotEqualValues(t, 0, pullStats.HandleRevProcessingTime.Value())
 	// Confirm connected client count has not increased, which uses same processRev code
 	assert.EqualValues(t, 0, pullStats.HandlePutRevCount.Value())
 }


### PR DESCRIPTION
CBG-2053

- Added additional stats for `handlePutRev`, and modified existing stats
- Moved `handleRev` code to shared function `processRev` which both `handleRev` and `handlePutRev` now use
- Added stats mapping for `processRev` so `handleRev` and `handlePutRev` both can have their own independant stats
- Added test to make sure stats for `handleRev` still work correctly

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/240/
