### PR TITLE
CBG-2058: Always pass a terminator to Compact

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -67,9 +67,9 @@ func setupTestDBForBucketWithOptions(t testing.TB, tBucket base.Bucket, dbcOptio
 func setupTestDBWithOptionsAndImport(t testing.TB, dbcOptions DatabaseContextOptions) *Database {
 	AddOptionsFromEnvironmentVariables(&dbcOptions)
 	if dbcOptions.GroupID == "" && base.IsEnterpriseEdition() {
-		// In a real SG this would be set in DefaultStartupConfig.
-		dbcOptions.GroupID = "default"
-		RegisterImportPindexImpl("default")
+		// TODO: Once RegisterImportPindexImpl is moved into NewDatabaseContext this won't be necessary
+		dbcOptions.GroupID = t.Name()
+		RegisterImportPindexImpl(t.Name())
 	}
 	context, err := NewDatabaseContext("db", base.GetTestBucket(t), true, dbcOptions)
 	require.NoError(t, err, "Couldn't create context for database 'db'")

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2520,6 +2520,7 @@ func TestImportCompactPanic(t *testing.T) {
 	db := setupTestDBWithOptionsAndImport(t, DatabaseContextOptions{
 		CompactInterval: 1,
 	})
+	defer db.Close()
 	db.PurgeInterval = time.Millisecond
 
 	// Create a document, then delete it, to create a tombstone


### PR DESCRIPTION
CBG-2058

If SGW was left running long enough that the compaction background task runs (so only on nodes with import enabled), and there are tombstones present older than the metadata purge interval, the task would check that a nil terminator is complete and thus panic. This PR ensures we always pass down a terminator to Compact, as well as adding a regression test.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/249/
