### PR TITLE
CBG-2060: [3.0.1 Backport] CBG-2058: Always pass a terminator to Compact

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -540,8 +540,14 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 		if dbContext.Options.CompactInterval != 0 {
 			if autoImport {
 				db := Database{DatabaseContext: dbContext}
+				// Wrap the dbContext's terminator in a SafeTerminator for the compaction task
+				bgtTerminator := base.NewSafeTerminator()
+				go func() {
+					<-dbContext.terminator
+					bgtTerminator.Close()
+				}()
 				bgt, err := NewBackgroundTask("Compact", dbContext.Name, func(ctx context.Context) error {
-					_, err := db.Compact(false, func(purgedDocCount *int) {}, nil)
+					_, err := db.Compact(false, func(purgedDocCount *int) {}, bgtTerminator)
 					if err != nil {
 						base.WarnfCtx(ctx, "Error trying to compact tombstoned documents for %q with error: %v", dbContext.Name, err)
 					}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2530,7 +2530,7 @@ func TestImportCompactPanic(t *testing.T) {
 	require.NoError(t, err)
 	_, err = db.DeleteDoc(doc.ID, rev)
 	require.NoError(t, err)
-	require.NoError(t, db.WaitForPendingChanges(base.TestCtx(t)))
+	require.NoError(t, db.WaitForPendingChanges(context.Background()))
 
 	// Wait for Compact to run - in the failing case it'll panic before incrementing the stat
 	_, ok := base.WaitForStat(func() int64 {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -68,6 +68,11 @@ func setupTestDBForBucketWithOptions(t testing.TB, tBucket base.Bucket, dbcOptio
 
 func setupTestDBWithOptionsAndImport(t testing.TB, dbcOptions DatabaseContextOptions) *Database {
 	AddOptionsFromEnvironmentVariables(&dbcOptions)
+	if dbcOptions.GroupID == "" && base.IsEnterpriseEdition() {
+		// TODO: Once RegisterImportPindexImpl is moved into NewDatabaseContext this won't be necessary
+		dbcOptions.GroupID = t.Name()
+		RegisterImportPindexImpl(t.Name())
+	}
 	context, err := NewDatabaseContext("db", base.GetTestBucket(t), true, dbcOptions)
 	require.NoError(t, err, "Couldn't create context for database 'db'")
 	db, err := CreateDatabase(context)
@@ -2505,6 +2510,33 @@ func TestGetAllUsers(t *testing.T) {
 	limitedUsers, err := db.GetUsers(2)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(limitedUsers))
+}
+
+// Regression test for CBG-2058.
+func TestImportCompactPanic(t *testing.T) {
+	if !base.TestUseXattrs() {
+		t.Skip("requires xattrs")
+	}
+
+	// Set the compaction and purge interval unrealistically low to reproduce faster
+	db := setupTestDBWithOptionsAndImport(t, DatabaseContextOptions{
+		CompactInterval: 1,
+	})
+	defer db.Close()
+	db.PurgeInterval = time.Millisecond
+
+	// Create a document, then delete it, to create a tombstone
+	rev, doc, err := db.Put("test", Body{})
+	require.NoError(t, err)
+	_, err = db.DeleteDoc(doc.ID, rev)
+	require.NoError(t, err)
+	require.NoError(t, db.WaitForPendingChanges(base.TestCtx(t)))
+
+	// Wait for Compact to run - in the failing case it'll panic before incrementing the stat
+	_, ok := base.WaitForStat(func() int64 {
+		return db.DbStats.Database().NumTombstonesCompacted.Value()
+	}, 1)
+	require.True(t, ok)
 }
 
 func waitAndAssertConditionWithOptions(t *testing.T, fn func() bool, retryCount, msSleepTime int, failureMsgAndArgs ...interface{}) {


### PR DESCRIPTION
CBG-2060

Backports #5531 (CBG-2058) to 3.0.1.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/251/
