### PR TITLE
CBG-2064: Allow mapping OIDC claims to roles/channels

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -201,8 +201,10 @@ func (auth *Authenticator) rebuildChannels(princ Principal) error {
 		channels.Add(viewChannels)
 	}
 
-	if oidc := princ.OIDCChannels(); oidc != nil {
-		channels.Add(oidc)
+	if user, ok := princ.(User); ok {
+		if oidc := user.OIDCChannels(); oidc != nil {
+			channels.Add(oidc)
+		}
 	}
 
 	// always grant access to the public document channel

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -845,6 +845,10 @@ func (auth *Authenticator) UpdateUserOIDCRolesChannels(user_ User, issuer string
 			return nil, base.ErrUpdateCancel
 		}
 
+		if user.OIDCIssuer() == issuer && user.OIDCChannels().Equals(newOIDCChannels) && user.OIDCRoles().Equals(newOIDCRoles) {
+			return nil, base.ErrUpdateCancel
+		}
+
 		nextSeq := user.Sequence() + 1
 		user.SetSequence(nextSeq)
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -778,13 +778,14 @@ func (auth *Authenticator) authenticateOIDCIdentity(identity *Identity, provider
 	}
 
 	if user != nil {
-		name := user.Name()
+		now := time.Now()
 		updates = PrincipalConfig{
-			Name:         &name,
-			Email:        &identity.Email,
-			OIDCIssuer:   &provider.Issuer,
-			OIDCRoles:    oidcRoles,
-			OIDCChannels: oidcChannels,
+			Name:            base.StringPtr(user.Name()),
+			Email:           &identity.Email,
+			OIDCIssuer:      &provider.Issuer,
+			OIDCRoles:       oidcRoles,
+			OIDCChannels:    oidcChannels,
+			OIDCLastUpdated: &now,
 		}
 	}
 

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -467,24 +467,11 @@ func getJWTClaimAsSet(identity *Identity, claim string) (base.Set, error) {
 		return base.Set{}, nil
 	}
 
-	switch typed := val.(type) {
-	case string:
-		return base.SetOf(typed), nil
-	case []string:
-		return base.SetFromArray(typed), nil
-	case []interface{}: // could be a []string
-		result := make([]string, 0, len(typed))
-		for i, val := range typed {
-			strVal, ok := val.(string)
-			if !ok {
-				return base.Set{}, fmt.Errorf("invalid value at JWT payload[%q][%d]: expected string, got %T", base.UD(claim).Redact(), i, val)
-			}
-			result = append(result, strVal)
-		}
-		return base.SetFromArray(result), nil
-	default:
-		return base.Set{}, fmt.Errorf("invalid value at JWT payload[%q]: expected string or []string, got %T", base.UD(claim).Redact(), val)
+	strs, nonStrings := base.ValueToStringArray(val)
+	if len(nonStrings) > 0 {
+		return nil, fmt.Errorf("invalid claim value %v: non-strings present", base.UD(claim))
 	}
+	return base.SetFromArray(strs), nil
 }
 
 // fetchCustomProviderConfig collects the provider configuration from the given discovery endpoint and determines

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -159,6 +159,9 @@ type OIDCProvider struct {
 	// Sync Gateway and the underlying OIDC library.
 	UsernameClaim string `json:"username_claim"`
 
+	// RolesClaim and ChannelsClaim allow specifying a claim (which must be a string or string[]) to add roles/channels
+	// to users. These are added in addition to any other roles/channels the user may have (via the admin API or the
+	// sync function). If the claim is absent from the access/ID token, no roles/channels will be added.
 	RolesClaim    string `json:"roles_claim"`
 	ChannelsClaim string `json:"channels_claim"`
 

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -1213,9 +1213,15 @@ func TestOIDCRolesChannels(t *testing.T) {
 					Subject: testSubject,
 					Claims:  login.claims,
 				}
-				user, _, err = auth.authenticateOIDCIdentity(identity, provider)
+				var updates PrincipalConfig
+				user, updates, _, err = auth.authenticateOIDCIdentity(identity, provider)
 				require.NoError(t, err, "error on authenticateOIDCIdentity")
 				require.NotNil(t, user, "nil user")
+				user.SetOIDCChannels(ch.AtSequence(updates.OIDCChannels, user.Sequence()), user.Sequence())
+				user.SetOIDCRoles(ch.AtSequence(updates.OIDCRoles, user.Sequence()), user.Sequence())
+
+				require.NoError(t, auth.rebuildRoles(user))
+				require.NoError(t, auth.rebuildChannels(user))
 
 				if user.RoleNames() == nil {
 					require.Empty(t, login.expectedRoles, "user's roles were nil when we expected roles")

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -1184,8 +1184,9 @@ func TestOIDCRolesChannels(t *testing.T) {
 
 			for i, login := range tc.logins {
 				var (
-					user User
-					err  error
+					user           User
+					err            error
+					lastUpdateTime time.Time
 				)
 				if i == 0 {
 					user, err = auth.NewUser(testUserPrefix+"_"+testSubject, "test", base.SetFromArray(login.explicitChannels))
@@ -1219,6 +1220,7 @@ func TestOIDCRolesChannels(t *testing.T) {
 				require.NotNil(t, user, "nil user")
 				user.SetOIDCChannels(ch.AtSequence(updates.OIDCChannels, user.Sequence()), user.Sequence())
 				user.SetOIDCRoles(ch.AtSequence(updates.OIDCRoles, user.Sequence()), user.Sequence())
+				user.SetOIDCLastUpdated(*updates.OIDCLastUpdated)
 
 				require.NoError(t, auth.rebuildRoles(user))
 				require.NoError(t, auth.rebuildChannels(user))
@@ -1229,6 +1231,9 @@ func TestOIDCRolesChannels(t *testing.T) {
 					require.Equal(t, base.SetFromArray(login.expectedRoles), user.RoleNames().AsSet())
 				}
 				require.Equal(t, base.SetFromArray(login.expectedChannels), user.Channels().AsSet())
+
+				require.Greater(t, user.OIDCLastUpdated(), lastUpdateTime)
+				lastUpdateTime = user.OIDCLastUpdated()
 			}
 		})
 	}

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/coreos/go-oidc"
 	"github.com/couchbase/sync_gateway/base"
+	ch "github.com/couchbase/sync_gateway/channels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/square/go-jose.v2"
@@ -981,6 +982,248 @@ func TestFormatUsername(t *testing.T) {
 			username, err := formatUsername(tc.username)
 			assert.Equal(t, tc.errorExpected, err)
 			assert.Equal(t, tc.usernameExpected, username)
+		})
+	}
+}
+
+func TestOIDCRolesChannels(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth, base.KeyAccess)
+	const (
+		testUserPrefix = "foo"
+		testIssuer     = "https://example.com"
+		testSubject    = "frodo"
+	)
+	type simulatedLogin struct {
+		explicitRoles, explicitChannels []string
+		claims                          map[string]interface{}
+		expectedRoles, expectedChannels []string
+	}
+	type testCase struct {
+		name                              string
+		rolesClaimName, channelsClaimName string
+		logins                            []simulatedLogin
+	}
+	cases := []testCase{
+		{
+			name: "base",
+			logins: []simulatedLogin{
+				{
+					expectedRoles:    []string{},
+					expectedChannels: []string{"!"},
+				},
+			},
+		},
+		{
+			name:           "roles from OIDC",
+			rolesClaimName: "roles",
+			logins: []simulatedLogin{
+				{
+					claims:           map[string]interface{}{"roles": []string{"foo"}},
+					expectedRoles:    []string{"foo"},
+					expectedChannels: []string{"!"},
+				},
+			},
+		},
+		{
+			name:           "claim is missing",
+			rolesClaimName: "roles",
+			logins: []simulatedLogin{
+				{
+					claims:           map[string]interface{}{},
+					expectedRoles:    []string{},
+					expectedChannels: []string{"!"},
+				},
+			},
+		},
+		{
+			name:           "combine explicit and OIDC roles",
+			rolesClaimName: "roles",
+			logins: []simulatedLogin{
+				{
+					explicitRoles:    []string{"bar"},
+					claims:           map[string]interface{}{"roles": []string{"foo"}},
+					expectedRoles:    []string{"foo", "bar"},
+					expectedChannels: []string{"!"},
+				},
+			},
+		},
+		{
+			name:           "grant, then revoke, OIDC roles",
+			rolesClaimName: "roles",
+			logins: []simulatedLogin{
+				{
+					claims:           map[string]interface{}{"roles": []string{"foo"}},
+					expectedRoles:    []string{"foo"},
+					expectedChannels: []string{"!"},
+				},
+				{
+					claims:           map[string]interface{}{"roles": []string{}},
+					expectedRoles:    []string{},
+					expectedChannels: []string{"!"},
+				},
+			},
+		},
+		{
+			name:           "same role explicit and OIDC",
+			rolesClaimName: "roles",
+			logins: []simulatedLogin{
+				{
+					explicitRoles:    []string{"foo"},
+					claims:           map[string]interface{}{"roles": []string{"foo"}},
+					expectedRoles:    []string{"foo"},
+					expectedChannels: []string{"!"},
+				},
+			},
+		},
+		{
+			name:           "grant, then revoke, OIDC role which is also explicit",
+			rolesClaimName: "roles",
+			logins: []simulatedLogin{
+				{
+					explicitRoles:    []string{"foo"},
+					claims:           map[string]interface{}{"roles": []string{"foo"}},
+					expectedRoles:    []string{"foo"},
+					expectedChannels: []string{"!"},
+				},
+				{
+					explicitRoles:    []string{"foo"},
+					claims:           map[string]interface{}{"roles": []string{}},
+					expectedRoles:    []string{"foo"},
+					expectedChannels: []string{"!"},
+				},
+			},
+		},
+		{
+			name:           "grant OIDC role, then revoke and grant another",
+			rolesClaimName: "roles",
+			logins: []simulatedLogin{
+				{
+					claims:           map[string]interface{}{"roles": []string{"foo"}},
+					expectedRoles:    []string{"foo"},
+					expectedChannels: []string{"!"},
+				},
+				{
+					claims:           map[string]interface{}{"roles": []string{"bar"}},
+					expectedRoles:    []string{"bar"},
+					expectedChannels: []string{"!"},
+				},
+			},
+		},
+		{
+			name:              "channels from OIDC",
+			channelsClaimName: "channels",
+			logins: []simulatedLogin{
+				{
+					claims:           map[string]interface{}{"channels": []string{"foo"}},
+					expectedRoles:    []string{},
+					expectedChannels: []string{"!", "foo"},
+				},
+			},
+		},
+		{
+			name:              "combine explicit and OIDC channels",
+			channelsClaimName: "channels",
+			logins: []simulatedLogin{
+				{
+					explicitChannels: []string{"bar"},
+					claims:           map[string]interface{}{"channels": []string{"foo"}},
+					expectedRoles:    []string{},
+					expectedChannels: []string{"!", "foo", "bar"},
+				},
+			},
+		},
+		{
+			name:              "combine OIDC roles and channels",
+			rolesClaimName:    "roles",
+			channelsClaimName: "channels",
+			logins: []simulatedLogin{
+				{
+					claims:           map[string]interface{}{"roles": []string{"rFoo"}, "channels": []string{"cBar"}},
+					expectedRoles:    []string{"rFoo"},
+					expectedChannels: []string{"!", "cBar"},
+				},
+			},
+		},
+		{
+			name:              "combine OIDC and explicit roles and channels",
+			rolesClaimName:    "roles",
+			channelsClaimName: "channels",
+			logins: []simulatedLogin{
+				{
+					claims:           map[string]interface{}{"roles": []string{"rFoo"}, "channels": []string{"cBar"}},
+					explicitRoles:    []string{"rBaz"},
+					explicitChannels: []string{"cQux"},
+					expectedRoles:    []string{"rFoo", "rBaz"},
+					expectedChannels: []string{"!", "cBar", "cQux"},
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Greater(t, len(tc.logins), 0, "Test case is missing simulated logins")
+
+			testBucket := base.GetTestBucket(t)
+			defer testBucket.Close()
+
+			testMockComputer := mockComputerV2{
+				roles:        map[string]ch.TimedSet{},
+				channels:     map[string]ch.TimedSet{},
+				roleChannels: map[string]ch.TimedSet{},
+			}
+
+			auth := NewAuthenticator(testBucket, &testMockComputer, DefaultAuthenticatorOptions())
+
+			provider := &OIDCProvider{
+				Name:          "foo",
+				Issuer:        testIssuer,
+				RolesClaim:    tc.rolesClaimName,
+				ChannelsClaim: tc.channelsClaimName,
+				UserPrefix:    testUserPrefix,
+			}
+
+			for i, login := range tc.logins {
+				var (
+					user User
+					err  error
+				)
+				if i == 0 {
+					user, err = auth.NewUser(testUserPrefix+"_"+testSubject, "test", base.SetFromArray(login.explicitChannels))
+					require.NoError(t, err, "Failed to register test user")
+				} else {
+					user, err = auth.GetUser(testUserPrefix + "_" + testSubject)
+					require.NoError(t, err, "Failed to get test user")
+				}
+				seq := user.Sequence() + 1
+				if !user.ExplicitRoles().Equals(base.SetFromArray(login.explicitRoles)) {
+					base.DebugfCtx(base.TestCtx(t), base.KeyAll, "setting explicit roles to %v", login.explicitRoles)
+					user.SetExplicitRoles(ch.AtSequence(base.SetFromArray(login.explicitRoles), seq), seq)
+					user.SetRoleInvalSeq(seq)
+				}
+				if !user.ExplicitChannels().Equals(base.SetFromArray(login.explicitChannels)) {
+					base.DebugfCtx(base.TestCtx(t), base.KeyAll, "setting explicit channels to %v", login.explicitRoles)
+					user.SetExplicitChannels(ch.AtSequence(base.SetFromArray(login.explicitChannels), seq), seq)
+					user.SetChannelInvalSeq(seq)
+				}
+				user.SetSequence(seq)
+				require.NoError(t, auth.Save(user), "Failed to save test user")
+
+				identity := &Identity{
+					Issuer:  testIssuer,
+					Subject: testSubject,
+					Claims:  login.claims,
+				}
+				user, _, err = auth.authenticateOIDCIdentity(identity, provider)
+				require.NoError(t, err, "error on authenticateOIDCIdentity")
+				require.NotNil(t, user, "nil user")
+
+				if user.RoleNames() == nil {
+					require.Empty(t, login.expectedRoles, "user's roles were nil when we expected roles")
+				} else {
+					require.Equal(t, base.SetFromArray(login.expectedRoles), user.RoleNames().AsSet())
+				}
+				require.Equal(t, base.SetFromArray(login.expectedChannels), user.Channels().AsSet())
+			}
 		})
 	}
 }

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -120,6 +120,8 @@ type User interface {
 	SetOIDCRoles(ch.TimedSet, uint64)
 	OIDCChannels() ch.TimedSet
 	SetOIDCChannels(ch.TimedSet, uint64)
+	OIDCIssuer() string
+	SetOIDCIssuer(string)
 
 	GetRoleInvalSeq() uint64
 

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -225,5 +225,9 @@ func (u PrincipalConfig) Merge(other PrincipalConfig) PrincipalConfig {
 		Password:          base.CoalesceStrings(other.Password, u.Password),
 		Disabled:          base.CoalesceBools(other.Disabled, u.Disabled),
 		ExplicitRoleNames: base.CoalesceSets(other.ExplicitRoleNames, u.ExplicitRoleNames),
+		OIDCIssuer:        base.CoalesceStrings(other.OIDCIssuer, u.OIDCIssuer),
+		OIDCRoles:         base.CoalesceSets(other.OIDCRoles, u.OIDCRoles),
+		OIDCChannels:      base.CoalesceSets(other.OIDCChannels, u.OIDCChannels),
+		OIDCLastUpdated:   base.CoalesceTimes(other.OIDCLastUpdated, u.OIDCLastUpdated),
 	}
 }

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -170,8 +170,11 @@ type PrincipalConfig struct {
 	Password          *string  `json:"password,omitempty"`
 	ExplicitRoleNames base.Set `json:"admin_roles,omitempty"`
 	// Fields below are read-only
-	Channels  base.Set `json:"all_channels,omitempty"`
-	RoleNames []string `json:"roles,omitempty"`
+	Channels     base.Set `json:"all_channels,omitempty"`
+	RoleNames    []string `json:"roles,omitempty"`
+	OIDCIssuer   *string  `json:"oidc_issuer,omitempty"`
+	OIDCRoles    base.Set `json:"oidc_roles,omitempty"`
+	OIDCChannels base.Set `json:"oidc_channels,omitempty"`
 }
 
 // IsPasswordValid checks if the passwords in this PrincipalConfig is valid.  Only allows

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -37,9 +37,6 @@ type Principal interface {
 	// Sets the explicit channels the Principal has access to.
 	SetExplicitChannels(ch.TimedSet, uint64)
 
-	OIDCChannels() ch.TimedSet
-	SetOIDCChannels(ch.TimedSet, uint64)
-
 	GetChannelInvalSeq() uint64
 
 	SetChannelInvalSeq(uint64)
@@ -121,6 +118,8 @@ type User interface {
 
 	OIDCRoles() ch.TimedSet
 	SetOIDCRoles(ch.TimedSet, uint64)
+	OIDCChannels() ch.TimedSet
+	SetOIDCChannels(ch.TimedSet, uint64)
 
 	GetRoleInvalSeq() uint64
 

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -9,6 +9,8 @@
 package auth
 
 import (
+	"time"
+
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
 )
@@ -122,6 +124,8 @@ type User interface {
 	SetOIDCChannels(ch.TimedSet, uint64)
 	OIDCIssuer() string
 	SetOIDCIssuer(string)
+	OIDCLastUpdated() time.Time
+	SetOIDCLastUpdated(time.Time)
 
 	GetRoleInvalSeq() uint64
 
@@ -170,11 +174,12 @@ type PrincipalConfig struct {
 	Password          *string  `json:"password,omitempty"`
 	ExplicitRoleNames base.Set `json:"admin_roles,omitempty"`
 	// Fields below are read-only
-	Channels     base.Set `json:"all_channels,omitempty"`
-	RoleNames    []string `json:"roles,omitempty"`
-	OIDCIssuer   *string  `json:"oidc_issuer,omitempty"`
-	OIDCRoles    base.Set `json:"oidc_roles,omitempty"`
-	OIDCChannels base.Set `json:"oidc_channels,omitempty"`
+	Channels        base.Set   `json:"all_channels,omitempty"`
+	RoleNames       []string   `json:"roles,omitempty"`
+	OIDCIssuer      *string    `json:"oidc_issuer,omitempty"`
+	OIDCRoles       base.Set   `json:"oidc_roles,omitempty"`
+	OIDCChannels    base.Set   `json:"oidc_channels,omitempty"`
+	OIDCLastUpdated *time.Time `json:"oidc_last_updated,omitempty"`
 }
 
 // IsPasswordValid checks if the passwords in this PrincipalConfig is valid.  Only allows

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -23,7 +23,12 @@ type Principal interface {
 	SetSequence(sequence uint64)
 
 	// The set of channels the Principal belongs to, and what sequence access was granted.
-	// Returns nil if invalidated
+	// Returns nil if invalidated.
+	// For both roles and users, the set of channels is the union of ExplicitChannels, OIDCChannels, and any channels
+	// they are granted through a sync function.
+	//
+	// NOTE: channels a user has access to through a role are *not* included in Channels(), so the user could have
+	// access to more documents than included in Channels. CanSeeChannel will also check against the user's roles.
 	Channels() ch.TimedSet
 
 	// The channels the Principal was explicitly granted access to thru the admin API.
@@ -31,6 +36,9 @@ type Principal interface {
 
 	// Sets the explicit channels the Principal has access to.
 	SetExplicitChannels(ch.TimedSet, uint64)
+
+	OIDCChannels() ch.TimedSet
+	SetOIDCChannels(ch.TimedSet, uint64)
 
 	GetChannelInvalSeq() uint64
 
@@ -101,7 +109,7 @@ type User interface {
 	// Changes the user's password.
 	SetPassword(password string) error
 
-	// The set of Roles the user belongs to (including ones given to it by the sync function)
+	// The set of Roles the user belongs to (including ones given to it by the sync function and by OIDC)
 	// Returns nil if invalidated
 	RoleNames() ch.TimedSet
 
@@ -110,6 +118,9 @@ type User interface {
 
 	// Sets the explicit roles the user belongs to.
 	SetExplicitRoles(ch.TimedSet, uint64)
+
+	OIDCRoles() ch.TimedSet
+	SetOIDCRoles(ch.TimedSet, uint64)
 
 	GetRoleInvalSeq() uint64
 

--- a/auth/role.go
+++ b/auth/role.go
@@ -24,17 +24,15 @@ import (
 
 /** A group that users can belong to, with associated channel permissions. */
 type roleImpl struct {
-	Name_             string      `json:"name,omitempty"`
-	ExplicitChannels_ ch.TimedSet `json:"admin_channels,omitempty"`
-	// TODO: it doesn't make sense for a role to have OIDC channels - this is only here because User inherits it
-	OIDCChannels_   ch.TimedSet     `json:"oidc_channels,omitempty"`
-	Channels_       ch.TimedSet     `json:"all_channels"`
-	Sequence_       uint64          `json:"sequence"`
-	ChannelHistory_ TimedSetHistory `json:"channel_history,omitempty"`   // Added to when a previously granted channel is revoked. Calculated inside of rebuildChannels.
-	ChannelInvalSeq uint64          `json:"channel_inval_seq,omitempty"` // Sequence at which the channels were invalidated. Data remains in Channels_ for history calculation.
-	Deleted         bool            `json:"deleted,omitempty"`
-	vbNo            *uint16
-	cas             uint64
+	Name_             string          `json:"name,omitempty"`
+	ExplicitChannels_ ch.TimedSet     `json:"admin_channels,omitempty"`
+	Channels_         ch.TimedSet     `json:"all_channels"`
+	Sequence_         uint64          `json:"sequence"`
+	ChannelHistory_   TimedSetHistory `json:"channel_history,omitempty"`   // Added to when a previously granted channel is revoked. Calculated inside of rebuildChannels.
+	ChannelInvalSeq   uint64          `json:"channel_inval_seq,omitempty"` // Sequence at which the channels were invalidated. Data remains in Channels_ for history calculation.
+	Deleted           bool            `json:"deleted,omitempty"`
+	vbNo              *uint16
+	cas               uint64
 }
 
 type TimedSetHistory map[string]GrantHistory
@@ -209,16 +207,6 @@ func (role *roleImpl) ExplicitChannels() ch.TimedSet {
 
 func (role *roleImpl) SetExplicitChannels(channels ch.TimedSet, invalSeq uint64) {
 	role.ExplicitChannels_ = channels
-	role.SetChannelInvalSeq(invalSeq)
-}
-
-func (role *roleImpl) OIDCChannels() ch.TimedSet {
-	return role.OIDCChannels_
-}
-
-func (role *roleImpl) SetOIDCChannels(channels ch.TimedSet, invalSeq uint64) {
-	role.OIDCChannels_ = channels
-	// change to OIDC channels means channels need to be recomputed
 	role.SetChannelInvalSeq(invalSeq)
 }
 

--- a/auth/user.go
+++ b/auth/user.go
@@ -42,6 +42,7 @@ type userImplBody struct {
 	PasswordHash_    []byte          `json:"passwordhash_bcrypt,omitempty"`
 	OldPasswordHash_ interface{}     `json:"passwordhash,omitempty"` // For pre-beta compatibility
 	ExplicitRoles_   ch.TimedSet     `json:"explicit_roles,omitempty"`
+	OIDCRoles_       ch.TimedSet     `json:"oidc_roles,omitempty"`
 	RolesSince_      ch.TimedSet     `json:"rolesSince"`
 	RoleInvalSeq     uint64          `json:"role_inval_seq,omitempty"` // Sequence at which the roles were invalidated. Data remains in RolesSince_ for history calculation.
 	RoleHistory_     TimedSetHistory `json:"role_history,omitempty"`   // Added to when a previously granted role is revoked. Calculated inside of rebuildRoles.
@@ -182,6 +183,16 @@ func (user *userImpl) InvalidatedRoles() ch.TimedSet {
 		return user.RolesSince_
 	}
 	return nil
+}
+
+func (user *userImpl) OIDCRoles() ch.TimedSet {
+	return user.OIDCRoles_
+}
+
+func (user *userImpl) SetOIDCRoles(channels ch.TimedSet, invalSeq uint64) {
+	user.OIDCRoles_ = channels
+	// change to OIDC roles means roles need to be recomputed
+	user.SetRoleInvalSeq(invalSeq)
 }
 
 func (user *userImpl) SetRoleHistory(history TimedSetHistory) {

--- a/auth/user.go
+++ b/auth/user.go
@@ -44,6 +44,7 @@ type userImplBody struct {
 	ExplicitRoles_   ch.TimedSet     `json:"explicit_roles,omitempty"`
 	OIDCRoles_       ch.TimedSet     `json:"oidc_roles,omitempty"`
 	OIDCChannels_    ch.TimedSet     `json:"oidc_channels,omitempty"`
+	OIDCIssuer_      string          `json:"oidc_issuer,omitempty"`
 	RolesSince_      ch.TimedSet     `json:"rolesSince"`
 	RoleInvalSeq     uint64          `json:"role_inval_seq,omitempty"` // Sequence at which the roles were invalidated. Data remains in RolesSince_ for history calculation.
 	RoleHistory_     TimedSetHistory `json:"role_history,omitempty"`   // Added to when a previously granted role is revoked. Calculated inside of rebuildRoles.
@@ -204,6 +205,14 @@ func (user *userImpl) SetOIDCChannels(channels ch.TimedSet, invalSeq uint64) {
 	user.OIDCChannels_ = channels
 	// change to OIDC channels means channels need to be recomputed
 	user.SetChannelInvalSeq(invalSeq)
+}
+
+func (user *userImpl) OIDCIssuer() string {
+	return user.OIDCIssuer_
+}
+
+func (user *userImpl) SetOIDCIssuer(val string) {
+	user.OIDCIssuer_ = val
 }
 
 func (user *userImpl) SetRoleHistory(history TimedSetHistory) {

--- a/auth/user.go
+++ b/auth/user.go
@@ -43,6 +43,7 @@ type userImplBody struct {
 	OldPasswordHash_ interface{}     `json:"passwordhash,omitempty"` // For pre-beta compatibility
 	ExplicitRoles_   ch.TimedSet     `json:"explicit_roles,omitempty"`
 	OIDCRoles_       ch.TimedSet     `json:"oidc_roles,omitempty"`
+	OIDCChannels_    ch.TimedSet     `json:"oidc_channels,omitempty"`
 	RolesSince_      ch.TimedSet     `json:"rolesSince"`
 	RoleInvalSeq     uint64          `json:"role_inval_seq,omitempty"` // Sequence at which the roles were invalidated. Data remains in RolesSince_ for history calculation.
 	RoleHistory_     TimedSetHistory `json:"role_history,omitempty"`   // Added to when a previously granted role is revoked. Calculated inside of rebuildRoles.
@@ -193,6 +194,16 @@ func (user *userImpl) SetOIDCRoles(channels ch.TimedSet, invalSeq uint64) {
 	user.OIDCRoles_ = channels
 	// change to OIDC roles means roles need to be recomputed
 	user.SetRoleInvalSeq(invalSeq)
+}
+
+func (user *userImpl) OIDCChannels() ch.TimedSet {
+	return user.OIDCChannels_
+}
+
+func (user *userImpl) SetOIDCChannels(channels ch.TimedSet, invalSeq uint64) {
+	user.OIDCChannels_ = channels
+	// change to OIDC channels means channels need to be recomputed
+	user.SetChannelInvalSeq(invalSeq)
 }
 
 func (user *userImpl) SetRoleHistory(history TimedSetHistory) {

--- a/auth/user.go
+++ b/auth/user.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"regexp"
 	"sync"
+	"time"
 
 	"golang.org/x/crypto/bcrypt"
 
@@ -45,6 +46,7 @@ type userImplBody struct {
 	OIDCRoles_       ch.TimedSet     `json:"oidc_roles,omitempty"`
 	OIDCChannels_    ch.TimedSet     `json:"oidc_channels,omitempty"`
 	OIDCIssuer_      string          `json:"oidc_issuer,omitempty"`
+	OIDCLastUpdated_ time.Time       `json:"oidc_last_updated_,omitempty"`
 	RolesSince_      ch.TimedSet     `json:"rolesSince"`
 	RoleInvalSeq     uint64          `json:"role_inval_seq,omitempty"` // Sequence at which the roles were invalidated. Data remains in RolesSince_ for history calculation.
 	RoleHistory_     TimedSetHistory `json:"role_history,omitempty"`   // Added to when a previously granted role is revoked. Calculated inside of rebuildRoles.
@@ -213,6 +215,14 @@ func (user *userImpl) OIDCIssuer() string {
 
 func (user *userImpl) SetOIDCIssuer(val string) {
 	user.OIDCIssuer_ = val
+}
+
+func (user *userImpl) OIDCLastUpdated() time.Time {
+	return user.OIDCLastUpdated_
+}
+
+func (user *userImpl) SetOIDCLastUpdated(val time.Time) {
+	user.OIDCLastUpdated_ = val
 }
 
 func (user *userImpl) SetRoleHistory(history TimedSetHistory) {

--- a/base/util.go
+++ b/base/util.go
@@ -1741,3 +1741,14 @@ func safeCutAfter(s, sep string) (value, remainder string) {
 	}
 	return val, before
 }
+
+// AllOrNoneNil returns true if either all of its arguments are nil, or none are.
+func AllOrNoneNil(vals ...interface{}) bool {
+	nonNil := 0
+	for _, val := range vals {
+		if val != nil {
+			nonNil++
+		}
+	}
+	return nonNil == 0 || nonNil == len(vals)
+}

--- a/base/util.go
+++ b/base/util.go
@@ -1704,3 +1704,14 @@ func CoalesceBools(a, b *bool) *bool {
 	}
 	return nil
 }
+
+// CoalesceTimes returns the first non-nil argument, or nil if both are nil.
+func CoalesceTimes(a, b *time.Time) *time.Time {
+	if a != nil {
+		return a
+	}
+	if b != nil {
+		return b
+	}
+	return nil
+}

--- a/db/users.go
+++ b/db/users.go
@@ -161,6 +161,10 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 			if updates.OIDCChannels != nil && !updatedOIDCChannels.Equals(updates.OIDCChannels) {
 				changed = true
 			}
+
+			if updates.OIDCLastUpdated != nil && !user.OIDCLastUpdated().Equal(*updates.OIDCLastUpdated) {
+				changed = true
+			}
 		}
 
 		// And finally save the Principal if anything has changed:
@@ -191,6 +195,9 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 			}
 			if updates.OIDCChannels != nil && updatedOIDCChannels.UpdateAtSequence(updates.OIDCChannels, nextSeq) {
 				user.SetOIDCChannels(updatedOIDCChannels, nextSeq)
+			}
+			if updates.OIDCLastUpdated != nil {
+				user.SetOIDCLastUpdated(*updates.OIDCLastUpdated)
 			}
 		}
 		err = authenticator.Save(princ)

--- a/db/users.go
+++ b/db/users.go
@@ -42,6 +42,11 @@ func (db *DatabaseContext) DeleteRole(ctx context.Context, name string, purge bo
 
 // UpdatePrincipal updates or creates a principal from a PrincipalConfig structure.
 func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.PrincipalConfig, isUser bool, allowReplace bool) (replaced bool, err error) {
+	// Sanity checking
+	if !base.AllOrNoneNil(updates.OIDCIssuer, updates.OIDCRoles, updates.OIDCChannels, updates.OIDCLastUpdated) {
+		return false, fmt.Errorf("must either specify all OIDC properties or none")
+	}
+
 	// Get the existing principal, or if this is a POST make sure there isn't one:
 	var princ auth.Principal
 	var user auth.User

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -242,10 +242,35 @@ User:
       description: |-
         All the roles that the user has been granted access to.
 
-        Access could have been granted through the sync function, or explicitly on the user under the `admin_roles` property.
+        Access could have been granted through the sync function, OpenID Connect, or explicitly on the user under the `admin_roles` property.
       type: array
       items:
         type: string
+      readOnly: true
+    oidc_roles:
+      description: |-
+        The roles that the user has been added to through OpenID Connect.
+      type: array
+      items:
+        type: string
+      readOnly: true
+    oidc_channels:
+      description: |-
+        The channels that the user has been granted access to through OpenID Connect.
+      type: array
+      items:
+        type: string
+      readOnly: true
+    oidc_issuer:
+      description: |-
+        The OpenID Connect issuer that the user last used to sign in.
+      type: string
+      readOnly: true
+    oidc_last_updated:
+      description: |-
+        The last time that the user's OIDC roles/channels were updated.
+      type: string
+      format: date-time
       readOnly: true
   title: User
 Role:

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1312,6 +1312,18 @@ Database:
 
                     The field name to use can be specified here.
                   type: string
+                roles_claim:
+                  description: |-
+                    If set, the value(s) of the given OpenID Connect authentication token claim will be added to the user's roles.
+                    
+                    The value of this claim must be either a string or an array of strings, any other type will result in an error.
+                  type: string
+                channels_claim:
+                  description: |-
+                    If set, the value(s) of the given OpenID Connect authentication token claim will be added to the user's channels.
+
+                    The value of this claim must be either a string or an array of strings, any other type will result in an error.
+                  type: string
                 allow_unsigned_provider_tokens:
                   description: Allows users accept unsigned tokens from providers.
                   type: boolean

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1188,6 +1188,9 @@ func marshalPrincipal(princ auth.Principal, includeDynamicGrantInfo bool) ([]byt
 		if includeDynamicGrantInfo {
 			info.Channels = user.InheritedChannels().AsSet()
 			info.RoleNames = user.RoleNames().AllKeys()
+			info.OIDCIssuer = user.OIDCIssuer()
+			info.OIDCRoles = user.OIDCRoles().AllKeys()
+			info.OIDCChannels = user.OIDCChannels().AllKeys()
 		}
 	} else {
 		if includeDynamicGrantInfo {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1174,7 +1174,7 @@ func externalUserName(name string) string {
 	return name
 }
 
-func marshalPrincipal(princ auth.Principal, includeDynamicGrantInfo bool) db.PrincipalConfig {
+func marshalPrincipal(princ auth.Principal, includeDynamicGrantInfo bool) auth.PrincipalConfig {
 	name := externalUserName(princ.Name())
 	info := auth.PrincipalConfig{
 		Name:             &name,
@@ -1303,17 +1303,17 @@ func (h *handler) getUserInfo() error {
 	info := marshalPrincipal(user, includeDynamicGrantInfo)
 	// If the user's OIDC issuer is no longer valid, remove the OIDC information to avoid confusing users
 	// (it'll get removed permanently the next time the user signs in)
-	if info.OIDCIssuer != "" {
+	if info.OIDCIssuer != nil {
 		issuerValid := false
 		for _, provider := range h.db.OIDCProviders {
-			if provider.Issuer == info.OIDCIssuer {
+			if provider.Issuer == *info.OIDCIssuer {
 				issuerValid = true
 				break
 			}
 		}
 		if !issuerValid {
-			info.OIDCIssuer = ""
-			info.OIDCLastUpdated = time.Time{}
+			info.OIDCIssuer = nil
+			info.OIDCLastUpdated = nil
 			info.OIDCRoles = nil
 			info.OIDCChannels = nil
 		}

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -282,6 +282,16 @@ func bootstrapStartupConfigForTest(t *testing.T) StartupConfig {
 	return config
 }
 
+const (
+	publicPort  = 4984
+	adminPort   = 4985
+	metricsPort = 4986
+)
+
+func bootstrapURL(basePort int) string {
+	return "http://localhost:" + strconv.Itoa(basePort+bootstrapTestPortOffset)
+}
+
 func bootstrapAdminRequest(t *testing.T, method, path, body string) *http.Response {
 	url := "http://localhost:" + strconv.FormatInt(4985+bootstrapTestPortOffset, 10) + path
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -275,21 +275,9 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 	}
 
 	// If the user has OIDC roles/channels configured, we need to check if the OIDC issuer they came from is still valid.
-	// TODO: is the best place to do this? checkAuth early-returns in various places and we need to ensure we check this in all cases.
-	if h.user != nil && (len(h.user.OIDCRoles()) > 0 || len(h.user.OIDCChannels()) > 0) {
-		providerStillValid := false
-		for _, provider := range dbContext.OIDCProviders {
-			// No need to verify audiences, as that was done when the user was authenticated
-			if provider.Issuer == h.user.OIDCIssuer() {
-				providerStillValid = true
-				break
-			}
-		}
-		if !providerStillValid {
-			base.InfofCtx(h.ctx(), base.KeyAuth, "User %v's OIDC roles/channels are from issuer %v which is no longer configured - revoking", base.UD(h.user.Name()), base.UD(h.user.OIDCIssuer()))
-			if err := dbContext.Authenticator(h.ctx()).UpdateUserOIDCRolesChannels(h.user, "", base.Set{}, base.Set{}); err != nil {
-				return err
-			}
+	if h.user != nil {
+		if err := verifyOIDCIssuerStillValid(h.ctx(), dbContext, h.user); err != nil {
+			return err
 		}
 	}
 
@@ -381,6 +369,26 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 	}
 
 	return method(h) // Call the actual handler code
+}
+
+// verifyOIDCIssuerStillValid checks that the OIDC issuer assigned to the user is still configured in the database.
+// If not, and they have any OIDC roles/channels assigned, it revokes them.
+func verifyOIDCIssuerStillValid(ctx context.Context, dbContext *db.DatabaseContext, user auth.User) error {
+	providerStillValid := false
+	for _, provider := range dbContext.OIDCProviders {
+		// No need to verify audiences, as that was done when the user was authenticated
+		if provider.Issuer == user.OIDCIssuer() {
+			providerStillValid = true
+			break
+		}
+	}
+	if !providerStillValid {
+		base.InfofCtx(ctx, base.KeyAuth, "User %v last signed in with OIDC issuer %v which is no longer configured - revoking any OIDC roles/channels", base.UD(user.Name()), base.UD(user.OIDCIssuer()))
+		if err := dbContext.Authenticator(ctx).UpdateUserOIDCRolesChannels(user, "", base.Set{}, base.Set{}); err != nil {
+			return errors.Wrapf(err, "failed to revoke user %s's OIDC roles/channels", base.UD(user.Name()).Redact())
+		}
+	}
+	return nil
 }
 
 func (h *handler) logRequestLine() {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -460,7 +460,9 @@ func (h *handler) checkAuth(dbCtx *db.DatabaseContext) (err error) {
 			if h.user == nil || authJwtErr != nil {
 				return base.HTTPErrorf(http.StatusUnauthorized, "Invalid login")
 			}
-			updates = updates.Merge(checkOIDCIssuerStillValid(h.ctx(), dbCtx, h.user))
+			if changes := checkOIDCIssuerStillValid(h.ctx(), dbCtx, h.user); changes != nil {
+				updates = updates.Merge(*changes)
+			}
 			_, err := dbCtx.UpdatePrincipal(h.ctx(), &updates, true, true)
 			if err != nil {
 				return fmt.Errorf("failed to update OIDC user after sign-in: %w", err)


### PR DESCRIPTION
CBG-2064

This PR adds two new configuration properties for OIDC providers, roles_claim and channels_claim, both empty by default. When set, SGW will look for a claim matching that and add its value to the user's role/channel sets.

* This adds three new properties to the persisted User - oidc_issuer, oidc_roles and oidc_channels.
* The new sets are unioned with the explicit roles/channels and any added through the sync function.
* We also store the issuer of the provider on the User doc - if, when they sign in, that provider has been removed from the DB configuration, we revoke the OIDC roles/channels.

An open question is whether the OIDC roles/channels need to be revoked if the user signs in through something other than OIDC. Right now this is not done (i.e. they will keep their OIDC roles/channels even if signing in through basic auth / admin _session) - if this needs changing this will likely be best done as a separate ticket as it requires changes to the non-OIDC login flow.

## Dependencies

- [x] #5546 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x]  `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/313/
