### PR TITLE
CBG-2050 Add option for read-only anonymous access

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -63,6 +63,10 @@ const (
 	maxHistoryEntriesPerGrant    = 10          // Ceiling of history entries count to ensure there is no more than 10 entries
 )
 
+const (
+	GuestUserReadOnly = "Anonymous access is read-only"
+)
+
 // Creates a new Authenticator that stores user info in the given Bucket.
 func NewAuthenticator(bucket base.Bucket, channelComputer ChannelComputer, options AuthenticatorOptions) *Authenticator {
 	return &Authenticator{

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -67,6 +67,9 @@ func NewBlipSyncContext(bc *blip.Context, db *Database, contextID string, replic
 	if u := db.User(); u != nil {
 		bsc.userName = u.Name()
 		u.InitializeRoles()
+		if u.Name() == "" && db.IsGuestReadOnly() {
+			bsc.readOnly = true
+		}
 	}
 
 	// Register default handlers
@@ -125,6 +128,9 @@ type BlipSyncContext struct {
 	// fatalErrorCallback is called by the replicator code when the replicator using this blipSyncContext should be
 	// stopped
 	fatalErrorCallback func(err error)
+
+	// when readOnly is true, handleRev requests are rejected
+	readOnly bool
 }
 
 // AllowedAttachment contains the metadata for handling allowed attachments

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -109,6 +109,10 @@ const (
 	// Sync Gateway specific properties (used for testing)
 	SGShowHandler = "sgShowHandler" // Used to request a response with sgHandler
 	SGHandler     = "sgHandler"     // Used to show which handler processed the message
+
+	// blip error properties
+	BlipErrorDomain = "Error-Domain"
+	BlipErrorCode   = "Error-Code"
 )
 
 // Function signature for something that parses a sequence id from a string

--- a/db/crud.go
+++ b/db/crud.go
@@ -2152,6 +2152,11 @@ func (db *Database) getChannelsAndAccess(doc *Document, body Body, metaMap map[s
 	err error) {
 	base.DebugfCtx(db.Ctx, base.KeyCRUD, "Invoking sync on doc %q rev %s", base.UD(doc.ID), body[BodyRev])
 
+	// Low-level protection against writes for read-only guest.  Handles write pathways that don't fail-fast
+	if db.user != nil && db.user.Name() == "" && db.DatabaseContext.IsGuestReadOnly() {
+		return result, access, roles, expiry, oldJson, base.HTTPErrorf(403, auth.GuestUserReadOnly)
+	}
+
 	// Get the parent revision, to pass to the sync function:
 	var oldJsonBytes []byte
 	if oldJsonBytes, err = db.getAncestorJSON(doc, revID); err != nil {

--- a/db/database.go
+++ b/db/database.go
@@ -176,6 +176,7 @@ type APIEndpoints struct {
 	EnableCouchbaseBucketFlush bool `json:"enable_couchbase_bucket_flush,omitempty"` // Whether Couchbase buckets can be flushed via Admin REST API
 }
 
+// UnsupportedOptions are not supported for external use
 type UnsupportedOptions struct {
 	UserViews                 *UserViewsOptions        `json:"user_views,omitempty"`                    // Config settings for user views
 	OidcTestProvider          *OidcTestProviderOptions `json:"oidc_test_provider,omitempty"`            // Config settings for OIDC Provider
@@ -185,6 +186,7 @@ type UnsupportedOptions struct {
 	OidcTlsSkipVerify         bool                     `json:"oidc_tls_skip_verify,omitempty"`          // Config option to enable self-signed certs for OIDC testing.
 	SgrTlsSkipVerify          bool                     `json:"sgr_tls_skip_verify,omitempty"`           // Config option to enable self-signed certs for SG-Replicate testing.
 	RemoteConfigTlsSkipVerify bool                     `json:"remote_config_tls_skip_verify,omitempty"` // Config option to enable self signed certificates for external JavaScript load.
+	GuestReadOnly             bool                     `json:"guest_read_only,omitempty"`               // Config option to restrict GUEST document access to read-only
 }
 
 type WarningThresholds struct {
@@ -1712,4 +1714,10 @@ func (context *DatabaseContext) AllowFlushNonCouchbaseBuckets() bool {
 
 func (context *DatabaseContext) LastSequence() (uint64, error) {
 	return context.sequences.lastSequence()
+}
+
+// Helpers for unsupported options
+func (context *DatabaseContext) IsGuestReadOnly() bool {
+	return context.Options.UnsupportedOptions != nil && context.Options.UnsupportedOptions.GuestReadOnly
+
 }

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -4198,3 +4198,58 @@ func TestProcessRevIncrementsStat(t *testing.T) {
 	// Confirm connected client count has not increased, which uses same processRev code
 	assert.EqualValues(t, 0, pullStats.HandlePutRevCount.Value())
 }
+
+// Attempt to send rev as GUEST when read-only guest is enabled
+func TestSendRevAsReadOnlyGuest(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
+
+	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+		noConflictsMode: true,
+		guestEnabled:    true,
+	})
+	assert.NoError(t, err, "Error creating BlipTester")
+	defer bt.Close()
+
+	// Send rev as guest with read-only=false
+	revRequest := blip.NewRequest()
+	revRequest.SetCompressed(false)
+	revRequest.SetProfile("rev")
+	revRequest.Properties["deleted"] = "false"
+	revRequest.Properties["id"] = "writeGuest"
+	revRequest.Properties["rev"] = "1-abc"
+	revRequest.SetBody([]byte(`{"key": "val"}`))
+
+	sent := bt.sender.Send(revRequest)
+	assert.True(t, sent)
+	revResponse := revRequest.Response()
+
+	errorCode, ok := revResponse.Properties[db.BlipErrorCode]
+	assert.False(t, ok)
+
+	body, err := revResponse.Body()
+	log.Printf("response body: %s", body)
+
+	// Send rev as guest with read-only=true
+	bt.DatabaseContext().Options.UnsupportedOptions.GuestReadOnly = true
+
+	revRequest = blip.NewRequest()
+	revRequest.SetCompressed(false)
+	revRequest.SetProfile("rev")
+	revRequest.Properties["deleted"] = "false"
+	revRequest.Properties["id"] = "readOnlyGuest"
+	revRequest.Properties["rev"] = "1-abc"
+	revRequest.SetBody([]byte(`{"key": "val"}`))
+
+	sent = bt.sender.Send(revRequest)
+	assert.True(t, sent)
+	revResponse = revRequest.Response()
+
+	errorCode, ok = revResponse.Properties[db.BlipErrorCode]
+	assert.True(t, ok)
+	assert.Equal(t, "403", errorCode)
+
+	body, err = revResponse.Body()
+	log.Printf("response body: %s", body)
+
+}


### PR DESCRIPTION
Adds an internal (unsupported) option to make anonymous access (via GUEST user) read-only.  Includes low-level enforcement immediately prior to sync function execution, but also performs an earlier check for 2.x and REST API calls.  REST API calls are identifying read-only calls based on the admin WriteAppData permission - this overloads that functionality somewhat, and would be a candidate for a wider refactoring of privileges for the REST API in future.

Also adds a missing userBlipHandler for MessageGetRev and MessagePutRev.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/259/
