### PR TITLE
[3.0.1] CBG-2033 Option for xattr storage of persistent config

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -182,7 +182,7 @@ func (cc *CouchbaseCluster) UpdateConfig(location, groupID string, updateCallbac
 			return uint64(removeCasOut), nil
 		}
 
-		replaceCasOut, err := cc.configPersistence.replaceRawConfig(collection, docID, newConfig, cas)
+		_, replaceCfgCasOut, err := cc.configPersistence.replaceRawConfig(collection, docID, newConfig, cas)
 		if err != nil {
 			if errors.Is(err, gocb.ErrCasMismatch) {
 				// retry on cas failure
@@ -191,7 +191,7 @@ func (cc *CouchbaseCluster) UpdateConfig(location, groupID string, updateCallbac
 			return 0, err
 		}
 
-		return uint64(replaceCasOut), nil
+		return replaceCfgCasOut, nil
 	}
 
 }

--- a/base/config_persistence.go
+++ b/base/config_persistence.go
@@ -1,0 +1,200 @@
+package base
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/couchbase/gocb/v2"
+	"github.com/couchbase/gocbcore/v10"
+	"github.com/couchbase/gocbcore/v10/memd"
+)
+
+// ConfigPersistence manages the underlying storage of database config documents in the bucket.
+// Implementations support using either document body or xattr for storage
+type ConfigPersistence interface {
+	// Operations for interacting with raw config ([]byte)
+	loadRawConfig(c *gocb.Collection, key string) ([]byte, gocb.Cas, error)
+	removeRawConfig(c *gocb.Collection, key string, cas gocb.Cas) (gocb.Cas, error)
+	replaceRawConfig(c *gocb.Collection, key string, value []byte, cas gocb.Cas) (gocb.Cas, error)
+
+	// Operations for interacting with marshalled config
+	loadConfig(c *gocb.Collection, key string, valuePtr interface{}) (cas uint64, err error)
+	insertConfig(c *gocb.Collection, key string, value interface{}) (cas uint64, err error)
+}
+
+// System xattr persistence
+type XattrBootstrapPersistence struct {
+}
+
+const cfgXattrKey = "_sync"
+const cfgXattrConfigPath = cfgXattrKey + ".config"
+const cfgXattrCasPath = cfgXattrKey + ".cas"
+const cfgXattrBody = `{"cfgVersion": 1}`
+
+func (xbp *XattrBootstrapPersistence) insertConfig(c *gocb.Collection, key string, value interface{}) (cas uint64, err error) {
+
+	mutateOps := []gocb.MutateInSpec{
+		gocb.UpsertSpec(cfgXattrConfigPath, value, UpsertSpecXattr),
+		gocb.UpsertSpec(cfgXattrCasPath, gocb.MutationMacroCAS, UpsertSpecXattr),
+		gocb.ReplaceSpec("", json.RawMessage(cfgXattrBody), nil),
+	}
+	options := &gocb.MutateInOptions{
+		StoreSemantic: gocb.StoreSemanticsInsert,
+	}
+	result, mutateErr := c.MutateIn(key, mutateOps, options)
+	if mutateErr != nil {
+		return 0, mutateErr
+	}
+	return uint64(result.Cas()), nil
+
+}
+
+func (xbp *XattrBootstrapPersistence) loadRawConfig(c *gocb.Collection, key string) ([]byte, gocb.Cas, error) {
+
+	var rawValue []byte
+	cas, err := xbp.loadConfig(c, key, &rawValue)
+	return rawValue, gocb.Cas(cas), err
+
+}
+
+func (xbp *XattrBootstrapPersistence) removeRawConfig(c *gocb.Collection, key string, cas gocb.Cas) (gocb.Cas, error) {
+
+	mutateOps := []gocb.MutateInSpec{
+		gocb.RemoveSpec(cfgXattrKey, RemoveSpecXattr),
+		gocb.RemoveSpec("", nil),
+	}
+	options := &gocb.MutateInOptions{
+		StoreSemantic: gocb.StoreSemanticsReplace,
+		Cas:           cas,
+	}
+	result, mutateErr := c.MutateIn(key, mutateOps, options)
+	if mutateErr == nil {
+		return result.Cas(), nil
+	}
+
+	// StatusKeyNotFound returned if document doesn't exist
+	if errors.Is(mutateErr, gocbcore.ErrDocumentNotFound) {
+		return 0, ErrNotFound
+	}
+
+	// StatusSubDocBadMulti returned if xattr doesn't exist
+	if isKVError(mutateErr, memd.StatusSubDocBadMulti) {
+		return 0, ErrNotFound
+	}
+	return 0, mutateErr
+
+}
+
+func (xbp *XattrBootstrapPersistence) replaceRawConfig(c *gocb.Collection, key string, value []byte, cas gocb.Cas) (gocb.Cas, error) {
+	mutateOps := []gocb.MutateInSpec{
+		gocb.UpsertSpec(cfgXattrConfigPath, bytesToRawMessage(value), UpsertSpecXattr),
+		gocb.UpsertSpec(cfgXattrCasPath, gocb.MutationMacroCAS, UpsertSpecXattr),
+	}
+	options := &gocb.MutateInOptions{
+		StoreSemantic: gocb.StoreSemanticsReplace,
+		Cas:           cas,
+	}
+	result, mutateErr := c.MutateIn(key, mutateOps, options)
+	if mutateErr != nil {
+		return 0, mutateErr
+	}
+	return result.Cas(), nil
+}
+
+func (xbp *XattrBootstrapPersistence) loadConfig(c *gocb.Collection, key string, valuePtr interface{}) (cas uint64, err error) {
+
+	ops := []gocb.LookupInSpec{
+		gocb.GetSpec(cfgXattrConfigPath, GetSpecXattr),
+	}
+	lookupOpts := &gocb.LookupInOptions{
+		Timeout: time.Second * 10,
+	}
+	lookupOpts.Internal.DocFlags = gocb.SubdocDocFlagAccessDeleted
+
+	res, lookupErr := c.LookupIn(key, ops, LookupOptsAccessDeleted)
+	if lookupErr == nil {
+		xattrContErr := res.ContentAt(0, valuePtr)
+		if xattrContErr != nil {
+			Debugf(KeyCRUD, "No xattr config found for key=%s, oath=%s: %v", key, cfgXattrConfigPath, xattrContErr)
+			return 0, ErrNotFound
+		}
+		cas := uint64(res.Cas())
+		return cas, nil
+	} else if errors.Is(lookupErr, gocbcore.ErrDocumentNotFound) {
+		Debugf(KeyCRUD, "No config document found for key=%s", key)
+		return 0, ErrNotFound
+	} else {
+		return 0, lookupErr
+	}
+}
+
+// Document Body persistence
+type DocumentBootstrapPersistence struct {
+}
+
+func (dbp *DocumentBootstrapPersistence) loadRawConfig(c *gocb.Collection, key string) ([]byte, gocb.Cas, error) {
+	res, err := c.Get(key, &gocb.GetOptions{
+		Transcoder: gocb.NewRawJSONTranscoder(),
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var bucketValue []byte
+	err = res.Content(&bucketValue)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return bucketValue, res.Cas(), err
+}
+
+func (dbp *DocumentBootstrapPersistence) removeRawConfig(c *gocb.Collection, key string, cas gocb.Cas) (gocb.Cas, error) {
+	deleteRes, err := c.Remove(key, &gocb.RemoveOptions{Cas: cas})
+	if err != nil {
+		return 0, err
+	}
+	return deleteRes.Cas(), err
+}
+
+func (dbp *DocumentBootstrapPersistence) replaceRawConfig(c *gocb.Collection, key string, value []byte, cas gocb.Cas) (gocb.Cas, error) {
+	replaceRes, err := c.Replace(key, value, &gocb.ReplaceOptions{Transcoder: gocb.NewRawJSONTranscoder(), Cas: cas})
+	if err != nil {
+		return 0, err
+	}
+
+	return replaceRes.Cas(), nil
+}
+
+func (dbp *DocumentBootstrapPersistence) loadConfig(c *gocb.Collection, key string, valuePtr interface{}) (cas uint64, err error) {
+
+	res, err := c.Get(key, &gocb.GetOptions{
+		Timeout:       time.Second * 10,
+		RetryStrategy: gocb.NewBestEffortRetryStrategy(nil),
+	})
+	if err != nil {
+		if errors.Is(err, gocb.ErrDocumentNotFound) {
+			return 0, ErrNotFound
+		}
+		return 0, err
+	}
+	err = res.Content(valuePtr)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(res.Cas()), nil
+}
+
+func (dbp *DocumentBootstrapPersistence) insertConfig(c *gocb.Collection, key string, value interface{}) (cas uint64, err error) {
+	res, err := c.Insert(key, value, nil)
+	if err != nil {
+		if isKVError(err, memd.StatusKeyExists) {
+			return 0, ErrAlreadyExists
+		}
+		return 0, err
+	}
+
+	return uint64(res.Cas()), nil
+}

--- a/base/config_persistence_test.go
+++ b/base/config_persistence_test.go
@@ -108,3 +108,131 @@ func TestConfigPersistence(t *testing.T) {
 	}
 
 }
+
+func TestXattrConfigPersistence(t *testing.T) {
+
+	if UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
+
+	sgCollection, ok := bucket.Bucket.(*Collection)
+	require.True(t, ok)
+
+	// create config
+	c := sgCollection.Collection
+	cp := &XattrBootstrapPersistence{}
+	configBody := make(map[string]interface{})
+	configBody["sampleConfig"] = "value"
+	configKey := "testConfigKey"
+	_, marshalErr := JSONMarshal(configBody)
+	require.NoError(t, marshalErr)
+
+	insertCas, insertErr := cp.insertConfig(c, configKey, configBody)
+	require.NoError(t, insertErr)
+
+	// modify the document body directly in the bucket
+	updatedBody := make(map[string]interface{})
+	updatedBody["unexpected"] = "value"
+	err := bucket.Set(configKey, 0, updatedBody)
+	require.NoError(t, err)
+
+	// attempt to re-insert, must return ErrAlreadyExists
+	_, reinsertErr := cp.insertConfig(c, configKey, configBody)
+	require.Equal(t, ErrAlreadyExists, reinsertErr)
+
+	// Retrieve the config, cas should still match insertCas
+	var loadedConfig map[string]interface{}
+	loadCas, loadErr := cp.loadConfig(c, configKey, &loadedConfig)
+	require.NoError(t, loadErr)
+	assert.Equal(t, insertCas, loadCas)
+	assert.Equal(t, configBody["sampleConfig"], loadedConfig["sampleConfig"])
+
+	// set the document to an empty body, shouldn't be treated as delete
+	err = bucket.Set(configKey, 0, nil)
+	require.NoError(t, err)
+
+	// Retrieve the config, cas should still match insertCas
+	loadCas, loadErr = cp.loadConfig(c, configKey, &loadedConfig)
+	require.NoError(t, loadErr)
+	assert.Equal(t, insertCas, loadCas)
+	assert.Equal(t, configBody["sampleConfig"], loadedConfig["sampleConfig"])
+
+	// Fetch the document directly from the bucket to verify resurrect handling didn't occur
+	var docBody map[string]interface{}
+	_, err = bucket.Get(configKey, &docBody)
+	assert.NoError(t, err)
+	assert.True(t, docBody == nil)
+
+	// delete the document directly in the bucket (system xattr will be preserved)
+	deleteErr := bucket.Delete(configKey)
+	assert.NoError(t, deleteErr)
+
+	// Retrieve the config, cas should still match insertCas
+	loadCas, loadErr = cp.loadConfig(c, configKey, &loadedConfig)
+	require.NoError(t, loadErr)
+	assert.Equal(t, insertCas, loadCas)
+	assert.Equal(t, configBody["sampleConfig"], loadedConfig["sampleConfig"])
+
+	// Fetch the document directly from the bucket to verify resurrect handling DID occur
+	_, err = bucket.Get(configKey, &docBody)
+	assert.NoError(t, err)
+	assert.True(t, docBody != nil)
+
+	// Retrieve the config, cas should still match insertCas
+	loadCas, loadErr = cp.loadConfig(c, configKey, &loadedConfig)
+	require.NoError(t, loadErr)
+	assert.Equal(t, insertCas, loadCas)
+	assert.Equal(t, configBody["sampleConfig"], loadedConfig["sampleConfig"])
+	/*
+		rawConfig, rawCas, rawErr := cp.loadRawConfig(c, configKey)
+		require.NoError(t, rawErr)
+		assert.Equal(t, insertCas, uint64(rawCas))
+		assert.Equal(t, rawConfigBody, rawConfig)
+
+		configBody["updated"] = true
+		updatedRawBody, marshalErr := JSONMarshal(configBody)
+		require.NoError(t, marshalErr)
+
+		// update with incorrect cas
+		_, _, updateErr := cp.replaceRawConfig(c, configKey, updatedRawBody, 1234)
+		require.Error(t, updateErr)
+
+		// update with correct cas
+		updateCas, _, updateErr := cp.replaceRawConfig(c, configKey, updatedRawBody, gocb.Cas(insertCas))
+		require.NoError(t, updateErr)
+
+		// retrieve config, validate updated value
+		var updatedConfig map[string]interface{}
+		loadCas, loadErr = cp.loadConfig(c, configKey, &updatedConfig)
+		require.NoError(t, loadErr)
+		assert.Equal(t, updateCas, gocb.Cas(loadCas))
+		assert.Equal(t, configBody["updated"], updatedConfig["updated"])
+
+		// retrieve raw config, validate updated value
+		rawConfig, rawCas, rawErr = cp.loadRawConfig(c, configKey)
+		require.NoError(t, rawErr)
+		assert.Equal(t, updateCas, rawCas)
+		assert.Equal(t, updatedRawBody, rawConfig)
+
+		// delete with incorrect cas
+		_, removeErr := cp.removeRawConfig(c, configKey, gocb.Cas(insertCas))
+		require.Error(t, removeErr)
+
+		// delete with correct cas
+		_, removeErr = cp.removeRawConfig(c, configKey, updateCas)
+		require.NoError(t, removeErr)
+
+		// attempt to retrieve config, validate not found
+		var deletedConfig map[string]interface{}
+		loadCas, loadErr = cp.loadConfig(c, configKey, &deletedConfig)
+		assert.Equal(t, ErrNotFound, loadErr)
+
+		// attempt to retrieve raw config, validate updated value
+		rawConfig, rawCas, rawErr = cp.loadRawConfig(c, configKey)
+		assert.Equal(t, ErrNotFound, loadErr)
+	*/
+
+}

--- a/base/config_persistence_test.go
+++ b/base/config_persistence_test.go
@@ -48,6 +48,10 @@ func TestConfigPersistence(t *testing.T) {
 			insertCas, insertErr := cp.insertConfig(c, configKey, configBody)
 			require.NoError(t, insertErr)
 
+			// attempt to re-insert, must return ErrAlreadyExists
+			_, reinsertErr := cp.insertConfig(c, configKey, configBody)
+			require.Equal(t, ErrAlreadyExists, reinsertErr)
+
 			var loadedConfig map[string]interface{}
 			loadCas, loadErr := cp.loadConfig(c, configKey, &loadedConfig)
 			require.NoError(t, loadErr)
@@ -64,11 +68,11 @@ func TestConfigPersistence(t *testing.T) {
 			require.NoError(t, marshalErr)
 
 			// update with incorrect cas
-			_, updateErr := cp.replaceRawConfig(c, configKey, updatedRawBody, 1234)
+			_, _, updateErr := cp.replaceRawConfig(c, configKey, updatedRawBody, 1234)
 			require.Error(t, updateErr)
 
 			// update with correct cas
-			updateCas, updateErr := cp.replaceRawConfig(c, configKey, updatedRawBody, gocb.Cas(insertCas))
+			updateCas, _, updateErr := cp.replaceRawConfig(c, configKey, updatedRawBody, gocb.Cas(insertCas))
 			require.NoError(t, updateErr)
 
 			// retrieve config, validate updated value

--- a/base/config_persistence_test.go
+++ b/base/config_persistence_test.go
@@ -1,0 +1,106 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/couchbase/gocb/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigPersistence(t *testing.T) {
+
+	if UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
+
+	sgCollection, ok := bucket.Bucket.(*Collection)
+	require.True(t, ok)
+
+	c := sgCollection.Collection
+
+	testCases := []struct {
+		name                  string
+		configPersistenceImpl ConfigPersistence
+	}{
+		{
+			name:                  "document body persistence",
+			configPersistenceImpl: &DocumentBootstrapPersistence{},
+		},
+		{
+			name:                  "xattr persistence",
+			configPersistenceImpl: &XattrBootstrapPersistence{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			cp := testCase.configPersistenceImpl
+			configBody := make(map[string]interface{})
+			configBody["sampleConfig"] = "value"
+			configKey := "testConfigKey"
+			rawConfigBody, marshalErr := JSONMarshal(configBody)
+			require.NoError(t, marshalErr)
+
+			insertCas, insertErr := cp.insertConfig(c, configKey, configBody)
+			require.NoError(t, insertErr)
+
+			var loadedConfig map[string]interface{}
+			loadCas, loadErr := cp.loadConfig(c, configKey, &loadedConfig)
+			require.NoError(t, loadErr)
+			assert.Equal(t, insertCas, loadCas)
+			assert.Equal(t, configBody["sampleConfig"], loadedConfig["sampleConfig"])
+
+			rawConfig, rawCas, rawErr := cp.loadRawConfig(c, configKey)
+			require.NoError(t, rawErr)
+			assert.Equal(t, insertCas, uint64(rawCas))
+			assert.Equal(t, rawConfigBody, rawConfig)
+
+			configBody["updated"] = true
+			updatedRawBody, marshalErr := JSONMarshal(configBody)
+			require.NoError(t, marshalErr)
+
+			// update with incorrect cas
+			_, updateErr := cp.replaceRawConfig(c, configKey, updatedRawBody, 1234)
+			require.Error(t, updateErr)
+
+			// update with correct cas
+			updateCas, updateErr := cp.replaceRawConfig(c, configKey, updatedRawBody, gocb.Cas(insertCas))
+			require.NoError(t, updateErr)
+
+			// retrieve config, validate updated value
+			var updatedConfig map[string]interface{}
+			loadCas, loadErr = cp.loadConfig(c, configKey, &updatedConfig)
+			require.NoError(t, loadErr)
+			assert.Equal(t, updateCas, gocb.Cas(loadCas))
+			assert.Equal(t, configBody["updated"], updatedConfig["updated"])
+
+			// retrieve raw config, validate updated value
+			rawConfig, rawCas, rawErr = cp.loadRawConfig(c, configKey)
+			require.NoError(t, rawErr)
+			assert.Equal(t, updateCas, rawCas)
+			assert.Equal(t, updatedRawBody, rawConfig)
+
+			// delete with incorrect cas
+			_, removeErr := cp.removeRawConfig(c, configKey, gocb.Cas(insertCas))
+			require.Error(t, removeErr)
+
+			// delete with correct cas
+			_, removeErr = cp.removeRawConfig(c, configKey, updateCas)
+			require.NoError(t, removeErr)
+
+			// attempt to retrieve config, validate not found
+			var deletedConfig map[string]interface{}
+			loadCas, loadErr = cp.loadConfig(c, configKey, &deletedConfig)
+			assert.Equal(t, ErrNotFound, loadErr)
+
+			// attempt to retrieve raw config, validate updated value
+			rawConfig, rawCas, rawErr = cp.loadRawConfig(c, configKey)
+			assert.Equal(t, ErrNotFound, loadErr)
+		})
+	}
+
+}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -115,7 +115,7 @@ func (h *handler) handleCreateDB() error {
 			return base.HTTPErrorf(http.StatusInternalServerError, "couldn't save database config: %v", err)
 		}
 		// store the cas in the loaded config after a successful insert
-		h.server.dbConfigs[dbName].cas = cas
+		h.server.dbConfigs[dbName].cfgCas = cas
 	} else {
 		// Intentionally pass in an empty BootstrapConfig to avoid inheriting any credentials or server when running with a legacy config (CBG-1764)
 		if err := config.setup(dbName, BootstrapConfig{}, nil); err != nil {
@@ -225,7 +225,7 @@ func (h *handler) handleGetDbConfig() error {
 		// refresh_config=true forces the config loaded out of the bucket to be applied on the node
 		if h.getBoolQuery("refresh_config") && h.server.bootstrapContext.connection != nil {
 			// set cas=0 to force a refresh
-			dbConfig.cas = 0
+			dbConfig.cfgCas = 0
 			h.server.applyConfigs(map[string]DatabaseConfig{h.db.Name: *dbConfig})
 		}
 
@@ -578,7 +578,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 		return err
 	}
 	// store the cas in the loaded config after a successful update
-	h.server.dbConfigs[dbName].cas = cas
+	h.server.dbConfigs[dbName].cfgCas = cas
 	h.response.Header().Set("ETag", updatedDbConfig.Version)
 	return base.HTTPErrorf(http.StatusCreated, "updated")
 
@@ -649,7 +649,7 @@ func (h *handler) handleDeleteDbConfigSync() error {
 	if err != nil {
 		return err
 	}
-	updatedDbConfig.cas = cas
+	updatedDbConfig.cfgCas = cas
 
 	dbName := h.db.Name
 	dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
@@ -714,7 +714,7 @@ func (h *handler) handlePutDbConfigSync() error {
 	if err != nil {
 		return err
 	}
-	updatedDbConfig.cas = cas
+	updatedDbConfig.cfgCas = cas
 
 	dbName := h.db.Name
 	dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
@@ -796,7 +796,7 @@ func (h *handler) handleDeleteDbConfigImportFilter() error {
 	if err != nil {
 		return err
 	}
-	updatedDbConfig.cas = cas
+	updatedDbConfig.cfgCas = cas
 
 	dbName := h.db.Name
 	dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
@@ -861,7 +861,7 @@ func (h *handler) handlePutDbConfigImportFilter() error {
 	if err != nil {
 		return err
 	}
-	updatedDbConfig.cas = cas
+	updatedDbConfig.cfgCas = cas
 
 	dbName := h.db.Name
 	dbCreds, _ := h.server.config.DatabaseCredentials[dbName]

--- a/rest/config.go
+++ b/rest/config.go
@@ -1062,11 +1062,11 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 
 // fetchAndLoadConfigs retrieves all database configs from the ServerContext's bootstrapConnection, and loads them into the ServerContext.
 // It will remove any databases currently running that are not found in the bucket.
-func (sc *ServerContext) fetchAndLoadConfigs() (count int, err error) {
+func (sc *ServerContext) fetchAndLoadConfigs(isInitialStartup bool) (count int, err error) {
 	sc.lock.Lock()
 	defer sc.lock.Unlock()
 
-	fetchedConfigs, err := sc.fetchConfigs()
+	fetchedConfigs, err := sc.fetchConfigs(isInitialStartup)
 	if err != nil {
 		return 0, err
 	}
@@ -1158,7 +1158,7 @@ func (sc *ServerContext) fetchDatabase(dbName string) (found bool, dbConfig *Dat
 }
 
 // fetchConfigs retrieves all database configs from the ServerContext's bootstrapConnection.
-func (sc *ServerContext) fetchConfigs() (dbNameConfigs map[string]DatabaseConfig, err error) {
+func (sc *ServerContext) fetchConfigs(isInitialStartup bool) (dbNameConfigs map[string]DatabaseConfig, err error) {
 	buckets, err := sc.bootstrapContext.connection.GetConfigBuckets()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get buckets from cluster: %w", err)
@@ -1177,7 +1177,11 @@ func (sc *ServerContext) fetchConfigs() (dbNameConfigs map[string]DatabaseConfig
 		if err != nil {
 			// Unexpected error fetching config - SDK has already performed retries, so we'll treat it as a database removal
 			// this could be due to invalid JSON or some other non-recoverable error.
-			base.DebugfCtx(context.TODO(), base.KeyConfig, "Unable to fetch config for group %q from bucket %q: %v", sc.config.Bootstrap.ConfigGroupID, bucket, err)
+			if isInitialStartup {
+				base.WarnfCtx(context.TODO(), "Unable to fetch config for group %q from bucket %q on startup: %v", sc.config.Bootstrap.ConfigGroupID, bucket, err)
+			} else {
+				base.DebugfCtx(context.TODO(), base.KeyConfig, "Unable to fetch config for group %q from bucket %q: %v", sc.config.Bootstrap.ConfigGroupID, bucket, err)
+			}
 			continue
 		}
 
@@ -1313,7 +1317,7 @@ func (sc *ServerContext) addLegacyPrincipals(legacyDbUsers, legacyDbRoles map[st
 // startServer starts and runs the server with the given configuration. (This function never returns.)
 func startServer(config *StartupConfig, sc *ServerContext) error {
 	if config.API.ProfileInterface != "" {
-		//runtime.MemProfileRate = 10 * 1024
+		// runtime.MemProfileRate = 10 * 1024
 		base.Infof(base.KeyAll, "Starting profile server on %s", base.UD(config.API.ProfileInterface))
 		go func() {
 			_ = http.ListenAndServe(config.API.ProfileInterface, nil)

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -8,10 +8,10 @@ import (
 
 // DatabaseConfig is a 3.x/persisted database config that represents a config stored in the bucket.
 type DatabaseConfig struct {
-	// cas is the Couchbase Server CAS of the database config in the bucket
+	// cas is the Couchbase Server CAS for the last mutation of the database config in the bucket
 	// used to skip applying configs to SG nodes that already have an up-to-date config.
 	// This value can be explicitly set to 0 before applyConfig to force reload.
-	cas uint64
+	cfgCas uint64
 
 	// Version is a generated Rev ID used for optimistic concurrency control using ETags/If-Match headers.
 	Version string `json:"version,omitempty"`

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -119,6 +119,7 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 
 		"unsupported.stats_log_frequency": {&config.Unsupported.StatsLogFrequency, fs.String("unsupported.stats_log_frequency", "", "How often should stats be written to stats logs")},
 		"unsupported.use_stdlib_json":     {&config.Unsupported.UseStdlibJSON, fs.Bool("unsupported.use_stdlib_json", false, "Bypass the jsoniter package and use Go's stdlib instead")},
+		"unsupported.use_xattr_config":    {&config.Unsupported.UseXattrConfig, fs.Bool("unsupported.use_xattr_config", false, "Store database configurations in system xattrs")},
 
 		"unsupported.http2.enabled": {&config.Unsupported.HTTP2.Enabled, fs.Bool("unsupported.http2.enabled", false, "Whether HTTP2 support is enabled")},
 

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -286,7 +286,7 @@ func (dbc *DbConfig) ToDatabaseConfig() *DatabaseConfig {
 	}
 
 	return &DatabaseConfig{
-		cas:      0,
+		cfgCas:   0,
 		DbConfig: *dbc,
 	}
 }

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -136,6 +136,7 @@ type ReplicatorConfig struct {
 type UnsupportedConfig struct {
 	StatsLogFrequency *base.ConfigDuration `json:"stats_log_frequency,omitempty"    help:"How often should stats be written to stats logs"`
 	UseStdlibJSON     *bool                `json:"use_stdlib_json,omitempty"        help:"Bypass the jsoniter package and use Go's stdlib instead"`
+	UseXattrConfig    *bool                `json:"use_xattr_config,omitempty"       help:"Store database configurations in system xattrs"`
 
 	HTTP2 *HTTP2Config `json:"http2,omitempty"`
 }

--- a/rest/main.go
+++ b/rest/main.go
@@ -358,7 +358,7 @@ func backupCurrentConfigFile(sourcePath string) (string, error) {
 func createCouchbaseClusterFromStartupConfig(config *StartupConfig) (*base.CouchbaseCluster, error) {
 	cluster, err := base.NewCouchbaseCluster(config.Bootstrap.Server, config.Bootstrap.Username,
 		config.Bootstrap.Password, config.Bootstrap.X509CertPath, config.Bootstrap.X509KeyPath,
-		config.Bootstrap.CACertPath, config.Bootstrap.ServerTLSSkipVerify)
+		config.Bootstrap.CACertPath, config.Bootstrap.ServerTLSSkipVerify, config.Unsupported.UseXattrConfig)
 	if err != nil {
 		base.Infof(base.KeyConfig, "Couldn't create couchbase cluster instance: %v", err)
 		return nil, err

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -22,7 +22,7 @@ type RestTesterCluster struct {
 // RefreshClusterDbConfigs will synchronously fetch the latest db configs from each bucket for each RestTester.
 func (rtc *RestTesterCluster) RefreshClusterDbConfigs() (count int, err error) {
 	for _, rt := range rtc.restTesters {
-		c, err := rt.ServerContext().fetchAndLoadConfigs()
+		c, err := rt.ServerContext().fetchAndLoadConfigs(false)
 		if err != nil {
 			return 0, err
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1412,7 +1412,7 @@ func (sc *ServerContext) initializeCouchbaseServerConnections() error {
 
 		sc.bootstrapContext.connection = couchbaseCluster
 
-		count, err := sc.fetchAndLoadConfigs()
+		count, err := sc.fetchAndLoadConfigs(true)
 		if err != nil {
 			return err
 		}
@@ -1439,7 +1439,7 @@ func (sc *ServerContext) initializeCouchbaseServerConnections() error {
 						return
 					case <-t.C:
 						base.Debugf(base.KeyConfig, "Fetching configs from buckets in cluster for group %q", sc.config.Bootstrap.ConfigGroupID)
-						count, err := sc.fetchAndLoadConfigs()
+						count, err := sc.fetchAndLoadConfigs(false)
 						if err != nil {
 							base.Warnf("Couldn't load configs from bucket when polled: %v", err)
 						}


### PR DESCRIPTION
Adds a new unsupported config flag for system xattr storage of persistent database config.  Abstracts config storage using a new ConfigPersistence interface.  The existing document body storage is implemented by DocumentBootstrapPersistence, the new xattr storage by XattrBootstrapPersistence.  

The new implementation differentiates between the document cas (used for cas-safe updates) and the config cas (used to detect whether a config has changed).  The latter has been renamed cfgCas.  When using DocumentBootstrapPersistence, these values are the same.  When using xattr storage, cas is stamped into the xattr when the config changes via macro expansion, and this value is used as cfgCas. 

If a config document is deleted directly in the bucket when using XattrBootstrapPersistence, it will be recreated on next load (with preserved system xattr).  

Does not support backwards compatibility with non-xattr storage.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration/1597/
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/263
