### PR TITLE
[3.0.1] Conditional startup config fetch warnings

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -1062,11 +1062,11 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 
 // fetchAndLoadConfigs retrieves all database configs from the ServerContext's bootstrapConnection, and loads them into the ServerContext.
 // It will remove any databases currently running that are not found in the bucket.
-func (sc *ServerContext) fetchAndLoadConfigs() (count int, err error) {
+func (sc *ServerContext) fetchAndLoadConfigs(isInitialStartup bool) (count int, err error) {
 	sc.lock.Lock()
 	defer sc.lock.Unlock()
 
-	fetchedConfigs, err := sc.fetchConfigs()
+	fetchedConfigs, err := sc.fetchConfigs(isInitialStartup)
 	if err != nil {
 		return 0, err
 	}
@@ -1158,7 +1158,7 @@ func (sc *ServerContext) fetchDatabase(dbName string) (found bool, dbConfig *Dat
 }
 
 // fetchConfigs retrieves all database configs from the ServerContext's bootstrapConnection.
-func (sc *ServerContext) fetchConfigs() (dbNameConfigs map[string]DatabaseConfig, err error) {
+func (sc *ServerContext) fetchConfigs(isInitialStartup bool) (dbNameConfigs map[string]DatabaseConfig, err error) {
 	buckets, err := sc.bootstrapContext.connection.GetConfigBuckets()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get buckets from cluster: %w", err)
@@ -1177,7 +1177,11 @@ func (sc *ServerContext) fetchConfigs() (dbNameConfigs map[string]DatabaseConfig
 		if err != nil {
 			// Unexpected error fetching config - SDK has already performed retries, so we'll treat it as a database removal
 			// this could be due to invalid JSON or some other non-recoverable error.
-			base.DebugfCtx(context.TODO(), base.KeyConfig, "Unable to fetch config for group %q from bucket %q: %v", sc.config.Bootstrap.ConfigGroupID, bucket, err)
+			if isInitialStartup {
+				base.WarnfCtx(context.TODO(), "Unable to fetch config for group %q from bucket %q on startup: %v", sc.config.Bootstrap.ConfigGroupID, bucket, err)
+			} else {
+				base.DebugfCtx(context.TODO(), base.KeyConfig, "Unable to fetch config for group %q from bucket %q: %v", sc.config.Bootstrap.ConfigGroupID, bucket, err)
+			}
 			continue
 		}
 
@@ -1313,7 +1317,7 @@ func (sc *ServerContext) addLegacyPrincipals(legacyDbUsers, legacyDbRoles map[st
 // startServer starts and runs the server with the given configuration. (This function never returns.)
 func startServer(config *StartupConfig, sc *ServerContext) error {
 	if config.API.ProfileInterface != "" {
-		//runtime.MemProfileRate = 10 * 1024
+		// runtime.MemProfileRate = 10 * 1024
 		base.Infof(base.KeyAll, "Starting profile server on %s", base.UD(config.API.ProfileInterface))
 		go func() {
 			_ = http.ListenAndServe(config.API.ProfileInterface, nil)

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -22,7 +22,7 @@ type RestTesterCluster struct {
 // RefreshClusterDbConfigs will synchronously fetch the latest db configs from each bucket for each RestTester.
 func (rtc *RestTesterCluster) RefreshClusterDbConfigs() (count int, err error) {
 	for _, rt := range rtc.restTesters {
-		c, err := rt.ServerContext().fetchAndLoadConfigs()
+		c, err := rt.ServerContext().fetchAndLoadConfigs(false)
 		if err != nil {
 			return 0, err
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1412,7 +1412,7 @@ func (sc *ServerContext) initializeCouchbaseServerConnections() error {
 
 		sc.bootstrapContext.connection = couchbaseCluster
 
-		count, err := sc.fetchAndLoadConfigs()
+		count, err := sc.fetchAndLoadConfigs(true)
 		if err != nil {
 			return err
 		}
@@ -1439,7 +1439,7 @@ func (sc *ServerContext) initializeCouchbaseServerConnections() error {
 						return
 					case <-t.C:
 						base.Debugf(base.KeyConfig, "Fetching configs from buckets in cluster for group %q", sc.config.Bootstrap.ConfigGroupID)
-						count, err := sc.fetchAndLoadConfigs()
+						count, err := sc.fetchAndLoadConfigs(false)
 						if err != nil {
 							base.Warnf("Couldn't load configs from bucket when polled: %v", err)
 						}


### PR DESCRIPTION
Proposed solution to allow warnings AND debug logging for fetch config errors based on initial startup or background config update.
 
This parameter (or an equivalent) was also required for a 3.1.0 feature to conditionally enable config version validation in #5495 whilst running, but not on initial startup.

## TODO
- [x] Forward-port into master if merged 


Jenkins pipeline failing to start due to temporary/unrelated issue, but GH actions running clean

```
[2022-05-13T09:03:12.070Z] + go get -v -u github.com/kisielk/errcheck
[2022-05-13T09:03:12.070Z] github.com/kisielk/errcheck (download)
[2022-05-13T09:03:12.070Z] created GOPATH=/home/ec2-user/workspace/Sync_Gateway_Pipeline_PR-5541/gotools; see 'go help gopath'
[2022-05-13T09:03:12.070Z] # cd .; git clone -- https://github.com/kisielk/errcheck /home/ec2-user/workspace/Sync_Gateway_Pipeline_PR-5541/gotools/src/github.com/kisielk/errcheck
[2022-05-13T09:03:12.070Z] Cloning into '/home/ec2-user/workspace/Sync_Gateway_Pipeline_PR-5541/gotools/src/github.com/kisielk/errcheck'...
[2022-05-13T09:03:12.070Z] Permission denied (publickey).
[2022-05-13T09:03:12.070Z] fatal: Could not read from remote repository.
[2022-05-13T09:03:12.070Z] 
[2022-05-13T09:03:12.070Z] Please make sure you have the correct access rights
[2022-05-13T09:03:12.070Z] and the repository exists.
[2022-05-13T09:03:12.070Z] package github.com/kisielk/errcheck: exit status 128
script returned exit code 1
```
