### PR TITLE
CBG-2072 [3.0.1 backport] ensure CRC32 hashes are always 8 characters

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -13,6 +13,7 @@ package base
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -71,7 +72,9 @@ func StartShardedDCPFeed(dbName string, configGroup string, uuid string, heartbe
 // Given a dbName, generate a unique and length-constrained index name for CBGT to use as part of their DCP name.
 func GenerateIndexName(dbName string) string {
 	// Index names *must* start with a letter, so we'll prepend 'db' before the per-database checksum (which starts with '0x')
-	return "db" + Crc32cHashString([]byte(dbName)) + "_index"
+	// Don't use Crc32cHashString here becuase this is intentionally non zero padded to match
+	// existing values.
+	return fmt.Sprintf("db0x%x_index", Crc32cHash([]byte(dbName)))
 }
 
 // Given a dbName, generates a name based on the approach used prior to CBG-626.  Used for upgrade handling

--- a/base/dcp_sharded_test.go
+++ b/base/dcp_sharded_test.go
@@ -1,0 +1,29 @@
+package base
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndexName(t *testing.T) {
+	tests := []struct {
+		dbName    string
+		indexName string
+	}{
+		{
+			dbName:    "",
+			indexName: "db0x0_index",
+		},
+		{
+			dbName:    "foo",
+			indexName: "db0xcfc4ae1d_index",
+		},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("dbName %s -> indexName %s", test.indexName, test.dbName), func(t *testing.T) {
+			require.Equal(t, test.indexName, GenerateIndexName(test.dbName))
+		})
+	}
+}

--- a/base/util.go
+++ b/base/util.go
@@ -1057,8 +1057,9 @@ func Crc32cHash(input []byte) uint32 {
 	return crc32.Checksum(input, table)
 }
 
+// Crc32cHashString returns a zero padded version of a crc32 hash to always be hexidecimal prefixed 8 character string
 func Crc32cHashString(input []byte) string {
-	return fmt.Sprintf("0x%x", Crc32cHash(input))
+	return fmt.Sprintf("0x%08x", Crc32cHash(input))
 }
 
 func SplitHostPort(hostport string) (string, string, error) {

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -1609,3 +1609,26 @@ func TestTerminateAndWaitForClose(t *testing.T) {
 		})
 	}
 }
+
+func TestCrc32cHashString(t *testing.T) {
+	tests := []struct {
+		input string
+		hash  string
+	}{
+		{
+			input: "",
+			hash:  "0x00000000",
+		},
+		{
+			input: "foo",
+			hash:  "0xcfc4ae1d",
+		},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("input %s -> hash %s", test.hash, test.input), func(t *testing.T) {
+			assert.Equal(t, test.hash, Crc32cHashString([]byte(test.input)))
+			// crc32 hashes are always leading 0x + length 8
+			assert.Equal(t, len(test.hash), 10)
+		})
+	}
+}

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -2359,3 +2359,56 @@ func TestImportInternalPropertiesHandling(t *testing.T) {
 		})
 	}
 }
+
+// Test import of an SDK expiry change
+func TestImportTouch(t *testing.T) {
+
+	SkipImportTestsIfNotEnabled(t)
+
+	rtConfig := RestTesterConfig{
+		SyncFn: `function(doc, oldDoc) {
+			if (oldDoc == null) {
+				channel("oldDocNil")
+			}
+			if (doc._deleted) {
+				channel("docDeleted")
+			}
+		}`,
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			AutoImport: false,
+		}},
+	}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+
+	bucket := rt.Bucket()
+
+	// 1. Create a document
+	key := "TestImportTouch"
+	docBody := make(map[string]interface{})
+	docBody["test"] = "TestImportTouch"
+	docBody["channels"] = "ABC"
+
+	_, err := bucket.Add(key, 0, docBody)
+	require.NoError(t, err, "Unable to insert doc TestImportDelete")
+
+	// Attempt to get the document via Sync Gateway, to trigger import.
+	response := rt.SendAdminRequest("GET", "/db/_raw/"+key+"?redact=false", "")
+	require.Equal(t, 200, response.Code)
+	var rawInsertResponse RawResponse
+	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
+	require.NoError(t, err, "Unable to unmarshal raw response")
+	initialRev := rawInsertResponse.Sync.Rev
+
+	// 2. Test import behaviour after SDK touch
+	_, err = bucket.Touch(key, 1000000)
+	require.NoError(t, err, "Unable to touch doc TestImportTouch")
+
+	// Attempt to get the document via Sync Gateway, to trigger import.
+	response = rt.SendAdminRequest("GET", "/db/_raw/"+key+"?redact=false", "")
+	require.Equal(t, 200, response.Code)
+	var rawUpdateResponse RawResponse
+	err = base.JSONUnmarshal(response.Body.Bytes(), &rawUpdateResponse)
+	require.NoError(t, err, "Unable to unmarshal raw response")
+	require.Equal(t, initialRev, rawUpdateResponse.Sync.Rev)
+}


### PR DESCRIPTION
Backports CBG-2071 to 3.0.1

