### PR TITLE
Forward-port: Conditionally log at warn level on initial startup for config fetch errors

### DIFF
--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -22,7 +22,7 @@ type RestTesterCluster struct {
 // RefreshClusterDbConfigs will synchronously fetch the latest db configs from each bucket for each RestTester.
 func (rtc *RestTesterCluster) RefreshClusterDbConfigs() (count int, err error) {
 	for _, rt := range rtc.restTesters {
-		c, err := rt.ServerContext().fetchAndLoadConfigs()
+		c, err := rt.ServerContext().fetchAndLoadConfigs(false)
 		if err != nil {
 			return 0, err
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1418,7 +1418,7 @@ func (sc *ServerContext) initializeCouchbaseServerConnections() error {
 
 		sc.bootstrapContext.connection = couchbaseCluster
 
-		count, err := sc.fetchAndLoadConfigs()
+		count, err := sc.fetchAndLoadConfigs(true)
 		if err != nil {
 			return err
 		}
@@ -1446,7 +1446,7 @@ func (sc *ServerContext) initializeCouchbaseServerConnections() error {
 						return
 					case <-t.C:
 						base.DebugfCtx(logCtx, base.KeyConfig, "Fetching configs from buckets in cluster for group %q", sc.config.Bootstrap.ConfigGroupID)
-						count, err := sc.fetchAndLoadConfigs()
+						count, err := sc.fetchAndLoadConfigs(false)
 						if err != nil {
 							base.WarnfCtx(logCtx, "Couldn't load configs from bucket when polled: %v", err)
 						}


### PR DESCRIPTION
Forward port 3.0.1 fix #5541 into master