### PR TITLE
Refactor db.UpdatePrincipal to take a struct from the auth package

### DIFF
--- a/auth/principal.go
+++ b/auth/principal.go
@@ -151,13 +151,13 @@ type User interface {
 // Name must always be specified, the other fields can be omitted to keep their current value.
 type PrincipalUpdates struct {
 	Name             string
-	ExplicitChannels *base.Set
+	ExplicitChannels base.Set
 	// Users only
 	Email             *string
 	OIDCIssuer        *string
 	Password          *string
 	Disabled          *bool
-	ExplicitRoleNames *base.Set
+	ExplicitRoleNames base.Set
 }
 
 // Merge returns a new PrincipalUpdates that represents the combination of both this and other's changes.

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -198,12 +198,8 @@ func (u PrincipalConfig) IsPasswordValid(allowEmptyPass bool) (isValid bool, rea
 // Merge returns a new PrincipalConfig that represents the combination of both this and other's changes.
 // If any changes conflict, those of the other take precedence.
 func (u PrincipalConfig) Merge(other PrincipalConfig) PrincipalConfig {
-	name := u.Name
-	if other.Name != nil {
-		name = other.Name
-	}
 	return PrincipalConfig{
-		Name:              name,
+		Name:              base.CoalesceStrings(other.Name, u.Name),
 		ExplicitChannels:  base.CoalesceSets(other.ExplicitChannels, u.ExplicitChannels),
 		Email:             base.CoalesceStrings(other.Email, u.Email),
 		Password:          base.CoalesceStrings(other.Password, u.Password),

--- a/base/util.go
+++ b/base/util.go
@@ -1684,7 +1684,7 @@ func CoalesceStrings(a, b *string) *string {
 }
 
 // CoalesceSets returns the first non-nil argument, or nil if both are nil.
-func CoalesceSets(a, b *Set) *Set {
+func CoalesceSets(a, b Set) Set {
 	if a != nil {
 		return a
 	}

--- a/base/util.go
+++ b/base/util.go
@@ -1669,3 +1669,38 @@ func TerminateAndWaitForClose(terminator chan struct{}, done chan struct{}, time
 
 	return nil
 }
+
+// TODO: replace these with a generic implementation once we upgrade to Go 1.18
+
+// CoalesceStrings returns the first non-nil argument, or nil if both are nil.
+func CoalesceStrings(a, b *string) *string {
+	if a != nil {
+		return a
+	}
+	if b != nil {
+		return b
+	}
+	return nil
+}
+
+// CoalesceSets returns the first non-nil argument, or nil if both are nil.
+func CoalesceSets(a, b *Set) *Set {
+	if a != nil {
+		return a
+	}
+	if b != nil {
+		return b
+	}
+	return nil
+}
+
+// CoalesceBools returns the first non-nil argument, or nil if both are nil.
+func CoalesceBools(a, b *bool) *bool {
+	if a != nil {
+		return a
+	}
+	if b != nil {
+		return b
+	}
+	return nil
+}

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -915,7 +915,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, userInfo)
 	userInfo.ExplicitChannels = base.SetOf("ABC", "PBS")
-	_, err = db.UpdatePrincipal(base.TestCtx(t), userInfo.AsPrincipalUpdates(), true, true)
+	_, err = db.UpdatePrincipal(base.TestCtx(t), userInfo, true, true)
 	require.NoError(t, err, "UpdatePrincipal failed")
 
 	WriteDirect(db, []string{"PBS"}, 9)

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -915,7 +915,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, userInfo)
 	userInfo.ExplicitChannels = base.SetOf("ABC", "PBS")
-	_, err = db.UpdatePrincipal(base.TestCtx(t), *userInfo, true, true)
+	_, err = db.UpdatePrincipal(base.TestCtx(t), userInfo.AsPrincipalUpdates(), true, true)
 	require.NoError(t, err, "UpdatePrincipal failed")
 
 	WriteDirect(db, []string{"PBS"}, 9)

--- a/db/change_listener_test.go
+++ b/db/change_listener_test.go
@@ -127,8 +127,8 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 
 	// Update the role to grant a new channel
 	updatedRole := PrincipalConfig{
-		Name:     &roleName,
-		Channels: base.SetFromArray([]string{"ABC"}),
+		Name:             &roleName,
+		ExplicitChannels: base.SetFromArray([]string{"DEF"}),
 	}
 	_, err = db.UpdatePrincipal(ctx, updatedRole.AsPrincipalUpdates(), false, true)
 	require.NoError(t, err, "Error updating role")

--- a/db/change_listener_test.go
+++ b/db/change_listener_test.go
@@ -57,7 +57,7 @@ func TestUserWaiter(t *testing.T) {
 		Name:     &username,
 		Channels: base.SetFromArray([]string{"ABC", "DEF"}),
 	}
-	_, err = db.UpdatePrincipal(ctx, updatedUser, true, true)
+	_, err = db.UpdatePrincipal(ctx, updatedUser.AsPrincipalUpdates(), true, true)
 	require.NoError(t, err, "Error updating user")
 
 	// Wait for notification from grant
@@ -109,7 +109,7 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 		Name:              &username,
 		ExplicitRoleNames: []string{roleName},
 	}
-	_, err = db.UpdatePrincipal(ctx, updatedUser, true, true)
+	_, err = db.UpdatePrincipal(ctx, updatedUser.AsPrincipalUpdates(), true, true)
 	require.NoError(t, err, "Error updating user")
 
 	// Wait for notify from updated user
@@ -130,7 +130,7 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 		Name:     &roleName,
 		Channels: base.SetFromArray([]string{"ABC"}),
 	}
-	_, err = db.UpdatePrincipal(ctx, updatedRole, false, true)
+	_, err = db.UpdatePrincipal(ctx, updatedRole.AsPrincipalUpdates(), false, true)
 	require.NoError(t, err, "Error updating role")
 
 	// Wait for user notification of updated role

--- a/db/change_listener_test.go
+++ b/db/change_listener_test.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"testing"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/stretchr/testify/assert"
@@ -53,11 +54,11 @@ func TestUserWaiter(t *testing.T) {
 	require.True(t, WaitForUserWaiterChange(userWaiter))
 
 	// Update the user to grant new channel
-	updatedUser := PrincipalConfig{
+	updatedUser := auth.PrincipalConfig{
 		Name:             &username,
 		ExplicitChannels: base.SetFromArray([]string{"ABC", "DEF"}),
 	}
-	_, err = db.UpdatePrincipal(ctx, updatedUser.AsPrincipalUpdates(), true, true)
+	_, err = db.UpdatePrincipal(ctx, &updatedUser, true, true)
 	require.NoError(t, err, "Error updating user")
 
 	// Wait for notification from grant
@@ -105,11 +106,11 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 	require.True(t, WaitForUserWaiterChange(userWaiter))
 
 	// Update the user to grant role
-	updatedUser := PrincipalConfig{
+	updatedUser := auth.PrincipalConfig{
 		Name:              &username,
-		ExplicitRoleNames: []string{roleName},
+		ExplicitRoleNames: base.SetOf(roleName),
 	}
-	_, err = db.UpdatePrincipal(ctx, updatedUser.AsPrincipalUpdates(), true, true)
+	_, err = db.UpdatePrincipal(ctx, &updatedUser, true, true)
 	require.NoError(t, err, "Error updating user")
 
 	// Wait for notify from updated user
@@ -126,11 +127,11 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 	userWaiter.RefreshUserKeys(userRefresh)
 
 	// Update the role to grant a new channel
-	updatedRole := PrincipalConfig{
+	updatedRole := auth.PrincipalConfig{
 		Name:             &roleName,
 		ExplicitChannels: base.SetFromArray([]string{"DEF"}),
 	}
-	_, err = db.UpdatePrincipal(ctx, updatedRole.AsPrincipalUpdates(), false, true)
+	_, err = db.UpdatePrincipal(ctx, &updatedRole, false, true)
 	require.NoError(t, err, "Error updating role")
 
 	// Wait for user notification of updated role

--- a/db/change_listener_test.go
+++ b/db/change_listener_test.go
@@ -54,8 +54,8 @@ func TestUserWaiter(t *testing.T) {
 
 	// Update the user to grant new channel
 	updatedUser := PrincipalConfig{
-		Name:     &username,
-		Channels: base.SetFromArray([]string{"ABC", "DEF"}),
+		Name:             &username,
+		ExplicitChannels: base.SetFromArray([]string{"ABC", "DEF"}),
 	}
 	_, err = db.UpdatePrincipal(ctx, updatedUser.AsPrincipalUpdates(), true, true)
 	require.NoError(t, err, "Error updating user")

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -116,7 +116,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	userInfo, err := db.GetPrincipalForTest(t, "naomi", true)
 	assert.True(t, userInfo != nil)
 	userInfo.ExplicitChannels = base.SetOf("ABC", "PBS")
-	_, err = db.UpdatePrincipal(base.TestCtx(t), userInfo.AsPrincipalUpdates(), true, true)
+	_, err = db.UpdatePrincipal(base.TestCtx(t), userInfo, true, true)
 	assert.NoError(t, err, "UpdatePrincipal failed")
 
 	err = db.WaitForPendingChanges(base.TestCtx(t))

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -116,7 +116,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	userInfo, err := db.GetPrincipalForTest(t, "naomi", true)
 	assert.True(t, userInfo != nil)
 	userInfo.ExplicitChannels = base.SetOf("ABC", "PBS")
-	_, err = db.UpdatePrincipal(base.TestCtx(t), *userInfo, true, true)
+	_, err = db.UpdatePrincipal(base.TestCtx(t), userInfo.AsPrincipalUpdates(), true, true)
 	assert.NoError(t, err, "UpdatePrincipal failed")
 
 	err = db.WaitForPendingChanges(base.TestCtx(t))

--- a/db/database.go
+++ b/db/database.go
@@ -1020,7 +1020,7 @@ outerLoop:
 }
 
 // Returns user information for all users (ID, disabled, email)
-func (db *DatabaseContext) GetUsers(ctx context.Context, limit int) (users []PrincipalConfig, err error) {
+func (db *DatabaseContext) GetUsers(ctx context.Context, limit int) (users []auth.PrincipalConfig, err error) {
 
 	if db.Options.UseViews {
 		return nil, errors.New("GetUsers not supported when running with useViews=true")
@@ -1041,7 +1041,7 @@ func (db *DatabaseContext) GetUsers(ctx context.Context, limit int) (users []Pri
 		paginationLimit = limit
 	}
 
-	users = []PrincipalConfig{}
+	users = []auth.PrincipalConfig{}
 
 	totalCount := 0
 
@@ -1068,9 +1068,9 @@ outerLoop:
 			startKey = base.UserPrefix + queryRow.Name
 			resultCount++
 			if queryRow.Name != "" && !skipAddition {
-				principal := PrincipalConfig{
+				principal := auth.PrincipalConfig{
 					Name:     &queryRow.Name,
-					Email:    queryRow.Email,
+					Email:    &queryRow.Email,
 					Disabled: &queryRow.Disabled,
 				}
 				users = append(users, principal)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -889,7 +889,7 @@ func TestUpdatePrincipal(t *testing.T) {
 	// Validate that a call to UpdatePrincipals with no changes to the user doesn't allocate a sequence
 	userInfo, err := db.GetPrincipalForTest(t, "naomi", true)
 	userInfo.ExplicitChannels = base.SetOf("ABC")
-	_, err = db.UpdatePrincipal(base.TestCtx(t), userInfo.AsPrincipalUpdates(), true, true)
+	_, err = db.UpdatePrincipal(base.TestCtx(t), userInfo, true, true)
 	assert.NoError(t, err, "Unable to update principal")
 
 	nextSeq, err := db.sequences.nextSequence()
@@ -898,7 +898,7 @@ func TestUpdatePrincipal(t *testing.T) {
 	// Validate that a call to UpdatePrincipals with changes to the user does allocate a sequence
 	userInfo, err = db.GetPrincipalForTest(t, "naomi", true)
 	userInfo.ExplicitChannels = base.SetOf("ABC", "PBS")
-	_, err = db.UpdatePrincipal(base.TestCtx(t), userInfo.AsPrincipalUpdates(), true, true)
+	_, err = db.UpdatePrincipal(base.TestCtx(t), userInfo, true, true)
 	assert.NoError(t, err, "Unable to update principal")
 
 	nextSeq, err = db.sequences.nextSequence()

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -889,7 +889,7 @@ func TestUpdatePrincipal(t *testing.T) {
 	// Validate that a call to UpdatePrincipals with no changes to the user doesn't allocate a sequence
 	userInfo, err := db.GetPrincipalForTest(t, "naomi", true)
 	userInfo.ExplicitChannels = base.SetOf("ABC")
-	_, err = db.UpdatePrincipal(base.TestCtx(t), *userInfo, true, true)
+	_, err = db.UpdatePrincipal(base.TestCtx(t), userInfo.AsPrincipalUpdates(), true, true)
 	assert.NoError(t, err, "Unable to update principal")
 
 	nextSeq, err := db.sequences.nextSequence()
@@ -898,7 +898,7 @@ func TestUpdatePrincipal(t *testing.T) {
 	// Validate that a call to UpdatePrincipals with changes to the user does allocate a sequence
 	userInfo, err = db.GetPrincipalForTest(t, "naomi", true)
 	userInfo.ExplicitChannels = base.SetOf("ABC", "PBS")
-	_, err = db.UpdatePrincipal(base.TestCtx(t), *userInfo, true, true)
+	_, err = db.UpdatePrincipal(base.TestCtx(t), userInfo.AsPrincipalUpdates(), true, true)
 	assert.NoError(t, err, "Unable to update principal")
 
 	nextSeq, err = db.sequences.nextSequence()

--- a/db/users.go
+++ b/db/users.go
@@ -93,9 +93,14 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 			}
 		}
 
-		// Ensure the caller isn't trying to set all_channels explicitly - it'll get recomputed automatically.
+		// Ensure the caller isn't trying to set all_channels or roles explicitly - it'll get recomputed automatically.
 		if len(updates.Channels) > 0 && !princ.Channels().Equals(updates.Channels) {
 			return false, base.HTTPErrorf(http.StatusBadRequest, "all_channels is read-only")
+		}
+		if user, ok := princ.(auth.User); ok {
+			if len(updates.RoleNames) > 0 && !user.RoleNames().Equals(base.SetFromArray(updates.RoleNames)) {
+				return false, base.HTTPErrorf(http.StatusBadRequest, "roles is read-only")
+			}
 		}
 
 		updatedExplicitChannels := princ.ExplicitChannels()

--- a/db/users.go
+++ b/db/users.go
@@ -97,11 +97,11 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		if len(newInfo.Channels) > 0 && !princ.Channels().Equals(newInfo.Channels) {
 			return false, base.HTTPErrorf(http.StatusBadRequest, "all_channels is read-only")
 		}
-    
-    updatedExplicitChannels := princ.ExplicitChannels()
+
+		updatedExplicitChannels := princ.ExplicitChannels()
 		if updatedExplicitChannels == nil {
 			updatedExplicitChannels = ch.TimedSet{}
-    }
+		}
 
 		updatedChannels := princ.ExplicitChannels()
 		if updatedChannels == nil {

--- a/db/users.go
+++ b/db/users.go
@@ -94,7 +94,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		}
 
 		// Ensure the caller isn't trying to set all_channels explicitly - it'll get recomputed automatically.
-		if len(newInfo.Channels) > 0 && !princ.Channels().Equals(newInfo.Channels) {
+		if len(updates.Channels) > 0 && !princ.Channels().Equals(updates.Channels) {
 			return false, base.HTTPErrorf(http.StatusBadRequest, "all_channels is read-only")
 		}
 

--- a/db/users.go
+++ b/db/users.go
@@ -32,8 +32,8 @@ type PrincipalConfig struct {
 	Password          *string  `json:"password,omitempty"`
 	ExplicitRoleNames []string `json:"admin_roles,omitempty"`
 	// Fields below are read-only
-	Channels        base.Set  `json:"all_channels,omitempty"`
-	RoleNames       []string  `json:"roles,omitempty"`
+	Channels  base.Set `json:"all_channels,omitempty"`
+	RoleNames []string `json:"roles,omitempty"`
 }
 
 // AsPrincipalUpdates converts this PrincipalConfig into a PrincipalUpdates structure.

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -377,7 +377,7 @@ func (dbc *DatabaseContext) ChannelViewForTest(tb testing.TB, channelName string
 }
 
 // Test-only version of GetPrincipal that doesn't trigger channel/role recalculation
-func (dbc *DatabaseContext) GetPrincipalForTest(tb testing.TB, name string, isUser bool) (info *PrincipalConfig, err error) {
+func (dbc *DatabaseContext) GetPrincipalForTest(tb testing.TB, name string, isUser bool) (info *auth.PrincipalConfig, err error) {
 	ctx := base.TestCtx(tb)
 	var princ auth.Principal
 	if isUser {
@@ -388,14 +388,15 @@ func (dbc *DatabaseContext) GetPrincipalForTest(tb testing.TB, name string, isUs
 	if princ == nil {
 		return
 	}
-	info = new(PrincipalConfig)
+	info = new(auth.PrincipalConfig)
 	info.Name = &name
 	info.ExplicitChannels = princ.ExplicitChannels().AsSet()
 	if user, ok := princ.(auth.User); ok {
 		info.Channels = user.InheritedChannels().AsSet()
-		info.Email = user.Email()
+		email := user.Email()
+		info.Email = &email
 		info.Disabled = base.BoolPtr(user.Disabled())
-		info.ExplicitRoleNames = user.ExplicitRoles().AllKeys()
+		info.ExplicitRoleNames = user.ExplicitRoles().AsSet()
 		info.RoleNames = user.RoleNames().AllKeys()
 	} else {
 		info.Channels = princ.Channels().AsSet()

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1223,7 +1223,7 @@ func (h *handler) updatePrincipal(name string, isUser bool) error {
 
 	internalName := internalUserName(*newInfo.Name)
 	newInfo.Name = &internalName
-	replaced, err := h.db.UpdatePrincipal(h.db.Ctx, newInfo, isUser, h.rq.Method != "POST")
+	replaced, err := h.db.UpdatePrincipal(h.db.Ctx, newInfo.AsPrincipalUpdates(), isUser, h.rq.Method != "POST")
 	if err != nil {
 		return err
 	} else if replaced {

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1077,9 +1077,9 @@ func TestDBGetConfigNames(t *testing.T) {
 	p := "password"
 
 	rt.DatabaseConfig = &DatabaseConfig{DbConfig: DbConfig{
-		Users: map[string]*db.PrincipalConfig{
-			"alice": &db.PrincipalConfig{Password: &p},
-			"bob":   &db.PrincipalConfig{Password: &p},
+		Users: map[string]*auth.PrincipalConfig{
+			"alice": &auth.PrincipalConfig{Password: &p},
+			"bob":   &auth.PrincipalConfig{Password: &p},
 		},
 	}}
 
@@ -2494,7 +2494,7 @@ func TestUserAndRoleResponseContentType(t *testing.T) {
 }
 
 func TestConfigRedaction(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{Users: map[string]*db.PrincipalConfig{"alice": {Password: base.StringPtr("password")}}}}})
+	rt := NewRestTester(t, &RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{Users: map[string]*auth.PrincipalConfig{"alice": {Password: base.StringPtr("password")}}}}})
 	defer rt.Close()
 
 	// Test default db config redaction
@@ -4305,7 +4305,7 @@ function (doc) {
 			rtConfig := &RestTesterConfig{
 				SyncFn: syncFunc,
 				DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-					Users: map[string]*db.PrincipalConfig{
+					Users: map[string]*auth.PrincipalConfig{
 						"alice": {
 							Password:         base.StringPtr("pass"),
 							ExplicitChannels: base.SetOf("chanAlpha", "chanBeta", "chanCharlie", "chanHotel", "chanIndia"),
@@ -4437,7 +4437,7 @@ function (doc) {
 func TestReplicatorDeprecatedCredentials(t *testing.T) {
 	passiveRT := NewRestTester(t, &RestTesterConfig{DatabaseConfig: &DatabaseConfig{
 		DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password: base.StringPtr("pass"),
 				},

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -278,6 +278,14 @@ func TestPrincipalForbidUpdatingChannels(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "all_channels":["baz"]}`)
 	assertStatus(t, response, 400)
 
+	// PUT admin_roles
+	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"letmein", "admin_roles":["foo", "bar"]}`)
+	assertStatus(t, response, 200)
+
+	// PUT roles - should fail
+	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "roles":["baz"]}`)
+	assertStatus(t, response, 400)
+
 	// Roles
 	// PUT admin_channels
 	response = rt.SendAdminRequest("PUT", "/db/_role/test", `{"admin_channels":["foo", "bar"]}`)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -96,7 +96,7 @@ func TestDisablePublicBasicAuth(t *testing.T) {
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
 				DisablePasswordAuth: true,
-				Guest: &db.PrincipalConfig{
+				Guest: &auth.PrincipalConfig{
 					Disabled: base.BoolPtr(true),
 				},
 			},

--- a/rest/config.go
+++ b/rest/config.go
@@ -115,8 +115,8 @@ type DbConfig struct {
 	BucketConfig
 	Name                             string                           `json:"name,omitempty"`                                 // Database name in REST API (stored as key in JSON)
 	Sync                             *string                          `json:"sync,omitempty"`                                 // Sync function defines which users can see which data
-	Users                            map[string]*db.PrincipalConfig   `json:"users,omitempty"`                                // Initial user accounts
-	Roles                            map[string]*db.PrincipalConfig   `json:"roles,omitempty"`                                // Initial roles
+	Users                            map[string]*auth.PrincipalConfig `json:"users,omitempty"`                                // Initial user accounts
+	Roles                            map[string]*auth.PrincipalConfig `json:"roles,omitempty"`                                // Initial roles
 	RevsLimit                        *uint32                          `json:"revs_limit,omitempty"`                           // Max depth a document's revision tree can grow to
 	AutoImport                       interface{}                      `json:"import_docs,omitempty"`                          // Whether to automatically import Couchbase Server docs into SG.  Xattrs must be enabled.  true or "continuous" both enable this.
 	ImportPartitions                 *uint16                          `json:"import_partitions,omitempty"`                    // Number of partitions for import sharding.  Impacts the total DCP concurrency for import
@@ -153,7 +153,7 @@ type DbConfig struct {
 	QueryPaginationLimit             *int                             `json:"query_pagination_limit,omitempty"`               // Query limit to be used during pagination of large queries
 	UserXattrKey                     string                           `json:"user_xattr_key,omitempty"`                       // Key of user xattr that will be accessible from the Sync Function. If empty the feature will be disabled.
 	ClientPartitionWindowSecs        *int                             `json:"client_partition_window_secs,omitempty"`         // How long clients can remain offline for without losing replication metadata. Default 30 days (in seconds)
-	Guest                            *db.PrincipalConfig              `json:"guest,omitempty"`                                // Guest user settings
+	Guest                            *auth.PrincipalConfig            `json:"guest,omitempty"`                                // Guest user settings
 }
 
 type DeltaSyncConfig struct {
@@ -1290,7 +1290,7 @@ func (sc *ServerContext) applyConfig(cnf DatabaseConfig) (applied bool, err erro
 // addLegacyPrincipals takes a map of databases that each have a map of names with principle configs.
 // Call this function to install the legacy principles to the upgraded database that use a persistent config.
 // Only call this function after the databases have been initalised via setupServerContext.
-func (sc *ServerContext) addLegacyPrincipals(legacyDbUsers, legacyDbRoles map[string]map[string]*db.PrincipalConfig) {
+func (sc *ServerContext) addLegacyPrincipals(legacyDbUsers, legacyDbRoles map[string]map[string]*auth.PrincipalConfig) {
 	for dbName, dbUser := range legacyDbUsers {
 		dbCtx, err := sc.GetDatabase(dbName)
 		if err != nil {

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/couchbase/gocbcore/v10/connstr"
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/db"
 	pkgerrors "github.com/pkg/errors"
 )
 
@@ -630,7 +630,7 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*LegacyServer
 						CACertPath: *cacertpath,
 						KeyPath:    *keypath,
 					},
-					Users: map[string]*db.PrincipalConfig{
+					Users: map[string]*auth.PrincipalConfig{
 						base.GuestUsername: {
 							Disabled:         base.BoolPtr(false),
 							ExplicitChannels: base.SetFromArray([]string{"*"}),

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -280,7 +280,7 @@ func TestLegacyGuestUserMigration(t *testing.T) {
 		t.Skip("CBS required")
 	}
 
-	expected := db.PrincipalConfig{
+	expected := auth.PrincipalConfig{
 		ExplicitChannels: base.SetFromArray([]string{"*"}),
 		Disabled:         base.BoolPtr(false),
 	}
@@ -358,7 +358,7 @@ func TestLegacyConfigPrinciplesMigration(t *testing.T) {
 	}
 
 	// Add principles already on bucket before migration
-	existingUsers := map[string]*db.PrincipalConfig{
+	existingUsers := map[string]*auth.PrincipalConfig{
 		"ExistingUserStatic": {
 			Name:             base.StringPtr("ExistingUserStatic"),
 			ExplicitChannels: base.SetOf("*"),
@@ -371,7 +371,7 @@ func TestLegacyConfigPrinciplesMigration(t *testing.T) {
 	err := rt.ServerContext().installPrincipals(rt.GetDatabase(), existingUsers, "user")
 	require.NoError(t, err)
 
-	existingRoles := map[string]*db.PrincipalConfig{
+	existingRoles := map[string]*auth.PrincipalConfig{
 		"ExistingRoleStatic": {
 			Name:             base.StringPtr("ExistingRoleStatic"),
 			ExplicitChannels: base.SetOf("*"),

--- a/rest/main.go
+++ b/rest/main.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/db"
 	pkgerrors "github.com/pkg/errors"
 )
 
@@ -69,8 +69,8 @@ func serverMainPersistentConfig(fs *flag.FlagSet, flagStartupConfig *StartupConf
 	}
 
 	var fileStartupConfig *StartupConfig
-	var legacyDbUsers map[string]map[string]*db.PrincipalConfig // [db][user]PrincipleConfig
-	var legacyDbRoles map[string]map[string]*db.PrincipalConfig // [db][roles]PrincipleConfig
+	var legacyDbUsers map[string]map[string]*auth.PrincipalConfig // [db][user]PrincipleConfig
+	var legacyDbRoles map[string]map[string]*auth.PrincipalConfig // [db][roles]PrincipleConfig
 	if len(configPath) == 1 {
 		fileStartupConfig, err = LoadStartupConfigFromPath(configPath[0])
 		if pkgerrors.Cause(err) == base.ErrUnknownField {
@@ -176,7 +176,7 @@ func getInitialStartupConfig(fileStartupConfig *StartupConfig, flagStartupConfig
 // automaticConfigUpgrade takes the config path of the current 2.x config and attempts to perform the update steps to
 // update it to a 3.x config
 // Returns the new startup config, a bool of whether to fallback to legacy config, map of users per database, map of roles per database, and an error
-func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersistentConfig bool, users map[string]map[string]*db.PrincipalConfig, roles map[string]map[string]*db.PrincipalConfig, err error) {
+func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersistentConfig bool, users map[string]map[string]*auth.PrincipalConfig, roles map[string]map[string]*auth.PrincipalConfig, err error) {
 	legacyServerConfig, err := LoadLegacyServerConfig(configPath)
 	if err != nil {
 		return nil, false, nil, nil, err
@@ -214,8 +214,8 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 		}
 
 		// Return users and roles separate from config
-		users = make(map[string]map[string]*db.PrincipalConfig)
-		roles = make(map[string]map[string]*db.PrincipalConfig)
+		users = make(map[string]map[string]*auth.PrincipalConfig)
+		roles = make(map[string]map[string]*auth.PrincipalConfig)
 		users[dbc.Name] = dbc.Users
 		roles[dbc.Name] = dbc.Roles
 		dbc.Roles = nil

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbaselabs/walrus"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -1018,7 +1019,7 @@ func setupSGRPeers(t *testing.T) (activeRT *RestTester, passiveRT *RestTester, r
 	passiveRT = NewRestTester(t, &RestTesterConfig{
 		TestBucket: passiveTestBucket.NoCloseClone(),
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("*"),

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
@@ -37,7 +38,7 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {Password: base.StringPtr("pass")},
 			},
 		}},
@@ -97,7 +98,7 @@ func TestActiveReplicatorHeartbeats(t *testing.T) {
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {Password: base.StringPtr("pass")},
 			},
 		}},
@@ -165,7 +166,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				username: {
 					Password:         base.StringPtr(password),
 					ExplicitChannels: base.SetOf(username),
@@ -255,7 +256,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -436,7 +437,7 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 			// Passive
 			rt2 := NewRestTester(t, &RestTesterConfig{
 				DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-					Users: map[string]*db.PrincipalConfig{
+					Users: map[string]*auth.PrincipalConfig{
 						"alice": {
 							Password:         base.StringPtr("pass"),
 							ExplicitChannels: base.SetOf("alice"),
@@ -576,7 +577,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -741,7 +742,7 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -895,7 +896,7 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -988,7 +989,7 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -1083,7 +1084,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -1209,7 +1210,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -1356,7 +1357,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb1,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -1534,7 +1535,7 @@ func TestActiveReplicatorPushFromCheckpointIgnored(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -1662,7 +1663,7 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -1757,7 +1758,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -1857,7 +1858,7 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -2033,7 +2034,7 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			rt2 := NewRestTester(t, &RestTesterConfig{
 				TestBucket: tb2,
 				DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-					Users: map[string]*db.PrincipalConfig{
+					Users: map[string]*auth.PrincipalConfig{
 						"alice": {
 							Password:         base.StringPtr("pass"),
 							ExplicitChannels: base.SetOf("*"),
@@ -2238,7 +2239,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			rt2 := NewRestTester(t, &RestTesterConfig{
 				TestBucket: base.GetTestBucket(t),
 				DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-					Users: map[string]*db.PrincipalConfig{
+					Users: map[string]*auth.PrincipalConfig{
 						"alice": {
 							Password:         base.StringPtr("pass"),
 							ExplicitChannels: base.SetOf("*"),
@@ -2432,7 +2433,7 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: base.GetTestBucket(t),
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -2509,7 +2510,7 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: base.GetTestBucket(t),
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -2573,7 +2574,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: base.GetTestBucket(t),
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -2728,7 +2729,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -2823,7 +2824,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	rt2 = NewRestTester(t, &RestTesterConfig{
 		TestBucket: base.GetTestBucket(t),
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -2900,7 +2901,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: base.GetTestBucket(t),
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -3056,7 +3057,7 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: base.GetTestBucket(t),
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -3156,7 +3157,7 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 		TestBucket: base.GetTestBucket(t),
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			AllowConflicts: base.BoolPtr(false),
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -3269,7 +3270,7 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("chan1", "chan2"),
@@ -3468,7 +3469,7 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 					rt2 := NewRestTester(t, &RestTesterConfig{
 						TestBucket: tb2,
 						DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-							Users: map[string]*db.PrincipalConfig{
+							Users: map[string]*auth.PrincipalConfig{
 								"alice": {
 									Password:         base.StringPtr("pass"),
 									ExplicitChannels: base.SetOf("alice"),
@@ -3650,7 +3651,7 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
 					Password:         base.StringPtr("pass"),
 					ExplicitChannels: base.SetOf("alice"),
@@ -3767,7 +3768,7 @@ func TestBlipSyncNonUpgradableConnection(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyHTTPResp)
 	rt := NewRestTester(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*db.PrincipalConfig{
+			Users: map[string]*auth.PrincipalConfig{
 				"alice": {Password: base.StringPtr("pass")},
 			},
 		}},
@@ -3990,7 +3991,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 			rt2 := NewRestTester(t, &RestTesterConfig{
 				TestBucket: tb2,
 				DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-					Users: map[string]*db.PrincipalConfig{
+					Users: map[string]*auth.PrincipalConfig{
 						"alice": {
 							Password:         base.StringPtr("pass"),
 							ExplicitChannels: base.SetOf("*"),
@@ -4479,7 +4480,7 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 			rt2 := NewRestTester(t, &RestTesterConfig{
 				TestBucket: base.GetTestBucket(t),
 				DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-					Users: map[string]*db.PrincipalConfig{
+					Users: map[string]*auth.PrincipalConfig{
 						"alice": {
 							Password:         base.StringPtr("pass"),
 							ExplicitChannels: base.SetOf("alice"),
@@ -4631,7 +4632,7 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 			rt2 := NewRestTester(t, &RestTesterConfig{
 				TestBucket: base.GetTestBucket(t),
 				DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-					Users: map[string]*db.PrincipalConfig{
+					Users: map[string]*auth.PrincipalConfig{
 						"alice": {
 							Password:         base.StringPtr("pass"),
 							ExplicitChannels: base.SetOf("alice"),

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -554,7 +554,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config DatabaseConfig, useE
 	}
 
 	if config.Guest != nil {
-		guest := map[string]*db.PrincipalConfig{base.GuestUsername: config.Guest}
+		guest := map[string]*auth.PrincipalConfig{base.GuestUsername: config.Guest}
 		if err := sc.installPrincipals(dbcontext, guest, "user"); err != nil {
 			return nil, err
 		}
@@ -1008,7 +1008,7 @@ func (sc *ServerContext) _removeDatabase(dbName string) bool {
 	return true
 }
 
-func (sc *ServerContext) installPrincipals(dbc *db.DatabaseContext, spec map[string]*db.PrincipalConfig, what string) error {
+func (sc *ServerContext) installPrincipals(dbc *db.DatabaseContext, spec map[string]*auth.PrincipalConfig, what string) error {
 	for name, princ := range spec {
 		isGuest := name == base.GuestUsername
 		if isGuest {
@@ -1022,7 +1022,7 @@ func (sc *ServerContext) installPrincipals(dbc *db.DatabaseContext, spec map[str
 		logCtx := context.TODO()
 		createdPrincipal := true
 		worker := func() (shouldRetry bool, err error, value interface{}) {
-			_, err = dbc.UpdatePrincipal(context.Background(), princ.AsPrincipalUpdates(), (what == "user"), isGuest)
+			_, err = dbc.UpdatePrincipal(context.Background(), princ, (what == "user"), isGuest)
 			if err != nil {
 				if status, _ := base.ErrorAsHTTPStatus(err); status == http.StatusConflict {
 					// Ignore and absorb this error if it's a conflict error, which just means that updatePrincipal didn't overwrite an existing user.

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1022,7 +1022,7 @@ func (sc *ServerContext) installPrincipals(dbc *db.DatabaseContext, spec map[str
 		logCtx := context.TODO()
 		createdPrincipal := true
 		worker := func() (shouldRetry bool, err error, value interface{}) {
-			_, err = dbc.UpdatePrincipal(context.Background(), *princ, (what == "user"), isGuest)
+			_, err = dbc.UpdatePrincipal(context.Background(), princ.AsPrincipalUpdates(), (what == "user"), isGuest)
 			if err != nil {
 				if status, _ := base.ErrorAsHTTPStatus(err); status == http.StatusConflict {
 					// Ignore and absorb this error if it's a conflict error, which just means that updatePrincipal didn't overwrite an existing user.

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
@@ -21,7 +22,7 @@ func TestUsersAPI(t *testing.T) {
 			DbConfig: DbConfig{
 				QueryPaginationLimit: base.IntPtr(5),
 				// Disable the guest user to support testing the zero user boundary condition
-				Guest: &db.PrincipalConfig{
+				Guest: &auth.PrincipalConfig{
 					Disabled: base.BoolPtr(false),
 				},
 			},
@@ -74,7 +75,7 @@ func TestUsersAPIDetailsViews(t *testing.T) {
 			DbConfig: DbConfig{
 				QueryPaginationLimit: base.IntPtr(5),
 				// Disable the guest user to support testing the zero user boundary condition
-				Guest: &db.PrincipalConfig{
+				Guest: &auth.PrincipalConfig{
 					Disabled: base.BoolPtr(false),
 				},
 			},
@@ -102,7 +103,7 @@ func TestUsersAPIDetails(t *testing.T) {
 			DbConfig: DbConfig{
 				QueryPaginationLimit: base.IntPtr(5),
 				// Disable the guest user to support testing the zero user boundary condition
-				Guest: &db.PrincipalConfig{
+				Guest: &auth.PrincipalConfig{
 					Disabled: base.BoolPtr(false),
 				},
 			},
@@ -112,7 +113,7 @@ func TestUsersAPIDetails(t *testing.T) {
 	defer rt.Close()
 
 	// Validate the zero user case
-	var responseUsers []db.PrincipalConfig
+	var responseUsers []auth.PrincipalConfig
 	response := rt.SendAdminRequest("GET", "/db/_user/?"+paramNameOnly+"=false", "")
 	assertStatus(t, response, 200)
 	err := json.Unmarshal(response.Body.Bytes(), &responseUsers)
@@ -165,7 +166,7 @@ func TestUsersAPIDetailsWithLimit(t *testing.T) {
 			DbConfig: DbConfig{
 				QueryPaginationLimit: base.IntPtr(5),
 				// Disable the guest user to support testing the zero user boundary condition
-				Guest: &db.PrincipalConfig{
+				Guest: &auth.PrincipalConfig{
 					Disabled: base.BoolPtr(false),
 				},
 			},
@@ -175,7 +176,7 @@ func TestUsersAPIDetailsWithLimit(t *testing.T) {
 	defer rt.Close()
 
 	// Validate the zero user case with limit
-	var responseUsers []db.PrincipalConfig
+	var responseUsers []auth.PrincipalConfig
 	response := rt.SendAdminRequest("GET", "/db/_user/?"+paramNameOnly+"=false&"+paramLimit+"=10", "")
 	assertStatus(t, response, 200)
 	err := json.Unmarshal(response.Body.Bytes(), &responseUsers)


### PR DESCRIPTION
In #5536, we need to be able to make changes to a user as a side-effect of OIDC signins. This would normally be done through `db.UpdatePrincipal`, but its parameter is a `db.PrincipalConfig` which we can't return from `auth` due to import cycles. Change its argument to be the new `auth.PrincipalUpdates` and update existing code accordingly.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/266/
