### PR TITLE
CBG-2075: register PIndex type definitions in CreateDatabaseContext

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -300,6 +300,11 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 		return nil, err
 	}
 
+	if autoImport {
+		// Register the cbgt pindex type for the configGroup
+		RegisterImportPindexImpl(options.GroupID)
+	}
+
 	dbContext := &DatabaseContext{
 		Name:       dbName,
 		UUID:       cbgt.NewUUID(),

--- a/db/database.go
+++ b/db/database.go
@@ -300,10 +300,8 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 		return nil, err
 	}
 
-	if autoImport {
-		// Register the cbgt pindex type for the configGroup
-		RegisterImportPindexImpl(options.GroupID)
-	}
+	// Register the cbgt pindex type for the configGroup
+	RegisterImportPindexImpl(options.GroupID)
 
 	dbContext := &DatabaseContext{
 		Name:       dbName,

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -67,9 +67,7 @@ func setupTestDBForBucketWithOptions(t testing.TB, tBucket base.Bucket, dbcOptio
 func setupTestDBWithOptionsAndImport(t testing.TB, dbcOptions DatabaseContextOptions) *Database {
 	AddOptionsFromEnvironmentVariables(&dbcOptions)
 	if dbcOptions.GroupID == "" && base.IsEnterpriseEdition() {
-		// TODO: Once RegisterImportPindexImpl is moved into NewDatabaseContext this won't be necessary
 		dbcOptions.GroupID = t.Name()
-		RegisterImportPindexImpl(t.Name())
 	}
 	context, err := NewDatabaseContext("db", base.GetTestBucket(t), true, dbcOptions)
 	require.NoError(t, err, "Couldn't create context for database 'db'")

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -782,9 +782,6 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		sendWWWAuthenticate = base.BoolPtr(false)
 	}
 
-	// Register the cbgt pindex type for the configGroup
-	db.RegisterImportPindexImpl(groupID)
-
 	contextOptions := db.DatabaseContextOptions{
 		CacheOptions:                  &cacheOptions,
 		RevisionCacheOptions:          revCacheOptions,


### PR DESCRIPTION
CBG-2075

Previously we would register PIndex type definitions in `dbcOptionsForConfig`, which is a bit of a smell as this is a side effect. Move these into `CreateDatabaseContext`.

The change should be safe - the only non-test code path that calls this calls `CreateDatabaseContext` immediately afterward, and the underlying PIndex registration operation is idempotent anyway.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/270/
  - `TestLogFlush` flake