### PR TITLE
CBG-2097 Use shared http client for serverContext and databaseContext

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -71,6 +71,12 @@ const (
 	// Can be used to set a global log level for all tests at runtime.
 	TestEnvGlobalLogLevel = "SG_TEST_LOG_LEVEL"
 
+	// Should x509 tests deploy certs to local macOS Couchbase Server?
+	TestEnvX509Local = "SG_TEST_X509_LOCAL"
+
+	// If TestEnvX509Local=true, must use SG_TEST_X509_LOCAL_USER to set macOS username to locate CBS cert inbox
+	TestEnvX509LocalUser = "SG_TEST_X509_LOCAL_USER"
+
 	DefaultUseXattrs      = true // Whether Sync Gateway uses xattrs for metadata storage, if not specified in the config
 	DefaultAllowConflicts = true // Whether Sync Gateway allows revision conflicts, if not specified in the config
 

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -200,6 +200,25 @@ func TestTLSSkipVerify() bool {
 	return val
 }
 
+func TestX509LocalServer() (bool, string) {
+	testX509LocalServer, isSet := os.LookupEnv(TestEnvX509Local)
+	if !isSet {
+		return false, ""
+	}
+
+	val, err := strconv.ParseBool(testX509LocalServer)
+	if err != nil {
+		panic(fmt.Sprintf("unable to parse %q value %q: %v", TestEnvX509Local, testX509LocalServer, err))
+	}
+
+	username, isSet := os.LookupEnv(TestEnvX509LocalUser)
+	if !isSet {
+		panic(fmt.Sprintf("TestEnvX509LocalUser must be set when TestEnvX509Local=true"))
+	}
+
+	return val, username
+}
+
 // Should tests try to drop GSI indexes before flushing buckets?
 // See SG #3422
 func TestsShouldDropIndexes() bool {

--- a/db/database.go
+++ b/db/database.go
@@ -118,7 +118,7 @@ type DatabaseContext struct {
 	SGReplicateMgr               *sgReplicateManager      // Manages interactions with sg-replicate replications
 	Heartbeater                  base.Heartbeater         // Node heartbeater for SG cluster awareness
 	ServeInsecureAttachmentTypes bool                     // Attachment content type will bypass the content-disposition handling, default false
-	GoCBHttpClient               *http.Client             // A HTTP Client from gocb to use the management endpoints
+	NoX509HTTPClient             *http.Client             // A HTTP Client from gocb to use the management endpoints
 	ServerContextHasStarted      chan struct{}            // Closed via PostStartup once the server has fully started
 }
 
@@ -1572,16 +1572,6 @@ func (dbCtx *DatabaseContext) ObtainManagementEndpoints() ([]string, error) {
 	return base.GoCBBucketMgmtEndpoints(cbStore)
 }
 
-func (dbCtx *DatabaseContext) InitializeGoCBHttpClient() (*http.Client, error) {
-	cbStore, ok := base.AsCouchbaseStore(dbCtx.Bucket)
-	if !ok {
-		base.WarnfCtx(context.TODO(), "Database %v: Unable to get server management endpoints. Underlying bucket type was not GoCBBucket.", base.MD(dbCtx.Name))
-		return nil, nil
-	}
-
-	return cbStore.HttpClient(), nil
-}
-
 func (dbCtx *DatabaseContext) ObtainManagementEndpointsAndHTTPClient() ([]string, *http.Client, error) {
 	cbStore, ok := base.AsCouchbaseStore(dbCtx.Bucket)
 	if !ok {
@@ -1591,7 +1581,7 @@ func (dbCtx *DatabaseContext) ObtainManagementEndpointsAndHTTPClient() ([]string
 
 	// This shouldn't happen as the only place we don't initialize this is in the case where we're not using a Couchbase
 	// Bucket. This means the above check should catch it but check just to be safe.
-	if dbCtx.GoCBHttpClient == nil {
+	if dbCtx.NoX509HTTPClient == nil {
 		return nil, nil, fmt.Errorf("unable to obtain http client")
 	}
 
@@ -1600,7 +1590,7 @@ func (dbCtx *DatabaseContext) ObtainManagementEndpointsAndHTTPClient() ([]string
 		return nil, nil, err
 	}
 
-	return endpoints, dbCtx.GoCBHttpClient, nil
+	return endpoints, dbCtx.NoX509HTTPClient, nil
 }
 
 func (context *DatabaseContext) GetUserViewsEnabled() bool {

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -204,6 +204,10 @@ func TestCheckPermissionsWithX509(t *testing.T) {
 	require.NoError(t, err)
 	ctx.GoCBAgent = goCBAgent
 
+	noX509HttpClient, err := ctx.initializeNoX509HttpClient()
+	require.NoError(t, err)
+	ctx.NoX509HTTPClient = noX509HttpClient
+
 	eps, httpClient, err := ctx.ObtainManagementEndpointsAndHTTPClient()
 	assert.NoError(t, err)
 
@@ -489,11 +493,21 @@ func TestAdminAuthWithX509(t *testing.T) {
 	require.NoError(t, err)
 	ctx.GoCBAgent = goCBAgent
 
+	noX509HttpClient, err := ctx.initializeNoX509HttpClient()
+	require.NoError(t, err)
+	ctx.NoX509HTTPClient = noX509HttpClient
+
 	managementEndpoints, httpClient, err := ctx.ObtainManagementEndpointsAndHTTPClient()
 	require.NoError(t, err)
 
-	_, _, err = checkAdminAuth("", base.TestClusterUsername(), base.TestClusterPassword(), "", httpClient, managementEndpoints, true, []Permission{{"!admin", false}}, nil)
+	var statusCode int
+	_, statusCode, err = checkAdminAuth("", base.TestClusterUsername(), base.TestClusterPassword(), "", httpClient, managementEndpoints, true, []Permission{{"!admin", false}}, nil)
 	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, statusCode)
+
+	_, statusCode, err = checkAdminAuth("", "invalidUser", "invalidPassword", "", httpClient, managementEndpoints, true, []Permission{{"!admin", false}}, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, statusCode)
 }
 
 func TestAdminAPIAuth(t *testing.T) {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -11,6 +11,7 @@ package rest
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"errors"
@@ -58,6 +59,7 @@ type ServerContext struct {
 	cpuPprofFile         *os.File        // An open file descriptor holds the reference during CPU profiling
 	_httpServers         []*http.Server  // A list of HTTP servers running under the ServerContext
 	GoCBAgent            *gocbcore.Agent // GoCB Agent to use when obtaining management endpoints
+	NoX509HTTPClient     *http.Client    // httpClient for the cluster that doesn't include x509 credentials, even if they are configured for the cluster
 	hasStarted           chan struct{}   // A channel that is closed via PostStartup once the ServerContext has fully started
 }
 
@@ -504,14 +506,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config DatabaseConfig, useE
 	}
 	dbcontext.BucketSpec = spec
 	dbcontext.ServerContextHasStarted = sc.hasStarted
-
-	if !dbcontext.BucketSpec.IsWalrusBucket() {
-		gocbHttpClient, err := dbcontext.InitializeGoCBHttpClient()
-		if err != nil {
-			return nil, err
-		}
-		dbcontext.GoCBHttpClient = gocbHttpClient
-	}
+	dbcontext.NoX509HTTPClient = sc.NoX509HTTPClient
 
 	syncFn := ""
 	if config.Sync != nil {
@@ -1241,12 +1236,95 @@ func (sc *ServerContext) initializeGoCBAgent() (*gocbcore.Agent, error) {
 	return agent, nil
 }
 
+// initializeNoX509HttpClient() returns an http client based on the bootstrap connection information, but
+// without any x509 keypair included in the tls config.  This client can be used to perform basic
+// authentication checks against the server.
+// Client creation otherwise clones the approach used by gocb.
+func (sc *ServerContext) initializeNoX509HttpClient() (*http.Client, error) {
+
+	// baseTlsConfig defines the tlsConfig except for ServerName, which is updated based
+	// on addr in DialTLS
+	baseTlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+	var rootCAs *x509.CertPool
+	tlsRootCAProvider, err := base.GoCBCoreTLSRootCAProvider(sc.config.Bootstrap.ServerTLSSkipVerify, sc.config.Bootstrap.CACertPath)
+	if err != nil {
+		return nil, err
+	}
+	rootCAs = tlsRootCAProvider()
+	if rootCAs != nil {
+		baseTlsConfig.RootCAs = rootCAs
+		baseTlsConfig.InsecureSkipVerify = false
+	} else {
+		baseTlsConfig.InsecureSkipVerify = true
+	}
+
+	httpDialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	maxIdleConns, _ := strconv.Atoi(base.DefaultHttpMaxIdleConns)
+	idleConnTimeoutMs, _ := strconv.Atoi(base.DefaultHttpIdleConnTimeoutMilliseconds)
+
+	// gocbcore: We set ForceAttemptHTTP2, which will update the base-config to support HTTP2
+	// automatically, so that all configs from it will look for that.
+	httpTransport := &http.Transport{
+		ForceAttemptHTTP2: true,
+
+		Dial: func(network, addr string) (net.Conn, error) {
+			return httpDialer.Dial(network, addr)
+		},
+		DialTLS: func(network, addr string) (net.Conn, error) {
+			tcpConn, err := httpDialer.Dial(network, addr)
+			if err != nil {
+				return nil, err
+			}
+
+			// Update tlsConfig.ServerName based on addr
+			tlsConfig := baseTlsConfig.Clone()
+			host, _, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+			tlsConfig.ServerName = host
+			tlsConn := tls.Client(tcpConn, tlsConfig)
+			return tlsConn, nil
+		},
+		MaxIdleConns:        maxIdleConns,
+		MaxIdleConnsPerHost: base.DefaultHttpMaxIdleConnsPerHost,
+		IdleConnTimeout:     time.Duration(idleConnTimeoutMs) * time.Millisecond,
+	}
+
+	httpCli := &http.Client{
+		Transport: httpTransport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			// gocbcore: All that we're doing here is setting auth on any redirects.
+			// For that reason we can just pull it off the oldest (first) request.
+			if len(via) >= 10 {
+				// Just duplicate the default behaviour for maximum redirects.
+				return errors.New("stopped after 10 redirects")
+			}
+
+			oldest := via[0]
+			auth := oldest.Header.Get("Authorization")
+			if auth != "" {
+				req.Header.Set("Authorization", auth)
+			}
+
+			return nil
+		},
+	}
+
+	return httpCli, nil
+}
+
 func (sc *ServerContext) ObtainManagementEndpointsAndHTTPClient() ([]string, *http.Client, error) {
 	if sc.GoCBAgent == nil {
 		return nil, nil, fmt.Errorf("unable to obtain agent")
 	}
 
-	return sc.GoCBAgent.MgmtEps(), sc.GoCBAgent.HTTPClient(), nil
+	return sc.GoCBAgent.MgmtEps(), sc.NoX509HTTPClient, nil
 }
 
 // CheckPermissions is used for Admin authentication to check a CBS RBAC user.
@@ -1408,6 +1486,11 @@ func (sc *ServerContext) initializeCouchbaseServerConnections() error {
 		return err
 	}
 	sc.GoCBAgent = goCBAgent
+
+	sc.NoX509HTTPClient, err = sc.initializeNoX509HttpClient()
+	if err != nil {
+		return err
+	}
 
 	// Fetch database configs from bucket and start polling for new buckets and config updates.
 	if sc.persistentConfig {

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -298,6 +298,10 @@ func TestObtainManagementEndpointsFromServerContextWithX509(t *testing.T) {
 	require.NoError(t, err)
 	ctx.GoCBAgent = goCBAgent
 
+	noX509HttpClient, err := ctx.initializeNoX509HttpClient()
+	require.NoError(t, err)
+	ctx.NoX509HTTPClient = noX509HttpClient
+
 	eps, _, err := ctx.ObtainManagementEndpointsAndHTTPClient()
 	assert.NoError(t, err)
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -148,6 +148,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 	sc.API.EnableAdminAuthenticationPermissionsCheck = &rt.enableAdminAuthPermissionsCheck
 	sc.Bootstrap.UseTLSServer = &rt.RestTesterConfig.useTLSServer
 	sc.Bootstrap.ServerTLSSkipVerify = base.BoolPtr(base.TestTLSSkipVerify())
+
 	if rt.RestTesterConfig.groupID != nil {
 		sc.Bootstrap.ConfigGroupID = *rt.RestTesterConfig.groupID
 	}
@@ -163,10 +164,6 @@ func (rt *RestTester) Bucket() base.Bucket {
 	rt.RestTesterServerContext = NewServerContext(&sc, rt.RestTesterConfig.persistentConfig)
 
 	if !base.ServerIsWalrus(sc.Bootstrap.Server) {
-		if err := rt.RestTesterServerContext.initializeCouchbaseServerConnections(); err != nil {
-			panic("Couldn't initialize Couchbase Server connection: " + err.Error())
-		}
-
 		// Copy any testbucket cert info into boostrap server config
 		// Required as present for X509 tests there is no way to pass this info to the bootstrap server context with a
 		// RestTester directly - Should hopefully be alleviated by CBG-1460
@@ -175,6 +172,10 @@ func (rt *RestTester) Bucket() base.Bucket {
 		sc.Bootstrap.X509KeyPath = testBucket.BucketSpec.Keypath
 
 		rt.testBucket.BucketSpec.TLSSkipVerify = base.TestTLSSkipVerify()
+
+		if err := rt.RestTesterServerContext.initializeCouchbaseServerConnections(); err != nil {
+			panic("Couldn't initialize Couchbase Server connection: " + err.Error())
+		}
 	}
 
 	// Copy this startup config at this point into initial startup config

--- a/rest/x509_utils_test.go
+++ b/rest/x509_utils_test.go
@@ -301,6 +301,64 @@ func loadCertsIntoCouchbaseServer(couchbaseServerURL url.URL, ca *caPair, node *
 	return nil
 }
 
+// loadCertsIntoLocalCouchbaseServer will upload the given certs into Couchbase Server (via SSH and the REST API)
+func loadCertsIntoLocalCouchbaseServer(couchbaseServerURL url.URL, ca *caPair, node *nodePair, localMacOSUser string) error {
+
+	localMacOSCouchbaseServerInbox := "/Users/" + localMacOSUser + "/Library/Application Support/Couchbase/var/lib/couchbase/inbox"
+
+	// Copy node cert and key
+	err := copyLocalFile(node.PEMFilepath, localMacOSCouchbaseServerInbox)
+	if err != nil {
+		return err
+	}
+	logCtx := context.Background()
+	base.DebugfCtx(logCtx, base.KeyAll, "copied x509 node chain.pem to integration test server")
+
+	err = copyLocalFile(node.KeyFilePath, localMacOSCouchbaseServerInbox)
+	if err != nil {
+		return err
+	}
+	base.DebugfCtx(logCtx, base.KeyAll, "copied x509 node pkey.key to integration test server")
+
+	restAPIURL := basicAuthRESTPIURLFromConnstrHost(couchbaseServerURL)
+
+	// Upload the CA cert via the REST API
+	resp, err := http.Post(restAPIURL.String()+"/controller/uploadClusterCA", "application/octet-stream", ca.PEM)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("couldn't uploadClusterCA: expected %d status code but got %d: %s", http.StatusOK, resp.StatusCode, respBody)
+	}
+	base.DebugfCtx(logCtx, base.KeyAll, "uploaded ca.pem to Couchbase Server")
+
+	// Make CBS read the newly uploaded certs
+	resp, err = http.Post(restAPIURL.String()+"/node/controller/reloadCertificate", "", nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("couldn't reloadCertificate: expected %d status code but got %d: %s", http.StatusOK, resp.StatusCode, respBody)
+	}
+	base.DebugfCtx(logCtx, base.KeyAll, "triggered reload of certificates on Couchbase Server")
+
+	if err := enableX509ClientCertsInCouchbaseServer(restAPIURL); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // couchbaseNodeConfiguredHostname returns the Couchbase node name for the given URL.
 func couchbaseNodeConfiguredHostname(restAPIURL url.URL) (string, error) {
 	resp, err := http.Get(restAPIURL.String() + "/pools/default")
@@ -398,6 +456,31 @@ func sshCopyFileAsExecutable(sourceFilepath, sshRemoteHost, destinationDirectory
 
 	// make the file we just copied readable and executable (required for Couchbase server to use the certs)
 	cmd = exec.Command("ssh", forceKeyOnly, skipHostFingerprint, sshRemoteHost, "chmod -R a+rx", filepath.Join(destinationDirectory, filepath.Base(sourceFilepath)))
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return errors.Wrap(err, string(output))
+	}
+
+	return nil
+}
+
+// copyLocalFile takes in a full source filepath and a destination directory.
+// The destination directory will be created in full if it does not exist, the file will be copied, and then the read and execute permissions set.
+func copyLocalFile(sourceFilepath, destinationDirectory string) error {
+
+	// make destination directory if it doesn't exist
+	cmd := exec.Command("mkdir", "-p", destinationDirectory)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return errors.Wrap(err, string(output))
+	}
+
+	// copy the file
+	cmd = exec.Command("cp", sourceFilepath, destinationDirectory)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return errors.Wrap(err, string(output))
+	}
+
+	// make the file we just copied readable and executable (required for Couchbase server to use the certs)
+	cmd = exec.Command("chmod", "-R", "a+rwx", filepath.Join(destinationDirectory, filepath.Base(sourceFilepath)))
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return errors.Wrap(err, string(output))
 	}


### PR DESCRIPTION
Define a standalone httpClient on the serverContext, and share with databaseContext on creation to be returned by the two versions of ObtainManagementEndpointsAndHTTPClient().

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/272/
  - Flake: `--- FAIL: TestLogFlush/Default (20.15s)`
