### PR TITLE
CBG-2098: Prepare manifest for 3.0.2 release

### DIFF
--- a/manifest/3.0/3.0.1.xml
+++ b/manifest/3.0/3.0.1.xml
@@ -25,14 +25,14 @@ licenses/APL2.txt.
   <!-- Build Scripts (required on CI servers) -->
   <project name="product-texts" path="product-texts" remote="couchbase"/>
   <project name="build" path="cbbuild" remote="couchbase" revision="a5d50edde6a7525bdff32f8ba3127a47ac2b291e">
-    <annotation name="VERSION" value="3.0.2"     keep="true"/>
+    <annotation name="VERSION" value="3.0.1"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
   </project>
 
 
   <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/3.0.2"/>
+  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="34cf114efc68e604853388eb37c16b853f3e2203"/>
 
   <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
 

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -273,15 +273,6 @@
             "trigger_blackduck": true,
             "start_build": 1
         },
-        "manifest/3.0.xml": {
-            "release": "3.0.1",
-            "release_name": "Couchbase Sync Gateway 3.0.1",
-            "production": true,
-            "interval": 120,
-            "go_version": "1.16.6",
-            "trigger_blackduck": true,
-            "start_build": 1
-        },
         "manifest/3.0/3.0.0.xml": {
             "do-build": false,
             "release": "3.0.0",
@@ -291,6 +282,25 @@
             "go_version": "1.16.6",
             "trigger_blackduck": true,
             "start_build": 544
+        },
+        "manifest/3.0/3.0.1.xml": {
+            "do-build": false,
+            "release": "3.0.1",
+            "release_name": "Couchbase Sync Gateway 3.0.1",
+            "production": true,
+            "interval": 1440,
+            "go_version": "1.16.6",
+            "trigger_blackduck": true,
+            "start_build": 22
+        },
+        "manifest/3.0.xml": {
+            "release": "3.0.2",
+            "release_name": "Couchbase Sync Gateway 3.0.2",
+            "production": true,
+            "interval": 120,
+            "go_version": "1.16.6",
+            "trigger_blackduck": true,
+            "start_build": 1
         },
         "manifest/dev.xml": {
             "release": "dev",


### PR DESCRIPTION
CBG-2098

Prepared manifest for 3.0.2 release: copied 3.0.xml to 3.0.1.xml (and updated SGW revision to point to the latest `release/3.0.1` SHA), updated 3.0.xml to reference 3.0.2, and updated product-config to build 3.0.2 instead of 3.0.1.

