### PR TITLE
CBG-2051: Fixed case sensitive internal property checking for removals and improve unit testing

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -828,11 +828,11 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	stats.bytes.Add(int64(len(bodyBytes)))
 
 	if bh.BlipSyncContext.purgeOnRemoval && bytes.Contains(bodyBytes, []byte(`"`+BodyRemoved+`":`)) {
-		var r removalDocument
-		if err := json.Unmarshal(bodyBytes, &r); err != nil {
+		var body Body
+		if err := body.Unmarshal(bodyBytes); err != nil {
 			return err
 		}
-		if r.Removed {
+		if removed, ok := body[BodyRemoved].(bool); ok && removed {
 			base.InfofCtx(bh.loggingCtx, base.KeySync, "Purging doc %v - removed at rev %v", base.UD(docID), revID)
 			if err := bh.db.Purge(docID); err != nil {
 				return err

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -4612,6 +4612,15 @@ func TestApiInternalPropertiesHandling(t *testing.T) {
 			inputBody:    map[string]interface{}{"_sync_cookies": true},
 			expectReject: true,
 		},
+		{
+			name: "Valid user defined uppercase properties", // Uses internal properties names but in upper case
+			// Known issue: _SYNC causes unmarshal error when not using xattrs
+			inputBody: map[string]interface{}{
+				"_ID": true, "_REV": true, "_DELETED": true, "_ATTACHMENTS": true, "_REVISIONS": true,
+				"_EXP": true, "_PURGED": true, "_REMOVED": true, "_SYNC_COOKIES": true,
+			},
+			expectReject: false,
+		},
 	}
 
 	rt := NewRestTester(t, nil)
@@ -4625,18 +4634,20 @@ func TestApiInternalPropertiesHandling(t *testing.T) {
 
 			resp := rt.SendAdminRequest("PUT", "/db/"+docID, string(rawBody))
 			if test.expectReject {
-				assert.NotEqual(t, 201, resp.Code)
+				assert.NotEqual(t, http.StatusOK, resp.Code)
 				return
 			}
-			require.Equal(t, 201, resp.Code)
+			assertStatus(t, resp, http.StatusCreated)
 
 			var bucketDoc map[string]interface{}
 			_, err = rt.Bucket().Get(docID, &bucketDoc)
 			assert.NoError(t, err)
+			body := rt.getDoc(docID)
 			// Confirm input body is in the bucket doc
 			if test.skipDocContentsVerification == nil || !*test.skipDocContentsVerification {
 				for k, v := range test.inputBody {
 					assert.Equal(t, v, bucketDoc[k])
+					assert.Equal(t, v, body[k])
 				}
 			}
 		})

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -4058,6 +4058,15 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 			inputBody:    map[string]interface{}{"_sync_cookies": true},
 			expectReject: true,
 		},
+		{
+			name: "Valid user defined uppercase properties", // Uses internal properties names but in upper case
+			// Known issue: _SYNC causes unmarshal error when not using xattrs
+			inputBody: map[string]interface{}{
+				"_ID": true, "_REV": true, "_DELETED": true, "_ATTACHMENTS": true, "_REVISIONS": true,
+				"_EXP": true, "_PURGED": true, "_REMOVED": true, "_SYNC_COOKIES": true,
+			},
+			expectReject: false,
+		},
 	}
 
 	// Setup
@@ -4094,10 +4103,12 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 			var bucketDoc map[string]interface{}
 			_, err = rt.Bucket().Get(docID, &bucketDoc)
 			assert.NoError(t, err)
+			body := rt.getDoc(docID)
 			// Confirm input body is in the bucket doc
 			if test.skipDocContentsVerification == nil || !*test.skipDocContentsVerification {
 				for k, v := range test.inputBody {
 					assert.Equal(t, v, bucketDoc[k])
+					assert.Equal(t, v, body[k])
 				}
 			}
 		})

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -2326,6 +2326,15 @@ func TestImportInternalPropertiesHandling(t *testing.T) {
 			importBody:   map[string]interface{}{"_sync_cookies": true},
 			expectReject: true,
 		},
+		{
+			name: "Valid user defined uppercase properties", // Uses internal properties names but in upper case
+			// Known issue: _SYNC causes unmarshal error when importing document that contains it
+			importBody: map[string]interface{}{
+				"_ID": true, "_REV": true, "_DELETED": true, "_ATTACHMENTS": true, "_REVISIONS": true,
+				"_EXP": true, "_PURGED": true, "_REMOVED": true, "_SYNC_COOKIES": true,
+			},
+			expectReject: false,
+		},
 	}
 
 	rt := NewRestTester(t, nil)


### PR DESCRIPTION
CBG-2051

- `processRev` purge on removal code is now case sensetive when checking for `_removed`
- Internal property tests now have a new upper case test case for testing internal properties
- Internal property tests now check the fields returned by the REST API 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/277/ `1 flaky test fail`
