### PR TITLE
CBG-2080: Stub new scopes/collections database config options

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -710,32 +710,33 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 	// scopes and collections validation
 	if len(dbConfig.Scopes) > 1 {
 		multiError = multiError.Append(fmt.Errorf("only one named scope is supported, but had %d (%v)", len(dbConfig.Scopes), dbConfig.Scopes))
-	}
-	for scopeName, scopeConfig := range dbConfig.Scopes {
-		if len(scopeConfig.Collections) == 0 {
-			multiError = multiError.Append(fmt.Errorf("must specify at least one collection in scope %v", scopeName))
-			continue
-		}
-
-		if dbConfig.Sync != nil {
-			multiError = multiError.Append(errors.New("cannot specify a database-level sync function with named scopes and collections"))
-		}
-		if dbConfig.ImportFilter != nil {
-			multiError = multiError.Append(errors.New("cannot specify a database-level import filter with named scopes and collections"))
-		}
-
-		// validate each collection's config
-		for collectionName, collectionConfig := range scopeConfig.Collections {
-			if isEmpty, err := validateJavascriptFunction(collectionConfig.SyncFn); err != nil {
-				multiError = multiError.Append(fmt.Errorf("collection %q sync function error: %w", collectionName, err))
-			} else if isEmpty {
-				collectionConfig.SyncFn = nil
+	} else {
+		for scopeName, scopeConfig := range dbConfig.Scopes {
+			if len(scopeConfig.Collections) == 0 {
+				multiError = multiError.Append(fmt.Errorf("must specify at least one collection in scope %v", scopeName))
+				continue
 			}
 
-			if isEmpty, err := validateJavascriptFunction(collectionConfig.ImportFilter); err != nil {
-				multiError = multiError.Append(fmt.Errorf("collection %q import filter error: %w", collectionName, err))
-			} else if isEmpty {
-				collectionConfig.ImportFilter = nil
+			if dbConfig.Sync != nil {
+				multiError = multiError.Append(errors.New("cannot specify a database-level sync function with named scopes and collections"))
+			}
+			if dbConfig.ImportFilter != nil {
+				multiError = multiError.Append(errors.New("cannot specify a database-level import filter with named scopes and collections"))
+			}
+
+			// validate each collection's config
+			for collectionName, collectionConfig := range scopeConfig.Collections {
+				if isEmpty, err := validateJavascriptFunction(collectionConfig.SyncFn); err != nil {
+					multiError = multiError.Append(fmt.Errorf("collection %q sync function error: %w", collectionName, err))
+				} else if isEmpty {
+					collectionConfig.SyncFn = nil
+				}
+
+				if isEmpty, err := validateJavascriptFunction(collectionConfig.ImportFilter); err != nil {
+					multiError = multiError.Append(fmt.Errorf("collection %q import filter error: %w", collectionName, err))
+				} else if isEmpty {
+					collectionConfig.ImportFilter = nil
+				}
 			}
 		}
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -708,14 +708,10 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 	}
 
 	// scopes and collections validation
-	numScopes := 0
+	if len(dbConfig.Scopes) > 1 {
+		multiError = multiError.Append(fmt.Errorf("only one named scope is supported, but had %d (%v)", len(dbConfig.Scopes), dbConfig.Scopes))
+	}
 	for scopeName, scopeConfig := range dbConfig.Scopes {
-		numScopes++
-		if numScopes > 1 {
-			multiError = multiError.Append(fmt.Errorf("only one named scope is supported, but had %d (%v)", len(dbConfig.Scopes), dbConfig.Scopes))
-			continue
-		}
-
 		if len(scopeConfig.Collections) == 0 {
 			multiError = multiError.Append(fmt.Errorf("must specify at least one collection in scope %v", scopeName))
 			continue

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2237,3 +2237,46 @@ func TestStartupConfigBcryptCostValidation(t *testing.T) {
 		})
 	}
 }
+
+func Test_validateJavascriptFunction(t *testing.T) {
+	tests := []struct {
+		name        string
+		jsFunc      *string
+		wantIsEmpty bool
+		wantErr     assert.ErrorAssertionFunc
+	}{
+		{
+			name:        "unset (nil)",
+			jsFunc:      nil,
+			wantIsEmpty: true,
+			wantErr:     assert.NoError,
+		},
+		{
+			name:        "whitespace only",
+			jsFunc:      base.StringPtr("   \t \n "),
+			wantIsEmpty: true,
+			wantErr:     assert.NoError,
+		},
+		{
+			name:        "invalid js",
+			jsFunc:      base.StringPtr("  func() { console.log(\"foo\"); } "),
+			wantIsEmpty: false,
+			wantErr:     assert.Error,
+		},
+		{
+			name:        "valid js",
+			jsFunc:      base.StringPtr(" function() { console.log(\"foo\"); }  "),
+			wantIsEmpty: false,
+			wantErr:     assert.NoError,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gotIsEmpty, err := validateJavascriptFunction(test.jsFunc)
+			if !test.wantErr(t, err, fmt.Sprintf("validateJavascriptFunction(%v)", test.jsFunc)) {
+				return
+			}
+			assert.Equalf(t, test.wantIsEmpty, gotIsEmpty, "validateJavascriptFunction(%v)", test.jsFunc)
+		})
+	}
+}


### PR DESCRIPTION
CBG-2080

Allows the new `scopes` and `collections` database config options to be used. Currently not wired up to anything.

Basic config validation is implemented:
- zero or one scope
- at least one collection under a scope
- valid js functions if set

Changes:
- Defined new `scopes` and `collections` config fields in database config struct.
- Extracted js function validation logic into function and unit tested.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/278
  - Flake: `--- FAIL: TestLogFlush/Default (20.14s)`