### PR TITLE
CBG-1823: Validate all_channels is not set by the user

### DIFF
--- a/db/change_listener_test.go
+++ b/db/change_listener_test.go
@@ -54,8 +54,8 @@ func TestUserWaiter(t *testing.T) {
 
 	// Update the user to grant new channel
 	updatedUser := PrincipalConfig{
-		Name:     &username,
-		Channels: base.SetFromArray([]string{"ABC", "DEF"}),
+		Name:             &username,
+		ExplicitChannels: base.SetFromArray([]string{"ABC", "DEF"}),
 	}
 	_, err = db.UpdatePrincipal(ctx, updatedUser, true, true)
 	require.NoError(t, err, "Error updating user")
@@ -127,8 +127,8 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 
 	// Update the role to grant a new channel
 	updatedRole := PrincipalConfig{
-		Name:     &roleName,
-		Channels: base.SetFromArray([]string{"ABC"}),
+		Name:             &roleName,
+		ExplicitChannels: base.SetFromArray([]string{"ABC", "DEF"}),
 	}
 	_, err = db.UpdatePrincipal(ctx, updatedRole, false, true)
 	require.NoError(t, err, "Error updating role")

--- a/db/users.go
+++ b/db/users.go
@@ -138,6 +138,11 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, newInfo Princip
 			}
 		}
 
+		// Ensure the caller isn't trying to set all_channels explicitly - it'll get recomputed automatically.
+		if len(newInfo.Channels) > 0 && !princ.Channels().Equals(newInfo.Channels) {
+			return false, base.HTTPErrorf(http.StatusBadRequest, "all_channels is read-only")
+		}
+
 		updatedChannels := princ.ExplicitChannels()
 		if updatedChannels == nil {
 			updatedChannels = ch.TimedSet{}

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -265,6 +265,29 @@ func TestUserAllowEmptyPassword(t *testing.T) {
 	assertStatus(t, response, 200)
 }
 
+func TestPrincipalForbidUpdatingChannels(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{})
+	defer rt.Close()
+
+	// Users
+	// PUT admin_channels
+	response := rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"letmein", "admin_channels":["foo", "bar"]}`)
+	assertStatus(t, response, 201)
+
+	// PUT all_channels - should fail
+	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "all_channels":["baz"]}`)
+	assertStatus(t, response, 400)
+
+	// Roles
+	// PUT admin_channels
+	response = rt.SendAdminRequest("PUT", "/db/_role/test", `{"admin_channels":["foo", "bar"]}`)
+	assertStatus(t, response, 201)
+
+	// PUT all_channels - should fail
+	response = rt.SendAdminRequest("PUT", "/db/_role/test", `{"all_channels":["baz"]}`)
+	assertStatus(t, response, 400)
+}
+
 // Test user access grant while that user has an active changes feed.  (see issue #880)
 func TestUserAccessRace(t *testing.T) {
 


### PR DESCRIPTION
CBG-1823

Previously, when users tried to set `all_channels` through `PUT /db/_user/<user>`, it would succeed but not actually change anything, which lead to confusing UX. Explicitly catch this case and return an error.

Also, fix an unrelated test which was using `Channels` incorrectly and started failing when this validation was introduced.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/279/
