### PR TITLE
CBG-2055 Do not evaluate revpos during storeAttachments

### DIFF
--- a/db/attachment.go
+++ b/db/attachment.go
@@ -290,12 +290,18 @@ func (db *Database) ForEachStubAttachment(body Body, minRevpos int, docID string
 			if err != nil && !base.IsDocNotFoundError(err) {
 				return err
 			}
-			if newData, err := callback(name, digest, data, meta); err != nil {
+			newData, err := callback(name, digest, data, meta)
+			if err != nil {
 				return err
-			} else if newData != nil {
+			}
+			if newData != nil {
 				meta["data"] = newData
 				delete(meta, "stub")
 				delete(meta, "follows")
+			} else {
+				// Update version in the case where this is a new attachment on the doc sharing a V2 digest with
+				// an existing attachment
+				meta["ver"] = AttVersion2
 			}
 		}
 	}

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -757,8 +757,8 @@ func TestStoreAttachments(t *testing.T) {
 	revId, doc, err = db.Put("doc5", revBody)
 	assert.Empty(t, revId, "The revId should be empty since revpos is not included in attachment")
 	assert.Empty(t, doc, "The doc should be empty since revpos is not included in attachment")
-	assert.Error(t, err, "It should throw 400 Missing/invalid revpos in stub attachment error")
-	assert.Contains(t, err.Error(), "400 Missing/invalid revpos in stub attachment")
+	assert.Error(t, err, "It should throw 400 Missing digest in stub attachment")
+	assert.Contains(t, err.Error(), "400 Missing digest in stub attachment")
 }
 
 // TestMigrateBodyAttachments will set up a document with an attachment in pre-2.5 metadata format, and test various upgrade scenarios.

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -951,6 +951,9 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 				// Check if we have this attachment name already, if we do, continue check
 				currentAttachment, ok := currentBucketDoc.Attachments[name]
 				if !ok {
+					// If we don't have this attachment already, ensure incoming revpos is greater than minRevPos, otherwise
+					// update to ensure it's fetched and uploaded
+					bodyAtts[name].(map[string]interface{})["revpos"], _ = ParseRevID(revID)
 					continue
 				}
 
@@ -987,10 +990,9 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 				}
 
 				// Compare the revpos and attachment digest. If incoming revpos is less than or equal to minRevPos and
-				// digest is different we need to override the revpos and set it to the current revision as the incoming
-				// revpos must be invalid and we need to request it.
+				// digest is different we need to override the revpos and set it to the current revision to ensure
+				// the attachment is requested and stored
 				if int(incomingAttachmentRevpos) <= minRevpos && currentAttachmentDigest != incomingAttachmentDigest {
-					minRevpos, _ = ParseRevID(history[len(history)-1])
 					bodyAtts[name].(map[string]interface{})["revpos"], _ = ParseRevID(revID)
 				}
 			}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -8034,57 +8034,8 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		assert.Equal(t, attBodyExpected, attBodyActual)
 	}
 
-	rawDocWithAttachmentAndSyncMeta := func() []byte {
-		return []byte(`{
-   "_sync": {
-      "rev": "1-5fc93bd36377008f96fdae2719c174ed",
-      "sequence": 2,
-      "recent_sequences": [
-         2
-      ],
-      "history": {
-         "revs": [
-            "1-5fc93bd36377008f96fdae2719c174ed"
-         ],
-         "parents": [
-            -1
-         ],
-         "channels": [
-            null
-         ]
-      },
-      "cas": "",
-      "attachments": {
-         "hi.txt": {
-            "revpos": 1,
-            "content_type": "text/plain",
-            "length": 2,
-            "stub": true,
-            "digest": "sha1-witfkXg0JglCjW9RssWvTAveakI="
-         }
-      },
-      "time_saved": "2021-09-01T17:33:03.054227821Z"
-   },
-  "key": "value"
-}`)
-	}
-
 	createDocWithLegacyAttachment := func(docID string, rawDoc []byte, attKey string, attBody []byte) {
-		// Write attachment directly to the bucket.
-		_, err := rt.Bucket().Add(attKey, 0, attBody)
-		require.NoError(t, err)
-
-		body := db.Body{}
-		err = body.Unmarshal(rawDoc)
-		require.NoError(t, err, "Error unmarshalling body")
-
-		// Write raw document to the bucket.
-		_, err = rt.Bucket().Add(docID, 0, rawDoc)
-		require.NoError(t, err)
-
-		// Migrate document metadata from document body to system xattr.
-		attachments := retrieveAttachmentMeta(docID)
-		require.Len(t, attachments, 1)
+		createDocWithLegacyAttachment(t, rt, docID, rawDoc, attKey, attBody)
 	}
 
 	t.Run("single attachment removal upon document update", func(t *testing.T) {
@@ -9392,4 +9343,64 @@ func TestAttachmentDeleteOnExpiry(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
+}
+
+func createDocWithLegacyAttachment(t *testing.T, rt *RestTester, docID string, rawDoc []byte, attKey string, attBody []byte) {
+	// Write attachment directly to the bucket.
+	_, err := rt.Bucket().Add(attKey, 0, attBody)
+	require.NoError(t, err)
+
+	body := db.Body{}
+	err = body.Unmarshal(rawDoc)
+	require.NoError(t, err, "Error unmarshalling body")
+
+	// Write raw document to the bucket.
+	_, err = rt.Bucket().Add(docID, 0, rawDoc)
+	require.NoError(t, err)
+
+	// Migrate document metadata from document body to system xattr.
+	attachments := retrieveAttachmentMeta(t, rt, docID)
+	require.Len(t, attachments, 1)
+}
+
+func retrieveAttachmentMeta(t *testing.T, rt *RestTester, docID string) (attMeta map[string]interface{}) {
+	body := rt.getDoc(docID)
+	attachments, ok := body["_attachments"].(map[string]interface{})
+	require.True(t, ok)
+	return attachments
+}
+
+func rawDocWithAttachmentAndSyncMeta() []byte {
+	return []byte(`{
+   "_sync": {
+      "rev": "1-5fc93bd36377008f96fdae2719c174ed",
+      "sequence": 2,
+      "recent_sequences": [
+         2
+      ],
+      "history": {
+         "revs": [
+            "1-5fc93bd36377008f96fdae2719c174ed"
+         ],
+         "parents": [
+            -1
+         ],
+         "channels": [
+            null
+         ]
+      },
+      "cas": "",
+      "attachments": {
+         "hi.txt": {
+            "revpos": 1,
+            "content_type": "text/plain",
+            "length": 2,
+            "stub": true,
+            "digest": "sha1-witfkXg0JglCjW9RssWvTAveakI="
+         }
+      },
+      "time_saved": "2021-09-01T17:33:03.054227821Z"
+   },
+  "key": "value"
+}`)
 }

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -3406,6 +3406,7 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 	attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
 	contentType := "text/plain"
 	length, digest, err := btc.saveAttachment(contentType, attachmentAData)
+	require.NoError(t, err)
 
 	// Update doc1, include reference to non-existing attachment with recent revpos
 	revIDDoc1, err := btc.PushRev("doc1", rev1ID, []byte(fmt.Sprintf(`{"key": "val", "_attachments":{"attachment":{"digest":"%s","length":%d,"content_type":"%s","stub":true,"revpos":1}}}`, digest, length, contentType)))

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -4222,3 +4222,46 @@ func TestSendRevAsReadOnlyGuest(t *testing.T) {
 	log.Printf("response body: %s", body)
 
 }
+
+// Repro CBG-2055: changing an attachment name on a stub causes version metadata to be lost
+func TestBlipAttachNameChange(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		guestEnabled: true,
+	})
+	defer rt.Close()
+
+	client1, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
+	require.NoError(t, err)
+	defer client1.Close()
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeySync, base.KeySyncMsg, base.KeyWebSocket, base.KeyWebSocketFrame, base.KeyHTTP, base.KeyCRUD)()
+
+	attachmentA := []byte("attachmentA")
+	attachmentAData := base64.StdEncoding.EncodeToString(attachmentA)
+	digest := db.Sha1DigestKey(attachmentA)
+
+	// Push initial attachment data
+	rev, err := client1.PushRev("doc", "", []byte(`{"key":"val","_attachments":{"attachment": {"data":"`+attachmentAData+`"}}}`))
+	require.NoError(t, err)
+
+	// Confirm attachment is in the bucket
+	attachmentAKey := db.MakeAttachmentKey(2, "doc", digest)
+	bucketAttachmentA, _, err := rt.Bucket().GetRaw(attachmentAKey)
+	require.NoError(t, err)
+	require.EqualValues(t, bucketAttachmentA, attachmentA)
+
+	// Simulate changing only the attachment name over CBL
+	// Use revpos 2 to simulate revpos bug in CBL 2.8 - 3.0.0
+	rev, err = client1.PushRev("doc", rev, []byte(`{"key":"val","_attachments":{"attach":{"revpos":2,"content_type":"","length":11,"stub":true,"digest":"`+digest+`"}}}`))
+	require.NoError(t, err)
+	err = rt.waitForRev("doc", rev)
+	require.NoError(t, err)
+
+	// Check if attachment is still in bucket
+	bucketAttachmentA, _, err = rt.Bucket().GetRaw(attachmentAKey)
+	assert.NoError(t, err)
+	assert.Equal(t, bucketAttachmentA, attachmentA)
+
+	resp := rt.SendAdminRequest("GET", "/db/doc/attach", "")
+	assertStatus(t, resp, http.StatusOK)
+	assert.Equal(t, attachmentA, resp.BodyBytes())
+}

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -4826,7 +4826,7 @@ func TestLocalWinsConflictResolution(t *testing.T) {
 			initialState:   newRevisionState(3, "a", false, 0),
 			localMutation:  newRevisionState(6, "b", false, 4),
 			remoteMutation: newRevisionState(6, "c", false, 5),
-			expectedResult: newRevisionState(7, "b", false, 7),
+			expectedResult: newRevisionState(7, "b", false, 5),
 		},
 	}
 


### PR DESCRIPTION
CBG-2055
revpos shouldn't be used as a criteria for attachment persistence for incoming writes. In particular during storeAttachments, a variety of circumstances can result in changes to the incoming revpos, and we don't want to fail to persist or remove attachments based on revpos.

In addition to removing the revpos check in storeAttachments, adds some additional handling in blip_handler for different flavors of revpos being sent by CBL to ensure it's being set to the incoming revID when the attachment doesn't exist.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration/1599/
