### PR TITLE
update to newer golangci-lint syntax

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,16 +16,15 @@ linters:
     - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
     - goconst # Finds repeated strings that could be replaced by a constant
     - gocritic # The most opinionated Go source code linter
-    - golint # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
     - goprintffuncname # Checks that printf-like functions are named with `f` at the end
     - gosec # (gas) Inspects source code for security problems
     - gosimple # (megacheck) Linter for Go source code that specializes in simplifying a code
     - govet # (vet, vetshadow) Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
     - ineffassign # Detects when assignments to existing variables are not used
-    - maligned # Tool to detect Go structs that would take less memory if their fields were sorted
     - nakedret # Finds naked returns in functions greater than a specified function length
     - nestif # Reports deeply nested if statements
     - prealloc # Finds slice declarations that could potentially be preallocated
+    - revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
     - staticcheck # (megacheck) Staticcheck is a go vet on steroids, applying a ton of static analysis checks
     - structcheck # Finds unused struct fields
     - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
@@ -66,3 +65,6 @@ issues:
     - path: _test\.go
       linters:
         - goconst
+  govet:
+    enable:
+      - fieldalignment # detect Go structs that would take less memory if their fields were sorted


### PR DESCRIPTION
Runs golangci-lint without errors with `golangci-lint@latest`