### PR TITLE
CBG-2100 allow x509 tests to use under jenkins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 *.exe
 *.iml
 sg_config.json
+coverage*.out
+coverage*.xml
+verbose*.out*
+verbose*.xml

--- a/base/constants.go
+++ b/base/constants.go
@@ -77,6 +77,9 @@ const (
 	// If TestEnvX509Local=true, must use SG_TEST_X509_LOCAL_USER to set macOS username to locate CBS cert inbox
 	TestEnvX509LocalUser = "SG_TEST_X509_LOCAL_USER"
 
+	// If set, corresponds to name of the docker image of couchbase server
+	TestEnvCouchbaseServerDockerName = "SG_TEST_COUCHBASE_SERVER_DOCKER_NAME"
+
 	DefaultUseXattrs      = true // Whether Sync Gateway uses xattrs for metadata storage, if not specified in the config
 	DefaultAllowConflicts = true // Whether Sync Gateway allows revision conflicts, if not specified in the config
 

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -200,6 +200,14 @@ func TestTLSSkipVerify() bool {
 	return val
 }
 
+func TestUseCouchbaseServerDockerName() (bool, string) {
+	testX509CouchbaseServerDockerName, isSet := os.LookupEnv(TestEnvCouchbaseServerDockerName)
+	if !isSet {
+		return false, ""
+	}
+	return true, testX509CouchbaseServerDockerName
+}
+
 func TestX509LocalServer() (bool, string) {
 	testX509LocalServer, isSet := os.LookupEnv(TestEnvX509Local)
 	if !isSet {

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 DEFAULT_PACKAGE_TIMEOUT="45m"
 
-if [ "$1" == "-m" ]; then
+set -u
+
+if [ "${1:-}" == "-m" ]; then
     echo "Running in automated master integration mode"
     # Set automated setting parameters
     SG_COMMIT="master"
@@ -26,7 +28,7 @@ set -e # Abort on errors
 set -x # Output all executed shell commands
 
 # Use Git SSH and define private repos
-git config --global --add url."git@github.com:".insteadOf "https://github.com/"
+git config --global --replace-all url."git@github.com:".insteadOf "https://github.com/"
 export GOPRIVATE=github.com/couchbaselabs/go-fleecedelta
 
 # Print commit
@@ -34,7 +36,7 @@ SG_COMMIT_HASH=$(git rev-parse HEAD)
 echo "Sync Gateway git commit hash: $SG_COMMIT_HASH"
 
 # Use Go modules (3.1 and above) or bootstrap for legacy Sync Gateway versions (3.0 and below)
-if [ ${USE_GO_MODULES} == "false" ]; then
+if [ "${USE_GO_MODULES:-}" == "false" ]; then
     mkdir -p sgw_int_testing # Make the directory if it does not exist
     cp bootstrap.sh sgw_int_testing/bootstrap.sh
     cd sgw_int_testing
@@ -52,16 +54,16 @@ else
 fi
 
 # Set environment vars
-GO_TEST_FLAGS="-v -p 1 -count=${RUN_COUNT}"
+GO_TEST_FLAGS="-v -p 1 -count=${RUN_COUNT:-1}"
 INT_LOG_FILE_NAME="verbose_int"
 
 if [ -d "godeps" ]; then
-    export GOPATH=`pwd`/godeps
+    export GOPATH=$(pwd)/godeps
 fi
-export PATH=$PATH:`go env GOPATH`/bin
+export PATH=$PATH:$(go env GOPATH)/bin
 echo "PATH: $PATH"
 
-if [ "${TEST_DEBUG}" == "true" ]; then
+if [ "${TEST_DEBUG:-}" == "true" ]; then
     export SG_TEST_LOG_LEVEL="debug"
     export SG_TEST_BUCKET_POOL_DEBUG="true"
 fi
@@ -70,37 +72,38 @@ if [ "${TARGET_TEST}" != "ALL" ]; then
     GO_TEST_FLAGS="${GO_TEST_FLAGS} -run ${TARGET_TEST}"
 fi
 
-if [ "${PACKAGE_TIMEOUT}" != "" ]; then
+if [ "${PACKAGE_TIMEOUT:-}" != "" ]; then
     GO_TEST_FLAGS="${GO_TEST_FLAGS} -test.timeout=${PACKAGE_TIMEOUT}"
 else
     echo "Defaulting package timeout to ${DEFAULT_PACKAGE_TIMEOUT}"
     GO_TEST_FLAGS="${GO_TEST_FLAGS} -test.timeout=${DEFAULT_PACKAGE_TIMEOUT}"
 fi
 
-if [ "${DETECT_RACES}" == "true" ]; then
+if [ "${DETECT_RACES:-}" == "true" ]; then
     GO_TEST_FLAGS="${GO_TEST_FLAGS} -race"
 fi
 
-if [ "${FAIL_FAST}" == "true" ]; then
+if [ "${FAIL_FAST:-}" == "true" ]; then
     GO_TEST_FLAGS="${GO_TEST_FLAGS} -failfast"
 fi
 
-if [ "${SG_TEST_PROFILE_FREQUENCY}" == "true" ]; then
+if [ "${SG_TEST_PROFILE_FREQUENCY:-}" == "true" ]; then
     export SG_TEST_PROFILE_FREQUENCY=${SG_TEST_PROFILE_FREQUENCY}
-fi    
+fi
 
 if [ "${RUN_WALRUS}" == "true" ]; then
     # EE
-    go test -coverprofile=coverage_walrus_ee.out -coverpkg=github.com/couchbase/sync_gateway/... -tags cb_sg_enterprise $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} >verbose_unit_ee.out.raw 2>&1 | true
+    go test -coverprofile=coverage_walrus_ee.out -coverpkg=github.com/couchbase/sync_gateway/... -tags cb_sg_enterprise $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} > verbose_unit_ee.out.raw 2>&1 | true
     # CE
-    go test -coverprofile=coverage_walrus_ce.out -coverpkg=github.com/couchbase/sync_gateway/... $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} >verbose_unit_ce.out.raw 2>&1 | true
+    go test -coverprofile=coverage_walrus_ce.out -coverpkg=github.com/couchbase/sync_gateway/... $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} > verbose_unit_ce.out.raw 2>&1 | true
 fi
 
+export SG_TEST_COUCHBASE_SERVER_DOCKER_NAME=couchbase
 # Start CBS
-docker stop couchbase || true
-docker rm couchbase || true
+docker stop ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} || true
+docker rm ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} || true
 # --volume: Makes and mounts a CBS folder for storing a CBCollect if needed
-docker run -d --name couchbase --volume `pwd`/cbs:/root --net=host couchbase/server:${COUCHBASE_SERVER_VERSION}
+docker run -d --name ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} --volume $(pwd)/cbs:/root --net=host couchbase/server:${COUCHBASE_SERVER_VERSION}
 
 # Test to see if Couchbase Server is up
 # Each retry min wait 5s, max 10s. Retry 20 times with exponential backoff (delay 0), fail at 120s
@@ -113,7 +116,7 @@ curl -u Administrator:password -v -X POST http://127.0.0.1:8091/node/controller/
 curl -u Administrator:password -v -X POST http://127.0.0.1:8091/pools/default -d 'memoryQuota=3072' -d 'indexMemoryQuota=3072' -d 'ftsMemoryQuota=256'
 curl -u Administrator:password -v -X POST http://127.0.0.1:8091/settings/web -d 'password=password&username=Administrator&port=SAME'
 curl -u Administrator:password -v -X POST http://localhost:8091/settings/indexes -d indexerThreads=4 -d logLevel=verbose -d maxRollbackPoints=10 \
--d storageMode=plasma -d memorySnapshotInterval=150 -d stableSnapshotInterval=40000
+    -d storageMode=plasma -d memorySnapshotInterval=150 -d stableSnapshotInterval=40000
 
 sleep 10
 
@@ -141,7 +144,6 @@ if grep -q "server logs for details\|Timed out after 1m0s waiting for a bucket t
     docker exec -t couchbase /opt/couchbase/bin/cbcollect_info /root/cbcollect.zip
 fi
 
-
 # Generate xunit test report that can be parsed by the JUnit Plugin
 LC_CTYPE=C tr -dc [:print:][:space:] < ${INT_LOG_FILE_NAME}.out.raw > ${INT_LOG_FILE_NAME}.out # Strip non-printable characters
 ~/go/bin/go2xunit -input "${INT_LOG_FILE_NAME}.out" -output "${INT_LOG_FILE_NAME}.xml"
@@ -160,7 +162,7 @@ if [ "${RUN_WALRUS}" == "true" ]; then
     ~/go/bin/gocov convert "coverage_walrus_ce.out" | ~/go/bin/gocov-xml > "coverage_walrus_ce.xml"
 fi
 
-if [ "${TEST_FAILED}" = true ] ; then
+if [ "${TEST_FAILED:-}" = true ]; then
     # If output contained `FAIL:`
     if grep -q 'FAIL:' "${INT_LOG_FILE_NAME}.out"; then
         # Test failure, so mark as unstable

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -73,6 +73,10 @@ func TestCheckPermissions(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server")
 	}
+	serverURL := base.UnitTestUrl()
+	if base.ServerIsTLS(serverURL) {
+		t.Skipf("URI %s can not start with couchbases://", serverURL)
+	}
 
 	clusterAdminPermission := Permission{"!admin", false}
 	clusterReadOnlyAdminPermission := Permission{"!ro_admin", false}
@@ -186,13 +190,17 @@ func TestCheckPermissions(t *testing.T) {
 }
 
 func TestCheckPermissionsWithX509(t *testing.T) {
+	serverURL := base.UnitTestUrl()
+	if !base.ServerIsTLS(serverURL) {
+		t.Skipf("URI %s needs to start with couchbases://", serverURL)
+	}
 	tb, teardownFn, caCertPath, certPath, keyPath := setupX509Tests(t, true)
 	defer tb.Close()
 	defer teardownFn()
 
 	ctx := NewServerContext(&StartupConfig{
 		Bootstrap: BootstrapConfig{
-			Server:       base.UnitTestUrl(),
+			Server:       serverURL,
 			X509CertPath: certPath,
 			X509KeyPath:  keyPath,
 			CACertPath:   caCertPath,
@@ -220,6 +228,10 @@ func TestCheckPermissionsWithX509(t *testing.T) {
 func TestCheckRoles(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server")
+	}
+	serverURL := base.UnitTestUrl()
+	if base.ServerIsTLS(serverURL) {
+		t.Skipf("URI %s can not start with couchbases://", serverURL)
 	}
 
 	rt := NewRestTester(t, nil)
@@ -475,13 +487,17 @@ func TestAdminAuth(t *testing.T) {
 }
 
 func TestAdminAuthWithX509(t *testing.T) {
+	serverURL := base.UnitTestUrl()
+	if !base.ServerIsTLS(serverURL) {
+		t.Skipf("URI %s needs to start with couchbases://", serverURL)
+	}
 	tb, teardownFn, caCertPath, certPath, keyPath := setupX509Tests(t, true)
 	defer tb.Close()
 	defer teardownFn()
 
 	ctx := NewServerContext(&StartupConfig{
 		Bootstrap: BootstrapConfig{
-			Server:       base.UnitTestUrl(),
+			Server:       serverURL,
 			X509CertPath: certPath,
 			X509KeyPath:  keyPath,
 			CACertPath:   caCertPath,

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -280,13 +280,17 @@ outerLoop:
 }
 
 func TestObtainManagementEndpointsFromServerContextWithX509(t *testing.T) {
+	serverURL := base.UnitTestUrl()
+	if !base.ServerIsTLS(serverURL) {
+		t.Skipf("URI %s needs to start with couchbases://", serverURL)
+	}
 	tb, teardownFn, caCertPath, certPath, keyPath := setupX509Tests(t, true)
 	defer tb.Close()
 	defer teardownFn()
 
 	ctx := NewServerContext(&StartupConfig{
 		Bootstrap: BootstrapConfig{
-			Server:       base.UnitTestUrl(),
+			Server:       serverURL,
 			X509CertPath: certPath,
 			X509KeyPath:  keyPath,
 			CACertPath:   caCertPath,

--- a/rest/x509_test.go
+++ b/rest/x509_test.go
@@ -154,11 +154,16 @@ func setupX509Tests(t *testing.T, useIPAddress bool) (testBucket *base.TestBucke
 	sgPair := generateX509SG(t, ca, base.TestClusterUsername(), time.Now().Add(time.Hour*24))
 	teardownFn := saveX509Files(t, ca, nodePair, sgPair)
 
-	isLocalX509, localUserName := base.TestX509LocalServer()
-	if isLocalX509 {
-		err = loadCertsIntoLocalCouchbaseServer(*testURL, ca, nodePair, localUserName)
+	usingDocker, dockerName := base.TestUseCouchbaseServerDockerName()
+	if usingDocker {
+		err = loadCertsIntoCouchbaseServerDocker(*testURL, ca, nodePair, dockerName)
 	} else {
-		err = loadCertsIntoCouchbaseServer(*testURL, ca, nodePair)
+		isLocalX509, localUserName := base.TestX509LocalServer()
+		if isLocalX509 {
+			err = loadCertsIntoLocalCouchbaseServer(*testURL, ca, nodePair, localUserName)
+		} else {
+			err = loadCertsIntoCouchbaseServer(*testURL, ca, nodePair)
+		}
 	}
 	require.NoError(t, err)
 


### PR DESCRIPTION
The bulk of these changes allow copy of CA certs and configuration into
a docker container, which is used by jenkins.

- Add jenkins output files to gitignore
- Make sure three ways of running X509 are supposed: couchbase server on
  docker, on localhost (OS X only), ssh to remote couchbase
- Some changes to jenkins script
	- allow set -u to tell what variables are missing. Use bash {:-}
	  syntax for potentially unset variables
	- run through shfmt
	- change git config --add to --replace-all to not write infinite
	  options to .gitconfig
- make sure all files produced by integration tests are marked in
  .gitignore