### PR TITLE
CBG-1866 Route failover information through worker for metadata update

### DIFF
--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -115,6 +115,7 @@ func NewDCPClient(ID string, callback sgbucket.FeedEventCallbackFunc, options DC
 	return client, nil
 }
 
+// Start returns an error and a channel to indicate when the DCPClient is done. If Start returns an error, DCPClient.Close() needs to be called.
 func (dc *DCPClient) Start() (doneChan chan error, err error) {
 	err = dc.initAgent(dc.spec)
 	if err != nil {
@@ -125,17 +126,14 @@ func (dc *DCPClient) Start() (doneChan chan error, err error) {
 	for i := uint16(0); i < dc.numVbuckets; i++ {
 		openErr := dc.openStream(i)
 		if openErr != nil {
-			// If this error condition is hit, the caller must call DCPClient.Close(). If we close here, should we make it blocking?
 			return dc.doneChannel, fmt.Errorf("Unable to start DCP client, error opening stream for vb %d: %w", i, openErr)
 		}
 	}
-	// It is possible, but unlikely for doneChannel to be closed when returning this if the DCPWorkers fail to start or finish very quickly.
 	return dc.doneChannel, nil
 }
 
 // Close is used externally to stop the DCP client. If the client was already closed due to error, returns that error
 func (dc *DCPClient) Close() error {
-	// Should this close be synchronous?
 	dc.close()
 	return dc.getCloseError()
 }

--- a/base/dcp_client_stream_event.go
+++ b/base/dcp_client_stream_event.go
@@ -36,6 +36,11 @@ type mutationEvent struct {
 	value    []byte
 }
 
+type streamOpenEvent struct {
+	streamEventCommon
+	failoverLogs []gocbcore.FailoverEntry
+}
+
 func (e mutationEvent) asFeedEvent() sgbucket.FeedEvent {
 	return sgbucket.FeedEvent{
 		Opcode:   sgbucket.FeedOpMutation,

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -9,10 +9,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/gocbcore/v10"
 	sgbucket "github.com/couchbase/sg-bucket"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+const oneShotDCPTimeout = 60 * time.Second
 
 func TestOneShotDCP(t *testing.T) {
 
@@ -23,13 +27,13 @@ func TestOneShotDCP(t *testing.T) {
 	bucket := GetTestBucket(t)
 	defer bucket.Close()
 
-	num_docs := 1000
+	numDocs := 1000
 	// write documents to bucket
 	body := map[string]interface{}{"foo": "bar"}
-	for i := 0; i < num_docs; i++ {
+	for i := 0; i < numDocs; i++ {
 		key := fmt.Sprintf("%s_%d", t.Name(), i)
 		err := bucket.Set(key, 0, nil, body)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	// create callback
@@ -46,14 +50,14 @@ func TestOneShotDCP(t *testing.T) {
 	}
 
 	dcpClient, err := NewDCPClient(feedID, counterCallback, clientOptions, bucket, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Add additional documents in a separate goroutine, to verify afterEndSeq handling
 	var additionalDocsWg sync.WaitGroup
 	additionalDocsWg.Add(1)
 	go func() {
 		updatedBody := map[string]interface{}{"foo": "bar"}
-		for i := num_docs; i < num_docs*2; i++ {
+		for i := numDocs; i < numDocs*2; i++ {
 			key := fmt.Sprintf("%s_%d", t.Name(), i)
 			err := bucket.Set(key, 0, nil, updatedBody)
 			assert.NoError(t, err)
@@ -62,18 +66,18 @@ func TestOneShotDCP(t *testing.T) {
 	}()
 
 	doneChan, startErr := dcpClient.Start()
-	assert.NoError(t, startErr)
+	require.NoError(t, startErr)
 
 	defer func() {
 		_ = dcpClient.Close()
 	}()
 
 	// wait for done
-	timeout := time.After(3 * time.Second)
+	timeout := time.After(oneShotDCPTimeout)
 	select {
 	case err := <-doneChan:
-		assert.Equal(t, uint64(num_docs), mutationCount)
-		assert.NoError(t, err)
+		require.Equal(t, uint64(numDocs), mutationCount)
+		require.NoError(t, err)
 	case <-timeout:
 		t.Errorf("timeout waiting for one-shot feed to complete")
 	}
@@ -101,7 +105,7 @@ func TestTerminateDCPFeed(t *testing.T) {
 	feedID := t.Name()
 
 	dcpClient, err := NewDCPClient(feedID, counterCallback, DCPClientOptions{}, bucket, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Add documents in a separate goroutine
 	var feedClosed AtomicBool
@@ -121,17 +125,17 @@ func TestTerminateDCPFeed(t *testing.T) {
 	}()
 
 	doneChan, startErr := dcpClient.Start()
-	assert.NoError(t, startErr)
+	require.NoError(t, startErr)
 
 	// Wait for some processing to complete, then close the feed
 	time.Sleep(10 * time.Millisecond)
 	log.Printf("Closing DCP Client")
 	err = dcpClient.Close()
 	log.Printf("DCP Client closed, waiting for feed close notification")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// wait for done
-	timeout := time.After(3 * time.Second)
+	timeout := time.After(oneShotDCPTimeout)
 	select {
 	case <-doneChan:
 		feedClosed.Set(true)
@@ -151,96 +155,115 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 	if UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}
+	testCases := []struct {
+		startSeqNo gocbcore.SeqNo
+		vbNo       uint16
+		vbUUID     gocbcore.VbUUID
+	}{
+		{
+			startSeqNo: 2,
+			vbUUID:     1234, // garbage UUID
+		},
+		{
+			startSeqNo: 0,
+			vbUUID:     1234, // garbage UUID
+		},
+	}
+	for _, test := range testCases {
+		t.Run(fmt.Sprintf("metadata mismatch %+v", test), func(t *testing.T) {
 
-	bucket := GetTestBucket(t)
-	defer bucket.Close()
+			bucket := GetTestBucket(t)
+			defer bucket.Close()
 
-	// create callback
-	mutationCount := uint64(0)
-	vbucketZeroCount := uint64(0)
-	counterCallback := func(event sgbucket.FeedEvent) bool {
-		if bytes.HasPrefix(event.Key, []byte(t.Name())) {
-			atomic.AddUint64(&mutationCount, 1)
-			if event.VbNo == 0 {
-				atomic.AddUint64(&vbucketZeroCount, 1)
+			// create callback
+			mutationCount := uint64(0)
+			vbucketZeroCount := uint64(0)
+			counterCallback := func(event sgbucket.FeedEvent) bool {
+				if bytes.HasPrefix(event.Key, []byte(t.Name())) {
+					atomic.AddUint64(&mutationCount, 1)
+					if event.VbNo == 0 {
+						atomic.AddUint64(&vbucketZeroCount, 1)
+					}
+				}
+				return false
 			}
-		}
-		return false
-	}
 
-	feedID := t.Name()
+			feedID := t.Name()
 
-	// Add documents
-	updatedBody := map[string]interface{}{"foo": "bar"}
-	for i := 0; i < 10000; i++ {
-		key := fmt.Sprintf("%s_%d", t.Name(), i)
-		err := bucket.Set(key, 0, nil, updatedBody)
-		assert.NoError(t, err)
-	}
+			// Add documents
+			updatedBody := map[string]interface{}{"foo": "bar"}
+			for i := 0; i < 10000; i++ {
+				key := fmt.Sprintf("%s_%d", t.Name(), i)
+				err := bucket.Set(key, 0, nil, updatedBody)
+				require.NoError(t, err)
+			}
 
-	// Perform first one-shot DCP feed - normal one-shot
-	dcpClientOpts := DCPClientOptions{
-		OneShot:        true,
-		FailOnRollback: true,
-	}
-	dcpClient, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, bucket, "")
-	assert.NoError(t, err)
+			// Perform first one-shot DCP feed - normal one-shot
+			dcpClientOpts := DCPClientOptions{
+				OneShot:        true,
+				FailOnRollback: true,
+			}
+			dcpClient, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, bucket, "")
+			require.NoError(t, err)
 
-	doneChan, startErr := dcpClient.Start()
-	assert.NoError(t, startErr)
+			doneChan, startErr := dcpClient.Start()
+			require.NoError(t, startErr)
 
-	// Wait for first feed to complete
-	timeout := time.After(3 * time.Second)
-	select {
-	case <-doneChan:
-		mutationCount := atomic.LoadUint64(&mutationCount)
-		assert.Equal(t, uint64(10000), mutationCount)
-	case <-timeout:
-		t.Errorf("timeout waiting for first one-shot feed to complete")
-	}
+			// Wait for first feed to complete
+			timeout := time.After(oneShotDCPTimeout)
+			select {
+			case <-doneChan:
+				mutationCount := atomic.LoadUint64(&mutationCount)
+				require.Equal(t, uint64(10000), mutationCount)
+			case <-timeout:
+				t.Errorf("timeout waiting for first one-shot feed to complete")
+			}
 
-	// store the number of mutations from vbucket zero for validating rollback on the third feed
-	vbucketZeroExpected := atomic.LoadUint64(&vbucketZeroCount)
+			// store the number of mutations from vbucket zero for validating rollback on the third feed
+			vbucketZeroExpected := atomic.LoadUint64(&vbucketZeroCount)
+			uuidMismatchMetadata := dcpClient.GetMetadata()
 
-	// Perform second one-shot DCP feed - VbUUID mismatch, failOnRollback=true
-	// Retrieve metadata from first DCP feed, and modify VbUUID to simulate rollback on server
-	uuidMismatchMetadata := dcpClient.GetMetadata()
-	uuidMismatchMetadata[0].VbUUID = 1234
+			// Perform second one-shot DCP feed - VbUUID mismatch, failOnRollback=true
+			// Retrieve metadata from first DCP feed, and modify VbUUID to simulate rollback on server
+			uuidMismatchMetadata[0].VbUUID = test.vbUUID
+			uuidMismatchMetadata[0].StartSeqNo = test.startSeqNo
 
-	dcpClientOpts = DCPClientOptions{
-		InitialMetadata: uuidMismatchMetadata,
-		FailOnRollback:  true,
-		OneShot:         true,
-	}
-	dcpClient2, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, bucket, "")
-	assert.NoError(t, err)
+			dcpClientOpts = DCPClientOptions{
+				InitialMetadata: uuidMismatchMetadata,
+				FailOnRollback:  true,
+				OneShot:         true,
+			}
+			dcpClient2, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, bucket, "")
+			require.NoError(t, err)
 
-	_, startErr2 := dcpClient2.Start()
-	assert.Error(t, startErr2)
+			_, startErr2 := dcpClient2.Start()
+			require.Error(t, startErr2)
 
-	log.Printf("Starting third feed")
-	// Perform a third DCP feed - mismatched VbUUID, failOnRollback=false
-	atomic.StoreUint64(&mutationCount, 0)
-	dcpClientOpts = DCPClientOptions{
-		InitialMetadata: uuidMismatchMetadata,
-		FailOnRollback:  false,
-		OneShot:         true,
-	}
-	dcpClient3, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, bucket, "")
-	assert.NoError(t, err)
+			log.Printf("Starting third feed")
+			// Perform a third DCP feed - mismatched VbUUID, failOnRollback=false
+			atomic.StoreUint64(&mutationCount, 0)
+			dcpClientOpts = DCPClientOptions{
+				InitialMetadata: uuidMismatchMetadata,
+				FailOnRollback:  false,
+				OneShot:         true,
+			}
+			dcpClient3, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, bucket, "")
+			require.NoError(t, err)
 
-	doneChan3, startErr3 := dcpClient3.Start()
-	assert.NoError(t, startErr3)
+			doneChan3, startErr3 := dcpClient3.Start()
+			require.NoError(t, startErr3)
 
-	// Wait for third feed to complete
-	timeout = time.After(3 * time.Second)
-	select {
-	case <-doneChan3:
-		// only vbucket 0 should have rolled back, expect mutation count to be only vbucketZero
-		mutationCount := atomic.LoadUint64(&mutationCount)
-		assert.Equal(t, int(vbucketZeroExpected), int(mutationCount))
-	case <-timeout:
-		t.Errorf("timeout waiting for first one-shot feed to complete")
+			// Wait for third feed to complete
+			timeout = time.After(oneShotDCPTimeout)
+			select {
+			case <-doneChan3:
+				// only vbucket 0 should have rolled back, expect mutation count to be only vbucketZero
+				mutationCount := atomic.LoadUint64(&mutationCount)
+				require.Equal(t, int(vbucketZeroExpected), int(mutationCount))
+			case <-timeout:
+				t.Errorf("timeout waiting for first one-shot feed to complete")
+			}
+		})
 	}
 }
 
@@ -278,7 +301,7 @@ func TestResumeStoppedFeed(t *testing.T) {
 	for i := 0; i < 10000; i++ {
 		key := fmt.Sprintf("%s_%d", t.Name(), i)
 		err := bucket.Set(key, 0, nil, updatedBody)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	// Start first one-shot DCP feed, will be stopped by callback after processing 5000 records
@@ -291,18 +314,17 @@ func TestResumeStoppedFeed(t *testing.T) {
 	}
 	var err error
 	dcpClient, err = NewDCPClient(feedID, counterCallback, dcpClientOpts, bucket, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	doneChan, startErr := dcpClient.Start()
-	assert.NoError(t, startErr)
+	require.NoError(t, startErr)
 
 	// Wait for first feed to complete
-	timeout := time.After(3 * time.Second)
-	time.Sleep(1 * time.Second)
+	timeout := time.After(oneShotDCPTimeout)
 	select {
 	case <-doneChan:
 		mutationCount := atomic.LoadUint64(&mutationCount)
-		assert.True(t, int(mutationCount) > 5000)
+		require.Greater(t, int(mutationCount), 5000)
 		log.Printf("Total processed first feed: %v", mutationCount)
 	case <-timeout:
 		t.Errorf("timeout waiting for first one-shot feed to complete")
@@ -323,21 +345,20 @@ func TestResumeStoppedFeed(t *testing.T) {
 		OneShot:        true,
 	}
 	dcpClient2, err := NewDCPClient(feedID, secondCallback, dcpClientOpts, bucket, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	doneChan2, startErr2 := dcpClient2.Start()
-	assert.NoError(t, startErr2)
+	require.NoError(t, startErr2)
 
 	// Wait for second feed to complete
-	timeout = time.After(3 * time.Second)
-	time.Sleep(1 * time.Second)
+	timeout = time.After(oneShotDCPTimeout)
 	select {
 	case <-doneChan2:
 		// validate the total count exceeds 10000, and the second feed didn't just reprocess everything
 		mutationCount := atomic.LoadUint64(&mutationCount)
-		assert.True(t, int(mutationCount) >= 10000)
+		require.GreaterOrEqual(t, int(mutationCount), 10000)
 		secondFeedCount := atomic.LoadUint64(&secondFeedCount)
-		assert.True(t, int(secondFeedCount) < 10000)
+		require.Less(t, int(secondFeedCount), 10000)
 		log.Printf("Total processed: %v, second feed: %v", mutationCount, secondFeedCount)
 	case <-timeout:
 		t.Errorf("timeout waiting for second one-shot feed to complete")

--- a/base/dcp_client_worker.go
+++ b/base/dcp_client_worker.go
@@ -93,6 +93,8 @@ func (w *DCPWorker) Start(wg *sync.WaitGroup) {
 			case event := <-w.eventFeed:
 				vbID := event.VbID()
 				switch e := event.(type) {
+				case streamOpenEvent:
+					w.metadata.SetFailoverEntries(e.vbID, e.failoverLogs)
 				case snapshotEvent:
 					// Set pending snapshot - don't persist to meta until we receive first sequence in the snapshot,
 					// to avoid attempting to restart with a new snapshot and old sequence value

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -838,7 +839,8 @@ func TestAttachmentCompactIncorrectStat(t *testing.T) {
 	count := int64(0)
 	var err error
 	go func() {
-		count, _, err = attachmentCompactMarkPhase(testDb, "mark", terminator, stat)
+		docCount, _, err := attachmentCompactMarkPhase(testDb, "mark", terminator, stat)
+		atomic.StoreInt64(&count, docCount)
 		require.NoError(t, err)
 	}()
 
@@ -850,7 +852,7 @@ func TestAttachmentCompactIncorrectStat(t *testing.T) {
 	}
 
 	compactionFuncReturnedRetryFunc := func() (shouldRetry bool, err error, value interface{}) {
-		if count == 0 {
+		if atomic.LoadInt64(&count) == 0 {
 			return true, nil, nil
 		}
 		return false, nil, nil

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -345,7 +345,10 @@ func TestAdminAuth(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server")
 	}
-
+	serverURL := base.UnitTestUrl()
+	if base.ServerIsTLS(serverURL) {
+		t.Skipf("URI %s needs to start with couchbase://", serverURL)
+	}
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
@@ -533,6 +536,10 @@ func TestAdminAPIAuth(t *testing.T) {
 
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
+	}
+	serverURL := base.UnitTestUrl()
+	if base.ServerIsTLS(serverURL) {
+		t.Skipf("URI %s can not start with couchbases://", serverURL)
 	}
 
 	rt := NewRestTester(t, &RestTesterConfig{


### PR DESCRIPTION
Avoids metadata races without adding mutex to metadata since the only metadata update information happens through a 
single select statement.

Fix additional dataraces in test code found by couchbases protocol with the race detector:

- use atomics to avoid data races
- change assert to require when required for test semantics
- make sure actually are testing something with attachment compaction by resetting count to zero
- allow longer time to start DCP workers in the case of TLS protocol.
- change how doneChannel works, so it will return error (or nil), followed by channel closed. This makes sure in the case of close error the workers are still stopped.
- close DCPClient even when it fails to start in test code.

Some ideas on changing semantics for more robust/obvious behavior:

- When DCPClient.Start() fails, don't force the caller to close the client
- Don't close DCPClient after the doneChannel is received (our API should assert that it is closed). https://cs.github.com/couchbase/sync_gateway/blob/6e0cb44aa1f61264160f5b4f21332d8b0119c38d/db/attachment_compaction.go?q=dcpclient.close#L138
- Consider DCPClient.Close or separate method to be synchronous, since DCP feed will still receive events while close is happening.
- Consider not returning doneChannel as part of DCPClient.Start since it could be already done when it returns (in the case of an error or very quick oneShot) and a select statement on a doneChannel would not detect that.
