### PR TITLE
CBG-1389: Sync Gateway will automatically restart on Windows if it fails

### DIFF
--- a/build/windows/wix_installer/sync-gateway.wxs
+++ b/build/windows/wix_installer/sync-gateway.wxs
@@ -99,8 +99,8 @@
                    Vital="yes">
             <util:ServiceConfig
                      FirstFailureActionType="restart"
-                     SecondFailureActionType="none"
-                     ThirdFailureActionType="none" />
+                     SecondFailureActionType="restart"
+                     ThirdFailureActionType="restart" />
           </ServiceInstall>
 
         <ServiceControl Id="sc_SGWService" Start="install" Stop="both" Remove="uninstall" Name="SyncGateway" Wait="yes">

--- a/build/windows/wix_installer/sync-gateway.wxs
+++ b/build/windows/wix_installer/sync-gateway.wxs
@@ -97,6 +97,10 @@
                    Type="ownProcess"
                    Arguments='start "[INSTALLDIR]$(var.WinSGWEXE)" "[INSTALLDIR]$(var.WinServiceConfig)" "[INSTALLDIR]var\lib\couchbase\logs\sync_gateway_error.log" '
                    Vital="yes">
+            <util:ServiceConfig
+                     FirstFailureActionType="restart"
+                     SecondFailureActionType="none"
+                     ThirdFailureActionType="none" />
           </ServiceInstall>
 
         <ServiceControl Id="sc_SGWService" Start="install" Stop="both" Remove="uninstall" Name="SyncGateway" Wait="yes">


### PR DESCRIPTION
CBG-1389

This will cause the Windows MSI installer to make the Sync Gateway service restart instantly if it fails (ie. a panic or fatal error occurs). This is done via the Windows Service recovery settings.

This is what the recovery settings on Windows show when the MSI has installed the service:
![MSI.png](https://user-images.githubusercontent.com/8864080/173621242-e0d28a23-53f1-4720-b1e1-23c914de7d70.png)


If SGW exits due to a user error (such as misconfiguration in the startup config), then Windows will be trying to start SGW constantly with no break causing log spam which is the same as what currently happens on via the Linux.

## Dependencies (if applicable)
- [ ] Get review from the build team