### PR TITLE
CBG-2059: More accurately tag redactable fields in HTTP logs

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -9,6 +9,7 @@
 package base
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -16,7 +17,10 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // GetLogKeys returns log keys in a map
@@ -364,4 +368,16 @@ func LogDebugEnabled(logKey LogKey) bool {
 // or if the traceLogger is enabled.
 func LogTraceEnabled(logKey LogKey) bool {
 	return consoleLogger.shouldLog(LevelTrace, logKey) || traceLogger.shouldLog(LevelTrace)
+}
+
+// AssertLogContains asserts that the logs produced by function f contain string s.
+func AssertLogContains(t *testing.T, s string, f func()) {
+	b := bytes.Buffer{}
+
+	// temporarily override logger output for the given function call
+	consoleLogger.logger.SetOutput(&b)
+	f()
+	consoleLogger.logger.SetOutput(os.Stderr)
+
+	assert.Contains(t, b.String(), s)
 }

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -23,18 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// asserts that the logs produced by function f contain string s.
-func assertLogContains(t *testing.T, s string, f func()) {
-	b := bytes.Buffer{}
-
-	// temporarily override logger output for the given function call
-	consoleLogger.logger.SetOutput(&b)
-	f()
-	consoleLogger.logger.SetOutput(os.Stderr)
-
-	assert.Contains(t, b.String(), s)
-}
-
 func TestRedactedLogFuncs(t *testing.T) {
 	if GlobalTestLoggingSet.IsTrue() {
 		t.Skip("Test does not work when a global test log level is set")
@@ -46,14 +34,14 @@ func TestRedactedLogFuncs(t *testing.T) {
 	defer func() { RedactUserData = false }()
 
 	RedactUserData = false
-	assertLogContains(t, "Username: alice", func() { InfofCtx(ctx, KeyAll, "Username: %s", username) })
+	AssertLogContains(t, "Username: alice", func() { InfofCtx(ctx, KeyAll, "Username: %s", username) })
 	RedactUserData = true
-	assertLogContains(t, "Username: <ud>alice</ud>", func() { InfofCtx(ctx, KeyAll, "Username: %s", username) })
+	AssertLogContains(t, "Username: <ud>alice</ud>", func() { InfofCtx(ctx, KeyAll, "Username: %s", username) })
 
 	RedactUserData = false
-	assertLogContains(t, "Username: alice", func() { WarnfCtx(ctx, "Username: %s", username) })
+	AssertLogContains(t, "Username: alice", func() { WarnfCtx(ctx, "Username: %s", username) })
 	RedactUserData = true
-	assertLogContains(t, "Username: <ud>alice</ud>", func() { WarnfCtx(ctx, "Username: %s", username) })
+	AssertLogContains(t, "Username: <ud>alice</ud>", func() { WarnfCtx(ctx, "Username: %s", username) })
 }
 
 func Benchmark_LoggingPerformance(b *testing.B) {

--- a/base/util.go
+++ b/base/util.go
@@ -695,15 +695,24 @@ func tagPathVars(req *http.Request, urlString *string) {
 	for k, v := range pathVars {
 		switch redactedPathVars[k] {
 		case "UD":
-			str = strings.Replace(str, "/"+v, "/"+UD(v).Redact(), 1)
+			str = replaceLast(str, "/"+v, "/"+UD(v).Redact())
 		case "MD":
-			str = strings.Replace(str, "/"+v, "/"+MD(v).Redact(), 1)
+			str = replaceLast(str, "/"+v, "/"+MD(v).Redact())
 		case "SD":
-			str = strings.Replace(str, "/"+v, "/"+SD(v).Redact(), 1)
+			str = replaceLast(str, "/"+v, "/"+SD(v).Redact())
 		}
 	}
 
 	*urlString = str
+}
+
+// replaceLast replaces the last instance of search in s with replacement.
+func replaceLast(s, search, replacement string) string {
+	idx := strings.LastIndex(s, search)
+	if idx == -1 {
+		return s
+	}
+	return s[:idx] + replacement + s[idx+len(search):]
 }
 
 // redactedQueryParams is a lookup map of query params to redaction types.

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -1631,3 +1631,22 @@ func TestCrc32cHashString(t *testing.T) {
 		})
 	}
 }
+
+func TestReplaceLast(t *testing.T) {
+	cases := []struct {
+		name, s, search, replacement, expected string
+	}{
+		{
+			name:        "basic",
+			s:           "foo foo",
+			search:      "foo",
+			replacement: "bar",
+			expected:    "foo bar",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, replaceLast(tc.s, tc.search, tc.replacement))
+		})
+	}
+}


### PR DESCRIPTION
CBG-2059

Previously when processing a HTTP log line in `tagPathVars`, we would redact the first instance of all the path variables that need redaction (e.g. `{docid}`). However, given the database `testificate` and document `test`, we would expect to log `/test/<ud>testificate</ud>`, but we'd actually log `/<ud>test</ud>ificate/test` - not only missing out the document name, but also redacting part of the DB name.

This patch changes the tagging to operate from the end of the string, as in nearly all circumstances the redactable path segments follow the non-redactable ones (a list is in the Jira ticket). As far as I'm aware the only exception is `/db/_user/{name}/_session/{sessionid}` (`name` is redactable but `sessionid` is not) - I'd expect the likelihood of a username being an exact substring of a session ID to be fairly limited. 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/323/
