### PR TITLE
CBG-2059: Add extra edge test case for HTTP log redaction

### DIFF
--- a/rest/handler_test.go
+++ b/rest/handler_test.go
@@ -119,6 +119,12 @@ func TestHTTPLoggingRedaction(t *testing.T) {
 			expectedLog: "/db/<ud>test</ud>/<ud>attach</ud>",
 		},
 		{
+			name:        "docid-attach-equalnames",
+			method:      http.MethodGet,
+			path:        "/db/test/test",
+			expectedLog: "/db/<ud>test</ud>/<ud>test</ud>",
+		},
+		{
 			name:        "user",
 			method:      http.MethodGet,
 			path:        "/db/_user/foo",


### PR DESCRIPTION
CBG-2059

Add a unit test to cover an edge case with HTTP log redaction.