### PR TITLE
CBD-4885, newer build scripts required.

### DIFF
--- a/manifest/3.0.xml
+++ b/manifest/3.0.xml
@@ -23,8 +23,8 @@ licenses/APL2.txt.
   <default remote="couchbase" revision="master"/>
 
   <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="a5d50edde6a7525bdff32f8ba3127a47ac2b291e">
+  <project name="product-texts" path="product-texts" remote="couchbase" revision="430cf239bcd11c240858e4bf0e5ec6cd3a81b4d7"/>
+  <project name="build" path="cbbuild" remote="couchbase">
     <annotation name="VERSION" value="3.0.3"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>


### PR DESCRIPTION
CBD-4885

Describe your PR here...
- Advance build repo SHA to pick up newer build scripts.  In old build scripts, we use miniconda to manage golang & python installations.  Miniconda imposed rate limit recently, which caused a lot of build failures.  We want to switch to miniforge going forward.  

## Pre-review checklist (remove once done)
N/A

## Dependencies (if applicable)
N/A

This has been tested and implemented on 3.1.0.  I have forked existing jobs and ensure 3.0.2-2 can be built properly with these sripts.
