### PR TITLE
CBG-2142: Correct build version strings

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -327,10 +327,6 @@ type couchbaseFeedImpl struct {
 	events chan sgbucket.FeedEvent
 }
 
-var (
-	versionString string
-)
-
 func (feed *couchbaseFeedImpl) Events() <-chan sgbucket.FeedEvent {
 	return feed.events
 }

--- a/base/version.go
+++ b/base/version.go
@@ -59,7 +59,7 @@ func init() {
 		// Split version number and build number (optional)
 		versionAndBuild := strings.Split(buildPlaceholderVersionBuildNumberString, "-")
 
-		versionString = versionAndBuild[0]
+		versionString := versionAndBuild[0]
 		versions := strings.Split(versionString, ".")
 		if len(versions) >= 0 {
 			majorStr = versions[0]

--- a/base/version.go
+++ b/base/version.go
@@ -59,7 +59,8 @@ func init() {
 		// Split version number and build number (optional)
 		versionAndBuild := strings.Split(buildPlaceholderVersionBuildNumberString, "-")
 
-		versions := strings.Split(versionAndBuild[0], ".")
+		versionString = versionAndBuild[0]
+		versions := strings.Split(versionString, ".")
 		if len(versions) >= 0 {
 			majorStr = versions[0]
 		} else if len(versions) >= 1 {
@@ -69,13 +70,13 @@ func init() {
 		} else if len(versions) >= 3 {
 			otherStr = versions[3]
 		} else {
-			PanicfCtx(context.Background(), "unknown version format (expected major.minor.patch[.other]) got %v", versions)
+			PanicfCtx(context.Background(), "unknown version format (expected major.minor.patch[.other]) got %v", versionString)
 		}
 
 		var formattedBuildStr string
 		if len(versionAndBuild) > 1 {
 			buildStr = versionAndBuild[1]
-			formattedBuildStr = ";" + buildStr
+			formattedBuildStr = buildStr + ";"
 		}
 
 		productName := buildPlaceholderServerName


### PR DESCRIPTION
CBG-2142

Fix incorrect formatting of version strings when pulling information from the build system introduced in #5495 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a

## Manual testing (with overridden `buildPlaceholder...` consts)

### Before

```
"version":"Couchbase Sync Gateway/(;1233504a98) CE"
```

### After

```
"version":"Couchbase Sync Gateway/3.1.0(123;3504a98) CE"
```