### PR TITLE
Use messages to print values for flaky test

### DIFF
--- a/db/query_test.go
+++ b/db/query_test.go
@@ -66,7 +66,7 @@ func TestQueryChannelsStatsView(t *testing.T) {
 	channelQueryErrorCountAfter := db.DbStats.Query(queryExpvar).QueryErrorCount.Value()
 
 	assert.Equal(t, channelQueryCountBefore+1, channelQueryCountAfter)
-	assert.True(t, channelQueryTimeAfter > channelQueryTimeBefore, "Channel query time stat didn't change")
+	assert.Greater(t, channelQueryTimeAfter, channelQueryTimeBefore, "Channel query time stat didn't change")
 	assert.Equal(t, channelQueryErrorCountBefore, channelQueryErrorCountAfter)
 
 }
@@ -113,7 +113,7 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 	channelQueryErrorCountAfter := db.DbStats.Query(QueryTypeChannels).QueryErrorCount.Value()
 
 	assert.Equal(t, channelQueryCountBefore+1, channelQueryCountAfter)
-	assert.True(t, channelQueryTimeAfter > channelQueryTimeBefore, "Channel query time stat didn't change")
+	assert.Greater(t, channelQueryTimeAfter, channelQueryTimeBefore, "Channel query time stat didn't change")
 	assert.Equal(t, channelQueryErrorCountBefore, channelQueryErrorCountAfter)
 
 }


### PR DESCRIPTION
I suspect these values are equal due to windows clock polling frequency, but it would be good to confirm before further investigation.