### PR TITLE
Skip TestLogFlush due to flakiness

### DIFF
--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -564,6 +564,9 @@ func TestUseTLSServer(t *testing.T) {
 }
 
 func TestLogFlush(t *testing.T) {
+	// FIXME: CBG-1869 flaky test
+	t.Skip("CBG-1869: Flaky test")
+
 	testCases := []struct {
 		Name                 string
 		ExpectedLogFileCount int


### PR DESCRIPTION
Skip `TestLogFlush` due to flakiness. By far the most flaky test we have, and from previous investigations, we know it's a test-only issue and flush functionally works.

![Screenshot 2022-06-21 at 12 13 41](https://user-images.githubusercontent.com/1525809/174786999-9d2caf54-5a4e-4382-b4c0-ab261de1e4a1.png)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/326/
