### PR TITLE
Run API specs through openapi-format

### DIFF
--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -20,154 +20,151 @@ servers:
         description: The hostname to use
         default: localhost
 paths:
-  # Admin only paths
-  /{db}/_session:
+  '/{db}/_session':
     $ref: './paths/admin/{db}~_session.yaml'
-  /{db}/_session/{sessionid}:
+  '/{db}/_session/{sessionid}':
     $ref: './paths/admin/{db}~_session~{sessionid}.yaml'
-  /{db}/_raw/{docid}:
+  '/{db}/_raw/{docid}':
     $ref: './paths/admin/{db}~_raw~{docid}.yaml'
-  /{db}/_revtree/{docid}:
+  '/{db}/_revtree/{docid}':
     $ref: './paths/admin/{db}~_revtree~{docid}.yaml'
-  /{db}/_user/:
+  '/{db}/_user/':
     $ref: './paths/admin/{db}~_user~.yaml'
-  /{db}/_user/{name}:
+  '/{db}/_user/{name}':
     $ref: './paths/admin/{db}~_user~{name}.yaml'
-  /{db}/_user/{name}/_session:
+  '/{db}/_user/{name}/_session':
     $ref: './paths/admin/{db}~_user~{name}~_session.yaml'
-  /{db}/_user/{name}/_session/{sessionid}:
+  '/{db}/_user/{name}/_session/{sessionid}':
     $ref: './paths/admin/{db}~_user~{name}~_session~{sessionid}.yaml'
-  /{db}/_role/:
+  '/{db}/_role/':
     $ref: './paths/admin/{db}~_role~.yaml'
-  /{db}/_role/{name}:
+  '/{db}/_role/{name}':
     $ref: './paths/admin/{db}~_role~{name}.yaml'
-  /{db}/_replication/:
+  '/{db}/_replication/':
     $ref: './paths/admin/{db}~_replication~.yaml'
-  /{db}/_replication/{replicationid}:
+  '/{db}/_replication/{replicationid}':
     $ref: './paths/admin/{db}~_replication~{replicationid}.yaml'
-  /{db}/_replicationStatus/:
+  '/{db}/_replicationStatus/':
     $ref: './paths/admin/{db}~_replicationStatus~.yaml'
-  /{db}/_replicationStatus/{replicationid}:
+  '/{db}/_replicationStatus/{replicationid}':
     $ref: './paths/admin/{db}~_replicationStatus~{replicationid}.yaml'
   /_logging:
-    $ref: './paths/admin/_logging.yaml'
-  /_profile/{profilename}:
+    $ref: ./paths/admin/_logging.yaml
+  '/_profile/{profilename}':
     $ref: './paths/admin/_profile~{profilename}.yaml'
   /_profile:
-    $ref: './paths/admin/_profile.yaml'
+    $ref: ./paths/admin/_profile.yaml
   /_heap:
-    $ref: './paths/admin/_heap.yaml'
+    $ref: ./paths/admin/_heap.yaml
   /_stats:
-    $ref: './paths/admin/_stats.yaml'
+    $ref: ./paths/admin/_stats.yaml
   /_config:
-    $ref: './paths/admin/_config.yaml'
+    $ref: ./paths/admin/_config.yaml
   /_status:
-    $ref: './paths/admin/_status.yaml'
+    $ref: ./paths/admin/_status.yaml
   /_sgcollect_info:
-    $ref: './paths/admin/_sgcollect_info.yaml'
+    $ref: ./paths/admin/_sgcollect_info.yaml
   /_debug/pprof/goroutine:
-    $ref: './paths/admin/_debug~pprof~goroutine.yaml'
+    $ref: ./paths/admin/_debug~pprof~goroutine.yaml
   /_debug/pprof/cmdline:
-    $ref: './paths/admin/_debug~pprof~cmdline.yaml'
+    $ref: ./paths/admin/_debug~pprof~cmdline.yaml
   /_debug/pprof/symbol:
-    $ref: './paths/admin/_debug~pprof~symbol.yaml'
+    $ref: ./paths/admin/_debug~pprof~symbol.yaml
   /_debug/pprof/heap:
-    $ref: './paths/admin/_debug~pprof~heap.yaml'
+    $ref: ./paths/admin/_debug~pprof~heap.yaml
   /_debug/pprof/profile:
-    $ref: './paths/admin/_debug~pprof~profile.yaml'
+    $ref: ./paths/admin/_debug~pprof~profile.yaml
   /_debug/pprof/block:
-    $ref: './paths/admin/_debug~pprof~block.yaml'
+    $ref: ./paths/admin/_debug~pprof~block.yaml
   /_debug/pprof/threadcreate:
-    $ref: './paths/admin/_debug~pprof~threadcreate.yaml'
+    $ref: ./paths/admin/_debug~pprof~threadcreate.yaml
   /_debug/pprof/mutex:
-    $ref: './paths/admin/_debug~pprof~mutex.yaml'
+    $ref: ./paths/admin/_debug~pprof~mutex.yaml
   /_debug/pprof/trace:
-    $ref: './paths/admin/_debug~pprof~trace.yaml'
+    $ref: ./paths/admin/_debug~pprof~trace.yaml
   /_debug/fgprof:
-    $ref: './paths/admin/_debug~fgprof.yaml'
+    $ref: ./paths/admin/_debug~fgprof.yaml
   /_post_upgrade:
-    $ref: './paths/admin/_post_upgrade.yaml'
-  /{db}/_config:
+    $ref: ./paths/admin/_post_upgrade.yaml
+  '/{db}/_config':
     $ref: './paths/admin/{db}~_config.yaml'
-  /{db}/_config/sync:
+  '/{db}/_config/sync':
     $ref: './paths/admin/{db}~_config~sync.yaml'
-  /{db}/_config/import_filter:
+  '/{db}/_config/import_filter':
     $ref: './paths/admin/{db}~_config~import_filter.yaml'
-  /{db}/_resync:
+  '/{db}/_resync':
     $ref: './paths/admin/{db}~_resync.yaml'
-  /{db}/_purge:
+  '/{db}/_purge':
     $ref: './paths/admin/{db}~_purge.yaml'
-  /{db}/_flush:
+  '/{db}/_flush':
     $ref: './paths/admin/{db}~_flush.yaml'
-  /{db}/_online:
+  '/{db}/_online':
     $ref: './paths/admin/{db}~_online.yaml'
-  /{db}/_offline:
+  '/{db}/_offline':
     $ref: './paths/admin/{db}~_offline.yaml'
-  /{db}/_dump/{view}:
+  '/{db}/_dump/{view}':
     $ref: './paths/admin/{db}~_dump~{view}.yaml'
-  /{db}/_view/{view}:
+  '/{db}/_view/{view}':
     $ref: './paths/admin/{db}~_view~{view}.yaml'
-  /{db}/_dumpchannel/{channel}:
+  '/{db}/_dumpchannel/{channel}':
     $ref: './paths/admin/{db}~_dumpchannel~{channel}.yaml'
-  /{db}/_repair:
+  '/{db}/_repair':
     $ref: './paths/admin/{db}~_repair.yaml'
   /_all_dbs:
-    $ref: './paths/admin/_all_dbs.yaml'
-  /{db}/_compact:
+    $ref: ./paths/admin/_all_dbs.yaml
+  '/{db}/_compact':
     $ref: './paths/admin/{db}~_compact.yaml'
-  /{db}/:
+  '/{db}/':
     $ref: './paths/admin/{db}~.yaml'
-  # Metric and admin paths
   /_expvar:
-    $ref: './paths/admin/_expvar.yaml'
-  # Common paths
+    $ref: ./paths/admin/_expvar.yaml
   /:
-    $ref: './paths/admin/~.yaml'
-  /{db}/_all_docs:
+    $ref: ./paths/admin/~.yaml
+  '/{db}/_all_docs':
     $ref: './paths/admin/{db}~_all_docs.yaml'
-  /{db}/_bulk_docs:
+  '/{db}/_bulk_docs':
     $ref: './paths/admin/{db}~_bulk_docs.yaml'
-  /{db}/_bulk_get:
+  '/{db}/_bulk_get':
     $ref: './paths/admin/{db}~_bulk_get.yaml'
-  /{db}/_changes:
+  '/{db}/_changes':
     $ref: './paths/admin/{db}~_changes.yaml'
-  /{db}/_design/{ddoc}:
+  '/{db}/_design/{ddoc}':
     $ref: './paths/admin/{db}~_design~{ddoc}.yaml'
-  /{db}/_design/{ddoc}/_view/{view}:
+  '/{db}/_design/{ddoc}/_view/{view}':
     $ref: './paths/admin/{db}~_design~{ddoc}~_view~{view}.yaml'
-  /{db}/_ensure_full_commit:
+  '/{db}/_ensure_full_commit':
     $ref: './paths/admin/{db}~_ensure_full_commit.yaml'
-  /{db}/_revs_diff:
+  '/{db}/_revs_diff':
     $ref: './paths/admin/{db}~_revs_diff.yaml'
-  /{db}/_local/{docid}:
+  '/{db}/_local/{docid}':
     $ref: './paths/admin/{db}~_local~{docid}.yaml'
-  /{db}/{docid}:
+  '/{db}/{docid}':
     $ref: './paths/admin/{db}~{docid}.yaml'
-  /{db}/{docid}/{attach}:
+  '/{db}/{docid}/{attach}':
     $ref: './paths/admin/{db}~{docid}~{attach}.yaml'
-  /{db}/_facebook:
+  '/{db}/_facebook':
     $ref: './paths/admin/{db}~_facebook.yaml'
-  /{db}/_google:
+  '/{db}/_google':
     $ref: './paths/admin/{db}~_google.yaml'
-  /{db}/_oidc:
+  '/{db}/_oidc':
     $ref: './paths/admin/{db}~_oidc.yaml'
-  /{db}/_oidc_challenge:
+  '/{db}/_oidc_challenge':
     $ref: './paths/admin/{db}~_oidc_challenge.yaml'
-  /{db}/_oidc_callback:
+  '/{db}/_oidc_callback':
     $ref: './paths/admin/{db}~_oidc_callback.yaml'
-  /{db}/_oidc_refresh:
+  '/{db}/_oidc_refresh':
     $ref: './paths/admin/{db}~_oidc_refresh.yaml'
-  /{db}/_oidc_testing/.well-known/openid-configuration:
+  '/{db}/_oidc_testing/.well-known/openid-configuration':
     $ref: './paths/admin/{db}~_oidc_testing~.well-known~openid-configuration.yaml'
-  /{db}/_oidc_testing/authorize:
+  '/{db}/_oidc_testing/authorize':
     $ref: './paths/admin/{db}~_oidc_testing~authorize.yaml'
-  /{db}/_oidc_testing/token:
+  '/{db}/_oidc_testing/token':
     $ref: './paths/admin/{db}~_oidc_testing~token.yaml'
-  /{db}/_oidc_testing/certs:
+  '/{db}/_oidc_testing/certs':
     $ref: './paths/admin/{db}~_oidc_testing~certs.yaml'
-  /{db}/_oidc_testing/authenticate:
+  '/{db}/_oidc_testing/authenticate':
     $ref: './paths/admin/{db}~_oidc_testing~authenticate.yaml'
-  /{db}/_blipsync:
+  '/{db}/_blipsync':
     $ref: './paths/admin/{db}~_blipsync.yaml'
 tags:
   - name: Admin only endpoints

--- a/docs/api/components/parameters.yaml
+++ b/docs/api/components/parameters.yaml
@@ -455,7 +455,7 @@ disable_oidc_validation:
   name: disable_oidc_validation
   in: query
   required: false
-  description: If set, will not attempt to validate the configured OpenID Connect providers are reachable.
+  description: 'If set, will not attempt to validate the configured OpenID Connect providers are reachable.'
   schema:
     type: boolean
     default: false
@@ -466,7 +466,7 @@ usersNameOnly:
   schema:
     type: boolean
     default: true
-  description: Whether to return user names only, or more detailed information for each user.
+  description: 'Whether to return user names only, or more detailed information for each user.'
 usersLimit:
   name: limit
   in: query
@@ -474,4 +474,3 @@ usersLimit:
   schema:
     type: integer
   description: How many results to return. Using a value of `0` results in no limit.
-

--- a/docs/api/components/requestBodies.yaml
+++ b/docs/api/components/requestBodies.yaml
@@ -2,31 +2,31 @@ User:
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/User'
+        $ref: ./schemas.yaml#/User
   description: Properties associated with a user
 Role:
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/Role'
+        $ref: ./schemas.yaml#/Role
   description: Properties associated with a role
 OIDC-login-page-handler:
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/OIDC-login-page-handler'
+        $ref: ./schemas.yaml#/OIDC-login-page-handler
   description: Properties passed from the OpenID Connect mock login page to the handler
 Doc-body:
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/Document'
+        $ref: ./schemas.yaml#/Document
   description: Properties of a document
 Replication-upsert:
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/Replication'
+        $ref: ./schemas.yaml#/Replication
   description: If the `replication_id` matches an existing replication then the existing configuration will be updated. Only the specified fields in the request will be used to update the existing configuration. Unspecified fields will remain untouched.
 Profile:
   content:

--- a/docs/api/components/responses.yaml
+++ b/docs/api/components/responses.yaml
@@ -3,7 +3,7 @@ Not-found:
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/HTTP-Error'
+        $ref: ./schemas.yaml#/HTTP-Error
       example:
         error: not_found
         reason: no such database "invalid-db"
@@ -12,37 +12,37 @@ Conflict:
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/HTTP-Error'
+        $ref: ./schemas.yaml#/HTTP-Error
 User:
   description: Properties associated with a user
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/User'
+        $ref: ./schemas.yaml#/User
 Role:
   description: Properties associated with a role
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/Role'
+        $ref: ./schemas.yaml#/Role
 Invalid-CORS:
   description: Origin is not in the approved list of allowed origins
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/HTTP-Error'
+        $ref: ./schemas.yaml#/HTTP-Error
 User-session-information:
   description: Properties associated with a user session
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/User-session-information'
+        $ref: ./schemas.yaml#/User-session-information
 OIDC-callback:
   description: Successfully authenticated with OpenID Connect.
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/OIDC-callback'
+        $ref: ./schemas.yaml#/OIDC-callback
 OIDC-invalid-provider:
   description: 'The provider provided is not defined in the Sync Gateway config. If no provided was specified then there is no default provider set. '
 OIDC-connection:
@@ -54,19 +54,19 @@ OIDC-invalid-scope:
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/HTTP-Error'
+        $ref: ./schemas.yaml#/HTTP-Error
 OIDC-testing-internal-error:
   description: An error occurred.
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/HTTP-Error'
+        $ref: ./schemas.yaml#/HTTP-Error
 OIDC-token:
   description: Properties expected back from an OpenID Connect provider after successful authentication
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/OIDC-token'
+        $ref: ./schemas.yaml#/OIDC-token
 OIDC-testing-redirect:
   description: Redirecting to Sync Gateway OpenID Connect callback URL
   headers:
@@ -82,25 +82,25 @@ invalid-doc-id:
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/HTTP-Error'
+        $ref: ./schemas.yaml#/HTTP-Error
 New-revision:
   description: New revision created successfully
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/New-revision'
+        $ref: ./schemas.yaml#/New-revision
 request-problem:
   description: There was a problem with your request
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/HTTP-Error'
+        $ref: ./schemas.yaml#/HTTP-Error
 Invalid-content-type:
   description: Invalid content type
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/HTTP-Error'
+        $ref: ./schemas.yaml#/HTTP-Error
 pprof-binary:
   description: OK
   content:
@@ -144,7 +144,7 @@ changes-feed:
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/Changes-feed'
+        $ref: ./schemas.yaml#/Changes-feed
 ddoc-forbidden:
   description: Forbidden access possibly due to not using the Admin API or the design document is a built-in Sync Gateway one.
 Replicator-created:
@@ -168,7 +168,7 @@ DB-config-precondition-failed:
   content:
     application/json:
       schema:
-        $ref: './schemas.yaml#/HTTP-Error'
+        $ref: ./schemas.yaml#/HTTP-Error
       example:
         error: Precondition Failed
         reason: Provided If-Match header does not match current config version

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -248,27 +248,23 @@ User:
         type: string
       readOnly: true
     oidc_roles:
-      description: |-
-        The roles that the user has been added to through OpenID Connect.
+      description: The roles that the user has been added to through OpenID Connect.
       type: array
       items:
         type: string
       readOnly: true
     oidc_channels:
-      description: |-
-        The channels that the user has been granted access to through OpenID Connect.
+      description: The channels that the user has been granted access to through OpenID Connect.
       type: array
       items:
         type: string
       readOnly: true
     oidc_issuer:
-      description: |-
-        The OpenID Connect issuer that the user last used to sign in.
+      description: The OpenID Connect issuer that the user last used to sign in.
       type: string
       readOnly: true
     oidc_last_updated:
-      description: |-
-        The last time that the user's OIDC roles/channels were updated.
+      description: The last time that the user's OIDC roles/channels were updated.
       type: string
       format: date-time
       readOnly: true
@@ -1340,7 +1336,7 @@ Database:
                 roles_claim:
                   description: |-
                     If set, the value(s) of the given OpenID Connect authentication token claim will be added to the user's roles.
-                    
+
                     The value of this claim must be either a string or an array of strings, any other type will result in an error.
                   type: string
                 channels_claim:

--- a/docs/api/metric.yaml
+++ b/docs/api/metric.yaml
@@ -20,12 +20,10 @@ servers:
         description: The hostname to use
         default: localhost
 paths:
-  # Metric only
   /_metrics:
-    $ref: './paths/metric/_metrics.yaml'
-  # Metric and admin
+    $ref: ./paths/metric/_metrics.yaml
   /_expvar:
-    $ref: './paths/metric/_expvar.yaml'
+    $ref: ./paths/metric/_expvar.yaml
 tags:
   - name: Prometheus
     description: Endpoints for use with Prometheus

--- a/docs/api/paths/admin/_all_dbs.yaml
+++ b/docs/api/paths/admin/_all_dbs.yaml
@@ -1,4 +1,3 @@
-# /_all_dbs
 get:
   summary: Get a list of all the databases
   description: |-
@@ -7,7 +6,7 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   responses:
-    "200":
+    '200':
       description: Successfully retrieved all database names
       content:
         application/json:
@@ -16,15 +15,15 @@ get:
             items:
               type: string
   tags:
-  - Admin only endpoints
-  - Database Management
+    - Admin only endpoints
+    - Database Management
 head:
   description: |-
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   responses:
-    "200":
+    '200':
       description: OK
   tags:
-  - Admin only endpoints
-  - Database Management
+    - Admin only endpoints
+    - Database Management

--- a/docs/api/paths/admin/_config.yaml
+++ b/docs/api/paths/admin/_config.yaml
@@ -1,4 +1,3 @@
-# /_config
 get:
   summary: Get server configuration
   description: |-
@@ -7,26 +6,25 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   parameters:
-  - $ref: ../../components/parameters.yaml#/deprecated-redact
-  - name: include_runtime
-    in: query
-    description: Whether to include the values set at runtime, default values, and
-      all loaded databases.
-    schema:
-      type: boolean
-      default: false
+    - $ref: ../../components/parameters.yaml#/deprecated-redact
+    - name: include_runtime
+      in: query
+      description: 'Whether to include the values set at runtime, default values, and all loaded databases.'
+      schema:
+        type: boolean
+        default: false
   responses:
-    "200":
+    '200':
       description: Successfully returned server configuration
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/Startup-config
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
   tags:
-  - Admin only endpoints
-  - Server
+    - Admin only endpoints
+    - Server
 put:
   summary: Set runtime configuration
   description: |-
@@ -44,10 +42,10 @@ put:
         schema:
           $ref: ../../components/schemas.yaml#/Startup-config
   responses:
-    "200":
+    '200':
       description: Successfully set runtime options
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
   tags:
-  - Admin only endpoints
-  - Server
+    - Admin only endpoints
+    - Server

--- a/docs/api/paths/admin/_debug~fgprof.yaml
+++ b/docs/api/paths/admin/_debug~fgprof.yaml
@@ -1,4 +1,3 @@
-# /_debug/fgprof
 get:
   summary: Get fgprof profile
   description: |-
@@ -7,17 +6,17 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   parameters:
-  - $ref: ../../components/parameters.yaml#/debug-profile-seconds
+    - $ref: ../../components/parameters.yaml#/debug-profile-seconds
   responses:
-    "200":
+    '200':
       description: OK
       content:
         application/x-gzip:
           schema:
             type: string
   tags:
-  - Admin only endpoints
-  - Profiling
+    - Admin only endpoints
+    - Profiling
 post:
   summary: Get fgprof profile
   description: |-
@@ -26,14 +25,14 @@ post:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   parameters:
-  - $ref: ../../components/parameters.yaml#/debug-profile-seconds
+    - $ref: ../../components/parameters.yaml#/debug-profile-seconds
   responses:
-    "200":
+    '200':
       description: OK
       content:
         application/x-gzip:
           schema:
             type: string
   tags:
-  - Admin only endpoints
-  - Profiling
+    - Admin only endpoints
+    - Profiling

--- a/docs/api/paths/admin/_debug~pprof~block.yaml
+++ b/docs/api/paths/admin/_debug~pprof~block.yaml
@@ -1,4 +1,3 @@
-# /_debug/pprof/block
 get:
   summary: Get block profile
   description: |-
@@ -7,11 +6,11 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   parameters:
-  - $ref: ../../components/parameters.yaml#/debug-profile-seconds
+    - $ref: ../../components/parameters.yaml#/debug-profile-seconds
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/pprof-binary
-    "403":
+    '403':
       description: Forbidden
       content:
         application/json:
@@ -21,8 +20,8 @@ get:
             error: forbidden
             reason: Can only run one mutex profile at a time
   tags:
-  - Admin only endpoints
-  - Profiling
+    - Admin only endpoints
+    - Profiling
 post:
   summary: Get block profile
   description: |-
@@ -31,11 +30,11 @@ post:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   parameters:
-  - $ref: ../../components/parameters.yaml#/debug-profile-seconds
+    - $ref: ../../components/parameters.yaml#/debug-profile-seconds
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/pprof-binary
-    "403":
+    '403':
       description: Forbidden
       content:
         application/json:
@@ -45,5 +44,5 @@ post:
             error: forbidden
             reason: Can only run one mutex profile at a time
   tags:
-  - Admin only endpoints
-  - Profiling
+    - Admin only endpoints
+    - Profiling

--- a/docs/api/paths/admin/_debug~pprof~cmdline.yaml
+++ b/docs/api/paths/admin/_debug~pprof~cmdline.yaml
@@ -6,15 +6,15 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   responses:
-    "200":
+    '200':
       description: OK
       content:
         text/plain:
           schema:
             type: string
   tags:
-  - Admin only endpoints
-  - Profiling
+    - Admin only endpoints
+    - Profiling
 post:
   summary: Get passed in command line parameters
   description: |-
@@ -23,12 +23,12 @@ post:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   responses:
-    "200":
+    '200':
       description: OK
       content:
         text/plain:
           schema:
             type: string
   tags:
-  - Admin only endpoints
-  - Profiling
+    - Admin only endpoints
+    - Profiling

--- a/docs/api/paths/admin/_debug~pprof~goroutine.yaml
+++ b/docs/api/paths/admin/_debug~pprof~goroutine.yaml
@@ -1,4 +1,3 @@
-# /_debug/pprof/goroutine
 get:
   summary: Get goroutine profile
   description: |-
@@ -7,13 +6,13 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   parameters:
-  - $ref: ../../components/parameters.yaml#/pprof-seconds
+    - $ref: ../../components/parameters.yaml#/pprof-seconds
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/pprof-binary
   tags:
-  - Admin only endpoints
-  - Profiling
+    - Admin only endpoints
+    - Profiling
 post:
   summary: Get goroutine profile
   description: |-
@@ -22,10 +21,10 @@ post:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   parameters:
-  - $ref: ../../components/parameters.yaml#/pprof-seconds
+    - $ref: ../../components/parameters.yaml#/pprof-seconds
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/pprof-binary
   tags:
-  - Admin only endpoints
-  - Profiling
+    - Admin only endpoints
+    - Profiling

--- a/docs/api/paths/admin/_debug~pprof~heap.yaml
+++ b/docs/api/paths/admin/_debug~pprof~heap.yaml
@@ -1,27 +1,26 @@
-# /_debug/pprof/heap
 get:
   summary: Get the heap pprof debug file
-  parameters:
-  - $ref: ../../components/parameters.yaml#/pprof-seconds
-  responses:
-    "200":
-      $ref: ../../components/responses.yaml#/pprof-binary
-  tags:
-  - Admin only endpoints
-  - Profiling
   description: |-
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
+  parameters:
+    - $ref: ../../components/parameters.yaml#/pprof-seconds
+  responses:
+    '200':
+      $ref: ../../components/responses.yaml#/pprof-binary
+  tags:
+    - Admin only endpoints
+    - Profiling
 post:
   summary: Get the heap pprof debug file
-  parameters:
-  - $ref: ../../components/parameters.yaml#/pprof-seconds
-  responses:
-    "200":
-      $ref: ../../components/responses.yaml#/pprof-binary
-  tags:
-  - Admin only endpoints
-  - Profiling
   description: |-
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
+  parameters:
+    - $ref: ../../components/parameters.yaml#/pprof-seconds
+  responses:
+    '200':
+      $ref: ../../components/responses.yaml#/pprof-binary
+  tags:
+    - Admin only endpoints
+    - Profiling

--- a/docs/api/paths/admin/_debug~pprof~mutex.yaml
+++ b/docs/api/paths/admin/_debug~pprof~mutex.yaml
@@ -1,4 +1,3 @@
-# /_debug/pprof/mutex
 get:
   summary: Get mutex profile
   description: |-
@@ -7,11 +6,11 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   parameters:
-  - $ref: ../../components/parameters.yaml#/debug-profile-seconds
+    - $ref: ../../components/parameters.yaml#/debug-profile-seconds
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/pprof-binary
-    "403":
+    '403':
       description: Forbidden
       content:
         application/json:
@@ -21,8 +20,8 @@ get:
             error: forbidden
             reason: Can only run one mutex profile at a time
   tags:
-  - Admin only endpoints
-  - Profiling
+    - Admin only endpoints
+    - Profiling
 post:
   summary: Get mutex profile
   description: |-
@@ -31,11 +30,11 @@ post:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   parameters:
-  - $ref: ../../components/parameters.yaml#/debug-profile-seconds
+    - $ref: ../../components/parameters.yaml#/debug-profile-seconds
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/pprof-binary
-    "403":
+    '403':
       description: Forbidden
       content:
         application/json:
@@ -45,5 +44,5 @@ post:
             error: forbidden
             reason: Can only run one mutex profile at a time
   tags:
-  - Admin only endpoints
-  - Profiling
+    - Admin only endpoints
+    - Profiling

--- a/docs/api/paths/admin/_debug~pprof~profile.yaml
+++ b/docs/api/paths/admin/_debug~pprof~profile.yaml
@@ -1,27 +1,26 @@
-# /debug/pprof/profile
 get:
   summary: Get the profile pprof debug file
-  parameters:
-  - $ref: ../../components/parameters.yaml#/pprof-seconds
-  responses:
-    "200":
-      $ref: ../../components/responses.yaml#/pprof-binary
-  tags:
-  - Admin only endpoints
-  - Profiling
   description: |-
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
+  parameters:
+    - $ref: ../../components/parameters.yaml#/pprof-seconds
+  responses:
+    '200':
+      $ref: ../../components/responses.yaml#/pprof-binary
+  tags:
+    - Admin only endpoints
+    - Profiling
 post:
   summary: Get the profile pprof debug file
-  parameters:
-  - $ref: ../../components/parameters.yaml#/pprof-seconds
-  responses:
-    "200":
-      $ref: ../../components/responses.yaml#/pprof-binary
-  tags:
-  - Admin only endpoints
-  - Profiling
   description: |-
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
+  parameters:
+    - $ref: ../../components/parameters.yaml#/pprof-seconds
+  responses:
+    '200':
+      $ref: ../../components/responses.yaml#/pprof-binary
+  tags:
+    - Admin only endpoints
+    - Profiling

--- a/docs/api/paths/admin/_debug~pprof~symbol.yaml
+++ b/docs/api/paths/admin/_debug~pprof~symbol.yaml
@@ -1,31 +1,30 @@
-# /_debug/pprof/symbol
 get:
   summary: Get symbol pprof debug information
+  description: |-
+    Required Sync Gateway RBAC roles:
+    * Sync Gateway Dev Ops
   responses:
-    "200":
+    '200':
       description: OK
       content:
         text/plain:
           schema:
             type: string
   tags:
-  - Admin only endpoints
-  - Profiling
-  description: |-
-    Required Sync Gateway RBAC roles:
-    * Sync Gateway Dev Ops
+    - Admin only endpoints
+    - Profiling
 post:
   summary: Get symbol pprof debug information
+  description: |-
+    Required Sync Gateway RBAC roles:
+    * Sync Gateway Dev Ops
   responses:
-    "200":
+    '200':
       description: OK
       content:
         text/plain:
           schema:
             type: string
   tags:
-  - Admin only endpoints
-  - Profiling
-  description: |-
-    Required Sync Gateway RBAC roles:
-    * Sync Gateway Dev Ops
+    - Admin only endpoints
+    - Profiling

--- a/docs/api/paths/admin/_debug~pprof~threadcreate.yaml
+++ b/docs/api/paths/admin/_debug~pprof~threadcreate.yaml
@@ -1,23 +1,22 @@
-# /_debug/pprof/threadcreate
 get:
   summary: Get the threadcreate pprof debug file
-  responses:
-    "200":
-      $ref: ../../components/responses.yaml#/pprof-binary
-  tags:
-  - Admin only endpoints
-  - Profiling
   description: |-
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
+  responses:
+    '200':
+      $ref: ../../components/responses.yaml#/pprof-binary
+  tags:
+    - Admin only endpoints
+    - Profiling
 post:
   summary: Get the threadcreate pprof debug file
-  responses:
-    "200":
-      $ref: ../../components/responses.yaml#/pprof-binary
-  tags:
-  - Admin only endpoints
-  - Profiling
   description: |-
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
+  responses:
+    '200':
+      $ref: ../../components/responses.yaml#/pprof-binary
+  tags:
+    - Admin only endpoints
+    - Profiling

--- a/docs/api/paths/admin/_debug~pprof~trace.yaml
+++ b/docs/api/paths/admin/_debug~pprof~trace.yaml
@@ -1,4 +1,3 @@
-# /_debug/pprof/trace
 get:
   summary: Get trace profile
   description: |-
@@ -7,17 +6,17 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   parameters:
-  - name: seconds
-    in: query
-    schema:
-      type: integer
-      default: 1
+    - name: seconds
+      in: query
+      schema:
+        type: integer
+        default: 1
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/pprof-binary
   tags:
-  - Admin only endpoints
-  - Profiling
+    - Admin only endpoints
+    - Profiling
 post:
   summary: Get trace profile
   description: |-
@@ -26,14 +25,14 @@ post:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   parameters:
-  - name: seconds
-    in: query
-    schema:
-      type: integer
-      default: 1
+    - name: seconds
+      in: query
+      schema:
+        type: integer
+        default: 1
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/pprof-binary
   tags:
-  - Admin only endpoints
-  - Profiling
+    - Admin only endpoints
+    - Profiling

--- a/docs/api/paths/admin/_expvar.yaml
+++ b/docs/api/paths/admin/_expvar.yaml
@@ -10,11 +10,11 @@ get:
     * Sync Gateway Dev Ops
     * External Stats Reader
   responses:
-    "200":
+    '200':
       description: Returned statistics
       content:
         application/javascript:
           schema:
             $ref: ../../components/schemas.yaml#/ExpVars
   tags:
-  - Metrics
+    - Metrics

--- a/docs/api/paths/admin/_heap.yaml
+++ b/docs/api/paths/admin/_heap.yaml
@@ -1,4 +1,3 @@
-# /_heap
 post:
   summary: Dump heap profile
   description: |-
@@ -9,10 +8,10 @@ post:
   requestBody:
     $ref: ../../components/requestBodies.yaml#/Profile
   responses:
-    "200":
+    '200':
       description: Successfully dumped heap profile
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
   tags:
-  - Admin only endpoints
-  - Profiling
+    - Admin only endpoints
+    - Profiling

--- a/docs/api/paths/admin/_logging.yaml
+++ b/docs/api/paths/admin/_logging.yaml
@@ -1,4 +1,3 @@
-# /_logging
 get:
   summary: Get console logging settings
   description: |-
@@ -8,7 +7,7 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   responses:
-    "200":
+    '200':
       description: Returned map of console log keys
       content:
         application/json:
@@ -16,8 +15,8 @@ get:
             $ref: ../../components/schemas.yaml#/DeprecatedLogKeyMap
   deprecated: true
   tags:
-  - Admin only endpoints
-  - Server
+    - Admin only endpoints
+    - Server
 put:
   summary: Set console logging settings
   description: |-
@@ -27,8 +26,8 @@ put:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   parameters:
-  - $ref: ../../components/parameters.yaml#/log-level
-  - $ref: ../../components/parameters.yaml#/log-level-int
+    - $ref: ../../components/parameters.yaml#/log-level
+    - $ref: ../../components/parameters.yaml#/log-level-int
   requestBody:
     description: The map of log keys to use for console logging.
     content:
@@ -36,14 +35,14 @@ put:
         schema:
           $ref: ../../components/schemas.yaml#/DeprecatedLogKeyMap
   responses:
-    "200":
+    '200':
       description: Log keys successfully replaced.
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
   deprecated: true
   tags:
-  - Admin only endpoints
-  - Server
+    - Admin only endpoints
+    - Server
 post:
   summary: Update console logging settings
   description: |-
@@ -53,8 +52,8 @@ post:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   parameters:
-  - $ref: ../../components/parameters.yaml#/log-level
-  - $ref: ../../components/parameters.yaml#/log-level-int
+    - $ref: ../../components/parameters.yaml#/log-level
+    - $ref: ../../components/parameters.yaml#/log-level-int
   requestBody:
     description: The console log keys to upsert.
     content:
@@ -62,11 +61,11 @@ post:
         schema:
           $ref: ../../components/schemas.yaml#/DeprecatedLogKeyMap
   responses:
-    "200":
+    '200':
       description: Log keys successfully updated.
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
   deprecated: true
   tags:
-  - Admin only endpoints
-  - Server
+    - Admin only endpoints
+    - Server

--- a/docs/api/paths/admin/_post_upgrade.yaml
+++ b/docs/api/paths/admin/_post_upgrade.yaml
@@ -1,4 +1,3 @@
-# /_post_upgrade
 post:
   summary: Run the post upgrade process on all databases
   description: |-
@@ -7,14 +6,14 @@ post:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   parameters:
-  - name: preview
-    in: query
-    description: If set, a dry-run will be done to return what would be removed.
-    schema:
-      type: string
-      default: "false"
+    - name: preview
+      in: query
+      description: 'If set, a dry-run will be done to return what would be removed.'
+      schema:
+        type: string
+        default: 'false'
   responses:
-    "200":
+    '200':
       description: Returned results
       content:
         application/json:
@@ -40,15 +39,13 @@ post:
                         items:
                           type: string
                     required:
-                    - removed_design_docs
-                    - removed_indexes
+                      - removed_design_docs
+                      - removed_indexes
               preview:
-                description: If set, nothing in the database was changed as this was
-                  a dry-run. This can be controlled by the `preview` query parameter
-                  in the request.
+                description: 'If set, nothing in the database was changed as this was a dry-run. This can be controlled by the `preview` query parameter in the request.'
                 type: boolean
             required:
-            - post_upgrade_results
+              - post_upgrade_results
   tags:
-  - Admin only endpoints
-  - Server
+    - Admin only endpoints
+    - Server

--- a/docs/api/paths/admin/_profile.yaml
+++ b/docs/api/paths/admin/_profile.yaml
@@ -1,4 +1,3 @@
-# /_profile
 post:
   summary: Start or Stop continuous CPU profiling
   description: |-
@@ -13,10 +12,10 @@ post:
   requestBody:
     $ref: ../../components/requestBodies.yaml#/Profile
   responses:
-    "200":
+    '200':
       description: Successfully started or stopped CPU profiling
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
   tags:
-  - Admin only endpoints
-  - Profiling
+    - Admin only endpoints
+    - Profiling

--- a/docs/api/paths/admin/_profile~{profilename}.yaml
+++ b/docs/api/paths/admin/_profile~{profilename}.yaml
@@ -1,17 +1,16 @@
-# /_profile/{profilename}
 parameters:
-- name: profilename
-  in: path
-  description: The handler to use for profiling.
-  required: true
-  schema:
-    type: string
-    enum:
-    - heap
-    - block
-    - threadcreate
-    - mutex
-    - goroutine
+  - name: profilename
+    in: path
+    description: The handler to use for profiling.
+    required: true
+    schema:
+      type: string
+      enum:
+        - heap
+        - block
+        - threadcreate
+        - mutex
+        - goroutine
 post:
   summary: Create point-in-time profile
   description: |-
@@ -22,12 +21,12 @@ post:
   requestBody:
     $ref: ../../components/requestBodies.yaml#/Profile
   responses:
-    "200":
+    '200':
       description: Successfully created profile
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Profiling
+    - Admin only endpoints
+    - Profiling

--- a/docs/api/paths/admin/_sgcollect_info.yaml
+++ b/docs/api/paths/admin/_sgcollect_info.yaml
@@ -1,4 +1,3 @@
-# /_sgcollect_info
 get:
   summary: Get the status of the Sync Gateway Collect Info
   description: |-
@@ -7,7 +6,7 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   responses:
-    "200":
+    '200':
       description: Returned sgcollect_info status
       content:
         application/json:
@@ -18,13 +17,13 @@ get:
                 description: The status of sgcollect_info.
                 type: string
                 enum:
-                - stopped
-                - running
+                  - stopped
+                  - running
             required:
-            - status
+              - status
   tags:
-  - Admin only endpoints
-  - Server
+    - Admin only endpoints
+    - Server
 post:
   summary: Start Sync Gateway Collect Info
   description: |-
@@ -40,13 +39,12 @@ post:
           type: object
           properties:
             redact_level:
-              description: The redaction level to use for redacting the collected
-                logs.
+              description: The redaction level to use for redacting the collected logs.
               type: string
               default: partial
               enum:
-              - partial
-              - none
+                - partial
+                - none
             redact_salt:
               description: The salt to use for the log redactions.
               type: string
@@ -66,7 +64,7 @@ post:
             upload_host:
               description: The host to send the logs too.
               type: string
-              default: https://uploads.couchbase.com
+              default: 'https://uploads.couchbase.com'
             upload_proxy:
               description: The proxy to use while uploading the logs.
               type: string
@@ -79,7 +77,7 @@ post:
               maxLength: 7
               minLength: 1
   responses:
-    "200":
+    '200':
       description: Successfully started sgcollect_info
       content:
         application/json:
@@ -90,17 +88,17 @@ post:
                 description: The new sgcollect_info status.
                 type: string
                 default: started
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "500":
+    '500':
       description: An error occurred while trying to run sgcollect_info
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
-  - Admin only endpoints
-  - Server
+    - Admin only endpoints
+    - Server
 delete:
   summary: Cancel the Sync Gateway Collect Info job
   description: |-
@@ -109,7 +107,7 @@ delete:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   responses:
-    "200":
+    '200':
       description: Job cancelled successfully
       content:
         application/json:
@@ -120,8 +118,8 @@ delete:
                 description: The new status of sgcollect_info.
                 type: string
                 default: cancelled
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
   tags:
-  - Admin only endpoints
-  - Server
+    - Admin only endpoints
+    - Server

--- a/docs/api/paths/admin/_stats.yaml
+++ b/docs/api/paths/admin/_stats.yaml
@@ -1,4 +1,3 @@
-# /_stats
 get:
   summary: Get memory statistics
   description: |-
@@ -9,7 +8,7 @@ get:
     * Sync Gateway Dev Ops
     * External Stats Reader
   responses:
-    "200":
+    '200':
       description: Returned memory usage statistics
       content:
         application/json:
@@ -20,5 +19,5 @@ get:
                 description: A set of Go runtime memory statistics.
                 additionalProperties: true
   tags:
-  - Admin only endpoints
-  - Metrics
+    - Admin only endpoints
+    - Metrics

--- a/docs/api/paths/admin/_status.yaml
+++ b/docs/api/paths/admin/_status.yaml
@@ -1,4 +1,3 @@
-# /_status
 get:
   summary: Get the server status
   description: |-
@@ -7,14 +6,14 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   responses:
-    "200":
+    '200':
       description: Returned the status successfully
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/Status
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
   tags:
-  - Admin only endpoints
-  - Server
+    - Admin only endpoints
+    - Server

--- a/docs/api/paths/admin/{db}~.yaml
+++ b/docs/api/paths/admin/{db}~.yaml
@@ -1,6 +1,5 @@
-# /{db}/
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: Get database information
   description: |-
@@ -9,7 +8,7 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   responses:
-    "200":
+    '200':
       description: Successfully returned database information
       content:
         application/json:
@@ -35,13 +34,11 @@ get:
                 type: integer
                 example: 123456
               instance_start_time:
-                description: Timestamp of when the database opened, in microseconds
-                  since the Unix epoch.
+                description: 'Timestamp of when the database opened, in microseconds since the Unix epoch.'
                 type: integer
                 example: 1644600082279583
               compact_running:
-                description: Indicates whether database compaction is currently taking
-                  place or not.
+                description: Indicates whether database compaction is currently taking place or not.
                 type: boolean
               purge_seq:
                 description: Unused field.
@@ -52,20 +49,19 @@ get:
                 type: number
                 default: 0
               state:
-                description: The database state. Change using the `/{db}/_offline`
-                  and `/{db}/_online` endpoints.
+                description: 'The database state. Change using the `/{db}/_offline` and `/{db}/_online` endpoints.'
                 type: string
                 enum:
-                - Online
-                - Offline
+                  - Online
+                  - Offline
               server_uuid:
                 description: Unique server identifier.
                 type: string
                 example: 995618a6a6cc9ac79731bd13240e19b5
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Database Management
+    - Database Management
 post:
   summary: Create a new document
   description: |-
@@ -78,14 +74,14 @@ post:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Application
   parameters:
-  - $ref: ../../components/parameters.yaml#/roundtrip
+    - $ref: ../../components/parameters.yaml#/roundtrip
   requestBody:
     content:
       application/json:
         schema:
           $ref: ../../components/schemas.yaml#/Document
   responses:
-    "200":
+    '200':
       description: New document revision created successfully.
       headers:
         Etag:
@@ -100,16 +96,16 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/New-revision
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "409":
+    '409':
       $ref: ../../components/responses.yaml#/Conflict
-    "415":
+    '415':
       $ref: ../../components/responses.yaml#/Invalid-content-type
   tags:
-  - Document
+    - Document
 delete:
   summary: Remove a database
   description: |-
@@ -120,24 +116,24 @@ delete:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Architect
   responses:
-    "200":
+    '200':
       description: Successfully removed the database
       content:
         application/json:
           schema:
             type: object
             properties: {}
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "500":
+    '500':
       description: Cannot remove database from bucket
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
-  - Admin only endpoints
-  - Database Management
+    - Admin only endpoints
+    - Database Management
 head:
   summary: Check if database exists
   description: |-
@@ -146,12 +142,12 @@ head:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   responses:
-    "200":
+    '200':
       description: Database exists
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Database Management
+    - Database Management
 put:
   summary: Create a new Sync Gateway database
   description: |-
@@ -174,34 +170,34 @@ put:
         schema:
           $ref: ../../components/schemas.yaml#/Database
   responses:
-    "201":
+    '201':
       description: Database created successfully
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "403":
+    '403':
       description: An authentication failure occurred
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/HTTP-Error
-    "409":
+    '409':
       description: A database already exists for this bucket
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/HTTP-Error
-    "412":
+    '412':
       description: A database under that name already exists
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/HTTP-Error
-    "500":
+    '500':
       description: A server error occurred
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
-  - Admin only endpoints
-  - Database Management
+    - Admin only endpoints
+    - Database Management

--- a/docs/api/paths/admin/{db}~_all_docs.yaml
+++ b/docs/api/paths/admin/{db}~_all_docs.yaml
@@ -1,6 +1,5 @@
-# /{db}/_all_docs
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: Gets all the documents in the database with the given parameters
   description: |-
@@ -10,24 +9,24 @@ get:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   parameters:
-  - $ref: ../../components/parameters.yaml#/include_docs
-  - $ref: ../../components/parameters.yaml#/Include-channels
-  - $ref: ../../components/parameters.yaml#/include-access
-  - $ref: ../../components/parameters.yaml#/include-revs
-  - $ref: ../../components/parameters.yaml#/include-seqs
-  - $ref: ../../components/parameters.yaml#/keys
-  - $ref: ../../components/parameters.yaml#/startkey
-  - $ref: ../../components/parameters.yaml#/endkey
-  - $ref: ../../components/parameters.yaml#/limit-result-rows
+    - $ref: ../../components/parameters.yaml#/include_docs
+    - $ref: ../../components/parameters.yaml#/Include-channels
+    - $ref: ../../components/parameters.yaml#/include-access
+    - $ref: ../../components/parameters.yaml#/include-revs
+    - $ref: ../../components/parameters.yaml#/include-seqs
+    - $ref: ../../components/parameters.yaml#/keys
+    - $ref: ../../components/parameters.yaml#/startkey
+    - $ref: ../../components/parameters.yaml#/endkey
+    - $ref: ../../components/parameters.yaml#/limit-result-rows
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/all-docs
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document
 post:
   summary: Get all the documents in the database using a built-in view
   description: |-
@@ -37,14 +36,14 @@ post:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   parameters:
-  - $ref: ../../components/parameters.yaml#/include_docs
-  - $ref: ../../components/parameters.yaml#/Include-channels
-  - $ref: ../../components/parameters.yaml#/include-access
-  - $ref: ../../components/parameters.yaml#/include-revs
-  - $ref: ../../components/parameters.yaml#/include-seqs
-  - $ref: ../../components/parameters.yaml#/startkey
-  - $ref: ../../components/parameters.yaml#/endkey
-  - $ref: ../../components/parameters.yaml#/limit-result-rows
+    - $ref: ../../components/parameters.yaml#/include_docs
+    - $ref: ../../components/parameters.yaml#/Include-channels
+    - $ref: ../../components/parameters.yaml#/include-access
+    - $ref: ../../components/parameters.yaml#/include-revs
+    - $ref: ../../components/parameters.yaml#/include-seqs
+    - $ref: ../../components/parameters.yaml#/startkey
+    - $ref: ../../components/parameters.yaml#/endkey
+    - $ref: ../../components/parameters.yaml#/limit-result-rows
   requestBody:
     content:
       application/json:
@@ -57,36 +56,36 @@ post:
               items:
                 type: string
           required:
-          - keys
+            - keys
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/all-docs
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document
 head:
   responses:
-    "200":
+    '200':
       description: OK
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document
   parameters:
-  - $ref: ../../components/parameters.yaml#/include_docs
-  - $ref: ../../components/parameters.yaml#/Include-channels
-  - $ref: ../../components/parameters.yaml#/include-access
-  - $ref: ../../components/parameters.yaml#/include-revs
-  - $ref: ../../components/parameters.yaml#/include-seqs
-  - $ref: ../../components/parameters.yaml#/keys
-  - $ref: ../../components/parameters.yaml#/startkey
-  - $ref: ../../components/parameters.yaml#/endkey
-  - $ref: ../../components/parameters.yaml#/limit-result-rows
+    - $ref: ../../components/parameters.yaml#/include_docs
+    - $ref: ../../components/parameters.yaml#/Include-channels
+    - $ref: ../../components/parameters.yaml#/include-access
+    - $ref: ../../components/parameters.yaml#/include-revs
+    - $ref: ../../components/parameters.yaml#/include-seqs
+    - $ref: ../../components/parameters.yaml#/keys
+    - $ref: ../../components/parameters.yaml#/startkey
+    - $ref: ../../components/parameters.yaml#/endkey
+    - $ref: ../../components/parameters.yaml#/limit-result-rows
   description: |-
     Required Sync Gateway RBAC roles:
     * Sync Gateway Application

--- a/docs/api/paths/admin/{db}~_blipsync.yaml
+++ b/docs/api/paths/admin/{db}~_blipsync.yaml
@@ -1,6 +1,5 @@
-# /{db}/_blipsync
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: Handle incoming BLIP Sync web socket request
   description: |-
@@ -9,22 +8,21 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Application
   parameters:
-  - name: client
-    in: query
-    description: This is the client type that is making the BLIP Sync request. Used
-      to control client-type specific replication behaviour.
-    schema:
-      type: string
-      default: cbl2
-      enum:
-      - cbl2
-      - sgr2
+    - name: client
+      in: query
+      description: This is the client type that is making the BLIP Sync request. Used to control client-type specific replication behaviour.
+      schema:
+        type: string
+        default: cbl2
+        enum:
+          - cbl2
+          - sgr2
   responses:
-    "101":
+    '101':
       description: Upgraded to a web socket connection
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "426":
+    '426':
       description: Cannot upgrade connection to a web socket connection
       content:
         application/json:
@@ -34,4 +32,4 @@ get:
             error: Upgrade Required
             reason: Can't upgrade this request to websocket connection
   tags:
-  - Replication
+    - Replication

--- a/docs/api/paths/admin/{db}~_bulk_docs.yaml
+++ b/docs/api/paths/admin/{db}~_bulk_docs.yaml
@@ -1,6 +1,5 @@
-# /{db}/_bulk_docs
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 post:
   summary: Bulk document operations
   description: |-
@@ -21,8 +20,7 @@ post:
           type: object
           properties:
             new_edits:
-              description: This controls whether to assign new revision identifiers
-                to new edits (`true`) or use the existing ones (`false`).
+              description: This controls whether to assign new revision identifiers to new edits (`true`) or use the existing ones (`false`).
               type: boolean
               default: true
             docs:
@@ -30,20 +28,20 @@ post:
               items:
                 $ref: ../../components/schemas.yaml#/Document
           required:
-          - docs
+            - docs
         example:
           new_edits: true
           docs:
-          - _id: FooBar
-            foo: bar
-          - _id: AliceSettings
-            _rev: 5-832a6db48ed130adadede928aee54576
-            FailedLoginAttempts: 7
-          - _id: BobSettings
-            _rev: 1-fa76ba41ee5fdfee1b91fc478ed09e59
-            _deleted: true
+            - _id: FooBar
+              foo: bar
+            - _id: AliceSettings
+              _rev: 5-832a6db48ed130adadede928aee54576
+              FailedLoginAttempts: 7
+            - _id: BobSettings
+              _rev: 1-fa76ba41ee5fdfee1b91fc478ed09e59
+              _deleted: true
   responses:
-    "201":
+    '201':
       description: |-
         Executed all operations.
 
@@ -56,12 +54,10 @@ post:
               type: object
               properties:
                 id:
-                  description: The ID of the document that the operation was performed
-                    on.
+                  description: The ID of the document that the operation was performed on.
                   type: string
                 rev:
-                  description: The new revision of the document if the operation was
-                    a success.
+                  description: The new revision of the document if the operation was a success.
                   type: string
                 error:
                   description: The error type if the operation of the document failed.
@@ -73,32 +69,32 @@ post:
                   description: The HTTP status code for why the operation failed.
                   type: integer
               required:
-              - id
+                - id
             uniqueItems: true
           examples:
             Success:
               value:
-              - id: FooBar
-                rev: 1-cd809becc169215072fd567eebd8b8de
-              - id: AliceSettings
-                rev: 6-b3e8dcf825b71ccee112f3572ec4323c
-              - id: BobSettings
-                rev: 2-5145e1086bb8d1d71a531e9f6b543c58
+                - id: FooBar
+                  rev: 1-cd809becc169215072fd567eebd8b8de
+                - id: AliceSettings
+                  rev: 6-b3e8dcf825b71ccee112f3572ec4323c
+                - id: BobSettings
+                  rev: 2-5145e1086bb8d1d71a531e9f6b543c58
             Partial success:
               value:
-              - error: conflict
-                id: FooBar
-                reason: Document exists
-                status: 409
-              - id: AliceSettings
-                rev: 6-b3e8dcf825b71ccee112f3572ec4323c
-              - error: conflict
-                id: BobSettings
-                reason: Document revision conflict
-                status: 409
-    "400":
+                - error: conflict
+                  id: FooBar
+                  reason: Document exists
+                  status: 409
+                - id: AliceSettings
+                  rev: 6-b3e8dcf825b71ccee112f3572ec4323c
+                - error: conflict
+                  id: BobSettings
+                  reason: Document revision conflict
+                  status: 409
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document

--- a/docs/api/paths/admin/{db}~_bulk_get.yaml
+++ b/docs/api/paths/admin/{db}~_bulk_get.yaml
@@ -1,6 +1,5 @@
-# /{db}/_bulk_get
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 post:
   summary: Get multiple documents in a MIME multipart response
   description: |
@@ -16,36 +15,28 @@ post:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   parameters:
-  - name: attachments
-    in: query
-    description: This is for whether to include attachments in each of the documents
-      returned or not.
-    schema:
-      type: boolean
-      default: "false"
-  - $ref: ../../components/parameters.yaml#/include-revs
-  - name: revs_limit
-    in: query
-    description: The number of revisions to include in the response from the document
-      history. This parameter only makes a different if the `revs` query parameter
-      is set to `true`. The full revision history will be returned if `revs` is set
-      but this is not.
-    schema:
-      type: integer
-  - name: X-Accept-Part-Encoding
-    in: header
-    description: If this header includes `gzip` then the part HTTP compression encoding
-      will be done.
-    schema:
-      type: string
-  - name: Accept-Encoding
-    in: header
-    description: If this header includes `gzip` then the the HTTP response will be
-      compressed. This takes priority over `X-Accept-Part-Encoding`. Only part compression
-      will be done if `X-Accept-Part-Encoding=gzip` and the `User-Agent` is below
-      1.2 due to clients not being able to handle full compression.
-    schema:
-      type: string
+    - name: attachments
+      in: query
+      description: This is for whether to include attachments in each of the documents returned or not.
+      schema:
+        type: boolean
+        default: 'false'
+    - $ref: ../../components/parameters.yaml#/include-revs
+    - name: revs_limit
+      in: query
+      description: The number of revisions to include in the response from the document history. This parameter only makes a different if the `revs` query parameter is set to `true`. The full revision history will be returned if `revs` is set but this is not.
+      schema:
+        type: integer
+    - name: X-Accept-Part-Encoding
+      in: header
+      description: If this header includes `gzip` then the part HTTP compression encoding will be done.
+      schema:
+        type: string
+    - name: Accept-Encoding
+      in: header
+      description: If this header includes `gzip` then the the HTTP response will be compressed. This takes priority over `X-Accept-Part-Encoding`. Only part compression will be done if `X-Accept-Part-Encoding=gzip` and the `User-Agent` is below 1.2 due to clients not being able to handle full compression.
+      schema:
+        type: string
   requestBody:
     content:
       application/json:
@@ -61,20 +52,20 @@ post:
                     description: ID of the document to retrieve.
                     type: string
                 required:
-                - id
+                  - id
           required:
-          - docs
+            - docs
         example:
           docs:
-          - id: FooBar
-          - id: attachment
-          - id: AliceSettings
+            - id: FooBar
+            - id: attachment
+            - id: AliceSettings
   responses:
-    "200":
+    '200':
       description: Returned the requested docs as `multipart/mixed` response type
-    "400":
+    '400':
       description: Bad Request
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document

--- a/docs/api/paths/admin/{db}~_changes.yaml
+++ b/docs/api/paths/admin/{db}~_changes.yaml
@@ -1,6 +1,5 @@
-# /{db}/_changes
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: Get changes list
   description: |-
@@ -12,109 +11,92 @@ get:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   parameters:
-  - name: limit
-    in: query
-    description: Maximum number of changes to return.
-    schema:
-      type: integer
-  - name: since
-    in: query
-    description: Starts the results from the change immediately after the given sequence
-      ID. Sequence IDs should be considered opaque; they come from the last_seq property
-      of a prior response.
-    schema:
-      type: string
-  - name: style
-    in: query
-    description: Controls whether to return the current winning revision (`main_only`)
-      or all the leaf revision including conflicts and deleted former conflicts (`all_docs`).
-    schema:
-      type: string
-      default: main_only
-      enum:
-      - main_only
-      - all_docs
-  - name: active_only
-    in: query
-    description: Set true to exclude deleted documents and notifications for documents
-      the user no longer has access to from the changes feed.
-    schema:
-      type: boolean
-      default: "false"
-  - $ref: ../../components/parameters.yaml#/include_docs
-  - name: revocations
-    in: query
-    description: If true, revocation messages will be sent on the changes feed.
-    schema:
-      type: boolean
-  - name: filter
-    in: query
-    description: Set a filter to either filter by channels or document IDs.
-    schema:
-      type: string
-      enum:
-      - sync_gateway/bychannel
-      - _doc_ids
-  - name: channels
-    in: query
-    description: A comma-separated list of channel names to filter the response to
-      only the channels specified. To use this option, the `filter` query option must
-      be set to `sync_gateway/bychannels`.
-    schema:
-      type: string
-  - name: doc_ids
-    in: query
-    description: A valid JSON array of document IDs to filter the documents in the
-      response to only the documents specified. To use this option, the `filter` query
-      option must be set to `_doc_ids` and the `feed` parameter must be `normal`.
-      Also accepts a comma separated list of document IDs instead.
-    schema:
-      type: array
-      items:
+    - name: limit
+      in: query
+      description: Maximum number of changes to return.
+      schema:
+        type: integer
+    - name: since
+      in: query
+      description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
+      schema:
         type: string
-  - name: heartbeat
-    in: query
-    description: The interval (in milliseconds) to send an empty line (CRLF) in the
-      response. This is to help prevent gateways from deciding the socket is idle
-      and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`.
-      This will override any timeouts to keep the feed alive indefinitely. Setting
-      to 0 results in no heartbeat. The maximum heartbeat can be set in the server
-      replication configuration.
-    schema:
-      type: integer
-      default: 0
-      minimum: 25000
-  - name: timeout
-    in: query
-    description: This is the maximum period (in milliseconds) to wait for a change
-      before the response is sent, even if there are no results. This is only applicable
-      for `feed=longpoll` or `feed=continuous` changes feeds. Setting to 0 results
-      in no timeout.
-    schema:
-      type: integer
-      default: 300000
-      maximum: 900000
-      minimum: 0
-  - name: feed
-    in: query
-    description: 'The type of changes feed to use. '
-    schema:
-      type: string
-      default: normal
-      enum:
-      - normal
-      - longpoll
-      - continuous
-      - websocket
+    - name: style
+      in: query
+      description: Controls whether to return the current winning revision (`main_only`) or all the leaf revision including conflicts and deleted former conflicts (`all_docs`).
+      schema:
+        type: string
+        default: main_only
+        enum:
+          - main_only
+          - all_docs
+    - name: active_only
+      in: query
+      description: Set true to exclude deleted documents and notifications for documents the user no longer has access to from the changes feed.
+      schema:
+        type: boolean
+        default: 'false'
+    - $ref: ../../components/parameters.yaml#/include_docs
+    - name: revocations
+      in: query
+      description: 'If true, revocation messages will be sent on the changes feed.'
+      schema:
+        type: boolean
+    - name: filter
+      in: query
+      description: Set a filter to either filter by channels or document IDs.
+      schema:
+        type: string
+        enum:
+          - sync_gateway/bychannel
+          - _doc_ids
+    - name: channels
+      in: query
+      description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannels`.'
+      schema:
+        type: string
+    - name: doc_ids
+      in: query
+      description: 'A valid JSON array of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`. Also accepts a comma separated list of document IDs instead.'
+      schema:
+        type: array
+        items:
+          type: string
+    - name: heartbeat
+      in: query
+      description: The interval (in milliseconds) to send an empty line (CRLF) in the response. This is to help prevent gateways from deciding the socket is idle and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`. This will override any timeouts to keep the feed alive indefinitely. Setting to 0 results in no heartbeat. The maximum heartbeat can be set in the server replication configuration.
+      schema:
+        type: integer
+        default: 0
+        minimum: 25000
+    - name: timeout
+      in: query
+      description: 'This is the maximum period (in milliseconds) to wait for a change before the response is sent, even if there are no results. This is only applicable for `feed=longpoll` or `feed=continuous` changes feeds. Setting to 0 results in no timeout.'
+      schema:
+        type: integer
+        default: 300000
+        maximum: 900000
+        minimum: 0
+    - name: feed
+      in: query
+      description: 'The type of changes feed to use. '
+      schema:
+        type: string
+        default: normal
+        enum:
+          - normal
+          - longpoll
+          - continuous
+          - websocket
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/changes-feed
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Database Management
+    - Database Management
 post:
   summary: Get changes list
   description: |-
@@ -135,71 +117,54 @@ post:
               description: Maximum number of changes to return.
               type: string
             style:
-              description: Controls whether to return the current winning revision
-                (`main_only`) or all the leaf revision including conflicts and deleted
-                former conflicts (`all_docs`).
+              description: Controls whether to return the current winning revision (`main_only`) or all the leaf revision including conflicts and deleted former conflicts (`all_docs`).
               type: string
             active_only:
-              description: Set true to exclude deleted documents and notifications
-                for documents the user no longer has access to from the changes feed.
+              description: Set true to exclude deleted documents and notifications for documents the user no longer has access to from the changes feed.
               type: string
             include_docs:
               description: Include the body associated with each document.
               type: string
             revocations:
-              description: If true, revocation messages will be sent on the changes
-                feed.
+              description: 'If true, revocation messages will be sent on the changes feed.'
               type: string
             filter:
               description: Set a filter to either filter by channels or document IDs.
               type: string
             channels:
-              description: A comma-separated list of channel names to filter the response
-                to only the channels specified. To use this option, the `filter` query
-                option must be set to `sync_gateway/bychannels`.
+              description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannels`.'
               type: string
             doc_ids:
-              description: A valid JSON array of document IDs to filter the documents
-                in the response to only the documents specified. To use this option,
-                the `filter` query option must be set to `_doc_ids` and the `feed`
-                parameter must be `normal`.
+              description: 'A valid JSON array of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`.'
               type: string
             heartbeat:
-              description: The interval (in milliseconds) to send an empty line (CRLF)
-                in the response. This is to help prevent gateways from deciding the
-                socket is idle and therefore closing it. This is only applicable to
-                `feed=longpoll` or `feed=continuous`. This will override any timeouts
-                to keep the feed alive indefinitely. Setting to 0 results in no heartbeat.
-                The maximum heartbeat can be set in the server replication configuration.
+              description: The interval (in milliseconds) to send an empty line (CRLF) in the response. This is to help prevent gateways from deciding the socket is idle and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`. This will override any timeouts to keep the feed alive indefinitely. Setting to 0 results in no heartbeat. The maximum heartbeat can be set in the server replication configuration.
               type: string
             timeout:
-              description: This is the maximum period (in milliseconds) to wait for
-                a change before the response is sent, even if there are no results.
-                This is only applicable for `feed=longpoll` or `feed=continuous` changes
-                feeds. Setting to 0 results in no timeout.
+              description: 'This is the maximum period (in milliseconds) to wait for a change before the response is sent, even if there are no results. This is only applicable for `feed=longpoll` or `feed=continuous` changes feeds. Setting to 0 results in no timeout.'
               type: string
             feed:
               description: 'The type of changes feed to use. '
               type: string
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/changes-feed
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Database Management
+    - Database Management
 head:
   responses:
-    "200":
+    '200':
       description: OK
-    "400":
+    '400':
       description: Bad Request
-    "404":
+    '404':
       description: Not Found
   tags:
-  - Database Management
+    - Database Management
   description: |-
     Required Sync Gateway RBAC roles:
     * Sync Gateway Application

--- a/docs/api/paths/admin/{db}~_compact.yaml
+++ b/docs/api/paths/admin/{db}~_compact.yaml
@@ -1,6 +1,5 @@
-# /{db}/_compact
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 post:
   summary: Manage a compact operation
   description: |-
@@ -15,49 +14,48 @@ post:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Architect
   parameters:
-  - $ref: ../../components/parameters.yaml#/compact-type
-  - name: action
-    in: query
-    description: Defines whether the a compact operation is being started or stopped.
-    schema:
-      type: string
-      default: start
-      enum:
-      - start
-      - stop
-  - name: reset
-    in: query
-    description: |-
-      **Attachment compaction only**
+    - $ref: ../../components/parameters.yaml#/compact-type
+    - name: action
+      in: query
+      description: Defines whether the a compact operation is being started or stopped.
+      schema:
+        type: string
+        default: start
+        enum:
+          - start
+          - stop
+    - name: reset
+      in: query
+      description: |-
+        **Attachment compaction only**
 
-      This forces a fresh compact start instead of trying to resume the previous failed compact operation.
-    schema:
-      type: boolean
-  - name: dry_run
-    in: query
-    description: |-
-      **Attachment compaction only**
+        This forces a fresh compact start instead of trying to resume the previous failed compact operation.
+      schema:
+        type: boolean
+    - name: dry_run
+      in: query
+      description: |-
+        **Attachment compaction only**
 
-      This will run through all 3 stages of attachment compact but will not purge any attachments. This can be used to check how many attachments will be purged.'
-    schema:
-      type: boolean
+        This will run through all 3 stages of attachment compact but will not purge any attachments. This can be used to check how many attachments will be purged.'
+      schema:
+        type: boolean
   responses:
-    "200":
+    '200':
       description: Started or stopped compact operation successfully
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "503":
-      description: Cannot start compaction due to another compaction operation still
-        running.
+    '503':
+      description: Cannot start compaction due to another compaction operation still running.
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
-  - Admin only endpoints
-  - Database Management
+    - Admin only endpoints
+    - Database Management
 get:
   summary: Get the status of the most recent compact operation
   description: |-
@@ -66,18 +64,18 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Architect
   parameters:
-  - $ref: ../../components/parameters.yaml#/compact-type
+    - $ref: ../../components/parameters.yaml#/compact-type
   responses:
-    "200":
+    '200':
       description: Compaction status retrieved successfully
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/Compact-status
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Database Management
+    - Admin only endpoints
+    - Database Management

--- a/docs/api/paths/admin/{db}~_config.yaml
+++ b/docs/api/paths/admin/{db}~_config.yaml
@@ -1,4 +1,3 @@
-# /{db}/_config
 get:
   summary: Get database configuration
   description: |-
@@ -7,39 +6,37 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Architect
   parameters:
-  - $ref: ../../components/parameters.yaml#/deprecated-redact
-  - name: include_javascript
-    in: query
-    description: Include the fields that have Javascript functions in the response.
-      E.g. sync function, import filter, and event handlers.
-    schema:
-      type: boolean
-      default: true
-  - $ref: ../../components/parameters.yaml#/include_runtime
-  - name: refresh_config
-    in: query
-    description: Forces the configuration to be reloaded on the Sync Gateway node.
-    schema:
-      type: boolean
-      default: false
+    - $ref: ../../components/parameters.yaml#/deprecated-redact
+    - name: include_javascript
+      in: query
+      description: 'Include the fields that have Javascript functions in the response. E.g. sync function, import filter, and event handlers.'
+      schema:
+        type: boolean
+        default: true
+    - $ref: ../../components/parameters.yaml#/include_runtime
+    - name: refresh_config
+      in: query
+      description: Forces the configuration to be reloaded on the Sync Gateway node.
+      schema:
+        type: boolean
+        default: false
   responses:
-    "200":
+    '200':
       description: Successfully retrieved database configuration
       headers:
         Etag:
           schema:
             type: string
-          description: The database configuration version. Use with If-Match for optimistic
-            concurrency control.
+          description: The database configuration version. Use with If-Match for optimistic concurrency control.
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/Database
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Database Configuration
+    - Admin only endpoints
+    - Database Configuration
 put:
   summary: Replace database configuration
   description: |-
@@ -51,8 +48,8 @@ put:
     * Sync Gateway Architect
     * Sync Gateway Application
   parameters:
-  - $ref: ../../components/parameters.yaml#/DB-config-If-Match
-  - $ref: ../../components/parameters.yaml#/disable_oidc_validation
+    - $ref: ../../components/parameters.yaml#/DB-config-If-Match
+    - $ref: ../../components/parameters.yaml#/disable_oidc_validation
   requestBody:
     description: The new database configuration to use
     content:
@@ -60,17 +57,17 @@ put:
         schema:
           $ref: ../../components/schemas.yaml#/Database
   responses:
-    "201":
+    '201':
       $ref: ../../components/responses.yaml#/DB-config-updated
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "412":
+    '412':
       $ref: ../../components/responses.yaml#/DB-config-precondition-failed
   tags:
-  - Admin only endpoints
-  - Database Configuration
+    - Admin only endpoints
+    - Database Configuration
 post:
   summary: Update database configuration
   description: |-
@@ -82,7 +79,7 @@ post:
     * Sync Gateway Architect
     * Sync Gateway Application
   parameters:
-  - $ref: ../../components/parameters.yaml#/DB-config-If-Match
+    - $ref: ../../components/parameters.yaml#/DB-config-If-Match
   requestBody:
     description: The database configuration fields to update
     content:
@@ -90,16 +87,16 @@ post:
         schema:
           $ref: ../../components/schemas.yaml#/Database
   responses:
-    "201":
+    '201':
       $ref: ../../components/responses.yaml#/DB-config-updated
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       description: Not Found
-    "412":
+    '412':
       $ref: ../../components/responses.yaml#/DB-config-precondition-failed
   tags:
-  - Admin only endpoints
-  - Database Configuration
+    - Admin only endpoints
+    - Database Configuration
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db

--- a/docs/api/paths/admin/{db}~_config~import_filter.yaml
+++ b/docs/api/paths/admin/{db}~_config~import_filter.yaml
@@ -1,6 +1,5 @@
-# /{db}/_config/import_filter
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: Get database import filter
   description: |-
@@ -11,7 +10,7 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Architect
   responses:
-    "200":
+    '200':
       description: Successfully retrieved the import filter
       headers:
         Etag:
@@ -22,11 +21,11 @@ get:
         application/javascript:
           schema:
             type: string
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Database Configuration
+    - Admin only endpoints
+    - Database Configuration
 put:
   summary: Set database import filter
   description: |-
@@ -35,8 +34,8 @@ put:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Architect
   parameters:
-  - $ref: ../../components/parameters.yaml#/DB-config-If-Match
-  - $ref: ../../components/parameters.yaml#/disable_oidc_validation
+    - $ref: ../../components/parameters.yaml#/DB-config-If-Match
+    - $ref: ../../components/parameters.yaml#/disable_oidc_validation
   requestBody:
     description: The import filter to use
     content:
@@ -44,17 +43,17 @@ put:
         schema:
           type: string
   responses:
-    "200":
+    '200':
       description: Updated import filter successfully
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "412":
+    '412':
       $ref: ../../components/responses.yaml#/DB-config-precondition-failed
   tags:
-  - Admin only endpoints
-  - Database Configuration
+    - Admin only endpoints
+    - Database Configuration
 delete:
   summary: Delete import filter
   description: |-
@@ -63,14 +62,14 @@ delete:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Architect
   parameters:
-  - $ref: ../../components/parameters.yaml#/DB-config-If-Match
+    - $ref: ../../components/parameters.yaml#/DB-config-If-Match
   responses:
-    "200":
+    '200':
       description: Successfully deleted the import filter
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "412":
+    '412':
       $ref: ../../components/responses.yaml#/DB-config-precondition-failed
   tags:
-  - Admin only endpoints
-  - Database Configuration
+    - Admin only endpoints
+    - Database Configuration

--- a/docs/api/paths/admin/{db}~_config~sync.yaml
+++ b/docs/api/paths/admin/{db}~_config~sync.yaml
@@ -1,6 +1,5 @@
-# {db}/_config/sync
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: Get database sync function
   description: |-
@@ -11,7 +10,7 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Architect
   responses:
-    "200":
+    '200':
       description: Successfully retrieved the sync function
       headers:
         Etag:
@@ -26,11 +25,11 @@ get:
             function (doc, oldDoc) {
               channel(doc.channels);
             }
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Database Configuration
+    - Admin only endpoints
+    - Database Configuration
 put:
   summary: Set database sync function
   description: |-
@@ -39,8 +38,8 @@ put:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Architect
   parameters:
-  - $ref: ../../components/parameters.yaml#/DB-config-If-Match
-  - $ref: ../../components/parameters.yaml#/disable_oidc_validation
+    - $ref: ../../components/parameters.yaml#/DB-config-If-Match
+    - $ref: ../../components/parameters.yaml#/disable_oidc_validation
   requestBody:
     description: The new sync function to use
     content:
@@ -52,16 +51,16 @@ put:
             channel(doc.channels);
           }
   responses:
-    "200":
+    '200':
       description: Updated sync function successfully
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "412":
+    '412':
       $ref: ../../components/responses.yaml#/DB-config-precondition-failed
   tags:
-  - Admin only endpoints
+    - Admin only endpoints
 delete:
   summary: Remove custom sync function
   description: |-
@@ -77,14 +76,14 @@ delete:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Architect
   parameters:
-  - $ref: ../../components/parameters.yaml#/If-Match
+    - $ref: ../../components/parameters.yaml#/If-Match
   responses:
-    "200":
+    '200':
       description: Successfully reset the sync function
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "412":
+    '412':
       $ref: ../../components/responses.yaml#/DB-config-precondition-failed
   tags:
-  - Admin only endpoints
-  - Database Configuration
+    - Admin only endpoints
+    - Database Configuration

--- a/docs/api/paths/admin/{db}~_design~{ddoc}.yaml
+++ b/docs/api/paths/admin/{db}~_design~{ddoc}.yaml
@@ -1,7 +1,6 @@
-# /{db}/_design/{ddoc}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- $ref: ../../components/parameters.yaml#/ddoc
+  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/ddoc
 get:
   summary: Get views of a design document | Unsupported
   description: |-
@@ -13,18 +12,18 @@ get:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   responses:
-    "200":
+    '200':
       description: Successfully returned design document.
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/Design-doc
-    "403":
+    '403':
       $ref: ../../components/responses.yaml#/ddoc-forbidden
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Unsupported
+    - Unsupported
 put:
   summary: Update views of a design document | Unsupported
   description: |-
@@ -40,14 +39,14 @@ put:
         schema:
           $ref: ../../components/schemas.yaml#/Design-doc
   responses:
-    "200":
+    '200':
       description: Design document changes successfully
-    "403":
+    '403':
       $ref: ../../components/responses.yaml#/ddoc-forbidden
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Unsupported
+    - Unsupported
 delete:
   summary: Delete a design document | Unsupported
   description: |-
@@ -58,25 +57,24 @@ delete:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Application
   responses:
-    "200":
+    '200':
       description: Design document deleted successfully
-    "403":
+    '403':
       $ref: ../../components/responses.yaml#/ddoc-forbidden
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Unsupported
+    - Unsupported
 head:
   responses:
-    "200":
+    '200':
       description: Design document exists
-    "403":
-      description: Forbidden access possibly due to not using the Admin API or the
-        design document is a built-in Sync Gateway one.
-    "404":
+    '403':
+      description: Forbidden access possibly due to not using the Admin API or the design document is a built-in Sync Gateway one.
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Unsupported
+    - Unsupported
   description: |-
     **This is unsupported**
 

--- a/docs/api/paths/admin/{db}~_design~{ddoc}~_view~{view}.yaml
+++ b/docs/api/paths/admin/{db}~_design~{ddoc}~_view~{view}.yaml
@@ -1,8 +1,7 @@
-# /{db}/_design/{ddoc}/_view/{view}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- $ref: ../../components/parameters.yaml#/ddoc
-- $ref: ../../components/parameters.yaml#/view
+  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/ddoc
+  - $ref: ../../components/parameters.yaml#/view
 get:
   summary: Query a view on a design document | Unsupported
   description: |-
@@ -14,23 +13,23 @@ get:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   parameters:
-  - $ref: ../../components/parameters.yaml#/inclusive_end
-  - $ref: ../../components/parameters.yaml#/descending
-  - $ref: ../../components/parameters.yaml#/include_docs-cbs3
-  - $ref: ../../components/parameters.yaml#/reduce
-  - $ref: ../../components/parameters.yaml#/group
-  - $ref: ../../components/parameters.yaml#/skip
-  - $ref: ../../components/parameters.yaml#/limit
-  - $ref: ../../components/parameters.yaml#/group_level
-  - $ref: ../../components/parameters.yaml#/startkey_docid
-  - $ref: ../../components/parameters.yaml#/endkey_docid
-  - $ref: ../../components/parameters.yaml#/stale
-  - $ref: ../../components/parameters.yaml#/startkey
-  - $ref: ../../components/parameters.yaml#/endkey
-  - $ref: ../../components/parameters.yaml#/key
-  - $ref: ../../components/parameters.yaml#/keys
+    - $ref: ../../components/parameters.yaml#/inclusive_end
+    - $ref: ../../components/parameters.yaml#/descending
+    - $ref: ../../components/parameters.yaml#/include_docs-cbs3
+    - $ref: ../../components/parameters.yaml#/reduce
+    - $ref: ../../components/parameters.yaml#/group
+    - $ref: ../../components/parameters.yaml#/skip
+    - $ref: ../../components/parameters.yaml#/limit
+    - $ref: ../../components/parameters.yaml#/group_level
+    - $ref: ../../components/parameters.yaml#/startkey_docid
+    - $ref: ../../components/parameters.yaml#/endkey_docid
+    - $ref: ../../components/parameters.yaml#/stale
+    - $ref: ../../components/parameters.yaml#/startkey
+    - $ref: ../../components/parameters.yaml#/endkey
+    - $ref: ../../components/parameters.yaml#/key
+    - $ref: ../../components/parameters.yaml#/keys
   responses:
-    "200":
+    '200':
       description: Returned view successfully
       content:
         application/json:
@@ -62,11 +61,11 @@ get:
                     Reason:
                       type: string
             required:
-            - total_rows
-            - rows
-    "403":
+              - total_rows
+              - rows
+    '403':
       description: Forbidden
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Unsupported
+    - Unsupported

--- a/docs/api/paths/admin/{db}~_dumpchannel~{channel}.yaml
+++ b/docs/api/paths/admin/{db}~_dumpchannel~{channel}.yaml
@@ -1,12 +1,11 @@
-# /{db}/_dumpchannel/{channel}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- name: channel
-  in: path
-  description: The channel to dump all the documents from.
-  required: true
-  schema:
-    type: string
+  - $ref: ../../components/parameters.yaml#/db
+  - name: channel
+    in: path
+    description: The channel to dump all the documents from.
+    required: true
+    schema:
+      type: string
 get:
   summary: Dump all the documents in a channel | Unsupported
   description: |-
@@ -18,22 +17,20 @@ get:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   parameters:
-  - name: since
-    in: query
-    description: Starts the results from the change immediately after the given sequence
-      ID. Sequence IDs should be considered opaque; they come from the last_seq property
-      of a prior response.
-    schema:
-      type: string
+    - name: since
+      in: query
+      description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
+      schema:
+        type: string
   responses:
-    "200":
+    '200':
       description: Successfully got all documents in the channel
       content:
         text/html:
           schema:
             type: string
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Unsupported
+    - Admin only endpoints
+    - Unsupported

--- a/docs/api/paths/admin/{db}~_dump~{view}.yaml
+++ b/docs/api/paths/admin/{db}~_dump~{view}.yaml
@@ -1,7 +1,6 @@
-# /{db}/_dump/{view}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- $ref: ../../components/parameters.yaml#/view
+  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/view
 get:
   summary: Dump a view | Unsupported
   description: |-
@@ -13,20 +12,20 @@ get:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   responses:
-    "200":
+    '200':
       description: Retrieved view successfully
       content:
         text/html:
           schema:
             type: string
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "500":
+    '500':
       description: Internal Server Error
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
-  - Admin only endpoints
-  - Unsupported
+    - Admin only endpoints
+    - Unsupported

--- a/docs/api/paths/admin/{db}~_ensure_full_commit.yaml
+++ b/docs/api/paths/admin/{db}~_ensure_full_commit.yaml
@@ -1,8 +1,7 @@
-# /{db}/_ensure_full_commit
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 post:
-  summary: ""
+  summary: ''
   description: |-
     This endpoint is non-functional but is present for CouchDB compatibility.
 
@@ -10,7 +9,7 @@ post:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   responses:
-    "201":
+    '201':
       description: OK
       content:
         application/json:
@@ -18,8 +17,7 @@ post:
             type: object
             properties:
               instance_start_time:
-                description: Timestamp of when the database opened, in microseconds
-                  since the Unix epoch.
+                description: 'Timestamp of when the database opened, in microseconds since the Unix epoch.'
                 type: integer
                 example: 1644600082279583
               ok:
@@ -27,4 +25,4 @@ post:
                 example: true
                 default: true
   tags:
-  - Database Management
+    - Database Management

--- a/docs/api/paths/admin/{db}~_facebook.yaml
+++ b/docs/api/paths/admin/{db}~_facebook.yaml
@@ -1,6 +1,5 @@
-# /{db}/_facebook
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 post:
   summary: Create a new Facebook-based session
   description: |-
@@ -17,13 +16,13 @@ post:
               description: Facebook access token to base the new session on.
               type: string
           required:
-          - access_token
+            - access_token
   responses:
-    "200":
+    '200':
       description: Session created successfully
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/Invalid-CORS
-    "401":
+    '401':
       description: Received error from Facebook verifier
       content:
         application/json:
@@ -34,9 +33,9 @@ post:
                 type: string
               reason:
                 type: string
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "502":
+    '502':
       description: Received invalid response from the Facebook verifier
       content:
         application/json:
@@ -47,7 +46,7 @@ post:
                 type: string
               reason:
                 type: string
-    "504":
+    '504':
       description: Unable to send request to Facebook API
       content:
         application/json:
@@ -60,4 +59,4 @@ post:
                 type: string
   deprecated: true
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/admin/{db}~_flush.yaml
+++ b/docs/api/paths/admin/{db}~_flush.yaml
@@ -1,6 +1,5 @@
-# /{db}/_flush
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 post:
   summary: Flush the entire database bucket | Unsupported
   description: |-
@@ -13,16 +12,16 @@ post:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Dev Ops
   responses:
-    "200":
+    '200':
       description: Successfully flushed the bucket
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "503":
+    '503':
       description: The bucket does not support flush or delete
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
-  - Admin only endpoints
-  - Unsupported
+    - Admin only endpoints
+    - Unsupported

--- a/docs/api/paths/admin/{db}~_google.yaml
+++ b/docs/api/paths/admin/{db}~_google.yaml
@@ -1,6 +1,5 @@
-# /{db}/_google
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 post:
   summary: Create a new Google-based session
   description: |-
@@ -17,15 +16,14 @@ post:
               description: Google ID token to base the new session on.
               type: string
           required:
-          - id_token
+            - id_token
   responses:
-    "200":
+    '200':
       description: Session created successfully
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/Invalid-CORS
-    "401":
-      description: Received error from Google token verifier or invalid application
-        ID in the config
+    '401':
+      description: Received error from Google token verifier or invalid application ID in the config
       content:
         application/json:
           schema:
@@ -35,9 +33,9 @@ post:
                 type: string
               reason:
                 type: string
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "502":
+    '502':
       description: Received invalid response from the Google token verifier
       content:
         application/json:
@@ -48,8 +46,8 @@ post:
                 type: string
               reason:
                 type: string
-    "504":
+    '504':
       description: Unable to send request to the Google token verifier
   deprecated: true
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/admin/{db}~_local~{docid}.yaml
+++ b/docs/api/paths/admin/{db}~_local~{docid}.yaml
@@ -1,12 +1,11 @@
-# /{db}/_local/{docid}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- name: docid
-  in: path
-  description: The name of the local document ID excluding the `_local/` prefix.
-  required: true
-  schema:
-    type: string
+  - $ref: ../../components/parameters.yaml#/db
+  - name: docid
+    in: path
+    description: The name of the local document ID excluding the `_local/` prefix.
+    required: true
+    schema:
+      type: string
 get:
   summary: Get local document
   description: |-
@@ -18,14 +17,14 @@ get:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   responses:
-    "200":
+    '200':
       description: Successfully found local document
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document
 put:
   summary: Upsert a local document
   description: |-
@@ -43,27 +42,25 @@ put:
           type: object
           properties:
             _rev:
-              description: Revision to replace. Required if updating existing local
-                document.
+              description: Revision to replace. Required if updating existing local document.
               type: string
   responses:
-    "201":
-      description: Document successfully written. The document ID will be prefixed
-        with `_local/`.
+    '201':
+      description: Document successfully written. The document ID will be prefixed with `_local/`.
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/New-revision
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "409":
-      description: A revision ID conflict would result from updating this document
-        revision.
+    '409':
+      description: A revision ID conflict would result from updating this document revision.
   tags:
-  - Document
+    - Document
 delete:
+  summary: Delete a local document
   description: |-
     This request deletes a local document.
 
@@ -72,35 +69,33 @@ delete:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Application
   parameters:
-  - name: rev
-    in: query
-    description: The revision ID of the revision to delete.
-    required: true
-    schema:
-      type: string
+    - name: rev
+      in: query
+      description: The revision ID of the revision to delete.
+      required: true
+      schema:
+        type: string
   responses:
-    "200":
+    '200':
       description: Successfully removed the local document.
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "409":
-      description: A revision ID conflict would result from deleting this document
-        revision.
+    '409':
+      description: A revision ID conflict would result from deleting this document revision.
   tags:
-  - Document
-  summary: Delete a local document
+    - Document
 head:
   responses:
-    "200":
+    '200':
       description: Document exists
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document
   summary: Check if local document exists
   description: |-
     This request checks if a local document exists.

--- a/docs/api/paths/admin/{db}~_offline.yaml
+++ b/docs/api/paths/admin/{db}~_offline.yaml
@@ -1,6 +1,5 @@
-# /{db}/_offline
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 post:
   summary: Take the database offline
   description: |-
@@ -19,16 +18,16 @@ post:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Architect
   responses:
-    "200":
+    '200':
       description: Database has been taken offline successfully
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "503":
+    '503':
       description: An error occurred while trying to take the database offline
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
-  - Admin only endpoints
-  - Database Management
+    - Admin only endpoints
+    - Database Management

--- a/docs/api/paths/admin/{db}~_oidc.yaml
+++ b/docs/api/paths/admin/{db}~_oidc.yaml
@@ -1,27 +1,24 @@
-# /{db}/_oidc
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: OpenID Connect authentication initiation via Location header redirect
-  description: 'Called by clients to initiate the OpenID Connect Authorization Code
-    Flow. Redirects to the OpenID Connect provider if successful. '
+  description: 'Called by clients to initiate the OpenID Connect Authorization Code Flow. Redirects to the OpenID Connect provider if successful. '
   parameters:
-  - $ref: ../../components/parameters.yaml#/provider
-  - $ref: ../../components/parameters.yaml#/offline
+    - $ref: ../../components/parameters.yaml#/provider
+    - $ref: ../../components/parameters.yaml#/offline
   responses:
-    "302":
-      description: Successfully connected with the OpenID Connect provider so now
-        redirecting to the requested OIDC provider for authentication.
+    '302':
+      description: Successfully connected with the OpenID Connect provider so now redirecting to the requested OIDC provider for authentication.
       headers:
         Location:
           schema:
             type: string
           description: The link to redirect to so the client can authenticate.
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/OIDC-invalid-provider
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "500":
+    '500':
       $ref: ../../components/responses.yaml#/OIDC-connection
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/admin/{db}~_oidc_callback.yaml
+++ b/docs/api/paths/admin/{db}~_oidc_callback.yaml
@@ -1,30 +1,27 @@
-# /{db}/_oidc_callback
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: OpenID Connect authentication callback
-  description: The callback URL that the client is redirected to after authenticating
-    with the OpenID Connect provider.
+  description: The callback URL that the client is redirected to after authenticating with the OpenID Connect provider.
   parameters:
-  - name: error
-    in: query
-    description: The OpenID Connect error, if any occurred.
-    schema:
-      type: string
-  - $ref: ../../components/parameters.yaml#/oidc-code
-  - $ref: ../../components/parameters.yaml#/provider
-  - $ref: ../../components/parameters.yaml#/oidc-state
+    - name: error
+      in: query
+      description: 'The OpenID Connect error, if any occurred.'
+      schema:
+        type: string
+    - $ref: ../../components/parameters.yaml#/oidc-code
+    - $ref: ../../components/parameters.yaml#/provider
+    - $ref: ../../components/parameters.yaml#/oidc-state
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/OIDC-callback
-    "400":
+    '400':
       description: A problem occurred when reading the callback request body
-    "401":
-      description: An error was received from the OpenID Connect provider. This means
-        the error query parameter was filled.
-    "404":
+    '401':
+      description: An error was received from the OpenID Connect provider. This means the error query parameter was filled.
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "500":
+    '500':
       description: A problem occurred in regards to the token
       content:
         application/json:
@@ -36,4 +33,4 @@ get:
               reason:
                 type: string
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/admin/{db}~_oidc_challenge.yaml
+++ b/docs/api/paths/admin/{db}~_oidc_challenge.yaml
@@ -1,30 +1,24 @@
-# /{db}/_oidc_challenge
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: OpenID Connect authentication initiation via WWW-Authenticate header
-  description: Called by clients to initiate the OpenID Connect Authorization Code
-    Flow. This will establish a connection with the provider, then put the redirect
-    URL in the `WWW-Authenticate` header.
+  description: 'Called by clients to initiate the OpenID Connect Authorization Code Flow. This will establish a connection with the provider, then put the redirect URL in the `WWW-Authenticate` header.'
   parameters:
-  - $ref: ../../components/parameters.yaml#/provider
-  - $ref: ../../components/parameters.yaml#/offline
+    - $ref: ../../components/parameters.yaml#/provider
+    - $ref: ../../components/parameters.yaml#/offline
   responses:
-    "400":
-      description: 'The provider provided is not defined in the Sync Gateway config.
-        If no provided was specified then there is no default provider set. '
-    "401":
-      description: Successfully connected with the OpenID Connect provider so now
-        the client can login.
+    '400':
+      description: 'The provider provided is not defined in the Sync Gateway config. If no provided was specified then there is no default provider set. '
+    '401':
+      description: Successfully connected with the OpenID Connect provider so now the client can login.
       headers:
         WWW-Authenticate:
           schema:
             type: string
           description: The OpenID Connect authentication URL.
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "500":
-      description: Unable to connect and validate with the OpenID Connect provider
-        requested
+    '500':
+      description: Unable to connect and validate with the OpenID Connect provider requested
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/admin/{db}~_oidc_refresh.yaml
+++ b/docs/api/paths/admin/{db}~_oidc_refresh.yaml
@@ -1,25 +1,24 @@
-# /{db}/_oidc_refresh
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: OpenID Connect token refresh
   description: Refresh the OpenID Connect token based on the provided refresh token.
   parameters:
-  - name: refresh_token
-    in: query
-    description: The OpenID Connect refresh token.
-    required: true
-    schema:
-      type: string
-  - $ref: ../../components/parameters.yaml#/provider
+    - name: refresh_token
+      in: query
+      description: The OpenID Connect refresh token.
+      required: true
+      schema:
+        type: string
+    - $ref: ../../components/parameters.yaml#/provider
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/OIDC-callback
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/OIDC-invalid-provider
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "500":
+    '500':
       $ref: ../../components/responses.yaml#/OIDC-connection
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/admin/{db}~_oidc_testing~.well-known~openid-configuration.yaml
+++ b/docs/api/paths/admin/{db}~_oidc_testing~.well-known~openid-configuration.yaml
@@ -1,13 +1,10 @@
-# /{db}/_oidc_testing/.well-known-openid-configuration
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: OpenID Connect mock provider
-  description: Mock an OpenID Connect provider response for testing purposes. This
-    returns a response that is the same structure as what Sync Gateway expects from
-    an OIDC provider after initiating OIDC authentication.
+  description: Mock an OpenID Connect provider response for testing purposes. This returns a response that is the same structure as what Sync Gateway expects from an OIDC provider after initiating OIDC authentication.
   responses:
-    "200":
+    '200':
       description: 'Successfully generated OpenID Connect provider mock response. '
       headers:
         Expiry:
@@ -41,9 +38,9 @@ get:
                 type: string
               token_endpoint_auth_methods_supported:
                 type: string
-    "403":
+    '403':
       $ref: ../../components/responses.yaml#/OIDC-test-provider-disabled
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/admin/{db}~_oidc_testing~authenticate.yaml
+++ b/docs/api/paths/admin/{db}~_oidc_testing~authenticate.yaml
@@ -1,57 +1,54 @@
-# /{db}/_oidc_testing/authenticate
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: OpenID Connect mock login page handler
-  description: Used to handle the login page displayed for the `GET /{db}/_oidc_testing/authorize`
-    endpoint.
+  description: 'Used to handle the login page displayed for the `GET /{db}/_oidc_testing/authorize` endpoint.'
   parameters:
-  - $ref: ../../components/parameters.yaml#/oidc-redirect_uri
-  - $ref: ../../components/parameters.yaml#/oidc-scope
-  - name: username
-    in: query
-    required: true
-    schema:
-      type: string
-  - name: tokenttl
-    in: query
-    required: true
-    schema:
-      type: integer
-  - name: identity-token-formats
-    in: query
-    required: true
-    schema:
-      type: string
-  - name: authenticated
-    in: query
-    required: true
-    schema:
-      type: string
+    - $ref: ../../components/parameters.yaml#/oidc-redirect_uri
+    - $ref: ../../components/parameters.yaml#/oidc-scope
+    - name: username
+      in: query
+      required: true
+      schema:
+        type: string
+    - name: tokenttl
+      in: query
+      required: true
+      schema:
+        type: integer
+    - name: identity-token-formats
+      in: query
+      required: true
+      schema:
+        type: string
+    - name: authenticated
+      in: query
+      required: true
+      schema:
+        type: string
   responses:
-    "302":
+    '302':
       $ref: ../../components/responses.yaml#/OIDC-testing-redirect
-    "403":
+    '403':
       $ref: ../../components/responses.yaml#/OIDC-test-provider-disabled
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - OpenID Connect
+    - OpenID Connect
 post:
   summary: OpenID Connect mock login page handler
-  description: Used to handle the login page displayed for the `GET /{db}/_oidc_testing/authorize`
-    endpoint.
+  description: 'Used to handle the login page displayed for the `GET /{db}/_oidc_testing/authorize` endpoint.'
   parameters:
-  - $ref: ../../components/parameters.yaml#/oidc-redirect_uri
-  - $ref: ../../components/parameters.yaml#/oidc-scope
+    - $ref: ../../components/parameters.yaml#/oidc-redirect_uri
+    - $ref: ../../components/parameters.yaml#/oidc-scope
   requestBody:
     $ref: ../../components/requestBodies.yaml#/OIDC-login-page-handler
   responses:
-    "302":
+    '302':
       $ref: ../../components/responses.yaml#/OIDC-testing-redirect
-    "403":
+    '403':
       $ref: ../../components/responses.yaml#/OIDC-test-provider-disabled
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/admin/{db}~_oidc_testing~authorize.yaml
+++ b/docs/api/paths/admin/{db}~_oidc_testing~authorize.yaml
@@ -1,39 +1,38 @@
-# /{db}/_oidc_testing/authorize
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: OpenID Connect mock login page
   description: Show a mock OpenID Connect login page for the client to log in to.
   parameters:
-  - $ref: ../../components/parameters.yaml#/oidc-scope
+    - $ref: ../../components/parameters.yaml#/oidc-scope
   responses:
-    "200":
+    '200':
       description: OK
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/OIDC-invalid-scope
-    "403":
+    '403':
       $ref: ../../components/responses.yaml#/OIDC-test-provider-disabled
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "500":
+    '500':
       $ref: ../../components/responses.yaml#/OIDC-testing-internal-error
   tags:
-  - OpenID Connect
+    - OpenID Connect
 post:
   summary: OpenID Connect mock login page
   description: Show a mock OpenID Connect login page for the client to log in to.
   parameters:
-  - $ref: ../../components/parameters.yaml#/oidc-scope
+    - $ref: ../../components/parameters.yaml#/oidc-scope
   responses:
-    "200":
+    '200':
       description: OK
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/OIDC-invalid-scope
-    "403":
+    '403':
       $ref: ../../components/responses.yaml#/OIDC-test-provider-disabled
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "500":
+    '500':
       $ref: ../../components/responses.yaml#/OIDC-testing-internal-error
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/admin/{db}~_oidc_testing~certs.yaml
+++ b/docs/api/paths/admin/{db}~_oidc_testing~certs.yaml
@@ -1,11 +1,10 @@
-# /{db}/_oidc_testing/certs
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: OpenID Connect public certificates for signing keys
   description: Return a mock OpenID Connect public key to be used as signing keys.
   responses:
-    "200":
+    '200':
       description: Returned public key successfully
       content:
         application/json:
@@ -30,16 +29,16 @@ get:
                     Algorithm:
                       type: string
                   required:
-                  - Key
-                  - KeyID
-                  - Use
+                    - Key
+                    - KeyID
+                    - Use
             required:
-            - keys
-    "403":
+              - keys
+    '403':
       $ref: ../../components/responses.yaml#/OIDC-test-provider-disabled
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "500":
+    '500':
       description: An error occurred while getting the private RSA key
       content:
         application/json:
@@ -51,4 +50,4 @@ get:
               reason:
                 type: string
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/admin/{db}~_oidc_testing~token.yaml
+++ b/docs/api/paths/admin/{db}~_oidc_testing~token.yaml
@@ -1,6 +1,5 @@
-# /{db}/_oidc_testing/token
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 post:
   summary: OpenID Connect mock token
   description: Return a mock OpenID Connect token for the OIDC authentication flow.
@@ -11,27 +10,24 @@ post:
           type: object
           properties:
             grant_type:
-              description: The grant type of the token to request. Can either be an
-                `authorization_code` or `refresh_token`.
+              description: The grant type of the token to request. Can either be an `authorization_code` or `refresh_token`.
               type: string
             code:
-              description: '**`grant_type=authorization_code` only**: The OpenID Connect
-                authentication token.'
+              description: '**`grant_type=authorization_code` only**: The OpenID Connect authentication token.'
               type: string
             refresh_token:
-              description: '**`grant_type=refresh_token` only**: The OpenID Connect
-                refresh token.'
+              description: '**`grant_type=refresh_token` only**: The OpenID Connect refresh token.'
               type: string
           required:
-          - grant_type
+            - grant_type
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/OIDC-token
-    "400":
+    '400':
       description: Invalid token provided
-    "403":
+    '403':
       $ref: ../../components/responses.yaml#/OIDC-test-provider-disabled
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/admin/{db}~_online.yaml
+++ b/docs/api/paths/admin/{db}~_online.yaml
@@ -1,6 +1,5 @@
-# /{db}/_online
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 post:
   summary: Bring the database online
   description: |-
@@ -29,17 +28,16 @@ post:
               type: integer
               default: 0
   responses:
-    "200":
-      description: Database will be brought online immediately or with the specified
-        delay
-    "404":
+    '200':
+      description: Database will be brought online immediately or with the specified delay
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "503":
+    '503':
       description: An error occurred
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
-  - Admin only endpoints
-  - Database Management
+    - Admin only endpoints
+    - Database Management

--- a/docs/api/paths/admin/{db}~_purge.yaml
+++ b/docs/api/paths/admin/{db}~_purge.yaml
@@ -1,6 +1,5 @@
-# /{db}/_purge
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 post:
   summary: Purge a document
   description: |-
@@ -16,12 +15,6 @@ post:
       application/json:
         schema:
           type: object
-          additionalProperties:
-            type: array
-            items:
-              type: string
-              enum:
-                - '*'
           properties:
             doc_id:
               description: |-
@@ -32,23 +25,27 @@ post:
               items:
                 type: string
                 enum:
+                  - '*'
+          additionalProperties:
+            type: array
+            items:
+              type: string
+              enum:
                 - '*'
         examples:
           Example:
             value:
               doc_id:
-              - '*'
+                - '*'
           Multiple purges example:
             value:
               doc_id_1:
-              - '*'
+                - '*'
               doc_id_2:
-              - '*'
+                - '*'
   responses:
-    "200":
-      description: Attempted documents purge. Check output to verify the documents
-        that were purged. The document IDs will not be listed if they have not been
-        purged (for example, due to no existing).
+    '200':
+      description: 'Attempted documents purge. Check output to verify the documents that were purged. The document IDs will not be listed if they have not been purged (for example, due to no existing).'
       content:
         application/json:
           schema:
@@ -63,29 +60,28 @@ post:
                     enum:
                       - '*'
             required:
-            - purged
+              - purged
           examples:
             Example:
               value:
                 purged:
                   doc_id:
-                  - '*'
+                    - '*'
             Multiple purges example:
               value:
                 purged:
                   doc_id_1:
-                  - '*'
+                    - '*'
                   doc_id_2:
-                  - '*'
-    "400":
-      description: Bad request. This could be due to the documents listed in the request
-        body not having the `["*"]` value for each document ID.
+                    - '*'
+    '400':
+      description: 'Bad request. This could be due to the documents listed in the request body not having the `["*"]` value for each document ID.'
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/HTTP-Error
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Document
+    - Admin only endpoints
+    - Document

--- a/docs/api/paths/admin/{db}~_raw~{docid}.yaml
+++ b/docs/api/paths/admin/{db}~_raw~{docid}.yaml
@@ -1,7 +1,6 @@
-# /{db}/_raw/{docid}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- $ref: ../../components/parameters.yaml#/docid
+  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/docid
 get:
   summary: Get a document with the corresponding metadata
   description: |-
@@ -13,15 +12,14 @@ get:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   parameters:
-  - $ref: ../../components/parameters.yaml#/include_doc
-  - name: redact
-    in: query
-    description: This redacts sensitive parts of the response. Cannot be used when
-      `include_docs=true`
-    schema:
-      type: boolean
+    - $ref: ../../components/parameters.yaml#/include_doc
+    - name: redact
+      in: query
+      description: This redacts sensitive parts of the response. Cannot be used when `include_docs=true`
+      schema:
+        type: boolean
   responses:
-    "200":
+    '200':
       description: Document found successfully
       content:
         application/json:
@@ -55,9 +53,7 @@ get:
                         items:
                           type: number
                       channels:
-                        description: The past channel history. Can contain string
-                          arrays, strings, or be null depending on if and how the
-                          channels where set.
+                        description: 'The past channel history. Can contain string arrays, strings, or be null depending on if and how the channels where set.'
                         type: array
                         items:
                           type: array
@@ -65,8 +61,7 @@ get:
                             type: string
                           nullable: true
                   cas:
-                    description: The document CAS (Concurrent Document Mutations)
-                      number used for document locking.
+                    description: The document CAS (Concurrent Document Mutations) number used for document locking.
                     type: string
                   value_crc32c:
                     description: The documents CRC32 number.
@@ -81,12 +76,10 @@ get:
                           description: The name of the channel.
                           type: string
                         start:
-                          description: The sequence number that document was added
-                            to the channel.
+                          description: The sequence number that document was added to the channel.
                           type: string
                         end:
-                          description: The sequence number the document was removed
-                            from the channel. Omitted if not removed.
+                          description: The sequence number the document was removed from the channel. Omitted if not removed.
                           type: string
                     nullable: true
                   channel_set_history:
@@ -102,27 +95,26 @@ get:
                           type: string
                     nullable: true
                   time_saved:
-                    description: The time and date the document was most recently
-                      changed.
+                    description: The time and date the document was most recently changed.
                     type: string
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Document
+    - Admin only endpoints
+    - Document
 head:
   responses:
-    "200":
+    '200':
       description: Document exists
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Document
+    - Admin only endpoints
+    - Document
   description: |-
     Required Sync Gateway RBAC roles:
     * Sync Gateway Application

--- a/docs/api/paths/admin/{db}~_repair.yaml
+++ b/docs/api/paths/admin/{db}~_repair.yaml
@@ -1,16 +1,15 @@
-# /{db}/_repair
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 post:
-  summary: ""
+  summary: ''
   description: |-
     This endpoint is disabled.
 
     Required Sync Gateway RBAC roles:
     * Sync Gateway Architect
   responses:
-    "500":
+    '500':
       description: This endpoint is disabled
   tags:
-  - Admin only endpoints
-  - Unsupported
+    - Admin only endpoints
+    - Unsupported

--- a/docs/api/paths/admin/{db}~_replicationStatus~.yaml
+++ b/docs/api/paths/admin/{db}~_replicationStatus~.yaml
@@ -1,6 +1,5 @@
-# /{db}/_replicationStatus
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: Get all replication statuses
   description: |-
@@ -9,12 +8,12 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Replicator
   parameters:
-  - $ref: ../../components/parameters.yaml#/replication-active-only
-  - $ref: ../../components/parameters.yaml#/replication-local-only
-  - $ref: ../../components/parameters.yaml#/replication-include-error
-  - $ref: ../../components/parameters.yaml#/replication-include-config
+    - $ref: ../../components/parameters.yaml#/replication-active-only
+    - $ref: ../../components/parameters.yaml#/replication-local-only
+    - $ref: ../../components/parameters.yaml#/replication-include-error
+    - $ref: ../../components/parameters.yaml#/replication-include-config
   responses:
-    "200":
+    '200':
       description: Successfully retrieved all replication statuses.
       content:
         application/json:
@@ -22,20 +21,20 @@ get:
             type: array
             items:
               $ref: ../../components/schemas.yaml#/Replication-status
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
   tags:
-  - Admin only endpoints
-  - Replication
+    - Admin only endpoints
+    - Replication
 head:
   responses:
-    "200":
+    '200':
       description: OK
-    "400":
+    '400':
       description: Bad Request
   tags:
-  - Admin only endpoints
-  - Replication
+    - Admin only endpoints
+    - Replication
   description: |-
     Required Sync Gateway RBAC roles:
     * Sync Gateway Replicator

--- a/docs/api/paths/admin/{db}~_replicationStatus~{replicationid}.yaml
+++ b/docs/api/paths/admin/{db}~_replicationStatus~{replicationid}.yaml
@@ -1,7 +1,6 @@
-# /{db}/_replicationStatus/{replicationid}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- $ref: ../../components/parameters.yaml#/replicationid
+  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/replicationid
 get:
   summary: Get replication status
   description: |-
@@ -10,28 +9,28 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Replicator
   parameters:
-  - $ref: ../../components/parameters.yaml#/replication-active-only
-  - $ref: ../../components/parameters.yaml#/replication-local-only
-  - $ref: ../../components/parameters.yaml#/replication-include-error
-  - $ref: ../../components/parameters.yaml#/replication-include-config
+    - $ref: ../../components/parameters.yaml#/replication-active-only
+    - $ref: ../../components/parameters.yaml#/replication-local-only
+    - $ref: ../../components/parameters.yaml#/replication-include-error
+    - $ref: ../../components/parameters.yaml#/replication-include-config
   responses:
-    "200":
+    '200':
       description: Successfully retrieved replication status
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/Replication-status
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       description: Could not find replication
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
-  - Admin only endpoints
-  - Replication
+    - Admin only endpoints
+    - Replication
 put:
   summary: Control a replication state
   description: |-
@@ -45,47 +44,47 @@ put:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Replicator
   parameters:
-  - name: action
-    in: query
-    description: The target state to put the replicator into.
-    required: true
-    schema:
-      type: string
-      enum:
-      - start
-      - stop
-      - reset
+    - name: action
+      in: query
+      description: The target state to put the replicator into.
+      required: true
+      schema:
+        type: string
+        enum:
+          - start
+          - stop
+          - reset
   responses:
-    "200":
+    '200':
       description: Successfully changed target state of replicator
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/Replication-status
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Replication
+    - Admin only endpoints
+    - Replication
 head:
   responses:
-    "200":
+    '200':
       description: Replication exists
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Replication
+    - Admin only endpoints
+    - Replication
   summary: Check if replication exists
   parameters:
-  - $ref: ../../components/parameters.yaml#/replication-active-only
-  - $ref: ../../components/parameters.yaml#/replication-local-only
-  - $ref: ../../components/parameters.yaml#/replication-include-error
-  - $ref: ../../components/parameters.yaml#/replication-include-config
+    - $ref: ../../components/parameters.yaml#/replication-active-only
+    - $ref: ../../components/parameters.yaml#/replication-local-only
+    - $ref: ../../components/parameters.yaml#/replication-include-error
+    - $ref: ../../components/parameters.yaml#/replication-include-config
   description: |-
     Check if a replication exists.
 

--- a/docs/api/paths/admin/{db}~_replication~.yaml
+++ b/docs/api/paths/admin/{db}~_replication~.yaml
@@ -1,6 +1,5 @@
-# /{db}/replication
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: Get all replication configurations
   description: |-
@@ -9,7 +8,7 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Replicator
   responses:
-    "200":
+    '200':
       description: |-
         Retrieved replication configurations successfully.
         The `assigned_node` fields will end with `(local)` or `(non-local)` depending on if the replication is running on this Sync Gateway node.
@@ -17,11 +16,11 @@ get:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/All-replications
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Replication
+    - Admin only endpoints
+    - Replication
 post:
   summary: Upsert a replication
   description: |-
@@ -34,26 +33,26 @@ post:
   requestBody:
     $ref: ../../components/requestBodies.yaml#/Replication-upsert
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/Replicator-updated
-    "201":
+    '201':
       $ref: ../../components/responses.yaml#/Replicator-created
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Replication
+    - Admin only endpoints
+    - Replication
 head:
   responses:
-    "200":
+    '200':
       description: OK
-    "404":
+    '404':
       description: Not Found
   tags:
-  - Admin only endpoints
-  - Replication
+    - Admin only endpoints
+    - Replication
   description: |-
     Required Sync Gateway RBAC roles:
     * Sync Gateway Replicator

--- a/docs/api/paths/admin/{db}~_replication~{replicationid}.yaml
+++ b/docs/api/paths/admin/{db}~_replication~{replicationid}.yaml
@@ -1,7 +1,6 @@
-# /{db}/_replication/{replicationid}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- $ref: ../../components/parameters.yaml#/replicationid
+  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/replicationid
 get:
   summary: Get a replication configuration
   description: |-
@@ -10,17 +9,17 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Replicator
   responses:
-    "200":
+    '200':
       description: Successfully retrieved the replication configuration
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/Retrieved-replication
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Replication
+    - Admin only endpoints
+    - Replication
 put:
   summary: Upsert a replication
   description: |-
@@ -35,17 +34,17 @@ put:
   requestBody:
     $ref: ../../components/requestBodies.yaml#/Replication-upsert
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/Replicator-updated
-    "201":
+    '201':
       $ref: ../../components/responses.yaml#/Replicator-created
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Replication
+    - Admin only endpoints
+    - Replication
 delete:
   summary: Stop and delete a replication
   description: |-
@@ -54,24 +53,24 @@ delete:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Replicator
   responses:
-    "200":
+    '200':
       description: Replication successfully deleted
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Replication
+    - Admin only endpoints
+    - Replication
 head:
   responses:
-    "200":
+    '200':
       description: Replication exists
-    "404":
+    '404':
       description: Replication does not exist
   tags:
-  - Admin only endpoints
-  - Replication
+    - Admin only endpoints
+    - Replication
   summary: Check if a replication exists
   description: |-
     Check if a replication exists.

--- a/docs/api/paths/admin/{db}~_resync.yaml
+++ b/docs/api/paths/admin/{db}~_resync.yaml
@@ -1,6 +1,5 @@
-# /{db}/_resync
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: Get resync status
   description: |-
@@ -9,17 +8,17 @@ get:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Architect
   responses:
-    "200":
+    '200':
       description: successfully retrieved the most recent resync operation status
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/Resync-status
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Database Management
+    - Admin only endpoints
+    - Database Management
 post:
   summary: Start or stop Resync
   description: |
@@ -39,34 +38,33 @@ post:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Architect
   parameters:
-  - name: action
-    in: query
-    description: This is whether to start a new resync job or stop an existing one.
-    schema:
-      type: string
-      default: start
-      enum:
-      - start
-      - stop
-  - name: regenerate_sequences
-    in: query
-    description: '**Use this only when requested to do so by the Couchbase support
-      team** This request will regenerate the sequence numbers for each document processed.'
-    schema:
-      type: boolean
+    - name: action
+      in: query
+      description: This is whether to start a new resync job or stop an existing one.
+      schema:
+        type: string
+        default: start
+        enum:
+          - start
+          - stop
+    - name: regenerate_sequences
+      in: query
+      description: '**Use this only when requested to do so by the Couchbase support team** This request will regenerate the sequence numbers for each document processed.'
+      schema:
+        type: boolean
   responses:
-    "200":
+    '200':
       description: successfully changed the status of the resync operation
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/Resync-status
-    "503":
+    '503':
       description: Service Unavailable
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
-  - Admin only endpoints
-  - Database Management
+    - Admin only endpoints
+    - Database Management

--- a/docs/api/paths/admin/{db}~_revs_diff.yaml
+++ b/docs/api/paths/admin/{db}~_revs_diff.yaml
@@ -1,4 +1,3 @@
-# /{db}/_revs_diff
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:
@@ -15,13 +14,12 @@ post:
           type: object
           properties:
             docid:
-              description: The document ID with an array of revisions to use for the
-                comparison.
+              description: The document ID with an array of revisions to use for the comparison.
               type: array
               items:
                 type: string
   responses:
-    "200":
+    '200':
       description: Comparisons successful
       content:
         application/json:
@@ -33,18 +31,16 @@ post:
                 type: object
                 properties:
                   missing:
-                    description: The revisions that are not in the database (and therefore
-                      `missing`).
+                    description: The revisions that are not in the database (and therefore `missing`).
                     type: array
                     items:
                       type: string
                   possible_ancestors:
-                    description: An array of known revisions that might be the recent
-                      ancestors.
+                    description: An array of known revisions that might be the recent ancestors.
                     type: array
                     items:
                       type: string
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Management

--- a/docs/api/paths/admin/{db}~_revtree~{docid}.yaml
+++ b/docs/api/paths/admin/{db}~_revtree~{docid}.yaml
@@ -1,7 +1,6 @@
-# /{db}/_revtree/{docid}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- $ref: ../../components/parameters.yaml#/docid
+  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/docid
 get:
   summary: Revision tree structure in Graphviz Dot format | Unsupported
   description: |-
@@ -18,16 +17,15 @@ get:
 
     **Note: This endpoint is useful for debugging purposes only. It is not officially supported.**
   responses:
-    "200":
+    '200':
       description: Found document
       content:
         application/json:
           schema:
             type: string
-          example: digraph graphname{"1-d4d949b7feafc8c31215684baa45b6cd" -> "2-4f3f24143ea43d85a9a340ac016fdfc4";
-            }
-    "404":
+          example: 'digraph graphname{"1-d4d949b7feafc8c31215684baa45b6cd" -> "2-4f3f24143ea43d85a9a340ac016fdfc4"; }'
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Unsupported
+    - Admin only endpoints
+    - Unsupported

--- a/docs/api/paths/admin/{db}~_role~.yaml
+++ b/docs/api/paths/admin/{db}~_role~.yaml
@@ -1,6 +1,5 @@
-# /{db}/_role/
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: Get all names of the roles
   description: |-
@@ -11,7 +10,7 @@ get:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   responses:
-    "200":
+    '200':
       description: Roles retrieved successfully
       content:
         application/json:
@@ -23,13 +22,13 @@ get:
             minItems: 0
             uniqueItems: true
           example:
-          - Administrator
-          - Moderator
-    "404":
+            - Administrator
+            - Moderator
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Database Security
+    - Admin only endpoints
+    - Database Security
 post:
   summary: Create a new role
   description: |-
@@ -41,24 +40,24 @@ post:
   requestBody:
     $ref: ../../components/requestBodies.yaml#/Role
   responses:
-    "201":
+    '201':
       description: New role created successfully
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "409":
+    '409':
       $ref: ../../components/responses.yaml#/Conflict
   tags:
-  - Admin only endpoints
-  - Database Security
+    - Admin only endpoints
+    - Database Security
 head:
   responses:
-    "200":
+    '200':
       description: OK
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Database Security
+    - Admin only endpoints
+    - Database Security
   description: |-
     Required Sync Gateway RBAC roles:
     * Sync Gateway Architect

--- a/docs/api/paths/admin/{db}~_role~{name}.yaml
+++ b/docs/api/paths/admin/{db}~_role~{name}.yaml
@@ -1,7 +1,6 @@
-# /{db}/_role/{name}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- $ref: ../../components/parameters.yaml#/role-name
+  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/role-name
 get:
   summary: Get a role
   description: |-
@@ -12,13 +11,13 @@ get:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/Role
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Database Security
+    - Admin only endpoints
+    - Database Security
 put:
   summary: Upsert a role
   description: |-
@@ -30,15 +29,15 @@ put:
   requestBody:
     $ref: ../../components/requestBodies.yaml#/Role
   responses:
-    "200":
+    '200':
       description: OK
-    "201":
+    '201':
       description: Created
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Database Security
+    - Admin only endpoints
+    - Database Security
 delete:
   summary: Delete a role
   description: |-
@@ -48,22 +47,22 @@ delete:
     * Sync Gateway Architect
     * Sync Gateway Application
   responses:
-    "200":
+    '200':
       description: OK
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Database Security
+    - Admin only endpoints
+    - Database Security
 head:
   responses:
-    "200":
+    '200':
       description: Role exists
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Database Security
+    - Admin only endpoints
+    - Database Security
   description: |-
     Check if the role exists by checking the status code.
 

--- a/docs/api/paths/admin/{db}~_session.yaml
+++ b/docs/api/paths/admin/{db}~_session.yaml
@@ -1,16 +1,15 @@
-# /{db}/_session
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: Get information about the current user
   description: This will get the information about the current user.
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/User-session-information
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Session
+    - Session
 post:
   summary: Create a new user session
   description: |-
@@ -32,10 +31,10 @@ post:
               description: User name to generate the session for.
               type: string
             ttl:
-              description: 'Time until the session expires. Uses default value of 24 hours if left blank.'
+              description: Time until the session expires. Uses default value of 24 hours if left blank.
               type: integer
   responses:
-    "200":
+    '200':
       description: Session created successfully. Returned body is dependant on if using Public or Admin APIs.
       content:
         application/json:
@@ -43,32 +42,31 @@ post:
             type: object
             properties:
               session_id:
-                description: 'The ID of the session. This is the value that would
-                  be put in to the cookie to keep the user authenticated.'
+                description: The ID of the session. This is the value that would be put in to the cookie to keep the user authenticated.
                 type: string
               expires:
-                description: 'The date and time the cookie expires.'
+                description: The date and time the cookie expires.
                 type: string
               cookie_name:
-                description: 'The name of the cookie that would be used to store the users session.'
+                description: The name of the cookie that would be used to store the users session.
                 type: string
           examples:
             Example:
               value:
                 session_id: c5af80a039db4ed9d2b6865576b6999935282689
-                expires: "2022-01-21T15:24:44Z"
+                expires: '2022-01-21T15:24:44Z'
                 cookie_name: SyncGatewaySession
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/Invalid-CORS
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Session
+    - Session
 head:
   responses:
-    "200":
+    '200':
       description: OK
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Session
+    - Session

--- a/docs/api/paths/admin/{db}~_session~{sessionid}.yaml
+++ b/docs/api/paths/admin/{db}~_session~{sessionid}.yaml
@@ -1,7 +1,6 @@
-# /{db}/_session/{sessionid}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- $ref: ../../components/parameters.yaml#/sessionid
+  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/sessionid
 get:
   summary: Get session information
   description: |-
@@ -12,12 +11,12 @@ get:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/User-session-information
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
+    - Admin only endpoints
 delete:
   summary: Remove session
   description: |-
@@ -27,10 +26,10 @@ delete:
     * Sync Gateway Architect
     * Sync Gateway Application
   responses:
-    "200":
+    '200':
       description: Successfully removed the user session
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Session
+    - Admin only endpoints
+    - Session

--- a/docs/api/paths/admin/{db}~_user~.yaml
+++ b/docs/api/paths/admin/{db}~_user~.yaml
@@ -1,6 +1,5 @@
-# /{db}/_user/
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: Get all the names of the users
   description: |-
@@ -14,7 +13,7 @@ get:
     - $ref: ../../components/parameters.yaml#/usersNameOnly
     - $ref: ../../components/parameters.yaml#/usersLimit
   responses:
-    "200":
+    '200':
       description: Users retrieved successfully
       content:
         application/json:
@@ -24,13 +23,13 @@ get:
             items:
               type: string
           example:
-          - Alice
-          - Bob
-    "404":
+            - Alice
+            - Bob
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Database Security
+    - Admin only endpoints
+    - Database Security
 post:
   summary: Create a new user
   description: |-
@@ -42,24 +41,24 @@ post:
   requestBody:
     $ref: ../../components/requestBodies.yaml#/User
   responses:
-    "201":
+    '201':
       description: New user created successfully
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "409":
+    '409':
       $ref: ../../components/responses.yaml#/Conflict
   tags:
-  - Admin only endpoints
-  - Database Security
+    - Admin only endpoints
+    - Database Security
 head:
   responses:
-    "200":
+    '200':
       description: OK
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Database Security
+    - Admin only endpoints
+    - Database Security
   description: |-
     Required Sync Gateway RBAC roles:
     * Sync Gateway Architect

--- a/docs/api/paths/admin/{db}~_user~{name}.yaml
+++ b/docs/api/paths/admin/{db}~_user~{name}.yaml
@@ -1,7 +1,6 @@
-# /{db}/_user/{name}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- $ref: ../../components/parameters.yaml#/user-name
+  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/user-name
 get:
   summary: Get a user
   description: |-
@@ -12,13 +11,13 @@ get:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/User
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Database Security
+    - Admin only endpoints
+    - Database Security
 put:
   summary: Upsert a user
   description: |-
@@ -30,15 +29,15 @@ put:
   requestBody:
     $ref: ../../components/requestBodies.yaml#/User
   responses:
-    "200":
+    '200':
       description: Existing user modified successfully
-    "201":
+    '201':
       description: New user created
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Database Security
+    - Admin only endpoints
+    - Database Security
 delete:
   summary: Delete a user
   description: |-
@@ -48,22 +47,22 @@ delete:
     * Sync Gateway Architect
     * Sync Gateway Application
   responses:
-    "200":
+    '200':
       description: User deleted successfully
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Database Security
+    - Admin only endpoints
+    - Database Security
 head:
   responses:
-    "200":
+    '200':
       description: User exists
-    "404":
+    '404':
       description: Not Found
   tags:
-  - Admin only endpoints
-  - Database Security
+    - Admin only endpoints
+    - Database Security
   summary: Check if user exists
   description: |-
     Check if the user exists by checking the status code.

--- a/docs/api/paths/admin/{db}~_user~{name}~_session.yaml
+++ b/docs/api/paths/admin/{db}~_user~{name}~_session.yaml
@@ -1,7 +1,6 @@
-# /{db}/_user/{name}/_session
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- $ref: ../../components/parameters.yaml#/user-name
+  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/user-name
 delete:
   summary: Remove all of a users sessions
   description: |-
@@ -13,10 +12,10 @@ delete:
     * Sync Gateway Architect
     * Sync Gateway Application
   responses:
-    "200":
+    '200':
       description: User now has no sessions
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Session
+    - Admin only endpoints
+    - Session

--- a/docs/api/paths/admin/{db}~_user~{name}~_session~{sessionid}.yaml
+++ b/docs/api/paths/admin/{db}~_user~{name}~_session~{sessionid}.yaml
@@ -1,8 +1,7 @@
-# /{db}/_user/{name}/_session/{sessionid}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- $ref: ../../components/parameters.yaml#/user-name
-- $ref: ../../components/parameters.yaml#/sessionid
+  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/user-name
+  - $ref: ../../components/parameters.yaml#/sessionid
 delete:
   summary: Remove session with user validation
   description: |-
@@ -12,11 +11,10 @@ delete:
     * Sync Gateway Architect
     * Sync Gateway Application
   responses:
-    "200":
-      description: Session has been successfully removed as the user was associated
-        with the session
-    "404":
+    '200':
+      description: Session has been successfully removed as the user was associated with the session
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Admin only endpoints
-  - Session
+    - Admin only endpoints
+    - Session

--- a/docs/api/paths/admin/{db}~_view~{view}.yaml
+++ b/docs/api/paths/admin/{db}~_view~{view}.yaml
@@ -1,7 +1,6 @@
-# /{db}/_view/{view}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- $ref: ../../components/parameters.yaml#/view
+  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/view
 get:
   summary: Query a view on the default design document | Unsupported
   description: |-
@@ -13,23 +12,23 @@ get:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   parameters:
-  - $ref: ../../components/parameters.yaml#/inclusive_end
-  - $ref: ../../components/parameters.yaml#/descending
-  - $ref: ../../components/parameters.yaml#/include_docs-cbs3
-  - $ref: ../../components/parameters.yaml#/reduce
-  - $ref: ../../components/parameters.yaml#/group
-  - $ref: ../../components/parameters.yaml#/skip
-  - $ref: ../../components/parameters.yaml#/limit
-  - $ref: ../../components/parameters.yaml#/group_level
-  - $ref: ../../components/parameters.yaml#/startkey_docid
-  - $ref: ../../components/parameters.yaml#/endkey_docid
-  - $ref: ../../components/parameters.yaml#/stale
-  - $ref: ../../components/parameters.yaml#/startkey
-  - $ref: ../../components/parameters.yaml#/endkey
-  - $ref: ../../components/parameters.yaml#/key
-  - $ref: ../../components/parameters.yaml#/keys
+    - $ref: ../../components/parameters.yaml#/inclusive_end
+    - $ref: ../../components/parameters.yaml#/descending
+    - $ref: ../../components/parameters.yaml#/include_docs-cbs3
+    - $ref: ../../components/parameters.yaml#/reduce
+    - $ref: ../../components/parameters.yaml#/group
+    - $ref: ../../components/parameters.yaml#/skip
+    - $ref: ../../components/parameters.yaml#/limit
+    - $ref: ../../components/parameters.yaml#/group_level
+    - $ref: ../../components/parameters.yaml#/startkey_docid
+    - $ref: ../../components/parameters.yaml#/endkey_docid
+    - $ref: ../../components/parameters.yaml#/stale
+    - $ref: ../../components/parameters.yaml#/startkey
+    - $ref: ../../components/parameters.yaml#/endkey
+    - $ref: ../../components/parameters.yaml#/key
+    - $ref: ../../components/parameters.yaml#/keys
   responses:
-    "200":
+    '200':
       description: Returned view successfully
       content:
         application/json:
@@ -61,11 +60,11 @@ get:
                     Reason:
                       type: string
             required:
-            - total_rows
-            - rows
-    "403":
+              - total_rows
+              - rows
+    '403':
       description: Forbidden
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Unsupported
+    - Unsupported

--- a/docs/api/paths/admin/{db}~{docid}.yaml
+++ b/docs/api/paths/admin/{db}~{docid}.yaml
@@ -1,7 +1,6 @@
-# /{db}/{docid}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- $ref: ../../components/parameters.yaml#/docid
+  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/docid
 get:
   summary: Get a document
   description: |-
@@ -11,16 +10,16 @@ get:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   parameters:
-  - $ref: ../../components/parameters.yaml#/rev
-  - $ref: ../../components/parameters.yaml#/open_revs
-  - $ref: ../../components/parameters.yaml#/show_exp
-  - $ref: ../../components/parameters.yaml#/revs_from
-  - $ref: ../../components/parameters.yaml#/atts_since
-  - $ref: ../../components/parameters.yaml#/revs_limit
-  - $ref: ../../components/parameters.yaml#/includeAttachments
-  - $ref: ../../components/parameters.yaml#/replicator2
+    - $ref: ../../components/parameters.yaml#/rev
+    - $ref: ../../components/parameters.yaml#/open_revs
+    - $ref: ../../components/parameters.yaml#/show_exp
+    - $ref: ../../components/parameters.yaml#/revs_from
+    - $ref: ../../components/parameters.yaml#/atts_since
+    - $ref: ../../components/parameters.yaml#/revs_limit
+    - $ref: ../../components/parameters.yaml#/includeAttachments
+    - $ref: ../../components/parameters.yaml#/replicator2
   responses:
-    "200":
+    '200':
       description: Document found and returned successfully
       headers:
         Etag:
@@ -31,7 +30,6 @@ get:
         application/json:
           schema:
             type: object
-            additionalProperties: true
             properties:
               _id:
                 description: The ID of the document.
@@ -39,25 +37,25 @@ get:
               _rev:
                 description: The revision ID of the document.
                 type: string
+            additionalProperties: true
           example:
             FailedLoginAttempts: 5
             Friends:
-            - Bob
+              - Bob
             _id: AliceSettings
             _rev: 1-64d4a1f179db5c1848fe52967b47c166
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/invalid-doc-id
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "501":
-      description: Not Implemented. It is likely this error was caused due to trying
-        to use an enterprise-only feature on the community edition.
+    '501':
+      description: Not Implemented. It is likely this error was caused due to trying to use an enterprise-only feature on the community edition.
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
-  - Document
+    - Document
 put:
   summary: Upsert a document
   description: |-
@@ -72,39 +70,38 @@ put:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Application
   parameters:
-  - $ref: ../../components/parameters.yaml#/roundtrip
-  - $ref: ../../components/parameters.yaml#/replicator2
-  - $ref: ../../components/parameters.yaml#/new_edits
-  - $ref: ../../components/parameters.yaml#/rev
-  - $ref: ../../components/parameters.yaml#/If-Match
+    - $ref: ../../components/parameters.yaml#/roundtrip
+    - $ref: ../../components/parameters.yaml#/replicator2
+    - $ref: ../../components/parameters.yaml#/new_edits
+    - $ref: ../../components/parameters.yaml#/rev
+    - $ref: ../../components/parameters.yaml#/If-Match
   requestBody:
     content:
       application/json:
         schema:
           $ref: ../../components/schemas.yaml#/Document
   responses:
-    "201":
+    '201':
       description: Created
       headers:
         Etag:
           schema:
             type: string
-          description: The revision of the written document. Not set if query option
-            `new_edits` is true.
+          description: The revision of the written document. Not set if query option `new_edits` is true.
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/New-revision
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "409":
+    '409':
       $ref: ../../components/responses.yaml#/Conflict
-    "415":
+    '415':
       $ref: ../../components/responses.yaml#/Invalid-content-type
   tags:
-  - Document
+    - Document
 delete:
   summary: Delete a document
   description: |-
@@ -115,37 +112,37 @@ delete:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Application
   parameters:
-  - $ref: ../../components/parameters.yaml#/rev
-  - $ref: ../../components/parameters.yaml#/If-Match
+    - $ref: ../../components/parameters.yaml#/rev
+    - $ref: ../../components/parameters.yaml#/If-Match
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/New-revision
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document
 head:
   responses:
-    "200":
+    '200':
       description: Document exists
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/invalid-doc-id
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document
   summary: Check if a document exists
   parameters:
-  - $ref: ../../components/parameters.yaml#/rev
-  - $ref: ../../components/parameters.yaml#/open_revs
-  - $ref: ../../components/parameters.yaml#/show_exp
-  - $ref: ../../components/parameters.yaml#/revs_from
-  - $ref: ../../components/parameters.yaml#/atts_since
-  - $ref: ../../components/parameters.yaml#/revs_limit
-  - $ref: ../../components/parameters.yaml#/includeAttachments
-  - $ref: ../../components/parameters.yaml#/replicator2
+    - $ref: ../../components/parameters.yaml#/rev
+    - $ref: ../../components/parameters.yaml#/open_revs
+    - $ref: ../../components/parameters.yaml#/show_exp
+    - $ref: ../../components/parameters.yaml#/revs_from
+    - $ref: ../../components/parameters.yaml#/atts_since
+    - $ref: ../../components/parameters.yaml#/revs_limit
+    - $ref: ../../components/parameters.yaml#/includeAttachments
+    - $ref: ../../components/parameters.yaml#/replicator2
   description: |-
     Return a status code based on if the document exists or not.
 

--- a/docs/api/paths/admin/{db}~{docid}~{attach}.yaml
+++ b/docs/api/paths/admin/{db}~{docid}~{attach}.yaml
@@ -1,15 +1,12 @@
-# /{db}/{docid}/{attach}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- $ref: ../../components/parameters.yaml#/docid
-- name: attach
-  in: path
-  description: The attachment name. This value must be URL encoded. For example, if
-    the attachment name is `blob_/avatar`, the path component passed to the URL should
-    be `blob_%2Favatar` (tested with [URLEncoder](https://www.urlencoder.org/)).
-  required: true
-  schema:
-    type: string
+  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/docid
+  - name: attach
+    in: path
+    description: 'The attachment name. This value must be URL encoded. For example, if the attachment name is `blob_/avatar`, the path component passed to the URL should be `blob_%2Favatar` (tested with [URLEncoder](https://www.urlencoder.org/)).'
+    required: true
+    schema:
+      type: string
 get:
   summary: Get an attachment from a document
   description: |-
@@ -23,27 +20,27 @@ get:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   parameters:
-  - $ref: ../../components/parameters.yaml#/rev
-  - name: content_encoding
-    in: query
-    description: Set to false to disable the `Content-Encoding` response header.
-    schema:
-      type: boolean
-      default: "true"
-  - name: Range
-    in: header
-    description: RFC-2616 bytes range header.
-    schema:
-      type: string
-    example: bytes=123-456
-  - name: meta
-    in: query
-    description: Return only the metadata of the attachment in the response body.
-    schema:
-      type: boolean
-      default: "false"
+    - $ref: ../../components/parameters.yaml#/rev
+    - name: content_encoding
+      in: query
+      description: Set to false to disable the `Content-Encoding` response header.
+      schema:
+        type: boolean
+        default: 'true'
+    - name: Range
+      in: header
+      description: RFC-2616 bytes range header.
+      schema:
+        type: string
+      example: bytes=123-456
+    - name: meta
+      in: query
+      description: Return only the metadata of the attachment in the response body.
+      schema:
+        type: boolean
+        default: 'false'
   responses:
-    "200":
+    '200':
       description: Found attachment successfully.
       headers:
         Content-Length:
@@ -54,14 +51,14 @@ get:
           schema:
             type: string
           description: 'The attachment digest. Does not get set when request `meta=true`. '
-    "206":
+    '206':
       description: Partial attachment content returned
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "416":
+    '416':
       description: Requested range exceeds content length
   tags:
-  - Document
+    - Document
 put:
   summary: Create or update an attachment on a document
   description: |-
@@ -76,23 +73,22 @@ put:
     Required Sync Gateway RBAC roles:
     * Sync Gateway Application
   parameters:
-  - name: Content-Type
-    in: header
-    description: The content type of the attachment.
-    schema:
-      type: string
-      default: application/octet-stream
-  - name: rev
-    in: query
-    description: The existing document revision ID to modify. Required only when modifying
-      an existing document.
-    schema:
-      type: string
-  - name: If-Match
-    in: header
-    description: An alternative way of specifying the document revision ID.
-    schema:
-      type: string
+    - name: Content-Type
+      in: header
+      description: The content type of the attachment.
+      schema:
+        type: string
+        default: application/octet-stream
+    - name: rev
+      in: query
+      description: The existing document revision ID to modify. Required only when modifying an existing document.
+      schema:
+        type: string
+    - name: If-Match
+      in: header
+      description: An alternative way of specifying the document revision ID.
+      schema:
+        type: string
   requestBody:
     description: The attachment data
     content:
@@ -101,7 +97,7 @@ put:
           description: The content to store in the body
           type: string
   responses:
-    "201":
+    '201':
       description: Attachment added to new or existing document successfully
       headers:
         Etag:
@@ -112,15 +108,15 @@ put:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/New-revision
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "409":
+    '409':
       $ref: ../../components/responses.yaml#/Conflict
   tags:
-  - Document
+    - Document
 head:
   responses:
-    "200":
+    '200':
       description: The document exists and the attachment exists on the document.
       headers:
         Content-Length:
@@ -131,10 +127,10 @@ head:
           schema:
             type: string
           description: The attachment digest.
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document
   summary: Check if attachment exists
   description: |-
     This request check if the attachment exists on the specified document.
@@ -143,4 +139,4 @@ head:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   parameters:
-  - $ref: ../../components/parameters.yaml#/rev
+    - $ref: ../../components/parameters.yaml#/rev

--- a/docs/api/paths/admin/~.yaml
+++ b/docs/api/paths/admin/~.yaml
@@ -1,9 +1,8 @@
-# /
 get:
   summary: Get server information
   description: Returns information about the Sync Gateway node.
   responses:
-    "200":
+    '200':
       description: Returned server information
       content:
         application/json:
@@ -11,8 +10,7 @@ get:
             type: object
             properties:
               ADMIN:
-                description: '`true` if the request is from the Admin API - otherwise
-                  omitted.'
+                description: '`true` if the request is from the Admin API - otherwise omitted.'
                 type: boolean
                 example: true
               couchdb:
@@ -34,7 +32,7 @@ get:
                     type: string
                     example: 3.1
                 required:
-                - name
+                  - name
               version:
                 description: |-
                   Product version, including the build number and edition (i.e. `EE` or `CE`)
@@ -42,15 +40,15 @@ get:
                 type: string
                 example: Couchbase Sync Gateway/3.1.0(1;a765231) EE
             required:
-            - couchdb
-            - vendor
+              - couchdb
+              - vendor
   tags:
-  - Server
+    - Server
 head:
   responses:
-    "200":
+    '200':
       description: Server is online
   tags:
-  - Server
+    - Server
   summary: Check if server online
   description: Check if the server is online by checking the status code of response.

--- a/docs/api/paths/metric/_expvar.yaml
+++ b/docs/api/paths/metric/_expvar.yaml
@@ -10,7 +10,7 @@ get:
     * Sync Gateway Dev Ops
     * External Stats Reader
   responses:
-    "200":
+    '200':
       description: Returned statistics
       content:
         application/javascript:

--- a/docs/api/paths/metric/_metrics.yaml
+++ b/docs/api/paths/metric/_metrics.yaml
@@ -8,11 +8,11 @@ get:
     * Sync Gateway Dev Ops
     * External Stats Reader
   responses:
-    "200":
+    '200':
       description: Successfully returned stats
       content:
         text/plain:
           schema:
             type: string
   tags:
-  - Prometheus
+    - Prometheus

--- a/docs/api/paths/public/{db}~.yaml
+++ b/docs/api/paths/public/{db}~.yaml
@@ -1,12 +1,10 @@
-# /{db}/
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: Get database information
-  description: |-
-    Retrieve information about the database.
+  description: Retrieve information about the database.
   responses:
-    "200":
+    '200':
       description: Successfully returned database information
       content:
         application/json:
@@ -32,13 +30,11 @@ get:
                 type: integer
                 example: 123456
               instance_start_time:
-                description: Timestamp of when the database opened, in microseconds
-                  since the Unix epoch.
+                description: 'Timestamp of when the database opened, in microseconds since the Unix epoch.'
                 type: integer
                 example: 1644600082279583
               compact_running:
-                description: Indicates whether database compaction is currently taking
-                  place or not.
+                description: Indicates whether database compaction is currently taking place or not.
                 type: boolean
               purge_seq:
                 description: Unused field.
@@ -49,20 +45,19 @@ get:
                 type: number
                 default: 0
               state:
-                description: The database state. Change using the `/{db}/_offline`
-                  and `/{db}/_online` endpoints.
+                description: 'The database state. Change using the `/{db}/_offline` and `/{db}/_online` endpoints.'
                 type: string
                 enum:
-                - Online
-                - Offline
+                  - Online
+                  - Offline
               server_uuid:
                 description: Unique server identifier.
                 type: string
                 example: 995618a6a6cc9ac79731bd13240e19b5
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Database Management
+    - Database Management
 post:
   summary: Create a new document
   description: |-
@@ -72,14 +67,14 @@ post:
 
     A document can have a maximum size of 20MB.
   parameters:
-  - $ref: ../../components/parameters.yaml#/roundtrip
+    - $ref: ../../components/parameters.yaml#/roundtrip
   requestBody:
     content:
       application/json:
         schema:
           $ref: ../../components/schemas.yaml#/Document
   responses:
-    "200":
+    '200':
       description: New document revision created successfully.
       headers:
         Etag:
@@ -94,24 +89,23 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/New-revision
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "409":
+    '409':
       $ref: ../../components/responses.yaml#/Conflict
-    "415":
+    '415':
       $ref: ../../components/responses.yaml#/Invalid-content-type
   tags:
-  - Document
+    - Document
 head:
   summary: Check if database exists
-  description: |-
-    Check if a database exists by using the response status code.
+  description: Check if a database exists by using the response status code.
   responses:
-    "200":
+    '200':
       description: Database exists
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Database Management
+    - Database Management

--- a/docs/api/paths/public/{db}~_all_docs.yaml
+++ b/docs/api/paths/public/{db}~_all_docs.yaml
@@ -1,42 +1,39 @@
-# /{db}/_all_docs
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: Gets all the documents in the database with the given parameters
-  description: |-
-    Returns all documents in the databased based on the specified parameters.
+  description: Returns all documents in the databased based on the specified parameters.
   parameters:
-  - $ref: ../../components/parameters.yaml#/include_docs
-  - $ref: ../../components/parameters.yaml#/Include-channels
-  - $ref: ../../components/parameters.yaml#/include-access
-  - $ref: ../../components/parameters.yaml#/include-revs
-  - $ref: ../../components/parameters.yaml#/include-seqs
-  - $ref: ../../components/parameters.yaml#/keys
-  - $ref: ../../components/parameters.yaml#/startkey
-  - $ref: ../../components/parameters.yaml#/endkey
-  - $ref: ../../components/parameters.yaml#/limit-result-rows
+    - $ref: ../../components/parameters.yaml#/include_docs
+    - $ref: ../../components/parameters.yaml#/Include-channels
+    - $ref: ../../components/parameters.yaml#/include-access
+    - $ref: ../../components/parameters.yaml#/include-revs
+    - $ref: ../../components/parameters.yaml#/include-seqs
+    - $ref: ../../components/parameters.yaml#/keys
+    - $ref: ../../components/parameters.yaml#/startkey
+    - $ref: ../../components/parameters.yaml#/endkey
+    - $ref: ../../components/parameters.yaml#/limit-result-rows
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/all-docs
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document
 post:
   summary: Get all the documents in the database using a built-in view
-  description: |-
-    Get a built-in view of all the documents in the database.
+  description: Get a built-in view of all the documents in the database.
   parameters:
-  - $ref: ../../components/parameters.yaml#/include_docs
-  - $ref: ../../components/parameters.yaml#/Include-channels
-  - $ref: ../../components/parameters.yaml#/include-access
-  - $ref: ../../components/parameters.yaml#/include-revs
-  - $ref: ../../components/parameters.yaml#/include-seqs
-  - $ref: ../../components/parameters.yaml#/startkey
-  - $ref: ../../components/parameters.yaml#/endkey
-  - $ref: ../../components/parameters.yaml#/limit-result-rows
+    - $ref: ../../components/parameters.yaml#/include_docs
+    - $ref: ../../components/parameters.yaml#/Include-channels
+    - $ref: ../../components/parameters.yaml#/include-access
+    - $ref: ../../components/parameters.yaml#/include-revs
+    - $ref: ../../components/parameters.yaml#/include-seqs
+    - $ref: ../../components/parameters.yaml#/startkey
+    - $ref: ../../components/parameters.yaml#/endkey
+    - $ref: ../../components/parameters.yaml#/limit-result-rows
   requestBody:
     content:
       application/json:
@@ -49,34 +46,34 @@ post:
               items:
                 type: string
           required:
-          - keys
+            - keys
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/all-docs
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document
 head:
   responses:
-    "200":
+    '200':
       description: OK
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document
   parameters:
-  - $ref: ../../components/parameters.yaml#/include_docs
-  - $ref: ../../components/parameters.yaml#/Include-channels
-  - $ref: ../../components/parameters.yaml#/include-access
-  - $ref: ../../components/parameters.yaml#/include-revs
-  - $ref: ../../components/parameters.yaml#/include-seqs
-  - $ref: ../../components/parameters.yaml#/keys
-  - $ref: ../../components/parameters.yaml#/startkey
-  - $ref: ../../components/parameters.yaml#/endkey
-  - $ref: ../../components/parameters.yaml#/limit-result-rows
-  description: |-
+    - $ref: ../../components/parameters.yaml#/include_docs
+    - $ref: ../../components/parameters.yaml#/Include-channels
+    - $ref: ../../components/parameters.yaml#/include-access
+    - $ref: ../../components/parameters.yaml#/include-revs
+    - $ref: ../../components/parameters.yaml#/include-seqs
+    - $ref: ../../components/parameters.yaml#/keys
+    - $ref: ../../components/parameters.yaml#/startkey
+    - $ref: ../../components/parameters.yaml#/endkey
+    - $ref: ../../components/parameters.yaml#/limit-result-rows
+  description: ''

--- a/docs/api/paths/public/{db}~_blipsync.yaml
+++ b/docs/api/paths/public/{db}~_blipsync.yaml
@@ -1,27 +1,24 @@
-# /{db}/_blipsync
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: Handle incoming BLIP Sync web socket request
-  description: |-
-    This handles incoming BLIP Sync requests from either Couchbase Lite or another Sync Gateway node. The connection has to be upgradable to a websocket connection or else the request will fail.
+  description: This handles incoming BLIP Sync requests from either Couchbase Lite or another Sync Gateway node. The connection has to be upgradable to a websocket connection or else the request will fail.
   parameters:
-  - name: client
-    in: query
-    description: This is the client type that is making the BLIP Sync request. Used
-      to control client-type specific replication behaviour.
-    schema:
-      type: string
-      default: cbl2
-      enum:
-      - cbl2
-      - sgr2
+    - name: client
+      in: query
+      description: This is the client type that is making the BLIP Sync request. Used to control client-type specific replication behaviour.
+      schema:
+        type: string
+        default: cbl2
+        enum:
+          - cbl2
+          - sgr2
   responses:
-    "101":
+    '101':
       description: Upgraded to a web socket connection
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "426":
+    '426':
       description: Cannot upgrade connection to a web socket connection
       content:
         application/json:
@@ -31,4 +28,4 @@ get:
             error: Upgrade Required
             reason: Can't upgrade this request to websocket connection
   tags:
-  - Replication
+    - Replication

--- a/docs/api/paths/public/{db}~_bulk_docs.yaml
+++ b/docs/api/paths/public/{db}~_bulk_docs.yaml
@@ -1,6 +1,5 @@
-# /{db}/_bulk_docs
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 post:
   summary: Bulk document operations
   description: |-
@@ -18,8 +17,7 @@ post:
           type: object
           properties:
             new_edits:
-              description: This controls whether to assign new revision identifiers
-                to new edits (`true`) or use the existing ones (`false`).
+              description: This controls whether to assign new revision identifiers to new edits (`true`) or use the existing ones (`false`).
               type: boolean
               default: true
             docs:
@@ -27,20 +25,20 @@ post:
               items:
                 $ref: ../../components/schemas.yaml#/Document
           required:
-          - docs
+            - docs
         example:
           new_edits: true
           docs:
-          - _id: FooBar
-            foo: bar
-          - _id: AliceSettings
-            _rev: 5-832a6db48ed130adadede928aee54576
-            FailedLoginAttempts: 7
-          - _id: BobSettings
-            _rev: 1-fa76ba41ee5fdfee1b91fc478ed09e59
-            _deleted: true
+            - _id: FooBar
+              foo: bar
+            - _id: AliceSettings
+              _rev: 5-832a6db48ed130adadede928aee54576
+              FailedLoginAttempts: 7
+            - _id: BobSettings
+              _rev: 1-fa76ba41ee5fdfee1b91fc478ed09e59
+              _deleted: true
   responses:
-    "201":
+    '201':
       description: |-
         Executed all operations.
 
@@ -53,12 +51,10 @@ post:
               type: object
               properties:
                 id:
-                  description: The ID of the document that the operation was performed
-                    on.
+                  description: The ID of the document that the operation was performed on.
                   type: string
                 rev:
-                  description: The new revision of the document if the operation was
-                    a success.
+                  description: The new revision of the document if the operation was a success.
                   type: string
                 error:
                   description: The error type if the operation of the document failed.
@@ -70,32 +66,32 @@ post:
                   description: The HTTP status code for why the operation failed.
                   type: integer
               required:
-              - id
+                - id
             uniqueItems: true
           examples:
             Success:
               value:
-              - id: FooBar
-                rev: 1-cd809becc169215072fd567eebd8b8de
-              - id: AliceSettings
-                rev: 6-b3e8dcf825b71ccee112f3572ec4323c
-              - id: BobSettings
-                rev: 2-5145e1086bb8d1d71a531e9f6b543c58
+                - id: FooBar
+                  rev: 1-cd809becc169215072fd567eebd8b8de
+                - id: AliceSettings
+                  rev: 6-b3e8dcf825b71ccee112f3572ec4323c
+                - id: BobSettings
+                  rev: 2-5145e1086bb8d1d71a531e9f6b543c58
             Partial success:
               value:
-              - error: conflict
-                id: FooBar
-                reason: Document exists
-                status: 409
-              - id: AliceSettings
-                rev: 6-b3e8dcf825b71ccee112f3572ec4323c
-              - error: conflict
-                id: BobSettings
-                reason: Document revision conflict
-                status: 409
-    "400":
+                - error: conflict
+                  id: FooBar
+                  reason: Document exists
+                  status: 409
+                - id: AliceSettings
+                  rev: 6-b3e8dcf825b71ccee112f3572ec4323c
+                - error: conflict
+                  id: BobSettings
+                  reason: Document revision conflict
+                  status: 409
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document

--- a/docs/api/paths/public/{db}~_bulk_get.yaml
+++ b/docs/api/paths/public/{db}~_bulk_get.yaml
@@ -1,6 +1,5 @@
-# /{db}/_bulk_get
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 post:
   summary: Get multiple documents in a MIME multipart response
   description: |
@@ -12,36 +11,28 @@ post:
 
     A body for a document that has attachments will be written as a nested `multipart/related` body.
   parameters:
-  - name: attachments
-    in: query
-    description: This is for whether to include attachments in each of the documents
-      returned or not.
-    schema:
-      type: boolean
-      default: "false"
-  - $ref: ../../components/parameters.yaml#/include-revs
-  - name: revs_limit
-    in: query
-    description: The number of revisions to include in the response from the document
-      history. This parameter only makes a different if the `revs` query parameter
-      is set to `true`. The full revision history will be returned if `revs` is set
-      but this is not.
-    schema:
-      type: integer
-  - name: X-Accept-Part-Encoding
-    in: header
-    description: If this header includes `gzip` then the part HTTP compression encoding
-      will be done.
-    schema:
-      type: string
-  - name: Accept-Encoding
-    in: header
-    description: If this header includes `gzip` then the the HTTP response will be
-      compressed. This takes priority over `X-Accept-Part-Encoding`. Only part compression
-      will be done if `X-Accept-Part-Encoding=gzip` and the `User-Agent` is below
-      1.2 due to clients not being able to handle full compression.
-    schema:
-      type: string
+    - name: attachments
+      in: query
+      description: This is for whether to include attachments in each of the documents returned or not.
+      schema:
+        type: boolean
+        default: 'false'
+    - $ref: ../../components/parameters.yaml#/include-revs
+    - name: revs_limit
+      in: query
+      description: The number of revisions to include in the response from the document history. This parameter only makes a different if the `revs` query parameter is set to `true`. The full revision history will be returned if `revs` is set but this is not.
+      schema:
+        type: integer
+    - name: X-Accept-Part-Encoding
+      in: header
+      description: If this header includes `gzip` then the part HTTP compression encoding will be done.
+      schema:
+        type: string
+    - name: Accept-Encoding
+      in: header
+      description: If this header includes `gzip` then the the HTTP response will be compressed. This takes priority over `X-Accept-Part-Encoding`. Only part compression will be done if `X-Accept-Part-Encoding=gzip` and the `User-Agent` is below 1.2 due to clients not being able to handle full compression.
+      schema:
+        type: string
   requestBody:
     content:
       application/json:
@@ -57,20 +48,20 @@ post:
                     description: ID of the document to retrieve.
                     type: string
                 required:
-                - id
+                  - id
           required:
-          - docs
+            - docs
         example:
           docs:
-          - id: FooBar
-          - id: attachment
-          - id: AliceSettings
+            - id: FooBar
+            - id: attachment
+            - id: AliceSettings
   responses:
-    "200":
+    '200':
       description: Returned the requested docs as `multipart/mixed` response type
-    "400":
+    '400':
       description: Bad Request
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document

--- a/docs/api/paths/public/{db}~_changes.yaml
+++ b/docs/api/paths/public/{db}~_changes.yaml
@@ -1,6 +1,5 @@
-# /{db}/_changes
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: Get changes list
   description: |-
@@ -8,109 +7,92 @@ get:
 
     This request can be used to listen for update and modifications to the database for post processing or synchronization. A continuously connected changes feed is a reasonable approach for generating a real-time log for most applications.
   parameters:
-  - name: limit
-    in: query
-    description: Maximum number of changes to return.
-    schema:
-      type: integer
-  - name: since
-    in: query
-    description: Starts the results from the change immediately after the given sequence
-      ID. Sequence IDs should be considered opaque; they come from the last_seq property
-      of a prior response.
-    schema:
-      type: string
-  - name: style
-    in: query
-    description: Controls whether to return the current winning revision (`main_only`)
-      or all the leaf revision including conflicts and deleted former conflicts (`all_docs`).
-    schema:
-      type: string
-      default: main_only
-      enum:
-      - main_only
-      - all_docs
-  - name: active_only
-    in: query
-    description: Set true to exclude deleted documents and notifications for documents
-      the user no longer has access to from the changes feed.
-    schema:
-      type: boolean
-      default: "false"
-  - $ref: ../../components/parameters.yaml#/include_docs
-  - name: revocations
-    in: query
-    description: If true, revocation messages will be sent on the changes feed.
-    schema:
-      type: boolean
-  - name: filter
-    in: query
-    description: Set a filter to either filter by channels or document IDs.
-    schema:
-      type: string
-      enum:
-      - sync_gateway/bychannel
-      - _doc_ids
-  - name: channels
-    in: query
-    description: A comma-separated list of channel names to filter the response to
-      only the channels specified. To use this option, the `filter` query option must
-      be set to `sync_gateway/bychannels`.
-    schema:
-      type: string
-  - name: doc_ids
-    in: query
-    description: A valid JSON array of document IDs to filter the documents in the
-      response to only the documents specified. To use this option, the `filter` query
-      option must be set to `_doc_ids` and the `feed` parameter must be `normal`.
-      Also accepts a comma separated list of document IDs instead.
-    schema:
-      type: array
-      items:
+    - name: limit
+      in: query
+      description: Maximum number of changes to return.
+      schema:
+        type: integer
+    - name: since
+      in: query
+      description: Starts the results from the change immediately after the given sequence ID. Sequence IDs should be considered opaque; they come from the last_seq property of a prior response.
+      schema:
         type: string
-  - name: heartbeat
-    in: query
-    description: The interval (in milliseconds) to send an empty line (CRLF) in the
-      response. This is to help prevent gateways from deciding the socket is idle
-      and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`.
-      This will override any timeouts to keep the feed alive indefinitely. Setting
-      to 0 results in no heartbeat. The maximum heartbeat can be set in the server
-      replication configuration.
-    schema:
-      type: integer
-      default: 0
-      minimum: 25000
-  - name: timeout
-    in: query
-    description: This is the maximum period (in milliseconds) to wait for a change
-      before the response is sent, even if there are no results. This is only applicable
-      for `feed=longpoll` or `feed=continuous` changes feeds. Setting to 0 results
-      in no timeout.
-    schema:
-      type: integer
-      default: 300000
-      maximum: 900000
-      minimum: 0
-  - name: feed
-    in: query
-    description: 'The type of changes feed to use. '
-    schema:
-      type: string
-      default: normal
-      enum:
-      - normal
-      - longpoll
-      - continuous
-      - websocket
+    - name: style
+      in: query
+      description: Controls whether to return the current winning revision (`main_only`) or all the leaf revision including conflicts and deleted former conflicts (`all_docs`).
+      schema:
+        type: string
+        default: main_only
+        enum:
+          - main_only
+          - all_docs
+    - name: active_only
+      in: query
+      description: Set true to exclude deleted documents and notifications for documents the user no longer has access to from the changes feed.
+      schema:
+        type: boolean
+        default: 'false'
+    - $ref: ../../components/parameters.yaml#/include_docs
+    - name: revocations
+      in: query
+      description: 'If true, revocation messages will be sent on the changes feed.'
+      schema:
+        type: boolean
+    - name: filter
+      in: query
+      description: Set a filter to either filter by channels or document IDs.
+      schema:
+        type: string
+        enum:
+          - sync_gateway/bychannel
+          - _doc_ids
+    - name: channels
+      in: query
+      description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannels`.'
+      schema:
+        type: string
+    - name: doc_ids
+      in: query
+      description: 'A valid JSON array of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`. Also accepts a comma separated list of document IDs instead.'
+      schema:
+        type: array
+        items:
+          type: string
+    - name: heartbeat
+      in: query
+      description: The interval (in milliseconds) to send an empty line (CRLF) in the response. This is to help prevent gateways from deciding the socket is idle and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`. This will override any timeouts to keep the feed alive indefinitely. Setting to 0 results in no heartbeat. The maximum heartbeat can be set in the server replication configuration.
+      schema:
+        type: integer
+        default: 0
+        minimum: 25000
+    - name: timeout
+      in: query
+      description: 'This is the maximum period (in milliseconds) to wait for a change before the response is sent, even if there are no results. This is only applicable for `feed=longpoll` or `feed=continuous` changes feeds. Setting to 0 results in no timeout.'
+      schema:
+        type: integer
+        default: 300000
+        maximum: 900000
+        minimum: 0
+    - name: feed
+      in: query
+      description: 'The type of changes feed to use. '
+      schema:
+        type: string
+        default: normal
+        enum:
+          - normal
+          - longpoll
+          - continuous
+          - websocket
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/changes-feed
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Database Management
+    - Database Management
 post:
   summary: Get changes list
   description: |-
@@ -127,69 +109,52 @@ post:
               description: Maximum number of changes to return.
               type: string
             style:
-              description: Controls whether to return the current winning revision
-                (`main_only`) or all the leaf revision including conflicts and deleted
-                former conflicts (`all_docs`).
+              description: Controls whether to return the current winning revision (`main_only`) or all the leaf revision including conflicts and deleted former conflicts (`all_docs`).
               type: string
             active_only:
-              description: Set true to exclude deleted documents and notifications
-                for documents the user no longer has access to from the changes feed.
+              description: Set true to exclude deleted documents and notifications for documents the user no longer has access to from the changes feed.
               type: string
             include_docs:
               description: Include the body associated with each document.
               type: string
             revocations:
-              description: If true, revocation messages will be sent on the changes
-                feed.
+              description: 'If true, revocation messages will be sent on the changes feed.'
               type: string
             filter:
               description: Set a filter to either filter by channels or document IDs.
               type: string
             channels:
-              description: A comma-separated list of channel names to filter the response
-                to only the channels specified. To use this option, the `filter` query
-                option must be set to `sync_gateway/bychannels`.
+              description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannels`.'
               type: string
             doc_ids:
-              description: A valid JSON array of document IDs to filter the documents
-                in the response to only the documents specified. To use this option,
-                the `filter` query option must be set to `_doc_ids` and the `feed`
-                parameter must be `normal`.
+              description: 'A valid JSON array of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`.'
               type: string
             heartbeat:
-              description: The interval (in milliseconds) to send an empty line (CRLF)
-                in the response. This is to help prevent gateways from deciding the
-                socket is idle and therefore closing it. This is only applicable to
-                `feed=longpoll` or `feed=continuous`. This will override any timeouts
-                to keep the feed alive indefinitely. Setting to 0 results in no heartbeat.
-                The maximum heartbeat can be set in the server replication configuration.
+              description: The interval (in milliseconds) to send an empty line (CRLF) in the response. This is to help prevent gateways from deciding the socket is idle and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`. This will override any timeouts to keep the feed alive indefinitely. Setting to 0 results in no heartbeat. The maximum heartbeat can be set in the server replication configuration.
               type: string
             timeout:
-              description: This is the maximum period (in milliseconds) to wait for
-                a change before the response is sent, even if there are no results.
-                This is only applicable for `feed=longpoll` or `feed=continuous` changes
-                feeds. Setting to 0 results in no timeout.
+              description: 'This is the maximum period (in milliseconds) to wait for a change before the response is sent, even if there are no results. This is only applicable for `feed=longpoll` or `feed=continuous` changes feeds. Setting to 0 results in no timeout.'
               type: string
             feed:
               description: 'The type of changes feed to use. '
               type: string
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/changes-feed
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Database Management
+    - Database Management
 head:
   responses:
-    "200":
+    '200':
       description: OK
-    "400":
+    '400':
       description: Bad Request
-    "404":
+    '404':
       description: Not Found
   tags:
-  - Database Management
-  description: |-
+    - Database Management
+  description: ''

--- a/docs/api/paths/public/{db}~_design~{ddoc}.yaml
+++ b/docs/api/paths/public/{db}~_design~{ddoc}.yaml
@@ -1,7 +1,6 @@
-# /{db}/_design/{ddoc}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- $ref: ../../components/parameters.yaml#/ddoc
+  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/ddoc
 get:
   summary: Get views of a design document | Unsupported
   description: |-
@@ -9,18 +8,18 @@ get:
 
     Query a design document.
   responses:
-    "200":
+    '200':
       description: Successfully returned design document.
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/Design-doc
-    "403":
+    '403':
       $ref: ../../components/responses.yaml#/ddoc-forbidden
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Unsupported
+    - Unsupported
 put:
   summary: Update views of a design document | Unsupported
   description: |-
@@ -33,14 +32,14 @@ put:
         schema:
           $ref: ../../components/schemas.yaml#/Design-doc
   responses:
-    "200":
+    '200':
       description: Design document changes successfully
-    "403":
+    '403':
       $ref: ../../components/responses.yaml#/ddoc-forbidden
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Unsupported
+    - Unsupported
 delete:
   summary: Delete a design document | Unsupported
   description: |-
@@ -48,25 +47,24 @@ delete:
 
     Delete a design document.
   responses:
-    "200":
+    '200':
       description: Design document deleted successfully
-    "403":
+    '403':
       $ref: ../../components/responses.yaml#/ddoc-forbidden
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Unsupported
+    - Unsupported
 head:
   responses:
-    "200":
+    '200':
       description: Design document exists
-    "403":
-      description: Forbidden access possibly due to not using the Admin API or the
-        design document is a built-in Sync Gateway one.
-    "404":
+    '403':
+      description: Forbidden access possibly due to not using the Admin API or the design document is a built-in Sync Gateway one.
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Unsupported
+    - Unsupported
   description: |-
     **This is unsupported**
 

--- a/docs/api/paths/public/{db}~_design~{ddoc}~_view~{view}.yaml
+++ b/docs/api/paths/public/{db}~_design~{ddoc}~_view~{view}.yaml
@@ -1,8 +1,7 @@
-# /{db}/_design/{ddoc}/_view/{view}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- $ref: ../../components/parameters.yaml#/ddoc
-- $ref: ../../components/parameters.yaml#/view
+  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/ddoc
+  - $ref: ../../components/parameters.yaml#/view
 get:
   summary: Query a view on a design document | Unsupported
   description: |-
@@ -10,23 +9,23 @@ get:
 
     Query a view on a design document.
   parameters:
-  - $ref: ../../components/parameters.yaml#/inclusive_end
-  - $ref: ../../components/parameters.yaml#/descending
-  - $ref: ../../components/parameters.yaml#/include_docs-cbs3
-  - $ref: ../../components/parameters.yaml#/reduce
-  - $ref: ../../components/parameters.yaml#/group
-  - $ref: ../../components/parameters.yaml#/skip
-  - $ref: ../../components/parameters.yaml#/limit
-  - $ref: ../../components/parameters.yaml#/group_level
-  - $ref: ../../components/parameters.yaml#/startkey_docid
-  - $ref: ../../components/parameters.yaml#/endkey_docid
-  - $ref: ../../components/parameters.yaml#/stale
-  - $ref: ../../components/parameters.yaml#/startkey
-  - $ref: ../../components/parameters.yaml#/endkey
-  - $ref: ../../components/parameters.yaml#/key
-  - $ref: ../../components/parameters.yaml#/keys
+    - $ref: ../../components/parameters.yaml#/inclusive_end
+    - $ref: ../../components/parameters.yaml#/descending
+    - $ref: ../../components/parameters.yaml#/include_docs-cbs3
+    - $ref: ../../components/parameters.yaml#/reduce
+    - $ref: ../../components/parameters.yaml#/group
+    - $ref: ../../components/parameters.yaml#/skip
+    - $ref: ../../components/parameters.yaml#/limit
+    - $ref: ../../components/parameters.yaml#/group_level
+    - $ref: ../../components/parameters.yaml#/startkey_docid
+    - $ref: ../../components/parameters.yaml#/endkey_docid
+    - $ref: ../../components/parameters.yaml#/stale
+    - $ref: ../../components/parameters.yaml#/startkey
+    - $ref: ../../components/parameters.yaml#/endkey
+    - $ref: ../../components/parameters.yaml#/key
+    - $ref: ../../components/parameters.yaml#/keys
   responses:
-    "200":
+    '200':
       description: Returned view successfully
       content:
         application/json:
@@ -58,11 +57,11 @@ get:
                     Reason:
                       type: string
             required:
-            - total_rows
-            - rows
-    "403":
+              - total_rows
+              - rows
+    '403':
       description: Forbidden
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Unsupported
+    - Unsupported

--- a/docs/api/paths/public/{db}~_ensure_full_commit.yaml
+++ b/docs/api/paths/public/{db}~_ensure_full_commit.yaml
@@ -1,12 +1,10 @@
-# /{db}/_ensure_full_commit
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 post:
-  summary: ""
-  description: |-
-    This endpoint is non-functional but is present for CouchDB compatibility.
+  summary: ''
+  description: This endpoint is non-functional but is present for CouchDB compatibility.
   responses:
-    "201":
+    '201':
       description: OK
       content:
         application/json:
@@ -14,8 +12,7 @@ post:
             type: object
             properties:
               instance_start_time:
-                description: Timestamp of when the database opened, in microseconds
-                  since the Unix epoch.
+                description: 'Timestamp of when the database opened, in microseconds since the Unix epoch.'
                 type: integer
                 example: 1644600082279583
               ok:
@@ -23,4 +20,4 @@ post:
                 example: true
                 default: true
   tags:
-  - Database Management
+    - Database Management

--- a/docs/api/paths/public/{db}~_facebook.yaml
+++ b/docs/api/paths/public/{db}~_facebook.yaml
@@ -1,6 +1,5 @@
-# /{db}/_facebook
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 post:
   summary: Create a new Facebook-based session
   description: |-
@@ -17,13 +16,13 @@ post:
               description: Facebook access token to base the new session on.
               type: string
           required:
-          - access_token
+            - access_token
   responses:
-    "200":
+    '200':
       description: Session created successfully
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/Invalid-CORS
-    "401":
+    '401':
       description: Received error from Facebook verifier
       content:
         application/json:
@@ -34,9 +33,9 @@ post:
                 type: string
               reason:
                 type: string
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "502":
+    '502':
       description: Received invalid response from the Facebook verifier
       content:
         application/json:
@@ -47,7 +46,7 @@ post:
                 type: string
               reason:
                 type: string
-    "504":
+    '504':
       description: Unable to send request to Facebook API
       content:
         application/json:
@@ -60,4 +59,4 @@ post:
                 type: string
   deprecated: true
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/public/{db}~_google.yaml
+++ b/docs/api/paths/public/{db}~_google.yaml
@@ -1,6 +1,5 @@
-# /{db}/_google
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 post:
   summary: Create a new Google-based session
   description: |-
@@ -17,15 +16,14 @@ post:
               description: Google ID token to base the new session on.
               type: string
           required:
-          - id_token
+            - id_token
   responses:
-    "200":
+    '200':
       description: Session created successfully
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/Invalid-CORS
-    "401":
-      description: Received error from Google token verifier or invalid application
-        ID in the config
+    '401':
+      description: Received error from Google token verifier or invalid application ID in the config
       content:
         application/json:
           schema:
@@ -35,9 +33,9 @@ post:
                 type: string
               reason:
                 type: string
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "502":
+    '502':
       description: Received invalid response from the Google token verifier
       content:
         application/json:
@@ -48,8 +46,8 @@ post:
                 type: string
               reason:
                 type: string
-    "504":
+    '504':
       description: Unable to send request to the Google token verifier
   deprecated: true
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/public/{db}~_local~{docid}.yaml
+++ b/docs/api/paths/public/{db}~_local~{docid}.yaml
@@ -1,12 +1,11 @@
-# /{db}/_local/{docid}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- name: docid
-  in: path
-  description: The name of the local document ID excluding the `_local/` prefix.
-  required: true
-  schema:
-    type: string
+  - $ref: ../../components/parameters.yaml#/db
+  - name: docid
+    in: path
+    description: The name of the local document ID excluding the `_local/` prefix.
+    required: true
+    schema:
+      type: string
 get:
   summary: Get local document
   description: |-
@@ -14,14 +13,14 @@ get:
 
     Local document IDs begin with `_local/`. Local documents are not replicated or indexed, don't support attachments, and don't save revision histories. In practice they are almost only used by Couchbase Lite's replicator, as a place to store replication checkpoint data.
   responses:
-    "200":
+    '200':
       description: Successfully found local document
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document
 put:
   summary: Upsert a local document
   description: |-
@@ -36,61 +35,57 @@ put:
           type: object
           properties:
             _rev:
-              description: Revision to replace. Required if updating existing local
-                document.
+              description: Revision to replace. Required if updating existing local document.
               type: string
   responses:
-    "201":
-      description: Document successfully written. The document ID will be prefixed
-        with `_local/`.
+    '201':
+      description: Document successfully written. The document ID will be prefixed with `_local/`.
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/New-revision
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "409":
-      description: A revision ID conflict would result from updating this document
-        revision.
+    '409':
+      description: A revision ID conflict would result from updating this document revision.
   tags:
-  - Document
+    - Document
 delete:
+  summary: Delete a local document
   description: |-
     This request deletes a local document.
 
     Local document IDs begin with `_local/`. Local documents are not replicated or indexed, don't support attachments, and don't save revision histories. In practice they are almost only used by Couchbase Lite's replicator, as a place to store replication checkpoint data.
   parameters:
-  - name: rev
-    in: query
-    description: The revision ID of the revision to delete.
-    required: true
-    schema:
-      type: string
+    - name: rev
+      in: query
+      description: The revision ID of the revision to delete.
+      required: true
+      schema:
+        type: string
   responses:
-    "200":
+    '200':
       description: Successfully removed the local document.
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "409":
-      description: A revision ID conflict would result from deleting this document
-        revision.
+    '409':
+      description: A revision ID conflict would result from deleting this document revision.
   tags:
-  - Document
-  summary: Delete a local document
+    - Document
 head:
   responses:
-    "200":
+    '200':
       description: Document exists
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document
   summary: Check if local document exists
   description: |-
     This request checks if a local document exists.

--- a/docs/api/paths/public/{db}~_oidc.yaml
+++ b/docs/api/paths/public/{db}~_oidc.yaml
@@ -1,27 +1,24 @@
-# /{db}/_oidc
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: OpenID Connect authentication initiation via Location header redirect
-  description: 'Called by clients to initiate the OpenID Connect Authorization Code
-    Flow. Redirects to the OpenID Connect provider if successful. '
+  description: 'Called by clients to initiate the OpenID Connect Authorization Code Flow. Redirects to the OpenID Connect provider if successful. '
   parameters:
-  - $ref: ../../components/parameters.yaml#/provider
-  - $ref: ../../components/parameters.yaml#/offline
+    - $ref: ../../components/parameters.yaml#/provider
+    - $ref: ../../components/parameters.yaml#/offline
   responses:
-    "302":
-      description: Successfully connected with the OpenID Connect provider so now
-        redirecting to the requested OIDC provider for authentication.
+    '302':
+      description: Successfully connected with the OpenID Connect provider so now redirecting to the requested OIDC provider for authentication.
       headers:
         Location:
           schema:
             type: string
           description: The link to redirect to so the client can authenticate.
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/OIDC-invalid-provider
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "500":
+    '500':
       $ref: ../../components/responses.yaml#/OIDC-connection
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/public/{db}~_oidc_callback.yaml
+++ b/docs/api/paths/public/{db}~_oidc_callback.yaml
@@ -1,30 +1,27 @@
-# /{db}/_oidc_callback
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: OpenID Connect authentication callback
-  description: The callback URL that the client is redirected to after authenticating
-    with the OpenID Connect provider.
+  description: The callback URL that the client is redirected to after authenticating with the OpenID Connect provider.
   parameters:
-  - name: error
-    in: query
-    description: The OpenID Connect error, if any occurred.
-    schema:
-      type: string
-  - $ref: ../../components/parameters.yaml#/oidc-code
-  - $ref: ../../components/parameters.yaml#/provider
-  - $ref: ../../components/parameters.yaml#/oidc-state
+    - name: error
+      in: query
+      description: 'The OpenID Connect error, if any occurred.'
+      schema:
+        type: string
+    - $ref: ../../components/parameters.yaml#/oidc-code
+    - $ref: ../../components/parameters.yaml#/provider
+    - $ref: ../../components/parameters.yaml#/oidc-state
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/OIDC-callback
-    "400":
+    '400':
       description: A problem occurred when reading the callback request body
-    "401":
-      description: An error was received from the OpenID Connect provider. This means
-        the error query parameter was filled.
-    "404":
+    '401':
+      description: An error was received from the OpenID Connect provider. This means the error query parameter was filled.
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "500":
+    '500':
       description: A problem occurred in regards to the token
       content:
         application/json:
@@ -36,4 +33,4 @@ get:
               reason:
                 type: string
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/public/{db}~_oidc_challenge.yaml
+++ b/docs/api/paths/public/{db}~_oidc_challenge.yaml
@@ -1,30 +1,24 @@
-# /{db}/_oidc_challenge
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: OpenID Connect authentication initiation via WWW-Authenticate header
-  description: Called by clients to initiate the OpenID Connect Authorization Code
-    Flow. This will establish a connection with the provider, then put the redirect
-    URL in the `WWW-Authenticate` header.
+  description: 'Called by clients to initiate the OpenID Connect Authorization Code Flow. This will establish a connection with the provider, then put the redirect URL in the `WWW-Authenticate` header.'
   parameters:
-  - $ref: ../../components/parameters.yaml#/provider
-  - $ref: ../../components/parameters.yaml#/offline
+    - $ref: ../../components/parameters.yaml#/provider
+    - $ref: ../../components/parameters.yaml#/offline
   responses:
-    "400":
-      description: 'The provider provided is not defined in the Sync Gateway config.
-        If no provided was specified then there is no default provider set. '
-    "401":
-      description: Successfully connected with the OpenID Connect provider so now
-        the client can login.
+    '400':
+      description: 'The provider provided is not defined in the Sync Gateway config. If no provided was specified then there is no default provider set. '
+    '401':
+      description: Successfully connected with the OpenID Connect provider so now the client can login.
       headers:
         WWW-Authenticate:
           schema:
             type: string
           description: The OpenID Connect authentication URL.
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "500":
-      description: Unable to connect and validate with the OpenID Connect provider
-        requested
+    '500':
+      description: Unable to connect and validate with the OpenID Connect provider requested
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/public/{db}~_oidc_refresh.yaml
+++ b/docs/api/paths/public/{db}~_oidc_refresh.yaml
@@ -1,25 +1,24 @@
-# /{db}/_oidc_refresh
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: OpenID Connect token refresh
   description: Refresh the OpenID Connect token based on the provided refresh token.
   parameters:
-  - name: refresh_token
-    in: query
-    description: The OpenID Connect refresh token.
-    required: true
-    schema:
-      type: string
-  - $ref: ../../components/parameters.yaml#/provider
+    - name: refresh_token
+      in: query
+      description: The OpenID Connect refresh token.
+      required: true
+      schema:
+        type: string
+    - $ref: ../../components/parameters.yaml#/provider
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/OIDC-callback
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/OIDC-invalid-provider
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "500":
+    '500':
       $ref: ../../components/responses.yaml#/OIDC-connection
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/public/{db}~_oidc_testing~.well-known~openid-configuration.yaml
+++ b/docs/api/paths/public/{db}~_oidc_testing~.well-known~openid-configuration.yaml
@@ -1,13 +1,10 @@
-# /{db}/_oidc_testing/.well-known-openid-configuration
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: OpenID Connect mock provider
-  description: Mock an OpenID Connect provider response for testing purposes. This
-    returns a response that is the same structure as what Sync Gateway expects from
-    an OIDC provider after initiating OIDC authentication.
+  description: Mock an OpenID Connect provider response for testing purposes. This returns a response that is the same structure as what Sync Gateway expects from an OIDC provider after initiating OIDC authentication.
   responses:
-    "200":
+    '200':
       description: 'Successfully generated OpenID Connect provider mock response. '
       headers:
         Expiry:
@@ -41,9 +38,9 @@ get:
                 type: string
               token_endpoint_auth_methods_supported:
                 type: string
-    "403":
+    '403':
       $ref: ../../components/responses.yaml#/OIDC-test-provider-disabled
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/public/{db}~_oidc_testing~authenticate.yaml
+++ b/docs/api/paths/public/{db}~_oidc_testing~authenticate.yaml
@@ -1,57 +1,54 @@
-# /{db}/_oidc_testing/authenticate
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: OpenID Connect mock login page handler
-  description: Used to handle the login page displayed for the `GET /{db}/_oidc_testing/authorize`
-    endpoint.
+  description: 'Used to handle the login page displayed for the `GET /{db}/_oidc_testing/authorize` endpoint.'
   parameters:
-  - $ref: ../../components/parameters.yaml#/oidc-redirect_uri
-  - $ref: ../../components/parameters.yaml#/oidc-scope
-  - name: username
-    in: query
-    required: true
-    schema:
-      type: string
-  - name: tokenttl
-    in: query
-    required: true
-    schema:
-      type: integer
-  - name: identity-token-formats
-    in: query
-    required: true
-    schema:
-      type: string
-  - name: authenticated
-    in: query
-    required: true
-    schema:
-      type: string
+    - $ref: ../../components/parameters.yaml#/oidc-redirect_uri
+    - $ref: ../../components/parameters.yaml#/oidc-scope
+    - name: username
+      in: query
+      required: true
+      schema:
+        type: string
+    - name: tokenttl
+      in: query
+      required: true
+      schema:
+        type: integer
+    - name: identity-token-formats
+      in: query
+      required: true
+      schema:
+        type: string
+    - name: authenticated
+      in: query
+      required: true
+      schema:
+        type: string
   responses:
-    "302":
+    '302':
       $ref: ../../components/responses.yaml#/OIDC-testing-redirect
-    "403":
+    '403':
       $ref: ../../components/responses.yaml#/OIDC-test-provider-disabled
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - OpenID Connect
+    - OpenID Connect
 post:
   summary: OpenID Connect mock login page handler
-  description: Used to handle the login page displayed for the `GET /{db}/_oidc_testing/authorize`
-    endpoint.
+  description: 'Used to handle the login page displayed for the `GET /{db}/_oidc_testing/authorize` endpoint.'
   parameters:
-  - $ref: ../../components/parameters.yaml#/oidc-redirect_uri
-  - $ref: ../../components/parameters.yaml#/oidc-scope
+    - $ref: ../../components/parameters.yaml#/oidc-redirect_uri
+    - $ref: ../../components/parameters.yaml#/oidc-scope
   requestBody:
     $ref: ../../components/requestBodies.yaml#/OIDC-login-page-handler
   responses:
-    "302":
+    '302':
       $ref: ../../components/responses.yaml#/OIDC-testing-redirect
-    "403":
+    '403':
       $ref: ../../components/responses.yaml#/OIDC-test-provider-disabled
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/public/{db}~_oidc_testing~authorize.yaml
+++ b/docs/api/paths/public/{db}~_oidc_testing~authorize.yaml
@@ -1,39 +1,38 @@
-# /{db}/_oidc_testing/authorize
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: OpenID Connect mock login page
   description: Show a mock OpenID Connect login page for the client to log in to.
   parameters:
-  - $ref: ../../components/parameters.yaml#/oidc-scope
+    - $ref: ../../components/parameters.yaml#/oidc-scope
   responses:
-    "200":
+    '200':
       description: OK
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/OIDC-invalid-scope
-    "403":
+    '403':
       $ref: ../../components/responses.yaml#/OIDC-test-provider-disabled
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "500":
+    '500':
       $ref: ../../components/responses.yaml#/OIDC-testing-internal-error
   tags:
-  - OpenID Connect
+    - OpenID Connect
 post:
   summary: OpenID Connect mock login page
   description: Show a mock OpenID Connect login page for the client to log in to.
   parameters:
-  - $ref: ../../components/parameters.yaml#/oidc-scope
+    - $ref: ../../components/parameters.yaml#/oidc-scope
   responses:
-    "200":
+    '200':
       description: OK
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/OIDC-invalid-scope
-    "403":
+    '403':
       $ref: ../../components/responses.yaml#/OIDC-test-provider-disabled
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "500":
+    '500':
       $ref: ../../components/responses.yaml#/OIDC-testing-internal-error
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/public/{db}~_oidc_testing~certs.yaml
+++ b/docs/api/paths/public/{db}~_oidc_testing~certs.yaml
@@ -1,11 +1,10 @@
-# /{db}/_oidc_testing/certs
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: OpenID Connect public certificates for signing keys
   description: Return a mock OpenID Connect public key to be used as signing keys.
   responses:
-    "200":
+    '200':
       description: Returned public key successfully
       content:
         application/json:
@@ -30,16 +29,16 @@ get:
                     Algorithm:
                       type: string
                   required:
-                  - Key
-                  - KeyID
-                  - Use
+                    - Key
+                    - KeyID
+                    - Use
             required:
-            - keys
-    "403":
+              - keys
+    '403':
       $ref: ../../components/responses.yaml#/OIDC-test-provider-disabled
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "500":
+    '500':
       description: An error occurred while getting the private RSA key
       content:
         application/json:
@@ -51,4 +50,4 @@ get:
               reason:
                 type: string
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/public/{db}~_oidc_testing~token.yaml
+++ b/docs/api/paths/public/{db}~_oidc_testing~token.yaml
@@ -1,6 +1,5 @@
-# /{db}/_oidc_testing/token
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 post:
   summary: OpenID Connect mock token
   description: Return a mock OpenID Connect token for the OIDC authentication flow.
@@ -11,27 +10,24 @@ post:
           type: object
           properties:
             grant_type:
-              description: The grant type of the token to request. Can either be an
-                `authorization_code` or `refresh_token`.
+              description: The grant type of the token to request. Can either be an `authorization_code` or `refresh_token`.
               type: string
             code:
-              description: '**`grant_type=authorization_code` only**: The OpenID Connect
-                authentication token.'
+              description: '**`grant_type=authorization_code` only**: The OpenID Connect authentication token.'
               type: string
             refresh_token:
-              description: '**`grant_type=refresh_token` only**: The OpenID Connect
-                refresh token.'
+              description: '**`grant_type=refresh_token` only**: The OpenID Connect refresh token.'
               type: string
           required:
-          - grant_type
+            - grant_type
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/OIDC-token
-    "400":
+    '400':
       description: Invalid token provided
-    "403":
+    '403':
       $ref: ../../components/responses.yaml#/OIDC-test-provider-disabled
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - OpenID Connect
+    - OpenID Connect

--- a/docs/api/paths/public/{db}~_revs_diff.yaml
+++ b/docs/api/paths/public/{db}~_revs_diff.yaml
@@ -1,10 +1,8 @@
-# /{db}/_revs_diff
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:
   summary: Compare revisions to what is in the database
-  description: |-
-    Takes a set of document IDs, each with a set of revision IDs. For each document, an array of unknown revisions are returned with an array of known revisions that may be recent ancestors.
+  description: 'Takes a set of document IDs, each with a set of revision IDs. For each document, an array of unknown revisions are returned with an array of known revisions that may be recent ancestors.'
   requestBody:
     content:
       application/json:
@@ -12,13 +10,12 @@ post:
           type: object
           properties:
             docid:
-              description: The document ID with an array of revisions to use for the
-                comparison.
+              description: The document ID with an array of revisions to use for the comparison.
               type: array
               items:
                 type: string
   responses:
-    "200":
+    '200':
       description: Comparisons successful
       content:
         application/json:
@@ -30,18 +27,16 @@ post:
                 type: object
                 properties:
                   missing:
-                    description: The revisions that are not in the database (and therefore
-                      `missing`).
+                    description: The revisions that are not in the database (and therefore `missing`).
                     type: array
                     items:
                       type: string
                   possible_ancestors:
-                    description: An array of known revisions that might be the recent
-                      ancestors.
+                    description: An array of known revisions that might be the recent ancestors.
                     type: array
                     items:
                       type: string
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Management

--- a/docs/api/paths/public/{db}~_session.yaml
+++ b/docs/api/paths/public/{db}~_session.yaml
@@ -1,16 +1,15 @@
-# /{db}/_session
 parameters:
-- $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/db
 get:
   summary: Get information about the current user
   description: This will get the information about the current user.
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/User-session-information
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Session
+    - Session
 post:
   summary: Create a new user session
   description: |-
@@ -28,38 +27,34 @@ post:
               description: User name to generate the session for.
               type: string
             password:
-              description: 'Password of the user to generate the session for.'
+              description: Password of the user to generate the session for.
               type: string
   responses:
-    "200":
-      description: Session created successfully. Returned body is dependant on if
-        using Public or Admin APIs
+    '200':
+      description: Session created successfully. Returned body is dependant on if using Public or Admin APIs
       content:
         application/json:
           schema:
             type: object
             properties:
               authentication_handlers:
-                type: array
                 description: Used for CouchDB compatability. Always contains "default" and "cookie".
+                type: array
                 items:
                   type: string
                   enum:
                     - default
                     - cookie
               ok:
+                description: Used for CouchDB compatability. Always true.
                 type: boolean
                 default: true
-                description: Used for CouchDB compatability. Always true.
               userCtx:
                 type: object
-                required:
-                  - channels
-                  - name
                 properties:
                   channels:
-                    type: object
                     description: A map of the channels the user is in along with the sequence number the user was granted access.
+                    type: object
                     additionalProperties:
                       oneOf:
                         - type: number
@@ -67,9 +62,12 @@ post:
                       minimum: 1
                       description: The channel name (as the key) and the channel sequence number the user was granted access to that channel.
                   name:
+                    description: The name of the user.
                     type: string
                     minLength: 1
-                    description: The name of the user.
+                required:
+                  - channels
+                  - name
             required:
               - authentication_handlers
               - ok
@@ -78,19 +76,19 @@ post:
             Example:
               value:
                 authentication_handlers:
-                - default
-                - cookie
+                  - default
+                  - cookie
                 ok: true
                 userCtx:
                   channels:
                     '!': 1
                   name: Bob
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/Invalid-CORS
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Session
+    - Session
 delete:
   summary: Log out
   description: |-
@@ -98,20 +96,20 @@ delete:
 
     If CORS is enabled, the origin must match an allowed login origin otherwise an error will be returned.
   responses:
-    "200":
+    '200':
       description: Successfully removed session (logged out)
-    "400":
+    '400':
       description: Bad Request
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Public only endpoints
-  - Session
+    - Public only endpoints
+    - Session
 head:
   responses:
-    "200":
+    '200':
       description: OK
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Session
+    - Session

--- a/docs/api/paths/public/{db}~{docid}.yaml
+++ b/docs/api/paths/public/{db}~{docid}.yaml
@@ -1,22 +1,20 @@
-# /{db}/{docid}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- $ref: ../../components/parameters.yaml#/docid
+  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/docid
 get:
   summary: Get a document
-  description: |-
-    Retrieve a document from the database by its doc ID.
+  description: Retrieve a document from the database by its doc ID.
   parameters:
-  - $ref: ../../components/parameters.yaml#/rev
-  - $ref: ../../components/parameters.yaml#/open_revs
-  - $ref: ../../components/parameters.yaml#/show_exp
-  - $ref: ../../components/parameters.yaml#/revs_from
-  - $ref: ../../components/parameters.yaml#/atts_since
-  - $ref: ../../components/parameters.yaml#/revs_limit
-  - $ref: ../../components/parameters.yaml#/includeAttachments
-  - $ref: ../../components/parameters.yaml#/replicator2
+    - $ref: ../../components/parameters.yaml#/rev
+    - $ref: ../../components/parameters.yaml#/open_revs
+    - $ref: ../../components/parameters.yaml#/show_exp
+    - $ref: ../../components/parameters.yaml#/revs_from
+    - $ref: ../../components/parameters.yaml#/atts_since
+    - $ref: ../../components/parameters.yaml#/revs_limit
+    - $ref: ../../components/parameters.yaml#/includeAttachments
+    - $ref: ../../components/parameters.yaml#/replicator2
   responses:
-    "200":
+    '200':
       description: Document found and returned successfully
       headers:
         Etag:
@@ -27,7 +25,6 @@ get:
         application/json:
           schema:
             type: object
-            additionalProperties: true
             properties:
               _id:
                 description: The ID of the document.
@@ -35,25 +32,25 @@ get:
               _rev:
                 description: The revision ID of the document.
                 type: string
+            additionalProperties: true
           example:
             FailedLoginAttempts: 5
             Friends:
-            - Bob
+              - Bob
             _id: AliceSettings
             _rev: 1-64d4a1f179db5c1848fe52967b47c166
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/invalid-doc-id
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "501":
-      description: Not Implemented. It is likely this error was caused due to trying
-        to use an enterprise-only feature on the community edition.
+    '501':
+      description: Not Implemented. It is likely this error was caused due to trying to use an enterprise-only feature on the community edition.
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
-  - Document
+    - Document
 put:
   summary: Upsert a document
   description: |-
@@ -65,39 +62,38 @@ put:
 
     The maximum size for a document is 20MB.
   parameters:
-  - $ref: ../../components/parameters.yaml#/roundtrip
-  - $ref: ../../components/parameters.yaml#/replicator2
-  - $ref: ../../components/parameters.yaml#/new_edits
-  - $ref: ../../components/parameters.yaml#/rev
-  - $ref: ../../components/parameters.yaml#/If-Match
+    - $ref: ../../components/parameters.yaml#/roundtrip
+    - $ref: ../../components/parameters.yaml#/replicator2
+    - $ref: ../../components/parameters.yaml#/new_edits
+    - $ref: ../../components/parameters.yaml#/rev
+    - $ref: ../../components/parameters.yaml#/If-Match
   requestBody:
     content:
       application/json:
         schema:
           $ref: ../../components/schemas.yaml#/Document
   responses:
-    "201":
+    '201':
       description: Created
       headers:
         Etag:
           schema:
             type: string
-          description: The revision of the written document. Not set if query option
-            `new_edits` is true.
+          description: The revision of the written document. Not set if query option `new_edits` is true.
       content:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/New-revision
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "409":
+    '409':
       $ref: ../../components/responses.yaml#/Conflict
-    "415":
+    '415':
       $ref: ../../components/responses.yaml#/Invalid-content-type
   tags:
-  - Document
+    - Document
 delete:
   summary: Delete a document
   description: |-
@@ -105,36 +101,35 @@ delete:
 
     A revision ID either in the header or on the query parameters is required.
   parameters:
-  - $ref: ../../components/parameters.yaml#/rev
-  - $ref: ../../components/parameters.yaml#/If-Match
+    - $ref: ../../components/parameters.yaml#/rev
+    - $ref: ../../components/parameters.yaml#/If-Match
   responses:
-    "200":
+    '200':
       $ref: ../../components/responses.yaml#/New-revision
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/request-problem
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document
 head:
   responses:
-    "200":
+    '200':
       description: Document exists
-    "400":
+    '400':
       $ref: ../../components/responses.yaml#/invalid-doc-id
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document
   summary: Check if a document exists
   parameters:
-  - $ref: ../../components/parameters.yaml#/rev
-  - $ref: ../../components/parameters.yaml#/open_revs
-  - $ref: ../../components/parameters.yaml#/show_exp
-  - $ref: ../../components/parameters.yaml#/revs_from
-  - $ref: ../../components/parameters.yaml#/atts_since
-  - $ref: ../../components/parameters.yaml#/revs_limit
-  - $ref: ../../components/parameters.yaml#/includeAttachments
-  - $ref: ../../components/parameters.yaml#/replicator2
-  description: |-
-    Return a status code based on if the document exists or not.
+    - $ref: ../../components/parameters.yaml#/rev
+    - $ref: ../../components/parameters.yaml#/open_revs
+    - $ref: ../../components/parameters.yaml#/show_exp
+    - $ref: ../../components/parameters.yaml#/revs_from
+    - $ref: ../../components/parameters.yaml#/atts_since
+    - $ref: ../../components/parameters.yaml#/revs_limit
+    - $ref: ../../components/parameters.yaml#/includeAttachments
+    - $ref: ../../components/parameters.yaml#/replicator2
+  description: Return a status code based on if the document exists or not.

--- a/docs/api/paths/public/{db}~{docid}~{attach}.yaml
+++ b/docs/api/paths/public/{db}~{docid}~{attach}.yaml
@@ -1,15 +1,12 @@
-# /{db}/{docid}/{attach}
 parameters:
-- $ref: ../../components/parameters.yaml#/db
-- $ref: ../../components/parameters.yaml#/docid
-- name: attach
-  in: path
-  description: The attachment name. This value must be URL encoded. For example, if
-    the attachment name is `blob_/avatar`, the path component passed to the URL should
-    be `blob_%2Favatar` (tested with [URLEncoder](https://www.urlencoder.org/)).
-  required: true
-  schema:
-    type: string
+  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/docid
+  - name: attach
+    in: path
+    description: 'The attachment name. This value must be URL encoded. For example, if the attachment name is `blob_/avatar`, the path component passed to the URL should be `blob_%2Favatar` (tested with [URLEncoder](https://www.urlencoder.org/)).'
+    required: true
+    schema:
+      type: string
 get:
   summary: Get an attachment from a document
   description: |-
@@ -19,27 +16,27 @@ get:
 
     If the `meta` query parameter is set then the response will be in JSON with the additional metadata tags.
   parameters:
-  - $ref: ../../components/parameters.yaml#/rev
-  - name: content_encoding
-    in: query
-    description: Set to false to disable the `Content-Encoding` response header.
-    schema:
-      type: boolean
-      default: "true"
-  - name: Range
-    in: header
-    description: RFC-2616 bytes range header.
-    schema:
-      type: string
-    example: bytes=123-456
-  - name: meta
-    in: query
-    description: Return only the metadata of the attachment in the response body.
-    schema:
-      type: boolean
-      default: "false"
+    - $ref: ../../components/parameters.yaml#/rev
+    - name: content_encoding
+      in: query
+      description: Set to false to disable the `Content-Encoding` response header.
+      schema:
+        type: boolean
+        default: 'true'
+    - name: Range
+      in: header
+      description: RFC-2616 bytes range header.
+      schema:
+        type: string
+      example: bytes=123-456
+    - name: meta
+      in: query
+      description: Return only the metadata of the attachment in the response body.
+      schema:
+        type: boolean
+        default: 'false'
   responses:
-    "200":
+    '200':
       description: Found attachment successfully.
       headers:
         Content-Length:
@@ -50,14 +47,14 @@ get:
           schema:
             type: string
           description: 'The attachment digest. Does not get set when request `meta=true`. '
-    "206":
+    '206':
       description: Partial attachment content returned
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "416":
+    '416':
       description: Requested range exceeds content length
   tags:
-  - Document
+    - Document
 put:
   summary: Create or update an attachment on a document
   description: |-
@@ -69,23 +66,22 @@ put:
 
     To remove an attachment from a document, omit the attachment in the `_attachments` object of the document in the `PUT /{db}/{docid}` request.
   parameters:
-  - name: Content-Type
-    in: header
-    description: The content type of the attachment.
-    schema:
-      type: string
-      default: application/octet-stream
-  - name: rev
-    in: query
-    description: The existing document revision ID to modify. Required only when modifying
-      an existing document.
-    schema:
-      type: string
-  - name: If-Match
-    in: header
-    description: An alternative way of specifying the document revision ID.
-    schema:
-      type: string
+    - name: Content-Type
+      in: header
+      description: The content type of the attachment.
+      schema:
+        type: string
+        default: application/octet-stream
+    - name: rev
+      in: query
+      description: The existing document revision ID to modify. Required only when modifying an existing document.
+      schema:
+        type: string
+    - name: If-Match
+      in: header
+      description: An alternative way of specifying the document revision ID.
+      schema:
+        type: string
   requestBody:
     description: The attachment data
     content:
@@ -94,7 +90,7 @@ put:
           description: The content to store in the body
           type: string
   responses:
-    "201":
+    '201':
       description: Attachment added to new or existing document successfully
       headers:
         Etag:
@@ -105,15 +101,15 @@ put:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/New-revision
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
-    "409":
+    '409':
       $ref: ../../components/responses.yaml#/Conflict
   tags:
-  - Document
+    - Document
 head:
   responses:
-    "200":
+    '200':
       description: The document exists and the attachment exists on the document.
       headers:
         Content-Length:
@@ -124,12 +120,11 @@ head:
           schema:
             type: string
           description: The attachment digest.
-    "404":
+    '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-  - Document
+    - Document
   summary: Check if attachment exists
-  description: |-
-    This request check if the attachment exists on the specified document.
+  description: This request check if the attachment exists on the specified document.
   parameters:
-  - $ref: ../../components/parameters.yaml#/rev
+    - $ref: ../../components/parameters.yaml#/rev

--- a/docs/api/paths/public/{targetdb}~.yaml
+++ b/docs/api/paths/public/{targetdb}~.yaml
@@ -1,19 +1,18 @@
 parameters:
-- name: targetdb
-  in: path
-  description: The database name to target.
-  required: true
-  schema:
-    type: string
+  - name: targetdb
+    in: path
+    description: The database name to target.
+    required: true
+    schema:
+      type: string
 put:
   summary: Create DB public API stub
-  description: A stub that always returns an error on the Public API, for createTarget/CouchDB
-    compatibility.
+  description: 'A stub that always returns an error on the Public API, for createTarget/CouchDB compatibility.'
   responses:
-    "403":
+    '403':
       description: Database does not exist and cannot be created over the public API
-    "412":
+    '412':
       description: Database exists
   tags:
-  - Public only endpoints
-  - Database Management
+    - Public only endpoints
+    - Database Management

--- a/docs/api/paths/public/~.yaml
+++ b/docs/api/paths/public/~.yaml
@@ -1,9 +1,8 @@
-# /
 get:
   summary: Get server information
   description: Returns information about the Sync Gateway node.
   responses:
-    "200":
+    '200':
       description: Returned server information
       content:
         application/json:
@@ -11,8 +10,7 @@ get:
             type: object
             properties:
               ADMIN:
-                description: '`true` if the request is from the Admin API - otherwise
-                  omitted.'
+                description: '`true` if the request is from the Admin API - otherwise omitted.'
                 type: boolean
                 example: true
               couchdb:
@@ -34,7 +32,7 @@ get:
                     type: string
                     example: 3.1
                 required:
-                - name
+                  - name
               version:
                 description: |-
                   Product version, including the build number and edition (i.e. `EE` or `CE`)
@@ -42,15 +40,15 @@ get:
                 type: string
                 example: Couchbase Sync Gateway/3.1.0(1;a765231) EE
             required:
-            - couchdb
-            - vendor
+              - couchdb
+              - vendor
   tags:
-  - Server
+    - Server
 head:
   responses:
-    "200":
+    '200':
       description: Server is online
   tags:
-  - Server
+    - Server
   summary: Check if server online
   description: Check if the server is online by checking the status code of response.

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -20,61 +20,59 @@ servers:
         description: The hostname to use
         default: localhost
 paths:
-  # Public only paths
-  /{db}/_session:
+  '/{db}/_session':
     $ref: './paths/public/{db}~_session.yaml'
-  /{targetdb}/:
+  '/{targetdb}/':
     $ref: './paths/public/{targetdb}~.yaml'
-  /{db}/:
+  '/{db}/':
     $ref: './paths/public/{db}~.yaml'
-  # Common paths
   /:
-    $ref: './paths/public/~.yaml'
-  /{db}/_all_docs:
+    $ref: ./paths/public/~.yaml
+  '/{db}/_all_docs':
     $ref: './paths/public/{db}~_all_docs.yaml'
-  /{db}/_bulk_docs:
+  '/{db}/_bulk_docs':
     $ref: './paths/public/{db}~_bulk_docs.yaml'
-  /{db}/_bulk_get:
+  '/{db}/_bulk_get':
     $ref: './paths/public/{db}~_bulk_get.yaml'
-  /{db}/_changes:
+  '/{db}/_changes':
     $ref: './paths/public/{db}~_changes.yaml'
-  /{db}/_design/{ddoc}:
+  '/{db}/_design/{ddoc}':
     $ref: './paths/public/{db}~_design~{ddoc}.yaml'
-  /{db}/_design/{ddoc}/_view/{view}:
+  '/{db}/_design/{ddoc}/_view/{view}':
     $ref: './paths/public/{db}~_design~{ddoc}~_view~{view}.yaml'
-  /{db}/_ensure_full_commit:
+  '/{db}/_ensure_full_commit':
     $ref: './paths/public/{db}~_ensure_full_commit.yaml'
-  /{db}/_revs_diff:
+  '/{db}/_revs_diff':
     $ref: './paths/public/{db}~_revs_diff.yaml'
-  /{db}/_local/{docid}:
+  '/{db}/_local/{docid}':
     $ref: './paths/public/{db}~_local~{docid}.yaml'
-  /{db}/{docid}:
+  '/{db}/{docid}':
     $ref: './paths/public/{db}~{docid}.yaml'
-  /{db}/{docid}/{attach}:
+  '/{db}/{docid}/{attach}':
     $ref: './paths/public/{db}~{docid}~{attach}.yaml'
-  /{db}/_facebook:
+  '/{db}/_facebook':
     $ref: './paths/public/{db}~_facebook.yaml'
-  /{db}/_google:
+  '/{db}/_google':
     $ref: './paths/public/{db}~_google.yaml'
-  /{db}/_oidc:
+  '/{db}/_oidc':
     $ref: './paths/public/{db}~_oidc.yaml'
-  /{db}/_oidc_challenge:
+  '/{db}/_oidc_challenge':
     $ref: './paths/public/{db}~_oidc_challenge.yaml'
-  /{db}/_oidc_callback:
+  '/{db}/_oidc_callback':
     $ref: './paths/public/{db}~_oidc_callback.yaml'
-  /{db}/_oidc_refresh:
+  '/{db}/_oidc_refresh':
     $ref: './paths/public/{db}~_oidc_refresh.yaml'
-  /{db}/_oidc_testing/.well-known/openid-configuration:
+  '/{db}/_oidc_testing/.well-known/openid-configuration':
     $ref: './paths/public/{db}~_oidc_testing~.well-known~openid-configuration.yaml'
-  /{db}/_oidc_testing/authorize:
+  '/{db}/_oidc_testing/authorize':
     $ref: './paths/public/{db}~_oidc_testing~authorize.yaml'
-  /{db}/_oidc_testing/token:
+  '/{db}/_oidc_testing/token':
     $ref: './paths/public/{db}~_oidc_testing~token.yaml'
-  /{db}/_oidc_testing/certs:
+  '/{db}/_oidc_testing/certs':
     $ref: './paths/public/{db}~_oidc_testing~certs.yaml'
-  /{db}/_oidc_testing/authenticate:
+  '/{db}/_oidc_testing/authenticate':
     $ref: './paths/public/{db}~_oidc_testing~authenticate.yaml'
-  /{db}/_blipsync:
+  '/{db}/_blipsync':
     $ref: './paths/public/{db}~_blipsync.yaml'
 tags:
   - name: Public only endpoints


### PR DESCRIPTION
Noisy diff, but just ran all the api docs through `openapi-format` (https://www.npmjs.com/package/openapi-format)

```sh
$ find docs/api -name \*.yaml -exec openapi-format {} -o {} \;
...
$ openapi lint
validating /docs/api/admin.yaml...
/docs/api/admin.yaml: validated in 257ms

validating /docs/api/public.yaml...
/docs/api/public.yaml: validated in 78ms

validating /docs/api/metric.yaml...
/docs/api/metric.yaml: validated in 11ms

Woohoo! Your OpenAPI definitions are valid. 🎉
```