### PR TITLE
CBG-2064: Include OIDCLastUpdated in marshalPrincipal result

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1201,6 +1201,10 @@ func marshalPrincipal(princ auth.Principal, includeDynamicGrantInfo bool) auth.P
 			info.OIDCIssuer = base.StringPtr(user.OIDCIssuer())
 			info.OIDCRoles = user.OIDCRoles().AsSet()
 			info.OIDCChannels = user.OIDCChannels().AsSet()
+			lastUpdated := user.OIDCLastUpdated()
+			if !lastUpdated.IsZero() {
+				info.OIDCLastUpdated = &lastUpdated
+			}
 		}
 	} else {
 		if includeDynamicGrantInfo {

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -2369,6 +2369,10 @@ func TestOpenIDConnectProviderRemoval(t *testing.T) {
 	assert.Equal(t, subject, adminResult["name"])
 	assert.Equal(t, mockAuthServer.options.issuer, adminResult["oidc_issuer"])
 	assert.Equal(t, []interface{}{testChannelName}, adminResult["oidc_channels"])
+	assert.NotEmpty(t, adminResult["oidc_last_updated"])
+	// check it's a valid time
+	_, err = time.Parse(time.RFC3339Nano, adminResult["oidc_last_updated"].(string))
+	require.NoError(t, err)
 
 	// Now simulate deleting the provider from the config.
 	// Need to do this get-then-replace because of CBG-2122


### PR DESCRIPTION
CBG-2064 (follow-up)

`marshalPrincipal` was incorrectly omitting OIDCLastUpdated, meaning this wasn't getting reflected in the admin API. Add it to the result, and add E2E test coverage to check for this.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/328/
  `TestAttachmentCompactIncorrectStat` flake
