### PR TITLE
CBG-2140: Config parsing and validation for Local JWT Auth

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -708,7 +708,7 @@ func (auth *Authenticator) AuthenticateTrustedJWT(token string, provider *OIDCPr
 	var identity *Identity
 	if provider.AllowUnsignedProviderTokens {
 		// Verify claims - ensures that the token we received from the provider is valid for Sync Gateway
-		identity, err = VerifyClaims(token, provider.ClientID, provider.Issuer)
+		identity, err = VerifyClaims(token, base.StringDefault(provider.ClientID, ""), provider.Issuer)
 		if err != nil {
 			base.DebugfCtx(auth.LogCtx, base.KeyAuth, "Error verifying raw token in AuthenticateTrustedJWT: %v", err)
 			return nil, PrincipalConfig{}, time.Time{}, err

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -682,9 +682,11 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 	var callbackURLFunc OIDCCallbackURLFunc
 	callbackURL := base.StringPtr("http://comcast:4984/_callback")
 	providerGoogle := &OIDCProvider{
-		Name:        "Google",
-		ClientID:    "aud1",
-		Issuer:      issuerGoogleAccounts,
+		Name: "Google",
+		JWTConfigCommon: JWTConfigCommon{
+			ClientID: base.StringPtr("aud1"),
+			Issuer:   issuerGoogleAccounts,
+		},
 		CallbackURL: callbackURL,
 	}
 
@@ -719,8 +721,10 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 		token, err := builder.CompactSerialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		provider := &OIDCProvider{
-			Name:        providerGoogle.Name,
-			Issuer:      issuerGoogleAccounts,
+			Name: providerGoogle.Name,
+			JWTConfigCommon: JWTConfigCommon{
+				Issuer: issuerGoogleAccounts,
+			},
 			CallbackURL: providerGoogle.CallbackURL}
 		user, _, expiry, err := auth.AuthenticateTrustedJWT(token, provider, callbackURLFunc)
 		assert.Error(t, err, "Error checking clientID config")
@@ -730,11 +734,13 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 
 	t.Run("issuer mismatch google provider valid token", func(t *testing.T) {
 		provider := &OIDCProvider{
-			Register:                    true,
-			CallbackURL:                 providerGoogle.CallbackURL,
-			Name:                        providerGoogle.Name,
-			Issuer:                      issuerGoogleAccounts,
-			ClientID:                    "aud1",
+			CallbackURL: providerGoogle.CallbackURL,
+			Name:        providerGoogle.Name,
+			JWTConfigCommon: JWTConfigCommon{
+				Register: true,
+				Issuer:   issuerGoogleAccounts,
+				ClientID: base.StringPtr("aud1"),
+			},
 			AllowUnsignedProviderTokens: true,
 		}
 		err = provider.InitUserPrefix(ctx)
@@ -760,11 +766,13 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 
 	t.Run("issuer mismatch google provider invalid token", func(t *testing.T) {
 		provider := &OIDCProvider{
-			Register:    true,
 			CallbackURL: providerGoogle.CallbackURL,
 			Name:        providerGoogle.Name,
-			Issuer:      issuerGoogleAccounts,
-			ClientID:    "aud1",
+			JWTConfigCommon: JWTConfigCommon{
+				Register: true,
+				Issuer:   issuerGoogleAccounts,
+				ClientID: base.StringPtr("aud1"),
+			},
 		}
 		err = provider.InitUserPrefix(ctx)
 		assert.NoError(t, err, "Error initializing user prefix")
@@ -787,11 +795,13 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 
 	t.Run("token with audience mismatch", func(t *testing.T) {
 		provider := &OIDCProvider{
-			Register:    true,
 			CallbackURL: providerGoogle.CallbackURL,
 			Name:        providerGoogle.Name,
-			Issuer:      issuerGoogleAccounts,
-			ClientID:    "aud4",
+			JWTConfigCommon: JWTConfigCommon{
+				Register: true,
+				Issuer:   issuerGoogleAccounts,
+				ClientID: base.StringPtr("aud4"),
+			},
 		}
 		err = provider.InitUserPrefix(ctx)
 		assert.NoError(t, err, "Error initializing user prefix")
@@ -814,11 +824,13 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 
 	t.Run("token with no audience claim", func(t *testing.T) {
 		provider := &OIDCProvider{
-			Register:    true,
 			CallbackURL: providerGoogle.CallbackURL,
 			Name:        providerGoogle.Name,
-			Issuer:      issuerGoogleAccounts,
-			ClientID:    "aud4",
+			JWTConfigCommon: JWTConfigCommon{
+				Register: true,
+				Issuer:   issuerGoogleAccounts,
+				ClientID: base.StringPtr("aud4"),
+			},
 		}
 		err = provider.InitUserPrefix(ctx)
 		assert.NoError(t, err, "Error initializing user prefix")
@@ -840,11 +852,13 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 
 	t.Run("authenticate with expired token", func(t *testing.T) {
 		provider := &OIDCProvider{
-			Register:    true,
 			CallbackURL: providerGoogle.CallbackURL,
 			Name:        providerGoogle.Name,
-			Issuer:      issuerGoogleAccounts,
-			ClientID:    "aud1",
+			JWTConfigCommon: JWTConfigCommon{
+				Register: true,
+				Issuer:   issuerGoogleAccounts,
+				ClientID: base.StringPtr("aud1"),
+			},
 		}
 		err = provider.InitUserPrefix(ctx)
 		assert.NoError(t, err, "Error initializing user prefix")
@@ -867,12 +881,14 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 
 	t.Run("token with nbf (not before) claim", func(t *testing.T) {
 		provider := &OIDCProvider{
-			Register:                    true,
 			CallbackURL:                 providerGoogle.CallbackURL,
 			Name:                        providerGoogle.Name,
-			Issuer:                      issuerGoogleAccounts,
-			ClientID:                    "aud1",
 			AllowUnsignedProviderTokens: true,
+			JWTConfigCommon: JWTConfigCommon{
+				Register: true,
+				Issuer:   issuerGoogleAccounts,
+				ClientID: base.StringPtr("aud1"),
+			},
 		}
 		err = provider.InitUserPrefix(ctx)
 		assert.NoError(t, err, "Error initializing user prefix")
@@ -898,11 +914,13 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 
 	t.Run("token with expired nbf (not before) claim", func(t *testing.T) {
 		provider := &OIDCProvider{
-			Register:    true,
 			CallbackURL: providerGoogle.CallbackURL,
 			Name:        providerGoogle.Name,
-			Issuer:      issuerGoogleAccounts,
-			ClientID:    "aud1",
+			JWTConfigCommon: JWTConfigCommon{
+				Issuer:   issuerGoogleAccounts,
+				ClientID: base.StringPtr("aud1"),
+				Register: true,
+			},
 		}
 		err = provider.InitUserPrefix(ctx)
 		assert.NoError(t, err, "Error initializing user prefix")
@@ -926,11 +944,13 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 
 	t.Run("token with no subject claim", func(t *testing.T) {
 		provider := &OIDCProvider{
-			Register:    true,
 			CallbackURL: providerGoogle.CallbackURL,
 			Name:        providerGoogle.Name,
-			Issuer:      issuerGoogleAccounts,
-			ClientID:    "aud1",
+			JWTConfigCommon: JWTConfigCommon{
+				Issuer:   issuerGoogleAccounts,
+				ClientID: base.StringPtr("aud1"),
+				Register: true,
+			},
 		}
 		err = provider.InitUserPrefix(ctx)
 		assert.NoError(t, err, "Error initializing user prefix")
@@ -958,12 +978,14 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 		assert.Equal(t, wantUsername, wantUser.Name())
 		assert.Equal(t, wantUserEmail, wantUser.Email())
 		provider := &OIDCProvider{
-			Register:                    true,
-			CallbackURL:                 providerGoogle.CallbackURL,
-			Name:                        providerGoogle.Name,
-			Issuer:                      issuerGoogleAccounts,
-			ClientID:                    "aud1",
-			UserPrefix:                  strings.ToLower(providerGoogle.Name),
+			CallbackURL: providerGoogle.CallbackURL,
+			Name:        providerGoogle.Name,
+			JWTConfigCommon: JWTConfigCommon{
+				Issuer:     issuerGoogleAccounts,
+				ClientID:   base.StringPtr("aud1"),
+				UserPrefix: strings.ToLower(providerGoogle.Name),
+				Register:   true,
+			},
 			AllowUnsignedProviderTokens: true,
 		}
 		err = provider.InitUserPrefix(ctx)
@@ -997,12 +1019,14 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 		assert.Equal(t, wantUserEmail, wantUser.Email())
 
 		provider := &OIDCProvider{
-			Register:                    true,
-			CallbackURL:                 providerGoogle.CallbackURL,
-			Name:                        providerGoogle.Name,
-			Issuer:                      issuerGoogleAccounts,
-			ClientID:                    "aud1",
-			UserPrefix:                  strings.ToLower(providerGoogle.Name),
+			CallbackURL: providerGoogle.CallbackURL,
+			Name:        providerGoogle.Name,
+			JWTConfigCommon: JWTConfigCommon{
+				Issuer:     issuerGoogleAccounts,
+				ClientID:   base.StringPtr("aud1"),
+				UserPrefix: strings.ToLower(providerGoogle.Name),
+				Register:   true,
+			},
 			AllowUnsignedProviderTokens: true,
 		}
 		err = provider.InitUserPrefix(ctx)
@@ -1030,12 +1054,14 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 	t.Run("new user with valid token and invalid email", func(t *testing.T) {
 		wantUsername := strings.ToLower(providerGoogle.Name) + "_layla"
 		provider := &OIDCProvider{
-			Register:                    true,
-			CallbackURL:                 providerGoogle.CallbackURL,
-			Name:                        providerGoogle.Name,
-			Issuer:                      issuerGoogleAccounts,
-			ClientID:                    "aud1",
-			UserPrefix:                  strings.ToLower(providerGoogle.Name),
+			CallbackURL: providerGoogle.CallbackURL,
+			Name:        providerGoogle.Name,
+			JWTConfigCommon: JWTConfigCommon{
+				Issuer:     issuerGoogleAccounts,
+				ClientID:   base.StringPtr("aud1"),
+				UserPrefix: strings.ToLower(providerGoogle.Name),
+				Register:   true,
+			},
 			AllowUnsignedProviderTokens: true,
 		}
 		err = provider.InitUserPrefix(ctx)
@@ -1142,15 +1168,19 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 	callbackURL := base.StringPtr("http://comcast:4984/_callback")
 	var callbackURLFunc OIDCCallbackURLFunc
 	providerGoogle := &OIDCProvider{
-		Name:        "Google",
-		ClientID:    "aud1",
-		Issuer:      issuerGoogleAccounts,
+		Name: "Google",
+		JWTConfigCommon: JWTConfigCommon{
+			ClientID: base.StringPtr("aud1"),
+			Issuer:   issuerGoogleAccounts,
+		},
 		CallbackURL: callbackURL,
 	}
 	providerFacebook := &OIDCProvider{
-		Name:        "Facebook",
-		ClientID:    "aud1",
-		Issuer:      issuerFacebookAccounts,
+		Name: "Facebook",
+		JWTConfigCommon: JWTConfigCommon{
+			ClientID: base.StringPtr("aud1"),
+			Issuer:   issuerFacebookAccounts,
+		},
 		CallbackURL: callbackURL,
 	}
 
@@ -1256,11 +1286,13 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 
 	t.Run("multiple providers with valid token signature verification failure", func(t *testing.T) {
 		providerGoogle := &OIDCProvider{
-			Register:    true,
 			CallbackURL: providerGoogle.CallbackURL,
 			Name:        providerGoogle.Name,
-			Issuer:      issuerGoogleAccounts,
-			ClientID:    "aud1",
+			JWTConfigCommon: JWTConfigCommon{
+				Issuer:   issuerGoogleAccounts,
+				ClientID: base.StringPtr("aud1"),
+				Register: true,
+			},
 		}
 		providers := OIDCProviderMap{providerGoogle.Name: providerGoogle, providerFacebook.Name: providerFacebook}
 		err = providerGoogle.InitUserPrefix(base.TestCtx(t))

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"gopkg.in/square/go-jose.v2"
+)
+
+// SupportedAlgorithms is list of signing algorithms explicitly supported
+// by github.com/coreos/go-oidc package. If a provider supports other algorithms,
+// such as HS256 or none, those values won't be passed to the IDTokenVerifier.
+var SupportedAlgorithms = map[jose.SignatureAlgorithm]bool{
+	jose.RS256: true,
+	jose.RS384: true,
+	jose.RS512: true,
+	jose.ES256: true,
+	jose.ES384: true,
+	jose.ES512: true,
+	jose.PS256: true,
+	jose.PS384: true,
+	jose.PS512: true,
+}
+
+// JWTConfigCommon groups together configuration options common to both OIDC and local JWT authentication.
+type JWTConfigCommon struct {
+	Issuer         string  `json:"issuer"`                    // OIDC Issuer
+	Register       bool    `json:"register"`                  // If true, server will register new user accounts
+	ClientID       *string `json:"client_id,omitempty"`       // Client ID
+	UserPrefix     string  `json:"user_prefix,omitempty"`     // Username prefix for users created for this provider
+	DisableSession bool    `json:"disable_session,omitempty"` // Disable Sync Gateway session creation on successful OIDC authentication
+	// UsernameClaim allows to specify a claim other than subject to use as the Sync Gateway username.
+	// The specified claim must be a string - numeric claims may be unmarshalled inconsistently between
+	// Sync Gateway and the underlying OIDC library.
+	UsernameClaim string `json:"username_claim"`
+
+	// RolesClaim and ChannelsClaim allow specifying a claim (which must be a string or string[]) to add roles/channels
+	// to users. These are added in addition to any other roles/channels the user may have (via the admin API or the
+	// sync function). If the claim is absent from the access/ID token, no roles/channels will be added.
+	RolesClaim    string `json:"roles_claim"`
+	ChannelsClaim string `json:"channels_claim"`
+}
+
+type (
+	JWTAlgorithm string
+	JWTAlgList   []JWTAlgorithm
+)
+
+type LocalJWTAuthProvider struct {
+	JWTConfigCommon
+
+	Algorithms JWTAlgList        `json:"algorithms"`
+	Keys       []jose.JSONWebKey `json:"keys"`
+}
+
+type LocalJWTConfig map[string]*LocalJWTAuthProvider

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -111,19 +111,25 @@ func TestOIDCProviderMap_GetProviderForIssuer(t *testing.T) {
 
 	clientID := "SGW-TEST"
 	cbProvider := OIDCProvider{
-		Name:     "Couchbase",
-		Issuer:   "http://127.0.0.1:1234",
-		ClientID: clientID,
+		Name: "Couchbase",
+		JWTConfigCommon: JWTConfigCommon{
+			Issuer:   "http://127.0.0.1:1234",
+			ClientID: &clientID,
+		},
 	}
 	glProvider := OIDCProvider{
-		Name:     "Gügul",
-		Issuer:   "http://127.0.0.1:1235",
-		ClientID: clientID,
+		Name: "Gügul",
+		JWTConfigCommon: JWTConfigCommon{
+			Issuer:   "http://127.0.0.1:1235",
+			ClientID: &clientID,
+		},
 	}
 	fbProvider := OIDCProvider{
-		Name:     "Fæsbuk",
-		Issuer:   "http://127.0.0.1:1236",
-		ClientID: clientID,
+		Name: "Fæsbuk",
+		JWTConfigCommon: JWTConfigCommon{
+			Issuer:   "http://127.0.0.1:1236",
+			ClientID: &clientID,
+		},
 	}
 	providerMap := OIDCProviderMap{
 		"gl": &glProvider,
@@ -173,8 +179,10 @@ func TestOIDCProviderMap_GetProviderForIssuer(t *testing.T) {
 
 func TestOIDCUsername(t *testing.T) {
 	provider := OIDCProvider{
-		Name:   "Some_Provider",
-		Issuer: "http://www.someprovider.com",
+		Name: "Some_Provider",
+		JWTConfigCommon: JWTConfigCommon{
+			Issuer: "http://www.someprovider.com",
+		},
 	}
 
 	ctx := base.TestCtx(t)
@@ -229,7 +237,9 @@ func TestInitOIDCClient(t *testing.T) {
 
 	t.Run("initialize openid connect client with unavailable issuer", func(t *testing.T) {
 		provider := &OIDCProvider{
-			Issuer:      "http://127.0.0.1:12345/auth",
+			JWTConfigCommon: JWTConfigCommon{
+				Issuer: "http://127.0.0.1:12345/auth",
+			},
 			CallbackURL: base.StringPtr("http://127.0.0.1:12345/callback"),
 		}
 		err := provider.initOIDCClient(ctx)
@@ -239,8 +249,10 @@ func TestInitOIDCClient(t *testing.T) {
 
 	t.Run("initialize openid connect client with valid provider config", func(t *testing.T) {
 		provider := &OIDCProvider{
-			ClientID:    "foo",
-			Issuer:      "https://accounts.google.com",
+			JWTConfigCommon: JWTConfigCommon{
+				ClientID: base.StringPtr("foo"),
+				Issuer:   "https://accounts.google.com",
+			},
 			CallbackURL: base.StringPtr("http://sgw-test:4984/_callback"),
 		}
 		err := provider.initOIDCClient(ctx)
@@ -252,8 +264,10 @@ func TestInitOIDCClient(t *testing.T) {
 func TestConcurrentSetConfig(t *testing.T) {
 	providerLock := sync.Mutex{}
 	provider := &OIDCProvider{
-		ClientID:    "foo",
-		Issuer:      "https://accounts.google.com",
+		JWTConfigCommon: JWTConfigCommon{
+			ClientID: base.StringPtr("foo"),
+			Issuer:   "https://accounts.google.com",
+		},
 		CallbackURL: base.StringPtr("http://sgw-test:4984/_callback"),
 	}
 
@@ -411,7 +425,7 @@ func TestFetchCustomProviderConfig(t *testing.T) {
 				issuer += "/"
 			}
 			discoveryURL := GetStandardDiscoveryEndpoint(issuer)
-			op := &OIDCProvider{Issuer: issuer}
+			op := &OIDCProvider{JWTConfigCommon: JWTConfigCommon{Issuer: issuer}}
 			metadata, _, _, err := op.fetchCustomProviderConfig(base.TestCtx(t), discoveryURL)
 			if err != nil {
 				assert.True(t, test.wantErr, "Unexpected Error!")
@@ -1175,11 +1189,13 @@ func TestOIDCRolesChannels(t *testing.T) {
 			auth := NewAuthenticator(testBucket, &testMockComputer, DefaultAuthenticatorOptions())
 
 			provider := &OIDCProvider{
-				Name:          "foo",
-				Issuer:        testIssuer,
-				RolesClaim:    tc.rolesClaimName,
-				ChannelsClaim: tc.channelsClaimName,
-				UserPrefix:    testUserPrefix,
+				Name: "foo",
+				JWTConfigCommon: JWTConfigCommon{
+					Issuer:        testIssuer,
+					RolesClaim:    tc.rolesClaimName,
+					ChannelsClaim: tc.channelsClaimName,
+					UserPrefix:    testUserPrefix,
+				},
 			}
 
 			for i, login := range tc.logins {

--- a/base/util.go
+++ b/base/util.go
@@ -845,6 +845,13 @@ func BoolDefault(b *bool, ifNil bool) bool {
 	return ifNil
 }
 
+func StringDefault(s *string, ifNil string) string {
+	if s != nil {
+		return *s
+	}
+	return ifNil
+}
+
 func Float32Ptr(f float32) *float32 {
 	return &f
 }

--- a/db/database.go
+++ b/db/database.go
@@ -483,7 +483,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 		dbContext.OIDCProviders = make(auth.OIDCProviderMap)
 
 		for name, provider := range options.OIDCOptions.Providers {
-			if provider.Issuer == "" || provider.ClientID == "" {
+			if provider.Issuer == "" || base.StringDefault(provider.ClientID, "") == "" {
 				base.WarnfCtx(logCtx, "Issuer and ClientID required for OIDC Provider - skipping provider %q", base.UD(name))
 				continue
 			}

--- a/db/database.go
+++ b/db/database.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -484,21 +483,11 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 
 		for name, provider := range options.OIDCOptions.Providers {
 			if provider.Issuer == "" || base.StringDefault(provider.ClientID, "") == "" {
-				base.WarnfCtx(logCtx, "Issuer and ClientID required for OIDC Provider - skipping provider %q", base.UD(name))
+				// TODO: this duplicates a check in DbConfig.validate to avoid a backwards compatibility issue
+				base.WarnfCtx(logCtx, "Issuer and Client ID not defined for provider %q - skipping", base.UD(name))
 				continue
 			}
-
-			if provider.ValidationKey == nil {
-				base.WarnfCtx(logCtx, "Validation Key not defined in config for provider %q - auth code flow will not be supported for this provider", base.UD(name))
-			}
-
-			if strings.Contains(name, "_") {
-				return nil, base.RedactErrorf("OpenID Connect provider names cannot contain underscore:%s", base.UD(name))
-			}
 			provider.Name = name
-			if _, ok := dbContext.OIDCProviders[provider.Issuer]; ok {
-				return nil, base.RedactErrorf("Multiple OIDC providers defined for issuer %v", base.UD(provider.Issuer))
-			}
 
 			// If this is the default provider, or there's only one provider defined, set IsDefault
 			if (options.OIDCOptions.DefaultProvider != nil && name == *options.OIDCOptions.DefaultProvider) || len(options.OIDCOptions.Providers) == 1 {
@@ -522,11 +511,6 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 
 			dbContext.OIDCProviders[name] = provider
 		}
-		if len(dbContext.OIDCProviders) == 0 {
-			return nil, errors.New("OpenID Connect defined in config, but no valid OpenID Connect providers specified")
-
-		}
-
 	}
 
 	if dbContext.UseXattrs() {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1863,61 +1863,6 @@ func mockOIDCOptionsWithBadName() *auth.OIDCOptions {
 	return &auth.OIDCOptions{DefaultProvider: &defaultProvider, Providers: providers}
 }
 
-func TestNewDatabaseContextWithOIDCProviderOptionErrors(t *testing.T) {
-	// Enable prometheus stats. Ensures that we recover / cleanup stats if we fail to initialize a DatabaseContext
-	base.SkipPrometheusStatsRegistration = false
-	defer func() {
-		base.SkipPrometheusStatsRegistration = true
-	}()
-
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
-
-	tests := []struct {
-		name          string
-		inputOptions  *auth.OIDCOptions
-		expectedError string
-	}{
-		// Provider should be skipped if no issuer is not provided in OIDCOptions. It should throw the error
-		// "OpenID Connect defined in config, but no valid OpenID Connect providers specified". Also a warning
-		// should be logged saying "Issuer and ClientID required for OIDC Provider - skipping provider"
-		{
-			name:          "TestWithNoIss",
-			inputOptions:  mockOIDCOptionsWithNoIss(),
-			expectedError: "OpenID Connect defined in config, but no valid OpenID Connect providers specified",
-		},
-		// Provider should be skipped if no client ID is not provided in OIDCOptions. It should throw the error
-		// "OpenID Connect defined in config, but no valid OpenID Connect providers specified". Also a warning
-		//	should be logged saying "Issuer and ClientID required for OIDC Provider - skipping provider"
-		{
-			name:          "TestWithNoClientID",
-			inputOptions:  mockOIDCOptionsWithNoClientID(),
-			expectedError: "OpenID Connect defined in config, but no valid OpenID Connect providers specified",
-		},
-		// If the provider name is illegal; meaning an underscore character in provider name is considered as
-		// illegal, it should throw an error stating OpenID Connect provider names cannot contain underscore.
-		{
-			name:          "TestWithWithBadName",
-			inputOptions:  mockOIDCOptionsWithBadName(),
-			expectedError: "OpenID Connect provider names cannot contain underscore",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			options := DatabaseContextOptions{
-				OIDCOptions: tc.inputOptions,
-			}
-			AddOptionsFromEnvironmentVariables(&options)
-
-			context, err := NewDatabaseContext("db", testBucket, false, options)
-			assert.Error(t, err, "Couldn't create context for database 'db'")
-			assert.Contains(t, err.Error(), tc.expectedError)
-			assert.Nil(t, context, "Database context shouldn't be created")
-		})
-	}
-}
-
 func TestNewDatabaseContextWithOIDCProviderOptions(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1758,37 +1758,45 @@ var (
 
 func mockOIDCProvider() auth.OIDCProvider {
 	return auth.OIDCProvider{
+		JWTConfigCommon: auth.JWTConfigCommon{
+			Issuer:   "https://accounts.google.com",
+			ClientID: base.StringPtr(clientID),
+		},
 		Name:          "Google",
-		Issuer:        "https://accounts.google.com",
 		CallbackURL:   &callbackURL,
-		ClientID:      clientID,
 		ValidationKey: &validationKey,
 	}
 }
 
 func mockOIDCProviderWithCallbackURLQuery() auth.OIDCProvider {
 	return auth.OIDCProvider{
+		JWTConfigCommon: auth.JWTConfigCommon{
+			Issuer:   "https://accounts.google.com",
+			ClientID: base.StringPtr(clientID),
+		},
 		Name:          "Google",
-		Issuer:        "https://accounts.google.com",
 		CallbackURL:   &callbackURLWithQuery,
-		ClientID:      clientID,
 		ValidationKey: &validationKey,
 	}
 }
 
 func mockOIDCProviderWithNoIss() auth.OIDCProvider {
 	return auth.OIDCProvider{
+		JWTConfigCommon: auth.JWTConfigCommon{
+			ClientID: base.StringPtr(clientID),
+		},
 		Name:          "Microsoft",
 		CallbackURL:   &callbackURL,
-		ClientID:      clientID,
 		ValidationKey: &validationKey,
 	}
 }
 
 func mockOIDCProviderWithNoClientID() auth.OIDCProvider {
 	return auth.OIDCProvider{
+		JWTConfigCommon: auth.JWTConfigCommon{
+			Issuer: "https://accounts.google.com",
+		},
 		Name:          "Amazon",
-		Issuer:        "https://accounts.amazon.com",
 		CallbackURL:   &callbackURL,
 		ValidationKey: &validationKey,
 	}
@@ -1797,9 +1805,11 @@ func mockOIDCProviderWithNoClientID() auth.OIDCProvider {
 func mockOIDCProviderWithNoValidationKey() auth.OIDCProvider {
 	return auth.OIDCProvider{
 		Name:        "Yahoo",
-		Issuer:      "https://accounts.yahoo.com",
 		CallbackURL: &callbackURL,
-		ClientID:    clientID,
+		JWTConfigCommon: auth.JWTConfigCommon{
+			Issuer:   "https://accounts.yahoo.com",
+			ClientID: base.StringPtr(clientID),
+		},
 	}
 }
 

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1276,24 +1276,22 @@ Database:
         provider_name:
           description: The providers name.
           type: object
+          required: ['issuer', 'client_id', 'algorithms', 'keys']
           properties:
             issuer:
               description: The value to match against the "iss" claim of JWTs.
               type: string
-              required: true
             register:
               description: If to register a new Sync Gateway user account when a user logs in with a JWT.
               type: boolean
             client_id:
               description: The value to match against the "aud" claim of JWTs. Set to an empty string to disable audience validation.
               type: string
-              required: true
             algorithms:
               description: The JWT signing algorithms to accept for authentication.
               type: array
               items:
                 type: string
-              required: true
             keys:
               description: The JSON Web Keys to use to validate JWTs.
               type: array

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1269,6 +1269,91 @@ Database:
         remote_config_tls_skip_verify:
           description: Enable self-signed certificates for external JavaScript load.
           type: boolean
+    local_jwt:
+      description: Configuration for Local JWT authentication.
+      type: object
+      properties:
+        provider_name:
+          description: The providers name.
+          type: object
+          properties:
+            issuer:
+              description: The value to match against the "iss" claim of JWTs.
+              type: string
+              required: true
+            register:
+              description: If to register a new Sync Gateway user account when a user logs in with a JWT.
+              type: boolean
+            client_id:
+              description: The value to match against the "aud" claim of JWTs. Set to an empty string to disable audience validation.
+              type: string
+              required: true
+            algorithms:
+              description: The JWT signing algorithms to accept for authentication.
+              type: array
+              items:
+                type: string
+              required: true
+            keys:
+              description: The JSON Web Keys to use to validate JWTs.
+              type: array
+              items:
+                type: object
+                properties:
+                  kty:
+                    type: string
+                    description: The cryptographic algorithm family used with the key, such as "RSA" or "EC"
+                    enum: [ 'RSA', 'EC' ]
+                  use:
+                    type: string
+                    description: The intended use of the public key. Only 'sig' is accepted.
+                    enum: [ 'sig' ]
+                  alg:
+                    type: string
+                    description: The algorithm intended for use with the key.
+                  kid:
+                    type: string
+                    description: The Key ID, used to identify the key to use.
+                  crv:
+                    type: string
+                    description: For Elliptic Curve keys, the name of the curve to use.
+                    enum: [ 'P-256', 'P-384', 'P-521' ]
+                  x:
+                    type: string
+                    description: For Elliptic Curve keys, the X coordinate of the point, as a base64url string.
+                  y:
+                    type: string
+                    description: For Elliptic Curve keys, the Y coordinate of the point, as a base64url string.
+                  n:
+                    type: string
+                    description: For RSA keys, the modulus value of the key, as a Base64urlUInt-encoded value.
+                  e:
+                    type: string
+                    description: For RSA keys, the exponent of the public key, as a Base64urlUInt-encoded value.
+            disable_session:
+              description: Disable Sync Gateway session creation on successful JWT authentication.
+              type: boolean
+            user_prefix:
+              description: This is the username prefix for all users created through this provider.
+              type: string
+            username_claim:
+              description: |-
+                Allows a different OpenID Connect field to be specified instead of the Subject (`sub`).
+                
+                The field name to use can be specified here.
+              type: string
+            roles_claim:
+              description: |-
+                If set, the value(s) of the given JSON Web Token claim will be added to the user's roles.
+                
+                The value of this claim must be either a string or an array of strings, any other type will result in an error.
+              type: string
+            channels_claim:
+              description: |-
+                If set, the value(s) of the given JSON Web Token claim will be added to the user's channels.
+                
+                The value of this claim must be either a string or an array of strings, any other type will result in an error.
+              type: string
     oidc:
       description: Configuration for OpenID Connect authentication.
       type: object

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -385,6 +385,31 @@ func TestConfigValidationJWTAndOIDC(t *testing.T) {
 			configJSON:    `{"name": "test", "local_jwt": { "test": { "issuer": "test", "client_id": "", "keys": [` + testRSA256JWK + `], "algorithms": ["RS256"] }, "test2": { "issuer": "test", "client_id": "", "keys": [` + testRSA256JWK + `], "algorithms": ["RS256"] } }}`,
 			expectedError: "duplicate OIDC/JWT issuer: test",
 		},
+		{
+			name:          "Local JWT: duplicate issuers (OIDC)",
+			configJSON:    `{"name": "test", "oidc": { "providers": { "test": {"issuer": "test", "client_id": "test"}, "test2": {"issuer": "test", "client_id": "test"} } }}`,
+			expectedError: "duplicate OIDC/JWT issuer: test",
+		},
+		{
+			name:          "Local JWT: duplicate issuers (mixed)",
+			configJSON:    `{"name": "test", "local_jwt": { "test": { "issuer": "test", "client_id": "", "keys": [` + testRSA256JWK + `], "algorithms": ["RS256"] }}, "oidc": { "providers": { "test": {"issuer": "test", "client_id": "test"} } }}`,
+			expectedError: "duplicate OIDC/JWT issuer: test",
+		},
+		{
+			name:          "OIDC: no providers",
+			configJSON:    `{"name": "test", "oidc": {"providers": {}}}`,
+			expectedError: "OpenID Connect defined in config, but no valid providers specified",
+		},
+		{
+			name:          "OIDC: no client ID",
+			configJSON:    `{"name": "test", "oidc": {"providers": { "test": {"issuer": "test", "client_id": ""} }}}`,
+			expectedError: "OpenID Connect defined in config, but no valid providers specified",
+		},
+		{
+			name:          "OIDC: illegal name",
+			configJSON:    `{"name": "test", "oidc": {"providers": { "invalid_test": {"issuer": "test", "client_id": "test"} }}}`,
+			expectedError: "OpenID Connect provider names cannot contain underscore",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -486,7 +486,7 @@ func (h *handler) checkAuth(dbCtx *db.DatabaseContext) (err error) {
 			if username, password := h.getBasicAuth(); username != "" && password != "" {
 				provider := dbCtx.Options.OIDCOptions.Providers.GetProviderForIssuer(h.ctx(), issuerUrlForDB(h, dbCtx.Name), testProviderAudiences)
 				if provider != nil && provider.ValidationKey != nil {
-					if provider.ClientID == username && *provider.ValidationKey == password {
+					if base.StringDefault(provider.ClientID, "") == username && *provider.ValidationKey == password {
 						return nil
 					}
 				}

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -463,8 +463,10 @@ func TestGetOIDCCallbackURL(t *testing.T) {
 func mockProvider(name string) *auth.OIDCProvider {
 	return &auth.OIDCProvider{
 		Name:          name,
-		ClientID:      "baz",
 		ValidationKey: base.StringPtr("qux"),
+		JWTConfigCommon: auth.JWTConfigCommon{
+			ClientID: base.StringPtr("baz"),
+		},
 	}
 }
 
@@ -2471,18 +2473,22 @@ func TestOpenIDConnectIssuerChange(t *testing.T) {
 	newCfg.OIDCConfig = &auth.OIDCOptions{
 		Providers: auth.OIDCProviderMap{
 			"test": &auth.OIDCProvider{
-				Issuer:   fmt.Sprintf("%s/%s/_oidc_testing", msg1.URL, rt1.DatabaseConfig.Name),
-				ClientID: "sync_gateway",
-				Register: true,
-				// this UsernameClaim is critical - we'll generate two users from two different OIDC issuers but with the same username
-				UsernameClaim: "username",
-				ChannelsClaim: "channels",
+				JWTConfigCommon: auth.JWTConfigCommon{
+					Issuer:   fmt.Sprintf("%s/%s/_oidc_testing", msg1.URL, rt1.DatabaseConfig.Name),
+					ClientID: base.StringPtr("sync_gateway"),
+					Register: true,
+					// this UsernameClaim is critical - we'll generate two users from two different OIDC issuers but with the same username
+					UsernameClaim: "username",
+					ChannelsClaim: "channels",
+				},
 			},
 			"test2": &auth.OIDCProvider{
-				Issuer:        fmt.Sprintf("%s/%s/_oidc_testing", msg2.URL, rt2.DatabaseConfig.Name),
-				ClientID:      "sync_gateway",
-				Register:      true,
-				UsernameClaim: "username",
+				JWTConfigCommon: auth.JWTConfigCommon{
+					Issuer:        fmt.Sprintf("%s/%s/_oidc_testing", msg2.URL, rt2.DatabaseConfig.Name),
+					ClientID:      base.StringPtr("sync_gateway"),
+					Register:      true,
+					UsernameClaim: "username",
+				},
 			},
 		},
 	}

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -127,10 +127,12 @@ func TestExtractSubjectFromRefreshToken(t *testing.T) {
 func restTesterConfigWithTestProviderEnabled() RestTesterConfig {
 	providers := auth.OIDCProviderMap{
 		"test": &auth.OIDCProvider{
-			Register:      true,
-			Issuer:        "${baseURL}/db/_oidc_testing",
+			JWTConfigCommon: auth.JWTConfigCommon{
+				Register: true,
+				Issuer:   "${baseURL}/db/_oidc_testing",
+				ClientID: base.StringPtr("sync_gateway"),
+			},
 			Name:          "test",
-			ClientID:      "sync_gateway",
 			ValidationKey: base.StringPtr("qux"),
 			CallbackURL:   base.StringPtr("${baseURL}/db/_oidc_callback"),
 		},
@@ -281,13 +283,15 @@ func TestOpenIDConnectTestProviderWithRealWorldToken(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			providers := auth.OIDCProviderMap{
 				"test": &auth.OIDCProvider{
-					Register:      true,
-					Issuer:        "${baseURL}/db/_oidc_testing",
+					JWTConfigCommon: auth.JWTConfigCommon{
+						Register:   true,
+						Issuer:     "${baseURL}/db/_oidc_testing",
+						ClientID:   base.StringPtr("sync_gateway"),
+						UserPrefix: "foo",
+					},
 					Name:          "test",
-					ClientID:      "sync_gateway",
 					ValidationKey: base.StringPtr("qux"),
 					CallbackURL:   base.StringPtr("${baseURL}/db/_oidc_callback"),
-					UserPrefix:    "foo",
 				},
 			}
 			defaultProvider := "test"
@@ -379,13 +383,15 @@ func TestOpenIDConnectTestProviderWithRealWorldToken(t *testing.T) {
 func TestOIDCWithBasicAuthDisabled(t *testing.T) {
 	providers := auth.OIDCProviderMap{
 		"test": &auth.OIDCProvider{
-			Register:      true,
-			Issuer:        "${baseURL}/db/_oidc_testing",
+			JWTConfigCommon: auth.JWTConfigCommon{
+				Register:   true,
+				Issuer:     "${baseURL}/db/_oidc_testing",
+				ClientID:   base.StringPtr("sync_gateway"),
+				UserPrefix: "foo",
+			},
 			Name:          "test",
-			ClientID:      "sync_gateway",
 			ValidationKey: base.StringPtr("qux"),
 			CallbackURL:   base.StringPtr("${baseURL}/db/_oidc_callback"),
-			UserPrefix:    "foo",
 		},
 	}
 	defaultProvider := "test"


### PR DESCRIPTION
CBG-2140

Sets up the configuration fields for local JWT authentication.

This is a slightly noisy diff - the majority of the changes are from moving some of the OIDC provider config's fields into a shared JWTConfigCommon structure and updating all the manual instantiations of it. The rest of the noise stems from changing `ClientID` from a `string` to a `*string` (per local JWT spec) - this won't functionally affect OIDC, because the OIDC validation (in `NewDatabaseContext`) verifies that it's non-empty. The most interesting files are likely `auth/jwt.go` and `rest/config+config_test.go`.

This doesn't implement all the validation logic, as one more check (duplicate OIDC/JWT issuers) will be broken out into a follow-up PR that refactors some of the OIDC validation logic.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/332/
