### PR TITLE
Up document count for test

### DIFF
--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -807,7 +807,7 @@ func createDocWithInBodyAttachment(t *testing.T, docID string, docBody []byte, a
 // Check for regression of CBG-1980 caused by DCP closing timing issue for the mark and sweep stage
 // May sometimes fail if docsToCreate is not high enough
 func TestAttachmentCompactIncorrectStat(t *testing.T) {
-	const docsToCreate = 500
+	const docsToCreate = 1000
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Requires CBS")
 	}


### PR DESCRIPTION
This test relies on having enough documents so that terminate will be called before all documents are marked. In jekins this test has failed, so increase document count.