### PR TITLE
CBG-2052: Implement Blip Unsub changes for Connected Client protocol

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -268,6 +268,12 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 }
 
 func (bh *blipHandler) handleUnsubChanges(rq *blip.Message) error {
+	bh.lock.Lock()
+	defer bh.lock.Unlock()
+
+	if bh.changesCtx == nil || bh.changesCtxCancel == nil || bh.changesCtx.Err() != nil {
+		return base.HTTPErrorf(http.StatusBadRequest, "No subChanges subscription active to unsubscribe from")
+	}
 	bh.changesCtxCancel()
 	return nil
 }

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -268,7 +268,6 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 }
 
 func (bh *blipHandler) handleUnsubChanges(rq *blip.Message) error {
-	fmt.Println("Unsubscribing from changes")
 	bh.changesCtxCancel()
 	return nil
 }

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -199,8 +199,8 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 		return fmt.Errorf("blipHandler already has an outstanding continous subChanges.  Cannot open another one")
 	}
 
-	// Create ctx if it does not exist or has been closed
-	if bh.changesCtx == nil || bh.changesCtx.Err() != nil {
+	// Create ctx if it has been cancelled
+	if bh.changesCtx.Err() != nil {
 		bh.changesCtx, bh.changesCtxCancel = context.WithCancel(context.Background())
 	}
 
@@ -272,7 +272,7 @@ func (bh *blipHandler) handleUnsubChanges(rq *blip.Message) error {
 	bh.lock.Lock()
 	defer bh.lock.Unlock()
 
-	if bh.changesCtx == nil || bh.changesCtxCancel == nil || bh.changesCtx.Err() != nil {
+	if !bh.activeSubChanges.IsTrue() {
 		return base.HTTPErrorf(http.StatusBadRequest, "No subChanges subscription active to unsubscribe from")
 	}
 	bh.changesCtxCancel()

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -178,8 +178,8 @@ func (bh *blipHandler) handleSetCheckpoint(rq *blip.Message) error {
 
 // Received a "subChanges" subscription request
 func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
-	bh.changesLock.Lock()
-	defer bh.changesLock.Unlock()
+	bh.changesCtxLock.Lock()
+	defer bh.changesCtxLock.Unlock()
 
 	defaultSince := bh.db.CreateZeroSinceValue()
 	latestSeq := func() (SequenceID, error) {
@@ -266,8 +266,8 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 }
 
 func (bh *blipHandler) handleUnsubChanges(rq *blip.Message) error {
-	bh.changesLock.Lock()
-	defer bh.changesLock.Unlock()
+	bh.changesCtxLock.Lock()
+	defer bh.changesCtxLock.Unlock()
 
 	if !bh.activeSubChanges.IsTrue() {
 		return base.HTTPErrorf(http.StatusBadRequest, "No subChanges subscription active to unsubscribe from")

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -269,9 +269,6 @@ func (bh *blipHandler) handleUnsubChanges(rq *blip.Message) error {
 	bh.changesCtxLock.Lock()
 	defer bh.changesCtxLock.Unlock()
 
-	if !bh.activeSubChanges.IsTrue() {
-		return base.HTTPErrorf(http.StatusBadRequest, "No subChanges subscription active to unsubscribe from")
-	}
 	bh.changesCtxCancel()
 	return nil
 }

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -264,8 +264,8 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 }
 
 func (bh *blipHandler) handleUnsubChanges(rq *blip.Message) error {
-	return base.HTTPErrorf(http.StatusNotImplemented, "unsubChanges not implemented yet")
-	// TODO: Implement unsubChanges
+	bh.Close()
+	return nil
 }
 
 type clientType uint8

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -322,7 +322,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 		ActiveOnly:  opts.activeOnly,
 		Revocations: opts.revocations,
 		Terminator:  bh.BlipSyncContext.terminator,
-		Ctx:         bh.loggingCtx,
+		LoggingCtx:  bh.loggingCtx,
 		clientType:  opts.clientType,
 		ChangesCtx:  bh.BlipSyncContext.changesCtx,
 	}

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -203,9 +203,7 @@ func (bsc *BlipSyncContext) Close() {
 		bsc.lock.Lock()
 		defer bsc.lock.Unlock()
 
-		if bsc.changesCtxCancel != nil {
-			bsc.changesCtxCancel()
-		}
+		bsc.changesCtxCancel()
 		close(bsc.terminator)
 	})
 }

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -98,6 +98,8 @@ type BlipSyncContext struct {
 	replicationStats                 *BlipSyncStats                            // Replication stats
 	purgeOnRemoval                   bool                                      // Purges the document when we pull a _removed:true revision.
 	conflictResolver                 *ConflictResolver                         // Conflict resolver for active replications
+	changesCtx                       context.Context                           // Used for the unsub changes Blip message to check if the subChanges feed should stop
+	changesCtxCancel                 context.CancelFunc                        // Cancel function for changesCtx to cancel subChanges being sent
 	changesPendingResponseCount      int64                                     // Number of changes messages pending changesResponse
 	// TODO: For review, whether sendRevAllConflicts needs to be per sendChanges invocation
 	sendRevNoConflicts bool                      // Whether to set noconflicts=true when sending revisions

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -97,7 +97,7 @@ type BlipSyncContext struct {
 	replicationStats                 *BlipSyncStats                            // Replication stats
 	purgeOnRemoval                   bool                                      // Purges the document when we pull a _removed:true revision.
 	conflictResolver                 *ConflictResolver                         // Conflict resolver for active replications
-	changesLock                      sync.Mutex
+	changesCtxLock                   sync.Mutex
 	changesCtx                       context.Context    // Used for the unsub changes Blip message to check if the subChanges feed should stop
 	changesCtxCancel                 context.CancelFunc // Cancel function for changesCtx to cancel subChanges being sent
 	changesPendingResponseCount      int64              // Number of changes messages pending changesResponse
@@ -199,8 +199,8 @@ func (bsc *BlipSyncContext) register(profile string, handlerFn func(*blipHandler
 func (bsc *BlipSyncContext) Close() {
 	bsc.terminatorOnce.Do(func() {
 		// Lock so that we don't close the changesCtx at the same time as handleSubChanges is creating it
-		bsc.changesLock.Lock()
-		defer bsc.changesLock.Unlock()
+		bsc.changesCtxLock.Lock()
+		defer bsc.changesCtxLock.Unlock()
 
 		bsc.changesCtxCancel()
 		close(bsc.terminator)

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1309,7 +1309,7 @@ func TestSkippedViewRetrieval(t *testing.T) {
 
 	// Validate expected entries
 	require.NoError(t, db.changeCache.waitForSequence(base.TestCtx(t), 15, base.DefaultWaitForSequence))
-	entries, err := db.changeCache.GetChanges("ABC", ChangesOptions{Since: SequenceID{Seq: 2}, ChangesCtx: context.Background()})
+	entries, err := db.changeCache.GetChanges("ABC", ChangesOptions{Since: SequenceID{Seq: 2}})
 	assert.NoError(t, err, "Get Changes returned error")
 	assert.Equal(t, 6, len(entries))
 	log.Printf("entries: %v", entries)

--- a/db/changes.go
+++ b/db/changes.go
@@ -525,8 +525,10 @@ func (db *Database) MultiChangesFeed(chans base.Set, options ChangesOptions) (<-
 	}
 
 	if options.ChangesCtx == nil {
-		base.ErrorfCtx(db.Ctx, "MultiChangesFeed: Changes Context not provided")
-		return nil, fmt.Errorf("changes Context not provided when starting multi changes feed")
+		if options.Continuous || options.Wait {
+			base.WarnfCtx(db.Ctx, "MultiChangesFeed: Changes Context missing for Continuous/Wait mode")
+		}
+		options.ChangesCtx = context.Background()
 	}
 	base.DebugfCtx(db.Ctx, base.KeyChanges, "Int sequence multi changes feed...")
 	return db.SimpleMultiChangesFeed(chans, options)

--- a/db/changes.go
+++ b/db/changes.go
@@ -525,11 +525,9 @@ func (db *Database) MultiChangesFeed(chans base.Set, options ChangesOptions) (<-
 	}
 
 	if options.ChangesCtx == nil {
-		if options.Continuous || options.Wait {
-			base.WarnfCtx(db.Ctx, "MultiChangesFeed: Changes Context missing for Continuous/Wait mode")
-		}
-		options.ChangesCtx = context.Background()
+		base.ErrorfCtx(db.Ctx, "MultiChangesFeed: Changes Context missing")
 	}
+
 	base.DebugfCtx(db.Ctx, base.KeyChanges, "Int sequence multi changes feed...")
 	return db.SimpleMultiChangesFeed(chans, options)
 
@@ -1054,7 +1052,7 @@ func (db *Database) waitForCacheUpdate(ctx context.Context, currentCachedSequenc
 	return false
 }
 
-// Synchronous convenience function that returns all changes as a simple array, FOR TEST USE ONLY
+// FOR TEST USE ONLY: Synchronous convenience function that returns all changes as a simple array,
 // Returns error if initial feed creation fails, or if an error is returned with the changes entries
 func (db *Database) GetChanges(channels base.Set, options ChangesOptions) ([]*ChangeEntry, error) {
 	if options.ChangesCtx == nil {

--- a/db/changes.go
+++ b/db/changes.go
@@ -400,7 +400,7 @@ func (db *Database) changesFeed(singleChannelCache SingleChannelCache, options C
 				paginationOptions.Limit = base.MinInt(remainingLimit, queryLimit)
 			}
 
-			// TODO: pass db.LoggingCtx down to changeCache?
+			// TODO: pass db.Ctx down to changeCache?
 			base.TracefCtx(db.Ctx, base.KeyChanges, "Querying channel %q with options: %+v", base.UD(singleChannelCache.ChannelName()), paginationOptions)
 			changes, err := singleChannelCache.GetChanges(paginationOptions)
 			if err != nil {

--- a/db/changes.go
+++ b/db/changes.go
@@ -38,7 +38,7 @@ type ChangesOptions struct {
 	ActiveOnly  bool            // If true, only return information on non-deleted, non-removed revisions
 	Revocations bool            // Specifies whether revocation messages should be sent on the changes feed
 	clientType  clientType      // Can be used to determine if the replication is being started from a CBL 2.x or SGR2 client
-	Ctx         context.Context // Used for adding context to logs
+	LoggingCtx  context.Context // Used for adding context to logs
 	ChangesCtx  context.Context // Used for cancelling checking the changes feed should stop
 }
 
@@ -401,7 +401,7 @@ func (db *Database) changesFeed(singleChannelCache SingleChannelCache, options C
 				paginationOptions.Limit = base.MinInt(remainingLimit, queryLimit)
 			}
 
-			// TODO: pass db.Ctx down to changeCache?
+			// TODO: pass db.LoggingCtx down to changeCache?
 			base.TracefCtx(db.Ctx, base.KeyChanges, "Querying channel %q with options: %+v", base.UD(singleChannelCache.ChannelName()), paginationOptions)
 			changes, err := singleChannelCache.GetChanges(paginationOptions)
 			if err != nil {

--- a/db/changes.go
+++ b/db/changes.go
@@ -1309,9 +1309,7 @@ func generateBlipSyncChanges(database *Database, inChannels base.Set, options Ch
 
 	// Store one-shot here to protect
 	isOneShot := !options.Continuous
-	// Use the context if provided in the options
-	ctx := options.ChangesCtx
-	err, forceClose = GenerateChanges(ctx, database, inChannels, options, docIDFilter, send)
+	err, forceClose = GenerateChanges(options.ChangesCtx, database, inChannels, options, docIDFilter, send)
 
 	if _, ok := err.(*ChangesSendErr); ok {
 		return nil, forceClose // error is probably because the client closed the connection

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -10,6 +10,7 @@ package db
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"testing"
@@ -481,7 +482,8 @@ func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
 		// Changes params: POST /pm/_changes?feed=normal&heartbeat=30000&style=all_docs&active_only=true
 		// Changes request of all docs (could also do GetDoc call, but misses other possible things). One shot, .. etc
 
-		options.Terminator = make(chan bool)
+		changesCtx, changesCtxCancel := context.WithCancel(context.Background())
+		options.ChangesCtx = changesCtx
 		feed, err := db.MultiChangesFeed(base.SetOf("*"), options)
 		if err != nil {
 			b.Fatalf("Error getting changes feed: %v", err)
@@ -492,7 +494,7 @@ func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
 				break
 			}
 		}
-		close(options.Terminator)
+		changesCtxCancel()
 
 	}
 

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -406,8 +406,8 @@ func (c *singleChannelCacheImpl) GetChanges(options ChangesOptions) ([]*LogEntry
 	// Check whether the changes process has been terminated while we waited for the view lock, to avoid the view
 	// overhead in that case (and prevent feedback loop on query backlog)
 	select {
-	case <-options.Terminator:
-		return nil, fmt.Errorf("Changes feed terminated while waiting for view lock")
+	case <-options.ChangesCtx.Done():
+		return nil, fmt.Errorf("Changes feed cancelled while waiting for view lock")
 	default:
 		// continue
 	}

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -371,10 +371,10 @@ func (c *singleChannelCacheImpl) GetChanges(options ChangesOptions) ([]*LogEntry
 	cacheValidFrom, resultFromCache := c.GetCachedChanges(options)
 	numFromCache := len(resultFromCache)
 	if numFromCache > 0 {
-		base.InfofCtx(options.Ctx, base.KeyCache, "GetCachedChanges(%q, %s) --> %d changes valid from #%d",
+		base.InfofCtx(options.LoggingCtx, base.KeyCache, "GetCachedChanges(%q, %s) --> %d changes valid from #%d",
 			base.UD(c.channelName), options.Since.String(), numFromCache, cacheValidFrom)
 	} else {
-		base.DebugfCtx(options.Ctx, base.KeyCache, "GetCachedChanges(%q, %s) --> nothing cached",
+		base.DebugfCtx(options.LoggingCtx, base.KeyCache, "GetCachedChanges(%q, %s) --> nothing cached",
 			base.UD(c.channelName), options.Since.String())
 	}
 	startSeq := options.Since.SafeSequence() + 1
@@ -395,7 +395,7 @@ func (c *singleChannelCacheImpl) GetChanges(options ChangesOptions) ([]*LogEntry
 	// the cache, so repeat the above:
 	cacheValidFrom, resultFromCache = c.GetCachedChanges(options)
 	if len(resultFromCache) > numFromCache {
-		base.InfofCtx(options.Ctx, base.KeyCache, "2nd GetCachedChanges(%q, %s) got %d more, valid from #%d!",
+		base.InfofCtx(options.LoggingCtx, base.KeyCache, "2nd GetCachedChanges(%q, %s) got %d more, valid from #%d!",
 			base.UD(c.channelName), options.Since.String(), len(resultFromCache)-numFromCache, cacheValidFrom)
 	}
 	if cacheValidFrom <= startSeq {
@@ -416,7 +416,7 @@ func (c *singleChannelCacheImpl) GetChanges(options ChangesOptions) ([]*LogEntry
 	// overlap, which helps confirm that we've got everything.
 	c.cacheStats.ChannelCacheMisses.Add(1)
 	endSeq := cacheValidFrom
-	resultFromQuery, err := c.queryHandler.getChangesInChannelFromQuery(options.Ctx, c.channelName, startSeq, endSeq, options.Limit, options.ActiveOnly)
+	resultFromQuery, err := c.queryHandler.getChangesInChannelFromQuery(options.LoggingCtx, c.channelName, startSeq, endSeq, options.Limit, options.ActiveOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -448,7 +448,7 @@ func (c *singleChannelCacheImpl) GetChanges(options ChangesOptions) ([]*LogEntry
 		}
 		result = append(result, resultFromCache[0:n]...)
 	}
-	base.InfofCtx(options.Ctx, base.KeyCache, "GetChangesInChannel(%q) --> %d rows", base.UD(c.channelName), len(result))
+	base.InfofCtx(options.LoggingCtx, base.KeyCache, "GetChangesInChannel(%q) --> %d rows", base.UD(c.channelName), len(result))
 
 	return result, nil
 }
@@ -839,7 +839,7 @@ type bypassChannelCache struct {
 func (b *bypassChannelCache) GetChanges(options ChangesOptions) ([]*LogEntry, error) {
 	startSeq := options.Since.SafeSequence() + 1
 	endSeq := uint64(math.MaxUint64)
-	return b.queryHandler.getChangesInChannelFromQuery(options.Ctx, b.channelName, startSeq, endSeq, options.Limit, options.ActiveOnly)
+	return b.queryHandler.getChangesInChannelFromQuery(options.LoggingCtx, b.channelName, startSeq, endSeq, options.Limit, options.ActiveOnly)
 }
 
 // No cached changes for bypassChannelCache

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -405,7 +405,7 @@ func (c *singleChannelCacheImpl) GetChanges(options ChangesOptions) ([]*LogEntry
 
 	// Check whether the changes process has been terminated while we waited for the view lock, to avoid the view
 	// overhead in that case (and prevent feedback loop on query backlog)
-	if options.ChangesCtx != nil && options.ChangesCtx.Err() != nil {
+	if options.ChangesCtx.Err() != nil {
 		return nil, fmt.Errorf("Changes feed cancelled while waiting for view lock")
 	}
 

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -405,11 +405,8 @@ func (c *singleChannelCacheImpl) GetChanges(options ChangesOptions) ([]*LogEntry
 
 	// Check whether the changes process has been terminated while we waited for the view lock, to avoid the view
 	// overhead in that case (and prevent feedback loop on query backlog)
-	select {
-	case <-options.ChangesCtx.Done():
+	if options.ChangesCtx != nil && options.ChangesCtx.Err() != nil {
 		return nil, fmt.Errorf("Changes feed cancelled while waiting for view lock")
-	default:
-		// continue
 	}
 
 	// Now query the view. We set the max sequence equal to cacheValidFrom, so we'll get one

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -38,7 +38,7 @@ func TestDuplicateDocID(t *testing.T) {
 	cache.addToCache(testLogEntry(2, "doc3", "3-a"), false)
 	cache.addToCache(testLogEntry(3, "doc5", "5-a"), false)
 
-	entries, err := cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 2, 3}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc5"}))
@@ -46,7 +46,7 @@ func TestDuplicateDocID(t *testing.T) {
 
 	// Add a new revision matching mid-list
 	cache.addToCache(testLogEntry(4, "doc3", "3-b"), false)
-	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 3, 4}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc5", "doc3"}))
@@ -54,7 +54,7 @@ func TestDuplicateDocID(t *testing.T) {
 
 	// Add a new revision matching first
 	cache.addToCache(testLogEntry(5, "doc1", "1-b"), false)
-	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{3, 4, 5}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc5", "doc3", "doc1"}))
@@ -62,7 +62,7 @@ func TestDuplicateDocID(t *testing.T) {
 
 	// Add a new revision matching last
 	cache.addToCache(testLogEntry(6, "doc1", "1-c"), false)
-	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{3, 4, 6}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc5", "doc3", "doc1"}))
@@ -85,7 +85,7 @@ func TestLateArrivingSequence(t *testing.T) {
 	cache.addToCache(testLogEntry(3, "doc3", "3-a"), false)
 	cache.addToCache(testLogEntry(5, "doc5", "5-a"), false)
 
-	entries, err := cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 3, 5}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc5"}))
@@ -94,7 +94,7 @@ func TestLateArrivingSequence(t *testing.T) {
 	// Add a late-arriving sequence
 	cache.AddLateSequence(testLogEntry(2, "doc2", "2-a"))
 	cache.addToCache(testLogEntry(2, "doc2", "2-a"), false)
-	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 2, 3, 5}))
@@ -118,7 +118,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	cache.addToCache(testLogEntry(10, "doc2", "2-a"), false)
 	cache.addToCache(testLogEntry(15, "doc3", "3-a"), false)
 
-	entries, err := cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{5, 10, 15}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc2", "doc3"}))
@@ -127,7 +127,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	// Add a late-arriving sequence
 	cache.AddLateSequence(testLogEntry(3, "doc0", "0-a"))
 	cache.addToCache(testLogEntry(3, "doc0", "0-a"), false)
-	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{3, 5, 10, 15}))
@@ -152,7 +152,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	cache.addToCache(testLogEntry(30, "doc3", "3-a"), false)
 	cache.addToCache(testLogEntry(40, "doc4", "4-a"), false)
 
-	entries, err := cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	assert.True(t, verifyChannelSequences(entries, []uint64{10, 20, 30, 40}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc2", "doc3", "doc4"}))
@@ -161,7 +161,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	// Add a late-arriving sequence that should replace earlier sequence
 	cache.AddLateSequence(testLogEntry(25, "doc1", "1-c"))
 	cache.addToCache(testLogEntry(25, "doc1", "1-c"), false)
-	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{20, 25, 30, 40}))
@@ -171,7 +171,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	// Add a late-arriving sequence that should be ignored (later sequence exists for that docID)
 	cache.AddLateSequence(testLogEntry(15, "doc1", "1-b"))
 	cache.addToCache(testLogEntry(15, "doc1", "1-b"), false)
-	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{20, 25, 30, 40}))
@@ -181,7 +181,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	// Add a late-arriving sequence adjacent to same ID (cache inserts differently)
 	cache.AddLateSequence(testLogEntry(27, "doc1", "1-d"))
 	cache.addToCache(testLogEntry(27, "doc1", "1-d"), false)
-	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{20, 27, 30, 40}))
@@ -191,7 +191,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	// Add a late-arriving sequence adjacent to same ID (cache inserts differently)
 	cache.AddLateSequence(testLogEntry(41, "doc4", "4-b"))
 	cache.addToCache(testLogEntry(41, "doc4", "4-b"), false)
-	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{20, 27, 30, 41}))
@@ -201,7 +201,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	// Add late arriving that's duplicate of oldest in cache
 	cache.AddLateSequence(testLogEntry(45, "doc2", "2-b"))
 	cache.addToCache(testLogEntry(45, "doc2", "2-b"), false)
-	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{27, 30, 41, 45}))
@@ -214,12 +214,12 @@ func TestPrependChanges(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	dbCtx, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	defer context.Close()
+	defer dbCtx.Close()
 
 	// 1. Test prepend to empty cache
-	cache := newSingleChannelCache(context, "PrependEmptyCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+	cache := newSingleChannelCache(dbCtx, "PrependEmptyCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	changesToPrepend := LogEntries{
 		testLogEntry(10, "doc3", "2-a"),
 		testLogEntry(12, "doc2", "2-a"),
@@ -230,12 +230,12 @@ func TestPrependChanges(t *testing.T) {
 	assert.Equal(t, 3, numPrepended)
 
 	// Validate cache
-	validFrom, cachedChanges := cache.GetCachedChanges(ChangesOptions{})
+	validFrom, cachedChanges := cache.GetCachedChanges(getChangesOptionsWithCtxOnly())
 	assert.Equal(t, uint64(5), validFrom)
 	require.Len(t, cachedChanges, 3)
 
 	// 2. Test prepend to populated cache, with overlap and duplicates
-	cache = newSingleChannelCache(context, "PrependPopulatedCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+	cache = newSingleChannelCache(dbCtx, "PrependPopulatedCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
 	cache.addToCache(testLogEntry(20, "doc2", "3-a"), false)
@@ -252,7 +252,7 @@ func TestPrependChanges(t *testing.T) {
 	assert.Equal(t, 2, numPrepended)
 
 	// Validate cache
-	validFrom, cachedChanges = cache.GetCachedChanges(ChangesOptions{})
+	validFrom, cachedChanges = cache.GetCachedChanges(getChangesOptionsWithCtxOnly())
 	assert.Equal(t, uint64(5), validFrom)
 	require.Len(t, cachedChanges, 4)
 	if len(cachedChanges) == 4 {
@@ -268,7 +268,7 @@ func TestPrependChanges(t *testing.T) {
 
 	// Write a new revision for a prepended doc to the cache, validate that old entry is removed
 	cache.addToCache(testLogEntry(24, "doc3", "3-a"), false)
-	validFrom, cachedChanges = cache.GetCachedChanges(ChangesOptions{})
+	validFrom, cachedChanges = cache.GetCachedChanges(getChangesOptionsWithCtxOnly())
 	assert.Equal(t, uint64(5), validFrom)
 	require.Len(t, cachedChanges, 4)
 	if len(cachedChanges) == 4 {
@@ -284,12 +284,12 @@ func TestPrependChanges(t *testing.T) {
 
 	// Prepend empty set, validate validFrom update
 	cache.prependChanges(LogEntries{}, 5, 14)
-	validFrom, cachedChanges = cache.GetCachedChanges(ChangesOptions{})
+	validFrom, cachedChanges = cache.GetCachedChanges(getChangesOptionsWithCtxOnly())
 	assert.Equal(t, uint64(5), validFrom)
 	require.Len(t, cachedChanges, 4)
 
 	// 3. Test prepend that exceeds cache capacity
-	cache = newSingleChannelCache(context, "PrependToFillCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+	cache = newSingleChannelCache(dbCtx, "PrependToFillCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
@@ -309,7 +309,7 @@ func TestPrependChanges(t *testing.T) {
 	assert.Equal(t, 1, numPrepended)
 
 	// Validate cache
-	validFrom, cachedChanges = cache.GetCachedChanges(ChangesOptions{})
+	validFrom, cachedChanges = cache.GetCachedChanges(getChangesOptionsWithCtxOnly())
 	assert.Equal(t, uint64(10), validFrom)
 	require.Len(t, cachedChanges, 5)
 	if len(cachedChanges) == 5 {
@@ -326,7 +326,7 @@ func TestPrependChanges(t *testing.T) {
 	}
 
 	// 4. Test prepend where all docids are already present in cache.  Cache entries shouldn't change, but validFrom is updated
-	cache = newSingleChannelCache(context, "PrependDuplicatesOnly", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+	cache = newSingleChannelCache(dbCtx, "PrependDuplicatesOnly", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
 	cache.addToCache(testLogEntry(20, "doc2", "3-a"), false)
@@ -341,7 +341,7 @@ func TestPrependChanges(t *testing.T) {
 	}
 	numPrepended = cache.prependChanges(changesToPrepend, 5, 14)
 	assert.Equal(t, 0, numPrepended)
-	validFrom, cachedChanges = cache.GetCachedChanges(ChangesOptions{})
+	validFrom, cachedChanges = cache.GetCachedChanges(getChangesOptionsWithCtxOnly())
 	assert.Equal(t, uint64(5), validFrom)
 	require.Len(t, cachedChanges, 4)
 	if len(cachedChanges) == 5 {
@@ -356,7 +356,7 @@ func TestPrependChanges(t *testing.T) {
 	}
 
 	// 5. Test prepend for an already full cache
-	cache = newSingleChannelCache(context, "PrependFullCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+	cache = newSingleChannelCache(dbCtx, "PrependFullCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
@@ -377,7 +377,7 @@ func TestPrependChanges(t *testing.T) {
 	assert.Equal(t, 0, numPrepended)
 
 	// Validate cache
-	validFrom, cachedChanges = cache.GetCachedChanges(ChangesOptions{})
+	validFrom, cachedChanges = cache.GetCachedChanges(getChangesOptionsWithCtxOnly())
 	assert.Equal(t, uint64(13), validFrom)
 	require.Len(t, cachedChanges, 5)
 	if len(cachedChanges) == 5 {
@@ -408,7 +408,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	cache.addToCache(testLogEntry(2, "doc3", "3-a"), false)
 	cache.addToCache(testLogEntry(3, "doc5", "5-a"), false)
 
-	entries, err := cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 2, 3}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc5"}))
@@ -416,7 +416,7 @@ func TestChannelCacheRemove(t *testing.T) {
 
 	// Now remove doc1
 	cache.Remove([]string{"doc1"}, time.Now())
-	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 2)
 	assert.True(t, verifyChannelSequences(entries, []uint64{2, 3}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc3", "doc5"}))
@@ -426,7 +426,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	// This will print a debug level log:
 	// [DBG] Cache+: Skipping removal of doc "doc5" from cache "Test1" - received after purge
 	cache.Remove([]string{"doc5"}, time.Now().Add(-time.Second*5))
-	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 2)
 	assert.True(t, verifyChannelSequences(entries, []uint64{2, 3}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc3", "doc5"}))
@@ -613,11 +613,11 @@ func TestBypassSingleChannelCache(t *testing.T) {
 		queryHandler: queryHandler,
 	}
 
-	entries, err := bypassCache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+	entries, err := bypassCache.GetChanges(getChangesOptionsWithZeroSeq())
 	assert.NoError(t, err)
 	require.Len(t, entries, 10)
 
-	validFrom, cachedEntries := bypassCache.GetCachedChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+	validFrom, cachedEntries := bypassCache.GetCachedChanges(getChangesOptionsWithZeroSeq())
 	assert.Equal(t, uint64(math.MaxUint64), validFrom)
 	require.Len(t, cachedEntries, 0)
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -9,6 +9,7 @@
 package db
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -824,8 +825,9 @@ func TestAllDocsOnly(t *testing.T) {
 
 	// Now check the changes feed:
 	var options ChangesOptions
-	options.Terminator = make(chan bool)
-	defer close(options.Terminator)
+	changesCtx, changesCtxCancel := context.WithCancel(context.Background())
+	options.ChangesCtx = changesCtx
+	defer changesCtxCancel()
 	changes, err := db.GetChanges(channels.SetOf(t, "all"), options)
 	assert.NoError(t, err, "Couldn't GetChanges")
 	require.Len(t, changes, 100)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1009,7 +1009,8 @@ func TestConflicts(t *testing.T) {
 
 	// Verify the _changes feed:
 	options := ChangesOptions{
-		Conflicts: true,
+		Conflicts:  true,
+		ChangesCtx: context.Background(),
 	}
 	changes, err := db.GetChanges(channels.SetOf(t, "all"), options)
 	assert.NoError(t, err, "Couldn't GetChanges")

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -4635,7 +4635,7 @@ func TestUnsubChanged(t *testing.T) {
 	_, err = unsubChangesResponse.Body()
 	require.NoError(t, err)
 
-	// Confirm no more chnages being sent
+	// Confirm no more changes being sent
 	resp = rt.updateDoc("doc2", "", `{"key":"val1"}`)
 	err = rt.WaitForConditionWithOptions(func() bool {
 		_, found = btc.GetRev("doc2", resp.Rev)
@@ -4643,6 +4643,7 @@ func TestUnsubChanged(t *testing.T) {
 	}, 10, 100)
 	assert.Error(t, err)
 
+	// Confirm the pull replication can be restarted and it sync doc2
 	err = btc.StartPull()
 	require.NoError(t, err)
 	_, found = btc.WaitForRev("doc2", resp.Rev)

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -4611,7 +4611,6 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 }
 
 func TestUnsubChanges(t *testing.T) {
-	const noSubchangesError = "No subChanges subscription active to unsubscribe from"
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
@@ -4620,10 +4619,10 @@ func TestUnsubChanges(t *testing.T) {
 	require.NoError(t, err)
 	defer btc.Close()
 
-	// Confirm correct error message returned when no subchanges active
+	// Confirm no error message or panic is returned in response
 	response, err := btc.UnsubPullChanges()
 	assert.NoError(t, err)
-	assert.EqualValues(t, noSubchangesError, response)
+	assert.Empty(t, response)
 
 	// Sub changes
 	err = btc.StartPull()
@@ -4651,10 +4650,10 @@ func TestUnsubChanges(t *testing.T) {
 	}, 10, 100)
 	assert.Error(t, err)
 
-	// Confirm correct error message is still returned when no subchanges active
+	// Confirm no error message is still returned when no subchanges active
 	response, err = btc.UnsubPullChanges()
 	assert.NoError(t, err)
-	assert.EqualValues(t, noSubchangesError, response)
+	assert.Empty(t, response)
 
 	// Confirm the pull replication can be restarted and it syncs doc2
 	err = btc.StartPull()

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -4643,4 +4643,8 @@ func TestUnsubChanged(t *testing.T) {
 	}, 10, 100)
 	assert.Error(t, err)
 
+	err = btc.StartPull()
+	require.NoError(t, err)
+	_, found = btc.WaitForRev("doc2", resp.Rev)
+	assert.True(t, found)
 }

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -556,6 +556,30 @@ func (btc *BlipTesterClient) StartPullSince(continuous, since, activeOnly string
 	return nil
 }
 
+func (btc *BlipTesterClient) UnsubPullChanges() (response []byte, err error) {
+	unsubChangesRequest := blip.NewRequest()
+	unsubChangesRequest.SetProfile(db.MessageUnsubChanges)
+	err = btc.pullReplication.sendMsg(unsubChangesRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err = unsubChangesRequest.Response().Body()
+	return response, err
+}
+
+func (btc *BlipTesterClient) UnsubPushChanges() (response []byte, err error) {
+	unsubChangesRequest := blip.NewRequest()
+	unsubChangesRequest.SetProfile(db.MessageUnsubChanges)
+	err = btc.pushReplication.sendMsg(unsubChangesRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err = unsubChangesRequest.Response().Body()
+	return response, err
+}
+
 // Close will empty the stored docs and close the underlying replications.
 func (btc *BlipTesterClient) Close() {
 	btc.docsLock.Lock()


### PR DESCRIPTION
CBG-2052

-  Replaced changes feed terminator option with cancellable context
- Unsub changes cancels the context if it exists, otherwise returns an error
- Unsub changes uses a lock to make sure that the context is not created by subChanges while unsubChanges is checking if the context exists
- Added a lock for when closing the blip handler
- Added testing for this

- Changed changes options `Ctx` to be called `LoggingCtx`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/391
