### PR TITLE
Backport Jenkinsfile fix to 2.8.3.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -379,7 +379,7 @@ pipeline {
             cobertura autoUpdateHealth: false, onlyStable: false, autoUpdateStability: false, coberturaReportFile: 'reports/coverage-*.xml', conditionalCoverageTargets: '70, 0, 0', failNoReports: false, failUnhealthy: false, failUnstable: false, lineCoverageTargets: '80, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '80, 0, 0', sourceEncoding: 'ASCII', zoomCoverageChart: false
 
             // Publish the junit test reports
-            junit allowEmptyResults: true, testDataPublishers: [[$class: 'JUnitFlakyTestDataPublisher']], testResults: 'reports/test-*.xml'
+            junit allowEmptyResults: true, testResults: 'reports/test-*.xml'
 
             // TODO: Might be better to clean the workspace to before a job runs instead
             step([$class: 'WsCleanup'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,8 @@ pipeline {
                 // to clone directly into a subdirectory instead?
                 sh 'mkdir .scm-checkout'
                 sh 'mv * .scm-checkout/'
+                // forces go to get private modules via ssh
+                sh 'git config --global url."git@github.com:".insteadOf "https://github.com/"'
             }
         }
         stage('Setup') {


### PR DESCRIPTION
Backport recent pipeline fix to remove `JUnitFlakyTest` from Jenkins.

This will cause the pipeline to report the correct status of the tests instead of failing each time.

Changed on master in commit: https://github.com/couchbase/sync_gateway/commit/234006a19ed7460b7844c6dda9a449d168ee6d75 

Dependencies
- [ ] Pipeline passed on this PR