### PR TITLE
CBD-4471, include notices.txt in the rpm.

### DIFF
--- a/build/rpm.spec.tmpl
+++ b/build/rpm.spec.tmpl
@@ -52,6 +52,11 @@ export DONT_STRIP=1
 rm -rf %{buildroot}
 mkdir -p %{buildroot}@@PREFIX@@
 gtar cf - * | (cd %{buildroot}@@PREFIX@@ ; gtar xf -)
+extra_files=%{buildroot}/extra.list
+touch %{extra_files}
+if [ -f %{buildroot}@@PREFIX@@/notices.txt ]; then
+echo @@PREFIX@@/notices.txt > %{extra_files}
+fi
 
 %clean
 
@@ -189,7 +194,7 @@ EOF
 
 exit 0
 
-%files
+%files -f %{extra_files}
 %defattr(-,bin,bin,-)
 
 # Directory structure


### PR DESCRIPTION
CBD-4471

Describe your PR here...
- Include notices.txt in the rpm.  notices.txt is generated by blackduck.  It contains 3rd party component license info.  We want to include it in the artifacts as described in CBD-4471.  

## Pre-review checklist (remove once done)

## Dependencies (if applicable)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)

