### PR TITLE
CBG-2073 update local message map after reading response

### DIFF
--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -114,7 +114,6 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 	}
 
 	btr.bt.blipContext.HandlerForProfile[db.MessageChanges] = func(msg *blip.Message) {
-		btr.storeMessage(msg)
 
 		// Exit early when there's nothing to do
 		if msg.NoReply() {
@@ -200,6 +199,8 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 		}
 
 		response.SetBody(b)
+		// Set message cafter msg.Response() which can change the state of the message
+		btr.storeMessage(msg)
 	}
 
 	btr.bt.blipContext.HandlerForProfile[db.MessageProposeChanges] = func(msg *blip.Message) {


### PR DESCRIPTION
Calling msg.Response() will wait for blip responseComplete in case it actually hasn't fully read the body correctly. Putting the addition to the map matches the behavior of the other handlers.

This race isn't very reproducible so this fix is speculative.

- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/346/
