### PR TITLE
CBG-2172: Improve reliability of TestAttachmentCompactIncorrectStat

### DIFF
--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -124,13 +124,13 @@ func attachmentCompactMarkPhase(db *Database, compactionID string, terminator *b
 	dcpFeedKey := compactionID + "_mark"
 	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, db.Bucket, db.Options.GroupID)
 	if err != nil {
-		base.WarnfCtx(db.Ctx, "[%s] Failed to create DCP client! %v", compactionLoggingID, err)
+		base.WarnfCtx(db.Ctx, "[%s] Failed to create attachment compaction DCP client! %v", compactionLoggingID, err)
 		return 0, nil, err
 	}
 
 	doneChan, err := dcpClient.Start()
 	if err != nil {
-		base.WarnfCtx(db.Ctx, "[%s] Failed to start DCP feed! %v", compactionLoggingID, err)
+		base.WarnfCtx(db.Ctx, "[%s] Failed to start attachment compaction DCP feed! %v", compactionLoggingID, err)
 		_ = dcpClient.Close()
 		return 0, nil, err
 	}
@@ -343,13 +343,13 @@ func attachmentCompactSweepPhase(db *Database, compactionID string, vbUUIDs []ui
 	base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Starting DCP feed %q for sweep phase of attachment compaction", compactionLoggingID, dcpFeedKey)
 	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, db.Bucket, db.Options.GroupID)
 	if err != nil {
-		base.WarnfCtx(db.Ctx, "[%s] Failed to create DCP client! %v", compactionLoggingID, err)
+		base.WarnfCtx(db.Ctx, "[%s] Failed to create attachment compaction DCP client! %v", compactionLoggingID, err)
 		return 0, err
 	}
 
 	doneChan, err := dcpClient.Start()
 	if err != nil {
-		base.WarnfCtx(db.Ctx, "[%s] Failed to start DCP feed! %v", compactionLoggingID, err)
+		base.WarnfCtx(db.Ctx, "[%s] Failed to start attachment compaction DCP feed! %v", compactionLoggingID, err)
 		_ = dcpClient.Close()
 		return 0, err
 	}
@@ -363,7 +363,7 @@ func attachmentCompactSweepPhase(db *Database, compactionID string, vbUUIDs []ui
 		base.DebugfCtx(db.Ctx, base.KeyAll, "[%s] Terminator closed. Ending sweep phase.", compactionLoggingID)
 		err = dcpClient.Close()
 		if err != nil {
-			base.WarnfCtx(db.Ctx, "[%s] Failed to close DCP client! %v", compactionLoggingID, err)
+			base.WarnfCtx(db.Ctx, "[%s] Failed to close attachment compaction DCP client! %v", compactionLoggingID, err)
 			return purgedAttachmentCount.Value(), err
 		}
 
@@ -473,11 +473,13 @@ func attachmentCompactCleanupPhase(db *Database, compactionID string, vbUUIDs []
 	dcpFeedKey := compactionID + "_cleanup"
 	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, db.Bucket, db.Options.GroupID)
 	if err != nil {
+		base.WarnfCtx(db.Ctx, "[%s] Failed to create attachment compaction DCP client! %v", compactionLoggingID, err)
 		return err
 	}
 
 	doneChan, err := dcpClient.Start()
 	if err != nil {
+		base.WarnfCtx(db.Ctx, "[%s] Failed to start attachment compaction DCP feed! %v", compactionLoggingID, err)
 		_ = dcpClient.Close()
 		return err
 	}
@@ -489,6 +491,7 @@ func attachmentCompactCleanupPhase(db *Database, compactionID string, vbUUIDs []
 	case <-terminator.Done():
 		err = dcpClient.Close()
 		if err != nil {
+			base.WarnfCtx(db.Ctx, "[%s] Failed to close attachment compaction DCP client! %v", compactionLoggingID, err)
 			return err
 		}
 

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -30,6 +30,7 @@ func attachmentCompactMarkPhase(db *Database, compactionID string, terminator *b
 
 	callback := func(event sgbucket.FeedEvent) bool {
 		docID := string(event.Key)
+		base.TracefCtx(db.Ctx, base.KeyAll, "[%s] Received DCP event %d for doc %v", compactionLoggingID, event.Opcode, base.UD(docID))
 
 		// We've had an error previously so no point doing work for any remaining items
 		if markProcessFailureErr != nil {
@@ -123,14 +124,17 @@ func attachmentCompactMarkPhase(db *Database, compactionID string, terminator *b
 	dcpFeedKey := compactionID + "_mark"
 	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, db.Bucket, db.Options.GroupID)
 	if err != nil {
+		base.WarnfCtx(db.Ctx, "[%s] Failed to create DCP client! %v", compactionLoggingID, err)
 		return 0, nil, err
 	}
 
 	doneChan, err := dcpClient.Start()
 	if err != nil {
+		base.WarnfCtx(db.Ctx, "[%s] Failed to start DCP feed! %v", compactionLoggingID, err)
 		_ = dcpClient.Close()
 		return 0, nil, err
 	}
+	base.DebugfCtx(db.Ctx, base.KeyAll, "[%s] DCP feed started.", compactionLoggingID)
 
 	select {
 	case <-doneChan:
@@ -140,6 +144,7 @@ func attachmentCompactMarkPhase(db *Database, compactionID string, terminator *b
 			return markedAttachmentCount.Value(), nil, markProcessFailureErr
 		}
 	case <-terminator.Done():
+		base.DebugfCtx(db.Ctx, base.KeyAll, "[%s] Terminator closed. Stopping mark phase.", compactionLoggingID)
 		err = dcpClient.Close()
 		if markProcessFailureErr != nil {
 			return markedAttachmentCount.Value(), nil, markProcessFailureErr
@@ -274,6 +279,7 @@ func attachmentCompactSweepPhase(db *Database, compactionID string, vbUUIDs []ui
 	// be deleted.
 	callback := func(event sgbucket.FeedEvent) bool {
 		docID := string(event.Key)
+		base.TracefCtx(db.Ctx, base.KeyAll, "[%s] Received DCP event %d for doc %v", compactionLoggingID, event.Opcode, base.UD(docID))
 
 		// We only want to look over v1 attachment docs, skip otherwise
 		if !strings.HasPrefix(docID, base.AttPrefix) {
@@ -311,6 +317,7 @@ func attachmentCompactSweepPhase(db *Database, compactionID string, vbUUIDs []ui
 		// in compactionID
 		// Therefore, we want to purge the doc (unless running as dryRun mode)
 		if !dryRun {
+			base.TracefCtx(db.Ctx, base.KeyAll, "[%s] Purging attachment %s", compactionLoggingID, base.UD(docID))
 			_, err := db.Bucket.Remove(docID, event.Cas)
 			if err != nil {
 				base.WarnfCtx(db.Ctx, "[%s] Unable to purge attachment %s: %v", compactionLoggingID, base.UD(docID), err)
@@ -332,26 +339,31 @@ func attachmentCompactSweepPhase(db *Database, compactionID string, vbUUIDs []ui
 		InitialMetadata: base.BuildDCPMetadataSliceFromVBUUIDs(vbUUIDs),
 	}
 
-	base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Starting DCP feed for sweep phase of attachment compaction", compactionLoggingID)
 	dcpFeedKey := compactionID + "_sweep"
+	base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Starting DCP feed %q for sweep phase of attachment compaction", compactionLoggingID, dcpFeedKey)
 	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, db.Bucket, db.Options.GroupID)
 	if err != nil {
+		base.WarnfCtx(db.Ctx, "[%s] Failed to create DCP client! %v", compactionLoggingID, err)
 		return 0, err
 	}
 
 	doneChan, err := dcpClient.Start()
 	if err != nil {
+		base.WarnfCtx(db.Ctx, "[%s] Failed to start DCP feed! %v", compactionLoggingID, err)
 		_ = dcpClient.Close()
 		return 0, err
 	}
+	base.DebugfCtx(db.Ctx, base.KeyAll, "[%s] DCP client started.", compactionLoggingID)
 
 	select {
 	case <-doneChan:
 		base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Sweep phase of attachment compaction completed. Deleted %d attachments", compactionLoggingID, purgedAttachmentCount.Value())
 		err = dcpClient.Close()
 	case <-terminator.Done():
+		base.DebugfCtx(db.Ctx, base.KeyAll, "[%s] Terminator closed. Ending sweep phase.", compactionLoggingID)
 		err = dcpClient.Close()
 		if err != nil {
+			base.WarnfCtx(db.Ctx, "[%s] Failed to close DCP client! %v", compactionLoggingID, err)
 			return purgedAttachmentCount.Value(), err
 		}
 

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -856,12 +856,16 @@ func TestAttachmentCompactIncorrectStat(t *testing.T) {
 		return false, nil, nil
 	}
 
-	// The timeToSleepMs here is low to ensure that this retry loop finishes after the mark starts, but before it has time to finish
-	err, _ := base.RetryLoop("wait for marking to start", statAboveZeroRetryFunc, base.CreateSleeperFunc(3_000, 10))
+	const (
+		maxAttempts = 3_000
+		// The timeToSleepMs here is low to ensure that this retry loop finishes after the mark starts, but before it has time to finish
+		timeToSleepMs = 10
+	)
+	err, _ := base.RetryLoop("wait for marking to start", statAboveZeroRetryFunc, base.CreateSleeperFunc(maxAttempts, timeToSleepMs))
 	require.NoError(t, err)
 
 	terminator.Close() // Terminate mark function
-	err, _ = base.RetryLoop("wait for marking function to return", compactionFuncReturnedRetryFunc, base.CreateSleeperFunc(3_000, 10))
+	err, _ = base.RetryLoop("wait for marking function to return", compactionFuncReturnedRetryFunc, base.CreateSleeperFunc(maxAttempts, timeToSleepMs))
 	require.NoError(t, err)
 	// Allow time for timing issue to be hit where stat increments when it shouldn't
 	time.Sleep(time.Second * 1)
@@ -881,11 +885,11 @@ func TestAttachmentCompactIncorrectStat(t *testing.T) {
 	}()
 
 	// The timeToSleepMs here is low to ensure that this retry loop finishes after the sweep starts, but before it has time to finish
-	err, _ = base.RetryLoop("wait for sweeping to start", statAboveZeroRetryFunc, base.CreateSleeperFunc(3_000, 10))
+	err, _ = base.RetryLoop("wait for sweeping to start", statAboveZeroRetryFunc, base.CreateSleeperFunc(maxAttempts, timeToSleepMs))
 	require.NoError(t, err)
 
 	terminator.Close() // Terminate sweep function
-	err, _ = base.RetryLoop("wait for sweeping function to return", compactionFuncReturnedRetryFunc, base.CreateSleeperFunc(3_000, 10))
+	err, _ = base.RetryLoop("wait for sweeping function to return", compactionFuncReturnedRetryFunc, base.CreateSleeperFunc(maxAttempts, timeToSleepMs))
 	require.NoError(t, err)
 	// Allow time for timing issue to be hit where stat increments when it shouldn't
 	time.Sleep(time.Second * 1)

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -807,7 +807,7 @@ func createDocWithInBodyAttachment(t *testing.T, docID string, docBody []byte, a
 // Check for regression of CBG-1980 caused by DCP closing timing issue for the mark and sweep stage
 // May sometimes fail if docsToCreate is not high enough
 func TestAttachmentCompactIncorrectStat(t *testing.T) {
-	const docsToCreate = 1000
+	const docsToCreate = 10_000
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Requires CBS")
 	}
@@ -836,7 +836,6 @@ func TestAttachmentCompactIncorrectStat(t *testing.T) {
 	terminator := base.NewSafeTerminator()
 	stat := &base.AtomicInt{}
 	count := int64(0)
-	var err error
 	go func() {
 		attachmentCount, _, err := attachmentCompactMarkPhase(testDb, "mark", terminator, stat)
 		atomic.StoreInt64(&count, attachmentCount)
@@ -857,11 +856,12 @@ func TestAttachmentCompactIncorrectStat(t *testing.T) {
 		return false, nil, nil
 	}
 
-	err, _ = base.RetryLoop("wait for marking to start", statAboveZeroRetryFunc, base.CreateSleeperFunc(1000, 1))
+	// The timeToSleepMs here is low to ensure that this retry loop finishes after the mark starts, but before it has time to finish
+	err, _ := base.RetryLoop("wait for marking to start", statAboveZeroRetryFunc, base.CreateSleeperFunc(3_000, 10))
 	require.NoError(t, err)
 
 	terminator.Close() // Terminate mark function
-	err, _ = base.RetryLoop("wait for marking function to return", compactionFuncReturnedRetryFunc, base.CreateSleeperFunc(200, 100))
+	err, _ = base.RetryLoop("wait for marking function to return", compactionFuncReturnedRetryFunc, base.CreateSleeperFunc(3_000, 10))
 	require.NoError(t, err)
 	// Allow time for timing issue to be hit where stat increments when it shouldn't
 	time.Sleep(time.Second * 1)
@@ -880,11 +880,12 @@ func TestAttachmentCompactIncorrectStat(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	err, _ = base.RetryLoop("wait for sweeping to start", statAboveZeroRetryFunc, base.CreateSleeperFunc(1000, 1))
+	// The timeToSleepMs here is low to ensure that this retry loop finishes after the sweep starts, but before it has time to finish
+	err, _ = base.RetryLoop("wait for sweeping to start", statAboveZeroRetryFunc, base.CreateSleeperFunc(3_000, 10))
 	require.NoError(t, err)
 
 	terminator.Close() // Terminate sweep function
-	err, _ = base.RetryLoop("wait for sweeping function to return", compactionFuncReturnedRetryFunc, base.CreateSleeperFunc(200, 100))
+	err, _ = base.RetryLoop("wait for sweeping function to return", compactionFuncReturnedRetryFunc, base.CreateSleeperFunc(3_000, 10))
 	require.NoError(t, err)
 	// Allow time for timing issue to be hit where stat increments when it shouldn't
 	time.Sleep(time.Second * 1)


### PR DESCRIPTION
CBG-2172

`TestAttachmentCompactIncorrectStat` has been somewhat flakey. This PR attempts to address that in two ways:

- Increasing the number of docs to process, to make it more likely that the mark/sweeps won't process them all
- Increasing the retry loop timeouts to make the test more forgiving of slower systems

It also adds extra debug/trace logging to help debug further flake.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/349/
