### PR TITLE
fix lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,7 +62,7 @@ linters:
 # Disable goconst in test files, often we have duplicated strings across tests, but don't make sense as constants.
 issues:
   exclude-rules:
-    - path: _test\.go
+    - path: (_test\.go|utilities_testing\.go)
       linters:
         - goconst
   govet:

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -53,6 +53,7 @@ type blipHandler struct {
 	serialNumber uint64    // This blip handler's serial number to differentiate logs w/ other handlers
 }
 
+// BlipSyncContextClientType represents whether to replicate to another Sync Gateway or Couchbase Lite
 type BLIPSyncContextClientType string
 
 const (

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2005,7 +2005,7 @@ func TestPurgeWithChannelCache(t *testing.T) {
 	assertStatus(t, rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar", "channels": ["abc", "def"]}`), http.StatusCreated)
 	assertStatus(t, rt.SendAdminRequest("PUT", "/db/doc2", `{"moo":"car", "channels": ["abc"]}`), http.StatusCreated)
 
-	changes, err := rt.WaitForChanges(2, "/db/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
+	changes, err := rt.waitForChanges(2, "/db/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
 	assert.NoError(t, err, "Error waiting for changes")
 	assert.Equal(t, "doc1", changes.Results[0].ID)
 	assert.Equal(t, "doc2", changes.Results[1].ID)
@@ -2017,7 +2017,7 @@ func TestPurgeWithChannelCache(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &body))
 	assert.Equal(t, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}}}, body)
 
-	changes, err = rt.WaitForChanges(1, "/db/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
+	changes, err = rt.waitForChanges(1, "/db/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
 	assert.NoError(t, err, "Error waiting for changes")
 	assert.Equal(t, "doc2", changes.Results[0].ID)
 
@@ -4554,7 +4554,7 @@ function (doc) {
 			value, _ := base.WaitForStat(receiverRT.GetDatabase().DbStats.Database().NumDocWrites.Value, 6)
 			assert.EqualValues(t, 6, value)
 
-			changesResults, err := receiverRT.WaitForChanges(6, "/db/_changes?since=0&include_docs=true", "", true)
+			changesResults, err := receiverRT.waitForChanges(6, "/db/_changes?since=0&include_docs=true", "", true)
 			assert.NoError(t, err)
 			assert.Len(t, changesResults.Results, 6)
 			// Check the docs are alices docs

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2467,7 +2467,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	assert.Equal(t, 9, changeCount)
 
 	expectedIDs := []string{"beta", "delta", "gamma", "a1", "b1", "d1", "g1", "alpha", "epsilon"}
-	changes, err = rt.WaitForChanges(len(expectedIDs), "/db/_changes", "alice", false)
+	changes, err = rt.waitForChanges(len(expectedIDs), "/db/_changes", "alice", false)
 	assert.NoError(t, err, "Unexpected error")
 	log.Printf("_changes looks like: %+v", changes)
 	assert.Equal(t, len(expectedIDs), len(changes.Results))
@@ -2858,14 +2858,14 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	}
 
 	limit := 50
-	changesResults, err := rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user1", false)
+	changesResults, err := rt.waitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user1", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 50)
 	since := changesResults.Results[49].Seq
 	assert.Equal(t, "doc48", changesResults.Results[49].ID)
 
 	// // Check the _changes feed with  since and limit, to get second half of feed
-	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?since=\"%s\"&limit=%d", since, limit), "user1", false)
+	changesResults, err = rt.waitForChanges(50, fmt.Sprintf("/db/_changes?since=\"%s\"&limit=%d", since, limit), "user1", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 50)
 	since = changesResults.Results[49].Seq
@@ -2876,7 +2876,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	// Retrieve all changes for user2 with no limits
-	changesResults, err = rt.WaitForChanges(101, fmt.Sprintf("/db/_changes"), "user2", false)
+	changesResults, err = rt.waitForChanges(101, fmt.Sprintf("/db/_changes"), "user2", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 101)
 	assert.Equal(t, "doc99", changesResults.Results[99].ID)
@@ -2894,7 +2894,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	userSequence := user3.Sequence()
 
 	// Get first 50 document changes.
-	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user3", false)
+	changesResults, err = rt.waitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user3", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 50)
 	since = changesResults.Results[49].Seq
@@ -2902,7 +2902,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, userSequence, since.TriggeredBy)
 
 	// // Get remainder of changes i.e. no limit parameter
-	changesResults, err = rt.WaitForChanges(51, fmt.Sprintf("/db/_changes?since=\"%s\"", since), "user3", false)
+	changesResults, err = rt.waitForChanges(51, fmt.Sprintf("/db/_changes?since=\"%s\"", since), "user3", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 51)
 	assert.Equal(t, "doc99", changesResults.Results[49].ID)
@@ -2914,7 +2914,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	user4, _ := rt.GetDatabase().Authenticator(base.TestCtx(t)).GetUser("user4")
 	user4Sequence := user4.Sequence()
 
-	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user4", false)
+	changesResults, err = rt.waitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user4", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 50)
 	since = changesResults.Results[49].Seq
@@ -2922,7 +2922,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, user4Sequence, since.TriggeredBy)
 
 	// // Check the _changes feed with  since and limit, to get second half of feed
-	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?since=%s&limit=%d", since, limit), "user4", false)
+	changesResults, err = rt.waitForChanges(50, fmt.Sprintf("/db/_changes?since=%s&limit=%d", since, limit), "user4", false)
 	assert.Equal(t, nil, err)
 	require.Len(t, changesResults.Results, 50)
 	assert.Equal(t, "doc99", changesResults.Results[49].ID)
@@ -7407,7 +7407,7 @@ func TestRevocationWithAdminChannels(t *testing.T) {
 	resp = rt.SendAdminRequest("PUT", "/db/doc", `{"channels": ["A"]}`)
 	assertStatus(t, resp, http.StatusCreated)
 
-	changes, err := rt.WaitForChanges(2, "/db/_changes?since=0&revocations=true", "user", false)
+	changes, err := rt.waitForChanges(2, "/db/_changes?since=0&revocations=true", "user", false)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(changes.Results))
 
@@ -7417,7 +7417,7 @@ func TestRevocationWithAdminChannels(t *testing.T) {
 	resp = rt.SendAdminRequest("PUT", "/db/_user/user", `{"admin_channels": [], "password": "letmein"}`)
 	assertStatus(t, resp, http.StatusOK)
 
-	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/db/_changes?since=%d&revocations=true", 2), "user", false)
+	changes, err = rt.waitForChanges(2, fmt.Sprintf("/db/_changes?since=%d&revocations=true", 2), "user", false)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(changes.Results))
 
@@ -7440,7 +7440,7 @@ func TestRevocationWithAdminRoles(t *testing.T) {
 	resp = rt.SendAdminRequest("PUT", "/db/doc", `{"channels": ["A"]}`)
 	assertStatus(t, resp, http.StatusCreated)
 
-	changes, err := rt.WaitForChanges(2, "/db/_changes?since=0&revocations=true", "user", false)
+	changes, err := rt.waitForChanges(2, "/db/_changes?since=0&revocations=true", "user", false)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(changes.Results))
 
@@ -7450,7 +7450,7 @@ func TestRevocationWithAdminRoles(t *testing.T) {
 	resp = rt.SendAdminRequest("PUT", "/db/_user/user", `{"admin_roles": []}`)
 	assertStatus(t, resp, http.StatusOK)
 
-	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/db/_changes?since=%d&revocations=true", 3), "user", false)
+	changes, err = rt.waitForChanges(2, fmt.Sprintf("/db/_changes?since=%d&revocations=true", 3), "user", false)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(changes.Results))
 
@@ -8810,7 +8810,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		require.NoError(t, err, "Unable to delete doc %q", docID)
 
 		// Wait until the "delete" mutation appears on the changes feed.
-		changes, err := rt.WaitForChanges(1, "/db/_changes", "", true)
+		changes, err := rt.waitForChanges(1, "/db/_changes", "", true)
 		assert.NoError(t, err, "Error waiting for changes")
 		log.Printf("changes: %+v", changes)
 		rt.requireDocNotFound(docID)
@@ -8863,7 +8863,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		require.NoError(t, err, "Error updating the document")
 
 		// Wait until the "update" mutation appears on the changes feed.
-		changes, err := rt.WaitForChanges(1, "/db/_changes", "", true)
+		changes, err := rt.waitForChanges(1, "/db/_changes", "", true)
 		assert.NoError(t, err, "Error waiting for changes")
 		log.Printf("changes: %+v", changes)
 

--- a/rest/api_test_helpers_test.go
+++ b/rest/api_test_helpers_test.go
@@ -115,7 +115,7 @@ func (rt *RestTester) putNewEditsFalse(docID string, newRevID string, parentRevI
 }
 
 func (rt *RestTester) RequireWaitChanges(numChangesExpected int, since string) changesResults {
-	changesResults, err := rt.WaitForChanges(numChangesExpected, "/db/_changes?since="+since, "", true)
+	changesResults, err := rt.waitForChanges(numChangesExpected, "/db/_changes?since="+since, "", true)
 	require.NoError(rt.tb, err)
 	require.Len(rt.tb, changesResults.Results, numChangesExpected)
 	return changesResults

--- a/rest/blip_api_no_race_test.go
+++ b/rest/blip_api_no_race_test.go
@@ -75,7 +75,7 @@ func TestBlipPusherUpdateDatabase(t *testing.T) {
 	}()
 
 	// and wait for a few to be done before we proceed with updating database config underneath replication
-	_, err = rt.WaitForChanges(5, "/db/_changes", "", true)
+	_, err = rt.waitForChanges(5, "/db/_changes", "", true)
 	require.NoError(t, err)
 
 	// just change the sync function to cause the database to reload

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -330,10 +330,10 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 				}
 
 				// Verify doc id and rev id have expected vals
-				docId := change[1].(string)
-				assert.True(t, strings.HasPrefix(docId, "preOneShot"))
+				docID := change[1].(string)
+				assert.True(t, strings.HasPrefix(docID, "preOneShot"))
 				assert.Equal(t, "1-abc", change[2]) // Rev id of pushed rev
-				docIdsReceived[docId] = true
+				docIdsReceived[docID] = true
 				receivedChangesWg.Done()
 			}
 
@@ -495,18 +495,18 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 				}
 
 				// Verify doc id and rev id have expected vals
-				docId := change[1].(string)
-				assert.True(t, strings.HasPrefix(docId, "docIDFiltered"))
+				docID := change[1].(string)
+				assert.True(t, strings.HasPrefix(docID, "docIDFiltered"))
 				assert.Equal(t, "1-abc", change[2]) // Rev id of pushed rev
-				log.Printf("Changes got docID: %s", docId)
+				log.Printf("Changes got docID: %s", docID)
 
 				// Ensure we only receive expected docs
-				_, isExpected := docIDsReceived[docId]
+				_, isExpected := docIDsReceived[docID]
 				if !isExpected {
-					t.Errorf(fmt.Sprintf("Received unexpected docId: %s", docId))
+					t.Errorf(fmt.Sprintf("Received unexpected docId: %s", docID))
 				} else {
 					// Add to received set, to ensure we get all expected docs
-					docIDsReceived[docId] = true
+					docIDsReceived[docID] = true
 					receivedChangesWg.Done()
 				}
 
@@ -1924,8 +1924,8 @@ func TestGetRemovedDoc(t *testing.T) {
 	rt.GetDatabase().FlushRevisionCacheForTest()
 
 	// Delete any temp revisions in case this prevents the bug from showing up (didn't make a difference)
-	tempRevisionDocId := base.RevPrefix + "foo:5:3-cde"
-	err = rt.GetDatabase().Bucket.Delete(tempRevisionDocId)
+	tempRevisionDocID := base.RevPrefix + "foo:5:3-cde"
+	err = rt.GetDatabase().Bucket.Delete(tempRevisionDocID)
 	assert.NoError(t, err, "Unexpected Error")
 
 	// Try to get rev 3 via BLIP API and assert that _removed == true
@@ -1963,9 +1963,9 @@ func TestMissingNoRev(t *testing.T) {
 
 	// Create 5 docs
 	for i := 0; i < 5; i++ {
-		docId := fmt.Sprintf("doc-%d", i)
+		docID := fmt.Sprintf("doc-%d", i)
 		docRev := fmt.Sprintf("1-abc%d", i)
-		sent, _, resp, err := bt.SendRev(docId, docRev, []byte(`{"key": "val", "channels": ["ABC"]}`), blip.Properties{})
+		sent, _, resp, err := bt.SendRev(docID, docRev, []byte(`{"key": "val", "channels": ["ABC"]}`), blip.Properties{})
 		assert.True(t, sent)
 		log.Printf("resp: %v, err: %v", resp, err)
 	}
@@ -3013,23 +3013,23 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 	btc.ClientDeltas = true
 	err = btc.StartPull()
 	assert.NoError(t, err)
-	const docId = "doc1"
+	const docID = "doc1"
 
 	// Create doc1 rev 1-77d9041e49931ceef58a1eef5fd032e8 on SG with an attachment
 	bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-	response := rt.SendAdminRequest(http.MethodPut, "/db/"+docId, bodyText)
+	response := rt.SendAdminRequest(http.MethodPut, "/db/"+docID, bodyText)
 	assert.Equal(t, http.StatusCreated, response.Code)
 
 	// Wait for the document to be replicated at the client
 	revId := respRevID(t, response)
-	data, ok := btc.WaitForRev(docId, revId)
+	data, ok := btc.WaitForRev(docID, revId)
 	assert.True(t, ok)
 	bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
 	require.JSONEq(t, bodyTextExpected, string(data))
 
 	// Update the replicated doc at client by adding another attachment.
 	bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="},"world.txt":{"data":"bGVsbG8gd29ybGQ="}}}`
-	revId, err = btc.PushRev(docId, revId, []byte(bodyText))
+	revId, err = btc.PushRev(docID, revId, []byte(bodyText))
 	require.NoError(t, err)
 	assert.Equal(t, "2-abc", revId)
 
@@ -3037,12 +3037,12 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 	_, ok = btc.pushReplication.WaitForMessage(2)
 	assert.True(t, ok)
 
-	resp := rt.SendAdminRequest(http.MethodGet, "/db/"+docId+"?rev="+revId, "")
+	resp := rt.SendAdminRequest(http.MethodGet, "/db/"+docID+"?rev="+revId, "")
 	assert.Equal(t, http.StatusOK, resp.Code)
 	var respBody db.Body
 	assert.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &respBody))
 
-	assert.Equal(t, docId, respBody[db.BodyId])
+	assert.Equal(t, docID, respBody[db.BodyId])
 	assert.Equal(t, "2-abc", respBody[db.BodyRev])
 	greetings := respBody["greetings"].([]interface{})
 	assert.Len(t, greetings, 1)
@@ -3095,23 +3095,23 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 
 	err = btc.StartPull()
 	assert.NoError(t, err)
-	const docId = "doc1"
+	const docID = "doc1"
 
 	// Create doc revision with attachment on SG.
 	bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-	response := rt.SendAdminRequest(http.MethodPut, "/db/"+docId, bodyText)
+	response := rt.SendAdminRequest(http.MethodPut, "/db/"+docID, bodyText)
 	assert.Equal(t, http.StatusCreated, response.Code)
 
 	// Wait for the document to be replicated to client.
 	revId := respRevID(t, response)
-	data, ok := btc.WaitForRev(docId, revId)
+	data, ok := btc.WaitForRev(docID, revId)
 	assert.True(t, ok)
 	bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
 	require.JSONEq(t, bodyTextExpected, string(data))
 
 	// Update the replicated doc at client along with keeping the same attachment stub.
 	bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	revId, err = btc.PushRev(docId, revId, []byte(bodyText))
+	revId, err = btc.PushRev(docID, revId, []byte(bodyText))
 	require.NoError(t, err)
 	assert.Equal(t, "2-abc", revId)
 
@@ -3119,12 +3119,12 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 	_, ok = btc.pushReplication.WaitForMessage(2)
 	assert.True(t, ok)
 
-	resp := rt.SendAdminRequest(http.MethodGet, "/db/"+docId+"?rev="+revId, "")
+	resp := rt.SendAdminRequest(http.MethodGet, "/db/"+docID+"?rev="+revId, "")
 	assert.Equal(t, http.StatusOK, resp.Code)
 	var respBody db.Body
 	assert.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &respBody))
 
-	assert.Equal(t, docId, respBody[db.BodyId])
+	assert.Equal(t, docID, respBody[db.BodyId])
 	assert.Equal(t, "2-abc", respBody[db.BodyRev])
 	greetings := respBody["greetings"].([]interface{})
 	assert.Len(t, greetings, 1)
@@ -3171,23 +3171,23 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 
 	err = btc.StartPull()
 	assert.NoError(t, err)
-	const docId = "doc1"
+	const docID = "doc1"
 
 	// Create doc revision with attachment on SG.
 	bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-	response := rt.SendAdminRequest(http.MethodPut, "/db/"+docId, bodyText)
+	response := rt.SendAdminRequest(http.MethodPut, "/db/"+docID, bodyText)
 	assert.Equal(t, http.StatusCreated, response.Code)
 
 	// Wait for the document to be replicated to client.
 	revId := respRevID(t, response)
-	data, ok := btc.WaitForRev(docId, revId)
+	data, ok := btc.WaitForRev(docID, revId)
 	assert.True(t, ok)
 	bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
 	require.JSONEq(t, bodyTextExpected, string(data))
 
 	// Update the replicated doc at client along with keeping the same attachment stub.
 	bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	revId, err = btc.PushRev(docId, revId, []byte(bodyText))
+	revId, err = btc.PushRev(docID, revId, []byte(bodyText))
 	require.NoError(t, err)
 	assert.Equal(t, "2-abc", revId)
 
@@ -3195,12 +3195,12 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 	_, ok = btc.pushReplication.WaitForMessage(2)
 	assert.True(t, ok)
 
-	resp := rt.SendAdminRequest(http.MethodGet, "/db/"+docId+"?rev="+revId, "")
+	resp := rt.SendAdminRequest(http.MethodGet, "/db/"+docID+"?rev="+revId, "")
 	assert.Equal(t, http.StatusOK, resp.Code)
 	var respBody db.Body
 	assert.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &respBody))
 
-	assert.Equal(t, docId, respBody[db.BodyId])
+	assert.Equal(t, docID, respBody[db.BodyId])
 	assert.Equal(t, "2-abc", respBody[db.BodyRev])
 	greetings := respBody["greetings"].([]interface{})
 	assert.Len(t, greetings, 1)
@@ -3631,7 +3631,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 
 	docRevID := rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"channels": []string{"A", "B"}})
 
-	changes, err := rt.WaitForChanges(1, "/db/_changes?since=0&revocations=true", "user", true)
+	changes, err := rt.waitForChanges(1, "/db/_changes?since=0&revocations=true", "user", true)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(changes.Results))
 	assert.Equal(t, "doc", changes.Results[0].ID)
@@ -3645,7 +3645,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 
 	docRevID = rt.createDocReturnRev(t, "doc", docRevID, map[string]interface{}{"channels": []string{"B"}})
 
-	changes, err = rt.WaitForChanges(1, fmt.Sprintf("/db/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
+	changes, err = rt.waitForChanges(1, fmt.Sprintf("/db/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(changes.Results))
 	assert.Equal(t, "doc", changes.Results[0].ID)
@@ -3660,7 +3660,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	_ = rt.createDocReturnRev(t, "doc", docRevID, map[string]interface{}{"channels": []string{}})
 	_ = rt.createDocReturnRev(t, "docmarker", "", map[string]interface{}{"channels": []string{"!"}})
 
-	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/db/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
+	changes, err = rt.waitForChanges(2, fmt.Sprintf("/db/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
 	require.NoError(t, err)
 	assert.Len(t, changes.Results, 2)
 	assert.Equal(t, "doc", changes.Results[0].ID)
@@ -3720,15 +3720,15 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 
 	err = btc.StartPull()
 	assert.NoError(t, err)
-	const docId = "doc1"
+	const docID = "doc1"
 
 	// CBL creates revisions 1-abc,2-abc on the client, with an attachment associated with rev 2.
 	bodyText := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-	err = btc.StoreRevOnClient(docId, "2-abc", []byte(bodyText))
+	err = btc.StoreRevOnClient(docID, "2-abc", []byte(bodyText))
 	require.NoError(t, err)
 
 	bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	revId, err := btc.PushRevWithHistory(docId, "", []byte(bodyText), 2, 0)
+	revId, err := btc.PushRevWithHistory(docID, "", []byte(bodyText), 2, 0)
 	require.NoError(t, err)
 	assert.Equal(t, "2-abc", revId)
 
@@ -3736,13 +3736,13 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 	_, ok := btc.pushReplication.WaitForMessage(2)
 	assert.True(t, ok)
 
-	resp := rt.SendAdminRequest(http.MethodGet, "/db/"+docId+"?rev="+revId, "")
+	resp := rt.SendAdminRequest(http.MethodGet, "/db/"+docID+"?rev="+revId, "")
 	assert.Equal(t, http.StatusOK, resp.Code)
 
 	// CBL updates the doc w/ two more revisions, 3-abc, 4-abc,
 	// these are sent to SG as 4-abc, history:[4-abc,3-abc,2-abc], the attachment has revpos=2
 	bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	revId, err = btc.PushRevWithHistory(docId, revId, []byte(bodyText), 2, 0)
+	revId, err = btc.PushRevWithHistory(docID, revId, []byte(bodyText), 2, 0)
 	require.NoError(t, err)
 	assert.Equal(t, "4-abc", revId)
 
@@ -3750,13 +3750,13 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 	_, ok = btc.pushReplication.WaitForMessage(4)
 	assert.True(t, ok)
 
-	resp = rt.SendAdminRequest(http.MethodGet, "/db/"+docId+"?rev="+revId, "")
+	resp = rt.SendAdminRequest(http.MethodGet, "/db/"+docID+"?rev="+revId, "")
 	assert.Equal(t, http.StatusOK, resp.Code)
 
 	var respBody db.Body
 	assert.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &respBody))
 
-	assert.Equal(t, docId, respBody[db.BodyId])
+	assert.Equal(t, docID, respBody[db.BodyId])
 	assert.Equal(t, "4-abc", respBody[db.BodyRev])
 	greetings := respBody["greetings"].([]interface{})
 	assert.Len(t, greetings, 1)
@@ -3792,17 +3792,17 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 
 	err = btc.StartPull()
 	assert.NoError(t, err)
-	const docId = "doc1"
+	const docID = "doc1"
 
 	// CBL creates revisions 1-abc, 2-abc, 3-abc, 4-abc on the client, with an attachment associated with rev 2.
 	// rev tree pruning on the CBL side, so 1-abc no longer exists.
 	// CBL replicates, sends to client as 4-abc history:[4-abc, 3-abc, 2-abc], attachment has revpos=2
 	bodyText := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-	err = btc.StoreRevOnClient(docId, "2-abc", []byte(bodyText))
+	err = btc.StoreRevOnClient(docID, "2-abc", []byte(bodyText))
 	require.NoError(t, err)
 
 	bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	revId, err := btc.PushRevWithHistory(docId, "2-abc", []byte(bodyText), 2, 0)
+	revId, err := btc.PushRevWithHistory(docID, "2-abc", []byte(bodyText), 2, 0)
 	require.NoError(t, err)
 	assert.Equal(t, "4-abc", revId)
 
@@ -3810,13 +3810,13 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 	_, ok := btc.pushReplication.WaitForMessage(2)
 	assert.True(t, ok)
 
-	resp := rt.SendAdminRequest(http.MethodGet, "/db/"+docId+"?rev="+revId, "")
+	resp := rt.SendAdminRequest(http.MethodGet, "/db/"+docID+"?rev="+revId, "")
 	assert.Equal(t, http.StatusOK, resp.Code)
 
 	var respBody db.Body
 	assert.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &respBody))
 
-	assert.Equal(t, docId, respBody[db.BodyId])
+	assert.Equal(t, docID, respBody[db.BodyId])
 	assert.Equal(t, "4-abc", respBody[db.BodyRev])
 	greetings := respBody["greetings"].([]interface{})
 	assert.Len(t, greetings, 1)
@@ -4162,7 +4162,7 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 			// Wait for rev to be received on RT
 			err = rt.WaitForPendingChanges()
 			require.NoError(t, err)
-			changes, err = rt.WaitForChanges(1, fmt.Sprintf("/db/_changes?since=%s", changes.Last_Seq), "", true)
+			changes, err = rt.waitForChanges(1, fmt.Sprintf("/db/_changes?since=%s", changes.Last_Seq), "", true)
 			require.NoError(t, err)
 
 			var bucketDoc map[string]interface{}

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -35,7 +35,8 @@ type BlipTesterClientOpts struct {
 	SendRevocations        bool
 	SupportedBLIPProtocols []string
 
-	rejectDeltasForSrcRev string // a deltaSrc rev ID for which to reject a delta
+	// a deltaSrc rev ID for which to reject a delta
+	rejectDeltasForSrcRev string //nolint: structcheck // false structcheck positive due to https://github.com/golangci/golangci-lint/issues/826
 }
 
 // BlipTesterClient is a fully fledged client to emulate CBL behaviour on both push and pull replications through methods on this type.
@@ -248,9 +249,8 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 					response := msg.Response()
 					response.SetError("HTTP", http.StatusUnprocessableEntity, "test code intentionally rejected delta")
 					return
-				} else {
-					panic("expected delta rev message to be sent without noreply flag")
 				}
+				panic("expected delta rev message to be sent without noreply flag")
 			}
 
 			// unmarshal body to extract deltaSrc
@@ -399,7 +399,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 }
 
 // saveAttachment takes a content-type, and base64 encoded data and stores the attachment on the client
-func (btc *BlipTesterClient) saveAttachment(contentType, base64data string) (dataLength int, digest string, err error) {
+func (btc *BlipTesterClient) saveAttachment(_, base64data string) (dataLength int, digest string, err error) {
 	btc.attachmentsLock.Lock()
 	defer btc.attachmentsLock.Unlock()
 
@@ -846,28 +846,28 @@ func (btr *BlipTesterReplicator) storeMessage(msg *blip.Message) {
 	btr.messages[msg.SerialNumber()] = msg
 }
 
-func (btc *BlipTesterClient) WaitForBlipRevMessage(docId, revId string) (msg *blip.Message, found bool) {
+func (btc *BlipTesterClient) WaitForBlipRevMessage(docID, revID string) (msg *blip.Message, found bool) {
 	ticker := time.NewTicker(50 * time.Millisecond)
 	timeout := time.After(10 * time.Second)
 	for {
 		select {
 		case <-timeout:
-			btc.rt.tb.Fatalf("BlipTesterClient timed out waiting for BLIP message docId: %v, revId: %v", docId, revId)
+			btc.rt.tb.Fatalf("BlipTesterClient timed out waiting for BLIP message docID: %v, revID: %v", docID, revID)
 			return nil, false
 		case <-ticker.C:
-			if data, found := btc.GetBlipRevMessage(docId, revId); found {
+			if data, found := btc.GetBlipRevMessage(docID, revID); found {
 				return data, found
 			}
 		}
 	}
 }
 
-func (btc *BlipTesterClient) GetBlipRevMessage(docId, revId string) (msg *blip.Message, found bool) {
+func (btc *BlipTesterClient) GetBlipRevMessage(docID, revID string) (msg *blip.Message, found bool) {
 	btc.docsLock.RLock()
 	defer btc.docsLock.RUnlock()
 
-	if rev, ok := btc.docs[docId]; ok {
-		if pair, found := rev[revId]; found {
+	if rev, ok := btc.docs[docID]; ok {
+		if pair, found := rev[revID]; found {
 			found = pair.message != nil
 			return pair.message, found
 		}

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -210,7 +210,7 @@ func TestPostChanges(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/db/pbs3", `{"value":3, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 
-	changes, err := rt.WaitForChanges(3, "/db/_changes?style=all_docs&heartbeat=300000&feed=longpoll&limit=50&since=0", "bernard", false)
+	changes, err := rt.waitForChanges(3, "/db/_changes?style=all_docs&heartbeat=300000&feed=longpoll&limit=50&since=0", "bernard", false)
 	assert.NoError(t, err)
 	assert.Len(t, changes.Results, 3)
 }
@@ -618,7 +618,7 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 		`{"seq":26,"id":"abc-2","deleted":true,"removed":["ABC"],"changes":[{"rev":"2-6055be21d970eb690f48452505ea02ed"}]}`,
 		`{"seq":27,"id":"abc-3","removed":["ABC"],"changes":[{"rev":"2-09b89154aa9a0e1620da0d86528d406a"}]}`,
 	}
-	changes, err := rt.WaitForChanges(len(expectedResults), "/db/_changes", "bernard", false)
+	changes, err := rt.waitForChanges(len(expectedResults), "/db/_changes", "bernard", false)
 	require.NoError(t, err, "Error retrieving changes results")
 
 	for index, result := range changes.Results {
@@ -646,7 +646,7 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 		`{"seq":"28:22","id":"mix-5","changes":[{"rev":"3-8192afec7aa6986420be1d57f1677960"}]}`,
 		`{"seq":28,"id":"_user/bernard","changes":[]}`,
 	}
-	changes, err = rt.WaitForChanges(len(expectedResults),
+	changes, err = rt.waitForChanges(len(expectedResults),
 		fmt.Sprintf("/db/_changes?since=%s", changes.Last_Seq), "bernard", false)
 	require.NoError(t, err, "Error retrieving changes results")
 
@@ -681,7 +681,7 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 		`{"seq":31,"id":"hbo-3","changes":[{"rev":"1-46f8c67c004681619052ee1a1cc8e104"}]}`,
 		`{"seq":32,"id":"mix-7","changes":[{"rev":"1-32f69cdbf1772a8e064f15e928a18f85"}]}`,
 	}
-	changes, err = rt.WaitForChanges(len(expectedResults),
+	changes, err = rt.waitForChanges(len(expectedResults),
 		fmt.Sprintf("/db/_changes?since=28:5"), "bernard", false)
 	require.NoError(t, err, "Error retrieving changes results")
 
@@ -740,7 +740,7 @@ func TestPostChangesAdminChannelGrantRemovalWithLimit(t *testing.T) {
 	cacheWaiter.AddAndWait(3)
 
 	// Issue changes request with limit less than 5.  Expect to get pbs-5, user doc, and abc-1
-	changes, err := rt.WaitForChanges(0, "/db/_changes?limit=3", "bernard", false)
+	changes, err := rt.waitForChanges(0, "/db/_changes?limit=3", "bernard", false)
 	assert.NoError(t, err)
 	require.Equal(t, len(changes.Results), 3)
 	assert.Equal(t, "pbs-5", changes.Results[0].ID)
@@ -749,7 +749,7 @@ func TestPostChangesAdminChannelGrantRemovalWithLimit(t *testing.T) {
 	lastSeq := changes.Last_Seq
 
 	// Issue a second changes request, expect to see last 2 documents.
-	moreChanges, err := rt.WaitForChanges(0, fmt.Sprintf("/db/_changes?limit=3&since=%s", lastSeq), "bernard", false)
+	moreChanges, err := rt.waitForChanges(0, fmt.Sprintf("/db/_changes?limit=3&since=%s", lastSeq), "bernard", false)
 	assert.NoError(t, err)
 	require.Equal(t, 2, len(moreChanges.Results))
 	assert.Equal(t, "abc-2", moreChanges.Results[0].ID)
@@ -805,7 +805,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	expectedResults := []string{
 		`{"seq":7,"id":"abc-1","changes":[{"rev":"1-0143105976caafbda3b90cf82948dc64"}]}`,
 	}
-	changes, err := rt.WaitForChanges(len(expectedResults), "/db/_changes", "bernard", false)
+	changes, err := rt.waitForChanges(len(expectedResults), "/db/_changes", "bernard", false)
 	require.NoError(t, err, "Error retrieving changes results")
 	for index, result := range changes.Results {
 		var expectedChange db.ChangeEntry
@@ -824,7 +824,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 		`{"seq":"8:2","id":"hbo-1","changes":[{"rev":"1-46f8c67c004681619052ee1a1cc8e104"}]}`,
 		`{"seq":8,"id":"grant-1","changes":[{"rev":"1-c5098bb14d12d647c901850ff6a6292a"}]}`,
 	}
-	changes, err = rt.WaitForChanges(1,
+	changes, err = rt.waitForChanges(1,
 		fmt.Sprintf("/db/_changes?since=%s", changes.Last_Seq), "bernard", false)
 	require.NoError(t, err, "Error retrieving changes results")
 	for index, result := range changes.Results {
@@ -847,7 +847,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	}
 
 	t.Run("grant via existing channel", func(t *testing.T) {
-		changes, err = rt.WaitForChanges(len(expectedResults), "/db/_changes?since=8:1", "alice", false)
+		changes, err = rt.waitForChanges(len(expectedResults), "/db/_changes?since=8:1", "alice", false)
 		require.NoError(t, err, "Error retrieving changes results for alice")
 		for index, result := range changes.Results {
 			var expectedChange db.ChangeEntry
@@ -857,7 +857,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	})
 
 	t.Run("grant via new channel", func(t *testing.T) {
-		changes, err = rt.WaitForChanges(len(expectedResults), "/db/_changes?since=8:1", "bernard", false)
+		changes, err = rt.waitForChanges(len(expectedResults), "/db/_changes?since=8:1", "bernard", false)
 		require.NoError(t, err, "Error retrieving changes results for bernard")
 		for index, result := range changes.Results {
 			var expectedChange db.ChangeEntry
@@ -924,7 +924,7 @@ func TestChangeWaiterExitOnChangesTermination(t *testing.T) {
 			// Create a doc and send an initial changes
 			resp := sendRequestFn(rt, test.username, http.MethodPut, "/db/doc1", `{"foo":"bar"}`)
 			assertStatus(t, resp, http.StatusCreated)
-			c, err := rt.WaitForChanges(1, "/db/_changes?since=0", "", true)
+			c, err := rt.waitForChanges(1, "/db/_changes?since=0", "", true)
 			require.NoError(t, err)
 
 			lastSeq := c.Last_Seq.(string)
@@ -3473,7 +3473,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	// Get pre-delete changes
-	changes, err := rt.WaitForChanges(5, "/db/_changes?style=all_docs", "bernard", false)
+	changes, err := rt.waitForChanges(5, "/db/_changes?style=all_docs", "bernard", false)
 	require.NoError(t, err, "Error retrieving changes results")
 	require.Len(t, changes.Results, 5)
 
@@ -3502,7 +3502,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	// Normal changes
-	changes, err = rt.WaitForChanges(10, "/db/_changes?style=all_docs", "bernard", false)
+	changes, err = rt.waitForChanges(10, "/db/_changes?style=all_docs", "bernard", false)
 	require.NoError(t, err, "Error retrieving changes results")
 	require.Len(t, changes.Results, 10)
 	for _, entry := range changes.Results {

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1340,7 +1340,7 @@ func TestXattrFeedBasedImportPreservesExpiry(t *testing.T) {
 	assert.NoError(t, err, "Error writing SDK doc")
 
 	// Wait until the change appears on the changes feed to ensure that it's been imported by this point
-	changes, err := rt.WaitForChanges(2, "/db/_changes", "", true)
+	changes, err := rt.waitForChanges(2, "/db/_changes", "", true)
 	assert.NoError(t, err, "Error waiting for changes")
 
 	log.Printf("changes: %+v", changes)
@@ -1392,7 +1392,7 @@ func TestFeedBasedMigrateWithExpiry(t *testing.T) {
 	// Wait for doc to appear on changes feed
 	// Wait until the change appears on the changes feed to ensure that it's been imported by this point
 	now := time.Now()
-	changes, err := rt.WaitForChanges(1, "/db/_changes", "", true)
+	changes, err := rt.waitForChanges(1, "/db/_changes", "", true)
 	assert.NoError(t, err, "Error waiting for changes")
 	changeEntry := changes.Results[0]
 	assert.Equal(t, key, changeEntry.ID)
@@ -1518,7 +1518,7 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 
 			// Wait until the change appears on the changes feed to ensure that it's been imported by this point.
 			// This is probably unnecessary in the case of on-demand imports, but it doesn't hurt to leave it in as a double check.
-			changes, err := rt.WaitForChanges(1, "/db/_changes", "", true)
+			changes, err := rt.waitForChanges(1, "/db/_changes", "", true)
 			require.NoError(t, err, "Error waiting for changes")
 			changeEntry := changes.Results[0]
 			assert.Equal(t, key, changeEntry.ID)
@@ -1726,7 +1726,7 @@ func TestImportZeroValueDecimalPlaces(t *testing.T) {
 		t.Logf("Inserting doc %s: %s", docID, string(docBody))
 	}
 
-	changes, err := rt.WaitForChanges((maxDecimalPlaces+1)-minDecimalPlaces, "/db/_changes", "", true)
+	changes, err := rt.waitForChanges((maxDecimalPlaces+1)-minDecimalPlaces, "/db/_changes", "", true)
 	assert.NoError(t, err, "Error waiting for changes")
 	require.Lenf(t, changes.Results, maxDecimalPlaces+1-minDecimalPlaces, "Expected %d changes in: %#v", (maxDecimalPlaces+1)-minDecimalPlaces, changes.Results)
 
@@ -1788,7 +1788,7 @@ func TestImportZeroValueDecimalPlacesScientificNotation(t *testing.T) {
 		t.Logf("Inserting doc %s: %s", docID, string(docBody))
 	}
 
-	changes, err := rt.WaitForChanges((maxDecimalPlaces+1)-minDecimalPlaces, "/db/_changes", "", true)
+	changes, err := rt.waitForChanges((maxDecimalPlaces+1)-minDecimalPlaces, "/db/_changes", "", true)
 	assert.NoError(t, err, "Error waiting for changes")
 	require.Lenf(t, changes.Results, maxDecimalPlaces+1-minDecimalPlaces, "Expected %d changes in: %#v", (maxDecimalPlaces+1)-minDecimalPlaces, changes.Results)
 

--- a/rest/replication_api_no_race_test.go
+++ b/rest/replication_api_no_race_test.go
@@ -78,7 +78,7 @@ func TestPushReplicationAPIUpdateDatabase(t *testing.T) {
 	}()
 
 	// and wait for a few to be done before we proceed with updating database config underneath replication
-	_, err := rt2.WaitForChanges(5, "/db/_changes", "", true)
+	_, err := rt2.waitForChanges(5, "/db/_changes", "", true)
 	require.NoError(t, err)
 
 	// just change the sync function to cause the database to reload

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -1600,7 +1600,7 @@ func TestReplicationConfigChange(t *testing.T) {
 
 	rt1.waitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
-	changesResults, err := rt2.WaitForChanges(4, "/db/_changes?since=0", "", true)
+	changesResults, err := rt2.waitForChanges(4, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 4)
 
@@ -1624,7 +1624,7 @@ func TestReplicationConfigChange(t *testing.T) {
 	assertStatus(t, resp, http.StatusOK)
 	rt1.waitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
-	changesResults, err = rt2.WaitForChanges(8, "/db/_changes?since=0", "", true)
+	changesResults, err = rt2.waitForChanges(8, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 8)
 }

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -221,7 +221,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	// wait for the document originally written to rt2 to arrive at rt1
-	changesResults, err := rt1.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	changesResults, err := rt1.waitForChanges(1, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -310,7 +310,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	// wait for the document originally written to rt2 to arrive at rt1
-	changesResults, err := rt1.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	changesResults, err := rt1.waitForChanges(1, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -331,7 +331,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	revID = respRevID(t, resp)
 
 	// wait for the new document written to rt2 to arrive at rt1
-	changesResults, err = rt1.WaitForChanges(2, "/db/_changes?since=0", "", true)
+	changesResults, err = rt1.waitForChanges(2, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 2)
 	assert.Equal(t, docID, changesResults.Results[1].ID)
@@ -500,7 +500,7 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 			rev1 := putDocResp.Rev
 
 			// wait for the document originally written to rt2 to arrive at rt1
-			changesResults, err := rt1.WaitForChanges(1, "/db/_changes?since=0", "", true)
+			changesResults, err := rt1.waitForChanges(1, "/db/_changes?since=0", "", true)
 			require.NoError(t, err)
 			require.Len(t, changesResults.Results, 1)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -514,7 +514,7 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 			resp = rt1.SendAdminRequest(http.MethodPut, "/db/"+docID+"?rev="+rev1, test.localConflictingRevBody)
 			assertStatus(t, resp, http.StatusCreated)
 
-			changesResults, err = rt1.WaitForChanges(1, "/db/_changes?since="+lastSeq, "", true)
+			changesResults, err = rt1.waitForChanges(1, "/db/_changes?since="+lastSeq, "", true)
 			require.NoError(t, err)
 			assert.Len(t, changesResults.Results, 1)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -528,11 +528,11 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 
 			rt1.waitForReplicationStatus("repl1", db.ReplicationStateRunning)
 
-			changesResults, err = rt1.WaitForChanges(1, "/db/_changes?since="+lastSeq, "", true)
+			changesResults, err = rt1.waitForChanges(1, "/db/_changes?since="+lastSeq, "", true)
 			require.NoError(t, err)
 			assert.Len(t, changesResults.Results, 1)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
-			lastSeq = changesResults.Last_Seq.(string)
+			_ = changesResults.Last_Seq.(string)
 
 			doc, err := rt1.GetDatabase().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 			require.NoError(t, err)
@@ -631,7 +631,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	// wait for all of the documents originally written to rt2 to arrive at rt1
-	changesResults, err := rt1.WaitForChanges(numRT2DocsInitial, "/db/_changes?since=0", "", true)
+	changesResults, err := rt1.waitForChanges(numRT2DocsInitial, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, numRT2DocsInitial)
 	docIDsSeen := make(map[string]bool, numRT2DocsInitial)
@@ -682,7 +682,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	// wait for all of the documents originally written to rt2 to arrive at rt1
-	changesResults, err = rt1.WaitForChanges(numRT2DocsTotal, "/db/_changes?since=0", "", true)
+	changesResults, err = rt1.waitForChanges(numRT2DocsTotal, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, numRT2DocsTotal)
 
@@ -805,7 +805,7 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 	assert.True(t, ok)
 
 	// wait for all of the documents originally written to rt2 to arrive at rt1
-	changesResults, err := rt1.WaitForChanges(numRT2DocsInitial, "/db/_changes?since=0", "", true)
+	changesResults, err := rt1.waitForChanges(numRT2DocsInitial, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, numRT2DocsInitial)
 	docIDsSeen := make(map[string]bool, numRT2DocsInitial)
@@ -1043,7 +1043,7 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	// wait for the document originally written to rt1 to arrive at rt2
-	changesResults, err := rt2.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	changesResults, err := rt2.waitForChanges(1, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -1130,7 +1130,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	// wait for the document originally written to rt1 to arrive at rt2
-	changesResults, err := rt2.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	changesResults, err := rt2.waitForChanges(1, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -1152,7 +1152,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 	revID = respRevID(t, resp)
 
 	// wait for the new document written to rt1 to arrive at rt2
-	changesResults, err = rt2.WaitForChanges(2, "/db/_changes?since=0", "", true)
+	changesResults, err = rt2.waitForChanges(2, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 2)
 	assert.Equal(t, docID, changesResults.Results[1].ID)
@@ -1250,7 +1250,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	// wait for all of the documents originally written to rt1 to arrive at rt2
-	changesResults, err := rt2.WaitForChanges(numRT1DocsInitial, "/db/_changes?since=0", "", true)
+	changesResults, err := rt2.waitForChanges(numRT1DocsInitial, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, numRT1DocsInitial)
 	docIDsSeen := make(map[string]bool, numRT1DocsInitial)
@@ -1299,7 +1299,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	// wait for all of the documents originally written to rt1 to arrive at rt2
-	changesResults, err = rt2.WaitForChanges(numRT1DocsTotal, "/db/_changes?since=0", "", true)
+	changesResults, err = rt2.waitForChanges(numRT1DocsTotal, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, numRT1DocsTotal)
 
@@ -1412,7 +1412,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	assert.NoError(t, edge1Replicator.Start())
 
 	// wait for all of the documents originally written to rt1 to arrive at edge1
-	changesResults, err := edge1.WaitForChanges(numRT1DocsInitial, "/db/_changes?since=0", "", true)
+	changesResults, err := edge1.waitForChanges(numRT1DocsInitial, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	edge1LastSeq := changesResults.Last_Seq
 	require.Len(t, changesResults.Results, numRT1DocsInitial)
@@ -1467,7 +1467,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	edge2Replicator := db.NewActiveReplicator(&arConfig)
 	assert.NoError(t, edge2Replicator.Start())
 
-	changesResults, err = edge2.WaitForChanges(numRT1DocsInitial, "/db/_changes?since=0", "", true)
+	changesResults, err = edge2.waitForChanges(numRT1DocsInitial, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 
 	edge2Replicator.Pull.Checkpointer.CheckpointNow()
@@ -1493,7 +1493,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	edge1Replicator2 := db.NewActiveReplicator(&arConfig)
 	require.NoError(t, edge1Replicator2.Start())
 
-	changesResults, err = edge1.WaitForChanges(1, fmt.Sprintf("/db/_changes?since=%v", edge1LastSeq), "", true)
+	changesResults, err = edge1.waitForChanges(1, fmt.Sprintf("/db/_changes?since=%v", edge1LastSeq), "", true)
 	require.NoErrorf(t, err, "changesResults: %v", changesResults)
 	changesResults.requireDocIDs(t, []string{fmt.Sprintf("%s%d", docIDPrefix, numRT1DocsInitial)})
 
@@ -1808,7 +1808,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	// wait for the document originally written to rt2 to arrive at rt1
-	changesResults, err := rt1.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	changesResults, err := rt1.waitForChanges(1, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -1828,7 +1828,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	revID = respRevID(t, resp)
 
 	// wait for the tombstone written to rt2 to arrive at rt1
-	changesResults, err = rt1.WaitForChanges(1, "/db/_changes?since="+strconv.FormatUint(doc.Sequence, 10), "", true)
+	changesResults, err = rt1.waitForChanges(1, "/db/_changes?since="+strconv.FormatUint(doc.Sequence, 10), "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -1909,7 +1909,7 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	// wait for the document originally written to rt2 to arrive at rt1
-	changesResults, err := rt1.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	changesResults, err := rt1.waitForChanges(1, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -2118,7 +2118,7 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			}
 			// wait for the document originally written to rt2 to arrive at rt1.  Should end up as winner under default conflict resolution
 
-			changesResults, err := rt1.WaitForChanges(1, "/db/_changes?since=0", "", true)
+			changesResults, err := rt1.waitForChanges(1, "/db/_changes?since=0", "", true)
 			require.NoError(t, err)
 			require.Len(t, changesResults.Results, 1)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -2337,7 +2337,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			log.Printf("========================Replication should be done, checking with changes")
 
 			// Validate results on the local (rt1)
-			changesResults, err := rt1.WaitForChanges(1, fmt.Sprintf("/db/_changes?since=%d", localDoc.Sequence), "", true)
+			changesResults, err := rt1.waitForChanges(1, fmt.Sprintf("/db/_changes?since=%d", localDoc.Sequence), "", true)
 			require.NoError(t, err)
 			require.Len(t, changesResults.Results, 1)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -2383,7 +2383,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 				// no changes should have been pushed back up to rt2, because this rev won.
 				rt2Since = 0
 			}
-			changesResults, err = rt2.WaitForChanges(1, fmt.Sprintf("/db/_changes?since=%d", rt2Since), "", true)
+			changesResults, err = rt2.waitForChanges(1, fmt.Sprintf("/db/_changes?since=%d", rt2Since), "", true)
 			require.NoError(t, err)
 			require.Len(t, changesResults.Results, 1)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -2482,7 +2482,7 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 	require.NoError(t, ar.Start())
 
 	// wait for the document originally written to rt1 to arrive at rt2
-	changesResults, err := rt2.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	changesResults, err := rt2.waitForChanges(1, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -2626,7 +2626,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	// wait for document originally written to rt2 to arrive at rt1
-	changesResults, err := rt1.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	changesResults, err := rt1.waitForChanges(1, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -2681,7 +2681,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().GetCheckpointHitCount)
 
 	// wait for document originally written to rt2 to arrive at rt1
-	changesResults, err = rt1.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	changesResults, err = rt1.waitForChanges(1, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -2783,7 +2783,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	// wait for document originally written to rt1 to arrive at rt2
-	changesResults, err := rt2.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	changesResults, err := rt2.waitForChanges(1, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -2851,7 +2851,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().GetCheckpointHitCount)
 
 	// wait for document originally written to rt1 to arrive at rt2
-	changesResults, err = rt2.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	changesResults, err = rt2.waitForChanges(1, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -2955,7 +2955,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	}, 1)
 
 	// wait for document originally written to rt1 to arrive at rt2
-	changesResults, err := rt2.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	changesResults, err := rt2.waitForChanges(1, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -2991,7 +2991,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	}, 2)
 
 	// wait for new document to arrive at rt2
-	changesResults, err = rt2.WaitForChanges(1, "/db/_changes?since="+lastSeq, "", true)
+	changesResults, err = rt2.waitForChanges(1, "/db/_changes?since="+lastSeq, "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID+"2", changesResults.Results[0].ID)
@@ -3024,7 +3024,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	// wait for new document to arrive at rt2 again
-	changesResults, err = rt2.WaitForChanges(1, "/db/_changes?since="+lastSeq, "", true)
+	changesResults, err = rt2.waitForChanges(1, "/db/_changes?since="+lastSeq, "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID+"2", changesResults.Results[0].ID)
@@ -3117,7 +3117,7 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 	assert.NoError(t, rt1.WaitForPendingChanges())
 
 	// wait for document originally written to rt1 to arrive at rt2
-	changesResults, err := rt2.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	changesResults, err := rt2.waitForChanges(1, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -3129,7 +3129,7 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 	assert.NoError(t, rt2.WaitForPendingChanges())
 
 	// wait for document originally written to rt2 to arrive at rt1
-	changesResults, err = rt1.WaitForChanges(1, "/db/_changes?since=1", "", true)
+	changesResults, err = rt1.waitForChanges(1, "/db/_changes?since=1", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -3210,7 +3210,7 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	// wait for the document originally written to rt1 to arrive at rt2
-	changesResults, err := rt2.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	changesResults, err := rt2.waitForChanges(1, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, rt1docID, changesResults.Results[0].ID)
@@ -3231,7 +3231,7 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	rt2revID := respRevID(t, resp)
 
 	// ... and wait to arrive at rt1
-	changesResults, err = rt1.WaitForChanges(2, "/db/_changes?since=0", "", true)
+	changesResults, err = rt1.waitForChanges(2, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 2)
 	assert.Equal(t, rt1docID, changesResults.Results[0].ID)
@@ -3326,7 +3326,7 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	// wait for all of the documents originally written to rt2 to arrive at rt1
-	changesResults, err := rt1.WaitForChanges(numDocsPerChannelInitial, "/db/_changes?since=0", "", true)
+	changesResults, err := rt1.waitForChanges(numDocsPerChannelInitial, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, numDocsPerChannelInitial)
 	docIDsSeen := make(map[string]bool, numDocsPerChannelInitial)
@@ -3377,7 +3377,7 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 	expectedChan1Docs := numDocsPerChannelInitial
 	expectedChan2Docs := numDocsPerChannelTotal
 	expectedTotalDocs := expectedChan1Docs + expectedChan2Docs
-	changesResults, err = rt1.WaitForChanges(expectedTotalDocs, "/db/_changes?since=0", "", true)
+	changesResults, err = rt1.waitForChanges(expectedTotalDocs, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, expectedTotalDocs)
 
@@ -4040,7 +4040,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 
 			// Wait for the document originally written to rt2 to arrive at rt1.
 			// Should end up as winner under default conflict resolution.
-			changesResults, err := rt1.WaitForChanges(1, "/db/_changes?&since=0", "", true)
+			changesResults, err := rt1.waitForChanges(1, "/db/_changes?&since=0", "", true)
 			require.NoError(t, err)
 			require.Len(t, changesResults.Results, 1)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -4247,7 +4247,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Stop the replication
-			resp = localActiveRT.SendAdminRequest("PUT", "/db/_replicationStatus/replication?action=stop", "")
+			_ = localActiveRT.SendAdminRequest("PUT", "/db/_replicationStatus/replication?action=stop", "")
 			localActiveRT.waitForReplicationStatus("replication", db.ReplicationStateStopped)
 
 			// Delete on the short branch and make another doc on the longer branch before deleting it
@@ -4305,7 +4305,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 			}
 
 			// Start up repl again
-			resp = localActiveRT.SendAdminRequest("PUT", "/db/_replicationStatus/replication?action=start", "")
+			_ = localActiveRT.SendAdminRequest("PUT", "/db/_replicationStatus/replication?action=start", "")
 			localActiveRT.waitForReplicationStatus("replication", db.ReplicationStateRunning)
 
 			// Wait for the recently longest branch to show up on both sides
@@ -4338,7 +4338,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Stop the replication
-			resp = localActiveRT.SendAdminRequest("PUT", "/db/_replicationStatus/replication?action=stop", "")
+			_ = localActiveRT.SendAdminRequest("PUT", "/db/_replicationStatus/replication?action=stop", "")
 			localActiveRT.waitForReplicationStatus("replication", db.ReplicationStateStopped)
 
 			// Resurrect Doc
@@ -4386,7 +4386,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 			require.NoError(t, err)
 
 			// Start the replication
-			resp = localActiveRT.SendAdminRequest("PUT", "/db/_replicationStatus/replication?action=start", "")
+			_ = localActiveRT.SendAdminRequest("PUT", "/db/_replicationStatus/replication?action=start", "")
 			localActiveRT.waitForReplicationStatus("replication", db.ReplicationStateRunning)
 
 			// Wait for doc to replicate from side resurrection was done on to the other side
@@ -4989,10 +4989,7 @@ func TestSendChangesToNoConflictPreHydrogenTarget(t *testing.T) {
 	assertStatus(t, response, http.StatusCreated)
 
 	err = rt2.WaitForCondition(func() bool {
-		if base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().ErrorCount.Value() == errorCountBefore+1 {
-			return true
-		}
-		return false
+		return base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().ErrorCount.Value() == errorCountBefore+1
 	})
 	assert.NoError(t, err)
 
@@ -5324,7 +5321,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	_ = rt2.createDocReturnRev(t, "docC", "", map[string][]string{"channels": []string{"C"}})
 
 	// Wait for docs to turn up on local / rt1
-	changesResults, err := rt1.WaitForChanges(5, "/db/_changes?since=0", "", true)
+	changesResults, err := rt1.waitForChanges(5, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	assert.Len(t, changesResults.Results, 5)
 
@@ -5481,7 +5478,7 @@ func TestReplicatorRevocationsWithTombstoneResurrection(t *testing.T) {
 
 	require.NoError(t, ar.Start())
 
-	changesResults, err := rt1.WaitForChanges(4, "/db/_changes?since=0", "", true)
+	changesResults, err := rt1.waitForChanges(4, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	assert.Len(t, changesResults.Results, 4)
 
@@ -5565,7 +5562,7 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 
 	require.NoError(t, ar.Start())
 
-	changesResults, err := rt1.WaitForChanges(3, "/db/_changes?since=0", "", true)
+	changesResults, err := rt1.waitForChanges(3, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	assert.Len(t, changesResults.Results, 3)
 
@@ -5672,7 +5669,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 
 	require.NoError(t, ar.Start())
 
-	changesResults, err := rt1.WaitForChanges(17, "/db/_changes?since=0", "", true)
+	changesResults, err := rt1.waitForChanges(17, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	assert.Len(t, changesResults.Results, 17)
 
@@ -5696,7 +5693,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 	require.NoError(t, ar.Start())
 	rt1.waitForReplicationStatus(ar.ID, db.ReplicationStateRunning)
 
-	changesResults, err = rt1.WaitForChanges(8, fmt.Sprintf("/db/_changes?since=%v", changesResults.Last_Seq), "", true)
+	changesResults, err = rt1.waitForChanges(8, fmt.Sprintf("/db/_changes?since=%v", changesResults.Last_Seq), "", true)
 	require.NoError(t, err)
 	assert.Len(t, changesResults.Results, 8)
 
@@ -5725,7 +5722,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 	err = rt2.WaitForPendingChanges()
 	assert.NoError(t, err)
 
-	changesResults, err = rt1.WaitForChanges(1, fmt.Sprintf("/db/_changes?since=%v", changesResults.Last_Seq), "", true)
+	changesResults, err = rt1.waitForChanges(1, fmt.Sprintf("/db/_changes?since=%v", changesResults.Last_Seq), "", true)
 	assert.NoError(t, err)
 	assert.Len(t, changesResults.Results, 1)
 
@@ -6057,7 +6054,7 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 	activeRT.waitForReplicationStatus(ar.ID, db.ReplicationStateRunning)
 
 	// Confirm document is replicated
-	changesResults, err := passiveRT.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	changesResults, err := passiveRT.waitForChanges(1, "/db/_changes?since=0", "", true)
 	assert.NoError(t, err)
 	assert.Len(t, changesResults.Results, 1)
 
@@ -6085,7 +6082,7 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 	require.NoError(t, ar.Start())
 	activeRT.waitForReplicationStatus(ar.ID, db.ReplicationStateRunning)
 
-	changesResults, err = passiveRT.WaitForChanges(1, fmt.Sprintf("/db/_changes?since=%v", changesResults.Last_Seq), "", true)
+	changesResults, err = passiveRT.waitForChanges(1, fmt.Sprintf("/db/_changes?since=%v", changesResults.Last_Seq), "", true)
 	assert.NoError(t, err)
 	assert.Len(t, changesResults.Results, 1)
 


### PR DESCRIPTION
- don't lint on test constants that are in test code (utilities_test.go)
- make waitForChanges private since it returns private struct
- create a common change handler in utilities_testing.go