### PR TITLE
CBG-2174: Narrow the lock in fetchAndLoadConfigs to avoid high response latency

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -1202,6 +1202,7 @@ func (sc *ServerContext) fetchAndLoadConfigs(isInitialStartup bool) (count int, 
 
 		// nothing to do, we can bail out without needing the write lock
 		if len(deletedDatabases) == 0 && len(fetchedConfigs) == 0 {
+			base.TracefCtx(context.TODO(), base.KeyConfig, "No persistent config changes to make")
 			return 0, nil
 		}
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -1177,13 +1177,13 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 // fetchAndLoadConfigs retrieves all database configs from the ServerContext's bootstrapConnection, and loads them into the ServerContext.
 // It will remove any databases currently running that are not found in the bucket.
 func (sc *ServerContext) fetchAndLoadConfigs(isInitialStartup bool) (count int, err error) {
-	sc.lock.Lock()
-	defer sc.lock.Unlock()
-
 	fetchedConfigs, err := sc.fetchConfigs(isInitialStartup)
 	if err != nil {
 		return 0, err
 	}
+
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
 
 	for _, dbName := range sc.bucketDbName {
 		if _, foundMatchingDb := fetchedConfigs[dbName]; !foundMatchingDb {


### PR DESCRIPTION
CBG-2174 - Periodic high response times on REST API due to persistent config polling

When running the periodic fetchAndLoadConfigs for discovering updated persistent database configs, we acquire the ServerContext lock before making the network calls to discover buckets and fetch config documents.

This can take a while (~3 seconds) due to having to list all buckets, and then for each fetch a config document, and we don't need to be holding the ServerContext lock to do this work.

Moving the lock down after we've done the network hops means we're only holding the ServerContext lock when we're applying the configs we got from the buckets, which is a relatively short operation.

E.g:

```
2022-06-30T13:53:35.364+01:00 [INF] HTTP: c:#011 GET /db1.asdf.qwerty/<ud>doc1</ud> (as <ud>Administrator</ud> as ADMIN)
2022-06-30T13:53:35.364+01:00 [INF] HTTP+: c:#011 #011:     --> 200   (0.8 ms)
2022-06-30T13:53:35.465+01:00 [DBG] Config+: Fetching configs from buckets in cluster for group "default"
2022-06-30T13:53:37.884+01:00 [DBG] Config+: Got config for group "default" from bucket "b1" with cas 1656592953873924096
2022-06-30T13:53:39.157+01:00 [DBG] Config+: Bucket "b2" did not contain config for group "default"
2022-06-30T13:53:39.157+01:00 [DBG] Config+: Database "db1" bucket "b1" config has not changed since last update
2022-06-30T13:53:39.158+01:00 [INF] Auth: c:#012 #012: User <ud>Administrator</ud> was successfully authorized as an admin
2022-06-30T13:53:39.158+01:00 [INF] HTTP: c:#012 GET /db1.asdf.qwerty/<ud>doc1</ud> (as <ud>Administrator</ud> as ADMIN)
2022-06-30T13:53:39.158+01:00 [INF] HTTP+: c:#012 #012:     --> 200   (3304.3 ms)
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/356/
