### PR TITLE
Actually run fieldalignment checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,12 +59,14 @@ linters:
     - whitespace # Tool for detection of leading and trailing whitespace
     - wsl # Whitespace Linter - Forces you to use empty lines!
 
+linters-settings:
+  govet:
+    enable:
+      - fieldalignment # detect Go structs that would take less memory if their fields were sorted
+
 # Disable goconst in test files, often we have duplicated strings across tests, but don't make sense as constants.
 issues:
   exclude-rules:
     - path: (_test\.go|utilities_testing\.go)
       linters:
         - goconst
-  govet:
-    enable:
-      - fieldalignment # detect Go structs that would take less memory if their fields were sorted


### PR DESCRIPTION
When I changed the linter before, it actually didn't run any fieldalignment checks (moved from special linter to govet). This makes sure they are run, `golangci-lint run ./... | grep govet` now returns non-zero amount of results.