### PR TITLE
CBG-2178: Fix flaky TestQueryChannelsStatsView on Windows

### DIFF
--- a/db/query_test.go
+++ b/db/query_test.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"fmt"
+	"runtime"
 	"strconv"
 	"testing"
 
@@ -66,7 +67,12 @@ func TestQueryChannelsStatsView(t *testing.T) {
 	channelQueryErrorCountAfter := db.DbStats.Query(queryExpvar).QueryErrorCount.Value()
 
 	assert.Equal(t, channelQueryCountBefore+1, channelQueryCountAfter)
-	assert.Greater(t, channelQueryTimeAfter, channelQueryTimeBefore, "Channel query time stat didn't change")
+	// time.Nanoseconds has poor precision on Windows
+	if runtime.GOOS == "windows" {
+		assert.GreaterOrEqual(t, channelQueryTimeAfter, channelQueryTimeBefore, "Channel query time stat didn't change")
+	} else {
+		assert.Greater(t, channelQueryTimeAfter, channelQueryTimeBefore, "Channel query time stat didn't change")
+	}
 	assert.Equal(t, channelQueryErrorCountBefore, channelQueryErrorCountAfter)
 
 }
@@ -113,7 +119,12 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 	channelQueryErrorCountAfter := db.DbStats.Query(QueryTypeChannels).QueryErrorCount.Value()
 
 	assert.Equal(t, channelQueryCountBefore+1, channelQueryCountAfter)
-	assert.Greater(t, channelQueryTimeAfter, channelQueryTimeBefore, "Channel query time stat didn't change")
+	// time.Nanoseconds has poor precision on Windows
+	if runtime.GOOS == "windows" {
+		assert.GreaterOrEqual(t, channelQueryTimeAfter, channelQueryTimeBefore, "Channel query time stat didn't change")
+	} else {
+		assert.Greater(t, channelQueryTimeAfter, channelQueryTimeBefore, "Channel query time stat didn't change")
+	}
 	assert.Equal(t, channelQueryErrorCountBefore, channelQueryErrorCountAfter)
 
 }


### PR DESCRIPTION
CBG-2178

Likely related to `time.Time.Nanoseconds()` having poor (~millisecond) precision on Windows.
