### PR TITLE
CBG-2144: Support loading Local JWT keys from a remote URI

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1190,28 +1190,28 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 
 	t.Run("no provider malformed token with bad header no payload", func(t *testing.T) {
 		var providers OIDCProviderMap
-		user, _, err := auth.AuthenticateUntrustedJWT("DmBb9C5", providers, LocalJWTConfig{}, callbackURLFunc)
+		user, _, err := auth.AuthenticateUntrustedJWT("DmBb9C5", providers, LocalJWTProviderMap{}, callbackURLFunc)
 		assert.Error(t, err, "No provider found to authenticate token")
 		assert.Nil(t, user, "User shouldn't be created or retrieved")
 	})
 
 	t.Run("single provider malformed token with bad header no payload", func(t *testing.T) {
 		providers := OIDCProviderMap{providerGoogle.Name: providerGoogle}
-		user, _, err := auth.AuthenticateUntrustedJWT("DmBb9C5", providers, LocalJWTConfig{}, callbackURLFunc)
+		user, _, err := auth.AuthenticateUntrustedJWT("DmBb9C5", providers, LocalJWTProviderMap{}, callbackURLFunc)
 		assert.Error(t, err, "Error parsing malformed token")
 		assert.Nil(t, user, "User shouldn't be created or retrieved")
 	})
 
 	t.Run("multiple providers malformed token with bad header no payload", func(t *testing.T) {
 		providers := OIDCProviderMap{providerGoogle.Name: providerGoogle, providerFacebook.Name: providerFacebook}
-		user, _, err := auth.AuthenticateUntrustedJWT("DmBb9C5", providers, LocalJWTConfig{}, callbackURLFunc)
+		user, _, err := auth.AuthenticateUntrustedJWT("DmBb9C5", providers, LocalJWTProviderMap{}, callbackURLFunc)
 		assert.Error(t, err, "Error parsing malformed token")
 		assert.Nil(t, user, "User shouldn't be created or retrieved")
 	})
 
 	t.Run("multiple providers malformed token with bad header bad payload", func(t *testing.T) {
 		providers := OIDCProviderMap{providerGoogle.Name: providerGoogle, providerFacebook.Name: providerFacebook}
-		user, _, err := auth.AuthenticateUntrustedJWT("DmBb9C5.C#m7G#7", providers, LocalJWTConfig{}, callbackURLFunc)
+		user, _, err := auth.AuthenticateUntrustedJWT("DmBb9C5.C#m7G#7", providers, LocalJWTProviderMap{}, callbackURLFunc)
 		assert.Error(t, err, "Error parsing malformed token")
 		assert.Nil(t, user, "User shouldn't be created or retrieved")
 	})
@@ -1219,7 +1219,7 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 	t.Run("multiple providers malformed token with bad header bad base64 payload", func(t *testing.T) {
 		providers := OIDCProviderMap{providerGoogle.Name: providerGoogle, providerFacebook.Name: providerFacebook}
 		token := "DmBb9C5." + ToBase64String(`{"unknown":"value"}`)
-		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTConfig{}, callbackURLFunc)
+		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTProviderMap{}, callbackURLFunc)
 		assert.Error(t, err, "Error parsing malformed token")
 		assert.Nil(t, user, "User shouldn't be created or retrieved")
 	})
@@ -1229,7 +1229,7 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 		builder := jwt.Signed(signer).Claims(jwt.Claims{})
 		token, err := builder.CompactSerialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
-		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTConfig{}, callbackURLFunc)
+		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTProviderMap{}, callbackURLFunc)
 		require.Error(t, err, "Error getting issuer and audience from token")
 		assert.Nil(t, user, "User shouldn't be created or retrieved")
 	})
@@ -1239,7 +1239,7 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 		builder := jwt.Signed(signer).Claims(jwt.Claims{Issuer: issuerGoogleAccounts})
 		token, err := builder.CompactSerialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
-		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTConfig{}, callbackURLFunc)
+		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTProviderMap{}, callbackURLFunc)
 		require.Error(t, err, "Error getting issuer and audience from token")
 		assert.Nil(t, user, "User shouldn't be created or retrieved")
 	})
@@ -1249,7 +1249,7 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 		builder := jwt.Signed(signer).Claims(jwt.Claims{Issuer: issuerGoogleAccounts, Audience: jwt.Audience{}})
 		token, err := builder.CompactSerialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
-		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTConfig{}, callbackURLFunc)
+		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTProviderMap{}, callbackURLFunc)
 		require.Error(t, err, "Error getting issuer and audience from token")
 		assert.Nil(t, user, "User shouldn't be created or retrieved")
 	})
@@ -1259,7 +1259,7 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 		builder := jwt.Signed(signer).Claims(jwt.Claims{Audience: jwt.Audience{"aud1", "aud2", "aud3"}})
 		token, err := builder.CompactSerialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
-		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTConfig{}, callbackURLFunc)
+		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTProviderMap{}, callbackURLFunc)
 		require.Error(t, err, "Error getting issuer and audience from token")
 		assert.Nil(t, user, "User shouldn't be created or retrieved")
 	})
@@ -1269,7 +1269,7 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 		builder := jwt.Signed(signer).Claims(jwt.Claims{Issuer: issuerAmazonAccounts, Audience: jwt.Audience{"aud1"}})
 		token, err := builder.CompactSerialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
-		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTConfig{}, callbackURLFunc)
+		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTProviderMap{}, callbackURLFunc)
 		require.Error(t, err, "No provider found against the configured issuer")
 		assert.Nil(t, user, "User shouldn't be created or retrieved")
 	})
@@ -1279,7 +1279,7 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 		builder := jwt.Signed(signer).Claims(jwt.Claims{Issuer: issuerGoogleAccounts, Audience: jwt.Audience{"aud2"}})
 		token, err := builder.CompactSerialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
-		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTConfig{}, callbackURLFunc)
+		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTProviderMap{}, callbackURLFunc)
 		require.Error(t, err, "No provider found against the configured issuer")
 		assert.Nil(t, user, "User shouldn't be created or retrieved")
 	})
@@ -1308,7 +1308,7 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 		builder := jwt.Signed(signer).Claims(claims)
 		token, err := builder.CompactSerialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
-		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTConfig{}, callbackURLFunc)
+		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTProviderMap{}, callbackURLFunc)
 		assert.Error(t, err, "Error authenticating with trusted JWT")
 		assert.Nil(t, user, "User shouldn't be returned without signature verification")
 	})

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -11,6 +11,11 @@ import (
 	"gopkg.in/square/go-jose.v2"
 )
 
+type jwtAuthenticator interface {
+	verifyToken(ctx context.Context, token string, callbackURLFunc OIDCCallbackURLFunc) (*Identity, error)
+	common() JWTConfigCommon
+}
+
 // SupportedAlgorithms is list of signing algorithms explicitly supported
 // by github.com/coreos/go-oidc package. If a provider supports other algorithms,
 // such as HS256 or none, those values won't be passed to the IDTokenVerifier.
@@ -125,16 +130,34 @@ func (j JSONWebKeys) VerifySignature(ctx context.Context, jwt string) (payload [
 	return nil, errors.New("failed to verify id token signature")
 }
 
-type LocalJWTAuthProvider struct {
+type LocalJWTAuthConfig struct {
 	JWTConfigCommon
-
 	Algorithms      []string    `json:"algorithms"`
 	Keys            JSONWebKeys `json:"keys"`
 	SkipExpiryCheck *bool       `json:"skip_expiry_check"`
 }
 
+// BuildProvider prepares a LocalJWTAuthProvider from this config, initialising keySet.
+func (l LocalJWTAuthConfig) BuildProvider(name string) *LocalJWTAuthProvider {
+	prov := &LocalJWTAuthProvider{
+		LocalJWTAuthConfig: l,
+		name_:              name,
+		keySet:             l.Keys,
+	}
+	prov.initUserPrefix()
+	return prov
+}
+
+type LocalJWTAuthProvider struct {
+	LocalJWTAuthConfig
+
+	name_ string
+	// keySet has the keys for this config, either in-memory or from oidc.NewRemoteKeySet.
+	keySet oidc.KeySet
+}
+
 func (l *LocalJWTAuthProvider) verifyToken(ctx context.Context, token string, _ OIDCCallbackURLFunc) (*Identity, error) {
-	verifier := oidc.NewVerifier(l.Issuer, l.Keys, &oidc.Config{
+	verifier := oidc.NewVerifier(l.Issuer, l.keySet, &oidc.Config{
 		ClientID:             *l.ClientID,
 		SkipClientIDCheck:    *l.ClientID == "",
 		SupportedSigningAlgs: l.Algorithms,
@@ -167,15 +190,15 @@ func (l *LocalJWTAuthProvider) common() JWTConfigCommon {
 	return l.JWTConfigCommon
 }
 
-func (l *LocalJWTAuthProvider) InitUserPrefix(ctx context.Context, name string) {
+func (l *LocalJWTAuthProvider) initUserPrefix() {
 	if l.UserPrefix != "" || l.UsernameClaim != "" {
 		return
 	}
 
 	issuerURL, err := url.ParseRequestURI(l.Issuer)
 	if err != nil {
-		base.WarnfCtx(ctx, "Unable to parse issuer URI when initializing user prefix - using provider name")
-		l.UserPrefix = name
+		base.WarnfCtx(context.TODO(), "Unable to parse issuer URI when initializing user prefix - using provider name")
+		l.UserPrefix = l.name_
 		return
 	}
 	l.UserPrefix = issuerURL.Host + issuerURL.Path
@@ -186,9 +209,5 @@ func (l *LocalJWTAuthProvider) InitUserPrefix(ctx context.Context, name string) 
 	l.UserPrefix = url.QueryEscape(l.UserPrefix)
 }
 
-type LocalJWTConfig map[string]*LocalJWTAuthProvider
-
-type jwtAuthenticator interface {
-	verifyToken(ctx context.Context, token string, callbackURLFunc OIDCCallbackURLFunc) (*Identity, error)
-	common() JWTConfigCommon
-}
+type LocalJWTConfig map[string]LocalJWTAuthConfig
+type LocalJWTProviderMap map[string]*LocalJWTAuthProvider

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -134,15 +134,26 @@ type LocalJWTAuthConfig struct {
 	JWTConfigCommon
 	Algorithms      []string    `json:"algorithms"`
 	Keys            JSONWebKeys `json:"keys"`
+	JWKSURI         string      `json:"jwks_uri"`
 	SkipExpiryCheck *bool       `json:"skip_expiry_check"`
 }
 
 // BuildProvider prepares a LocalJWTAuthProvider from this config, initialising keySet.
 func (l LocalJWTAuthConfig) BuildProvider(name string) *LocalJWTAuthProvider {
-	prov := &LocalJWTAuthProvider{
-		LocalJWTAuthConfig: l,
-		name_:              name,
-		keySet:             l.Keys,
+	var prov *LocalJWTAuthProvider
+	// validation ensures these are truly mutually exclusive
+	if len(l.Keys) > 0 {
+		prov = &LocalJWTAuthProvider{
+			LocalJWTAuthConfig: l,
+			name_:              name,
+			keySet:             l.Keys,
+		}
+	} else {
+		prov = &LocalJWTAuthProvider{
+			LocalJWTAuthConfig: l,
+			name_:              name,
+			keySet:             oidc.NewRemoteKeySet(context.Background(), l.JWKSURI),
+		}
 	}
 	prov.initUserPrefix()
 	return prov

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -145,13 +145,13 @@ func (l LocalJWTAuthConfig) BuildProvider(name string) *LocalJWTAuthProvider {
 	if len(l.Keys) > 0 {
 		prov = &LocalJWTAuthProvider{
 			LocalJWTAuthConfig: l,
-			name_:              name,
+			name:               name,
 			keySet:             l.Keys,
 		}
 	} else {
 		prov = &LocalJWTAuthProvider{
 			LocalJWTAuthConfig: l,
-			name_:              name,
+			name:               name,
 			keySet:             oidc.NewRemoteKeySet(context.Background(), l.JWKSURI),
 		}
 	}
@@ -162,7 +162,7 @@ func (l LocalJWTAuthConfig) BuildProvider(name string) *LocalJWTAuthProvider {
 type LocalJWTAuthProvider struct {
 	LocalJWTAuthConfig
 
-	name_ string
+	name string
 	// keySet has the keys for this config, either in-memory or from oidc.NewRemoteKeySet.
 	keySet oidc.KeySet
 }
@@ -209,7 +209,7 @@ func (l *LocalJWTAuthProvider) initUserPrefix() {
 	issuerURL, err := url.ParseRequestURI(l.Issuer)
 	if err != nil {
 		base.WarnfCtx(context.TODO(), "Unable to parse issuer URI when initializing user prefix - using provider name")
-		l.UserPrefix = l.name_
+		l.UserPrefix = l.name
 		return
 	}
 	l.UserPrefix = issuerURL.Host + issuerURL.Path

--- a/auth/jwt_test.go
+++ b/auth/jwt_test.go
@@ -23,7 +23,7 @@ const anyError = "SGW_TEST_ANY_ERROR"
 func TestJWTVerifyToken(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 
-	test := func(provider LocalJWTAuthProvider, token string, expectedError string) func(t *testing.T) {
+	test := func(provider *LocalJWTAuthProvider, token string, expectedError string) func(t *testing.T) {
 		return func(t *testing.T) {
 			_, err := provider.verifyToken(base.TestCtx(t), token, dummyCallbackURL)
 			switch expectedError {
@@ -83,18 +83,18 @@ func TestJWTVerifyToken(t *testing.T) {
 		Issuer:   testIssuer,
 		ClientID: base.StringPtr(testClientID),
 	}
-	baseProvider := LocalJWTAuthProvider{
+	baseProvider := LocalJWTAuthConfig{
 		JWTConfigCommon: common,
 		Algorithms:      []string{"RS256", "ES256"},
 		Keys:            []jose.JSONWebKey{testRSAJWK, testECJWK, testEncRSAJWK},
 		SkipExpiryCheck: base.BoolPtr(true),
-	}
-	providerWithExpiryCheck := LocalJWTAuthProvider{
+	}.BuildProvider("test")
+	providerWithExpiryCheck := LocalJWTAuthConfig{
 		JWTConfigCommon: common,
 		Algorithms:      []string{"RS256", "ES256"},
 		Keys:            []jose.JSONWebKey{testRSAJWK, testECJWK, testEncRSAJWK},
 		SkipExpiryCheck: base.BoolPtr(false),
-	}
+	}.BuildProvider("test")
 
 	t.Run("garbage", test(baseProvider, "INVALID", anyError))
 

--- a/db/database.go
+++ b/db/database.go
@@ -104,8 +104,9 @@ type DatabaseContext struct {
 	ResyncManager                *BackgroundManager
 	TombstoneCompactionManager   *BackgroundManager
 	AttachmentCompactionManager  *BackgroundManager
-	ExitChanges                  chan struct{}            // Active _changes feeds on the DB will close when this channel is closed
-	OIDCProviders                auth.OIDCProviderMap     // OIDC clients
+	ExitChanges                  chan struct{}        // Active _changes feeds on the DB will close when this channel is closed
+	OIDCProviders                auth.OIDCProviderMap // OIDC clients
+	LocalJWTProviders            auth.LocalJWTProviderMap
 	PurgeInterval                time.Duration            // Metadata purge interval
 	serverUUID                   string                   // UUID of the server, if available
 	DbStats                      *base.DbStats            // stats that correspond to this database context
@@ -524,6 +525,11 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 
 			dbContext.OIDCProviders[name] = provider
 		}
+	}
+
+	dbContext.LocalJWTProviders = make(auth.LocalJWTProviderMap, len(options.LocalJWTConfig))
+	for name, cfg := range options.LocalJWTConfig {
+		dbContext.LocalJWTProviders[name] = cfg.BuildProvider(name)
 	}
 
 	if dbContext.UseXattrs() {

--- a/rest/config.go
+++ b/rest/config.go
@@ -754,9 +754,16 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 		if local.ClientID == nil {
 			multiError = multiError.Append(fmt.Errorf("Client ID required for Local JWT provider %s (set to \"\" to disable audience validation)", name))
 		}
-		if len(local.Keys) == 0 || len(local.Algorithms) == 0 {
-			multiError = multiError.Append(fmt.Errorf("Keys and Algorithms required for Local JWT provider %s", name))
+		if len(local.Algorithms) == 0 {
+			multiError = multiError.Append(fmt.Errorf("algorithms required for Local JWT provider %s", name))
 		}
+		if len(local.Keys) == 0 && len(local.JWKSURI) == 0 {
+			multiError = multiError.Append(fmt.Errorf("either 'keys' or 'jwks_uri' must be specified for Local JWT provider %s", name))
+		}
+		if len(local.Keys) > 0 && len(local.JWKSURI) > 0 {
+			multiError = multiError.Append(fmt.Errorf("'keys' and 'jwks_uri' are mutually exclusive for Local JWT provider %s", name))
+		}
+
 		didReportKIDError := false
 		for i, key := range local.Keys {
 			if key.KeyID == "" && len(local.Keys) > 1 && !didReportKIDError {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -356,6 +356,11 @@ func TestConfigValidationJWTAndOIDC(t *testing.T) {
 			configJSON: `{"name": "test", "local_jwt": { "test": { "issuer": "test", "client_id": "", "keys": [` + testRSA256JWK + `], "algorithms": ["RS256"] } }}`,
 		},
 		{
+			name:          "Local JWT: no keys",
+			configJSON:    `{"name": "test", "local_jwt": { "test": { "issuer": "test", "client_id": "", "algorithms": ["RS256"] } }}`,
+			expectedError: `either 'keys' or 'jwks_uri' must be specified for Local JWT provider test`,
+		},
+		{
 			name:          "Local JWT: private key",
 			configJSON:    `{"name": "test", "local_jwt": { "test": { "issuer": "test", "client_id": "", "keys": [` + testPrivateRSA256JWK + `], "algorithms": ["RS256"] } }}`,
 			expectedError: `key "rsa-priv" is not a public key`,

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -529,10 +529,10 @@ func (h *handler) checkAuth(dbCtx *db.DatabaseContext) (err error) {
 	}(time.Now())
 
 	// If oidc enabled, check for bearer ID token
-	if dbCtx.Options.OIDCOptions != nil || len(dbCtx.Options.LocalJWTConfig) > 0 {
+	if dbCtx.Options.OIDCOptions != nil || len(dbCtx.LocalJWTProviders) > 0 {
 		if token := h.getBearerToken(); token != "" {
 			var updates auth.PrincipalConfig
-			h.user, updates, err = dbCtx.Authenticator(h.ctx()).AuthenticateUntrustedJWT(token, dbCtx.OIDCProviders, dbCtx.Options.LocalJWTConfig, h.getOIDCCallbackURL)
+			h.user, updates, err = dbCtx.Authenticator(h.ctx()).AuthenticateUntrustedJWT(token, dbCtx.OIDCProviders, dbCtx.LocalJWTProviders, h.getOIDCCallbackURL)
 			if h.user == nil || err != nil {
 				return base.HTTPErrorf(http.StatusUnauthorized, "Invalid login")
 			}
@@ -622,7 +622,7 @@ func checkJWTIssuerStillValid(ctx context.Context, dbCtx *db.DatabaseContext, us
 			break
 		}
 	}
-	for _, provider := range dbCtx.Options.LocalJWTConfig {
+	for _, provider := range dbCtx.LocalJWTProviders {
 		if provider.Issuer == issuer {
 			providerStillValid = true
 			break


### PR DESCRIPTION
CBG-2144

Adds the `jwks_uri` configuration property, allowing loading of JWT verification keys from a remote JWKS URI (mutually exclusive with storing keys in memory).

May be easier to review commit by commit.

## Dependencies

- [x] #5593 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/413/
  * `TestRemoveObsoleteDesignDocs/gocb.v2 ` flake
