### PR TITLE
CBG-2134: Public channel is now added to the default GUEST user config

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -107,10 +107,6 @@ func (auth *Authenticator) GetUser(name string) (User, error) {
 	} else if princ == nil {
 		if name == "" {
 			princ = auth.defaultGuestUser()
-			err := auth.rebuildChannels(princ)
-			if err != nil {
-				return nil, err
-			}
 		} else {
 			return nil, nil
 		}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -107,6 +107,10 @@ func (auth *Authenticator) GetUser(name string) (User, error) {
 	} else if princ == nil {
 		if name == "" {
 			princ = auth.defaultGuestUser()
+			err := auth.rebuildChannels(princ)
+			if err != nil {
+				return nil, err
+			}
 		} else {
 			return nil, nil
 		}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -258,12 +258,7 @@ func TestGetGuestUser(t *testing.T) {
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 	user, err := auth.GetUser("")
 	require.Equal(t, nil, err)
-
-	guestUser := auth.defaultGuestUser()
-	err = auth.rebuildChannels(guestUser)
-	require.NoError(t, err)
-
-	assert.Equal(t, guestUser, user)
+	assert.Equal(t, auth.defaultGuestUser(), user)
 }
 
 func TestSaveUsers(t *testing.T) {

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -252,13 +252,18 @@ func TestGetMissingRole(t *testing.T) {
 }
 
 func TestGetGuestUser(t *testing.T) {
-
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
+
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 	user, err := auth.GetUser("")
-	assert.Equal(t, nil, err)
-	assert.Equal(t, auth.defaultGuestUser(), user)
+	require.Equal(t, nil, err)
+
+	guestUser := auth.defaultGuestUser()
+	err = auth.rebuildChannels(guestUser)
+	require.NoError(t, err)
+
+	assert.Equal(t, guestUser, user)
 }
 
 func TestSaveUsers(t *testing.T) {

--- a/auth/user.go
+++ b/auth/user.go
@@ -75,7 +75,6 @@ func (auth *Authenticator) defaultGuestUser() User {
 		auth: auth,
 	}
 	user.Channels_ = user.ExplicitChannels_.Copy()
-	user.Channels_.AddChannel(ch.DocumentStarChannel, 1)
 	return user
 }
 

--- a/auth/user.go
+++ b/auth/user.go
@@ -75,6 +75,7 @@ func (auth *Authenticator) defaultGuestUser() User {
 		auth: auth,
 	}
 	user.Channels_ = user.ExplicitChannels_.Copy()
+	user.Channels_.AddChannel(ch.DocumentStarChannel, 1)
 	return user
 }
 

--- a/auth/user.go
+++ b/auth/user.go
@@ -74,7 +74,6 @@ func (auth *Authenticator) defaultGuestUser() User {
 		},
 		auth: auth,
 	}
-	user.Channels_ = user.ExplicitChannels_.Copy()
 	return user
 }
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -227,8 +227,10 @@ func (rt *RestTester) Bucket() base.Bucket {
 		// testBucket's closeFn
 		rt.testBucket.Bucket = rt.RestTesterServerContext.Database("db").Bucket
 
-		if err := rt.SetAdminParty(rt.guestEnabled); err != nil {
-			rt.tb.Fatalf("Error from SetAdminParty %v", err)
+		if rt.DatabaseConfig.Guest == nil {
+			if err := rt.SetAdminParty(rt.guestEnabled); err != nil {
+				rt.tb.Fatalf("Error from SetAdminParty %v", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
CBG-2134

- The GUEST users channels are rebuilt on first auth
- The rest tester no longer sets admin party if the database config GUEST user config is filled
- Added testing for this change

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/366/
