### PR TITLE
CBG-2157: Allow SG databases to be created for a single named collection

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -169,6 +169,7 @@ type BucketSpec struct {
 	MaxConcurrentQueryOps         *int           // maximum number of concurrent query operations (default: DefaultMaxConcurrentQueryOps)
 	BucketOpTimeout               *time.Duration // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
 	KvPoolSize                    int            // gocb kv_pool_size - number of pipelines per node. Initialized on GetGoCBConnString
+	Scope, Collection             *string        // An optional named scope/collection. If not specified, the _default scope/collection will be used.
 }
 
 // Create a RetrySleeper based on the bucket spec properties.  Used to retry bucket operations after transient errors.

--- a/base/collection.go
+++ b/base/collection.go
@@ -116,8 +116,17 @@ func GetCollectionFromCluster(cluster *gocb.Cluster, spec BucketSpec, waitUntilR
 	// Safe to get first node as there will always be at least one node in the list and cluster compat is uniform across all nodes.
 	clusterCompatMajor, clusterCompatMinor := decodeClusterVersion(nodesMetadata[0].ClusterCompatibility)
 
+	c := bucket.DefaultCollection()
+	if spec.Collection != nil {
+		if spec.Scope != nil {
+			c = bucket.Scope(*spec.Scope).Collection(*spec.Collection)
+		} else {
+			c = bucket.Collection(*spec.Collection)
+		}
+	}
+
 	collection := &Collection{
-		Collection:                bucket.DefaultCollection(),
+		Collection:                c,
 		Spec:                      spec,
 		cluster:                   cluster,
 		clusterCompatMajorVersion: uint64(clusterCompatMajor),
@@ -698,7 +707,7 @@ func (c *Collection) BucketItemCount() (itemCount int, err error) {
 
 	// TODO: implement APIBucketItemCount for collections as part of CouchbaseStore refactoring.  Until then, give flush a moment to finish
 	time.Sleep(1 * time.Second)
-	//itemCount, err = bucket.APIBucketItemCount()
+	// itemCount, err = bucket.APIBucketItemCount()
 	return 0, err
 }
 

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -57,7 +57,8 @@ func TestAttachmentMark(t *testing.T) {
 		assert.NoError(t, err)
 
 		compactIDSection, ok := attachmentData[CompactionIDKey]
-		assert.True(t, ok)
+		require.True(t, ok)
+		require.NotNil(t, compactIDSection)
 
 		_, ok = compactIDSection.(map[string]interface{})[t.Name()]
 		assert.True(t, ok)

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -716,7 +716,7 @@ func (bsc *BlipSyncContext) sendRevAsDelta(sender *blip.Sender, docID, revID, de
 	bsc.replicationStats.SendRevDeltaRequestedCount.Add(1)
 
 	revDelta, redactedRev, err := handleChangesResponseDb.GetDelta(docID, deltaSrcRevID, revID)
-	if err == ErrForbidden { //nolint: gocritic // can't convert if/else if to switch since base.IsFleeceDeltaError is not switchable
+	if err == ErrForbidden { // nolint: gocritic // can't convert if/else if to switch since base.IsFleeceDeltaError is not switchable
 		return err
 	} else if base.IsFleeceDeltaError(err) {
 		// Something went wrong in the diffing library. We want to know about this!

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -76,8 +76,8 @@ type BlipSyncContext struct {
 	blipContextDb                    *Database       // 'master' database instance for the replication, used as source when creating handler-specific databases
 	loggingCtx                       context.Context // logging context for connection
 	dbUserLock                       sync.RWMutex    // Must be held when refreshing the db user
-	gotSubChanges                    bool            //nolint: structcheck // false structcheck positive due to https://github.com/golangci/golangci-lint/issues/826
-	continuous                       bool            //nolint: structcheck // false structcheck positive due to https://github.com/golangci/golangci-lint/issues/826
+	gotSubChanges                    bool            // nolint: structcheck // false structcheck positive due to https://github.com/golangci/golangci-lint/issues/826
+	continuous                       bool            // nolint: structcheck // false structcheck positive due to https://github.com/golangci/golangci-lint/issues/826
 	lock                             sync.Mutex
 	allowedAttachments               map[string]AllowedAttachment
 	handlerSerialNumber              uint64                                    // Each handler within a context gets a unique serial number for logging

--- a/db/database.go
+++ b/db/database.go
@@ -119,7 +119,7 @@ type DatabaseContext struct {
 	ServeInsecureAttachmentTypes bool                     // Attachment content type will bypass the content-disposition handling, default false
 	NoX509HTTPClient             *http.Client             // A HTTP Client from gocb to use the management endpoints
 	ServerContextHasStarted      chan struct{}            // Closed via PostStartup once the server has fully started
-	Scopes                       map[string]Scope         // A map keyed by scope name containing a set of scopes/collections.
+	Scopes                       map[string]Scope         // A map keyed by scope name containing a set of scopes/collections. Nil if running with only _default._default
 }
 
 type Scope struct {

--- a/db/database.go
+++ b/db/database.go
@@ -119,6 +119,15 @@ type DatabaseContext struct {
 	ServeInsecureAttachmentTypes bool                     // Attachment content type will bypass the content-disposition handling, default false
 	NoX509HTTPClient             *http.Client             // A HTTP Client from gocb to use the management endpoints
 	ServerContextHasStarted      chan struct{}            // Closed via PostStartup once the server has fully started
+	Scopes                       map[string]Scope         // A map keyed by scope name containing a set of scopes/collections.
+}
+
+type Scope struct {
+	Collections map[string]Collection
+}
+
+type Collection struct {
+	Datastore base.Bucket // Where data is stored for the collection
 }
 
 type DatabaseContextOptions struct {

--- a/db/database.go
+++ b/db/database.go
@@ -127,7 +127,7 @@ type Scope struct {
 }
 
 type Collection struct {
-	Datastore base.Bucket // Where data is stored for the collection
+	Datastore base.Bucket // Where data is stored for the collection - This should be changed to allow multiple collections to share the same underlying SDK connection once support for >1 collection is added.
 }
 
 type DatabaseContextOptions struct {

--- a/db/database.go
+++ b/db/database.go
@@ -127,7 +127,7 @@ type Scope struct {
 }
 
 type Collection struct {
-	Datastore base.Bucket // Where data is stored for the collection - This should be changed to allow multiple collections to share the same underlying SDK connection once support for >1 collection is added.
+	CollectionCtx *DatabaseContext // SG Database operations (e.g. GetDocument) for this collection.
 }
 
 type DatabaseContextOptions struct {

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -95,7 +95,7 @@ func TestCollectionsPutDocInKeyspace(t *testing.T) {
 			docID := fmt.Sprintf("doc%d", i)
 			path := fmt.Sprintf("/%s/%s", test.keyspace, docID)
 			resp := rt.SendUserRequestWithHeaders(http.MethodPut, path, `{"test":true}`, nil, username, password)
-			assertStatus(t, resp, test.expectedStatus)
+			requireStatus(t, resp, test.expectedStatus)
 
 			if test.expectedStatus == http.StatusCreated {
 				// go and check that the doc didn't just end up in the default collection of the test bucket

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -1,0 +1,107 @@
+//  Copyright 2022-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/auth"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCollectionsPutDocInKeyspace creates a collection and starts up a RestTester instance on it.
+// Ensures that various keyspaces can be used to insert a doc in the collection.
+func TestCollectionsPutDocInKeyspace(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Walrus does not support scopes and collections")
+	}
+
+	const (
+		scopeName      = "foo"
+		collectionName = "bar"
+	)
+
+	tests := []struct {
+		name           string
+		keyspace       string
+		expectedStatus int
+	}{
+		{
+			name:           "implicit scope and collection",
+			keyspace:       "db",
+			expectedStatus: http.StatusCreated,
+		},
+		{
+			name:           "fully qualified",
+			keyspace:       fmt.Sprintf("%s.%s.%s", "db", scopeName, collectionName),
+			expectedStatus: http.StatusCreated,
+		},
+		{
+			name:           "collection only",
+			keyspace:       fmt.Sprintf("%s.%s", "db", collectionName),
+			expectedStatus: http.StatusCreated,
+		},
+		{
+			name:           "invalid collection",
+			keyspace:       fmt.Sprintf("%s.%s.%s", "db", scopeName, "buzz"),
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:           "invalid scope",
+			keyspace:       fmt.Sprintf("%s.%s.%s", "db", "buzz", collectionName),
+			expectedStatus: http.StatusNotFound,
+		},
+	}
+
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+
+	const (
+		username = "alice"
+		password = "pass"
+	)
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		createScopesAndCollections: true,
+		TestBucket:                 tb.NoCloseClone(), // Clone so scope/collection isn't set on tb from rt
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					username: {Password: base.StringPtr(password)},
+				},
+				Scopes: ScopesConfig{
+					scopeName: ScopeConfig{
+						Collections: map[string]CollectionConfig{
+							collectionName: {},
+						},
+					},
+				},
+			},
+		},
+	})
+	defer rt.Close()
+
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			docID := fmt.Sprintf("doc%d", i)
+			path := fmt.Sprintf("/%s/%s", test.keyspace, docID)
+			resp := rt.SendUserRequestWithHeaders(http.MethodPut, path, `{"test":true}`, nil, username, password)
+			assertStatus(t, resp, test.expectedStatus)
+
+			if test.expectedStatus == http.StatusCreated {
+				// go and check that the doc didn't just end up in the default collection of the test bucket
+				docBody, _, err := tb.GetRaw(docID)
+				assert.Truef(t, base.IsDocNotFoundError(err), "didn't expect doc %q to be in the default collection but got body:%s err:%v", docID, docBody, err)
+			}
+		})
+	}
+}

--- a/rest/config.go
+++ b/rest/config.go
@@ -94,13 +94,14 @@ func (dc *DbConfig) MakeBucketSpec() base.BucketSpec {
 		tlsPort = bc.KvTLSPort
 	}
 
-	// FIXME: This is a hack to get named collection tests working.
-	// Grab one scope/collection name.
-	// Phase 2 means DbConfig needs to contain a set of collections, not just one...
+	// FIXME: This is a hack to get a single named collection working.
+	// Grab just one scope/collection from the defined set.
+	// Phase 2 (multi collection) means DatabaseContext needs a set of BucketSpec/Collections, not just one...
 	var scope, collection *string
 	for scopeName, scopeConfig := range dc.Scopes {
 		scope = &scopeName
 		for collectionName := range scopeConfig.Collections {
+			base.WarnfCtx(context.TODO(), "WIP Collections (Phase 1) - Running db %q in scope %q collection %q", dc.Name, scopeName, collectionName)
 			collection = &collectionName
 			break
 		}

--- a/rest/config.go
+++ b/rest/config.go
@@ -1361,7 +1361,7 @@ func (sc *ServerContext) fetchConfigs(isInitialStartup bool) (dbNameConfigs map[
 			cnf.KeyPath = sc.config.Bootstrap.X509KeyPath
 		}
 
-		base.TracefCtx(logCtx, base.KeyConfig, "Got config for group %q from bucket %q with cas %d", sc.config.Bootstrap.ConfigGroupID, bucket, cas)
+		base.DebugfCtx(logCtx, base.KeyConfig, "Got config for group %q from bucket %q with cas %d", sc.config.Bootstrap.ConfigGroupID, bucket, cas)
 		fetchedConfigs[cnf.Name] = cnf
 	}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -793,6 +793,12 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 		multiError = multiError.Append(fmt.Errorf("only one named scope is supported, but had %d (%v)", len(dbConfig.Scopes), dbConfig.Scopes))
 	} else {
 		for scopeName, scopeConfig := range dbConfig.Scopes {
+			// WIP: Collections Phase 1 - Only allow a single collection
+			if len(scopeConfig.Collections) != 1 {
+				multiError = multiError.Append(fmt.Errorf("WIP Collections Phase 1 only supports a single collection - had %d", len(scopeConfig.Collections)))
+				continue
+			}
+
 			if len(scopeConfig.Collections) == 0 {
 				multiError = multiError.Append(fmt.Errorf("must specify at least one collection in scope %v", scopeName))
 				continue

--- a/rest/config.go
+++ b/rest/config.go
@@ -94,8 +94,7 @@ func (dc *DbConfig) MakeBucketSpec() base.BucketSpec {
 		tlsPort = bc.KvTLSPort
 	}
 
-	// FIXME: This is a hack to get a single named collection working.
-	// Grab just one scope/collection from the defined set.
+	// WIP: Collections Phase 1 - Grab just one scope/collection from the defined set.
 	// Phase 2 (multi collection) means DatabaseContext needs a set of BucketSpec/Collections, not just one...
 	var scope, collection *string
 	for scopeName, scopeConfig := range dc.Scopes {

--- a/rest/config.go
+++ b/rest/config.go
@@ -94,6 +94,18 @@ func (dc *DbConfig) MakeBucketSpec() base.BucketSpec {
 		tlsPort = bc.KvTLSPort
 	}
 
+	// FIXME: This is a hack to get named collection tests working.
+	// Grab one scope/collection name.
+	// Phase 2 means DbConfig needs to contain a set of collections, not just one...
+	var scope, collection *string
+	for scopeName, scopeConfig := range dc.Scopes {
+		scope = &scopeName
+		for collectionName := range scopeConfig.Collections {
+			collection = &collectionName
+			break
+		}
+	}
+
 	return base.BucketSpec{
 		Server:                server,
 		BucketName:            bucketName,
@@ -103,6 +115,8 @@ func (dc *DbConfig) MakeBucketSpec() base.BucketSpec {
 		KvTLSPort:             tlsPort,
 		Auth:                  bc,
 		MaxConcurrentQueryOps: bc.MaxConcurrentQueryOps,
+		Scope:                 scope,
+		Collection:            collection,
 	}
 }
 
@@ -1347,7 +1361,7 @@ func (sc *ServerContext) fetchConfigs(isInitialStartup bool) (dbNameConfigs map[
 			cnf.KeyPath = sc.config.Bootstrap.X509KeyPath
 		}
 
-		base.DebugfCtx(logCtx, base.KeyConfig, "Got config for group %q from bucket %q with cas %d", sc.config.Bootstrap.ConfigGroupID, bucket, cas)
+		base.TracefCtx(logCtx, base.KeyConfig, "Got config for group %q from bucket %q with cas %d", sc.config.Bootstrap.ConfigGroupID, bucket, cas)
 		fetchedConfigs[cnf.Name] = cnf
 	}
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -300,6 +300,9 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 		if !foundScope || !foundCollection {
 			return base.HTTPErrorf(http.StatusNotFound, "keyspace %s.%s.%s not found", base.MD(keyspaceDb), base.MD(*keyspaceScope), base.MD(*keyspaceCollection))
 		}
+	} else {
+		keyspaceScope = base.StringPtr(base.DefaultScope)
+		keyspaceCollection = base.StringPtr(base.DefaultCollection)
 	}
 
 	// If this call is in the context of a DB make sure the DB is in a valid state

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -89,6 +89,8 @@ type handler struct {
 	statusMessage         string
 	requestBody           io.ReadCloser
 	db                    *db.Database
+	keyspaceScope         string
+	keyspaceCollection    string
 	user                  auth.User
 	authorizedAdminUser   string
 	privs                 handlerPrivs
@@ -432,9 +434,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 
 	// Now set the request's Database (i.e. context + user)
 	if dbContext != nil {
-		// TODO: Set keyspace fields in h for access in API handlers
-		_, _ = keyspaceScope, keyspaceCollection
-
+		h.keyspaceScope, h.keyspaceCollection = *keyspaceScope, *keyspaceCollection
 		h.db, err = db.GetDatabase(dbContext, h.user)
 		if err != nil {
 			return err

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -278,41 +278,41 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 		}
 	}
 
-	// Named collections handling
-	if dbContext.Scopes != nil {
-		// Allow an empty scope to refer to the one SG is running with, rather than falling back to _default
-		if keyspaceScope == nil {
-			// TODO: There could be a configurable dbContext.defaultNamedScope if we allow >1 scope
-			//       for now we don't need it - just use the one we're running with.
-			for scopeName := range dbContext.Scopes {
-				keyspaceScope = &scopeName
-				break
-			}
-		}
-		scope, foundScope := dbContext.Scopes[*keyspaceScope]
-		if !foundScope {
-			return base.HTTPErrorf(http.StatusNotFound, "keyspace %s.%s.%s not found", base.MD(keyspaceDb), base.MD(*keyspaceScope), base.MD(*keyspaceCollection))
-		}
-
-		if keyspaceCollection == nil {
-			if len(scope.Collections) > 1 {
-				// _default doesn't exist for a non-default scope - so make it a required element if it's ambiguous
-				return base.HTTPErrorf(http.StatusBadRequest, "Ambiguous keyspace: %s.%s", keyspaceDb, *keyspaceScope)
-			}
-			keyspaceCollection = dbContext.BucketSpec.Collection
-		}
-		_, foundCollection := scope.Collections[*keyspaceCollection]
-		if !foundCollection {
-			return base.HTTPErrorf(http.StatusNotFound, "keyspace %s.%s.%s not found", base.MD(keyspaceDb), base.MD(*keyspaceScope), base.MD(*keyspaceCollection))
-		}
-	} else {
-		// Set these for handlers that expect a scope/collection to be set, even if not using named collections.
-		keyspaceScope = base.StringPtr(base.DefaultScope)
-		keyspaceCollection = base.StringPtr(base.DefaultCollection)
-	}
-
 	// If this call is in the context of a DB make sure the DB is in a valid state
 	if dbContext != nil {
+		// Named collections handling
+		if dbContext.Scopes != nil {
+			// Allow an empty scope to refer to the one SG is running with, rather than falling back to _default
+			if keyspaceScope == nil {
+				// TODO: There could be a configurable dbContext.defaultNamedScope if we allow >1 scope
+				//       for now we don't need it - just use the one we're running with.
+				for scopeName := range dbContext.Scopes {
+					keyspaceScope = &scopeName
+					break
+				}
+			}
+			scope, foundScope := dbContext.Scopes[*keyspaceScope]
+			if !foundScope {
+				return base.HTTPErrorf(http.StatusNotFound, "keyspace %s.%s.%s not found", base.MD(keyspaceDb), base.MD(*keyspaceScope), base.MD(*keyspaceCollection))
+			}
+
+			if keyspaceCollection == nil {
+				if len(scope.Collections) > 1 {
+					// _default doesn't exist for a non-default scope - so make it a required element if it's ambiguous
+					return base.HTTPErrorf(http.StatusBadRequest, "Ambiguous keyspace: %s.%s", keyspaceDb, *keyspaceScope)
+				}
+				keyspaceCollection = dbContext.BucketSpec.Collection
+			}
+			_, foundCollection := scope.Collections[*keyspaceCollection]
+			if !foundCollection {
+				return base.HTTPErrorf(http.StatusNotFound, "keyspace %s.%s.%s not found", base.MD(keyspaceDb), base.MD(*keyspaceScope), base.MD(*keyspaceCollection))
+			}
+		} else {
+			// Set these for handlers that expect a scope/collection to be set, even if not using named collections.
+			keyspaceScope = base.StringPtr(base.DefaultScope)
+			keyspaceCollection = base.StringPtr(base.DefaultCollection)
+		}
+
 		if !h.runOffline {
 
 			// get a read lock on the dbContext

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -514,7 +514,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config DatabaseConfig, useE
 		dbcontext.Scopes = map[string]db.Scope{
 			*spec.Scope: {
 				Collections: map[string]db.Collection{
-					*spec.Collection: {Datastore: bucket},
+					*spec.Collection: {CollectionCtx: dbcontext}, // TODO: Prior to Phase 2 - move DatabaseContext methods like PutSpecial, etc. into CollectionContext
 				},
 			},
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -509,6 +509,17 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config DatabaseConfig, useE
 	dbcontext.ServerContextHasStarted = sc.hasStarted
 	dbcontext.NoX509HTTPClient = sc.NoX509HTTPClient
 
+	// WIP: Collections Phase 1 - Hardcode the single scope/collection into DatabaseContext.
+	if spec.Scope != nil && spec.Collection != nil {
+		dbcontext.Scopes = map[string]db.Scope{
+			*spec.Scope: {
+				Collections: map[string]db.Collection{
+					*spec.Collection: {Datastore: bucket},
+				},
+			},
+		}
+	}
+
 	syncFn := ""
 	if config.Sync != nil {
 		syncFn = *config.Sync


### PR DESCRIPTION
CBG-2157

Allows a SG database to start up aginst a single named scope/collection and use the REST API to read and write documents in that keyspace instead of the default scope and collection.

- Validates that REST API keyspace usage is valid and matches running configuration.
- Exposes `DatabaseContext.Scopes[].Collections[]` for access in handlers (e.g. `getCollections`)
- Supports KV operations on the named collection.
- Persistent config still operates on default scope/collection.

Does not support:
- Query/Index/Views (CBG-2159 / CBG-2158)
- DCP (CBG-2182)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/369/
