### PR TITLE
CBG-2151: A noRev is only sent on ErrNotFound

### DIFF
--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -64,7 +64,7 @@ type LeakyBucketConfig struct {
 
 	// GetRawCallback issues a callback prior to running GetRaw. Allows tests to issue a doc mutation or deletion prior
 	// to GetRaw being ran.
-	GetRawCallback func(key string)
+	GetRawCallback func(key string) error
 
 	PostUpdateCallback func(key string)
 
@@ -105,13 +105,16 @@ func (b *LeakyBucket) Get(k string, rv interface{}) (cas uint64, err error) {
 	return b.bucket.Get(k, rv)
 }
 
-func (b *LeakyBucket) SetGetRawCallback(callback func(string)) {
+func (b *LeakyBucket) SetGetRawCallback(callback func(string) error) {
 	b.config.GetRawCallback = callback
 }
 
 func (b *LeakyBucket) GetRaw(k string) (v []byte, cas uint64, err error) {
 	if b.config.GetRawCallback != nil {
-		b.config.GetRawCallback(k)
+		err = b.config.GetRawCallback(k)
+		if err != nil {
+			return nil, 0, err
+		}
 	}
 	return b.bucket.GetRaw(k)
 }

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -303,7 +303,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 
 	triggerCallback := false
 	triggerStopCallback := false
-	leakyBucket.SetGetRawCallback(func(s string) {
+	leakyBucket.SetGetRawCallback(func(s string) error {
 		if triggerCallback {
 			err = testDB2.AttachmentCompactionManager.Start(map[string]interface{}{"database": testDB2})
 			assert.Error(t, err)
@@ -315,6 +315,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 			err = testDB2.AttachmentCompactionManager.Stop()
 			assert.NoError(t, err)
 		}
+		return nil
 	})
 
 	// Trigger start with immediate abort. Then resume, ensure that dry run is resumed
@@ -447,7 +448,7 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 
 	triggerCallback := false
 	triggerStopCallback := false
-	leakyBucket.SetGetRawCallback(func(s string) {
+	leakyBucket.SetGetRawCallback(func(s string) error {
 		if triggerCallback {
 			err = testDB2.AttachmentCompactionManager.Start(map[string]interface{}{"database": testDB2})
 			assert.Error(t, err)
@@ -459,6 +460,7 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 			err = testDB2.AttachmentCompactionManager.Stop()
 			assert.NoError(t, err)
 		}
+		return nil
 	})
 
 	// Trigger start with immediate abort. Then resume, ensure that dry run is resumed

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -541,8 +541,10 @@ func (bsc *BlipSyncContext) sendNoRev(sender *blip.Sender, docID, revID string, 
 // Pushes a revision body to the client
 func (bsc *BlipSyncContext) sendRevision(sender *blip.Sender, docID, revID string, seq SequenceID, knownRevs map[string]bool, maxHistory int, handleChangesResponseDb *Database) error {
 	rev, err := handleChangesResponseDb.GetRev(docID, revID, true, nil)
-	if err != nil {
+	if base.IsDocNotFoundError(err) {
 		return bsc.sendNoRev(sender, docID, revID, seq, err)
+	} else if err != nil {
+		return err
 	}
 
 	base.TracefCtx(bsc.loggingCtx, base.KeySync, "sendRevision, rev attachments for %s/%s are %v", base.UD(docID), revID, base.UD(rev.Attachments))

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -544,7 +544,7 @@ func (bsc *BlipSyncContext) sendRevision(sender *blip.Sender, docID, revID strin
 	if base.IsDocNotFoundError(err) {
 		return bsc.sendNoRev(sender, docID, revID, seq, err)
 	} else if err != nil {
-		return err
+		return fmt.Errorf("failed to GetRev for doc %s with rev %s: %w", base.UD(docID).Redact(), base.MD(revID).Redact(), err)
 	}
 
 	base.TracefCtx(bsc.loggingCtx, base.KeySync, "sendRevision, rev attachments for %s/%s are %v", base.UD(docID), revID, base.UD(rev.Attachments))

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -7817,7 +7817,7 @@ func TestRevocationUserHasDocAccessDocNotFound(t *testing.T) {
 	require.True(t, ok)
 
 	leakyBucket.SetGetRawCallback(func(s string) error {
-		assert.NoError(t, leakyBucket.Delete("doc"))
+		require.NoError(t, leakyBucket.Delete("doc"))
 		return nil
 	})
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -7816,8 +7816,9 @@ func TestRevocationUserHasDocAccessDocNotFound(t *testing.T) {
 	leakyBucket, ok := base.AsLeakyBucket(rt.Bucket())
 	require.True(t, ok)
 
-	leakyBucket.SetGetRawCallback(func(s string) {
+	leakyBucket.SetGetRawCallback(func(s string) error {
 		assert.NoError(t, leakyBucket.Delete("doc"))
+		return nil
 	})
 
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -4576,7 +4576,7 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 			}
 
 			resp := rt.SendAdminRequest(http.MethodPut, "/db/"+docName, `{"foo":"bar"}`)
-			assertStatus(t, resp, http.StatusCreated)
+			requireStatus(t, resp, http.StatusCreated)
 
 			// Make the LeakyBucket return an error
 			leakyBucket.SetGetRawCallback(func(key string) error {


### PR DESCRIPTION
CBG-2151

- Added error returning for `GetRaw` for the LeakyBucket
- Added testing to make sure a `noRev` is sent on `ErrNotFound` only.
- An error gets returned from `sendRevision` if it is not `ErrNotFound` otherwise a `noRev` gets sent

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/372/
