### PR TITLE
CBG-2073 Always read the message before copying

### DIFF
--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -817,6 +817,8 @@ func (btr *BlipTesterReplicator) GetMessages() map[blip.MessageNumber]blip.Messa
 
 	messages := make(map[blip.MessageNumber]blip.Message, len(btr.messages))
 	for k, v := range btr.messages {
+		// Read the body before copying, since it might be read asynchronously
+		_, _ = v.Body()
 		messages[k] = *v
 	}
 


### PR DESCRIPTION
This reads the body of message and probably reduces the frequency of the race condition. It can probably still race but it will make it less likely.