### PR TITLE
CBG-2183: Fix replication panic w/ non-existent role in user role history

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -131,6 +131,7 @@ func (auth *Authenticator) GetRoleIncDeleted(name string) (Role, error) {
 }
 
 // Common implementation of GetUser and GetRole. factory() parameter returns a new empty instance.
+// Returns (nil, nil) if the principal doesn't exist, or (nil, error) if getting it failed for some reason.
 func (auth *Authenticator) getPrincipal(docID string, factory func() Principal) (Principal, error) {
 	var princ Principal
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -4495,6 +4495,7 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 	}
 }
 
+// Regression test for CBG-2183.
 func TestBlipRevokeNonExistentRole(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
 		guestEnabled: false,

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -4494,3 +4494,40 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 		require.Equal(t, keyValueErr.DocumentID, v2Key)
 	}
 }
+
+func TestBlipRevokeNonExistentRole(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		guestEnabled: false,
+	})
+	defer rt.Close()
+
+	base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
+
+	// 1. Create user with admin_roles including two roles not previously defined (a1 and a2, for example)
+	const testUsername = "bilbo"
+	res := rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/_user/%s", rt.GetDatabase().Name, testUsername), fmt.Sprintf(`{"name": %q, "password": "test", "admin_roles": ["a1", "a2"], "admin_channels": ["c1"]}`, testUsername))
+	assertStatus(t, res, http.StatusCreated)
+
+	// Create a doc so we have something to replicate
+	res = rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/testdoc", rt.GetDatabase().Name), `{"channels": ["c1"]}`)
+	assertStatus(t, res, http.StatusCreated)
+
+	// 3. Update the user to not reference one of the roles (update to ['a1'], for example)
+	// [also revoke channel c1 so the doc shows up in the revocation queries]
+	res = rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/_user/%s", rt.GetDatabase().Name, testUsername), fmt.Sprintf(`{"name": %q, "password": "test", "admin_roles": ["a1"], "admin_channels": []}`, testUsername))
+	assertStatus(t, res, http.StatusOK)
+
+	// 4. Try to sync
+	bt, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+		Username:        testUsername,
+		SendRevocations: true,
+	})
+	require.NoError(t, err)
+	defer bt.Close()
+
+	require.NoError(t, bt.StartPull())
+	// in the failing case we'll panic before hitting this
+	base.WaitForStat(func() int64 {
+		return rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplCaughtUp.Value()
+	}, 1)
+}


### PR DESCRIPTION
CBG-2183

`getPrincipal` returns a nil principal and nil error if the principal doesn't exist, but `ChannelGrantedPeriods` was missing a nil check. Add one with an appropriate log message, and add a regression test.

Fixes #5610.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/374/
