### PR TITLE
CBG-2185: Permit (but warn) duplicate OIDC/JWT issuers

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -765,7 +765,7 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 	}
 
 	if len(seenIssuers) > 0 {
-		// CBG-2143: This should be an error but having duplicate configs is valid so this would be a breaking change
+		// CBG-2185: This should be an error but having duplicate configs is valid so this would be a breaking change
 		for iss, count := range seenIssuers {
 			if count > 1 {
 				// issuer names are not UD - see https://github.com/couchbase/sync_gateway/pull/5513#discussion_r856335452 for context

--- a/rest/config.go
+++ b/rest/config.go
@@ -764,13 +764,11 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 		seenIssuers[local.Issuer]++
 	}
 
-	if len(seenIssuers) > 0 {
-		// CBG-2185: This should be an error but having duplicate configs is valid so this would be a breaking change
-		for iss, count := range seenIssuers {
-			if count > 1 {
-				// issuer names are not UD - see https://github.com/couchbase/sync_gateway/pull/5513#discussion_r856335452 for context
-				base.WarnfCtx(ctx, "Found multiple OIDC/JWT providers using the same issuer (%s) - Implicit Grant flow may use incorrect providers.", iss)
-			}
+	// CBG-2185: This should be an error but having duplicate configs is valid so this would be a breaking change
+	for iss, count := range seenIssuers {
+		if count > 1 {
+			// issuer names are not UD - see https://github.com/couchbase/sync_gateway/pull/5513#discussion_r856335452 for context
+			base.WarnfCtx(ctx, "Found multiple OIDC/JWT providers using the same issuer (%s) - Implicit Grant flow may use incorrect providers.", iss)
 		}
 	}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -766,15 +766,11 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 
 	if len(seenIssuers) > 0 {
 		// CBG-2143: This should be an error but having duplicate configs is valid so this would be a breaking change
-		duplicateIssuers := make([]string, 0, len(seenIssuers))
 		for iss, count := range seenIssuers {
 			if count > 1 {
-				duplicateIssuers = append(duplicateIssuers, iss)
+				// issuer names are not UD - see https://github.com/couchbase/sync_gateway/pull/5513#discussion_r856335452 for context
+				base.WarnfCtx(ctx, "Found multiple OIDC/JWT providers using the same issuer (%s) - Implicit Grant flow may use incorrect providers.", iss)
 			}
-		}
-		if len(duplicateIssuers) > 0 {
-			// issuer names are not UD - see https://github.com/couchbase/sync_gateway/pull/5513#discussion_r856335452 for context
-			base.WarnfCtx(ctx, "Multiple OIDC/JWT issuers have the same provider - Implicit Grant flow may use incorrect providers. Duplicate issuers: %v", duplicateIssuers)
 		}
 	}
 

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -381,21 +381,6 @@ func TestConfigValidationJWTAndOIDC(t *testing.T) {
 			expectedError: `signing algorithm "none" invalid or unsupported`,
 		},
 		{
-			name:          "Local JWT: duplicate issuers (local-JWT)",
-			configJSON:    `{"name": "test", "local_jwt": { "test": { "issuer": "test", "client_id": "", "keys": [` + testRSA256JWK + `], "algorithms": ["RS256"] }, "test2": { "issuer": "test", "client_id": "", "keys": [` + testRSA256JWK + `], "algorithms": ["RS256"] } }}`,
-			expectedError: "duplicate OIDC/JWT issuer: test",
-		},
-		{
-			name:          "Local JWT: duplicate issuers (OIDC)",
-			configJSON:    `{"name": "test", "oidc": { "providers": { "test": {"issuer": "test", "client_id": "test"}, "test2": {"issuer": "test", "client_id": "test"} } }}`,
-			expectedError: "duplicate OIDC/JWT issuer: test",
-		},
-		{
-			name:          "Local JWT: duplicate issuers (mixed)",
-			configJSON:    `{"name": "test", "local_jwt": { "test": { "issuer": "test", "client_id": "", "keys": [` + testRSA256JWK + `], "algorithms": ["RS256"] }}, "oidc": { "providers": { "test": {"issuer": "test", "client_id": "test"} } }}`,
-			expectedError: "duplicate OIDC/JWT issuer: test",
-		},
-		{
 			name:          "OIDC: no providers",
 			configJSON:    `{"name": "test", "oidc": {"providers": {}}}`,
 			expectedError: "OpenID Connect defined in config, but no valid providers specified",


### PR DESCRIPTION
CBG-2185

We added a check for duplicate OIDC/JWT issuers because it causes Implicit Grant flow to be nondeterministic, but this broke existing configs that were valid in lower versions. Allow this but log a warning.