### PR TITLE
Undefer resp.Body.Close() usage in OIDC/JWT tests

### DIFF
--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -183,7 +183,7 @@ func TestBootstrapDuplicateBucket(t *testing.T) {
 	// CBG-1785 - Check the error has been changed from the original misleading error to a more informative one.
 	respBody, err := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
-	_ = resp.Body.Close()
+	require.NoError(t, resp.Body.Close())
 	assert.NotContains(t, string(respBody), fmt.Sprintf(`Database \"%s\" already exists`, "db2"))
 	assert.Contains(t, string(respBody), fmt.Sprintf(`Bucket \"%s\" already in use by database \"%s\"`, tb.GetName(), "db1"))
 }
@@ -233,7 +233,7 @@ func TestBootstrapDuplicateDatabase(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	respBody, err := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
-	_ = resp.Body.Close()
+	require.NoError(t, resp.Body.Close())
 	assert.Contains(t, string(respBody), `"num_doc_writes":1`)
 
 	// Create db1 again and expect it to fail
@@ -241,7 +241,7 @@ func TestBootstrapDuplicateDatabase(t *testing.T) {
 	assert.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
 	respBody, err = ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
-	_ = resp.Body.Close()
+	require.NoError(t, resp.Body.Close())
 	assert.Contains(t, string(respBody), fmt.Sprintf(`Duplicate database name \"%s\"`, "db1"))
 
 	// check to see we still have a doc written stat (as a proxy to determine if the database restarted)
@@ -249,7 +249,7 @@ func TestBootstrapDuplicateDatabase(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	respBody, err = ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
-	_ = resp.Body.Close()
+	require.NoError(t, resp.Body.Close())
 	assert.Contains(t, string(respBody), `"num_doc_writes":1`)
 }
 

--- a/rest/jwt_auth_test.go
+++ b/rest/jwt_auth_test.go
@@ -108,7 +108,7 @@ func TestLocalJWTAuthenticationE2E(t *testing.T) {
 
 			res, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
-			defer res.Body.Close()
+			assert.NoError(t, res.Body.Close())
 
 			if !preExistingUser && !register {
 				require.Equal(t, http.StatusUnauthorized, res.StatusCode)
@@ -215,7 +215,7 @@ func TestLocalJWTAuthenticationEdgeCases(t *testing.T) {
 
 			res, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
-			defer res.Body.Close()
+			assert.NoError(t, res.Body.Close())
 
 			assert.Equal(t, expectedStatus, res.StatusCode)
 		}
@@ -335,7 +335,7 @@ func TestLocalJWTAndOIDCCoexistence(t *testing.T) {
 		req.Header.Set("Authorization", BearerToken+" "+token)
 		res, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
-		defer res.Body.Close()
+		assert.NoError(t, res.Body.Close())
 		require.Equal(t, http.StatusOK, res.StatusCode)
 
 		user, err := restTester.GetDatabase().Authenticator(base.TestCtx(t)).GetUser(expectedUsername)

--- a/rest/login_test.go
+++ b/rest/login_test.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // This test exists because there have been problems with builds of Go being unable to make HTTPS
@@ -22,11 +24,9 @@ func TestVerifyHTTPSSupport(t *testing.T) {
 	}
 
 	resp, err := http.Get("https://google.com")
-	defer func() {
-		if resp != nil {
-			_ = resp.Body.Close()
-		}
-	}()
+	if resp != nil {
+		assert.NoError(t, resp.Body.Close())
+	}
 
 	if err != nil {
 		// Skip test if dial tcp fails with no such host.


### PR DESCRIPTION
- Undefer resp.Body.Close() usage in OIDC/JWT tests and assert on the errors
- Add more Body.Close() assertions instead of ignoring

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/377/
