### PR TITLE
Jenkins Integration: Line-buffered test console output

### DIFF
--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -138,7 +138,7 @@ if [ "${SG_EDITION}" == "EE" ]; then
     GO_TEST_FLAGS="${GO_TEST_FLAGS} -tags cb_sg_enterprise"
 fi
 
-go test ${GO_TEST_FLAGS} -coverprofile=coverage_int.out -coverpkg=github.com/couchbase/sync_gateway/... github.com/couchbase/sync_gateway/${TARGET_PACKAGE} 2>&1 | tee "${INT_LOG_FILE_NAME}.out.raw" | grep -E '(--- (FAIL|PASS|SKIP):|github.com/couchbase/sync_gateway(/.+)?\t|TEST: |panic: )'
+go test ${GO_TEST_FLAGS} -coverprofile=coverage_int.out -coverpkg=github.com/couchbase/sync_gateway/... github.com/couchbase/sync_gateway/${TARGET_PACKAGE} 2>&1 | stdbuf -oL tee "${INT_LOG_FILE_NAME}.out.raw" | stdbuf -oL grep -E '(--- (FAIL|PASS|SKIP):|github.com/couchbase/sync_gateway(/.+)?\t|TEST: |panic: )'
 if [ "${PIPESTATUS[0]}" -ne "0" ]; then # If test exit code is not 0 (failed)
     echo "Go test failed! Parsing logs to find cause..."
     TEST_FAILED=true


### PR DESCRIPTION
Use stdbuf to force line-buffering for the piped/filtered integration test output
- Allows you to observe tests as each runs, rather than a long delay for a buffer to be filled before flushing to console output
- Happens because we're piping `go test` output through tee/grep which uses a 4k buffer

On `macos`, GNU stdbuf is available in the `coreutils` homebrew package.

## e.g:

### Before (identical timestamps because all of them were buffered)
```
12:44:54 --- PASS: TestMergeAttachments (0.00s)
12:44:54     --- PASS: TestMergeAttachments/all_nil (0.00s)
12:44:54     --- PASS: TestMergeAttachments/pre25Atts_only (0.00s)
12:44:54     --- PASS: TestMergeAttachments/docAtts_only (0.00s)
12:44:54     --- PASS: TestMergeAttachments/disjoint_set (0.00s)
12:44:54     --- PASS: TestMergeAttachments/25Atts_wins (0.00s)
12:44:54     --- PASS: TestMergeAttachments/docAtts_wins (0.00s)
12:44:54     --- PASS: TestMergeAttachments/invalid_pre25_revpos (0.00s)
12:44:54 --- PASS: TestDatabase (0.75s)
12:44:54 --- PASS: TestGetDeleted (0.75s)
12:44:54 --- PASS: TestGetRemovedAsUser (0.44s)
12:44:54 --- PASS: TestGetRemovalMultiChannel (0.47s)
12:44:54 --- PASS: TestDeltaSyncWhenFromRevIsChannelRemoval (0.95s)
12:44:54 --- PASS: TestDeltaSyncWhenToRevIsChannelRemoval (0.83s)
12:44:54 --- PASS: TestGetRemoved (0.43s)
12:44:54 --- PASS: TestGetRemovedAndDeleted (0.76s)
12:44:54 --- PASS: TestAllDocsOnly (1.32s)
12:44:54 --- PASS: TestUpdatePrincipal (0.37s)
12:44:54 --- PASS: TestRepeatedConflict (0.67s)
```

### After (per-line timestamps and streamed output)
```
13:59:42 --- PASS: TestMergeAttachments (0.00s)
13:59:42     --- PASS: TestMergeAttachments/all_nil (0.00s)
13:59:42     --- PASS: TestMergeAttachments/pre25Atts_only (0.00s)
13:59:42     --- PASS: TestMergeAttachments/docAtts_only (0.00s)
13:59:42     --- PASS: TestMergeAttachments/disjoint_set (0.00s)
13:59:42     --- PASS: TestMergeAttachments/25Atts_wins (0.00s)
13:59:42     --- PASS: TestMergeAttachments/docAtts_wins (0.00s)
13:59:42     --- PASS: TestMergeAttachments/invalid_pre25_revpos (0.00s)
13:59:43 --- PASS: TestDatabase (0.87s)
13:59:44 --- PASS: TestGetDeleted (0.75s)
13:59:45 --- PASS: TestGetRemovedAsUser (0.78s)
13:59:47 --- PASS: TestGetRemovalMultiChannel (2.44s)
13:59:49 --- PASS: TestDeltaSyncWhenFromRevIsChannelRemoval (1.78s)
13:59:51 --- PASS: TestDeltaSyncWhenToRevIsChannelRemoval (1.78s)
13:59:51 --- PASS: TestGetRemoved (0.02s)
13:59:51 --- PASS: TestGetRemovedAndDeleted (0.52s)
13:59:53 --- PASS: TestAllDocsOnly (1.70s)
13:59:53 --- PASS: TestUpdatePrincipal (0.39s)
13:59:54 --- PASS: TestRepeatedConflict (0.68s)
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `db` `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/378/
