### PR TITLE
CBG-2158: Collections support for index/queries

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1657,7 +1657,7 @@ func (bucket *CouchbaseBucketGoCB) APIBucketItemCount() (itemCount int, err erro
 // QueryBucketItemCount uses a request plus query to get the number of items in a bucket, as the REST API can be slow to update its value.
 // Requires a primary index on the bucket.
 func QueryBucketItemCount(n1qlStore N1QLStore) (itemCount int, err error) {
-	statement := fmt.Sprintf("SELECT COUNT(1) AS count FROM `%s`", KeyspaceQueryToken)
+	statement := fmt.Sprintf("SELECT COUNT(1) AS count FROM %s", KeyspaceQueryToken)
 	r, err := n1qlStore.Query(statement, nil, RequestPlus, true)
 	if err != nil {
 		return -1, err

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -22,11 +22,12 @@ import (
 	"gopkg.in/couchbase/gocb.v1"
 )
 
-const KeyspaceQueryToken = "$_keyspace" // Token used for bucket name replacement in query statements
-const MaxQueryRetries = 30              // Maximum query retries on indexer error
-const IndexStateOnline = "online"       // bucket state value, as returned by SELECT FROM system:indexes.  Index has been created and built.
-const IndexStateDeferred = "deferred"   // bucket state value, as returned by SELECT FROM system:indexes.  Index has been created but not built.
-const IndexStatePending = "pending"     // bucket state value, as returned by SELECT FROM system:indexes.  Index has been created, build is in progress
+const KeyspaceQueryToken = "$_keyspace"    // Token used for bucket name replacement in query statements
+const KeyspaceAlias = "queryKeyspaceAlias" // Keyspace alias set for the keyspace in FROM statements in queries
+const MaxQueryRetries = 30                 // Maximum query retries on indexer error
+const IndexStateOnline = "online"          // bucket state value, as returned by SELECT FROM system:indexes.  Index has been created and built.
+const IndexStateDeferred = "deferred"      // bucket state value, as returned by SELECT FROM system:indexes.  Index has been created but not built.
+const IndexStatePending = "pending"        // bucket state value, as returned by SELECT FROM system:indexes.  Index has been created, build is in progress
 const PrimaryIndexName = "#primary"
 
 // IndexOptions used to build the 'with' clause

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -40,7 +40,7 @@ type N1qlIndexOptions struct {
 var _ N1QLStore = &CouchbaseBucketGoCB{}
 
 // Keyspace for a bucket in the default scope and collection can just be a bucket name
-func (bucket *CouchbaseBucketGoCB) EscapedFullyQualifiedKeyspace() string {
+func (bucket *CouchbaseBucketGoCB) EscapedKeyspace() string {
 	return fmt.Sprintf("`%s`", bucket.GetName())
 }
 

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -22,12 +22,12 @@ import (
 	"gopkg.in/couchbase/gocb.v1"
 )
 
-const KeyspaceQueryToken = "$_keyspace"    // Token used for keyspace name replacement in query statement. The replacement will be an escaped keyspace.
-const KeyspaceAlias = "queryKeyspaceAlias" // Keyspace alias set for the keyspace in FROM statements in queries
-const MaxQueryRetries = 30                 // Maximum query retries on indexer error
-const IndexStateOnline = "online"          // bucket state value, as returned by SELECT FROM system:indexes.  Index has been created and built.
-const IndexStateDeferred = "deferred"      // bucket state value, as returned by SELECT FROM system:indexes.  Index has been created but not built.
-const IndexStatePending = "pending"        // bucket state value, as returned by SELECT FROM system:indexes.  Index has been created, build is in progress
+const KeyspaceQueryToken = "$_keyspace"           // Token used for keyspace name replacement in query statement. The replacement will be an escaped keyspace.
+const KeyspaceQueryAlias = "sgQueryKeyspaceAlias" // Keyspace alias set for the keyspace in FROM statements in queries
+const MaxQueryRetries = 30                        // Maximum query retries on indexer error
+const IndexStateOnline = "online"                 // bucket state value, as returned by SELECT FROM system:indexes.  Index has been created and built.
+const IndexStateDeferred = "deferred"             // bucket state value, as returned by SELECT FROM system:indexes.  Index has been created but not built.
+const IndexStatePending = "pending"               // bucket state value, as returned by SELECT FROM system:indexes.  Index has been created, build is in progress
 const PrimaryIndexName = "#primary"
 
 // IndexOptions used to build the 'with' clause

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -12,6 +12,7 @@ package base
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -37,8 +38,23 @@ type N1qlIndexOptions struct {
 
 var _ N1QLStore = &CouchbaseBucketGoCB{}
 
-// Keyspace for a bucket is bucket name
-func (bucket *CouchbaseBucketGoCB) Keyspace() string {
+// Keyspace for a bucket is just a bucket name
+func (bucket *CouchbaseBucketGoCB) EscapedFullyQualifiedKeyspace() string {
+	return fmt.Sprintf("`%s`", bucket.GetName())
+}
+
+// IndexMetaBucketID returns the value of bucket_id for the system:indexes table for the bucket.
+func (bucket *CouchbaseBucketGoCB) IndexMetaBucketID() string {
+	return ""
+}
+
+// IndexMetaScopeID returns the value of scope_id for the system:indexes table for the bucket.
+func (bucket *CouchbaseBucketGoCB) IndexMetaScopeID() string {
+	return ""
+}
+
+// IndexMetaKeyspaceID returns the value of keyspace_id for the system:indexes table for the bucket.
+func (bucket *CouchbaseBucketGoCB) IndexMetaKeyspaceID() string {
 	return bucket.GetName()
 }
 

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -22,7 +22,7 @@ import (
 	"gopkg.in/couchbase/gocb.v1"
 )
 
-const KeyspaceQueryToken = "$_keyspace"    // Token used for bucket name replacement in query statements
+const KeyspaceQueryToken = "$_keyspace"    // Token used for keyspace name replacement in query statement. The replacement will be an escaped keyspace.
 const KeyspaceAlias = "queryKeyspaceAlias" // Keyspace alias set for the keyspace in FROM statements in queries
 const MaxQueryRetries = 30                 // Maximum query retries on indexer error
 const IndexStateOnline = "online"          // bucket state value, as returned by SELECT FROM system:indexes.  Index has been created and built.
@@ -39,7 +39,7 @@ type N1qlIndexOptions struct {
 
 var _ N1QLStore = &CouchbaseBucketGoCB{}
 
-// Keyspace for a bucket is just a bucket name
+// Keyspace for a bucket in the default scope and collection can just be a bucket name
 func (bucket *CouchbaseBucketGoCB) EscapedFullyQualifiedKeyspace() string {
 	return fmt.Sprintf("`%s`", bucket.GetName())
 }

--- a/base/collection.go
+++ b/base/collection.go
@@ -657,6 +657,40 @@ func (c *Collection) isRecoverableWriteError(err error) bool {
 	return false
 }
 
+// dropAllScopesAndCollections attempts to drop *all* non-_default scopes and collections from the bucket associated with the collection.  Intended for test usage only.
+func (c *Collection) dropAllScopesAndCollections() error {
+	cm := c.Bucket().Collections()
+	scopes, err := cm.GetAllScopes(nil)
+	if err != nil {
+		WarnfCtx(context.TODO(), "Error getting scopes on bucket %s: %v  Will retry.", MD(c.Bucket().Name()).Redact(), err)
+		return err
+	}
+
+	// For each non-default scope, drop them.
+	// For each collection within the default scope, drop them.
+	for _, scope := range scopes {
+		if scope.Name != DefaultScope {
+			if err := cm.DropScope(scope.Name, nil); err != nil {
+				WarnfCtx(context.TODO(), "Error dropping scope %s on bucket %s: %v  Will retry.", MD(scope).Redact(), MD(c.Bucket().Name()).Redact(), err)
+				return err
+			}
+			continue
+		}
+
+		// can't delete _default scope - but we can delete the non-_default collections within it
+		for _, collection := range scope.Collections {
+			if collection.Name != DefaultCollection {
+				if err := cm.DropCollection(collection, nil); err != nil {
+					WarnfCtx(context.TODO(), "Error dropping collection %s in scope %s on bucket %s: %v  Will retry.", MD(collection.Name).Redact(), MD(scope).Redact(), MD(c.Bucket().Name()).Redact(), err)
+					return err
+				}
+			}
+		}
+
+	}
+	return nil
+}
+
 // This flushes the *entire* bucket associated with the collection (not just the collection).  Intended for test usage only.
 func (c *Collection) Flush() error {
 

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -31,17 +31,26 @@ func (c *Collection) EscapedFullyQualifiedKeyspace() string {
 
 // IndexMetaBucketID returns the value of bucket_id for the system:indexes table for the collection.
 func (c *Collection) IndexMetaBucketID() string {
-	return c.BucketName()
+	if c.ScopeName() != DefaultScope && c.Name() != DefaultCollection {
+		return c.BucketName()
+	}
+	return ""
 }
 
 // IndexMetaScopeID returns the value of scope_id for the system:indexes table for the collection.
 func (c *Collection) IndexMetaScopeID() string {
-	return c.ScopeName()
+	if c.ScopeName() != DefaultScope && c.Name() != DefaultCollection {
+		return c.ScopeName()
+	}
+	return ""
 }
 
 // IndexMetaKeyspaceID returns the value of keyspace_id for the system:indexes table for the collection.
 func (c *Collection) IndexMetaKeyspaceID() string {
-	return c.Name()
+	if c.ScopeName() != DefaultScope && c.Name() != DefaultCollection {
+		return c.Name()
+	}
+	return c.BucketName()
 }
 
 func (c *Collection) Query(statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (resultsIterator sgbucket.QueryResultIterator, err error) {

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -26,34 +26,34 @@ var _ N1QLStore = &Collection{}
 
 // EscapedKeyspace returns the escaped fully-qualified identifier for the keyspace (e.g. `bucket`.`scope`.`collection`)
 func (c *Collection) EscapedKeyspace() string {
-	if c.ScopeName() != DefaultScope && c.Name() != DefaultCollection {
-		return fmt.Sprintf("`%s`.`%s`.`%s`", c.BucketName(), c.ScopeName(), c.Name())
+	if c.ScopeName() == DefaultScope && c.Name() == DefaultCollection {
+		return fmt.Sprintf("`%s`", c.BucketName())
 	}
-	return fmt.Sprintf("`%s`", c.BucketName())
+	return fmt.Sprintf("`%s`.`%s`.`%s`", c.BucketName(), c.ScopeName(), c.Name())
 }
 
 // IndexMetaBucketID returns the value of bucket_id for the system:indexes table for the collection.
 func (c *Collection) IndexMetaBucketID() string {
-	if c.ScopeName() != DefaultScope && c.Name() != DefaultCollection {
-		return c.BucketName()
+	if c.ScopeName() == DefaultScope && c.Name() == DefaultCollection {
+		return ""
 	}
-	return ""
+	return c.BucketName()
 }
 
 // IndexMetaScopeID returns the value of scope_id for the system:indexes table for the collection.
 func (c *Collection) IndexMetaScopeID() string {
-	if c.ScopeName() != DefaultScope && c.Name() != DefaultCollection {
-		return c.ScopeName()
+	if c.ScopeName() == DefaultScope && c.Name() == DefaultCollection {
+		return ""
 	}
-	return ""
+	return c.ScopeName()
 }
 
 // IndexMetaKeyspaceID returns the value of keyspace_id for the system:indexes table for the collection.
 func (c *Collection) IndexMetaKeyspaceID() string {
-	if c.ScopeName() != DefaultScope && c.Name() != DefaultCollection {
-		return c.Name()
+	if c.ScopeName() == DefaultScope && c.Name() == DefaultCollection {
+		return c.BucketName()
 	}
-	return c.BucketName()
+	return c.Name()
 }
 
 func (c *Collection) Query(statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (resultsIterator sgbucket.QueryResultIterator, err error) {

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -13,6 +13,7 @@ package base
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -23,15 +24,30 @@ import (
 
 var _ N1QLStore = &Collection{}
 
-// Keyspace for a collection is bucket name until wider collection support is added
-func (c *Collection) Keyspace() string {
-	return c.Bucket().Name()
+// EscapedFullyQualifiedKeyspace returns the escaped fully-qualified identifier for the keyspace (e.g. `bucket`.`scope`.`collection`)
+func (c *Collection) EscapedFullyQualifiedKeyspace() string {
+	return fmt.Sprintf("`%s`.`%s`.`%s`", c.BucketName(), c.ScopeName(), c.Name())
+}
+
+// IndexMetaBucketID returns the value of bucket_id for the system:indexes table for the collection.
+func (c *Collection) IndexMetaBucketID() string {
+	return c.BucketName()
+}
+
+// IndexMetaScopeID returns the value of scope_id for the system:indexes table for the collection.
+func (c *Collection) IndexMetaScopeID() string {
+	return c.ScopeName()
+}
+
+// IndexMetaKeyspaceID returns the value of keyspace_id for the system:indexes table for the collection.
+func (c *Collection) IndexMetaKeyspaceID() string {
+	return c.Name()
 }
 
 func (c *Collection) Query(statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (resultsIterator sgbucket.QueryResultIterator, err error) {
 	logCtx := context.TODO()
 
-	bucketStatement := strings.Replace(statement, KeyspaceQueryToken, c.Keyspace(), -1)
+	keyspaceStatement := strings.Replace(statement, KeyspaceQueryToken, c.EscapedFullyQualifiedKeyspace(), -1)
 
 	n1qlOptions := &gocb.QueryOptions{
 		ScanConsistency: gocb.QueryScanConsistency(consistency),
@@ -41,8 +57,8 @@ func (c *Collection) Query(statement string, params map[string]interface{}, cons
 
 	waitTime := 10 * time.Millisecond
 	for i := 1; i <= MaxQueryRetries; i++ {
-		TracefCtx(logCtx, KeyQuery, "Executing N1QL query: %v - %+v", UD(bucketStatement), UD(params))
-		queryResults, queryErr := c.runQuery(bucketStatement, n1qlOptions)
+		TracefCtx(logCtx, KeyQuery, "Executing N1QL query: %v - %+v", UD(keyspaceStatement), UD(params))
+		queryResults, queryErr := c.runQuery(keyspaceStatement, n1qlOptions)
 		if queryErr == nil {
 			resultsIterator := &gocbRawIterator{
 				rawResult:                  queryResults.Raw(),
@@ -58,7 +74,7 @@ func (c *Collection) Query(statement string, params map[string]interface{}, cons
 
 		// Non-retry error - return
 		if !isTransientIndexerError(queryErr) {
-			WarnfCtx(logCtx, "Error when querying index using statement: [%s] parameters: [%+v] error:%v", UD(bucketStatement), UD(params), queryErr)
+			WarnfCtx(logCtx, "Error when querying index using statement: [%s] parameters: [%+v] error:%v", UD(keyspaceStatement), UD(params), queryErr)
 			return resultsIterator, pkgerrors.WithStack(queryErr)
 		}
 
@@ -70,7 +86,7 @@ func (c *Collection) Query(statement string, params map[string]interface{}, cons
 		waitTime = waitTime * 2
 	}
 
-	WarnfCtx(logCtx, "Exceeded max retries for query when querying index using statement: [%s] parameters: [%+v], err:%v", UD(bucketStatement), UD(params), err)
+	WarnfCtx(logCtx, "Exceeded max retries for query when querying index using statement: [%s] parameters: [%+v], err:%v", UD(keyspaceStatement), UD(params), err)
 	return nil, err
 }
 

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -24,9 +24,12 @@ import (
 
 var _ N1QLStore = &Collection{}
 
-// EscapedFullyQualifiedKeyspace returns the escaped fully-qualified identifier for the keyspace (e.g. `bucket`.`scope`.`collection`)
-func (c *Collection) EscapedFullyQualifiedKeyspace() string {
-	return fmt.Sprintf("`%s`.`%s`.`%s`", c.BucketName(), c.ScopeName(), c.Name())
+// EscapedKeyspace returns the escaped fully-qualified identifier for the keyspace (e.g. `bucket`.`scope`.`collection`)
+func (c *Collection) EscapedKeyspace() string {
+	if c.ScopeName() != DefaultScope && c.Name() != DefaultCollection {
+		return fmt.Sprintf("`%s`.`%s`.`%s`", c.BucketName(), c.ScopeName(), c.Name())
+	}
+	return fmt.Sprintf("`%s`", c.BucketName())
 }
 
 // IndexMetaBucketID returns the value of bucket_id for the system:indexes table for the collection.
@@ -56,7 +59,7 @@ func (c *Collection) IndexMetaKeyspaceID() string {
 func (c *Collection) Query(statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (resultsIterator sgbucket.QueryResultIterator, err error) {
 	logCtx := context.TODO()
 
-	keyspaceStatement := strings.Replace(statement, KeyspaceQueryToken, c.EscapedFullyQualifiedKeyspace(), -1)
+	keyspaceStatement := strings.Replace(statement, KeyspaceQueryToken, c.EscapedKeyspace(), -1)
 
 	n1qlOptions := &gocb.QueryOptions{
 		ScanConsistency: gocb.QueryScanConsistency(consistency),

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -485,12 +485,12 @@ func (b *LeakyBucket) IsSupported(feature sgbucket.DataStoreFeature) bool {
 	return b.bucket.IsSupported(feature)
 }
 
-func (b *LeakyBucket) EscapedFullyQualifiedKeyspace() string {
+func (b *LeakyBucket) EscapedKeyspace() string {
 	n1qlStore, ok := AsN1QLStore(b.bucket)
 	if !ok {
 		return ""
 	}
-	return n1qlStore.EscapedFullyQualifiedKeyspace()
+	return n1qlStore.EscapedKeyspace()
 }
 
 func (b *LeakyBucket) IndexMetaKeyspaceID() string {

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -485,12 +485,36 @@ func (b *LeakyBucket) IsSupported(feature sgbucket.DataStoreFeature) bool {
 	return b.bucket.IsSupported(feature)
 }
 
-func (b *LeakyBucket) Keyspace() string {
+func (b *LeakyBucket) EscapedFullyQualifiedKeyspace() string {
 	n1qlStore, ok := AsN1QLStore(b.bucket)
 	if !ok {
 		return ""
 	}
-	return n1qlStore.Keyspace()
+	return n1qlStore.EscapedFullyQualifiedKeyspace()
+}
+
+func (b *LeakyBucket) IndexMetaKeyspaceID() string {
+	n1qlStore, ok := AsN1QLStore(b.bucket)
+	if !ok {
+		return ""
+	}
+	return n1qlStore.IndexMetaKeyspaceID()
+}
+
+func (b *LeakyBucket) IndexMetaScopeID() string {
+	n1qlStore, ok := AsN1QLStore(b.bucket)
+	if !ok {
+		return ""
+	}
+	return n1qlStore.IndexMetaScopeID()
+}
+
+func (b *LeakyBucket) IndexMetaBucketID() string {
+	n1qlStore, ok := AsN1QLStore(b.bucket)
+	if !ok {
+		return ""
+	}
+	return n1qlStore.IndexMetaBucketID()
 }
 
 func (b *LeakyBucket) Query(statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (results sgbucket.QueryResultIterator, err error) {

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -617,6 +617,13 @@ type TBPBucketReadierFunc func(ctx context.Context, b Bucket, tbp *TestBucketPoo
 
 // FlushBucketEmptierFunc ensures the bucket is empty by flushing. It is not recommended to use with GSI.
 var FlushBucketEmptierFunc TBPBucketReadierFunc = func(ctx context.Context, b Bucket, tbp *TestBucketPool) error {
+
+	if c, ok := b.(*Collection); ok {
+		if err := c.dropAllScopesAndCollections(); err != nil {
+			return err
+		}
+	}
+
 	flushableBucket, ok := b.(sgbucket.FlushableStore)
 	if !ok {
 		return errors.New("FlushBucketEmptierFunc used with non-flushable bucket")

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -37,7 +37,7 @@ const (
 // This gets replaced before the statement is sent to N1QL by the replaceSyncTokens methods.
 var syncNoXattr = fmt.Sprintf("%s.%s", base.KeyspaceQueryToken, base.SyncPropertyName)
 var syncXattr = "meta().xattrs." + base.SyncXattrName
-var syncXattrQuery = fmt.Sprintf("meta(%s).xattrs.%s", base.KeyspaceAlias, base.SyncXattrName) // Replacement for $sync token for xattr queries
+var syncXattrQuery = fmt.Sprintf("meta(%s).xattrs.%s", base.KeyspaceQueryAlias, base.SyncXattrName) // Replacement for $sync token for xattr queries
 
 type SGIndexType int
 
@@ -155,7 +155,7 @@ func init() {
 		readinessQuery, ok := readinessQueries[i]
 		if ok {
 			sgIndex.required = true
-			sgIndex.readinessQuery = fmt.Sprintf(readinessQuery, base.KeyspaceQueryToken, base.KeyspaceAlias)
+			sgIndex.readinessQuery = fmt.Sprintf(readinessQuery, base.KeyspaceQueryToken, base.KeyspaceQueryAlias)
 		}
 
 		sgIndexes[i] = sgIndex

--- a/db/query.go
+++ b/db/query.go
@@ -55,7 +55,7 @@ var QueryAccess = SGQuery{
 			"FROM %s AS %s "+
 			"USE INDEX ($idx) "+
 			"WHERE any op in object_pairs($sync.access) satisfies op.name = $userName end;",
-		base.KeyspaceQueryToken, base.KeyspaceAlias),
+		base.KeyspaceQueryToken, base.KeyspaceQueryAlias),
 	adhoc: true,
 }
 
@@ -66,7 +66,7 @@ var QueryRoleAccess = SGQuery{
 			"FROM %s AS %s "+
 			"USE INDEX ($idx) "+
 			"WHERE any op in object_pairs($sync.role_access) satisfies op.name = $userName end;",
-		base.KeyspaceQueryToken, base.KeyspaceAlias),
+		base.KeyspaceQueryToken, base.KeyspaceQueryAlias),
 	adhoc: true,
 }
 
@@ -99,8 +99,8 @@ var QueryChannels = SGQuery{
 			"BETWEEN  [$channelName, $startSeq] AND [$channelName, $endSeq]) "+
 			"%s"+
 			"ORDER BY [op.name, LEAST($sync.sequence, op.val.seq),IFMISSING(op.val.rev,null),IFMISSING(op.val.del,null)]",
-		base.KeyspaceAlias,
-		base.KeyspaceQueryToken, base.KeyspaceAlias,
+		base.KeyspaceQueryAlias,
+		base.KeyspaceQueryToken, base.KeyspaceQueryAlias,
 		activeOnlyFilter),
 	adhoc: false,
 }
@@ -117,8 +117,8 @@ var QueryStarChannel = SGQuery{
 			"WHERE $sync.sequence >= $startSeq AND $sync.sequence < $endSeq "+
 			"AND META().id NOT LIKE '%s' %s"+
 			"ORDER BY $sync.sequence",
-		base.KeyspaceAlias,
-		base.KeyspaceQueryToken, base.KeyspaceAlias,
+		base.KeyspaceQueryAlias,
+		base.KeyspaceQueryToken, base.KeyspaceQueryAlias,
 		SyncDocWildcard, activeOnlyFilter),
 	adhoc: false,
 }
@@ -134,8 +134,8 @@ var QuerySequences = SGQuery{
 			"USE INDEX($idx) "+
 			"WHERE $sync.sequence IN $inSequences "+
 			"AND META().id NOT LIKE '%s'",
-		base.KeyspaceAlias,
-		base.KeyspaceQueryToken, base.KeyspaceAlias,
+		base.KeyspaceQueryAlias,
+		base.KeyspaceQueryToken, base.KeyspaceQueryAlias,
 		SyncDocWildcard),
 	adhoc: false,
 }
@@ -160,13 +160,13 @@ var QueryPrincipals = SGQuery{
 			"OR META(%s).id LIKE '%s') "+
 			"AND META(%s).id >= $%s "+ // Uses >= for inclusive startKey
 			"ORDER BY META(%s).id",
-		base.KeyspaceAlias,
-		base.KeyspaceQueryToken, base.KeyspaceAlias,
-		base.KeyspaceAlias, SyncDocWildcard,
-		base.KeyspaceAlias, `\\_sync:user:%`,
-		base.KeyspaceAlias, `\\_sync:role:%`,
-		base.KeyspaceAlias, QueryParamStartKey,
-		base.KeyspaceAlias),
+		base.KeyspaceQueryAlias,
+		base.KeyspaceQueryToken, base.KeyspaceQueryAlias,
+		base.KeyspaceQueryAlias, SyncDocWildcard,
+		base.KeyspaceQueryAlias, `\\_sync:user:%`,
+		base.KeyspaceQueryAlias, `\\_sync:role:%`,
+		base.KeyspaceQueryAlias, QueryParamStartKey,
+		base.KeyspaceQueryAlias),
 	adhoc: false,
 }
 
@@ -187,13 +187,13 @@ var QueryUsers = SGQuery{
 			"WHERE META(%s).id LIKE '%s' "+
 			"AND META(%s).id >= $%s "+ // Using >= to match QueryPrincipals startKey handling
 			"ORDER BY META(%s).id",
-		base.KeyspaceAlias,
-		base.KeyspaceAlias,
-		base.KeyspaceAlias,
-		base.KeyspaceQueryToken, base.KeyspaceAlias,
-		base.KeyspaceAlias, `\\_sync:user:%`,
-		base.KeyspaceAlias, QueryParamStartKey,
-		base.KeyspaceAlias),
+		base.KeyspaceQueryAlias,
+		base.KeyspaceQueryAlias,
+		base.KeyspaceQueryAlias,
+		base.KeyspaceQueryToken, base.KeyspaceQueryAlias,
+		base.KeyspaceQueryAlias, `\\_sync:user:%`,
+		base.KeyspaceQueryAlias, QueryParamStartKey,
+		base.KeyspaceQueryAlias),
 	adhoc: false,
 }
 
@@ -206,10 +206,10 @@ var QuerySessions = SGQuery{
 			"WHERE META(%s).id LIKE '%s' "+
 			"AND META(%s).id LIKE '%s' "+
 			"AND username = $userName",
-		base.KeyspaceAlias,
-		base.KeyspaceQueryToken, base.KeyspaceAlias,
-		base.KeyspaceAlias, SyncDocWildcard,
-		base.KeyspaceAlias, `\\_sync:session:%`),
+		base.KeyspaceQueryAlias,
+		base.KeyspaceQueryToken, base.KeyspaceQueryAlias,
+		base.KeyspaceQueryAlias, SyncDocWildcard,
+		base.KeyspaceQueryAlias, `\\_sync:session:%`),
 	adhoc: false,
 }
 var QueryTombstones = SGQuery{
@@ -219,8 +219,8 @@ var QueryTombstones = SGQuery{
 			"FROM %s AS %s "+
 			"USE INDEX ($idx) "+
 			"WHERE $sync.tombstoned_at BETWEEN 0 AND $olderThan",
-		base.KeyspaceAlias,
-		base.KeyspaceQueryToken, base.KeyspaceAlias),
+		base.KeyspaceQueryAlias,
+		base.KeyspaceQueryToken, base.KeyspaceQueryAlias),
 	adhoc: false,
 }
 
@@ -243,9 +243,9 @@ var QueryAllDocs = SGQuery{
 			"META(%s).id NOT LIKE '%s' "+
 			"AND $sync IS NOT MISSING "+
 			"AND ($sync.flags IS MISSING OR BITTEST($sync.flags,1) = false)",
-		base.KeyspaceAlias,
-		base.KeyspaceQueryToken, base.KeyspaceAlias,
-		base.KeyspaceAlias, SyncDocWildcard),
+		base.KeyspaceQueryAlias,
+		base.KeyspaceQueryToken, base.KeyspaceQueryAlias,
+		base.KeyspaceQueryAlias, SyncDocWildcard),
 	adhoc: false,
 }
 

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -16,10 +16,11 @@ import (
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestCollectionsPutDocInKeyspace creates a collection and starts up a RestTester instance on it.
-// Ensures that various keyspaces can be used to insert a doc in the collection.
+// Ensures that various keyspaces can or can't be used to insert a doc in the collection.
 func TestCollectionsPutDocInKeyspace(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Walrus does not support scopes and collections")
@@ -104,4 +105,126 @@ func TestCollectionsPutDocInKeyspace(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCollectionsDCP(t *testing.T) {
+	t.Skip("Collections-aware DCP not implemented yet")
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Walrus does not support scopes and collections")
+	}
+
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		createScopesAndCollections: true,
+		TestBucket:                 tb.NoCloseClone(), // Clone so scope/collection isn't set on tb from rt
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				Scopes: ScopesConfig{
+					"foo": ScopeConfig{
+						Collections: map[string]CollectionConfig{
+							"bar": {},
+						},
+					},
+				},
+			},
+		},
+	})
+	defer rt.Close()
+
+	const docID = "doc1"
+
+	ok, err := tb.AddRaw(docID, 0, []byte(`{"test":true}`))
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// ensure the doc is picked up by the import DCP feed and actually gets imported
+	err = rt.WaitForCondition(func() bool {
+		return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value() == 1
+	})
+	require.NoError(t, err)
+
+	// ensure the doc comes back over the caching feed after import
+	assert.NoError(t, rt.WaitForDoc(docID))
+}
+
+func TestCollectionsQuery(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Walrus does not support scopes and collections")
+	}
+
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		createScopesAndCollections: true,
+		TestBucket:                 tb.NoCloseClone(), // Clone so scope/collection isn't set on tb from rt
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				Scopes: ScopesConfig{
+					"foo": ScopeConfig{
+						Collections: map[string]CollectionConfig{
+							"bar": {},
+						},
+					},
+				},
+			},
+		},
+	})
+	defer rt.Close()
+
+	const (
+		scope      = "foo"
+		collection = "bar"
+		keyspace   = "db." + scope + "." + collection
+		docID      = "doc1"
+	)
+
+	resp := rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/%s", keyspace, docID), `{"test":true}`)
+	requireStatus(t, resp, http.StatusCreated)
+
+	// use the rt.Bucket which has got the foo.bar scope/collection set up
+	n1qlStore, ok := base.AsN1QLStore(rt.Bucket())
+	require.True(t, ok)
+
+	idxName := t.Name() + "_primary"
+	require.NoError(t, n1qlStore.CreatePrimaryIndex(idxName, nil))
+	require.NoError(t, n1qlStore.WaitForIndexOnline(idxName))
+
+	res, err := n1qlStore.Query("SELECT keyspace_id, bucket_id, scope_id from system:indexes WHERE name = $idxName",
+		map[string]interface{}{"idxName": idxName}, base.RequestPlus, true)
+	require.NoError(t, err)
+
+	var indexMetaResult struct {
+		BucketID   *string `json:"bucket_id"`
+		ScopeID    *string `json:"scope_id"`
+		KeyspaceID *string `json:"keyspace_id"`
+	}
+	require.NoError(t, res.One(&indexMetaResult))
+	require.NotNil(t, indexMetaResult)
+
+	// if the index was created on the _default collection in the bucket, keyspace_id is the bucket name, and the other fields are not present.
+	assert.NotNilf(t, indexMetaResult.BucketID, "bucket_id was not present - index was created on the _default collection!")
+	assert.NotNilf(t, indexMetaResult.ScopeID, "scope_id was not present - index was created on the _default collection!")
+	require.NotNilf(t, indexMetaResult.KeyspaceID, "keyspace_id should be present")
+	assert.NotEqualf(t, tb.Bucket.GetName(), *indexMetaResult.KeyspaceID, "keyspace_id was the bucket name - index was created on the _default collection!")
+
+	// if the index was created on a collection, the keyspace_id becomes the collection, along with additional fields for bucket and scope.
+	assert.Equal(t, tb.Bucket.GetName(), *indexMetaResult.BucketID)
+	assert.Equal(t, scope, *indexMetaResult.ScopeID)
+	assert.Equal(t, collection, *indexMetaResult.KeyspaceID)
+
+	// try and query the document that we wrote via SG
+	res, err = n1qlStore.Query("SELECT test FROM "+base.KeyspaceQueryToken+" WHERE test = true", nil, base.RequestPlus, true)
+	require.NoError(t, err)
+
+	var primaryQueryResult struct {
+		Test *bool `json:"test"`
+	}
+	require.NoError(t, res.One(&primaryQueryResult))
+	require.NotNil(t, primaryQueryResult)
+
+	assert.True(t, *primaryQueryResult.Test)
 }


### PR DESCRIPTION
CBG-2158

Add collection support to SG's index/query code
- All queries now specify an alias for use in `META()`
  - e.g. `FROM $_keyspace AS queryKeyspaceAlias` 
  - Avoids: `Ambiguous reference to field 'b1'` in queries using `META($_keyspace)` (where $_keyspace ~= `b1`.`sc`.`col`)
- Also drop collections in bucket readier when flushing - Flush does not remove collections...
- Adds (skipped/failing) test for collections DCP support
- Adds test for collections bucket API query support
  - End-to-end SG query test somewhat dependent on DCP support

## Dependencies
- [x] #5622 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `gsi=true` ran locally - no _new_ failures

