### PR TITLE
Fix scope/collections cleanup in test teardown

### DIFF
--- a/base/collection.go
+++ b/base/collection.go
@@ -657,6 +657,40 @@ func (c *Collection) isRecoverableWriteError(err error) bool {
 	return false
 }
 
+// dropAllScopesAndCollections attempts to drop *all* non-_default scopes and collections from the bucket associated with the collection.  Intended for test usage only.
+func (c *Collection) dropAllScopesAndCollections() error {
+	cm := c.Bucket().Collections()
+	scopes, err := cm.GetAllScopes(nil)
+	if err != nil {
+		WarnfCtx(context.TODO(), "Error getting scopes on bucket %s: %v  Will retry.", MD(c.Bucket().Name()).Redact(), err)
+		return err
+	}
+
+	// For each non-default scope, drop them.
+	// For each collection within the default scope, drop them.
+	for _, scope := range scopes {
+		if scope.Name != DefaultScope {
+			if err := cm.DropScope(scope.Name, nil); err != nil {
+				WarnfCtx(context.TODO(), "Error dropping scope %s on bucket %s: %v  Will retry.", MD(scope).Redact(), MD(c.Bucket().Name()).Redact(), err)
+				return err
+			}
+			continue
+		}
+
+		// can't delete _default scope - but we can delete the non-_default collections within it
+		for _, collection := range scope.Collections {
+			if collection.Name != DefaultCollection {
+				if err := cm.DropCollection(collection, nil); err != nil {
+					WarnfCtx(context.TODO(), "Error dropping collection %s in scope %s on bucket %s: %v  Will retry.", MD(collection.Name).Redact(), MD(scope).Redact(), MD(c.Bucket().Name()).Redact(), err)
+					return err
+				}
+			}
+		}
+
+	}
+	return nil
+}
+
 // This flushes the *entire* bucket associated with the collection (not just the collection).  Intended for test usage only.
 func (c *Collection) Flush() error {
 

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -617,6 +617,13 @@ type TBPBucketReadierFunc func(ctx context.Context, b Bucket, tbp *TestBucketPoo
 
 // FlushBucketEmptierFunc ensures the bucket is empty by flushing. It is not recommended to use with GSI.
 var FlushBucketEmptierFunc TBPBucketReadierFunc = func(ctx context.Context, b Bucket, tbp *TestBucketPool) error {
+
+	if c, ok := b.(*Collection); ok {
+		if err := c.dropAllScopesAndCollections(); err != nil {
+			return err
+		}
+	}
+
 	flushableBucket, ok := b.(sgbucket.FlushableStore)
 	if !ok {
 		return errors.New("FlushBucketEmptierFunc used with non-flushable bucket")


### PR DESCRIPTION
When flushing a bucket, the scopes and collections are not dropped within it.

This causes issues related to 'scope already exists'-type errors when test teardown only flushes a bucket, and keeps scopes and collections around (despite the documents being removed from them)

This becomes an issue as soon as we have >1 tests using scopes and collections, so will unblock:
- #5620
- #5618