### PR TITLE
CBG-2159: Add collections test to ensure SG indexes are built and queryable

### DIFF
--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -150,7 +150,9 @@ func TestCollectionsDCP(t *testing.T) {
 	assert.NoError(t, rt.WaitForDoc(docID))
 }
 
-func TestCollectionsQuery(t *testing.T) {
+// TestCollectionsBasicIndexQuery ensures that the bucket API is able to create an index on a collection
+// and query documents written to the collection.
+func TestCollectionsBasicIndexQuery(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Walrus does not support scopes and collections")
 	}
@@ -227,4 +229,85 @@ func TestCollectionsQuery(t *testing.T) {
 	require.NotNil(t, primaryQueryResult)
 
 	assert.True(t, *primaryQueryResult.Test)
+}
+
+// TestCollectionsSGIndexQuery is more of an end-to-end test to ensure SG indexes are built correctly,
+// and the channel access query is able to run when pulling a document as a user, and backfill the channel cache.
+func TestCollectionsSGIndexQuery(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Walrus does not support scopes and collections")
+	}
+
+	base.SetUpTestLogging(t, base.LevelTrace, base.KeyHTTP, base.KeyQuery, base.KeyCRUD)
+
+	// force GSI for this one test
+	useViews := base.BoolPtr(false)
+
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+
+	const (
+		username       = "alice"
+		password       = "letmein"
+		validChannel   = "valid"
+		invalidChannel = "invalid"
+
+		scope      = "foo"
+		collection = "bar"
+		keyspace   = "db." + scope + "." + collection
+
+		validDocID   = "doc1"
+		invalidDocID = "doc2"
+	)
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		createScopesAndCollections: true,
+		TestBucket:                 tb.NoCloseClone(), // Clone so scope/collection isn't set on tb from rt
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				UseViews: useViews,
+				Users: map[string]*auth.PrincipalConfig{
+					username: {
+						ExplicitChannels: base.SetOf(validChannel),
+						Password:         base.StringPtr(password),
+					},
+				},
+				Scopes: ScopesConfig{
+					scope: ScopeConfig{
+						Collections: map[string]CollectionConfig{
+							collection: {},
+						},
+					},
+				},
+			},
+		},
+	})
+	defer rt.Close()
+
+	resp := rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/%s", keyspace, validDocID), `{"test": true, "channels": ["`+validChannel+`"]}`)
+	requireStatus(t, resp, http.StatusCreated)
+	resp = rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/%s", keyspace, invalidDocID), `{"test": true, "channels": ["`+invalidChannel+`"]}`)
+	requireStatus(t, resp, http.StatusCreated)
+
+	resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/_all_docs", ``, nil, username, password)
+	requireStatus(t, resp, http.StatusOK)
+	var allDocsResponse struct {
+		TotalRows int `json:"total_rows"`
+		Rows      []struct {
+			ID string `json:"id"`
+		} `json:"rows"`
+	}
+	require.NoError(t, base.JSONDecoder(resp.Body).Decode(&allDocsResponse))
+	assert.Equal(t, 1, allDocsResponse.TotalRows)
+	require.Len(t, allDocsResponse.Rows, 1)
+	assert.Equal(t, validDocID, allDocsResponse.Rows[0].ID)
+
+	resp = rt.SendUserRequestWithHeaders(http.MethodGet, fmt.Sprintf("/%s/%s", keyspace, validDocID), ``, nil, username, password)
+	requireStatus(t, resp, http.StatusOK)
+	resp = rt.SendUserRequestWithHeaders(http.MethodGet, fmt.Sprintf("/%s/%s", keyspace, invalidDocID), ``, nil, username, password)
+	requireStatus(t, resp, http.StatusForbidden)
+
+	// TODO: This will fail until the caching DCP feed is working on the collection, as the changes feed falls into a deferred backfill.
+	// _, err := rt.waitForChanges(1, "/db/_changes", username, false)
+	// assert.NoError(t, err)
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -196,8 +196,8 @@ func (rt *RestTester) Bucket() base.Bucket {
 			rt.DatabaseConfig = &DatabaseConfig{}
 		}
 
-		if base.TestsDisableGSI() {
-			rt.DatabaseConfig.UseViews = base.BoolPtr(true)
+		if rt.DatabaseConfig.UseViews == nil {
+			rt.DatabaseConfig.UseViews = base.BoolPtr(base.TestsDisableGSI())
 		}
 
 		if rt.createScopesAndCollections {


### PR DESCRIPTION
Adds a test to ensure SG indexes are built and queryable by issuing all_docs as a user.

The commented changes feed backfill at the bottom of the test is not working due to the DCP feed not working yet.

## Dependencies
- [x] #5622 
- [x] #5618 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `gsi=true ^TestCollections...` https://jenkins.sgwdev.com/job/SyncGateway-Integration/399/
