### PR TITLE
CBG-2198: TestPullOneshotReplicationAPI fix: Wait for pending changes before starting the one-shot replication

### DIFF
--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -900,6 +900,8 @@ func TestPullOneshotReplicationAPI(t *testing.T) {
 		docIDs[i] = docID
 	}
 
+	require.NoError(t, remoteRT.WaitForPendingChanges())
+
 	// Create oneshot replication, verify running
 	replicationID := t.Name()
 	activeRT.createReplication(replicationID, remoteURLString, db.ActiveReplicatorTypePull, nil, false, db.ConflictResolverDefault)


### PR DESCRIPTION
CBG-2198

This test doesn't wait for all writes to be cached before running a one-shot replication.
This means if >0 write wasn't cached and the replicator starts quick enough, it can miss documents.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `TestPullOneshotReplicationAPI` https://jenkins.sgwdev.com/job/SyncGateway-Integration/392/
