### PR TITLE
CBG-2143: Added unsupported option to force forbidden errors from REST API

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -887,7 +887,6 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 		if err != nil {
 			return nil, nil, false, nil, err
 		}
-		newRev := CreateRevIDWithBytes(generation, matchRev, canonicalBytesForRevID)
 
 		// We needed to keep _deleted around in the body until we generated a rev ID, but now we can ditch it.
 		_, isDeleted := body[BodyDeleted]
@@ -929,6 +928,8 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 		if err != nil {
 			return nil, nil, false, nil, err
 		}
+
+		newRev := CreateRevIDWithBytes(generation, matchRev, canonicalBytesForRevID)
 
 		if err := doc.History.addRevision(newDoc.ID, RevInfo{ID: newRev, Parent: matchRev, Deleted: deleted}); err != nil {
 			base.InfofCtx(db.Ctx, base.KeyCRUD, "Failed to add revision ID: %s, for doc: %s, error: %v", newRev, base.UD(docid), err)

--- a/db/crud.go
+++ b/db/crud.go
@@ -291,11 +291,11 @@ func (db *Database) getRev(docid, revid string, maxHistory int, historyFrom []st
 
 	isAuthorized, redactedRev := db.authorizeUserForChannels(docid, revision.RevID, revision.Channels, revision.Deleted, requestedHistory)
 	if !isAuthorized {
-		if db.ForceAPIForbiddenErrors() {
-			base.InfofCtx(db.Ctx, base.KeyCRUD, "Not authorized to view doc: %s %s", base.UD(docid), base.MD(revid))
+		if revid == "" {
 			return DocumentRevision{}, ErrForbidden
 		}
-		if revid == "" {
+		if db.ForceAPIForbiddenErrors() {
+			base.InfofCtx(db.Ctx, base.KeyCRUD, "Not authorized to view doc: %s %s", base.UD(docid), base.MD(revid))
 			return DocumentRevision{}, ErrForbidden
 		}
 		return redactedRev, nil

--- a/db/database.go
+++ b/db/database.go
@@ -198,6 +198,7 @@ type UnsupportedOptions struct {
 	SgrTlsSkipVerify          bool                     `json:"sgr_tls_skip_verify,omitempty"`           // Config option to enable self-signed certs for SG-Replicate testing.
 	RemoteConfigTlsSkipVerify bool                     `json:"remote_config_tls_skip_verify,omitempty"` // Config option to enable self signed certificates for external JavaScript load.
 	GuestReadOnly             bool                     `json:"guest_read_only,omitempty"`               // Config option to restrict GUEST document access to read-only
+	ForceAPIForbiddenErrors   bool                     `json:"force_api_forbidden_errors,omitempty"`    // Config option to force the REST API to return forbidden errors
 }
 
 type WarningThresholds struct {
@@ -1715,5 +1716,8 @@ func (context *DatabaseContext) LastSequence() (uint64, error) {
 // Helpers for unsupported options
 func (context *DatabaseContext) IsGuestReadOnly() bool {
 	return context.Options.UnsupportedOptions != nil && context.Options.UnsupportedOptions.GuestReadOnly
+}
 
+func (context *DatabaseContext) ForceAPIForbiddenErrors() bool {
+	return context.Options.UnsupportedOptions != nil && context.Options.UnsupportedOptions.ForceAPIForbiddenErrors
 }

--- a/db/revision.go
+++ b/db/revision.go
@@ -231,7 +231,7 @@ func (db *DatabaseContext) getOldRevisionJSON(ctx context.Context, docid string,
 	data, _, err := db.Bucket.GetRaw(oldRevisionKey(docid, revid))
 	if base.IsDocNotFoundError(err) {
 		base.DebugfCtx(ctx, base.KeyCRUD, "No old revision %q / %q", base.UD(docid), revid)
-		err = base.HTTPErrorf(404, "missing")
+		err = ErrMissing
 	}
 	if data != nil {
 		// Strip out the non-JSON prefix

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -36,7 +36,7 @@ func (t *testBackingStore) GetDocument(ctx context.Context, docid string, unmars
 
 	for _, d := range t.notFoundDocIDs {
 		if docid == d {
-			return nil, base.HTTPErrorf(404, "missing")
+			return nil, ErrMissing
 		}
 	}
 

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1302,6 +1302,9 @@ Database:
         guest_read_only:
           description: Restrict GUEST document access to read-only.
           type: boolean
+        force_api_forbidden_errors:
+          description: Force REST API errors to return forbidden
+          type: boolean
     local_jwt:
       description: Configuration for Local JWT authentication.
       type: object

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -9456,179 +9456,200 @@ func TestAttachmentDeleteOnExpiry(t *testing.T) {
 
 }
 
-// CBG-2143: Make sure the REST API is returning forbidden errors if unsupported config option is set
+// CBG-2143: Make sure the REST API is returning forbidden errors if when unsupported config option is set
 func TestForceAPIForbiddenErrors(t *testing.T) {
-	const expectedErrorReason = "forbidden"
-	rt := NewRestTester(t, &RestTesterConfig{
-		SyncFn: `
-		function(doc, oldDoc) {
-			if (!doc.doNotSync) {
-				access("NoPerms", "chan2");
-				access("Perms", "chan2");
-				requireAccess("chan");
-				channel(doc.channels);
-			}
-		}`,
-		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Unsupported: &db.UnsupportedOptions{
-				ForceAPIForbiddenErrors: true,
-			},
-			Guest: &auth.PrincipalConfig{
-				Disabled: base.BoolPtr(false),
-			},
-			Users: map[string]*auth.PrincipalConfig{
-				"NoPerms": {
-					Password: base.StringPtr("password"),
-				},
-				"Perms": {
-					ExplicitChannels: base.SetOf("chan"),
-					Password:         base.StringPtr("password"),
-				},
-			},
-		}},
-	})
-	defer rt.Close()
-
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
-
-	// Create the initial document
-	resp := rt.SendAdminRequest(http.MethodPut, "/db/doc", `{"doNotSync": true, "foo": "bar", "channels": "chan", "_attachment":{"attach": {"data": "`+base64.StdEncoding.EncodeToString([]byte("attachmentA"))+`"}}}`)
-	requireStatus(t, resp, http.StatusCreated)
-	rev := respRevID(t, resp)
-
-	// GET requests
-	// User has no permissions to access document
-	resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/doc", "", nil, "NoPerms", "password")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
-
-	// Guest has no permissions to access document
-	resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/doc", "", nil, "", "")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
-
-	// User has no permissions to access rev
-	resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/doc?rev="+rev, "", nil, "NoPerms", "password")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
-
-	// Guest has no permissions to access rev
-	resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/doc?rev="+rev, "", nil, "", "")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
-
-	// Attachments should be forbidden as well
-	resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/doc/attach", "", nil, "NoPerms", "password")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
-
-	// Attachment revs should be forbidden as well
-	resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/doc/attach?rev="+rev, "", nil, "NoPerms", "password")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
-
-	// Attachments should be forbidden for guests as well
-	resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/doc/attach", "", nil, "", "")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
-
-	// Attachment revs should be forbidden for guests as well
-	resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/doc/attach?rev="+rev, "", nil, "", "")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
-
-	// Document does not exist should cause 403
-	resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/notfound", "", nil, "NoPerms", "password")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
-
-	// Document does not exist for guest should cause 403
-	resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/notfound", "", nil, "", "")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
-
-	// PUT requests
-	// PUT doc with user with no write perms
-	resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/db/doc", `{}`, nil, "NoPerms", "password")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
-
-	// PUT with rev
-	resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/db/doc?rev="+rev, `{}`, nil, "NoPerms", "password")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
-
-	// PUT with incorrect rev
-	resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/db/doc?rev=1-abc", `{}`, nil, "NoPerms", "password")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
-
-	// PUT request as Guest
-	resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/db/doc", `{}`, nil, "", "")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
-
-	// PUT with rev as Guest
-	resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/db/doc?rev="+rev, `{}`, nil, "", "")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
-
-	// PUT with incorrect rev as Guest
-	resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/db/doc?rev=1-abc", `{}`, nil, "", "")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
-
-	// PUT with access but no rev
-	resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/db/doc", `{}`, nil, "Perms", "password")
-	assertHTTPErrorReason(t, resp, http.StatusConflict, "Document exists")
-
-	// PUT with access but wrong rev
-	resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/db/doc?rev=1-abc", `{}`, nil, "Perms", "password")
-	assertHTTPErrorReason(t, resp, http.StatusConflict, "Document revision conflict")
-
-	// Confirm no access grants where granted
-	resp = rt.SendAdminRequest(http.MethodGet, "/db/_user/NoPerms", ``)
-	requireStatus(t, resp, http.StatusOK)
-	var allChannels struct {
-		Channels []string `json:"all_channels"`
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeyHTTP)
+	testCases := []struct {
+		forceForbiddenErrors bool
+	}{
+		{
+			forceForbiddenErrors: true,
+		},
+		{
+			forceForbiddenErrors: false,
+		},
 	}
-	err := json.Unmarshal(resp.BodyBytes(), &allChannels)
-	require.NoError(t, err)
-	assert.NotContains(t, allChannels.Channels, "chan2")
+	for _, test := range testCases {
+		t.Run(fmt.Sprintf("Forbidden errors %v", test.forceForbiddenErrors), func(t *testing.T) {
+			// assertRespStatus changes behaviour depending on if forcing forbidden errors
+			assertRespStatus := func(resp *TestResponse, statusIfForbiddenErrorsFalse int) {
+				if test.forceForbiddenErrors {
+					assertHTTPErrorReason(t, resp, http.StatusForbidden, "forbidden")
+					return
+				}
+				assertStatus(t, resp, statusIfForbiddenErrorsFalse)
+			}
 
-	resp = rt.SendAdminRequest(http.MethodGet, "/db/_user/Perms", ``)
-	requireStatus(t, resp, http.StatusOK)
-	err = json.Unmarshal(resp.BodyBytes(), &allChannels)
-	require.NoError(t, err)
-	assert.NotContains(t, allChannels.Channels, "chan2")
+			rt := NewRestTester(t, &RestTesterConfig{
+				SyncFn: `
+				function(doc, oldDoc) {
+					if (!doc.doNotSync) {
+						access("NoPerms", "chan2");
+						access("Perms", "chan2");
+						requireAccess("chan");
+						channel(doc.channels);
+					}
+				}`,
+				DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+					Unsupported: &db.UnsupportedOptions{
+						ForceAPIForbiddenErrors: test.forceForbiddenErrors,
+					},
+					Guest: &auth.PrincipalConfig{
+						Disabled: base.BoolPtr(false),
+					},
+					Users: map[string]*auth.PrincipalConfig{
+						"NoPerms": {
+							Password: base.StringPtr("password"),
+						},
+						"Perms": {
+							ExplicitChannels: base.SetOf("chan"),
+							Password:         base.StringPtr("password"),
+						},
+					},
+				}},
+			})
+			defer rt.Close()
 
-	// Successful PUT which will grant access grants
-	resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/db/doc?rev="+rev, `{"channels": "chan"}`, nil, "Perms", "password")
-	assertStatus(t, resp, http.StatusCreated)
+			// Create the initial document
+			resp := rt.SendAdminRequest(http.MethodPut, "/db/doc", `{"doNotSync": true, "foo": "bar", "channels": "chan", "_attachment":{"attach": {"data": "`+base64.StdEncoding.EncodeToString([]byte("attachmentA"))+`"}}}`)
+			requireStatus(t, resp, http.StatusCreated)
+			rev := respRevID(t, resp)
 
-	// Make sure channel access grant was successful
-	resp = rt.SendAdminRequest(http.MethodGet, "/db/_user/Perms", ``)
-	requireStatus(t, resp, http.StatusOK)
-	err = json.Unmarshal(resp.BodyBytes(), &allChannels)
-	require.NoError(t, err)
-	assert.Contains(t, allChannels.Channels, "chan2")
+			// GET requests
+			// User has no permissions to access document
+			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/doc", "", nil, "NoPerms", "password")
+			assertRespStatus(resp, http.StatusForbidden)
 
-	// DELETE requests
-	// Attempt to delete document with no permissions
-	resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/db/doc", "", nil, "NoPerms", "password")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
+			// Guest has no permissions to access document
+			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/doc", "", nil, "", "")
+			assertRespStatus(resp, http.StatusForbidden)
 
-	// Attempt to delete document rev with no permissions
-	resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/db/doc?rev="+rev, "", nil, "NoPerms", "password")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
+			// User has no permissions to access rev
+			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/doc?rev="+rev, "", nil, "NoPerms", "password")
+			assertRespStatus(resp, http.StatusOK)
 
-	// Attempt to delete document with wrong rev
-	resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/db/doc?rev=1-abc", "", nil, "NoPerms", "password")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
+			// Guest has no permissions to access rev
+			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/doc?rev="+rev, "", nil, "", "")
+			assertRespStatus(resp, http.StatusOK)
 
-	// Attempt to delete document document that does not exist
-	resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/db/notfound", "", nil, "NoPerms", "password")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
+			// Attachments should be forbidden as well
+			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/doc/attach", "", nil, "NoPerms", "password")
+			assertRespStatus(resp, http.StatusForbidden)
 
-	// Attempt to delete document with no permissions as guest
-	resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/db/doc", "", nil, "", "")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
+			// Attachment revs should be forbidden as well
+			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/doc/attach?rev="+rev, "", nil, "NoPerms", "password")
+			assertRespStatus(resp, http.StatusNotFound)
 
-	// Attempt to delete document rev with no write perms as guest
-	resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/db/doc?rev="+rev, "", nil, "", "")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
+			// Attachments should be forbidden for guests as well
+			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/doc/attach", "", nil, "", "")
+			assertRespStatus(resp, http.StatusForbidden)
 
-	// Attempt to delete document with wrong rev as guest
-	resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/db/doc?rev=1-abc", "", nil, "", "")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
+			// Attachment revs should be forbidden for guests as well
+			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/doc/attach?rev="+rev, "", nil, "", "")
+			assertRespStatus(resp, http.StatusNotFound)
 
-	// Attempt to delete document that does not exist as guest
-	resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/db/notfound", "", nil, "", "")
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, expectedErrorReason)
+			// Document does not exist should cause 403
+			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/notfound", "", nil, "NoPerms", "password")
+			assertRespStatus(resp, http.StatusNotFound)
+
+			// Document does not exist for guest should cause 403
+			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/notfound", "", nil, "", "")
+			assertRespStatus(resp, http.StatusNotFound)
+
+			// PUT requests
+			// PUT doc with user with no write perms
+			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/db/doc", `{}`, nil, "NoPerms", "password")
+			assertRespStatus(resp, http.StatusConflict)
+
+			// PUT with rev
+			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/db/doc?rev="+rev, `{}`, nil, "NoPerms", "password")
+			assertRespStatus(resp, http.StatusForbidden)
+
+			// PUT with incorrect rev
+			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/db/doc?rev=1-abc", `{}`, nil, "NoPerms", "password")
+			assertRespStatus(resp, http.StatusConflict)
+
+			// PUT request as Guest
+			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/db/doc", `{}`, nil, "", "")
+			assertRespStatus(resp, http.StatusConflict)
+
+			// PUT with rev as Guest
+			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/db/doc?rev="+rev, `{}`, nil, "", "")
+			assertRespStatus(resp, http.StatusForbidden)
+
+			// PUT with incorrect rev as Guest
+			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/db/doc?rev=1-abc", `{}`, nil, "", "")
+			assertRespStatus(resp, http.StatusConflict)
+
+			// PUT with access but no rev
+			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/db/doc", `{}`, nil, "Perms", "password")
+			assertHTTPErrorReason(t, resp, http.StatusConflict, "Document exists")
+
+			// PUT with access but wrong rev
+			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/db/doc?rev=1-abc", `{}`, nil, "Perms", "password")
+			assertHTTPErrorReason(t, resp, http.StatusConflict, "Document revision conflict")
+
+			// Confirm no access grants where granted
+			resp = rt.SendAdminRequest(http.MethodGet, "/db/_user/NoPerms", ``)
+			requireStatus(t, resp, http.StatusOK)
+			var allChannels struct {
+				Channels []string `json:"all_channels"`
+			}
+			err := json.Unmarshal(resp.BodyBytes(), &allChannels)
+			require.NoError(t, err)
+			assert.NotContains(t, allChannels.Channels, "chan2")
+
+			resp = rt.SendAdminRequest(http.MethodGet, "/db/_user/Perms", ``)
+			requireStatus(t, resp, http.StatusOK)
+			err = json.Unmarshal(resp.BodyBytes(), &allChannels)
+			require.NoError(t, err)
+			assert.NotContains(t, allChannels.Channels, "chan2")
+
+			// Successful PUT which will grant access grants
+			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/db/doc?rev="+rev, `{"channels": "chan"}`, nil, "Perms", "password")
+			assertStatus(t, resp, http.StatusCreated)
+
+			// Make sure channel access grant was successful
+			resp = rt.SendAdminRequest(http.MethodGet, "/db/_user/Perms", ``)
+			requireStatus(t, resp, http.StatusOK)
+			err = json.Unmarshal(resp.BodyBytes(), &allChannels)
+			require.NoError(t, err)
+			assert.Contains(t, allChannels.Channels, "chan2")
+
+			// DELETE requests
+			// Attempt to delete document with no permissions
+			resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/db/doc", "", nil, "NoPerms", "password")
+			assertRespStatus(resp, http.StatusConflict)
+
+			// Attempt to delete document rev with no permissions
+			resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/db/doc?rev="+rev, "", nil, "NoPerms", "password")
+			assertRespStatus(resp, http.StatusConflict)
+
+			// Attempt to delete document with wrong rev
+			resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/db/doc?rev=1-abc", "", nil, "NoPerms", "password")
+			assertRespStatus(resp, http.StatusConflict)
+
+			// Attempt to delete document document that does not exist
+			resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/db/notfound", "", nil, "NoPerms", "password")
+			assertRespStatus(resp, http.StatusForbidden)
+
+			// Attempt to delete document with no permissions as guest
+			resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/db/doc", "", nil, "", "")
+			assertRespStatus(resp, http.StatusConflict)
+
+			// Attempt to delete document rev with no write perms as guest
+			resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/db/doc?rev="+rev, "", nil, "", "")
+			assertRespStatus(resp, http.StatusConflict)
+
+			// Attempt to delete document with wrong rev as guest
+			resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/db/doc?rev=1-abc", "", nil, "", "")
+			assertRespStatus(resp, http.StatusConflict)
+
+			// Attempt to delete document that does not exist as guest
+			resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/db/notfound", "", nil, "", "")
+			assertRespStatus(resp, http.StatusForbidden)
+		})
+	}
 }
 
 func createDocWithLegacyAttachment(t *testing.T, rt *RestTester, docID string, rawDoc []byte, attKey string, attBody []byte) {

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -73,9 +73,17 @@ func (h *handler) handleGetDoc() error {
 				base.DebugfCtx(h.ctx(), base.KeyImport, fmt.Sprintf("Import cancelled as document %v is purged", base.UD(docid)))
 				return nil
 			}
+			if h.db.ForceAPIForbiddenErrors() && base.IsDocNotFoundError(err) {
+				base.InfofCtx(h.ctx(), base.KeyCRUD, "Doc %q not found: %v", base.UD(docid), err)
+				return db.ErrForbidden
+			}
 			return err
 		}
 		if value == nil {
+			if h.db.ForceAPIForbiddenErrors() {
+				base.InfofCtx(h.ctx(), base.KeyCRUD, "Doc %q missing", base.UD(docid))
+				return db.ErrForbidden
+			}
 			return kNotFoundError
 		}
 		h.setHeader("Etag", strconv.Quote(value[db.BodyRev].(string)))


### PR DESCRIPTION
CBG-2143

* Refactored HTTP error responses to be in same place
* Added unsupported DB config option to force forbidden errors via REST API
* Added prepareSyncFn function to output all the variables needed to put in to runSyncFn.
* Added additional logging for API Errors

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/483
- [x] `xattrs=true test=TestForceAPIForbiddenErrors` https://jenkins.sgwdev.com/job/SyncGateway-Integration/512
