### PR TITLE
CBG-2199: Make emptyAllDocsIndex operate directly on a n1qlStore instead of opening a DatabaseContext

### DIFF
--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -173,66 +173,55 @@ func WaitForUserWaiterChange(userWaiter *ChangeWaiter) bool {
 	return isChanged
 }
 
-// emptyAllDocsIndex ensures the AllDocs index for the given bucket is empty. Works similarly to db.Compact, except on a different index.
+// emptyAllDocsIndex ensures the AllDocs index for the given bucket is empty. Works similarly to db.Compact, except on a different index and without a DatabaseContext
 func emptyAllDocsIndex(ctx context.Context, b base.Bucket, tbp *base.TestBucketPool) (numCompacted int, err error) {
 	purgedDocCount := 0
 	purgeBody := Body{"_purged": true}
 
-	dbCtx, err := NewDatabaseContext(b.GetName(), base.NoCloseClone(b), false, DatabaseContextOptions{
-		UseViews:                 base.TestsDisableGSI(),
-		EnableXattr:              base.TestUseXattrs(),
-		skipRegisterImportPIndex: true,
-	})
-	if err != nil {
-		return 0, err
-	}
-	defer dbCtx.Close()
-
-	database, err := GetDatabase(dbCtx, nil)
-	if err != nil {
-		return 0, err
+	n1qlStore, ok := base.AsN1QLStore(b)
+	if !ok {
+		return 0, fmt.Errorf("bucket was not a n1ql store")
 	}
 
 	// A stripped down version of db.Compact() that works on AllDocs instead of tombstones
-	for {
-		results, err := database.QueryChannels(ctx, "*", 0, 0, 0, false)
-		if err != nil {
-			return 0, err
-		}
-		var tombstonesRow QueryIdRow
-		var resultCount int
-		for results.Next(&tombstonesRow) {
-			resultCount++
-			tbp.Logf(ctx, "compactTestBucket deleting %q", tombstonesRow.Id)
-			// First, attempt to purge.
-			purgeErr := database.Purge(tombstonesRow.Id)
-			if purgeErr == nil {
-			} else if base.IsKeyNotFoundError(b, purgeErr) {
-				// If key no longer exists, need to add and remove to trigger removal from view
-				_, addErr := b.Add(tombstonesRow.Id, 0, purgeBody)
-				if addErr != nil {
-					tbp.Logf(ctx, "Error compacting key %s (add) - will not be compacted.  %v", tombstonesRow.Id, addErr)
-					continue
-				}
+	statement := `SELECT META(ks).id AS id
+FROM ` + base.KeyspaceQueryToken + ` AS ks USE INDEX (sg_allDocs_x1)
+WHERE META(ks).xattrs._sync.sequence >= 0
+    AND META(ks).xattrs._sync.sequence < 9223372036854775807
+    AND META(ks).id NOT LIKE '\\_sync:%'`
+	results, err := n1qlStore.Query(statement, nil, base.RequestPlus, true)
+	if err != nil {
+		return 0, err
+	}
 
-				if delErr := b.Delete(tombstonesRow.Id); delErr != nil {
-					tbp.Logf(ctx, "Error compacting key %s (delete) - will not be compacted.  %v", tombstonesRow.Id, delErr)
-				}
-				purgedDocCount++
-			} else {
-				tbp.Logf(ctx, "Error compacting key %s (purge) - will not be compacted.  %v", tombstonesRow.Id, purgeErr)
+	var tombstonesRow QueryIdRow
+	for results.Next(&tombstonesRow) {
+		// First, attempt to purge.
+		var purgeErr error
+		if base.TestUseXattrs() {
+			purgeErr = b.DeleteWithXattr(tombstonesRow.Id, base.SyncXattrName)
+		} else {
+			purgeErr = b.Delete(tombstonesRow.Id)
+		}
+		if base.IsKeyNotFoundError(b, purgeErr) {
+			// If key no longer exists, need to add and remove to trigger removal from view
+			_, addErr := b.Add(tombstonesRow.Id, 0, purgeBody)
+			if addErr != nil {
+				tbp.Logf(ctx, "Error compacting key %s (add) - will not be compacted.  %v", tombstonesRow.Id, addErr)
+				continue
 			}
-		}
-		err = results.Close()
-		if err != nil {
-			return 0, err
-		}
 
-		tbp.Logf(ctx, "Compacted %v docs in batch", purgedDocCount)
-
-		if resultCount < QueryTombstoneBatch {
-			break
+			if delErr := b.Delete(tombstonesRow.Id); delErr != nil {
+				tbp.Logf(ctx, "Error compacting key %s (delete) - will not be compacted.  %v", tombstonesRow.Id, delErr)
+			}
+			purgedDocCount++
+		} else if purgeErr != nil {
+			tbp.Logf(ctx, "Error compacting key %s (purge) - will not be compacted.  %v", tombstonesRow.Id, purgeErr)
 		}
+	}
+	err = results.Close()
+	if err != nil {
+		return 0, err
 	}
 
 	tbp.Logf(ctx, "Finished compaction ... Total docs purged: %d", purgedDocCount)


### PR DESCRIPTION
CBG-2199

As a follow up to the comments in #5625 - `NewDatabaseContext` was having other side effects than just unnessesary cbgt PIndex registration, which were manifesting themselves when running the revocation tests with GSI enabled.

By initializing a DatabaseContext during bucket cleanup, there was the potential for the database to create unused sequence docs as they came over DCP for documents created in the test prior to marking the bucket for cleanup.

This happened _after_ the `DELETE FROM`, which meant by the time the bucket was used by the next test, there were unused sequences in the bucket and it threw off all the sequence numbering for the revocation tests, which reasonably assumed the test bucket sequence started at 0.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true` `^TestRevocationScenario` https://jenkins.sgwdev.com/job/SyncGateway-Integration/418/
- [x] `GSI=true` `^(TestChannelHistoryPruning|TestDocChannelSetPruning|TestEnsureRevocationAfterDocMutation|TestEnsureRevocationUsingDocHistory|TestRevocationMutationMovesIntoRevokedChannel|TestRevocationResumeAndLowSeqCheck|TestRevocationResumeSameRoleAndLowSeqCheck)$` https://jenkins.sgwdev.com/job/SyncGateway-Integration/419/