### PR TITLE
Preserve LeakyBucket behaviour when run through AsN1QLStore

### DIFF
--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -362,7 +362,8 @@ func AsN1QLStore(bucket Bucket) (N1QLStore, bool) {
 	case *LoggingBucket:
 		underlyingBucket = typedBucket.GetUnderlyingBucket()
 	case *LeakyBucket:
-		underlyingBucket = typedBucket.GetUnderlyingBucket()
+		// LeakyBucket implements N1QLStore, so pass through
+		return typedBucket, true
 	case *TestBucket:
 		underlyingBucket = typedBucket.Bucket
 	default:

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2387,6 +2387,8 @@ func TestTombstoneCompactionStopWithManager(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
+	require.NoError(t, db.WaitForPendingChanges(base.TestCtx(t)))
+
 	leakyBucket, ok := base.AsLeakyBucket(db.Bucket)
 	require.True(t, ok)
 

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -270,8 +270,7 @@ var ViewsAndGSIBucketReadier base.TBPBucketReadierFunc = func(ctx context.Contex
 
 // ViewsAndGSIBucketInit is run synchronously only once per-bucket to do any initial setup. For non-integration Walrus buckets, this is run for each new Walrus bucket.
 var ViewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b base.Bucket, tbp *base.TestBucketPool) error {
-	n1qlStore, ok := base.AsN1QLStore(b)
-	if !ok {
+	if base.UnitTestUrlIsWalrus() {
 		// Check we're not running with an invalid combination of backing store and xattrs.
 		if base.TestUseXattrs() {
 			return fmt.Errorf("xattrs not supported when using Walrus buckets")
@@ -284,6 +283,11 @@ var ViewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 	// Exit early if we're not using GSI.
 	if base.TestsDisableGSI() {
 		return nil
+	}
+
+	n1qlStore, ok := base.AsN1QLStore(b)
+	if !ok {
+		return fmt.Errorf("bucket %T was not a N1QL store", b)
 	}
 
 	if empty, err := isIndexEmpty(n1qlStore, base.TestUseXattrs()); empty && err == nil {


### PR DESCRIPTION
The `LeakyBucket` wrapper/behaviour was being lost via `dbContext.N1QLQueryWithStats()` when it called `AsN1QLStore()` before running the query.

- Fixes `TestTombstoneCompactionStopWithManager` when running under GSI, which relies on `PostN1QLQueryCallback`

## Dependencies
- [x] `emptyAllDocsIndex` fix #5631 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true ^TestTombstoneCompactionStopWithManager$` https://jenkins.sgwdev.com/job/SyncGateway-Integration/420/
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/422/
- [ ] `xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/423/
  - 2 unrelated failures but will follow up after
