### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -17,7 +17,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"io/ioutil"
 	"math"
 	"math/big"
 	"os"
@@ -359,9 +358,8 @@ func TestGetViewQueryTimeout(t *testing.T) {
 	assert.Equal(t, expectedViewQueryTimeout, fakeBucketSpec.GetViewQueryTimeout())
 }
 
-func mockCertificatesAndKeys(t *testing.T) (certPath, clientCertPath, clientKeyPath, rootCertPath, rootKeyPath string) {
-	certPath, err := ioutil.TempDir("", "certs")
-	require.NoError(t, err, "Temp directory should be created")
+func mockCertificatesAndKeys(t *testing.T) (clientCertPath, clientKeyPath, rootCertPath, rootKeyPath string) {
+	certPath := t.TempDir()
 
 	rootKeyPath = filepath.Join(certPath, "root.key")
 	rootCertPath = filepath.Join(certPath, "root.pem")
@@ -422,7 +420,7 @@ func mockCertificatesAndKeys(t *testing.T) (certPath, clientCertPath, clientKeyP
 	require.True(t, FileExists(clientKeyPath), "File %v should exists", clientKeyPath)
 	require.True(t, FileExists(clientCertPath), "File %v should exists", clientCertPath)
 
-	return certPath, clientCertPath, clientKeyPath, rootCertPath, rootKeyPath
+	return clientCertPath, clientKeyPath, rootCertPath, rootKeyPath
 }
 
 func saveAsKeyFile(t *testing.T, filename string, key *ecdsa.PrivateKey) {
@@ -446,13 +444,7 @@ func saveAsCertFile(t *testing.T, filename string, derBytes []byte) {
 
 func TestTLSConfig(t *testing.T) {
 	// Mock fake root CA and client certificates for verification
-	certPath, clientCertPath, clientKeyPath, rootCertPath, rootKeyPath := mockCertificatesAndKeys(t)
-
-	// Remove the keys and certificates after verification
-	defer func() {
-		assert.NoError(t, os.RemoveAll(certPath))
-		assert.False(t, DirExists(certPath), "Directory: %v shouldn't exists", certPath)
-	}()
+	clientCertPath, clientKeyPath, rootCertPath, rootKeyPath := mockCertificatesAndKeys(t)
 
 	// Simulate error creating tlsConfig for DCP processing
 	spec := BucketSpec{

--- a/base/gocb_utils_test.go
+++ b/base/gocb_utils_test.go
@@ -2,7 +2,6 @@ package base
 
 import (
 	"crypto/x509"
-	"os"
 	"runtime"
 	"testing"
 
@@ -13,13 +12,7 @@ import (
 
 func TestGoCBv2SecurityConfig(t *testing.T) {
 	// Mock fake root CA and client certificates for verification
-	certPath, _, _, rootCertPath, _ := mockCertificatesAndKeys(t)
-
-	// Remove the keys and certificates after verification
-	defer func() {
-		require.NoError(t, os.RemoveAll(certPath))
-		require.False(t, DirExists(certPath), "Directory: %v shouldn't exists", certPath)
-	}()
+	_, _, rootCertPath, _ := mockCertificatesAndKeys(t)
 
 	tests := []struct {
 		name           string

--- a/base/logger_file_test.go
+++ b/base/logger_file_test.go
@@ -112,7 +112,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	var dirContents []os.FileInfo
 
 	//Regular Test With multiple files above high and low watermark
-	dir, _ := ioutil.TempDir("", "tempdir1")
+	dir := t.TempDir()
 
 	err := makeTestFile(2, logFilePrefix+"error-2019-02-01T12-00-00.log.gz", dir)
 	assert.NoError(t, err)
@@ -148,7 +148,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.NoError(t, os.RemoveAll(dir))
 
 	//Hit low watermark but not high watermark
-	dir, _ = ioutil.TempDir("", "tempdir2")
+	dir = t.TempDir()
 	err = makeTestFile(3, logFilePrefix+"error.log.gz", dir)
 	assert.NoError(t, err)
 	err = runLogDeletion(dir, "error", 2, 4)
@@ -158,7 +158,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.NoError(t, os.RemoveAll(dir))
 
 	//Single file hitting low and high watermark
-	dir, _ = ioutil.TempDir("", "tempdir3")
+	dir = t.TempDir()
 	err = makeTestFile(5, logFilePrefix+"error.log.gz", dir)
 	assert.NoError(t, err)
 	err = runLogDeletion(dir, "error", 2, 4)
@@ -168,7 +168,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.NoError(t, os.RemoveAll(dir))
 
 	//Not hitting low or high therefore no deletion
-	dir, _ = ioutil.TempDir("", "tempdir4")
+	dir = t.TempDir()
 	err = makeTestFile(1, logFilePrefix+"error.log.gz", dir)
 	assert.NoError(t, err)
 	err = runLogDeletion(dir, "error", 2, 4)
@@ -178,7 +178,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.NoError(t, os.RemoveAll(dir))
 
 	//Test deletion with files at the end of date boundaries
-	dir, _ = ioutil.TempDir("", "tempdir5")
+	dir = t.TempDir()
 	err = makeTestFile(1, logFilePrefix+"error-2018-12-31T23-59-59.log.gz", dir)
 	assert.NoError(t, err)
 	err = makeTestFile(1, logFilePrefix+"error-2019-01-01T00-00-00.log.gz", dir)
@@ -204,7 +204,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.NoError(t, os.RemoveAll(dir))
 
 	//Test deletion with no .gz files to ensure nothing is deleted
-	dir, _ = ioutil.TempDir("", "tempdir6")
+	dir = t.TempDir()
 	err = makeTestFile(1, logFilePrefix+"error", dir)
 	assert.NoError(t, err)
 	err = makeTestFile(1, logFilePrefix+"info", dir)

--- a/base/logging_config_test.go
+++ b/base/logging_config_test.go
@@ -11,7 +11,6 @@ licenses/APL2.txt.
 package base
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -56,15 +55,13 @@ func TestLogFilePathWritable(t *testing.T) {
 		},
 	}
 	for _, test := range testCases {
+		// Create tempdir here to avoid slash operator in t.Name()
+		tmpPath := t.TempDir()
+		t.Logf("created tmpPath: %q", tmpPath)
+
 		t.Run(test.name, func(t *testing.T) {
-			tmpPath, err := ioutil.TempDir("", "TestLogFilePathWritable*") // Cannot use t.Name() due to slash separator
-			require.NoError(t, err)
-			defer func() { require.NoError(t, os.RemoveAll(tmpPath)) }()
-
-			t.Logf("created tmpPath: %q", tmpPath)
-
 			logFilePath := filepath.Join(tmpPath, "logs")
-			err = os.Mkdir(logFilePath, test.logFilePathPerms)
+			err := os.Mkdir(logFilePath, test.logFilePathPerms)
 			require.NoError(t, err)
 
 			err = validateLogFilePath(logFilePath)

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -11,7 +11,6 @@ package base
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -84,8 +83,7 @@ func BenchmarkLogRotation(b *testing.B) {
 			_, err := rand.Read(data)
 			require.NoError(bm, err)
 
-			logPath, err := ioutil.TempDir("", "benchmark-logrotate")
-			require.NoError(bm, err)
+			logPath := b.TempDir()
 			logger := lumberjack.Logger{Filename: filepath.Join(logPath, "output.log"), Compress: test.compress}
 
 			bm.ResetTimer()

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -190,9 +190,8 @@ func TestCheckPermissionsWithX509(t *testing.T) {
 	if !base.ServerIsTLS(serverURL) {
 		t.Skipf("URI %s needs to start with couchbases://", serverURL)
 	}
-	tb, teardownFn, caCertPath, certPath, keyPath := setupX509Tests(t, true)
+	tb, caCertPath, certPath, keyPath := setupX509Tests(t, true)
 	defer tb.Close()
-	defer teardownFn()
 
 	ctx := NewServerContext(&StartupConfig{
 		Bootstrap: BootstrapConfig{
@@ -483,9 +482,8 @@ func TestAdminAuthWithX509(t *testing.T) {
 	if !base.ServerIsTLS(serverURL) {
 		t.Skipf("URI %s needs to start with couchbases://", serverURL)
 	}
-	tb, teardownFn, caCertPath, certPath, keyPath := setupX509Tests(t, true)
+	tb, caCertPath, certPath, keyPath := setupX509Tests(t, true)
 	defer tb.Close()
-	defer teardownFn()
 
 	ctx := NewServerContext(&StartupConfig{
 		Bootstrap: BootstrapConfig{

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5218,9 +5218,7 @@ func TestHandleProfiling(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	dirPath, err := ioutil.TempDir("", "pprof")
-	require.NoError(t, err, "Temp directory should be created")
-	defer func() { assert.NoError(t, os.RemoveAll(dirPath)) }()
+	dirPath := t.TempDir()
 
 	tests := []struct {
 		inputProfile string
@@ -5292,9 +5290,7 @@ func TestHandleHeapProfiling(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	dirPath, err := ioutil.TempDir("", "heap-pprof")
-	require.NoError(t, err, "Temp directory should be created")
-	defer func() { assert.NoError(t, os.RemoveAll(dirPath)) }()
+	dirPath := t.TempDir()
 
 	// Send a valid request for heap profiling
 	filePath := filepath.Join(dirPath, "heap.pprof")

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -314,12 +314,10 @@ func TestLegacyGuestUserMigration(t *testing.T) {
 		tb.GetName(),
 	)
 
-	tmpDir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	defer func() { require.NoError(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	configPath := filepath.Join(tmpDir, "config.json")
-	err = ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
+	err := ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
 	require.NoError(t, err)
 
 	sc, _, _, _, err := automaticConfigUpgrade(configPath)
@@ -415,9 +413,7 @@ func TestLegacyConfigPrinciplesMigration(t *testing.T) {
 	}`
 	config = fmt.Sprintf(config, base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), rt.Bucket().GetName())
 
-	tmpDir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	defer func() { require.NoError(t, os.RemoveAll(tmpDir)) }()
+	tmpDir := t.TempDir()
 
 	configPath := filepath.Join(tmpDir, "config.json")
 	err = ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -43,11 +43,10 @@ func TestAutomaticConfigUpgrade(t *testing.T) {
 		tb.GetName(),
 	)
 
-	tmpDir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	configPath := filepath.Join(tmpDir, "config.json")
-	err = ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
+	err := ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
 	require.NoError(t, err)
 
 	startupConfig, _, _, _, err := automaticConfigUpgrade(configPath)
@@ -136,17 +135,17 @@ func TestAutomaticConfigUpgradeError(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		// Create tempdir here to avoid slash operator in t.Name()
+		tmpDir := t.TempDir()
+
 		t.Run(testCase.Name, func(t *testing.T) {
 			tb := base.GetTestBucket(t)
 			defer tb.Close()
 
 			config := fmt.Sprintf(testCase.Config, base.TestTLSSkipVerify(), base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), tb.GetName())
 
-			tmpDir, err := ioutil.TempDir("", strings.ReplaceAll(t.Name(), "/", ""))
-			require.NoError(t, err)
-
 			configPath := filepath.Join(tmpDir, "config.json")
-			err = ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
+			err := ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
 			require.NoError(t, err)
 
 			_, _, _, _, err = automaticConfigUpgrade(configPath)
@@ -163,8 +162,7 @@ func TestAutomaticConfigUpgradeExistingConfigAndNewGroup(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
 
-	tmpDir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	config := fmt.Sprintf(`{
 	"server_tls_skip_verify": %t,
@@ -184,7 +182,7 @@ func TestAutomaticConfigUpgradeExistingConfigAndNewGroup(t *testing.T) {
 		tb.GetName(),
 	)
 	configPath := filepath.Join(tmpDir, "config.json")
-	err = ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
+	err := ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
 	require.NoError(t, err)
 
 	// Run migration once

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -284,9 +284,8 @@ func TestObtainManagementEndpointsFromServerContextWithX509(t *testing.T) {
 	if !base.ServerIsTLS(serverURL) {
 		t.Skipf("URI %s needs to start with couchbases://", serverURL)
 	}
-	tb, teardownFn, caCertPath, certPath, keyPath := setupX509Tests(t, true)
+	tb, caCertPath, certPath, keyPath := setupX509Tests(t, true)
 	defer tb.Close()
-	defer teardownFn()
 
 	ctx := NewServerContext(&StartupConfig{
 		Bootstrap: BootstrapConfig{
@@ -622,8 +621,7 @@ func TestLogFlush(t *testing.T) {
 			base.InitializeMemoryLoggers()
 
 			// Add temp dir to save log files to
-			tempPath, err := ioutil.TempDir("", "logs"+testCase.Name)
-			require.NoError(t, err)
+			tempPath := t.TempDir()
 			testDirName := filepath.Base(tempPath)
 
 			// Log some stuff (which will go into the memory loggers)
@@ -639,7 +637,7 @@ func TestLogFlush(t *testing.T) {
 			config = testCase.EnableFunc(config)
 
 			// Setup logging
-			err = config.SetupAndValidateLogging()
+			err := config.SetupAndValidateLogging()
 			assert.NoError(t, err)
 
 			// Flush memory loggers

--- a/rest/x509_test.go
+++ b/rest/x509_test.go
@@ -30,9 +30,8 @@ import (
 func TestX509RoundtripUsingIP(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	tb, teardownFn, _, _, _ := setupX509Tests(t, true)
+	tb, _, _, _ := setupX509Tests(t, true)
 	defer tb.Close()
-	defer teardownFn()
 
 	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb, useTLSServer: true})
 	defer rt.Close()
@@ -51,9 +50,8 @@ func TestX509RoundtripUsingIP(t *testing.T) {
 func TestX509RoundtripUsingDomain(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	tb, teardownFn, _, _, _ := setupX509Tests(t, false)
+	tb, _, _, _ := setupX509Tests(t, false)
 	defer tb.Close()
-	defer teardownFn()
 
 	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb, useTLSServer: true})
 	defer rt.Close()
@@ -70,9 +68,8 @@ func TestX509RoundtripUsingDomain(t *testing.T) {
 func TestX509UnknownAuthorityWrap(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	tb, teardownFn, _, _, _ := setupX509Tests(t, true)
+	tb, _, _, _ := setupX509Tests(t, true)
 	defer tb.Close()
-	defer teardownFn()
 
 	tb.BucketSpec.CACertPath = ""
 
@@ -92,9 +89,8 @@ func TestX509UnknownAuthorityWrap(t *testing.T) {
 }
 
 func TestAttachmentCompactionRun(t *testing.T) {
-	tb, teardownFn, _, _, _ := setupX509Tests(t, true)
+	tb, _, _, _ := setupX509Tests(t, true)
 	defer tb.Close()
-	defer teardownFn()
 
 	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb, useTLSServer: true})
 	defer rt.Close()
@@ -115,7 +111,7 @@ func TestAttachmentCompactionRun(t *testing.T) {
 	assert.Equal(t, int64(20), status.MarkedAttachments)
 }
 
-func setupX509Tests(t *testing.T, useIPAddress bool) (testBucket *base.TestBucket, teardownFunc func(), caCertPath string, certPath string, keyPath string) {
+func setupX509Tests(t *testing.T, useIPAddress bool) (testBucket *base.TestBucket, caCertPath string, certPath string, keyPath string) {
 	if !x509TestsEnabled() {
 		t.Skipf("x509 tests not enabled via %s flag", x509TestFlag)
 	}
@@ -152,7 +148,7 @@ func setupX509Tests(t *testing.T, useIPAddress bool) (testBucket *base.TestBucke
 
 	nodePair := generateX509Node(t, ca, testIPs, testURls)
 	sgPair := generateX509SG(t, ca, base.TestClusterUsername(), time.Now().Add(time.Hour*24))
-	teardownFn := saveX509Files(t, ca, nodePair, sgPair)
+	saveX509Files(t, ca, nodePair, sgPair)
 
 	usingDocker, dockerName := base.TestUseCouchbaseServerDockerName()
 	if usingDocker {
@@ -186,5 +182,5 @@ func setupX509Tests(t *testing.T, useIPAddress bool) (testBucket *base.TestBucke
 	tb.BucketSpec.Certpath = certPath
 	tb.BucketSpec.Keypath = keyPath
 
-	return tb, teardownFn, caCertPath, certPath, keyPath
+	return tb, caCertPath, certPath, keyPath
 }

--- a/rest/x509_utils_test.go
+++ b/rest/x509_utils_test.go
@@ -64,12 +64,11 @@ func x509TestsEnabled() bool {
 }
 
 // saveX509Files creates temp files for the given certs/keys and returns the full filepaths for each.
-func saveX509Files(t *testing.T, ca *caPair, node *nodePair, sg *sgPair) (teardownFn func()) {
-	dirName, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
+func saveX509Files(t *testing.T, ca *caPair, node *nodePair, sg *sgPair) {
+	dirName := t.TempDir()
 
 	caPEMFilepath := filepath.Join(dirName, "ca.pem")
-	err = ioutil.WriteFile(caPEMFilepath, ca.PEM.Bytes(), os.FileMode(0777))
+	err := ioutil.WriteFile(caPEMFilepath, ca.PEM.Bytes(), os.FileMode(0777))
 	require.NoError(t, err)
 	ca.PEMFilepath = caPEMFilepath
 
@@ -90,10 +89,6 @@ func saveX509Files(t *testing.T, ca *caPair, node *nodePair, sg *sgPair) (teardo
 	err = ioutil.WriteFile(sgKeyFilepath, sg.Key.Bytes(), os.FileMode(0777))
 	require.NoError(t, err)
 	sg.KeyFilePath = sgKeyFilepath
-
-	return func() {
-		require.NoError(t, os.RemoveAll(dirName), "unexpected error when trying to clean up cert files")
-	}
 }
 
 // A set of types for sets of specific certs/keys so we can provide strongly-typed hints for their use (to prevent mixups)


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] ~~Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)~~
- [x] ~~Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`~~

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/