### PR TITLE
Make the bootstrapAdminRequest helpers less error-prone by closing resp.Body internally

### DIFF
--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -294,15 +294,22 @@ func (r *bootstrapAdminResponse) requireResponse(status int, body string) {
 }
 
 func bootstrapAdminRequest(t *testing.T, method, path, body string) bootstrapAdminResponse {
-	return bootstrapAdminRequestWithHeaders(t, method, path, body, nil)
+	return doBootstrapAdminRequest(t, method, "", path, body, nil)
 }
 
 func bootstrapAdminRequestCustomHost(t *testing.T, method, host, path, body string) bootstrapAdminResponse {
-	return bootstrapAdminRequest(t, method, host+path, body)
+	return doBootstrapAdminRequest(t, method, host, path, body, nil)
 }
 
 func bootstrapAdminRequestWithHeaders(t *testing.T, method, path, body string, headers map[string]string) bootstrapAdminResponse {
-	url := "http://localhost:" + strconv.FormatInt(4985+bootstrapTestPortOffset, 10) + path
+	return doBootstrapAdminRequest(t, method, "", path, body, headers)
+}
+
+func doBootstrapAdminRequest(t *testing.T, method, host, path, body string, headers map[string]string) bootstrapAdminResponse {
+	if host == "" {
+		host = "http://localhost:" + strconv.FormatInt(4985+bootstrapTestPortOffset, 10)
+	}
+	url := host + path
 
 	buf := bytes.NewBufferString(body)
 	req, err := http.NewRequest(method, url, buf)
@@ -324,5 +331,6 @@ func bootstrapAdminRequestWithHeaders(t *testing.T, method, path, body string, h
 		t:          t,
 		StatusCode: resp.StatusCode,
 		Body:       string(rBody),
+		Header:     resp.Header,
 	}
 }

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -54,25 +54,24 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 		),
 	)
-	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp.requireStatus(http.StatusCreated)
 
 	// upsert 1 config field
 	resp = bootstrapAdminRequest(t, http.MethodPost, "/db1/_config",
 		`{"cache": {"rev_cache":{"size":1234}}}`,
 	)
-	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp.requireStatus(http.StatusCreated)
 
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/", ``)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	var dbRootResp DatabaseRoot
 	resp.requireStatus(http.StatusOK)
+	var dbRootResp DatabaseRoot
 	require.NoError(t, base.JSONUnmarshal([]byte(resp.Body), &dbRootResp))
 	assert.Equal(t, "db1", dbRootResp.DBName)
 	assert.Equal(t, db.RunStateString[db.DBOnline], dbRootResp.State)
 
 	// Inspect the config
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/_config", ``)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.requireStatus(http.StatusOK)
 	var dbConfigResp DatabaseConfig
 	require.NoError(t, base.JSONUnmarshal([]byte(resp.Body), &dbConfigResp))
 	assert.Equal(t, "db1", dbConfigResp.Name)
@@ -108,7 +107,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 
 	// Ensure the database was bootstrapped on startup
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/", ``)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.requireStatus(http.StatusOK)
 	dbRootResp = DatabaseRoot{}
 	require.NoError(t, base.JSONUnmarshal([]byte(resp.Body), &dbRootResp))
 	assert.Equal(t, "db1", dbRootResp.DBName)
@@ -116,7 +115,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 
 	// Inspect config again, and ensure no changes since bootstrap
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/_config", ``)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.requireStatus(http.StatusOK)
 	dbConfigResp = DatabaseConfig{}
 	require.NoError(t, base.JSONUnmarshal([]byte(resp.Body), &dbConfigResp))
 	assert.Equal(t, "db1", dbConfigResp.Name)
@@ -166,7 +165,7 @@ func TestBootstrapDuplicateBucket(t *testing.T) {
 			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 		),
 	)
-	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp.requireStatus(http.StatusCreated)
 
 	// Create db2 using the same bucket and expect it to fail
 	resp = bootstrapAdminRequest(t, http.MethodPut, "/db2/",
@@ -216,11 +215,11 @@ func TestBootstrapDuplicateDatabase(t *testing.T) {
 	)
 
 	resp := bootstrapAdminRequest(t, http.MethodPut, "/db1/", dbConfig)
-	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp.requireStatus(http.StatusCreated)
 
 	// Write a doc, we'll rely on it for later stat assertions to ensure the database isn't being reloaded.
 	resp = bootstrapAdminRequest(t, http.MethodPut, "/db1/doc1", `{"test": true}`)
-	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp.requireStatus(http.StatusCreated)
 
 	// check to see we have a doc written stat
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/_expvar", "")

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -2363,6 +2363,7 @@ func TestOpenIDConnectProviderRemoval(t *testing.T) {
 	res = bootstrapAdminRequest(t, http.MethodGet, fmt.Sprintf("/db/_user/%s", subject), "")
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	var adminResult db.Body
+	require.NoError(t, base.JSONUnmarshal([]byte(res.Body), &adminResult))
 	base.DebugfCtx(base.TestCtx(t), base.KeyAll, "User data from admin API: %v", adminResult)
 
 	assert.Equal(t, subject, adminResult["name"])

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -2354,18 +2354,15 @@ func TestOpenIDConnectProviderRemoval(t *testing.T) {
 	req, err := http.NewRequest(http.MethodPost, bootstrapURL(publicPort)+"/db/_session", bytes.NewBufferString("{}"))
 	require.NoError(t, err, "Initializing auth request")
 	req.Header.Set("Authorization", BearerToken+" "+jwt)
-	res, err = http.DefaultClient.Do(req)
+	httpRes, err := http.DefaultClient.Do(req)
 	require.NoError(t, err, "Performing auth request")
-	assert.NoError(t, res.Body.Close())
-	require.Equal(t, http.StatusOK, res.StatusCode)
+	assert.NoError(t, httpRes.Body.Close())
+	require.Equal(t, http.StatusOK, httpRes.StatusCode)
 
 	// Check that the user is present in the admin API
 	res = bootstrapAdminRequest(t, http.MethodGet, fmt.Sprintf("/db/_user/%s", subject), "")
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	var adminResult db.Body
-	err = json.NewDecoder(res.Body).Decode(&adminResult)
-	require.NoError(t, err)
-	assert.NoError(t, res.Body.Close())
 	base.DebugfCtx(base.TestCtx(t), base.KeyAll, "User data from admin API: %v", adminResult)
 
 	assert.Equal(t, subject, adminResult["name"])
@@ -2390,15 +2387,13 @@ func TestOpenIDConnectProviderRemoval(t *testing.T) {
 	"num_index_replicas": 0,
 	"oidc":` + string(mustMarshalJSON(t, &oidcOptions)) + `}`
 	res = bootstrapAdminRequest(t, http.MethodPut, "/db/_config?disable_oidc_validation=true", dbConfig)
-	assert.NoError(t, res.Body.Close())
-	require.Equal(t, http.StatusCreated, res.StatusCode)
+	res.requireStatus(http.StatusCreated)
 
 	// Check that the user is still present, but with no OIDC info
 	res = bootstrapAdminRequest(t, http.MethodGet, fmt.Sprintf("/db/_user/%s", subject), "")
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	adminResult = db.Body{}
-	require.NoError(t, json.NewDecoder(res.Body).Decode(&adminResult))
-	assert.NoError(t, res.Body.Close())
+	require.NoError(t, base.JSONUnmarshal([]byte(res.Body), &adminResult))
 	base.DebugfCtx(base.TestCtx(t), base.KeyAll, "User data from admin API: %v", adminResult)
 
 	assert.NotContains(t, adminResult, "jwt_issuer", "Expected to not have jwt_issuer in /_user response")
@@ -2407,29 +2402,26 @@ func TestOpenIDConnectProviderRemoval(t *testing.T) {
 	req, err = http.NewRequest(http.MethodPost, bootstrapURL(publicPort)+"/db/_session", bytes.NewBufferString("{}"))
 	require.NoError(t, err, "Initializing second auth request")
 	req.Header.Set("Authorization", BearerToken+" "+jwt)
-	res, err = http.DefaultClient.Do(req)
+	httpRes, err = http.DefaultClient.Do(req)
 	require.NoError(t, err, "Performing second auth request")
-	assert.NoError(t, res.Body.Close())
-	assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	assert.Equal(t, http.StatusUnauthorized, httpRes.StatusCode)
 
 	// Finally, check that the user can sign in through basic auth, but their OIDC roles/channels get revoked
 	res = bootstrapAdminRequest(t, http.MethodPut, fmt.Sprintf("/db/_user/%s", subject), `{"password": "hunter2"}`)
-	assert.NoError(t, res.Body.Close())
 	require.Equal(t, http.StatusOK, res.StatusCode)
 
 	req, err = http.NewRequest(http.MethodPost, bootstrapURL(publicPort)+"/db/_session", bytes.NewBufferString("{}"))
 	require.NoError(t, err, "Initializing basic auth request")
 	req.SetBasicAuth(subject, "hunter2")
-	res, err = http.DefaultClient.Do(req)
+	httpRes, err = http.DefaultClient.Do(req)
 	require.NoError(t, err, "Performing basic auth request")
-	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, http.StatusOK, httpRes.StatusCode)
 
 	var sessionResponse struct {
 		UserCtx db.Body `json:"userCtx"`
 	}
-	require.NoError(t, json.NewDecoder(res.Body).Decode(&sessionResponse))
+	require.NoError(t, json.NewDecoder(httpRes.Body).Decode(&sessionResponse))
 	require.NotContains(t, sessionResponse.UserCtx["channels"], testChannelName)
-	assert.NoError(t, res.Body.Close())
 }
 
 // This test verifies the edge case of having two different OIDC providers with different role/channel configurations

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -317,11 +317,11 @@ func TestImportFilterEndpoint(t *testing.T) {
 			tb.GetName(), base.TestsDisableGSI(),
 		),
 	)
-	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp.requireStatus(http.StatusCreated)
 
 	// Ensure we won't fail with an empty import filter
 	resp = bootstrapAdminRequest(t, http.MethodPut, "/db1/_config/import_filter", "")
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.requireStatus(http.StatusOK)
 
 	// Add a document
 	err = tb.Bucket.Set("importDoc1", 0, nil, []byte("{}"))
@@ -329,11 +329,11 @@ func TestImportFilterEndpoint(t *testing.T) {
 
 	// Ensure document is imported based on default import filter
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/importDoc1", "")
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.requireStatus(http.StatusOK)
 
 	// Modify the import filter to always reject import
 	resp = bootstrapAdminRequest(t, http.MethodPut, "/db1/_config/import_filter", `function(){return false}`)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.requireStatus(http.StatusOK)
 
 	// Add a document
 	err = tb.Bucket.Set("importDoc2", 0, nil, []byte("{}"))
@@ -341,11 +341,11 @@ func TestImportFilterEndpoint(t *testing.T) {
 
 	// Ensure document is not imported and is rejected based on updated filter
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/importDoc2", "")
-	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	resp.requireStatus(http.StatusNotFound)
 	assert.Contains(t, resp.Body, "Not imported")
 
 	resp = bootstrapAdminRequest(t, http.MethodDelete, "/db1/_config/import_filter", "")
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.requireStatus(http.StatusOK)
 
 	// Add a document
 	err = tb.Bucket.Set("importDoc3", 0, nil, []byte("{}"))
@@ -353,5 +353,5 @@ func TestImportFilterEndpoint(t *testing.T) {
 
 	// Ensure document is imported based on default import filter
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/importDoc3", "")
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.requireStatus(http.StatusOK)
 }

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -317,12 +317,10 @@ func TestImportFilterEndpoint(t *testing.T) {
 			tb.GetName(), base.TestsDisableGSI(),
 		),
 	)
-	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
 	// Ensure we won't fail with an empty import filter
 	resp = bootstrapAdminRequest(t, http.MethodPut, "/db1/_config/import_filter", "")
-	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Add a document
@@ -331,12 +329,10 @@ func TestImportFilterEndpoint(t *testing.T) {
 
 	// Ensure document is imported based on default import filter
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/importDoc1", "")
-	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Modify the import filter to always reject import
 	resp = bootstrapAdminRequest(t, http.MethodPut, "/db1/_config/import_filter", `function(){return false}`)
-	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Add a document
@@ -345,14 +341,10 @@ func TestImportFilterEndpoint(t *testing.T) {
 
 	// Ensure document is not imported and is rejected based on updated filter
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/importDoc2", "")
-	responseBody, err := ioutil.ReadAll(resp.Body)
-	assert.NoError(t, resp.Body.Close())
-	assert.NoError(t, err)
-	assert.Contains(t, string(responseBody), "Not imported")
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Contains(t, resp.Body, "Not imported")
 
 	resp = bootstrapAdminRequest(t, http.MethodDelete, "/db1/_config/import_filter", "")
-	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Add a document
@@ -361,6 +353,5 @@ func TestImportFilterEndpoint(t *testing.T) {
 
 	// Ensure document is imported based on default import filter
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/importDoc3", "")
-	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }


### PR DESCRIPTION
The `bootstrapAdminRequest` utility functions do not use the typical `rest.TestResponse`, as they're not intercepting the `RestTester` handlers, and are actually making HTTP requests to a running server.

This changes the utility function to read and close the response body, to avoid cases where this wasn't done in tests, and includes assertion helper methods for easier use.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/477/