### PR TITLE
GSI test fix: Incorrect pointer/non-pointer assertions in TestUsersAPIDetails

### DIFF
--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -177,8 +177,10 @@ func validateUsersNameOnlyFalse(t *testing.T, rt *RestTester) {
 		// Check property values, and validate no duplicate users returned in response
 		userMap := make(map[string]interface{})
 		for _, principal := range responseUsers {
+			require.NotNil(t, principal.Name)
 			if *principal.Name != "user5" {
-				assert.Equal(t, *principal.Name+"@foo.com", principal.Email)
+				require.NotNil(t, principal.Email)
+				assert.Equal(t, *principal.Name+"@foo.com", *principal.Email)
 			}
 			if *principal.Name == "user3" || *principal.Name == "user8" {
 				assert.Equal(t, true, *principal.Disabled)


### PR DESCRIPTION
Dereference `principal.Email` now it's a pointer ( #5546 ) for assertion.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `^TestUsersAPIDetails` `gsi=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/431/