### PR TITLE
ActiveReplicator push collection panic fix/test coverage

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -272,7 +272,7 @@ type CBLReplicationPullStats struct {
 	AttachmentPullCount *SgwIntStat `json:"attachment_pull_count"`
 	// The high watermark for the number of documents buffered during feed processing, waiting on a missing earlier sequence.
 	MaxPending *SgwIntStat `json:"max_pending"`
-	/// The total number of active replications. This metric only counts continuous pull replications.
+	// The total number of active replications. This metric only counts continuous pull replications.
 	NumReplicationsActive *SgwIntStat `json:"num_replications_active"`
 	// The total number of continuous pull replications in the active state.
 	NumPullReplActiveContinuous *SgwIntStat `json:"num_pull_repl_active_continuous"`
@@ -532,6 +532,9 @@ type DbReplicatorStats struct {
 	ConflictResolvedRemoteCount *SgwIntStat `json:"sgr_conflict_resolved_remote_count"`
 	// The total number of conflicting documents that were resolved successfully by a merge action (by the active replicator)
 	ConflictResolvedMergedCount *SgwIntStat `json:"sgr_conflict_resolved_merge_count"`
+
+	// The number of times a handler panicked and didn't know how to recover from it.
+	NumHandlersPanicked *SgwIntStat `json:"-"`
 }
 
 type SecurityStats struct {
@@ -1114,6 +1117,7 @@ func (d *DbStats) DBReplicatorStats(replicationID string) *DbReplicatorStats {
 			ConflictResolvedMergedCount: NewIntStat(SubsystemReplication, "sgr_conflict_resolved_merge_count", labelKeys, labelVals, prometheus.CounterValue, 0),
 			NumConnectAttemptsPull:      NewIntStat(SubsystemReplication, "sgr_num_connect_attempts_pull", labelKeys, labelVals, prometheus.CounterValue, 0),
 			NumReconnectsAbortedPull:    NewIntStat(SubsystemReplication, "sgr_num_reconnects_aborted_pull", labelKeys, labelVals, prometheus.CounterValue, 0),
+			NumHandlersPanicked:         NewIntStat(SubsystemReplication, "sgr_num_handlers_panicked", labelKeys, labelVals, prometheus.CounterValue, 0),
 		}
 	}
 

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -108,6 +108,14 @@ func (ar *ActiveReplicator) Stop() error {
 		return pullErr
 	}
 
+	if base.BoolDefault(ar.config.reportHandlerPanicsOnStop, true) {
+		if stats := ar.config.ReplicationStatsMap; stats != nil {
+			if val := stats.NumHandlersPanicked.Value(); val > 0 {
+				return fmt.Errorf("%d handlers panicked", val)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -99,6 +99,10 @@ type ActiveReplicatorConfig struct {
 	// Map corresponding to db.replications.[replicationID] in Sync Gateway's expvars.  Populated with
 	// replication stats in blip_sync_stats.go
 	ReplicationStatsMap *base.DbReplicatorStats
+
+	// Returns an error from ActiveReplicator.Stop() if the replicator encountered any recovered panics inside handlers.
+	// Intended for test usage only, enabled by default but disabled for the prod-ISGR codepath.
+	reportHandlerPanicsOnStop *bool
 }
 
 // SetCheckpointPrefix is a cross-package way of defining a checkpoint prefix for an ActiveReplicatorConfig intended for test usage.

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -88,6 +88,7 @@ func (apr *ActivePushReplicator) _connect() error {
 	bh := blipHandler{
 		BlipSyncContext: apr.blipSyncContext,
 		db:              apr.config.ActiveDB,
+		collection:      apr.config.ActiveDB,
 		serialNumber:    apr.blipSyncContext.incrementSerialNumber(),
 	}
 

--- a/db/blip_connected_client.go
+++ b/db/blip_connected_client.go
@@ -22,7 +22,7 @@ func (bh *blipHandler) handleGetRev(rq *blip.Message) error {
 	docID := rq.Properties[GetRevMessageId]
 	ifNotRev := rq.Properties[GetRevIfNotRev]
 
-	rev, err := bh.db.GetRev(docID, "", false, nil)
+	rev, err := bh.collection.GetRev(docID, "", false, nil)
 	if err != nil {
 		status, reason := base.ErrorAsHTTPStatus(err)
 		return &base.HTTPError{Status: status, Message: reason}

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -343,6 +343,7 @@ func (flag changesDeletedFlag) HasFlag(deletedFlag changesDeletedFlag) bool {
 func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions) (isComplete bool) {
 	defer func() {
 		if panicked := recover(); panicked != nil {
+			bh.replicationStats.NumHandlersPanicked.Add(1)
 			base.WarnfCtx(bh.loggingCtx, "[%s] PANIC sending changes: %v\n%s", bh.blipContext.ID, panicked, debug.Stack())
 		}
 	}()

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -440,10 +440,10 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 	// On forceClose, send notify to trigger immediate exit from change waiter
 	if forceClose {
 		user := ""
-		if bh.collection.User() != nil {
-			user = bh.collection.User().Name()
+		if bh.db.User() != nil {
+			user = bh.db.User().Name()
 		}
-		bh.collection.DatabaseContext.NotifyTerminatedChanges(user)
+		bh.db.DatabaseContext.NotifyTerminatedChanges(user)
 	}
 
 	return !forceClose

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -152,6 +152,7 @@ func (bsc *BlipSyncContext) register(profile string, handlerFn func(*blipHandler
 				}
 
 				// This is a panic we don't know about - so continue to log at warn with a generic 500 response via go-blip
+				bsc.replicationStats.NumHandlersPanicked.Add(1)
 				base.WarnfCtx(bsc.loggingCtx, "PANIC handling BLIP request %v: %v\n%s", rq, err, debug.Stack())
 				panic(err)
 			}
@@ -231,6 +232,7 @@ func (bsc *BlipSyncContext) _copyContextDatabase() *Database {
 func (bsc *BlipSyncContext) handleChangesResponse(sender *blip.Sender, response *blip.Message, changeArray [][]interface{}, requestSent time.Time, handleChangesResponseDb *Database) error {
 	defer func() {
 		if panicked := recover(); panicked != nil {
+			bsc.replicationStats.NumHandlersPanicked.Add(1)
 			base.WarnfCtx(bsc.loggingCtx, "PANIC handling 'changes' response: %v\n%s", panicked, debug.Stack())
 		}
 	}()
@@ -396,6 +398,7 @@ func (bsc *BlipSyncContext) sendRevisionWithProperties(sender *blip.Sender, docI
 		go func(activeSubprotocol string) {
 			defer func() {
 				if panicked := recover(); panicked != nil {
+					bsc.replicationStats.NumHandlersPanicked.Add(1)
 					base.WarnfCtx(bsc.loggingCtx, "PANIC handling 'sendRevision' response: %v\n%s", panicked, debug.Stack())
 					bsc.Close()
 				}

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -60,6 +60,7 @@ type BlipSyncStats struct {
 	SendChangesCount                 *base.SgwIntStat // sendChanges
 	NumConnectAttempts               *base.SgwIntStat
 	NumReconnectsAborted             *base.SgwIntStat
+	NumHandlersPanicked              *base.SgwIntStat
 }
 
 func NewBlipSyncStats() *BlipSyncStats {
@@ -107,6 +108,7 @@ func NewBlipSyncStats() *BlipSyncStats {
 		SendChangesCount:                 &base.SgwIntStat{},
 		NumConnectAttempts:               &base.SgwIntStat{},
 		NumReconnectsAborted:             &base.SgwIntStat{},
+		NumHandlersPanicked:              &base.SgwIntStat{},
 	}
 }
 
@@ -166,6 +168,8 @@ func BlipSyncStatsForSGRPush(replicationStats *base.DbReplicatorStats) *BlipSync
 	blipStats.NumConnectAttempts = replicationStats.NumConnectAttemptsPush
 	blipStats.NumReconnectsAborted = replicationStats.NumReconnectsAbortedPush
 
+	blipStats.NumHandlersPanicked = replicationStats.NumHandlersPanicked
+
 	return blipStats
 }
 
@@ -182,6 +186,8 @@ func BlipSyncStatsForSGRPull(replicationStats *base.DbReplicatorStats) *BlipSync
 	blipStats.HandleChangesCount = replicationStats.DocsCheckedReceived
 	blipStats.NumConnectAttempts = replicationStats.NumConnectAttemptsPull
 	blipStats.NumReconnectsAborted = replicationStats.NumReconnectsAbortedPull
+
+	blipStats.NumHandlersPanicked = replicationStats.NumHandlersPanicked
 
 	return blipStats
 }

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -662,6 +662,9 @@ func (m *sgReplicateManager) InitializeReplication(config *ReplicationCfg) (repl
 	allReplicationsStatsMap := m.dbContext.DbStats.DBReplicatorStats(rc.ID)
 	rc.ReplicationStatsMap = allReplicationsStatsMap
 
+	// disable recovered panic reporting (test only)
+	rc.reportHandlerPanicsOnStop = base.BoolPtr(false)
+
 	replicator = NewActiveReplicator(rc)
 
 	return replicator, nil


### PR DESCRIPTION
Two fixes for `ActiveReplicator` push panicing due to nil collection on `sendChanges` `NotifyTerminatedChanges`, either of which fix the panic:
- Initialise `bh.collection` on an `ActivePushReplicator` to match `collectionBlipHandler` behaviour
- Keep `sendChanges` `NotifyTerminatedChanges` on database instead of collection (because users are/will be db-scoped, not collection-scoped)

### Misc fix:
- Connected client: make `GetRev` operate on the `collection` instead of `db`

### Test enhancements:
- Make `ActiveReplicator` report unexpected handler panics on `Stop` - but opt-out for the ISGR codepath (i.e. used for test-only assertions)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/437/