### PR TITLE
CBG-2215: Integration test fixes for 6.x and collections

### DIFF
--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -619,7 +619,7 @@ type TBPBucketReadierFunc func(ctx context.Context, b Bucket, tbp *TestBucketPoo
 var FlushBucketEmptierFunc TBPBucketReadierFunc = func(ctx context.Context, b Bucket, tbp *TestBucketPool) error {
 
 	if c, ok := b.(*Collection); ok {
-		if err := c.dropAllScopesAndCollections(); err != nil {
+		if err := c.dropAllScopesAndCollections(); err != nil && !errors.Is(err, ErrCollectionsUnsupported) {
 			return err
 		}
 	}

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -156,6 +156,7 @@ func TestCollectionsBasicIndexQuery(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Walrus does not support scopes and collections")
 	}
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	tb := base.GetTestBucket(t)
 	defer tb.Close()


### PR DESCRIPTION
CBG-2215

The test bucket framework always tried to drop scopes and collections, which would fail on Server pre-7, eventually leading to bucket flush timeouts.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `server 7.0.3` https://jenkins.sgwdev.com/job/SyncGateway-Integration/445/
- [ ] `server 6.6.5` https://jenkins.sgwdev.com/job/SyncGateway-Integration/448/