### PR TITLE
Removing temporary/unused skipRegisterImportPIndex

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -159,7 +159,6 @@ type DatabaseContextOptions struct {
 	ClientPartitionWindow         time.Duration
 	BcryptCost                    int
 	GroupID                       string
-	skipRegisterImportPIndex      bool // if set, skips the global gocb PIndex registration
 }
 
 type SGReplicateOptions struct {
@@ -312,9 +311,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	}
 
 	// Register the cbgt pindex type for the configGroup
-	if !options.skipRegisterImportPIndex {
-		RegisterImportPindexImpl(options.GroupID)
-	}
+	RegisterImportPindexImpl(options.GroupID)
 
 	dbContext := &DatabaseContext{
 		Name:       dbName,


### PR DESCRIPTION
Field is now unused.

Originally added in #5625 as a temporary fix...
The underlying fix that removed the need for this: #5631 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] n/a - dead code