### PR TITLE
Tweak locking in ActiveReplicator 'GetStatus' accessors to fix detected race

### DIFF
--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -171,10 +171,10 @@ func (apr *ActivePullReplicator) _initCheckpointer() error {
 func (apr *ActivePullReplicator) GetStatus() *ReplicationStatus {
 	var lastSeqPulled string
 	apr.lock.RLock()
+	defer apr.lock.RUnlock()
 	if apr.Checkpointer != nil {
 		lastSeqPulled = apr.Checkpointer.calculateSafeProcessedSeq()
 	}
-	apr.lock.RUnlock()
 	status := apr.getPullStatus(lastSeqPulled)
 	return status
 }

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -206,10 +206,10 @@ func (apr *ActivePushReplicator) _initCheckpointer() error {
 func (apr *ActivePushReplicator) GetStatus() *ReplicationStatus {
 	var lastSeqPushed string
 	apr.lock.RLock()
+	defer apr.lock.RUnlock()
 	if apr.Checkpointer != nil {
 		lastSeqPushed = apr.Checkpointer.calculateSafeProcessedSeq()
 	}
-	apr.lock.RUnlock()
 	status := apr.getPushStatus(lastSeqPushed)
 	return status
 }


### PR DESCRIPTION
Prevents race detector flagging race between replicator init and `putReplicationStatus` requests (e.g. when you start a replicator, it's possible for `GetStatus` to attempt to read a value that's being changed by the replicator starting up)

- `apr.getPushStatus`/`apr.getPullStatus` accessors read `apr.initialStatus` which is set on replicator checkpointer init, which isn't covered by the RLock

https://jenkins.sgwdev.com/job/Sync%20Gateway%20Pipeline/job/master/181

```
2022-07-20T14:41:42.142Z [INF] HTTP: c:#13998 PUT http://localhost/db/_replicationStatus/replication?action=start (as ADMIN)
2022-07-20T14:41:42.142Z [DBG] Replicate+: c:sgr-mgr-db Initiating replication rebalance.  Nodes: 1  Replications: 1
2022-07-20T14:41:42.142Z [DBG] Replicate+: c:sgr-mgr-db Replication rebalance complete, persistence is pending...
2022-07-20T14:41:42.152Z [DBG] Replicate+: c:sgr-mgr-db Successfully persisted sg-replicate cluster definition.
2022-07-20T14:41:42.153Z [DBG] Replicate+: c:sgr-mgr-db Aligning state for existing replication replication
2022-07-20T14:41:42.153Z [INF] Replicate: Starting replication replication - previous state stopped
2022-07-20T14:41:42.157Z [INF] HTTP: c:#13999 GET /db/ (as ADMIN)
2022-07-20T14:41:42.158Z [WRN] Database db: Unable to get server UUID. Underlying bucket type was not GoCBBucket. -- db.(*DatabaseContext).GetServerUUID() at database.go:641
2022-07-20T14:41:42.164Z [INF] HTTP: c:#14000 GET /db/_blipsync?client=sgr2 (as ADMIN)
2022-07-20T14:41:42.169Z [DBG] Replicate+: c:replication-push got local checkpoint: &{0-6 b604353a755eef2d7c26c773c627bc3afcb1e16f 5 0xc001074b40}
2022-07-20T14:41:42.181Z [DBG] Replicate+: c:replication-push got remote checkpoint: &{0-2 b604353a755eef2d7c26c773c627bc3afcb1e16f 5 <nil>}
2022-07-20T14:41:42.181Z [INF] Replicate: c:replication-push using checkpointed seq: "5"
==================
WARNING: DATA RACE
Write at 0x00c0001d7720 by goroutine 193:
  github.com/couchbase/sync_gateway/db.(*ActivePushReplicator)._initCheckpointer()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/active_replicator_push.go:192 +0x3d2
  github.com/couchbase/sync_gateway/db.(*ActivePushReplicator)._connect()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/active_replicator_push.go:81 +0x32a
  github.com/couchbase/sync_gateway/db.(*ActivePushReplicator).Start()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/active_replicator_push.go:54 +0x3d1
  github.com/couchbase/sync_gateway/db.(*ActiveReplicator).Start()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/active_replicator.go:68 +0xe5
  github.com/couchbase/sync_gateway/db.(*ActiveReplicator).alignState()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/sg_replicate_cfg.go:407 +0x25e
  github.com/couchbase/sync_gateway/db.(*sgReplicateManager).RefreshReplicationCfg()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/sg_replicate_cfg.go:753 +0x94a
  github.com/couchbase/sync_gateway/db.(*sgReplicateManager).SubscribeCfgChanges.func1()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/sg_replicate_cfg.go:811 +0x217

Previous read at 0x00c0001d7720 by goroutine 69:
  github.com/couchbase/sync_gateway/db.(*ActivePushReplicator).getPushStatus()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/active_replicator_push.go:231 +0x484
  github.com/couchbase/sync_gateway/db.(*ActivePushReplicator).GetStatus()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/active_replicator_push.go:213 +0x124
  github.com/couchbase/sync_gateway/db.(*ActiveReplicator).GetStatus()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/active_replicator.go:187 +0x304
  github.com/couchbase/sync_gateway/db.(*sgReplicateManager).GetReplicationStatus()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/sg_replicate_cfg.go:1334 +0x15e
  github.com/couchbase/sync_gateway/db.(*sgReplicateManager).PutReplicationStatus()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/sg_replicate_cfg.go:1394 +0x1b1
  github.com/couchbase/sync_gateway/rest.(*handler).putReplicationStatus()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/admin_api.go:1591 +0x156
  github.com/couchbase/sync_gateway/rest.(*handler).invoke()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/handler.go:454 +0x33f9
  github.com/couchbase/sync_gateway/rest.makeHandler.func1()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/handler.go:126 +0x10c
  net/http.HandlerFunc.ServeHTTP()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.17.11/src/net/http/server.go:2047 +0x4d
  github.com/gorilla/mux.(*Router).ServeHTTP()
      /home/ec2-user/go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0x366
  github.com/couchbase/sync_gateway/rest.wrapRouter.func1()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/routing.go:346 +0x949
  net/http.HandlerFunc.ServeHTTP()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.17.11/src/net/http/server.go:2047 +0x4d
  github.com/couchbase/sync_gateway/rest.(*RestTester).SendAdminRequest()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/utilities_testing.go:605 +0x471
  github.com/couchbase/sync_gateway/rest.TestSGR2TombstoneConflictHandling.func3()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/replicator_test.go:4389 +0x1184
  testing.tRunner()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.17.11/src/testing/testing.go:1259 +0x22f
  testing.(*T).Rundwrap21()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.17.11/src/testing/testing.go:1306 +0x47

Goroutine 193 (running) created at:
  github.com/couchbase/sync_gateway/db.(*sgReplicateManager).SubscribeCfgChanges()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/sg_replicate_cfg.go:802 +0x27c
  github.com/couchbase/sync_gateway/db.(*sgReplicateManager).StartReplications()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/sg_replicate_cfg.go:524 +0x864
  github.com/couchbase/sync_gateway/db.(*DatabaseContext).StartReplications.func1()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/sg_replicate_cfg.go:445 +0x418

Goroutine 69 (running) created at:
  testing.(*T).Run()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.17.11/src/testing/testing.go:1306 +0x726
  github.com/couchbase/sync_gateway/rest.TestSGR2TombstoneConflictHandling()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/replicator_test.go:4176 +0x3cc
  testing.tRunner()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.17.11/src/testing/testing.go:1259 +0x22f
  testing.(*T).Rundwrap21()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.17.11/src/testing/testing.go:1306 +0x47
==================
2022-07-20T14:41:42.182Z [INF] Replicate: c:replication-push Initialized push replication status: &{PullReplicationStatus:{DocsRead:0 DocsCheckedPull:0 DocsPurged:0 RejectedLocal:0 LastSeqPull: DeltasRecv:0 DeltasRequested:0} PushReplicationStatus:{DocsWritten:3 DocsCheckedPush:4 DocWriteFailures:0 DocWriteConflict:0 RejectedRemote:0 LastSeqPush:5 DeltasSent:0} ID: Config:<nil> Status:stopped ErrorMessage:}
2022-07-20T14:41:42.183Z [INF] Sync: c:replication-push Sending changes since 5
```

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/471/
- [x] `-race TestSGR2TombstoneConflictHandling count=5` https://jenkins.sgwdev.com/job/SyncGateway-Integration/472/