### PR TITLE
CBG-2150: Added cluster aware functionality to the resync operation

### DIFF
--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"net/http"
 	"sync"
+	"testing"
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -390,10 +391,19 @@ func (b *BackgroundManager) setRunState(state BackgroundProcessState) {
 }
 
 // Currently only test
-func (b *BackgroundManager) GetRunState() BackgroundProcessState {
+func (b *BackgroundManager) GetRunState(t *testing.T) BackgroundProcessState {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 	return b.State
+}
+
+// For test use only
+// Returns empty string if background process is not cluster aware
+func (b *BackgroundManager) GetHeartbeatDocID(t *testing.T) string {
+	if b.isClusterAware() {
+		return b.clusterAwareOptions.HeartbeatDocID()
+	}
+	return ""
 }
 
 func (b *BackgroundManager) SetError(err error) {

--- a/db/database.go
+++ b/db/database.go
@@ -599,7 +599,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 		// No cleanup necessary, stop heartbeater above will take care of it
 	}
 
-	dbContext.ResyncManager = NewResyncManager()
+	dbContext.ResyncManager = NewResyncManager(bucket)
 	dbContext.TombstoneCompactionManager = NewTombstoneCompactionManager()
 	dbContext.AttachmentCompactionManager = NewAttachmentCompactionManager(bucket)
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2413,7 +2413,7 @@ func TestTombstoneCompactionStopWithManager(t *testing.T) {
 	assert.NoError(t, db.TombstoneCompactionManager.Start(map[string]interface{}{"database": db}))
 
 	waitAndAssertConditionWithOptions(t, func() bool {
-		return db.TombstoneCompactionManager.GetRunState() == BackgroundProcessStateStopped
+		return db.TombstoneCompactionManager.GetRunState(t) == BackgroundProcessStateStopped
 	}, 60, 1000)
 
 	var tombstoneCompactionStatus TombstoneManagerResponse

--- a/docs/api/paths/admin/{keyspace}~_resync.yaml
+++ b/docs/api/paths/admin/{keyspace}~_resync.yaml
@@ -3,7 +3,7 @@ parameters:
 get:
   summary: Get resync status
   description: |-
-    This will retrieve the status of last resync operation (whether it is running or not).
+    This will retrieve the status of last resync operation (whether it is running or not) in the Sync Gateway cluster.
 
     Required Sync Gateway RBAC roles:
     * Sync Gateway Architect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/couchbase/goutils v0.1.2
 	github.com/couchbase/sg-bucket v0.0.0-20220725152948-e1112ff01a3d
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f
-	github.com/couchbaselabs/walrus v0.0.0-20220725155239-d81b0db73299
+	github.com/couchbaselabs/walrus v0.0.0-20220726144228-c44d71d14a7a
 	github.com/elastic/gosigar v0.14.2
 	github.com/felixge/fgprof v0.9.2
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,6 @@ github.com/couchbase/gomemcached v0.1.4 h1:5n5wmr4dBu+X7XteP8QHP5S9inK9MBjNpN9b7
 github.com/couchbase/gomemcached v0.1.4/go.mod h1:mxliKQxOv84gQ0bJWbI+w9Wxdpt9HjDvgW9MjCym5Vo=
 github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9BCs=
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
-github.com/couchbase/sg-bucket v0.0.0-20220722152228-4e219181fb0f h1:rNM7XAcUxnpJq9BTNWzqZkhfHiXU7lGfOg2/+UYXQYQ=
-github.com/couchbase/sg-bucket v0.0.0-20220722152228-4e219181fb0f/go.mod h1:9XQoB1t+elPP+yEjHGOX3xcC3Z0/qDgOI7h/fc9XjlU=
 github.com/couchbase/sg-bucket v0.0.0-20220725152948-e1112ff01a3d h1:cYrMXK8u0FQEKTes5PkRmbkao1EjESwH+6SHc7rDHsE=
 github.com/couchbase/sg-bucket v0.0.0-20220725152948-e1112ff01a3d/go.mod h1:9XQoB1t+elPP+yEjHGOX3xcC3Z0/qDgOI7h/fc9XjlU=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f h1:al5DxXEBAUmINnP5dR950gL47424WzncuRpNdg0TWR0=
@@ -85,10 +83,8 @@ github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f/go.mo
 github.com/couchbaselabs/gocaves/client v0.0.0-20211209111208-6db33aa50187/go.mod h1:AVekAZwIY2stsJOMWLAS/0uA/+qdp7pjO8EHnl61QkY=
 github.com/couchbaselabs/gocaves/client v0.0.0-20211209113245-27e13f721acf h1:Pd0DPZFJwOdCOeHE0SnpAkEJHeqvsMUfeBJVgCOZs5I=
 github.com/couchbaselabs/gocaves/client v0.0.0-20211209113245-27e13f721acf/go.mod h1:AVekAZwIY2stsJOMWLAS/0uA/+qdp7pjO8EHnl61QkY=
-github.com/couchbaselabs/walrus v0.0.0-20220722152754-bfc5c2e08db4 h1:ihM6vMNRr8OL/j7BLyjvUhIrCVUTNQBNgNKyYe1txPg=
-github.com/couchbaselabs/walrus v0.0.0-20220722152754-bfc5c2e08db4/go.mod h1:Vs+du44ZEHbron16thW2q4S66b0nX05Etk7Q78ZyLsY=
-github.com/couchbaselabs/walrus v0.0.0-20220725155239-d81b0db73299 h1:98ld7hcNMo1b4MPZfBcVYs7d1t8l7uLV18Hw1xDkH78=
-github.com/couchbaselabs/walrus v0.0.0-20220725155239-d81b0db73299/go.mod h1:C5TylJ1hRbYFgPnc/6gKUUPkLvkt7xDotgApqzd3dbg=
+github.com/couchbaselabs/walrus v0.0.0-20220726144228-c44d71d14a7a h1:hiVwAQnRHvo1oTYaOhNmxNg1KB0dTC9Htw/zDj0L0TU=
+github.com/couchbaselabs/walrus v0.0.0-20220726144228-c44d71d14a7a/go.mod h1:C5TylJ1hRbYFgPnc/6gKUUPkLvkt7xDotgApqzd3dbg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -4963,3 +4963,56 @@ func TestTombstoneCompactionPurgeInterval(t *testing.T) {
 		})
 	}
 }
+
+// CBG-2150: Tests that resync status is cluster aware
+func TestResyncPersistence(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	tb := base.GetTestBucket(t)
+	noCloseTB := tb.NoCloseClone()
+
+	rt1 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: noCloseTB,
+	})
+
+	rt2 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb,
+	})
+
+	defer rt2.Close()
+	defer rt1.Close()
+
+	// Create a document to process through resync
+	rt1.createDoc(t, "doc1")
+
+	// Start resync
+	resp := rt1.SendAdminRequest("POST", "/db/_offline", "")
+	requireStatus(t, resp, http.StatusOK)
+
+	waitAndAssertCondition(t, func() bool {
+		state := atomic.LoadUint32(&rt1.GetDatabase().State)
+		return state == db.DBOffline
+	})
+
+	resp = rt1.SendAdminRequest("POST", "/db/_resync?action=start", "")
+	requireStatus(t, resp, http.StatusOK)
+
+	// Wait for resync to complete
+	var resyncManagerStatus db.ResyncManagerResponse
+	err := rt1.WaitForCondition(func() bool {
+		resp = rt1.SendAdminRequest("GET", "/db/_resync", "")
+		err := json.Unmarshal(resp.BodyBytes(), &resyncManagerStatus)
+		assert.NoError(t, err)
+		return resyncManagerStatus.State == db.BackgroundProcessStateCompleted
+	})
+	require.NoError(t, err)
+
+	// Check statuses match
+	resp2 := rt2.SendAdminRequest("GET", "/db/_resync", "")
+	requireStatus(t, resp, http.StatusOK)
+	fmt.Printf("RT1 Resync Status: %s\n", resp.BodyBytes())
+	fmt.Printf("RT2 Resync Status: %s\n", resp2.BodyBytes())
+	assert.Equal(t, resp.BodyBytes(), resp2.BodyBytes())
+}

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -3885,7 +3885,7 @@ func TestTombstoneCompaction(t *testing.T) {
 
 		err := rt.WaitForCondition(func() bool {
 			time.Sleep(1 * time.Second)
-			return rt.GetDatabase().TombstoneCompactionManager.GetRunState() == db.BackgroundProcessStateCompleted
+			return rt.GetDatabase().TombstoneCompactionManager.GetRunState(t) == db.BackgroundProcessStateCompleted
 		})
 		assert.NoError(t, err)
 


### PR DESCRIPTION
CBG-2150

- Resync status is now shared between all nodes in the cluster. This means that the stats (i.e. docs changed and docs processed) as well as the background manager stats (such as the state) is now retrievable to all the nodes in the cluster, rather than just the node running the operation.
- Modified Walrus so resync tests will work with Walrus

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...) - not removed in test intentionally for future debugging purposes
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (in-order)
- [x] https://github.com/couchbaselabs/walrus/pull/66
- [x] Update Go mod file to latest Walrus master version
- [x] Rebase on master once https://github.com/couchbase/sync_gateway/pull/5661 is merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/487/