### PR TITLE
[POC] Unsupported flag for CB <6.5 compatibility

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -95,19 +95,22 @@ func GetBaseBucket(b Bucket) Bucket {
 	return b
 }
 
-func ChooseCouchbaseDriver(bucketType CouchbaseBucketType) CouchbaseDriver {
+func ChooseCouchbaseDriver(bucketType CouchbaseBucketType, legacyCompat bool) CouchbaseDriver {
+	if !legacyCompat {
+		return GoCBv2
+	}
 
 	// Otherwise use the default driver for the bucket type
 	// return DefaultDriverForBucketType[bucketType]
 	switch bucketType {
 	case DataBucket:
-		return GoCBv2
+		return GoCBCustomSGTranscoder
 	case IndexBucket:
-		return GoCBv2
+		return GoCB
 	default:
 		// If a new bucket type is added and this method isn't updated, flag a warning (or, could panic)
 		Warnf("Unexpected bucket type: %v", bucketType)
-		return GoCBv2
+		return GoCB
 	}
 
 }

--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -315,10 +315,10 @@ func TestGetStatsVbSeqno(t *testing.T) {
 }
 
 func TestChooseCouchbaseDriver(t *testing.T) {
-	assert.Equal(t, GoCBv2, ChooseCouchbaseDriver(DataBucket))
-	assert.Equal(t, GoCBv2, ChooseCouchbaseDriver(IndexBucket))
+	assert.Equal(t, GoCBv2, ChooseCouchbaseDriver(DataBucket, false))
+	assert.Equal(t, GoCBv2, ChooseCouchbaseDriver(IndexBucket, false))
 	unknownCouchbaseBucketType := CouchbaseBucketType(math.MaxInt8)
-	assert.Equal(t, GoCBv2, ChooseCouchbaseDriver(unknownCouchbaseBucketType))
+	assert.Equal(t, GoCBv2, ChooseCouchbaseDriver(unknownCouchbaseBucketType, false))
 }
 
 func TestCouchbaseDriverToString(t *testing.T) {

--- a/base/connection_string.go
+++ b/base/connection_string.go
@@ -1,0 +1,234 @@
+package base
+
+import (
+	"errors"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// This file adapted from https://github.com/couchbase/tools-common/tree/69822d8835143927e78488b4d0d1f42357077f5d/connstr.
+
+var (
+	// ErrInvalidConnectionString is returned if the part matching regex results in a <nil> return value i.e. it doesn't
+	// match against the input string.
+	ErrInvalidConnectionString = errors.New("invalid connection string")
+
+	// ErrNoAddressesParsed is returned when the resulting parsed connection string doesn't contain any addresses.
+	ErrNoAddressesParsed = errors.New("parsed connection string contains no addresses")
+
+	// ErrNoAddressesResolved is returned when the resolved connection string doesn't contain any addresses.
+	ErrNoAddressesResolved = errors.New("resolved connection string contains no addresses")
+
+	// ErrBadScheme is returned if the user supplied a scheme that's not supported. Currently 'http', 'https',
+	// 'couchbase' and 'couchbases' are supported.
+	ErrBadScheme = errors.New("bad scheme")
+
+	// ErrBadPort is returned if the parsed port is an invalid 16 bit unsigned integer.
+	ErrBadPort = errors.New("bad port")
+)
+
+const (
+	// DefaultHTTPPort is the default http management port for Couchbase Server. Will be used when no port is supplied
+	// when using a non-ssl scheme.
+	DefaultHTTPPort = 8091
+
+	// DefaultHTTPSPort is the default https management port for Couchbase Server. Will be used when no port is supplied
+	// when using a ssl scheme.
+	DefaultHTTPSPort = 18091
+)
+
+// Address represents an address used to connect to Couchbase Server. Should not be used directly i.e. access should be
+// provided through a 'ConnectionString' or a 'ResolvedConnectionString'.
+type Address struct {
+	Host string
+	Port uint16
+}
+
+// ConnectionString represents a connection string that can be supplied to the 'backup' tools to give the tools a node
+// or nodes in a cluster to bootstrap from.
+type ConnectionString struct {
+	Scheme    string
+	Addresses []Address
+}
+
+// ResolvedConnectionString is similar to a 'ConnectionString', however, addresses are resolved i.e. ports/schemes are
+// converted into something that we can use to bootstrap from.
+//
+// NOTE: If provided with a valid srv record (an address with the scheme 'couchbase' or 'couchbases', and no port). This
+// function will lookup the srv record and use those addresses.
+type ResolvedConnectionString struct {
+	UseSSL    bool
+	Addresses []Address
+}
+
+var validSchemes = SetOf("", "http", "https", "couchbase", "couchbases")
+
+// ParseConnectionString the given connection string and perform first tier validation i.e. it's possible for a parsed connection string
+// to fail when the 'Resolve' function is called.
+//
+// For more information on the connection string formats accepted by this function, refer to the host formats
+// documentation at https://docs.couchbase.com/server/7.0/backup-restore/cbbackupmgr-backup.html#host-formats.
+func ParseConnectionString(connectionString string) (*ConnectionString, error) {
+	// partMatcher matches and groups the different parts of a given connection string. For example:
+	// couchbases://10.0.0.1:11222,10.0.0.2,10.0.0.3:11207
+	// Group 1: couchbases://
+	// Group 2: couchbases
+	// Group 7: 10.0.0.1:11222,10.0.0.2,10.0.0.3:11207
+	partMatcher := regexp.MustCompile(`((.*):\/\/)?(([^\/?:]*)(:([^\/?:@]*))?@)?([^\/?]*)(\/([^\?]*))?`)
+
+	// hostMatcher matches and groups different parts of a comma separated list of hostname in a connection string.
+	// For example:
+	// 10.0.0.1:11222,10.0.0.2,10.0.0.3:11207
+	// Match 1:
+	//   Group 1: 10.0.0.1
+	//   Group 3: 10.0.0.1
+	//   Group 4: :11222
+	//   Group 5: 11222
+	// Match 2:
+	//   Group 1: 10.0.0.2
+	//   Group 3: 10.0.0.2
+	//   Group 4:
+	//   Group 5:
+	// Match 3:
+	//   Group 1: 10.0.0.3
+	//   Group 3: 10.0.0.3
+	//   Group 4: :11222
+	//   Group 5: 11222
+	hostMatcher := regexp.MustCompile(`((\[[^\]]+\]+)|([^;\,\:]+))(:([0-9]*))?(;\,)?`)
+
+	parts := partMatcher.FindStringSubmatch(connectionString)
+	if parts == nil {
+		return nil, ErrInvalidConnectionString
+	}
+
+	parsed := &ConnectionString{
+		Scheme: parts[2],
+	}
+
+	if !validSchemes.Contains(parsed.Scheme) {
+		return nil, ErrBadScheme
+	}
+
+	// We don't need to check if 'FindAllStringSubmatch' returns <nil> since ranging over a <nil> slice results in no
+	// iterations. We will then return an 'ErrNoAddressesParsed' error which is more informative than
+	// 'ErrInvalidConnectionString'.
+	for _, hostInfo := range hostMatcher.FindAllStringSubmatch(parts[7], -1) {
+		address := Address{
+			Host: hostInfo[1],
+		}
+
+		if hostInfo[5] != "" {
+			port, err := strconv.ParseUint(hostInfo[5], 10, 16)
+			if err != nil {
+				return nil, ErrBadPort
+			}
+
+			address.Port = uint16(port)
+		}
+
+		parsed.Addresses = append(parsed.Addresses, address)
+	}
+
+	if len(parsed.Addresses) == 0 {
+		return nil, ErrNoAddressesParsed
+	}
+
+	return parsed, nil
+}
+
+// Resolve the current connection string and return addresses which can be used to bootstrap from. Will perform
+// additional validation, once resolved the connection string is valid and can be used.
+func (c *ConnectionString) Resolve() (*ResolvedConnectionString, error) {
+	var (
+		defaultPort uint16
+		resolved    = &ResolvedConnectionString{}
+	)
+
+	switch c.Scheme {
+	case "http", "couchbase":
+		defaultPort = DefaultHTTPPort
+	case "https", "couchbases":
+		defaultPort = DefaultHTTPSPort
+		resolved.UseSSL = true
+	case "":
+		defaultPort = DefaultHTTPPort
+	default:
+		return nil, ErrBadScheme
+	}
+
+	if resolved := c.resolveSRV(); resolved != nil {
+		return resolved, nil
+	}
+
+	for _, address := range c.Addresses {
+		resolvedAddress := Address{
+			Host: address.Host,
+			Port: address.Port,
+		}
+
+		if address.Port == 0 || address.Port == defaultPort || address.Port == DefaultHTTPPort {
+			resolvedAddress.Port = DefaultHTTPPort
+			if resolved.UseSSL {
+				resolvedAddress.Port = DefaultHTTPSPort
+			}
+		}
+
+		resolved.Addresses = append(resolved.Addresses, resolvedAddress)
+	}
+
+	if len(resolved.Addresses) == 0 {
+		return nil, ErrNoAddressesResolved
+	}
+
+	return resolved, nil
+}
+
+// resolveSRV attempts to resolve the connection string as an srv record, the resulting connection string will be
+// non-nil if it was a valid srv record containing one or more addresses.
+func (c *ConnectionString) resolveSRV() *ResolvedConnectionString {
+	validScheme := func(scheme string) bool {
+		return scheme == "couchbase" || scheme == "couchbases"
+	}
+
+	validHostnameNoIP := func(addresses []Address) bool {
+		return len(addresses) == 1 && addresses[0].Port == 0
+	}
+
+	validIP := func(address string) bool {
+		return strings.Contains(address, ":") || net.ParseIP(address) != nil
+	}
+
+	if !validScheme(c.Scheme) || !validHostnameNoIP(c.Addresses) || validIP(c.Addresses[0].Host) {
+		return nil
+	}
+
+	_, servers, err := net.LookupSRV(c.Scheme, "tcp", c.Addresses[0].Host)
+	if err != nil || len(servers) <= 0 {
+		return nil
+	}
+
+	resolved := &ResolvedConnectionString{
+		UseSSL: c.Scheme == "couchbases",
+	}
+
+	for _, server := range servers {
+		resolved.Addresses = append(resolved.Addresses, Address{
+			Host: strings.TrimSuffix(server.Target, "."),
+			Port: srvPort(c.Scheme),
+		})
+	}
+
+	return resolved
+}
+
+// srvPort - Returns the port which should be used when resolving an SRV record. We don't use the port from the record
+// itself since by default, it points to the KV port.
+func srvPort(scheme string) uint16 {
+	if scheme == "couchbases" {
+		return DefaultHTTPSPort
+	}
+
+	return DefaultHTTPPort
+}

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -750,7 +750,7 @@ func TestClusterPassword() string {
 }
 
 func TestClusterDriver() CouchbaseDriver {
-	driver := ChooseCouchbaseDriver(DataBucket)
+	driver := ChooseCouchbaseDriver(DataBucket, false)
 	if envClusterDriver := os.Getenv(envTestClusterDriver); envClusterDriver != "" {
 		driver = AsCouchbaseDriver(envClusterDriver)
 	}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1720,7 +1720,7 @@ func BenchmarkDatabase(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		bucket, _ := ConnectToBucket(base.BucketSpec{
 			Server:          base.UnitTestUrl(),
-			CouchbaseDriver: base.ChooseCouchbaseDriver(base.DataBucket),
+			CouchbaseDriver: base.ChooseCouchbaseDriver(base.DataBucket, false),
 			BucketName:      fmt.Sprintf("b-%d", i)})
 		context, _ := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{})
 		db, _ := CreateDatabase(context)
@@ -1737,7 +1737,7 @@ func BenchmarkPut(b *testing.B) {
 
 	bucket, _ := ConnectToBucket(base.BucketSpec{
 		Server:          base.UnitTestUrl(),
-		CouchbaseDriver: base.ChooseCouchbaseDriver(base.DataBucket),
+		CouchbaseDriver: base.ChooseCouchbaseDriver(base.DataBucket, false),
 		BucketName:      "Bucket"})
 	context, _ := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{})
 	db, _ := CreateDatabase(context)

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -117,9 +117,10 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"replicator.max_heartbeat":    {&config.Replicator.MaxHeartbeat, fs.String("replicator.max_heartbeat", "", "Max heartbeat value for _changes request")},
 		"replicator.blip_compression": {&config.Replicator.BLIPCompression, fs.Int("replicator.blip_compression", 0, "BLIP data compression level (0-9)")},
 
-		"unsupported.stats_log_frequency": {&config.Unsupported.StatsLogFrequency, fs.String("unsupported.stats_log_frequency", "", "How often should stats be written to stats logs")},
-		"unsupported.use_stdlib_json":     {&config.Unsupported.UseStdlibJSON, fs.Bool("unsupported.use_stdlib_json", false, "Bypass the jsoniter package and use Go's stdlib instead")},
-		"unsupported.use_xattr_config":    {&config.Unsupported.UseXattrConfig, fs.Bool("unsupported.use_xattr_config", false, "Store database configurations in system xattrs")},
+		"unsupported.stats_log_frequency":         {&config.Unsupported.StatsLogFrequency, fs.String("unsupported.stats_log_frequency", "", "How often should stats be written to stats logs")},
+		"unsupported.use_stdlib_json":             {&config.Unsupported.UseStdlibJSON, fs.Bool("unsupported.use_stdlib_json", false, "Bypass the jsoniter package and use Go's stdlib instead")},
+		"unsupported.use_xattr_config":            {&config.Unsupported.UseXattrConfig, fs.Bool("unsupported.use_xattr_config", false, "Store database configurations in system xattrs")},
+		"unsupported.legacy_server_compatibility": {&config.Unsupported.LegacyServerCompat, fs.Bool("unsupported.legacy_server_compatibility", false, "Enable support for Couchbase Server <6.5")},
 
 		"unsupported.http2.enabled": {&config.Unsupported.HTTP2.Enabled, fs.Bool("unsupported.http2.enabled", false, "Whether HTTP2 support is enabled")},
 

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -192,7 +192,7 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 			}
 		}
 		if lc.Unsupported.LegacyServerCompat != nil {
-			sc.Unsupported.LegacyServerCompat = *lc.Unsupported.LegacyServerCompat
+			sc.Unsupported.LegacyServerCompat = lc.Unsupported.LegacyServerCompat
 		}
 	}
 

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -97,6 +97,7 @@ type UnsupportedServerConfigLegacy struct {
 	Http2Config           *HTTP2Config `json:"http2,omitempty"`               // Config settings for HTTP2
 	StatsLogFrequencySecs *uint        `json:"stats_log_freq_secs,omitempty"` // How often should stats be written to stats logs
 	UseStdlibJSON         *bool        `json:"use_stdlib_json,omitempty"`     // Bypass the jsoniter package and use Go's stdlib instead
+	LegacyServerCompat    *bool        `json:"legacy_server_compatibility"`   // Disable use of gocb v2 (CBG-2218)
 }
 
 // ToStartupConfig returns the given LegacyServerConfig as a StartupConfig and a set of DBConfigs.
@@ -189,6 +190,9 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 			sc.Unsupported.HTTP2 = &HTTP2Config{
 				Enabled: lc.Unsupported.Http2Config.Enabled,
 			}
+		}
+		if lc.Unsupported.LegacyServerCompat != nil {
+			sc.Unsupported.LegacyServerCompat = *lc.Unsupported.LegacyServerCompat
 		}
 	}
 

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -134,9 +134,10 @@ type ReplicatorConfig struct {
 }
 
 type UnsupportedConfig struct {
-	StatsLogFrequency *base.ConfigDuration `json:"stats_log_frequency,omitempty"    help:"How often should stats be written to stats logs"`
-	UseStdlibJSON     *bool                `json:"use_stdlib_json,omitempty"        help:"Bypass the jsoniter package and use Go's stdlib instead"`
-	UseXattrConfig    *bool                `json:"use_xattr_config,omitempty"       help:"Store database configurations in system xattrs"`
+	StatsLogFrequency  *base.ConfigDuration `json:"stats_log_frequency,omitempty"    help:"How often should stats be written to stats logs"`
+	UseStdlibJSON      *bool                `json:"use_stdlib_json,omitempty"        help:"Bypass the jsoniter package and use Go's stdlib instead"`
+	UseXattrConfig     *bool                `json:"use_xattr_config,omitempty"       help:"Store database configurations in system xattrs"`
+	LegacyServerCompat bool                 `json:"legacy_server_compatibility"` // Disable use of gocb v2 (CBG-2218)
 
 	HTTP2 *HTTP2Config `json:"http2,omitempty"`
 }

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -137,7 +137,7 @@ type UnsupportedConfig struct {
 	StatsLogFrequency  *base.ConfigDuration `json:"stats_log_frequency,omitempty"    help:"How often should stats be written to stats logs"`
 	UseStdlibJSON      *bool                `json:"use_stdlib_json,omitempty"        help:"Bypass the jsoniter package and use Go's stdlib instead"`
 	UseXattrConfig     *bool                `json:"use_xattr_config,omitempty"       help:"Store database configurations in system xattrs"`
-	LegacyServerCompat bool                 `json:"legacy_server_compatibility"` // Disable use of gocb v2 (CBG-2218)
+	LegacyServerCompat *bool                `json:"legacy_server_compatibility"` // Disable use of gocb v2 (CBG-2218)
 
 	HTTP2 *HTTP2Config `json:"http2,omitempty"`
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -109,7 +109,7 @@ func NewServerContext(config *StartupConfig, persistentConfig bool) *ServerConte
 		hasStarted:       make(chan struct{}),
 	}
 
-	if config.Unsupported.LegacyServerCompat {
+	if base.BoolDefault(config.Unsupported.LegacyServerCompat, false) {
 		base.Warnf("legacy_server_compatibility is enabled. This flag is unsupported and will be removed in the next version of Sync Gateway." +
 			" Please upgrade to Couchbase Server 6.5 or above before upgrading Sync Gateway.")
 	}
@@ -350,7 +350,7 @@ func GetBucketSpec(config *DatabaseConfig, serverConfig *StartupConfig) (spec ba
 
 	spec.FeedType = strings.ToLower(config.FeedType)
 
-	spec.CouchbaseDriver = base.ChooseCouchbaseDriver(base.DataBucket, serverConfig.Unsupported.LegacyServerCompat)
+	spec.CouchbaseDriver = base.ChooseCouchbaseDriver(base.DataBucket, base.BoolDefault(serverConfig.Unsupported.LegacyServerCompat, false))
 
 	if config.ViewQueryTimeoutSecs != nil {
 		spec.ViewQueryTimeoutSecs = config.ViewQueryTimeoutSecs
@@ -1485,7 +1485,7 @@ func (sc *ServerContext) Database(name string) *db.DatabaseContext {
 }
 
 func (sc *ServerContext) initializeCouchbaseServerConnections() error {
-	if sc.config.Unsupported.LegacyServerCompat {
+	if base.BoolDefault(sc.config.Unsupported.LegacyServerCompat, false) {
 		// HACK: In legacy compat we can't use gocb to retrieve the management endpoints, instead parse the connection
 		// string and use those endpoints.
 		err := sc.resolveManagementEndpoints()

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -344,7 +344,7 @@ func GetBucketSpec(config *DatabaseConfig, serverConfig *StartupConfig) (spec ba
 
 	spec.FeedType = strings.ToLower(config.FeedType)
 
-	spec.CouchbaseDriver = base.ChooseCouchbaseDriver(base.DataBucket)
+	spec.CouchbaseDriver = base.ChooseCouchbaseDriver(base.DataBucket, serverConfig.Unsupported.LegacyServerCompat)
 
 	if config.ViewQueryTimeoutSecs != nil {
 		spec.ViewQueryTimeoutSecs = config.ViewQueryTimeoutSecs
@@ -1475,12 +1475,15 @@ func (sc *ServerContext) Database(name string) *db.DatabaseContext {
 }
 
 func (sc *ServerContext) initializeCouchbaseServerConnections() error {
-	goCBAgent, err := sc.initializeGoCBAgent()
-	if err != nil {
-		return err
+	if !sc.config.Unsupported.LegacyServerCompat {
+		goCBAgent, err := sc.initializeGoCBAgent()
+		if err != nil {
+			return err
+		}
+		sc.GoCBAgent = goCBAgent
 	}
-	sc.GoCBAgent = goCBAgent
 
+	var err error
 	sc.NoX509HTTPClient, err = sc.initializeNoX509HttpClient()
 	if err != nil {
 		return err


### PR DESCRIPTION
This is a proof-of-concept of an unsupported flag to address CBG-2217/CBG-2218 by disabling all code that uses GoCB v2 (since it relies on GCCCP which is only introduced in 6.5). This flag is only available in legacy config mode because persistent config uses gocb v2 for config polling.