### PR TITLE
[3.0.4] CBG-2156: Fix resetting disable_password_auth to false (#5562)

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -4093,6 +4093,20 @@ func TestEmptyStringJavascriptFunctions(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 }
 
+// Regression test for CBG-2119 - ensure that the disable_password_auth bool field is handled correctly both when set as true and as false
+func TestDisablePasswordAuthThroughAdminAPI(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{})
+	defer rt.Close()
+
+	res := rt.SendAdminRequest(http.MethodPost, "/db/_config", `{"bucket":"`+rt.Bucket().GetName()+`","num_index_replicas":0,"disable_password_auth": true}`)
+	assertStatus(t, res, http.StatusCreated)
+	assert.True(t, rt.GetDatabase().Options.DisablePasswordAuthentication)
+
+	res = rt.SendAdminRequest(http.MethodPost, "/db/_config", `{"bucket":"`+rt.Bucket().GetName()+`","num_index_replicas":0,"disable_password_auth": false}`)
+	assertStatus(t, res, http.StatusCreated)
+	assert.False(t, rt.GetDatabase().Options.DisablePasswordAuthentication)
+}
+
 // Tests replications to make sure they are namespaced by group ID
 func TestGroupIDReplications(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() || !base.TestUseXattrs() {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -95,7 +95,7 @@ func TestDisablePublicBasicAuth(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
-				DisablePasswordAuth: true,
+				DisablePasswordAuth: base.BoolPtr(true),
 				Guest: &db.PrincipalConfig{
 					Disabled: base.BoolPtr(true),
 				},

--- a/rest/config.go
+++ b/rest/config.go
@@ -141,7 +141,7 @@ type DbConfig struct {
 	NumIndexReplicas                 *uint                            `json:"num_index_replicas,omitempty"`                   // Number of GSI index replicas used for core indexes
 	UseViews                         *bool                            `json:"use_views,omitempty"`                            // Force use of views instead of GSI
 	SendWWWAuthenticateHeader        *bool                            `json:"send_www_authenticate_header,omitempty"`         // If false, disables setting of 'WWW-Authenticate' header in 401 responses. Implicitly false if disable_password_auth is true.
-	DisablePasswordAuth              bool                             `json:"disable_password_auth,omitempty"`                // If true, disables user/pass authentication, only permitting OIDC or guest access
+	DisablePasswordAuth              *bool                            `json:"disable_password_auth,omitempty"`                // If true, disables user/pass authentication, only permitting OIDC or guest access
 	BucketOpTimeoutMs                *uint32                          `json:"bucket_op_timeout_ms,omitempty"`                 // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
 	SlowQueryWarningThresholdMs      *uint32                          `json:"slow_query_warning_threshold,omitempty"`         // Log warnings if N1QL queries take this many ms
 	DeltaSync                        *DeltaSyncConfig                 `json:"delta_sync,omitempty"`                           // Config for delta sync

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -399,7 +399,7 @@ func TestOIDCWithBasicAuthDisabled(t *testing.T) {
 					Enabled: true,
 				},
 			},
-			DisablePasswordAuth: true,
+			DisablePasswordAuth: base.BoolPtr(true),
 		}}}
 	restTester := NewRestTester(t, &restTesterConfig)
 	require.NoError(t, restTester.SetAdminParty(false))

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -768,7 +768,7 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 
 	// If basic auth is disabled, it doesn't make sense to send WWW-Authenticate
 	sendWWWAuthenticate := config.SendWWWAuthenticateHeader
-	if config.DisablePasswordAuth {
+	if base.BoolDefault(config.DisablePasswordAuth, false) {
 		sendWWWAuthenticate = base.BoolPtr(false)
 	}
 
@@ -791,7 +791,7 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		SessionCookieHttpOnly:         base.BoolDefault(config.SessionCookieHTTPOnly, false),
 		AllowConflicts:                config.ConflictsAllowed(),
 		SendWWWAuthenticateHeader:     sendWWWAuthenticate,
-		DisablePasswordAuthentication: config.DisablePasswordAuth,
+		DisablePasswordAuthentication: base.BoolDefault(config.DisablePasswordAuth, false),
 		DeltaSyncOptions:              deltaSyncOptions,
 		CompactInterval:               compactIntervalSecs,
 		QueryPaginationLimit:          queryPaginationLimit,


### PR DESCRIPTION
Cherry-picks #5562 to 3.0.4

## Dependencies
- [x] rebase on #5654 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] n/a (covered by `TestDisablePasswordAuthThroughAdminAPI` unit test) 