### PR TITLE
[3.0.4] CBG-2168: Fix replication panic w/ non-existent role in user role history (#5611)

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -128,6 +128,7 @@ func (auth *Authenticator) GetRoleIncDeleted(name string) (Role, error) {
 }
 
 // Common implementation of GetUser and GetRole. factory() parameter returns a new empty instance.
+// Returns (nil, nil) if the principal doesn't exist, or (nil, error) if getting it failed for some reason.
 func (auth *Authenticator) getPrincipal(docID string, factory func() Principal) (Principal, error) {
 	var princ Principal
 

--- a/auth/user.go
+++ b/auth/user.go
@@ -10,6 +10,7 @@ package auth
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math"
 	"net/http"
@@ -380,7 +381,7 @@ func (user *userImpl) ChannelGrantedPeriods(chanName string) ([]GrantHistorySequ
 			// However, it's also possible (though rare) that the role used to exist but was explicitly purged, and thus
 			// could have granted access to channels before it was purged - but we can't determine what those channels were.
 			// We can't distinguish these cases, so log to be safe.
-			base.WarnfCtx(user.auth.LogCtx, "Unable to determine complete access history for user %v because role %v doesn't exist or has been purged (for channel %v).", base.UD(user.Name()), base.UD(roleName), base.UD(chanName))
+			base.WarnfCtx(context.TODO(), "Unable to determine complete access history for user %v because role %v doesn't exist or has been purged (for channel %v).", base.UD(user.Name()), base.UD(roleName), base.UD(chanName))
 			continue
 		}
 

--- a/auth/user.go
+++ b/auth/user.go
@@ -375,6 +375,14 @@ func (user *userImpl) ChannelGrantedPeriods(chanName string) ([]GrantHistorySequ
 		if err != nil {
 			return nil, err
 		}
+		if role == nil {
+			// In most cases, this means the role never existed (and therefore didn't affect access).
+			// However, it's also possible (though rare) that the role used to exist but was explicitly purged, and thus
+			// could have granted access to channels before it was purged - but we can't determine what those channels were.
+			// We can't distinguish these cases, so log to be safe.
+			base.WarnfCtx(user.auth.LogCtx, "Unable to determine complete access history for user %v because role %v doesn't exist or has been purged (for channel %v).", base.UD(user.Name()), base.UD(roleName), base.UD(chanName))
+			continue
+		}
 
 		// Iterate over channel history on old roles
 		roleChannelHistory, ok := role.ChannelHistory()[chanName]

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -4382,3 +4382,41 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 	require.True(t, errors.Is(err, sgbucket.MissingError{Key: v2Key}))
 
 }
+
+// Regression test for CBG-2183.
+func TestBlipRevokeNonExistentRole(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		guestEnabled: false,
+	})
+	defer rt.Close()
+
+	base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
+
+	// 1. Create user with admin_roles including two roles not previously defined (a1 and a2, for example)
+	const testUsername = "bilbo"
+	res := rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/_user/%s", rt.GetDatabase().Name, testUsername), fmt.Sprintf(`{"name": %q, "password": "test", "admin_roles": ["a1", "a2"], "admin_channels": ["c1"]}`, testUsername))
+	assertStatus(t, res, http.StatusCreated)
+
+	// Create a doc so we have something to replicate
+	res = rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/testdoc", rt.GetDatabase().Name), `{"channels": ["c1"]}`)
+	assertStatus(t, res, http.StatusCreated)
+
+	// 3. Update the user to not reference one of the roles (update to ['a1'], for example)
+	// [also revoke channel c1 so the doc shows up in the revocation queries]
+	res = rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/_user/%s", rt.GetDatabase().Name, testUsername), fmt.Sprintf(`{"name": %q, "password": "test", "admin_roles": ["a1"], "admin_channels": []}`, testUsername))
+	assertStatus(t, res, http.StatusOK)
+
+	// 4. Try to sync
+	bt, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+		Username:        testUsername,
+		SendRevocations: true,
+	})
+	require.NoError(t, err)
+	defer bt.Close()
+
+	require.NoError(t, bt.StartPull())
+	// in the failing case we'll panic before hitting this
+	base.WaitForStat(func() int64 {
+		return rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplCaughtUp.Value()
+	}, 1)
+}

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -4390,7 +4390,7 @@ func TestBlipRevokeNonExistentRole(t *testing.T) {
 	})
 	defer rt.Close()
 
-	base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 
 	// 1. Create user with admin_roles including two roles not previously defined (a1 and a2, for example)
 	const testUsername = "bilbo"


### PR DESCRIPTION
Cherry-picks #5611 to 3.0.4

## Dependencies
- [x] rebase on #5654 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] n/a (covered by unit test `TestBlipRevokeNonExistentRole`)