### PR TITLE
[3.0.4] CBG-2202: Principal name restrictions tweaks (#5506 / #5609)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -380,7 +380,7 @@ pipeline {
             cobertura autoUpdateHealth: false, onlyStable: false, autoUpdateStability: false, coberturaReportFile: 'reports/coverage-*.xml', conditionalCoverageTargets: '70, 0, 0', failNoReports: false, failUnhealthy: false, failUnstable: false, lineCoverageTargets: '80, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '80, 0, 0', sourceEncoding: 'ASCII', zoomCoverageChart: false
 
             // Publish the junit test reports
-            junit allowEmptyResults: true, testDataPublishers: [[$class: 'JUnitFlakyTestDataPublisher']], testResults: 'reports/test-*.xml'
+            junit allowEmptyResults: true, testResults: 'reports/test-*.xml'
 
             step([$class: 'WsCleanup'])
             sh "go clean -cache"

--- a/auth/role.go
+++ b/auth/role.go
@@ -10,6 +10,7 @@ package auth
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -104,8 +105,12 @@ func (role *roleImpl) initRole(name string, channels base.Set) error {
 // IsValidPrincipalName checks if the given user/role name would be valid. Valid names must be valid UTF-8, containing
 // at least one alphanumeric (except for the guest user), and no colons, commas, backticks, or slashes.
 func IsValidPrincipalName(name string) bool {
-	if len(name) == 0 {
+	namelen := len(name)
+	if namelen == 0 {
 		return true // guest user
+	}
+	if namelen > base.MaxPrincipalNameLen {
+		return false
 	}
 	if !utf8.ValidString(name) {
 		return false
@@ -125,6 +130,64 @@ func IsValidPrincipalName(name string) bool {
 		}
 	}
 	return seenAnAlphanum
+}
+
+// ValidatePrincipalName performs the same checks as IsValidPrincipalName, but adds length check and retuns a more
+// verbose error message.  This function is slower than IsValidPrincipalName, and should be used only for user
+// and role creation.  Names should have a max length of 239 chars, to account for SG prefixes.  All validation
+// errors are concatenated and returned as one error message.
+func ValidatePrincipalName(name string) error {
+	namelen := len(name)
+	if namelen == 0 {
+		return nil // guest user
+	}
+
+	const validationMsg = "invalid name: "
+	msgs := make([]string, 0, 4)
+
+	if namelen > base.MaxPrincipalNameLen {
+		const msg = "length exceeds 239" // leaving as const to avoid fmt performance (21% slower)
+		msgs = append(msgs, msg)
+	}
+
+	if !utf8.ValidString(name) {
+		const msg = "non UTF-8 encoding"
+		msgs = append(msgs, msg)
+	}
+
+	seenAnInvalid := false
+	seenAnAlphanum := false
+	for _, char := range name {
+		// Reasons for forbidding each of these:
+		// colons: basic authentication uses them to separate usernames from passwords
+		// commas: fails channels.IsValidChannel, which channels.compileAccessMap uses via SetFromArray
+		// slashes: would need to make many (possibly breaking) changes to routing
+		// backticks: MB-50619
+		if (char == '/' || char == ':' || char == ',' || char == '`') && !seenAnInvalid {
+			seenAnInvalid = true
+			const msg = "contains '/', ':', ',', or '`'"
+			msgs = append(msgs, msg)
+			if seenAnAlphanum {
+				break
+			}
+		}
+		if !seenAnAlphanum && (unicode.IsLetter(char) || unicode.IsNumber(char)) {
+			seenAnAlphanum = true
+			if seenAnInvalid {
+				break
+			}
+		}
+	}
+
+	if !seenAnAlphanum {
+		const msg = "must contain alphanumeric"
+		msgs = append(msgs, msg)
+	}
+
+	if len(msgs) > 0 {
+		return errors.New(validationMsg + strings.Join(msgs, "; "))
+	}
+	return nil
 }
 
 // Creates a new Role object.

--- a/auth/role_test.go
+++ b/auth/role_test.go
@@ -149,7 +149,7 @@ func BenchmarkValidatePrincipalName(b *testing.B) {
 	for _, tc := range testcases {
 		b.Run(tc.desc, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				ValidatePrincipalName(tc.name)
+				_ = ValidatePrincipalName(tc.name)
 			}
 		})
 

--- a/auth/role_test.go
+++ b/auth/role_test.go
@@ -56,14 +56,102 @@ func TestAuthorizeChannelsRole(t *testing.T) {
 }
 
 func BenchmarkIsValidPrincipalName(b *testing.B) {
-	const nameLength = 50
+	const nameLength = 25
 	name := strings.Builder{}
 	for i := 0; i < nameLength; i++ {
 		name.WriteRune(rune(rand.Intn('z'-'a') + 'a'))
 	}
 	nameStr := name.String()
+
+	testcases := []struct {
+		desc string
+		name string
+	}{
+		{desc: "valid name", name: nameStr + nameStr},
+		{desc: "invalid char", name: nameStr + "/" + nameStr}, // negative case for comparison with validate func
+	}
+
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		IsValidPrincipalName(nameStr)
+	for _, tc := range testcases {
+		b.Run(tc.desc, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				IsValidPrincipalName(tc.name)
+			}
+		})
+
+	}
+}
+
+func TestValidatePrincipalName(t *testing.T) {
+	getName := func(l int) string {
+		name := strings.Builder{}
+		for i := 0; i < l; i++ {
+			name.WriteRune(rune(rand.Intn('z'-'a') + 'a'))
+		}
+		return name.String()
+	}
+	name25 := getName(25)
+	name50 := getName(50)
+	name240 := getName(240)
+	nonUTF := "\xc3\x28"
+	noAlpha := "!@#$%"
+
+	testcases := []struct {
+		desc   string
+		name   string
+		expect string
+	}{
+		{desc: "valid name", name: name50, expect: ""},
+		{desc: "valid guest", name: "", expect: ""},
+		{desc: "invalid char", name: name25 + "/" + name25, expect: "contains '/', ':', ',', or '`'"},
+		{desc: "invalid length", name: name240, expect: "length exceeds"},
+		{desc: "invalid utf-8", name: nonUTF, expect: "non UTF-8 encoding"},
+		{desc: "invalid no alpha", name: noAlpha, expect: "must contain alphanumeric"},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := ValidatePrincipalName(tc.name)
+			if tc.expect == "" {
+				assert.Nil(t, err)
+				assert.True(t, IsValidPrincipalName(tc.name)) // assert compatible with older function
+			} else if assert.NotNil(t, err) {
+				t.Log("msg: ", err.Error())
+				assert.Contains(t, err.Error(), tc.expect)
+				assert.False(t, IsValidPrincipalName(tc.name))
+			}
+		})
+	}
+}
+
+func BenchmarkValidatePrincipalName(b *testing.B) {
+	getName := func(l int) string {
+		name := strings.Builder{}
+		for i := 0; i < l; i++ {
+			name.WriteRune(rune(rand.Intn('z'-'a') + 'a'))
+		}
+		return name.String()
+	}
+	name25 := getName(25)
+	name50 := getName(50)
+	name251 := getName(251)
+
+	testcases := []struct {
+		desc string
+		name string
+	}{
+		{desc: "valid name", name: name50},
+		{desc: "invalid char", name: name25 + "/" + name25},
+		{desc: "invalid length", name: name251},
+	}
+
+	b.ResetTimer()
+	for _, tc := range testcases {
+		b.Run(tc.desc, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				ValidatePrincipalName(tc.name)
+			}
+		})
+
 	}
 }

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -212,6 +212,39 @@ func TestIsValidEmail(t *testing.T) {
 
 }
 
+func TestInvalidUsernamesRejected(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Username string
+	}{
+		{
+			Name:     "colons",
+			Username: "foo:bar",
+		},
+		{
+			Name:     "commas",
+			Username: "foo,bar",
+		},
+		{
+			Name:     "slashes",
+			Username: "foo/bar",
+		},
+		{
+			Name:     "no alphanumeric",
+			Username: "..",
+		},
+		{
+			Name:     "invalid UTF-8",
+			Username: "foo\xf9bar",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			require.False(t, IsValidPrincipalName(tc.Username), "expected '%s' to be rejected", tc.Username)
+		})
+	}
+}
+
 func TestCanSeeChannelSince(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
 	testBucket := base.GetTestBucket(t)

--- a/base/constants.go
+++ b/base/constants.go
@@ -193,6 +193,9 @@ var (
 
 	// ErrUnknownField is marked as the cause of the error when trying to decode a JSON snippet with unknown fields
 	ErrUnknownField = errors.New("unrecognized JSON field")
+
+	// MaxPrincipalNameLen is the maximum length for user and role names, accounting for internal prefixes, and is used to validate CRUD
+	MaxPrincipalNameLen = 250 - MaxInt(len(UserPrefix), len(RolePrefix))
 )
 
 func DCPCheckpointPrefixWithGroupID(groupID string) string {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1370,15 +1370,15 @@ func TestAccessFunctionValidation(t *testing.T) {
 	_, _, err = db.Put("doc2", body)
 	assert.NoError(t, err, "")
 
-	body = Body{"users": []string{"bad username"}, "userChannels": []string{"BBC1"}}
+	body = Body{"users": []string{"bad,username"}, "userChannels": []string{"BBC1"}}
 	_, _, err = db.Put("doc3", body)
 	assertHTTPError(t, err, 500)
 
-	body = Body{"users": []string{"role:bad rolename"}, "userChannels": []string{"BBC1"}}
+	body = Body{"users": []string{"role:bad:rolename"}, "userChannels": []string{"BBC1"}}
 	_, _, err = db.Put("doc4", body)
 	assertHTTPError(t, err, 500)
 
-	body = Body{"users": []string{"roll:over"}, "userChannels": []string{"BBC1"}}
+	body = Body{"users": []string{",.,.,.,.,."}, "userChannels": []string{"BBC1"}}
 	_, _, err = db.Put("doc5", body)
 	assertHTTPError(t, err, 500)
 

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -454,28 +454,18 @@ func TestAccessQuery(t *testing.T) {
 	assert.Equal(t, 5, rowCount)
 	assert.NoError(t, results.Close())
 
-	// Attempt to introduce syntax error.  Should return zero rows for user `user1'`, and not return error
-	username = "user1'"
-	results, queryErr = db.QueryAccess(username)
-	assert.NoError(t, queryErr, "Query error")
-	rowCount = 0
-	for results.Next(&row) {
-		rowCount++
-	}
-	assert.Equal(t, 0, rowCount)
-	assert.NoError(t, results.Close())
-
-	// Attempt to introduce syntax error.  Should return zero rows for user `user1`AND`, and not return error.
+	// Attempt to introduce syntax errors. Each of these should return zero rows and no error.
 	// Validates select clause protection
-	username = "user1`AND"
-	results, queryErr = db.QueryAccess(username)
-	assert.NoError(t, queryErr, "Query error")
-	rowCount = 0
-	for results.Next(&row) {
-		rowCount++
+	for _, username := range []string{"user1'", "user1`AND", "user1?", "user1 ! user2$"} {
+		results, queryErr = db.QueryAccess(username)
+		assert.NoError(t, queryErr, "Query error")
+		rowCount = 0
+		for results.Next(&row) {
+			rowCount++
+		}
+		assert.Equal(t, 0, rowCount)
+		assert.NoError(t, results.Close())
 	}
-	assert.Equal(t, 0, rowCount)
-	assert.NoError(t, results.Close())
 }
 
 func TestRoleAccessQuery(t *testing.T) {
@@ -507,28 +497,18 @@ func TestRoleAccessQuery(t *testing.T) {
 	assert.Equal(t, 5, rowCount)
 	assert.NoError(t, results.Close())
 
-	// Attempt to introduce syntax error.  Should return zero rows for user `user1'`, and not return error
-	username = "user1'"
-	results, queryErr = db.QueryRoleAccess(username)
-	assert.NoError(t, queryErr, "Query error")
-	rowCount = 0
-	for results.Next(&row) {
-		rowCount++
-	}
-	assert.Equal(t, 0, rowCount)
-	assert.NoError(t, results.Close())
-
-	// Attempt to introduce syntax error.  Should return zero rows for user `user1`AND`, and not return error
+	// Attempt to introduce syntax errors. Each of these should return zero rows and no error.
 	// Validates select clause protection
-	username = "user1`AND"
-	results, queryErr = db.QueryRoleAccess(username)
-	assert.NoError(t, queryErr, "Query error")
-	rowCount = 0
-	for results.Next(&row) {
-		rowCount++
+	for _, username := range []string{"user1'", "user1`AND", "user1?", "user1 ! user2$"} {
+		results, queryErr = db.QueryRoleAccess(username)
+		assert.NoError(t, queryErr, "Query error")
+		rowCount = 0
+		for results.Next(&row) {
+			rowCount++
+		}
+		assert.Equal(t, 0, rowCount)
+		assert.NoError(t, results.Close())
 	}
-	assert.Equal(t, 0, rowCount)
-	assert.NoError(t, results.Close())
 }
 
 // Parse the plan looking for use of the fetch operation (appears as the key/value pair "#operator":"Fetch")

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -456,7 +456,9 @@ func TestAccessQuery(t *testing.T) {
 
 	// Attempt to introduce syntax errors. Each of these should return zero rows and no error.
 	// Validates select clause protection
-	for _, username := range []string{"user1'", "user1`AND", "user1?", "user1 ! user2$"} {
+	usernames := []string{"user1'", "user1?", "user1 ! user2$"}
+	// usernames = append(usernames, "user1`AND") // TODO: MB-50619 - broken until Server 7.1.0
+	for _, username := range usernames {
 		results, queryErr = db.QueryAccess(username)
 		assert.NoError(t, queryErr, "Query error")
 		rowCount = 0
@@ -499,7 +501,9 @@ func TestRoleAccessQuery(t *testing.T) {
 
 	// Attempt to introduce syntax errors. Each of these should return zero rows and no error.
 	// Validates select clause protection
-	for _, username := range []string{"user1'", "user1`AND", "user1?", "user1 ! user2$"} {
+	usernames := []string{"user1'", "user1?", "user1 ! user2$"}
+	// usernames = append(usernames, "user1`AND") // TODO: MB-50619 - broken until Server 7.1.0
+	for _, username := range usernames {
 		results, queryErr = db.QueryRoleAccess(username)
 		assert.NoError(t, queryErr, "Query error")
 		rowCount = 0

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1220,6 +1220,10 @@ func (h *handler) updatePrincipal(name string, isUser bool) error {
 	}
 
 	internalName := internalUserName(*newInfo.Name)
+	if err = auth.ValidatePrincipalName(internalName); err != nil {
+		return base.HTTPErrorf(http.StatusBadRequest, err.Error())
+	}
+
 	newInfo.Name = &internalName
 	replaced, err := h.db.UpdatePrincipal(newInfo, isUser, h.rq.Method != "POST")
 	if err != nil {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -477,7 +477,7 @@ func TestFunkyUsernames(t *testing.T) {
 			rt := NewRestTester(t, nil)
 			defer rt.Close()
 
-			a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+			a := rt.ServerContext().Database("db").Authenticator()
 
 			// Create a test user
 			user, err := a.NewUser(tc.UserName, "letmein", channels.SetOf(t, "foo"))
@@ -537,7 +537,7 @@ func TestFunkyRoleNames(t *testing.T) {
 			})
 			defer rt.Close()
 
-			a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+			a := rt.ServerContext().Database("db").Authenticator()
 
 			// Create a test user
 			user, err := a.NewUser(username, "letmein", channels.SetOf(t))

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -22,6 +22,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -446,6 +447,116 @@ func TestFunkyDocIDs(t *testing.T) {
 	assertStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/foo+bar%2Bmoo+car3", "")
 	assertStatus(t, response, 200)
+}
+
+func TestFunkyUsernames(t *testing.T) {
+	cases := []struct {
+		Name     string
+		UserName string
+	}{
+		{
+			Name:     "hashes",
+			UserName: "foo#bar",
+		},
+		{
+			Name:     "question mark",
+			UserName: "foo?bar",
+		},
+		{
+			Name:     "dollars",
+			UserName: "$foo$bar",
+		},
+		{
+			Name:     "underscore prefix",
+			UserName: "_sync-foobar",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			require.Truef(t, auth.IsValidPrincipalName(tc.UserName), "expected '%s' to be accepted", tc.UserName)
+			rt := NewRestTester(t, nil)
+			defer rt.Close()
+
+			a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+
+			// Create a test user
+			user, err := a.NewUser(tc.UserName, "letmein", channels.SetOf(t, "foo"))
+			require.NoError(t, err)
+			require.NoError(t, a.Save(user))
+
+			response := rt.Send(requestByUser("PUT", "/db/AC+DC", `{"foo":"bar", "channels": ["foo"]}`, tc.UserName))
+			assertStatus(t, response, 201)
+
+			response = rt.Send(requestByUser("GET", "/db/_all_docs", "", tc.UserName))
+			assertStatus(t, response, 200)
+
+			response = rt.Send(requestByUser("GET", "/db/AC+DC", "", tc.UserName))
+			assertStatus(t, response, 200)
+			var overlay struct {
+				Rev string `json:"_rev"`
+			}
+			require.NoError(t, json.Unmarshal(response.Body.Bytes(), &overlay))
+
+			response = rt.Send(requestByUser("DELETE", "/db/AC+DC?rev="+overlay.Rev, "", tc.UserName))
+			assertStatus(t, response, 200)
+		})
+	}
+}
+
+func TestFunkyRoleNames(t *testing.T) {
+	cases := []struct {
+		Name     string
+		RoleName string
+	}{
+		{
+			Name:     "hashes",
+			RoleName: "foo#bar",
+		},
+		{
+			Name:     "question mark",
+			RoleName: "foo?bar",
+		},
+		{
+			Name:     "dollars",
+			RoleName: "$foo$bar",
+		},
+		{
+			Name:     "underscore prefix",
+			RoleName: "_sync-foobar",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			require.Truef(t, auth.IsValidPrincipalName(tc.RoleName), "expected '%s' to be accepted", tc.RoleName)
+			roleNameJSON, err := json.Marshal("role:" + tc.RoleName)
+			require.NoError(t, err)
+			const username = "user1"
+			syncFn := fmt.Sprintf(`function(doc) {channel(doc.channels); role("%s", %s);}`, username, string(roleNameJSON))
+			rt := NewRestTester(t, &RestTesterConfig{
+				SyncFn: syncFn,
+			})
+			defer rt.Close()
+
+			a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+
+			// Create a test user
+			user, err := a.NewUser(username, "letmein", channels.SetOf(t))
+			require.NoError(t, err)
+			require.NoError(t, a.Save(user))
+
+			// Create role
+			response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_role/%s", url.PathEscape(tc.RoleName)), `{"admin_channels": ["testchannel"]}`)
+			assertStatus(t, response, 201)
+
+			// Create test document
+			response = rt.SendAdminRequest("PUT", "/db/testdoc", `{"channels":["testchannel"]}`)
+			assertStatus(t, response, 201)
+
+			// Assert user can access it
+			response = rt.Send(requestByUser("GET", "/db/testdoc", "", username))
+			assertStatus(t, response, 200)
+		})
+	}
 }
 
 func TestFunkyDocAndAttachmentIDs(t *testing.T) {


### PR DESCRIPTION
Backports #5506 and #5609 and dependencies/test/pipeline fixes to 3.0.4

## Dependencies
- [x] rebase on #5654 
- [x] cherry-pick #5656 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `^Test(Role)?AccessQuery$ gsi=true xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/486/