### PR TITLE
Remove stage parallelism from Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,15 +62,17 @@ pipeline {
                         stage('Go Tools') {
                             steps {
                                 withEnv(["GOPATH=${GOTOOLS}"]) {
-                                    // unhandled error checker
-                                    sh 'go get -v -u github.com/kisielk/errcheck'
-                                    // goveralls is used to send coverprofiles to coveralls.io
-                                    sh 'go get -v -u github.com/mattn/goveralls'
-                                    // Jenkins coverage reporting tools
-                                    sh 'go get -v -u github.com/axw/gocov/...'
-                                    sh 'go get -v -u github.com/AlekSi/gocov-xml'
-                                    // Jenkins test reporting tools
-                                    sh 'go get -v -u github.com/tebeka/go2xunit'
+                                    sshagent(credentials: ['CB SG Robot Github SSH Key']) {
+                                        // unhandled error checker
+                                        sh 'go get -v -u github.com/kisielk/errcheck'
+                                        // goveralls is used to send coverprofiles to coveralls.io
+                                        sh 'go get -v -u github.com/mattn/goveralls'
+                                        // Jenkins coverage reporting tools
+                                        sh 'go get -v -u github.com/axw/gocov/...'
+                                        sh 'go get -v -u github.com/AlekSi/gocov-xml'
+                                        // Jenkins test reporting tools
+                                        sh 'go get -v -u github.com/tebeka/go2xunit'
+                                    }
                                 }
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
             }
         }
         stage('Setup') {
-            parallel {
+            stages {
                 stage('Bootstrap') {
                     steps {
                         echo "Bootstrapping commit ${SG_COMMIT}"


### PR DESCRIPTION
First attempt at fixing the `go get .../errcheck permission denied`

I think it might be a race between `Bootstrap` and `Go Tools` stages, so force them to run sequentially like we do on `master`.