### PR TITLE
Comment out the problematic test case for CBS < 7.1 (MB-50619)

### DIFF
--- a/db/query_test.go
+++ b/db/query_test.go
@@ -466,7 +466,9 @@ func TestAccessQuery(t *testing.T) {
 
 	// Attempt to introduce syntax errors. Each of these should return zero rows and no error.
 	// Validates select clause protection
-	for _, username := range []string{"user1'", "user1`AND", "user1?", "user1 ! user2$"} {
+	usernames := []string{"user1'", "user1?", "user1 ! user2$"}
+	// usernames = append(usernames, "user1`AND") // TODO: MB-50619 - broken until Server 7.1.0
+	for _, username := range usernames {
 		results, queryErr = db.QueryAccess(base.TestCtx(t), username)
 		assert.NoError(t, queryErr, "Query error")
 		rowCount = 0
@@ -509,7 +511,9 @@ func TestRoleAccessQuery(t *testing.T) {
 
 	// Attempt to introduce syntax errors. Each of these should return zero rows and no error.
 	// Validates select clause protection
-	for _, username := range []string{"user1'", "user1`AND", "user1?", "user1 ! user2$"} {
+	usernames := []string{"user1'", "user1?", "user1 ! user2$"}
+	// usernames = append(usernames, "user1`AND") // TODO: MB-50619 - broken until Server 7.1.0
+	for _, username := range usernames {
 		results, queryErr = db.QueryRoleAccess(base.TestCtx(t), username)
 		assert.NoError(t, queryErr, "Query error")
 		rowCount = 0


### PR DESCRIPTION
Due to MB-50619, this particular test case fails when running on servers before 7.1.0 - which we rolled back to.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `^Test(Role)?AccessQuery$ gsi=true xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/485/