### PR TITLE
CBG-2155 move collectionMapping to blipsync context

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -51,9 +51,8 @@ const maxInFlightChangesBatches = 2
 
 type blipHandler struct {
 	*BlipSyncContext
-	db                *Database   // Handler-specific copy of the BlipSyncContext's blipContextDb
-	collection        *Database   // Handler-specific copy of the BlipSyncContext's collection specific DB
-	collectionMapping []*Database // Mapping of array id to collection mapping
+	db         *Database // Handler-specific copy of the BlipSyncContext's blipContextDb
+	collection *Database // Handler-specific copy of the BlipSyncContext's collection specific DB
 
 	serialNumber uint64 // This blip handler's serial number to differentiate logs w/ other handlers
 }
@@ -136,7 +135,7 @@ func collectionBlipHandler(next blipHandlerFunc) blipHandlerFunc {
 			return next(bh, bm)
 		}
 		if len(bh.collectionMapping) == 0 {
-			return base.HTTPErrorf(http.StatusBadRequest, "Passing collection requires calling GetCollections first")
+			return base.HTTPErrorf(http.StatusBadRequest, "Passing collection requires calling %s first", MessageGetCollections)
 		}
 
 		collectionIndex, err := strconv.Atoi(collectionIndexStr)

--- a/db/blip_handler_test.go
+++ b/db/blip_handler_test.go
@@ -114,8 +114,8 @@ func TestCollectionBlipHandler(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			bh := blipHandler{
-				db:                allDBContext,
-				collectionMapping: testCase.collectionMapping,
+				db:              allDBContext,
+				BlipSyncContext: &BlipSyncContext{collectionMapping: testCase.collectionMapping},
 			}
 
 			passedMiddleware := false

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -116,6 +116,8 @@ type BlipSyncContext struct {
 
 	// when readOnly is true, handleRev requests are rejected
 	readOnly bool
+
+	collectionMapping []*Database // Mapping of array id to collection mapping
 }
 
 // AllowedAttachment contains the metadata for handling allowed attachments


### PR DESCRIPTION
This was accidentally on the blipHandler struct which is specific to each handler.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/491/