### PR TITLE
CBG-2208: Fixed NotFound handling for tombstone compaction

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -1183,7 +1183,7 @@ func (db *Database) Compact(skipRunningStateCheck bool, callback compactCallback
 			purgeErr := db.Purge(tombstonesRow.Id)
 			if purgeErr == nil {
 				purgedDocs = append(purgedDocs, tombstonesRow.Id)
-			} else if base.IsKeyNotFoundError(db.Bucket, purgeErr) {
+			} else if base.IsDocNotFoundError(purgeErr) {
 				// If key no longer exists, need to add and remove to trigger removal from view
 				_, addErr := db.Bucket.Add(tombstonesRow.Id, 0, purgeBody)
 				if addErr != nil {


### PR DESCRIPTION
CBG-2208

- Tombstone compaction now checks if the purge error was a `NotFound`error which it was original intent was meant to be. 

Manually tested by making `db.Purge(id)` in compaction take a doc ID that does not exist.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/506/