### PR TITLE
CBG-2226: PurgeInterval refreshed with at tombstone compaction time

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2479,7 +2479,7 @@ func TestImportCompactPanic(t *testing.T) {
 		CompactInterval: 1,
 	})
 	defer db.Close()
-	db.PurgeInterval = time.Millisecond
+	db.PurgeInterval = 0
 
 	// Create a document, then delete it, to create a tombstone
 	rev, doc, err := db.Put("test", Body{})

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -4954,6 +4954,11 @@ func TestTombstoneCompactionPurgeInterval(t *testing.T) {
 			require.NoError(t, err)
 
 			// Check purge interval is as expected
+			if !base.TestUseXattrs() {
+				// Not using xattrs should cause compaction to not run therefore not changing purge interval
+				assert.EqualValues(t, test.dbPurgeInterval, dbc.PurgeInterval)
+				return
+			}
 			assert.EqualValues(t, test.expectedPurgeIntervalAfterCompact, dbc.PurgeInterval)
 		})
 	}


### PR DESCRIPTION
CBG-2226

- Refresh tombstone purge interval with the server metadata purge interval when compaction is started. 
- The purge interval will not be updated if it is 0 in the db which is only applicable in test cases
- Use existing purge interval if SG fails to retrieve server metadata purge interval
- Added testing with helper function

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/505/
- [x] `xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/511/ `known failures`