### PR TITLE
CBG-2227: Fix invalid collection-aware query when using xattrs=false

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -82,6 +82,11 @@ type CouchbaseStore interface {
 	mgmtRequest(method, uri, contentType string, body io.Reader) (*http.Response, error)
 }
 
+func AsCollection(bucket Bucket) (*Collection, bool) {
+	collection, ok := GetBaseBucket(bucket).(*Collection)
+	return collection, ok
+}
+
 func AsCouchbaseStore(b Bucket) (CouchbaseStore, bool) {
 	couchbaseBucket, ok := GetBaseBucket(b).(CouchbaseStore)
 	return couchbaseBucket, ok

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -29,7 +29,8 @@ func (c *Collection) EscapedKeyspace() string {
 	if c.ScopeName() == DefaultScope && c.Name() == DefaultCollection {
 		return fmt.Sprintf("`%s`", c.BucketName())
 	}
-	return fmt.Sprintf("`%s`.`%s`.`%s`", c.BucketName(), c.ScopeName(), c.Name())
+	// "default:"" is the only valid keyspace namespace but it must be specified...
+	return fmt.Sprintf("default:`%s`.`%s`.`%s`", c.BucketName(), c.ScopeName(), c.Name())
 }
 
 // IndexMetaBucketID returns the value of bucket_id for the system:indexes table for the collection.

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -313,7 +313,7 @@ func GetIndexMeta(store N1QLStore, indexName string) (exists bool, meta *IndexMe
 }
 
 func getIndexMetaWithoutRetry(store N1QLStore, indexName string) (exists bool, meta *IndexMeta, err error) {
-	statement := fmt.Sprintf("SELECT state from system:indexes WHERE indexes.name = '%s' AND indexes.keyspace_id = '%s'", indexName, store.IndexMetaKeyspaceID())
+	statement := fmt.Sprintf("SELECT state FROM system:indexes WHERE indexes.name = '%s' AND indexes.keyspace_id = '%s'", indexName, store.IndexMetaKeyspaceID())
 	if store.IndexMetaBucketID() != "" {
 		statement += fmt.Sprintf(" AND indexes.bucket_id = '%s'", store.IndexMetaBucketID())
 	}

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -79,10 +79,13 @@ func ExplainQuery(store N1QLStore, statement string, params map[string]interface
 }
 
 // CreateIndex issues a CREATE INDEX query in the current bucket, using the form:
-//   CREATE INDEX indexName ON bucket.Name(expression) WHERE filterExpression WITH options
+//
+//	CREATE INDEX indexName ON bucket.Name(expression) WHERE filterExpression WITH options
+//
 // Sample usage with resulting statement:
-//     CreateIndex("myIndex", "field1, field2, nested.field", "field1 > 0", N1qlIndexOptions{numReplica:1})
-//   CREATE INDEX myIndex on myBucket(field1, field2, nested.field) WHERE field1 > 0 WITH {"numReplica":1}
+//
+//	  CreateIndex("myIndex", "field1, field2, nested.field", "field1 > 0", N1qlIndexOptions{numReplica:1})
+//	CREATE INDEX myIndex on myBucket(field1, field2, nested.field) WHERE field1 > 0 WITH {"numReplica":1}
 func CreateIndex(store N1QLStore, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
 	createStatement := fmt.Sprintf("CREATE INDEX `%s` ON %s(%s)", indexName, store.EscapedKeyspace(), expression)
 
@@ -217,7 +220,8 @@ func BuildDeferredIndexes(s N1QLStore, indexSet []string) error {
 }
 
 // BuildIndexes executes a BUILD INDEX statement in the current bucket, using the form:
-//   BUILD INDEX ON `bucket.Name`(`index1`, `index2`, ...)
+//
+//	BUILD INDEX ON `bucket.Name`(`index1`, `index2`, ...)
 func buildIndexes(s N1QLStore, indexNames []string) error {
 	if len(indexNames) == 0 {
 		return nil
@@ -375,7 +379,9 @@ func AsN1QLStore(bucket Bucket) (N1QLStore, bool) {
 }
 
 // Index not found errors (returned by DropIndex) don't have a specific N1QL error code - they are of the form:
-//   [5000] GSI index testIndex_not_found not found.
+//
+//	[5000] GSI index testIndex_not_found not found.
+//
 // Stuck with doing a string compare to differentiate between 'not found' and other errors
 func IsIndexNotFoundError(err error) bool {
 	return strings.Contains(err.Error(), "not found")
@@ -385,7 +391,8 @@ func IsIndexNotFoundError(err error) bool {
 // error:[5000] GSI CreateIndex() - cause: Encountered transient error.  Index creation will be retried in background.  Error: Index testIndex_value will retry building in the background for reason: Bucket test_data_bucket In Recovery.
 // error:[5000] GSI Drop() - cause: Fail to drop index on some indexer nodes.  Error=Encountered error when dropping index: Indexer In Recovery. Drop index will be retried in background.
 // error:[5000] BuildIndexes - cause: Build index fails.  %vIndex testIndexDeferred will retry building in the background for reason: Build Already In Progress. Bucket test_data_bucket.
-//  https://issues.couchbase.com/browse/MB-19358 is filed to request improved indexer error codes for these scenarios (and others)
+//
+//	https://issues.couchbase.com/browse/MB-19358 is filed to request improved indexer error codes for these scenarios (and others)
 func IsIndexerRetryIndexError(err error) bool {
 	if err == nil {
 		return false

--- a/cnf_bootstrap.json
+++ b/cnf_bootstrap.json
@@ -1,0 +1,14 @@
+{
+	"bootstrap": {
+		"server": "couchbases://localhost",
+		"username": "Administrator",
+		"password": "password",
+		"server_tls_skip_verify": true
+	},
+	"logging": {
+		"console": {
+			"log_level": "info",
+			"log_keys": ["*"]
+		}
+	}
+}

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -36,7 +36,7 @@ const (
 // When running w/out xattrs, it's just replaced by the doc path `bucketname`._sync
 // This gets replaced before the statement is sent to N1QL by the replaceSyncTokens methods.
 var syncNoXattr = fmt.Sprintf("%s.%s", base.KeyspaceQueryToken, base.SyncPropertyName)
-var syncNoXattrQuery = fmt.Sprintf("%s.%s", base.KeyspaceQueryAlias, base.SyncPropertyName)
+var syncNoXattrQuery = fmt.Sprintf("%s.%s", base.KeyspaceQueryToken, base.SyncPropertyName)
 var syncXattr = "meta().xattrs." + base.SyncXattrName
 var syncXattrQuery = fmt.Sprintf("meta(%s).xattrs.%s", base.KeyspaceQueryAlias, base.SyncXattrName) // Replacement for $sync token for xattr queries
 
@@ -409,8 +409,8 @@ func isIndexerError(err error) bool {
 }
 
 // Iterates over the index set, removing obsolete indexes:
-//  - indexes based on the inverse value of xattrs being used by the database
-//  - indexes associated with previous versions of the index, for either xattrs=true or xattrs=false
+//   - indexes based on the inverse value of xattrs being used by the database
+//   - indexes associated with previous versions of the index, for either xattrs=true or xattrs=false
 func removeObsoleteIndexes(bucket base.N1QLStore, previewOnly bool, useXattrs bool, useViews bool, indexMap map[SGIndexType]SGIndex) (removedIndexes []string, err error) {
 	removedIndexes = make([]string, 0)
 

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -36,6 +36,7 @@ const (
 // When running w/out xattrs, it's just replaced by the doc path `bucketname`._sync
 // This gets replaced before the statement is sent to N1QL by the replaceSyncTokens methods.
 var syncNoXattr = fmt.Sprintf("%s.%s", base.KeyspaceQueryToken, base.SyncPropertyName)
+var syncNoXattrQuery = fmt.Sprintf("%s.%s", base.KeyspaceQueryAlias, base.SyncPropertyName)
 var syncXattr = "meta().xattrs." + base.SyncXattrName
 var syncXattrQuery = fmt.Sprintf("meta(%s).xattrs.%s", base.KeyspaceQueryAlias, base.SyncXattrName) // Replacement for $sync token for xattr queries
 
@@ -483,7 +484,7 @@ func replaceSyncTokensQuery(statement string, useXattrs bool) string {
 	if useXattrs {
 		return strings.Replace(statement, syncToken, syncXattrQuery, -1)
 	} else {
-		return strings.Replace(statement, syncToken, syncNoXattr, -1)
+		return strings.Replace(statement, syncToken, syncNoXattrQuery, -1)
 	}
 }
 

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -37,7 +37,7 @@ func TestInitializeIndexes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("xattrs=%v", test.xattrs), func(t *testing.T) {
-			db := setupTestDB(t)
+			db := setupTestDBWithOptions(t, DatabaseContextOptions{EnableXattr: test.xattrs})
 			defer db.Close()
 
 			n1qlStore, isGoCBBucket := base.AsN1QLStore(db.Bucket)

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -46,7 +46,7 @@ func TestInitializeIndexes(t *testing.T) {
 			dropErr := base.DropAllBucketIndexes(n1qlStore)
 			require.NoError(t, dropErr, "Error dropping all indexes")
 
-			initErr := InitializeIndexes(n1qlStore, test.xattrs, 0)
+			initErr := InitializeIndexes(n1qlStore, test.xattrs, 0, true)
 			assert.NoError(t, initErr, "Error initializing all indexes")
 
 			// Recreate the primary index required by the test bucket pooling framework
@@ -117,7 +117,7 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	log.Printf("removedIndexes: %+v", removedIndexes)
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in setup case")
 
-	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0)
+	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false)
 	assert.NoError(t, err)
 
 	// Running w/ opposite xattrs flag should preview removal of the indexes associated with this db context
@@ -136,7 +136,7 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in post-cleanup no-op")
 
 	// Restore indexes after test
-	err = InitializeIndexes(n1qlStore, db.UseXattrs(), 0)
+	err = InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false)
 	assert.NoError(t, err)
 }
 
@@ -178,7 +178,7 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes with hacked sgIndexes")
 
 	// Restore indexes after test
-	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0)
+	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false)
 	assert.NoError(t, err)
 
 	validateErr := validateAllIndexesOnline(db.Bucket)
@@ -234,7 +234,7 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Restore indexes after test
-	err = InitializeIndexes(n1QLStore, db.UseXattrs(), 0)
+	err = InitializeIndexes(n1QLStore, db.UseXattrs(), 0, false)
 	assert.NoError(t, err)
 
 	validateErr := validateAllIndexesOnline(db.Bucket)
@@ -255,7 +255,7 @@ func TestRemoveObsoleteIndexOnError(t *testing.T) {
 	require.True(t, db.Bucket.IsSupported(sgbucket.DataStoreFeatureN1ql))
 
 	// Use existing versions of IndexAccess and IndexChannels and create an old version that will be removed by obsolete
-	//indexes. Resulting from the removal candidates for removeObsoleteIndexes will be:
+	// indexes. Resulting from the removal candidates for removeObsoleteIndexes will be:
 	// All previous versions and opposite of current xattr setting eg. for this test ran with non-xattrs:
 	// [sg_channels_x2 sg_channels_x1 sg_channels_1 sg_access_x2 sg_access_x1 sg_access_1]
 	testIndexes := map[SGIndexType]SGIndex{}
@@ -281,7 +281,7 @@ func TestRemoveObsoleteIndexOnError(t *testing.T) {
 
 	// Restore indexes after test
 	n1qlStore, _ := base.AsN1QLStore(db.Bucket)
-	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0)
+	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false)
 	assert.NoError(t, err)
 
 	validateErr := validateAllIndexesOnline(db.Bucket)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -298,7 +298,7 @@ var ViewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 	}
 
 	tbp.Logf(ctx, "dropping existing bucket indexes")
-	if err := base.DropAllBucketIndexes(n1qlStore); err != nil {
+	if err := base.DropAllBucketIndexes(ctx, n1qlStore); err != nil {
 		tbp.Logf(ctx, "Failed to drop bucket indexes: %v", err)
 		return err
 	}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -304,7 +304,7 @@ var ViewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 	}
 
 	tbp.Logf(ctx, "creating SG bucket indexes")
-	if err := InitializeIndexes(n1qlStore, base.TestUseXattrs(), 0); err != nil {
+	if err := InitializeIndexes(n1qlStore, base.TestUseXattrs(), 0, false); err != nil {
 		return err
 	}
 

--- a/integration-init.sh
+++ b/integration-init.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -u
+set -e # Abort on errors
+set -x # Output all executed shell commands
+
+CB_HTTP_ADDR='http://localhost:8091'
+CB_USERNAME='Administrator'
+CB_PASSWORD='password'
+CB_NODE_HOSTNAME='127.0.0.1'
+CB_MEM_QUOTA_BYTES='4096'
+CB_INDEX_MEM_QUOTA_BYTES='1024'
+
+# Test to see if Couchbase Server is up
+# Each retry min wait 5s, max 10s. Retry 20 times with exponential backoff (delay 0), fail at 120s
+curl --retry-all-errors --connect-timeout 5 --max-time 10 --retry 20 --retry-delay 0 --retry-max-time 120 "${CB_HTTP_ADDR}"
+
+# Set up CBS
+curl -u "${CB_USERNAME}:${CB_PASSWORD}" -v -X POST "${CB_HTTP_ADDR}/nodes/self/controller/settings" -d 'path=%2Fopt%2Fcouchbase%2Fvar%2Flib%2Fcouchbase%2Fdata&' -d 'index_path=%2Fopt%2Fcouchbase%2Fvar%2Flib%2Fcouchbase%2Fdata&' -d 'cbas_path=%2Fopt%2Fcouchbase%2Fvar%2Flib%2Fcouchbase%2Fdata&' -d 'eventing_path=%2Fopt%2Fcouchbase%2Fvar%2Flib%2Fcouchbase%2Fdata&'
+curl -u "${CB_USERNAME}:${CB_PASSWORD}" -v -X POST "${CB_HTTP_ADDR}/node/controller/rename" -d "hostname=${CB_NODE_HOSTNAME}"
+curl -u "${CB_USERNAME}:${CB_PASSWORD}" -v -X POST "${CB_HTTP_ADDR}/node/controller/setupServices" -d 'services=kv%2Cn1ql%2Cindex'
+curl -u "${CB_USERNAME}:${CB_PASSWORD}" -v -X POST "${CB_HTTP_ADDR}/pools/default" -d "memoryQuota=${CB_MEM_QUOTA_BYTES}" -d "indexMemoryQuota=${CB_INDEX_MEM_QUOTA_BYTES}"
+curl -u "${CB_USERNAME}:${CB_PASSWORD}" -v -X POST "${CB_HTTP_ADDR}/settings/web" -d 'password=password&username=Administrator&port=SAME'
+curl -u "${CB_USERNAME}:${CB_PASSWORD}" -v -X POST "${CB_HTTP_ADDR}/settings/indexes" -d 'indexerThreads=4' -d 'logLevel=verbose' -d 'maxRollbackPoints=10' -d 'storageMode=plasma' -d 'memorySnapshotInterval=150' -d 'stableSnapshotInterval=40000'

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -431,7 +431,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config DatabaseConfig, useE
 			return nil, errors.New("Cannot create indexes on non-Couchbase data store.")
 
 		}
-		indexErr := db.InitializeIndexes(n1qlStore, config.UseXattrs(), numReplicas)
+		indexErr := db.InitializeIndexes(n1qlStore, config.UseXattrs(), numReplicas, false)
 		if indexErr != nil {
 			return nil, indexErr
 		}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -207,7 +207,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 					scopes[scopeName] = append(scopes[scopeName], collName)
 				}
 			}
-			if err := base.CreateTestBucketScopesAndCollections(base.TestCtx(rt.tb), rt.testBucket, scopes); err != nil {
+			if err := base.CreateBucketScopesAndCollections(base.TestCtx(rt.tb), rt.testBucket.BucketSpec, scopes); err != nil {
 				rt.tb.Fatalf("Error creating test scopes/collections: %v", err)
 			}
 		}
@@ -1165,12 +1165,12 @@ func getChangesHandler(changesFinishedWg, revsFinishedWg *sync.WaitGroup) func(r
 //
 // - Call subChanges (continuous=false) endpoint to get all changes from Sync Gateway
 // - Respond to each "change" request telling the other side to send the revision
-//		- NOTE: this could be made more efficient by only requesting the revision for the docid/revid pair
-//              passed in the parameter.
+//   - NOTE: this could be made more efficient by only requesting the revision for the docid/revid pair
+//     passed in the parameter.
+//
 // - If the rev handler is called back with the desired docid/revid pair, save that into a variable that will be returned
 // - Block until all pending operations are complete
 // - Return the resultDoc or an empty resultDoc
-//
 func (bt *BlipTester) GetDocAtRev(requestedDocID, requestedDocRev string) (resultDoc RestDocument, err error) {
 
 	docs := map[string]RestDocument{}


### PR DESCRIPTION
CBG-2227

The collection-aware queries/indexes need to use different sync tokens - the index needs to be built on the keyspace (`bucket1`), the query needs to be run on the keyspace alias we defined inside the queries.

- Make TestInitializeIndexes run both xattr=true/false combinations, regardless of `SG_TEST_USE_XATTR` setting for additional coverage.
- Allow fast-fail in `InitializeIndexes` for testing to avoid 15 minute test failures...
- Use `syncNoXattrQuery` which has the keyspace query alias, rather than the literal keyspace.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `gsi=true xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/507/
- [ ] `gsi=true xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/508/