### PR TITLE
CBG-2230: Fix startup panic with invalid x509 config

### DIFF
--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -96,11 +96,11 @@ func (ca CertificateAuthenticator) Credentials(req gocbcore.AuthCredsRequest) ([
 }
 
 // GoCBCoreAuthConfig returns a gocbcore.AuthProvider to use when connecting given a set of credentials via a gocbcore agent.
-func GoCBCoreAuthConfig(username, password, certPath, keyPath string) (a gocbcore.AuthProvider, err error) {
+func GoCBCoreAuthConfig(username, password, certPath, keyPath string) (gocbcore.AuthProvider, error) {
 	if certPath != "" && keyPath != "" {
 		cert, certLoadErr := tls.LoadX509KeyPair(certPath, keyPath)
 		if certLoadErr != nil {
-			return nil, err
+			return nil, certLoadErr
 		}
 		return CertificateAuthenticator{
 			ClientCertificate: &cert,

--- a/base/gocb_utils_test.go
+++ b/base/gocb_utils_test.go
@@ -84,3 +84,10 @@ func TestGoCBv2SecurityConfig(t *testing.T) {
 		})
 	}
 }
+
+// Regression test for CBG-2230. Ensure that we return an error, rather than nil/nil, when given an invalid path to
+// x.509 certs.
+func TestGoCBCoreAuthConfigInvalidPaths(t *testing.T) {
+	_, err := GoCBCoreAuthConfig("", "", "/non/existent/cert", "/non/existent/key")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
CBG-2230

If `GoCBCoreAuthConfig` failed to load a x509 key pair, it would return a nil authenticator and nil error, which would cause gocbcore to panic. Return the correct error, and remove the named `err` return value as it wasn't used.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
N/A, covered by unit tests