### PR TITLE
CBG-2231: [3.0.4 Backport] CBG-2230: Fix startup panic with invalid x509 config

### DIFF
--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -95,11 +95,11 @@ func (ca CertificateAuthenticator) Credentials(req gocbcore.AuthCredsRequest) ([
 }
 
 // GoCBCoreAuthConfig returns a gocbcore.AuthProvider to use when connecting given a set of credentials via a gocbcore agent.
-func GoCBCoreAuthConfig(username, password, certPath, keyPath string) (a gocbcore.AuthProvider, err error) {
+func GoCBCoreAuthConfig(username, password, certPath, keyPath string) (gocbcore.AuthProvider, error) {
 	if certPath != "" && keyPath != "" {
 		cert, certLoadErr := tls.LoadX509KeyPair(certPath, keyPath)
 		if certLoadErr != nil {
-			return nil, err
+			return nil, certLoadErr
 		}
 		return CertificateAuthenticator{
 			ClientCertificate: &cert,

--- a/base/gocb_utils_test.go
+++ b/base/gocb_utils_test.go
@@ -91,3 +91,10 @@ func TestGoCBv2SecurityConfig(t *testing.T) {
 		})
 	}
 }
+
+// Regression test for CBG-2230. Ensure that we return an error, rather than nil/nil, when given an invalid path to
+// x.509 certs.
+func TestGoCBCoreAuthConfigInvalidPaths(t *testing.T) {
+	_, err := GoCBCoreAuthConfig("", "", "/non/existent/cert", "/non/existent/key")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
CBG-2231

Backport #5665 to 3.0.4.

## Dependencies (if applicable)
- [x] Review of #5665 
