### PR TITLE
Skip LiteCore SyncServer tests because they're segfaulting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -296,6 +296,8 @@ pipeline {
                             }
                         }
                         stage('against EE') {
+                            // CBG-2237 skipping stage due to regular litecore test segfaults
+                            when { expression { return false } }
                             steps {
                                 githubNotify(credentialsId: "${GH_ACCESS_TOKEN_CREDENTIAL}", context: 'sgw-pipeline-litecore-ee', description: 'Running LiteCore Tests', status: 'PENDING')
                                 sh 'touch verbose_litecore.out'


### PR DESCRIPTION
Filed CBG-2237 to track re-enabling or getting more information to the litecore team for a fix

