### PR TITLE
CBG-2179: Backport CBG-2174: Fix periodic high response times on REST API due to persistent config polling

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -1080,7 +1080,7 @@ func (sc *ServerContext) fetchAndLoadConfigs(isInitialStartup bool) (count int, 
 			}
 		}
 		for dbName, fetchedConfig := range fetchedConfigs {
-			if dbConfig, ok := sc.dbConfigs[dbName]; ok && dbConfig.cas >= fetchedConfig.cas {
+			if dbConfig, ok := sc.dbConfigs[dbName]; ok && dbConfig.cfgCas >= fetchedConfig.cfgCas {
 				base.DebugfCtx(context.TODO(), base.KeyConfig, "Database %q bucket %q config has not changed since last update", fetchedConfig.Name, *fetchedConfig.Bucket)
 				delete(fetchedConfigs, dbName)
 			}

--- a/rest/config.go
+++ b/rest/config.go
@@ -1076,6 +1076,7 @@ func (sc *ServerContext) fetchAndLoadConfigs(isInitialStartup bool) (count int, 
 		for _, dbName := range sc.bucketDbName {
 			if _, foundMatchingDb := fetchedConfigs[dbName]; !foundMatchingDb {
 				deletedDatabases = append(deletedDatabases, dbName)
+				delete(fetchedConfigs, dbName)
 			}
 		}
 		for dbName, fetchedConfig := range fetchedConfigs {
@@ -1097,9 +1098,17 @@ func (sc *ServerContext) fetchAndLoadConfigs(isInitialStartup bool) (count int, 
 	sc.lock.Lock()
 	defer sc.lock.Unlock()
 	for _, dbName := range deletedDatabases {
-		if _, foundMatchingDb := fetchedConfigs[dbName]; !foundMatchingDb {
+		// It's possible that the "deleted" database was not written to the server until after sc.fetchConfigs had returned...
+		// we'll need to pay for the cost of getting the config again now that we've got the write lock to double-check this db is definitely ok to remove...
+		found, _, err := sc.fetchDatabase(dbName)
+		if err != nil {
+			base.InfofCtx(context.TODO(), base.KeyConfig, "Error fetching config for database %q to check whether we need to remove it: %v", dbName, err)
+		}
+		if !found {
 			base.InfofCtx(context.TODO(), base.KeyConfig, "Database %q was running on this node, but config was not found on the server - removing database", base.MD(dbName))
 			sc._removeDatabase(dbName)
+		} else {
+			base.DebugfCtx(context.TODO(), base.KeyConfig, "Found config for database %q after acquiring write lock - not removing database", base.MD(dbName))
 		}
 	}
 


### PR DESCRIPTION
CBG-2179

- Backport CBG-2174: Periodic high response times on REST API due to persistent config polling
- Fixed database CAS check manually

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/524/ `2 known flaky test failures`