### PR TITLE
CBG-2213: Better handle CBGT feed rolling upgrades

### DIFF
--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -42,13 +42,10 @@ const (
 	DestShardedFeed
 )
 
-var feedType cbgtFeedType
-
 func init() {
 	for i := 0; i < len(vbucketIdStrings); i++ {
 		vbucketIdStrings[i] = fmt.Sprintf("%d", i)
 	}
-	feedType = cbgtFeedType_gocb
 	cbgt.DCPFeedPrefix = "sg:"
 }
 

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -31,12 +31,16 @@ const CBGTIndexTypeSyncGatewayImport = "syncGateway-import-"
 const DefaultImportPartitions = 16
 
 const (
-	nodeVersionHelium  = 1
-	currentNodeVersion = nodeVersionHelium
+	compatVersionHelium      = 1
+	currentNodeCompatVersion = compatVersionHelium
 )
 
+// nodeExtras is the contents of the JSON value of the cbgt.NodeDef.Extras field as used by Sync Gateway.
 type nodeExtras struct {
-	Version uint `json:"v"`
+	// CompatVersion is the node's "compatibility version", an integer that is incremented each time there is a cluster-wide
+	// behaviour change that nodes need to handle differently depending on if older nodes are present. For example, see
+	// CBG-2213.
+	CompatVersion uint `json:"v"`
 }
 
 // CbgtContext holds the two handles we have for CBGT-related functionality.
@@ -246,7 +250,7 @@ func getCBGTIndexUUID(manager *cbgt.Manager, indexName string) (exists bool, pre
 func initCBGTManager(bucket Bucket, spec BucketSpec, cfgSG cbgt.Cfg, dbUUID string, dbName string) (*CbgtContext, error) {
 	// Check if there are pre-Helium nodes, and if so, set the LithiumCompat flag to ensure we don't try to start a
 	// collections-enabled feed when some nodes won't support it.
-	minVersion, err := getMinNodeVersion(cfgSG)
+	minVersion, err := getMinNodeCompatVersion(cfgSG)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get minimum node version in cluster: %w", err)
 	}
@@ -280,7 +284,7 @@ func initCBGTManager(bucket Bucket, spec BucketSpec, cfgSG cbgt.Cfg, dbUUID stri
 
 	// extras: Can be used to pass Sync Gateway specific node information to callbacks. Used to detect node upgrades -
 	// currently pre-Helium to Helium.
-	extras, err := JSONMarshal(&nodeExtras{Version: currentNodeVersion})
+	extras, err := JSONMarshal(&nodeExtras{CompatVersion: currentNodeCompatVersion})
 	if err != nil {
 		return nil, err
 	}
@@ -345,7 +349,7 @@ func initCBGTManager(bucket Bucket, spec BucketSpec, cfgSG cbgt.Cfg, dbUUID stri
 		),
 		Manager:       mgr,
 		Cfg:           cfgSG,
-		LithiumCompat: NewAtomicBool(minVersion < nodeVersionHelium),
+		LithiumCompat: NewAtomicBool(minVersion < compatVersionHelium),
 	}
 	if cbgtContext.LithiumCompat.IsTrue() {
 		WarnfCtx(cbgtContext.loggingCtx, "Found old (3.0.x or below) Sync Gateway nodes in cluster - entering compatibility mode."+
@@ -402,7 +406,7 @@ func (c *CbgtContext) StartManager(dbName string, configGroup string, bucket Buc
 	return nil
 }
 
-func getNodeVersion(def *cbgt.NodeDef) (uint, error) {
+func getNodeCompatVersion(def *cbgt.NodeDef) (uint, error) {
 	if len(def.Extras) == 0 {
 		return 0, nil
 	}
@@ -410,21 +414,22 @@ func getNodeVersion(def *cbgt.NodeDef) (uint, error) {
 	if err := JSONUnmarshal([]byte(def.Extras), &extras); err != nil {
 		return 0, fmt.Errorf("parsing node extras: %w", err)
 	}
-	return extras.Version, nil
+	return extras.CompatVersion, nil
 }
 
-func getMinNodeVersion(cfg cbgt.Cfg) (uint, error) {
+// getMinNodeCompatVersion returns the compatibility version value of the oldest node currently in the cluster.
+func getMinNodeCompatVersion(cfg cbgt.Cfg) (uint, error) {
 	nodes, _, err := cbgt.CfgGetNodeDefs(cfg, cbgt.NODE_DEFS_KNOWN)
 	if err != nil {
 		return 0, err
 	}
 	if nodes == nil || len(nodes.NodeDefs) == 0 {
 		// If there are no nodes at all, it's likely we're the first node in the cluster.
-		return currentNodeVersion, nil
+		return currentNodeCompatVersion, nil
 	}
 	minVersion := uint(math.MaxUint)
 	for _, node := range nodes.NodeDefs {
-		nodeVersion, err := getNodeVersion(node)
+		nodeVersion, err := getNodeCompatVersion(node)
 		if err != nil {
 			return 0, fmt.Errorf("failed to get version of node %v: %w", MD(node.HostPort).Redact(), err)
 		}
@@ -576,7 +581,7 @@ func (l *importHeartbeatListener) subscribeNodeChanges() error {
 		for {
 			select {
 			case <-cfgEvents:
-				minVersion, localNodeRegistered, err := l.reloadNodes()
+				minCompatVersion, localNodeRegistered, err := l.reloadNodes()
 				if err != nil {
 					WarnfCtx(logCtx, "Error while reloading heartbeat node definitions: %v", err)
 				}
@@ -587,7 +592,7 @@ func (l *importHeartbeatListener) subscribeNodeChanges() error {
 					}
 				}
 
-				if l.ctx.LithiumCompat.IsTrue() && minVersion >= nodeVersionHelium {
+				if l.ctx.LithiumCompat.IsTrue() && minCompatVersion >= compatVersionHelium {
 					// Can now exit compat mode as all nodes are at least Helium
 					InfofCtx(logCtx, KeyDCP, "Exiting compatibility mode - can now start import feed on non-default collections.")
 					l.ctx.LithiumCompat.CompareAndSwap(true, false)
@@ -601,11 +606,11 @@ func (l *importHeartbeatListener) subscribeNodeChanges() error {
 	return nil
 }
 
-func (l *importHeartbeatListener) reloadNodes() (minVersion uint, localNodePresent bool, err error) {
+func (l *importHeartbeatListener) reloadNodes() (minCompatVersion uint, localNodePresent bool, err error) {
 
 	nodeUUIDs := make([]string, 0)
 	nodeDefTypes := []string{cbgt.NODE_DEFS_KNOWN, cbgt.NODE_DEFS_WANTED}
-	minVersion = uint(math.MaxUint)
+	minCompatVersion = uint(math.MaxUint)
 	for _, nodeDefType := range nodeDefTypes {
 		nodeSet, _, err := cbgt.CfgGetNodeDefs(l.cfg, nodeDefType)
 		if err != nil {
@@ -617,12 +622,12 @@ func (l *importHeartbeatListener) reloadNodes() (minVersion uint, localNodePrese
 				if nodeDef.UUID == l.mgr.UUID() {
 					localNodePresent = true
 				}
-				nodeVersion, err := getNodeVersion(nodeDef)
+				nodeVersion, err := getNodeCompatVersion(nodeDef)
 				if err != nil {
 					return 0, false, fmt.Errorf("failed to get version of node %v: %w", MD(nodeDef.HostPort).Redact(), err)
 				}
-				if nodeVersion < minVersion {
-					minVersion = nodeVersion
+				if nodeVersion < minCompatVersion {
+					minCompatVersion = nodeVersion
 				}
 			}
 		}
@@ -631,7 +636,7 @@ func (l *importHeartbeatListener) reloadNodes() (minVersion uint, localNodePrese
 	l.nodeIDs = nodeUUIDs
 	l.lock.Unlock()
 
-	return minVersion, localNodePresent, nil
+	return minCompatVersion, localNodePresent, nil
 }
 
 // GetNodes returns a copy of the in-memory node set

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -210,15 +210,15 @@ func TestCBGTIndexCreation(t *testing.T) {
 				}
 
 				err = context.Manager.CreateIndex(
-					SOURCE_GOCB_DCP_SG, // sourceType
-					bucket.GetName(),   // sourceName
-					bucketUUID,         // sourceUUID
-					sourceParams,       // sourceParams
-					indexType,          // indexType
-					legacyIndexName,    // indexName
-					indexParams,        // indexParams
-					planParams,         // planParams
-					"",                 // prevIndexUUID
+					SOURCE_DCP_SG,    // sourceType
+					bucket.GetName(), // sourceName
+					bucketUUID,       // sourceUUID
+					sourceParams,     // sourceParams
+					indexType,        // indexType
+					legacyIndexName,  // indexName
+					indexParams,      // indexParams
+					planParams,       // planParams
+					"",               // prevIndexUUID
 				)
 				require.NoError(t, err, "Unable to create legacy-style index")
 			}
@@ -281,15 +281,15 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 	}
 
 	err = context.Manager.CreateIndex(
-		SOURCE_GOCB_DCP_SG, // sourceType
-		bucket.GetName(),   // sourceName
-		bucketUUID,         // sourceUUID
-		sourceParams,       // sourceParams
-		indexType,          // indexType
-		legacyIndexName,    // indexName
-		indexParams,        // indexParams
-		planParams,         // planParams
-		"",                 // prevIndexUUID
+		SOURCE_DCP_SG,    // sourceType
+		bucket.GetName(), // sourceName
+		bucketUUID,       // sourceUUID
+		sourceParams,     // sourceParams
+		indexType,        // indexType
+		legacyIndexName,  // indexName
+		indexParams,      // indexParams
+		planParams,       // planParams
+		"",               // prevIndexUUID
 	)
 	require.NoError(t, err, "Unable to create legacy-style index")
 
@@ -357,15 +357,15 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 	}
 
 	err = context.Manager.CreateIndex(
-		SOURCE_GOCB_DCP_SG, // sourceType
-		bucket.GetName(),   // sourceName
-		bucketUUID,         // sourceUUID
-		sourceParams,       // sourceParams
-		indexType,          // indexType
-		legacyIndexName,    // indexName
-		indexParams,        // indexParams
-		planParams,         // planParams
-		"",                 // prevIndexUUID
+		SOURCE_DCP_SG,    // sourceType
+		bucket.GetName(), // sourceName
+		bucketUUID,       // sourceUUID
+		sourceParams,     // sourceParams
+		indexType,        // indexType
+		legacyIndexName,  // indexName
+		indexParams,      // indexParams
+		planParams,       // planParams
+		"",               // prevIndexUUID
 	)
 	require.NoError(t, err, "Unable to create legacy-style index")
 

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -343,15 +343,30 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 		"some-datasource",
 		eventHandlers,
 		options)
-	listener1, err := NewImportHeartbeatListener(cfgCB, testManager)
+	listener1, err := NewImportHeartbeatListener(&CbgtContext{
+		Cfg:           cfgCB,
+		Manager:       testManager,
+		loggingCtx:    TestCtx(t),
+		LithiumCompat: NewAtomicBool(false),
+	})
 	assert.NoError(t, err)
 	assert.NoError(t, node1.RegisterListener(listener1))
 
-	listener2, err := NewImportHeartbeatListener(cfgCB, testManager)
+	listener2, err := NewImportHeartbeatListener(&CbgtContext{
+		Cfg:           cfgCB,
+		Manager:       testManager,
+		loggingCtx:    TestCtx(t),
+		LithiumCompat: NewAtomicBool(false),
+	})
 	assert.NoError(t, err)
 	assert.NoError(t, node2.RegisterListener(listener2))
 
-	listener3, err := NewImportHeartbeatListener(cfgCB, testManager)
+	listener3, err := NewImportHeartbeatListener(&CbgtContext{
+		Cfg:           cfgCB,
+		Manager:       testManager,
+		loggingCtx:    TestCtx(t),
+		LithiumCompat: NewAtomicBool(false),
+	})
 	assert.NoError(t, err)
 	assert.NoError(t, node3.RegisterListener(listener3))
 

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -344,28 +344,25 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 		eventHandlers,
 		options)
 	listener1, err := NewImportHeartbeatListener(&CbgtContext{
-		Cfg:           cfgCB,
-		Manager:       testManager,
-		loggingCtx:    TestCtx(t),
-		LithiumCompat: NewAtomicBool(false),
+		Cfg:        cfgCB,
+		Manager:    testManager,
+		loggingCtx: TestCtx(t),
 	})
 	assert.NoError(t, err)
 	assert.NoError(t, node1.RegisterListener(listener1))
 
 	listener2, err := NewImportHeartbeatListener(&CbgtContext{
-		Cfg:           cfgCB,
-		Manager:       testManager,
-		loggingCtx:    TestCtx(t),
-		LithiumCompat: NewAtomicBool(false),
+		Cfg:        cfgCB,
+		Manager:    testManager,
+		loggingCtx: TestCtx(t),
 	})
 	assert.NoError(t, err)
 	assert.NoError(t, node2.RegisterListener(listener2))
 
 	listener3, err := NewImportHeartbeatListener(&CbgtContext{
-		Cfg:           cfgCB,
-		Manager:       testManager,
-		loggingCtx:    TestCtx(t),
-		LithiumCompat: NewAtomicBool(false),
+		Cfg:        cfgCB,
+		Manager:    testManager,
+		loggingCtx: TestCtx(t),
 	})
 	assert.NoError(t, err)
 	assert.NoError(t, node3.RegisterListener(listener3))

--- a/base/version_comparable.go
+++ b/base/version_comparable.go
@@ -24,6 +24,16 @@ type ComparableVersion struct {
 	str                               string
 }
 
+var zeroComparableVersion = &ComparableVersion{
+	epoch:   0,
+	major:   0,
+	minor:   0,
+	patch:   0,
+	other:   0,
+	build:   0,
+	edition: "",
+}
+
 // NewComparableVersionFromString parses a ComparableVersion from the given version string.
 // Expected format: `[epoch:]major.minor.patch[.other][@build][-edition]`
 func NewComparableVersionFromString(version string) (*ComparableVersion, error) {
@@ -116,6 +126,21 @@ func (pv *ComparableVersion) String() string {
 		pv.str = pv.formatComparableVersion()
 	})
 	return pv.str
+}
+
+// MarshalJSON implements json.Marshaler for ComparableVersion. The JSON representation is the version string.
+func (pv *ComparableVersion) MarshalJSON() ([]byte, error) {
+	return JSONMarshal(pv.String())
+}
+
+func (pv *ComparableVersion) UnmarshalJSON(val []byte) error {
+	var strVal string
+	err := JSONUnmarshal(val, &strVal)
+	if err != nil {
+		return err
+	}
+	pv.epoch, pv.major, pv.minor, pv.patch, pv.other, pv.build, pv.edition, err = parseComparableVersion(strVal)
+	return err
 }
 
 const (

--- a/db/database.go
+++ b/db/database.go
@@ -161,6 +161,7 @@ type DatabaseContextOptions struct {
 	GroupID                       string
 	JavascriptTimeout             time.Duration // Max time the JS functions run for (ie. sync fn, import filter)
 	skipRegisterImportPIndex      bool          // if set, skips the global gocb PIndex registration
+	skipStartHeartbeatChecking    bool          // if set, does not automatically call StartCheckingHeartbeats
 }
 
 type SGReplicateOptions struct {
@@ -592,7 +593,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 
 	// Start checking heartbeats for other nodes.  Must be done after caching feed starts, to ensure any removals
 	// are detected and processed by this node.
-	if dbContext.Heartbeater != nil {
+	if dbContext.Heartbeater != nil && !options.skipStartHeartbeatChecking {
 		err = dbContext.Heartbeater.StartCheckingHeartbeats()
 		if err != nil {
 			return nil, err

--- a/db/database.go
+++ b/db/database.go
@@ -161,7 +161,6 @@ type DatabaseContextOptions struct {
 	GroupID                       string
 	JavascriptTimeout             time.Duration // Max time the JS functions run for (ie. sync fn, import filter)
 	skipRegisterImportPIndex      bool          // if set, skips the global gocb PIndex registration
-	skipStartHeartbeatChecking    bool          // if set, does not automatically call StartCheckingHeartbeats
 }
 
 type SGReplicateOptions struct {
@@ -593,7 +592,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 
 	// Start checking heartbeats for other nodes.  Must be done after caching feed starts, to ensure any removals
 	// are detected and processed by this node.
-	if dbContext.Heartbeater != nil && !options.skipStartHeartbeatChecking {
+	if dbContext.Heartbeater != nil {
 		err = dbContext.Heartbeater.StartCheckingHeartbeats()
 		if err != nil {
 			return nil, err

--- a/db/dcp_sharded_upgrade_test.go
+++ b/db/dcp_sharded_upgrade_test.go
@@ -175,6 +175,9 @@ func TestShardedDCPUpgrade(t *testing.T) {
 	if !base.IsEnterpriseEdition() {
 		t.Skip("EE-only test")
 	}
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Heartbeat listener requires Couchbase Server")
+	}
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyDCP, base.KeyImport, base.KeyCluster)
 	tb := base.GetTestBucket(t)
 	defer tb.Close()

--- a/db/dcp_sharded_upgrade_test.go
+++ b/db/dcp_sharded_upgrade_test.go
@@ -213,7 +213,6 @@ func TestShardedDCPUpgrade(t *testing.T) {
 	require.NoError(t, err, "NewDatabaseContext")
 	defer db.Close()
 
-	// Wait until cbgt removes the old (non-existent) node from the config
 	err, _ = base.RetryLoop("wait for non-existent node to be removed", func() (shouldRetry bool, err error, value interface{}) {
 		nodes, _, err := cbgt.CfgGetNodeDefs(db.CfgSG, cbgt.NODE_DEFS_KNOWN)
 		if err != nil {
@@ -228,7 +227,6 @@ func TestShardedDCPUpgrade(t *testing.T) {
 	}, base.CreateSleeperFunc(100, 100))
 	require.NoError(t, err)
 
-	// wait for all pindexes to be reassigned
 	err, _ = base.RetryLoop("wait for all pindexes to be reassigned", func() (shouldRetry bool, err error, value interface{}) {
 		pIndexes, _, err := cbgt.CfgGetPlanPIndexes(db.CfgSG)
 		if err != nil {

--- a/db/dcp_sharded_upgrade_test.go
+++ b/db/dcp_sharded_upgrade_test.go
@@ -202,8 +202,6 @@ func TestShardedDCPUpgrade(t *testing.T) {
 	)
 	require.NoError(t, tb.SetRaw(testDoc1, 0, nil, []byte(`{}`)))
 
-	// Start a database context with heartbeating disabled, so we can check that the manager picks up the appropriate pindexes
-	// but does not yet kick out the old node
 	db, err := NewDatabaseContext(tb.GetName(), tb.NoCloseClone(), true, DatabaseContextOptions{
 		GroupID:     "",
 		EnableXattr: true,
@@ -211,12 +209,9 @@ func TestShardedDCPUpgrade(t *testing.T) {
 		ImportOptions: ImportOptions{
 			ImportPartitions: numPartitions,
 		},
-		skipStartHeartbeatChecking: true,
 	})
 	require.NoError(t, err, "NewDatabaseContext")
 	defer db.Close()
-
-	require.NoError(t, db.Heartbeater.StartCheckingHeartbeats(), "StartCheckingHeartbeats")
 
 	// Wait until cbgt removes the old (non-existent) node from the config
 	err, _ = base.RetryLoop("wait for non-existent node to be removed", func() (shouldRetry bool, err error, value interface{}) {

--- a/db/dcp_sharded_upgrade_test.go
+++ b/db/dcp_sharded_upgrade_test.go
@@ -1,0 +1,283 @@
+package db
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const indexDefs = `{
+  "uuid": "438836eb24955a74",
+  "indexDefs": {
+    "db0x2d9928b7_index": {
+      "type": "syncGateway-import-",
+      "name": "db0x2d9928b7_index",
+      "uuid": "438836eb24955a74",
+      "sourceType": "couchbase-dcp-sg",
+      "sourceName": "%[1]s",
+      "sourceUUID": "%[2]s",
+      "planParams": {
+        "maxPartitionsPerPIndex": 64
+      },
+      "params": {
+        "destKey": "%[1]s_import"
+      },
+      "sourceParams": {
+        "includeXAttrs": true,
+        "sg_dbname": "%[1]s"
+      }
+    }
+  },
+  "implVersion": "5.5.0"
+}`
+
+const nodeDefs = `{
+  "uuid": "5f2462bb9e15a7b2",
+  "nodeDefs": {
+    "680cce1d31e72b69": {
+      "hostPort": "680cce1d31e72b69",
+      "uuid": "680cce1d31e72b69",
+      "implVersion": "5.5.0",
+      "tags": [
+        "feed",
+        "janitor",
+        "pindex",
+        "planner"
+      ],
+      "container": "",
+      "weight": 1,
+      "extras": ""
+    }
+  },
+  "implVersion": "5.5.0"
+}`
+
+const planPIndexes = `{
+  "uuid": "554a51c130c9b945",
+  "planPIndexes": {
+    "db0x2d9928b7_index_438836eb24955a74_103fc5fb": {
+      "name": "db0x2d9928b7_index_438836eb24955a74_103fc5fb",
+      "uuid": "20623badea9024a1",
+      "indexType": "syncGateway-import-",
+      "indexName": "db0x2d9928b7_index",
+      "indexUUID": "438836eb24955a74",
+      "sourceType": "couchbase-dcp-sg",
+      "sourceName": "%[1]s",
+      "sourceUUID": "%[2]s",
+      "sourcePartitions": "$SourcePartitions",
+      "nodes": {
+        "680cce1d31e72b69": {
+          "canRead": true,
+          "canWrite": true,
+          "priority": 0
+        }
+      },
+      "indexParams": {
+        "destKey": "%[1]s_import"
+      },
+      "sourceParams": {
+        "includeXAttrs": true,
+        "sg_dbname": "%[1]s"
+      }
+    },
+    "db0x2d9928b7_index_438836eb24955a74_1076212c": {
+      "name": "db0x2d9928b7_index_438836eb24955a74_1076212c",
+      "uuid": "617290ccf3f3e7d3",
+      "indexType": "syncGateway-import-",
+      "indexName": "db0x2d9928b7_index",
+      "indexUUID": "438836eb24955a74",
+      "sourceType": "couchbase-dcp-sg",
+      "sourceName": "%[1]s",
+      "sourceUUID": "%[2]s",
+      "sourcePartitions": "$SourcePartitions",
+      "nodes": {
+        "680cce1d31e72b69": {
+          "canRead": true,
+          "canWrite": true,
+          "priority": 0
+        }
+      },
+      "indexParams": {
+        "destKey": "%[1]s_import"
+      },
+      "sourceParams": {
+        "includeXAttrs": true,
+        "sg_dbname": "%[1]s"
+      }
+    },
+    "db0x2d9928b7_index_438836eb24955a74_120a6de6": {
+      "name": "db0x2d9928b7_index_438836eb24955a74_120a6de6",
+      "uuid": "3ccf34ea23fb9727",
+      "indexType": "syncGateway-import-",
+      "indexName": "db0x2d9928b7_index",
+      "indexUUID": "438836eb24955a74",
+      "sourceType": "couchbase-dcp-sg",
+      "sourceName": "%[1]s",
+      "sourceUUID": "%[2]s",
+      "sourcePartitions": "$SourcePartitions",
+      "nodes": {
+        "680cce1d31e72b69": {
+          "canRead": true,
+          "canWrite": true,
+          "priority": 0
+        }
+      },
+      "indexParams": {
+        "destKey": "%[1]s_import"
+      },
+      "sourceParams": {
+        "includeXAttrs": true,
+        "sg_dbname": "%[1]s"
+      }
+    },
+    "db0x2d9928b7_index_438836eb24955a74_15a93994": {
+      "name": "db0x2d9928b7_index_438836eb24955a74_15a93994",
+      "uuid": "4c167ac08c668923",
+      "indexType": "syncGateway-import-",
+      "indexName": "db0x2d9928b7_index",
+      "indexUUID": "438836eb24955a74",
+      "sourceType": "couchbase-dcp-sg",
+      "sourceName": "%[1]s",
+      "sourceUUID": "%[2]s",
+      "sourcePartitions": "$SourcePartitions",
+      "nodes": {
+        "680cce1d31e72b69": {
+          "canRead": true,
+          "canWrite": true,
+          "priority": 0
+        }
+      },
+      "indexParams": {
+        "destKey": "%[1]s_import"
+      },
+      "sourceParams": {
+        "includeXAttrs": true,
+        "sg_dbname": "%[1]s"
+      }
+    }
+  },
+  "implVersion": "5.5.0",
+  "warnings": {
+    "db0x2d9928b7_index": []
+  }
+}`
+
+func TestShardedDCPUpgradeHelium(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Requires Couchbase Server")
+	}
+	if !base.IsEnterpriseEdition() {
+		t.Skip("EE-only test")
+	}
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyDCP, base.KeyImport, base.KeyCluster)
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+	bucketUUID, err := tb.UUID()
+	require.NoError(t, err, "get bucket UUID")
+
+	numVBuckets, err := tb.GetMaxVbno()
+	require.NoError(t, err)
+
+	const numPartitions = 4
+
+	require.NoError(t, tb.SetRaw(base.SyncPrefix+"cfgindexDefs", 0, nil, []byte(fmt.Sprintf(indexDefs, tb.GetName(), bucketUUID))))
+	require.NoError(t, tb.SetRaw(base.SyncPrefix+"cfgnodeDefs-known", 0, nil, []byte(nodeDefs)))
+	require.NoError(t, tb.SetRaw(base.SyncPrefix+"cfgnodeDefs-wanted", 0, nil, []byte(nodeDefs)))
+	planPIndexesJSON := preparePlanPIndexesJSON(t, tb, numVBuckets, numPartitions)
+	require.NoError(t, tb.SetRaw(base.SyncPrefix+"cfgplanPIndexes", 0, nil, []byte(planPIndexesJSON)))
+
+	// Write a doc before starting the dbContext to check that import works
+	const (
+		testDoc1 = "testDoc1"
+		testDoc2 = "testDoc2"
+	)
+	require.NoError(t, tb.SetRaw(testDoc1, 0, nil, []byte(`{}`)))
+
+	t.Log("TEST: setup complete")
+
+	// Start this retry loop asynchronously because the change may happen before NewDatabaseContext returns
+	db, err := NewDatabaseContext(tb.GetName(), tb, true, DatabaseContextOptions{
+		GroupID:                    "",
+		EnableXattr:                true,
+		UseViews:                   base.TestsDisableGSI(),
+		skipStartHeartbeatChecking: true,
+		ImportOptions: ImportOptions{
+			ImportPartitions: numPartitions,
+		},
+	})
+	require.NoError(t, err, "NewDatabaseContext")
+	defer db.Close()
+
+	//pIndexes, _, err := cbgt.CfgGetPlanPIndexes(db.CfgSG)
+	//require.NoError(t, err)
+	// TODO: sometimes cbgt adds and immediately removes a PIndex causing this to fail
+	//assert.Len(t, pIndexes.PlanPIndexes, numPartitions, "number of planPIndexes should match partitions after DbContext start")
+
+	require.NoError(t, db.WaitForPendingChanges(base.TestCtx(t)))
+	doc, err := db.GetDocument(base.TestCtx(t), testDoc1, DocUnmarshalAll)
+	require.NoError(t, err, "GetDocument 1")
+	require.NotNil(t, doc, "GetDocument 1")
+
+	assert.True(t, db.ImportListener.cbgtContext.LithiumCompat.IsTrue(), "LithiumCompat")
+
+	require.NoError(t, db.Heartbeater.StartCheckingHeartbeats())
+
+	// Now wait for it to pick up that the Lithium "node" isn't actually heartbeating
+	err, _ = base.RetryLoop("wait for LithiumCompat to become false", func() (shouldRetry bool, err error, value interface{}) {
+		if db == nil {
+			return true, nil, nil
+		}
+		return db.ImportListener.cbgtContext.LithiumCompat.IsTrue(), nil, nil
+		// will take around ~10 seconds at least
+	}, base.CreateSleeperFunc(200, 10))
+	assert.NoError(t, err, "LithiumCompat never became false")
+
+	//pIndexes, _, err = cbgt.CfgGetPlanPIndexes(db.CfgSG)
+	//require.NoError(t, err)
+	// TODO: sometimes cbgt adds and immediately removes a PIndex causing this to fail
+	//assert.Len(t, pIndexes.PlanPIndexes, numPartitions, "number of planPIndexes should match partitions after LithiumCompat change")
+
+	// And write another doc to check that import still works
+	require.NoError(t, tb.SetRaw(testDoc2, 0, nil, []byte(`{}`)))
+	require.NoError(t, db.WaitForPendingChanges(base.TestCtx(t)))
+	doc, err = db.GetDocument(base.TestCtx(t), testDoc2, DocUnmarshalAll)
+	require.NoError(t, err, "GetDocument 2")
+	require.NotNil(t, doc, "GetDocument 2")
+}
+
+// preparePlanPIndexesJSON processes the hard-coded planPIndexes value and replaces the $SourcePartitions with increasing
+// vBucket numbers.
+func preparePlanPIndexesJSON(t *testing.T, tb *base.TestBucket, numVBuckets uint16, numPartitions int) string {
+	t.Helper()
+
+	uuid, err := tb.UUID()
+	require.NoError(t, err, "get bucket UUID")
+	planPIndexesJSON := fmt.Sprintf(planPIndexes, tb.GetName(), uuid)
+	numVBsPerPartition := int(numVBuckets) / numPartitions
+	highestVBNo := 0
+
+	for strings.Contains(planPIndexesJSON, "$SourcePartitions") {
+		if highestVBNo == int(numVBuckets) {
+			t.Fatalf("Test misconfigured = numPartitions is %d, but planPIndexes has more instances of '$SourcePartitions'", numPartitions)
+		}
+		vBs := make([]string, 0, numVBsPerPartition)
+		prevHighestVBNo := highestVBNo
+		for ; highestVBNo < (prevHighestVBNo + numVBsPerPartition); highestVBNo++ {
+			vBs = append(vBs, strconv.Itoa(highestVBNo))
+		}
+		sourcePartitionsStr := strings.Join(vBs, ",")
+		planPIndexesJSON = strings.Replace(planPIndexesJSON, "$SourcePartitions", sourcePartitionsStr, 1)
+	}
+	if highestVBNo != int(numVBuckets) {
+		t.Fatalf("Test misconfigured = numPartitions is %d, but planPIndexes doesn't have enough '$SourcePartitions'", numPartitions)
+	}
+	return planPIndexesJSON
+}


### PR DESCRIPTION
CBG-2213

Change the behaviour of the sharded DCP feed to accommodate rolling online upgrades from pre-Helium to Helium nodes.

* Rather than registering a new feed type for the gocbcore-backed feed, reuse the existing feed type - when only streaming the default collection, there is no functional difference. This means that there is no need to delete and re-create the index upon upgrade, which simplifies behaviour.
  * This also means we can simplify the connection string logic, as there is no need to replace `couchbase[s]://` with `http[s]://` for gocbcore (as we used to for cbdatasource).
* Add an integration test for the above behaviour. The upgrade itself will likely need functional testing (and/or CBG-2273).

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `server=7.0.3` https://jenkins.sgwdev.com/job/SyncGateway-Integration/530/
- [ ] `server=6.6.5`https://jenkins.sgwdev.com/job/SyncGateway-Integration/531/
- Bucket flush failures on both. Re-ran with only the `db` package in https://jenkins.sgwdev.com/job/SyncGateway-Integration/585/ and https://jenkins.sgwdev.com/job/SyncGateway-Integration/586/ respectively.