### PR TITLE
CBG-2234 make DCPClient.Close blocking

### DIFF
--- a/base/gocb_dcp_feed.go
+++ b/base/gocb_dcp_feed.go
@@ -85,38 +85,24 @@ func StartGocbDCPFeed(collection *Collection, bucketName string, args sgbucket.F
 	loggingCtx := context.TODO()
 	if err != nil {
 		ErrorfCtx(loggingCtx, "Failed to start DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), err)
-		// simplify in CBG-2234
-		closeErr := dcpClient.Close()
-		ErrorfCtx(loggingCtx, "Finished called async close error from DCP Feed %q for bucket %q", feedName, MD(bucketName))
-		if closeErr != nil {
-			ErrorfCtx(loggingCtx, "Close error from DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), closeErr)
-		}
-		asyncCloseErr := <-doneChan
-		ErrorfCtx(loggingCtx, "Finished calling async close error from DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), asyncCloseErr)
 		return err
 	}
 	InfofCtx(loggingCtx, KeyDCP, "Started DCP Feed %q for bucket %q", feedName, MD(bucketName))
 	go func() {
 		select {
 		case dcpCloseError := <-doneChan:
-			// simplify close in CBG-2234
 			// This is a close because DCP client closed on its own, which should never happen since once
 			// DCP feed is started, there is nothing that will close it
 			InfofCtx(loggingCtx, KeyDCP, "Forced closed DCP Feed %q for %q", feedName, MD(bucketName))
 			// wait for channel close
-			<-doneChan
 			if dcpCloseError != nil {
 				WarnfCtx(loggingCtx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseError)
 			}
-			// FIXME: close dbContext here
+			ErrorfCtx(loggingCtx, "DCP Feed %q for %q closed unexpectedly, this behavior is undefined, err: %w", feedName, MD(bucketName), dcpCloseError)
 			break
 		case <-args.Terminator:
 			InfofCtx(loggingCtx, KeyDCP, "Closing DCP Feed %q for bucket %q based on termination notification", feedName, MD(bucketName))
 			dcpCloseErr := dcpClient.Close()
-			if dcpCloseErr != nil {
-				WarnfCtx(loggingCtx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseErr)
-			}
-			dcpCloseErr = <-doneChan
 			if dcpCloseErr != nil {
 				WarnfCtx(loggingCtx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseErr)
 			}


### PR DESCRIPTION
This makes jenkins tests hang in rest sometimes, but this looks like it doesn't change behavior. It will pass if you run all the tests separately.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1017/
- [x] `GSI=false,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1019/