### PR TITLE
Refactor: move CreateTestBucketScopesAndCollections to base

### DIFF
--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -203,7 +203,14 @@ func (rt *RestTester) Bucket() base.Bucket {
 		}
 
 		if rt.createScopesAndCollections {
-			if err := createTestBucketScopesAndCollections(base.TestCtx(rt.tb), rt.testBucket, rt.DatabaseConfig.Scopes); err != nil {
+			scopes := make(map[string][]string)
+			for scopeName, scopeCfg := range rt.DatabaseConfig.Scopes {
+				scopes[scopeName] = make([]string, 0, len(scopeCfg.Collections))
+				for collName := range scopeCfg.Collections {
+					scopes[scopeName] = append(scopes[scopeName], collName)
+				}
+			}
+			if err := base.CreateTestBucketScopesAndCollections(base.TestCtx(rt.tb), rt.testBucket, scopes); err != nil {
 				rt.tb.Fatalf("Error creating test scopes/collections: %v", err)
 			}
 		}


### PR DESCRIPTION
Allows it to be used from packages other than `rest`.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/569/