### PR TITLE
CBG-2255: Added new startup flag for changing SG defaults

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -160,6 +160,7 @@ type DatabaseContextOptions struct {
 	BcryptCost                    int
 	GroupID                       string
 	JavascriptTimeout             time.Duration // Max time the JS functions run for (ie. sync fn, import filter)
+	Serverless                    bool          // If running in serverless mode
 	skipRegisterImportPIndex      bool          // if set, skips the global gocb PIndex registration
 }
 

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1942,6 +1942,10 @@ Startup-config:
       description: Settings that are not officially supported. It is highly recommended these are **not** used.
       type: object
       properties:
+        serverless:
+          description: Put SG in to serverless mode
+          type: boolean
+          readOnly: true
         stats_log_frequency:
           description: |-
             How often should stats be written to stats logs.
@@ -1988,10 +1992,6 @@ Startup-config:
     couchbase_keepalive_interval:
       description: TCP keep-alive interval between SG and Couchbase server
       type: integer
-      readOnly: true
-    serverless:
-      description: Put SG in to serverless mode
-      type: boolean
       readOnly: true
   title: Startup-config
 File-logging-config:

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1989,6 +1989,10 @@ Startup-config:
       description: TCP keep-alive interval between SG and Couchbase server
       type: integer
       readOnly: true
+    serverless:
+      description: Put SG in to serverless mode
+      type: boolean
+      readOnly: true
   title: Startup-config
 File-logging-config:
   type: object

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1943,7 +1943,7 @@ Startup-config:
       type: object
       properties:
         serverless:
-          description: Put SG in to serverless mode
+          description: Run SG in to serverless mode
           type: boolean
           readOnly: true
         stats_log_frequency:

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -126,6 +126,8 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 
 		"max_file_descriptors": {&config.MaxFileDescriptors, fs.Uint64("max_file_descriptors", 0, "Max # of open file descriptors (RLIMIT_NOFILE)")},
 
+		"serverless": {&config.Serverless, fs.Bool("serverless", false, "Put SG in to serverless mode.")},
+
 		"couchbase_keepalive_interval": {&config.CouchbaseKeepaliveInterval, fs.Int("couchbase_keepalive_interval", 0, "TCP keep-alive interval between SG and Couchbase server")},
 	}
 }

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -117,7 +117,7 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"replicator.max_heartbeat":    {&config.Replicator.MaxHeartbeat, fs.String("replicator.max_heartbeat", "", "Max heartbeat value for _changes request")},
 		"replicator.blip_compression": {&config.Replicator.BLIPCompression, fs.Int("replicator.blip_compression", 0, "BLIP data compression level (0-9)")},
 
-		"unsupported.serverless":          {&config.Unsupported.Serverless, fs.Bool("unsupported.serverless", false, "Put SG in to serverless mode.")},
+		"unsupported.serverless":          {&config.Unsupported.Serverless, fs.Bool("unsupported.serverless", false, "Run SG in to serverless mode.")},
 		"unsupported.stats_log_frequency": {&config.Unsupported.StatsLogFrequency, fs.String("unsupported.stats_log_frequency", "", "How often should stats be written to stats logs")},
 		"unsupported.use_stdlib_json":     {&config.Unsupported.UseStdlibJSON, fs.Bool("unsupported.use_stdlib_json", false, "Bypass the jsoniter package and use Go's stdlib instead")},
 

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -117,6 +117,7 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"replicator.max_heartbeat":    {&config.Replicator.MaxHeartbeat, fs.String("replicator.max_heartbeat", "", "Max heartbeat value for _changes request")},
 		"replicator.blip_compression": {&config.Replicator.BLIPCompression, fs.Int("replicator.blip_compression", 0, "BLIP data compression level (0-9)")},
 
+		"unsupported.serverless":          {&config.Unsupported.Serverless, fs.Bool("unsupported.serverless", false, "Put SG in to serverless mode.")},
 		"unsupported.stats_log_frequency": {&config.Unsupported.StatsLogFrequency, fs.String("unsupported.stats_log_frequency", "", "How often should stats be written to stats logs")},
 		"unsupported.use_stdlib_json":     {&config.Unsupported.UseStdlibJSON, fs.Bool("unsupported.use_stdlib_json", false, "Bypass the jsoniter package and use Go's stdlib instead")},
 
@@ -125,8 +126,6 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"database_credentials": {&config.DatabaseCredentials, fs.String("database_credentials", "null", "JSON-encoded per-database credentials")},
 
 		"max_file_descriptors": {&config.MaxFileDescriptors, fs.Uint64("max_file_descriptors", 0, "Max # of open file descriptors (RLIMIT_NOFILE)")},
-
-		"serverless": {&config.Serverless, fs.Bool("serverless", false, "Put SG in to serverless mode.")},
 
 		"couchbase_keepalive_interval": {&config.CouchbaseKeepaliveInterval, fs.Int("couchbase_keepalive_interval", 0, "TCP keep-alive interval between SG and Couchbase server")},
 	}

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -70,7 +70,6 @@ type StartupConfig struct {
 
 	MaxFileDescriptors         uint64 `json:"max_file_descriptors,omitempty" help:"Max # of open file descriptors (RLIMIT_NOFILE)"`
 	CouchbaseKeepaliveInterval *int   `json:"couchbase_keepalive_interval,omitempty" help:"TCP keep-alive interval between SG and Couchbase server"`
-	Serverless                 *bool  `json:"serverless,omitempty" help:"Put SG in to serverless mode."`
 
 	DeprecatedConfig *DeprecatedConfig `json:"-,omitempty" help:"Deprecated options that can be set from a legacy config upgrade, but cannot be set from a 3.0 config."`
 }
@@ -136,6 +135,7 @@ type ReplicatorConfig struct {
 }
 
 type UnsupportedConfig struct {
+	Serverless        *bool                `json:"serverless,omitempty" help:"Put SG in to serverless mode."`
 	StatsLogFrequency *base.ConfigDuration `json:"stats_log_frequency,omitempty"    help:"How often should stats be written to stats logs"`
 	UseStdlibJSON     *bool                `json:"use_stdlib_json,omitempty"        help:"Bypass the jsoniter package and use Go's stdlib instead"`
 

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -51,6 +51,7 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 			BcryptCost: auth.DefaultBcryptCost,
 		},
 		Unsupported: UnsupportedConfig{
+			Serverless:        base.BoolPtr(false),
 			StatsLogFrequency: base.NewConfigDuration(time.Minute),
 		},
 		MaxFileDescriptors: DefaultMaxFileDescriptors,

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -70,6 +70,7 @@ type StartupConfig struct {
 
 	MaxFileDescriptors         uint64 `json:"max_file_descriptors,omitempty" help:"Max # of open file descriptors (RLIMIT_NOFILE)"`
 	CouchbaseKeepaliveInterval *int   `json:"couchbase_keepalive_interval,omitempty" help:"TCP keep-alive interval between SG and Couchbase server"`
+	Serverless                 *bool  `json:"serverless,omitempty" help:"Put SG in to serverless mode."`
 
 	DeprecatedConfig *DeprecatedConfig `json:"-,omitempty" help:"Deprecated options that can be set from a legacy config upgrade, but cannot be set from a 3.0 config."`
 }

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -136,7 +136,7 @@ type ReplicatorConfig struct {
 }
 
 type UnsupportedConfig struct {
-	Serverless        *bool                `json:"serverless,omitempty" help:"Put SG in to serverless mode."`
+	Serverless        *bool                `json:"serverless,omitempty" help:"Run SG in to serverless mode."`
 	StatsLogFrequency *base.ConfigDuration `json:"stats_log_frequency,omitempty"    help:"How often should stats be written to stats logs"`
 	UseStdlibJSON     *bool                `json:"use_stdlib_json,omitempty"        help:"Bypass the jsoniter package and use Go's stdlib instead"`
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -826,6 +826,7 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		BcryptCost:                bcryptCost,
 		GroupID:                   groupID,
 		JavascriptTimeout:         javascriptTimeout,
+		Serverless:                base.BoolDefault(sc.config.Unsupported.Serverless, false),
 	}
 
 	return contextOptions, nil


### PR DESCRIPTION
CBG-2255

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`