### PR TITLE
CBG-2203 Report db read error on collection, for client to retry

### DIFF
--- a/db/blip_handler_collections.go
+++ b/db/blip_handler_collections.go
@@ -76,7 +76,7 @@ func (bh *blipHandler) handleGetCollections(rq *blip.Message) error {
 			} else {
 				errMsg := fmt.Sprintf("Unable to fetch client checkpoint %q for collection %s: %s", key, scopeAndCollection, err)
 				base.WarnfCtx(bh.loggingCtx, errMsg)
-				return base.HTTPErrorf(status, errMsg)
+				return base.HTTPErrorf(http.StatusServiceUnavailable, errMsg)
 			}
 			continue
 		}


### PR DESCRIPTION
I don't know how to test this without a leaky bucket, since I need `GetSpecial` to fail. I tried taking the database offline and setting `BucketOpTimeoutMs` be be a very small value but it still would hang for long periods of time.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/596/