### PR TITLE
CBG-2264: Set collection property on outgoing BLIP messages

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -51,8 +51,9 @@ const maxInFlightChangesBatches = 2
 
 type blipHandler struct {
 	*BlipSyncContext
-	db         *Database // Handler-specific copy of the BlipSyncContext's blipContextDb
-	collection *Database // Handler-specific copy of the BlipSyncContext's collection specific DB
+	db            *Database // Handler-specific copy of the BlipSyncContext's blipContextDb
+	collection    *Database // Handler-specific copy of the BlipSyncContext's collection specific DB
+	collectionIdx *int      // index into BlipSyncContext.collectionMapping for the collection
 
 	serialNumber uint64 // This blip handler's serial number to differentiate logs w/ other handlers
 }
@@ -143,6 +144,7 @@ func collectionBlipHandler(next blipHandlerFunc) blipHandlerFunc {
 			return base.HTTPErrorf(http.StatusBadRequest, "collection property needs to be an int, was %q", collectionIndexStr)
 		}
 
+		bh.collectionIdx = &collectionIndex
 		if len(bh.collectionMapping) <= collectionIndex {
 			return base.HTTPErrorf(http.StatusBadRequest, "Collection index %d is outside indexes set by GetCollections", collectionIndex)
 		}
@@ -485,6 +487,9 @@ func (bh *blipHandler) sendBatchOfChanges(sender *blip.Sender, changeArray [][]i
 	if ignoreNoConflicts {
 		outrq.Properties[ChangesMessageIgnoreNoConflicts] = trueProperty
 	}
+	if bh.collectionIdx != nil {
+		outrq.Properties[BlipCollection] = strconv.Itoa(*bh.collectionIdx)
+	}
 	err := outrq.SetJSONBody(changeArray)
 	if err != nil {
 		base.InfofCtx(bh.loggingCtx, base.KeyAll, "Error setting changes: %v", err)
@@ -750,7 +755,11 @@ func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 
 // ////// DOCUMENTS:
 
-func (bsc *BlipSyncContext) sendRevAsDelta(sender *blip.Sender, docID, revID, deltaSrcRevID string, seq SequenceID, knownRevs map[string]bool, maxHistory int, handleChangesResponseDb *Database) error {
+func (bsc *BlipSyncContext) sendRevAsDelta(sender *blip.Sender, docID, revID string, deltaSrcRevID string, seq SequenceID, knownRevs map[string]bool, maxHistory int, handleChangesResponseDb *Database) error {
+	var collectionIdx *int
+	if coll, ok := bsc.getCollectionIndexForDB(handleChangesResponseDb); ok {
+		collectionIdx = &coll
+	}
 
 	bsc.replicationStats.SendRevDeltaRequestedCount.Add(1)
 
@@ -772,7 +781,7 @@ func (bsc *BlipSyncContext) sendRevAsDelta(sender *blip.Sender, docID, revID, de
 	if redactedRev != nil {
 		history := toHistory(redactedRev.History, knownRevs, maxHistory)
 		properties := blipRevMessageProperties(history, redactedRev.Deleted, seq)
-		return bsc.sendRevisionWithProperties(sender, docID, revID, redactedRev.BodyBytes, nil, properties, seq, nil)
+		return bsc.sendRevisionWithProperties(sender, docID, revID, collectionIdx, redactedRev.BodyBytes, nil, properties, seq, nil)
 	}
 
 	if revDelta == nil {
@@ -786,7 +795,7 @@ func (bsc *BlipSyncContext) sendRevAsDelta(sender *blip.Sender, docID, revID, de
 	}
 
 	base.TracefCtx(bsc.loggingCtx, base.KeySync, "docID: %s - delta: %v", base.UD(docID), base.UD(string(revDelta.DeltaBytes)))
-	if err := bsc.sendDelta(sender, docID, deltaSrcRevID, revDelta, seq, resendFullRevisionFunc); err != nil {
+	if err := bsc.sendDelta(sender, docID, collectionIdx, deltaSrcRevID, revDelta, seq, resendFullRevisionFunc); err != nil {
 		return err
 	}
 
@@ -1194,7 +1203,11 @@ var errNoBlipHandler = fmt.Errorf("404 - No handler for BLIP request")
 func (bh *blipHandler) sendGetAttachment(sender *blip.Sender, docID string, name string, digest string, meta map[string]interface{}) ([]byte, error) {
 	base.DebugfCtx(bh.loggingCtx, base.KeySync, "    Asking for attachment %q for doc %s (digest %s)", base.UD(name), base.UD(docID), digest)
 	outrq := blip.NewRequest()
-	outrq.Properties = map[string]string{BlipProfile: MessageGetAttachment, GetAttachmentDigest: digest}
+	outrq.SetProfile(MessageGetAttachment)
+	outrq.Properties[GetAttachmentDigest] = digest
+	if bh.collectionIdx != nil {
+		outrq.Properties[BlipCollection] = strconv.Itoa(*bh.collectionIdx)
+	}
 	if isCompressible(name, meta) {
 		outrq.Properties[BlipCompress] = trueProperty
 	}
@@ -1240,7 +1253,11 @@ func (bh *blipHandler) sendProveAttachment(sender *blip.Sender, docID, name, dig
 		return err
 	}
 	outrq := blip.NewRequest()
-	outrq.Properties = map[string]string{BlipProfile: MessageProveAttachment, ProveAttachmentDigest: digest}
+	outrq.SetProfile(MessageProveAttachment)
+	outrq.Properties[ProveAttachmentDigest] = digest
+	if bh.collectionIdx != nil {
+		outrq.Properties[BlipCollection] = strconv.Itoa(*bh.collectionIdx)
+	}
 	outrq.SetBody(nonce)
 	if !bh.sendBLIPMessage(sender, outrq) {
 		return ErrClosedBLIPSender

--- a/db/blip_handler_collections.go
+++ b/db/blip_handler_collections.go
@@ -90,3 +90,15 @@ func (bh *blipHandler) handleGetCollections(rq *blip.Message) error {
 	}
 	return response.SetJSONBody(checkpoints)
 }
+
+func (bsc *BlipSyncContext) getCollectionIndexForDB(db *Database) (int, bool) {
+	if bsc.collectionMapping == nil {
+		return 0, false
+	}
+	for i, iDB := range bsc.collectionMapping {
+		if iDB.BucketSpec.Scope == db.BucketSpec.Scope && iDB.BucketSpec.Collection == db.BucketSpec.Collection {
+			return i, true
+		}
+	}
+	return 0, false
+}

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strconv"
 	"strings"
 
 	"github.com/couchbase/go-blip"
@@ -33,11 +34,12 @@ const (
 	MessageGetAttachment   = "getAttachment"
 	MessageProposeChanges  = "proposeChanges"
 	MessageProveAttachment = "proveAttachment"
-	MessageGetRev          = "getRev"       // Connected Client API
-	MessagePutRev          = "putRev"       // Connected Client API
-	MessageUnsubChanges    = "unsubChanges" // Connected Client API
+	MessageGetCollections  = "getCollections"
 
-	MessageGetCollections = "getCollections" // Connected Client API
+	MessageGetRev       = "getRev"       // Connected Client API
+	MessagePutRev       = "putRev"       // Connected Client API
+	MessageUnsubChanges = "unsubChanges" // Connected Client API
+
 )
 
 // Message properties
@@ -392,6 +394,26 @@ func (rm *RevMessage) SetNoConflicts(noConflicts bool) {
 	}
 }
 
+func (rm *RevMessage) Collection() (int, bool) {
+	val, ok := rm.Properties[BlipCollection]
+	if !ok {
+		return 0, false
+	}
+	intVal, err := strconv.Atoi(val)
+	if err != nil {
+		panic(fmt.Errorf("rev message has invalid %q %q: %w", BlipCollection, val, err))
+	}
+	return intVal, true
+}
+
+func (rm *RevMessage) SetCollection(val *int) {
+	if val != nil {
+		rm.Properties[BlipCollection] = strconv.Itoa(*val)
+	} else {
+		delete(rm.Properties, BlipCollection)
+	}
+}
+
 // setProperties will add the given properties to the blip message, overwriting any that already exist.
 func (rm *RevMessage) SetProperties(properties blip.Properties) {
 	for k, v := range properties {
@@ -405,6 +427,10 @@ func (rm *RevMessage) String() string {
 
 	if id, foundId := rm.ID(); foundId {
 		buffer.WriteString(fmt.Sprintf("Id:%v ", base.UD(id).Redact()))
+	}
+
+	if coll, ok := rm.Collection(); ok {
+		buffer.WriteString(fmt.Sprintf("Collection:%v ", coll))
 	}
 
 	if rev, foundRev := rm.Rev(); foundRev {
@@ -459,6 +485,14 @@ func (nrm *noRevMessage) SetReason(reason string) {
 
 func (nrm *noRevMessage) SetError(message string) {
 	nrm.Properties[NorevMessageError] = message
+}
+
+func (nrm *noRevMessage) SetCollection(val *int) {
+	if val != nil {
+		nrm.Properties[BlipCollection] = strconv.Itoa(*val)
+	} else {
+		delete(nrm.Properties, BlipCollection)
+	}
 }
 
 type getAttachmentParams struct {

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -1095,9 +1095,8 @@ func (btc *BlipTesterClient) getCollectionNameFromMessage(msg *blip.Message) (st
 		return "", nil
 	}
 
-	// FIXME: Remove when we have CBG-2264 implemented - Change this to return error
 	if collectionIdx == "" {
-		return btc.Collections[0], nil
+		return "", fmt.Errorf("no collection given in %q message", msg.Profile())
 	}
 
 	idx, err := strconv.Atoi(collectionIdx)

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -1105,7 +1105,7 @@ func (btc *BlipTesterClient) getCollectionNameFromMessage(msg *blip.Message) (st
 	}
 
 	if len(btc.Collections) < idx+1 {
-		return "", fmt.Errorf("idx not valid")
+		return "", fmt.Errorf("idx %d not valid", idx)
 	}
 	return btc.Collections[idx], nil
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -905,6 +905,10 @@ type BlipTester struct {
 
 	// The blip sender that can be used for sending messages over the websocket connection
 	sender *blip.Sender
+
+	// Set when we receive a reply to a getCollections request. Used to verify that all messages after that contain a
+	// `collection` property.
+	useCollections *base.AtomicBool
 }
 
 // Close the bliptester
@@ -957,7 +961,8 @@ func NewBlipTesterFromSpec(tb testing.TB, spec BlipTesterSpec) (*BlipTester, err
 // Create a BlipTester using the given spec
 func createBlipTesterWithSpec(tb testing.TB, spec BlipTesterSpec, rt *RestTester) (*BlipTester, error) {
 	bt := &BlipTester{
-		restTester: rt,
+		restTester:     rt,
+		useCollections: base.NewAtomicBool(false),
 	}
 
 	// Since blip requests all go over the public handler, wrap the public handler with the httptest server


### PR DESCRIPTION
CBG-2264

Ensure that outgoing `rev`, `norev`, `changes`, `getAttachment`, and `proveAttachment` messages all have a `collection` property set if collections are in use.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `gsi=true,package=rest` https://jenkins.sgwdev.com/job/SyncGateway-Integration/612/