### PR TITLE
Consistently clean up test scopes/collections

### DIFF
--- a/base/collection.go
+++ b/base/collection.go
@@ -705,10 +705,6 @@ func (c *Collection) Flush() error {
 	bucketManager := c.cluster.Buckets()
 
 	workerFlush := func() (shouldRetry bool, err error, value interface{}) {
-		if err := c.DropAllScopesAndCollections(); err != nil && !errors.Is(err, ErrCollectionsUnsupported) {
-			return true, err, nil
-		}
-
 		if err := bucketManager.FlushBucket(c.Bucket().Name(), nil); err != nil {
 			WarnfCtx(context.TODO(), "Error flushing bucket %s: %v  Will retry.", MD(c.Bucket().Name()).Redact(), err)
 			return true, err, nil

--- a/base/collection.go
+++ b/base/collection.go
@@ -662,8 +662,8 @@ func (c *Collection) isRecoverableWriteError(err error) bool {
 	return false
 }
 
-// dropAllScopesAndCollections attempts to drop *all* non-_default scopes and collections from the bucket associated with the collection.  Intended for test usage only.
-func (c *Collection) dropAllScopesAndCollections() error {
+// DropAllScopesAndCollections attempts to drop *all* non-_default scopes and collections from the bucket associated with the collection.  Intended for test usage only.
+func (c *Collection) DropAllScopesAndCollections() error {
 	cm := c.Bucket().Collections()
 	scopes, err := cm.GetAllScopes(nil)
 	if err != nil {
@@ -705,7 +705,7 @@ func (c *Collection) Flush() error {
 	bucketManager := c.cluster.Buckets()
 
 	workerFlush := func() (shouldRetry bool, err error, value interface{}) {
-		if err := c.dropAllScopesAndCollections(); err != nil && !errors.Is(err, ErrCollectionsUnsupported) {
+		if err := c.DropAllScopesAndCollections(); err != nil && !errors.Is(err, ErrCollectionsUnsupported) {
 			return true, err, nil
 		}
 

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -619,7 +619,7 @@ type TBPBucketReadierFunc func(ctx context.Context, b Bucket, tbp *TestBucketPoo
 var FlushBucketEmptierFunc TBPBucketReadierFunc = func(ctx context.Context, b Bucket, tbp *TestBucketPool) error {
 
 	if c, ok := b.(*Collection); ok {
-		if err := c.dropAllScopesAndCollections(); err != nil && !errors.Is(err, ErrCollectionsUnsupported) {
+		if err := c.DropAllScopesAndCollections(); err != nil && !errors.Is(err, ErrCollectionsUnsupported) {
 			return err
 		}
 	}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -230,12 +230,6 @@ WHERE META(ks).xattrs._sync.sequence >= 0
 
 // ViewsAndGSIBucketReadier empties the bucket, initializes Views, and waits until GSI indexes are empty. It is run asynchronously as soon as a test is finished with a bucket.
 var ViewsAndGSIBucketReadier base.TBPBucketReadierFunc = func(ctx context.Context, b base.Bucket, tbp *base.TestBucketPool) error {
-	if c, ok := b.(*base.Collection); ok {
-		if err := c.DropAllScopesAndCollections(); err != nil && !errors.Is(err, base.ErrCollectionsUnsupported) {
-			return err
-		}
-	}
-
 	if base.TestsDisableGSI() {
 		tbp.Logf(ctx, "flushing bucket and readying views")
 		if err := base.FlushBucketEmptierFunc(ctx, b, tbp); err != nil {
@@ -243,6 +237,12 @@ var ViewsAndGSIBucketReadier base.TBPBucketReadierFunc = func(ctx context.Contex
 		}
 		// Exit early if we're not using GSI.
 		return viewBucketReadier(ctx, b, tbp)
+	}
+
+	if c, ok := b.(*base.Collection); ok {
+		if err := c.DropAllScopesAndCollections(); err != nil && !errors.Is(err, base.ErrCollectionsUnsupported) {
+			return err
+		}
 	}
 
 	tbp.Logf(ctx, "emptying bucket via N1QL, readying views and indexes")

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -230,6 +230,11 @@ WHERE META(ks).xattrs._sync.sequence >= 0
 
 // ViewsAndGSIBucketReadier empties the bucket, initializes Views, and waits until GSI indexes are empty. It is run asynchronously as soon as a test is finished with a bucket.
 var ViewsAndGSIBucketReadier base.TBPBucketReadierFunc = func(ctx context.Context, b base.Bucket, tbp *base.TestBucketPool) error {
+	if c, ok := b.(*base.Collection); ok {
+		if err := c.DropAllScopesAndCollections(); err != nil && !errors.Is(err, base.ErrCollectionsUnsupported) {
+			return err
+		}
+	}
 
 	if base.TestsDisableGSI() {
 		tbp.Logf(ctx, "flushing bucket and readying views")


### PR DESCRIPTION
Tests that use `FlushBucketEmptierFunc` (`auth` and `base` packages) would run `dropAllScopesAndCollections` when cleaning up a test bucket, but tests that use `ViewsAndGSIBucketReadier` would not, leading to test failures because of dangling scopes/collections. This PR makes the latter also use the (newly exported) `DropAllScopesAndCollections`.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true,gsi=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/606/