### PR TITLE
Remove structcheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,6 @@ linters:
     - prealloc # Finds slice declarations that could potentially be preallocated
     - revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
     - staticcheck # (megacheck) Staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    - structcheck # Finds unused struct fields
     - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
     - unconvert # Remove unnecessary type conversions
     - unparam # Reports unused function parameters

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -36,7 +36,7 @@ type BlipTesterClientOpts struct {
 	SupportedBLIPProtocols []string
 
 	// a deltaSrc rev ID for which to reject a delta
-	rejectDeltasForSrcRev string //nolint: structcheck // false structcheck positive due to https://github.com/golangci/golangci-lint/issues/826
+	rejectDeltasForSrcRev string
 }
 
 // BlipTesterClient is a fully fledged client to emulate CBL behaviour on both push and pull replications through methods on this type.


### PR DESCRIPTION
This wasn't fixed for go-1.8 and the last commit to https://github.com/golangci/check is from 2018.
Additionally, it shows up with false positives.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`