### PR TITLE
Temporary skip prior to CBG-2214 for Windows time resolution issue

### DIFF
--- a/rest/jwt_auth_test.go
+++ b/rest/jwt_auth_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -466,5 +467,8 @@ func TestLocalJWTRolesChannels(t *testing.T) {
 	assert.Contains(t, user.RoleNames(), "jwt_only_role")
 	assert.Contains(t, user.Channels().AllKeys(), "jwt_only_channel")
 	assert.Equal(t, testIssuer, user.JWTIssuer())
-	assert.Greater(t, user.JWTLastUpdated(), reqTime)
+	// FIXME: Temporary skip prior to CBG-2214 - Windows time resolution is not good enough to do this greater (but not equals) assertion
+	if runtime.GOOS != "windows" {
+		assert.Greater(t, user.JWTLastUpdated(), reqTime)
+	}
 }


### PR DESCRIPTION
## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a (covered by Windows GH action test)