### PR TITLE
CBG-2256: Added per bucket credentials to startup config

### DIFF
--- a/base/gocb_dcp_feed.go
+++ b/base/gocb_dcp_feed.go
@@ -76,15 +76,15 @@ func StartGocbDCPFeed(collection *Collection, bucketName string, args sgbucket.F
 	doneChan, err := dcpClient.Start()
 	loggingCtx := context.TODO()
 	if err != nil {
-		ErrorfCtx(loggingCtx, "!!! Failed to start DCP Feed %q for bucket %q: %w", feedName, MD(bucketName), err)
+		ErrorfCtx(loggingCtx, "Failed to start DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), err)
 		// simplify in CBG-2234
 		closeErr := dcpClient.Close()
-		ErrorfCtx(loggingCtx, "!!! Finished called async close error from DCP Feed %q for bucket %q", feedName, MD(bucketName))
+		ErrorfCtx(loggingCtx, "Finished called async close error from DCP Feed %q for bucket %q", feedName, MD(bucketName))
 		if closeErr != nil {
-			ErrorfCtx(loggingCtx, "!!! Close error from DCP Feed %q for bucket %q: %w", feedName, MD(bucketName), closeErr)
+			ErrorfCtx(loggingCtx, "Close error from DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), closeErr)
 		}
 		asyncCloseErr := <-doneChan
-		ErrorfCtx(loggingCtx, "!!! Finished calling async close error from DCP Feed %q for bucket %q: %w", feedName, MD(bucketName), asyncCloseErr)
+		ErrorfCtx(loggingCtx, "Finished calling async close error from DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), asyncCloseErr)
 		return err
 	}
 	InfofCtx(loggingCtx, KeyDCP, "Started DCP Feed %q for bucket %q", feedName, MD(bucketName))
@@ -98,7 +98,7 @@ func StartGocbDCPFeed(collection *Collection, bucketName string, args sgbucket.F
 			// wait for channel close
 			<-doneChan
 			if dcpCloseError != nil {
-				WarnfCtx(loggingCtx, "Error on closing DCP Feed %q for %q: %w", feedName, MD(bucketName), dcpCloseError)
+				WarnfCtx(loggingCtx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseError)
 			}
 			// FIXME: close dbContext here
 			break
@@ -106,11 +106,11 @@ func StartGocbDCPFeed(collection *Collection, bucketName string, args sgbucket.F
 			InfofCtx(loggingCtx, KeyDCP, "Closing DCP Feed %q for bucket %q based on termination notification", feedName, MD(bucketName))
 			dcpCloseErr := dcpClient.Close()
 			if dcpCloseErr != nil {
-				WarnfCtx(loggingCtx, "Error on closing DCP Feed %q for %q: %w", feedName, MD(bucketName), dcpCloseErr)
+				WarnfCtx(loggingCtx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseErr)
 			}
 			dcpCloseErr = <-doneChan
 			if dcpCloseErr != nil {
-				WarnfCtx(loggingCtx, "Error on closing DCP Feed %q for %q: %w", feedName, MD(bucketName), dcpCloseErr)
+				WarnfCtx(loggingCtx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseErr)
 			}
 			break
 		}

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -985,6 +985,23 @@ CollectionConfig:
       type: string
       example: 'function(doc) { if (doc.type != ''mobile'') { return false; } return true; }'
   title: Collection config
+CredentialsConfig:
+  description: The configuration for the credentials set.
+  type: object
+  properties:
+    username:
+      description: Username for authenticating to the bucket
+      type: string
+    password:
+      description: Password for authenticating to the bucket. This value is always redacted.
+      type: string
+    x509_cert_path:
+      description: Cert path (public key) for X.509 bucket auth
+      type: string
+    x509_key_path:
+      description: Key path (private key) for X.509 bucket auth
+      type: string
+  title: Credentials config
 Database:
   description: The properties of a database configuration.
   type: object
@@ -1967,21 +1984,13 @@ Startup-config:
       description: 'A map of database name to credentials, that can be used instead of the bootstrap ones.'
       type: object
       additionalProperties:
-        description: The name of the database.
-        type: object
-        properties:
-          username:
-            description: Username for authenticating to the bucket
-            type: string
-          password:
-            description: Password for authenticating to the bucket. This value is always redacted.
-            type: string
-          x509_cert_path:
-            description: Cert path (public key) for X.509 bucket auth
-            type: string
-          x509_key_path:
-            description: Key path (private key) for X.509 bucket auth
-            type: string
+        $ref: '#/CredentialsConfig'
+      readOnly: true
+    bucket_credentials:
+      description: 'A map of bucket names to credentials, that can be used instead of the bootstrap ones.'
+      type: object
+      additionalProperties:
+        $ref: '#/CredentialsConfig'
       readOnly: true
     max_file_descriptors:
       description: Max of open file descriptors (RLIMIT_NOFILE)

--- a/rest/config.go
+++ b/rest/config.go
@@ -284,7 +284,7 @@ func (dbc *DbConfig) inheritFromBootstrap(b BootstrapConfig) {
 	}
 }
 
-func (dbConfig *DbConfig) setPerDatabaseCredentials(dbCredentials DatabaseCredentialsConfig) {
+func (dbConfig *DbConfig) setPerDatabaseCredentials(dbCredentials CredentialsConfig) {
 	// X.509 overrides username/password
 	if dbCredentials.X509CertPath != "" || dbCredentials.X509KeyPath != "" {
 		dbConfig.CertPath = dbCredentials.X509CertPath
@@ -300,7 +300,7 @@ func (dbConfig *DbConfig) setPerDatabaseCredentials(dbCredentials DatabaseCreden
 }
 
 // setup populates fields in the dbConfig
-func (dbConfig *DbConfig) setup(dbName string, bootstrapConfig BootstrapConfig, dbCredentials *DatabaseCredentialsConfig) error {
+func (dbConfig *DbConfig) setup(dbName string, bootstrapConfig BootstrapConfig, dbCredentials *CredentialsConfig) error {
 
 	dbConfig.inheritFromBootstrap(bootstrapConfig)
 	if dbCredentials != nil {
@@ -1157,6 +1157,34 @@ func (sc *StartupConfig) validate(isEnterpriseEdition bool) (errorMessages error
 		multiError = multiError.Append(fmt.Errorf("%v: %d outside allowed range: %d-%d", auth.ErrInvalidBcryptCost, sc.Auth.BcryptCost, auth.DefaultBcryptCost, bcrypt.MaxCost))
 	}
 
+	if len(sc.Bootstrap.ConfigGroupID) > persistentConfigGroupIDMaxLength {
+		multiError = multiError.Append(fmt.Errorf("group_id must be at most %d characters in length", persistentConfigGroupIDMaxLength))
+	}
+
+	if sc.BucketCredentials != nil && sc.DatabaseCredentials != nil && len(sc.BucketCredentials) > 0 && len(sc.DatabaseCredentials) > 0 {
+		multiError = multiError.Append(fmt.Errorf("bucket_credentials and database_credentials cannot be used at the same time"))
+	}
+
+	if sc.DatabaseCredentials != nil {
+		for dbName, creds := range sc.DatabaseCredentials {
+			if (creds.X509CertPath != "" || creds.X509KeyPath != "") && (creds.Username != "" || creds.Password != "") {
+				base.WarnfCtx(context.TODO(), "database %q in database_credentials cannot use both x509 and basic auth. Will use x509 only.", base.MD(dbName))
+			}
+		}
+	}
+
+	if base.BoolDefault(sc.Unsupported.Serverless, false) && len(sc.BucketCredentials) == 0 {
+		multiError = multiError.Append(fmt.Errorf("at least 1 bucket must be defined in bucket_credentials when running in serverless mode"))
+	}
+
+	if sc.BucketCredentials != nil {
+		for bucketName, creds := range sc.BucketCredentials {
+			if (creds.X509CertPath != "" || creds.X509KeyPath != "") && (creds.Username != "" || creds.Password != "") {
+				multiError = multiError.Append(fmt.Errorf("bucket %q in bucket_credentials cannot use both x509 and basic auth", base.MD(bucketName)))
+			}
+		}
+	}
+
 	// EE only features
 	if !isEnterpriseEdition {
 		if sc.API.EnableAdminAuthenticationPermissionsCheck != nil && *sc.API.EnableAdminAuthenticationPermissionsCheck {
@@ -1166,10 +1194,6 @@ func (sc *StartupConfig) validate(isEnterpriseEdition bool) (errorMessages error
 		if sc.Bootstrap.ConfigGroupID != persistentConfigDefaultGroupID {
 			multiError = multiError.Append(fmt.Errorf("customization of group_id is only supported in enterprise edition"))
 		}
-	}
-
-	if len(sc.Bootstrap.ConfigGroupID) > persistentConfigGroupIDMaxLength {
-		multiError = multiError.Append(fmt.Errorf("group_id must be at most %d characters in length", persistentConfigGroupIDMaxLength))
 	}
 
 	return multiError.ErrorOrNil()

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -123,7 +123,8 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 
 		"unsupported.http2.enabled": {&config.Unsupported.HTTP2.Enabled, fs.Bool("unsupported.http2.enabled", false, "Whether HTTP2 support is enabled")},
 
-		"database_credentials": {&config.DatabaseCredentials, fs.String("database_credentials", "null", "JSON-encoded per-database credentials")},
+		"database_credentials": {&config.DatabaseCredentials, fs.String("database_credentials", "null", "JSON-encoded per-database credentials, that can be used instead of the bootstrap ones. Cannot be used in conjunction with bucket_credentials.")},
+		"bucket_credentials":   {&config.BucketCredentials, fs.String("bucket_credentials", "null", "JSON-encoded per-bucket credentials, that can be used instead of the bootstrap ones. Cannot be used in conjunction with database_credentials.")},
 
 		"max_file_descriptors": {&config.MaxFileDescriptors, fs.Uint64("max_file_descriptors", 0, "Max # of open file descriptors (RLIMIT_NOFILE)")},
 
@@ -206,6 +207,18 @@ func fillConfigWithFlags(fs *flag.FlagSet, flags map[string]configFlag) error {
 					return
 				}
 				*val.config.(*PerDatabaseCredentialsConfig) = dbCredentials
+			case *PerBucketCredentialsConfig:
+				str := *val.flagValue.(*string)
+				var bucketCredentials PerBucketCredentialsConfig
+				d := base.JSONDecoder(strings.NewReader(str))
+				d.DisallowUnknownFields()
+				err := d.Decode(&bucketCredentials)
+				if err != nil {
+					err = fmt.Errorf("flag %s for value %q error: %w", f.Name, str, err)
+					errorMessages = errorMessages.Append(err)
+					return
+				}
+				*val.config.(*PerBucketCredentialsConfig) = bucketCredentials
 			default:
 				errorMessages = errorMessages.Append(fmt.Errorf("Unknown type %v for flag %v\n", rval.Type(), f.Name))
 			}

--- a/rest/config_flags_test.go
+++ b/rest/config_flags_test.go
@@ -38,6 +38,8 @@ func TestAllConfigFlags(t *testing.T) {
 				val = "trace"
 			case *PerDatabaseCredentialsConfig:
 				val = `{"db1":{"password":"foo"}}`
+			case *PerBucketCredentialsConfig:
+				val = `{"bucket":{"password":"foo"}}`
 			}
 			flags = append(flags, "-"+name, val)
 		case bool:

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -67,7 +67,8 @@ type StartupConfig struct {
 	Replicator  ReplicatorConfig   `json:"replicator,omitempty"`
 	Unsupported UnsupportedConfig  `json:"unsupported,omitempty"`
 
-	DatabaseCredentials PerDatabaseCredentialsConfig `json:"database_credentials,omitempty" help:"A map of database name to credentials, that can be used instead of the bootstrap ones."`
+	DatabaseCredentials PerDatabaseCredentialsConfig `json:"database_credentials,omitempty" help:"A map of database name to credentials, that can be used instead of the bootstrap ones. Cannot be used in conjunction with bucket_credentials."`
+	BucketCredentials   PerBucketCredentialsConfig   `json:"bucket_credentials,omitempty" help:"A map of bucket names to credentials, that can be used instead of the bootstrap ones. Cannot be used in conjunction with database_credentials."`
 
 	MaxFileDescriptors         uint64 `json:"max_file_descriptors,omitempty" help:"Max # of open file descriptors (RLIMIT_NOFILE)"`
 	CouchbaseKeepaliveInterval *int   `json:"couchbase_keepalive_interval,omitempty" help:"TCP keep-alive interval between SG and Couchbase server"`
@@ -147,9 +148,11 @@ type HTTP2Config struct {
 	Enabled *bool `json:"enabled,omitempty" help:"Whether HTTP2 support is enabled"`
 }
 
-type PerDatabaseCredentialsConfig map[string]*DatabaseCredentialsConfig
+type PerDatabaseCredentialsConfig map[string]*CredentialsConfig
 
-type DatabaseCredentialsConfig struct {
+type PerBucketCredentialsConfig map[string]*CredentialsConfig
+
+type CredentialsConfig struct {
 	Username     string `json:"username,omitempty"       help:"Username for authenticating to the bucket"`
 	Password     string `json:"password,omitempty"       help:"Password for authenticating to the bucket"`
 	X509CertPath string `json:"x509_cert_path,omitempty" help:"Cert path (public key) for X.509 bucket auth"`
@@ -174,6 +177,12 @@ func (sc *StartupConfig) Redacted() (*StartupConfig, error) {
 	}
 
 	for _, credentialsConfig := range config.DatabaseCredentials {
+		if credentialsConfig != nil && credentialsConfig.Password != "" {
+			credentialsConfig.Password = base.RedactedStr
+		}
+	}
+
+	for _, credentialsConfig := range config.BucketCredentials {
 		if credentialsConfig != nil && credentialsConfig.Password != "" {
 			credentialsConfig.Password = base.RedactedStr
 		}


### PR DESCRIPTION
CBG-2256

- Added new config option `bucket_credentials` with testing
- Added warning if setting both x509 and basic auth on per db credentials
- Added exclusivity to make sure the user does not use both per db credentials and bucket credentials
- Changed `DatabaseCredentialsConfig` to a more generic name of `CredentialsConfig`
- Fix debug log message left in master

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/608/