### PR TITLE
Update timeout and assert response error on sync fn and import filter timeout tests

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -9719,10 +9719,10 @@ func TestSyncFnTimeout(t *testing.T) {
 	syncFnFinishedWG.Add(1)
 	go func() {
 		response := rt.SendAdminRequest("PUT", "/db/doc", `{"foo": "bar"}`)
-		requireStatus(t, response, 500) // TODO: Change to assertStatus when CBG-2143 merged maybe with response matching if response is changed
+		assertHTTPErrorReason(t, response, 500, "JS sync function timed out")
 		syncFnFinishedWG.Done()
 	}()
-	timeoutErr := WaitWithTimeout(&syncFnFinishedWG, time.Second*5)
+	timeoutErr := WaitWithTimeout(&syncFnFinishedWG, time.Second*15)
 	assert.NoError(t, timeoutErr)
 }
 
@@ -9745,9 +9745,9 @@ func TestImportFilterTimeout(t *testing.T) {
 	syncFnFinishedWG.Add(1)
 	go func() {
 		response := rt.SendAdminRequest("GET", "/db/doc", ``)
-		requireStatus(t, response, 404) // TODO: Change to assertStatus when CBG-2143 merged
+		assertStatus(t, response, 404)
 		syncFnFinishedWG.Done()
 	}()
-	timeoutErr := WaitWithTimeout(&syncFnFinishedWG, time.Second*5)
+	timeoutErr := WaitWithTimeout(&syncFnFinishedWG, time.Second*15)
 	assert.NoError(t, timeoutErr)
 }


### PR DESCRIPTION
- Update timeouts for `TestSyncFnTimeout` and `TestImportFilterTimeout` to 15 seconds instead of 5
- Assert response error text for `TestSyncFnTimeout` to make sure the error is the error expected

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`