### PR TITLE
Fix TestWebhookProperties WaitGroup ordering

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4758,20 +4758,19 @@ func TestWebhookProperties(t *testing.T) {
 	rt := NewRestTester(t, rtConfig)
 	defer rt.Close()
 
-	rt.SendAdminRequest("PUT", "/db/doc1", `{"foo": "bar"}`)
 	wg.Add(1)
+	rt.SendAdminRequest("PUT", "/db/doc1", `{"foo": "bar"}`)
 
 	if base.TestUseXattrs() {
+		wg.Add(1)
 		body := make(map[string]interface{})
 		body["foo"] = "bar"
 		added, err := rt.Bucket().Add("doc2", 0, body)
 		assert.True(t, added)
 		assert.NoError(t, err)
-		wg.Add(1)
 	}
 
-	wg.Wait()
-
+	require.NoError(t, WaitWithTimeout(&wg, 30*time.Second))
 }
 
 func TestBasicGetReplicator2(t *testing.T) {


### PR DESCRIPTION
Saw this [happen in Jenkins](https://jenkins.sgwdev.com/job/Sync%20Gateway%20Pipeline/job/master/217). When the test runs quick enough that the webhook handler is run before the test has had chance to increment the WaitGroup, the WaitGroup goes negative and panics... WaitGroups should be incremented _before_ another goroutine has chance to decrement.

Also added a timeout to wg.Wait to avoid indefinitely waiting for something to not happen.

```
=== RUN   TestWebhookProperties
2022-08-12T11:30:06.022Z [INF] Design docs for current view version (2.1) do not exist - creating...
2022-08-12T11:30:06.023Z [INF] Design docs successfully created for view version 2.1.
2022-08-12T11:30:06.023Z [INF] Verifying view availability for bucket <ud>sg_int_walrus_b44e6d75399f652705ad2e2ce813752c</ud>...
2022-08-12T11:30:06.024Z [INF] Views ready for bucket <ud>sg_int_walrus_b44e6d75399f652705ad2e2ce813752c</ud>.
2022-08-12T11:30:06.024Z [INF] Logging stats with frequency: &{1m0s}
2022-08-12T11:30:06.037Z [WRN] Running Sync Gateway without shared bucket access is deprecated. Recommendation: set enable_shared_bucket_access=true -- rest.GetBucketSpec() at server_context.go:357
2022-08-12T11:30:06.037Z [INF] Opening db /db as bucket "sg_int_walrus_b44e6d75399f652705ad2e2ce813752c", pool "default", server <walrus:>
2022-08-12T11:30:06.038Z [INF] Opening Walrus database sg_int_walrus_b44e6d75399f652705ad2e2ce813752c on <walrus:>
2022-08-12T11:30:06.042Z [INF] Design docs for current SG view version (2.1) found.
2022-08-12T11:30:06.042Z [INF] Verifying view availability for bucket <ud>sg_int_walrus_b44e6d75399f652705ad2e2ce813752c</ud>...
2022-08-12T11:30:06.042Z [INF] Views ready for bucket <ud>sg_int_walrus_b44e6d75399f652705ad2e2ce813752c</ud>.
2022-08-12T11:30:06.043Z [INF] delta_sync enabled=false with rev_max_age_seconds=86400 for database db
2022-08-12T11:30:06.046Z [INF] Created background task: "CleanAgedItems" with interval 1m0s
2022-08-12T11:30:06.046Z [INF] Created background task: "InsertPendingEntries" with interval 2.5s
2022-08-12T11:30:06.047Z [INF] Created background task: "CleanSkippedSequenceQueue" with interval 30m0s
2022-08-12T11:30:06.047Z [INF] Using default sync function 'channel(doc.channels)' for database "db"
2022-08-12T11:30:06.097Z [INF] HTTP: c:#8581 PUT http://localhost/db/<ud>doc1</ud> (as ADMIN)
2022/08/12 11:30:06 http: panic serving 127.0.0.1:58232: sync: negative WaitGroup counter
goroutine 40832 [running]:
net/http.(*conn).serve.func1()
	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.18.5/src/net/http/server.go:1825 +0x106
panic({0x1b2c760, 0x213bdd0})
	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.18.5/src/runtime/panic.go:844 +0x258
sync.(*WaitGroup).Add(0xc000240bc0, 0xffffffffffffffff)
	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.18.5/src/sync/waitgroup.go:80 +0x1f8
sync.(*WaitGroup).Done(...)
	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.18.5/src/sync/waitgroup.go:105
github.com/couchbase/sync_gateway/rest.TestWebhookProperties.func1({0xc00a20432c?, 0x4a0719?}, 0xc0002ec300)
	/home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/api_test.go:4740 +0x290
net/http.HandlerFunc.ServeHTTP(0xc000bca048, {0x2146240, 0xc000770000}, 0x1?)
	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.18.5/src/net/http/server.go:2084 +0x4e
net/http.serverHandler.ServeHTTP({0x2143448?}, {0x2146240, 0xc000770000}, 0xc0002ec300)
	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.18.5/src/net/http/server.go:2916 +0x897
net/http.(*conn).serve(0xc00044a0a0, {0x2146d70, 0xc0007fa750})
	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.18.5/src/net/http/server.go:1966 +0xbab
created by net/http.(*Server).Serve
	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.18.5/src/net/http/server.go:3071 +0x80d
2022-08-12T11:30:06.103Z [WRN] Error attempting to post <ud>Document change event for doc id: doc1</ud> to url <ud>http://127.0.0.1:46157</ud>: Post "http://127.0.0.1:46157": EOF -- db.(*Webhook).HandleEvent.func1() at event_handler.go:155
--- PASS: TestWebhookProperties (0.10s)
```

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] n/a