### PR TITLE
Fix all combinations of xattrs/keyspaces for index/query definitions

### DIFF
--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -189,7 +189,14 @@ func (c *Collection) IsErrNoResults(err error) bool {
 func (c *Collection) getIndexes() (indexes []string, err error) {
 
 	indexes = []string{}
-	indexInfo, err := c.cluster.QueryIndexes().GetAllIndexes(c.BucketName(), nil)
+	var opts *gocb.GetAllQueryIndexesOptions
+	if !c.isDefaultScopeCollection() {
+		opts = &gocb.GetAllQueryIndexesOptions{
+			ScopeName:      c.ScopeName(),
+			CollectionName: c.Name(),
+		}
+	}
+	indexInfo, err := c.cluster.QueryIndexes().GetAllIndexes(c.BucketName(), opts)
 	if err != nil {
 		return indexes, err
 	}

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -24,9 +24,14 @@ import (
 
 var _ N1QLStore = &Collection{}
 
+// isDefaultScopeCollection returns true if the given Collection is on the _default._default scope and collection.
+func (c *Collection) isDefaultScopeCollection() bool {
+	return c.ScopeName() == DefaultScope && c.Name() == DefaultCollection
+}
+
 // EscapedKeyspace returns the escaped fully-qualified identifier for the keyspace (e.g. `bucket`.`scope`.`collection`)
 func (c *Collection) EscapedKeyspace() string {
-	if c.ScopeName() == DefaultScope && c.Name() == DefaultCollection {
+	if c.isDefaultScopeCollection() {
 		return fmt.Sprintf("`%s`", c.BucketName())
 	}
 	return fmt.Sprintf("`%s`.`%s`.`%s`", c.BucketName(), c.ScopeName(), c.Name())
@@ -34,7 +39,7 @@ func (c *Collection) EscapedKeyspace() string {
 
 // IndexMetaBucketID returns the value of bucket_id for the system:indexes table for the collection.
 func (c *Collection) IndexMetaBucketID() string {
-	if c.ScopeName() == DefaultScope && c.Name() == DefaultCollection {
+	if c.isDefaultScopeCollection() {
 		return ""
 	}
 	return c.BucketName()
@@ -42,7 +47,7 @@ func (c *Collection) IndexMetaBucketID() string {
 
 // IndexMetaScopeID returns the value of scope_id for the system:indexes table for the collection.
 func (c *Collection) IndexMetaScopeID() string {
-	if c.ScopeName() == DefaultScope && c.Name() == DefaultCollection {
+	if c.isDefaultScopeCollection() {
 		return ""
 	}
 	return c.ScopeName()
@@ -50,7 +55,7 @@ func (c *Collection) IndexMetaScopeID() string {
 
 // IndexMetaKeyspaceID returns the value of keyspace_id for the system:indexes table for the collection.
 func (c *Collection) IndexMetaKeyspaceID() string {
-	if c.ScopeName() == DefaultScope && c.Name() == DefaultCollection {
+	if c.isDefaultScopeCollection() {
 		return c.BucketName()
 	}
 	return c.Name()

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -309,7 +309,7 @@ func GetIndexMeta(store N1QLStore, indexName string) (exists bool, meta *IndexMe
 }
 
 func getIndexMetaWithoutRetry(store N1QLStore, indexName string) (exists bool, meta *IndexMeta, err error) {
-	statement := fmt.Sprintf("SELECT state from system:indexes WHERE indexes.name = '%s' AND indexes.keyspace_id = '%s'", indexName, store.IndexMetaKeyspaceID())
+	statement := fmt.Sprintf("SELECT state FROM system:indexes WHERE indexes.name = '%s' AND indexes.keyspace_id = '%s'", indexName, store.IndexMetaKeyspaceID())
 	if store.IndexMetaBucketID() != "" {
 		statement += fmt.Sprintf(" AND indexes.bucket_id = '%s'", store.IndexMetaBucketID())
 	}

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -278,11 +278,11 @@ func (t TestAuthenticator) GetCredentials() (username, password, bucketname stri
 	return t.Username, t.Password, t.BucketName
 }
 
-// Reset bucket state
-func DropAllBucketIndexes(bucket N1QLStore) error {
+// DropAllIndexes removes all indexes defined on the bucket or collection
+func DropAllIndexes(ctx context.Context, n1QLStore N1QLStore) error {
 
-	// Retrieve all indexes
-	indexes, err := bucket.getIndexes()
+	// Retrieve all indexes on the bucket/collection
+	indexes, err := n1QLStore.getIndexes()
 	if err != nil {
 		return err
 	}
@@ -299,14 +299,14 @@ func DropAllBucketIndexes(bucket N1QLStore) error {
 
 			defer wg.Done()
 
-			log.Printf("Dropping index %s on bucket %s...", indexToDrop, bucket.GetName())
-			dropErr := bucket.DropIndex(indexToDrop)
+			InfofCtx(ctx, KeySGTest, "Dropping index %s on bucket %s...", indexToDrop, n1QLStore.GetName())
+			dropErr := n1QLStore.DropIndex(indexToDrop)
 			if dropErr != nil {
 				asyncErrors <- dropErr
-				log.Printf("...failed to drop index %s on bucket %s: %s", indexToDrop, bucket.GetName(), dropErr)
+				ErrorfCtx(ctx, "...failed to drop index %s on bucket %s: %s", indexToDrop, n1QLStore.GetName(), dropErr)
 				return
 			}
-			log.Printf("...successfully dropped index %s on bucket %s", indexToDrop, bucket.GetName())
+			InfofCtx(ctx, KeySGTest, "...successfully dropped index %s on bucket %s", indexToDrop, n1QLStore.GetName())
 		}(index)
 
 	}

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -713,8 +713,8 @@ func waitUntilScopeAndCollectionExists(collection *gocb.Collection) error {
 	return err
 }
 
-// CreateTestBucketScopesAndCollections will create the given scopes and collections within the given test bucket.
-func CreateTestBucketScopesAndCollections(ctx context.Context, tb *TestBucket, scopes map[string][]string) error {
+// CreateBucketScopesAndCollections will create the given scopes and collections within the given BucketSpec.
+func CreateBucketScopesAndCollections(ctx context.Context, bucketSpec BucketSpec, scopes map[string][]string) error {
 	atLeastOneScope := false
 	for _, collections := range scopes {
 		for range collections {
@@ -728,16 +728,16 @@ func CreateTestBucketScopesAndCollections(ctx context.Context, tb *TestBucket, s
 		return nil
 	}
 
-	un, pw, _ := tb.BucketSpec.Auth.GetCredentials()
+	un, pw, _ := bucketSpec.Auth.GetCredentials()
 	var rootCAs *x509.CertPool
-	if tlsConfig := tb.BucketSpec.TLSConfig(); tlsConfig != nil {
+	if tlsConfig := bucketSpec.TLSConfig(); tlsConfig != nil {
 		rootCAs = tlsConfig.RootCAs
 	}
-	cluster, err := gocb.Connect(tb.BucketSpec.Server, gocb.ClusterOptions{
+	cluster, err := gocb.Connect(bucketSpec.Server, gocb.ClusterOptions{
 		Username: un,
 		Password: pw,
 		SecurityConfig: gocb.SecurityConfig{
-			TLSSkipVerify: tb.BucketSpec.TLSSkipVerify,
+			TLSSkipVerify: bucketSpec.TLSSkipVerify,
 			TLSRootCAs:    rootCAs,
 		},
 	})
@@ -746,7 +746,7 @@ func CreateTestBucketScopesAndCollections(ctx context.Context, tb *TestBucket, s
 	}
 	defer func() { _ = cluster.Close(nil) }()
 
-	cm := cluster.Bucket(tb.GetName()).Collections()
+	cm := cluster.Bucket(bucketSpec.BucketName).Collections()
 
 	for scopeName, collections := range scopes {
 		if err := cm.CreateScope(scopeName, nil); err != nil && !errors.Is(err, gocb.ErrScopeExists) {
@@ -762,7 +762,7 @@ func CreateTestBucketScopesAndCollections(ctx context.Context, tb *TestBucket, s
 				return fmt.Errorf("failed to create collection %s in scope %s: %w", collectionName, scopeName, err)
 			}
 			DebugfCtx(ctx, KeySGTest, "Created collection %s.%s", scopeName, collectionName)
-			if err := waitUntilScopeAndCollectionExists(cluster.Bucket(tb.GetName()).Scope(scopeName).Collection(collectionName)); err != nil {
+			if err := waitUntilScopeAndCollectionExists(cluster.Bucket(bucketSpec.BucketName).Scope(scopeName).Collection(collectionName)); err != nil {
 				return err
 			}
 			DebugfCtx(ctx, KeySGTest, "Collection now exists %s.%s", scopeName, collectionName)

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -22,9 +22,10 @@ import (
 )
 
 const (
-	indexNameFormat = "sg_%s_%s%d" // Name, xattrs, version.  e.g. "sg_channels_x1"
-	syncToken       = "$sync"      // Sync token, used to swap between xattr/non-xattr handling in n1ql statements
-	indexToken      = "$idx"       // Index token, used to hint which index should be used for the query
+	indexNameFormat   = "sg_%s_%s%d"    // Name, xattrs, version.  e.g. "sg_channels_x1"
+	syncRelativeToken = "$relativesync" // Relative sync token (no keyspace), used to swap between xattr/non-xattr handling in n1ql statements
+	syncToken         = "$sync"         // Sync token, used to swap between xattr/non-xattr handling in n1ql statements
+	indexToken        = "$idx"          // Index token, used to hint which index should be used for the query
 
 	// N1ql-encoded wildcard expression matching the '_sync:' prefix used for all sync gateway's system documents.
 	// Need to escape the underscore in '_sync' to prevent it being treated as a N1QL wildcard
@@ -35,7 +36,8 @@ const (
 // When running with xattrs, that gets replaced with META().xattrs._sync (or META(bucketname).xattrs._sync for query).
 // When running w/out xattrs, it's just replaced by the doc path `bucketname`._sync
 // This gets replaced before the statement is sent to N1QL by the replaceSyncTokens methods.
-var syncNoXattr = fmt.Sprintf("%s.%s", base.KeyspaceQueryToken, base.SyncPropertyName)
+var syncNoXattr = base.SyncPropertyName
+var syncNoXattrQuery = fmt.Sprintf("%s.%s", base.KeyspaceQueryAlias, base.SyncPropertyName)
 var syncXattr = "meta().xattrs." + base.SyncXattrName
 var syncXattrQuery = fmt.Sprintf("meta(%s).xattrs.%s", base.KeyspaceQueryAlias, base.SyncXattrName) // Replacement for $sync token for xattr queries
 
@@ -120,17 +122,17 @@ var (
 		IndexAccess: "SELECT $sync.access.foo as val " +
 			"FROM %s AS %s " +
 			"USE INDEX ($idx) " +
-			"WHERE ANY op in OBJECT_PAIRS($sync.access) SATISFIES op.name = 'foo' end " +
+			"WHERE ANY op in OBJECT_PAIRS($relativesync.access) SATISFIES op.name = 'foo' end " +
 			"LIMIT 1",
 		IndexRoleAccess: "SELECT $sync.role_access.foo as val " +
 			"FROM %s AS %s " +
 			"USE INDEX ($idx) " +
-			"WHERE ANY op in OBJECT_PAIRS($sync.role_access) SATISFIES op.name = 'foo' end " +
+			"WHERE ANY op in OBJECT_PAIRS($relativesync.role_access) SATISFIES op.name = 'foo' end " +
 			"LIMIT 1",
 		IndexChannels: "SELECT  [op.name, LEAST($sync.sequence, op.val.seq),IFMISSING(op.val.rev,null), IFMISSING(op.val.del,null)][1] AS sequence " +
 			"FROM %s AS %s " +
 			"USE INDEX ($idx) " +
-			"UNNEST OBJECT_PAIRS($sync.channels) AS op " +
+			"UNNEST OBJECT_PAIRS($relativesync.channels) AS op " +
 			"WHERE [op.name, LEAST($sync.sequence, op.val.seq),IFMISSING(op.val.rev,null), IFMISSING(op.val.del,null)]  BETWEEN  ['foo', 0] AND ['foo', 1] " +
 			"ORDER BY [op.name, LEAST($sync.sequence, op.val.seq),IFMISSING(op.val.rev,null),IFMISSING(op.val.del,null)] " +
 			"LIMIT 1",
@@ -469,21 +471,25 @@ func removeObsoleteIndex(bucket base.N1QLStore, indexName string, previewOnly bo
 
 }
 
-// Replace sync tokens ($sync) in the provided createIndex statement with the appropriate token, depending on whether xattrs should be used.
+// Replace sync tokens ($sync and $relativesync) in the provided createIndex statement with the appropriate token, depending on whether xattrs should be used.
 func replaceSyncTokensIndex(statement string, useXattrs bool) string {
 	if useXattrs {
-		return strings.Replace(statement, syncToken, syncXattr, -1)
+		str := strings.ReplaceAll(statement, syncRelativeToken, syncXattr)
+		return strings.ReplaceAll(str, syncToken, syncXattr)
 	} else {
-		return strings.Replace(statement, syncToken, syncNoXattr, -1)
+		str := strings.ReplaceAll(statement, syncRelativeToken, syncNoXattr)
+		return strings.ReplaceAll(str, syncToken, syncNoXattr)
 	}
 }
 
 // Replace sync tokens ($sync) in the provided createIndex statement with the appropriate token, depending on whether xattrs should be used.
 func replaceSyncTokensQuery(statement string, useXattrs bool) string {
 	if useXattrs {
-		return strings.Replace(statement, syncToken, syncXattrQuery, -1)
+		str := strings.ReplaceAll(statement, syncRelativeToken, syncXattrQuery)
+		return strings.ReplaceAll(str, syncToken, syncXattrQuery)
 	} else {
-		return strings.Replace(statement, syncToken, syncNoXattr, -1)
+		str := strings.ReplaceAll(statement, syncRelativeToken, syncNoXattrQuery)
+		return strings.ReplaceAll(str, syncToken, syncNoXattrQuery)
 	}
 }
 

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -46,7 +46,7 @@ func TestInitializeIndexes(t *testing.T) {
 			dropErr := base.DropAllBucketIndexes(n1qlStore)
 			require.NoError(t, dropErr, "Error dropping all indexes")
 
-			initErr := InitializeIndexes(n1qlStore, test.xattrs, 0)
+			initErr := InitializeIndexes(n1qlStore, test.xattrs, 0, true)
 			assert.NoError(t, initErr, "Error initializing all indexes")
 
 			// Recreate the primary index required by the test bucket pooling framework
@@ -117,7 +117,7 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	log.Printf("removedIndexes: %+v", removedIndexes)
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in setup case")
 
-	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0)
+	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false)
 	assert.NoError(t, err)
 
 	// Running w/ opposite xattrs flag should preview removal of the indexes associated with this db context
@@ -136,7 +136,7 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in post-cleanup no-op")
 
 	// Restore indexes after test
-	err = InitializeIndexes(n1qlStore, db.UseXattrs(), 0)
+	err = InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false)
 	assert.NoError(t, err)
 }
 
@@ -178,7 +178,7 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes with hacked sgIndexes")
 
 	// Restore indexes after test
-	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0)
+	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false)
 	assert.NoError(t, err)
 
 	validateErr := validateAllIndexesOnline(db.Bucket)
@@ -234,7 +234,7 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Restore indexes after test
-	err = InitializeIndexes(n1QLStore, db.UseXattrs(), 0)
+	err = InitializeIndexes(n1QLStore, db.UseXattrs(), 0, false)
 	assert.NoError(t, err)
 
 	validateErr := validateAllIndexesOnline(db.Bucket)
@@ -255,7 +255,7 @@ func TestRemoveObsoleteIndexOnError(t *testing.T) {
 	require.True(t, db.Bucket.IsSupported(sgbucket.DataStoreFeatureN1ql))
 
 	// Use existing versions of IndexAccess and IndexChannels and create an old version that will be removed by obsolete
-	//indexes. Resulting from the removal candidates for removeObsoleteIndexes will be:
+	// indexes. Resulting from the removal candidates for removeObsoleteIndexes will be:
 	// All previous versions and opposite of current xattr setting eg. for this test ran with non-xattrs:
 	// [sg_channels_x2 sg_channels_x1 sg_channels_1 sg_access_x2 sg_access_x1 sg_access_1]
 	testIndexes := map[SGIndexType]SGIndex{}
@@ -281,7 +281,7 @@ func TestRemoveObsoleteIndexOnError(t *testing.T) {
 
 	// Restore indexes after test
 	n1qlStore, _ := base.AsN1QLStore(db.Bucket)
-	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0)
+	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false)
 	assert.NoError(t, err)
 
 	validateErr := validateAllIndexesOnline(db.Bucket)

--- a/db/query.go
+++ b/db/query.go
@@ -54,7 +54,7 @@ var QueryAccess = SGQuery{
 		"SELECT $sync.access.`$$selectUserName` as `value` "+
 			"FROM %s AS %s "+
 			"USE INDEX ($idx) "+
-			"WHERE any op in object_pairs($sync.access) satisfies op.name = $userName end;",
+			"WHERE any op in object_pairs($relativesync.access) satisfies op.name = $userName end;",
 		base.KeyspaceQueryToken, base.KeyspaceQueryAlias),
 	adhoc: true,
 }
@@ -65,7 +65,7 @@ var QueryRoleAccess = SGQuery{
 		"SELECT $sync.role_access.`$$selectUserName` as `value` "+
 			"FROM %s AS %s "+
 			"USE INDEX ($idx) "+
-			"WHERE any op in object_pairs($sync.role_access) satisfies op.name = $userName end;",
+			"WHERE any op in object_pairs($relativesync.role_access) satisfies op.name = $userName end;",
 		base.KeyspaceQueryToken, base.KeyspaceQueryAlias),
 	adhoc: true,
 }
@@ -94,7 +94,7 @@ var QueryChannels = SGQuery{
 			"META(%s).id AS id "+
 			"FROM %s AS %s "+
 			"USE INDEX ($idx) "+
-			"UNNEST OBJECT_PAIRS($sync.channels) AS op "+
+			"UNNEST OBJECT_PAIRS($relativesync.channels) AS op "+
 			"WHERE ([op.name, LEAST($sync.sequence, op.val.seq),IFMISSING(op.val.rev,null),IFMISSING(op.val.del,null)]  "+
 			"BETWEEN  [$channelName, $startSeq] AND [$channelName, $endSeq]) "+
 			"%s"+

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -303,7 +303,7 @@ var ViewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 	}
 
 	tbp.Logf(ctx, "dropping existing bucket indexes")
-	if err := base.DropAllBucketIndexes(n1qlStore); err != nil {
+	if err := base.DropAllIndexes(ctx, n1qlStore); err != nil {
 		tbp.Logf(ctx, "Failed to drop bucket indexes: %v", err)
 		return err
 	}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -309,7 +309,7 @@ var ViewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 	}
 
 	tbp.Logf(ctx, "creating SG bucket indexes")
-	if err := InitializeIndexes(n1qlStore, base.TestUseXattrs(), 0); err != nil {
+	if err := InitializeIndexes(n1qlStore, base.TestUseXattrs(), 0, false); err != nil {
 		return err
 	}
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -431,7 +431,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config DatabaseConfig, useE
 			return nil, errors.New("Cannot create indexes on non-Couchbase data store.")
 
 		}
-		indexErr := db.InitializeIndexes(n1qlStore, config.UseXattrs(), numReplicas)
+		indexErr := db.InitializeIndexes(n1qlStore, config.UseXattrs(), numReplicas, false)
 		if indexErr != nil {
 			return nil, indexErr
 		}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -207,7 +207,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 					scopes[scopeName] = append(scopes[scopeName], collName)
 				}
 			}
-			if err := base.CreateTestBucketScopesAndCollections(base.TestCtx(rt.tb), rt.testBucket, scopes); err != nil {
+			if err := base.CreateBucketScopesAndCollections(base.TestCtx(rt.tb), rt.testBucket.BucketSpec, scopes); err != nil {
 				rt.tb.Fatalf("Error creating test scopes/collections: %v", err)
 			}
 		}


### PR DESCRIPTION
CBG-2227

May be easier to review by commit in some areas but at a high level:
- Expanded `TestInitializeIndexes` to cover all combinations of xattrs/non-xattrs/bucket/collection regardless of `SG_TEST_` options
- Set non-xattr UNNEST/OBJECT_PAIRS expressions as a relative document path, instead of qualified with bucket/keyspace - this didn't work for collections, and likely only happened to work with a bucket by chance.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/614/
- [ ] `gsi=true xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/615/