### PR TITLE
try dropping version of go required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.48.0
+          version: v1.47.3
           args: --config=.golangci-strict.yml --timeout=3m
   test:
     runs-on: ${{ matrix.os }}

--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -16,7 +16,7 @@ linters:
     - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
     #- goconst # Finds repeated strings that could be replaced by a constant
     #- gocritic # The most opinionated Go source code linter
-    #- goimports # Goimports does everything that gofmt does. Additionally it checks unused imports
+    - goimports # Goimports does everything that gofmt does. Additionally it checks unused imports
     #- goprintffuncname # Checks that printf-like functions are named with `f` at the end
     #- gosec # (gas) Inspects source code for security problems
     #- gosimple # (megacheck) Linter for Go source code that specializes in simplifying a code

--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -44,7 +44,6 @@ linters:
     - godox # Tool for detection of FIXME, TODO and other comment keywords
     - goerr113 # Golang linter to check the errors handling expressions
     - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    - goimports # Goimports does everything that gofmt does. Additionally it checks unused imports
     - gomnd # An analyzer to detect magic numbers.
     - gomodguard # Allow and block list linter for direct Go module dependencies.
     - interfacer # Linter that suggests narrower interface types


### PR DESCRIPTION
golangci-lint in actions is installed from a binary, see if this version is built with go-1.18 so goimports doesn't complain about goimports in comments.

Describe your PR here...
- Use bullet points if there's more than one thing changed

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/