### PR TITLE
Allow DropIndex to work on collections

### DIFF
--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -31,7 +31,7 @@ func (c *Collection) isDefaultScopeCollection() bool {
 
 // EscapedKeyspace returns the escaped fully-qualified identifier for the keyspace (e.g. `bucket`.`scope`.`collection`)
 func (c *Collection) EscapedKeyspace() string {
-	if c.isDefaultScopeCollection() {
+	if !c.IsSupported(sgbucket.DataStoreFeatureCollections) {
 		return fmt.Sprintf("`%s`", c.BucketName())
 	}
 	return fmt.Sprintf("`%s`.`%s`.`%s`", c.BucketName(), c.ScopeName(), c.Name())

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -335,7 +335,8 @@ func getIndexMetaWithoutRetry(store N1QLStore, indexName string) (exists bool, m
 
 // DropIndex drops the specified index from the current bucket.
 func DropIndex(store N1QLStore, indexName string) error {
-	statement := fmt.Sprintf("DROP INDEX `%s` ON %s", indexName, store.EscapedKeyspace())
+	statement := fmt.Sprintf("DROP INDEX default:%s.`%s`", store.EscapedKeyspace(), indexName)
+
 	err := store.executeStatement(statement)
 	if err != nil && !IsIndexerRetryIndexError(err) {
 		return err

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -335,7 +335,7 @@ func getIndexMetaWithoutRetry(store N1QLStore, indexName string) (exists bool, m
 
 // DropIndex drops the specified index from the current bucket.
 func DropIndex(store N1QLStore, indexName string) error {
-	statement := fmt.Sprintf("DROP INDEX %s.`%s`", store.EscapedKeyspace(), indexName)
+	statement := fmt.Sprintf("DROP INDEX `%s` ON %s", indexName, store.EscapedKeyspace())
 	err := store.executeStatement(statement)
 	if err != nil && !IsIndexerRetryIndexError(err) {
 		return err

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -48,9 +48,11 @@ func TestInitializeIndexes(t *testing.T) {
 				collection, err := base.AsCollection(b)
 				require.NoError(t, err)
 				// override underlying collection for test bucket
-				collection.Collection = collection.Bucket().Scope("foo").Collection("bar")
+				scopeName := "foo_1"
+				collectionName := "bar_1"
+				collection.Collection = collection.Bucket().Scope(scopeName).Collection(collectionName)
 
-				err = base.CreateBucketScopesAndCollections(base.TestCtx(t), collection.Spec, map[string][]string{"foo": {"bar"}})
+				err = base.CreateBucketScopesAndCollections(base.TestCtx(t), collection.Spec, map[string][]string{scopeName: {collectionName}})
 				require.NoError(t, err)
 			}
 
@@ -69,6 +71,10 @@ func TestInitializeIndexes(t *testing.T) {
 
 			validateErr := validateAllIndexesOnline(b)
 			require.NoError(t, validateErr, "Error validating indexes online")
+
+			// Drop again
+			dropErr = base.DropAllIndexes(base.TestCtx(t), n1qlStore)
+			require.NoError(t, dropErr, "Error dropping all indexes")
 		})
 	}
 

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -59,22 +59,21 @@ func TestInitializeIndexes(t *testing.T) {
 			n1qlStore, isGoCBBucket := base.AsN1QLStore(b)
 			require.True(t, isGoCBBucket)
 
-			dropErr := base.DropAllIndexes(base.TestCtx(t), n1qlStore)
-			require.NoError(t, dropErr, "Error dropping all indexes")
+			// Make sure we can drop and reinitialize twice
+			for i := 0; i < 2; i++ {
+				dropErr := base.DropAllIndexes(base.TestCtx(t), n1qlStore)
+				require.NoError(t, dropErr, "Error dropping all indexes")
 
-			initErr := InitializeIndexes(n1qlStore, test.xattrs, 0, true)
-			require.NoError(t, initErr, "Error initializing all indexes")
+				initErr := InitializeIndexes(n1qlStore, test.xattrs, 0, true)
+				require.NoError(t, initErr, "Error initializing all indexes")
 
-			// Recreate the primary index required by the test bucket pooling framework
-			err := n1qlStore.CreatePrimaryIndex(base.PrimaryIndexName, nil)
-			require.NoError(t, err)
+				// Recreate the primary index required by the test bucket pooling framework
+				err := n1qlStore.CreatePrimaryIndex(base.PrimaryIndexName, nil)
+				require.NoError(t, err)
 
-			validateErr := validateAllIndexesOnline(b)
-			require.NoError(t, validateErr, "Error validating indexes online")
-
-			// Drop again
-			dropErr = base.DropAllIndexes(base.TestCtx(t), n1qlStore)
-			require.NoError(t, dropErr, "Error dropping all indexes")
+				validateErr := validateAllIndexesOnline(b)
+				require.NoError(t, validateErr, "Error validating indexes online")
+			}
 		})
 	}
 


### PR DESCRIPTION
This prevents errors on DropIndexes in tests in db packages. This is not exercised until we do tests on named collections, but it works for non named collections.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/654/