### PR TITLE
Added retry loop to AssertLogContains

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -374,10 +374,18 @@ func LogTraceEnabled(logKey LogKey) bool {
 func AssertLogContains(t *testing.T, s string, f func()) {
 	b := bytes.Buffer{}
 
-	// temporarily override logger output for the given function call
+	// Temporarily override logger output for the given function call
 	consoleLogger.logger.SetOutput(&b)
 	f()
+	// Allow time for logs to be printed
+	retry := func() (shouldRetry bool, err error, value interface{}) {
+		if strings.Contains(b.String(), s) {
+			return false, nil, nil
+		}
+		return true, nil, nil
+	}
+	err, _ := RetryLoop("wait for logs", retry, CreateSleeperFunc(10, 100))
 	consoleLogger.logger.SetOutput(os.Stderr)
 
-	assert.Contains(t, b.String(), s)
+	assert.NoError(t, err, "Console logs did not contain %q", s)
 }


### PR DESCRIPTION
Added retry loop to `AssertLogContains` to allow time for logs to be printed. 

Had issues with this test failing due to a delay in the logs being printed. For example:
```
        	Error:      	"2022-08-17T18:26:35.861Z [INF] Design docs successfully created for view version 2.1.\n2022-08-17T18:26:35.861Z [INF] Verifying view availability for bucket <ud>sg_int_1_1660760006789818120</ud>...\n2022-08-17T18:26:35.877Z [INF] Views ready for bucket <ud>sg_int_1_1660760006789818120</ud>.\n2022-08-17T18:26:35.877Z [INF] Logging stats with frequency: &{1m0s}\n2022-08-17T18:26:35.892Z [INF] Opening db /db as bucket \"sg_int_1_1660760006789818120\", pool \"default\", server <couchbase://127.0.0.1>\n2022-08-17T18:26:35.892Z [INF] GoCBv2 Opening Couchbase database sg_int_1_1660760006789818120 on <couchbase://127.0.0.1> as user \"<ud>Administrator</ud>\"\n2022-08-17T18:26:35.893Z [INF] Setting query timeouts for bucket sg_int_1_1660760006789818120 to 1m15s\n2022-08-17T18:26:35.925Z [INF] Setting max_concurrent_query_ops to 256 based on query node count (1)\n2022-08-17T18:26:35.947Z [INF] Design docs for current SG view version (2.1) found.\n2022-08-17T18:26:35.947Z [INF] Verifying view availability for bucket <ud>sg_int_1_1660760006789818120</ud>...\n2022-08-17T18:26:35.974Z [INF] Views ready for bucket <ud>sg_int_1_1660760006789818120</ud>.\n2022-08-17T18:26:35.974Z [INF] delta_sync enabled=false with rev_max_age_seconds=86400 for database db\n2022-08-17T18:26:35.975Z [INF] Created background task: \"CleanAgedItems\" with interval 1m0s\n2022-08-17T18:26:35.975Z [INF] Created background task: \"InsertPendingEntries\" with interval 2.5s\n2022-08-17T18:26:35.975Z [INF] Created background task: \"CleanSkippedSequenceQueue\" with interval 30m0s\n2022-08-17T18:26:36.186Z [INF] Setting max_concurrent_query_ops to 256 based on query node count (1)\n2022-08-17T18:26:36.495Z [INF] c:db:db Using metadata purge interval of 3.00 days for tombstone compaction.\n2022-08-17T18:26:36.495Z [INF] Created background task: \"Compact\" with interval 24h0m0s\n2022-08-17T18:26:36.499Z [INF] Using default sync function 'channel(doc.channels)' for database \"db\"\n" does not contain "/db/_local/<ud>test</ud>"
        	Test:       	TestHTTPLoggingRedaction/local
2022-08-17T18:26:36.857Z [INF] HTTP: c:#14004 GET http://localhost/db/_local/<ud>test</ud> (as GUEST)
2022-08-17T18:26:36.857Z [INF] HTTP: c:#14004 #14004:     --> 401 Login required  (356.9 ms)
```

The line `2022-08-17T18:26:36.857Z [INF] HTTP: c:#14004 GET http://localhost/db/_local/<ud>test</ud> (as GUEST)` gets printed after the function has already ran due to it being ~350ms late. This retry loop will fix this and allow time for the logs to be printed/catch up.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/651/