### PR TITLE
CBG-2291: Improve assertion handling for DesignDoc tests

### DIFF
--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -22,11 +22,9 @@ import (
 
 // A wrapper around a Bucket to support forced errors.  For testing use only.
 type LeakyBucket struct {
-	bucket               Bucket
-	incrCount            uint16
-	deleteDDocErrorCount int
-	getDDocErrorCount    int
-	config               LeakyBucketConfig
+	bucket    Bucket
+	incrCount uint16
+	config    LeakyBucketConfig
 }
 
 // The config object that controls the LeakyBucket behavior
@@ -78,6 +76,13 @@ type LeakyBucketConfig struct {
 
 	// When IgnoreClose is set to true, bucket.Close() is a no-op.  Used when multiple references to a bucket are active.
 	IgnoreClose bool
+}
+
+func (b *LeakyBucket) SetDDocDeleteErrorCount(i int) {
+	b.config.DDocDeleteErrorCount = i
+}
+func (b *LeakyBucket) SetDDocGetErrorCount(i int) {
+	b.config.DDocGetErrorCount = i
 }
 
 func NewLeakyBucket(bucket Bucket, config LeakyBucketConfig) *LeakyBucket {

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -783,6 +783,7 @@ func RequireAllAssertions(t *testing.T, assertionResults ...bool) {
 	for _, ok := range assertionResults {
 		if !ok {
 			failed = true
+			break
 		}
 	}
 	require.Falsef(t, failed, "One or more assertions failed: %v", assertionResults)

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -771,3 +771,19 @@ func CreateBucketScopesAndCollections(ctx context.Context, bucketSpec BucketSpec
 
 	return nil
 }
+
+// RequireAllAssertions ensures that all assertion results were true/ok, and fails the test if any were not.
+// Usage:
+//     RequireAllAssertions(t,
+//         assert.True(t, condition1),
+//         assert.True(t, condition2),
+//     )
+func RequireAllAssertions(t *testing.T, assertionResults ...bool) {
+	var failed bool
+	for _, ok := range assertionResults {
+		if !ok {
+			failed = true
+		}
+	}
+	require.Falsef(t, failed, "One or more assertions failed: %v", assertionResults)
+}

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -34,9 +34,10 @@ const DesignDocVersion = "2.1"
 const DesignDocFormat = "%s_%s" // Design doc prefix, view version
 
 // DesignDocPreviousVersions defines the set of versions included during removal of obsolete
-// design docs.  Must be updated whenever DesignDocVersion is incremented.
-// Uses a hardcoded list instead of version comparison to simpify the processing
+// design docs in removeObsoleteDesignDocs.  Must be updated whenever DesignDocVersion is incremented.
+// Uses a hardcoded list instead of version comparison to simplify the processing
 // (particularly since there aren't expected to be many view versions before moving to GSI).
+// See setDesignDocPreviousVersionsForTest for a way to temporarily override this during tests.
 var DesignDocPreviousVersions = []string{"", "2.0"}
 
 const (

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -726,6 +726,10 @@ func IsMissingDDocError(err error) bool {
 		return true
 	}
 
+	if errors.Is(err, base.ErrNotFound) {
+		return true
+	}
+
 	return false
 
 }

--- a/db/design_doc_test.go
+++ b/db/design_doc_test.go
@@ -85,7 +85,7 @@ func TestRemoveObsoleteDesignDocs(t *testing.T) {
 }
 
 func TestRemoveDesignDocsUseViewsTrueAndFalse(t *testing.T) {
-	DesignDocPreviousVersions = []string{"2.0"}
+	setDesignDocPreviousVersionsForTest(t, "2.0")
 
 	base.ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
@@ -144,8 +144,9 @@ func TestRemoveDesignDocsUseViewsTrueAndFalse(t *testing.T) {
 
 // Test remove obsolete design docs returns the same in both preview and non-preview
 func TestRemoveObsoleteDesignDocsErrors(t *testing.T) {
+	setDesignDocPreviousVersionsForTest(t, "test")
 
-	DesignDocPreviousVersions = []string{"test"}
+	SetDesignDocPreviousVersionsForTest(t, "test")
 
 	leakyBucketConfig := base.LeakyBucketConfig{
 		DDocGetErrorCount:    1,
@@ -182,17 +183,4 @@ func TestRemoveObsoleteDesignDocsErrors(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equalf(t, removedDDocsPreview, removedDDocsNonPreview, "preview and non-preview should return the same design docs")
-}
-
-func assertDesignDocExists(t testing.TB, bucket base.Bucket, ddocName string) bool {
-	_, err := bucket.GetDDoc(ddocName)
-	return assert.NoErrorf(t, err, "Design doc %s should exist but got an error fetching it: %v", ddocName, err)
-}
-
-func assertDesignDocNotExists(t testing.TB, bucket base.Bucket, ddocName string) bool {
-	ddoc, err := bucket.GetDDoc(ddocName)
-	if err == nil {
-		return assert.Failf(t, "Design doc %s should not exist but but it did: %v", ddocName, ddoc)
-	}
-	return assert.Truef(t, IsMissingDDocError(err), "Design doc %s should not exist but got a different error fetching it: %v", ddocName, err)
 }

--- a/db/design_doc_test.go
+++ b/db/design_doc_test.go
@@ -146,14 +146,7 @@ func TestRemoveDesignDocsUseViewsTrueAndFalse(t *testing.T) {
 func TestRemoveObsoleteDesignDocsErrors(t *testing.T) {
 	setDesignDocPreviousVersionsForTest(t, "test")
 
-	SetDesignDocPreviousVersionsForTest(t, "test")
-
-	leakyBucketConfig := base.LeakyBucketConfig{
-		DDocGetErrorCount:    1,
-		DDocDeleteErrorCount: 1,
-	}
-
-	bucket := base.NewLeakyBucket(base.GetTestBucket(t), leakyBucketConfig)
+	bucket := base.NewLeakyBucket(base.GetTestBucket(t), base.LeakyBucketConfig{})
 	defer bucket.Close()
 
 	mapFunction := `function (doc, meta){ emit(); }`
@@ -176,6 +169,11 @@ func TestRemoveObsoleteDesignDocsErrors(t *testing.T) {
 		assertDesignDocExists(t, bucket, DesignDocSyncGatewayPrefix+"_test"),
 		assertDesignDocExists(t, bucket, DesignDocSyncHousekeepingPrefix+"_test"),
 	)
+
+	lb, ok := base.AsLeakyBucket(bucket)
+	require.Truef(t, ok, "bucket is not a leaky bucket")
+	lb.SetDDocGetErrorCount(1)
+	lb.SetDDocDeleteErrorCount(1)
 
 	removedDDocsPreview, err := removeObsoleteDesignDocs(bucket, true, false)
 	assert.NoError(t, err)

--- a/db/design_doc_util_test.go
+++ b/db/design_doc_util_test.go
@@ -1,0 +1,32 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+)
+
+// setDesignDocPreviousVersionsForTest sets the previous versions of the design docs for testing purposes and reverts to the original set once the test is done.
+func setDesignDocPreviousVersionsForTest(t testing.TB, versions ...string) {
+	original := DesignDocPreviousVersions
+	t.Cleanup(func() {
+		DesignDocPreviousVersions = original
+	})
+	DesignDocPreviousVersions = versions
+}
+
+// assertDesignDocExists ensures that the design doc exists in the bucket.
+func assertDesignDocExists(t testing.TB, bucket base.Bucket, ddocName string) bool {
+	_, err := bucket.GetDDoc(ddocName)
+	return assert.NoErrorf(t, err, "Design doc %s should exist but got an error fetching it: %v", ddocName, err)
+}
+
+// assertDesignDocDoesNotExist ensures that the design doc does not exist in the bucket.
+func assertDesignDocNotExists(t testing.TB, bucket base.Bucket, ddocName string) bool {
+	ddoc, err := bucket.GetDDoc(ddocName)
+	if err == nil {
+		return assert.Failf(t, "Design doc %s should not exist but but it did: %v", ddocName, ddoc)
+	}
+	return assert.Truef(t, IsMissingDDocError(err), "Design doc %s should not exist but got a different error fetching it: %v", ddocName, err)
+}


### PR DESCRIPTION
CBG-2291

Some errors were being ignored or only asserted on - which made these tests report failures in a misleading way.

- Added `setDesignDocPreviousVersionsForTest` helper to allow tests to temporarily override `DesignDocPreviousVersions` but revert back to original state
- Added `ErrNotFound` to `IsMissingDDocError` to reflect Bucket API implementations 
- Switched to `require` for constructive/destructive actions (`PutDDoc`/`removeObsolteDesignDocs preview:false`) where we know the test is going to fail later on.
- Added `RequireAllAssertions` helper to ensure all ddocs were created successfully before proceeding further
- Better assertion messages for `designDocExists`/`!designDocExists`

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/653/
- [x] `^Test.*DesignDoc.*$` https://jenkins.sgwdev.com/job/SyncGateway-Integration/652/