### PR TITLE
CBG-2257: Per bucket credentials can now be used for fetching configs

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"syscall"
 
+	"golang.org/x/exp/maps"
+
 	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/square/go-jose.v2"
 
@@ -284,7 +286,7 @@ func (dbc *DbConfig) inheritFromBootstrap(b BootstrapConfig) {
 	}
 }
 
-func (dbConfig *DbConfig) setPerDatabaseCredentials(dbCredentials CredentialsConfig) {
+func (dbConfig *DbConfig) setPerDatabaseCredentials(dbCredentials base.CredentialsConfig) {
 	// X.509 overrides username/password
 	if dbCredentials.X509CertPath != "" || dbCredentials.X509KeyPath != "" {
 		dbConfig.CertPath = dbCredentials.X509CertPath
@@ -300,7 +302,7 @@ func (dbConfig *DbConfig) setPerDatabaseCredentials(dbCredentials CredentialsCon
 }
 
 // setup populates fields in the dbConfig
-func (dbConfig *DbConfig) setup(dbName string, bootstrapConfig BootstrapConfig, dbCredentials *CredentialsConfig) error {
+func (dbConfig *DbConfig) setup(dbName string, bootstrapConfig BootstrapConfig, dbCredentials *base.CredentialsConfig) error {
 
 	dbConfig.inheritFromBootstrap(bootstrapConfig)
 	if dbCredentials != nil {
@@ -1173,7 +1175,7 @@ func (sc *StartupConfig) validate(isEnterpriseEdition bool) (errorMessages error
 		}
 	}
 
-	if base.BoolDefault(sc.Unsupported.Serverless, false) && len(sc.BucketCredentials) == 0 {
+	if sc.IsServerless() && len(sc.BucketCredentials) == 0 {
 		multiError = multiError.Append(fmt.Errorf("at least 1 bucket must be defined in bucket_credentials when running in serverless mode"))
 	}
 
@@ -1369,16 +1371,18 @@ func (sc *ServerContext) fetchDatabase(dbName string) (found bool, dbConfig *Dat
 // fetchConfigs retrieves all database configs from the ServerContext's bootstrapConnection.
 func (sc *ServerContext) fetchConfigs(isInitialStartup bool) (dbNameConfigs map[string]DatabaseConfig, err error) {
 	var buckets []string
-	// If serverless, return buckets that have credentials set that do not have a db associated with them
-	if base.BoolDefault(sc.config.Unsupported.Serverless, false) {
-		buckets = make([]string, len(sc.config.BucketCredentials)-len(sc.bucketDbName))
-		for bucket := range sc.config.BucketCredentials {
-			i := 0
-			if sc.bucketDbName[bucket] == "" {
-				buckets[i] = bucket
-				i++
-			}
-		}
+	if sc.config.IsServerless() {
+		buckets = maps.Keys(sc.config.BucketCredentials)
+		// TODO: Enable code as part of CBG-2280
+		// Return buckets that have credentials set that do not have a db associated with them
+		//buckets = make([]string, len(sc.config.BucketCredentials)-len(sc.bucketDbName))
+		//for bucket := range sc.config.BucketCredentials {
+		//	i := 0
+		//	if sc.bucketDbName[bucket] == "" {
+		//		buckets[i] = bucket
+		//		i++
+		//	}
+		//}
 	} else {
 		buckets, err = sc.bootstrapContext.connection.GetConfigBuckets()
 		if err != nil {

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -207,9 +207,9 @@ func fillConfigWithFlags(fs *flag.FlagSet, flags map[string]configFlag) error {
 					return
 				}
 				*val.config.(*PerDatabaseCredentialsConfig) = dbCredentials
-			case *PerBucketCredentialsConfig:
+			case *base.PerBucketCredentialsConfig:
 				str := *val.flagValue.(*string)
-				var bucketCredentials PerBucketCredentialsConfig
+				var bucketCredentials base.PerBucketCredentialsConfig
 				d := base.JSONDecoder(strings.NewReader(str))
 				d.DisallowUnknownFields()
 				err := d.Decode(&bucketCredentials)
@@ -218,7 +218,7 @@ func fillConfigWithFlags(fs *flag.FlagSet, flags map[string]configFlag) error {
 					errorMessages = errorMessages.Append(err)
 					return
 				}
-				*val.config.(*PerBucketCredentialsConfig) = bucketCredentials
+				*val.config.(*base.PerBucketCredentialsConfig) = bucketCredentials
 			default:
 				errorMessages = errorMessages.Append(fmt.Errorf("Unknown type %v for flag %v\n", rval.Type(), f.Name))
 			}

--- a/rest/config_flags_test.go
+++ b/rest/config_flags_test.go
@@ -38,7 +38,7 @@ func TestAllConfigFlags(t *testing.T) {
 				val = "trace"
 			case *PerDatabaseCredentialsConfig:
 				val = `{"db1":{"password":"foo"}}`
-			case *PerBucketCredentialsConfig:
+			case *base.PerBucketCredentialsConfig:
 				val = `{"bucket":{"password":"foo"}}`
 			}
 			flags = append(flags, "-"+name, val)

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -67,8 +67,8 @@ type StartupConfig struct {
 	Replicator  ReplicatorConfig   `json:"replicator,omitempty"`
 	Unsupported UnsupportedConfig  `json:"unsupported,omitempty"`
 
-	DatabaseCredentials PerDatabaseCredentialsConfig `json:"database_credentials,omitempty" help:"A map of database name to credentials, that can be used instead of the bootstrap ones. Cannot be used in conjunction with bucket_credentials."`
-	BucketCredentials   PerBucketCredentialsConfig   `json:"bucket_credentials,omitempty" help:"A map of bucket names to credentials, that can be used instead of the bootstrap ones. Cannot be used in conjunction with database_credentials."`
+	DatabaseCredentials PerDatabaseCredentialsConfig    `json:"database_credentials,omitempty" help:"A map of database name to credentials, that can be used instead of the bootstrap ones. Cannot be used in conjunction with bucket_credentials."`
+	BucketCredentials   base.PerBucketCredentialsConfig `json:"bucket_credentials,omitempty" help:"A map of bucket names to credentials, that can be used instead of the bootstrap ones. Cannot be used in conjunction with database_credentials."`
 
 	MaxFileDescriptors         uint64 `json:"max_file_descriptors,omitempty" help:"Max # of open file descriptors (RLIMIT_NOFILE)"`
 	CouchbaseKeepaliveInterval *int   `json:"couchbase_keepalive_interval,omitempty" help:"TCP keep-alive interval between SG and Couchbase server"`
@@ -148,16 +148,7 @@ type HTTP2Config struct {
 	Enabled *bool `json:"enabled,omitempty" help:"Whether HTTP2 support is enabled"`
 }
 
-type PerDatabaseCredentialsConfig map[string]*CredentialsConfig
-
-type PerBucketCredentialsConfig map[string]*CredentialsConfig
-
-type CredentialsConfig struct {
-	Username     string `json:"username,omitempty"       help:"Username for authenticating to the bucket"`
-	Password     string `json:"password,omitempty"       help:"Password for authenticating to the bucket"`
-	X509CertPath string `json:"x509_cert_path,omitempty" help:"Cert path (public key) for X.509 bucket auth"`
-	X509KeyPath  string `json:"x509_key_path,omitempty"  help:"Key path (private key) for X.509 bucket auth"`
-}
+type PerDatabaseCredentialsConfig map[string]*base.CredentialsConfig
 
 type DeprecatedConfig struct {
 	Facebook *FacebookConfigLegacy `json:"-" help:""`
@@ -189,6 +180,10 @@ func (sc *StartupConfig) Redacted() (*StartupConfig, error) {
 	}
 
 	return &config, nil
+}
+
+func (sc *StartupConfig) IsServerless() bool {
+	return base.BoolDefault(sc.Unsupported.Serverless, false)
 }
 
 func LoadStartupConfigFromPath(path string) (*StartupConfig, error) {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2529,3 +2529,85 @@ func TestBucketCredentialsValidation(t *testing.T) {
 		})
 	}
 }
+
+// Tests behaviour of CBG-2257 to poll only buckets in BucketCredentials that don't currently have a database
+func TestServerlessPollBuckets(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	// Get test bucket
+	tb1 := base.GetTestBucket(t)
+	defer tb1.Close()
+
+	config := bootstrapStartupConfigForTest(t)
+	config.Unsupported.Serverless = base.BoolPtr(true)
+	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0)
+	// Use invalid bucket to get past validation stage - will cause warnings throughout test
+	config.BucketCredentials = map[string]*CredentialsConfig{"invalid_bucket": {}}
+
+	sc, err := setupServerContext(&config, true)
+	require.NoError(t, err)
+
+	serverErr := make(chan error, 0)
+	defer func() {
+		sc.Close()
+		require.NoError(t, <-serverErr)
+	}()
+
+	go func() {
+		serverErr <- startServer(&config, sc)
+	}()
+	require.NoError(t, sc.waitForRESTAPIs())
+
+	// Confirm fetch does not return any configs due to no databases existing
+	configs, err := sc.fetchConfigs(false)
+	require.NoError(t, err)
+	assert.Empty(t, configs)
+
+	// Create a database
+	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb1, groupID: base.StringPtr(config.Bootstrap.ConfigGroupID), persistentConfig: true})
+	defer rt.Close()
+	// Create a new db on the RT to confirm fetch won't retrieve it (due to bucket not being in BucketCredentials)
+	resp := rt.SendAdminRequest(http.MethodPut, "/db/", fmt.Sprintf(`{
+		"bucket": "%s",
+		"use_views": %t,
+		"num_index_replicas": 0
+	}`, tb1.GetName(), base.TestsDisableGSI()))
+	requireStatus(t, resp, http.StatusCreated)
+
+	// Confirm fetch does not return any configs due to no databases in the bucket credentials config
+	configs, err = sc.fetchConfigs(false)
+	require.NoError(t, err)
+	assert.Empty(t, configs)
+
+	// Add test bucket to bucket credentials config
+	sc.config.BucketCredentials = map[string]*CredentialsConfig{
+		tb1.GetName(): {
+			Username: base.TestClusterUsername(),
+			Password: base.TestClusterPassword(),
+		},
+	}
+
+	// Update the CouchbaseCluster to include the new bucket credentials
+	couchbaseCluster, err := createCouchbaseClusterFromStartupConfig(sc.config)
+	require.NoError(t, err)
+	sc.bootstrapContext.connection = couchbaseCluster
+
+	// Confirm fetch does return config for db in tb1
+	configs, err = sc.fetchConfigs(false)
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+	assert.NotNil(t, configs["db"])
+	count, err := sc.fetchAndLoadConfigs(false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	// Confirm fetch does not return any configs due to db being known about already (so existing db does not get polled)
+	configs, err = sc.fetchConfigs(false)
+	require.NoError(t, err)
+	assert.Empty(t, configs)
+	count, err = sc.fetchAndLoadConfigs(false)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1673,7 +1673,7 @@ func TestSetupDbConfigCredentials(t *testing.T) {
 		name              string
 		dbConfig          DbConfig
 		bootstrapConfig   BootstrapConfig
-		credentialsConfig *CredentialsConfig
+		credentialsConfig *base.CredentialsConfig
 		expectX509        bool
 	}{
 		{
@@ -1686,26 +1686,26 @@ func TestSetupDbConfigCredentials(t *testing.T) {
 			name:              "db username/password override",
 			dbConfig:          DbConfig{Name: "db"},
 			bootstrapConfig:   BootstrapConfig{Server: "couchbase://example.org", Username: "bob", Password: "foobar"},
-			credentialsConfig: &CredentialsConfig{Username: expectedUsername, Password: expectedPassword},
+			credentialsConfig: &base.CredentialsConfig{Username: expectedUsername, Password: expectedPassword},
 		},
 		{
 			name:              "db username/password override from x509",
 			dbConfig:          DbConfig{Name: "db"},
 			bootstrapConfig:   BootstrapConfig{Server: "couchbase://example.org", X509CertPath: "/tmp/x509cert", X509KeyPath: "/tmp/x509key"},
-			credentialsConfig: &CredentialsConfig{Username: expectedUsername, Password: expectedPassword},
+			credentialsConfig: &base.CredentialsConfig{Username: expectedUsername, Password: expectedPassword},
 		},
 		{
 			name:              "db x509 override from username/password",
 			dbConfig:          DbConfig{Name: "db"},
 			bootstrapConfig:   BootstrapConfig{Server: "couchbase://example.org", Username: "bob", Password: "foobar"},
-			credentialsConfig: &CredentialsConfig{X509CertPath: expectedX509Cert, X509KeyPath: expectedX509Key},
+			credentialsConfig: &base.CredentialsConfig{X509CertPath: expectedX509Cert, X509KeyPath: expectedX509Key},
 			expectX509:        true,
 		},
 		{
 			name:              "db x509 override",
 			dbConfig:          DbConfig{Name: "db"},
 			bootstrapConfig:   BootstrapConfig{Server: "couchbase://example.org", X509CertPath: "/tmp/bs-x509cert", X509KeyPath: "/tmp/bs-x509key"},
-			credentialsConfig: &CredentialsConfig{X509CertPath: expectedX509Cert, X509KeyPath: expectedX509Key},
+			credentialsConfig: &base.CredentialsConfig{X509CertPath: expectedX509Cert, X509KeyPath: expectedX509Key},
 			expectX509:        true,
 		},
 	}
@@ -2427,67 +2427,67 @@ func TestBucketCredentialsValidation(t *testing.T) {
 		{
 			name: "Valid bucket using x509",
 			startupConfig: StartupConfig{
-				BucketCredentials: PerBucketCredentialsConfig{"bucket": &CredentialsConfig{X509CertPath: "cert", X509KeyPath: "key"}},
+				BucketCredentials: base.PerBucketCredentialsConfig{"bucket": &base.CredentialsConfig{X509CertPath: "cert", X509KeyPath: "key"}},
 			},
 		},
 		{
 			name: "Valid bucket using basic auth",
 			startupConfig: StartupConfig{
-				BucketCredentials: PerBucketCredentialsConfig{"bucket": &CredentialsConfig{Username: "uname", Password: "pass"}}},
+				BucketCredentials: base.PerBucketCredentialsConfig{"bucket": &base.CredentialsConfig{Username: "uname", Password: "pass"}}},
 		},
 		{
 			name: "Valid database using basic auth",
 			startupConfig: StartupConfig{
-				DatabaseCredentials: PerDatabaseCredentialsConfig{"db": &CredentialsConfig{Username: "uname", Password: "pword"}},
+				DatabaseCredentials: PerDatabaseCredentialsConfig{"db": &base.CredentialsConfig{Username: "uname", Password: "pword"}},
 			},
 		},
 		{
 			name: "Blank database and filled bucket creds provided",
 			startupConfig: StartupConfig{
 				DatabaseCredentials: PerDatabaseCredentialsConfig{},
-				BucketCredentials:   PerBucketCredentialsConfig{"bucket": &CredentialsConfig{X509CertPath: "cert", X509KeyPath: "key"}},
+				BucketCredentials:   base.PerBucketCredentialsConfig{"bucket": &base.CredentialsConfig{X509CertPath: "cert", X509KeyPath: "key"}},
 			},
 		},
 		{
 			name: "Filled database and blank bucket creds provided",
 			startupConfig: StartupConfig{
-				BucketCredentials:   PerBucketCredentialsConfig{},
-				DatabaseCredentials: PerDatabaseCredentialsConfig{"bucket": &CredentialsConfig{X509CertPath: "cert", X509KeyPath: "key"}},
+				BucketCredentials:   base.PerBucketCredentialsConfig{},
+				DatabaseCredentials: PerDatabaseCredentialsConfig{"bucket": &base.CredentialsConfig{X509CertPath: "cert", X509KeyPath: "key"}},
 			},
 		},
 		{
 			name: "Database and bucket creds provided",
 			startupConfig: StartupConfig{
-				DatabaseCredentials: PerDatabaseCredentialsConfig{"bucket": &CredentialsConfig{X509CertPath: "cert", X509KeyPath: "key"}},
-				BucketCredentials:   PerBucketCredentialsConfig{"bucket": &CredentialsConfig{X509CertPath: "cert", X509KeyPath: "key"}},
+				DatabaseCredentials: PerDatabaseCredentialsConfig{"bucket": &base.CredentialsConfig{X509CertPath: "cert", X509KeyPath: "key"}},
+				BucketCredentials:   base.PerBucketCredentialsConfig{"bucket": &base.CredentialsConfig{X509CertPath: "cert", X509KeyPath: "key"}},
 			},
 			expectedError: &bucketAndDBCredsError,
 		},
 		{
 			name: "Bucket creds for x509 and basic auth",
 			startupConfig: StartupConfig{
-				BucketCredentials: PerBucketCredentialsConfig{"bucket": &CredentialsConfig{X509CertPath: "cert", X509KeyPath: "key", Username: "uname", Password: "pword"}},
+				BucketCredentials: base.PerBucketCredentialsConfig{"bucket": &base.CredentialsConfig{X509CertPath: "cert", X509KeyPath: "key", Username: "uname", Password: "pword"}},
 			},
 			expectedError: &bucketCredsError,
 		},
 		{
 			name: "Bucket creds for x509 key and basic auth password only",
 			startupConfig: StartupConfig{
-				BucketCredentials: PerBucketCredentialsConfig{"bucket": &CredentialsConfig{X509KeyPath: "key", Password: "pword"}},
+				BucketCredentials: base.PerBucketCredentialsConfig{"bucket": &base.CredentialsConfig{X509KeyPath: "key", Password: "pword"}},
 			},
 			expectedError: &bucketCredsError,
 		},
 		{
 			name: "Bucket creds for x509 cert and basic auth username only",
 			startupConfig: StartupConfig{
-				BucketCredentials: PerBucketCredentialsConfig{"bucket": &CredentialsConfig{X509CertPath: "cert", Username: "uname"}},
+				BucketCredentials: base.PerBucketCredentialsConfig{"bucket": &base.CredentialsConfig{X509CertPath: "cert", Username: "uname"}},
 			},
 			expectedError: &bucketCredsError,
 		},
 		{
 			name: "Bucket creds for x509 cert and basic auth username only",
 			startupConfig: StartupConfig{
-				BucketCredentials: PerBucketCredentialsConfig{"bucket": &CredentialsConfig{X509CertPath: "cert", Username: "uname"}},
+				BucketCredentials: base.PerBucketCredentialsConfig{"bucket": &base.CredentialsConfig{X509CertPath: "cert", Username: "uname"}},
 			},
 			expectedError: &bucketCredsError,
 		},
@@ -2501,7 +2501,7 @@ func TestBucketCredentialsValidation(t *testing.T) {
 		{
 			name: "No bucket credentials provided when running in serverless mode",
 			startupConfig: StartupConfig{
-				BucketCredentials: PerBucketCredentialsConfig{},
+				BucketCredentials: base.PerBucketCredentialsConfig{},
 				Unsupported:       UnsupportedConfig{Serverless: base.BoolPtr(true)},
 			},
 			expectedError: &bucketNoCredsServerless,
@@ -2510,7 +2510,7 @@ func TestBucketCredentialsValidation(t *testing.T) {
 			name: "Bucket credentials provided when running in serverless mode",
 			startupConfig: StartupConfig{
 				Unsupported:       UnsupportedConfig{Serverless: base.BoolPtr(true)},
-				BucketCredentials: PerBucketCredentialsConfig{"bucket": &CredentialsConfig{Username: "u", Password: "p"}},
+				BucketCredentials: base.PerBucketCredentialsConfig{"bucket": &base.CredentialsConfig{Username: "u", Password: "p"}},
 			},
 		},
 	}
@@ -2528,86 +2528,4 @@ func TestBucketCredentialsValidation(t *testing.T) {
 			}
 		})
 	}
-}
-
-// Tests behaviour of CBG-2257 to poll only buckets in BucketCredentials that don't currently have a database
-func TestServerlessPollBuckets(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
-
-	// Get test bucket
-	tb1 := base.GetTestBucket(t)
-	defer tb1.Close()
-
-	config := bootstrapStartupConfigForTest(t)
-	config.Unsupported.Serverless = base.BoolPtr(true)
-	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0)
-	// Use invalid bucket to get past validation stage - will cause warnings throughout test
-	config.BucketCredentials = map[string]*CredentialsConfig{"invalid_bucket": {}}
-
-	sc, err := setupServerContext(&config, true)
-	require.NoError(t, err)
-
-	serverErr := make(chan error, 0)
-	defer func() {
-		sc.Close()
-		require.NoError(t, <-serverErr)
-	}()
-
-	go func() {
-		serverErr <- startServer(&config, sc)
-	}()
-	require.NoError(t, sc.waitForRESTAPIs())
-
-	// Confirm fetch does not return any configs due to no databases existing
-	configs, err := sc.fetchConfigs(false)
-	require.NoError(t, err)
-	assert.Empty(t, configs)
-
-	// Create a database
-	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb1, groupID: base.StringPtr(config.Bootstrap.ConfigGroupID), persistentConfig: true})
-	defer rt.Close()
-	// Create a new db on the RT to confirm fetch won't retrieve it (due to bucket not being in BucketCredentials)
-	resp := rt.SendAdminRequest(http.MethodPut, "/db/", fmt.Sprintf(`{
-		"bucket": "%s",
-		"use_views": %t,
-		"num_index_replicas": 0
-	}`, tb1.GetName(), base.TestsDisableGSI()))
-	requireStatus(t, resp, http.StatusCreated)
-
-	// Confirm fetch does not return any configs due to no databases in the bucket credentials config
-	configs, err = sc.fetchConfigs(false)
-	require.NoError(t, err)
-	assert.Empty(t, configs)
-
-	// Add test bucket to bucket credentials config
-	sc.config.BucketCredentials = map[string]*CredentialsConfig{
-		tb1.GetName(): {
-			Username: base.TestClusterUsername(),
-			Password: base.TestClusterPassword(),
-		},
-	}
-
-	// Update the CouchbaseCluster to include the new bucket credentials
-	couchbaseCluster, err := createCouchbaseClusterFromStartupConfig(sc.config)
-	require.NoError(t, err)
-	sc.bootstrapContext.connection = couchbaseCluster
-
-	// Confirm fetch does return config for db in tb1
-	configs, err = sc.fetchConfigs(false)
-	require.NoError(t, err)
-	require.Len(t, configs, 1)
-	assert.NotNil(t, configs["db"])
-	count, err := sc.fetchAndLoadConfigs(false)
-	require.NoError(t, err)
-	assert.Equal(t, 1, count)
-
-	// Confirm fetch does not return any configs due to db being known about already (so existing db does not get polled)
-	configs, err = sc.fetchConfigs(false)
-	require.NoError(t, err)
-	assert.Empty(t, configs)
-	count, err = sc.fetchAndLoadConfigs(false)
-	require.NoError(t, err)
-	assert.Equal(t, 0, count)
 }

--- a/rest/main.go
+++ b/rest/main.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/couchbase/gocb/v2"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	pkgerrors "github.com/pkg/errors"
@@ -359,9 +360,22 @@ func backupCurrentConfigFile(sourcePath string) (string, error) {
 }
 
 func createCouchbaseClusterFromStartupConfig(config *StartupConfig) (*base.CouchbaseCluster, error) {
-	cluster, err := base.NewCouchbaseCluster(config.Bootstrap.Server, config.Bootstrap.Username,
-		config.Bootstrap.Password, config.Bootstrap.X509CertPath, config.Bootstrap.X509KeyPath,
-		config.Bootstrap.CACertPath, config.Bootstrap.ServerTLSSkipVerify)
+	// Populate individual bucket credentials
+	perBucketAuth := make(map[string]*gocb.Authenticator, len(config.BucketCredentials))
+	for bucket, credentials := range config.BucketCredentials {
+		authenticator, err := base.GoCBv2Authenticator(
+			credentials.Username, credentials.Password,
+			credentials.X509CertPath, credentials.X509KeyPath,
+		)
+		if err != nil {
+			return nil, err
+		}
+		perBucketAuth[bucket] = &authenticator
+	}
+
+	cluster, err := base.NewCouchbaseCluster(config.Bootstrap.Server, config.Bootstrap.Username, config.Bootstrap.Password,
+		config.Bootstrap.X509CertPath, config.Bootstrap.X509KeyPath, config.Bootstrap.CACertPath,
+		base.BoolDefault(config.Unsupported.Serverless, false), perBucketAuth, config.Bootstrap.ServerTLSSkipVerify)
 	if err != nil {
 		base.InfofCtx(context.Background(), base.KeyConfig, "Couldn't create couchbase cluster instance: %v", err)
 		return nil, err

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1516,7 +1516,6 @@ func (sc *ServerContext) initializeCouchbaseServerConnections() error {
 		if err != nil {
 			return err
 		}
-
 		sc.bootstrapContext.connection = couchbaseCluster
 
 		count, err := sc.fetchAndLoadConfigs(true)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -826,7 +826,7 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		BcryptCost:                bcryptCost,
 		GroupID:                   groupID,
 		JavascriptTimeout:         javascriptTimeout,
-		Serverless:                base.BoolDefault(sc.config.Unsupported.Serverless, false),
+		Serverless:                sc.config.IsServerless(),
 	}
 
 	return contextOptions, nil

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -1,0 +1,94 @@
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests behaviour of CBG-2257 to poll only buckets in BucketCredentials that don't currently have a database
+func TestServerlessPollBuckets(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	// Get test bucket
+	tb1 := base.GetTestBucket(t)
+	defer tb1.Close()
+
+	config := bootstrapStartupConfigForTest(t)
+	config.Unsupported.Serverless = base.BoolPtr(true)
+	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0)
+	// Use invalid bucket to get past validation stage - will cause warnings throughout test
+	config.BucketCredentials = map[string]*base.CredentialsConfig{"invalid_bucket": {}}
+
+	sc, err := setupServerContext(&config, true)
+	require.NoError(t, err)
+
+	serverErr := make(chan error, 0)
+	defer func() {
+		sc.Close()
+		require.NoError(t, <-serverErr)
+	}()
+
+	go func() {
+		serverErr <- startServer(&config, sc)
+	}()
+	require.NoError(t, sc.waitForRESTAPIs())
+
+	// Confirm fetch does not return any configs due to no databases existing
+	configs, err := sc.fetchConfigs(false)
+	require.NoError(t, err)
+	assert.Empty(t, configs)
+
+	// Create a database
+	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb1, groupID: base.StringPtr(config.Bootstrap.ConfigGroupID), persistentConfig: true})
+	defer rt.Close()
+	// Create a new db on the RT to confirm fetch won't retrieve it (due to bucket not being in BucketCredentials)
+	resp := rt.SendAdminRequest(http.MethodPut, "/db/", fmt.Sprintf(`{
+		"bucket": "%s",
+		"use_views": %t,
+		"num_index_replicas": 0
+	}`, tb1.GetName(), base.TestsDisableGSI()))
+	requireStatus(t, resp, http.StatusCreated)
+
+	// Confirm fetch does not return any configs due to no databases in the bucket credentials config
+	configs, err = sc.fetchConfigs(false)
+	require.NoError(t, err)
+	assert.Empty(t, configs)
+
+	// Add test bucket to bucket credentials config
+	sc.config.BucketCredentials = map[string]*base.CredentialsConfig{
+		tb1.GetName(): {
+			Username: base.TestClusterUsername(),
+			Password: base.TestClusterPassword(),
+		},
+	}
+
+	// Update the CouchbaseCluster to include the new bucket credentials
+	couchbaseCluster, err := createCouchbaseClusterFromStartupConfig(sc.config)
+	require.NoError(t, err)
+	sc.bootstrapContext.connection = couchbaseCluster
+
+	// Confirm fetch does return config for db in tb1
+	configs, err = sc.fetchConfigs(false)
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+	assert.NotNil(t, configs["db"])
+	count, err := sc.fetchAndLoadConfigs(false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	// Confirm fetch does not return any configs due to db being known about already (so existing db does not get polled)
+	// TODO: Enable as part of CBG-2280
+	//configs, err = sc.fetchConfigs(false)
+	//require.NoError(t, err)
+	//assert.Empty(t, configs)
+	//count, err = sc.fetchAndLoadConfigs(false)
+	//require.NoError(t, err)
+	//assert.Equal(t, 0, count)
+}


### PR DESCRIPTION
CBG-2257

- Fetching configs now only grabs buckets from the `bucket_credentials` ~~that don't already have a db associated with them~~ when running in serverless mode.
- `CouchbaseCluster.getBucket` can now use bucket credentials if set in the startup config `bucket_credentials` field. This will be force used when running in serverless mode.
	- This also means that `InsertConfig` and `DeleteConfig` use the per bucket authentication details which is useful for CBG-2258

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/660/