### PR TITLE
CBG-2294: Fix product version parsing

### DIFF
--- a/base/version.go
+++ b/base/version.go
@@ -61,16 +61,20 @@ func init() {
 
 		versionString := versionAndBuild[0]
 		versions := strings.Split(versionString, ".")
-		if len(versions) >= 0 {
-			majorStr = versions[0]
-		} else if len(versions) >= 1 {
-			minorStr = versions[1]
-		} else if len(versions) >= 2 {
-			patchStr = versions[2]
-		} else if len(versions) >= 3 {
-			otherStr = versions[3]
-		} else {
+		if len(versions) == 0 || len(versions) > 4 {
 			PanicfCtx(context.Background(), "unknown version format (expected major.minor.patch[.other]) got %v", versionString)
+		}
+		if len(versions) > 0 {
+			majorStr = versions[0]
+		}
+		if len(versions) > 1 {
+			minorStr = versions[1]
+		}
+		if len(versions) > 2 {
+			patchStr = versions[2]
+		}
+		if len(versions) > 3 {
+			otherStr = versions[3]
 		}
 
 		var formattedBuildStr string


### PR DESCRIPTION
CBG-2294

Previously when parsing the product version as a ComparableVersion we would only respect the major number, e.g. `3.1.0-275` would get parsed as `ComparableVersion{Major:3 Minor:0 Patch:0}`. This PR makes it parse correctly.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
n/a