### PR TITLE
CBG-2258: Per bucket credentials can now be used for persisting a database

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -75,7 +75,8 @@ func (h *handler) handleCreateDB() error {
 		}
 
 		dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
-		if err := config.setup(dbName, h.server.config.Bootstrap, dbCreds); err != nil {
+		bucketCreds, _ := h.server.config.BucketCredentials[bucket]
+		if err := config.setup(dbName, h.server.config.Bootstrap, dbCreds, bucketCreds, h.server.config.IsServerless()); err != nil {
 			return err
 		}
 
@@ -122,7 +123,7 @@ func (h *handler) handleCreateDB() error {
 		h.server.dbConfigs[dbName].cas = cas
 	} else {
 		// Intentionally pass in an empty BootstrapConfig to avoid inheriting any credentials or server when running with a legacy config (CBG-1764)
-		if err := config.setup(dbName, BootstrapConfig{}, nil); err != nil {
+		if err := config.setup(dbName, BootstrapConfig{}, nil, nil, false); err != nil {
 			return err
 		}
 
@@ -508,7 +509,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 		}
 
 		dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
-		if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds); err != nil {
+		if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds, nil, false); err != nil {
 			return err
 		}
 		if err := h.server.ReloadDatabaseWithConfig(*updatedDbConfig); err != nil {
@@ -563,7 +564,8 @@ func (h *handler) handlePutDbConfig() (err error) {
 				return nil, err
 			}
 			dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
-			if err := tmpConfig.setup(dbName, h.server.config.Bootstrap, dbCreds); err != nil {
+			bucketCreds, _ := h.server.config.BucketCredentials[bucket]
+			if err := tmpConfig.setup(dbName, h.server.config.Bootstrap, dbCreds, bucketCreds, h.server.config.IsServerless()); err != nil {
 				return nil, err
 			}
 
@@ -661,7 +663,8 @@ func (h *handler) handleDeleteDbConfigSync() error {
 
 	dbName := h.db.Name
 	dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
-	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds); err != nil {
+	bucketCreds, _ := h.server.config.BucketCredentials[bucket]
+	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds, bucketCreds, h.server.config.IsServerless()); err != nil {
 		return err
 	}
 
@@ -727,7 +730,8 @@ func (h *handler) handlePutDbConfigSync() error {
 
 	dbName := h.db.Name
 	dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
-	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds); err != nil {
+	bucketCreds, _ := h.server.config.BucketCredentials[bucket]
+	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds, bucketCreds, h.server.config.IsServerless()); err != nil {
 		return err
 	}
 
@@ -811,7 +815,8 @@ func (h *handler) handleDeleteDbConfigImportFilter() error {
 
 	dbName := h.db.Name
 	dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
-	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds); err != nil {
+	bucketCreds, _ := h.server.config.BucketCredentials[bucket]
+	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds, bucketCreds, h.server.config.IsServerless()); err != nil {
 		return err
 	}
 
@@ -878,7 +883,8 @@ func (h *handler) handlePutDbConfigImportFilter() error {
 
 	dbName := h.db.Name
 	dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
-	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds); err != nil {
+	bucketCreds, _ := h.server.config.BucketCredentials[bucket]
+	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds, bucketCreds, h.server.config.IsServerless()); err != nil {
 		return err
 	}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -28,7 +28,6 @@ import (
 	"syscall"
 
 	"golang.org/x/crypto/bcrypt"
-	"golang.org/x/exp/maps"
 	"gopkg.in/square/go-jose.v2"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -1314,7 +1313,10 @@ func (sc *ServerContext) _fetchAndLoadDatabase(dbName string) (found bool, err e
 func (sc *ServerContext) fetchDatabase(dbName string) (found bool, dbConfig *DatabaseConfig, err error) {
 	var buckets []string
 	if sc.config.IsServerless() {
-		buckets = maps.Keys(sc.config.BucketCredentials)
+		buckets = make([]string, len(sc.config.BucketCredentials))
+		for bucket, _ := range sc.config.BucketCredentials {
+			buckets = append(buckets, bucket)
+		}
 	} else {
 		buckets, err = sc.bootstrapContext.connection.GetConfigBuckets()
 		if err != nil {
@@ -1380,7 +1382,10 @@ func (sc *ServerContext) fetchDatabase(dbName string) (found bool, dbConfig *Dat
 func (sc *ServerContext) fetchConfigs(isInitialStartup bool) (dbNameConfigs map[string]DatabaseConfig, err error) {
 	var buckets []string
 	if sc.config.IsServerless() {
-		buckets = maps.Keys(sc.config.BucketCredentials)
+		buckets = make([]string, len(sc.config.BucketCredentials))
+		for bucket, _ := range sc.config.BucketCredentials {
+			buckets = append(buckets, bucket)
+		}
 		// TODO: Enable code as part of CBG-2280
 		// Return buckets that have credentials set that do not have a db associated with them
 		//buckets = make([]string, len(sc.config.BucketCredentials)-len(sc.bucketDbName))

--- a/rest/config.go
+++ b/rest/config.go
@@ -27,9 +27,8 @@ import (
 	"strings"
 	"syscall"
 
-	"golang.org/x/exp/maps"
-
 	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/exp/maps"
 	"gopkg.in/square/go-jose.v2"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -286,32 +285,35 @@ func (dbc *DbConfig) inheritFromBootstrap(b BootstrapConfig) {
 	}
 }
 
-func (dbConfig *DbConfig) setPerDatabaseCredentials(dbCredentials base.CredentialsConfig) {
+func (dbConfig *DbConfig) setDatabaseCredentials(credentials base.CredentialsConfig) {
 	// X.509 overrides username/password
-	if dbCredentials.X509CertPath != "" || dbCredentials.X509KeyPath != "" {
-		dbConfig.CertPath = dbCredentials.X509CertPath
-		dbConfig.KeyPath = dbCredentials.X509KeyPath
+	if credentials.X509CertPath != "" || credentials.X509KeyPath != "" {
+		dbConfig.CertPath = credentials.X509CertPath
+		dbConfig.KeyPath = credentials.X509KeyPath
 		dbConfig.Username = ""
 		dbConfig.Password = ""
 	} else {
-		dbConfig.Username = dbCredentials.Username
-		dbConfig.Password = dbCredentials.Password
+		dbConfig.Username = credentials.Username
+		dbConfig.Password = credentials.Password
 		dbConfig.CertPath = ""
 		dbConfig.KeyPath = ""
 	}
 }
 
 // setup populates fields in the dbConfig
-func (dbConfig *DbConfig) setup(dbName string, bootstrapConfig BootstrapConfig, dbCredentials *base.CredentialsConfig) error {
-
-	dbConfig.inheritFromBootstrap(bootstrapConfig)
-	if dbCredentials != nil {
-		dbConfig.setPerDatabaseCredentials(*dbCredentials)
-	}
-
+func (dbConfig *DbConfig) setup(dbName string, bootstrapConfig BootstrapConfig, dbCredentials, bucketCredentials *base.CredentialsConfig, forcePerBucketAuth bool) error {
 	dbConfig.Name = dbName
 	if dbConfig.Bucket == nil {
 		dbConfig.Bucket = &dbConfig.Name
+	}
+
+	dbConfig.inheritFromBootstrap(bootstrapConfig)
+	if bucketCredentials != nil {
+		dbConfig.setDatabaseCredentials(*bucketCredentials)
+	} else if forcePerBucketAuth {
+		return fmt.Errorf("unable to setup database on bucket %q since credentials are not defined in bucket_credentials", base.MD(*dbConfig.Bucket).Redact())
+	} else if dbCredentials != nil {
+		dbConfig.setDatabaseCredentials(*dbCredentials)
 	}
 
 	if dbConfig.Server != nil {
@@ -1310,10 +1312,16 @@ func (sc *ServerContext) _fetchAndLoadDatabase(dbName string) (found bool, err e
 }
 
 func (sc *ServerContext) fetchDatabase(dbName string) (found bool, dbConfig *DatabaseConfig, err error) {
-	buckets, err := sc.bootstrapContext.connection.GetConfigBuckets()
-	if err != nil {
-		return false, nil, fmt.Errorf("couldn't get buckets from cluster: %w", err)
+	var buckets []string
+	if sc.config.IsServerless() {
+		buckets = maps.Keys(sc.config.BucketCredentials)
+	} else {
+		buckets, err = sc.bootstrapContext.connection.GetConfigBuckets()
+		if err != nil {
+			return false, nil, fmt.Errorf("couldn't get buckets from cluster: %w", err)
+		}
 	}
+
 	logCtx := context.TODO()
 
 	// move bucket matching dbName to the front so it's searched first
@@ -1422,7 +1430,7 @@ func (sc *ServerContext) fetchConfigs(isInitialStartup bool) (dbNameConfigs map[
 
 		// stamp per-database credentials if set
 		if dbCredentials, ok := sc.config.DatabaseCredentials[cnf.Name]; ok && dbCredentials != nil {
-			cnf.setPerDatabaseCredentials(*dbCredentials)
+			cnf.setDatabaseCredentials(*dbCredentials)
 		}
 
 		// any authentication fields defined on the dbconfig take precedence over any in the bootstrap config

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -404,7 +404,7 @@ func setupServerConfig(args []string) (config *LegacyServerConfig, err error) {
 
 func setupAndValidateDatabases(databases DbConfigMap) error {
 	for name, dbConfig := range databases {
-		if err := dbConfig.setup(name, BootstrapConfig{}, nil); err != nil {
+		if err := dbConfig.setup(name, BootstrapConfig{}, nil, nil, false); err != nil {
 			return err
 		}
 		if err := dbConfig.validate(context.Background(), false); err != nil {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1711,7 +1711,7 @@ func TestSetupDbConfigCredentials(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.dbConfig.setup(test.dbConfig.Name, test.bootstrapConfig, test.credentialsConfig)
+			err := test.dbConfig.setup(test.dbConfig.Name, test.bootstrapConfig, test.credentialsConfig, nil, false)
 			require.NoError(t, err)
 			if test.expectX509 {
 				assert.Equal(t, "", test.dbConfig.Username)
@@ -1818,7 +1818,7 @@ func TestSetupDbConfigWithSyncFunction(t *testing.T) {
 					Err:        test.errExpected,
 				}
 			}
-			err := dbConfig.setup(dbConfig.Name, BootstrapConfig{}, nil)
+			err := dbConfig.setup(dbConfig.Name, BootstrapConfig{}, nil, nil, false)
 			if test.errExpected != nil {
 				require.True(t, errors.As(err, &test.errExpected)) // nolint: govet // CBG-2242
 			} else {
@@ -1918,7 +1918,7 @@ func TestSetupDbConfigWithImportFilterFunction(t *testing.T) {
 					Err:        test.errExpected,
 				}
 			}
-			err := dbConfig.setup(dbConfig.Name, BootstrapConfig{}, nil)
+			err := dbConfig.setup(dbConfig.Name, BootstrapConfig{}, nil, nil, false)
 			if test.errExpected != nil {
 				require.True(t, errors.As(err, &test.errExpected)) // nolint: govet // CBG-2242
 			} else {
@@ -2030,7 +2030,7 @@ func TestSetupDbConfigWithConflictResolutionFunction(t *testing.T) {
 					Err:        test.errExpected,
 				}
 			}
-			err := dbConfig.setup(dbConfig.Name, BootstrapConfig{}, nil)
+			err := dbConfig.setup(dbConfig.Name, BootstrapConfig{}, nil, nil, false)
 			if test.errExpected != nil {
 				require.True(t, errors.As(err, &test.errExpected)) // nolint: govet // CBG-2242
 			} else {

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -174,5 +174,5 @@ func TestServerlessBucketCredentialsFetchDatabases(t *testing.T) {
 	// Make sure fetch fails as it cannot see all buckets in cluster
 	found, _, err = rt.ServerContext().fetchDatabase("db")
 	assert.NoError(t, err)
-	assert.True(t, found)
+	assert.False(t, found)
 }

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -92,3 +92,87 @@ func TestServerlessPollBuckets(t *testing.T) {
 	//require.NoError(t, err)
 	//assert.Equal(t, 0, count)
 }
+
+// Tests behaviour of CBG-2258 to force per bucket credentials to be used when setting up db in serverless mode
+func TestServerlessDBSetupForceCreds(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	tb1 := base.GetTestBucket(t)
+	defer tb1.Close()
+
+	testCases := []struct {
+		name                  string
+		bucketName            string // Bucket to attempt to create DB on
+		perBucketCreds        base.PerBucketCredentialsConfig
+		dbCreationRespAsserts func(resp *TestResponse)
+	}{
+		{
+			name:           "Correct credentials defined and force used",
+			bucketName:     tb1.GetName(),
+			perBucketCreds: nil,
+			dbCreationRespAsserts: func(resp *TestResponse) {
+				assertStatus(t, resp, http.StatusCreated)
+			},
+		},
+		{
+			name:           "Credentials not defined",
+			bucketName:     tb1.GetName(),
+			perBucketCreds: map[string]*base.CredentialsConfig{"invalid_bucket": {}},
+			dbCreationRespAsserts: func(resp *TestResponse) {
+				assertStatus(t, resp, http.StatusInternalServerError)
+				assert.Contains(t, string(resp.BodyBytes()), "credentials are not defined in bucket_credentials")
+			},
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb1, serverless: true, persistentConfig: true})
+			defer rt.Close()
+
+			if test.perBucketCreds != nil {
+				rt.ReplacePerBucketCredentials(test.perBucketCreds)
+			}
+
+			resp := rt.SendAdminRequest(http.MethodPut, "/db/", fmt.Sprintf(`{
+				"bucket": "%s",
+				"use_views": %t,
+				"num_index_replicas": 0
+			}`, tb1.GetName(), base.TestsDisableGSI()))
+			test.dbCreationRespAsserts(resp)
+		})
+	}
+}
+
+// Tests behaviour of CBG-2258 to make sure fetch databases only uses buckets listed on StartupConfig.BucketCredentials
+// when running in serverless mode
+func TestServerlessBucketCredentialsFetchDatabases(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	tb1 := base.GetTestBucket(t)
+	defer tb1.Close()
+	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb1, persistentConfig: true, serverless: true})
+	defer rt.Close()
+
+	resp := rt.SendAdminRequest(http.MethodPut, "/db/", fmt.Sprintf(`{
+				"bucket": "%s",
+				"use_views": %t,
+				"num_index_replicas": 0
+	}`, tb1.GetName(), base.TestsDisableGSI()))
+	requireStatus(t, resp, http.StatusCreated)
+
+	// Make sure DB can be fetched
+	found, _, err := rt.ServerContext().fetchDatabase("db")
+	assert.NoError(t, err)
+	assert.True(t, found)
+
+	// Limit SG to buckets defined on BucketCredentials map
+	rt.ReplacePerBucketCredentials(map[string]*base.CredentialsConfig{"invalid_bucket": {}})
+	// Make sure fetch fails as it cannot see all buckets in cluster
+	found, _, err = rt.ServerContext().fetchDatabase("db")
+	assert.NoError(t, err)
+	assert.True(t, found)
+}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -59,6 +59,7 @@ type RestTesterConfig struct {
 	persistentConfig                bool
 	groupID                         *string
 	createScopesAndCollections      bool // If true, will automatically create any defined scopes and collections on startup.
+	serverless                      bool // Runs SG in serverless mode. Should be used in conjunction with persistent config
 }
 
 // RestTester provides a fake server for testing endpoints
@@ -150,6 +151,15 @@ func (rt *RestTester) Bucket() base.Bucket {
 	sc.API.EnableAdminAuthenticationPermissionsCheck = &rt.enableAdminAuthPermissionsCheck
 	sc.Bootstrap.UseTLSServer = &rt.RestTesterConfig.useTLSServer
 	sc.Bootstrap.ServerTLSSkipVerify = base.BoolPtr(base.TestTLSSkipVerify())
+	sc.Unsupported.Serverless = &rt.serverless
+	if rt.serverless {
+		sc.BucketCredentials = map[string]*base.CredentialsConfig{
+			testBucket.GetName(): {
+				Username: base.TestClusterUsername(),
+				Password: base.TestClusterPassword(),
+			},
+		}
+	}
 
 	if rt.RestTesterConfig.groupID != nil {
 		sc.Bootstrap.ConfigGroupID = *rt.RestTesterConfig.groupID
@@ -725,6 +735,16 @@ func (rt *RestTester) GetDocumentSequence(key string) (sequence uint64) {
 	var rawResponse RawResponse
 	_ = base.JSONUnmarshal(response.BodyBytes(), &rawResponse)
 	return rawResponse.Sync.Sequence
+}
+
+// ReplacePerBucketCredentials replaces buckets defined on StartupConfig.BucketCredentials then recreates the couchbase
+// cluster to pick up the changes
+func (rt *RestTester) ReplacePerBucketCredentials(config base.PerBucketCredentialsConfig) {
+	rt.ServerContext().config.BucketCredentials = config
+	// Update the CouchbaseCluster to include the new bucket credentials
+	couchbaseCluster, err := createCouchbaseClusterFromStartupConfig(rt.ServerContext().config)
+	require.NoError(rt.tb, err)
+	rt.ServerContext().bootstrapContext.connection = couchbaseCluster
 }
 
 type TestResponse struct {


### PR DESCRIPTION
CBG-2258

- Use per bucket credentials to persist a database
- Serverless enforces that cluster wide credentials cannot be used to persist the database

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/672