### PR TITLE
CBG-2252: remove logcontextkey, add logcontextwith

### DIFF
--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -102,9 +102,7 @@ func NewDCPCommon(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbN
 	}
 
 	dcpContextID := fmt.Sprintf("%s-%s", MD(bucket.GetName()).Redact(), feedID)
-	c.loggingCtx = context.WithValue(context.Background(), LogContextKey{},
-		LogContext{CorrelationID: dcpContextID},
-	)
+	c.loggingCtx = LogContextWith(context.Background(), &LogContext{CorrelationID: dcpContextID})
 
 	return c
 }

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -343,11 +343,9 @@ func initCBGTManager(bucket Bucket, spec BucketSpec, cfgSG cbgt.Cfg, dbUUID stri
 		options)
 
 	cbgtContext := &CbgtContext{
-		loggingCtx: context.WithValue(context.Background(), LogContextKey{},
-			LogContext{CorrelationID: MD(spec.BucketName).Redact() + "-" + DCPImportFeedID},
-		),
-		Manager: mgr,
-		Cfg:     cfgSG,
+		loggingCtx: LogContextWith(context.Background(), &LogContext{CorrelationID: MD(spec.BucketName).Redact() + "-" + DCPImportFeedID}),
+		Manager:    mgr,
+		Cfg:        cfgSG,
 	}
 
 	if spec.Auth != nil || (spec.Certpath != "" && spec.Keypath != "") {

--- a/base/logging.go
+++ b/base/logging.go
@@ -300,7 +300,7 @@ func addPrefixes(format string, ctx context.Context, logLevel LogLevel, logKey L
 
 	if ctx != nil {
 		var ctxVal any
-		for _, k := range allContextAdderKeys {
+		for _, k := range allLogContextKeys {
 			if ctxVal = ctx.Value(k); ctxVal != nil {
 				if logCtx, ok := ctxVal.(ContextAdder); ok {
 					format = logCtx.addContext(format)

--- a/base/logging.go
+++ b/base/logging.go
@@ -299,9 +299,12 @@ func addPrefixes(format string, ctx context.Context, logLevel LogLevel, logKey L
 	}
 
 	if ctx != nil {
-		if ctxVal := ctx.Value(LogContextKey{}); ctxVal != nil {
-			if logCtx, ok := ctxVal.(LogContext); ok {
-				format = logCtx.addContext(format)
+		var ctxVal any
+		for _, k := range allContextAdderKeys {
+			if ctxVal = ctx.Value(k); ctxVal != nil {
+				if logCtx, ok := ctxVal.(ContextAdder); ok {
+					format = logCtx.addContext(format)
+				}
 			}
 		}
 	}

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -54,8 +54,8 @@ func (lc *LogContext) addContext(format string) string {
 	return format
 }
 
-func (lc *LogContext) getContextKey() ContextAdderKey {
-	return logContextKey
+func (lc *LogContext) getContextKey() LogContextKey {
+	return requestContextKey
 }
 
 func FormatBlipContextID(contextID string) string {
@@ -78,7 +78,7 @@ func bucketCtx(parent context.Context, b Bucket) context.Context {
 
 // bucketNameCtx extends the parent context with a bucket name.
 func bucketNameCtx(parent context.Context, bucketName string) context.Context {
-	parentLogCtx, _ := parent.Value(logContextKey).(LogContext)
+	parentLogCtx, _ := parent.Value(requestContextKey).(LogContext)
 	newCtx := LogContext{
 		TestName:       parentLogCtx.TestName,
 		TestBucketName: bucketName,
@@ -86,11 +86,11 @@ func bucketNameCtx(parent context.Context, bucketName string) context.Context {
 	return LogContextWith(parent, &newCtx)
 }
 
-// ContextAdderKey is the type used to store custom data in the go context
-type ContextAdderKey int
+// LogContextKey is the type used to store custom data in the go context
+type LogContextKey int
 
 const (
-	logContextKey ContextAdderKey = iota
+	requestContextKey LogContextKey = iota
 	serverLogContextKey
 	databaseLogContextKey
 )
@@ -99,13 +99,13 @@ const (
 // The custom context should provide its own key to be used with go contexts,
 // and be able to add its custom info to the log format msg.
 type ContextAdder interface {
-	getContextKey() ContextAdderKey
+	getContextKey() LogContextKey
 	addContext(format string) string
 }
 
-// allContextAdderKeys contains the keys of all custom contexts,
+// allLogContextKeys contains the keys of all custom contexts,
 // and is used when writing log prefixes (addPrefixes)
-var allContextAdderKeys = [...]ContextAdderKey{logContextKey, serverLogContextKey, databaseLogContextKey}
+var allLogContextKeys = [...]LogContextKey{requestContextKey, serverLogContextKey, databaseLogContextKey}
 
 // LogContextWith is called to add custom context to the go context.
 // All custom contexts should implement ContextAdder interface
@@ -118,7 +118,7 @@ type ServerLogContext struct {
 	ConfigGroupID string
 }
 
-func (c *ServerLogContext) getContextKey() ContextAdderKey {
+func (c *ServerLogContext) getContextKey() LogContextKey {
 	return serverLogContextKey
 }
 
@@ -134,7 +134,7 @@ type DatabaseLogContext struct {
 	DatabaseName string
 }
 
-func (c *DatabaseLogContext) getContextKey() ContextAdderKey {
+func (c *DatabaseLogContext) getContextKey() LogContextKey {
 	return databaseLogContextKey
 }
 

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -45,9 +45,7 @@ var ErrCfgCasError = &cbgt.CfgCASError{}
 func NewCfgSG(bucket Bucket, groupID string) (*CfgSG, error) {
 
 	cfgContextID := MD(bucket.GetName()).Redact() + "-cfgSG"
-	loggingCtx := context.WithValue(context.Background(), LogContextKey{},
-		LogContext{CorrelationID: cfgContextID},
-	)
+	loggingCtx := LogContextWith(context.Background(), &LogContext{CorrelationID: cfgContextID})
 
 	c := &CfgSG{
 		bucket:        bucket,

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -214,9 +214,7 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 	}
 
 	bsc = NewBlipSyncContext(blipContext, arc.config.ActiveDB, blipContext.ID, arc.replicationStats)
-	bsc.loggingCtx = context.WithValue(context.Background(), base.LogContextKey{},
-		base.LogContext{CorrelationID: arc.config.ID + idSuffix},
-	)
+	bsc.loggingCtx = base.LogContextWith(context.Background(), &base.LogContext{CorrelationID: arc.config.ID + idSuffix})
 
 	// NewBlipSyncContext has already set deltas as disabled/enabled based on config.ActiveDB.
 	// If deltas have been disabled in the replication config, override this value

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -44,7 +44,7 @@ func (apr *ActivePullReplicator) Start() error {
 	}
 
 	apr.setState(ReplicationStateStarting)
-	logCtx := context.WithValue(context.Background(), base.LogContextKey{}, base.LogContext{CorrelationID: apr.config.ID + "-" + string(ActiveReplicatorTypePull)})
+	logCtx := base.LogContextWith(context.Background(), &base.LogContext{CorrelationID: apr.config.ID + "-" + string(ActiveReplicatorTypePull)})
 	apr.ctx, apr.ctxCancel = context.WithCancel(logCtx)
 
 	err := apr._connect()

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -48,7 +48,7 @@ func (apr *ActivePushReplicator) Start() error {
 	}
 
 	apr.setState(ReplicationStateStarting)
-	logCtx := context.WithValue(context.Background(), base.LogContextKey{}, base.LogContext{CorrelationID: apr.config.ID + "-" + string(ActiveReplicatorTypePush)})
+	logCtx := base.LogContextWith(context.Background(), &base.LogContext{CorrelationID: apr.config.ID + "-" + string(ActiveReplicatorTypePush)})
 	apr.ctx, apr.ctxCancel = context.WithCancel(logCtx)
 
 	err := apr._connect()

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -394,9 +394,7 @@ func TestLateSequenceHandlingDuringCompact(t *testing.T) {
 			channelName := fmt.Sprintf("chan_%d", i)
 			perRequestDb, err := CreateDatabase(db.DatabaseContext)
 			assert.NoError(t, err)
-			perRequestDb.Ctx = context.WithValue(base.TestCtx(t), base.LogContextKey{},
-				base.LogContext{CorrelationID: fmt.Sprintf("context_%s", channelName)},
-			)
+			perRequestDb.Ctx = base.LogContextWith(base.TestCtx(t), &base.LogContext{CorrelationID: fmt.Sprintf("context_%s", channelName)})
 			feed, err := perRequestDb.MultiChangesFeed(base.SetOf(channelName), options)
 			require.NoError(t, err, "Feed initialization error")
 

--- a/db/database.go
+++ b/db/database.go
@@ -346,9 +346,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	)
 
 	dbContext.EventMgr = NewEventManager()
-	logCtx := context.WithValue(context.Background(), base.LogContextKey{}, base.LogContext{
-		CorrelationID: "db:" + base.MD(dbName).Redact(),
-	})
+	logCtx := base.LogContextWith(context.Background(), &base.LogContext{CorrelationID: "db:" + base.MD(dbName).Redact()})
 
 	var err error
 	dbContext.sequences, err = newSequenceAllocator(bucket, dbContext.DbStats.Database())

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -458,9 +458,8 @@ func NewSGReplicateManager(dbContext *DatabaseContext, cfg cbgt.Cfg) (*sgReplica
 	}
 
 	return &sgReplicateManager{
-		cfg: cfg,
-		loggingCtx: context.WithValue(context.Background(), base.LogContextKey{},
-			base.LogContext{CorrelationID: sgrClusterMgrContextID + dbContext.Name}),
+		cfg:                        cfg,
+		loggingCtx:                 base.LogContextWith(context.Background(), &base.LogContext{CorrelationID: sgrClusterMgrContextID + dbContext.Name}),
 		clusterUpdateTerminator:    make(chan struct{}),
 		clusterSubscribeTerminator: make(chan struct{}),
 		dbContext:                  dbContext,

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -11,7 +11,6 @@ licenses/APL2.txt.
 package db
 
 import (
-	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -390,8 +389,7 @@ func TestRebalanceReplications(t *testing.T) {
 		t.Run(fmt.Sprintf("%s", testCase.name), func(t *testing.T) {
 
 			cluster := NewSGRCluster()
-			cluster.loggingCtx = context.WithValue(base.TestCtx(t), base.LogContextKey{},
-				base.LogContext{CorrelationID: sgrClusterMgrContextID + "test"})
+			cluster.loggingCtx = base.LogContextWith(base.TestCtx(t), &base.LogContext{CorrelationID: sgrClusterMgrContextID + "test"})
 			cluster.Nodes = testCase.nodes
 			cluster.Replications = testCase.replications
 			cluster.RebalanceReplications()

--- a/db/utils.go
+++ b/db/utils.go
@@ -42,7 +42,7 @@ func NewBackgroundTask(taskName string, dbName string, task BackgroundTaskFunc, 
 		for {
 			select {
 			case <-ticker.C:
-				ctx := context.WithValue(logCtx, base.LogContextKey{}, base.LogContext{CorrelationID: base.NewTaskID(dbName, taskName)})
+				ctx := base.LogContextWith(logCtx, &base.LogContext{CorrelationID: base.NewTaskID(dbName, taskName)})
 				if err := task(ctx); err != nil {
 					base.ErrorfCtx(ctx, "Background task returned error: %v", err)
 					return

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -11,7 +11,6 @@ licenses/APL2.txt.
 package rest
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
@@ -44,9 +43,7 @@ func (h *handler) handleBLIPSync() error {
 	}
 
 	// Overwrite the existing logging context with the blip context ID
-	h.db.Ctx = context.WithValue(h.db.Ctx, base.LogContextKey{},
-		base.LogContext{CorrelationID: base.FormatBlipContextID(blipContext.ID)},
-	)
+	h.db.Ctx = base.LogContextWith(h.db.Ctx, &base.LogContext{CorrelationID: base.FormatBlipContextID(blipContext.ID)})
 
 	// Create a new BlipSyncContext attached to the given blipContext.
 	ctx := db.NewBlipSyncContext(blipContext, h.db, h.formatSerialNumber(), db.BlipSyncStatsForCBL(h.db.DbStats))

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -169,9 +169,7 @@ func newHandler(server *ServerContext, privs handlerPrivs, r http.ResponseWriter
 // ctx returns the request-scoped context for logging/cancellation.
 func (h *handler) ctx() context.Context {
 	if h.rqCtx == nil {
-		h.rqCtx = context.WithValue(h.rq.Context(), base.LogContextKey{},
-			base.LogContext{CorrelationID: h.formatSerialNumber()},
-		)
+		h.rqCtx = base.LogContextWith(h.rq.Context(), &base.LogContext{CorrelationID: h.formatSerialNumber()})
 	}
 	return h.rqCtx
 }

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -94,7 +94,7 @@ func (sg *sgCollect) Start(logFilePath string, ctxSerialNumber uint64, zipFilena
 	args = append(args, "--sync-gateway-executable", sgPath)
 	args = append(args, zipPath)
 
-	ctx := context.WithValue(context.Background(), base.LogContextKey{}, base.LogContext{CorrelationID: fmt.Sprintf("SGCollect-%03d", ctxSerialNumber)})
+	ctx := base.LogContextWith(context.Background(), &base.LogContext{CorrelationID: fmt.Sprintf("SGCollect-%03d", ctxSerialNumber)})
 
 	sg.context, sg.cancel = context.WithCancel(ctx)
 	cmd := exec.CommandContext(sg.context, sgCollectPath, args...)


### PR DESCRIPTION
CBG-2252

Describe your PR here...
- Created interface for all custom contexts
- Changed addPrefixes to use custom context keys
- Replaced uses of LogContextKey with new LogContextWith 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/669/