### PR TITLE
Make test bucket pool wait until query service is ready before use

### DIFF
--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -206,3 +206,10 @@ func (c *Collection) getIndexes() (indexes []string, err error) {
 	}
 	return indexes, nil
 }
+
+// waitUntilQueryServiceReady will wait for the specified duration until the query service is available.
+func (c *Collection) waitUntilQueryServiceReady(timeout time.Duration) error {
+	return c.cluster.WaitUntilReady(timeout,
+		&gocb.WaitUntilReadyOptions{ServiceTypes: []gocb.ServiceType{gocb.ServiceTypeQuery}},
+	)
+}

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -58,6 +58,9 @@ type N1QLStore interface {
 
 	// getIndexes retrieves all index names, used by test harness
 	getIndexes() (indexes []string, err error)
+
+	// waitUntilQueryServiceReady waits until the query service is ready to accept requests
+	waitUntilQueryServiceReady(timeout time.Duration) error
 }
 
 func ExplainQuery(store N1QLStore, statement string, params map[string]interface{}) (plan map[string]interface{}, err error) {

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -629,6 +629,14 @@ func (b *LeakyBucket) getIndexes() ([]string, error) {
 	return n1qlStore.getIndexes()
 }
 
+func (b *LeakyBucket) waitUntilQueryServiceReady(timeout time.Duration) error {
+	n1qlStore, ok := AsN1QLStore(b.bucket)
+	if !ok {
+		return fmt.Errorf("bucket is not an N1QL bucket")
+	}
+	return n1qlStore.waitUntilQueryServiceReady(timeout)
+}
+
 func (b *LeakyBucket) IsErrNoResults(err error) bool {
 	n1qlStore, ok := AsN1QLStore(b.bucket)
 	if !ok {


### PR DESCRIPTION
Make the test bucket pool wait for a query service to be ready before attempting to use it to clean out the prepared statements.

In scripted constrained environments like integration test jobs it's easier to hit a case where we try running this query and the query service has not started up yet. Especially in older CB Server versions, where startup is generally slower.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `6.6.5 xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/680/