### PR TITLE
Convert some asserts in TestPurgeWithChannelCache to requires

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2036,9 +2036,11 @@ func TestPurgeWithChannelCache(t *testing.T) {
 	requireStatus(t, rt.SendAdminRequest("PUT", "/db/doc2", `{"moo":"car", "channels": ["abc"]}`), http.StatusCreated)
 
 	changes, err := rt.waitForChanges(2, "/db/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
-	assert.NoError(t, err, "Error waiting for changes")
-	assert.Equal(t, "doc1", changes.Results[0].ID)
-	assert.Equal(t, "doc2", changes.Results[1].ID)
+	require.NoError(t, err, "Error waiting for changes")
+	base.RequireAllAssertions(t,
+		assert.Equal(t, "doc1", changes.Results[0].ID),
+		assert.Equal(t, "doc2", changes.Results[1].ID),
+	)
 
 	// Purge "doc1"
 	resp := rt.SendAdminRequest("POST", "/db/_purge", `{"doc1":["*"]}`)
@@ -2048,7 +2050,7 @@ func TestPurgeWithChannelCache(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}}}, body)
 
 	changes, err = rt.waitForChanges(1, "/db/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
-	assert.NoError(t, err, "Error waiting for changes")
+	require.NoError(t, err, "Error waiting for changes")
 	assert.Equal(t, "doc2", changes.Results[0].ID)
 
 }


### PR DESCRIPTION
Prevent a panic later in the test if one of the initial requests fails.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
n/a