### PR TITLE
Handle stdlib wrapped errors in ErrorAsHTTPStatus

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -169,7 +169,7 @@ func ErrorAsHTTPStatus(err error) (int, string) {
 	case *RetryTimeoutError:
 		return http.StatusGatewayTimeout, unwrappedErr.Error()
 	}
-	return http.StatusInternalServerError, fmt.Sprintf("Internal error: %v", unwrappedErr)
+	return http.StatusInternalServerError, fmt.Sprintf("Internal error: %v", err)
 }
 
 // Returns the standard CouchDB error string for an HTTP error status.

--- a/base/error.go
+++ b/base/error.go
@@ -88,7 +88,7 @@ func ErrorAsHTTPStatus(err error) (int, string) {
 		return 200, "OK"
 	}
 
-	unwrappedErr := pkgerrors.Cause(err)
+	unwrappedErr := errors.Unwrap(err)
 
 	// Check for SGErrors
 	switch unwrappedErr {

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -525,7 +525,7 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 	// Attempt to retrieve via view.  Above operations were all synchronous (on-demand import of SDK delete, SG delete), so
 	// stale=false view results should be immediately updated.
 	results, err := rt.GetDatabase().ChannelViewForTest(t, "ABC", 0, 1000)
-	assert.NoError(t, err, "Error issuing channel view query")
+	require.NoError(t, err, "Error issuing channel view query")
 	for _, entry := range results {
 		log.Printf("Got view result: %v", entry)
 	}
@@ -1341,7 +1341,7 @@ func TestXattrFeedBasedImportPreservesExpiry(t *testing.T) {
 
 	// Wait until the change appears on the changes feed to ensure that it's been imported by this point
 	changes, err := rt.waitForChanges(2, "/db/_changes", "", true)
-	assert.NoError(t, err, "Error waiting for changes")
+	require.NoError(t, err, "Error waiting for changes")
 
 	log.Printf("changes: %+v", changes)
 	changeEntry := changes.Results[0]
@@ -1393,7 +1393,7 @@ func TestFeedBasedMigrateWithExpiry(t *testing.T) {
 	// Wait until the change appears on the changes feed to ensure that it's been imported by this point
 	now := time.Now()
 	changes, err := rt.waitForChanges(1, "/db/_changes", "", true)
-	assert.NoError(t, err, "Error waiting for changes")
+	require.NoError(t, err, "Error waiting for changes")
 	changeEntry := changes.Results[0]
 	assert.Equal(t, key, changeEntry.ID)
 	log.Printf("Saw doc on changes feed after %v", time.Since(now))


### PR DESCRIPTION
`base.ErrorAsHTTPStatus` today uses `pkgerrors.Cause` to get the underlying HTTP error, which works as expected when code uses `pkgerrors.Wrap()`, but not the more idiomatic (since Go 1.13) `fmt.Errorf()`. Replace `pkgerrors.Cause` with an `unwrap`per that properly handles errors wrapped per the Go 1.13 idiom.

`pkgerrors` also implements the Go 1.13 interfaces (https://github.com/pkg/errors/blob/5dd12d0cfe7f152f80558d591504ce685299311e/errors.go#L247-L248), so there should be no concerns for old code that still uses the `pkgerrors` style.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/697/