### PR TITLE
CBG-2286: Check on startup if the bucket supports collections

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -94,9 +94,14 @@ func (h *handler) handleCreateDB() error {
 
 		_, err = h.server._applyConfig(loadedConfig, true, false)
 		if err != nil {
+			var httpErr *base.HTTPError
+			if errors.As(err, &httpErr) {
+				return httpErr
+			}
 			if errors.Is(err, base.ErrAuthError) {
 				return base.HTTPErrorf(http.StatusForbidden, "auth failure accessing provided bucket: %s", bucket)
-			} else if errors.Is(err, base.ErrAlreadyExists) {
+			}
+			if errors.Is(err, base.ErrAlreadyExists) {
 				return base.HTTPErrorf(http.StatusConflict, "couldn't load database: %s", err)
 			}
 			return base.HTTPErrorf(http.StatusInternalServerError, "couldn't load database: %v", err)

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 
 	"github.com/couchbase/gocbcore/v10/connstr"
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -562,6 +563,51 @@ func TestUseTLSServer(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test that we correctly error out when trying to use collections against a CBS that doesn't support them. NB: this
+// test only runs against Couchbase Server <7.0.
+func TestServerContextSetupCollectionsSupport(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Requires Couchbase Server")
+	}
+
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+	if tb.IsSupported(sgbucket.DataStoreFeatureCollections) {
+		t.Skip("Only runs on datastores without collections support")
+	}
+
+	serverConfig := &StartupConfig{
+		Bootstrap: BootstrapConfig{
+			UseTLSServer:        base.BoolPtr(base.ServerIsTLS(base.UnitTestUrl())),
+			ServerTLSSkipVerify: base.BoolPtr(base.TestTLSSkipVerify()),
+		},
+		API: APIConfig{CORS: &CORSConfig{}, AdminInterface: DefaultAdminInterface},
+	}
+	serverContext := NewServerContext(serverConfig, false)
+	defer serverContext.Close()
+
+	dbConfig := DbConfig{
+		BucketConfig: BucketConfig{
+			Server:   base.StringPtr(base.UnitTestUrl()),
+			Bucket:   base.StringPtr(tb.GetName()),
+			Username: base.TestClusterUsername(),
+			Password: base.TestClusterPassword(),
+		},
+		Name:             tb.GetName(),
+		NumIndexReplicas: base.UintPtr(0),
+		EnableXattrs:     base.BoolPtr(base.TestUseXattrs()),
+		Scopes: ScopesConfig{
+			"foo": ScopeConfig{
+				Collections: CollectionsConfig{
+					"bar": CollectionConfig{},
+				},
+			},
+		},
+	}
+	_, err := serverContext._getOrAddDatabaseFromConfig(DatabaseConfig{DbConfig: dbConfig}, false, true)
+	require.ErrorIs(t, err, errCollectionsUnsupported)
 }
 
 func TestLogFlush(t *testing.T) {

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -606,7 +606,7 @@ func TestServerContextSetupCollectionsSupport(t *testing.T) {
 			},
 		},
 	}
-	_, err := serverContext._getOrAddDatabaseFromConfig(DatabaseConfig{DbConfig: dbConfig}, false, true)
+	_, err := serverContext._getOrAddDatabaseFromConfig(DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(true))
 	require.ErrorIs(t, err, errCollectionsUnsupported)
 }
 


### PR DESCRIPTION
CBG-2286

Refuse to create the DB if collections are configured, but the datastore doesn't support it.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `package rest, CB 7.0.3` https://jenkins.sgwdev.com/job/SyncGateway-Integration/700/
- [ ] `package rest, CB 6.6.5` https://jenkins.sgwdev.com/job/SyncGateway-Integration/701/

## Manual verification

Starting a SG against a CB 6.6.5 instance, when issuing a `PUT /collections/` with a scope/collection defined, I get

```json
{
  "error": "Bad Request",
  "reason": "Named collections specified in database config, but not supported by connected Couchbase Server."
}
```