### PR TITLE
CBG-2344: Implement remaining DCPClient callbacks and always use collections

### DIFF
--- a/base/collection.go
+++ b/base/collection.go
@@ -29,6 +29,8 @@ import (
 
 var ErrCollectionsUnsupported = errors.New("collections not supported")
 
+const DefaultCollectionID = 0x0
+
 var _ sgbucket.KVStore = &Collection{}
 var _ CouchbaseStore = &Collection{}
 
@@ -1013,7 +1015,10 @@ func (c *Collection) GetCollectionID() (uint32, error) {
 	if !c.IsSupported(sgbucket.DataStoreFeatureCollections) {
 		return 0, fmt.Errorf("Couchbase server does not support collections")
 	}
-
+	// default collection has a known ID
+	if c.IsDefaultScopeCollection() {
+		return DefaultCollectionID, nil
+	}
 	// return cached value if present
 	collectionIDAtomic := c.collectionID.Load()
 	if collectionIDAtomic != nil {

--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -369,7 +369,7 @@ func (dc *DCPClient) openStreamRequest(vbID uint16) error {
 		// If no collection IDs specified, filter to the default collection
 		collIds := dc.collectionIDs
 		if len(collIds) == 0 {
-			collIds = []uint32{0}
+			collIds = []uint32{DefaultCollectionID}
 		}
 		options.FilterOptions = &gocbcore.OpenStreamFilterOptions{CollectionIDs: collIds}
 	}

--- a/base/dcp_client_stream_event.go
+++ b/base/dcp_client_stream_event.go
@@ -78,7 +78,27 @@ func (e deletionEvent) asFeedEvent() sgbucket.FeedEvent {
 	}
 }
 
+type expirationEvent struct {
+	streamEventCommon
+	seq uint64
+	key []byte
+}
+
+func (e expirationEvent) asFeedEvent() sgbucket.FeedEvent {
+	return sgbucket.FeedEvent{
+		Opcode:       sgbucket.FeedOpExpiration,
+		Key:          e.key,
+		VbNo:         e.vbID,
+		TimeReceived: time.Now(),
+	}
+}
+
 type endStreamEvent struct {
 	streamEventCommon
 	err error
+}
+
+type seqnoAdvancedEvent struct {
+	streamEventCommon
+	seq uint64
 }

--- a/base/dcp_client_stream_event.go
+++ b/base/dcp_client_stream_event.go
@@ -78,21 +78,6 @@ func (e deletionEvent) asFeedEvent() sgbucket.FeedEvent {
 	}
 }
 
-type expirationEvent struct {
-	streamEventCommon
-	seq uint64
-	key []byte
-}
-
-func (e expirationEvent) asFeedEvent() sgbucket.FeedEvent {
-	return sgbucket.FeedEvent{
-		Opcode:       sgbucket.FeedOpExpiration,
-		Key:          e.key,
-		VbNo:         e.vbID,
-		TimeReceived: time.Now(),
-	}
-}
-
 type endStreamEvent struct {
 	streamEventCommon
 	err error

--- a/base/dcp_client_stream_observer.go
+++ b/base/dcp_client_stream_observer.go
@@ -85,14 +85,8 @@ func (dc *DCPClient) End(end gocbcore.DcpStreamEnd, err error) {
 }
 
 func (dc *DCPClient) Expiration(expiration gocbcore.DcpExpiration) {
-	dc.workerForVbno(expiration.VbID).Send(expirationEvent{
-		streamEventCommon: streamEventCommon{
-			vbID:     expiration.VbID,
-			streamID: expiration.StreamID,
-		},
-		seq: expiration.SeqNo,
-		key: expiration.Key,
-	})
+	// SG doesn't opt in to expirations, so they'll come through as deletion events
+	// (cf.https://github.com/couchbase/kv_engine/blob/master/docs/dcp/documentation/expiry-opcode-output.md)
 }
 
 func (dc *DCPClient) CreateCollection(creation gocbcore.DcpCollectionCreation) {

--- a/base/dcp_client_stream_observer.go
+++ b/base/dcp_client_stream_observer.go
@@ -85,7 +85,14 @@ func (dc *DCPClient) End(end gocbcore.DcpStreamEnd, err error) {
 }
 
 func (dc *DCPClient) Expiration(expiration gocbcore.DcpExpiration) {
-	// Not used by SG at this time
+	dc.workerForVbno(expiration.VbID).Send(expirationEvent{
+		streamEventCommon: streamEventCommon{
+			vbID:     expiration.VbID,
+			streamID: expiration.StreamID,
+		},
+		seq: expiration.SeqNo,
+		key: expiration.Key,
+	})
 }
 
 func (dc *DCPClient) CreateCollection(creation gocbcore.DcpCollectionCreation) {
@@ -117,7 +124,13 @@ func (dc *DCPClient) OSOSnapshot(snapshot gocbcore.DcpOSOSnapshot) {
 }
 
 func (dc *DCPClient) SeqNoAdvanced(seqNoAdvanced gocbcore.DcpSeqNoAdvanced) {
-	// Not used by SG at this time
+	dc.workerForVbno(seqNoAdvanced.VbID).Send(seqnoAdvancedEvent{
+		streamEventCommon: streamEventCommon{
+			vbID:     seqNoAdvanced.VbID,
+			streamID: seqNoAdvanced.StreamID,
+		},
+		seq: seqNoAdvanced.SeqNo,
+	})
 }
 
 // A one-shot DCP feed specifies the endSeq when opening the stream, but Couchbase Server only ends the DCP stream

--- a/base/dcp_client_stream_observer.go
+++ b/base/dcp_client_stream_observer.go
@@ -1,6 +1,8 @@
 package base
 
 import (
+	"context"
+
 	"github.com/couchbase/gocbcore/v10"
 )
 
@@ -87,6 +89,7 @@ func (dc *DCPClient) End(end gocbcore.DcpStreamEnd, err error) {
 func (dc *DCPClient) Expiration(expiration gocbcore.DcpExpiration) {
 	// SG doesn't opt in to expirations, so they'll come through as deletion events
 	// (cf.https://github.com/couchbase/kv_engine/blob/master/docs/dcp/documentation/expiry-opcode-output.md)
+	WarnfCtx(context.TODO(), "Unexpected DCP expiration event (vb:%d) for key %v", expiration.VbID, UD(string(expiration.Key)))
 }
 
 func (dc *DCPClient) CreateCollection(creation gocbcore.DcpCollectionCreation) {

--- a/base/dcp_client_worker.go
+++ b/base/dcp_client_worker.go
@@ -118,11 +118,6 @@ func (w *DCPWorker) Start(wg *sync.WaitGroup) {
 						w.mutationCallback(e.asFeedEvent())
 					}
 					w.updateSeq(e.key, vbID, e.seq)
-				case expirationEvent:
-					if w.mutationCallback != nil && !w.ignoreDeletes {
-						w.mutationCallback(e.asFeedEvent())
-					}
-					w.updateSeq(e.key, vbID, e.seq)
 				case seqnoAdvancedEvent:
 					w.updateSeq(nil, vbID, e.seq)
 				case endStreamEvent:

--- a/base/dcp_client_worker.go
+++ b/base/dcp_client_worker.go
@@ -118,6 +118,13 @@ func (w *DCPWorker) Start(wg *sync.WaitGroup) {
 						w.mutationCallback(e.asFeedEvent())
 					}
 					w.updateSeq(e.key, vbID, e.seq)
+				case expirationEvent:
+					if w.mutationCallback != nil && !w.ignoreDeletes {
+						w.mutationCallback(e.asFeedEvent())
+					}
+					w.updateSeq(e.key, vbID, e.seq)
+				case seqnoAdvancedEvent:
+					w.updateSeq(nil, vbID, e.seq)
 				case endStreamEvent:
 					w.endStreamCallback(e)
 				}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.1.5-0.20220809160836-bf53e9527651
 	github.com/couchbase/gomemcached v0.1.4
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20220725152948-e1112ff01a3d
+	github.com/couchbase/sg-bucket v0.0.0-20220824103435-aa28032bc2a3
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f
 	github.com/couchbaselabs/walrus v0.0.0-20220726144228-c44d71d14a7a
 	github.com/elastic/gosigar v0.14.2
@@ -31,7 +31,7 @@ require (
 	github.com/stretchr/testify v1.7.1
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
-	golang.org/x/net v0.0.0-20220805013720-a33c5aa5df48
+	golang.org/x/net v0.0.0-20220822230855-b0a4917ee28c
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	gopkg.in/couchbase/gocb.v1 v1.6.7
 	gopkg.in/couchbase/gocbcore.v7 v7.1.18

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/couchbase/goutils v0.1.2
 	github.com/couchbase/sg-bucket v0.0.0-20220824103435-aa28032bc2a3
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f
-	github.com/couchbaselabs/walrus v0.0.0-20220726144228-c44d71d14a7a
+	github.com/couchbaselabs/walrus v0.0.0-20220824104645-4bbd432c7128
 	github.com/elastic/gosigar v0.14.2
 	github.com/felixge/fgprof v0.9.2
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9B
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
 github.com/couchbase/sg-bucket v0.0.0-20220725152948-e1112ff01a3d h1:cYrMXK8u0FQEKTes5PkRmbkao1EjESwH+6SHc7rDHsE=
 github.com/couchbase/sg-bucket v0.0.0-20220725152948-e1112ff01a3d/go.mod h1:9XQoB1t+elPP+yEjHGOX3xcC3Z0/qDgOI7h/fc9XjlU=
+github.com/couchbase/sg-bucket v0.0.0-20220824103435-aa28032bc2a3 h1:bPd/j0+YqKAOcekv0INIxjSiheB6Lle7wXAanGPb5Eo=
+github.com/couchbase/sg-bucket v0.0.0-20220824103435-aa28032bc2a3/go.mod h1:9XQoB1t+elPP+yEjHGOX3xcC3Z0/qDgOI7h/fc9XjlU=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f h1:al5DxXEBAUmINnP5dR950gL47424WzncuRpNdg0TWR0=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f/go.mod h1:daOs69VstinwoALl3wwWxjBf1nD4lIe3wwYhKHKDapY=
 github.com/couchbaselabs/gocaves/client v0.0.0-20220223122017-22859b310bd2 h1:UlwJ2GWpZQAQCLHyO3xHKcqAjUUcX2w7FKpbxCIUQks=
@@ -385,6 +387,8 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220805013720-a33c5aa5df48 h1:N9Vc/rorQUDes6B9CNdIxAn5jODGj2wzfrei2x4wNj4=
 golang.org/x/net v0.0.0-20220805013720-a33c5aa5df48/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.0.0-20220822230855-b0a4917ee28c h1:JVAXQ10yGGVbSyoer5VILysz6YKjdNT2bsvlayjqhes=
+golang.org/x/net v0.0.0-20220822230855-b0a4917ee28c/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/couchbaselabs/gocaves/client v0.0.0-20220223122017-22859b310bd2 h1:Ul
 github.com/couchbaselabs/gocaves/client v0.0.0-20220223122017-22859b310bd2/go.mod h1:AVekAZwIY2stsJOMWLAS/0uA/+qdp7pjO8EHnl61QkY=
 github.com/couchbaselabs/walrus v0.0.0-20220726144228-c44d71d14a7a h1:hiVwAQnRHvo1oTYaOhNmxNg1KB0dTC9Htw/zDj0L0TU=
 github.com/couchbaselabs/walrus v0.0.0-20220726144228-c44d71d14a7a/go.mod h1:C5TylJ1hRbYFgPnc/6gKUUPkLvkt7xDotgApqzd3dbg=
+github.com/couchbaselabs/walrus v0.0.0-20220824104645-4bbd432c7128 h1:jvVNAyzrEyplEP+o43Y7zUYfxMD5m/6N2vf5kswEUZ8=
+github.com/couchbaselabs/walrus v0.0.0-20220824104645-4bbd432c7128/go.mod h1:bg6u+qv616GUzyZng1swDEpgSn1k9FKpV+mxX7jAcAw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
CBG-2344

Implement the DCPClient callbacks that we need to be fully Collections-aware:
* Expiration - handled similarly to Deletion, except as a separate stream event type
* SeqNoAdvanced - increments the VB seqno but otherwise no special handling

Also enables collections on DCPClient by default, even when only streaming the default collection - partly as a workaround for MB-53448 (which only affects "legacy" DCP clients).

Note that we don't handle the CollectionID on the DCP messages - we likely will need to when we move to multi-collection support.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [x] https://github.com/couchbase/sg-bucket/pull/79
- [x] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/699/
  * timed out