### PR TITLE
Moved serverless options to its own struct in the Startup Config

### DIFF
--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -117,11 +117,10 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"replicator.max_heartbeat":    {&config.Replicator.MaxHeartbeat, fs.String("replicator.max_heartbeat", "", "Max heartbeat value for _changes request")},
 		"replicator.blip_compression": {&config.Replicator.BLIPCompression, fs.Int("replicator.blip_compression", 0, "BLIP data compression level (0-9)")},
 
-		"unsupported.serverless":          {&config.Unsupported.Serverless, fs.Bool("unsupported.serverless", false, "Run SG in to serverless mode.")},
 		"unsupported.stats_log_frequency": {&config.Unsupported.StatsLogFrequency, fs.String("unsupported.stats_log_frequency", "", "How often should stats be written to stats logs")},
 		"unsupported.use_stdlib_json":     {&config.Unsupported.UseStdlibJSON, fs.Bool("unsupported.use_stdlib_json", false, "Bypass the jsoniter package and use Go's stdlib instead")},
-
-		"unsupported.http2.enabled": {&config.Unsupported.HTTP2.Enabled, fs.Bool("unsupported.http2.enabled", false, "Whether HTTP2 support is enabled")},
+		"unsupported.http2.enabled":       {&config.Unsupported.HTTP2.Enabled, fs.Bool("unsupported.http2.enabled", false, "Whether HTTP2 support is enabled")},
+		"unsupported.serverless.enabled":  {&config.Unsupported.Serverless.Enabled, fs.Bool("unsupported.serverless.enabled", false, "Settings for running Sync Gateway in serverless mode.")},
 
 		"database_credentials": {&config.DatabaseCredentials, fs.String("database_credentials", "null", "JSON-encoded per-database credentials, that can be used instead of the bootstrap ones. Cannot be used in conjunction with bucket_credentials.")},
 		"bucket_credentials":   {&config.BucketCredentials, fs.String("bucket_credentials", "null", "JSON-encoded per-bucket credentials, that can be used instead of the bootstrap ones. Cannot be used in conjunction with database_credentials.")},

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -51,7 +51,6 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 			BcryptCost: auth.DefaultBcryptCost,
 		},
 		Unsupported: UnsupportedConfig{
-			Serverless:        base.BoolPtr(false),
 			StatsLogFrequency: base.NewConfigDuration(time.Minute),
 		},
 		MaxFileDescriptors: DefaultMaxFileDescriptors,
@@ -137,11 +136,14 @@ type ReplicatorConfig struct {
 }
 
 type UnsupportedConfig struct {
-	Serverless        *bool                `json:"serverless,omitempty" help:"Run SG in to serverless mode."`
 	StatsLogFrequency *base.ConfigDuration `json:"stats_log_frequency,omitempty"    help:"How often should stats be written to stats logs"`
 	UseStdlibJSON     *bool                `json:"use_stdlib_json,omitempty"        help:"Bypass the jsoniter package and use Go's stdlib instead"`
+	HTTP2             *HTTP2Config         `json:"http2,omitempty"`
+	Serverless        ServerlessConfig     `json:"serverless,omitempty"`
+}
 
-	HTTP2 *HTTP2Config `json:"http2,omitempty"`
+type ServerlessConfig struct {
+	Enabled *bool `json:"enabled,omitempty" help:"Enable Sync Gateway serverless mode."`
 }
 
 type HTTP2Config struct {
@@ -183,7 +185,7 @@ func (sc *StartupConfig) Redacted() (*StartupConfig, error) {
 }
 
 func (sc *StartupConfig) IsServerless() bool {
-	return base.BoolDefault(sc.Unsupported.Serverless, false)
+	return base.BoolDefault(sc.Unsupported.Serverless.Enabled, false)
 }
 
 func LoadStartupConfigFromPath(path string) (*StartupConfig, error) {
@@ -199,7 +201,7 @@ func LoadStartupConfigFromPath(path string) (*StartupConfig, error) {
 	return &sc, err
 }
 
-// NewEmptyStartupConfig initialises an empty StartupConfig with all struct fields empty
+// NewEmptyStartupConfig initialises an empty StartupConfig with all *struct fields empty
 func NewEmptyStartupConfig() StartupConfig {
 	return StartupConfig{
 		API: APIConfig{

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2495,7 +2495,7 @@ func TestBucketCredentialsValidation(t *testing.T) {
 		{
 			name: "Nil bucket credentials provided when running in serverless mode",
 			startupConfig: StartupConfig{
-				Unsupported: UnsupportedConfig{Serverless: base.BoolPtr(true)},
+				Unsupported: UnsupportedConfig{Serverless: ServerlessConfig{Enabled: base.BoolPtr(true)}},
 			},
 			expectedError: &bucketNoCredsServerless,
 		},
@@ -2503,14 +2503,14 @@ func TestBucketCredentialsValidation(t *testing.T) {
 			name: "No bucket credentials provided when running in serverless mode",
 			startupConfig: StartupConfig{
 				BucketCredentials: base.PerBucketCredentialsConfig{},
-				Unsupported:       UnsupportedConfig{Serverless: base.BoolPtr(true)},
+				Unsupported:       UnsupportedConfig{Serverless: ServerlessConfig{Enabled: base.BoolPtr(true)}},
 			},
 			expectedError: &bucketNoCredsServerless,
 		},
 		{
 			name: "Bucket credentials provided when running in serverless mode",
 			startupConfig: StartupConfig{
-				Unsupported:       UnsupportedConfig{Serverless: base.BoolPtr(true)},
+				Unsupported:       UnsupportedConfig{Serverless: ServerlessConfig{Enabled: base.BoolPtr(true)}},
 				BucketCredentials: base.PerBucketCredentialsConfig{"bucket": &base.CredentialsConfig{Username: "u", Password: "p"}},
 			},
 		},

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -21,7 +21,7 @@ func TestServerlessPollBuckets(t *testing.T) {
 	defer tb1.Close()
 
 	config := bootstrapStartupConfigForTest(t)
-	config.Unsupported.Serverless = base.BoolPtr(true)
+	config.Unsupported.Serverless = ServerlessConfig{Enabled: base.BoolPtr(true)}
 	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0)
 	// Use invalid bucket to get past validation stage - will cause warnings throughout test
 	config.BucketCredentials = map[string]*base.CredentialsConfig{"invalid_bucket": {}}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -151,7 +151,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 	sc.API.EnableAdminAuthenticationPermissionsCheck = &rt.enableAdminAuthPermissionsCheck
 	sc.Bootstrap.UseTLSServer = &rt.RestTesterConfig.useTLSServer
 	sc.Bootstrap.ServerTLSSkipVerify = base.BoolPtr(base.TestTLSSkipVerify())
-	sc.Unsupported.Serverless = &rt.serverless
+	sc.Unsupported.Serverless.Enabled = &rt.serverless
 	if rt.serverless {
 		sc.BucketCredentials = map[string]*base.CredentialsConfig{
 			testBucket.GetName(): {


### PR DESCRIPTION
Move the serverless options in to it's own struct in the startup config.

The reason for the new stuct not being a pointer is because it's always going to be initalized with default settings for future serverless settings

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/714/