### PR TITLE
CBG-2305: Implemented functions for suspending and unsuspending databases

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1735,6 +1735,21 @@ Compact-status:
     - start_time
     - last_error
   title: Compact-status
+Serverless:
+  description: Configuration for when SG is running in serverless mode
+  type: object
+  properties:
+    enabled:
+      description: Run SG in to serverless mode
+      type: boolean
+      readOnly: true
+    fetch_configs_cache_ttl:
+      description: |-
+        How long to cache configs fetched from the buckets for. This cache is used for requested databases that SG does not know about.
+        
+        This is a duration and therefore can be provided with units "h", "m", "s", "ms", "us", and "ns". For example, 5 hours, 20 minutes, and 30 seconds would be `5h20m30s`.
+      type: string
+      default: 1s
 Startup-config:
   type: object
   properties:
@@ -1960,9 +1975,7 @@ Startup-config:
       type: object
       properties:
         serverless:
-          description: Run SG in to serverless mode
-          type: boolean
-          readOnly: true
+          $ref: '#/Serverless'
         stats_log_frequency:
           description: |-
             How often should stats be written to stats logs.

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1620,6 +1620,13 @@ Database:
       description: The maximum number of seconds the sync, import filter, and custom conflict resolver JavaScript functions are allowed to run for before timing out. Set to 0 to allow the JS functions to run uncapped.
       type: number
       default: 60
+    suspendable:
+      description: |-
+        Set to true to allow the database to be suspended and unsuspended. 
+        
+        Defaults to true when running in serverless mode otherwise defaults to false.
+      type: boolean
+      default: false
   title: Database-config
 Event-config:
   type: object
@@ -1743,9 +1750,9 @@ Serverless:
       description: Run SG in to serverless mode
       type: boolean
       readOnly: true
-    fetch_configs_cache_ttl:
+    fetch_configs_ttl:
       description: |-
-        How long to cache configs fetched from the buckets for. This cache is used for requested databases that SG does not know about.
+        How long database configs should be kept for in Sync Gateway before refreshing. Set to 0 to fetch configs everytime. This is used for requested databases that SG does not know about. 
         
         This is a duration and therefore can be provided with units "h", "m", "s", "ms", "us", and "ns". For example, 5 hours, 20 minutes, and 30 seconds would be `5h20m30s`.
       type: string

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1750,7 +1750,7 @@ Serverless:
       description: Run SG in to serverless mode
       type: boolean
       readOnly: true
-    fetch_configs_ttl:
+    min_config_fetch_interval:
       description: |-
         How long database configs should be kept for in Sync Gateway before refreshing. Set to 0 to fetch configs everytime. This is used for requested databases that SG does not know about. 
         

--- a/rest/config.go
+++ b/rest/config.go
@@ -1362,7 +1362,7 @@ func (sc *ServerContext) _fetchAndLoadDatabase(ctx context.Context, dbName strin
 func (sc *ServerContext) fetchDatabase(ctx context.Context, dbName string) (found bool, dbConfig *DatabaseConfig, err error) {
 	var buckets []string
 	if sc.config.IsServerless() {
-		buckets = make([]string, len(sc.config.BucketCredentials))
+		buckets = make([]string, 0, len(sc.config.BucketCredentials))
 		for bucket, _ := range sc.config.BucketCredentials {
 			buckets = append(buckets, bucket)
 		}

--- a/rest/config.go
+++ b/rest/config.go
@@ -1446,7 +1446,7 @@ func (sc *ServerContext) fetchConfigsSince(ctx context.Context, refreshInterval 
 		minInterval = refreshInterval.Value()
 	}
 
-	if sc.fetchConfigsLastUpdate.IsZero() || time.Since(sc.fetchConfigsLastUpdate) > minInterval {
+	if time.Since(sc.fetchConfigsLastUpdate) > minInterval {
 		_, err = sc.fetchAndLoadConfigs(ctx, false)
 		if err != nil {
 			return nil, err

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -133,6 +133,7 @@ func DefaultDbConfig(sc *StartupConfig) *DbConfig {
 		UserXattrKey:                     "",
 		ClientPartitionWindowSecs:        base.IntPtr(int(base.DefaultClientPartitionWindow.Seconds())),
 		JavascriptTimeoutSecs:            base.Uint32Ptr(base.DefaultJavascriptTimeoutSecs),
+		Suspendable:                      base.BoolPtr(sc.IsServerless()),
 	}
 
 	revsLimit := db.DefaultRevsLimitNoConflicts

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -117,11 +117,11 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"replicator.max_heartbeat":    {&config.Replicator.MaxHeartbeat, fs.String("replicator.max_heartbeat", "", "Max heartbeat value for _changes request")},
 		"replicator.blip_compression": {&config.Replicator.BLIPCompression, fs.Int("replicator.blip_compression", 0, "BLIP data compression level (0-9)")},
 
-		"unsupported.stats_log_frequency":          {&config.Unsupported.StatsLogFrequency, fs.String("unsupported.stats_log_frequency", "", "How often should stats be written to stats logs")},
-		"unsupported.use_stdlib_json":              {&config.Unsupported.UseStdlibJSON, fs.Bool("unsupported.use_stdlib_json", false, "Bypass the jsoniter package and use Go's stdlib instead")},
-		"unsupported.http2.enabled":                {&config.Unsupported.HTTP2.Enabled, fs.Bool("unsupported.http2.enabled", false, "Whether HTTP2 support is enabled")},
-		"unsupported.serverless.enabled":           {&config.Unsupported.Serverless.Enabled, fs.Bool("unsupported.serverless.enabled", false, "Settings for running Sync Gateway in serverless mode.")},
-		"unsupported.serverless.fetch_configs_ttl": {&config.Unsupported.Serverless.FetchConfigsTTL, fs.String("unsupported.serverless.fetch_configs_ttl", "", "How long to cache configs fetched from the buckets for. This cache is used for requested databases that SG does not know about.")},
+		"unsupported.stats_log_frequency":                  {&config.Unsupported.StatsLogFrequency, fs.String("unsupported.stats_log_frequency", "", "How often should stats be written to stats logs")},
+		"unsupported.use_stdlib_json":                      {&config.Unsupported.UseStdlibJSON, fs.Bool("unsupported.use_stdlib_json", false, "Bypass the jsoniter package and use Go's stdlib instead")},
+		"unsupported.http2.enabled":                        {&config.Unsupported.HTTP2.Enabled, fs.Bool("unsupported.http2.enabled", false, "Whether HTTP2 support is enabled")},
+		"unsupported.serverless.enabled":                   {&config.Unsupported.Serverless.Enabled, fs.Bool("unsupported.serverless.enabled", false, "Settings for running Sync Gateway in serverless mode.")},
+		"unsupported.serverless.min_config_fetch_interval": {&config.Unsupported.Serverless.MinConfigFetchInterval, fs.String("unsupported.serverless.min_config_fetch_interval", "", "How long to cache configs fetched from the buckets for. This cache is used for requested databases that SG does not know about.")},
 
 		"unsupported.user_queries": {&config.Unsupported.UserQueries, fs.Bool("unsupported.user_queries", false, "Whether user-query APIs are enabled")},
 

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -117,11 +117,11 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"replicator.max_heartbeat":    {&config.Replicator.MaxHeartbeat, fs.String("replicator.max_heartbeat", "", "Max heartbeat value for _changes request")},
 		"replicator.blip_compression": {&config.Replicator.BLIPCompression, fs.Int("replicator.blip_compression", 0, "BLIP data compression level (0-9)")},
 
-		"unsupported.stats_log_frequency":                {&config.Unsupported.StatsLogFrequency, fs.String("unsupported.stats_log_frequency", "", "How often should stats be written to stats logs")},
-		"unsupported.use_stdlib_json":                    {&config.Unsupported.UseStdlibJSON, fs.Bool("unsupported.use_stdlib_json", false, "Bypass the jsoniter package and use Go's stdlib instead")},
-		"unsupported.http2.enabled":                      {&config.Unsupported.HTTP2.Enabled, fs.Bool("unsupported.http2.enabled", false, "Whether HTTP2 support is enabled")},
-		"unsupported.serverless.enabled":                 {&config.Unsupported.Serverless.Enabled, fs.Bool("unsupported.serverless.enabled", false, "Settings for running Sync Gateway in serverless mode.")},
-		"unsupported.serverless.fetch_configs_cache_ttl": {&config.Unsupported.Serverless.FetchConfigsCacheTTL, fs.String("unsupported.serverless.fetch_configs_cache_ttl", "", "How long to cache configs fetched from the buckets for. This cache is used for requested databases that SG does not know about.")},
+		"unsupported.stats_log_frequency":          {&config.Unsupported.StatsLogFrequency, fs.String("unsupported.stats_log_frequency", "", "How often should stats be written to stats logs")},
+		"unsupported.use_stdlib_json":              {&config.Unsupported.UseStdlibJSON, fs.Bool("unsupported.use_stdlib_json", false, "Bypass the jsoniter package and use Go's stdlib instead")},
+		"unsupported.http2.enabled":                {&config.Unsupported.HTTP2.Enabled, fs.Bool("unsupported.http2.enabled", false, "Whether HTTP2 support is enabled")},
+		"unsupported.serverless.enabled":           {&config.Unsupported.Serverless.Enabled, fs.Bool("unsupported.serverless.enabled", false, "Settings for running Sync Gateway in serverless mode.")},
+		"unsupported.serverless.fetch_configs_ttl": {&config.Unsupported.Serverless.FetchConfigsTTL, fs.String("unsupported.serverless.fetch_configs_ttl", "", "How long to cache configs fetched from the buckets for. This cache is used for requested databases that SG does not know about.")},
 
 		"unsupported.user_queries": {&config.Unsupported.UserQueries, fs.Bool("unsupported.user_queries", false, "Whether user-query APIs are enabled")},
 

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -117,10 +117,11 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"replicator.max_heartbeat":    {&config.Replicator.MaxHeartbeat, fs.String("replicator.max_heartbeat", "", "Max heartbeat value for _changes request")},
 		"replicator.blip_compression": {&config.Replicator.BLIPCompression, fs.Int("replicator.blip_compression", 0, "BLIP data compression level (0-9)")},
 
-		"unsupported.stats_log_frequency": {&config.Unsupported.StatsLogFrequency, fs.String("unsupported.stats_log_frequency", "", "How often should stats be written to stats logs")},
-		"unsupported.use_stdlib_json":     {&config.Unsupported.UseStdlibJSON, fs.Bool("unsupported.use_stdlib_json", false, "Bypass the jsoniter package and use Go's stdlib instead")},
-		"unsupported.http2.enabled":       {&config.Unsupported.HTTP2.Enabled, fs.Bool("unsupported.http2.enabled", false, "Whether HTTP2 support is enabled")},
-		"unsupported.serverless.enabled":  {&config.Unsupported.Serverless.Enabled, fs.Bool("unsupported.serverless.enabled", false, "Settings for running Sync Gateway in serverless mode.")},
+		"unsupported.stats_log_frequency":                {&config.Unsupported.StatsLogFrequency, fs.String("unsupported.stats_log_frequency", "", "How often should stats be written to stats logs")},
+		"unsupported.use_stdlib_json":                    {&config.Unsupported.UseStdlibJSON, fs.Bool("unsupported.use_stdlib_json", false, "Bypass the jsoniter package and use Go's stdlib instead")},
+		"unsupported.http2.enabled":                      {&config.Unsupported.HTTP2.Enabled, fs.Bool("unsupported.http2.enabled", false, "Whether HTTP2 support is enabled")},
+		"unsupported.serverless.enabled":                 {&config.Unsupported.Serverless.Enabled, fs.Bool("unsupported.serverless.enabled", false, "Settings for running Sync Gateway in serverless mode.")},
+		"unsupported.serverless.fetch_configs_cache_ttl": {&config.Unsupported.Serverless.FetchConfigsCacheTTL, fs.String("unsupported.serverless.fetch_configs_cache_ttl", "", "How long to cache configs fetched from the buckets for. This cache is used for requested databases that SG does not know about.")},
 
 		"unsupported.user_queries": {&config.Unsupported.UserQueries, fs.Bool("unsupported.user_queries", false, "Whether user-query APIs are enabled")},
 

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -52,6 +52,10 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 		},
 		Unsupported: UnsupportedConfig{
 			StatsLogFrequency: base.NewConfigDuration(time.Minute),
+			Serverless: ServerlessConfig{
+				Enabled:              base.BoolPtr(false),
+				FetchConfigsCacheTTL: base.NewConfigDuration(DefaultFetchConfigsCacheTTL),
+			},
 		},
 		MaxFileDescriptors: DefaultMaxFileDescriptors,
 	}
@@ -144,7 +148,8 @@ type UnsupportedConfig struct {
 }
 
 type ServerlessConfig struct {
-	Enabled *bool `json:"enabled,omitempty" help:"Enable Sync Gateway serverless mode."`
+	Enabled              *bool                `json:"enabled,omitempty" help:"Enable Sync Gateway serverless mode."`
+	FetchConfigsCacheTTL *base.ConfigDuration `json:"fetch_configs_cache_ttl,omitempty" help:"How long to cache configs fetched from the buckets for. This cache is used for requested databases that SG does not know about."`
 }
 
 type HTTP2Config struct {

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -53,8 +53,8 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 		Unsupported: UnsupportedConfig{
 			StatsLogFrequency: base.NewConfigDuration(time.Minute),
 			Serverless: ServerlessConfig{
-				Enabled:              base.BoolPtr(false),
-				FetchConfigsCacheTTL: base.NewConfigDuration(DefaultFetchConfigsCacheTTL),
+				Enabled:         base.BoolPtr(false),
+				FetchConfigsTTL: base.NewConfigDuration(DefaultFetchConfigsTTL),
 			},
 		},
 		MaxFileDescriptors: DefaultMaxFileDescriptors,
@@ -148,8 +148,8 @@ type UnsupportedConfig struct {
 }
 
 type ServerlessConfig struct {
-	Enabled              *bool                `json:"enabled,omitempty" help:"Enable Sync Gateway serverless mode."`
-	FetchConfigsCacheTTL *base.ConfigDuration `json:"fetch_configs_cache_ttl,omitempty" help:"How long to cache configs fetched from the buckets for. This cache is used for requested databases that SG does not know about."`
+	Enabled         *bool                `json:"enabled,omitempty" help:"Enable Sync Gateway serverless mode."`
+	FetchConfigsTTL *base.ConfigDuration `json:"fetch_configs_ttl,omitempty" help:"How long to cache configs fetched from the buckets for. This cache is used for requested databases that SG does not know about."`
 }
 
 type HTTP2Config struct {

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -53,8 +53,8 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 		Unsupported: UnsupportedConfig{
 			StatsLogFrequency: base.NewConfigDuration(time.Minute),
 			Serverless: ServerlessConfig{
-				Enabled:         base.BoolPtr(false),
-				FetchConfigsTTL: base.NewConfigDuration(DefaultFetchConfigsTTL),
+				Enabled:                base.BoolPtr(false),
+				MinConfigFetchInterval: base.NewConfigDuration(DefaultMinConfigFetchInterval),
 			},
 		},
 		MaxFileDescriptors: DefaultMaxFileDescriptors,
@@ -148,8 +148,8 @@ type UnsupportedConfig struct {
 }
 
 type ServerlessConfig struct {
-	Enabled         *bool                `json:"enabled,omitempty" help:"Enable Sync Gateway serverless mode."`
-	FetchConfigsTTL *base.ConfigDuration `json:"fetch_configs_ttl,omitempty" help:"How long to cache configs fetched from the buckets for. This cache is used for requested databases that SG does not know about."`
+	Enabled                *bool                `json:"enabled,omitempty" help:"Enable Sync Gateway serverless mode."`
+	MinConfigFetchInterval *base.ConfigDuration `json:"min_config_fetch_interval,omitempty" help:"How long to cache configs fetched from the buckets for. This cache is used for requested databases that SG does not know about."`
 }
 
 type HTTP2Config struct {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1096,7 +1096,7 @@ func (sc *ServerContext) _suspendDatabase(dbName string) bool {
 		return false
 	}
 	bucket := dbCtx.Bucket.GetName()
-	base.InfofCtx(context.TODO(), base.KeyAll, "Suspending db %q (bucket %q)", base.MD(dbName), base.MD(bucket).Redact())
+	base.InfofCtx(context.TODO(), base.KeyAll, "Suspending db %q (bucket %q)", base.MD(dbName), base.MD(bucket))
 
 	if !sc._unloadDatabase(dbName) {
 		return false
@@ -1126,7 +1126,7 @@ func (sc *ServerContext) _unsuspendDatabase(dbName string) (*db.DatabaseContext,
 		cas, err := sc.bootstrapContext.connection.GetConfig(bucket, sc.config.Bootstrap.ConfigGroupID, dbConfig)
 		if err == base.ErrNotFound {
 			// Database no longer exists, so clean up dbConfigs
-			base.InfofCtx(context.TODO(), base.KeyConfig, "Database %q has been removed while suspended from bucket %q", base.MD(dbName).Redact(), base.MD(bucket).Redact())
+			base.InfofCtx(context.TODO(), base.KeyConfig, "Database %q has been removed while suspended from bucket %q", base.MD(dbName), base.MD(bucket))
 			delete(sc.dbConfigs, dbName)
 			return nil, err
 		} else if err != nil {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1052,24 +1052,12 @@ func (sc *ServerContext) _removeDatabase(ctx context.Context, dbName string) boo
 	delete(sc.bucketDbName, bucket)
 	return true
 }
-func (sc *ServerContext) isDatabaseSuspended(dbName string) bool {
-	sc.lock.RLock()
-	defer sc.lock.RUnlock()
-	return sc._isDatabaseSuspended(dbName)
-}
 
 func (sc *ServerContext) _isDatabaseSuspended(dbName string) bool {
 	if _, loaded := sc.databases_[dbName]; !loaded && sc.dbConfigs[dbName] != nil {
 		return true
 	}
 	return false
-}
-
-func (sc *ServerContext) suspendDatabase(ctx context.Context, dbName string) error {
-	sc.lock.Lock()
-	defer sc.lock.Unlock()
-
-	return sc._suspendDatabase(ctx, dbName)
 }
 
 func (sc *ServerContext) _suspendDatabase(ctx context.Context, dbName string) error {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -238,8 +238,10 @@ func (sc *ServerContext) GetServerlessDatabase(name string) (*db.DatabaseContext
 	}
 
 	dbc, err := sc.unsuspendDatabase(name)
-	if err != base.ErrNotFound {
+	if err != nil && err != base.ErrNotFound {
 		return nil, err
+	} else if err == nil {
+		return dbc, nil
 	}
 
 	// Fallback to fetching configs from buckets if database not found

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -181,7 +181,7 @@ func TestServerlessSuspendDatabase(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
 
-	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb, persistentConfig: true, serverless: true})
+	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, persistentConfig: true, serverless: true})
 	defer rt.Close()
 
 	sc := rt.ServerContext()
@@ -192,7 +192,7 @@ func TestServerlessSuspendDatabase(t *testing.T) {
 		"use_views": %t,
 		"num_index_replicas": 0
 	}`, tb.GetName(), base.TestsDisableGSI()))
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	assert.False(t, sc.isDatabaseSuspended(t, "db"))
 	assert.NotNil(t, sc.databases_["db"])
@@ -254,7 +254,7 @@ func TestServerlessUnsuspendFetchFallback(t *testing.T) {
 	defer tb.Close()
 
 	rt := NewRestTester(t, &RestTesterConfig{
-		TestBucket:       tb,
+		CustomTestBucket: tb,
 		serverless:       true,
 		persistentConfig: true,
 		MutateStartupConfig: func(config *StartupConfig) {
@@ -270,7 +270,7 @@ func TestServerlessUnsuspendFetchFallback(t *testing.T) {
 			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 		),
 	)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	// Suspend the database and remove it from dbConfigs, forcing unsuspendDatabase to fetch config from the bucket
 	err := sc.suspendDatabase(t, rt.Context(), "db")
@@ -300,7 +300,7 @@ func TestServerlessFetchConfigsLimited(t *testing.T) {
 	defer tb.Close()
 
 	rt := NewRestTester(t, &RestTesterConfig{
-		TestBucket:       tb,
+		CustomTestBucket: tb,
 		persistentConfig: true,
 		MutateStartupConfig: func(config *StartupConfig) {
 			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0)
@@ -315,7 +315,7 @@ func TestServerlessFetchConfigsLimited(t *testing.T) {
 			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 		),
 	)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	// Purposely make configs get caches
 	sc.config.Unsupported.Serverless.MinConfigFetchInterval = base.NewConfigDuration(time.Hour)
@@ -372,7 +372,7 @@ func TestServerlessUpdateSuspendedDb(t *testing.T) {
 	defer tb.Close()
 
 	rt := NewRestTester(t, &RestTesterConfig{
-		TestBucket:       tb,
+		CustomTestBucket: tb,
 		persistentConfig: true,
 		MutateStartupConfig: func(config *StartupConfig) {
 			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0)
@@ -387,7 +387,7 @@ func TestServerlessUpdateSuspendedDb(t *testing.T) {
 			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 		),
 	)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	// Suspend the database
 	assert.NoError(t, sc.suspendDatabase(t, rt.Context(), "db"))
@@ -458,7 +458,7 @@ func TestSuspendingFlags(t *testing.T) {
 			tb := base.GetTestBucket(t)
 			defer tb.Close()
 
-			rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb, persistentConfig: true, serverless: test.serverlessMode})
+			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, persistentConfig: true, serverless: test.serverlessMode})
 			defer rt.Close()
 
 			sc := rt.ServerContext()
@@ -473,7 +473,7 @@ func TestSuspendingFlags(t *testing.T) {
 				%s
 				"num_index_replicas": 0
 			}`, tb.GetName(), base.TestsDisableGSI(), suspendableDbOption))
-			requireStatus(t, resp, http.StatusCreated)
+			RequireStatus(t, resp, http.StatusCreated)
 
 			err := sc.suspendDatabase(t, rt.Context(), "db")
 			if test.expectCanSuspend {

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -1,9 +1,11 @@
 package rest
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
@@ -168,4 +170,257 @@ func TestServerlessBucketCredentialsFetchDatabases(t *testing.T) {
 	found, _, err = rt.ServerContext().fetchDatabase(ctx, "db")
 	assert.NoError(t, err)
 	assert.False(t, found)
+}
+
+func TestServerlessSuspendDatabase(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server due to updating database config using a Bootstrap connection")
+	}
+
+	// Get test bucket
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+
+	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb, persistentConfig: true})
+	defer rt.Close()
+
+	sc := rt.ServerContext()
+
+	resp := rt.SendAdminRequest(http.MethodPut, "/db/", fmt.Sprintf(`{
+		"bucket": "%s",
+		"use_views": %t,
+		"num_index_replicas": 0
+	}`, tb.GetName(), base.TestsDisableGSI()))
+	requireStatus(t, resp, http.StatusCreated)
+
+	assert.NotNil(t, sc.databases_["db"])
+	assert.Equal(t, "db", sc.bucketDbName[tb.GetName()])
+	assert.NotNil(t, sc.dbConfigs["db"])
+
+	// Unsuspend db that is not suspended should just return db context
+	dbCtx, err := sc.unsuspendDatabase("db")
+	assert.NotNil(t, dbCtx)
+	assert.NoError(t, err)
+
+	// Confirm false returned when db does not exist
+	suspended := sc.suspendDatabase("invalid_db")
+	assert.False(t, suspended)
+
+	// Confirm true returned when suspended a database successfully
+	suspended = sc.suspendDatabase("db")
+	assert.True(t, suspended)
+
+	// Make sure database is suspended
+	assert.Nil(t, sc.databases_["db"])
+	assert.Empty(t, sc.bucketDbName[tb.GetName()])
+	assert.NotNil(t, sc.dbConfigs["db"])
+
+	// Update config in bucket to see if unsuspending check for updates
+	cas, err := sc.bootstrapContext.connection.UpdateConfig(tb.GetName(), sc.config.Bootstrap.ConfigGroupID,
+		func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
+			return json.Marshal(sc.dbConfigs["db"])
+		},
+	)
+	require.NoError(t, err)
+	assert.NotEqual(t, cas, sc.dbConfigs["db"].cas)
+
+	// Unsuspend db
+	dbCtx, err = sc.unsuspendDatabase("db")
+	assert.NotNil(t, dbCtx)
+	assert.NotNil(t, sc.databases_["db"])
+	assert.Equal(t, "db", sc.bucketDbName[tb.GetName()])
+	require.NotNil(t, sc.dbConfigs["db"])
+
+	// Make sure updated config is being used
+	assert.Equal(t, cas, sc.dbConfigs["db"].cas)
+
+	// Attempt unsuspend of invalid db
+	dbCtx, err = sc.unsuspendDatabase("invalid")
+	assert.Nil(t, dbCtx)
+	assert.Nil(t, sc.databases_["invalid"])
+	assert.Nil(t, sc.dbConfigs["invalid"])
+}
+
+// Confirms that when the database config is not in sc.dbConfigs, the fetch callback is check if the config is in a bucket
+func TestServerlessUnsuspendFetchFallback(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+
+	// Set up server context
+	config := bootstrapStartupConfigForTest(t)
+	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0) // Make sure database does not get imported by fetchAndLoadConfigs
+
+	sc, err := setupServerContext(&config, true)
+	require.NoError(t, err)
+
+	serverErr := make(chan error, 0)
+	defer func() {
+		sc.Close()
+		require.NoError(t, <-serverErr)
+	}()
+
+	go func() {
+		serverErr <- startServer(&config, sc)
+	}()
+	require.NoError(t, sc.waitForRESTAPIs())
+
+	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/",
+		fmt.Sprintf(
+			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,
+			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
+		),
+	)
+	resp.requireStatus(http.StatusCreated)
+
+	// Suspend the database and remove it from dbConfigs, forcing unsuspendDatabase to fetch config from the bucket
+	sc.suspendDatabase("db")
+	delete(sc.dbConfigs, "db")
+	assert.Nil(t, sc.databases_["db"])
+
+	// Unsuspend db and confirm unsuspending worked
+	dbCtx, err := sc.GetServerlessDatabase("db")
+	assert.NoError(t, err)
+	assert.NotNil(t, dbCtx)
+	assert.NotNil(t, sc.databases_["db"])
+
+	// Attempt to get invalid database
+	dbCtx, err = sc.GetServerlessDatabase("invalid")
+	assert.Contains(t, err.Error(), "no such database")
+}
+
+// Confirms that ServerContext.fetchConfigsCache works correctly
+func TestServerlessFetchConfigsLimited(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+
+	// Set up server context
+	config := bootstrapStartupConfigForTest(t)
+	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0) // Make sure database does not get imported by fetchAndLoadConfigs
+
+	sc, err := setupServerContext(&config, true)
+	require.NoError(t, err)
+
+	serverErr := make(chan error, 0)
+	defer func() {
+		sc.Close()
+		require.NoError(t, <-serverErr)
+	}()
+
+	go func() {
+		serverErr <- startServer(&config, sc)
+	}()
+	require.NoError(t, sc.waitForRESTAPIs())
+
+	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/",
+		fmt.Sprintf(
+			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,
+			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
+		),
+	)
+	resp.requireStatus(http.StatusCreated)
+
+	// Purposely make configs get caches
+	sc.config.Unsupported.Serverless.FetchConfigsCacheTTL = base.NewConfigDuration(time.Hour)
+	dbConfigsBefore, err := sc.fetchConfigsCache()
+	require.NotEmpty(t, dbConfigsBefore["db"])
+	timeCached := sc.fetchConfigsCacheUpdated
+	assert.NotZero(t, timeCached)
+	require.NoError(t, err)
+
+	// Update database config in the bucket
+	newCas, err := sc.bootstrapContext.connection.UpdateConfig(tb.GetName(), sc.config.Bootstrap.ConfigGroupID,
+		func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
+			return json.Marshal(sc.dbConfigs["db"])
+		},
+	)
+
+	// Fetch configs again and expect same config to be returned
+	dbConfigsAfter, err := sc.fetchConfigsCache()
+	require.NotEmpty(t, dbConfigsAfter["db"])
+	assert.Equal(t, dbConfigsBefore["db"].cas, dbConfigsAfter["db"].cas)
+	assert.Equal(t, timeCached, sc.fetchConfigsCacheUpdated)
+
+	// Make caching 1ms so it will grab newest config
+	sc.config.Unsupported.Serverless.FetchConfigsCacheTTL = base.NewConfigDuration(time.Millisecond)
+	// Sleep to make sure enough time passes
+	time.Sleep(time.Millisecond * 500)
+	dbConfigsAfter, err = sc.fetchConfigsCache()
+	require.NotEmpty(t, dbConfigsAfter["db"])
+	assert.Equal(t, newCas, dbConfigsAfter["db"].cas)
+	// Change back for next test before next config update (not fully necessary but just to be safe)
+	sc.config.Unsupported.Serverless.FetchConfigsCacheTTL = base.NewConfigDuration(time.Hour)
+
+	// Update database config in the bucket again to test caching disable case
+	newCas, err = sc.bootstrapContext.connection.UpdateConfig(tb.GetName(), sc.config.Bootstrap.ConfigGroupID,
+		func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
+			return json.Marshal(sc.dbConfigs["db"])
+		},
+	)
+
+	// Disable caching and expect new config
+	sc.config.Unsupported.Serverless.FetchConfigsCacheTTL = base.NewConfigDuration(0)
+	dbConfigsAfter, err = sc.fetchConfigsCache()
+	require.NotEmpty(t, dbConfigsAfter["db"])
+	assert.Equal(t, newCas, dbConfigsAfter["db"].cas)
+}
+
+// Checks what happens to a suspended database when the config is modified by another node and the periodic fetchAndLoadConfigs gets called.
+// Currently, it will be unsuspended however that behaviour may be changed in the future
+func TestServerlessUpdateSuspendedDb(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+
+	// Set up server context
+	config := bootstrapStartupConfigForTest(t)
+	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0) // Make sure fetchAndLoadConfigs does not get triggered
+
+	sc, err := setupServerContext(&config, true)
+	require.NoError(t, err)
+
+	serverErr := make(chan error, 0)
+	defer func() {
+		sc.Close()
+		require.NoError(t, <-serverErr)
+	}()
+
+	go func() {
+		serverErr <- startServer(&config, sc)
+	}()
+	require.NoError(t, sc.waitForRESTAPIs())
+
+	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/",
+		fmt.Sprintf(
+			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,
+			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
+		),
+	)
+	resp.requireStatus(http.StatusCreated)
+
+	// Suspend the database
+	assert.True(t, sc.suspendDatabase("db"))
+	// Update database config
+	newCas, err := sc.bootstrapContext.connection.UpdateConfig(tb.GetName(), sc.config.Bootstrap.ConfigGroupID,
+		func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
+			return json.Marshal(sc.dbConfigs["db"])
+		},
+	)
+	// Confirm dbConfig cas did not update yet in SG, or get unsuspended
+	assert.NotEqual(t, sc.dbConfigs["db"].cas, newCas)
+	assert.Nil(t, sc.databases_["db"])
+	// Trigger update frequency (would usually happen every ConfigUpdateFrequency seconds)
+	count, err := sc.fetchAndLoadConfigs(false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	// Check if it reloaded the database
+	assert.NotNil(t, sc.databases_["db"])
 }

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -165,7 +165,7 @@ func TestServerlessBucketCredentialsFetchDatabases(t *testing.T) {
 	assert.True(t, found)
 
 	// Limit SG to buckets defined on BucketCredentials map
-	rt.ReplacePerBucketCredentials(map[string]*base.CredentialsConfig{"invalid_bucket": {}})
+	rt.ReplacePerBucketCredentials(map[string]*base.CredentialsConfig{})
 	// Make sure fetch fails as it cannot see all buckets in cluster
 	found, _, err = rt.ServerContext().fetchDatabase(ctx, "db")
 	assert.NoError(t, err)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1874,3 +1874,16 @@ func waitAndAssertBackgroundManagerExpiredHeartbeat(t testing.TB, bm *db.Backgro
 	}
 	return assert.Truef(t, base.IsDocNotFoundError(err), "expected heartbeat doc to expire, but got a different error: %v", err)
 }
+
+func (sc *ServerContext) isDatabaseSuspended(t *testing.T, dbName string) bool {
+	sc.lock.RLock()
+	defer sc.lock.RUnlock()
+	return sc._isDatabaseSuspended(dbName)
+}
+
+func (sc *ServerContext) suspendDatabase(t *testing.T, ctx context.Context, dbName string) error {
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
+
+	return sc._suspendDatabase(ctx, dbName)
+}

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -369,7 +369,7 @@ func TestAdminReduceViewQuery(t *testing.T) {
 	// todo support group reduce, see #955
 	// // test group=true
 	// response = rt.sendAdminRequest("GET", "/db/_design/foo/_view/bar?reduce=true&group=true", ``)
-	// requireStatus(t, response, 200)
+	// RequireStatus(t, response, 200)
 	// base.JSONUnmarshal(response.Body.Bytes(), &result)
 	// // we should get 2 rows with the reduce result
 	// goassert.Equals(t, len(result.Rows), 2)


### PR DESCRIPTION
CBG-2305

- Added new functions on the ServerContext for suspending and unsuspending a database
- Changed to `getDatabase`to try to unsuspend the database first, before attempting to find the config in the buckets (which is cached when running in serverless).
- Added new function to fetch configs from the buckets on CBS and will cache them. By default, this will refresh the dbConfigs if it's older than a second when called. This is customisable through the config option `FetchConfigsTTL`.
- Added testing for this
- Fixed persistent config testing by setting default group ID
- Added db level option `suspendable` to indicate if a database can be suspended or not. Defaults to true if running in serverless mode

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/831/