### PR TITLE
CBG-2314: Per-DB Logging: Main, ServerContext, and DatabaseContext

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -602,7 +602,7 @@ func retrievePurgeInterval(bucket CouchbaseStore, uri string) (time.Duration, er
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusForbidden {
-		WarnfCtx(resp.Request.Context(), "403 Forbidden attempting to access %s.  Bucket user must have Bucket Full Access and Bucket Admin roles to retrieve metadata purge interval.", UD(uri))
+		WarnfCtx(context.TODO(), "403 Forbidden attempting to access %s.  Bucket user must have Bucket Full Access and Bucket Admin roles to retrieve metadata purge interval.", UD(uri))
 	} else if resp.StatusCode != http.StatusOK {
 		return 0, errors.New(resp.Status)
 	}

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -82,7 +82,7 @@ type DCPCommon struct {
 	checkpointPrefix       string                         // DCP checkpoint key prefix
 }
 
-func NewDCPCommon(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dbStats *expvar.Map, feedID, checkpointPrefix string) *DCPCommon {
+func NewDCPCommon(ctx context.Context, callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dbStats *expvar.Map, feedID, checkpointPrefix string) *DCPCommon {
 	newBackfillStatus := backfillStatus{}
 
 	c := &DCPCommon{
@@ -102,7 +102,7 @@ func NewDCPCommon(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbN
 	}
 
 	dcpContextID := fmt.Sprintf("%s-%s", MD(bucket.GetName()).Redact(), feedID)
-	c.loggingCtx = LogContextWith(context.Background(), &LogContext{CorrelationID: dcpContextID})
+	c.loggingCtx = LogContextWith(ctx, &LogContext{CorrelationID: dcpContextID})
 
 	return c
 }

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -65,9 +65,9 @@ type DCPDest struct {
 	metaInitComplete   []bool      // Whether metadata initialization has been completed, per vbNo
 }
 
-func NewDCPDest(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dcpStats *expvar.Map, feedID string, importPartitionStat *SgwIntStat, checkpointPrefix string) (SGDest, context.Context) {
+func NewDCPDest(ctx context.Context, callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dcpStats *expvar.Map, feedID string, importPartitionStat *SgwIntStat, checkpointPrefix string) (SGDest, context.Context) {
 
-	dcpCommon := NewDCPCommon(callback, bucket, maxVbNo, persistCheckpoints, dcpStats, feedID, checkpointPrefix)
+	dcpCommon := NewDCPCommon(ctx, callback, bucket, maxVbNo, persistCheckpoints, dcpStats, feedID, checkpointPrefix)
 
 	d := &DCPDest{
 		DCPCommon:          dcpCommon,

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -42,7 +42,7 @@ type DCPReceiver struct {
 
 func NewDCPReceiver(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dbStats *expvar.Map, feedID string, checkpointPrefix string) (cbdatasource.Receiver, context.Context) {
 
-	dcpCommon := NewDCPCommon(callback, bucket, maxVbNo, persistCheckpoints, dbStats, feedID, checkpointPrefix)
+	dcpCommon := NewDCPCommon(context.TODO(), callback, bucket, maxVbNo, persistCheckpoints, dbStats, feedID, checkpointPrefix)
 	r := &DCPReceiver{
 		DCPCommon: dcpCommon,
 	}

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -644,13 +644,13 @@ type CbgtDestFactoryFunc = func() (cbgt.Dest, error)
 var cbgtDestFactories = make(map[string]CbgtDestFactoryFunc)
 var cbgtDestFactoriesLock sync.Mutex
 
-func StoreDestFactory(destKey string, dest CbgtDestFactoryFunc) {
+func StoreDestFactory(ctx context.Context, destKey string, dest CbgtDestFactoryFunc) {
 	cbgtDestFactoriesLock.Lock()
 	_, ok := cbgtDestFactories[destKey]
 
 	// We don't expect duplicate destKey registration - log a warning if it already exists
 	if ok {
-		WarnfCtx(context.Background(), "destKey %s already exists in cbgtDestFactories - new value will replace the existing dest", destKey)
+		WarnfCtx(ctx, "destKey %s already exists in cbgtDestFactories - new value will replace the existing dest", destKey)
 	}
 	cbgtDestFactories[destKey] = dest
 	cbgtDestFactoriesLock.Unlock()

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -54,8 +54,8 @@ type CbgtContext struct {
 
 // StartShardedDCPFeed initializes and starts a CBGT Manager targeting the provided bucket.
 // dbName is used to define a unique path name for local file storage of pindex files
-func StartShardedDCPFeed(dbName string, configGroup string, uuid string, heartbeater Heartbeater, bucket Bucket, spec BucketSpec, numPartitions uint16, cfg cbgt.Cfg) (*CbgtContext, error) {
-	cbgtContext, err := initCBGTManager(bucket, spec, cfg, uuid, dbName)
+func StartShardedDCPFeed(ctx context.Context, dbName string, configGroup string, uuid string, heartbeater Heartbeater, bucket Bucket, spec BucketSpec, numPartitions uint16, cfg cbgt.Cfg) (*CbgtContext, error) {
+	cbgtContext, err := initCBGTManager(ctx, bucket, spec, cfg, uuid, dbName)
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +241,7 @@ func getCBGTIndexUUID(manager *cbgt.Manager, indexName string) (exists bool, pre
 // createCBGTManager creates a new manager for a given bucket and bucketSpec
 // Inline comments below provide additional detail on how cbgt uses each manager
 // parameter, and the implications for SG
-func initCBGTManager(bucket Bucket, spec BucketSpec, cfgSG cbgt.Cfg, dbUUID string, dbName string) (*CbgtContext, error) {
+func initCBGTManager(ctx context.Context, bucket Bucket, spec BucketSpec, cfgSG cbgt.Cfg, dbUUID string, dbName string) (*CbgtContext, error) {
 	// Check if there are pre-Helium nodes, and if so, set the LithiumCompat flag to ensure we don't try to start a
 	// collections-enabled feed when some nodes won't support it.
 	minVersion, err := getMinNodeVersion(cfgSG)
@@ -343,7 +343,7 @@ func initCBGTManager(bucket Bucket, spec BucketSpec, cfgSG cbgt.Cfg, dbUUID stri
 		options)
 
 	cbgtContext := &CbgtContext{
-		loggingCtx: LogContextWith(context.Background(), &LogContext{CorrelationID: MD(spec.BucketName).Redact() + "-" + DCPImportFeedID}),
+		loggingCtx: LogContextWith(ctx, &LogContext{CorrelationID: MD(spec.BucketName).Redact() + "-" + DCPImportFeedID}),
 		Manager:    mgr,
 		Cfg:        cfgSG,
 	}

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -150,8 +150,9 @@ func TestCBGTIndexCreation(t *testing.T) {
 			spec := bucket.BucketSpec
 
 			// Use an in-memory cfg, set up cbgt manager
+			ctx := LogContextWith(TestCtx(t), &DatabaseLogContext{DatabaseName: tc.dbName})
 			cfg := cbgt.NewCfgMem()
-			context, err := initCBGTManager(bucket, spec, cfg, "testIndexCreation", tc.dbName)
+			context, err := initCBGTManager(ctx, bucket, spec, cfg, "testIndexCreation", tc.dbName)
 			assert.NoError(t, err)
 			defer context.RemoveFeedCredentials(tc.dbName)
 
@@ -224,7 +225,7 @@ func TestCBGTIndexCreation(t *testing.T) {
 			}
 
 			// Create cbgt index via SG handling
-			err = createCBGTIndex(context, tc.dbName, configGroup, bucket, spec, 16)
+			err = createCBGTIndex(ctx, context, tc.dbName, configGroup, bucket, spec, 16)
 			require.NoError(t, err)
 
 			// Verify single index exists, and matches expected naming
@@ -253,8 +254,9 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 	testDbName := "testDB"
 
 	// Use an in-memory cfg, set up cbgt manager
+	ctx := TestCtx(t)
 	cfg := cbgt.NewCfgMem()
-	context, err := initCBGTManager(bucket, spec, cfg, "testIndexCreation", testDbName)
+	context, err := initCBGTManager(ctx, bucket, spec, cfg, "testIndexCreation", testDbName)
 	assert.NoError(t, err)
 	defer context.RemoveFeedCredentials(testDbName)
 
@@ -294,7 +296,7 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 	require.NoError(t, err, "Unable to create legacy-style index")
 
 	// Create cbgt index
-	err = createCBGTIndex(context, testDbName, configGroup, bucket, spec, 16)
+	err = createCBGTIndex(ctx, context, testDbName, configGroup, bucket, spec, 16)
 	require.NoError(t, err)
 
 	// Verify single index created
@@ -303,7 +305,7 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 	assert.Equal(t, 1, len(indexDefsMap))
 
 	// Attempt to recreate index
-	err = createCBGTIndex(context, testDbName, configGroup, bucket, spec, 16)
+	err = createCBGTIndex(ctx, context, testDbName, configGroup, bucket, spec, 16)
 	require.NoError(t, err)
 
 	// Verify single index defined (acts as upsert to existing)
@@ -329,8 +331,9 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 		"01234567890123456789012345678901234567890123456789"
 
 	// Use an in-memory cfg, set up cbgt manager
+	ctx := TestCtx(t)
 	cfg := cbgt.NewCfgMem()
-	context, err := initCBGTManager(bucket, spec, cfg, "testIndexCreation", unsafeTestDBName)
+	context, err := initCBGTManager(ctx, bucket, spec, cfg, "testIndexCreation", unsafeTestDBName)
 	assert.NoError(t, err)
 	defer context.RemoveFeedCredentials(unsafeTestDBName)
 
@@ -370,7 +373,7 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 	require.NoError(t, err, "Unable to create legacy-style index")
 
 	// Create cbgt index
-	err = createCBGTIndex(context, unsafeTestDBName, configGroup, bucket, spec, 16)
+	err = createCBGTIndex(ctx, context, unsafeTestDBName, configGroup, bucket, spec, 16)
 	require.NoError(t, err)
 
 	// Verify single index created
@@ -379,7 +382,7 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 	assert.Equal(t, 1, len(indexDefsMap))
 
 	// Attempt to recreate index
-	err = createCBGTIndex(context, unsafeTestDBName, configGroup, bucket, spec, 16)
+	err = createCBGTIndex(ctx, context, unsafeTestDBName, configGroup, bucket, spec, 16)
 	require.NoError(t, err)
 
 	// Verify single index defined (acts as upsert to existing)
@@ -426,13 +429,14 @@ func TestConcurrentCBGTIndexCreation(t *testing.T) {
 			// random sleep to hit race conditions that depend on initial creation
 			time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
 
+			ctx := TestCtx(t)
 			managerUUID := fmt.Sprintf("%s%d", t.Name(), i)
-			context, err := initCBGTManager(bucket, spec, cfg, managerUUID, testDBName)
+			context, err := initCBGTManager(ctx, bucket, spec, cfg, managerUUID, testDBName)
 			assert.NoError(t, err)
 
 			// StartManager starts the manager and creates the index
 			log.Printf("Starting manager for %s", managerUUID)
-			startErr := context.StartManager(testDBName, configGroup, bucket, spec, DefaultImportPartitions)
+			startErr := context.StartManager(ctx, testDBName, configGroup, bucket, spec, DefaultImportPartitions)
 			assert.NoError(t, startErr)
 
 			managerWg.Done()

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -344,25 +344,22 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 		eventHandlers,
 		options)
 	listener1, err := NewImportHeartbeatListener(&CbgtContext{
-		Cfg:        cfgCB,
-		Manager:    testManager,
-		loggingCtx: TestCtx(t),
+		Cfg:     cfgCB,
+		Manager: testManager,
 	})
 	assert.NoError(t, err)
 	assert.NoError(t, node1.RegisterListener(listener1))
 
 	listener2, err := NewImportHeartbeatListener(&CbgtContext{
-		Cfg:        cfgCB,
-		Manager:    testManager,
-		loggingCtx: TestCtx(t),
+		Cfg:     cfgCB,
+		Manager: testManager,
 	})
 	assert.NoError(t, err)
 	assert.NoError(t, node2.RegisterListener(listener2))
 
 	listener3, err := NewImportHeartbeatListener(&CbgtContext{
-		Cfg:        cfgCB,
-		Manager:    testManager,
-		loggingCtx: TestCtx(t),
+		Cfg:     cfgCB,
+		Manager: testManager,
 	})
 	assert.NoError(t, err)
 	assert.NoError(t, node3.RegisterListener(listener3))

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -117,6 +117,7 @@ func LogContextWith(parent context.Context, adder ContextAdder) context.Context 
 
 // ServerLogContext stores server context data for logging
 type ServerLogContext struct {
+	LogContextID string
 }
 
 func (c *ServerLogContext) getContextKey() LogContextKey {
@@ -124,7 +125,9 @@ func (c *ServerLogContext) getContextKey() LogContextKey {
 }
 
 func (c *ServerLogContext) addContext(format string) string {
-	// nothing to log for now
+	if c != nil && c.LogContextID != "" {
+		format = "sc:" + c.LogContextID + " " + format
+	}
 	return format
 }
 

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -117,7 +117,6 @@ func LogContextWith(parent context.Context, adder ContextAdder) context.Context 
 
 // ServerLogContext stores server context data for logging
 type ServerLogContext struct {
-	ConfigGroupID string
 }
 
 func (c *ServerLogContext) getContextKey() LogContextKey {
@@ -125,9 +124,7 @@ func (c *ServerLogContext) getContextKey() LogContextKey {
 }
 
 func (c *ServerLogContext) addContext(format string) string {
-	if c != nil && c.ConfigGroupID != "" {
-		format = "g:" + c.ConfigGroupID + " " + format
-	}
+	// nothing to log for now
 	return format
 }
 

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -53,7 +53,7 @@ func NewActiveReplicator(config *ActiveReplicatorConfig) *ActiveReplicator {
 		}
 	}
 
-	base.InfofCtx(config.ActiveDB.Ctx, base.KeyReplicate, "Created active replicator ID:%s statusKey: %s", config.ID, ar.statusKey)
+	base.InfofCtx(ar.Push.ctx, base.KeyReplicate, "Created active replicator ID:%s statusKey: %s", config.ID, ar.statusKey)
 	return ar
 }
 

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -213,7 +213,7 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 		}
 	}
 
-	bsc = NewBlipSyncContext(blipContext, arc.config.ActiveDB, blipContext.ID, arc.replicationStats)
+	bsc = NewBlipSyncContext(arc.ctx, blipContext, arc.config.ActiveDB, blipContext.ID, arc.replicationStats)
 	bsc.loggingCtx = base.LogContextWith(context.Background(), &base.LogContext{CorrelationID: arc.config.ID + idSuffix})
 
 	// NewBlipSyncContext has already set deltas as disabled/enabled based on config.ActiveDB.

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -32,7 +32,7 @@ type ActiveReplicator struct {
 }
 
 // NewActiveReplicator returns a bidirectional active replicator for the given config.
-func NewActiveReplicator(config *ActiveReplicatorConfig) *ActiveReplicator {
+func NewActiveReplicator(ctx context.Context, config *ActiveReplicatorConfig) *ActiveReplicator {
 	ar := &ActiveReplicator{
 		ID:        config.ID,
 		config:    config,
@@ -53,11 +53,11 @@ func NewActiveReplicator(config *ActiveReplicatorConfig) *ActiveReplicator {
 		}
 	}
 
-	base.InfofCtx(ar.Push.ctx, base.KeyReplicate, "Created active replicator ID:%s statusKey: %s", config.ID, ar.statusKey)
+	base.InfofCtx(ctx, base.KeyReplicate, "Created active replicator ID:%s statusKey: %s", config.ID, ar.statusKey)
 	return ar
 }
 
-func (ar *ActiveReplicator) Start() error {
+func (ar *ActiveReplicator) Start(ctx context.Context) error {
 
 	if ar.Push == nil && ar.Pull == nil {
 		return fmt.Errorf("Attempted to start activeReplicator for %s with neither Push nor Pull defined", base.UD(ar.ID))
@@ -65,12 +65,12 @@ func (ar *ActiveReplicator) Start() error {
 
 	var pushErr error
 	if ar.Push != nil {
-		pushErr = ar.Push.Start()
+		pushErr = ar.Push.Start(ctx)
 	}
 
 	var pullErr error
 	if ar.Pull != nil {
-		pullErr = ar.Pull.Start()
+		pullErr = ar.Pull.Start(ctx)
 	}
 
 	if pushErr != nil {

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -677,12 +677,12 @@ func getLocalCheckpoint(db *DatabaseContext, clientID string) (*replicationCheck
 
 // setLocalCheckpointStatus updates status in a replication checkpoint without a checkpointer.  Increments existing
 // rev, preserves non-status fields (seq)
-func setLocalCheckpointStatus(db *Database, clientID string, status string, errorMessage string) {
+func setLocalCheckpointStatus(ctx context.Context, db *Database, clientID string, status string, errorMessage string) {
 
 	// getCheckpoint to obtain the current rev
 	checkpoint, err := getLocalCheckpoint(db.DatabaseContext, clientID)
 	if err != nil {
-		base.WarnfCtx(db.Ctx, "Unable to retrieve local checkpoint for %s, status not updated", clientID)
+		base.WarnfCtx(ctx, "Unable to retrieve local checkpoint for %s, status not updated", clientID)
 		return
 	}
 	if checkpoint == nil {
@@ -695,12 +695,12 @@ func setLocalCheckpointStatus(db *Database, clientID string, status string, erro
 
 	checkpoint.Status.Status = status
 	checkpoint.Status.ErrorMessage = errorMessage
-	base.TracefCtx(db.Ctx, base.KeyReplicate, "setLocalCheckpoint(%v)", checkpoint)
+	base.TracefCtx(ctx, base.KeyReplicate, "setLocalCheckpoint(%v)", checkpoint)
 	newRev, putErr := db.putSpecial(DocTypeLocal, CheckpointDocIDPrefix+clientID, checkpoint.Rev, checkpoint.AsBody())
 	if putErr != nil {
-		base.WarnfCtx(db.Ctx, "Unable to persist status in local checkpoint for %s, status not updated: %v", clientID, putErr)
+		base.WarnfCtx(ctx, "Unable to persist status in local checkpoint for %s, status not updated: %v", clientID, putErr)
 	} else {
-		base.TracefCtx(db.Ctx, base.KeyReplicate, "setLocalCheckpointStatus successful for %s, newRev: %s: %+v %+v", clientID, newRev, checkpoint, checkpoint.Status)
+		base.TracefCtx(ctx, base.KeyReplicate, "setLocalCheckpointStatus successful for %s, newRev: %s: %+v %+v", clientID, newRev, checkpoint, checkpoint.Status)
 	}
 	return
 }

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -267,7 +267,7 @@ func (a *activeReplicatorCommon) _publishStatus() {
 	if a.Checkpointer != nil {
 		a.Checkpointer.setLocalCheckpointStatus(status, errorMessage)
 	} else {
-		setLocalCheckpointStatus(a.config.ActiveDB, a.CheckpointID, status, errorMessage)
+		setLocalCheckpointStatus(a.ctx, a.config.ActiveDB, a.CheckpointID, status, errorMessage)
 	}
 
 }

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -31,7 +31,7 @@ func NewPullReplicator(config *ActiveReplicatorConfig) *ActivePullReplicator {
 	return &apr
 }
 
-func (apr *ActivePullReplicator) Start() error {
+func (apr *ActivePullReplicator) Start(ctx context.Context) error {
 	apr.lock.Lock()
 	defer apr.lock.Unlock()
 
@@ -44,7 +44,7 @@ func (apr *ActivePullReplicator) Start() error {
 	}
 
 	apr.setState(ReplicationStateStarting)
-	logCtx := base.LogContextWith(context.Background(), &base.LogContext{CorrelationID: apr.config.ID + "-" + string(ActiveReplicatorTypePull)})
+	logCtx := base.LogContextWith(ctx, &base.LogContext{CorrelationID: apr.config.ID + "-" + string(ActiveReplicatorTypePull)})
 	apr.ctx, apr.ctxCancel = context.WithCancel(logCtx)
 
 	err := apr._connect()

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -104,7 +104,7 @@ func (apr *ActivePullReplicator) _connect() error {
 	apr.setState(ReplicationStateRunning)
 
 	if apr.blipSyncContext.blipContext.ActiveSubprotocol() == BlipCBMobileReplicationV2 && apr.config.PurgeOnRemoval {
-		base.ErrorfCtx(apr.config.ActiveDB.Ctx, "Pull replicator ID:%s running with revocations enabled but target does not support revocations. Sync Gateway 3.0 required.", apr.config.ID)
+		base.ErrorfCtx(apr.ctx, "Pull replicator ID:%s running with revocations enabled but target does not support revocations. Sync Gateway 3.0 required.", apr.config.ID)
 	}
 
 	return nil

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -35,7 +35,7 @@ func NewPushReplicator(config *ActiveReplicatorConfig) *ActivePushReplicator {
 	return &apr
 }
 
-func (apr *ActivePushReplicator) Start() error {
+func (apr *ActivePushReplicator) Start(ctx context.Context) error {
 	apr.lock.Lock()
 	defer apr.lock.Unlock()
 
@@ -48,7 +48,7 @@ func (apr *ActivePushReplicator) Start() error {
 	}
 
 	apr.setState(ReplicationStateStarting)
-	logCtx := base.LogContextWith(context.Background(), &base.LogContext{CorrelationID: apr.config.ID + "-" + string(ActiveReplicatorTypePush)})
+	logCtx := base.LogContextWith(ctx, &base.LogContext{CorrelationID: apr.config.ID + "-" + string(ActiveReplicatorTypePush)})
 	apr.ctx, apr.ctxCancel = context.WithCancel(logCtx)
 
 	err := apr._connect()

--- a/db/attachment.go
+++ b/db/attachment.go
@@ -63,7 +63,7 @@ const maxAttachmentSizeBytes = 20 * 1024 * 1024
 // Given Attachments Meta to be stored in the database, storeAttachments goes through the map, finds attachments with
 // inline bodies, copies the bodies into the Couchbase db, and replaces the bodies with the 'digest' attributes which
 // are the keys to retrieving them.
-func (db *Database) storeAttachments(doc *Document, newAttachmentsMeta AttachmentsMeta, generation int, parentRev string, docHistory []string) (AttachmentData, error) {
+func (db *Database) storeAttachments(ctx context.Context, doc *Document, newAttachmentsMeta AttachmentsMeta, generation int, parentRev string, docHistory []string) (AttachmentData, error) {
 	if len(newAttachmentsMeta) == 0 {
 		return nil, nil
 	}
@@ -114,7 +114,7 @@ func (db *Database) storeAttachments(doc *Document, newAttachmentsMeta Attachmen
 			}
 			// Try to look up the attachment in ancestor attachments
 			if parentAttachments == nil {
-				parentAttachments = db.retrieveAncestorAttachments(doc, parentRev, docHistory)
+				parentAttachments = db.retrieveAncestorAttachments(ctx, doc, parentRev, docHistory)
 			}
 
 			// Note: in a non-conflict CAS retry, parentAttachments may be nil, because the attachment
@@ -159,10 +159,10 @@ func retrieveV2AttachmentKeys(docID string, docAttachments AttachmentsMeta) (att
 // Attempts to retrieve ancestor attachments for a document. First attempts to find and use a non-pruned ancestor.
 // If no non-pruned ancestor is available, checks whether the currently active doc has a common ancestor with the new revision.
 // If it does, can use the attachments on the active revision with revpos earlier than that common ancestor.
-func (db *Database) retrieveAncestorAttachments(doc *Document, parentRev string, docHistory []string) map[string]interface{} {
+func (db *Database) retrieveAncestorAttachments(ctx context.Context, doc *Document, parentRev string, docHistory []string) map[string]interface{} {
 
 	// Attempt to find a non-pruned parent or ancestor
-	if ancestorAttachments, foundAncestor := db.getAvailableRevAttachments(doc, parentRev); foundAncestor {
+	if ancestorAttachments, foundAncestor := db.getAvailableRevAttachments(ctx, doc, parentRev); foundAncestor {
 		return ancestorAttachments
 	}
 
@@ -236,15 +236,15 @@ func (db *Database) GetAttachment(key string) ([]byte, error) {
 }
 
 // Stores a base64-encoded attachment and returns the key to get it by.
-func (db *Database) setAttachment(key string, value []byte) error {
+func (db *Database) setAttachment(ctx context.Context, key string, value []byte) error {
 	_, err := db.Bucket.AddRaw(key, 0, value)
 	if err == nil {
-		base.InfofCtx(db.Ctx, base.KeyCRUD, "\tAdded attachment %q", base.UD(key))
+		base.InfofCtx(ctx, base.KeyCRUD, "\tAdded attachment %q", base.UD(key))
 	}
 	return err
 }
 
-func (db *Database) setAttachments(attachments AttachmentData) error {
+func (db *Database) setAttachments(ctx context.Context, attachments AttachmentData) error {
 	for key, data := range attachments {
 		attachmentSize := int64(len(data))
 		if attachmentSize > int64(maxAttachmentSizeBytes) {
@@ -252,7 +252,7 @@ func (db *Database) setAttachments(attachments AttachmentData) error {
 		}
 		_, err := db.Bucket.AddRaw(key, 0, data)
 		if err == nil {
-			base.InfofCtx(db.Ctx, base.KeyCRUD, "\tAdded attachment %q", base.UD(key))
+			base.InfofCtx(ctx, base.KeyCRUD, "\tAdded attachment %q", base.UD(key))
 			db.DbStats.CBLReplicationPush().AttachmentPushCount.Add(1)
 			db.DbStats.CBLReplicationPush().AttachmentPushBytes.Add(attachmentSize)
 		} else {

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -20,7 +20,8 @@ func TestAttachmentMark(t *testing.T) {
 	}
 
 	testDb := setupTestDB(t)
-	defer testDb.Close()
+	ctx := testDb.AddDatabaseLogContext(base.TestCtx(t))
+	defer testDb.Close(ctx)
 
 	body := map[string]interface{}{"foo": "bar"}
 	for i := 0; i < 10; i++ {
@@ -71,7 +72,8 @@ func TestAttachmentSweep(t *testing.T) {
 	}
 
 	testDb := setupTestDB(t)
-	defer testDb.Close()
+	ctx := testDb.AddDatabaseLogContext(base.TestCtx(t))
+	defer testDb.Close(ctx)
 
 	makeMarkedDoc := func(docid string, compactID string) {
 		err := testDb.Bucket.SetRaw(docid, 0, nil, []byte("{}"))
@@ -116,7 +118,8 @@ func TestAttachmentCleanup(t *testing.T) {
 	}
 
 	testDb := setupTestDB(t)
-	defer testDb.Close()
+	ctx := testDb.AddDatabaseLogContext(base.TestCtx(t))
+	defer testDb.Close(ctx)
 
 	makeMarkedDoc := func(docid string, compactID string) {
 		err := testDb.Bucket.SetRaw(docid, 0, nil, []byte("{}"))
@@ -220,7 +223,8 @@ func TestAttachmentMarkAndSweepAndCleanup(t *testing.T) {
 	}
 
 	testDb := setupTestDB(t)
-	defer testDb.Close()
+	ctx := testDb.AddDatabaseLogContext(base.TestCtx(t))
+	defer testDb.Close(ctx)
 
 	attKeys := make([]string, 0, 15)
 	for i := 0; i < 10; i++ {
@@ -291,10 +295,12 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 	defer b.Close()
 
 	testDB1 := setupTestDBForBucket(t, b)
-	defer testDB1.Close()
+	ctx1 := testDB1.AddDatabaseLogContext(base.TestCtx(t))
+	defer testDB1.Close(ctx1)
 
 	testDB2 := setupTestDBForBucket(t, b.NoCloseClone())
-	defer testDB2.Close()
+	ctx2 := testDB2.AddDatabaseLogContext(base.TestCtx(t))
+	defer testDB2.Close(ctx2)
 
 	var err error
 
@@ -436,10 +442,12 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 	defer b.Close()
 
 	testDB1 := setupTestDBForBucket(t, b)
-	defer testDB1.Close()
+	ctx1 := testDB1.AddDatabaseLogContext(base.TestCtx(t))
+	defer testDB1.Close(ctx1)
 
 	testDB2 := setupTestDBForBucket(t, b.NoCloseClone())
-	defer testDB2.Close()
+	ctx2 := testDB2.AddDatabaseLogContext(base.TestCtx(t))
+	defer testDB2.Close(ctx2)
 
 	var err error
 
@@ -542,7 +550,8 @@ func TestAttachmentProcessError(t *testing.T) {
 	defer b.Close()
 
 	testDB1 := setupTestDBForBucket(t, b)
-	defer testDB1.Close()
+	ctx1 := testDB1.AddDatabaseLogContext(base.TestCtx(t))
+	defer testDB1.Close(ctx1)
 
 	CreateLegacyAttachmentDoc(t, testDB1, "docID", []byte("{}"), "attKey", []byte("{}"))
 
@@ -573,7 +582,8 @@ func TestAttachmentDifferentVBUUIDsBetweenPhases(t *testing.T) {
 	}
 
 	testDB := setupTestDB(t)
-	defer testDB.Close()
+	ctx1 := testDB.AddDatabaseLogContext(base.TestCtx(t))
+	defer testDB.Close(ctx1)
 
 	// Run mark phase as usual
 	terminator := base.NewSafeTerminator()
@@ -816,7 +826,8 @@ func TestAttachmentCompactIncorrectStat(t *testing.T) {
 	}
 
 	testDb := setupTestDB(t)
-	defer testDb.Close()
+	ctx1 := testDb.AddDatabaseLogContext(base.TestCtx(t))
+	defer testDb.Close(ctx1)
 	// Create the docs that will be marked and not swept
 	body := map[string]interface{}{"foo": "bar"}
 	for i := 0; i < docsToCreate; i++ {

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -311,7 +311,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 	triggerStopCallback := false
 	leakyBucket.SetGetRawCallback(func(s string) error {
 		if triggerCallback {
-			err = testDB2.AttachmentCompactionManager.Start(map[string]interface{}{"database": testDB2})
+			err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]interface{}{"database": testDB2})
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "Process already running")
 			triggerCallback = false
@@ -326,7 +326,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 
 	// Trigger start with immediate abort. Then resume, ensure that dry run is resumed
 	triggerStopCallback = true
-	err = testDB2.AttachmentCompactionManager.Start(map[string]interface{}{"database": testDB2, "dryRun": true})
+	err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]interface{}{"database": testDB2, "dryRun": true})
 	assert.NoError(t, err)
 
 	err = WaitForConditionWithOptions(func() bool {
@@ -351,7 +351,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, testStatus.DryRun)
 
-	err = testDB2.AttachmentCompactionManager.Start(map[string]interface{}{"database": testDB2, "dryRun": false})
+	err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]interface{}{"database": testDB2, "dryRun": false})
 	assert.NoError(t, err)
 
 	err = WaitForConditionWithOptions(func() bool {
@@ -377,7 +377,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 
 	// Trigger start with immediate stop (stopped from db2)
 	triggerStopCallback = true
-	err = testDB1.AttachmentCompactionManager.Start(map[string]interface{}{"database": testDB1})
+	err = testDB1.AttachmentCompactionManager.Start(ctx1, map[string]interface{}{"database": testDB1})
 	assert.NoError(t, err)
 
 	err = WaitForConditionWithOptions(func() bool {
@@ -396,7 +396,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 
 	// Kick off another run with an attempted start from the other node, checks for error on other node
 	triggerCallback = true
-	err = testDB1.AttachmentCompactionManager.Start(map[string]interface{}{"database": testDB1})
+	err = testDB1.AttachmentCompactionManager.Start(ctx1, map[string]interface{}{"database": testDB1})
 	assert.NoError(t, err)
 
 	err = WaitForConditionWithOptions(func() bool {
@@ -458,7 +458,7 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 	triggerStopCallback := false
 	leakyBucket.SetGetRawCallback(func(s string) error {
 		if triggerCallback {
-			err = testDB2.AttachmentCompactionManager.Start(map[string]interface{}{"database": testDB2})
+			err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]interface{}{"database": testDB2})
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "Process already running")
 			triggerCallback = false
@@ -473,7 +473,7 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 
 	// Trigger start with immediate abort. Then resume, ensure that dry run is resumed
 	triggerStopCallback = true
-	err = testDB2.AttachmentCompactionManager.Start(map[string]interface{}{"database": testDB2, "dryRun": true})
+	err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]interface{}{"database": testDB2, "dryRun": true})
 	assert.NoError(t, err)
 
 	err = WaitForConditionWithOptions(func() bool {
@@ -498,7 +498,7 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, testStatus.DryRun)
 
-	err = testDB2.AttachmentCompactionManager.Start(map[string]interface{}{"database": testDB2, "dryRun": false})
+	err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]interface{}{"database": testDB2, "dryRun": false})
 	assert.NoError(t, err)
 
 	err = WaitForConditionWithOptions(func() bool {
@@ -524,15 +524,15 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 
 	// Trigger start with immediate stop (stopped from db2)
 	triggerStopCallback = true
-	err = testDB1.AttachmentCompactionManager.Start(map[string]interface{}{"database": testDB1})
+	err = testDB1.AttachmentCompactionManager.Start(ctx1, map[string]interface{}{"database": testDB1})
 	assert.NoError(t, err)
 
 	// Kick off another run with an attempted start, verify we don't get 'process already running' error
-	err = testDB1.AttachmentCompactionManager.Start(map[string]interface{}{"database": testDB1})
+	err = testDB1.AttachmentCompactionManager.Start(ctx1, map[string]interface{}{"database": testDB1})
 	// Hitting this error may be racy (depending on when heartbeat is polled from previous stop), but we should never
 	// get a 'process already running' error
 	if err != nil {
-		err = testDB2.AttachmentCompactionManager.Start(map[string]interface{}{"database": testDB2})
+		err = testDB2.AttachmentCompactionManager.Start(ctx2, map[string]interface{}{"database": testDB2})
 		assert.NotContains(t, err.Error(), "Process already running")
 	}
 }
@@ -555,7 +555,7 @@ func TestAttachmentProcessError(t *testing.T) {
 
 	CreateLegacyAttachmentDoc(t, testDB1, "docID", []byte("{}"), "attKey", []byte("{}"))
 
-	err := testDB1.AttachmentCompactionManager.Start(map[string]interface{}{"database": testDB1})
+	err := testDB1.AttachmentCompactionManager.Start(ctx1, map[string]interface{}{"database": testDB1})
 	assert.NoError(t, err)
 
 	var status AttachmentManagerResponse

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -331,8 +331,7 @@ func TestAttachmentCASRetryAfterNewAttachment(t *testing.T) {
 		UpdateCallback: writeUpdateCallback,
 	}
 
-	db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
-	ctx = db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
 	defer db.Close(ctx)
 
 	// Test creating & updating a document:
@@ -392,8 +391,7 @@ func TestAttachmentCASRetryDuringNewAttachment(t *testing.T) {
 		UpdateCallback: writeUpdateCallback,
 	}
 
-	db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
-	ctx = db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
 	defer db.Close(ctx)
 
 	// Test creating & updating a document:

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -330,7 +330,8 @@ func TestAttachmentCASRetryAfterNewAttachment(t *testing.T) {
 	}
 
 	db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	// Test creating & updating a document:
 
@@ -389,7 +390,8 @@ func TestAttachmentCASRetryDuringNewAttachment(t *testing.T) {
 	}
 
 	db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	// Test creating & updating a document:
 
@@ -887,7 +889,8 @@ func TestMigrateBodyAttachments(t *testing.T) {
 	// Reading the active rev of a doc containing pre 2.5 meta. Make sure the rev ID is not changed, and the metadata is appearing in syncData.
 	t.Run("2.1 meta, read active rev", func(t *testing.T) {
 		db := setupFn(t)
-		defer db.Close()
+		ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+		defer db.Close(ctx)
 
 		rev, err := db.GetRev(docKey, "", true, nil)
 		require.NoError(t, err)
@@ -916,7 +919,8 @@ func TestMigrateBodyAttachments(t *testing.T) {
 	// Reading a non-active revision shouldn't perform an upgrade, but should transform the metadata in memory for the returned rev.
 	t.Run("2.1 meta, read non-active rev", func(t *testing.T) {
 		db := setupFn(t)
-		defer db.Close()
+		ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+		defer db.Close(ctx)
 
 		rev, err := db.GetRev(docKey, "3-a", true, nil)
 		require.NoError(t, err)
@@ -945,7 +949,8 @@ func TestMigrateBodyAttachments(t *testing.T) {
 	// Writing a new rev should migrate the metadata and write that upgrade back to the bucket.
 	t.Run("2.1 meta, write new rev", func(t *testing.T) {
 		db := setupFn(t)
-		defer db.Close()
+		ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+		defer db.Close(ctx)
 
 		// Update the doc with a the same body as rev 3-a, and make sure attachments are migrated.
 		newBody := Body{
@@ -988,7 +993,8 @@ func TestMigrateBodyAttachments(t *testing.T) {
 	// Adding a new attachment should migrate existing attachments, without losing any.
 	t.Run("2.1 meta, add new attachment", func(t *testing.T) {
 		db := setupFn(t)
-		defer db.Close()
+		ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+		defer db.Close(ctx)
 
 		rev, err := db.GetRev(docKey, "3-a", true, nil)
 		require.NoError(t, err)

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -86,7 +86,7 @@ type BackgroundManagerStatus struct {
 // BackgroundManagerProcessI is an interface satisfied by any of the background processes
 // Examples of this: ReSync, Compaction
 type BackgroundManagerProcessI interface {
-	Init(options map[string]interface{}, clusterStatus []byte) error
+	Init(ctx context.Context, options map[string]interface{}, clusterStatus []byte) error
 	Run(ctx context.Context, options map[string]interface{}, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error
 	GetProcessStatus(status BackgroundManagerStatus) (statusOut []byte, meta []byte, err error)
 	ResetStatus()
@@ -111,7 +111,7 @@ func (b *BackgroundManager) Start(ctx context.Context, options map[string]interf
 	b.resetStatus()
 	b.StartTime = time.Now().UTC()
 
-	err = b.Process.Init(options, processClusterStatus)
+	err = b.Process.Init(ctx, options, processClusterStatus)
 	if err != nil {
 		return err
 	}

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -87,20 +87,19 @@ type BackgroundManagerStatus struct {
 // Examples of this: ReSync, Compaction
 type BackgroundManagerProcessI interface {
 	Init(options map[string]interface{}, clusterStatus []byte) error
-	Run(options map[string]interface{}, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error
+	Run(ctx context.Context, options map[string]interface{}, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error
 	GetProcessStatus(status BackgroundManagerStatus) (statusOut []byte, meta []byte, err error)
 	ResetStatus()
 }
 
 type updateStatusCallbackFunc func() error
 
-func (b *BackgroundManager) Start(options map[string]interface{}) error {
+func (b *BackgroundManager) Start(ctx context.Context, options map[string]interface{}) error {
 	err := b.markStart()
 	if err != nil {
 		return err
 	}
 
-	logCtx := context.TODO()
 	var processClusterStatus []byte
 	if b.isClusterAware() {
 		processClusterStatus, _, err = b.clusterAwareOptions.bucket.GetRaw(b.clusterAwareOptions.StatusDocID())
@@ -127,7 +126,7 @@ func (b *BackgroundManager) Start(options map[string]interface{}) error {
 				case <-ticker.C:
 					err = b.UpdateStatusClusterAware()
 					if err != nil {
-						base.WarnfCtx(logCtx, "Failed to update background manager status: %v", err)
+						base.WarnfCtx(ctx, "Failed to update background manager status: %v", err)
 					}
 				case <-terminator.Done():
 					ticker.Stop()
@@ -138,9 +137,9 @@ func (b *BackgroundManager) Start(options map[string]interface{}) error {
 	}
 
 	go func() {
-		err := b.Process.Run(options, b.UpdateStatusClusterAware, b.terminator)
+		err := b.Process.Run(ctx, options, b.UpdateStatusClusterAware, b.terminator)
 		if err != nil {
-			base.ErrorfCtx(logCtx, "Error: %v", err)
+			base.ErrorfCtx(ctx, "Error: %v", err)
 			b.SetError(err)
 		}
 
@@ -159,7 +158,7 @@ func (b *BackgroundManager) Start(options map[string]interface{}) error {
 		if b.isClusterAware() {
 			err = b.UpdateStatusClusterAware()
 			if err != nil {
-				base.WarnfCtx(logCtx, "Failed to update background manager status: %v", err)
+				base.WarnfCtx(ctx, "Failed to update background manager status: %v", err)
 			}
 
 			// Delete the heartbeat doc to allow another process to run
@@ -171,7 +170,7 @@ func (b *BackgroundManager) Start(options map[string]interface{}) error {
 	if b.isClusterAware() {
 		err = b.UpdateStatusClusterAware()
 		if err != nil {
-			base.ErrorfCtx(logCtx, "Failed to update background manager status: %v", err)
+			base.ErrorfCtx(ctx, "Failed to update background manager status: %v", err)
 		}
 	}
 

--- a/db/background_mgr_tombstone_compaction.go
+++ b/db/background_mgr_tombstone_compaction.go
@@ -9,6 +9,7 @@
 package db
 
 import (
+	"context"
 	"sync/atomic"
 	"time"
 
@@ -39,7 +40,7 @@ func (t *TombstoneCompactionManager) Init(options map[string]interface{}, cluste
 	return nil
 }
 
-func (t *TombstoneCompactionManager) Run(options map[string]interface{}, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
+func (t *TombstoneCompactionManager) Run(ctx context.Context, options map[string]interface{}, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
 	database := options["database"].(*Database)
 
 	defer atomic.CompareAndSwapUint32(&database.CompactState, DBCompactRunning, DBCompactNotRunning)
@@ -47,7 +48,7 @@ func (t *TombstoneCompactionManager) Run(options map[string]interface{}, persist
 		atomic.StoreInt64(&t.PurgedDocCount, int64(*docsPurged))
 	}
 
-	_, err := database.Compact(true, callback, terminator)
+	_, err := database.Compact(ctx, true, callback, terminator)
 	if err != nil {
 		return err
 	}

--- a/db/background_mgr_tombstone_compaction.go
+++ b/db/background_mgr_tombstone_compaction.go
@@ -33,7 +33,7 @@ func NewTombstoneCompactionManager() *BackgroundManager {
 	}
 }
 
-func (t *TombstoneCompactionManager) Init(options map[string]interface{}, clusterStatus []byte) error {
+func (t *TombstoneCompactionManager) Init(ctx context.Context, options map[string]interface{}, clusterStatus []byte) error {
 	database := options["database"].(*Database)
 	database.DbStats.Database().CompactionAttachmentStartTime.Set(time.Now().UTC().Unix())
 

--- a/db/blip_connected_client.go
+++ b/db/blip_connected_client.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -89,8 +90,8 @@ func (bh *blipHandler) handleFunction(rq *blip.Message) error {
 		return err
 	}
 	bh.logEndpointEntry(rq.Profile(), fmt.Sprintf("name: %s", name))
-	return bh.db.WithTimeout(UserQueryTimeout, func() error {
-		results, err := bh.db.CallUserFunction(name, requestParams, true)
+	return bh.db.WithTimeout(bh.changesCtx, UserQueryTimeout, func(ctx context.Context) error {
+		results, err := bh.db.CallUserFunction(ctx, name, requestParams, true)
 		if err != nil {
 			return base.HTTPErrorf(http.StatusInternalServerError, "Error running function: %v", err)
 		}
@@ -113,9 +114,9 @@ func (bh *blipHandler) handleQuery(rq *blip.Message) error {
 	}
 	bh.logEndpointEntry(rq.Profile(), fmt.Sprintf("name: %s", name))
 
-	return bh.db.WithTimeout(UserQueryTimeout, func() error {
+	return bh.db.WithTimeout(bh.changesCtx, UserQueryTimeout, func(ctx context.Context) error {
 		// Run the query:
-		results, err := bh.db.UserN1QLQuery(name, requestParams)
+		results, err := bh.db.UserN1QLQuery(ctx, name, requestParams)
 		if err != nil {
 			return err
 		}
@@ -128,7 +129,7 @@ func (bh *blipHandler) handleQuery(rq *blip.Message) error {
 			if err = enc.Encode(row); err != nil { // always ends with a newline
 				return err
 			}
-			if err = bh.db.CheckTimeout(); err != nil {
+			if err = bh.db.CheckTimeout(ctx); err != nil {
 				return err
 			}
 		}
@@ -166,8 +167,8 @@ func (bh *blipHandler) handleGraphQL(rq *blip.Message) error {
 	}
 
 	bh.logEndpointEntry(rq.Profile(), fmt.Sprintf("query: %s", query))
-	return bh.db.WithTimeout(UserQueryTimeout, func() error {
-		result, err := bh.db.UserGraphQLQuery(query, operationName, variables, true)
+	return bh.db.WithTimeout(bh.changesCtx, UserQueryTimeout, func(ctx context.Context) error {
+		result, err := bh.db.UserGraphQLQuery(ctx, query, operationName, variables, true)
 		if err != nil {
 			return err
 		}

--- a/db/blip_connected_client.go
+++ b/db/blip_connected_client.go
@@ -90,7 +90,7 @@ func (bh *blipHandler) handleFunction(rq *blip.Message) error {
 		return err
 	}
 	bh.logEndpointEntry(rq.Profile(), fmt.Sprintf("name: %s", name))
-	return bh.db.WithTimeout(bh.changesCtx, UserQueryTimeout, func(ctx context.Context) error {
+	return bh.db.WithTimeout(bh.loggingCtx, UserQueryTimeout, func(ctx context.Context) error {
 		results, err := bh.db.CallUserFunction(ctx, name, requestParams, true)
 		if err != nil {
 			return base.HTTPErrorf(http.StatusInternalServerError, "Error running function: %v", err)
@@ -114,7 +114,7 @@ func (bh *blipHandler) handleQuery(rq *blip.Message) error {
 	}
 	bh.logEndpointEntry(rq.Profile(), fmt.Sprintf("name: %s", name))
 
-	return bh.db.WithTimeout(bh.changesCtx, UserQueryTimeout, func(ctx context.Context) error {
+	return bh.db.WithTimeout(bh.loggingCtx, UserQueryTimeout, func(ctx context.Context) error {
 		// Run the query:
 		results, err := bh.db.UserN1QLQuery(ctx, name, requestParams)
 		if err != nil {
@@ -167,7 +167,7 @@ func (bh *blipHandler) handleGraphQL(rq *blip.Message) error {
 	}
 
 	bh.logEndpointEntry(rq.Profile(), fmt.Sprintf("query: %s", query))
-	return bh.db.WithTimeout(bh.changesCtx, UserQueryTimeout, func(ctx context.Context) error {
+	return bh.db.WithTimeout(bh.loggingCtx, UserQueryTimeout, func(ctx context.Context) error {
 		result, err := bh.db.UserGraphQLQuery(ctx, query, operationName, variables, true)
 		if err != nil {
 			return err

--- a/db/blip_connected_client.go
+++ b/db/blip_connected_client.go
@@ -27,7 +27,7 @@ func (bh *blipHandler) handleGetRev(rq *blip.Message) error {
 	docID := rq.Properties[GetRevMessageId]
 	ifNotRev := rq.Properties[GetRevIfNotRev]
 
-	rev, err := bh.collection.GetRev(docID, "", false, nil)
+	rev, err := bh.collection.GetRev(bh.loggingCtx, docID, "", false, nil)
 	if err != nil {
 		status, reason := base.ErrorAsHTTPStatus(err)
 		return &base.HTTPError{Status: status, Message: reason}

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -388,7 +388,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 	// Create a distinct database instance for changes, to avoid races between reloadUser invocation in changes.go
 	// and BlipSyncContext user access.
 	changesDb := bh.copyContextDatabase()
-	_, forceClose := generateBlipSyncChanges(changesDb, channelSet, options, opts.docIDs, func(changes []*ChangeEntry) error {
+	_, forceClose := generateBlipSyncChanges(bh.loggingCtx, changesDb, channelSet, options, opts.docIDs, func(changes []*ChangeEntry) error {
 		base.DebugfCtx(bh.loggingCtx, base.KeySync, "    Sending %d changes", len(changes))
 		for _, change := range changes {
 			if !strings.HasPrefix(change.ID, "_") {
@@ -405,7 +405,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 						}
 
 						// If the user has access to the doc through another channel don't send change
-						userHasAccessToDoc, err := UserHasDocAccess(bh.collection, change.ID, item["rev"])
+						userHasAccessToDoc, err := UserHasDocAccess(bh.loggingCtx, bh.collection, change.ID, item["rev"])
 						if err == nil && userHasAccessToDoc {
 							continue
 						}

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -599,7 +599,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 	for _, change := range changeList {
 		docID := change[1].(string)
 		revID := change[2].(string)
-		missing, possible := bh.collection.RevDiff(docID, []string{revID})
+		missing, possible := bh.collection.RevDiff(bh.loggingCtx, docID, []string{revID})
 		if nWritten > 0 {
 			output.Write([]byte(","))
 		}
@@ -625,7 +625,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 
 		if bh.purgeOnRemoval && bh.blipContext.ActiveSubprotocol() == BlipCBMobileReplicationV3 &&
 			(deletedFlags.HasFlag(changesDeletedFlagRevoked) || deletedFlags.HasFlag(changesDeletedFlagRemoved)) {
-			err := bh.collection.Purge(docID)
+			err := bh.collection.Purge(bh.loggingCtx, docID)
 			if err != nil {
 				base.WarnfCtx(bh.loggingCtx, "Failed to purge document: %v", err)
 			}
@@ -724,7 +724,7 @@ func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 		if len(change) > 2 {
 			parentRevID = change[2].(string)
 		}
-		status, currentRev := bh.collection.CheckProposedRev(docID, revID, parentRevID)
+		status, currentRev := bh.collection.CheckProposedRev(bh.loggingCtx, docID, revID, parentRevID)
 		if status != 0 {
 			// Skip writing trailing zeroes; but if we write a number afterwards we have to catch up
 			if nWritten > 0 {
@@ -769,7 +769,7 @@ func (bsc *BlipSyncContext) sendRevAsDelta(sender *blip.Sender, docID, revID str
 
 	bsc.replicationStats.SendRevDeltaRequestedCount.Add(1)
 
-	revDelta, redactedRev, err := handleChangesResponseDb.GetDelta(docID, deltaSrcRevID, revID)
+	revDelta, redactedRev, err := handleChangesResponseDb.GetDelta(bsc.loggingCtx, docID, deltaSrcRevID, revID)
 	if err == ErrForbidden { // nolint: gocritic // can't convert if/else if to switch since base.IsFleeceDeltaError is not switchable
 		return err
 	} else if base.IsFleeceDeltaError(err) {
@@ -885,7 +885,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		}
 		if removed, ok := body[BodyRemoved].(bool); ok && removed {
 			base.InfofCtx(bh.loggingCtx, base.KeySync, "Purging doc %v - removed at rev %v", base.UD(docID), revID)
-			if err := bh.collection.Purge(docID); err != nil {
+			if err := bh.collection.Purge(bh.loggingCtx, docID); err != nil {
 				return err
 			}
 			stats.docsPurgedCount.Add(1)
@@ -918,7 +918,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		//       while retrieving deltaSrcRevID.  Couchbase Lite replication guarantees client has access to deltaSrcRevID,
 		//       due to no-conflict write restriction, but we still need to enforce security here to prevent leaking data about previous
 		//       revisions to malicious actors (in the scenario where that user has write but not read access).
-		deltaSrcRev, err := bh.collection.GetRev(docID, deltaSrcRevID, false, nil)
+		deltaSrcRev, err := bh.collection.GetRev(bh.loggingCtx, docID, deltaSrcRevID, false, nil)
 		if err != nil {
 			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Can't fetch doc %s for deltaSrc=%s %v", base.UD(docID), deltaSrcRevID, err)
 		}
@@ -1091,9 +1091,9 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	// bh.conflictResolver != nil represents an active SGR2 and BLIPClientTypeSGR2 represents a passive SGR2
 	forceAllowConflictingTombstone := newDoc.Deleted && (bh.conflictResolver != nil || bh.clientType == BLIPClientTypeSGR2)
 	if bh.conflictResolver != nil {
-		_, _, err = bh.collection.PutExistingRevWithConflictResolution(newDoc, history, true, bh.conflictResolver, forceAllowConflictingTombstone, rawBucketDoc)
+		_, _, err = bh.collection.PutExistingRevWithConflictResolution(bh.loggingCtx, newDoc, history, true, bh.conflictResolver, forceAllowConflictingTombstone, rawBucketDoc)
 	} else {
-		_, _, err = bh.collection.PutExistingRev(newDoc, history, revNoConflicts, forceAllowConflictingTombstone, rawBucketDoc)
+		_, _, err = bh.collection.PutExistingRev(bh.loggingCtx, newDoc, history, revNoConflicts, forceAllowConflictingTombstone, rawBucketDoc)
 	}
 	if err != nil {
 		return err

--- a/db/blip_handler_collections.go
+++ b/db/blip_handler_collections.go
@@ -66,7 +66,7 @@ func (bh *blipHandler) handleGetCollections(rq *blip.Message) error {
 			continue
 		}
 		key := CheckpointDocIDPrefix + requestBody.CheckpointIDs[i]
-		collectionDB := &Database{DatabaseContext: collection.CollectionCtx, user: bh.blipContextDb.User(), Ctx: bh.db.Ctx}
+		collectionDB := &Database{DatabaseContext: collection.CollectionCtx, user: bh.blipContextDb.User()}
 		value, err := collectionDB.GetSpecial(DocTypeLocal, key)
 		if err != nil {
 			status, _ := base.ErrorAsHTTPStatus(err)

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -43,7 +43,7 @@ func NewBlipSyncContext(ctx context.Context, bc *blip.Context, db *Database, con
 		replicationStats:        replicationStats,
 		inFlightChangesThrottle: make(chan struct{}, maxInFlightChangesBatches),
 	}
-	bsc.changesCtx, bsc.changesCtxCancel = context.WithCancel(context.Background())
+	bsc.changesCtx, bsc.changesCtxCancel = context.WithCancel(ctx)
 	if bsc.replicationStats == nil {
 		bsc.replicationStats = NewBlipSyncStats()
 	}

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -32,11 +32,11 @@ const (
 
 var ErrClosedBLIPSender = errors.New("use of closed BLIP sender")
 
-func NewBlipSyncContext(bc *blip.Context, db *Database, contextID string, replicationStats *BlipSyncStats) *BlipSyncContext {
+func NewBlipSyncContext(ctx context.Context, bc *blip.Context, db *Database, contextID string, replicationStats *BlipSyncStats) *BlipSyncContext {
 	bsc := &BlipSyncContext{
 		blipContext:             bc,
 		blipContextDb:           db,
-		loggingCtx:              db.Ctx,
+		loggingCtx:              ctx,
 		terminator:              make(chan bool),
 		userChangeWaiter:        db.NewUserWaiter(),
 		sgCanUseDeltas:          db.DeltaSyncEnabled(),
@@ -59,7 +59,7 @@ func NewBlipSyncContext(bc *blip.Context, db *Database, contextID string, replic
 	// Register default handlers
 	bc.DefaultHandler = bsc.NotFoundHandler
 	bc.FatalErrorHandler = func(err error) {
-		base.InfofCtx(db.Ctx, base.KeyHTTP, "%s:     --> BLIP+WebSocket connection error: %v", contextID, err)
+		base.InfofCtx(ctx, base.KeyHTTP, "%s:     --> BLIP+WebSocket connection error: %v", contextID, err)
 	}
 
 	// Register 2.x replicator handlers
@@ -232,8 +232,7 @@ func (bsc *BlipSyncContext) copyContextDatabase() *Database {
 }
 
 func (bsc *BlipSyncContext) _copyContextDatabase() *Database {
-	databaseCopy, _ := GetDatabase(context.TODO(), bsc.blipContextDb.DatabaseContext, bsc.blipContextDb.User())
-	databaseCopy.Ctx = bsc.loggingCtx
+	databaseCopy, _ := GetDatabase(bsc.blipContextDb.DatabaseContext, bsc.blipContextDb.User())
 	return databaseCopy
 }
 
@@ -566,7 +565,7 @@ func (bsc *BlipSyncContext) sendRevision(sender *blip.Sender, docID, revID strin
 		collectionIdx = &coll
 	}
 
-	rev, err := handleChangesResponseDb.GetRev(docID, revID, true, nil)
+	rev, err := handleChangesResponseDb.GetRev(bsc.loggingCtx, docID, revID, true, nil)
 	if base.IsDocNotFoundError(err) {
 		return bsc.sendNoRev(sender, docID, revID, collectionIdx, seq, err)
 	} else if err != nil {

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -232,7 +232,7 @@ func (bsc *BlipSyncContext) copyContextDatabase() *Database {
 }
 
 func (bsc *BlipSyncContext) _copyContextDatabase() *Database {
-	databaseCopy, _ := GetDatabase(bsc.blipContextDb.DatabaseContext, bsc.blipContextDb.User())
+	databaseCopy, _ := GetDatabase(context.TODO(), bsc.blipContextDb.DatabaseContext, bsc.blipContextDb.User())
 	databaseCopy.Ctx = bsc.loggingCtx
 	return databaseCopy
 }

--- a/db/blip_sync_context_test.go
+++ b/db/blip_sync_context_test.go
@@ -46,10 +46,11 @@ func TestBlipSyncContextSetUseDeltas(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := &BlipSyncContext{
-				blipContextDb:    &Database{Ctx: base.TestCtx(t)},
+				blipContextDb:    &Database{},
 				useDeltas:        tt.startingCtxDeltas,
 				sgCanUseDeltas:   tt.sgCanUseDeltas,
 				replicationStats: NewBlipSyncStats(),
+				loggingCtx:       base.TestCtx(t),
 			}
 
 			ctx.setUseDeltas(tt.clientCanUseDeltas)
@@ -87,8 +88,9 @@ func BenchmarkBlipSyncContextSetUseDeltas(b *testing.B) {
 	for _, tt := range tests {
 		b.Run(tt.name, func(b *testing.B) {
 			ctx := &BlipSyncContext{
-				blipContextDb:    &Database{Ctx: base.TestCtx(b)},
+				blipContextDb:    &Database{},
 				replicationStats: NewBlipSyncStats(),
+				loggingCtx:       base.TestCtx(b),
 			}
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -230,7 +230,7 @@ func (c *changeCache) Stop() {
 	close(c.terminator)
 
 	// Wait for changeCache background tasks to finish.
-	waitForBGTCompletion(BGTCompletionMaxWait, c.backgroundTasks, c.context.Name)
+	waitForBGTCompletion(context.TODO(), BGTCompletionMaxWait, c.backgroundTasks, c.context.Name)
 
 	// Stop the channel cache and it's background tasks.
 	c.channelCache.Stop()

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -114,8 +114,7 @@ func TestSkippedSequenceList(t *testing.T) {
 
 func TestLateSequenceHandling(t *testing.T) {
 
-	context := setupTestDBWithCacheOptions(t, DefaultCacheOptions())
-	ctx := context.AddDatabaseLogContext(base.TestCtx(t))
+	context, ctx := setupTestDBWithCacheOptions(t, DefaultCacheOptions())
 	defer context.Close(ctx)
 
 	stats := base.NewSyncGatewayStats()
@@ -249,8 +248,7 @@ func TestLateSequenceErrorRecovery(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
 
-	db := setupTestDBWithCacheOptions(t, shortWaitCache())
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close(ctx)
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -371,8 +369,7 @@ func TestLateSequenceHandlingDuringCompact(t *testing.T) {
 
 	cacheOptions := shortWaitCache()
 	cacheOptions.ChannelCacheOptions.MaxNumChannels = 100
-	db := setupTestDBWithCacheOptions(t, cacheOptions)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDBWithCacheOptions(t, cacheOptions)
 	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
@@ -548,8 +545,7 @@ func TestChannelCacheBufferingWithUserDoc(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyDCP)
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -587,8 +583,7 @@ func TestChannelCacheBackfill(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 
-	db := setupTestDBWithCacheOptions(t, shortWaitCache())
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close(ctx)
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -653,8 +648,7 @@ func TestContinuousChangesBackfill(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache, base.KeyChanges, base.KeyDCP)
 
-	db := setupTestDBWithCacheOptions(t, shortWaitCache())
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
@@ -755,8 +749,7 @@ func TestLowSequenceHandling(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyQuery)
 
-	db := setupTestDBWithCacheOptions(t, shortWaitCache())
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
@@ -822,8 +815,7 @@ func TestLowSequenceHandlingAcrossChannels(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyQuery)
 
-	db := setupTestDBWithCacheOptions(t, shortWaitCache())
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
@@ -881,8 +873,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges, base.KeyQuery)
 
-	db := setupTestDBWithCacheOptions(t, shortWaitCache())
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
@@ -991,9 +982,8 @@ func TestChannelQueryCancellation(t *testing.T) {
 		PostQueryCallback: postQueryCallback,
 	}
 
-	db := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
+	db, ctx := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
 	defer db.Close(ctx)
 
 	// Write a handful of docs/sequences to the bucket
@@ -1086,8 +1076,7 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges, base.KeyCache)
 
-	db := setupTestDBWithCacheOptions(t, shortWaitCache())
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
@@ -1180,8 +1169,7 @@ func TestChannelRace(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges)
 
-	db := setupTestDBWithCacheOptions(t, shortWaitCache())
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
@@ -1285,8 +1273,7 @@ func TestSkippedViewRetrieval(t *testing.T) {
 	leakyConfig := base.LeakyBucketConfig{
 		TapFeedMissingDocs: []string{"doc-3", "doc-7", "doc-10", "doc-13", "doc-14"},
 	}
-	db := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), leakyConfig)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), leakyConfig)
 	defer db.Close(ctx)
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -1360,8 +1347,7 @@ func TestStopChangeCache(t *testing.T) {
 	leakyConfig := base.LeakyBucketConfig{
 		TapFeedMissingDocs: []string{"doc-3"},
 	}
-	db := setupTestLeakyDBWithCacheOptions(t, cacheOptions, leakyConfig)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestLeakyDBWithCacheOptions(t, cacheOptions, leakyConfig)
 
 	// Write sequences direct
 	WriteDirect(db, []string{"ABC"}, 1)
@@ -1394,8 +1380,7 @@ func TestChannelCacheSize(t *testing.T) {
 	options.ChannelCacheOptions.ChannelCacheMaxLength = 600
 
 	log.Printf("Options in test:%+v", options)
-	db := setupTestDBWithCacheOptions(t, options)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDBWithCacheOptions(t, options)
 	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
@@ -1615,8 +1600,7 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 	options.ChannelCacheOptions.ChannelCacheMinLength = 600
 	options.ChannelCacheOptions.ChannelCacheMaxLength = 600
 
-	db := setupTestDBWithCacheOptions(t, options)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDBWithCacheOptions(t, options)
 	defer db.Close(ctx)
 
 	// -------- Setup notifyChange callback ----------------
@@ -1700,8 +1684,7 @@ func TestInitializeEmptyCache(t *testing.T) {
 	cacheOptions := DefaultCacheOptions()
 	cacheOptions.ChannelCacheMaxLength = 50
 
-	db := setupTestDBWithCacheOptions(t, cacheOptions)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDBWithCacheOptions(t, cacheOptions)
 	defer db.Close(ctx)
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -1752,8 +1735,7 @@ func TestInitializeCacheUnderLoad(t *testing.T) {
 	cacheOptions := DefaultCacheOptions()
 	cacheOptions.ChannelCacheMaxLength = 50
 
-	db := setupTestDBWithCacheOptions(t, cacheOptions)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDBWithCacheOptions(t, cacheOptions)
 	defer db.Close(ctx)
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -1807,8 +1789,7 @@ func TestNotifyForInactiveChannel(t *testing.T) {
 	// Enable relevant logging
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache, base.KeyDCP)
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	// -------- Setup notifyChange callback ----------------
@@ -1855,9 +1836,8 @@ func TestMaxChannelCacheConfig(t *testing.T) {
 	for _, val := range channelCacheMaxChannels {
 		options := DefaultCacheOptions()
 		options.ChannelCacheOptions.MaxNumChannels = val
-		db := setupTestDBWithCacheOptions(t, options)
+		db, ctx := setupTestDBWithCacheOptions(t, options)
 		assert.Equal(t, val, db.DatabaseContext.Options.CacheOptions.MaxNumChannels)
-		ctx := db.AddDatabaseLogContext(base.TestCtx(t))
 		defer db.Close(ctx)
 	}
 }
@@ -1874,8 +1854,7 @@ func TestChangeCache_InsertPendingEntries(t *testing.T) {
 	cacheOptions := DefaultCacheOptions()
 	cacheOptions.CachePendingSeqMaxWait = 100 * time.Millisecond
 
-	db := setupTestDBWithCacheOptions(t, cacheOptions)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDBWithCacheOptions(t, cacheOptions)
 	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -182,8 +182,9 @@ func TestLateSequenceHandling(t *testing.T) {
 
 func TestLateSequenceHandlingWithMultipleListeners(t *testing.T) {
 
+	ctx := base.TestCtx(t)
 	b := base.GetTestBucket(t)
-	context, err := NewDatabaseContext("db", b, false, DatabaseContextOptions{})
+	context, err := NewDatabaseContext(ctx, "db", b, false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close()
 

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -115,7 +115,8 @@ func TestSkippedSequenceList(t *testing.T) {
 func TestLateSequenceHandling(t *testing.T) {
 
 	context := setupTestDBWithCacheOptions(t, DefaultCacheOptions())
-	defer context.Close()
+	ctx := context.AddDatabaseLogContext(base.TestCtx(t))
+	defer context.Close(ctx)
 
 	stats := base.NewSyncGatewayStats()
 	cacheStats := stats.NewDBStats("", false, false, false).CacheStats
@@ -249,7 +250,8 @@ func TestLateSequenceErrorRecovery(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
 
 	db := setupTestDBWithCacheOptions(t, shortWaitCache())
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
 	// Create a user with access to channel ABC
@@ -370,7 +372,8 @@ func TestLateSequenceHandlingDuringCompact(t *testing.T) {
 	cacheOptions := shortWaitCache()
 	cacheOptions.ChannelCacheOptions.MaxNumChannels = 100
 	db := setupTestDBWithCacheOptions(t, cacheOptions)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -546,7 +549,8 @@ func TestChannelCacheBufferingWithUserDoc(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyDCP)
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
 	// Simulate seq 1 (user doc) being delayed - write 2 first
@@ -584,7 +588,8 @@ func TestChannelCacheBackfill(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 
 	db := setupTestDBWithCacheOptions(t, shortWaitCache())
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
 	// Create a user with access to channel ABC
@@ -649,7 +654,8 @@ func TestContinuousChangesBackfill(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache, base.KeyChanges, base.KeyDCP)
 
 	db := setupTestDBWithCacheOptions(t, shortWaitCache())
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -750,7 +756,8 @@ func TestLowSequenceHandling(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyQuery)
 
 	db := setupTestDBWithCacheOptions(t, shortWaitCache())
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -816,7 +823,8 @@ func TestLowSequenceHandlingAcrossChannels(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyQuery)
 
 	db := setupTestDBWithCacheOptions(t, shortWaitCache())
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -874,7 +882,8 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges, base.KeyQuery)
 
 	db := setupTestDBWithCacheOptions(t, shortWaitCache())
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -984,7 +993,8 @@ func TestChannelQueryCancellation(t *testing.T) {
 
 	db := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	// Write a handful of docs/sequences to the bucket
 	_, _, err := db.Put("key1", Body{"channels": "ABC"})
@@ -1077,7 +1087,8 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges, base.KeyCache)
 
 	db := setupTestDBWithCacheOptions(t, shortWaitCache())
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -1170,7 +1181,8 @@ func TestChannelRace(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges)
 
 	db := setupTestDBWithCacheOptions(t, shortWaitCache())
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -1274,7 +1286,8 @@ func TestSkippedViewRetrieval(t *testing.T) {
 		TapFeedMissingDocs: []string{"doc-3", "doc-7", "doc-10", "doc-13", "doc-14"},
 	}
 	db := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), leakyConfig)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
 	// Allow db to initialize and run initial CleanSkippedSequenceQueue
@@ -1348,6 +1361,7 @@ func TestStopChangeCache(t *testing.T) {
 		TapFeedMissingDocs: []string{"doc-3"},
 	}
 	db := setupTestLeakyDBWithCacheOptions(t, cacheOptions, leakyConfig)
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
 
 	// Write sequences direct
 	WriteDirect(db, []string{"ABC"}, 1)
@@ -1359,7 +1373,7 @@ func TestStopChangeCache(t *testing.T) {
 	require.NoError(t, err)
 
 	// tear down the DB.  Should stop the cache before view retrieval of the skipped sequence is attempted.
-	db.Close()
+	db.Close(ctx)
 
 	// Hang around a while to see if the housekeeping tasks fire and panic
 	time.Sleep(1 * time.Second)
@@ -1381,7 +1395,8 @@ func TestChannelCacheSize(t *testing.T) {
 
 	log.Printf("Options in test:%+v", options)
 	db := setupTestDBWithCacheOptions(t, options)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -1601,7 +1616,8 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 	options.ChannelCacheOptions.ChannelCacheMaxLength = 600
 
 	db := setupTestDBWithCacheOptions(t, options)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	// -------- Setup notifyChange callback ----------------
 
@@ -1685,7 +1701,8 @@ func TestInitializeEmptyCache(t *testing.T) {
 	cacheOptions.ChannelCacheMaxLength = 50
 
 	db := setupTestDBWithCacheOptions(t, cacheOptions)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
@@ -1736,7 +1753,8 @@ func TestInitializeCacheUnderLoad(t *testing.T) {
 	cacheOptions.ChannelCacheMaxLength = 50
 
 	db := setupTestDBWithCacheOptions(t, cacheOptions)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
 	// Writes [docCount] documents.  Use wait group (writesDone)to identify when all docs have been written.
@@ -1790,7 +1808,8 @@ func TestNotifyForInactiveChannel(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache, base.KeyDCP)
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	// -------- Setup notifyChange callback ----------------
 
@@ -1838,7 +1857,8 @@ func TestMaxChannelCacheConfig(t *testing.T) {
 		options.ChannelCacheOptions.MaxNumChannels = val
 		db := setupTestDBWithCacheOptions(t, options)
 		assert.Equal(t, val, db.DatabaseContext.Options.CacheOptions.MaxNumChannels)
-		db.Close()
+		ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+		defer db.Close(ctx)
 	}
 }
 
@@ -1855,7 +1875,8 @@ func TestChangeCache_InsertPendingEntries(t *testing.T) {
 	cacheOptions.CachePendingSeqMaxWait = 100 * time.Millisecond
 
 	db := setupTestDBWithCacheOptions(t, cacheOptions)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 

--- a/db/change_listener_test.go
+++ b/db/change_listener_test.go
@@ -25,8 +25,7 @@ func TestUserWaiter(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	// Create user
@@ -69,8 +68,7 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	// Create role

--- a/db/change_listener_test.go
+++ b/db/change_listener_test.go
@@ -28,12 +28,10 @@ func TestUserWaiter(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
-	ctx := base.TestCtx(t)
-
 	// Create user
 	username := "bob"
-	authenticator := db.Authenticator(ctx)
-	require.NotNil(t, authenticator, "db.Authenticator(base.TestCtx(t)) returned nil")
+	authenticator := db.Authenticator(db.Ctx)
+	require.NotNil(t, authenticator, "db.Authenticator(db.Ctx) returned nil")
 	user, err := authenticator.NewUser(username, "letmein", channels.SetOf(t, "ABC"))
 	require.NoError(t, err, "Error creating new user")
 
@@ -58,7 +56,7 @@ func TestUserWaiter(t *testing.T) {
 		Name:             &username,
 		ExplicitChannels: base.SetFromArray([]string{"ABC", "DEF"}),
 	}
-	_, err = db.UpdatePrincipal(ctx, &updatedUser, true, true)
+	_, err = db.UpdatePrincipal(db.Ctx, &updatedUser, true, true)
 	require.NoError(t, err, "Error updating user")
 
 	// Wait for notification from grant
@@ -73,19 +71,17 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
-	ctx := base.TestCtx(t)
-
 	// Create role
 	roleName := "good_egg"
-	authenticator := db.Authenticator(ctx)
-	require.NotNil(t, authenticator, "db.Authenticator(base.TestCtx(t)) returned nil")
+	authenticator := db.Authenticator(db.Ctx)
+	require.NotNil(t, authenticator, "db.Authenticator(db.Ctx) returned nil")
 	role, err := authenticator.NewRole(roleName, channels.SetOf(t, "ABC"))
 	require.NoError(t, err, "Error creating new role")
 	require.NoError(t, authenticator.Save(role))
 
 	// Create user
 	username := "bob"
-	require.NotNil(t, authenticator, "db.Authenticator(base.TestCtx(t)) returned nil")
+	require.NotNil(t, authenticator, "db.Authenticator(db.Ctx) returned nil")
 	user, err := authenticator.NewUser(username, "letmein", nil)
 	require.NoError(t, err, "Error creating new user")
 
@@ -110,7 +106,7 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 		Name:              &username,
 		ExplicitRoleNames: base.SetOf(roleName),
 	}
-	_, err = db.UpdatePrincipal(ctx, &updatedUser, true, true)
+	_, err = db.UpdatePrincipal(db.Ctx, &updatedUser, true, true)
 	require.NoError(t, err, "Error updating user")
 
 	// Wait for notify from updated user
@@ -131,7 +127,7 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 		Name:             &roleName,
 		ExplicitChannels: base.SetFromArray([]string{"ABC", "DEF"}),
 	}
-	_, err = db.UpdatePrincipal(ctx, &updatedRole, false, true)
+	_, err = db.UpdatePrincipal(db.Ctx, &updatedRole, false, true)
 	require.NoError(t, err, "Error updating role")
 
 	// Wait for user notification of updated role

--- a/db/change_listener_test.go
+++ b/db/change_listener_test.go
@@ -26,7 +26,8 @@ func TestUserWaiter(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	// Create user
 	username := "bob"
@@ -69,7 +70,8 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	// Create role
 	roleName := "good_egg"

--- a/db/change_listener_test.go
+++ b/db/change_listener_test.go
@@ -31,7 +31,7 @@ func TestUserWaiter(t *testing.T) {
 
 	// Create user
 	username := "bob"
-	authenticator := db.Authenticator(db.Ctx)
+	authenticator := db.Authenticator(ctx)
 	require.NotNil(t, authenticator, "db.Authenticator(db.Ctx) returned nil")
 	user, err := authenticator.NewUser(username, "letmein", channels.SetOf(t, "ABC"))
 	require.NoError(t, err, "Error creating new user")
@@ -57,7 +57,7 @@ func TestUserWaiter(t *testing.T) {
 		Name:             &username,
 		ExplicitChannels: base.SetFromArray([]string{"ABC", "DEF"}),
 	}
-	_, err = db.UpdatePrincipal(db.Ctx, &updatedUser, true, true)
+	_, err = db.UpdatePrincipal(ctx, &updatedUser, true, true)
 	require.NoError(t, err, "Error updating user")
 
 	// Wait for notification from grant
@@ -75,15 +75,15 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 
 	// Create role
 	roleName := "good_egg"
-	authenticator := db.Authenticator(db.Ctx)
-	require.NotNil(t, authenticator, "db.Authenticator(db.Ctx) returned nil")
+	authenticator := db.Authenticator(ctx)
+	require.NotNil(t, authenticator, "db.Authenticator(ctx) returned nil")
 	role, err := authenticator.NewRole(roleName, channels.SetOf(t, "ABC"))
 	require.NoError(t, err, "Error creating new role")
 	require.NoError(t, authenticator.Save(role))
 
 	// Create user
 	username := "bob"
-	require.NotNil(t, authenticator, "db.Authenticator(db.Ctx) returned nil")
+	require.NotNil(t, authenticator, "db.Authenticator(ctx) returned nil")
 	user, err := authenticator.NewUser(username, "letmein", nil)
 	require.NoError(t, err, "Error creating new user")
 
@@ -108,7 +108,7 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 		Name:              &username,
 		ExplicitRoleNames: base.SetOf(roleName),
 	}
-	_, err = db.UpdatePrincipal(db.Ctx, &updatedUser, true, true)
+	_, err = db.UpdatePrincipal(ctx, &updatedUser, true, true)
 	require.NoError(t, err, "Error updating user")
 
 	// Wait for notify from updated user
@@ -129,7 +129,7 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 		Name:             &roleName,
 		ExplicitChannels: base.SetFromArray([]string{"ABC", "DEF"}),
 	}
-	_, err = db.UpdatePrincipal(db.Ctx, &updatedRole, false, true)
+	_, err = db.UpdatePrincipal(ctx, &updatedRole, false, true)
 	require.NoError(t, err, "Error updating role")
 
 	// Wait for user notification of updated role

--- a/db/changes.go
+++ b/db/changes.go
@@ -127,7 +127,7 @@ func (db *Database) addDocToChangeEntry(ctx context.Context, entry *ChangeEntry,
 	} else if options.IncludeDocs {
 		// Retrieve document via rev cache
 		revID := entry.Changes[0]["rev"]
-		err := db.AddDocToChangeEntryUsingRevCache(entry, revID)
+		err := db.AddDocToChangeEntryUsingRevCache(ctx, entry, revID)
 		if err != nil {
 			base.WarnfCtx(ctx, "Changes feed: error getting revision body for %q (%s): %v", base.UD(entry.ID), revID, err)
 		}
@@ -135,8 +135,8 @@ func (db *Database) addDocToChangeEntry(ctx context.Context, entry *ChangeEntry,
 
 }
 
-func (db *Database) AddDocToChangeEntryUsingRevCache(entry *ChangeEntry, revID string) (err error) {
-	rev, err := db.getRev(entry.ID, revID, 0, nil, RevCacheIncludeBody)
+func (db *Database) AddDocToChangeEntryUsingRevCache(ctx context.Context, entry *ChangeEntry, revID string) (err error) {
+	rev, err := db.getRev(ctx, entry.ID, revID, 0, nil, RevCacheIncludeBody)
 	if err != nil {
 		return err
 	}
@@ -164,7 +164,7 @@ func (db *Database) AddDocInstanceToChangeEntry(ctx context.Context, entry *Chan
 	}
 	if options.IncludeDocs {
 		var err error
-		entry.Doc, _, err = db.get1xRevFromDoc(doc, revID, false)
+		entry.Doc, _, err = db.get1xRevFromDoc(ctx, doc, revID, false)
 		db.DbStats.Database().NumDocReadsRest.Add(1)
 		if err != nil {
 			base.WarnfCtx(ctx, "Changes feed: error getting doc %q/%q: %v", base.UD(doc.ID), revID, err)

--- a/db/changes.go
+++ b/db/changes.go
@@ -78,12 +78,12 @@ type ViewDoc struct {
 	Json json.RawMessage // should be type 'document', but that fails to unmarshal correctly
 }
 
-func (db *Database) AddDocToChangeEntry(entry *ChangeEntry, options ChangesOptions) {
-	db.addDocToChangeEntry(entry, options)
+func (db *Database) AddDocToChangeEntry(ctx context.Context, entry *ChangeEntry, options ChangesOptions) {
+	db.addDocToChangeEntry(ctx, entry, options)
 }
 
 // Adds a document body and/or its conflicts to a ChangeEntry
-func (db *Database) addDocToChangeEntry(entry *ChangeEntry, options ChangesOptions) {
+func (db *Database) addDocToChangeEntry(ctx context.Context, entry *ChangeEntry, options ChangesOptions) {
 
 	includeConflicts := options.Conflicts && entry.branched
 	if !options.IncludeDocs && !includeConflicts {
@@ -106,30 +106,30 @@ func (db *Database) addDocToChangeEntry(entry *ChangeEntry, options ChangesOptio
 
 	if options.IncludeDocs && includeConflicts {
 		// Load doc body + metadata
-		doc, err := db.GetDocument(db.Ctx, entry.ID, DocUnmarshalAll)
+		doc, err := db.GetDocument(ctx, entry.ID, DocUnmarshalAll)
 		if err != nil {
-			base.WarnfCtx(db.Ctx, "Changes feed: error getting doc %q: %v", base.UD(entry.ID), err)
+			base.WarnfCtx(ctx, "Changes feed: error getting doc %q: %v", base.UD(entry.ID), err)
 			return
 		}
-		db.AddDocInstanceToChangeEntry(entry, doc, options)
+		db.AddDocInstanceToChangeEntry(ctx, entry, doc, options)
 
 	} else if includeConflicts {
 		// Load doc metadata only
 		doc := &Document{}
 		var err error
-		doc.SyncData, err = db.GetDocSyncData(db.Ctx, entry.ID)
+		doc.SyncData, err = db.GetDocSyncData(ctx, entry.ID)
 		if err != nil {
-			base.WarnfCtx(db.Ctx, "Changes feed: error getting doc sync data %q: %v", base.UD(entry.ID), err)
+			base.WarnfCtx(ctx, "Changes feed: error getting doc sync data %q: %v", base.UD(entry.ID), err)
 			return
 		}
-		db.AddDocInstanceToChangeEntry(entry, doc, options)
+		db.AddDocInstanceToChangeEntry(ctx, entry, doc, options)
 
 	} else if options.IncludeDocs {
 		// Retrieve document via rev cache
 		revID := entry.Changes[0]["rev"]
 		err := db.AddDocToChangeEntryUsingRevCache(entry, revID)
 		if err != nil {
-			base.WarnfCtx(db.Ctx, "Changes feed: error getting revision body for %q (%s): %v", base.UD(entry.ID), revID, err)
+			base.WarnfCtx(ctx, "Changes feed: error getting revision body for %q (%s): %v", base.UD(entry.ID), revID, err)
 		}
 	}
 
@@ -145,7 +145,7 @@ func (db *Database) AddDocToChangeEntryUsingRevCache(entry *ChangeEntry, revID s
 }
 
 // Adds a document body and/or its conflicts to a ChangeEntry
-func (db *Database) AddDocInstanceToChangeEntry(entry *ChangeEntry, doc *Document, options ChangesOptions) {
+func (db *Database) AddDocInstanceToChangeEntry(ctx context.Context, entry *ChangeEntry, doc *Document, options ChangesOptions) {
 
 	includeConflicts := options.Conflicts && entry.branched
 
@@ -167,7 +167,7 @@ func (db *Database) AddDocInstanceToChangeEntry(entry *ChangeEntry, doc *Documen
 		entry.Doc, _, err = db.get1xRevFromDoc(doc, revID, false)
 		db.DbStats.Database().NumDocReadsRest.Add(1)
 		if err != nil {
-			base.WarnfCtx(db.Ctx, "Changes feed: error getting doc %q/%q: %v", base.UD(doc.ID), revID, err)
+			base.WarnfCtx(ctx, "Changes feed: error getting doc %q/%q: %v", base.UD(doc.ID), revID, err)
 		}
 	}
 }
@@ -179,7 +179,7 @@ func (db *Database) AddDocInstanceToChangeEntry(entry *ChangeEntry, doc *Documen
 // This is used in this function in 'wasDocInChannelAtSeq'.
 // revokeFrom: This is the point at which we should run the changes feed from to find the documents we should revoke. It
 // is calculated higher up based on whether we are resuming an interrupted feed or not.
-func (db *Database) buildRevokedFeed(channelName string, options ChangesOptions, revokedAt, revocationSinceSeq, revokeFrom uint64, to string) <-chan *ChangeEntry {
+func (db *Database) buildRevokedFeed(ctx context.Context, channelName string, options ChangesOptions, revokedAt, revocationSinceSeq, revokeFrom uint64, to string) <-chan *ChangeEntry {
 	feed := make(chan *ChangeEntry, 1)
 	sinceVal := options.Since.Seq
 
@@ -217,17 +217,17 @@ func (db *Database) buildRevokedFeed(channelName string, options ChangesOptions,
 			}
 
 			// Get changes from 0 to latest seq
-			base.TracefCtx(db.Ctx, base.KeyChanges, "Querying channel %q for revocation with options: %+v", base.UD(singleChannelCache.ChannelName()), paginationOptions)
+			base.TracefCtx(ctx, base.KeyChanges, "Querying channel %q for revocation with options: %+v", base.UD(singleChannelCache.ChannelName()), paginationOptions)
 			changes, err := singleChannelCache.GetChanges(paginationOptions)
 			if err != nil {
-				base.WarnfCtx(db.Ctx, "Error retrieving changes for channel %q: %v", base.UD(singleChannelCache.ChannelName()), err)
+				base.WarnfCtx(ctx, "Error retrieving changes for channel %q: %v", base.UD(singleChannelCache.ChannelName()), err)
 				change := ChangeEntry{
 					Err: base.ErrChannelFeed,
 				}
 				feed <- &change
 				return
 			}
-			base.DebugfCtx(db.Ctx, base.KeyChanges, "[revocationChangesFeed] Found %d changes for channel %q", len(changes), base.UD(singleChannelCache.ChannelName()))
+			base.DebugfCtx(ctx, base.KeyChanges, "[revocationChangesFeed] Found %d changes for channel %q", len(changes), base.UD(singleChannelCache.ChannelName()))
 
 			sentChanges := 0
 			for _, logEntry := range changes {
@@ -241,23 +241,23 @@ func (db *Database) buildRevokedFeed(channelName string, options ChangesOptions,
 				// Otherwise: we need to determine whether a previous revision of the document was in the channel prior
 				// to the since value, and only send a revocation if that was the case
 				if logEntry.Sequence > sinceVal {
-					requiresRevocation, err := db.wasDocInChannelPriorToRevocation(logEntry.DocID, singleChannelCache.ChannelName(), revocationSinceSeq)
+					requiresRevocation, err := db.wasDocInChannelPriorToRevocation(ctx, logEntry.DocID, singleChannelCache.ChannelName(), revocationSinceSeq)
 					if err != nil {
 						change := ChangeEntry{
 							Err: base.ErrChannelFeed,
 						}
 						feed <- &change
-						base.WarnfCtx(db.Ctx, "Error checking document history during revocation, seq: %v in channel %s, ending revocation feed. Error: %v", seqID, base.UD(singleChannelCache.ChannelName()), err)
+						base.WarnfCtx(ctx, "Error checking document history during revocation, seq: %v in channel %s, ending revocation feed. Error: %v", seqID, base.UD(singleChannelCache.ChannelName()), err)
 						return
 					}
 
 					if !requiresRevocation {
-						base.DebugfCtx(db.Ctx, base.KeyChanges, "Channel feed processing revocation, seq: %v in channel %s does not require revocation", seqID, base.UD(singleChannelCache.ChannelName()))
+						base.DebugfCtx(ctx, base.KeyChanges, "Channel feed processing revocation, seq: %v in channel %s does not require revocation", seqID, base.UD(singleChannelCache.ChannelName()))
 						continue
 					}
 				}
 
-				userHasAccessToDoc, err := UserHasDocAccess(db, logEntry.DocID, logEntry.RevID)
+				userHasAccessToDoc, err := UserHasDocAccess(ctx, db, logEntry.DocID, logEntry.RevID)
 				if err != nil {
 					change := ChangeEntry{
 						Err: base.ErrChannelFeed,
@@ -274,11 +274,11 @@ func (db *Database) buildRevokedFeed(channelName string, options ChangesOptions,
 				change := makeRevocationChangeEntry(logEntry, seqID, singleChannelCache.ChannelName())
 				lastSeq = logEntry.Sequence
 
-				base.DebugfCtx(db.Ctx, base.KeyChanges, "Channel feed processing revocation seq: %v in channel %s ", seqID, base.UD(singleChannelCache.ChannelName()))
+				base.DebugfCtx(ctx, base.KeyChanges, "Channel feed processing revocation seq: %v in channel %s ", seqID, base.UD(singleChannelCache.ChannelName()))
 
 				select {
 				case <-options.ChangesCtx.Done():
-					base.DebugfCtx(db.Ctx, base.KeyChanges, "Terminating revocation channel feed %s", base.UD(to))
+					base.DebugfCtx(ctx, base.KeyChanges, "Terminating revocation channel feed %s", base.UD(to))
 					return
 
 				case feed <- &change:
@@ -302,8 +302,8 @@ func (db *Database) buildRevokedFeed(channelName string, options ChangesOptions,
 	return feed
 }
 
-func UserHasDocAccess(db *Database, docID, revID string) (bool, error) {
-	rev, err := db.revisionCache.Get(db.Ctx, docID, revID, false, false)
+func UserHasDocAccess(ctx context.Context, db *Database, docID, revID string) (bool, error) {
+	rev, err := db.revisionCache.Get(ctx, docID, revID, false, false)
 	if err != nil {
 		if base.IsDocNotFoundError(err) {
 			return false, nil
@@ -320,9 +320,9 @@ func UserHasDocAccess(db *Database, docID, revID string) (bool, error) {
 }
 
 // Checks if a document needs to be revoked. This is used in the case where the since < doc sequence
-func (db *Database) wasDocInChannelPriorToRevocation(docID, chanName string, since uint64) (bool, error) {
+func (db *Database) wasDocInChannelPriorToRevocation(ctx context.Context, docID, chanName string, since uint64) (bool, error) {
 	// Get doc sync data so we can verify the docs grant history
-	syncData, err := db.GetDocSyncData(db.Ctx, docID)
+	syncData, err := db.GetDocSyncData(ctx, docID)
 	if err != nil {
 		return false, err
 	}
@@ -368,7 +368,7 @@ func (db *Database) wasDocInChannelPriorToRevocation(docID, chanName string, sin
 
 // Creates a Go-channel of all the changes made on a channel.
 // Does NOT handle the Wait option. Does NOT check authorization.
-func (db *Database) changesFeed(singleChannelCache SingleChannelCache, options ChangesOptions, to string) <-chan *ChangeEntry {
+func (db *Database) changesFeed(ctx context.Context, singleChannelCache SingleChannelCache, options ChangesOptions, to string) <-chan *ChangeEntry {
 
 	feed := make(chan *ChangeEntry, 1)
 
@@ -401,17 +401,17 @@ func (db *Database) changesFeed(singleChannelCache SingleChannelCache, options C
 			}
 
 			// TODO: pass db.Ctx down to changeCache?
-			base.TracefCtx(db.Ctx, base.KeyChanges, "Querying channel %q with options: %+v", base.UD(singleChannelCache.ChannelName()), paginationOptions)
+			base.TracefCtx(ctx, base.KeyChanges, "Querying channel %q with options: %+v", base.UD(singleChannelCache.ChannelName()), paginationOptions)
 			changes, err := singleChannelCache.GetChanges(paginationOptions)
 			if err != nil {
-				base.WarnfCtx(db.Ctx, "Error retrieving changes for channel %q: %v", base.UD(singleChannelCache.ChannelName()), err)
+				base.WarnfCtx(ctx, "Error retrieving changes for channel %q: %v", base.UD(singleChannelCache.ChannelName()), err)
 				change := ChangeEntry{
 					Err: base.ErrChannelFeed,
 				}
 				feed <- &change
 				return
 			}
-			base.DebugfCtx(db.Ctx, base.KeyChanges, "[changesFeed] Found %d changes for channel %q", len(changes), base.UD(singleChannelCache.ChannelName()))
+			base.DebugfCtx(ctx, base.KeyChanges, "[changesFeed] Found %d changes for channel %q", len(changes), base.UD(singleChannelCache.ChannelName()))
 
 			// Now write each log entry to the 'feed' channel in turn:
 			sentChanges := 0
@@ -432,10 +432,10 @@ func (db *Database) changesFeed(singleChannelCache SingleChannelCache, options C
 					continue
 				}
 
-				base.DebugfCtx(db.Ctx, base.KeyChanges, "Channel feed processing seq:%v in channel %s %s", seqID, base.UD(singleChannelCache.ChannelName()), base.UD(to))
+				base.DebugfCtx(ctx, base.KeyChanges, "Channel feed processing seq:%v in channel %s %s", seqID, base.UD(singleChannelCache.ChannelName()), base.UD(to))
 				select {
 				case <-options.ChangesCtx.Done():
-					base.DebugfCtx(db.Ctx, base.KeyChanges, "Terminating channel feed %s", base.UD(to))
+					base.DebugfCtx(ctx, base.KeyChanges, "Terminating channel feed %s", base.UD(to))
 					return
 				case feed <- &change:
 					sentChanges++
@@ -519,17 +519,17 @@ func makeErrorEntry(message string) ChangeEntry {
 	return change
 }
 
-func (db *Database) MultiChangesFeed(chans base.Set, options ChangesOptions) (<-chan *ChangeEntry, error) {
+func (db *Database) MultiChangesFeed(ctx context.Context, chans base.Set, options ChangesOptions) (<-chan *ChangeEntry, error) {
 	if len(chans) == 0 {
 		return nil, nil
 	}
 
 	if options.ChangesCtx == nil {
-		base.ErrorfCtx(db.Ctx, "MultiChangesFeed: Changes Context missing")
+		base.ErrorfCtx(ctx, "MultiChangesFeed: Changes Context missing")
 	}
 
-	base.DebugfCtx(db.Ctx, base.KeyChanges, "Int sequence multi changes feed...")
-	return db.SimpleMultiChangesFeed(chans, options)
+	base.DebugfCtx(ctx, base.KeyChanges, "Int sequence multi changes feed...")
+	return db.SimpleMultiChangesFeed(ctx, chans, options)
 
 }
 
@@ -562,27 +562,27 @@ func (db *Database) appendUserFeed(feeds []<-chan *ChangeEntry, options ChangesO
 	return feeds
 }
 
-func (db *Database) checkForUserUpdates(userChangeCount uint64, changeWaiter *ChangeWaiter, isContinuous bool) (isChanged bool, newCount uint64, changedChannels channels.ChangedKeys, err error) {
+func (db *Database) checkForUserUpdates(ctx context.Context, userChangeCount uint64, changeWaiter *ChangeWaiter, isContinuous bool) (isChanged bool, newCount uint64, changedChannels channels.ChangedKeys, err error) {
 
 	newCount = changeWaiter.CurrentUserCount()
 	// If not continuous, we force user reload as a workaround for https://github.com/couchbase/sync_gateway/issues/2068.  For continuous, #2068 is handled by changedChannels check, and
 	// we can reload only when there's been a user change notification
 	if newCount > userChangeCount || !isContinuous {
 		var previousChannels channels.TimedSet
-		base.DebugfCtx(db.Ctx, base.KeyChanges, "MultiChangesFeed reloading user %+v", base.UD(db.user))
+		base.DebugfCtx(ctx, base.KeyChanges, "MultiChangesFeed reloading user %+v", base.UD(db.user))
 		userChangeCount = newCount
 
 		if db.user != nil {
 			previousChannels = db.user.InheritedChannels()
 			previousRoles := db.user.RoleNames()
-			if err := db.ReloadUser(); err != nil {
-				base.WarnfCtx(db.Ctx, "Error reloading user %q: %v", base.UD(db.user.Name()), err)
+			if err := db.ReloadUser(ctx); err != nil {
+				base.WarnfCtx(ctx, "Error reloading user %q: %v", base.UD(db.user.Name()), err)
 				return false, 0, nil, err
 			}
 			// check whether channel set has changed
 			changedChannels = db.user.InheritedChannels().CompareKeys(previousChannels)
 			if len(changedChannels) > 0 {
-				base.DebugfCtx(db.Ctx, base.KeyChanges, "Modified channel set after user reload: %v", base.UD(changedChannels))
+				base.DebugfCtx(ctx, base.KeyChanges, "Modified channel set after user reload: %v", base.UD(changedChannels))
 			}
 
 			changedRoles := db.user.RoleNames().CompareKeys(previousRoles)
@@ -596,23 +596,23 @@ func (db *Database) checkForUserUpdates(userChangeCount uint64, changeWaiter *Ch
 }
 
 // Returns the (ordered) union of all of the changes made to multiple channels.
-func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOptions) (<-chan *ChangeEntry, error) {
+func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans base.Set, options ChangesOptions) (<-chan *ChangeEntry, error) {
 
 	to := ""
 	if db.user != nil && db.user.Name() != "" {
 		to = fmt.Sprintf("  (to %s)", db.user.Name())
 	}
 
-	base.InfofCtx(db.Ctx, base.KeyChanges, "MultiChangesFeed(channels: %s, options: %s) ... %s", base.UD(chans), options, base.UD(to))
+	base.InfofCtx(ctx, base.KeyChanges, "MultiChangesFeed(channels: %s, options: %s) ... %s", base.UD(chans), options, base.UD(to))
 	output := make(chan *ChangeEntry, 50)
 
 	go func() {
 
 		defer func() {
 			if panicked := recover(); panicked != nil {
-				base.WarnfCtx(db.Ctx, "[%s] Unexpected panic sending changes - terminating changes: \n %s", panicked, debug.Stack())
+				base.WarnfCtx(ctx, "[%s] Unexpected panic sending changes - terminating changes: \n %s", panicked, debug.Stack())
 			} else {
-				base.InfofCtx(db.Ctx, base.KeyChanges, "MultiChangesFeed done %s", base.UD(to))
+				base.InfofCtx(ctx, base.KeyChanges, "MultiChangesFeed done %s", base.UD(to))
 			}
 			close(output)
 		}()
@@ -636,8 +636,8 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 			// initialization.  Without this, notification for user doc changes in that window (a) won't be
 			// included in the initial changes loop iteration, and (b) won't wake up the ChangeWaiter.
 			if db.user != nil {
-				if err := db.ReloadUser(); err != nil {
-					base.WarnfCtx(db.Ctx, "Error reloading user during changes initialization %q: %v", base.UD(db.user.Name()), err)
+				if err := db.ReloadUser(ctx); err != nil {
+					base.WarnfCtx(ctx, "Error reloading user during changes initialization %q: %v", base.UD(db.user.Name()), err)
 					change := makeErrorEntry("User not found during reload - terminating changes feed")
 					output <- &change
 					return
@@ -653,7 +653,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 			var channelsRemoved []string
 			channelsSince, channelsRemoved = db.user.FilterToAvailableChannels(chans)
 			if len(channelsRemoved) > 0 {
-				base.InfofCtx(db.Ctx, base.KeyChanges, "Channels %s request without access by user %s", base.UD(channelsRemoved), base.UD(db.user.Name()))
+				base.InfofCtx(ctx, base.KeyChanges, "Channels %s request without access by user %s", base.UD(channelsRemoved), base.UD(db.user.Name()))
 			}
 		} else {
 			channelsSince = channels.AtSequence(chans, 0)
@@ -683,14 +683,14 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 			if changeWaiter != nil {
 				changeWaiter.UpdateChannels(channelsSince)
 			}
-			base.DebugfCtx(db.Ctx, base.KeyChanges, "MultiChangesFeed: channels expand to %#v ... %s", base.UD(channelsSince.String()), base.UD(to))
+			base.DebugfCtx(ctx, base.KeyChanges, "MultiChangesFeed: channels expand to %#v ... %s", base.UD(channelsSince.String()), base.UD(to))
 
 			// lowSequence is used to send composite keys to clients, so that they can obtain any currently
 			// skipped sequences in a future iteration or request.
 			oldestSkipped := db.changeCache.getOldestSkippedSequence()
 			if oldestSkipped > 0 {
 				lowSequence = oldestSkipped - 1
-				base.InfofCtx(db.Ctx, base.KeyChanges, "%d is the oldest skipped sequence, using stable sequence number of %d for this feed %s", oldestSkipped, lowSequence, base.UD(to))
+				base.InfofCtx(ctx, base.KeyChanges, "%d is the oldest skipped sequence, using stable sequence number of %d for this feed %s", oldestSkipped, lowSequence, base.UD(to))
 			} else {
 				lowSequence = 0
 			}
@@ -728,7 +728,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 					if lateSequenceFeedHandler != nil {
 						latefeed, err := db.getLateFeed(lateSequenceFeedHandler, singleChannelCache)
 						if err != nil {
-							base.WarnfCtx(db.Ctx, "MultiChangesFeed got error reading late sequence feed %q, rolling back channel changes feed to last sent low sequence #%d.", base.UD(name), lastSentLowSeq)
+							base.WarnfCtx(ctx, "MultiChangesFeed got error reading late sequence feed %q, rolling back channel changes feed to last sent low sequence #%d.", base.UD(name), lastSentLowSeq)
 							chanOpts.Since.LowSeq = lastSentLowSeq
 							if lateFeed := db.newLateSequenceFeed(singleChannelCache); lateFeed != nil {
 								lateSequenceFeeds[name] = lateFeed
@@ -770,7 +770,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 				// Backfill required when seqAddedAt is before current sequence
 				backfillRequired := seqAddedAt > 1 && options.Since.Before(SequenceID{Seq: seqAddedAt}) && seqAddedAt <= currentCachedSequence
 				if seqAddedAt > currentCachedSequence {
-					base.DebugfCtx(db.Ctx, base.KeyChanges, "Grant for channel [%s] is after the current sequence - skipped for this iteration.  Grant:[%d] Current:[%d] %s", base.UD(name), seqAddedAt, currentCachedSequence, base.UD(to))
+					base.DebugfCtx(ctx, base.KeyChanges, "Grant for channel [%s] is after the current sequence - skipped for this iteration.  Grant:[%d] Current:[%d] %s", base.UD(name), seqAddedAt, currentCachedSequence, base.UD(to))
 					deferredBackfill = true
 					continue
 				}
@@ -787,7 +787,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 					chanOpts.Since = SequenceID{Seq: options.Since.TriggeredBy - 1}
 				}
 
-				feed := db.changesFeed(singleChannelCache, chanOpts, to)
+				feed := db.changesFeed(ctx, singleChannelCache, chanOpts, to)
 				feeds = append(feeds, feed)
 
 			}
@@ -820,7 +820,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 						}
 					}
 
-					feed := db.buildRevokedFeed(channel, options, revokedSeq, revocationSinceSeq, revokeFrom, to)
+					feed := db.buildRevokedFeed(ctx, channel, options, revokedSeq, revocationSinceSeq, revokeFrom, to)
 					feeds = append(feeds, feed)
 				}
 			}
@@ -845,7 +845,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 						} else {
 							// On feed error, send the error and exit changes processing
 							if current[i].Err == base.ErrChannelFeed {
-								base.WarnfCtx(db.Ctx, "MultiChangesFeed got error reading changes feed: %v", current[i].Err)
+								base.WarnfCtx(ctx, "MultiChangesFeed got error reading changes feed: %v", current[i].Err)
 								output <- current[i]
 								return
 							}
@@ -899,7 +899,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 				// at or before the cached sequence
 				isValidRevocation := minEntry.Revoked == true && minEntry.Seq.TriggeredBy <= currentCachedSequence
 				if currentCachedSequence < minEntry.Seq.Seq && !isValidRevocation {
-					base.DebugfCtx(db.Ctx, base.KeyChanges, "Found sequence later than stable sequence: stable:[%d] entry:[%d] (%s)", currentCachedSequence, minEntry.Seq.Seq, base.UD(minEntry.ID))
+					base.DebugfCtx(ctx, base.KeyChanges, "Found sequence later than stable sequence: stable:[%d] entry:[%d] (%s)", currentCachedSequence, minEntry.Seq.Seq, base.UD(minEntry.ID))
 					postStableSeqsFound = true
 					continue
 				}
@@ -913,7 +913,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 
 				// Add the doc body or the conflicting rev IDs, if those options are set:
 				if options.IncludeDocs || options.Conflicts {
-					db.addDocToChangeEntry(minEntry, options)
+					db.addDocToChangeEntry(ctx, minEntry, options)
 				}
 
 				// Update the low sequence on the entry we're going to send
@@ -922,7 +922,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 				lastSentLowSeq = lowSequence
 
 				// Send the entry, and repeat the loop:
-				base.DebugfCtx(db.Ctx, base.KeyChanges, "MultiChangesFeed sending %+v %s", base.UD(minEntry), base.UD(to))
+				base.DebugfCtx(ctx, base.KeyChanges, "MultiChangesFeed sending %+v %s", base.UD(minEntry), base.UD(to))
 
 				select {
 				case <-options.ChangesCtx.Done():
@@ -953,12 +953,12 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 
 			// If nothing found, and in wait mode: wait for the db to change, then run again.
 			// First notify the reader that we're waiting by sending a nil.
-			base.DebugfCtx(db.Ctx, base.KeyChanges, "MultiChangesFeed waiting... %s", base.UD(to))
+			base.DebugfCtx(ctx, base.KeyChanges, "MultiChangesFeed waiting... %s", base.UD(to))
 			output <- nil
 
 			// If this is an initial replication using CBL 2.x (active only), flip activeOnly now the client has caught up.
 			if options.clientType == clientTypeCBL2 && options.ActiveOnly {
-				base.DebugfCtx(db.Ctx, base.KeyChanges, "%v MultiChangesFeed initial replication caught up - setting ActiveOnly to false... %s", options.Since, base.UD(to))
+				base.DebugfCtx(ctx, base.KeyChanges, "%v MultiChangesFeed initial replication caught up - setting ActiveOnly to false... %s", options.Since, base.UD(to))
 				options.ActiveOnly = false
 			}
 
@@ -1003,10 +1003,10 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 
 			// Check whether user channel access has changed while waiting:
 			var err error
-			userChanged, userCounter, changedChannels, err = db.checkForUserUpdates(userCounter, changeWaiter, options.Continuous)
+			userChanged, userCounter, changedChannels, err = db.checkForUserUpdates(ctx, userCounter, changeWaiter, options.Continuous)
 			if err != nil {
 				change := makeErrorEntry("User not found during reload - terminating changes feed")
-				base.DebugfCtx(db.Ctx, base.KeyChanges, "User not found during reload - terminating changes feed with entry %+v", base.UD(change))
+				base.DebugfCtx(ctx, base.KeyChanges, "User not found during reload - terminating changes feed with entry %+v", base.UD(change))
 				output <- &change
 				return
 			}
@@ -1054,7 +1054,7 @@ func (db *Database) waitForCacheUpdate(ctx context.Context, currentCachedSequenc
 
 // FOR TEST USE ONLY: Synchronous convenience function that returns all changes as a simple array,
 // Returns error if initial feed creation fails, or if an error is returned with the changes entries
-func (db *Database) GetChanges(channels base.Set, options ChangesOptions) ([]*ChangeEntry, error) {
+func (db *Database) GetChanges(ctx context.Context, channels base.Set, options ChangesOptions) ([]*ChangeEntry, error) {
 	if options.ChangesCtx == nil {
 		changesCtx, changesCtxCancel := context.WithCancel(context.Background())
 		options.ChangesCtx = changesCtx
@@ -1062,7 +1062,7 @@ func (db *Database) GetChanges(channels base.Set, options ChangesOptions) ([]*Ch
 	}
 
 	var changes = make([]*ChangeEntry, 0, 50)
-	feed, err := db.MultiChangesFeed(channels, options)
+	feed, err := db.MultiChangesFeed(ctx, channels, options)
 	if err == nil && feed != nil {
 		for entry := range feed {
 			if entry.Err != nil {
@@ -1196,7 +1196,7 @@ func (db *Database) closeLateFeeds(feeds map[string]*lateSequenceFeed) {
 
 // Generate the changes for a specific list of doc ID's, only documents accessible to the user will generate
 // results. Only supports non-continuous changes, closes buffered channel before returning.
-func (db *Database) DocIDChangesFeed(userChannels base.Set, explicitDocIds []string, options ChangesOptions) (<-chan *ChangeEntry, error) {
+func (db *Database) DocIDChangesFeed(ctx context.Context, userChannels base.Set, explicitDocIds []string, options ChangesOptions) (<-chan *ChangeEntry, error) {
 
 	// Subroutine that creates a response row for a document:
 	output := make(chan *ChangeEntry, len(explicitDocIds))
@@ -1205,7 +1205,7 @@ func (db *Database) DocIDChangesFeed(userChannels base.Set, explicitDocIds []str
 	// Sort results by sequence
 	var sequences base.SortedUint64Slice
 	for _, docID := range explicitDocIds {
-		row := createChangesEntry(docID, db, options)
+		row := createChangesEntry(ctx, docID, db, options)
 		if row != nil {
 			rowMap[row.Seq.Seq] = row
 			sequences = append(sequences, row.Seq.Seq)
@@ -1230,12 +1230,12 @@ func (db *Database) DocIDChangesFeed(userChannels base.Set, explicitDocIds []str
 }
 
 // createChangesEntry is used when creating a doc ID filtered changes feed
-func createChangesEntry(docid string, db *Database, options ChangesOptions) *ChangeEntry {
+func createChangesEntry(ctx context.Context, docid string, db *Database, options ChangesOptions) *ChangeEntry {
 	row := &ChangeEntry{ID: docid}
 
-	populatedDoc, err := db.GetDocument(db.Ctx, docid, DocUnmarshalSync)
+	populatedDoc, err := db.GetDocument(ctx, docid, DocUnmarshalSync)
 	if err != nil {
-		base.InfofCtx(db.Ctx, base.KeyChanges, "Unable to get changes for docID %v, caused by %v", base.UD(docid), err)
+		base.InfofCtx(ctx, base.KeyChanges, "Unable to get changes for docID %v, caused by %v", base.UD(docid), err)
 		return nil
 	}
 
@@ -1281,7 +1281,7 @@ func createChangesEntry(docid string, db *Database, options ChangesOptions) *Cha
 
 	row.Removed = base.SetFromArray(removedChannels)
 	if options.IncludeDocs || options.Conflicts {
-		db.AddDocInstanceToChangeEntry(row, populatedDoc, options)
+		db.AddDocInstanceToChangeEntry(ctx, row, populatedDoc, options)
 	}
 
 	return row
@@ -1303,11 +1303,11 @@ func (options ChangesOptions) String() string {
 }
 
 // Used by BLIP connections for changes.  Supports both one-shot and continuous changes.
-func generateBlipSyncChanges(database *Database, inChannels base.Set, options ChangesOptions, docIDFilter []string, send func([]*ChangeEntry) error) (err error, forceClose bool) {
+func generateBlipSyncChanges(ctx context.Context, database *Database, inChannels base.Set, options ChangesOptions, docIDFilter []string, send func([]*ChangeEntry) error) (err error, forceClose bool) {
 
 	// Store one-shot here to protect
 	isOneShot := !options.Continuous
-	err, forceClose = GenerateChanges(options.ChangesCtx, database, inChannels, options, docIDFilter, send)
+	err, forceClose = GenerateChanges(ctx, options.ChangesCtx, database, inChannels, options, docIDFilter, send)
 
 	if _, ok := err.(*ChangesSendErr); ok {
 		return nil, forceClose // error is probably because the client closed the connection
@@ -1326,7 +1326,7 @@ type ChangesSendErr struct{ error }
 // Shell of the continuous changes feed -- calls out to a `send` function to deliver the change.
 // This is called from BLIP connections as well as HTTP handlers, which is why this is not a
 // method on `handler`.
-func GenerateChanges(cancelCtx context.Context, database *Database, inChannels base.Set, options ChangesOptions, docIDFilter []string, send func([]*ChangeEntry) error) (err error, forceClose bool) {
+func GenerateChanges(ctx context.Context, cancelCtx context.Context, database *Database, inChannels base.Set, options ChangesOptions, docIDFilter []string, send func([]*ChangeEntry) error) (err error, forceClose bool) {
 	// Set up heartbeat/timeout
 	var timeoutInterval time.Duration
 	var timer *time.Timer
@@ -1378,9 +1378,9 @@ loop:
 			}
 			var feedErr error
 			if len(docIDFilter) > 0 {
-				feed, feedErr = database.DocIDChangesFeed(inChannels, docIDFilter, options)
+				feed, feedErr = database.DocIDChangesFeed(ctx, inChannels, docIDFilter, options)
 			} else {
-				feed, feedErr = database.MultiChangesFeed(inChannels, options)
+				feed, feedErr = database.MultiChangesFeed(ctx, inChannels, options)
 			}
 			if feedErr != nil || feed == nil {
 				return feedErr, forceClose
@@ -1427,7 +1427,7 @@ loop:
 						break collect
 					}
 				}
-				base.TracefCtx(database.Ctx, base.KeyChanges, "sending %d change(s)", len(entries))
+				base.TracefCtx(ctx, base.KeyChanges, "sending %d change(s)", len(entries))
 				sendErr = send(entries)
 
 				if sendErr == nil && waiting {
@@ -1450,7 +1450,7 @@ loop:
 			}
 		case <-heartbeat:
 			sendErr = send(nil)
-			base.DebugfCtx(database.Ctx, base.KeyChanges, "heartbeat written to _changes feed for request received")
+			base.DebugfCtx(ctx, base.KeyChanges, "heartbeat written to _changes feed for request received")
 		case <-timeout:
 			forceClose = true
 			break loop

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -54,7 +54,8 @@ func TestFilterToAvailableChannels(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			db := setupTestDB(t)
-			defer db.Close()
+			ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+			defer db.Close(ctx)
 
 			auth := db.Authenticator(base.TestCtx(t))
 			user, err := auth.NewUser("test", "pass", testCase.userChans)
@@ -95,7 +96,8 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	}
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 
@@ -209,7 +211,8 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -294,7 +297,8 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	}
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -367,7 +371,8 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 func TestActiveOnlyCacheUpdate(t *testing.T) {
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
 	// Create 10 documents
@@ -432,7 +437,8 @@ func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
 	base.SetUpBenchmarkLogging(b, base.LevelWarn, base.KeyHTTP)
 
 	db := setupTestDB(b)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(b))
+	defer db.Close(ctx)
 
 	fieldVal := func(valSizeBytes int) string {
 		buffer := bytes.Buffer{}

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -53,8 +53,7 @@ func TestFilterToAvailableChannels(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges)
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			db := setupTestDB(t)
-			ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+			db, ctx := setupTestDB(t)
 			defer db.Close(ctx)
 
 			auth := db.Authenticator(base.TestCtx(t))
@@ -95,8 +94,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
@@ -210,8 +208,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
@@ -296,8 +293,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 		t.Skip("This test is known to be failing against couchbase server with XATTRS enabled.  Same error as TestDocDeletionFromChannelCoalescedRemoved")
 	}
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
@@ -370,8 +366,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 
 func TestActiveOnlyCacheUpdate(t *testing.T) {
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
@@ -436,8 +431,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
 	base.SetUpBenchmarkLogging(b, base.LevelWarn, base.KeyHTTP)
 
-	db := setupTestDB(b)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(b))
+	db, ctx := setupTestDB(b)
 	defer db.Close(ctx)
 
 	fieldVal := func(valSizeBytes int) string {

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -64,7 +64,7 @@ func TestFilterToAvailableChannels(t *testing.T) {
 
 			for i := 0; i < testCase.genChanAndDocs; i++ {
 				id := fmt.Sprintf("%d", i+1)
-				_, _, err = db.Put("doc"+id, Body{"channels": []string{"ch" + id}})
+				_, _, err = db.Put(ctx, "doc"+id, Body{"channels": []string{"ch" + id}})
 				require.NoError(t, err)
 			}
 			err = db.WaitForPendingChanges(base.TestCtx(t))
@@ -73,7 +73,7 @@ func TestFilterToAvailableChannels(t *testing.T) {
 			db.user, err = auth.GetUser("test")
 			require.NoError(t, err)
 
-			ch, err := db.GetChanges(testCase.accessChans, getChangesOptionsWithZeroSeq())
+			ch, err := db.GetChanges(ctx, testCase.accessChans, getChangesOptionsWithZeroSeq())
 			require.NoError(t, err)
 			require.Len(t, ch, len(testCase.expectedDocsReturned))
 
@@ -111,7 +111,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
 
 	// Create a doc on two channels (sequence 1):
-	revid, _, err := db.Put("doc1", Body{"channels": []string{"ABC", "PBS"}})
+	revid, _, err := db.Put(ctx, "doc1", Body{"channels": []string{"ABC", "PBS"}})
 	require.NoError(t, err)
 	cacheWaiter.AddAndWait(1)
 
@@ -127,7 +127,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 
 	// Check the _changes feed:
 	db.user, _ = authenticator.GetUser("naomi")
-	changes, err := db.GetChanges(base.SetOf("*"), getChangesOptionsWithZeroSeq())
+	changes, err := db.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq())
 	assert.NoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)
 	require.Len(t, changes, 3)
@@ -149,13 +149,13 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	lastSeq, _ = db.ParseSequenceID(lastSeq.String())
 
 	// Add a new doc (sequence 3):
-	revid, _, err = db.Put("doc2", Body{"channels": []string{"PBS"}})
+	revid, _, err = db.Put(ctx, "doc2", Body{"channels": []string{"PBS"}})
 	require.NoError(t, err)
 
 	// Check the _changes feed -- this is to make sure the changeCache properly received
 	// sequence 2 (the user doc) and isn't stuck waiting for it.
 	cacheWaiter.AddAndWait(1)
-	changes, err = db.GetChanges(base.SetOf("*"), getChangesOptionsWithSeq(lastSeq))
+	changes, err = db.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithSeq(lastSeq))
 
 	assert.NoError(t, err, "Couldn't GetChanges (2nd)")
 
@@ -164,7 +164,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	assert.Equal(t, []ChangeRev{{"rev": revid}}, changes[0].Changes)
 
 	// validate from zero
-	changes, err = db.GetChanges(base.SetOf("*"), getChangesOptionsWithZeroSeq())
+	changes, err = db.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq())
 	assert.NoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)
 
@@ -224,12 +224,12 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
 
 	// Create a doc on two channels (sequence 1):
-	revid, _, err := db.Put("alpha", Body{"channels": []string{"A", "B"}})
+	revid, _, err := db.Put(ctx, "alpha", Body{"channels": []string{"A", "B"}})
 	require.NoError(t, err)
 	cacheWaiter.AddAndWait(1)
 
 	db.user, _ = authenticator.GetUser("alice")
-	changes, err := db.GetChanges(base.SetOf("*"), getChangesOptionsWithZeroSeq())
+	changes, err := db.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq())
 	assert.NoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)
 	assert.Equal(t, 1, len(changes))
@@ -271,7 +271,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	// Check the _changes feed -- this is to make sure the changeCache properly received
 	// sequence 3 and isn't stuck waiting for it.
 	cacheWaiter.AddAndWait(1)
-	changes, err = db.GetChanges(base.SetOf("*"), getChangesOptionsWithSeq(lastSeq))
+	changes, err = db.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithSeq(lastSeq))
 
 	assert.NoError(t, err, "Couldn't GetChanges (2nd)")
 
@@ -310,12 +310,12 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
 
 	// Create a doc on two channels (sequence 1):
-	revid, _, err := db.Put("alpha", Body{"channels": []string{"A", "B"}})
+	revid, _, err := db.Put(ctx, "alpha", Body{"channels": []string{"A", "B"}})
 	require.NoError(t, err)
 	cacheWaiter.AddAndWait(1)
 
 	db.user, _ = authenticator.GetUser("alice")
-	changes, err := db.GetChanges(base.SetOf("*"), getChangesOptionsWithZeroSeq())
+	changes, err := db.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq())
 	assert.NoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)
 
@@ -355,7 +355,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	// sequence 3 (the modified document) and isn't stuck waiting for it.
 	cacheWaiter.AddAndWait(1)
 
-	changes, err = db.GetChanges(base.SetOf("*"), getChangesOptionsWithSeq(lastSeq))
+	changes, err = db.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithSeq(lastSeq))
 
 	assert.NoError(t, err, "Couldn't GetChanges (2nd)")
 
@@ -381,14 +381,14 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 	for i := 1; i <= 10; i++ {
 		key := fmt.Sprintf("%s_%d", t.Name(), i)
 		body := Body{"foo": "bar"}
-		revId, _, err = db.Put(key, body)
+		revId, _, err = db.Put(ctx, key, body)
 		require.NoError(t, err, "Couldn't create document")
 	}
 
 	// Tombstone 5 documents
 	for i := 2; i <= 6; i++ {
 		key := fmt.Sprintf("%s_%d", t.Name(), i)
-		_, err = db.DeleteDoc(key, revId)
+		_, err = db.DeleteDoc(ctx, key, revId)
 		require.NoError(t, err, "Couldn't delete document")
 	}
 
@@ -404,7 +404,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 	initQueryCount := db.DbStats.Cache().ViewQueries.Value()
 
 	// Get changes with active_only=true
-	activeChanges, err := db.GetChanges(base.SetOf("*"), changesOptions)
+	activeChanges, err := db.GetChanges(ctx, base.SetOf("*"), changesOptions)
 	require.NoError(t, err, "Error getting changes with active_only true")
 	require.Equal(t, 5, len(activeChanges))
 
@@ -414,7 +414,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 
 	// Get changes with active_only=false, validate that triggers a new query
 	changesOptions.ActiveOnly = false
-	allChanges, err := db.GetChanges(base.SetOf("*"), changesOptions)
+	allChanges, err := db.GetChanges(ctx, base.SetOf("*"), changesOptions)
 	require.NoError(t, err, "Error getting changes with active_only true")
 	require.Equal(t, 10, len(allChanges))
 
@@ -423,7 +423,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 
 	// Get changes with active_only=false again, verify results are served from the cache
 	changesOptions.ActiveOnly = false
-	allChanges, err = db.GetChanges(base.SetOf("*"), changesOptions)
+	allChanges, err = db.GetChanges(ctx, base.SetOf("*"), changesOptions)
 	require.NoError(t, err, "Error getting changes with active_only true")
 	require.Equal(t, 10, len(allChanges))
 
@@ -467,21 +467,21 @@ func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
 		docid, err := base.GenerateRandomID()
 		require.NoError(b, err)
 		docBody := createDoc(numKeys, valSizeBytes)
-		revId, _, err := db.Put(docid, docBody)
+		revId, _, err := db.Put(ctx, docid, docBody)
 		if err != nil {
 			b.Fatalf("Error creating doc: %v", err)
 		}
 
 		// Create child rev 1
 		docBody["child"] = "A"
-		_, _, err = db.PutExistingRevWithBody(docid, docBody, []string{"2-A", revId}, false)
+		_, _, err = db.PutExistingRevWithBody(ctx, docid, docBody, []string{"2-A", revId}, false)
 		if err != nil {
 			b.Fatalf("Error creating child1 rev: %v", err)
 		}
 
 		// Create child rev 2
 		docBody["child"] = "B"
-		_, _, err = db.PutExistingRevWithBody(docid, docBody, []string{"2-B", revId}, false)
+		_, _, err = db.PutExistingRevWithBody(ctx, docid, docBody, []string{"2-B", revId}, false)
 		if err != nil {
 			b.Fatalf("Error creating child2 rev: %v", err)
 		}
@@ -502,7 +502,7 @@ func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
 
 		changesCtx, changesCtxCancel := context.WithCancel(context.Background())
 		options.ChangesCtx = changesCtx
-		feed, err := db.MultiChangesFeed(base.SetOf("*"), options)
+		feed, err := db.MultiChangesFeed(ctx, base.SetOf("*"), options)
 		if err != nil {
 			b.Fatalf("Error getting changes feed: %v", err)
 		}

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -140,7 +140,7 @@ func (c *channelCacheImpl) Stop() {
 	close(c.terminator)
 
 	// Wait for channel cache background tasks to finish.
-	waitForBGTCompletion(BGTCompletionMaxWait, c.backgroundTasks, c.dbName)
+	waitForBGTCompletion(context.TODO(), BGTCompletionMaxWait, c.backgroundTasks, c.dbName)
 }
 
 func (c *channelCacheImpl) Init(initialSequence uint64) {

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -30,7 +30,6 @@ func TestDuplicateDocID(t *testing.T) {
 	ctx := base.TestCtx(t)
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	ctx = context.AddDatabaseLogContext(ctx)
 	defer context.Close(ctx)
 
 	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
@@ -79,7 +78,6 @@ func TestLateArrivingSequence(t *testing.T) {
 	ctx := base.TestCtx(t)
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	ctx = context.AddDatabaseLogContext(ctx)
 	defer context.Close(ctx)
 
 	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
@@ -114,7 +112,6 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	ctx := base.TestCtx(t)
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	ctx = context.AddDatabaseLogContext(ctx)
 	defer context.Close(ctx)
 
 	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
@@ -149,7 +146,6 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	ctx := base.TestCtx(t)
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	ctx = context.AddDatabaseLogContext(ctx)
 	defer context.Close(ctx)
 
 	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
@@ -225,7 +221,6 @@ func TestPrependChanges(t *testing.T) {
 	ctx := base.TestCtx(t)
 	dbCtx, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	ctx = dbCtx.AddDatabaseLogContext(ctx)
 	defer dbCtx.Close(ctx)
 
 	// 1. Test prepend to empty cache
@@ -411,7 +406,6 @@ func TestChannelCacheRemove(t *testing.T) {
 	ctx := base.TestCtx(t)
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	ctx = context.AddDatabaseLogContext(ctx)
 	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 
@@ -452,7 +446,6 @@ func TestChannelCacheStats(t *testing.T) {
 	ctx := base.TestCtx(t)
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	ctx = context.AddDatabaseLogContext(ctx)
 	defer context.Close(ctx)
 	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	cache := newSingleChannelCache(context, "Test1", 0, testStats)
@@ -524,7 +517,6 @@ func TestChannelCacheStatsOnPrune(t *testing.T) {
 	ctx := base.TestCtx(t)
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	ctx = context.AddDatabaseLogContext(ctx)
 	defer context.Close(ctx)
 	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	cache := newSingleChannelCache(context, "Test1", 0, testStats)
@@ -556,7 +548,6 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	ctx := base.TestCtx(t)
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	ctx = context.AddDatabaseLogContext(ctx)
 	defer context.Close(ctx)
 	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	cache := newSingleChannelCache(context, "Test1", 99, testStats)
@@ -647,7 +638,6 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 	ctx := base.TestCtx(b)
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
-	ctx = context.AddDatabaseLogContext(ctx)
 	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate doc IDs
@@ -668,7 +658,6 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 	ctx := base.TestCtx(b)
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
-	ctx = context.AddDatabaseLogContext(ctx)
 	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate doc IDs
@@ -687,7 +676,6 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 	ctx := base.TestCtx(b)
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
-	ctx = context.AddDatabaseLogContext(ctx)
 	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate doc IDs
@@ -706,7 +694,6 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 	ctx := base.TestCtx(b)
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
-	ctx = context.AddDatabaseLogContext(ctx)
 	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate doc IDs
@@ -725,7 +712,6 @@ func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 	ctx := base.TestCtx(b)
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
-	ctx = context.AddDatabaseLogContext(ctx)
 	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate doc IDs
@@ -744,7 +730,6 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 	ctx := base.TestCtx(b)
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
-	ctx = context.AddDatabaseLogContext(ctx)
 	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate doc IDs
@@ -763,7 +748,6 @@ func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 	ctx := base.TestCtx(b)
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
-	ctx = context.AddDatabaseLogContext(ctx)
 	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate docs

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -27,9 +27,11 @@ func TestDuplicateDocID(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx := base.TestCtx(t)
+	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	defer context.Close()
+	ctx = context.AddDatabaseLogContext(ctx)
+	defer context.Close(ctx)
 
 	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 
@@ -74,9 +76,11 @@ func TestLateArrivingSequence(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx := base.TestCtx(t)
+	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	defer context.Close()
+	ctx = context.AddDatabaseLogContext(ctx)
+	defer context.Close(ctx)
 
 	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 
@@ -107,9 +111,11 @@ func TestLateSequenceAsFirst(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx := base.TestCtx(t)
+	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	defer context.Close()
+	ctx = context.AddDatabaseLogContext(ctx)
+	defer context.Close(ctx)
 
 	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 
@@ -140,9 +146,11 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx := base.TestCtx(t)
+	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	defer context.Close()
+	ctx = context.AddDatabaseLogContext(ctx)
+	defer context.Close(ctx)
 
 	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 
@@ -214,9 +222,11 @@ func TestPrependChanges(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	dbCtx, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx := base.TestCtx(t)
+	dbCtx, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	defer dbCtx.Close()
+	ctx = dbCtx.AddDatabaseLogContext(ctx)
+	defer dbCtx.Close(ctx)
 
 	// 1. Test prepend to empty cache
 	cache := newSingleChannelCache(dbCtx, "PrependEmptyCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
@@ -398,9 +408,11 @@ func TestChannelCacheRemove(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx := base.TestCtx(t)
+	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	defer context.Close()
+	ctx = context.AddDatabaseLogContext(ctx)
+	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 
 	// Add some entries to cache
@@ -437,9 +449,11 @@ func TestChannelCacheStats(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx := base.TestCtx(t)
+	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	defer context.Close()
+	ctx = context.AddDatabaseLogContext(ctx)
+	defer context.Close(ctx)
 	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	cache := newSingleChannelCache(context, "Test1", 0, testStats)
 
@@ -507,9 +521,11 @@ func TestChannelCacheStatsOnPrune(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx := base.TestCtx(t)
+	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	defer context.Close()
+	ctx = context.AddDatabaseLogContext(ctx)
+	defer context.Close(ctx)
 	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	cache := newSingleChannelCache(context, "Test1", 0, testStats)
 	cache.options.ChannelCacheMaxLength = 5
@@ -537,9 +553,11 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx := base.TestCtx(t)
+	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	defer context.Close()
+	ctx = context.AddDatabaseLogContext(ctx)
+	defer context.Close(ctx)
 	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	cache := newSingleChannelCache(context, "Test1", 99, testStats)
 	cache.options.ChannelCacheMaxLength = 15
@@ -626,9 +644,11 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 
 	base.DisableTestLogging(b)
 
-	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
+	ctx := base.TestCtx(b)
+	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
-	defer context.Close()
+	ctx = context.AddDatabaseLogContext(ctx)
+	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate doc IDs
 	docIDs := make([]string, b.N)
@@ -645,9 +665,11 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 
 	base.DisableTestLogging(b)
 
-	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
+	ctx := base.TestCtx(b)
+	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
-	defer context.Close()
+	ctx = context.AddDatabaseLogContext(ctx)
+	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate doc IDs
 
@@ -662,9 +684,11 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 
 	base.DisableTestLogging(b)
 
-	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
+	ctx := base.TestCtx(b)
+	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
-	defer context.Close()
+	ctx = context.AddDatabaseLogContext(ctx)
+	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate doc IDs
 
@@ -679,9 +703,11 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 
 	base.DisableTestLogging(b)
 
-	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
+	ctx := base.TestCtx(b)
+	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
-	defer context.Close()
+	ctx = context.AddDatabaseLogContext(ctx)
+	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate doc IDs
 
@@ -696,9 +722,11 @@ func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 
 	base.DisableTestLogging(b)
 
-	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
+	ctx := base.TestCtx(b)
+	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
-	defer context.Close()
+	ctx = context.AddDatabaseLogContext(ctx)
+	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate doc IDs
 
@@ -713,9 +741,11 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 
 	base.SetUpBenchmarkLogging(b, base.LevelInfo, base.KeyHTTP)
 
-	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
+	ctx := base.TestCtx(b)
+	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
-	defer context.Close()
+	ctx = context.AddDatabaseLogContext(ctx)
+	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate doc IDs
 
@@ -730,9 +760,11 @@ func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 
 	base.DisableTestLogging(b)
 
-	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
+	ctx := base.TestCtx(b)
+	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
-	defer context.Close()
+	ctx = context.AddDatabaseLogContext(ctx)
+	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate docs
 	docs := make([]*LogEntry, b.N)

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -29,9 +29,11 @@ func TestChannelCacheMaxSize(t *testing.T) {
 
 	bucket := base.GetTestBucket(t)
 
-	dbCtx, err := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{})
+	ctx := base.TestCtx(t)
+	dbCtx, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	defer dbCtx.Close()
+	ctx = dbCtx.AddDatabaseLogContext(ctx)
+	defer dbCtx.Close(ctx)
 	cache := dbCtx.changeCache.getChannelCache()
 
 	// Make channels active

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -32,7 +32,6 @@ func TestChannelCacheMaxSize(t *testing.T) {
 	ctx := base.TestCtx(t)
 	dbCtx, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(t, err)
-	ctx = dbCtx.AddDatabaseLogContext(ctx)
 	defer dbCtx.Close(ctx)
 	cache := dbCtx.changeCache.getChannelCache()
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -191,10 +191,10 @@ func (db *DatabaseContext) GetDocSyncData(ctx context.Context, docid string) (Sy
 // if the document gets updated after the initial retrieval attempt that triggered this.
 func (db *DatabaseContext) OnDemandImportForGet(ctx context.Context, docid string, rawDoc []byte, rawXattr []byte, rawUserXattr []byte, cas uint64) (docOut *Document, err error) {
 	isDelete := rawDoc == nil
-	importDb := Database{DatabaseContext: db, user: nil, Ctx: ctx}
+	importDb := Database{DatabaseContext: db, user: nil}
 	var importErr error
 
-	docOut, importErr = importDb.ImportDocRaw(docid, rawDoc, rawXattr, rawUserXattr, isDelete, cas, nil, ImportOnDemand)
+	docOut, importErr = importDb.ImportDocRaw(ctx, docid, rawDoc, rawXattr, rawUserXattr, isDelete, cas, nil, ImportOnDemand)
 	if importErr == base.ErrImportCancelledFilter {
 		// If the import was cancelled due to filter, treat as not found
 		return nil, base.HTTPErrorf(404, "Not imported")
@@ -205,32 +205,32 @@ func (db *DatabaseContext) OnDemandImportForGet(ctx context.Context, docid strin
 }
 
 // GetRev returns the revision for the given docID and revID, or the current active revision if revID is empty.
-func (db *Database) GetRev(docID, revID string, history bool, attachmentsSince []string) (DocumentRevision, error) {
+func (db *Database) GetRev(ctx context.Context, docID, revID string, history bool, attachmentsSince []string) (DocumentRevision, error) {
 	maxHistory := 0
 	if history {
 		maxHistory = math.MaxInt32
 	}
-	return db.getRev(docID, revID, maxHistory, nil, RevCacheOmitBody)
+	return db.getRev(ctx, docID, revID, maxHistory, nil, RevCacheOmitBody)
 }
 
 // Returns the body of the current revision of a document
-func (db *Database) Get1xBody(docid string) (Body, error) {
-	return db.Get1xRevBody(docid, "", false, nil)
+func (db *Database) Get1xBody(ctx context.Context, docid string) (Body, error) {
+	return db.Get1xRevBody(ctx, docid, "", false, nil)
 }
 
 // Get Rev with all-or-none history based on specified 'history' flag
-func (db *Database) Get1xRevBody(docid, revid string, history bool, attachmentsSince []string) (Body, error) {
+func (db *Database) Get1xRevBody(ctx context.Context, docid, revid string, history bool, attachmentsSince []string) (Body, error) {
 	maxHistory := 0
 	if history {
 		maxHistory = math.MaxInt32
 	}
 
-	return db.Get1xRevBodyWithHistory(docid, revid, maxHistory, nil, attachmentsSince, false)
+	return db.Get1xRevBodyWithHistory(ctx, docid, revid, maxHistory, nil, attachmentsSince, false)
 }
 
 // Retrieves rev with request history specified as collection of revids (historyFrom)
-func (db *Database) Get1xRevBodyWithHistory(docid, revid string, maxHistory int, historyFrom []string, attachmentsSince []string, showExp bool) (Body, error) {
-	rev, err := db.getRev(docid, revid, maxHistory, historyFrom, RevCacheIncludeBody)
+func (db *Database) Get1xRevBodyWithHistory(ctx context.Context, docid, revid string, maxHistory int, historyFrom []string, attachmentsSince []string, showExp bool) (Body, error) {
+	rev, err := db.getRev(ctx, docid, revid, maxHistory, historyFrom, RevCacheIncludeBody)
 	if err != nil {
 		return nil, err
 	}
@@ -257,14 +257,14 @@ func (db *Database) Get1xRevBodyWithHistory(docid, revid string, maxHistory int,
 // * attachmentsSince is nil to return no attachment bodies, otherwise a (possibly empty) list of
 //   revisions for which the client already has attachments and doesn't need bodies. Any attachment
 //   that hasn't changed since one of those revisions will be returned as a stub.
-func (db *Database) getRev(docid, revid string, maxHistory int, historyFrom []string, includeBody bool) (revision DocumentRevision, err error) {
+func (db *Database) getRev(ctx context.Context, docid, revid string, maxHistory int, historyFrom []string, includeBody bool) (revision DocumentRevision, err error) {
 	if revid != "" {
 		// Get a specific revision body and history from the revision cache
 		// (which will load them if necessary, by calling revCacheLoader, above)
-		revision, err = db.revisionCache.Get(db.Ctx, docid, revid, includeBody, RevCacheOmitDelta)
+		revision, err = db.revisionCache.Get(ctx, docid, revid, includeBody, RevCacheOmitDelta)
 	} else {
 		// No rev ID given, so load active revision
-		revision, err = db.revisionCache.GetActive(db.Ctx, docid, includeBody)
+		revision, err = db.revisionCache.GetActive(ctx, docid, includeBody)
 	}
 
 	if err != nil {
@@ -273,7 +273,7 @@ func (db *Database) getRev(docid, revid string, maxHistory int, historyFrom []st
 
 	if revision.BodyBytes == nil {
 		if db.ForceAPIForbiddenErrors() {
-			base.InfofCtx(db.Ctx, base.KeyCRUD, "Doc: %s %s is missing", base.UD(docid), base.MD(revid))
+			base.InfofCtx(ctx, base.KeyCRUD, "Doc: %s %s is missing", base.UD(docid), base.MD(revid))
 			return DocumentRevision{}, ErrForbidden
 		}
 		return DocumentRevision{}, ErrMissing
@@ -295,7 +295,7 @@ func (db *Database) getRev(docid, revid string, maxHistory int, historyFrom []st
 			return DocumentRevision{}, ErrForbidden
 		}
 		if db.ForceAPIForbiddenErrors() {
-			base.InfofCtx(db.Ctx, base.KeyCRUD, "Not authorized to view doc: %s %s", base.UD(docid), base.MD(revid))
+			base.InfofCtx(ctx, base.KeyCRUD, "Not authorized to view doc: %s %s", base.UD(docid), base.MD(revid))
 			return DocumentRevision{}, ErrForbidden
 		}
 		return redactedRev, nil
@@ -316,13 +316,13 @@ func (db *Database) getRev(docid, revid string, maxHistory int, historyFrom []st
 
 // GetDelta attempts to return the delta between fromRevId and toRevId.  If the delta can't be generated,
 // returns nil.
-func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta *RevisionDelta, redactedRev *DocumentRevision, err error) {
+func (db *Database) GetDelta(ctx context.Context, docID, fromRevID, toRevID string) (delta *RevisionDelta, redactedRev *DocumentRevision, err error) {
 
 	if docID == "" || fromRevID == "" || toRevID == "" {
 		return nil, nil, nil
 	}
 
-	fromRevision, err := db.revisionCache.Get(db.Ctx, docID, fromRevID, RevCacheOmitBody, RevCacheIncludeDelta)
+	fromRevision, err := db.revisionCache.Get(ctx, docID, fromRevID, RevCacheOmitBody, RevCacheIncludeDelta)
 
 	// If the fromRevision is a removal cache entry (no body), but the user has access to that removal, then just
 	// return 404 missing to indicate that the body of the revision is no longer available.
@@ -365,7 +365,7 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta *RevisionD
 
 		// db.DbStats.StatsDeltaSync().Add(base.StatKeyDeltaCacheMisses, 1)
 		db.DbStats.DeltaSync().DeltaCacheMiss.Add(1)
-		toRevision, err := db.revisionCache.Get(db.Ctx, docID, toRevID, RevCacheOmitBody, RevCacheIncludeDelta)
+		toRevision, err := db.revisionCache.Get(ctx, docID, toRevID, RevCacheOmitBody, RevCacheIncludeDelta)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -383,7 +383,7 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta *RevisionD
 		// If the revision we're generating a delta to is a tombstone, mark it as such and don't bother generating a delta
 		if deleted {
 			revCacheDelta := newRevCacheDelta([]byte(base.EmptyDocument), fromRevID, toRevision, deleted, nil)
-			db.revisionCache.UpdateDelta(db.Ctx, docID, fromRevID, revCacheDelta)
+			db.revisionCache.UpdateDelta(ctx, docID, fromRevID, revCacheDelta)
 			return &revCacheDelta, nil, nil
 		}
 
@@ -423,7 +423,7 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta *RevisionD
 		revCacheDelta := newRevCacheDelta(deltaBytes, fromRevID, toRevision, deleted, toRevAttStorageMeta)
 
 		// Write the newly calculated delta back into the cache before returning
-		db.revisionCache.UpdateDelta(db.Ctx, docID, fromRevID, revCacheDelta)
+		db.revisionCache.UpdateDelta(ctx, docID, fromRevID, revCacheDelta)
 		return &revCacheDelta, nil, nil
 	}
 
@@ -458,12 +458,12 @@ func (db *Database) authorizeUserForChannels(docID, revID string, channels base.
 
 // Returns the body of a revision of a document, as well as the document's current channels
 // and the user/roles it grants channel access to.
-func (db *Database) Get1xRevAndChannels(docID string, revID string, listRevisions bool) (bodyBytes []byte, channels channels.ChannelMap, access UserAccessMap, roleAccess UserAccessMap, flags uint8, sequence uint64, gotRevID string, removed bool, err error) {
-	doc, err := db.GetDocument(db.Ctx, docID, DocUnmarshalAll)
+func (db *Database) Get1xRevAndChannels(ctx context.Context, docID string, revID string, listRevisions bool) (bodyBytes []byte, channels channels.ChannelMap, access UserAccessMap, roleAccess UserAccessMap, flags uint8, sequence uint64, gotRevID string, removed bool, err error) {
+	doc, err := db.GetDocument(ctx, docID, DocUnmarshalAll)
 	if doc == nil {
 		return
 	}
-	bodyBytes, removed, err = db.get1xRevFromDoc(doc, revID, listRevisions)
+	bodyBytes, removed, err = db.get1xRevFromDoc(ctx, doc, revID, listRevisions)
 	if err != nil {
 		return
 	}
@@ -618,11 +618,11 @@ func extractInlineAttachments(bodyBytes []byte) (attachments AttachmentsMeta, cl
 
 // Gets the body of a revision's nearest ancestor, as raw JSON (without _id or _rev.)
 // If no ancestor has any JSON, returns nil but no error.
-func (db *Database) getAncestorJSON(doc *Document, revid string) ([]byte, error) {
+func (db *Database) getAncestorJSON(ctx context.Context, doc *Document, revid string) ([]byte, error) {
 	for {
 		if revid = doc.History.getParent(revid); revid == "" {
 			return nil, nil
-		} else if body := doc.getRevisionBodyJSON(db.Ctx, revid, db.RevisionBodyLoader); body != nil {
+		} else if body := doc.getRevisionBodyJSON(ctx, revid, db.RevisionBodyLoader); body != nil {
 			return body, nil
 		}
 	}
@@ -631,7 +631,7 @@ func (db *Database) getAncestorJSON(doc *Document, revid string) ([]byte, error)
 // Returns the body of a revision given a document struct. Checks user access.
 // If the user is not authorized to see the specific revision they asked for,
 // instead returns a minimal deletion or removal revision to let them know it's gone.
-func (db *Database) get1xRevFromDoc(doc *Document, revid string, listRevisions bool) (bodyBytes []byte, removed bool, err error) {
+func (db *Database) get1xRevFromDoc(ctx context.Context, doc *Document, revid string, listRevisions bool) (bodyBytes []byte, removed bool, err error) {
 	var attachments AttachmentsMeta
 	if err := db.authorizeDoc(doc, revid); err != nil {
 		// As a special case, you don't need channel access to see a deletion revision,
@@ -656,7 +656,7 @@ func (db *Database) get1xRevFromDoc(doc *Document, revid string, listRevisions b
 				return nil, false, ErrDeleted
 			}
 		}
-		if bodyBytes, _, attachments, err = db.getRevision(db.Ctx, doc, revid); err != nil {
+		if bodyBytes, _, attachments, err = db.getRevision(ctx, doc, revid); err != nil {
 			return nil, false, err
 		}
 	}
@@ -691,9 +691,9 @@ func (db *Database) get1xRevFromDoc(doc *Document, revid string, listRevisions b
 }
 
 // Returns the body and rev ID of the asked-for revision or the most recent available ancestor.
-func (db *Database) getAvailableRev(doc *Document, revid string) ([]byte, string, AttachmentsMeta, error) {
+func (db *Database) getAvailableRev(ctx context.Context, doc *Document, revid string) ([]byte, string, AttachmentsMeta, error) {
 	for ; revid != ""; revid = doc.History[revid].Parent {
-		if bodyBytes, _, attachments, _ := db.getRevision(db.Ctx, doc, revid); bodyBytes != nil {
+		if bodyBytes, _, attachments, _ := db.getRevision(ctx, doc, revid); bodyBytes != nil {
 			return bodyBytes, revid, attachments, nil
 		}
 	}
@@ -701,8 +701,8 @@ func (db *Database) getAvailableRev(doc *Document, revid string) ([]byte, string
 }
 
 // Returns the 1x-style body of the asked-for revision or the most recent available ancestor.
-func (db *Database) getAvailable1xRev(doc *Document, revid string) ([]byte, error) {
-	bodyBytes, ancestorRevID, attachments, err := db.getAvailableRev(doc, revid)
+func (db *Database) getAvailable1xRev(ctx context.Context, doc *Document, revid string) ([]byte, error) {
+	bodyBytes, ancestorRevID, attachments, err := db.getAvailableRev(ctx, doc, revid)
 	if err != nil {
 		return nil, err
 	}
@@ -730,8 +730,8 @@ func (db *Database) getAvailable1xRev(doc *Document, revid string) ([]byte, erro
 
 // Returns the attachments of the asked-for revision or the most recent available ancestor.
 // Returns nil if no attachments or ancestors are found.
-func (db *Database) getAvailableRevAttachments(doc *Document, revid string) (ancestorAttachments AttachmentsMeta, foundAncestor bool) {
-	_, _, attachments, err := db.getAvailableRev(doc, revid)
+func (db *Database) getAvailableRevAttachments(ctx context.Context, doc *Document, revid string) (ancestorAttachments AttachmentsMeta, foundAncestor bool) {
+	_, _, attachments, err := db.getAvailableRev(ctx, doc, revid)
 	if err != nil {
 		return nil, false
 	}
@@ -740,10 +740,10 @@ func (db *Database) getAvailableRevAttachments(doc *Document, revid string) (anc
 }
 
 // Moves a revision's ancestor's body out of the document object and into a separate db doc.
-func (db *Database) backupAncestorRevs(doc *Document, newDoc *Document) {
+func (db *Database) backupAncestorRevs(ctx context.Context, doc *Document, newDoc *Document) {
 	newBodyBytes, err := newDoc.BodyBytes()
 	if err != nil {
-		base.WarnfCtx(db.Ctx, "Error getting body bytes when backing up ancestor revs")
+		base.WarnfCtx(ctx, "Error getting body bytes when backing up ancestor revs")
 		return
 	}
 
@@ -753,15 +753,15 @@ func (db *Database) backupAncestorRevs(doc *Document, newDoc *Document) {
 	for {
 		if ancestorRevId = doc.History.getParent(ancestorRevId); ancestorRevId == "" {
 			// No ancestors with JSON found.  Check if we need to back up current rev for delta sync, then return
-			db.backupRevisionJSON(doc.ID, newDoc.RevID, "", newBodyBytes, nil, doc.Attachments)
+			db.backupRevisionJSON(ctx, doc.ID, newDoc.RevID, "", newBodyBytes, nil, doc.Attachments)
 			return
-		} else if json = doc.getRevisionBodyJSON(db.Ctx, ancestorRevId, db.RevisionBodyLoader); json != nil {
+		} else if json = doc.getRevisionBodyJSON(ctx, ancestorRevId, db.RevisionBodyLoader); json != nil {
 			break
 		}
 	}
 
 	// Back up the revision JSON as a separate doc in the bucket:
-	db.backupRevisionJSON(doc.ID, newDoc.RevID, ancestorRevId, newBodyBytes, json, doc.Attachments)
+	db.backupRevisionJSON(ctx, doc.ID, newDoc.RevID, ancestorRevId, newBodyBytes, json, doc.Attachments)
 
 	// Nil out the ancestor rev's body in the document struct:
 	if ancestorRevId == doc.CurrentRev {
@@ -773,7 +773,7 @@ func (db *Database) backupAncestorRevs(doc *Document, newDoc *Document) {
 
 // ////// UPDATING DOCUMENTS:
 
-func (db *Database) OnDemandImportForWrite(docid string, doc *Document, deleted bool) error {
+func (db *Database) OnDemandImportForWrite(ctx context.Context, docid string, doc *Document, deleted bool) error {
 
 	// Check whether the doc requiring import is an SDK delete
 	isDelete := false
@@ -785,7 +785,7 @@ func (db *Database) OnDemandImportForWrite(docid string, doc *Document, deleted 
 	// Use an admin-scoped database for import
 	importDb := Database{DatabaseContext: db.DatabaseContext, user: nil}
 
-	importedDoc, importErr := importDb.ImportDoc(docid, doc, isDelete, nil, ImportOnDemand)
+	importedDoc, importErr := importDb.ImportDoc(ctx, docid, doc, isDelete, nil, ImportOnDemand)
 
 	if importErr == base.ErrImportCancelledFilter {
 		// Document exists, but existing doc wasn't imported based on import filter.  Treat write as insert
@@ -800,7 +800,7 @@ func (db *Database) OnDemandImportForWrite(docid string, doc *Document, deleted 
 
 // Updates or creates a document.
 // The new body's BodyRev property must match the current revision's, if any.
-func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document, err error) {
+func (db *Database) Put(ctx context.Context, docid string, body Body) (newRevID string, doc *Document, err error) {
 
 	delete(body, BodyId)
 
@@ -838,13 +838,13 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 	}
 
 	allowImport := db.UseXattrs()
-	doc, newRevID, err = db.updateAndReturnDoc(newDoc.ID, allowImport, expiry, nil, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+	doc, newRevID, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, expiry, nil, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		var isSgWrite bool
 		var crc32Match bool
 
 		// Is this doc an sgWrite?
 		if doc != nil {
-			isSgWrite, crc32Match, _ = doc.IsSGWrite(db.Ctx, nil)
+			isSgWrite, crc32Match, _ = doc.IsSGWrite(ctx, nil)
 			if crc32Match {
 				db.DbStats.Database().Crc32MatchCount.Add(1)
 			}
@@ -853,10 +853,10 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 		// (Be careful: this block can be invoked multiple times if there are races!)
 		// If the existing doc isn't an SG write, import prior to updating
 		if doc != nil && !isSgWrite && db.UseXattrs() {
-			err := db.OnDemandImportForWrite(newDoc.ID, doc, deleted)
+			err := db.OnDemandImportForWrite(ctx, newDoc.ID, doc, deleted)
 			if err != nil {
 				if db.ForceAPIForbiddenErrors() {
-					base.InfofCtx(db.Ctx, base.KeyCRUD, "Importing doc %q prior to write caused error", base.UD(newDoc.ID))
+					base.InfofCtx(ctx, base.KeyCRUD, "Importing doc %q prior to write caused error", base.UD(newDoc.ID))
 					return nil, nil, false, nil, ErrForbidden
 				}
 				return nil, nil, false, nil, err
@@ -877,7 +877,7 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 					generation++
 				}
 			}
-		} else if !doc.History.isLeaf(matchRev) || db.IsIllegalConflict(doc, matchRev, deleted, false, nil) {
+		} else if !doc.History.isLeaf(matchRev) || db.IsIllegalConflict(ctx, doc, matchRev, deleted, false, nil) {
 			conflictErr = base.HTTPErrorf(http.StatusConflict, "Document revision conflict")
 		}
 
@@ -909,13 +909,13 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 				// Make sure the user has permission to modify the document before confirming doc existence
 				mutableBody, metaMap, newRevID, err := db.prepareSyncFn(doc, newDoc)
 				if err != nil {
-					base.InfofCtx(db.Ctx, base.KeyCRUD, "Failed to prepare to run sync function: %v", err)
+					base.InfofCtx(ctx, base.KeyCRUD, "Failed to prepare to run sync function: %v", err)
 					return nil, nil, false, nil, ErrForbidden
 				}
 
-				_, _, _, _, _, err = db.runSyncFn(doc, mutableBody, metaMap, newRevID)
+				_, _, _, _, _, err = db.runSyncFn(ctx, doc, mutableBody, metaMap, newRevID)
 				if err != nil {
-					base.DebugfCtx(db.Ctx, base.KeyCRUD, "Could not modify doc %q due to %s and sync func rejection: %v", base.UD(doc.ID), conflictErr, err)
+					base.DebugfCtx(ctx, base.KeyCRUD, "Could not modify doc %q due to %s and sync func rejection: %v", base.UD(doc.ID), conflictErr, err)
 					return nil, nil, false, nil, ErrForbidden
 				}
 			}
@@ -924,7 +924,7 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 
 		// Process the attachments, and populate _sync with metadata. This alters 'body' so it has to
 		// be done before calling CreateRevID (the ID is based on the digest of the body.)
-		newAttachments, err := db.storeAttachments(doc, newDoc.DocAttachments, generation, matchRev, nil)
+		newAttachments, err := db.storeAttachments(ctx, doc, newDoc.DocAttachments, generation, matchRev, nil)
 		if err != nil {
 			return nil, nil, false, nil, err
 		}
@@ -932,7 +932,7 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 		newRev := CreateRevIDWithBytes(generation, matchRev, canonicalBytesForRevID)
 
 		if err := doc.History.addRevision(newDoc.ID, RevInfo{ID: newRev, Parent: matchRev, Deleted: deleted}); err != nil {
-			base.InfofCtx(db.Ctx, base.KeyCRUD, "Failed to add revision ID: %s, for doc: %s, error: %v", newRev, base.UD(docid), err)
+			base.InfofCtx(ctx, base.KeyCRUD, "Failed to add revision ID: %s, for doc: %s, error: %v", newRev, base.UD(docid), err)
 			return nil, nil, false, nil, base.ErrRevTreeAddRevFailure
 		}
 
@@ -946,8 +946,8 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 }
 
 // Adds an existing revision to a document along with its history (list of rev IDs.)
-func (db *Database) PutExistingRev(newDoc *Document, docHistory []string, noConflicts bool, forceAllConflicts bool, existingDoc *sgbucket.BucketDocument) (doc *Document, newRevID string, err error) {
-	return db.PutExistingRevWithConflictResolution(newDoc, docHistory, noConflicts, nil, forceAllConflicts, existingDoc)
+func (db *Database) PutExistingRev(ctx context.Context, newDoc *Document, docHistory []string, noConflicts bool, forceAllConflicts bool, existingDoc *sgbucket.BucketDocument) (doc *Document, newRevID string, err error) {
+	return db.PutExistingRevWithConflictResolution(ctx, newDoc, docHistory, noConflicts, nil, forceAllConflicts, existingDoc)
 }
 
 // PutExistingRevWithConflictResolution Adds an existing revision to a document along with its history (list of rev IDs.)
@@ -955,7 +955,7 @@ func (db *Database) PutExistingRev(newDoc *Document, docHistory []string, noConf
 //     1. If noConflicts == false, the revision will be added to the rev tree as a conflict
 //     2. If noConflicts == true and a conflictResolverFunc is not provided, a 409 conflict error will be returned
 //     3. If noConflicts == true and a conflictResolverFunc is provided, conflicts will be resolved and the result added to the document.
-func (db *Database) PutExistingRevWithConflictResolution(newDoc *Document, docHistory []string, noConflicts bool, conflictResolver *ConflictResolver, forceAllowConflictingTombstone bool, existingDoc *sgbucket.BucketDocument) (doc *Document, newRevID string, err error) {
+func (db *Database) PutExistingRevWithConflictResolution(ctx context.Context, newDoc *Document, docHistory []string, noConflicts bool, conflictResolver *ConflictResolver, forceAllowConflictingTombstone bool, existingDoc *sgbucket.BucketDocument) (doc *Document, newRevID string, err error) {
 	newRev := docHistory[0]
 	generation, _ := ParseRevID(newRev)
 	if generation < 0 {
@@ -963,7 +963,7 @@ func (db *Database) PutExistingRevWithConflictResolution(newDoc *Document, docHi
 	}
 
 	allowImport := db.UseXattrs()
-	doc, _, err = db.updateAndReturnDoc(newDoc.ID, allowImport, newDoc.DocExpiry, nil, existingDoc, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+	doc, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, newDoc.DocExpiry, nil, existingDoc, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)
 
 		var isSgWrite bool
@@ -971,7 +971,7 @@ func (db *Database) PutExistingRevWithConflictResolution(newDoc *Document, docHi
 
 		// Is this doc an sgWrite?
 		if doc != nil {
-			isSgWrite, crc32Match, _ = doc.IsSGWrite(db.Ctx, nil)
+			isSgWrite, crc32Match, _ = doc.IsSGWrite(ctx, nil)
 			if crc32Match {
 				db.DbStats.Database().Crc32MatchCount.Add(1)
 			}
@@ -979,7 +979,7 @@ func (db *Database) PutExistingRevWithConflictResolution(newDoc *Document, docHi
 
 		// If the existing doc isn't an SG write, import prior to updating
 		if doc != nil && !isSgWrite && db.UseXattrs() {
-			err := db.OnDemandImportForWrite(newDoc.ID, doc, newDoc.Deleted)
+			err := db.OnDemandImportForWrite(ctx, newDoc.ID, doc, newDoc.Deleted)
 			if err != nil {
 				return nil, nil, false, nil, err
 			}
@@ -996,7 +996,7 @@ func (db *Database) PutExistingRevWithConflictResolution(newDoc *Document, docHi
 			}
 		}
 		if currentRevIndex == 0 {
-			base.DebugfCtx(db.Ctx, base.KeyCRUD, "PutExistingRevWithBody(%q): No new revisions to add", base.UD(newDoc.ID))
+			base.DebugfCtx(ctx, base.KeyCRUD, "PutExistingRevWithBody(%q): No new revisions to add", base.UD(newDoc.ID))
 			newDoc.RevID = newRev
 			return nil, nil, false, nil, base.ErrUpdateCancel // No new revisions to add
 		}
@@ -1006,13 +1006,13 @@ func (db *Database) PutExistingRevWithConflictResolution(newDoc *Document, docHi
 		// We only bypass conflict resolution for incoming tombstones if the local doc is also a tombstone
 		allowConflictingTombstone := forceAllowConflictingTombstone && doc.IsDeleted()
 
-		if !allowConflictingTombstone && db.IsIllegalConflict(doc, parent, newDoc.Deleted, noConflicts, docHistory) {
+		if !allowConflictingTombstone && db.IsIllegalConflict(ctx, doc, parent, newDoc.Deleted, noConflicts, docHistory) {
 			if conflictResolver == nil {
 				return nil, nil, false, nil, base.HTTPErrorf(http.StatusConflict, "Document revision conflict")
 			}
-			_, updatedHistory, err := db.resolveConflict(doc, newDoc, docHistory, conflictResolver)
+			_, updatedHistory, err := db.resolveConflict(ctx, doc, newDoc, docHistory, conflictResolver)
 			if err != nil {
-				base.InfofCtx(db.Ctx, base.KeyCRUD, "Error resolving conflict for %s: %v", base.UD(doc.ID), err)
+				base.InfofCtx(ctx, base.KeyCRUD, "Error resolving conflict for %s: %v", base.UD(doc.ID), err)
 				return nil, nil, false, nil, err
 			}
 			if updatedHistory != nil {
@@ -1049,7 +1049,7 @@ func (db *Database) PutExistingRevWithConflictResolution(newDoc *Document, docHi
 
 		// Process the attachments, replacing bodies with digests.
 		parentRevID := doc.History[newRev].Parent
-		newAttachments, err := db.storeAttachments(doc, newDoc.DocAttachments, generation, parentRevID, docHistory)
+		newAttachments, err := db.storeAttachments(ctx, doc, newDoc.DocAttachments, generation, parentRevID, docHistory)
 		if err != nil {
 			return nil, nil, false, nil, err
 		}
@@ -1062,7 +1062,7 @@ func (db *Database) PutExistingRevWithConflictResolution(newDoc *Document, docHi
 	return doc, newRev, err
 }
 
-func (db *Database) PutExistingRevWithBody(docid string, body Body, docHistory []string, noConflicts bool) (doc *Document, newRev string, err error) {
+func (db *Database) PutExistingRevWithBody(ctx context.Context, docid string, body Body, docHistory []string, noConflicts bool) (doc *Document, newRev string, err error) {
 	err = validateAPIDocUpdate(body)
 	if err != nil {
 		return nil, "", err
@@ -1087,7 +1087,7 @@ func (db *Database) PutExistingRevWithBody(docid string, body Body, docHistory [
 
 	newDoc.UpdateBody(body)
 
-	doc, newRevID, putExistingRevErr := db.PutExistingRev(newDoc, docHistory, noConflicts, false, nil)
+	doc, newRevID, putExistingRevErr := db.PutExistingRev(ctx, newDoc, docHistory, noConflicts, false, nil)
 
 	if putExistingRevErr != nil {
 		return nil, "", putExistingRevErr
@@ -1100,7 +1100,7 @@ func (db *Database) PutExistingRevWithBody(docid string, body Body, docHistory [
 // resolveConflict runs the conflictResolverFunction with doc and newDoc.  doc and newDoc's bodies and revision trees
 // may be changed based on the outcome of conflict resolution - see resolveDocLocalWins, resolveDocRemoteWins and
 // resolveDocMerge for specifics on what is changed under each scenario.
-func (db *Database) resolveConflict(localDoc *Document, remoteDoc *Document, docHistory []string, resolver *ConflictResolver) (resolvedRevID string, updatedHistory []string, resolveError error) {
+func (db *Database) resolveConflict(ctx context.Context, localDoc *Document, remoteDoc *Document, docHistory []string, resolver *ConflictResolver) (resolvedRevID string, updatedHistory []string, resolveError error) {
 
 	if resolver == nil {
 		return "", nil, errors.New("Conflict resolution function is nil for resolveConflict")
@@ -1145,19 +1145,19 @@ func (db *Database) resolveConflict(localDoc *Document, remoteDoc *Document, doc
 
 	resolvedBody, resolutionType, resolveFuncError := resolver.Resolve(conflict)
 	if resolveFuncError != nil {
-		base.InfofCtx(db.Ctx, base.KeyReplicate, "Error when running conflict resolution for doc %s: %v", base.UD(localDoc.ID), resolveFuncError)
+		base.InfofCtx(ctx, base.KeyReplicate, "Error when running conflict resolution for doc %s: %v", base.UD(localDoc.ID), resolveFuncError)
 		return "", nil, resolveFuncError
 	}
 
 	switch resolutionType {
 	case ConflictResolutionLocal:
-		resolvedRevID, updatedHistory, resolveError = db.resolveDocLocalWins(localDoc, remoteDoc, conflict, docHistory)
+		resolvedRevID, updatedHistory, resolveError = db.resolveDocLocalWins(ctx, localDoc, remoteDoc, conflict, docHistory)
 		return resolvedRevID, updatedHistory, resolveError
 	case ConflictResolutionRemote:
-		resolvedRevID, resolveError = db.resolveDocRemoteWins(localDoc, conflict)
+		resolvedRevID, resolveError = db.resolveDocRemoteWins(ctx, localDoc, conflict)
 		return resolvedRevID, nil, resolveError
 	case ConflictResolutionMerge:
-		resolvedRevID, updatedHistory, resolveError = db.resolveDocMerge(localDoc, remoteDoc, conflict, docHistory, resolvedBody)
+		resolvedRevID, updatedHistory, resolveError = db.resolveDocMerge(ctx, localDoc, remoteDoc, conflict, docHistory, resolvedBody)
 		return resolvedRevID, updatedHistory, resolveError
 	default:
 		return "", nil, fmt.Errorf("Unexpected conflict resolution type: %v", resolutionType)
@@ -1167,16 +1167,16 @@ func (db *Database) resolveConflict(localDoc *Document, remoteDoc *Document, doc
 // resolveDocRemoteWins makes the following changes to the document:
 //   - Tombstones the local revision
 // The remote revision is added to the revision tree by the standard update processing.
-func (db *Database) resolveDocRemoteWins(localDoc *Document, conflict Conflict) (resolvedRevID string, err error) {
+func (db *Database) resolveDocRemoteWins(ctx context.Context, localDoc *Document, conflict Conflict) (resolvedRevID string, err error) {
 
 	// Tombstone the local revision
 	localRevID := localDoc.CurrentRev
-	tombstoneRevID, tombstoneErr := db.tombstoneActiveRevision(localDoc, localRevID)
+	tombstoneRevID, tombstoneErr := db.tombstoneActiveRevision(ctx, localDoc, localRevID)
 	if err != nil {
 		return "", tombstoneErr
 	}
 	remoteRevID := conflict.RemoteDocument.ExtractRev()
-	base.DebugfCtx(db.Ctx, base.KeyReplicate, "Resolved conflict for doc %s as remote wins - remote rev is %s, previous local rev %s tombstoned by %s, ", base.UD(localDoc.ID), remoteRevID, localRevID, tombstoneRevID)
+	base.DebugfCtx(ctx, base.KeyReplicate, "Resolved conflict for doc %s as remote wins - remote rev is %s, previous local rev %s tombstoned by %s, ", base.UD(localDoc.ID), remoteRevID, localRevID, tombstoneRevID)
 	return remoteRevID, nil
 }
 
@@ -1188,7 +1188,7 @@ func (db *Database) resolveDocRemoteWins(localDoc *Document, conflict Conflict) 
 //       results in additional replication work for clients that have previously replicated the local
 //       revision.  This will be addressed post-Hydrogen with version vector work, but additional analysis
 //       of options for Hydrogen should be completed.
-func (db *Database) resolveDocLocalWins(localDoc *Document, remoteDoc *Document, conflict Conflict, docHistory []string) (resolvedRevID string, updatedHistory []string, err error) {
+func (db *Database) resolveDocLocalWins(ctx context.Context, localDoc *Document, remoteDoc *Document, conflict Conflict, docHistory []string) (resolvedRevID string, updatedHistory []string, err error) {
 
 	// Clone the local revision as a child of the remote revision
 	docBodyBytes, err := localDoc.BodyBytes()
@@ -1248,7 +1248,7 @@ func (db *Database) resolveDocLocalWins(localDoc *Document, remoteDoc *Document,
 		for _, value := range remoteDoc.DocAttachments {
 			attachmentMeta, ok := value.(map[string]interface{})
 			if !ok {
-				base.WarnfCtx(db.Ctx, "Unable to parse attachment meta during conflict resolution for %s/%s: %v", base.UD(localDoc.ID), localDoc.SyncData.CurrentRev, value)
+				base.WarnfCtx(ctx, "Unable to parse attachment meta during conflict resolution for %s/%s: %v", base.UD(localDoc.ID), localDoc.SyncData.CurrentRev, value)
 				continue
 			}
 			revpos, ok := base.ToInt64(attachmentMeta["revpos"])
@@ -1262,12 +1262,12 @@ func (db *Database) resolveDocLocalWins(localDoc *Document, remoteDoc *Document,
 
 	// Tombstone the local revision
 	localRevID := localDoc.CurrentRev
-	tombstoneRevID, tombstoneErr := db.tombstoneActiveRevision(localDoc, localRevID)
+	tombstoneRevID, tombstoneErr := db.tombstoneActiveRevision(ctx, localDoc, localRevID)
 	if tombstoneErr != nil {
 		return "", nil, tombstoneErr
 	}
 
-	base.DebugfCtx(db.Ctx, base.KeyReplicate, "Resolved conflict for doc %s as localWins - local rev %s moved to %s, and tombstoned with %s", base.UD(localDoc.ID), localRevID, newRevID, tombstoneRevID)
+	base.DebugfCtx(ctx, base.KeyReplicate, "Resolved conflict for doc %s as localWins - local rev %s moved to %s, and tombstoned with %s", base.UD(localDoc.ID), localRevID, newRevID, tombstoneRevID)
 	return newRevID, docHistory, nil
 }
 
@@ -1275,7 +1275,7 @@ func (db *Database) resolveDocLocalWins(localDoc *Document, remoteDoc *Document,
 //   - Tombstones the local revision
 //   - Modifies the incoming document body to the merged body
 //   - Modifies the incoming history to prepend the merged revid (retaining the previous remote revID as its parent)
-func (db *Database) resolveDocMerge(localDoc *Document, remoteDoc *Document, conflict Conflict, docHistory []string, mergedBody Body) (resolvedRevID string, updatedHistory []string, err error) {
+func (db *Database) resolveDocMerge(ctx context.Context, localDoc *Document, remoteDoc *Document, conflict Conflict, docHistory []string, mergedBody Body) (resolvedRevID string, updatedHistory []string, err error) {
 
 	// Move attachments from the merged body to the incoming DocAttachments for normal processing.
 	bodyAtts, ok := mergedBody[BodyAttachments]
@@ -1289,7 +1289,7 @@ func (db *Database) resolveDocMerge(localDoc *Document, remoteDoc *Document, con
 
 	// Tombstone the local revision
 	localRevID := localDoc.CurrentRev
-	tombstoneRevID, tombstoneErr := db.tombstoneActiveRevision(localDoc, localRevID)
+	tombstoneRevID, tombstoneErr := db.tombstoneActiveRevision(ctx, localDoc, localRevID)
 	if tombstoneErr != nil {
 		return "", nil, tombstoneErr
 	}
@@ -1309,12 +1309,12 @@ func (db *Database) resolveDocMerge(localDoc *Document, remoteDoc *Document, con
 	// Update the history for the remote doc to prepend the merged revID
 	docHistory = append([]string{mergedRevID}, docHistory...)
 
-	base.DebugfCtx(db.Ctx, base.KeyReplicate, "Resolved conflict for doc %s as merge - merged rev %s added as child of %s, previous local rev %s tombstoned by %s", base.UD(localDoc.ID), mergedRevID, remoteRevID, localRevID, tombstoneRevID)
+	base.DebugfCtx(ctx, base.KeyReplicate, "Resolved conflict for doc %s as merge - merged rev %s added as child of %s, previous local rev %s tombstoned by %s", base.UD(localDoc.ID), mergedRevID, remoteRevID, localRevID, tombstoneRevID)
 	return mergedRevID, docHistory, nil
 }
 
 // tombstoneRevision updates the document's revision tree to add a tombstone revision as a child of the specified revID
-func (db *Database) tombstoneActiveRevision(doc *Document, revID string) (tombstoneRevID string, err error) {
+func (db *Database) tombstoneActiveRevision(ctx context.Context, doc *Document, revID string) (tombstoneRevID string, err error) {
 
 	if doc.CurrentRev != revID {
 		return "", fmt.Errorf("Attempted to tombstone active revision for doc (%s), but provided rev (%s) doesn't match current rev(%s)", base.UD(doc.ID), revID, doc.CurrentRev)
@@ -1322,7 +1322,7 @@ func (db *Database) tombstoneActiveRevision(doc *Document, revID string) (tombst
 
 	// Don't tombstone an already deleted revision, return the incoming revID instead.
 	if doc.IsDeleted() {
-		base.DebugfCtx(db.Ctx, base.KeyReplicate, "Active revision %s/%s is already tombstoned.", base.UD(doc.ID), revID)
+		base.DebugfCtx(ctx, base.KeyReplicate, "Active revision %s/%s is already tombstoned.", base.UD(doc.ID), revID)
 		return revID, nil
 	}
 
@@ -1342,7 +1342,7 @@ func (db *Database) tombstoneActiveRevision(doc *Document, revID string) (tombst
 	// Backup previous revision body, then remove the current body from the doc
 	bodyBytes, err := doc.BodyBytes()
 	if err == nil {
-		_ = db.setOldRevisionJSON(doc.ID, revID, bodyBytes, db.Options.OldRevExpirySeconds)
+		_ = db.setOldRevisionJSON(ctx, doc.ID, revID, bodyBytes, db.Options.OldRevExpirySeconds)
 	}
 	doc.RemoveBody()
 
@@ -1362,12 +1362,12 @@ func (doc *Document) updateWinningRevAndSetDocFlags() {
 	}
 }
 
-func (db *Database) storeOldBodyInRevTreeAndUpdateCurrent(doc *Document, prevCurrentRev string, newRevID string, newDoc *Document, newDocHasAttachments bool) {
+func (db *Database) storeOldBodyInRevTreeAndUpdateCurrent(ctx context.Context, doc *Document, prevCurrentRev string, newRevID string, newDoc *Document, newDocHasAttachments bool) {
 	if doc.HasBody() && doc.CurrentRev != prevCurrentRev && prevCurrentRev != "" {
 		// Store the doc's previous body into the revision tree:
 		oldBodyJson, marshalErr := doc.BodyBytes()
 		if marshalErr != nil {
-			base.WarnfCtx(db.Ctx, "Unable to marshal document body for storage in rev tree: %v", marshalErr)
+			base.WarnfCtx(ctx, "Unable to marshal document body for storage in rev tree: %v", marshalErr)
 		}
 
 		var kvPairs []base.KVPair
@@ -1408,7 +1408,7 @@ func (db *Database) storeOldBodyInRevTreeAndUpdateCurrent(doc *Document, prevCur
 		// Stamp _attachments and _deleted into rev tree bodies
 		oldBodyJson, marshalErr = base.InjectJSONProperties(oldBodyJson, kvPairs...)
 		if marshalErr != nil {
-			base.WarnfCtx(db.Ctx, "Unable to marshal document body properties for storage in rev tree: %v", marshalErr)
+			base.WarnfCtx(ctx, "Unable to marshal document body properties for storage in rev tree: %v", marshalErr)
 		}
 		doc.setNonWinningRevisionBody(prevCurrentRev, oldBodyJson, db.AllowExternalRevBodyStorage(), oldDocHasAttachments)
 	}
@@ -1458,19 +1458,19 @@ func (db *Database) prepareSyncFn(doc *Document, newDoc *Document) (mutableBody 
 
 // Run the sync function on the given document and body. Need to inject the document ID and rev ID temporarily to run
 // the sync function.
-func (db *Database) runSyncFn(doc *Document, body Body, metaMap map[string]interface{}, newRevId string) (*uint32, string, base.Set, channels.AccessMap, channels.AccessMap, error) {
-	channelSet, access, roles, syncExpiry, oldBody, err := db.getChannelsAndAccess(doc, body, metaMap, newRevId)
+func (db *Database) runSyncFn(ctx context.Context, doc *Document, body Body, metaMap map[string]interface{}, newRevId string) (*uint32, string, base.Set, channels.AccessMap, channels.AccessMap, error) {
+	channelSet, access, roles, syncExpiry, oldBody, err := db.getChannelsAndAccess(ctx, doc, body, metaMap, newRevId)
 	if err != nil {
 		return nil, ``, nil, nil, nil, err
 	}
-	db.checkDocChannelsAndGrantsLimits(doc.ID, channelSet, access, roles)
+	db.checkDocChannelsAndGrantsLimits(ctx, doc.ID, channelSet, access, roles)
 	return syncExpiry, oldBody, channelSet, access, roles, nil
 }
 
-func (db *Database) recalculateSyncFnForActiveRev(doc *Document, metaMap map[string]interface{}, newRevID string) (channelSet base.Set, access, roles channels.AccessMap, syncExpiry *uint32, oldBodyJSON string, err error) {
+func (db *Database) recalculateSyncFnForActiveRev(ctx context.Context, doc *Document, metaMap map[string]interface{}, newRevID string) (channelSet base.Set, access, roles channels.AccessMap, syncExpiry *uint32, oldBodyJSON string, err error) {
 	// In some cases an older revision might become the current one. If so, get its
 	// channels & access, for purposes of updating the doc:
-	curBodyBytes, err := db.getAvailable1xRev(doc, doc.CurrentRev)
+	curBodyBytes, err := db.getAvailable1xRev(ctx, doc, doc.CurrentRev)
 	if err != nil {
 		return
 	}
@@ -1482,15 +1482,15 @@ func (db *Database) recalculateSyncFnForActiveRev(doc *Document, metaMap map[str
 	}
 
 	if curBody != nil {
-		base.DebugfCtx(db.Ctx, base.KeyCRUD, "updateDoc(%q): Rev %q causes %q to become current again",
+		base.DebugfCtx(ctx, base.KeyCRUD, "updateDoc(%q): Rev %q causes %q to become current again",
 			base.UD(doc.ID), newRevID, doc.CurrentRev)
-		channelSet, access, roles, syncExpiry, oldBodyJSON, err = db.getChannelsAndAccess(doc, curBody, metaMap, doc.CurrentRev)
+		channelSet, access, roles, syncExpiry, oldBodyJSON, err = db.getChannelsAndAccess(ctx, doc, curBody, metaMap, doc.CurrentRev)
 		if err != nil {
 			return
 		}
 	} else {
 		// Shouldn't be possible (CurrentRev is a leaf so won't have been compacted)
-		base.WarnfCtx(db.Ctx, "updateDoc(%q): Rev %q missing, can't call getChannelsAndAccess "+
+		base.WarnfCtx(ctx, "updateDoc(%q): Rev %q missing, can't call getChannelsAndAccess "+
 			"on it (err=%v)", base.UD(doc.ID), doc.CurrentRev, err)
 		channelSet = nil
 		access = nil
@@ -1499,9 +1499,9 @@ func (db *Database) recalculateSyncFnForActiveRev(doc *Document, metaMap map[str
 	return
 }
 
-func (db *Database) addAttachments(newAttachments AttachmentData) error {
+func (db *Database) addAttachments(ctx context.Context, newAttachments AttachmentData) error {
 	// Need to check and add attachments here to ensure the attachment is within size constraints
-	err := db.setAttachments(newAttachments)
+	err := db.setAttachments(ctx, newAttachments)
 	if err != nil {
 		if errors.Is(err, ErrAttachmentTooLarge) || err.Error() == "document value was too large" {
 			err = base.HTTPErrorf(http.StatusRequestEntityTooLarge, "Attachment too large")
@@ -1516,7 +1516,7 @@ func (db *Database) addAttachments(newAttachments AttachmentData) error {
 // Assigns provided sequence to the document
 // Update unusedSequences in the event that there is a conflict and we have to provide a new sequence number
 // Update and prune RecentSequences
-func (db *Database) assignSequence(docSequence uint64, doc *Document, unusedSequences []uint64) ([]uint64, error) {
+func (db *Database) assignSequence(ctx context.Context, docSequence uint64, doc *Document, unusedSequences []uint64) ([]uint64, error) {
 	var err error
 
 	// Assign the next sequence number, for _changes feed.
@@ -1527,7 +1527,7 @@ func (db *Database) assignSequence(docSequence uint64, doc *Document, unusedSequ
 			// we previously allocated is unusable now. We have to allocate a new sequence
 			// instead, but we add the unused one(s) to the document so when the changeCache
 			// reads the doc it won't freak out over the break in the sequence numbering.
-			base.InfofCtx(db.Ctx, base.KeyCache, "updateDoc %q: Unused sequence #%d", base.UD(doc.ID), docSequence)
+			base.InfofCtx(ctx, base.KeyCache, "updateDoc %q: Unused sequence #%d", base.UD(doc.ID), docSequence)
 			unusedSequences = append(unusedSequences, docSequence)
 		}
 
@@ -1541,7 +1541,7 @@ func (db *Database) assignSequence(docSequence uint64, doc *Document, unusedSequ
 			} else {
 				releaseErr := db.sequences.releaseSequence(docSequence)
 				if releaseErr != nil {
-					base.WarnfCtx(db.Ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", docSequence, err)
+					base.WarnfCtx(ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", docSequence, err)
 				}
 			}
 		}
@@ -1618,7 +1618,7 @@ Truth table for AllowConflicts and noConflicts combinations:
                        AllowConflicts=true     AllowConflicts=false
    noConflicts=true    continue checks         continue checks
    noConflicts=false   return false            continue checks */
-func (db *Database) IsIllegalConflict(doc *Document, parentRevID string, deleted, noConflicts bool, docHistory []string) bool {
+func (db *Database) IsIllegalConflict(ctx context.Context, doc *Document, parentRevID string, deleted, noConflicts bool, docHistory []string) bool {
 
 	if db.AllowConflicts() && !noConflicts {
 		return false
@@ -1641,7 +1641,7 @@ func (db *Database) IsIllegalConflict(doc *Document, parentRevID string, deleted
 				return false
 			}
 		}
-		base.DebugfCtx(db.Ctx, base.KeyCRUD, "Conflict - tombstone updates to non-leaf or already tombstoned revisions aren't valid when allow_conflicts=false")
+		base.DebugfCtx(ctx, base.KeyCRUD, "Conflict - tombstone updates to non-leaf or already tombstoned revisions aren't valid when allow_conflicts=false")
 		return true
 	}
 
@@ -1650,7 +1650,7 @@ func (db *Database) IsIllegalConflict(doc *Document, parentRevID string, deleted
 		for _, ancestorRevID := range docHistory {
 			_, ok := doc.History[ancestorRevID]
 			if ok {
-				base.DebugfCtx(db.Ctx, base.KeyCRUD, "Conflict - document is deleted, but update would branch from existing revision.")
+				base.DebugfCtx(ctx, base.KeyCRUD, "Conflict - document is deleted, but update would branch from existing revision.")
 				return true
 			}
 		}
@@ -1658,11 +1658,11 @@ func (db *Database) IsIllegalConflict(doc *Document, parentRevID string, deleted
 	}
 
 	// If we haven't found a valid conflict scenario by this point, flag as invalid
-	base.DebugfCtx(db.Ctx, base.KeyCRUD, "Conflict - non-tombstone updates to non-winning revisions aren't valid when allow_conflicts=false")
+	base.DebugfCtx(ctx, base.KeyCRUD, "Conflict - non-tombstone updates to non-winning revisions aren't valid when allow_conflicts=false")
 	return true
 }
 
-func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImport bool, previousDocSequenceIn uint64, unusedSequences []uint64, callback updateAndReturnDocCallback, expiry uint32) (retSyncFuncExpiry *uint32, retNewRevID string, retStoredDoc *Document, retOldBodyJSON string, retUnusedSequences []uint64, changedAccessPrincipals []string, changedRoleAccessUsers []string, createNewRevIDSkipped bool, err error) {
+func (db *Database) documentUpdateFunc(ctx context.Context, docExists bool, doc *Document, allowImport bool, previousDocSequenceIn uint64, unusedSequences []uint64, callback updateAndReturnDocCallback, expiry uint32) (retSyncFuncExpiry *uint32, retNewRevID string, retStoredDoc *Document, retOldBodyJSON string, retUnusedSequences []uint64, changedAccessPrincipals []string, changedRoleAccessUsers []string, createNewRevIDSkipped bool, err error) {
 
 	err = db.validateExistingDoc(doc, allowImport, docExists)
 	if err != nil {
@@ -1683,12 +1683,12 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 	prevCurrentRev := doc.CurrentRev
 	doc.updateWinningRevAndSetDocFlags()
 	newDocHasAttachments := len(newAttachments) > 0
-	db.storeOldBodyInRevTreeAndUpdateCurrent(doc, prevCurrentRev, newRevID, newDoc, newDocHasAttachments)
+	db.storeOldBodyInRevTreeAndUpdateCurrent(ctx, doc, prevCurrentRev, newRevID, newDoc, newDocHasAttachments)
 
-	syncExpiry, oldBodyJSON, channelSet, access, roles, err := db.runSyncFn(doc, mutableBody, metaMap, newRevID)
+	syncExpiry, oldBodyJSON, channelSet, access, roles, err := db.runSyncFn(ctx, doc, mutableBody, metaMap, newRevID)
 	if err != nil {
 		if db.ForceAPIForbiddenErrors() {
-			base.InfofCtx(db.Ctx, base.KeyCRUD, "Sync function rejected update to %s %s due to %v",
+			base.InfofCtx(ctx, base.KeyCRUD, "Sync function rejected update to %s %s due to %v",
 				base.UD(doc.ID), base.MD(doc.RevID), err)
 			err = ErrForbidden
 		}
@@ -1699,14 +1699,14 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 		doc.History[newRevID].Channels = channelSet
 	}
 
-	err = db.addAttachments(newAttachments)
+	err = db.addAttachments(ctx, newAttachments)
 	if err != nil {
 		return
 	}
 
-	db.backupAncestorRevs(doc, newDoc)
+	db.backupAncestorRevs(ctx, doc, newDoc)
 
-	unusedSequences, err = db.assignSequence(previousDocSequenceIn, doc, unusedSequences)
+	unusedSequences, err = db.assignSequence(ctx, previousDocSequenceIn, doc, unusedSequences)
 	if err != nil {
 		return
 	}
@@ -1717,9 +1717,9 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 		// need to update the doc's top-level Channels and Access properties to correspond
 		// to the current rev's state.
 		if newRevID != doc.CurrentRev {
-			channelSet, access, roles, syncExpiry, oldBodyJSON, err = db.recalculateSyncFnForActiveRev(doc, metaMap, newRevID)
+			channelSet, access, roles, syncExpiry, oldBodyJSON, err = db.recalculateSyncFnForActiveRev(ctx, doc, metaMap, newRevID)
 		}
-		_, err = doc.updateChannels(db.Ctx, channelSet)
+		_, err = doc.updateChannels(ctx, channelSet)
 		if err != nil {
 			return
 		}
@@ -1727,13 +1727,13 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 		changedRoleAccessUsers = doc.RoleAccess.updateAccess(doc, roles)
 	} else {
 
-		base.DebugfCtx(db.Ctx, base.KeyCRUD, "updateDoc(%q): Rev %q leaves %q still current",
+		base.DebugfCtx(ctx, base.KeyCRUD, "updateDoc(%q): Rev %q leaves %q still current",
 			base.UD(doc.ID), newRevID, prevCurrentRev)
 	}
 
 	// Prune old revision history to limit the number of revisions:
 	if pruned := doc.pruneRevisions(db.RevsLimit, doc.CurrentRev); pruned > 0 {
-		base.DebugfCtx(db.Ctx, base.KeyCRUD, "updateDoc(%q): Pruned %d old revisions", base.UD(doc.ID), pruned)
+		base.DebugfCtx(ctx, base.KeyCRUD, "updateDoc(%q): Pruned %d old revisions", base.UD(doc.ID), pruned)
 	}
 
 	updatedExpiry = doc.updateExpiry(syncExpiry, updatedExpiry, expiry)
@@ -1753,7 +1753,7 @@ type updateAndReturnDocCallback func(*Document) (resultDoc *Document, resultAtta
 //   1. Receive the updated document body in the response
 //   2. Specify the existing document body/xattr/cas, to avoid initial retrieval of the doc in cases that the current contents are already known (e.g. import).
 //      On cas failure, the document will still be reloaded from the bucket as usual.
-func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry uint32, opts *sgbucket.MutateInOptions, existingDoc *sgbucket.BucketDocument, callback updateAndReturnDocCallback) (doc *Document, newRevID string, err error) {
+func (db *Database) updateAndReturnDoc(ctx context.Context, docid string, allowImport bool, expiry uint32, opts *sgbucket.MutateInOptions, existingDoc *sgbucket.BucketDocument, callback updateAndReturnDocCallback) (doc *Document, newRevID string, err error) {
 
 	key := realDocID(docid)
 	if key == "" {
@@ -1783,14 +1783,14 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			if doc, err = unmarshalDocument(docid, currentValue); err != nil {
 				return
 			}
-			previousAttachments, err = getAttachmentIDsForLeafRevisions(db, doc, newRevID)
+			previousAttachments, err = getAttachmentIDsForLeafRevisions(ctx, db, doc, newRevID)
 			if err != nil {
 				skipObsoleteAttachmentsRemoval = true
-				base.ErrorfCtx(db.Ctx, "Error retrieving previous leaf attachments of doc: %s, Error: %v", base.UD(docid), err)
+				base.ErrorfCtx(ctx, "Error retrieving previous leaf attachments of doc: %s, Error: %v", base.UD(docid), err)
 			}
 			prevCurrentRev = doc.CurrentRev
 			docExists := currentValue != nil
-			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, createNewRevIDSkipped, err = db.documentUpdateFunc(docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
+			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, createNewRevIDSkipped, err = db.documentUpdateFunc(ctx, docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
 			if err != nil {
 				return
 			}
@@ -1799,7 +1799,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			inConflict = doc.hasFlag(channels.Conflict)
 			// Return the new raw document value for the bucket to store.
 			raw, err = doc.MarshalBodyAndSync()
-			base.DebugfCtx(db.Ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.CurrentRev)
+			base.DebugfCtx(ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.CurrentRev)
 			docBytes = len(raw)
 			return raw, syncFuncExpiry, false, err
 		})
@@ -1829,14 +1829,14 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 				doc.inlineSyncData = true
 			}
 
-			previousAttachments, err = getAttachmentIDsForLeafRevisions(db, doc, newRevID)
+			previousAttachments, err = getAttachmentIDsForLeafRevisions(ctx, db, doc, newRevID)
 			if err != nil {
 				skipObsoleteAttachmentsRemoval = true
-				base.ErrorfCtx(db.Ctx, "Error retrieving previous leaf attachments of doc: %s, Error: %v", base.UD(docid), err)
+				base.ErrorfCtx(ctx, "Error retrieving previous leaf attachments of doc: %s, Error: %v", base.UD(docid), err)
 			}
 
 			docExists := currentValue != nil
-			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, createNewRevIDSkipped, err = db.documentUpdateFunc(docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
+			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, createNewRevIDSkipped, err = db.documentUpdateFunc(ctx, docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
 			if err != nil {
 				return
 			}
@@ -1862,24 +1862,24 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 					xattrBytes = len(rawXattr)
 					if uint32(xattrBytes) >= *xattrBytesThreshold {
 						db.DbStats.Database().WarnXattrSizeCount.Add(1)
-						base.WarnfCtx(db.Ctx, "Doc id: %v sync metadata size: %d bytes exceeds %d bytes for sync metadata warning threshold", base.UD(doc.ID), xattrBytes, *xattrBytesThreshold)
+						base.WarnfCtx(ctx, "Doc id: %v sync metadata size: %d bytes exceeds %d bytes for sync metadata warning threshold", base.UD(doc.ID), xattrBytes, *xattrBytesThreshold)
 					}
 				}
 			}
 
 			// Prior to saving doc invalidate the revision in cache
 			if createNewRevIDSkipped {
-				db.revisionCache.Invalidate(db.Ctx, doc.ID, doc.CurrentRev)
+				db.revisionCache.Invalidate(ctx, doc.ID, doc.CurrentRev)
 			}
 
-			base.DebugfCtx(db.Ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.CurrentRev)
+			base.DebugfCtx(ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.CurrentRev)
 			return raw, rawXattr, deleteDoc, syncFuncExpiry, err
 		})
 		if err != nil {
 			if err == base.ErrDocumentMigrated {
-				base.DebugfCtx(db.Ctx, base.KeyCRUD, "Migrated document %q to use xattr.", base.UD(key))
+				base.DebugfCtx(ctx, base.KeyCRUD, "Migrated document %q to use xattr.", base.UD(key))
 			} else {
-				base.DebugfCtx(db.Ctx, base.KeyCRUD, "Did not update document %q w/ xattr: %v", base.UD(key), err)
+				base.DebugfCtx(ctx, base.KeyCRUD, "Did not update document %q w/ xattr: %v", base.UD(key), err)
 			}
 		} else if doc != nil {
 			doc.Cas = casOut
@@ -1890,13 +1890,13 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 	if err != nil {
 		if docSequence > 0 {
 			if seqErr := db.sequences.releaseSequence(docSequence); seqErr != nil {
-				base.WarnfCtx(db.Ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", docSequence, seqErr)
+				base.WarnfCtx(ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", docSequence, seqErr)
 			}
 
 		}
 		for _, sequence := range unusedSequences {
 			if seqErr := db.sequences.releaseSequence(sequence); seqErr != nil {
-				base.WarnfCtx(db.Ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", sequence, seqErr)
+				base.WarnfCtx(ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", sequence, seqErr)
 			}
 		}
 	}
@@ -1905,7 +1905,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 		return nil, "", nil
 	} else if err == couchbase.ErrOverwritten {
 		// ErrOverwritten is ok; if a later revision got persisted, that's fine too
-		base.DebugfCtx(db.Ctx, base.KeyCRUD, "Note: Rev %q/%q was overwritten in RAM before becoming indexable",
+		base.DebugfCtx(ctx, base.KeyCRUD, "Note: Rev %q/%q was overwritten in RAM before becoming indexable",
 			base.UD(docid), newRevID)
 	} else if err != nil {
 		return nil, "", err
@@ -1945,37 +1945,37 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 		}
 
 		if createNewRevIDSkipped {
-			db.revisionCache.Upsert(db.Ctx, documentRevision)
+			db.revisionCache.Upsert(ctx, documentRevision)
 		} else {
-			db.revisionCache.Put(db.Ctx, documentRevision)
+			db.revisionCache.Put(ctx, documentRevision)
 		}
 
 		if db.EventMgr.HasHandlerForEvent(DocumentChange) {
 			webhookJSON, err := doc.BodyWithSpecialProperties()
 			if err != nil {
-				base.WarnfCtx(db.Ctx, "Error marshalling doc with id %s and revid %s for webhook post: %v", base.UD(docid), base.UD(newRevID), err)
+				base.WarnfCtx(ctx, "Error marshalling doc with id %s and revid %s for webhook post: %v", base.UD(docid), base.UD(newRevID), err)
 			} else {
 				winningRevChange := prevCurrentRev != doc.CurrentRev
 				err = db.EventMgr.RaiseDocumentChangeEvent(webhookJSON, docid, oldBodyJSON, revChannels, winningRevChange)
 				if err != nil {
-					base.DebugfCtx(db.Ctx, base.KeyCRUD, "Error raising document change event: %v", err)
+					base.DebugfCtx(ctx, base.KeyCRUD, "Error raising document change event: %v", err)
 				}
 			}
 		}
 	} else {
 		// Revision has been pruned away so won't be added to cache
-		base.InfofCtx(db.Ctx, base.KeyCRUD, "doc %q / %q, has been pruned, it has not been inserted into the revision cache", base.UD(docid), newRevID)
+		base.InfofCtx(ctx, base.KeyCRUD, "doc %q / %q, has been pruned, it has not been inserted into the revision cache", base.UD(docid), newRevID)
 	}
 
 	// Now that the document has successfully been stored, we can make other db changes:
-	base.DebugfCtx(db.Ctx, base.KeyCRUD, "Stored doc %q / %q as #%v", base.UD(docid), newRevID, doc.Sequence)
+	base.DebugfCtx(ctx, base.KeyCRUD, "Stored doc %q / %q as #%v", base.UD(docid), newRevID, doc.Sequence)
 
 	leafAttachments := make(map[string]struct{})
 	if !skipObsoleteAttachmentsRemoval {
-		leafAttachments, err = getAttachmentIDsForLeafRevisions(db, doc, newRevID)
+		leafAttachments, err = getAttachmentIDsForLeafRevisions(ctx, db, doc, newRevID)
 		if err != nil {
 			skipObsoleteAttachmentsRemoval = true
-			base.ErrorfCtx(db.Ctx, "Error retrieving current leaf attachments of doc: %s, Error: %v", base.UD(docid), err)
+			base.ErrorfCtx(ctx, "Error retrieving current leaf attachments of doc: %s, Error: %v", base.UD(docid), err)
 		}
 	}
 
@@ -1985,14 +1985,14 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			if _, found := leafAttachments[previousAttachmentID]; !found {
 				err = db.Bucket.Delete(previousAttachmentID)
 				if err != nil {
-					base.ErrorfCtx(db.Ctx, "Error deleting obsolete attachment %q of doc %q, Error: %v", previousAttachmentID, base.UD(doc.ID), err)
+					base.ErrorfCtx(ctx, "Error deleting obsolete attachment %q of doc %q, Error: %v", previousAttachmentID, base.UD(doc.ID), err)
 				} else {
 					obsoleteAttachments = append(obsoleteAttachments, previousAttachmentID)
 				}
 			}
 		}
 		if len(obsoleteAttachments) > 0 {
-			base.DebugfCtx(db.Ctx, base.KeyCRUD, "Deleted obsolete attachments (key: %v, doc: %q)", obsoleteAttachments, base.UD(doc.ID))
+			base.DebugfCtx(ctx, base.KeyCRUD, "Deleted obsolete attachments (key: %v, doc: %q)", obsoleteAttachments, base.UD(doc.ID))
 		}
 	}
 
@@ -2000,11 +2000,11 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 	doc.deleteRemovedRevisionBodies(db.Bucket)
 
 	// Mark affected users/roles as needing to recompute their channel access:
-	db.MarkPrincipalsChanged(docid, newRevID, changedAccessPrincipals, changedRoleAccessUsers, doc.Sequence)
+	db.MarkPrincipalsChanged(ctx, docid, newRevID, changedAccessPrincipals, changedRoleAccessUsers, doc.Sequence)
 	return doc, newRevID, nil
 }
 
-func getAttachmentIDsForLeafRevisions(db *Database, doc *Document, newRevID string) (map[string]struct{}, error) {
+func getAttachmentIDsForLeafRevisions(ctx context.Context, db *Database, doc *Document, newRevID string) (map[string]struct{}, error) {
 	leafAttachments := make(map[string]struct{})
 
 	currentAttachments, err := retrieveV2AttachmentKeys(doc.ID, doc.Attachments)
@@ -2026,7 +2026,7 @@ func getAttachmentIDsForLeafRevisions(db *Database, doc *Document, newRevID stri
 	})
 
 	for _, leafRevision := range documentLeafRevisions {
-		_, _, attachmentMeta, err := db.getRevision(db.Ctx, doc, leafRevision)
+		_, _, attachmentMeta, err := db.getRevision(ctx, doc, leafRevision)
 		if err != nil {
 			return nil, err
 		}
@@ -2045,7 +2045,7 @@ func getAttachmentIDsForLeafRevisions(db *Database, doc *Document, newRevID stri
 	return leafAttachments, nil
 }
 
-func (db *Database) checkDocChannelsAndGrantsLimits(docID string, channels base.Set, accessGrants channels.AccessMap, roleGrants channels.AccessMap) {
+func (db *Database) checkDocChannelsAndGrantsLimits(ctx context.Context, docID string, channels base.Set, accessGrants channels.AccessMap, roleGrants channels.AccessMap) {
 	if db.Options.UnsupportedOptions == nil || db.Options.UnsupportedOptions.WarningThresholds == nil {
 		return
 	}
@@ -2055,7 +2055,7 @@ func (db *Database) checkDocChannelsAndGrantsLimits(docID string, channels base.
 		channelCount := len(channels)
 		if uint32(channelCount) >= *channelCountThreshold {
 			db.DbStats.Database().WarnChannelsPerDocCount.Add(1)
-			base.WarnfCtx(db.Ctx, "Doc id: %v channel count: %d exceeds %d for channels per doc warning threshold", base.UD(docID), channelCount, *channelCountThreshold)
+			base.WarnfCtx(ctx, "Doc id: %v channel count: %d exceeds %d for channels per doc warning threshold", base.UD(docID), channelCount, *channelCountThreshold)
 		}
 	}
 
@@ -2064,7 +2064,7 @@ func (db *Database) checkDocChannelsAndGrantsLimits(docID string, channels base.
 		grantCount := len(accessGrants) + len(roleGrants)
 		if uint32(grantCount) >= *grantThreshold {
 			db.DbStats.Database().WarnGrantsPerDocCount.Add(1)
-			base.WarnfCtx(db.Ctx, "Doc id: %v access and role grants count: %d exceeds %d for grants per doc warning threshold", base.UD(docID), grantCount, *grantThreshold)
+			base.WarnfCtx(ctx, "Doc id: %v access and role grants count: %d exceeds %d for grants per doc warning threshold", base.UD(docID), grantCount, *grantThreshold)
 		}
 	}
 
@@ -2073,21 +2073,21 @@ func (db *Database) checkDocChannelsAndGrantsLimits(docID string, channels base.
 		for c := range channels {
 			if uint32(len(c)) > *channelNameSizeThreshold {
 				db.DbStats.Database().WarnChannelNameSizeCount.Add(1)
-				base.WarnfCtx(db.Ctx, "Doc: %q channel %q exceeds %d characters for channel name size warning threshold", base.UD(docID), base.UD(c), *channelNameSizeThreshold)
+				base.WarnfCtx(ctx, "Doc: %q channel %q exceeds %d characters for channel name size warning threshold", base.UD(docID), base.UD(c), *channelNameSizeThreshold)
 			}
 		}
 	}
 }
 
-func (db *Database) MarkPrincipalsChanged(docid string, newRevID string, changedPrincipals, changedRoleUsers []string, invalSeq uint64) {
+func (db *Database) MarkPrincipalsChanged(ctx context.Context, docid string, newRevID string, changedPrincipals, changedRoleUsers []string, invalSeq uint64) {
 
 	reloadActiveUser := false
 
 	// Mark affected users/roles as needing to recompute their channel access:
 	if len(changedPrincipals) > 0 {
-		base.InfofCtx(db.Ctx, base.KeyAccess, "Rev %q / %q invalidates channels of %s", base.UD(docid), newRevID, changedPrincipals)
+		base.InfofCtx(ctx, base.KeyAccess, "Rev %q / %q invalidates channels of %s", base.UD(docid), newRevID, changedPrincipals)
 		for _, changedAccessPrincipalName := range changedPrincipals {
-			db.invalUserOrRoleChannels(changedAccessPrincipalName, invalSeq)
+			db.invalUserOrRoleChannels(ctx, changedAccessPrincipalName, invalSeq)
 			// Check whether the active user needs to be recalculated.  Skip check if reload has already been identified
 			// as required for a previous changedPrincipal
 			if db.user != nil && reloadActiveUser == false {
@@ -2096,14 +2096,14 @@ func (db *Database) MarkPrincipalsChanged(docid string, newRevID string, changed
 				if isRole {
 					for roleName := range db.user.RoleNames() {
 						if roleName == changedPrincipalName {
-							base.DebugfCtx(db.Ctx, base.KeyAccess, "Active user belongs to role %q with modified channel access - user %q will be reloaded.", base.UD(roleName), base.UD(db.user.Name()))
+							base.DebugfCtx(ctx, base.KeyAccess, "Active user belongs to role %q with modified channel access - user %q will be reloaded.", base.UD(roleName), base.UD(db.user.Name()))
 							reloadActiveUser = true
 							break
 						}
 					}
 				} else if db.user.Name() == changedPrincipalName {
 					// User matches
-					base.DebugfCtx(db.Ctx, base.KeyAccess, "Channel set for active user has been modified - user %q will be reloaded.", base.UD(db.user.Name()))
+					base.DebugfCtx(ctx, base.KeyAccess, "Channel set for active user has been modified - user %q will be reloaded.", base.UD(db.user.Name()))
 					reloadActiveUser = true
 				}
 
@@ -2112,12 +2112,12 @@ func (db *Database) MarkPrincipalsChanged(docid string, newRevID string, changed
 	}
 
 	if len(changedRoleUsers) > 0 {
-		base.InfofCtx(db.Ctx, base.KeyAccess, "Rev %q / %q invalidates roles of %s", base.UD(docid), newRevID, base.UD(changedRoleUsers))
+		base.InfofCtx(ctx, base.KeyAccess, "Rev %q / %q invalidates roles of %s", base.UD(docid), newRevID, base.UD(changedRoleUsers))
 		for _, name := range changedRoleUsers {
-			db.invalUserRoles(name, invalSeq)
+			db.invalUserRoles(ctx, name, invalSeq)
 			// If this is the current in memory db.user, reload to generate updated roles
 			if db.user != nil && db.user.Name() == name {
-				base.DebugfCtx(db.Ctx, base.KeyAccess, "Role set for active user has been modified - user %q will be reloaded.", base.UD(db.user.Name()))
+				base.DebugfCtx(ctx, base.KeyAccess, "Role set for active user has been modified - user %q will be reloaded.", base.UD(db.user.Name()))
 				reloadActiveUser = true
 
 			}
@@ -2125,9 +2125,9 @@ func (db *Database) MarkPrincipalsChanged(docid string, newRevID string, changed
 	}
 
 	if reloadActiveUser {
-		user, err := db.Authenticator(db.Ctx).GetUser(db.user.Name())
+		user, err := db.Authenticator(ctx).GetUser(db.user.Name())
 		if err != nil {
-			base.WarnfCtx(db.Ctx, "Error reloading active db.user[%s], security information will not be recalculated until next authentication --> %+v", base.UD(db.user.Name()), err)
+			base.WarnfCtx(ctx, "Error reloading active db.user[%s], security information will not be recalculated until next authentication --> %+v", base.UD(db.user.Name()), err)
 		} else {
 			db.user = user
 		}
@@ -2136,7 +2136,7 @@ func (db *Database) MarkPrincipalsChanged(docid string, newRevID string, changed
 }
 
 // Creates a new document, assigning it a random doc ID.
-func (db *Database) Post(body Body) (docid string, rev string, doc *Document, err error) {
+func (db *Database) Post(ctx context.Context, body Body) (docid string, rev string, doc *Document, err error) {
 	if body[BodyRev] != nil {
 		return "", "", nil, base.HTTPErrorf(http.StatusNotFound, "No previous revision to replace")
 	}
@@ -2150,7 +2150,7 @@ func (db *Database) Post(body Body) (docid string, rev string, doc *Document, er
 		}
 	}
 
-	rev, doc, err = db.Put(docid, body)
+	rev, doc, err = db.Put(ctx, docid, body)
 	if err != nil {
 		docid = ""
 	}
@@ -2158,20 +2158,20 @@ func (db *Database) Post(body Body) (docid string, rev string, doc *Document, er
 }
 
 // Deletes a document, by adding a new revision whose _deleted property is true.
-func (db *Database) DeleteDoc(docid string, revid string) (string, error) {
+func (db *Database) DeleteDoc(ctx context.Context, docid string, revid string) (string, error) {
 	body := Body{BodyDeleted: true, BodyRev: revid}
-	newRevID, _, err := db.Put(docid, body)
+	newRevID, _, err := db.Put(ctx, docid, body)
 	return newRevID, err
 }
 
 // Purges a document from the bucket (no tombstone)
-func (db *Database) Purge(key string) error {
-	doc, err := db.GetDocument(db.Ctx, key, DocUnmarshalAll)
+func (db *Database) Purge(ctx context.Context, key string) error {
+	doc, err := db.GetDocument(ctx, key, DocUnmarshalAll)
 	if err != nil {
 		return err
 	}
 
-	attachments, err := getAttachmentIDsForLeafRevisions(db, doc, "")
+	attachments, err := getAttachmentIDsForLeafRevisions(ctx, db, doc, "")
 	if err != nil {
 		return err
 	}
@@ -2179,7 +2179,7 @@ func (db *Database) Purge(key string) error {
 	for attachmentID := range attachments {
 		err = db.Bucket.Delete(attachmentID)
 		if err != nil {
-			base.WarnfCtx(db.Ctx, "Unable to delete attachment %q. Error: %v", attachmentID, err)
+			base.WarnfCtx(ctx, "Unable to delete attachment %q. Error: %v", attachmentID, err)
 		}
 	}
 
@@ -2194,14 +2194,14 @@ func (db *Database) Purge(key string) error {
 
 // Calls the JS sync function to assign the doc to channels, grant users
 // access to channels, and reject invalid documents.
-func (db *Database) getChannelsAndAccess(doc *Document, body Body, metaMap map[string]interface{}, revID string) (
+func (db *Database) getChannelsAndAccess(ctx context.Context, doc *Document, body Body, metaMap map[string]interface{}, revID string) (
 	result base.Set,
 	access channels.AccessMap,
 	roles channels.AccessMap,
 	expiry *uint32,
 	oldJson string,
 	err error) {
-	base.DebugfCtx(db.Ctx, base.KeyCRUD, "Invoking sync on doc %q rev %s", base.UD(doc.ID), body[BodyRev])
+	base.DebugfCtx(ctx, base.KeyCRUD, "Invoking sync on doc %q rev %s", base.UD(doc.ID), body[BodyRev])
 
 	// Low-level protection against writes for read-only guest.  Handles write pathways that don't fail-fast
 	if db.user != nil && db.user.Name() == "" && db.DatabaseContext.IsGuestReadOnly() {
@@ -2210,7 +2210,7 @@ func (db *Database) getChannelsAndAccess(doc *Document, body Body, metaMap map[s
 
 	// Get the parent revision, to pass to the sync function:
 	var oldJsonBytes []byte
-	if oldJsonBytes, err = db.getAncestorJSON(doc, revID); err != nil {
+	if oldJsonBytes, err = db.getAncestorJSON(ctx, doc, revID); err != nil {
 		return
 	}
 	oldJson = string(oldJsonBytes)
@@ -2233,8 +2233,8 @@ func (db *Database) getChannelsAndAccess(doc *Document, body Body, metaMap map[s
 			expiry = output.Expiry
 			err = output.Rejection
 			if err != nil {
-				base.InfofCtx(db.Ctx, base.KeyAll, "Sync fn rejected doc %q / %q --> %s", base.UD(doc.ID), base.UD(doc.NewestRev), err)
-				base.DebugfCtx(db.Ctx, base.KeyAll, "    rejected doc %q / %q : new=%+v  old=%s", base.UD(doc.ID), base.UD(doc.NewestRev), base.UD(body), base.UD(oldJson))
+				base.InfofCtx(ctx, base.KeyAll, "Sync fn rejected doc %q / %q --> %s", base.UD(doc.ID), base.UD(doc.NewestRev), err)
+				base.DebugfCtx(ctx, base.KeyAll, "    rejected doc %q / %q : new=%+v  old=%s", base.UD(doc.ID), base.UD(doc.NewestRev), base.UD(body), base.UD(oldJson))
 				db.DbStats.Security().NumDocsRejected.Add(1)
 				if isAccessError(err) {
 					db.DbStats.Security().NumAccessErrors.Add(1)
@@ -2244,7 +2244,7 @@ func (db *Database) getChannelsAndAccess(doc *Document, body Body, metaMap map[s
 			}
 
 		} else {
-			base.WarnfCtx(db.Ctx, "Sync fn exception: %+v; doc = %s", err, base.UD(body))
+			base.WarnfCtx(ctx, "Sync fn exception: %+v; doc = %s", err, base.UD(body))
 			if errors.Is(err, sgbucket.ErrJSTimeout) {
 				err = base.HTTPErrorf(500, "JS sync function timed out")
 			} else {
@@ -2258,7 +2258,7 @@ func (db *Database) getChannelsAndAccess(doc *Document, body Body, metaMap map[s
 		if value != nil {
 			array, nonStrings := base.ValueToStringArray(value)
 			if nonStrings != nil {
-				base.WarnfCtx(db.Ctx, "Channel names must be string values only. Ignoring non-string channels: %s", base.UD(nonStrings))
+				base.WarnfCtx(ctx, "Channel names must be string values only. Ignoring non-string channels: %s", base.UD(nonStrings))
 			}
 			result, err = channels.SetFromArray(array, channels.KeepStar)
 		}
@@ -2377,7 +2377,7 @@ func (context *DatabaseContext) checkForUpgrade(key string, unmarshalLevel Docum
 
 // Given a document ID and a set of revision IDs, looks up which ones are not known. Returns an
 // array of the unknown revisions, and an array of known revisions that might be recent ancestors.
-func (db *Database) RevDiff(docid string, revids []string) (missing, possible []string) {
+func (db *Database) RevDiff(ctx context.Context, docid string, revids []string) (missing, possible []string) {
 	if strings.HasPrefix(docid, "_design/") && db.user != nil {
 		return // Users can't upload design docs, so ignore them
 	}
@@ -2390,21 +2390,21 @@ func (db *Database) RevDiff(docid string, revids []string) (missing, possible []
 
 		if err != nil {
 			if !base.IsDocNotFoundError(err) {
-				base.WarnfCtx(db.Ctx, "RevDiff(%q) --> %T %v", base.UD(docid), err, err)
+				base.WarnfCtx(ctx, "RevDiff(%q) --> %T %v", base.UD(docid), err, err)
 			}
 			missing = revids
 			return
 		}
 		doc, err := unmarshalDocumentWithXattr(docid, nil, xattrValue, nil, cas, DocUnmarshalSync)
 		if err != nil {
-			base.ErrorfCtx(db.Ctx, "RevDiff(%q) Doc Unmarshal Failed: %T %v", base.UD(docid), err, err)
+			base.ErrorfCtx(ctx, "RevDiff(%q) Doc Unmarshal Failed: %T %v", base.UD(docid), err, err)
 		}
 		history = doc.History
 	} else {
-		doc, err := db.GetDocument(db.Ctx, docid, DocUnmarshalSync)
+		doc, err := db.GetDocument(ctx, docid, DocUnmarshalSync)
 		if err != nil {
 			if !base.IsDocNotFoundError(err) {
-				base.WarnfCtx(db.Ctx, "RevDiff(%q) --> %T %v", base.UD(docid), err, err)
+				base.WarnfCtx(ctx, "RevDiff(%q) --> %T %v", base.UD(docid), err, err)
 				// If something goes wrong getting the doc, treat it as though it's nonexistent.
 			}
 			missing = revids
@@ -2458,11 +2458,11 @@ const (
 
 // Given a docID/revID to be pushed by a client, check whether it can be added _without conflict_.
 // This is used by the BLIP replication code in "allow_conflicts=false" mode.
-func (db *Database) CheckProposedRev(docid string, revid string, parentRevID string) (status ProposedRevStatus, currentRev string) {
-	doc, err := db.GetDocument(db.Ctx, docid, DocUnmarshalAll)
+func (db *Database) CheckProposedRev(ctx context.Context, docid string, revid string, parentRevID string) (status ProposedRevStatus, currentRev string) {
+	doc, err := db.GetDocument(ctx, docid, DocUnmarshalAll)
 	if err != nil {
 		if !base.IsDocNotFoundError(err) {
-			base.WarnfCtx(db.Ctx, "CheckProposedRev(%q) --> %T %v", base.UD(docid), err, err)
+			base.WarnfCtx(ctx, "CheckProposedRev(%q) --> %T %v", base.UD(docid), err, err)
 			return ProposedRev_Error, ""
 		}
 		// Doc doesn't exist locally; adding it is OK (even if it has a history)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -73,7 +73,7 @@ func TestRevisionCacheLoad(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
+	_, _, err := db.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
 	assert.NoError(t, err, "add 1-a")
 
 	// Flush the cache
@@ -81,10 +81,10 @@ func TestRevisionCacheLoad(t *testing.T) {
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 1-a...")
-	_, err = db.Get1xRevBody("doc1", "1-a", false, nil)
+	_, err = db.Get1xRevBody(ctx, "doc1", "1-a", false, nil)
 	assert.NoError(t, err, "Couldn't get document")
 
-	docRev, err := db.GetRev("doc1", "1-a", false, nil)
+	docRev, err := db.GetRev(ctx, "doc1", "1-a", false, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "1-a", docRev.RevID)
 
@@ -92,7 +92,7 @@ func TestRevisionCacheLoad(t *testing.T) {
 	_, err = base.InjectJSONProperties(docRev.BodyBytes, base.KVPair{Key: "modified", Val: "property"})
 	assert.NoError(t, err)
 
-	docRevAgain, err := db.GetRev("doc1", "1-a", false, nil)
+	docRevAgain, err := db.GetRev(ctx, "doc1", "1-a", false, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "1-a", docRevAgain.RevID)
 
@@ -114,7 +114,7 @@ func TestHasAttachmentsFlag(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
+	_, _, err := db.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -125,14 +125,14 @@ func TestHasAttachmentsFlag(t *testing.T) {
 	rev2a_body := unjson(`{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
 	rev2a_body["key1"] = prop_1000_bytes
 	rev2a_body["version"] = "2a"
-	doc, newRev, err := db.PutExistingRevWithBody("doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := db.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 2-a...")
-	gotDoc, err := db.GetDocument(db.Ctx, "doc1", DocUnmarshalSync)
+	gotDoc, err := db.GetDocument(ctx, "doc1", DocUnmarshalSync)
 	assert.NoError(t, err)
 	require.Contains(t, gotDoc.Attachments, "hello.txt")
 	attachmentData, ok := gotDoc.Attachments["hello.txt"].(map[string]interface{})
@@ -151,14 +151,14 @@ func TestHasAttachmentsFlag(t *testing.T) {
 	rev2b_body := unjson(`{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	doc, newRev, err = db.PutExistingRevWithBody("doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err = db.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify rev 2-b")
-	gotDoc, err = db.GetDocument(db.Ctx, "doc1", DocUnmarshalSync)
+	gotDoc, err = db.GetDocument(ctx, "doc1", DocUnmarshalSync)
 	assert.NoError(t, err)
 	require.Contains(t, gotDoc.Attachments, "hello.txt")
 	attachmentData, ok = gotDoc.Attachments["hello.txt"].(map[string]interface{})
@@ -245,14 +245,14 @@ func TestHasAttachmentsFlagForLegacyAttachments(t *testing.T) {
 		require.NoError(t, err)
 
 		// Migrate document metadata from document body to system xattr.
-		_, _, err = db.migrateMetadata(docID, body, existingBucketDoc, nil)
+		_, _, err = db.migrateMetadata(ctx, docID, body, existingBucketDoc, nil)
 		require.NoError(t, err)
 	}
 
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
+	_, _, err := db.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a with legacy attachment.
@@ -268,7 +268,7 @@ func TestHasAttachmentsFlagForLegacyAttachments(t *testing.T) {
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 2-a...")
-	gotbody, err := db.Get1xBody("doc1")
+	gotbody, err := db.Get1xBody(ctx, "doc1")
 	assert.NoError(t, err, "Couldn't get document")
 	assert.Equal(t, Body{"_id": "doc1", "_rev": "1-a", "key1": "value1", "version": "1a"}, gotbody)
 
@@ -281,14 +281,14 @@ func TestHasAttachmentsFlagForLegacyAttachments(t *testing.T) {
 	rev2b_body := Body{}
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	doc, newRev, err := db.PutExistingRevWithBody("doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err := db.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify rev 2-b")
-	gotbody, err = db.Get1xBody("doc1")
+	gotbody, err = db.Get1xBody(ctx, "doc1")
 	assert.NoError(t, err, "Couldn't get document")
 	assert.Equal(t, rev2b_body, gotbody)
 
@@ -316,7 +316,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
+	_, _, err := db.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -327,14 +327,14 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2a_body := Body{}
 	rev2a_body["key1"] = prop_1000_bytes
 	rev2a_body["version"] = "2a"
-	doc, newRev, err := db.PutExistingRevWithBody("doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := db.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 2-a...")
-	gotbody, err := db.Get1xBody("doc1")
+	gotbody, err := db.Get1xBody(ctx, "doc1")
 	assert.NoError(t, err, "Couldn't get document")
 	assert.Equal(t, rev2a_body, gotbody)
 
@@ -346,14 +346,14 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2b_body := Body{}
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	doc, newRev, err = db.PutExistingRevWithBody("doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err = db.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify rev 2-b")
-	gotbody, err = db.Get1xBody("doc1")
+	gotbody, err = db.Get1xBody(ctx, "doc1")
 	assert.NoError(t, err, "Couldn't get document")
 	assert.Equal(t, rev2b_body, gotbody)
 
@@ -375,7 +375,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 
 	// Retrieve the non-inline revision
 	db.FlushRevisionCacheForTest()
-	rev2aGet, err := db.Get1xRevBody("doc1", "2-a", false, nil)
+	rev2aGet, err := db.Get1xRevBody(ctx, "doc1", "2-a", false, nil)
 	assert.NoError(t, err, "Couldn't get rev 2-a")
 	assert.Equal(t, rev2a_body, rev2aGet)
 
@@ -389,20 +389,20 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3b_body := Body{}
 	rev3b_body["version"] = "3b"
 	rev3b_body[BodyDeleted] = true
-	doc, newRev, err = db.PutExistingRevWithBody("doc1", rev3b_body, []string{"3-b", "2-b"}, false)
+	doc, newRev, err = db.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b"}, false)
 	rev3b_body[BodyId] = doc.ID
 	rev3b_body[BodyRev] = newRev
 	rev3b_body[BodyDeleted] = true
 	assert.NoError(t, err, "add 3-b (tombstone)")
 
 	// Retrieve tombstone
-	rev3bGet, err := db.Get1xRevBody("doc1", "3-b", false, nil)
+	rev3bGet, err := db.Get1xRevBody(ctx, "doc1", "3-b", false, nil)
 	assert.NoError(t, err, "Couldn't get rev 3-b")
 	assert.Equal(t, rev3b_body, rev3bGet)
 
 	// Retrieve the document, validate that we get 2-a
 	log.Printf("Retrieve doc, expect 2-a")
-	gotbody, err = db.Get1xBody("doc1")
+	gotbody, err = db.Get1xBody(ctx, "doc1")
 	assert.NoError(t, err, "Couldn't get document")
 	assert.Equal(t, rev2a_body, gotbody)
 
@@ -426,14 +426,14 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2c_body := Body{}
 	rev2c_body["key1"] = prop_1000_bytes
 	rev2c_body["version"] = "2c"
-	doc, newRev, err = db.PutExistingRevWithBody("doc1", rev2c_body, []string{"2-c", "1-a"}, false)
+	doc, newRev, err = db.PutExistingRevWithBody(ctx, "doc1", rev2c_body, []string{"2-c", "1-a"}, false)
 	rev2c_body[BodyId] = doc.ID
 	rev2c_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-c")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify rev 2-c")
-	gotbody, err = db.Get1xBody("doc1")
+	gotbody, err = db.Get1xBody(ctx, "doc1")
 	assert.NoError(t, err, "Couldn't get document")
 	assert.Equal(t, rev2c_body, gotbody)
 
@@ -448,7 +448,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3c_body["version"] = "3c"
 	rev3c_body["key1"] = prop_1000_bytes
 	rev3c_body[BodyDeleted] = true
-	doc, newRev, err = db.PutExistingRevWithBody("doc1", rev3c_body, []string{"3-c", "2-c"}, false)
+	doc, newRev, err = db.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-c"}, false)
 	rev3c_body[BodyId] = doc.ID
 	rev3c_body[BodyRev] = newRev
 	rev3c_body[BodyDeleted] = true
@@ -463,12 +463,12 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 
 	// Retrieve the non-inline tombstone revision
 	db.FlushRevisionCacheForTest()
-	rev3cGet, err := db.Get1xRevBody("doc1", "3-c", false, nil)
+	rev3cGet, err := db.Get1xRevBody(ctx, "doc1", "3-c", false, nil)
 	assert.NoError(t, err, "Couldn't get rev 3-c")
 	assert.Equal(t, rev3c_body, rev3cGet)
 
 	log.Printf("Retrieve doc, verify active rev is 2-a")
-	gotbody, err = db.Get1xBody("doc1")
+	gotbody, err = db.Get1xBody(ctx, "doc1")
 	assert.NoError(t, err, "Couldn't get document")
 	assert.Equal(t, rev2a_body, gotbody)
 
@@ -477,7 +477,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3a_body := Body{}
 	rev3a_body["key1"] = prop_1000_bytes
 	rev3a_body["version"] = "3a"
-	_, _, err = db.PutExistingRevWithBody("doc1", rev2c_body, []string{"3-a", "2-a"}, false)
+	_, _, err = db.PutExistingRevWithBody(ctx, "doc1", rev2c_body, []string{"3-a", "2-a"}, false)
 	assert.NoError(t, err, "add 3-a")
 
 	revTree, err = getRevTreeList(db.Bucket, "doc1", db.UseXattrs())
@@ -500,7 +500,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	// Create rev 2-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
+	_, _, err := db.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -511,14 +511,14 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev2a_body := Body{}
 	rev2a_body["key1"] = prop_1000_bytes
 	rev2a_body["version"] = "2a"
-	doc, newRev, err := db.PutExistingRevWithBody("doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := db.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 2-a...")
-	gotbody, err := db.Get1xBody("doc1")
+	gotbody, err := db.Get1xBody(ctx, "doc1")
 	assert.NoError(t, err, "Couldn't get document")
 	assert.Equal(t, rev2a_body, gotbody)
 
@@ -530,14 +530,14 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev2b_body := Body{}
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	doc, newRev, err = db.PutExistingRevWithBody("doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err = db.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify rev 2-b")
-	gotbody, err = db.Get1xBody("doc1")
+	gotbody, err = db.Get1xBody(ctx, "doc1")
 	assert.NoError(t, err, "Couldn't get document")
 	assert.Equal(t, rev2b_body, gotbody)
 
@@ -559,7 +559,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 
 	// Retrieve the non-inline revision
 	db.FlushRevisionCacheForTest()
-	rev2aGet, err := db.Get1xRevBody("doc1", "2-a", false, nil)
+	rev2aGet, err := db.Get1xRevBody(ctx, "doc1", "2-a", false, nil)
 	assert.NoError(t, err, "Couldn't get rev 2-a")
 	assert.Equal(t, rev2a_body, rev2aGet)
 
@@ -575,7 +575,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev3b_body["version"] = "3b"
 	rev3b_body["key1"] = prop_1000_bytes
 	rev3b_body[BodyDeleted] = true
-	doc, newRev, err = db.PutExistingRevWithBody("doc1", rev3b_body, []string{"3-b", "2-b"}, false)
+	doc, newRev, err = db.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b"}, false)
 	rev3b_body[BodyId] = doc.ID
 	rev3b_body[BodyRev] = newRev
 	rev3b_body[BodyDeleted] = true
@@ -583,13 +583,13 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 
 	// Retrieve tombstone
 	db.FlushRevisionCacheForTest()
-	rev3bGet, err := db.Get1xRevBody("doc1", "3-b", false, nil)
+	rev3bGet, err := db.Get1xRevBody(ctx, "doc1", "3-b", false, nil)
 	assert.NoError(t, err, "Couldn't get rev 3-b")
 	assert.Equal(t, rev3b_body, rev3bGet)
 
 	// Retrieve the document, validate that we get 2-a
 	log.Printf("Retrieve doc, expect 2-a")
-	gotbody, err = db.Get1xBody("doc1")
+	gotbody, err = db.Get1xBody(ctx, "doc1")
 	assert.NoError(t, err, "Couldn't get document")
 	assert.Equal(t, rev2a_body, gotbody)
 
@@ -609,32 +609,32 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	activeRevBody := Body{}
 	activeRevBody["version"] = "...a"
 	activeRevBody["key1"] = prop_1000_bytes
-	_, _, err = db.PutExistingRevWithBody("doc1", activeRevBody, []string{"3-a", "2-a"}, false)
+	_, _, err = db.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"3-a", "2-a"}, false)
 	assert.NoError(t, err, "add 3-a")
-	_, _, err = db.PutExistingRevWithBody("doc1", activeRevBody, []string{"4-a", "3-a"}, false)
+	_, _, err = db.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"4-a", "3-a"}, false)
 	assert.NoError(t, err, "add 4-a")
-	_, _, err = db.PutExistingRevWithBody("doc1", activeRevBody, []string{"5-a", "4-a"}, false)
+	_, _, err = db.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"5-a", "4-a"}, false)
 	assert.NoError(t, err, "add 5-a")
-	_, _, err = db.PutExistingRevWithBody("doc1", activeRevBody, []string{"6-a", "5-a"}, false)
+	_, _, err = db.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"6-a", "5-a"}, false)
 	assert.NoError(t, err, "add 6-a")
-	_, _, err = db.PutExistingRevWithBody("doc1", activeRevBody, []string{"7-a", "6-a"}, false)
+	_, _, err = db.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"7-a", "6-a"}, false)
 	assert.NoError(t, err, "add 7-a")
-	_, _, err = db.PutExistingRevWithBody("doc1", activeRevBody, []string{"8-a", "7-a"}, false)
+	_, _, err = db.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"8-a", "7-a"}, false)
 	assert.NoError(t, err, "add 8-a")
 
 	// Verify that 3-b is still present at this point
 	db.FlushRevisionCacheForTest()
-	rev3bGet, err = db.Get1xRevBody("doc1", "3-b", false, nil)
+	rev3bGet, err = db.Get1xRevBody(ctx, "doc1", "3-b", false, nil)
 	assert.NoError(t, err, "Rev 3-b should still exist")
 
 	// Add one more rev that triggers pruning since gen(9-3) > revsLimit
-	_, _, err = db.PutExistingRevWithBody("doc1", activeRevBody, []string{"9-a", "8-a"}, false)
+	_, _, err = db.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"9-a", "8-a"}, false)
 	assert.NoError(t, err, "add 9-a")
 
 	// Verify that 3-b has been pruned
 	log.Printf("Attempt to retrieve 3-b, expect pruned")
 	db.FlushRevisionCacheForTest()
-	rev3bGet, err = db.Get1xRevBody("doc1", "3-b", false, nil)
+	rev3bGet, err = db.Get1xRevBody(ctx, "doc1", "3-b", false, nil)
 	assert.Equal(t, "404 missing", err.Error())
 
 	// Ensure previous tombstone body backup has been removed
@@ -656,7 +656,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a", "large": prop_1000_bytes}
-	_, _, err := db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
+	_, _, err := db.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
 	require.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -665,14 +665,14 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 2-a
 	log.Printf("Create rev 2-a")
 	rev2a_body := Body{"key1": "value2", "version": "2a", "large": prop_1000_bytes}
-	doc, newRev, err := db.PutExistingRevWithBody("doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := db.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
 	assert.NoError(t, err, "add 2-a")
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 2-a...")
-	gotbody, err := db.Get1xBody("doc1")
+	gotbody, err := db.Get1xBody(ctx, "doc1")
 	require.NoError(t, err, "Couldn't get document")
 	assert.Equal(t, rev2a_body, gotbody)
 
@@ -685,14 +685,14 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 3-a")
 	rev3a_body := Body{"key1": "value2", "version": "3a", "large": prop_1000_bytes}
-	doc, newRev, err = db.PutExistingRevWithBody("doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false)
+	doc, newRev, err = db.PutExistingRevWithBody(ctx, "doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false)
 	require.NoError(t, err, "add 3-a")
 	rev3a_body[BodyId] = doc.ID
 	rev3a_body[BodyRev] = newRev
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 3-a...")
-	gotbody, err = db.Get1xBody("doc1")
+	gotbody, err = db.Get1xBody(ctx, "doc1")
 	require.NoError(t, err, "Couldn't get document")
 	assert.Equal(t, rev3a_body, gotbody)
 
@@ -704,12 +704,12 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 2-b")
 	rev2b_body := Body{"key1": "value2", "version": "2b", "large": prop_1000_bytes}
-	_, _, err = db.PutExistingRevWithBody("doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	_, _, err = db.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
 	require.NoError(t, err, "add 2-b")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify still rev 3-a")
-	gotbody, err = db.Get1xBody("doc1")
+	gotbody, err = db.Get1xBody(ctx, "doc1")
 	require.NoError(t, err, "Couldn't get document")
 	assert.Equal(t, rev3a_body, gotbody)
 
@@ -727,14 +727,14 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 6-a")
 	rev6a_body := Body{"key1": "value2", "version": "6a", "large": prop_1000_bytes}
-	doc, newRev, err = db.PutExistingRevWithBody("doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false)
+	doc, newRev, err = db.PutExistingRevWithBody(ctx, "doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false)
 	require.NoError(t, err, "add 6-a")
 	rev6a_body[BodyId] = doc.ID
 	rev6a_body[BodyRev] = newRev
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 6-a...")
-	gotbody, err = db.Get1xBody("doc1")
+	gotbody, err = db.Get1xBody(ctx, "doc1")
 	require.NoError(t, err, "Couldn't get document")
 	assert.Equal(t, rev6a_body, gotbody)
 
@@ -752,7 +752,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 3-b")
 	rev3b_body := Body{"key1": "value2", "version": "3b", "large": prop_1000_bytes}
-	_, _, err = db.PutExistingRevWithBody("doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false)
+	_, _, err = db.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false)
 	require.NoError(t, err, "add 3-b")
 
 	// Same again and again
@@ -771,12 +771,12 @@ func TestOldRevisionStorage(t *testing.T) {
 
 	log.Printf("Create rev 3-c")
 	rev3c_body := Body{"key1": "value2", "version": "3c", "large": prop_1000_bytes}
-	_, _, err = db.PutExistingRevWithBody("doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
+	_, _, err = db.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
 	require.NoError(t, err, "add 3-c")
 
 	log.Printf("Create rev 3-d")
 	rev3d_body := Body{"key1": "value2", "version": "3d", "large": prop_1000_bytes}
-	_, _, err = db.PutExistingRevWithBody("doc1", rev3d_body, []string{"3-d", "2-b", "1-a"}, false)
+	_, _, err = db.PutExistingRevWithBody(ctx, "doc1", rev3d_body, []string{"3-d", "2-b", "1-a"}, false)
 	require.NoError(t, err, "add 3-d")
 
 	// Create new winning revision on 'b' branch.  Triggers movement of 6-a to inline storage.  Force cas retry, check document contents
@@ -795,7 +795,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	//     7-b
 	log.Printf("Create rev 7-b")
 	rev7b_body := Body{"key1": "value2", "version": "7b", "large": prop_1000_bytes}
-	_, _, err = db.PutExistingRevWithBody("doc1", rev7b_body, []string{"7-b", "6-b", "5-b", "4-b", "3-b"}, false)
+	_, _, err = db.PutExistingRevWithBody(ctx, "doc1", rev7b_body, []string{"7-b", "6-b", "5-b", "4-b", "3-b"}, false)
 	require.NoError(t, err, "add 7-b")
 
 }
@@ -818,7 +818,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "v": "1a"}
-	_, _, err := db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
+	_, _, err := db.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -827,14 +827,14 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 2-a
 	log.Printf("Create rev 2-a")
 	rev2a_body := Body{"key1": "value2", "v": "2a"}
-	doc, newRev, err := db.PutExistingRevWithBody("doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := db.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 2-a...")
-	gotbody, err := db.Get1xBody("doc1")
+	gotbody, err := db.Get1xBody(ctx, "doc1")
 	assert.NoError(t, err, "Couldn't get document")
 	assert.Equal(t, rev2a_body, gotbody)
 
@@ -846,7 +846,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 3-a")
 	rev3a_body := Body{"key1": "value2", "v": "3a"}
-	doc, newRev, err = db.PutExistingRevWithBody("doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false)
+	doc, newRev, err = db.PutExistingRevWithBody(ctx, "doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false)
 	rev3a_body[BodyId] = doc.ID
 	rev3a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 3-a")
@@ -859,14 +859,14 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 2-b")
 	rev2b_body := Body{"key1": "value2", "v": "2b"}
-	doc, newRev, err = db.PutExistingRevWithBody("doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err = db.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify still rev 3-a")
-	gotbody, err = db.Get1xBody("doc1")
+	gotbody, err = db.Get1xBody(ctx, "doc1")
 	assert.NoError(t, err, "Couldn't get document")
 	assert.Equal(t, rev3a_body, gotbody)
 
@@ -884,14 +884,14 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 6-a")
 	rev6a_body := Body{"key1": "value2", "v": "6a"}
-	doc, newRev, err = db.PutExistingRevWithBody("doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false)
+	doc, newRev, err = db.PutExistingRevWithBody(ctx, "doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false)
 	rev6a_body[BodyId] = doc.ID
 	rev6a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 6-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 6-a...")
-	gotbody, err = db.Get1xBody("doc1")
+	gotbody, err = db.Get1xBody(ctx, "doc1")
 	assert.NoError(t, err, "Couldn't get document")
 	assert.Equal(t, rev6a_body, gotbody)
 
@@ -910,7 +910,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 3-b")
 	rev3b_body := Body{"key1": "value2", "v": "3b"}
-	_, _, err = db.PutExistingRevWithBody("doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false)
+	_, _, err = db.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false)
 	assert.NoError(t, err, "add 3-b")
 
 	// Same again
@@ -930,7 +930,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 
 	log.Printf("Create rev 3-c")
 	rev3c_body := Body{"key1": "value2", "v": "3c"}
-	_, _, err = db.PutExistingRevWithBody("doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
+	_, _, err = db.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
 	assert.NoError(t, err, "add 3-c")
 
 }
@@ -946,10 +946,10 @@ func TestLargeSequence(t *testing.T) {
 
 	// Write a doc via SG
 	body := Body{"key1": "largeSeqTest"}
-	_, _, err := db.PutExistingRevWithBody("largeSeqDoc", body, []string{"1-a"}, false)
+	_, _, err := db.PutExistingRevWithBody(ctx, "largeSeqDoc", body, []string{"1-a"}, false)
 	assert.NoError(t, err, "add largeSeqDoc")
 
-	syncData, err := db.GetDocSyncData(db.Ctx, "largeSeqDoc")
+	syncData, err := db.GetDocSyncData(ctx, "largeSeqDoc")
 	assert.NoError(t, err, "Error retrieving document sync data")
 	assert.Equal(t, uint64(9223372036854775808), syncData.Sequence)
 }
@@ -1022,7 +1022,7 @@ func TestMalformedRevisionStorageRecovery(t *testing.T) {
 	// 6-a
 	log.Printf("Attempt to create rev 3-c")
 	rev3c_body := Body{"key1": "value2", "v": "3c"}
-	_, _, err := db.PutExistingRevWithBody("doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
+	_, _, err := db.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
 	assert.NoError(t, err, "add 3-c")
 }
 
@@ -1034,51 +1034,51 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 	defer db.Close(ctx)
 
 	body := Body{"foo": "bar", "rev": "1-a"}
-	_, _, _ = db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
+	_, _, _ = db.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
 
 	largeDoc := make([]byte, 1000000)
 	longBody := Body{"val": string(largeDoc), "rev": "1-a"}
-	_, _, _ = db.PutExistingRevWithBody("doc2", longBody, []string{"1-a"}, false)
+	_, _, _ = db.PutExistingRevWithBody(ctx, "doc2", longBody, []string{"1-a"}, false)
 
 	var shortWithAttachmentsDataBody Body
 	shortWithAttachmentsData := `{"test": true, "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}, "rev":"1-a"}`
 	_ = base.JSONUnmarshal([]byte(shortWithAttachmentsData), &shortWithAttachmentsDataBody)
-	_, _, _ = db.PutExistingRevWithBody("doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false)
+	_, _, _ = db.PutExistingRevWithBody(ctx, "doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false)
 
 	b.Run("ShortLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.Get1xRevBody("doc1", "", false, nil)
+			_, _ = db.Get1xRevBody(ctx, "doc1", "", false, nil)
 		}
 	})
 	b.Run("LongLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.Get1xRevBody("doc2", "", false, nil)
+			_, _ = db.Get1xRevBody(ctx, "doc2", "", false, nil)
 		}
 	})
 	b.Run("ShortWithAttachmentsLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.Get1xRevBody("doc3", "", false, nil)
+			_, _ = db.Get1xRevBody(ctx, "doc3", "", false, nil)
 		}
 	})
 
 	updateBody := Body{"rev": "2-a"}
-	_, _, _ = db.PutExistingRevWithBody("doc1", updateBody, []string{"2-a", "1-a"}, false)
-	_, _, _ = db.PutExistingRevWithBody("doc2", updateBody, []string{"2-a", "1-a"}, false)
-	_, _, _ = db.PutExistingRevWithBody("doc3", updateBody, []string{"2-a", "1-a"}, false)
+	_, _, _ = db.PutExistingRevWithBody(ctx, "doc1", updateBody, []string{"2-a", "1-a"}, false)
+	_, _, _ = db.PutExistingRevWithBody(ctx, "doc2", updateBody, []string{"2-a", "1-a"}, false)
+	_, _, _ = db.PutExistingRevWithBody(ctx, "doc3", updateBody, []string{"2-a", "1-a"}, false)
 
 	b.Run("ShortOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.Get1xRevBody("doc1", "1-a", false, nil)
+			_, _ = db.Get1xRevBody(ctx, "doc1", "1-a", false, nil)
 		}
 	})
 	b.Run("LongOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.Get1xRevBody("doc2", "1-a", false, nil)
+			_, _ = db.Get1xRevBody(ctx, "doc2", "1-a", false, nil)
 		}
 	})
 	b.Run("ShortWithAttachmentsOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.Get1xRevBody("doc3", "1-a", false, nil)
+			_, _ = db.Get1xRevBody(ctx, "doc3", "1-a", false, nil)
 		}
 	})
 }
@@ -1091,51 +1091,51 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 	defer db.Close(ctx)
 
 	body := Body{"foo": "bar", "rev": "1-a"}
-	_, _, _ = db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
+	_, _, _ = db.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
 
 	largeDoc := make([]byte, 1000000)
 	longBody := Body{"val": string(largeDoc), "rev": "1-a"}
-	_, _, _ = db.PutExistingRevWithBody("doc2", longBody, []string{"1-a"}, false)
+	_, _, _ = db.PutExistingRevWithBody(ctx, "doc2", longBody, []string{"1-a"}, false)
 
 	var shortWithAttachmentsDataBody Body
 	shortWithAttachmentsData := `{"test": true, "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}, "rev":"1-a"}`
 	_ = base.JSONUnmarshal([]byte(shortWithAttachmentsData), &shortWithAttachmentsDataBody)
-	_, _, _ = db.PutExistingRevWithBody("doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false)
+	_, _, _ = db.PutExistingRevWithBody(ctx, "doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false)
 
 	b.Run("ShortLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.GetRev("doc1", "", false, nil)
+			_, _ = db.GetRev(ctx, "doc1", "", false, nil)
 		}
 	})
 	b.Run("LongLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.GetRev("doc2", "", false, nil)
+			_, _ = db.GetRev(ctx, "doc2", "", false, nil)
 		}
 	})
 	b.Run("ShortWithAttachmentsLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.GetRev("doc3", "", false, nil)
+			_, _ = db.GetRev(ctx, "doc3", "", false, nil)
 		}
 	})
 
 	updateBody := Body{"rev": "2-a"}
-	_, _, _ = db.PutExistingRevWithBody("doc1", updateBody, []string{"2-a", "1-a"}, false)
-	_, _, _ = db.PutExistingRevWithBody("doc2", updateBody, []string{"2-a", "1-a"}, false)
-	_, _, _ = db.PutExistingRevWithBody("doc3", updateBody, []string{"2-a", "1-a"}, false)
+	_, _, _ = db.PutExistingRevWithBody(ctx, "doc1", updateBody, []string{"2-a", "1-a"}, false)
+	_, _, _ = db.PutExistingRevWithBody(ctx, "doc2", updateBody, []string{"2-a", "1-a"}, false)
+	_, _, _ = db.PutExistingRevWithBody(ctx, "doc3", updateBody, []string{"2-a", "1-a"}, false)
 
 	b.Run("ShortOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.GetRev("doc1", "1-a", false, nil)
+			_, _ = db.GetRev(ctx, "doc1", "1-a", false, nil)
 		}
 	})
 	b.Run("LongOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.GetRev("doc2", "1-a", false, nil)
+			_, _ = db.GetRev(ctx, "doc2", "1-a", false, nil)
 		}
 	})
 	b.Run("ShortWithAttachmentsOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.GetRev("doc3", "1-a", false, nil)
+			_, _ = db.GetRev(ctx, "doc3", "1-a", false, nil)
 		}
 	})
 }
@@ -1149,10 +1149,10 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 	defer db.Close(ctx)
 
 	body := Body{"foo": "bar"}
-	_, _, _ = db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
+	_, _, _ = db.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
 
 	getDelta := func(newDoc *Document) {
-		deltaSrcRev, _ := db.GetRev("doc1", "1-a", false, nil)
+		deltaSrcRev, _ := db.GetRev(ctx, "doc1", "1-a", false, nil)
 
 		deltaSrcBody, _ := deltaSrcRev.MutableBody()
 
@@ -1196,27 +1196,27 @@ func TestGetAvailableRevAttachments(t *testing.T) {
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
 	defer context.Close(ctx)
-	db, err := CreateDatabase(ctx, context)
+	db, err := CreateDatabase(context)
 	assert.NoError(t, err, "Couldn't create database 'db'")
 
 	// Create the very first revision of the document with attachment; let's call this as rev 1-a
 	payload := `{"sku":"6213100","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
-	doc, rev, err := db.PutExistingRevWithBody("camera", unjson(payload), []string{"1-a"}, false)
+	doc, rev, err := db.PutExistingRevWithBody(ctx, "camera", unjson(payload), []string{"1-a"}, false)
 	assert.NoError(t, err, "Couldn't create document")
 	ancestor := rev // Ancestor revision
 
 	// Create the second revision of the document with attachment reference;
 	payload = `{"sku":"6213101","_attachments":{"camera.txt":{"stub":true,"revpos":1}}}`
-	doc, rev, err = db.PutExistingRevWithBody("camera", unjson(payload), []string{"2-a", "1-a"}, false)
+	doc, rev, err = db.PutExistingRevWithBody(ctx, "camera", unjson(payload), []string{"2-a", "1-a"}, false)
 	parent := rev // Immediate ancestor or parent revision
 	assert.NoError(t, err, "Couldn't create document")
 
 	payload = `{"sku":"6213102","_attachments":{"camera.txt":{"stub":true,"revpos":1}}}`
-	doc, rev, err = db.PutExistingRevWithBody("camera", unjson(payload), []string{"3-a", "2-a"}, false)
+	doc, rev, err = db.PutExistingRevWithBody(ctx, "camera", unjson(payload), []string{"3-a", "2-a"}, false)
 	assert.NoError(t, err, "Couldn't create document")
 
 	// Get available attachments by immediate ancestor revision or parent revision
-	meta, found := db.getAvailableRevAttachments(doc, parent)
+	meta, found := db.getAvailableRevAttachments(ctx, doc, parent)
 	attachment := meta["camera.txt"].(map[string]interface{})
 	assert.Equal(t, "sha1-VoSNiNQGHE1HirIS5HMxj6CrlHI=", attachment["digest"])
 	assert.Equal(t, json.Number("20"), attachment["length"])
@@ -1224,7 +1224,7 @@ func TestGetAvailableRevAttachments(t *testing.T) {
 	assert.True(t, found, "Ancestor should exists")
 
 	// Get available attachments by immediate ancestor revision
-	meta, found = db.getAvailableRevAttachments(doc, ancestor)
+	meta, found = db.getAvailableRevAttachments(ctx, doc, ancestor)
 	attachment = meta["camera.txt"].(map[string]interface{})
 	assert.Equal(t, "sha1-VoSNiNQGHE1HirIS5HMxj6CrlHI=", attachment["digest"])
 	assert.Equal(t, json.Number("20"), attachment["length"])
@@ -1237,20 +1237,20 @@ func TestGet1xRevAndChannels(t *testing.T) {
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
 	defer context.Close(ctx)
-	db, err := CreateDatabase(ctx, context)
+	db, err := CreateDatabase(context)
 	assert.NoError(t, err, "Couldn't create database 'db'")
 
 	docId := "dd6d2dcc679d12b9430a9787bab45b33"
 	payload := `{"sku":"6213100","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
-	doc1, rev1, err := db.PutExistingRevWithBody(docId, unjson(payload), []string{"1-a"}, false)
+	doc1, rev1, err := db.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"1-a"}, false)
 	assert.NoError(t, err, "Couldn't create document")
 
 	payload = `{"sku":"6213101","_attachments":{"lens.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
-	doc2, rev2, err := db.PutExistingRevWithBody(docId, unjson(payload), []string{"2-a", "1-a"}, false)
+	doc2, rev2, err := db.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"2-a", "1-a"}, false)
 	assert.NoError(t, err, "Couldn't create document")
 
 	// Get the 1x revision from document with list revision enabled
-	bodyBytes, removed, err := db.get1xRevFromDoc(doc2, rev2, true)
+	bodyBytes, removed, err := db.get1xRevFromDoc(ctx, doc2, rev2, true)
 	assert.False(t, removed)
 	assert.NoError(t, err, "It should not throw any error")
 	assert.NotNil(t, bodyBytes, "Document body bytes should be received")
@@ -1260,7 +1260,7 @@ func TestGet1xRevAndChannels(t *testing.T) {
 
 	// Get the 1x revision from document with list revision enabled. Also validate that the
 	// BodyRevisions property is present and correct since listRevisions=true.
-	bodyBytes, removed, err = db.get1xRevFromDoc(doc1, rev1, true)
+	bodyBytes, removed, err = db.get1xRevFromDoc(ctx, doc1, rev1, true)
 	assert.False(t, removed)
 	assert.NoError(t, err, "It should not throw any error")
 	assert.NotNil(t, bodyBytes, "Document body bytes should be received")
@@ -1274,15 +1274,15 @@ func TestGet1xRevAndChannels(t *testing.T) {
 	assert.Equal(t, []interface{}{"a"}, revisions[RevisionsIds])
 
 	// Delete the document, creating tombstone revision rev3
-	rev3, err := db.DeleteDoc(docId, rev2)
-	bodyBytes, removed, err = db.get1xRevFromDoc(doc2, rev3, true)
+	rev3, err := db.DeleteDoc(ctx, docId, rev2)
+	bodyBytes, removed, err = db.get1xRevFromDoc(ctx, doc2, rev3, true)
 	assert.False(t, removed)
 	assert.Error(t, err, "It should throw 404 missing error")
 	assert.Nil(t, bodyBytes, "Document body bytes should be empty")
 
 	// get1xRevFromDoc for doc2 should be returning the current revision id (in this case, the tombstone revision rev3).
 	// Also validate that the BodyRevisions property is present and correct since listRevisions=true.
-	bodyBytes, removed, err = db.get1xRevFromDoc(doc2, "", true)
+	bodyBytes, removed, err = db.get1xRevFromDoc(ctx, doc2, "", true)
 	assert.False(t, removed)
 	assert.NoError(t, err, "It should not throw any error")
 	assert.NotNil(t, bodyBytes, "Document body bytes should be received")
@@ -1301,20 +1301,20 @@ func TestGet1xRevFromDoc(t *testing.T) {
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
 	defer context.Close(ctx)
-	db, err := CreateDatabase(ctx, context)
+	db, err := CreateDatabase(context)
 	assert.NoError(t, err, "Couldn't create database 'db'")
 
 	// Create the first revision of the document
 	docId := "356779a9a1696714480f57fa3fb66d4c"
 	payload := `{"city":"Los Angeles"}`
-	doc, rev1, err := db.PutExistingRevWithBody(docId, unjson(payload), []string{"1-a"}, false)
+	doc, rev1, err := db.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"1-a"}, false)
 	assert.NoError(t, err, "Couldn't create document")
 	assert.NotEmpty(t, doc, "Document shouldn't be empty")
 	assert.Equal(t, "1-a", rev1, "Provided input revision ID should be returned")
 
 	// Get rev1 using get1xRevFromDoc. Also validate that the BodyRevisions property is present
 	// and correct since listRevisions=true.
-	bodyBytes, removed, err := db.get1xRevFromDoc(doc, rev1, true)
+	bodyBytes, removed, err := db.get1xRevFromDoc(ctx, doc, rev1, true)
 	assert.NotEmpty(t, bodyBytes, "Document body bytes should be returned")
 	assert.False(t, removed, "This shouldn't be a removed document")
 	var response = Body{}
@@ -1329,14 +1329,14 @@ func TestGet1xRevFromDoc(t *testing.T) {
 
 	// Create the second revision of the document
 	payload = `{"city":"Hollywood"}`
-	doc, rev2, err := db.PutExistingRevWithBody(docId, unjson(payload), []string{"2-a", "1-a"}, false)
+	doc, rev2, err := db.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"2-a", "1-a"}, false)
 	assert.NoError(t, err, "Couldn't create document")
 	assert.NotEmpty(t, doc, "Document shouldn't be empty")
 	assert.Equal(t, "2-a", rev2, "Provided input revision ID should be returned")
 
 	// Get rev2 using get1xRevFromDoc. Also validate that the BodyRevisions property is present
 	// and correct since listRevisions=true.
-	bodyBytes, removed, err = db.get1xRevFromDoc(doc, rev2, true)
+	bodyBytes, removed, err = db.get1xRevFromDoc(ctx, doc, rev2, true)
 	assert.NotEmpty(t, bodyBytes, "Document body bytes should be returned")
 	assert.False(t, removed, "This shouldn't be a removed document")
 	assert.NoError(t, response.Unmarshal(bodyBytes))
@@ -1351,7 +1351,7 @@ func TestGet1xRevFromDoc(t *testing.T) {
 	// Get body bytes from doc with unknown revision id; it simulates the error scenario.
 	// A 404 missing error should be thrown when trying get the body bytes of the document
 	// which doesn't exists in the revision tree. The revision "3-a" doesn't exists in database.
-	bodyBytes, removed, err = db.get1xRevFromDoc(doc, "3-a", true)
+	bodyBytes, removed, err = db.get1xRevFromDoc(ctx, doc, "3-a", true)
 	assert.Error(t, err, "It should throw 404 missing error")
 	assert.Contains(t, err.Error(), "404 missing")
 	assert.Empty(t, bodyBytes, "Provided revision doesn't exists")
@@ -1360,13 +1360,13 @@ func TestGet1xRevFromDoc(t *testing.T) {
 
 	// Deletes the document, by adding a new revision whose _deleted property is true.
 	body := Body{BodyDeleted: true, BodyRev: rev2}
-	rev3, doc, err := db.Put(docId, body)
+	rev3, doc, err := db.Put(ctx, docId, body)
 	assert.NoError(t, err, "Document should be deleted")
 	assert.NotEmpty(t, rev3, "Document revision shouldn't be empty")
 
 	// Get the document body bytes with the tombstone revision rev3, with listRevisions=true
 	// Also validate that the BodyRevisions property is present and correct.
-	bodyBytes, removed, err = db.get1xRevFromDoc(doc, rev3, true)
+	bodyBytes, removed, err = db.get1xRevFromDoc(ctx, doc, rev3, true)
 	assert.NotEmpty(t, bodyBytes, "Document body bytes should be returned")
 	assert.False(t, removed, "This shouldn't be a removed document")
 	assert.NoError(t, response.Unmarshal(bodyBytes))
@@ -1380,7 +1380,7 @@ func TestGet1xRevFromDoc(t *testing.T) {
 
 	// If the provided revision ID is blank and the current revision is already deleted
 	// when checking document revision history, it should throw 404 deleted error.
-	bodyBytes, removed, err = db.get1xRevFromDoc(doc, "", true)
+	bodyBytes, removed, err = db.get1xRevFromDoc(ctx, doc, "", true)
 	assert.Error(t, err, "404 deleted")
 	assert.Contains(t, err.Error(), "404 deleted")
 	assert.Empty(t, bodyBytes, "Document body bytes should be empty")

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1180,10 +1180,12 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 }
 
 func TestGetAvailableRevAttachments(t *testing.T) {
-	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx := base.TestCtx(t)
+	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
-	defer context.Close()
-	db, err := CreateDatabase(context)
+	ctx = context.AddDatabaseLogContext(ctx)
+	defer context.Close(ctx)
+	db, err := CreateDatabase(ctx, context)
 	assert.NoError(t, err, "Couldn't create database 'db'")
 
 	// Create the very first revision of the document with attachment; let's call this as rev 1-a
@@ -1220,10 +1222,12 @@ func TestGetAvailableRevAttachments(t *testing.T) {
 }
 
 func TestGet1xRevAndChannels(t *testing.T) {
-	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx := base.TestCtx(t)
+	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
-	defer context.Close()
-	db, err := CreateDatabase(context)
+	ctx = context.AddDatabaseLogContext(ctx)
+	defer context.Close(ctx)
+	db, err := CreateDatabase(ctx, context)
 	assert.NoError(t, err, "Couldn't create database 'db'")
 
 	docId := "dd6d2dcc679d12b9430a9787bab45b33"
@@ -1283,10 +1287,12 @@ func TestGet1xRevAndChannels(t *testing.T) {
 }
 
 func TestGet1xRevFromDoc(t *testing.T) {
-	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx := base.TestCtx(t)
+	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
-	defer context.Close()
-	db, err := CreateDatabase(context)
+	ctx = context.AddDatabaseLogContext(ctx)
+	defer context.Close(ctx)
+	db, err := CreateDatabase(ctx, context)
 	assert.NoError(t, err, "Couldn't create database 'db'")
 
 	// Create the first revision of the document

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -130,7 +130,7 @@ func TestHasAttachmentsFlag(t *testing.T) {
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 2-a...")
-	gotDoc, err := db.GetDocument(base.TestCtx(t), "doc1", DocUnmarshalSync)
+	gotDoc, err := db.GetDocument(db.Ctx, "doc1", DocUnmarshalSync)
 	assert.NoError(t, err)
 	require.Contains(t, gotDoc.Attachments, "hello.txt")
 	attachmentData, ok := gotDoc.Attachments["hello.txt"].(map[string]interface{})
@@ -156,7 +156,7 @@ func TestHasAttachmentsFlag(t *testing.T) {
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify rev 2-b")
-	gotDoc, err = db.GetDocument(base.TestCtx(t), "doc1", DocUnmarshalSync)
+	gotDoc, err = db.GetDocument(db.Ctx, "doc1", DocUnmarshalSync)
 	assert.NoError(t, err)
 	require.Contains(t, gotDoc.Attachments, "hello.txt")
 	attachmentData, ok = gotDoc.Attachments["hello.txt"].(map[string]interface{})
@@ -941,7 +941,7 @@ func TestLargeSequence(t *testing.T) {
 	_, _, err := db.PutExistingRevWithBody("largeSeqDoc", body, []string{"1-a"}, false)
 	assert.NoError(t, err, "add largeSeqDoc")
 
-	syncData, err := db.GetDocSyncData(base.TestCtx(t), "largeSeqDoc")
+	syncData, err := db.GetDocSyncData(db.Ctx, "largeSeqDoc")
 	assert.NoError(t, err, "Error retrieving document sync data")
 	assert.Equal(t, uint64(9223372036854775808), syncData.Sequence)
 }
@@ -1183,7 +1183,6 @@ func TestGetAvailableRevAttachments(t *testing.T) {
 	ctx := base.TestCtx(t)
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
-	ctx = context.AddDatabaseLogContext(ctx)
 	defer context.Close(ctx)
 	db, err := CreateDatabase(ctx, context)
 	assert.NoError(t, err, "Couldn't create database 'db'")
@@ -1225,7 +1224,6 @@ func TestGet1xRevAndChannels(t *testing.T) {
 	ctx := base.TestCtx(t)
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
-	ctx = context.AddDatabaseLogContext(ctx)
 	defer context.Close(ctx)
 	db, err := CreateDatabase(ctx, context)
 	assert.NoError(t, err, "Couldn't create database 'db'")
@@ -1290,7 +1288,6 @@ func TestGet1xRevFromDoc(t *testing.T) {
 	ctx := base.TestCtx(t)
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
-	ctx = context.AddDatabaseLogContext(ctx)
 	defer context.Close(ctx)
 	db, err := CreateDatabase(ctx, context)
 	assert.NoError(t, err, "Couldn't create database 'db'")

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -65,7 +65,8 @@ func TestRevisionCacheLoad(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	db := setupTestDBWithViewsEnabled(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	base.TestExternalRevStorage = true
 
@@ -104,7 +105,8 @@ func TestRevisionCacheLoad(t *testing.T) {
 func TestHasAttachmentsFlag(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	base.TestExternalRevStorage = true
 	prop_1000_bytes := base.CreateProperty(1000)
@@ -182,7 +184,8 @@ func TestHasAttachmentsFlagForLegacyAttachments(t *testing.T) {
 	}
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	base.TestExternalRevStorage = true
 	prop_1000_bytes := base.CreateProperty(1000)
@@ -303,7 +306,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	base.TestExternalRevStorage = true
 
@@ -486,7 +490,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 func TestRevisionStoragePruneTombstone(t *testing.T) {
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	base.TestExternalRevStorage = true
 
@@ -643,7 +648,8 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 func TestOldRevisionStorage(t *testing.T) {
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	prop_1000_bytes := base.CreateProperty(1000)
 
@@ -804,7 +810,8 @@ func TestOldRevisionStorageError(t *testing.T) {
 		ForceErrorSetRawKeys: []string{forceErrorKey},
 	}
 	db := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), leakyConfig)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {channel(doc.channels);}`, 0)
 
@@ -932,7 +939,8 @@ func TestOldRevisionStorageError(t *testing.T) {
 func TestLargeSequence(t *testing.T) {
 
 	db := setupTestDBWithCustomSyncSeq(t, 9223372036854775807)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -971,7 +979,8 @@ const rawDocMalformedRevisionStorage = `
 
 func TestMalformedRevisionStorageRecovery(t *testing.T) {
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {channel(doc.channels);}`, 0)
 
@@ -1021,7 +1030,8 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 	base.DisableTestLogging(b)
 
 	db := setupTestDB(b)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(b))
+	defer db.Close(ctx)
 
 	body := Body{"foo": "bar", "rev": "1-a"}
 	_, _, _ = db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
@@ -1077,7 +1087,8 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 	base.DisableTestLogging(b)
 
 	db := setupTestDB(b)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(b))
+	defer db.Close(ctx)
 
 	body := Body{"foo": "bar", "rev": "1-a"}
 	_, _, _ = db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
@@ -1134,7 +1145,8 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 	base.DisableTestLogging(b)
 
 	db := setupTestDB(b)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(b))
+	defer db.Close(ctx)
 
 	body := Body{"foo": "bar"}
 	_, _, _ = db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -64,8 +64,7 @@ func TestRevisionCacheLoad(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	db := setupTestDBWithViewsEnabled(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDBWithViewsEnabled(t)
 	defer db.Close(ctx)
 
 	base.TestExternalRevStorage = true
@@ -104,8 +103,7 @@ func TestRevisionCacheLoad(t *testing.T) {
 
 func TestHasAttachmentsFlag(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	base.TestExternalRevStorage = true
@@ -183,8 +181,7 @@ func TestHasAttachmentsFlagForLegacyAttachments(t *testing.T) {
 		t.Skip("Test only works with a Couchbase server and Xattrs")
 	}
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	base.TestExternalRevStorage = true
@@ -305,8 +302,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	base.TestExternalRevStorage = true
@@ -489,8 +485,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 // TestRevisionStoragePruneTombstone - tests cleanup of external tombstone bodies when pruned.
 func TestRevisionStoragePruneTombstone(t *testing.T) {
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	base.TestExternalRevStorage = true
@@ -647,8 +642,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 // Checks for unwanted interaction between old revision body backups and revision cache
 func TestOldRevisionStorage(t *testing.T) {
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	prop_1000_bytes := base.CreateProperty(1000)
@@ -809,8 +803,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	leakyConfig := base.LeakyBucketConfig{
 		ForceErrorSetRawKeys: []string{forceErrorKey},
 	}
-	db := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), leakyConfig)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), leakyConfig)
 	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {channel(doc.channels);}`, 0)
@@ -938,8 +931,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 // Validate JSON number handling for large sequence values
 func TestLargeSequence(t *testing.T) {
 
-	db := setupTestDBWithCustomSyncSeq(t, 9223372036854775807)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDBWithCustomSyncSeq(t, 9223372036854775807)
 	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
@@ -978,8 +970,7 @@ const rawDocMalformedRevisionStorage = `
     }`
 
 func TestMalformedRevisionStorageRecovery(t *testing.T) {
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {channel(doc.channels);}`, 0)
@@ -1029,8 +1020,7 @@ func TestMalformedRevisionStorageRecovery(t *testing.T) {
 func BenchmarkDatabaseGet1xRev(b *testing.B) {
 	base.DisableTestLogging(b)
 
-	db := setupTestDB(b)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(b))
+	db, ctx := setupTestDB(b)
 	defer db.Close(ctx)
 
 	body := Body{"foo": "bar", "rev": "1-a"}
@@ -1086,8 +1076,7 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 func BenchmarkDatabaseGetRev(b *testing.B) {
 	base.DisableTestLogging(b)
 
-	db := setupTestDB(b)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(b))
+	db, ctx := setupTestDB(b)
 	defer db.Close(ctx)
 
 	body := Body{"foo": "bar", "rev": "1-a"}
@@ -1144,8 +1133,7 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 func BenchmarkHandleRevDelta(b *testing.B) {
 	base.DisableTestLogging(b)
 
-	db := setupTestDB(b)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(b))
+	db, ctx := setupTestDB(b)
 	defer db.Close(ctx)
 
 	body := Body{"foo": "bar"}

--- a/db/database.go
+++ b/db/database.go
@@ -1867,3 +1867,13 @@ func (db *Database) CheckTimeout() error {
 		return nil
 	}
 }
+
+/// LOGGING
+
+// AddDatabaseLogContext adds database name to the parent context for logging
+func (dbCtx *DatabaseContext) AddDatabaseLogContext(ctx context.Context) context.Context {
+	if dbCtx != nil && dbCtx.Name != "" {
+		return base.LogContextWith(ctx, &base.DatabaseLogContext{DatabaseName: dbCtx.Name})
+	}
+	return ctx
+}

--- a/db/database.go
+++ b/db/database.go
@@ -424,7 +424,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	}
 
 	// Initialize sg-replicate manager
-	dbContext.SGReplicateMgr, err = NewSGReplicateManager(dbContext, dbContext.CfgSG)
+	dbContext.SGReplicateMgr, err = NewSGReplicateManager(ctx, dbContext, dbContext.CfgSG)
 	if err != nil {
 		return nil, err
 	}

--- a/db/database.go
+++ b/db/database.go
@@ -329,7 +329,8 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		return nil, err
 	}
 
-	// add db info to ctx before passing it down
+	// add db info to ctx before having a DatabaseContext (cannot call AddDatabaseLogContext),
+	// in order to pass it to RegisterImportPindexImpl
 	ctx = base.LogContextWith(ctx, &base.DatabaseLogContext{DatabaseName: dbName})
 
 	// Register the cbgt pindex type for the configGroup
@@ -696,7 +697,6 @@ func (context *DatabaseContext) Close(ctx context.Context) {
 	context.BucketLock.Lock()
 	defer context.BucketLock.Unlock()
 
-	ctx = context.AddDatabaseLogContext(ctx) // add db info to ctx before passing it down
 	context.OIDCProviders.Stop()
 	close(context.terminator)
 	// Wait for database background tasks to finish.

--- a/db/dcp_sharded_upgrade_test.go
+++ b/db/dcp_sharded_upgrade_test.go
@@ -215,8 +215,8 @@ func TestShardedDCPUpgrade(t *testing.T) {
 		},
 	})
 	require.NoError(t, err, "NewDatabaseContext")
-	ctx = db.AddDatabaseLogContext(ctx)
 	defer db.Close(ctx)
+	ctx = db.AddDatabaseLogContext(ctx)
 
 	err, _ = base.RetryLoop("wait for non-existent node to be removed", func() (shouldRetry bool, err error, value interface{}) {
 		nodes, _, err := cbgt.CfgGetNodeDefs(db.CfgSG, cbgt.NODE_DEFS_KNOWN)
@@ -249,15 +249,15 @@ func TestShardedDCPUpgrade(t *testing.T) {
 	require.NoError(t, err)
 
 	// assert that the doc we created before starting this node gets imported once all the pindexes are reassigned
-	require.NoError(t, db.WaitForPendingChanges(base.TestCtx(t)))
-	doc, err := db.GetDocument(base.TestCtx(t), testDoc1, DocUnmarshalAll)
+	require.NoError(t, db.WaitForPendingChanges(ctx))
+	doc, err := db.GetDocument(ctx, testDoc1, DocUnmarshalAll)
 	require.NoError(t, err, "GetDocument 1")
 	require.NotNil(t, doc, "GetDocument 1")
 
 	// Write a doc to the test bucket to check that import still works
 	require.NoError(t, tb.SetRaw(testDoc2, 0, nil, []byte(`{}`)))
-	require.NoError(t, db.WaitForPendingChanges(base.TestCtx(t)))
-	doc, err = db.GetDocument(base.TestCtx(t), testDoc2, DocUnmarshalAll)
+	require.NoError(t, db.WaitForPendingChanges(ctx))
+	doc, err = db.GetDocument(ctx, testDoc2, DocUnmarshalAll)
 	require.NoError(t, err, "GetDocument 2")
 	require.NotNil(t, doc, "GetDocument 2")
 }

--- a/db/dcp_sharded_upgrade_test.go
+++ b/db/dcp_sharded_upgrade_test.go
@@ -205,7 +205,8 @@ func TestShardedDCPUpgrade(t *testing.T) {
 	)
 	require.NoError(t, tb.SetRaw(testDoc1, 0, nil, []byte(`{}`)))
 
-	db, err := NewDatabaseContext(tb.GetName(), tb.NoCloseClone(), true, DatabaseContextOptions{
+	ctx := base.TestCtx(t)
+	db, err := NewDatabaseContext(ctx, tb.GetName(), tb.NoCloseClone(), true, DatabaseContextOptions{
 		GroupID:     "",
 		EnableXattr: true,
 		UseViews:    base.TestsDisableGSI(),
@@ -214,7 +215,8 @@ func TestShardedDCPUpgrade(t *testing.T) {
 		},
 	})
 	require.NoError(t, err, "NewDatabaseContext")
-	defer db.Close()
+	ctx = db.AddDatabaseLogContext(ctx)
+	defer db.Close(ctx)
 
 	err, _ = base.RetryLoop("wait for non-existent node to be removed", func() (shouldRetry bool, err error, value interface{}) {
 		nodes, _, err := cbgt.CfgGetNodeDefs(db.CfgSG, cbgt.NODE_DEFS_KNOWN)

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -40,7 +40,7 @@ func NewImportListener(groupID string) *importListener {
 
 // StartImportFeed starts an import DCP feed.  Always starts the feed based on previous checkpoints (Backfill:FeedResume).
 // Writes DCP stats into the StatKeyImportDcpStats map
-func (il *importListener) StartImportFeed(bucket base.Bucket, dbStats *base.DbStats, dbContext *DatabaseContext) (err error) {
+func (il *importListener) StartImportFeed(ctx context.Context, bucket base.Bucket, dbStats *base.DbStats, dbContext *DatabaseContext) (err error) {
 	il.bucketName = bucket.GetName()
 	il.database = Database{DatabaseContext: dbContext, user: nil}
 	il.stats = dbStats.Database()
@@ -67,15 +67,15 @@ func (il *importListener) StartImportFeed(bucket base.Bucket, dbStats *base.DbSt
 		Scopes:           scopes,
 	}
 
-	base.InfofCtx(context.TODO(), base.KeyDCP, "Attempting to start import DCP feed %v...", base.MD(base.ImportDestKey(il.database.Name)))
+	base.InfofCtx(ctx, base.KeyDCP, "Attempting to start import DCP feed %v...", base.MD(base.ImportDestKey(il.database.Name)))
 
 	importFeedStatsMap := dbContext.DbStats.Database().ImportFeedMapStats
 
 	// Store the listener in global map for dbname-based retrieval by cbgt prior to index registration
-	base.StoreDestFactory(base.ImportDestKey(il.database.Name), il.NewImportDest)
+	base.StoreDestFactory(ctx, base.ImportDestKey(il.database.Name), il.NewImportDest)
 
 	// Start DCP mutation feed
-	base.InfofCtx(context.TODO(), base.KeyDCP, "Starting DCP import feed for bucket: %q ", base.UD(bucket.GetName()))
+	base.InfofCtx(ctx, base.KeyDCP, "Starting DCP import feed for bucket: %q ", base.UD(bucket.GetName()))
 
 	// TODO: need to clean up StartDCPFeed to push bucket dependencies down
 	cbStore, ok := base.AsCouchbaseStore(bucket)

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -28,6 +28,7 @@ type importListener struct {
 	stats            *base.DatabaseStats // Database stats group
 	cbgtContext      *base.CbgtContext   // Handle to cbgt manager,cfg
 	checkpointPrefix string              // DCP checkpoint key prefix
+	loggingCtx       context.Context     // ctx for logging, since function signatures without ctx are required by external dependency, for ex.: sgbucket.FeedEventCallbackFunc
 }
 
 func NewImportListener(groupID string) *importListener {
@@ -44,6 +45,7 @@ func (il *importListener) StartImportFeed(ctx context.Context, bucket base.Bucke
 	il.bucketName = bucket.GetName()
 	il.database = Database{DatabaseContext: dbContext, user: nil}
 	il.stats = dbStats.Database()
+	il.loggingCtx = ctx
 	scopes := make(map[string][]string)
 	// TODO: remove once both sharded and non-sharded DCP feeds support more than one collection (CBG-2182, CBG-2193)
 	if len(dbContext.Scopes) > 1 {
@@ -117,7 +119,7 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) (shouldPers
 
 	// If this is a delete and there are no xattrs (no existing SG revision), we shouldn't import
 	if event.Opcode == sgbucket.FeedOpDeletion && len(event.Value) == 0 {
-		base.DebugfCtx(context.TODO(), base.KeyImport, "Ignoring delete mutation for %s - no existing Sync Gateway metadata.", base.UD(event.Key))
+		base.DebugfCtx(il.loggingCtx, base.KeyImport, "Ignoring delete mutation for %s - no existing Sync Gateway metadata.", base.UD(event.Key))
 		return true
 	}
 
@@ -131,14 +133,12 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) (shouldPers
 }
 
 func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
-	logCtx := context.TODO()
-
 	// Unmarshal the doc metadata (if present) to determine if this mutation requires import.
 	syncData, rawBody, rawXattr, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(event.Value, event.DataType, il.database.Options.UserXattrKey, false)
 	if err != nil {
-		base.DebugfCtx(logCtx, base.KeyImport, "Found sync metadata, but unable to unmarshal for feed document %q.  Will not be imported.  Error: %v", base.UD(event.Key), err)
+		base.DebugfCtx(il.loggingCtx, base.KeyImport, "Found sync metadata, but unable to unmarshal for feed document %q.  Will not be imported.  Error: %v", base.UD(event.Key), err)
 		if err == base.ErrEmptyMetadata {
-			base.WarnfCtx(logCtx, "Unexpected empty metadata when processing feed event.  docid: %s opcode: %v datatype:%v", base.UD(event.Key), event.Opcode, event.DataType)
+			base.WarnfCtx(il.loggingCtx, "Unexpected empty metadata when processing feed event.  docid: %s opcode: %v datatype:%v", base.UD(event.Key), event.Opcode, event.DataType)
 		}
 		return
 	}
@@ -163,19 +163,19 @@ func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
 		// last attempt to exit processing if the importListener has been closed before attempting to write to the bucket
 		select {
 		case <-il.terminator:
-			base.InfofCtx(logCtx, base.KeyImport, "Aborting import for doc %q - importListener.terminator was closed", base.UD(docID))
+			base.InfofCtx(il.loggingCtx, base.KeyImport, "Aborting import for doc %q - importListener.terminator was closed", base.UD(docID))
 			return
 		default:
 		}
 
-		_, err := il.database.ImportDocRaw(docID, rawBody, rawXattr, rawUserXattr, isDelete, event.Cas, &event.Expiry, ImportFromFeed)
+		_, err := il.database.ImportDocRaw(il.loggingCtx, docID, rawBody, rawXattr, rawUserXattr, isDelete, event.Cas, &event.Expiry, ImportFromFeed)
 		if err != nil {
 			if err == base.ErrImportCasFailure {
-				base.DebugfCtx(logCtx, base.KeyImport, "Not importing mutation - document %s has been subsequently updated and will be imported based on that mutation.", base.UD(docID))
+				base.DebugfCtx(il.loggingCtx, base.KeyImport, "Not importing mutation - document %s has been subsequently updated and will be imported based on that mutation.", base.UD(docID))
 			} else if err == base.ErrImportCancelledFilter {
 				// No logging required - filter info already logged during importDoc
 			} else {
-				base.DebugfCtx(logCtx, base.KeyImport, "Did not import doc %q - external update will not be accessible via Sync Gateway.  Reason: %v", base.UD(docID), err)
+				base.DebugfCtx(il.loggingCtx, base.KeyImport, "Did not import doc %q - external update will not be accessible via Sync Gateway.  Reason: %v", base.UD(docID), err)
 			}
 		}
 	}
@@ -191,7 +191,7 @@ func (il *importListener) Stop() {
 			for _, pIndex := range pindexes {
 				err := il.cbgtContext.Manager.ClosePIndex(pIndex)
 				if err != nil {
-					base.DebugfCtx(context.TODO(), base.KeyImport, "Error closing pindex: %v", err)
+					base.DebugfCtx(il.loggingCtx, base.KeyImport, "Error closing pindex: %v", err)
 				}
 			}
 			// ClosePIndex calls are synchronous, so can stop manager once they've completed

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -28,7 +28,7 @@ type importListener struct {
 	stats            *base.DatabaseStats // Database stats group
 	cbgtContext      *base.CbgtContext   // Handle to cbgt manager,cfg
 	checkpointPrefix string              // DCP checkpoint key prefix
-	loggingCtx       context.Context     // ctx for logging, since function signatures without ctx are required by external dependency, for ex.: sgbucket.FeedEventCallbackFunc
+	loggingCtx       context.Context     // ctx for logging on event callbacks
 }
 
 func NewImportListener(groupID string) *importListener {

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -93,7 +93,7 @@ func (il *importListener) StartImportFeed(ctx context.Context, bucket base.Bucke
 		}
 		return base.StartGocbDCPFeed(collection, bucket.GetName(), feedArgs, il.ProcessFeedEvent, importFeedStatsMap.Map, base.DCPMetadataStoreCS, groupID)
 	}
-	il.cbgtContext, err = base.StartShardedDCPFeed(dbContext.Name, dbContext.Options.GroupID, dbContext.UUID, dbContext.Heartbeater, bucket, cbStore.GetSpec(), dbContext.Options.ImportOptions.ImportPartitions, dbContext.CfgSG)
+	il.cbgtContext, err = base.StartShardedDCPFeed(ctx, dbContext.Name, dbContext.Options.GroupID, dbContext.UUID, dbContext.Heartbeater, bucket, cbStore.GetSpec(), dbContext.Options.ImportOptions.ImportPartitions, dbContext.CfgSG)
 	return err
 }
 

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -98,7 +98,6 @@ func (il *importListener) NewImportDest() (cbgt.Dest, error) {
 	importFeedStatsMap := il.database.DbStats.Database().ImportFeedMapStats
 	importPartitionStat := il.database.DbStats.SharedBucketImport().ImportPartitions
 
-	ctx := base.LogContextWith(context.TODO(), &base.DatabaseLogContext{DatabaseName: il.database.Name})
-	importDest, _ := base.NewDCPDest(ctx, callback, bucket, maxVbNo, true, importFeedStatsMap.Map, base.DCPImportFeedID, importPartitionStat, il.checkpointPrefix)
+	importDest, _ := base.NewDCPDest(il.loggingCtx, callback, bucket, maxVbNo, true, importFeedStatsMap.Map, base.DCPImportFeedID, importPartitionStat, il.checkpointPrefix)
 	return importDest, nil
 }

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -22,13 +22,13 @@ import (
 // RegisterImportPindexImpl registers the PIndex type definition.  This is invoked by cbgt when a Pindex (collection of
 // vbuckets) is assigned to this node.
 
-func RegisterImportPindexImpl(configGroup string) {
+func RegisterImportPindexImpl(ctx context.Context, configGroup string) {
 
 	// Since RegisterPIndexImplType is a global var without synchronization, index type needs to be
 	// config group scoped.  The associated importListener within the context is retrieved based on the
 	// dbname in the index params
 	pIndexType := base.CBGTIndexTypeSyncGatewayImport + configGroup
-	base.InfofCtx(context.TODO(), base.KeyDCP, "Registering PindexImplType for %s", pIndexType)
+	base.InfofCtx(ctx, base.KeyDCP, "Registering PindexImplType for %s", pIndexType)
 	cbgt.RegisterPIndexImplType(pIndexType,
 		&cbgt.PIndexImplType{
 			New:       NewImportPIndexImpl,
@@ -98,6 +98,7 @@ func (il *importListener) NewImportDest() (cbgt.Dest, error) {
 	importFeedStatsMap := il.database.DbStats.Database().ImportFeedMapStats
 	importPartitionStat := il.database.DbStats.SharedBucketImport().ImportPartitions
 
-	importDest, _ := base.NewDCPDest(callback, bucket, maxVbNo, true, importFeedStatsMap.Map, base.DCPImportFeedID, importPartitionStat, il.checkpointPrefix)
+	ctx := base.LogContextWith(context.TODO(), &base.DatabaseLogContext{DatabaseName: il.database.Name})
+	importDest, _ := base.NewDCPDest(ctx, callback, bucket, maxVbNo, true, importFeedStatsMap.Map, base.DCPImportFeedID, importPartitionStat, il.checkpointPrefix)
 	return importDest, nil
 }

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -81,6 +81,7 @@ func TestMigrateMetadata(t *testing.T) {
 
 	// Call migrateMeta with stale args that have old stale expiry
 	_, _, err = db.migrateMetadata(
+		ctx,
 		key,
 		body,
 		existingBucketDoc,
@@ -178,7 +179,7 @@ func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 			require.NoError(t, err)
 
 			// Import the doc (will migrate as part of the import since the doc contains sync meta)
-			_, errImportDoc := db.importDoc(key, body, &expiry, false, existingBucketDoc, ImportOnDemand)
+			_, errImportDoc := db.importDoc(ctx, key, body, &expiry, false, existingBucketDoc, ImportOnDemand)
 			assert.NoError(t, errImportDoc, "Unexpected error")
 
 			// Make sure the doc in the bucket has expected XATTR
@@ -327,7 +328,7 @@ func TestImportWithCasFailureUpdate(t *testing.T) {
 			runOnce = true
 
 			// Trigger import
-			_, err = db.importDoc(testcase.docname, bodyD, nil, false, existingBucketDoc, ImportOnDemand)
+			_, err = db.importDoc(ctx, testcase.docname, bodyD, nil, false, existingBucketDoc, ImportOnDemand)
 			assert.NoError(t, err)
 
 			// Check document has the rev and new body
@@ -396,7 +397,7 @@ func TestImportNullDoc(t *testing.T) {
 	existingDoc := &sgbucket.BucketDocument{Body: rawNull, Cas: 1}
 
 	// Import a null document
-	importedDoc, err := db.importDoc(key+"1", body, nil, false, existingDoc, ImportOnDemand)
+	importedDoc, err := db.importDoc(ctx, key+"1", body, nil, false, existingDoc, ImportOnDemand)
 	assert.Equal(t, base.ErrEmptyDocument, err)
 	assert.True(t, importedDoc == nil, "Expected no imported doc")
 }
@@ -411,7 +412,7 @@ func TestImportNullDocRaw(t *testing.T) {
 	// Feed import of null doc
 	exp := uint32(0)
 
-	importedDoc, err := db.ImportDocRaw("TestImportNullDoc", []byte("null"), []byte("{}"), nil, false, 1, &exp, ImportFromFeed)
+	importedDoc, err := db.ImportDocRaw(ctx, "TestImportNullDoc", []byte("null"), []byte("{}"), nil, false, 1, &exp, ImportFromFeed)
 	assert.Equal(t, base.ErrEmptyDocument, err)
 	assert.True(t, importedDoc == nil, "Expected no imported doc")
 }

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"testing"
@@ -41,8 +42,7 @@ func TestMigrateMetadata(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyMigrate, base.KeyImport)
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	key := "TestMigrateMetadata"
@@ -113,8 +113,7 @@ func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyMigrate, base.KeyImport)
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	type testcase struct {
@@ -204,6 +203,7 @@ func TestImportWithCasFailureUpdate(t *testing.T) {
 	var db *Database
 	var existingBucketDoc *sgbucket.BucketDocument
 	var runOnce bool
+	var ctx context.Context
 
 	type testcase struct {
 		callback func(key string)
@@ -303,8 +303,7 @@ func TestImportWithCasFailureUpdate(t *testing.T) {
 
 	for _, testcase := range testcases {
 		t.Run(fmt.Sprintf("%s", testcase.docname), func(t *testing.T) {
-			db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), base.LeakyBucketConfig{WriteWithXattrCallback: testcase.callback})
-			ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+			db, ctx = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), base.LeakyBucketConfig{WriteWithXattrCallback: testcase.callback})
 			defer db.Close(ctx)
 
 			bodyBytes := rawDocWithSyncMeta()
@@ -387,8 +386,7 @@ func TestImportNullDoc(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyImport)
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	key := "TestImportNullDoc"
@@ -405,8 +403,7 @@ func TestImportNullDoc(t *testing.T) {
 func TestImportNullDocRaw(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyImport)
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	// Feed import of null doc
@@ -430,8 +427,7 @@ func assertXattrSyncMetaRevGeneration(t *testing.T, bucket base.Bucket, key stri
 
 func TestEvaluateFunction(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyImport)
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	// Simulate unexpected error invoking import filter for document

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -42,7 +42,8 @@ func TestMigrateMetadata(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyMigrate, base.KeyImport)
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	key := "TestMigrateMetadata"
 	bodyBytes := rawDocWithSyncMeta()
@@ -112,7 +113,8 @@ func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyMigrate, base.KeyImport)
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	type testcase struct {
 		docBody            []byte
@@ -301,7 +303,8 @@ func TestImportWithCasFailureUpdate(t *testing.T) {
 	for _, testcase := range testcases {
 		t.Run(fmt.Sprintf("%s", testcase.docname), func(t *testing.T) {
 			db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), base.LeakyBucketConfig{WriteWithXattrCallback: testcase.callback})
-			defer db.Close()
+			ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+			defer db.Close(ctx)
 
 			bodyBytes := rawDocWithSyncMeta()
 			body := Body{}
@@ -384,7 +387,8 @@ func TestImportNullDoc(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyImport)
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	key := "TestImportNullDoc"
 	var body Body
@@ -401,7 +405,8 @@ func TestImportNullDocRaw(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyImport)
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	// Feed import of null doc
 	exp := uint32(0)
@@ -425,7 +430,8 @@ func assertXattrSyncMetaRevGeneration(t *testing.T, bucket base.Bucket, key stri
 func TestEvaluateFunction(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyImport)
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	// Simulate unexpected error invoking import filter for document
 	body := Body{"key": "value", "version": "1a"}

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -40,8 +40,7 @@ func TestInitializeIndexes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("xattrs=%v collections=%v", test.xattrs, test.collections), func(t *testing.T) {
-			db := setupTestDBWithOptions(t, DatabaseContextOptions{EnableXattr: test.xattrs})
-			ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+			db, ctx := setupTestDBWithOptions(t, DatabaseContextOptions{EnableXattr: test.xattrs})
 			defer db.Close(ctx)
 
 			var b base.Bucket = db.Bucket
@@ -117,8 +116,7 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	require.True(t, db.Bucket.IsSupported(sgbucket.DataStoreFeatureN1ql))
@@ -166,8 +164,7 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	require.True(t, db.Bucket.IsSupported(sgbucket.DataStoreFeatureN1ql))
@@ -213,8 +210,7 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	copiedIndexes := copySGIndexes(sgIndexes)
@@ -270,8 +266,7 @@ func TestRemoveObsoleteIndexOnError(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	leakyBucket := base.NewLeakyBucket(db.Bucket, base.LeakyBucketConfig{DropIndexErrorNames: []string{"sg_access_1", "sg_access_x1"}})

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -41,7 +41,8 @@ func TestInitializeIndexes(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("xattrs=%v collections=%v", test.xattrs, test.collections), func(t *testing.T) {
 			db := setupTestDBWithOptions(t, DatabaseContextOptions{EnableXattr: test.xattrs})
-			defer db.Close()
+			ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+			defer db.Close(ctx)
 
 			var b base.Bucket = db.Bucket
 			if test.collections {
@@ -117,7 +118,8 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	}
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	require.True(t, db.Bucket.IsSupported(sgbucket.DataStoreFeatureN1ql))
 
@@ -165,7 +167,8 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	}
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	require.True(t, db.Bucket.IsSupported(sgbucket.DataStoreFeatureN1ql))
 	n1qlStore, ok := base.AsN1QLStore(db.Bucket)
@@ -211,7 +214,8 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 	}
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	copiedIndexes := copySGIndexes(sgIndexes)
 
@@ -267,7 +271,8 @@ func TestRemoveObsoleteIndexOnError(t *testing.T) {
 	}
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	leakyBucket := base.NewLeakyBucket(db.Bucket, base.LeakyBucketConfig{DropIndexErrorNames: []string{"sg_access_1", "sg_access_x1"}})
 	copiedIndexes := copySGIndexes(sgIndexes)

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -37,13 +37,13 @@ func TestQueryChannelsStatsView(t *testing.T) {
 	// docID -> Sequence
 	docSeqMap := make(map[string]uint64, 3)
 
-	_, doc, err := db.Put("queryTestDoc1", Body{"channels": []string{"ABC"}})
+	_, doc, err := db.Put(ctx, "queryTestDoc1", Body{"channels": []string{"ABC"}})
 	require.NoError(t, err, "Put queryDoc1")
 	docSeqMap["queryTestDoc1"] = doc.Sequence
-	_, doc, err = db.Put("queryTestDoc2", Body{"channels": []string{"ABC"}})
+	_, doc, err = db.Put(ctx, "queryTestDoc2", Body{"channels": []string{"ABC"}})
 	require.NoError(t, err, "Put queryDoc2")
 	docSeqMap["queryTestDoc2"] = doc.Sequence
-	_, doc, err = db.Put("queryTestDoc3", Body{"channels": []string{"ABC"}})
+	_, doc, err = db.Put(ctx, "queryTestDoc3", Body{"channels": []string{"ABC"}})
 	require.NoError(t, err, "Put queryDoc3")
 	docSeqMap["queryTestDoc3"] = doc.Sequence
 
@@ -92,13 +92,13 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 	// docID -> Sequence
 	docSeqMap := make(map[string]uint64, 3)
 
-	_, doc, err := db.Put("queryTestDoc1", Body{"channels": []string{"ABC"}})
+	_, doc, err := db.Put(ctx, "queryTestDoc1", Body{"channels": []string{"ABC"}})
 	require.NoError(t, err, "Put queryDoc1")
 	docSeqMap["queryTestDoc1"] = doc.Sequence
-	_, doc, err = db.Put("queryTestDoc2", Body{"channels": []string{"ABC"}})
+	_, doc, err = db.Put(ctx, "queryTestDoc2", Body{"channels": []string{"ABC"}})
 	require.NoError(t, err, "Put queryDoc2")
 	docSeqMap["queryTestDoc2"] = doc.Sequence
-	_, doc, err = db.Put("queryTestDoc3", Body{"channels": []string{"ABC"}})
+	_, doc, err = db.Put(ctx, "queryTestDoc3", Body{"channels": []string{"ABC"}})
 	require.NoError(t, err, "Put queryDoc3")
 	docSeqMap["queryTestDoc3"] = doc.Sequence
 
@@ -144,7 +144,7 @@ func TestQuerySequencesStatsView(t *testing.T) {
 	// Add docs without channel assignment (will only be assigned to the star channel)
 	for i := 1; i <= 10; i++ {
 		docID := fmt.Sprintf("queryTestDoc%d", i)
-		_, doc, err := db.Put(docID, Body{"nochannels": true})
+		_, doc, err := db.Put(ctx, docID, Body{"nochannels": true})
 		assert.NoError(t, err, "Put queryDoc")
 		docSeqMap[docID] = doc.Sequence
 	}
@@ -192,7 +192,7 @@ func TestQuerySequencesStatsView(t *testing.T) {
 	// Add some docs in different channels, to validate query handling when non-star channel docs are present
 	for i := 1; i <= 10; i++ {
 		docID := fmt.Sprintf("queryTestDocChanneled%d", i)
-		_, doc, err := db.Put(docID, Body{"channels": []string{fmt.Sprintf("ABC%d", i)}})
+		_, doc, err := db.Put(ctx, docID, Body{"channels": []string{fmt.Sprintf("ABC%d", i)}})
 		require.NoError(t, err, "Put queryDoc")
 		docSeqMap[docID] = doc.Sequence
 	}
@@ -240,7 +240,7 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 	// Add docs without channel assignment (will only be assigned to the star channel)
 	for i := 1; i <= 10; i++ {
 		docID := fmt.Sprintf("queryTestDoc%d", i)
-		_, doc, err := db.Put(docID, Body{"nochannels": true})
+		_, doc, err := db.Put(ctx, docID, Body{"nochannels": true})
 		require.NoError(t, err, "Put queryDoc")
 		docSeqMap[docID] = doc.Sequence
 	}
@@ -286,7 +286,7 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 	// Add some docs in different channels, to validate query handling when non-star channel docs are present
 	for i := 1; i <= 10; i++ {
 		docID := fmt.Sprintf("queryTestDocChanneled%d", i)
-		_, doc, err := db.Put(docID, Body{"channels": []string{fmt.Sprintf("ABC%d", i)}})
+		_, doc, err := db.Put(ctx, docID, Body{"channels": []string{fmt.Sprintf("ABC%d", i)}})
 		require.NoError(t, err, "Put queryDoc")
 		docSeqMap[docID] = doc.Sequence
 	}
@@ -385,7 +385,7 @@ func TestAllDocsQuery(t *testing.T) {
 
 	// Add docs with channel assignment
 	for i := 1; i <= 10; i++ {
-		_, _, err := db.Put(fmt.Sprintf("allDocsTest%d", i), Body{"channels": []string{"ABC"}})
+		_, _, err := db.Put(ctx, fmt.Sprintf("allDocsTest%d", i), Body{"channels": []string{"ABC"}})
 		assert.NoError(t, err, "Put allDocsTest doc")
 	}
 
@@ -455,7 +455,7 @@ func TestAccessQuery(t *testing.T) {
 }`, 0)
 	// Add docs with access grants assignment
 	for i := 1; i <= 5; i++ {
-		_, _, err := db.Put(fmt.Sprintf("accessTest%d", i), Body{"accessUser": "user1", "accessChannel": fmt.Sprintf("channel%d", i)})
+		_, _, err := db.Put(ctx, fmt.Sprintf("accessTest%d", i), Body{"accessUser": "user1", "accessChannel": fmt.Sprintf("channel%d", i)})
 		assert.NoError(t, err, "Put accessTest doc")
 	}
 
@@ -501,7 +501,7 @@ func TestRoleAccessQuery(t *testing.T) {
 }`, 0)
 	// Add docs with access grants assignment
 	for i := 1; i <= 5; i++ {
-		_, _, err := db.Put(fmt.Sprintf("accessTest%d", i), Body{"accessUser": "user1", "accessChannel": fmt.Sprintf("channel%d", i)})
+		_, _, err := db.Put(ctx, fmt.Sprintf("accessTest%d", i), Body{"accessUser": "user1", "accessChannel": fmt.Sprintf("channel%d", i)})
 		assert.NoError(t, err, "Put accessTest doc")
 	}
 
@@ -596,7 +596,7 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	// Create 10 added documents
 	for i := 1; i <= 10; i++ {
 		id := "created" + strconv.Itoa(i)
-		doc, revId, err := db.PutExistingRevWithBody(id, body, []string{"1-a"}, false)
+		doc, revId, err := db.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "1-a", revId)
 		docIdFlagMap[doc.ID] = uint8(0x0)
@@ -609,12 +609,12 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	// Create 10 deleted documents
 	for i := 1; i <= 10; i++ {
 		id := "deleted" + strconv.Itoa(i)
-		doc, revId, err := db.PutExistingRevWithBody(id, body, []string{"1-a"}, false)
+		doc, revId, err := db.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "1-a", revId)
 
 		body[BodyDeleted] = true
-		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"2-a", "1-a"}, false)
+		doc, revId, err = db.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "2-a", revId, "Couldn't create tombstone revision")
 
@@ -626,22 +626,22 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	for i := 1; i <= 10; i++ {
 		body["sound"] = "meow"
 		id := "branched" + strconv.Itoa(i)
-		doc, revId, err := db.PutExistingRevWithBody(id, body, []string{"1-a"}, false)
+		doc, revId, err := db.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
 		require.NoError(t, err, "Couldn't create document revision 1-a")
 		require.Equal(t, "1-a", revId)
 
 		body["sound"] = "bark"
-		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"2-b", "1-a"}, false)
+		doc, revId, err = db.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false)
 		require.NoError(t, err, "Couldn't create revision 2-b")
 		require.Equal(t, "2-b", revId)
 
 		body["sound"] = "bleat"
-		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"2-a", "1-a"}, false)
+		doc, revId, err = db.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false)
 		require.NoError(t, err, "Couldn't create revision 2-a")
 		require.Equal(t, "2-a", revId)
 
 		body[BodyDeleted] = true
-		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"3-a", "2-a"}, false)
+		doc, revId, err = db.PutExistingRevWithBody(ctx, id, body, []string{"3-a", "2-a"}, false)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "3-a", revId, "Couldn't create tombstone revision")
 
@@ -653,27 +653,27 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	for i := 1; i <= 10; i++ {
 		body["sound"] = "meow"
 		id := "branched|deleted" + strconv.Itoa(i)
-		doc, revId, err := db.PutExistingRevWithBody(id, body, []string{"1-a"}, false)
+		doc, revId, err := db.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
 		require.NoError(t, err, "Couldn't create document revision 1-a")
 		require.Equal(t, "1-a", revId)
 
 		body["sound"] = "bark"
-		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"2-b", "1-a"}, false)
+		doc, revId, err = db.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false)
 		require.NoError(t, err, "Couldn't create revision 2-b")
 		require.Equal(t, "2-b", revId)
 
 		body["sound"] = "bleat"
-		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"2-a", "1-a"}, false)
+		doc, revId, err = db.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false)
 		require.NoError(t, err, "Couldn't create revision 2-a")
 		require.Equal(t, "2-a", revId)
 
 		body[BodyDeleted] = true
-		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"3-a", "2-a"}, false)
+		doc, revId, err = db.PutExistingRevWithBody(ctx, id, body, []string{"3-a", "2-a"}, false)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "3-a", revId, "Couldn't create tombstone revision")
 
 		body[BodyDeleted] = true
-		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"3-b", "2-b"}, false)
+		doc, revId, err = db.PutExistingRevWithBody(ctx, id, body, []string{"3-b", "2-b"}, false)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "3-b", revId, "Couldn't create tombstone revision")
 
@@ -685,17 +685,17 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	for i := 1; i <= 10; i++ {
 		body["sound"] = "meow"
 		id := "branched|conflict" + strconv.Itoa(i)
-		doc, revId, err := db.PutExistingRevWithBody(id, body, []string{"1-a"}, false)
+		doc, revId, err := db.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
 		require.NoError(t, err, "Couldn't create document revision 1-a")
 		require.Equal(t, "1-a", revId)
 
 		body["sound"] = "bark"
-		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"2-b", "1-a"}, false)
+		doc, revId, err = db.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false)
 		require.NoError(t, err, "Couldn't create revision 2-b")
 		require.Equal(t, "2-b", revId)
 
 		body["sound"] = "bleat"
-		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"2-a", "1-a"}, false)
+		doc, revId, err = db.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false)
 		require.NoError(t, err, "Couldn't create revision 2-a")
 		require.Equal(t, "2-a", revId)
 

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -31,7 +31,8 @@ func TestQueryChannelsStatsView(t *testing.T) {
 	}
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	// docID -> Sequence
 	docSeqMap := make(map[string]uint64, 3)
@@ -85,7 +86,8 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 	}
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	// docID -> Sequence
 	docSeqMap := make(map[string]uint64, 3)
@@ -133,7 +135,8 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 func TestQuerySequencesStatsView(t *testing.T) {
 
 	db := setupTestDBWithViewsEnabled(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	// docID -> Sequence
 	docSeqMap := make(map[string]uint64, 20)
@@ -228,7 +231,8 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 	}
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	// docID -> Sequence
 	docSeqMap := make(map[string]uint64, 20)
@@ -321,7 +325,8 @@ func TestCoveringQueries(t *testing.T) {
 	}
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	n1QLStore, ok := base.AsN1QLStore(db.Bucket)
 	if !ok {
@@ -375,7 +380,8 @@ func TestAllDocsQuery(t *testing.T) {
 	}
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	// Add docs with channel assignment
 	for i := 1; i <= 10; i++ {
@@ -441,7 +447,8 @@ func TestAccessQuery(t *testing.T) {
 	}
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {
 	access(doc.accessUser, doc.accessChannel)
@@ -486,7 +493,8 @@ func TestRoleAccessQuery(t *testing.T) {
 	}
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {
 	role(doc.accessUser, "role:" + doc.accessChannel)
@@ -572,7 +580,8 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	}
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	docIdFlagMap := make(map[string]uint8)
 	var startSeq, endSeq uint64

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -30,8 +30,7 @@ func TestQueryChannelsStatsView(t *testing.T) {
 		t.Skip("This test is view only, but GSI is enabled")
 	}
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	// docID -> Sequence
@@ -85,8 +84,7 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 		t.Skip("This test is Couchbase Server only")
 	}
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	// docID -> Sequence
@@ -134,8 +132,7 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 // Validate query and stats for sequence view query
 func TestQuerySequencesStatsView(t *testing.T) {
 
-	db := setupTestDBWithViewsEnabled(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDBWithViewsEnabled(t)
 	defer db.Close(ctx)
 
 	// docID -> Sequence
@@ -230,8 +227,7 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	// docID -> Sequence
@@ -324,8 +320,7 @@ func TestCoveringQueries(t *testing.T) {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	n1QLStore, ok := base.AsN1QLStore(db.Bucket)
@@ -379,8 +374,7 @@ func TestAllDocsQuery(t *testing.T) {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	// Add docs with channel assignment
@@ -446,8 +440,7 @@ func TestAccessQuery(t *testing.T) {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {
@@ -492,8 +485,7 @@ func TestRoleAccessQuery(t *testing.T) {
 		t.Skip("This test is Couchbase Server only")
 	}
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {
@@ -579,8 +571,7 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	docIdFlagMap := make(map[string]uint8)

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -179,7 +179,8 @@ func TestBackingStore(t *testing.T) {
 func TestRevisionCacheInternalProperties(t *testing.T) {
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	// Invalid _revisions property will be stripped.  Should also not be present in the rev cache.
 	rev1body := Body{
@@ -227,7 +228,8 @@ func TestBypassRevisionCache(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	docBody := Body{
 		"value": 1234,
@@ -288,7 +290,8 @@ func TestPutRevisionCacheAttachmentProperty(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	rev1body := Body{
 		"value":         1234,
@@ -329,7 +332,8 @@ func TestPutExistingRevRevisionCacheAttachmentProperty(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	docKey := "doc1"
 	rev1body := Body{
@@ -440,7 +444,8 @@ func TestConcurrentLoad(t *testing.T) {
 
 func TestInvalidate(t *testing.T) {
 	db := setupTestDB(t)
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	rev1id, _, err := db.Put("doc", Body{"val": 123})
 	assert.NoError(t, err)

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -178,8 +178,7 @@ func TestBackingStore(t *testing.T) {
 // Ensure internal properties aren't being incorrectly stored in revision cache
 func TestRevisionCacheInternalProperties(t *testing.T) {
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	// Invalid _revisions property will be stripped.  Should also not be present in the rev cache.
@@ -227,8 +226,7 @@ func TestBypassRevisionCache(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	docBody := Body{
@@ -289,8 +287,7 @@ func TestPutRevisionCacheAttachmentProperty(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	rev1body := Body{
@@ -331,8 +328,7 @@ func TestPutExistingRevRevisionCacheAttachmentProperty(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	docKey := "doc1"
@@ -443,8 +439,7 @@ func TestConcurrentLoad(t *testing.T) {
 }
 
 func TestInvalidate(t *testing.T) {
-	db := setupTestDB(t)
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	rev1id, _, err := db.Put(ctx, "doc", Body{"val": 123})

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -106,7 +106,8 @@ func TestBackupOldRevision(t *testing.T) {
 		Enabled:          deltasEnabled,
 		RevMaxAgeSeconds: DefaultDeltaSyncRevMaxAge,
 	}})
-	defer db.Close()
+	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
+	defer db.Close(ctx)
 
 	docID := t.Name()
 

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -102,11 +102,10 @@ func TestBackupOldRevision(t *testing.T) {
 	deltasEnabled := base.IsEnterpriseEdition()
 	xattrsEnabled := base.TestUseXattrs()
 
-	db := setupTestDBWithOptions(t, DatabaseContextOptions{DeltaSyncOptions: DeltaSyncOptions{
+	db, ctx := setupTestDBWithOptions(t, DatabaseContextOptions{DeltaSyncOptions: DeltaSyncOptions{
 		Enabled:          deltasEnabled,
 		RevMaxAgeSeconds: DefaultDeltaSyncRevMaxAge,
 	}})
-	ctx := db.AddDatabaseLogContext(base.TestCtx(t))
 	defer db.Close(ctx)
 
 	docID := t.Name()

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -111,7 +111,7 @@ func TestBackupOldRevision(t *testing.T) {
 
 	docID := t.Name()
 
-	rev1ID, _, err := db.Put(docID, Body{"test": true})
+	rev1ID, _, err := db.Put(ctx, docID, Body{"test": true})
 	require.NoError(t, err)
 
 	// make sure we didn't accidentally store an empty old revision
@@ -130,7 +130,7 @@ func TestBackupOldRevision(t *testing.T) {
 
 	// create rev 2 and check backups for both revs
 	rev2ID := "2-abc"
-	_, _, err = db.PutExistingRevWithBody(docID, Body{"test": true, "updated": true}, []string{rev2ID, rev1ID}, true)
+	_, _, err = db.PutExistingRevWithBody(ctx, docID, Body{"test": true, "updated": true}, []string{rev2ID, rev1ID}, true)
 	require.NoError(t, err)
 
 	// now in all cases we'll have rev 1 backed up (for at least 5 minutes)

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -424,7 +424,7 @@ func (ar *ActiveReplicator) alignState(ctx context.Context, targetState string) 
 
 func (dbc *DatabaseContext) StartReplications(ctx context.Context) {
 	if dbc.Options.SGReplicateOptions.Enabled {
-		base.DebugfCtx(ctx, base.KeyReplicate, "Will start Inter-Sync Gateway Replications for database %q", dbc.Name)
+		base.DebugfCtx(dbc.SGReplicateMgr.loggingCtx, base.KeyReplicate, "Will start Inter-Sync Gateway Replications for database %q", dbc.Name)
 		dbc.SGReplicateMgr.closeWg.Add(1)
 		go func() {
 			defer dbc.SGReplicateMgr.closeWg.Done()
@@ -442,7 +442,7 @@ func (dbc *DatabaseContext) StartReplications(ctx context.Context) {
 				return
 			}
 
-			err := dbc.SGReplicateMgr.StartReplications(ctx) // TODO: use dbc.SGReplicateMgr.loggingCtx, if that is not removed ?
+			err := dbc.SGReplicateMgr.StartReplications(dbc.SGReplicateMgr.loggingCtx) // TODO: use dbc.SGReplicateMgr.loggingCtx, if that is not removed ?
 			if err != nil {
 				base.ErrorfCtx(dbc.SGReplicateMgr.loggingCtx, "Error starting %q Inter-Sync Gateway Replications: %v", dbc.Name, err)
 			}

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -362,7 +362,7 @@ func (rc *ReplicationConfig) Redacted() *ReplicationConfig {
 // sgReplicateManager should be used for all interactions with the stored cluster definition.
 type sgReplicateManager struct {
 	cfg                        cbgt.Cfg                      // Key-value store implementation
-	loggingCtx                 context.Context               // logging context for manager operations
+	loggingCtx                 context.Context               // logging context for manager operations	// TODO: eval removing or adding custom LogContext
 	heartbeatListener          *ReplicationHeartbeatListener // node heartbeat listener for replication distribution
 	localNodeUUID              string                        // nodeUUID for this SG node
 	activeReplicators          map[string]*ActiveReplicator  // currently assigned replications
@@ -381,7 +381,7 @@ type sgReplicateManager struct {
 //     stopped -> resetting
 //     resetting -> stopped
 //     running -> stopped
-func (ar *ActiveReplicator) alignState(targetState string) error {
+func (ar *ActiveReplicator) alignState(ctx context.Context, targetState string) error {
 	if ar == nil {
 		return nil
 	}
@@ -393,7 +393,7 @@ func (ar *ActiveReplicator) alignState(targetState string) error {
 
 	switch targetState {
 	case ReplicationStateStopped:
-		base.InfofCtx(context.TODO(), base.KeyReplicate, "Stopping replication %s - previous state %s", ar.ID, currentState)
+		base.InfofCtx(ctx, base.KeyReplicate, "Stopping replication %s - previous state %s", ar.ID, currentState)
 		stopErr := ar.Stop()
 		if stopErr != nil {
 			return fmt.Errorf("Unable to gracefully stop active replicator for replication %s: %v", ar.ID, stopErr)
@@ -403,8 +403,8 @@ func (ar *ActiveReplicator) alignState(targetState string) error {
 			// a replicator in a reconnecting state is already running
 			return nil
 		}
-		base.InfofCtx(context.TODO(), base.KeyReplicate, "Starting replication %s - previous state %s", ar.ID, currentState)
-		startErr := ar.Start()
+		base.InfofCtx(ctx, base.KeyReplicate, "Starting replication %s - previous state %s", ar.ID, currentState)
+		startErr := ar.Start(ctx)
 		if startErr != nil {
 			return fmt.Errorf("Unable to start active replicator for replication %s: %v", ar.ID, startErr)
 		}
@@ -412,7 +412,7 @@ func (ar *ActiveReplicator) alignState(targetState string) error {
 		if currentState != ReplicationStateStopped {
 			return fmt.Errorf("Replication must be stopped before it can be reset")
 		}
-		base.InfofCtx(context.TODO(), base.KeyReplicate, "Resetting replication %s - previous state %s", ar.ID, currentState)
+		base.InfofCtx(ctx, base.KeyReplicate, "Resetting replication %s - previous state %s", ar.ID, currentState)
 		resetErr := ar.Reset()
 		if resetErr != nil {
 			return fmt.Errorf("Unable to reset active replicator for replication %s: %v", ar.ID, resetErr)
@@ -422,9 +422,9 @@ func (ar *ActiveReplicator) alignState(targetState string) error {
 
 }
 
-func (dbc *DatabaseContext) StartReplications() {
+func (dbc *DatabaseContext) StartReplications(ctx context.Context) {
 	if dbc.Options.SGReplicateOptions.Enabled {
-		base.DebugfCtx(dbc.SGReplicateMgr.loggingCtx, base.KeyReplicate, "Will start Inter-Sync Gateway Replications for database %q", dbc.Name)
+		base.DebugfCtx(ctx, base.KeyReplicate, "Will start Inter-Sync Gateway Replications for database %q", dbc.Name)
 		dbc.SGReplicateMgr.closeWg.Add(1)
 		go func() {
 			defer dbc.SGReplicateMgr.closeWg.Done()
@@ -442,24 +442,24 @@ func (dbc *DatabaseContext) StartReplications() {
 				return
 			}
 
-			err := dbc.SGReplicateMgr.StartReplications()
+			err := dbc.SGReplicateMgr.StartReplications(ctx) // TODO: use dbc.SGReplicateMgr.loggingCtx, if that is not removed ?
 			if err != nil {
 				base.ErrorfCtx(dbc.SGReplicateMgr.loggingCtx, "Error starting %q Inter-Sync Gateway Replications: %v", dbc.Name, err)
 			}
 		}()
 	} else {
-		base.DebugfCtx(context.TODO(), base.KeyReplicate, "Not starting Inter-Sync Gateway Replications for database %q - is disabled", dbc.Name)
+		base.DebugfCtx(ctx, base.KeyReplicate, "Not starting Inter-Sync Gateway Replications for database %q - is disabled", dbc.Name)
 	}
 }
 
-func NewSGReplicateManager(dbContext *DatabaseContext, cfg cbgt.Cfg) (*sgReplicateManager, error) {
+func NewSGReplicateManager(ctx context.Context, dbContext *DatabaseContext, cfg cbgt.Cfg) (*sgReplicateManager, error) {
 	if cfg == nil {
 		return nil, errors.New("Cfg must be provided for SGReplicateManager")
 	}
 
 	return &sgReplicateManager{
 		cfg:                        cfg,
-		loggingCtx:                 base.LogContextWith(context.Background(), &base.LogContext{CorrelationID: sgrClusterMgrContextID + dbContext.Name}),
+		loggingCtx:                 base.LogContextWith(ctx, &base.LogContext{CorrelationID: sgrClusterMgrContextID + dbContext.Name}),
 		clusterUpdateTerminator:    make(chan struct{}),
 		clusterSubscribeTerminator: make(chan struct{}),
 		dbContext:                  dbContext,
@@ -496,7 +496,7 @@ func (m *sgReplicateManager) StartLocalNode(nodeUUID string, heartbeater base.He
 
 // StartReplications performs an initial retrieval of the cluster config, starts any replications
 // assigned to this node, and starts the process to monitor future changes to the cluster config.
-func (m *sgReplicateManager) StartReplications() error {
+func (m *sgReplicateManager) StartReplications(ctx context.Context) error {
 
 	replications, err := m.GetReplications()
 	if err != nil {
@@ -514,13 +514,13 @@ func (m *sgReplicateManager) StartReplications() error {
 			m.activeReplicators[replicationID] = activeReplicator
 			m.activeReplicatorsLock.Unlock()
 			if replicationCfg.TargetState == "" || replicationCfg.TargetState == ReplicationStateRunning {
-				if startErr := activeReplicator.Start(); startErr != nil {
+				if startErr := activeReplicator.Start(ctx); startErr != nil {
 					base.WarnfCtx(m.loggingCtx, "Unable to start replication %s: %v", replicationID, startErr)
 				}
 			}
 		}
 	}
-	return m.SubscribeCfgChanges()
+	return m.SubscribeCfgChanges(ctx)
 }
 
 // NewActiveReplicatorConfig converts an incoming ReplicationCfg to an ActiveReplicatorConfig
@@ -664,7 +664,7 @@ func (m *sgReplicateManager) InitializeReplication(config *ReplicationCfg) (repl
 	// disable recovered panic reporting (test only)
 	rc.reportHandlerPanicsOnStop = base.BoolPtr(false)
 
-	replicator = NewActiveReplicator(rc)
+	replicator = NewActiveReplicator(m.loggingCtx, rc)
 
 	return replicator, nil
 }
@@ -706,7 +706,7 @@ func (m *sgReplicateManager) Stop() {
 
 // RefreshReplicationCfg is called when the cfg changes.  Checks whether replications
 // have been added to or removed from this node
-func (m *sgReplicateManager) RefreshReplicationCfg() error {
+func (m *sgReplicateManager) RefreshReplicationCfg(ctx context.Context) error {
 
 	base.InfofCtx(m.loggingCtx, base.KeyCluster, "Replication definitions changed - refreshing...")
 	configReplications, err := m.GetReplications()
@@ -752,7 +752,7 @@ func (m *sgReplicateManager) RefreshReplicationCfg() error {
 				}
 			}
 
-			stateErr := activeReplicator.alignState(replicationCfg.TargetState)
+			stateErr := activeReplicator.alignState(ctx, replicationCfg.TargetState)
 			if stateErr != nil {
 				base.WarnfCtx(m.loggingCtx, "Error updating active replication %s to state %s: %v", replicationID, replicationCfg.TargetState, stateErr)
 			}
@@ -782,7 +782,7 @@ func (m *sgReplicateManager) RefreshReplicationCfg() error {
 
 				if replicationCfg.TargetState == "" || replicationCfg.TargetState == ReplicationStateRunning {
 					base.InfofCtx(m.loggingCtx, base.KeyReplicate, "Starting newly assigned replication %s", replicationID)
-					if startErr := replicator.Start(); startErr != nil {
+					if startErr := replicator.Start(ctx); startErr != nil {
 						base.WarnfCtx(m.loggingCtx, "Unable to start replication after refresh %s: %v", replicationID, startErr)
 					}
 				}
@@ -792,7 +792,7 @@ func (m *sgReplicateManager) RefreshReplicationCfg() error {
 	return nil
 }
 
-func (m *sgReplicateManager) SubscribeCfgChanges() error {
+func (m *sgReplicateManager) SubscribeCfgChanges(ctx context.Context) error {
 	cfgEvents := make(chan cbgt.CfgEvent)
 
 	err := m.cfg.Subscribe(cfgKeySGRCluster, cfgEvents)
@@ -810,7 +810,7 @@ func (m *sgReplicateManager) SubscribeCfgChanges() error {
 				if !ok {
 					return
 				}
-				err := m.RefreshReplicationCfg()
+				err := m.RefreshReplicationCfg(ctx)
 				if err != nil {
 					base.WarnfCtx(m.loggingCtx, "Error while updating replications based on latest cfg: %v", err)
 				}

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -29,7 +29,8 @@ func TestReplicateManagerReplications(t *testing.T) {
 	testCfg, err := base.NewCfgSG(testBucket, "")
 	require.NoError(t, err)
 
-	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
+	ctx := base.TestCtx(t)
+	manager, err := NewSGReplicateManager(ctx, &DatabaseContext{Name: "test"}, testCfg)
 	require.NoError(t, err)
 	defer manager.Stop()
 
@@ -92,7 +93,8 @@ func TestReplicateManagerNodes(t *testing.T) {
 	testCfg, err := base.NewCfgSG(testBucket, "")
 	require.NoError(t, err)
 
-	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
+	ctx := base.TestCtx(t)
+	manager, err := NewSGReplicateManager(ctx, &DatabaseContext{Name: "test"}, testCfg)
 	require.NoError(t, err)
 	defer manager.Stop()
 
@@ -144,10 +146,11 @@ func TestReplicateManagerConcurrentNodeOperations(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
+	ctx := base.TestCtx(t)
 	testCfg, err := base.NewCfgSG(testBucket, "")
 	require.NoError(t, err)
 
-	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
+	manager, err := NewSGReplicateManager(ctx, &DatabaseContext{Name: "test"}, testCfg)
 	require.NoError(t, err)
 	defer manager.Stop()
 
@@ -188,10 +191,11 @@ func TestReplicateManagerConcurrentReplicationOperations(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
+	ctx := base.TestCtx(t)
 	testCfg, err := base.NewCfgSG(testBucket, "")
 	require.NoError(t, err)
 
-	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
+	manager, err := NewSGReplicateManager(ctx, &DatabaseContext{Name: "test"}, testCfg)
 	require.NoError(t, err)
 	defer manager.Stop()
 
@@ -618,7 +622,7 @@ func TestIsCfgChanged(t *testing.T) {
 	testCfg, err := base.NewCfgSG(testBucket, "")
 	require.NoError(t, err)
 
-	mgr, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
+	mgr, err := NewSGReplicateManager(base.TestCtx(t), &DatabaseContext{Name: "test"}, testCfg)
 	require.NoError(t, err)
 	defer mgr.Stop()
 

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -643,19 +643,20 @@ func TestReplicateGroupIDAssignedNodes(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
+	ctx := base.TestCtx(t)
 
 	// Set up databases
-	dbDefault, err := NewDatabaseContext("default", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: ""})
+	dbDefault, err := NewDatabaseContext(ctx, "default", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: ""})
 	require.NoError(t, err)
-	defer dbDefault.Close()
+	defer dbDefault.Close(ctx)
 
-	dbGroupA, err := NewDatabaseContext("groupa", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupA"})
+	dbGroupA, err := NewDatabaseContext(ctx, "groupa", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupA"})
 	require.NoError(t, err)
-	defer dbGroupA.Close()
+	defer dbGroupA.Close(ctx)
 
-	dbGroupB, err := NewDatabaseContext("groupb", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupB"})
+	dbGroupB, err := NewDatabaseContext(ctx, "groupb", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupB"})
 	require.NoError(t, err)
-	defer dbGroupB.Close()
+	defer dbGroupB.Close(ctx)
 
 	// Set up replicators
 	err = dbDefault.SGReplicateMgr.RegisterNode("nodeDefault")

--- a/db/user_query_n1ql_test.go
+++ b/db/user_query_n1ql_test.go
@@ -84,12 +84,13 @@ func TestUserN1QLQueries(t *testing.T) {
 	}
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	ctx := base.TestCtx(t)
 	cacheOptions := DefaultCacheOptions()
 	db := setupTestDBWithOptions(t, DatabaseContextOptions{
 		CacheOptions: &cacheOptions,
 		UserQueries:  kUserQueriesConfig,
 	})
-	defer db.Close()
+	defer db.Close(ctx)
 
 	// First run the tests as an admin:
 	t.Run("AsAdmin", func(t *testing.T) { testUserQueriesAsAdmin(t, db) })
@@ -103,66 +104,70 @@ func TestUserN1QLQueries(t *testing.T) {
 }
 
 func testUserQueriesCommon(t *testing.T, db *Database) {
+	ctx := base.TestCtx(t)
+
 	// dynamic channel list
-	iter, err := db.UserN1QLQuery("airports_in_city", map[string]interface{}{"city": "London"})
+	iter, err := db.UserN1QLQuery(ctx, "airports_in_city", map[string]interface{}{"city": "London"})
 	assert.NoError(t, err)
 	assertQueryResults(t, `[{"city":"London"}]`, iter)
 
-	iter, err = db.UserN1QLQuery("square", map[string]interface{}{"numero": 16})
+	iter, err = db.UserN1QLQuery(ctx, "square", map[string]interface{}{"numero": 16})
 	assert.NoError(t, err)
 	assertQueryResults(t, `[{"square":256}]`, iter)
 
-	iter, err = db.UserN1QLQuery("inject", map[string]interface{}{"foo": "1337 as pwned"})
+	iter, err = db.UserN1QLQuery(ctx, "inject", map[string]interface{}{"foo": "1337 as pwned"})
 	assert.NoError(t, err)
 	assertQueryResults(t, `[{"$1":"1337 as pwned"}]`, iter)
 
 	// ERRORS:
 
 	// Missing a parameter:
-	_, err = db.UserN1QLQuery("square", nil)
+	_, err = db.UserN1QLQuery(ctx, "square", nil)
 	assertHTTPError(t, err, 400)
 	assert.ErrorContains(t, err, "numero")
 	assert.ErrorContains(t, err, "square")
 
 	// Extra parameter:
-	_, err = db.UserN1QLQuery("square", map[string]interface{}{"numero": 42, "number": 0})
+	_, err = db.UserN1QLQuery(ctx, "square", map[string]interface{}{"numero": 42, "number": 0})
 	assertHTTPError(t, err, 400)
 	assert.ErrorContains(t, err, "number")
 	assert.ErrorContains(t, err, "square")
 
 	// Function definition has a syntax error:
-	_, err = db.UserN1QLQuery("syntax_error", nil)
+	_, err = db.UserN1QLQuery(ctx, "syntax_error", nil)
 	assertHTTPError(t, err, 500)
 	assert.ErrorContains(t, err, "syntax_error")
 }
 
 func testUserQueriesAsAdmin(t *testing.T, db *Database) {
 	testUserQueriesCommon(t, db)
+	ctx := base.TestCtx(t)
 
-	iter, err := db.UserN1QLQuery("user", nil)
+	iter, err := db.UserN1QLQuery(ctx, "user", nil)
 	assert.NoError(t, err)
 	assertQueryResults(t, `[{"user":{}}]`, iter)
 
-	iter, err = db.UserN1QLQuery("user_parts", nil)
+	iter, err = db.UserN1QLQuery(ctx, "user_parts", nil)
 	assert.NoError(t, err)
 	assertQueryResults(t, `[{}]`, iter)
 
 	// admin only:
-	iter, err = db.UserN1QLQuery("admin_only", nil)
+	iter, err = db.UserN1QLQuery(ctx, "admin_only", nil)
 	assert.NoError(t, err)
 	assertQueryResults(t, `[{"status":"ok"}]`, iter)
 
 	// ERRORS:
 
 	// No such query:
-	_, err = db.UserN1QLQuery("xxxx", nil)
+	_, err = db.UserN1QLQuery(ctx, "xxxx", nil)
 	assertHTTPError(t, err, 404)
 }
 
 func testUserQueriesAsUser(t *testing.T, db *Database) {
 	testUserQueriesCommon(t, db)
+	ctx := base.TestCtx(t)
 
-	iter, err := db.UserN1QLQuery("user", nil)
+	iter, err := db.UserN1QLQuery(ctx, "user", nil)
 	assert.NoError(t, err)
 	// (Can't compare the entire result string because the order of items in the "channels" array
 	// is undefined and can change from one run to another.)
@@ -170,21 +175,21 @@ func testUserQueriesAsUser(t *testing.T, db *Database) {
 	assert.True(t, strings.HasPrefix(resultStr, `[{"user":{"channels":["`))
 	assert.True(t, strings.HasSuffix(resultStr, `"],"email":"","name":"alice","roles":["hero"]}}]`))
 
-	iter, err = db.UserN1QLQuery("user_parts", nil)
+	iter, err = db.UserN1QLQuery(ctx, "user_parts", nil)
 	assert.NoError(t, err)
 	assertQueryResults(t, `[{"email":"","name":"alice"}]`, iter)
 
 	// ERRORS:
 
 	// Not allowed (admin only):
-	_, err = db.UserN1QLQuery("admin_only", nil)
+	_, err = db.UserN1QLQuery(ctx, "admin_only", nil)
 	assertHTTPError(t, err, 403)
 
 	// Not allowed (dynamic channel list):
-	_, err = db.UserN1QLQuery("airports_in_city", map[string]interface{}{"city": "Chicago"})
+	_, err = db.UserN1QLQuery(ctx, "airports_in_city", map[string]interface{}{"city": "Chicago"})
 	assertHTTPError(t, err, 403)
 
 	// No such query:
-	_, err = db.UserN1QLQuery("xxxx", nil)
+	_, err = db.UserN1QLQuery(ctx, "xxxx", nil)
 	assertHTTPError(t, err, 403) // not 404 as for an admin
 }

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -111,7 +111,7 @@ func (h *handler) handleCreateDB() error {
 		cas, err := h.server.bootstrapContext.connection.InsertConfig(bucket, h.server.config.Bootstrap.ConfigGroupID, persistedConfig)
 		if err != nil {
 			// unload the requested database config to prevent the cluster being in an inconsistent state
-			h.server._removeDatabase(dbName)
+			h.server._removeDatabase(h.ctx(), dbName)
 			if errors.Is(err, base.ErrAuthError) {
 				return base.HTTPErrorf(http.StatusForbidden, "auth failure accessing provided bucket using bootstrap credentials: %s", bucket)
 			} else if errors.Is(err, base.ErrAlreadyExists) {
@@ -221,7 +221,7 @@ func (h *handler) handleGetDbConfig() error {
 	// - Returning if include_runtime=false
 	var responseConfig *DbConfig
 	if h.server.bootstrapContext.connection != nil {
-		found, dbConfig, err := h.server.fetchDatabase(h.db.Name)
+		found, dbConfig, err := h.server.fetchDatabase(h.ctx(), h.db.Name)
 		if err != nil {
 			return err
 		}
@@ -608,7 +608,7 @@ func (h *handler) handleGetDbConfigSync() error {
 	)
 
 	if h.server.bootstrapContext.connection != nil {
-		found, dbConfig, err := h.server.fetchDatabase(h.db.Name)
+		found, dbConfig, err := h.server.fetchDatabase(h.ctx(), h.db.Name)
 		if err != nil {
 			return err
 		}
@@ -762,7 +762,7 @@ func (h *handler) handleGetDbConfigImportFilter() error {
 	)
 
 	if h.server.bootstrapContext.connection != nil {
-		found, dbConfig, err := h.server.fetchDatabase(h.db.Name)
+		found, dbConfig, err := h.server.fetchDatabase(h.ctx(), h.db.Name)
 		if err != nil {
 			return err
 		}
@@ -921,7 +921,7 @@ func (h *handler) handleDeleteDB() error {
 		}
 	}
 
-	if !h.server.RemoveDatabase(h.db.Name) {
+	if !h.server.RemoveDatabase(h.ctx(), h.db.Name) {
 		return base.HTTPErrorf(http.StatusNotFound, "missing")
 	}
 	_, _ = h.response.Write([]byte("{}"))

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -202,7 +202,7 @@ func (h *handler) handleDbOnline() error {
 func (h *handler) handleDbOffline() error {
 	h.assertAdminOnly()
 	var err error
-	if err = h.db.TakeDbOffline("ADMIN Request"); err != nil {
+	if err = h.db.TakeDbOffline(h.ctx(), "ADMIN Request"); err != nil {
 		base.InfofCtx(h.ctx(), base.KeyCRUD, "Unable to take Database : %v, offline", base.MD(h.db.Name))
 	}
 
@@ -1064,7 +1064,7 @@ func (h *handler) handleGetStatus() error {
 		status.Databases[database.Name] = DatabaseStatus{
 			SequenceNumber:    lastSeq,
 			State:             runState,
-			ServerUUID:        database.GetServerUUID(),
+			ServerUUID:        database.GetServerUUID(h.ctx()),
 			ReplicationStatus: replicationsStatus,
 			SGRCluster:        cluster,
 		}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -202,7 +202,7 @@ func (h *handler) handleDbOnline() error {
 func (h *handler) handleDbOffline() error {
 	h.assertAdminOnly()
 	var err error
-	if err = h.db.TakeDbOffline("ADMIN Request"); err != nil {
+	if err = h.db.TakeDbOffline(h.ctx(), "ADMIN Request"); err != nil {
 		base.InfofCtx(h.ctx(), base.KeyCRUD, "Unable to take Database : %v, offline", base.MD(h.db.Name))
 	}
 

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -202,7 +202,6 @@ func TestCheckPermissionsWithX509(t *testing.T) {
 			CACertPath:   caCertPath,
 		},
 	}, false)
-	ctx = svrctx.AddServerLogContext(ctx)
 	defer svrctx.Close(ctx)
 
 	goCBAgent, err := svrctx.initializeGoCBAgent(ctx)
@@ -497,7 +496,6 @@ func TestAdminAuthWithX509(t *testing.T) {
 			CACertPath:   caCertPath,
 		},
 	}, false)
-	ctx = svrctx.AddServerLogContext(ctx)
 	defer svrctx.Close(ctx)
 
 	goCBAgent, err := svrctx.initializeGoCBAgent(ctx)

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -452,8 +452,9 @@ func TestAdminAuth(t *testing.T) {
 		var httpClient *http.Client
 		var err error
 
+		ctx := rt.Context()
 		if testCase.BucketName != "" {
-			managementEndpoints, httpClient, err = rt.GetDatabase().ObtainManagementEndpointsAndHTTPClient()
+			managementEndpoints, httpClient, err = rt.GetDatabase().ObtainManagementEndpointsAndHTTPClient(ctx)
 		} else {
 			managementEndpoints, httpClient, err = rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
 		}

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -193,7 +193,8 @@ func TestCheckPermissionsWithX509(t *testing.T) {
 	tb, caCertPath, certPath, keyPath := setupX509Tests(t, true)
 	defer tb.Close()
 
-	svrctx := NewServerContext(&StartupConfig{
+	ctx := base.TestCtx(t)
+	svrctx := NewServerContext(ctx, &StartupConfig{
 		Bootstrap: BootstrapConfig{
 			Server:       serverURL,
 			X509CertPath: certPath,
@@ -201,10 +202,10 @@ func TestCheckPermissionsWithX509(t *testing.T) {
 			CACertPath:   caCertPath,
 		},
 	}, false)
-	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: svrctx.config.Bootstrap.ConfigGroupID})
 	defer svrctx.Close(ctx)
 
-	goCBAgent, err := svrctx.initializeGoCBAgent()
+	ctx = svrctx.AddServerLogContext(ctx)
+	goCBAgent, err := svrctx.initializeGoCBAgent(ctx)
 	require.NoError(t, err)
 	svrctx.GoCBAgent = goCBAgent
 
@@ -486,7 +487,8 @@ func TestAdminAuthWithX509(t *testing.T) {
 	tb, caCertPath, certPath, keyPath := setupX509Tests(t, true)
 	defer tb.Close()
 
-	svrctx := NewServerContext(&StartupConfig{
+	ctx := base.TestCtx(t)
+	svrctx := NewServerContext(ctx, &StartupConfig{
 		Bootstrap: BootstrapConfig{
 			Server:       serverURL,
 			X509CertPath: certPath,
@@ -494,10 +496,10 @@ func TestAdminAuthWithX509(t *testing.T) {
 			CACertPath:   caCertPath,
 		},
 	}, false)
-	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: svrctx.config.Bootstrap.ConfigGroupID})
 	defer svrctx.Close(ctx)
 
-	goCBAgent, err := svrctx.initializeGoCBAgent()
+	ctx = svrctx.AddServerLogContext(ctx)
+	goCBAgent, err := svrctx.initializeGoCBAgent(ctx)
 	require.NoError(t, err)
 	svrctx.GoCBAgent = goCBAgent
 

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -193,7 +193,7 @@ func TestCheckPermissionsWithX509(t *testing.T) {
 	tb, caCertPath, certPath, keyPath := setupX509Tests(t, true)
 	defer tb.Close()
 
-	ctx := NewServerContext(&StartupConfig{
+	svrctx := NewServerContext(&StartupConfig{
 		Bootstrap: BootstrapConfig{
 			Server:       serverURL,
 			X509CertPath: certPath,
@@ -201,17 +201,18 @@ func TestCheckPermissionsWithX509(t *testing.T) {
 			CACertPath:   caCertPath,
 		},
 	}, false)
-	defer ctx.Close()
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: svrctx.config.Bootstrap.ConfigGroupID})
+	defer svrctx.Close(ctx)
 
-	goCBAgent, err := ctx.initializeGoCBAgent()
+	goCBAgent, err := svrctx.initializeGoCBAgent()
 	require.NoError(t, err)
-	ctx.GoCBAgent = goCBAgent
+	svrctx.GoCBAgent = goCBAgent
 
-	noX509HttpClient, err := ctx.initializeNoX509HttpClient()
+	noX509HttpClient, err := svrctx.initializeNoX509HttpClient()
 	require.NoError(t, err)
-	ctx.NoX509HTTPClient = noX509HttpClient
+	svrctx.NoX509HTTPClient = noX509HttpClient
 
-	eps, httpClient, err := ctx.ObtainManagementEndpointsAndHTTPClient()
+	eps, httpClient, err := svrctx.ObtainManagementEndpointsAndHTTPClient()
 	assert.NoError(t, err)
 
 	statusCode, _, err := CheckPermissions(httpClient, eps, "", base.TestClusterUsername(), base.TestClusterPassword(), []Permission{Permission{"!admin", false}}, nil)
@@ -485,7 +486,7 @@ func TestAdminAuthWithX509(t *testing.T) {
 	tb, caCertPath, certPath, keyPath := setupX509Tests(t, true)
 	defer tb.Close()
 
-	ctx := NewServerContext(&StartupConfig{
+	svrctx := NewServerContext(&StartupConfig{
 		Bootstrap: BootstrapConfig{
 			Server:       serverURL,
 			X509CertPath: certPath,
@@ -493,17 +494,18 @@ func TestAdminAuthWithX509(t *testing.T) {
 			CACertPath:   caCertPath,
 		},
 	}, false)
-	defer ctx.Close()
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: svrctx.config.Bootstrap.ConfigGroupID})
+	defer svrctx.Close(ctx)
 
-	goCBAgent, err := ctx.initializeGoCBAgent()
+	goCBAgent, err := svrctx.initializeGoCBAgent()
 	require.NoError(t, err)
-	ctx.GoCBAgent = goCBAgent
+	svrctx.GoCBAgent = goCBAgent
 
-	noX509HttpClient, err := ctx.initializeNoX509HttpClient()
+	noX509HttpClient, err := svrctx.initializeNoX509HttpClient()
 	require.NoError(t, err)
-	ctx.NoX509HTTPClient = noX509HttpClient
+	svrctx.NoX509HTTPClient = noX509HttpClient
 
-	managementEndpoints, httpClient, err := ctx.ObtainManagementEndpointsAndHTTPClient()
+	managementEndpoints, httpClient, err := svrctx.ObtainManagementEndpointsAndHTTPClient()
 	require.NoError(t, err)
 
 	var statusCode int

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -202,9 +202,9 @@ func TestCheckPermissionsWithX509(t *testing.T) {
 			CACertPath:   caCertPath,
 		},
 	}, false)
+	ctx = svrctx.AddServerLogContext(ctx)
 	defer svrctx.Close(ctx)
 
-	ctx = svrctx.AddServerLogContext(ctx)
 	goCBAgent, err := svrctx.initializeGoCBAgent(ctx)
 	require.NoError(t, err)
 	svrctx.GoCBAgent = goCBAgent
@@ -496,9 +496,9 @@ func TestAdminAuthWithX509(t *testing.T) {
 			CACertPath:   caCertPath,
 		},
 	}, false)
+	ctx = svrctx.AddServerLogContext(ctx)
 	defer svrctx.Close(ctx)
 
-	ctx = svrctx.AddServerLogContext(ctx)
 	goCBAgent, err := svrctx.initializeGoCBAgent(ctx)
 	require.NoError(t, err)
 	svrctx.GoCBAgent = goCBAgent

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3929,12 +3929,13 @@ func TestDbConfigPersistentSGVersions(t *testing.T) {
 	// enable the background update worker for this test only
 	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(time.Millisecond * 250)
 
-	sc, err := setupServerContext(&config, true)
+	ctx := base.TestCtx(t)
+	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
+	ctx = sc.AddServerLogContext(ctx)
 
 	go func() {
-		serverErr <- startServer(&config, sc)
+		serverErr <- startServer(ctx, &config, sc)
 	}()
 	require.NoError(t, sc.waitForRESTAPIs())
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -4034,6 +4034,7 @@ func TestDbConfigPersistentSGVersions(t *testing.T) {
 	// Start a new SG node and ensure we *can* load the "newer" config version on initial startup, to support downgrade
 	sc, err = setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
+	ctx = sc.AddServerLogContext(ctx)
 	defer func() {
 		sc.Close(ctx)
 		require.NoError(t, <-serverErr)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -4558,7 +4558,8 @@ function (doc) {
 			resp = activeRT.SendAdminRequest("PUT", "/db/_replication/"+replName, replConf)
 			requireStatus(t, resp, http.StatusCreated)
 
-			err = activeRT.GetDatabase().SGReplicateMgr.StartReplications()
+			activeCtx := activeRT.Context()
+			err = activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeCtx)
 			require.NoError(t, err)
 			activeRT.waitForReplicationStatus(replName, db.ReplicationStateRunning)
 
@@ -4632,8 +4633,9 @@ func TestReplicatorDeprecatedCredentials(t *testing.T) {
 
 	activeRT := NewRestTester(t, nil)
 	defer activeRT.Close()
+	activeCtx := activeRT.Context()
 
-	err := activeRT.GetDatabase().SGReplicateMgr.StartReplications()
+	err := activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeCtx)
 	require.NoError(t, err)
 
 	rev := activeRT.createDoc(t, "test")
@@ -4686,13 +4688,13 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 
 	activeRT := NewRestTester(t, nil)
 	defer activeRT.Close()
+	activeCtx := activeRT.Context()
 
 	// Disable checkpointing at an interval
 	activeRT.GetDatabase().SGReplicateMgr.CheckpointInterval = 0
-	err := activeRT.GetDatabase().SGReplicateMgr.StartReplications()
+	err := activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeCtx)
 	require.NoError(t, err)
 
-	activeCtx := activeRT.Context()
 	database, err := db.CreateDatabase(activeRT.GetDatabase())
 	require.NoError(t, err)
 	rev, doc, err := database.Put(activeCtx, "test", db.Body{})

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -5025,7 +5025,8 @@ func TestTombstoneCompactionPurgeInterval(t *testing.T) {
 			setServerPurgeInterval(t, rt, test.newServerInterval)
 
 			// Start compact to modify purge interval
-			database, _ := db.GetDatabase(dbc, nil)
+			ctx := rt.Context()
+			database, _ := db.GetDatabase(ctx, dbc, nil)
 			_, err = database.Compact(false, func(purgedDocCount *int) {}, base.NewSafeTerminator())
 			require.NoError(t, err)
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -4705,7 +4705,7 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 	err := activeRT.GetDatabase().SGReplicateMgr.StartReplications()
 	require.NoError(t, err)
 
-	database, err := db.CreateDatabase(activeRT.GetDatabase())
+	database, err := db.CreateDatabase(activeRT.Context(), activeRT.GetDatabase())
 	require.NoError(t, err)
 	rev, doc, err := database.Put("test", db.Body{})
 	require.NoError(t, err)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3307,8 +3307,9 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
@@ -3367,8 +3368,9 @@ func TestDbConfigCredentials(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
@@ -3431,8 +3433,9 @@ func TestInvalidDBConfig(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
@@ -3484,8 +3487,9 @@ func TestCreateDbOnNonExistentBucket(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
@@ -3516,8 +3520,9 @@ func TestPutDbConfigChangeName(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
@@ -3557,8 +3562,9 @@ func TestPutDBConfigOIDC(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
@@ -3673,8 +3679,9 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
@@ -3758,8 +3765,9 @@ func TestLegacyCredentialInheritance(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, false)
 	require.NoError(t, err)
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
@@ -3845,8 +3853,9 @@ func TestDbOfflineConfigPersistent(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
@@ -3922,6 +3931,7 @@ func TestDbConfigPersistentSGVersions(t *testing.T) {
 
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 
 	go func() {
 		serverErr <- startServer(&config, sc)
@@ -4003,14 +4013,14 @@ func TestDbConfigPersistentSGVersions(t *testing.T) {
 	assertRevsLimit(sc, 789)
 
 	// Shut down the first SG node
-	sc.Close()
+	sc.Close(ctx)
 	require.NoError(t, <-serverErr)
 
 	// Start a new SG node and ensure we *can* load the "newer" config version on initial startup, to support downgrade
 	sc, err = setupServerContext(&config, true)
 	require.NoError(t, err)
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
@@ -4037,13 +4047,14 @@ func TestDeleteFunctionsWhileDbOffline(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 	serverErr := make(chan error, 0)
 	go func() {
 		serverErr <- startServer(&config, sc)
 	}()
 	require.NoError(t, sc.waitForRESTAPIs())
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
@@ -4122,13 +4133,14 @@ func TestSetFunctionsWhileDbOffline(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 	serverErr := make(chan error, 0)
 	go func() {
 		serverErr <- startServer(&config, sc)
 	}()
 	require.NoError(t, sc.waitForRESTAPIs())
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
@@ -4187,8 +4199,9 @@ func TestEmptyStringJavascriptFunctions(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
@@ -4294,8 +4307,9 @@ func TestGroupIDReplications(t *testing.T) {
 		sc, err := setupServerContext(&config, true)
 		require.NoError(t, err)
 		serverContexts = append(serverContexts, sc)
+		ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 		defer func() {
-			sc.Close()
+			sc.Close(ctx)
 			require.NoError(t, <-serverErr)
 		}()
 		go func() {
@@ -4389,9 +4403,10 @@ func TestDeleteDatabasePointingAtSameBucketPersistent(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 	serverErr := make(chan error, 0)
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 	go func() {

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3313,7 +3313,6 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 	ctx := base.TestCtx(t)
 	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
 	defer func() {
 		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
@@ -3375,7 +3374,6 @@ func TestDbConfigCredentials(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
 	defer func() {
 		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
@@ -3441,7 +3439,6 @@ func TestInvalidDBConfig(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
 	defer func() {
 		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
@@ -3496,7 +3493,6 @@ func TestCreateDbOnNonExistentBucket(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
 	defer func() {
 		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
@@ -3530,7 +3526,6 @@ func TestPutDbConfigChangeName(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
 	defer func() {
 		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
@@ -3573,7 +3568,6 @@ func TestPutDBConfigOIDC(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
 	defer func() {
 		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
@@ -3691,7 +3685,6 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
 	defer func() {
 		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
@@ -3778,7 +3771,6 @@ func TestLegacyCredentialInheritance(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(ctx, &config, false)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
 	defer func() {
 		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
@@ -3867,7 +3859,6 @@ func TestDbOfflineConfigPersistent(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
 	defer func() {
 		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
@@ -3946,7 +3937,7 @@ func TestDbConfigPersistentSGVersions(t *testing.T) {
 	ctx := base.TestCtx(t)
 	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
+	ctx = sc.SetContextLogID(ctx, "initial")
 
 	go func() {
 		serverErr <- startServer(ctx, &config, sc)
@@ -4034,7 +4025,7 @@ func TestDbConfigPersistentSGVersions(t *testing.T) {
 	// Start a new SG node and ensure we *can* load the "newer" config version on initial startup, to support downgrade
 	sc, err = setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
+	ctx = sc.SetContextLogID(ctx, "newerconfig")
 	defer func() {
 		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
@@ -4064,7 +4055,6 @@ func TestDeleteFunctionsWhileDbOffline(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
 	serverErr := make(chan error, 0)
 	go func() {
 		serverErr <- startServer(ctx, &config, sc)
@@ -4151,7 +4141,6 @@ func TestSetFunctionsWhileDbOffline(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
 	serverErr := make(chan error, 0)
 	go func() {
 		serverErr <- startServer(ctx, &config, sc)
@@ -4218,7 +4207,6 @@ func TestEmptyStringJavascriptFunctions(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
 	defer func() {
 		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
@@ -4327,7 +4315,7 @@ func TestGroupIDReplications(t *testing.T) {
 		sc, err := setupServerContext(ctx, &config, true)
 		require.NoError(t, err)
 		serverContexts = append(serverContexts, sc)
-		ctx = sc.AddServerLogContext(ctx)
+		ctx = sc.SetContextLogID(ctx, config.Bootstrap.ConfigGroupID)
 		defer func() {
 			sc.Close(ctx)
 			require.NoError(t, <-serverErr)
@@ -4385,7 +4373,7 @@ func TestGroupIDReplications(t *testing.T) {
 				expectedPushed = 1
 			}
 
-			ctx := sc.AddServerLogContext(base.TestCtx(t))
+			ctx := sc.SetContextLogID(base.TestCtx(t), sc.config.Bootstrap.ConfigGroupID)
 			dbContext, err := sc.GetDatabase(ctx, "db")
 			require.NoError(t, err)
 			actualPushed, _ := base.WaitForStat(dbContext.DbStats.DBReplicatorStats("repl").NumDocPushed.Value, expectedPushed)
@@ -4425,7 +4413,6 @@ func TestDeleteDatabasePointingAtSameBucketPersistent(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
 	serverErr := make(chan error, 0)
 	defer func() {
 		sc.Close(ctx)

--- a/rest/api.go
+++ b/rest/api.go
@@ -120,7 +120,7 @@ func (h *handler) handleCompact() error {
 	if compactionType == "tombstone" {
 		if action == string(db.BackgroundProcessActionStart) {
 			if atomic.CompareAndSwapUint32(&h.db.CompactState, db.DBCompactNotRunning, db.DBCompactRunning) {
-				err := h.db.TombstoneCompactionManager.Start(map[string]interface{}{
+				err := h.db.TombstoneCompactionManager.Start(h.ctx(), map[string]interface{}{
 					"database": h.db,
 				})
 				if err != nil {
@@ -156,7 +156,7 @@ func (h *handler) handleCompact() error {
 
 	if compactionType == "attachment" {
 		if action == string(db.BackgroundProcessActionStart) {
-			err := h.db.AttachmentCompactionManager.Start(map[string]interface{}{
+			err := h.db.AttachmentCompactionManager.Start(h.ctx(), map[string]interface{}{
 				"database": h.db,
 				"reset":    h.getBoolQuery("reset"),
 				"dryRun":   h.getBoolQuery("dry_run"),
@@ -285,7 +285,7 @@ func (h *handler) handlePostResync() error {
 
 	if action == string(db.BackgroundProcessActionStart) {
 		if atomic.CompareAndSwapUint32(&h.db.State, db.DBOffline, db.DBResyncing) {
-			err := h.db.ResyncManager.Start(map[string]interface{}{
+			err := h.db.ResyncManager.Start(h.ctx(), map[string]interface{}{
 				"database":            h.db,
 				"regenerateSequences": regenerateSequences,
 			})

--- a/rest/api.go
+++ b/rest/api.go
@@ -206,10 +206,10 @@ func (h *handler) handleFlush() error {
 		config := h.server.GetDatabaseConfig(name)
 
 		// This needs to first call RemoveDatabase since flushing the bucket under Sync Gateway might cause issues.
-		h.server.RemoveDatabase(name)
+		h.server.RemoveDatabase(h.ctx(), name)
 
 		// Create a bucket connection spec from the database config
-		spec, err := GetBucketSpec(config, h.server.config)
+		spec, err := GetBucketSpec(h.ctx(), config, h.server.config)
 		if err != nil {
 			return err
 		}
@@ -244,7 +244,7 @@ func (h *handler) handleFlush() error {
 
 		name := h.db.Name
 		config := h.server.GetDatabaseConfig(name)
-		h.server.RemoveDatabase(name)
+		h.server.RemoveDatabase(h.ctx(), name)
 		err := bucket.CloseAndDelete()
 		_, err2 := h.server.AddDatabaseFromConfig(h.ctx(), *config)
 		if err == nil {
@@ -459,7 +459,7 @@ func (h *handler) handleProfiling() error {
 		if isCPUProfile {
 			base.InfofCtx(h.ctx(), base.KeyAll, "... ending CPU profile")
 			pprof.StopCPUProfile()
-			h.server.CloseCpuPprofFile()
+			h.server.CloseCpuPprofFile(h.ctx())
 			return nil
 		}
 		return base.HTTPErrorf(http.StatusBadRequest, "Missing JSON 'file' parameter")

--- a/rest/api.go
+++ b/rest/api.go
@@ -215,7 +215,7 @@ func (h *handler) handleFlush() error {
 		}
 
 		// Manually re-open a temporary bucket connection just for flushing purposes
-		tempBucketForFlush, err := db.GetConnectToBucketFn(false)(spec)
+		tempBucketForFlush, err := db.GetConnectToBucketFn(false)(h.ctx(), spec)
 		if err != nil {
 			return err
 		}
@@ -339,7 +339,7 @@ func (h *handler) handlePostUpgrade() error {
 
 	preview := h.getBoolQuery("preview")
 
-	postUpgradeResults, err := h.server.PostUpgrade(preview)
+	postUpgradeResults, err := h.server.PostUpgrade(h.ctx(), preview)
 	if err != nil {
 		return err
 	}
@@ -402,7 +402,7 @@ func (h *handler) handleGetDB() error {
 		PurgeSequenceNumber:           0, // TODO: Should track this value
 		DiskFormatVersion:             0, // Probably meaningless, but add for compatibility
 		State:                         runState,
-		ServerUUID:                    h.db.DatabaseContext.GetServerUUID(),
+		ServerUUID:                    h.db.DatabaseContext.GetServerUUID(h.ctx()),
 		// TODO: If running with multiple scope/collections
 		// Scopes: map[string]databaseRootScope{
 		// 	"scope1": {

--- a/rest/api.go
+++ b/rest/api.go
@@ -233,7 +233,7 @@ func (h *handler) handleFlush() error {
 		}
 
 		// Re-open database and add to Sync Gateway
-		_, err2 := h.server.AddDatabaseFromConfig(*config)
+		_, err2 := h.server.AddDatabaseFromConfig(h.ctx(), *config)
 		if err2 != nil {
 			return err2
 		}
@@ -246,7 +246,7 @@ func (h *handler) handleFlush() error {
 		config := h.server.GetDatabaseConfig(name)
 		h.server.RemoveDatabase(name)
 		err := bucket.CloseAndDelete()
-		_, err2 := h.server.AddDatabaseFromConfig(*config)
+		_, err2 := h.server.AddDatabaseFromConfig(h.ctx(), *config)
 		if err == nil {
 			err = err2
 		}
@@ -423,7 +423,7 @@ func (h *handler) handleGetDB() error {
 // fixes issue #562
 func (h *handler) handleCreateTarget() error {
 	dbname := h.PathVar("targetdb")
-	if _, err := h.server.GetDatabase(dbname); err != nil {
+	if _, err := h.server.GetDatabase(h.ctx(), dbname); err != nil {
 		return base.HTTPErrorf(http.StatusForbidden, "Creating a DB over the public API is unsupported")
 	} else {
 		return base.HTTPErrorf(http.StatusPreconditionFailed, "Database already exists")

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -308,7 +308,8 @@ func TestCollectionsChangeConfigScope(t *testing.T) {
 	base.TestRequiresCollections(t)
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
-	err := base.CreateBucketScopesAndCollections(base.TestCtx(t), tb.BucketSpec, map[string][]string{
+	ctx := base.TestCtx(t)
+	err := base.CreateBucketScopesAndCollections(ctx, tb.BucketSpec, map[string][]string{
 		"fooScope": {
 			"bar",
 		},
@@ -320,15 +321,15 @@ func TestCollectionsChangeConfigScope(t *testing.T) {
 
 	serverErr := make(chan error)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(&config, true)
+	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
 	go func() {
-		serverErr <- startServer(&config, sc)
+		serverErr <- startServer(ctx, &config, sc)
 	}()
 	require.NoError(t, sc.waitForRESTAPIs())
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2021,7 +2021,6 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 	ctx := base.TestCtx(t)
 	h := &handler{}
 	h.server = NewServerContext(ctx, &StartupConfig{}, false)
-	ctx = h.server.AddServerLogContext(ctx)
 	defer h.server.Close(ctx)
 
 	// Basic case, no heartbeat, no timeout
@@ -3681,7 +3680,6 @@ func TestEventConfigValidationSuccess(t *testing.T) {
 
 	ctx := base.TestCtx(t)
 	sc := NewServerContext(ctx, &StartupConfig{}, false)
-	ctx = sc.AddServerLogContext(ctx)
 	defer sc.Close(ctx)
 
 	// Valid config
@@ -4223,7 +4221,6 @@ func TestUnsupportedConfig(t *testing.T) {
 
 	ctx := base.TestCtx(t)
 	sc := NewServerContext(ctx, &StartupConfig{}, false)
-	ctx = sc.AddServerLogContext(ctx)
 	defer sc.Close(ctx)
 
 	testProviderOnlyJSON := `{"name": "test_provider_only",

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2021,8 +2021,8 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 	ctx := base.TestCtx(t)
 	h := &handler{}
 	h.server = NewServerContext(ctx, &StartupConfig{}, false)
-	defer h.server.Close(ctx)
 	ctx = h.server.AddServerLogContext(ctx)
+	defer h.server.Close(ctx)
 
 	// Basic case, no heartbeat, no timeout
 	optStr := `{"feed":"longpoll", "since": "123456:78", "limit":123, "style": "all_docs",
@@ -3681,6 +3681,7 @@ func TestEventConfigValidationSuccess(t *testing.T) {
 
 	ctx := base.TestCtx(t)
 	sc := NewServerContext(ctx, &StartupConfig{}, false)
+	ctx = sc.AddServerLogContext(ctx)
 	defer sc.Close(ctx)
 
 	// Valid config
@@ -3704,7 +3705,6 @@ func TestEventConfigValidationSuccess(t *testing.T) {
 	err := base.JSONUnmarshal([]byte(configJSON), &dbConfig)
 	assert.True(t, err == nil)
 
-	ctx = sc.AddServerLogContext(ctx)
 	_, err = sc.AddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig})
 	assert.True(t, err == nil)
 }
@@ -4223,8 +4223,8 @@ func TestUnsupportedConfig(t *testing.T) {
 
 	ctx := base.TestCtx(t)
 	sc := NewServerContext(ctx, &StartupConfig{}, false)
-	defer sc.Close(ctx)
 	ctx = sc.AddServerLogContext(ctx)
+	defer sc.Close(ctx)
 
 	testProviderOnlyJSON := `{"name": "test_provider_only",
         			"server": "walrus:",

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -7618,7 +7618,7 @@ func TestMetricsHandler(t *testing.T) {
 
 	// Create and remove a database
 	// This ensures that creation and removal of a DB is possible without a re-registration issue ( the below rest tester will re-register "db")
-	context, err := db.NewDatabaseContext("db", base.GetTestBucket(t), false, db.DatabaseContextOptions{})
+	context, err := db.NewDatabaseContext(base.TestCtx(t), "db", base.GetTestBucket(t), false, db.DatabaseContextOptions{})
 	require.NoError(t, err)
 	context.Close()
 
@@ -7643,7 +7643,7 @@ func TestMetricsHandler(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Initialize another database to ensure both are registered successfully
-	context, err = db.NewDatabaseContext("db2", base.GetTestBucket(t), false, db.DatabaseContextOptions{})
+	context, err = db.NewDatabaseContext(rt.Context(), "db2", base.GetTestBucket(t), false, db.DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close()
 
@@ -7787,7 +7787,7 @@ func TestUserHasDocAccessDocNotFound(t *testing.T) {
 	requireStatus(t, resp, http.StatusCreated)
 	revID := respRevID(t, resp)
 
-	database, err := db.CreateDatabase(rt.GetDatabase())
+	database, err := db.CreateDatabase(rt.Context(), rt.GetDatabase())
 	assert.NoError(t, err)
 
 	userHasDocAccess, err := db.UserHasDocAccess(database, "doc", revID)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2013,7 +2013,8 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 
 	h := &handler{}
 	h.server = NewServerContext(&StartupConfig{}, false)
-	defer h.server.Close()
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: h.server.config.Bootstrap.ConfigGroupID})
+	defer h.server.Close(ctx)
 
 	// Basic case, no heartbeat, no timeout
 	optStr := `{"feed":"longpoll", "since": "123456:78", "limit":123, "style": "all_docs",
@@ -3664,7 +3665,8 @@ func TestEventConfigValidationSuccess(t *testing.T) {
 	}
 
 	sc := NewServerContext(&StartupConfig{}, false)
-	defer sc.Close()
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
+	defer sc.Close(ctx)
 
 	// Valid config
 	configJSON := `{"name": "default",
@@ -4203,7 +4205,8 @@ func TestLongpollWithWildcard(t *testing.T) {
 func TestUnsupportedConfig(t *testing.T) {
 
 	sc := NewServerContext(&StartupConfig{}, false)
-	defer sc.Close()
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
+	defer sc.Close(ctx)
 	testProviderOnlyJSON := `{"name": "test_provider_only",
         			"server": "walrus:",
         			"bucket": "test_provider_only",

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2022,6 +2022,7 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 	h := &handler{}
 	h.server = NewServerContext(ctx, &StartupConfig{}, false)
 	defer h.server.Close(ctx)
+	ctx = h.server.AddServerLogContext(ctx)
 
 	// Basic case, no heartbeat, no timeout
 	optStr := `{"feed":"longpoll", "since": "123456:78", "limit":123, "style": "all_docs",

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -38,7 +38,8 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 	defer rt.Close()
 
 	// Create user:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -830,6 +830,7 @@ function(doc, oldDoc) {
 	rtConfig := RestTesterConfig{SyncFn: syncFunction}
 	var rt = NewRestTester(t, &rtConfig)
 	defer rt.Close()
+	ctx := rt.Context()
 
 	// Create bliptester that is connected as user1, with no access to channel ABC
 	bt, err := NewBlipTesterFromSpecWithRT(t, &BlipTesterSpec{
@@ -849,10 +850,10 @@ function(doc, oldDoc) {
 
 	// Set up a ChangeWaiter for this test, to block until the user change notification happens
 	dbc := rt.GetDatabase()
-	user1, err := dbc.Authenticator(base.TestCtx(t)).GetUser("user1")
+	user1, err := dbc.Authenticator(ctx).GetUser("user1")
 	require.NoError(t, err)
 
-	userDb, err := db.GetDatabase(dbc, user1)
+	userDb, err := db.GetDatabase(ctx, dbc, user1)
 	require.NoError(t, err)
 
 	userWaiter := userDb.NewUserWaiter()
@@ -1324,6 +1325,7 @@ func TestReloadUser(t *testing.T) {
 	rtConfig := RestTesterConfig{SyncFn: syncFn}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
+	ctx := rt.Context()
 	bt, err := NewBlipTesterFromSpecWithRT(t, &BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
@@ -1333,10 +1335,10 @@ func TestReloadUser(t *testing.T) {
 
 	// Set up a ChangeWaiter for this test, to block until the user change notification happens
 	dbc := rt.GetDatabase()
-	user1, err := dbc.Authenticator(base.TestCtx(t)).GetUser("user1")
+	user1, err := dbc.Authenticator(ctx).GetUser("user1")
 	require.NoError(t, err)
 
-	userDb, err := db.GetDatabase(dbc, user1)
+	userDb, err := db.GetDatabase(ctx, dbc, user1)
 	require.NoError(t, err)
 
 	userWaiter := userDb.NewUserWaiter()
@@ -1974,7 +1976,7 @@ func TestMissingNoRev(t *testing.T) {
 	ctx := rt.Context()
 	targetDbContext, err := rt.ServerContext().GetDatabase(ctx, "db")
 	assert.NoError(t, err, "failed")
-	targetDb, err := db.GetDatabase(targetDbContext, nil)
+	targetDb, err := db.GetDatabase(ctx, targetDbContext, nil)
 	assert.NoError(t, err, "failed")
 
 	// Pull docs, expect to pull 5 docs since none of them has purged yet.

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1971,7 +1971,8 @@ func TestMissingNoRev(t *testing.T) {
 	}
 
 	// Get a reference to the database
-	targetDbContext, err := rt.ServerContext().GetDatabase("db")
+	ctx := rt.Context()
+	targetDbContext, err := rt.ServerContext().GetDatabase(ctx, "db")
 	assert.NoError(t, err, "failed")
 	targetDb, err := db.GetDatabase(targetDbContext, nil)
 	assert.NoError(t, err, "failed")

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -853,7 +853,7 @@ function(doc, oldDoc) {
 	user1, err := dbc.Authenticator(ctx).GetUser("user1")
 	require.NoError(t, err)
 
-	userDb, err := db.GetDatabase(ctx, dbc, user1)
+	userDb, err := db.GetDatabase(dbc, user1)
 	require.NoError(t, err)
 
 	userWaiter := userDb.NewUserWaiter()
@@ -1338,7 +1338,7 @@ func TestReloadUser(t *testing.T) {
 	user1, err := dbc.Authenticator(ctx).GetUser("user1")
 	require.NoError(t, err)
 
-	userDb, err := db.GetDatabase(ctx, dbc, user1)
+	userDb, err := db.GetDatabase(dbc, user1)
 	require.NoError(t, err)
 
 	userWaiter := userDb.NewUserWaiter()
@@ -1957,6 +1957,8 @@ func TestGetRemovedDoc(t *testing.T) {
 func TestMissingNoRev(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
+	ctx := rt.Context()
+
 	bt, err := NewBlipTesterFromSpecWithRT(t, nil, rt)
 	require.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
@@ -1973,10 +1975,9 @@ func TestMissingNoRev(t *testing.T) {
 	}
 
 	// Get a reference to the database
-	ctx := rt.Context()
 	targetDbContext, err := rt.ServerContext().GetDatabase(ctx, "db")
 	assert.NoError(t, err, "failed")
-	targetDb, err := db.GetDatabase(ctx, targetDbContext, nil)
+	targetDb, err := db.GetDatabase(targetDbContext, nil)
 	assert.NoError(t, err, "failed")
 
 	// Pull docs, expect to pull 5 docs since none of them has purged yet.
@@ -1986,7 +1987,7 @@ func TestMissingNoRev(t *testing.T) {
 
 	// Purge one doc
 	doc0Id := fmt.Sprintf("doc-%d", 0)
-	err = targetDb.Purge(doc0Id)
+	err = targetDb.Purge(ctx, doc0Id)
 	assert.NoError(t, err, "failed")
 
 	// Flush rev cache

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -4245,10 +4245,11 @@ func TestProcessRevIncrementsStat(t *testing.T) {
 
 	activeRT, remoteRT, remoteURLString, teardown := setupSGRPeers(t)
 	defer teardown()
+	activeCtx := activeRT.Context()
 
 	remoteURL, _ := url.Parse(remoteURLString)
 
-	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
+	ar := db.NewActiveReplicator(activeCtx, &db.ActiveReplicatorConfig{
 		ID:                  t.Name(),
 		Direction:           db.ActiveReplicatorTypePull,
 		ActiveDB:            &db.Database{DatabaseContext: activeRT.GetDatabase()},
@@ -4265,7 +4266,7 @@ func TestProcessRevIncrementsStat(t *testing.T) {
 
 	rev := remoteRT.createDoc(t, "doc")
 
-	assert.NoError(t, ar.Start())
+	assert.NoError(t, ar.Start(activeCtx))
 	defer func() { require.NoError(t, ar.Stop()) }()
 
 	err := activeRT.WaitForPendingChanges()

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -24,7 +24,7 @@ import (
 func (h *handler) handleBLIPSync() error {
 	// Exit early when the connection can't be switched to websocket protocol.
 	if _, ok := h.response.(http.Hijacker); !ok {
-		base.DebugfCtx(h.db.Ctx, base.KeyHTTP, "Non-upgradable request received for BLIP+WebSocket protocol")
+		base.DebugfCtx(h.ctx(), base.KeyHTTP, "Non-upgradable request received for BLIP+WebSocket protocol")
 		return base.HTTPErrorf(http.StatusUpgradeRequired, "Can't upgrade this request to websocket connection")
 	}
 
@@ -37,16 +37,16 @@ func (h *handler) handleBLIPSync() error {
 	}
 
 	// Create a BLIP context:
-	blipContext, err := db.NewSGBlipContext(h.db.Ctx, "")
+	blipContext, err := db.NewSGBlipContext(h.ctx(), "")
 	if err != nil {
 		return err
 	}
 
 	// Overwrite the existing logging context with the blip context ID
-	h.db.Ctx = base.LogContextWith(h.db.Ctx, &base.LogContext{CorrelationID: base.FormatBlipContextID(blipContext.ID)})
+	h.rqCtx = base.LogContextWith(h.ctx(), &base.LogContext{CorrelationID: base.FormatBlipContextID(blipContext.ID)})
 
 	// Create a new BlipSyncContext attached to the given blipContext.
-	ctx := db.NewBlipSyncContext(blipContext, h.db, h.formatSerialNumber(), db.BlipSyncStatsForCBL(h.db.DbStats))
+	ctx := db.NewBlipSyncContext(h.ctx(), blipContext, h.db, h.formatSerialNumber(), db.BlipSyncStatsForCBL(h.db.DbStats))
 	defer ctx.Close()
 
 	if string(db.BLIPClientTypeSGR2) == h.getQuery(db.BLIPSyncClientTypeQueryParam) {
@@ -62,7 +62,7 @@ func (h *handler) handleBLIPSync() error {
 		return http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
 				h.logStatus(http.StatusSwitchingProtocols, fmt.Sprintf("[%s] Upgraded to WebSocket protocol %s+%s%s", blipContext.ID, blip.WebSocketSubProtocolPrefix, blipContext.ActiveSubprotocol(), h.formattedEffectiveUserName()))
-				defer base.InfofCtx(h.db.Ctx, base.KeyHTTP, "%s:    --> BLIP+WebSocket connection closed", h.formatSerialNumber())
+				defer base.InfofCtx(h.ctx(), base.KeyHTTP, "%s:    --> BLIP+WebSocket connection closed", h.formatSerialNumber())
 				next.ServeHTTP(w, r)
 			})
 	}

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -46,7 +46,7 @@ func (h *handler) handleBLIPSync() error {
 	h.rqCtx = base.LogContextWith(h.ctx(), &base.LogContext{CorrelationID: base.FormatBlipContextID(blipContext.ID)})
 
 	// Create a new BlipSyncContext attached to the given blipContext.
-	ctx := db.NewBlipSyncContext(h.ctx(), blipContext, h.db, h.formatSerialNumber(), db.BlipSyncStatsForCBL(h.db.DbStats))
+	ctx := db.NewBlipSyncContext(h.rqCtx, blipContext, h.db, h.formatSerialNumber(), db.BlipSyncStatsForCBL(h.db.DbStats))
 	defer ctx.Close()
 
 	if string(db.BLIPClientTypeSGR2) == h.getQuery(db.BLIPSyncClientTypeQueryParam) {

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -35,7 +35,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
+	ctx = sc.SetContextLogID(ctx, "initial")
 
 	// sc closed and serverErr read later in the test
 	serverErr := make(chan error, 0)
@@ -98,7 +98,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	ctx = base.TestCtx(t)
 	sc, err = setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
+	ctx = sc.SetContextLogID(ctx, "loaddatabase")
 
 	serverErr = make(chan error, 0)
 	go func() {
@@ -152,7 +152,6 @@ func TestBootstrapDuplicateBucket(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
 
 	defer func() {
 		sc.Close(ctx)
@@ -204,7 +203,6 @@ func TestBootstrapDuplicateDatabase(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
 
 	defer func() {
 		sc.Close(ctx)

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -31,15 +31,16 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	// Start SG with no databases
+	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(&config, true)
+	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
+	ctx = sc.AddServerLogContext(ctx)
 
 	// sc closed and serverErr read later in the test
 	serverErr := make(chan error, 0)
 	go func() {
-		serverErr <- startServer(&config, sc)
+		serverErr <- startServer(ctx, &config, sc)
 	}()
 	require.NoError(t, sc.waitForRESTAPIs())
 
@@ -94,13 +95,14 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	sc.Close(ctx)
 	require.NoError(t, <-serverErr)
 
-	sc, err = setupServerContext(&config, true)
+	ctx = base.TestCtx(t)
+	sc, err = setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
+	ctx = sc.AddServerLogContext(ctx)
 
 	serverErr = make(chan error, 0)
 	go func() {
-		serverErr <- startServer(&config, sc)
+		serverErr <- startServer(ctx, &config, sc)
 	}()
 	require.NoError(t, sc.waitForRESTAPIs())
 	defer func() {
@@ -146,17 +148,19 @@ func TestBootstrapDuplicateBucket(t *testing.T) {
 	serverErr := make(chan error, 0)
 
 	// Start SG with no databases
+	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(&config, true)
+	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
+	ctx = sc.AddServerLogContext(ctx)
+
 	defer func() {
 		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
 	go func() {
-		serverErr <- startServer(&config, sc)
+		serverErr <- startServer(ctx, &config, sc)
 	}()
 	require.NoError(t, sc.waitForRESTAPIs())
 
@@ -196,17 +200,19 @@ func TestBootstrapDuplicateDatabase(t *testing.T) {
 	serverErr := make(chan error, 0)
 
 	// Start SG with no databases
+	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(&config, true)
+	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
+	ctx = sc.AddServerLogContext(ctx)
+
 	defer func() {
 		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
 	go func() {
-		serverErr <- startServer(&config, sc)
+		serverErr <- startServer(ctx, &config, sc)
 	}()
 	require.NoError(t, sc.waitForRESTAPIs())
 

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -34,6 +34,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 
 	// sc closed and serverErr read later in the test
 	serverErr := make(chan error, 0)
@@ -90,18 +91,20 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	resp.requireResponse(http.StatusOK, `{"_id":"doc1","_rev":"1-cd809becc169215072fd567eebd8b8de","foo":"bar"}`)
 
 	// Restart Sync Gateway
-	sc.Close()
+	sc.Close(ctx)
 	require.NoError(t, <-serverErr)
 
 	sc, err = setupServerContext(&config, true)
 	require.NoError(t, err)
+	ctx = base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
+
 	serverErr = make(chan error, 0)
 	go func() {
 		serverErr <- startServer(&config, sc)
 	}()
 	require.NoError(t, sc.waitForRESTAPIs())
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
@@ -146,8 +149,9 @@ func TestBootstrapDuplicateBucket(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
@@ -195,8 +199,9 @@ func TestBootstrapDuplicateDatabase(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -129,7 +129,7 @@ func (h *handler) handleAllDocs() error {
 
 		if explicitDocIDs != nil || includeDocs || includeAccess {
 			// Fetch the document body and other metadata that lives with it:
-			bodyBytes, channelSet, access, roleAccess, _, _, currentRevID, removed, err := h.db.Get1xRevAndChannels(doc.DocID, doc.RevID, includeRevs)
+			bodyBytes, channelSet, access, roleAccess, _, _, currentRevID, removed, err := h.db.Get1xRevAndChannels(h.ctx(), doc.DocID, doc.RevID, includeRevs)
 			if err != nil {
 				row.Status, _ = base.ErrorAsHTTPStatus(err)
 				return row
@@ -216,7 +216,7 @@ func (h *handler) handleAllDocs() error {
 
 		}
 	} else {
-		if err := h.db.ForEachDocID(writeDoc, options); err != nil {
+		if err := h.db.ForEachDocID(h.ctx(), writeDoc, options); err != nil {
 			return err
 		}
 	}
@@ -421,7 +421,7 @@ func (h *handler) handleBulkGet() error {
 			}
 
 			if err == nil {
-				body, err = h.db.Get1xRevBodyWithHistory(docid, revid, docRevsLimit, revsFrom, attsSince, showExp)
+				body, err = h.db.Get1xRevBodyWithHistory(h.ctx(), docid, revid, docRevsLimit, revsFrom, attsSince, showExp)
 			}
 
 			if err != nil {
@@ -496,9 +496,9 @@ func (h *handler) handleBulkDocs() error {
 		var revid string
 		if newEdits {
 			if docid != "" {
-				revid, _, err = h.db.Put(docid, doc)
+				revid, _, err = h.db.Put(h.ctx(), docid, doc)
 			} else {
-				docid, revid, _, err = h.db.Post(doc)
+				docid, revid, _, err = h.db.Post(h.ctx(), doc)
 			}
 		} else {
 			revisions := db.ParseRevisions(doc)
@@ -506,7 +506,7 @@ func (h *handler) handleBulkDocs() error {
 				err = base.HTTPErrorf(http.StatusBadRequest, "Bad _revisions")
 			} else {
 				revid = revisions[0]
-				_, _, err = h.db.PutExistingRevWithBody(docid, doc, revisions, false)
+				_, _, err = h.db.PutExistingRevWithBody(h.ctx(), docid, doc, revisions, false)
 			}
 		}
 

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -434,7 +434,7 @@ func (h *handler) handleBulkGet() error {
 				}
 			}
 
-			_ = WriteRevisionAsPart(h.rq.Context(), h.db.DatabaseContext.DbStats.CBLReplicationPull(), body, err != nil, canCompressParts, writer)
+			_ = WriteRevisionAsPart(h.ctx(), h.db.DatabaseContext.DbStats.CBLReplicationPull(), body, err != nil, canCompressParts, writer)
 
 			h.db.DbStats.Database().NumDocReadsRest.Add(1)
 		}

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -59,7 +59,7 @@ func TestReproduce2383(t *testing.T) {
 	requireStatus(t, response, 201)
 
 	cacheWaiter.Wait()
-	assert.NoError(t, testDb.FlushChannelCache())
+	assert.NoError(t, testDb.FlushChannelCache(ctx))
 
 	var changes struct {
 		Results  []db.ChangeEntry
@@ -1001,7 +1001,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 2)
 	WriteDirect(testDb, []string{"PBS"}, 5)
 	WriteDirect(testDb, []string{"PBS"}, 6)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(base.TestCtx(t), 6))
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 6))
 
 	// Check the _changes feed:
 	var changes struct {
@@ -1040,7 +1040,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 
 	// Send a later doc - low sequence still 3, high sequence goes to 7
 	WriteDirect(testDb, []string{"PBS"}, 7)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(base.TestCtx(t), 7))
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 7))
 
 	// Send another changes request with the same since ("2::6") to ensure we see data once there are changes
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1094,7 +1094,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 3)
 	WriteDirect(testDb, []string{"PBS"}, 4)
 	WriteDirect(testDb, []string{"PBS"}, 5)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(base.TestCtx(t), 5))
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 5))
 
 	// Check the _changes feed:
 	var changes struct {
@@ -1114,7 +1114,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 8)
 	WriteDirect(testDb, []string{"PBS"}, 9)
 	WriteDirect(testDb, []string{"PBS"}, 10)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(base.TestCtx(t), 10))
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 10))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1128,7 +1128,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	// Write a few more docs
 	WriteDirect(testDb, []string{"PBS"}, 11)
 	WriteDirect(testDb, []string{"PBS"}, 12)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(base.TestCtx(t), 12))
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 12))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1225,7 +1225,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 3)
 	WriteDirect(testDb, []string{"PBS"}, 4)
 	WriteDirect(testDb, []string{"PBS"}, 5)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(base.TestCtx(t), 5))
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 5))
 
 	// Check the _changes feed:
 	var changes struct {
@@ -1245,7 +1245,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 8)
 	WriteDirect(testDb, []string{"PBS"}, 9)
 	WriteDirect(testDb, []string{"PBS"}, 10)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(base.TestCtx(t), 10))
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 10))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1259,7 +1259,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	// Write a few more docs
 	WriteDirect(testDb, []string{"PBS"}, 11)
 	WriteDirect(testDb, []string{"PBS"}, 12)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(base.TestCtx(t), 12))
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 12))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1361,7 +1361,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 3)
 	WriteDirect(testDb, []string{"PBS"}, 4)
 	WriteDirect(testDb, []string{"PBS"}, 5)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(base.TestCtx(t), 5))
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 5))
 
 	// Check the _changes feed:
 	var changes struct {
@@ -1381,7 +1381,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 8)
 	WriteDirect(testDb, []string{"PBS"}, 9)
 	WriteDirect(testDb, []string{"PBS"}, 10)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(base.TestCtx(t), 10))
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 10))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1395,7 +1395,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	// Write a few more docs
 	WriteDirect(testDb, []string{"PBS"}, 11)
 	WriteDirect(testDb, []string{"PBS"}, 12)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(base.TestCtx(t), 12))
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 12))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -2205,7 +2205,7 @@ func TestChangesViewBackfillFromQueryOnly(t *testing.T) {
 	cacheWaiter.Wait()
 
 	// Flush the channel cache
-	assert.NoError(t, testDb.FlushChannelCache())
+	assert.NoError(t, testDb.FlushChannelCache(ctx))
 
 	var changes struct {
 		Results  []db.ChangeEntry
@@ -2278,7 +2278,7 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 	cacheWaiter.Wait()
 
 	// Flush the channel cache
-	assert.NoError(t, testDb.FlushChannelCache())
+	assert.NoError(t, testDb.FlushChannelCache(ctx))
 
 	// Issue a since=0 changes request, with limit less than the number of PBS documents
 	var changes struct {
@@ -2379,7 +2379,7 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 	cacheWaiter.Wait()
 
 	// Flush the channel cache
-	assert.NoError(t, testDb.FlushChannelCache())
+	assert.NoError(t, testDb.FlushChannelCache(ctx))
 
 	// Issue a since=n changes request, where n > 0 and is a non-PBS sequence.  Validate that there's a view-based backfill
 	var changes struct {
@@ -2464,7 +2464,7 @@ func TestChangesViewBackfillNoOverlap(t *testing.T) {
 	cacheWaiter.Wait()
 
 	// Flush the channel cache
-	assert.NoError(t, testDb.FlushChannelCache())
+	assert.NoError(t, testDb.FlushChannelCache(ctx))
 
 	// Write some more docs to the bucket, with a gap before the first PBS sequence
 	response := rt.SendAdminRequest("PUT", "/db/abc11", `{"channels":["ABC"]}`)
@@ -2545,7 +2545,7 @@ func TestChangesViewBackfill(t *testing.T) {
 	cacheWaiter.AddAndWait(3)
 
 	// Flush the channel cache
-	assert.NoError(t, testDb.FlushChannelCache())
+	assert.NoError(t, testDb.FlushChannelCache(ctx))
 
 	// Add a few more docs (to increment the channel cache's validFrom)
 	response = rt.SendAdminRequest("PUT", "/db/doc4", `{"channels":["PBS"]}`)
@@ -2617,7 +2617,7 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 	cacheWaiter.Wait()
 
 	// Flush the channel cache
-	assert.NoError(t, testDb.FlushChannelCache())
+	assert.NoError(t, testDb.FlushChannelCache(ctx))
 
 	// Add a few more docs (to increment the channel cache's validFrom)
 	response = rt.SendAdminRequest("PUT", "/db/doc2", `{"channels":["PBS"]}`)
@@ -2673,6 +2673,7 @@ func TestChangesQueryBackfillWithLimit(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	testDb := rt.GetDatabase()
+	ctx := rt.Context()
 
 	changesLimitTests := []struct {
 		name                string // test name
@@ -2787,7 +2788,7 @@ func TestChangesQueryBackfillWithLimit(t *testing.T) {
 
 			// Create user
 			username := "user_" + test.name
-			a := testDb.Authenticator(base.TestCtx(t))
+			a := testDb.Authenticator(ctx)
 			testUser, err := a.NewUser(username, "letmein", channels.SetOf(t, test.name))
 			assert.NoError(t, err)
 			assert.NoError(t, a.Save(testUser))
@@ -2804,7 +2805,7 @@ func TestChangesQueryBackfillWithLimit(t *testing.T) {
 			cacheWaiter.AddAndWait(test.totalDocuments * 2)
 
 			// Flush the channel cache
-			assert.NoError(t, testDb.FlushChannelCache())
+			assert.NoError(t, testDb.FlushChannelCache(ctx))
 			startQueryCount := testDb.GetChannelQueryCount()
 
 			// Issue a since=0 changes request.
@@ -2837,12 +2838,13 @@ func TestMultichannelChangesQueryBackfillWithLimit(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	testDb := rt.GetDatabase()
+	ctx := rt.Context()
 
 	testDb.Options.CacheOptions.ChannelQueryLimit = 5
 
 	// Create user with access to three channels
 	username := "user_" + t.Name()
-	a := testDb.Authenticator(base.TestCtx(t))
+	a := testDb.Authenticator(ctx)
 	testUser, err := a.NewUser(username, "letmein", channels.SetOf(t, "ch1", "ch2", "ch3"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(testUser))
@@ -2867,7 +2869,7 @@ func TestMultichannelChangesQueryBackfillWithLimit(t *testing.T) {
 	cacheWaiter.AddAndWait(50)
 
 	// Flush the channel cache
-	assert.NoError(t, testDb.FlushChannelCache())
+	assert.NoError(t, testDb.FlushChannelCache(ctx))
 
 	// 1. Issue a since=0 changes request, validate results
 	var changes struct {
@@ -2887,7 +2889,7 @@ func TestMultichannelChangesQueryBackfillWithLimit(t *testing.T) {
 	}
 
 	// 2. Same again, but with limit on the changes request
-	assert.NoError(t, testDb.FlushChannelCache())
+	assert.NoError(t, testDb.FlushChannelCache(ctx))
 	changes.Results = nil
 	changesJSON = fmt.Sprintf(`{"since":0, "limit":25}`)
 	changes.Results = nil
@@ -2934,7 +2936,7 @@ func TestChangesQueryStarChannelBackfillLimit(t *testing.T) {
 	cacheWaiter.AddAndWait(10)
 
 	// Flush the channel cache
-	assert.NoError(t, testDb.FlushChannelCache())
+	assert.NoError(t, testDb.FlushChannelCache(ctx))
 	startQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 
 	// Issue a since=0 changes request.  Validate that there's a view-based backfill
@@ -2988,7 +2990,7 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 	cacheWaiter.Wait()
 
 	// Flush the channel cache
-	assert.NoError(t, testDb.FlushChannelCache())
+	assert.NoError(t, testDb.FlushChannelCache(ctx))
 
 	// Write another doc, to initialize the cache (and guarantee overlap)
 	response = rt.SendAdminRequest("PUT", "/db/doc2", `{"channels":["PBS"]}`)
@@ -3076,7 +3078,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	testDb := rt.ServerContext().Database(ctx, "db")
 
 	// Create user:
-	a := testDb.Authenticator(base.TestCtx(t))
+	a := testDb.Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS", "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
@@ -3351,7 +3353,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 
 	// Active only NO Limit, POST
 	testDb := rt.ServerContext().Database(ctx, "db")
-	assert.NoError(t, testDb.FlushChannelCache())
+	assert.NoError(t, testDb.FlushChannelCache(ctx))
 
 	changesJSON = `{"style":"all_docs", "active_only":true}`
 	changes.Results = nil
@@ -3368,7 +3370,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	}
 
 	// Active only with Limit, POST
-	assert.NoError(t, testDb.FlushChannelCache())
+	assert.NoError(t, testDb.FlushChannelCache(ctx))
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":5}`
 	changes.Results = nil
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
@@ -3384,7 +3386,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	}
 
 	// Active only with Limit, GET
-	assert.NoError(t, testDb.FlushChannelCache())
+	assert.NoError(t, testDb.FlushChannelCache(ctx))
 	changes.Results = nil
 	changesResponse = rt.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true&limit=5", "", "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
@@ -3398,7 +3400,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	}
 
 	// Active only with Limit set higher than number of revisions, POST
-	assert.NoError(t, testDb.FlushChannelCache())
+	assert.NoError(t, testDb.FlushChannelCache(ctx))
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":15}`
 	changes.Results = nil
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
@@ -3414,7 +3416,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	}
 
 	// No limit active only, GET, followed by normal (https://github.com/couchbase/sync_gateway/issues/2955)
-	assert.NoError(t, testDb.FlushChannelCache())
+	assert.NoError(t, testDb.FlushChannelCache(ctx))
 	changes.Results = nil
 	changesResponse = rt.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true", "", "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -40,12 +40,13 @@ func TestReproduce2383(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	user, err := a.NewUser("ben", "letmein", channels.SetOf(t, "PBS"))
 	assert.NoError(t, err, "Error creating new user")
 	assert.NoError(t, a.Save(user))
 
-	testDb := rt.ServerContext().Database("db")
+	testDb := rt.ServerContext().Database(ctx, "db")
 
 	// Put several documents
 	cacheWaiter := testDb.NewDCPCachingCountWaiter(t)
@@ -125,7 +126,8 @@ func TestDocDeletionFromChannel(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 
 	// Create user:
 	alice, _ := a.NewUser("alice", "letmein", channels.SetOf(t, "zero"))
@@ -195,7 +197,8 @@ func TestPostChanges(t *testing.T) {
 	defer rt.Close()
 
 	// Create user:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
@@ -228,7 +231,8 @@ func TestPostChangesUserTiming(t *testing.T) {
 	defer rt.Close()
 
 	// Create user:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "bernard"))
 	assert.True(t, err == nil)
 	assert.NoError(t, a.Save(bernard))
@@ -401,7 +405,8 @@ func TestPostChangesChannelFilterInteger(t *testing.T) {
 func postChangesChannelFilter(t *testing.T, rt *RestTester) {
 
 	// Create user:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
@@ -464,7 +469,8 @@ func TestPostChangesAdminChannelGrant(t *testing.T) {
 	defer rt.Close()
 
 	// Create user with access to channel ABC:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
@@ -549,7 +555,8 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 	defer rt.Close()
 
 	// Create user with access to channel ABC:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
@@ -703,7 +710,8 @@ func TestPostChangesAdminChannelGrantRemovalWithLimit(t *testing.T) {
 	defer rt.Close()
 
 	// Create user with access to channel ABC:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
@@ -773,7 +781,8 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	defer rt.Close()
 
 	// Create user with access to channel NBC:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	alice, err := a.NewUser("alice", "letmein", channels.SetOf(t, "NBC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(alice))
@@ -980,7 +989,8 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	testDb := rt.ServerContext().Database("db")
+	ctx := rt.Context()
+	testDb := rt.ServerContext().Database(ctx, "db")
 
 	// Create user:
 	requireStatus(t, rt.SendAdminRequest("GET", "/db/_user/bernard", ""), 404)
@@ -1071,7 +1081,8 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	testDb := rt.ServerContext().Database("db")
+	ctx := rt.Context()
+	testDb := rt.ServerContext().Database(ctx, "db")
 
 	// Create user:
 	requireStatus(t, rt.SendAdminRequest("GET", "/db/_user/bernard", ""), 404)
@@ -1205,7 +1216,8 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	testDb := rt.ServerContext().Database("db")
+	ctx := rt.Context()
+	testDb := rt.ServerContext().Database(ctx, "db")
 
 	// Simulate 5 non-skipped writes (seq 1,2,3,4,5)
 	WriteDirect(testDb, []string{"PBS"}, 1)
@@ -1336,7 +1348,8 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	testDb := rt.ServerContext().Database("db")
+	ctx := rt.Context()
+	testDb := rt.ServerContext().Database(ctx, "db")
 
 	// Create user:
 	requireStatus(t, rt.SendAdminRequest("GET", "/db/_user/bernard", ""), 404)
@@ -1608,7 +1621,8 @@ func TestChangesActiveOnlyInteger(t *testing.T) {
 	defer rt.Close()
 
 	// Create user:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS", "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
@@ -2166,12 +2180,13 @@ func TestChangesViewBackfillFromQueryOnly(t *testing.T) {
 	defer rt.Close()
 
 	// Create user:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
-	testDb := rt.ServerContext().Database("db")
+	testDb := rt.ServerContext().Database(ctx, "db")
 	cacheWaiter := testDb.NewDCPCachingCountWaiter(t)
 	// Write 30 docs to the bucket, 10 from channel PBS.  Expected sequence assignment:
 	//  1, 4, 7, ...   ABC
@@ -2238,12 +2253,13 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 	defer rt.Close()
 
 	// Create user:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
-	testDb := rt.ServerContext().Database("db")
+	testDb := rt.ServerContext().Database(ctx, "db")
 	cacheWaiter := testDb.NewDCPCachingCountWaiter(t)
 
 	// Write 30 docs to the bucket, 10 from channel PBS.  Expected sequence assignment:
@@ -2337,12 +2353,13 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 	defer rt.Close()
 
 	// Create user:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
-	testDb := rt.ServerContext().Database("db")
+	testDb := rt.ServerContext().Database(ctx, "db")
 	cacheWaiter := testDb.NewDCPCachingCountWaiter(t)
 
 	// Write 30 docs to the bucket, 10 from channel PBS.  Expected sequence assignment:
@@ -2421,12 +2438,13 @@ func TestChangesViewBackfillNoOverlap(t *testing.T) {
 	defer rt.Close()
 
 	// Create user:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
-	testDb := rt.ServerContext().Database("db")
+	testDb := rt.ServerContext().Database(ctx, "db")
 	cacheWaiter := testDb.NewDCPCachingCountWaiter(t)
 
 	// Write 30 docs to the bucket, 10 from channel PBS.  Expected sequence assignment:
@@ -2507,12 +2525,13 @@ func TestChangesViewBackfill(t *testing.T) {
 	defer rt.Close()
 
 	// Create user:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS", "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
-	testDb := rt.ServerContext().Database("db")
+	testDb := rt.ServerContext().Database(ctx, "db")
 	cacheWaiter := testDb.NewDCPCachingCountWaiter(t)
 
 	// Put several documents
@@ -2578,12 +2597,13 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 	defer rt.Close()
 
 	// Create user:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "*"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
-	testDb := rt.ServerContext().Database("db")
+	testDb := rt.ServerContext().Database(ctx, "db")
 	cacheWaiter := testDb.NewDCPCachingCountWaiter(t)
 
 	// Put several documents
@@ -2895,12 +2915,13 @@ func TestChangesQueryStarChannelBackfillLimit(t *testing.T) {
 	defer rt.Close()
 
 	// Create user:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "*"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
-	testDb := rt.ServerContext().Database("db")
+	testDb := rt.ServerContext().Database(ctx, "db")
 	cacheWaiter := testDb.NewDCPCachingCountWaiter(t)
 
 	// Put 10 documents
@@ -2946,12 +2967,13 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 	defer rt.Close()
 
 	// Create user:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
-	testDb := rt.ServerContext().Database("db")
+	testDb := rt.ServerContext().Database(ctx, "db")
 	cacheWaiter := testDb.NewDCPCachingCountWaiter(t)
 	cacheWaiter.Add(1)
 
@@ -3050,7 +3072,8 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
 
-	testDb := rt.ServerContext().Database("db")
+	ctx := rt.Context()
+	testDb := rt.ServerContext().Database(ctx, "db")
 
 	// Create user:
 	a := testDb.Authenticator(base.TestCtx(t))
@@ -3233,12 +3256,13 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	defer rt.Close()
 
 	// Create user:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS", "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
-	cacheWaiter := rt.ServerContext().Database("db").NewDCPCachingCountWaiter(t)
+	cacheWaiter := rt.ServerContext().Database(ctx, "db").NewDCPCachingCountWaiter(t)
 	// Put several documents
 	var body db.Body
 	response := rt.SendAdminRequest("PUT", "/db/deletedDoc", `{"channel":["PBS"]}`)
@@ -3326,7 +3350,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	}
 
 	// Active only NO Limit, POST
-	testDb := rt.ServerContext().Database("db")
+	testDb := rt.ServerContext().Database(ctx, "db")
 	assert.NoError(t, testDb.FlushChannelCache())
 
 	changesJSON = `{"style":"all_docs", "active_only":true}`
@@ -3436,7 +3460,8 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	// defer it.Close()
 
 	// Create user:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS", "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
@@ -3667,7 +3692,8 @@ func TestIncludeDocsWithPrincipals(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	testDb := rt.ServerContext().Database("db")
+	ctx := rt.Context()
+	testDb := rt.ServerContext().Database(ctx, "db")
 
 	cacheWaiter := testDb.NewDCPCachingCountWaiter(t)
 
@@ -3722,7 +3748,8 @@ func TestChangesAdminChannelGrantLongpollNotify(t *testing.T) {
 	defer rt.Close()
 
 	// Create user with access to channel ABC:
-	a := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))

--- a/rest/config.go
+++ b/rest/config.go
@@ -886,12 +886,12 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 	}
 
 	if dbConfig.UserFunctions != nil {
-		if err := db.ValidateUserFunctions(dbConfig.UserFunctions); err != nil {
+		if err := db.ValidateUserFunctions(ctx, dbConfig.UserFunctions); err != nil {
 			multiError = multiError.Append(err)
 		}
 	}
 	if dbConfig.GraphQL != nil {
-		if err := dbConfig.GraphQL.Validate(); err != nil {
+		if err := dbConfig.GraphQL.Validate(ctx); err != nil {
 			multiError = multiError.Append(err)
 		}
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -1278,7 +1278,6 @@ func setupServerContext(ctx context.Context, config *StartupConfig, persistentCo
 	}
 
 	sc := NewServerContext(ctx, config, persistentConfig)
-	ctx = sc.AddServerLogContext(ctx) // add server log info before passing donwn
 	if !base.ServerIsWalrus(config.Bootstrap.Server) {
 		if err := sc.initializeCouchbaseServerConnections(ctx); err != nil {
 			return nil, err

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -342,6 +342,7 @@ func TestLegacyConfigPrinciplesMigration(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 	rt.GetDatabase().AllowEmptyPassword = true // So users don't have to have password set
+	ctx := rt.Context()
 
 	// Expected principle names that should exist on bucket after migration
 	expectedUsers := []string{
@@ -366,7 +367,7 @@ func TestLegacyConfigPrinciplesMigration(t *testing.T) {
 			ExplicitChannels: base.SetOf("*"),
 		},
 	}
-	err := rt.ServerContext().installPrincipals(rt.GetDatabase(), existingUsers, "user")
+	err := rt.ServerContext().installPrincipals(ctx, rt.GetDatabase(), existingUsers, "user")
 	require.NoError(t, err)
 
 	existingRoles := map[string]*auth.PrincipalConfig{
@@ -379,7 +380,7 @@ func TestLegacyConfigPrinciplesMigration(t *testing.T) {
 			ExplicitChannels: base.SetOf("*"),
 		},
 	}
-	err = rt.ServerContext().installPrincipals(rt.GetDatabase(), existingRoles, "role")
+	err = rt.ServerContext().installPrincipals(ctx, rt.GetDatabase(), existingRoles, "role")
 	require.NoError(t, err)
 
 	// Config to migrate to persistent config on bucket
@@ -422,7 +423,7 @@ func TestLegacyConfigPrinciplesMigration(t *testing.T) {
 	// Copy behaviour of serverMainPersistentConfig - upgrade config, pass legacy users and roles in to addLegacyPrinciples (after server context is created)
 	_, _, users, roles, err := automaticConfigUpgrade(configPath)
 	require.NoError(t, err)
-	rt.ServerContext().addLegacyPrincipals(users, roles)
+	rt.ServerContext().addLegacyPrincipals(ctx, users, roles)
 
 	// Check that principles all exist on bucket
 	authenticator := auth.NewAuthenticator(bucket, nil, auth.DefaultAuthenticatorOptions())

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -996,8 +996,8 @@ func TestValidateServerContextSharedBuckets(t *testing.T) {
 
 	ctx := base.TestCtx(t)
 	sc := NewServerContext(ctx, config, false)
-	defer sc.Close(ctx)
 	ctx = sc.AddServerLogContext(ctx)
+	defer sc.Close(ctx)
 	for _, dbConfig := range databases {
 		_, err := sc.AddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: *dbConfig})
 		require.NoError(t, err, "Couldn't add database from config")
@@ -1352,8 +1352,8 @@ func TestSetupServerContext(t *testing.T) {
 		config.Bootstrap.Password = base.TestClusterPassword()
 		ctx := base.TestCtx(t)
 		sc, err := setupServerContext(ctx, &config, false)
-		defer sc.Close(ctx)
 		ctx = sc.AddServerLogContext(ctx)
+		defer sc.Close(ctx)
 		require.NoError(t, err)
 		require.NotNil(t, sc)
 	})

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -995,7 +995,8 @@ func TestValidateServerContextSharedBuckets(t *testing.T) {
 	require.Nil(t, setupAndValidateDatabases(databases), "Unexpected error while validating databases")
 
 	sc := NewServerContext(config, false)
-	defer sc.Close()
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
+	defer sc.Close(ctx)
 	for _, dbConfig := range databases {
 		_, err := sc.AddDatabaseFromConfig(DatabaseConfig{DbConfig: *dbConfig})
 		require.NoError(t, err, "Couldn't add database from config")
@@ -1349,7 +1350,8 @@ func TestSetupServerContext(t *testing.T) {
 		config.Bootstrap.Username = base.TestClusterUsername()
 		config.Bootstrap.Password = base.TestClusterPassword()
 		sc, err := setupServerContext(&config, false)
-		defer sc.Close()
+		ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
+		defer sc.Close(ctx)
 		require.NoError(t, err)
 		require.NotNil(t, sc)
 	})

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -996,7 +996,6 @@ func TestValidateServerContextSharedBuckets(t *testing.T) {
 
 	ctx := base.TestCtx(t)
 	sc := NewServerContext(ctx, config, false)
-	ctx = sc.AddServerLogContext(ctx)
 	defer sc.Close(ctx)
 	for _, dbConfig := range databases {
 		_, err := sc.AddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: *dbConfig})
@@ -1352,7 +1351,6 @@ func TestSetupServerContext(t *testing.T) {
 		config.Bootstrap.Password = base.TestClusterPassword()
 		ctx := base.TestCtx(t)
 		sc, err := setupServerContext(ctx, &config, false)
-		ctx = sc.AddServerLogContext(ctx)
 		defer sc.Close(ctx)
 		require.NoError(t, err)
 		require.NotNil(t, sc)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -994,11 +994,12 @@ func TestValidateServerContextSharedBuckets(t *testing.T) {
 
 	require.Nil(t, setupAndValidateDatabases(databases), "Unexpected error while validating databases")
 
-	sc := NewServerContext(config, false)
-	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
+	ctx := base.TestCtx(t)
+	sc := NewServerContext(ctx, config, false)
 	defer sc.Close(ctx)
+	ctx = sc.AddServerLogContext(ctx)
 	for _, dbConfig := range databases {
-		_, err := sc.AddDatabaseFromConfig(DatabaseConfig{DbConfig: *dbConfig})
+		_, err := sc.AddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: *dbConfig})
 		require.NoError(t, err, "Couldn't add database from config")
 	}
 
@@ -1349,9 +1350,10 @@ func TestSetupServerContext(t *testing.T) {
 		config.Bootstrap.ServerTLSSkipVerify = base.BoolPtr(base.TestTLSSkipVerify())
 		config.Bootstrap.Username = base.TestClusterUsername()
 		config.Bootstrap.Password = base.TestClusterPassword()
-		sc, err := setupServerContext(&config, false)
-		ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
+		ctx := base.TestCtx(t)
+		sc, err := setupServerContext(ctx, &config, false)
 		defer sc.Close(ctx)
+		ctx = sc.AddServerLogContext(ctx)
 		require.NoError(t, err)
 		require.NotNil(t, sc)
 	})
@@ -2119,7 +2121,7 @@ func TestWebhookFilterFunctionLoad(t *testing.T) {
 			defer close(terminator)
 			ctx := &db.DatabaseContext{EventMgr: db.NewEventManager(terminator)}
 			sc := &ServerContext{}
-			err := sc.initEventHandlers(ctx, &dbConfig)
+			err := sc.initEventHandlers(base.TestCtx(t), ctx, &dbConfig)
 			if test.errExpected != nil {
 				requireErrorWithX509UnknownAuthority(t, err, test.errExpected)
 			} else {

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -67,7 +67,7 @@ func (h *handler) handleGetDoc() error {
 
 	if openRevs == "" {
 		// Single-revision GET:
-		value, err := h.db.Get1xRevBodyWithHistory(docid, revid, revsLimit, revsFrom, attachmentsSince, showExp)
+		value, err := h.db.Get1xRevBodyWithHistory(h.ctx(), docid, revid, revsLimit, revsFrom, attachmentsSince, showExp)
 		if err != nil {
 			if err == base.ErrImportCancelledPurged {
 				base.DebugfCtx(h.ctx(), base.KeyImport, fmt.Sprintf("Import cancelled as document %v is purged", base.UD(docid)))
@@ -105,7 +105,7 @@ func (h *handler) handleGetDoc() error {
 
 		if openRevs == "all" {
 			// open_revs=all
-			doc, err := h.db.GetDocument(h.db.Ctx, docid, db.DocUnmarshalSync)
+			doc, err := h.db.GetDocument(h.ctx(), docid, db.DocUnmarshalSync)
 			if err != nil {
 				return err
 			}
@@ -124,7 +124,7 @@ func (h *handler) handleGetDoc() error {
 		if h.requestAccepts("multipart/") {
 			err := h.writeMultipart("mixed", func(writer *multipart.Writer) error {
 				for _, revid := range revids {
-					revBody, err := h.db.Get1xRevBodyWithHistory(docid, revid, revsLimit, revsFrom, attachmentsSince, showExp)
+					revBody, err := h.db.Get1xRevBodyWithHistory(h.ctx(), docid, revid, revsLimit, revsFrom, attachmentsSince, showExp)
 					if err != nil {
 						revBody = db.Body{"missing": revid} // TODO: More specific error
 					}
@@ -140,7 +140,7 @@ func (h *handler) handleGetDoc() error {
 			_, _ = h.response.Write([]byte(`[` + "\n"))
 			separator := []byte(``)
 			for _, revid := range revids {
-				revBody, err := h.db.Get1xRevBodyWithHistory(docid, revid, revsLimit, revsFrom, attachmentsSince, showExp)
+				revBody, err := h.db.Get1xRevBodyWithHistory(h.ctx(), docid, revid, revsLimit, revsFrom, attachmentsSince, showExp)
 				if err != nil {
 					revBody = db.Body{"missing": revid} // TODO: More specific error
 				} else {
@@ -165,7 +165,7 @@ func (h *handler) handleGetDocReplicator2(docid, revid string) error {
 		return base.HTTPErrorf(http.StatusNotImplemented, "replicator2 endpoints are only supported in EE")
 	}
 
-	rev, err := h.db.GetRev(docid, revid, true, nil)
+	rev, err := h.db.GetRev(h.ctx(), docid, revid, true, nil)
 	if err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ func (h *handler) handleGetAttachment() error {
 	docid := h.PathVar("docid")
 	attachmentName := h.PathVar("attach")
 	revid := h.getQuery("rev")
-	rev, err := h.db.GetRev(docid, revid, false, nil)
+	rev, err := h.db.GetRev(h.ctx(), docid, revid, false, nil)
 	if err != nil {
 		return err
 	}
@@ -310,7 +310,7 @@ func (h *handler) handlePutAttachment() error {
 		return err
 	}
 
-	body, err := h.db.Get1xRevBody(docid, revid, false, nil)
+	body, err := h.db.Get1xRevBody(h.ctx(), docid, revid, false, nil)
 	if err != nil {
 		if base.IsDocNotFoundError(err) {
 			// couchdb creates empty body on attachment PUT
@@ -342,7 +342,7 @@ func (h *handler) handlePutAttachment() error {
 	attachments[attachmentName] = attachment
 	body[db.BodyAttachments] = attachments
 
-	newRev, _, err := h.db.Put(docid, body)
+	newRev, _, err := h.db.Put(h.ctx(), docid, body)
 	if err != nil {
 		return err
 	}
@@ -400,7 +400,7 @@ func (h *handler) handlePutDoc() error {
 			return base.HTTPErrorf(http.StatusBadRequest, "Revision IDs provided do not match")
 		}
 
-		newRev, doc, err = h.db.Put(docid, body)
+		newRev, doc, err = h.db.Put(h.ctx(), docid, body)
 		if err != nil {
 			return err
 		}
@@ -411,7 +411,7 @@ func (h *handler) handlePutDoc() error {
 		if revisions == nil {
 			return base.HTTPErrorf(http.StatusBadRequest, "Bad _revisions")
 		}
-		doc, newRev, err = h.db.PutExistingRevWithBody(docid, body, revisions, false)
+		doc, newRev, err = h.db.PutExistingRevWithBody(h.ctx(), docid, body, revisions, false)
 		if err != nil {
 			return err
 		}
@@ -488,7 +488,7 @@ func (h *handler) handlePutDocReplicator2(docid string, roundTrip bool) (err err
 		newDoc.UpdateBody(body)
 	}
 
-	doc, rev, err := h.db.PutExistingRev(newDoc, history, true, false, nil)
+	doc, rev, err := h.db.PutExistingRev(h.ctx(), newDoc, history, true, false, nil)
 
 	if err != nil {
 		return err
@@ -516,7 +516,7 @@ func (h *handler) handlePostDoc() error {
 		return err
 	}
 
-	docid, newRev, doc, err := h.db.Post(body)
+	docid, newRev, doc, err := h.db.Post(h.ctx(), body)
 	if err != nil {
 		return err
 	}
@@ -541,7 +541,7 @@ func (h *handler) handleDeleteDoc() error {
 	if revid == "" {
 		revid = h.rq.Header.Get("If-Match")
 	}
-	newRev, err := h.db.DeleteDoc(docid, revid)
+	newRev, err := h.db.DeleteDoc(h.ctx(), docid, revid)
 	if err == nil {
 		h.writeRawJSONStatus(http.StatusOK, []byte(`{"id":`+base.ConvertToJSONString(docid)+`,"ok":true,"rev":"`+newRev+`"}`))
 	}

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -93,7 +93,7 @@ func (h *handler) handleGetDoc() error {
 		if h.requestAccepts("multipart/") && (hasBodies || !h.requestAccepts("application/json")) {
 			canCompress := strings.Contains(h.rq.Header.Get("X-Accept-Part-Encoding"), "gzip")
 			return h.writeMultipart("related", func(writer *multipart.Writer) error {
-				WriteMultipartDocument(h.rq.Context(), h.db.DatabaseContext.DbStats.CBLReplicationPull(), value, writer, canCompress)
+				WriteMultipartDocument(h.ctx(), h.db.DatabaseContext.DbStats.CBLReplicationPull(), value, writer, canCompress)
 				return nil
 			})
 		} else {
@@ -128,7 +128,7 @@ func (h *handler) handleGetDoc() error {
 					if err != nil {
 						revBody = db.Body{"missing": revid} // TODO: More specific error
 					}
-					_ = WriteRevisionAsPart(h.rq.Context(), h.db.DatabaseContext.DbStats.CBLReplicationPull(), revBody, err != nil, false, writer)
+					_ = WriteRevisionAsPart(h.ctx(), h.db.DatabaseContext.DbStats.CBLReplicationPull(), revBody, err != nil, false, writer)
 					h.db.DbStats.Database().NumDocReadsRest.Add(1)
 				}
 				return nil
@@ -418,7 +418,7 @@ func (h *handler) handlePutDoc() error {
 	}
 
 	if doc != nil && roundTrip {
-		if err := h.db.WaitForSequenceNotSkipped(h.rq.Context(), doc.Sequence); err != nil {
+		if err := h.db.WaitForSequenceNotSkipped(h.ctx(), doc.Sequence); err != nil {
 			return err
 		}
 	}
@@ -495,7 +495,7 @@ func (h *handler) handlePutDocReplicator2(docid string, roundTrip bool) (err err
 	}
 
 	if doc != nil && roundTrip {
-		if err := h.db.WaitForSequenceNotSkipped(h.rq.Context(), doc.Sequence); err != nil {
+		if err := h.db.WaitForSequenceNotSkipped(h.ctx(), doc.Sequence); err != nil {
 			return err
 		}
 	}
@@ -522,7 +522,7 @@ func (h *handler) handlePostDoc() error {
 	}
 
 	if doc != nil && roundTrip {
-		err := h.db.WaitForSequenceNotSkipped(h.rq.Context(), doc.Sequence)
+		err := h.db.WaitForSequenceNotSkipped(h.ctx(), doc.Sequence)
 		if err != nil {
 			return err
 		}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -453,7 +453,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 	// Now set the request's Database (i.e. context + user)
 	if dbContext != nil {
 		h.keyspaceScope, h.keyspaceCollection = *keyspaceScope, *keyspaceCollection
-		h.db, err = db.GetDatabase(h.ctx(), dbContext, h.user)
+		h.db, err = db.GetDatabase(dbContext, h.user)
 		if err != nil {
 			return err
 		}
@@ -1208,7 +1208,7 @@ func (h *handler) writeError(err error) {
 		if status >= 500 {
 			// Log additional context when the handler has a database reference
 			if h.db != nil {
-				base.ErrorfCtx(h.db.Ctx, "%s: %v", h.formatSerialNumber(), err)
+				base.ErrorfCtx(h.ctx(), "%s: %v", h.formatSerialNumber(), err)
 			} else {
 				base.ErrorfCtx(h.ctx(), "%s: %v", h.formatSerialNumber(), err)
 			}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -166,9 +166,6 @@ func newHandler(server *ServerContext, privs handlerPrivs, r http.ResponseWriter
 	}
 
 	h.rqCtx = base.LogContextWith(h.rq.Context(), &base.LogContext{CorrelationID: h.formatSerialNumber()})
-	if h.server != nil && h.server.config != nil && h.server.config.Bootstrap.ConfigGroupID != "" {
-		h.rqCtx = base.LogContextWith(h.rqCtx, &base.ServerLogContext{})
-	}
 
 	return h
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -167,7 +167,7 @@ func newHandler(server *ServerContext, privs handlerPrivs, r http.ResponseWriter
 
 	h.rqCtx = base.LogContextWith(h.rq.Context(), &base.LogContext{CorrelationID: h.formatSerialNumber()})
 	if h.server != nil && h.server.config != nil && h.server.config.Bootstrap.ConfigGroupID != "" {
-		h.rqCtx = base.LogContextWith(h.rqCtx, &base.ServerLogContext{ConfigGroupID: h.server.config.Bootstrap.ConfigGroupID})
+		h.rqCtx = base.LogContextWith(h.rqCtx, &base.ServerLogContext{})
 	}
 
 	return h

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -396,7 +396,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 		var authScope string
 
 		if dbContext != nil {
-			managementEndpoints, httpClient, err = dbContext.ObtainManagementEndpointsAndHTTPClient()
+			managementEndpoints, httpClient, err = dbContext.ObtainManagementEndpointsAndHTTPClient(h.ctx())
 			authScope = dbContext.Bucket.GetName()
 		} else {
 			managementEndpoints, httpClient, err = h.server.ObtainManagementEndpointsAndHTTPClient()

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -165,7 +165,8 @@ func newHandler(server *ServerContext, privs handlerPrivs, r http.ResponseWriter
 		runOffline:   runOffline,
 	}
 
-	h.rqCtx = base.LogContextWith(h.rq.Context(), &base.LogContext{CorrelationID: h.formatSerialNumber()})
+	// initialize h.rqCtx
+	_ = h.ctx()
 
 	return h
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -456,11 +456,10 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 	// Now set the request's Database (i.e. context + user)
 	if dbContext != nil {
 		h.keyspaceScope, h.keyspaceCollection = *keyspaceScope, *keyspaceCollection
-		h.db, err = db.GetDatabase(dbContext, h.user)
+		h.db, err = db.GetDatabase(h.ctx(), dbContext, h.user)
 		if err != nil {
 			return err
 		}
-		h.db.Ctx = h.ctx()
 	}
 
 	return method(h) // Call the actual handler code

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -269,7 +269,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 	var dbContext *db.DatabaseContext
 	if keyspaceDb != "" {
 		h.addDatabaseLogContext(keyspaceDb)
-		if dbContext, err = h.server.GetDatabase(keyspaceDb); err != nil {
+		if dbContext, err = h.server.GetDatabase(h.ctx(), keyspaceDb); err != nil {
 			base.InfofCtx(h.ctx(), base.KeyHTTP, "Error trying to get db %s: %v", base.MD(keyspaceDb), err)
 
 			if shouldCheckAdminAuth {

--- a/rest/handler_config_database.go
+++ b/rest/handler_config_database.go
@@ -26,7 +26,7 @@ func (h *handler) getDBConfig() (config *DbConfig, etagVersion string, err error
 			return &dbConfig.DbConfig, etagVersion, nil
 		}
 		return nil, "", nil
-	} else if found, databaseConfig, err := h.server.fetchDatabase(h.db.Name); err != nil {
+	} else if found, databaseConfig, err := h.server.fetchDatabase(h.ctx(), h.db.Name); err != nil {
 		return nil, "", err
 	} else if !found {
 		return nil, "", base.HTTPErrorf(http.StatusNotFound, "database config not found")
@@ -91,7 +91,7 @@ func (h *handler) mutateDbConfig(mutator func(*DbConfig) error) error {
 		defer h.server.lock.Unlock()
 
 		// TODO: Dynamic update instead of reload
-		if err := h.server._reloadDatabaseWithConfig(*updatedDbConfig, false); err != nil {
+		if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
 			return err
 		}
 		h.setEtag(updatedDbConfig.Version)

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -163,7 +163,7 @@ func TestXattrImportOldDocRevHistory(t *testing.T) {
 
 	// Get db.Database to perform PurgeOldRevisionJSON
 	dbc := rt.GetDatabase()
-	database, err := db.GetDatabase(dbc, nil)
+	database, err := db.GetDatabase(rt.Context(), dbc, nil)
 	assert.NoError(t, err)
 
 	for i := 0; i < 10; i++ {

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -163,13 +163,14 @@ func TestXattrImportOldDocRevHistory(t *testing.T) {
 
 	// Get db.Database to perform PurgeOldRevisionJSON
 	dbc := rt.GetDatabase()
-	database, err := db.GetDatabase(rt.Context(), dbc, nil)
+	database, err := db.GetDatabase(dbc, nil)
 	assert.NoError(t, err)
 
+	ctx := rt.Context()
 	for i := 0; i < 10; i++ {
 		updateResponse := rt.updateDoc(docID, revID, fmt.Sprintf(`{"val":%d}`, i))
 		// Purge old revision JSON to simulate expiry, and to verify import doesn't attempt multiple retrievals
-		purgeErr := database.PurgeOldRevisionJSON(docID, revID)
+		purgeErr := database.PurgeOldRevisionJSON(ctx, docID, revID)
 		assert.NoError(t, purgeErr)
 		revID = updateResponse.Rev
 	}

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -2051,7 +2051,7 @@ func TestDcpBackfill(t *testing.T) {
 	}
 	assert.True(t, backfillComplete, fmt.Sprintf("Backfill didn't complete after 20s. Latest: %d/%d", completedBackfill, expectedBackfill))
 
-	log.Printf("done...%s  (%d/%d)", newRt.ServerContext().Database("db").Name, completedBackfill, expectedBackfill)
+	log.Printf("done...%s  (%d/%d)", newRt.ServerContext().Database(newRt.Context(), "db").Name, completedBackfill, expectedBackfill)
 
 }
 

--- a/rest/jwt_auth_test.go
+++ b/rest/jwt_auth_test.go
@@ -84,7 +84,7 @@ func TestLocalJWTAuthenticationE2E(t *testing.T) {
 			defer mockSyncGateway.Close()
 			mockSyncGatewayURL := mockSyncGateway.URL
 
-			authenticator := restTester.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+			authenticator := restTester.ServerContext().Database(restTester.Context(), "db").Authenticator(base.TestCtx(t))
 			if preExistingUser {
 				user, err := authenticator.RegisterNewUser(expectedUsername, "")
 				require.NoError(t, err, "Failed to create test user")

--- a/rest/main.go
+++ b/rest/main.go
@@ -45,23 +45,22 @@ func serverMain(ctx context.Context, osArgs []string) error {
 	}
 
 	if *disablePersistentConfig {
-		return legacyServerMain(osArgs, flagStartupConfig)
+		return legacyServerMain(ctx, osArgs, flagStartupConfig)
 	}
 
-	disablePersistentConfigFallback, err := serverMainPersistentConfig(fs, flagStartupConfig)
+	disablePersistentConfigFallback, err := serverMainPersistentConfig(ctx, fs, flagStartupConfig)
 	if disablePersistentConfigFallback {
-		return legacyServerMain(osArgs, flagStartupConfig)
+		return legacyServerMain(ctx, osArgs, flagStartupConfig)
 	}
 
 	return err
 }
 
 // serverMainPersistentConfig runs the Sync Gateway server with persistent config.
-func serverMainPersistentConfig(fs *flag.FlagSet, flagStartupConfig *StartupConfig) (disablePersistentConfigFallback bool, err error) {
+func serverMainPersistentConfig(ctx context.Context, fs *flag.FlagSet, flagStartupConfig *StartupConfig) (disablePersistentConfigFallback bool, err error) {
 
 	sc := DefaultStartupConfig(defaultLogFilePath)
-	logCtx := context.Background()
-	base.TracefCtx(logCtx, base.KeyAll, "default config: %#v", sc)
+	base.TracefCtx(ctx, base.KeyAll, "default config: %#v", sc)
 
 	configPath := fs.Args()
 	if len(configPath) > 1 {
@@ -77,7 +76,7 @@ func serverMainPersistentConfig(fs *flag.FlagSet, flagStartupConfig *StartupConf
 			// If we have an unknown field error processing config its possible that the config is a 2.x config
 			// requiring automatic upgrade. We should attempt to perform this upgrade
 
-			base.InfofCtx(logCtx, base.KeyAll, "Found unknown fields in startup config. Attempting to read as legacy config.")
+			base.InfofCtx(ctx, base.KeyAll, "Found unknown fields in startup config. Attempting to read as legacy config.")
 
 			var upgradeError error
 			fileStartupConfig, disablePersistentConfigFallback, legacyDbUsers, legacyDbRoles, upgradeError = automaticConfigUpgrade(configPath[0])
@@ -87,8 +86,8 @@ func serverMainPersistentConfig(fs *flag.FlagSet, flagStartupConfig *StartupConf
 				// the config is actually a 3.x config but with a genuine unknown field, therefore we should  return the
 				// original error from LoadStartupConfigFromPath.
 				if pkgerrors.Cause(upgradeError) == base.ErrUnknownField {
-					base.WarnfCtx(logCtx, "Automatic upgrade attempt failed, %s not recognized as legacy config format: %v", base.MD(configPath[0]), upgradeError)
-					base.WarnfCtx(logCtx, "Provided config %s not recognized as bootstrap config format: %v", base.MD(configPath[0]), err)
+					base.WarnfCtx(ctx, "Automatic upgrade attempt failed, %s not recognized as legacy config format: %v", base.MD(configPath[0]), upgradeError)
+					base.WarnfCtx(ctx, "Provided config %s not recognized as bootstrap config format: %v", base.MD(configPath[0]), err)
 					return false, fmt.Errorf("unknown config fields supplied. Unable to continue")
 				}
 
@@ -107,7 +106,7 @@ func serverMainPersistentConfig(fs *flag.FlagSet, flagStartupConfig *StartupConf
 			if err != nil {
 				return false, err
 			}
-			base.TracefCtx(logCtx, base.KeyAll, "got config from file: %#v", redactedConfig)
+			base.TracefCtx(ctx, base.KeyAll, "got config from file: %#v", redactedConfig)
 			err = sc.Merge(fileStartupConfig)
 			if err != nil {
 				return false, err
@@ -117,7 +116,7 @@ func serverMainPersistentConfig(fs *flag.FlagSet, flagStartupConfig *StartupConf
 
 	// merge flagStartupConfig on top of fileStartupConfig, because flags take precedence over config files.
 	if flagStartupConfig != nil {
-		base.TracefCtx(logCtx, base.KeyAll, "got config from flags: %#v", flagStartupConfig)
+		base.TracefCtx(ctx, base.KeyAll, "got config from flags: %#v", flagStartupConfig)
 		err := sc.Merge(flagStartupConfig)
 		if err != nil {
 			return false, err
@@ -128,24 +127,25 @@ func serverMainPersistentConfig(fs *flag.FlagSet, flagStartupConfig *StartupConf
 	if err != nil {
 		return false, err
 	}
-	base.TracefCtx(logCtx, base.KeyAll, "final config: %#v", redactedConfig)
+	base.TracefCtx(ctx, base.KeyAll, "final config: %#v", redactedConfig)
 
 	initialStartupConfig, err := getInitialStartupConfig(fileStartupConfig, flagStartupConfig)
 	if err != nil {
 		return false, err
 	}
 
-	base.InfofCtx(logCtx, base.KeyAll, "Config: Starting in persistent mode using config group %q", sc.Bootstrap.ConfigGroupID)
-	ctx, err := setupServerContext(&sc, true)
+	base.InfofCtx(ctx, base.KeyAll, "Config: Starting in persistent mode using config group %q", sc.Bootstrap.ConfigGroupID)
+	svrctx, err := setupServerContext(ctx, &sc, true)
 	if err != nil {
 		return false, err
 	}
+	ctx = svrctx.AddServerLogContext(ctx)
 
-	ctx.initialStartupConfig = initialStartupConfig
+	svrctx.initialStartupConfig = initialStartupConfig
 
-	ctx.addLegacyPrincipals(legacyDbUsers, legacyDbRoles)
+	svrctx.addLegacyPrincipals(ctx, legacyDbUsers, legacyDbRoles)
 
-	return false, startServer(&sc, ctx)
+	return false, startServer(ctx, &sc, svrctx)
 }
 
 func getInitialStartupConfig(fileStartupConfig *StartupConfig, flagStartupConfig *StartupConfig) (*StartupConfig, error) {

--- a/rest/main.go
+++ b/rest/main.go
@@ -29,7 +29,7 @@ func ServerMain() {
 
 // TODO: Pass ctx down into HTTP servers so that serverMain can be stopped.
 func serverMain(ctx context.Context, osArgs []string) error {
-	RegisterSignalHandler()
+	RegisterSignalHandler(ctx)
 	defer base.FatalPanicHandler()
 
 	base.InitializeMemoryLoggers()

--- a/rest/main.go
+++ b/rest/main.go
@@ -139,7 +139,6 @@ func serverMainPersistentConfig(ctx context.Context, fs *flag.FlagSet, flagStart
 	if err != nil {
 		return false, err
 	}
-	ctx = svrctx.AddServerLogContext(ctx)
 
 	svrctx.initialStartupConfig = initialStartupConfig
 

--- a/rest/main_legacy.go
+++ b/rest/main_legacy.go
@@ -52,7 +52,6 @@ func legacyServerMain(ctx context.Context, osArgs []string, flagStartupConfig *S
 	if err != nil {
 		return err
 	}
-	ctx = svrctx.AddServerLogContext(ctx)
 
 	svrctx.initialStartupConfig = initialStartupConfig
 

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -95,7 +95,7 @@ func (h *handler) handleOIDCCommon() (redirectURLString string, err error) {
 		return redirectURLString, err
 	}
 
-	client, err := provider.GetClient(h.db.Ctx, h.getOIDCCallbackURL)
+	client, err := provider.GetClient(h.ctx(), h.getOIDCCallbackURL)
 	if err != nil {
 		return redirectURLString, base.HTTPErrorf(
 			http.StatusInternalServerError, fmt.Sprintf("Unable to obtain client for provider: %s - %v", providerName, err))
@@ -171,7 +171,7 @@ func (h *handler) handleOIDCCallback() error {
 		http.SetCookie(h.response, stateCookie)
 	}
 
-	client, err := provider.GetClient(h.db.Ctx, h.getOIDCCallbackURL)
+	client, err := provider.GetClient(h.ctx(), h.getOIDCCallbackURL)
 	if err != nil {
 		return fmt.Errorf("OIDC initialization error: %w", err)
 	}
@@ -224,7 +224,7 @@ func (h *handler) handleOIDCRefresh() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Unable to identify provider for callback request")
 	}
 
-	client, err := provider.GetClient(h.db.Ctx, h.getOIDCCallbackURL)
+	client, err := provider.GetClient(h.ctx(), h.getOIDCCallbackURL)
 	if err != nil {
 		return fmt.Errorf("OIDC initialization error: %w", err)
 	}
@@ -264,7 +264,7 @@ func (h *handler) handleOIDCRefresh() error {
 }
 
 func (h *handler) createSessionForTrustedIdToken(rawIDToken string, provider *auth.OIDCProvider) (username string, sessionID string, err error) {
-	user, updates, tokenExpiryTime, err := h.db.Authenticator(h.db.Ctx).AuthenticateTrustedJWT(rawIDToken, provider, h.getOIDCCallbackURL)
+	user, updates, tokenExpiryTime, err := h.db.Authenticator(h.ctx()).AuthenticateTrustedJWT(rawIDToken, provider, h.getOIDCCallbackURL)
 	if err != nil {
 		return "", "", err
 	}

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -2318,7 +2318,6 @@ func TestOpenIDConnectProviderRemoval(t *testing.T) {
 	startupConfig := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(ctx, &startupConfig, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
 	serverErr := make(chan error, 0)
 	go func() {
 		serverErr <- startServer(ctx, &startupConfig, sc)

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -2316,13 +2316,14 @@ func TestOpenIDConnectProviderRemoval(t *testing.T) {
 	startupConfig := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&startupConfig, true)
 	require.NoError(t, err)
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 	serverErr := make(chan error, 0)
 	go func() {
 		serverErr <- startServer(&startupConfig, sc)
 	}()
 	require.NoError(t, sc.waitForRESTAPIs())
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -1116,10 +1116,11 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 
+	ctx := restTester.Context()
 	mockSyncGateway := httptest.NewServer(restTester.TestPublicHandler())
 	defer mockSyncGateway.Close()
 	mockSyncGatewayURL := mockSyncGateway.URL
-	authenticator := restTester.ServerContext().Database("db").Authenticator(base.TestCtx(t))
+	authenticator := restTester.ServerContext().Database(ctx, "db").Authenticator(base.TestCtx(t))
 
 	sendAuthRequest := func(claimSet claimSet) (*http.Response, error) {
 		token, err := mockAuthServer.makeToken(claimSet)
@@ -1194,7 +1195,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		runGoodAuthTest(claimSet, username)
 
 		// Bad email shouldn't not be saved on successful authentication.
-		user, err := restTester.ServerContext().Database("db").Authenticator(base.TestCtx(t)).GetUser("foo_noah")
+		user, err := restTester.ServerContext().Database(ctx, "db").Authenticator(base.TestCtx(t)).GetUser("foo_noah")
 		require.NoError(t, err, "Error getting user from db")
 		assert.Equal(t, username, user.Name())
 		assert.Empty(t, user.Email(), "Bad email shouldn't be saved")
@@ -1208,7 +1209,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		runGoodAuthTest(claimSet, username)
 
 		// Bad email shouldn't not be saved on successful authentication.
-		user, err := restTester.ServerContext().Database("db").Authenticator(base.TestCtx(t)).GetUser(username)
+		user, err := restTester.ServerContext().Database(ctx, "db").Authenticator(base.TestCtx(t)).GetUser(username)
 		require.NoError(t, err, "Error getting user from db")
 		assert.Equal(t, username, user.Name())
 		assert.Equal(t, "foo_noah@couchbase.com", user.Email(), "Bad email shouldn't be saved")
@@ -1222,7 +1223,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		runGoodAuthTest(claimSet, username)
 
 		// Good email should be updated on successful authentication.
-		user, err := restTester.ServerContext().Database("db").Authenticator(base.TestCtx(t)).GetUser(username)
+		user, err := restTester.ServerContext().Database(ctx, "db").Authenticator(base.TestCtx(t)).GetUser(username)
 		require.NoError(t, err, "Error getting user from db")
 		assert.Equal(t, username, user.Name())
 		assert.Equal(t, "foo_noah@example.com", user.Email(), "Email is not updated")
@@ -2313,13 +2314,14 @@ func TestOpenIDConnectProviderRemoval(t *testing.T) {
 	mockAuthServer.options.issuer = mockAuthServer.URL + "/" + providerName
 	refreshProviderConfig(providers, mockAuthServer.URL)
 
+	ctx := base.TestCtx(t)
 	startupConfig := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(&startupConfig, true)
+	sc, err := setupServerContext(ctx, &startupConfig, true)
 	require.NoError(t, err)
-	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
+	ctx = sc.AddServerLogContext(ctx)
 	serverErr := make(chan error, 0)
 	go func() {
-		serverErr <- startServer(&startupConfig, sc)
+		serverErr <- startServer(ctx, &startupConfig, sc)
 	}()
 	require.NoError(t, sc.waitForRESTAPIs())
 	defer func() {

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -296,7 +296,6 @@ func TestImportFilterEndpoint(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
 	defer func() {
 		sc.Close(ctx)
 		require.NoError(t, <-serverErr)

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -292,17 +292,18 @@ func TestImportFilterEndpoint(t *testing.T) {
 	serverErr := make(chan error, 0)
 
 	// Start SG with no databases
+	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(&config, true)
+	sc, err := setupServerContext(ctx, &config, true)
 	require.NoError(t, err)
-	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
+	ctx = sc.AddServerLogContext(ctx)
 	defer func() {
 		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
 	go func() {
-		serverErr <- startServer(&config, sc)
+		serverErr <- startServer(ctx, &config, sc)
 	}()
 	require.NoError(t, sc.waitForRESTAPIs())
 

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -295,8 +295,9 @@ func TestImportFilterEndpoint(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	ctx := base.LogContextWith(base.TestCtx(t), &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
 	defer func() {
-		sc.Close()
+		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -3014,9 +3014,9 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	err = rt2.Bucket().Set(checkpointDocID, 0, nil, firstCheckpoint)
 	assert.NoError(t, err)
 
-	rt2db, err := db.GetDatabase(ctx2, rt2.GetDatabase(), nil)
+	rt2db, err := db.GetDatabase(rt2.GetDatabase(), nil)
 	require.NoError(t, err)
-	err = rt2db.Purge(docID + "2")
+	err = rt2db.Purge(ctx2, docID+"2")
 	assert.NoError(t, err)
 
 	require.NoError(t, rt2.GetDatabase().FlushChannelCache(ctx2))

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -22,7 +22,7 @@ type RestTesterCluster struct {
 // RefreshClusterDbConfigs will synchronously fetch the latest db configs from each bucket for each RestTester.
 func (rtc *RestTesterCluster) RefreshClusterDbConfigs() (count int, err error) {
 	for _, rt := range rtc.restTesters {
-		c, err := rt.ServerContext().fetchAndLoadConfigs(false)
+		c, err := rt.ServerContext().fetchAndLoadConfigs(rt.Context(), false)
 		if err != nil {
 			return 0, err
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -122,7 +122,7 @@ func NewServerContext(ctx context.Context, config *StartupConfig, persistentConf
 	}
 
 	ctx = sc.AddServerLogContext(ctx) // add server log info before passing donwn
-	sc.startStatsLogger(ctx)
+	sc.startStatsLogger(ctx)          // TODO: move to setupServerContext ?
 
 	return sc
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1580,7 +1580,7 @@ func (sc *ServerContext) initializeCouchbaseServerConnections(ctx context.Contex
 
 func (sc *ServerContext) AddServerLogContext(ctx context.Context) context.Context {
 	if sc != nil && sc.config != nil && sc.config.Bootstrap.ConfigGroupID != "" {
-		return base.LogContextWith(ctx, &base.ServerLogContext{ConfigGroupID: sc.config.Bootstrap.ConfigGroupID})
+		return base.LogContextWith(ctx, &base.ServerLogContext{})
 	}
 	return ctx
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -596,7 +596,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "online", "DB loaded from config", &sc.config.API.AdminInterface)
 	}
 
-	dbcontext.StartReplications()
+	dbcontext.StartReplications(ctx)
 
 	return dbcontext, nil
 }

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -118,7 +118,6 @@ func TestAllDatabaseNames(t *testing.T) {
 		Bootstrap: BootstrapConfig{UseTLSServer: base.BoolPtr(base.ServerIsTLS(base.UnitTestUrl())), ServerTLSSkipVerify: base.BoolPtr(base.TestTLSSkipVerify())},
 		API:       APIConfig{CORS: &CORSConfig{}, AdminInterface: DefaultAdminInterface}}
 	serverContext := NewServerContext(ctx, serverConfig, false)
-	ctx = serverContext.AddServerLogContext(ctx)
 	defer serverContext.Close(ctx)
 
 	xattrs := base.TestUseXattrs()
@@ -161,7 +160,6 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 	ctx := base.TestCtx(t)
 	serverConfig := &StartupConfig{API: APIConfig{CORS: &CORSConfig{}, AdminInterface: DefaultAdminInterface}}
 	serverContext := NewServerContext(ctx, serverConfig, false)
-	ctx = serverContext.AddServerLogContext(ctx)
 	defer serverContext.Close(ctx)
 
 	oldRevExpirySeconds := uint32(600)
@@ -236,7 +234,6 @@ func TestStatsLoggerStopped(t *testing.T) {
 	// Start up stats logger by creating server context
 	ctx := base.TestCtx(t)
 	svrctx := NewServerContext(ctx, &sc, false)
-	ctx = svrctx.AddServerLogContext(ctx)
 
 	// Close server context which will send signal to close stats logger
 	svrctx.Close(ctx)
@@ -305,7 +302,6 @@ func TestObtainManagementEndpointsFromServerContextWithX509(t *testing.T) {
 			CACertPath:   caCertPath,
 		},
 	}, false)
-	ctx = svrctx.AddServerLogContext(ctx)
 	svrctx.Close(ctx)
 
 	goCBAgent, err := svrctx.initializeGoCBAgent(ctx)
@@ -363,7 +359,6 @@ func TestStartAndStopHTTPServers(t *testing.T) {
 	ctx := base.TestCtx(t)
 	sc, err := setupServerContext(ctx, &config, false)
 	require.NoError(t, err)
-	ctx = sc.AddServerLogContext(ctx)
 
 	serveErr := make(chan error, 0)
 	go func() {

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -589,6 +589,7 @@ func TestServerContextSetupCollectionsSupport(t *testing.T) {
 		t.Skip("Only runs on datastores without collections support")
 	}
 
+	ctx := base.TestCtx(t)
 	serverConfig := &StartupConfig{
 		Bootstrap: BootstrapConfig{
 			UseTLSServer:        base.BoolPtr(base.ServerIsTLS(base.UnitTestUrl())),
@@ -596,8 +597,8 @@ func TestServerContextSetupCollectionsSupport(t *testing.T) {
 		},
 		API: APIConfig{CORS: &CORSConfig{}, AdminInterface: DefaultAdminInterface},
 	}
-	serverContext := NewServerContext(serverConfig, false)
-	defer serverContext.Close()
+	serverContext := NewServerContext(ctx, serverConfig, false)
+	defer serverContext.Close(ctx)
 
 	dbConfig := DbConfig{
 		BucketConfig: BucketConfig{
@@ -617,7 +618,7 @@ func TestServerContextSetupCollectionsSupport(t *testing.T) {
 			},
 		},
 	}
-	_, err := serverContext._getOrAddDatabaseFromConfig(DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(true))
+	_, err := serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(true))
 	require.ErrorIs(t, err, errCollectionsUnsupported)
 }
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -215,22 +215,14 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 		AutoImport:          false,
 	}
 
-<<<<<<< HEAD
-	dbContext, err = serverContext._getOrAddDatabaseFromConfig(DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(false))
-=======
-	dbContext, err = serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, false, false)
->>>>>>> 270f801b (CBG-2314: svr ctx tests pt 2)
+	dbContext, err = serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(false))
 	assert.Nil(t, dbContext, "Can't create database context with duplicate database name")
 	assert.Error(t, err, "It should throw 412 Duplicate database names")
 	assert.Contains(t, err.Error(), strconv.Itoa(http.StatusPreconditionFailed))
 
 	// Get or add database from config with duplicate database name and useExisting as true
 	// Existing database context should be returned
-<<<<<<< HEAD
-	dbContext, err = serverContext._getOrAddDatabaseFromConfig(DatabaseConfig{DbConfig: dbConfig}, true, db.GetConnectToBucketFn(false))
-=======
-	dbContext, err = serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, true, false)
->>>>>>> 270f801b (CBG-2314: svr ctx tests pt 2)
+	dbContext, err = serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, true, db.GetConnectToBucketFn(false))
 	assert.NoError(t, err, "No error while trying to get the existing database name")
 	assert.Equal(t, server, dbContext.BucketSpec.Server)
 	assert.Equal(t, bucketName, dbContext.BucketSpec.BucketName)

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -325,7 +325,7 @@ func TestUserAPI(t *testing.T) {
 	assert.Equal(t, `["snej"]`, string(response.Body.Bytes()))
 
 	// Check that the actual User object is correct:
-	user, _ := rt.ServerContext().Database(ctx, "db").Authenticator(base.TestCtx(t)).GetUser("snej")
+	user, _ := rt.ServerContext().Database(ctx, "db").Authenticator(ctx).GetUser("snej")
 	assert.Equal(t, "snej", user.Name())
 	assert.Equal(t, "jens@couchbase.com", user.Email())
 	assert.Equal(t, channels.TimedSet{"bar": channels.NewVbSimpleSequence(0x1), "foo": channels.NewVbSimpleSequence(0x1)}, user.ExplicitChannels())
@@ -335,7 +335,7 @@ func TestUserAPI(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"123", "admin_channels":["foo", "bar"]}`)
 	requireStatus(t, response, 200)
 
-	user, _ = rt.ServerContext().Database(ctx, "db").Authenticator(base.TestCtx(t)).GetUser("snej")
+	user, _ = rt.ServerContext().Database(ctx, "db").Authenticator(ctx).GetUser("snej")
 	assert.True(t, user.Authenticate("123"))
 
 	// DELETE the user

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -302,6 +302,7 @@ func TestUserAPI(t *testing.T) {
 	// PUT a user
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
+	ctx := rt.Context()
 
 	requireStatus(t, rt.SendAdminRequest("GET", "/db/_user/snej", ""), 404)
 	response := rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"letmein", "admin_channels":["foo", "bar"]}`)
@@ -324,7 +325,7 @@ func TestUserAPI(t *testing.T) {
 	assert.Equal(t, `["snej"]`, string(response.Body.Bytes()))
 
 	// Check that the actual User object is correct:
-	user, _ := rt.ServerContext().Database("db").Authenticator(base.TestCtx(t)).GetUser("snej")
+	user, _ := rt.ServerContext().Database(ctx, "db").Authenticator(base.TestCtx(t)).GetUser("snej")
 	assert.Equal(t, "snej", user.Name())
 	assert.Equal(t, "jens@couchbase.com", user.Email())
 	assert.Equal(t, channels.TimedSet{"bar": channels.NewVbSimpleSequence(0x1), "foo": channels.NewVbSimpleSequence(0x1)}, user.ExplicitChannels())
@@ -334,7 +335,7 @@ func TestUserAPI(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"123", "admin_channels":["foo", "bar"]}`)
 	requireStatus(t, response, 200)
 
-	user, _ = rt.ServerContext().Database("db").Authenticator(base.TestCtx(t)).GetUser("snej")
+	user, _ = rt.ServerContext().Database(ctx, "db").Authenticator(base.TestCtx(t)).GetUser("snej")
 	assert.True(t, user.Authenticate("123"))
 
 	// DELETE the user

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -441,7 +441,7 @@ func (rt *RestTester) Close() {
 	}
 	rt.closed = true
 	if rt.RestTesterServerContext != nil {
-		rt.RestTesterServerContext.Close(base.TestCtx(rt.tb))
+		rt.RestTesterServerContext.Close(rt.Context())
 	}
 	if rt.testBucket != nil {
 		rt.testBucket.Close()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -441,7 +441,7 @@ func (rt *RestTester) Close() {
 	}
 	rt.closed = true
 	if rt.RestTesterServerContext != nil {
-		rt.RestTesterServerContext.Close(rt.Context())
+		rt.RestTesterServerContext.Close(base.TestCtx(rt.tb))
 	}
 	if rt.testBucket != nil {
 		rt.testBucket.Close()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -437,7 +437,7 @@ func (rt *RestTester) Close() {
 	}
 	rt.closed = true
 	if rt.RestTesterServerContext != nil {
-		rt.RestTesterServerContext.Close()
+		rt.RestTesterServerContext.Close(base.TestCtx(rt.tb))
 	}
 	if rt.testBucket != nil {
 		rt.testBucket.Close()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -955,7 +955,7 @@ func (s *SlowResponseRecorder) Write(buf []byte) (int, error) {
 // AddDatabaseFromConfigWithBucket adds a database to the ServerContext and sets a specific bucket on the database context.
 // If an existing config is found for the name, returns an error.
 func (sc *ServerContext) AddDatabaseFromConfigWithBucket(ctx context.Context, tb testing.TB, config DatabaseConfig, bucket base.Bucket) (*db.DatabaseContext, error) {
-	return sc.getOrAddDatabaseFromConfig(ctx, config, false, func(spec base.BucketSpec) (base.Bucket, error) {
+	return sc.getOrAddDatabaseFromConfig(ctx, config, false, func(ctx context.Context, spec base.BucketSpec) (base.Bucket, error) {
 		return bucket, nil
 	})
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -193,7 +193,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 	// Post-validation, we can lower the bcrypt cost beyond SG limits to reduce test runtime.
 	sc.Auth.BcryptCost = bcrypt.MinCost
 
-	rt.RestTesterServerContext = NewServerContext(&sc, rt.RestTesterConfig.persistentConfig)
+	rt.RestTesterServerContext = NewServerContext(base.TestCtx(rt.tb), &sc, rt.RestTesterConfig.persistentConfig)
 	ctx := rt.Context()
 
 	if !base.ServerIsWalrus(sc.Bootstrap.Server) {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -238,7 +238,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 					scopes[scopeName] = append(scopes[scopeName], collName)
 				}
 			}
-			if err := base.CreateBucketScopesAndCollections(base.TestCtx(rt.tb), rt.testBucket.BucketSpec, scopes); err != nil {
+			if err := base.CreateBucketScopesAndCollections(ctx, rt.testBucket.BucketSpec, scopes); err != nil {
 				rt.tb.Fatalf("Error creating test scopes/collections: %v", err)
 			}
 		}
@@ -300,7 +300,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 		if err != nil {
 			rt.tb.Fatalf("Error from AddDatabaseFromConfig: %v", err)
 		}
-		ctx = rt.Context()
+		ctx = rt.Context() // get new ctx with db info before passing it down
 
 		// Update the testBucket Bucket to the one associated with the database context.  The new (dbContext) bucket
 		// will be closed when the rest tester closes the server context. The original bucket will be closed using the
@@ -659,7 +659,7 @@ func (rt *RestTester) WaitForNViewResults(numResultsExpected int, viewUrlPath st
 		// If the view is undefined, it might be a race condition where the view is still being created
 		// See https://github.com/couchbase/sync_gateway/issues/3570#issuecomment-390487982
 		if strings.Contains(response.Body.String(), "view_undefined") {
-			base.InfofCtx(response.Req.Context(), base.KeyAll, "view_undefined error: %v.  Retrying", response.Body.String())
+			base.InfofCtx(rt.Context(), base.KeyAll, "view_undefined error: %v.  Retrying", response.Body.String())
 			return true, nil, nil
 		}
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -439,9 +439,10 @@ func (rt *RestTester) Close() {
 	if rt.tb == nil {
 		panic("RestTester not properly initialized please use NewRestTester function")
 	}
+	ctx := rt.Context() // capture ctx before closing rt
 	rt.closed = true
 	if rt.RestTesterServerContext != nil {
-		rt.RestTesterServerContext.Close(base.TestCtx(rt.tb))
+		rt.RestTesterServerContext.Close(ctx)
 	}
 	if rt.testBucket != nil {
 		rt.testBucket.Close()

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -189,7 +189,7 @@ func TestViewQueryUserAccess(t *testing.T) {
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc2", Key: "state2", Value: "doc2"}, result.Rows[1])
 
 	// Create a user:
-	a := rt.ServerContext().Database(ctx, "db").Authenticator(base.TestCtx(t))
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	password := "123456"
 	testUser, _ := a.NewUser("testUser", password, channels.SetOf(t, "*"))
 	assert.NoError(t, a.Save(testUser))
@@ -703,7 +703,7 @@ func TestViewQueryWrappers(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 3, result.Len())
 
-	a := rt.ServerContext().Database(ctx, "db").Authenticator(base.TestCtx(t))
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	testUser, err := a.NewUser("testUser", "password", channels.SetOf(t, "userchannel"))
 	assert.NoError(t, err)
 	err = a.Save(testUser)

--- a/rest/x509_test.go
+++ b/rest/x509_test.go
@@ -81,7 +81,7 @@ func TestX509UnknownAuthorityWrap(t *testing.T) {
 	sc.Bootstrap.Username = username
 	sc.Bootstrap.Password = password
 
-	_, err := initClusterAgent(sc.Bootstrap.Server, sc.Bootstrap.Username, sc.Bootstrap.Password,
+	_, err := initClusterAgent(base.TestCtx(t), sc.Bootstrap.Server, sc.Bootstrap.Username, sc.Bootstrap.Password,
 		sc.Bootstrap.X509CertPath, sc.Bootstrap.X509KeyPath, sc.Bootstrap.CACertPath, sc.Bootstrap.ServerTLSSkipVerify)
 	assert.Error(t, err)
 

--- a/rest/x509_test.go
+++ b/rest/x509_test.go
@@ -94,6 +94,7 @@ func TestAttachmentCompactionRun(t *testing.T) {
 
 	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb, useTLSServer: true})
 	defer rt.Close()
+	ctx := rt.Context()
 
 	for i := 0; i < 20; i++ {
 		docID := fmt.Sprintf("testDoc-%d", i)
@@ -101,7 +102,7 @@ func TestAttachmentCompactionRun(t *testing.T) {
 		attBody := map[string]interface{}{"value": strconv.Itoa(i)}
 		attJSONBody, err := base.JSONMarshal(attBody)
 		assert.NoError(t, err)
-		CreateLegacyAttachmentDoc(t, &db.Database{DatabaseContext: rt.GetDatabase()}, docID, []byte("{}"), attID, attJSONBody)
+		CreateLegacyAttachmentDoc(t, ctx, &db.Database{DatabaseContext: rt.GetDatabase()}, docID, []byte("{}"), attID, attJSONBody)
 	}
 
 	resp := rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")


### PR DESCRIPTION
CBG-2314

Describe your PR here...
- Added context in APIs for main, handler, ServerContext, DatabaseContext, and respective Tests.
- Removed Database.Ctx, replaced by ctx parameter.
- Removed CbgtContext.loggingCtx, replaced by ctx parameter.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/792/