### PR TITLE
Remove gocb/v1 tests

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -660,11 +660,6 @@ func ForAllDataStores(t *testing.T, testCallback func(*testing.T, sgbucket.DataS
 		})
 	}
 
-	dataStores = append(dataStores, dataStore{
-		name:   "gocb.v1",
-		driver: GoCBCustomSGTranscoder,
-	})
-
 	for _, dataStore := range dataStores {
 		t.Run(dataStore.name, func(t *testing.T) {
 			bucket := GetTestBucketForDriver(t, dataStore.driver)

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -653,12 +653,10 @@ type dataStore struct {
 func ForAllDataStores(t *testing.T, testCallback func(*testing.T, sgbucket.DataStore)) {
 	dataStores := make([]dataStore, 0)
 
-	if TestUseCouchbaseServer() {
-		dataStores = append(dataStores, dataStore{
-			name:   "gocb.v2",
-			driver: GoCBv2,
-		})
-	}
+	dataStores = append(dataStores, dataStore{
+		name:   "gocb.v2",
+		driver: GoCBv2,
+	})
 
 	for _, dataStore := range dataStores {
 		t.Run(dataStore.name, func(t *testing.T) {


### PR DESCRIPTION
This is a side effect of #5705 because I would have need to change `CouchbaseBucketGoCB.EscapedKeyspace()` like I did for `Collection.EscapedKeyspace()`.

`CouchbaseBucketGoCB` can not be used in collections, and I do not believe it is currently used. This test prevents GSI=true from working right now.
 
## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [x] Link upstream PRs
- [x] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
I don't have an integration test build because of other issues, but it passes the GSI base/db tests.
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/