### PR TITLE
CBG-2357 Move check for GetCollectionID based on server version

### DIFF
--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -49,7 +49,7 @@ func TestOneShotDCP(t *testing.T) {
 	collection, err := AsCollection(bucket)
 	require.NoError(t, err)
 	var collectionIDs []uint32
-	if collection.Spec.Scope != nil && collection.Spec.Collection != nil {
+	if collection.IsSupported(sgbucket.DataStoreFeatureCollections) {
 		collectionID, err := collection.GetCollectionID()
 		require.NoError(t, err)
 		collectionIDs = append(collectionIDs, collectionID)
@@ -213,7 +213,7 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 			collection, err := AsCollection(bucket)
 			require.NoError(t, err)
 			var collectionIDs []uint32
-			if collection.Spec.Scope != nil && collection.Spec.Collection != nil {
+			if collection.IsSupported(sgbucket.DataStoreFeatureCollections) {
 				collectionID, err := collection.GetCollectionID()
 				require.NoError(t, err)
 				collectionIDs = append(collectionIDs, collectionID)
@@ -341,7 +341,7 @@ func TestResumeStoppedFeed(t *testing.T) {
 	collection, err := AsCollection(bucket)
 	require.NoError(t, err)
 	var collectionIDs []uint32
-	if collection.Spec.Scope != nil && collection.Spec.Collection != nil {
+	if collection.IsSupported(sgbucket.DataStoreFeatureCollections) {
 		collectionID, err := collection.GetCollectionID()
 		require.NoError(t, err)
 		collectionIDs = append(collectionIDs, collectionID)

--- a/base/gocb_dcp_feed.go
+++ b/base/gocb_dcp_feed.go
@@ -50,7 +50,7 @@ func StartGocbDCPFeed(collection *Collection, bucketName string, args sgbucket.F
 		return err
 	}
 	var collectionIDs []uint32
-	if collection.Spec.Scope != nil && collection.Spec.Collection != nil {
+	if collection.IsSupported(sgbucket.DataStoreFeatureCollections) {
 		collectionID, err := collection.GetCollectionID()
 		if err != nil {
 			return err

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -541,7 +541,7 @@ func getCompactionIDSubDocPath(compactionID string) string {
 // getCompactionDCPClientOptions returns the default set of DCPClientOptions suitable for attachment compaction
 func getCompactionDCPClientOptions(collection *base.Collection, groupID string) (*base.DCPClientOptions, error) {
 	var collectionIDs []uint32
-	if collection.Spec.Scope != nil && collection.Spec.Collection != nil {
+	if collection.IsSupported(sgbucket.DataStoreFeatureCollections) {
 		collectionID, err := collection.GetCollectionID()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Moves check up a level, as we noticed in DCP we want to pass collectionID even on `_default._default`. It pushes logic of #5719 to callers.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/728/