### PR TITLE
Set import partitions to 1 in the rest tester

### DIFF
--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -250,7 +250,8 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 		rt.DatabaseConfig.SGReplicateEnabled = base.BoolPtr(rt.RestTesterConfig.sgReplicateEnabled)
 
-		if rt.DatabaseConfig.ImportPartitions == nil {
+		autoImport, _ := rt.DatabaseConfig.AutoImportEnabled()
+		if rt.DatabaseConfig.ImportPartitions == nil && base.TestUseXattrs() && base.IsEnterpriseEdition() && autoImport {
 			// Speed up test setup - most tests don't need more than one partition given we only have one node
 			rt.DatabaseConfig.ImportPartitions = base.Uint16Ptr(1)
 		}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -250,6 +250,8 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 		rt.DatabaseConfig.SGReplicateEnabled = base.BoolPtr(rt.RestTesterConfig.sgReplicateEnabled)
 
+		rt.DatabaseConfig.ImportPartitions = base.Uint16Ptr(1)
+
 		if rt.leakyBucketConfig != nil {
 			// Scopes and collections have to be set on the bucket being passed in for the db to use.
 			// WIP: Collections Phase 1 - Grab just one scope/collection from the defined set.

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -250,7 +250,10 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 		rt.DatabaseConfig.SGReplicateEnabled = base.BoolPtr(rt.RestTesterConfig.sgReplicateEnabled)
 
-		rt.DatabaseConfig.ImportPartitions = base.Uint16Ptr(1)
+		if rt.DatabaseConfig.ImportPartitions != nil {
+			// Speed up test setup - most tests don't need more than one partition given we only have one node
+			rt.DatabaseConfig.ImportPartitions = base.Uint16Ptr(1)
+		}
 
 		if rt.leakyBucketConfig != nil {
 			// Scopes and collections have to be set on the bucket being passed in for the db to use.

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -250,7 +250,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 		rt.DatabaseConfig.SGReplicateEnabled = base.BoolPtr(rt.RestTesterConfig.sgReplicateEnabled)
 
-		if rt.DatabaseConfig.ImportPartitions != nil {
+		if rt.DatabaseConfig.ImportPartitions == nil {
 			// Speed up test setup - most tests don't need more than one partition given we only have one node
 			rt.DatabaseConfig.ImportPartitions = base.Uint16Ptr(1)
 		}


### PR DESCRIPTION
Should speed up test setup - as far as I'm aware we don't need multiple partitions in most tests, and where we do we explicitly set it.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/759/
  * bucket flush timeout
- [x] `xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/758/