### PR TITLE
CBG-2247: Etags should be quoted

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -230,12 +230,7 @@ func (h *handler) handleGetDbConfig() error {
 			return base.HTTPErrorf(http.StatusNotFound, "database config not found")
 		}
 
-		quoteETag, err := h.setEtag(dbConfig.Version)
-		if err != nil {
-			return err
-		}
-		h.response.Header().Set("ETag", quoteETag)
-
+		h.setEtag(dbConfig.Version)
 		// refresh_config=true forces the config loaded out of the bucket to be applied on the node
 		if h.getBoolQuery("refresh_config") && h.server.bootstrapContext.connection != nil {
 			// set cas=0 to force a refresh
@@ -536,13 +531,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 				return nil, err
 			}
 
-			headerVersion := h.rq.Header.Get("If-Match")
-			headerVersion, err = h.readETag(headerVersion)
-			if err != nil {
-				return nil, err
-			}
-
-			if headerVersion != "" && headerVersion != bucketDbConfig.Version {
+			if h.headerDoesNotMatchEtag("If-Match", bucketDbConfig.Version) {
 				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 			}
 
@@ -603,11 +592,8 @@ func (h *handler) handlePutDbConfig() (err error) {
 	}
 	// store the cas in the loaded config after a successful update
 	h.server.dbConfigs[dbName].cas = cas
-	quoteETag, err := h.setEtag(updatedDbConfig.Version)
-	if err != nil {
-		return err
-	}
-	h.response.Header().Set("ETag", quoteETag)
+	h.setEtag(updatedDbConfig.Version)
+
 	return base.HTTPErrorf(http.StatusCreated, "updated")
 
 }
@@ -636,11 +622,7 @@ func (h *handler) handleGetDbConfigSync() error {
 		}
 	}
 
-	quoteETag, err := h.setEtag(etagVersion)
-	if err != nil {
-		return err
-	}
-	h.response.Header().Set("ETag", quoteETag)
+	h.setEtag(etagVersion)
 	h.writeJavascript(syncFunction)
 	return nil
 }
@@ -664,13 +646,7 @@ func (h *handler) handleDeleteDbConfigSync() error {
 				return nil, err
 			}
 
-			headerVersion := h.rq.Header.Get("If-Match")
-			headerVersion, err = h.readETag(headerVersion)
-			if err != nil {
-				return nil, err
-			}
-
-			if headerVersion != "" && headerVersion != bucketDbConfig.Version {
+			if h.headerDoesNotMatchEtag("If-Match", bucketDbConfig.Version) {
 				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 			}
 
@@ -731,13 +707,7 @@ func (h *handler) handlePutDbConfigSync() error {
 				return nil, err
 			}
 
-			headerVersion := h.rq.Header.Get("If-Match")
-			headerVersion, err = h.readETag(headerVersion)
-			if err != nil {
-				return nil, err
-			}
-
-			if headerVersion != "" && headerVersion != bucketDbConfig.Version {
+			if h.headerDoesNotMatchEtag("If-Match", bucketDbConfig.Version) {
 				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 			}
 
@@ -802,11 +772,7 @@ func (h *handler) handleGetDbConfigImportFilter() error {
 		}
 	}
 
-	quoteETag, err := h.setEtag(etagVersion)
-	if err != nil {
-		return err
-	}
-	h.response.Header().Set("ETag", quoteETag)
+	h.setEtag(etagVersion)
 	h.writeJavascript(importFilterFunction)
 	return nil
 }
@@ -830,13 +796,7 @@ func (h *handler) handleDeleteDbConfigImportFilter() error {
 				return nil, err
 			}
 
-			headerVersion := h.rq.Header.Get("If-Match")
-			headerVersion, err = h.readETag(headerVersion)
-			if err != nil {
-				return nil, err
-			}
-
-			if headerVersion != "" && headerVersion != bucketDbConfig.Version {
+			if h.headerDoesNotMatchEtag("If-Match", bucketDbConfig.Version) {
 				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 			}
 
@@ -898,13 +858,7 @@ func (h *handler) handlePutDbConfigImportFilter() error {
 				return nil, err
 			}
 
-			headerVersion := h.rq.Header.Get("If-Match")
-			headerVersion, err = h.readETag(headerVersion)
-			if err != nil {
-				return nil, err
-			}
-
-			if headerVersion != "" && headerVersion != bucketDbConfig.Version {
+			if h.headerDoesNotMatchEtag("If-Match", bucketDbConfig.Version) {
 				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 			}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -30,6 +30,8 @@ const kDefaultDBOnlineDelay = 0
 
 const paramDisableOIDCValidation = "disable_oidc_validation"
 
+const IfMatchHeader = "If-Match"
+
 // GetUsers  - GET /{db}/_user/
 const paramNameOnly = "name_only"
 const paramLimit = "limit"
@@ -531,7 +533,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 				return nil, err
 			}
 
-			if h.headerDoesNotMatchEtag("If-Match", bucketDbConfig.Version) {
+			if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
 				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 			}
 
@@ -646,7 +648,7 @@ func (h *handler) handleDeleteDbConfigSync() error {
 				return nil, err
 			}
 
-			if h.headerDoesNotMatchEtag("If-Match", bucketDbConfig.Version) {
+			if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
 				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 			}
 
@@ -707,7 +709,7 @@ func (h *handler) handlePutDbConfigSync() error {
 				return nil, err
 			}
 
-			if h.headerDoesNotMatchEtag("If-Match", bucketDbConfig.Version) {
+			if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
 				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 			}
 
@@ -796,7 +798,7 @@ func (h *handler) handleDeleteDbConfigImportFilter() error {
 				return nil, err
 			}
 
-			if h.headerDoesNotMatchEtag("If-Match", bucketDbConfig.Version) {
+			if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
 				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 			}
 
@@ -858,7 +860,7 @@ func (h *handler) handlePutDbConfigImportFilter() error {
 				return nil, err
 			}
 
-			if h.headerDoesNotMatchEtag("If-Match", bucketDbConfig.Version) {
+			if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
 				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 			}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -30,8 +30,6 @@ const kDefaultDBOnlineDelay = 0
 
 const paramDisableOIDCValidation = "disable_oidc_validation"
 
-const IfMatchHeader = "If-Match"
-
 // GetUsers  - GET /{db}/_user/
 const paramNameOnly = "name_only"
 const paramLimit = "limit"

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -230,7 +231,8 @@ func (h *handler) handleGetDbConfig() error {
 			return base.HTTPErrorf(http.StatusNotFound, "database config not found")
 		}
 
-		h.response.Header().Set("ETag", dbConfig.Version)
+		quoteETag := strconv.Quote(dbConfig.Version)
+		h.response.Header().Set("ETag", quoteETag)
 
 		// refresh_config=true forces the config loaded out of the bucket to be applied on the node
 		if h.getBoolQuery("refresh_config") && h.server.bootstrapContext.connection != nil {
@@ -533,6 +535,10 @@ func (h *handler) handlePutDbConfig() (err error) {
 			}
 
 			headerVersion := h.rq.Header.Get("If-Match")
+			if headerVersion != "" {
+				headerVersion, _ = strconv.Unquote(headerVersion)
+			}
+
 			if headerVersion != "" && headerVersion != bucketDbConfig.Version {
 				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 			}
@@ -594,7 +600,8 @@ func (h *handler) handlePutDbConfig() (err error) {
 	}
 	// store the cas in the loaded config after a successful update
 	h.server.dbConfigs[dbName].cas = cas
-	h.response.Header().Set("ETag", updatedDbConfig.Version)
+	quoteETag := strconv.Quote(updatedDbConfig.Version)
+	h.response.Header().Set("ETag", quoteETag)
 	return base.HTTPErrorf(http.StatusCreated, "updated")
 
 }
@@ -623,7 +630,8 @@ func (h *handler) handleGetDbConfigSync() error {
 		}
 	}
 
-	h.response.Header().Set("ETag", etagVersion)
+	quoteETag := strconv.Quote(etagVersion)
+	h.response.Header().Set("ETag", quoteETag)
 	h.writeJavascript(syncFunction)
 	return nil
 }
@@ -648,6 +656,10 @@ func (h *handler) handleDeleteDbConfigSync() error {
 			}
 
 			headerVersion := h.rq.Header.Get("If-Match")
+			if headerVersion != "" {
+				headerVersion, _ = strconv.Unquote(headerVersion)
+			}
+
 			if headerVersion != "" && headerVersion != bucketDbConfig.Version {
 				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 			}
@@ -710,6 +722,10 @@ func (h *handler) handlePutDbConfigSync() error {
 			}
 
 			headerVersion := h.rq.Header.Get("If-Match")
+			if headerVersion != "" {
+				headerVersion, _ = strconv.Unquote(headerVersion)
+			}
+
 			if headerVersion != "" && headerVersion != bucketDbConfig.Version {
 				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 			}
@@ -775,7 +791,8 @@ func (h *handler) handleGetDbConfigImportFilter() error {
 		}
 	}
 
-	h.response.Header().Set("ETag", etagVersion)
+	quoteETag := strconv.Quote(etagVersion)
+	h.response.Header().Set("ETag", quoteETag)
 	h.writeJavascript(importFilterFunction)
 	return nil
 }
@@ -800,6 +817,10 @@ func (h *handler) handleDeleteDbConfigImportFilter() error {
 			}
 
 			headerVersion := h.rq.Header.Get("If-Match")
+			if headerVersion != "" {
+				headerVersion, _ = strconv.Unquote(headerVersion)
+			}
+
 			if headerVersion != "" && headerVersion != bucketDbConfig.Version {
 				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 			}
@@ -863,6 +884,10 @@ func (h *handler) handlePutDbConfigImportFilter() error {
 			}
 
 			headerVersion := h.rq.Header.Get("If-Match")
+			if headerVersion != "" {
+				headerVersion, _ = strconv.Unquote(headerVersion)
+			}
+
 			if headerVersion != "" && headerVersion != bucketDbConfig.Version {
 				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 			}

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3298,7 +3298,8 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db/_config", "")
 	resp.requireStatus(http.StatusOK)
 	eTag := resp.Header.Get("ETag")
-	assert.NotEqual(t, "", eTag)
+	unquoteETag, _ := strconv.Unquote(eTag)
+	assert.NotEqual(t, "", unquoteETag)
 
 	resp = bootstrapAdminRequestWithHeaders(t, http.MethodPost, "/db/_config", "{}", map[string]string{"If-Match": eTag})
 	resp.requireStatus(http.StatusCreated)
@@ -3313,7 +3314,7 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 	getETag := resp.Header.Get("ETag")
 	assert.Equal(t, putETag, getETag)
 
-	resp = bootstrapAdminRequestWithHeaders(t, http.MethodPost, "/db/_config", "{}", map[string]string{"If-Match": "x"})
+	resp = bootstrapAdminRequestWithHeaders(t, http.MethodPost, "/db/_config", "{}", map[string]string{"If-Match": strconv.Quote("x")})
 	resp.requireStatus(http.StatusPreconditionFailed)
 }
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3298,7 +3298,6 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db/_config", "")
 	resp.requireStatus(http.StatusOK)
 	eTag := resp.Header.Get("ETag")
-	//unquoteETag, _ := strconv.Unquote(eTag)
 	unquoteETag := strings.Trim(eTag, `"`)
 	assert.NotEqual(t, "", unquoteETag)
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3298,7 +3298,8 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db/_config", "")
 	resp.requireStatus(http.StatusOK)
 	eTag := resp.Header.Get("ETag")
-	unquoteETag, _ := strconv.Unquote(eTag)
+	//unquoteETag, _ := strconv.Unquote(eTag)
+	unquoteETag := strings.Trim(eTag, `"`)
 	assert.NotEqual(t, "", unquoteETag)
 
 	resp = bootstrapAdminRequestWithHeaders(t, http.MethodPost, "/db/_config", "{}", map[string]string{"If-Match": eTag})
@@ -3314,7 +3315,8 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 	getETag := resp.Header.Get("ETag")
 	assert.Equal(t, putETag, getETag)
 
-	resp = bootstrapAdminRequestWithHeaders(t, http.MethodPost, "/db/_config", "{}", map[string]string{"If-Match": strconv.Quote("x")})
+	quotedStr := `"` + "x" + `"`
+	resp = bootstrapAdminRequestWithHeaders(t, http.MethodPost, "/db/_config", "{}", map[string]string{"If-Match": quotedStr})
 	resp.requireStatus(http.StatusPreconditionFailed)
 }
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3314,7 +3314,7 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 	getETag := resp.Header.Get("ETag")
 	assert.Equal(t, putETag, getETag)
 
-	quotedStr := `"` + "x" + `"`
+	quotedStr := `"x"`
 	resp = bootstrapAdminRequestWithHeaders(t, http.MethodPost, "/db/_config", "{}", map[string]string{"If-Match": quotedStr})
 	resp.requireStatus(http.StatusPreconditionFailed)
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -843,7 +843,7 @@ func TestManualAttachment(t *testing.T) {
 	RequireStatus(t, response, 409)
 
 	// attach to existing document with wrong rev using If-Match header (should fail)
-	reqHeaders["If-Match"] = "1-dnf"
+	reqHeaders["If-Match"] = strconv.Quote("1-dnf")
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1", attachmentBody, reqHeaders)
 	RequireStatus(t, response, 409)
 	delete(reqHeaders, "If-Match")
@@ -890,7 +890,7 @@ func TestManualAttachment(t *testing.T) {
 
 	// try to overwrite that attachment again, this time using If-Match header
 	attachmentBody = "updated content again"
-	reqHeaders["If-Match"] = revIdAfterUpdateAttachment
+	reqHeaders["If-Match"] = strconv.Quote(revIdAfterUpdateAttachment)
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1", attachmentBody, reqHeaders)
 	RequireStatus(t, response, 201)
 	body = db.Body{}
@@ -963,7 +963,7 @@ func TestManualAttachmentNewDoc(t *testing.T) {
 	RequireStatus(t, response, 409)
 
 	// attach to new document using bogus rev using If-Match header (should fail)
-	reqHeaders["If-Match"] = "1-xyz"
+	reqHeaders["If-Match"] = strconv.Quote("1-xyz")
 	response = rt.SendAdminRequestWithHeaders("PUT", "/db/notexistyet/attach1", attachmentBody, reqHeaders)
 	RequireStatus(t, response, 409)
 	delete(reqHeaders, "If-Match")

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -843,7 +843,7 @@ func TestManualAttachment(t *testing.T) {
 	RequireStatus(t, response, 409)
 
 	// attach to existing document with wrong rev using If-Match header (should fail)
-	reqHeaders["If-Match"] = strconv.Quote("1-dnf")
+	reqHeaders["If-Match"] = `"` + "1-dnf" + `"`
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1", attachmentBody, reqHeaders)
 	RequireStatus(t, response, 409)
 	delete(reqHeaders, "If-Match")
@@ -890,7 +890,7 @@ func TestManualAttachment(t *testing.T) {
 
 	// try to overwrite that attachment again, this time using If-Match header
 	attachmentBody = "updated content again"
-	reqHeaders["If-Match"] = strconv.Quote(revIdAfterUpdateAttachment)
+	reqHeaders["If-Match"] = `"` + revIdAfterUpdateAttachment + `"`
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1", attachmentBody, reqHeaders)
 	RequireStatus(t, response, 201)
 	body = db.Body{}
@@ -963,7 +963,7 @@ func TestManualAttachmentNewDoc(t *testing.T) {
 	RequireStatus(t, response, 409)
 
 	// attach to new document using bogus rev using If-Match header (should fail)
-	reqHeaders["If-Match"] = strconv.Quote("1-xyz")
+	reqHeaders["If-Match"] = `"` + "1-xyz" + `"`
 	response = rt.SendAdminRequestWithHeaders("PUT", "/db/notexistyet/attach1", attachmentBody, reqHeaders)
 	RequireStatus(t, response, 409)
 	delete(reqHeaders, "If-Match")

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -963,7 +963,7 @@ func TestManualAttachmentNewDoc(t *testing.T) {
 	RequireStatus(t, response, 409)
 
 	// attach to new document using bogus rev using If-Match header (should fail)
-	reqHeaders["If-Match"] = `"` + "1-xyz" + `"`
+	reqHeaders["If-Match"] = `"1-xyz"`
 	response = rt.SendAdminRequestWithHeaders("PUT", "/db/notexistyet/attach1", attachmentBody, reqHeaders)
 	RequireStatus(t, response, 409)
 	delete(reqHeaders, "If-Match")

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -304,6 +304,7 @@ func (h *handler) handlePutAttachment() error {
 	revid := h.getQuery("rev")
 	if revid == "" {
 		revid = h.rq.Header.Get("If-Match")
+		revid, _ = strconv.Unquote(revid)
 	}
 	attachmentData, err := h.readBody()
 	if err != nil {
@@ -394,6 +395,7 @@ func (h *handler) handlePutDoc() error {
 		if oldRev := h.getQuery("rev"); oldRev != "" {
 			body[db.BodyRev] = oldRev
 		} else if ifMatch := h.rq.Header.Get("If-Match"); ifMatch != "" {
+			ifMatch, _ = strconv.Unquote(ifMatch)
 			body[db.BodyRev] = ifMatch
 		}
 		if bodyRev != nil && bodyRev != body[db.BodyRev] {
@@ -452,6 +454,7 @@ func (h *handler) handlePutDocReplicator2(docid string, roundTrip bool) (err err
 	if oldRev := h.getQuery("rev"); oldRev != "" {
 		parentRev = oldRev
 	} else if ifMatch := h.rq.Header.Get("If-Match"); ifMatch != "" {
+		ifMatch, _ = strconv.Unquote(ifMatch)
 		parentRev = ifMatch
 	}
 
@@ -540,6 +543,7 @@ func (h *handler) handleDeleteDoc() error {
 	revid := h.getQuery("rev")
 	if revid == "" {
 		revid = h.rq.Header.Get("If-Match")
+		revid, _ = strconv.Unquote(revid)
 	}
 	newRev, err := h.db.DeleteDoc(h.ctx(), docid, revid)
 	if err == nil {

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -397,10 +397,7 @@ func (h *handler) handlePutDoc() error {
 		bodyRev := body[db.BodyRev]
 		if oldRev := h.getQuery("rev"); oldRev != "" {
 			body[db.BodyRev] = oldRev
-		} else if ifMatch, err := h.getEtag("If-Match"); ifMatch != "" {
-			if err != nil {
-				return err
-			}
+		} else if ifMatch, _ := h.getEtag("If-Match"); ifMatch != "" {
 			body[db.BodyRev] = ifMatch
 		}
 		if bodyRev != nil && bodyRev != body[db.BodyRev] {
@@ -458,10 +455,7 @@ func (h *handler) handlePutDocReplicator2(docid string, roundTrip bool) (err err
 	var parentRev string
 	if oldRev := h.getQuery("rev"); oldRev != "" {
 		parentRev = oldRev
-	} else if ifMatch, err := h.getEtag("If-Match"); ifMatch != "" {
-		if err != nil {
-			return nil
-		}
+	} else if ifMatch, _ := h.getEtag("If-Match"); ifMatch != "" {
 		parentRev = ifMatch
 	}
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -1277,10 +1277,10 @@ func (h *handler) handleRange(contentLength uint64) (status int, start uint64, e
 
 // Given an HTTP "Range:" header value, parses it and returns the approppriate HTTP status code,
 // and the numeric byte range if appropriate:
-//   - If the Range header is empty or syntactically invalid, it ignores it and returns status=200.
-//   - If the header is valid but exceeds the contentLength, it returns status=416 (Not Satisfiable).
-//   - Otherwise it returns status=206 and sets the start and end values in HTTP terms, i.e. with
-//     the first byte numbered 0, and the end value inclusive (so the first 100 bytes are 0-99.)
+// * If the Range header is empty or syntactically invalid, it ignores it and returns status=200.
+// * If the header is valid but exceeds the contentLength, it returns status=416 (Not Satisfiable).
+// * Otherwise it returns status=206 and sets the start and end values in HTTP terms, i.e. with
+//   the first byte numbered 0, and the end value inclusive (so the first 100 bytes are 0-99.)
 func parseHTTPRangeHeader(rangeStr string, contentLength uint64) (status int, start uint64, end uint64) {
 	// http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35
 	status = http.StatusOK

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -1286,10 +1286,10 @@ func (h *handler) handleRange(contentLength uint64) (status int, start uint64, e
 
 // Given an HTTP "Range:" header value, parses it and returns the approppriate HTTP status code,
 // and the numeric byte range if appropriate:
-// * If the Range header is empty or syntactically invalid, it ignores it and returns status=200.
-// * If the header is valid but exceeds the contentLength, it returns status=416 (Not Satisfiable).
-// * Otherwise it returns status=206 and sets the start and end values in HTTP terms, i.e. with
-//   the first byte numbered 0, and the end value inclusive (so the first 100 bytes are 0-99.)
+//   - If the Range header is empty or syntactically invalid, it ignores it and returns status=200.
+//   - If the header is valid but exceeds the contentLength, it returns status=416 (Not Satisfiable).
+//   - Otherwise it returns status=206 and sets the start and end values in HTTP terms, i.e. with
+//     the first byte numbered 0, and the end value inclusive (so the first 100 bytes are 0-99.)
 func parseHTTPRangeHeader(rangeStr string, contentLength uint64) (status int, start uint64, end uint64) {
 	// http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35
 	status = http.StatusOK

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -849,6 +849,15 @@ func (h *handler) headerDoesNotMatchEtag(headerName string, etag string) bool {
 	return value != "" && !strings.Contains(value, `"`+etag+`"`)
 }
 
+func (h *handler) getEtag(headerName string) (string, error) {
+	value := h.rq.Header.Get(headerName)
+	if len(value) > 0 && !strings.Contains(value, `"`) {
+		return "", fmt.Errorf("ETag value is not quoted when trying to read the value")
+	}
+	eTag := strings.Trim(value, `"`)
+	return eTag, nil
+}
+
 // Returns the request body as a raw byte array.
 func (h *handler) readBody() ([]byte, error) {
 	return ioutil.ReadAll(h.requestBody)

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -844,8 +844,8 @@ func (h *handler) headerMatchesEtag(headerName string, etag string) bool {
 
 // Returns true if the header exists, and its value does NOT match the given etag.
 // (The etag parameter should not be double-quoted; the function will take care of that.)
-func (h *handler) headerDoesNotMatchEtag(headerName string, etag string) bool {
-	value := h.rq.Header.Get(headerName)
+func (h *handler) headerDoesNotMatchEtag(etag string) bool {
+	value := h.rq.Header.Get("If-Match")
 	return value != "" && !strings.Contains(value, `"`+etag+`"`)
 }
 

--- a/rest/handler_config_database.go
+++ b/rest/handler_config_database.go
@@ -55,7 +55,7 @@ func (h *handler) mutateDbConfig(mutator func(*DbConfig) error) error {
 					return nil, err
 				}
 
-				if h.headerDoesNotMatchEtag("If-Match", bucketDbConfig.Version) {
+				if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
 					return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 				}
 


### PR DESCRIPTION
CBG-2247

Added functionality to quote ETags when setting them. Then also Unquoting If-Match headers when they are used. 
- Changed admin_api.go to set quoted ETags then Unquote them when getting If-Match
- doc_api.go changed to unquote If-Match headers 
- admin_api_test.go has been updated to reflect these changes along side api_test.go 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/870/