### PR TITLE
Move _sync metadata constants to new file and describe all of them

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -148,7 +148,10 @@ func (cc *CouchbaseCluster) GetConfig(location, groupID string, valuePtr interfa
 
 	defer teardown()
 
-	docID := PersistentConfigPrefixWithGroupID(groupID)
+	docID, err := PersistentConfigKey(groupID)
+	if err != nil {
+		return 0, err
+	}
 	res, err := b.DefaultCollection().Get(docID, &gocb.GetOptions{
 		Timeout:       time.Second * 10,
 		RetryStrategy: gocb.NewBestEffortRetryStrategy(nil),
@@ -178,7 +181,10 @@ func (cc *CouchbaseCluster) InsertConfig(location, groupID string, value interfa
 	}
 	defer teardown()
 
-	docID := PersistentConfigPrefixWithGroupID(groupID)
+	docID, err := PersistentConfigKey(groupID)
+	if err != nil {
+		return 0, err
+	}
 	res, err := b.DefaultCollection().Insert(docID, value, nil)
 	if err != nil {
 		if isKVError(err, memd.StatusKeyExists) {
@@ -203,7 +209,10 @@ func (cc *CouchbaseCluster) UpdateConfig(location, groupID string, updateCallbac
 
 	collection := b.DefaultCollection()
 
-	docID := PersistentConfigPrefixWithGroupID(groupID)
+	docID, err := PersistentConfigKey(groupID)
+	if err != nil {
+		return 0, err
+	}
 	for {
 		res, err := collection.Get(docID, &gocb.GetOptions{
 			Transcoder: gocb.NewRawJSONTranscoder(),

--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -148,7 +148,8 @@ func (cc *CouchbaseCluster) GetConfig(location, groupID string, valuePtr interfa
 
 	defer teardown()
 
-	res, err := b.DefaultCollection().Get(PersistentConfigPrefix+groupID, &gocb.GetOptions{
+	docID := PersistentConfigPrefixWithGroupID(groupID)
+	res, err := b.DefaultCollection().Get(docID, &gocb.GetOptions{
 		Timeout:       time.Second * 10,
 		RetryStrategy: gocb.NewBestEffortRetryStrategy(nil),
 	})
@@ -177,7 +178,7 @@ func (cc *CouchbaseCluster) InsertConfig(location, groupID string, value interfa
 	}
 	defer teardown()
 
-	docID := PersistentConfigPrefix + groupID
+	docID := PersistentConfigPrefixWithGroupID(groupID)
 	res, err := b.DefaultCollection().Insert(docID, value, nil)
 	if err != nil {
 		if isKVError(err, memd.StatusKeyExists) {
@@ -202,7 +203,7 @@ func (cc *CouchbaseCluster) UpdateConfig(location, groupID string, updateCallbac
 
 	collection := b.DefaultCollection()
 
-	docID := PersistentConfigPrefix + groupID
+	docID := PersistentConfigPrefixWithGroupID(groupID)
 	for {
 		res, err := collection.Get(docID, &gocb.GetOptions{
 			Transcoder: gocb.NewRawJSONTranscoder(),

--- a/base/constants.go
+++ b/base/constants.go
@@ -122,42 +122,15 @@ const (
 	// The limit in Couchbase Server for total system xattr size
 	couchbaseMaxSystemXattrSize = 1 * 1024 * 1024 // 1MB
 
-	// ==== Sync Prefix Documents & Keys ====
-	SyncPrefix = "_sync:"
-
-	AttPrefix              = SyncPrefix + "att:"
-	Att2Prefix             = SyncPrefix + "att2:"
-	BackfillCompletePrefix = SyncPrefix + "backfill:complete:"
-	BackfillPendingPrefix  = SyncPrefix + "backfill:pending:"
-	DCPCheckpointPrefix    = SyncPrefix + "dcp_ck:"
-	RepairBackup           = SyncPrefix + "repair:backup:"
-	RepairDryRun           = SyncPrefix + "repair:dryrun:"
-	RevBodyPrefix          = SyncPrefix + "rb:"
-	RevPrefix              = SyncPrefix + "rev:"
-	RolePrefix             = SyncPrefix + "role:"
-	SessionPrefix          = SyncPrefix + "session:"
-	SGCfgPrefix            = SyncPrefix + "cfg"
-	SyncSeqPrefix          = SyncPrefix + "seq:"
-	UserEmailPrefix        = SyncPrefix + "useremail:"
-	UserPrefix             = SyncPrefix + "user:"
-	UnusedSeqPrefix        = SyncPrefix + "unusedSeq:"
-	UnusedSeqRangePrefix   = SyncPrefix + "unusedSeqs:"
-
-	DCPBackfillSeqKey = SyncPrefix + "dcp_backfill"
-	SyncDataKey       = SyncPrefix + "syncdata"
-	SyncSeqKey        = SyncPrefix + "seq"
-
-	PersistentConfigPrefix = SyncPrefix + "dbconfig:"
-
 	AttachmentCompactionXattrName = SyncXattrName + "-compact"
 
+	// SyncPropertyName is used when storing sync data inline in a document.
 	SyncPropertyName = "_sync"
-	SyncXattrName    = "_sync"
+	// SyncXattrName is used when storing sync data in a document's xattrs.
+	SyncXattrName = "_sync"
 
 	// Intended to be used in Meta Map and related tests
 	MetaMapXattrsKey = "xattrs"
-
-	SGRStatusPrefix = SyncPrefix + "sgrStatus:"
 
 	// Prefix for transaction metadata documents
 	TxnPrefix = "_txn:"
@@ -215,27 +188,6 @@ var (
 	// MaxPrincipalNameLen is the maximum length for user and role names, accounting for internal prefixes, and is used to validate CRUD
 	MaxPrincipalNameLen = 250 - Max(len(UserPrefix), len(RolePrefix))
 )
-
-func DCPCheckpointPrefixWithGroupID(groupID string) string {
-	if groupID != "" {
-		return DCPCheckpointPrefix + groupID + ":"
-	}
-	return DCPCheckpointPrefix
-}
-
-func SGCfgPrefixWithGroupID(groupID string) string {
-	if groupID != "" {
-		return SGCfgPrefix + ":" + groupID + ":"
-	}
-	return SGCfgPrefix
-}
-
-func SyncDataKeyWithGroupID(groupID string) string {
-	if groupID != "" {
-		return SyncDataKey + ":" + groupID
-	}
-	return SyncDataKey
-}
 
 // UnitTestUrl returns the configured test URL.
 func UnitTestUrl() string {

--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -1,0 +1,85 @@
+package base
+
+// A list of constants that define Sync Gateway metadata document IDs/Prefixes
+
+/*
+Copyright 2022-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+const SyncDocPrefix = "_sync:" // SyncDocPrefix is a common prefix for all Sync Gateway metadata documents
+
+// Sync Gateway Metadata documents
+const (
+	SyncSeqKey                       = SyncDocPrefix + "seq"                           // SyncSeqKey is a counter document storing the SG sequence number of a collection
+	UnusedSeqPrefix                  = SyncDocPrefix + "unusedSeq:"                    // UnusedSeqPrefix stores a sequence that was reserved by SG but was unused
+	UnusedSeqRangePrefix             = SyncDocPrefix + "unusedSeqs:"                   // UnusedSeqRangePrefix stores a sequence range that was reserved by SG but was unused
+	RevBodyPrefix                    = SyncDocPrefix + "rb:"                           // RevBodyPrefix stores a conflicting revision's body
+	RevPrefix                        = SyncDocPrefix + "rev:"                          // RevPrefix stores an old revision's body for temporary lookup (in-flight requests or delta sync)
+	BackgroundProcessHeartbeatPrefix = SyncDocPrefix + "background_process:heartbeat:" // BackgroundProcessHeartbeatPrefix stores a background process heartbeat
+	BackgroundProcessStatusPrefix    = SyncDocPrefix + "background_process:status:"    // BackgroundProcessStatusPrefix stores a background process status
+	UserPrefix                       = SyncDocPrefix + "user:"                         // UserPrefix stores user documents keyed by user name
+	RolePrefix                       = SyncDocPrefix + "role:"                         // RolePrefix stores role documents keyed by role name
+	UserEmailPrefix                  = SyncDocPrefix + "useremail:"                    // UserEmailPrefix maps a user's email to a user name for UserPrefix lookups
+	SessionPrefix                    = SyncDocPrefix + "session:"                      // SessionPrefix stores user sessions keyed by session ID
+	AttPrefix                        = SyncDocPrefix + "att:"                          // AttPrefix SG (v1) attachment data
+	Att2Prefix                       = SyncDocPrefix + "att2:"                         // Att2Prefix SG v2 attachment data
+	DCPBackfillSeqKey                = SyncDocPrefix + "dcp_backfill"                  // DCPBackfillSeqKey stores a BackfillSequences for a DCP feed
+	RepairBackupPrefix               = SyncDocPrefix + "repair:backup:"                // RepairBackupPrefix is the doc prefix used to store a backup of a repaired document
+	RepairDryRunPrefix               = SyncDocPrefix + "repair:dryrun:"                // RepairDryRunPrefix is the doc prefix used to store a repaired document in dry-run mode
+	SGRStatusPrefix                  = SyncDocPrefix + "sgrStatus:"                    // SGRStatusPrefix is the doc prefix used to store ISGR status documents
+)
+
+// Sync Gateway Metadata documents that should be GroupID scoped and accessed via the "WithGroupID" helper methods below
+const (
+	DCPCheckpointPrefixWithoutGroupID    = SyncDocPrefix + "dcp_ck:"   // DCPCheckpointPrefixWithoutGroupID stores a DCP checkpoint
+	SGCfgPrefixWithoutGroupID            = SyncDocPrefix + "cfg"       // SGCfgPrefixWithoutGroupID stores CfgSG/cbgt data
+	HeartbeaterPrefixWithoutGroupID      = SyncDocPrefix               // HeartbeaterPrefixWithoutGroupID stores a SG node heartbeat document
+	PersistentConfigPrefixWithoutGroupID = SyncDocPrefix + "dbconfig:" // PersistentConfigPrefixWithoutGroupID stores a database config
+	SyncFunctionKeyWithoutGroupID        = SyncDocPrefix + "syncdata"  // SyncFunctionKeyWithoutGroupID stores a copy of the Sync Function
+)
+
+// SyncFunctionKeyWithGroupID returns a doc ID to use when storing the sync function
+func SyncFunctionKeyWithGroupID(groupID string) string {
+	if groupID != "" {
+		return SyncFunctionKeyWithoutGroupID + ":" + groupID
+	}
+	return SyncFunctionKeyWithoutGroupID
+}
+
+// DCPCheckpointPrefixWithGroupID returns a doc ID prefix to use for DCP checkpoints
+func DCPCheckpointPrefixWithGroupID(groupID string) string {
+	if groupID != "" {
+		return DCPCheckpointPrefixWithoutGroupID + groupID + ":"
+	}
+	return DCPCheckpointPrefixWithoutGroupID
+}
+
+// SGCfgPrefixWithGroupID returns a doc ID prefix to use for CfgSG/cbgt documents
+func SGCfgPrefixWithGroupID(groupID string) string {
+	if groupID != "" {
+		return SGCfgPrefixWithoutGroupID + ":" + groupID + ":"
+	}
+	return SGCfgPrefixWithoutGroupID
+}
+
+// HeartbeaterPrefixWithGroupID returns a document prefix to use for heartbeat documents
+func HeartbeaterPrefixWithGroupID(groupID string) string {
+	if groupID != "" {
+		return HeartbeaterPrefixWithoutGroupID + groupID + ":"
+	}
+	return HeartbeaterPrefixWithoutGroupID
+}
+
+// PersistentConfigPrefixWithGroupID returns a document prefix to use to store database configs
+func PersistentConfigPrefixWithGroupID(groupID string) string {
+	if groupID != "" {
+		return PersistentConfigPrefixWithoutGroupID + groupID
+	}
+	return PersistentConfigPrefixWithoutGroupID
+}

--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -1,9 +1,3 @@
-package base
-
-import "errors"
-
-// A list of constants that define Sync Gateway metadata document IDs/Prefixes
-
 /*
 Copyright 2022-Present Couchbase, Inc.
 
@@ -13,6 +7,10 @@ file, in accordance with the Business Source License, use of this software will
 be governed by the Apache License, Version 2.0, included in the file
 licenses/APL2.txt.
 */
+
+package base
+
+import "errors"
 
 const SyncDocPrefix = "_sync:" // SyncDocPrefix is a common prefix for all Sync Gateway metadata documents
 

--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -1,5 +1,7 @@
 package base
 
+import "errors"
+
 // A list of constants that define Sync Gateway metadata document IDs/Prefixes
 
 /*
@@ -76,10 +78,10 @@ func HeartbeaterPrefixWithGroupID(groupID string) string {
 	return HeartbeaterPrefixWithoutGroupID
 }
 
-// PersistentConfigPrefixWithGroupID returns a document prefix to use to store database configs
-func PersistentConfigPrefixWithGroupID(groupID string) string {
-	if groupID != "" {
-		return PersistentConfigPrefixWithoutGroupID + groupID
+// PersistentConfigKey returns a document key to use to store database configs
+func PersistentConfigKey(groupID string) (string, error) {
+	if groupID == "" {
+		return "", errors.New("PersistentConfigKey requires a group ID, even if it's just `default`.")
 	}
-	return PersistentConfigPrefixWithoutGroupID
+	return PersistentConfigPrefixWithoutGroupID + groupID, nil
 }

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -526,7 +526,7 @@ func dcpKeyFilter(key []byte) bool {
 	}
 
 	// If it's not a _sync doc, process
-	if !bytes.HasPrefix(key, []byte(SyncPrefix)) {
+	if !bytes.HasPrefix(key, []byte(SyncDocPrefix)) {
 		return true
 	}
 
@@ -535,7 +535,7 @@ func dcpKeyFilter(key []byte) bool {
 		bytes.HasPrefix(key, []byte(UnusedSeqRangePrefix)) ||
 		bytes.HasPrefix(key, []byte(UserPrefix)) ||
 		bytes.HasPrefix(key, []byte(RolePrefix)) ||
-		bytes.HasPrefix(key, []byte(SGCfgPrefix)) {
+		bytes.HasPrefix(key, []byte(SGCfgPrefixWithoutGroupID)) {
 		return true
 	}
 

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -460,7 +460,7 @@ func initCfgCB(bucket Bucket, spec BucketSpec) (*cbgt.CfgCB, error) {
 	// cfg: Implementation of cbgt.Cfg interface.  Responsible for configuration management
 	//      Sync Gateway uses bucket-based config management
 	options := map[string]interface{}{
-		"keyPrefix": SyncPrefix,
+		"keyPrefix": SyncDocPrefix,
 	}
 	urls, errConvertServerSpec := CouchbaseURIToHttpURL(bucket, spec.Server, nil)
 	if errConvertServerSpec != nil {

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -67,9 +67,9 @@ func TestDCPKeyFilter(t *testing.T) {
 	assert.True(t, dcpKeyFilter([]byte(SGCfgPrefixWithGroupID("group")+"123")))
 
 	assert.False(t, dcpKeyFilter([]byte(SyncSeqKey)))
-	assert.False(t, dcpKeyFilter([]byte(SyncPrefix+"unusualSeq")))
-	assert.False(t, dcpKeyFilter([]byte(SyncDataKey)))
-	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefix+"12")))
+	assert.False(t, dcpKeyFilter([]byte(SyncDocPrefix+"unusualSeq")))
+	assert.False(t, dcpKeyFilter([]byte(SyncFunctionKeyWithoutGroupID)))
+	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefixWithoutGroupID+"12")))
 	assert.False(t, dcpKeyFilter([]byte(TxnPrefix+"atrData")))
 	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefixWithGroupID("group")+"12")))
 

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -104,7 +104,7 @@ func TestCouchbaseHeartbeaters(t *testing.T) {
 
 	SetUpTestLogging(t, LevelDebug, KeyDCP)
 
-	keyprefix := SyncPrefix + t.Name()
+	keyprefix := SyncDocPrefix + t.Name()
 
 	testBucket := GetTestBucket(t)
 	defer testBucket.Close()
@@ -183,7 +183,7 @@ func TestCouchbaseHeartbeatersMultipleListeners(t *testing.T) {
 		t.Skip("Skipping heartbeattest in short mode")
 	}
 
-	keyprefix := SyncPrefix + t.Name()
+	keyprefix := SyncDocPrefix + t.Name()
 	testBucket := GetTestBucket(t)
 	defer testBucket.Close()
 
@@ -291,7 +291,7 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 		t.Skip("Skipping heartbeattest in short mode")
 	}
 
-	keyprefix := SyncPrefix + t.Name()
+	keyprefix := SyncDocPrefix + t.Name()
 
 	testBucket := GetTestBucket(t)
 	defer testBucket.Close()

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -50,7 +50,7 @@ func attachmentCompactMarkPhase(db *Database, compactionID string, terminator *b
 		}
 
 		// We only want to process full docs. Not any sync docs.
-		if strings.HasPrefix(docID, base.SyncPrefix) {
+		if strings.HasPrefix(docID, base.SyncDocPrefix) {
 			return true
 		}
 

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -68,11 +68,11 @@ type ClusterAwareBackgroundManagerOptions struct {
 }
 
 func (b *ClusterAwareBackgroundManagerOptions) HeartbeatDocID() string {
-	return base.SyncPrefix + ":background_process:heartbeat:" + b.processSuffix
+	return base.BackgroundProcessHeartbeatPrefix + b.processSuffix
 }
 
 func (b *ClusterAwareBackgroundManagerOptions) StatusDocID() string {
-	return base.SyncPrefix + ":background_process:status:" + b.processSuffix
+	return base.BackgroundProcessStatusPrefix + b.processSuffix
 }
 
 // BackgroundManagerStatus simply stores data used in BackgroundManager. This data can also be exposed to users over

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -109,7 +109,7 @@ func (listener *changeListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool 
 	requiresCheckpointPersistence := true
 	if event.Opcode == sgbucket.FeedOpMutation || event.Opcode == sgbucket.FeedOpDeletion {
 		key := string(event.Key)
-		if !strings.HasPrefix(key, base.SyncPrefix) { // Anything other than internal SG docs can go straight to OnDocChanged
+		if !strings.HasPrefix(key, base.SyncDocPrefix) { // Anything other than internal SG docs can go straight to OnDocChanged
 			if listener.OnDocChanged != nil {
 				listener.OnDocChanged(event)
 			}
@@ -123,7 +123,7 @@ func (listener *changeListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool 
 			if listener.OnDocChanged != nil && event.Opcode == sgbucket.FeedOpMutation {
 				listener.OnDocChanged(event)
 			}
-		} else if strings.HasPrefix(key, base.DCPCheckpointPrefix) { // SG DCP checkpoint docs (including other config group IDs)
+		} else if strings.HasPrefix(key, base.DCPCheckpointPrefixWithoutGroupID) { // SG DCP checkpoint docs (including other config group IDs)
 			// Do not require checkpoint persistence when DCP checkpoint docs come back over DCP - otherwise
 			// we'll end up in a feedback loop for their vbucket if persistence is enabled
 			// NOTE: checkpoint persistence is disabled altogether for the caching feed.  Leaving this check in place

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -363,7 +363,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	// Retrieve the raw revision body backup of 2-a, and verify it's intact
 	log.Printf("Verify document storage of 2-a")
 	var revisionBody Body
-	rawRevision, _, err := db.Bucket.GetRaw(base.SyncPrefix + "rb:4GctXhLVg13d59D0PUTPRD0i58Hbe1d0djgo1qOEpfI=")
+	rawRevision, _, err := db.Bucket.GetRaw(base.SyncDocPrefix + "rb:4GctXhLVg13d59D0PUTPRD0i58Hbe1d0djgo1qOEpfI=")
 	assert.NoError(t, err, "Couldn't get raw backup revision")
 	assert.NoError(t, base.JSONUnmarshal(rawRevision, &revisionBody))
 	assert.Equal(t, rev2a_body["version"], revisionBody["version"])
@@ -546,7 +546,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	// Retrieve the raw revision body backup of 2-a, and verify it's intact
 	log.Printf("Verify document storage of 2-a")
 	var revisionBody Body
-	rawRevision, _, err := db.Bucket.GetRaw(base.SyncPrefix + "rb:4GctXhLVg13d59D0PUTPRD0i58Hbe1d0djgo1qOEpfI=")
+	rawRevision, _, err := db.Bucket.GetRaw(base.SyncDocPrefix + "rb:4GctXhLVg13d59D0PUTPRD0i58Hbe1d0djgo1qOEpfI=")
 	assert.NoError(t, err, "Couldn't get raw backup revision")
 	assert.NoError(t, base.JSONUnmarshal(rawRevision, &revisionBody))
 	assert.Equal(t, rev2a_body["version"], revisionBody["version"])
@@ -634,7 +634,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 
 	// Ensure previous tombstone body backup has been removed
 	log.Printf("Verify revision body doc has been removed from bucket")
-	_, _, err = db.Bucket.GetRaw(base.SyncPrefix + "rb:ULDLuEgDoKFJeET2hojeFANXM8SrHdVfAGONki+kPxM=")
+	_, _, err = db.Bucket.GetRaw(base.SyncDocPrefix + "rb:ULDLuEgDoKFJeET2hojeFANXM8SrHdVfAGONki+kPxM=")
 	assert.True(t, base.IsKeyNotFoundError(db.Bucket, err), "Revision should be not found")
 
 }

--- a/db/database.go
+++ b/db/database.go
@@ -429,10 +429,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	// sending heartbeats before registering itself to the cfg, to avoid triggering immediate removal by other active nodes.
 	if base.IsEnterpriseEdition() && (importEnabled || sgReplicateEnabled) {
 		// Create heartbeater
-		heartbeaterPrefix := base.SyncPrefix
-		if dbContext.Options.GroupID != "" {
-			heartbeaterPrefix = heartbeaterPrefix + dbContext.Options.GroupID + ":"
-		}
+		heartbeaterPrefix := base.HeartbeaterPrefixWithGroupID(dbContext.Options.GroupID)
 		heartbeater, err := base.NewCouchbaseHeartbeater(bucket, heartbeaterPrefix, dbContext.UUID)
 		if err != nil {
 			return nil, pkgerrors.Wrapf(err, "Error starting heartbeater for bucket %s", base.MD(bucket.GetName()).Redact())
@@ -1348,7 +1345,8 @@ func (dbCtx *DatabaseContext) UpdateSyncFun(syncFun string) (changed bool, err e
 		Sync string
 	}
 
-	_, err = dbCtx.Bucket.Update(base.SyncDataKeyWithGroupID(dbCtx.Options.GroupID), 0, func(currentValue []byte) ([]byte, *uint32, bool, error) {
+	syncFunctionDocID := base.SyncFunctionKeyWithGroupID(dbCtx.Options.GroupID)
+	_, err = dbCtx.Bucket.Update(syncFunctionDocID, 0, func(currentValue []byte) ([]byte, *uint32, bool, error) {
 		// The first time opening a new db, currentValue will be nil. Don't treat this as a change.
 		if currentValue != nil {
 			parseErr := base.JSONUnmarshal(currentValue, &syncData)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -104,9 +104,9 @@ func setupTestDBWithCustomSyncSeq(t testing.TB, customSeq uint64) *Database {
 	AddOptionsFromEnvironmentVariables(&dbcOptions)
 	tBucket := base.GetTestBucket(t)
 
-	log.Printf("Initializing test %s to %d", base.SyncSeqPrefix, customSeq)
+	log.Printf("Initializing test %s to %d", base.SyncSeqKey, customSeq)
 	_, incrErr := tBucket.Incr(base.SyncSeqKey, customSeq, customSeq, 0)
-	assert.NoError(t, incrErr, fmt.Sprintf("Couldn't increment %s seq by %d", base.SyncSeqPrefix, customSeq))
+	assert.NoError(t, incrErr, fmt.Sprintf("Couldn't increment %s by %d", base.SyncSeqKey, customSeq))
 
 	context, err := NewDatabaseContext("db", tBucket, false, dbcOptions)
 	assert.NoError(t, err, "Couldn't create context for database 'db'")

--- a/db/dcp_sharded_upgrade_test.go
+++ b/db/dcp_sharded_upgrade_test.go
@@ -192,11 +192,11 @@ func TestShardedDCPUpgrade(t *testing.T) {
 		indexName     = "db0x2d9928b7_index"
 	)
 
-	require.NoError(t, tb.SetRaw(base.SyncPrefix+"cfgindexDefs", 0, nil, []byte(fmt.Sprintf(indexDefs, tb.GetName(), bucketUUID))))
-	require.NoError(t, tb.SetRaw(base.SyncPrefix+"cfgnodeDefs-known", 0, nil, []byte(nodeDefs)))
-	require.NoError(t, tb.SetRaw(base.SyncPrefix+"cfgnodeDefs-wanted", 0, nil, []byte(nodeDefs)))
+	require.NoError(t, tb.SetRaw(base.SyncDocPrefix+"cfgindexDefs", 0, nil, []byte(fmt.Sprintf(indexDefs, tb.GetName(), bucketUUID))))
+	require.NoError(t, tb.SetRaw(base.SyncDocPrefix+"cfgnodeDefs-known", 0, nil, []byte(nodeDefs)))
+	require.NoError(t, tb.SetRaw(base.SyncDocPrefix+"cfgnodeDefs-wanted", 0, nil, []byte(nodeDefs)))
 	planPIndexesJSON := preparePlanPIndexesJSON(t, tb, numVBuckets, numPartitions)
-	require.NoError(t, tb.SetRaw(base.SyncPrefix+"cfgplanPIndexes", 0, nil, []byte(planPIndexesJSON)))
+	require.NoError(t, tb.SetRaw(base.SyncDocPrefix+"cfgplanPIndexes", 0, nil, []byte(planPIndexesJSON)))
 
 	// Write a doc before starting the dbContext to check that import works
 	const (

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -210,9 +210,9 @@ func wrapViews(ddoc *sgbucket.DesignDoc, enableUserViews bool, useXattrs bool) {
 	// add channel filtering.
 	for name, view := range ddoc.Views {
 		if enableUserViews {
-			view.Map = fmt.Sprintf(syncViewUserWrapper, base.SyncPrefix, base.SyncXattrName, base.SyncPropertyName, view.Map)
+			view.Map = fmt.Sprintf(syncViewUserWrapper, base.SyncDocPrefix, base.SyncXattrName, base.SyncPropertyName, view.Map)
 		} else {
-			view.Map = fmt.Sprintf(syncViewAdminWrapper, base.SyncPrefix, base.SyncXattrName, base.SyncPropertyName, view.Map)
+			view.Map = fmt.Sprintf(syncViewAdminWrapper, base.SyncDocPrefix, base.SyncXattrName, base.SyncPropertyName, view.Map)
 		}
 		ddoc.Views[name] = view // view is not a pointer, so have to copy it back
 	}
@@ -388,7 +388,7 @@ func installViews(bucket base.Bucket) error {
                      		channelNames.push(ch);
                      }
                      emit(meta.id, {r:sync.rev, s:sync.sequence, c:channelNames}); }`
-	alldocs_map = fmt.Sprintf(alldocs_map, syncData, base.SyncPrefix)
+	alldocs_map = fmt.Sprintf(alldocs_map, syncData, base.SyncDocPrefix)
 
 	// View for importing unknown docs
 	// Key is [existing?, docid] where 'existing?' is false for unknown docs
@@ -397,7 +397,7 @@ func installViews(bucket base.Bucket) error {
                      if(meta.id.substring(0,6) != "%s") {
                        var exists = (sync !== undefined);
                        emit([exists, meta.id], null); } }`
-	import_map = fmt.Sprintf(import_map, syncData, base.SyncPrefix)
+	import_map = fmt.Sprintf(import_map, syncData, base.SyncDocPrefix)
 
 	// Sessions view - used for session delete
 	// Key is username; value is docid
@@ -468,7 +468,7 @@ func installViews(bucket base.Bucket) error {
 						}
 					}`
 
-	channels_map = fmt.Sprintf(channels_map, syncData, base.SyncPrefix, ch.Deleted, EnableStarChannelLog,
+	channels_map = fmt.Sprintf(channels_map, syncData, base.SyncDocPrefix, ch.Deleted, EnableStarChannelLog,
 		ch.Removed|ch.Deleted, ch.Removed)
 
 	// Channel access view, used by ComputeChannelsForPrincipal()
@@ -484,7 +484,7 @@ func installViews(bucket base.Bucket) error {
 	                        }
 	                    }
 	               }`
-	access_map = fmt.Sprintf(access_map, syncData, base.SyncPrefix)
+	access_map = fmt.Sprintf(access_map, syncData, base.SyncDocPrefix)
 
 	// Vbucket sequence version of channel access view, used by ComputeChannelsForPrincipal()
 	// Key is username; value is dictionary channelName->firstSequence (compatible with TimedSet)
@@ -509,7 +509,7 @@ func installViews(bucket base.Bucket) error {
 
 		                    }
 		               }`
-	access_vbSeq_map = fmt.Sprintf(access_vbSeq_map, syncData, base.SyncPrefix)
+	access_vbSeq_map = fmt.Sprintf(access_vbSeq_map, syncData, base.SyncDocPrefix)
 
 	// Role access view, used by ComputeRolesForUser()
 	// Key is username; value is array of role names
@@ -524,7 +524,7 @@ func installViews(bucket base.Bucket) error {
 	                        }
 	                    }
 	               }`
-	roleAccess_map = fmt.Sprintf(roleAccess_map, syncData, base.SyncPrefix)
+	roleAccess_map = fmt.Sprintf(roleAccess_map, syncData, base.SyncDocPrefix)
 
 	// Vbucket sequence version of role access view, used by ComputeRolesForUser()
 	// Key is username; value is dictionary channelName->firstSequence (compatible with TimedSet)
@@ -549,7 +549,7 @@ func installViews(bucket base.Bucket) error {
 
 		                    }
 		               }`
-	roleAccess_vbSeq_map = fmt.Sprintf(roleAccess_vbSeq_map, syncData, base.SyncPrefix)
+	roleAccess_vbSeq_map = fmt.Sprintf(roleAccess_vbSeq_map, syncData, base.SyncDocPrefix)
 
 	designDocMap := map[string]*sgbucket.DesignDoc{}
 	designDocMap[DesignDocSyncGateway()] = &sgbucket.DesignDoc{

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -107,9 +107,9 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) (shouldPers
 	key := string(event.Key)
 
 	// Ignore internal documents
-	if strings.HasPrefix(key, base.SyncPrefix) {
+	if strings.HasPrefix(key, base.SyncDocPrefix) {
 		// Ignore all DCP checkpoints no matter config group ID
-		if strings.HasPrefix(key, base.DCPCheckpointPrefix) {
+		if strings.HasPrefix(key, base.DCPCheckpointPrefixWithoutGroupID) {
 			return false
 		}
 		return true

--- a/db/repair_bucket.go
+++ b/db/repair_bucket.go
@@ -272,10 +272,10 @@ func (r RepairBucket) WriteRepairedDocsToBucket(docId string, originalDoc, updat
 	var contentToSave []byte
 
 	if r.DryRun {
-		backupOrDryRunDocId = base.RepairDryRun + docId
+		backupOrDryRunDocId = base.RepairDryRunPrefix + docId
 		contentToSave = updatedDoc
 	} else {
-		backupOrDryRunDocId = base.RepairBackup + docId
+		backupOrDryRunDocId = base.RepairBackupPrefix + docId
 		contentToSave = originalDoc
 	}
 

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -129,7 +129,7 @@ func TestRepairBucketRevTreeCycles(t *testing.T) {
 	assert.False(t, repairedDoc.History.ContainsCycles())
 
 	// There should be a backup doc in the bucket with ID _sync:repair:backup:docIdProblematicRevTree
-	rawVal, _, errGetDoc = bucket.GetRaw(base.RepairBackup + "docIdProblematicRevTree")
+	rawVal, _, errGetDoc = bucket.GetRaw(base.RepairBackupPrefix + "docIdProblematicRevTree")
 	assert.NoError(t, errGetDoc, fmt.Sprintf("Error getting backup doc: %v", errGetDoc))
 
 	backupDoc, errUnmarshalBackup := unmarshalDocument(docIdProblematicRevTree, rawVal)
@@ -177,7 +177,7 @@ func TestRepairBucketDryRun(t *testing.T) {
 	// Since doc was not repaired due to dry, should still contain cycles
 	assert.True(t, repairedDoc.History.ContainsCycles())
 
-	rawVal, _, errGetDoc = bucket.GetRaw(base.RepairDryRun + "docIdProblematicRevTree2")
+	rawVal, _, errGetDoc = bucket.GetRaw(base.RepairDryRunPrefix + "docIdProblematicRevTree2")
 	assert.NoError(t, errGetDoc, fmt.Sprintf("Error getting backup doc: %v", errGetDoc))
 
 	backupDoc, errUnmarshalBackup := unmarshalDocument(docIdProblematicRevTree2, rawVal)

--- a/db/special_docs.go
+++ b/db/special_docs.go
@@ -109,5 +109,5 @@ func (db *Database) DeleteSpecial(doctype string, docid string, revid string) er
 }
 
 func RealSpecialDocID(doctype string, docid string) string {
-	return base.SyncPrefix + doctype + ":" + docid
+	return base.SyncDocPrefix + doctype + ":" + docid
 }

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -4690,7 +4690,7 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 
 	// Check checkpoint document was wrote to bucket with correct status
 	// _sync:local:checkpoint/sgr2cp:push:TestReplicatorCheckpointOnStop
-	expectedCheckpointName := base.SyncPrefix + "local:checkpoint/" + db.PushCheckpointID(t.Name())
+	expectedCheckpointName := base.SyncDocPrefix + "local:checkpoint/" + db.PushCheckpointID(t.Name())
 	val, _, err := activeRT.Bucket().GetRaw(expectedCheckpointName)
 	require.NoError(t, err)
 	var config struct { // db.replicationCheckpoint

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -2974,7 +2974,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 
 	cID := ar.Push.CheckpointID
-	checkpointDocID := base.SyncPrefix + "local:checkpoint/" + cID
+	checkpointDocID := base.SyncDocPrefix + "local:checkpoint/" + cID
 
 	var firstCheckpoint interface{}
 	_, err = rt2.Bucket().Get(checkpointDocID, &firstCheckpoint)
@@ -3100,13 +3100,13 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	pushCheckpointID := ar.Push.CheckpointID
-	pushCheckpointDocID := base.SyncPrefix + "local:checkpoint/" + pushCheckpointID
+	pushCheckpointDocID := base.SyncDocPrefix + "local:checkpoint/" + pushCheckpointID
 	err = rt2.Bucket().Set(pushCheckpointDocID, 0, nil, map[string]interface{}{"last_sequence": "0", "_rev": "abc"})
 	require.NoError(t, err)
 
 	pullCheckpointID := ar.Pull.CheckpointID
 	require.NoError(t, err)
-	pullCheckpointDocID := base.SyncPrefix + "local:checkpoint/" + pullCheckpointID
+	pullCheckpointDocID := base.SyncDocPrefix + "local:checkpoint/" + pullCheckpointID
 	err = rt1.Bucket().Set(pullCheckpointDocID, 0, nil, map[string]interface{}{"last_sequence": "0", "_rev": "abc"})
 	require.NoError(t, err)
 

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -193,7 +193,8 @@ func TestPersistentDbConfigWithInvalidUpsert(t *testing.T) {
 	assert.NotContains(t, string(resp.BodyBytes()), `"revs_limit":`)
 
 	// remove the db config directly from the bucket
-	docID := base.PersistentConfigPrefixWithGroupID(*rtc.config.groupID)
+	docID, err := base.PersistentConfigKey(*rtc.config.groupID)
+	require.NoError(t, err)
 	require.NoError(t, rtc.testBucket.Delete(docID))
 
 	// ensure all nodes remove the database

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -193,7 +193,8 @@ func TestPersistentDbConfigWithInvalidUpsert(t *testing.T) {
 	assert.NotContains(t, string(resp.BodyBytes()), `"revs_limit":`)
 
 	// remove the db config directly from the bucket
-	require.NoError(t, rtc.testBucket.Delete(base.PersistentConfigPrefix+*rtc.config.groupID))
+	docID := base.PersistentConfigPrefixWithGroupID(*rtc.config.groupID)
+	require.NoError(t, rtc.testBucket.Delete(docID))
 
 	// ensure all nodes remove the database
 	count, err = rtc.RefreshClusterDbConfigs()


### PR DESCRIPTION
- Rename `SyncPrefix` to `SyncDocPrefix` for clarity
- Store Group-ID aware constants separately and always use helper methods to generate
- Pull `background_process` doc ID prefixes into constants (and fix incorrect colon prefix)
  - Changes doc IDs from `_sync::background_process:...` to `_sync:background_process:...` but as heartbeat and status-only docs, it does not require any upgrade or migration
- Remove unused `Backfill` constants

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/737/