### PR TITLE
CBG-2278: Fix ClusterAware BackgroundManager teardown race

### DIFF
--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -48,6 +48,7 @@ type BackgroundManager struct {
 	BackgroundManagerStatus
 	lastError           error
 	terminator          *base.SafeTerminator
+	terminatorWaitGroup sync.WaitGroup
 	clusterAwareOptions *ClusterAwareBackgroundManagerOptions
 	lock                sync.Mutex
 	Process             BackgroundManagerProcessI
@@ -117,7 +118,9 @@ func (b *BackgroundManager) Start(options map[string]interface{}) error {
 	}
 
 	if b.isClusterAware() {
+		b.terminatorWaitGroup.Add(1)
 		go func(terminator *base.SafeTerminator) {
+			defer b.terminatorWaitGroup.Done()
 			ticker := time.NewTicker(BackgroundManagerStatusUpdateIntervalSecs * time.Second)
 			for {
 				select {
@@ -126,7 +129,6 @@ func (b *BackgroundManager) Start(options map[string]interface{}) error {
 					if err != nil {
 						base.WarnfCtx(logCtx, "Failed to update background manager status: %v", err)
 					}
-
 				case <-terminator.Done():
 					ticker.Stop()
 					return
@@ -136,10 +138,7 @@ func (b *BackgroundManager) Start(options map[string]interface{}) error {
 	}
 
 	go func() {
-		updateStatusClusterAwareCallback := func() error {
-			return b.UpdateStatusClusterAware()
-		}
-		err := b.Process.Run(options, updateStatusClusterAwareCallback, b.terminator)
+		err := b.Process.Run(options, b.UpdateStatusClusterAware, b.terminator)
 		if err != nil {
 			base.ErrorfCtx(logCtx, "Error: %v", err)
 			b.SetError(err)
@@ -342,6 +341,7 @@ func (b *BackgroundManager) Stop() error {
 // Only to be used internally to this file and by tests.
 func (b *BackgroundManager) Terminate() {
 	b.terminator.Close()
+	b.terminatorWaitGroup.Wait()
 }
 
 func (b *BackgroundManager) markStop() error {


### PR DESCRIPTION
CBG-2278

Fix ClusterAware BackgroundManager teardown race by making Terminate() block until the other background goroutine has exited.

Should fix `TestResync` which was panicing writing a status doc to a closed bucket on teardown.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/751/