### PR TITLE
CBG-2315: Disallow changing scope after DB creation

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -508,7 +508,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 
 	if !h.server.persistentConfig {
 		updatedDbConfig := &DatabaseConfig{DbConfig: *dbConfig}
-		err = updatedDbConfig.validateConfigUpdate(h.ctx(), h.db.Options, validateOIDC)
+		err = updatedDbConfig.validateConfigUpdate(h.ctx(), h.db.DatabaseContext, validateOIDC)
 		if err != nil {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
@@ -550,7 +550,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 			if err := dbConfig.validatePersistentDbConfig(); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
-			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), h.db.Options, validateOIDC); err != nil {
+			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), h.db.DatabaseContext, validateOIDC); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
 
@@ -714,7 +714,7 @@ func (h *handler) handlePutDbConfigSync() error {
 
 			bucketDbConfig.Sync = &js
 
-			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), h.db.Options, !h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
+			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), h.db.DatabaseContext, !h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
 
@@ -867,7 +867,7 @@ func (h *handler) handlePutDbConfigImportFilter() error {
 
 			bucketDbConfig.ImportFilter = &js
 
-			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), h.db.Options, !h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
+			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), h.db.DatabaseContext, !h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -508,7 +508,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 
 	if !h.server.persistentConfig {
 		updatedDbConfig := &DatabaseConfig{DbConfig: *dbConfig}
-		err = updatedDbConfig.validateConfigUpdate(h.ctx(), h.db.DatabaseContext, validateOIDC)
+		err = updatedDbConfig.validate(h.ctx(), validateOIDC)
 		if err != nil {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
@@ -550,7 +550,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 			if err := dbConfig.validatePersistentDbConfig(); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
-			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), h.db.DatabaseContext, validateOIDC); err != nil {
+			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), bucketDbConfig.DbConfig, validateOIDC); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
 
@@ -714,7 +714,7 @@ func (h *handler) handlePutDbConfigSync() error {
 
 			bucketDbConfig.Sync = &js
 
-			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), h.db.DatabaseContext, !h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
+			if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
 
@@ -867,7 +867,7 @@ func (h *handler) handlePutDbConfigImportFilter() error {
 
 			bucketDbConfig.ImportFilter = &js
 
-			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), h.db.DatabaseContext, !h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
+			if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -537,6 +537,8 @@ func (h *handler) handlePutDbConfig() (err error) {
 				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 			}
 
+			oldBucketDbConfig := bucketDbConfig.DbConfig
+
 			if h.rq.Method == http.MethodPost {
 				base.TracefCtx(h.rq.Context(), base.KeyConfig, "merging upserted config into bucket config")
 				if err := base.ConfigMerge(&bucketDbConfig.DbConfig, dbConfig); err != nil {
@@ -550,7 +552,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 			if err := dbConfig.validatePersistentDbConfig(); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
-			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), bucketDbConfig.DbConfig, validateOIDC); err != nil {
+			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), oldBucketDbConfig, validateOIDC); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -508,7 +508,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 
 	if !h.server.persistentConfig {
 		updatedDbConfig := &DatabaseConfig{DbConfig: *dbConfig}
-		err = updatedDbConfig.validate(h.ctx(), validateOIDC)
+		err = updatedDbConfig.validateConfigUpdate(h.ctx(), h.db.Options, validateOIDC)
 		if err != nil {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
@@ -550,7 +550,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 			if err := dbConfig.validatePersistentDbConfig(); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
-			if err := bucketDbConfig.validate(h.ctx(), validateOIDC); err != nil {
+			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), h.db.Options, validateOIDC); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
 
@@ -714,7 +714,7 @@ func (h *handler) handlePutDbConfigSync() error {
 
 			bucketDbConfig.Sync = &js
 
-			if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
+			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), h.db.Options, !h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
 
@@ -867,7 +867,7 @@ func (h *handler) handlePutDbConfigImportFilter() error {
 
 			bucketDbConfig.ImportFilter = &js
 
-			if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
+			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), h.db.Options, !h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -533,7 +533,7 @@ func (dbConfig *DbConfig) validatePersistentDbConfig() (errorMessages error) {
 }
 
 // validateConfigUpdate combines the results of validate and validateChanges.
-func (dbConfig *DbConfig) validateConfigUpdate(ctx context.Context, old *db.DatabaseContext, validateOIDCConfig bool) error {
+func (dbConfig *DbConfig) validateConfigUpdate(ctx context.Context, old DbConfig, validateOIDCConfig bool) error {
 	err := dbConfig.validate(ctx, validateOIDCConfig)
 	var multiErr *base.MultiError
 	if !errors.As(err, &multiErr) {
@@ -545,7 +545,7 @@ func (dbConfig *DbConfig) validateConfigUpdate(ctx context.Context, old *db.Data
 
 // validateChanges compares the current DbConfig with the "old" config, and returns an error if any disallowed changes
 // are attempted.
-func (dbConfig *DbConfig) validateChanges(ctx context.Context, old *db.DatabaseContext) error {
+func (dbConfig *DbConfig) validateChanges(ctx context.Context, old DbConfig) error {
 	if len(dbConfig.Scopes) != len(old.Scopes) {
 		return fmt.Errorf("cannot change scopes after database creation")
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -549,18 +549,16 @@ func (dbConfig *DbConfig) validateChanges(ctx context.Context, old DbConfig) err
 	if len(dbConfig.Scopes) != len(old.Scopes) {
 		return fmt.Errorf("cannot change scopes after database creation")
 	}
-	if len(dbConfig.Scopes) > 0 {
-		// Collections Phase 1/2 permits only one scope
-		var newScope, oldScope string
-		for name := range dbConfig.Scopes {
-			newScope = name
-		}
-		for name := range old.Scopes {
-			oldScope = name
-		}
-		if newScope != oldScope {
-			return fmt.Errorf("cannot change scopes after database creation")
-		}
+	newScopes := make(base.Set, len(dbConfig.Scopes))
+	oldScopes := make(base.Set, len(old.Scopes))
+	for scopeName := range dbConfig.Scopes {
+		newScopes.Add(scopeName)
+	}
+	for scopeName := range old.Scopes {
+		oldScopes.Add(scopeName)
+	}
+	if !newScopes.Equals(oldScopes) {
+		return fmt.Errorf("cannot change scopes after database creation")
 	}
 	return nil
 }

--- a/rest/config.go
+++ b/rest/config.go
@@ -533,7 +533,7 @@ func (dbConfig *DbConfig) validatePersistentDbConfig() (errorMessages error) {
 }
 
 // validateConfigUpdate combines the results of validate and validateChanges.
-func (dbConfig *DbConfig) validateConfigUpdate(ctx context.Context, old db.DatabaseContextOptions, validateOIDCConfig bool) error {
+func (dbConfig *DbConfig) validateConfigUpdate(ctx context.Context, old *db.DatabaseContext, validateOIDCConfig bool) error {
 	err := dbConfig.validate(ctx, validateOIDCConfig)
 	var multiErr *base.MultiError
 	if !errors.As(err, &multiErr) {
@@ -545,7 +545,7 @@ func (dbConfig *DbConfig) validateConfigUpdate(ctx context.Context, old db.Datab
 
 // validateChanges compares the current DbConfig with the "old" config, and returns an error if any disallowed changes
 // are attempted.
-func (dbConfig *DbConfig) validateChanges(ctx context.Context, old db.DatabaseContextOptions) error {
+func (dbConfig *DbConfig) validateChanges(ctx context.Context, old *db.DatabaseContext) error {
 	if len(dbConfig.Scopes) != len(old.Scopes) {
 		return fmt.Errorf("cannot change scopes after database creation")
 	}


### PR DESCRIPTION
CBG-2315

Validate that the `scopes` property of the DB config cannot be changed after initial creation.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/755/
  * Likely flake.
- [x] `.*Collections.*` https://jenkins.sgwdev.com/job/SyncGateway-Integration/766/