### PR TITLE
Add TestMain goroutine profile

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -80,6 +80,9 @@ const (
 	// If set, corresponds to name of the docker image of couchbase server
 	TestEnvCouchbaseServerDockerName = "SG_TEST_COUCHBASE_SERVER_DOCKER_NAME"
 
+	// TestEnvGoroutineDump if set to true will capture a goroutine pprof profile and log the location at the end of each package
+	TestEnvGoroutineDump = "SG_TEST_GOROUTINE_DUMP"
+
 	DefaultUseXattrs      = true // Whether Sync Gateway uses xattrs for metadata storage, if not specified in the config
 	DefaultAllowConflicts = true // Whether Sync Gateway allows revision conflicts, if not specified in the config
 

--- a/base/main_test.go
+++ b/base/main_test.go
@@ -27,6 +27,9 @@ func TestMain(m *testing.M) {
 	GTestBucketPool = NewTestBucketPool(FlushBucketEmptierFunc, NoopInitFunc)
 	teardownFuncs = append(teardownFuncs, GTestBucketPool.Close)
 
+	// must be the last teardown function added to the list to correctly detect leaked goroutines
+	teardownFuncs = append(teardownFuncs, SetUpTestGoroutineDump(m))
+
 	// Run the test suite
 	status := m.Run()
 

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -335,6 +335,46 @@ func CreateProperty(size int) (result string) {
 	return string(resultBytes)
 }
 
+// SetUpTestGoroutineDump will collect a goroutine pprof profile when teardownFn is called. Intended to be run at the end of TestMain to give us insight into goroutine leaks.
+func SetUpTestGoroutineDump(m *testing.M) (teardownFn func()) {
+	const numExpected = 1
+
+	if ok, _ := strconv.ParseBool(os.Getenv(TestEnvGoroutineDump)); !ok {
+		return func() {}
+	}
+
+	timestamp := time.Now().Unix()
+	filename := fmt.Sprintf("test-pprof-%s-%d.pb.gz", "goroutine", timestamp)
+	// create the file upfront so we know we're able to write to it before we run tests
+	file, err := os.Create(filename)
+	if err != nil {
+		panic(err)
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	return func() {
+		if n := runtime.NumGoroutine() - numExpected; n > 0 {
+			if err := pprof.Lookup("goroutine").WriteTo(os.Stderr, 2); err != nil {
+				panic(err)
+			}
+			if err := pprof.Lookup("goroutine").WriteTo(file, 0); err != nil {
+				panic(err)
+			}
+			log.Printf(color("\n"+
+				"TEST: =================================================\n"+
+				"TEST: Leaked goroutines after testing: got %d expected %d\n"+
+				"TEST: =================================================\n", LevelError), n, numExpected)
+			log.Printf("TEST: Written goroutine profile to: %s%c%s", wd, os.PathSeparator, file.Name())
+		} else {
+			log.Print(color("TEST: No leaked goroutines found", LevelDebug))
+		}
+	}
+}
+
 // SetUpGlobalTestMemoryWatermark will periodically write an in-use memory watermark,
 // and will cause the tests to fail on teardown if the watermark has exceeded the threshold.
 func SetUpGlobalTestMemoryWatermark(m *testing.M, memWatermarkThresholdMB uint64) (teardownFn func()) {

--- a/channels/main_test.go
+++ b/channels/main_test.go
@@ -26,6 +26,9 @@ func TestMain(m *testing.M) {
 
 	base.SkipPrometheusStatsRegistration = true
 
+	// must be the last teardown function added to the list to correctly detect leaked goroutines
+	teardownFuncs = append(teardownFuncs, base.SetUpTestGoroutineDump(m))
+
 	// Run the test suite
 	status := m.Run()
 

--- a/db/main_test.go
+++ b/db/main_test.go
@@ -29,6 +29,9 @@ func TestMain(m *testing.M) {
 	base.GTestBucketPool = base.NewTestBucketPool(ViewsAndGSIBucketReadier, ViewsAndGSIBucketInit)
 	teardownFuncs = append(teardownFuncs, base.GTestBucketPool.Close)
 
+	// must be the last teardown function added to the list to correctly detect leaked goroutines
+	teardownFuncs = append(teardownFuncs, base.SetUpTestGoroutineDump(m))
+
 	// Run the test suite
 	status := m.Run()
 

--- a/rest/main_test.go
+++ b/rest/main_test.go
@@ -32,6 +32,9 @@ func TestMain(m *testing.M) {
 	base.GTestBucketPool = base.NewTestBucketPool(db.ViewsAndGSIBucketReadier, db.ViewsAndGSIBucketInit)
 	teardownFuncs = append(teardownFuncs, base.GTestBucketPool.Close)
 
+	// must be the last teardown function added to the list to correctly detect leaked goroutines
+	teardownFuncs = append(teardownFuncs, base.SetUpTestGoroutineDump(m))
+
 	// Run the test suite
 	status := m.Run()
 


### PR DESCRIPTION
CBG-2367

Opt-in with env var `SG_TEST_GOROUTINE_DUMP=true`
- If we see more than the 1 expected goroutine at the end of TestMain:
  - Will print a plaintext goroutine dump
  - Will write a pprof goroutine profile to the current working directory and log its name

Example outputs:
```
2022/09/02 13:37:14 TEST: No leaked goroutines found
ok  	github.com/couchbase/sync_gateway/auth	5.983s
```

```
goroutine 1 [running]:
runtime/pprof.writeGoroutineStacks({0x1e34520, 0xc000014020})
	/usr/local/Cellar/go/1.19/libexec/src/runtime/pprof/pprof.go:692 +0x70
runtime/pprof.writeGoroutine({0x1e34520?, 0xc000014020?}, 0x10a4400?)
	/usr/local/Cellar/go/1.19/libexec/src/runtime/pprof/pprof.go:681 +0x2b
runtime/pprof.(*Profile).WriteTo(0x1c89755?, {0x1e34520?, 0xc000014020?}, 0x0?)
	/usr/local/Cellar/go/1.19/libexec/src/runtime/pprof/pprof.go:330 +0x14b
github.com/couchbase/sync_gateway/base.SetUpTestGoroutineDump.func2()
	/Users/benbrooks/dev/cb/sg/base/util_testing.go:361 +0x168
github.com/couchbase/sync_gateway/auth.TestMain(0xffffffffffffffff?)
	/Users/benbrooks/dev/cb/sg/auth/main_test.go:40 +0x336
main.main()
	_testmain.go:239 +0x1d3

goroutine 127 [select]:
github.com/couchbase/sync_gateway/auth.(*OIDCProvider).startDiscoverySync.func1()
	/Users/benbrooks/dev/cb/sg/auth/oidc.go:696 +0xbf
created by github.com/couchbase/sync_gateway/auth.(*OIDCProvider).startDiscoverySync
	/Users/benbrooks/dev/cb/sg/auth/oidc.go:694 +0x1ac
```
...
```
2022/09/02 13:46:26
TEST: =================================================
TEST: Leaked goroutines after testing: got 9 expected 1
TEST: =================================================

2022/09/02 13:46:26 TEST: Written goroutine profile to: /Users/benbrooks/dev/cb/sg/auth/test-pprof-goroutine-1662122781.pb.gz
ok  	github.com/couchbase/sync_gateway/auth	6.099s
```

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a