### PR TITLE
CBG-2242: fix errors.As in tests

### DIFF
--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -28,6 +28,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -1656,7 +1657,16 @@ func TestLoadJavaScript(t *testing.T) {
 			}()
 			js, err := loadJavaScript(inputJavaScriptOrPath, test.insecureSkipVerify)
 			if test.errExpected != nil {
-				require.True(t, assert.ErrorAs(t, err, &test.errExpected))
+				errx509Type := x509.UnknownAuthorityError{}
+				if test.errExpected == errx509Type {
+					expectedErrorString := test.errExpected.Error()
+					if runtime.GOOS == "darwin" {
+						expectedErrorString = "certificate is not trusted"
+					}
+					require.ErrorContains(t, err, expectedErrorString)
+				} else {
+					require.ErrorContains(t, err, test.errExpected.Error())
+				}
 			}
 			assert.Equal(t, test.jsExpected, js)
 		})
@@ -1812,16 +1822,18 @@ func TestSetupDbConfigWithSyncFunction(t *testing.T) {
 					RemoteConfigTlsSkipVerify: true,
 				}
 			}
-			if test.errExpected != nil {
-				test.errExpected = &JavaScriptLoadError{
-					JSLoadType: SyncFunction,
-					Path:       sync,
-					Err:        test.errExpected,
-				}
-			}
 			err := dbConfig.setup(dbConfig.Name, BootstrapConfig{}, nil, nil, false)
 			if test.errExpected != nil {
-				require.True(t, assert.ErrorAs(t, err, &test.errExpected))
+				errx509Type := x509.UnknownAuthorityError{}
+				if test.errExpected == errx509Type {
+					expectedErrorString := test.errExpected.Error()
+					if runtime.GOOS == "darwin" {
+						expectedErrorString = "certificate is not trusted"
+					}
+					require.ErrorContains(t, err, expectedErrorString)
+				} else {
+					require.ErrorContains(t, err, test.errExpected.Error())
+				}
 			} else {
 				assert.Equal(t, test.jsSyncFnExpected, *dbConfig.Sync)
 			}
@@ -1912,16 +1924,18 @@ func TestSetupDbConfigWithImportFilterFunction(t *testing.T) {
 					RemoteConfigTlsSkipVerify: true,
 				}
 			}
-			if test.errExpected != nil {
-				test.errExpected = &JavaScriptLoadError{
-					JSLoadType: ImportFilter,
-					Path:       importFilter,
-					Err:        test.errExpected,
-				}
-			}
 			err := dbConfig.setup(dbConfig.Name, BootstrapConfig{}, nil, nil, false)
 			if test.errExpected != nil {
-				require.True(t, assert.ErrorAs(t, err, &test.errExpected))
+				errx509Type := x509.UnknownAuthorityError{}
+				if test.errExpected == errx509Type {
+					expectedErrorString := test.errExpected.Error()
+					if runtime.GOOS == "darwin" {
+						expectedErrorString = "certificate is not trusted"
+					}
+					require.ErrorContains(t, err, expectedErrorString)
+				} else {
+					require.ErrorContains(t, err, test.errExpected.Error())
+				}
 			} else {
 				assert.Equal(t, test.jsImportFilterExpected, *dbConfig.ImportFilter)
 			}
@@ -2024,16 +2038,18 @@ func TestSetupDbConfigWithConflictResolutionFunction(t *testing.T) {
 					RemoteConfigTlsSkipVerify: true,
 				}
 			}
-			if test.errExpected != nil {
-				test.errExpected = &JavaScriptLoadError{
-					JSLoadType: ConflictResolver,
-					Path:       conflictResolutionFn,
-					Err:        test.errExpected,
-				}
-			}
 			err := dbConfig.setup(dbConfig.Name, BootstrapConfig{}, nil, nil, false)
 			if test.errExpected != nil {
-				require.True(t, assert.ErrorAs(t, err, &test.errExpected))
+				errx509Type := x509.UnknownAuthorityError{}
+				if test.errExpected == errx509Type {
+					expectedErrorString := test.errExpected.Error()
+					if runtime.GOOS == "darwin" {
+						expectedErrorString = "certificate is not trusted"
+					}
+					require.ErrorContains(t, err, expectedErrorString)
+				} else {
+					require.ErrorContains(t, err, test.errExpected.Error())
+				}
 			} else {
 				require.NotNil(t, dbConfig.Replications["replication1"])
 				conflictResolutionFnActual := dbConfig.Replications["replication1"].ConflictResolutionFn
@@ -2141,7 +2157,16 @@ func TestWebhookFilterFunctionLoad(t *testing.T) {
 			sc := &ServerContext{}
 			err := sc.initEventHandlers(ctx, &dbConfig)
 			if test.errExpected != nil {
-				require.True(t, assert.ErrorAs(t, err, &test.errExpected))
+				errx509Type := x509.UnknownAuthorityError{}
+				if test.errExpected == errx509Type {
+					expectedErrorString := test.errExpected.Error()
+					if runtime.GOOS == "darwin" {
+						expectedErrorString = "certificate is not trusted"
+					}
+					require.ErrorContains(t, err, expectedErrorString)
+				} else {
+					require.ErrorContains(t, err, test.errExpected.Error())
+				}
 			}
 		})
 	}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1656,7 +1656,7 @@ func TestLoadJavaScript(t *testing.T) {
 			}()
 			js, err := loadJavaScript(inputJavaScriptOrPath, test.insecureSkipVerify)
 			if test.errExpected != nil {
-				require.True(t, errors.As(err, &test.errExpected)) // nolint: govet // CBG-2242
+				require.True(t, assert.ErrorAs(t, err, &test.errExpected))
 			}
 			assert.Equal(t, test.jsExpected, js)
 		})
@@ -1821,7 +1821,7 @@ func TestSetupDbConfigWithSyncFunction(t *testing.T) {
 			}
 			err := dbConfig.setup(dbConfig.Name, BootstrapConfig{}, nil, nil, false)
 			if test.errExpected != nil {
-				require.True(t, errors.As(err, &test.errExpected)) // nolint: govet // CBG-2242
+				require.True(t, assert.ErrorAs(t, err, &test.errExpected))
 			} else {
 				assert.Equal(t, test.jsSyncFnExpected, *dbConfig.Sync)
 			}
@@ -1921,7 +1921,7 @@ func TestSetupDbConfigWithImportFilterFunction(t *testing.T) {
 			}
 			err := dbConfig.setup(dbConfig.Name, BootstrapConfig{}, nil, nil, false)
 			if test.errExpected != nil {
-				require.True(t, errors.As(err, &test.errExpected)) // nolint: govet // CBG-2242
+				require.True(t, assert.ErrorAs(t, err, &test.errExpected))
 			} else {
 				assert.Equal(t, test.jsImportFilterExpected, *dbConfig.ImportFilter)
 			}
@@ -2033,7 +2033,7 @@ func TestSetupDbConfigWithConflictResolutionFunction(t *testing.T) {
 			}
 			err := dbConfig.setup(dbConfig.Name, BootstrapConfig{}, nil, nil, false)
 			if test.errExpected != nil {
-				require.True(t, errors.As(err, &test.errExpected)) // nolint: govet // CBG-2242
+				require.True(t, assert.ErrorAs(t, err, &test.errExpected))
 			} else {
 				require.NotNil(t, dbConfig.Replications["replication1"])
 				conflictResolutionFnActual := dbConfig.Replications["replication1"].ConflictResolutionFn
@@ -2141,7 +2141,7 @@ func TestWebhookFilterFunctionLoad(t *testing.T) {
 			sc := &ServerContext{}
 			err := sc.initEventHandlers(ctx, &dbConfig)
 			if test.errExpected != nil {
-				require.True(t, errors.As(err, &test.errExpected)) // nolint: govet // CBG-2242
+				require.True(t, assert.ErrorAs(t, err, &test.errExpected))
 			}
 		})
 	}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1657,7 +1657,7 @@ func TestLoadJavaScript(t *testing.T) {
 			}()
 			js, err := loadJavaScript(inputJavaScriptOrPath, test.insecureSkipVerify)
 			if test.errExpected != nil {
-				assertX509UnknownAuthority(t, err, test.errExpected)
+				requireErrorWithX509UnknownAuthority(t, err, test.errExpected)
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, test.jsExpected, js)
@@ -1817,7 +1817,7 @@ func TestSetupDbConfigWithSyncFunction(t *testing.T) {
 			}
 			err := dbConfig.setup(dbConfig.Name, BootstrapConfig{}, nil, nil, false)
 			if test.errExpected != nil {
-				assertX509UnknownAuthority(t, err, test.errExpected)
+				requireErrorWithX509UnknownAuthority(t, err, test.errExpected)
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, test.jsSyncFnExpected, *dbConfig.Sync)
@@ -1911,7 +1911,7 @@ func TestSetupDbConfigWithImportFilterFunction(t *testing.T) {
 			}
 			err := dbConfig.setup(dbConfig.Name, BootstrapConfig{}, nil, nil, false)
 			if test.errExpected != nil {
-				assertX509UnknownAuthority(t, err, test.errExpected)
+				requireErrorWithX509UnknownAuthority(t, err, test.errExpected)
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, test.jsImportFilterExpected, *dbConfig.ImportFilter)
@@ -2017,7 +2017,7 @@ func TestSetupDbConfigWithConflictResolutionFunction(t *testing.T) {
 			}
 			err := dbConfig.setup(dbConfig.Name, BootstrapConfig{}, nil, nil, false)
 			if test.errExpected != nil {
-				assertX509UnknownAuthority(t, err, test.errExpected)
+				requireErrorWithX509UnknownAuthority(t, err, test.errExpected)
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, dbConfig.Replications["replication1"])
@@ -2126,7 +2126,7 @@ func TestWebhookFilterFunctionLoad(t *testing.T) {
 			sc := &ServerContext{}
 			err := sc.initEventHandlers(ctx, &dbConfig)
 			if test.errExpected != nil {
-				assertX509UnknownAuthority(t, err, test.errExpected)
+				requireErrorWithX509UnknownAuthority(t, err, test.errExpected)
 			} else {
 				require.NoError(t, err)
 			}
@@ -2609,7 +2609,9 @@ func TestCollectionsValidation(t *testing.T) {
 	}
 }
 
-func assertX509UnknownAuthority(t testing.TB, actual, expected error) {
+// This function allows for error checking on both x509.UnknownAuthorityError non-x509.UnknownAuthorityError types as we switch on the expected error type
+// We get OS specific errors on x509.UnknownAuthorityError so we switch the expected error string if on darwin OS
+func requireErrorWithX509UnknownAuthority(t testing.TB, actual, expected error) {
 	expectedErrorString := expected.Error()
 	switch errorType := expected.(type) {
 	case x509.UnknownAuthorityError:

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2113,13 +2113,6 @@ func TestWebhookFilterFunctionLoad(t *testing.T) {
 					RemoteConfigTlsSkipVerify: true,
 				}
 			}
-			if test.errExpected != nil {
-				test.errExpected = &JavaScriptLoadError{
-					JSLoadType: WebhookFilter,
-					Path:       webhookFilter,
-					Err:        test.errExpected,
-				}
-			}
 			terminator := make(chan bool)
 			defer close(terminator)
 			ctx := &db.DatabaseContext{EventMgr: db.NewEventManager(terminator)}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1659,11 +1659,7 @@ func TestLoadJavaScript(t *testing.T) {
 			if test.errExpected != nil {
 				errx509Type := x509.UnknownAuthorityError{}
 				if test.errExpected == errx509Type {
-					expectedErrorString := test.errExpected.Error()
-					if runtime.GOOS == "darwin" {
-						expectedErrorString = "certificate is not trusted"
-					}
-					require.ErrorContains(t, err, expectedErrorString)
+					require.ErrorContains(t, err, assertX509UnknownAuthority(test.errExpected))
 				} else {
 					require.ErrorContains(t, err, test.errExpected.Error())
 				}
@@ -1826,11 +1822,7 @@ func TestSetupDbConfigWithSyncFunction(t *testing.T) {
 			if test.errExpected != nil {
 				errx509Type := x509.UnknownAuthorityError{}
 				if test.errExpected == errx509Type {
-					expectedErrorString := test.errExpected.Error()
-					if runtime.GOOS == "darwin" {
-						expectedErrorString = "certificate is not trusted"
-					}
-					require.ErrorContains(t, err, expectedErrorString)
+					require.ErrorContains(t, err, assertX509UnknownAuthority(test.errExpected))
 				} else {
 					require.ErrorContains(t, err, test.errExpected.Error())
 				}
@@ -1928,11 +1920,7 @@ func TestSetupDbConfigWithImportFilterFunction(t *testing.T) {
 			if test.errExpected != nil {
 				errx509Type := x509.UnknownAuthorityError{}
 				if test.errExpected == errx509Type {
-					expectedErrorString := test.errExpected.Error()
-					if runtime.GOOS == "darwin" {
-						expectedErrorString = "certificate is not trusted"
-					}
-					require.ErrorContains(t, err, expectedErrorString)
+					require.ErrorContains(t, err, assertX509UnknownAuthority(test.errExpected))
 				} else {
 					require.ErrorContains(t, err, test.errExpected.Error())
 				}
@@ -2042,11 +2030,7 @@ func TestSetupDbConfigWithConflictResolutionFunction(t *testing.T) {
 			if test.errExpected != nil {
 				errx509Type := x509.UnknownAuthorityError{}
 				if test.errExpected == errx509Type {
-					expectedErrorString := test.errExpected.Error()
-					if runtime.GOOS == "darwin" {
-						expectedErrorString = "certificate is not trusted"
-					}
-					require.ErrorContains(t, err, expectedErrorString)
+					require.ErrorContains(t, err, assertX509UnknownAuthority(test.errExpected))
 				} else {
 					require.ErrorContains(t, err, test.errExpected.Error())
 				}
@@ -2159,11 +2143,7 @@ func TestWebhookFilterFunctionLoad(t *testing.T) {
 			if test.errExpected != nil {
 				errx509Type := x509.UnknownAuthorityError{}
 				if test.errExpected == errx509Type {
-					expectedErrorString := test.errExpected.Error()
-					if runtime.GOOS == "darwin" {
-						expectedErrorString = "certificate is not trusted"
-					}
-					require.ErrorContains(t, err, expectedErrorString)
+					require.ErrorContains(t, err, assertX509UnknownAuthority(test.errExpected))
 				} else {
 					require.ErrorContains(t, err, test.errExpected.Error())
 				}
@@ -2645,4 +2625,12 @@ func TestCollectionsValidation(t *testing.T) {
 
 		})
 	}
+}
+
+func assertX509UnknownAuthority(err error) string {
+	expectedErrorString := err.Error()
+	if runtime.GOOS == "darwin" {
+		expectedErrorString = "certificate is not trusted"
+	}
+	return expectedErrorString
 }

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2123,12 +2123,7 @@ func TestWebhookFilterFunctionLoad(t *testing.T) {
 			sc := &ServerContext{}
 			err := sc.initEventHandlers(ctx, &dbConfig)
 			if test.errExpected != nil {
-				errx509Type := x509.UnknownAuthorityError{}
-				if test.errExpected == errx509Type {
-					assertX509UnknownAuthority(t, err, test.errExpected)
-				} else {
-					require.ErrorContains(t, err, test.errExpected.Error())
-				}
+				assertX509UnknownAuthority(t, err, test.errExpected)
 			}
 		})
 	}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1819,6 +1819,7 @@ func TestSetupDbConfigWithSyncFunction(t *testing.T) {
 			if test.errExpected != nil {
 				assertX509UnknownAuthority(t, err, test.errExpected)
 			} else {
+				require.NoError(t, err)
 				assert.Equal(t, test.jsSyncFnExpected, *dbConfig.Sync)
 			}
 		})
@@ -1912,6 +1913,7 @@ func TestSetupDbConfigWithImportFilterFunction(t *testing.T) {
 			if test.errExpected != nil {
 				assertX509UnknownAuthority(t, err, test.errExpected)
 			} else {
+				require.NoError(t, err)
 				assert.Equal(t, test.jsImportFilterExpected, *dbConfig.ImportFilter)
 			}
 		})
@@ -2124,6 +2126,8 @@ func TestWebhookFilterFunctionLoad(t *testing.T) {
 			err := sc.initEventHandlers(ctx, &dbConfig)
 			if test.errExpected != nil {
 				assertX509UnknownAuthority(t, err, test.errExpected)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2019,6 +2019,7 @@ func TestSetupDbConfigWithConflictResolutionFunction(t *testing.T) {
 			if test.errExpected != nil {
 				assertX509UnknownAuthority(t, err, test.errExpected)
 			} else {
+				require.NoError(t, err)
 				require.NotNil(t, dbConfig.Replications["replication1"])
 				conflictResolutionFnActual := dbConfig.Replications["replication1"].ConflictResolutionFn
 				assert.Equal(t, test.jsConflictResExpected, conflictResolutionFnActual)


### PR DESCRIPTION
CBG-2242

Small changes to config_test.go to fix issues with Errors.As in new version of go. Using testify package seems to fix the issue. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] N/A