### PR TITLE
Add addlicense template, CI check and run `addlicense` fo existing files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,17 @@ jobs:
       - name: go-build
         run: go build "./..."
 
+  addlicense:
+    name: addlicense
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18.5
+      - run: go install github.com/google/addlicense@latest
+      - uses: actions/checkout@v3
+      - run: addlicense -check -f licenses/addlicense.tmpl .
+
   golangci:
     name: lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.18.5
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: go-build
         run: go build "./..."
 
@@ -65,10 +65,10 @@ jobs:
       GOPRIVATE: github.com/couchbaselabs
       MallocNanoZone: 0
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.18.5
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
@@ -85,10 +85,10 @@ jobs:
     env:
       GOPRIVATE: github.com/couchbaselabs
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.18.5
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run Tests
         run: go test -race -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package auth
 
 import (

--- a/auth/jwt_test.go
+++ b/auth/jwt_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package auth
 
 import (

--- a/auth/jwt_test_utils.go
+++ b/auth/jwt_test_utils.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package auth
 
 import (

--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/bootstrap_test.go
+++ b/base/bootstrap_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/bucket_xattr.go
+++ b/base/bucket_xattr.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/collection_utils.go
+++ b/base/collection_utils.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/dcp_client_metadata.go
+++ b/base/dcp_client_metadata.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/dcp_client_stream_event.go
+++ b/base/dcp_client_stream_event.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/dcp_client_stream_observer.go
+++ b/base/dcp_client_stream_observer.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/dcp_client_worker.go
+++ b/base/dcp_client_worker.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/dcp_feed_type.go
+++ b/base/dcp_feed_type.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/dcp_sharded_test.go
+++ b/base/dcp_sharded_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/gocb_dcp_feed.go
+++ b/base/gocb_dcp_feed.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/gocb_utils_test.go
+++ b/base/gocb_utils_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/logger_external_test.go
+++ b/base/logger_external_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/version_comparable.go
+++ b/base/version_comparable.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/version_comparable_test.go
+++ b/base/version_comparable_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/build/windows/wix_installer/Config.wxi
+++ b/build/windows/wix_installer/Config.wxi
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2022-Present Couchbase, Inc.
+
+ Use of this software is governed by the Business Source License included
+ in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+ in that file, in accordance with the Business Source License, use of this
+ software will be governed by the Apache License, Version 2.0, included in
+ the file licenses/APL2.txt.
+-->
+
 <Include>
   <?ifndef Company ?>
     <?define Company = "Couchbase"?>

--- a/build/windows/wix_installer/sync-gateway.wxs
+++ b/build/windows/wix_installer/sync-gateway.wxs
@@ -1,4 +1,14 @@
 <?xml version='1.0' encoding='Windows-1252'?>
+<!--
+ Copyright 2022-Present Couchbase, Inc.
+
+ Use of this software is governed by the Business Source License included
+ in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+ in that file, in accordance with the Business Source License, use of this
+ software will be governed by the Apache License, Version 2.0, included in
+ the file licenses/APL2.txt.
+-->
+
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'
      xmlns:util='http://schemas.microsoft.com/wix/UtilExtension'>
 

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package db
 
 import (

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package db
 
 import (

--- a/db/blip_handler_collections.go
+++ b/db/blip_handler_collections.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package db
 
 import (

--- a/db/blip_handler_collections_test.go
+++ b/db/blip_handler_collections_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package db
 
 import (

--- a/db/blip_handler_test.go
+++ b/db/blip_handler_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package db
 
 import (

--- a/db/dcp_sharded_upgrade_test.go
+++ b/db/dcp_sharded_upgrade_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package db
 
 import (

--- a/db/design_doc_util_test.go
+++ b/db/design_doc_util_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package db
 
 import (

--- a/db/validation.go
+++ b/db/validation.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package db
 
 import (

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 openapi: 3.0.3
 info:
   title: Sync Gateway

--- a/docs/api/components/parameters.yaml
+++ b/docs/api/components/parameters.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 DB-config-If-Match:
   name: If-Match
   in: header

--- a/docs/api/components/requestBodies.yaml
+++ b/docs/api/components/requestBodies.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 User:
   content:
     application/json:

--- a/docs/api/components/responses.yaml
+++ b/docs/api/components/responses.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 Not-found:
   description: Resource could not be found
   content:

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 ExpVars:
   type: object
   properties:

--- a/docs/api/metric.yaml
+++ b/docs/api/metric.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 openapi: 3.0.3
 info:
   title: Sync Gateway

--- a/docs/api/paths/admin/_all_dbs.yaml
+++ b/docs/api/paths/admin/_all_dbs.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get a list of all the databases
   description: |-

--- a/docs/api/paths/admin/_config.yaml
+++ b/docs/api/paths/admin/_config.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get server configuration
   description: |-

--- a/docs/api/paths/admin/_debug~fgprof.yaml
+++ b/docs/api/paths/admin/_debug~fgprof.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get fgprof profile
   description: |-

--- a/docs/api/paths/admin/_debug~pprof~block.yaml
+++ b/docs/api/paths/admin/_debug~pprof~block.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get block profile
   description: |-

--- a/docs/api/paths/admin/_debug~pprof~cmdline.yaml
+++ b/docs/api/paths/admin/_debug~pprof~cmdline.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get passed in command line parameters
   description: |-

--- a/docs/api/paths/admin/_debug~pprof~goroutine.yaml
+++ b/docs/api/paths/admin/_debug~pprof~goroutine.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get goroutine profile
   description: |-

--- a/docs/api/paths/admin/_debug~pprof~heap.yaml
+++ b/docs/api/paths/admin/_debug~pprof~heap.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get the heap pprof debug file
   description: |-

--- a/docs/api/paths/admin/_debug~pprof~mutex.yaml
+++ b/docs/api/paths/admin/_debug~pprof~mutex.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get mutex profile
   description: |-

--- a/docs/api/paths/admin/_debug~pprof~profile.yaml
+++ b/docs/api/paths/admin/_debug~pprof~profile.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get the profile pprof debug file
   description: |-

--- a/docs/api/paths/admin/_debug~pprof~symbol.yaml
+++ b/docs/api/paths/admin/_debug~pprof~symbol.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get symbol pprof debug information
   description: |-

--- a/docs/api/paths/admin/_debug~pprof~threadcreate.yaml
+++ b/docs/api/paths/admin/_debug~pprof~threadcreate.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get the threadcreate pprof debug file
   description: |-

--- a/docs/api/paths/admin/_debug~pprof~trace.yaml
+++ b/docs/api/paths/admin/_debug~pprof~trace.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get trace profile
   description: |-

--- a/docs/api/paths/admin/_expvar.yaml
+++ b/docs/api/paths/admin/_expvar.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get all Sync Gateway statistics
   description: |-

--- a/docs/api/paths/admin/_heap.yaml
+++ b/docs/api/paths/admin/_heap.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 post:
   summary: Dump heap profile
   description: |-

--- a/docs/api/paths/admin/_logging.yaml
+++ b/docs/api/paths/admin/_logging.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get console logging settings
   description: |-

--- a/docs/api/paths/admin/_post_upgrade.yaml
+++ b/docs/api/paths/admin/_post_upgrade.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 post:
   summary: Run the post upgrade process on all databases
   description: |-

--- a/docs/api/paths/admin/_profile.yaml
+++ b/docs/api/paths/admin/_profile.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 post:
   summary: Start or Stop continuous CPU profiling
   description: |-

--- a/docs/api/paths/admin/_profile~{profilename}.yaml
+++ b/docs/api/paths/admin/_profile~{profilename}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - name: profilename
     in: path

--- a/docs/api/paths/admin/_sgcollect_info.yaml
+++ b/docs/api/paths/admin/_sgcollect_info.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get the status of the Sync Gateway Collect Info
   description: |-

--- a/docs/api/paths/admin/_stats.yaml
+++ b/docs/api/paths/admin/_stats.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get memory statistics
   description: |-

--- a/docs/api/paths/admin/_status.yaml
+++ b/docs/api/paths/admin/_status.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get the server status
   description: |-

--- a/docs/api/paths/admin/{db}~.yaml
+++ b/docs/api/paths/admin/{db}~.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/admin/{db}~_all_docs.yaml
+++ b/docs/api/paths/admin/{db}~_all_docs.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/admin/{db}~_blipsync.yaml
+++ b/docs/api/paths/admin/{db}~_blipsync.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/admin/{db}~_changes.yaml
+++ b/docs/api/paths/admin/{db}~_changes.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/admin/{db}~_config.yaml
+++ b/docs/api/paths/admin/{db}~_config.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get database configuration
   description: |-

--- a/docs/api/paths/admin/{db}~_config~import_filter.yaml
+++ b/docs/api/paths/admin/{db}~_config~import_filter.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/admin/{db}~_config~sync.yaml
+++ b/docs/api/paths/admin/{db}~_config~sync.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/admin/{db}~_design~{ddoc}.yaml
+++ b/docs/api/paths/admin/{db}~_design~{ddoc}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/ddoc

--- a/docs/api/paths/admin/{db}~_design~{ddoc}~_view~{view}.yaml
+++ b/docs/api/paths/admin/{db}~_design~{ddoc}~_view~{view}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/ddoc

--- a/docs/api/paths/admin/{db}~_dumpchannel~{channel}.yaml
+++ b/docs/api/paths/admin/{db}~_dumpchannel~{channel}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - name: channel

--- a/docs/api/paths/admin/{db}~_dump~{view}.yaml
+++ b/docs/api/paths/admin/{db}~_dump~{view}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/view

--- a/docs/api/paths/admin/{db}~_ensure_full_commit.yaml
+++ b/docs/api/paths/admin/{db}~_ensure_full_commit.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:

--- a/docs/api/paths/admin/{db}~_facebook.yaml
+++ b/docs/api/paths/admin/{db}~_facebook.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:

--- a/docs/api/paths/admin/{db}~_flush.yaml
+++ b/docs/api/paths/admin/{db}~_flush.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:

--- a/docs/api/paths/admin/{db}~_google.yaml
+++ b/docs/api/paths/admin/{db}~_google.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:

--- a/docs/api/paths/admin/{db}~_offline.yaml
+++ b/docs/api/paths/admin/{db}~_offline.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:

--- a/docs/api/paths/admin/{db}~_oidc.yaml
+++ b/docs/api/paths/admin/{db}~_oidc.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/admin/{db}~_oidc_callback.yaml
+++ b/docs/api/paths/admin/{db}~_oidc_callback.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/admin/{db}~_oidc_challenge.yaml
+++ b/docs/api/paths/admin/{db}~_oidc_challenge.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/admin/{db}~_oidc_refresh.yaml
+++ b/docs/api/paths/admin/{db}~_oidc_refresh.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/admin/{db}~_oidc_testing~.well-known~openid-configuration.yaml
+++ b/docs/api/paths/admin/{db}~_oidc_testing~.well-known~openid-configuration.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/admin/{db}~_oidc_testing~authenticate.yaml
+++ b/docs/api/paths/admin/{db}~_oidc_testing~authenticate.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/admin/{db}~_oidc_testing~authorize.yaml
+++ b/docs/api/paths/admin/{db}~_oidc_testing~authorize.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/admin/{db}~_oidc_testing~certs.yaml
+++ b/docs/api/paths/admin/{db}~_oidc_testing~certs.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/admin/{db}~_oidc_testing~token.yaml
+++ b/docs/api/paths/admin/{db}~_oidc_testing~token.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:

--- a/docs/api/paths/admin/{db}~_online.yaml
+++ b/docs/api/paths/admin/{db}~_online.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:

--- a/docs/api/paths/admin/{db}~_repair.yaml
+++ b/docs/api/paths/admin/{db}~_repair.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:

--- a/docs/api/paths/admin/{db}~_replicationStatus~.yaml
+++ b/docs/api/paths/admin/{db}~_replicationStatus~.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/admin/{db}~_replicationStatus~{replicationid}.yaml
+++ b/docs/api/paths/admin/{db}~_replicationStatus~{replicationid}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/replicationid

--- a/docs/api/paths/admin/{db}~_replication~.yaml
+++ b/docs/api/paths/admin/{db}~_replication~.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/admin/{db}~_replication~{replicationid}.yaml
+++ b/docs/api/paths/admin/{db}~_replication~{replicationid}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/replicationid

--- a/docs/api/paths/admin/{db}~_role~.yaml
+++ b/docs/api/paths/admin/{db}~_role~.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/admin/{db}~_role~{name}.yaml
+++ b/docs/api/paths/admin/{db}~_role~{name}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/role-name

--- a/docs/api/paths/admin/{db}~_session.yaml
+++ b/docs/api/paths/admin/{db}~_session.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/admin/{db}~_session~{sessionid}.yaml
+++ b/docs/api/paths/admin/{db}~_session~{sessionid}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/sessionid

--- a/docs/api/paths/admin/{db}~_user~.yaml
+++ b/docs/api/paths/admin/{db}~_user~.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/admin/{db}~_user~{name}.yaml
+++ b/docs/api/paths/admin/{db}~_user~{name}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/user-name

--- a/docs/api/paths/admin/{db}~_user~{name}~_session.yaml
+++ b/docs/api/paths/admin/{db}~_user~{name}~_session.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/user-name

--- a/docs/api/paths/admin/{db}~_user~{name}~_session~{sessionid}.yaml
+++ b/docs/api/paths/admin/{db}~_user~{name}~_session~{sessionid}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/user-name

--- a/docs/api/paths/admin/{db}~_view~{view}.yaml
+++ b/docs/api/paths/admin/{db}~_view~{view}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/view

--- a/docs/api/paths/admin/{keyspace}~.yaml
+++ b/docs/api/paths/admin/{keyspace}~.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:

--- a/docs/api/paths/admin/{keyspace}~_bulk_docs.yaml
+++ b/docs/api/paths/admin/{keyspace}~_bulk_docs.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:

--- a/docs/api/paths/admin/{keyspace}~_bulk_get.yaml
+++ b/docs/api/paths/admin/{keyspace}~_bulk_get.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:

--- a/docs/api/paths/admin/{keyspace}~_compact.yaml
+++ b/docs/api/paths/admin/{keyspace}~_compact.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:

--- a/docs/api/paths/admin/{keyspace}~_local~{docid}.yaml
+++ b/docs/api/paths/admin/{keyspace}~_local~{docid}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
   - name: docid

--- a/docs/api/paths/admin/{keyspace}~_purge.yaml
+++ b/docs/api/paths/admin/{keyspace}~_purge.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:

--- a/docs/api/paths/admin/{keyspace}~_raw~{docid}.yaml
+++ b/docs/api/paths/admin/{keyspace}~_raw~{docid}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
   - $ref: ../../components/parameters.yaml#/docid

--- a/docs/api/paths/admin/{keyspace}~_resync.yaml
+++ b/docs/api/paths/admin/{keyspace}~_resync.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 get:

--- a/docs/api/paths/admin/{keyspace}~_revs_diff.yaml
+++ b/docs/api/paths/admin/{keyspace}~_revs_diff.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:

--- a/docs/api/paths/admin/{keyspace}~_revtree~{docid}.yaml
+++ b/docs/api/paths/admin/{keyspace}~_revtree~{docid}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
   - $ref: ../../components/parameters.yaml#/docid

--- a/docs/api/paths/admin/{keyspace}~{docid}.yaml
+++ b/docs/api/paths/admin/{keyspace}~{docid}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
   - $ref: ../../components/parameters.yaml#/docid

--- a/docs/api/paths/admin/{keyspace}~{docid}~{attach}.yaml
+++ b/docs/api/paths/admin/{keyspace}~{docid}~{attach}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
   - $ref: ../../components/parameters.yaml#/docid

--- a/docs/api/paths/admin/~.yaml
+++ b/docs/api/paths/admin/~.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get server information
   description: Returns information about the Sync Gateway node.

--- a/docs/api/paths/metric/_expvar.yaml
+++ b/docs/api/paths/metric/_expvar.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get all Sync Gateway statistics
   description: |-

--- a/docs/api/paths/metric/_metrics.yaml
+++ b/docs/api/paths/metric/_metrics.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Debugging/monitoring runtime stats in Prometheus Exposition format
   description: |-

--- a/docs/api/paths/public/{db}~.yaml
+++ b/docs/api/paths/public/{db}~.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/public/{db}~_all_docs.yaml
+++ b/docs/api/paths/public/{db}~_all_docs.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/public/{db}~_blipsync.yaml
+++ b/docs/api/paths/public/{db}~_blipsync.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/public/{db}~_changes.yaml
+++ b/docs/api/paths/public/{db}~_changes.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/public/{db}~_design~{ddoc}.yaml
+++ b/docs/api/paths/public/{db}~_design~{ddoc}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/ddoc

--- a/docs/api/paths/public/{db}~_design~{ddoc}~_view~{view}.yaml
+++ b/docs/api/paths/public/{db}~_design~{ddoc}~_view~{view}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/ddoc

--- a/docs/api/paths/public/{db}~_ensure_full_commit.yaml
+++ b/docs/api/paths/public/{db}~_ensure_full_commit.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:

--- a/docs/api/paths/public/{db}~_facebook.yaml
+++ b/docs/api/paths/public/{db}~_facebook.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:

--- a/docs/api/paths/public/{db}~_google.yaml
+++ b/docs/api/paths/public/{db}~_google.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:

--- a/docs/api/paths/public/{db}~_oidc.yaml
+++ b/docs/api/paths/public/{db}~_oidc.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/public/{db}~_oidc_callback.yaml
+++ b/docs/api/paths/public/{db}~_oidc_callback.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/public/{db}~_oidc_challenge.yaml
+++ b/docs/api/paths/public/{db}~_oidc_challenge.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/public/{db}~_oidc_refresh.yaml
+++ b/docs/api/paths/public/{db}~_oidc_refresh.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/public/{db}~_oidc_testing~.well-known~openid-configuration.yaml
+++ b/docs/api/paths/public/{db}~_oidc_testing~.well-known~openid-configuration.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/public/{db}~_oidc_testing~authenticate.yaml
+++ b/docs/api/paths/public/{db}~_oidc_testing~authenticate.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/public/{db}~_oidc_testing~authorize.yaml
+++ b/docs/api/paths/public/{db}~_oidc_testing~authorize.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/public/{db}~_oidc_testing~certs.yaml
+++ b/docs/api/paths/public/{db}~_oidc_testing~certs.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/public/{db}~_oidc_testing~token.yaml
+++ b/docs/api/paths/public/{db}~_oidc_testing~token.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:

--- a/docs/api/paths/public/{db}~_session.yaml
+++ b/docs/api/paths/public/{db}~_session.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:

--- a/docs/api/paths/public/{keyspace}~.yaml
+++ b/docs/api/paths/public/{keyspace}~.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:

--- a/docs/api/paths/public/{keyspace}~_bulk_docs.yaml
+++ b/docs/api/paths/public/{keyspace}~_bulk_docs.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:

--- a/docs/api/paths/public/{keyspace}~_bulk_get.yaml
+++ b/docs/api/paths/public/{keyspace}~_bulk_get.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:

--- a/docs/api/paths/public/{keyspace}~_local~{docid}.yaml
+++ b/docs/api/paths/public/{keyspace}~_local~{docid}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
   - name: docid

--- a/docs/api/paths/public/{keyspace}~_revs_diff.yaml
+++ b/docs/api/paths/public/{keyspace}~_revs_diff.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:

--- a/docs/api/paths/public/{keyspace}~{docid}.yaml
+++ b/docs/api/paths/public/{keyspace}~{docid}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
   - $ref: ../../components/parameters.yaml#/docid

--- a/docs/api/paths/public/{keyspace}~{docid}~{attach}.yaml
+++ b/docs/api/paths/public/{keyspace}~{docid}~{attach}.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
   - $ref: ../../components/parameters.yaml#/docid

--- a/docs/api/paths/public/{targetdb}~.yaml
+++ b/docs/api/paths/public/{targetdb}~.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 parameters:
   - name: targetdb
     in: path

--- a/docs/api/paths/public/~.yaml
+++ b/docs/api/paths/public/~.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 get:
   summary: Get server information
   description: Returns information about the Sync Gateway node.

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -1,3 +1,11 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 openapi: 3.0.3
 info:
   title: Sync Gateway

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 DEFAULT_PACKAGE_TIMEOUT="45m"
 
 set -u

--- a/licenses/addlicense.tmpl
+++ b/licenses/addlicense.tmpl
@@ -1,0 +1,7 @@
+Copyright {{.Year}}-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included
+in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+in that file, in accordance with the Business Source License, use of this
+software will be governed by the Apache License, Version 2.0, included in
+the file licenses/APL2.txt.

--- a/rest/admin_api_auth_routing_permissions.go
+++ b/rest/admin_api_auth_routing_permissions.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/attachmentcompactiontest/attachment_compaction_api_test.go
+++ b/rest/attachmentcompactiontest/attachment_compaction_api_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package attachmentcompactiontest
 
 import (

--- a/rest/blip_api_collections_test.go
+++ b/rest/blip_api_collections_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/config_flags_test.go
+++ b/rest/config_flags_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/config_startup_test.go
+++ b/rest/config_startup_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/jwt_auth_test.go
+++ b/rest/jwt_auth_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/main.go
+++ b/rest/main.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/main_legacy.go
+++ b/rest/main_legacy.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/main_legacy_test.go
+++ b/rest/main_legacy_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/utilities_testing_attachment.go
+++ b/rest/utilities_testing_attachment.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/utilities_testing_bootstrap.go
+++ b/rest/utilities_testing_bootstrap.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/utilities_testing_user.go
+++ b/rest/utilities_testing_user.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (


### PR DESCRIPTION
Allows [`addlicense`](https://github.com/google/addlicense) to set the Couchbase file copyright headers, as defined in `licenses/addlicense.tmpl` and runs a check in GitHub Actions to ensure it has been done for newly created files.

## TODO
- [x] Actally run the tool to fix the issues found by GitHub actions

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a