### PR TITLE
Fix goroutine leak in TestLogLevelConcurrency

### DIFF
--- a/base/log_level_test.go
+++ b/base/log_level_test.go
@@ -159,7 +159,7 @@ func TestLogLevelConcurrency(t *testing.T) {
 	}()
 
 	time.Sleep(time.Millisecond * 100)
-	stop <- struct{}{}
+	close(stop)
 }
 
 func BenchmarkLogLevelName(b *testing.B) {


### PR DESCRIPTION
## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
n/a