### PR TITLE
Fix goroutine leak in TestTerminateAndWaitForClose

### DIFF
--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -66,9 +66,11 @@ func NewTaskID(contextID string, taskName string) string {
 	return contextID + "-" + taskName + "-" + strconv.Itoa(rand.Intn(65536))
 }
 
-// TestCtx creates a log context for the given test.
+// TestCtx creates a context for the given test which is also cancelled once the test has completed.
 func TestCtx(t testing.TB) context.Context {
-	return LogContextWith(context.Background(), &LogContext{TestName: t.Name()})
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	t.Cleanup(cancelCtx)
+	return LogContextWith(ctx, &LogContext{TestName: t.Name()})
 }
 
 // bucketCtx extends the parent context with a bucket name.

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -357,7 +357,7 @@ func SetUpTestGoroutineDump(m *testing.M) (teardownFn func()) {
 	}
 
 	return func() {
-		if n := runtime.NumGoroutine() - numExpected; n > 0 {
+		if n := runtime.NumGoroutine(); n > numExpected {
 			if err := pprof.Lookup("goroutine").WriteTo(os.Stderr, 2); err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
The test was intentionally starting up some goroutines that never returned to test some timeout behaviour. Tweaked so that they're only kept open for the duration of the test using `TestCtx`.


## Before

```
=== RUN   TestTerminateAndWaitForClose
=== RUN   TestTerminateAndWaitForClose/terminate_and_done
=== RUN   TestTerminateAndWaitForClose/terminate_and_done_within_timeout
=== RUN   TestTerminateAndWaitForClose/terminate_and_done_after_timeout
=== RUN   TestTerminateAndWaitForClose/terminate_and_no_done
=== RUN   TestTerminateAndWaitForClose/no_terminate
--- PASS: TestTerminateAndWaitForClose (14.00s)
    --- PASS: TestTerminateAndWaitForClose/terminate_and_done (0.00s)
    --- PASS: TestTerminateAndWaitForClose/terminate_and_done_within_timeout (5.00s)
    --- PASS: TestTerminateAndWaitForClose/terminate_and_done_after_timeout (3.00s)
    --- PASS: TestTerminateAndWaitForClose/terminate_and_no_done (3.00s)
    --- PASS: TestTerminateAndWaitForClose/no_terminate (3.00s)
PASS
2022/09/06 11:57:52 TEST: Memory high water mark 2.54 MB
goroutine 1 [running]:
runtime/pprof.writeGoroutineStacks({0x1df72a0, 0xc000014020})
	/usr/local/Cellar/go/1.19/libexec/src/runtime/pprof/pprof.go:692 +0x70
runtime/pprof.writeGoroutine({0x1df72a0?, 0xc000014020?}, 0x10a4300?)
	/usr/local/Cellar/go/1.19/libexec/src/runtime/pprof/pprof.go:681 +0x2b
runtime/pprof.(*Profile).WriteTo(0x1c52e23?, {0x1df72a0?, 0xc000014020?}, 0x0?)
	/usr/local/Cellar/go/1.19/libexec/src/runtime/pprof/pprof.go:330 +0x14b
github.com/couchbase/sync_gateway/base.SetUpTestGoroutineDump.func2()
	/Users/benbrooks/dev/cb/sg/base/util_testing.go:361 +0x168
github.com/couchbase/sync_gateway/base.TestMain(0xffffffffffffffff?)
	/Users/benbrooks/dev/cb/sg/base/main_test.go:37 +0x336
main.main()
	_testmain.go:473 +0x1d3

goroutine 26 [sleep]:
time.Sleep(0x2540be400)
	/usr/local/Cellar/go/1.19/libexec/src/runtime/time.go:195 +0x135
github.com/couchbase/sync_gateway/base.TestTerminateAndWaitForClose.func3(0x0?, 0x0?)
	/Users/benbrooks/dev/cb/sg/base/util_test.go:1568 +0x34
created by github.com/couchbase/sync_gateway/base.TestTerminateAndWaitForClose.func6
	/Users/benbrooks/dev/cb/sg/base/util_test.go:1601 +0xae

goroutine 52 [select (no cases)]:
github.com/couchbase/sync_gateway/base.TestTerminateAndWaitForClose.func5(0x0?, 0x0?)
	/Users/benbrooks/dev/cb/sg/base/util_test.go:1593 +0x17
created by github.com/couchbase/sync_gateway/base.TestTerminateAndWaitForClose.func6
	/Users/benbrooks/dev/cb/sg/base/util_test.go:1601 +0xae
2022/09/06 11:57:52
TEST: =================================================
TEST: Leaked goroutines after testing: got 2 expected 1
TEST: =================================================

2022/09/06 11:57:52 TEST: Written goroutine profile to: /Users/benbrooks/dev/cb/sg/base/test-pprof-goroutine-1662461858.pb.gz
ok  	github.com/couchbase/sync_gateway/base	14.504s
```

## After

```
=== RUN   TestTerminateAndWaitForClose
2022-09-06T11:56:46.483+01:00 [INF] base.TestTerminateAndWaitForClose: Setup logging: level: info - keys: [TEST]
=== RUN   TestTerminateAndWaitForClose/terminate_and_done_immediate
2022-09-06T11:56:46.483+01:00 [INF] TEST: t:TestTerminateAndWaitForClose/terminate_and_done_immediate got t closing d
=== RUN   TestTerminateAndWaitForClose/terminate_and_done_within_timeout
2022-09-06T11:56:46.483+01:00 [INF] TEST: t:TestTerminateAndWaitForClose/terminate_and_done_within_timeout got t waiting to close d
2022-09-06T11:56:49.484+01:00 [INF] TEST: t:TestTerminateAndWaitForClose/terminate_and_done_within_timeout closing d
=== RUN   TestTerminateAndWaitForClose/terminate_and_done_after_timeout
2022-09-06T11:56:49.484+01:00 [INF] TEST: t:TestTerminateAndWaitForClose/terminate_and_done_after_timeout got t waiting to close d
=== RUN   TestTerminateAndWaitForClose/terminate_and_no_done
2022-09-06T11:56:52.485+01:00 [INF] TEST: t:TestTerminateAndWaitForClose/terminate_and_done_after_timeout test context done
2022-09-06T11:56:52.486+01:00 [INF] TEST: t:TestTerminateAndWaitForClose/terminate_and_no_done got t not closing d
=== RUN   TestTerminateAndWaitForClose/no_terminate
2022-09-06T11:56:55.487+01:00 [INF] TEST: t:TestTerminateAndWaitForClose/no_terminate not reading t
2022-09-06T11:56:58.488+01:00 [INF] base.TestTerminateAndWaitForClose: Reset logging
--- PASS: TestTerminateAndWaitForClose (12.00s)
    --- PASS: TestTerminateAndWaitForClose/terminate_and_done_immediate (0.00s)
    --- PASS: TestTerminateAndWaitForClose/terminate_and_done_within_timeout (3.00s)
    --- PASS: TestTerminateAndWaitForClose/terminate_and_done_after_timeout (3.00s)
    --- PASS: TestTerminateAndWaitForClose/terminate_and_no_done (3.00s)
    --- PASS: TestTerminateAndWaitForClose/no_terminate (3.00s)
PASS
2022/09/06 11:56:58 TEST: Memory high water mark 2.70 MB
2022/09/06 11:56:58 TEST: No leaked goroutines found
ok  	github.com/couchbase/sync_gateway/base	12.527s
```

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a (walrus-covered test change)