### PR TITLE
Fix TestLogLevelConcurrency leak

### DIFF
--- a/base/log_level_test.go
+++ b/base/log_level_test.go
@@ -122,8 +122,12 @@ func TestLogLevelText(t *testing.T) {
 
 // This test has no assertions, but will flag any data races when run under `-race`.
 func TestLogLevelConcurrency(t *testing.T) {
-	logLevel := LevelWarn
+	const runFor = time.Millisecond * 100
+
 	stop := make(chan struct{})
+	defer close(stop)
+
+	logLevel := LevelWarn
 
 	go func() {
 		for {
@@ -158,8 +162,7 @@ func TestLogLevelConcurrency(t *testing.T) {
 		}
 	}()
 
-	time.Sleep(time.Millisecond * 100)
-	stop <- struct{}{}
+	time.Sleep(runFor)
 }
 
 func BenchmarkLogLevelName(b *testing.B) {


### PR DESCRIPTION
Test was sending a "stop" signal but only to one of the 3 goroutines. `close(stop)` sends the signal to all of them.

## Before

```
> go test -run='^TestLogLevelConcurrency$' -v -count=1 ./base
=== RUN   TestLogLevelConcurrency
--- PASS: TestLogLevelConcurrency (0.10s)
PASS
2022/09/06 12:04:47 TEST: Memory high water mark increased to 2.59 MB (heap: 2.15 MB stack: 0.44 MB)
2022/09/06 12:04:47 TEST: Memory high water mark 2.59 MB
goroutine 1 [running]:
runtime/pprof.writeGoroutineStacks({0x1df72a0, 0xc000014020})
	/usr/local/Cellar/go/1.19/libexec/src/runtime/pprof/pprof.go:692 +0x70
runtime/pprof.writeGoroutine({0x1df72a0?, 0xc000014020?}, 0x10a4300?)
	/usr/local/Cellar/go/1.19/libexec/src/runtime/pprof/pprof.go:681 +0x2b
runtime/pprof.(*Profile).WriteTo(0x1c52e23?, {0x1df72a0?, 0xc000014020?}, 0x0?)
	/usr/local/Cellar/go/1.19/libexec/src/runtime/pprof/pprof.go:330 +0x14b
github.com/couchbase/sync_gateway/base.SetUpTestGoroutineDump.func2()
	/Users/benbrooks/dev/cb/sg/base/util_testing.go:361 +0x168
github.com/couchbase/sync_gateway/base.TestMain(0xffffffffffffffff?)
	/Users/benbrooks/dev/cb/sg/base/main_test.go:37 +0x336
main.main()
	_testmain.go:473 +0x1d3

goroutine 46 [runnable]:
github.com/couchbase/sync_gateway/base.TestLogLevelConcurrency.func2()
	/Users/benbrooks/dev/cb/sg/base/log_level_test.go:144 +0x45
created by github.com/couchbase/sync_gateway/base.TestLogLevelConcurrency
	/Users/benbrooks/dev/cb/sg/base/log_level_test.go:139 +0xed

goroutine 47 [runnable]:
github.com/couchbase/sync_gateway/base.TestLogLevelConcurrency.func3()
	/Users/benbrooks/dev/cb/sg/base/log_level_test.go:155 +0x34
created by github.com/couchbase/sync_gateway/base.TestLogLevelConcurrency
	/Users/benbrooks/dev/cb/sg/base/log_level_test.go:150 +0x145
2022/09/06 12:04:47
TEST: =================================================
TEST: Leaked goroutines after testing: got 2 expected 1
TEST: =================================================

2022/09/06 12:04:47 TEST: Written goroutine profile to: /Users/benbrooks/dev/cb/sg/base/test-pprof-goroutine-1662462287.pb.gz
ok  	github.com/couchbase/sync_gateway/base	0.620s
```

## After

```
> go test -run='^TestLogLevelConcurrency$' -v -count=1 ./base
=== RUN   TestLogLevelConcurrency
--- PASS: TestLogLevelConcurrency (0.10s)
PASS
2022/09/06 12:02:13 TEST: Memory high water mark increased to 2.44 MB (heap: 2.06 MB stack: 0.38 MB)
2022/09/06 12:02:13 TEST: Memory high water mark 2.44 MB
2022/09/06 12:02:13 TEST: No leaked goroutines found
ok  	github.com/couchbase/sync_gateway/base	0.633s
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a (walrus covered test change)