### PR TITLE
Fix goroutine leaks in db tests with Walrus

### DIFF
--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSequenceAllocator(t *testing.T) {
@@ -196,7 +197,8 @@ func TestReleaseSequenceWait(t *testing.T) {
 	testStats := sgw.NewDBStats("", false, false, false).Database()
 
 	a, err := newSequenceAllocator(bucket, testStats)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	defer a.Stop()
 
 	startTime := time.Now().Add(-1 * time.Second)
 	amountWaited := a.waitForReleasedSequences(startTime)

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -644,44 +644,23 @@ func TestReplicateGroupIDAssignedNodes(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
 
-	// Set up SG Configs
-	cfgDefault, err := base.NewCfgSG(tb, "")
-	require.NoError(t, err)
-
-	cfgGroupA, err := base.NewCfgSG(tb, "GroupA")
-	require.NoError(t, err)
-
-	cfgGGroupB, err := base.NewCfgSG(tb, "GroupB")
-	require.NoError(t, err)
-
-	// Set up replicators
+	// Set up databases
 	dbDefault, err := NewDatabaseContext("default", tb, false, DatabaseContextOptions{GroupID: ""})
 	require.NoError(t, err)
 	defer dbDefault.Close()
-
-	managerDefault, err := NewSGReplicateManager(dbDefault, cfgDefault)
-	require.NoError(t, err)
-
-	err = managerDefault.RegisterNode("nodeDefault")
-	require.NoError(t, err)
-	err = managerDefault.AddReplication(&ReplicationCfg{
-		ReplicationConfig: ReplicationConfig{
-			ID:           "repl",
-			InitialState: ReplicationStateStopped,
-		},
-	})
-	require.NoError(t, err)
 
 	dbGroupA, err := NewDatabaseContext("groupa", tb, false, DatabaseContextOptions{GroupID: "GroupA"})
 	require.NoError(t, err)
 	defer dbGroupA.Close()
 
-	managerGroupA, err := NewSGReplicateManager(dbGroupA, cfgGroupA)
+	dbGroupB, err := NewDatabaseContext("groupb", tb, false, DatabaseContextOptions{GroupID: "GroupB"})
 	require.NoError(t, err)
+	defer dbGroupB.Close()
 
-	err = managerGroupA.RegisterNode("nodeGroupA")
+	// Set up replicators
+	err = dbDefault.SGReplicateMgr.RegisterNode("nodeDefault")
 	require.NoError(t, err)
-	err = managerGroupA.AddReplication(&ReplicationCfg{
+	err = dbDefault.SGReplicateMgr.AddReplication(&ReplicationCfg{
 		ReplicationConfig: ReplicationConfig{
 			ID:           "repl",
 			InitialState: ReplicationStateStopped,
@@ -689,16 +668,19 @@ func TestReplicateGroupIDAssignedNodes(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	dbGroupB, err := NewDatabaseContext("groupb", tb, false, DatabaseContextOptions{GroupID: "GroupB"})
+	err = dbGroupA.SGReplicateMgr.RegisterNode("nodeGroupA")
 	require.NoError(t, err)
-	defer dbGroupB.Close()
+	err = dbGroupA.SGReplicateMgr.AddReplication(&ReplicationCfg{
+		ReplicationConfig: ReplicationConfig{
+			ID:           "repl",
+			InitialState: ReplicationStateStopped,
+		},
+	})
+	require.NoError(t, err)
 
-	managerGroupB, err := NewSGReplicateManager(dbGroupB, cfgGGroupB)
+	err = dbGroupB.SGReplicateMgr.RegisterNode("nodeGroupB")
 	require.NoError(t, err)
-
-	err = managerGroupB.RegisterNode("nodeGroupB")
-	require.NoError(t, err)
-	err = managerGroupB.AddReplication(&ReplicationCfg{
+	err = dbGroupB.SGReplicateMgr.AddReplication(&ReplicationCfg{
 		ReplicationConfig: ReplicationConfig{
 			ID:           "repl",
 			InitialState: ReplicationStateStopped,
@@ -707,28 +689,24 @@ func TestReplicateGroupIDAssignedNodes(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check replications are assigned to correct nodes
-	replications, err := managerDefault.GetReplications()
+	replications, err := dbDefault.SGReplicateMgr.GetReplications()
 	require.NoError(t, err)
 	assert.Len(t, replications, 1)
 	cfg, exists := replications["repl"]
 	require.True(t, exists, "Replicator not found")
 	assert.Equal(t, "nodeDefault", cfg.AssignedNode)
 
-	replications, err = managerGroupA.GetReplications()
+	replications, err = dbGroupA.SGReplicateMgr.GetReplications()
 	require.NoError(t, err)
 	assert.Len(t, replications, 1)
 	cfg, exists = replications["repl"]
 	require.True(t, exists, "Replicator not found")
 	assert.Equal(t, "nodeGroupA", cfg.AssignedNode)
 
-	replications, err = managerGroupB.GetReplications()
+	replications, err = dbGroupB.SGReplicateMgr.GetReplications()
 	require.NoError(t, err)
 	assert.Len(t, replications, 1)
 	cfg, exists = replications["repl"]
 	require.True(t, exists, "Replicator not found")
 	assert.Equal(t, "nodeGroupB", cfg.AssignedNode)
-
-	managerDefault.Stop()
-	managerGroupA.Stop()
-	managerGroupB.Stop()
 }

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -649,6 +649,8 @@ func TestReplicateGroupIDAssignedNodes(t *testing.T) {
 	// Set up replicators
 	dbDefault, err := NewDatabaseContext("default", tb, false, DatabaseContextOptions{GroupID: ""})
 	require.NoError(t, err)
+	defer dbDefault.Close()
+
 	managerDefault, err := NewSGReplicateManager(dbDefault, cfgDefault)
 	require.NoError(t, err)
 	err = managerDefault.RegisterNode("nodeDefault")
@@ -663,6 +665,8 @@ func TestReplicateGroupIDAssignedNodes(t *testing.T) {
 
 	dbGroupA, err := NewDatabaseContext("groupa", tb, false, DatabaseContextOptions{GroupID: "GroupA"})
 	require.NoError(t, err)
+	defer dbGroupA.Close()
+
 	managerGroupA, err := NewSGReplicateManager(dbGroupA, cfgGroupA)
 	require.NoError(t, err)
 	err = managerGroupA.RegisterNode("nodeGroupA")
@@ -677,6 +681,8 @@ func TestReplicateGroupIDAssignedNodes(t *testing.T) {
 
 	dbGroupB, err := NewDatabaseContext("groupb", tb, false, DatabaseContextOptions{GroupID: "GroupB"})
 	require.NoError(t, err)
+	defer dbGroupB.Close()
+
 	managerGroupB, err := NewSGReplicateManager(dbGroupB, cfgGGroupB)
 	require.NoError(t, err)
 	err = managerGroupB.RegisterNode("nodeGroupB")

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -645,15 +645,15 @@ func TestReplicateGroupIDAssignedNodes(t *testing.T) {
 	defer tb.Close()
 
 	// Set up databases
-	dbDefault, err := NewDatabaseContext("default", tb, false, DatabaseContextOptions{GroupID: ""})
+	dbDefault, err := NewDatabaseContext("default", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: ""})
 	require.NoError(t, err)
 	defer dbDefault.Close()
 
-	dbGroupA, err := NewDatabaseContext("groupa", tb, false, DatabaseContextOptions{GroupID: "GroupA"})
+	dbGroupA, err := NewDatabaseContext("groupa", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupA"})
 	require.NoError(t, err)
 	defer dbGroupA.Close()
 
-	dbGroupB, err := NewDatabaseContext("groupb", tb, false, DatabaseContextOptions{GroupID: "GroupB"})
+	dbGroupB, err := NewDatabaseContext("groupb", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupB"})
 	require.NoError(t, err)
 	defer dbGroupB.Close()
 


### PR DESCRIPTION
Fixes misc. leaked goroutines when running the `db` package with Walrus due to:
- Unstopped sequenceAllocator
- Unclosed DatabaseContexts

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] n/a (walrus only)