### PR TITLE
Skip views tests with gsi enabled

### DIFF
--- a/base/bucket_view_test.go
+++ b/base/bucket_view_test.go
@@ -21,6 +21,9 @@ import (
 )
 
 func TestView(t *testing.T) {
+	if !TestsDisableGSI() {
+		t.Skip("GSI tests are not compatible with views")
+	}
 	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
 		ddocName := "testDDoc"

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -89,7 +89,9 @@ func setupTestDBWithCacheOptions(t testing.TB, options CacheOptions) *Database {
 // Forces UseViews:true in the database context.  Useful for testing w/ views while running
 // tests against Couchbase Server
 func setupTestDBWithViewsEnabled(t testing.TB) *Database {
-
+	if !base.TestsDisableGSI() {
+		t.Skip("GSI is not compatible with views")
+	}
 	dbcOptions := DatabaseContextOptions{
 		UseViews: true,
 	}

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -464,6 +464,10 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
+	if !base.TestsDisableGSI() {
+		t.Skip("views tests are not applicable under GSI")
+	}
+
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -56,6 +56,10 @@ func TestViewQuery(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
 
+	if !base.TestsDisableGSI() {
+		t.Skip("views tests are not applicable under GSI")
+	}
+
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_design/foo", `{"views":{"bar": {"map": "function(doc) {emit(doc.key, doc.value);}"}}}`)
 	requireStatus(t, response, http.StatusCreated)
 	response = rt.SendRequest(http.MethodPut, "/db/doc1", `{"key":10, "value":"ten"}`)
@@ -90,8 +94,12 @@ func TestViewQuery(t *testing.T) {
 
 }
 
-// Tests #1109, wh ere design doc contains multiple views
+// Tests #1109, where design doc contains multiple views
 func TestViewQueryMultipleViews(t *testing.T) {
+	if !base.TestsDisableGSI() {
+		t.Skip("views tests are not applicable under GSI")
+	}
+
 	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
 
@@ -121,6 +129,10 @@ func TestViewQueryMultipleViews(t *testing.T) {
 }
 
 func TestViewQueryWithParams(t *testing.T) {
+	if !base.TestsDisableGSI() {
+		t.Skip("views tests are not applicable under GSI")
+	}
+
 	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
 
@@ -145,6 +157,10 @@ func TestViewQueryWithParams(t *testing.T) {
 }
 
 func TestViewQueryUserAccess(t *testing.T) {
+	if !base.TestsDisableGSI() {
+		t.Skip("views tests are not applicable under GSI")
+	}
+
 	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
 
@@ -232,6 +248,10 @@ func TestViewQueryMultipleViewsInterfaceValues(t *testing.T) {
 }
 
 func TestUserViewQuery(t *testing.T) {
+	if !base.TestsDisableGSI() {
+		t.Skip("views tests are not applicable under GSI")
+	}
+
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
 		guestEnabled: true,
@@ -305,6 +325,10 @@ func TestUserViewQuery(t *testing.T) {
 
 // This includes a fix for #857
 func TestAdminReduceViewQuery(t *testing.T) {
+	if !base.TestsDisableGSI() {
+		t.Skip("views tests are not applicable under GSI")
+	}
+
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
 		guestEnabled: true,
@@ -356,6 +380,10 @@ func TestAdminReduceViewQuery(t *testing.T) {
 }
 
 func TestAdminReduceSumQuery(t *testing.T) {
+	if !base.TestsDisableGSI() {
+		t.Skip("views tests are not applicable under GSI")
+	}
+
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
 		guestEnabled: true,
@@ -392,6 +420,10 @@ func TestAdminReduceSumQuery(t *testing.T) {
 }
 
 func TestAdminGroupReduceSumQuery(t *testing.T) {
+	if !base.TestsDisableGSI() {
+		t.Skip("views tests are not applicable under GSI")
+	}
+
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
 		guestEnabled: true,
@@ -431,6 +463,9 @@ func TestViewQueryWithKeys(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Walrus does not support the 'keys' view parameter")
 	}
+	if !base.TestsDisableGSI() {
+		t.Skip("views tests are not applicable under GSI")
+	}
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -469,6 +504,10 @@ func TestViewQueryWithCompositeKeys(t *testing.T) {
 		t.Skip("Walrus does not support the 'keys' view parameter")
 	}
 
+	if !base.TestsDisableGSI() {
+		t.Skip("views tests are not applicable under GSI")
+	}
+
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -505,6 +544,9 @@ func TestViewQueryWithIntKeys(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Walrus does not support the 'keys' view parameter")
 	}
+	if !base.TestsDisableGSI() {
+		t.Skip("views tests are not applicable under GSI")
+	}
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -539,6 +581,10 @@ func TestViewQueryWithIntKeys(t *testing.T) {
 }
 
 func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
+	if !base.TestsDisableGSI() {
+		t.Skip("views tests are not applicable under GSI")
+	}
+
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
 		guestEnabled: true,
@@ -632,6 +678,9 @@ func TestPostInstallCleanup(t *testing.T) {
 }
 
 func TestViewQueryWrappers(t *testing.T) {
+	if !base.TestsDisableGSI() {
+		t.Skip("views tests are not applicable under GSI")
+	}
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
@@ -673,12 +722,16 @@ func TestViewQueryWithXattrAndNonXattr(t *testing.T) {
 		t.Skip("Test requires xattrs to be enabled")
 	}
 
+	if !base.TestsDisableGSI() {
+		t.Skip("views tests are not applicable under GSI")
+	}
 	rtConfig := &RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			AutoImport: false,
 		}},
 	}
+
 	rt := NewRestTester(t, rtConfig)
 	defer rt.Close()
 


### PR DESCRIPTION
These tests won't work under collections, and don't need to be run with GSI enabled.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [x] Link upstream PRs
- [x] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/783/