### PR TITLE
Add base.RequireNumTestBuckets to tests that need more than one bucket

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -4251,6 +4251,8 @@ func TestGroupIDReplications(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() || !base.TestUseXattrs() {
 		t.Skip("This test only works against Couchbase Server with xattrs enabled")
 	}
+	base.RequireNumTestBuckets(t, 2)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	// Create test buckets to replicate between
@@ -4587,6 +4589,8 @@ function (doc) {
 // Test that the username and password fields in the replicator still work and get redacted appropriately.
 // This should log a deprecation notice.
 func TestReplicatorDeprecatedCredentials(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+
 	passiveRT := NewRestTester(t, &RestTesterConfig{DatabaseConfig: &DatabaseConfig{
 		DbConfig: DbConfig{
 			Users: map[string]*auth.PrincipalConfig{
@@ -4648,6 +4652,8 @@ func TestReplicatorDeprecatedCredentials(t *testing.T) {
 
 // CBG-1581: Ensure activeReplicatorCommon does final checkpoint on stop/disconnect
 func TestReplicatorCheckpointOnStop(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+
 	passiveRT := NewRestTester(t, nil)
 	defer passiveRT.Close()
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -7585,6 +7585,8 @@ func TestRevocationResumeSameRoleAndLowSeqCheck(t *testing.T) {
 }
 
 func TestMetricsHandler(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+
 	base.SkipPrometheusStatsRegistration = false
 	defer func() {
 		base.SkipPrometheusStatsRegistration = true

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -2428,6 +2428,8 @@ func TestOpenIDConnectProviderRemoval(t *testing.T) {
 // This test verifies the edge case of having two different OIDC providers with different role/channel configurations
 // but with UsernameClaim set in a way that means they create users with the same username, yet with different access.
 func TestOpenIDConnectIssuerChange(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth, base.KeyAccess, base.KeyHTTP)
 	const (
 		testDocName = "testDoc"

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -5746,6 +5746,9 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 	if !base.IsEnterpriseEdition() {
 		t.Skipf("Requires EE for delta sync")
 	}
+
+	base.RequireNumTestBuckets(t, 2)
+
 	defer db.SuspendSequenceBatching()()
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
@@ -5845,6 +5848,8 @@ func TestUnprocessableDeltas(t *testing.T) {
 		t.Skipf("Requires EE for some delta sync")
 	}
 
+	base.RequireNumTestBuckets(t, 2)
+
 	defer db.SuspendSequenceBatching()()
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
@@ -5936,6 +5941,9 @@ func TestUnprocessableDeltas(t *testing.T) {
 
 // CBG-1428 - check for regression of ISGR not ignoring _removed:true bodies when purgeOnRemoval is disabled
 func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
+
+	base.RequireNumTestBuckets(t, 2)
+
 	// Copies the behaviour of TestGetRemovedAsUser but with replication and no user
 	defer db.SuspendSequenceBatching()()
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)


### PR DESCRIPTION

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/