### PR TITLE
Disable test with xattrs

### DIFF
--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -107,7 +107,9 @@ func TestCollectionsPutDocInKeyspace(t *testing.T) {
 
 func TestCollectionsDCP(t *testing.T) {
 	base.TestRequiresCollections(t)
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyDCP, base.KeyImport)
+	if !base.TestUseXattrs() {
+		t.Skip("Test does not provide inline _sync data for non xattrs")
+	}
 
 	tb := base.GetTestBucket(t)
 	defer tb.Close()

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -108,7 +108,7 @@ func TestCollectionsPutDocInKeyspace(t *testing.T) {
 func TestCollectionsDCP(t *testing.T) {
 	base.TestRequiresCollections(t)
 	if !base.TestUseXattrs() {
-		t.Skip("Test does not provide inline _sync data for non xattrs")
+		t.Skip("Test relies on import - needs xattrs")
 	}
 
 	tb := base.GetTestBucket(t)


### PR DESCRIPTION
This test doesn't write `_sync` docs inline, but they can be tested with named collections when all tests are using them.
