### PR TITLE
CBG-2336: Per DB credentials override per bucket credentials

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -5049,3 +5049,75 @@ func TestResyncPersistence(t *testing.T) {
 	fmt.Printf("RT2 Resync Status: %s\n", resp2.BodyBytes())
 	assert.Equal(t, resp.BodyBytes(), resp2.BodyBytes())
 }
+
+// Make sure per DB credentials override per bucket credentials
+func TestPerDBCredsOverride(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	// Get test bucket
+	tb1 := base.GetTestBucket(t)
+	defer tb1.Close()
+
+	config := bootstrapStartupConfigForTest(t)
+	config.BucketCredentials = map[string]*base.CredentialsConfig{
+		tb1.GetName(): {
+			Username: base.TestClusterUsername(),
+			Password: base.TestClusterPassword(),
+		},
+	}
+	config.DatabaseCredentials = map[string]*base.CredentialsConfig{
+		"db": {
+			Username: "invalid",
+			Password: "invalid",
+		},
+	}
+
+	sc, err := setupServerContext(&config, true)
+	require.NoError(t, err)
+
+	serverErr := make(chan error, 0)
+	defer func() {
+		sc.Close()
+		require.NoError(t, <-serverErr)
+	}()
+
+	go func() {
+		serverErr <- startServer(&config, sc)
+	}()
+	require.NoError(t, sc.waitForRESTAPIs())
+
+	couchbaseCluster, err := createCouchbaseClusterFromStartupConfig(sc.config)
+	require.NoError(t, err)
+	sc.bootstrapContext.connection = couchbaseCluster
+
+	dbConfig := `{
+		"bucket": "` + tb1.GetName() + `",
+		"enable_shared_bucket_access": ` + strconv.FormatBool(base.TestUseXattrs()) + `,
+		"use_views": ` + strconv.FormatBool(base.TestsDisableGSI()) + `,
+		"num_index_replicas": 0
+	}`
+
+	res := bootstrapAdminRequest(t, http.MethodPut, "/db/", dbConfig)
+	// Make sure request failed as it could authenticate with the bucket
+	assert.Equal(t, http.StatusForbidden, res.StatusCode)
+
+	// Allow database to be created sucessfully
+	sc.config.DatabaseCredentials = map[string]*base.CredentialsConfig{}
+	res = bootstrapAdminRequest(t, http.MethodPut, "/db/", dbConfig)
+	assert.Equal(t, http.StatusCreated, res.StatusCode)
+
+	// Confirm fetch configs causes bucket credentials to be overrode
+	sc.config.DatabaseCredentials = map[string]*base.CredentialsConfig{
+		"db": {
+			Username: "invalidUsername",
+			Password: "invalidPassword",
+		},
+	}
+	configs, err := sc.fetchConfigs(false)
+	require.NoError(t, err)
+	require.NotNil(t, configs["db"])
+	assert.Equal(t, "invalidUsername", configs["db"].BucketConfig.Username)
+	assert.Equal(t, "invalidPassword", configs["db"].BucketConfig.Password)
+}

--- a/rest/config.go
+++ b/rest/config.go
@@ -311,7 +311,9 @@ func (dbConfig *DbConfig) setup(dbName string, bootstrapConfig BootstrapConfig, 
 		dbConfig.setDatabaseCredentials(*bucketCredentials)
 	} else if forcePerBucketAuth {
 		return fmt.Errorf("unable to setup database on bucket %q since credentials are not defined in bucket_credentials", base.MD(*dbConfig.Bucket).Redact())
-	} else if dbCredentials != nil {
+	}
+	// Per db credentials override bootstrap and bucket level credentials
+	if dbCredentials != nil {
 		dbConfig.setDatabaseCredentials(*dbCredentials)
 	}
 
@@ -1197,10 +1199,6 @@ func (sc *StartupConfig) validate(isEnterpriseEdition bool) (errorMessages error
 
 	if len(sc.Bootstrap.ConfigGroupID) > persistentConfigGroupIDMaxLength {
 		multiError = multiError.Append(fmt.Errorf("group_id must be at most %d characters in length", persistentConfigGroupIDMaxLength))
-	}
-
-	if sc.BucketCredentials != nil && sc.DatabaseCredentials != nil && len(sc.BucketCredentials) > 0 && len(sc.DatabaseCredentials) > 0 {
-		multiError = multiError.Append(fmt.Errorf("bucket_credentials and database_credentials cannot be used at the same time"))
 	}
 
 	if sc.DatabaseCredentials != nil {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2413,7 +2413,6 @@ func Test_validateJavascriptFunction(t *testing.T) {
 }
 
 func TestBucketCredentialsValidation(t *testing.T) {
-	bucketAndDBCredsError := "bucket_credentials and database_credentials cannot be used at the same time"
 	bucketCredsError := "bucket_credentials cannot use both x509 and basic auth"
 	bucketNoCredsServerless := "at least 1 bucket must be defined in bucket_credentials when running in serverless mode"
 	testCases := []struct {
@@ -2462,7 +2461,6 @@ func TestBucketCredentialsValidation(t *testing.T) {
 				DatabaseCredentials: PerDatabaseCredentialsConfig{"bucket": &base.CredentialsConfig{X509CertPath: "cert", X509KeyPath: "key"}},
 				BucketCredentials:   base.PerBucketCredentialsConfig{"bucket": &base.CredentialsConfig{X509CertPath: "cert", X509KeyPath: "key"}},
 			},
-			expectedError: &bucketAndDBCredsError,
 		},
 		{
 			name: "Bucket creds for x509 and basic auth",
@@ -2524,7 +2522,6 @@ func TestBucketCredentialsValidation(t *testing.T) {
 
 			} else if err != nil {
 				assert.NotContains(t, err.Error(), bucketCredsError)
-				assert.NotContains(t, err.Error(), bucketAndDBCredsError)
 				assert.NotContains(t, err.Error(), bucketNoCredsServerless)
 			}
 		})


### PR DESCRIPTION
CBG-2336

- Per db credentials override per bucket credentials when creating a new database and fetching database configs
- Added testing

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/785/