### PR TITLE
CBG-2369: Leaking EventManager goroutines

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -361,7 +361,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 		dbContext.DbStats.Cache(),
 	)
 
-	dbContext.EventMgr = NewEventManager()
+	dbContext.EventMgr = NewEventManager(dbContext.terminator)
 	logCtx := base.LogContextWith(context.Background(), &base.LogContext{CorrelationID: "db:" + base.MD(dbName).Redact()})
 
 	var err error

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -83,8 +83,10 @@ func (th *TestingHandler) String() string {
 }
 
 func TestDocumentChangeEvent(t *testing.T) {
+	terminator := make(chan bool)
+	defer close(terminator)
 
-	em := NewEventManager()
+	em := NewEventManager(terminator)
 	em.Start(0, -1)
 
 	// Setup test data
@@ -123,8 +125,10 @@ func TestDocumentChangeEvent(t *testing.T) {
 }
 
 func TestDBStateChangeEvent(t *testing.T) {
+	terminator := make(chan bool)
+	defer close(terminator)
 
-	em := NewEventManager()
+	em := NewEventManager(terminator)
 	em.Start(0, -1)
 
 	// Setup test data
@@ -162,10 +166,11 @@ func TestDBStateChangeEvent(t *testing.T) {
 // Test sending many events with slow-running execution to validate they get dropped after hitting
 // the max concurrent goroutines
 func TestSlowExecutionProcessing(t *testing.T) {
-
+	terminator := make(chan bool)
+	defer close(terminator)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyEvents)
 
-	em := NewEventManager()
+	em := NewEventManager(terminator)
 	em.Start(0, -1)
 
 	ids := make([]string, 20)
@@ -204,8 +209,10 @@ func TestSlowExecutionProcessing(t *testing.T) {
 }
 
 func TestCustomHandler(t *testing.T) {
+	terminator := make(chan bool)
+	defer close(terminator)
 
-	em := NewEventManager()
+	em := NewEventManager(terminator)
 	em.Start(0, -1)
 
 	ids := make([]string, 20)
@@ -245,8 +252,10 @@ func TestCustomHandler(t *testing.T) {
 }
 
 func TestUnhandledEvent(t *testing.T) {
+	terminator := make(chan bool)
+	defer close(terminator)
 
-	em := NewEventManager()
+	em := NewEventManager(terminator)
 	em.Start(0, -1)
 
 	ids := make([]string, 20)
@@ -424,7 +433,8 @@ func InitWebhookTest() (*httptest.Server, *WebhookRequest) {
 }
 
 func TestWebhookBasic(t *testing.T) {
-
+	terminator := make(chan bool)
+	defer close(terminator)
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
@@ -454,7 +464,7 @@ func TestWebhookBasic(t *testing.T) {
 
 	// Test basic webhook
 	log.Println("Test basic webhook")
-	em := NewEventManager()
+	em := NewEventManager(terminator)
 	em.Start(0, -1)
 	webhookHandler, _ := NewWebhook(fmt.Sprintf("%s/echo", url), "", nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
@@ -471,7 +481,7 @@ func TestWebhookBasic(t *testing.T) {
 	// Test webhook filter function
 	log.Println("Test filter function")
 	wr.Clear()
-	em = NewEventManager()
+	em = NewEventManager(terminator)
 	em.Start(0, -1)
 	filterFunction := `function(doc) {
 							if (doc.value < 6) {
@@ -496,7 +506,7 @@ func TestWebhookBasic(t *testing.T) {
 	// Validate payload
 	log.Println("Test payload validation")
 	wr.Clear()
-	em = NewEventManager()
+	em = NewEventManager(terminator)
 	em.Start(0, -1)
 	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), "", nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
@@ -513,7 +523,7 @@ func TestWebhookBasic(t *testing.T) {
 	// Test fast fill, fast webhook
 	log.Println("Test fast fill, fast webhook")
 	wr.Clear()
-	em = NewEventManager()
+	em = NewEventManager(terminator)
 	em.Start(5, -1)
 	timeout := uint64(60)
 	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), "", &timeout, nil)
@@ -534,7 +544,7 @@ func TestWebhookBasic(t *testing.T) {
 		log.Println("Test queue full, slow webhook")
 		wr.Clear()
 		errCount := 0
-		em = NewEventManager()
+		em = NewEventManager(terminator)
 		em.Start(5, 1)
 		webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow", url), "", nil, nil)
 		em.RegisterEventHandler(webhookHandler, DocumentChange)
@@ -557,7 +567,7 @@ func TestWebhookBasic(t *testing.T) {
 	// Test queue full, slow webhook, long wait time.  Throttles events
 	log.Println("Test queue full, slow webhook, long wait")
 	wr.Clear()
-	em = NewEventManager()
+	em = NewEventManager(terminator)
 	em.Start(5, 1500)
 	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow", url), "", nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
@@ -578,6 +588,8 @@ func TestWebhookOldDoc(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
+	terminator := make(chan bool)
+	defer close(terminator)
 
 	ts, wr := InitWebhookTest()
 	defer ts.Close()
@@ -604,7 +616,7 @@ func TestWebhookOldDoc(t *testing.T) {
 
 	// Test basic webhook where an old doc is passed but not filtered
 	log.Println("Test basic webhook where an old doc is passed but not filtered")
-	em := NewEventManager()
+	em := NewEventManager(terminator)
 	em.Start(0, -1)
 	webhookHandler, _ := NewWebhook(fmt.Sprintf("%s/echo", url), "", nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
@@ -626,7 +638,7 @@ func TestWebhookOldDoc(t *testing.T) {
 	// Test webhook where an old doc is passed and is not used by the filter
 	log.Println("Test filter function with old doc which is not referenced")
 	wr.Clear()
-	em = NewEventManager()
+	em = NewEventManager(terminator)
 	em.Start(0, -1)
 	filterFunction := `function(doc) {
 							if (doc.value < 6) {
@@ -654,7 +666,7 @@ func TestWebhookOldDoc(t *testing.T) {
 	// Test webhook where an old doc is passed and is validated by the filter
 	log.Println("Test filter function with old doc")
 	wr.Clear()
-	em = NewEventManager()
+	em = NewEventManager(terminator)
 	em.Start(0, -1)
 	filterFunction = `function(doc, oldDoc) {
 							if (doc.value < 6 && doc.value == -oldDoc.value) {
@@ -682,7 +694,7 @@ func TestWebhookOldDoc(t *testing.T) {
 	// Test webhook where an old doc is not passed but is referenced in the filter function args
 	log.Println("Test filter function with old doc")
 	wr.Clear()
-	em = NewEventManager()
+	em = NewEventManager(terminator)
 	em.Start(0, -1)
 	filterFunction = `function(doc, oldDoc) {
 							if (oldDoc) {
@@ -719,6 +731,8 @@ func TestWebhookTimeout(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
+	terminator := make(chan bool)
+	defer close(terminator)
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	ts, wr := InitWebhookTest()
@@ -746,7 +760,7 @@ func TestWebhookTimeout(t *testing.T) {
 
 	// Test fast execution, short timeout.  All events processed
 	log.Println("Test fast webhook, short timeout")
-	em := NewEventManager()
+	em := NewEventManager(terminator)
 	em.Start(0, -1)
 	timeout := uint64(2)
 	webhookHandler, _ := NewWebhook(fmt.Sprintf("%s/echo", url), "", &timeout, nil)
@@ -768,7 +782,7 @@ func TestWebhookTimeout(t *testing.T) {
 	log.Println("Test slow webhook, short timeout")
 	wr.Clear()
 	errCount := 0
-	em = NewEventManager()
+	em = NewEventManager(terminator)
 	em.Start(1, 1500)
 	timeout = uint64(1)
 	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow_2s", url), "", &timeout, nil)
@@ -793,7 +807,7 @@ func TestWebhookTimeout(t *testing.T) {
 	log.Println("Test very slow webhook, short timeout")
 	wr.Clear()
 	errCount = 0
-	em = NewEventManager()
+	em = NewEventManager(terminator)
 	em.Start(1, 100)
 	timeout = uint64(9)
 	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow_5s", url), "", &timeout, nil)
@@ -816,7 +830,7 @@ func TestWebhookTimeout(t *testing.T) {
 	log.Println("Test slow webhook, no timeout, wait for process ")
 	wr.Clear()
 	errCount = 0
-	em = NewEventManager()
+	em = NewEventManager(terminator)
 	em.Start(1, 1500)
 	timeout = uint64(0)
 	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow", url), "", &timeout, nil)
@@ -841,6 +855,9 @@ func TestUnavailableWebhook(t *testing.T) {
 	ts, wr := InitWebhookTest()
 	defer ts.Close()
 
+	terminator := make(chan bool)
+	defer close(terminator)
+
 	ids := make([]string, 20)
 	for i := 0; i < 20; i++ {
 		ids[i] = fmt.Sprintf("%d", i)
@@ -862,7 +879,7 @@ func TestUnavailableWebhook(t *testing.T) {
 
 	// Test unreachable webhook
 
-	em := NewEventManager()
+	em := NewEventManager(terminator)
 	em.Start(0, -1)
 	webhookHandler, _ := NewWebhook("http://badhost:1000/echo", "", nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2136,6 +2136,7 @@ func TestWebhookFilterFunctionLoad(t *testing.T) {
 				}
 			}
 			terminator := make(chan bool)
+			defer close(terminator)
 			ctx := &db.DatabaseContext{EventMgr: db.NewEventManager(terminator)}
 			sc := &ServerContext{}
 			err := sc.initEventHandlers(ctx, &dbConfig)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2135,7 +2135,8 @@ func TestWebhookFilterFunctionLoad(t *testing.T) {
 					Err:        test.errExpected,
 				}
 			}
-			ctx := &db.DatabaseContext{EventMgr: db.NewEventManager()}
+			terminator := make(chan bool)
+			ctx := &db.DatabaseContext{EventMgr: db.NewEventManager(terminator)}
 			sc := &ServerContext{}
 			err := sc.initEventHandlers(ctx, &dbConfig)
 			if test.errExpected != nil {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -913,7 +913,6 @@ func (sc *ServerContext) initEventHandlers(dbcontext *db.DatabaseContext, config
 	if config.EventHandlers == nil {
 		return nil
 	}
-
 	// Load Webhook Filter Function.
 	eventHandlersByType := map[db.EventType][]*EventConfig{
 		db.DocumentChange: config.EventHandlers.DocumentChanged,


### PR DESCRIPTION
CBG-2369

Made some changes to pass a terminator to EventManager goroutine. This fixes the issue when running `SG_TEST_GOROUTINE_DUMP=true go test -v -count=1 ./db` now produces no leaked goroutines. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] N/A