### PR TITLE
Add 'sync_gateway' binary produced by 'go build' to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage*.out
 coverage*.xml
 verbose*.out*
 verbose*.xml
+sync_gateway

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ coverage*.xml
 verbose*.out*
 verbose*.xml
 sync_gateway
+*.pb.gz


### PR DESCRIPTION
`go build` produces a `sync_gateway` binary on linux/macOS - Add it to the project's `.gitignore` - Windows already covered with `*.exe` 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a