### PR TITLE
[Backport 3.0.4] CBG-2419: Backport CBG-2416: Unregister Prometheus stats on database close

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -650,6 +650,9 @@ func (s *SgwStats) ClearDBStats(name string) {
 	s.DbStats[name].unregisterCacheStats()
 	s.DbStats[name].unregisterCBLReplicationPullStats()
 	s.DbStats[name].unregisterCBLReplicationPushStats()
+	for replName := range s.DbStats[name].DbReplicatorStats {
+		s.DbStats[name].unregisterReplicationStats(replName)
+	}
 	s.DbStats[name].unregisterDatabaseStats()
 	s.DbStats[name].unregisterSecurityStats()
 
@@ -929,6 +932,36 @@ func (d *DbStats) initSecurityStats() {
 			TotalAuthTime:    NewIntStat(SubsystemSecurity, "total_auth_time", labelKeys, labelVals, prometheus.GaugeValue, 0),
 		}
 	}
+}
+
+func (d *DbStats) unregisterReplicationStats(replicationID string) {
+	if d.DbReplicatorStats[replicationID] == nil {
+		return
+	}
+
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].NumAttachmentBytesPushed)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].NumAttachmentPushed)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].NumDocPushed)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].NumDocsFailedToPush)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].PushConflictCount)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].PushRejectedCount)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].PushDeltaSentCount)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].DocsCheckedSent)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].NumConnectAttemptsPush)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].NumReconnectsAbortedPush)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].NumAttachmentBytesPulled)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].NumAttachmentsPulled)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].PulledCount)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].PurgedCount)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].FailedToPullCount)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].DeltaReceivedCount)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].DeltaRequestedCount)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].DocsCheckedReceived)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].ConflictResolvedLocalCount)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].ConflictResolvedRemoteCount)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].ConflictResolvedMergedCount)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].NumConnectAttemptsPull)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].NumReconnectsAbortedPull)
 }
 
 func (d *DbStats) unregisterSecurityStats() {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -154,6 +154,11 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 	if rt.RestTesterConfig.groupID != nil {
 		sc.Bootstrap.ConfigGroupID = *rt.RestTesterConfig.groupID
+	} else if rt.RestTesterConfig.persistentConfig {
+		// If running in persistent config mode, the database has to be manually created. If the db name is the same as a
+		// past tests db name, a db already exists error could happen if the past tests bucket is still flushing. Prevent this
+		// by setting the group ID as the current test bucket name by default.
+		sc.Bootstrap.ConfigGroupID = testBucket.GetName()
 	}
 
 	// Allow EE-only config even in CE for testing using group IDs.


### PR DESCRIPTION
CBG-2419

- Backported CBG-2416
- Manually tested unit test repro without fix to confirm test works and issue exists
- Removed stat added to 3.1 that does not exist in 3.0.4
- Update requireStatuses to assertStatuses

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/802/