### PR TITLE
Improve resync test waits by printing information on failure

### DIFF
--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -10,6 +10,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"sync"
 	"testing"
@@ -391,7 +392,7 @@ func (b *BackgroundManager) setRunState(state BackgroundProcessState) {
 }
 
 // Currently only test
-func (b *BackgroundManager) GetRunState(t *testing.T) BackgroundProcessState {
+func (b *BackgroundManager) GetRunState(t testing.TB) BackgroundProcessState {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 	return b.State
@@ -399,11 +400,21 @@ func (b *BackgroundManager) GetRunState(t *testing.T) BackgroundProcessState {
 
 // For test use only
 // Returns empty string if background process is not cluster aware
-func (b *BackgroundManager) GetHeartbeatDocID(t *testing.T) string {
+func (b *BackgroundManager) GetHeartbeatDocID(t testing.TB) string {
 	if b.isClusterAware() {
 		return b.clusterAwareOptions.HeartbeatDocID()
 	}
 	return ""
+}
+
+// For test use only
+// Returns error if background process is not cluster aware
+func (b *BackgroundManager) GetHeartbeatDoc(t testing.TB) ([]byte, error) {
+	if b.isClusterAware() {
+		b, _, err := b.clusterAwareOptions.bucket.GetRaw(b.GetHeartbeatDocID(t))
+		return b, err
+	}
+	return nil, fmt.Errorf("background process is not cluster aware")
 }
 
 func (b *BackgroundManager) SetError(err error) {

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1301,7 +1301,12 @@ func TestResync(t *testing.T) {
 				var val interface{}
 				_, err = rt.Bucket().Get(rt.GetDatabase().ResyncManager.GetHeartbeatDocID(t), &val)
 
-				return resyncManagerStatus.State == db.BackgroundProcessStateCompleted && base.IsDocNotFoundError(err)
+				if resyncManagerStatus.State == db.BackgroundProcessStateCompleted && base.IsDocNotFoundError(err) {
+					return true
+				} else {
+					t.Logf("resyncManagerStatus.State != %v: %v - err:%v", db.BackgroundProcessStateCompleted, resyncManagerStatus.State, err)
+					return false
+				}
 			})
 			assert.NoError(t, err)
 
@@ -1397,18 +1402,8 @@ func TestResyncErrorScenarios(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
 	requireStatus(t, response, http.StatusOK)
 
-	err := rt.WaitForCondition(func() bool {
-		response := rt.SendAdminRequest("GET", "/db/_resync", "")
-		var status db.ResyncManagerResponse
-		err := json.Unmarshal(response.BodyBytes(), &status)
-		assert.NoError(t, err)
-
-		var val interface{}
-		_, err = rt.Bucket().Get(rt.GetDatabase().ResyncManager.GetHeartbeatDocID(t), &val)
-
-		return status.State == db.BackgroundProcessStateCompleted && base.IsDocNotFoundError(err)
-	})
-	assert.NoError(t, err)
+	waitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted, rt.GetDatabase().ResyncManager.GetRunState)
+	waitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
 
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
 	requireStatus(t, response, http.StatusBadRequest)
@@ -1420,18 +1415,8 @@ func TestResyncErrorScenarios(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/db/_resync", "")
 	requireStatus(t, response, http.StatusOK)
 
-	err = rt.WaitForCondition(func() bool {
-		response := rt.SendAdminRequest("GET", "/db/_resync", "")
-		var status db.ResyncManagerResponse
-		err := json.Unmarshal(response.BodyBytes(), &status)
-		assert.NoError(t, err)
-
-		var val interface{}
-		_, err = rt.Bucket().Get(rt.GetDatabase().ResyncManager.GetHeartbeatDocID(t), &val)
-
-		return status.State == db.BackgroundProcessStateCompleted && base.IsDocNotFoundError(err)
-	})
-	assert.NoError(t, err)
+	waitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted, rt.GetDatabase().ResyncManager.GetRunState)
+	waitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
 
 	assert.True(t, callbackFired, "expecting callback to be fired")
 }
@@ -1510,21 +1495,8 @@ func TestResyncStop(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
 	requireStatus(t, response, http.StatusOK)
 
-	err = rt.WaitForCondition(func() bool {
-		response := rt.SendAdminRequest("GET", "/db/_resync", "")
-		type ResyncManagerResponse struct {
-			Status db.BackgroundProcessState `json:"status"`
-		}
-		var resyncManagerStatus ResyncManagerResponse
-		err := json.Unmarshal(response.BodyBytes(), &resyncManagerStatus)
-		assert.NoError(t, err)
-
-		var val interface{}
-		_, err = rt.Bucket().Get(rt.GetDatabase().ResyncManager.GetHeartbeatDocID(t), &val)
-
-		return resyncManagerStatus.Status == db.BackgroundProcessStateStopped && base.IsDocNotFoundError(err)
-	})
-	assert.NoError(t, err)
+	waitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateStopped, rt.GetDatabase().ResyncManager.GetRunState)
+	waitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
 
 	assert.True(t, callbackFired, "expecting callback to be fired")
 
@@ -1638,13 +1610,8 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=start&regenerate_sequences=true", "")
 	requireStatus(t, response, http.StatusOK)
 
-	err = rt.WaitForCondition(func() bool {
-		var val interface{}
-		_, err = rt.Bucket().Get(rt.GetDatabase().ResyncManager.GetHeartbeatDocID(t), &val)
-
-		return rt.GetDatabase().ResyncManager.GetRunState(t) == db.BackgroundProcessStateCompleted && base.IsDocNotFoundError(err)
-	})
-	assert.NoError(t, err)
+	waitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted, rt.GetDatabase().ResyncManager.GetRunState)
+	waitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
 
 	_, err = rt.Bucket().Get(base.RolePrefix+"role1", &body)
 	assert.NoError(t, err)
@@ -5044,7 +5011,13 @@ func TestResyncPersistence(t *testing.T) {
 		resp = rt1.SendAdminRequest("GET", "/db/_resync", "")
 		err := json.Unmarshal(resp.BodyBytes(), &resyncManagerStatus)
 		assert.NoError(t, err)
-		return resyncManagerStatus.State == db.BackgroundProcessStateCompleted
+
+		if resyncManagerStatus.State == db.BackgroundProcessStateCompleted {
+			return true
+		} else {
+			t.Logf("resyncManagerStatus.State != %v: %v", db.BackgroundProcessStateCompleted, resyncManagerStatus.State)
+			return false
+		}
 	})
 	require.NoError(t, err)
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1859,3 +1859,22 @@ func waitAndAssertConditionTimeout(t *testing.T, timeout time.Duration, fn func(
 		}
 	}
 }
+
+func waitAndAssertBackgroundManagerState(t testing.TB, expected db.BackgroundProcessState, getStateFunc func(t testing.TB) db.BackgroundProcessState) bool {
+	err, actual := base.RetryLoop(t.Name()+"-waitAndAssertBackgroundManagerState", func() (shouldRetry bool, err error, value interface{}) {
+		actual := getStateFunc(t)
+		return expected != actual, nil, actual
+	}, base.CreateMaxDoublingSleeperFunc(30, 100, 1000))
+	return assert.NoErrorf(t, err, "expected background manager state %v, but got: %v", expected, actual)
+}
+
+func waitAndAssertBackgroundManagerExpiredHeartbeat(t testing.TB, bm *db.BackgroundManager) bool {
+	err, b := base.RetryLoop(t.Name()+"-assertNoHeartbeatDoc", func() (shouldRetry bool, err error, value interface{}) {
+		b, err := bm.GetHeartbeatDoc(t)
+		return !base.IsDocNotFoundError(err), err, b
+	}, base.CreateMaxDoublingSleeperFunc(30, 100, 1000))
+	if b != nil {
+		return assert.NoErrorf(t, err, "expected heartbeat doc to expire, but found one: %v", b)
+	}
+	return assert.Truef(t, base.IsDocNotFoundError(err), "expected heartbeat doc to expire, but got a different error: %v", err)
+}


### PR DESCRIPTION
A lot of the resync tests fail semi-regularly but we have no information about how they're failing... This aims to solve that by making assertion functions that print details when it fails.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/803/