### PR TITLE
Bump log level/keys in TestReplicatorDoNotSendDeltaWhenSrcIsTombstone

### DIFF
--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -5750,7 +5750,7 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
 	defer db.SuspendSequenceBatching()()
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyHTTPResp, base.KeyChanges, base.KeySync, base.KeySyncMsg, base.KeyWebSocket, base.KeyWebSocketFrame, base.KeyDCP)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	// Passive //
 	passiveBucket := base.GetTestBucket(t)

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -5750,7 +5750,7 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
 	defer db.SuspendSequenceBatching()()
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyHTTPResp, base.KeyChanges, base.KeySync, base.KeySyncMsg, base.KeyWebSocket, base.KeyWebSocketFrame, base.KeyDCP)
 
 	// Passive //
 	passiveBucket := base.GetTestBucket(t)


### PR DESCRIPTION
This test fails semi-regularly but we do not have verbose enough detail in the logs to determine if a replication race condition is causing the failure condition.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] n/a