### PR TITLE
Bump logging in TestReplicatorRevocationsMultipleAlternateAccess

### DIFF
--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -5274,6 +5274,8 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll) // CBG-1981
+
 	// Passive
 	revocationTester, rt2 := initScenario(t, nil)
 	defer rt2.Close()


### PR DESCRIPTION
Test is flaky but have too little info to diagnose (CBG-1981)