### PR TITLE
Mark >1.5sec tests as LongRunning skip with -short

### DIFF
--- a/base/util_test.go
+++ b/base/util_test.go
@@ -1524,7 +1524,6 @@ func TestConfigDuration(t *testing.T) {
 }
 
 func TestTerminateAndWaitForClose(t *testing.T) {
-
 	LongRunningTest(t)
 
 	SetUpTestLogging(t, LevelInfo, KeySGTest)

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -1524,6 +1524,9 @@ func TestConfigDuration(t *testing.T) {
 }
 
 func TestTerminateAndWaitForClose(t *testing.T) {
+
+	LongRunningTest(t)
+
 	SetUpTestLogging(t, LevelInfo, KeySGTest)
 
 	tests := []struct {

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -824,3 +824,21 @@ func RequireAllAssertions(t *testing.T, assertionResults ...bool) {
 	}
 	require.Falsef(t, failed, "One or more assertions failed: %v", assertionResults)
 }
+
+// LongRunningTest skips the test if running in -short mode, and logs if the test completed quickly under other circumstances.
+func LongRunningTest(t *testing.T) {
+	const (
+		shortTestThreshold = time.Second
+	)
+	if testing.Short() {
+		t.Skip("skipping long running test in short mode")
+		return
+	}
+	start := time.Now()
+	t.Cleanup(func() {
+		testDuration := time.Since(start)
+		if !t.Failed() && testDuration < shortTestThreshold {
+			t.Logf("TEST: %q was marked as long running, but finished in %v (less than %v) - consider removing LongRunningTest", t.Name(), testDuration, shortTestThreshold)
+		}
+	})
+}

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -811,6 +811,8 @@ func createDocWithInBodyAttachment(t *testing.T, ctx context.Context, docID stri
 // Check for regression of CBG-1980 caused by DCP closing timing issue for the mark and sweep stage
 // May sometimes fail if docsToCreate is not high enough
 func TestAttachmentCompactIncorrectStat(t *testing.T) {
+	base.LongRunningTest(t)
+
 	const docsToCreate = 10_000
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Requires CBS")

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -863,10 +863,6 @@ func TestLowSequenceHandlingAcrossChannels(t *testing.T) {
 // user gets added to a new channel with existing entries (and existing backfill)
 func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
-
 	if base.TestUseXattrs() {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
@@ -1257,6 +1253,8 @@ func TestChannelRace(t *testing.T) {
 // been seen on the TAP feed yet).  Longer term could consider enhancing leaky bucket to 'miss' the entry on the tap feed.
 func TestSkippedViewRetrieval(t *testing.T) {
 
+	base.LongRunningTest(t)
+
 	if base.TestUseXattrs() {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
@@ -1326,10 +1324,6 @@ func TestSkippedViewRetrieval(t *testing.T) {
 
 // Test that housekeeping goroutines get terminated when change cache is stopped
 func TestStopChangeCache(t *testing.T) {
-
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges, base.KeyDCP)
 

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -90,10 +90,6 @@ func TestFilterToAvailableChannels(t *testing.T) {
 // Unit test for bug #314
 func TestChangesAfterChannelAdded(t *testing.T) {
 
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
-
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
@@ -198,10 +194,6 @@ func getChangesOptionsWithCtxOnly() ChangesOptions {
 
 func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
-
 	if !base.UnitTestUrlIsWalrus() && base.TestUseXattrs() {
 		t.Skip("This test is known to be failing against couchbase server with XATTRS enabled.  See https://gist.github.com/tleyden/a41632355fadde54f19e84ba68015512")
 	}
@@ -284,10 +276,6 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 }
 
 func TestDocDeletionFromChannelCoalesced(t *testing.T) {
-
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
 
 	if !base.UnitTestUrlIsWalrus() && base.TestUseXattrs() {
 		t.Skip("This test is known to be failing against couchbase server with XATTRS enabled.  Same error as TestDocDeletionFromChannelCoalescedRemoved")

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -931,6 +931,8 @@ func TestOldRevisionStorageError(t *testing.T) {
 // Validate JSON number handling for large sequence values
 func TestLargeSequence(t *testing.T) {
 
+	base.LongRunningTest(t)
+
 	db, ctx := setupTestDBWithCustomSyncSeq(t, 9223372036854775807)
 	defer db.Close(ctx)
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -956,10 +956,6 @@ func TestRepeatedConflict(t *testing.T) {
 
 func TestConflicts(t *testing.T) {
 
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
-
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -433,8 +433,8 @@ func InitWebhookTest() (*httptest.Server, *WebhookRequest) {
 }
 
 func TestWebhookBasic(t *testing.T) {
-
 	base.LongRunningTest(t)
+
 	terminator := make(chan bool)
 	defer close(terminator)
 

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -433,11 +433,10 @@ func InitWebhookTest() (*httptest.Server, *WebhookRequest) {
 }
 
 func TestWebhookBasic(t *testing.T) {
+
+	base.LongRunningTest(t)
 	terminator := make(chan bool)
 	defer close(terminator)
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
 
 	ts, wr := InitWebhookTest()
 	defer ts.Close()
@@ -585,9 +584,6 @@ func TestWebhookBasic(t *testing.T) {
 // Test Webhook where there is an old doc revision and where the filter
 // function is expecting an old doc revision.
 func TestWebhookOldDoc(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
 	terminator := make(chan bool)
 	defer close(terminator)
 
@@ -728,9 +724,8 @@ func TestWebhookOldDoc(t *testing.T) {
 }
 
 func TestWebhookTimeout(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
+	base.LongRunningTest(t)
+
 	terminator := make(chan bool)
 	defer close(terminator)
 

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -520,6 +520,7 @@ func TestAdminAuthWithX509(t *testing.T) {
 }
 
 func TestAdminAPIAuth(t *testing.T) {
+	base.LongRunningTest(t)
 
 	// Don't really care about the log level but this test hits the logging endpoint so this is used to reset the logging
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyNone)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -298,9 +298,7 @@ func TestPrincipalForbidUpdatingChannels(t *testing.T) {
 // Test user access grant while that user has an active changes feed.  (see issue #880)
 func TestUserAccessRace(t *testing.T) {
 
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
+	base.LongRunningTest(t)
 
 	// This test only runs against Walrus due to known sporadic failures.
 	// See https://github.com/couchbase/sync_gateway/issues/3006
@@ -1136,9 +1134,6 @@ func TestDBGetConfigNames(t *testing.T) {
 
 // Take DB offline and ensure can post _resync
 func TestDBOfflinePostResync(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -1174,9 +1169,6 @@ func TestDBOfflinePostResync(t *testing.T) {
 
 // Take DB offline and ensure only one _resync can be in progress
 func TestDBOfflineSingleResync(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
 
 	syncFn := `
 	function(doc) {
@@ -1534,6 +1526,8 @@ func TestResyncStop(t *testing.T) {
 }
 
 func TestResyncRegenerateSequences(t *testing.T) {
+
+	base.LongRunningTest(t)
 	syncFn := `
 	function(doc) {
 		if (doc.userdoc){
@@ -1779,9 +1773,6 @@ func TestDBOnlineConcurrent(t *testing.T) {
 func TestSingleDBOnlineWithDelay(t *testing.T) {
 
 	t.Skip("Use case covered by TestDBOnlineWithTwoDelays, skipping due to slow test")
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -1822,9 +1813,8 @@ func TestSingleDBOnlineWithDelay(t *testing.T) {
 // DB should should only be brought online once
 // there should be no errors
 func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
+
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
 
@@ -1871,9 +1861,7 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 // there should be no errors
 func TestDBOnlineWithTwoDelays(t *testing.T) {
 
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
+	base.LongRunningTest(t)
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1220,6 +1220,8 @@ func TestDBOfflineSingleResync(t *testing.T) {
 }
 
 func TestResync(t *testing.T) {
+	base.LongRunningTest(t)
+
 	testCases := []struct {
 		name               string
 		docsCreated        int
@@ -4444,6 +4446,8 @@ func TestDeleteDatabasePointingAtSameBucketPersistent(t *testing.T) {
 
 // CBG-1046: Add ability to specify user for active peer in sg-replicate2
 func TestSpecifyUserDocsToReplicate(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 

--- a/rest/admin_query_api_test.go
+++ b/rest/admin_query_api_test.go
@@ -62,6 +62,8 @@ func TestUserQueryDBConfigGetWithoutFeatureFlag(t *testing.T) {
 
 // Test use of "Etag" and "If-Match" headers to safely update function/query/graphql config.
 func TestUserQueryDBConfigMVCC(t *testing.T) {
+	base.LongRunningTest(t)
+
 	rt := newRestTesterForUserQueries(t, DbConfig{
 		UserFunctions: map[string]*db.UserFunctionConfig{
 			"xxx": {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5354,8 +5354,8 @@ func TestHandlePprofsCmdlineAndSymbol(t *testing.T) {
 }
 
 func TestHandlePprofs(t *testing.T) {
-
 	base.LongRunningTest(t)
+
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -725,10 +725,6 @@ func assertGatewayStatus(t *testing.T, response *TestResponse, expected int) {
 
 func TestCORSLoginOriginOnSessionPost(t *testing.T) {
 
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
-
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
@@ -2840,10 +2836,6 @@ func TestSyncFnDocBodyPropertiesSwitchActiveTombstone(t *testing.T) {
 
 // Test for wrong _changes entries for user joining a populated channel
 func TestUserJoiningPopulatedChannel(t *testing.T) {
-
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache, base.KeyAccess, base.KeyCRUD, base.KeyChanges)
 
@@ -5362,6 +5354,8 @@ func TestHandlePprofsCmdlineAndSymbol(t *testing.T) {
 }
 
 func TestHandlePprofs(t *testing.T) {
+
+	base.LongRunningTest(t)
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -28,10 +28,6 @@ import (
 
 func TestChangesAccessNotifyInteger(t *testing.T) {
 
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
-
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel);}`})
@@ -83,10 +79,6 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 // channels in the filter were being included in the waiter initialization, but not in the subsequent wait.  Resulting difference in count was resulting
 // in longpoll terminating without any changes.
 func TestChangesNotifyChannelFilter(t *testing.T) {
-
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -164,6 +164,8 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 // Wait until we get the expected updates
 func TestContinuousChangesSubscription(t *testing.T) {
 
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)
 
 	bt, err := NewBlipTester(t)
@@ -275,10 +277,6 @@ func TestContinuousChangesSubscription(t *testing.T) {
 // Start subChanges w/ continuous=false, batchsize=20
 // Validate we get the expected updates and changes ends
 func TestBlipOneShotChangesSubscription(t *testing.T) {
-
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
@@ -3893,6 +3891,9 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 // Asserts on stats to test for regression of CBG-1824: Make sure SubChangesOneShotActive gets decremented when one shot
 // sub changes request has completed
 func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
+
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	bt, err := NewBlipTester(t)
@@ -4541,6 +4542,8 @@ func TestBlipRevokeNonExistentRole(t *testing.T) {
 // Tests changes made in CBG-2151 to return errors from sendRevision unless it's a document not found error,
 // in which case a noRev should be sent.
 func TestSendRevisionNoRevHandling(t *testing.T) {
+
+	base.LongRunningTest(t)
 	if !base.UnitTestUrlIsWalrus() {
 		t.Skip("Skip LeakyBucket test when running in integration")
 	}

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1195,8 +1195,10 @@ func TestBlipSendAndGetRev(t *testing.T) {
 }
 
 // Test send and retrieval of a doc with a large numeric value.  Ensure proper large number handling.
-//   Validate deleted handling (includes check for https://github.com/couchbase/sync_gateway/issues/3341)
+//
+//	Validate deleted handling (includes check for https://github.com/couchbase/sync_gateway/issues/3341)
 func TestBlipSendAndGetLargeNumberRev(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -221,10 +221,6 @@ func TestPostChanges(t *testing.T) {
 // Tests race between waking up the changes feed, and detecting that the user doc has changed
 func TestPostChangesUserTiming(t *testing.T) {
 
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
-
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel)}`})
@@ -282,10 +278,6 @@ func TestPostChangesUserTiming(t *testing.T) {
 }
 
 func TestPostChangesSinceInteger(t *testing.T) {
-
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
@@ -458,10 +450,6 @@ func postChangesChannelFilter(t *testing.T, rt *RestTester) {
 }
 
 func TestPostChangesAdminChannelGrant(t *testing.T) {
-
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
@@ -1434,10 +1422,6 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 
 func TestUnusedSequences(t *testing.T) {
 
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
-
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyCRUD, base.KeyHTTP)
 
 	// Only do 10 iterations if running against walrus.  If against a live couchbase server,
@@ -1734,10 +1718,6 @@ func TestChangesActiveOnlyInteger(t *testing.T) {
 }
 
 func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
-
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyNone)
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -868,6 +868,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 // Reproduces CBG-1113 and #1329 (even with the fix in PR #1360)
 // Tests all combinations of HTTP feed types, admin/non-admin, and with and without a manual notify to wake up.
 func TestChangeWaiterExitOnChangesTermination(t *testing.T) {
+	base.LongRunningTest(t)
 
 	const username = "bernard"
 
@@ -1421,6 +1422,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 }
 
 func TestUnusedSequences(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyCRUD, base.KeyHTTP)
 
@@ -3854,6 +3856,8 @@ func TestCacheCompactDuringChangesWait(t *testing.T) {
 }
 
 func TestTombstoneCompaction(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	if base.UnitTestUrlIsWalrus() {

--- a/rest/handler_test.go
+++ b/rest/handler_test.go
@@ -83,6 +83,8 @@ func TestParseHTTPRangeHeader(t *testing.T) {
 }
 
 func TestHTTPLoggingRedaction(t *testing.T) {
+
+	base.LongRunningTest(t)
 	cases := []struct {
 		name, method, path, expectedLog string
 		admin                           bool

--- a/rest/jwt_auth_test.go
+++ b/rest/jwt_auth_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestLocalJWTAuthenticationE2E(t *testing.T) {
+	base.LongRunningTest(t)
+
 	const (
 		testIssuer             = "test_issuer"
 		testClientID           = "test_aud"
@@ -154,6 +156,8 @@ func TestLocalJWTAuthenticationE2E(t *testing.T) {
 }
 
 func TestLocalJWTAuthenticationEdgeCases(t *testing.T) {
+
+	base.LongRunningTest(t)
 	testRSAKeypair, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 	testRSAJWK := jose.JSONWebKey{

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -535,6 +535,8 @@ func (m mockProviderChannelsClaim) Apply(provider *auth.OIDCProvider) {
 
 // E2E test that checks OpenID Connect Authorization Code Flow.
 func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
+
+	base.LongRunningTest(t)
 	type test struct {
 		name                string
 		providers           auth.OIDCProviderMap
@@ -1811,6 +1813,8 @@ func TestCallbackStateClientCookies(t *testing.T) {
 // E2E test that checks OpenID Connect Authorization Code Flow with the specified username_claim
 // as Sync Gateway username.
 func TestOpenIDConnectAuthCodeFlowWithUsernameClaim(t *testing.T) {
+
+	base.LongRunningTest(t)
 	var (
 		defaultProvider = "foo"
 		authURL         = "/db/_oidc?provider=foo&offline=true"

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -210,6 +210,8 @@ func TestProviderOIDCAuthWithTlsSkipVerifyEnabled(t *testing.T) {
 }
 
 func TestProviderOIDCAuthWithTlsSkipVerifyDisabled(t *testing.T) {
+
+	base.LongRunningTest(t)
 	restTesterConfig := restTesterConfigWithTestProviderEnabled()
 	restTesterConfig.DatabaseConfig.Unsupported.OidcTlsSkipVerify = false
 	restTester := NewRestTester(t, &restTesterConfig)

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -520,7 +520,6 @@ func TestReplicationsFromConfig(t *testing.T) {
 //   - Creates a continuous push replication on rt1 via the REST API
 //   - Validates documents are replicated to rt2
 func TestPushReplicationAPI(t *testing.T) {
-
 	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
@@ -947,7 +946,6 @@ func TestPullOneshotReplicationAPI(t *testing.T) {
 //
 //	WriteUpdateWithXattr.  Have been unable to reproduce the same with a leaky bucket UpdateCallback.
 func TestReplicationConcurrentPush(t *testing.T) {
-
 	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -521,6 +521,8 @@ func TestReplicationsFromConfig(t *testing.T) {
 //   - Validates documents are replicated to rt2
 func TestPushReplicationAPI(t *testing.T) {
 
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
@@ -885,6 +887,8 @@ func TestReplicationRebalancePush(t *testing.T) {
 //   - Validates replication status count when replication is local and non-local
 func TestPullOneshotReplicationAPI(t *testing.T) {
 
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
@@ -938,9 +942,13 @@ func TestPullOneshotReplicationAPI(t *testing.T) {
 //   - Write documents to rt1 belonging to both channels
 //   - Write documents to rt1, each belonging to one of the channels (verifies replications are still running)
 //   - Validate replications do not report errors, all docs are replicated
+//
 // Note: This test intermittently reproduced CBG-998 under -race when a 1s sleep was added post-callback to
-//   WriteUpdateWithXattr.  Have been unable to reproduce the same with a leaky bucket UpdateCallback.
+//
+//	WriteUpdateWithXattr.  Have been unable to reproduce the same with a leaky bucket UpdateCallback.
 func TestReplicationConcurrentPush(t *testing.T) {
+
+	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -1962,7 +1962,6 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 //   - Publishes the REST API on a httptest server for the passive node (so the active can connect to it)
 //   - Uses an ActiveReplicator configured for pull to start pulling changes from rt2.
 func TestActiveReplicatorPullConflict(t *testing.T) {
-
 	base.LongRunningTest(t)
 
 	// scenarios
@@ -3455,8 +3454,8 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 // - Unroutable remote address
 // Will test both indefinite retry, and a timeout.
 func TestActiveReplicatorReconnectOnStart(t *testing.T) {
-
 	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	if testing.Short() {
@@ -4447,6 +4446,8 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 // This test ensures that the local tombstone revision wins over non-tombstone revision
 // whilst applying default conflict resolution policy through pushAndPull replication.
 func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
+
+	base.LongRunningTest(t)
 	base.RequireNumTestBuckets(t, 2)
 	if !base.TestUseXattrs() {
 		t.Skip("This test only works with XATTRS enabled")
@@ -4600,6 +4601,8 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 // This test ensures that the remote tombstone revision wins over non-tombstone revision
 // whilst applying default conflict resolution policy through pushAndPull replication.
 func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
+
+	base.LongRunningTest(t)
 	base.RequireNumTestBuckets(t, 2)
 	if !base.TestUseXattrs() {
 		t.Skip("This test only works with XATTRS enabled")

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -1863,6 +1863,8 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 //   - Drops the document out of the channel so the replicator in rt1 pulls a _removed revision.
 func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyReplicate)
@@ -1960,6 +1962,8 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 //   - Publishes the REST API on a httptest server for the passive node (so the active can connect to it)
 //   - Uses an ActiveReplicator configured for pull to start pulling changes from rt2.
 func TestActiveReplicatorPullConflict(t *testing.T) {
+
+	base.LongRunningTest(t)
 
 	// scenarios
 	conflictResolutionTests := []struct {
@@ -2186,6 +2190,8 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 //   - Uses an ActiveReplicator configured for pushAndPull from rt2.
 //   - verifies expected conflict resolution, and that expected result is replicated to both peers
 func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
+
+	base.LongRunningTest(t)
 
 	// scenarios
 	conflictResolutionTests := []struct {
@@ -3449,6 +3455,8 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 // - Unroutable remote address
 // Will test both indefinite retry, and a timeout.
 func TestActiveReplicatorReconnectOnStart(t *testing.T) {
+
+	base.LongRunningTest(t)
 	base.RequireNumTestBuckets(t, 2)
 
 	if testing.Short() {
@@ -3803,6 +3811,8 @@ func TestBlipSyncNonUpgradableConnection(t *testing.T) {
 //   - Uses an ActiveReplicator configured for pull to start pulling changes from rt2.
 func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 
+	base.LongRunningTest(t)
+
 	createRevID := func(generation int, parentRevID string, body db.Body) string {
 		rev, err := db.CreateRevID(generation, parentRevID, body)
 		require.NoError(t, err, "Error creating revision")
@@ -4110,6 +4120,8 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 }
 
 func TestSGR2TombstoneConflictHandling(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	tombstoneTests := []struct {

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -141,6 +141,8 @@ func dbConfigForTestBucket(tb *base.TestBucket) DbConfig {
 }
 
 func TestPersistentDbConfigWithInvalidUpsert(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	rtc := NewRestTesterCluster(t, nil)

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -134,6 +134,8 @@ func TestServerlessDBSetupForceCreds(t *testing.T) {
 // Tests behaviour of CBG-2258 to make sure fetch databases only uses buckets listed on StartupConfig.BucketCredentials
 // when running in serverless mode
 func TestServerlessBucketCredentialsFetchDatabases(t *testing.T) {
+	base.LongRunningTest(t)
+
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}


### PR DESCRIPTION
With only 24 of 981 walrus tests skipped, it saves nearly 4 minutes of total test runtime, allowing most of the test suite to run in ~1 minute 

Also applied to 10sec+ integration tests

## normal
```
> go test -count=1 ./... | tee test.out
?   	github.com/couchbase/sync_gateway	[no test files]
ok  	github.com/couchbase/sync_gateway/auth	8.115s
ok  	github.com/couchbase/sync_gateway/base	13.207s
ok  	github.com/couchbase/sync_gateway/channels	0.696s
ok  	github.com/couchbase/sync_gateway/db	87.661s
ok  	github.com/couchbase/sync_gateway/rest	207.007s
```

## -short
```
> go test -short -count=1 ./... | tee test-short.out
?   	github.com/couchbase/sync_gateway	[no test files]
ok  	github.com/couchbase/sync_gateway/auth	6.397s
ok  	github.com/couchbase/sync_gateway/base	0.911s
ok  	github.com/couchbase/sync_gateway/channels	0.602s
ok  	github.com/couchbase/sync_gateway/db	7.759s
ok  	github.com/couchbase/sync_gateway/rest	47.741s
```

## Distribution of unit test duration

![Screenshot 2022-09-15 at 12 14 22](https://user-images.githubusercontent.com/1525809/190390068-a5121969-eab1-46c7-93d2-68d83753492f.png)

## Distribution of integration test duration 

![Screenshot 2022-09-15 at 13 59 43](https://user-images.githubusercontent.com/1525809/190409989-22b6f724-04e8-4cdc-8439-1402f0a34936.png)
