### PR TITLE
Run all files through Go 1.19's go fmt for comment changes

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1400,15 +1400,16 @@ func initializeScenario(t *testing.T, auth *Authenticator) (*userImpl, Principal
 // =======================================================================================================
 
 // Scenario 1
-// Initiate user and role
-// Grant role channel and role
-//  - Changes Request - Seq 25 - Has channel 1 access, no history
-// No changes
-//  - Changes Request - Seq 40 - Has channel 1 access, no history
-// Role revoke, role channel revoke then role re-grant and role channel re-grant
-//  - Changes Request - Seq 80 - Has channel 1 access, no history
-// Role revoke, role channel revoke
-//  - Changes Request - Seq 110 - Doesn't have channel access, history added for both role and channel
+//
+//	Initiate user and role
+//	Grant role channel and role
+//	 - Changes Request - Seq 25 - Has channel 1 access, no history
+//	No changes
+//	 - Changes Request - Seq 40 - Has channel 1 access, no history
+//	Role revoke, role channel revoke then role re-grant and role channel re-grant
+//	 - Changes Request - Seq 80 - Has channel 1 access, no history
+//	Role revoke, role channel revoke
+//	 - Changes Request - Seq 110 - Doesn't have channel access, history added for both role and channel
 func TestRevocationScenario1(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -1491,15 +1492,16 @@ func TestRevocationScenario1(t *testing.T) {
 }
 
 // Scenario 2
-// Initiate user and role
-// Grant role channel and role
-//  - Changes Request - Seq 25 - Has channel 1 access, no history
-// Revoke role
-//  - Changes Request - Seq 50 - Doesn't have channel access, role history added
-// Revoke channel, re-grant role, re-grant channel
-//  - Changes Request - Seq 80 - Has channel access, retains role history
-// Role revoke, role channel revoke
-//  - Changes Request - Seq 110 - Doesn't have channel access, history added for both role and channel
+//
+//	Initiate user and role
+//	Grant role channel and role
+//	 - Changes Request - Seq 25 - Has channel 1 access, no history
+//	Revoke role
+//	 - Changes Request - Seq 50 - Doesn't have channel access, role history added
+//	Revoke channel, re-grant role, re-grant channel
+//	 - Changes Request - Seq 80 - Has channel access, retains role history
+//	Role revoke, role channel revoke
+//	 - Changes Request - Seq 110 - Doesn't have channel access, history added for both role and channel
 func TestRevocationScenario2(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -1588,15 +1590,16 @@ func TestRevocationScenario2(t *testing.T) {
 }
 
 // Scenario 3
-// Initiate user and role
-// Grant role channel and role
-//  - Changes Request - Seq 25 - Has channel 1 access, no history
-// Revoke role, revoke role channel
-//  - Changes Request - Seq 60 - Doesn't have channel access, history added for both role and channel
-// Grant role channel and role
-//  - Changes Request - Seq 80 - Has channel access, retains history
-// Role revoke, role channel revoke
-//  - Changes Request - Seq 110 - Doesn't have channel access, history added for both role and channel
+//
+//	Initiate user and role
+//	Grant role channel and role
+//	  - Changes Request - Seq 25 - Has channel 1 access, no history
+//	Revoke role, revoke role channel
+//	  - Changes Request - Seq 60 - Doesn't have channel access, history added for both role and channel
+//	Grant role channel and role
+//	  - Changes Request - Seq 80 - Has channel access, retains history
+//	Role revoke, role channel revoke
+//	  - Changes Request - Seq 110 - Doesn't have channel access, history added for both role and channel
 func TestRevocationScenario3(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -1694,15 +1697,16 @@ func TestRevocationScenario3(t *testing.T) {
 }
 
 // Scenario 4
-// Initiate user and role
-// Grant role channel and role
-//  - Changes Request - Seq 25 - Has channel 1 access, no history
-// Revoke role, revoke role channel, re-grant role
-//  - Changes Request - Seq 70 - Doesn't have channel access, history added for role channel
-// Grant role
-//  - Changes Request - Seq 80 - Has channel access, retains history
-// Role revoke, role channel revoke
-//  - Changes Request - Seq 110 - Doesn't have channel access, history added for both role and channel
+//
+//	Initiate user and role
+//	Grant role channel and role
+//	  - Changes Request - Seq 25 - Has channel 1 access, no history
+//	Revoke role, revoke role channel, re-grant role
+//	  - Changes Request - Seq 70 - Doesn't have channel access, history added for role channel
+//	Grant role
+//	  - Changes Request - Seq 80 - Has channel access, retains history
+//	Role revoke, role channel revoke
+//	  - Changes Request - Seq 110 - Doesn't have channel access, history added for both role and channel
 func TestRevocationScenario4(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -1789,13 +1793,14 @@ func TestRevocationScenario4(t *testing.T) {
 }
 
 // Scenario 5
-// Initiate user and role
-// Grant role channel and role
-//  - Changes Request - Seq 25 - Has channel 1 access, no history
-// Revoke role, revoke role channel, re-grant role, re-grant channel
-//  - Changes Request - Seq 80 - Has channel 1 access, no history
-// Revoke role and role channel
-//  - Changes Request - Seq 110 - Doesn't have channel access, history added for both role and channel
+//
+//	Initiate user and role
+//	Grant role channel and role
+//	  - Changes Request - Seq 25 - Has channel 1 access, no history
+//	Revoke role, revoke role channel, re-grant role, re-grant channel
+//	  - Changes Request - Seq 80 - Has channel 1 access, no history
+//	Revoke role and role channel
+//	  - Changes Request - Seq 110 - Doesn't have channel access, history added for both role and channel
 func TestRevocationScenario5(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -1866,13 +1871,14 @@ func TestRevocationScenario5(t *testing.T) {
 }
 
 // Scenario 6
-// Initiate user and role
-// Grant role channel and role
-//  - Changes Request - Seq 25 - Has channel 1 access, no history
-// Revoke role, revoke role channel, re-grant role, re-grant channel, re-revoke channel
-//  - Changes Request - Seq 90 - Doesn't have channel 1 access, history added for role channel
-// Revoke role
-//  - Changes Request - Seq 110 - Doesn't have channel access, history added for role
+//
+//	Initiate user and role
+//	Grant role channel and role
+//	  - Changes Request - Seq 25 - Has channel 1 access, no history
+//	Revoke role, revoke role channel, re-grant role, re-grant channel, re-revoke channel
+//	  - Changes Request - Seq 90 - Doesn't have channel 1 access, history added for role channel
+//	Revoke role
+//	  - Changes Request - Seq 110 - Doesn't have channel access, history added for role
 func TestRevocationScenario6(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -1947,13 +1953,14 @@ func TestRevocationScenario6(t *testing.T) {
 }
 
 // Scenario 7
-// Initiate user and role
-// Grant role channel and role
-//  - Changes Request - Seq 25 - Has channel 1 access, no history
-// Revoke role, revoke role channel, re-grant role, re-grant channel, re-revoke channel, re-revoke role
-//  - Changes Request - Seq 100 - Doesn't have channel 1 access, history added for role channel and role
-// No Change
-//  - Changes Request - Seq 110 - Doesn't have channel access, history retained
+//
+//	Initiate user and role
+//	Grant role channel and role
+//	  - Changes Request - Seq 25 - Has channel 1 access, no history
+//	Revoke role, revoke role channel, re-grant role, re-grant channel, re-revoke channel, re-revoke role
+//	  - Changes Request - Seq 100 - Doesn't have channel 1 access, history added for role channel and role
+//	No Change
+//	  - Changes Request - Seq 110 - Doesn't have channel access, history retained
 func TestRevocationScenario7(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -2027,11 +2034,12 @@ func TestRevocationScenario7(t *testing.T) {
 }
 
 // Scenario 8
-// Initiate user and role
-// Grant role channel and role, revoke role
-//  - Changes Request - Seq 50 - Doesn't have channel 1 access, no history
-// Revoke role channel, re-grant role, re-grant channel, re-revoke channel, re-revoke role
-//  - Changes Request - Seq 110 - Doesn't have channel 1 access, no history
+//
+//	Initiate user and role
+//	Grant role channel and role, revoke role
+//	  - Changes Request - Seq 50 - Doesn't have channel 1 access, no history
+//	Revoke role channel, re-grant role, re-grant channel, re-revoke channel, re-revoke role
+//	  - Changes Request - Seq 110 - Doesn't have channel 1 access, no history
 func TestRevocationScenario8(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -2086,11 +2094,12 @@ func TestRevocationScenario8(t *testing.T) {
 }
 
 // Scenario 9
-// Initiate user and role
-// Grant role channel and role, revoke role and role channel
-//  - Changes Request - Seq 60 - Doesn't have channel 1 access, no history
-// Re-grant role, re-grant channel, re-revoke channel, re-revoke role
-//  - Changes Request - Seq 110 - Doesn't have channel 1 access, no history
+//
+//	Initiate user and role
+//	Grant role channel and role, revoke role and role channel
+//	  - Changes Request - Seq 60 - Doesn't have channel 1 access, no history
+//	Re-grant role, re-grant channel, re-revoke channel, re-revoke role
+//	  - Changes Request - Seq 110 - Doesn't have channel 1 access, no history
 func TestRevocationScenario9(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -2142,11 +2151,12 @@ func TestRevocationScenario9(t *testing.T) {
 }
 
 // Scenario 10
-// Initiate user and role
-// Grant role channel and role, revoke role and role channel, re-grant role
-//  - Changes Request - Seq 70 - Doesn't have channel 1 access, no history
-// Re-grant channel, re-revoke channel, re-revoke role
-//  - Changes Request - Seq 110 - Doesn't have channel 1 access, no history
+//
+//	Initiate user and role
+//	Grant role channel and role, revoke role and role channel, re-grant role
+//	  - Changes Request - Seq 70 - Doesn't have channel 1 access, no history
+//	Re-grant channel, re-revoke channel, re-revoke role
+//	  - Changes Request - Seq 110 - Doesn't have channel 1 access, no history
 func TestRevocationScenario10(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -2201,11 +2211,12 @@ func TestRevocationScenario10(t *testing.T) {
 }
 
 // Scenario 11
-// Initiate user and role
-// Grant role channel and role, revoke role and role channel, re-grant role, re-grant channel
-//  - Changes Request - Seq 80 - Has channel 1 access, no history
-// Revoke channel, revoke role
-//  - Changes Request - Seq 110 - Doesn't have channel 1 access, adds role and channel history
+//
+//	Initiate user and role
+//	Grant role channel and role, revoke role and role channel, re-grant role, re-grant channel
+//	  - Changes Request - Seq 80 - Has channel 1 access, no history
+//	Revoke channel, revoke role
+//	  - Changes Request - Seq 110 - Doesn't have channel 1 access, adds role and channel history
 func TestRevocationScenario11(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -2266,11 +2277,12 @@ func TestRevocationScenario11(t *testing.T) {
 }
 
 // Scenario 12
-// Initiate user and role
-// Grant role channel and role, revoke role and role channel, re-grant role, re-grant channel, re-revoke channel
-//  - Changes Request - Seq 90 - Doesn't have channel 1 access, no history
-// Revoke role
-//  - Changes Request - Seq 110 - Doesn't have channel 1 access, no history
+//
+//	Initiate user and role
+//	Grant role channel and role, revoke role and role channel, re-grant role, re-grant channel, re-revoke channel
+//	  - Changes Request - Seq 90 - Doesn't have channel 1 access, no history
+//	Revoke role
+//	  - Changes Request - Seq 110 - Doesn't have channel 1 access, no history
 func TestRevocationScenario12(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -2325,11 +2337,12 @@ func TestRevocationScenario12(t *testing.T) {
 }
 
 // Scenario 13
-// Initiate user and role
-// Grant role channel and role, revoke role and role channel, re-grant role, re-grant channel, re-revoke channel, re-revoke role
-//  - Changes Request - Seq 100 - Doesn't have channel 1 access, no history
-// No changes
-//  - Changes Request - Seq 110 - Doesn't have channel 1 access, no history
+//
+//	Initiate user and role
+//	Grant role channel and role, revoke role and role channel, re-grant role, re-grant channel, re-revoke channel, re-revoke role
+//	  - Changes Request - Seq 100 - Doesn't have channel 1 access, no history
+//	No changes
+//	  - Changes Request - Seq 110 - Doesn't have channel 1 access, no history
 func TestRevocationScenario13(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -2381,12 +2394,13 @@ func TestRevocationScenario13(t *testing.T) {
 }
 
 // Scenario 14
-// Initiate user and role
-// Grant role channel and role
-//  - Changes Request - Seq 25 - Has channel access no history
-// Revoke role
-//  - Changes Request Seq 45 since 25. Ensure revocation.
-// 	- Changes Request Seq 45 since 45 same seq as revocation. Ensure no revocation message.
+//
+//	Initiate user and role
+//	Grant role channel and role
+//	  - Changes Request - Seq 25 - Has channel access no history
+//	Revoke role
+//	  - Changes Request Seq 45 since 25. Ensure revocation.
+//	  - Changes Request Seq 45 since 45 same seq as revocation. Ensure no revocation message.
 func TestRevocationScenario14(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()

--- a/auth/user.go
+++ b/auth/user.go
@@ -245,12 +245,14 @@ func (revokedChannels RevokedChannels) add(chanName string, triggeredBy uint64) 
 // RevokedChannels returns a map of revoked channels => most recent sequence at which access to that channel was lost
 // Steps:
 // Get revoked roles and for each:
-// 	- Revoke the current channels if the role is deleted
-//  - Revoke the role revoked channels
+//   - Revoke the current channels if the role is deleted
+//   - Revoke the role revoked channels
+//
 // Get current roles and for each:
-//  - Revoke the role revoked channels
+//   - Revoke the role revoked channels
+//
 // Get user:
-//  - Revoke users revoked channels
+//   - Revoke users revoked channels
 func (user *userImpl) RevokedChannels(since uint64, lowSeq uint64, triggeredBy uint64) RevokedChannels {
 	// checkSeq represents the value that we use to 'diff' against ie. What channels did the user have at checkSeq but
 	// no longer has.

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -758,7 +758,9 @@ func isGoCBTimeoutError(err error) bool {
 }
 
 // If the error is a net/url.Error and the error message is:
-// 		net/http: request canceled while waiting for connection
+//
+//	net/http: request canceled while waiting for connection
+//
 // Then it means that the view request timed out, most likely due to the fact that it's a stale=false query and
 // it's rebuilding the index.  In that case, it's desirable to return a more informative error than the
 // underlying net/url.Error. See https://github.com/couchbase/sync_gateway/issues/2639
@@ -1253,7 +1255,8 @@ type XattrEnabledDesignDoc struct {
 }
 
 // For the view engine to index tombstones, we need to set an explicit property in the design doc.
-//      see https://issues.couchbase.com/browse/MB-24616
+// see: https://issues.couchbase.com/browse/MB-24616
+//
 // This design doc property isn't exposed via the SDK (it's an internal-only property), so we need to
 // jump through some hoops to create the design doc.  Follows same approach used internally by gocb.
 func (bucket *CouchbaseBucketGoCB) putDDocForTombstones(ddoc *gocb.DesignDocument) error {

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -145,7 +145,7 @@ func TestAddRaw(t *testing.T) {
 
 // TestAddRawTimeout attempts to fill up the gocbpipeline by writing large documents concurrently with a small timeout,
 // to verify that timeout errors are returned, and the operation isn't retried (which would return a cas error).
-//   (see CBG-463)
+// (see CBG-463)
 func TestAddRawTimeoutRetry(t *testing.T) {
 	bucket := GetTestBucket(t)
 	defer bucket.Close()
@@ -1773,7 +1773,7 @@ func TestGetXattr(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, ErrNotFound, pkgerrors.Cause(err))
 
-		////Get Xattr From Tombstoned Doc With Deleted User Xattr
+		// Get Xattr From Tombstoned Doc With Deleted User Xattr
 		cas, err = bucket.WriteCasWithXattr(key3, xattrName3, 0, uint64(0), nil, val3, xattrVal3)
 		_, err = bucket.Remove(key3, cas)
 		require.NoError(t, err)
@@ -1858,7 +1858,7 @@ func TestGetXattrAndBody(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, ErrNotFound, pkgerrors.Cause(err))
 
-		////Get Xattr From Tombstoned Doc With Deleted User Xattr -> returns not found
+		// Get Xattr From Tombstoned Doc With Deleted User Xattr -> returns not found
 		cas, err = bucket.WriteCasWithXattr(key3, xattrName3, 0, uint64(0), nil, val3, xattrVal3)
 		_, err = bucket.Remove(key3, cas)
 		require.NoError(t, err)
@@ -2395,7 +2395,7 @@ func TestInsertTombstoneWithXattr(t *testing.T) {
 
 // TestRawBackwardCompatibilityFromJSON ensures that bucket implementation handles the case
 // where legacy SG versions set incorrect data types:
-//    - write as JSON, read as binary, (re-)write as binary
+//   - write as JSON, read as binary, (re-)write as binary
 func TestRawBackwardCompatibilityFromJSON(t *testing.T) {
 
 	if UnitTestUrlIsWalrus() {
@@ -2434,7 +2434,7 @@ func TestRawBackwardCompatibilityFromJSON(t *testing.T) {
 
 // TestRawBackwardCompatibilityFromBinary ensures that bucket implementation handles the case
 // where legacy SG versions set incorrect data types:
-//    - write as binary, read as raw JSON, rewrite as raw JSON
+//   - write as binary, read as raw JSON, rewrite as raw JSON
 func TestRawBackwardCompatibilityFromBinary(t *testing.T) {
 
 	if UnitTestUrlIsWalrus() {

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -62,13 +62,16 @@ func (bucket *CouchbaseBucketGoCB) IndexMetaKeyspaceID() string {
 // Query accepts a parameterized statement,  optional list of params, and an optional flag to force adhoc query execution.
 // Params specified using the $param notation in the statement are intended to be used w/ N1QL prepared statements, and will be
 // passed through as params to n1ql.  e.g.:
-//   SELECT _sync.sequence FROM $_keyspace WHERE _sync.sequence > $minSeq
+//
+//	SELECT _sync.sequence FROM $_keyspace WHERE _sync.sequence > $minSeq
+//
 // https://developer.couchbase.com/documentation/server/current/sdk/go/n1ql-queries-with-sdk.html for additional details.
 // Will additionally replace all instances of KeyspaceQueryToken($_keyspace) in the statement
 // with the bucket name.  'bucket' should not be included in params.
 //
 // If adhoc=true, prepared statement handling will be disabled.  Should only be set to true for queries that can't be prepared, e.g.:
-//  SELECT _sync.channels.ABC.seq from $bucket
+//
+//	SELECT _sync.channels.ABC.seq from $bucket
 //
 // Query retries on Indexer Errors, as these are normally transient
 func (bucket *CouchbaseBucketGoCB) Query(statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (results sgbucket.QueryResultIterator, err error) {

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -82,10 +82,13 @@ func ExplainQuery(store N1QLStore, statement string, params map[string]interface
 }
 
 // CreateIndex issues a CREATE INDEX query in the current bucket, using the form:
-//   CREATE INDEX indexName ON bucket.Name(expression) WHERE filterExpression WITH options
+//
+//	CREATE INDEX indexName ON bucket.Name(expression) WHERE filterExpression WITH options
+//
 // Sample usage with resulting statement:
-//     CreateIndex("myIndex", "field1, field2, nested.field", "field1 > 0", N1qlIndexOptions{numReplica:1})
-//   CREATE INDEX myIndex on myBucket(field1, field2, nested.field) WHERE field1 > 0 WITH {"numReplica":1}
+//
+//	  CreateIndex("myIndex", "field1, field2, nested.field", "field1 > 0", N1qlIndexOptions{numReplica:1})
+//	CREATE INDEX myIndex on myBucket(field1, field2, nested.field) WHERE field1 > 0 WITH {"numReplica":1}
 func CreateIndex(store N1QLStore, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
 	createStatement := fmt.Sprintf("CREATE INDEX `%s` ON %s(%s)", indexName, store.EscapedKeyspace(), expression)
 
@@ -220,7 +223,8 @@ func BuildDeferredIndexes(s N1QLStore, indexSet []string) error {
 }
 
 // BuildIndexes executes a BUILD INDEX statement in the current bucket, using the form:
-//   BUILD INDEX ON `bucket.Name`(`index1`, `index2`, ...)
+//
+//	BUILD INDEX ON `bucket.Name`(`index1`, `index2`, ...)
 func buildIndexes(s N1QLStore, indexNames []string) error {
 	if len(indexNames) == 0 {
 		return nil
@@ -379,7 +383,9 @@ func AsN1QLStore(bucket Bucket) (N1QLStore, bool) {
 }
 
 // Index not found errors (returned by DropIndex) don't have a specific N1QL error code - they are of the form:
-//   [5000] GSI index testIndex_not_found not found.
+//
+//	[5000] GSI index testIndex_not_found not found.
+//
 // Stuck with doing a string compare to differentiate between 'not found' and other errors
 func IsIndexNotFoundError(err error) bool {
 	return strings.Contains(err.Error(), "not found")
@@ -389,7 +395,8 @@ func IsIndexNotFoundError(err error) bool {
 // error:[5000] GSI CreateIndex() - cause: Encountered transient error.  Index creation will be retried in background.  Error: Index testIndex_value will retry building in the background for reason: Bucket test_data_bucket In Recovery.
 // error:[5000] GSI Drop() - cause: Fail to drop index on some indexer nodes.  Error=Encountered error when dropping index: Indexer In Recovery. Drop index will be retried in background.
 // error:[5000] BuildIndexes - cause: Build index fails.  %vIndex testIndexDeferred will retry building in the background for reason: Build Already In Progress. Bucket test_data_bucket.
-//  https://issues.couchbase.com/browse/MB-19358 is filed to request improved indexer error codes for these scenarios (and others)
+//
+// https://issues.couchbase.com/browse/MB-19358 is filed to request improved indexer error codes for these scenarios (and others)
 func IsIndexerRetryIndexError(err error) bool {
 	if err == nil {
 		return false

--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -82,8 +82,7 @@ func (c *Collection) UpdateXattr(k string, xattrKey string, exp uint32, cas uint
 // SubdocGetXattr retrieves the named xattr
 // Notes on error handling
 //   - gocb v2 returns subdoc errors at the op level, in the ContentAt response
-//   - 'successful' error codes, like SucDocSuccessDeleted, aren't returned, and instead just set the internal.Deleted property on the
-//   response
+//   - 'successful' error codes, like SucDocSuccessDeleted, aren't returned, and instead just set the internal.Deleted property on the response
 func (c *Collection) SubdocGetXattr(k string, xattrKey string, xv interface{}) (casOut uint64, err error) {
 	c.waitForAvailKvOp()
 	defer c.releaseKvOp()

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -336,10 +336,11 @@ func DeleteXattrs(store SubdocXattrStore, k string, xattrKeys ...string) error {
 //   - DocExists but NoXattr
 //   - XattrExists but NoDoc
 //   - NoDoc and NoXattr
+//
 // In all cases, the end state will be NoDoc and NoXattr.
 // Expected errors:
-//    - Temporary server overloaded errors, in which case the caller should retry
-//    - If the doc is in the the NoDoc and NoXattr state, it will return a KeyNotFound error
+//   - Temporary server overloaded errors, in which case the caller should retry
+//   - If the doc is in the the NoDoc and NoXattr state, it will return a KeyNotFound error
 func DeleteWithXattr(store KvXattrStore, k string, xattrKey string) error {
 	// Delegate to internal method that can take a testing-related callback
 	return deleteWithXattrInternal(store, k, xattrKey, nil)

--- a/base/dcp_client_stream_observer.go
+++ b/base/dcp_client_stream_observer.go
@@ -73,7 +73,6 @@ func (dc *DCPClient) Deletion(deletion gocbcore.DcpDeletion) {
 
 }
 
-//
 func (dc *DCPClient) End(end gocbcore.DcpStreamEnd, err error) {
 
 	e := endStreamEvent{

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -201,7 +201,7 @@ func (c *DCPCommon) incrementCheckpointCount(vbucketId uint16) {
 //   - We don't otherwise persist the last sequence we processed
 //   - For SG feed processing, there's no harm if we receive feed events for mutations we've previously seen
 //   - The ongoing performance overhead of persisting last sequence outweighs the minor performance benefit of not reprocessing a few
-//    sequences in a checkpoint on startup
+//     sequences in a checkpoint on startup
 func (c *DCPCommon) loadCheckpoint(vbNo uint16) (vbMetadata []byte, snapshotStartSeq uint64, snapshotEndSeq uint64, err error) {
 	rawValue, _, err := c.bucket.GetRaw(fmt.Sprintf("%s%d", c.checkpointPrefix, vbNo))
 	if err != nil {
@@ -278,9 +278,10 @@ func (c *DCPCommon) initMetadata(maxVbNo uint16) {
 }
 
 // TODO: Convert checkpoint persistence to an asynchronous batched process, since
-//       restarting w/ an older checkpoint:
-//         - Would only result in some repeated entry processing, which is already handled by the indexer
-//         - Is a relatively infrequent operation
+//
+//	restarting w/ an older checkpoint:
+//	  - Would only result in some repeated entry processing, which is already handled by the indexer
+//	  - Is a relatively infrequent operation
 func (c *DCPCommon) persistCheckpoint(vbNo uint16, value []byte) error {
 	TracefCtx(c.loggingCtx, KeyDCP, "Persisting checkpoint for vbno %d", vbNo)
 	return c.bucket.SetRaw(fmt.Sprintf("%s%d", c.checkpointPrefix, vbNo), 0, nil, value)

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -456,9 +456,10 @@ func TestConcurrentCBGTIndexCreation(t *testing.T) {
 }
 
 // Compare Atoi vs map lookup for partition conversion
-//    BenchmarkPartitionToVbNo/map-16         	100000000	        10.4 ns/op
-//    BenchmarkPartitionToVbNo/atoi-16        	500000000	         3.85 ns/op
-//    BenchmarkPartitionToVbNo/parseUint-16   	300000000	         5.04 ns/op
+//
+//	BenchmarkPartitionToVbNo/map-16         	100000000	        10.4 ns/op
+//	BenchmarkPartitionToVbNo/atoi-16        	500000000	         3.85 ns/op
+//	BenchmarkPartitionToVbNo/parseUint-16   	300000000	         5.04 ns/op
 func BenchmarkPartitionToVbNo(b *testing.B) {
 
 	// Initialize lookup map

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -53,17 +53,17 @@ type HeartbeatListener interface {
 //
 // The default timing intervals are defined to balance the following:
 //
-//    Network latency tolerance = heartbeatExpirySeconds - heartbeatSendInterval   (default = 10-1= 9s)
-//       Network latency tolerance is the minimum amount of time before this node may be flagged as offline
-//       by another node. Must be large enough to avoid triggering false positives during network load spikes on this node.
+//	Network latency tolerance = heartbeatExpirySeconds - heartbeatSendInterval   (default = 10-1= 9s)
+//	   Network latency tolerance is the minimum amount of time before this node may be flagged as offline
+//	   by another node. Must be large enough to avoid triggering false positives during network load spikes on this node.
 //
-//    Rebalance latency = heartbeatExpirySeconds + heartbeatPollInterval   (default = 10+2 = 12s)
-//       The maximum amount of time between a node going offline, and rebalance being triggered for that node.
+//	Rebalance latency = heartbeatExpirySeconds + heartbeatPollInterval   (default = 10+2 = 12s)
+//	   The maximum amount of time between a node going offline, and rebalance being triggered for that node.
 //
-//    Heartbeat ops/second/cluster = n/heartbeatSendInterval + (n^2)/heartbeatPollInterval (default = n + (n^2)/2)
-//       Number of heartbeat ops/second for a cluster of n nodes - one heartbeat touch per node per heartbeatSendInterval,
-//       n heartbeat reads per node per heartbeatPollInterval
-//       e.g  Default for a 4 node cluster: 12 ops/second
+//	Heartbeat ops/second/cluster = n/heartbeatSendInterval + (n^2)/heartbeatPollInterval (default = n + (n^2)/2)
+//	   Number of heartbeat ops/second for a cluster of n nodes - one heartbeat touch per node per heartbeatSendInterval,
+//	   n heartbeat reads per node per heartbeatPollInterval
+//	   e.g  Default for a 4 node cluster: 12 ops/second
 type couchbaseHeartBeater struct {
 	bucket                  Bucket
 	nodeUUID                string

--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -45,12 +45,13 @@ var _ gocb.Logger = GoCBLogger{}
 
 // Log wraps the levelled SG logs for gocb to use.
 // Log levels are mapped as follows:
-//   Error  -> SG Error
-//   Warn   -> SG Warn
-//   Info   -> SG Debug
-//   Debug  -> SG Trace
-//   Trace  -> SG Trace
-//   Others -> no-op
+//
+//	Error  -> SG Error
+//	Warn   -> SG Warn
+//	Info   -> SG Debug
+//	Debug  -> SG Trace
+//	Trace  -> SG Trace
+//	Others -> no-op
 func (GoCBLogger) Log(level gocb.LogLevel, offset int, format string, v ...interface{}) error {
 	switch level {
 	case gocb.LogError:
@@ -85,9 +86,11 @@ func (GoCBCoreV7Logger) Log(level gocbcorev7.LogLevel, offset int, format string
 
 // **************************************************************************
 // Implementation of callback for github.com/couchbase/clog.SetLoggerCallback
-//    Our main library that uses clog is cbgt, so all logging goes to KeyDCP.
-//    Note that although sg-replicate uses clog's log levels, sgreplicateLogFn
-//    bypasses clog logging, and so won't end up in this callback.
+//
+//	Our main library that uses clog is cbgt, so all logging goes to KeyDCP.
+//	Note that although sg-replicate uses clog's log levels, sgreplicateLogFn
+//	bypasses clog logging, and so won't end up in this callback.
+//
 // **************************************************************************
 func ClogCallback(level, format string, v ...interface{}) string {
 	switch level {

--- a/base/range_safe_collection.go
+++ b/base/range_safe_collection.go
@@ -16,9 +16,9 @@ import (
 
 // RangeSafeCollection is a concurrency-safe collection comprising an AppendOnlyList and a
 // map for key-based retrieval of list elements.  It has the following characteristics
-//  - concurrency-safe
-//  - snapshot-based iteration, Range doesn't block Append
-//  - key-based access to entries
+//   - concurrency-safe
+//   - snapshot-based iteration, Range doesn't block Append
+//   - key-based access to entries
 type RangeSafeCollection struct {
 	valueMap    map[string]*AppendOnlyListElement // map from key to collection elements
 	valueList   AppendOnlyList                    // List of collection elements

--- a/base/redactor_userdata.go
+++ b/base/redactor_userdata.go
@@ -25,13 +25,13 @@ var RedactUserData = true
 
 // UserData is a type which implements the Redactor interface for logging purposes of user data.
 //
-//  User data is data that is stored into Couchbase by the application user account:
-//  - Key and value pairs in JSON documents, or the key exclusively
-//  - Application/Admin usernames that identify the human person
-//  - Query statements included in the log file collected by support that leak the document fields (Select floor_price from stock).
-//  - Names and email addresses asked during product registration and alerting
-//  - Usernames
-//  - Document xattrs
+//	User data is data that is stored into Couchbase by the application user account:
+//	- Key and value pairs in JSON documents, or the key exclusively
+//	- Application/Admin usernames that identify the human person
+//	- Query statements included in the log file collected by support that leak the document fields (Select floor_price from stock).
+//	- Names and email addresses asked during product registration and alerting
+//	- Usernames
+//	- Document xattrs
 type UserData string
 
 func (ud UserData) String() string {

--- a/base/rlimit.go
+++ b/base/rlimit.go
@@ -22,12 +22,12 @@ import (
 //
 // Background information:
 //
-// - SG docs
-//   http://developer.couchbase.com/documentation/mobile/1.1.0/develop/guides/sync-gateway/os-level-tuning/max-file-descriptors/index.html
-// - Related SG issues
-//   https://github.com/couchbase/sync_gateway/issues/1083
-// - Hard limit vs Soft limit
-//   http://unix.stackexchange.com/questions/29577/ulimit-difference-between-hard-and-soft-limits
+//   - SG docs
+//     http://developer.couchbase.com/documentation/mobile/1.1.0/develop/guides/sync-gateway/os-level-tuning/max-file-descriptors/index.html
+//   - Related SG issues
+//     https://github.com/couchbase/sync_gateway/issues/1083
+//   - Hard limit vs Soft limit
+//     http://unix.stackexchange.com/questions/29577/ulimit-difference-between-hard-and-soft-limits
 func SetMaxFileDescriptors(requestedSoftFDLimit uint64) (uint64, error) {
 
 	var limits syscall.Rlimit
@@ -71,11 +71,11 @@ func SetMaxFileDescriptors(requestedSoftFDLimit uint64) (uint64, error) {
 //
 // Rules:
 //
-// 1. Only return a value that is HIGHER than the existing soft limit, since
-//    it is assumed to be user error to pass a config value that imposes a
-//    a lower limit than the system limit
-// 2. Only return a value that is LESS-THAN-OR-EQUAL to the existing hard limit
-//    since trying to set something higher than the hard limit will fail
+//  1. Only return a value that is HIGHER than the existing soft limit, since
+//     it is assumed to be user error to pass a config value that imposes a
+//     a lower limit than the system limit
+//  2. Only return a value that is LESS-THAN-OR-EQUAL to the existing hard limit
+//     since trying to set something higher than the hard limit will fail
 func getSoftFDLimit(requestedSoftFDLimit uint64, limit syscall.Rlimit) (requiresUpdate bool, recommendedSoftFDLimit uint64) {
 
 	currentSoftFdLimit := limit.Cur

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -23,7 +23,6 @@ import (
 // It implements cbgt.Cfg for use with cbgt, but can be used for to manage
 // any shared data.  It uses Sync Gateway's existing
 // bucket as a keystore, and existing caching feed for change notifications.
-//
 type CfgSG struct {
 	bucket        Bucket
 	loggingCtx    context.Context

--- a/base/util.go
+++ b/base/util.go
@@ -327,11 +327,11 @@ func CbsExpiryToDuration(expiry uint32) time.Duration {
 }
 
 // ReflectExpiry attempts to convert expiry from one of the following formats to a Couchbase Server expiry value:
-//   1. Numeric JSON values are converted to uint32 and returned as-is
-//   2. JSON numbers are converted to uint32 and returned as-is
-//   3. String JSON values that are numbers are converted to int32 and returned as-is
-//   4. String JSON values that are ISO-8601 dates are converted to UNIX time and returned
-//   5. Null JSON values return 0
+//  1. Numeric JSON values are converted to uint32 and returned as-is
+//  2. JSON numbers are converted to uint32 and returned as-is
+//  3. String JSON values that are numbers are converted to int32 and returned as-is
+//  4. String JSON values that are ISO-8601 dates are converted to UNIX time and returned
+//  5. Null JSON values return 0
 func ReflectExpiry(rawExpiry interface{}) (*uint32, error) {
 	switch expiry := rawExpiry.(type) {
 	case int64:

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -810,10 +810,11 @@ func CreateBucketScopesAndCollections(ctx context.Context, bucketSpec BucketSpec
 
 // RequireAllAssertions ensures that all assertion results were true/ok, and fails the test if any were not.
 // Usage:
-//     RequireAllAssertions(t,
-//         assert.True(t, condition1),
-//         assert.True(t, condition2),
-//     )
+//
+//	RequireAllAssertions(t,
+//	    assert.True(t, condition1),
+//	    assert.True(t, condition2),
+//	)
 func RequireAllAssertions(t *testing.T, assertionResults ...bool) {
 	var failed bool
 	for _, ok := range assertionResults {

--- a/channels/timed_set.go
+++ b/channels/timed_set.go
@@ -248,9 +248,10 @@ func (set TimedSet) CompareKeys(other TimedSet) ChangedKeys {
 }
 
 // TimedSet can unmarshal from either:
-//   1. The regular format {"channel":vbSequence, ...}
-//   2. The sequence-only format {"channel":uint64, ...} or
-//   3. An array of channel names.
+//  1. The regular format {"channel":vbSequence, ...}
+//  2. The sequence-only format {"channel":uint64, ...} or
+//  3. An array of channel names.
+//
 // In the last two cases, all vbNos will be 0.
 // In the latter case all the sequences will be 0.
 func (setPtr *TimedSet) UnmarshalJSON(data []byte) error {

--- a/db/attachment.go
+++ b/db/attachment.go
@@ -350,7 +350,7 @@ func ProveAttachment(attachmentData, nonce []byte) (proof string) {
 	return proof
 }
 
-//////// HELPERS:
+// ////// HELPERS:
 // Returns _attachments property from body, when found.  Checks for either map[string]interface{} (unmarshalled with body),
 // or AttachmentsMeta (written by body by SG)
 func GetBodyAttachments(body Body) AttachmentsMeta {

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -46,8 +46,8 @@ var EnableStarChannelLog = true
 // Core responsibilities:
 //
 // - Receive DCP changes via callbacks
-//    - Perform sequence buffering to ensure documents are received in sequence order
-//    - Propagating DCP changes down to appropriate channel caches
+//   - Perform sequence buffering to ensure documents are received in sequence order
+//   - Propagating DCP changes down to appropriate channel caches
 type changeCache struct {
 	context            *DatabaseContext
 	logCtx             context.Context

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -940,18 +940,18 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 // Tests channel cache backfill with slow query, validates that a request that is terminated while
 // waiting for the view lock doesn't trigger a view query.  Runs multiple goroutines, using a channel
 // and two waitgroups to ensure expected ordering of events, as follows
-//    1. Define a PostQueryCallback (via leaky bucket) that does two things:
-//        - closes a notification channel (queryBlocked) to indicate that the initial query is blocking
-//        - blocks via a WaitGroup (queryWg)
-//    2. Start a goroutine to issue a changes request
-//        - when view executes, will trigger callback handling above
-//    3. Start a second goroutine to issue another changes request.
-//        - will block waiting for queryLock, which increments StatKeyChannelCachePendingQueries stat
-//    4. Wait until StatKeyChannelCachePendingQueries is incremented
-//    5. Terminate second changes request
-//    6. Unblock the initial view query
-//       - releases the view lock, second changes request is unblocked
-//       - since it's been terminated, should return error before executing a second view query
+//  1. Define a PostQueryCallback (via leaky bucket) that does two things:
+//     - closes a notification channel (queryBlocked) to indicate that the initial query is blocking
+//     - blocks via a WaitGroup (queryWg)
+//  2. Start a goroutine to issue a changes request
+//     - when view executes, will trigger callback handling above
+//  3. Start a second goroutine to issue another changes request.
+//     - will block waiting for queryLock, which increments StatKeyChannelCachePendingQueries stat
+//  4. Wait until StatKeyChannelCachePendingQueries is incremented
+//  5. Terminate second changes request
+//  6. Unblock the initial view query
+//     - releases the view lock, second changes request is unblocked
+//     - since it's been terminated, should return error before executing a second view query
 func TestChannelQueryCancellation(t *testing.T) {
 
 	if !base.UnitTestUrlIsWalrus() {
@@ -1145,19 +1145,22 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 // Test race condition causing skipped sequences in changes feed.  Channel feeds are processed sequentially
 // in the main changes.go iteration loop, without a lock on the underlying channel caches.  The following
 // sequence is possible while running a changes feed for channels "A", "B":
-//    1. Sequence 100, Channel A arrives, and triggers changes loop iteration
-//    2. Changes loop calls changes.changesFeed(A) - gets 100
-//    3. Sequence 101, Channel A arrives
-//    4. Sequence 102, Channel B arrives
-//    5. Changes loop calls changes.changesFeed(B) - gets 102
-//    6. Changes sends 100, 102, and sets since=102
+//  1. Sequence 100, Channel A arrives, and triggers changes loop iteration
+//  2. Changes loop calls changes.changesFeed(A) - gets 100
+//  3. Sequence 101, Channel A arrives
+//  4. Sequence 102, Channel B arrives
+//  5. Changes loop calls changes.changesFeed(B) - gets 102
+//  6. Changes sends 100, 102, and sets since=102
+//
 // Here 101 is skipped, and never gets sent.  There are a number of ways a sufficient delay between #2 and #5
 // could be introduced in a real-world scenario
-//     - there are channels C,D,E,F,G with large caches that get processed between A and B
+//   - there are channels C,D,E,F,G with large caches that get processed between A and B
+//
 // To test, uncomment the following
 // lines at the start of changesFeed() in changes.go to simulate slow processing:
-//	    base.Infof(base.KeyChanges, "Simulate slow processing time for channel %s - sleeping for 100 ms", channel)
-//	    time.Sleep(100 * time.Millisecond)
+//
+//	base.Infof(base.KeyChanges, "Simulate slow processing time for channel %s - sleeping for 100 ms", channel)
+//	time.Sleep(100 * time.Millisecond)
 func TestChannelRace(t *testing.T) {
 	// TODO: Test current fails intermittently on concurrent access to var changes.
 	// Disabling for now - should be refactored.

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -334,6 +334,7 @@ func AsSingleChannelCache(cacheValue interface{}) *singleChannelCacheImpl {
 }
 
 // Adds a new channel to the channel cache.  Locking seqLock is required here to prevent missed data in the following scenario:
+//
 //	//     1. addChannelCache issued for channel A
 //	//     2. addChannelCache obtains stable sequence, seq=10
 //	//     3. addToCache (from another goroutine) receives sequence 11 in channel A, but detects that it's inactive (not in c.channelCaches)

--- a/db/crud.go
+++ b/db/crud.go
@@ -250,13 +250,13 @@ func (db *Database) Get1xRevBodyWithHistory(ctx context.Context, docid, revid st
 
 // Underlying revision retrieval used by Get1xRevBody, Get1xRevBodyWithHistory, GetRevCopy.
 // Returns the revision of a document using the revision cache.
-// * revid may be "", meaning the current revision.
-// * maxHistory is >0 if the caller wants a revision history; it's the max length of the history.
-// * historyFrom is an optional list of revIDs the client already has. If any of these are found
-//   in the revision's history, it will be trimmed after that revID.
-// * attachmentsSince is nil to return no attachment bodies, otherwise a (possibly empty) list of
-//   revisions for which the client already has attachments and doesn't need bodies. Any attachment
-//   that hasn't changed since one of those revisions will be returned as a stub.
+//   - revid may be "", meaning the current revision.
+//   - maxHistory is >0 if the caller wants a revision history; it's the max length of the history.
+//   - historyFrom is an optional list of revIDs the client already has. If any of these are found
+//     in the revision's history, it will be trimmed after that revID.
+//   - attachmentsSince is nil to return no attachment bodies, otherwise a (possibly empty) list of
+//     revisions for which the client already has attachments and doesn't need bodies. Any attachment
+//     that hasn't changed since one of those revisions will be returned as a stub.
 func (db *Database) getRev(ctx context.Context, docid, revid string, maxHistory int, historyFrom []string, includeBody bool) (revision DocumentRevision, err error) {
 	if revid != "" {
 		// Get a specific revision body and history from the revision cache
@@ -952,9 +952,9 @@ func (db *Database) PutExistingRev(ctx context.Context, newDoc *Document, docHis
 
 // PutExistingRevWithConflictResolution Adds an existing revision to a document along with its history (list of rev IDs.)
 // If this new revision would result in a conflict:
-//     1. If noConflicts == false, the revision will be added to the rev tree as a conflict
-//     2. If noConflicts == true and a conflictResolverFunc is not provided, a 409 conflict error will be returned
-//     3. If noConflicts == true and a conflictResolverFunc is provided, conflicts will be resolved and the result added to the document.
+//  1. If noConflicts == false, the revision will be added to the rev tree as a conflict
+//  2. If noConflicts == true and a conflictResolverFunc is not provided, a 409 conflict error will be returned
+//  3. If noConflicts == true and a conflictResolverFunc is provided, conflicts will be resolved and the result added to the document.
 func (db *Database) PutExistingRevWithConflictResolution(ctx context.Context, newDoc *Document, docHistory []string, noConflicts bool, conflictResolver *ConflictResolver, forceAllowConflictingTombstone bool, existingDoc *sgbucket.BucketDocument) (doc *Document, newRevID string, err error) {
 	newRev := docHistory[0]
 	generation, _ := ParseRevID(newRev)
@@ -1166,6 +1166,7 @@ func (db *Database) resolveConflict(ctx context.Context, localDoc *Document, rem
 
 // resolveDocRemoteWins makes the following changes to the document:
 //   - Tombstones the local revision
+//
 // The remote revision is added to the revision tree by the standard update processing.
 func (db *Database) resolveDocRemoteWins(ctx context.Context, localDoc *Document, conflict Conflict) (resolvedRevID string, err error) {
 
@@ -1184,10 +1185,12 @@ func (db *Database) resolveDocRemoteWins(ctx context.Context, localDoc *Document
 //   - Adds the remote revision to the rev tree
 //   - Makes a copy of the local revision as a child of the remote revision
 //   - Tombstones the (original) local revision
+//
 // TODO: This is CBL 2.x handling, and is compatible with the current version of the replicator, but
-//       results in additional replication work for clients that have previously replicated the local
-//       revision.  This will be addressed post-Hydrogen with version vector work, but additional analysis
-//       of options for Hydrogen should be completed.
+//
+//	results in additional replication work for clients that have previously replicated the local
+//	revision.  This will be addressed post-Hydrogen with version vector work, but additional analysis
+//	of options for Hydrogen should be completed.
 func (db *Database) resolveDocLocalWins(ctx context.Context, localDoc *Document, remoteDoc *Document, conflict Conflict, docHistory []string) (resolvedRevID string, updatedHistory []string, err error) {
 
 	// Clone the local revision as a child of the remote revision
@@ -1750,9 +1753,9 @@ func (db *Database) documentUpdateFunc(ctx context.Context, docExists bool, doc 
 type updateAndReturnDocCallback func(*Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error)
 
 // Calling updateAndReturnDoc directly allows callers to:
-//   1. Receive the updated document body in the response
-//   2. Specify the existing document body/xattr/cas, to avoid initial retrieval of the doc in cases that the current contents are already known (e.g. import).
-//      On cas failure, the document will still be reloaded from the bucket as usual.
+//  1. Receive the updated document body in the response
+//  2. Specify the existing document body/xattr/cas, to avoid initial retrieval of the doc in cases that the current contents are already known (e.g. import).
+//     On cas failure, the document will still be reloaded from the bucket as usual.
 func (db *Database) updateAndReturnDoc(ctx context.Context, docid string, allowImport bool, expiry uint32, opts *sgbucket.MutateInOptions, existingDoc *sgbucket.BucketDocument, callback updateAndReturnDocCallback) (doc *Document, newRevID string, err error) {
 
 	key := realDocID(docid)

--- a/db/database.go
+++ b/db/database.go
@@ -783,7 +783,8 @@ func (dbCtx *DatabaseContext) RemoveObsoleteIndexes(ctx context.Context, preview
 
 // Trigger terminate check handling for connected continuous replications.
 // TODO: The underlying code (NotifyCheckForTermination) doesn't actually leverage the specific username - should be refactored
-//    to remove
+//
+//	to remove
 func (context *DatabaseContext) NotifyTerminatedChanges(username string) {
 	context.mutationListener.NotifyCheckForTermination(base.SetOf(base.UserPrefix + username))
 }

--- a/db/import.go
+++ b/db/import.go
@@ -95,11 +95,12 @@ func (db *Database) ImportDoc(ctx context.Context, docid string, existingDoc *Do
 }
 
 // Import document
-//   docid  - document key
-//   body - marshalled body of document to be imported
-//   isDelete - whether the document to be imported is a delete
-//   existingDoc - bytes/cas/expiry of the  document to be imported (including xattr when available)
-//   mode - ImportMode - ImportFromFeed or ImportOnDemand
+//
+//	docid  - document key
+//	body - marshalled body of document to be imported
+//	isDelete - whether the document to be imported is a delete
+//	existingDoc - bytes/cas/expiry of the  document to be imported (including xattr when available)
+//	mode - ImportMode - ImportFromFeed or ImportOnDemand
 func (db *Database) importDoc(ctx context.Context, docid string, body Body, expiry *uint32, isDelete bool, existingDoc *sgbucket.BucketDocument, mode ImportMode) (docOut *Document, err error) {
 
 	base.DebugfCtx(ctx, base.KeyImport, "Attempting to import doc %q...", base.UD(docid))

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -105,7 +105,6 @@ func TestMigrateMetadata(t *testing.T) {
 //
 // - Same as scenario 1, except that in step 1 it writes a doc with sync metadata, so that it excercises the migration code
 // - Temporarily set expectedGeneration:2, see https://github.com/couchbase/sync_gateway/issues/3804
-//
 func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 	if !base.TestUseXattrs() {
 		t.Skip("This test only works with XATTRS enabled")

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -410,8 +410,8 @@ func isIndexerError(err error) bool {
 }
 
 // Iterates over the index set, removing obsolete indexes:
-//  - indexes based on the inverse value of xattrs being used by the database
-//  - indexes associated with previous versions of the index, for either xattrs=true or xattrs=false
+//   - indexes based on the inverse value of xattrs being used by the database
+//   - indexes associated with previous versions of the index, for either xattrs=true or xattrs=false
 func removeObsoleteIndexes(bucket base.N1QLStore, previewOnly bool, useXattrs bool, useViews bool, indexMap map[SGIndexType]SGIndex) (removedIndexes []string, err error) {
 	removedIndexes = make([]string, 0)
 

--- a/db/query.go
+++ b/db/query.go
@@ -250,9 +250,10 @@ var QueryTombstones = SGQuery{
 // QueryAllDocs is using the star channel's index, which is indexed by sequence, then ordering the results by doc id.
 // We currently don't have a performance-tuned use of AllDocs today - if needed, should create a custom index indexed by doc id.
 // Note: QueryAllDocs function may appends additional filter and ordering of the form:
-//    AND META(base.KeyspaceQueryAlias).id >= '%s'
-//    AND META(base.KeyspaceQueryAlias).id <= '%s'
-//    ORDER BY META(base.KeyspaceQueryAlias).id
+//
+//	AND META(base.KeyspaceQueryAlias).id >= '%s'
+//	AND META(base.KeyspaceQueryAlias).id <= '%s'
+//	ORDER BY META(base.KeyspaceQueryAlias).id
 var QueryAllDocs = SGQuery{
 	name: QueryTypeAllDocs,
 	statement: fmt.Sprintf(

--- a/db/repair_bucket.go
+++ b/db/repair_bucket.go
@@ -101,43 +101,39 @@ func (r *RepairBucket) InitFrom(params RepairBucketParams) *RepairBucket {
 	return r
 }
 
-/*
-
-This is how the view is iterated:
-
-┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
-                ┌ ─ ─ ─│─ ─ ─ ─ ─ ─ ─ ─
-│                               ┌ ─ ─ ─│─ ─ ─ ─ ─ ─ ─ ┐
-                │      │                ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐
-│┌────┐  ┌────┐  ┌────┐  ┌────┐ │┌────┐│ ┌────┐       │
- │doc1│  │doc2│ ││doc3││ │doc4│  │doc5│ ││doc6│               │
-│└────┘  └────┘  └────┘  └────┘ │└────┘│ └────┘       │
-                │      │                │                     │
-└ ─ ─ ─ ─ ─ ▲ ─ ─ ─ ─ ─         │      │              │
-            │   └ ─ ─ ─ ─ ─ ▲ ─ ─ ─ ─ ─ │                     │
-            │               │   └ ─ ─ ─ ─ ─▲─ ─ ─ ─ ─ ┘
-      StartKey: ""          │           └ ─│─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
-        Limit: 3            │              │       ▲
-    NumProcessed: 3         │              │       │
-                    StartKey: "doc3"       │       │
-                        Limit: 3           │       │
-                    NumProcessed: 2        │       └────────┐
-                                           │                │
-                                   StartKey: "doc5"         │
-                                       Limit: 3             │
-                                   NumProcessed: 1          │
-                                                            │
-                                                    StartKey: "doc6"
-                                                        Limit: 3
-                                                    NumProcessed: 0
-
-* It starts with an empty start key
-* For the next page, it uses the last key processed as the new start key
-* Since the start key is inclusive, it will see the start key twice (on first page, and on next page)
-* If it's iterating a result page and sees a doc with the start key (eg, doc3 in above), it will ignore it so it doesn't process it twice
-* Stop condition: if NumProcessed is 0, because the only doc in result set had already been processed.
-*
-*/
+// This is how the view is iterated:
+//
+//	┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+//	                ┌ ─ ─ ─│─ ─ ─ ─ ─ ─ ─ ─
+//	│                               ┌ ─ ─ ─│─ ─ ─ ─ ─ ─ ─ ┐
+//	                │      │                ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐
+//	│┌────┐  ┌────┐  ┌────┐  ┌────┐ │┌────┐│ ┌────┐       │
+//	 │doc1│  │doc2│ ││doc3││ │doc4│  │doc5│ ││doc6│               │
+//	│└────┘  └────┘  └────┘  └────┘ │└────┘│ └────┘       │
+//	                │      │                │                     │
+//	└ ─ ─ ─ ─ ─ ▲ ─ ─ ─ ─ ─         │      │              │
+//	            │   └ ─ ─ ─ ─ ─ ▲ ─ ─ ─ ─ ─ │                     │
+//	            │               │   └ ─ ─ ─ ─ ─▲─ ─ ─ ─ ─ ┘
+//	      StartKey: ""          │           └ ─│─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
+//	        Limit: 3            │              │       ▲
+//	    NumProcessed: 3         │              │       │
+//	                    StartKey: "doc3"       │       │
+//	                        Limit: 3           │       │
+//	                    NumProcessed: 2        │       └────────┐
+//	                                           │                │
+//	                                   StartKey: "doc5"         │
+//	                                       Limit: 3             │
+//	                                   NumProcessed: 1          │
+//	                                                            │
+//	                                                    StartKey: "doc6"
+//	                                                        Limit: 3
+//	                                                    NumProcessed: 0
+//
+// It starts with an empty start key
+// For the next page, it uses the last key processed as the new start key
+// Since the start key is inclusive, it will see the start key twice (on first page, and on next page)
+// If it's iterating a result page and sees a doc with the start key (eg, doc3 in above), it will ignore it so it doesn't process it twice
+// Stop condition: if NumProcessed is 0, because the only doc in result set had already been processed.
 func (r RepairBucket) RepairBucket() (results []RepairBucketResult, err error) {
 
 	logCtx := context.TODO()

--- a/db/revision.go
+++ b/db/revision.go
@@ -37,8 +37,10 @@ const (
 )
 
 // A revisions property found within a Body.  Expected to be of the form:
-//   Revisions["start"]: int64, starting generation number
-//   Revisions["ids"]: []string, list of digests
+//
+//	Revisions["start"]: int64, starting generation number
+//	Revisions["ids"]: []string, list of digests
+//
 // Used as map[string]interface{} instead of Revisions struct because it's unmarshalled
 // along with Body, and we don't need the overhead of allocating a new object
 type Revisions map[string]interface{}
@@ -245,12 +247,13 @@ func (db *DatabaseContext) getOldRevisionJSON(ctx context.Context, docid string,
 
 // Makes a backup of revision body for use by delta sync, and in-flight replications requesting an old revision.
 // Backup policy depends on whether delta sync and/or shared_bucket_access is enabled
-//   delta=false || delta_rev_max_age_seconds=0
-//      - old revision stored, with expiry OldRevExpirySeconds
-//   delta=true && shared_bucket_access=true
-//      - new revision stored (as duplicate), with expiry rev_max_age_seconds
-//   delta=true && shared_bucket_access=false
-//      - old revision stored, with expiry rev_max_age_seconds
+//
+//	delta=false || delta_rev_max_age_seconds=0
+//	   - old revision stored, with expiry OldRevExpirySeconds
+//	delta=true && shared_bucket_access=true
+//	   - new revision stored (as duplicate), with expiry rev_max_age_seconds
+//	delta=true && shared_bucket_access=false
+//	   - old revision stored, with expiry rev_max_age_seconds
 func (db *Database) backupRevisionJSON(ctx context.Context, docId, newRevId, oldRevId string, newBody []byte, oldBody []byte, newAtts AttachmentsMeta) {
 
 	// Without delta sync, store the old rev for in-flight replication purposes

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -37,7 +37,7 @@ func (rev RevInfo) IsRoot() bool {
 	return rev.Parent == ""
 }
 
-//  A revision tree maps each revision ID to its RevInfo.
+// A revision tree maps each revision ID to its RevInfo.
 type RevTree map[string]*RevInfo
 
 // The form in which a RevTree is stored in JSON. For space-efficiency it's stored as an array of
@@ -226,7 +226,9 @@ func (tree RevTree) RepairCycles() (err error) {
 }
 
 // Detect situations like:
-//     node: &{ID:10-684759c169c75629d02b90fe10b56925 Parent:184-a6b3f72a2bc1f988bfb720fec8db3a1d Deleted:fa...
+//
+//	node: &{ID:10-684759c169c75629d02b90fe10b56925 Parent:184-a6b3f72a2bc1f988bfb720fec8db3a1d Deleted:fa...
+//
 // where the parent generation is *higher* than the node generation, which is never a valid scenario.
 // Likewise, detect situations where the parent generation is equal to the node generation, which is also invalid.
 func (node RevInfo) ParentGenGTENodeGen() bool {
@@ -448,15 +450,17 @@ func (tree RevTree) copy() RevTree {
 // There is one exception to that, which is tombstoned (deleted) branches that have been deemed "too old"
 // to keep around.  The criteria for "too old" is as follows:
 //
-// - Find the generation of the shortest non-tombstoned branch (eg, 100)
-// - Calculate the tombstone generation threshold based on this formula:
-//      tombstoneGenerationThreshold = genShortestNonTSBranch - maxDepth
-//      Ex: if maxDepth is 20, and tombstoneGenerationThreshold is 100, then tombstoneGenerationThreshold will be 80
-// - Check each tombstoned branch, and if the leaf node on that branch has a generation older (less) than
-//   tombstoneGenerationThreshold, then remove all nodes on that branch up to the root of the branch.
+//   - Find the generation of the shortest non-tombstoned branch (eg, 100)
+//   - Calculate the tombstone generation threshold based on this formula:
+//     tombstoneGenerationThreshold = genShortestNonTSBranch - maxDepth
+//     Ex: if maxDepth is 20, and tombstoneGenerationThreshold is 100, then tombstoneGenerationThreshold will be 80
+//   - Check each tombstoned branch, and if the leaf node on that branch has a generation older (less) than
+//     tombstoneGenerationThreshold, then remove all nodes on that branch up to the root of the branch.
+//
 // Returns:
-//  pruned: number of revisions pruned
-//  prunedTombstoneBodyKeys: set of tombstones with external body storage that were pruned, as map[revid]bodyKey
+//
+//	pruned: number of revisions pruned
+//	prunedTombstoneBodyKeys: set of tombstones with external body storage that were pruned, as map[revid]bodyKey
 func (tree RevTree) pruneRevisions(maxDepth uint32, keepRev string) (pruned int, prunedTombstoneBodyKeys map[string]string) {
 
 	if len(tree) <= int(maxDepth) {
@@ -559,7 +563,9 @@ func (tree RevTree) computeDepthsAndFindLeaves() (maxDepth uint32, leaves []stri
 }
 
 // Find the minimum generation that has a non-deleted leaf.  For example in this rev tree:
-//   http://cbmobile-bucket.s3.amazonaws.com/diagrams/example-sync-gateway-revtrees/three_branches.png
+//
+//	http://cbmobile-bucket.s3.amazonaws.com/diagrams/example-sync-gateway-revtrees/three_branches.png
+//
 // The minimim generation that has a non-deleted leaf is "7-non-winning unresolved"
 func (tree RevTree) FindShortestNonTombstonedBranch() (generation int, found bool) {
 	return tree.FindShortestNonTombstonedBranchFromLeaves(tree.GetLeaves())
@@ -587,7 +593,9 @@ func (tree RevTree) FindShortestNonTombstonedBranchFromLeaves(leaves []string) (
 }
 
 // Find the generation of the longest deleted branch.  For example in this rev tree:
-//   http://cbmobile-bucket.s3.amazonaws.com/diagrams/example-sync-gateway-revtrees/four_branches_two_tombstoned.png
+//
+//	http://cbmobile-bucket.s3.amazonaws.com/diagrams/example-sync-gateway-revtrees/four_branches_two_tombstoned.png
+//
 // The longest deleted branch has a generation of 10
 func (tree RevTree) FindLongestTombstonedBranch() (generation int) {
 	return tree.FindLongestTombstonedBranchFromLeaves(tree.GetLeaves())

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -27,9 +27,11 @@ var testmap = RevTree{"3-three": {ID: "3-three", Parent: "2-two", Body: []byte("
 	"2-two": {ID: "2-two", Parent: "1-one", Channels: base.SetOf("ABC", "CBS")},
 	"1-one": {ID: "1-one", Channels: base.SetOf("ABC")}}
 
-//               / 3-three
+//	/ 3-three
+//
 // 1-one -- 2-two
-//               \ 3-drei
+//
+//	\ 3-drei
 var branchymap = RevTree{"3-three": {ID: "3-three", Parent: "2-two"},
 	"2-two":  {ID: "2-two", Parent: "1-one"},
 	"1-one":  {ID: "1-one"},
@@ -48,9 +50,9 @@ type BranchSpec struct {
 	Digest                  string
 }
 
-//            / 3-a -- 4-a -- 5-a ...... etc (winning branch)
-// 1-a -- 2-a
-//            \ 3-b -- 4-b ... etc (losing branch)
+//	/ 3-a -- 4-a -- 5-a ...... etc (winning branch)
+//	1-a -- 2-a
+//	\ 3-b -- 4-b ... etc (losing branch)
 //
 // NOTE: the 1-a -- 2-a unconflicted branch can be longer, depending on value of unconflictedBranchNumRevs
 func getTwoBranchTestRevtree1(unconflictedBranchNumRevs, winningBranchNumRevs, losingBranchNumRevs int, tombstoneLosingBranch bool) RevTree {
@@ -67,11 +69,11 @@ func getTwoBranchTestRevtree1(unconflictedBranchNumRevs, winningBranchNumRevs, l
 
 }
 
-//            / 3-a -- 4-a -- 5-a ...... etc (winning branch)
-// 1-a -- 2-a
-//            \ 3-b -- 4-b ... etc (losing branch #1)
-//            \ 3-c -- 4-c ... etc (losing branch #2)
-//            \ 3-d -- 4-d ... etc (losing branch #n)
+//	           / 3-a -- 4-a -- 5-a ...... etc (winning branch)
+//	1-a -- 2-a
+//	           \ 3-b -- 4-b ... etc (losing branch #1)
+//	           \ 3-c -- 4-c ... etc (losing branch #2)
+//	           \ 3-d -- 4-d ... etc (losing branch #n)
 //
 // NOTE: the 1-a -- 2-a unconflicted branch can be longer, depending on value of unconflictedBranchNumRevs
 func getMultiBranchTestRevtree1(unconflictedBranchNumRevs, winningBranchNumRevs int, losingBranches []BranchSpec) RevTree {

--- a/db/sequence_id.go
+++ b/db/sequence_id.go
@@ -39,9 +39,11 @@ var MaxSequenceID = SequenceID{
 }
 
 // Format sequence ID to send to clients.  Sequence IDs can be in one of the following formats:
-//   Seq                    - simple sequence
-//   TriggeredBy:Seq        - when TriggeredBy is non-zero, LowSeq is zero
-//   LowSeq:TriggeredBy:Seq - when LowSeq is non-zero.
+//
+//	Seq                    - simple sequence
+//	TriggeredBy:Seq        - when TriggeredBy is non-zero, LowSeq is zero
+//	LowSeq:TriggeredBy:Seq - when LowSeq is non-zero.
+//
 // When LowSeq is non-zero but TriggeredBy is zero, will appear as LowSeq::Seq.
 // When LowSeq is non-zero but is greater than s.Seq (occurs when sending previously skipped sequences), ignore LowSeq.
 func (s SequenceID) String() string {

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -376,11 +376,12 @@ type sgReplicateManager struct {
 
 // alignState attempts to update the current replicator state to align with the provided targetState, if
 // it's a valid state transition.
-//  Valid:
-//     stopped -> running
-//     stopped -> resetting
-//     resetting -> stopped
-//     running -> stopped
+//
+//	Valid:
+//	   stopped -> running
+//	   stopped -> resetting
+//	   resetting -> stopped
+//	   running -> stopped
 func (ar *ActiveReplicator) alignState(ctx context.Context, targetState string) error {
 	if ar == nil {
 		return nil

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2764,12 +2764,13 @@ func TestSyncFnOldDocBodyPropertiesTombstoneResurrect(t *testing.T) {
 
 // TestSyncFnDocBodyPropertiesSwitchActiveTombstone creates a branched revtree, where the first tombstone created becomes active again after the shorter b branch is tombstoned.
 // The test makes sure that in this scenario, the "doc" body of the sync function when switching from (T) 3-b to (T) 4-a contains a _deleted property (stamped by getAvailable1xRev)
-//     1-a
-//     ├── 2-a
-//     │   └── 3-a
-//     │       └──────── (T) 4-a
-//     └──────────── 2-b
-//                   └────────────── (T) 3-b
+//
+//	1-a
+//	├── 2-a
+//	│   └── 3-a
+//	│       └──────── (T) 4-a
+//	└──────────── 2-b
+//	              └────────────── (T) 3-b
 func TestSyncFnDocBodyPropertiesSwitchActiveTombstone(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyJavascript)

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -40,6 +40,7 @@ import (
 // - Setup
 //   - Create an httptest server listening on a port that wraps the Sync Gateway Admin Handler
 //   - Make a BLIP/Websocket client connection to Sync Gateway
+//
 // - Test
 //   - Verify Sync Gateway will accept the doc revision that is about to be sent
 //   - Send the doc revision in a rev request
@@ -1150,7 +1151,8 @@ function(doc, oldDoc) {
 }
 
 // Test send and retrieval of a doc.
-//   Validate deleted handling (includes check for https://github.com/couchbase/sync_gateway/issues/3341)
+//
+//	Validate deleted handling (includes check for https://github.com/couchbase/sync_gateway/issues/3341)
 func TestBlipSendAndGetRev(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
@@ -1197,7 +1199,8 @@ func TestBlipSendAndGetRev(t *testing.T) {
 }
 
 // Test send and retrieval of a doc with a large numeric value.  Ensure proper large number handling.
-//   Validate deleted handling (includes check for https://github.com/couchbase/sync_gateway/issues/3341)
+//
+//	Validate deleted handling (includes check for https://github.com/couchbase/sync_gateway/issues/3341)
 func TestBlipSendAndGetLargeNumberRev(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
@@ -1856,7 +1859,6 @@ func TestPutRevConflictsMode(t *testing.T) {
 //
 // Actual:
 // - Same as Expected (this test is unable to repro SG #3281, but is being left in as a regression test)
-//
 func TestGetRemovedDoc(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -336,11 +336,12 @@ func (h *handler) handleDumpChannel() error {
 // where the boolean ?revs parameter adds a revision history to each doc
 // and the boolean ?attachments parameter includes attachment bodies.
 // The body of the request is JSON and looks like:
-// {
-//   "docs": [
-//		{"id": "docid", "rev": "revid", "atts_since": [12,...]}, ...
-// 	 ]
-// }
+//
+//	{
+//	  "docs": [
+//			{"id": "docid", "rev": "revid", "atts_since": [12,...]}, ...
+//		 ]
+//	}
 func (h *handler) handleBulkGet() error {
 
 	includeAttachments := h.getBoolQuery("attachments")

--- a/rest/config.go
+++ b/rest/config.go
@@ -217,9 +217,7 @@ type CacheConfig struct {
 	DeprecatedCacheConfig
 }
 
-// ***************************************************************
-//	Kept around for CBG-356 backwards compatability
-// ***************************************************************
+// Deprecated: Kept around for CBG-356 backwards compatability
 type DeprecatedCacheConfig struct {
 	DeprecatedCachePendingSeqMaxWait *uint32 `json:"max_wait_pending,omitempty"`         // Max wait for pending sequence before skipping
 	DeprecatedCachePendingSeqMaxNum  *int    `json:"max_num_pending,omitempty"`          // Max number of pending sequences before skipping
@@ -1435,14 +1433,14 @@ func (sc *ServerContext) fetchConfigs(ctx context.Context, isInitialStartup bool
 		}
 		// TODO: Enable code as part of CBG-2280
 		// Return buckets that have credentials set that do not have a db associated with them
-		//buckets = make([]string, len(sc.config.BucketCredentials)-len(sc.bucketDbName))
-		//for bucket := range sc.config.BucketCredentials {
+		// buckets = make([]string, len(sc.config.BucketCredentials)-len(sc.bucketDbName))
+		// for bucket := range sc.config.BucketCredentials {
 		//	i := 0
 		//	if sc.bucketDbName[bucket] == "" {
 		//		buckets[i] = bucket
 		//		i++
 		//	}
-		//}
+		// }
 	} else {
 		buckets, err = sc.bootstrapContext.connection.GetConfigBuckets()
 		if err != nil {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -1277,10 +1277,10 @@ func (h *handler) handleRange(contentLength uint64) (status int, start uint64, e
 
 // Given an HTTP "Range:" header value, parses it and returns the approppriate HTTP status code,
 // and the numeric byte range if appropriate:
-// * If the Range header is empty or syntactically invalid, it ignores it and returns status=200.
-// * If the header is valid but exceeds the contentLength, it returns status=416 (Not Satisfiable).
-// * Otherwise it returns status=206 and sets the start and end values in HTTP terms, i.e. with
-//   the first byte numbered 0, and the end value inclusive (so the first 100 bytes are 0-99.)
+//   - If the Range header is empty or syntactically invalid, it ignores it and returns status=200.
+//   - If the header is valid but exceeds the contentLength, it returns status=416 (Not Satisfiable).
+//   - Otherwise it returns status=206 and sets the start and end values in HTTP terms, i.e. with
+//     the first byte numbered 0, and the end value inclusive (so the first 100 bytes are 0-99.)
 func parseHTTPRangeHeader(rangeStr string, contentLength uint64) (status int, start uint64, end uint64) {
 	// http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35
 	status = http.StatusOK

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -39,7 +39,7 @@ import (
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
-//  A forceError is being used when you want to force an error of type 'forceErrorType'
+// A forceError is being used when you want to force an error of type 'forceErrorType'
 type forceError struct {
 	errorType            forceErrorType // An error type to be forced
 	expectedErrorCode    int            // Expected HTTP response code

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -938,8 +938,10 @@ func TestPullOneshotReplicationAPI(t *testing.T) {
 //   - Write documents to rt1 belonging to both channels
 //   - Write documents to rt1, each belonging to one of the channels (verifies replications are still running)
 //   - Validate replications do not report errors, all docs are replicated
+//
 // Note: This test intermittently reproduced CBG-998 under -race when a 1s sleep was added post-callback to
-//   WriteUpdateWithXattr.  Have been unable to reproduce the same with a leaky bucket UpdateCallback.
+//
+//	WriteUpdateWithXattr.  Have been unable to reproduce the same with a leaky bucket UpdateCallback.
 func TestReplicationConcurrentPush(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
@@ -1007,14 +1009,15 @@ func TestReplicationConcurrentPush(t *testing.T) {
 // Helper functions for SGR testing
 
 // setupSGRPeers sets up two rest testers to be used for sg-replicate testing with the following configuration:
-//   activeRT:
-//     - backed by test bucket
-//     - has sgreplicate enabled
-//   passiveRT:
-//     - backed by different test bucket
-//     - user 'alice' created with star channel access
-//     - http server wrapping the public API, remoteDBURLString targets the rt2 database as user alice (e.g. http://alice:pass@host/db)
-//   returned teardown function closes activeRT, passiveRT and the http server, should be invoked with defer
+//
+//	activeRT:
+//	  - backed by test bucket
+//	  - has sgreplicate enabled
+//	passiveRT:
+//	  - backed by different test bucket
+//	  - user 'alice' created with star channel access
+//	  - http server wrapping the public API, remoteDBURLString targets the rt2 database as user alice (e.g. http://alice:pass@host/db)
+//	returned teardown function closes activeRT, passiveRT and the http server, should be invoked with defer
 func setupSGRPeers(t *testing.T) (activeRT *RestTester, passiveRT *RestTester, remoteDBURLString string, teardown func()) {
 	// Set up passive RestTester (rt2)
 	passiveTestBucket := base.GetTestBucket(t)

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -4748,7 +4748,7 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 // TestLocalWinsConflictResolution:
 //   - Starts 2 RestTesters, one active, and one passive.
 //   - Validates document metadata (deleted, attachments) are preserved during LocalWins conflict
-//    resolution, when local rev is rewritten as child of remote
+//     resolution, when local rev is rewritten as child of remote
 func TestLocalWinsConflictResolution(t *testing.T) {
 
 	if !base.IsEnterpriseEdition() {

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -24,8 +24,8 @@ const dbRegex = "[^_/][^/]*"
 const docRegex = "[^_/][^/]*"
 
 // Regex that matches a URI containing either:
-//  - A regular doc ID with an escaped "/" character
-//  - A user name with an escaped "/" character
+//   - A regular doc ID with an escaped "/" character
+//   - A user name with an escaped "/" character
 var docWithSlashPathRegex *regexp.Regexp
 
 func init() {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1284,12 +1284,12 @@ func getChangesHandler(changesFinishedWg, revsFinishedWg *sync.WaitGroup) func(r
 //
 // - Call subChanges (continuous=false) endpoint to get all changes from Sync Gateway
 // - Respond to each "change" request telling the other side to send the revision
-//		- NOTE: this could be made more efficient by only requesting the revision for the docid/revid pair
-//              passed in the parameter.
+//   - NOTE: this could be made more efficient by only requesting the revision for the docid/revid pair
+//     passed in the parameter.
+//
 // - If the rev handler is called back with the desired docid/revid pair, save that into a variable that will be returned
 // - Block until all pending operations are complete
 // - Return the resultDoc or an empty resultDoc
-//
 func (bt *BlipTester) GetDocAtRev(requestedDocID, requestedDocRev string) (resultDoc RestDocument, err error) {
 
 	docs := map[string]RestDocument{}


### PR DESCRIPTION
Go 1.19 has tweaked the rules of comments to allow additional formatting, including code blocks (tab prefixed), lists, etc.

Run all files through the 1.19 gofmt tool to avoid diff noise in unrelated changes.