### PR TITLE
Collate testmain to facilitate creating more testmains

### DIFF
--- a/auth/main_test.go
+++ b/auth/main_test.go
@@ -11,34 +11,12 @@ licenses/APL2.txt.
 package auth
 
 import (
-	"os"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
 )
 
 func TestMain(m *testing.M) {
-	// can't use defer because of os.Exit
-	// FIFO queue of teardown functions (note: opposite of defer's LIFO ordering)
-	teardownFuncs := make([]func(), 0)
-	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestLogging(m))
-	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestProfiling(m))
-	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestMemoryWatermark(m, 512))
-
-	base.SkipPrometheusStatsRegistration = true
-
-	base.GTestBucketPool = base.NewTestBucketPool(base.FlushBucketEmptierFunc, base.NoopInitFunc)
-	teardownFuncs = append(teardownFuncs, base.GTestBucketPool.Close)
-
-	// must be the last teardown function added to the list to correctly detect leaked goroutines
-	teardownFuncs = append(teardownFuncs, base.SetUpTestGoroutineDump(m))
-
-	// Run the test suite
-	status := m.Run()
-
-	for _, fn := range teardownFuncs {
-		fn()
-	}
-
-	os.Exit(status)
+	memWatermarkThresholdMB := uint64(2048)
+	base.TestBucketPoolNoIndexes(m, memWatermarkThresholdMB)
 }

--- a/base/main_test.go
+++ b/base/main_test.go
@@ -11,31 +11,10 @@ licenses/APL2.txt.
 package base
 
 import (
-	"os"
 	"testing"
 )
 
 func TestMain(m *testing.M) {
-	// can't use defer because of os.Exit
-	teardownFuncs := make([]func(), 0)
-	teardownFuncs = append(teardownFuncs, SetUpGlobalTestLogging(m))
-	teardownFuncs = append(teardownFuncs, SetUpGlobalTestProfiling(m))
-	teardownFuncs = append(teardownFuncs, SetUpGlobalTestMemoryWatermark(m, 2048))
-
-	SkipPrometheusStatsRegistration = true
-
-	GTestBucketPool = NewTestBucketPool(FlushBucketEmptierFunc, NoopInitFunc)
-	teardownFuncs = append(teardownFuncs, GTestBucketPool.Close)
-
-	// must be the last teardown function added to the list to correctly detect leaked goroutines
-	teardownFuncs = append(teardownFuncs, SetUpTestGoroutineDump(m))
-
-	// Run the test suite
-	status := m.Run()
-
-	for _, fn := range teardownFuncs {
-		fn()
-	}
-
-	os.Exit(status)
+	memWatermarkThresholdMB := uint64(2048)
+	TestBucketPoolNoIndexes(m, memWatermarkThresholdMB)
 }

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -794,7 +794,7 @@ func TestBucketPoolMain(m *testing.M, bucketReadierFunc TBPBucketReadierFunc, bu
 
 	SkipPrometheusStatsRegistration = true
 
-	GTestBucketPool = NewTestBucketPool(FlushBucketEmptierFunc, NoopInitFunc)
+	GTestBucketPool = NewTestBucketPool(bucketReadierFunc, bucketInitFunc)
 	teardownFuncs = append(teardownFuncs, GTestBucketPool.Close)
 
 	// must be the last teardown function added to the list to correctly detect leaked goroutines

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -782,3 +782,35 @@ func TestClusterDriver() CouchbaseDriver {
 	}
 	return driver
 }
+
+// TestBucketPoolMain is used as TestMain in main_test.go packages
+func TestBucketPoolMain(m *testing.M, bucketReadierFunc TBPBucketReadierFunc, bucketInitFunc TBPBucketInitFunc,
+	memWatermarkThresholdMB uint64) {
+	// can't use defer because of os.Exit
+	teardownFuncs := make([]func(), 0)
+	teardownFuncs = append(teardownFuncs, SetUpGlobalTestLogging(m))
+	teardownFuncs = append(teardownFuncs, SetUpGlobalTestProfiling(m))
+	teardownFuncs = append(teardownFuncs, SetUpGlobalTestMemoryWatermark(m, memWatermarkThresholdMB))
+
+	SkipPrometheusStatsRegistration = true
+
+	GTestBucketPool = NewTestBucketPool(FlushBucketEmptierFunc, NoopInitFunc)
+	teardownFuncs = append(teardownFuncs, GTestBucketPool.Close)
+
+	// must be the last teardown function added to the list to correctly detect leaked goroutines
+	teardownFuncs = append(teardownFuncs, SetUpTestGoroutineDump(m))
+
+	// Run the test suite
+	status := m.Run()
+
+	for _, fn := range teardownFuncs {
+		fn()
+	}
+
+	os.Exit(status)
+}
+
+// TestBucketPoolNoIndexes runs a TestMain for packages that do not require creation of indexes
+func TestBucketPoolNoIndexes(m *testing.M, memWatermarkThresholdMB uint64) {
+	TestBucketPoolMain(m, FlushBucketEmptierFunc, NoopInitFunc, memWatermarkThresholdMB)
+}

--- a/db/main_test.go
+++ b/db/main_test.go
@@ -11,33 +11,10 @@ licenses/APL2.txt.
 package db
 
 import (
-	"os"
 	"testing"
-
-	"github.com/couchbase/sync_gateway/base"
 )
 
 func TestMain(m *testing.M) {
-	// can't use defer because of os.Exit
-	teardownFuncs := make([]func(), 0)
-	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestLogging(m))
-	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestProfiling(m))
-	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestMemoryWatermark(m, 2048))
-
-	base.SkipPrometheusStatsRegistration = true
-
-	base.GTestBucketPool = base.NewTestBucketPool(ViewsAndGSIBucketReadier, ViewsAndGSIBucketInit)
-	teardownFuncs = append(teardownFuncs, base.GTestBucketPool.Close)
-
-	// must be the last teardown function added to the list to correctly detect leaked goroutines
-	teardownFuncs = append(teardownFuncs, base.SetUpTestGoroutineDump(m))
-
-	// Run the test suite
-	status := m.Run()
-
-	for _, fn := range teardownFuncs {
-		fn()
-	}
-
-	os.Exit(status)
+	memWatermarkThresholdMB := uint64(2048)
+	TestBucketPoolWithIndexes(m, memWatermarkThresholdMB)
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -228,8 +228,8 @@ WHERE META(ks).xattrs._sync.sequence >= 0
 	return purgedDocCount, nil
 }
 
-// ViewsAndGSIBucketReadier empties the bucket, initializes Views, and waits until GSI indexes are empty. It is run asynchronously as soon as a test is finished with a bucket.
-var ViewsAndGSIBucketReadier base.TBPBucketReadierFunc = func(ctx context.Context, b base.Bucket, tbp *base.TestBucketPool) error {
+// viewsAndGSIBucketReadier empties the bucket, initializes Views, and waits until GSI indexes are empty. It is run asynchronously as soon as a test is finished with a bucket.
+var viewsAndGSIBucketReadier base.TBPBucketReadierFunc = func(ctx context.Context, b base.Bucket, tbp *base.TestBucketPool) error {
 	if base.TestsDisableGSI() {
 		tbp.Logf(ctx, "flushing bucket and readying views")
 		if err := base.FlushBucketEmptierFunc(ctx, b, tbp); err != nil {
@@ -273,8 +273,8 @@ var ViewsAndGSIBucketReadier base.TBPBucketReadierFunc = func(ctx context.Contex
 	return nil
 }
 
-// ViewsAndGSIBucketInit is run synchronously only once per-bucket to do any initial setup. For non-integration Walrus buckets, this is run for each new Walrus bucket.
-var ViewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b base.Bucket, tbp *base.TestBucketPool) error {
+// viewsAndGSIBucketInit is run synchronously only once per-bucket to do any initial setup. For non-integration Walrus buckets, this is run for each new Walrus bucket.
+var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b base.Bucket, tbp *base.TestBucketPool) error {
 	if base.UnitTestUrlIsWalrus() {
 		// Check we're not running with an invalid combination of backing store and xattrs.
 		if base.TestUseXattrs() {
@@ -401,4 +401,9 @@ func (dbc *DatabaseContext) GetPrincipalForTest(tb testing.TB, name string, isUs
 		info.Channels = princ.Channels().AsSet()
 	}
 	return
+}
+
+// TestBucketPoolWithIndexes runs a TestMain for packages that do not require creation of indexes
+func TestBucketPoolWithIndexes(m *testing.M, memWatermarkThresholdMB uint64) {
+	base.TestBucketPoolMain(m, viewsAndGSIBucketReadier, viewsAndGSIBucketInit, memWatermarkThresholdMB)
 }

--- a/rest/main_test.go
+++ b/rest/main_test.go
@@ -11,7 +11,6 @@ licenses/APL2.txt.
 package rest
 
 import (
-	"os"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -21,28 +20,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// can't use defer because of os.Exit
-	teardownFuncs := make([]func(), 0)
-	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestLogging(m))
-	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestProfiling(m))
-	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestMemoryWatermark(m, 8192))
-
-	base.SkipPrometheusStatsRegistration = true
-
-	base.GTestBucketPool = base.NewTestBucketPool(db.ViewsAndGSIBucketReadier, db.ViewsAndGSIBucketInit)
-	teardownFuncs = append(teardownFuncs, base.GTestBucketPool.Close)
-
-	// must be the last teardown function added to the list to correctly detect leaked goroutines
-	teardownFuncs = append(teardownFuncs, base.SetUpTestGoroutineDump(m))
-
-	// Run the test suite
-	status := m.Run()
-
-	for _, fn := range teardownFuncs {
-		fn()
-	}
-
-	os.Exit(status)
+	memWatermarkThresholdMB := uint64(8192)
+	db.TestBucketPoolWithIndexes(m, memWatermarkThresholdMB)
 }
 
 func TestConfigOverwritesLegacyFlags(t *testing.T) {


### PR DESCRIPTION
Put shared common TestMains into one in `base` for non GSI and one in `db` which handles bucket creation with secondary indexes.. Waffled on choosing the word "index or GSI" here.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/814/