### PR TITLE
Make functions required for testing outside of package public

### DIFF
--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -534,7 +534,7 @@ func TestAdminAPIAuth(t *testing.T) {
 	}
 
 	rt := NewRestTester(t, &RestTesterConfig{
-		adminInterfaceAuthentication:   true,
+		AdminInterfaceAuthentication:   true,
 		metricsInterfaceAuthentication: true,
 	})
 	defer rt.Close()
@@ -973,10 +973,10 @@ func TestAdminAPIAuth(t *testing.T) {
 		}
 		t.Run(endPoint.Method+formattedEndpoint, func(t *testing.T) {
 			resp := rt.SendAdminRequest(endPoint.Method, formattedEndpoint, body)
-			requireStatus(t, resp, http.StatusUnauthorized)
+			RequireStatus(t, resp, http.StatusUnauthorized)
 
 			resp = rt.SendAdminRequestWithAuth(endPoint.Method, formattedEndpoint, body, "noaccess", "password")
-			requireStatus(t, resp, http.StatusForbidden)
+			RequireStatus(t, resp, http.StatusForbidden)
 
 			if !endPoint.SkipSuccessTest {
 
@@ -991,7 +991,7 @@ func TestAdminAPIAuth(t *testing.T) {
 					if endPoint.Method == http.MethodGet || endPoint.Method == http.MethodHead || endPoint.Method == http.MethodOptions {
 						assert.True(t, resp.Code != http.StatusUnauthorized && resp.Code != http.StatusForbidden)
 					} else {
-						requireStatus(t, resp, http.StatusForbidden)
+						RequireStatus(t, resp, http.StatusForbidden)
 					}
 
 					resp = rt.SendAdminRequestWithAuth(endPoint.Method, formattedEndpoint, body, "ClusterAdminUser", "password")
@@ -1089,7 +1089,7 @@ func TestNewlyCreateSGWPermissions(t *testing.T) {
 	syncGatewayReplicator := "sync_gateway_replicator"
 
 	rt := NewRestTester(t, &RestTesterConfig{
-		adminInterfaceAuthentication:    true,
+		AdminInterfaceAuthentication:    true,
 		enableAdminAuthPermissionsCheck: true,
 	})
 	defer rt.Close()
@@ -1536,7 +1536,7 @@ func TestNewlyCreateSGWPermissions(t *testing.T) {
 
 				if !isAllowedUser {
 					resp := rt.SendAdminRequestWithAuth(endpoint.Method, endpoint.Endpoint, "", testUser, "password")
-					requireStatus(t, resp, http.StatusForbidden)
+					RequireStatus(t, resp, http.StatusForbidden)
 				}
 			})
 		}
@@ -1553,7 +1553,7 @@ func TestCreateDBSpecificBucketPerm(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
 	rt := NewRestTester(t, &RestTesterConfig{
-		adminInterfaceAuthentication: true,
+		AdminInterfaceAuthentication: true,
 	})
 	defer rt.Close()
 
@@ -1568,5 +1568,5 @@ func TestCreateDBSpecificBucketPerm(t *testing.T) {
 	defer DeleteUser(t, httpClient, eps[0], mobileSyncGateway)
 
 	resp := rt.SendAdminRequestWithAuth("PUT", "/db2/", `{"bucket": "`+tb.GetName()+`", "username": "`+base.TestClusterUsername()+`", "password": "`+base.TestClusterPassword()+`", "num_index_replicas": 0, "use_views": `+strconv.FormatBool(base.TestsDisableGSI())+`}`, mobileSyncGateway, "password")
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 }

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -86,7 +86,7 @@ func TestPutDocSpecialChar(t *testing.T) {
 				t.Skipf("Skipping enterprise-only test")
 			}
 			tr := rt.SendAdminRequest(testCase.method, fmt.Sprintf("/db/%s", testCase.pathDocID), testCase.body)
-			requireStatus(t, tr, testCase.expectedResp)
+			RequireStatus(t, tr, testCase.expectedResp)
 			var body map[string]interface{}
 			err := json.Unmarshal(tr.BodyBytes(), &body)
 			assert.NoError(t, err)
@@ -95,7 +95,7 @@ func TestPutDocSpecialChar(t *testing.T) {
 
 	t.Run("Delete Double quote Doc ID", func(t *testing.T) { // Should be done for Local Document deletion when it returns response
 		tr := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", `del"ete"Me`), "{}") // Create the doc to delete
-		requireStatus(t, tr, http.StatusCreated)
+		RequireStatus(t, tr, http.StatusCreated)
 		var putBody struct {
 			Rev string `json:"rev"`
 		}
@@ -103,7 +103,7 @@ func TestPutDocSpecialChar(t *testing.T) {
 		assert.NoError(t, err)
 
 		tr = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/%s?rev=%s", `del"ete"Me`, putBody.Rev), "{}")
-		requireStatus(t, tr, http.StatusOK)
+		RequireStatus(t, tr, http.StatusOK)
 		var body map[string]interface{}
 		err = json.Unmarshal(tr.BodyBytes(), &body)
 		assert.NoError(t, err)
@@ -122,7 +122,7 @@ func TestNoPanicInvalidUpdate(t *testing.T) {
 	response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", docId), `{"value":"initial"}`)
 	response.DumpBody()
 
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Discover revision ID
 	// TODO: The schema for SG responses should be defined in our code somewhere to avoid this clunky approach
@@ -171,47 +171,47 @@ func TestUserPasswordValidation(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"letmein", "admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// PUT a user without a password, should fail
 	response = rt.SendAdminRequest("PUT", "/db/_user/ajresnopassword", `{"email":"ajres@couchbase.com", "admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	// POST a user without a password, should fail
 	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"ajresnopassword", "email":"ajres@couchbase.com", "admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	// PUT a user with a two character password, should fail
 	response = rt.SendAdminRequest("PUT", "/db/_user/ajresnopassword", `{"email":"ajres@couchbase.com", "password":"in", "admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	// POST a user with a two character password, should fail
 	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"ajresnopassword", "email":"ajres@couchbase.com", "password":"an", "admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	// PUT a user with a zero character password, should fail
 	response = rt.SendAdminRequest("PUT", "/db/_user/ajresnopassword", `{"email":"ajres@couchbase.com", "password":"", "admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	// POST a user with a zero character password, should fail
 	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"ajresnopassword", "email":"ajres@couchbase.com", "password":"", "admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	// PUT update a user with a two character password, should fail
 	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"password":"an"}`)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	// PUT update a user with a one character password, should fail
 	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"password":"a"}`)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	// PUT update a user with a zero character password, should fail
 	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"password":""}`)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	// PUT update a user with a three character password, should succeed
 	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"password":"abc"}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 }
 
 func TestUserAllowEmptyPassword(t *testing.T) {
@@ -221,47 +221,47 @@ func TestUserAllowEmptyPassword(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"letmein", "admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// PUT a user without a password, should succeed
 	response = rt.SendAdminRequest("PUT", "/db/_user/nopassword1", `{"email":"ajres@couchbase.com", "admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// POST a user without a password, should succeed
 	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"nopassword2", "email":"ajres@couchbase.com", "admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// PUT a user with a two character password, should fail
 	response = rt.SendAdminRequest("PUT", "/db/_user/nopassword3", `{"email":"ajres@couchbase.com", "password":"in", "admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	// POST a user with a two character password, should fail
 	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"nopassword4", "email":"ajres@couchbase.com", "password":"an", "admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	// PUT a user with a zero character password, should succeed
 	response = rt.SendAdminRequest("PUT", "/db/_user/nopassword5", `{"email":"ajres@couchbase.com", "password":"", "admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// POST a user with a zero character password, should succeed
 	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"nopassword6", "email":"ajres@couchbase.com", "password":"", "admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// PUT update a user with a two character password, should fail
 	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"password":"an"}`)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	// PUT update a user with a one character password, should fail
 	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"password":"a"}`)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	// PUT update a user with a zero character password, should succeed
 	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"password":""}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	// PUT update a user with a three character password, should succeed
 	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"password":"abc"}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 }
 
 func TestPrincipalForbidUpdatingChannels(t *testing.T) {
@@ -271,28 +271,28 @@ func TestPrincipalForbidUpdatingChannels(t *testing.T) {
 	// Users
 	// PUT admin_channels
 	response := rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"letmein", "admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// PUT all_channels - should fail
 	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "all_channels":["baz"]}`)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	// PUT admin_roles
 	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"letmein", "admin_roles":["foo", "bar"]}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	// PUT roles - should fail
 	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "roles":["baz"]}`)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	// Roles
 	// PUT admin_channels
 	response = rt.SendAdminRequest("PUT", "/db/_role/test", `{"admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// PUT all_channels - should fail
 	response = rt.SendAdminRequest("PUT", "/db/_role/test", `{"all_channels":["baz"]}`)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 }
 
 // Test user access grant while that user has an active changes feed.  (see issue #880)
@@ -335,11 +335,11 @@ function(doc, oldDoc) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", `{"name":"bernard", "password":"letmein", "admin_channels":["profile-bernard"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// Try to force channel initialisation for user bernard
 	response = rt.SendAdminRequest("GET", "/db/_user/bernard", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	// Create list docs
 	input := `{"docs": [`
@@ -379,7 +379,7 @@ function(doc, oldDoc) {
 			// Timeout allows us to read continuous changes after processing is complete.  Needs to be long enough to
 			// ensure it doesn't terminate before the first change is sent.
 			log.Printf("Invoking _changes?feed=continuous&since=%s&timeout=2000", since)
-			changesResponse := rt.Send(requestByUser("GET", fmt.Sprintf("/db/_changes?feed=continuous&since=%s&timeout=2000", since), "", "bernard"))
+			changesResponse := rt.Send(RequestByUser("GET", fmt.Sprintf("/db/_changes?feed=continuous&since=%s&timeout=2000", since), "", "bernard"))
 
 			changes, err := readContinuousChanges(changesResponse)
 			assert.NoError(t, err)
@@ -424,7 +424,7 @@ function(doc, oldDoc) {
 		input = input + `]}`
 
 		log.Printf("Sending 2nd round of _bulk_docs")
-		response = rt.Send(requestByUser("POST", "/db/_bulk_docs", input, "bernard"))
+		response = rt.Send(RequestByUser("POST", "/db/_bulk_docs", input, "bernard"))
 		log.Printf("Sent 2nd round of _bulk_docs")
 
 	}
@@ -451,7 +451,7 @@ func TestLoggingKeys(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{}, logKeys)
 
 	// Set logKeys, Changes+ should enable Changes (PUT replaces any existing log keys)
-	requireStatus(t, rt.SendAdminRequest("PUT", "/_logging", `{"Changes+":true, "Cache":true, "HTTP":true}`), 200)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/_logging", `{"Changes+":true, "Cache":true, "HTTP":true}`), 200)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var updatedLogKeys map[string]interface{}
@@ -459,7 +459,7 @@ func TestLoggingKeys(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{"Changes": true, "Cache": true, "HTTP": true}, updatedLogKeys)
 
 	// Disable Changes logKey which should also disable Changes+
-	requireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes":false}`), 200)
+	RequireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes":false}`), 200)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var deletedLogKeys map[string]interface{}
@@ -467,7 +467,7 @@ func TestLoggingKeys(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{"Cache": true, "HTTP": true}, deletedLogKeys)
 
 	// Enable Changes++, which should enable Changes (POST append logKeys)
-	requireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":true}`), 200)
+	RequireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":true}`), 200)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var appendedLogKeys map[string]interface{}
@@ -475,7 +475,7 @@ func TestLoggingKeys(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{"Changes": true, "Cache": true, "HTTP": true}, appendedLogKeys)
 
 	// Disable Changes++ (POST modifies logKeys)
-	requireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":false}`), 200)
+	RequireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":false}`), 200)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var disabledLogKeys map[string]interface{}
@@ -483,10 +483,10 @@ func TestLoggingKeys(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{"Cache": true, "HTTP": true}, disabledLogKeys)
 
 	// Re-Enable Changes++, which should enable Changes (POST append logKeys)
-	requireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":true}`), 200)
+	RequireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":true}`), 200)
 
 	// Disable Changes+ which should disable Changes (POST modifies logKeys)
-	requireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes+":false}`), 200)
+	RequireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes+":false}`), 200)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var disabled2LogKeys map[string]interface{}
@@ -494,10 +494,10 @@ func TestLoggingKeys(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{"Cache": true, "HTTP": true}, disabled2LogKeys)
 
 	// Re-Enable Changes++, which should enable Changes (POST append logKeys)
-	requireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":true}`), 200)
+	RequireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":true}`), 200)
 
 	// Disable Changes (POST modifies logKeys)
-	requireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes":false}`), 200)
+	RequireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes":false}`), 200)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var disabled3LogKeys map[string]interface{}
@@ -505,7 +505,7 @@ func TestLoggingKeys(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{"Cache": true, "HTTP": true}, disabled3LogKeys)
 
 	// Disable all logKeys by using PUT with an empty channel list
-	requireStatus(t, rt.SendAdminRequest("PUT", "/_logging", `{}`), 200)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/_logging", `{}`), 200)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var noLogKeys map[string]interface{}
@@ -531,24 +531,24 @@ func TestLoggingLevels(t *testing.T) {
 	assert.Equal(t, map[string]bool{}, logKeys)
 
 	// Set log level via logLevel query parameter
-	requireStatus(t, rt.SendAdminRequest("PUT", "/_logging?logLevel=error", ``), http.StatusOK)
-	requireStatus(t, rt.SendAdminRequest("PUT", "/_logging?logLevel=invalidLogLevel", ``), http.StatusBadRequest)
-	requireStatus(t, rt.SendAdminRequest("PUT", "/_logging?logLevel=", ``), http.StatusBadRequest)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/_logging?logLevel=error", ``), http.StatusOK)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/_logging?logLevel=invalidLogLevel", ``), http.StatusBadRequest)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/_logging?logLevel=", ``), http.StatusBadRequest)
 
 	// Set log level via old level query parameter
-	requireStatus(t, rt.SendAdminRequest("PUT", "/_logging?level=1", ``), http.StatusOK)
-	requireStatus(t, rt.SendAdminRequest("PUT", "/_logging?level=2", ``), http.StatusOK)
-	requireStatus(t, rt.SendAdminRequest("PUT", "/_logging?level=3", ``), http.StatusOK)
-	requireStatus(t, rt.SendAdminRequest("PUT", "/_logging?level=10", ``), http.StatusOK) // Value is clamped to acceptable range, without returning an error
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/_logging?level=1", ``), http.StatusOK)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/_logging?level=2", ``), http.StatusOK)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/_logging?level=3", ``), http.StatusOK)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/_logging?level=10", ``), http.StatusOK) // Value is clamped to acceptable range, without returning an error
 
-	requireStatus(t, rt.SendAdminRequest("PUT", "/_logging?level=0", ``), http.StatusBadRequest) // Zero-value is ignored and body is to be parsed
-	requireStatus(t, rt.SendAdminRequest("PUT", "/_logging?level=0", `{}`), http.StatusOK)       // Zero-value is ignored and body is to be parsed
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/_logging?level=0", ``), http.StatusBadRequest) // Zero-value is ignored and body is to be parsed
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/_logging?level=0", `{}`), http.StatusOK)       // Zero-value is ignored and body is to be parsed
 
-	requireStatus(t, rt.SendAdminRequest("PUT", "/_logging?level=invalidLogLevel", ``), http.StatusBadRequest)
-	requireStatus(t, rt.SendAdminRequest("PUT", "/_logging?level=", ``), http.StatusBadRequest)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/_logging?level=invalidLogLevel", ``), http.StatusBadRequest)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/_logging?level=", ``), http.StatusBadRequest)
 
 	// Trying to set log level via the body will not work (the endpoint expects a log key map)
-	requireStatus(t, rt.SendAdminRequest("PUT", "/_logging", `{"logLevel": "debug"}`), http.StatusBadRequest)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/_logging", `{"logLevel": "debug"}`), http.StatusBadRequest)
 }
 
 func TestLoggingCombined(t *testing.T) {
@@ -569,7 +569,7 @@ func TestLoggingCombined(t *testing.T) {
 	assert.Equal(t, map[string]bool{}, logKeys)
 
 	// Set log keys and log level in a single request
-	requireStatus(t, rt.SendAdminRequest("PUT", "/_logging?logLevel=trace", `{"Changes":true, "Cache":true, "HTTP":true}`), http.StatusOK)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/_logging?logLevel=trace", `{"Changes":true, "Cache":true, "HTTP":true}`), http.StatusOK)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &logKeys))
@@ -581,10 +581,10 @@ func TestGetStatus(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendRequest("GET", "/_status", "")
-	requireStatus(t, response, 404)
+	RequireStatus(t, response, 404)
 
 	response = rt.SendAdminRequest("GET", "/_status", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	var responseBody Status
 	err := base.JSONUnmarshal(response.Body.Bytes(), &responseBody)
 	assert.NoError(t, err)
@@ -592,7 +592,7 @@ func TestGetStatus(t *testing.T) {
 	assert.Equal(t, base.LongVersionString, responseBody.Version)
 
 	response = rt.SendAdminRequest("OPTIONS", "/_status", "")
-	requireStatus(t, response, 204)
+	RequireStatus(t, response, 204)
 	assert.Equal(t, "GET", response.Header().Get("Allow"))
 }
 
@@ -606,13 +606,13 @@ func TestUserDeleteDuringChangesWithAccess(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", `{"name":"bernard", "password":"letmein", "admin_channels":["foo"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		changesResponse := rt.Send(requestByUser("GET", "/db/_changes?feed=continuous&since=0&timeout=3000", "", "bernard"))
+		changesResponse := rt.Send(RequestByUser("GET", "/db/_changes?feed=continuous&since=0&timeout=3000", "", "bernard"))
 		// When testing single threaded, this reproduces the issue described in #809.
 		// When testing multithreaded (-cpu 4 -race), there are three (valid) possibilities"
 		// 1. The DELETE gets processed before the _changes auth completes: this will return 401
@@ -683,16 +683,16 @@ func TestRoleAPI(t *testing.T) {
 	defer rt.Close()
 
 	// PUT a role
-	requireStatus(t, rt.SendAdminRequest("GET", "/db/_role/hipster", ""), 404)
+	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_role/hipster", ""), 404)
 	response := rt.SendAdminRequest("PUT", "/db/_role/hipster", `{"admin_channels":["fedoras", "fixies"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/db/_role/testdeleted", `{"admin_channels":["fedoras", "fixies"]}`)
-	requireStatus(t, response, 201)
-	requireStatus(t, rt.SendAdminRequest("DELETE", "/db/_role/testdeleted", ""), 200)
+	RequireStatus(t, response, 201)
+	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_role/testdeleted", ""), 200)
 
 	// GET the role and make sure the result is OK
 	response = rt.SendAdminRequest("GET", "/db/_role/hipster", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, "hipster", body["name"])
@@ -700,28 +700,28 @@ func TestRoleAPI(t *testing.T) {
 	assert.Equal(t, nil, body["password"])
 
 	response = rt.SendAdminRequest("GET", "/db/_role/", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	assert.Equal(t, `["hipster"]`, response.Body.String())
 
 	// DELETE the role
-	requireStatus(t, rt.SendAdminRequest("DELETE", "/db/_role/hipster", ""), 200)
-	requireStatus(t, rt.SendAdminRequest("GET", "/db/_role/hipster", ""), 404)
+	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_role/hipster", ""), 200)
+	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_role/hipster", ""), 404)
 
 	// POST a role
 	response = rt.SendAdminRequest("POST", "/db/_role", `{"name":"hipster", "admin_channels":["fedoras", "fixies"]}`)
-	requireStatus(t, response, 301)
+	RequireStatus(t, response, 301)
 	response = rt.SendAdminRequest("POST", "/db/_role/", `{"name":"hipster", "admin_channels":["fedoras", "fixies"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/_role/hipster", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	body = nil
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, "hipster", body["name"])
-	requireStatus(t, rt.SendAdminRequest("DELETE", "/db/_role/hipster", ""), 200)
+	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_role/hipster", ""), 200)
 
 	// GET including deleted
 	response = rt.SendAdminRequest("GET", "/db/_role/?deleted=true", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	assert.Equal(t, `["hipster","testdeleted"]`, response.Body.String())
 }
 
@@ -733,7 +733,7 @@ func TestGuestUser(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest(http.MethodGet, guestUserEndpoint, "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, base.GuestUsername, body["name"])
@@ -742,11 +742,11 @@ func TestGuestUser(t *testing.T) {
 
 	// Disable the guest user:
 	response = rt.SendAdminRequest(http.MethodPut, guestUserEndpoint, `{"disabled":true}`)
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	// Get guest user and verify it is now disabled:
 	response = rt.SendAdminRequest(http.MethodGet, guestUserEndpoint, "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, base.GuestUsername, body["name"])
 	assert.True(t, body["disabled"].(bool))
@@ -760,7 +760,7 @@ func TestGuestUser(t *testing.T) {
 
 	// We can't delete the guest user, but we should get a reasonable error back.
 	response = rt.SendAdminRequest(http.MethodDelete, guestUserEndpoint, "")
-	requireStatus(t, response, http.StatusMethodNotAllowed)
+	RequireStatus(t, response, http.StatusMethodNotAllowed)
 }
 
 // Test that TTL values greater than the default max offset TTL 2592000 seconds are processed correctly
@@ -782,14 +782,14 @@ func TestSessionTtlGreaterThan30Days(t *testing.T) {
 	assert.True(t, user.Disabled())
 
 	response := rt.SendRequest("PUT", "/db/doc", `{"hi": "there"}`)
-	requireStatus(t, response, 401)
+	RequireStatus(t, response, 401)
 
 	user, err = a.NewUser("pupshaw", "letmein", channels.SetOf(t, "*"))
 	assert.NoError(t, a.Save(user))
 
 	// create a session with the maximum offset ttl value (30days) 2592000 seconds
 	response = rt.SendAdminRequest("POST", "/db/_session", `{"name":"pupshaw", "ttl":2592000}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	layout := "2006-01-02T15:04:05"
 
@@ -802,7 +802,7 @@ func TestSessionTtlGreaterThan30Days(t *testing.T) {
 
 	// create a session with a ttl value one second greater thatn the max offset ttl 2592001 seconds
 	response = rt.SendAdminRequest("POST", "/db/_session", `{"name":"pupshaw", "ttl":2592001}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	body = nil
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
@@ -820,7 +820,7 @@ func TestSessionTtlGreaterThan30Days(t *testing.T) {
 // Check whether the session is getting extended or refreshed if 10% or more of the current
 // expiration time has elapsed.
 func TestSessionExtension(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	id, err := base.GenerateRandomSecret()
@@ -842,12 +842,12 @@ func TestSessionExtension(t *testing.T) {
 
 	response := rt.SendRequestWithHeaders("PUT", "/db/doc1", `{"hi": "there"}`, reqHeaders)
 	log.Printf("PUT Request: Set-Cookie: %v", response.Header().Get("Set-Cookie"))
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	assert.Contains(t, response.Header().Get("Set-Cookie"), auth.DefaultCookieName+"="+fakeSession.ID)
 
 	response = rt.SendRequestWithHeaders("GET", "/db/doc1", "", reqHeaders)
 	log.Printf("GET Request: Set-Cookie: %v", response.Header().Get("Set-Cookie"))
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	assert.Equal(t, "", response.Header().Get("Set-Cookie"))
 
 	// Explicitly delete the fake session doc from the bucket to simulate the test
@@ -858,7 +858,7 @@ func TestSessionExtension(t *testing.T) {
 
 	response = rt.SendRequestWithHeaders("GET", "/db/doc1", "", reqHeaders)
 	log.Printf("GET Request: Set-Cookie: %v", response.Header().Get("Set-Cookie"))
-	requireStatus(t, response, http.StatusUnauthorized)
+	RequireStatus(t, response, http.StatusUnauthorized)
 
 }
 
@@ -869,11 +869,11 @@ func TestSessionAPI(t *testing.T) {
 
 	// create session test users
 	response := rt.SendAdminRequest("POST", "/db/_user/", `{"name":"user1", "password":"1234"}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"user2", "password":"1234"}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"user3", "password":"1234"}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// create multiple sessions for the users
 	user1sessions := make([]string, 5)
@@ -881,71 +881,71 @@ func TestSessionAPI(t *testing.T) {
 	user3sessions := make([]string, 5)
 
 	for i := 0; i < 5; i++ {
-		user1sessions[i] = rt.createSession(t, "user1")
-		user2sessions[i] = rt.createSession(t, "user2")
-		user3sessions[i] = rt.createSession(t, "user3")
+		user1sessions[i] = rt.CreateSession(t, "user1")
+		user2sessions[i] = rt.CreateSession(t, "user2")
+		user3sessions[i] = rt.CreateSession(t, "user3")
 	}
 
 	// GET Tests
 	// 1. GET a session and make sure the result is OK
 	response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/_session/%s", user1sessions[0]), "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	// DELETE tests
 	// 1. DELETE a session by session id
 	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/_session/%s", user1sessions[0]), "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	// Attempt to GET the deleted session and make sure it's not found
 	response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/_session/%s", user1sessions[0]), "")
-	requireStatus(t, response, 404)
+	RequireStatus(t, response, 404)
 
 	// 2. DELETE a session with user validation
 	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/_user/%s/_session/%s", "user1", user1sessions[1]), "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	// Attempt to GET the deleted session and make sure it's not found
 	response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/_session/%s", user1sessions[1]), "")
-	requireStatus(t, response, 404)
+	RequireStatus(t, response, 404)
 
 	// 3. DELETE a session not belonging to the user (should fail)
 	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/_user/%s/_session/%s", "user1", user2sessions[0]), "")
-	requireStatus(t, response, 404)
+	RequireStatus(t, response, 404)
 
 	// GET the session and make sure it still exists
 	response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/_session/%s", user2sessions[0]), "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	// 4. DELETE all sessions for a user
 	response = rt.SendAdminRequest("DELETE", "/db/_user/user2/_session", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	// Validate that all sessions were deleted
 	for i := 0; i < 5; i++ {
 		response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/_session/%s", user2sessions[i]), "")
-		requireStatus(t, response, 404)
+		RequireStatus(t, response, 404)
 	}
 
 	// 5. DELETE sessions when password is changed
 	// Change password for user3
 	response = rt.SendAdminRequest("PUT", "/db/_user/user3", `{"password":"5678"}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	// Validate that all sessions were deleted
 	for i := 0; i < 5; i++ {
 		response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/_session/%s", user3sessions[i]), "")
-		requireStatus(t, response, 404)
+		RequireStatus(t, response, 404)
 	}
 
 	// DELETE the users
-	requireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/user1", ""), 200)
-	requireStatus(t, rt.SendAdminRequest("GET", "/db/_user/user1", ""), 404)
+	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/user1", ""), 200)
+	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/user1", ""), 404)
 
-	requireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/user2", ""), 200)
-	requireStatus(t, rt.SendAdminRequest("GET", "/db/_user/user2", ""), 404)
+	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/user2", ""), 200)
+	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/user2", ""), 404)
 
-	requireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/user3", ""), 200)
-	requireStatus(t, rt.SendAdminRequest("GET", "/db/_user/user3", ""), 404)
+	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/user3", ""), 200)
+	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/user3", ""), 404)
 
 }
 
@@ -958,19 +958,19 @@ func TestFlush(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	rt.createDoc(t, "doc1")
-	rt.createDoc(t, "doc2")
-	requireStatus(t, rt.SendAdminRequest("GET", "/db/doc1", ""), 200)
-	requireStatus(t, rt.SendAdminRequest("GET", "/db/doc2", ""), 200)
+	rt.CreateDoc(t, "doc1")
+	rt.CreateDoc(t, "doc2")
+	RequireStatus(t, rt.SendAdminRequest("GET", "/db/doc1", ""), 200)
+	RequireStatus(t, rt.SendAdminRequest("GET", "/db/doc2", ""), 200)
 
 	log.Printf("Flushing db...")
-	requireStatus(t, rt.SendAdminRequest("POST", "/db/_flush", ""), 200)
+	RequireStatus(t, rt.SendAdminRequest("POST", "/db/_flush", ""), 200)
 	require.NoError(t, rt.SetAdminParty(true)) // needs to be re-enabled after flush since guest user got wiped
 
 	// After the flush, the db exists but the documents are gone:
-	requireStatus(t, rt.SendAdminRequest("GET", "/db/", ""), 200)
-	requireStatus(t, rt.SendAdminRequest("GET", "/db/doc1", ""), 404)
-	requireStatus(t, rt.SendAdminRequest("GET", "/db/doc2", ""), 404)
+	RequireStatus(t, rt.SendAdminRequest("GET", "/db/", ""), 200)
+	RequireStatus(t, rt.SendAdminRequest("GET", "/db/doc1", ""), 404)
+	RequireStatus(t, rt.SendAdminRequest("GET", "/db/doc2", ""), 404)
 }
 
 // Test a single call to take DB offline
@@ -986,7 +986,7 @@ func TestDBOfflineSingle(t *testing.T) {
 	assert.True(t, body["state"].(string) == "Online")
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
@@ -1027,8 +1027,8 @@ func TestDBOfflineConcurrent(t *testing.T) {
 
 	err := WaitWithTimeout(&wg, time.Second*30)
 	assert.NoError(t, err, "Error waiting for waitgroup")
-	requireStatus(t, goroutineresponse1, http.StatusOK)
-	requireStatus(t, goroutineresponse2, http.StatusOK)
+	RequireStatus(t, goroutineresponse1, http.StatusOK)
+	RequireStatus(t, goroutineresponse2, http.StatusOK)
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
@@ -1050,7 +1050,7 @@ func TestStartDBOffline(t *testing.T) {
 	assert.True(t, body["state"].(string) == "Online")
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
@@ -1071,14 +1071,14 @@ func TestDBOffline503Response(t *testing.T) {
 	assert.True(t, body["state"].(string) == "Online")
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.True(t, body["state"].(string) == "Offline")
 
-	requireStatus(t, rt.SendRequest("GET", "/db/doc1", ""), 503)
+	RequireStatus(t, rt.SendRequest("GET", "/db/doc1", ""), 503)
 }
 
 // Take DB offline and ensure can put db config
@@ -1094,14 +1094,14 @@ func TestDBOfflinePutDbConfig(t *testing.T) {
 	assert.True(t, body["state"].(string) == "Online")
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.True(t, body["state"].(string) == "Offline")
 
-	requireStatus(t, rt.SendRequest("PUT", "/db/_config", ""), 404)
+	RequireStatus(t, rt.SendRequest("PUT", "/db/_config", ""), 404)
 }
 
 // Tests that the users returned in the config endpoint have the correct names
@@ -1145,14 +1145,14 @@ func TestDBOfflinePostResync(t *testing.T) {
 	assert.True(t, body["state"].(string) == "Online")
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.True(t, body["state"].(string) == "Offline")
 
-	requireStatus(t, rt.SendAdminRequest("POST", "/db/_resync?action=start", ""), 200)
+	RequireStatus(t, rt.SendAdminRequest("POST", "/db/_resync?action=start", ""), 200)
 	err := rt.WaitForCondition(func() bool {
 		response := rt.SendAdminRequest("GET", "/db/_resync", "")
 		var status db.ResyncManagerResponse
@@ -1179,7 +1179,7 @@ func TestDBOfflineSingleResync(t *testing.T) {
 
 	// create documents in DB to cause resync to take a few seconds
 	for i := 0; i < 1000; i++ {
-		rt.createDoc(t, fmt.Sprintf("doc%v", i))
+		rt.CreateDoc(t, fmt.Sprintf("doc%v", i))
 	}
 	assert.Equal(t, int64(1000), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 
@@ -1190,7 +1190,7 @@ func TestDBOfflineSingleResync(t *testing.T) {
 	assert.True(t, body["state"].(string) == "Online")
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
@@ -1198,10 +1198,10 @@ func TestDBOfflineSingleResync(t *testing.T) {
 	assert.True(t, body["state"].(string) == "Offline")
 
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	// Send a second _resync request.  This must return a 400 since the first one is blocked processing
-	requireStatus(t, rt.SendAdminRequest("POST", "/db/_resync?action=start", ""), 503)
+	RequireStatus(t, rt.SendAdminRequest("POST", "/db/_resync?action=start", ""), 503)
 
 	err := rt.WaitForCondition(func() bool {
 		response := rt.SendAdminRequest("GET", "/db/_resync", "")
@@ -1270,14 +1270,14 @@ func TestResync(t *testing.T) {
 			defer rt.Close()
 
 			for i := 0; i < testCase.docsCreated; i++ {
-				rt.createDoc(t, fmt.Sprintf("doc%d", i))
+				rt.CreateDoc(t, fmt.Sprintf("doc%d", i))
 			}
 
 			response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-			requireStatus(t, response, http.StatusServiceUnavailable)
+			RequireStatus(t, response, http.StatusServiceUnavailable)
 
 			response = rt.SendAdminRequest("POST", "/db/_offline", "")
-			requireStatus(t, response, http.StatusOK)
+			RequireStatus(t, response, http.StatusOK)
 
 			waitAndAssertCondition(t, func() bool {
 				state := atomic.LoadUint32(&rt.GetDatabase().State)
@@ -1285,7 +1285,7 @@ func TestResync(t *testing.T) {
 			})
 
 			response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-			requireStatus(t, response, http.StatusOK)
+			RequireStatus(t, response, http.StatusOK)
 
 			var resyncManagerStatus db.ResyncManagerResponse
 			err := rt.WaitForCondition(func() bool {
@@ -1338,8 +1338,8 @@ func TestResyncErrorScenarios(t *testing.T) {
 
 	rt := NewRestTester(t,
 		&RestTesterConfig{
-			SyncFn:     syncFn,
-			TestBucket: leakyTestBucket,
+			SyncFn:           syncFn,
+			CustomTestBucket: leakyTestBucket,
 		},
 	)
 	defer rt.Close()
@@ -1357,7 +1357,7 @@ func TestResyncErrorScenarios(t *testing.T) {
 			if useCallback {
 				callbackFired = true
 				response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-				requireStatus(t, response, http.StatusServiceUnavailable)
+				RequireStatus(t, response, http.StatusServiceUnavailable)
 				useCallback = false
 			}
 		})
@@ -1366,27 +1366,27 @@ func TestResyncErrorScenarios(t *testing.T) {
 			if useCallback {
 				callbackFired = true
 				response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-				requireStatus(t, response, http.StatusServiceUnavailable)
+				RequireStatus(t, response, http.StatusServiceUnavailable)
 				useCallback = false
 			}
 		})
 	}
 
 	for i := 0; i < 1000; i++ {
-		rt.createDoc(t, fmt.Sprintf("doc%d", i))
+		rt.CreateDoc(t, fmt.Sprintf("doc%d", i))
 	}
 
 	response := rt.SendAdminRequest("GET", "/db/_resync", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-	requireStatus(t, response, http.StatusServiceUnavailable)
+	RequireStatus(t, response, http.StatusServiceUnavailable)
 
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
-	requireStatus(t, response, http.StatusBadRequest)
+	RequireStatus(t, response, http.StatusBadRequest)
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	waitAndAssertCondition(t, func() bool {
 		state := atomic.LoadUint32(&rt.GetDatabase().State)
@@ -1395,20 +1395,20 @@ func TestResyncErrorScenarios(t *testing.T) {
 
 	useCallback = true
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	waitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted, rt.GetDatabase().ResyncManager.GetRunState)
 	waitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
 
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
-	requireStatus(t, response, http.StatusBadRequest)
+	RequireStatus(t, response, http.StatusBadRequest)
 
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=invalid", "")
-	requireStatus(t, response, http.StatusBadRequest)
+	RequireStatus(t, response, http.StatusBadRequest)
 
 	// Test empty action, should default to start
 	response = rt.SendAdminRequest("POST", "/db/_resync", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	waitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted, rt.GetDatabase().ResyncManager.GetRunState)
 	waitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
@@ -1436,7 +1436,7 @@ func TestResyncStop(t *testing.T) {
 			DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 				QueryPaginationLimit: base.IntPtr(10),
 			}},
-			TestBucket: leakyTestBucket,
+			CustomTestBucket: leakyTestBucket,
 		},
 	)
 	defer rt.Close()
@@ -1454,7 +1454,7 @@ func TestResyncStop(t *testing.T) {
 			if useCallback {
 				callbackFired = true
 				response := rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
-				requireStatus(t, response, http.StatusOK)
+				RequireStatus(t, response, http.StatusOK)
 				useCallback = false
 			}
 		})
@@ -1463,14 +1463,14 @@ func TestResyncStop(t *testing.T) {
 			if useCallback {
 				callbackFired = true
 				response := rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
-				requireStatus(t, response, http.StatusOK)
+				RequireStatus(t, response, http.StatusOK)
 				useCallback = false
 			}
 		})
 	}
 
 	for i := 0; i < 1000; i++ {
-		rt.createDoc(t, fmt.Sprintf("doc%d", i))
+		rt.CreateDoc(t, fmt.Sprintf("doc%d", i))
 	}
 
 	err := rt.WaitForCondition(func() bool {
@@ -1479,7 +1479,7 @@ func TestResyncStop(t *testing.T) {
 	assert.NoError(t, err)
 
 	response := rt.SendAdminRequest("POST", "/db/_offline", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	waitAndAssertCondition(t, func() bool {
 		state := atomic.LoadUint32(&rt.GetDatabase().State)
@@ -1488,7 +1488,7 @@ func TestResyncStop(t *testing.T) {
 
 	useCallback = true
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	waitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateStopped, rt.GetDatabase().ResyncManager.GetRunState)
 	waitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
@@ -1523,8 +1523,8 @@ func TestResyncRegenerateSequences(t *testing.T) {
 
 	rt := NewRestTester(t,
 		&RestTesterConfig{
-			SyncFn:     syncFn,
-			TestBucket: testBucket,
+			SyncFn:           syncFn,
+			CustomTestBucket: testBucket,
 		},
 	)
 	defer rt.Close()
@@ -1535,7 +1535,7 @@ func TestResyncRegenerateSequences(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		docID := fmt.Sprintf("doc%d", i)
-		rt.createDoc(t, docID)
+		rt.CreateDoc(t, docID)
 
 		response = rt.SendAdminRequest("GET", "/db/_raw/"+docID, "")
 		require.Equal(t, http.StatusOK, response.Code)
@@ -1548,11 +1548,11 @@ func TestResyncRegenerateSequences(t *testing.T) {
 
 	role := "role1"
 	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_role/%s", role), fmt.Sprintf(`{"name":"%s", "admin_channels":["channel_1"]}`, role))
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	username := "user1"
 	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_user/%s", username), fmt.Sprintf(`{"name":"%s", "password":"letmein", "admin_channels":["channel_1"], "admin_roles": ["%s"]}`, username, role))
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	_, err := rt.Bucket().Get(base.RolePrefix+"role1", &body)
 	assert.NoError(t, err)
@@ -1563,10 +1563,10 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	user1SeqBefore := body["sequence"].(float64)
 
 	response = rt.SendAdminRequest("PUT", "/db/userdoc", `{"userdoc": true}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	response = rt.SendAdminRequest("PUT", "/db/userdoc2", `{"userdoc": true}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Let everything catch up before opening changes feed
 	require.NoError(t, rt.WaitForPendingChanges())
@@ -1592,20 +1592,20 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	request, _ := http.NewRequest("GET", "/db/_changes", nil)
 	request.SetBasicAuth("user1", "letmein")
 	response = rt.Send(request)
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	err = json.Unmarshal(response.BodyBytes(), &changesResp)
 	assert.Len(t, changesResp.Results, 3)
 	assert.True(t, changesRespContains(changesResp, "userdoc"))
 	assert.True(t, changesRespContains(changesResp, "userdoc2"))
 
 	response = rt.SendAdminRequest("GET", "/db/_resync", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=start&regenerate_sequences=true", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	waitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted, rt.GetDatabase().ResyncManager.GetRunState)
 	waitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
@@ -1631,7 +1631,7 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	}
 
 	response = rt.SendAdminRequest("GET", "/db/_resync", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	var resyncStatus db.ResyncManagerResponse
 	err = base.JSONUnmarshal(response.BodyBytes(), &resyncStatus)
 	assert.NoError(t, err)
@@ -1639,7 +1639,7 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	assert.Equal(t, 12, resyncStatus.DocsProcessed)
 
 	response = rt.SendAdminRequest("POST", "/db/_online", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	err = rt.WaitForCondition(func() bool {
 		state := atomic.LoadUint32(&rt.GetDatabase().State)
@@ -1651,7 +1651,7 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	request, _ = http.NewRequest("GET", "/db/_changes?since="+changesResp.LastSeq, nil)
 	request.SetBasicAuth("user1", "letmein")
 	response = rt.Send(request)
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	err = json.Unmarshal(response.BodyBytes(), &changesResp)
 	assert.Len(t, changesResp.Results, 3)
 	assert.True(t, changesRespContains(changesResp, "userdoc"))
@@ -1671,7 +1671,7 @@ func TestDBOnlineSingle(t *testing.T) {
 	assert.True(t, body["state"].(string) == "Online")
 
 	rt.SendAdminRequest("POST", "/db/_offline", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
@@ -1679,7 +1679,7 @@ func TestDBOnlineSingle(t *testing.T) {
 	assert.True(t, body["state"].(string) == "Offline")
 
 	rt.SendAdminRequest("POST", "/db/_online", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	time.Sleep(500 * time.Millisecond)
 
@@ -1704,7 +1704,7 @@ func TestDBOnlineConcurrent(t *testing.T) {
 	assert.True(t, body["state"].(string) == "Online")
 
 	rt.SendAdminRequest("POST", "/db/_offline", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
@@ -1718,14 +1718,14 @@ func TestDBOnlineConcurrent(t *testing.T) {
 	go func(rt *RestTester) {
 		defer wg.Done()
 		goroutineresponse1 = rt.SendAdminRequest("POST", "/db/_online", "")
-		requireStatus(t, goroutineresponse1, 200)
+		RequireStatus(t, goroutineresponse1, 200)
 	}(rt)
 
 	var goroutineresponse2 *TestResponse
 	go func(rt *RestTester) {
 		defer wg.Done()
 		goroutineresponse2 = rt.SendAdminRequest("POST", "/db/_online", "")
-		requireStatus(t, goroutineresponse2, 200)
+		RequireStatus(t, goroutineresponse2, 200)
 	}(rt)
 
 	// This only waits until both _online requests have been posted
@@ -1753,7 +1753,7 @@ func TestSingleDBOnlineWithDelay(t *testing.T) {
 	assert.True(t, body["state"].(string) == "Online")
 
 	rt.SendAdminRequest("POST", "/db/_offline", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
@@ -1761,7 +1761,7 @@ func TestSingleDBOnlineWithDelay(t *testing.T) {
 	assert.True(t, body["state"].(string) == "Offline")
 
 	rt.SendAdminRequest("POST", "/db/_online", "{\"delay\":1}")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
@@ -1799,17 +1799,17 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 		require.Equal(t, "Online", rt.GetDBState())
 
 		response = rt.SendAdminRequest("POST", "/db/_offline", "")
-		requireStatus(t, response, 200)
+		RequireStatus(t, response, 200)
 
 		// Bring DB online with delay of two seconds
 		response = rt.SendAdminRequest("POST", "/db/_online", "{\"delay\":1}")
-		requireStatus(t, response, 200)
+		RequireStatus(t, response, 200)
 
 		require.Equal(t, "Offline", rt.GetDBState())
 
 		// Bring DB online immediately
 		response = rt.SendAdminRequest("POST", "/db/_online", "")
-		requireStatus(t, response, 200)
+		RequireStatus(t, response, 200)
 
 		// Wait for DB to come online (retry loop)
 		errDBState = rt.WaitForDBOnline()
@@ -1841,7 +1841,7 @@ func TestDBOnlineWithTwoDelays(t *testing.T) {
 	assert.True(t, body["state"].(string) == "Online")
 
 	rt.SendAdminRequest("POST", "/db/_offline", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
@@ -1850,11 +1850,11 @@ func TestDBOnlineWithTwoDelays(t *testing.T) {
 
 	// Bring DB online with delay of one seconds
 	rt.SendAdminRequest("POST", "/db/_online", "{\"delay\":1}")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	// Bring DB online with delay of two seconds
 	rt.SendAdminRequest("POST", "/db/_online", "{\"delay\":2}")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
@@ -1876,10 +1876,10 @@ func TestDBOnlineWithTwoDelays(t *testing.T) {
 	assert.True(t, body["state"].(string) == "Online")
 }
 
-func (rt *RestTester) createSession(t *testing.T, username string) string {
+func (rt *RestTester) CreateSession(t *testing.T, username string) string {
 
 	response := rt.SendAdminRequest("POST", "/db/_session", fmt.Sprintf(`{"name":%q}`, username))
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
@@ -1894,7 +1894,7 @@ func TestPurgeWithBadJsonPayload(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("POST", "/db/_purge", "foo")
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 }
 
 func TestPurgeWithNonArrayRevisionList(t *testing.T) {
@@ -1903,7 +1903,7 @@ func TestPurgeWithNonArrayRevisionList(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("POST", "/db/_purge", `{"foo":"list"}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	var body map[string]interface{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
@@ -1916,7 +1916,7 @@ func TestPurgeWithEmptyRevisionList(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("POST", "/db/_purge", `{"foo":[]}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	var body map[string]interface{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
@@ -1929,7 +1929,7 @@ func TestPurgeWithGreaterThanOneRevision(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("POST", "/db/_purge", `{"foo":["rev1","rev2"]}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	var body map[string]interface{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
@@ -1942,7 +1942,7 @@ func TestPurgeWithNonStarRevision(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("POST", "/db/_purge", `{"foo":["rev1"]}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	var body map[string]interface{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
@@ -1953,35 +1953,35 @@ func TestPurgeWithStarRevision(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	requireStatus(t, rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar"}`), 201)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar"}`), 201)
 
 	response := rt.SendAdminRequest("POST", "/db/_purge", `{"doc1":["*"]}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	var body map[string]interface{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}}}, body)
 
 	// Create new versions of the doc1 without conflicts
-	requireStatus(t, rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar"}`), 201)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar"}`), 201)
 }
 
 func TestPurgeWithMultipleValidDocs(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	requireStatus(t, rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar"}`), 201)
-	requireStatus(t, rt.SendAdminRequest("PUT", "/db/doc2", `{"moo":"car"}`), 201)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar"}`), 201)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/db/doc2", `{"moo":"car"}`), 201)
 
 	response := rt.SendAdminRequest("POST", "/db/_purge", `{"doc1":["*"],"doc2":["*"]}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	var body map[string]interface{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}, "doc2": []interface{}{"*"}}}, body)
 
 	// Create new versions of the docs without conflicts
-	requireStatus(t, rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar"}`), 201)
-	requireStatus(t, rt.SendAdminRequest("PUT", "/db/doc2", `{"moo":"car"}`), 201)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar"}`), 201)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/db/doc2", `{"moo":"car"}`), 201)
 }
 
 // TestPurgeWithChannelCache will make sure thant upon calling _purge, the channel caches are also cleaned
@@ -1990,10 +1990,10 @@ func TestPurgeWithChannelCache(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	requireStatus(t, rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar", "channels": ["abc", "def"]}`), http.StatusCreated)
-	requireStatus(t, rt.SendAdminRequest("PUT", "/db/doc2", `{"moo":"car", "channels": ["abc"]}`), http.StatusCreated)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar", "channels": ["abc", "def"]}`), http.StatusCreated)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/db/doc2", `{"moo":"car", "channels": ["abc"]}`), http.StatusCreated)
 
-	changes, err := rt.waitForChanges(2, "/db/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
+	changes, err := rt.WaitForChanges(2, "/db/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
 	require.NoError(t, err, "Error waiting for changes")
 	base.RequireAllAssertions(t,
 		assert.Equal(t, "doc1", changes.Results[0].ID),
@@ -2002,12 +2002,12 @@ func TestPurgeWithChannelCache(t *testing.T) {
 
 	// Purge "doc1"
 	resp := rt.SendAdminRequest("POST", "/db/_purge", `{"doc1":["*"]}`)
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	var body map[string]interface{}
 	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &body))
 	assert.Equal(t, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}}}, body)
 
-	changes, err = rt.waitForChanges(1, "/db/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
+	changes, err = rt.WaitForChanges(1, "/db/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
 	require.NoError(t, err, "Error waiting for changes")
 	assert.Equal(t, "doc2", changes.Results[0].ID)
 
@@ -2017,20 +2017,20 @@ func TestPurgeWithSomeInvalidDocs(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	requireStatus(t, rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar"}`), 201)
-	requireStatus(t, rt.SendAdminRequest("PUT", "/db/doc2", `{"moo":"car"}`), 201)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar"}`), 201)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/db/doc2", `{"moo":"car"}`), 201)
 
 	response := rt.SendAdminRequest("POST", "/db/_purge", `{"doc1":["*"],"doc2":["1-123"]}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	var body map[string]interface{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}}}, body)
 
 	// Create new versions of the doc1 without conflicts
-	requireStatus(t, rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar"}`), 201)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar"}`), 201)
 
 	// Create new versions of the doc2 fails because it already exists
-	requireStatus(t, rt.SendAdminRequest("PUT", "/db/doc2", `{"moo":"car"}`), 409)
+	RequireStatus(t, rt.SendAdminRequest("PUT", "/db/doc2", `{"moo":"car"}`), 409)
 }
 
 func TestRawRedaction(t *testing.T) {
@@ -2038,7 +2038,7 @@ func TestRawRedaction(t *testing.T) {
 	defer rt.Close()
 
 	res := rt.SendAdminRequest("PUT", "/db/testdoc", `{"foo":"bar", "channels": ["achannel"]}`)
-	requireStatus(t, res, http.StatusCreated)
+	RequireStatus(t, res, http.StatusCreated)
 
 	// Test redact being disabled by default
 	res = rt.SendAdminRequest("GET", "/db/_raw/testdoc", ``)
@@ -2073,7 +2073,7 @@ func TestRawRedaction(t *testing.T) {
 
 	// Test that you can't use include_doc and redact at the same time
 	res = rt.SendAdminRequest("GET", "/db/_raw/testdoc?include_doc=true&redact=true", ``)
-	requireStatus(t, res, http.StatusBadRequest)
+	RequireStatus(t, res, http.StatusBadRequest)
 }
 
 func TestRawTombstone(t *testing.T) {
@@ -2084,8 +2084,8 @@ func TestRawTombstone(t *testing.T) {
 
 	// Create a doc
 	resp := rt.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"foo":"bar"}`)
-	requireStatus(t, resp, http.StatusCreated)
-	revID := respRevID(t, resp)
+	RequireStatus(t, resp, http.StatusCreated)
+	revID := RespRevID(t, resp)
 
 	resp = rt.SendAdminRequest(http.MethodGet, "/db/_raw/"+docID, ``)
 	assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
@@ -2096,8 +2096,8 @@ func TestRawTombstone(t *testing.T) {
 
 	// Delete the doc
 	resp = rt.SendAdminRequest(http.MethodDelete, "/db/"+docID+"?rev="+revID, ``)
-	requireStatus(t, resp, http.StatusOK)
-	revID = respRevID(t, resp)
+	RequireStatus(t, resp, http.StatusOK)
+	revID = RespRevID(t, resp)
 
 	resp = rt.SendAdminRequest(http.MethodGet, "/db/_raw/"+docID, ``)
 	assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
@@ -2107,8 +2107,8 @@ func TestRawTombstone(t *testing.T) {
 	assert.Contains(t, string(resp.BodyBytes()), `"_deleted":true`)
 }
 
-// respRevID returns a rev ID from the given response, or fails the given test if a rev ID was not found.
-func respRevID(t *testing.T, response *TestResponse) (revID string) {
+// RespRevID returns a rev ID from the given response, or fails the given test if a rev ID was not found.
+func RespRevID(t *testing.T, response *TestResponse) (revID string) {
 	var r struct {
 		RevID *string `json:"rev"`
 	}
@@ -2135,11 +2135,11 @@ func TestHandleCreateDB(t *testing.T) {
 	assert.NoError(t, err, "Error unmarshalling changes response")
 
 	resp := rt.SendAdminRequest(http.MethodPut, resource, string(reqBody))
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 	assert.Empty(t, resp.Body.String())
 
 	resp = rt.SendAdminRequest(http.MethodGet, resource, string(reqBody))
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	assert.NoError(t, respBody.Unmarshal([]byte(resp.Body.String())))
 	assert.Equal(t, bucket, respBody["db_name"].(string))
 	assert.Equal(t, "Online", respBody["state"].(string))
@@ -2148,7 +2148,7 @@ func TestHandleCreateDB(t *testing.T) {
 	// parsing error from the handler; handleCreateDB.
 	reqBodyJson := `"server":"walrus:","pool":"default","bucket":"albums","kv_tls_port":11207`
 	resp = rt.SendAdminRequest(http.MethodPut, "/photos/", reqBodyJson)
-	requireStatus(t, resp, http.StatusBadRequest)
+	RequireStatus(t, resp, http.StatusBadRequest)
 }
 
 func TestHandlePutDbConfigWithBackticks(t *testing.T) {
@@ -2157,7 +2157,7 @@ func TestHandlePutDbConfigWithBackticks(t *testing.T) {
 
 	// Get database info before putting config.
 	resp := rt.SendAdminRequest(http.MethodGet, "/backticks/", "")
-	requireStatus(t, resp, http.StatusNotFound)
+	RequireStatus(t, resp, http.StatusNotFound)
 
 	// Create database with valid JSON config that contains sync function enclosed in backticks.
 	syncFunc := `function(doc, oldDoc) { console.log("foo");}`
@@ -2167,11 +2167,11 @@ func TestHandlePutDbConfigWithBackticks(t *testing.T) {
         "sync": ` + "`" + syncFunc + "`" + `
 	}`
 	resp = rt.SendAdminRequest(http.MethodPut, "/backticks/", reqBodyWithBackticks)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	// Get database config after putting config.
 	resp = rt.SendAdminRequest(http.MethodGet, "/backticks/_config?include_runtime=true", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	var respBody db.Body
 	require.NoError(t, respBody.Unmarshal([]byte(resp.Body.String())))
 	assert.Equal(t, "walrus:", respBody["server"].(string))
@@ -2181,7 +2181,7 @@ func TestHandlePutDbConfigWithBackticks(t *testing.T) {
 func TestHandleDBConfig(t *testing.T) {
 	tb := base.GetTestBucket(t)
 
-	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb})
+	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb})
 	defer rt.Close()
 
 	bucket := tb.GetName()
@@ -2190,7 +2190,7 @@ func TestHandleDBConfig(t *testing.T) {
 
 	// Get database config before putting any config.
 	resp := rt.SendAdminRequest(http.MethodGet, resource, "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	var respBody db.Body
 	assert.NoError(t, respBody.Unmarshal(resp.Body.Bytes()))
 	assert.Nil(t, respBody["bucket"])
@@ -2216,12 +2216,12 @@ func TestHandleDBConfig(t *testing.T) {
 	reqBody, err := base.JSONMarshal(dbConfig)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	resp = rt.SendAdminRequest(http.MethodPut, resource, string(reqBody))
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 	assert.Empty(t, resp.Body.String())
 
 	// Get database config after putting valid database config
 	resp = rt.SendAdminRequest(http.MethodGet, resource, "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	respBody = nil
 	assert.NoError(t, respBody.Unmarshal(resp.Body.Bytes()))
 
@@ -2273,19 +2273,19 @@ func TestHandleDeleteDB(t *testing.T) {
 
 	// Try to delete the database which doesn't exists
 	resp := rt.SendAdminRequest(http.MethodDelete, "/albums/", "{}")
-	requireStatus(t, resp, http.StatusNotFound)
+	RequireStatus(t, resp, http.StatusNotFound)
 	assert.Contains(t, string(resp.BodyBytes()), "no such database")
 	var v map[string]interface{}
 	assert.NoError(t, json.Unmarshal(resp.BodyBytes(), &v), "couldn't unmarshal %s", string(resp.BodyBytes()))
 
 	// Create the database
 	resp = rt.SendAdminRequest(http.MethodPut, "/albums/", `{"server":"walrus:"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 	assert.Empty(t, resp.Body.String())
 
 	// Delete the database
 	resp = rt.SendAdminRequest(http.MethodDelete, "/albums/", "{}")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	assert.Contains(t, resp.Body.String(), "{}")
 }
 
@@ -2296,7 +2296,7 @@ func TestHandleGetConfig(t *testing.T) {
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest(http.MethodGet, "/_config", "{}")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	var respBody StartupConfig
 	assert.NoError(t, base.JSONUnmarshal([]byte(resp.Body.String()), &respBody))
@@ -2315,13 +2315,13 @@ func TestHandleGetRevTree(t *testing.T) {
     	{"_id": "foo", "type": "user", "updated_at": "2016-06-25T17:37:49.715Z", "status": "offline", "_rev": "1-789"}]}`
 
 	resp := rt.SendAdminRequest(http.MethodPost, "/db/_bulk_docs", reqBodyJson)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 	respBodyExpected := `[{"id":"foo","rev":"1-123"},{"id":"foo","rev":"1-456"},{"id":"foo","rev":"1-789"}]`
 	assert.Equal(t, respBodyExpected, resp.Body.String())
 
 	// Get the revision tree  of the user foo
 	resp = rt.SendAdminRequest(http.MethodGet, "/db/_revtree/foo", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	assert.Contains(t, resp.Body.String(), "1-123")
 	assert.Contains(t, resp.Body.String(), "1-456")
 	assert.Contains(t, resp.Body.String(), "1-789")
@@ -2336,17 +2336,17 @@ func TestHandleSGCollect(t *testing.T) {
 
 	// Check SGCollect status before triggering it; status should be stopped if no process is running.
 	resp := rt.SendAdminRequest(http.MethodGet, resource, reqBodyJson)
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	assert.Equal(t, resp.Body.String(), `{"status":"stopped"}`)
 
 	// Try to cancel SGCollect before triggering it; Error stopping sgcollect_info: not running
 	resp = rt.SendAdminRequest(http.MethodDelete, resource, reqBodyJson)
-	requireStatus(t, resp, http.StatusBadRequest)
+	RequireStatus(t, resp, http.StatusBadRequest)
 	assert.Contains(t, resp.Body.String(), "Error stopping sgcollect_info: not running")
 
 	// Try to start SGCollect with invalid body; It should throw with unexpected end of JSON input error
 	resp = rt.SendAdminRequest(http.MethodPost, resource, reqBodyJson)
-	requireStatus(t, resp, http.StatusBadRequest)
+	RequireStatus(t, resp, http.StatusBadRequest)
 }
 
 func TestSessionExpirationDateTimeFormat(t *testing.T) {
@@ -2360,7 +2360,7 @@ func TestSessionExpirationDateTimeFormat(t *testing.T) {
 
 	var body db.Body
 	response := rt.SendAdminRequest(http.MethodPost, "/db/_session", `{"name":"alice"}`)
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	expires, err := time.Parse(time.RFC3339, body["expires"].(string))
@@ -2370,7 +2370,7 @@ func TestSessionExpirationDateTimeFormat(t *testing.T) {
 	sessionId := body["session_id"].(string)
 	require.NotEmpty(t, sessionId, "Couldn't parse sessionID from response body")
 	response = rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/db/_session/%s", sessionId), "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	expires, err = time.Parse(time.RFC3339, body["expires"].(string))
@@ -2539,7 +2539,7 @@ func TestConfigRedaction(t *testing.T) {
 // Reproduces panic seen in CBG-1053
 func TestAdhocReplicationStatus(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll, base.KeyReplicate)
-	rt := NewRestTester(t, &RestTesterConfig{sgReplicateEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{SgReplicateEnabled: true})
 	defer rt.Close()
 
 	srv := httptest.NewServer(rt.TestAdminHandler())
@@ -2554,7 +2554,7 @@ func TestAdhocReplicationStatus(t *testing.T) {
 	}`
 
 	resp := rt.SendAdminRequest("PUT", "/db/_replication/pushandpull-with-target-oneshot-adhoc", replConf)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	// With the error hitting the replicationStatus endpoint will either return running, if not completed, and once
 	// completed panics. With the fix after running it'll return a 404 as replication no longer exists.
@@ -2593,7 +2593,7 @@ func TestUserXattrsRawGet(t *testing.T) {
 	}
 
 	resp := rt.SendAdminRequest("PUT", "/db/"+docKey, "{}")
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 	require.NoError(t, rt.WaitForPendingChanges())
 
 	_, err := userXattrStore.WriteUserXattr(docKey, xattrKey, "val")
@@ -2604,7 +2604,7 @@ func TestUserXattrsRawGet(t *testing.T) {
 	})
 
 	resp = rt.SendAdminRequest("GET", "/db/_raw/"+docKey, "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	var RawReturn struct {
 		Meta struct {
@@ -2623,15 +2623,15 @@ func TestRolePurge(t *testing.T) {
 
 	// Create role
 	resp := rt.SendAdminRequest("PUT", "/db/_role/role", `{"admin_channels":["channel"]}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	// Delete role
 	resp = rt.SendAdminRequest("DELETE", "/db/_role/role", ``)
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	// Ensure role is gone
 	resp = rt.SendAdminRequest("GET", "/db/_role/role", ``)
-	requireStatus(t, resp, http.StatusNotFound)
+	RequireStatus(t, resp, http.StatusNotFound)
 
 	// Ensure role is 'soft-deleted' and we can still get the doc
 	role, err := rt.GetDatabase().Authenticator(base.TestCtx(t)).GetRoleIncDeleted("role")
@@ -2640,11 +2640,11 @@ func TestRolePurge(t *testing.T) {
 
 	// Re-create role
 	resp = rt.SendAdminRequest("PUT", "/db/_role/role", `{"admin_channels":["channel"]}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	// Delete role again but with purge flag
 	resp = rt.SendAdminRequest("DELETE", "/db/_role/role?purge=true", ``)
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	// Ensure role is purged, can't access at all
 	role, err = rt.GetDatabase().Authenticator(base.TestCtx(t)).GetRoleIncDeleted("role")
@@ -2653,7 +2653,7 @@ func TestRolePurge(t *testing.T) {
 
 	// Ensure role returns 404 via REST call
 	resp = rt.SendAdminRequest("GET", "/db/_role/role", ``)
-	requireStatus(t, resp, http.StatusNotFound)
+	RequireStatus(t, resp, http.StatusNotFound)
 }
 
 func TestSoftDeleteCasMismatch(t *testing.T) {
@@ -2666,9 +2666,9 @@ func TestSoftDeleteCasMismatch(t *testing.T) {
 
 	// Create role
 	resp := rt.SendAdminRequest("PUT", "/db/_role/role", `{"admin_channels":["channel"]}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
-	leakyBucket, ok := base.AsLeakyBucket(rt.testBucket)
+	leakyBucket, ok := base.AsLeakyBucket(rt.TestBucket)
 	require.True(t, ok)
 
 	// Set callback to trigger a DELETE AFTER an update. This will trigger a CAS mismatch.
@@ -2678,12 +2678,12 @@ func TestSoftDeleteCasMismatch(t *testing.T) {
 		if triggerCallback {
 			triggerCallback = false
 			resp = rt.SendAdminRequest("DELETE", "/db/_role/role", ``)
-			requireStatus(t, resp, http.StatusOK)
+			RequireStatus(t, resp, http.StatusOK)
 		}
 	})
 
 	resp = rt.SendAdminRequest("PUT", "/db/_role/role", `{"admin_channels":["chan"]}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 }
 
 func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
@@ -2723,21 +2723,21 @@ func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
 
 			// Create role
 			resp := rt.SendAdminRequest("PUT", "/db/_role/role", `{"admin_channels":["channel"]}`)
-			requireStatus(t, resp, http.StatusCreated)
+			RequireStatus(t, resp, http.StatusCreated)
 
 			// Create user
 			resp = rt.SendAdminRequest("PUT", "/db/_user/user", `{"password": "pass"}`)
-			requireStatus(t, resp, http.StatusCreated)
+			RequireStatus(t, resp, http.StatusCreated)
 
 			// Add channel to role
 			resp = rt.SendAdminRequest("PUT", "/db/roleChannels", `{"channels": "inherit"}`)
-			requireStatus(t, resp, http.StatusCreated)
+			RequireStatus(t, resp, http.StatusCreated)
 
 			// Add role to user
 			resp = rt.SendAdminRequest("PUT", "/db/userRoles", `{"roles": "role:role"}`)
-			requireStatus(t, resp, http.StatusCreated)
+			RequireStatus(t, resp, http.StatusCreated)
 
-			leakyBucket, ok := base.AsLeakyBucket(rt.testBucket)
+			leakyBucket, ok := base.AsLeakyBucket(rt.TestBucket)
 			require.True(t, ok)
 
 			triggerCallback := false
@@ -2745,7 +2745,7 @@ func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
 				if triggerCallback {
 					triggerCallback = false
 					resp = rt.SendAdminRequest("DELETE", "/db/_role/role", ``)
-					requireStatus(t, resp, http.StatusOK)
+					RequireStatus(t, resp, http.StatusOK)
 				}
 			})
 
@@ -2843,7 +2843,7 @@ func TestChannelNameSizeWarningBoundaries(t *testing.T) {
 			chanName := strings.Repeat("A", test.channelLength)
 			tr := rt.SendAdminRequest("PUT", "/db/"+docId, `{"chan":"`+chanName+`"}`)
 
-			requireStatus(t, tr, http.StatusCreated)
+			RequireStatus(t, tr, http.StatusCreated)
 			chanNameWarnCountAfter := rt.ServerContext().Database(ctx, "db").DbStats.Database().WarnChannelNameSizeCount.Value()
 			if test.expectWarn {
 				assert.Equal(t, chanNameWarnCountBefore+1, chanNameWarnCountAfter)
@@ -2864,13 +2864,13 @@ func TestChannelNameSizeWarningUpdateExistingDoc(t *testing.T) {
 	chanName := strings.Repeat("B", int(base.DefaultWarnThresholdChannelNameSize)+5)
 	t.Run("Update doc without changing channel", func(t *testing.T) {
 		tr := rt.SendAdminRequest("PUT", "/db/replace", `{"chan":"`+chanName+`"}`) // init doc
-		requireStatus(t, tr, http.StatusCreated)
+		RequireStatus(t, tr, http.StatusCreated)
 
 		ctx := rt.Context()
 		before := rt.ServerContext().Database(ctx, "db").DbStats.Database().WarnChannelNameSizeCount.Value()
-		revId := respRevID(t, tr)
+		revId := RespRevID(t, tr)
 		tr = rt.SendAdminRequest("PUT", "/db/replace?rev="+revId, `{"chan":"`+chanName+`", "data":"test"}`)
-		requireStatus(t, tr, http.StatusCreated)
+		RequireStatus(t, tr, http.StatusCreated)
 		after := rt.ServerContext().Database(ctx, "db").DbStats.Database().WarnChannelNameSizeCount.Value()
 		assert.Equal(t, before+1, after)
 	})
@@ -2888,14 +2888,14 @@ func TestChannelNameSizeWarningDocChannelUpdate(t *testing.T) {
 
 		chanName := strings.Repeat("C", channelLength)
 		tr := rt.SendAdminRequest("PUT", "/db/replaceNewChannel", `{"chan":"`+chanName+`"}`) // init doc
-		requireStatus(t, tr, http.StatusCreated)
+		RequireStatus(t, tr, http.StatusCreated)
 
 		ctx := rt.Context()
 		before := rt.ServerContext().Database(ctx, "db").DbStats.Database().WarnChannelNameSizeCount.Value()
-		revId := respRevID(t, tr)
+		revId := RespRevID(t, tr)
 		chanName = strings.Repeat("D", channelLength+5)
 		tr = rt.SendAdminRequest("PUT", "/db/replaceNewChannel?rev="+revId, fmt.Sprintf(`{"chan":"`+chanName+`", "data":"test"}`))
-		requireStatus(t, tr, http.StatusCreated)
+		RequireStatus(t, tr, http.StatusCreated)
 		after := rt.ServerContext().Database(ctx, "db").DbStats.Database().WarnChannelNameSizeCount.Value()
 		assert.Equal(t, before+1, after)
 	})
@@ -2912,13 +2912,13 @@ func TestChannelNameSizeWarningDeleteChannel(t *testing.T) {
 	t.Run("Delete channel over max length", func(t *testing.T) {
 		chanName := strings.Repeat("F", channelLength)
 		tr := rt.SendAdminRequest("PUT", "/db/deleteme", `{"chan":"`+chanName+`"}`) // init channel
-		requireStatus(t, tr, http.StatusCreated)
+		RequireStatus(t, tr, http.StatusCreated)
 
 		ctx := rt.Context()
 		before := rt.ServerContext().Database(ctx, "db").DbStats.Database().WarnChannelNameSizeCount.Value()
-		revId := respRevID(t, tr)
+		revId := RespRevID(t, tr)
 		tr = rt.SendAdminRequest("DELETE", "/db/deleteme?rev="+revId, "")
-		requireStatus(t, tr, http.StatusOK)
+		RequireStatus(t, tr, http.StatusOK)
 		after := rt.ServerContext().Database(ctx, "db").DbStats.Database().WarnChannelNameSizeCount.Value()
 		assert.Equal(t, before, after)
 	})
@@ -3081,12 +3081,12 @@ func TestConfigEndpoint(t *testing.T) {
 			// Request to _config
 			resp := rt.SendAdminRequest("PUT", "/_config", testCase.Config)
 			if testCase.ExpectError {
-				requireStatus(t, resp, http.StatusBadRequest)
+				RequireStatus(t, resp, http.StatusBadRequest)
 				t.Logf("got response: %s", resp.BodyBytes())
 				return
 			}
 
-			requireStatus(t, resp, http.StatusOK)
+			RequireStatus(t, resp, http.StatusOK)
 
 			assert.Equal(t, testCase.ConsoleLevel, *base.ConsoleLogLevel())
 			assert.Equal(t, testCase.ConsoleLogKeys, base.ConsoleLogKey().EnabledLogKeys())
@@ -3106,18 +3106,18 @@ func TestLoggingDeprecationWarning(t *testing.T) {
 
 	// Create doc just to startup server and force any initial warnings
 	resp := rt.SendAdminRequest("PUT", "/db/doc", "{}")
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	warnCountBefore := base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value()
 
 	resp = rt.SendAdminRequest("GET", "/_logging", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	warnCountAfter := base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value()
 	assert.Equal(t, int64(1), warnCountAfter-warnCountBefore)
 
 	resp = rt.SendAdminRequest("PUT", "/_logging", "{}")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	warnCountAfter2 := base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value()
 	assert.Equal(t, int64(1), warnCountAfter2-warnCountAfter)
@@ -3132,7 +3132,7 @@ func TestInitialStartupConfig(t *testing.T) {
 
 	// Get config
 	resp := rt.SendAdminRequest("GET", "/_config", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	var initialStartupConfig StartupConfig
 	err := json.Unmarshal(resp.BodyBytes(), &initialStartupConfig)
@@ -3150,7 +3150,7 @@ func TestInitialStartupConfig(t *testing.T) {
 
 	// Get config
 	resp = rt.SendAdminRequest("GET", "/_config", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	initialStartupConfig = StartupConfig{}
 	err = json.Unmarshal(resp.BodyBytes(), &initialStartupConfig)
 	require.NoError(t, err)
@@ -3180,7 +3180,7 @@ func TestIncludeRuntimeStartupConfig(t *testing.T) {
 
 	// Get config
 	resp := rt.SendAdminRequest("GET", "/_config?include_runtime=true", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	var runtimeServerConfigResponse RunTimeServerConfigResponse
 	err = json.Unmarshal(resp.BodyBytes(), &runtimeServerConfigResponse)
@@ -3205,14 +3205,14 @@ func TestIncludeRuntimeStartupConfig(t *testing.T) {
 		}
 	}
 	`)
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	// Update revs limit too so we can check db config
 	dbConfig := rt.ServerContext().GetDatabaseConfig("db")
 	dbConfig.RevsLimit = base.Uint32Ptr(100)
 
 	resp = rt.SendAdminRequest("GET", "/_config?include_runtime=true", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	err = json.Unmarshal(resp.BodyBytes(), &runtimeServerConfigResponse)
 	require.NoError(t, err)
 
@@ -3224,7 +3224,7 @@ func TestIncludeRuntimeStartupConfig(t *testing.T) {
 	assert.Equal(t, "debug", runtimeServerConfigResponse.Logging.Console.LogLevel.String())
 
 	resp = rt.SendAdminRequest("GET", "/_config?include_runtime=true&redact=true", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	err = json.Unmarshal(resp.BodyBytes(), &runtimeServerConfigResponse)
 	require.NoError(t, err)
 
@@ -3240,10 +3240,10 @@ func TestIncludeRuntimeStartupConfig(t *testing.T) {
 	}`
 
 	response := rt.SendAdminRequest("PUT", "/db/_replication/repl", string(replicationConfig))
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	resp = rt.SendAdminRequest("GET", "/_config?include_runtime=true", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	err = json.Unmarshal(resp.BodyBytes(), &runtimeServerConfigResponse)
 	require.NoError(t, err)
 
@@ -3268,7 +3268,7 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 	// Start SG with no databases
 	config := bootstrapStartupConfigForTest(t)
 	ctx := base.TestCtx(t)
-	sc, err := setupServerContext(ctx, &config, true)
+	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	defer func() {
 		sc.Close(ctx)
@@ -3329,7 +3329,7 @@ func TestDbConfigCredentials(t *testing.T) {
 	// Start SG with no databases
 	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(ctx, &config, true)
+	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	defer func() {
 		sc.Close(ctx)
@@ -3394,7 +3394,7 @@ func TestInvalidDBConfig(t *testing.T) {
 	// Start SG with no databases
 	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(ctx, &config, true)
+	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	defer func() {
 		sc.Close(ctx)
@@ -3448,7 +3448,7 @@ func TestCreateDbOnNonExistentBucket(t *testing.T) {
 	// Start SG with no databases
 	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(ctx, &config, true)
+	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	defer func() {
 		sc.Close(ctx)
@@ -3481,7 +3481,7 @@ func TestPutDbConfigChangeName(t *testing.T) {
 	// Start SG with no databases
 	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(ctx, &config, true)
+	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	defer func() {
 		sc.Close(ctx)
@@ -3523,7 +3523,7 @@ func TestPutDBConfigOIDC(t *testing.T) {
 	// Start SG with no databases
 	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(ctx, &config, true)
+	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	defer func() {
 		sc.Close(ctx)
@@ -3608,7 +3608,7 @@ func TestNotExistentDBRequest(t *testing.T) {
 		t.Skip("Test requires Couchbase Server")
 	}
 
-	rt := NewRestTester(t, &RestTesterConfig{adminInterfaceAuthentication: true})
+	rt := NewRestTester(t, &RestTesterConfig{AdminInterfaceAuthentication: true})
 	defer rt.Close()
 
 	eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
@@ -3619,11 +3619,11 @@ func TestNotExistentDBRequest(t *testing.T) {
 
 	// Request to non-existent db with valid credentials
 	resp := rt.SendAdminRequestWithAuth("PUT", "/dbx/_config", "", "random", "password")
-	requireStatus(t, resp, http.StatusForbidden)
+	RequireStatus(t, resp, http.StatusForbidden)
 
 	// Request to non-existent db with invalid credentials
 	resp = rt.SendAdminRequestWithAuth("PUT", "/dbx/_config", "", "random", "passwordx")
-	requireStatus(t, resp, http.StatusUnauthorized)
+	RequireStatus(t, resp, http.StatusUnauthorized)
 }
 
 func TestConfigsIncludeDefaults(t *testing.T) {
@@ -3640,7 +3640,7 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 	// Start SG with no databases
 	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(ctx, &config, true)
+	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	defer func() {
 		sc.Close(ctx)
@@ -3726,7 +3726,7 @@ func TestLegacyCredentialInheritance(t *testing.T) {
 	// Start SG with no databases
 	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(ctx, &config, false)
+	sc, err := SetupServerContext(ctx, &config, false)
 	require.NoError(t, err)
 	defer func() {
 		sc.Close(ctx)
@@ -3814,7 +3814,7 @@ func TestDbOfflineConfigPersistent(t *testing.T) {
 	// Start SG with no databases
 	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(ctx, &config, true)
+	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	defer func() {
 		sc.Close(ctx)
@@ -3892,7 +3892,7 @@ func TestDbConfigPersistentSGVersions(t *testing.T) {
 	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(time.Millisecond * 250)
 
 	ctx := base.TestCtx(t)
-	sc, err := setupServerContext(ctx, &config, true)
+	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	ctx = sc.SetContextLogID(ctx, "initial")
 
@@ -3980,7 +3980,7 @@ func TestDbConfigPersistentSGVersions(t *testing.T) {
 	require.NoError(t, <-serverErr)
 
 	// Start a new SG node and ensure we *can* load the "newer" config version on initial startup, to support downgrade
-	sc, err = setupServerContext(ctx, &config, true)
+	sc, err = SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	ctx = sc.SetContextLogID(ctx, "newerconfig")
 	defer func() {
@@ -4010,7 +4010,7 @@ func TestDeleteFunctionsWhileDbOffline(t *testing.T) {
 	// Start SG with bootstrap credentials filled
 	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(ctx, &config, true)
+	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	serverErr := make(chan error, 0)
 	go func() {
@@ -4096,7 +4096,7 @@ func TestSetFunctionsWhileDbOffline(t *testing.T) {
 	// Start SG with bootstrap credentials filled
 	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(ctx, &config, true)
+	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	serverErr := make(chan error, 0)
 	go func() {
@@ -4162,7 +4162,7 @@ func TestEmptyStringJavascriptFunctions(t *testing.T) {
 	// Start SG with no databases
 	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(ctx, &config, true)
+	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	defer func() {
 		sc.Close(ctx)
@@ -4215,11 +4215,11 @@ func TestDisablePasswordAuthThroughAdminAPI(t *testing.T) {
 	defer rt.Close()
 
 	res := rt.SendAdminRequest(http.MethodPost, "/db/_config", `{"bucket":"`+rt.Bucket().GetName()+`","num_index_replicas":0,"disable_password_auth": true}`)
-	requireStatus(t, res, http.StatusCreated)
+	RequireStatus(t, res, http.StatusCreated)
 	assert.True(t, rt.GetDatabase().Options.DisablePasswordAuthentication)
 
 	res = rt.SendAdminRequest(http.MethodPost, "/db/_config", `{"bucket":"`+rt.Bucket().GetName()+`","num_index_replicas":0,"disable_password_auth": false}`)
-	requireStatus(t, res, http.StatusCreated)
+	RequireStatus(t, res, http.StatusCreated)
 	assert.False(t, rt.GetDatabase().Options.DisablePasswordAuthentication)
 }
 
@@ -4240,7 +4240,7 @@ func TestGroupIDReplications(t *testing.T) {
 	defer activeBucket.Close()
 
 	// Set up passive bucket RT
-	rt := NewRestTester(t, &RestTesterConfig{TestBucket: passiveBucket})
+	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: passiveBucket})
 	defer rt.Close()
 
 	// Make rt listen on an actual HTTP port, so it can receive replications
@@ -4265,11 +4265,11 @@ func TestGroupIDReplications(t *testing.T) {
 		config.API.MetricsInterface = fmt.Sprintf("127.0.0.1:%d", 4986+bootstrapTestPortOffset+portOffset)
 		config.Bootstrap.ConfigGroupID = group
 		if group == "" {
-			config.Bootstrap.ConfigGroupID = persistentConfigDefaultGroupID
+			config.Bootstrap.ConfigGroupID = PersistentConfigDefaultGroupID
 		}
 
 		ctx := base.TestCtx(t)
-		sc, err := setupServerContext(ctx, &config, true)
+		sc, err := SetupServerContext(ctx, &config, true)
 		require.NoError(t, err)
 		serverContexts = append(serverContexts, sc)
 		ctx = sc.SetContextLogID(ctx, config.Bootstrap.ConfigGroupID)
@@ -4305,7 +4305,7 @@ func TestGroupIDReplications(t *testing.T) {
 			InitialState:           db.ReplicationStateRunning,
 			ConflictResolutionType: db.ConflictResolverDefault,
 		}
-		resp := bootstrapAdminRequestCustomHost(t, http.MethodPost, adminHosts[i], "/db/_replication/", marshalConfig(t, replicationConfig))
+		resp := bootstrapAdminRequestCustomHost(t, http.MethodPost, adminHosts[i], "/db/_replication/", MarshalConfig(t, replicationConfig))
 		resp.requireStatus(http.StatusCreated)
 	}
 
@@ -4346,10 +4346,10 @@ func TestDeleteDatabasePointingAtSameBucket(t *testing.T) {
 	}
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 	tb := base.GetTestBucket(t)
-	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb})
+	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb})
 	defer rt.Close()
 	resp := rt.SendAdminRequest(http.MethodDelete, "/db/", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	// Make another database that uses import in-order to trigger the panic instantly instead of having to time.Sleep
 	resp = rt.SendAdminRequest(http.MethodPut, "/db1/", fmt.Sprintf(`{
 		"bucket": "%s",
@@ -4368,7 +4368,7 @@ func TestDeleteDatabasePointingAtSameBucketPersistent(t *testing.T) {
 	// Start SG with no databases in bucket(s)
 	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(ctx, &config, true)
+	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	serverErr := make(chan error, 0)
 	defer func() {
@@ -4496,7 +4496,7 @@ function (doc) {
 }
 `
 			resp := senderRT.SendAdminRequest("POST", "/db/_bulk_docs", bulkDocsBody)
-			requireStatus(t, resp, http.StatusCreated)
+			RequireStatus(t, resp, http.StatusCreated)
 
 			err := senderRT.WaitForPendingChanges()
 			require.NoError(t, err)
@@ -4515,17 +4515,17 @@ function (doc) {
 				}`
 
 			resp = activeRT.SendAdminRequest("PUT", "/db/_replication/"+replName, replConf)
-			requireStatus(t, resp, http.StatusCreated)
+			RequireStatus(t, resp, http.StatusCreated)
 
 			activeCtx := activeRT.Context()
 			err = activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeCtx)
 			require.NoError(t, err)
-			activeRT.waitForReplicationStatus(replName, db.ReplicationStateRunning)
+			activeRT.WaitForReplicationStatus(replName, db.ReplicationStateRunning)
 
 			value, _ := base.WaitForStat(receiverRT.GetDatabase().DbStats.Database().NumDocWrites.Value, 6)
 			assert.EqualValues(t, 6, value)
 
-			changesResults, err := receiverRT.waitForChanges(6, "/db/_changes?since=0&include_docs=true", "", true)
+			changesResults, err := receiverRT.WaitForChanges(6, "/db/_changes?since=0&include_docs=true", "", true)
 			assert.NoError(t, err)
 			assert.Len(t, changesResults.Results, 6)
 			// Check the docs are alices docs
@@ -4538,7 +4538,7 @@ function (doc) {
 			// Stop and remove replicator (to stop checkpointing after teardown causing panic)
 			_, err = activeRT.GetDatabase().SGReplicateMgr.PutReplicationStatus(replName, "stop")
 			require.NoError(t, err)
-			activeRT.waitForReplicationStatus(replName, db.ReplicationStateStopped)
+			activeRT.WaitForReplicationStatus(replName, db.ReplicationStateStopped)
 			err = activeRT.GetDatabase().SGReplicateMgr.DeleteReplication(replName)
 			require.NoError(t, err)
 
@@ -4554,8 +4554,8 @@ function (doc) {
 					}`
 
 			resp = activeRT.SendAdminRequest("PUT", "/db/_replication/"+replName, replConf)
-			requireStatus(t, resp, http.StatusCreated)
-			activeRT.waitForReplicationStatus(replName, db.ReplicationStateRunning)
+			RequireStatus(t, resp, http.StatusCreated)
+			activeRT.WaitForReplicationStatus(replName, db.ReplicationStateRunning)
 
 			value, _ = base.WaitForStat(receiverRT.GetDatabase().DbStats.Database().NumDocWrites.Value, 10)
 			assert.EqualValues(t, 10, value)
@@ -4563,7 +4563,7 @@ function (doc) {
 			// Stop and remove replicator
 			_, err = activeRT.GetDatabase().SGReplicateMgr.PutReplicationStatus(replName, "stop")
 			require.NoError(t, err)
-			activeRT.waitForReplicationStatus(replName, db.ReplicationStateStopped)
+			activeRT.WaitForReplicationStatus(replName, db.ReplicationStateStopped)
 			err = activeRT.GetDatabase().SGReplicateMgr.DeleteReplication(replName)
 			require.NoError(t, err)
 		})
@@ -4597,7 +4597,7 @@ func TestReplicatorDeprecatedCredentials(t *testing.T) {
 	err := activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeCtx)
 	require.NoError(t, err)
 
-	rev := activeRT.createDoc(t, "test")
+	rev := activeRT.CreateDoc(t, "test")
 
 	replConfig := `
 {
@@ -4610,15 +4610,15 @@ func TestReplicatorDeprecatedCredentials(t *testing.T) {
 }
 `
 	resp := activeRT.SendAdminRequest("POST", "/db/_replication/", replConfig)
-	requireStatus(t, resp, 201)
+	RequireStatus(t, resp, 201)
 
-	activeRT.waitForReplicationStatus(t.Name(), db.ReplicationStateRunning)
+	activeRT.WaitForReplicationStatus(t.Name(), db.ReplicationStateRunning)
 
-	err = passiveRT.waitForRev("test", rev)
+	err = passiveRT.WaitForRev("test", rev)
 	require.NoError(t, err)
 
 	resp = activeRT.SendAdminRequest("GET", "/db/_replication/"+t.Name(), "")
-	requireStatus(t, resp, 200)
+	RequireStatus(t, resp, 200)
 
 	var config db.ReplicationConfig
 	err = json.Unmarshal(resp.BodyBytes(), &config)
@@ -4630,7 +4630,7 @@ func TestReplicatorDeprecatedCredentials(t *testing.T) {
 
 	_, err = activeRT.GetDatabase().SGReplicateMgr.PutReplicationStatus(t.Name(), "stop")
 	require.NoError(t, err)
-	activeRT.waitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
+	activeRT.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
 	err = activeRT.GetDatabase().SGReplicateMgr.DeleteReplication(t.Name())
 	require.NoError(t, err)
 }
@@ -4669,16 +4669,16 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 }
 `
 	resp := activeRT.SendAdminRequest("POST", "/db/_replication/", replConfig)
-	requireStatus(t, resp, 201)
+	RequireStatus(t, resp, 201)
 
-	activeRT.waitForReplicationStatus(t.Name(), db.ReplicationStateRunning)
+	activeRT.WaitForReplicationStatus(t.Name(), db.ReplicationStateRunning)
 
-	err = passiveRT.waitForRev("test", rev)
+	err = passiveRT.WaitForRev("test", rev)
 	require.NoError(t, err)
 
 	_, err = activeRT.GetDatabase().SGReplicateMgr.PutReplicationStatus(t.Name(), "stop")
 	require.NoError(t, err)
-	activeRT.waitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
+	activeRT.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
 
 	// Check checkpoint document was wrote to bucket with correct status
 	// _sync:local:checkpoint/sgr2cp:push:TestReplicatorCheckpointOnStop
@@ -4773,15 +4773,15 @@ func TestApiInternalPropertiesHandling(t *testing.T) {
 
 			resp := rt.SendAdminRequest("PUT", "/db/"+docID, string(rawBody))
 			if test.expectedErrorStatus != nil {
-				requireStatus(t, resp, *test.expectedErrorStatus)
+				RequireStatus(t, resp, *test.expectedErrorStatus)
 				return
 			}
-			requireStatus(t, resp, http.StatusCreated)
+			RequireStatus(t, resp, http.StatusCreated)
 
 			var bucketDoc map[string]interface{}
 			_, err = rt.Bucket().Get(docID, &bucketDoc)
 			assert.NoError(t, err)
-			body := rt.getDoc(docID)
+			body := rt.GetDoc(docID)
 			// Confirm input body is in the bucket doc
 			if test.skipDocContentsVerification == nil || !*test.skipDocContentsVerification {
 				for k, v := range test.inputBody {
@@ -4849,8 +4849,8 @@ func TestPutIDRevMatchBody(t *testing.T) {
 	defer rt.Close()
 	// Create document to create rev from
 	resp := rt.SendAdminRequest("PUT", "/db/doc", "{}")
-	requireStatus(t, resp, 201)
-	rev := respRevID(t, resp)
+	RequireStatus(t, resp, 201)
+	rev := RespRevID(t, resp)
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
@@ -4865,13 +4865,13 @@ func TestPutIDRevMatchBody(t *testing.T) {
 
 			resp = rt.SendAdminRequest("PUT", "/db/"+docID+"?rev="+docRev, docBody)
 			if test.expectError {
-				requireStatus(t, resp, 400)
+				RequireStatus(t, resp, 400)
 				return
 			}
-			requireStatus(t, resp, 201)
+			RequireStatus(t, resp, 201)
 			if test.docID == "" {
 				// Update rev to branch off for next test
-				rev = respRevID(t, resp)
+				rev = RespRevID(t, resp)
 			}
 		})
 	}
@@ -4889,24 +4889,24 @@ func TestPublicChanGuestAccess(t *testing.T) {
 
 	// Create a document on the public channel
 	resp := rt.SendAdminRequest(http.MethodPut, "/db/doc", `{"channels": ["!"], "foo": "bar"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	// Check guest user has access to public channel
 	resp = rt.SendRequest(http.MethodGet, "/db/doc", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	assert.EqualValues(t, "bar", resp.GetRestDocument()["foo"])
 
 	resp = rt.SendAdminRequest(http.MethodGet, "/db/_user/GUEST", ``)
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	fmt.Println("GUEST user:", resp.Body.String())
 	assert.EqualValues(t, []interface{}{"!"}, resp.GetRestDocument()["all_channels"])
 
 	// Confirm guest user cannot access other channels it has no access too
 	resp = rt.SendAdminRequest(http.MethodPut, "/db/docNoAccess", `{"channels": ["cookie"], "foo": "bar"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	resp = rt.SendRequest(http.MethodGet, "/db/docNoAccess", "")
-	requireStatus(t, resp, http.StatusForbidden)
+	RequireStatus(t, resp, http.StatusForbidden)
 }
 
 func setServerPurgeInterval(t *testing.T, rt *RestTester, newPurgeInterval string) {
@@ -5000,22 +5000,22 @@ func TestResyncPersistence(t *testing.T) {
 	noCloseTB := tb.NoCloseClone()
 
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		TestBucket: noCloseTB,
+		CustomTestBucket: noCloseTB,
 	})
 
 	rt2 := NewRestTester(t, &RestTesterConfig{
-		TestBucket: tb,
+		CustomTestBucket: tb,
 	})
 
 	defer rt2.Close()
 	defer rt1.Close()
 
 	// Create a document to process through resync
-	rt1.createDoc(t, "doc1")
+	rt1.CreateDoc(t, "doc1")
 
 	// Start resync
 	resp := rt1.SendAdminRequest("POST", "/db/_offline", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	waitAndAssertCondition(t, func() bool {
 		state := atomic.LoadUint32(&rt1.GetDatabase().State)
@@ -5023,7 +5023,7 @@ func TestResyncPersistence(t *testing.T) {
 	})
 
 	resp = rt1.SendAdminRequest("POST", "/db/_resync?action=start", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	// Wait for resync to complete
 	var resyncManagerStatus db.ResyncManagerResponse
@@ -5043,7 +5043,7 @@ func TestResyncPersistence(t *testing.T) {
 
 	// Check statuses match
 	resp2 := rt2.SendAdminRequest("GET", "/db/_resync", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	fmt.Printf("RT1 Resync Status: %s\n", resp.BodyBytes())
 	fmt.Printf("RT2 Resync Status: %s\n", resp2.BodyBytes())
 	assert.Equal(t, resp.BodyBytes(), resp2.BodyBytes())
@@ -5074,7 +5074,7 @@ func TestPerDBCredsOverride(t *testing.T) {
 	}
 
 	ctx := base.TestCtx(t)
-	sc, err := setupServerContext(ctx, &config, true)
+	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 
 	serverErr := make(chan error, 0)

--- a/rest/admin_query_api_test.go
+++ b/rest/admin_query_api_test.go
@@ -661,13 +661,13 @@ func newRestTesterForUserQueries(t *testing.T, queryConfig DbConfig) *RestTester
 	})
 
 	_ = rt.Bucket() // initializes the bucket as a side effect
-	dbConfig := dbConfigForTestBucket(rt.testBucket)
+	dbConfig := dbConfigForTestBucket(rt.TestBucket)
 	dbConfig.UserFunctions = queryConfig.UserFunctions
 	dbConfig.UserQueries = queryConfig.UserQueries
 	dbConfig.GraphQL = queryConfig.GraphQL
 
 	resp, err := rt.CreateDatabase("db", dbConfig)
-	if !assert.NoError(t, err) || !assertStatus(t, resp, 201) {
+	if !assert.NoError(t, err) || !AssertStatus(t, resp, 201) {
 		rt.Close()
 		t.FailNow()
 		return nil // (never reached)

--- a/rest/api_benchmark_test.go
+++ b/rest/api_benchmark_test.go
@@ -103,7 +103,7 @@ func BenchmarkReadOps_Get(b *testing.B) {
 				if bm.asUser == "" {
 					getResponse = rt.SendAdminRequest("GET", bm.URI, "")
 				} else {
-					getResponse = rt.Send(requestByUser("GET", bm.URI, "", bm.asUser))
+					getResponse = rt.Send(RequestByUser("GET", bm.URI, "", bm.asUser))
 				}
 				b.StopTimer()
 				if getResponse.Code != 200 {
@@ -171,7 +171,7 @@ func BenchmarkReadOps_GetRevCacheMisses(b *testing.B) {
 				if bm.asUser == "" {
 					getResponse = rt.SendAdminRequest("GET", docURI, "")
 				} else {
-					getResponse = rt.Send(requestByUser("GET", docURI, "", bm.asUser))
+					getResponse = rt.Send(RequestByUser("GET", docURI, "", bm.asUser))
 				}
 				b.StopTimer()
 				if getResponse.Code != 200 {
@@ -244,7 +244,7 @@ func BenchmarkReadOps_Changes(b *testing.B) {
 				if bm.asUser == "" {
 					changesResponse = rt.SendAdminRequest("GET", bm.URI, "")
 				} else {
-					changesResponse = rt.Send(requestByUser("GET", bm.URI, "", bm.asUser))
+					changesResponse = rt.Send(RequestByUser("GET", bm.URI, "", bm.asUser))
 				}
 				b.StopTimer()
 				if changesResponse.Code != 200 {
@@ -301,7 +301,7 @@ func BenchmarkReadOps_RevsDiff(b *testing.B) {
 				if bm.asUser == "" {
 					getResponse = rt.SendAdminRequest("POST", bm.URI, revsDiffBody)
 				} else {
-					getResponse = rt.Send(requestByUser("POST", bm.URI, revsDiffBody, bm.asUser))
+					getResponse = rt.Send(RequestByUser("POST", bm.URI, revsDiffBody, bm.asUser))
 				}
 				b.StopTimer()
 				if getResponse.Code != 200 {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -56,27 +56,27 @@ func TestRoot(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendRequest("GET", "/", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, "Welcome", body["couchdb"])
 
 	response = rt.SendRequest("HEAD", "/", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	response = rt.SendRequest("OPTIONS", "/", "")
-	requireStatus(t, response, 204)
+	RequireStatus(t, response, 204)
 	assert.Equal(t, "GET, HEAD", response.Header().Get("Allow"))
 	response = rt.SendRequest("PUT", "/", "")
-	requireStatus(t, response, 405)
+	RequireStatus(t, response, 405)
 	assert.Equal(t, "GET, HEAD", response.Header().Get("Allow"))
 }
 
 func TestDBRoot(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	response := rt.SendRequest("GET", "/db/", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	var body db.Body
 	err := base.JSONUnmarshal(response.Body.Bytes(), &body)
 	assert.NoError(t, err)
@@ -85,9 +85,9 @@ func TestDBRoot(t *testing.T) {
 	assert.Equal(t, "Online", body["state"])
 
 	response = rt.SendRequest("HEAD", "/db/", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	response = rt.SendRequest("OPTIONS", "/db/", "")
-	requireStatus(t, response, 204)
+	RequireStatus(t, response, 204)
 	assert.Equal(t, "GET, HEAD, POST, PUT", response.Header().Get("Allow"))
 }
 
@@ -106,7 +106,7 @@ func TestDisablePublicBasicAuth(t *testing.T) {
 	ctx := rt.Context()
 
 	response := rt.SendRequest(http.MethodGet, "/db/", "")
-	requireStatus(t, response, http.StatusUnauthorized)
+	RequireStatus(t, response, http.StatusUnauthorized)
 	assert.NotContains(t, response.Header(), "WWW-Authenticate", "expected to not receive a WWW-Auth header when password auth is disabled")
 
 	// Double-check that even if we provide valid credentials we still won't be let in
@@ -115,26 +115,26 @@ func TestDisablePublicBasicAuth(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(user))
 
-	response = rt.Send(requestByUser(http.MethodGet, "/db/", "", "user1"))
-	requireStatus(t, response, http.StatusUnauthorized)
+	response = rt.Send(RequestByUser(http.MethodGet, "/db/", "", "user1"))
+	RequireStatus(t, response, http.StatusUnauthorized)
 	assert.NotContains(t, response.Header(), "WWW-Authenticate", "expected to not receive a WWW-Auth header when password auth is disabled")
 
 	// Also check that we can't create a session through POST /db/_session
 	response = rt.SendRequest(http.MethodPost, "/db/_session", `{"name":"user1","password":"letmein"}`)
-	requireStatus(t, response, http.StatusUnauthorized)
+	RequireStatus(t, response, http.StatusUnauthorized)
 
 	// As a sanity check, ensure it does work when the setting is disabled
 	rt.ServerContext().Database(ctx, "db").Options.DisablePasswordAuthentication = false
-	response = rt.Send(requestByUser(http.MethodGet, "/db/", "", "user1"))
-	requireStatus(t, response, http.StatusOK)
+	response = rt.Send(RequestByUser(http.MethodGet, "/db/", "", "user1"))
+	RequireStatus(t, response, http.StatusOK)
 
 	response = rt.SendRequest(http.MethodPost, "/db/_session", `{"name":"user1","password":"letmein"}`)
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 }
 
-func (rt *RestTester) createDoc(t *testing.T, docid string) string {
+func (rt *RestTester) CreateDoc(t *testing.T, docid string) string {
 	response := rt.SendAdminRequest("PUT", "/db/"+docid, `{"prop":true}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
@@ -149,22 +149,22 @@ func TestDocLifecycle(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	revid := rt.createDoc(t, "doc")
+	revid := rt.CreateDoc(t, "doc")
 	assert.Equal(t, "1-45ca73d819d5b1c9b8eea95290e79004", revid)
 
 	response := rt.SendAdminRequest("DELETE", "/db/doc?rev="+revid, "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 }
 
 // Validate that Etag header value is surrounded with double quotes, see issue #808
 func TestDocEtag(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	response := rt.SendRequest("PUT", "/db/doc", `{"prop":true}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
@@ -177,7 +177,7 @@ func TestDocEtag(t *testing.T) {
 	assert.Equal(t, strconv.Quote(revid), response.Header().Get("Etag"))
 
 	response = rt.SendRequest("GET", "/db/doc", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	// Validate Etag returned when retrieving doc
 	assert.Equal(t, strconv.Quote(revid), response.Header().Get("Etag"))
@@ -203,7 +203,7 @@ func TestDocEtag(t *testing.T) {
 
 	// attach to existing document with correct rev (should succeed)
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc/attach1?rev="+revid, attachmentBody, reqHeaders)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
@@ -218,7 +218,7 @@ func TestDocEtag(t *testing.T) {
 
 	// retrieve attachment
 	response = rt.SendRequest("GET", "/db/doc/attach1", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	assert.Equal(t, attachmentBody, string(response.Body.Bytes()))
 	assert.Equal(t, "", response.Header().Get("Content-Disposition"))
 	assert.Equal(t, attachmentContentType, response.Header().Get("Content-Type"))
@@ -230,11 +230,11 @@ func TestDocEtag(t *testing.T) {
 
 // Add and retrieve an attachment, including a subrange
 func TestDocAttachment(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	response := rt.SendRequest("PUT", "/db/doc", `{"prop":true}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revid := body["rev"].(string)
@@ -247,11 +247,11 @@ func TestDocAttachment(t *testing.T) {
 
 	// attach to existing document with correct rev (should succeed)
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc/attach1?rev="+revid, attachmentBody, reqHeaders)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// retrieve attachment
 	response = rt.SendRequest("GET", "/db/doc/attach1", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	assert.Equal(t, attachmentBody, string(response.Body.Bytes()))
 	assert.Equal(t, "bytes", response.Header().Get("Accept-Ranges"))
 	assert.Equal(t, "", response.Header().Get("Content-Disposition"))
@@ -260,7 +260,7 @@ func TestDocAttachment(t *testing.T) {
 
 	// retrieve subrange
 	response = rt.SendRequestWithHeaders("GET", "/db/doc/attach1", "", map[string]string{"Range": "bytes=5-6"})
-	requireStatus(t, response, 206)
+	RequireStatus(t, response, 206)
 	assert.Equal(t, "is", string(response.Body.Bytes()))
 	assert.Equal(t, "bytes", response.Header().Get("Accept-Ranges"))
 	assert.Equal(t, "2", response.Header().Get("Content-Length"))
@@ -269,11 +269,11 @@ func TestDocAttachment(t *testing.T) {
 }
 
 func TestDocAttachmentMetaOption(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	response := rt.SendRequest(http.MethodPut, "/db/doc", `{"prop":true}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revid := body["rev"].(string)
@@ -286,7 +286,7 @@ func TestDocAttachmentMetaOption(t *testing.T) {
 
 	// Validate attachment response.
 	assertAttachmentResponse := func(response *TestResponse) {
-		requireStatus(t, response, http.StatusOK)
+		RequireStatus(t, response, http.StatusOK)
 		assert.Equal(t, attachmentBody, string(response.Body.Bytes()))
 		assert.Equal(t, "bytes", response.Header().Get("Accept-Ranges"))
 		assert.Empty(t, response.Header().Get("Content-Disposition"))
@@ -296,7 +296,7 @@ func TestDocAttachmentMetaOption(t *testing.T) {
 
 	// Attach to existing document.
 	response = rt.SendRequestWithHeaders(http.MethodPut, "/db/doc/attach1?rev="+revid, attachmentBody, reqHeaders)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Retrieve attachment
 	response = rt.SendRequest(http.MethodGet, "/db/doc/attach1", "")
@@ -304,7 +304,7 @@ func TestDocAttachmentMetaOption(t *testing.T) {
 
 	// Retrieve attachment meta only by explicitly enabling meta option.
 	response = rt.SendRequest(http.MethodGet, "/db/doc/attach1?meta=true", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	responseBody := make(map[string]interface{})
 	err := base.JSONUnmarshal(response.Body.Bytes(), &responseBody)
@@ -360,15 +360,15 @@ func TestDocAttachmentOnRemovedRev(t *testing.T) {
 	user, err = a.NewUser("user1", "letmein", channels.SetOf(t, "foo"))
 	assert.NoError(t, a.Save(user))
 
-	response := rt.Send(requestByUser("PUT", "/db/doc", `{"prop":true, "channels":["foo"]}`, "user1"))
-	requireStatus(t, response, 201)
+	response := rt.Send(RequestByUser("PUT", "/db/doc", `{"prop":true, "channels":["foo"]}`, "user1"))
+	RequireStatus(t, response, 201)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revid := body["rev"].(string)
 
 	// Put new revision removing document from users channel set
-	response = rt.Send(requestByUser("PUT", "/db/doc?rev="+revid, `{"prop":true}`, "user1"))
-	requireStatus(t, response, 201)
+	response = rt.Send(RequestByUser("PUT", "/db/doc?rev="+revid, `{"prop":true}`, "user1"))
+	RequireStatus(t, response, 201)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revid = body["rev"].(string)
 
@@ -380,7 +380,7 @@ func TestDocAttachmentOnRemovedRev(t *testing.T) {
 
 	// attach to existing document with correct rev (should fail)
 	response = rt.SendUserRequestWithHeaders("PUT", "/db/doc/attach1?rev="+revid, attachmentBody, reqHeaders, "user1", "letmein")
-	requireStatus(t, response, 404)
+	RequireStatus(t, response, 404)
 }
 
 func TestDocumentUpdateWithNullBody(t *testing.T) {
@@ -399,56 +399,56 @@ func TestDocumentUpdateWithNullBody(t *testing.T) {
 	user, err = a.NewUser("user1", "letmein", channels.SetOf(t, "foo"))
 	assert.NoError(t, a.Save(user))
 	// Create document
-	response := rt.Send(requestByUser("PUT", "/db/doc", `{"prop":true, "channels":["foo"]}`, "user1"))
-	requireStatus(t, response, 201)
+	response := rt.Send(RequestByUser("PUT", "/db/doc", `{"prop":true, "channels":["foo"]}`, "user1"))
+	RequireStatus(t, response, 201)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revid := body["rev"].(string)
 
 	// Put new revision with null body
-	response = rt.Send(requestByUser("PUT", "/db/doc?rev="+revid, "", "user1"))
-	requireStatus(t, response, 400)
+	response = rt.Send(RequestByUser("PUT", "/db/doc?rev="+revid, "", "user1"))
+	RequireStatus(t, response, 400)
 }
 
 func TestFunkyDocIDs(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	rt.createDoc(t, "AC%2FDC")
+	rt.CreateDoc(t, "AC%2FDC")
 
 	response := rt.SendAdminRequest("GET", "/db/AC%2FDC", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
-	rt.createDoc(t, "AC+DC")
+	rt.CreateDoc(t, "AC+DC")
 	response = rt.SendAdminRequest("GET", "/db/AC+DC", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
-	rt.createDoc(t, "AC+DC+GC")
+	rt.CreateDoc(t, "AC+DC+GC")
 	response = rt.SendAdminRequest("GET", "/db/AC+DC+GC", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	response = rt.SendAdminRequest("PUT", "/db/foo+bar+moo+car", `{"prop":true}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/foo+bar+moo+car", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
-	rt.createDoc(t, "AC%2BDC2")
+	rt.CreateDoc(t, "AC%2BDC2")
 	response = rt.SendAdminRequest("GET", "/db/AC%2BDC2", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
-	rt.createDoc(t, "AC%2BDC%2BGC2")
+	rt.CreateDoc(t, "AC%2BDC%2BGC2")
 	response = rt.SendAdminRequest("GET", "/db/AC%2BDC%2BGC2", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	response = rt.SendAdminRequest("PUT", "/db/foo%2Bbar%2Bmoo%2Bcar2", `{"prop":true}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/foo%2Bbar%2Bmoo%2Bcar2", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	response = rt.SendAdminRequest("PUT", "/db/foo%2Bbar+moo%2Bcar3", `{"prop":true}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/foo+bar%2Bmoo+car3", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 }
 
 func TestFunkyUsernames(t *testing.T) {
@@ -487,21 +487,21 @@ func TestFunkyUsernames(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, a.Save(user))
 
-			response := rt.Send(requestByUser("PUT", "/db/AC+DC", `{"foo":"bar", "channels": ["foo"]}`, tc.UserName))
-			requireStatus(t, response, 201)
+			response := rt.Send(RequestByUser("PUT", "/db/AC+DC", `{"foo":"bar", "channels": ["foo"]}`, tc.UserName))
+			RequireStatus(t, response, 201)
 
-			response = rt.Send(requestByUser("GET", "/db/_all_docs", "", tc.UserName))
-			requireStatus(t, response, 200)
+			response = rt.Send(RequestByUser("GET", "/db/_all_docs", "", tc.UserName))
+			RequireStatus(t, response, 200)
 
-			response = rt.Send(requestByUser("GET", "/db/AC+DC", "", tc.UserName))
-			requireStatus(t, response, 200)
+			response = rt.Send(RequestByUser("GET", "/db/AC+DC", "", tc.UserName))
+			RequireStatus(t, response, 200)
 			var overlay struct {
 				Rev string `json:"_rev"`
 			}
 			require.NoError(t, json.Unmarshal(response.Body.Bytes(), &overlay))
 
-			response = rt.Send(requestByUser("DELETE", "/db/AC+DC?rev="+overlay.Rev, "", tc.UserName))
-			requireStatus(t, response, 200)
+			response = rt.Send(RequestByUser("DELETE", "/db/AC+DC?rev="+overlay.Rev, "", tc.UserName))
+			RequireStatus(t, response, 200)
 		})
 	}
 }
@@ -550,21 +550,21 @@ func TestFunkyRoleNames(t *testing.T) {
 
 			// Create role
 			response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_role/%s", url.PathEscape(tc.RoleName)), `{"admin_channels": ["testchannel"]}`)
-			requireStatus(t, response, 201)
+			RequireStatus(t, response, 201)
 
 			// Create test document
 			response = rt.SendAdminRequest("PUT", "/db/testdoc", `{"channels":["testchannel"]}`)
-			requireStatus(t, response, 201)
+			RequireStatus(t, response, 201)
 
 			// Assert user can access it
-			response = rt.Send(requestByUser("GET", "/db/testdoc", "", username))
-			requireStatus(t, response, 200)
+			response = rt.Send(RequestByUser("GET", "/db/testdoc", "", username))
+			RequireStatus(t, response, 200)
 		})
 	}
 }
 
 func TestFunkyDocAndAttachmentIDs(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	attachmentBody := "this is the body of attachment"
@@ -586,25 +586,25 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	// createDoc creates a document revision and returns the revision ID.
 	createDoc := func(docID string) (revID string) {
 		response := rt.SendRequest(http.MethodPut, "/db/"+docID, `{"prop":true}`)
-		requireStatus(t, response, http.StatusCreated)
+		RequireStatus(t, response, http.StatusCreated)
 		return requireRevID(response)
 	}
 
 	// assertResponse asserts that the specified attachment exists in the response body.
 	assertResponse := func(response *TestResponse, attachmentBody string) {
-		requireStatus(t, response, http.StatusOK)
+		RequireStatus(t, response, http.StatusOK)
 		require.Equal(t, attachmentBody, string(response.Body.Bytes()))
 		require.Empty(t, response.Header().Get("Content-Disposition"))
 		require.Equal(t, attachmentContentType, response.Header().Get("Content-Type"))
 	}
 
 	// Create document with simple name
-	doc1revId := rt.createDoc(t, "doc1")
+	doc1revId := rt.CreateDoc(t, "doc1")
 
 	// Add attachment with single embedded '/' (%2F HEX)
 	resource := "/db/doc1/attachpath%2Fattachment.txt?rev=" + doc1revId
 	response := rt.SendRequestWithHeaders(http.MethodPut, resource, attachmentBody, reqHeaders)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	revIdAfterAttachment := requireRevID(response)
 
 	// Retrieve attachment
@@ -614,7 +614,7 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	// Add attachment with two embedded '/' (%2F HEX)
 	resource = "/db/doc1/attachpath%2Fattachpath2%2Fattachment.txt?rev=" + revIdAfterAttachment
 	response = rt.SendRequestWithHeaders(http.MethodPut, resource, attachmentBody, reqHeaders)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Retrieve attachment
 	response = rt.SendRequest(http.MethodGet, "/db/doc1/attachpath%2Fattachpath2%2Fattachment.txt", "")
@@ -624,12 +624,12 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	doc1revId = createDoc("AC%2FDC")
 
 	response = rt.SendRequest(http.MethodGet, "/db/AC%2FDC", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	// Add attachment with single embedded '/' (%2F HEX)
 	response = rt.SendRequestWithHeaders(http.MethodPut, "/db/AC%2FDC/attachpath%2Fattachment.txt?rev="+doc1revId,
 		attachmentBody, reqHeaders)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	revIdAfterAttachment = requireRevID(response)
 
 	// Retrieve attachment
@@ -639,7 +639,7 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	// Add attachment with two embedded '/' (%2F HEX)
 	resource = "/db/AC%2FDC/attachpath%2Fattachpath2%2Fattachment.txt?rev=" + revIdAfterAttachment
 	response = rt.SendRequestWithHeaders(http.MethodPut, resource, attachmentBody, reqHeaders)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Retrieve attachment
 	response = rt.SendRequest(http.MethodGet, "/db/AC%2FDC/attachpath%2Fattachpath2%2Fattachment.txt", "")
@@ -648,12 +648,12 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	// Create Doc with embedded '+' (%2B HEX) in name
 	doc1revId = createDoc("AC%2BDC%2BGC2")
 	response = rt.SendRequest(http.MethodGet, "/db/AC%2BDC%2BGC2", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	// Add attachment with single embedded '/' (%2F HEX)
 	resource = "/db/AC%2BDC%2BGC2/attachpath%2Fattachment.txt?rev=" + doc1revId
 	response = rt.SendRequestWithHeaders(http.MethodPut, resource, attachmentBody, reqHeaders)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	revIdAfterAttachment = requireRevID(response)
 
 	// Retrieve attachment
@@ -663,7 +663,7 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	// Add attachment with two embedded '/' (%2F HEX)
 	resource = "/db/AC%2BDC%2BGC2/attachpath%2Fattachpath2%2Fattachment.txt?rev=" + revIdAfterAttachment
 	response = rt.SendRequestWithHeaders(http.MethodPut, resource, attachmentBody, reqHeaders)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Retrieve attachment
 	response = rt.SendRequest(http.MethodGet, "/db/AC%2BDC%2BGC2/attachpath%2Fattachpath2%2Fattachment.txt", "")
@@ -720,7 +720,7 @@ func assertGatewayStatus(t *testing.T, response *TestResponse, expected int) {
 		respBody := response.Body.String()
 		t.Skipf("WARNING: Host could not be reached: %s", respBody)
 	}
-	requireStatus(t, response, expected)
+	RequireStatus(t, response, expected)
 }
 
 func TestCORSLoginOriginOnSessionPost(t *testing.T) {
@@ -733,7 +733,7 @@ func TestCORSLoginOriginOnSessionPost(t *testing.T) {
 	}
 
 	response := rt.SendRequestWithHeaders("POST", "/db/_session", "{\"name\":\"jchris\",\"password\":\"secret\"}", reqHeaders)
-	requireStatus(t, response, 401)
+	RequireStatus(t, response, 401)
 
 	response = rt.SendRequestWithHeaders("POST", "/db/_facebook", `{"access_token":"true"}`, reqHeaders)
 	assertGatewayStatus(t, response, 401)
@@ -753,7 +753,7 @@ func TestCORSLoginOriginOnSessionPostNoCORSConfig(t *testing.T) {
 	sc.config.API.CORS = nil
 
 	response := rt.SendRequestWithHeaders("POST", "/db/_session", `{"name":"jchris","password":"secret"}`, reqHeaders)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 }
 
 func TestNoCORSOriginOnSessionPost(t *testing.T) {
@@ -765,14 +765,14 @@ func TestNoCORSOriginOnSessionPost(t *testing.T) {
 	}
 
 	response := rt.SendRequestWithHeaders("POST", "/db/_session", "{\"name\":\"jchris\",\"password\":\"secret\"}", reqHeaders)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	response = rt.SendRequestWithHeaders("POST", "/db/_facebook", `{"access_token":"true"}`, reqHeaders)
 	assertGatewayStatus(t, response, 400)
 }
 
 func TestCORSLogoutOriginOnSessionDelete(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	reqHeaders := map[string]string{
@@ -780,7 +780,7 @@ func TestCORSLogoutOriginOnSessionDelete(t *testing.T) {
 	}
 
 	response := rt.SendRequestWithHeaders("DELETE", "/db/_session", "", reqHeaders)
-	requireStatus(t, response, 404)
+	RequireStatus(t, response, 404)
 
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
@@ -788,7 +788,7 @@ func TestCORSLogoutOriginOnSessionDelete(t *testing.T) {
 }
 
 func TestCORSLogoutOriginOnSessionDeleteNoCORSConfig(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	reqHeaders := map[string]string{
@@ -800,7 +800,7 @@ func TestCORSLogoutOriginOnSessionDeleteNoCORSConfig(t *testing.T) {
 	sc.config.API.CORS = nil
 
 	response := rt.SendRequestWithHeaders("DELETE", "/db/_session", "", reqHeaders)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
@@ -808,7 +808,7 @@ func TestCORSLogoutOriginOnSessionDeleteNoCORSConfig(t *testing.T) {
 }
 
 func TestNoCORSOriginOnSessionDelete(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	reqHeaders := map[string]string{
@@ -816,7 +816,7 @@ func TestNoCORSOriginOnSessionDelete(t *testing.T) {
 	}
 
 	response := rt.SendRequestWithHeaders("DELETE", "/db/_session", "", reqHeaders)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
@@ -824,10 +824,10 @@ func TestNoCORSOriginOnSessionDelete(t *testing.T) {
 }
 
 func TestManualAttachment(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
-	doc1revId := rt.createDoc(t, "doc1")
+	doc1revId := rt.CreateDoc(t, "doc1")
 
 	// attach to existing document without rev (should fail)
 	attachmentBody := "this is the body of attachment"
@@ -836,21 +836,21 @@ func TestManualAttachment(t *testing.T) {
 		"Content-Type": attachmentContentType,
 	}
 	response := rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1", attachmentBody, reqHeaders)
-	requireStatus(t, response, 409)
+	RequireStatus(t, response, 409)
 
 	// attach to existing document with wrong rev (should fail)
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1?rev=1-xyz", attachmentBody, reqHeaders)
-	requireStatus(t, response, 409)
+	RequireStatus(t, response, 409)
 
 	// attach to existing document with wrong rev using If-Match header (should fail)
 	reqHeaders["If-Match"] = "1-dnf"
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1", attachmentBody, reqHeaders)
-	requireStatus(t, response, 409)
+	RequireStatus(t, response, 409)
 	delete(reqHeaders, "If-Match")
 
 	// attach to existing document with correct rev (should succeed)
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1?rev="+doc1revId, attachmentBody, reqHeaders)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
@@ -862,7 +862,7 @@ func TestManualAttachment(t *testing.T) {
 
 	// retrieve attachment
 	response = rt.SendRequest("GET", "/db/doc1/attach1", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	assert.Equal(t, attachmentBody, string(response.Body.Bytes()))
 	assert.True(t, response.Header().Get("Content-Disposition") == "")
 	assert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
@@ -870,7 +870,7 @@ func TestManualAttachment(t *testing.T) {
 	// retrieve attachment as admin should have
 	// Content-disposition: attachment
 	response = rt.SendAdminRequest("GET", "/db/doc1/attach1", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	assert.Equal(t, attachmentBody, string(response.Body.Bytes()))
 	assert.True(t, response.Header().Get("Content-Disposition") == `attachment`)
 	assert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
@@ -878,7 +878,7 @@ func TestManualAttachment(t *testing.T) {
 	// try to overwrite that attachment
 	attachmentBody = "updated content"
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1?rev="+revIdAfterAttachment, attachmentBody, reqHeaders)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	body = db.Body{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
@@ -892,7 +892,7 @@ func TestManualAttachment(t *testing.T) {
 	attachmentBody = "updated content again"
 	reqHeaders["If-Match"] = revIdAfterUpdateAttachment
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1", attachmentBody, reqHeaders)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	body = db.Body{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
@@ -905,7 +905,7 @@ func TestManualAttachment(t *testing.T) {
 
 	// retrieve attachment
 	response = rt.SendRequest("GET", "/db/doc1/attach1", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	assert.Equal(t, attachmentBody, string(response.Body.Bytes()))
 	assert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
 
@@ -914,7 +914,7 @@ func TestManualAttachment(t *testing.T) {
 	// should default to application/octet-stream
 	attachmentBody = "separate content"
 	response = rt.SendRequest("PUT", "/db/doc1/attach2?rev="+revIdAfterUpdateAttachmentAgain, attachmentBody)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	body = db.Body{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
@@ -926,13 +926,13 @@ func TestManualAttachment(t *testing.T) {
 
 	// retrieve attachment
 	response = rt.SendRequest("GET", "/db/doc1/attach2", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	assert.Equal(t, attachmentBody, string(response.Body.Bytes()))
 	assert.True(t, response.Header().Get("Content-Type") == "application/octet-stream")
 
 	// now check the attachments index on the document
 	response = rt.SendRequest("GET", "/db/doc1", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	body = db.Body{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	bodyAttachments, ok := body["_attachments"].(map[string]interface{})
@@ -960,17 +960,17 @@ func TestManualAttachmentNewDoc(t *testing.T) {
 		"Content-Type": attachmentContentType,
 	}
 	response := rt.SendAdminRequestWithHeaders("PUT", "/db/notexistyet/attach1?rev=1-abc", attachmentBody, reqHeaders)
-	requireStatus(t, response, 409)
+	RequireStatus(t, response, 409)
 
 	// attach to new document using bogus rev using If-Match header (should fail)
 	reqHeaders["If-Match"] = "1-xyz"
 	response = rt.SendAdminRequestWithHeaders("PUT", "/db/notexistyet/attach1", attachmentBody, reqHeaders)
-	requireStatus(t, response, 409)
+	RequireStatus(t, response, 409)
 	delete(reqHeaders, "If-Match")
 
 	// attach to new document without any rev (should succeed)
 	response = rt.SendAdminRequestWithHeaders("PUT", "/db/notexistyet/attach1", attachmentBody, reqHeaders)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
@@ -981,14 +981,14 @@ func TestManualAttachmentNewDoc(t *testing.T) {
 
 	// retrieve attachment
 	response = rt.SendAdminRequest("GET", "/db/notexistyet/attach1", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	assert.Equal(t, attachmentBody, string(response.Body.Bytes()))
 	assert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
 
 	// now check the document
 	body = db.Body{}
 	response = rt.SendAdminRequest("GET", "/db/notexistyet", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	// body should only have 3 top-level entries _id, _rev, _attachments
 	assert.True(t, len(body) == 3)
@@ -1000,7 +1000,7 @@ func TestBulkDocs(t *testing.T) {
 
 	input := `{"docs": [{"_id": "bulk1", "n": 1}, {"_id": "bulk2", "n": 2}, {"_id": "_local/bulk3", "n": 3}]}`
 	response := rt.SendAdminRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	var docs []interface{}
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
@@ -1008,7 +1008,7 @@ func TestBulkDocs(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{"rev": "1-50133ddd8e49efad34ad9ecae4cb9907", "id": "bulk1"}, docs[0])
 
 	response = rt.SendAdminRequest("GET", "/db/bulk1", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	var respBody db.Body
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &respBody))
 	assert.Equal(t, "bulk1", respBody[db.BodyId])
@@ -1018,7 +1018,7 @@ func TestBulkDocs(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{"rev": "0-1", "id": "_local/bulk3"}, docs[2])
 
 	response = rt.SendAdminRequest("GET", "/db/_local/bulk3", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &respBody))
 	assert.Equal(t, "_local/bulk3", respBody[db.BodyId])
 	assert.Equal(t, "0-1", respBody[db.BodyRev])
@@ -1032,7 +1032,7 @@ func TestBulkDocs(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{"rev": "2-7e384b16e63ee3218349ee568f156d6f", "id": "bulk1"}, docs[0])
 
 	response = rt.SendAdminRequest("GET", "/db/_local/bulk3", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &respBody))
 	assert.Equal(t, "_local/bulk3", respBody[db.BodyId])
 	assert.Equal(t, "0-2", respBody[db.BodyRev])
@@ -1045,11 +1045,11 @@ func TestBulkDocsIDGeneration(t *testing.T) {
 
 	input := `{"docs": [{"n": 1}, {"_id": 123, "n": 2}]}`
 	response := rt.SendAdminRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	var docs []map[string]string
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
 	log.Printf("response: %s", response.Body.Bytes())
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	assert.Equal(t, 2, len(docs))
 	assert.Equal(t, "1-50133ddd8e49efad34ad9ecae4cb9907", docs[0]["rev"])
 	assert.True(t, docs[0]["id"] != "")
@@ -1067,7 +1067,7 @@ func TestBulkDocsUnusedSequences(t *testing.T) {
 
 	input := `{"docs": [{"_id": "bulk1", "n": 1}, {"_id": "bulk2", "n": 2, "type": "invalid"}, {"_id": "bulk3", "n": 3}]}`
 	response := rt.SendRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	doc1Rev, err := rt.GetDatabase().GetDocSyncData("bulk1")
 	assert.NoError(t, err, "GetDocSyncData error")
@@ -1085,7 +1085,7 @@ func TestBulkDocsUnusedSequences(t *testing.T) {
 	//send another _bulk_docs and validate the sequences used
 	input = `{"docs": [{"_id": "bulk21", "n": 21}, {"_id": "bulk22", "n": 22}, {"_id": "bulk23", "n": 23}]}`
 	response = rt.SendRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	//Sequence 3 get used here
 	doc21Rev, err := rt.GetDatabase().GetDocSyncData("bulk21")
@@ -1115,7 +1115,7 @@ func TestBulkDocsUnusedSequencesMultipleSG(t *testing.T) {
 
 	input := `{"docs": [{"_id": "bulk1", "n": 1}, {"_id": "bulk2", "n": 2, "type": "invalid"}, {"_id": "bulk3", "n": 3}]}`
 	response := rt1.SendRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	doc1Rev, err := rt1.GetDatabase().GetDocSyncData("bulk1")
 	assert.NoError(t, err, "GetDocSyncData error")
@@ -1153,7 +1153,7 @@ func TestBulkDocsUnusedSequencesMultipleSG(t *testing.T) {
 	//send another _bulk_docs to rt2 and validate the sequences used
 	input = `{"docs": [{"_id": "bulk21", "n": 21}, {"_id": "bulk22", "n": 22}, {"_id": "bulk23", "n": 23}]}`
 	response = rt2.SendRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	//Sequence 3 does not get used here as its using a different sequence allocator
 	doc21Rev, err := rt2.GetDatabase().GetDocSyncData("bulk21")
@@ -1176,7 +1176,7 @@ func TestBulkDocsUnusedSequencesMultipleSG(t *testing.T) {
 	//Now send a bulk_doc to rt1 and see if it uses sequence 3
 	input = `{"docs": [{"_id": "bulk31", "n": 31}, {"_id": "bulk32", "n": 32}, {"_id": "bulk33", "n": 33}]}`
 	response = rt1.SendRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	//Sequence 3 get used here as its using first sequence allocator
 	doc31Rev, err := rt1.GetDatabase().GetDocSyncData("bulk31")
@@ -1203,7 +1203,7 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 	//add new docs, doc2 will be rejected by sync function
 	input := `{"docs": [{"_id": "bulk1", "n": 1}, {"_id": "bulk2", "n": 2, "type": "invalid"}, {"_id": "bulk3", "n": 3}]}`
 	response := rt1.SendRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	doc1Rev, err := rt1.GetDatabase().GetDocSyncData("bulk1")
 	assert.NoError(t, err, "GetDocSyncData error")
@@ -1244,7 +1244,7 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 	//send another _bulk_docs to rt2, including an update to doc "bulk1" and validate the sequences used
 	input = `{"docs": [{"_id": "bulk21", "n": 21}, {"_id": "bulk22", "n": 22}, {"_id": "bulk23", "n": 23}, {"_id": "bulk1", "_rev": "` + doc1RevID + `", "n": 2}]}`
 	response = rt2.SendRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	//Sequence 3 does not get used here as its using a different sequence allocator
 	doc21Rev, err := rt2.GetDatabase().GetDocSyncData("bulk21")
@@ -1275,7 +1275,7 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 	//Now send a bulk_doc to rt1 to update doc bulk1 again
 	input = `{"docs": [{"_id": "bulk1", "_rev": "` + doc1RevID2 + `", "n": 2}]}`
 	response = rt1.SendRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	//Sequence 8 should get used here as sequence 3 should have been dropped by the first sequence allocator
 	doc1Rev3, err := rt1.GetDatabase().GetDocSyncData("bulk1")
@@ -1301,7 +1301,7 @@ func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 	//add new docs, doc2 will be rejected by sync function
 	input := `{"docs": [{"_id": "bulk1", "n": 1}, {"_id": "bulk2", "n": 2, "type": "invalid"}, {"_id": "bulk3", "n": 3}]}`
 	response := rt1.SendRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	doc1Rev, err := rt1.GetDatabase().GetDocSyncData("bulk1")
 	assert.NoError(t, err, "GetDocSyncData error")
@@ -1342,7 +1342,7 @@ func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 	//send another _bulk_docs to rt2, including an update to doc "bulk1" and another invalid rev to create an unused sequence
 	input = `{"docs": [{"_id": "bulk21", "n": 21}, {"_id": "bulk22", "n": 22}, {"_id": "bulk23", "n": 23, "type": "invalid"}, {"_id": "bulk1", "_rev": "` + doc1RevID + `", "n": 2}]}`
 	response = rt2.SendRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	//Sequence 3 does not get used here as its using a different sequence allocator
 	doc21Rev, err := rt2.GetDatabase().GetDocSyncData("bulk21")
@@ -1369,7 +1369,7 @@ func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 	//Now send a bulk_doc to rt1 to update doc bulk1 again
 	input = `{"docs": [{"_id": "bulk1", "_rev": "` + doc1RevID2 + `", "n": 2}]}`
 	response = rt1.SendRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	//Sequence 8 should get used here as sequence 3 should have been dropped by the first sequence allocator
 	doc1Rev3, err := rt1.GetDatabase().GetDocSyncData("bulk1")
@@ -1382,7 +1382,7 @@ func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 	//Now send a bulk_doc to rt2 to update doc bulk1 again
 	input = `{"docs": [{"_id": "bulk1", "_rev": "` + doc1RevID3 + `", "n": 2}]}`
 	response = rt1.SendRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	//Sequence 9 should get used here as sequence 6 should have been dropped by the second sequence allocator
 	doc1Rev4, err := rt1.GetDatabase().GetDocSyncData("bulk1")
@@ -1406,7 +1406,7 @@ func TestBulkDocsEmptyDocs(t *testing.T) {
 
 	input := `{}`
 	response := rt.SendAdminRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 }
 
 func TestBulkDocsMalformedDocs(t *testing.T) {
@@ -1415,13 +1415,13 @@ func TestBulkDocsMalformedDocs(t *testing.T) {
 
 	input := `{"docs":["A","B"]}`
 	response := rt.SendAdminRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	// For non-string id, ensure it reverts to id generation and doesn't panic
 	input = `{"docs": [{"_id": 3, "n": 1}]}`
 	response = rt.SendAdminRequest("POST", "/db/_bulk_docs", input)
 	log.Printf("response:%s", response.Body.Bytes())
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 }
 
 // TestBulkGetEfficientBodyCompression makes sure that the multipart writer of the bulk get response is efficiently compressing the document bodies.
@@ -1446,7 +1446,7 @@ func TestBulkGetEfficientBodyCompression(t *testing.T) {
 	for i := 0; i < numDocs; i++ {
 		resp := rt.SendAdminRequest(http.MethodPut,
 			"/db/"+docKeyPrefix+strconv.Itoa(i), doc)
-		requireStatus(t, resp, http.StatusCreated)
+		RequireStatus(t, resp, http.StatusCreated)
 	}
 
 	// craft a _bulk_get body to get all of them back out
@@ -1463,7 +1463,7 @@ func TestBulkGetEfficientBodyCompression(t *testing.T) {
 
 	// request an uncompressed _bulk_get
 	resp := rt.SendAdminRequestWithHeaders(http.MethodPost, "/db/_bulk_get", bulkGetBody, bulkGetHeaders)
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	uncompressedBodyLen := resp.Body.Len()
 	assert.Truef(t, uncompressedBodyLen >= minUncompressedSize, "Expected uncompressed response to be larger than minUncompressedSize (%d bytes) - got %d bytes", minUncompressedSize, uncompressedBodyLen)
@@ -1471,7 +1471,7 @@ func TestBulkGetEfficientBodyCompression(t *testing.T) {
 	// try the request again, but accept gzip encoding
 	bulkGetHeaders["Accept-Encoding"] = "gzip"
 	resp = rt.SendAdminRequestWithHeaders(http.MethodPost, "/db/_bulk_get", bulkGetBody, bulkGetHeaders)
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	compressedBodyLen := resp.Body.Len()
 	compressionRatio := float64(uncompressedBodyLen) / float64(compressedBodyLen)
@@ -1486,7 +1486,7 @@ func TestBulkGetEmptyDocs(t *testing.T) {
 
 	input := `{}`
 	response := rt.SendAdminRequest("POST", "/db/_bulk_get", input)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 }
 
 func TestBulkDocsChangeToAccess(t *testing.T) {
@@ -1512,8 +1512,8 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 
 	input := `{"docs": [{"_id": "bulk1", "type" : "setaccess", "owner":"user1" , "channel":"chan1"}, {"_id": "bulk2" , "channel":"chan1"}]}`
 
-	response := rt.Send(requestByUser("POST", "/db/_bulk_docs", input, "user1"))
-	requireStatus(t, response, 201)
+	response := rt.Send(RequestByUser("POST", "/db/_bulk_docs", input, "user1"))
+	RequireStatus(t, response, 201)
 
 	var docs []interface{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
@@ -1566,8 +1566,8 @@ func TestBulkDocsChangeToRoleAccess(t *testing.T) {
 				}
 				]}`
 
-	response := rt.Send(requestByUser("POST", "/db/_bulk_docs", input, "user1"))
-	requireStatus(t, response, 201)
+	response := rt.Send(RequestByUser("POST", "/db/_bulk_docs", input, "user1"))
+	RequireStatus(t, response, 201)
 
 	var docs []interface{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
@@ -1589,7 +1589,7 @@ func TestBulkDocsNoEdits(t *testing.T) {
                      "_revisions": {"start": 34, "ids": ["def", "three", "two", "one"]}}
               ]}`
 	response := rt.SendAdminRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	var docs []interface{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
 	assert.Equal(t, 2, len(docs))
@@ -1603,7 +1603,7 @@ func TestBulkDocsNoEdits(t *testing.T) {
                    "_revisions": {"start": 14, "ids": ["jkl", "def", "abc", "eleven", "ten", "nine"]}}
             ]}`
 	response = rt.SendAdminRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
 	assert.Equal(t, 1, len(docs))
 	assert.Equal(t, map[string]interface{}{"rev": "14-jkl", "id": "bdne1"}, docs[0])
@@ -1614,7 +1614,7 @@ type RevDiffResponse map[string][]string
 type RevsDiffResponse map[string]RevDiffResponse
 
 func TestRevsDiff(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	// Create some docs:
@@ -1625,7 +1625,7 @@ func TestRevsDiff(t *testing.T) {
                      "_revisions": {"start": 34, "ids": ["def", "three", "two", "one"]}}
               ]}`
 	response := rt.SendRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// Now call _revs_diff:
 	input = `{"rd1": ["13-def", "12-xyz"],
@@ -1634,7 +1634,7 @@ func TestRevsDiff(t *testing.T) {
               "_design/ddoc": ["1-woo"]
              }`
 	response = rt.SendRequest("POST", "/db/_revs_diff", input)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	var diffResponse RevsDiffResponse
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &diffResponse))
 	sort.Strings(diffResponse["rd1"]["possible_ancestors"])
@@ -1655,13 +1655,13 @@ func TestOpenRevs(t *testing.T) {
                      "_revisions": {"start": 12, "ids": ["abc", "eleven", "ten", "nine"]}}
               ]}`
 	response := rt.SendAdminRequest("POST", "/db/_bulk_docs", input)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	reqHeaders := map[string]string{
 		"Accept": "application/json",
 	}
 	response = rt.SendAdminRequestWithHeaders("GET", `/db/or1?open_revs=["12-abc","10-ten"]`, "", reqHeaders)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	var respBody []map[string]interface{}
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &respBody))
@@ -1697,17 +1697,17 @@ func TestBulkGetPerDocRevsLimit(t *testing.T) {
 		var body db.Body
 
 		response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%v", k), fmt.Sprintf(`{"val":"1-%s"}`, k))
-		requireStatus(t, response, 201)
+		RequireStatus(t, response, 201)
 		require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 		rev := body["rev"].(string)
 
 		response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%v?rev=%s", k, rev), fmt.Sprintf(`{"val":"2-%s"}`, k))
-		requireStatus(t, response, 201)
+		RequireStatus(t, response, 201)
 		require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 		rev = body["rev"].(string)
 
 		response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%v?rev=%s", k, rev), fmt.Sprintf(`{"val":"3-%s"}`, k))
-		requireStatus(t, response, 201)
+		RequireStatus(t, response, 201)
 		require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 		rev = body["rev"].(string)
 
@@ -1802,12 +1802,12 @@ func TestLocalDocs(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("GET", "/db/_local/loc1", "")
-	requireStatus(t, response, 404)
+	RequireStatus(t, response, 404)
 
 	response = rt.SendAdminRequest("PUT", "/db/_local/loc1", `{"hi": "there"}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/_local/loc1", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	var respBody db.Body
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &respBody))
 	assert.Equal(t, "_local/loc1", respBody[db.BodyId])
@@ -1815,11 +1815,11 @@ func TestLocalDocs(t *testing.T) {
 	assert.Equal(t, "there", respBody["hi"])
 
 	response = rt.SendAdminRequest("PUT", "/db/_local/loc1", `{"hi": "there"}`)
-	requireStatus(t, response, 409)
+	RequireStatus(t, response, 409)
 	response = rt.SendAdminRequest("PUT", "/db/_local/loc1", `{"hi": "again", "_rev": "0-1"}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/_local/loc1", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &respBody))
 	assert.Equal(t, "_local/loc1", respBody[db.BodyId])
 	assert.Equal(t, "0-2", respBody[db.BodyRev])
@@ -1827,30 +1827,30 @@ func TestLocalDocs(t *testing.T) {
 
 	// Check the handling of large integers, which caused trouble for us at one point:
 	response = rt.SendAdminRequest("PUT", "/db/_local/loc1", `{"big": 123456789, "_rev": "0-2"}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/_local/loc1", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &respBody))
 	assert.Equal(t, "_local/loc1", respBody[db.BodyId])
 	assert.Equal(t, "0-3", respBody[db.BodyRev])
 	assert.Equal(t, float64(123456789), respBody["big"])
 
 	response = rt.SendAdminRequest("DELETE", "/db/_local/loc1", "")
-	requireStatus(t, response, 409)
+	RequireStatus(t, response, 409)
 	response = rt.SendAdminRequest("DELETE", "/db/_local/loc1?rev=0-3", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	response = rt.SendAdminRequest("GET", "/db/_local/loc1", "")
-	requireStatus(t, response, 404)
+	RequireStatus(t, response, 404)
 	response = rt.SendAdminRequest("DELETE", "/db/_local/loc1", "")
-	requireStatus(t, response, 404)
+	RequireStatus(t, response, 404)
 
 	// Check the handling of URL encoded slash at end of _local%2Fdoc
 	response = rt.SendAdminRequest("PUT", "/db/_local%2Floc12", `{"hi": "there"}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/_local/loc2", "")
-	requireStatus(t, response, 404)
+	RequireStatus(t, response, 404)
 	response = rt.SendAdminRequest("DELETE", "/db/_local%2floc2", "")
-	requireStatus(t, response, 404)
+	RequireStatus(t, response, 404)
 }
 
 func TestLocalDocExpiry(t *testing.T) {
@@ -1870,7 +1870,7 @@ func TestLocalDocExpiry(t *testing.T) {
 	log.Printf("Expiry expected between %d and %d", timeNow, oneMoreHour)
 
 	response := rt.SendAdminRequest("PUT", "/db/_local/loc1", `{"hi": "there"}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	cbStore, ok := base.AsCouchbaseStore(rt.Bucket())
 	require.True(t, ok)
@@ -1884,7 +1884,7 @@ func TestLocalDocExpiry(t *testing.T) {
 
 	// Retrieve local doc, ensure non-zero expiry is preserved
 	response = rt.SendAdminRequest("GET", "/db/_local/loc1", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	expiry, getMetaError = cbStore.GetExpiry(localDocKey)
 	log.Printf("Expiry after GET is %v", expiry)
 	assert.True(t, expiry > timeNow, "expiry is not greater than current time")
@@ -1904,10 +1904,10 @@ func TestResponseEncoding(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/db/_local/loc1", docJSON)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequestWithHeaders("GET", "/db/_local/loc1", "",
 		map[string]string{"Accept-Encoding": "foo, gzip, bar"})
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	assert.Equal(t, "gzip", response.Header().Get("Content-Encoding"))
 	unzip, err := gzip.NewReader(response.Body)
 	assert.NoError(t, err)
@@ -1933,15 +1933,15 @@ func TestLogin(t *testing.T) {
 	assert.True(t, user.Disabled())
 
 	response := rt.SendRequest("PUT", "/db/doc", `{"hi": "there"}`)
-	requireStatus(t, response, 401)
+	RequireStatus(t, response, 401)
 
 	user, err = a.NewUser("pupshaw", "letmein", channels.SetOf(t, "*"))
 	assert.NoError(t, a.Save(user))
 
-	requireStatus(t, rt.SendRequest("GET", "/db/_session", ""), 200)
+	RequireStatus(t, rt.SendRequest("GET", "/db/_session", ""), 200)
 
 	response = rt.SendRequest("POST", "/db/_session", `{"name":"pupshaw", "password":"letmein"}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	log.Printf("Set-Cookie: %s", response.Header().Get("Set-Cookie"))
 	assert.True(t, response.Header().Get("Set-Cookie") != "")
 }
@@ -1951,12 +1951,12 @@ func TestInvalidSession(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/db/testdoc", `{"hi": "there"}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	headers := map[string]string{}
 	headers["Cookie"] = fmt.Sprintf("%s=%s", auth.DefaultCookieName, "FakeSession")
 	response = rt.SendRequestWithHeaders("GET", "/db/testdoc", "", headers)
-	requireStatus(t, response, 401)
+	RequireStatus(t, response, 401)
 
 	var body db.Body
 	err := base.JSONUnmarshal(response.Body.Bytes(), &body)
@@ -1986,7 +1986,7 @@ func TestCustomCookieName(t *testing.T) {
 
 	// Create a user
 	response := rt.SendAdminRequest("POST", "/db/_user/", `{"name":"user1", "password":"1234"}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// Create a session
 	resp := rt.SendRequest("POST", "/db/_session", `{"name":"user1", "password":"1234"}`)
@@ -2102,11 +2102,11 @@ func TestAllDocsAccessControl(t *testing.T) {
 	err = a.Save(guest)
 	assert.NoError(t, err)
 
-	requireStatus(t, rt.SendRequest("PUT", "/db/doc5", `{"channels":"Cinemax"}`), 201)
-	requireStatus(t, rt.SendRequest("PUT", "/db/doc4", `{"channels":["WB", "Cinemax"]}`), 201)
-	requireStatus(t, rt.SendRequest("PUT", "/db/doc3", `{"channels":["CBS", "Cinemax"]}`), 201)
-	requireStatus(t, rt.SendRequest("PUT", "/db/doc2", `{"channels":["CBS"]}`), 201)
-	requireStatus(t, rt.SendRequest("PUT", "/db/doc1", `{"channels":[]}`), 201)
+	RequireStatus(t, rt.SendRequest("PUT", "/db/doc5", `{"channels":"Cinemax"}`), 201)
+	RequireStatus(t, rt.SendRequest("PUT", "/db/doc4", `{"channels":["WB", "Cinemax"]}`), 201)
+	RequireStatus(t, rt.SendRequest("PUT", "/db/doc3", `{"channels":["CBS", "Cinemax"]}`), 201)
+	RequireStatus(t, rt.SendRequest("PUT", "/db/doc2", `{"channels":["CBS"]}`), 201)
+	RequireStatus(t, rt.SendRequest("PUT", "/db/doc1", `{"channels":[]}`), 201)
 
 	guest.SetDisabled(true)
 	err = a.Save(guest)
@@ -2120,19 +2120,19 @@ func TestAllDocsAccessControl(t *testing.T) {
 	request, _ := http.NewRequest("GET", "/db/doc3", nil)
 	request.SetBasicAuth("alice", "letmein")
 	response := rt.Send(request)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	// Get a single doc the user doesn't have access to:
 	request, _ = http.NewRequest("GET", "/db/doc2", nil)
 	request.SetBasicAuth("alice", "letmein")
 	response = rt.Send(request)
-	requireStatus(t, response, 403)
+	RequireStatus(t, response, 403)
 
 	// Check that _all_docs only returns the docs the user has access to:
 	request, _ = http.NewRequest("GET", "/db/_all_docs?channels=true", nil)
 	request.SetBasicAuth("alice", "letmein")
 	response = rt.Send(request)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	allDocsResult := allDocsResponse{}
 	log.Printf("Response = %s", response.Body.Bytes())
@@ -2150,7 +2150,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	request, _ = http.NewRequest("GET", "/db/_all_docs?limit=1&channels=true", nil)
 	request.SetBasicAuth("alice", "letmein")
 	response = rt.Send(request)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
@@ -2164,7 +2164,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	request, _ = http.NewRequest("GET", "/db/_all_docs?startkey=doc5&channels=true", nil)
 	request.SetBasicAuth("alice", "letmein")
 	response = rt.Send(request)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
@@ -2178,7 +2178,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	request, _ = http.NewRequest("GET", `/db/_all_docs?startkey="doc5"&channels=true`, nil)
 	request.SetBasicAuth("alice", "letmein")
 	response = rt.Send(request)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
@@ -2192,7 +2192,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	request, _ = http.NewRequest("GET", "/db/_all_docs?endkey=doc3&channels=true", nil)
 	request.SetBasicAuth("alice", "letmein")
 	response = rt.Send(request)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
@@ -2206,7 +2206,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	request, _ = http.NewRequest("GET", `/db/_all_docs?endkey="doc3"&channels=true`, nil)
 	request.SetBasicAuth("alice", "letmein")
 	response = rt.Send(request)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
@@ -2220,7 +2220,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	request, _ = http.NewRequest("GET", "/db/_all_docs?include_docs=true", nil)
 	request.SetBasicAuth("alice", "letmein")
 	response = rt.Send(request)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
@@ -2236,7 +2236,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	request, _ = http.NewRequest("POST", "/db/_all_docs?channels=true", bytes.NewBufferString(body))
 	request.SetBasicAuth("alice", "letmein")
 	response = rt.Send(request)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	log.Printf("Response from POST _all_docs = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
@@ -2261,7 +2261,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	request, _ = http.NewRequest("GET", `/db/_all_docs?channels=true&keys=%5B%22doc4%22%2C%22doc1%22%2C%22doc3%22%2C%22b0gus%22%5D`, nil)
 	request.SetBasicAuth("alice", "letmein")
 	response = rt.Send(request)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	log.Printf("Response from GET _all_docs = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
@@ -2283,7 +2283,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	request, _ = http.NewRequest("POST", "/db/_all_docs?limit=1&channels=true", bytes.NewBufferString(body))
 	request.SetBasicAuth("alice", "letmein")
 	response = rt.Send(request)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	log.Printf("Response from POST _all_docs = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
@@ -2296,7 +2296,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	// Check _all_docs as admin:
 	response = rt.SendAdminRequest("GET", "/db/_all_docs", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	allDocsResult = allDocsResponse{}
@@ -2330,26 +2330,26 @@ func TestChannelAccessChanges(t *testing.T) {
 	assert.NoError(t, a.Save(zegpold))
 
 	// Create some docs that give users access:
-	response := rt.Send(request("PUT", "/db/alpha", `{"owner":"alice"}`))
-	requireStatus(t, response, 201)
+	response := rt.Send(Request("PUT", "/db/alpha", `{"owner":"alice"}`))
+	RequireStatus(t, response, 201)
 	var body db.Body
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
 	alphaRevID := body["rev"].(string)
 
-	requireStatus(t, rt.Send(request("PUT", "/db/beta", `{"owner":"boadecia"}`)), 201)
-	requireStatus(t, rt.Send(request("PUT", "/db/delta", `{"owner":"alice"}`)), 201)
-	requireStatus(t, rt.Send(request("PUT", "/db/gamma", `{"owner":"zegpold"}`)), 201)
+	RequireStatus(t, rt.Send(Request("PUT", "/db/beta", `{"owner":"boadecia"}`)), 201)
+	RequireStatus(t, rt.Send(Request("PUT", "/db/delta", `{"owner":"alice"}`)), 201)
+	RequireStatus(t, rt.Send(Request("PUT", "/db/gamma", `{"owner":"zegpold"}`)), 201)
 
-	requireStatus(t, rt.Send(request("PUT", "/db/a1", `{"channel":"alpha"}`)), 201)
-	requireStatus(t, rt.Send(request("PUT", "/db/b1", `{"channel":"beta"}`)), 201)
-	requireStatus(t, rt.Send(request("PUT", "/db/d1", `{"channel":"delta"}`)), 201)
-	requireStatus(t, rt.Send(request("PUT", "/db/g1", `{"channel":"gamma"}`)), 201)
+	RequireStatus(t, rt.Send(Request("PUT", "/db/a1", `{"channel":"alpha"}`)), 201)
+	RequireStatus(t, rt.Send(Request("PUT", "/db/b1", `{"channel":"beta"}`)), 201)
+	RequireStatus(t, rt.Send(Request("PUT", "/db/d1", `{"channel":"delta"}`)), 201)
+	RequireStatus(t, rt.Send(Request("PUT", "/db/g1", `{"channel":"gamma"}`)), 201)
 
 	rt.MustWaitForDoc("g1", t)
 
-	changes := changesResults{}
-	response = rt.Send(requestByUser("GET", "/db/_changes", "", "zegpold"))
+	changes := ChangesResults{}
+	response = rt.Send(RequestByUser("GET", "/db/_changes", "", "zegpold"))
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 
 	assert.NoError(t, err)
@@ -2392,7 +2392,7 @@ func TestChannelAccessChanges(t *testing.T) {
 
 	// Update a document to revoke access to alice and grant it to zegpold:
 	str := fmt.Sprintf(`{"owner":"zegpold", "_rev":%q}`, alphaRevID)
-	requireStatus(t, rt.Send(request("PUT", "/db/alpha", str)), 201)
+	RequireStatus(t, rt.Send(Request("PUT", "/db/alpha", str)), 201)
 
 	alphaGrantDocSeq, err := rt.SequenceForDoc("alpha")
 	assert.NoError(t, err, "Error retrieving document sequence")
@@ -2422,16 +2422,16 @@ func TestChannelAccessChanges(t *testing.T) {
 	rt.MustWaitForDoc("alpha", t)
 
 	// Look at alice's _changes feed:
-	changes = changesResults{}
-	response = rt.Send(requestByUser("GET", "/db/_changes", "", "alice"))
+	changes = ChangesResults{}
+	response = rt.Send(RequestByUser("GET", "/db/_changes", "", "alice"))
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Len(t, changes.Results, 1)
 	assert.NoError(t, err)
 	assert.Equal(t, "d1", changes.Results[0].ID)
 
 	// The complete _changes feed for zegpold contains docs a1 and g1:
-	changes = changesResults{}
-	response = rt.Send(requestByUser("GET", "/db/_changes", "", "zegpold"))
+	changes = ChangesResults{}
+	response = rt.Send(RequestByUser("GET", "/db/_changes", "", "zegpold"))
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	assert.NoError(t, err)
 	require.Len(t, changes.Results, 2)
@@ -2443,7 +2443,7 @@ func TestChannelAccessChanges(t *testing.T) {
 
 	// Changes feed with since=gamma:8 would ordinarily be empty, but zegpold got access to channel
 	// alpha after sequence 8, so the pre-existing docs in that channel are included:
-	response = rt.Send(requestByUser("GET", fmt.Sprintf("/db/_changes?since=\"%s\"", since),
+	response = rt.Send(RequestByUser("GET", fmt.Sprintf("/db/_changes?since=\"%s\"", since),
 		"", "zegpold"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	changes.Results = nil
@@ -2452,7 +2452,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	assert.Equal(t, "a1", changes.Results[0].ID)
 
 	// What happens if we call access() with a nonexistent username?
-	requireStatus(t, rt.Send(request("PUT", "/db/epsilon", `{"owner":"waldo"}`)), 201) // seq 10
+	RequireStatus(t, rt.Send(Request("PUT", "/db/epsilon", `{"owner":"waldo"}`)), 201) // seq 10
 
 	// Must wait for sequence to arrive in cache, since the cache processor will be paused when UpdateSyncFun() is called
 	// below, which could lead to a data race if the cache processor is paused while it's processing a change
@@ -2472,7 +2472,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	assert.Equal(t, 9, changeCount)
 
 	expectedIDs := []string{"beta", "delta", "gamma", "a1", "b1", "d1", "g1", "alpha", "epsilon"}
-	changes, err = rt.waitForChanges(len(expectedIDs), "/db/_changes", "alice", false)
+	changes, err = rt.WaitForChanges(len(expectedIDs), "/db/_changes", "alice", false)
 	assert.NoError(t, err, "Unexpected error")
 	log.Printf("_changes looks like: %+v", changes)
 	assert.Equal(t, len(expectedIDs), len(changes.Results))
@@ -2517,7 +2517,7 @@ func TestAccessOnTombstone(t *testing.T) {
 
 	// Create doc that gives user access to its channel
 	response := rt.SendAdminRequest("PUT", "/db/alpha", `{"owner":"bernard", "channel":"PBS"}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	var body db.Body
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
@@ -2530,7 +2530,7 @@ func TestAccessOnTombstone(t *testing.T) {
 	var changes struct {
 		Results []db.ChangeEntry
 	}
-	response = rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
+	response = rt.Send(RequestByUser("GET", "/db/_changes", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
@@ -2541,18 +2541,18 @@ func TestAccessOnTombstone(t *testing.T) {
 
 	// Delete the document
 	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/alpha?rev=%s", revId), "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	// Make sure it actually was deleted
 	response = rt.SendAdminRequest("GET", "/db/alpha", "")
-	requireStatus(t, response, 404)
+	RequireStatus(t, response, 404)
 
 	// Wait for change caching to complete
 	assert.NoError(t, rt.WaitForPendingChanges())
 
 	// Check user access again:
 	changes.Results = nil
-	response = rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
+	response = rt.Send(RequestByUser("GET", "/db/_changes", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Len(t, changes.Results, 1)
@@ -2596,7 +2596,7 @@ func TestSyncFnBodyProperties(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/db/"+testDocID, `{"`+testdataKey+`":true}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	syncData, err := rt.GetDatabase().GetDocSyncData(base.TestCtx(t), testDocID)
 	assert.NoError(t, err)
@@ -2638,14 +2638,14 @@ func TestSyncFnBodyPropertiesTombstone(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/db/"+testDocID, `{"`+testdataKey+`":true}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	var body db.Body
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
 	revID := body["rev"].(string)
 
 	response = rt.SendAdminRequest("DELETE", "/db/"+testDocID+"?rev="+revID, `{}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	syncData, err := rt.GetDatabase().GetDocSyncData(base.TestCtx(t), testDocID)
 	assert.NoError(t, err)
@@ -2686,14 +2686,14 @@ func TestSyncFnOldDocBodyProperties(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/db/"+testDocID, `{"`+testdataKey+`":true}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	var body db.Body
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
 	revID := body["rev"].(string)
 
 	response = rt.SendAdminRequest("PUT", "/db/"+testDocID+"?rev="+revID, `{"`+testdataKey+`":true,"update":2}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	syncData, err := rt.GetDatabase().GetDocSyncData(base.TestCtx(t), testDocID)
 	assert.NoError(t, err)
@@ -2735,21 +2735,21 @@ func TestSyncFnOldDocBodyPropertiesTombstoneResurrect(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/db/"+testDocID, `{"`+testdataKey+`":true}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	var body db.Body
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
 	revID := body["rev"].(string)
 
 	response = rt.SendAdminRequest("DELETE", "/db/"+testDocID+"?rev="+revID, `{}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	body = nil
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
 	revID = body["rev"].(string)
 
 	response = rt.SendAdminRequest("PUT", "/db/"+testDocID+"?rev="+revID, `{"`+testdataKey+`":true}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	syncData, err := rt.GetDatabase().GetDocSyncData(base.TestCtx(t), testDocID)
 	assert.NoError(t, err)
@@ -2800,34 +2800,34 @@ func TestSyncFnDocBodyPropertiesSwitchActiveTombstone(t *testing.T) {
 
 	// rev 1-a
 	resp := rt.SendAdminRequest("PUT", "/db/"+testDocID, `{"`+testdataKey+`":1}`)
-	requireStatus(t, resp, 201)
-	rev1ID := respRevID(t, resp)
+	RequireStatus(t, resp, 201)
+	rev1ID := RespRevID(t, resp)
 
 	// rev 2-a
 	resp = rt.SendAdminRequest("PUT", "/db/"+testDocID+"?rev="+rev1ID, `{"`+testdataKey+`":2}`)
-	requireStatus(t, resp, 201)
-	rev2aID := respRevID(t, resp)
+	RequireStatus(t, resp, 201)
+	rev2aID := RespRevID(t, resp)
 
 	// rev 3-a
 	resp = rt.SendAdminRequest("PUT", "/db/"+testDocID+"?rev="+rev2aID, `{"`+testdataKey+`":3,"syncOldDocBodyCheck":true}`)
-	requireStatus(t, resp, 201)
-	rev3aID := respRevID(t, resp)
+	RequireStatus(t, resp, 201)
+	rev3aID := RespRevID(t, resp)
 
 	// rev 2-b
 	_, rev1Hash := db.ParseRevID(rev1ID)
 	resp = rt.SendAdminRequest("PUT", "/db/"+testDocID+"?new_edits=false", `{"`+db.BodyRevisions+`":{"start":2,"ids":["b", "`+rev1Hash+`"]}}`)
-	requireStatus(t, resp, 201)
-	rev2bID := respRevID(t, resp)
+	RequireStatus(t, resp, 201)
+	rev2bID := RespRevID(t, resp)
 
 	// tombstone at 4-a
 	resp = rt.SendAdminRequest("DELETE", "/db/"+testDocID+"?rev="+rev3aID, `{}`)
-	requireStatus(t, resp, 200)
+	RequireStatus(t, resp, 200)
 
 	numErrorsBefore, err := strconv.Atoi(base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().ErrorCount.String())
 	assert.NoError(t, err)
 	// tombstone at 3-b
 	resp = rt.SendAdminRequest("DELETE", "/db/"+testDocID+"?rev="+rev2bID, `{}`)
-	requireStatus(t, resp, 200)
+	RequireStatus(t, resp, 200)
 
 	numErrorsAfter, err := strconv.Atoi(base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().ErrorCount.String())
 	assert.NoError(t, err)
@@ -2853,23 +2853,23 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 
 	// Create user1
 	response := rt.SendAdminRequest("PUT", "/db/_user/user1", `{"email":"user1@couchbase.com", "password":"letmein", "admin_channels":["alpha"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// Create 100 docs
 	for i := 0; i < 100; i++ {
 		docpath := fmt.Sprintf("/db/doc%d", i)
-		requireStatus(t, rt.Send(request("PUT", docpath, `{"foo": "bar", "channels":["alpha"]}`)), 201)
+		RequireStatus(t, rt.Send(Request("PUT", docpath, `{"foo": "bar", "channels":["alpha"]}`)), 201)
 	}
 
 	limit := 50
-	changesResults, err := rt.waitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user1", false)
+	changesResults, err := rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user1", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 50)
 	since := changesResults.Results[49].Seq
 	assert.Equal(t, "doc48", changesResults.Results[49].ID)
 
 	// // Check the _changes feed with  since and limit, to get second half of feed
-	changesResults, err = rt.waitForChanges(50, fmt.Sprintf("/db/_changes?since=\"%s\"&limit=%d", since, limit), "user1", false)
+	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?since=\"%s\"&limit=%d", since, limit), "user1", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 50)
 	since = changesResults.Results[49].Seq
@@ -2877,20 +2877,20 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 
 	// Create user2
 	response = rt.SendAdminRequest("PUT", "/db/_user/user2", `{"email":"user2@couchbase.com", "password":"letmein", "admin_channels":["alpha"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// Retrieve all changes for user2 with no limits
-	changesResults, err = rt.waitForChanges(101, fmt.Sprintf("/db/_changes"), "user2", false)
+	changesResults, err = rt.WaitForChanges(101, fmt.Sprintf("/db/_changes"), "user2", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 101)
 	assert.Equal(t, "doc99", changesResults.Results[99].ID)
 
 	// Create user3
 	response = rt.SendAdminRequest("PUT", "/db/_user/user3", `{"email":"user3@couchbase.com", "password":"letmein", "admin_channels":["alpha"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	getUserResponse := rt.SendAdminRequest("GET", "/db/_user/user3", "")
-	requireStatus(t, getUserResponse, 200)
+	RequireStatus(t, getUserResponse, 200)
 	log.Printf("create user response: %s", getUserResponse.Body.Bytes())
 
 	// Get the sequence from the user doc to validate against the triggered by value in the changes results
@@ -2898,7 +2898,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	userSequence := user3.Sequence()
 
 	// Get first 50 document changes.
-	changesResults, err = rt.waitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user3", false)
+	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user3", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 50)
 	since = changesResults.Results[49].Seq
@@ -2906,19 +2906,19 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, userSequence, since.TriggeredBy)
 
 	// // Get remainder of changes i.e. no limit parameter
-	changesResults, err = rt.waitForChanges(51, fmt.Sprintf("/db/_changes?since=\"%s\"", since), "user3", false)
+	changesResults, err = rt.WaitForChanges(51, fmt.Sprintf("/db/_changes?since=\"%s\"", since), "user3", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 51)
 	assert.Equal(t, "doc99", changesResults.Results[49].ID)
 
 	// Create user4
 	response = rt.SendAdminRequest("PUT", "/db/_user/user4", `{"email":"user4@couchbase.com", "password":"letmein", "admin_channels":["alpha"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	// Get the sequence from the user doc to validate against the triggered by value in the changes results
 	user4, _ := rt.GetDatabase().Authenticator(base.TestCtx(t)).GetUser("user4")
 	user4Sequence := user4.Sequence()
 
-	changesResults, err = rt.waitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user4", false)
+	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user4", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 50)
 	since = changesResults.Results[49].Seq
@@ -2926,7 +2926,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, user4Sequence, since.TriggeredBy)
 
 	// // Check the _changes feed with  since and limit, to get second half of feed
-	changesResults, err = rt.waitForChanges(50, fmt.Sprintf("/db/_changes?since=%s&limit=%d", since, limit), "user4", false)
+	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?since=%s&limit=%d", since, limit), "user4", false)
 	assert.Equal(t, nil, err)
 	require.Len(t, changesResults.Results, 50)
 	assert.Equal(t, "doc99", changesResults.Results[49].ID)
@@ -2951,25 +2951,25 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 
 	// POST a role
 	response := rt.SendAdminRequest("POST", "/db/_role/", `{"name":"role1","admin_channels":["chan1"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/_role/role1", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, "role1", body["name"])
 
 	// Put document to trigger sync function
-	response = rt.Send(request("PUT", "/db/doc1", `{"user":"user1", "role":"role:role1", "channel":"chan1"}`)) // seq=1
-	requireStatus(t, response, 201)
+	response = rt.Send(Request("PUT", "/db/doc1", `{"user":"user1", "role":"role:role1", "channel":"chan1"}`)) // seq=1
+	RequireStatus(t, response, 201)
 	body = nil
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
 
 	// POST the new user the GET and verify that it shows the assigned role
 	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"user1", "password":"letmein"}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/_user/user1", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	body = nil
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, "user1", body["name"])
@@ -2999,13 +2999,13 @@ func TestRoleAccessChanges(t *testing.T) {
 
 	// Create users:
 	response := rt.SendAdminRequest("PUT", "/db/_user/alice", `{"password":"letmein", "admin_channels":["alpha"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	response = rt.SendAdminRequest("PUT", "/db/_user/zegpold", `{"password":"letmein", "admin_channels":["beta"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	response = rt.SendAdminRequest("PUT", "/db/_role/hipster", `{"admin_channels":["gamma"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	/*
 		alice, err := a.NewUser("alice", "letmein", channels.SetOf(t, "alpha"))
 		assert.NoError(t, a.Save(alice))
@@ -3019,9 +3019,9 @@ func TestRoleAccessChanges(t *testing.T) {
 	// Create some docs in the channels:
 	cacheWaiter := rt.ServerContext().Database(ctx, "db").NewDCPCachingCountWaiter(t)
 	cacheWaiter.Add(1)
-	response = rt.Send(request("PUT", "/db/fashion",
+	response = rt.Send(Request("PUT", "/db/fashion",
 		`{"user":"alice","role":["role:hipster","role:bogus"]}`))
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
@@ -3030,10 +3030,10 @@ func TestRoleAccessChanges(t *testing.T) {
 	roleGrantSequence := rt.GetDocumentSequence("fashion")
 
 	cacheWaiter.Add(4)
-	requireStatus(t, rt.Send(request("PUT", "/db/g1", `{"channel":"gamma"}`)), 201)
-	requireStatus(t, rt.Send(request("PUT", "/db/a1", `{"channel":"alpha"}`)), 201)
-	requireStatus(t, rt.Send(request("PUT", "/db/b1", `{"channel":"beta"}`)), 201)
-	requireStatus(t, rt.Send(request("PUT", "/db/d1", `{"channel":"delta"}`)), 201)
+	RequireStatus(t, rt.Send(Request("PUT", "/db/g1", `{"channel":"gamma"}`)), 201)
+	RequireStatus(t, rt.Send(Request("PUT", "/db/a1", `{"channel":"alpha"}`)), 201)
+	RequireStatus(t, rt.Send(Request("PUT", "/db/b1", `{"channel":"beta"}`)), 201)
+	RequireStatus(t, rt.Send(Request("PUT", "/db/d1", `{"channel":"delta"}`)), 201)
 
 	// Check user access:
 	alice, _ := a.GetUser("alice")
@@ -3069,7 +3069,7 @@ func TestRoleAccessChanges(t *testing.T) {
 	}
 
 	cacheWaiter.Wait()
-	response = rt.Send(requestByUser("GET", "/db/_changes", "", "alice"))
+	response = rt.Send(RequestByUser("GET", "/db/_changes", "", "alice"))
 	log.Printf("1st _changes looks like: %s", response.Body.Bytes())
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Equal(t, 3, len(changes.Results))
@@ -3077,7 +3077,7 @@ func TestRoleAccessChanges(t *testing.T) {
 	assert.Equal(t, "g1", changes.Results[1].ID)
 	assert.Equal(t, "a1", changes.Results[2].ID)
 
-	response = rt.Send(requestByUser("GET", "/db/_changes", "", "zegpold"))
+	response = rt.Send(RequestByUser("GET", "/db/_changes", "", "zegpold"))
 	log.Printf("2nd _changes looks like: %s", response.Body.Bytes())
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Equal(t, 2, len(changes.Results))
@@ -3088,7 +3088,7 @@ func TestRoleAccessChanges(t *testing.T) {
 	// Update "fashion" doc to grant zegpold the role "hipster" and take it away from alice:
 	cacheWaiter.Add(1)
 	str := fmt.Sprintf(`{"user":"zegpold", "role":"role:hipster", "_rev":%q}`, fashionRevID)
-	requireStatus(t, rt.Send(request("PUT", "/db/fashion", str)), 201)
+	RequireStatus(t, rt.Send(Request("PUT", "/db/fashion", str)), 201)
 
 	updatedRoleGrantSequence := rt.GetDocumentSequence("fashion")
 
@@ -3113,7 +3113,7 @@ func TestRoleAccessChanges(t *testing.T) {
 	// The complete _changes feed for zegpold contains docs g1 and b1:
 	cacheWaiter.Wait()
 	changes.Results = nil
-	response = rt.Send(requestByUser("GET", "/db/_changes", "", "zegpold"))
+	response = rt.Send(RequestByUser("GET", "/db/_changes", "", "zegpold"))
 	log.Printf("3rd _changes looks like: %s", response.Body.Bytes())
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	log.Printf("changes: %+v", changes.Results)
@@ -3124,7 +3124,7 @@ func TestRoleAccessChanges(t *testing.T) {
 
 	// Changes feed with since=lastSeqPreGrant would ordinarily be empty, but zegpold got access to channel
 	// gamma after lastSeqPreGrant, so the pre-existing docs in that channel are included:
-	response = rt.Send(requestByUser("GET", fmt.Sprintf("/db/_changes?since=%v", lastSeqPreGrant), "", "zegpold"))
+	response = rt.Send(RequestByUser("GET", fmt.Sprintf("/db/_changes?since=%v", lastSeqPreGrant), "", "zegpold"))
 	log.Printf("4th _changes looks like: %s", response.Body.Bytes())
 	changes.Results = nil
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
@@ -3164,8 +3164,8 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create a doc
-	response := rt.Send(request("PUT", "/db/doc1", `{"foo":"bar", "channels":["ch1"]}`))
-	requireStatus(t, response, 201)
+	response := rt.Send(Request("PUT", "/db/doc1", `{"foo":"bar", "channels":["ch1"]}`))
+	RequireStatus(t, response, 201)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
@@ -3173,7 +3173,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 
 	// Run GET _all_docs as admin with channels=true:
 	response = rt.SendAdminRequest("GET", "/db/_all_docs?channels=true", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
@@ -3185,7 +3185,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 	// Run POST _all_docs as admin with explicit docIDs and channels=true:
 	keys := `{"keys": ["doc1"]}`
 	response = rt.SendAdminRequest("POST", "/db/_all_docs?channels=true", keys)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
@@ -3196,12 +3196,12 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 
 	// Commit rev 2 that maps to a differenet channel
 	str := fmt.Sprintf(`{"foo":"bar", "channels":["ch2"], "_rev":%q}`, doc1RevID)
-	requireStatus(t, rt.Send(request("PUT", "/db/doc1", str)), 201)
+	RequireStatus(t, rt.Send(Request("PUT", "/db/doc1", str)), 201)
 
 	// Run GET _all_docs as admin with channels=true
 	// Make sure that only the new channel appears in the docs channel list
 	response = rt.SendAdminRequest("GET", "/db/_all_docs?channels=true", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
@@ -3214,7 +3214,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 	// Make sure that only the new channel appears in the docs channel list
 	keys = `{"keys": ["doc1"]}`
 	response = rt.SendAdminRequest("POST", "/db/_all_docs?channels=true", keys)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
@@ -3230,7 +3230,7 @@ func TestAttachmentsNoCrossTalk(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	doc1revId := rt.createDoc(t, "doc1")
+	doc1revId := rt.CreateDoc(t, "doc1")
 
 	attachmentBody := "this is the body of attachment"
 	attachmentContentType := "content/type"
@@ -3240,7 +3240,7 @@ func TestAttachmentsNoCrossTalk(t *testing.T) {
 
 	// attach to existing document with correct rev (should succeed)
 	response := rt.SendAdminRequestWithHeaders("PUT", "/db/doc1/attach1?rev="+doc1revId, attachmentBody, reqHeaders)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
@@ -3309,7 +3309,7 @@ func TestAddingAttachment(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(tt *testing.T) {
-			docrevId := rt.createDoc(tt, testCase.docName)
+			docrevId := rt.CreateDoc(tt, testCase.docName)
 
 			attachmentBody := base64.StdEncoding.EncodeToString(make([]byte, testCase.byteSize))
 			attachmentContentType := "content/type"
@@ -3320,11 +3320,11 @@ func TestAddingAttachment(t *testing.T) {
 			// Set attachment
 			response := rt.SendAdminRequestWithHeaders("PUT", "/db/"+testCase.docName+"/attach1?rev="+docrevId,
 				attachmentBody, reqHeaders)
-			requireStatus(tt, response, testCase.expectedPut)
+			RequireStatus(tt, response, testCase.expectedPut)
 
 			// Get attachment back
 			response = rt.SendAdminRequestWithHeaders("GET", "/db/"+testCase.docName+"/attach1", "", reqHeaders)
-			requireStatus(tt, response, testCase.expectedGet)
+			RequireStatus(tt, response, testCase.expectedGet)
 
 			// If able to retrieve document check it is same as original
 			if response.Code == 200 {
@@ -3382,8 +3382,8 @@ func TestOldDocHandling(t *testing.T) {
 	assert.NoError(t, a.Save(frank))
 
 	// Create a doc:
-	response := rt.Send(request("PUT", "/db/testOldDocId", `{"foo":"bar"}`))
-	requireStatus(t, response, 201)
+	response := rt.Send(Request("PUT", "/db/testOldDocId", `{"foo":"bar"}`))
+	RequireStatus(t, response, 201)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
@@ -3391,7 +3391,7 @@ func TestOldDocHandling(t *testing.T) {
 
 	// Update a document to validate oldDoc id handling.  Will reject if old doc id not available
 	str := fmt.Sprintf(`{"foo":"ball", "_rev":%q}`, alphaRevID)
-	requireStatus(t, rt.Send(request("PUT", "/db/testOldDocId", str)), 201)
+	RequireStatus(t, rt.Send(Request("PUT", "/db/testOldDocId", str)), 201)
 
 }
 
@@ -3430,13 +3430,13 @@ func TestStarAccess(t *testing.T) {
 	err = a.Save(guest)
 	assert.NoError(t, err)
 
-	requireStatus(t, rt.SendRequest("PUT", "/db/doc1", `{"channels":["books"]}`), 201)
-	requireStatus(t, rt.SendRequest("PUT", "/db/doc2", `{"channels":["gifts"]}`), 201)
-	requireStatus(t, rt.SendRequest("PUT", "/db/doc3", `{"channels":["!"]}`), 201)
-	requireStatus(t, rt.SendRequest("PUT", "/db/doc4", `{"channels":["gifts"]}`), 201)
-	requireStatus(t, rt.SendRequest("PUT", "/db/doc5", `{"channels":["!"]}`), 201)
+	RequireStatus(t, rt.SendRequest("PUT", "/db/doc1", `{"channels":["books"]}`), 201)
+	RequireStatus(t, rt.SendRequest("PUT", "/db/doc2", `{"channels":["gifts"]}`), 201)
+	RequireStatus(t, rt.SendRequest("PUT", "/db/doc3", `{"channels":["!"]}`), 201)
+	RequireStatus(t, rt.SendRequest("PUT", "/db/doc4", `{"channels":["gifts"]}`), 201)
+	RequireStatus(t, rt.SendRequest("PUT", "/db/doc5", `{"channels":["!"]}`), 201)
 	// document added to no channel should only end up available to users with * access
-	requireStatus(t, rt.SendRequest("PUT", "/db/doc6", `{"channels":[]}`), 201)
+	RequireStatus(t, rt.SendRequest("PUT", "/db/doc6", `{"channels":[]}`), 201)
 
 	guest.SetDisabled(true)
 	err = a.Save(guest)
@@ -3448,21 +3448,21 @@ func TestStarAccess(t *testing.T) {
 	assert.NoError(t, a.Save(bernard))
 
 	// GET /db/docid - basic test for channel user has
-	response := rt.Send(requestByUser("GET", "/db/doc1", "", "bernard"))
-	requireStatus(t, response, 200)
+	response := rt.Send(RequestByUser("GET", "/db/doc1", "", "bernard"))
+	RequireStatus(t, response, 200)
 
 	// GET /db/docid - negative test for channel user doesn't have
-	response = rt.Send(requestByUser("GET", "/db/doc2", "", "bernard"))
-	requireStatus(t, response, 403)
+	response = rt.Send(RequestByUser("GET", "/db/doc2", "", "bernard"))
+	RequireStatus(t, response, 403)
 
 	// GET /db/docid - test for doc with ! channel
-	response = rt.Send(requestByUser("GET", "/db/doc3", "", "bernard"))
-	requireStatus(t, response, 200)
+	response = rt.Send(RequestByUser("GET", "/db/doc3", "", "bernard"))
+	RequireStatus(t, response, 200)
 
 	// GET /db/_all_docs?channels=true
 	// Check that _all_docs returns the docs the user has access to:
-	response = rt.Send(requestByUser("GET", "/db/_all_docs?channels=true", "", "bernard"))
-	requireStatus(t, response, 200)
+	response = rt.Send(RequestByUser("GET", "/db/_all_docs?channels=true", "", "bernard"))
+	RequireStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
@@ -3478,7 +3478,7 @@ func TestStarAccess(t *testing.T) {
 	_ = rt.WaitForSequence(expectedSeq)
 
 	// GET /db/_changes
-	response = rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
+	response = rt.Send(RequestByUser("GET", "/db/_changes", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
@@ -3488,7 +3488,7 @@ func TestStarAccess(t *testing.T) {
 	assert.Equal(t, uint64(1), since.Seq)
 
 	// GET /db/_changes for single channel
-	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=books", "", "bernard"))
+	response = rt.Send(RequestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=books", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
@@ -3498,7 +3498,7 @@ func TestStarAccess(t *testing.T) {
 	assert.Equal(t, uint64(1), since.Seq)
 
 	// GET /db/_changes for ! channel
-	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=!", "", "bernard"))
+	response = rt.Send(RequestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=!", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
@@ -3508,7 +3508,7 @@ func TestStarAccess(t *testing.T) {
 	assert.Equal(t, uint64(3), since.Seq)
 
 	// GET /db/_changes for unauthorized channel
-	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=gifts", "", "bernard"))
+	response = rt.Send(RequestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=gifts", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
@@ -3523,17 +3523,17 @@ func TestStarAccess(t *testing.T) {
 	assert.NoError(t, a.Save(fran))
 
 	// GET /db/docid - basic test for doc that has channel
-	response = rt.Send(requestByUser("GET", "/db/doc1", "", "fran"))
-	requireStatus(t, response, 200)
+	response = rt.Send(RequestByUser("GET", "/db/doc1", "", "fran"))
+	RequireStatus(t, response, 200)
 
 	// GET /db/docid - test for doc with ! channel
-	response = rt.Send(requestByUser("GET", "/db/doc3", "", "fran"))
-	requireStatus(t, response, 200)
+	response = rt.Send(RequestByUser("GET", "/db/doc3", "", "fran"))
+	RequireStatus(t, response, 200)
 
 	// GET /db/_all_docs?channels=true
 	// Check that _all_docs returns all docs (based on user * channel)
-	response = rt.Send(requestByUser("GET", "/db/_all_docs?channels=true", "", "fran"))
-	requireStatus(t, response, 200)
+	response = rt.Send(RequestByUser("GET", "/db/_all_docs?channels=true", "", "fran"))
+	RequireStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
@@ -3543,7 +3543,7 @@ func TestStarAccess(t *testing.T) {
 	assert.Equal(t, []string{"books"}, allDocsResult.Rows[0].Value.Channels)
 
 	// GET /db/_changes
-	response = rt.Send(requestByUser("GET", "/db/_changes", "", "fran"))
+	response = rt.Send(RequestByUser("GET", "/db/_changes", "", "fran"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
@@ -3553,7 +3553,7 @@ func TestStarAccess(t *testing.T) {
 	assert.Equal(t, uint64(1), since.Seq)
 
 	// GET /db/_changes for ! channel
-	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=!", "", "fran"))
+	response = rt.Send(RequestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=!", "", "fran"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
@@ -3570,17 +3570,17 @@ func TestStarAccess(t *testing.T) {
 	assert.NoError(t, a.Save(manny))
 
 	// GET /db/docid - basic test for doc that has channel
-	response = rt.Send(requestByUser("GET", "/db/doc1", "", "manny"))
-	requireStatus(t, response, 403)
+	response = rt.Send(RequestByUser("GET", "/db/doc1", "", "manny"))
+	RequireStatus(t, response, 403)
 
 	// GET /db/docid - test for doc with ! channel
-	response = rt.Send(requestByUser("GET", "/db/doc3", "", "manny"))
-	requireStatus(t, response, 200)
+	response = rt.Send(RequestByUser("GET", "/db/doc3", "", "manny"))
+	RequireStatus(t, response, 200)
 
 	// GET /db/_all_docs?channels=true
 	// Check that _all_docs only returns ! docs (based on doc ! channel)
-	response = rt.Send(requestByUser("GET", "/db/_all_docs?channels=true", "", "manny"))
-	requireStatus(t, response, 200)
+	response = rt.Send(RequestByUser("GET", "/db/_all_docs?channels=true", "", "manny"))
+	RequireStatus(t, response, 200)
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
@@ -3588,7 +3588,7 @@ func TestStarAccess(t *testing.T) {
 	assert.Equal(t, "doc3", allDocsResult.Rows[0].ID)
 
 	// GET /db/_changes
-	response = rt.Send(requestByUser("GET", "/db/_changes", "", "manny"))
+	response = rt.Send(RequestByUser("GET", "/db/_changes", "", "manny"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
@@ -3598,7 +3598,7 @@ func TestStarAccess(t *testing.T) {
 	assert.Equal(t, uint64(3), since.Seq)
 
 	// GET /db/_changes for ! channel
-	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=!", "", "manny"))
+	response = rt.Send(RequestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=!", "", "manny"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
@@ -3615,10 +3615,10 @@ func TestCreateTarget(t *testing.T) {
 
 	// Attempt to create existing target DB on public API
 	response := rt.SendRequest("PUT", "/db/", "")
-	requireStatus(t, response, 412)
+	RequireStatus(t, response, 412)
 	// Attempt to create new target DB on public API
 	response = rt.SendRequest("PUT", "/foo/", "")
-	requireStatus(t, response, 403)
+	RequireStatus(t, response, 403)
 }
 
 // Test for issue 758 - basic auth with stale session cookie
@@ -3629,12 +3629,12 @@ func TestBasicAuthWithSessionCookie(t *testing.T) {
 
 	// Create two users
 	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", `{"name":"bernard", "password":"letmein", "admin_channels":["bernard"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/db/_user/manny", `{"name":"manny", "password":"letmein","admin_channels":["manny"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// Create a session for the first user
-	response = rt.Send(requestByUser("POST", "/db/_session", `{"name":"bernard", "password":"letmein"}`, "bernard"))
+	response = rt.Send(RequestByUser("POST", "/db/_session", `{"name":"bernard", "password":"letmein"}`, "bernard"))
 	log.Println("response.Header()", response.Header())
 	assert.True(t, response.Header().Get("Set-Cookie") != "")
 
@@ -3645,23 +3645,23 @@ func TestBasicAuthWithSessionCookie(t *testing.T) {
 		"Cookie": cookie,
 	}
 	response = rt.SendRequestWithHeaders("PUT", "/db/bernardDoc", `{"hi": "there", "channels":["bernard"]}`, reqHeaders)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendRequestWithHeaders("GET", "/db/bernardDoc", "", reqHeaders)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	// Create a doc as the second user, with basic auth, channel-restricted to the second user
-	response = rt.Send(requestByUser("PUT", "/db/mannyDoc", `{"hi": "there", "channels":["manny"]}`, "manny"))
-	requireStatus(t, response, 201)
-	response = rt.Send(requestByUser("GET", "/db/mannyDoc", "", "manny"))
-	requireStatus(t, response, 200)
-	response = rt.Send(requestByUser("GET", "/db/bernardDoc", "", "manny"))
-	requireStatus(t, response, 403)
+	response = rt.Send(RequestByUser("PUT", "/db/mannyDoc", `{"hi": "there", "channels":["manny"]}`, "manny"))
+	RequireStatus(t, response, 201)
+	response = rt.Send(RequestByUser("GET", "/db/mannyDoc", "", "manny"))
+	RequireStatus(t, response, 200)
+	response = rt.Send(RequestByUser("GET", "/db/bernardDoc", "", "manny"))
+	RequireStatus(t, response, 403)
 
 	// Attempt to retrieve the docs with the first user's cookie, second user's basic auth credentials.  Basic Auth should take precedence
 	response = rt.SendUserRequestWithHeaders("GET", "/db/bernardDoc", "", reqHeaders, "manny", "letmein")
-	requireStatus(t, response, 403)
+	RequireStatus(t, response, 403)
 	response = rt.SendUserRequestWithHeaders("GET", "/db/mannyDoc", "", reqHeaders, "manny", "letmein")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 }
 
@@ -3720,7 +3720,7 @@ func TestEventConfigValidationInvalid(t *testing.T) {
 
 	buf := bytes.NewBufferString(dbConfigJSON)
 	var dbConfig DbConfig
-	err := decodeAndSanitiseConfig(buf, &dbConfig)
+	err := DecodeAndSanitiseConfig(buf, &dbConfig)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "document_scribbled_on")
 }
@@ -3744,7 +3744,7 @@ func TestBulkGetRevPruning(t *testing.T) {
 
 	// Do a write
 	response := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels":[]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revId := body["rev"]
 
@@ -3806,14 +3806,14 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 	// Add a doc
 	resource := fmt.Sprintf("/db/%v", docIdDoc1)
 	response := rt.SendAdminRequest("PUT", resource, `{"prop":true}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revidDoc1 := body["rev"].(string)
 
 	// Add another doc
 	docIdDoc2 := "doc2"
 	responseDoc2 := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%v", docIdDoc2), `{"prop":true}`)
-	requireStatus(t, responseDoc2, 201)
+	RequireStatus(t, responseDoc2, 201)
 	revidDoc2 := body["rev"].(string)
 
 	// attach to existing document with correct rev (should succeed)
@@ -3828,7 +3828,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 		attachmentBody,
 		reqHeaders,
 	)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// Get the couchbase doc
 	couchbaseDoc := db.Body{}
@@ -3997,29 +3997,29 @@ func TestDocExpiry(t *testing.T) {
 
 	var body db.Body
 	response := rt.SendAdminRequest("PUT", "/db/expNumericTTL", `{"_exp":100}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// Validate that exp isn't returned on the standard GET, bulk get
 	response = rt.SendAdminRequest("GET", "/db/expNumericTTL", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	_, ok := body["_exp"]
 	assert.Equal(t, false, ok)
 
 	bulkGetDocs := `{"docs": [{"id": "expNumericTTL", "rev": "1-ca9ad22802b66f662ff171f226211d5c"}]}`
 	response = rt.SendAdminRequest("POST", "/db/_bulk_get", bulkGetDocs)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	responseString := string(response.Body.Bytes())
 	assert.True(t, !strings.Contains(responseString, "_exp"), "Bulk get response contains _exp property when show_exp not set.")
 
 	response = rt.SendAdminRequest("POST", "/db/_bulk_get?show_exp=true", bulkGetDocs)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	responseString = string(response.Body.Bytes())
 	assert.True(t, strings.Contains(responseString, "_exp"), "Bulk get response doesn't contain _exp property when show_exp was set.")
 
 	body = nil
 	response = rt.SendAdminRequest("GET", "/db/expNumericTTL?show_exp=true", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	_, ok = body["_exp"]
 	assert.Equal(t, true, ok)
@@ -4027,9 +4027,9 @@ func TestDocExpiry(t *testing.T) {
 	// Validate other exp formats
 	body = nil
 	response = rt.SendAdminRequest("PUT", "/db/expNumericUnix", `{"val":1, "_exp":4260211200}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/expNumericUnix?show_exp=true", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	log.Printf("numeric unix response: %s", response.Body.Bytes())
 	_, ok = body["_exp"]
@@ -4037,36 +4037,36 @@ func TestDocExpiry(t *testing.T) {
 
 	body = nil
 	response = rt.SendAdminRequest("PUT", "/db/expNumericString", `{"val":1, "_exp":"100"}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/expNumericString?show_exp=true", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	_, ok = body["_exp"]
 	assert.Equal(t, true, ok)
 
 	body = nil
 	response = rt.SendAdminRequest("PUT", "/db/expBadString", `{"_exp":"abc"}`)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 	response = rt.SendAdminRequest("GET", "/db/expBadString?show_exp=true", "")
-	requireStatus(t, response, 404)
+	RequireStatus(t, response, 404)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	_, ok = body["_exp"]
 	assert.Equal(t, false, ok)
 
 	body = nil
 	response = rt.SendAdminRequest("PUT", "/db/expDateString", `{"_exp":"2105-01-01T00:00:00.000+00:00"}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/expDateString?show_exp=true", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	_, ok = body["_exp"]
 	assert.Equal(t, true, ok)
 
 	body = nil
 	response = rt.SendAdminRequest("PUT", "/db/expBadDateString", `{"_exp":"2105-0321-01T00:00:00.000+00:00"}`)
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 	response = rt.SendAdminRequest("GET", "/db/expBadDateString?show_exp=true", "")
-	requireStatus(t, response, 404)
+	RequireStatus(t, response, 404)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	_, ok = body["_exp"]
 	assert.Equal(t, false, ok)
@@ -4081,10 +4081,10 @@ func TestDocSyncFunctionExpiry(t *testing.T) {
 
 	var body db.Body
 	response := rt.SendAdminRequest("PUT", "/db/expNumericTTL", `{"expiry":100}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	response = rt.SendAdminRequest("GET", "/db/expNumericTTL?show_exp=true", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	value, ok := body["_exp"]
 	assert.Equal(t, true, ok)
@@ -4184,8 +4184,8 @@ func TestLongpollWithWildcard(t *testing.T) {
 	err = db.RestartListener()
 	assert.True(t, err == nil)
 	// Put a document to increment the counter for the * channel
-	response := rt.Send(request("PUT", "/db/lost", `{"channel":["ABC"]}`))
-	requireStatus(t, response, 201)
+	response := rt.Send(Request("PUT", "/db/lost", `{"channel":["ABC"]}`))
+	RequireStatus(t, response, 201)
 
 	// Previous bug: changeWaiter was treating the implicit '*' wildcard in the _changes request as the '*' channel, so the wait counter
 	// was being initialized to 1 (the previous PUT).  Later the wildcard was resolved to actual channels (PBS, _sync:user:bernard), which
@@ -4196,7 +4196,7 @@ func TestLongpollWithWildcard(t *testing.T) {
 		wg.Add(1)
 		defer wg.Done()
 		changesJSON := `{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"0"}`
-		changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+		changesResponse := rt.Send(RequestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 		log.Printf("_changes looks like: %s", changesResponse.Body.Bytes())
 		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 		// Checkthat the changes loop isn't returning an empty result immediately (the previous bug) - should
@@ -4206,7 +4206,7 @@ func TestLongpollWithWildcard(t *testing.T) {
 
 	// Send a doc that will properly close the longpoll response
 	time.Sleep(1 * time.Second)
-	response = rt.Send(request("PUT", "/db/sherlock", `{"channel":["PBS"]}`))
+	response = rt.Send(Request("PUT", "/db/sherlock", `{"channel":["PBS"]}`))
 	wg.Wait()
 }
 
@@ -4387,7 +4387,7 @@ func TestConflictWithInvalidAttachment(t *testing.T) {
 	defer rt.Close()
 
 	// Create Doc
-	docrevId := rt.createDoc(t, "doc1")
+	docrevId := rt.CreateDoc(t, "doc1")
 
 	docRevDigest := strings.Split(docrevId, "-")[1]
 
@@ -4400,7 +4400,7 @@ func TestConflictWithInvalidAttachment(t *testing.T) {
 	// Set attachment
 	attachmentBody := "aGVsbG8gd29ybGQ=" // hello.txt
 	response := rt.SendAdminRequestWithHeaders("PUT", "/db/doc1/attach1?rev="+docrevId, attachmentBody, reqHeaders)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docrevId2 := body["rev"].(string)
@@ -4408,18 +4408,18 @@ func TestConflictWithInvalidAttachment(t *testing.T) {
 	// Update Doc
 	rev3Input := `{"_attachments":{"attach1":{"content-type": "content/type", "digest":"sha1-b7fDq/pHG8Nf5F3fe0K2nu0xcw0=", "length": 16, "revpos": 2, "stub": true}}, "_id": "doc1", "_rev": "` + docrevId2 + `", "prop":true}`
 	response = rt.SendAdminRequest("PUT", "/db/doc1", rev3Input)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docrevId3 := body["rev"].(string)
 
 	// Get Existing Doc & Update rev
 	rev4Input := `{"_attachments":{"attach1":{"content-type": "content/type", "digest":"sha1-b7fDq/pHG8Nf5F3fe0K2nu0xcw0=", "length": 16, "revpos": 2, "stub": true}}, "_id": "doc1", "_rev": "` + docrevId3 + `", "prop":true}`
 	response = rt.SendAdminRequest("PUT", "/db/doc1", rev4Input)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Get Existing Doc to Modify
 	response = rt.SendAdminRequest("GET", "/db/doc1?revs=true", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 
 	// Modify Doc
@@ -4437,7 +4437,7 @@ func TestConflictWithInvalidAttachment(t *testing.T) {
 
 	// Send changed / conflict doc
 	response = rt.SendAdminRequest("PUT", "/db/doc1?new_edits=false", newBody)
-	requireStatus(t, response, http.StatusBadRequest)
+	RequireStatus(t, response, http.StatusBadRequest)
 }
 
 // Create doc with attachment at rev 1 using pre-2.5 metadata (outside of _sync)
@@ -4457,7 +4457,7 @@ func TestAttachmentRevposPre25Metadata(t *testing.T) {
 	require.True(t, ok)
 
 	response := rt.SendAdminRequest("PUT", "/db/doc1?rev=1-6e5a9ed9e2e8637d495ac5dd2fa90479", `{"test":false,"_attachments":{"hello.txt":{"stub":true,"revpos":1}}}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	var putResp struct {
 		OK  bool   `json:"ok"`
 		Rev string `json:"rev"`
@@ -4466,7 +4466,7 @@ func TestAttachmentRevposPre25Metadata(t *testing.T) {
 	require.True(t, putResp.OK)
 
 	response = rt.SendAdminRequest("GET", "/db/doc1", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	var body struct {
 		Test        bool             `json:"test"`
 		Attachments db.AttachmentMap `json:"_attachments"`
@@ -4485,7 +4485,7 @@ func TestConflictingBranchAttachments(t *testing.T) {
 	defer rt.Close()
 
 	// Create a document
-	docRevId := rt.createDoc(t, "doc1")
+	docRevId := rt.CreateDoc(t, "doc1")
 	docRevDigest := strings.Split(docRevId, "-")[1]
 
 	// //Create diverging tree
@@ -4493,7 +4493,7 @@ func TestConflictingBranchAttachments(t *testing.T) {
 
 	reqBodyRev2 := `{"_rev": "2-two", "_revisions": {"ids": ["two", "` + docRevDigest + `"], "start": 2}}`
 	response := rt.SendAdminRequest("PUT", "/db/doc1?new_edits=false", reqBodyRev2)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId2 := body["rev"].(string)
@@ -4501,7 +4501,7 @@ func TestConflictingBranchAttachments(t *testing.T) {
 
 	reqBodyRev2a := `{"_rev": "2-two", "_revisions": {"ids": ["twoa", "` + docRevDigest + `"], "start": 2}}`
 	response = rt.SendAdminRequest("PUT", "/db/doc1?new_edits=false", reqBodyRev2a)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId2a := body["rev"].(string)
 	assert.Equal(t, "2-twoa", docRevId2a)
@@ -4515,28 +4515,28 @@ func TestConflictingBranchAttachments(t *testing.T) {
 	// Put attachment on doc1 rev 2
 	rev3Attachment := `aGVsbG8gd29ybGQ=` // hello.txt
 	response = rt.SendAdminRequestWithHeaders("PUT", "/db/doc1/attach1?rev=2-two", rev3Attachment, reqHeaders)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId3 := body["rev"].(string)
 
 	// Put attachment on doc1 conflicting rev 2a
 	rev3aAttachment := `Z29vZGJ5ZSBjcnVlbCB3b3JsZA==` // bye.txt
 	response = rt.SendAdminRequestWithHeaders("PUT", "/db/doc1/attach1a?rev=2-twoa", rev3aAttachment, reqHeaders)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId3a := body["rev"].(string)
 
 	// Perform small update on doc3
 	rev4Body := `{"_id": "doc1", "_attachments": {"attach1": {"content_type": "content/type", "digest": "sha1-b7fDq/pHG8Nf5F3fe0K2nu0xcw0=", "length": 16, "revpos": 3, "stub":true}}}`
 	response = rt.SendAdminRequest("PUT", "/db/doc1?rev="+docRevId3, rev4Body)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId4 := body["rev"].(string)
 
 	// Perform small update on doc3a
 	rev4aBody := `{"_id": "doc1", "_attachments": {"attach1a": {"content_type": "content/type", "digest": "sha1-rdfKyt3ssqPHnWBUxl/xauXXcUs=", "length": 28, "revpos": 3, "stub": true}}}`
 	response = rt.SendAdminRequest("PUT", "/db/doc1?rev="+docRevId3a, rev4aBody)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId4a := body["rev"].(string)
 
@@ -4559,7 +4559,7 @@ func TestAttachmentsWithTombstonedConflict(t *testing.T) {
 	defer rt.Close()
 
 	// Create a document
-	docRevId := rt.createDoc(t, "doc1")
+	docRevId := rt.CreateDoc(t, "doc1")
 	// docRevDigest := strings.Split(docRevId, "-")[1]
 
 	// Create an attachment
@@ -4572,21 +4572,21 @@ func TestAttachmentsWithTombstonedConflict(t *testing.T) {
 	var body db.Body
 	rev2Attachment := `aGVsbG8gd29ybGQ=` // hello.txt
 	response := rt.SendAdminRequestWithHeaders("PUT", "/db/doc1/attach1?rev="+docRevId, rev2Attachment, reqHeaders)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId2 := body["rev"].(string)
 
 	// Create rev 3, preserve the attachment
 	rev3Body := `{"_id": "doc1", "mod":"mod_3", "_attachments": {"attach1": {"content_type": "content/type", "digest": "sha1-b7fDq/pHG8Nf5F3fe0K2nu0xcw0=", "length": 16, "revpos": 2, "stub":true}}}`
 	response = rt.SendAdminRequest("PUT", "/db/doc1?rev="+docRevId2, rev3Body)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId3 := body["rev"].(string)
 
 	// Add another attachment at rev 4
 	rev4Attachment := `Z29vZGJ5ZSBjcnVlbCB3b3JsZA==` // bye.txt
 	response = rt.SendAdminRequestWithHeaders("PUT", "/db/doc1/attach2?rev="+docRevId3, rev4Attachment, reqHeaders)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId4 := body["rev"].(string)
 
@@ -4598,7 +4598,7 @@ func TestAttachmentsWithTombstonedConflict(t *testing.T) {
 		` "attach2": {"content_type": "content/type", "digest": "sha1-rdfKyt3ssqPHnWBUxl/xauXXcUs=", "length": 28, "revpos": 4, "stub":true}}` +
 		`}`
 	response = rt.SendAdminRequest("PUT", "/db/doc1?rev="+docRevId4, rev5Body)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId5 := body["rev"].(string)
 
@@ -4610,7 +4610,7 @@ func TestAttachmentsWithTombstonedConflict(t *testing.T) {
 		` "attach2": {"content_type": "content/type", "digest": "sha1-rdfKyt3ssqPHnWBUxl/xauXXcUs=", "length": 28, "revpos": 4, "stub":true}}` +
 		`}`
 	response = rt.SendAdminRequest("PUT", "/db/doc1?rev="+docRevId5, rev6Body)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	// docRevId6 := body["rev"].(string)
 
@@ -4623,7 +4623,7 @@ func TestAttachmentsWithTombstonedConflict(t *testing.T) {
 	// Create conflicting rev 6 that doesn't have attachments
 	reqBodyRev6a := `{"_rev": "6-a", "_revisions": {"ids": ["a", "` + docRevId5 + `"], "start": 6}}`
 	response = rt.SendAdminRequest("PUT", "/db/doc1?new_edits=false", reqBodyRev6a)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId2a := body["rev"].(string)
 	assert.Equal(t, "6-a", docRevId2a)
@@ -4636,7 +4636,7 @@ func TestAttachmentsWithTombstonedConflict(t *testing.T) {
 
 	// Tombstone revision 6-a, leaves 6-7368e68932e8261dba7ad831e3cd5a5e as winner
 	response = rt.SendAdminRequest("DELETE", "/db/doc1?rev=6-a", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	// Retrieve current winning rev with attachments
 	var rev7Response db.Body
@@ -4663,8 +4663,8 @@ func TestNumAccessErrors(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(user))
 
-	response := rt.Send(requestByUser("PUT", "/db/doc", `{"prop":true, "channels":["foo"]}`, "user"))
-	requireStatus(t, response, 403)
+	response := rt.Send(RequestByUser("PUT", "/db/doc", `{"prop":true, "channels":["foo"]}`, "user"))
+	RequireStatus(t, response, 403)
 
 	base.WaitForStat(func() int64 { return rt.GetDatabase().DbStats.SecurityStats.NumAccessErrors.Value() }, 1)
 }
@@ -4685,7 +4685,7 @@ func TestNonImportedDuplicateID(t *testing.T) {
 	assert.True(t, ok)
 	assert.Nil(t, err)
 	res := rt.SendAdminRequest("PUT", "/db/key", `{"prop":true}`)
-	requireStatus(t, res, http.StatusConflict)
+	RequireStatus(t, res, http.StatusConflict)
 }
 
 func TestChanCacheActiveRevsStat(t *testing.T) {
@@ -4700,25 +4700,25 @@ func TestChanCacheActiveRevsStat(t *testing.T) {
 	err := base.JSONUnmarshal(response.Body.Bytes(), &responseBody)
 	assert.NoError(t, err)
 	rev1 := fmt.Sprint(responseBody["rev"])
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	response = rt.SendAdminRequest("PUT", "/db/testdoc2", `{"value":"a value", "channels":["a"]}`)
 	err = base.JSONUnmarshal(response.Body.Bytes(), &responseBody)
 	assert.NoError(t, err)
 	rev2 := fmt.Sprint(responseBody["rev"])
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	err = rt.WaitForPendingChanges()
 	assert.NoError(t, err)
 
 	response = rt.SendAdminRequest("GET", "/db/_changes?active_only=true&include_docs=true&filter=sync_gateway/bychannel&channels=a&feed=normal&since=0&heartbeat=0&timeout=300000", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	response = rt.SendAdminRequest("PUT", "/db/testdoc?new_edits=true&rev="+rev1, `{"value":"a value", "channels":[]}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	response = rt.SendAdminRequest("PUT", "/db/testdoc2?new_edits=true&rev="+rev2, `{"value":"a value", "channels":[]}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	err = rt.WaitForPendingChanges()
 	assert.NoError(t, err)
@@ -4795,7 +4795,7 @@ func TestBasicGetReplicator2(t *testing.T) {
 
 	// Put document as usual
 	response := rt.SendAdminRequest("PUT", "/db/doc1", `{"foo": "bar"}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	err := base.JSONUnmarshal(response.Body.Bytes(), &body)
 	assert.NoError(t, err)
 	assert.True(t, body["ok"].(bool))
@@ -4804,23 +4804,23 @@ func TestBasicGetReplicator2(t *testing.T) {
 	// Get a document with rev using replicator2
 	response = rt.SendAdminRequest("GET", "/db/doc1?replicator2=true&rev="+revID, ``)
 	if base.IsEnterpriseEdition() {
-		requireStatus(t, response, http.StatusOK)
+		RequireStatus(t, response, http.StatusOK)
 		err = base.JSONUnmarshal(response.Body.Bytes(), &body)
 		assert.NoError(t, err)
 		assert.Equal(t, "bar", body["foo"])
 	} else {
-		requireStatus(t, response, http.StatusNotImplemented)
+		RequireStatus(t, response, http.StatusNotImplemented)
 	}
 
 	// Get a document without specifying rev using replicator2
 	response = rt.SendAdminRequest("GET", "/db/doc1?replicator2=true", ``)
 	if base.IsEnterpriseEdition() {
-		requireStatus(t, response, http.StatusOK)
+		RequireStatus(t, response, http.StatusOK)
 		err = base.JSONUnmarshal(response.Body.Bytes(), &body)
 		assert.NoError(t, err)
 		assert.Equal(t, "bar", body["foo"])
 	} else {
-		requireStatus(t, response, http.StatusNotImplemented)
+		RequireStatus(t, response, http.StatusNotImplemented)
 	}
 }
 
@@ -4832,7 +4832,7 @@ func TestAttachmentGetReplicator2(t *testing.T) {
 
 	// Put document as usual with attachment
 	response := rt.SendAdminRequest("PUT", "/db/doc1", `{"foo": "bar", "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	err := base.JSONUnmarshal(response.Body.Bytes(), &body)
 	assert.NoError(t, err)
 	assert.True(t, body["ok"].(bool))
@@ -4840,13 +4840,13 @@ func TestAttachmentGetReplicator2(t *testing.T) {
 	// Get a document with rev using replicator2
 	response = rt.SendAdminRequest("GET", "/db/doc1?replicator2=true", ``)
 	if base.IsEnterpriseEdition() {
-		requireStatus(t, response, http.StatusOK)
+		RequireStatus(t, response, http.StatusOK)
 		err = base.JSONUnmarshal(response.Body.Bytes(), &body)
 		assert.NoError(t, err)
 		assert.Equal(t, "bar", body["foo"])
 		assert.Contains(t, body[db.BodyAttachments], "hello.txt")
 	} else {
-		requireStatus(t, response, http.StatusNotImplemented)
+		RequireStatus(t, response, http.StatusNotImplemented)
 	}
 }
 
@@ -4862,37 +4862,37 @@ func TestBasicPutReplicator2(t *testing.T) {
 
 	response := rt.SendAdminRequest("PUT", "/db/doc1?replicator2=true", `{}`)
 	if base.IsEnterpriseEdition() {
-		requireStatus(t, response, http.StatusCreated)
+		RequireStatus(t, response, http.StatusCreated)
 		err = base.JSONUnmarshal(response.Body.Bytes(), &body)
 		assert.NoError(t, err)
 		assert.True(t, body["ok"].(bool))
 		revID = body["rev"].(string)
 		assert.Equal(t, 1, int(rt.GetDatabase().DbStats.Database().NumDocWrites.Value()))
 	} else {
-		requireStatus(t, response, http.StatusNotImplemented)
+		RequireStatus(t, response, http.StatusNotImplemented)
 	}
 
 	// Put basic doc with replicator2 flag and ensure it saves correctly
 	response = rt.SendAdminRequest("PUT", "/db/doc1?replicator2=true&rev="+revID, `{"foo": "bar"}`)
 	if base.IsEnterpriseEdition() {
-		requireStatus(t, response, http.StatusCreated)
+		RequireStatus(t, response, http.StatusCreated)
 		err = base.JSONUnmarshal(response.Body.Bytes(), &body)
 		assert.NoError(t, err)
 		assert.True(t, body["ok"].(bool))
 		assert.Equal(t, 2, int(rt.GetDatabase().DbStats.Database().NumDocWrites.Value()))
 	} else {
-		requireStatus(t, response, http.StatusNotImplemented)
+		RequireStatus(t, response, http.StatusNotImplemented)
 	}
 
 	response = rt.SendAdminRequest("GET", "/db/doc1", ``)
 	if base.IsEnterpriseEdition() {
-		requireStatus(t, response, http.StatusOK)
+		RequireStatus(t, response, http.StatusOK)
 		err = base.JSONUnmarshal(response.Body.Bytes(), &body)
 		assert.NoError(t, err)
 		assert.Equal(t, "bar", body["foo"])
 		assert.Equal(t, 1, int(rt.GetDatabase().DbStats.Database().NumDocReadsRest.Value()))
 	} else {
-		requireStatus(t, response, http.StatusNotFound)
+		RequireStatus(t, response, http.StatusNotFound)
 	}
 }
 
@@ -4903,7 +4903,7 @@ func TestDeletedPutReplicator2(t *testing.T) {
 	var body db.Body
 
 	response := rt.SendAdminRequest("PUT", "/db/doc1", "{}")
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	err := base.JSONUnmarshal(response.Body.Bytes(), &body)
 	assert.NoError(t, err)
 	assert.True(t, body["ok"].(bool))
@@ -4912,7 +4912,7 @@ func TestDeletedPutReplicator2(t *testing.T) {
 
 	response = rt.SendAdminRequest("PUT", "/db/doc1?replicator2=true&rev="+revID+"&deleted=true", "{}")
 	if base.IsEnterpriseEdition() {
-		requireStatus(t, response, http.StatusCreated)
+		RequireStatus(t, response, http.StatusCreated)
 		err = base.JSONUnmarshal(response.Body.Bytes(), &body)
 		assert.NoError(t, err)
 		assert.True(t, body["ok"].(bool))
@@ -4920,25 +4920,25 @@ func TestDeletedPutReplicator2(t *testing.T) {
 		assert.Equal(t, 2, int(rt.GetDatabase().DbStats.Database().NumDocWrites.Value()))
 
 		response = rt.SendAdminRequest("GET", "/db/doc1", ``)
-		requireStatus(t, response, http.StatusNotFound)
+		RequireStatus(t, response, http.StatusNotFound)
 		assert.Equal(t, 0, int(rt.GetDatabase().DbStats.Database().NumDocReadsRest.Value()))
 	} else {
-		requireStatus(t, response, http.StatusNotImplemented)
+		RequireStatus(t, response, http.StatusNotImplemented)
 	}
 
 	response = rt.SendAdminRequest("PUT", "/db/doc1?replicator2=true&rev="+revID+"&deleted=false", `{}`)
 	if base.IsEnterpriseEdition() {
-		requireStatus(t, response, http.StatusCreated)
+		RequireStatus(t, response, http.StatusCreated)
 		err = base.JSONUnmarshal(response.Body.Bytes(), &body)
 		assert.NoError(t, err)
 		assert.True(t, body["ok"].(bool))
 		assert.Equal(t, 3, int(rt.GetDatabase().DbStats.Database().NumDocWrites.Value()))
 
 		response = rt.SendAdminRequest("GET", "/db/doc1", ``)
-		requireStatus(t, response, http.StatusOK)
+		RequireStatus(t, response, http.StatusOK)
 		assert.Equal(t, 1, int(rt.GetDatabase().DbStats.Database().NumDocReadsRest.Value()))
 	} else {
-		requireStatus(t, response, http.StatusNotImplemented)
+		RequireStatus(t, response, http.StatusNotImplemented)
 	}
 }
 
@@ -4978,7 +4978,7 @@ func TestWebhookSpecialProperties(t *testing.T) {
 
 	wg.Add(1)
 	res := rt.SendAdminRequest("PUT", "/db/"+t.Name(), `{"foo": "bar", "_deleted": true}`)
-	requireStatus(t, res, http.StatusCreated)
+	RequireStatus(t, res, http.StatusCreated)
 	wg.Wait()
 }
 
@@ -5030,7 +5030,7 @@ func TestWebhookPropsWithAttachments(t *testing.T) {
 	// Create first revision of the document with no attachment.
 	wg.Add(1)
 	response := rt.SendAdminRequest(http.MethodPut, "/db/doc1", `{"foo": "bar"}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	require.True(t, body["ok"].(bool))
@@ -5043,7 +5043,7 @@ func TestWebhookPropsWithAttachments(t *testing.T) {
 	resource := "/db/doc1/attach1?rev=" + doc1revId
 	wg.Add(1)
 	response = rt.SendAdminRequestWithHeaders(http.MethodPut, resource, attachmentBody, reqHeaders)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	require.True(t, body["ok"].(bool))
 	revIdAfterAttachment := body["rev"].(string)
@@ -5102,19 +5102,19 @@ func TestWebhookWinningRevChangedEvent(t *testing.T) {
 
 	wg.Add(2)
 	res := rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar"}`)
-	requireStatus(t, res, http.StatusCreated)
-	rev1 := respRevID(t, res)
+	RequireStatus(t, res, http.StatusCreated)
+	rev1 := RespRevID(t, res)
 	_, rev1Hash := db.ParseRevID(rev1)
 
 	// push winning branch
 	wg.Add(2)
 	res = rt.SendAdminRequest("PUT", "/db/doc1?new_edits=false", `{"foo":"buzz","_revisions":{"start":3,"ids":["buzz","bar","`+rev1Hash+`"]}}`)
-	requireStatus(t, res, http.StatusCreated)
+	RequireStatus(t, res, http.StatusCreated)
 
 	// push non-winning branch
 	wg.Add(1)
 	res = rt.SendAdminRequest("PUT", "/db/doc1?new_edits=false", `{"foo":"buzzzzz","_revisions":{"start":2,"ids":["buzzzzz","`+rev1Hash+`"]}}`)
-	requireStatus(t, res, http.StatusCreated)
+	RequireStatus(t, res, http.StatusCreated)
 
 	wg.Wait()
 	assert.Equal(t, 2, int(atomic.LoadUint32(&WinningRevChangedCount)))
@@ -5123,7 +5123,7 @@ func TestWebhookWinningRevChangedEvent(t *testing.T) {
 	// tombstone the winning branch and ensure we get a rev changed message for the promoted branch
 	wg.Add(2)
 	res = rt.SendAdminRequest("DELETE", "/db/doc1?rev=3-buzz", ``)
-	requireStatus(t, res, http.StatusOK)
+	RequireStatus(t, res, http.StatusOK)
 
 	wg.Wait()
 	assert.Equal(t, 3, int(atomic.LoadUint32(&WinningRevChangedCount)))
@@ -5132,12 +5132,12 @@ func TestWebhookWinningRevChangedEvent(t *testing.T) {
 	// push a separate winning branch
 	wg.Add(2)
 	res = rt.SendAdminRequest("PUT", "/db/doc1?new_edits=false", `{"foo":"quux","_revisions":{"start":4,"ids":["quux", "buzz","bar","`+rev1Hash+`"]}}`)
-	requireStatus(t, res, http.StatusCreated)
+	RequireStatus(t, res, http.StatusCreated)
 
 	// tombstone the winning branch, we should get a second webhook fired for rev 2-buzzzzz now it's been resurrected
 	wg.Add(2)
 	res = rt.SendAdminRequest("DELETE", "/db/doc1?rev=4-quux", ``)
-	requireStatus(t, res, http.StatusOK)
+	RequireStatus(t, res, http.StatusOK)
 
 	wg.Wait()
 	assert.Equal(t, 5, int(atomic.LoadUint32(&WinningRevChangedCount)))
@@ -5250,25 +5250,25 @@ func TestHandleProfiling(t *testing.T) {
 		filePath := filepath.Join(dirPath, fmt.Sprintf("%s.pprof", tc.inputProfile))
 		reqBodyText := fmt.Sprintf(`{"file":"%v"}`, filepath.ToSlash(filePath))
 		response := rt.SendAdminRequest(http.MethodPost, resource, reqBodyText)
-		requireStatus(t, response, http.StatusOK)
+		RequireStatus(t, response, http.StatusOK)
 		fi, err := os.Stat(filePath)
 		assert.NoError(t, err, "fetching the file information")
 		assert.True(t, fi.Size() > 0)
 
 		// Send profile request with missing JSON 'file' parameter.
 		response = rt.SendAdminRequest(http.MethodPost, resource, "{}")
-		requireStatus(t, response, http.StatusBadRequest)
+		RequireStatus(t, response, http.StatusBadRequest)
 		assert.Contains(t, string(response.BodyBytes()), "Missing JSON 'file' parameter")
 
 		// Send a profile request with invalid json body
 		response = rt.SendAdminRequest(http.MethodPost, resource, "invalid json body")
-		requireStatus(t, response, http.StatusBadRequest)
+		RequireStatus(t, response, http.StatusBadRequest)
 		assert.Contains(t, string(response.BodyBytes()), "Invalid JSON")
 
 		// Send a profile request with unknown file path; Internal Server Error
 		reqBodyText = `{"file":"sftp://unknown/path"}`
 		response = rt.SendAdminRequest(http.MethodPost, resource, reqBodyText)
-		requireStatus(t, response, http.StatusInternalServerError)
+		RequireStatus(t, response, http.StatusInternalServerError)
 		assert.Contains(t, string(response.BodyBytes()), "Internal Server Error")
 	}
 
@@ -5277,7 +5277,7 @@ func TestHandleProfiling(t *testing.T) {
 	reqBodyText := fmt.Sprintf(`{"file":"%v"}`, filepath.ToSlash(filePath))
 	response := rt.SendAdminRequest(http.MethodPost, "/_profile/unknown", reqBodyText)
 	log.Printf("string(response.BodyBytes()): %v", string(response.BodyBytes()))
-	requireStatus(t, response, http.StatusNotFound)
+	RequireStatus(t, response, http.StatusNotFound)
 	assert.Contains(t, string(response.BodyBytes()), `No such profile \"unknown\"`)
 
 	// Send profile request with filename and empty profile name; it should end up creating cpu profile
@@ -5285,7 +5285,7 @@ func TestHandleProfiling(t *testing.T) {
 	reqBodyText = fmt.Sprintf(`{"file":"%v"}`, filepath.ToSlash(filePath))
 	response = rt.SendAdminRequest(http.MethodPost, "/_profile", reqBodyText)
 	log.Printf("string(response.BodyBytes()): %v", string(response.BodyBytes()))
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	fi, err := os.Stat(filePath)
 	assert.NoError(t, err, "fetching the file information")
 	assert.False(t, fi.Size() > 0)
@@ -5293,7 +5293,7 @@ func TestHandleProfiling(t *testing.T) {
 	// Send profile request with no filename and profile name; it should stop cpu profile
 	response = rt.SendAdminRequest(http.MethodPost, "/_profile", "")
 	log.Printf("string(response.BodyBytes()): %v", string(response.BodyBytes()))
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	fi, err = os.Stat(filePath)
 	assert.NoError(t, err, "fetching the file information")
 	assert.True(t, fi.Size() > 0)
@@ -5309,19 +5309,19 @@ func TestHandleHeapProfiling(t *testing.T) {
 	filePath := filepath.Join(dirPath, "heap.pprof")
 	reqBodyText := fmt.Sprintf(`{"file":"%v"}`, filepath.ToSlash(filePath))
 	response := rt.SendAdminRequest(http.MethodPost, "/_heap", reqBodyText)
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	fi, err := os.Stat(filePath)
 	assert.NoError(t, err, "fetching heap profile file information")
 	assert.True(t, fi.Size() > 0)
 
 	// Send a profile request with invalid json body
 	response = rt.SendAdminRequest(http.MethodPost, "/_heap", "invalid json body")
-	requireStatus(t, response, http.StatusBadRequest)
+	RequireStatus(t, response, http.StatusBadRequest)
 	assert.Contains(t, string(response.BodyBytes()), "Invalid JSON")
 
 	// Send profile request with missing JSON 'file' parameter.
 	response = rt.SendAdminRequest(http.MethodPost, "/_heap", "{}")
-	requireStatus(t, response, http.StatusInternalServerError)
+	RequireStatus(t, response, http.StatusInternalServerError)
 	assert.Contains(t, string(response.BodyBytes()), "Internal error: open")
 }
 
@@ -5343,13 +5343,13 @@ func TestHandlePprofsCmdlineAndSymbol(t *testing.T) {
 			assert.Equal(t, "", response.Header().Get("Content-Disposition"))
 			assert.Equal(t, "text/plain; charset=utf-8", response.Header().Get("Content-Type"))
 			assert.Equal(t, "nosniff", response.Header().Get("X-Content-Type-Options"))
-			requireStatus(t, response, http.StatusOK)
+			RequireStatus(t, response, http.StatusOK)
 
 			response = rt.SendAdminRequest(http.MethodPost, inputResource, "")
 			assert.Equal(t, "", response.Header().Get("Content-Disposition"))
 			assert.Equal(t, "text/plain; charset=utf-8", response.Header().Get("Content-Type"))
 			assert.Equal(t, "nosniff", response.Header().Get("X-Content-Type-Options"))
-			requireStatus(t, response, http.StatusOK)
+			RequireStatus(t, response, http.StatusOK)
 		})
 	}
 }
@@ -5405,14 +5405,14 @@ func TestHandlePprofs(t *testing.T) {
 			assert.Truef(t, strings.HasPrefix(cdHeader, expectedContentDispositionPrefix), "Expected header prefix: %q but got %q", expectedContentDispositionPrefix, cdHeader)
 			assert.Equal(t, "application/octet-stream", response.Header().Get("Content-Type"))
 			assert.Equal(t, "nosniff", response.Header().Get("X-Content-Type-Options"))
-			requireStatus(t, response, http.StatusOK)
+			RequireStatus(t, response, http.StatusOK)
 
 			response = rt.SendAdminRequest(http.MethodPost, tc.inputResource, "")
 			cdHeader = response.Header().Get("Content-Disposition")
 			assert.Truef(t, strings.HasPrefix(cdHeader, expectedContentDispositionPrefix), "Expected header prefix: %q but got %q", expectedContentDispositionPrefix, cdHeader)
 			assert.Equal(t, "application/octet-stream", response.Header().Get("Content-Type"))
 			assert.Equal(t, "nosniff", response.Header().Get("X-Content-Type-Options"))
-			requireStatus(t, response, http.StatusOK)
+			RequireStatus(t, response, http.StatusOK)
 		})
 	}
 }
@@ -5425,7 +5425,7 @@ func TestHandleStats(t *testing.T) {
 	response := rt.SendAdminRequest(http.MethodGet, "/_stats", "")
 	assert.Equal(t, "application/json", response.Header().Get("Content-Type"))
 	assert.Contains(t, string(response.BodyBytes()), "MemStats")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 }
 
 // Try to create session with invalid cert but valid credentials
@@ -5435,7 +5435,7 @@ func TestSessionFail(t *testing.T) {
 
 	// Create user
 	response := rt.SendAdminRequest("PUT", "/db/_user/user1", `{"name":"user1", "password":"letmein", "admin_channels":["user1"]}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	id, err := base.GenerateRandomSecret()
 	require.NoError(t, err)
@@ -5454,7 +5454,7 @@ func TestSessionFail(t *testing.T) {
 
 	// Attempt to create session with invalid cert but valid login
 	response = rt.SendRequestWithHeaders("POST", "/db/_session", `{"name":"user1", "password":"letmein"}`, reqHeaders)
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 }
 
 func TestImportOnWriteMigration(t *testing.T) {
@@ -5479,15 +5479,15 @@ func TestImportOnWriteMigration(t *testing.T) {
 
 	// Update doc with xattr - get 409, creates new rev, has old body
 	response := rt.SendAdminRequest("PUT", "/db/doc1?rev=1-fc2cf22c5e5007bd966869ebfe9e276a", `{"value":"new"}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Update doc with xattr - successful update
 	response = rt.SendAdminRequest("PUT", "/db/doc1?rev=2-44ad6f128a2b1f75d0d0bb49b1fc0019", `{"value":"newer"}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 }
 
 func TestAttachmentContentType(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	type attTest struct {
@@ -5542,7 +5542,7 @@ func TestAttachmentContentType(t *testing.T) {
 		}
 		attachmentBody := fmt.Sprintf(`{"key":"val", "_attachments": {"login.aspx": {"data": "PGgxPllvdXJCYW5rIExvZ2luPC9oMT4KPGlucHV0Lz4KPGlucHV0Lz4KPGlucHV0IHR5cGU9InN1Ym1pdCIvPg=="%s}}}`, contentType)
 		response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/doc_%d", index), attachmentBody)
-		requireStatus(t, response, http.StatusCreated)
+		RequireStatus(t, response, http.StatusCreated)
 
 		response = rt.SendRequest("GET", fmt.Sprintf("/db/doc_%d/login.aspx", index), "")
 		contentDisposition := response.Header().Get("Content-Disposition")
@@ -5593,13 +5593,13 @@ func TestHideProductInfo(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("hide:%v admin:%v", test.hideProductInfo, test.admin), func(t *testing.T) {
-			rt := NewRestTester(t, &RestTesterConfig{hideProductInfo: test.hideProductInfo})
+			rt := NewRestTester(t, &RestTesterConfig{HideProductInfo: test.hideProductInfo})
 			defer rt.Close()
 
 			// admins can always see product info, even if setting is enabled
 			if test.admin {
 				resp := rt.SendAdminRequest(http.MethodGet, "/", "")
-				requireStatus(t, resp, http.StatusOK)
+				RequireStatus(t, resp, http.StatusOK)
 
 				assert.Equal(t, base.VersionString, resp.Header().Get("Server"))
 
@@ -5610,7 +5610,7 @@ func TestHideProductInfo(t *testing.T) {
 
 			// non-admins can only see product info when the hideProductInfo option is disabled
 			resp := rt.SendRequest(http.MethodGet, "/", "")
-			requireStatus(t, resp, http.StatusOK)
+			RequireStatus(t, resp, http.StatusOK)
 
 			serverHeader := resp.Header().Get("Server")
 			body := string(resp.BodyBytes())
@@ -5635,10 +5635,10 @@ func TestDeleteNonExistentDoc(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("DELETE", "/db/fake", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	response = rt.SendAdminRequest("GET", "/db/fake", "")
-	requireStatus(t, response, http.StatusNotFound)
+	RequireStatus(t, response, http.StatusNotFound)
 
 	var body map[string]interface{}
 	_, err := rt.GetDatabase().Bucket.Get("fake", &body)
@@ -5659,15 +5659,15 @@ func TestDeleteEmptyBodyDoc(t *testing.T) {
 
 	var body db.Body
 	response := rt.SendAdminRequest("PUT", "/db/doc1", "{}")
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	assert.NoError(t, json.Unmarshal(response.BodyBytes(), &body))
 	rev := body["rev"].(string)
 
 	response = rt.SendAdminRequest("DELETE", "/db/doc1?rev="+rev, "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	response = rt.SendAdminRequest("GET", "/db/doc1", "")
-	requireStatus(t, response, http.StatusNotFound)
+	RequireStatus(t, response, http.StatusNotFound)
 
 	var doc map[string]interface{}
 	_, err := rt.GetDatabase().Bucket.Get("doc1", &doc)
@@ -5685,17 +5685,17 @@ func TestPutEmptyDoc(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/db/doc", "{}")
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	response = rt.SendAdminRequest("GET", "/db/doc", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	assert.Equal(t, `{"_id":"doc","_rev":"1-ca9ad22802b66f662ff171f226211d5c"}`, string(response.BodyBytes()))
 
 	response = rt.SendAdminRequest("PUT", "/db/doc?rev=1-ca9ad22802b66f662ff171f226211d5c", `{"val": "newval"}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	response = rt.SendAdminRequest("GET", "/db/doc", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	assert.Equal(t, `{"_id":"doc","_rev":"2-2f981cadffde70e8a1d9dc386a410e0d","val":"newval"}`, string(response.BodyBytes()))
 }
 
@@ -5704,7 +5704,7 @@ func TestTombstonedBulkDocs(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("POST", "/db/_bulk_docs", `{"new_edits": false, "docs": [{"_id":"`+t.Name()+`", "_deleted": true, "_revisions":{"start":9, "ids":["c45c049b7fe6cf64cd8595c1990f6504", "6e01ac52ffd5ce6a4f7f4024c08d296f"]}}]}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	var body map[string]interface{}
 	_, err := rt.GetDatabase().Bucket.Get(t.Name(), &body)
@@ -5743,10 +5743,10 @@ func TestTombstonedBulkDocsWithPriorPurge(t *testing.T) {
 	require.NoError(t, err)
 
 	resp := rt.SendAdminRequest("POST", "/db/_purge", `{"`+t.Name()+`": ["*"]}`)
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	response := rt.SendAdminRequest("POST", "/db/_bulk_docs", `{"new_edits": false, "docs": [{"_id":"`+t.Name()+`", "_deleted": true, "_revisions":{"start":9, "ids":["c45c049b7fe6cf64cd8595c1990f6504", "6e01ac52ffd5ce6a4f7f4024c08d296f"]}}]}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	var body map[string]interface{}
 	_, err = rt.GetDatabase().Bucket.Get(t.Name(), &body)
@@ -5789,7 +5789,7 @@ func TestTombstonedBulkDocsWithExistingTombstone(t *testing.T) {
 	require.NoError(t, err)
 
 	response := rt.SendAdminRequest("POST", "/db/_bulk_docs", `{"new_edits": false, "docs": [{"_id":"`+t.Name()+`", "_deleted": true, "_revisions":{"start":9, "ids":["c45c049b7fe6cf64cd8595c1990f6504", "6e01ac52ffd5ce6a4f7f4024c08d296f"]}}]}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	var body map[string]interface{}
 	_, err = rt.GetDatabase().Bucket.Get(t.Name(), &body)
@@ -5837,14 +5837,14 @@ func TestPutTombstoneWithoutCreateAsDeletedFlagCasFailure(t *testing.T) {
 	// base.RunXattrCallback = true
 	// base.UpdateXattrCallback = func() {
 	// 	response := rt.SendAdminRequest("PUT", "/db/doc", `{"val": "update"}`)
-	// 	requireStatus(t, response, http.StatusCreated)
+	// 	RequireStatus(t, response, http.StatusCreated)
 	// }
 
 	response := rt.SendAdminRequest("PUT", "/db/doc", `{"_deleted": true, "val": "original"}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	response = rt.SendAdminRequest("GET", "/db/doc", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	var body db.Body
 	err := json.Unmarshal(response.BodyBytes(), &body)
@@ -5914,7 +5914,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 
 	// Add doc
 	resp := rt.SendAdminRequest("PUT", "/db/"+docKey, "{}")
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	// Add xattr to doc
 	_, err := userXattrStore.WriteUserXattr(docKey, xattrKey, channelName)
@@ -6042,7 +6042,7 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 
 	// GET to trigger import
 	resp := rt.SendAdminRequest("GET", "/db/"+docKey, "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	// Wait for import
 	err = rt.WaitForCondition(func() bool {
@@ -6059,7 +6059,7 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 
 	// GET to trigger import
 	resp = rt.SendAdminRequest("GET", "/db/"+docKey, "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	// Wait for import
 	err = rt.WaitForCondition(func() bool {
@@ -6083,7 +6083,7 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 
 	// Perform GET and ensure import isn't triggered as crc32 hash is the same
 	resp = rt.SendAdminRequest("GET", "/db/"+docKey, "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	var syncData2 db.SyncData
 	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
@@ -6136,7 +6136,7 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 
 	// Initial PUT
 	resp := rt.SendAdminRequest("PUT", "/db/"+docKey, `{}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	// SDK PUT
 	err := rt.Bucket().Set(docKey, 0, nil, []byte(`{"update": "update"}`))
@@ -6144,7 +6144,7 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 
 	// Trigger Import
 	resp = rt.SendAdminRequest("PUT", "/db/"+docKey, `{}`)
-	requireStatus(t, resp, http.StatusConflict)
+	RequireStatus(t, resp, http.StatusConflict)
 
 	// Wait for import
 	err = rt.WaitForCondition(func() bool {
@@ -6161,7 +6161,7 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 
 	// Trigger import
 	resp = rt.SendAdminRequest("PUT", "/db/"+docKey, `{"update": "update"}`)
-	requireStatus(t, resp, http.StatusConflict)
+	RequireStatus(t, resp, http.StatusConflict)
 
 	// Wait for import
 	err = rt.WaitForCondition(func() bool {
@@ -6206,7 +6206,7 @@ func TestRemovingUserXattr(t *testing.T) {
 			autoImport: false,
 			importTrigger: func(t *testing.T, rt *RestTester, docKey string) {
 				resp := rt.SendAdminRequest("GET", "/db/"+docKey, "")
-				requireStatus(t, resp, http.StatusOK)
+				RequireStatus(t, resp, http.StatusOK)
 			},
 		},
 		{
@@ -6214,7 +6214,7 @@ func TestRemovingUserXattr(t *testing.T) {
 			autoImport: false,
 			importTrigger: func(t *testing.T, rt *RestTester, docKey string) {
 				resp := rt.SendAdminRequest("PUT", "/db/"+docKey, "{}")
-				requireStatus(t, resp, http.StatusConflict)
+				RequireStatus(t, resp, http.StatusConflict)
 			},
 		},
 		{
@@ -6255,7 +6255,7 @@ func TestRemovingUserXattr(t *testing.T) {
 
 			// Initial PUT
 			resp := rt.SendAdminRequest("PUT", "/db/"+docKey, `{}`)
-			requireStatus(t, resp, http.StatusCreated)
+			RequireStatus(t, resp, http.StatusCreated)
 
 			// Add xattr
 			_, err := gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
@@ -6344,7 +6344,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 
 	// Initial PUT
 	resp := rt.SendAdminRequest("PUT", "/db/"+docKey, `{}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	require.NoError(t, rt.WaitForPendingChanges())
 
@@ -6409,7 +6409,7 @@ func TestDocumentChannelHistory(t *testing.T) {
 	// Create doc in channel test and ensure a single channel history entry with only a start sequence
 	// and no old channel history entries
 	resp := rt.SendAdminRequest("PUT", "/db/doc", `{"channels": ["test"]}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 	err := json.Unmarshal(resp.BodyBytes(), &body)
 	assert.NoError(t, err)
 	syncData, err := rt.GetDatabase().GetDocSyncData(base.TestCtx(t), "doc")
@@ -6422,7 +6422,7 @@ func TestDocumentChannelHistory(t *testing.T) {
 	// Update doc to remove from channel and ensure a single channel history entry with both start and end sequences
 	// and no old channel history entries
 	resp = rt.SendAdminRequest("PUT", "/db/doc?rev="+body["rev"].(string), `{"channels": []}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 	err = json.Unmarshal(resp.BodyBytes(), &body)
 	assert.NoError(t, err)
 	syncData, err = rt.GetDatabase().GetDocSyncData(base.TestCtx(t), "doc")
@@ -6435,7 +6435,7 @@ func TestDocumentChannelHistory(t *testing.T) {
 	// Update doc to add to channels test and test2 and ensure a single channel history entry for both test and test2
 	// both with start sequences only and ensure old test entry was moved to old
 	resp = rt.SendAdminRequest("PUT", "/db/doc?rev="+body["rev"].(string), `{"channels": ["test", "test2"]}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 	err = json.Unmarshal(resp.BodyBytes(), &body)
 	assert.NoError(t, err)
 	syncData, err = rt.GetDatabase().GetDocSyncData(base.TestCtx(t), "doc")
@@ -6495,12 +6495,12 @@ func TestChannelHistoryLegacyDoc(t *testing.T) {
 
 	// Get doc and ensure its available
 	resp := rt.SendAdminRequest("GET", "/db/doc1", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	// Remove doc from channel and ensure that channel history is built correctly with current end sequence and
 	// setting start sequence
 	resp = rt.SendAdminRequest("PUT", "/db/doc1?rev=1-08267a64bf0e3963bab7dece1ea0887a", `{"channels": []}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 	err = json.Unmarshal(resp.BodyBytes(), &body)
 	assert.NoError(t, err)
 	syncData, err := rt.GetDatabase().GetDocSyncData(base.TestCtx(t), "doc1")
@@ -6542,7 +6542,7 @@ func (tester *ChannelRevocationTester) addRole(user, role string) {
 	}
 
 	tester.roles.Roles[user] = append(tester.roles.Roles[user], fmt.Sprintf("role:%s", role))
-	revID := tester.restTester.createDocReturnRev(tester.test, "userRoles", tester.roleRev, tester.roles)
+	revID := tester.restTester.CreateDocReturnRev(tester.test, "userRoles", tester.roleRev, tester.roles)
 	tester.roleRev = revID
 }
 
@@ -6556,7 +6556,7 @@ func (tester *ChannelRevocationTester) removeRole(user, role string) {
 		}
 	}
 	tester.roles.Roles[user] = append(roles[:delIdx], roles[delIdx+1:]...)
-	tester.roleRev = tester.restTester.createDocReturnRev(tester.test, "userRoles", tester.roleRev, tester.roles)
+	tester.roleRev = tester.restTester.CreateDocReturnRev(tester.test, "userRoles", tester.roleRev, tester.roles)
 }
 
 func (tester *ChannelRevocationTester) addRoleChannel(role, channel string) {
@@ -6567,7 +6567,7 @@ func (tester *ChannelRevocationTester) addRoleChannel(role, channel string) {
 	role = fmt.Sprintf("role:%s", role)
 
 	tester.roleChannels.Channels[role] = append(tester.roleChannels.Channels[role], channel)
-	tester.roleChannelRev = tester.restTester.createDocReturnRev(tester.test, "roleChannels", tester.roleChannelRev, tester.roleChannels)
+	tester.roleChannelRev = tester.restTester.CreateDocReturnRev(tester.test, "roleChannels", tester.roleChannelRev, tester.roleChannels)
 }
 
 func (tester *ChannelRevocationTester) removeRoleChannel(role, channel string) {
@@ -6581,7 +6581,7 @@ func (tester *ChannelRevocationTester) removeRoleChannel(role, channel string) {
 		}
 	}
 	tester.roleChannels.Channels[role] = append(channelsSlice[:delIdx], channelsSlice[delIdx+1:]...)
-	tester.roleChannelRev = tester.restTester.createDocReturnRev(tester.test, "roleChannels", tester.roleChannelRev, tester.roleChannels)
+	tester.roleChannelRev = tester.restTester.CreateDocReturnRev(tester.test, "roleChannels", tester.roleChannelRev, tester.roleChannels)
 }
 
 func (tester *ChannelRevocationTester) addUserChannel(user, channel string) {
@@ -6590,7 +6590,7 @@ func (tester *ChannelRevocationTester) addUserChannel(user, channel string) {
 	}
 
 	tester.userChannels.Channels[user] = append(tester.userChannels.Channels[user], channel)
-	tester.userChannelRev = tester.restTester.createDocReturnRev(tester.test, "userChannels", tester.userChannelRev, tester.userChannels)
+	tester.userChannelRev = tester.restTester.CreateDocReturnRev(tester.test, "userChannels", tester.userChannelRev, tester.userChannels)
 }
 
 func (tester *ChannelRevocationTester) removeUserChannel(user, channel string) {
@@ -6603,7 +6603,7 @@ func (tester *ChannelRevocationTester) removeUserChannel(user, channel string) {
 		}
 	}
 	tester.userChannels.Channels[user] = append(channelsSlice[:delIdx], channelsSlice[delIdx+1:]...)
-	tester.userChannelRev = tester.restTester.createDocReturnRev(tester.test, "userChannels", tester.userChannelRev, tester.userChannels)
+	tester.userChannelRev = tester.restTester.CreateDocReturnRev(tester.test, "userChannels", tester.userChannelRev, tester.userChannels)
 }
 
 func (tester *ChannelRevocationTester) fillToSeq(seq uint64) {
@@ -6627,8 +6627,8 @@ func (tester *ChannelRevocationTester) fillToSeq(seq uint64) {
 	}
 }
 
-func (tester *ChannelRevocationTester) getChanges(sinceSeq interface{}, expectedLength int) changesResults {
-	var changes changesResults
+func (tester *ChannelRevocationTester) getChanges(sinceSeq interface{}, expectedLength int) ChangesResults {
+	var changes ChangesResults
 
 	// Ensure any previous mutations have caught up before issuing changes request
 	err := tester.restTester.WaitForPendingChanges()
@@ -6650,7 +6650,7 @@ func (tester *ChannelRevocationTester) getChanges(sinceSeq interface{}, expected
 	return changes
 }
 
-func initScenario(t *testing.T, rtConfig *RestTesterConfig) (ChannelRevocationTester, *RestTester) {
+func InitScenario(t *testing.T, rtConfig *RestTesterConfig) (ChannelRevocationTester, *RestTester) {
 	defaultSyncFn := `
 			function (doc, oldDoc){
 				if (doc._id === 'userRoles'){				
@@ -6691,15 +6691,15 @@ func initScenario(t *testing.T, rtConfig *RestTesterConfig) (ChannelRevocationTe
 	}
 
 	resp := rt.SendAdminRequest("PUT", "/db/_user/user", `{"name": "user", "password": "test"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	resp = rt.SendAdminRequest("PUT", "/db/_role/foo", `{}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	return revocationTester, rt
 }
 
-func (rt *RestTester) createDocReturnRev(t *testing.T, docID string, revID string, bodyIn interface{}) string {
+func (rt *RestTester) CreateDocReturnRev(t *testing.T, docID string, revID string, bodyIn interface{}) string {
 	bodyJSON, err := base.JSONMarshal(bodyIn)
 	assert.NoError(t, err)
 
@@ -6709,7 +6709,7 @@ func (rt *RestTester) createDocReturnRev(t *testing.T, docID string, revID strin
 	}
 
 	resp := rt.SendAdminRequest("PUT", url, string(bodyJSON))
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &body))
@@ -6726,11 +6726,11 @@ func (rt *RestTester) createDocReturnRev(t *testing.T, docID string, revID strin
 func TestRevocationScenario1(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
 	revocationTester.addRoleChannel("foo", "ch1")
@@ -6777,11 +6777,11 @@ func TestRevocationScenario1(t *testing.T) {
 func TestRevocationScenario2(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
 	revocationTester.addRoleChannel("foo", "ch1")
@@ -6829,11 +6829,11 @@ func TestRevocationScenario2(t *testing.T) {
 func TestRevocationScenario3(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
 	revocationTester.addRoleChannel("foo", "ch1")
@@ -6881,11 +6881,11 @@ func TestRevocationScenario3(t *testing.T) {
 func TestRevocationScenario4(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
 	revocationTester.addRoleChannel("foo", "ch1")
@@ -6933,11 +6933,11 @@ func TestRevocationScenario4(t *testing.T) {
 func TestRevocationScenario5(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
 	revocationTester.addRoleChannel("foo", "ch1")
@@ -6979,11 +6979,11 @@ func TestRevocationScenario5(t *testing.T) {
 func TestRevocationScenario6(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
 	revocationTester.addRoleChannel("foo", "ch1")
@@ -7026,11 +7026,11 @@ func TestRevocationScenario6(t *testing.T) {
 func TestRevocationScenario7(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
 	revocationTester.addRoleChannel("foo", "ch1")
@@ -7073,11 +7073,11 @@ func TestRevocationScenario7(t *testing.T) {
 func TestRevocationScenario8(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
 	revocationTester.addRoleChannel("foo", "ch1")
@@ -7113,11 +7113,11 @@ func TestRevocationScenario8(t *testing.T) {
 func TestRevocationScenario9(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
 	revocationTester.addRoleChannel("foo", "ch1")
@@ -7153,11 +7153,11 @@ func TestRevocationScenario9(t *testing.T) {
 func TestRevocationScenario10(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
 	revocationTester.addRoleChannel("foo", "ch1")
@@ -7193,11 +7193,11 @@ func TestRevocationScenario10(t *testing.T) {
 func TestRevocationScenario11(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
 	revocationTester.addRoleChannel("foo", "ch1")
@@ -7234,11 +7234,11 @@ func TestRevocationScenario11(t *testing.T) {
 func TestRevocationScenario12(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
 	revocationTester.addRoleChannel("foo", "ch1")
@@ -7274,11 +7274,11 @@ func TestRevocationScenario12(t *testing.T) {
 func TestRevocationScenario13(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
 	revocationTester.addRoleChannel("foo", "ch1")
@@ -7313,11 +7313,11 @@ func TestRevocationScenario13(t *testing.T) {
 func TestRevocationScenario14(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
 	revocationTester.addRoleChannel("foo", "ch1")
@@ -7343,7 +7343,7 @@ func TestRevocationScenario14(t *testing.T) {
 func TestEnsureRevocationAfterDocMutation(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	// Give role access to channel A and give user access to role
@@ -7352,7 +7352,7 @@ func TestEnsureRevocationAfterDocMutation(t *testing.T) {
 
 	// Skip to seq 4 Create doc channel A
 	revocationTester.fillToSeq(4)
-	revID := rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"channels": "A"})
+	revID := rt.CreateDocReturnRev(t, "doc", "", map[string]interface{}{"channels": "A"})
 
 	// Skip to seq 10 then do pull since 4 to get doc
 	revocationTester.fillToSeq(10)
@@ -7365,7 +7365,7 @@ func TestEnsureRevocationAfterDocMutation(t *testing.T) {
 
 	// Skip to seq 19 and then update doc foo
 	revocationTester.fillToSeq(19)
-	revID = rt.createDocReturnRev(t, "doc", revID, map[string]interface{}{"channels": "A"})
+	revID = rt.CreateDocReturnRev(t, "doc", revID, map[string]interface{}{"channels": "A"})
 	err := rt.WaitForPendingChanges()
 	require.NoError(t, err)
 
@@ -7378,7 +7378,7 @@ func TestEnsureRevocationAfterDocMutation(t *testing.T) {
 func TestEnsureRevocationUsingDocHistory(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	// Give role access to channel A and give user access to role
@@ -7387,7 +7387,7 @@ func TestEnsureRevocationUsingDocHistory(t *testing.T) {
 
 	// Skip to seq 4 Create doc channel A
 	revocationTester.fillToSeq(4)
-	revID := rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"channels": "A"})
+	revID := rt.CreateDocReturnRev(t, "doc", "", map[string]interface{}{"channels": "A"})
 
 	// Do pull to get doc
 	changes := revocationTester.getChanges(4, 1)
@@ -7398,8 +7398,8 @@ func TestEnsureRevocationUsingDocHistory(t *testing.T) {
 	revocationTester.removeRoleChannel("foo", "A")
 
 	// Remove doc from A and re-add
-	revID = rt.createDocReturnRev(t, "doc", revID, map[string]interface{}{})
-	revID = rt.createDocReturnRev(t, "doc", revID, map[string]interface{}{"channels": "A"})
+	revID = rt.CreateDocReturnRev(t, "doc", revID, map[string]interface{}{})
+	revID = rt.CreateDocReturnRev(t, "doc", revID, map[string]interface{}{"channels": "A"})
 
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "8:10", changes.Last_Seq)
@@ -7413,12 +7413,12 @@ func TestRevocationWithAdminChannels(t *testing.T) {
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/_user/user", `{"admin_channels": ["A"], "password": "letmein"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	resp = rt.SendAdminRequest("PUT", "/db/doc", `{"channels": ["A"]}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
-	changes, err := rt.waitForChanges(2, "/db/_changes?since=0&revocations=true", "user", false)
+	changes, err := rt.WaitForChanges(2, "/db/_changes?since=0&revocations=true", "user", false)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(changes.Results))
 
@@ -7426,9 +7426,9 @@ func TestRevocationWithAdminChannels(t *testing.T) {
 	assert.False(t, changes.Results[0].Revoked)
 
 	resp = rt.SendAdminRequest("PUT", "/db/_user/user", `{"admin_channels": [], "password": "letmein"}`)
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
-	changes, err = rt.waitForChanges(2, fmt.Sprintf("/db/_changes?since=%d&revocations=true", 2), "user", false)
+	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/db/_changes?since=%d&revocations=true", 2), "user", false)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(changes.Results))
 
@@ -7443,15 +7443,15 @@ func TestRevocationWithAdminRoles(t *testing.T) {
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/_role/role", `{"admin_channels": ["A"]}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	resp = rt.SendAdminRequest("PUT", "/db/_user/user", `{"admin_roles": ["role"], "password": "letmein"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	resp = rt.SendAdminRequest("PUT", "/db/doc", `{"channels": ["A"]}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
-	changes, err := rt.waitForChanges(2, "/db/_changes?since=0&revocations=true", "user", false)
+	changes, err := rt.WaitForChanges(2, "/db/_changes?since=0&revocations=true", "user", false)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(changes.Results))
 
@@ -7459,9 +7459,9 @@ func TestRevocationWithAdminRoles(t *testing.T) {
 	assert.False(t, changes.Results[1].Revoked)
 
 	resp = rt.SendAdminRequest("PUT", "/db/_user/user", `{"admin_roles": []}`)
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
-	changes, err = rt.waitForChanges(2, fmt.Sprintf("/db/_changes?since=%d&revocations=true", 3), "user", false)
+	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/db/_changes?since=%d&revocations=true", 3), "user", false)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(changes.Results))
 
@@ -7472,23 +7472,23 @@ func TestRevocationWithAdminRoles(t *testing.T) {
 func TestRevocationMutationMovesIntoRevokedChannel(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "A")
 
 	revocationTester.fillToSeq(4)
-	docRevID := rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"channels": []string{}})
-	doc2RevID := rt.createDocReturnRev(t, "doc2", "", map[string]interface{}{"channels": []string{"A"}})
+	docRevID := rt.CreateDocReturnRev(t, "doc", "", map[string]interface{}{"channels": []string{}})
+	doc2RevID := rt.CreateDocReturnRev(t, "doc2", "", map[string]interface{}{"channels": []string{"A"}})
 
 	changes := revocationTester.getChanges(0, 2)
 	assert.Len(t, changes.Results, 2)
 	assert.Equal(t, "doc2", changes.Results[1].ID)
 
 	revocationTester.removeRole("user", "foo")
-	docRevID = rt.createDocReturnRev(t, "doc", docRevID, map[string]interface{}{"channels": []string{"A"}})
-	doc2RevID = rt.createDocReturnRev(t, "doc2", doc2RevID, map[string]interface{}{"channels": []string{"A"}, "val": "mutate"})
+	docRevID = rt.CreateDocReturnRev(t, "doc", docRevID, map[string]interface{}{"channels": []string{"A"}})
+	doc2RevID = rt.CreateDocReturnRev(t, "doc2", doc2RevID, map[string]interface{}{"channels": []string{"A"}, "val": "mutate"})
 
 	changes = revocationTester.getChanges(6, 1)
 	assert.Len(t, changes.Results, 1)
@@ -7499,11 +7499,11 @@ func TestRevocationMutationMovesIntoRevokedChannel(t *testing.T) {
 func TestRevocationResumeAndLowSeqCheck(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/_role/foo2", `{}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "ch1")
@@ -7512,8 +7512,8 @@ func TestRevocationResumeAndLowSeqCheck(t *testing.T) {
 	revocationTester.addRoleChannel("foo2", "ch2")
 
 	revocationTester.fillToSeq(9)
-	revIDDoc := rt.createDocReturnRev(t, "doc1", "", map[string]interface{}{"channels": []string{"ch1"}})
-	revIDDoc2 := rt.createDocReturnRev(t, "doc2", "", map[string]interface{}{"channels": []string{"ch2"}})
+	revIDDoc := rt.CreateDocReturnRev(t, "doc1", "", map[string]interface{}{"channels": []string{"ch1"}})
+	revIDDoc2 := rt.CreateDocReturnRev(t, "doc2", "", map[string]interface{}{"channels": []string{"ch2"}})
 
 	changes := revocationTester.getChanges(0, 3)
 
@@ -7524,10 +7524,10 @@ func TestRevocationResumeAndLowSeqCheck(t *testing.T) {
 	revocationTester.removeRoleChannel("foo2", "ch2")
 
 	revocationTester.fillToSeq(39)
-	revIDDoc = rt.createDocReturnRev(t, "doc1", revIDDoc, map[string]interface{}{"channels": []string{"ch1"}, "val": "mutate"})
+	revIDDoc = rt.CreateDocReturnRev(t, "doc1", revIDDoc, map[string]interface{}{"channels": []string{"ch1"}, "val": "mutate"})
 
 	revocationTester.fillToSeq(49)
-	revIDDoc2 = rt.createDocReturnRev(t, "doc2", revIDDoc2, map[string]interface{}{"channels": []string{"ch2"}, "val": "mutate"})
+	revIDDoc2 = rt.CreateDocReturnRev(t, "doc2", revIDDoc2, map[string]interface{}{"channels": []string{"ch2"}, "val": "mutate"})
 
 	changes = revocationTester.getChanges(changes.Last_Seq, 2)
 	assert.Equal(t, "doc1", changes.Results[0].ID)
@@ -7554,7 +7554,7 @@ func TestRevocationResumeAndLowSeqCheck(t *testing.T) {
 func TestRevocationResumeSameRoleAndLowSeqCheck(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	revocationTester.addRole("user", "foo")
@@ -7562,8 +7562,8 @@ func TestRevocationResumeSameRoleAndLowSeqCheck(t *testing.T) {
 	revocationTester.addRoleChannel("foo", "ch2")
 
 	revocationTester.fillToSeq(9)
-	revIDDoc := rt.createDocReturnRev(t, "doc1", "", map[string]interface{}{"channels": []string{"ch1"}})
-	revIDDoc2 := rt.createDocReturnRev(t, "doc2", "", map[string]interface{}{"channels": []string{"ch2"}})
+	revIDDoc := rt.CreateDocReturnRev(t, "doc1", "", map[string]interface{}{"channels": []string{"ch1"}})
+	revIDDoc2 := rt.CreateDocReturnRev(t, "doc2", "", map[string]interface{}{"channels": []string{"ch2"}})
 
 	changes := revocationTester.getChanges(0, 3)
 
@@ -7574,10 +7574,10 @@ func TestRevocationResumeSameRoleAndLowSeqCheck(t *testing.T) {
 	revocationTester.removeRoleChannel("foo", "ch2")
 
 	revocationTester.fillToSeq(39)
-	revIDDoc = rt.createDocReturnRev(t, "doc1", revIDDoc, map[string]interface{}{"channels": []string{"ch1"}, "val": "mutate"})
+	revIDDoc = rt.CreateDocReturnRev(t, "doc1", revIDDoc, map[string]interface{}{"channels": []string{"ch1"}, "val": "mutate"})
 
 	revocationTester.fillToSeq(49)
-	revIDDoc2 = rt.createDocReturnRev(t, "doc2", revIDDoc2, map[string]interface{}{"channels": []string{"ch2"}, "val": "mutate"})
+	revIDDoc2 = rt.CreateDocReturnRev(t, "doc2", revIDDoc2, map[string]interface{}{"channels": []string{"ch2"}, "val": "mutate"})
 
 	changes = revocationTester.getChanges(changes.Last_Seq, 2)
 	assert.Equal(t, "doc1", changes.Results[0].ID)
@@ -7662,7 +7662,7 @@ func TestMetricsHandler(t *testing.T) {
 func TestRevocationsWithQueryLimit(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, &RestTesterConfig{
+	revocationTester, rt := InitScenario(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			QueryPaginationLimit: base.IntPtr(2),
 			CacheConfig: &CacheConfig{
@@ -7681,9 +7681,9 @@ func TestRevocationsWithQueryLimit(t *testing.T) {
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	revocationTester.fillToSeq(9)
-	_ = rt.createDocReturnRev(t, "doc1", "", map[string]interface{}{"channels": []string{"ch1"}})
-	_ = rt.createDocReturnRev(t, "doc2", "", map[string]interface{}{"channels": []string{"ch1"}})
-	_ = rt.createDocReturnRev(t, "doc3", "", map[string]interface{}{"channels": []string{"ch1"}})
+	_ = rt.CreateDocReturnRev(t, "doc1", "", map[string]interface{}{"channels": []string{"ch1"}})
+	_ = rt.CreateDocReturnRev(t, "doc2", "", map[string]interface{}{"channels": []string{"ch1"}})
+	_ = rt.CreateDocReturnRev(t, "doc3", "", map[string]interface{}{"channels": []string{"ch1"}})
 
 	changes := revocationTester.getChanges("0", 4)
 
@@ -7711,7 +7711,7 @@ func TestRevocationsWithQueryLimit(t *testing.T) {
 func TestRevocationsWithQueryLimitChangesLimit(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, &RestTesterConfig{
+	revocationTester, rt := InitScenario(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			QueryPaginationLimit: base.IntPtr(2),
 			CacheConfig: &CacheConfig{
@@ -7730,16 +7730,16 @@ func TestRevocationsWithQueryLimitChangesLimit(t *testing.T) {
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	revocationTester.fillToSeq(9)
-	_ = rt.createDocReturnRev(t, "doc1", "", map[string]interface{}{"channels": []string{"ch1"}})
-	_ = rt.createDocReturnRev(t, "doc2", "", map[string]interface{}{"channels": []string{"ch1"}})
-	_ = rt.createDocReturnRev(t, "doc3", "", map[string]interface{}{"channels": []string{"ch1"}})
+	_ = rt.CreateDocReturnRev(t, "doc1", "", map[string]interface{}{"channels": []string{"ch1"}})
+	_ = rt.CreateDocReturnRev(t, "doc2", "", map[string]interface{}{"channels": []string{"ch1"}})
+	_ = rt.CreateDocReturnRev(t, "doc3", "", map[string]interface{}{"channels": []string{"ch1"}})
 
 	changes := revocationTester.getChanges("0", 4)
 
 	revocationTester.removeRole("user", "foo")
 
-	waitForUserChangesWithLimit := func(sinceVal interface{}, limit int) changesResults {
-		var changesRes changesResults
+	waitForUserChangesWithLimit := func(sinceVal interface{}, limit int) ChangesResults {
+		var changesRes ChangesResults
 		err := rt.WaitForCondition(func() bool {
 			resp := rt.SendUserRequestWithHeaders("GET", fmt.Sprintf("/db/_changes?since=%v&revocations=true&limit=%d", sinceVal, limit), "", nil, "user", "test")
 			require.Equal(t, http.StatusOK, resp.Code)
@@ -7778,8 +7778,8 @@ func TestUserHasDocAccessDocNotFound(t *testing.T) {
 	ctx := rt.Context()
 
 	resp := rt.SendAdminRequest("PUT", "/db/doc", `{"channels": ["A"]}`)
-	requireStatus(t, resp, http.StatusCreated)
-	revID := respRevID(t, resp)
+	RequireStatus(t, resp, http.StatusCreated)
+	revID := RespRevID(t, resp)
 
 	database, err := db.CreateDatabase(rt.GetDatabase())
 	assert.NoError(t, err)
@@ -7801,7 +7801,7 @@ func TestRevocationUserHasDocAccessDocNotFound(t *testing.T) {
 		t.Skip("Skip test with LeakyBucket dependency when running in integration")
 	}
 
-	revocationTester, rt := initScenario(t, &RestTesterConfig{
+	revocationTester, rt := InitScenario(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			QueryPaginationLimit: base.IntPtr(2),
 			CacheConfig: &CacheConfig{
@@ -7820,7 +7820,7 @@ func TestRevocationUserHasDocAccessDocNotFound(t *testing.T) {
 	revocationTester.addRoleChannel("foo", "A")
 
 	resp := rt.SendAdminRequest("PUT", "/db/doc", `{"channels": ["A"]}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	changes := revocationTester.getChanges(0, 2)
 	assert.Len(t, changes.Results, 2)
@@ -7846,14 +7846,14 @@ func TestRevocationUserHasDocAccessDocNotFound(t *testing.T) {
 // that will hit the various cases that wasDocInChannelAtSeq will handle
 func TestWasDocInChannelAtSeq(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "a")
 	revocationTester.addRoleChannel("foo", "c")
 
-	revID := rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"channels": []string{"a"}})
+	revID := rt.CreateDocReturnRev(t, "doc", "", map[string]interface{}{"channels": []string{"a"}})
 
 	changes := revocationTester.getChanges(0, 2)
 	assert.Len(t, changes.Results, 2)
@@ -7861,19 +7861,19 @@ func TestWasDocInChannelAtSeq(t *testing.T) {
 	revocationTester.removeRoleChannel("foo", "a")
 	revocationTester.removeRoleChannel("foo", "c")
 
-	_ = rt.createDocReturnRev(t, "doc", revID, map[string]interface{}{"channels": []string{}})
-	_ = rt.createDocReturnRev(t, "doc2", "", map[string]interface{}{"channels": []string{"b", "a"}})
+	_ = rt.CreateDocReturnRev(t, "doc", revID, map[string]interface{}{"channels": []string{}})
+	_ = rt.CreateDocReturnRev(t, "doc2", "", map[string]interface{}{"channels": []string{"b", "a"}})
 
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 
 	revocationTester.addRoleChannel("foo", "c")
-	doc3Rev := rt.createDocReturnRev(t, "doc3", "", map[string]interface{}{"channels": []string{"c"}})
+	doc3Rev := rt.CreateDocReturnRev(t, "doc3", "", map[string]interface{}{"channels": []string{"c"}})
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 
 	revocationTester.removeRoleChannel("foo", "c")
-	_ = rt.createDocReturnRev(t, "doc3", doc3Rev, map[string]interface{}{"channels": []string{"c"}})
+	_ = rt.CreateDocReturnRev(t, "doc3", doc3Rev, map[string]interface{}{"channels": []string{"c"}})
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 }
@@ -7882,16 +7882,16 @@ func TestWasDocInChannelAtSeq(t *testing.T) {
 // that will hit the various cases that ChannelGrantedPeriods will handle
 func TestChannelGrantedPeriods(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	revocationTester.addUserChannel("user", "a")
-	revId := rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"channels": []string{"a"}})
+	revId := rt.CreateDocReturnRev(t, "doc", "", map[string]interface{}{"channels": []string{"a"}})
 	changes := revocationTester.getChanges(0, 2)
 	assert.Len(t, changes.Results, 2)
 
 	revocationTester.removeUserChannel("user", "a")
-	revId = rt.createDocReturnRev(t, "doc", revId, map[string]interface{}{"mutate": "mutate", "channels": []string{"a"}})
+	revId = rt.CreateDocReturnRev(t, "doc", revId, map[string]interface{}{"mutate": "mutate", "channels": []string{"a"}})
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 
@@ -7900,40 +7900,40 @@ func TestChannelGrantedPeriods(t *testing.T) {
 	assert.Len(t, changes.Results, 1)
 
 	revocationTester.removeUserChannel("user", "a")
-	revId = rt.createDocReturnRev(t, "doc", revId, map[string]interface{}{"mutate": "mutate2", "channels": []string{"a"}})
+	revId = rt.CreateDocReturnRev(t, "doc", revId, map[string]interface{}{"mutate": "mutate2", "channels": []string{"a"}})
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 
 	revocationTester.addUserChannel("user", "a")
-	revId = rt.createDocReturnRev(t, "doc", revId, map[string]interface{}{"mutate": "mutate3", "channels": []string{"a"}})
+	revId = rt.CreateDocReturnRev(t, "doc", revId, map[string]interface{}{"mutate": "mutate3", "channels": []string{"a"}})
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 
 	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "b")
-	revId = rt.createDocReturnRev(t, "doc", revId, map[string]interface{}{"channels": []string{"b"}})
+	revId = rt.CreateDocReturnRev(t, "doc", revId, map[string]interface{}{"channels": []string{"b"}})
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 
 	revocationTester.removeRoleChannel("foo", "b")
 	revocationTester.removeRole("user", "foo")
-	revId = rt.createDocReturnRev(t, "doc", revId, map[string]interface{}{"mutate": "mutate", "channels": []string{"b"}})
+	revId = rt.CreateDocReturnRev(t, "doc", revId, map[string]interface{}{"mutate": "mutate", "channels": []string{"b"}})
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 }
 
 func TestChannelHistoryPruning(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "a")
 
 	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": ["a"]}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	// Enter a load of history by looping over adding and removing a channel. Needs a get changes in there to trigger
 	// the actual rebuild
-	var changes changesResults
+	var changes ChangesResults
 	for i := 0; i < 20; i++ {
 		changes = revocationTester.getChanges(0, 2)
 		assert.Len(t, changes.Results, 2)
@@ -7954,7 +7954,7 @@ func TestChannelHistoryPruning(t *testing.T) {
 	// Add an additional channel to ensure only the latter one is pruned
 	revocationTester.addRoleChannel("foo", "b")
 	resp = rt.SendAdminRequest("PUT", "/db/doc2", `{"channels": ["b"]}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 	changes = revocationTester.getChanges(changes.Last_Seq, 2)
 	assert.Len(t, changes.Results, 2)
 	revocationTester.removeRoleChannel("foo", "b")
@@ -7990,16 +7990,16 @@ func TestChannelHistoryPruning(t *testing.T) {
 
 func TestChannelRevocationWithContiguousSequences(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	revocationTester.addUserChannel("user", "a")
-	revID := rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"channels": "a"})
+	revID := rt.CreateDocReturnRev(t, "doc", "", map[string]interface{}{"channels": "a"})
 	changes := revocationTester.getChanges(0, 2)
 	assert.Len(t, changes.Results, 2)
 
 	revocationTester.removeUserChannel("user", "a")
-	revID = rt.createDocReturnRev(t, "doc", revID, map[string]interface{}{"mutate": "mutate", "channels": "a"})
+	revID = rt.CreateDocReturnRev(t, "doc", revID, map[string]interface{}{"mutate": "mutate", "channels": "a"})
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 	assert.Equal(t, "doc", changes.Results[0].ID)
@@ -8012,7 +8012,7 @@ func TestChannelRevocationWithContiguousSequences(t *testing.T) {
 	assert.False(t, changes.Results[0].Revoked)
 
 	revocationTester.removeUserChannel("user", "a")
-	revID = rt.createDocReturnRev(t, "doc", revID, map[string]interface{}{"mutate": "mutate2", "channels": "a"})
+	revID = rt.CreateDocReturnRev(t, "doc", revID, map[string]interface{}{"mutate": "mutate2", "channels": "a"})
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 	assert.Equal(t, "doc", changes.Results[0].ID)
@@ -8038,7 +8038,7 @@ func TestRevocationWithUserXattrs(t *testing.T) {
 
 	xattrKey := "channelInfo"
 
-	revocationTester, rt := initScenario(t, &RestTesterConfig{
+	revocationTester, rt := InitScenario(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			AutoImport:   true,
 			UserXattrKey: xattrKey,
@@ -8064,12 +8064,12 @@ func TestRevocationWithUserXattrs(t *testing.T) {
 	}
 
 	resp := rt.SendAdminRequest("PUT", "/db/accessDoc", `{}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	_, err := gocbBucket.WriteUserXattr("accessDoc", xattrKey, map[string]interface{}{"userChannels": map[string]interface{}{"user": "a"}})
 	assert.NoError(t, err)
 
-	_ = rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"channels": []string{"a"}})
+	_ = rt.CreateDocReturnRev(t, "doc", "", map[string]interface{}{"channels": []string{"a"}})
 
 	changes := revocationTester.getChanges(0, 2)
 	assert.Len(t, changes.Results, 2)
@@ -8086,11 +8086,11 @@ func TestDocChannelSetPruning(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	revID := rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"channels": []string{"a"}})
+	revID := rt.CreateDocReturnRev(t, "doc", "", map[string]interface{}{"channels": []string{"a"}})
 
 	for i := 0; i < 10; i++ {
-		revID = rt.createDocReturnRev(t, "doc", revID, map[string]interface{}{"channels": []string{}})
-		revID = rt.createDocReturnRev(t, "doc", revID, map[string]interface{}{"channels": []string{"a"}})
+		revID = rt.CreateDocReturnRev(t, "doc", revID, map[string]interface{}{"channels": []string{}})
+		revID = rt.CreateDocReturnRev(t, "doc", revID, map[string]interface{}{"channels": []string{"a"}})
 	}
 
 	syncData, err := rt.GetDatabase().GetDocSyncData(base.TestCtx(t), "doc")
@@ -8104,7 +8104,7 @@ func TestDocChannelSetPruning(t *testing.T) {
 
 func TestBasicAttachmentRemoval(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	attContentType := "content/type"
@@ -8115,7 +8115,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 	storeAttachment := func(doc, rev, attName, attBody string) string {
 		resource := fmt.Sprintf("/db/%s/%s?rev=%s", doc, attName, rev)
 		response := rt.SendRequestWithHeaders(http.MethodPut, resource, attBody, reqHeaders)
-		requireStatus(t, response, http.StatusCreated)
+		RequireStatus(t, response, http.StatusCreated)
 		var body db.Body
 		require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 		require.True(t, body["ok"].(bool))
@@ -8125,7 +8125,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 	retrieveAttachment := func(docID, attName string) (attBody string) {
 		resource := fmt.Sprintf("/db/%s/%s", docID, attName)
 		response := rt.SendRequest(http.MethodGet, resource, "")
-		requireStatus(t, response, http.StatusOK)
+		RequireStatus(t, response, http.StatusOK)
 		return string(response.Body.Bytes())
 	}
 
@@ -8134,7 +8134,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		response := rt.SendRequest(http.MethodGet, resource, "")
 		var meta map[string]interface{}
 		require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &meta))
-		requireStatus(t, response, http.StatusOK)
+		RequireStatus(t, response, http.StatusOK)
 		key, found := meta["key"].(string)
 		require.True(t, found)
 		return key
@@ -8143,11 +8143,11 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 	requireAttachmentNotFound := func(docID, attName string) {
 		resource := fmt.Sprintf("/db/%s/%s", docID, attName)
 		response := rt.SendRequest(http.MethodGet, resource, "")
-		requireStatus(t, response, http.StatusNotFound)
+		RequireStatus(t, response, http.StatusNotFound)
 	}
 
 	retrieveAttachmentMeta := func(docID string) (attMeta map[string]interface{}) {
-		body := rt.getDoc(docID)
+		body := rt.GetDoc(docID)
 		attachments, ok := body["_attachments"].(map[string]interface{})
 		require.True(t, ok)
 		return attachments
@@ -8160,14 +8160,14 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		assert.Equal(t, attBodyExpected, attBodyActual)
 	}
 
-	createDocWithLegacyAttachment := func(docID string, rawDoc []byte, attKey string, attBody []byte) {
-		createDocWithLegacyAttachment(t, rt, docID, rawDoc, attKey, attBody)
+	CreateDocWithLegacyAttachment := func(docID string, rawDoc []byte, attKey string, attBody []byte) {
+		CreateDocWithLegacyAttachment(t, rt, docID, rawDoc, attKey, attBody)
 	}
 
 	t.Run("single attachment removal upon document update", func(t *testing.T) {
 		// Create a document.
 		docID := "foo"
-		revID := rt.createDoc(t, docID)
+		revID := rt.CreateDoc(t, docID)
 		require.Equal(t, "1-45ca73d819d5b1c9b8eea95290e79004", revID)
 
 		// Add an attachment to the document.
@@ -8197,21 +8197,21 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		require.NotEmpty(t, attKey)
 
 		// Remove attachment from the bucket via document update.
-		response := rt.updateDoc(docID, revID, `{"prop":true}`)
+		response := rt.UpdateDoc(docID, revID, `{"prop":true}`)
 		require.NotEmpty(t, response.Rev)
 
 		// Check whether the attachment is removed from the underlying storage.
 		requireAttachmentNotFound(docID, attName)
-		rt.requireDocNotFound(attKey)
+		rt.RequireDocNotFound(attKey)
 
 		// Perform cleanup after the test ends.
-		rt.purgeDoc(docID)
+		rt.PurgeDoc(docID)
 	})
 
 	t.Run("single attachment removal upon document delete", func(t *testing.T) {
 		// Create a document.
 		docID := "bar"
-		revID := rt.createDoc(t, docID)
+		revID := rt.CreateDoc(t, docID)
 		require.NotEmpty(t, revID)
 
 		// Add an attachment to the document.
@@ -8241,20 +8241,20 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		require.NotEmpty(t, attKey)
 
 		// Delete/tombstone the document.
-		rt.deleteDoc(docID, revID)
+		rt.DeleteDoc(docID, revID)
 
 		// Check whether the attachment is removed from the underlying storage.
 		requireAttachmentNotFound(docID, attName)
-		rt.requireDocNotFound(attKey)
+		rt.RequireDocNotFound(attKey)
 
 		// Perform cleanup after the test ends.
-		rt.purgeDoc(docID)
+		rt.PurgeDoc(docID)
 	})
 
 	t.Run("single attachment removal upon document purge", func(t *testing.T) {
 		// Create a document.
 		docID := "baz"
-		revID := rt.createDoc(t, docID)
+		revID := rt.CreateDoc(t, docID)
 		require.NotEmpty(t, revID)
 
 		// Add an attachment to the document.
@@ -8284,17 +8284,17 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		require.NotEmpty(t, attKey)
 
 		// Purge the entire document.
-		rt.purgeDoc(docID)
+		rt.PurgeDoc(docID)
 
 		// Check whether the attachment is removed from the underlying storage.
 		requireAttachmentNotFound(docID, attName)
-		rt.requireDocNotFound(attKey)
+		rt.RequireDocNotFound(attKey)
 	})
 
 	t.Run("single attachment removal upon attachment update", func(t *testing.T) {
 		// Create a document.
 		docID := "qux"
-		revID := rt.createDoc(t, docID)
+		revID := rt.CreateDoc(t, docID)
 		require.Equal(t, "1-45ca73d819d5b1c9b8eea95290e79004", revID)
 
 		// Add an attachment to the document.
@@ -8345,7 +8345,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		assert.Nil(t, meta["ver"], "Attachment version shouldn't be exposed")
 
 		// Check whether the old attachment blob is removed from the underlying storage.
-		rt.requireDocNotFound(attKeyOld)
+		rt.RequireDocNotFound(attKeyOld)
 
 		// Retrieve new attachment key used for internal attachment storage and retrieval.
 		attKeyNew := retrieveAttachmentKey(docID, attName)
@@ -8353,13 +8353,13 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		require.NotEqual(t, attKeyOld, attKeyNew)
 
 		// Perform cleanup after the test ends.
-		rt.purgeDoc(docID)
+		rt.PurgeDoc(docID)
 	})
 
 	t.Run("multiple attachments removal upon document update", func(t *testing.T) {
 		// Create a document.
 		docID := "foo1"
-		revID := rt.createDoc(t, docID)
+		revID := rt.CreateDoc(t, docID)
 		require.Equal(t, "1-45ca73d819d5b1c9b8eea95290e79004", revID)
 
 		// Add an attachment to the document.
@@ -8426,23 +8426,23 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		require.NotEqual(t, att1Key, att2Key)
 
 		// Remove both attachments from the bucket via document update.
-		response := rt.updateDoc(docID, revID, `{"prop":true}`)
+		response := rt.UpdateDoc(docID, revID, `{"prop":true}`)
 		require.NotEmpty(t, response.Rev)
 
 		// Check whether both attachments are removed from the underlying storage.
 		requireAttachmentNotFound(docID, att1Name)
-		rt.requireDocNotFound(att1Key)
+		rt.RequireDocNotFound(att1Key)
 		requireAttachmentNotFound(docID, att2Name)
-		rt.requireDocNotFound(att2Key)
+		rt.RequireDocNotFound(att2Key)
 
 		// Perform cleanup after the test ends.
-		rt.purgeDoc(docID)
+		rt.PurgeDoc(docID)
 	})
 
 	t.Run("multiple attachments removal upon document delete", func(t *testing.T) {
 		// Create a document.
 		docID := "foo2"
-		revID := rt.createDoc(t, docID)
+		revID := rt.CreateDoc(t, docID)
 		require.Equal(t, "1-45ca73d819d5b1c9b8eea95290e79004", revID)
 
 		// Add an attachment to the document.
@@ -8509,22 +8509,22 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		require.NotEqual(t, att1Key, att2Key)
 
 		// Delete/tombstone the document.
-		rt.deleteDoc(docID, revID)
+		rt.DeleteDoc(docID, revID)
 
 		// Check whether both attachments are removed from the underlying storage.
 		requireAttachmentNotFound(docID, att1Name)
-		rt.requireDocNotFound(att1Key)
+		rt.RequireDocNotFound(att1Key)
 		requireAttachmentNotFound(docID, att2Name)
-		rt.requireDocNotFound(att2Key)
+		rt.RequireDocNotFound(att2Key)
 
 		// Perform cleanup after the test ends.
-		rt.purgeDoc(docID)
+		rt.PurgeDoc(docID)
 	})
 
 	t.Run("multiple attachments removal upon document purge", func(t *testing.T) {
 		// Create a document.
 		docID := "foo3"
-		revID := rt.createDoc(t, docID)
+		revID := rt.CreateDoc(t, docID)
 		require.Equal(t, "1-45ca73d819d5b1c9b8eea95290e79004", revID)
 
 		// Add an attachment to the document.
@@ -8591,13 +8591,13 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		require.NotEqual(t, att1Key, att2Key)
 
 		// Purge the entire document.
-		rt.purgeDoc(docID)
+		rt.PurgeDoc(docID)
 
 		// Check whether both attachments are removed from the underlying storage.
 		requireAttachmentNotFound(docID, att1Name)
-		rt.requireDocNotFound(att1Key)
+		rt.RequireDocNotFound(att1Key)
 		requireAttachmentNotFound(docID, att2Name)
-		rt.requireDocNotFound(att2Key)
+		rt.RequireDocNotFound(att2Key)
 	})
 
 	t.Run("single inline attachment removal upon document update", func(t *testing.T) {
@@ -8607,7 +8607,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		attBody := "this is the body of attachment foo.txt"
 		attBodyEncoded := base64.StdEncoding.EncodeToString([]byte(attBody))
 		body := fmt.Sprintf(`{"prop": true, "_attachments": {"%s": {"data":"%s"}}}`, attName, attBodyEncoded)
-		putResponse := rt.putDoc(docID, body)
+		putResponse := rt.PutDoc(docID, body)
 		revID := putResponse.Rev
 		require.Equal(t, "1-45ca73d819d5b1c9b8eea95290e79004", revID)
 
@@ -8631,15 +8631,15 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		require.NotEmpty(t, attKey)
 
 		// Remove attachment from the bucket via document update.
-		response := rt.updateDoc(docID, revID, `{"prop":true}`)
+		response := rt.UpdateDoc(docID, revID, `{"prop":true}`)
 		require.NotEmpty(t, response.Rev)
 
 		// Check whether the attachment is removed from the underlying storage.
 		requireAttachmentNotFound(docID, attName)
-		rt.requireDocNotFound(attKey)
+		rt.RequireDocNotFound(attKey)
 
 		// Perform cleanup after the test ends.
-		rt.purgeDoc(docID)
+		rt.PurgeDoc(docID)
 	})
 
 	t.Run("single inline attachment removal upon document delete", func(t *testing.T) {
@@ -8649,7 +8649,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		attBody := "this is the body of attachment foo.txt"
 		attBodyEncoded := base64.StdEncoding.EncodeToString([]byte(attBody))
 		body := fmt.Sprintf(`{"prop": true, "_attachments": {"%s": {"data":"%s"}}}`, attName, attBodyEncoded)
-		putResponse := rt.putDoc(docID, body)
+		putResponse := rt.PutDoc(docID, body)
 		revID := putResponse.Rev
 		require.Equal(t, "1-45ca73d819d5b1c9b8eea95290e79004", revID)
 
@@ -8673,14 +8673,14 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		require.NotEmpty(t, attKey)
 
 		// Delete/tombstone the document.
-		rt.deleteDoc(docID, revID)
+		rt.DeleteDoc(docID, revID)
 
 		// Check whether the attachment is removed from the underlying storage.
 		requireAttachmentNotFound(docID, attName)
-		rt.requireDocNotFound(attKey)
+		rt.RequireDocNotFound(attKey)
 
 		// Perform cleanup after the test ends.
-		rt.purgeDoc(docID)
+		rt.PurgeDoc(docID)
 	})
 
 	t.Run("single inline attachment removal upon document purge", func(t *testing.T) {
@@ -8690,7 +8690,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		attBody := "this is the body of attachment foo.txt"
 		attBodyEncoded := base64.StdEncoding.EncodeToString([]byte(attBody))
 		body := fmt.Sprintf(`{"prop": true, "_attachments": {"%s": {"data":"%s"}}}`, attName, attBodyEncoded)
-		putResponse := rt.putDoc(docID, body)
+		putResponse := rt.PutDoc(docID, body)
 		revID := putResponse.Rev
 		require.Equal(t, "1-45ca73d819d5b1c9b8eea95290e79004", revID)
 
@@ -8714,11 +8714,11 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		require.Equal(t, "_sync:att2:ccNG7Q7yTHRLEo8vQ3aDuYDnBmZfFu3E2YtCqbg8/dk=:sha1-CTJaowVFZ4ozgmvBageTH9w+OKU=", attKey)
 
 		// Purge the entire document.
-		rt.purgeDoc(docID)
+		rt.PurgeDoc(docID)
 
 		// Check whether the attachment is removed from the underlying storage.
 		requireAttachmentNotFound(docID, attName)
-		rt.requireDocNotFound(attKey)
+		rt.RequireDocNotFound(attKey)
 	})
 
 	t.Run("single inline attachment removal upon attachment update", func(t *testing.T) {
@@ -8728,7 +8728,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		attBody := "this is the body of attachment foo.txt"
 		attBodyEncoded := base64.StdEncoding.EncodeToString([]byte(attBody))
 		body := fmt.Sprintf(`{"prop": true, "_attachments": {"%s": {"data":"%s"}}}`, attName, attBodyEncoded)
-		putResponse := rt.putDoc(docID, body)
+		putResponse := rt.PutDoc(docID, body)
 		revID := putResponse.Rev
 		require.Equal(t, "1-45ca73d819d5b1c9b8eea95290e79004", revID)
 
@@ -8772,7 +8772,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		assert.Nil(t, meta["ver"], "Attachment version shouldn't be exposed")
 
 		// Check whether the old attachment blob is removed from the underlying storage.
-		rt.requireDocNotFound(attKeyOld)
+		rt.RequireDocNotFound(attKeyOld)
 
 		// Retrieve new attachment key used for internal attachment storage and retrieval.
 		attKeyNew := retrieveAttachmentKey(docID, attName)
@@ -8780,7 +8780,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		require.NotEqual(t, attKeyOld, attKeyNew)
 
 		// Perform cleanup after the test ends.
-		rt.purgeDoc(docID)
+		rt.PurgeDoc(docID)
 	})
 
 	t.Run("attachment removal upon document delete via SDK", func(t *testing.T) {
@@ -8798,7 +8798,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		attBody := "this is the body of attachment foo.txt"
 		attBodyEncoded := base64.StdEncoding.EncodeToString([]byte(attBody))
 		body := fmt.Sprintf(`{"prop": true, "_attachments": {"%s": {"data":"%s"}}}`, attName, attBodyEncoded)
-		putResponse := rt.putDoc(docID, body)
+		putResponse := rt.PutDoc(docID, body)
 		revID := putResponse.Rev
 		require.Equal(t, "1-45ca73d819d5b1c9b8eea95290e79004", revID)
 
@@ -8826,14 +8826,14 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		require.NoError(t, err, "Unable to delete doc %q", docID)
 
 		// Wait until the "delete" mutation appears on the changes feed.
-		changes, err := rt.waitForChanges(1, "/db/_changes", "", true)
+		changes, err := rt.WaitForChanges(1, "/db/_changes", "", true)
 		assert.NoError(t, err, "Error waiting for changes")
 		log.Printf("changes: %+v", changes)
-		rt.requireDocNotFound(docID)
+		rt.RequireDocNotFound(docID)
 
 		// Check whether the attachment is removed from the underlying storage.
 		requireAttachmentNotFound(docID, attName)
-		rt.requireDocNotFound(attKey)
+		rt.RequireDocNotFound(attKey)
 	})
 
 	t.Run("skip attachment removal upon document update via SDK", func(t *testing.T) {
@@ -8851,7 +8851,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		attBody := "this is the body of attachment foo.txt"
 		attBodyEncoded := base64.StdEncoding.EncodeToString([]byte(attBody))
 		body := fmt.Sprintf(`{"prop": true, "_attachments": {"%s": {"data":"%s"}}}`, attName, attBodyEncoded)
-		putResponse := rt.putDoc(docID, body)
+		putResponse := rt.PutDoc(docID, body)
 		revID := putResponse.Rev
 		require.Equal(t, "1-45ca73d819d5b1c9b8eea95290e79004", revID)
 
@@ -8879,7 +8879,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		require.NoError(t, err, "Error updating the document")
 
 		// Wait until the "update" mutation appears on the changes feed.
-		changes, err := rt.waitForChanges(1, "/db/_changes", "", true)
+		changes, err := rt.WaitForChanges(1, "/db/_changes", "", true)
 		assert.NoError(t, err, "Error waiting for changes")
 		log.Printf("changes: %+v", changes)
 
@@ -8888,7 +8888,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		require.Equal(t, attBody, actualAttBody)
 
 		// Get the document and check doc body and attachment metadata.
-		updatedBody := rt.getDoc(docID)
+		updatedBody := rt.GetDoc(docID)
 		require.False(t, updatedBody["prop"].(bool))
 		revID, ok = updatedBody["_rev"].(string)
 		require.True(t, ok)
@@ -8908,7 +8908,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 	t.Run("doc with multiple attachments and removal of a single one upon document update", func(t *testing.T) {
 		// Create a document.
 		docID := "foo12"
-		revID := rt.createDoc(t, docID)
+		revID := rt.CreateDoc(t, docID)
 		require.Equal(t, "1-45ca73d819d5b1c9b8eea95290e79004", revID)
 
 		// Add an attachment to the document.
@@ -8975,7 +8975,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		require.NotEqual(t, att1Key, att2Key)
 
 		// Remove one of the attachment from the bucket via document update.
-		response := rt.updateDoc(docID, revID, `{"prop":true, "_attachments": {"alice.txt": {"stub": true, "revpos": 2}}}`)
+		response := rt.UpdateDoc(docID, revID, `{"prop":true, "_attachments": {"alice.txt": {"stub": true, "revpos": 2}}}`)
 		require.NotEmpty(t, response.Rev)
 
 		// Get the document and check the attachment metadata.
@@ -8994,14 +8994,14 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 
 		// Check whether removed attachment is also removed from the underlying storage.
 		requireAttachmentNotFound(docID, att2Name)
-		rt.requireDocNotFound(att2Key)
+		rt.RequireDocNotFound(att2Key)
 
 		// Verify that att1Name is still found in the bucket.
 		actualAttBody = retrieveAttachment(docID, att1Name)
 		require.Equal(t, att1Body, actualAttBody)
 
 		// Perform cleanup after the test ends.
-		rt.purgeDoc(docID)
+		rt.PurgeDoc(docID)
 	})
 
 	t.Run("legacy attachment persistence upon doc delete (single doc referencing an attachment)", func(t *testing.T) {
@@ -9015,21 +9015,21 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		rawDoc := rawDocWithAttachmentAndSyncMeta()
 
 		// Create a document with legacy attachment.
-		createDocWithLegacyAttachment(docID, rawDoc, attKey, attBody)
+		CreateDocWithLegacyAttachment(docID, rawDoc, attKey, attBody)
 
 		// Get the document and grab the revID.
-		responseBody := rt.getDoc(docID)
+		responseBody := rt.GetDoc(docID)
 		revID := responseBody["_rev"].(string)
 		require.NotEmpty(t, revID)
 
 		// Delete/tombstone the document.
-		rt.deleteDoc(docID, revID)
+		rt.DeleteDoc(docID, revID)
 
 		// Check whether legacy attachment is still persisted in the bucket.
 		requireAttachmentFound(attKey, attBody)
 
 		// Perform cleanup after the test ends.
-		rt.purgeDoc(docID)
+		rt.PurgeDoc(docID)
 	})
 
 	t.Run("legacy attachment persistence upon doc delete (multiple docs referencing same attachment)", func(t *testing.T) {
@@ -9044,36 +9044,36 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		rawDoc := rawDocWithAttachmentAndSyncMeta()
 
 		// Create a document with legacy attachment.
-		createDocWithLegacyAttachment(docID1, rawDoc, attKey, attBody)
+		CreateDocWithLegacyAttachment(docID1, rawDoc, attKey, attBody)
 
 		// Create another document referencing the same legacy attachment.
-		createDocWithLegacyAttachment(docID2, rawDoc, attKey, attBody)
+		CreateDocWithLegacyAttachment(docID2, rawDoc, attKey, attBody)
 
 		// Get revID of the first document.
-		responseBody := rt.getDoc(docID1)
+		responseBody := rt.GetDoc(docID1)
 		revID1 := responseBody["_rev"].(string)
 		require.NotEmpty(t, revID1)
 
 		// Delete/tombstone the first document.
-		rt.deleteDoc(docID1, revID1)
+		rt.DeleteDoc(docID1, revID1)
 
 		// Check whether legacy attachment is still persisted in the bucket.
 		requireAttachmentFound(attKey, attBody)
 
 		// Get revID of the second document.
-		responseBody = rt.getDoc(docID2)
+		responseBody = rt.GetDoc(docID2)
 		revID2 := responseBody["_rev"].(string)
 		require.NotEmpty(t, revID2)
 
 		// Delete/tombstone the second document.
-		rt.deleteDoc(docID2, revID2)
+		rt.DeleteDoc(docID2, revID2)
 
 		// Check whether legacy attachment is still persisted in the bucket.
 		requireAttachmentFound(attKey, attBody)
 
 		// Perform cleanup after the test ends.
-		rt.purgeDoc(docID1)
-		rt.purgeDoc(docID2)
+		rt.PurgeDoc(docID1)
+		rt.PurgeDoc(docID2)
 	})
 
 	t.Run("legacy attachment persistence upon doc update (single doc referencing an attachment)", func(t *testing.T) {
@@ -9087,22 +9087,22 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		rawDoc := rawDocWithAttachmentAndSyncMeta()
 
 		// Create a document with legacy attachment.
-		createDocWithLegacyAttachment(docID, rawDoc, attKey, attBody)
+		CreateDocWithLegacyAttachment(docID, rawDoc, attKey, attBody)
 
 		// Get the document and grab the revID.
-		responseBody := rt.getDoc(docID)
+		responseBody := rt.GetDoc(docID)
 		revID := responseBody["_rev"].(string)
 		require.NotEmpty(t, revID)
 
 		// Remove attachment from the document via document update.
-		response := rt.updateDoc(docID, revID, `{"prop":true}`)
+		response := rt.UpdateDoc(docID, revID, `{"prop":true}`)
 		require.NotEmpty(t, response.Rev)
 
 		// Check whether legacy attachment is still persisted in the bucket.
 		requireAttachmentFound(attKey, attBody)
 
 		// Perform cleanup after the test ends.
-		rt.purgeDoc(docID)
+		rt.PurgeDoc(docID)
 	})
 
 	t.Run("legacy attachment persistence upon doc update (multiple docs referencing same attachment)", func(t *testing.T) {
@@ -9117,38 +9117,38 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		rawDoc := rawDocWithAttachmentAndSyncMeta()
 
 		// Create a document with legacy attachment.
-		createDocWithLegacyAttachment(docID1, rawDoc, attKey, attBody)
+		CreateDocWithLegacyAttachment(docID1, rawDoc, attKey, attBody)
 
 		// Create another document referencing the same legacy attachment.
-		createDocWithLegacyAttachment(docID2, rawDoc, attKey, attBody)
+		CreateDocWithLegacyAttachment(docID2, rawDoc, attKey, attBody)
 
 		// Get revID of the first document.
-		responseBody := rt.getDoc(docID1)
+		responseBody := rt.GetDoc(docID1)
 		revID1 := responseBody["_rev"].(string)
 		require.NotEmpty(t, revID1)
 
 		// Remove attachment from the first document via document update.
-		response := rt.updateDoc(docID1, revID1, `{"prop":true}`)
+		response := rt.UpdateDoc(docID1, revID1, `{"prop":true}`)
 		require.NotEmpty(t, response.Rev)
 
 		// Check whether legacy attachment is still persisted in the bucket.
 		requireAttachmentFound(attKey, attBody)
 
 		// Get revID of the second document.
-		responseBody = rt.getDoc(docID2)
+		responseBody = rt.GetDoc(docID2)
 		revID2 := responseBody["_rev"].(string)
 		require.NotEmpty(t, revID2)
 
 		// Remove attachment from the second document via document update.
-		response = rt.updateDoc(docID2, revID2, `{"prop":true}`)
+		response = rt.UpdateDoc(docID2, revID2, `{"prop":true}`)
 		require.NotEmpty(t, response.Rev)
 
 		// Check whether legacy attachment is still persisted in the bucket.
 		requireAttachmentFound(attKey, attBody)
 
 		// Perform cleanup after the test ends.
-		rt.purgeDoc(docID1)
-		rt.purgeDoc(docID2)
+		rt.PurgeDoc(docID1)
+		rt.PurgeDoc(docID2)
 	})
 
 	t.Run("legacy attachment persistence upon doc purge (single doc referencing an attachment)", func(t *testing.T) {
@@ -9162,15 +9162,15 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		rawDoc := rawDocWithAttachmentAndSyncMeta()
 
 		// Create a document with legacy attachment.
-		createDocWithLegacyAttachment(docID, rawDoc, attKey, attBody)
+		CreateDocWithLegacyAttachment(docID, rawDoc, attKey, attBody)
 
 		// Get the document and grab the revID.
-		responseBody := rt.getDoc(docID)
+		responseBody := rt.GetDoc(docID)
 		revID := responseBody["_rev"].(string)
 		require.NotEmpty(t, revID)
 
 		// Purge the entire document.
-		rt.purgeDoc(docID)
+		rt.PurgeDoc(docID)
 
 		// Check whether legacy attachment is still persisted in the bucket.
 		requireAttachmentFound(attKey, attBody)
@@ -9188,29 +9188,29 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		rawDoc := rawDocWithAttachmentAndSyncMeta()
 
 		// Create a document with legacy attachment.
-		createDocWithLegacyAttachment(docID1, rawDoc, attKey, attBody)
+		CreateDocWithLegacyAttachment(docID1, rawDoc, attKey, attBody)
 
 		// Create another document referencing the same legacy attachment.
-		createDocWithLegacyAttachment(docID2, rawDoc, attKey, attBody)
+		CreateDocWithLegacyAttachment(docID2, rawDoc, attKey, attBody)
 
 		// Get revID of the first document.
-		responseBody := rt.getDoc(docID1)
+		responseBody := rt.GetDoc(docID1)
 		revID1 := responseBody["_rev"].(string)
 		require.NotEmpty(t, revID1)
 
 		// Purge the first document.
-		rt.purgeDoc(docID1)
+		rt.PurgeDoc(docID1)
 
 		// Check whether legacy attachment is still persisted in the bucket.
 		requireAttachmentFound(attKey, attBody)
 
 		// Get revID of the second document.
-		responseBody = rt.getDoc(docID2)
+		responseBody = rt.GetDoc(docID2)
 		revID2 := responseBody["_rev"].(string)
 		require.NotEmpty(t, revID2)
 
 		// Purge the second document.
-		rt.purgeDoc(docID2)
+		rt.PurgeDoc(docID2)
 
 		// Check whether legacy attachment is still persisted in the bucket.
 		requireAttachmentFound(attKey, attBody)
@@ -9229,28 +9229,28 @@ func TestAttachmentRemovalWithConflicts(t *testing.T) {
 	defer rt.Close()
 
 	// Create doc rev 1
-	revid := rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"test": "x"})
+	revid := rt.CreateDocReturnRev(t, "doc", "", map[string]interface{}{"test": "x"})
 
 	// Create doc rev 2 with attachment
-	revid = rt.createDocReturnRev(t, "doc", revid, map[string]interface{}{"_attachments": map[string]interface{}{"hello.txt": map[string]interface{}{"data": "aGVsbG8gd29ybGQ="}}})
+	revid = rt.CreateDocReturnRev(t, "doc", revid, map[string]interface{}{"_attachments": map[string]interface{}{"hello.txt": map[string]interface{}{"data": "aGVsbG8gd29ybGQ="}}})
 	err := rt.WaitForPendingChanges()
 	assert.NoError(t, err)
 
 	// Create doc rev 3 referencing previous attachment
 	resp := rt.SendAdminRequest("PUT", "/db/doc?rev="+revid, `{"_attachments": {"hello.txt": {"revpos":2,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`)
-	requireStatus(t, resp, http.StatusCreated)
-	losingRev3 := respRevID(t, resp)
+	RequireStatus(t, resp, http.StatusCreated)
+	losingRev3 := RespRevID(t, resp)
 
 	// Create doc conflicting with previous revid referencing previous attachment too
 	_, revIDHash := db.ParseRevID(revid)
 	resp = rt.SendAdminRequest("PUT", "/db/doc?new_edits=false", `{"_rev": "3-b", "_revisions": {"ids": ["b", "`+revIDHash+`"], "start": 3}, "_attachments": {"hello.txt": {"revpos":2,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}, "Winning Rev": true}`)
-	requireStatus(t, resp, http.StatusCreated)
-	winningRev3 := respRevID(t, resp)
+	RequireStatus(t, resp, http.StatusCreated)
+	winningRev3 := RespRevID(t, resp)
 
 	// Update the winning rev 3 and ensure attachment remains around as the other leaf still references this attachment
 	resp = rt.SendAdminRequest("PUT", "/db/doc?rev="+winningRev3, `{"update": 2}`)
-	requireStatus(t, resp, http.StatusCreated)
-	finalRev4 := respRevID(t, resp)
+	RequireStatus(t, resp, http.StatusCreated)
+	finalRev4 := RespRevID(t, resp)
 
 	type docResp struct {
 		Attachments db.AttachmentsMeta `json:"_attachments"`
@@ -9259,7 +9259,7 @@ func TestAttachmentRemovalWithConflicts(t *testing.T) {
 	var doc1 docResp
 	// Get losing rev and ensure attachment is still there and has not been deleted
 	resp = rt.SendAdminRequestWithHeaders("GET", "/db/doc?attachments=true&rev="+losingRev3, "", map[string]string{"Accept": "application/json"})
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	err = base.JSONUnmarshal(resp.BodyBytes(), &doc1)
 	assert.NoError(t, err)
@@ -9276,7 +9276,7 @@ func TestAttachmentRemovalWithConflicts(t *testing.T) {
 	var doc2 docResp
 	// Get winning rev and ensure attachment is indeed removed from this rev
 	resp = rt.SendAdminRequestWithHeaders("GET", "/db/doc?attachments=true&rev="+finalRev4, "", map[string]string{"Accept": "application/json"})
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	err = base.JSONUnmarshal(resp.BodyBytes(), &doc2)
 	assert.NoError(t, err)
@@ -9284,7 +9284,7 @@ func TestAttachmentRemovalWithConflicts(t *testing.T) {
 
 	// Now remove the attachment in the losing rev by deleting the revision and ensure the attachment gets deleted
 	resp = rt.SendAdminRequest("DELETE", "/db/doc?rev="+losingRev3, "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	_, _, err = rt.GetDatabase().Bucket.GetRaw(attachmentKey)
 	assert.Error(t, err)
@@ -9298,14 +9298,14 @@ func TestTombstoneCompactionAPI(t *testing.T) {
 
 	for i := 0; i < 100; i++ {
 		resp := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/doc%d", i), "{}")
-		requireStatus(t, resp, http.StatusCreated)
-		rev := respRevID(t, resp)
+		RequireStatus(t, resp, http.StatusCreated)
+		rev := RespRevID(t, resp)
 		resp = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/doc%d?rev=%s", i, rev), "{}")
-		requireStatus(t, resp, http.StatusOK)
+		RequireStatus(t, resp, http.StatusOK)
 	}
 
 	resp := rt.SendAdminRequest("GET", "/db/_compact", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	var tombstoneCompactionStatus db.TombstoneManagerResponse
 	err := base.JSONUnmarshal(resp.BodyBytes(), &tombstoneCompactionStatus)
@@ -9318,11 +9318,11 @@ func TestTombstoneCompactionAPI(t *testing.T) {
 	assert.NotEqual(t, 0, firstStartTimeStat)
 
 	resp = rt.SendAdminRequest("POST", "/db/_compact", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	err = rt.WaitForCondition(func() bool {
 		resp = rt.SendAdminRequest("GET", "/db/_compact", "")
-		requireStatus(t, resp, http.StatusOK)
+		RequireStatus(t, resp, http.StatusOK)
 
 		err = base.JSONUnmarshal(resp.BodyBytes(), &tombstoneCompactionStatus)
 		assert.NoError(t, err)
@@ -9333,7 +9333,7 @@ func TestTombstoneCompactionAPI(t *testing.T) {
 	assert.True(t, rt.GetDatabase().DbStats.Database().CompactionAttachmentStartTime.Value() > firstStartTimeStat)
 
 	resp = rt.SendAdminRequest("GET", "/db/_compact", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	err = base.JSONUnmarshal(resp.BodyBytes(), &tombstoneCompactionStatus)
 	assert.NoError(t, err)
 
@@ -9355,20 +9355,20 @@ func TestAttachmentsMissing(t *testing.T) {
 	_ = rt.Bucket()
 
 	resp := rt.SendAdminRequest("PUT", "/db/"+t.Name(), `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
-	requireStatus(t, resp, http.StatusCreated)
-	rev1ID := respRevID(t, resp)
+	RequireStatus(t, resp, http.StatusCreated)
+	rev1ID := RespRevID(t, resp)
 
 	resp = rt.SendAdminRequest("PUT", "/db/"+t.Name()+"?rev="+rev1ID, `{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}, "testval": ["xxx","xxx"]}`)
-	requireStatus(t, resp, http.StatusCreated)
-	rev2ID := respRevID(t, resp)
+	RequireStatus(t, resp, http.StatusCreated)
+	rev2ID := RespRevID(t, resp)
 
 	resp = rt.SendAdminRequest("PUT", "/db/"+t.Name()+"?new_edits=false", `{"_rev": "2-b", "_revisions": {"ids": ["b", "ca9ad22802b66f662ff171f226211d5c"], "start": 2}, "Winning Rev": true}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	rt.GetDatabase().FlushRevisionCacheForTest()
 
 	resp = rt.SendAdminRequest("GET", "/db/"+t.Name()+"?rev="+rev2ID, ``)
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	assert.Contains(t, string(resp.BodyBytes()), "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=")
 }
 
@@ -9380,20 +9380,20 @@ func TestAttachmentsMissingNoBody(t *testing.T) {
 	_ = rt.Bucket()
 
 	resp := rt.SendAdminRequest("PUT", "/db/"+t.Name(), `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
-	requireStatus(t, resp, http.StatusCreated)
-	rev1ID := respRevID(t, resp)
+	RequireStatus(t, resp, http.StatusCreated)
+	rev1ID := RespRevID(t, resp)
 
 	resp = rt.SendAdminRequest("PUT", "/db/"+t.Name()+"?rev="+rev1ID, `{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`)
-	requireStatus(t, resp, http.StatusCreated)
-	rev2ID := respRevID(t, resp)
+	RequireStatus(t, resp, http.StatusCreated)
+	rev2ID := RespRevID(t, resp)
 
 	resp = rt.SendAdminRequest("PUT", "/db/"+t.Name()+"?new_edits=false", `{"_rev": "2-b", "_revisions": {"ids": ["b", "ca9ad22802b66f662ff171f226211d5c"], "start": 2}}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	rt.GetDatabase().FlushRevisionCacheForTest()
 
 	resp = rt.SendAdminRequest("GET", "/db/"+t.Name()+"?rev="+rev2ID, ``)
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	assert.Contains(t, string(resp.BodyBytes()), "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=")
 }
 
@@ -9403,13 +9403,13 @@ func TestAttachmentDeleteOnPurge(t *testing.T) {
 
 	// Create doc with attachment
 	resp := rt.SendAdminRequest("PUT", "/db/"+t.Name(), `{"_attachments": {"hello": {"data": "aGVsbG8gd29ybGQ="}}}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 	err := rt.WaitForPendingChanges()
 	assert.NoError(t, err)
 
 	// Ensure attachment is uploaded and key the attachment doc key
 	resp = rt.SendAdminRequest("GET", "/db/"+t.Name()+"/hello?meta=true", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	var body db.Body
 	err = base.JSONUnmarshal(resp.BodyBytes(), &body)
@@ -9424,7 +9424,7 @@ func TestAttachmentDeleteOnPurge(t *testing.T) {
 
 	// Purge the document
 	resp = rt.SendAdminRequest("POST", "/db/_purge", `{"`+t.Name()+`": ["*"]}`)
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	// Ensure that the attachment has now been deleted
 	_, _, err = rt.GetDatabase().Bucket.GetRaw(key)
@@ -9442,7 +9442,7 @@ func TestAttachmentDeleteOnExpiry(t *testing.T) {
 
 	// Create doc with attachment and expiry
 	resp := rt.SendAdminRequest("PUT", "/db/"+t.Name(), `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}, "_exp": 2}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 	err := rt.WaitForPendingChanges()
 	assert.NoError(t, err)
 
@@ -9455,7 +9455,7 @@ func TestAttachmentDeleteOnExpiry(t *testing.T) {
 
 	// Trigger OnDemand Import for that doc to trigger tombstone
 	resp = rt.SendAdminRequest("GET", "/db/"+t.Name(), "")
-	requireStatus(t, resp, http.StatusNotFound)
+	RequireStatus(t, resp, http.StatusNotFound)
 
 	att2Key := db.MakeAttachmentKey(db.AttVersion2, t.Name(), "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=")
 
@@ -9492,7 +9492,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 					assertHTTPErrorReason(t, resp, http.StatusForbidden, "forbidden")
 					return
 				}
-				assertStatus(t, resp, statusIfForbiddenErrorsFalse)
+				AssertStatus(t, resp, statusIfForbiddenErrorsFalse)
 			}
 
 			rt := NewRestTester(t, &RestTesterConfig{
@@ -9527,8 +9527,8 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 
 			// Create the initial document
 			resp := rt.SendAdminRequest(http.MethodPut, "/db/doc", `{"doNotSync": true, "foo": "bar", "channels": "chan", "_attachment":{"attach": {"data": "`+base64.StdEncoding.EncodeToString([]byte("attachmentA"))+`"}}}`)
-			requireStatus(t, resp, http.StatusCreated)
-			rev := respRevID(t, resp)
+			RequireStatus(t, resp, http.StatusCreated)
+			rev := RespRevID(t, resp)
 
 			// GET requests
 			// User has no permissions to access document
@@ -9606,7 +9606,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 
 			// Confirm no access grants where granted
 			resp = rt.SendAdminRequest(http.MethodGet, "/db/_user/NoPerms", ``)
-			requireStatus(t, resp, http.StatusOK)
+			RequireStatus(t, resp, http.StatusOK)
 			var allChannels struct {
 				Channels []string `json:"all_channels"`
 			}
@@ -9615,18 +9615,18 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			assert.NotContains(t, allChannels.Channels, "chan2")
 
 			resp = rt.SendAdminRequest(http.MethodGet, "/db/_user/Perms", ``)
-			requireStatus(t, resp, http.StatusOK)
+			RequireStatus(t, resp, http.StatusOK)
 			err = json.Unmarshal(resp.BodyBytes(), &allChannels)
 			require.NoError(t, err)
 			assert.NotContains(t, allChannels.Channels, "chan2")
 
 			// Successful PUT which will grant access grants
 			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/db/doc?rev="+rev, `{"channels": "chan"}`, nil, "Perms", "password")
-			assertStatus(t, resp, http.StatusCreated)
+			AssertStatus(t, resp, http.StatusCreated)
 
 			// Make sure channel access grant was successful
 			resp = rt.SendAdminRequest(http.MethodGet, "/db/_user/Perms", ``)
-			requireStatus(t, resp, http.StatusOK)
+			RequireStatus(t, resp, http.StatusOK)
 			err = json.Unmarshal(resp.BodyBytes(), &allChannels)
 			require.NoError(t, err)
 			assert.Contains(t, allChannels.Channels, "chan2")
@@ -9667,7 +9667,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 	}
 }
 
-func createDocWithLegacyAttachment(t *testing.T, rt *RestTester, docID string, rawDoc []byte, attKey string, attBody []byte) {
+func CreateDocWithLegacyAttachment(t *testing.T, rt *RestTester, docID string, rawDoc []byte, attKey string, attBody []byte) {
 	// Write attachment directly to the bucket.
 	_, err := rt.Bucket().Add(attKey, 0, attBody)
 	require.NoError(t, err)
@@ -9686,7 +9686,7 @@ func createDocWithLegacyAttachment(t *testing.T, rt *RestTester, docID string, r
 }
 
 func retrieveAttachmentMeta(t *testing.T, rt *RestTester, docID string) (attMeta map[string]interface{}) {
-	body := rt.getDoc(docID)
+	body := rt.GetDoc(docID)
 	attachments, ok := body["_attachments"].(map[string]interface{})
 	require.True(t, ok)
 	return attachments
@@ -9764,9 +9764,21 @@ func TestImportFilterTimeout(t *testing.T) {
 	syncFnFinishedWG.Add(1)
 	go func() {
 		response := rt.SendAdminRequest("GET", "/db/doc", ``)
-		assertStatus(t, response, 404)
+		AssertStatus(t, response, 404)
 		syncFnFinishedWG.Done()
 	}()
 	timeoutErr := WaitWithTimeout(&syncFnFinishedWG, time.Second*15)
 	assert.NoError(t, timeoutErr)
+}
+
+func assertHTTPErrorReason(t testing.TB, response *TestResponse, expectedStatus int, expectedReason string) {
+	var httpError struct {
+		Reason string `json:"reason"`
+	}
+	err := base.JSONUnmarshal(response.BodyBytes(), &httpError)
+	require.NoError(t, err, "Failed to unmarshal HTTP error: %v", response.BodyBytes())
+
+	AssertStatus(t, response, expectedStatus)
+
+	assert.Equal(t, expectedReason, httpError.Reason)
 }

--- a/rest/api_test_helpers_test.go
+++ b/rest/api_test_helpers_test.go
@@ -19,37 +19,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type putDocResponse struct {
+type PutDocResponse struct {
 	ID  string
 	Ok  bool
 	Rev string
 }
 
-func (rt *RestTester) getDoc(docID string) (body db.Body) {
+func (rt *RestTester) GetDoc(docID string) (body db.Body) {
 	rawResponse := rt.SendAdminRequest("GET", "/db/"+docID, "")
-	requireStatus(rt.tb, rawResponse, 200)
+	RequireStatus(rt.tb, rawResponse, 200)
 	require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &body))
 	return body
 }
 
-func (rt *RestTester) requireDocNotFound(docID string) {
+func (rt *RestTester) RequireDocNotFound(docID string) {
 	rawResponse := rt.SendAdminRequest(http.MethodGet, "/db/"+docID, "")
-	requireStatus(rt.tb, rawResponse, http.StatusNotFound)
+	RequireStatus(rt.tb, rawResponse, http.StatusNotFound)
 }
 
-func (rt *RestTester) putDoc(docID string, body string) (response putDocResponse) {
+func (rt *RestTester) PutDoc(docID string, body string) (response PutDocResponse) {
 	rawResponse := rt.SendAdminRequest("PUT", "/db/"+docID, body)
-	requireStatus(rt.tb, rawResponse, 201)
+	RequireStatus(rt.tb, rawResponse, 201)
 	require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &response))
 	require.True(rt.tb, response.Ok)
 	require.NotEmpty(rt.tb, response.Rev)
 	return response
 }
 
-func (rt *RestTester) updateDoc(docID, revID, body string) (response putDocResponse) {
+func (rt *RestTester) UpdateDoc(docID, revID, body string) (response PutDocResponse) {
 	resource := fmt.Sprintf("/db/%s?rev=%s", docID, revID)
 	rawResponse := rt.SendAdminRequest(http.MethodPut, resource, body)
-	requireStatus(rt.tb, rawResponse, http.StatusCreated)
+	RequireStatus(rt.tb, rawResponse, http.StatusCreated)
 	require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &response))
 	require.True(rt.tb, response.Ok)
 	require.NotEmpty(rt.tb, response.Rev)
@@ -58,14 +58,14 @@ func (rt *RestTester) updateDoc(docID, revID, body string) (response putDocRespo
 
 func (rt *RestTester) tombstoneDoc(docID string, revID string) {
 	rawResponse := rt.SendAdminRequest("DELETE", "/db/"+docID+"?rev="+revID, "")
-	requireStatus(rt.tb, rawResponse, 200)
+	RequireStatus(rt.tb, rawResponse, 200)
 }
 
-func (rt *RestTester) upsertDoc(docID string, body string) (response putDocResponse) {
+func (rt *RestTester) upsertDoc(docID string, body string) (response PutDocResponse) {
 
 	getResponse := rt.SendAdminRequest("GET", "/db/"+docID, "")
 	if getResponse.Code == 404 {
-		return rt.putDoc(docID, body)
+		return rt.PutDoc(docID, body)
 	}
 	var getBody db.Body
 	require.NoError(rt.tb, base.JSONUnmarshal(getResponse.Body.Bytes(), &getBody))
@@ -73,22 +73,22 @@ func (rt *RestTester) upsertDoc(docID string, body string) (response putDocRespo
 	require.True(rt.tb, ok)
 
 	rawResponse := rt.SendAdminRequest("PUT", "/db/"+docID+"?rev="+revID, body)
-	requireStatus(rt.tb, rawResponse, 200)
+	RequireStatus(rt.tb, rawResponse, 200)
 	require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &response))
 	require.True(rt.tb, response.Ok)
 	require.NotEmpty(rt.tb, response.Rev)
 	return response
 }
 
-func (rt *RestTester) deleteDoc(docID, revID string) {
-	requireStatus(rt.tb, rt.SendAdminRequest(http.MethodDelete,
+func (rt *RestTester) DeleteDoc(docID, revID string) {
+	RequireStatus(rt.tb, rt.SendAdminRequest(http.MethodDelete,
 		fmt.Sprintf("/db/%s?rev=%s", docID, revID), ""), http.StatusOK)
 }
 
 // prugeDoc removes all the revisions (active and tombstones) of the specified document.
-func (rt *RestTester) purgeDoc(docID string) {
+func (rt *RestTester) PurgeDoc(docID string) {
 	response := rt.SendAdminRequest(http.MethodPost, "/db/_purge", fmt.Sprintf(`{"%s":["*"]}`, docID))
-	requireStatus(rt.tb, response, http.StatusOK)
+	RequireStatus(rt.tb, response, http.StatusOK)
 	var body map[string]interface{}
 	require.NoError(rt.tb, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	require.Equal(rt.tb, body, map[string]interface{}{"purged": map[string]interface{}{docID: []interface{}{"*"}}})
@@ -96,7 +96,7 @@ func (rt *RestTester) purgeDoc(docID string) {
 
 // PutDocumentWithRevID builds a new_edits=false style put to create a revision with the specified revID.
 // If parentRevID is not specified, treated as insert
-func (rt *RestTester) putNewEditsFalse(docID string, newRevID string, parentRevID string, bodyString string) (response putDocResponse) {
+func (rt *RestTester) putNewEditsFalse(docID string, newRevID string, parentRevID string, bodyString string) (response PutDocResponse) {
 
 	var body db.Body
 	marshalErr := base.JSONUnmarshal([]byte(bodyString), &body)
@@ -104,7 +104,7 @@ func (rt *RestTester) putNewEditsFalse(docID string, newRevID string, parentRevI
 
 	rawResponse, err := rt.PutDocumentWithRevID(docID, newRevID, parentRevID, body)
 	require.NoError(rt.tb, err)
-	requireStatus(rt.tb, rawResponse, 201)
+	RequireStatus(rt.tb, rawResponse, 201)
 	require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &response))
 	require.True(rt.tb, response.Ok)
 	require.NotEmpty(rt.tb, response.Rev)
@@ -114,14 +114,14 @@ func (rt *RestTester) putNewEditsFalse(docID string, newRevID string, parentRevI
 	return response
 }
 
-func (rt *RestTester) RequireWaitChanges(numChangesExpected int, since string) changesResults {
-	changesResults, err := rt.waitForChanges(numChangesExpected, "/db/_changes?since="+since, "", true)
+func (rt *RestTester) RequireWaitChanges(numChangesExpected int, since string) ChangesResults {
+	changesResults, err := rt.WaitForChanges(numChangesExpected, "/db/_changes?since="+since, "", true)
 	require.NoError(rt.tb, err)
 	require.Len(rt.tb, changesResults.Results, numChangesExpected)
 	return changesResults
 }
 
-func (rt *RestTester) waitForRev(docID string, revID string) error {
+func (rt *RestTester) WaitForRev(docID string, revID string) error {
 	return rt.WaitForCondition(func() bool {
 		rawResponse := rt.SendAdminRequest("GET", "/db/"+docID, "")
 		if rawResponse.Code != 200 && rawResponse.Code != 201 {

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -42,11 +42,11 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 
 	// Put several documents in channel PBS
 	response := rt.SendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/db/pbs2", `{"value":2, "channel":["PBS"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/db/pbs3", `{"value":3, "channel":["PBS"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	caughtUpWaiter := rt.GetDatabase().NewPullReplicationCaughtUpWaiter(t)
 	// Start longpoll changes request
@@ -59,7 +59,7 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 			Last_Seq db.SequenceID
 		}
 		changesJSON := `{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"0"}`
-		changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+		changesResponse := rt.Send(RequestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 		assert.Equal(t, 3, len(changes.Results))
 	}()
@@ -69,7 +69,7 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 
 	// Put document that triggers access grant for user, PBS
 	response = rt.SendAdminRequest("PUT", "/db/access1", `{"accessUser":"bernard", "accessChannel":["PBS"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	wg.Wait()
 }
@@ -87,12 +87,12 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 
 	// Create user:
 	userResponse := rt.SendAdminRequest("PUT", "/db/_user/bernard", `{"name":"bernard", "password":"letmein", "admin_channels":["ABC"]}`)
-	requireStatus(t, userResponse, 201)
+	RequireStatus(t, userResponse, 201)
 
 	// Get user, to trigger all_channels calculation and bump the user change count BEFORE we write the PBS docs - otherwise the user key count
 	// will still be higher than the latest change count.
 	userResponse = rt.SendAdminRequest("GET", "/db/_user/bernard", "")
-	requireStatus(t, userResponse, 200)
+	RequireStatus(t, userResponse, 200)
 
 	/*
 		a := it.ServerContext().Database("db").Authenticator(base.TestCtx(t))
@@ -103,11 +103,11 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 
 	// Put several documents in channel PBS
 	response := rt.SendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/db/pbs2", `{"value":2, "channel":["PBS"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/db/pbs3", `{"value":3, "channel":["PBS"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// Run an initial changes request to get the user doc, and update since based on last_seq:
 	var initialChanges struct {
@@ -122,7 +122,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 					 "filter":"` + base.ByChannelFilter + `",
 					 "channels":"ABC,PBS"}`
 	sinceZeroJSON := fmt.Sprintf(changesJSON, "0")
-	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", sinceZeroJSON, "bernard"))
+	changesResponse := rt.Send(RequestByUser("POST", "/db/_changes", sinceZeroJSON, "bernard"))
 	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &initialChanges)
 	assert.NoError(t, err, "Unexpected error unmarshalling initialChanges")
 	lastSeq := initialChanges.Last_Seq.String()
@@ -140,7 +140,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 			Last_Seq db.SequenceID
 		}
 		sinceLastJSON := fmt.Sprintf(changesJSON, lastSeq)
-		changesResponse := rt.Send(requestByUser("POST", "/db/_changes", sinceLastJSON, "bernard"))
+		changesResponse := rt.Send(RequestByUser("POST", "/db/_changes", sinceLastJSON, "bernard"))
 		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 		assert.Equal(t, 1, len(changes.Results))
 	}()
@@ -150,7 +150,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 
 	// Put public document that triggers termination of the longpoll
 	response = rt.SendAdminRequest("PUT", "/db/abc1", `{"value":3, "channel":["ABC"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	wg.Wait()
 }
 

--- a/rest/attachment_compaction_api_test.go
+++ b/rest/attachment_compaction_api_test.go
@@ -25,7 +25,7 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 
 	// Perform GET before compact has been ran, ensure it starts in valid 'stopped' state
 	resp := rt.SendAdminRequest("GET", "/db/_compact?type=attachment", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	var response db.AttachmentManagerResponse
 	err := base.JSONUnmarshal(resp.BodyBytes(), &response)
@@ -37,18 +37,18 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 
 	// Kick off compact
 	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	// Attempt to kick off again and validate it correctly errors
 	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
-	requireStatus(t, resp, http.StatusServiceUnavailable)
+	RequireStatus(t, resp, http.StatusServiceUnavailable)
 
 	// Wait for run to complete
 	err = rt.WaitForCondition(func() bool {
 		time.Sleep(1 * time.Second)
 
 		resp := rt.SendAdminRequest("GET", "/db/_compact?type=attachment", "")
-		requireStatus(t, resp, http.StatusOK)
+		RequireStatus(t, resp, http.StatusOK)
 
 		var response db.AttachmentManagerResponse
 		err = base.JSONUnmarshal(resp.BodyBytes(), &response)
@@ -82,14 +82,14 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 
 	// Start attachment compaction run
 	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	// Wait for run to complete
 	err = rt.WaitForCondition(func() bool {
 		time.Sleep(1 * time.Second)
 
 		resp := rt.SendAdminRequest("GET", "/db/_compact?type=attachment", "")
-		requireStatus(t, resp, http.StatusOK)
+		RequireStatus(t, resp, http.StatusOK)
 
 		var response db.AttachmentManagerResponse
 		err = base.JSONUnmarshal(resp.BodyBytes(), &response)
@@ -101,7 +101,7 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 
 	// Validate results of GET
 	resp = rt.SendAdminRequest("GET", "/db/_compact?type=attachment", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	err = base.JSONUnmarshal(resp.BodyBytes(), &response)
 	require.NoError(t, err)
@@ -112,18 +112,18 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 
 	// Start another run
 	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	// Attempt to terminate that run
 	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment&action=stop", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	// Verify it has been marked as 'stopping' --> its possible we'll get stopped instead based on timing of persisted doc update
 	err = rt.WaitForCondition(func() bool {
 		time.Sleep(1 * time.Second)
 
 		resp := rt.SendAdminRequest("GET", "/db/_compact?type=attachment", "")
-		requireStatus(t, resp, http.StatusOK)
+		RequireStatus(t, resp, http.StatusOK)
 
 		var response db.AttachmentManagerResponse
 		err = base.JSONUnmarshal(resp.BodyBytes(), &response)
@@ -146,10 +146,10 @@ func TestAttachmentCompactionPersistence(t *testing.T) {
 	noCloseTB := tb.NoCloseClone()
 
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		TestBucket: noCloseTB,
+		CustomTestBucket: noCloseTB,
 	})
 	rt2 := NewRestTester(t, &RestTesterConfig{
-		TestBucket: tb,
+		CustomTestBucket: tb,
 	})
 
 	defer rt2.Close()
@@ -157,39 +157,39 @@ func TestAttachmentCompactionPersistence(t *testing.T) {
 
 	// Start attachment compaction on one SGW
 	resp := rt1.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	_ = rt1.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
 
 	// Ensure compaction is marked complete on the other node too
 	var rt2AttachmentStatus db.AttachmentManagerResponse
 	resp = rt2.SendAdminRequest("GET", "/db/_compact?type=attachment", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	err := base.JSONUnmarshal(resp.BodyBytes(), &rt2AttachmentStatus)
 	assert.NoError(t, err)
 	assert.Equal(t, rt2AttachmentStatus.State, db.BackgroundProcessStateCompleted)
 
 	// Start compaction again
 	resp = rt1.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	status := rt1.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateRunning)
 	compactID := status.CompactID
 
 	// Abort process early from rt1
 	resp = rt1.SendAdminRequest("POST", "/db/_compact?type=attachment&action=stop", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	status = rt2.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateStopped)
 
 	// Ensure aborted status is present on rt2
 	resp = rt2.SendAdminRequest("GET", "/db/_compact?type=attachment", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	err = base.JSONUnmarshal(resp.BodyBytes(), &rt2AttachmentStatus)
 	assert.NoError(t, err)
 	assert.Equal(t, db.BackgroundProcessStateStopped, rt2AttachmentStatus.State)
 
 	// Attempt to start again from rt2 --> Should resume based on aborted state (same compactionID)
 	resp = rt2.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	status = rt2.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateRunning)
 	assert.Equal(t, compactID, status.CompactID)
 
@@ -219,7 +219,7 @@ func TestAttachmentCompactionDryRun(t *testing.T) {
 	}
 
 	resp := rt.SendAdminRequest("POST", "/db/_compact?type=attachment&dry_run=true", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	status := rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
 	assert.True(t, status.DryRun)
 	assert.Equal(t, int64(5), status.PurgedAttachments)
@@ -230,7 +230,7 @@ func TestAttachmentCompactionDryRun(t *testing.T) {
 	}
 
 	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	status = rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
 	assert.False(t, status.DryRun)
 	assert.Equal(t, int64(5), status.PurgedAttachments)
@@ -252,18 +252,18 @@ func TestAttachmentCompactionReset(t *testing.T) {
 
 	// Start compaction
 	resp := rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	status := rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateRunning)
 	compactID := status.CompactID
 
 	// Stop compaction before complete -- enters aborted state
 	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment&action=stop", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	status = rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateStopped)
 
 	// Ensure status is aborted
 	resp = rt.SendAdminRequest("GET", "/db/_compact?type=attachment", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	var attachmentStatus db.AttachmentManagerResponse
 	err := base.JSONUnmarshal(resp.BodyBytes(), &attachmentStatus)
 	assert.NoError(t, err)
@@ -271,7 +271,7 @@ func TestAttachmentCompactionReset(t *testing.T) {
 
 	// Start compaction again but with reset=true --> meaning it shouldn't try to resume
 	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment&reset=true", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	status = rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateRunning)
 	assert.NotEqual(t, compactID, status.CompactID)
 
@@ -309,11 +309,11 @@ func TestAttachmentCompactionInvalidDocs(t *testing.T) {
 
 	// Write a normal doc to ensure this passes through fine
 	resp := rt.SendAdminRequest("PUT", "/db/normal-doc", "{}")
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	// Start compaction
 	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	status := rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
 
 	assert.Equal(t, int64(2), status.PurgedAttachments)
@@ -337,7 +337,7 @@ func TestAttachmentCompactionStartTimeAndStats(t *testing.T) {
 
 	// Start compaction
 	resp := rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	status := rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
 
 	// Check stats and start time response is correct
@@ -349,7 +349,7 @@ func TestAttachmentCompactionStartTimeAndStats(t *testing.T) {
 
 	// Start compaction again
 	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	status = rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
 
 	// Check that stats have been updated to new run and previous attachment count stat remains
@@ -377,10 +377,10 @@ func TestAttachmentCompactionAbort(t *testing.T) {
 	}
 
 	resp := rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment&action=stop", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	status := rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateStopped)
 	assert.Equal(t, int64(0), status.PurgedAttachments)
@@ -390,7 +390,7 @@ func (rt *RestTester) WaitForAttachmentCompactionStatus(t *testing.T, state db.B
 	var response db.AttachmentManagerResponse
 	err := rt.WaitForConditionWithOptions(func() bool {
 		resp := rt.SendAdminRequest("GET", "/db/_compact?type=attachment", "")
-		requireStatus(t, resp, http.StatusOK)
+		RequireStatus(t, resp, http.StatusOK)
 
 		err := base.JSONUnmarshal(resp.BodyBytes(), &response)
 		assert.NoError(t, err)

--- a/rest/blip_api_collections_test.go
+++ b/rest/blip_api_collections_test.go
@@ -21,7 +21,7 @@ func TestBlipGetCollections(t *testing.T) {
 	//checkpointIDWithError := "checkpointError"
 
 	rt := NewRestTester(t, &RestTesterConfig{
-		guestEnabled: true,
+		GuestEnabled: true,
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
 				Scopes: ScopesConfig{
@@ -159,7 +159,7 @@ func TestBlipGetCollectionsAndSetCheckpoint(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	rt := NewRestTester(t, &RestTesterConfig{
-		guestEnabled: true,
+		GuestEnabled: true,
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
 				Scopes: ScopesConfig{
@@ -236,7 +236,7 @@ func TestCollectionsPeerDoesNotHave(t *testing.T) {
 	)
 
 	rt := NewRestTester(t, &RestTesterConfig{
-		guestEnabled: true,
+		GuestEnabled: true,
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
 				Scopes: ScopesConfig{
@@ -273,7 +273,7 @@ func TestCollectionsReplication(t *testing.T) {
 	)
 
 	rt := NewRestTester(t, &RestTesterConfig{
-		guestEnabled: true,
+		GuestEnabled: true,
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
 				Scopes: ScopesConfig{
@@ -296,7 +296,7 @@ func TestCollectionsReplication(t *testing.T) {
 	defer btc.Close()
 
 	resp := rt.SendAdminRequest(http.MethodPut, "/db."+scopeAndCollectionKey+"/doc1", "{}")
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	require.NoError(t, rt.WaitForPendingChanges())
 

--- a/rest/blip_api_no_race_test.go
+++ b/rest/blip_api_no_race_test.go
@@ -39,9 +39,9 @@ func TestBlipPusherUpdateDatabase(t *testing.T) {
 	defer tb.Close()
 
 	rtConfig := RestTesterConfig{
-		DatabaseConfig: &DatabaseConfig{},
-		guestEnabled:   true,
-		TestBucket:     tb.NoCloseClone(),
+		DatabaseConfig:   &DatabaseConfig{},
+		GuestEnabled:     true,
+		CustomTestBucket: tb.NoCloseClone(),
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -75,7 +75,7 @@ func TestBlipPusherUpdateDatabase(t *testing.T) {
 	}()
 
 	// and wait for a few to be done before we proceed with updating database config underneath replication
-	_, err = rt.waitForChanges(5, "/db/_changes", "", true)
+	_, err = rt.WaitForChanges(5, "/db/_changes", "", true)
 	require.NoError(t, err)
 
 	// just change the sync function to cause the database to reload
@@ -83,7 +83,7 @@ func TestBlipPusherUpdateDatabase(t *testing.T) {
 	dbConfig.Sync = base.StringPtr(`function(doc){console.log("update");}`)
 	resp, err := rt.ReplaceDbConfig("db", dbConfig)
 	require.NoError(t, err)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	// Did we tell the client to close the connection (via HTTP/503)?
 	// The BlipTesterClient doesn't implement reconnect - but CBL resets the replication connection.

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -607,7 +607,7 @@ func TestProposedChangesNoConflictsMode(t *testing.T) {
 
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		noConflictsMode: true,
-		guestEnabled:    true,
+		GuestEnabled:    true,
 	})
 	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
@@ -647,30 +647,30 @@ func TestProposedChangesIncludeConflictingRev(t *testing.T) {
 
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		noConflictsMode: true,
-		guestEnabled:    true,
+		GuestEnabled:    true,
 	})
 	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
 	// Write existing docs to server directly (not via blip)
 	rt := bt.restTester
-	resp := rt.putDoc("conflictingInsert", `{"version":1}`)
+	resp := rt.PutDoc("conflictingInsert", `{"version":1}`)
 	conflictingInsertRev := resp.Rev
 
-	resp = rt.putDoc("matchingInsert", `{"version":1}`)
+	resp = rt.PutDoc("matchingInsert", `{"version":1}`)
 	matchingInsertRev := resp.Rev
 
-	resp = rt.putDoc("conflictingUpdate", `{"version":1}`)
+	resp = rt.PutDoc("conflictingUpdate", `{"version":1}`)
 	conflictingUpdateRev1 := resp.Rev
-	resp = rt.updateDoc("conflictingUpdate", resp.Rev, `{"version":2}`)
+	resp = rt.UpdateDoc("conflictingUpdate", resp.Rev, `{"version":2}`)
 	conflictingUpdateRev2 := resp.Rev
 
-	resp = rt.putDoc("matchingUpdate", `{"version":1}`)
+	resp = rt.PutDoc("matchingUpdate", `{"version":1}`)
 	matchingUpdateRev1 := resp.Rev
-	resp = rt.updateDoc("matchingUpdate", resp.Rev, `{"version":2}`)
+	resp = rt.UpdateDoc("matchingUpdate", resp.Rev, `{"version":2}`)
 	matchingUpdateRev2 := resp.Rev
 
-	resp = rt.putDoc("newUpdate", `{"version":1}`)
+	resp = rt.PutDoc("newUpdate", `{"version":1}`)
 	newUpdateRev1 := resp.Rev
 
 	type proposeChangesCase struct {
@@ -859,7 +859,7 @@ function(doc, oldDoc) {
 
 	// Update the user to grant them access to ABC
 	response := rt.SendAdminRequest("PUT", "/db/_user/user1", `{"admin_channels":["ABC"]}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	// Wait for notification
 	require.True(t, db.WaitForUserWaiterChange(userWaiter))
@@ -875,7 +875,7 @@ function(doc, oldDoc) {
 
 	// Validate that the doc was written (GET request doesn't get a 404)
 	getResponse := rt.SendAdminRequest("GET", "/db/foo", "")
-	requireStatus(t, getResponse, 200)
+	RequireStatus(t, getResponse, 200)
 
 }
 
@@ -992,7 +992,7 @@ function(doc, oldDoc) {
 	receivedChangesWg.Add(1)
 	revsFinishedWg.Add(1)
 	response := rt.SendAdminRequest("PUT", "/db/grantDoc", `{"accessUser":"user1", "accessChannel":"ABC", "channels":["ABC"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	require.NoError(t, rt.WaitForPendingChanges())
 
 	// Wait until all expected changes are received by change handler
@@ -1173,7 +1173,7 @@ func TestBlipSendAndGetRev(t *testing.T) {
 
 	// Get non-deleted rev
 	response := bt.restTester.SendAdminRequest("GET", "/db/sendAndGetRev?rev=1-abc", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	var responseBody RestDocument
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &responseBody), "Error unmarshalling GET doc response")
 	_, ok := responseBody[db.BodyDeleted]
@@ -1188,7 +1188,7 @@ func TestBlipSendAndGetRev(t *testing.T) {
 
 	// Get the tombstoned document
 	response = bt.restTester.SendAdminRequest("GET", "/db/sendAndGetRev?rev=2-bcd", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	responseBody = RestDocument{}
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &responseBody), "Error unmarshalling GET doc response")
 	deletedValue, deletedOK := responseBody[db.BodyDeleted].(bool)
@@ -1222,7 +1222,7 @@ func TestBlipSendAndGetLargeNumberRev(t *testing.T) {
 
 	// Get non-deleted rev
 	response := bt.restTester.SendAdminRequest("GET", "/db/largeNumberRev?rev=1-abc", "")
-	requireStatus(t, response, 200) // Check the raw bytes, because unmarshalling the response would be another opportunity for the number to get modified
+	RequireStatus(t, response, 200) // Check the raw bytes, because unmarshalling the response would be another opportunity for the number to get modified
 	responseString := string(response.Body.Bytes())
 	if !strings.Contains(responseString, `9223372036854775807`) {
 		t.Errorf("Response does not contain the expected number format.  Response: %s", responseString)
@@ -1282,7 +1282,7 @@ func TestBlipSetCheckpoint(t *testing.T) {
 
 	// Validate checkpoint existence in bucket (local file name "/" needs to be URL encoded as %252F)
 	response := rt.SendAdminRequest("GET", "/db/_local/checkpoint%252Ftestclient", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	var responseBody map[string]interface{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &responseBody)
 	assert.Equal(t, "1000", responseBody["client_seq"])
@@ -1347,7 +1347,7 @@ func TestReloadUser(t *testing.T) {
 
 	// Put document that triggers access grant for user to channel PBS
 	response := rt.SendAdminRequest("PUT", "/db/access1", `{"accessUser":"user1", "accessChannel":["PBS"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// Wait for notification
 	require.True(t, db.WaitForUserWaiterChange(userWaiter))
@@ -1401,7 +1401,7 @@ func TestAccessGrantViaSyncFunction(t *testing.T) {
 
 	// Put document that triggers access grant for user to channel PBS
 	response := rt.SendAdminRequest("PUT", "/db/access1", `{"accessUser":"user1", "accessChannel":["PBS"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// Add another doc in the PBS channel
 	_, _, _, _ = bt.SendRev(
@@ -1442,7 +1442,7 @@ func TestAccessGrantViaAdminApi(t *testing.T) {
 
 	// Update the user doc to grant access to PBS
 	response := bt.restTester.SendAdminRequest("PUT", "/db/_user/user1", `{"admin_channels":["user1", "PBS"]}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	// Add another doc in the PBS channel
 	_, _, _, _ = bt.SendRev(
@@ -1956,7 +1956,7 @@ func TestGetRemovedDoc(t *testing.T) {
 //   - Expected: receive all 5 docs (4 revs and 1 norev)
 //   - Actual: only receive 4 docs (4 revs)
 func TestMissingNoRev(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 	ctx := rt.Context()
 
@@ -2014,7 +2014,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 				Enabled: &sgUseDeltas,
 			},
 		}},
-		guestEnabled: true,
+		GuestEnabled: true,
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -2094,7 +2094,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 				Enabled: base.BoolPtr(true),
 			},
 		}},
-		guestEnabled: true,
+		GuestEnabled: true,
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -2102,7 +2102,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 	// create doc1 rev 1
 	resp := rt.SendAdminRequest(http.MethodPut, "/db/doc1", `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 	assert.Equal(t, http.StatusCreated, resp.Code)
-	rev1ID := respRevID(t, resp)
+	rev1ID := RespRevID(t, resp)
 
 	deltaSentCount := rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 
@@ -2124,7 +2124,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 	// create doc1 rev 2
 	resp = rt.SendAdminRequest(http.MethodPut, "/db/doc1?rev="+rev1ID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
 	assert.Equal(t, http.StatusCreated, resp.Code)
-	rev2ID := respRevID(t, resp)
+	rev2ID := RespRevID(t, resp)
 
 	data, ok = client.WaitForRev("doc1", rev2ID)
 	assert.True(t, ok)
@@ -2448,7 +2448,7 @@ func TestBlipPullRevMessageHistory(t *testing.T) {
 				Enabled: &sgUseDeltas,
 			},
 		}},
-		guestEnabled: true,
+		GuestEnabled: true,
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -2499,7 +2499,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 				Enabled: &sgUseDeltas,
 			},
 		}},
-		guestEnabled: true,
+		GuestEnabled: true,
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -2591,7 +2591,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 				Enabled: &sgUseDeltas,
 			},
 		}},
-		guestEnabled: true,
+		GuestEnabled: true,
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -2702,7 +2702,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 				Enabled: &sgUseDeltas,
 			},
 		}},
-		guestEnabled: true,
+		GuestEnabled: true,
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -2757,7 +2757,7 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 				Enabled: &sgUseDeltas,
 			},
 		}},
-		guestEnabled: true,
+		GuestEnabled: true,
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -2850,7 +2850,7 @@ func TestActiveOnlyContinuous(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
@@ -2858,7 +2858,7 @@ func TestActiveOnlyContinuous(t *testing.T) {
 	defer btc.Close()
 
 	resp := rt.SendAdminRequest(http.MethodPut, "/db/doc1", `{"test":true}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 	var docResp struct {
 		Rev string `json:"rev"`
 	}
@@ -2873,7 +2873,7 @@ func TestActiveOnlyContinuous(t *testing.T) {
 
 	// delete the doc and make sure the client still gets the tombstone replicated
 	resp = rt.SendAdminRequest(http.MethodDelete, "/db/doc1?rev="+docResp.Rev, ``)
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &docResp))
 
 	rev, found = btc.WaitForRev("doc1", docResp.Rev)
@@ -2886,7 +2886,7 @@ func TestBlipNorev(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
@@ -2945,7 +2945,7 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 				Enabled: base.BoolPtr(true),
 			},
 		}},
-		guestEnabled: true,
+		GuestEnabled: true,
 	})
 	defer rt.Close()
 
@@ -3006,7 +3006,7 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 				Enabled: base.BoolPtr(true),
 			},
 		}},
-		guestEnabled: true,
+		GuestEnabled: true,
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -3026,7 +3026,7 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, response.Code)
 
 	// Wait for the document to be replicated at the client
-	revId := respRevID(t, response)
+	revId := RespRevID(t, response)
 	data, ok := btc.WaitForRev(docID, revId)
 	assert.True(t, ok)
 	bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
@@ -3087,7 +3087,7 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 				},
 			},
 		},
-		guestEnabled: true,
+		GuestEnabled: true,
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -3108,7 +3108,7 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, response.Code)
 
 	// Wait for the document to be replicated to client.
-	revId := respRevID(t, response)
+	revId := RespRevID(t, response)
 	data, ok := btc.WaitForRev(docID, revId)
 	assert.True(t, ok)
 	bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
@@ -3165,7 +3165,7 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 				},
 			},
 		},
-		guestEnabled: true,
+		GuestEnabled: true,
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -3184,7 +3184,7 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, response.Code)
 
 	// Wait for the document to be replicated to client.
-	revId := respRevID(t, response)
+	revId := RespRevID(t, response)
 	data, ok := btc.WaitForRev(docID, revId)
 	assert.True(t, ok)
 	bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
@@ -3227,7 +3227,7 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 
 func TestUpdateExistingAttachment(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
-		guestEnabled: true,
+		GuestEnabled: true,
 	})
 	defer rt.Close()
 
@@ -3240,10 +3240,10 @@ func TestUpdateExistingAttachment(t *testing.T) {
 
 	// Add doc1 and doc2
 	req := rt.SendAdminRequest("PUT", "/db/doc1", `{}`)
-	requireStatus(t, req, http.StatusCreated)
+	RequireStatus(t, req, http.StatusCreated)
 	doc1Bytes := req.BodyBytes()
 	req = rt.SendAdminRequest("PUT", "/db/doc2", `{}`)
-	requireStatus(t, req, http.StatusCreated)
+	RequireStatus(t, req, http.StatusCreated)
 	doc2Bytes := req.BodyBytes()
 
 	require.NoError(t, rt.WaitForPendingChanges())
@@ -3269,9 +3269,9 @@ func TestUpdateExistingAttachment(t *testing.T) {
 	revIDDoc2, err := btc.PushRev("doc2", doc2Body["rev"].(string), []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentBData+`"}}}`))
 	require.NoError(t, err)
 
-	err = rt.waitForRev("doc1", revIDDoc1)
+	err = rt.WaitForRev("doc1", revIDDoc1)
 	assert.NoError(t, err)
-	err = rt.waitForRev("doc2", revIDDoc2)
+	err = rt.WaitForRev("doc2", revIDDoc2)
 	assert.NoError(t, err)
 
 	_, err = rt.GetDatabase().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
@@ -3280,7 +3280,7 @@ func TestUpdateExistingAttachment(t *testing.T) {
 	revIDDoc1, err = btc.PushRev("doc1", revIDDoc1, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=","length":11,"content_type":"","stub":true,"revpos":3}}}`))
 	require.NoError(t, err)
 
-	err = rt.waitForRev("doc1", revIDDoc1)
+	err = rt.WaitForRev("doc1", revIDDoc1)
 	assert.NoError(t, err)
 
 	doc1, err := rt.GetDatabase().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
@@ -3297,7 +3297,7 @@ func TestUpdateExistingAttachment(t *testing.T) {
 // digest doesn't change, regardless of revpos.
 func TestCBLRevposHandling(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
-		guestEnabled: true,
+		GuestEnabled: true,
 	})
 	defer rt.Close()
 
@@ -3310,10 +3310,10 @@ func TestCBLRevposHandling(t *testing.T) {
 
 	// Add doc1 and doc2
 	req := rt.SendAdminRequest("PUT", "/db/doc1", `{}`)
-	requireStatus(t, req, http.StatusCreated)
+	RequireStatus(t, req, http.StatusCreated)
 	doc1Bytes := req.BodyBytes()
 	req = rt.SendAdminRequest("PUT", "/db/doc2", `{}`)
-	requireStatus(t, req, http.StatusCreated)
+	RequireStatus(t, req, http.StatusCreated)
 	doc2Bytes := req.BodyBytes()
 
 	require.NoError(t, rt.WaitForPendingChanges())
@@ -3339,9 +3339,9 @@ func TestCBLRevposHandling(t *testing.T) {
 	revIDDoc2, err := btc.PushRev("doc2", doc2Body["rev"].(string), []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentBData+`"}}}`))
 	require.NoError(t, err)
 
-	err = rt.waitForRev("doc1", revIDDoc1)
+	err = rt.WaitForRev("doc1", revIDDoc1)
 	assert.NoError(t, err)
-	err = rt.waitForRev("doc2", revIDDoc2)
+	err = rt.WaitForRev("doc2", revIDDoc2)
 	assert.NoError(t, err)
 
 	_, err = rt.GetDatabase().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
@@ -3351,7 +3351,7 @@ func TestCBLRevposHandling(t *testing.T) {
 	revIDDoc1, err = btc.PushRev("doc1", revIDDoc1, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-wzp8ZyykdEuZ9GuqmxQ7XDrY7Co=","length":11,"content_type":"","stub":true,"revpos":2}}}`))
 	require.NoError(t, err)
 
-	err = rt.waitForRev("doc1", revIDDoc1)
+	err = rt.WaitForRev("doc1", revIDDoc1)
 	assert.NoError(t, err)
 
 	// Update doc1, don't change attachment, use revpos=generation of revid, as CBL 2.x does.  Should not proveAttachment on digest match.
@@ -3382,7 +3382,7 @@ func TestCBLRevposHandling(t *testing.T) {
 // Verifies that getAttachment is triggered, and attachment is properly persisted.
 func TestPushUnknownAttachmentAsStub(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
-		guestEnabled: true,
+		GuestEnabled: true,
 	})
 	defer rt.Close()
 
@@ -3394,7 +3394,7 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 
 	// Add doc1 and doc2
 	req := rt.SendAdminRequest("PUT", "/db/doc1", `{}`)
-	requireStatus(t, req, http.StatusCreated)
+	RequireStatus(t, req, http.StatusCreated)
 	doc1Bytes := req.BodyBytes()
 
 	require.NoError(t, rt.WaitForPendingChanges())
@@ -3419,7 +3419,7 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 	revIDDoc1, err := btc.PushRev("doc1", rev1ID, []byte(fmt.Sprintf(`{"key": "val", "_attachments":{"attachment":{"digest":"%s","length":%d,"content_type":"%s","stub":true,"revpos":1}}}`, digest, length, contentType)))
 	require.NoError(t, err)
 
-	err = rt.waitForRev("doc1", revIDDoc1)
+	err = rt.WaitForRev("doc1", revIDDoc1)
 	assert.NoError(t, err)
 
 	// verify that attachment exists on document and was persisted
@@ -3432,7 +3432,7 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 func TestRevocationMessage(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
@@ -3450,7 +3450,7 @@ func TestRevocationMessage(t *testing.T) {
 
 	// Skip to seq 4 and then create doc in channel A
 	revocationTester.fillToSeq(4)
-	revID := rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"channels": "A"})
+	revID := rt.CreateDocReturnRev(t, "doc", "", map[string]interface{}{"channels": "A"})
 
 	require.NoError(t, rt.WaitForPendingChanges())
 
@@ -3465,10 +3465,10 @@ func TestRevocationMessage(t *testing.T) {
 	// Remove role from user
 	revocationTester.removeRole("user", "foo")
 
-	revID = rt.createDocReturnRev(t, "doc1", "", map[string]interface{}{"channels": "!"})
+	revID = rt.CreateDocReturnRev(t, "doc1", "", map[string]interface{}{"channels": "!"})
 
 	revocationTester.fillToSeq(10)
-	revID = rt.createDocReturnRev(t, "doc1", revID, map[string]interface{}{})
+	revID = rt.CreateDocReturnRev(t, "doc1", revID, map[string]interface{}{})
 
 	require.NoError(t, rt.WaitForPendingChanges())
 
@@ -3542,7 +3542,7 @@ func TestRevocationMessage(t *testing.T) {
 func TestRevocationNoRev(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := initScenario(t, nil)
+	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
@@ -3560,7 +3560,7 @@ func TestRevocationNoRev(t *testing.T) {
 
 	// Skip to seq 4 and then create doc in channel A
 	revocationTester.fillToSeq(4)
-	revID := rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"channels": "A"})
+	revID := rt.CreateDocReturnRev(t, "doc", "", map[string]interface{}{"channels": "A"})
 
 	require.NoError(t, rt.WaitForPendingChanges())
 	firstOneShotSinceSeq := rt.GetDocumentSequence("doc")
@@ -3575,9 +3575,9 @@ func TestRevocationNoRev(t *testing.T) {
 	// Remove role from user
 	revocationTester.removeRole("user", "foo")
 
-	revID = rt.createDocReturnRev(t, "doc", revID, map[string]interface{}{"channels": "A", "val": "mutate"})
+	revID = rt.CreateDocReturnRev(t, "doc", revID, map[string]interface{}{"channels": "A", "val": "mutate"})
 
-	waitRevID := rt.createDocReturnRev(t, "docmarker", "", map[string]interface{}{"channels": "!"})
+	waitRevID := rt.CreateDocReturnRev(t, "docmarker", "", map[string]interface{}{"channels": "!"})
 	require.NoError(t, rt.WaitForPendingChanges())
 
 	lastSeqStr := strconv.FormatUint(firstOneShotSinceSeq, 10)
@@ -3623,7 +3623,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/_user/user", `{"admin_channels": ["A", "B"], "password": "test"}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
 		Username:        "user",
@@ -3634,9 +3634,9 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	assert.NoError(t, err)
 	defer btc.Close()
 
-	docRevID := rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"channels": []string{"A", "B"}})
+	docRevID := rt.CreateDocReturnRev(t, "doc", "", map[string]interface{}{"channels": []string{"A", "B"}})
 
-	changes, err := rt.waitForChanges(1, "/db/_changes?since=0&revocations=true", "user", true)
+	changes, err := rt.WaitForChanges(1, "/db/_changes?since=0&revocations=true", "user", true)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(changes.Results))
 	assert.Equal(t, "doc", changes.Results[0].ID)
@@ -3648,9 +3648,9 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	_, ok := btc.WaitForRev("doc", "1-9b49fa26d87ad363b2b08de73ff029a9")
 	assert.True(t, ok)
 
-	docRevID = rt.createDocReturnRev(t, "doc", docRevID, map[string]interface{}{"channels": []string{"B"}})
+	docRevID = rt.CreateDocReturnRev(t, "doc", docRevID, map[string]interface{}{"channels": []string{"B"}})
 
-	changes, err = rt.waitForChanges(1, fmt.Sprintf("/db/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
+	changes, err = rt.WaitForChanges(1, fmt.Sprintf("/db/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(changes.Results))
 	assert.Equal(t, "doc", changes.Results[0].ID)
@@ -3662,10 +3662,10 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	_, ok = btc.WaitForRev("doc", "2-f0d4cbcdd4a9ec835799055fdba45263")
 	assert.True(t, ok)
 
-	_ = rt.createDocReturnRev(t, "doc", docRevID, map[string]interface{}{"channels": []string{}})
-	_ = rt.createDocReturnRev(t, "docmarker", "", map[string]interface{}{"channels": []string{"!"}})
+	_ = rt.CreateDocReturnRev(t, "doc", docRevID, map[string]interface{}{"channels": []string{}})
+	_ = rt.CreateDocReturnRev(t, "docmarker", "", map[string]interface{}{"channels": []string{"!"}})
 
-	changes, err = rt.waitForChanges(2, fmt.Sprintf("/db/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
+	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/db/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
 	require.NoError(t, err)
 	assert.Len(t, changes.Results, 2)
 	assert.Equal(t, "doc", changes.Results[0].ID)
@@ -3714,7 +3714,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
-		guestEnabled: true,
+		GuestEnabled: true,
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -3786,7 +3786,7 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
-		guestEnabled: true,
+		GuestEnabled: true,
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -3846,7 +3846,7 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rt := NewRestTester(t, &RestTesterConfig{
-		guestEnabled: true,
+		GuestEnabled: true,
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
 				AllowConflicts: base.BoolPtr(true),
@@ -3860,7 +3860,7 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 	defer btc.Close()
 
 	// Push an initial rev with attachment data
-	initialRevID := rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"_attachments": map[string]interface{}{"hello.txt": map[string]interface{}{"data": "aGVsbG8gd29ybGQ="}}})
+	initialRevID := rt.CreateDocReturnRev(t, "doc", "", map[string]interface{}{"_attachments": map[string]interface{}{"hello.txt": map[string]interface{}{"data": "aGVsbG8gd29ybGQ="}}})
 	err = rt.WaitForPendingChanges()
 	assert.NoError(t, err)
 
@@ -4011,7 +4011,7 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 
 func TestAttachmentWithErroneousRevPos(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
-		guestEnabled: true,
+		GuestEnabled: true,
 	})
 	defer rt.Close()
 
@@ -4020,7 +4020,7 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 	defer btc.Close()
 
 	// Create rev 1 with the hello.txt attachment
-	revid := rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"val": "val", "_attachments": map[string]interface{}{"hello.txt": map[string]interface{}{"data": "aGVsbG8gd29ybGQ="}}})
+	revid := rt.CreateDocReturnRev(t, "doc", "", map[string]interface{}{"val": "val", "_attachments": map[string]interface{}{"hello.txt": map[string]interface{}{"data": "aGVsbG8gd29ybGQ="}}})
 	err = rt.WaitForPendingChanges()
 	assert.NoError(t, err)
 
@@ -4045,7 +4045,7 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 
 	// Get the attachment and ensure the data is updated
 	resp := rt.SendAdminRequest(http.MethodGet, "/db/doc/hello.txt", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	assert.Equal(t, "goodbye cruel world", string(resp.BodyBytes()))
 }
 
@@ -4143,7 +4143,7 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 	}
 
 	// Setup
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
@@ -4151,7 +4151,7 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 	defer client.Close()
 
 	// Track last sequence for next changes feed
-	var changes changesResults
+	var changes ChangesResults
 	changes.Last_Seq = "0"
 
 	for i, test := range testCases {
@@ -4170,13 +4170,13 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 			// Wait for rev to be received on RT
 			err = rt.WaitForPendingChanges()
 			require.NoError(t, err)
-			changes, err = rt.waitForChanges(1, fmt.Sprintf("/db/_changes?since=%s", changes.Last_Seq), "", true)
+			changes, err = rt.WaitForChanges(1, fmt.Sprintf("/db/_changes?since=%s", changes.Last_Seq), "", true)
 			require.NoError(t, err)
 
 			var bucketDoc map[string]interface{}
 			_, err = rt.Bucket().Get(docID, &bucketDoc)
 			assert.NoError(t, err)
-			body := rt.getDoc(docID)
+			body := rt.GetDoc(docID)
 			// Confirm input body is in the bucket doc
 			if test.skipDocContentsVerification == nil || !*test.skipDocContentsVerification {
 				for k, v := range test.inputBody {
@@ -4191,7 +4191,7 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 // CBG-2004: Test that prove attachment over Blip works correctly when receiving a ErrAttachmentNotFound
 func TestProveAttachmentNotFound(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
-		guestEnabled: true,
+		GuestEnabled: true,
 	})
 	defer rt.Close()
 
@@ -4235,10 +4235,10 @@ func TestProveAttachmentNotFound(t *testing.T) {
 	err = rt.WaitForPendingChanges()
 	require.NoError(t, err)
 	// Check attachment is on the document
-	body := rt.getDoc("doc1")
+	body := rt.GetDoc("doc1")
 	assert.Equal(t, "2-abc", body.ExtractRev())
 	resp := rt.SendAdminRequest("GET", "/db/doc1/attach", "")
-	requireStatus(t, resp, 200)
+	RequireStatus(t, resp, 200)
 	assert.EqualValues(t, attachmentData, resp.BodyBytes())
 }
 
@@ -4268,14 +4268,14 @@ func TestProcessRevIncrementsStat(t *testing.T) {
 	require.EqualValues(t, 0, pullStats.HandleRevBytes.Value())
 	require.EqualValues(t, 0, pullStats.HandlePutRevCount.Value())
 
-	rev := remoteRT.createDoc(t, "doc")
+	rev := remoteRT.CreateDoc(t, "doc")
 
 	assert.NoError(t, ar.Start(activeCtx))
 	defer func() { require.NoError(t, ar.Stop()) }()
 
 	err := activeRT.WaitForPendingChanges()
 	require.NoError(t, err)
-	err = activeRT.waitForRev("doc", rev)
+	err = activeRT.WaitForRev("doc", rev)
 	require.NoError(t, err)
 
 	assert.EqualValues(t, 1, pullStats.HandleRevCount.Value())
@@ -4291,7 +4291,7 @@ func TestSendRevAsReadOnlyGuest(t *testing.T) {
 
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		noConflictsMode: true,
-		guestEnabled:    true,
+		GuestEnabled:    true,
 	})
 	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
@@ -4343,7 +4343,7 @@ func TestSendRevAsReadOnlyGuest(t *testing.T) {
 // TestBlipAttachNameChange tests CBL handling - attachments with changed names are sent as stubs, and not new attachments
 func TestBlipAttachNameChange(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
-		guestEnabled: true,
+		GuestEnabled: true,
 	})
 	defer rt.Close()
 
@@ -4370,7 +4370,7 @@ func TestBlipAttachNameChange(t *testing.T) {
 	// Use revpos 2 to simulate revpos bug in CBL 2.8 - 3.0.0
 	rev, err = client1.PushRev("doc", rev, []byte(`{"key":"val","_attachments":{"attach":{"revpos":2,"content_type":"","length":11,"stub":true,"digest":"`+digest+`"}}}`))
 	require.NoError(t, err)
-	err = rt.waitForRev("doc", rev)
+	err = rt.WaitForRev("doc", rev)
 	require.NoError(t, err)
 
 	// Check if attachment is still in bucket
@@ -4379,14 +4379,14 @@ func TestBlipAttachNameChange(t *testing.T) {
 	assert.Equal(t, bucketAttachmentA, attachmentA)
 
 	resp := rt.SendAdminRequest("GET", "/db/doc/attach", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	assert.Equal(t, attachmentA, resp.BodyBytes())
 }
 
 // TestBlipLegacyAttachNameChange ensures that CBL name changes for legacy attachments are handled correctly
 func TestBlipLegacyAttachNameChange(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
-		guestEnabled: true,
+		GuestEnabled: true,
 	})
 	defer rt.Close()
 
@@ -4403,10 +4403,10 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 	rawDoc := rawDocWithAttachmentAndSyncMeta()
 
 	// Create a document with legacy attachment.
-	createDocWithLegacyAttachment(t, rt, docID, rawDoc, attKey, attBody)
+	CreateDocWithLegacyAttachment(t, rt, docID, rawDoc, attKey, attBody)
 
 	// Get the document and grab the revID.
-	responseBody := rt.getDoc(docID)
+	responseBody := rt.GetDoc(docID)
 	revID := responseBody["_rev"].(string)
 	require.NotEmpty(t, revID)
 
@@ -4427,18 +4427,18 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 	// Use revpos 2 to simulate revpos bug in CBL 2.8 - 3.0.0
 	revID, err = client1.PushRev("doc", revID, []byte(`{"key":"val","_attachments":{"attach":{"revpos":2,"content_type":"test/plain","length":2,"stub":true,"digest":"`+digest+`"}}}`))
 	require.NoError(t, err)
-	err = rt.waitForRev("doc", revID)
+	err = rt.WaitForRev("doc", revID)
 	require.NoError(t, err)
 
 	resp := rt.SendAdminRequest("GET", "/db/doc/attach", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	assert.Equal(t, attBody, resp.BodyBytes())
 }
 
 // TestBlipLegacyAttachNameChange ensures that CBL updates for documents associated with legacy attachments are handled correctly
 func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
-		guestEnabled: true,
+		GuestEnabled: true,
 	})
 	defer rt.Close()
 
@@ -4456,10 +4456,10 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 	rawDoc := rawDocWithAttachmentAndSyncMeta()
 
 	// Create a document with legacy attachment.
-	createDocWithLegacyAttachment(t, rt, docID, rawDoc, attKey, attBody)
+	CreateDocWithLegacyAttachment(t, rt, docID, rawDoc, attKey, attBody)
 
 	// Get the document and grab the revID.
-	responseBody := rt.getDoc(docID)
+	responseBody := rt.GetDoc(docID)
 	revID := responseBody["_rev"].(string)
 	require.NotEmpty(t, revID)
 
@@ -4479,11 +4479,11 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 	// Update the document, leaving body intact
 	revID, err = client1.PushRev("doc", revID, []byte(`{"key":"val1","_attachments":{"`+attName+`":{"revpos":2,"content_type":"text/plain","length":2,"stub":true,"digest":"`+digest+`"}}}`))
 	require.NoError(t, err)
-	err = rt.waitForRev("doc", revID)
+	err = rt.WaitForRev("doc", revID)
 	require.NoError(t, err)
 
 	resp := rt.SendAdminRequest("GET", "/db/doc/"+attName, "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	assert.Equal(t, attBody, resp.BodyBytes())
 
 	// Validate that the attachment hasn't been migrated to V2
@@ -4507,7 +4507,7 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 // Regression test for CBG-2183.
 func TestBlipRevokeNonExistentRole(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
-		guestEnabled: false,
+		GuestEnabled: false,
 	})
 	defer rt.Close()
 
@@ -4516,16 +4516,16 @@ func TestBlipRevokeNonExistentRole(t *testing.T) {
 	// 1. Create user with admin_roles including two roles not previously defined (a1 and a2, for example)
 	const testUsername = "bilbo"
 	res := rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/_user/%s", rt.GetDatabase().Name, testUsername), fmt.Sprintf(`{"name": %q, "password": "test", "admin_roles": ["a1", "a2"], "admin_channels": ["c1"]}`, testUsername))
-	requireStatus(t, res, http.StatusCreated)
+	RequireStatus(t, res, http.StatusCreated)
 
 	// Create a doc so we have something to replicate
 	res = rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/testdoc", rt.GetDatabase().Name), `{"channels": ["c1"]}`)
-	requireStatus(t, res, http.StatusCreated)
+	RequireStatus(t, res, http.StatusCreated)
 
 	// 3. Update the user to not reference one of the roles (update to ['a1'], for example)
 	// [also revoke channel c1 so the doc shows up in the revocation queries]
 	res = rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/_user/%s", rt.GetDatabase().Name, testUsername), fmt.Sprintf(`{"name": %q, "password": "test", "admin_roles": ["a1"], "admin_channels": []}`, testUsername))
-	requireStatus(t, res, http.StatusOK)
+	RequireStatus(t, res, http.StatusOK)
 
 	// 4. Try to sync
 	bt, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
@@ -4567,8 +4567,8 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 		t.Run(fmt.Sprintf("%s", test.error), func(t *testing.T) {
 			docName := fmt.Sprintf("%s", test.error)
 			rt := NewRestTester(t, &RestTesterConfig{
-				guestEnabled: true,
-				TestBucket:   base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{}),
+				GuestEnabled:     true,
+				CustomTestBucket: base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{}),
 			})
 			defer rt.Close()
 
@@ -4587,7 +4587,7 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 			}
 
 			resp := rt.SendAdminRequest(http.MethodPut, "/db/"+docName, `{"foo":"bar"}`)
-			requireStatus(t, resp, http.StatusCreated)
+			RequireStatus(t, resp, http.StatusCreated)
 
 			// Make the LeakyBucket return an error
 			leakyBucket.SetGetRawCallback(func(key string) error {
@@ -4615,7 +4615,7 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 			}
 
 			// Make sure document did not get replicated
-			_, found := btc.GetRev(docName, respRevID(t, resp))
+			_, found := btc.GetRev(docName, RespRevID(t, resp))
 			assert.False(t, found)
 		})
 	}
@@ -4623,7 +4623,7 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 
 func TestUnsubChanges(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 
 	defer rt.Close()
 
@@ -4638,7 +4638,7 @@ func TestUnsubChanges(t *testing.T) {
 	// Sub changes
 	err = btc.StartPull()
 	require.NoError(t, err)
-	resp := rt.updateDoc("doc1", "", `{"key":"val1"}`)
+	resp := rt.UpdateDoc("doc1", "", `{"key":"val1"}`)
 	_, found := btc.WaitForRev("doc1", resp.Rev)
 	require.True(t, found)
 
@@ -4654,7 +4654,7 @@ func TestUnsubChanges(t *testing.T) {
 	assert.EqualValues(t, 0, activeReplVal)
 
 	// Confirm no more changes are being sent
-	resp = rt.updateDoc("doc2", "", `{"key":"val1"}`)
+	resp = rt.UpdateDoc("doc2", "", `{"key":"val1"}`)
 	err = rt.WaitForConditionWithOptions(func() bool {
 		_, found = btc.GetRev("doc2", resp.Rev)
 		return found

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -33,7 +33,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	// Start SG with no databases
 	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(ctx, &config, true)
+	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	ctx = sc.SetContextLogID(ctx, "initial")
 
@@ -96,7 +96,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	require.NoError(t, <-serverErr)
 
 	ctx = base.TestCtx(t)
-	sc, err = setupServerContext(ctx, &config, true)
+	sc, err = SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	ctx = sc.SetContextLogID(ctx, "loaddatabase")
 
@@ -150,7 +150,7 @@ func TestBootstrapDuplicateBucket(t *testing.T) {
 	// Start SG with no databases
 	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(ctx, &config, true)
+	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 
 	defer func() {
@@ -201,7 +201,7 @@ func TestBootstrapDuplicateDatabase(t *testing.T) {
 	// Start SG with no databases
 	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(ctx, &config, true)
+	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 
 	defer func() {

--- a/rest/config.go
+++ b/rest/config.go
@@ -1040,8 +1040,8 @@ func (config *DbConfig) redactInPlace() error {
 	return nil
 }
 
-// decodeAndSanitiseConfig will sanitise a config from an io.Reader and unmarshal it into the given config parameter.
-func decodeAndSanitiseConfig(r io.Reader, config interface{}) (err error) {
+// DecodeAndSanitiseConfig will sanitise a config from an io.Reader and unmarshal it into the given config parameter.
+func DecodeAndSanitiseConfig(r io.Reader, config interface{}) (err error) {
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return err
@@ -1179,7 +1179,8 @@ func (sc *ServerContext) addHTTPServer(s *http.Server) {
 	sc._httpServers = append(sc._httpServers, s)
 }
 
-func (sc *StartupConfig) validate(isEnterpriseEdition bool) (errorMessages error) {
+// Validate returns errors errors if invalid config is present
+func (sc *StartupConfig) Validate(isEnterpriseEdition bool) (errorMessages error) {
 	var multiError *base.MultiError
 	if sc.Bootstrap.Server == "" {
 		multiError = multiError.Append(fmt.Errorf("a server must be provided in the Bootstrap configuration"))
@@ -1239,7 +1240,7 @@ func (sc *StartupConfig) validate(isEnterpriseEdition bool) (errorMessages error
 			multiError = multiError.Append(fmt.Errorf("enable_advanced_auth_dp is only supported in enterprise edition"))
 		}
 
-		if sc.Bootstrap.ConfigGroupID != persistentConfigDefaultGroupID {
+		if sc.Bootstrap.ConfigGroupID != PersistentConfigDefaultGroupID {
 			multiError = multiError.Append(fmt.Errorf("customization of group_id is only supported in enterprise edition"))
 		}
 	}
@@ -1247,8 +1248,8 @@ func (sc *StartupConfig) validate(isEnterpriseEdition bool) (errorMessages error
 	return multiError.ErrorOrNil()
 }
 
-// setupServerContext creates a new ServerContext given its configuration and performs the context validation.
-func setupServerContext(ctx context.Context, config *StartupConfig, persistentConfig bool) (*ServerContext, error) {
+// SetupServerContext creates a new ServerContext given its configuration and performs the context validation.
+func SetupServerContext(ctx context.Context, config *StartupConfig, persistentConfig bool) (*ServerContext, error) {
 	// Logging config will now have been loaded from command line
 	// or from a sync_gateway config file so we can validate the
 	// configuration and setup logging now
@@ -1269,7 +1270,7 @@ func setupServerContext(ctx context.Context, config *StartupConfig, persistentCo
 		return nil, err
 	}
 
-	if err := config.validate(base.IsEnterpriseEdition()); err != nil {
+	if err := config.Validate(base.IsEnterpriseEdition()); err != nil {
 		return nil, err
 	}
 
@@ -1582,7 +1583,7 @@ func (sc *ServerContext) _applyConfig(ctx context.Context, cnf DatabaseConfig, f
 
 // addLegacyPrincipals takes a map of databases that each have a map of names with principle configs.
 // Call this function to install the legacy principles to the upgraded database that use a persistent config.
-// Only call this function after the databases have been initalised via setupServerContext.
+// Only call this function after the databases have been initalised via SetupServerContext.
 func (sc *ServerContext) addLegacyPrincipals(ctx context.Context, legacyDbUsers, legacyDbRoles map[string]map[string]*auth.PrincipalConfig) {
 	for dbName, dbUser := range legacyDbUsers {
 		dbCtx, err := sc.GetDatabase(ctx, dbName)

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -361,7 +361,7 @@ func LoadLegacyServerConfig(path string) (config *LegacyServerConfig, err error)
 
 // readLegacyServerConfig returns a validated LegacyServerConfig from an io.Reader
 func readLegacyServerConfig(r io.Reader) (config *LegacyServerConfig, err error) {
-	err = decodeAndSanitiseConfig(r, &config)
+	err = DecodeAndSanitiseConfig(r, &config)
 	if err != nil {
 		return config, err
 	}

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -327,7 +327,7 @@ func TestLegacyGuestUserMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	var dbConfig DbConfig
-	_, err = cluster.GetConfig(tb.GetName(), persistentConfigDefaultGroupID, &dbConfig)
+	_, err = cluster.GetConfig(tb.GetName(), PersistentConfigDefaultGroupID, &dbConfig)
 	require.NoError(t, err)
 
 	assert.Equal(t, &expected, dbConfig.Guest)

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	// persistentConfigDefaultGroupID is used when no explicit config Group ID is defined.
-	persistentConfigDefaultGroupID   = "default"
+	// PersistentConfigDefaultGroupID is used when no explicit config Group ID is defined.
+	PersistentConfigDefaultGroupID   = "default"
 	persistentConfigGroupIDMaxLength = 100
 	// persistentConfigDefaultUpdateFrequency is a duration that defines how frequent configs are refreshed from Couchbase Server.
 	persistentConfigDefaultUpdateFrequency = time.Second * 10
@@ -23,7 +23,7 @@ const (
 func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 	return StartupConfig{
 		Bootstrap: BootstrapConfig{
-			ConfigGroupID:         persistentConfigDefaultGroupID,
+			ConfigGroupID:         PersistentConfigDefaultGroupID,
 			ConfigUpdateFrequency: base.NewConfigDuration(persistentConfigDefaultUpdateFrequency),
 			ServerTLSSkipVerify:   base.BoolPtr(false),
 			UseTLSServer:          base.BoolPtr(DefaultUseTLSServer),
@@ -198,7 +198,7 @@ func LoadStartupConfigFromPath(path string) (*StartupConfig, error) {
 	defer func() { _ = rc.Close() }()
 
 	var sc StartupConfig
-	err = decodeAndSanitiseConfig(rc, &sc)
+	err = DecodeAndSanitiseConfig(rc, &sc)
 	return &sc, err
 }
 

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1350,7 +1350,7 @@ func TestSetupServerContext(t *testing.T) {
 		config.Bootstrap.Username = base.TestClusterUsername()
 		config.Bootstrap.Password = base.TestClusterPassword()
 		ctx := base.TestCtx(t)
-		sc, err := setupServerContext(ctx, &config, false)
+		sc, err := SetupServerContext(ctx, &config, false)
 		defer sc.Close(ctx)
 		require.NoError(t, err)
 		require.NotNil(t, sc)
@@ -1367,12 +1367,12 @@ func TestConfigGroupIDValidation(t *testing.T) {
 	}{
 		{
 			name:       "No change, CE mode",
-			cfgGroupID: persistentConfigDefaultGroupID,
+			cfgGroupID: PersistentConfigDefaultGroupID,
 			eeMode:     false,
 		},
 		{
 			name:       "No change, EE mode",
-			cfgGroupID: persistentConfigDefaultGroupID,
+			cfgGroupID: PersistentConfigDefaultGroupID,
 			eeMode:     true,
 		},
 		{
@@ -1415,7 +1415,7 @@ func TestConfigGroupIDValidation(t *testing.T) {
 					UseTLSServer:  base.BoolPtr(base.ServerIsTLS(base.UnitTestUrl())),
 				},
 			}
-			err := sc.validate(isEnterpriseEdition)
+			err := sc.Validate(isEnterpriseEdition)
 			if test.expectedError != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), test.expectedError)
@@ -1466,7 +1466,7 @@ func TestClientTLSMissing(t *testing.T) {
 			if test.tlsCert {
 				config.API.HTTPS.TLSCertPath = "test.cert"
 			}
-			err := config.validate(base.IsEnterpriseEdition())
+			err := config.Validate(base.IsEnterpriseEdition())
 			if test.expectError {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), errorTLSOneMissing)
@@ -2342,7 +2342,7 @@ func TestStartupConfigBcryptCostValidation(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			sc := StartupConfig{Auth: AuthConfig{BcryptCost: test.cost}}
-			err := sc.validate(base.IsEnterpriseEdition())
+			err := sc.Validate(base.IsEnterpriseEdition())
 			if test.expectError {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), errContains)
@@ -2499,7 +2499,7 @@ func TestBucketCredentialsValidation(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.startupConfig.validate(base.IsEnterpriseEdition())
+			err := test.startupConfig.Validate(base.IsEnterpriseEdition())
 			if test.expectedError != nil {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), *test.expectedError)

--- a/rest/doc_api_test.go
+++ b/rest/doc_api_test.go
@@ -109,11 +109,11 @@ func TestDocumentNumbers(t *testing.T) {
 		t.Run(test.name, func(ts *testing.T) {
 			// Create document
 			response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", test.name), test.body)
-			requireStatus(ts, response, 201)
+			RequireStatus(ts, response, 201)
 
 			// Get document, validate number value
 			getResponse := rt.SendAdminRequest("GET", fmt.Sprintf("/db/%s", test.name), "")
-			requireStatus(ts, getResponse, 200)
+			RequireStatus(ts, getResponse, 200)
 
 			// Check the raw bytes, because unmarshalling the response would be another opportunity for the number to get modified
 			responseString := string(getResponse.Body.Bytes())
@@ -136,7 +136,7 @@ func TestDocumentNumbers(t *testing.T) {
 
 func TestGuestReadOnly(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
-		guestEnabled: true,
+		GuestEnabled: true,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			Unsupported: &db.UnsupportedOptions{
 				GuestReadOnly: true,
@@ -150,15 +150,15 @@ func TestGuestReadOnly(t *testing.T) {
 	rt.GetDatabase()
 	// Write a document as admin
 	response := rt.SendAdminRequest("PUT", "/db/doc", "{}")
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Attempt to read as guest
 	response = rt.SendRequest("GET", "/db/doc", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	assert.Equal(t, `{"_id":"doc","_rev":"1-ca9ad22802b66f662ff171f226211d5c"}`, string(response.BodyBytes()))
 
 	// Attempt to write as guest
 	response = rt.SendRequest("PUT", "/db/doc?rev=1-ca9ad22802b66f662ff171f226211d5c", `{"val": "newval"}`)
-	requireStatus(t, response, http.StatusForbidden)
+	RequireStatus(t, response, http.StatusForbidden)
 
 }

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -49,6 +49,14 @@ func HasActiveChannel(channelSet map[string]interface{}, channelName string) boo
 	return true
 }
 
+// gocb V2 accepts expiry as a duration and converts to a uint32 epoch time, then does the reverse on retrieval.
+// Sync Gateway's bucket interface uses uint32 expiry. The net result is that expiry values written and then read via SG's
+// bucket API go through a transformation based on time.Now (or time.Until) that can result in inexact matches.
+// assertExpiry validates that the two expiry values are within a 10 second window
+func assertExpiry(t testing.TB, expected uint32, actual uint32) {
+	assert.True(t, base.DiffUint32(expected, actual) < 10, fmt.Sprintf("Unexpected difference between expected: %v actual %v", expected, actual))
+}
+
 // Test import of an SDK delete.
 func TestXattrImportOldDoc(t *testing.T) {
 
@@ -158,7 +166,7 @@ func TestXattrImportOldDocRevHistory(t *testing.T) {
 
 	// 1. Create revision with history
 	docID := t.Name()
-	putResponse := rt.putDoc(docID, `{"val":-1}`)
+	putResponse := rt.PutDoc(docID, `{"val":-1}`)
 	revID := putResponse.Rev
 
 	// Get db.Database to perform PurgeOldRevisionJSON
@@ -168,7 +176,7 @@ func TestXattrImportOldDocRevHistory(t *testing.T) {
 
 	ctx := rt.Context()
 	for i := 0; i < 10; i++ {
-		updateResponse := rt.updateDoc(docID, revID, fmt.Sprintf(`{"val":%d}`, i))
+		updateResponse := rt.UpdateDoc(docID, revID, fmt.Sprintf(`{"val":%d}`, i))
 		// Purge old revision JSON to simulate expiry, and to verify import doesn't attempt multiple retrievals
 		purgeErr := database.PurgeOldRevisionJSON(ctx, docID, revID)
 		assert.NoError(t, purgeErr)
@@ -1345,7 +1353,7 @@ func TestXattrFeedBasedImportPreservesExpiry(t *testing.T) {
 	assert.NoError(t, err, "Error writing SDK doc")
 
 	// Wait until the change appears on the changes feed to ensure that it's been imported by this point
-	changes, err := rt.waitForChanges(2, "/db/_changes", "", true)
+	changes, err := rt.WaitForChanges(2, "/db/_changes", "", true)
 	require.NoError(t, err, "Error waiting for changes")
 
 	log.Printf("changes: %+v", changes)
@@ -1397,7 +1405,7 @@ func TestFeedBasedMigrateWithExpiry(t *testing.T) {
 	// Wait for doc to appear on changes feed
 	// Wait until the change appears on the changes feed to ensure that it's been imported by this point
 	now := time.Now()
-	changes, err := rt.waitForChanges(1, "/db/_changes", "", true)
+	changes, err := rt.WaitForChanges(1, "/db/_changes", "", true)
 	require.NoError(t, err, "Error waiting for changes")
 	changeEntry := changes.Results[0]
 	assert.Equal(t, key, changeEntry.ID)
@@ -1449,7 +1457,7 @@ func TestOnDemandWriteImportReplacingNullDoc(t *testing.T) {
 	mobileBodyMarshalled, err := base.JSONMarshal(mobileBody)
 	assert.NoError(t, err, "Error marshalling body")
 	response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", key), string(mobileBodyMarshalled))
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 }
 
@@ -1523,7 +1531,7 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 
 			// Wait until the change appears on the changes feed to ensure that it's been imported by this point.
 			// This is probably unnecessary in the case of on-demand imports, but it doesn't hurt to leave it in as a double check.
-			changes, err := rt.waitForChanges(1, "/db/_changes", "", true)
+			changes, err := rt.WaitForChanges(1, "/db/_changes", "", true)
 			require.NoError(t, err, "Error waiting for changes")
 			changeEntry := changes.Results[0]
 			assert.Equal(t, key, changeEntry.ID)
@@ -1731,7 +1739,7 @@ func TestImportZeroValueDecimalPlaces(t *testing.T) {
 		t.Logf("Inserting doc %s: %s", docID, string(docBody))
 	}
 
-	changes, err := rt.waitForChanges((maxDecimalPlaces+1)-minDecimalPlaces, "/db/_changes", "", true)
+	changes, err := rt.WaitForChanges((maxDecimalPlaces+1)-minDecimalPlaces, "/db/_changes", "", true)
 	assert.NoError(t, err, "Error waiting for changes")
 	require.Lenf(t, changes.Results, maxDecimalPlaces+1-minDecimalPlaces, "Expected %d changes in: %#v", (maxDecimalPlaces+1)-minDecimalPlaces, changes.Results)
 
@@ -1793,7 +1801,7 @@ func TestImportZeroValueDecimalPlacesScientificNotation(t *testing.T) {
 		t.Logf("Inserting doc %s: %s", docID, string(docBody))
 	}
 
-	changes, err := rt.waitForChanges((maxDecimalPlaces+1)-minDecimalPlaces, "/db/_changes", "", true)
+	changes, err := rt.WaitForChanges((maxDecimalPlaces+1)-minDecimalPlaces, "/db/_changes", "", true)
 	assert.NoError(t, err, "Error waiting for changes")
 	require.Lenf(t, changes.Results, maxDecimalPlaces+1-minDecimalPlaces, "Expected %d changes in: %#v", (maxDecimalPlaces+1)-minDecimalPlaces, changes.Results)
 
@@ -2364,9 +2372,9 @@ func TestImportInternalPropertiesHandling(t *testing.T) {
 				return
 			}
 			if test.expectedStatusCode != nil {
-				requireStatus(rt.tb, resp, *test.expectedStatusCode)
+				RequireStatus(rt.tb, resp, *test.expectedStatusCode)
 			} else {
-				requireStatus(rt.tb, resp, 200)
+				RequireStatus(rt.tb, resp, 200)
 			}
 			var body db.Body
 			require.NoError(rt.tb, base.JSONUnmarshal(resp.Body.Bytes(), &body))

--- a/rest/jwt_auth_test.go
+++ b/rest/jwt_auth_test.go
@@ -461,7 +461,7 @@ func TestLocalJWTRolesChannels(t *testing.T) {
 	res := restTester.SendRequestWithHeaders(http.MethodPost, "/db/_session", "{}", map[string]string{
 		"Authorization": BearerToken + " " + token,
 	})
-	requireStatus(t, res, http.StatusOK)
+	RequireStatus(t, res, http.StatusOK)
 
 	authn := restTester.GetDatabase().Authenticator(base.TestCtx(t))
 	user, err := authn.GetUser(testProviderName + "_" + testSubject)

--- a/rest/main.go
+++ b/rest/main.go
@@ -135,7 +135,7 @@ func serverMainPersistentConfig(ctx context.Context, fs *flag.FlagSet, flagStart
 	}
 
 	base.InfofCtx(ctx, base.KeyAll, "Config: Starting in persistent mode using config group %q", sc.Bootstrap.ConfigGroupID)
-	svrctx, err := setupServerContext(ctx, &sc, true)
+	svrctx, err := SetupServerContext(ctx, &sc, true)
 	if err != nil {
 		return false, err
 	}
@@ -222,7 +222,7 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 		dbc.Roles = nil
 		dbc.Users = nil
 
-		configGroupID := persistentConfigDefaultGroupID
+		configGroupID := PersistentConfigDefaultGroupID
 		if startupConfig.Bootstrap.ConfigGroupID != "" {
 			configGroupID = startupConfig.Bootstrap.ConfigGroupID
 		}

--- a/rest/main_legacy.go
+++ b/rest/main_legacy.go
@@ -48,7 +48,7 @@ func legacyServerMain(ctx context.Context, osArgs []string, flagStartupConfig *S
 		return err
 	}
 
-	svrctx, err := setupServerContext(ctx, &sc, false)
+	svrctx, err := SetupServerContext(ctx, &sc, false)
 	if err != nil {
 		return err
 	}

--- a/rest/multipart_test.go
+++ b/rest/multipart_test.go
@@ -43,11 +43,11 @@ Content-Type: application/json
 --0123456789--`
 
 	response := rt.SendAdminRequestWithHeaders(http.MethodPut, "/db/doc1", bodyText, reqHeaders)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	response = rt.SendAdminRequestWithHeaders(http.MethodGet, "/db/doc1", "", reqHeaders)
 	log.Printf("response: %v", string(response.BodyBytes()))
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 }
 
 func TestReadJSONFromMIME(t *testing.T) {
@@ -138,10 +138,10 @@ Content-Disposition: attachment; filename=att.txt
 --123--`
 
 	response := rt.SendAdminRequestWithHeaders(http.MethodPut, "/db/doc1", bodyText, reqHeaders)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	response = rt.SendAdminRequestWithHeaders(http.MethodGet, "/db/doc1", "", reqHeaders)
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	var body db.Body
 	assert.NoError(t, base.JSONUnmarshal(response.BodyBytes(), &body))

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -971,18 +971,18 @@ func createUser(t *testing.T, restTester *RestTester, name string) {
 	body := fmt.Sprintf(`{"name":"%s", "password":"pass", "email":"%s@couchbase.com"}`, name, name)
 	userEndpoint := fmt.Sprintf("/db/_user/%s", url.QueryEscape(name))
 	response := restTester.SendAdminRequest(http.MethodPut, userEndpoint, body)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	response = restTester.SendAdminRequest(http.MethodGet, userEndpoint, "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 }
 
 // deleteUser deletes the specified user.
 func deleteUser(t *testing.T, restTester *RestTester, name string) {
 	userEndpoint := fmt.Sprintf("/db/_user/%s", name)
 	response := restTester.SendAdminRequest(http.MethodDelete, userEndpoint, "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	response = restTester.SendAdminRequest(http.MethodGet, userEndpoint, "")
-	requireStatus(t, response, http.StatusNotFound)
+	RequireStatus(t, response, http.StatusNotFound)
 }
 
 // createOIDCRequest creates the request with the sessionEndpoint and token put in.
@@ -2233,7 +2233,7 @@ func TestOpenIDConnectRolesChannelsClaims(t *testing.T) {
 				payloadJSON, err := json.Marshal(payload)
 				require.NoError(t, err, "Failed to marshal role payload")
 				res := restTester.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/_role/%s", restTester.DatabaseConfig.Name, roleName), string(payloadJSON))
-				requireStatus(t, res, http.StatusCreated)
+				RequireStatus(t, res, http.StatusCreated)
 			}
 
 			testDocBody := struct {
@@ -2244,7 +2244,7 @@ func TestOpenIDConnectRolesChannelsClaims(t *testing.T) {
 			testDocJSON, err := json.Marshal(testDocBody)
 			require.NoError(t, err, "Failed to marshal test doc payload")
 			res := restTester.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/%s", restTester.DatabaseConfig.Name, testDocName), string(testDocJSON))
-			requireStatus(t, res, http.StatusCreated)
+			RequireStatus(t, res, http.StatusCreated)
 
 			mockSyncGateway := httptest.NewServer(restTester.TestPublicHandler())
 			defer mockSyncGateway.Close()
@@ -2320,7 +2320,7 @@ func TestOpenIDConnectProviderRemoval(t *testing.T) {
 
 	ctx := base.TestCtx(t)
 	startupConfig := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(ctx, &startupConfig, true)
+	sc, err := SetupServerContext(ctx, &startupConfig, true)
 	require.NoError(t, err)
 	serverErr := make(chan error, 0)
 	go func() {
@@ -2447,8 +2447,8 @@ func TestOpenIDConnectIssuerChange(t *testing.T) {
 	tb1 := base.GetTestBucket(t)
 	defer tb1.Close()
 	rt1Config := RestTesterConfig{
-		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{}},
-		TestBucket:     tb1,
+		DatabaseConfig:   &DatabaseConfig{DbConfig: DbConfig{}},
+		CustomTestBucket: tb1,
 	}
 	rt1 := NewRestTester(t, &rt1Config)
 	require.NoError(t, rt1.SetAdminParty(false))
@@ -2496,7 +2496,7 @@ func TestOpenIDConnectIssuerChange(t *testing.T) {
 	updateReqJSON, err := json.Marshal(&newCfg)
 	require.NoError(t, err, "Failed to marshal update request body")
 	testRes := rt1.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/_config", rt1Config.DatabaseConfig.Name), string(updateReqJSON))
-	requireStatus(t, testRes, http.StatusCreated)
+	RequireStatus(t, testRes, http.StatusCreated)
 
 	cookieJar, err := cookiejar.New(nil)
 	require.NoError(t, err)
@@ -2510,7 +2510,7 @@ func TestOpenIDConnectIssuerChange(t *testing.T) {
 	testDocJSON, err := json.Marshal(testDocBody)
 	require.NoError(t, err, "Failed to marshal test doc payload")
 	tdRes := rt1.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/%s", rt1.DatabaseConfig.Name, testDocName), string(testDocJSON))
-	requireStatus(t, tdRes, http.StatusCreated)
+	RequireStatus(t, tdRes, http.StatusCreated)
 
 	jwt, err := createJWTWithExtraClaims(subject, fmt.Sprintf("%s/%s/_oidc_testing", msg1.URL, rt1.DatabaseConfig.Name), AuthState{TokenTTL: time.Hour}, map[string]interface{}{
 		"username": "frodo",

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -92,7 +92,7 @@ func TestAutomaticConfigUpgrade(t *testing.T) {
 	require.NoError(t, err)
 
 	var dbConfig DbConfig
-	_, err = cbs.GetConfig(tb.GetName(), persistentConfigDefaultGroupID, &dbConfig)
+	_, err = cbs.GetConfig(tb.GetName(), PersistentConfigDefaultGroupID, &dbConfig)
 	require.NoError(t, err)
 
 	assert.Equal(t, "db", dbConfig.Name)
@@ -219,7 +219,7 @@ func TestAutomaticConfigUpgradeExistingConfigAndNewGroup(t *testing.T) {
 	require.NoError(t, err)
 
 	var dbConfig DbConfig
-	originalDefaultDbConfigCAS, err := cbs.GetConfig(tb.GetName(), persistentConfigDefaultGroupID, &dbConfig)
+	originalDefaultDbConfigCAS, err := cbs.GetConfig(tb.GetName(), PersistentConfigDefaultGroupID, &dbConfig)
 	assert.NoError(t, err)
 
 	// Ensure that revs limit hasn't actually been set
@@ -268,7 +268,7 @@ func TestAutomaticConfigUpgradeExistingConfigAndNewGroup(t *testing.T) {
 
 		// Ensure default has not changed
 		dbConfig = DbConfig{}
-		defaultDbConfigCAS, err := cbs.GetConfig(tb.GetName(), persistentConfigDefaultGroupID, &dbConfig)
+		defaultDbConfigCAS, err := cbs.GetConfig(tb.GetName(), PersistentConfigDefaultGroupID, &dbConfig)
 		assert.NoError(t, err)
 		assert.Equal(t, originalDefaultDbConfigCAS, defaultDbConfigCAS)
 	} else {
@@ -294,7 +294,7 @@ func TestImportFilterEndpoint(t *testing.T) {
 	// Start SG with no databases
 	ctx := base.TestCtx(t)
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(ctx, &config, true)
+	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	defer func() {
 		sc.Close(ctx)

--- a/rest/query_api_test.go
+++ b/rest/query_api_test.go
@@ -61,7 +61,7 @@ func testConcurrently(t *testing.T, rt *RestTester, testFunc func() bool) bool {
 }
 
 func TestConcurrentQueries(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true, EnableUserQueries: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true, EnableUserQueries: true})
 	defer rt.Close()
 	rt.DatabaseConfig = &DatabaseConfig{DbConfig: DbConfig{
 		UserFunctions: map[string]*db.UserFunctionConfig{

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -45,12 +45,12 @@ func TestReplicationAPI(t *testing.T) {
 	}
 
 	// PUT replication
-	response := rt.SendAdminRequest("PUT", "/db/_replication/replication1", marshalConfig(t, replicationConfig))
-	requireStatus(t, response, http.StatusCreated)
+	response := rt.SendAdminRequest("PUT", "/db/_replication/replication1", MarshalConfig(t, replicationConfig))
+	RequireStatus(t, response, http.StatusCreated)
 
 	// GET replication for PUT
 	response = rt.SendAdminRequest("GET", "/db/_replication/replication1", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	var configResponse db.ReplicationConfig
 	err := json.Unmarshal(response.BodyBytes(), &configResponse)
 	log.Printf("configResponse direction type: %T", configResponse.Direction)
@@ -62,12 +62,12 @@ func TestReplicationAPI(t *testing.T) {
 
 	// POST replication
 	replicationConfig.ID = "replication2"
-	response = rt.SendAdminRequest("POST", "/db/_replication/", marshalConfig(t, replicationConfig))
-	requireStatus(t, response, http.StatusCreated)
+	response = rt.SendAdminRequest("POST", "/db/_replication/", MarshalConfig(t, replicationConfig))
+	RequireStatus(t, response, http.StatusCreated)
 
 	// GET replication for POST
 	response = rt.SendAdminRequest("GET", "/db/_replication/replication2", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	configResponse = db.ReplicationConfig{}
 	err = json.Unmarshal(response.BodyBytes(), &configResponse)
 	require.NoError(t, err)
@@ -77,7 +77,7 @@ func TestReplicationAPI(t *testing.T) {
 
 	// GET all replications
 	response = rt.SendAdminRequest("GET", "/db/_replication/", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	var replicationsResponse map[string]db.ReplicationConfig
 	log.Printf("response: %s", response.BodyBytes())
 	err = json.Unmarshal(response.BodyBytes(), &replicationsResponse)
@@ -90,15 +90,15 @@ func TestReplicationAPI(t *testing.T) {
 
 	// DELETE replication
 	response = rt.SendAdminRequest("DELETE", "/db/_replication/replication1", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	// Verify delete was successful
 	response = rt.SendAdminRequest("GET", "/db/_replication/replication1", "")
-	requireStatus(t, response, http.StatusNotFound)
+	RequireStatus(t, response, http.StatusNotFound)
 
 	// DELETE non-existent replication
 	response = rt.SendAdminRequest("DELETE", "/db/_replication/replication3", "")
-	requireStatus(t, response, http.StatusNotFound)
+	RequireStatus(t, response, http.StatusNotFound)
 
 }
 
@@ -167,8 +167,8 @@ func TestValidateReplicationAPI(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_replication/%s", test.ID), marshalConfig(t, test.config))
-			requireStatus(t, response, test.expectedResponseCode)
+			response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_replication/%s", test.ID), MarshalConfig(t, test.config))
+			RequireStatus(t, response, test.expectedResponseCode)
 			if test.expectedErrorContains != "" {
 				assert.Contains(t, string(response.Body.Bytes()), test.expectedErrorContains)
 			}
@@ -228,11 +228,11 @@ func TestValidateReplicationAPI_CE(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_replication/%s", test.ID), marshalConfig(t, test.config))
+			response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_replication/%s", test.ID), MarshalConfig(t, test.config))
 			if base.IsEnterpriseEdition() {
-				requireStatus(t, response, 201)
+				RequireStatus(t, response, 201)
 			} else {
-				requireStatus(t, response, 400)
+				RequireStatus(t, response, 400)
 			}
 		})
 	}
@@ -246,7 +246,7 @@ func TestReplicationStatusAPI(t *testing.T) {
 
 	// GET replication status for non-existent replication ID
 	response := rt.SendAdminRequest("GET", "/db/_replicationStatus/replication1", "")
-	requireStatus(t, response, http.StatusNotFound)
+	RequireStatus(t, response, http.StatusNotFound)
 
 	replicationConfig := db.ReplicationConfig{
 		ID:        "replication1",
@@ -255,12 +255,12 @@ func TestReplicationStatusAPI(t *testing.T) {
 	}
 
 	// PUT replication1
-	response = rt.SendAdminRequest("PUT", "/db/_replication/replication1", marshalConfig(t, replicationConfig))
-	requireStatus(t, response, http.StatusCreated)
+	response = rt.SendAdminRequest("PUT", "/db/_replication/replication1", MarshalConfig(t, replicationConfig))
+	RequireStatus(t, response, http.StatusCreated)
 
 	// GET replication status for replication1
 	response = rt.SendAdminRequest("GET", "/db/_replicationStatus/replication1", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	var statusResponse db.ReplicationStatus
 	err := json.Unmarshal(response.BodyBytes(), &statusResponse)
 	require.NoError(t, err)
@@ -273,12 +273,12 @@ func TestReplicationStatusAPI(t *testing.T) {
 		Remote:    "http://remote:4984/db",
 		Direction: "pull",
 	}
-	response = rt.SendAdminRequest("PUT", "/db/_replication/replication2", marshalConfig(t, replication2Config))
-	requireStatus(t, response, http.StatusCreated)
+	response = rt.SendAdminRequest("PUT", "/db/_replication/replication2", MarshalConfig(t, replication2Config))
+	RequireStatus(t, response, http.StatusCreated)
 
 	// GET replication status for all replications
 	response = rt.SendAdminRequest("GET", "/db/_replicationStatus/", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	var allStatusResponse []*db.ReplicationStatus
 	err = json.Unmarshal(response.BodyBytes(), &allStatusResponse)
 	require.NoError(t, err)
@@ -288,11 +288,11 @@ func TestReplicationStatusAPI(t *testing.T) {
 
 	// PUT replication status, no action
 	response = rt.SendAdminRequest("PUT", "/db/_replicationStatus/replication1", "")
-	requireStatus(t, response, http.StatusBadRequest)
+	RequireStatus(t, response, http.StatusBadRequest)
 
 	// PUT replication status with action
 	response = rt.SendAdminRequest("PUT", "/db/_replicationStatus/replication1?action=start", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 }
 
 func TestReplicationStatusStopAdhoc(t *testing.T) {
@@ -302,7 +302,7 @@ func TestReplicationStatusStopAdhoc(t *testing.T) {
 
 	// GET replication status for non-existent replication ID
 	response := rt.SendAdminRequest("GET", "/db/_replicationStatus/replication1", "")
-	requireStatus(t, response, http.StatusNotFound)
+	RequireStatus(t, response, http.StatusNotFound)
 
 	permanentReplicationConfig := db.ReplicationConfig{
 		ID:         "replication1",
@@ -320,16 +320,16 @@ func TestReplicationStatusStopAdhoc(t *testing.T) {
 	}
 
 	// PUT non-adhoc replication
-	response = rt.SendAdminRequest("PUT", "/db/_replication/replication1", marshalConfig(t, permanentReplicationConfig))
-	requireStatus(t, response, http.StatusCreated)
+	response = rt.SendAdminRequest("PUT", "/db/_replication/replication1", MarshalConfig(t, permanentReplicationConfig))
+	RequireStatus(t, response, http.StatusCreated)
 
 	// PUT adhoc replication
-	response = rt.SendAdminRequest("PUT", "/db/_replication/replication2", marshalConfig(t, adhocReplicationConfig))
-	requireStatus(t, response, http.StatusCreated)
+	response = rt.SendAdminRequest("PUT", "/db/_replication/replication2", MarshalConfig(t, adhocReplicationConfig))
+	RequireStatus(t, response, http.StatusCreated)
 
 	// GET replication status for all replications
 	response = rt.SendAdminRequest("GET", "/db/_replicationStatus/", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	var allStatusResponse []*db.ReplicationStatus
 	err := json.Unmarshal(response.BodyBytes(), &allStatusResponse)
 	require.NoError(t, err)
@@ -338,7 +338,7 @@ func TestReplicationStatusStopAdhoc(t *testing.T) {
 
 	// PUT _replicationStatus to stop non-adhoc replication
 	response = rt.SendAdminRequest("PUT", "/db/_replicationStatus/replication1?action=stop", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	var stopResponse *db.ReplicationStatus
 	err = json.Unmarshal(response.BodyBytes(), &stopResponse)
 	require.NoError(t, err)
@@ -346,7 +346,7 @@ func TestReplicationStatusStopAdhoc(t *testing.T) {
 
 	// PUT _replicationStatus to stop adhoc replication
 	response = rt.SendAdminRequest("PUT", "/db/_replicationStatus/replication2?action=stop", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	var stopAdhocResponse *db.ReplicationStatus
 	err = json.Unmarshal(response.BodyBytes(), &stopAdhocResponse)
 	require.NoError(t, err)
@@ -354,7 +354,7 @@ func TestReplicationStatusStopAdhoc(t *testing.T) {
 
 	// GET replication status for all replications
 	response = rt.SendAdminRequest("GET", "/db/_replicationStatus/", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	var updatedStatusResponse []*db.ReplicationStatus
 	err = json.Unmarshal(response.BodyBytes(), &updatedStatusResponse)
 	require.NoError(t, err)
@@ -370,7 +370,7 @@ func TestReplicationStatusAPIIncludeConfig(t *testing.T) {
 
 	// GET replication status for non-existent replication ID
 	response := rt.SendAdminRequest("GET", "/db/_replicationStatus/replication1?includeConfig=true", "")
-	requireStatus(t, response, http.StatusNotFound)
+	RequireStatus(t, response, http.StatusNotFound)
 
 	replicationConfig := db.ReplicationConfig{
 		ID:        "replication1",
@@ -379,12 +379,12 @@ func TestReplicationStatusAPIIncludeConfig(t *testing.T) {
 	}
 
 	// PUT replication1
-	response = rt.SendAdminRequest("PUT", "/db/_replication/replication1", marshalConfig(t, replicationConfig))
-	requireStatus(t, response, http.StatusCreated)
+	response = rt.SendAdminRequest("PUT", "/db/_replication/replication1", MarshalConfig(t, replicationConfig))
+	RequireStatus(t, response, http.StatusCreated)
 
 	// GET replication status for replication1
 	response = rt.SendAdminRequest("GET", "/db/_replicationStatus/replication1?includeConfig=true", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	var statusResponse db.ReplicationStatus
 	err := json.Unmarshal(response.BodyBytes(), &statusResponse)
 	require.NoError(t, err)
@@ -397,12 +397,12 @@ func TestReplicationStatusAPIIncludeConfig(t *testing.T) {
 		Remote:    "http://remote:4984/db",
 		Direction: "pull",
 	}
-	response = rt.SendAdminRequest("PUT", "/db/_replication/replication2", marshalConfig(t, replication2Config))
-	requireStatus(t, response, http.StatusCreated)
+	response = rt.SendAdminRequest("PUT", "/db/_replication/replication2", MarshalConfig(t, replication2Config))
+	RequireStatus(t, response, http.StatusCreated)
 
 	// GET replication status for all replications
 	response = rt.SendAdminRequest("GET", "/db/_replicationStatus/?includeConfig=true", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	var allStatusResponse []*db.ReplicationStatus
 	err = json.Unmarshal(response.BodyBytes(), &allStatusResponse)
 	require.NoError(t, err)
@@ -412,15 +412,15 @@ func TestReplicationStatusAPIIncludeConfig(t *testing.T) {
 
 	// PUT replication status, no action
 	response = rt.SendAdminRequest("PUT", "/db/_replicationStatus/replication1", "")
-	requireStatus(t, response, http.StatusBadRequest)
+	RequireStatus(t, response, http.StatusBadRequest)
 
 	// PUT replication status with action
 	response = rt.SendAdminRequest("PUT", "/db/_replicationStatus/replication1?action=start", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 }
 
-func marshalConfig(t *testing.T, config db.ReplicationConfig) string {
+func MarshalConfig(t *testing.T, config db.ReplicationConfig) string {
 	replicationPayload, err := json.Marshal(config)
 	require.NoError(t, err)
 	return string(replicationPayload)
@@ -497,7 +497,7 @@ func TestReplicationsFromConfig(t *testing.T) {
 
 			// Retrieve replications
 			response := rt.SendAdminRequest("GET", "/db/_replication/", "")
-			requireStatus(t, response, http.StatusOK)
+			RequireStatus(t, response, http.StatusOK)
 			var configResponse map[string]*db.ReplicationConfig
 			err := json.Unmarshal(response.BodyBytes(), &configResponse)
 			require.NoError(t, err)
@@ -530,31 +530,31 @@ func TestPushReplicationAPI(t *testing.T) {
 
 	// Create doc1 on rt1
 	docID1 := t.Name() + "rt1doc"
-	_ = rt1.putDoc(docID1, `{"source":"rt1","channels":["alice"]}`)
+	_ = rt1.PutDoc(docID1, `{"source":"rt1","channels":["alice"]}`)
 
 	// Create push replication, verify running
 	replicationID := t.Name()
 	rt1.createReplication(replicationID, remoteURLString, db.ActiveReplicatorTypePush, nil, true, db.ConflictResolverDefault)
-	rt1.waitForReplicationStatus(replicationID, db.ReplicationStateRunning)
+	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
 	// wait for document originally written to rt1 to arrive at rt2
 	changesResults := rt2.RequireWaitChanges(1, "0")
 	assert.Equal(t, docID1, changesResults.Results[0].ID)
 
 	// Validate doc1 contents on remote
-	doc1Body := rt2.getDoc(docID1)
+	doc1Body := rt2.GetDoc(docID1)
 	assert.Equal(t, "rt1", doc1Body["source"])
 
 	// Create doc2 on rt1
 	docID2 := t.Name() + "rt1doc2"
-	_ = rt2.putDoc(docID2, `{"source":"rt1","channels":["alice"]}`)
+	_ = rt2.PutDoc(docID2, `{"source":"rt1","channels":["alice"]}`)
 
 	// wait for doc2 to arrive at rt2
 	changesResults = rt2.RequireWaitChanges(1, changesResults.Last_Seq.(string))
 	assert.Equal(t, docID2, changesResults.Results[0].ID)
 
 	// Validate doc2 contents
-	doc2Body := rt2.getDoc(docID2)
+	doc2Body := rt2.GetDoc(docID2)
 	assert.Equal(t, "rt1", doc2Body["source"])
 }
 
@@ -573,31 +573,31 @@ func TestPullReplicationAPI(t *testing.T) {
 
 	// Create doc1 on rt2
 	docID1 := t.Name() + "rt2doc"
-	_ = rt2.putDoc(docID1, `{"source":"rt2","channels":["alice"]}`)
+	_ = rt2.PutDoc(docID1, `{"source":"rt2","channels":["alice"]}`)
 
 	// Create pull replication, verify running
 	replicationID := t.Name()
 	rt1.createReplication(replicationID, remoteURLString, db.ActiveReplicatorTypePull, nil, true, db.ConflictResolverDefault)
-	rt1.waitForReplicationStatus(replicationID, db.ReplicationStateRunning)
+	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
 	// wait for document originally written to rt2 to arrive at rt1
 	changesResults := rt1.RequireWaitChanges(1, "0")
 	changesResults.requireDocIDs(t, []string{docID1})
 
 	// Validate doc1 contents
-	doc1Body := rt1.getDoc(docID1)
+	doc1Body := rt1.GetDoc(docID1)
 	assert.Equal(t, "rt2", doc1Body["source"])
 
 	// Create doc2 on rt2
 	docID2 := t.Name() + "rt2doc2"
-	_ = rt2.putDoc(docID2, `{"source":"rt2","channels":["alice"]}`)
+	_ = rt2.PutDoc(docID2, `{"source":"rt2","channels":["alice"]}`)
 
 	// wait for new document to arrive at rt1
 	changesResults = rt1.RequireWaitChanges(1, changesResults.Last_Seq.(string))
 	changesResults.requireDocIDs(t, []string{docID2})
 
 	// Validate doc2 contents
-	doc2Body := rt1.getDoc(docID2)
+	doc2Body := rt1.GetDoc(docID2)
 	assert.Equal(t, "rt2", doc2Body["source"])
 }
 
@@ -615,12 +615,12 @@ func TestReplicationStatusActions(t *testing.T) {
 
 	// Create doc1 on rt2
 	docID1 := t.Name() + "rt2doc"
-	_ = rt2.putDoc(docID1, `{"source":"rt2","channels":["alice"]}`)
+	_ = rt2.PutDoc(docID1, `{"source":"rt2","channels":["alice"]}`)
 
 	// Create pull replication, verify running
 	replicationID := t.Name()
 	rt1.createReplication(replicationID, remoteURLString, db.ActiveReplicatorTypePull, nil, true, db.ConflictResolverDefault)
-	rt1.waitForReplicationStatus(replicationID, db.ReplicationStateRunning)
+	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
 	// Start goroutine to continuously poll for status of replication on rt1 to detect race conditions
 	doneChan := make(chan struct{})
@@ -643,24 +643,24 @@ func TestReplicationStatusActions(t *testing.T) {
 	changesResults.requireDocIDs(t, []string{docID1})
 
 	// Validate doc1 contents
-	doc1Body := rt1.getDoc(docID1)
+	doc1Body := rt1.GetDoc(docID1)
 	assert.Equal(t, "rt2", doc1Body["source"])
 
 	// Create doc2 on rt2
 	docID2 := t.Name() + "rt2doc2"
-	_ = rt2.putDoc(docID2, `{"source":"rt2","channels":["alice"]}`)
+	_ = rt2.PutDoc(docID2, `{"source":"rt2","channels":["alice"]}`)
 
 	// wait for new document to arrive at rt1
 	changesResults = rt1.RequireWaitChanges(1, changesResults.Last_Seq.(string))
 	changesResults.requireDocIDs(t, []string{docID2})
 
 	// Validate doc2 contents
-	doc2Body := rt1.getDoc(docID2)
+	doc2Body := rt1.GetDoc(docID2)
 	assert.Equal(t, "rt2", doc2Body["source"])
 
 	// Stop replication
 	response := rt1.SendAdminRequest("PUT", "/db/_replicationStatus/"+replicationID+"?action=stop", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	// Wait for stopped.  Non-instant as config change needs to arrive over DCP
 	stateError := rt1.WaitForCondition(func() bool {
@@ -671,7 +671,7 @@ func TestReplicationStatusActions(t *testing.T) {
 
 	// Reset replication
 	response = rt1.SendAdminRequest("PUT", "/db/_replicationStatus/"+replicationID+"?action=reset", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	resetErr := rt1.WaitForCondition(func() bool {
 		status := rt1.GetReplicationStatus(replicationID)
@@ -681,7 +681,7 @@ func TestReplicationStatusActions(t *testing.T) {
 
 	// Restart the replication
 	response = rt1.SendAdminRequest("PUT", "/db/_replicationStatus/"+replicationID+"?action=start", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	// Verify replication has restarted from zero. Since docs have already been replicated,
 	// expect no docs read, two docs checked.
@@ -724,24 +724,24 @@ func TestReplicationRebalancePull(t *testing.T) {
 	// Create docs on remote
 	docABC1 := t.Name() + "ABC1"
 	docDEF1 := t.Name() + "DEF1"
-	_ = remoteRT.putDoc(docABC1, `{"source":"remoteRT","channels":["ABC"]}`)
-	_ = remoteRT.putDoc(docDEF1, `{"source":"remoteRT","channels":["DEF"]}`)
+	_ = remoteRT.PutDoc(docABC1, `{"source":"remoteRT","channels":["ABC"]}`)
+	_ = remoteRT.PutDoc(docDEF1, `{"source":"remoteRT","channels":["DEF"]}`)
 
 	// Create pull replications, verify running
 	activeRT.createReplication("rep_ABC", remoteURLString, db.ActiveReplicatorTypePull, []string{"ABC"}, true, db.ConflictResolverDefault)
 	activeRT.createReplication("rep_DEF", remoteURLString, db.ActiveReplicatorTypePull, []string{"DEF"}, true, db.ConflictResolverDefault)
 	activeRT.waitForAssignedReplications(2)
-	activeRT.waitForReplicationStatus("rep_ABC", db.ReplicationStateRunning)
-	activeRT.waitForReplicationStatus("rep_DEF", db.ReplicationStateRunning)
+	activeRT.WaitForReplicationStatus("rep_ABC", db.ReplicationStateRunning)
+	activeRT.WaitForReplicationStatus("rep_DEF", db.ReplicationStateRunning)
 
 	// wait for documents originally written to remoteRT to arrive at activeRT
 	changesResults := activeRT.RequireWaitChanges(2, "0")
 	changesResults.requireDocIDs(t, []string{docABC1, docDEF1})
 
 	// Validate doc contents
-	docABC1Body := activeRT.getDoc(docABC1)
+	docABC1Body := activeRT.GetDoc(docABC1)
 	assert.Equal(t, "remoteRT", docABC1Body["source"])
-	docDEF1Body := activeRT.getDoc(docDEF1)
+	docDEF1Body := activeRT.GetDoc(docDEF1)
 	assert.Equal(t, "remoteRT", docDEF1Body["source"])
 
 	// Add another node to the active cluster
@@ -756,22 +756,22 @@ func TestReplicationRebalancePull(t *testing.T) {
 
 	// Create additional docs on remoteRT
 	docABC2 := t.Name() + "ABC2"
-	_ = remoteRT.putDoc(docABC2, `{"source":"remoteRT","channels":["ABC"]}`)
+	_ = remoteRT.PutDoc(docABC2, `{"source":"remoteRT","channels":["ABC"]}`)
 	docDEF2 := t.Name() + "DEF2"
-	_ = remoteRT.putDoc(docDEF2, `{"source":"remoteRT","channels":["DEF"]}`)
+	_ = remoteRT.PutDoc(docDEF2, `{"source":"remoteRT","channels":["DEF"]}`)
 
 	// wait for new documents to arrive at activeRT
 	changesResults = activeRT.RequireWaitChanges(2, changesResults.Last_Seq.(string))
 	changesResults.requireDocIDs(t, []string{docABC2, docDEF2})
 
 	// Validate doc contents
-	docABC2Body := activeRT.getDoc(docABC2)
+	docABC2Body := activeRT.GetDoc(docABC2)
 	assert.Equal(t, "remoteRT", docABC2Body["source"])
-	docDEF2Body := activeRT.getDoc(docDEF2)
+	docDEF2Body := activeRT.GetDoc(docDEF2)
 	assert.Equal(t, "remoteRT", docDEF2Body["source"])
-	docABC2Body2 := activeRT2.getDoc(docABC2)
+	docABC2Body2 := activeRT2.GetDoc(docABC2)
 	assert.Equal(t, "remoteRT", docABC2Body2["source"])
-	docDEF2Body2 := activeRT2.getDoc(docDEF2)
+	docDEF2Body2 := activeRT2.GetDoc(docDEF2)
 	assert.Equal(t, "remoteRT", docDEF2Body2["source"])
 
 	// Validate replication stats across rebalance, on both active nodes
@@ -814,23 +814,23 @@ func TestReplicationRebalancePush(t *testing.T) {
 	// Create docs on active
 	docABC1 := t.Name() + "ABC1"
 	docDEF1 := t.Name() + "DEF1"
-	_ = activeRT.putDoc(docABC1, `{"source":"activeRT","channels":["ABC"]}`)
-	_ = activeRT.putDoc(docDEF1, `{"source":"activeRT","channels":["DEF"]}`)
+	_ = activeRT.PutDoc(docABC1, `{"source":"activeRT","channels":["ABC"]}`)
+	_ = activeRT.PutDoc(docDEF1, `{"source":"activeRT","channels":["DEF"]}`)
 
 	// Create push replications, verify running
 	activeRT.createReplication("rep_ABC", remoteURLString, db.ActiveReplicatorTypePush, []string{"ABC"}, true, db.ConflictResolverDefault)
-	activeRT.waitForReplicationStatus("rep_ABC", db.ReplicationStateRunning)
+	activeRT.WaitForReplicationStatus("rep_ABC", db.ReplicationStateRunning)
 	activeRT.createReplication("rep_DEF", remoteURLString, db.ActiveReplicatorTypePush, []string{"DEF"}, true, db.ConflictResolverDefault)
-	activeRT.waitForReplicationStatus("rep_DEF", db.ReplicationStateRunning)
+	activeRT.WaitForReplicationStatus("rep_DEF", db.ReplicationStateRunning)
 
 	// wait for documents to be pushed to remote
 	changesResults := remoteRT.RequireWaitChanges(2, "0")
 	changesResults.requireDocIDs(t, []string{docABC1, docDEF1})
 
 	// Validate doc contents
-	docABC1Body := remoteRT.getDoc(docABC1)
+	docABC1Body := remoteRT.GetDoc(docABC1)
 	assert.Equal(t, "activeRT", docABC1Body["source"])
-	docDEF1Body := remoteRT.getDoc(docDEF1)
+	docDEF1Body := remoteRT.GetDoc(docDEF1)
 	assert.Equal(t, "activeRT", docDEF1Body["source"])
 
 	// Add another node to the active cluster
@@ -843,18 +843,18 @@ func TestReplicationRebalancePush(t *testing.T) {
 
 	// Create additional docs on local
 	docABC2 := t.Name() + "ABC2"
-	_ = activeRT.putDoc(docABC2, `{"source":"activeRT","channels":["ABC"]}`)
+	_ = activeRT.PutDoc(docABC2, `{"source":"activeRT","channels":["ABC"]}`)
 	docDEF2 := t.Name() + "DEF2"
-	_ = activeRT.putDoc(docDEF2, `{"source":"activeRT","channels":["DEF"]}`)
+	_ = activeRT.PutDoc(docDEF2, `{"source":"activeRT","channels":["DEF"]}`)
 
 	// wait for new documents to arrive at remote
 	changesResults = remoteRT.RequireWaitChanges(2, changesResults.Last_Seq.(string))
 	changesResults.requireDocIDs(t, []string{docABC2, docDEF2})
 
 	// Validate doc contents
-	docABC2Body := remoteRT.getDoc(docABC2)
+	docABC2Body := remoteRT.GetDoc(docABC2)
 	assert.Equal(t, "activeRT", docABC2Body["source"])
-	docDEF2Body := remoteRT.getDoc(docDEF2)
+	docDEF2Body := remoteRT.GetDoc(docDEF2)
 	assert.Equal(t, "activeRT", docDEF2Body["source"])
 
 	// Validate replication stats across rebalance, on both active nodes
@@ -899,7 +899,7 @@ func TestPullOneshotReplicationAPI(t *testing.T) {
 	docIDs := make([]string, 20)
 	for i := 0; i < 20; i++ {
 		docID := fmt.Sprintf("%s%s%d", t.Name(), "rt2doc", i)
-		_ = remoteRT.putDoc(docID, `{"source":"rt2","channels":["alice"]}`)
+		_ = remoteRT.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
 		docIDs[i] = docID
 	}
 
@@ -908,18 +908,18 @@ func TestPullOneshotReplicationAPI(t *testing.T) {
 	// Create oneshot replication, verify running
 	replicationID := t.Name()
 	activeRT.createReplication(replicationID, remoteURLString, db.ActiveReplicatorTypePull, nil, false, db.ConflictResolverDefault)
-	activeRT.waitForReplicationStatus(replicationID, db.ReplicationStateRunning)
+	activeRT.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
 	// wait for documents originally written to rt2 to arrive at rt1
 	changesResults := activeRT.RequireWaitChanges(docCount, "0")
 	changesResults.requireDocIDs(t, docIDs)
 
 	// Validate sample doc contents
-	doc1Body := activeRT.getDoc(docIDs[0])
+	doc1Body := activeRT.GetDoc(docIDs[0])
 	assert.Equal(t, "rt2", doc1Body["source"])
 
 	// Wait for replication to stop
-	activeRT.waitForReplicationStatus(replicationID, db.ReplicationStateStopped)
+	activeRT.WaitForReplicationStatus(replicationID, db.ReplicationStateStopped)
 
 	// Validate docs read from active
 	status := activeRT.GetReplicationStatus(replicationID)
@@ -961,15 +961,15 @@ func TestReplicationConcurrentPush(t *testing.T) {
 	defer teardown()
 	// Create push replications, verify running
 	activeRT.createReplication("rep_ABC", remoteURLString, db.ActiveReplicatorTypePush, []string{"ABC"}, true, db.ConflictResolverDefault)
-	activeRT.waitForReplicationStatus("rep_ABC", db.ReplicationStateRunning)
+	activeRT.WaitForReplicationStatus("rep_ABC", db.ReplicationStateRunning)
 	activeRT.createReplication("rep_DEF", remoteURLString, db.ActiveReplicatorTypePush, []string{"DEF"}, true, db.ConflictResolverDefault)
-	activeRT.waitForReplicationStatus("rep_DEF", db.ReplicationStateRunning)
+	activeRT.WaitForReplicationStatus("rep_DEF", db.ReplicationStateRunning)
 
 	// Create docs on active
 	docAllChannels1 := t.Name() + "All1"
 	docAllChannels2 := t.Name() + "All2"
-	_ = activeRT.putDoc(docAllChannels1, `{"source":"activeRT1","channels":["ABC","DEF"]}`)
-	_ = activeRT.putDoc(docAllChannels2, `{"source":"activeRT2","channels":["ABC","DEF"]}`)
+	_ = activeRT.PutDoc(docAllChannels1, `{"source":"activeRT1","channels":["ABC","DEF"]}`)
+	_ = activeRT.PutDoc(docAllChannels2, `{"source":"activeRT2","channels":["ABC","DEF"]}`)
 
 	// wait for documents to be pushed to remote
 	changesResults := remoteRT.RequireWaitChanges(2, "0")
@@ -1003,9 +1003,9 @@ func TestReplicationConcurrentPush(t *testing.T) {
 	}))
 
 	// Validate doc contents
-	docAll1Body := remoteRT.getDoc(docAllChannels1)
+	docAll1Body := remoteRT.GetDoc(docAllChannels1)
 	assert.Equal(t, "activeRT1", docAll1Body["source"])
-	docAll2Body := remoteRT.getDoc(docAllChannels2)
+	docAll2Body := remoteRT.GetDoc(docAllChannels2)
 	assert.Equal(t, "activeRT2", docAll2Body["source"])
 
 }
@@ -1026,7 +1026,7 @@ func setupSGRPeers(t *testing.T) (activeRT *RestTester, passiveRT *RestTester, r
 	// Set up passive RestTester (rt2)
 	passiveTestBucket := base.GetTestBucket(t)
 	passiveRT = NewRestTester(t, &RestTesterConfig{
-		TestBucket: passiveTestBucket.NoCloseClone(),
+		CustomTestBucket: passiveTestBucket.NoCloseClone(),
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
@@ -1049,8 +1049,8 @@ func setupSGRPeers(t *testing.T) (activeRT *RestTester, passiveRT *RestTester, r
 	// Set up active RestTester (rt1)
 	activeTestBucket := base.GetTestBucket(t)
 	activeRT = NewRestTester(t, &RestTesterConfig{
-		TestBucket:         activeTestBucket.NoCloseClone(),
-		sgReplicateEnabled: true,
+		CustomTestBucket:   activeTestBucket.NoCloseClone(),
+		SgReplicateEnabled: true,
 	})
 	// Initalize RT and bucket
 	_ = activeRT.Bucket()
@@ -1070,8 +1070,8 @@ func addActiveRT(t *testing.T, testBucket *base.TestBucket) (activeRT *RestTeste
 
 	// Create a new rest tester, using a NoCloseClone of testBucket, which disables the TestBucketPool teardown
 	activeRT = NewRestTester(t, &RestTesterConfig{
-		TestBucket:         testBucket.NoCloseClone(),
-		sgReplicateEnabled: true,
+		CustomTestBucket:   testBucket.NoCloseClone(),
+		SgReplicateEnabled: true,
 	})
 
 	// If this is a walrus bucket, we need to jump through some hoops to ensure the shared in-memory walrus bucket isn't
@@ -1107,7 +1107,7 @@ func (rt *RestTester) createReplication(replicationID string, remoteURLString st
 	payload, err := json.Marshal(replicationConfig)
 	require.NoError(rt.tb, err)
 	resp := rt.SendAdminRequest(http.MethodPost, "/db/_replication/", string(payload))
-	requireStatus(rt.tb, resp, http.StatusCreated)
+	RequireStatus(rt.tb, resp, http.StatusCreated)
 }
 
 func (rt *RestTester) waitForAssignedReplications(count int) {
@@ -1118,7 +1118,7 @@ func (rt *RestTester) waitForAssignedReplications(count int) {
 	require.NoError(rt.tb, rt.WaitForCondition(successFunc))
 }
 
-func (rt *RestTester) waitForReplicationStatus(replicationID string, targetStatus string) {
+func (rt *RestTester) WaitForReplicationStatus(replicationID string, targetStatus string) {
 	successFunc := func() bool {
 		status := rt.GetReplicationStatus(replicationID)
 		return status.Status == targetStatus
@@ -1128,21 +1128,21 @@ func (rt *RestTester) waitForReplicationStatus(replicationID string, targetStatu
 
 func (rt *RestTester) GetReplications() (replications map[string]db.ReplicationCfg) {
 	rawResponse := rt.SendAdminRequest("GET", "/db/_replication/", "")
-	requireStatus(rt.tb, rawResponse, 200)
+	RequireStatus(rt.tb, rawResponse, 200)
 	require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &replications))
 	return replications
 }
 
 func (rt *RestTester) GetReplicationStatus(replicationID string) (status db.ReplicationStatus) {
 	rawResponse := rt.SendAdminRequest("GET", "/db/_replicationStatus/"+replicationID, "")
-	requireStatus(rt.tb, rawResponse, 200)
+	RequireStatus(rt.tb, rawResponse, 200)
 	require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &status))
 	return status
 }
 
 func (rt *RestTester) GetReplicationStatuses(queryString string) (statuses []db.ReplicationStatus) {
 	rawResponse := rt.SendAdminRequest("GET", "/db/_replicationStatus/"+queryString, "")
-	requireStatus(rt.tb, rawResponse, 200)
+	RequireStatus(rt.tb, rawResponse, 200)
 	require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &statuses))
 	return statuses
 }
@@ -1160,12 +1160,12 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 		Direction:      db.ActiveReplicatorTypePull,
 		Adhoc:          true,
 	}
-	response := rt.SendAdminRequest(http.MethodPut, "/db/_replication/replication1", marshalConfig(t, replication1Config))
-	requireStatus(t, response, http.StatusCreated)
+	response := rt.SendAdminRequest(http.MethodPut, "/db/_replication/replication1", MarshalConfig(t, replication1Config))
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Check whether auth are credentials redacted from replication response
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_replication/replication1", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	var configResponse db.ReplicationConfig
 	err := json.Unmarshal(response.BodyBytes(), &configResponse)
 	require.NoError(t, err, "Error un-marshalling replication response")
@@ -1190,12 +1190,12 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 		Direction: db.ActiveReplicatorTypePull,
 		Adhoc:     true,
 	}
-	response = rt.SendAdminRequest(http.MethodPost, "/db/_replication/", marshalConfig(t, replication2Config))
-	requireStatus(t, response, http.StatusCreated)
+	response = rt.SendAdminRequest(http.MethodPost, "/db/_replication/", MarshalConfig(t, replication2Config))
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Check whether auth are credentials redacted from replication response
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_replication/replication2", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	configResponse = db.ReplicationConfig{}
 	err = json.Unmarshal(response.BodyBytes(), &configResponse)
 	require.NoError(t, err, "Error un-marshalling replication response")
@@ -1203,7 +1203,7 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 
 	// Check whether auth are credentials redacted from all replications response
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_replication/", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	log.Printf("response: %s", response.BodyBytes())
 
 	var replicationsResponse map[string]db.ReplicationConfig
@@ -1221,7 +1221,7 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 
 	// Check whether auth are credentials redacted replication status for all replications
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_replicationStatus/?includeConfig=true", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	var allStatusResponse []*db.ReplicationStatus
 	require.NoError(t, json.Unmarshal(response.BodyBytes(), &allStatusResponse))
 	require.Equal(t, 2, len(allStatusResponse), "Replication count mismatch")
@@ -1235,15 +1235,15 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 
 	// Delete both replications
 	response = rt.SendAdminRequest(http.MethodDelete, "/db/_replication/replication1", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	response = rt.SendAdminRequest(http.MethodDelete, "/db/_replication/replication2", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	// Verify deletes were successful
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_replication/replication1", "")
-	requireStatus(t, response, http.StatusNotFound)
+	RequireStatus(t, response, http.StatusNotFound)
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_replication/replication2", "")
-	requireStatus(t, response, http.StatusNotFound)
+	RequireStatus(t, response, http.StatusNotFound)
 }
 
 func TestValidateReplication(t *testing.T) {
@@ -1439,8 +1439,8 @@ func TestGetStatusWithReplication(t *testing.T) {
 		Direction:      db.ActiveReplicatorTypePull,
 		Adhoc:          true,
 	}
-	response := rt.SendAdminRequest(http.MethodPut, "/db/_replication/replication1", marshalConfig(t, config1))
-	requireStatus(t, response, http.StatusCreated)
+	response := rt.SendAdminRequest(http.MethodPut, "/db/_replication/replication1", MarshalConfig(t, config1))
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Create another replication
 	config2 := db.ReplicationConfig{
@@ -1449,12 +1449,12 @@ func TestGetStatusWithReplication(t *testing.T) {
 		Direction: db.ActiveReplicatorTypePull,
 		Adhoc:     true,
 	}
-	response = rt.SendAdminRequest(http.MethodPut, "/db/_replication/replication2", marshalConfig(t, config2))
-	requireStatus(t, response, http.StatusCreated)
+	response = rt.SendAdminRequest(http.MethodPut, "/db/_replication/replication2", MarshalConfig(t, config2))
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Check _status response
 	response = rt.SendAdminRequest(http.MethodGet, "/_status", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	var status Status
 	err := json.Unmarshal(response.BodyBytes(), &status)
 	require.NoError(t, err, "Error un-marshalling replication response")
@@ -1495,15 +1495,15 @@ func TestGetStatusWithReplication(t *testing.T) {
 
 	// Delete both replications
 	response = rt.SendAdminRequest(http.MethodDelete, "/db/_replication/replication1", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	response = rt.SendAdminRequest(http.MethodDelete, "/db/_replication/replication2", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	// Verify deletes were successful
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_replication/replication1", "")
-	requireStatus(t, response, http.StatusNotFound)
+	RequireStatus(t, response, http.StatusNotFound)
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_replication/replication2", "")
-	requireStatus(t, response, http.StatusNotFound)
+	RequireStatus(t, response, http.StatusNotFound)
 
 	// Check _cluster response after replications are removed
 	status = Status{}
@@ -1531,10 +1531,10 @@ func TestRequireReplicatorStoppedBeforeUpsert(t *testing.T) {
 	}`
 
 	response := rt.SendAdminRequest("PUT", "/db/_replication/replication1", string(replicationConfig))
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	response = rt.SendAdminRequest("GET", "/db/_replicationStatus/", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	var body []map[string]interface{}
 	err := base.JSONUnmarshal(response.BodyBytes(), &body)
@@ -1551,13 +1551,13 @@ func TestRequireReplicatorStoppedBeforeUpsert(t *testing.T) {
 	}`
 
 	response = rt.SendAdminRequest("PUT", "/db/_replication/replication1", string(replicationConfigUpdate))
-	requireStatus(t, response, http.StatusBadRequest)
+	RequireStatus(t, response, http.StatusBadRequest)
 
 	response = rt.SendAdminRequest("PUT", "/db/_replicationStatus/replication1?action=stop", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	response = rt.SendAdminRequest("PUT", "/db/_replication/replication1", string(replicationConfigUpdate))
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 }
 
@@ -1587,7 +1587,7 @@ func TestReplicationConfigChange(t *testing.T) {
 	}
 	`
 	resp := rt1.SendAdminRequest("POST", "/db/_bulk_docs", bulkDocs)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	replicationID := "testRepl"
 
@@ -1605,17 +1605,17 @@ func TestReplicationConfigChange(t *testing.T) {
 
 	// Create replication for first channel
 	resp = rt1.SendAdminRequest("PUT", "/db/_replication/"+replicationID, replConf)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
-	rt1.waitForReplicationStatus(replicationID, db.ReplicationStateRunning)
+	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
-	changesResults, err := rt2.waitForChanges(4, "/db/_changes?since=0", "", true)
+	changesResults, err := rt2.WaitForChanges(4, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 4)
 
 	resp = rt1.SendAdminRequest("PUT", "/db/_replicationStatus/"+replicationID+"?action=stop", "")
-	requireStatus(t, resp, http.StatusOK)
-	rt1.waitForReplicationStatus(replicationID, db.ReplicationStateStopped)
+	RequireStatus(t, resp, http.StatusOK)
+	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateStopped)
 
 	// Upsert replication to use second channel
 	replConfUpdate := `
@@ -1627,13 +1627,13 @@ func TestReplicationConfigChange(t *testing.T) {
 			}`
 
 	resp = rt1.SendAdminRequest("PUT", "/db/_replication/"+replicationID, replConfUpdate)
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	resp = rt1.SendAdminRequest("PUT", "/db/_replicationStatus/"+replicationID+"?action=start", "")
-	requireStatus(t, resp, http.StatusOK)
-	rt1.waitForReplicationStatus(replicationID, db.ReplicationStateRunning)
+	RequireStatus(t, resp, http.StatusOK)
+	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
-	changesResults, err = rt2.waitForChanges(8, "/db/_changes?since=0", "", true)
+	changesResults, err = rt2.WaitForChanges(8, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 8)
 }
@@ -1675,23 +1675,23 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 	// Create docs on remote
 	docABC1 := t.Name() + "ABC1"
 	docDEF1 := t.Name() + "DEF1"
-	_ = remoteRT.putDoc(docABC1, `{"source":"remoteRT","channels":["ABC"]}`)
-	_ = remoteRT.putDoc(docDEF1, `{"source":"remoteRT","channels":["DEF"]}`)
+	_ = remoteRT.PutDoc(docABC1, `{"source":"remoteRT","channels":["ABC"]}`)
+	_ = remoteRT.PutDoc(docDEF1, `{"source":"remoteRT","channels":["DEF"]}`)
 
 	// Create pull replications, verify running
 	activeRT.createReplication("rep_ABC", remoteURLString, db.ActiveReplicatorTypePull, []string{"ABC"}, true, db.ConflictResolverDefault)
 	activeRT.createReplication("rep_DEF", remoteURLString, db.ActiveReplicatorTypePull, []string{"DEF"}, true, db.ConflictResolverDefault)
 	activeRT.waitForAssignedReplications(2)
-	activeRT.waitForReplicationStatus("rep_ABC", db.ReplicationStateRunning)
-	activeRT.waitForReplicationStatus("rep_DEF", db.ReplicationStateRunning)
+	activeRT.WaitForReplicationStatus("rep_ABC", db.ReplicationStateRunning)
+	activeRT.WaitForReplicationStatus("rep_DEF", db.ReplicationStateRunning)
 
 	// wait for documents originally written to remoteRT to arrive at activeRT
 	changesResults := activeRT.RequireWaitChanges(2, "0")
 	changesResults.requireDocIDs(t, []string{docABC1, docDEF1})
 
 	// Validate doc replication
-	_ = activeRT.getDoc(docABC1)
-	_ = activeRT.getDoc(docDEF1)
+	_ = activeRT.GetDoc(docABC1)
+	_ = activeRT.GetDoc(docDEF1)
 
 	// Add another node to the active cluster
 	activeRT2 := addActiveRT(t, activeRT.TestBucket)
@@ -1703,19 +1703,19 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 
 	// Create additional docs on remoteRT
 	docABC2 := t.Name() + "ABC2"
-	_ = remoteRT.putDoc(docABC2, `{"source":"remoteRT","channels":["ABC"]}`)
+	_ = remoteRT.PutDoc(docABC2, `{"source":"remoteRT","channels":["ABC"]}`)
 	docDEF2 := t.Name() + "DEF2"
-	_ = remoteRT.putDoc(docDEF2, `{"source":"remoteRT","channels":["DEF"]}`)
+	_ = remoteRT.PutDoc(docDEF2, `{"source":"remoteRT","channels":["DEF"]}`)
 
 	// wait for new documents to arrive at activeRT
 	changesResults = activeRT.RequireWaitChanges(2, changesResults.Last_Seq.(string))
 	changesResults.requireDocIDs(t, []string{docABC2, docDEF2})
 
 	// Validate doc contents via both active nodes
-	_ = activeRT.getDoc(docABC2)
-	_ = activeRT.getDoc(docDEF2)
-	_ = activeRT2.getDoc(docABC2)
-	_ = activeRT2.getDoc(docDEF2)
+	_ = activeRT.GetDoc(docABC2)
+	_ = activeRT.GetDoc(docDEF2)
+	_ = activeRT2.GetDoc(docABC2)
+	_ = activeRT2.GetDoc(docDEF2)
 
 	activeRTUUID := activeRT.GetDatabase().UUID
 	activeRT2UUID := activeRT2.GetDatabase().UUID
@@ -1742,9 +1742,9 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 
 	// Add more docs to remote, to validate rebalanced replications are running
 	docABC3 := t.Name() + "ABC3"
-	_ = remoteRT.putDoc(docABC3, `{"source":"remoteRT","channels":["ABC"]}`)
+	_ = remoteRT.PutDoc(docABC3, `{"source":"remoteRT","channels":["ABC"]}`)
 	docDEF3 := t.Name() + "DEF3"
-	_ = remoteRT.putDoc(docDEF3, `{"source":"remoteRT","channels":["DEF"]}`)
+	_ = remoteRT.PutDoc(docDEF3, `{"source":"remoteRT","channels":["DEF"]}`)
 
 	changesResults = activeRT.RequireWaitChanges(2, changesResults.Last_Seq.(string))
 	changesResults.requireDocIDs(t, []string{docABC3, docDEF3})
@@ -1771,7 +1771,7 @@ func TestDBReplicationStatsTeardown(t *testing.T) {
 	defer tb.Close()
 	rt := NewRestTester(t, &RestTesterConfig{
 		persistentConfig: true,
-		TestBucket:       tb,
+		CustomTestBucket: tb,
 	})
 	defer rt.Close()
 
@@ -1785,7 +1785,7 @@ func TestDBReplicationStatsTeardown(t *testing.T) {
 				"use_views": %t,
 				"num_index_replicas": 0
 	}`, tb.GetName(), base.TestsDisableGSI()))
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	tb2 := base.GetTestBucket(t)
 	defer tb2.Close()
@@ -1794,14 +1794,14 @@ func TestDBReplicationStatsTeardown(t *testing.T) {
 				"use_views": %t,
 				"num_index_replicas": 0
 	}`, tb2.GetName(), base.TestsDisableGSI()))
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	rt.createReplication("repl1", db2Url.String(), db.ActiveReplicatorTypePull, nil, true, db.ConflictResolverDefault)
-	rt.waitForReplicationStatus("repl1", db.ReplicationStateRunning)
+	rt.WaitForReplicationStatus("repl1", db.ReplicationStateRunning)
 
 	// Force DB reload by modifying config
 	resp = rt.SendAdminRequest(http.MethodPost, "/db/_config", `{"import_docs": false}`)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
-	rt.waitForReplicationStatus("repl1", db.ReplicationStateRunning)
+	rt.WaitForReplicationStatus("repl1", db.ReplicationStateRunning)
 }

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -104,7 +104,7 @@ func NewRestTesterCluster(t *testing.T, config *RestTesterClusterConfig) *RestTe
 	if tb == nil {
 		tb = base.GetTestBucket(t)
 	}
-	config.rtConfig.TestBucket = tb.NoCloseClone()
+	config.rtConfig.CustomTestBucket = tb.NoCloseClone()
 
 	// Start up all rest testers in parallel
 	wg := sync.WaitGroup{}
@@ -155,14 +155,14 @@ func TestPersistentDbConfigWithInvalidUpsert(t *testing.T) {
 	// Create database on a random node.
 	resp, err := rtc.RoundRobin().CreateDatabase(db, dbConfig)
 	require.NoError(t, err)
-	requireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, resp, http.StatusCreated)
 
 	// A duplicate create shouldn't work, even if this were a node that doesn't have the database loaded yet.
 	// But this _will_ trigger an on-demand load on this node. So now we have 2 nodes running the database.
 	resp, err = rtc.RoundRobin().CreateDatabase(db, dbConfig)
 	require.NoError(t, err)
 	// CouchDB returns this status and body in this scenario
-	requireStatus(t, resp, http.StatusPreconditionFailed)
+	RequireStatus(t, resp, http.StatusPreconditionFailed)
 	assert.Contains(t, string(resp.BodyBytes()), "Duplicate database name")
 
 	// The remaining nodes will get the config via polling.
@@ -173,7 +173,7 @@ func TestPersistentDbConfigWithInvalidUpsert(t *testing.T) {
 	// Sanity-check they have all loaded after the forced update.
 	rtc.ForEachNode(func(rt *RestTester) {
 		resp := rt.SendAdminRequest(http.MethodGet, "/"+db+"/", "")
-		requireStatus(t, resp, http.StatusOK)
+		RequireStatus(t, resp, http.StatusOK)
 	})
 
 	// Now we'll attempt to write an invalid database to a single node.
@@ -183,15 +183,15 @@ func TestPersistentDbConfigWithInvalidUpsert(t *testing.T) {
 	// upsert with an invalid config option
 	resp, err = rtNode.UpsertDbConfig(db, DbConfig{RevsLimit: base.Uint32Ptr(0)})
 	require.NoError(t, err)
-	requireStatus(t, resp, http.StatusBadRequest)
+	RequireStatus(t, resp, http.StatusBadRequest)
 
 	// On the same node, make sure the database is still running.
 	resp = rtNode.SendAdminRequest(http.MethodGet, "/"+db+"/", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	// and make sure we roll back the database to the previous version (without revs_limit set)
 	resp = rtNode.SendAdminRequest(http.MethodGet, "/"+db+"/_config", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 	assert.NotContains(t, string(resp.BodyBytes()), `"revs_limit":`)
 
 	// remove the db config directly from the bucket
@@ -205,7 +205,7 @@ func TestPersistentDbConfigWithInvalidUpsert(t *testing.T) {
 	assert.Equal(t, 0, count)
 	rtc.ForEachNode(func(rt *RestTester) {
 		resp := rt.SendAdminRequest(http.MethodGet, "/"+db+"/", "")
-		requireStatus(t, resp, http.StatusNotFound)
+		RequireStatus(t, resp, http.StatusNotFound)
 	})
 
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -786,7 +786,7 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 	}
 
 	groupID := ""
-	if sc.config.Bootstrap.ConfigGroupID != persistentConfigDefaultGroupID {
+	if sc.config.Bootstrap.ConfigGroupID != PersistentConfigDefaultGroupID {
 		groupID = sc.config.Bootstrap.ConfigGroupID
 	}
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -357,7 +357,7 @@ func TestStartAndStopHTTPServers(t *testing.T) {
 	config.Bootstrap.Password = base.TestClusterPassword()
 
 	ctx := base.TestCtx(t)
-	sc, err := setupServerContext(ctx, &config, false)
+	sc, err := SetupServerContext(ctx, &config, false)
 	require.NoError(t, err)
 
 	serveErr := make(chan error, 0)
@@ -432,7 +432,7 @@ func TestTLSSkipVerifyCombinations(t *testing.T) {
 				},
 			}
 
-			err := startupConfig.validate(base.IsEnterpriseEdition())
+			err := startupConfig.Validate(base.IsEnterpriseEdition())
 			if test.expectError {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), errorText)
@@ -556,7 +556,7 @@ func TestUseTLSServer(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			sc := StartupConfig{Bootstrap: BootstrapConfig{Server: test.server, UseTLSServer: &test.useTLSServer}}
 
-			err := sc.validate(base.IsEnterpriseEdition())
+			err := sc.Validate(base.IsEnterpriseEdition())
 
 			if test.expectedError != nil {
 				require.Error(t, err)

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -34,7 +34,7 @@ func TestUsersAPI(t *testing.T) {
 	// Validate the zero user case
 	var responseUsers []string
 	response := rt.SendAdminRequest("GET", "/db/_user/", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	err := json.Unmarshal(response.Body.Bytes(), &responseUsers)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(responseUsers))
@@ -43,11 +43,11 @@ func TestUsersAPI(t *testing.T) {
 	for i := 1; i < 13; i++ {
 		userName := fmt.Sprintf("user%d", i)
 		response := rt.SendAdminRequest("PUT", "/db/_user/"+userName, `{"password":"letmein", "admin_channels":["foo", "bar"]}`)
-		requireStatus(t, response, 201)
+		RequireStatus(t, response, 201)
 
 		// check user count
 		response = rt.SendAdminRequest("GET", "/db/_user/", "")
-		requireStatus(t, response, 200)
+		RequireStatus(t, response, 200)
 		err := json.Unmarshal(response.Body.Bytes(), &responseUsers)
 		assert.NoError(t, err)
 		assert.Equal(t, i, len(responseUsers))
@@ -86,7 +86,7 @@ func TestUsersAPIDetailsViews(t *testing.T) {
 
 	// Validate error handling
 	response := rt.SendAdminRequest("GET", fmt.Sprintf("/db/_user/?%s=false", paramNameOnly), "")
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 }
 
@@ -131,7 +131,7 @@ func TestUsersAPIDetailsWithoutGuest(t *testing.T) {
 				QueryPaginationLimit: base.IntPtr(5),
 			},
 		},
-		guestEnabled: false,
+		GuestEnabled: false,
 	}
 	rt := NewRestTester(t, rtConfig)
 	defer rt.Close()
@@ -146,7 +146,7 @@ func validateUsersNameOnlyFalse(t *testing.T, rt *RestTester) {
 	// Validate the zero user case
 	var responseUsers []auth.PrincipalConfig
 	response := rt.SendAdminRequest("GET", "/db/_user/?"+paramNameOnly+"=false", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	err := json.Unmarshal(response.Body.Bytes(), &responseUsers)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(responseUsers))
@@ -165,11 +165,11 @@ func validateUsersNameOnlyFalse(t *testing.T, rt *RestTester) {
 		} else {
 			response = rt.SendAdminRequest("PUT", "/db/_user/"+userName, `{"password":"letmein", "email": "`+userName+`@foo.com", "disabled":`+disabled+`, "admin_channels":["foo", "bar"]}`)
 		}
-		requireStatus(t, response, 201)
+		RequireStatus(t, response, 201)
 
 		// check user count
 		response = rt.SendAdminRequest("GET", "/db/_user/?"+paramNameOnly+"=false", "")
-		requireStatus(t, response, 200)
+		RequireStatus(t, response, 200)
 		err := json.Unmarshal(response.Body.Bytes(), &responseUsers)
 		assert.NoError(t, err)
 		assert.Equal(t, i, len(responseUsers))
@@ -219,7 +219,7 @@ func TestUsersAPIDetailsWithLimit(t *testing.T) {
 	// Validate the zero user case with limit
 	var responseUsers []auth.PrincipalConfig
 	response := rt.SendAdminRequest("GET", "/db/_user/?"+paramNameOnly+"=false&"+paramLimit+"=10", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	err := json.Unmarshal(response.Body.Bytes(), &responseUsers)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(responseUsers))
@@ -229,12 +229,12 @@ func TestUsersAPIDetailsWithLimit(t *testing.T) {
 	for i := 1; i <= numUsers; i++ {
 		userName := fmt.Sprintf("user%d", i)
 		response := rt.SendAdminRequest("PUT", "/db/_user/"+userName, `{"password":"letmein", "admin_channels":["foo", "bar"]}`)
-		requireStatus(t, response, 201)
+		RequireStatus(t, response, 201)
 	}
 
 	// limit without name_only=false should return Bad Request
 	response = rt.SendAdminRequest("GET", "/db/_user/?"+paramLimit+"=10", "")
-	requireStatus(t, response, 400)
+	RequireStatus(t, response, 400)
 
 	testCases := []struct {
 		name          string
@@ -280,7 +280,7 @@ func TestUsersAPIDetailsWithLimit(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			response = rt.SendAdminRequest("GET", "/db/_user/?"+paramNameOnly+"=false&"+paramLimit+"="+testCase.limit, "")
-			requireStatus(t, response, 200)
+			RequireStatus(t, response, 200)
 			err = json.Unmarshal(response.Body.Bytes(), &responseUsers)
 			assert.NoError(t, err)
 			assert.Equal(t, testCase.expectedCount, len(responseUsers))
@@ -304,13 +304,13 @@ func TestUserAPI(t *testing.T) {
 	defer rt.Close()
 	ctx := rt.Context()
 
-	requireStatus(t, rt.SendAdminRequest("GET", "/db/_user/snej", ""), 404)
+	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/snej", ""), 404)
 	response := rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"letmein", "admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// GET the user and make sure the result is OK
 	response = rt.SendAdminRequest("GET", "/db/_user/snej", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, "snej", body["name"])
@@ -321,7 +321,7 @@ func TestUserAPI(t *testing.T) {
 
 	// Check the list of all users:
 	response = rt.SendAdminRequest("GET", "/db/_user/", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	assert.Equal(t, `["snej"]`, string(response.Body.Bytes()))
 
 	// Check that the actual User object is correct:
@@ -333,76 +333,76 @@ func TestUserAPI(t *testing.T) {
 
 	// Change the password and verify it:
 	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"123", "admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	user, _ = rt.ServerContext().Database(ctx, "db").Authenticator(ctx).GetUser("snej")
 	assert.True(t, user.Authenticate("123"))
 
 	// DELETE the user
-	requireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/snej", ""), 200)
-	requireStatus(t, rt.SendAdminRequest("GET", "/db/_user/snej", ""), 404)
+	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/snej", ""), 200)
+	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/snej", ""), 404)
 
 	// POST a user
 	response = rt.SendAdminRequest("POST", "/db/_user", `{"name":"snej", "password":"letmein", "admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 301)
+	RequireStatus(t, response, 301)
 	rt.Bucket().Dump()
 
 	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"snej", "password":"letmein", "admin_channels":["foo", "bar"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/_user/snej", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	body = nil
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, "snej", body["name"])
 
 	// Create a role
-	requireStatus(t, rt.SendAdminRequest("GET", "/db/_role/hipster", ""), 404)
+	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_role/hipster", ""), 404)
 	response = rt.SendAdminRequest("PUT", "/db/_role/hipster", `{"admin_channels":["fedoras", "fixies"]}`)
-	requireStatus(t, response, 201)
+	RequireStatus(t, response, 201)
 
 	// Give the user that role
 	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"admin_channels":["foo", "bar"],"admin_roles":["hipster"]}`)
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 
 	// GET the user and verify that it shows the channels inherited from the role
 	response = rt.SendAdminRequest("GET", "/db/_user/snej", "")
-	requireStatus(t, response, 200)
+	RequireStatus(t, response, 200)
 	body = nil
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, []interface{}{"hipster"}, body["admin_roles"])
 	assert.Equal(t, []interface{}{"!", "bar", "fedoras", "fixies", "foo"}, body["all_channels"])
 
 	// DELETE the user
-	requireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/snej", ""), 200)
+	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/snej", ""), 200)
 
 	// POST a user with URL encoded '|' in name see #2870
-	requireStatus(t, rt.SendAdminRequest("POST", "/db/_user/", `{"name":"0%7C59", "password":"letmein", "admin_channels":["foo", "bar"]}`), 201)
+	RequireStatus(t, rt.SendAdminRequest("POST", "/db/_user/", `{"name":"0%7C59", "password":"letmein", "admin_channels":["foo", "bar"]}`), 201)
 
 	// GET the user, will fail
-	requireStatus(t, rt.SendAdminRequest("GET", "/db/_user/0%7C59", ""), 404)
+	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/0%7C59", ""), 404)
 
 	// DELETE the user, will fail
-	requireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/0%7C59", ""), 404)
+	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/0%7C59", ""), 404)
 
 	// GET the user, double escape username, will succeed
-	requireStatus(t, rt.SendAdminRequest("GET", "/db/_user/0%257C59", ""), 200)
+	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/0%257C59", ""), 200)
 
 	// DELETE the user, double escape username, will succeed
-	requireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/0%257C59", ""), 200)
+	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/0%257C59", ""), 200)
 
 	// POST a user with URL encoded '|' and non-encoded @ in name see #2870
-	requireStatus(t, rt.SendAdminRequest("POST", "/db/_user/", `{"name":"0%7C@59", "password":"letmein", "admin_channels":["foo", "bar"]}`), 201)
+	RequireStatus(t, rt.SendAdminRequest("POST", "/db/_user/", `{"name":"0%7C@59", "password":"letmein", "admin_channels":["foo", "bar"]}`), 201)
 
 	// GET the user, will fail
-	requireStatus(t, rt.SendAdminRequest("GET", "/db/_user/0%7C@59", ""), 404)
+	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/0%7C@59", ""), 404)
 
 	// DELETE the user, will fail
-	requireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/0%7C@59", ""), 404)
+	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/0%7C@59", ""), 404)
 
 	// GET the user, double escape username, will succeed
-	requireStatus(t, rt.SendAdminRequest("GET", "/db/_user/0%257C%4059", ""), 200)
+	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/0%257C%4059", ""), 200)
 
 	// DELETE the user, double escape username, will succeed
-	requireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/0%257C%4059", ""), 200)
+	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/0%257C%4059", ""), 200)
 
 }

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -22,38 +22,38 @@ import (
 )
 
 func TestDesignDocs(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	response := rt.SendRequest(http.MethodGet, "/db/_design/foo", "")
-	requireStatus(t, response, http.StatusForbidden)
+	RequireStatus(t, response, http.StatusForbidden)
 	response = rt.SendRequest(http.MethodPut, "/db/_design/foo", `{}`)
-	requireStatus(t, response, http.StatusForbidden)
+	RequireStatus(t, response, http.StatusForbidden)
 	response = rt.SendRequest(http.MethodDelete, "/db/_design/foo", "")
-	requireStatus(t, response, http.StatusForbidden)
+	RequireStatus(t, response, http.StatusForbidden)
 
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_design/foo", "")
-	requireStatus(t, response, http.StatusNotFound)
+	RequireStatus(t, response, http.StatusNotFound)
 	response = rt.SendAdminRequest(http.MethodPut, "/db/_design/foo", `{}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_design/foo", "")
 
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_design%2ffoo", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_design%2Ffoo", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	response = rt.SendAdminRequest(http.MethodDelete, "/db/_design/foo", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	response = rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/db/_design/%s", db.DesignDocSyncGateway()), "{}")
-	requireStatus(t, response, http.StatusForbidden)
+	RequireStatus(t, response, http.StatusForbidden)
 	response = rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/db/_design/%s", db.DesignDocSyncGateway()), "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 }
 
 func TestViewQuery(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	if !base.TestsDisableGSI() {
@@ -61,11 +61,11 @@ func TestViewQuery(t *testing.T) {
 	}
 
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_design/foo", `{"views":{"bar": {"map": "function(doc) {emit(doc.key, doc.value);}"}}}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	response = rt.SendRequest(http.MethodPut, "/db/doc1", `{"key":10, "value":"ten"}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	response = rt.SendRequest(http.MethodPut, "/db/doc2", `{"key":7, "value":"seven"}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	// The wait is needed here because the query does not have stale=false.
 	// TODO: update the query to use stale=false and remove the wait
@@ -100,16 +100,16 @@ func TestViewQueryMultipleViews(t *testing.T) {
 		t.Skip("views tests are not applicable under GSI")
 	}
 
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	// Define three views
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_design/foo", `{"views": {"by_fname": {"map": "function (doc, meta) { emit(doc.fname, null); }"},"by_lname": {"map": "function (doc, meta) { emit(doc.lname, null); }"},"by_age": {"map": "function (doc, meta) { emit(doc.age, null); }"}}}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	response = rt.SendRequest(http.MethodPut, "/db/doc1", `{"fname": "Alice", "lname":"Ten", "age":10}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	response = rt.SendRequest(http.MethodPut, "/db/doc2", `{"fname": "Bob", "lname":"Seven", "age":7}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	result, err := rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/by_age")
 	assert.NoError(t, err, "Unexpected error")
@@ -133,15 +133,15 @@ func TestViewQueryWithParams(t *testing.T) {
 		t.Skip("views tests are not applicable under GSI")
 	}
 
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_design/foodoc", `{"views": {"foobarview": {"map": "function(doc, meta) {if (doc.value == \"foo\") {emit(doc.key, null);}}"}}}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	response = rt.SendRequest(http.MethodPut, "/db/doc1", `{"value": "foo", "key": "test1"}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	response = rt.SendRequest(http.MethodPut, "/db/doc2", `{"value": "foo", "key": "test2"}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	result, err := rt.WaitForNAdminViewResults(2, `/db/_design/foodoc/_view/foobarview?conflicts=true&descending=false&endkey="test2"&endkey_docid=doc2&end_key_doc_id=doc2&startkey="test1"&startkey_docid=doc1`)
 	assert.NoError(t, err, "Unexpected error")
@@ -161,19 +161,19 @@ func TestViewQueryUserAccess(t *testing.T) {
 		t.Skip("views tests are not applicable under GSI")
 	}
 
-	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
 	ctx := rt.Context()
 	rt.ServerContext().Database(ctx, "db").SetUserViewsEnabled(true)
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_design/foo", `{"views":{"bar": {"map":"function (doc, meta) { if (doc.type != 'type1') { return; } if (doc.state == 'state1' || doc.state == 'state2' || doc.state == 'state3') { emit(doc.state, meta.id); }}"}}}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	response = rt.SendRequest(http.MethodPut, "/db/doc1", `{"type":"type1", "state":"state1"}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	response = rt.SendRequest(http.MethodPut, "/db/doc2", `{"type":"type1", "state":"state2"}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	response = rt.SendRequest(http.MethodPut, "/db/doc3", `{"type":"type2", "state":"state2"}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	result, err := rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar?stale=false")
 	assert.NoError(t, err, "Unexpected error in WaitForNAdminViewResults")
@@ -206,7 +206,7 @@ func TestViewQueryUserAccess(t *testing.T) {
 	request, _ := http.NewRequest(http.MethodGet, "/db/_design/foo/_view/bar?stale=false", nil)
 	request.SetBasicAuth(testUser.Name(), password)
 	userResponse := rt.Send(request)
-	requireStatus(t, userResponse, http.StatusForbidden)
+	RequireStatus(t, userResponse, http.StatusForbidden)
 }
 
 func TestViewQueryMultipleViewsInterfaceValues(t *testing.T) {
@@ -219,14 +219,14 @@ func TestViewQueryMultipleViewsInterfaceValues(t *testing.T) {
 
 	// Define three views
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_design/foo", `{"views": {"by_fname": {"map": "function (doc, meta) { emit(doc.fname, null); }"},"by_lname": {"map": "function (doc, meta) { emit(doc.lname, null); }"},"by_age": {"map": "function (doc, meta) { emit(doc.age, doc); }"}}}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	response = rt.SendRequest(http.MethodPut, "/db/doc1", `{"fname": "Alice", "lname":"Ten", "age":10}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	response = rt.SendRequest(http.MethodPut, "/db/doc2", `{"fname": "Bob", "lname":"Seven", "age":7}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_design/foo/_view/by_age", ``)
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	var result sgbucket.ViewResult
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
 	require.Len(t, result.Rows, 2)
@@ -234,14 +234,14 @@ func TestViewQueryMultipleViewsInterfaceValues(t *testing.T) {
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc1", Key: 10.0, Value: interface{}(nil)}, result.Rows[1])
 
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_design/foo/_view/by_fname", ``)
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
 	require.Len(t, result.Rows, 2)
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc1", Key: "Alice", Value: interface{}(nil)}, result.Rows[0])
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc2", Key: "Bob", Value: interface{}(nil)}, result.Rows[1])
 
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_design/foo/_view/by_lname", ``)
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
 	require.Len(t, result.Rows, 2)
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc2", Key: "Seven", Value: interface{}(nil)}, result.Rows[0])
@@ -255,7 +255,7 @@ func TestUserViewQuery(t *testing.T) {
 
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
-		guestEnabled: true,
+		GuestEnabled: true,
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -266,13 +266,13 @@ func TestUserViewQuery(t *testing.T) {
 
 	// Create a view:
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_design/foo", `{"views":{"bar": {"map": "function(doc) {emit(doc.key, doc.value);}"}}}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Create docs:
 	response = rt.SendRequest(http.MethodPut, "/db/doc1", `{"key":10, "value":"ten", "channel":"W"}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	response = rt.SendRequest(http.MethodPut, "/db/doc2", `{"key":7, "value":"seven", "channel":"Q"}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Create a user:
 	password := "123456"
@@ -322,7 +322,7 @@ func TestUserViewQuery(t *testing.T) {
 	request, _ := http.NewRequest(http.MethodGet, "/db/_design/sync_gateway/_view/access", nil)
 	request.SetBasicAuth(quinn.Name(), password)
 	response = rt.Send(request)
-	requireStatus(t, response, http.StatusForbidden)
+	RequireStatus(t, response, http.StatusForbidden)
 }
 
 // This includes a fix for #857
@@ -333,23 +333,23 @@ func TestAdminReduceViewQuery(t *testing.T) {
 
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
-		guestEnabled: true,
+		GuestEnabled: true,
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	// Create a view with a reduce:
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_design/foo", `{"views":{"bar": {"map": "function(doc) {emit(doc.key, doc.value);}", "reduce": "_count"}}}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	for i := 0; i < 9; i++ {
 		// Create docs:
 		response = rt.SendRequest(http.MethodPut, fmt.Sprintf("/db/doc%v", i), `{"key":0, "value":"0", "channel":"W"}`)
-		requireStatus(t, response, http.StatusCreated)
+		RequireStatus(t, response, http.StatusCreated)
 
 	}
 	response = rt.SendRequest(http.MethodPut, fmt.Sprintf("/db/doc%v", 10), `{"key":1, "value":"0", "channel":"W"}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Wait for all created documents to avoid race when using "reduce"
 	_, err := rt.WaitForNAdminViewResults(10, "/db/_design/foo/_view/bar?reduce=false")
@@ -388,22 +388,22 @@ func TestAdminReduceSumQuery(t *testing.T) {
 
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
-		guestEnabled: true,
+		GuestEnabled: true,
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	// Create a view with a reduce:
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_design/foo", `{"options":{"raw":true},"views":{"bar": {"map": "function(doc) {if (doc.key && doc.value) emit(doc.key, doc.value);}", "reduce": "_sum"}}}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	for i := 0; i < 9; i++ {
 		// Create docs:
 		response = rt.SendRequest(http.MethodPut, fmt.Sprintf("/db/doc%v", i), `{"key":"A", "value":1}`)
-		requireStatus(t, response, http.StatusCreated)
+		RequireStatus(t, response, http.StatusCreated)
 	}
 	response = rt.SendRequest(http.MethodPut, fmt.Sprintf("/db/doc%v", 10), `{"key":"B", "value":99}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Wait for all created documents to avoid race when using "reduce"
 	_, err := rt.WaitForNAdminViewResults(10, "/db/_design/foo/_view/bar?reduce=false")
@@ -428,23 +428,23 @@ func TestAdminGroupReduceSumQuery(t *testing.T) {
 
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
-		guestEnabled: true,
+		GuestEnabled: true,
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	// Create a view with a reduce:
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_design/foo", `{"options":{"raw":true},"views":{"bar": {"map": "function(doc) {if (doc.key && doc.value) emit(doc.key, doc.value);}", "reduce": "_sum"}}}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	for i := 0; i < 9; i++ {
 		// Create docs:
 		response = rt.SendRequest(http.MethodPut, fmt.Sprintf("/db/doc%v", i), `{"key":"A", "value":1}`)
-		requireStatus(t, response, http.StatusCreated)
+		RequireStatus(t, response, http.StatusCreated)
 
 	}
 	response = rt.SendRequest(http.MethodPut, fmt.Sprintf("/db/doc%v", 10), `{"key":"B", "value":99}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	var result sgbucket.ViewResult
 
@@ -475,17 +475,17 @@ func TestViewQueryWithKeys(t *testing.T) {
 
 	// Create a view
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_design/foo", `{"views":{"bar": {"map": "function(doc) {emit(doc.key, doc.value);}"}}}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	assert.NoError(t, rt.WaitForViewAvailable("/db/_design/foo/_view/bar"), "Error waiting for view availability")
 
 	// Create a doc
 	response = rt.SendAdminRequest(http.MethodPut, "/db/query_with_keys", `{"key":"channel_a", "value":99}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Admin view query:
 	viewUrlPath := "/db/_design/foo/_view/bar?keys=%5B%22channel_a%22%5D&stale=false"
 	response = rt.SendAdminRequest(http.MethodGet, viewUrlPath, ``)
-	requireStatus(t, response, http.StatusOK) // Query string was parsed properly
+	RequireStatus(t, response, http.StatusOK) // Query string was parsed properly
 
 	var result sgbucket.ViewResult
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
@@ -494,7 +494,7 @@ func TestViewQueryWithKeys(t *testing.T) {
 	// Ensure that query for non-existent keys returns no rows
 	viewUrlPath = "/db/_design/foo/_view/bar?keys=%5B%22channel_b%22%5D&stale=false"
 	response = rt.SendAdminRequest(http.MethodGet, viewUrlPath, ``)
-	requireStatus(t, response, http.StatusOK) // Query string was parsed properly
+	RequireStatus(t, response, http.StatusOK) // Query string was parsed properly
 
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
 	require.Len(t, result.Rows, 0)
@@ -516,18 +516,18 @@ func TestViewQueryWithCompositeKeys(t *testing.T) {
 
 	// Create a view
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_design/foo", `{"views":{"composite_key_test": {"map": "function(doc) {emit([doc.key, doc.seq], doc.value);}"}}}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	assert.NoError(t, rt.WaitForViewAvailable("/db/_design/foo/_view/composite_key_test"), "Error waiting for view availability")
 
 	// Create a doc
 	response = rt.SendAdminRequest(http.MethodPut, "/db/doc_composite_key", `{"key":"channel_a", "seq":55, "value":99}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Admin view query:
 	//   keys:[["channel_a", 55]]
 	viewUrlPath := "/db/_design/foo/_view/composite_key_test?keys=%5B%5B%22channel_a%22%2C%2055%5D%5D&stale=false"
 	response = rt.SendAdminRequest(http.MethodGet, viewUrlPath, ``)
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	var result sgbucket.ViewResult
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
 	require.Len(t, result.Rows, 1)
@@ -535,7 +535,7 @@ func TestViewQueryWithCompositeKeys(t *testing.T) {
 	// Ensure that a query for non-existent key returns no rows
 	viewUrlPath = "/db/_design/foo/_view/composite_key_test?keys=%5B%5B%22channel_b%22%2C%2055%5D%5D&stale=false"
 	response = rt.SendAdminRequest(http.MethodGet, viewUrlPath, ``)
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
 	require.Len(t, result.Rows, 0)
@@ -556,18 +556,18 @@ func TestViewQueryWithIntKeys(t *testing.T) {
 
 	// Create a view
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_design/foo", `{"views":{"int_key_test": {"map": "function(doc) {emit(doc.seq, doc.value);}"}}}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	assert.NoError(t, rt.WaitForViewAvailable("/db/_design/foo/_view/int_key_test"), "Error waiting for view availability")
 
 	// Create a doc
 	response = rt.SendAdminRequest(http.MethodPut, "/db/doc_int_key", `{"key":"channel_a", "seq":55, "value":99}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Admin view query:
 	//   keys:[55,65]
 	viewUrlPath := "/db/_design/foo/_view/int_key_test?keys=%5B55,65%5D&stale=false"
 	response = rt.SendAdminRequest(http.MethodGet, viewUrlPath, ``)
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	var result sgbucket.ViewResult
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
 	require.Len(t, result.Rows, 1)
@@ -576,7 +576,7 @@ func TestViewQueryWithIntKeys(t *testing.T) {
 	//   keys:[65,75]
 	viewUrlPath = "/db/_design/foo/_view/int_key_test?keys=%5B65,75%5D&stale=false"
 	response = rt.SendAdminRequest(http.MethodGet, viewUrlPath, ``)
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
 	require.Len(t, result.Rows, 0)
@@ -589,23 +589,23 @@ func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
 
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
-		guestEnabled: true,
+		GuestEnabled: true,
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	// Create a view with a reduce:
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_design/foo", `{"options":{"raw":true},"views":{"bar": {"map": "function(doc) {if (doc.key && doc.value) emit(doc.key, doc.value);}", "reduce": "_sum"}}}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	for i := 0; i < 9; i++ {
 		// Create docs:
 		response = rt.SendRequest(http.MethodPut, fmt.Sprintf("/db/doc%v", i), fmt.Sprintf(`{"key":["A",{},%v], "value":1}`, i))
-		requireStatus(t, response, http.StatusCreated)
+		RequireStatus(t, response, http.StatusCreated)
 
 	}
 	response = rt.SendRequest(http.MethodPut, fmt.Sprintf("/db/doc%v", 10), `{"key":["B",4,1], "value":99}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	var result sgbucket.ViewResult
 
@@ -649,7 +649,7 @@ func TestPostInstallCleanup(t *testing.T) {
 	// Run post-upgrade in preview mode
 	var postUpgradeResponse PostUpgradeResponse
 	response := rt.SendAdminRequest(http.MethodPost, "/_post_upgrade?preview=true", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
 	assert.True(t, postUpgradeResponse.Preview)
 	require.Lenf(t, postUpgradeResponse.Result["db"].RemovedDDocs, 2, "Response: %#v", postUpgradeResponse)
@@ -657,7 +657,7 @@ func TestPostInstallCleanup(t *testing.T) {
 	// Run post-upgrade in non-preview mode
 	postUpgradeResponse = PostUpgradeResponse{}
 	response = rt.SendAdminRequest(http.MethodPost, "/_post_upgrade", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
 	assert.False(t, postUpgradeResponse.Preview)
 	require.Len(t, postUpgradeResponse.Result["db"].RemovedDDocs, 2)
@@ -665,7 +665,7 @@ func TestPostInstallCleanup(t *testing.T) {
 	// Run post-upgrade in preview mode again, expect no results for database
 	postUpgradeResponse = PostUpgradeResponse{}
 	response = rt.SendAdminRequest(http.MethodPost, "/_post_upgrade?preview=true", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
 	assert.True(t, postUpgradeResponse.Preview)
 	require.Len(t, postUpgradeResponse.Result["db"].RemovedDDocs, 0)
@@ -673,7 +673,7 @@ func TestPostInstallCleanup(t *testing.T) {
 	// Run post-upgrade in non-preview mode again, expect no results for database
 	postUpgradeResponse = PostUpgradeResponse{}
 	response = rt.SendAdminRequest(http.MethodPost, "/_post_upgrade", "")
-	requireStatus(t, response, http.StatusOK)
+	RequireStatus(t, response, http.StatusOK)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
 	assert.False(t, postUpgradeResponse.Preview)
 	require.Len(t, postUpgradeResponse.Result["db"].RemovedDDocs, 0)
@@ -690,11 +690,11 @@ func TestViewQueryWrappers(t *testing.T) {
 	rt.ServerContext().Database(ctx, "db").SetUserViewsEnabled(true)
 
 	response := rt.SendAdminRequest(http.MethodPut, "/db/admindoc", `{"value":"foo"}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	response = rt.SendAdminRequest(http.MethodPut, "/db/admindoc2", `{"value":"foo"}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 	response = rt.SendAdminRequest(http.MethodPut, "/db/userdoc", `{"value":"foo", "channels": ["userchannel"]}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	response = rt.SendAdminRequest(http.MethodPut, "/db/_design/foodoc", `{"views": {"foobarview": {"map": "function(doc, meta) {if (doc.value == \"foo\") {emit(doc.key, null);}}"}}}`)
 	assert.Equal(t, http.StatusCreated, response.Code)
@@ -739,7 +739,7 @@ func TestViewQueryWithXattrAndNonXattr(t *testing.T) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/db/doc1", `{"value":"foo"}`)
-	requireStatus(t, response, http.StatusCreated)
+	RequireStatus(t, response, http.StatusCreated)
 
 	// Document with sync data in body
 	body := `{"_sync": { "rev": "1-fc2cf22c5e5007bd966869ebfe9e276a", "sequence": 2, "recent_sequences": [ 2 ], "history": { "revs": [ "1-fc2cf22c5e5007bd966869ebfe9e276a" ], "parents": [ -1], "channels": [ null ] }, "cas": "","value_crc32c": "", "time_saved": "2019-04-10T12:40:04.490083+01:00" }, "value": "foo"}`

--- a/rest/x509_test.go
+++ b/rest/x509_test.go
@@ -33,12 +33,12 @@ func TestX509RoundtripUsingIP(t *testing.T) {
 	tb, _, _, _ := setupX509Tests(t, true)
 	defer tb.Close()
 
-	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb, useTLSServer: true})
+	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, useTLSServer: true})
 	defer rt.Close()
 
 	// write a doc to ensure bucket ops work
 	tr := rt.SendAdminRequest(http.MethodPut, "/db/"+t.Name(), `{"sgwrite":true}`)
-	requireStatus(t, tr, http.StatusCreated)
+	RequireStatus(t, tr, http.StatusCreated)
 
 	// wait for doc to come back over DCP
 	err := rt.WaitForDoc(t.Name())
@@ -53,12 +53,12 @@ func TestX509RoundtripUsingDomain(t *testing.T) {
 	tb, _, _, _ := setupX509Tests(t, false)
 	defer tb.Close()
 
-	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb, useTLSServer: true})
+	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, useTLSServer: true})
 	defer rt.Close()
 
 	// write a doc to ensure bucket ops work
 	tr := rt.SendAdminRequest(http.MethodPut, "/db/"+t.Name(), `{"sgwrite":true}`)
-	requireStatus(t, tr, http.StatusCreated)
+	RequireStatus(t, tr, http.StatusCreated)
 
 	// wait for doc to come back over DCP
 	err := rt.WaitForDoc(t.Name())
@@ -92,7 +92,7 @@ func TestAttachmentCompactionRun(t *testing.T) {
 	tb, _, _, _ := setupX509Tests(t, true)
 	defer tb.Close()
 
-	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb, useTLSServer: true})
+	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, useTLSServer: true})
 	defer rt.Close()
 	ctx := rt.Context()
 
@@ -106,7 +106,7 @@ func TestAttachmentCompactionRun(t *testing.T) {
 	}
 
 	resp := rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
-	requireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp, http.StatusOK)
 
 	status := rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
 	assert.Equal(t, int64(20), status.MarkedAttachments)


### PR DESCRIPTION
CBG-2400 makes a collection of test functions public. This will shorten the overall review or CBG-2400 tests.

The only controversial part of this review is that `RestTesterConfig` had a `TestBucket` and `RestTester` embeds `RestTesterConfig`, and so to make `RestTester.testBucket` -> `RestTester.TestBucket` I change `RestTesterConfig.TestBucket` -> `RestTesterConfig.CustomTestBucket`.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/834/