### PR TITLE
Update golangci yamls to be compatible with 1.49

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.47.3
+          version: v1.49.0
           args: --config=.golangci-strict.yml --timeout=3m
   test:
     runs-on: ${{ matrix.os }}
@@ -65,7 +65,7 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.5.1
+        uses: guyarb/golang-test-annotations@v0.6.0
         with:
           test-results: test.json
 
@@ -83,6 +83,6 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.5.1
+        uses: guyarb/golang-test-annotations@v0.6.0
         with:
           test-results: test.json

--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -11,7 +11,6 @@
 linters:
   enable:
     #- bodyclose # checks whether HTTP response body is closed successfully
-    #- deadcode # Finds unused code
     #- dupl # Tool for code clone detection
     - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
     #- goconst # Finds repeated strings that could be replaced by a constant
@@ -30,7 +29,7 @@ linters:
     - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
     #- unconvert # Remove unnecessary type conversions
     #- unparam # Reports unused function parameters
-    #- varcheck # Finds unused global variables and constants
+    #- unused # (megacheck) Checks Go code for unused constants, variables, functions and types
   disable:
     - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
     - depguard # Go linter that checks if package imports are in a list of acceptable packages

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,6 @@
 linters:
   enable:
     - bodyclose # checks whether HTTP response body is closed successfully
-    - deadcode # Finds unused code
     - dupl # Tool for code clone detection
     - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
     - goconst # Finds repeated strings that could be replaced by a constant
@@ -29,7 +28,7 @@ linters:
     - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
     - unconvert # Remove unnecessary type conversions
     - unparam # Reports unused function parameters
-    - varcheck # Finds unused global variables and constants
+    - unused # (megacheck) Checks Go code for unused constants, variables, functions and types
   disable:
     - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
     - depguard # Go linter that checks if package imports are in a list of acceptable packages
@@ -54,7 +53,6 @@ linters:
     - scopelint # Scopelint checks for unpinned variables in go programs
     - stylecheck # Stylecheck is a replacement for golint
     - testpackage # linter that makes you use a separate _test package
-    - unused # (megacheck) Checks Go code for unused constants, variables, functions and types
     - whitespace # Tool for detection of leading and trailing whitespace
     - wsl # Whitespace Linter - Forces you to use empty lines!
 


### PR DESCRIPTION
deadcode and varcheck have no maintainers and were replaced with unused
Update versions in CI.