### PR TITLE
CBG-2400 split some packages out of rest

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -74,9 +74,9 @@ func (h *handler) handleCreateDB() error {
 			return base.HTTPErrorf(http.StatusInternalServerError, "couldn't create copy of db config: %v", err)
 		}
 
-		dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
-		bucketCreds, _ := h.server.config.BucketCredentials[bucket]
-		if err := config.setup(dbName, h.server.config.Bootstrap, dbCreds, bucketCreds, h.server.config.IsServerless()); err != nil {
+		dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
+		bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
+		if err := config.setup(dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
 			return err
 		}
 
@@ -108,7 +108,7 @@ func (h *handler) handleCreateDB() error {
 		}
 
 		// now we've started the db successfully, we can persist it to the cluster
-		cas, err := h.server.bootstrapContext.connection.InsertConfig(bucket, h.server.config.Bootstrap.ConfigGroupID, persistedConfig)
+		cas, err := h.server.BootstrapContext.Connection.InsertConfig(bucket, h.server.Config.Bootstrap.ConfigGroupID, persistedConfig)
 		if err != nil {
 			// unload the requested database config to prevent the cluster being in an inconsistent state
 			h.server._removeDatabase(h.ctx(), dbName)
@@ -220,7 +220,7 @@ func (h *handler) handleGetDbConfig() error {
 	// - Applying if refresh_config is set
 	// - Returning if include_runtime=false
 	var responseConfig *DbConfig
-	if h.server.bootstrapContext.connection != nil {
+	if h.server.BootstrapContext.Connection != nil {
 		found, dbConfig, err := h.server.fetchDatabase(h.ctx(), h.db.Name)
 		if err != nil {
 			return err
@@ -233,7 +233,7 @@ func (h *handler) handleGetDbConfig() error {
 		h.response.Header().Set("ETag", dbConfig.Version)
 
 		// refresh_config=true forces the config loaded out of the bucket to be applied on the node
-		if h.getBoolQuery("refresh_config") && h.server.bootstrapContext.connection != nil {
+		if h.getBoolQuery("refresh_config") && h.server.BootstrapContext.Connection != nil {
 			// set cas=0 to force a refresh
 			dbConfig.cas = 0
 			h.server.applyConfigs(h.ctx(), map[string]DatabaseConfig{h.db.Name: *dbConfig})
@@ -257,7 +257,7 @@ func (h *handler) handleGetDbConfig() error {
 	if includeRuntime {
 
 		var err error
-		responseConfig, err = MergeDatabaseConfigWithDefaults(h.server.config, h.server.GetDbConfig(h.db.Name))
+		responseConfig, err = MergeDatabaseConfigWithDefaults(h.server.Config, h.server.GetDbConfig(h.db.Name))
 		if err != nil {
 			return err
 		}
@@ -311,7 +311,7 @@ func (h *handler) handleGetConfig() error {
 
 		allDbNames := h.server.AllDatabaseNames()
 		databaseMap := make(map[string]*DbConfig, len(allDbNames))
-		cfg.StartupConfig, err = h.server.config.Redacted()
+		cfg.StartupConfig, err = h.server.Config.Redacted()
 		if err != nil {
 			return err
 		}
@@ -323,7 +323,7 @@ func (h *handler) handleGetConfig() error {
 				continue
 			}
 
-			dbConfig, err := MergeDatabaseConfigWithDefaults(h.server.config, dbConfig)
+			dbConfig, err := MergeDatabaseConfigWithDefaults(h.server.Config, dbConfig)
 			if err != nil {
 				return err
 			}
@@ -352,7 +352,7 @@ func (h *handler) handleGetConfig() error {
 			}
 		}
 
-		cfg.Logging = *base.BuildLoggingConfigFromLoggers(h.server.config.Logging.RedactionLevel, h.server.config.Logging.LogFilePath)
+		cfg.Logging = *base.BuildLoggingConfigFromLoggers(h.server.Config.Logging.RedactionLevel, h.server.Config.Logging.LogFilePath)
 		cfg.Databases = databaseMap
 
 		h.writeJSON(cfg)
@@ -513,8 +513,8 @@ func (h *handler) handlePutDbConfig() (err error) {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
 
-		dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
-		if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds, nil, false); err != nil {
+		dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
+		if err := updatedDbConfig.setup(dbName, h.server.Config.Bootstrap, dbCreds, nil, false); err != nil {
 			return err
 		}
 		if err := h.server.ReloadDatabaseWithConfig(h.ctx(), *updatedDbConfig); err != nil {
@@ -524,8 +524,8 @@ func (h *handler) handlePutDbConfig() (err error) {
 	}
 
 	var updatedDbConfig *DatabaseConfig
-	cas, err := h.server.bootstrapContext.connection.UpdateConfig(
-		bucket, h.server.config.Bootstrap.ConfigGroupID,
+	cas, err := h.server.BootstrapContext.Connection.UpdateConfig(
+		bucket, h.server.Config.Bootstrap.ConfigGroupID,
 		func(rawBucketConfig []byte) (newConfig []byte, err error) {
 			var bucketDbConfig DatabaseConfig
 			if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {
@@ -570,9 +570,9 @@ func (h *handler) handlePutDbConfig() (err error) {
 			if err = base.DeepCopyInefficient(&tmpConfig, bucketDbConfig); err != nil {
 				return nil, err
 			}
-			dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
-			bucketCreds, _ := h.server.config.BucketCredentials[bucket]
-			if err := tmpConfig.setup(dbName, h.server.config.Bootstrap, dbCreds, bucketCreds, h.server.config.IsServerless()); err != nil {
+			dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
+			bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
+			if err := tmpConfig.setup(dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
 				return nil, err
 			}
 
@@ -607,7 +607,7 @@ func (h *handler) handleGetDbConfigSync() error {
 		syncFunction string
 	)
 
-	if h.server.bootstrapContext.connection != nil {
+	if h.server.BootstrapContext.Connection != nil {
 		found, dbConfig, err := h.server.fetchDatabase(h.ctx(), h.db.Name)
 		if err != nil {
 			return err
@@ -639,8 +639,8 @@ func (h *handler) handleDeleteDbConfigSync() error {
 	bucket := h.db.Bucket.GetName()
 
 	var updatedDbConfig *DatabaseConfig
-	cas, err := h.server.bootstrapContext.connection.UpdateConfig(
-		bucket, h.server.config.Bootstrap.ConfigGroupID,
+	cas, err := h.server.BootstrapContext.Connection.UpdateConfig(
+		bucket, h.server.Config.Bootstrap.ConfigGroupID,
 		func(rawBucketConfig []byte) (newConfig []byte, err error) {
 			var bucketDbConfig DatabaseConfig
 			if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {
@@ -669,9 +669,9 @@ func (h *handler) handleDeleteDbConfigSync() error {
 	updatedDbConfig.cas = cas
 
 	dbName := h.db.Name
-	dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
-	bucketCreds, _ := h.server.config.BucketCredentials[bucket]
-	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds, bucketCreds, h.server.config.IsServerless()); err != nil {
+	dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
+	bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
+	if err := updatedDbConfig.setup(dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
 		return err
 	}
 
@@ -701,8 +701,8 @@ func (h *handler) handlePutDbConfigSync() error {
 	bucket := h.db.Bucket.GetName()
 
 	var updatedDbConfig *DatabaseConfig
-	cas, err := h.server.bootstrapContext.connection.UpdateConfig(
-		bucket, h.server.config.Bootstrap.ConfigGroupID,
+	cas, err := h.server.BootstrapContext.Connection.UpdateConfig(
+		bucket, h.server.Config.Bootstrap.ConfigGroupID,
 		func(rawBucketConfig []byte) (newConfig []byte, err error) {
 			var bucketDbConfig DatabaseConfig
 			if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {
@@ -736,9 +736,9 @@ func (h *handler) handlePutDbConfigSync() error {
 	updatedDbConfig.cas = cas
 
 	dbName := h.db.Name
-	dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
-	bucketCreds, _ := h.server.config.BucketCredentials[bucket]
-	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds, bucketCreds, h.server.config.IsServerless()); err != nil {
+	dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
+	bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
+	if err := updatedDbConfig.setup(dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
 		return err
 	}
 
@@ -761,7 +761,7 @@ func (h *handler) handleGetDbConfigImportFilter() error {
 		importFilterFunction string
 	)
 
-	if h.server.bootstrapContext.connection != nil {
+	if h.server.BootstrapContext.Connection != nil {
 		found, dbConfig, err := h.server.fetchDatabase(h.ctx(), h.db.Name)
 		if err != nil {
 			return err
@@ -791,8 +791,8 @@ func (h *handler) handleDeleteDbConfigImportFilter() error {
 	bucket := h.db.Bucket.GetName()
 
 	var updatedDbConfig *DatabaseConfig
-	cas, err := h.server.bootstrapContext.connection.UpdateConfig(
-		bucket, h.server.config.Bootstrap.ConfigGroupID,
+	cas, err := h.server.BootstrapContext.Connection.UpdateConfig(
+		bucket, h.server.Config.Bootstrap.ConfigGroupID,
 		func(rawBucketConfig []byte) (newConfig []byte, err error) {
 			var bucketDbConfig DatabaseConfig
 			if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {
@@ -821,9 +821,9 @@ func (h *handler) handleDeleteDbConfigImportFilter() error {
 	updatedDbConfig.cas = cas
 
 	dbName := h.db.Name
-	dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
-	bucketCreds, _ := h.server.config.BucketCredentials[bucket]
-	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds, bucketCreds, h.server.config.IsServerless()); err != nil {
+	dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
+	bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
+	if err := updatedDbConfig.setup(dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
 		return err
 	}
 
@@ -854,8 +854,8 @@ func (h *handler) handlePutDbConfigImportFilter() error {
 	bucket := h.db.Bucket.GetName()
 
 	var updatedDbConfig *DatabaseConfig
-	cas, err := h.server.bootstrapContext.connection.UpdateConfig(
-		bucket, h.server.config.Bootstrap.ConfigGroupID,
+	cas, err := h.server.BootstrapContext.Connection.UpdateConfig(
+		bucket, h.server.Config.Bootstrap.ConfigGroupID,
 		func(rawBucketConfig []byte) (newConfig []byte, err error) {
 			var bucketDbConfig DatabaseConfig
 			if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {
@@ -889,9 +889,9 @@ func (h *handler) handlePutDbConfigImportFilter() error {
 	updatedDbConfig.cas = cas
 
 	dbName := h.db.Name
-	dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
-	bucketCreds, _ := h.server.config.BucketCredentials[bucket]
-	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds, bucketCreds, h.server.config.IsServerless()); err != nil {
+	dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
+	bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
+	if err := updatedDbConfig.setup(dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
 		return err
 	}
 
@@ -913,7 +913,7 @@ func (h *handler) handleDeleteDB() error {
 
 	if h.server.persistentConfig {
 		bucket := h.db.Bucket.GetName()
-		_, err := h.server.bootstrapContext.connection.UpdateConfig(bucket, h.server.config.Bootstrap.ConfigGroupID, func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
+		_, err := h.server.BootstrapContext.Connection.UpdateConfig(bucket, h.server.Config.Bootstrap.ConfigGroupID, func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
 			return nil, nil
 		})
 		if err != nil {
@@ -1171,7 +1171,7 @@ func (h *handler) handleSGCollect() error {
 
 	zipFilename := sgcollectFilename()
 
-	logFilePath := h.server.config.Logging.LogFilePath
+	logFilePath := h.server.Config.Logging.LogFilePath
 
 	if err := sgcollectInstance.Start(logFilePath, h.serialNumber, zipFilename, params); err != nil {
 		return base.HTTPErrorf(http.StatusInternalServerError, "Error running sgcollect_info: %v", err)

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -2,72 +2,15 @@ package rest
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
-	"net/url"
 	"reflect"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func MakeUser(t *testing.T, httpClient *http.Client, serverURL, username, password string, roles []string) {
-	form := url.Values{}
-	form.Add("password", password)
-	form.Add("roles", strings.Join(roles, ","))
-
-	retryWorker := func() (shouldRetry bool, err error, value interface{}) {
-		req, err := http.NewRequest("PUT", fmt.Sprintf("%s/settings/rbac/users/local/%s", serverURL, username), strings.NewReader(form.Encode()))
-		require.NoError(t, err)
-
-		req.SetBasicAuth(base.TestClusterUsername(), base.TestClusterPassword())
-		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			return true, err, resp
-		}
-		return false, err, resp
-	}
-
-	err, resp := base.RetryLoop("Admin Auth testing MakeUser", retryWorker, base.CreateSleeperFunc(10, 100))
-	require.NoError(t, err)
-
-	if resp.(*http.Response).StatusCode != http.StatusOK {
-		bodyResp, err := ioutil.ReadAll(resp.(*http.Response).Body)
-		assert.NoError(t, err)
-		fmt.Println(string(bodyResp))
-	}
-	require.Equal(t, http.StatusOK, resp.(*http.Response).StatusCode)
-
-	require.NoError(t, resp.(*http.Response).Body.Close(), "Error closing response body")
-}
-
-func DeleteUser(t *testing.T, httpClient *http.Client, serverURL, username string) {
-	retryWorker := func() (shouldRetry bool, err error, value interface{}) {
-		req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/settings/rbac/users/local/%s", serverURL, username), nil)
-		require.NoError(t, err)
-
-		req.SetBasicAuth(base.TestClusterUsername(), base.TestClusterPassword())
-
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			return true, err, resp
-		}
-		return false, err, resp
-	}
-
-	err, resp := base.RetryLoop("Admin Auth testing DeleteUser", retryWorker, base.CreateSleeperFunc(10, 100))
-	require.NoError(t, err)
-
-	require.Equal(t, http.StatusOK, resp.(*http.Response).StatusCode)
-
-	require.NoError(t, resp.(*http.Response).Body.Close(), "Error closing response body")
-}
 
 func TestCheckPermissions(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {

--- a/rest/adminapitest/main_test.go
+++ b/rest/adminapitest/main_test.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2020-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package adminapitest
+
+import (
+	"testing"
+
+	"github.com/couchbase/sync_gateway/db"
+)
+
+func TestMain(m *testing.M) {
+	memWatermarkThresholdMB := uint64(256)
+	db.TestBucketPoolWithIndexes(m, memWatermarkThresholdMB)
+}

--- a/rest/adminapitest/main_test.go
+++ b/rest/adminapitest/main_test.go
@@ -17,6 +17,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	memWatermarkThresholdMB := uint64(256)
+	memWatermarkThresholdMB := uint64(4096)
 	db.TestBucketPoolWithIndexes(m, memWatermarkThresholdMB)
 }

--- a/rest/api.go
+++ b/rest/api.go
@@ -209,7 +209,7 @@ func (h *handler) handleFlush() error {
 		h.server.RemoveDatabase(h.ctx(), name)
 
 		// Create a bucket connection spec from the database config
-		spec, err := GetBucketSpec(h.ctx(), config, h.server.config)
+		spec, err := GetBucketSpec(h.ctx(), config, h.server.Config)
 		if err != nil {
 			return err
 		}

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -320,7 +320,7 @@ func TestCollectionsChangeConfigScope(t *testing.T) {
 	require.NoError(t, err)
 
 	serverErr := make(chan error)
-	config := bootstrapStartupConfigForTest(t)
+	config := BootstrapStartupConfigForTest(t)
 	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	defer func() {
@@ -329,12 +329,12 @@ func TestCollectionsChangeConfigScope(t *testing.T) {
 	}()
 
 	go func() {
-		serverErr <- startServer(ctx, &config, sc)
+		serverErr <- StartServer(ctx, &config, sc)
 	}()
-	require.NoError(t, sc.waitForRESTAPIs())
+	require.NoError(t, sc.WaitForRESTAPIs())
 
 	// Create a DB configured with one scope
-	res := bootstrapAdminRequest(t, http.MethodPut, "/db/", string(mustMarshalJSON(t, map[string]any{
+	res := BootstrapAdminRequest(t, http.MethodPut, "/db/", string(mustMarshalJSON(t, map[string]any{
 		"bucket":                      tb.GetName(),
 		"num_index_replicas":          0,
 		"enable_shared_bucket_access": base.TestUseXattrs(),
@@ -350,7 +350,7 @@ func TestCollectionsChangeConfigScope(t *testing.T) {
 	require.Equal(t, http.StatusCreated, res.StatusCode, "failed to create DB")
 
 	// Try updating its scopes
-	res = bootstrapAdminRequest(t, http.MethodPut, "/db/_config", string(mustMarshalJSON(t, map[string]any{
+	res = BootstrapAdminRequest(t, http.MethodPut, "/db/_config", string(mustMarshalJSON(t, map[string]any{
 		"bucket":                      tb.GetName(),
 		"num_index_replicas":          0,
 		"enable_shared_bucket_access": base.TestUseXattrs(),

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -132,19 +132,6 @@ func TestDisablePublicBasicAuth(t *testing.T) {
 	RequireStatus(t, response, http.StatusOK)
 }
 
-func (rt *RestTester) CreateDoc(t *testing.T, docid string) string {
-	response := rt.SendAdminRequest("PUT", "/db/"+docid, `{"prop":true}`)
-	RequireStatus(t, response, 201)
-	var body db.Body
-	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
-	assert.Equal(t, true, body["ok"])
-	revid := body["rev"].(string)
-	if revid == "" {
-		t.Fatalf("No revid in response for PUT doc")
-	}
-	return revid
-}
-
 func TestDocLifecycle(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -704,7 +691,7 @@ func TestCORSOrigin(t *testing.T) {
 
 	// test with a config without * should reject non-matches
 	sc := rt.ServerContext()
-	sc.config.API.CORS.Origin = []string{"http://example.com", "http://staging.example.com"}
+	sc.Config.API.CORS.Origin = []string{"http://example.com", "http://staging.example.com"}
 	// now test a non-listed origin
 	// b/c * is in config we get *
 	reqHeaders = map[string]string{
@@ -750,7 +737,7 @@ func TestCORSLoginOriginOnSessionPostNoCORSConfig(t *testing.T) {
 
 	// Set CORS to nil
 	sc := rt.ServerContext()
-	sc.config.API.CORS = nil
+	sc.Config.API.CORS = nil
 
 	response := rt.SendRequestWithHeaders("POST", "/db/_session", `{"name":"jchris","password":"secret"}`, reqHeaders)
 	RequireStatus(t, response, 400)
@@ -797,7 +784,7 @@ func TestCORSLogoutOriginOnSessionDeleteNoCORSConfig(t *testing.T) {
 
 	// Set CORS to nil
 	sc := rt.ServerContext()
-	sc.config.API.CORS = nil
+	sc.Config.API.CORS = nil
 
 	response := rt.SendRequestWithHeaders("DELETE", "/db/_session", "", reqHeaders)
 	RequireStatus(t, response, 400)
@@ -2065,7 +2052,7 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 	assert.Equal(t, uint64(kMaxTimeoutMS), options.TimeoutMs)
 
 	// Set max heartbeat in server context, attempt to set heartbeat greater than max
-	h.server.config.Replicator.MaxHeartbeat = base.NewConfigDuration(time.Minute)
+	h.server.Config.Replicator.MaxHeartbeat = base.NewConfigDuration(time.Minute)
 	optStr = `{"feed":"longpoll", "since": "1", "heartbeat":90000}`
 	feed, options, filter, channelsArray, _, _, err = h.readChangesOptionsFromJSON([]byte(optStr))
 	assert.NoError(t, err)

--- a/rest/api_test_helpers_test.go
+++ b/rest/api_test_helpers_test.go
@@ -25,13 +25,6 @@ type PutDocResponse struct {
 	Rev string
 }
 
-func (rt *RestTester) GetDoc(docID string) (body db.Body) {
-	rawResponse := rt.SendAdminRequest("GET", "/db/"+docID, "")
-	RequireStatus(rt.tb, rawResponse, 200)
-	require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &body))
-	return body
-}
-
 func (rt *RestTester) RequireDocNotFound(docID string) {
 	rawResponse := rt.SendAdminRequest(http.MethodGet, "/db/"+docID, "")
 	RequireStatus(rt.tb, rawResponse, http.StatusNotFound)
@@ -119,16 +112,4 @@ func (rt *RestTester) RequireWaitChanges(numChangesExpected int, since string) C
 	require.NoError(rt.tb, err)
 	require.Len(rt.tb, changesResults.Results, numChangesExpected)
 	return changesResults
-}
-
-func (rt *RestTester) WaitForRev(docID string, revID string) error {
-	return rt.WaitForCondition(func() bool {
-		rawResponse := rt.SendAdminRequest("GET", "/db/"+docID, "")
-		if rawResponse.Code != 200 && rawResponse.Code != 201 {
-			return false
-		}
-		var body db.Body
-		require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &body))
-		return body.ExtractRev() == revID
-	})
 }

--- a/rest/attachmentcompactiontest/main_test.go
+++ b/rest/attachmentcompactiontest/main_test.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2020-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package attachmentcompactiontest
+
+import (
+	"testing"
+
+	"github.com/couchbase/sync_gateway/db"
+)
+
+func TestMain(m *testing.M) {
+	memWatermarkThresholdMB := uint64(256)
+	db.TestBucketPoolWithIndexes(m, memWatermarkThresholdMB)
+}

--- a/rest/blip_api_no_race_test.go
+++ b/rest/blip_api_no_race_test.go
@@ -87,7 +87,7 @@ func TestBlipPusherUpdateDatabase(t *testing.T) {
 
 	// Did we tell the client to close the connection (via HTTP/503)?
 	// The BlipTesterClient doesn't implement reconnect - but CBL resets the replication connection.
-	waitAndAssertCondition(t, func() bool {
+	WaitAndAssertCondition(t, func() bool {
 		lastErr, ok := lastPushRevErr.Load().(error)
 		if !ok {
 			return false

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -528,10 +528,10 @@ func createBlipTesterClientOpts(tb testing.TB, rt *RestTester, opts *BlipTesterC
 		return nil, err
 	}
 
-	if btc.pushReplication, err = newBlipTesterReplication(btc.rt.tb, "push"+id.String(), &btc); err != nil {
+	if btc.pushReplication, err = newBlipTesterReplication(btc.rt.TB, "push"+id.String(), &btc); err != nil {
 		return nil, err
 	}
-	if btc.pullReplication, err = newBlipTesterReplication(btc.rt.tb, "pull"+id.String(), &btc); err != nil {
+	if btc.pullReplication, err = newBlipTesterReplication(btc.rt.TB, "pull"+id.String(), &btc); err != nil {
 		return nil, err
 	}
 
@@ -939,7 +939,7 @@ func (btc *BlipTesterCollectionClient) WaitForRev(docID, revID string) (data []b
 	for {
 		select {
 		case <-timeout:
-			btc.parent.rt.tb.Fatalf("BlipTesterClient timed out waiting for doc ID: %v rev ID: %v", docID, revID)
+			btc.parent.rt.TB.Fatalf("BlipTesterClient timed out waiting for doc ID: %v rev ID: %v", docID, revID)
 			return nil, false
 		case <-ticker.C:
 			if data, found := btc.GetRev(docID, revID); found {
@@ -983,7 +983,7 @@ func (btr *BlipTesterReplicator) WaitForMessage(serialNumber blip.MessageNumber)
 	for {
 		select {
 		case <-timeout:
-			btr.bt.restTester.tb.Fatalf("BlipTesterReplicator timed out waiting for BLIP message: %v", serialNumber)
+			btr.bt.restTester.TB.Fatalf("BlipTesterReplicator timed out waiting for BLIP message: %v", serialNumber)
 			return nil, false
 		case <-ticker.C:
 			if msg, ok := btr.GetMessage(serialNumber); ok {
@@ -1005,7 +1005,7 @@ func (btc *BlipTesterCollectionClient) WaitForBlipRevMessage(docID, revID string
 	for {
 		select {
 		case <-timeout:
-			btc.parent.rt.tb.Fatalf("BlipTesterClient timed out waiting for BLIP message docID: %v, revID: %v", docID, revID)
+			btc.parent.rt.TB.Fatalf("BlipTesterClient timed out waiting for BLIP message docID: %v, revID: %v", docID, revID)
 			return nil, false
 		case <-ticker.C:
 			if data, found := btc.GetBlipRevMessage(docID, revID); found {

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -32,7 +32,7 @@ func (h *handler) handleBLIPSync() error {
 	h.db.DatabaseContext.DbStats.Database().NumReplicationsTotal.Add(1)
 	defer h.db.DatabaseContext.DbStats.Database().NumReplicationsActive.Add(-1)
 
-	if c := h.server.config.Replicator.BLIPCompression; c != nil {
+	if c := h.server.Config.Replicator.BLIPCompression; c != nil {
 		blip.CompressionLevel = *c
 	}
 

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -1,22 +1,14 @@
 package rest
 
 import (
-	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
-	"strconv"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-)
-
-const (
-	// offset for standard port numbers to avoid conflicts 4984 -> 14984
-	bootstrapTestPortOffset = 10000
 )
 
 // TestBootstrapRESTAPISetup will bootstrap against a cluster with no databases,
@@ -32,7 +24,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 
 	// Start SG with no databases
 	ctx := base.TestCtx(t)
-	config := bootstrapStartupConfigForTest(t)
+	config := BootstrapStartupConfigForTest(t)
 	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 	ctx = sc.SetContextLogID(ctx, "initial")
@@ -40,9 +32,9 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	// sc closed and serverErr read later in the test
 	serverErr := make(chan error, 0)
 	go func() {
-		serverErr <- startServer(ctx, &config, sc)
+		serverErr <- StartServer(ctx, &config, sc)
 	}()
-	require.NoError(t, sc.waitForRESTAPIs())
+	require.NoError(t, sc.WaitForRESTAPIs())
 
 	// Get a test bucket, and use it to create the database.
 	tb := base.GetTestBucket(t)
@@ -50,30 +42,30 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 		fmt.Println("closing test bucket")
 		tb.Close()
 	}()
-	resp := bootstrapAdminRequest(t, http.MethodPut, "/db1/",
+	resp := BootstrapAdminRequest(t, http.MethodPut, "/db1/",
 		fmt.Sprintf(
 			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,
 			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 		),
 	)
-	resp.requireStatus(http.StatusCreated)
+	resp.RequireStatus(http.StatusCreated)
 
 	// upsert 1 config field
-	resp = bootstrapAdminRequest(t, http.MethodPost, "/db1/_config",
+	resp = BootstrapAdminRequest(t, http.MethodPost, "/db1/_config",
 		`{"cache": {"rev_cache":{"size":1234}}}`,
 	)
-	resp.requireStatus(http.StatusCreated)
+	resp.RequireStatus(http.StatusCreated)
 
-	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/", ``)
-	resp.requireStatus(http.StatusOK)
+	resp = BootstrapAdminRequest(t, http.MethodGet, "/db1/", ``)
+	resp.RequireStatus(http.StatusOK)
 	var dbRootResp DatabaseRoot
 	require.NoError(t, base.JSONUnmarshal([]byte(resp.Body), &dbRootResp))
 	assert.Equal(t, "db1", dbRootResp.DBName)
 	assert.Equal(t, db.RunStateString[db.DBOnline], dbRootResp.State)
 
 	// Inspect the config
-	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/_config", ``)
-	resp.requireStatus(http.StatusOK)
+	resp = BootstrapAdminRequest(t, http.MethodGet, "/db1/_config", ``)
+	resp.RequireStatus(http.StatusOK)
 	var dbConfigResp DatabaseConfig
 	require.NoError(t, base.JSONUnmarshal([]byte(resp.Body), &dbConfigResp))
 	assert.Equal(t, "db1", dbConfigResp.Name)
@@ -86,10 +78,10 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	require.Equal(t, uint32(1234), *dbConfigResp.CacheConfig.RevCacheConfig.Size)
 
 	// Sanity check to use the database
-	resp = bootstrapAdminRequest(t, http.MethodPut, "/db1/doc1", `{"foo":"bar"}`)
-	resp.requireResponse(http.StatusCreated, `{"id":"doc1","ok":true,"rev":"1-cd809becc169215072fd567eebd8b8de"}`)
-	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/doc1", ``)
-	resp.requireResponse(http.StatusOK, `{"_id":"doc1","_rev":"1-cd809becc169215072fd567eebd8b8de","foo":"bar"}`)
+	resp = BootstrapAdminRequest(t, http.MethodPut, "/db1/doc1", `{"foo":"bar"}`)
+	resp.RequireResponse(http.StatusCreated, `{"id":"doc1","ok":true,"rev":"1-cd809becc169215072fd567eebd8b8de"}`)
+	resp = BootstrapAdminRequest(t, http.MethodGet, "/db1/doc1", ``)
+	resp.RequireResponse(http.StatusOK, `{"_id":"doc1","_rev":"1-cd809becc169215072fd567eebd8b8de","foo":"bar"}`)
 
 	// Restart Sync Gateway
 	sc.Close(ctx)
@@ -102,25 +94,25 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 
 	serverErr = make(chan error, 0)
 	go func() {
-		serverErr <- startServer(ctx, &config, sc)
+		serverErr <- StartServer(ctx, &config, sc)
 	}()
-	require.NoError(t, sc.waitForRESTAPIs())
+	require.NoError(t, sc.WaitForRESTAPIs())
 	defer func() {
 		sc.Close(ctx)
 		require.NoError(t, <-serverErr)
 	}()
 
 	// Ensure the database was bootstrapped on startup
-	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/", ``)
-	resp.requireStatus(http.StatusOK)
+	resp = BootstrapAdminRequest(t, http.MethodGet, "/db1/", ``)
+	resp.RequireStatus(http.StatusOK)
 	dbRootResp = DatabaseRoot{}
 	require.NoError(t, base.JSONUnmarshal([]byte(resp.Body), &dbRootResp))
 	assert.Equal(t, "db1", dbRootResp.DBName)
 	assert.Equal(t, db.RunStateString[db.DBOnline], dbRootResp.State)
 
 	// Inspect config again, and ensure no changes since bootstrap
-	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/_config", ``)
-	resp.requireStatus(http.StatusOK)
+	resp = BootstrapAdminRequest(t, http.MethodGet, "/db1/_config", ``)
+	resp.RequireStatus(http.StatusOK)
 	dbConfigResp = DatabaseConfig{}
 	require.NoError(t, base.JSONUnmarshal([]byte(resp.Body), &dbConfigResp))
 	assert.Equal(t, "db1", dbConfigResp.Name)
@@ -133,8 +125,8 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	require.Equal(t, uint32(1234), *dbConfigResp.CacheConfig.RevCacheConfig.Size)
 
 	// Ensure it's _actually_ the same bucket
-	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/doc1", ``)
-	resp.requireResponse(http.StatusOK, `{"_id":"doc1","_rev":"1-cd809becc169215072fd567eebd8b8de","foo":"bar"}`)
+	resp = BootstrapAdminRequest(t, http.MethodGet, "/db1/doc1", ``)
+	resp.RequireResponse(http.StatusOK, `{"_id":"doc1","_rev":"1-cd809becc169215072fd567eebd8b8de","foo":"bar"}`)
 }
 
 // TestBootstrapDuplicateBucket will attempt to create two databases sharing the same bucket and ensure this isn't allowed.
@@ -149,7 +141,7 @@ func TestBootstrapDuplicateBucket(t *testing.T) {
 
 	// Start SG with no databases
 	ctx := base.TestCtx(t)
-	config := bootstrapStartupConfigForTest(t)
+	config := BootstrapStartupConfigForTest(t)
 	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 
@@ -159,29 +151,29 @@ func TestBootstrapDuplicateBucket(t *testing.T) {
 	}()
 
 	go func() {
-		serverErr <- startServer(ctx, &config, sc)
+		serverErr <- StartServer(ctx, &config, sc)
 	}()
-	require.NoError(t, sc.waitForRESTAPIs())
+	require.NoError(t, sc.WaitForRESTAPIs())
 
 	// Get a test bucket, and use it to create the database.
 	tb := base.GetTestBucket(t)
 	defer func() { tb.Close() }()
-	resp := bootstrapAdminRequest(t, http.MethodPut, "/db1/",
+	resp := BootstrapAdminRequest(t, http.MethodPut, "/db1/",
 		fmt.Sprintf(
 			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,
 			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 		),
 	)
-	resp.requireStatus(http.StatusCreated)
+	resp.RequireStatus(http.StatusCreated)
 
 	// Create db2 using the same bucket and expect it to fail
-	resp = bootstrapAdminRequest(t, http.MethodPut, "/db2/",
+	resp = BootstrapAdminRequest(t, http.MethodPut, "/db2/",
 		fmt.Sprintf(
 			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,
 			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 		),
 	)
-	resp.requireStatus(http.StatusConflict)
+	resp.RequireStatus(http.StatusConflict)
 
 	// CBG-1785 - Check the error has been changed from the original misleading error to a more informative one.
 	assert.NotContains(t, resp.Body, fmt.Sprintf(`Database \"%s\" already exists`, "db2"))
@@ -200,7 +192,7 @@ func TestBootstrapDuplicateDatabase(t *testing.T) {
 
 	// Start SG with no databases
 	ctx := base.TestCtx(t)
-	config := bootstrapStartupConfigForTest(t)
+	config := BootstrapStartupConfigForTest(t)
 	sc, err := SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 
@@ -210,9 +202,9 @@ func TestBootstrapDuplicateDatabase(t *testing.T) {
 	}()
 
 	go func() {
-		serverErr <- startServer(ctx, &config, sc)
+		serverErr <- StartServer(ctx, &config, sc)
 	}()
-	require.NoError(t, sc.waitForRESTAPIs())
+	require.NoError(t, sc.WaitForRESTAPIs())
 
 	// Get a test bucket, and use it to create the database.
 	tb := base.GetTestBucket(t)
@@ -223,122 +215,25 @@ func TestBootstrapDuplicateDatabase(t *testing.T) {
 		tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 	)
 
-	resp := bootstrapAdminRequest(t, http.MethodPut, "/db1/", dbConfig)
-	resp.requireStatus(http.StatusCreated)
+	resp := BootstrapAdminRequest(t, http.MethodPut, "/db1/", dbConfig)
+	resp.RequireStatus(http.StatusCreated)
 
 	// Write a doc, we'll rely on it for later stat assertions to ensure the database isn't being reloaded.
-	resp = bootstrapAdminRequest(t, http.MethodPut, "/db1/doc1", `{"test": true}`)
-	resp.requireStatus(http.StatusCreated)
+	resp = BootstrapAdminRequest(t, http.MethodPut, "/db1/doc1", `{"test": true}`)
+	resp.RequireStatus(http.StatusCreated)
 
 	// check to see we have a doc written stat
-	resp = bootstrapAdminRequest(t, http.MethodGet, "/_expvar", "")
-	resp.requireStatus(http.StatusOK)
+	resp = BootstrapAdminRequest(t, http.MethodGet, "/_expvar", "")
+	resp.RequireStatus(http.StatusOK)
 	assert.Contains(t, resp.Body, `"num_doc_writes":1`)
 
 	// Create db1 again and expect it to fail
-	resp = bootstrapAdminRequest(t, http.MethodPut, "/db1/", dbConfig)
-	resp.requireStatus(http.StatusPreconditionFailed)
+	resp = BootstrapAdminRequest(t, http.MethodPut, "/db1/", dbConfig)
+	resp.RequireStatus(http.StatusPreconditionFailed)
 	assert.Contains(t, resp.Body, fmt.Sprintf(`Duplicate database name \"%s\"`, "db1"))
 
 	// check to see we still have a doc written stat (as a proxy to determine if the database restarted)
-	resp = bootstrapAdminRequest(t, http.MethodGet, "/_expvar", "")
-	resp.requireStatus(http.StatusOK)
+	resp = BootstrapAdminRequest(t, http.MethodGet, "/_expvar", "")
+	resp.RequireStatus(http.StatusOK)
 	assert.Contains(t, resp.Body, `"num_doc_writes":1`)
-}
-
-func bootstrapStartupConfigForTest(t *testing.T) StartupConfig {
-	config := DefaultStartupConfig("")
-
-	config.Logging.Console = &base.ConsoleLoggerConfig{
-		LogLevel: base.ConsoleLogLevel(),
-		LogKeys:  base.ConsoleLogKey().EnabledLogKeys(),
-	}
-
-	config.API.AdminInterfaceAuthentication = base.BoolPtr(false)
-
-	config.API.PublicInterface = "127.0.0.1:" + strconv.FormatInt(4984+bootstrapTestPortOffset, 10)
-	config.API.AdminInterface = "127.0.0.1:" + strconv.FormatInt(4985+bootstrapTestPortOffset, 10)
-	config.API.MetricsInterface = "127.0.0.1:" + strconv.FormatInt(4986+bootstrapTestPortOffset, 10)
-
-	config.Bootstrap.Server = base.UnitTestUrl()
-	config.Bootstrap.Username = base.TestClusterUsername()
-	config.Bootstrap.Password = base.TestClusterPassword()
-	config.Bootstrap.ServerTLSSkipVerify = base.BoolPtr(base.TestTLSSkipVerify())
-	config.Bootstrap.UseTLSServer = base.BoolPtr(base.ServerIsTLS(base.UnitTestUrl()))
-
-	// avoid loading existing configs by choosing a non-default config group
-	if !base.IsEnterpriseEdition() {
-		t.Skipf("EE-ONLY: Skipping test %s due to requiring non-default Config Group ID", t.Name())
-	}
-	config.Bootstrap.ConfigGroupID = t.Name()
-
-	return config
-}
-
-const (
-	publicPort  = 4984
-	adminPort   = 4985
-	metricsPort = 4986
-)
-
-func bootstrapURL(basePort int) string {
-	return "http://localhost:" + strconv.Itoa(basePort+bootstrapTestPortOffset)
-}
-
-type bootstrapAdminResponse struct {
-	StatusCode int
-	Body       string
-	Header     http.Header
-	t          *testing.T
-}
-
-func (r *bootstrapAdminResponse) requireStatus(status int) {
-	require.Equal(r.t, status, r.StatusCode, "unexpected status code - body: %s", r.Body)
-}
-
-func (r *bootstrapAdminResponse) requireResponse(status int, body string) {
-	require.Equal(r.t, status, r.StatusCode, "unexpected status code - body: %s", r.Body)
-	require.Equal(r.t, body, r.Body, "unexpected body")
-}
-
-func bootstrapAdminRequest(t *testing.T, method, path, body string) bootstrapAdminResponse {
-	return doBootstrapAdminRequest(t, method, "", path, body, nil)
-}
-
-func bootstrapAdminRequestCustomHost(t *testing.T, method, host, path, body string) bootstrapAdminResponse {
-	return doBootstrapAdminRequest(t, method, host, path, body, nil)
-}
-
-func bootstrapAdminRequestWithHeaders(t *testing.T, method, path, body string, headers map[string]string) bootstrapAdminResponse {
-	return doBootstrapAdminRequest(t, method, "", path, body, headers)
-}
-
-func doBootstrapAdminRequest(t *testing.T, method, host, path, body string, headers map[string]string) bootstrapAdminResponse {
-	if host == "" {
-		host = "http://localhost:" + strconv.FormatInt(4985+bootstrapTestPortOffset, 10)
-	}
-	url := host + path
-
-	buf := bytes.NewBufferString(body)
-	req, err := http.NewRequest(method, url, buf)
-	require.NoError(t, err)
-
-	for headerName, headerVal := range headers {
-		req.Header.Set(headerName, headerVal)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-
-	rBody, err := ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	require.NoError(t, resp.Body.Close())
-
-	return bootstrapAdminResponse{
-		t:          t,
-		StatusCode: resp.StatusCode,
-		Body:       string(rBody),
-		Header:     resp.Header,
-	}
 }

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -139,7 +139,7 @@ func (h *handler) updateChangesOptionsFromQuery(feed *string, options *db.Change
 			"heartbeat",
 			kDefaultHeartbeatMS,
 			kMinHeartbeatMS,
-			uint64(h.server.config.Replicator.MaxHeartbeat.Value().Milliseconds()),
+			uint64(h.server.Config.Replicator.MaxHeartbeat.Value().Milliseconds()),
 			true,
 		)
 	}
@@ -205,7 +205,7 @@ func (h *handler) handleChanges() error {
 			"heartbeat",
 			kDefaultHeartbeatMS,
 			kMinHeartbeatMS,
-			uint64(h.server.config.Replicator.MaxHeartbeat.Value().Milliseconds()),
+			uint64(h.server.Config.Replicator.MaxHeartbeat.Value().Milliseconds()),
 			true,
 		)
 		options.TimeoutMs = base.GetRestrictedIntQuery(
@@ -601,7 +601,7 @@ func (h *handler) readChangesOptionsFromJSON(jsonData []byte) (feed string, opti
 		input.HeartbeatMs,
 		kDefaultHeartbeatMS,
 		kMinHeartbeatMS,
-		uint64(h.server.config.Replicator.MaxHeartbeat.Value().Milliseconds()),
+		uint64(h.server.Config.Replicator.MaxHeartbeat.Value().Milliseconds()),
 		true,
 	)
 

--- a/rest/changesttest/main_test.go
+++ b/rest/changesttest/main_test.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2020-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package changestest
+
+import (
+	"testing"
+
+	"github.com/couchbase/sync_gateway/db"
+)
+
+func TestMain(m *testing.M) {
+	memWatermarkThresholdMB := uint64(2048)
+	db.TestBucketPoolWithIndexes(m, memWatermarkThresholdMB)
+}

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -323,7 +323,7 @@ func TestLegacyGuestUserMigration(t *testing.T) {
 	sc, _, _, _, err := automaticConfigUpgrade(configPath)
 	require.NoError(t, err)
 
-	cluster, err := createCouchbaseClusterFromStartupConfig(sc)
+	cluster, err := CreateCouchbaseClusterFromStartupConfig(sc)
 	require.NoError(t, err)
 
 	var dbConfig DbConfig

--- a/rest/facebook.go
+++ b/rest/facebook.go
@@ -28,7 +28,7 @@ func (h *handler) handleFacebookPOST() error {
 	// CORS not allowed for login #115 #762
 	originHeader := h.rq.Header["Origin"]
 	if len(originHeader) > 0 {
-		matched := matchedOrigin(h.server.config.API.CORS.LoginOrigin, originHeader)
+		matched := matchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
 		if matched == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
 		}
@@ -46,7 +46,7 @@ func (h *handler) handleFacebookPOST() error {
 		return err
 	}
 
-	createUserIfNeeded := h.server.config.DeprecatedConfig.Facebook.Register
+	createUserIfNeeded := h.server.Config.DeprecatedConfig.Facebook.Register
 	return h.makeSessionFromNameAndEmail(facebookResponse.Id, facebookResponse.Email, createUserIfNeeded)
 
 }

--- a/rest/google.go
+++ b/rest/google.go
@@ -30,7 +30,7 @@ func (h *handler) handleGooglePOST() error {
 	// CORS not allowed for login #115 #762
 	originHeader := h.rq.Header["Origin"]
 	if len(originHeader) > 0 {
-		matched := matchedOrigin(h.server.config.API.CORS.LoginOrigin, originHeader)
+		matched := matchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
 		if matched == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
 		}
@@ -46,12 +46,12 @@ func (h *handler) handleGooglePOST() error {
 	}
 
 	// validate the google id token
-	googleResponse, err := verifyGoogle(params.IDToken, h.server.config.DeprecatedConfig.Google.AppClientID)
+	googleResponse, err := verifyGoogle(params.IDToken, h.server.Config.DeprecatedConfig.Google.AppClientID)
 	if err != nil {
 		return err
 	}
 
-	createUserIfNeeded := h.server.config.DeprecatedConfig.Google.Register
+	createUserIfNeeded := h.server.Config.DeprecatedConfig.Google.Register
 	return h.makeSessionFromNameAndEmail(googleResponse.UserID, googleResponse.Email, createUserIfNeeded)
 }
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -216,7 +216,7 @@ func parseKeyspace(ks string) (db string, scope, collection *string, err error) 
 // Top-level handler call. It's passed a pointer to the specific method to run.
 func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, responsePermissions []Permission) error {
 	var err error
-	if h.server.config.API.CompressResponses == nil || *h.server.config.API.CompressResponses {
+	if h.server.Config.API.CompressResponses == nil || *h.server.Config.API.CompressResponses {
 		if encoded := NewEncodedResponseWriter(h.response, h.rq); encoded != nil {
 			h.response = encoded
 			defer encoded.Close()
@@ -250,7 +250,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 
 	// If an Admin Request and admin auth enabled or a metrics request with metrics auth enabled we need to check the
 	// user credentials
-	shouldCheckAdminAuth := (h.privs == adminPrivs && *h.server.config.API.AdminInterfaceAuthentication) || (h.privs == metricsPrivs && *h.server.config.API.MetricsInterfaceAuthentication)
+	shouldCheckAdminAuth := (h.privs == adminPrivs && *h.server.Config.API.AdminInterfaceAuthentication) || (h.privs == metricsPrivs && *h.server.Config.API.MetricsInterfaceAuthentication)
 
 	keyspaceDb := h.PathVar("db")
 	var keyspaceScope, keyspaceCollection *string
@@ -376,7 +376,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 	if shouldCheckAdminAuth {
 		// If server is walrus but auth is enabled we should just kick the user out as invalid as we have nothing to
 		// validate credentials against
-		if base.ServerIsWalrus(h.server.config.Bootstrap.Server) {
+		if base.ServerIsWalrus(h.server.Config.Bootstrap.Server) {
 			return base.HTTPErrorf(http.StatusUnauthorized, "Authorization not possible with Walrus server. "+
 				"Either use Couchbase Server or disable admin auth by setting api.admin_interface_authentication and api.metrics_interface_authentication to false.")
 		}
@@ -423,7 +423,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 		}
 
 		permissions, statusCode, err := checkAdminAuth(authScope, username, password, h.rq.Method, httpClient,
-			managementEndpoints, *h.server.config.API.EnableAdminAuthenticationPermissionsCheck, accessPermissions,
+			managementEndpoints, *h.server.Config.API.EnableAdminAuthenticationPermissionsCheck, accessPermissions,
 			responsePermissions)
 		if err != nil {
 			base.WarnfCtx(h.ctx(), "An error occurred whilst checking whether a user was authorized: %v", err)
@@ -1088,7 +1088,7 @@ func (h *handler) writeJSONStatus(status int, value interface{}) {
 		h.writeStatus(http.StatusInternalServerError, "JSON serialization failed")
 		return
 	}
-	if base.BoolDefault(h.server.config.API.Pretty, false) {
+	if base.BoolDefault(h.server.Config.API.Pretty, false) {
 		var buffer bytes.Buffer
 		_ = json.Indent(&buffer, jsonOut, "", "  ")
 		jsonOut = append(buffer.Bytes(), '\n')
@@ -1351,7 +1351,7 @@ func (h *handler) formatSerialNumber() string {
 // shouldShowProductVersion returns whether the handler should show detailed product info (version).
 // Admin requests can always see this, regardless of the HideProductVersion setting.
 func (h *handler) shouldShowProductVersion() bool {
-	hideProductVersion := base.BoolDefault(h.server.config.API.HideProductVersion, false)
+	hideProductVersion := base.BoolDefault(h.server.Config.API.HideProductVersion, false)
 	return h.privs == adminPrivs || !hideProductVersion
 }
 

--- a/rest/handler_config_database.go
+++ b/rest/handler_config_database.go
@@ -17,7 +17,7 @@ import (
 // Returns the current database config object for this request
 func (h *handler) getDBConfig() (config *DbConfig, etagVersion string, err error) {
 	h.assertAdminOnly()
-	if h.server.bootstrapContext.connection == nil {
+	if h.server.BootstrapContext.Connection == nil {
 		if dbConfig := h.server.GetDatabaseConfig(h.db.Name); dbConfig != nil {
 			etagVersion = dbConfig.Version
 			if etagVersion == "" {
@@ -47,8 +47,8 @@ func (h *handler) mutateDbConfig(mutator func(*DbConfig) error) error {
 		// Update persistently-stored config:
 		bucket := h.db.Bucket.GetName()
 		var updatedDbConfig *DatabaseConfig
-		cas, err := h.server.bootstrapContext.connection.UpdateConfig(
-			bucket, h.server.config.Bootstrap.ConfigGroupID,
+		cas, err := h.server.BootstrapContext.Connection.UpdateConfig(
+			bucket, h.server.Config.Bootstrap.ConfigGroupID,
 			func(rawBucketConfig []byte) (newConfig []byte, err error) {
 				var bucketDbConfig DatabaseConfig
 				if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {
@@ -81,9 +81,9 @@ func (h *handler) mutateDbConfig(mutator func(*DbConfig) error) error {
 		}
 		updatedDbConfig.cas = cas
 
-		dbCreds := h.server.config.DatabaseCredentials[dbName]
-		bucketCreds := h.server.config.BucketCredentials[bucket]
-		if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds, bucketCreds, h.server.config.IsServerless()); err != nil {
+		dbCreds := h.server.Config.DatabaseCredentials[dbName]
+		bucketCreds := h.server.Config.BucketCredentials[bucket]
+		if err := updatedDbConfig.setup(dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
 			return err
 		}
 

--- a/rest/importtest/main_test.go
+++ b/rest/importtest/main_test.go
@@ -8,7 +8,7 @@ be governed by the Apache License, Version 2.0, included in the file
 licenses/APL2.txt.
 */
 
-package attachmentcompactiontest
+package importtest
 
 import (
 	"testing"

--- a/rest/main.go
+++ b/rest/main.go
@@ -144,7 +144,7 @@ func serverMainPersistentConfig(ctx context.Context, fs *flag.FlagSet, flagStart
 
 	svrctx.addLegacyPrincipals(ctx, legacyDbUsers, legacyDbRoles)
 
-	return false, startServer(ctx, &sc, svrctx)
+	return false, StartServer(ctx, &sc, svrctx)
 }
 
 func getInitialStartupConfig(fileStartupConfig *StartupConfig, flagStartupConfig *StartupConfig) (*StartupConfig, error) {
@@ -198,7 +198,7 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 	}
 
 	// Attempt to establish connection to server
-	cluster, err := createCouchbaseClusterFromStartupConfig(startupConfig)
+	cluster, err := CreateCouchbaseClusterFromStartupConfig(startupConfig)
 	if err != nil {
 		return nil, false, nil, nil, err
 	}
@@ -357,7 +357,7 @@ func backupCurrentConfigFile(sourcePath string) (string, error) {
 	return backupPath, nil
 }
 
-func createCouchbaseClusterFromStartupConfig(config *StartupConfig) (*base.CouchbaseCluster, error) {
+func CreateCouchbaseClusterFromStartupConfig(config *StartupConfig) (*base.CouchbaseCluster, error) {
 	cluster, err := base.NewCouchbaseCluster(config.Bootstrap.Server, config.Bootstrap.Username, config.Bootstrap.Password,
 		config.Bootstrap.X509CertPath, config.Bootstrap.X509KeyPath, config.Bootstrap.CACertPath,
 		config.IsServerless(), config.BucketCredentials, config.Bootstrap.ServerTLSSkipVerify)

--- a/rest/main_legacy.go
+++ b/rest/main_legacy.go
@@ -60,7 +60,7 @@ func legacyServerMain(ctx context.Context, osArgs []string, flagStartupConfig *S
 		return err
 	}
 
-	return startServer(ctx, &sc, svrctx)
+	return StartServer(ctx, &sc, svrctx)
 }
 
 type legacyConfigFlag struct {

--- a/rest/replication_api_no_race_test.go
+++ b/rest/replication_api_no_race_test.go
@@ -94,7 +94,7 @@ func TestPushReplicationAPIUpdateDatabase(t *testing.T) {
 	require.True(t, ok)
 
 	// wait for the last document written to rt1 to arrive at rt2
-	waitAndAssertCondition(t, func() bool {
+	WaitAndAssertCondition(t, func() bool {
 		_, err := rt2.GetDatabase().GetDocument(base.TestCtx(t), lastDocIDString, db.DocUnmarshalNone)
 		return err == nil
 	})

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -79,11 +79,11 @@ func createCommonRouter(sc *ServerContext, privs handlerPrivs) (root, db, keyspa
 	// These have public privileges so that they can be called without being logged in already
 	dbr.Handle("/_session", makeHandler(sc, publicPrivs, nil, nil, (*handler).handleSessionGET)).Methods("GET", "HEAD")
 
-	if sc.config.DeprecatedConfig != nil {
-		if sc.config.DeprecatedConfig.Facebook != nil {
+	if sc.Config.DeprecatedConfig != nil {
+		if sc.Config.DeprecatedConfig.Facebook != nil {
 			dbr.Handle("/_facebook", makeHandler(sc, publicPrivs, nil, nil, (*handler).handleFacebookPOST)).Methods("POST")
 		}
-		if sc.config.DeprecatedConfig.Google != nil {
+		if sc.Config.DeprecatedConfig.Google != nil {
 			dbr.Handle("/_google", makeHandler(sc, publicPrivs, nil, nil, (*handler).handleGooglePOST)).Methods("POST")
 		}
 	}
@@ -110,7 +110,7 @@ func createCommonRouter(sc *ServerContext, privs handlerPrivs) (root, db, keyspa
 	dbr.Handle("/_blipsync", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handleBLIPSync)).Methods("GET")
 
 	// User queries & functions
-	if sc.config.Unsupported.UserQueries != nil && *sc.config.Unsupported.UserQueries {
+	if sc.Config.Unsupported.UserQueries != nil && *sc.Config.Unsupported.UserQueries {
 		dbr.Handle("/_function/{name}", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleUserFunction)).Methods("GET", "POST")
 		dbr.Handle("/_graphql", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleGraphQL)).Methods("GET")
 		dbr.Handle("/_graphql", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handleGraphQL)).Methods("POST")
@@ -303,7 +303,7 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handlePostUpgrade)).Methods("POST")
 
 	// User query config APIs:
-	if sc.config.Unsupported.UserQueries != nil && *sc.config.Unsupported.UserQueries {
+	if sc.Config.Unsupported.UserQueries != nil && *sc.Config.Unsupported.UserQueries {
 		dbr.Handle("/_config/functions",
 			makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetDbConfigFunctions)).Methods("GET")
 		dbr.Handle("/_config/functions/{function}",
@@ -369,11 +369,11 @@ func wrapRouter(sc *ServerContext, privs handlerPrivs, router *mux.Router) http.
 
 		// Inject CORS if enabled and requested and not admin port
 		originHeader := rq.Header["Origin"]
-		if privs != adminPrivs && sc.config.API.CORS != nil && len(originHeader) > 0 {
-			origin := matchedOrigin(sc.config.API.CORS.Origin, originHeader)
+		if privs != adminPrivs && sc.Config.API.CORS != nil && len(originHeader) > 0 {
+			origin := matchedOrigin(sc.Config.API.CORS.Origin, originHeader)
 			response.Header().Add("Access-Control-Allow-Origin", origin)
 			response.Header().Add("Access-Control-Allow-Credentials", "true")
-			response.Header().Add("Access-Control-Allow-Headers", strings.Join(sc.config.API.CORS.Headers, ", "))
+			response.Header().Add("Access-Control-Allow-Headers", strings.Join(sc.Config.API.CORS.Headers, ", "))
 		}
 
 		if router.Match(rq, &match) {
@@ -394,8 +394,8 @@ func wrapRouter(sc *ServerContext, privs handlerPrivs, router *mux.Router) http.
 				h.writeStatus(http.StatusNotFound, "unknown URL")
 			} else {
 				response.Header().Add("Allow", strings.Join(options, ", "))
-				if privs != adminPrivs && sc.config.API.CORS != nil && len(originHeader) > 0 {
-					response.Header().Add("Access-Control-Max-Age", strconv.Itoa(sc.config.API.CORS.MaxAge))
+				if privs != adminPrivs && sc.Config.API.CORS != nil && len(originHeader) > 0 {
+					response.Header().Add("Access-Control-Max-Age", strconv.Itoa(sc.Config.API.CORS.MaxAge))
 					response.Header().Add("Access-Control-Allow-Methods", strings.Join(options, ", "))
 				}
 				if rq.Method != "OPTIONS" {

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -362,7 +362,7 @@ func TestStartAndStopHTTPServers(t *testing.T) {
 
 	serveErr := make(chan error, 0)
 	go func() {
-		serveErr <- startServer(ctx, &config, sc)
+		serveErr <- StartServer(ctx, &config, sc)
 	}()
 
 	defer func() {

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -33,11 +33,11 @@ func TestServerlessPollBuckets(t *testing.T) {
 	ctx := rt.Context()
 
 	// Blank out all per-bucket creds
-	perBucketCreds := sc.config.BucketCredentials
+	perBucketCreds := sc.Config.BucketCredentials
 	rt.ReplacePerBucketCredentials(map[string]*base.CredentialsConfig{})
 
 	// Confirm fetch does not return any configs due to no databases existing
-	configs, err := sc.fetchConfigs(ctx, false)
+	configs, err := sc.FetchConfigs(ctx, false)
 	require.NoError(t, err)
 	assert.Empty(t, configs)
 
@@ -53,7 +53,7 @@ func TestServerlessPollBuckets(t *testing.T) {
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// Confirm fetch does not return any configs due to no databases in the bucket credentials config
-	configs, err = sc.fetchConfigs(ctx, false)
+	configs, err = sc.FetchConfigs(ctx, false)
 	require.NoError(t, err)
 	assert.Empty(t, configs)
 
@@ -61,7 +61,7 @@ func TestServerlessPollBuckets(t *testing.T) {
 	rt.ReplacePerBucketCredentials(perBucketCreds)
 
 	// Confirm fetch does return config for db in tb1
-	configs, err = sc.fetchConfigs(ctx, false)
+	configs, err = sc.FetchConfigs(ctx, false)
 	require.NoError(t, err)
 	require.Len(t, configs, 1)
 	assert.NotNil(t, configs["db"])
@@ -71,7 +71,7 @@ func TestServerlessPollBuckets(t *testing.T) {
 
 	// Confirm fetch does not return any configs due to db being known about already (so existing db does not get polled)
 	// TODO: Enable as part of CBG-2280
-	//configs, err = sc.fetchConfigs(false)
+	//configs, err = sc.FetchConfigs(false)
 	//require.NoError(t, err)
 	//assert.Empty(t, configs)
 	//count, err = sc.fetchAndLoadConfigs(false)

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -40,8 +40,8 @@ func (h *handler) handleSessionPOST() error {
 	originHeader := h.rq.Header["Origin"]
 	if len(originHeader) > 0 {
 		matched := ""
-		if h.server.config.API.CORS != nil {
-			matched = matchedOrigin(h.server.config.API.CORS.LoginOrigin, originHeader)
+		if h.server.Config.API.CORS != nil {
+			matched = matchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
 		}
 		if matched == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
@@ -96,8 +96,8 @@ func (h *handler) handleSessionDELETE() error {
 	originHeader := h.rq.Header["Origin"]
 	if len(originHeader) > 0 {
 		matched := ""
-		if h.server.config.API.CORS != nil {
-			matched = matchedOrigin(h.server.config.API.CORS.LoginOrigin, originHeader)
+		if h.server.Config.API.CORS != nil {
+			matched = matchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
 		}
 		if matched == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")

--- a/rest/utilities_testing_attachment.go
+++ b/rest/utilities_testing_attachment.go
@@ -1,0 +1,73 @@
+package rest
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func (rt *RestTester) WaitForAttachmentCompactionStatus(t *testing.T, state db.BackgroundProcessState) db.AttachmentManagerResponse {
+	var response db.AttachmentManagerResponse
+	err := rt.WaitForConditionWithOptions(func() bool {
+		resp := rt.SendAdminRequest("GET", "/db/_compact?type=attachment", "")
+		RequireStatus(t, resp, http.StatusOK)
+
+		err := base.JSONUnmarshal(resp.BodyBytes(), &response)
+		assert.NoError(t, err)
+
+		return response.State == state
+	}, 90, 1000)
+	assert.NoError(t, err)
+
+	return response
+}
+
+func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, testDB *db.Database, docID string, body []byte, attID string, attBody []byte) string {
+	if !base.TestUseXattrs() {
+		t.Skip("Requires xattrs")
+	}
+
+	attDigest := db.Sha1DigestKey(attBody)
+
+	attDocID := db.MakeAttachmentKey(db.AttVersion1, docID, attDigest)
+	_, err := testDB.Bucket.AddRaw(attDocID, 0, attBody)
+	require.NoError(t, err)
+
+	var unmarshalledBody db.Body
+	err = base.JSONUnmarshal(body, &unmarshalledBody)
+	require.NoError(t, err)
+
+	_, _, err = testDB.Put(ctx, docID, unmarshalledBody)
+	require.NoError(t, err)
+
+	_, err = testDB.Bucket.WriteUpdateWithXattr(docID, base.SyncXattrName, "", 0, nil, nil, func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, err error) {
+		attachmentSyncData := map[string]interface{}{
+			attID: map[string]interface{}{
+				"content_type": "application/json",
+				"digest":       attDigest,
+				"length":       2,
+				"revpos":       2,
+				"stub":         true,
+			},
+		}
+
+		attachmentSyncDataBytes, err := base.JSONMarshal(attachmentSyncData)
+		require.NoError(t, err)
+
+		xattr, err = base.InjectJSONPropertiesFromBytes(xattr, base.KVPairBytes{
+			Key: "attachments",
+			Val: attachmentSyncDataBytes,
+		})
+		require.NoError(t, err)
+
+		return doc, xattr, false, nil, nil
+	})
+	require.NoError(t, err)
+
+	return attDocID
+}

--- a/rest/utilities_testing_bootstrap.go
+++ b/rest/utilities_testing_bootstrap.go
@@ -1,0 +1,114 @@
+package rest
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// offset for standard port numbers to avoid conflicts 4984 -> 14984
+	BootstrapTestPortOffset = 10000
+)
+
+func BootstrapStartupConfigForTest(t *testing.T) StartupConfig {
+	config := DefaultStartupConfig("")
+
+	config.Logging.Console = &base.ConsoleLoggerConfig{
+		LogLevel: base.ConsoleLogLevel(),
+		LogKeys:  base.ConsoleLogKey().EnabledLogKeys(),
+	}
+
+	config.API.AdminInterfaceAuthentication = base.BoolPtr(false)
+
+	config.API.PublicInterface = "127.0.0.1:" + strconv.FormatInt(4984+BootstrapTestPortOffset, 10)
+	config.API.AdminInterface = "127.0.0.1:" + strconv.FormatInt(4985+BootstrapTestPortOffset, 10)
+	config.API.MetricsInterface = "127.0.0.1:" + strconv.FormatInt(4986+BootstrapTestPortOffset, 10)
+
+	config.Bootstrap.Server = base.UnitTestUrl()
+	config.Bootstrap.Username = base.TestClusterUsername()
+	config.Bootstrap.Password = base.TestClusterPassword()
+	config.Bootstrap.ServerTLSSkipVerify = base.BoolPtr(base.TestTLSSkipVerify())
+	config.Bootstrap.UseTLSServer = base.BoolPtr(base.ServerIsTLS(base.UnitTestUrl()))
+
+	// avoid loading existing configs by choosing a non-default config group
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("EE-ONLY: Skipping test %s due to requiring non-default Config Group ID", t.Name())
+	}
+	config.Bootstrap.ConfigGroupID = t.Name()
+
+	return config
+}
+
+const (
+	publicPort  = 4984
+	adminPort   = 4985
+	metricsPort = 4986
+)
+
+func bootstrapURL(basePort int) string {
+	return "http://localhost:" + strconv.Itoa(basePort+BootstrapTestPortOffset)
+}
+
+type bootstrapAdminResponse struct {
+	StatusCode int
+	Body       string
+	Header     http.Header
+	t          *testing.T
+}
+
+func (r *bootstrapAdminResponse) RequireStatus(status int) {
+	require.Equal(r.t, status, r.StatusCode, "unexpected status code - body: %s", r.Body)
+}
+
+func (r *bootstrapAdminResponse) RequireResponse(status int, body string) {
+	require.Equal(r.t, status, r.StatusCode, "unexpected status code - body: %s", r.Body)
+	require.Equal(r.t, body, r.Body, "unexpected body")
+}
+
+func BootstrapAdminRequest(t *testing.T, method, path, body string) bootstrapAdminResponse {
+	return doBootstrapAdminRequest(t, method, "", path, body, nil)
+}
+
+func BootstrapAdminRequestCustomHost(t *testing.T, method, host, path, body string) bootstrapAdminResponse {
+	return doBootstrapAdminRequest(t, method, host, path, body, nil)
+}
+
+func BootstrapAdminRequestWithHeaders(t *testing.T, method, path, body string, headers map[string]string) bootstrapAdminResponse {
+	return doBootstrapAdminRequest(t, method, "", path, body, headers)
+}
+
+func doBootstrapAdminRequest(t *testing.T, method, host, path, body string, headers map[string]string) bootstrapAdminResponse {
+	if host == "" {
+		host = "http://localhost:" + strconv.FormatInt(4985+BootstrapTestPortOffset, 10)
+	}
+	url := host + path
+
+	buf := bytes.NewBufferString(body)
+	req, err := http.NewRequest(method, url, buf)
+	require.NoError(t, err)
+
+	for headerName, headerVal := range headers {
+		req.Header.Set(headerName, headerVal)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	rBody, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	require.NoError(t, resp.Body.Close())
+
+	return bootstrapAdminResponse{
+		t:          t,
+		StatusCode: resp.StatusCode,
+		Body:       string(rBody),
+		Header:     resp.Header,
+	}
+}

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -1,0 +1,100 @@
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func (rt *RestTester) GetDoc(docID string) (body db.Body) {
+	rawResponse := rt.SendAdminRequest("GET", "/db/"+docID, "")
+	RequireStatus(rt.tb, rawResponse, 200)
+	require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &body))
+	return body
+}
+
+func (rt *RestTester) CreateDoc(t *testing.T, docid string) string {
+	response := rt.SendAdminRequest("PUT", "/db/"+docid, `{"prop":true}`)
+	RequireStatus(t, response, 201)
+	var body db.Body
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
+	assert.Equal(t, true, body["ok"])
+	revid := body["rev"].(string)
+	if revid == "" {
+		t.Fatalf("No revid in response for PUT doc")
+	}
+	return revid
+}
+
+func (rt *RestTester) WaitForRev(docID string, revID string) error {
+	return rt.WaitForCondition(func() bool {
+		rawResponse := rt.SendAdminRequest("GET", "/db/"+docID, "")
+		if rawResponse.Code != 200 && rawResponse.Code != 201 {
+			return false
+		}
+		var body db.Body
+		require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &body))
+		return body.ExtractRev() == revID
+	})
+}
+
+// createReplication creates a replication via the REST API with the specified ID, remoteURL, direction and channel filter
+func (rt *RestTester) createReplication(replicationID string, remoteURLString string, direction db.ActiveReplicatorDirection, channels []string, continuous bool, conflictResolver db.ConflictResolverType) {
+	replicationConfig := &db.ReplicationConfig{
+		ID:                     replicationID,
+		Direction:              direction,
+		Remote:                 remoteURLString,
+		Continuous:             continuous,
+		ConflictResolutionType: conflictResolver,
+	}
+	if len(channels) > 0 {
+		replicationConfig.Filter = base.ByChannelFilter
+		replicationConfig.QueryParams = map[string]interface{}{"channels": channels}
+	}
+	payload, err := json.Marshal(replicationConfig)
+	require.NoError(rt.tb, err)
+	resp := rt.SendAdminRequest(http.MethodPost, "/db/_replication/", string(payload))
+	RequireStatus(rt.tb, resp, http.StatusCreated)
+}
+
+func (rt *RestTester) waitForAssignedReplications(count int) {
+	successFunc := func() bool {
+		replicationStatuses := rt.GetReplicationStatuses("?localOnly=true")
+		return len(replicationStatuses) == count
+	}
+	require.NoError(rt.tb, rt.WaitForCondition(successFunc))
+}
+
+func (rt *RestTester) WaitForReplicationStatus(replicationID string, targetStatus string) {
+	successFunc := func() bool {
+		status := rt.GetReplicationStatus(replicationID)
+		return status.Status == targetStatus
+	}
+	require.NoError(rt.tb, rt.WaitForCondition(successFunc))
+}
+
+func (rt *RestTester) GetReplications() (replications map[string]db.ReplicationCfg) {
+	rawResponse := rt.SendAdminRequest("GET", "/db/_replication/", "")
+	RequireStatus(rt.tb, rawResponse, 200)
+	require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &replications))
+	return replications
+}
+
+func (rt *RestTester) GetReplicationStatus(replicationID string) (status db.ReplicationStatus) {
+	rawResponse := rt.SendAdminRequest("GET", "/db/_replicationStatus/"+replicationID, "")
+	RequireStatus(rt.tb, rawResponse, 200)
+	require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &status))
+	return status
+}
+
+func (rt *RestTester) GetReplicationStatuses(queryString string) (statuses []db.ReplicationStatus) {
+	rawResponse := rt.SendAdminRequest("GET", "/db/_replicationStatus/"+queryString, "")
+	RequireStatus(rt.tb, rawResponse, 200)
+	require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &statuses))
+	return statuses
+}

--- a/rest/utilities_testing_user.go
+++ b/rest/utilities_testing_user.go
@@ -1,0 +1,68 @@
+package rest
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func MakeUser(t *testing.T, httpClient *http.Client, serverURL, username, password string, roles []string) {
+	form := url.Values{}
+	form.Add("password", password)
+	form.Add("roles", strings.Join(roles, ","))
+
+	retryWorker := func() (shouldRetry bool, err error, value interface{}) {
+		req, err := http.NewRequest("PUT", fmt.Sprintf("%s/settings/rbac/users/local/%s", serverURL, username), strings.NewReader(form.Encode()))
+		require.NoError(t, err)
+
+		req.SetBasicAuth(base.TestClusterUsername(), base.TestClusterPassword())
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return true, err, resp
+		}
+		return false, err, resp
+	}
+
+	err, resp := base.RetryLoop("Admin Auth testing MakeUser", retryWorker, base.CreateSleeperFunc(10, 100))
+	require.NoError(t, err)
+
+	if resp.(*http.Response).StatusCode != http.StatusOK {
+		bodyResp, err := ioutil.ReadAll(resp.(*http.Response).Body)
+		assert.NoError(t, err)
+		fmt.Println(string(bodyResp))
+	}
+	require.Equal(t, http.StatusOK, resp.(*http.Response).StatusCode)
+
+	require.NoError(t, resp.(*http.Response).Body.Close(), "Error closing response body")
+}
+
+func DeleteUser(t *testing.T, httpClient *http.Client, serverURL, username string) {
+	retryWorker := func() (shouldRetry bool, err error, value interface{}) {
+		req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/settings/rbac/users/local/%s", serverURL, username), nil)
+		require.NoError(t, err)
+
+		req.SetBasicAuth(base.TestClusterUsername(), base.TestClusterPassword())
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return true, err, resp
+		}
+		return false, err, resp
+	}
+
+	err, resp := base.RetryLoop("Admin Auth testing DeleteUser", retryWorker, base.CreateSleeperFunc(10, 100))
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, resp.(*http.Response).StatusCode)
+
+	require.NoError(t, resp.(*http.Response).Body.Close(), "Error closing response body")
+}


### PR DESCRIPTION
CBG-2400

- Created two new packages in rest/attachmentcompactiontest and adminapitest.
- Moved test code that was in test only parts of rest to utility packages `rest/utilities_testing_*.go`

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/835/