### PR TITLE
CBG-2423 Avoid bucketLock contention on DatabaseContext.Close

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -694,8 +694,6 @@ func (context *DatabaseContext) GetChangeCache() *changeCache {
 }
 
 func (context *DatabaseContext) Close(ctx context.Context) {
-	context.BucketLock.Lock()
-	defer context.BucketLock.Unlock()
 
 	context.OIDCProviders.Stop()
 	close(context.terminator)
@@ -711,6 +709,8 @@ func (context *DatabaseContext) Close(ctx context.Context) {
 	if context.SGReplicateMgr != nil {
 		context.SGReplicateMgr.Stop()
 	}
+	context.BucketLock.Lock()
+	defer context.BucketLock.Unlock()
 	context.Bucket.Close()
 	context.Bucket = nil
 


### PR DESCRIPTION
Move BucketLock.Lock until after SGReplicateMgr.Stop() to avoid scenario where replication changes processing is blocked trying to acquire bucketLock.RLock (via database.IsClosed).

CBG-2423

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/837/