### PR TITLE
CBG-2313, CBG-2364: DCPClient sequence handling improvements

### DIFF
--- a/base/dcp_client_metadata.go
+++ b/base/dcp_client_metadata.go
@@ -36,9 +36,6 @@ type DCPMetadataStore interface {
 	// GetMeta retrieves DCPMetadata for a vbucket
 	GetMeta(vbID uint16) DCPMetadata
 
-	// SetEndSeqNos sets the end sequence numbers for all specified vbuckets
-	SetEndSeqNos(map[uint16]uint64)
-
 	// SetSnapshot updates the metadata based on a DCP snapshotEvent
 	SetSnapshot(e snapshotEvent)
 
@@ -57,14 +54,12 @@ type DCPMetadataStore interface {
 }
 
 type DCPMetadataMem struct {
-	metadata  []DCPMetadata
-	endSeqNos []gocbcore.SeqNo
+	metadata []DCPMetadata
 }
 
 func NewDCPMetadataMem(numVbuckets uint16) *DCPMetadataMem {
 	m := &DCPMetadataMem{
-		metadata:  make([]DCPMetadata, numVbuckets),
-		endSeqNos: make([]gocbcore.SeqNo, numVbuckets),
+		metadata: make([]DCPMetadata, numVbuckets),
 	}
 	for vbNo := uint16(0); vbNo < numVbuckets; vbNo++ {
 		m.metadata[vbNo] = DCPMetadata{
@@ -80,7 +75,6 @@ func (m *DCPMetadataMem) Rollback(vbID uint16) {
 	m.metadata[vbID] = DCPMetadata{
 		VbUUID:          0,
 		StartSeqNo:      0,
-		EndSeqNo:        m.endSeqNos[vbID],
 		SnapStartSeqNo:  0,
 		SnapEndSeqNo:    0,
 		FailoverEntries: make([]gocbcore.FailoverEntry, 0),
@@ -107,16 +101,6 @@ func (m *DCPMetadataMem) UpdateSeq(vbID uint16, seq uint64) {
 func (m *DCPMetadataMem) SetFailoverEntries(vbID uint16, fe []gocbcore.FailoverEntry) {
 	m.metadata[vbID].FailoverEntries = fe
 	m.metadata[vbID].VbUUID = getVbUUID(fe, m.metadata[vbID].StartSeqNo)
-}
-
-// SetEndSeqNos will update the metadata endSeqNos to the values provided.  Vbuckets not
-// present in the endSeqNos map will have their EndSeqNo set to zero.
-func (m *DCPMetadataMem) SetEndSeqNos(endSeqNos map[uint16]uint64) {
-	for i := 0; i < len(m.metadata); i++ {
-		endSeqNo, _ := endSeqNos[uint16(i)]
-		m.metadata[i].EndSeqNo = gocbcore.SeqNo(endSeqNo)
-		m.endSeqNos[i] = gocbcore.SeqNo(endSeqNo)
-	}
 }
 
 // Persist is no-op for in-memory metadata store
@@ -162,7 +146,6 @@ type DCPMetadataCS struct {
 	bucket    Bucket
 	keyPrefix string
 	metadata  []DCPMetadata
-	endSeqNos []gocbcore.SeqNo
 }
 
 func NewDCPMetadataCS(store Bucket, numVbuckets uint16, numWorkers int, keyPrefix string) *DCPMetadataCS {
@@ -171,7 +154,6 @@ func NewDCPMetadataCS(store Bucket, numVbuckets uint16, numWorkers int, keyPrefi
 		bucket:    store,
 		keyPrefix: keyPrefix,
 		metadata:  make([]DCPMetadata, numVbuckets),
-		endSeqNos: make([]gocbcore.SeqNo, numVbuckets),
 	}
 	for vbNo := uint16(0); vbNo < numVbuckets; vbNo++ {
 		m.metadata[vbNo] = DCPMetadata{
@@ -221,15 +203,6 @@ func (m *DCPMetadataCS) UpdateSeq(vbNo uint16, seq uint64) {
 func (m *DCPMetadataCS) SetFailoverEntries(vbID uint16, fe []gocbcore.FailoverEntry) {
 	m.metadata[vbID].FailoverEntries = fe
 	m.metadata[vbID].VbUUID = getVbUUID(fe, m.metadata[vbID].StartSeqNo)
-}
-
-// SetEndSeqNos will update the metadata endSeqNos to the values provided.  Vbuckets not
-// present in the endSeqNos map will have their EndSeqNo set to zero.
-func (m *DCPMetadataCS) SetEndSeqNos(endSeqNos map[uint16]uint64) {
-	for i := 0; i < len(m.metadata); i++ {
-		endSeqNo, _ := endSeqNos[uint16(i)]
-		m.metadata[i].EndSeqNo = gocbcore.SeqNo(endSeqNo)
-	}
 }
 
 // Persist is called by worker.  Triggers persistence of metadata for all listed vbuckets.  This set must be the same

--- a/base/dcp_client_stream_observer.go
+++ b/base/dcp_client_stream_observer.go
@@ -25,9 +25,6 @@ func (dc *DCPClient) SnapshotMarker(snapshotMarker gocbcore.DcpSnapshotMarker) {
 }
 
 func (dc *DCPClient) Mutation(mutation gocbcore.DcpMutation) {
-	if dc.afterEndSeq(mutation.VbID, mutation.SeqNo) {
-		return
-	}
 
 	if dc.filteredKey(mutation.Key) {
 		return
@@ -50,9 +47,6 @@ func (dc *DCPClient) Mutation(mutation gocbcore.DcpMutation) {
 }
 
 func (dc *DCPClient) Deletion(deletion gocbcore.DcpDeletion) {
-	if dc.afterEndSeq(deletion.VbID, deletion.SeqNo) {
-		return
-	}
 
 	if dc.filteredKey(deletion.Key) {
 		return
@@ -127,16 +121,6 @@ func (dc *DCPClient) SeqNoAdvanced(seqNoAdvanced gocbcore.DcpSeqNoAdvanced) {
 		},
 		seq: seqNoAdvanced.SeqNo,
 	})
-}
-
-// A one-shot DCP feed specifies the endSeq when opening the stream, but Couchbase Server only ends the DCP stream
-// when it reaches the end of a snapshot that is greater than or equal to the endSeq value.  DCPClient should not
-// process any sequences in that final snapshot that are greater than endSeq - afterEndSeq provides that additional check.
-func (dc *DCPClient) afterEndSeq(vbID uint16, seq uint64) bool {
-	if len(dc.endSeqNos) > 0 && dc.endSeqNos[vbID] < seq {
-		return true
-	}
-	return false
 }
 
 func (dc *DCPClient) filteredKey(key []byte) bool {

--- a/base/dcp_client_worker.go
+++ b/base/dcp_client_worker.go
@@ -19,7 +19,6 @@ import (
 // works this channel and synchronously invokes the mutationCallback for mutations or deletions.
 type DCPWorker struct {
 	ID                    int
-	endSeqNos             []uint64
 	eventFeed             chan streamEvent
 	terminator            chan bool
 	checkpointPrefixBytes []byte
@@ -63,7 +62,6 @@ func NewDCPWorker(workerID int, metadata DCPMetadataStore, mutationCallback sgbu
 		ID:                    workerID,
 		eventFeed:             eventQueue,
 		terminator:            terminator,
-		endSeqNos:             endSeqNos,
 		checkpointPrefixBytes: []byte(checkpointPrefix),
 		mutationCallback:      mutationCallback,
 		endStreamCallback:     endCallback,


### PR DESCRIPTION
CBG-2313, CBG-2364

- Set the [To Latest flag](https://github.com/couchbase/kv_engine/blob/master/docs/dcp/documentation/commands/add-stream.md) when we start a DCP client, rather than manually setting the end seqnos to the current high seqno which is unreliable
- Remove the high-seqnos storage on metadata - no longer used by the above
- Also remove the "after end seq" check, which relies on the above and could also cause consistency issues (cf. CBG-2364)

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `gsi=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/869/
  - timed out
- [x] `^TestAttachment` https://jenkins.sgwdev.com/job/SyncGateway-Integration/865/
- [x] `^TestDCP` https://jenkins.sgwdev.com/job/SyncGateway-Integration/872/