### PR TITLE
CBG-2421: [3.0.4 Backport] CBG-2047: Upgrade prometheus/client_golang to v1.11.1

### DIFF
--- a/manifest/3.0.xml
+++ b/manifest/3.0.xml
@@ -144,15 +144,15 @@ licenses/APL2.txt.
   <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
 
   <!-- prometheus -->
-  <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c182affec369e30f25d3eb8cd8a478dee585ae7d"/>
-  <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="d3accfda2168b0e253f98cff3ef81586e8b88d9f"/>
-  <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="60555c9708c786597e6b07bf846d0dc5c2a46f54"/>
-  <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="546f1fd8d7df61d94633b254641f9f8f48248ada"/>
-  <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="869cfc74c3b4eea1f80f29819f1dab68ed3c780e"/>
+  <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c12348ce28de40eed0136aa2b644d0ee0650e56c"/>
+  <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="989baa30fe956631907493ccee1f8e7708660d96"/>
+  <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="7bc5445566f0fe75b15de23e6b93886e982d7bf9"/>
+  <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="2af6d036253eee1a9a08c6ddf6be6d67537bcdff"/>
+  <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="f436cbb89ece38bf080d446b3ca27053b305eaac"/>
   <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
-  <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="d7df74196a9e781ede915320c11c378c1b2f3a1f"/>
-  <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="b5d812f8a3706043e23a9cd5babf2e5423744d30"/>
-  <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="1ecb1f411c1f2ce65a2db6ea4a8ae927182d342e"/>
+  <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="e7a6b52374f7e2abfb8abb27249d53a1997b09a7"/>
+  <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="ae97035608a719c7a1c1c41bed0ae0744bdb0c6f"/>
+  <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="f2d1f6cbe10b90d22296ea09a7217081c2798009"/>
 
   <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
 


### PR DESCRIPTION
CBG-2421

Bump prometheus/client_golang and its dependencies.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
n/a