### PR TITLE
CBG-2362: Identify whether SG is running in persistent config mode (or not) via REST API

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2145,3 +2145,45 @@ Status:
         Blank if `api.hide_product_version=true` in the startup configuration.
       type: string
   title: Status
+NodeInfo:
+  type: object
+  properties:
+    ADMIN:
+      description: '`true` if the request is from the Admin API - otherwise omitted.'
+      type: boolean
+      example: true
+    couchdb:
+      description: CouchDB welcome
+      type: string
+      example: Welcome
+    vendor:
+      description: Product vendor
+      type: object
+      properties:
+        name:
+          description: Product name
+          type: string
+          example: Couchbase Sync Gateway
+        version:
+          description: |-
+            API version.
+            Omitted if `api.hide_product_version=true`
+          type: string
+          example: 3.1
+      required:
+        - name
+    version:
+      description: |-
+        Product version, including the build number and edition (i.e. `EE` or `CE`)
+        Omitted if `api.hide_product_version=true`
+      type: string
+      example: Couchbase Sync Gateway/3.1.0(1;a765231) EE
+    PersistentConfig:
+      description: |-
+        Indication for whether sync gateway is running in persistent config mode or legacy config mode.
+        `true` if the sync gateway node is running in persistent config mode.
+      type: boolean
+      example: true
+  required:
+    - couchdb
+    - vendor

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2178,7 +2178,7 @@ NodeInfo:
         Omitted if `api.hide_product_version=true`
       type: string
       example: Couchbase Sync Gateway/3.1.0(1;a765231) EE
-    PersistentConfig:
+    persistent_config:
       description: |-
         Indication for whether sync gateway is running in persistent config mode or legacy config mode.
         `true` if the sync gateway node is running in persistent config mode.

--- a/docs/api/paths/admin/~.yaml
+++ b/docs/api/paths/admin/~.yaml
@@ -7,41 +7,7 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              ADMIN:
-                description: '`true` if the request is from the Admin API - otherwise omitted.'
-                type: boolean
-                example: true
-              couchdb:
-                description: CouchDB welcome
-                type: string
-                example: Welcome
-              vendor:
-                description: Product vendor
-                type: object
-                properties:
-                  name:
-                    description: Product name
-                    type: string
-                    example: Couchbase Sync Gateway
-                  version:
-                    description: |-
-                      API version.
-                      Omitted if `api.hide_product_version=true`
-                    type: string
-                    example: 3.1
-                required:
-                  - name
-              version:
-                description: |-
-                  Product version, including the build number and edition (i.e. `EE` or `CE`)
-                  Omitted if `api.hide_product_version=true`
-                type: string
-                example: Couchbase Sync Gateway/3.1.0(1;a765231) EE
-            required:
-              - couchdb
-              - vendor
+            $ref: ../../components/schemas.yaml#/NodeInfo
   tags:
     - Server
 head:

--- a/docs/api/paths/public/~.yaml
+++ b/docs/api/paths/public/~.yaml
@@ -7,41 +7,7 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              ADMIN:
-                description: '`true` if the request is from the Admin API - otherwise omitted.'
-                type: boolean
-                example: true
-              couchdb:
-                description: CouchDB welcome
-                type: string
-                example: Welcome
-              vendor:
-                description: Product vendor
-                type: object
-                properties:
-                  name:
-                    description: Product name
-                    type: string
-                    example: Couchbase Sync Gateway
-                  version:
-                    description: |-
-                      API version.
-                      Omitted if `api.hide_product_version=true`
-                    type: string
-                    example: 3.1
-                required:
-                  - name
-              version:
-                description: |-
-                  Product version, including the build number and edition (i.e. `EE` or `CE`)
-                  Omitted if `api.hide_product_version=true`
-                type: string
-                example: Couchbase Sync Gateway/3.1.0(1;a765231) EE
-            required:
-              - couchdb
-              - vendor
+            $ref: ../../components/schemas.yaml#/NodeInfo
   tags:
     - Server
 head:

--- a/rest/api.go
+++ b/rest/api.go
@@ -39,7 +39,7 @@ type rootResponse struct {
 	CouchDB          string `json:"couchdb,omitempty"` // TODO: Lithium - remove couchdb welcome
 	Vendor           vendor `json:"vendor,omitempty"`
 	Version          string `json:"version,omitempty"`
-	PersistentConfig bool   `json:"persistentConfig,omitempty"`
+	PersistentConfig bool   `json:"persistent_config,omitempty"`
 }
 
 type vendor struct {

--- a/rest/api.go
+++ b/rest/api.go
@@ -39,7 +39,7 @@ type rootResponse struct {
 	CouchDB          string `json:"couchdb,omitempty"` // TODO: Lithium - remove couchdb welcome
 	Vendor           vendor `json:"vendor,omitempty"`
 	Version          string `json:"version,omitempty"`
-	PersistentConfig bool   `json:"persistent_config,omitempty"`
+	PersistentConfig bool   `json:"persistent_config"`
 }
 
 type vendor struct {

--- a/rest/api.go
+++ b/rest/api.go
@@ -35,10 +35,11 @@ const (
 )
 
 type rootResponse struct {
-	Admin   bool   `json:"ADMIN,omitempty"`
-	CouchDB string `json:"couchdb,omitempty"` // TODO: Lithium - remove couchdb welcome
-	Vendor  vendor `json:"vendor,omitempty"`
-	Version string `json:"version,omitempty"`
+	Admin            bool   `json:"ADMIN,omitempty"`
+	CouchDB          string `json:"couchdb,omitempty"` // TODO: Lithium - remove couchdb welcome
+	Vendor           vendor `json:"vendor,omitempty"`
+	Version          string `json:"version,omitempty"`
+	PersistentConfig bool   `json:"persistentConfig,omitempty"`
 }
 
 type vendor struct {
@@ -54,6 +55,7 @@ func (h *handler) handleRoot() error {
 		Vendor: vendor{
 			Name: base.ProductNameString,
 		},
+		PersistentConfig: h.server.persistentConfig,
 	}
 
 	if h.shouldShowProductVersion() {


### PR DESCRIPTION
CBG-2362

Simple change to root response struct to include persistent cofig boolean to indicate whether it is running in persistent config mode or not. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] N/A