### PR TITLE
CBG-2295: context logging, second batch

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -38,8 +38,8 @@ func canSeeAllChannels(princ Principal, channels base.Set) bool {
 
 func TestValidateGuestUser(t *testing.T) {
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 	user, err := auth.NewUser("", "", nil)
 	assert.True(t, user != nil)
@@ -48,8 +48,8 @@ func TestValidateGuestUser(t *testing.T) {
 
 func TestValidateUser(t *testing.T) {
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 	user, err := auth.NewUser("invalid:name", "", nil)
 	assert.Equal(t, user, (User)(nil))
@@ -64,8 +64,8 @@ func TestValidateUser(t *testing.T) {
 
 func TestValidateRole(t *testing.T) {
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 	role, err := auth.NewRole("invalid:name", nil)
 	assert.Equal(t, (User)(nil), role)
@@ -80,8 +80,8 @@ func TestValidateRole(t *testing.T) {
 
 func TestValidateUserEmail(t *testing.T) {
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 	badEmails := []string{"", "foo", "foo@", "@bar", "foo@bar@buzz"}
 	for _, e := range badEmails {
@@ -98,8 +98,8 @@ func TestValidateUserEmail(t *testing.T) {
 
 func TestUserPasswords(t *testing.T) {
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 	user, _ := auth.NewUser("me", "letmein", nil)
 	assert.True(t, user.Authenticate("letmein"))
@@ -120,8 +120,8 @@ func TestUserPasswords(t *testing.T) {
 
 func TestSerializeUser(t *testing.T) {
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 	user, _ := auth.NewUser("me", "letmein", ch.SetOf(t, "me", "public"))
 	require.NoError(t, user.SetEmail("foo@example.com"))
@@ -141,8 +141,8 @@ func TestSerializeUser(t *testing.T) {
 
 func TestSerializeRole(t *testing.T) {
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 	role, _ := auth.NewRole("froods", ch.SetOf(t, "hoopy", "public"))
 	encoded, _ := base.JSONMarshal(role)
@@ -159,8 +159,8 @@ func TestSerializeRole(t *testing.T) {
 func TestUserAccess(t *testing.T) {
 
 	// User with no access:
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 	user, _ := auth.NewUser("foo", "password", nil)
 	assert.Equal(t, ch.SetOf(t, "!"), user.ExpandWildCardChannel(ch.SetOf(t, "*")))
@@ -230,8 +230,8 @@ func TestUserAccess(t *testing.T) {
 
 func TestGetMissingUser(t *testing.T) {
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 	user, err := auth.GetUser("noSuchUser")
 	assert.Equal(t, nil, err)
@@ -243,8 +243,8 @@ func TestGetMissingUser(t *testing.T) {
 
 func TestGetMissingRole(t *testing.T) {
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 	role, err := auth.GetRole("noSuchRole")
 	assert.Equal(t, nil, err)
@@ -252,8 +252,8 @@ func TestGetMissingRole(t *testing.T) {
 }
 
 func TestGetGuestUser(t *testing.T) {
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 	user, err := auth.GetUser("")
@@ -263,8 +263,8 @@ func TestGetGuestUser(t *testing.T) {
 
 func TestSaveUsers(t *testing.T) {
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 	user, _ := auth.NewUser("testUser", "password", ch.SetOf(t, "test"))
 	err := auth.Save(user)
@@ -277,8 +277,8 @@ func TestSaveUsers(t *testing.T) {
 
 func TestSaveRoles(t *testing.T) {
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 	role, _ := auth.NewRole("testRole", ch.SetOf(t, "test"))
 	err := auth.Save(role)
@@ -316,8 +316,8 @@ func (self *mockComputer) UseGlobalSequence() bool {
 }
 
 func TestRebuildUserChannels(t *testing.T) {
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 	computer := mockComputer{channels: ch.AtSequence(ch.SetOf(t, "derived1", "derived2"), 1)}
 	auth := NewAuthenticator(bucket, &computer, DefaultAuthenticatorOptions())
 	user, _ := auth.NewUser("testUser", "password", ch.SetOf(t, "explicit1"))
@@ -334,8 +334,8 @@ func TestRebuildUserChannels(t *testing.T) {
 
 func TestRebuildRoleChannels(t *testing.T) {
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 	computer := mockComputer{roleChannels: ch.AtSequence(ch.SetOf(t, "derived1", "derived2"), 1)}
 	auth := NewAuthenticator(bucket, &computer, DefaultAuthenticatorOptions())
 	role, err := auth.NewRole("testRole", ch.SetOf(t, "explicit1"))
@@ -353,8 +353,8 @@ func TestRebuildRoleChannels(t *testing.T) {
 
 func TestRebuildChannelsError(t *testing.T) {
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 	computer := mockComputer{}
 	auth := NewAuthenticator(bucket, &computer, DefaultAuthenticatorOptions())
 	role, err := auth.NewRole("testRole2", ch.SetOf(t, "explicit1"))
@@ -373,8 +373,8 @@ func TestRebuildChannelsError(t *testing.T) {
 
 func TestRebuildUserRoles(t *testing.T) {
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 	computer := mockComputer{roles: ch.AtSequence(base.SetOf("role1", "role2"), 3)}
 	auth := NewAuthenticator(bucket, &computer, DefaultAuthenticatorOptions())
 	user, _ := auth.NewUser("testUser", "letmein", nil)
@@ -402,8 +402,8 @@ func TestRebuildUserRoles(t *testing.T) {
 
 func TestRoleInheritance(t *testing.T) {
 	// Create some roles:
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 	role, _ := auth.NewRole("square", ch.SetOf(t, "dull", "duller", "dullest"))
 	assert.Equal(t, nil, auth.Save(role))
@@ -428,8 +428,8 @@ func TestRoleInheritance(t *testing.T) {
 }
 
 func TestRegisterUser(t *testing.T) {
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 
 	// Register user based on name, email
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
@@ -487,8 +487,8 @@ func TestRegisterUser(t *testing.T) {
 
 func TestCASUpdatePrincipal(t *testing.T) {
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 
 	// Create user
 	username := "foo"
@@ -556,8 +556,8 @@ func TestCASUpdatePrincipal(t *testing.T) {
 }
 
 func TestConcurrentUserWrites(t *testing.T) {
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 
 	username := "foo"
 	password := "password"
@@ -673,11 +673,9 @@ func TestConcurrentUserWrites(t *testing.T) {
 
 func TestAuthenticateTrustedJWT(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth, base.KeyAccess, base.KeyHTTP)
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
-
-	ctx := base.TestCtx(t)
 
 	var callbackURLFunc OIDCCallbackURLFunc
 	callbackURL := base.StringPtr("http://comcast:4984/_callback")
@@ -1090,8 +1088,8 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 }
 
 func TestGetPrincipal(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
 	const (
@@ -1160,8 +1158,8 @@ func ToBase64String(key string) string {
 }
 
 func TestAuthenticateUntrustedJWT(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
 	issuerFacebookAccounts := "https://accounts.facebook.com"
@@ -1411,8 +1409,8 @@ func initializeScenario(t *testing.T, auth *Authenticator) (*userImpl, Principal
 //	Role revoke, role channel revoke
 //	 - Changes Request - Seq 110 - Doesn't have channel access, history added for both role and channel
 func TestRevocationScenario1(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	testMockComputer := mockComputerV2{
 		roles:        map[string]ch.TimedSet{},
@@ -1503,8 +1501,8 @@ func TestRevocationScenario1(t *testing.T) {
 //	Role revoke, role channel revoke
 //	 - Changes Request - Seq 110 - Doesn't have channel access, history added for both role and channel
 func TestRevocationScenario2(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	testMockComputer := mockComputerV2{
 		roles:        map[string]ch.TimedSet{},
@@ -1601,8 +1599,8 @@ func TestRevocationScenario2(t *testing.T) {
 //	Role revoke, role channel revoke
 //	  - Changes Request - Seq 110 - Doesn't have channel access, history added for both role and channel
 func TestRevocationScenario3(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	testMockComputer := mockComputerV2{
 		roles:        map[string]ch.TimedSet{},
@@ -1708,8 +1706,8 @@ func TestRevocationScenario3(t *testing.T) {
 //	Role revoke, role channel revoke
 //	  - Changes Request - Seq 110 - Doesn't have channel access, history added for both role and channel
 func TestRevocationScenario4(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	testMockComputer := mockComputerV2{
 		roles:        map[string]ch.TimedSet{},
@@ -1802,8 +1800,8 @@ func TestRevocationScenario4(t *testing.T) {
 //	Revoke role and role channel
 //	  - Changes Request - Seq 110 - Doesn't have channel access, history added for both role and channel
 func TestRevocationScenario5(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	testMockComputer := mockComputerV2{
 		roles:        map[string]ch.TimedSet{},
@@ -1880,8 +1878,8 @@ func TestRevocationScenario5(t *testing.T) {
 //	Revoke role
 //	  - Changes Request - Seq 110 - Doesn't have channel access, history added for role
 func TestRevocationScenario6(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	testMockComputer := mockComputerV2{
 		roles:        map[string]ch.TimedSet{},
@@ -1962,8 +1960,8 @@ func TestRevocationScenario6(t *testing.T) {
 //	No Change
 //	  - Changes Request - Seq 110 - Doesn't have channel access, history retained
 func TestRevocationScenario7(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	testMockComputer := mockComputerV2{
 		roles:        map[string]ch.TimedSet{},
@@ -2041,8 +2039,8 @@ func TestRevocationScenario7(t *testing.T) {
 //	Revoke role channel, re-grant role, re-grant channel, re-revoke channel, re-revoke role
 //	  - Changes Request - Seq 110 - Doesn't have channel 1 access, no history
 func TestRevocationScenario8(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	testMockComputer := mockComputerV2{
 		roles:        map[string]ch.TimedSet{},
@@ -2101,8 +2099,8 @@ func TestRevocationScenario8(t *testing.T) {
 //	Re-grant role, re-grant channel, re-revoke channel, re-revoke role
 //	  - Changes Request - Seq 110 - Doesn't have channel 1 access, no history
 func TestRevocationScenario9(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	testMockComputer := mockComputerV2{
 		roles:        map[string]ch.TimedSet{},
@@ -2158,8 +2156,8 @@ func TestRevocationScenario9(t *testing.T) {
 //	Re-grant channel, re-revoke channel, re-revoke role
 //	  - Changes Request - Seq 110 - Doesn't have channel 1 access, no history
 func TestRevocationScenario10(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	testMockComputer := mockComputerV2{
 		roles:        map[string]ch.TimedSet{},
@@ -2218,8 +2216,8 @@ func TestRevocationScenario10(t *testing.T) {
 //	Revoke channel, revoke role
 //	  - Changes Request - Seq 110 - Doesn't have channel 1 access, adds role and channel history
 func TestRevocationScenario11(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	testMockComputer := mockComputerV2{
 		roles:        map[string]ch.TimedSet{},
@@ -2284,8 +2282,8 @@ func TestRevocationScenario11(t *testing.T) {
 //	Revoke role
 //	  - Changes Request - Seq 110 - Doesn't have channel 1 access, no history
 func TestRevocationScenario12(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	testMockComputer := mockComputerV2{
 		roles:        map[string]ch.TimedSet{},
@@ -2344,8 +2342,8 @@ func TestRevocationScenario12(t *testing.T) {
 //	No changes
 //	  - Changes Request - Seq 110 - Doesn't have channel 1 access, no history
 func TestRevocationScenario13(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	testMockComputer := mockComputerV2{
 		roles:        map[string]ch.TimedSet{},
@@ -2402,8 +2400,8 @@ func TestRevocationScenario13(t *testing.T) {
 //	  - Changes Request Seq 45 since 25. Ensure revocation.
 //	  - Changes Request Seq 45 since 45 same seq as revocation. Ensure no revocation message.
 func TestRevocationScenario14(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	testMockComputer := mockComputerV2{
 		roles:        map[string]ch.TimedSet{},
@@ -2443,8 +2441,8 @@ func TestRevocationScenario14(t *testing.T) {
 }
 
 func TestRoleSoftDelete(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
 	const roleName = "role"
@@ -2556,8 +2554,8 @@ func TestObtainChannelsForDeletedRole(t *testing.T) {
 				roleChannels: map[string]ch.TimedSet{},
 			}
 
-			testBucket := base.GetTestBucket(t)
-			defer testBucket.Close()
+			ctx, testBucket := base.GetTestBucket(t)
+			defer testBucket.Close(ctx)
 			auth := NewAuthenticator(testBucket, testMockComputer, DefaultAuthenticatorOptions())
 
 			const roleName = "role"
@@ -2589,8 +2587,8 @@ func TestObtainChannelsForDeletedRole(t *testing.T) {
 }
 
 func TestInvalidateRoles(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	leakyBucket := base.NewLeakyBucket(testBucket, base.LeakyBucketConfig{})
 

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -2660,7 +2660,7 @@ func TestInvalidateChannels(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			base.ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+			base.ForAllDataStores(t, func(t *testing.T, bucket base.Bucket) {
 
 				leakyBucket := base.NewLeakyBucket(bucket, base.LeakyBucketConfig{})
 

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -2658,7 +2658,7 @@ func TestInvalidateChannels(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			base.ForAllDataStores(t, func(t *testing.T, bucket base.Bucket) {
+			base.ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket base.Bucket) {
 
 				leakyBucket := base.NewLeakyBucket(bucket, base.LeakyBucketConfig{})
 

--- a/auth/auth_time_sensitive_test.go
+++ b/auth/auth_time_sensitive_test.go
@@ -28,8 +28,8 @@ import (
 // is _extremely_ slow (~100ms!) so we use a cache to speed it up (see password_hash.go).
 func TestAuthenticationSpeed(t *testing.T) {
 
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 	auth := NewAuthenticator(testBucket.Bucket, nil, DefaultAuthenticatorOptions())
 	user, _ := auth.NewUser("me", "goIsKewl", nil)
 	assert.True(t, user.Authenticate("goIsKewl"))

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -1181,8 +1181,8 @@ func TestJWTRolesChannels(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Greater(t, len(tc.logins), 0, "Test case is missing simulated logins")
 
-			testBucket := base.GetTestBucket(t)
-			defer testBucket.Close()
+			ctx, testBucket := base.GetTestBucket(t)
+			defer testBucket.Close(ctx)
 
 			testMockComputer := mockComputerV2{
 				roles:        map[string]ch.TimedSet{},

--- a/auth/password_hash_test.go
+++ b/auth/password_hash_test.go
@@ -59,8 +59,8 @@ func TestBcryptDefaultCostTime(t *testing.T) {
 }
 
 func TestSetBcryptCost(t *testing.T) {
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 

--- a/auth/role_test.go
+++ b/auth/role_test.go
@@ -40,8 +40,8 @@ func TestInitRole(t *testing.T) {
 }
 
 func TestAuthorizeChannelsRole(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
 	role, err := auth.NewRole("root", channels.SetOf(t, "superuser"))

--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -25,8 +25,8 @@ func TestCreateSession(t *testing.T) {
 	var username string = "Alice"
 	const invalidSessionTTLError = "400 Invalid session time-to-live"
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
@@ -65,8 +65,8 @@ func TestCreateSession(t *testing.T) {
 func TestDeleteSession(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 	var username string = "Alice"
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
@@ -94,8 +94,8 @@ func TestDeleteSession(t *testing.T) {
 // If nil is provided instead of valid login session, nil must be returned.
 func TestMakeSessionCookie(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
@@ -120,8 +120,8 @@ func TestMakeSessionCookie(t *testing.T) {
 }
 
 func TestMakeSessionCookieProperties(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
@@ -155,8 +155,8 @@ func TestMakeSessionCookieProperties(t *testing.T) {
 func TestDeleteSessionForCookie(t *testing.T) {
 	const defaultEndpoint = "http://localhost/"
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -29,8 +29,8 @@ func TestUserAuthenticateDisabled(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 
 	// Create user
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
@@ -64,8 +64,8 @@ func TestUserAuthenticatePasswordHashUpgrade(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 
 	// Create user
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
@@ -247,8 +247,8 @@ func TestInvalidUsernamesRejected(t *testing.T) {
 
 func TestCanSeeChannelSince(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 	freeChannels := base.SetFromArray([]string{"ESPN", "HBO", "FX", "AMC"})
@@ -275,8 +275,8 @@ func TestCanSeeChannelSince(t *testing.T) {
 
 func TestGetAddedChannels(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
@@ -318,8 +318,8 @@ func TestUserAuthenticateWithDisabledUserAccount(t *testing.T) {
 		username = "alice"
 		password = "hunter2"
 	)
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
@@ -340,8 +340,8 @@ func TestUserAuthenticateWithOldPasswordHash(t *testing.T) {
 		username = "alice"
 		password = "hunter2"
 	)
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
@@ -361,8 +361,8 @@ func TestUserAuthenticateWithBadPasswordHash(t *testing.T) {
 		username = "alice"
 		password = "hunter2"
 	)
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
@@ -382,8 +382,8 @@ func TestUserAuthenticateWithNoHashAndBadPassword(t *testing.T) {
 		username = "alice"
 		password = "hunter2"
 	)
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -100,7 +100,7 @@ func GetBaseBucket(b Bucket) Bucket {
 	return b
 }
 
-func ChooseCouchbaseDriver(bucketType CouchbaseBucketType) CouchbaseDriver {
+func ChooseCouchbaseDriver(ctx context.Context, bucketType CouchbaseBucketType) CouchbaseDriver {
 
 	// Otherwise use the default driver for the bucket type
 	// return DefaultDriverForBucketType[bucketType]
@@ -111,7 +111,7 @@ func ChooseCouchbaseDriver(bucketType CouchbaseBucketType) CouchbaseDriver {
 		return GoCBv2
 	default:
 		// If a new bucket type is added and this method isn't updated, flag a warning (or, could panic)
-		WarnfCtx(context.Background(), "Unexpected bucket type: %v", bucketType)
+		WarnfCtx(ctx, "Unexpected bucket type: %v", bucketType)
 		return GoCBv2
 	}
 
@@ -298,13 +298,13 @@ func (b BucketSpec) GetViewQueryTimeoutMs() uint64 {
 
 // TLSConfig creates a TLS configuration and populates the certificates
 // Errors will get logged then nil is returned.
-func (b BucketSpec) TLSConfig() *tls.Config {
+func (b BucketSpec) TLSConfig(ctx context.Context) *tls.Config {
 	var certPool *x509.CertPool = nil
 	if !b.TLSSkipVerify { // Add certs if ServerTLSSkipVerify is not set
 		var err error
 		certPool, err = getRootCAs(b.CACertPath)
 		if err != nil {
-			ErrorfCtx(context.Background(), "Error creating tlsConfig for DCP processing: %v", err)
+			ErrorfCtx(ctx, "Error creating tlsConfig for DCP processing: %v", err)
 			return nil
 		}
 	}
@@ -318,7 +318,7 @@ func (b BucketSpec) TLSConfig() *tls.Config {
 	if b.Certpath != "" && b.Keypath != "" {
 		cert, err := tls.LoadX509KeyPair(b.Certpath, b.Keypath)
 		if err != nil {
-			ErrorfCtx(context.Background(), "Error creating tlsConfig for DCP processing: %v", err)
+			ErrorfCtx(ctx, "Error creating tlsConfig for DCP processing: %v", err)
 			return nil
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -74,7 +74,7 @@ type CouchbaseStore interface {
 	ServerUUID(ctx context.Context) (uuid string, err error)
 	MaxTTL(ctx context.Context) (int, error)
 	HttpClient(ctx context.Context) *http.Client
-	GetExpiry(k string) (expiry uint32, getMetaError error)
+	GetExpiry(ctx context.Context, k string) (expiry uint32, getMetaError error)
 	GetSpec() BucketSpec
 	GetMaxVbno() (uint16, error)
 

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -74,7 +74,7 @@ type CouchbaseStore interface {
 	ServerUUID(ctx context.Context) (uuid string, err error)
 	MaxTTL(ctx context.Context) (int, error)
 	HttpClient(ctx context.Context) *http.Client
-	GetExpiry(ctx context.Context, k string) (expiry uint32, getMetaError error)
+	GetExpiry(k string) (expiry uint32, getMetaError error)
 	GetSpec() BucketSpec
 	GetMaxVbno() (uint16, error)
 

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -57,8 +57,7 @@ const (
 const DefaultViewTimeoutSecs = 75 // 75s
 
 type SGFlushableStore interface {
-	Flush() error
-	FlushCtx(ctx context.Context) error
+	Flush(ctx context.Context) error
 }
 
 // WrappingBucket interface used to identify buckets that wrap an underlying

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -13,7 +13,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"expvar"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -151,39 +150,7 @@ func init() {
 	gomemcached.MaxBodyLen = int(20 * 1024 * 1024)
 }
 
-// type Bucket sgbucket.DataStore
-
-type Bucket interface {
-	sgbucket.DataStore
-	CloseCtx(ctx context.Context)
-	StartDCPFeedCtx(ctx context.Context, args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error
-	StartTapFeedCtx(ctx context.Context, args sgbucket.FeedArguments, dbStats *expvar.Map) (sgbucket.MutationFeed, error)
-}
-
-type sgWalrusBucket struct {
-	*walrus.WalrusBucket
-}
-
-func NewSGWalrusBucket(url string, poolName string, bucketName string) (Bucket, error) {
-	b, err := walrus.GetBucket(url, poolName, bucketName)
-	if err != nil {
-		return nil, err
-	}
-	return &sgWalrusBucket{b}, nil
-}
-func (b *sgWalrusBucket) CloseCtx(ctx context.Context) {
-	DebugfCtx(ctx, KeyBucket, "walrus close for bucket %v", b.GetName())
-	b.Close()
-}
-func (b *sgWalrusBucket) StartDCPFeedCtx(ctx context.Context, args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
-	DebugfCtx(ctx, KeyBucket, "walrus StartDCPFeed for bucket %v", b.GetName())
-	return b.StartDCPFeed(args, callback, dbStats)
-}
-func (b *sgWalrusBucket) StartTapFeedCtx(ctx context.Context, args sgbucket.FeedArguments, dbStats *expvar.Map) (sgbucket.MutationFeed, error) {
-	DebugfCtx(ctx, KeyBucket, "walrus StartTapFeed for bucket %v", b.GetName())
-	return b.StartTapFeed(args, dbStats)
-}
-
+type Bucket sgbucket.DataStore
 type FeedArguments sgbucket.FeedArguments
 type TapFeed sgbucket.MutationFeed
 
@@ -432,7 +399,7 @@ func GetBucket(ctx context.Context, spec BucketSpec) (bucket Bucket, err error) 
 	if spec.IsWalrusBucket() {
 		InfofCtx(ctx, KeyAll, "Opening Walrus database %s on <%s>", MD(spec.BucketName), SD(spec.Server))
 		sgbucket.SetLogging(ConsoleLogKey().Enabled(KeyBucket))
-		bucket, err = NewSGWalrusBucket(spec.Server, DefaultPool, spec.BucketName)
+		bucket, err = walrus.GetBucket(spec.Server, DefaultPool, spec.BucketName)
 		if err != nil {
 			return nil, fmt.Errorf("unexpected walrus getbucket error: %w", err)
 		}
@@ -477,7 +444,7 @@ func GetBucket(ctx context.Context, spec BucketSpec) (bucket Bucket, err error) 
 	}
 
 	if LogDebugEnabled(KeyBucket) {
-		bucket = &LoggingBucket{bucket: bucket}
+		bucket = &LoggingBucket{logCtx: ctx, bucket: bucket}
 	}
 	return
 }

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -609,7 +609,7 @@ func retrievePurgeInterval(ctx context.Context, bucket CouchbaseStore, uri strin
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusForbidden {
-		WarnfCtx(context.TODO(), "403 Forbidden attempting to access %s.  Bucket user must have Bucket Full Access and Bucket Admin roles to retrieve metadata purge interval.", UD(uri))
+		WarnfCtx(ctx, "403 Forbidden attempting to access %s.  Bucket user must have Bucket Full Access and Bucket Admin roles to retrieve metadata purge interval.", UD(uri))
 	} else if resp.StatusCode != http.StatusOK {
 		return 0, errors.New(resp.Status)
 	}
@@ -628,9 +628,9 @@ func retrievePurgeInterval(ctx context.Context, bucket CouchbaseStore, uri strin
 	return time.Duration(purgeIntervalHours) * time.Hour, nil
 }
 
-func ensureBodyClosed(body io.ReadCloser) {
+func ensureBodyClosed(ctx context.Context, body io.ReadCloser) {
 	err := body.Close()
 	if err != nil {
-		DebugfCtx(context.TODO(), KeyBucket, "Failed to close socket: %v", err)
+		DebugfCtx(ctx, KeyBucket, "Failed to close socket: %v", err)
 	}
 }

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -56,6 +56,10 @@ const (
 
 const DefaultViewTimeoutSecs = 75 // 75s
 
+type SGFlushableStore interface {
+	Flush(ctx context.Context) error
+}
+
 // WrappingBucket interface used to identify buckets that wrap an underlying
 // bucket (leaky bucket, logging bucket)
 type WrappingBucket interface {

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1704,7 +1704,7 @@ func (bucket *CouchbaseBucketGoCB) getExpirySingleAttempt(k string) (expiry uint
 
 }
 
-func (bucket *CouchbaseBucketGoCB) GetExpiry(ctx context.Context, k string) (expiry uint32, getMetaError error) {
+func (bucket *CouchbaseBucketGoCB) GetExpiry(k string) (expiry uint32, getMetaError error) {
 
 	worker := func() (shouldRetry bool, err error, value interface{}) {
 		expirySingleAttempt, err := bucket.getExpirySingleAttempt(k)

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1706,7 +1706,7 @@ func (bucket *CouchbaseBucketGoCB) getExpirySingleAttempt(k string) (expiry uint
 
 }
 
-func (bucket *CouchbaseBucketGoCB) GetExpiry(k string) (expiry uint32, getMetaError error) {
+func (bucket *CouchbaseBucketGoCB) GetExpiry(ctx context.Context, k string) (expiry uint32, getMetaError error) {
 
 	worker := func() (shouldRetry bool, err error, value interface{}) {
 		expirySingleAttempt, err := bucket.getExpirySingleAttempt(k)

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1138,7 +1138,7 @@ func (bucket *CouchbaseBucketGoCB) Incr(k string, amt, def uint64, exp uint32) (
 
 }
 
-func (bucket *CouchbaseBucketGoCB) GetDDocs() (ddocs map[string]sgbucket.DesignDoc, err error) {
+func (bucket *CouchbaseBucketGoCB) GetDDocs(ctx context.Context) (ddocs map[string]sgbucket.DesignDoc, err error) {
 	bucketManager, err := bucket.getBucketManager()
 	if err != nil {
 		return nil, err
@@ -1167,7 +1167,7 @@ func (bucket *CouchbaseBucketGoCB) GetDDocs() (ddocs map[string]sgbucket.DesignD
 	return ddocs, nil
 }
 
-func (bucket *CouchbaseBucketGoCB) GetDDoc(docname string) (ddoc sgbucket.DesignDoc, err error) {
+func (bucket *CouchbaseBucketGoCB) GetDDoc(ctx context.Context, docname string) (ddoc sgbucket.DesignDoc, err error) {
 
 	bucketManager, err := bucket.getBucketManager()
 	if err != nil {
@@ -1208,7 +1208,7 @@ func (bucket *CouchbaseBucketGoCB) getBucketManager() (*gocb.BucketManager, erro
 	return manager, nil
 }
 
-func (bucket *CouchbaseBucketGoCB) PutDDoc(docname string, sgDesignDoc *sgbucket.DesignDoc) error {
+func (bucket *CouchbaseBucketGoCB) PutDDoc(ctx context.Context, docname string, sgDesignDoc *sgbucket.DesignDoc) error {
 
 	manager, err := bucket.getBucketManager()
 	if err != nil {
@@ -1331,7 +1331,7 @@ func (bucket *CouchbaseBucketGoCB) IsError(err error, errorType sgbucket.DataSto
 	}
 }
 
-func (bucket *CouchbaseBucketGoCB) DeleteDDoc(docname string) error {
+func (bucket *CouchbaseBucketGoCB) DeleteDDoc(ctx context.Context, docname string) error {
 
 	manager, err := bucket.getBucketManager()
 	if err != nil {
@@ -1342,7 +1342,7 @@ func (bucket *CouchbaseBucketGoCB) DeleteDDoc(docname string) error {
 
 }
 
-func (bucket *CouchbaseBucketGoCB) View(ddoc, name string, params map[string]interface{}) (sgbucket.ViewResult, error) {
+func (bucket *CouchbaseBucketGoCB) View(ctx context.Context, ddoc, name string, params map[string]interface{}) (sgbucket.ViewResult, error) {
 
 	// Block until there is an available concurrent view op, release on function exit
 	bucket.waitForAvailQueryOp()
@@ -1419,7 +1419,7 @@ func (bucket *CouchbaseBucketGoCB) View(ddoc, name string, params map[string]int
 
 }
 
-func (bucket CouchbaseBucketGoCB) ViewQuery(ddoc, name string, params map[string]interface{}) (sgbucket.QueryResultIterator, error) {
+func (bucket CouchbaseBucketGoCB) ViewQuery(ctx context.Context, ddoc, name string, params map[string]interface{}) (sgbucket.QueryResultIterator, error) {
 
 	bucket.waitForAvailQueryOp()
 	defer bucket.releaseQueryOp()

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -491,7 +491,7 @@ func TestCreateBatchesEntries(t *testing.T) {
 	}
 
 	batchSize := uint(2)
-	batches := createBatchesEntries(batchSize, entries)
+	batches := createBatchesEntries(TestCtx(t), batchSize, entries)
 	log.Printf("batches: %+v", batches)
 	assert.Equal(t, 4, len(batches))
 	assert.Equal(t, "one", batches[0][0].Key)
@@ -506,7 +506,7 @@ func TestCreateBatchesEntries(t *testing.T) {
 func TestCreateBatchesKeys(t *testing.T) {
 	keys := []string{"one", "two", "three", "four", "five", "six", "seven"}
 	batchSize := uint(2)
-	batches := createBatchesKeys(batchSize, keys)
+	batches := createBatchesKeys(TestCtx(t), batchSize, keys)
 	log.Printf("batches: %+v", batches)
 	assert.Equal(t, 4, len(batches))
 	assert.Equal(t, "one", batches[0][0])
@@ -1930,7 +1930,7 @@ func TestApplyViewQueryOptions(t *testing.T) {
 	viewQuery := gocb.NewViewQuery("ddoc", "viewname")
 
 	// Call applyViewQueryOptions (method being tested) which modifies viewQuery according to params
-	if err := applyViewQueryOptions(viewQuery, params); err != nil {
+	if err := applyViewQueryOptions(TestCtx(t), viewQuery, params); err != nil {
 		t.Fatalf("Error calling applyViewQueryOptions: %v", err)
 	}
 
@@ -2013,7 +2013,7 @@ func TestApplyViewQueryOptionsWithStrings(t *testing.T) {
 	// Create a new viewquery
 	viewQuery := gocb.NewViewQuery("ddoc", "viewname")
 
-	if err := applyViewQueryOptions(viewQuery, params); err != nil {
+	if err := applyViewQueryOptions(TestCtx(t), viewQuery, params); err != nil {
 		t.Fatalf("Error calling applyViewQueryOptions: %v", err)
 	}
 
@@ -2033,7 +2033,7 @@ func TestApplyViewQueryStaleOptions(t *testing.T) {
 	viewQuery := gocb.NewViewQuery("ddoc", "viewname")
 
 	// if it doesn't blow up, test passes
-	if err := applyViewQueryOptions(viewQuery, params); err != nil {
+	if err := applyViewQueryOptions(TestCtx(t), viewQuery, params); err != nil {
 		t.Fatalf("Error calling applyViewQueryOptions: %v", err)
 	}
 
@@ -2044,7 +2044,7 @@ func TestApplyViewQueryStaleOptions(t *testing.T) {
 	// Create a new viewquery
 	viewQuery = gocb.NewViewQuery("ddoc", "viewname")
 
-	if err := applyViewQueryOptions(viewQuery, params); err != nil {
+	if err := applyViewQueryOptions(TestCtx(t), viewQuery, params); err != nil {
 		t.Fatalf("Error calling applyViewQueryOptions: %v", err)
 	}
 

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -55,7 +55,7 @@ func TestTranscoder(t *testing.T) {
 }
 
 func TestSetGet(t *testing.T) {
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		key := t.Name()
 		val := make(map[string]interface{}, 0)
@@ -82,7 +82,7 @@ func TestSetGet(t *testing.T) {
 }
 
 func TestSetGetRaw(t *testing.T) {
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		key := t.Name()
 		val := []byte("bar")
@@ -109,7 +109,7 @@ func TestSetGetRaw(t *testing.T) {
 }
 
 func TestAddRaw(t *testing.T) {
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		key := t.Name()
 		val := []byte("bar")
 
@@ -179,7 +179,7 @@ func TestAddRawTimeoutRetry(t *testing.T) {
 }
 
 func TestWriteCasBasic(t *testing.T) {
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		key := t.Name()
 		val := []byte("bar2")
 
@@ -215,7 +215,7 @@ func TestWriteCasBasic(t *testing.T) {
 }
 
 func TestWriteCasAdvanced(t *testing.T) {
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		key := t.Name()
 
 		_, _, err := bucket.GetRaw(key)
@@ -248,7 +248,7 @@ func TestWriteCasAdvanced(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		key := t.Name()
 		valInitial := []byte(`{"state":"initial"}`)
 		valUpdated := []byte(`{"state":"updated"}`)
@@ -303,7 +303,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestUpdateCASFailure(t *testing.T) {
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		key := t.Name()
 		valInitial := []byte(`{"state":"initial"}`)
 		valCasMismatch := []byte(`{"state":"casMismatch"}`)
@@ -350,7 +350,7 @@ func TestUpdateCASFailure(t *testing.T) {
 }
 
 func TestUpdateCASFailureOnInsert(t *testing.T) {
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		key := t.Name()
 		valCasMismatch := []byte(`{"state":"casMismatch"}`)
 		valInitial := []byte(`{"state":"initial"}`)
@@ -393,7 +393,7 @@ func TestUpdateCASFailureOnInsert(t *testing.T) {
 }
 
 func TestIncrCounter(t *testing.T) {
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		key := t.Name()
 
 		defer func() {
@@ -429,7 +429,7 @@ func TestGetAndTouchRaw(t *testing.T) {
 
 	key := t.Name()
 	val := []byte("bar")
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		defer func() {
 			err := bucket.Delete(key)
@@ -533,7 +533,7 @@ func TestXattrWriteCasSimple(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		key := t.Name()
 		xattrName := SyncXattrName
 		val := make(map[string]interface{})
@@ -593,7 +593,7 @@ func TestXattrWriteCasUpsert(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		key := t.Name()
 		xattrName := SyncXattrName
@@ -658,7 +658,7 @@ func TestXattrWriteCasWithXattrCasCheck(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		key := t.Name()
 		xattrName := SyncXattrName
@@ -725,7 +725,7 @@ func TestXattrWriteCasRaw(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		key := t.Name()
 		xattrName := SyncXattrName
@@ -775,7 +775,7 @@ func TestXattrWriteCasTombstoneResurrect(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		key := t.Name()
 		xattrName := SyncXattrName
@@ -852,7 +852,7 @@ func TestXattrWriteCasTombstoneUpdate(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		key := t.Name()
 		xattrName := SyncXattrName
 		val := make(map[string]interface{})
@@ -929,7 +929,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		key := t.Name()
 		xattrName := SyncXattrName
@@ -1036,7 +1036,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 func TestWriteUpdateWithXattrUserXattr(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		key := t.Name()
 		xattrKey := SyncXattrName
@@ -1114,7 +1114,7 @@ func TestXattrDeleteDocument(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		// Create document with XATTR
 		xattrName := SyncXattrName
 		val := make(map[string]interface{})
@@ -1162,7 +1162,7 @@ func TestXattrDeleteDocumentUpdate(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		// Create document with XATTR
 		xattrName := SyncXattrName
@@ -1230,7 +1230,7 @@ func TestXattrDeleteDocumentAndUpdateXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		// Create document with XATTR
 		xattrName := SyncXattrName
 		val := make(map[string]interface{})
@@ -1279,7 +1279,7 @@ func TestXattrTombstoneDocAndUpdateXattr(t *testing.T) {
 
 	SetUpTestLogging(t, LevelDebug, KeyCRUD)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		key1 := t.Name() + "DocExistsXattrExists"
 		key2 := t.Name() + "DocExistsNoXattr"
@@ -1375,7 +1375,7 @@ func TestXattrDeleteDocAndXattr(t *testing.T) {
 
 	SetUpTestLogging(t, LevelDebug, KeyCRUD)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		key1 := t.Name() + "DocExistsXattrExists"
 		key2 := t.Name() + "DocExistsNoXattr"
@@ -1454,7 +1454,7 @@ func TestDeleteWithXattrWithSimulatedRaceResurrect(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		key := t.Name()
 		xattrName := SyncXattrName
@@ -1503,7 +1503,7 @@ func TestXattrRetrieveDocumentAndXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		key1 := t.Name() + "DocExistsXattrExists"
 		key2 := t.Name() + "DocExistsNoXattr"
@@ -1589,7 +1589,7 @@ func TestXattrMutateDocAndXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		key1 := t.Name() + "DocExistsXattrExists"
 		key2 := t.Name() + "DocExistsNoXattr"
@@ -1696,7 +1696,7 @@ func TestGetXattr(t *testing.T) {
 
 	SetUpTestLogging(t, LevelDebug, KeyAll)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		// Doc 1
 		key1 := t.Name() + "DocExistsXattrExists"
@@ -1788,7 +1788,7 @@ func TestGetXattrAndBody(t *testing.T) {
 
 	SetUpTestLogging(t, LevelDebug, KeyAll)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		// Doc 1
 		key1 := t.Name() + "DocExistsXattrExists"
@@ -2181,7 +2181,7 @@ EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
 	return certPath, keyPath, cleanupFn
 }
 
-func createTombstonedDoc(bucket sgbucket.DataStore, key, xattrName string) {
+func createTombstonedDoc(bucket Bucket, key, xattrName string) {
 
 	// Create document with XATTR
 
@@ -2259,7 +2259,7 @@ func TestUpdateXattrWithDeleteBodyAndIsDelete(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 	SetUpTestLogging(t, LevelDebug, KeyCRUD)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		subdocXattrStore, ok := AsSubdocXattrStore(bucket)
 		require.True(t, ok)
@@ -2302,7 +2302,7 @@ func TestUserXattrGetWithXattr(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 	SetUpTestLogging(t, LevelDebug, KeyCRUD)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		userXattrStore, ok := AsUserXattrStore(bucket)
 		require.True(t, ok)
@@ -2335,7 +2335,7 @@ func TestUserXattrGetWithXattrNil(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 	SetUpTestLogging(t, LevelDebug, KeyCRUD)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		docKey := t.Name()
 
@@ -2362,7 +2362,7 @@ func TestInsertTombstoneWithXattr(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 	SetUpTestLogging(t, LevelDebug, KeyCRUD)
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		subdocXattrStore, ok := AsSubdocXattrStore(bucket)
 		require.True(t, ok)
@@ -2402,7 +2402,7 @@ func TestRawBackwardCompatibilityFromJSON(t *testing.T) {
 		t.Skip("RawBackwardCompatibility tests depend on couchbase transcoding")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		key := t.Name()
 		val := []byte(`{"foo":"bar"}`)
@@ -2441,7 +2441,7 @@ func TestRawBackwardCompatibilityFromBinary(t *testing.T) {
 		t.Skip("RawBackwardCompatibility tests depend on couchbase transcoding")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		key := t.Name()
 		val := []byte(`{{"foo":"bar"}`)
@@ -2478,7 +2478,7 @@ func TestGetExpiry(t *testing.T) {
 		t.Skip("Walrus doesn't support expiry")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		ctx := TestCtx(t)
 		store, ok := AsCouchbaseStore(bucket)
@@ -2525,7 +2525,7 @@ func TestGetStatsVbSeqNo(t *testing.T) {
 		t.Skip("Walrus doesn't support stats-vbseqno")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		maxVbNo, err := bucket.GetMaxVbno()
 		assert.NoError(t, err)
 

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -2059,7 +2059,7 @@ func TestCouchbaseServerMaxTTL(t *testing.T) {
 
 	cbStore, ok := AsCouchbaseStore(bucket)
 	require.True(t, ok)
-	maxTTL, err := cbStore.MaxTTL()
+	maxTTL, err := cbStore.MaxTTL(TestCtx(t))
 	assert.NoError(t, err, "Unexpected error")
 	assert.Equal(t, 0, maxTTL)
 

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -147,8 +147,8 @@ func TestAddRaw(t *testing.T) {
 // to verify that timeout errors are returned, and the operation isn't retried (which would return a cas error).
 // (see CBG-463)
 func TestAddRawTimeoutRetry(t *testing.T) {
-	bucket := GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
 
 	gocbBucket, ok := bucket.Bucket.(*CouchbaseBucketGoCB)
 	if ok {
@@ -2054,8 +2054,8 @@ func TestCouchbaseServerMaxTTL(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	bucket := GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
 
 	cbStore, ok := AsCouchbaseStore(bucket)
 	require.True(t, ok)
@@ -2071,8 +2071,8 @@ func TestCouchbaseServerIncorrectLogin(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	// Override test bucket spec with invalid creds
 	testBucket.BucketSpec.Auth = TestAuthenticator{
@@ -2098,8 +2098,8 @@ func TestCouchbaseServerIncorrectX509Login(t *testing.T) {
 		t.Skip("This test doesn't work using GoCBv2")
 	}
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	// Remove existing password-based authentication
 	testBucket.BucketSpec.Auth = nil
@@ -2556,8 +2556,8 @@ func TestUpsertOptionPreserveExpiry(t *testing.T) {
 	if !TestUseCouchbaseServer() {
 		t.Skip("Test can only be ran against CBS due to GoCB v2 use")
 	}
-	bucket := GetTestBucketForDriver(t, GoCBv2)
-	defer bucket.Close()
+	ctx, bucket := GetTestBucketForDriver(t, GoCBv2)
+	defer bucket.Close(ctx)
 	if !bucket.IsSupported(sgbucket.DataStoreFeaturePreserveExpiry) {
 		t.Skip("Preserve expiry is not supported with this CBS version. Skipping test...")
 	}
@@ -2587,7 +2587,6 @@ func TestUpsertOptionPreserveExpiry(t *testing.T) {
 
 	for i, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := TestCtx(t)
 			cbStore, _ := AsCouchbaseStore(bucket)
 			key := fmt.Sprintf("test%d", i)
 			val := make(map[string]interface{}, 0)

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -2492,7 +2492,7 @@ func TestGetExpiry(t *testing.T) {
 		err := bucket.Set(key, expiryValue, nil, val)
 		assert.NoError(t, err, "Error calling Set()")
 
-		expiry, expiryErr := store.GetExpiry(ctx, key)
+		expiry, expiryErr := store.GetExpiry(key)
 		assert.NoError(t, expiryErr)
 
 		// gocb v2 expiry does an expiry-to-duration conversion which results in non-exact equality,
@@ -2507,12 +2507,12 @@ func TestGetExpiry(t *testing.T) {
 		}
 
 		// ensure expiry retrieval on tombstone doesn't return error
-		tombstoneExpiry, tombstoneExpiryErr := store.GetExpiry(ctx, key)
+		tombstoneExpiry, tombstoneExpiryErr := store.GetExpiry(key)
 		assert.NoError(t, tombstoneExpiryErr)
 		log.Printf("tombstoneExpiry: %d", tombstoneExpiry)
 
 		// ensure expiry retrieval on non-existent doc returns key not found
-		_, nonExistentExpiryErr := store.GetExpiry(ctx, "nonExistentKey")
+		_, nonExistentExpiryErr := store.GetExpiry("nonExistentKey")
 		assert.Error(t, nonExistentExpiryErr)
 		assert.True(t, IsKeyNotFoundError(bucket, nonExistentExpiryErr))
 
@@ -2599,7 +2599,7 @@ func TestUpsertOptionPreserveExpiry(t *testing.T) {
 			err = bucket.Set(key, DurationToCbsExpiry(time.Hour*24), nil, val)
 			assert.NoError(t, err, "Error calling Set()")
 
-			beforeExp, err := cbStore.GetExpiry(ctx, key)
+			beforeExp, err := cbStore.GetExpiry(key)
 			require.NoError(t, err)
 			require.NotEqual(t, 0, beforeExp)
 
@@ -2607,7 +2607,7 @@ func TestUpsertOptionPreserveExpiry(t *testing.T) {
 			err = bucket.Set(key, 0, test.upsertOptions, val)
 			assert.NoError(t, err, "Error calling Set()")
 
-			afterExp, err := cbStore.GetExpiry(ctx, key)
+			afterExp, err := cbStore.GetExpiry(key)
 			assert.NoError(t, err)
 			if test.expectMatch {
 				assert.Equal(t, beforeExp, afterExp) // Make sure both expiry timestamps match

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -2082,7 +2082,7 @@ func TestCouchbaseServerIncorrectLogin(t *testing.T) {
 	}
 
 	// Attempt to open the bucket again using invalid creds. We should expect an error.
-	bucket, err := GetBucket(testBucket.BucketSpec)
+	bucket, err := GetBucket(TestCtx(t), testBucket.BucketSpec)
 	assert.Equal(t, ErrAuthError, err)
 	assert.Nil(t, bucket)
 }
@@ -2122,7 +2122,7 @@ func TestCouchbaseServerIncorrectX509Login(t *testing.T) {
 	testBucket.BucketSpec.Keypath = keyPath
 
 	// Attempt to open a test bucket with invalid certs
-	bucket, err := GetBucket(testBucket.BucketSpec)
+	bucket, err := GetBucket(TestCtx(t), testBucket.BucketSpec)
 
 	// We no longer need the cert files, so go ahead and clean those up now before any assertions stop the test.
 	x509CleanupFn()

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -10,6 +10,7 @@ package base
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -55,7 +56,7 @@ func TestTranscoder(t *testing.T) {
 }
 
 func TestSetGet(t *testing.T) {
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		key := t.Name()
 		val := make(map[string]interface{}, 0)
@@ -82,7 +83,7 @@ func TestSetGet(t *testing.T) {
 }
 
 func TestSetGetRaw(t *testing.T) {
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		key := t.Name()
 		val := []byte("bar")
@@ -109,7 +110,7 @@ func TestSetGetRaw(t *testing.T) {
 }
 
 func TestAddRaw(t *testing.T) {
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		key := t.Name()
 		val := []byte("bar")
 
@@ -179,7 +180,7 @@ func TestAddRawTimeoutRetry(t *testing.T) {
 }
 
 func TestWriteCasBasic(t *testing.T) {
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		key := t.Name()
 		val := []byte("bar2")
 
@@ -215,7 +216,7 @@ func TestWriteCasBasic(t *testing.T) {
 }
 
 func TestWriteCasAdvanced(t *testing.T) {
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		key := t.Name()
 
 		_, _, err := bucket.GetRaw(key)
@@ -248,7 +249,7 @@ func TestWriteCasAdvanced(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		key := t.Name()
 		valInitial := []byte(`{"state":"initial"}`)
 		valUpdated := []byte(`{"state":"updated"}`)
@@ -303,7 +304,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestUpdateCASFailure(t *testing.T) {
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		key := t.Name()
 		valInitial := []byte(`{"state":"initial"}`)
 		valCasMismatch := []byte(`{"state":"casMismatch"}`)
@@ -350,7 +351,7 @@ func TestUpdateCASFailure(t *testing.T) {
 }
 
 func TestUpdateCASFailureOnInsert(t *testing.T) {
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		key := t.Name()
 		valCasMismatch := []byte(`{"state":"casMismatch"}`)
 		valInitial := []byte(`{"state":"initial"}`)
@@ -393,7 +394,7 @@ func TestUpdateCASFailureOnInsert(t *testing.T) {
 }
 
 func TestIncrCounter(t *testing.T) {
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		key := t.Name()
 
 		defer func() {
@@ -429,7 +430,7 @@ func TestGetAndTouchRaw(t *testing.T) {
 
 	key := t.Name()
 	val := []byte("bar")
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		defer func() {
 			err := bucket.Delete(key)
@@ -533,7 +534,7 @@ func TestXattrWriteCasSimple(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		key := t.Name()
 		xattrName := SyncXattrName
 		val := make(map[string]interface{})
@@ -593,7 +594,7 @@ func TestXattrWriteCasUpsert(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		key := t.Name()
 		xattrName := SyncXattrName
@@ -658,7 +659,7 @@ func TestXattrWriteCasWithXattrCasCheck(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		key := t.Name()
 		xattrName := SyncXattrName
@@ -725,7 +726,7 @@ func TestXattrWriteCasRaw(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		key := t.Name()
 		xattrName := SyncXattrName
@@ -775,7 +776,7 @@ func TestXattrWriteCasTombstoneResurrect(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		key := t.Name()
 		xattrName := SyncXattrName
@@ -852,7 +853,7 @@ func TestXattrWriteCasTombstoneUpdate(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		key := t.Name()
 		xattrName := SyncXattrName
 		val := make(map[string]interface{})
@@ -929,7 +930,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		key := t.Name()
 		xattrName := SyncXattrName
@@ -1036,7 +1037,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 func TestWriteUpdateWithXattrUserXattr(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		key := t.Name()
 		xattrKey := SyncXattrName
@@ -1114,7 +1115,7 @@ func TestXattrDeleteDocument(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		// Create document with XATTR
 		xattrName := SyncXattrName
 		val := make(map[string]interface{})
@@ -1162,7 +1163,7 @@ func TestXattrDeleteDocumentUpdate(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		// Create document with XATTR
 		xattrName := SyncXattrName
@@ -1230,7 +1231,7 @@ func TestXattrDeleteDocumentAndUpdateXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		// Create document with XATTR
 		xattrName := SyncXattrName
 		val := make(map[string]interface{})
@@ -1279,7 +1280,7 @@ func TestXattrTombstoneDocAndUpdateXattr(t *testing.T) {
 
 	SetUpTestLogging(t, LevelDebug, KeyCRUD)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		key1 := t.Name() + "DocExistsXattrExists"
 		key2 := t.Name() + "DocExistsNoXattr"
@@ -1375,7 +1376,7 @@ func TestXattrDeleteDocAndXattr(t *testing.T) {
 
 	SetUpTestLogging(t, LevelDebug, KeyCRUD)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		key1 := t.Name() + "DocExistsXattrExists"
 		key2 := t.Name() + "DocExistsNoXattr"
@@ -1454,7 +1455,7 @@ func TestDeleteWithXattrWithSimulatedRaceResurrect(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		key := t.Name()
 		xattrName := SyncXattrName
@@ -1503,7 +1504,7 @@ func TestXattrRetrieveDocumentAndXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		key1 := t.Name() + "DocExistsXattrExists"
 		key2 := t.Name() + "DocExistsNoXattr"
@@ -1589,7 +1590,7 @@ func TestXattrMutateDocAndXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		key1 := t.Name() + "DocExistsXattrExists"
 		key2 := t.Name() + "DocExistsNoXattr"
@@ -1696,7 +1697,7 @@ func TestGetXattr(t *testing.T) {
 
 	SetUpTestLogging(t, LevelDebug, KeyAll)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		// Doc 1
 		key1 := t.Name() + "DocExistsXattrExists"
@@ -1788,7 +1789,7 @@ func TestGetXattrAndBody(t *testing.T) {
 
 	SetUpTestLogging(t, LevelDebug, KeyAll)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		// Doc 1
 		key1 := t.Name() + "DocExistsXattrExists"
@@ -2259,7 +2260,7 @@ func TestUpdateXattrWithDeleteBodyAndIsDelete(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 	SetUpTestLogging(t, LevelDebug, KeyCRUD)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		subdocXattrStore, ok := AsSubdocXattrStore(bucket)
 		require.True(t, ok)
@@ -2302,7 +2303,7 @@ func TestUserXattrGetWithXattr(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 	SetUpTestLogging(t, LevelDebug, KeyCRUD)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		userXattrStore, ok := AsUserXattrStore(bucket)
 		require.True(t, ok)
@@ -2335,7 +2336,7 @@ func TestUserXattrGetWithXattrNil(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 	SetUpTestLogging(t, LevelDebug, KeyCRUD)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		docKey := t.Name()
 
@@ -2362,7 +2363,7 @@ func TestInsertTombstoneWithXattr(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 	SetUpTestLogging(t, LevelDebug, KeyCRUD)
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		subdocXattrStore, ok := AsSubdocXattrStore(bucket)
 		require.True(t, ok)
@@ -2402,7 +2403,7 @@ func TestRawBackwardCompatibilityFromJSON(t *testing.T) {
 		t.Skip("RawBackwardCompatibility tests depend on couchbase transcoding")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		key := t.Name()
 		val := []byte(`{"foo":"bar"}`)
@@ -2441,7 +2442,7 @@ func TestRawBackwardCompatibilityFromBinary(t *testing.T) {
 		t.Skip("RawBackwardCompatibility tests depend on couchbase transcoding")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		key := t.Name()
 		val := []byte(`{{"foo":"bar"}`)
@@ -2478,9 +2479,8 @@ func TestGetExpiry(t *testing.T) {
 		t.Skip("Walrus doesn't support expiry")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
-		ctx := TestCtx(t)
 		store, ok := AsCouchbaseStore(bucket)
 		assert.True(t, ok)
 
@@ -2525,7 +2525,7 @@ func TestGetStatsVbSeqNo(t *testing.T) {
 		t.Skip("Walrus doesn't support stats-vbseqno")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		maxVbNo, err := bucket.GetMaxVbno()
 		assert.NoError(t, err)
 

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -117,13 +117,13 @@ func (bucket *CouchbaseBucketGoCB) ExplainQuery(ctx context.Context, statement s
 	return ExplainQuery(ctx, bucket, statement, params)
 }
 
-func (bucket *CouchbaseBucketGoCB) CreateIndex(indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
-	return CreateIndex(bucket, indexName, expression, filterExpression, options)
+func (bucket *CouchbaseBucketGoCB) CreateIndex(ctx context.Context, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
+	return CreateIndex(ctx, bucket, indexName, expression, filterExpression, options)
 }
 
 // Issues a build command for any deferred sync gateway indexes associated with the bucket.
-func (bucket *CouchbaseBucketGoCB) BuildDeferredIndexes(indexSet []string) error {
-	return BuildDeferredIndexes(bucket, indexSet)
+func (bucket *CouchbaseBucketGoCB) BuildDeferredIndexes(ctx context.Context, indexSet []string) error {
+	return BuildDeferredIndexes(ctx, bucket, indexSet)
 }
 
 func (bucket *CouchbaseBucketGoCB) waitUntilQueryServiceReady(_ time.Duration) error {
@@ -160,22 +160,22 @@ func (bucket *CouchbaseBucketGoCB) executeStatement(statement string) error {
 	return results.Close()
 }
 
-func (bucket *CouchbaseBucketGoCB) CreatePrimaryIndex(indexName string, options *N1qlIndexOptions) error {
-	return CreatePrimaryIndex(bucket, indexName, options)
+func (bucket *CouchbaseBucketGoCB) CreatePrimaryIndex(ctx context.Context, indexName string, options *N1qlIndexOptions) error {
+	return CreatePrimaryIndex(ctx, bucket, indexName, options)
 }
 
 // Waits for index state to be online.  Waits no longer than provided timeout
-func (bucket *CouchbaseBucketGoCB) WaitForIndexOnline(indexName string) error {
-	return WaitForIndexOnline(bucket, indexName)
+func (bucket *CouchbaseBucketGoCB) WaitForIndexOnline(ctx context.Context, indexName string) error {
+	return WaitForIndexOnline(ctx, bucket, indexName)
 }
 
-func (bucket *CouchbaseBucketGoCB) GetIndexMeta(indexName string) (exists bool, meta *IndexMeta, err error) {
-	return GetIndexMeta(bucket, indexName)
+func (bucket *CouchbaseBucketGoCB) GetIndexMeta(ctx context.Context, indexName string) (exists bool, meta *IndexMeta, err error) {
+	return GetIndexMeta(ctx, bucket, indexName)
 }
 
 // DropIndex drops the specified index from the current bucket.
-func (bucket *CouchbaseBucketGoCB) DropIndex(indexName string) error {
-	return DropIndex(bucket, indexName)
+func (bucket *CouchbaseBucketGoCB) DropIndex(ctx context.Context, indexName string) error {
+	return DropIndex(ctx, bucket, indexName)
 }
 
 func (bucket *CouchbaseBucketGoCB) IsErrNoResults(err error) bool {

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -16,8 +16,6 @@ import (
 	"log"
 	"testing"
 
-	sgbucket "github.com/couchbase/sg-bucket"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/couchbase/gocb.v1"
@@ -36,7 +34,7 @@ func TestN1qlQuery(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
@@ -144,7 +142,7 @@ func TestN1qlFilterExpression(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")
@@ -221,7 +219,7 @@ func TestIndexMeta(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")
@@ -265,7 +263,7 @@ func TestMalformedN1qlQuery(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")
@@ -337,7 +335,7 @@ func TestCreateAndDropIndex(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")
@@ -365,7 +363,7 @@ func TestCreateDuplicateIndex(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")
@@ -397,7 +395,7 @@ func TestCreateAndDropIndexSpecialCharacters(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")
@@ -425,7 +423,7 @@ func TestDeferredCreateIndex(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")
@@ -467,7 +465,7 @@ func TestBuildDeferredIndexes(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")
@@ -532,7 +530,7 @@ func TestCreateAndDropIndexErrors(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")
@@ -610,7 +608,7 @@ func TestWaitForBucketExistence(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -54,19 +54,19 @@ func TestN1qlQuery(t *testing.T) {
 		}
 
 		indexExpression := "val"
-		err := n1qlStore.CreateIndex("testIndex_value", indexExpression, "", testN1qlOptions)
+		err := n1qlStore.CreateIndex(ctx, "testIndex_value", indexExpression, "", testN1qlOptions)
 		if err != nil && err != ErrAlreadyExists {
 			t.Errorf("Error creating index: %s", err)
 		}
 
 		// Wait for index readiness
-		onlineErr := n1qlStore.WaitForIndexOnline("testIndex_value")
+		onlineErr := n1qlStore.WaitForIndexOnline(ctx, "testIndex_value")
 		if onlineErr != nil {
 			t.Fatalf("Error waiting for index to come online: %v", err)
 		}
 
 		// Check index state
-		exists, state, stateErr := n1qlStore.GetIndexMeta("testIndex_value")
+		exists, state, stateErr := n1qlStore.GetIndexMeta(ctx, "testIndex_value")
 		assert.NoError(t, stateErr, "Error validating index state")
 		assert.True(t, state != nil, "No state returned for index")
 		assert.Equal(t, "online", state.State)
@@ -75,13 +75,13 @@ func TestN1qlQuery(t *testing.T) {
 		// Defer index teardown
 		defer func() {
 			// Drop the index
-			err = n1qlStore.DropIndex("testIndex_value")
+			err = n1qlStore.DropIndex(ctx, "testIndex_value")
 			if err != nil {
 				t.Fatalf("Error dropping index: %s", err)
 			}
 		}()
 
-		readyErr := n1qlStore.WaitForIndexOnline("testIndex_value")
+		readyErr := n1qlStore.WaitForIndexOnline(ctx, "testIndex_value")
 		require.NoError(t, readyErr, "Error validating index online")
 
 		// Query the index
@@ -162,19 +162,19 @@ func TestN1qlFilterExpression(t *testing.T) {
 
 		indexExpression := "val"
 		filterExpression := "val < 3"
-		err := n1qlStore.CreateIndex("testIndex_filtered_value", indexExpression, filterExpression, testN1qlOptions)
+		err := n1qlStore.CreateIndex(ctx, "testIndex_filtered_value", indexExpression, filterExpression, testN1qlOptions)
 		if err != nil {
 			t.Fatalf("Error creating index: %s", err)
 		}
 
 		// Wait for index readiness
-		readyErr := n1qlStore.WaitForIndexOnline("testIndex_filtered_value")
+		readyErr := n1qlStore.WaitForIndexOnline(ctx, "testIndex_filtered_value")
 		require.NoError(t, readyErr, "Error validating index online")
 
 		// Defer index teardown
 		defer func() {
 			// Drop the index
-			err = n1qlStore.DropIndex("testIndex_filtered_value")
+			err = n1qlStore.DropIndex(ctx, "testIndex_filtered_value")
 			if err != nil {
 				t.Fatalf("Error dropping index: %s", err)
 			}
@@ -227,30 +227,30 @@ func TestIndexMeta(t *testing.T) {
 		}
 
 		// Check index state pre-creation
-		exists, meta, err := n1qlStore.GetIndexMeta("testIndex_value")
+		exists, meta, err := n1qlStore.GetIndexMeta(ctx, "testIndex_value")
 		assert.False(t, exists)
 		assert.NoError(t, err, "Error getting meta for non-existent index")
 
 		indexExpression := "val"
-		err = n1qlStore.CreateIndex("testIndex_value", indexExpression, "", testN1qlOptions)
+		err = n1qlStore.CreateIndex(ctx, "testIndex_value", indexExpression, "", testN1qlOptions)
 		if err != nil {
 			t.Fatalf("Error creating index: %s", err)
 		}
 
-		readyErr := n1qlStore.WaitForIndexOnline("testIndex_value")
+		readyErr := n1qlStore.WaitForIndexOnline(ctx, "testIndex_value")
 		require.NoError(t, readyErr, "Error validating index online")
 
 		// Defer index teardown
 		defer func() {
 			// Drop the index
-			err = n1qlStore.DropIndex("testIndex_value")
+			err = n1qlStore.DropIndex(ctx, "testIndex_value")
 			if err != nil {
 				t.Fatalf("Error dropping index: %s", err)
 			}
 		}()
 
 		// Check index state post-creation
-		exists, meta, err = n1qlStore.GetIndexMeta("testIndex_value")
+		exists, meta, err = n1qlStore.GetIndexMeta(ctx, "testIndex_value")
 		assert.True(t, exists)
 		assert.Equal(t, "online", meta.State)
 		assert.NoError(t, err, "Error retrieving index state")
@@ -282,18 +282,18 @@ func TestMalformedN1qlQuery(t *testing.T) {
 		}
 
 		indexExpression := "val"
-		err := n1qlStore.CreateIndex("testIndex_value_malformed", indexExpression, "", testN1qlOptions)
+		err := n1qlStore.CreateIndex(ctx, "testIndex_value_malformed", indexExpression, "", testN1qlOptions)
 		if err != nil {
 			t.Fatalf("Error creating index: %s", err)
 		}
 
-		readyErr := n1qlStore.WaitForIndexOnline("testIndex_value_malformed")
+		readyErr := n1qlStore.WaitForIndexOnline(ctx, "testIndex_value_malformed")
 		assert.NoError(t, readyErr, "Error validating index online")
 
 		// Defer index teardown
 		defer func() {
 			// Drop the index
-			err = n1qlStore.DropIndex("testIndex_value_malformed")
+			err = n1qlStore.DropIndex(ctx, "testIndex_value_malformed")
 			if err != nil {
 				t.Fatalf("Error dropping index: %s", err)
 			}
@@ -343,16 +343,16 @@ func TestCreateAndDropIndex(t *testing.T) {
 		}
 
 		createExpression := SyncPropertyName + ".sequence"
-		err := n1qlStore.CreateIndex("testIndex_sequence", createExpression, "", testN1qlOptions)
+		err := n1qlStore.CreateIndex(ctx, "testIndex_sequence", createExpression, "", testN1qlOptions)
 		if err != nil {
 			t.Fatalf("Error creating index: %s", err)
 		}
 
-		readyErr := n1qlStore.WaitForIndexOnline("testIndex_sequence")
+		readyErr := n1qlStore.WaitForIndexOnline(ctx, "testIndex_sequence")
 		assert.NoError(t, readyErr, "Error validating index online")
 
 		// Drop the index
-		err = n1qlStore.DropIndex("testIndex_sequence")
+		err = n1qlStore.DropIndex(ctx, "testIndex_sequence")
 		if err != nil {
 			t.Fatalf("Error dropping index: %s", err)
 		}
@@ -371,20 +371,20 @@ func TestCreateDuplicateIndex(t *testing.T) {
 		}
 
 		createExpression := SyncPropertyName + ".sequence"
-		err := n1qlStore.CreateIndex("testIndexDuplicateSequence", createExpression, "", testN1qlOptions)
+		err := n1qlStore.CreateIndex(ctx, "testIndexDuplicateSequence", createExpression, "", testN1qlOptions)
 		if err != nil {
 			t.Fatalf("Error creating index: %s", err)
 		}
 
-		readyErr := n1qlStore.WaitForIndexOnline("testIndexDuplicateSequence")
+		readyErr := n1qlStore.WaitForIndexOnline(ctx, "testIndexDuplicateSequence")
 		assert.NoError(t, readyErr, "Error validating index online")
 
 		// Attempt to create duplicate, validate duplicate error
-		duplicateErr := n1qlStore.CreateIndex("testIndexDuplicateSequence", createExpression, "", testN1qlOptions)
+		duplicateErr := n1qlStore.CreateIndex(ctx, "testIndexDuplicateSequence", createExpression, "", testN1qlOptions)
 		assert.Equal(t, ErrAlreadyExists, duplicateErr)
 
 		// Drop the index
-		err = n1qlStore.DropIndex("testIndexDuplicateSequence")
+		err = n1qlStore.DropIndex(ctx, "testIndexDuplicateSequence")
 		if err != nil {
 			t.Fatalf("Error dropping index: %s", err)
 		}
@@ -403,16 +403,16 @@ func TestCreateAndDropIndexSpecialCharacters(t *testing.T) {
 		}
 
 		createExpression := SyncPropertyName + ".sequence"
-		err := n1qlStore.CreateIndex("testIndex-sequence", createExpression, "", testN1qlOptions)
+		err := n1qlStore.CreateIndex(ctx, "testIndex-sequence", createExpression, "", testN1qlOptions)
 		if err != nil {
 			t.Fatalf("Error creating index: %s", err)
 		}
 
-		readyErr := n1qlStore.WaitForIndexOnline("testIndex-sequence")
+		readyErr := n1qlStore.WaitForIndexOnline(ctx, "testIndex-sequence")
 		assert.NoError(t, readyErr, "Error validating index online")
 
 		// Drop the index
-		err = n1qlStore.DropIndex("testIndex-sequence")
+		err = n1qlStore.DropIndex(ctx, "testIndex-sequence")
 		if err != nil {
 			t.Fatalf("Error dropping index: %s", err)
 		}
@@ -431,7 +431,7 @@ func TestDeferredCreateIndex(t *testing.T) {
 		}
 
 		indexName := "testIndexDeferred"
-		assert.NoError(t, tearDownTestIndex(n1qlStore, indexName), "Error in pre-test cleanup")
+		assert.NoError(t, tearDownTestIndex(ctx, n1qlStore, indexName), "Error in pre-test cleanup")
 
 		deferN1qlOptions := &N1qlIndexOptions{
 			NumReplica: 0,
@@ -439,23 +439,23 @@ func TestDeferredCreateIndex(t *testing.T) {
 		}
 
 		createExpression := SyncPropertyName + ".sequence"
-		err := n1qlStore.CreateIndex(indexName, createExpression, "", deferN1qlOptions)
+		err := n1qlStore.CreateIndex(ctx, indexName, createExpression, "", deferN1qlOptions)
 		if err != nil {
 			t.Fatalf("Error creating index: %s", err)
 		}
 
 		// Drop the index
 		defer func() {
-			err = n1qlStore.DropIndex(indexName)
+			err = n1qlStore.DropIndex(ctx, indexName)
 			if err != nil {
 				t.Fatalf("Error dropping index: %s", err)
 			}
 		}()
 
-		buildErr := buildIndexes(n1qlStore, []string{indexName})
+		buildErr := buildIndexes(ctx, n1qlStore, []string{indexName})
 		assert.NoError(t, buildErr, "Error building indexes")
 
-		readyErr := n1qlStore.WaitForIndexOnline(indexName)
+		readyErr := n1qlStore.WaitForIndexOnline(ctx, indexName)
 		assert.NoError(t, readyErr, "Error validating index online")
 	})
 
@@ -474,8 +474,8 @@ func TestBuildDeferredIndexes(t *testing.T) {
 
 		deferredIndexName := "testIndexDeferred"
 		nonDeferredIndexName := "testIndexNonDeferred"
-		assert.NoError(t, tearDownTestIndex(n1qlStore, deferredIndexName), "Error in pre-test cleanup")
-		assert.NoError(t, tearDownTestIndex(n1qlStore, nonDeferredIndexName), "Error in pre-test cleanup")
+		assert.NoError(t, tearDownTestIndex(ctx, n1qlStore, deferredIndexName), "Error in pre-test cleanup")
+		assert.NoError(t, tearDownTestIndex(ctx, n1qlStore, nonDeferredIndexName), "Error in pre-test cleanup")
 
 		deferN1qlOptions := &N1qlIndexOptions{
 			NumReplica: 0,
@@ -484,44 +484,44 @@ func TestBuildDeferredIndexes(t *testing.T) {
 
 		// Create a deferred and a non-deferred index
 		createExpression := SyncPropertyName + ".sequence"
-		err := n1qlStore.CreateIndex(deferredIndexName, createExpression, "", deferN1qlOptions)
+		err := n1qlStore.CreateIndex(ctx, deferredIndexName, createExpression, "", deferN1qlOptions)
 		if err != nil {
 			t.Errorf("Error creating index: %s", err)
 		}
 
 		createExpression = SyncPropertyName + ".rev"
-		err = n1qlStore.CreateIndex(nonDeferredIndexName, createExpression, "", &N1qlIndexOptions{NumReplica: 0})
+		err = n1qlStore.CreateIndex(ctx, nonDeferredIndexName, createExpression, "", &N1qlIndexOptions{NumReplica: 0})
 		if err != nil {
 			t.Fatalf("Error creating index: %s", err)
 		}
 
 		// Drop the indexes
 		defer func() {
-			err = n1qlStore.DropIndex(deferredIndexName)
+			err = n1qlStore.DropIndex(ctx, deferredIndexName)
 			if err != nil {
 				t.Fatalf("Error dropping deferred index: %s", err)
 			}
 		}()
 		defer func() {
-			err = n1qlStore.DropIndex(nonDeferredIndexName)
+			err = n1qlStore.DropIndex(ctx, nonDeferredIndexName)
 			if err != nil {
 				t.Fatalf("Error dropping non-deferred index: %s", err)
 			}
 		}()
 
-		buildErr := n1qlStore.BuildDeferredIndexes([]string{deferredIndexName, nonDeferredIndexName})
+		buildErr := n1qlStore.BuildDeferredIndexes(ctx, []string{deferredIndexName, nonDeferredIndexName})
 		assert.NoError(t, buildErr, "Error building indexes")
 
-		readyErr := n1qlStore.WaitForIndexOnline(deferredIndexName)
+		readyErr := n1qlStore.WaitForIndexOnline(ctx, deferredIndexName)
 		assert.NoError(t, readyErr, "Error validating index online")
-		readyErr = n1qlStore.WaitForIndexOnline(nonDeferredIndexName)
+		readyErr = n1qlStore.WaitForIndexOnline(ctx, nonDeferredIndexName)
 		assert.NoError(t, readyErr, "Error validating index online")
 
 		// Ensure no errors from no-op scenarios
-		alreadyBuiltErr := n1qlStore.BuildDeferredIndexes([]string{deferredIndexName, nonDeferredIndexName})
+		alreadyBuiltErr := n1qlStore.BuildDeferredIndexes(ctx, []string{deferredIndexName, nonDeferredIndexName})
 		assert.NoError(t, alreadyBuiltErr, "Error building already built indexes")
 
-		emptySetErr := n1qlStore.BuildDeferredIndexes([]string{})
+		emptySetErr := n1qlStore.BuildDeferredIndexes(ctx, []string{})
 		assert.NoError(t, emptySetErr, "Error building empty set")
 	})
 }
@@ -538,38 +538,38 @@ func TestCreateAndDropIndexErrors(t *testing.T) {
 		}
 		// Malformed expression
 		createExpression := "_sync sequence"
-		err := n1qlStore.CreateIndex("testIndex_malformed", createExpression, "", testN1qlOptions)
+		err := n1qlStore.CreateIndex(ctx, "testIndex_malformed", createExpression, "", testN1qlOptions)
 		if err == nil {
 			t.Fatalf("Expected error for malformed index expression")
 		}
 
 		// Create index
 		createExpression = "_sync.sequence"
-		err = n1qlStore.CreateIndex("testIndex_sequence", createExpression, "", testN1qlOptions)
+		err = n1qlStore.CreateIndex(ctx, "testIndex_sequence", createExpression, "", testN1qlOptions)
 		if err != nil {
 			t.Fatalf("Error creating index: %s", err)
 		}
 
 		// Attempt to recreate duplicate index
-		err = n1qlStore.CreateIndex("testIndex_sequence", createExpression, "", testN1qlOptions)
+		err = n1qlStore.CreateIndex(ctx, "testIndex_sequence", createExpression, "", testN1qlOptions)
 		if err == nil {
 			t.Fatalf("Expected error attempting to recreate already existing index")
 		}
 
 		// Drop non-existent index
-		err = n1qlStore.DropIndex("testIndex_not_found")
+		err = n1qlStore.DropIndex(ctx, "testIndex_not_found")
 		if err == nil {
 			t.Fatalf("Expected error attempting to drop non-existent index")
 		}
 
 		// Drop the index
-		err = n1qlStore.DropIndex("testIndex_sequence")
+		err = n1qlStore.DropIndex(ctx, "testIndex_sequence")
 		if err != nil {
 			t.Fatalf("Error dropping index: %s", err)
 		}
 
 		// Drop index that's already been dropped
-		err = n1qlStore.DropIndex("testIndex_sequence")
+		err = n1qlStore.DropIndex(ctx, "testIndex_sequence")
 		if err == nil {
 			t.Fatalf("Expected error attempting to drop index twice")
 		}
@@ -588,15 +588,15 @@ func queryResultCount(queryResults gocb.QueryResults) (count int, err error) {
 	}
 }
 
-func tearDownTestIndex(n1qlStore N1QLStore, indexName string) (err error) {
+func tearDownTestIndex(ctx context.Context, n1qlStore N1QLStore, indexName string) (err error) {
 
-	exists, _, err := n1qlStore.GetIndexMeta(indexName)
+	exists, _, err := n1qlStore.GetIndexMeta(ctx, indexName)
 	if err != nil {
 		return err
 	}
 
 	if exists {
-		return n1qlStore.DropIndex(indexName)
+		return n1qlStore.DropIndex(ctx, indexName)
 	} else {
 		return nil
 	}
@@ -628,18 +628,18 @@ func TestWaitForBucketExistence(t *testing.T) {
 			assert.NoError(t, err, "No error while trying to fetch the index metadata")
 
 			if indexExists {
-				err := n1qlStore.DropIndex(indexName)
+				err := n1qlStore.DropIndex(ctx, indexName)
 				assert.NoError(t, err, "Index should be removed from the bucket")
 			}
 
-			err = n1qlStore.CreateIndex(indexName, expression, filterExpression, options)
+			err = n1qlStore.CreateIndex(ctx, indexName, expression, filterExpression, options)
 			assert.NoError(t, err, "Index should be created in the bucket")
 		}()
 
-		assert.NoError(t, WaitForIndexOnline(n1qlStore, indexName))
+		assert.NoError(t, WaitForIndexOnline(ctx, n1qlStore, indexName))
 
 		// Drop the index;
-		err := n1qlStore.DropIndex(indexName)
+		err := n1qlStore.DropIndex(ctx, indexName)
 		assert.NoError(t, err, "Index should be removed from the bucket")
 	})
 }

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -34,7 +35,7 @@ func TestN1qlQuery(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
@@ -142,7 +143,7 @@ func TestN1qlFilterExpression(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")
@@ -219,7 +220,7 @@ func TestIndexMeta(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")
@@ -263,7 +264,7 @@ func TestMalformedN1qlQuery(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")
@@ -335,7 +336,7 @@ func TestCreateAndDropIndex(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")
@@ -363,7 +364,7 @@ func TestCreateDuplicateIndex(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")
@@ -395,7 +396,7 @@ func TestCreateAndDropIndexSpecialCharacters(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")
@@ -423,7 +424,7 @@ func TestDeferredCreateIndex(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")
@@ -465,7 +466,7 @@ func TestBuildDeferredIndexes(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")
@@ -530,7 +531,7 @@ func TestCreateAndDropIndexErrors(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")
@@ -608,7 +609,7 @@ func TestWaitForBucketExistence(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	ForAllDataStores(t, func(t *testing.T, bucket Bucket) {
+	ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket Bucket) {
 		n1qlStore, ok := AsN1QLStore(bucket)
 		if !ok {
 			t.Fatalf("Requires bucket to be N1QLStore")

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -89,7 +89,7 @@ func TestN1qlQuery(t *testing.T) {
 		params := make(map[string]interface{})
 		params["minvalue"] = 2
 
-		queryResults, queryErr := n1qlStore.Query(queryExpression, params, RequestPlus, false)
+		queryResults, queryErr := n1qlStore.Query(ctx, queryExpression, params, RequestPlus, false)
 		require.NoError(t, queryErr, "Error executing n1ql query")
 
 		// Struct to receive the query response (META().id, val)
@@ -115,7 +115,7 @@ func TestN1qlQuery(t *testing.T) {
 		params = make(map[string]interface{})
 		params["minvalue"] = 10
 
-		queryResults, queryErr = n1qlStore.Query(queryExpression, params, RequestPlus, false)
+		queryResults, queryErr = n1qlStore.Query(ctx, queryExpression, params, RequestPlus, false)
 		assert.NoError(t, queryErr, "Error executing n1ql query")
 
 		count = 0
@@ -182,7 +182,7 @@ func TestN1qlFilterExpression(t *testing.T) {
 
 		// Query the index
 		queryExpression := fmt.Sprintf("SELECT META().id, val FROM %s WHERE %s AND META().id = 'doc1'", KeyspaceQueryToken, filterExpression)
-		queryResults, queryErr := n1qlStore.Query(queryExpression, nil, RequestPlus, false)
+		queryResults, queryErr := n1qlStore.Query(ctx, queryExpression, nil, RequestPlus, false)
 		require.NoError(t, queryErr, "Error executing n1ql query")
 
 		// Struct to receive the query response (META().id, val)
@@ -302,26 +302,26 @@ func TestMalformedN1qlQuery(t *testing.T) {
 		// Query with syntax error
 		queryExpression := "SELECT META().id, val WHERE val > $minvalue"
 		params := make(map[string]interface{})
-		_, queryErr := n1qlStore.Query(queryExpression, params, RequestPlus, false)
+		_, queryErr := n1qlStore.Query(ctx, queryExpression, params, RequestPlus, false)
 		assert.True(t, queryErr != nil, "Expected error for malformed n1ql query (syntax)")
 
 		// Query against non-existing bucket
 		queryExpression = fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > $minvalue", "badBucket")
 		params = map[string]interface{}{"minvalue": 2}
-		_, queryErr = n1qlStore.Query(queryExpression, params, RequestPlus, false)
+		_, queryErr = n1qlStore.Query(ctx, queryExpression, params, RequestPlus, false)
 		assert.True(t, queryErr != nil, "Expected error for malformed n1ql query (no bucket)")
 
 		// Specify params for non-parameterized query (no error expected, ensure doesn't break)
 		queryExpression = fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > 5", KeyspaceQueryToken)
 		params = map[string]interface{}{"minvalue": 2}
-		queryResults, queryErr := n1qlStore.Query(queryExpression, params, RequestPlus, false)
+		queryResults, queryErr := n1qlStore.Query(ctx, queryExpression, params, RequestPlus, false)
 		require.True(t, queryErr == nil, "Unexpected error for malformed n1ql query (extra params)")
 		assert.NoError(t, queryResults.Close())
 
 		// Omit params for parameterized query
 		queryExpression = fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > $minvalue", KeyspaceQueryToken)
 		params = map[string]interface{}{"othervalue": 2}
-		results, queryErr := n1qlStore.Query(queryExpression, params, RequestPlus, false)
+		results, queryErr := n1qlStore.Query(ctx, queryExpression, params, RequestPlus, false)
 		if queryErr == nil {
 			for results.NextBytes() != nil {
 			}

--- a/base/collection.go
+++ b/base/collection.go
@@ -809,10 +809,10 @@ func (c *Collection) HttpClient(ctx context.Context) *http.Client {
 // GetExpiry requires a full document retrieval in order to obtain the expiry, which is reasonable for
 // current use cases (on-demand import).  If there's a need for expiry as part of normal get, this shouldn't be
 // used - an enhanced version of Get() should be implemented to avoid two ops
-func (c *Collection) GetExpiry(ctx context.Context, k string) (expiry uint32, getMetaError error) {
+func (c *Collection) GetExpiry(k string) (expiry uint32, getMetaError error) {
 	agent, err := c.getGoCBAgent()
 	if err != nil {
-		WarnfCtx(ctx, "Unable to obtain gocbcore.Agent while retrieving expiry:%v", err)
+		WarnfCtx(context.TODO(), "Unable to obtain gocbcore.Agent while retrieving expiry:%v", err) // TODO: get final version of sg-bucket GetExpiry
 		return 0, err
 	}
 

--- a/base/collection.go
+++ b/base/collection.go
@@ -812,10 +812,10 @@ func (c *Collection) HttpClient(ctx context.Context) *http.Client {
 // GetExpiry requires a full document retrieval in order to obtain the expiry, which is reasonable for
 // current use cases (on-demand import).  If there's a need for expiry as part of normal get, this shouldn't be
 // used - an enhanced version of Get() should be implemented to avoid two ops
-func (c *Collection) GetExpiry(k string) (expiry uint32, getMetaError error) {
+func (c *Collection) GetExpiry(ctx context.Context, k string) (expiry uint32, getMetaError error) {
 	agent, err := c.getGoCBAgent()
 	if err != nil {
-		WarnfCtx(context.TODO(), "Unable to obtain gocbcore.Agent while retrieving expiry:%v", err)
+		WarnfCtx(ctx, "Unable to obtain gocbcore.Agent while retrieving expiry:%v", err)
 		return 0, err
 	}
 

--- a/base/collection.go
+++ b/base/collection.go
@@ -705,11 +705,7 @@ func (c *Collection) DropAllScopesAndCollections(ctx context.Context) error {
 }
 
 // This flushes the *entire* bucket associated with the collection (not just the collection).  Intended for test usage only.
-func (c *Collection) Flush() error {
-	return c.FlushCtx(context.TODO())
-}
-
-func (c *Collection) FlushCtx(ctx context.Context) error {
+func (c *Collection) Flush(ctx context.Context) error {
 
 	bucketManager := c.cluster.Buckets()
 

--- a/base/collection.go
+++ b/base/collection.go
@@ -788,22 +788,22 @@ func (c *Collection) QueryEpsCount() (int, error) {
 
 // Gets the metadata purge interval for the bucket.  First checks for a bucket-specific value.  If not
 // found, retrieves the cluster-wide value.
-func (c *Collection) MetadataPurgeInterval() (time.Duration, error) {
-	return getMetadataPurgeInterval(c)
+func (c *Collection) MetadataPurgeInterval(ctx context.Context) (time.Duration, error) {
+	return getMetadataPurgeInterval(ctx, c)
 }
 
-func (c *Collection) ServerUUID() (uuid string, err error) {
-	return getServerUUID(c)
+func (c *Collection) ServerUUID(ctx context.Context) (uuid string, err error) {
+	return getServerUUID(ctx, c)
 }
 
-func (c *Collection) MaxTTL() (int, error) {
-	return getMaxTTL(c)
+func (c *Collection) MaxTTL(ctx context.Context) (int, error) {
+	return getMaxTTL(ctx, c)
 }
 
-func (c *Collection) HttpClient() *http.Client {
+func (c *Collection) HttpClient(ctx context.Context) *http.Client {
 	agent, err := c.getGoCBAgent()
 	if err != nil {
-		WarnfCtx(context.TODO(), "Unable to obtain gocbcore.Agent while retrieving httpClient:%v", err)
+		WarnfCtx(ctx, "Unable to obtain gocbcore.Agent while retrieving httpClient:%v", err)
 		return nil
 	}
 	return agent.HTTPClient()
@@ -866,7 +866,7 @@ func getTranscoder(value interface{}) gocb.Transcoder {
 	}
 }
 
-func (c *Collection) mgmtRequest(method, uri, contentType string, body io.Reader) (*http.Response, error) {
+func (c *Collection) mgmtRequest(ctx context.Context, method, uri, contentType string, body io.Reader) (*http.Response, error) {
 	if contentType == "" && body != nil {
 		// TODO: CBG-1948
 		panic("Content-type must be specified for non-null body.")
@@ -891,7 +891,7 @@ func (c *Collection) mgmtRequest(method, uri, contentType string, body io.Reader
 		req.SetBasicAuth(username, password)
 	}
 
-	return c.HttpClient().Do(req)
+	return c.HttpClient(ctx).Do(req)
 }
 
 // This prevents Sync Gateway from overflowing gocb's pipeline

--- a/base/collection.go
+++ b/base/collection.go
@@ -204,6 +204,10 @@ func (c *Collection) UUID() (string, error) {
 }
 
 func (c *Collection) Close() {
+	c.CloseCtx(context.TODO())
+}
+
+func (c *Collection) CloseCtx(ctx context.Context) {
 	if c.cluster != nil {
 		if err := c.cluster.Close(nil); err != nil {
 			WarnfCtx(context.TODO(), "Error closing collection cluster: %v", err)
@@ -535,10 +539,19 @@ func (c *Collection) Incr(k string, amt, def uint64, exp uint32) (uint64, error)
 }
 
 func (c *Collection) StartDCPFeed(args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
-	groupID := ""
-	return StartGocbDCPFeed(context.TODO(), c, c.Spec.BucketName, args, callback, dbStats, DCPMetadataStoreInMemory, groupID)
+	return c.StartDCPFeedCtx(context.TODO(), args, callback, dbStats)
 }
+
+func (c *Collection) StartDCPFeedCtx(ctx context.Context, args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
+	groupID := ""
+	return StartGocbDCPFeed(ctx, c, c.Spec.BucketName, args, callback, dbStats, DCPMetadataStoreInMemory, groupID)
+}
+
 func (c *Collection) StartTapFeed(args sgbucket.FeedArguments, dbStats *expvar.Map) (sgbucket.MutationFeed, error) {
+	return c.StartTapFeedCtx(context.TODO(), args, dbStats)
+}
+
+func (c *Collection) StartTapFeedCtx(ctx context.Context, args sgbucket.FeedArguments, dbStats *expvar.Map) (sgbucket.MutationFeed, error) {
 	return nil, errors.New("StartTapFeed not implemented")
 }
 func (c *Collection) Dump() {

--- a/base/collection.go
+++ b/base/collection.go
@@ -534,10 +534,6 @@ func (c *Collection) Incr(k string, amt, def uint64, exp uint32) (uint64, error)
 	return incrResult.Content(), nil
 }
 
-func (c *Collection) StartDCPFeedCtx(ctx context.Context, args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
-	groupID := ""
-	return StartGocbDCPFeed(ctx, c, c.Spec.BucketName, args, callback, dbStats, DCPMetadataStoreInMemory, groupID)
-}
 func (c *Collection) StartDCPFeed(args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
 	groupID := ""
 	return StartGocbDCPFeed(context.TODO(), c, c.Spec.BucketName, args, callback, dbStats, DCPMetadataStoreInMemory, groupID)

--- a/base/collection.go
+++ b/base/collection.go
@@ -33,6 +33,7 @@ const DefaultCollectionID = 0x0
 
 var _ CouchbaseStore = &Collection{}
 var _ Bucket = &Collection{}
+var _ N1QLStore = &Collection{}
 
 // Connect to the default collection for the specified bucket
 func GetCouchbaseCollection(ctx context.Context, spec BucketSpec) (*Collection, error) {
@@ -722,7 +723,7 @@ func (c *Collection) Flush(ctx context.Context) error {
 
 	// Wait until the bucket item count is 0, since flush is asynchronous
 	worker := func() (shouldRetry bool, err error, value interface{}) {
-		itemCount, err := c.BucketItemCount()
+		itemCount, err := c.BucketItemCount(ctx)
 		if err != nil {
 			return false, err, nil
 		}
@@ -749,8 +750,8 @@ func (c *Collection) Flush(ctx context.Context) error {
 
 // BucketItemCount first tries to retrieve an accurate bucket count via N1QL,
 // but falls back to the REST API if that cannot be done (when there's no index to count all items in a bucket)
-func (c *Collection) BucketItemCount() (itemCount int, err error) {
-	itemCount, err = QueryBucketItemCount(c)
+func (c *Collection) BucketItemCount(ctx context.Context) (itemCount int, err error) {
+	itemCount, err = QueryBucketItemCount(ctx, c)
 	if err == nil {
 		return itemCount, nil
 	}

--- a/base/collection.go
+++ b/base/collection.go
@@ -33,7 +33,6 @@ const DefaultCollectionID = 0x0
 
 var _ CouchbaseStore = &Collection{}
 var _ Bucket = &Collection{}
-var _ N1QLStore = &Collection{}
 
 // Connect to the default collection for the specified bucket
 func GetCouchbaseCollection(ctx context.Context, spec BucketSpec) (*Collection, error) {
@@ -813,7 +812,8 @@ func (c *Collection) HttpClient(ctx context.Context) *http.Client {
 func (c *Collection) GetExpiry(k string) (expiry uint32, getMetaError error) {
 	agent, err := c.getGoCBAgent()
 	if err != nil {
-		WarnfCtx(context.TODO(), "Unable to obtain gocbcore.Agent while retrieving expiry:%v", err) // TODO: get final version of sg-bucket GetExpiry
+		// TODO: get final version of sg-bucket GetExpiry
+		WarnfCtx(context.TODO(), "Unable to obtain gocbcore.Agent while retrieving expiry:%v", err)
 		return 0, err
 	}
 

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -110,30 +110,30 @@ func (c *Collection) ExplainQuery(ctx context.Context, statement string, params 
 	return ExplainQuery(ctx, c, statement, params)
 }
 
-func (c *Collection) CreateIndex(indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
-	return CreateIndex(c, indexName, expression, filterExpression, options)
+func (c *Collection) CreateIndex(ctx context.Context, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
+	return CreateIndex(ctx, c, indexName, expression, filterExpression, options)
 }
 
-func (c *Collection) CreatePrimaryIndex(indexName string, options *N1qlIndexOptions) error {
-	return CreatePrimaryIndex(c, indexName, options)
+func (c *Collection) CreatePrimaryIndex(ctx context.Context, indexName string, options *N1qlIndexOptions) error {
+	return CreatePrimaryIndex(ctx, c, indexName, options)
 }
 
-func (c *Collection) WaitForIndexOnline(indexName string) error {
-	return WaitForIndexOnline(c, indexName)
+func (c *Collection) WaitForIndexOnline(ctx context.Context, indexName string) error {
+	return WaitForIndexOnline(ctx, c, indexName)
 }
 
-func (c *Collection) GetIndexMeta(indexName string) (exists bool, meta *IndexMeta, err error) {
-	return GetIndexMeta(c, indexName)
+func (c *Collection) GetIndexMeta(ctx context.Context, indexName string) (exists bool, meta *IndexMeta, err error) {
+	return GetIndexMeta(ctx, c, indexName)
 }
 
 // DropIndex drops the specified index from the current bucket.
-func (c *Collection) DropIndex(indexName string) error {
-	return DropIndex(c, indexName)
+func (c *Collection) DropIndex(ctx context.Context, indexName string) error {
+	return DropIndex(ctx, c, indexName)
 }
 
 // Issues a build command for any deferred sync gateway indexes associated with the bucket.
-func (c *Collection) BuildDeferredIndexes(indexSet []string) error {
-	return BuildDeferredIndexes(c, indexSet)
+func (c *Collection) BuildDeferredIndexes(ctx context.Context, indexSet []string) error {
+	return BuildDeferredIndexes(ctx, c, indexSet)
 }
 
 func (c *Collection) runQuery(statement string, n1qlOptions *gocb.QueryOptions) (*gocb.QueryResult, error) {

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -36,14 +36,14 @@ const (
 // N1QLStore defines the set of operations Sync Gateway uses to manage and interact with N1QL
 type N1QLStore interface {
 	GetName() string
-	BuildDeferredIndexes(indexSet []string) error
-	CreateIndex(indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error
-	CreatePrimaryIndex(indexName string, options *N1qlIndexOptions) error
-	DropIndex(indexName string) error
+	BuildDeferredIndexes(ctx context.Context, indexSet []string) error
+	CreateIndex(ctx context.Context, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error
+	CreatePrimaryIndex(ctx context.Context, indexName string, options *N1qlIndexOptions) error
+	DropIndex(ctx context.Context, indexName string) error
 	ExplainQuery(ctx context.Context, statement string, params map[string]interface{}) (plan map[string]interface{}, err error)
-	GetIndexMeta(indexName string) (exists bool, meta *IndexMeta, err error)
+	GetIndexMeta(ctx context.Context, indexName string) (exists bool, meta *IndexMeta, err error)
 	Query(ctx context.Context, statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (results sgbucket.QueryResultIterator, err error)
-	WaitForIndexOnline(indexName string) error
+	WaitForIndexOnline(ctx context.Context, indexName string) error
 	IsErrNoResults(error) bool
 	EscapedKeyspace() string
 	IndexMetaBucketID() string
@@ -89,7 +89,7 @@ func ExplainQuery(ctx context.Context, store N1QLStore, statement string, params
 //
 //	  CreateIndex("myIndex", "field1, field2, nested.field", "field1 > 0", N1qlIndexOptions{numReplica:1})
 //	CREATE INDEX myIndex on myBucket(field1, field2, nested.field) WHERE field1 > 0 WITH {"numReplica":1}
-func CreateIndex(store N1QLStore, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
+func CreateIndex(ctx context.Context, store N1QLStore, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
 	createStatement := fmt.Sprintf("CREATE INDEX `%s` ON %s(%s)", indexName, store.EscapedKeyspace(), expression)
 
 	// Add filter expression, when present
@@ -100,7 +100,7 @@ func CreateIndex(store N1QLStore, indexName string, expression string, filterExp
 	// Replace any KeyspaceQueryToken references in the index expression
 	createStatement = strings.Replace(createStatement, KeyspaceQueryToken, store.EscapedKeyspace(), -1)
 
-	createErr := createIndex(store, indexName, createStatement, options)
+	createErr := createIndex(ctx, store, indexName, createStatement, options)
 	if createErr != nil {
 		if strings.Contains(createErr.Error(), "already exists") || strings.Contains(createErr.Error(), "duplicate index name") {
 			return ErrAlreadyExists
@@ -109,12 +109,12 @@ func CreateIndex(store N1QLStore, indexName string, expression string, filterExp
 	return createErr
 }
 
-func CreatePrimaryIndex(store N1QLStore, indexName string, options *N1qlIndexOptions) error {
+func CreatePrimaryIndex(ctx context.Context, store N1QLStore, indexName string, options *N1qlIndexOptions) error {
 	createStatement := fmt.Sprintf("CREATE PRIMARY INDEX `%s` ON %s", indexName, store.EscapedKeyspace())
-	return createIndex(store, indexName, createStatement, options)
+	return createIndex(ctx, store, indexName, createStatement, options)
 }
 
-func createIndex(store N1QLStore, indexName string, createStatement string, options *N1qlIndexOptions) error {
+func createIndex(ctx context.Context, store N1QLStore, indexName string, createStatement string, options *N1qlIndexOptions) error {
 
 	if options != nil {
 		withClause, marshalErr := JSONMarshal(options)
@@ -124,7 +124,7 @@ func createIndex(store N1QLStore, indexName string, createStatement string, opti
 		createStatement = fmt.Sprintf(`%s with %s`, createStatement, withClause)
 	}
 
-	DebugfCtx(context.TODO(), KeyQuery, "Attempting to create index using statement: [%s]", UD(createStatement))
+	DebugfCtx(ctx, KeyQuery, "Attempting to create index using statement: [%s]", UD(createStatement))
 
 	err := store.executeStatement(createStatement)
 	if err == nil {
@@ -132,27 +132,27 @@ func createIndex(store N1QLStore, indexName string, createStatement string, opti
 	}
 
 	if IsIndexerRetryIndexError(err) {
-		InfofCtx(context.TODO(), KeyQuery, "Indexer error creating index - waiting for server background retry.  Error:%v", err)
+		InfofCtx(ctx, KeyQuery, "Indexer error creating index - waiting for server background retry.  Error:%v", err)
 		// Wait for bucket to be created in background before returning
-		return waitForIndexExistence(store, indexName, true)
+		return waitForIndexExistence(ctx, store, indexName, true)
 	}
 
 	if IsCreateDuplicateIndexError(err) {
-		InfofCtx(context.TODO(), KeyQuery, "Duplicate index creation in progress - waiting for index readiness.  Error:%v", err)
+		InfofCtx(ctx, KeyQuery, "Duplicate index creation in progress - waiting for index readiness.  Error:%v", err)
 		// Wait for bucket to be created in background before returning
-		return waitForIndexExistence(store, indexName, true)
+		return waitForIndexExistence(ctx, store, indexName, true)
 	}
 
 	return pkgerrors.WithStack(RedactErrorf("Error creating index with statement: %s.  Error: %v", UD(createStatement), err))
 }
 
 // Waits for index to exist/not exist.  Used in response to background create/drop processing by server.
-func waitForIndexExistence(store N1QLStore, indexName string, shouldExist bool) error {
+func waitForIndexExistence(ctx context.Context, store N1QLStore, indexName string, shouldExist bool) error {
 
 	worker := func() (shouldRetry bool, err error, value interface{}) {
 		// GetIndexMeta has its own error retry handling,
 		// but keep the retry logic up here for checking if the index exists.
-		exists, _, err := store.GetIndexMeta(indexName)
+		exists, _, err := store.GetIndexMeta(ctx, indexName)
 		if err != nil {
 			return false, err, nil
 		}
@@ -174,7 +174,7 @@ func waitForIndexExistence(store N1QLStore, indexName string, shouldExist bool) 
 }
 
 // BuildDeferredIndexes issues a build command for any deferred sync gateway indexes associated with the bucket.
-func BuildDeferredIndexes(s N1QLStore, indexSet []string) error {
+func BuildDeferredIndexes(ctx context.Context, s N1QLStore, indexSet []string) error {
 
 	if len(indexSet) == 0 {
 		return nil
@@ -217,15 +217,15 @@ func BuildDeferredIndexes(s N1QLStore, indexSet []string) error {
 		return nil
 	}
 
-	InfofCtx(context.TODO(), KeyQuery, "Building deferred indexes: %v", deferredIndexes)
-	buildErr := buildIndexes(s, deferredIndexes)
+	InfofCtx(ctx, KeyQuery, "Building deferred indexes: %v", deferredIndexes)
+	buildErr := buildIndexes(ctx, s, deferredIndexes)
 	return buildErr
 }
 
 // BuildIndexes executes a BUILD INDEX statement in the current bucket, using the form:
 //
 //	BUILD INDEX ON `bucket.Name`(`index1`, `index2`, ...)
-func buildIndexes(s N1QLStore, indexNames []string) error {
+func buildIndexes(ctx context.Context, s N1QLStore, indexNames []string) error {
 	if len(indexNames) == 0 {
 		return nil
 	}
@@ -238,10 +238,10 @@ func buildIndexes(s N1QLStore, indexNames []string) error {
 
 	// If indexer reports build will be completed in the background, wait to validate build actually happens.
 	if IsIndexerRetryBuildError(err) {
-		InfofCtx(context.TODO(), KeyQuery, "Indexer error creating index - waiting for background build.  Error:%v", err)
+		InfofCtx(ctx, KeyQuery, "Indexer error creating index - waiting for background build.  Error:%v", err)
 		// Wait for bucket to be created in background before returning
 		for _, indexName := range indexNames {
-			waitErr := s.WaitForIndexOnline(indexName)
+			waitErr := s.WaitForIndexOnline(ctx, indexName)
 			if waitErr != nil {
 				return waitErr
 			}
@@ -253,9 +253,9 @@ func buildIndexes(s N1QLStore, indexNames []string) error {
 }
 
 // WaitForIndexOnline waits for index state to be online
-func WaitForIndexOnline(store N1QLStore, indexName string) error {
+func WaitForIndexOnline(ctx context.Context, store N1QLStore, indexName string) error {
 	worker := func() (shouldRetry bool, err error, value interface{}) {
-		exists, indexMeta, getMetaErr := store.GetIndexMeta(indexName)
+		exists, indexMeta, getMetaErr := store.GetIndexMeta(ctx, indexName)
 		if exists && indexMeta.State == IndexStateOnline {
 			return false, nil, nil
 		}
@@ -286,13 +286,13 @@ type getIndexMetaRetryValues struct {
 	meta   *IndexMeta
 }
 
-func GetIndexMeta(store N1QLStore, indexName string) (exists bool, meta *IndexMeta, err error) {
+func GetIndexMeta(ctx context.Context, store N1QLStore, indexName string) (exists bool, meta *IndexMeta, err error) {
 
 	worker := func() (shouldRetry bool, err error, value interface{}) {
 		exists, meta, err := getIndexMetaWithoutRetry(store, indexName)
 		if err != nil {
 			// retry
-			WarnfCtx(context.TODO(), "Error from GetIndexMeta for index %s: %v will retry", indexName, err)
+			WarnfCtx(ctx, "Error from GetIndexMeta for index %s: %v will retry", indexName, err)
 			return true, err, nil
 		}
 		return false, nil, getIndexMetaRetryValues{
@@ -341,7 +341,7 @@ func getIndexMetaWithoutRetry(store N1QLStore, indexName string) (exists bool, m
 }
 
 // DropIndex drops the specified index from the current bucket.
-func DropIndex(store N1QLStore, indexName string) error {
+func DropIndex(ctx context.Context, store N1QLStore, indexName string) error {
 	statement := fmt.Sprintf("DROP INDEX default:%s.`%s`", store.EscapedKeyspace(), indexName)
 
 	err := store.executeStatement(statement)
@@ -350,9 +350,9 @@ func DropIndex(store N1QLStore, indexName string) error {
 	}
 
 	if IsIndexerRetryIndexError(err) {
-		InfofCtx(context.TODO(), KeyQuery, "Indexer error dropping index - waiting for server background retry.  Error:%v", err)
+		InfofCtx(ctx, KeyQuery, "Indexer error dropping index - waiting for server background retry.  Error:%v", err)
 		// Wait for bucket to be dropped in background before returning
-		return waitForIndexExistence(store, indexName, false)
+		return waitForIndexExistence(ctx, store, indexName, false)
 	}
 
 	return err

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -40,9 +40,9 @@ type N1QLStore interface {
 	CreateIndex(indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error
 	CreatePrimaryIndex(indexName string, options *N1qlIndexOptions) error
 	DropIndex(indexName string) error
-	ExplainQuery(statement string, params map[string]interface{}) (plan map[string]interface{}, err error)
+	ExplainQuery(ctx context.Context, statement string, params map[string]interface{}) (plan map[string]interface{}, err error)
 	GetIndexMeta(indexName string) (exists bool, meta *IndexMeta, err error)
-	Query(statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (results sgbucket.QueryResultIterator, err error)
+	Query(ctx context.Context, statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (results sgbucket.QueryResultIterator, err error)
 	WaitForIndexOnline(indexName string) error
 	IsErrNoResults(error) bool
 	EscapedKeyspace() string
@@ -63,9 +63,9 @@ type N1QLStore interface {
 	waitUntilQueryServiceReady(timeout time.Duration) error
 }
 
-func ExplainQuery(store N1QLStore, statement string, params map[string]interface{}) (plan map[string]interface{}, err error) {
+func ExplainQuery(ctx context.Context, store N1QLStore, statement string, params map[string]interface{}) (plan map[string]interface{}, err error) {
 	explainStatement := fmt.Sprintf("EXPLAIN %s", statement)
-	explainResults, explainErr := store.Query(explainStatement, params, RequestPlus, true)
+	explainResults, explainErr := store.Query(ctx, explainStatement, params, RequestPlus, true)
 
 	if explainErr != nil {
 		return nil, explainErr

--- a/base/collection_view.go
+++ b/base/collection_view.go
@@ -95,7 +95,7 @@ func (c *Collection) PutDDoc(ctx context.Context, docname string, sgDesignDoc *s
 	var worker RetryWorker = func() (bool, error, interface{}) {
 		err := manager.UpsertDesignDocument(gocbDesignDoc, gocb.DesignDocumentNamespaceProduction, nil)
 		if err != nil {
-			WarnfCtx(context.Background(), "Got error from UpsertDesignDocument: %v - Retrying...", err)
+			WarnfCtx(ctx, "Got error from UpsertDesignDocument: %v - Retrying...", err)
 			return true, err, nil
 		}
 		return false, nil, nil
@@ -176,7 +176,7 @@ func (c *Collection) DeleteDDoc(ctx context.Context, docname string) error {
 func (c *Collection) View(ctx context.Context, ddoc, name string, params map[string]interface{}) (sgbucket.ViewResult, error) {
 
 	var viewResult sgbucket.ViewResult
-	gocbViewResult, err := c.executeViewQuery(ddoc, name, params)
+	gocbViewResult, err := c.executeViewQuery(ctx, ddoc, name, params)
 	if err != nil {
 		return viewResult, err
 	}
@@ -233,18 +233,18 @@ func unmarshalViewMetadata(viewResult *gocb.ViewResultRaw) (viewMetadata, error)
 
 func (c *Collection) ViewQuery(ctx context.Context, ddoc, name string, params map[string]interface{}) (sgbucket.QueryResultIterator, error) {
 
-	gocbViewResult, err := c.executeViewQuery(ddoc, name, params)
+	gocbViewResult, err := c.executeViewQuery(ctx, ddoc, name, params)
 	if err != nil {
 		return nil, err
 	}
 	return &gocbRawIterator{rawResult: gocbViewResult, concurrentQueryOpLimitChan: c.queryOps}, nil
 }
 
-func (c *Collection) executeViewQuery(ddoc, name string, params map[string]interface{}) (*gocb.ViewResultRaw, error) {
+func (c *Collection) executeViewQuery(ctx context.Context, ddoc, name string, params map[string]interface{}) (*gocb.ViewResultRaw, error) {
 	viewResult := sgbucket.ViewResult{}
 	viewResult.Rows = sgbucket.ViewRows{}
 
-	viewOpts, optsErr := createViewOptions(params)
+	viewOpts, optsErr := createViewOptions(ctx, params)
 	if optsErr != nil {
 		return nil, optsErr
 	}
@@ -275,37 +275,37 @@ func (c *Collection) releaseQueryOp() {
 }
 
 // Applies the viewquery options as specified in the params map to the gocb.ViewOptions
-func createViewOptions(params map[string]interface{}) (viewOpts *gocb.ViewOptions, err error) {
+func createViewOptions(ctx context.Context, params map[string]interface{}) (viewOpts *gocb.ViewOptions, err error) {
 
 	viewOpts = &gocb.ViewOptions{}
 	for optionName, optionValue := range params {
 		switch optionName {
 		case ViewQueryParamStale:
-			viewOpts.ScanConsistency = asViewConsistency(optionValue)
+			viewOpts.ScanConsistency = asViewConsistency(ctx, optionValue)
 		case ViewQueryParamReduce:
-			viewOpts.Reduce = asBool(optionValue)
+			viewOpts.Reduce = asBool(ctx, optionValue)
 		case ViewQueryParamLimit:
 			uintVal, err := normalizeIntToUint(optionValue)
 			if err != nil {
-				WarnfCtx(context.Background(), "ViewQueryParamLimit error: %v", err)
+				WarnfCtx(ctx, "ViewQueryParamLimit error: %v", err)
 			}
 			viewOpts.Limit = uint32(uintVal)
 		case ViewQueryParamDescending:
-			if asBool(optionValue) == true {
+			if asBool(ctx, optionValue) == true {
 				viewOpts.Order = gocb.ViewOrderingDescending
 			}
 		case ViewQueryParamSkip:
 			uintVal, err := normalizeIntToUint(optionValue)
 			if err != nil {
-				WarnfCtx(context.Background(), "ViewQueryParamSkip error: %v", err)
+				WarnfCtx(ctx, "ViewQueryParamSkip error: %v", err)
 			}
 			viewOpts.Skip = uint32(uintVal)
 		case ViewQueryParamGroup:
-			viewOpts.Group = asBool(optionValue)
+			viewOpts.Group = asBool(ctx, optionValue)
 		case ViewQueryParamGroupLevel:
 			uintVal, err := normalizeIntToUint(optionValue)
 			if err != nil {
-				WarnfCtx(context.Background(), "ViewQueryParamGroupLevel error: %v", err)
+				WarnfCtx(ctx, "ViewQueryParamGroupLevel error: %v", err)
 			}
 			viewOpts.GroupLevel = uint32(uintVal)
 		case ViewQueryParamKey:
@@ -337,7 +337,7 @@ func createViewOptions(params map[string]interface{}) (viewOpts *gocb.ViewOption
 	// Default value of inclusiveEnd in Couchbase Server is true (if not specified)
 	inclusiveEnd := true
 	if _, ok := params[ViewQueryParamInclusiveEnd]; ok {
-		inclusiveEnd = asBool(params[ViewQueryParamInclusiveEnd])
+		inclusiveEnd = asBool(ctx, params[ViewQueryParamInclusiveEnd])
 	}
 	viewOpts.StartKey = startKey
 	viewOpts.EndKey = endKey
@@ -358,7 +358,7 @@ func createViewOptions(params map[string]interface{}) (viewOpts *gocb.ViewOption
 }
 
 // Used to convert the stale view parameter to a gocb ViewScanConsistency
-func asViewConsistency(value interface{}) gocb.ViewScanConsistency {
+func asViewConsistency(ctx context.Context, value interface{}) gocb.ViewScanConsistency {
 
 	switch typeValue := value.(type) {
 	case string:
@@ -370,7 +370,7 @@ func asViewConsistency(value interface{}) gocb.ViewScanConsistency {
 		}
 		parsedVal, err := strconv.ParseBool(typeValue)
 		if err != nil {
-			WarnfCtx(context.Background(), "asStale called with unknown value: %v.  defaulting to stale=false", typeValue)
+			WarnfCtx(ctx, "asStale called with unknown value: %v.  defaulting to stale=false", typeValue)
 			return gocb.ViewScanConsistencyRequestPlus
 		}
 		if parsedVal {
@@ -385,7 +385,7 @@ func asViewConsistency(value interface{}) gocb.ViewScanConsistency {
 			return gocb.ViewScanConsistencyRequestPlus
 		}
 	default:
-		WarnfCtx(context.Background(), "asViewConsistency called with unknown type: %T.  defaulting to RequestPlus", typeValue)
+		WarnfCtx(ctx, "asViewConsistency called with unknown type: %T.  defaulting to RequestPlus", typeValue)
 		return gocb.ViewScanConsistencyRequestPlus
 	}
 

--- a/base/collection_view.go
+++ b/base/collection_view.go
@@ -88,7 +88,7 @@ func (c *Collection) PutDDoc(ctx context.Context, docname string, sgDesignDoc *s
 
 	// If design doc needs to be tombstone-aware, requires custom creation*
 	if sgDesignDoc.Options != nil && sgDesignDoc.Options.IndexXattrOnTombstones {
-		return c.putDDocForTombstones(&gocbDesignDoc)
+		return c.putDDocForTombstones(ctx, &gocbDesignDoc)
 	}
 
 	// Retry for all errors (The view service sporadically returns 500 status codes with Erlang errors (for unknown reasons) - E.g: 500 {"error":"case_clause","reason":"false"})
@@ -147,7 +147,7 @@ type NoNameDesignDocument struct {
 	Views map[string]NoNameView `json:"views"`
 }
 
-func (c *Collection) putDDocForTombstones(ddoc *gocb.DesignDocument) error {
+func (c *Collection) putDDocForTombstones(ctx context.Context, ddoc *gocb.DesignDocument) error {
 	username, password, _ := c.Spec.Auth.GetCredentials()
 	agent, err := c.getGoCBAgent()
 	if err != nil {
@@ -165,7 +165,7 @@ func (c *Collection) putDDocForTombstones(ddoc *gocb.DesignDocument) error {
 		return err
 	}
 
-	return putDDocForTombstones(ddoc.Name, data, agent.CapiEps(), agent.HTTPClient(), username, password)
+	return putDDocForTombstones(ctx, ddoc.Name, data, agent.CapiEps(), agent.HTTPClient(), username, password)
 
 }
 

--- a/base/collection_view.go
+++ b/base/collection_view.go
@@ -31,7 +31,7 @@ type viewMetadata struct {
 	TotalRows int `json:"total_rows,omitempty"`
 }
 
-func (c *Collection) GetDDoc(docname string) (ddoc sgbucket.DesignDoc, err error) {
+func (c *Collection) GetDDoc(ctx context.Context, docname string) (ddoc sgbucket.DesignDoc, err error) {
 	manager := c.Bucket().ViewIndexes()
 	designDoc, err := manager.GetDesignDocument(docname, gocb.DesignDocumentNamespaceProduction, nil)
 	if err != nil {
@@ -50,7 +50,7 @@ func (c *Collection) GetDDoc(docname string) (ddoc sgbucket.DesignDoc, err error
 	return ddoc, err
 }
 
-func (c *Collection) GetDDocs() (ddocs map[string]sgbucket.DesignDoc, err error) {
+func (c *Collection) GetDDocs(ctx context.Context) (ddocs map[string]sgbucket.DesignDoc, err error) {
 	manager := c.Bucket().ViewIndexes()
 	gocbDDocs, getErr := manager.GetAllDesignDocuments(gocb.DesignDocumentNamespaceProduction, nil)
 	if getErr != nil {
@@ -71,7 +71,7 @@ func (c *Collection) GetDDocs() (ddocs map[string]sgbucket.DesignDoc, err error)
 	return ddocs, err
 }
 
-func (c *Collection) PutDDoc(docname string, sgDesignDoc *sgbucket.DesignDoc) error {
+func (c *Collection) PutDDoc(ctx context.Context, docname string, sgDesignDoc *sgbucket.DesignDoc) error {
 	manager := c.Bucket().ViewIndexes()
 	gocbDesignDoc := gocb.DesignDocument{
 		Name:  docname,
@@ -169,11 +169,11 @@ func (c *Collection) putDDocForTombstones(ddoc *gocb.DesignDocument) error {
 
 }
 
-func (c *Collection) DeleteDDoc(docname string) error {
+func (c *Collection) DeleteDDoc(ctx context.Context, docname string) error {
 	return c.Bucket().ViewIndexes().DropDesignDocument(docname, gocb.DesignDocumentNamespaceProduction, nil)
 }
 
-func (c *Collection) View(ddoc, name string, params map[string]interface{}) (sgbucket.ViewResult, error) {
+func (c *Collection) View(ctx context.Context, ddoc, name string, params map[string]interface{}) (sgbucket.ViewResult, error) {
 
 	var viewResult sgbucket.ViewResult
 	gocbViewResult, err := c.executeViewQuery(ddoc, name, params)
@@ -231,7 +231,7 @@ func unmarshalViewMetadata(viewResult *gocb.ViewResultRaw) (viewMetadata, error)
 	return viewMeta, err
 }
 
-func (c *Collection) ViewQuery(ddoc, name string, params map[string]interface{}) (sgbucket.QueryResultIterator, error) {
+func (c *Collection) ViewQuery(ctx context.Context, ddoc, name string, params map[string]interface{}) (sgbucket.QueryResultIterator, error) {
 
 	gocbViewResult, err := c.executeViewQuery(ddoc, name, params)
 	if err != nil {

--- a/base/collection_view.go
+++ b/base/collection_view.go
@@ -205,7 +205,7 @@ func (c *Collection) View(ctx context.Context, ddoc, name string, params map[str
 
 		viewMeta, err := unmarshalViewMetadata(gocbViewResult)
 		if err != nil {
-			WarnfCtx(context.TODO(), "Unable to type get metadata for gocb ViewResult - the total rows count will be missing.")
+			WarnfCtx(ctx, "Unable to type get metadata for gocb ViewResult - the total rows count will be missing.")
 		} else {
 			viewResult.TotalRows = viewMeta.TotalRows
 		}

--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -63,7 +63,7 @@ type DCPClientOptions struct {
 	CollectionIDs              []uint32                  // CollectionIDs used by gocbcore, if empty, uses default collections
 }
 
-func NewDCPClient(ID string, callback sgbucket.FeedEventCallbackFunc, options DCPClientOptions, collection *Collection) (*DCPClient, error) {
+func NewDCPClient(ctx context.Context, ID string, callback sgbucket.FeedEventCallbackFunc, options DCPClientOptions, collection *Collection) (*DCPClient, error) {
 
 	numWorkers := defaultNumWorkers
 	if options.NumWorkers > 0 {
@@ -104,7 +104,7 @@ func NewDCPClient(ID string, callback sgbucket.FeedEventCallbackFunc, options DC
 	checkpointPrefix := fmt.Sprintf("%s:%v", client.checkpointPrefix, ID)
 	switch options.MetadataStoreType {
 	case DCPMetadataStoreCS:
-		client.metadata = NewDCPMetadataCS(collection, numVbuckets, numWorkers, checkpointPrefix)
+		client.metadata = NewDCPMetadataCS(ctx, collection, numVbuckets, numWorkers, checkpointPrefix)
 	case DCPMetadataStoreInMemory:
 		client.metadata = NewDCPMetadataMem(numVbuckets)
 	default:
@@ -429,7 +429,7 @@ func (dc *DCPClient) deactivateVbucket(ctx context.Context, vbID uint16) {
 		dc.close(ctx)
 		// On successful one-shot feed completion, purge persisted checkpoints
 		if dc.oneShot {
-			dc.metadata.Purge(len(dc.workers))
+			dc.metadata.Purge(ctx, len(dc.workers))
 		}
 	}
 }

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -24,8 +24,8 @@ func TestOneShotDCP(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	bucket := GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
 
 	numDocs := 1000
 	// write documents to bucket
@@ -105,8 +105,8 @@ func TestTerminateDCPFeed(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	bucket := GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
 
 	// create callback
 	mutationCount := uint64(0)
@@ -188,8 +188,8 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(fmt.Sprintf("metadata mismatch %+v", test), func(t *testing.T) {
 
-			bucket := GetTestBucket(t)
-			defer bucket.Close()
+			ctx, bucket := GetTestBucket(t)
+			defer bucket.Close(ctx)
 
 			// create callback
 			mutationCount := uint64(0)
@@ -309,8 +309,8 @@ func TestResumeStoppedFeed(t *testing.T) {
 
 	SetUpTestLogging(t, LevelDebug, KeyAll)
 
-	bucket := GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
 
 	var dcpClient *DCPClient
 
@@ -420,8 +420,8 @@ func TestBadAgentPriority(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server, since DCPClient requires a base.Collection")
 	}
 
-	bucket := GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
 
 	feedID := "fakeID"
 	panicCallback := func(event sgbucket.FeedEvent) bool {

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -63,7 +63,7 @@ func TestOneShotDCP(t *testing.T) {
 		CollectionIDs: collectionIDs,
 	}
 
-	dcpClient, err := NewDCPClient(feedID, counterCallback, clientOptions, collection)
+	dcpClient, err := NewDCPClient(ctx, feedID, counterCallback, clientOptions, collection)
 	require.NoError(t, err)
 
 	doneChan, startErr := dcpClient.Start(ctx)
@@ -120,7 +120,7 @@ func TestTerminateDCPFeed(t *testing.T) {
 
 	collection, err := AsCollection(bucket)
 	require.NoError(t, err)
-	dcpClient, err := NewDCPClient(feedID, counterCallback, DCPClientOptions{}, collection)
+	dcpClient, err := NewDCPClient(ctx, feedID, counterCallback, DCPClientOptions{}, collection)
 	require.NoError(t, err)
 
 	// Add documents in a separate goroutine
@@ -229,7 +229,7 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 				CollectionIDs:  collectionIDs,
 			}
 
-			dcpClient, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, collection)
+			dcpClient, err := NewDCPClient(ctx, feedID, counterCallback, dcpClientOpts, collection)
 			require.NoError(t, err)
 
 			doneChan, startErr := dcpClient.Start(ctx)
@@ -260,7 +260,7 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 				OneShot:         true,
 				CollectionIDs:   collectionIDs,
 			}
-			dcpClient2, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, collection)
+			dcpClient2, err := NewDCPClient(ctx, feedID, counterCallback, dcpClientOpts, collection)
 			require.NoError(t, err)
 
 			doneChan2, startErr2 := dcpClient2.Start(ctx)
@@ -280,7 +280,7 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 			collection, err = AsCollection(bucket)
 			require.NoError(t, err)
 
-			dcpClient3, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, collection)
+			dcpClient3, err := NewDCPClient(ctx, feedID, counterCallback, dcpClientOpts, collection)
 			require.NoError(t, err)
 
 			doneChan3, startErr3 := dcpClient3.Start(ctx)
@@ -357,7 +357,7 @@ func TestResumeStoppedFeed(t *testing.T) {
 		CollectionIDs:              collectionIDs,
 	}
 
-	dcpClient, err = NewDCPClient(feedID, counterCallback, dcpClientOpts, collection)
+	dcpClient, err = NewDCPClient(ctx, feedID, counterCallback, dcpClientOpts, collection)
 	require.NoError(t, err)
 
 	doneChan, startErr := dcpClient.Start(ctx)
@@ -392,7 +392,7 @@ func TestResumeStoppedFeed(t *testing.T) {
 	collection, err = AsCollection(bucket)
 	require.NoError(t, err)
 
-	dcpClient2, err := NewDCPClient(feedID, secondCallback, dcpClientOpts, collection)
+	dcpClient2, err := NewDCPClient(ctx, feedID, secondCallback, dcpClientOpts, collection)
 	require.NoError(t, err)
 
 	doneChan2, startErr2 := dcpClient2.Start(ctx)
@@ -433,7 +433,7 @@ func TestBadAgentPriority(t *testing.T) {
 	}
 	collection, err := AsCollection(bucket)
 	require.NoError(t, err)
-	dcpClient, err := NewDCPClient(feedID, panicCallback, dcpClientOpts, collection)
+	dcpClient, err := NewDCPClient(ctx, feedID, panicCallback, dcpClientOpts, collection)
 	require.Error(t, err)
 	require.Nil(t, dcpClient)
 }

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -66,11 +66,11 @@ func TestOneShotDCP(t *testing.T) {
 	dcpClient, err := NewDCPClient(feedID, counterCallback, clientOptions, collection)
 	require.NoError(t, err)
 
-	doneChan, startErr := dcpClient.Start()
+	doneChan, startErr := dcpClient.Start(ctx)
 	require.NoError(t, startErr)
 
 	defer func() {
-		_ = dcpClient.Close()
+		_ = dcpClient.Close(ctx)
 	}()
 
 	// Add additional documents in a separate goroutine, to verify one-shot behaviour
@@ -140,13 +140,13 @@ func TestTerminateDCPFeed(t *testing.T) {
 		}
 	}()
 
-	doneChan, startErr := dcpClient.Start()
+	doneChan, startErr := dcpClient.Start(ctx)
 	require.NoError(t, startErr)
 
 	// Wait for some processing to complete, then close the feed
 	time.Sleep(10 * time.Millisecond)
 	log.Printf("Closing DCP Client")
-	err = dcpClient.Close()
+	err = dcpClient.Close(ctx)
 	log.Printf("DCP Client closed, waiting for feed close notification")
 	require.NoError(t, err)
 
@@ -232,7 +232,7 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 			dcpClient, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, collection)
 			require.NoError(t, err)
 
-			doneChan, startErr := dcpClient.Start()
+			doneChan, startErr := dcpClient.Start(ctx)
 			require.NoError(t, startErr)
 
 			// Wait for first feed to complete
@@ -263,10 +263,10 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 			dcpClient2, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, collection)
 			require.NoError(t, err)
 
-			doneChan2, startErr2 := dcpClient2.Start()
+			doneChan2, startErr2 := dcpClient2.Start(ctx)
 			require.Error(t, startErr2)
 
-			require.NoError(t, dcpClient2.Close())
+			require.NoError(t, dcpClient2.Close(ctx))
 			<-doneChan2
 			log.Printf("Starting third feed")
 			// Perform a third DCP feed - mismatched VbUUID, failOnRollback=false
@@ -283,7 +283,7 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 			dcpClient3, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, collection)
 			require.NoError(t, err)
 
-			doneChan3, startErr3 := dcpClient3.Start()
+			doneChan3, startErr3 := dcpClient3.Start(ctx)
 			require.NoError(t, startErr3)
 
 			// Wait for third feed to complete
@@ -320,7 +320,7 @@ func TestResumeStoppedFeed(t *testing.T) {
 		if bytes.HasPrefix(event.Key, []byte(t.Name())) {
 			count := atomic.AddUint64(&mutationCount, 1)
 			if count > 5000 {
-				err := dcpClient.Close()
+				err := dcpClient.Close(ctx)
 				assert.NoError(t, err)
 			}
 		}
@@ -360,7 +360,7 @@ func TestResumeStoppedFeed(t *testing.T) {
 	dcpClient, err = NewDCPClient(feedID, counterCallback, dcpClientOpts, collection)
 	require.NoError(t, err)
 
-	doneChan, startErr := dcpClient.Start()
+	doneChan, startErr := dcpClient.Start(ctx)
 	require.NoError(t, startErr)
 
 	// Wait for first feed to complete
@@ -395,7 +395,7 @@ func TestResumeStoppedFeed(t *testing.T) {
 	dcpClient2, err := NewDCPClient(feedID, secondCallback, dcpClientOpts, collection)
 	require.NoError(t, err)
 
-	doneChan2, startErr2 := dcpClient2.Start()
+	doneChan2, startErr2 := dcpClient2.Start(ctx)
 	require.NoError(t, startErr2)
 
 	// Wait for second feed to complete

--- a/base/dcp_client_worker.go
+++ b/base/dcp_client_worker.go
@@ -150,7 +150,7 @@ func (w *DCPWorker) updateSeq(key []byte, vbID uint16, seq uint64) {
 	w.metadata.UpdateSeq(vbID, seq)
 
 	if time.Since(w.lastMetaPersistTime) > w.metaPersistFrequency {
-		w.metadata.Persist(w.ID, w.assignedVbs)
+		w.metadata.Persist(w.loggingCtx, w.ID, w.assignedVbs)
 	}
 
 }

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -241,7 +241,7 @@ func (c *DCPCommon) initMetadata(maxVbNo uint16) {
 	defer c.m.Unlock()
 
 	// Check for persisted backfill sequences
-	backfillSeqs, err := c.backfill.loadBackfillSequences(c.metaStore)
+	backfillSeqs, err := c.backfill.loadBackfillSequences(c.loggingCtx, c.metaStore)
 	if err != nil {
 		// Backfill sequences not present or invalid - will use metadata only
 		backfillSeqs = nil
@@ -307,7 +307,7 @@ func (c *DCPCommon) updateSeq(vbucketId uint16, seq uint64, warnOnLowerSeqNo boo
 
 	// If in backfill, update backfill tracking
 	if c.backfill.isActive() {
-		c.backfill.updateStats(vbucketId, previousSequence, c.seqs, c.metaStore)
+		c.backfill.updateStats(c.loggingCtx, vbucketId, previousSequence, c.seqs, c.metaStore)
 	}
 
 }
@@ -430,12 +430,11 @@ func (b *backfillStatus) snapshotStart(vbNo uint16, snapStart uint64, snapEnd ui
 	b.snapStart[vbNo] = snapStart
 	b.snapEnd[vbNo] = snapEnd
 }
-func (b *backfillStatus) updateStats(vbno uint16, previousVbSequence uint64, currentSequences []uint64, bucket Bucket) {
+func (b *backfillStatus) updateStats(ctx context.Context, vbno uint16, previousVbSequence uint64, currentSequences []uint64, bucket Bucket) {
 	if !b.vbActive[vbno] {
 		return
 	}
 
-	logCtx := context.TODO()
 	currentVbSequence := currentSequences[vbno]
 
 	// Update backfill progress.  If this vbucket has run past the end of the backfill, only include up to
@@ -458,28 +457,28 @@ func (b *backfillStatus) updateStats(vbno uint16, previousVbSequence uint64, cur
 		b.lastPersistTime = time.Now()
 		err := b.persistBackfillSequences(bucket, currentSequences)
 		if err != nil {
-			WarnfCtx(logCtx, "Error persisting back-fill sequences: %v", err)
+			WarnfCtx(ctx, "Error persisting back-fill sequences: %v", err)
 		}
-		b.logBackfillProgress()
+		b.logBackfillProgress(ctx)
 	}
 
 	// If backfill is complete, log and do backfill inactivation/cleanup
 	if b.receivedSequences >= b.expectedSequences {
-		InfofCtx(logCtx, KeyDCP, "Backfill complete")
+		InfofCtx(ctx, KeyDCP, "Backfill complete")
 		b.active = false
 		err := b.purgeBackfillSequences(bucket)
 		if err != nil {
-			WarnfCtx(logCtx, "Error purging back-fill sequences: %v", err)
+			WarnfCtx(ctx, "Error purging back-fill sequences: %v", err)
 		}
 	}
 }
 
 // Logs current backfill progress.  Expects caller to have the lock on r.m
-func (b *backfillStatus) logBackfillProgress() {
+func (b *backfillStatus) logBackfillProgress(ctx context.Context) {
 	if !b.active {
 		return
 	}
-	InfofCtx(context.TODO(), KeyDCP, "Backfill in progress: %d%% (%d / %d)", int(b.receivedSequences*100/b.expectedSequences), b.receivedSequences, b.expectedSequences)
+	InfofCtx(ctx, KeyDCP, "Backfill in progress: %d%% (%d / %d)", int(b.receivedSequences*100/b.expectedSequences), b.receivedSequences, b.expectedSequences)
 }
 
 // BackfillSequences defines the format used to persist snapshot information to the _sync:dcp_backfill document
@@ -499,13 +498,13 @@ func (b *backfillStatus) persistBackfillSequences(bucket Bucket, currentSeqs []u
 	return bucket.Set(DCPBackfillSeqKey, 0, nil, backfillSeqs)
 }
 
-func (b *backfillStatus) loadBackfillSequences(bucket Bucket) (*BackfillSequences, error) {
+func (b *backfillStatus) loadBackfillSequences(ctx context.Context, bucket Bucket) (*BackfillSequences, error) {
 	var backfillSeqs BackfillSequences
 	_, err := bucket.Get(DCPBackfillSeqKey, &backfillSeqs)
 	if err != nil {
 		return nil, err
 	}
-	InfofCtx(context.TODO(), KeyDCP, "Previously persisted backfill sequences found - will resume")
+	InfofCtx(ctx, KeyDCP, "Previously persisted backfill sequences found - will resume")
 	return &backfillSeqs, nil
 }
 
@@ -628,11 +627,11 @@ const (
 )
 
 // getNetworkTypeFromConnSpec returns the configured network type, or clusterNetworkAuto if nothing is defined.
-func getNetworkTypeFromConnSpec(spec gocbconnstr.ConnSpec) clusterNetworkType {
+func getNetworkTypeFromConnSpec(ctx context.Context, spec gocbconnstr.ConnSpec) clusterNetworkType {
 	networkType := clusterNetworkAuto
 	if networkOpt, ok := spec.Options["network"]; ok && len(networkOpt) > 0 {
 		if len(networkOpt) > 1 {
-			WarnfCtx(context.TODO(), "multiple 'network' options found in connection string - using first one: %q", networkOpt[0])
+			WarnfCtx(ctx, "multiple 'network' options found in connection string - using first one: %q", networkOpt[0])
 		}
 		networkType = clusterNetworkType(networkOpt[0])
 	}

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -106,7 +106,7 @@ func (d *DCPDest) DataUpdate(partition string, key []byte, seq uint64,
 	if !dcpKeyFilter(key) {
 		return nil
 	}
-	event := makeFeedEventForDest(key, val, cas, partitionToVbNo(partition), collectionIDFromExtras(extras), 0, 0, sgbucket.FeedOpMutation)
+	event := makeFeedEventForDest(key, val, cas, partitionToVbNo(d.loggingCtx, partition), collectionIDFromExtras(extras), 0, 0, sgbucket.FeedOpMutation)
 	d.dataUpdate(seq, event)
 	return nil
 }
@@ -130,7 +130,7 @@ func (d *DCPDest) DataUpdateEx(partition string, key []byte, seq uint64, val []b
 		if !ok {
 			return errors.New("Unable to cast extras of type DEST_EXTRAS_TYPE_GOCB_DCP to cbgt.GocbExtras")
 		}
-		event = makeFeedEventForDest(key, val, cas, partitionToVbNo(partition), dcpExtras.CollectionId, dcpExtras.Expiry, dcpExtras.Datatype, sgbucket.FeedOpMutation)
+		event = makeFeedEventForDest(key, val, cas, partitionToVbNo(d.loggingCtx, partition), dcpExtras.CollectionId, dcpExtras.Expiry, dcpExtras.Datatype, sgbucket.FeedOpMutation)
 
 	}
 
@@ -145,7 +145,7 @@ func (d *DCPDest) DataDelete(partition string, key []byte, seq uint64,
 		return nil
 	}
 
-	event := makeFeedEventForDest(key, nil, cas, partitionToVbNo(partition), collectionIDFromExtras(extras), 0, 0, sgbucket.FeedOpDeletion)
+	event := makeFeedEventForDest(key, nil, cas, partitionToVbNo(d.loggingCtx, partition), collectionIDFromExtras(extras), 0, 0, sgbucket.FeedOpDeletion)
 	d.dataUpdate(seq, event)
 	return nil
 }
@@ -168,7 +168,7 @@ func (d *DCPDest) DataDeleteEx(partition string, key []byte, seq uint64,
 		if !ok {
 			return errors.New("Unable to cast extras of type DEST_EXTRAS_TYPE_GOCB_DCP to cbgt.GocbExtras")
 		}
-		event = makeFeedEventForDest(key, dcpExtras.Value, cas, partitionToVbNo(partition), dcpExtras.CollectionId, dcpExtras.Expiry, dcpExtras.Datatype, sgbucket.FeedOpDeletion)
+		event = makeFeedEventForDest(key, dcpExtras.Value, cas, partitionToVbNo(d.loggingCtx, partition), dcpExtras.CollectionId, dcpExtras.Expiry, dcpExtras.Datatype, sgbucket.FeedOpDeletion)
 
 	}
 	d.dataUpdate(seq, event)
@@ -177,12 +177,12 @@ func (d *DCPDest) DataDeleteEx(partition string, key []byte, seq uint64,
 
 func (d *DCPDest) SnapshotStart(partition string,
 	snapStart, snapEnd uint64) error {
-	d.snapshotStart(partitionToVbNo(partition), snapStart, snapEnd)
+	d.snapshotStart(partitionToVbNo(d.loggingCtx, partition), snapStart, snapEnd)
 	return nil
 }
 
 func (d *DCPDest) OpaqueGet(partition string) (value []byte, lastSeq uint64, err error) {
-	vbNo := partitionToVbNo(partition)
+	vbNo := partitionToVbNo(d.loggingCtx, partition)
 	if !d.metaInitComplete[vbNo] {
 		d.InitVbMeta(vbNo)
 		d.metaInitComplete[vbNo] = true
@@ -196,7 +196,7 @@ func (d *DCPDest) OpaqueGet(partition string) (value []byte, lastSeq uint64, err
 }
 
 func (d *DCPDest) OpaqueSet(partition string, value []byte) error {
-	vbNo := partitionToVbNo(partition)
+	vbNo := partitionToVbNo(d.loggingCtx, partition)
 	if !d.metaInitComplete[vbNo] {
 		d.InitVbMeta(vbNo)
 		d.metaInitComplete[vbNo] = true
@@ -206,12 +206,12 @@ func (d *DCPDest) OpaqueSet(partition string, value []byte) error {
 }
 
 func (d *DCPDest) Rollback(partition string, rollbackSeq uint64) error {
-	return d.rollback(partitionToVbNo(partition), rollbackSeq)
+	return d.rollback(partitionToVbNo(d.loggingCtx, partition), rollbackSeq)
 }
 
 func (d *DCPDest) RollbackEx(partition string, vbucketUUID uint64, rollbackSeq uint64) error {
 	cbgtMeta := makeVbucketMetadataForSequence(vbucketUUID, rollbackSeq)
-	return d.rollbackEx(partitionToVbNo(partition), vbucketUUID, rollbackSeq, cbgtMeta)
+	return d.rollbackEx(partitionToVbNo(d.loggingCtx, partition), vbucketUUID, rollbackSeq, cbgtMeta)
 }
 
 // TODO: Not implemented, review potential usage
@@ -237,10 +237,10 @@ func (d *DCPDest) Stats(io.Writer) error {
 	return nil
 }
 
-func partitionToVbNo(partition string) uint16 {
+func partitionToVbNo(ctx context.Context, partition string) uint16 {
 	vbNo, err := strconv.Atoi(partition)
 	if err != nil {
-		ErrorfCtx(context.Background(), "Unexpected non-numeric partition value %s, ignoring: %v", partition, err)
+		ErrorfCtx(ctx, "Unexpected non-numeric partition value %s, ignoring: %v", partition, err)
 		return 0
 	}
 	return uint16(vbNo)

--- a/base/dcp_feed_type.go
+++ b/base/dcp_feed_type.go
@@ -150,7 +150,7 @@ type SGFeedIndexParams struct {
 
 // cbgtFeedParams returns marshalled cbgt.DCPFeedParams as string, to be passed as feedparams during cbgt.Manager init.
 // Used to pass basic auth credentials and xattr flag to cbgt.
-func cbgtFeedParams(spec BucketSpec, scope string, collections []string, dbName string) (string, error) {
+func cbgtFeedParams(ctx context.Context, spec BucketSpec, scope string, collections []string, dbName string) (string, error) {
 	feedParams := &SGFeedSourceParams{}
 	feedParams.DbName = dbName
 
@@ -167,7 +167,7 @@ func cbgtFeedParams(spec BucketSpec, scope string, collections []string, dbName 
 	if err != nil {
 		return "", err
 	}
-	TracefCtx(context.TODO(), KeyDCP, "CBGT feed params: %v", UD(string(paramBytes)))
+	TracefCtx(ctx, KeyDCP, "CBGT feed params: %v", UD(string(paramBytes)))
 	return string(paramBytes), nil
 }
 

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -291,7 +291,7 @@ func StartDCPFeed(ctx context.Context, bucket Bucket, spec BucketSpec, args sgbu
 
 	if spec.IsTLS() {
 		dataSourceOptions.TLSConfig = func() *tls.Config {
-			return spec.TLSConfig()
+			return spec.TLSConfig(ctx)
 		}
 	}
 

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -295,7 +295,7 @@ func StartDCPFeed(ctx context.Context, bucket Bucket, spec BucketSpec, args sgbu
 		}
 	}
 
-	networkType := getNetworkTypeFromConnSpec(connSpec)
+	networkType := getNetworkTypeFromConnSpec(ctx, connSpec)
 	InfofCtx(ctx, KeyDCP, "Using network type: %s", networkType)
 
 	// default (aka internal) networking is handled by cbdatasource, so we can avoid the shims altogether in this case, for all other cases we need shims to remap hosts.

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -155,7 +155,7 @@ func createCBGTIndex(ctx context.Context, c *CbgtContext, dbName string, configG
 	cbgt.RegisterBucketDataSourceOptionsCallback(indexName, c.Manager.UUID(), func(options *cbdatasource.BucketDataSourceOptions) *cbdatasource.BucketDataSourceOptions {
 		if spec.IsTLS() {
 			options.TLSConfig = func() *tls.Config {
-				return spec.TLSConfig()
+				return spec.TLSConfig(ctx)
 			}
 		}
 

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -580,7 +580,7 @@ func (l *importHeartbeatListener) subscribeNodeChanges(ctx context.Context) erro
 		return err
 	}
 	go func() {
-		defer FatalPanicHandler()
+		defer FatalPanicHandler(ctx)
 		for {
 			select {
 			case <-cfgEvents:

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -70,7 +70,7 @@ func StartShardedDCPFeed(ctx context.Context, dbName string, configGroup string,
 
 	// Register heartbeat listener to trigger removal from cfg when
 	// other SG nodes stop sending heartbeats.
-	listener, err := registerHeartbeatListener(heartbeater, cbgtContext)
+	listener, err := registerHeartbeatListener(ctx, heartbeater, cbgtContext)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func createCBGTIndex(ctx context.Context, c *CbgtContext, dbName string, configG
 		return err
 	}
 
-	sourceParams, err := cbgtFeedParams(spec, scope, collections, dbName)
+	sourceParams, err := cbgtFeedParams(ctx, spec, scope, collections, dbName)
 	if err != nil {
 		return err
 	}
@@ -159,7 +159,7 @@ func createCBGTIndex(ctx context.Context, c *CbgtContext, dbName string, configG
 			}
 		}
 
-		networkType := getNetworkTypeFromConnSpec(connSpec)
+		networkType := getNetworkTypeFromConnSpec(ctx, connSpec)
 		InfofCtx(ctx, KeyDCP, "Using network type: %s", networkType)
 
 		// default (aka internal) networking is handled by cbdatasource, so we can avoid the shims altogether in this case, for all other cases we need shims to remap hosts.
@@ -492,14 +492,14 @@ func initCfgCB(bucket Bucket, spec BucketSpec) (*cbgt.CfgCB, error) {
 	return cfgCB, nil
 }
 
-func registerHeartbeatListener(heartbeater Heartbeater, cbgtContext *CbgtContext) (*importHeartbeatListener, error) {
+func registerHeartbeatListener(ctx context.Context, heartbeater Heartbeater, cbgtContext *CbgtContext) (*importHeartbeatListener, error) {
 
 	if cbgtContext == nil || cbgtContext.Manager == nil || cbgtContext.Cfg == nil || heartbeater == nil {
 		return nil, errors.New("Unable to register import heartbeat listener with nil manager, cfg or heartbeater")
 	}
 
 	// Register listener for import, uses cfg and manager to manage set of participating nodes
-	importHeartbeatListener, err := NewImportHeartbeatListener(cbgtContext)
+	importHeartbeatListener, err := NewImportHeartbeatListener(ctx, cbgtContext)
 	if err != nil {
 		return nil, err
 	}
@@ -522,16 +522,16 @@ type importHeartbeatListener struct {
 	lock       sync.RWMutex  // lock for nodeIDs access
 }
 
-func NewImportHeartbeatListener(ctx *CbgtContext) (*importHeartbeatListener, error) {
+func NewImportHeartbeatListener(ctx context.Context, cbgtContext *CbgtContext) (*importHeartbeatListener, error) {
 
 	if ctx == nil {
 		return nil, errors.New("ctx must not be nil for ImportHeartbeatListener")
 	}
 
 	listener := &importHeartbeatListener{
-		ctx:        ctx,
-		mgr:        ctx.Manager,
-		cfg:        ctx.Cfg,
+		ctx:        cbgtContext,
+		mgr:        cbgtContext.Manager,
+		cfg:        cbgtContext.Cfg,
 		terminator: make(chan struct{}),
 	}
 
@@ -542,7 +542,7 @@ func NewImportHeartbeatListener(ctx *CbgtContext) (*importHeartbeatListener, err
 	}
 
 	// Subscribe to changes to the known node set key
-	err = listener.subscribeNodeChanges()
+	err = listener.subscribeNodeChanges(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -555,29 +555,28 @@ func (l *importHeartbeatListener) Name() string {
 }
 
 // When we detect other nodes have stopped pushing heartbeats, use manager to remove from cfg
-func (l *importHeartbeatListener) StaleHeartbeatDetected(nodeUUID string) {
+func (l *importHeartbeatListener) StaleHeartbeatDetected(ctx context.Context, nodeUUID string) {
 
-	InfofCtx(context.TODO(), KeyCluster, "StaleHeartbeatDetected by import listener for node: %v", nodeUUID)
+	InfofCtx(ctx, KeyCluster, "StaleHeartbeatDetected by import listener for node: %v", nodeUUID)
 	err := cbgt.UnregisterNodes(l.cfg, l.mgr.Version(), []string{nodeUUID})
 	if err != nil {
-		WarnfCtx(context.TODO(), "Attempt to unregister %v from CBGT got error: %v", nodeUUID, err)
+		WarnfCtx(ctx, "Attempt to unregister %v from CBGT got error: %v", nodeUUID, err)
 	}
 }
 
 // subscribeNodeChanges registers with the manager's cfg implementation for notifications on changes to the
 // NODE_DEFS_KNOWN key.  When notified, refreshes the handlers nodeIDs.
-func (l *importHeartbeatListener) subscribeNodeChanges() error {
-	logCtx := context.TODO()
+func (l *importHeartbeatListener) subscribeNodeChanges(ctx context.Context) error {
 
 	cfgEvents := make(chan cbgt.CfgEvent)
 	err := l.cfg.Subscribe(cbgt.CfgNodeDefsKey(cbgt.NODE_DEFS_KNOWN), cfgEvents)
 	if err != nil {
-		DebugfCtx(logCtx, KeyCluster, "Error subscribing NODE_DEFS_KNOWN changes: %v", err)
+		DebugfCtx(ctx, KeyCluster, "Error subscribing NODE_DEFS_KNOWN changes: %v", err)
 		return err
 	}
 	err = l.cfg.Subscribe(cbgt.CfgNodeDefsKey(cbgt.NODE_DEFS_WANTED), cfgEvents)
 	if err != nil {
-		DebugfCtx(logCtx, KeyCluster, "Error subscribing NODE_DEFS_WANTED changes: %v", err)
+		DebugfCtx(ctx, KeyCluster, "Error subscribing NODE_DEFS_WANTED changes: %v", err)
 		return err
 	}
 	go func() {
@@ -587,12 +586,12 @@ func (l *importHeartbeatListener) subscribeNodeChanges() error {
 			case <-cfgEvents:
 				localNodeRegistered, err := l.reloadNodes()
 				if err != nil {
-					WarnfCtx(logCtx, "Error while reloading heartbeat node definitions: %v", err)
+					WarnfCtx(ctx, "Error while reloading heartbeat node definitions: %v", err)
 				}
 				if !localNodeRegistered {
 					registerErr := l.mgr.Register(cbgt.NODE_DEFS_WANTED)
 					if registerErr != nil {
-						WarnfCtx(logCtx, "Error attempting to re-register node, node will not participate in import until restarted or cbgt cfg is next updated: %v", registerErr)
+						WarnfCtx(ctx, "Error attempting to re-register node, node will not participate in import until restarted or cbgt cfg is next updated: %v", registerErr)
 					}
 				}
 

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -144,13 +144,13 @@ func TestCBGTIndexCreation(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			bucket := GetTestBucket(t)
-			defer bucket.Close()
+			ctx, bucket := GetTestBucket(t)
+			defer bucket.Close(ctx)
 
 			spec := bucket.BucketSpec
 
 			// Use an in-memory cfg, set up cbgt manager
-			ctx := LogContextWith(TestCtx(t), &DatabaseLogContext{DatabaseName: tc.dbName})
+			ctx = LogContextWith(ctx, &DatabaseLogContext{DatabaseName: tc.dbName})
 			cfg := cbgt.NewCfgMem()
 			context, err := initCBGTManager(ctx, bucket, spec, cfg, "testIndexCreation", tc.dbName)
 			assert.NoError(t, err)
@@ -247,14 +247,13 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 	if UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server bucket")
 	}
-	bucket := GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
 
 	spec := bucket.BucketSpec
 	testDbName := "testDB"
 
 	// Use an in-memory cfg, set up cbgt manager
-	ctx := TestCtx(t)
 	cfg := cbgt.NewCfgMem()
 	context, err := initCBGTManager(ctx, bucket, spec, cfg, "testIndexCreation", testDbName)
 	assert.NoError(t, err)
@@ -321,8 +320,8 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 	if UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server bucket")
 	}
-	bucket := GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
 
 	spec := bucket.BucketSpec
 	unsafeTestDBName := "testDB" +
@@ -331,7 +330,6 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 		"01234567890123456789012345678901234567890123456789"
 
 	// Use an in-memory cfg, set up cbgt manager
-	ctx := TestCtx(t)
 	cfg := cbgt.NewCfgMem()
 	context, err := initCBGTManager(ctx, bucket, spec, cfg, "testIndexCreation", unsafeTestDBName)
 	assert.NoError(t, err)
@@ -400,8 +398,8 @@ func TestConcurrentCBGTIndexCreation(t *testing.T) {
 	if UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server bucket")
 	}
-	bucket := GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := GetTestBucket(t)
+	defer bucket.Close(ctx)
 
 	spec := bucket.BucketSpec
 	testDBName := "testDB"

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -201,7 +201,7 @@ func TestCBGTIndexCreation(t *testing.T) {
 			if tc.existingCurrentIndex {
 				// Define an existing CBGT index with current naming
 				bucketUUID, _ := bucket.UUID()
-				sourceParams, err := cbgtFeedParams(spec, "", nil, tc.dbName)
+				sourceParams, err := cbgtFeedParams(ctx, spec, "", nil, tc.dbName)
 				require.NoError(t, err)
 				legacyIndexName := GenerateIndexName(tc.dbName)
 				indexParams := `{"name": "` + tc.dbName + `"}`
@@ -272,7 +272,7 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 
 	// Define a CBGT index with legacy naming within safe limits
 	bucketUUID, _ := bucket.UUID()
-	sourceParams, err := cbgtFeedParams(spec, "", nil, testDbName)
+	sourceParams, err := cbgtFeedParams(ctx, spec, "", nil, testDbName)
 	require.NoError(t, err)
 	legacyIndexName := GenerateLegacyIndexName(testDbName)
 	indexParams := `{"name": "` + testDbName + `"}`
@@ -348,7 +348,7 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 
 	// Define a CBGT index with legacy naming not within safe limits
 	bucketUUID, _ := bucket.UUID()
-	sourceParams, err := cbgtFeedParams(spec, "", nil, unsafeTestDBName)
+	sourceParams, err := cbgtFeedParams(ctx, spec, "", nil, unsafeTestDBName)
 	require.NoError(t, err)
 	legacyIndexName := GenerateLegacyIndexName(unsafeTestDBName)
 	indexParams := `{"name": "` + unsafeTestDBName + `"}`

--- a/base/gocb_dcp_feed.go
+++ b/base/gocb_dcp_feed.go
@@ -73,11 +73,11 @@ func StartGocbDCPFeed(ctx context.Context, collection *Collection, bucketName st
 		return err
 	}
 
-	doneChan, err := dcpClient.Start()
+	doneChan, err := dcpClient.Start(ctx)
 	if err != nil {
 		ErrorfCtx(ctx, "Failed to start DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), err)
 		// simplify in CBG-2234
-		closeErr := dcpClient.Close()
+		closeErr := dcpClient.Close(ctx)
 		ErrorfCtx(ctx, "Finished called async close error from DCP Feed %q for bucket %q", feedName, MD(bucketName))
 		if closeErr != nil {
 			ErrorfCtx(ctx, "Close error from DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), closeErr)
@@ -103,7 +103,7 @@ func StartGocbDCPFeed(ctx context.Context, collection *Collection, bucketName st
 			break
 		case <-args.Terminator:
 			InfofCtx(ctx, KeyDCP, "Closing DCP Feed %q for bucket %q based on termination notification", feedName, MD(bucketName))
-			dcpCloseErr := dcpClient.Close()
+			dcpCloseErr := dcpClient.Close(ctx)
 			if dcpCloseErr != nil {
 				WarnfCtx(ctx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseErr)
 			}

--- a/base/gocb_dcp_feed.go
+++ b/base/gocb_dcp_feed.go
@@ -40,7 +40,7 @@ func getHighSeqMetadata(collection *Collection) ([]DCPMetadata, error) {
 }
 
 // StartGocbDCPFeed starts a DCP Feed.
-func StartGocbDCPFeed(collection *Collection, bucketName string, args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map, metadataStoreType DCPMetadataStoreType, groupID string) error {
+func StartGocbDCPFeed(ctx context.Context, collection *Collection, bucketName string, args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map, metadataStoreType DCPMetadataStoreType, groupID string) error {
 	metadata, err := getHighSeqMetadata(collection)
 	if err != nil {
 		return err
@@ -74,43 +74,42 @@ func StartGocbDCPFeed(collection *Collection, bucketName string, args sgbucket.F
 	}
 
 	doneChan, err := dcpClient.Start()
-	loggingCtx := context.TODO()
 	if err != nil {
-		ErrorfCtx(loggingCtx, "Failed to start DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), err)
+		ErrorfCtx(ctx, "Failed to start DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), err)
 		// simplify in CBG-2234
 		closeErr := dcpClient.Close()
-		ErrorfCtx(loggingCtx, "Finished called async close error from DCP Feed %q for bucket %q", feedName, MD(bucketName))
+		ErrorfCtx(ctx, "Finished called async close error from DCP Feed %q for bucket %q", feedName, MD(bucketName))
 		if closeErr != nil {
-			ErrorfCtx(loggingCtx, "Close error from DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), closeErr)
+			ErrorfCtx(ctx, "Close error from DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), closeErr)
 		}
 		asyncCloseErr := <-doneChan
-		ErrorfCtx(loggingCtx, "Finished calling async close error from DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), asyncCloseErr)
+		ErrorfCtx(ctx, "Finished calling async close error from DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), asyncCloseErr)
 		return err
 	}
-	InfofCtx(loggingCtx, KeyDCP, "Started DCP Feed %q for bucket %q", feedName, MD(bucketName))
+	InfofCtx(ctx, KeyDCP, "Started DCP Feed %q for bucket %q", feedName, MD(bucketName))
 	go func() {
 		select {
 		case dcpCloseError := <-doneChan:
 			// simplify close in CBG-2234
 			// This is a close because DCP client closed on its own, which should never happen since once
 			// DCP feed is started, there is nothing that will close it
-			InfofCtx(loggingCtx, KeyDCP, "Forced closed DCP Feed %q for %q", feedName, MD(bucketName))
+			InfofCtx(ctx, KeyDCP, "Forced closed DCP Feed %q for %q", feedName, MD(bucketName))
 			// wait for channel close
 			<-doneChan
 			if dcpCloseError != nil {
-				WarnfCtx(loggingCtx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseError)
+				WarnfCtx(ctx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseError)
 			}
 			// FIXME: close dbContext here
 			break
 		case <-args.Terminator:
-			InfofCtx(loggingCtx, KeyDCP, "Closing DCP Feed %q for bucket %q based on termination notification", feedName, MD(bucketName))
+			InfofCtx(ctx, KeyDCP, "Closing DCP Feed %q for bucket %q based on termination notification", feedName, MD(bucketName))
 			dcpCloseErr := dcpClient.Close()
 			if dcpCloseErr != nil {
-				WarnfCtx(loggingCtx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseErr)
+				WarnfCtx(ctx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseErr)
 			}
 			dcpCloseErr = <-doneChan
 			if dcpCloseErr != nil {
-				WarnfCtx(loggingCtx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseErr)
+				WarnfCtx(ctx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseErr)
 			}
 			break
 		}

--- a/base/gocb_dcp_feed.go
+++ b/base/gocb_dcp_feed.go
@@ -58,6 +58,7 @@ func StartGocbDCPFeed(ctx context.Context, collection *Collection, bucketName st
 		collectionIDs = append(collectionIDs, collectionID)
 	}
 	dcpClient, err := NewDCPClient(
+		ctx,
 		feedName,
 		callback,
 		DCPClientOptions{

--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -149,7 +149,7 @@ func getRootCAs(caCertPath string) (*x509.CertPool, error) {
 	rootCAs, err := x509.SystemCertPool()
 	if err != nil {
 		rootCAs = x509.NewCertPool()
-		WarnfCtx(context.Background(), "Could not retrieve root CAs: %v", err)
+		WarnfCtx(context.TODO(), "Could not retrieve root CAs: %v", err)
 	}
 	return rootCAs, nil
 }

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -153,7 +153,7 @@ func (h *couchbaseHeartBeater) StartSendingHeartbeats() error {
 
 	ticker := time.NewTicker(h.heartbeatSendInterval)
 	go func() {
-		defer FatalPanicHandler()
+		defer FatalPanicHandler(h.loggingCtx)
 		defer func() {
 			h.sendActive.Set(false)
 		}()
@@ -182,7 +182,7 @@ func (h *couchbaseHeartBeater) StartCheckingHeartbeats() error {
 
 	ticker := time.NewTicker(h.heartbeatPollInterval)
 	go func() {
-		defer FatalPanicHandler()
+		defer FatalPanicHandler(h.loggingCtx)
 		defer func() { h.checkActive.Set(false) }()
 		for {
 			select {

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -106,8 +106,8 @@ func TestCouchbaseHeartbeaters(t *testing.T) {
 
 	keyprefix := SyncDocPrefix + t.Name()
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	// Setup heartbeaters and listeners
 	nodeCount := 3
@@ -184,8 +184,8 @@ func TestCouchbaseHeartbeatersMultipleListeners(t *testing.T) {
 	}
 
 	keyprefix := SyncDocPrefix + t.Name()
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	// Setup heartbeaters and listeners
 	nodeCount := 3
@@ -293,8 +293,8 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 
 	keyprefix := SyncDocPrefix + t.Name()
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	// Initialize cfgCB
 	cfgCB, err := initCfgCB(testBucket, testBucket.BucketSpec)

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -115,7 +115,7 @@ func TestCouchbaseHeartbeaters(t *testing.T) {
 	listeners := make([]*documentBackedListener, nodeCount)
 	for i := 0; i < nodeCount; i++ {
 		nodeUUID := fmt.Sprintf("node%d", i)
-		node, err := NewCouchbaseHeartbeater(testBucket, keyprefix, nodeUUID)
+		node, err := NewCouchbaseHeartbeater(ctx, testBucket, keyprefix, nodeUUID)
 		assert.NoError(t, err)
 
 		// Lower heartbeat expiry to avoid long-running test
@@ -194,7 +194,7 @@ func TestCouchbaseHeartbeatersMultipleListeners(t *testing.T) {
 	sgrListeners := make([]*documentBackedListener, nodeCount)
 	for i := 0; i < nodeCount; i++ {
 		nodeUUID := fmt.Sprintf("node%d", i)
-		node, err := NewCouchbaseHeartbeater(testBucket, keyprefix, nodeUUID)
+		node, err := NewCouchbaseHeartbeater(ctx, testBucket, keyprefix, nodeUUID)
 		assert.NoError(t, err)
 
 		// Lower heartbeat expiry to avoid long-running test
@@ -309,11 +309,11 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create three heartbeaters (representing three nodes)
-	node1, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node1")
+	node1, err := NewCouchbaseHeartbeater(ctx, testBucket, keyprefix, "node1")
 	assert.NoError(t, err)
-	node2, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node2")
+	node2, err := NewCouchbaseHeartbeater(ctx, testBucket, keyprefix, "node2")
 	assert.NoError(t, err)
-	node3, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node3")
+	node3, err := NewCouchbaseHeartbeater(ctx, testBucket, keyprefix, "node3")
 	assert.NoError(t, err)
 
 	assert.NoError(t, node1.SetExpirySeconds(2))

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -128,7 +128,7 @@ func TestCouchbaseHeartbeaters(t *testing.T) {
 		// Simulates service starting on node, and self-registering the nodeUUID to that listener's node set
 		listener, err := NewDocumentBackedListener(testBucket, keyprefix)
 		require.NoError(t, err)
-		assert.NoError(t, listener.AddNode(nodeUUID))
+		assert.NoError(t, listener.AddNode(ctx, nodeUUID))
 		assert.NoError(t, node.RegisterListener(listener))
 
 		nodes[i] = node
@@ -207,7 +207,7 @@ func TestCouchbaseHeartbeatersMultipleListeners(t *testing.T) {
 		// Simulates service starting on node, and self-registering the nodeUUID to that listener's node set
 		importListener, err := NewDocumentBackedListener(testBucket, keyprefix+":import")
 		require.NoError(t, err)
-		assert.NoError(t, importListener.AddNode(nodeUUID))
+		assert.NoError(t, importListener.AddNode(ctx, nodeUUID))
 		assert.NoError(t, node.RegisterListener(importListener))
 		importListeners[i] = importListener
 
@@ -215,7 +215,7 @@ func TestCouchbaseHeartbeatersMultipleListeners(t *testing.T) {
 		if i < 2 {
 			sgrListener, err := NewDocumentBackedListener(testBucket, keyprefix+":sgr")
 			require.NoError(t, err)
-			assert.NoError(t, sgrListener.AddNode(nodeUUID))
+			assert.NoError(t, sgrListener.AddNode(ctx, nodeUUID))
 			assert.NoError(t, node.RegisterListener(sgrListener))
 			sgrListeners[i] = sgrListener
 		}
@@ -343,21 +343,21 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 		"some-datasource",
 		eventHandlers,
 		options)
-	listener1, err := NewImportHeartbeatListener(&CbgtContext{
+	listener1, err := NewImportHeartbeatListener(ctx, &CbgtContext{
 		Cfg:     cfgCB,
 		Manager: testManager,
 	})
 	assert.NoError(t, err)
 	assert.NoError(t, node1.RegisterListener(listener1))
 
-	listener2, err := NewImportHeartbeatListener(&CbgtContext{
+	listener2, err := NewImportHeartbeatListener(ctx, &CbgtContext{
 		Cfg:     cfgCB,
 		Manager: testManager,
 	})
 	assert.NoError(t, err)
 	assert.NoError(t, node2.RegisterListener(listener2))
 
-	listener3, err := NewImportHeartbeatListener(&CbgtContext{
+	listener3, err := NewImportHeartbeatListener(ctx, &CbgtContext{
 		Cfg:     cfgCB,
 		Manager: testManager,
 	})

--- a/base/http_listener.go
+++ b/base/http_listener.go
@@ -34,7 +34,7 @@ const (
 
 // This is like a combination of http.ListenAndServe and http.ListenAndServeTLS, which also
 // uses ThrottledListen to limit the number of open HTTP connections.
-func ListenAndServeHTTP(addr string, connLimit uint, certFile, keyFile string, handler http.Handler,
+func ListenAndServeHTTP(ctx context.Context, addr string, connLimit uint, certFile, keyFile string, handler http.Handler,
 	readTimeout, writeTimeout, readHeaderTimeout, idleTimeout time.Duration, http2Enabled bool,
 	tlsMinVersion uint16) (serveFn func() error, server *http.Server, err error) {
 	var config *tls.Config
@@ -46,7 +46,7 @@ func ListenAndServeHTTP(addr string, connLimit uint, certFile, keyFile string, h
 			protocolsEnabled = []string{"h2", "http/1.1"}
 		}
 		config.NextProtos = protocolsEnabled
-		InfofCtx(context.TODO(), KeyHTTP, "Protocols enabled: %v on %v", config.NextProtos, SD(addr))
+		InfofCtx(ctx, KeyHTTP, "Protocols enabled: %v on %v", config.NextProtos, SD(addr))
 		config.Certificates = make([]tls.Certificate, 1)
 		var err error
 		config.Certificates[0], err = tls.LoadX509KeyPair(certFile, keyFile)

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -195,32 +195,32 @@ func (b *LeakyBucket) Incr(k string, amt, def uint64, exp uint32) (uint64, error
 	return val, err
 }
 
-func (b *LeakyBucket) GetDDocs() (map[string]sgbucket.DesignDoc, error) {
-	return b.bucket.GetDDocs()
+func (b *LeakyBucket) GetDDocs(ctx context.Context) (map[string]sgbucket.DesignDoc, error) {
+	return b.bucket.GetDDocs(ctx)
 }
-func (b *LeakyBucket) GetDDoc(docname string) (ddoc sgbucket.DesignDoc, err error) {
+func (b *LeakyBucket) GetDDoc(ctx context.Context, docname string) (ddoc sgbucket.DesignDoc, err error) {
 	if b.config.DDocGetErrorCount > 0 {
 		b.config.DDocGetErrorCount--
 		return ddoc, errors.New(fmt.Sprintf("Artificial leaky bucket error %d fails remaining", b.config.DDocGetErrorCount))
 	}
-	return b.bucket.GetDDoc(docname)
+	return b.bucket.GetDDoc(ctx, docname)
 }
-func (b *LeakyBucket) PutDDoc(docname string, value *sgbucket.DesignDoc) error {
-	return b.bucket.PutDDoc(docname, value)
+func (b *LeakyBucket) PutDDoc(ctx context.Context, docname string, value *sgbucket.DesignDoc) error {
+	return b.bucket.PutDDoc(ctx, docname, value)
 }
-func (b *LeakyBucket) DeleteDDoc(docname string) error {
+func (b *LeakyBucket) DeleteDDoc(ctx context.Context, docname string) error {
 	if b.config.DDocDeleteErrorCount > 0 {
 		b.config.DDocDeleteErrorCount--
 		return errors.New(fmt.Sprintf("Artificial leaky bucket error %d fails remaining", b.config.DDocDeleteErrorCount))
 	}
-	return b.bucket.DeleteDDoc(docname)
+	return b.bucket.DeleteDDoc(ctx, docname)
 }
-func (b *LeakyBucket) View(ddoc, name string, params map[string]interface{}) (sgbucket.ViewResult, error) {
-	return b.bucket.View(ddoc, name, params)
+func (b *LeakyBucket) View(ctx context.Context, ddoc, name string, params map[string]interface{}) (sgbucket.ViewResult, error) {
+	return b.bucket.View(ctx, ddoc, name, params)
 }
 
-func (b *LeakyBucket) ViewQuery(ddoc, name string, params map[string]interface{}) (sgbucket.QueryResultIterator, error) {
-	iterator, err := b.bucket.ViewQuery(ddoc, name, params)
+func (b *LeakyBucket) ViewQuery(ctx context.Context, ddoc, name string, params map[string]interface{}) (sgbucket.QueryResultIterator, error) {
+	iterator, err := b.bucket.ViewQuery(ctx, ddoc, name, params)
 
 	if b.config.FirstTimeViewCustomPartialError {
 		b.config.FirstTimeViewCustomPartialError = !b.config.FirstTimeViewCustomPartialError

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -554,47 +554,47 @@ func (b *LeakyBucket) ExplainQuery(ctx context.Context, statement string, params
 	return n1qlStore.ExplainQuery(ctx, statement, params)
 }
 
-func (b *LeakyBucket) CreateIndex(indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
+func (b *LeakyBucket) CreateIndex(ctx context.Context, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
 	n1qlStore, ok := AsN1QLStore(b.bucket)
 	if !ok {
 		return errors.New("Not N1QL Store")
 	}
-	return n1qlStore.CreateIndex(indexName, expression, filterExpression, options)
+	return n1qlStore.CreateIndex(ctx, indexName, expression, filterExpression, options)
 }
 
-func (b *LeakyBucket) BuildDeferredIndexes(indexSet []string) error {
+func (b *LeakyBucket) BuildDeferredIndexes(ctx context.Context, indexSet []string) error {
 	n1qlStore, ok := AsN1QLStore(b.bucket)
 	if !ok {
 		return errors.New("Not N1QL Store")
 	}
-	return n1qlStore.BuildDeferredIndexes(indexSet)
+	return n1qlStore.BuildDeferredIndexes(ctx, indexSet)
 }
 
-func (b *LeakyBucket) CreatePrimaryIndex(indexName string, options *N1qlIndexOptions) error {
+func (b *LeakyBucket) CreatePrimaryIndex(ctx context.Context, indexName string, options *N1qlIndexOptions) error {
 	n1qlStore, ok := AsN1QLStore(b.bucket)
 	if !ok {
 		return errors.New("Not N1QL Store")
 	}
-	return n1qlStore.CreatePrimaryIndex(indexName, options)
+	return n1qlStore.CreatePrimaryIndex(ctx, indexName, options)
 }
 
-func (b *LeakyBucket) WaitForIndexOnline(indexName string) error {
+func (b *LeakyBucket) WaitForIndexOnline(ctx context.Context, indexName string) error {
 	n1qlStore, ok := AsN1QLStore(b.bucket)
 	if !ok {
 		return errors.New("Not N1QL Store")
 	}
-	return n1qlStore.WaitForIndexOnline(indexName)
+	return n1qlStore.WaitForIndexOnline(ctx, indexName)
 }
 
-func (b *LeakyBucket) GetIndexMeta(indexName string) (exists bool, meta *IndexMeta, err error) {
+func (b *LeakyBucket) GetIndexMeta(ctx context.Context, indexName string) (exists bool, meta *IndexMeta, err error) {
 	n1qlStore, ok := AsN1QLStore(b.bucket)
 	if !ok {
 		return false, nil, errors.New("Not N1QL Store")
 	}
-	return n1qlStore.GetIndexMeta(indexName)
+	return n1qlStore.GetIndexMeta(ctx, indexName)
 }
 
-func (b *LeakyBucket) DropIndex(indexName string) error {
+func (b *LeakyBucket) DropIndex(ctx context.Context, indexName string) error {
 
 	n1qlStore, ok := AsN1QLStore(b.bucket)
 	if !ok {
@@ -609,7 +609,7 @@ func (b *LeakyBucket) DropIndex(indexName string) error {
 		}
 	}
 
-	return n1qlStore.DropIndex(indexName)
+	return n1qlStore.DropIndex(ctx, indexName)
 }
 
 func (b *LeakyBucket) executeQuery(statement string) (results sgbucket.QueryResultIterator, err error) {

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -181,16 +181,27 @@ func (b *LoggingBucket) ViewQuery(ddoc, name string, params map[string]interface
 }
 
 func (b *LoggingBucket) StartTapFeed(args sgbucket.FeedArguments, dbStats *expvar.Map) (sgbucket.MutationFeed, error) {
+	return b.StartTapFeedCtx(context.TODO(), args, dbStats)
+}
+
+func (b *LoggingBucket) StartTapFeedCtx(ctx context.Context, args sgbucket.FeedArguments, dbStats *expvar.Map) (sgbucket.MutationFeed, error) {
 	defer b.log(time.Now())
 	return b.bucket.StartTapFeed(args, dbStats)
 }
 
 func (b *LoggingBucket) StartDCPFeed(args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
+	return b.StartDCPFeedCtx(context.TODO(), args, callback, dbStats)
+}
+
+func (b *LoggingBucket) StartDCPFeedCtx(ctx context.Context, args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
 	defer b.log(time.Now())
 	return b.bucket.StartDCPFeed(args, callback, dbStats)
 }
 
 func (b *LoggingBucket) Close() {
+	b.bucket.CloseCtx(context.TODO())
+}
+func (b *LoggingBucket) CloseCtx(ctx context.Context) {
 	defer b.log(time.Now())
 	b.bucket.Close()
 }

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -160,30 +160,30 @@ func (b *LoggingBucket) WriteSubDoc(k string, subdocKey string, cas uint64, valu
 	return b.bucket.WriteSubDoc(k, subdocKey, cas, value)
 }
 
-func (b *LoggingBucket) GetDDocs() (map[string]sgbucket.DesignDoc, error) {
+func (b *LoggingBucket) GetDDocs(ctx context.Context) (map[string]sgbucket.DesignDoc, error) {
 	defer b.log(time.Now())
-	return b.bucket.GetDDocs()
+	return b.bucket.GetDDocs(ctx)
 }
-func (b *LoggingBucket) GetDDoc(docname string) (sgbucket.DesignDoc, error) {
+func (b *LoggingBucket) GetDDoc(ctx context.Context, docname string) (sgbucket.DesignDoc, error) {
 	defer b.log(time.Now(), docname)
-	return b.bucket.GetDDoc(docname)
+	return b.bucket.GetDDoc(ctx, docname)
 }
-func (b *LoggingBucket) PutDDoc(docname string, value *sgbucket.DesignDoc) error {
+func (b *LoggingBucket) PutDDoc(ctx context.Context, docname string, value *sgbucket.DesignDoc) error {
 	defer b.log(time.Now(), docname)
-	return b.bucket.PutDDoc(docname, value)
+	return b.bucket.PutDDoc(ctx, docname, value)
 }
-func (b *LoggingBucket) DeleteDDoc(docname string) error {
+func (b *LoggingBucket) DeleteDDoc(ctx context.Context, docname string) error {
 	defer b.log(time.Now(), docname)
-	return b.bucket.DeleteDDoc(docname)
+	return b.bucket.DeleteDDoc(ctx, docname)
 }
-func (b *LoggingBucket) View(ddoc, name string, params map[string]interface{}) (sgbucket.ViewResult, error) {
+func (b *LoggingBucket) View(ctx context.Context, ddoc, name string, params map[string]interface{}) (sgbucket.ViewResult, error) {
 	defer b.log(time.Now(), ddoc, name)
-	return b.bucket.View(ddoc, name, params)
+	return b.bucket.View(ctx, ddoc, name, params)
 }
 
-func (b *LoggingBucket) ViewQuery(ddoc, name string, params map[string]interface{}) (sgbucket.QueryResultIterator, error) {
+func (b *LoggingBucket) ViewQuery(ctx context.Context, ddoc, name string, params map[string]interface{}) (sgbucket.QueryResultIterator, error) {
 	defer b.log(time.Now(), ddoc, name)
-	return b.bucket.ViewQuery(ddoc, name, params)
+	return b.bucket.ViewQuery(ctx, ddoc, name, params)
 }
 
 func (b *LoggingBucket) StartTapFeed(ctx context.Context, args sgbucket.FeedArguments, dbStats *expvar.Map) (sgbucket.MutationFeed, error) {

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -776,7 +776,7 @@ func TestClusterPassword() string {
 }
 
 func TestClusterDriver() CouchbaseDriver {
-	driver := ChooseCouchbaseDriver(DataBucket)
+	driver := ChooseCouchbaseDriver(context.TODO(), DataBucket)
 	if envClusterDriver := os.Getenv(envTestClusterDriver); envClusterDriver != "" {
 		driver = AsCouchbaseDriver(envClusterDriver)
 	}

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -613,7 +613,7 @@ var PrimaryIndexInitFunc TBPBucketInitFunc = func(ctx context.Context, b Bucket,
 	if hasPrimary, _, err := getIndexMetaWithoutRetry(n1qlStore, PrimaryIndexName); err != nil {
 		return err
 	} else if !hasPrimary {
-		err := n1qlStore.CreatePrimaryIndex(PrimaryIndexName, nil)
+		err := n1qlStore.CreatePrimaryIndex(ctx, PrimaryIndexName, nil)
 		if err != nil {
 			return err
 		}

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/couchbaselabs/walrus"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -223,7 +222,7 @@ func (tbp *TestBucketPool) GetWalrusTestBucket(t testing.TB, url string) (b Buck
 	id, err := GenerateRandomID()
 	require.NoError(t, err)
 
-	walrusBucket, err := walrus.GetBucket(url, DefaultPool, tbpBucketNamePrefix+"walrus_"+id)
+	walrusBucket, err := NewSGWalrusBucket(url, DefaultPool, tbpBucketNamePrefix+"walrus_"+id)
 	if err != nil {
 		tbp.Fatalf(testCtx, "couldn't get walrus bucket: %v", err)
 	}

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbaselabs/walrus"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -628,16 +627,17 @@ type TBPBucketReadierFunc func(ctx context.Context, b Bucket, tbp *TestBucketPoo
 var FlushBucketEmptierFunc TBPBucketReadierFunc = func(ctx context.Context, b Bucket, tbp *TestBucketPool) error {
 
 	if c, ok := b.(*Collection); ok {
-		if err := c.DropAllScopesAndCollections(); err != nil && !errors.Is(err, ErrCollectionsUnsupported) {
+		if err := c.DropAllScopesAndCollections(ctx); err != nil && !errors.Is(err, ErrCollectionsUnsupported) {
 			return err
 		}
 	}
 
-	flushableBucket, ok := b.(sgbucket.FlushableStore)
+	// flushableBucket, ok := b.(sgbucket.FlushableStore)
+	flushableBucket, ok := b.(SGFlushableStore)
 	if !ok {
 		return errors.New("FlushBucketEmptierFunc used with non-flushable bucket")
 	}
-	return flushableBucket.Flush()
+	return flushableBucket.Flush(ctx)
 }
 
 // N1QLBucketEmptierFunc ensures the bucket is empty by using N1QL deletes. This is the preferred approach when using GSI.

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -467,7 +467,7 @@ func (tbp *TestBucketPool) createTestBuckets(numBuckets int, bucketQuotaMB int, 
 	// create required number of buckets (skipping any already existing ones)
 	for i := 0; i < numBuckets; i++ {
 		testBucketName := fmt.Sprintf(tbpBucketNameFormat, tbpBucketNamePrefix, i, bucketNameTimestamp)
-		ctx := bucketNameCtx(context.Background(), testBucketName)
+		ctx := bucketNameCtx(context.TODO(), testBucketName)
 
 		// Bucket creation takes a few seconds for each bucket,
 		// so create and wait for readiness concurrently.
@@ -478,7 +478,7 @@ func (tbp *TestBucketPool) createTestBuckets(numBuckets int, bucketQuotaMB int, 
 				tbp.Fatalf(ctx, "Couldn't create test bucket: %v", err)
 			}
 
-			b, err := tbp.cluster.openTestBucket(tbpBucketName(bucketName), 10*numBuckets)
+			b, err := tbp.cluster.openTestBucket(ctx, tbpBucketName(bucketName), 10*numBuckets)
 			if err != nil {
 				tbp.Fatalf(ctx, "Timed out trying to open new bucket: %v", err)
 			}
@@ -562,7 +562,7 @@ loop:
 				defer tbp.bucketReadierWaitGroup.Done()
 
 				start := time.Now()
-				b, err := tbp.cluster.openTestBucket(testBucketName, 5)
+				b, err := tbp.cluster.openTestBucket(ctx, testBucketName, 5)
 				if err != nil {
 					tbp.Logf(ctx, "Couldn't open bucket to get ready, got error: %v", err)
 					return
@@ -637,7 +637,7 @@ var FlushBucketEmptierFunc TBPBucketReadierFunc = func(ctx context.Context, b Bu
 	if !ok {
 		return errors.New("FlushBucketEmptierFunc used with non-flushable bucket")
 	}
-	return flushableBucket.Flush(ctx)
+	return flushableBucket.FlushCtx(ctx)
 }
 
 // N1QLBucketEmptierFunc ensures the bucket is empty by using N1QL deletes. This is the preferred approach when using GSI.

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -494,7 +494,7 @@ func (tbp *TestBucketPool) createTestBuckets(ctx context.Context, numBuckets int
 					tbp.Fatalf(ctx, "Timed out waiting for query service to be ready: %v", err)
 				}
 
-				queryRes, err := n1qlStore.Query(`DELETE FROM system:prepareds WHERE statement LIKE "%`+KeyspaceQueryToken+`%";`, nil, RequestPlus, true)
+				queryRes, err := n1qlStore.Query(ctx, `DELETE FROM system:prepareds WHERE statement LIKE "%`+KeyspaceQueryToken+`%";`, nil, RequestPlus, true)
 				if err != nil {
 					tbp.Fatalf(ctx, "Couldn't remove old prepared statements: %v", err)
 				}
@@ -654,7 +654,7 @@ var N1QLBucketEmptierFunc TBPBucketReadierFunc = func(ctx context.Context, bucke
 		return fmt.Errorf("bucket does not have primary index, so can't empty bucket using N1QL")
 	}
 
-	if itemCount, err := QueryBucketItemCount(n1qlStore); err != nil {
+	if itemCount, err := QueryBucketItemCount(ctx, n1qlStore); err != nil {
 		return err
 	} else if itemCount == 0 {
 		tbp.Logf(ctx, "Bucket already empty - skipping")
@@ -663,7 +663,7 @@ var N1QLBucketEmptierFunc TBPBucketReadierFunc = func(ctx context.Context, bucke
 		// Use N1QL to empty bucket, with the hope that the query service is happier to deal with this than a bucket flush/rollback.
 		// Requires a primary index on the bucket.
 		// TODO: How can we delete xattr only docs from here too? It would avoid needing to call db.emptyAllDocsIndex in ViewsAndGSIBucketReadier
-		res, err := n1qlStore.Query(fmt.Sprintf(`DELETE FROM %s`, KeyspaceQueryToken), nil, RequestPlus, true)
+		res, err := n1qlStore.Query(ctx, fmt.Sprintf(`DELETE FROM %s`, KeyspaceQueryToken), nil, RequestPlus, true)
 		if err != nil {
 			return err
 		}

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -632,7 +632,6 @@ var FlushBucketEmptierFunc TBPBucketReadierFunc = func(ctx context.Context, b Bu
 		}
 	}
 
-	// flushableBucket, ok := b.(sgbucket.FlushableStore)
 	flushableBucket, ok := b.(SGFlushableStore)
 	if !ok {
 		return errors.New("FlushBucketEmptierFunc used with non-flushable bucket")

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -637,7 +637,7 @@ var FlushBucketEmptierFunc TBPBucketReadierFunc = func(ctx context.Context, b Bu
 	if !ok {
 		return errors.New("FlushBucketEmptierFunc used with non-flushable bucket")
 	}
-	return flushableBucket.FlushCtx(ctx)
+	return flushableBucket.Flush(ctx)
 }
 
 // N1QLBucketEmptierFunc ensures the bucket is empty by using N1QL deletes. This is the preferred approach when using GSI.

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -118,7 +118,7 @@ func (c *tbpClusterV1) openTestBucket(ctx context.Context, testBucketName tbpBuc
 	bucketSpec := getBucketSpec(testBucketName)
 
 	waitForNewBucketWorker := func() (shouldRetry bool, err error, value interface{}) {
-		gocbBucket, err := GetCouchbaseBucketGoCBFromAuthenticatedCluster(c.cluster, bucketSpec, "")
+		gocbBucket, err := GetCouchbaseBucketGoCBFromAuthenticatedCluster(ctx, c.cluster, bucketSpec, "")
 		if err != nil {
 			c.logger(ctx, "Retrying OpenBucket")
 			return true, err, nil

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -15,7 +15,7 @@ type tbpCluster interface {
 	getBucketNames() ([]string, error)
 	insertBucket(name string, quotaMB int) error
 	removeBucket(name string) error
-	openTestBucket(name tbpBucketName, waitUntilReadySeconds int) (Bucket, error)
+	openTestBucket(ctx context.Context, name tbpBucketName, waitUntilReadySeconds int) (Bucket, error)
 	close() error
 }
 
@@ -110,10 +110,10 @@ func (c *tbpClusterV1) removeBucket(name string) error {
 }
 
 // openTestBucket opens the bucket of the given name for the gocb cluster in the given TestBucketPool.
-func (c *tbpClusterV1) openTestBucket(testBucketName tbpBucketName, waitUntilReadySeconds int) (Bucket, error) {
+func (c *tbpClusterV1) openTestBucket(ctx context.Context, testBucketName tbpBucketName, waitUntilReadySeconds int) (Bucket, error) {
 
 	sleeper := CreateSleeperFunc(waitUntilReadySeconds, 1000)
-	ctx := bucketNameCtx(context.Background(), string(testBucketName))
+	ctx = bucketNameCtx(ctx, string(testBucketName))
 
 	bucketSpec := getBucketSpec(testBucketName)
 
@@ -247,12 +247,12 @@ func (c *tbpClusterV2) removeBucket(name string) error {
 }
 
 // openTestBucket opens the bucket of the given name for the gocb cluster in the given TestBucketPool.
-func (c *tbpClusterV2) openTestBucket(testBucketName tbpBucketName, waitUntilReadySeconds int) (Bucket, error) {
+func (c *tbpClusterV2) openTestBucket(ctx context.Context, testBucketName tbpBucketName, waitUntilReadySeconds int) (Bucket, error) {
 
 	bucketCluster := initV2Cluster(c.server)
 	bucketSpec := getBucketSpec(testBucketName)
 
-	return GetCollectionFromCluster(bucketCluster, bucketSpec, waitUntilReadySeconds)
+	return GetCollectionFromCluster(ctx, bucketCluster, bucketSpec, waitUntilReadySeconds)
 }
 
 func (c *tbpClusterV2) close() error {

--- a/base/util.go
+++ b/base/util.go
@@ -1489,10 +1489,10 @@ type JSONEncoderI interface {
 	SetEscapeHTML(on bool)
 }
 
-func FatalPanicHandler() {
+func FatalPanicHandler(ctx context.Context) {
 	// Log any panics using the built-in loggers so that the stacktraces end up in SG log files before exiting.
 	if r := recover(); r != nil {
-		FatalfCtx(context.TODO(), "Unexpected panic: %v - stopping process\n%v", r, string(debug.Stack()))
+		FatalfCtx(ctx, "Unexpected panic: %v - stopping process\n%v", r, string(debug.Stack()))
 	}
 }
 

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -767,7 +767,7 @@ func CreateBucketScopesAndCollections(ctx context.Context, bucketSpec BucketSpec
 
 	un, pw, _ := bucketSpec.Auth.GetCredentials()
 	var rootCAs *x509.CertPool
-	if tlsConfig := bucketSpec.TLSConfig(); tlsConfig != nil {
+	if tlsConfig := bucketSpec.TLSConfig(ctx); tlsConfig != nil {
 		rootCAs = tlsConfig.RootCAs
 	}
 	cluster, err := gocb.Connect(bucketSpec.Server, gocb.ClusterOptions{

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -522,7 +522,7 @@ func SetUpGlobalTestLogging(m *testing.M) (teardownFn func()) {
 		var l LogLevel
 		err := l.UnmarshalText([]byte(logLevel))
 		if err != nil {
-			FatalfCtx(context.TODO(), "TEST: Invalid log level used for %q: %s", TestEnvGlobalLogLevel, err)
+			FatalfCtx(context.Background(), "TEST: Invalid log level used for %q: %s", TestEnvGlobalLogLevel, err)
 		}
 		caller := GetCallersName(1, false)
 		InfofCtx(context.Background(), KeyAll, "%s: Setup logging: level: %v - keys: %v", caller, logLevel, KeyAll)
@@ -738,11 +738,11 @@ func TestRequiresCollections(t *testing.T) {
 	}
 }
 
-func waitUntilScopeAndCollectionExists(collection *gocb.Collection) error {
+func waitUntilScopeAndCollectionExists(ctx context.Context, collection *gocb.Collection) error {
 	err, _ := RetryLoop("wait for scope and collection to exist", func() (shouldRetry bool, err error, value interface{}) {
 		_, err = collection.Exists("waitUntilScopeAndCollectionExists", nil)
 		if err != nil {
-			WarnfCtx(context.TODO(), "Error checking if collection exists: %v", err)
+			WarnfCtx(ctx, "Error checking if collection exists: %v", err)
 			return true, err, nil
 		}
 		return false, nil, nil
@@ -799,7 +799,7 @@ func CreateBucketScopesAndCollections(ctx context.Context, bucketSpec BucketSpec
 				return fmt.Errorf("failed to create collection %s in scope %s: %w", collectionName, scopeName, err)
 			}
 			DebugfCtx(ctx, KeySGTest, "Created collection %s.%s", scopeName, collectionName)
-			if err := waitUntilScopeAndCollectionExists(cluster.Bucket(bucketSpec.BucketName).Scope(scopeName).Collection(collectionName)); err != nil {
+			if err := waitUntilScopeAndCollectionExists(ctx, cluster.Bucket(bucketSpec.BucketName).Scope(scopeName).Collection(collectionName)); err != nil {
 				return err
 			}
 			DebugfCtx(ctx, KeySGTest, "Collection now exists %s.%s", scopeName, collectionName)

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -156,7 +156,7 @@ func GetTestBucketForDriver(t testing.TB, driver CouchbaseDriver) *TestBucket {
 		t.Fatalf("Server must use couchbase scheme for gocb testing")
 	}
 
-	store, err := GetBucket(spec)
+	store, err := GetBucket(TestCtx(t), spec)
 	if err != nil {
 		t.Fatalf("Unable to get store for driver %s: %v", driver, err)
 	}

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -691,7 +691,7 @@ type dataStore struct {
 }
 
 // ForAllDataStores is used to run a test against multiple data stores (gocb bucket, gocb collection)
-func ForAllDataStores(t *testing.T, testCallback func(*testing.T, Bucket)) {
+func ForAllDataStores(t *testing.T, testCallback func(*testing.T, context.Context, Bucket)) {
 	dataStores := make([]dataStore, 0)
 
 	dataStores = append(dataStores, dataStore{
@@ -703,7 +703,7 @@ func ForAllDataStores(t *testing.T, testCallback func(*testing.T, Bucket)) {
 		t.Run(dataStore.name, func(t *testing.T) {
 			ctx, bucket := GetTestBucketForDriver(t, dataStore.driver)
 			defer bucket.Close(ctx)
-			testCallback(t, bucket)
+			testCallback(t, ctx, bucket)
 		})
 	}
 }

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -301,7 +301,7 @@ func DropAllIndexes(ctx context.Context, n1QLStore N1QLStore) error {
 			defer wg.Done()
 
 			InfofCtx(ctx, KeySGTest, "Dropping index %s on bucket %s...", indexToDrop, n1QLStore.GetName())
-			dropErr := n1QLStore.DropIndex(indexToDrop)
+			dropErr := n1QLStore.DropIndex(ctx, indexToDrop)
 			if dropErr != nil {
 				asyncErrors <- dropErr
 				ErrorfCtx(ctx, "...failed to drop index %s on bucket %s: %s", indexToDrop, n1QLStore.GetName(), dropErr)

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/couchbase/gocb/v2"
-	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -690,7 +689,7 @@ type dataStore struct {
 }
 
 // ForAllDataStores is used to run a test against multiple data stores (gocb bucket, gocb collection)
-func ForAllDataStores(t *testing.T, testCallback func(*testing.T, sgbucket.DataStore)) {
+func ForAllDataStores(t *testing.T, testCallback func(*testing.T, Bucket)) {
 	dataStores := make([]dataStore, 0)
 
 	dataStores = append(dataStores, dataStore{

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -85,7 +85,7 @@ func (tb *TestBucket) NoCloseClone(ctx context.Context) *TestBucket {
 	return &TestBucket{
 		Bucket:     NoCloseClone(tb.Bucket),
 		BucketSpec: tb.BucketSpec,
-		closeFn:    func() { tb.Close(ctx) },
+		closeFn:    func() {},
 	}
 }
 

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -332,13 +332,13 @@ func (ar *ActiveReplicator) purgeCheckpoints() {
 }
 
 // LoadReplicationStatus attempts to load both push and pull replication checkpoints, and constructs the combined status
-func LoadReplicationStatus(dbContext *DatabaseContext, replicationID string) (status *ReplicationStatus, err error) {
+func LoadReplicationStatus(ctx context.Context, dbContext *DatabaseContext, replicationID string) (status *ReplicationStatus, err error) {
 
 	status = &ReplicationStatus{
 		ID: replicationID,
 	}
 
-	pullCheckpoint, _ := getLocalCheckpoint(dbContext, PullCheckpointID(replicationID))
+	pullCheckpoint, _ := getLocalCheckpoint(ctx, dbContext, PullCheckpointID(replicationID))
 	if pullCheckpoint != nil {
 		if pullCheckpoint.Status != nil {
 			status.PullReplicationStatus = pullCheckpoint.Status.PullReplicationStatus
@@ -350,7 +350,7 @@ func LoadReplicationStatus(dbContext *DatabaseContext, replicationID string) (st
 		}
 	}
 
-	pushCheckpoint, _ := getLocalCheckpoint(dbContext, PushCheckpointID(replicationID))
+	pushCheckpoint, _ := getLocalCheckpoint(ctx, dbContext, PushCheckpointID(replicationID))
 	if pushCheckpoint != nil {
 		if pushCheckpoint.Status != nil {
 			status.PushReplicationStatus = pushCheckpoint.Status.PushReplicationStatus

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -659,15 +659,15 @@ func (c *Checkpointer) setLocalCheckpointStatus(status string, errorMessage stri
 	return
 }
 
-func getLocalCheckpoint(db *DatabaseContext, clientID string) (*replicationCheckpoint, error) {
-	base.TracefCtx(context.TODO(), base.KeyReplicate, "getLocalCheckpoint for %s", clientID)
+func getLocalCheckpoint(ctx context.Context, db *DatabaseContext, clientID string) (*replicationCheckpoint, error) {
+	base.TracefCtx(ctx, base.KeyReplicate, "getLocalCheckpoint for %s", clientID)
 
 	checkpointBytes, err := db.GetSpecialBytes(DocTypeLocal, CheckpointDocIDPrefix+clientID)
 	if err != nil {
 		if !base.IsKeyNotFoundError(db.Bucket, err) {
 			return nil, err
 		}
-		base.DebugfCtx(context.TODO(), base.KeyReplicate, "couldn't find existing local checkpoint for ID %q", clientID)
+		base.DebugfCtx(ctx, base.KeyReplicate, "couldn't find existing local checkpoint for ID %q", clientID)
 		return nil, nil
 	}
 	var checkpoint *replicationCheckpoint
@@ -680,7 +680,7 @@ func getLocalCheckpoint(db *DatabaseContext, clientID string) (*replicationCheck
 func setLocalCheckpointStatus(ctx context.Context, db *Database, clientID string, status string, errorMessage string) {
 
 	// getCheckpoint to obtain the current rev
-	checkpoint, err := getLocalCheckpoint(db.DatabaseContext, clientID)
+	checkpoint, err := getLocalCheckpoint(ctx, db.DatabaseContext, clientID)
 	if err != nil {
 		base.WarnfCtx(ctx, "Unable to retrieve local checkpoint for %s, status not updated", clientID)
 		return

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -137,7 +137,7 @@ func attachmentCompactMarkPhase(ctx context.Context, db *Database, compactionID 
 	if err != nil {
 		return 0, nil, err
 	}
-	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, *clientOptions, collection)
+	dcpClient, err := base.NewDCPClient(ctx, dcpFeedKey, callback, *clientOptions, collection)
 	if err != nil {
 		base.WarnfCtx(ctx, "[%s] Failed to create attachment compaction DCP client! %v", compactionLoggingID, err)
 		return 0, nil, err
@@ -360,7 +360,7 @@ func attachmentCompactSweepPhase(ctx context.Context, db *Database, compactionID
 
 	dcpFeedKey := generateCompactionDCPStreamName(compactionID, SweepPhase)
 	base.InfofCtx(ctx, base.KeyAll, "[%s] Starting DCP feed %q for sweep phase of attachment compaction", compactionLoggingID, dcpFeedKey)
-	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, *clientOptions, collection)
+	dcpClient, err := base.NewDCPClient(ctx, dcpFeedKey, callback, *clientOptions, collection)
 	if err != nil {
 		base.WarnfCtx(ctx, "[%s] Failed to create attachment compaction DCP client! %v", compactionLoggingID, err)
 		return 0, err
@@ -495,7 +495,7 @@ func attachmentCompactCleanupPhase(ctx context.Context, db *Database, compaction
 	base.InfofCtx(ctx, base.KeyAll, "[%s] Starting DCP feed for cleanup phase of attachment compaction", compactionLoggingID)
 
 	dcpFeedKey := generateCompactionDCPStreamName(compactionID, CleanupPhase)
-	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, *clientOptions, collection)
+	dcpClient, err := base.NewDCPClient(ctx, dcpFeedKey, callback, *clientOptions, collection)
 	if err != nil {
 		base.WarnfCtx(ctx, "[%s] Failed to create attachment compaction DCP client! %v", compactionLoggingID, err)
 		return err

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -288,8 +288,9 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	b := base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{})
-	defer b.Close()
+	ctx, b := base.GetTestBucket(t)
+	b = b.LeakyBucketClone(ctx, base.LeakyBucketConfig{})
+	defer b.Close(ctx)
 
 	testDB1, ctx1 := setupTestDBForBucket(t, b)
 	defer testDB1.Close(ctx1)
@@ -433,8 +434,9 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	b := base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{})
-	defer b.Close()
+	ctx, b := base.GetTestBucket(t)
+	b = b.LeakyBucketClone(ctx, base.LeakyBucketConfig{})
+	defer b.Close(ctx)
 
 	testDB1, ctx1 := setupTestDBForBucket(t, b)
 	defer testDB1.Close(ctx1)
@@ -535,12 +537,13 @@ func TestAttachmentProcessError(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	b := base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{
+	ctx, b := base.GetTestBucket(t)
+	b = b.LeakyBucketClone(ctx, base.LeakyBucketConfig{
 		SetXattrCallback: func(key string) error {
 			return fmt.Errorf("some error")
 		},
 	})
-	defer b.Close()
+	defer b.Close(ctx)
 
 	testDB1, ctx1 := setupTestDBForBucket(t, b)
 	defer testDB1.Close(ctx1)

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -295,7 +295,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 	testDB1, ctx1 := setupTestDBForBucket(t, b)
 	defer testDB1.Close(ctx1)
 
-	testDB2, ctx2 := setupTestDBForBucket(t, b.NoCloseClone())
+	testDB2, ctx2 := setupTestDBForBucket(t, b.NoCloseClone(ctx))
 	defer testDB2.Close(ctx2)
 
 	var err error
@@ -441,7 +441,7 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 	testDB1, ctx1 := setupTestDBForBucket(t, b)
 	defer testDB1.Close(ctx1)
 
-	testDB2, ctx2 := setupTestDBForBucket(t, b.NoCloseClone())
+	testDB2, ctx2 := setupTestDBForBucket(t, b.NoCloseClone(ctx))
 	defer testDB2.Close(ctx2)
 
 	var err error

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -224,7 +224,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 
 	defaultSince := bh.collection.CreateZeroSinceValue()
 	latestSeq := func() (SequenceID, error) {
-		seq, err := bh.collection.LastSequence()
+		seq, err := bh.collection.LastSequence(bh.loggingCtx)
 		return SequenceID{Seq: seq}, err
 	}
 	subChangesParams, err := NewSubChangesParams(bh.loggingCtx, rq, defaultSince, latestSeq, bh.collection.ParseSequenceID)

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -176,7 +176,7 @@ func (c *changeCache) Init(logCtx context.Context, dbcontext *DatabaseContext, n
 		c.options = DefaultCacheOptions()
 	}
 
-	channelCache, err := NewChannelCacheForContext(c.options.ChannelCacheOptions, c.context)
+	channelCache, err := NewChannelCacheForContext(c.logCtx, c.options.ChannelCacheOptions, c.context)
 	if err != nil {
 		return err
 	}
@@ -187,13 +187,13 @@ func (c *changeCache) Init(logCtx context.Context, dbcontext *DatabaseContext, n
 	heap.Init(&c.pendingLogs)
 
 	// background tasks that perform housekeeping duties on the cache
-	bgt, err := NewBackgroundTask("InsertPendingEntries", c.context.Name, c.InsertPendingEntries, c.options.CachePendingSeqMaxWait/2, c.terminator)
+	bgt, err := NewBackgroundTask(c.logCtx, "InsertPendingEntries", c.context.Name, c.InsertPendingEntries, c.options.CachePendingSeqMaxWait/2, c.terminator)
 	if err != nil {
 		return err
 	}
 	c.backgroundTasks = append(c.backgroundTasks, bgt)
 
-	bgt, err = NewBackgroundTask("CleanSkippedSequenceQueue", c.context.Name, c.CleanSkippedSequenceQueue, c.options.CacheSkippedSeqMaxWait/2, c.terminator)
+	bgt, err = NewBackgroundTask(c.logCtx, "CleanSkippedSequenceQueue", c.context.Name, c.CleanSkippedSequenceQueue, c.options.CacheSkippedSeqMaxWait/2, c.terminator)
 	if err != nil {
 		return err
 	}

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -265,7 +265,7 @@ func (c *changeCache) Clear() error {
 	// the point at which the change cache was initialized / re-initialized.
 	// No need to touch c.nextSequence here, because we don't want to touch the sequence buffering state.
 	var err error
-	c.initialSequence, err = c.context.LastSequence()
+	c.initialSequence, err = c.context.LastSequence(c.logCtx)
 	if err != nil {
 		return err
 	}

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -182,8 +182,7 @@ func TestLateSequenceHandling(t *testing.T) {
 
 func TestLateSequenceHandlingWithMultipleListeners(t *testing.T) {
 
-	ctx := base.TestCtx(t)
-	b := base.GetTestBucket(t)
+	ctx, b := base.GetTestBucket(t)
 	context, err := NewDatabaseContext(ctx, "db", b, false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close(ctx)
@@ -1977,8 +1976,8 @@ func BenchmarkProcessEntry(b *testing.B) {
 
 	for _, bm := range processEntryBenchmarks {
 		b.Run(bm.name, func(b *testing.B) {
-			ctx := base.TestCtx(b)
-			context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
+			ctx, bucket := base.GetTestBucket(b)
+			context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 			require.NoError(b, err)
 			defer context.Close(ctx)
 
@@ -2205,8 +2204,8 @@ func BenchmarkDocChanged(b *testing.B) {
 
 	for _, bm := range processEntryBenchmarks {
 		b.Run(bm.name, func(b *testing.B) {
-			ctx := base.TestCtx(b)
-			context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
+			ctx, bucket := base.GetTestBucket(b)
+			context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 			require.NoError(b, err)
 			defer context.Close(ctx)
 

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -89,7 +89,7 @@ func (listener *changeListener) StartMutationFeed(bucket base.Bucket, dbStats *e
 					close(listener.FeedArgs.DoneChan)
 				}
 			}()
-			defer base.FatalPanicHandler()
+			defer base.FatalPanicHandler(listener.loggingCtx)
 			defer listener.notifyStopping()
 			for event := range listener.tapFeed.Events() {
 				event.TimeReceived = time.Now()

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -79,7 +79,7 @@ func (listener *changeListener) StartMutationFeed(bucket base.Bucket, dbStats *e
 		//    TAP feed is a go-channel of Tap events served by the bucket.  Start the feed, then
 		//    start a goroutine to work the event channel, calling ProcessEvent for each event
 		var err error
-		listener.tapFeed, err = bucket.StartTapFeed(listener.FeedArgs, dbStats)
+		listener.tapFeed, err = bucket.StartTapFeed(listener.loggingCtx, listener.FeedArgs, dbStats)
 		if err != nil {
 			return err
 		}
@@ -101,7 +101,7 @@ func (listener *changeListener) StartMutationFeed(bucket base.Bucket, dbStats *e
 		// DCP Feed
 		//    DCP receiver isn't go-channel based - DCPReceiver calls ProcessEvent directly.
 		base.InfofCtx(listener.loggingCtx, base.KeyDCP, "Using DCP feed for bucket: %q (based on feed_type specified in config file)", base.MD(bucket.GetName()))
-		return bucket.StartDCPFeed(listener.FeedArgs, listener.ProcessFeedEvent, dbStats)
+		return bucket.StartDCPFeed(listener.loggingCtx, listener.FeedArgs, listener.ProcessFeedEvent, dbStats)
 	}
 }
 

--- a/db/changes.go
+++ b/db/changes.go
@@ -198,7 +198,7 @@ func (db *Database) buildRevokedFeed(ctx context.Context, channelName string, op
 	singleChannelCache := db.changeCache.getChannelCache().getBypassChannelCache(channelName)
 
 	go func() {
-		defer base.FatalPanicHandler()
+		defer base.FatalPanicHandler(ctx)
 		defer close(feed)
 		var itemsSent int
 		var lastSeq uint64
@@ -383,7 +383,7 @@ func (db *Database) changesFeed(ctx context.Context, singleChannelCache SingleCh
 	paginationOptions.Since.LowSeq = 0
 
 	go func() {
-		defer base.FatalPanicHandler()
+		defer base.FatalPanicHandler(ctx)
 		defer close(feed)
 		var itemsSent int
 		var lastSeq uint64

--- a/db/changes.go
+++ b/db/changes.go
@@ -1093,7 +1093,7 @@ func (dbc *DatabaseContext) WaitForSequenceNotSkipped(ctx context.Context, seque
 
 // WaitForPendingChanges blocks until the change-cache has caught up with the latest writes to the database.
 func (dbc *DatabaseContext) WaitForPendingChanges(ctx context.Context) (err error) {
-	lastSequence, err := dbc.LastSequence()
+	lastSequence, err := dbc.LastSequence(ctx)
 	base.DebugfCtx(ctx, base.KeyChanges, "Waiting for sequence: %d", lastSequence)
 	return dbc.changeCache.waitForSequence(ctx, lastSequence, base.DefaultWaitForSequence)
 }

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -99,11 +99,11 @@ type channelCacheImpl struct {
 	validFromLock        sync.RWMutex              // Mutex used to avoid race between AddToCache and addChannelCache.  See CBG-520 for more details
 }
 
-func NewChannelCacheForContext(options ChannelCacheOptions, context *DatabaseContext) (*channelCacheImpl, error) {
-	return newChannelCache(context.Name, options, context, context.activeChannels, context.DbStats.Cache())
+func NewChannelCacheForContext(ctx context.Context, options ChannelCacheOptions, context *DatabaseContext) (*channelCacheImpl, error) {
+	return newChannelCache(ctx, context.Name, options, context, context.activeChannels, context.DbStats.Cache())
 }
 
-func newChannelCache(dbName string, options ChannelCacheOptions, queryHandler ChannelQueryHandler,
+func newChannelCache(ctx context.Context, dbName string, options ChannelCacheOptions, queryHandler ChannelQueryHandler,
 	activeChannels *channels.ActiveChannels, cacheStats *base.CacheStats) (*channelCacheImpl, error) {
 
 	channelCache := &channelCacheImpl{
@@ -118,7 +118,7 @@ func newChannelCache(dbName string, options ChannelCacheOptions, queryHandler Ch
 		activeChannels:       activeChannels,
 		cacheStats:           cacheStats,
 	}
-	bgt, err := NewBackgroundTask("CleanAgedItems", dbName, channelCache.cleanAgedItems, options.ChannelCacheAge, channelCache.terminator)
+	bgt, err := NewBackgroundTask(ctx, "CleanAgedItems", dbName, channelCache.cleanAgedItems, options.ChannelCacheAge, channelCache.terminator)
 	if err != nil {
 		return nil, err
 	}

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -39,19 +39,19 @@ type ChannelCache interface {
 	Init(initialSequence uint64)
 
 	// Adds an entry to the cache, returns set of channels it was added to
-	AddToCache(change *LogEntry) []string
+	AddToCache(ctx context.Context, change *LogEntry) []string
 
 	// Notifies the cache of a principal update.  Updates the cache's high sequence
 	AddPrincipal(change *LogEntry)
 
 	// Remove purges the given doc IDs from all channel caches and returns the number of items removed.
-	Remove(docIDs []string, startTime time.Time) (count int)
+	Remove(ctx context.Context, docIDs []string, startTime time.Time) (count int)
 
 	// Returns set of changes for a given channel, within the bounds specified in options
-	GetChanges(channelName string, options ChangesOptions) ([]*LogEntry, error)
+	GetChanges(ctx context.Context, channelName string, options ChangesOptions) ([]*LogEntry, error)
 
 	// Returns the set of all cached data for a given channel (intended for diagnostic usage)
-	GetCachedChanges(channelName string) []*LogEntry
+	GetCachedChanges(ctx context.Context, channelName string) []*LogEntry
 
 	// Clear reinitializes the cache to an empty state
 	Clear()
@@ -64,13 +64,13 @@ type ChannelCache interface {
 	GetHighCacheSequence() uint64
 
 	// Access to individual channel cache
-	getSingleChannelCache(channelName string) SingleChannelCache
+	getSingleChannelCache(ctx context.Context, channelName string) SingleChannelCache
 
 	// Access to individual bypass channel cache
 	getBypassChannelCache(channelName string) SingleChannelCache
 
 	// Stop stops the channel cache and it's background tasks.
-	Stop()
+	Stop(ctx context.Context)
 }
 
 // ChannelQueryHandler interface is implemented by databaseContext.
@@ -135,12 +135,12 @@ func (c *channelCacheImpl) Clear() {
 }
 
 // Stop stops the channel cache and it's background tasks.
-func (c *channelCacheImpl) Stop() {
+func (c *channelCacheImpl) Stop(ctx context.Context) {
 	// Signal to terminate channel cache background tasks.
 	close(c.terminator)
 
 	// Wait for channel cache background tasks to finish.
-	waitForBGTCompletion(context.TODO(), BGTCompletionMaxWait, c.backgroundTasks, c.dbName)
+	waitForBGTCompletion(ctx, BGTCompletionMaxWait, c.backgroundTasks, c.dbName)
 }
 
 func (c *channelCacheImpl) Init(initialSequence uint64) {
@@ -174,9 +174,9 @@ func (c *channelCacheImpl) updateHighCacheSequence(sequence uint64) {
 
 // GetSingleChannelCache will create the cache for the channel if it doesn't exist.  If the cache is at
 // capacity, will return a bypass channel cache.
-func (c *channelCacheImpl) getSingleChannelCache(channelName string) SingleChannelCache {
+func (c *channelCacheImpl) getSingleChannelCache(ctx context.Context, channelName string) SingleChannelCache {
 
-	return c.getChannelCache(channelName)
+	return c.getChannelCache(ctx, channelName)
 }
 
 func (c *channelCacheImpl) AddPrincipal(change *LogEntry) {
@@ -185,7 +185,7 @@ func (c *channelCacheImpl) AddPrincipal(change *LogEntry) {
 
 // Adds an entry to the appropriate channels' caches, returning the affected channels.  lateSequence
 // flag indicates whether it was a change arriving out of sequence
-func (c *channelCacheImpl) AddToCache(change *LogEntry) (updatedChannels []string) {
+func (c *channelCacheImpl) AddToCache(ctx context.Context, change *LogEntry) (updatedChannels []string) {
 
 	ch := change.Channels
 	change.Channels = nil // not needed anymore, so free some memory
@@ -199,7 +199,7 @@ func (c *channelCacheImpl) AddToCache(change *LogEntry) (updatedChannels []strin
 	// twice)
 	if change.Skipped {
 		c.lateSeqLock.Lock()
-		base.InfofCtx(context.TODO(), base.KeyChanges, "Acquired late sequence lock in order to cache %d - doc %q / %q", change.Sequence, base.UD(change.DocID), change.RevID)
+		base.InfofCtx(ctx, base.KeyChanges, "Acquired late sequence lock in order to cache %d - doc %q / %q", change.Sequence, base.UD(change.DocID), change.RevID)
 		defer c.lateSeqLock.Unlock()
 	}
 
@@ -216,7 +216,7 @@ func (c *channelCacheImpl) AddToCache(change *LogEntry) (updatedChannels []strin
 			}
 			channelCache, ok := c.getActiveChannelCache(channelName)
 			if ok {
-				channelCache.addToCache(change, removal != nil)
+				channelCache.addToCache(ctx, change, removal != nil)
 				if change.Skipped {
 					channelCache.AddLateSequence(change)
 				}
@@ -229,7 +229,7 @@ func (c *channelCacheImpl) AddToCache(change *LogEntry) (updatedChannels []strin
 	if EnableStarChannelLog && !explicitStarChannel {
 		channelCache, ok := c.getActiveChannelCache(channels.UserStarChannel)
 		if ok {
-			channelCache.addToCache(change, false)
+			channelCache.addToCache(ctx, change, false)
 			if change.Skipped {
 				channelCache.AddLateSequence(change)
 			}
@@ -244,7 +244,7 @@ func (c *channelCacheImpl) AddToCache(change *LogEntry) (updatedChannels []strin
 
 // Remove purges the given doc IDs from all channel caches and returns the number of items removed.
 // count will be larger than the input slice if the same document is removed from multiple channel caches.
-func (c *channelCacheImpl) Remove(docIDs []string, startTime time.Time) (count int) {
+func (c *channelCacheImpl) Remove(ctx context.Context, docIDs []string, startTime time.Time) (count int) {
 	// Exit early if there's no work to do
 	if len(docIDs) == 0 {
 		return 0
@@ -256,7 +256,7 @@ func (c *channelCacheImpl) Remove(docIDs []string, startTime time.Time) (count i
 			return false
 		}
 
-		count += channelCache.Remove(docIDs, startTime)
+		count += channelCache.Remove(ctx, docIDs, startTime)
 		return true
 	}
 
@@ -265,14 +265,14 @@ func (c *channelCacheImpl) Remove(docIDs []string, startTime time.Time) (count i
 	return count
 }
 
-func (c *channelCacheImpl) GetChanges(channelName string, options ChangesOptions) ([]*LogEntry, error) {
+func (c *channelCacheImpl) GetChanges(ctx context.Context, channelName string, options ChangesOptions) ([]*LogEntry, error) {
 
-	return c.getChannelCache(channelName).GetChanges(options)
+	return c.getChannelCache(ctx, channelName).GetChanges(options)
 }
 
-func (c *channelCacheImpl) GetCachedChanges(channelName string) []*LogEntry {
+func (c *channelCacheImpl) GetCachedChanges(ctx context.Context, channelName string) []*LogEntry {
 	options := ChangesOptions{Since: SequenceID{Seq: 0}}
-	_, changes := c.getChannelCache(channelName).GetCachedChanges(options)
+	_, changes := c.getChannelCache(ctx, channelName).GetCachedChanges(options)
 	return changes
 }
 
@@ -292,7 +292,7 @@ func (c *channelCacheImpl) cleanAgedItems(ctx context.Context) error {
 	return nil
 }
 
-func (c *channelCacheImpl) getChannelCache(channelName string) SingleChannelCache {
+func (c *channelCacheImpl) getChannelCache(ctx context.Context, channelName string) SingleChannelCache {
 
 	cacheValue, found := c.channelCaches.Get(channelName)
 	if found {
@@ -300,7 +300,7 @@ func (c *channelCacheImpl) getChannelCache(channelName string) SingleChannelCach
 	}
 
 	// Attempt to add a singleChannelCache for the channel name.  If unsuccessful, return a bypass channel cache
-	singleChannelCache, ok := c.addChannelCache(channelName)
+	singleChannelCache, ok := c.addChannelCache(ctx, channelName)
 	if ok {
 		return singleChannelCache
 	}
@@ -341,7 +341,7 @@ func AsSingleChannelCache(cacheValue interface{}) *singleChannelCacheImpl {
 //	//     4. addChannelCache initializes cache with validFrom=10 and adds to c.channelCaches
 //	//  This scenario would result in sequence 11 missing from the cache.  Locking seqLock ensures that
 //	//  step 3 blocks until step 4 is complete (and so sees the channel as active)
-func (c *channelCacheImpl) addChannelCache(channelName string) (*singleChannelCacheImpl, bool) {
+func (c *channelCacheImpl) addChannelCache(ctx context.Context, channelName string) (*singleChannelCacheImpl, bool) {
 
 	// Return nil if the cache at capacity.
 	if c.channelCaches.Length() >= c.maxChannels {
@@ -360,7 +360,7 @@ func (c *channelCacheImpl) addChannelCache(channelName string) (*singleChannelCa
 	singleChannelCache = AsSingleChannelCache(cacheValue)
 
 	if cacheSize > c.compactHighWatermark {
-		c.startCacheCompaction()
+		c.startCacheCompaction(ctx)
 	}
 
 	if created {
@@ -405,30 +405,29 @@ func (c *channelCacheImpl) isCompactActive() bool {
 }
 
 // startCacheCompaction starts a goroutine for cache compaction if it's not already running.
-func (c *channelCacheImpl) startCacheCompaction() {
+func (c *channelCacheImpl) startCacheCompaction(ctx context.Context) {
 	compactNotStarted := c.compactRunning.CompareAndSwap(false, true)
 	if compactNotStarted {
-		go c.compactChannelCache()
+		go c.compactChannelCache(ctx)
 	}
 }
 
 // Compact runs until the number of channels in the cache is lower than compactLowWatermark
-func (c *channelCacheImpl) compactChannelCache() {
+func (c *channelCacheImpl) compactChannelCache(ctx context.Context) {
 	defer c.compactRunning.Set(false)
 
 	// Increment compact count on start, as timing is updated per loop iteration
 	c.cacheStats.ChannelCacheCompactCount.Add(1)
 
-	logCtx := context.TODO()
 	cacheSize := c.channelCaches.Length()
-	base.InfofCtx(logCtx, base.KeyCache, "Starting channel cache compaction, size %d", cacheSize)
+	base.InfofCtx(ctx, base.KeyCache, "Starting channel cache compaction, size %d", cacheSize)
 	for {
 		// channelCache close handling
 		compactIterationStart := time.Now()
 
 		select {
 		case <-c.terminator:
-			base.DebugfCtx(logCtx, base.KeyCache, "Channel cache compaction stopped due to cache close.")
+			base.DebugfCtx(ctx, base.KeyCache, "Channel cache compaction stopped due to cache close.")
 			return
 		default:
 			// continue
@@ -437,10 +436,10 @@ func (c *channelCacheImpl) compactChannelCache() {
 		// Maintain a target number of items to compact per iteration.  Break the list iteration when the target is reached
 		targetEvictCount := cacheSize - c.compactLowWatermark
 		if targetEvictCount <= 0 {
-			base.InfofCtx(logCtx, base.KeyCache, "Stopping channel cache compaction, size %d", cacheSize)
+			base.InfofCtx(ctx, base.KeyCache, "Stopping channel cache compaction, size %d", cacheSize)
 			return
 		}
-		base.TracefCtx(logCtx, base.KeyCache, "Target eviction count: %d (lwm:%d)", targetEvictCount, c.compactLowWatermark)
+		base.TracefCtx(ctx, base.KeyCache, "Target eviction count: %d (lwm:%d)", targetEvictCount, c.compactLowWatermark)
 
 		// Iterates through cache entries based on cache size at start of compaction iteration loop.  Intentionally
 		// ignores channels added during compaction iteration
@@ -454,7 +453,7 @@ func (c *channelCacheImpl) compactChannelCache() {
 			elementCount++
 			singleChannelCache, ok := elem.Value.(*singleChannelCacheImpl)
 			if !ok {
-				base.WarnfCtx(logCtx, "Non-cache entry (%T) found in channel cache during compaction - ignoring", elem.Value)
+				base.WarnfCtx(ctx, "Non-cache entry (%T) found in channel cache during compaction - ignoring", elem.Value)
 				return true
 			}
 
@@ -467,16 +466,16 @@ func (c *channelCacheImpl) compactChannelCache() {
 			// Determine whether NRU channel is active, to establish eviction priority
 			isActive := c.activeChannels.IsActive(singleChannelCache.channelName)
 			if !isActive {
-				base.TracefCtx(logCtx, base.KeyCache, "Marking inactive cache entry %q for eviction ", base.UD(singleChannelCache.channelName))
+				base.TracefCtx(ctx, base.KeyCache, "Marking inactive cache entry %q for eviction ", base.UD(singleChannelCache.channelName))
 				inactiveEvictionCandidates = append(inactiveEvictionCandidates, elem)
 			} else {
-				base.TracefCtx(logCtx, base.KeyCache, "Marking NRU cache entry %q for eviction", base.UD(singleChannelCache.channelName))
+				base.TracefCtx(ctx, base.KeyCache, "Marking NRU cache entry %q for eviction", base.UD(singleChannelCache.channelName))
 				nruEvictionCandidates = append(nruEvictionCandidates, elem)
 			}
 
 			// If we have enough inactive channels to reach targetCount, terminate range
 			if len(inactiveEvictionCandidates) >= targetEvictCount {
-				base.TracefCtx(logCtx, base.KeyCache, "Eviction count target (%d) reached with inactive channels, proceeding to removal", targetEvictCount)
+				base.TracefCtx(ctx, base.KeyCache, "Eviction count target (%d) reached with inactive channels, proceeding to removal", targetEvictCount)
 				return false
 			}
 			return true
@@ -514,7 +513,7 @@ func (c *channelCacheImpl) compactChannelCache() {
 		// Update eviction stats
 		c.updateEvictionStats(inactiveEvictCount, len(evictionElements), compactIterationStart)
 
-		base.TracefCtx(logCtx, base.KeyCache, "Compact iteration complete - eviction count: %d (lwm:%d)", len(evictionElements), c.compactLowWatermark)
+		base.TracefCtx(ctx, base.KeyCache, "Compact iteration complete - eviction count: %d (lwm:%d)", len(evictionElements), c.compactLowWatermark)
 	}
 }
 

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -35,9 +35,9 @@ func TestDuplicateDocID(t *testing.T) {
 	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 
 	// Add some entries to cache
-	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
-	cache.addToCache(testLogEntry(2, "doc3", "3-a"), false)
-	cache.addToCache(testLogEntry(3, "doc5", "5-a"), false)
+	cache.addToCache(ctx, testLogEntry(1, "doc1", "1-a"), false)
+	cache.addToCache(ctx, testLogEntry(2, "doc3", "3-a"), false)
+	cache.addToCache(ctx, testLogEntry(3, "doc5", "5-a"), false)
 
 	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
@@ -46,7 +46,7 @@ func TestDuplicateDocID(t *testing.T) {
 	assert.True(t, err == nil)
 
 	// Add a new revision matching mid-list
-	cache.addToCache(testLogEntry(4, "doc3", "3-b"), false)
+	cache.addToCache(ctx, testLogEntry(4, "doc3", "3-b"), false)
 	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 3, 4}))
@@ -54,7 +54,7 @@ func TestDuplicateDocID(t *testing.T) {
 	assert.True(t, err == nil)
 
 	// Add a new revision matching first
-	cache.addToCache(testLogEntry(5, "doc1", "1-b"), false)
+	cache.addToCache(ctx, testLogEntry(5, "doc1", "1-b"), false)
 	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{3, 4, 5}))
@@ -62,7 +62,7 @@ func TestDuplicateDocID(t *testing.T) {
 	assert.True(t, err == nil)
 
 	// Add a new revision matching last
-	cache.addToCache(testLogEntry(6, "doc1", "1-c"), false)
+	cache.addToCache(ctx, testLogEntry(6, "doc1", "1-c"), false)
 	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{3, 4, 6}))
@@ -83,9 +83,9 @@ func TestLateArrivingSequence(t *testing.T) {
 	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 
 	// Add some entries to cache
-	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
-	cache.addToCache(testLogEntry(3, "doc3", "3-a"), false)
-	cache.addToCache(testLogEntry(5, "doc5", "5-a"), false)
+	cache.addToCache(ctx, testLogEntry(1, "doc1", "1-a"), false)
+	cache.addToCache(ctx, testLogEntry(3, "doc3", "3-a"), false)
+	cache.addToCache(ctx, testLogEntry(5, "doc5", "5-a"), false)
 
 	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
@@ -95,7 +95,7 @@ func TestLateArrivingSequence(t *testing.T) {
 
 	// Add a late-arriving sequence
 	cache.AddLateSequence(testLogEntry(2, "doc2", "2-a"))
-	cache.addToCache(testLogEntry(2, "doc2", "2-a"), false)
+	cache.addToCache(ctx, testLogEntry(2, "doc2", "2-a"), false)
 	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
@@ -117,9 +117,9 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 
 	// Add some entries to cache
-	cache.addToCache(testLogEntry(5, "doc1", "1-a"), false)
-	cache.addToCache(testLogEntry(10, "doc2", "2-a"), false)
-	cache.addToCache(testLogEntry(15, "doc3", "3-a"), false)
+	cache.addToCache(ctx, testLogEntry(5, "doc1", "1-a"), false)
+	cache.addToCache(ctx, testLogEntry(10, "doc2", "2-a"), false)
+	cache.addToCache(ctx, testLogEntry(15, "doc3", "3-a"), false)
 
 	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
@@ -129,7 +129,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 
 	// Add a late-arriving sequence
 	cache.AddLateSequence(testLogEntry(3, "doc0", "0-a"))
-	cache.addToCache(testLogEntry(3, "doc0", "0-a"), false)
+	cache.addToCache(ctx, testLogEntry(3, "doc0", "0-a"), false)
 	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
@@ -151,10 +151,10 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 
 	// Add some entries to cache
-	cache.addToCache(testLogEntry(10, "doc1", "1-a"), false)
-	cache.addToCache(testLogEntry(20, "doc2", "2-a"), false)
-	cache.addToCache(testLogEntry(30, "doc3", "3-a"), false)
-	cache.addToCache(testLogEntry(40, "doc4", "4-a"), false)
+	cache.addToCache(ctx, testLogEntry(10, "doc1", "1-a"), false)
+	cache.addToCache(ctx, testLogEntry(20, "doc2", "2-a"), false)
+	cache.addToCache(ctx, testLogEntry(30, "doc3", "3-a"), false)
+	cache.addToCache(ctx, testLogEntry(40, "doc4", "4-a"), false)
 
 	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
@@ -164,7 +164,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 
 	// Add a late-arriving sequence that should replace earlier sequence
 	cache.AddLateSequence(testLogEntry(25, "doc1", "1-c"))
-	cache.addToCache(testLogEntry(25, "doc1", "1-c"), false)
+	cache.addToCache(ctx, testLogEntry(25, "doc1", "1-c"), false)
 	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
@@ -174,7 +174,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 
 	// Add a late-arriving sequence that should be ignored (later sequence exists for that docID)
 	cache.AddLateSequence(testLogEntry(15, "doc1", "1-b"))
-	cache.addToCache(testLogEntry(15, "doc1", "1-b"), false)
+	cache.addToCache(ctx, testLogEntry(15, "doc1", "1-b"), false)
 	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
@@ -184,7 +184,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 
 	// Add a late-arriving sequence adjacent to same ID (cache inserts differently)
 	cache.AddLateSequence(testLogEntry(27, "doc1", "1-d"))
-	cache.addToCache(testLogEntry(27, "doc1", "1-d"), false)
+	cache.addToCache(ctx, testLogEntry(27, "doc1", "1-d"), false)
 	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
@@ -194,7 +194,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 
 	// Add a late-arriving sequence adjacent to same ID (cache inserts differently)
 	cache.AddLateSequence(testLogEntry(41, "doc4", "4-b"))
-	cache.addToCache(testLogEntry(41, "doc4", "4-b"), false)
+	cache.addToCache(ctx, testLogEntry(41, "doc4", "4-b"), false)
 	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
@@ -204,7 +204,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 
 	// Add late arriving that's duplicate of oldest in cache
 	cache.AddLateSequence(testLogEntry(45, "doc2", "2-b"))
-	cache.addToCache(testLogEntry(45, "doc2", "2-b"), false)
+	cache.addToCache(ctx, testLogEntry(45, "doc2", "2-b"), false)
 	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
@@ -231,7 +231,7 @@ func TestPrependChanges(t *testing.T) {
 		testLogEntry(14, "doc1", "2-a"),
 	}
 
-	numPrepended := cache.prependChanges(changesToPrepend, 5, 14)
+	numPrepended := cache.prependChanges(ctx, changesToPrepend, 5, 14)
 	assert.Equal(t, 3, numPrepended)
 
 	// Validate cache
@@ -242,8 +242,8 @@ func TestPrependChanges(t *testing.T) {
 	// 2. Test prepend to populated cache, with overlap and duplicates
 	cache = newSingleChannelCache(dbCtx, "PrependPopulatedCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	cache.validFrom = 13
-	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
-	cache.addToCache(testLogEntry(20, "doc2", "3-a"), false)
+	cache.addToCache(ctx, testLogEntry(14, "doc1", "2-a"), false)
+	cache.addToCache(ctx, testLogEntry(20, "doc2", "3-a"), false)
 
 	// Prepend
 	changesToPrepend = LogEntries{
@@ -253,7 +253,7 @@ func TestPrependChanges(t *testing.T) {
 		testLogEntry(14, "doc1", "2-a"),
 	}
 
-	numPrepended = cache.prependChanges(changesToPrepend, 5, 14)
+	numPrepended = cache.prependChanges(ctx, changesToPrepend, 5, 14)
 	assert.Equal(t, 2, numPrepended)
 
 	// Validate cache
@@ -272,7 +272,7 @@ func TestPrependChanges(t *testing.T) {
 	}
 
 	// Write a new revision for a prepended doc to the cache, validate that old entry is removed
-	cache.addToCache(testLogEntry(24, "doc3", "3-a"), false)
+	cache.addToCache(ctx, testLogEntry(24, "doc3", "3-a"), false)
 	validFrom, cachedChanges = cache.GetCachedChanges(getChangesOptionsWithCtxOnly())
 	assert.Equal(t, uint64(5), validFrom)
 	require.Len(t, cachedChanges, 4)
@@ -288,7 +288,7 @@ func TestPrependChanges(t *testing.T) {
 	}
 
 	// Prepend empty set, validate validFrom update
-	cache.prependChanges(LogEntries{}, 5, 14)
+	cache.prependChanges(ctx, LogEntries{}, 5, 14)
 	validFrom, cachedChanges = cache.GetCachedChanges(getChangesOptionsWithCtxOnly())
 	assert.Equal(t, uint64(5), validFrom)
 	require.Len(t, cachedChanges, 4)
@@ -297,10 +297,10 @@ func TestPrependChanges(t *testing.T) {
 	cache = newSingleChannelCache(dbCtx, "PrependToFillCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13
-	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
-	cache.addToCache(testLogEntry(20, "doc2", "3-a"), false)
-	cache.addToCache(testLogEntry(22, "doc3", "3-a"), false)
-	cache.addToCache(testLogEntry(23, "doc4", "3-a"), false)
+	cache.addToCache(ctx, testLogEntry(14, "doc1", "2-a"), false)
+	cache.addToCache(ctx, testLogEntry(20, "doc2", "3-a"), false)
+	cache.addToCache(ctx, testLogEntry(22, "doc3", "3-a"), false)
+	cache.addToCache(ctx, testLogEntry(23, "doc4", "3-a"), false)
 
 	// Prepend changes.  Only room for one more in cache.  doc1 and doc2 should be ignored (already in cache), doc 6 should get cached, doc 5 should be discarded.  validFrom should be doc6 (10)
 	changesToPrepend = LogEntries{
@@ -310,7 +310,7 @@ func TestPrependChanges(t *testing.T) {
 		testLogEntry(14, "doc1", "2-a"),
 	}
 
-	numPrepended = cache.prependChanges(changesToPrepend, 5, 14)
+	numPrepended = cache.prependChanges(ctx, changesToPrepend, 5, 14)
 	assert.Equal(t, 1, numPrepended)
 
 	// Validate cache
@@ -333,10 +333,10 @@ func TestPrependChanges(t *testing.T) {
 	// 4. Test prepend where all docids are already present in cache.  Cache entries shouldn't change, but validFrom is updated
 	cache = newSingleChannelCache(dbCtx, "PrependDuplicatesOnly", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	cache.validFrom = 13
-	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
-	cache.addToCache(testLogEntry(20, "doc2", "3-a"), false)
-	cache.addToCache(testLogEntry(22, "doc3", "3-a"), false)
-	cache.addToCache(testLogEntry(23, "doc4", "3-a"), false)
+	cache.addToCache(ctx, testLogEntry(14, "doc1", "2-a"), false)
+	cache.addToCache(ctx, testLogEntry(20, "doc2", "3-a"), false)
+	cache.addToCache(ctx, testLogEntry(22, "doc3", "3-a"), false)
+	cache.addToCache(ctx, testLogEntry(23, "doc4", "3-a"), false)
 
 	changesToPrepend = LogEntries{
 		testLogEntry(8, "doc2", "2-a"),
@@ -344,7 +344,7 @@ func TestPrependChanges(t *testing.T) {
 		testLogEntry(12, "doc4", "2-a"),
 		testLogEntry(14, "doc1", "2-a"),
 	}
-	numPrepended = cache.prependChanges(changesToPrepend, 5, 14)
+	numPrepended = cache.prependChanges(ctx, changesToPrepend, 5, 14)
 	assert.Equal(t, 0, numPrepended)
 	validFrom, cachedChanges = cache.GetCachedChanges(getChangesOptionsWithCtxOnly())
 	assert.Equal(t, uint64(5), validFrom)
@@ -364,11 +364,11 @@ func TestPrependChanges(t *testing.T) {
 	cache = newSingleChannelCache(dbCtx, "PrependFullCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13
-	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
-	cache.addToCache(testLogEntry(20, "doc2", "3-a"), false)
-	cache.addToCache(testLogEntry(22, "doc3", "3-a"), false)
-	cache.addToCache(testLogEntry(23, "doc4", "3-a"), false)
-	cache.addToCache(testLogEntry(25, "doc5", "3-a"), false)
+	cache.addToCache(ctx, testLogEntry(14, "doc1", "2-a"), false)
+	cache.addToCache(ctx, testLogEntry(20, "doc2", "3-a"), false)
+	cache.addToCache(ctx, testLogEntry(22, "doc3", "3-a"), false)
+	cache.addToCache(ctx, testLogEntry(23, "doc4", "3-a"), false)
+	cache.addToCache(ctx, testLogEntry(25, "doc5", "3-a"), false)
 
 	// Prepend changes, no room for in cache.
 	changesToPrepend = LogEntries{
@@ -378,7 +378,7 @@ func TestPrependChanges(t *testing.T) {
 		testLogEntry(14, "doc1", "2-a"),
 	}
 
-	numPrepended = cache.prependChanges(changesToPrepend, 6, 14)
+	numPrepended = cache.prependChanges(ctx, changesToPrepend, 6, 14)
 	assert.Equal(t, 0, numPrepended)
 
 	// Validate cache
@@ -410,9 +410,9 @@ func TestChannelCacheRemove(t *testing.T) {
 	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 
 	// Add some entries to cache
-	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
-	cache.addToCache(testLogEntry(2, "doc3", "3-a"), false)
-	cache.addToCache(testLogEntry(3, "doc5", "5-a"), false)
+	cache.addToCache(ctx, testLogEntry(1, "doc1", "1-a"), false)
+	cache.addToCache(ctx, testLogEntry(2, "doc3", "3-a"), false)
+	cache.addToCache(ctx, testLogEntry(3, "doc5", "5-a"), false)
 
 	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
@@ -421,7 +421,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	assert.True(t, err == nil)
 
 	// Now remove doc1
-	cache.Remove([]string{"doc1"}, time.Now())
+	cache.Remove(ctx, []string{"doc1"}, time.Now())
 	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 2)
 	assert.True(t, verifyChannelSequences(entries, []uint64{2, 3}))
@@ -431,7 +431,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	// Try to remove doc5 with a startTime before it was added to ensure it's not removed
 	// This will print a debug level log:
 	// [DBG] Cache+: Skipping removal of doc "doc5" from cache "Test1" - received after purge
-	cache.Remove([]string{"doc5"}, time.Now().Add(-time.Second*5))
+	cache.Remove(ctx, []string{"doc5"}, time.Now().Add(-time.Second*5))
 	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 2)
 	assert.True(t, verifyChannelSequences(entries, []uint64{2, 3}))
@@ -451,9 +451,9 @@ func TestChannelCacheStats(t *testing.T) {
 	cache := newSingleChannelCache(context, "Test1", 0, testStats)
 
 	// Add some entries to cache
-	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
-	cache.addToCache(testLogEntry(2, "doc2", "1-a"), false)
-	cache.addToCache(testLogEntry(3, "doc3", "1-a"), false)
+	cache.addToCache(ctx, testLogEntry(1, "doc1", "1-a"), false)
+	cache.addToCache(ctx, testLogEntry(2, "doc2", "1-a"), false)
+	cache.addToCache(ctx, testLogEntry(3, "doc3", "1-a"), false)
 
 	active, tombstones, removals := getCacheUtilization(testStats)
 	assert.Equal(t, 3, active)
@@ -461,22 +461,22 @@ func TestChannelCacheStats(t *testing.T) {
 	assert.Equal(t, 0, removals)
 
 	// Update keys already present in the cache, shouldn't modify utilization
-	cache.addToCache(testLogEntry(4, "doc1", "2-a"), false)
-	cache.addToCache(testLogEntry(5, "doc2", "2-a"), false)
+	cache.addToCache(ctx, testLogEntry(4, "doc1", "2-a"), false)
+	cache.addToCache(ctx, testLogEntry(5, "doc2", "2-a"), false)
 	active, tombstones, removals = getCacheUtilization(testStats)
 	assert.Equal(t, 3, active)
 	assert.Equal(t, 0, tombstones)
 	assert.Equal(t, 0, removals)
 
 	// Add a removal rev for a doc not previously in the cache
-	cache.addToCache(testLogEntry(6, "doc4", "2-a"), true)
+	cache.addToCache(ctx, testLogEntry(6, "doc4", "2-a"), true)
 	active, tombstones, removals = getCacheUtilization(testStats)
 	assert.Equal(t, 3, active)
 	assert.Equal(t, 0, tombstones)
 	assert.Equal(t, 1, removals)
 
 	// Add a removal rev for a doc previously in the cache
-	cache.addToCache(testLogEntry(7, "doc1", "3-a"), true)
+	cache.addToCache(ctx, testLogEntry(7, "doc1", "3-a"), true)
 	active, tombstones, removals = getCacheUtilization(testStats)
 	assert.Equal(t, 2, active)
 	assert.Equal(t, 0, tombstones)
@@ -485,7 +485,7 @@ func TestChannelCacheStats(t *testing.T) {
 	// Add a new tombstone to the cache
 	tombstone := testLogEntry(8, "doc5", "2-a")
 	tombstone.SetDeleted()
-	cache.addToCache(tombstone, false)
+	cache.addToCache(ctx, tombstone, false)
 	active, tombstones, removals = getCacheUtilization(testStats)
 	assert.Equal(t, 2, active)
 	assert.Equal(t, 1, tombstones)
@@ -494,7 +494,7 @@ func TestChannelCacheStats(t *testing.T) {
 	// Add a tombstone that's also a removal.  Should only be tracked as removal
 	tombstone = testLogEntry(9, "doc6", "2-a")
 	tombstone.SetDeleted()
-	cache.addToCache(tombstone, true)
+	cache.addToCache(ctx, tombstone, true)
 	active, tombstones, removals = getCacheUtilization(testStats)
 	assert.Equal(t, 2, active)
 	assert.Equal(t, 1, tombstones)
@@ -503,7 +503,7 @@ func TestChannelCacheStats(t *testing.T) {
 	// Tombstone a document id already present in the cache as an active revision
 	tombstone = testLogEntry(10, "doc2", "3-a")
 	tombstone.SetDeleted()
-	cache.addToCache(tombstone, false)
+	cache.addToCache(ctx, tombstone, false)
 	active, tombstones, removals = getCacheUtilization(testStats)
 	assert.Equal(t, 1, active)
 	assert.Equal(t, 2, tombstones)
@@ -523,16 +523,16 @@ func TestChannelCacheStatsOnPrune(t *testing.T) {
 	cache.options.ChannelCacheMaxLength = 5
 
 	// Add more than ChannelCacheMaxLength entries to cache
-	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
-	cache.addToCache(testLogEntry(2, "doc2", "1-a"), true)
-	cache.addToCache(testLogEntry(3, "doc3", "1-a"), false)
-	cache.addToCache(testLogEntry(4, "doc4", "1-a"), true)
-	cache.addToCache(testLogEntry(5, "doc5", "1-a"), false)
-	cache.addToCache(testLogEntry(6, "doc6", "1-a"), true)
-	cache.addToCache(testLogEntry(7, "doc7", "1-a"), false)
-	cache.addToCache(testLogEntry(8, "doc8", "1-a"), true)
-	cache.addToCache(testLogEntry(9, "doc9", "1-a"), false)
-	cache.addToCache(testLogEntry(10, "doc10", "1-a"), true)
+	cache.addToCache(ctx, testLogEntry(1, "doc1", "1-a"), false)
+	cache.addToCache(ctx, testLogEntry(2, "doc2", "1-a"), true)
+	cache.addToCache(ctx, testLogEntry(3, "doc3", "1-a"), false)
+	cache.addToCache(ctx, testLogEntry(4, "doc4", "1-a"), true)
+	cache.addToCache(ctx, testLogEntry(5, "doc5", "1-a"), false)
+	cache.addToCache(ctx, testLogEntry(6, "doc6", "1-a"), true)
+	cache.addToCache(ctx, testLogEntry(7, "doc7", "1-a"), false)
+	cache.addToCache(ctx, testLogEntry(8, "doc8", "1-a"), true)
+	cache.addToCache(ctx, testLogEntry(9, "doc9", "1-a"), false)
+	cache.addToCache(ctx, testLogEntry(10, "doc10", "1-a"), true)
 
 	active, tombstones, removals := getCacheUtilization(testStats)
 	assert.Equal(t, 2, active)
@@ -554,15 +554,15 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	cache.options.ChannelCacheMaxLength = 15
 
 	// Add 9 entries to cache, 3 of each type
-	cache.addToCache(testLogEntry(100, "active1", "2-a"), false)
-	cache.addToCache(testLogEntry(102, "active2", "2-a"), false)
-	cache.addToCache(testLogEntry(104, "removal1", "2-a"), true)
-	cache.addToCache(et(106, "tombstone1", "2-a"), false)
-	cache.addToCache(testLogEntry(107, "removal2", "2-a"), true)
-	cache.addToCache(testLogEntry(108, "removal3", "2-a"), true)
-	cache.addToCache(et(110, "tombstone2", "2-a"), false)
-	cache.addToCache(et(111, "tombstone3", "2-a"), false)
-	cache.addToCache(testLogEntry(112, "active3", "2-a"), false)
+	cache.addToCache(ctx, testLogEntry(100, "active1", "2-a"), false)
+	cache.addToCache(ctx, testLogEntry(102, "active2", "2-a"), false)
+	cache.addToCache(ctx, testLogEntry(104, "removal1", "2-a"), true)
+	cache.addToCache(ctx, et(106, "tombstone1", "2-a"), false)
+	cache.addToCache(ctx, testLogEntry(107, "removal2", "2-a"), true)
+	cache.addToCache(ctx, testLogEntry(108, "removal3", "2-a"), true)
+	cache.addToCache(ctx, et(110, "tombstone2", "2-a"), false)
+	cache.addToCache(ctx, et(111, "tombstone3", "2-a"), false)
+	cache.addToCache(ctx, testLogEntry(112, "active3", "2-a"), false)
 
 	active, tombstones, removals := getCacheUtilization(testStats)
 	assert.Equal(t, 3, active)
@@ -576,7 +576,7 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	prependDuplicatesSet[2] = (testLogEntry(52, "removal1", "1-a"))
 	prependDuplicatesSet[3] = (et(53, "tombstone1", "1-a"))
 	prependDuplicatesSet[4] = (testLogEntry(54, "tombstone3", "1-a"))
-	cache.prependChanges(prependDuplicatesSet, 50, 99)
+	cache.prependChanges(ctx, prependDuplicatesSet, 50, 99)
 
 	active, tombstones, removals = getCacheUtilization(testStats)
 	assert.Equal(t, 3, active)
@@ -596,7 +596,7 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	prependSet[8] = (testLogEntry(48, "new9", "1-a"))
 	prependSet[9] = (et(49, "new10", "1-a"))
 	prependSet[10] = (et(50, "active1", "1-a"))
-	cache.prependChanges(prependSet, 40, 50)
+	cache.prependChanges(ctx, prependSet, 40, 50)
 	active, tombstones, removals = getCacheUtilization(testStats)
 	assert.Equal(t, 6, active)
 	assert.Equal(t, 6, tombstones)
@@ -647,7 +647,7 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		cache.addToCache(testLogEntry(uint64(i), docIDs[i], "1-a"), false)
+		cache.addToCache(ctx, testLogEntry(uint64(i), docIDs[i], "1-a"), false)
 	}
 }
 
@@ -665,7 +665,7 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 	docIDs, revStrings := generateDocs(5.0, b.N)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		cache.addToCache(testLogEntry(uint64(i), docIDs[i], revStrings[i]), false)
+		cache.addToCache(ctx, testLogEntry(uint64(i), docIDs[i], revStrings[i]), false)
 	}
 }
 
@@ -683,7 +683,7 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 	docIDs, revStrings := generateDocs(20.0, b.N)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		cache.addToCache(testLogEntry(uint64(i), docIDs[i], revStrings[i]), false)
+		cache.addToCache(ctx, testLogEntry(uint64(i), docIDs[i], revStrings[i]), false)
 	}
 }
 
@@ -701,7 +701,7 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 	docIDs, revStrings := generateDocs(50.0, b.N)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		cache.addToCache(testLogEntry(uint64(i), docIDs[i], revStrings[i]), false)
+		cache.addToCache(ctx, testLogEntry(uint64(i), docIDs[i], revStrings[i]), false)
 	}
 }
 
@@ -719,7 +719,7 @@ func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 	docIDs, revStrings := generateDocs(80.0, b.N)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		cache.addToCache(testLogEntry(uint64(i), docIDs[i], revStrings[i]), false)
+		cache.addToCache(ctx, testLogEntry(uint64(i), docIDs[i], revStrings[i]), false)
 	}
 }
 
@@ -737,7 +737,7 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 	docIDs, revStrings := generateDocs(95.0, b.N)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		cache.addToCache(testLogEntry(uint64(i), docIDs[i], revStrings[i]), false)
+		cache.addToCache(ctx, testLogEntry(uint64(i), docIDs[i], revStrings[i]), false)
 	}
 }
 
@@ -767,7 +767,7 @@ func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		cache.addToCache(docs[i], false)
+		cache.addToCache(ctx, docs[i], false)
 	}
 }
 

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -27,8 +27,8 @@ func TestDuplicateDocID(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx, bucket := base.GetTestBucket(t)
+	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close(ctx)
 
@@ -75,8 +75,8 @@ func TestLateArrivingSequence(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx, bucket := base.GetTestBucket(t)
+	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close(ctx)
 
@@ -109,8 +109,8 @@ func TestLateSequenceAsFirst(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx, bucket := base.GetTestBucket(t)
+	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close(ctx)
 
@@ -143,8 +143,8 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx, bucket := base.GetTestBucket(t)
+	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close(ctx)
 
@@ -218,8 +218,8 @@ func TestPrependChanges(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	ctx := base.TestCtx(t)
-	dbCtx, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx, bucket := base.GetTestBucket(t)
+	dbCtx, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer dbCtx.Close(ctx)
 
@@ -403,8 +403,8 @@ func TestChannelCacheRemove(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx, bucket := base.GetTestBucket(t)
+	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
@@ -443,8 +443,8 @@ func TestChannelCacheStats(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx, bucket := base.GetTestBucket(t)
+	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close(ctx)
 	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
@@ -514,8 +514,8 @@ func TestChannelCacheStatsOnPrune(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx, bucket := base.GetTestBucket(t)
+	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close(ctx)
 	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
@@ -545,8 +545,8 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx, bucket := base.GetTestBucket(t)
+	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close(ctx)
 	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
@@ -635,8 +635,8 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 
 	base.DisableTestLogging(b)
 
-	ctx := base.TestCtx(b)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
+	ctx, bucket := base.GetTestBucket(b)
+	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
@@ -655,8 +655,8 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 
 	base.DisableTestLogging(b)
 
-	ctx := base.TestCtx(b)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
+	ctx, bucket := base.GetTestBucket(b)
+	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
@@ -673,8 +673,8 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 
 	base.DisableTestLogging(b)
 
-	ctx := base.TestCtx(b)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
+	ctx, bucket := base.GetTestBucket(b)
+	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
@@ -691,8 +691,8 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 
 	base.DisableTestLogging(b)
 
-	ctx := base.TestCtx(b)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
+	ctx, bucket := base.GetTestBucket(b)
+	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
@@ -709,8 +709,8 @@ func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 
 	base.DisableTestLogging(b)
 
-	ctx := base.TestCtx(b)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
+	ctx, bucket := base.GetTestBucket(b)
+	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
@@ -727,8 +727,8 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 
 	base.SetUpBenchmarkLogging(b, base.LevelInfo, base.KeyHTTP)
 
-	ctx := base.TestCtx(b)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
+	ctx, bucket := base.GetTestBucket(b)
+	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
@@ -745,8 +745,8 @@ func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 
 	base.DisableTestLogging(b)
 
-	ctx := base.TestCtx(b)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
+	ctx, bucket := base.GetTestBucket(b)
+	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close(ctx)
 	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -27,9 +27,8 @@ func TestChannelCacheMaxSize(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	bucket := base.GetTestBucket(t)
+	ctx, bucket := base.GetTestBucket(t)
 
-	ctx := base.TestCtx(t)
 	dbCtx, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer dbCtx.Close(ctx)

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -80,11 +80,12 @@ func TestChannelCacheSimpleCompact(t *testing.T) {
 	options := DefaultCacheOptions().ChannelCacheOptions
 	options.MaxNumChannels = 20
 
+	ctx := base.TestCtx(t)
 	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache(ctx, "testDb", options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 	defer cache.Stop()
 
@@ -116,11 +117,12 @@ func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 	options.CompactHighWatermarkPercent = 90
 	options.CompactLowWatermarkPercent = 50
 
+	ctx := base.TestCtx(t)
 	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache(ctx, "testDb", options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 	defer cache.Stop()
 
@@ -171,11 +173,12 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 	options.CompactHighWatermarkPercent = 90
 	options.CompactLowWatermarkPercent = 70
 
+	ctx := base.TestCtx(t)
 	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache(ctx, "testDb", options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 	defer cache.Stop()
 
@@ -264,11 +267,12 @@ func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 	options.CompactHighWatermarkPercent = 90
 	options.CompactLowWatermarkPercent = 70
 
+	ctx := base.TestCtx(t)
 	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache(ctx, "testDb", options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 	defer cache.Stop()
 
@@ -334,11 +338,12 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 	options.CompactHighWatermarkPercent = 90
 	options.CompactLowWatermarkPercent = 70
 
+	ctx := base.TestCtx(t)
 	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache(ctx, "testDb", options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 	defer cache.Stop()
 
@@ -399,11 +404,12 @@ func TestChannelCacheBypass(t *testing.T) {
 	options.CompactHighWatermarkPercent = 100
 	options.CompactLowWatermarkPercent = 50
 
+	ctx := base.TestCtx(t)
 	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache(ctx, "testDb", options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 	defer cache.Stop()
 
@@ -495,11 +501,12 @@ func TestChannelCacheBackgroundTaskWithIllegalTimeInterval(t *testing.T) {
 	options.ChannelCacheAge = 0
 	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 
+	ctx := base.TestCtx(t)
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
 
-	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache(ctx, "testDb", options, queryHandler, activeChannels, testStats)
 	assert.Error(t, err, "Background task error whilst creating channel cache")
 	assert.Nil(t, cache)
 

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1182,8 +1182,8 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 }
 
 func TestGetAvailableRevAttachments(t *testing.T) {
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx, bucket := base.GetTestBucket(t)
+	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
 	defer context.Close(ctx)
 	db, err := CreateDatabase(context)
@@ -1223,8 +1223,8 @@ func TestGetAvailableRevAttachments(t *testing.T) {
 }
 
 func TestGet1xRevAndChannels(t *testing.T) {
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx, bucket := base.GetTestBucket(t)
+	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
 	defer context.Close(ctx)
 	db, err := CreateDatabase(context)
@@ -1287,8 +1287,8 @@ func TestGet1xRevAndChannels(t *testing.T) {
 }
 
 func TestGet1xRevFromDoc(t *testing.T) {
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
+	ctx, bucket := base.GetTestBucket(t)
+	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
 	defer context.Close(ctx)
 	db, err := CreateDatabase(context)

--- a/db/database.go
+++ b/db/database.go
@@ -801,7 +801,7 @@ func (dbCtx *DatabaseContext) RemoveObsoleteIndexes(ctx context.Context, preview
 		return make([]string, 0), nil
 	}
 
-	return removeObsoleteIndexes(n1qlStore, previewOnly, dbCtx.UseXattrs(), dbCtx.UseViews(), sgIndexes)
+	return removeObsoleteIndexes(ctx, n1qlStore, previewOnly, dbCtx.UseXattrs(), dbCtx.UseViews(), sgIndexes)
 }
 
 // Trigger terminate check handling for connected continuous replications.

--- a/db/database.go
+++ b/db/database.go
@@ -277,7 +277,7 @@ type OpenBucketFn func(ctx context.Context, spec base.BucketSpec) (base.Bucket, 
 
 // connectToBucketFailFast opens a Couchbase connect and return a specific bucket without retrying on failure.
 func connectToBucketFailFast(ctx context.Context, spec base.BucketSpec) (bucket base.Bucket, err error) {
-	bucket, err = base.GetBucket(spec)
+	bucket, err = base.GetBucket(ctx, spec)
 	_, err = connectToBucketErrorHandling(ctx, spec, err)
 	return bucket, err
 }
@@ -287,7 +287,7 @@ func connectToBucket(ctx context.Context, spec base.BucketSpec) (base.Bucket, er
 
 	// start a retry loop to connect to the bucket backing off double the delay each time
 	worker := func() (bool, error, interface{}) {
-		bucket, err := base.GetBucket(spec)
+		bucket, err := base.GetBucket(ctx, spec)
 
 		// Retry if there was a non-fatal error
 		fatalError, newErr := connectToBucketErrorHandling(ctx, spec, err)

--- a/db/database.go
+++ b/db/database.go
@@ -577,7 +577,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		dbContext.PurgeInterval = DefaultPurgeInterval
 		cbStore, ok := base.AsCouchbaseStore(bucket)
 		if ok {
-			serverPurgeInterval, err := cbStore.MetadataPurgeInterval()
+			serverPurgeInterval, err := cbStore.MetadataPurgeInterval(ctx)
 			if err != nil {
 				base.WarnfCtx(ctx, "Unable to retrieve server's metadata purge interval - will use default value. %s", err)
 			} else if serverPurgeInterval > 0 {
@@ -616,7 +616,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	// Make sure there is no MaxTTL set on the bucket (SG #3314)
 	cbs, ok := base.AsCouchbaseStore(bucket)
 	if ok {
-		maxTTL, err := cbs.MaxTTL()
+		maxTTL, err := cbs.MaxTTL(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -698,7 +698,7 @@ func (dbCtx *DatabaseContext) GetServerUUID(ctx context.Context) string {
 			return ""
 		}
 
-		uuid, err := cbs.ServerUUID()
+		uuid, err := cbs.ServerUUID(ctx)
 		if err != nil {
 			base.WarnfCtx(ctx, "Database %v: Unable to get server UUID: %v", base.MD(dbCtx.Name), err)
 			return ""
@@ -1287,7 +1287,7 @@ func (db *Database) Compact(ctx context.Context, skipRunningStateCheck bool, cal
 	if db.PurgeInterval > 0 {
 		cbStore, ok := base.AsCouchbaseStore(db.Bucket)
 		if ok {
-			serverPurgeInterval, err := cbStore.MetadataPurgeInterval()
+			serverPurgeInterval, err := cbStore.MetadataPurgeInterval(ctx)
 			if err != nil {
 				base.WarnfCtx(ctx, "Unable to retrieve server's metadata purge interval - using existing purge interval. %s", err)
 			} else if serverPurgeInterval > 0 {

--- a/db/database.go
+++ b/db/database.go
@@ -784,8 +784,8 @@ func (dbCtx *DatabaseContext) FlushChannelCache(ctx context.Context) error {
 }
 
 // Removes previous versions of Sync Gateway's design docs found on the server
-func (context *DatabaseContext) RemoveObsoleteDesignDocs(previewOnly bool) (removedDesignDocs []string, err error) {
-	return removeObsoleteDesignDocs(context.Bucket, previewOnly, context.UseViews())
+func (context *DatabaseContext) RemoveObsoleteDesignDocs(ctx context.Context, previewOnly bool) (removedDesignDocs []string, err error) {
+	return removeObsoleteDesignDocs(ctx, context.Bucket, previewOnly, context.UseViews())
 }
 
 // Removes previous versions of Sync Gateway's indexes found on the server

--- a/db/database.go
+++ b/db/database.go
@@ -734,7 +734,7 @@ func (context *DatabaseContext) Close(ctx context.Context) {
 	if context.SGReplicateMgr != nil {
 		context.SGReplicateMgr.Stop()
 	}
-	context.Bucket.Close()
+	context.Bucket.Close(ctx)
 	context.Bucket = nil
 
 	base.RemovePerDbStats(context.Name)

--- a/db/database.go
+++ b/db/database.go
@@ -827,7 +827,7 @@ func (dc *DatabaseContext) TakeDbOffline(ctx context.Context, reason string) err
 		// set DB state to Offline
 		atomic.StoreUint32(&dc.State, DBOffline)
 
-		if err := dc.EventMgr.RaiseDBStateChangeEvent(dc.Name, "offline", reason, dc.Options.AdminInterface); err != nil {
+		if err := dc.EventMgr.RaiseDBStateChangeEvent(ctx, dc.Name, "offline", reason, dc.Options.AdminInterface); err != nil {
 			base.DebugfCtx(ctx, base.KeyCRUD, "Error raising database state change event: %v", err)
 		}
 
@@ -1518,8 +1518,8 @@ func (db *Database) UpdateAllDocChannels(ctx context.Context, regenerateSequence
 						}
 
 						changedChannels, err := doc.updateChannels(ctx, channels)
-						changed = len(doc.Access.updateAccess(doc, access)) +
-							len(doc.RoleAccess.updateAccess(doc, roles)) +
+						changed = len(doc.Access.updateAccess(ctx, doc, access)) +
+							len(doc.RoleAccess.updateAccess(ctx, doc, roles)) +
 							len(changedChannels)
 						if err != nil {
 							return

--- a/db/database.go
+++ b/db/database.go
@@ -515,7 +515,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	}
 
 	cleanupFunctions = append(cleanupFunctions, func() {
-		dbContext.changeCache.Stop()
+		dbContext.changeCache.Stop(ctx)
 	})
 
 	// If this is an xattr import node, start import feed.  Must be started after the caching DCP feed, as import cfg
@@ -726,7 +726,7 @@ func (context *DatabaseContext) Close(ctx context.Context) {
 	waitForBGTCompletion(ctx, BGTCompletionMaxWait, context.backgroundTasks, context.Name)
 	context.sequences.Stop()
 	context.mutationListener.Stop()
-	context.changeCache.Stop()
+	context.changeCache.Stop(ctx)
 	context.ImportListener.Stop()
 	if context.Heartbeater != nil {
 		context.Heartbeater.Stop()
@@ -822,7 +822,7 @@ func (dc *DatabaseContext) TakeDbOffline(ctx context.Context, reason string) err
 		dc.AccessLock.Lock()
 		defer dc.AccessLock.Unlock()
 
-		dc.changeCache.Stop()
+		dc.changeCache.Stop(ctx)
 
 		// set DB state to Offline
 		atomic.StoreUint32(&dc.State, DBOffline)

--- a/db/database.go
+++ b/db/database.go
@@ -461,7 +461,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	if base.IsEnterpriseEdition() && (importEnabled || sgReplicateEnabled) {
 		// Create heartbeater
 		heartbeaterPrefix := base.HeartbeaterPrefixWithGroupID(dbContext.Options.GroupID)
-		heartbeater, err := base.NewCouchbaseHeartbeater(bucket, heartbeaterPrefix, dbContext.UUID)
+		heartbeater, err := base.NewCouchbaseHeartbeater(ctx, bucket, heartbeaterPrefix, dbContext.UUID)
 		if err != nil {
 			return nil, pkgerrors.Wrapf(err, "Error starting heartbeater for bucket %s", base.MD(bucket.GetName()).Redact())
 		}

--- a/db/database.go
+++ b/db/database.go
@@ -390,7 +390,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	dbContext.EventMgr = NewEventManager(dbContext.terminator)
 
 	var err error
-	dbContext.sequences, err = newSequenceAllocator(bucket, dbContext.DbStats.Database())
+	dbContext.sequences, err = newSequenceAllocator(ctx, bucket, dbContext.DbStats.Database())
 	if err != nil {
 		return nil, err
 	}
@@ -595,7 +595,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 					<-dbContext.terminator
 					bgtTerminator.Close()
 				}()
-				bgt, err := NewBackgroundTask("Compact", dbContext.Name, func(ctx context.Context) error {
+				bgt, err := NewBackgroundTask(ctx, "Compact", dbContext.Name, func(ctx context.Context) error {
 					_, err := db.Compact(ctx, false, func(purgedDocCount *int) {}, bgtTerminator)
 					if err != nil {
 						base.WarnfCtx(ctx, "Error trying to compact tombstoned documents for %q with error: %v", dbContext.Name, err)

--- a/db/database.go
+++ b/db/database.go
@@ -491,7 +491,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	// Start DCP feed
 	base.InfofCtx(ctx, base.KeyDCP, "Starting mutation feed on bucket %v due to either channel cache mode or doc tracking (auto-import)", base.MD(bucket.GetName()))
 	cacheFeedStatsMap := dbContext.DbStats.Database().CacheFeedMapStats
-	err = dbContext.mutationListener.Start(bucket, cacheFeedStatsMap.Map)
+	err = dbContext.mutationListener.Start(ctx, bucket, cacheFeedStatsMap.Map)
 
 	// Check if there is an error starting the DCP feed
 	if err != nil {
@@ -765,13 +765,13 @@ func (context *DatabaseContext) IsClosed() bool {
 }
 
 // For testing only!
-func (context *DatabaseContext) RestartListener() error {
+func (context *DatabaseContext) RestartListener(ctx context.Context) error {
 	context.mutationListener.Stop()
 	// Delay needed to properly stop
 	time.Sleep(2 * time.Second)
 	context.mutationListener.Init(context.Bucket.GetName(), context.Options.GroupID)
 	cacheFeedStatsMap := context.DbStats.Database().CacheFeedMapStats
-	if err := context.mutationListener.Start(context.Bucket, cacheFeedStatsMap.Map); err != nil {
+	if err := context.mutationListener.Start(ctx, context.Bucket, cacheFeedStatsMap.Map); err != nil {
 		return err
 	}
 	return nil

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1725,7 +1725,7 @@ func BenchmarkDatabase(b *testing.B) {
 		ctx := base.TestCtx(b)
 		bucket, _ := connectToBucket(ctx, base.BucketSpec{
 			Server:          base.UnitTestUrl(),
-			CouchbaseDriver: base.ChooseCouchbaseDriver(base.DataBucket),
+			CouchbaseDriver: base.ChooseCouchbaseDriver(ctx, base.DataBucket),
 			BucketName:      fmt.Sprintf("b-%d", i)})
 		dbCtx, _ := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 		db, _ := CreateDatabase(dbCtx)
@@ -1743,7 +1743,7 @@ func BenchmarkPut(b *testing.B) {
 	ctx := base.TestCtx(b)
 	bucket, _ := connectToBucket(ctx, base.BucketSpec{
 		Server:          base.UnitTestUrl(),
-		CouchbaseDriver: base.ChooseCouchbaseDriver(base.DataBucket),
+		CouchbaseDriver: base.ChooseCouchbaseDriver(ctx, base.DataBucket),
 		BucketName:      "Bucket"})
 	context, _ := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	db, _ := CreateDatabase(context)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -785,7 +785,7 @@ func TestAllDocsOnly(t *testing.T) {
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
 	// Trigger creation of the channel cache for channel "all"
-	db.changeCache.getChannelCache().getSingleChannelCache("all")
+	db.changeCache.getChannelCache().getSingleChannelCache(ctx, "all")
 
 	ids := make([]AllDocsEntry, 100)
 	for i := 0; i < 100; i++ {
@@ -828,7 +828,7 @@ func TestAllDocsOnly(t *testing.T) {
 	// There are 101 sequences overall, so the 1st one it has should be #52.
 	err = db.changeCache.waitForSequence(ctx, 101, base.DefaultWaitForSequence)
 	require.NoError(t, err)
-	changeLog := db.GetChangeLog("all", 0)
+	changeLog := db.GetChangeLog(ctx, "all", 0)
 	require.Len(t, changeLog, 50)
 	assert.Equal(t, "alldoc-51", changeLog[0].DocID)
 
@@ -959,7 +959,7 @@ func TestConflicts(t *testing.T) {
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
 	// Instantiate channel cache for channel 'all'
-	db.changeCache.getChannelCache().getSingleChannelCache("all")
+	db.changeCache.getChannelCache().getSingleChannelCache(ctx, "all")
 
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
 
@@ -971,7 +971,7 @@ func TestConflicts(t *testing.T) {
 	// Wait for rev to be cached
 	cacheWaiter.AddAndWait(1)
 
-	changeLog := db.GetChangeLog("all", 0)
+	changeLog := db.GetChangeLog(ctx, "all", 0)
 	assert.Equal(t, 1, len(changeLog))
 
 	// Create two conflicting changes:
@@ -1005,7 +1005,7 @@ func TestConflicts(t *testing.T) {
 
 	// Verify the change-log of the "all" channel:
 	cacheWaiter.Wait()
-	changeLog = db.GetChangeLog("all", 0)
+	changeLog = db.GetChangeLog(ctx, "all", 0)
 	assert.Equal(t, 1, len(changeLog))
 	assert.Equal(t, uint64(3), changeLog[0].Sequence)
 	assert.Equal(t, "doc", changeLog[0].DocID)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -53,8 +53,8 @@ func setupTestDBForBucket(t testing.TB, bucket base.Bucket) (*Database, context.
 // override somedbcOptions properties.
 func setupTestDBWithOptions(t testing.TB, dbcOptions DatabaseContextOptions) (*Database, context.Context) {
 
-	tBucket := base.GetTestBucket(t)
-	return setupTestDBForBucketWithOptions(t, tBucket, dbcOptions)
+	ctx, tBucket := base.GetTestBucket(t)
+	return setupTestDBForBucketWithOptions(t, ctx, tBucket, dbcOptions)
 }
 
 func setupTestDBForBucketWithOptions(t testing.TB, tBucket base.Bucket, dbcOptions DatabaseContextOptions) (*Database, context.Context) {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -901,7 +901,7 @@ func TestUpdatePrincipal(t *testing.T) {
 	_, err = db.UpdatePrincipal(ctx, userInfo, true, true)
 	assert.NoError(t, err, "Unable to update principal")
 
-	nextSeq, err := db.sequences.nextSequence()
+	nextSeq, err := db.sequences.nextSequence(ctx)
 	assert.Equal(t, uint64(1), nextSeq)
 
 	// Validate that a call to UpdatePrincipals with changes to the user does allocate a sequence
@@ -910,7 +910,7 @@ func TestUpdatePrincipal(t *testing.T) {
 	_, err = db.UpdatePrincipal(ctx, userInfo, true, true)
 	assert.NoError(t, err, "Unable to update principal")
 
-	nextSeq, err = db.sequences.nextSequence()
+	nextSeq, err = db.sequences.nextSequence(ctx)
 	assert.Equal(t, uint64(3), nextSeq)
 }
 

--- a/db/dcp_sharded_upgrade_test.go
+++ b/db/dcp_sharded_upgrade_test.go
@@ -179,8 +179,8 @@ func TestShardedDCPUpgrade(t *testing.T) {
 		t.Skip("Heartbeat listener requires Couchbase Server")
 	}
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyDCP, base.KeyImport, base.KeyCluster)
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
+	ctx, tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
 	bucketUUID, err := tb.UUID()
 	require.NoError(t, err, "get bucket UUID")
 
@@ -205,8 +205,7 @@ func TestShardedDCPUpgrade(t *testing.T) {
 	)
 	require.NoError(t, tb.SetRaw(testDoc1, 0, nil, []byte(`{}`)))
 
-	ctx := base.TestCtx(t)
-	db, err := NewDatabaseContext(ctx, tb.GetName(), tb.NoCloseClone(), true, DatabaseContextOptions{
+	db, err := NewDatabaseContext(ctx, tb.GetName(), tb.NoCloseClone(ctx), true, DatabaseContextOptions{
 		GroupID:     "",
 		EnableXattr: true,
 		UseViews:    base.TestsDisableGSI(),

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -82,14 +82,14 @@ func (db *Database) checkDDocAccess(ddocName string) error {
 	return nil
 }
 
-func (db *Database) GetDesignDoc(ddocName string) (ddoc sgbucket.DesignDoc, err error) {
+func (db *Database) GetDesignDoc(ctx context.Context, ddocName string) (ddoc sgbucket.DesignDoc, err error) {
 	if err = db.checkDDocAccess(ddocName); err != nil {
 		return ddoc, err
 	}
-	return db.Bucket.GetDDoc(ddocName)
+	return db.Bucket.GetDDoc(ctx, ddocName)
 }
 
-func (db *Database) PutDesignDoc(ddocName string, ddoc sgbucket.DesignDoc) (err error) {
+func (db *Database) PutDesignDoc(ctx context.Context, ddocName string, ddoc sgbucket.DesignDoc) (err error) {
 	wrap := true
 	if opts := ddoc.Options; opts != nil {
 		if opts.Raw == true {
@@ -100,7 +100,7 @@ func (db *Database) PutDesignDoc(ddocName string, ddoc sgbucket.DesignDoc) (err 
 		wrapViews(&ddoc, db.GetUserViewsEnabled(), db.UseXattrs())
 	}
 	if err = db.checkDDocAccess(ddocName); err == nil {
-		err = db.Bucket.PutDDoc(ddocName, &ddoc)
+		err = db.Bucket.PutDDoc(ctx, ddocName, &ddoc)
 	}
 	return
 }
@@ -218,14 +218,14 @@ func wrapViews(ddoc *sgbucket.DesignDoc, enableUserViews bool, useXattrs bool) {
 	}
 }
 
-func (db *Database) DeleteDesignDoc(ddocName string) (err error) {
+func (db *Database) DeleteDesignDoc(ctx context.Context, ddocName string) (err error) {
 	if err = db.checkDDocAccess(ddocName); err == nil {
-		err = db.Bucket.DeleteDDoc(ddocName)
+		err = db.Bucket.DeleteDDoc(ctx, ddocName)
 	}
 	return
 }
 
-func (db *Database) QueryDesignDoc(ddocName string, viewName string, options map[string]interface{}) (*sgbucket.ViewResult, error) {
+func (db *Database) QueryDesignDoc(ctx context.Context, ddocName string, viewName string, options map[string]interface{}) (*sgbucket.ViewResult, error) {
 
 	// Regular users have limitations on what they can query
 	if db.user != nil {
@@ -240,7 +240,7 @@ func (db *Database) QueryDesignDoc(ddocName string, viewName string, options map
 		}
 	}
 
-	result, err := db.Bucket.View(ddocName, viewName, options)
+	result, err := db.Bucket.View(ctx, ddocName, viewName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -324,44 +324,44 @@ func stripSyncProperty(row *sgbucket.ViewRow) {
 	}
 }
 
-func InitializeViews(bucket base.Bucket) error {
+func InitializeViews(ctx context.Context, bucket base.Bucket) error {
 	collection, ok := bucket.(*base.Collection)
 	if ok && !collection.IsDefaultScopeCollection() {
 		return fmt.Errorf("Can not initialize views on a non default collection")
 	}
 	// Check whether design docs are already present
-	ddocsExist := checkExistingDDocs(bucket)
+	ddocsExist := checkExistingDDocs(ctx, bucket)
 
 	// If not present, install design docs and views
 	if !ddocsExist {
-		base.InfofCtx(context.TODO(), base.KeyAll, "Design docs for current view version (%s) do not exist - creating...", DesignDocVersion)
-		if err := installViews(bucket); err != nil {
+		base.InfofCtx(ctx, base.KeyAll, "Design docs for current view version (%s) do not exist - creating...", DesignDocVersion)
+		if err := installViews(ctx, bucket); err != nil {
 			return err
 		}
 	}
 
 	// Wait for views to be indexed and available
-	return WaitForViews(bucket)
+	return WaitForViews(ctx, bucket)
 }
 
-func checkExistingDDocs(bucket base.Bucket) bool {
+func checkExistingDDocs(ctx context.Context, bucket base.Bucket) bool {
 
 	// Check whether design docs already exist
-	_, getDDocErr := bucket.GetDDoc(DesignDocSyncGateway())
+	_, getDDocErr := bucket.GetDDoc(ctx, DesignDocSyncGateway())
 	sgDDocExists := getDDocErr == nil
 
-	_, getDDocErr = bucket.GetDDoc(DesignDocSyncHousekeeping())
+	_, getDDocErr = bucket.GetDDoc(ctx, DesignDocSyncHousekeeping())
 	sgHousekeepingDDocExists := getDDocErr == nil
 
 	if sgDDocExists && sgHousekeepingDDocExists {
-		base.InfofCtx(context.TODO(), base.KeyAll, "Design docs for current SG view version (%s) found.", DesignDocVersion)
+		base.InfofCtx(ctx, base.KeyAll, "Design docs for current SG view version (%s) found.", DesignDocVersion)
 		return true
 	}
 
 	return false
 }
 
-func installViews(bucket base.Bucket) error {
+func installViews(ctx context.Context, bucket base.Bucket) error {
 
 	// syncData specifies the path to Sync Gateway sync metadata used in the map function -
 	// in the document body when xattrs available, in the mobile xattr when xattrs enabled.
@@ -589,9 +589,9 @@ func installViews(bucket base.Bucket) error {
 
 		// start a retry loop to put design document backing off double the delay each time
 		worker := func() (shouldRetry bool, err error, value interface{}) {
-			err = bucket.PutDDoc(designDocName, designDoc)
+			err = bucket.PutDDoc(ctx, designDocName, designDoc)
 			if err != nil {
-				base.WarnfCtx(context.TODO(), "Error installing Couchbase design doc: %v", err)
+				base.WarnfCtx(ctx, "Error installing Couchbase design doc: %v", err)
 			}
 			return err != nil, err, nil
 		}
@@ -604,24 +604,24 @@ func installViews(bucket base.Bucket) error {
 		}
 	}
 
-	base.InfofCtx(context.TODO(), base.KeyAll, "Design docs successfully created for view version %s.", DesignDocVersion)
+	base.InfofCtx(ctx, base.KeyAll, "Design docs successfully created for view version %s.", DesignDocVersion)
 
 	return nil
 }
 
 // Issue a stale=false queries against critical views to guarantee indexing is complete and views are ready
-func WaitForViews(bucket base.Bucket) error {
+func WaitForViews(ctx context.Context, bucket base.Bucket) error {
 	var viewsWg sync.WaitGroup
 	views := []string{ViewChannels, ViewAccess, ViewRoleAccess}
 	viewErrors := make(chan error, len(views))
 
-	base.InfofCtx(context.TODO(), base.KeyAll, "Verifying view availability for bucket %s...", base.UD(bucket.GetName()))
+	base.InfofCtx(ctx, base.KeyAll, "Verifying view availability for bucket %s...", base.UD(bucket.GetName()))
 
 	for _, viewName := range views {
 		viewsWg.Add(1)
 		go func(view string) {
 			defer viewsWg.Done()
-			viewErr := waitForViewIndexing(bucket, DesignDocSyncGateway(), view)
+			viewErr := waitForViewIndexing(ctx, bucket, DesignDocSyncGateway(), view)
 			if viewErr != nil {
 				viewErrors <- viewErr
 			}
@@ -635,13 +635,13 @@ func WaitForViews(bucket base.Bucket) error {
 		return err
 	}
 
-	base.InfofCtx(context.TODO(), base.KeyAll, "Views ready for bucket %s.", base.UD(bucket.GetName()))
+	base.InfofCtx(ctx, base.KeyAll, "Views ready for bucket %s.", base.UD(bucket.GetName()))
 	return nil
 
 }
 
 // Issues stale=false view queries to determine when view indexing is complete.  Retries on timeout
-func waitForViewIndexing(bucket base.Bucket, ddocName string, viewName string) error {
+func waitForViewIndexing(ctx context.Context, bucket base.Bucket, ddocName string, viewName string) error {
 	opts := map[string]interface{}{"stale": false, "key": fmt.Sprintf("view_%s_ready_check", viewName), "limit": 1}
 
 	// Not using standard retry loop here, because we want to retry indefinitely on view timeout (since view indexing could potentially take hours), and
@@ -650,7 +650,7 @@ func waitForViewIndexing(bucket base.Bucket, ddocName string, viewName string) e
 	retrySleep := float64(100)
 	maxRetry := 18
 	for {
-		results, err := bucket.ViewQuery(ddocName, viewName, opts)
+		results, err := bucket.ViewQuery(ctx, ddocName, viewName, opts)
 		if results != nil {
 			_ = results.Close()
 		}
@@ -660,14 +660,14 @@ func waitForViewIndexing(bucket base.Bucket, ddocName string, viewName string) e
 
 		// Retry on timeout or undefined view errors , otherwise return the error
 		if err == base.ErrViewTimeoutError {
-			base.InfofCtx(context.TODO(), base.KeyAll, "Timeout waiting for view %q to be ready for bucket %q - retrying...", viewName, base.UD(bucket.GetName()))
+			base.InfofCtx(ctx, base.KeyAll, "Timeout waiting for view %q to be ready for bucket %q - retrying...", viewName, base.UD(bucket.GetName()))
 		} else {
 			// For any other error, retry up to maxRetry, to wait for view initialization on the server
 			errRetryCount++
 			if errRetryCount > maxRetry {
 				return err
 			}
-			base.WarnfCtx(context.TODO(), "Error waiting for view %q to be ready for bucket %q - retrying...(%d/%d)", viewName, bucket.GetName(), errRetryCount, maxRetry)
+			base.WarnfCtx(ctx, "Error waiting for view %q to be ready for bucket %q - retrying...(%d/%d)", viewName, bucket.GetName(), errRetryCount, maxRetry)
 			time.Sleep(time.Duration(retrySleep) * time.Millisecond)
 			retrySleep *= float64(1.5)
 		}
@@ -675,7 +675,7 @@ func waitForViewIndexing(bucket base.Bucket, ddocName string, viewName string) e
 
 }
 
-func removeObsoleteDesignDocs(bucket base.Bucket, previewOnly bool, useViews bool) (removedDesignDocs []string, err error) {
+func removeObsoleteDesignDocs(ctx context.Context, bucket base.Bucket, previewOnly bool, useViews bool) (removedDesignDocs []string, err error) {
 
 	removedDesignDocs = make([]string, 0)
 	designDocPrefixes := []string{DesignDocSyncGatewayPrefix, DesignDocSyncHousekeepingPrefix}
@@ -696,7 +696,7 @@ func removeObsoleteDesignDocs(bucket base.Bucket, previewOnly bool, useViews boo
 			}
 
 			if !previewOnly {
-				removeDDocErr := bucket.DeleteDDoc(ddocName)
+				removeDDocErr := bucket.DeleteDDoc(ctx, ddocName)
 				if removeDDocErr != nil && !IsMissingDDocError(removeDDocErr) {
 					base.WarnfCtx(context.TODO(), "Unexpected error when removing design doc %q: %s", ddocName, removeDDocErr)
 				}
@@ -705,7 +705,7 @@ func removeObsoleteDesignDocs(bucket base.Bucket, previewOnly bool, useViews boo
 					removedDesignDocs = append(removedDesignDocs, ddocName)
 				}
 			} else {
-				_, existsDDocErr := bucket.GetDDoc(ddocName)
+				_, existsDDocErr := bucket.GetDDoc(ctx, ddocName)
 				if existsDDocErr != nil && !IsMissingDDocError(existsDDocErr) {
 					base.WarnfCtx(context.TODO(), "Unexpected error when checking existence of design doc %q: %s", ddocName, existsDDocErr)
 				}

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -698,7 +698,7 @@ func removeObsoleteDesignDocs(ctx context.Context, bucket base.Bucket, previewOn
 			if !previewOnly {
 				removeDDocErr := bucket.DeleteDDoc(ctx, ddocName)
 				if removeDDocErr != nil && !IsMissingDDocError(removeDDocErr) {
-					base.WarnfCtx(context.TODO(), "Unexpected error when removing design doc %q: %s", ddocName, removeDDocErr)
+					base.WarnfCtx(ctx, "Unexpected error when removing design doc %q: %s", ddocName, removeDDocErr)
 				}
 				// Only include in list of removedDesignDocs if it was actually removed
 				if removeDDocErr == nil {
@@ -707,7 +707,7 @@ func removeObsoleteDesignDocs(ctx context.Context, bucket base.Bucket, previewOn
 			} else {
 				_, existsDDocErr := bucket.GetDDoc(ctx, ddocName)
 				if existsDDocErr != nil && !IsMissingDDocError(existsDDocErr) {
-					base.WarnfCtx(context.TODO(), "Unexpected error when checking existence of design doc %q: %s", ddocName, existsDDocErr)
+					base.WarnfCtx(ctx, "Unexpected error when checking existence of design doc %q: %s", ddocName, existsDDocErr)
 				}
 				// Only include in list of removedDesignDocs if it exists
 				if existsDDocErr == nil {

--- a/db/design_doc_test.go
+++ b/db/design_doc_test.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"context"
 	"testing"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -21,18 +22,18 @@ import (
 
 func TestRemoveObsoleteDesignDocs(t *testing.T) {
 
-	base.ForAllDataStores(t, func(t *testing.T, bucket base.Bucket) {
+	base.ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket base.Bucket) {
 		mapFunction := `function (doc, meta) { emit(); }`
 
 		// Add some design docs in the old format
-		err := bucket.PutDDoc(DesignDocSyncGatewayPrefix, &sgbucket.DesignDoc{
+		err := bucket.PutDDoc(ctx, DesignDocSyncGatewayPrefix, &sgbucket.DesignDoc{
 			Views: sgbucket.ViewMap{
 				"channels": sgbucket.ViewDef{Map: mapFunction},
 			},
 		})
 		require.NoError(t, err, "Unable to create design doc (DesignDocSyncGatewayPrefix)")
 
-		err = bucket.PutDDoc(DesignDocSyncHousekeepingPrefix, &sgbucket.DesignDoc{
+		err = bucket.PutDDoc(ctx, DesignDocSyncHousekeepingPrefix, &sgbucket.DesignDoc{
 			Views: sgbucket.ViewMap{
 				"all_docs": sgbucket.ViewDef{Map: mapFunction},
 			},
@@ -40,7 +41,7 @@ func TestRemoveObsoleteDesignDocs(t *testing.T) {
 		require.NoError(t, err, "Unable to create design doc (DesignDocSyncHousekeepingPrefix)")
 
 		// Add some user design docs that shouldn't be removed
-		err = bucket.PutDDoc("sync_gateway_user_ddoc", &sgbucket.DesignDoc{
+		err = bucket.PutDDoc(ctx, "sync_gateway_user_ddoc", &sgbucket.DesignDoc{
 			Views: sgbucket.ViewMap{
 				"channels_custom": sgbucket.ViewDef{Map: mapFunction},
 			},
@@ -49,13 +50,13 @@ func TestRemoveObsoleteDesignDocs(t *testing.T) {
 
 		// Verify creation was successful
 		base.RequireAllAssertions(t,
-			assertDesignDocExists(t, bucket, DesignDocSyncGatewayPrefix),
-			assertDesignDocExists(t, bucket, DesignDocSyncHousekeepingPrefix),
-			assertDesignDocExists(t, bucket, "sync_gateway_user_ddoc"),
+			assertDesignDocExists(t, ctx, bucket, DesignDocSyncGatewayPrefix),
+			assertDesignDocExists(t, ctx, bucket, DesignDocSyncHousekeepingPrefix),
+			assertDesignDocExists(t, ctx, bucket, "sync_gateway_user_ddoc"),
 		)
 
 		// Invoke removal in preview mode
-		removedDDocs, removeErr := removeObsoleteDesignDocs(bucket, true, true)
+		removedDDocs, removeErr := removeObsoleteDesignDocs(ctx, bucket, true, true)
 		require.NoError(t, removeErr, "Error removing previous design docs")
 		assert.Equal(t, 2, len(removedDDocs))
 		assert.True(t, base.StringSliceContains(removedDDocs, DesignDocSyncGatewayPrefix), "Missing design doc from removed set")
@@ -63,13 +64,13 @@ func TestRemoveObsoleteDesignDocs(t *testing.T) {
 
 		// Re-verify ddocs still exist (preview)
 		base.RequireAllAssertions(t,
-			assertDesignDocExists(t, bucket, DesignDocSyncGatewayPrefix),
-			assertDesignDocExists(t, bucket, DesignDocSyncHousekeepingPrefix),
-			assertDesignDocExists(t, bucket, "sync_gateway_user_ddoc"),
+			assertDesignDocExists(t, ctx, bucket, DesignDocSyncGatewayPrefix),
+			assertDesignDocExists(t, ctx, bucket, DesignDocSyncHousekeepingPrefix),
+			assertDesignDocExists(t, ctx, bucket, "sync_gateway_user_ddoc"),
 		)
 
 		// Invoke removal in non-preview mode
-		removedDDocs, removeErr = removeObsoleteDesignDocs(bucket, false, true)
+		removedDDocs, removeErr = removeObsoleteDesignDocs(ctx, bucket, false, true)
 		require.NoError(t, removeErr, "Error removing previous design docs")
 		assert.Equal(t, 2, len(removedDDocs))
 		assert.True(t, base.StringSliceContains(removedDDocs, DesignDocSyncGatewayPrefix), "Missing design doc from removed set")
@@ -77,9 +78,9 @@ func TestRemoveObsoleteDesignDocs(t *testing.T) {
 
 		// Verify ddocs are in expected state
 		base.RequireAllAssertions(t,
-			assertDesignDocNotExists(t, bucket, DesignDocSyncGatewayPrefix),
-			assertDesignDocNotExists(t, bucket, DesignDocSyncHousekeepingPrefix),
-			assertDesignDocExists(t, bucket, "sync_gateway_user_ddoc"),
+			assertDesignDocNotExists(t, ctx, bucket, DesignDocSyncGatewayPrefix),
+			assertDesignDocNotExists(t, ctx, bucket, DesignDocSyncHousekeepingPrefix),
+			assertDesignDocExists(t, ctx, bucket, "sync_gateway_user_ddoc"),
 		)
 	})
 }
@@ -87,29 +88,29 @@ func TestRemoveObsoleteDesignDocs(t *testing.T) {
 func TestRemoveDesignDocsUseViewsTrueAndFalse(t *testing.T) {
 	setDesignDocPreviousVersionsForTest(t, "2.0")
 
-	base.ForAllDataStores(t, func(t *testing.T, bucket base.Bucket) {
+	base.ForAllDataStores(t, func(t *testing.T, ctx context.Context, bucket base.Bucket) {
 
 		mapFunction := `function (doc, meta){ emit(); }`
 
-		err := bucket.PutDDoc(DesignDocSyncGatewayPrefix+"_2.0", &sgbucket.DesignDoc{
+		err := bucket.PutDDoc(ctx, DesignDocSyncGatewayPrefix+"_2.0", &sgbucket.DesignDoc{
 			Views: sgbucket.ViewMap{
 				"channels": sgbucket.ViewDef{Map: mapFunction},
 			},
 		})
 		require.NoError(t, err)
-		err = bucket.PutDDoc(DesignDocSyncHousekeepingPrefix+"_2.0", &sgbucket.DesignDoc{
+		err = bucket.PutDDoc(ctx, DesignDocSyncHousekeepingPrefix+"_2.0", &sgbucket.DesignDoc{
 			Views: sgbucket.ViewMap{
 				"channels": sgbucket.ViewDef{Map: mapFunction},
 			},
 		})
 		require.NoError(t, err)
-		err = bucket.PutDDoc(DesignDocSyncGatewayPrefix+"_2.1", &sgbucket.DesignDoc{
+		err = bucket.PutDDoc(ctx, DesignDocSyncGatewayPrefix+"_2.1", &sgbucket.DesignDoc{
 			Views: sgbucket.ViewMap{
 				"channels": sgbucket.ViewDef{Map: mapFunction},
 			},
 		})
 		require.NoError(t, err)
-		err = bucket.PutDDoc(DesignDocSyncHousekeepingPrefix+"_2.1", &sgbucket.DesignDoc{
+		err = bucket.PutDDoc(ctx, DesignDocSyncHousekeepingPrefix+"_2.1", &sgbucket.DesignDoc{
 			Views: sgbucket.ViewMap{
 				"channels": sgbucket.ViewDef{Map: mapFunction},
 			},
@@ -118,26 +119,26 @@ func TestRemoveDesignDocsUseViewsTrueAndFalse(t *testing.T) {
 
 		// Verify creation was successful
 		base.RequireAllAssertions(t,
-			assertDesignDocExists(t, bucket, DesignDocSyncGatewayPrefix+"_2.0"),
-			assertDesignDocExists(t, bucket, DesignDocSyncHousekeepingPrefix+"_2.0"),
-			assertDesignDocExists(t, bucket, DesignDocSyncGatewayPrefix+"_2.1"),
-			assertDesignDocExists(t, bucket, DesignDocSyncHousekeepingPrefix+"_2.1"),
+			assertDesignDocExists(t, ctx, bucket, DesignDocSyncGatewayPrefix+"_2.0"),
+			assertDesignDocExists(t, ctx, bucket, DesignDocSyncHousekeepingPrefix+"_2.0"),
+			assertDesignDocExists(t, ctx, bucket, DesignDocSyncGatewayPrefix+"_2.1"),
+			assertDesignDocExists(t, ctx, bucket, DesignDocSyncHousekeepingPrefix+"_2.1"),
 		)
 
 		useViewsTrueRemovalPreview := []string{"sync_gateway_2.0", "sync_housekeeping_2.0"}
-		removedDDocsPreview, _ := removeObsoleteDesignDocs(bucket, true, true)
+		removedDDocsPreview, _ := removeObsoleteDesignDocs(ctx, bucket, true, true)
 		assert.Equal(t, useViewsTrueRemovalPreview, removedDDocsPreview)
 
 		useViewsFalseRemovalPreview := []string{"sync_gateway_2.0", "sync_housekeeping_2.0", "sync_gateway_2.1", "sync_housekeeping_2.1"}
-		removedDDocsPreview, _ = removeObsoleteDesignDocs(bucket, true, false)
+		removedDDocsPreview, _ = removeObsoleteDesignDocs(ctx, bucket, true, false)
 		assert.Equal(t, useViewsFalseRemovalPreview, removedDDocsPreview)
 
 		useViewsTrueRemoval := []string{"sync_gateway_2.0", "sync_housekeeping_2.0"}
-		removedDDocs, _ := removeObsoleteDesignDocs(bucket, false, true)
+		removedDDocs, _ := removeObsoleteDesignDocs(ctx, bucket, false, true)
 		require.Equal(t, useViewsTrueRemoval, removedDDocs)
 
 		useViewsTrueRemoval = []string{"sync_gateway_2.1", "sync_housekeeping_2.1"}
-		removedDDocs, _ = removeObsoleteDesignDocs(bucket, false, false)
+		removedDDocs, _ = removeObsoleteDesignDocs(ctx, bucket, false, false)
 		require.Equal(t, useViewsTrueRemoval, removedDDocs)
 	})
 }
@@ -146,18 +147,19 @@ func TestRemoveDesignDocsUseViewsTrueAndFalse(t *testing.T) {
 func TestRemoveObsoleteDesignDocsErrors(t *testing.T) {
 	setDesignDocPreviousVersionsForTest(t, "test")
 
-	bucket := base.NewLeakyBucket(base.GetTestBucket(t), base.LeakyBucketConfig{})
-	defer bucket.Close()
+	ctx, tbucket := base.GetTestBucket(t)
+	bucket := base.NewLeakyBucket(tbucket, base.LeakyBucketConfig{})
+	defer bucket.Close(ctx)
 
 	mapFunction := `function (doc, meta){ emit(); }`
 
-	err := bucket.PutDDoc(DesignDocSyncGatewayPrefix+"_test", &sgbucket.DesignDoc{
+	err := bucket.PutDDoc(ctx, DesignDocSyncGatewayPrefix+"_test", &sgbucket.DesignDoc{
 		Views: sgbucket.ViewMap{
 			"channels": sgbucket.ViewDef{Map: mapFunction},
 		},
 	})
 	require.NoError(t, err)
-	err = bucket.PutDDoc(DesignDocSyncHousekeepingPrefix+"_test", &sgbucket.DesignDoc{
+	err = bucket.PutDDoc(ctx, DesignDocSyncHousekeepingPrefix+"_test", &sgbucket.DesignDoc{
 		Views: sgbucket.ViewMap{
 			"channels": sgbucket.ViewDef{Map: mapFunction},
 		},
@@ -166,8 +168,8 @@ func TestRemoveObsoleteDesignDocsErrors(t *testing.T) {
 
 	// Verify creation was successful
 	base.RequireAllAssertions(t,
-		assertDesignDocExists(t, bucket, DesignDocSyncGatewayPrefix+"_test"),
-		assertDesignDocExists(t, bucket, DesignDocSyncHousekeepingPrefix+"_test"),
+		assertDesignDocExists(t, ctx, bucket, DesignDocSyncGatewayPrefix+"_test"),
+		assertDesignDocExists(t, ctx, bucket, DesignDocSyncHousekeepingPrefix+"_test"),
 	)
 
 	lb, ok := base.AsLeakyBucket(bucket)
@@ -175,9 +177,9 @@ func TestRemoveObsoleteDesignDocsErrors(t *testing.T) {
 	lb.SetDDocGetErrorCount(1)
 	lb.SetDDocDeleteErrorCount(1)
 
-	removedDDocsPreview, err := removeObsoleteDesignDocs(bucket, true, false)
+	removedDDocsPreview, err := removeObsoleteDesignDocs(ctx, bucket, true, false)
 	assert.NoError(t, err)
-	removedDDocsNonPreview, err := removeObsoleteDesignDocs(bucket, false, false)
+	removedDDocsNonPreview, err := removeObsoleteDesignDocs(ctx, bucket, false, false)
 	require.NoError(t, err)
 
 	assert.Equalf(t, removedDDocsPreview, removedDDocsNonPreview, "preview and non-preview should return the same design docs")

--- a/db/design_doc_test.go
+++ b/db/design_doc_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestRemoveObsoleteDesignDocs(t *testing.T) {
 
-	base.ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	base.ForAllDataStores(t, func(t *testing.T, bucket base.Bucket) {
 		mapFunction := `function (doc, meta) { emit(); }`
 
 		// Add some design docs in the old format
@@ -87,7 +87,7 @@ func TestRemoveObsoleteDesignDocs(t *testing.T) {
 func TestRemoveDesignDocsUseViewsTrueAndFalse(t *testing.T) {
 	setDesignDocPreviousVersionsForTest(t, "2.0")
 
-	base.ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+	base.ForAllDataStores(t, func(t *testing.T, bucket base.Bucket) {
 
 		mapFunction := `function (doc, meta){ emit(); }`
 

--- a/db/design_doc_util_test.go
+++ b/db/design_doc_util_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -17,14 +18,14 @@ func setDesignDocPreviousVersionsForTest(t testing.TB, versions ...string) {
 }
 
 // assertDesignDocExists ensures that the design doc exists in the bucket.
-func assertDesignDocExists(t testing.TB, bucket base.Bucket, ddocName string) bool {
-	_, err := bucket.GetDDoc(ddocName)
+func assertDesignDocExists(t testing.TB, ctx context.Context, bucket base.Bucket, ddocName string) bool {
+	_, err := bucket.GetDDoc(ctx, ddocName)
 	return assert.NoErrorf(t, err, "Design doc %s should exist but got an error fetching it: %v", ddocName, err)
 }
 
 // assertDesignDocDoesNotExist ensures that the design doc does not exist in the bucket.
-func assertDesignDocNotExists(t testing.TB, bucket base.Bucket, ddocName string) bool {
-	ddoc, err := bucket.GetDDoc(ddocName)
+func assertDesignDocNotExists(t testing.TB, ctx context.Context, bucket base.Bucket, ddocName string) bool {
+	ddoc, err := bucket.GetDDoc(ctx, ddocName)
 	if err == nil {
 		return assert.Failf(t, "Design doc %s should not exist but but it did: %v", ddocName, ddoc)
 	}

--- a/db/document.go
+++ b/db/document.go
@@ -982,7 +982,7 @@ func (doc *Document) updateChannels(ctx context.Context, newChannels base.Set) (
 // Determine whether the specified revision was a channel removal, based on doc.Channels.  If so, construct the standard document body for a
 // removal notification (_removed=true)
 // Set of channels returned from IsChannelRemoval are "Active" channels and NOT "Removed".
-func (doc *Document) IsChannelRemoval(revID string) (bodyBytes []byte, history Revisions, channels base.Set, isRemoval bool, isDelete bool, err error) {
+func (doc *Document) IsChannelRemoval(ctx context.Context, revID string) (bodyBytes []byte, history Revisions, channels base.Set, isRemoval bool, isDelete bool, err error) {
 
 	removedChannels := make(base.Set)
 
@@ -1022,7 +1022,7 @@ func (doc *Document) IsChannelRemoval(revID string) (bodyBytes []byte, history R
 	if len(revHistory) == 0 {
 		revHistory = []string{revID}
 	}
-	history = encodeRevisions(doc.ID, revHistory)
+	history = encodeRevisions(ctx, doc.ID, revHistory)
 
 	return bodyBytes, history, activeChannels, true, isDelete, nil
 }

--- a/db/event.go
+++ b/db/event.go
@@ -165,7 +165,7 @@ func NewJSEventFunction(fnSource string) *JSEventFunction {
 }
 
 // Calls a jsEventFunction returning an interface{}
-func (ef *JSEventFunction) CallFunction(event Event) (interface{}, error) {
+func (ef *JSEventFunction) CallFunction(ctx context.Context, event Event) (interface{}, error) {
 
 	var err error
 	var result interface{}
@@ -178,12 +178,12 @@ func (ef *JSEventFunction) CallFunction(event Event) (interface{}, error) {
 	case *DBStateChangeEvent:
 		result, err = ef.Call(event.Doc)
 	default:
-		base.WarnfCtx(context.TODO(), "unknown event %v tried to call function", event.EventType())
+		base.WarnfCtx(ctx, "unknown event %v tried to call function", event.EventType())
 		return "", fmt.Errorf("unknown event %v tried to call function", event.EventType())
 	}
 
 	if err != nil {
-		base.WarnfCtx(context.TODO(), "Error calling function - function processing aborted: %v", err)
+		base.WarnfCtx(ctx, "Error calling function - function processing aborted: %v", err)
 		return "", err
 	}
 
@@ -191,9 +191,9 @@ func (ef *JSEventFunction) CallFunction(event Event) (interface{}, error) {
 }
 
 // Calls a jsEventFunction returning bool.
-func (ef *JSEventFunction) CallValidateFunction(event Event) (bool, error) {
+func (ef *JSEventFunction) CallValidateFunction(ctx context.Context, event Event) (bool, error) {
 
-	result, err := ef.CallFunction(event)
+	result, err := ef.CallFunction(ctx, event)
 	if err != nil {
 		return false, err
 	}
@@ -208,7 +208,7 @@ func (ef *JSEventFunction) CallValidateFunction(event Event) (bool, error) {
 		}
 		return boolResult, nil
 	default:
-		base.WarnfCtx(context.TODO(), "Event validate function returned non-boolean result %T %v", result, result)
+		base.WarnfCtx(ctx, "Event validate function returned non-boolean result %T %v", result, result)
 		return false, errors.New("Validate function returned non-boolean value.")
 	}
 

--- a/db/event_handler.go
+++ b/db/event_handler.go
@@ -125,7 +125,7 @@ func (wh *Webhook) HandleEvent(ctx context.Context, event Event) bool {
 
 	if wh.filter != nil {
 		// If filter function is defined, use it to determine whether to post
-		success, err := wh.filter.CallValidateFunction(event)
+		success, err := wh.filter.CallValidateFunction(ctx, event)
 		if err != nil {
 			base.WarnfCtx(ctx, "Error calling webhook filter function: %v", err)
 		}

--- a/db/event_handler_test.go
+++ b/db/event_handler_test.go
@@ -46,6 +46,8 @@ func TestSanitizedUrl(t *testing.T) {
 }
 
 func TestCallValidateFunction(t *testing.T) {
+	ctx := base.TestCtx(t)
+
 	// Boolean return type handling of CallValidateFunction; Mock up a document change event and
 	// filter function which returns a bool value while calling CallValidateFunction.
 	channels := base.SetFromArray([]string{"Netflix"})
@@ -56,28 +58,28 @@ func TestCallValidateFunction(t *testing.T) {
 	// Boolean return type handling of CallValidateFunction; bool true value.
 	source := `function(doc) { if (doc.key1 == "value1") { return true; } else { return false; } }`
 	filterFunc := NewJSEventFunction(source)
-	result, err := filterFunc.CallValidateFunction(event)
+	result, err := filterFunc.CallValidateFunction(ctx, event)
 	assert.True(t, result, "It should return true since doc.key1 is value1")
 	assert.NoError(t, err, "It should return boolean result")
 
 	// Boolean return type handling of CallValidateFunction; bool false value.
 	source = `function(doc) { if (doc.key1 == "value2") { return true; } else { return false; } }`
 	filterFunc = NewJSEventFunction(source)
-	result, err = filterFunc.CallValidateFunction(event)
+	result, err = filterFunc.CallValidateFunction(ctx, event)
 	assert.False(t, result, "It should return false since doc.key1 is not value2")
 	assert.NoError(t, err, "It should return boolean result")
 
 	// Parsable boolean string return type handling of CallValidateFunction.
 	source = `function(doc) { if (doc.key1 == "value1") { return "true"; } else { return "false"; } }`
 	filterFunc = NewJSEventFunction(source)
-	result, err = filterFunc.CallValidateFunction(event)
+	result, err = filterFunc.CallValidateFunction(ctx, event)
 	assert.True(t, result, "It should return true since doc.key1 is value1")
 	assert.NoError(t, err, "It should return parsable boolean result")
 
 	// Non parsable boolean string return type handling of CallValidateFunction.
 	source = `function(doc) { if (doc.key1 == "value1") { return "TrUe"; } else { return "false"; } }`
 	filterFunc = NewJSEventFunction(source)
-	result, err = filterFunc.CallValidateFunction(event)
+	result, err = filterFunc.CallValidateFunction(ctx, event)
 	assert.False(t, result, "It should return false since 'TrUe' is non parsable boolean string")
 	assert.Error(t, err, "It should return parsable throw ParseBool error")
 	assert.Contains(t, err.Error(), `invalid syntax`)
@@ -85,7 +87,7 @@ func TestCallValidateFunction(t *testing.T) {
 	// Not boolean and not parsable boolean string return type handling of CallValidateFunction.
 	source = `function(doc) { if (doc.key1 == "Pi") { return 3.14; } else { return 0.0; } }`
 	filterFunc = NewJSEventFunction(source)
-	result, err = filterFunc.CallValidateFunction(event)
+	result, err = filterFunc.CallValidateFunction(ctx, event)
 	assert.False(t, result, "It should return not boolean and not parsable boolean string value")
 	assert.Error(t, err, "It should throw Validate function returned non-boolean value error")
 	assert.Contains(t, err.Error(), "Validate function returned non-boolean value.")
@@ -93,7 +95,7 @@ func TestCallValidateFunction(t *testing.T) {
 	// Simulate CallFunction failure by making syntax error in filter function.
 	source = `function(doc) { invalidKeyword if (doc.key1 == "value1") { return true; } else { return false; } }`
 	filterFunc = NewJSEventFunction(source)
-	result, err = filterFunc.CallValidateFunction(event)
+	result, err = filterFunc.CallValidateFunction(ctx, event)
 	assert.False(t, result, "It should return false due to the syntax error in filter function")
 	assert.Error(t, err, "It should throw an error due to syntax error")
 	assert.Contains(t, err.Error(), "Unexpected token")

--- a/db/event_manager.go
+++ b/db/event_manager.go
@@ -64,7 +64,7 @@ func NewEventManager(terminator chan bool) *EventManager {
 }
 
 // Starts the listener queue for the event manager
-func (em *EventManager) Start(maxProcesses uint, waitTime int) {
+func (em *EventManager) Start(ctx context.Context, maxProcesses uint, waitTime int) {
 
 	if maxProcesses == 0 {
 		maxProcesses = kMaxActiveEvents
@@ -75,7 +75,7 @@ func (em *EventManager) Start(maxProcesses uint, waitTime int) {
 		em.waitTime = waitTime
 	}
 
-	base.InfofCtx(context.TODO(), base.KeyEvents, "Starting event manager with max processes:%d, wait time:%d ms", maxProcesses, em.waitTime)
+	base.InfofCtx(ctx, base.KeyEvents, "Starting event manager with max processes:%d, wait time:%d ms", maxProcesses, em.waitTime)
 	// activeCountChannel limits the number of concurrent events being processed
 	em.activeCountChannel = make(chan bool, maxProcesses)
 
@@ -93,7 +93,7 @@ func (em *EventManager) Start(maxProcesses uint, waitTime int) {
 				return
 			case event := <-em.asyncEventChannel:
 				em.activeCountChannel <- true
-				go em.ProcessEvent(event)
+				go em.ProcessEvent(ctx, event)
 			}
 		}
 	}()
@@ -101,25 +101,24 @@ func (em *EventManager) Start(maxProcesses uint, waitTime int) {
 }
 
 // Concurrent processing of all async event handlers registered for the event type
-func (em *EventManager) ProcessEvent(event Event) {
+func (em *EventManager) ProcessEvent(ctx context.Context, event Event) {
 	defer func() { <-em.activeCountChannel }()
-	logCtx := context.TODO()
 	// Send event to all registered handlers concurrently.  WaitGroup blocks
 	// until all are finished
 	var wg sync.WaitGroup
 	for _, handler := range em.eventHandlers[event.EventType()] {
-		base.DebugfCtx(logCtx, base.KeyEvents, "Event queue worker sending event %s to: %s", base.UD(event.String()), handler)
+		base.DebugfCtx(ctx, base.KeyEvents, "Event queue worker sending event %s to: %s", base.UD(event.String()), handler)
 		wg.Add(1)
 		go func(event Event, handler EventHandler) {
 			defer wg.Done()
 			//TODO: Currently we're not tracking success/fail from event handlers.  When this
 			// is needed, could pass a channel to HandleEvent for tracking results
-			if handler.HandleEvent(event) {
+			if handler.HandleEvent(ctx, event) {
 				em.IncrementEventsProcessedSuccess(1)
 			} else {
 				em.IncrementEventsProcessedFail(1)
 			}
-			base.TracefCtx(logCtx, base.KeyAll, "Webhook event processed %s", event)
+			base.TracefCtx(ctx, base.KeyAll, "Webhook event processed %s", event)
 
 		}(event, handler)
 	}
@@ -140,7 +139,7 @@ func (em *EventManager) HasHandlerForEvent(eventType EventType) bool {
 }
 
 // Adds async events to the channel for processing
-func (em *EventManager) raiseEvent(event Event) error {
+func (em *EventManager) raiseEvent(ctx context.Context, event Event) error {
 	if !event.Synchronous() {
 		// When asyncEventChannel is full, the raiseEvent method will block for (waitTime).
 		// Default value of (waitTime) is 5 ms.
@@ -148,10 +147,10 @@ func (em *EventManager) raiseEvent(event Event) error {
 		defer timer.Stop()
 		select {
 		case em.asyncEventChannel <- event:
-			base.TracefCtx(context.TODO(), base.KeyAll, "Event sent to channel %s", event.String())
+			base.TracefCtx(ctx, base.KeyAll, "Event sent to channel %s", event.String())
 		case <-timer.C:
 			// Event queue channel is full - ignore event and log error
-			base.WarnfCtx(context.TODO(), "Event queue full - discarding event: %s", base.UD(event.String()))
+			base.WarnfCtx(ctx, "Event queue full - discarding event: %s", base.UD(event.String()))
 			return errors.New("Event queue full")
 		}
 	}
@@ -161,7 +160,7 @@ func (em *EventManager) raiseEvent(event Event) error {
 
 // Raises a document change event based on the the document body and channel set.  If the
 // event manager doesn't have a listener for this event, ignores.
-func (em *EventManager) RaiseDocumentChangeEvent(docBytes []byte, docID string, oldBodyJSON string, channels base.Set, winningRevChange bool) error {
+func (em *EventManager) RaiseDocumentChangeEvent(ctx context.Context, docBytes []byte, docID string, oldBodyJSON string, channels base.Set, winningRevChange bool) error {
 
 	if !em.activeEventTypes[DocumentChange] {
 		return nil
@@ -174,13 +173,13 @@ func (em *EventManager) RaiseDocumentChangeEvent(docBytes []byte, docID string, 
 		WinningRevChange: winningRevChange,
 	}
 
-	return em.raiseEvent(event)
+	return em.raiseEvent(ctx, event)
 
 }
 
 // Raises a DB state change event based on the db name, admininterface, new state, reason and local system time.
 // If the event manager doesn't have a listener for this event, ignores.
-func (em *EventManager) RaiseDBStateChangeEvent(dbName string, state string, reason string, adminInterface *string) error {
+func (em *EventManager) RaiseDBStateChangeEvent(ctx context.Context, dbName string, state string, reason string, adminInterface *string) error {
 
 	if !em.activeEventTypes[DBStateChange] {
 		return nil
@@ -202,5 +201,5 @@ func (em *EventManager) RaiseDBStateChangeEvent(dbName string, state string, rea
 		Doc: body,
 	}
 
-	return em.raiseEvent(event)
+	return em.raiseEvent(ctx, event)
 }

--- a/db/import.go
+++ b/db/import.go
@@ -131,7 +131,7 @@ func (db *Database) importDoc(ctx context.Context, docid string, body Body, expi
 		// Get the doc expiry if it wasn't passed in and preserve expiry is not supported
 		if expiry == nil {
 			cbStore, _ := base.AsCouchbaseStore(db.Bucket)
-			getExpiry, getExpiryErr := cbStore.GetExpiry(ctx, docid)
+			getExpiry, getExpiryErr := cbStore.GetExpiry(docid)
 			if getExpiryErr != nil {
 				return nil, getExpiryErr
 			}
@@ -163,7 +163,7 @@ func (db *Database) importDoc(ctx context.Context, docid string, body Body, expi
 				if !mutationOptions.PreserveExpiry {
 					// Reload the doc expiry if GoCB is not preserving expiry
 					cbStore, _ := base.AsCouchbaseStore(db.Bucket)
-					expiry, getExpiryErr := cbStore.GetExpiry(ctx, newDoc.ID)
+					expiry, getExpiryErr := cbStore.GetExpiry(newDoc.ID)
 					if getExpiryErr != nil {
 						return nil, nil, false, nil, getExpiryErr
 					}

--- a/db/import.go
+++ b/db/import.go
@@ -372,7 +372,7 @@ func (db *Database) migrateMetadata(ctx context.Context, docid string, body Body
 	}
 
 	// Move any large revision bodies to external storage
-	err = doc.migrateRevisionBodies(db.Bucket)
+	err = doc.migrateRevisionBodies(ctx, db.Bucket)
 	if err != nil {
 		base.InfofCtx(ctx, base.KeyMigrate, "Error migrating revision bodies to external storage, doc %q, (cas=%d), Error: %v", base.UD(docid), doc.Cas, err)
 	}

--- a/db/import.go
+++ b/db/import.go
@@ -131,7 +131,7 @@ func (db *Database) importDoc(ctx context.Context, docid string, body Body, expi
 		// Get the doc expiry if it wasn't passed in and preserve expiry is not supported
 		if expiry == nil {
 			cbStore, _ := base.AsCouchbaseStore(db.Bucket)
-			getExpiry, getExpiryErr := cbStore.GetExpiry(docid)
+			getExpiry, getExpiryErr := cbStore.GetExpiry(ctx, docid)
 			if getExpiryErr != nil {
 				return nil, getExpiryErr
 			}
@@ -163,7 +163,7 @@ func (db *Database) importDoc(ctx context.Context, docid string, body Body, expi
 				if !mutationOptions.PreserveExpiry {
 					// Reload the doc expiry if GoCB is not preserving expiry
 					cbStore, _ := base.AsCouchbaseStore(db.Bucket)
-					expiry, getExpiryErr := cbStore.GetExpiry(newDoc.ID)
+					expiry, getExpiryErr := cbStore.GetExpiry(ctx, newDoc.ID)
 					if getExpiryErr != nil {
 						return nil, nil, false, nil, getExpiryErr
 					}

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -118,7 +118,7 @@ func (il *importListener) StartImportFeed(ctx context.Context, bucket base.Bucke
 		if err != nil {
 			return err
 		}
-		return base.StartGocbDCPFeed(collection, bucket.GetName(), feedArgs, il.ProcessFeedEvent, importFeedStatsMap.Map, base.DCPMetadataStoreCS, groupID)
+		return base.StartGocbDCPFeed(ctx, collection, bucket.GetName(), feedArgs, il.ProcessFeedEvent, importFeedStatsMap.Map, base.DCPMetadataStoreCS, groupID)
 	}
 	il.cbgtContext, err = base.StartShardedDCPFeed(ctx, dbContext.Name, dbContext.Options.GroupID, dbContext.UUID, dbContext.Heartbeater,
 		bucket, cbStore.GetSpec(), scopeName, collectionNamesByScope[scopeName], dbContext.Options.ImportOptions.ImportPartitions, dbContext.CfgSG)

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -110,7 +110,7 @@ func (il *importListener) StartImportFeed(ctx context.Context, bucket base.Bucke
 	cbStore, ok := base.AsCouchbaseStore(bucket)
 	if !ok {
 		// walrus is not a couchbasestore
-		return bucket.StartDCPFeed(feedArgs, il.ProcessFeedEvent, importFeedStatsMap.Map)
+		return bucket.StartDCPFeed(ctx, feedArgs, il.ProcessFeedEvent, importFeedStatsMap.Map)
 	}
 	if !base.IsEnterpriseEdition() {
 		groupID := ""

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -67,11 +67,12 @@ func getListenerImportDest(indexParams string) (cbgt.Dest, error) {
 // NewImportPIndexImpl is called when the node is first added to the cbgt cfg.  On a node restart,
 // OpenImportPindexImplUsing is called.
 func NewImportPIndexImpl(indexType, indexParams, path string, restart func()) (cbgt.PIndexImpl, cbgt.Dest, error) {
-	defer base.FatalPanicHandler()
+	logCtx := context.TODO()
+	defer base.FatalPanicHandler(logCtx)
 
 	importDest, err := getListenerImportDest(indexParams)
 	if err != nil {
-		base.ErrorfCtx(context.TODO(), "Error creating NewImportDest during NewImportPIndexImpl: %v", err)
+		base.ErrorfCtx(logCtx, "Error creating NewImportDest during NewImportPIndexImpl: %v", err)
 	}
 	return nil, importDest, err
 }

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -185,7 +185,7 @@ func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 
 			// Verify the expiry has been preserved after the import
 			cbStore, _ := base.AsCouchbaseStore(db.Bucket)
-			expiry, err = cbStore.GetExpiry(ctx, key)
+			expiry, err = cbStore.GetExpiry(key)
 			require.NoError(t, err, "Error calling GetExpiry()")
 			updatedExpiryDuration := base.CbsExpiryToDuration(expiry)
 			assert.True(t, updatedExpiryDuration > expiryDuration)

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -185,7 +185,7 @@ func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 
 			// Verify the expiry has been preserved after the import
 			cbStore, _ := base.AsCouchbaseStore(db.Bucket)
-			expiry, err = cbStore.GetExpiry(key)
+			expiry, err = cbStore.GetExpiry(ctx, key)
 			require.NoError(t, err, "Error calling GetExpiry()")
 			updatedExpiryDuration := base.CbsExpiryToDuration(expiry)
 			assert.True(t, updatedExpiryDuration > expiryDuration)

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -224,7 +224,7 @@ func (i *SGIndex) createIfNeeded(ctx context.Context, bucket base.N1QLStore, use
 			//  2. SG previously crashed between index creation and index build.
 			// GSI doesn't like concurrent build requests, so wait and recheck index state before treating as option 2.
 			// (see known issue documented https://developer.couchbase.com/documentation/server/current/n1ql/n1ql-language-reference/build-index.html)
-			base.InfofCtx(context.TODO(), base.KeyQuery, "Index %s already in deferred state - waiting 10s to re-evaluate before issuing build to avoid concurrent build requests.", indexName)
+			base.InfofCtx(ctx, base.KeyQuery, "Index %s already in deferred state - waiting 10s to re-evaluate before issuing build to avoid concurrent build requests.", indexName)
 			time.Sleep(10 * time.Second)
 			exists, indexMeta, metaErr = bucket.GetIndexMeta(ctx, indexName)
 			if metaErr != nil || indexMeta == nil {

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -219,9 +219,9 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 	n1QLStore, ok := base.AsN1QLStore(db.Bucket)
 	assert.True(t, ok)
 
-	_, err := removeObsoleteDesignDocs(db.Bucket, !db.UseXattrs(), db.UseViews())
+	_, err := removeObsoleteDesignDocs(ctx, db.Bucket, !db.UseXattrs(), db.UseViews())
 	assert.NoError(t, err)
-	_, err = removeObsoleteDesignDocs(db.Bucket, !db.UseXattrs(), !db.UseViews())
+	_, err = removeObsoleteDesignDocs(ctx, db.Bucket, !db.UseXattrs(), !db.UseViews())
 	assert.NoError(t, err)
 
 	expectedIndexes := int(indexTypeCount)
@@ -239,17 +239,17 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 	assert.NoError(t, removeErr)
 
 	// Cleanup design docs created during test
-	_, err = removeObsoleteDesignDocs(db.Bucket, db.UseXattrs(), db.UseViews())
+	_, err = removeObsoleteDesignDocs(ctx, db.Bucket, db.UseXattrs(), db.UseViews())
 	assert.NoError(t, err)
-	_, err = removeObsoleteDesignDocs(db.Bucket, db.UseXattrs(), !db.UseViews())
+	_, err = removeObsoleteDesignDocs(ctx, db.Bucket, db.UseXattrs(), !db.UseViews())
 	assert.NoError(t, err)
-	_, err = removeObsoleteDesignDocs(db.Bucket, !db.UseXattrs(), db.UseViews())
+	_, err = removeObsoleteDesignDocs(ctx, db.Bucket, !db.UseXattrs(), db.UseViews())
 	assert.NoError(t, err)
-	_, err = removeObsoleteDesignDocs(db.Bucket, !db.UseXattrs(), !db.UseViews())
+	_, err = removeObsoleteDesignDocs(ctx, db.Bucket, !db.UseXattrs(), !db.UseViews())
 	assert.NoError(t, err)
 
 	// Restore ddocs after test
-	err = InitializeViews(db.Bucket)
+	err = InitializeViews(ctx, db.Bucket)
 	assert.NoError(t, err)
 
 	// Restore indexes after test

--- a/db/query.go
+++ b/db/query.go
@@ -305,7 +305,7 @@ func (context *DatabaseContext) N1QLQueryWithStats(ctx context.Context, queryNam
 
 	queryStat := context.DbStats.Query(queryName)
 
-	results, err = n1QLStore.Query(statement, params, consistency, adhoc)
+	results, err = n1QLStore.Query(ctx, statement, params, consistency, adhoc)
 	if err != nil {
 		queryStat.QueryErrorCount.Add(1)
 	}

--- a/db/query.go
+++ b/db/query.go
@@ -326,7 +326,7 @@ func (context *DatabaseContext) ViewQueryWithStats(ctx context.Context, ddoc str
 
 	queryStat := context.DbStats.Query(fmt.Sprintf(base.StatViewFormat, ddoc, viewName))
 
-	results, err = context.Bucket.ViewQuery(ddoc, viewName, params)
+	results, err = context.Bucket.ViewQuery(ctx, ddoc, viewName, params)
 	if err != nil {
 		queryStat.QueryErrorCount.Add(1)
 	}

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -330,7 +330,7 @@ func TestCoveringQueries(t *testing.T) {
 
 	// channels
 	channelsStatement, params := db.buildChannelsQuery("ABC", 0, 10, 100, false)
-	plan, explainErr := n1QLStore.ExplainQuery(channelsStatement, params)
+	plan, explainErr := n1QLStore.ExplainQuery(ctx, channelsStatement, params)
 	assert.NoError(t, explainErr, "Error generating explain for channels query")
 	covered := isCovered(plan)
 	planJSON, err := base.JSONMarshal(plan)
@@ -339,7 +339,7 @@ func TestCoveringQueries(t *testing.T) {
 
 	// star channel
 	channelStarStatement, params := db.buildChannelsQuery("*", 0, 10, 100, false)
-	plan, explainErr = n1QLStore.ExplainQuery(channelStarStatement, params)
+	plan, explainErr = n1QLStore.ExplainQuery(ctx, channelStarStatement, params)
 	assert.NoError(t, explainErr, "Error generating explain for star channel query")
 	covered = isCovered(plan)
 	planJSON, err = base.JSONMarshal(plan)
@@ -350,7 +350,7 @@ func TestCoveringQueries(t *testing.T) {
 	// in the SELECT.
 	// Including here for ease-of-conversion when we get an indexing enhancement to support covered queries.
 	accessStatement := db.buildAccessQuery("user1")
-	plan, explainErr = n1QLStore.ExplainQuery(accessStatement, nil)
+	plan, explainErr = n1QLStore.ExplainQuery(ctx, accessStatement, nil)
 	assert.NoError(t, explainErr, "Error generating explain for access query")
 	covered = isCovered(plan)
 	planJSON, err = base.JSONMarshal(plan)
@@ -359,7 +359,7 @@ func TestCoveringQueries(t *testing.T) {
 
 	// roleAccess
 	roleAccessStatement := db.buildRoleAccessQuery("user1")
-	plan, explainErr = n1QLStore.ExplainQuery(roleAccessStatement, nil)
+	plan, explainErr = n1QLStore.ExplainQuery(ctx, roleAccessStatement, nil)
 	assert.NoError(t, explainErr, "Error generating explain for roleAccess query")
 	covered = isCovered(plan)
 	planJSON, err = base.JSONMarshal(plan)

--- a/db/repair_bucket.go
+++ b/db/repair_bucket.go
@@ -134,7 +134,7 @@ func (r *RepairBucket) InitFrom(params RepairBucketParams) *RepairBucket {
 // Since the start key is inclusive, it will see the start key twice (on first page, and on next page)
 // If it's iterating a result page and sees a doc with the start key (eg, doc3 in above), it will ignore it so it doesn't process it twice
 // Stop condition: if NumProcessed is 0, because the only doc in result set had already been processed.
-func (r RepairBucket) RepairBucket() (results []RepairBucketResult, err error) {
+func (r RepairBucket) RepairBucket(ctx context.Context) (results []RepairBucketResult, err error) {
 
 	logCtx := context.TODO()
 	base.InfofCtx(logCtx, base.KeyCRUD, "RepairBucket() invoked")
@@ -154,7 +154,7 @@ func (r RepairBucket) RepairBucket() (results []RepairBucketResult, err error) {
 		options["limit"] = r.ViewQueryPageSize
 
 		base.InfofCtx(logCtx, base.KeyCRUD, "RepairBucket() querying view with options: %+v", options)
-		vres, err := r.Bucket.View(DesignDocSyncHousekeeping(), ViewImport, options)
+		vres, err := r.Bucket.View(ctx, DesignDocSyncHousekeeping(), ViewImport, options)
 		base.InfofCtx(logCtx, base.KeyCRUD, "RepairBucket() queried view and got %d results", len(vres.Rows))
 		if err != nil {
 			// TODO: Maybe we could retry if the view timed out (as seen in #3267)

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -73,7 +73,7 @@ func TestRepairBucket(t *testing.T) {
 	ctx, bucket, numDocs := testBucketWithViewsAndBrokenDoc(t)
 	defer bucket.Close(ctx)
 
-	repairJob := func(docId string, originalCBDoc []byte) (transformedCBDoc []byte, transformed bool, err error) {
+	repairJob := func(ctx context.Context, docId string, originalCBDoc []byte) (transformedCBDoc []byte, transformed bool, err error) {
 		return nil, true, nil
 	}
 	repairBucket := NewRepairBucket(bucket).
@@ -105,7 +105,7 @@ func TestRepairBucketRevTreeCycles(t *testing.T) {
 
 	repairBucket := NewRepairBucket(bucket)
 
-	repairBucket.InitFrom(RepairBucketParams{
+	repairBucket.InitFrom(ctx, RepairBucketParams{
 		DryRun: false,
 		RepairJobs: []RepairJobParams{
 			{
@@ -154,7 +154,7 @@ func TestRepairBucketDryRun(t *testing.T) {
 
 	repairBucket := NewRepairBucket(bucket)
 
-	repairBucket.InitFrom(RepairBucketParams{
+	repairBucket.InitFrom(ctx, RepairBucketParams{
 		DryRun: true,
 		RepairJobs: []RepairJobParams{
 			{

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -264,7 +264,7 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 	if bodyBytes, body, attachments, err = backingStore.getRevision(ctx, doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether
 		// the revision was a channel removal. If so, we want to store as removal in the revision cache
-		removalBodyBytes, removalHistory, activeChannels, isRemoval, isDelete, isRemovalErr := doc.IsChannelRemoval(revid)
+		removalBodyBytes, removalHistory, activeChannels, isRemoval, isDelete, isRemovalErr := doc.IsChannelRemoval(ctx, revid)
 		if isRemovalErr != nil {
 			return bodyBytes, body, history, channels, isRemoval, nil, isDelete, nil, isRemovalErr
 		}
@@ -283,7 +283,7 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 	if getHistoryErr != nil {
 		return bodyBytes, body, history, channels, removed, nil, deleted, nil, getHistoryErr
 	}
-	history = encodeRevisions(doc.ID, validatedHistory)
+	history = encodeRevisions(ctx, doc.ID, validatedHistory)
 	channels = doc.History[revid].Channels
 
 	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, err

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -787,7 +787,7 @@ func splitRevisionList(revisions Revisions) (int, []string) {
 // Standard CouchDB encoding of a revision list: digests without numeric generation prefixes go in
 // the "ids" property, and the first (largest) generation number in the "start" property.
 // The docID parameter is informational only - and used when logging edge cases.
-func encodeRevisions(docID string, revs []string) Revisions {
+func encodeRevisions(ctx context.Context, docID string, revs []string) Revisions {
 	ids := make([]string, len(revs))
 	var start int
 	for i, revid := range revs {
@@ -796,7 +796,7 @@ func encodeRevisions(docID string, revs []string) Revisions {
 		if i == 0 {
 			start = gen
 		} else if gen != start-i {
-			base.WarnfCtx(context.TODO(), "Found gap in revision list for doc %q. Expecting gen %v but got %v in %v", base.UD(docID), start-i, gen, revs)
+			base.WarnfCtx(ctx, "Found gap in revision list for doc %q. Expecting gen %v but got %v in %v", base.UD(docID), start-i, gen, revs)
 		}
 	}
 	return Revisions{RevisionsStart: start, RevisionsIds: ids}

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -755,34 +755,36 @@ func BenchmarkEncodeRevisions(b *testing.B) {
 		},
 	}
 
+	ctx := base.TestCtx(b)
 	for _, test := range tests {
 		docID := b.Name() + "-" + test.name
 		b.Run(test.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_ = encodeRevisions(docID, test.input)
+				_ = encodeRevisions(ctx, docID, test.input)
 			}
 		})
 	}
 }
 
 func TestEncodeRevisions(t *testing.T) {
-	encoded := encodeRevisions(t.Name(), []string{"5-huey", "4-dewey", "3-louie"})
+	encoded := encodeRevisions(base.TestCtx(t), t.Name(), []string{"5-huey", "4-dewey", "3-louie"})
 	assert.Equal(t, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie"}}, encoded)
 }
 
 func TestEncodeRevisionsGap(t *testing.T) {
-	encoded := encodeRevisions(t.Name(), []string{"5-huey", "3-louie"})
+	encoded := encodeRevisions(base.TestCtx(t), t.Name(), []string{"5-huey", "3-louie"})
 	assert.Equal(t, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "louie"}}, encoded)
 }
 
 func TestEncodeRevisionsZero(t *testing.T) {
-	encoded := encodeRevisions(t.Name(), []string{"1-foo", "0-bar"})
+	encoded := encodeRevisions(base.TestCtx(t), t.Name(), []string{"1-foo", "0-bar"})
 	assert.Equal(t, Revisions{RevisionsStart: 1, RevisionsIds: []string{"foo", ""}}, encoded)
 }
 
 func TestTrimEncodedRevisionsToAncestor(t *testing.T) {
 
-	encoded := encodeRevisions(t.Name(), []string{"5-huey", "4-dewey", "3-louie", "2-screwy"})
+	ctx := base.TestCtx(t)
+	encoded := encodeRevisions(ctx, t.Name(), []string{"5-huey", "4-dewey", "3-louie", "2-screwy"})
 
 	result, trimmedRevs := trimEncodedRevisionsToAncestor(encoded, []string{"3-walter", "17-gretchen", "1-fooey"}, 1000)
 	assert.True(t, result)
@@ -801,7 +803,7 @@ func TestTrimEncodedRevisionsToAncestor(t *testing.T) {
 	assert.Equal(t, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey"}}, trimmedRevs)
 
 	// Check maxLength with no ancestors:
-	encoded = encodeRevisions(t.Name(), []string{"5-huey", "4-dewey", "3-louie", "2-screwy"})
+	encoded = encodeRevisions(ctx, t.Name(), []string{"5-huey", "4-dewey", "3-louie", "2-screwy"})
 
 	result, trimmedRevs = trimEncodedRevisionsToAncestor(encoded, nil, 6)
 	assert.True(t, result)

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -54,7 +54,7 @@ type sequenceAllocator struct {
 	releaseSequenceWait     time.Duration       // Supports test customization
 }
 
-func newSequenceAllocator(bucket base.Bucket, dbStatsMap *base.DatabaseStats) (*sequenceAllocator, error) {
+func newSequenceAllocator(ctx context.Context, bucket base.Bucket, dbStatsMap *base.DatabaseStats) (*sequenceAllocator, error) {
 	if dbStatsMap == nil {
 		return nil, fmt.Errorf("dbStatsMap parameter must be non-nil")
 	}
@@ -70,7 +70,7 @@ func newSequenceAllocator(bucket base.Bucket, dbStatsMap *base.DatabaseStats) (*
 	// The reserveNotify channel manages communication between the releaseSequenceMonitor goroutine and _reserveSequenceRange invocations.
 	s.reserveNotify = make(chan struct{}, 1)
 	go func() {
-		defer base.FatalPanicHandler()
+		defer base.FatalPanicHandler(ctx)
 		s.releaseSequenceMonitor()
 	}()
 	_, err := s.lastSequence() // just reads latest sequence from bucket

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -22,8 +22,8 @@ import (
 
 func TestSequenceAllocator(t *testing.T) {
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 
 	sgw := base.NewSyncGatewayStats()
 	testStats := sgw.NewDBStats("", false, false, false).Database()
@@ -87,8 +87,8 @@ func TestSequenceAllocator(t *testing.T) {
 
 func TestReleaseSequencesOnStop(t *testing.T) {
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 
 	sgw := base.NewSyncGatewayStats()
 	testStats := sgw.NewDBStats("", false, false, false).Database()
@@ -161,8 +161,9 @@ func TestSequenceAllocatorDeadlock(t *testing.T) {
 		}
 	}
 
-	bucket := base.NewLeakyBucket(base.GetTestBucket(t), base.LeakyBucketConfig{IncrCallback: incrCallback})
-	defer bucket.Close()
+	ctx, tbucket := base.GetTestBucket(t)
+	bucket := base.NewLeakyBucket(tbucket, base.LeakyBucketConfig{IncrCallback: incrCallback})
+	defer bucket.Close(ctx)
 
 	sgw := base.NewSyncGatewayStats()
 	testStats := sgw.NewDBStats("", false, false, false).Database()
@@ -190,8 +191,8 @@ func TestSequenceAllocatorDeadlock(t *testing.T) {
 }
 
 func TestReleaseSequenceWait(t *testing.T) {
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
+	ctx, bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 
 	sgw := base.NewSyncGatewayStats()
 	testStats := sgw.NewDBStats("", false, false, false).Database()

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -97,7 +97,7 @@ func TestReleaseSequencesOnStop(t *testing.T) {
 	defer func() { MaxSequenceIncrFrequency = oldFrequency }()
 	MaxSequenceIncrFrequency = 1000 * time.Millisecond
 
-	a, err := newSequenceAllocator(bucket, testStats)
+	a, err := newSequenceAllocator(ctx, bucket, testStats)
 	// Reduce sequence wait for Stop testing
 	a.releaseSequenceWait = 10 * time.Millisecond
 	assert.NoError(t, err, "error creating allocator")
@@ -172,7 +172,7 @@ func TestSequenceAllocatorDeadlock(t *testing.T) {
 	defer func() { MaxSequenceIncrFrequency = oldFrequency }()
 	MaxSequenceIncrFrequency = 1000 * time.Millisecond
 
-	a, err = newSequenceAllocator(bucket, testStats)
+	a, err = newSequenceAllocator(ctx, bucket, testStats)
 	// Reduce sequence wait for Stop testing
 	a.releaseSequenceWait = 10 * time.Millisecond
 	assert.NoError(t, err, "error creating allocator")
@@ -197,7 +197,7 @@ func TestReleaseSequenceWait(t *testing.T) {
 	sgw := base.NewSyncGatewayStats()
 	testStats := sgw.NewDBStats("", false, false, false).Database()
 
-	a, err := newSequenceAllocator(bucket, testStats)
+	a, err := newSequenceAllocator(ctx, bucket, testStats)
 	require.NoError(t, err)
 	defer a.Stop()
 

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -803,7 +803,7 @@ func (m *sgReplicateManager) SubscribeCfgChanges(ctx context.Context) error {
 	}
 	m.closeWg.Add(1)
 	go func() {
-		defer base.FatalPanicHandler()
+		defer base.FatalPanicHandler(m.loggingCtx)
 		defer m.closeWg.Done()
 		for {
 			select {
@@ -1499,7 +1499,7 @@ func (l *ReplicationHeartbeatListener) subscribeNodeSetChanges() error {
 		return err
 	}
 	go func() {
-		defer base.FatalPanicHandler()
+		defer base.FatalPanicHandler(l.mgr.loggingCtx)
 		for {
 			select {
 			case <-cfgEvents:

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -1338,7 +1338,7 @@ func (m *sgReplicateManager) GetReplicationStatus(replicationID string, options 
 	} else {
 		// Attempt to retrieve persisted status
 		var loadErr error
-		status, loadErr = LoadReplicationStatus(m.dbContext, replicationID)
+		status, loadErr = LoadReplicationStatus(m.loggingCtx, m.dbContext, replicationID)
 		if loadErr != nil {
 			// Unable to load persisted status.  Create status stub based on config
 			var err error

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -1445,6 +1445,8 @@ type ReplicationHeartbeatListener struct {
 	lock       sync.RWMutex  // lock for nodeIDs access
 }
 
+var _ base.HeartbeatListener = &ReplicationHeartbeatListener{}
+
 func NewReplicationHeartbeatListener(mgr *sgReplicateManager) (*ReplicationHeartbeatListener, error) {
 
 	if mgr == nil {
@@ -1476,7 +1478,7 @@ func (l *ReplicationHeartbeatListener) Name() string {
 }
 
 // When we detect other nodes have stopped pushing heartbeats, use manager to remove from cfg
-func (l *ReplicationHeartbeatListener) StaleHeartbeatDetected(nodeUUID string) {
+func (l *ReplicationHeartbeatListener) StaleHeartbeatDetected(ctx context.Context, nodeUUID string) {
 
 	base.InfofCtx(l.mgr.loggingCtx, base.KeyCluster, "StaleHeartbeatDetected by sg-replicate listener for node: %v", nodeUUID)
 	err := l.mgr.RemoveNode(nodeUUID)

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -23,13 +23,12 @@ import (
 // Test node operations on SGReplicateManager
 func TestReplicateManagerReplications(t *testing.T) {
 
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	testCfg, err := base.NewCfgSG(testBucket, "")
 	require.NoError(t, err)
 
-	ctx := base.TestCtx(t)
 	manager, err := NewSGReplicateManager(ctx, &DatabaseContext{Name: "test"}, testCfg)
 	require.NoError(t, err)
 	defer manager.Stop()
@@ -87,13 +86,12 @@ func TestReplicateManagerReplications(t *testing.T) {
 // Test node operations on SGReplicateManager
 func TestReplicateManagerNodes(t *testing.T) {
 
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	testCfg, err := base.NewCfgSG(testBucket, "")
 	require.NoError(t, err)
 
-	ctx := base.TestCtx(t)
 	manager, err := NewSGReplicateManager(ctx, &DatabaseContext{Name: "test"}, testCfg)
 	require.NoError(t, err)
 	defer manager.Stop()
@@ -143,10 +141,9 @@ func TestReplicateManagerNodes(t *testing.T) {
 // Test concurrent node operations on SGReplicateManager
 func TestReplicateManagerConcurrentNodeOperations(t *testing.T) {
 
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
-	ctx := base.TestCtx(t)
 	testCfg, err := base.NewCfgSG(testBucket, "")
 	require.NoError(t, err)
 
@@ -188,10 +185,9 @@ func TestReplicateManagerConcurrentNodeOperations(t *testing.T) {
 // Test concurrent replication operations on SGReplicateManager
 func TestReplicateManagerConcurrentReplicationOperations(t *testing.T) {
 
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
-	ctx := base.TestCtx(t)
 	testCfg, err := base.NewCfgSG(testBucket, "")
 	require.NoError(t, err)
 
@@ -616,8 +612,8 @@ func TestIsCfgChanged(t *testing.T) {
 		},
 	}
 
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
+	ctx, testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
 
 	testCfg, err := base.NewCfgSG(testBucket, "")
 	require.NoError(t, err)
@@ -645,20 +641,19 @@ func TestIsCfgChanged(t *testing.T) {
 // Test replicators assigned nodes with different group IDs
 func TestReplicateGroupIDAssignedNodes(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
-	ctx := base.TestCtx(t)
+	ctx, tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
 
 	// Set up databases
-	dbDefault, err := NewDatabaseContext(ctx, "default", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: ""})
+	dbDefault, err := NewDatabaseContext(ctx, "default", tb.NoCloseClone(ctx), false, DatabaseContextOptions{GroupID: ""})
 	require.NoError(t, err)
 	defer dbDefault.Close(ctx)
 
-	dbGroupA, err := NewDatabaseContext(ctx, "groupa", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupA"})
+	dbGroupA, err := NewDatabaseContext(ctx, "groupa", tb.NoCloseClone(ctx), false, DatabaseContextOptions{GroupID: "GroupA"})
 	require.NoError(t, err)
 	defer dbGroupA.Close(ctx)
 
-	dbGroupB, err := NewDatabaseContext(ctx, "groupb", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupB"})
+	dbGroupB, err := NewDatabaseContext(ctx, "groupb", tb.NoCloseClone(ctx), false, DatabaseContextOptions{GroupID: "GroupB"})
 	require.NoError(t, err)
 	defer dbGroupB.Close(ctx)
 

--- a/db/user_function.go
+++ b/db/user_function.go
@@ -85,7 +85,7 @@ func (db *Database) CallUserFunction(ctx context.Context, name string, args map[
 	}
 
 	// Check that the user is authorized:
-	if err := fn.Allow.authorize(db.user, args, "function", name); err != nil {
+	if err := fn.Allow.authorize(ctx, db.user, args, "function", name); err != nil {
 		return nil, err
 	}
 

--- a/db/user_function_test.go
+++ b/db/user_function_test.go
@@ -345,8 +345,8 @@ func TestUserFunctionSyntaxError(t *testing.T) {
 		CacheOptions:  &cacheOptions,
 		UserFunctions: kUserFunctionBadConfig,
 	}
-	tBucket := base.GetTestBucket(t)
-	defer tBucket.Close()
+	ctx, tBucket := base.GetTestBucket(t)
+	defer tBucket.Close(ctx)
 	AddOptionsFromEnvironmentVariables(&dbcOptions)
 	_, err := NewDatabaseContext(ctx, "db", tBucket, false, dbcOptions)
 	assert.Error(t, err)

--- a/db/user_function_test.go
+++ b/db/user_function_test.go
@@ -376,61 +376,61 @@ func TestUserFunctionAllow(t *testing.T) {
 
 	allow := UserQueryAllow{}
 
-	ch, err := allow.expandPattern("someChannel", params, user)
+	ch, err := allow.expandPattern(ctx, "someChannel", params, user)
 	assert.NoError(t, err)
 	assert.Equal(t, ch, "someChannel")
 
-	ch, err = allow.expandPattern("sales-$CITY-all", params, user)
+	ch, err = allow.expandPattern(ctx, "sales-$CITY-all", params, user)
 	assert.NoError(t, err)
 	assert.Equal(t, ch, "sales-Paris-all")
 
-	ch, err = allow.expandPattern("sales$(CITY)All", params, user)
+	ch, err = allow.expandPattern(ctx, "sales$(CITY)All", params, user)
 	assert.NoError(t, err)
 	assert.Equal(t, ch, "salesParisAll")
 
-	ch, err = allow.expandPattern("sales$CITY-$BREAD", params, user)
+	ch, err = allow.expandPattern(ctx, "sales$CITY-$BREAD", params, user)
 	assert.NoError(t, err)
 	assert.Equal(t, ch, "salesParis-Baguette")
 
-	ch, err = allow.expandPattern("sales-upTo-$YEAR", params, user)
+	ch, err = allow.expandPattern(ctx, "sales-upTo-$YEAR", params, user)
 	assert.NoError(t, err)
 	assert.Equal(t, ch, "sales-upTo-2020")
 
-	ch, err = allow.expandPattern("employee-$(context.user.name)", params, user)
+	ch, err = allow.expandPattern(ctx, "employee-$(context.user.name)", params, user)
 	assert.NoError(t, err)
 	assert.Equal(t, ch, "employee-maurice")
 
-	ch, err = allow.expandPattern("employee-$(user.name)", params, user)
+	ch, err = allow.expandPattern(ctx, "employee-$(user.name)", params, user)
 	assert.NoError(t, err)
 	assert.Equal(t, ch, "employee-maurice")
 
-	ch, err = allow.expandPattern("$(context.user.email)", params, user)
+	ch, err = allow.expandPattern(ctx, "$(context.user.email)", params, user)
 	assert.NoError(t, err)
 	assert.Equal(t, ch, "maurice@academie.fr")
 
-	ch, err = allow.expandPattern("$(user.email)", params, user)
+	ch, err = allow.expandPattern(ctx, "$(user.email)", params, user)
 	assert.NoError(t, err)
 	assert.Equal(t, ch, "maurice@academie.fr")
 
 	// Should replace `$$` with `$`
-	ch, err = allow.expandPattern("expen$$ive", params, user)
+	ch, err = allow.expandPattern(ctx, "expen$$ive", params, user)
 	assert.NoError(t, err)
 	assert.Equal(t, ch, "expen$ive")
 
 	// No-ops since the `$` does not match a pattern:
-	ch, err = allow.expandPattern("$+wow", params, user)
+	ch, err = allow.expandPattern(ctx, "$+wow", params, user)
 	assert.NoError(t, err)
 	assert.Equal(t, ch, "$+wow")
 
-	ch, err = allow.expandPattern("foobar$", params, user)
+	ch, err = allow.expandPattern(ctx, "foobar$", params, user)
 	assert.NoError(t, err)
 	assert.Equal(t, ch, "foobar$")
 
 	// error: param value is not a string
-	_, err = allow.expandPattern("knows-$WORDS", params, user)
+	_, err = allow.expandPattern(ctx, "knows-$WORDS", params, user)
 	assert.NotNil(t, err)
 
 	// error: undefined parameter
-	_, err = allow.expandPattern("sales-upTo-$FOO", params, user)
+	_, err = allow.expandPattern(ctx, "sales-upTo-$FOO", params, user)
 	assert.NotNil(t, err)
 }

--- a/db/user_query_n1ql.go
+++ b/db/user_query_n1ql.go
@@ -60,7 +60,7 @@ func (db *Database) UserN1QLQuery(ctx context.Context, name string, args map[str
 	}
 
 	// Check that the user is authorized:
-	if err := query.Allow.authorize(db.user, args, "query", name); err != nil {
+	if err := query.Allow.authorize(ctx, db.user, args, "query", name); err != nil {
 		return nil, err
 	}
 

--- a/db/users.go
+++ b/db/users.go
@@ -32,7 +32,7 @@ func (db *DatabaseContext) DeleteRole(ctx context.Context, name string, purge bo
 		return base.ErrNotFound
 	}
 
-	seq, err := db.sequences.nextSequence()
+	seq, err := db.sequences.nextSequence(ctx)
 	if err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		// Update the persistent sequence number of this principal (only allocate a sequence when needed - issue #673):
 		nextSeq := uint64(0)
 		var err error
-		nextSeq, err = dbc.sequences.nextSequence()
+		nextSeq, err = dbc.sequences.nextSequence(ctx)
 		if err != nil {
 			return replaced, err
 		}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -324,20 +324,20 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 // viewBucketReadier removes any existing views and installs a new set into the given bucket.
 func viewBucketReadier(ctx context.Context, b base.Bucket, tbp *base.TestBucketPool) error {
 
-	ddocs, err := b.GetDDocs()
+	ddocs, err := b.GetDDocs(ctx)
 	if err != nil {
 		return err
 	}
 
 	for ddocName, _ := range ddocs {
 		tbp.Logf(ctx, "removing existing view: %s", ddocName)
-		if err := b.DeleteDDoc(ddocName); err != nil {
+		if err := b.DeleteDDoc(ctx, ddocName); err != nil {
 			return err
 		}
 	}
 
 	tbp.Logf(ctx, "initializing bucket views")
-	err = InitializeViews(b)
+	err = InitializeViews(ctx, b)
 	if err != nil {
 		return err
 	}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -313,7 +313,7 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 		return err
 	}
 
-	err := n1qlStore.CreatePrimaryIndex(base.PrimaryIndexName, nil)
+	err := n1qlStore.CreatePrimaryIndex(ctx, base.PrimaryIndexName, nil)
 	if err != nil {
 		return err
 	}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -240,7 +240,7 @@ var viewsAndGSIBucketReadier base.TBPBucketReadierFunc = func(ctx context.Contex
 	}
 
 	if c, ok := b.(*base.Collection); ok {
-		if err := c.DropAllScopesAndCollections(); err != nil && !errors.Is(err, base.ErrCollectionsUnsupported) {
+		if err := c.DropAllScopesAndCollections(ctx); err != nil && !errors.Is(err, base.ErrCollectionsUnsupported) {
 			return err
 		}
 	}

--- a/db/utils.go
+++ b/db/utils.go
@@ -22,7 +22,7 @@ type BackgroundTaskFunc func(ctx context.Context) error
 
 // backgroundTask runs task at the specified time interval in its own goroutine until stopped or an error is thrown by
 // the BackgroundTaskFunc
-func NewBackgroundTask(taskName string, dbName string, task BackgroundTaskFunc, interval time.Duration,
+func NewBackgroundTask(ctx context.Context, taskName string, dbName string, task BackgroundTaskFunc, interval time.Duration,
 	c chan bool) (bgt BackgroundTask, err error) {
 	if interval <= 0 {
 		return BackgroundTask{}, &BackgroundTaskError{TaskName: taskName, Interval: interval}
@@ -32,23 +32,22 @@ func NewBackgroundTask(taskName string, dbName string, task BackgroundTaskFunc, 
 		doneChan: make(chan struct{}),
 	}
 
-	logCtx := context.Background()
-	base.InfofCtx(logCtx, base.KeyAll, "Created background task: %q with interval %v", taskName, interval)
+	base.InfofCtx(ctx, base.KeyAll, "Created background task: %q with interval %v", taskName, interval)
 	go func() {
 		defer close(bgt.doneChan)
-		defer base.FatalPanicHandler()
+		defer base.FatalPanicHandler(ctx)
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
-				ctx := base.LogContextWith(logCtx, &base.LogContext{CorrelationID: base.NewTaskID(dbName, taskName)})
+				ctx := base.LogContextWith(ctx, &base.LogContext{CorrelationID: base.NewTaskID(dbName, taskName)})
 				if err := task(ctx); err != nil {
 					base.ErrorfCtx(ctx, "Background task returned error: %v", err)
 					return
 				}
 			case <-c:
-				base.DebugfCtx(logCtx, base.KeyAll, "Terminating background task: %q", taskName)
+				base.DebugfCtx(ctx, base.KeyAll, "Terminating background task: %q", taskName)
 				return
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,9 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.1.5-0.20220809160836-bf53e9527651
 	github.com/couchbase/gomemcached v0.1.4
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20220921180558-dda1aff4e925
+	github.com/couchbase/sg-bucket v0.0.0-20220921181957-ab132b7057de
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f
-	github.com/couchbaselabs/walrus v0.0.0-20220916224322-bff647f0abe9
+	github.com/couchbaselabs/walrus v0.0.0-20220921183430-858268b2aee1
 	github.com/elastic/gosigar v0.14.2
 	github.com/felixge/fgprof v0.9.2
 	github.com/google/uuid v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/couchbase/goutils v0.1.2
 	github.com/couchbase/sg-bucket v0.0.0-20220921180558-dda1aff4e925
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f
-	github.com/couchbaselabs/walrus v0.0.0-20220916160453-6f7d5a152116
+	github.com/couchbaselabs/walrus v0.0.0-20220916224322-bff647f0abe9
 	github.com/elastic/gosigar v0.14.2
 	github.com/felixge/fgprof v0.9.2
 	github.com/google/uuid v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -76,3 +76,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
 )
+
+replace github.com/couchbase/sg-bucket => ../sg-bucket
+
+replace github.com/couchbaselabs/walrus => ../walrus

--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
 )
-
-replace github.com/couchbase/sg-bucket => ../sg-bucket
-
-replace github.com/couchbaselabs/walrus => ../walrus

--- a/go.sum
+++ b/go.sum
@@ -81,12 +81,17 @@ github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9B
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
 github.com/couchbase/sg-bucket v0.0.0-20220921180558-dda1aff4e925 h1:NC2Nd/ibO3LK3xIc95CLydUdhxjEbziRgxqF2kswkZA=
 github.com/couchbase/sg-bucket v0.0.0-20220921180558-dda1aff4e925/go.mod h1:9XQoB1t+elPP+yEjHGOX3xcC3Z0/qDgOI7h/fc9XjlU=
+github.com/couchbase/sg-bucket v0.0.0-20220921181957-ab132b7057de h1:h6/zc2LZszzwisvaOW+eq55wZVndxWAq5fTc4cLx0L8=
+github.com/couchbase/sg-bucket v0.0.0-20220921181957-ab132b7057de/go.mod h1:9XQoB1t+elPP+yEjHGOX3xcC3Z0/qDgOI7h/fc9XjlU=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f h1:al5DxXEBAUmINnP5dR950gL47424WzncuRpNdg0TWR0=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f/go.mod h1:daOs69VstinwoALl3wwWxjBf1nD4lIe3wwYhKHKDapY=
 github.com/couchbaselabs/gocaves/client v0.0.0-20220223122017-22859b310bd2 h1:UlwJ2GWpZQAQCLHyO3xHKcqAjUUcX2w7FKpbxCIUQks=
 github.com/couchbaselabs/gocaves/client v0.0.0-20220223122017-22859b310bd2/go.mod h1:AVekAZwIY2stsJOMWLAS/0uA/+qdp7pjO8EHnl61QkY=
 github.com/couchbaselabs/walrus v0.0.0-20220916160453-6f7d5a152116 h1:/+J3rdBCFJieNnyQiFDSUBJnZD2D6Uh/1Dy4PXC+0WQ=
 github.com/couchbaselabs/walrus v0.0.0-20220916160453-6f7d5a152116/go.mod h1:1Gy0YiYTNnuS4ThzYwKqz5X8q9qlCjAoqb/E1QbJdps=
+github.com/couchbaselabs/walrus v0.0.0-20220916224322-bff647f0abe9/go.mod h1:Wv56pdJi51oVMXAkk5fTHvVwETC5+czFvePyXStk2qg=
+github.com/couchbaselabs/walrus v0.0.0-20220921183430-858268b2aee1 h1:gZZXdLyuLhuV7PN9KaaQio2vkDsmRGObIAkfO8ZtIGE=
+github.com/couchbaselabs/walrus v0.0.0-20220921183430-858268b2aee1/go.mod h1:JCyGz3KKosV9QhOuh9w5VUue2VOZpGKrE6EEU0OHtcU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1041,7 +1041,7 @@ func (h *handler) handleGetStatus() error {
 
 		// Don't bother trying to lookup LastSequence() if offline
 		if runState != db.RunStateString[db.DBOffline] {
-			lastSeq, _ = database.LastSequence()
+			lastSeq, _ = database.LastSequence(h.ctx())
 		}
 
 		replicationsStatus, err := database.SGReplicateMgr.GetReplicationStatusAll(db.DefaultReplicationStatusOptions())

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -108,7 +108,7 @@ func (h *handler) handleCreateDB() error {
 		}
 
 		// now we've started the db successfully, we can persist it to the cluster
-		cas, err := h.server.BootstrapContext.Connection.InsertConfig(bucket, h.server.Config.Bootstrap.ConfigGroupID, persistedConfig)
+		cas, err := h.server.BootstrapContext.Connection.InsertConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, persistedConfig)
 		if err != nil {
 			// unload the requested database config to prevent the cluster being in an inconsistent state
 			h.server._removeDatabase(h.ctx(), dbName)
@@ -524,7 +524,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 
 	var updatedDbConfig *DatabaseConfig
 	cas, err := h.server.BootstrapContext.Connection.UpdateConfig(
-		bucket, h.server.Config.Bootstrap.ConfigGroupID,
+		h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID,
 		func(rawBucketConfig []byte) (newConfig []byte, err error) {
 			var bucketDbConfig DatabaseConfig
 			if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {
@@ -639,7 +639,7 @@ func (h *handler) handleDeleteDbConfigSync() error {
 
 	var updatedDbConfig *DatabaseConfig
 	cas, err := h.server.BootstrapContext.Connection.UpdateConfig(
-		bucket, h.server.Config.Bootstrap.ConfigGroupID,
+		h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID,
 		func(rawBucketConfig []byte) (newConfig []byte, err error) {
 			var bucketDbConfig DatabaseConfig
 			if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {
@@ -700,7 +700,7 @@ func (h *handler) handlePutDbConfigSync() error {
 
 	var updatedDbConfig *DatabaseConfig
 	cas, err := h.server.BootstrapContext.Connection.UpdateConfig(
-		bucket, h.server.Config.Bootstrap.ConfigGroupID,
+		h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID,
 		func(rawBucketConfig []byte) (newConfig []byte, err error) {
 			var bucketDbConfig DatabaseConfig
 			if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {
@@ -789,7 +789,7 @@ func (h *handler) handleDeleteDbConfigImportFilter() error {
 
 	var updatedDbConfig *DatabaseConfig
 	cas, err := h.server.BootstrapContext.Connection.UpdateConfig(
-		bucket, h.server.Config.Bootstrap.ConfigGroupID,
+		h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID,
 		func(rawBucketConfig []byte) (newConfig []byte, err error) {
 			var bucketDbConfig DatabaseConfig
 			if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {
@@ -851,7 +851,7 @@ func (h *handler) handlePutDbConfigImportFilter() error {
 
 	var updatedDbConfig *DatabaseConfig
 	cas, err := h.server.BootstrapContext.Connection.UpdateConfig(
-		bucket, h.server.Config.Bootstrap.ConfigGroupID,
+		h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID,
 		func(rawBucketConfig []byte) (newConfig []byte, err error) {
 			var bucketDbConfig DatabaseConfig
 			if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {
@@ -908,7 +908,7 @@ func (h *handler) handleDeleteDB() error {
 
 	if h.server.persistentConfig {
 		bucket := h.db.Bucket.GetName()
-		_, err := h.server.BootstrapContext.Connection.UpdateConfig(bucket, h.server.Config.Bootstrap.ConfigGroupID, func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
+		_, err := h.server.BootstrapContext.Connection.UpdateConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
 			return nil, nil
 		})
 		if err != nil {

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -133,10 +133,9 @@ func TestCheckPermissionsWithX509(t *testing.T) {
 	if !base.ServerIsTLS(serverURL) {
 		t.Skipf("URI %s needs to start with couchbases://", serverURL)
 	}
-	tb, caCertPath, certPath, keyPath := setupX509Tests(t, true)
-	defer tb.Close()
+	ctx, tb, caCertPath, certPath, keyPath := setupX509Tests(t, true)
+	defer tb.Close(ctx)
 
-	ctx := base.TestCtx(t)
 	svrctx := NewServerContext(ctx, &StartupConfig{
 		Bootstrap: BootstrapConfig{
 			Server:       serverURL,
@@ -427,10 +426,9 @@ func TestAdminAuthWithX509(t *testing.T) {
 	if !base.ServerIsTLS(serverURL) {
 		t.Skipf("URI %s needs to start with couchbases://", serverURL)
 	}
-	tb, caCertPath, certPath, keyPath := setupX509Tests(t, true)
-	defer tb.Close()
+	ctx, tb, caCertPath, certPath, keyPath := setupX509Tests(t, true)
+	defer tb.Close(ctx)
 
-	ctx := base.TestCtx(t)
 	svrctx := NewServerContext(ctx, &StartupConfig{
 		Bootstrap: BootstrapConfig{
 			Server:       serverURL,
@@ -1500,8 +1498,8 @@ func TestCreateDBSpecificBucketPerm(t *testing.T) {
 	})
 	defer rt.Close()
 
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
+	ctx, tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
 
 	eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
 	require.NoError(t, err)

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -3914,7 +3914,7 @@ func TestDbConfigPersistentSGVersions(t *testing.T) {
 	require.NoError(t, err)
 
 	// initialise with db config
-	_, err = sc.BootstrapContext.Connection.InsertConfig(tb.GetName(), t.Name(), dbConfig)
+	_, err = sc.BootstrapContext.Connection.InsertConfig(ctx, tb.GetName(), t.Name(), dbConfig)
 	require.NoError(t, err)
 
 	assertRevsLimit := func(sc *rest.ServerContext, revsLimit uint32) {
@@ -3935,7 +3935,7 @@ func TestDbConfigPersistentSGVersions(t *testing.T) {
 	assertRevsLimit(sc, 123)
 
 	writeRevsLimitConfigWithVersion := func(sc *rest.ServerContext, version string, revsLimit uint32) error {
-		_, err = sc.BootstrapContext.Connection.UpdateConfig(tb.GetName(), t.Name(), func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
+		_, err = sc.BootstrapContext.Connection.UpdateConfig(ctx, tb.GetName(), t.Name(), func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
 			var db rest.DatabaseConfig
 			if err := base.JSONUnmarshal(rawBucketConfig, &db); err != nil {
 				return nil, err

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4956,7 +4956,7 @@ func TestTombstoneCompactionPurgeInterval(t *testing.T) {
 	ctx := rt.Context()
 
 	cbStore, _ := base.AsCouchbaseStore(rt.Bucket())
-	serverPurgeInterval, err := cbStore.MetadataPurgeInterval()
+	serverPurgeInterval, err := cbStore.MetadataPurgeInterval(ctx)
 	require.NoError(t, err)
 	// Set server purge interval back to what it was for bucket reuse
 	defer setServerPurgeInterval(t, rt, fmt.Sprintf("%.2f", serverPurgeInterval.Hours()/24))

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -5050,8 +5050,8 @@ func TestPerDBCredsOverride(t *testing.T) {
 	}
 
 	// Get test bucket
-	tb1 := base.GetTestBucket(t)
-	defer tb1.Close()
+	ctx, tb1 := base.GetTestBucket(t)
+	defer tb1.Close(ctx)
 
 	config := rest.BootstrapStartupConfigForTest(t)
 	config.BucketCredentials = map[string]*base.CredentialsConfig{
@@ -5067,7 +5067,6 @@ func TestPerDBCredsOverride(t *testing.T) {
 		},
 	}
 
-	ctx := base.TestCtx(t)
 	sc, err := rest.SetupServerContext(ctx, &config, true)
 	require.NoError(t, err)
 

--- a/rest/api.go
+++ b/rest/api.go
@@ -227,7 +227,7 @@ func (h *handler) handleFlush() error {
 		if tempBucketForFlush, ok := tempBucketForFlush.(base.SGFlushableStore); ok {
 
 			// Flush
-			err := tempBucketForFlush.FlushCtx(h.ctx())
+			err := tempBucketForFlush.Flush(h.ctx())
 			if err != nil {
 				return err
 			}

--- a/rest/api.go
+++ b/rest/api.go
@@ -391,7 +391,7 @@ func (h *handler) handleGetDB() error {
 	// Don't bother trying to lookup LastSequence() if offline
 	runState := db.RunStateString[atomic.LoadUint32(&h.db.State)]
 	if runState != db.RunStateString[db.DBOffline] {
-		lastSeq, _ := h.db.LastSequence()
+		lastSeq, _ := h.db.LastSequence(h.ctx())
 		defaultCollectionLastSeq = &lastSeq
 	}
 

--- a/rest/api.go
+++ b/rest/api.go
@@ -227,7 +227,7 @@ func (h *handler) handleFlush() error {
 		if tempBucketForFlush, ok := tempBucketForFlush.(base.SGFlushableStore); ok {
 
 			// Flush
-			err := tempBucketForFlush.Flush(h.ctx())
+			err := tempBucketForFlush.FlushCtx(h.ctx())
 			if err != nil {
 				return err
 			}

--- a/rest/api.go
+++ b/rest/api.go
@@ -194,7 +194,7 @@ func (h *handler) handleFlush() error {
 	baseBucket := base.GetBaseBucket(h.db.Bucket)
 
 	// If it can be flushed, then flush it
-	if _, ok := baseBucket.(sgbucket.FlushableStore); ok {
+	if _, ok := baseBucket.(base.SGFlushableStore); ok {
 
 		// If it's not a walrus bucket, don't allow flush unless the unsupported config is set
 		if !h.db.BucketSpec.IsWalrusBucket() {
@@ -224,10 +224,10 @@ func (h *handler) handleFlush() error {
 		defer tempBucketForFlush.Close() // Close the temporary connection to the bucket that was just for purposes of flushing it
 
 		// Flush the bucket (assuming it conforms to sgbucket.DeleteableStore interface
-		if tempBucketForFlush, ok := tempBucketForFlush.(sgbucket.FlushableStore); ok {
+		if tempBucketForFlush, ok := tempBucketForFlush.(base.SGFlushableStore); ok {
 
 			// Flush
-			err := tempBucketForFlush.Flush()
+			err := tempBucketForFlush.Flush(h.ctx())
 			if err != nil {
 				return err
 			}

--- a/rest/api.go
+++ b/rest/api.go
@@ -221,7 +221,7 @@ func (h *handler) handleFlush() error {
 		if err != nil {
 			return err
 		}
-		defer tempBucketForFlush.Close() // Close the temporary connection to the bucket that was just for purposes of flushing it
+		defer tempBucketForFlush.Close(h.ctx()) // Close the temporary connection to the bucket that was just for purposes of flushing it
 
 		// Flush the bucket (assuming it conforms to sgbucket.DeleteableStore interface
 		if tempBucketForFlush, ok := tempBucketForFlush.(base.SGFlushableStore); ok {
@@ -247,7 +247,7 @@ func (h *handler) handleFlush() error {
 		name := h.db.Name
 		config := h.server.GetDatabaseConfig(name)
 		h.server.RemoveDatabase(h.ctx(), name)
-		err := bucket.CloseAndDelete()
+		err := bucket.CloseAndDelete(h.ctx())
 		_, err2 := h.server.AddDatabaseFromConfig(h.ctx(), *config)
 		if err == nil {
 			err = err2

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -151,12 +151,12 @@ func TestMultiCollectionDCP(t *testing.T) {
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyDCP, base.KeyImport)
 
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
+	ctx, tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		createScopesAndCollections: true,
-		CustomTestBucket:           tb.NoCloseClone(), // Clone so scope/collection isn't set on tb from rt
+		CustomTestBucket:           tb.NoCloseClone(ctx), // Clone so scope/collection isn't set on tb from rt
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
 				AutoImport: true,

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -234,7 +234,7 @@ func TestCollectionsBasicIndexQuery(t *testing.T) {
 	require.NoError(t, n1qlStore.CreatePrimaryIndex(idxName, nil))
 	require.NoError(t, n1qlStore.WaitForIndexOnline(idxName))
 
-	res, err := n1qlStore.Query("SELECT keyspace_id, bucket_id, scope_id from system:indexes WHERE name = $idxName",
+	res, err := n1qlStore.Query(tbctx, "SELECT keyspace_id, bucket_id, scope_id from system:indexes WHERE name = $idxName",
 		map[string]interface{}{"idxName": idxName}, base.RequestPlus, true)
 	require.NoError(t, err)
 
@@ -258,7 +258,7 @@ func TestCollectionsBasicIndexQuery(t *testing.T) {
 	assert.Equal(t, collection, *indexMetaResult.KeyspaceID)
 
 	// try and query the document that we wrote via SG
-	res, err = n1qlStore.Query("SELECT test FROM "+base.KeyspaceQueryToken+" WHERE test = true", nil, base.RequestPlus, true)
+	res, err = n1qlStore.Query(tbctx, "SELECT test FROM "+base.KeyspaceQueryToken+" WHERE test = true", nil, base.RequestPlus, true)
 	require.NoError(t, err)
 
 	var primaryQueryResult struct {

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -61,8 +61,8 @@ func TestCollectionsPutDocInKeyspace(t *testing.T) {
 		},
 	}
 
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
+	tbctx, tb := base.GetTestBucket(t)
+	defer tb.Close(tbctx)
 
 	const (
 		username = "alice"
@@ -71,7 +71,7 @@ func TestCollectionsPutDocInKeyspace(t *testing.T) {
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		createScopesAndCollections: true,
-		CustomTestBucket:           tb.NoCloseClone(), // Clone so scope/collection isn't set on tb from rt
+		CustomTestBucket:           tb.NoCloseClone(tbctx), // Clone so scope/collection isn't set on tb from rt
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
 				Users: map[string]*auth.PrincipalConfig{
@@ -111,12 +111,12 @@ func TestSingleCollectionDCP(t *testing.T) {
 		t.Skip("Test relies on import - needs xattrs")
 	}
 
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
+	tbctx, tb := base.GetTestBucket(t)
+	defer tb.Close(tbctx)
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		createScopesAndCollections: true,
-		CustomTestBucket:           tb.NoCloseClone(), // Clone so scope/collection isn't set on tb from rt
+		CustomTestBucket:           tb.NoCloseClone(tbctx), // Clone so scope/collection isn't set on tb from rt
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
 				AutoImport: true,
@@ -196,12 +196,12 @@ func TestMultiCollectionDCP(t *testing.T) {
 func TestCollectionsBasicIndexQuery(t *testing.T) {
 	base.TestRequiresCollections(t)
 
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
+	tbctx, tb := base.GetTestBucket(t)
+	defer tb.Close(tbctx)
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		createScopesAndCollections: true,
-		CustomTestBucket:           tb.NoCloseClone(), // Clone so scope/collection isn't set on tb from rt
+		CustomTestBucket:           tb.NoCloseClone(tbctx), // Clone so scope/collection isn't set on tb from rt
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
 				Scopes: ScopesConfig{
@@ -280,8 +280,8 @@ func TestCollectionsSGIndexQuery(t *testing.T) {
 	// force GSI for this one test
 	useViews := base.BoolPtr(false)
 
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
+	tbctx, tb := base.GetTestBucket(t)
+	defer tb.Close(tbctx)
 
 	const (
 		username       = "alice"
@@ -299,7 +299,7 @@ func TestCollectionsSGIndexQuery(t *testing.T) {
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		createScopesAndCollections: true,
-		CustomTestBucket:           tb.NoCloseClone(), // Clone so scope/collection isn't set on tb from rt
+		CustomTestBucket:           tb.NoCloseClone(tbctx), // Clone so scope/collection isn't set on tb from rt
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
 				UseViews: useViews,
@@ -350,8 +350,8 @@ func TestCollectionsSGIndexQuery(t *testing.T) {
 
 func TestCollectionsChangeConfigScope(t *testing.T) {
 	base.TestRequiresCollections(t)
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
+	tbctx, tb := base.GetTestBucket(t)
+	defer tb.Close(tbctx)
 	ctx := base.TestCtx(t)
 	err := base.CreateBucketScopesAndCollections(ctx, tb.BucketSpec, map[string][]string{
 		"fooScope": {

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -231,8 +231,8 @@ func TestCollectionsBasicIndexQuery(t *testing.T) {
 	require.True(t, ok)
 
 	idxName := t.Name() + "_primary"
-	require.NoError(t, n1qlStore.CreatePrimaryIndex(idxName, nil))
-	require.NoError(t, n1qlStore.WaitForIndexOnline(idxName))
+	require.NoError(t, n1qlStore.CreatePrimaryIndex(tbctx, idxName, nil))
+	require.NoError(t, n1qlStore.WaitForIndexOnline(tbctx, idxName))
 
 	res, err := n1qlStore.Query(tbctx, "SELECT keyspace_id, bucket_id, scope_id from system:indexes WHERE name = $idxName",
 		map[string]interface{}{"idxName": idxName}, base.RequestPlus, true)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -7598,10 +7598,11 @@ func TestMetricsHandler(t *testing.T) {
 
 	// Create and remove a database
 	// This ensures that creation and removal of a DB is possible without a re-registration issue ( the below rest tester will re-register "db")
-	ctx := base.TestCtx(t)
-	context, err := db.NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, db.DatabaseContextOptions{})
+	ctx, tbucket := base.GetTestBucket(t)
+	context, err := db.NewDatabaseContext(ctx, "db", tbucket, false, db.DatabaseContextOptions{})
 	require.NoError(t, err)
-	context.Close(context.AddDatabaseLogContext(ctx))
+	ctx = context.AddDatabaseLogContext(ctx)
+	context.Close(ctx)
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -7624,9 +7625,11 @@ func TestMetricsHandler(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Initialize another database to ensure both are registered successfully
-	context, err = db.NewDatabaseContext(ctx, "db2", base.GetTestBucket(t), false, db.DatabaseContextOptions{})
+	ctx, tbucket = base.GetTestBucket(t)
+	context, err = db.NewDatabaseContext(ctx, "db2", tbucket, false, db.DatabaseContextOptions{})
 	require.NoError(t, err)
-	defer context.Close(context.AddDatabaseLogContext(ctx))
+	ctx = context.AddDatabaseLogContext(ctx)
+	defer context.Close(ctx)
 
 	// Validate that metrics still works with both db and db2 databases and that they have entries
 	resp, err = httpClient.Get(srv.URL + "/_metrics")

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1848,6 +1848,7 @@ func TestLocalDocExpiry(t *testing.T) {
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
+	ctx := rt.Context()
 
 	timeNow := uint32(time.Now().Unix())
 	oneMoreHour := uint32(time.Now().Add(time.Hour).Unix())
@@ -1863,7 +1864,7 @@ func TestLocalDocExpiry(t *testing.T) {
 	require.True(t, ok)
 
 	localDocKey := db.RealSpecialDocID(db.DocTypeLocal, "loc1")
-	expiry, getMetaError := cbStore.GetExpiry(localDocKey)
+	expiry, getMetaError := cbStore.GetExpiry(ctx, localDocKey)
 	log.Printf("Expiry after PUT is %v", expiry)
 	assert.True(t, expiry > timeNow, "expiry is not greater than current time")
 	assert.True(t, expiry < oneMoreHour, "expiry is not greater than current time")
@@ -1872,7 +1873,7 @@ func TestLocalDocExpiry(t *testing.T) {
 	// Retrieve local doc, ensure non-zero expiry is preserved
 	response = rt.SendAdminRequest("GET", "/db/_local/loc1", "")
 	RequireStatus(t, response, 200)
-	expiry, getMetaError = cbStore.GetExpiry(localDocKey)
+	expiry, getMetaError = cbStore.GetExpiry(ctx, localDocKey)
 	log.Printf("Expiry after GET is %v", expiry)
 	assert.True(t, expiry > timeNow, "expiry is not greater than current time")
 	assert.True(t, expiry < oneMoreHour, "expiry is not greater than current time")

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -6594,7 +6594,7 @@ func (tester *ChannelRevocationTester) removeUserChannel(user, channel string) {
 }
 
 func (tester *ChannelRevocationTester) fillToSeq(seq uint64) {
-	currentSeq, err := tester.restTester.GetDatabase().LastSequence()
+	currentSeq, err := tester.restTester.GetDatabase().LastSequence(tester.restTester.Context())
 	require.NoError(tester.test, err)
 
 	loopCount := seq - currentSeq

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4169,7 +4169,7 @@ func TestLongpollWithWildcard(t *testing.T) {
 	// triggers early termination of the changes loop.  This can only be reproduced if the feed is restarted after the user is created -
 	// otherwise the count for the user pseudo-channel will always be non-zero
 	db, _ := rt.ServerContext().GetDatabase(ctx, "db")
-	err = db.RestartListener()
+	err = db.RestartListener(ctx)
 	assert.True(t, err == nil)
 	// Put a document to increment the counter for the * channel
 	response := rt.Send(Request("PUT", "/db/lost", `{"channel":["ABC"]}`))

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1848,7 +1848,6 @@ func TestLocalDocExpiry(t *testing.T) {
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
-	ctx := rt.Context()
 
 	timeNow := uint32(time.Now().Unix())
 	oneMoreHour := uint32(time.Now().Add(time.Hour).Unix())
@@ -1864,7 +1863,7 @@ func TestLocalDocExpiry(t *testing.T) {
 	require.True(t, ok)
 
 	localDocKey := db.RealSpecialDocID(db.DocTypeLocal, "loc1")
-	expiry, getMetaError := cbStore.GetExpiry(ctx, localDocKey)
+	expiry, getMetaError := cbStore.GetExpiry(localDocKey)
 	log.Printf("Expiry after PUT is %v", expiry)
 	assert.True(t, expiry > timeNow, "expiry is not greater than current time")
 	assert.True(t, expiry < oneMoreHour, "expiry is not greater than current time")
@@ -1873,7 +1872,7 @@ func TestLocalDocExpiry(t *testing.T) {
 	// Retrieve local doc, ensure non-zero expiry is preserved
 	response = rt.SendAdminRequest("GET", "/db/_local/loc1", "")
 	RequireStatus(t, response, 200)
-	expiry, getMetaError = cbStore.GetExpiry(ctx, localDocKey)
+	expiry, getMetaError = cbStore.GetExpiry(localDocKey)
 	log.Printf("Expiry after GET is %v", expiry)
 	assert.True(t, expiry > timeNow, "expiry is not greater than current time")
 	assert.True(t, expiry < oneMoreHour, "expiry is not greater than current time")

--- a/rest/attachmentcompactiontest/attachment_compaction_api_test.go
+++ b/rest/attachmentcompactiontest/attachment_compaction_api_test.go
@@ -142,8 +142,8 @@ func TestAttachmentCompactionPersistence(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	tb := base.GetTestBucket(t)
-	noCloseTB := tb.NoCloseClone()
+	tbctx, tb := base.GetTestBucket(t)
+	noCloseTB := tb.NoCloseClone(tbctx)
 
 	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: noCloseTB,

--- a/rest/blip_api_no_race_test.go
+++ b/rest/blip_api_no_race_test.go
@@ -35,13 +35,13 @@ func TestBlipPusherUpdateDatabase(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyHTTPResp, base.KeySync)
 
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
+	tbctx, tb := base.GetTestBucket(t)
+	defer tb.Close(tbctx)
 
 	rtConfig := RestTesterConfig{
 		DatabaseConfig:   &DatabaseConfig{},
 		GuestEnabled:     true,
-		CustomTestBucket: tb.NoCloseClone(),
+		CustomTestBucket: tb.NoCloseClone(tbctx),
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -4563,12 +4563,13 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 			expectNoRev: false,
 		},
 	}
+	tbctx, tb := base.GetTestBucket(t)
 	for _, test := range testCases {
 		t.Run(fmt.Sprintf("%s", test.error), func(t *testing.T) {
 			docName := fmt.Sprintf("%s", test.error)
 			rt := NewRestTester(t, &RestTesterConfig{
 				GuestEnabled:     true,
-				CustomTestBucket: base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{}),
+				CustomTestBucket: tb.LeakyBucketClone(tbctx, base.LeakyBucketConfig{}),
 			})
 			defer rt.Close()
 

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -37,10 +37,10 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	require.NoError(t, sc.WaitForRESTAPIs())
 
 	// Get a test bucket, and use it to create the database.
-	tb := base.GetTestBucket(t)
+	tbctx, tb := base.GetTestBucket(t)
 	defer func() {
 		fmt.Println("closing test bucket")
-		tb.Close()
+		tb.Close(tbctx)
 	}()
 	resp := BootstrapAdminRequest(t, http.MethodPut, "/db1/",
 		fmt.Sprintf(
@@ -156,8 +156,8 @@ func TestBootstrapDuplicateBucket(t *testing.T) {
 	require.NoError(t, sc.WaitForRESTAPIs())
 
 	// Get a test bucket, and use it to create the database.
-	tb := base.GetTestBucket(t)
-	defer func() { tb.Close() }()
+	tbctx, tb := base.GetTestBucket(t)
+	defer func() { tb.Close(tbctx) }()
 	resp := BootstrapAdminRequest(t, http.MethodPut, "/db1/",
 		fmt.Sprintf(
 			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,
@@ -207,8 +207,8 @@ func TestBootstrapDuplicateDatabase(t *testing.T) {
 	require.NoError(t, sc.WaitForRESTAPIs())
 
 	// Get a test bucket, and use it to create the database.
-	tb := base.GetTestBucket(t)
-	defer func() { tb.Close() }()
+	tbctx, tb := base.GetTestBucket(t)
+	defer func() { tb.Close(tbctx) }()
 
 	dbConfig := fmt.Sprintf(
 		`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -307,7 +307,7 @@ func (h *handler) handleDumpChannel() error {
 	since := h.getIntQuery("since", 0)
 	base.InfofCtx(h.ctx(), base.KeyHTTP, "Dump channel %q", base.UD(channelName))
 
-	chanLog := h.db.GetChangeLog(channelName, since)
+	chanLog := h.db.GetChangeLog(h.ctx(), channelName, since)
 	if chanLog == nil {
 		return base.HTTPErrorf(http.StatusNotFound, "no such channel")
 	}

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -232,7 +232,7 @@ func (h *handler) handleDump() error {
 	viewName := h.PathVar("view")
 	base.InfofCtx(h.ctx(), base.KeyHTTP, "Dump view %q", base.MD(viewName))
 	opts := db.Body{"stale": false, "reduce": false}
-	result, err := h.db.Bucket.View(db.DesignDocSyncGateway(), viewName, opts)
+	result, err := h.db.Bucket.View(h.ctx(), db.DesignDocSyncGateway(), viewName, opts)
 	if err != nil {
 		return err
 	}
@@ -285,7 +285,7 @@ func (h *handler) handleRepair() error {
 
 	repairBucket.InitFrom(repairBucketParams)
 
-	repairBucketResult, repairDocsErr := repairBucket.RepairBucket()
+	repairBucketResult, repairDocsErr := repairBucket.RepairBucket(h.ctx())
 	if repairDocsErr != nil {
 		return err
 	}

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -199,7 +199,7 @@ func (h *handler) handleAllDocs() error {
 	options.Limit = h.getIntQuery("limit", 0)
 
 	// Now it's time to actually write the response!
-	lastSeq, _ := h.db.LastSequence()
+	lastSeq, _ := h.db.LastSequence(h.ctx())
 	h.setHeader("Content-Type", "application/json")
 	// response.Write below would set Status OK implicitly. We manually do it here to ensure that our handler knows
 	//that the header has been written to, meaning we can prevent it from attempting to set the header again later on.
@@ -283,7 +283,7 @@ func (h *handler) handleRepair() error {
 
 	repairBucket := db.NewRepairBucket(h.db.Bucket)
 
-	repairBucket.InitFrom(repairBucketParams)
+	repairBucket.InitFrom(h.ctx(), repairBucketParams)
 
 	repairBucketResult, repairDocsErr := repairBucket.RepairBucket(h.ctx())
 	if repairDocsErr != nil {

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -495,7 +495,7 @@ func (h *handler) sendContinuousChangesByWebSocket(inChannels base.Set, options 
 		// Read changes-feed options from an initial incoming WebSocket message in JSON format:
 		var wsoptions db.ChangesOptions
 		var compress bool
-		if msg, err := readWebSocketMessage(conn); err != nil {
+		if msg, err := readWebSocketMessage(h.ctx(), conn); err != nil {
 			return
 		} else {
 			var channelNames []string
@@ -619,12 +619,12 @@ func (h *handler) readChangesOptionsFromJSON(jsonData []byte) (feed string, opti
 }
 
 // Helper function to read a complete message from a WebSocket
-func readWebSocketMessage(conn *websocket.Conn) ([]byte, error) {
+func readWebSocketMessage(ctx context.Context, conn *websocket.Conn) ([]byte, error) {
 
 	var message []byte
 	if err := websocket.Message.Receive(conn, &message); err != nil {
 		if err != io.EOF {
-			base.WarnfCtx(context.TODO(), "Error reading initial websocket message: %v", err)
+			base.WarnfCtx(ctx, "Error reading initial websocket message: %v", err)
 			return nil, err
 		}
 	}

--- a/rest/changesttest/changes_api_test.go
+++ b/rest/changesttest/changes_api_test.go
@@ -988,9 +988,9 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 
 	// Simulate seq 3 and 4 being delayed - write 1,2,5,6
-	WriteDirect(testDb, []string{"PBS"}, 2)
-	WriteDirect(testDb, []string{"PBS"}, 5)
-	WriteDirect(testDb, []string{"PBS"}, 6)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 2)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 5)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 6)
 	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 6))
 
 	// Check the _changes feed:
@@ -1015,7 +1015,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	require.Len(t, changes.Results, 0)
 
 	// Send a missing doc - low sequence should move to 3
-	WriteDirect(testDb, []string{"PBS"}, 3)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 3)
 	require.NoError(t, rt.WaitForSequence(3))
 
 	// WaitForSequence doesn't wait for low sequence to be updated on each channel - additional delay to ensure
@@ -1029,7 +1029,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	require.Len(t, changes.Results, 3)
 
 	// Send a later doc - low sequence still 3, high sequence goes to 7
-	WriteDirect(testDb, []string{"PBS"}, 7)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 7)
 	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 7))
 
 	// Send another changes request with the same since ("2::6") to ensure we see data once there are changes
@@ -1080,10 +1080,10 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 
 	// Simulate 4 non-skipped writes (seq 2,3,4,5)
-	WriteDirect(testDb, []string{"PBS"}, 2)
-	WriteDirect(testDb, []string{"PBS"}, 3)
-	WriteDirect(testDb, []string{"PBS"}, 4)
-	WriteDirect(testDb, []string{"PBS"}, 5)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 2)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 3)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 4)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 5)
 	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 5))
 
 	// Check the _changes feed:
@@ -1100,10 +1100,10 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	// Skip sequence 6, write docs 7-10
-	WriteDirect(testDb, []string{"PBS"}, 7)
-	WriteDirect(testDb, []string{"PBS"}, 8)
-	WriteDirect(testDb, []string{"PBS"}, 9)
-	WriteDirect(testDb, []string{"PBS"}, 10)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 7)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 8)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 9)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 10)
 	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 10))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
@@ -1116,8 +1116,8 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	assert.Equal(t, "5::10", changes.Last_Seq)
 
 	// Write a few more docs
-	WriteDirect(testDb, []string{"PBS"}, 11)
-	WriteDirect(testDb, []string{"PBS"}, 12)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 11)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 12)
 	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 12))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
@@ -1130,8 +1130,8 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	assert.Equal(t, "5::12", changes.Last_Seq)
 
 	// Write another doc, then the skipped doc - both should be sent, last_seq should move to 13
-	WriteDirect(testDb, []string{"PBS"}, 13)
-	WriteDirect(testDb, []string{"PBS"}, 6)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 13)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 6)
 	require.NoError(t, rt.WaitForSequence(13))
 
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1210,11 +1210,11 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	testDb := rt.ServerContext().Database(ctx, "db")
 
 	// Simulate 5 non-skipped writes (seq 1,2,3,4,5)
-	WriteDirect(testDb, []string{"PBS"}, 1)
-	WriteDirect(testDb, []string{"PBS"}, 2)
-	WriteDirect(testDb, []string{"PBS"}, 3)
-	WriteDirect(testDb, []string{"PBS"}, 4)
-	WriteDirect(testDb, []string{"PBS"}, 5)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 1)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 2)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 3)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 4)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 5)
 	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 5))
 
 	// Check the _changes feed:
@@ -1231,10 +1231,10 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	// Skip sequence 6, write docs 7-10
-	WriteDirect(testDb, []string{"PBS"}, 7)
-	WriteDirect(testDb, []string{"PBS"}, 8)
-	WriteDirect(testDb, []string{"PBS"}, 9)
-	WriteDirect(testDb, []string{"PBS"}, 10)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 7)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 8)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 9)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 10)
 	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 10))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
@@ -1247,8 +1247,8 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	assert.Equal(t, "5::10", changes.Last_Seq)
 
 	// Write a few more docs
-	WriteDirect(testDb, []string{"PBS"}, 11)
-	WriteDirect(testDb, []string{"PBS"}, 12)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 11)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 12)
 	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 12))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
@@ -1261,8 +1261,8 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	assert.Equal(t, "5::12", changes.Last_Seq)
 
 	// Write another doc, then the skipped doc - both should be sent, last_seq should move to 13
-	WriteDirect(testDb, []string{"PBS"}, 13)
-	WriteDirect(testDb, []string{"PBS"}, 6)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 13)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 6)
 	require.NoError(t, rt.WaitForSequence(13))
 
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1347,10 +1347,10 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 
 	// Simulate 4 non-skipped writes (seq 2,3,4,5)
-	WriteDirect(testDb, []string{"PBS"}, 2)
-	WriteDirect(testDb, []string{"PBS"}, 3)
-	WriteDirect(testDb, []string{"PBS"}, 4)
-	WriteDirect(testDb, []string{"PBS"}, 5)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 2)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 3)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 4)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 5)
 	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 5))
 
 	// Check the _changes feed:
@@ -1367,10 +1367,10 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	// Skip sequence 6, write docs 7-10
-	WriteDirect(testDb, []string{"PBS"}, 7)
-	WriteDirect(testDb, []string{"PBS"}, 8)
-	WriteDirect(testDb, []string{"PBS"}, 9)
-	WriteDirect(testDb, []string{"PBS"}, 10)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 7)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 8)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 9)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 10)
 	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 10))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
@@ -1383,8 +1383,8 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	assert.Equal(t, "5::10", changes.Last_Seq)
 
 	// Write a few more docs
-	WriteDirect(testDb, []string{"PBS"}, 11)
-	WriteDirect(testDb, []string{"PBS"}, 12)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 11)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 12)
 	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 12))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
@@ -1416,7 +1416,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	require.NoError(t, rt.GetDatabase().WaitForCaughtUp(caughtUpCount+1))
 
 	// Write the skipped doc, wait for longpoll to return
-	WriteDirect(testDb, []string{"PBS"}, 6)
+	WriteDirect(ctx, testDb, []string{"PBS"}, 6)
 	// WriteDirect(testDb, []string{"PBS"}, 13)
 	longpollWg.Wait()
 
@@ -3942,12 +3942,12 @@ func waitForCompactStopped(dbc *db.DatabaseContext) error {
 
 // ////// HELPERS:
 
-func WriteDirect(testDb *db.DatabaseContext, channelArray []string, sequence uint64) {
+func WriteDirect(ctx context.Context, testDb *db.DatabaseContext, channelArray []string, sequence uint64) {
 	docId := fmt.Sprintf("doc-%v", sequence)
-	WriteDirectWithKey(testDb, docId, channelArray, sequence)
+	WriteDirectWithKey(ctx, testDb, docId, channelArray, sequence)
 }
 
-func WriteDirectWithKey(testDb *db.DatabaseContext, key string, channelArray []string, sequence uint64) {
+func WriteDirectWithKey(ctx context.Context, testDb *db.DatabaseContext, key string, channelArray []string, sequence uint64) {
 
 	if base.TestUseXattrs() {
 		panic(fmt.Sprintf("WriteDirectWithKey() cannot be used in tests that are xattr enabled"))
@@ -3973,6 +3973,6 @@ func WriteDirectWithKey(testDb *db.DatabaseContext, key string, channelArray []s
 
 	_, err := testDb.Bucket.Add(key, 0, db.Body{base.SyncPropertyName: syncData, "key": key})
 	if err != nil {
-		base.PanicfCtx(context.TODO(), "Error while add ket to bucket: %v", err)
+		base.PanicfCtx(ctx, "Error while add ket to bucket: %v", err)
 	}
 }

--- a/rest/config.go
+++ b/rest/config.go
@@ -80,7 +80,7 @@ type BucketConfig struct {
 	MaxConcurrentQueryOps *int    `json:"max_concurrent_query_ops,omitempty"` // Max concurrent  query ops
 }
 
-func (dc *DbConfig) MakeBucketSpec() base.BucketSpec {
+func (dc *DbConfig) MakeBucketSpec(ctx context.Context) base.BucketSpec {
 	bc := &dc.BucketConfig
 
 	server := ""
@@ -104,7 +104,7 @@ func (dc *DbConfig) MakeBucketSpec() base.BucketSpec {
 	for scopeName, scopeConfig := range dc.Scopes {
 		scope = &scopeName
 		for collectionName := range scopeConfig.Collections {
-			base.WarnfCtx(context.TODO(), "WIP Collections (Phase 1) - Running db %q in scope %q collection %q", dc.Name, scopeName, collectionName)
+			base.WarnfCtx(ctx, "WIP Collections (Phase 1) - Running db %q in scope %q collection %q", dc.Name, scopeName, collectionName)
 			collection = &collectionName
 			break
 		}
@@ -1185,7 +1185,7 @@ func (sc *ServerContext) addHTTPServer(s *http.Server) {
 }
 
 // Validate returns errors errors if invalid config is present
-func (sc *StartupConfig) Validate(isEnterpriseEdition bool) (errorMessages error) {
+func (sc *StartupConfig) Validate(ctx context.Context, isEnterpriseEdition bool) (errorMessages error) {
 	var multiError *base.MultiError
 	if sc.Bootstrap.Server == "" {
 		multiError = multiError.Append(fmt.Errorf("a server must be provided in the Bootstrap configuration"))
@@ -1222,7 +1222,7 @@ func (sc *StartupConfig) Validate(isEnterpriseEdition bool) (errorMessages error
 	if sc.DatabaseCredentials != nil {
 		for dbName, creds := range sc.DatabaseCredentials {
 			if (creds.X509CertPath != "" || creds.X509KeyPath != "") && (creds.Username != "" || creds.Password != "") {
-				base.WarnfCtx(context.TODO(), "database %q in database_credentials cannot use both x509 and basic auth. Will use x509 only.", base.MD(dbName))
+				base.WarnfCtx(ctx, "database %q in database_credentials cannot use both x509 and basic auth. Will use x509 only.", base.MD(dbName))
 			}
 		}
 	}
@@ -1275,7 +1275,7 @@ func SetupServerContext(ctx context.Context, config *StartupConfig, persistentCo
 		return nil, err
 	}
 
-	if err := config.Validate(base.IsEnterpriseEdition()); err != nil {
+	if err := config.Validate(ctx, base.IsEnterpriseEdition()); err != nil {
 		return nil, err
 	}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -1395,7 +1395,7 @@ func (sc *ServerContext) fetchDatabase(ctx context.Context, dbName string) (foun
 
 	for _, bucket := range buckets {
 		var cnf DatabaseConfig
-		cas, err := sc.BootstrapContext.Connection.GetConfig(bucket, sc.Config.Bootstrap.ConfigGroupID, &cnf)
+		cas, err := sc.BootstrapContext.Connection.GetConfig(ctx, bucket, sc.Config.Bootstrap.ConfigGroupID, &cnf)
 		if err == base.ErrNotFound {
 			base.DebugfCtx(ctx, base.KeyConfig, "%q did not contain config in group %q", bucket, sc.Config.Bootstrap.ConfigGroupID)
 			continue
@@ -1487,7 +1487,7 @@ func (sc *ServerContext) FetchConfigs(ctx context.Context, isInitialStartup bool
 	for _, bucket := range buckets {
 		base.TracefCtx(ctx, base.KeyConfig, "Checking for config for group %q from bucket %q", sc.Config.Bootstrap.ConfigGroupID, bucket)
 		var cnf DatabaseConfig
-		cas, err := sc.BootstrapContext.Connection.GetConfig(bucket, sc.Config.Bootstrap.ConfigGroupID, &cnf)
+		cas, err := sc.BootstrapContext.Connection.GetConfig(ctx, bucket, sc.Config.Bootstrap.ConfigGroupID, &cnf)
 		if err == base.ErrNotFound {
 			base.DebugfCtx(ctx, base.KeyConfig, "Bucket %q did not contain config for group %q", bucket, sc.Config.Bootstrap.ConfigGroupID)
 			continue

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -285,9 +285,8 @@ func TestLegacyGuestUserMigration(t *testing.T) {
 		Disabled:         base.BoolPtr(false),
 	}
 
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
-	ctx := base.TestCtx(t)
+	ctx, tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
 
 	config := fmt.Sprintf(`{
 	"server_tls_skip_verify": %t,

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -287,6 +287,7 @@ func TestLegacyGuestUserMigration(t *testing.T) {
 
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
+	ctx := base.TestCtx(t)
 
 	config := fmt.Sprintf(`{
 	"server_tls_skip_verify": %t,
@@ -320,14 +321,14 @@ func TestLegacyGuestUserMigration(t *testing.T) {
 	err := ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
 	require.NoError(t, err)
 
-	sc, _, _, _, err := automaticConfigUpgrade(configPath)
+	sc, _, _, _, err := automaticConfigUpgrade(ctx, configPath)
 	require.NoError(t, err)
 
 	cluster, err := CreateCouchbaseClusterFromStartupConfig(sc)
 	require.NoError(t, err)
 
 	var dbConfig DbConfig
-	_, err = cluster.GetConfig(tb.GetName(), PersistentConfigDefaultGroupID, &dbConfig)
+	_, err = cluster.GetConfig(ctx, tb.GetName(), PersistentConfigDefaultGroupID, &dbConfig)
 	require.NoError(t, err)
 
 	assert.Equal(t, &expected, dbConfig.Guest)
@@ -421,7 +422,7 @@ func TestLegacyConfigPrinciplesMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Copy behaviour of serverMainPersistentConfig - upgrade config, pass legacy users and roles in to addLegacyPrinciples (after server context is created)
-	_, _, users, roles, err := automaticConfigUpgrade(configPath)
+	_, _, users, roles, err := automaticConfigUpgrade(ctx, configPath)
 	require.NoError(t, err)
 	rt.ServerContext().addLegacyPrincipals(ctx, users, roles)
 

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -12,7 +12,6 @@ package rest
 
 import (
 	"bytes"
-	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -1415,7 +1414,7 @@ func TestConfigGroupIDValidation(t *testing.T) {
 					UseTLSServer:  base.BoolPtr(base.ServerIsTLS(base.UnitTestUrl())),
 				},
 			}
-			err := sc.Validate(isEnterpriseEdition)
+			err := sc.Validate(base.TestCtx(t), isEnterpriseEdition)
 			if test.expectedError != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), test.expectedError)
@@ -1466,7 +1465,7 @@ func TestClientTLSMissing(t *testing.T) {
 			if test.tlsCert {
 				config.API.HTTPS.TLSCertPath = "test.cert"
 			}
-			err := config.Validate(base.IsEnterpriseEdition())
+			err := config.Validate(base.TestCtx(t), base.IsEnterpriseEdition())
 			if test.expectError {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), errorTLSOneMissing)
@@ -2342,7 +2341,7 @@ func TestStartupConfigBcryptCostValidation(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			sc := StartupConfig{Auth: AuthConfig{BcryptCost: test.cost}}
-			err := sc.Validate(base.IsEnterpriseEdition())
+			err := sc.Validate(base.TestCtx(t), base.IsEnterpriseEdition())
 			if test.expectError {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), errContains)
@@ -2499,7 +2498,7 @@ func TestBucketCredentialsValidation(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.startupConfig.Validate(base.IsEnterpriseEdition())
+			err := test.startupConfig.Validate(base.TestCtx(t), base.IsEnterpriseEdition())
 			if test.expectedError != nil {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), *test.expectedError)
@@ -2589,7 +2588,7 @@ func TestCollectionsValidation(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			validateOIDCConfig := false
-			err := test.dbConfig.validate(context.TODO(), validateOIDCConfig)
+			err := test.dbConfig.validate(base.TestCtx(t), validateOIDCConfig)
 			if test.expectedError != nil {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), *test.expectedError)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -940,11 +940,11 @@ func TestValidateServerContextSharedBuckets(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	tb1 := base.GetTestBucket(t)
-	defer tb1.Close()
+	tbctx1, tb1 := base.GetTestBucket(t)
+	defer tb1.Close(tbctx1)
 
-	tb2 := base.GetTestBucket(t)
-	defer tb2.Close()
+	tbctx2, tb2 := base.GetTestBucket(t)
+	defer tb2.Close(tbctx2)
 
 	tb1User, tb1Password, _ := tb1.BucketSpec.Auth.GetCredentials()
 	tb2User, tb2Password, _ := tb2.BucketSpec.Auth.GetCredentials()

--- a/rest/handler_config_database.go
+++ b/rest/handler_config_database.go
@@ -48,7 +48,7 @@ func (h *handler) mutateDbConfig(mutator func(*DbConfig) error) error {
 		bucket := h.db.Bucket.GetName()
 		var updatedDbConfig *DatabaseConfig
 		cas, err := h.server.BootstrapContext.Connection.UpdateConfig(
-			bucket, h.server.Config.Bootstrap.ConfigGroupID,
+			h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID,
 			func(rawBucketConfig []byte) (newConfig []byte, err error) {
 				var bucketDbConfig DatabaseConfig
 				if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -1316,6 +1316,7 @@ func TestXattrFeedBasedImportPreservesExpiry(t *testing.T) {
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	bucket := rt.Bucket()
+	ctx := rt.Context()
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
@@ -1333,7 +1334,7 @@ func TestXattrFeedBasedImportPreservesExpiry(t *testing.T) {
 
 	// Verify the expiry is as expected
 	cbStore, _ := base.AsCouchbaseStore(bucket)
-	beforeExpiry, err := cbStore.GetExpiry(mobileKey)
+	beforeExpiry, err := cbStore.GetExpiry(ctx, mobileKey)
 	require.NoError(t, err, "Error calling GetExpiry()")
 	assertExpiry(t, uint32(expiryUnixEpoch), beforeExpiry)
 
@@ -1354,12 +1355,12 @@ func TestXattrFeedBasedImportPreservesExpiry(t *testing.T) {
 	assertXattrSyncMetaRevGeneration(t, bucket, mobileKeyNoExpiry, 1)
 
 	// Verify the expiry has been preserved after the import
-	afterExpiry, err := cbStore.GetExpiry(mobileKey)
+	afterExpiry, err := cbStore.GetExpiry(ctx, mobileKey)
 	assert.NoError(t, err, "Error calling GetExpiry()")
 	assertExpiry(t, beforeExpiry, afterExpiry)
 
 	// Negative test case -- make sure no expiry was erroneously added by the import
-	expiry, err := cbStore.GetExpiry(mobileKeyNoExpiry)
+	expiry, err := cbStore.GetExpiry(ctx, mobileKeyNoExpiry)
 	assert.NoError(t, err, "Error calling GetExpiry()")
 	assert.True(t, expiry == 0)
 }
@@ -1378,6 +1379,7 @@ func TestFeedBasedMigrateWithExpiry(t *testing.T) {
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	bucket := rt.Bucket()
+	ctx := rt.Context()
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
@@ -1405,7 +1407,7 @@ func TestFeedBasedMigrateWithExpiry(t *testing.T) {
 
 	// Now get the doc expiry and validate that it has been migrated into the doc metadata
 	cbStore, _ := base.AsCouchbaseStore(bucket)
-	expiry, err := cbStore.GetExpiry(key)
+	expiry, err := cbStore.GetExpiry(ctx, key)
 	assert.True(t, expiry > 0)
 	assert.NoError(t, err, "Error calling getExpiry()")
 	log.Printf("expiry: %v", expiry)
@@ -1500,6 +1502,7 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 			rt := rest.NewRestTester(t, &rtConfig)
 			defer rt.Close()
 			bucket := rt.Bucket()
+			ctx := rt.Context()
 
 			base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
@@ -1512,7 +1515,7 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 
 			// Verify the expiry is as expected
 			cbStore, _ := base.AsCouchbaseStore(bucket)
-			beforeExpiry, err := cbStore.GetExpiry(key)
+			beforeExpiry, err := cbStore.GetExpiry(ctx, key)
 			require.NoError(t, err, "Error calling GetExpiry()")
 			assertExpiry(t, uint32(expiryUnixEpoch), beforeExpiry)
 
@@ -1529,7 +1532,7 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 			assertXattrSyncMetaRevGeneration(t, bucket, key, testCase.expectedRevGeneration)
 
 			// Verify the expiry has not been changed from the original expiry value
-			afterExpiry, err := cbStore.GetExpiry(key)
+			afterExpiry, err := cbStore.GetExpiry(ctx, key)
 			require.NoError(t, err, "Error calling GetExpiry()")
 			assertExpiry(t, beforeExpiry, afterExpiry)
 		})
@@ -1584,6 +1587,7 @@ func TestOnDemandMigrateWithExpiry(t *testing.T) {
 			rt := rest.NewRestTester(t, &rtConfig)
 			defer rt.Close()
 			bucket := rt.Bucket()
+			ctx := rt.Context()
 
 			base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
@@ -1601,7 +1605,7 @@ func TestOnDemandMigrateWithExpiry(t *testing.T) {
 
 			// Now get the doc expiry and validate that it has been migrated into the doc metadata
 			cbStore, _ := base.AsCouchbaseStore(bucket)
-			expiry, err := cbStore.GetExpiry(key)
+			expiry, err := cbStore.GetExpiry(ctx, key)
 			assert.NoError(t, err, "Error calling GetExpiry()")
 			assert.True(t, expiry > 0)
 			log.Printf("expiry: %v", expiry)

--- a/rest/main.go
+++ b/rest/main.go
@@ -30,7 +30,7 @@ func ServerMain() {
 // TODO: Pass ctx down into HTTP servers so that serverMain can be stopped.
 func serverMain(ctx context.Context, osArgs []string) error {
 	RegisterSignalHandler(ctx)
-	defer base.FatalPanicHandler()
+	defer base.FatalPanicHandler(ctx)
 
 	base.InitializeMemoryLoggers()
 	base.LogSyncGatewayVersion()

--- a/rest/main.go
+++ b/rest/main.go
@@ -23,7 +23,7 @@ import (
 // does the initial setup and finally starts the server.
 func ServerMain() {
 	if err := serverMain(context.Background(), os.Args); err != nil {
-		base.FatalfCtx(context.TODO(), "Couldn't start Sync Gateway: %v", err)
+		base.FatalfCtx(context.Background(), "Couldn't start Sync Gateway: %v", err)
 	}
 }
 

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -2333,8 +2333,8 @@ func TestOpenIDConnectProviderRemoval(t *testing.T) {
 	}()
 
 	// Get a test bucket, and use it to create the database.
-	tb := base.GetTestBucket(t)
-	defer func() { tb.Close() }()
+	tbctx, tb := base.GetTestBucket(t)
+	defer func() { tb.Close(tbctx) }()
 
 	oidcOptions := auth.OIDCOptions{Providers: providers, DefaultProvider: base.StringPtr(providerName)}
 	dbConfig := `{
@@ -2444,8 +2444,8 @@ func TestOpenIDConnectIssuerChange(t *testing.T) {
 
 	// We need to create two different sync gateways, so that we have two different OIDC issuers to test with.
 	// Note that we set the OIDC config after the mock SG is running, because we need to know its URL for the issuer field
-	tb1 := base.GetTestBucket(t)
-	defer tb1.Close()
+	tbctx1, tb1 := base.GetTestBucket(t)
+	defer tb1.Close(tbctx1)
 	rt1Config := RestTesterConfig{
 		DatabaseConfig:   &DatabaseConfig{DbConfig: DbConfig{}},
 		CustomTestBucket: tb1,

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -20,8 +20,8 @@ func TestAutomaticConfigUpgrade(t *testing.T) {
 		t.Skip("CBS required")
 	}
 
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
+	tbctx, tb := base.GetTestBucket(t)
+	defer tb.Close(tbctx)
 	ctx := base.TestCtx(t)
 
 	config := fmt.Sprintf(`{
@@ -140,9 +140,8 @@ func TestAutomaticConfigUpgradeError(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		t.Run(testCase.Name, func(t *testing.T) {
-			tb := base.GetTestBucket(t)
-			defer tb.Close()
-			ctx := base.TestCtx(t)
+			ctx, tb := base.GetTestBucket(t)
+			defer tb.Close(ctx)
 
 			config := fmt.Sprintf(testCase.Config, base.TestTLSSkipVerify(), base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), tb.GetName())
 
@@ -161,9 +160,8 @@ func TestAutomaticConfigUpgradeExistingConfigAndNewGroup(t *testing.T) {
 		t.Skip("CBS required")
 	}
 
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
-	ctx := base.TestCtx(t)
+	ctx, tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
 
 	tmpDir := t.TempDir()
 
@@ -310,10 +308,10 @@ func TestImportFilterEndpoint(t *testing.T) {
 	require.NoError(t, sc.WaitForRESTAPIs())
 
 	// Get a test bucket, and use it to create the database.
-	tb := base.GetTestBucket(t)
+	tbctx, tb := base.GetTestBucket(t)
 	defer func() {
 		fmt.Println("closing test bucket")
-		tb.Close()
+		tb.Close(tbctx)
 	}()
 	resp := BootstrapAdminRequest(t, http.MethodPut, "/db1/",
 		fmt.Sprintf(

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/couchbase/sync_gateway/auth"
-	"github.com/couchbaselabs/walrus"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
@@ -1076,8 +1075,7 @@ func addActiveRT(t *testing.T, testBucket *base.TestBucket) (activeRT *RestTeste
 	// Instead, we need to modify the leaky bucket config (created for vbno handling) after the fact.
 	leakyBucket, ok := activeRT.GetDatabase().Bucket.(*base.LeakyBucket)
 	if ok {
-		underlyingBucket := leakyBucket.GetUnderlyingBucket()
-		if _, ok := underlyingBucket.(*walrus.WalrusBucket); ok {
+		if testBucket.BucketSpec.IsWalrusBucket() {
 			leakyBucket.SetIgnoreClose(true)
 		}
 	}

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -158,7 +158,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
+	_, tb2 := base.GetTestBucket(t)
 
 	const (
 		username = "AL_1c.e-@"
@@ -197,7 +197,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	passiveDBURL.User = url.UserPassword(username, password)
 
 	// Active
-	tb1 := base.GetTestBucket(t)
+	_, tb1 := base.GetTestBucket(t)
 
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1,
@@ -254,7 +254,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
+	_, tb2 := base.GetTestBucket(t)
 
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb2,
@@ -287,7 +287,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	// Active
-	tb1 := base.GetTestBucket(t)
+	_, tb1 := base.GetTestBucket(t)
 
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1,
@@ -577,7 +577,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	)
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
+	_, tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -608,7 +608,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	// Active
-	tb1 := base.GetTestBucket(t)
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1,
 	})
@@ -743,7 +743,7 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 	)
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
+	_, tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -758,7 +758,7 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
-	tb1 := base.GetTestBucket(t)
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1,
 	})
@@ -897,7 +897,7 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyReplicate)
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
+	_, tb2 := base.GetTestBucket(t)
 
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb2,
@@ -931,7 +931,7 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	// Active
-	tb1 := base.GetTestBucket(t)
+	_, tb1 := base.GetTestBucket(t)
 
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1,
@@ -991,7 +991,7 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
+	_, tb2 := base.GetTestBucket(t)
 
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb2,
@@ -1007,7 +1007,7 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
-	tb1 := base.GetTestBucket(t)
+	_, tb1 := base.GetTestBucket(t)
 
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1,
@@ -1081,7 +1081,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Active
-	tb1 := base.GetTestBucket(t)
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1,
 	})
@@ -1089,7 +1089,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 	ctx1 := rt1.Context()
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
+	_, tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -1201,7 +1201,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	)
 
 	// Active
-	tb1 := base.GetTestBucket(t)
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1,
 	})
@@ -1216,7 +1216,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	}
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
+	_, tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -1363,7 +1363,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	)
 
 	// Central cluster
-	tb1 := base.GetTestBucket(t)
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -1394,7 +1394,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	rt1DBURL.User = url.UserPassword("alice", "pass")
 
 	// Edge 1
-	edge1Bucket := base.GetTestBucket(t)
+	_, edge1Bucket := base.GetTestBucket(t)
 	edge1 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: edge1Bucket,
 	})
@@ -1463,7 +1463,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	assert.NoError(t, edge1Replicator.Stop())
 
 	// Edge 2
-	edge2Bucket := base.GetTestBucket(t)
+	_, edge2Bucket := base.GetTestBucket(t)
 	edge2 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: edge2Bucket,
 	})
@@ -1536,7 +1536,7 @@ func TestActiveReplicatorPushFromCheckpointIgnored(t *testing.T) {
 	)
 
 	// Active
-	tb1 := base.GetTestBucket(t)
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1,
 	})
@@ -1544,7 +1544,7 @@ func TestActiveReplicatorPushFromCheckpointIgnored(t *testing.T) {
 	ctx1 := rt1.Context()
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
+	_, tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -1671,7 +1671,7 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
+	_, tb2 := base.GetTestBucket(t)
 
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb2,
@@ -1687,7 +1687,7 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
-	tb1 := base.GetTestBucket(t)
+	_, tb1 := base.GetTestBucket(t)
 
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1,
@@ -1767,7 +1767,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
+	_, tb2 := base.GetTestBucket(t)
 
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb2,
@@ -1798,7 +1798,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	// Active
-	tb1 := base.GetTestBucket(t)
+	_, tb1 := base.GetTestBucket(t)
 
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1,
@@ -1870,7 +1870,7 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyReplicate)
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
+	_, tb2 := base.GetTestBucket(t)
 
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb2,
@@ -1901,7 +1901,7 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	// Active
-	tb1 := base.GetTestBucket(t)
+	_, tb1 := base.GetTestBucket(t)
 
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1,
@@ -2048,7 +2048,7 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD)
 
 			// Passive
-			tb2 := base.GetTestBucket(t)
+			_, tb2 := base.GetTestBucket(t)
 
 			rt2 := NewRestTester(t, &RestTesterConfig{
 				CustomTestBucket: tb2,
@@ -2082,7 +2082,7 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			passiveDBURL.User = url.UserPassword("alice", "pass")
 
 			// Active
-			tb1 := base.GetTestBucket(t)
+			_, tb1 := base.GetTestBucket(t)
 
 			rt1 := NewRestTester(t, &RestTesterConfig{
 				CustomTestBucket: tb1,
@@ -2258,8 +2258,9 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD)
 
 			// Passive
+			_, tb2 := base.GetTestBucket(t)
 			rt2 := NewRestTester(t, &RestTesterConfig{
-				CustomTestBucket: base.GetTestBucket(t),
+				CustomTestBucket: tb2,
 				DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 					Users: map[string]*auth.PrincipalConfig{
 						"alice": {
@@ -2311,8 +2312,9 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			passiveDBURL.User = url.UserPassword("alice", "pass")
 
 			// Active
+			_, tb1 := base.GetTestBucket(t)
 			rt1 := NewRestTester(t, &RestTesterConfig{
-				CustomTestBucket: base.GetTestBucket(t),
+				CustomTestBucket: tb1,
 			})
 			defer rt1.Close()
 			ctx1 := rt1.Context()
@@ -2453,8 +2455,9 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Passive
+	_, tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
@@ -2467,8 +2470,9 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb1,
 	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -2531,8 +2535,9 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Passive
+	_, tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
@@ -2545,8 +2550,9 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb1,
 	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -2596,8 +2602,9 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	// Passive
+	_, tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
@@ -2626,8 +2633,9 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	// Active
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb1,
 	})
 	ctx1 := rt1.Context()
 
@@ -2688,8 +2696,9 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	rt1.Close()
 
 	// recreate rt1 with a new bucket
+	_, tb1 = base.GetTestBucket(t)
 	rt1 = NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb1,
 	})
 	defer rt1.Close()
 	ctx1 = rt1.Context()
@@ -2752,7 +2761,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
+	_, tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -2775,7 +2784,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	// Active
-	tb1 := base.GetTestBucket(t)
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1,
 	})
@@ -2849,8 +2858,9 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	rt2.Close()
 
 	// recreate rt2 with a new bucket, http server and update target URL in the replicator
+	_, tb2 = base.GetTestBucket(t)
 	rt2 = NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
@@ -2926,8 +2936,9 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyBucket, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	// Passive
+	_, tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
@@ -2950,8 +2961,9 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	// Active
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb1,
 	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -3084,8 +3096,9 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyBucket, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	// Passive
+	_, tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			Users: map[string]*auth.PrincipalConfig{
 				"alice": {
@@ -3107,8 +3120,9 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	// Active
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb1,
 	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -3184,8 +3198,9 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Passive
+	_, tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			AllowConflicts: base.BoolPtr(false),
 			Users: map[string]*auth.PrincipalConfig{
@@ -3199,8 +3214,9 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb1,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			AllowConflicts: base.BoolPtr(false),
 		}},
@@ -3298,7 +3314,7 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 	)
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
+	_, tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -3329,7 +3345,7 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	// Active
-	tb1 := base.GetTestBucket(t)
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1,
 	})
@@ -3500,7 +3516,7 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 					base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 					// Passive
-					tb2 := base.GetTestBucket(t)
+					_, tb2 := base.GetTestBucket(t)
 					rt2 := NewRestTester(t, &RestTesterConfig{
 						CustomTestBucket: tb2,
 						DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -3534,7 +3550,7 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 					}
 
 					// Active
-					tb1 := base.GetTestBucket(t)
+					_, tb1 := base.GetTestBucket(t)
 					rt1 := NewRestTester(t, &RestTesterConfig{
 						CustomTestBucket: tb1,
 					})
@@ -3604,7 +3620,7 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp)
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
+	_, tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb2,
 	})
@@ -3622,7 +3638,7 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 	remoteDBURL.User = url.UserPassword("alice", "pass")
 
 	// Active
-	tb1 := base.GetTestBucket(t)
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1,
 	})
@@ -3684,7 +3700,7 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp)
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
+	_, tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -3710,7 +3726,7 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 	remoteDBURL.User = url.UserPassword("bob", "pass")
 
 	// Active
-	tb1 := base.GetTestBucket(t)
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1,
 	})
@@ -4000,7 +4016,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 			base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 			// Passive
-			tb2 := base.GetTestBucket(t)
+			_, tb2 := base.GetTestBucket(t)
 
 			rt2 := NewRestTester(t, &RestTesterConfig{
 				CustomTestBucket: tb2,
@@ -4038,7 +4054,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 			passiveDBURL.User = url.UserPassword("alice", "pass")
 
 			// Active
-			tb1 := base.GetTestBucket(t)
+			_, tb1 := base.GetTestBucket(t)
 
 			rt1 := NewRestTester(t, &RestTesterConfig{
 				CustomTestBucket: tb1,
@@ -4233,7 +4249,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 			}
 
 			// Passive
-			passiveBucket := base.GetTestBucket(t)
+			_, passiveBucket := base.GetTestBucket(t)
 			remotePassiveRT := NewRestTester(t, &RestTesterConfig{
 				CustomTestBucket: passiveBucket,
 			})
@@ -4243,7 +4259,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 			defer srv.Close()
 
 			// Active
-			activeBucket := base.GetTestBucket(t)
+			_, activeBucket := base.GetTestBucket(t)
 			localActiveRT := NewRestTester(t, &RestTesterConfig{
 				CustomTestBucket:   activeBucket,
 				SgReplicateEnabled: true,
@@ -4496,8 +4512,9 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 	for _, test := range defaultConflictResolverWithTombstoneTests {
 		t.Run(test.name, func(tt *testing.T) {
 			// Passive
+			_, tb2 := base.GetTestBucket(t)
 			rt2 := NewRestTester(t, &RestTesterConfig{
-				CustomTestBucket: base.GetTestBucket(t),
+				CustomTestBucket: tb2,
 				DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 					Users: map[string]*auth.PrincipalConfig{
 						"alice": {
@@ -4519,8 +4536,9 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 			passiveDBURL.User = url.UserPassword("alice", "pass")
 
 			// Active
+			_, tb1 := base.GetTestBucket(t)
 			rt1 := NewRestTester(t, &RestTesterConfig{
-				CustomTestBucket: base.GetTestBucket(t),
+				CustomTestBucket: tb1,
 			})
 			defer rt1.Close()
 			ctx1 := rt1.Context()
@@ -4651,8 +4669,9 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 	for _, test := range defaultConflictResolverWithTombstoneTests {
 		t.Run(test.name, func(t *testing.T) {
 			// Passive
+			_, tb2 := base.GetTestBucket(t)
 			rt2 := NewRestTester(t, &RestTesterConfig{
-				CustomTestBucket: base.GetTestBucket(t),
+				CustomTestBucket: tb2,
 				DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 					Users: map[string]*auth.PrincipalConfig{
 						"alice": {
@@ -4674,8 +4693,9 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 			passiveDBURL.User = url.UserPassword("alice", "pass")
 
 			// Active
+			_, tb1 := base.GetTestBucket(t)
 			rt1 := NewRestTester(t, &RestTesterConfig{
-				CustomTestBucket: base.GetTestBucket(t),
+				CustomTestBucket: tb1,
 			})
 			defer rt1.Close()
 			ctx1 := rt1.Context()
@@ -4994,7 +5014,7 @@ func TestSendChangesToNoConflictPreHydrogenTarget(t *testing.T) {
 	errorCountBefore := base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().ErrorCount.Value()
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
+	_, tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb2,
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -5003,8 +5023,9 @@ func TestSendChangesToNoConflictPreHydrogenTarget(t *testing.T) {
 	})
 	defer rt2.Close()
 
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb1,
 	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -5159,8 +5180,9 @@ func TestReplicatorRevocations(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb1,
 	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -5214,8 +5236,9 @@ func TestReplicatorRevocationsNoRev(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb1,
 	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -5270,8 +5293,9 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb1,
 	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -5334,8 +5358,9 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb1,
 	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -5435,8 +5460,9 @@ func TestConflictResolveMergeWithMutatedRev(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb1,
 	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -5498,8 +5524,9 @@ func TestReplicatorRevocationsWithTombstoneResurrection(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb1,
 	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -5583,8 +5610,9 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb1,
 	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -5687,8 +5715,9 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
+	_, tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
+		CustomTestBucket: tb1,
 	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -5813,7 +5842,7 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	// Passive //
-	passiveBucket := base.GetTestBucket(t)
+	_, passiveBucket := base.GetTestBucket(t)
 	passiveRT := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: passiveBucket,
 		DatabaseConfig: &DatabaseConfig{
@@ -5831,7 +5860,7 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 	defer srv.Close()
 
 	// Active //
-	activeBucket := base.GetTestBucket(t)
+	_, activeBucket := base.GetTestBucket(t)
 	activeRT := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: activeBucket,
 		DatabaseConfig: &DatabaseConfig{
@@ -5915,7 +5944,7 @@ func TestUnprocessableDeltas(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	// Passive //
-	passiveBucket := base.GetTestBucket(t)
+	_, passiveBucket := base.GetTestBucket(t)
 	passiveRT := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: passiveBucket,
 		DatabaseConfig: &DatabaseConfig{
@@ -5933,7 +5962,7 @@ func TestUnprocessableDeltas(t *testing.T) {
 	defer srv.Close()
 
 	// Active //
-	activeBucket := base.GetTestBucket(t)
+	_, activeBucket := base.GetTestBucket(t)
 	activeRT := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: activeBucket,
 		DatabaseConfig: &DatabaseConfig{
@@ -6011,7 +6040,7 @@ func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	// Passive //
-	passiveBucket := base.GetTestBucket(t)
+	_, passiveBucket := base.GetTestBucket(t)
 	passiveRT := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: passiveBucket,
 	})
@@ -6022,7 +6051,7 @@ func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 	defer srv.Close()
 
 	// Active //
-	activeBucket := base.GetTestBucket(t)
+	_, activeBucket := base.GetTestBucket(t)
 	activeRT := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: activeBucket,
 	})

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -354,7 +354,7 @@ func GetBucketSpec(ctx context.Context, config *DatabaseConfig, serverConfig *St
 
 	spec.FeedType = strings.ToLower(config.FeedType)
 
-	spec.CouchbaseDriver = base.ChooseCouchbaseDriver(base.DataBucket)
+	spec.CouchbaseDriver = base.ChooseCouchbaseDriver(ctx, base.DataBucket)
 
 	if config.ViewQueryTimeoutSecs != nil {
 		spec.ViewQueryTimeoutSecs = config.ViewQueryTimeoutSecs

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1092,7 +1092,7 @@ func (sc *ServerContext) _unsuspendDatabase(ctx context.Context, dbName string) 
 		if dbConfig.Bucket != nil {
 			bucket = *dbConfig.Bucket
 		}
-		cas, err := sc.BootstrapContext.Connection.GetConfig(bucket, sc.Config.Bootstrap.ConfigGroupID, dbConfig)
+		cas, err := sc.BootstrapContext.Connection.GetConfig(ctx, bucket, sc.Config.Bootstrap.ConfigGroupID, dbConfig)
 		if err == base.ErrNotFound {
 			// Database no longer exists, so clean up dbConfigs
 			base.InfofCtx(ctx, base.KeyConfig, "Database %q has been removed while suspended from bucket %q", base.MD(dbName), base.MD(bucket))

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -285,7 +285,7 @@ func (sc *ServerContext) PostUpgrade(ctx context.Context, preview bool) (postUpg
 
 	for name, database := range sc.databases_ {
 		// View cleanup
-		removedDDocs, _ := database.RemoveObsoleteDesignDocs(preview)
+		removedDDocs, _ := database.RemoveObsoleteDesignDocs(ctx, preview)
 
 		// Index cleanup
 		var removedIndexes []string
@@ -447,7 +447,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 			return nil, indexErr
 		}
 	} else {
-		viewErr := db.InitializeViews(bucket)
+		viewErr := db.InitializeViews(ctx, bucket)
 		if viewErr != nil {
 			return nil, viewErr
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -442,7 +442,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 			return nil, errors.New("Cannot create indexes on non-Couchbase data store.")
 
 		}
-		indexErr := db.InitializeIndexes(n1qlStore, config.UseXattrs(), numReplicas, false)
+		indexErr := db.InitializeIndexes(ctx, n1qlStore, config.UseXattrs(), numReplicas, false)
 		if indexErr != nil {
 			return nil, indexErr
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -176,7 +176,7 @@ func (sc *ServerContext) Close(ctx context.Context) {
 
 	for _, db := range sc.databases_ {
 		db.Close(ctx)
-		_ = db.EventMgr.RaiseDBStateChangeEvent(db.Name, "offline", "Database context closed", &sc.Config.API.AdminInterface)
+		_ = db.EventMgr.RaiseDBStateChangeEvent(ctx, db.Name, "offline", "Database context closed", &sc.Config.API.AdminInterface)
 	}
 	sc.databases_ = nil
 
@@ -597,10 +597,10 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 
 	if base.BoolDefault(config.StartOffline, false) {
 		atomic.StoreUint32(&dbcontext.State, db.DBOffline)
-		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "offline", "DB loaded from config", &sc.Config.API.AdminInterface)
+		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(ctx, dbName, "offline", "DB loaded from config", &sc.Config.API.AdminInterface)
 	} else {
 		atomic.StoreUint32(&dbcontext.State, db.DBOnline)
-		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "online", "DB loaded from config", &sc.Config.API.AdminInterface)
+		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(ctx, dbName, "online", "DB loaded from config", &sc.Config.API.AdminInterface)
 	}
 
 	dbcontext.StartReplications(ctx)
@@ -963,7 +963,7 @@ func (sc *ServerContext) initEventHandlers(ctx context.Context, dbcontext *db.Da
 			base.WarnfCtx(ctx, "Error parsing wait_for_process from config, using default %s", err)
 		}
 	}
-	dbcontext.EventMgr.Start(config.EventHandlers.MaxEventProc, int(customWaitTime))
+	dbcontext.EventMgr.Start(ctx, config.EventHandlers.MaxEventProc, int(customWaitTime))
 
 	return nil
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -342,7 +342,7 @@ func (sc *ServerContext) getOrAddDatabaseFromConfig(ctx context.Context, config 
 
 func GetBucketSpec(ctx context.Context, config *DatabaseConfig, serverConfig *StartupConfig) (spec base.BucketSpec, err error) {
 
-	spec = config.MakeBucketSpec()
+	spec = config.MakeBucketSpec(ctx)
 
 	if serverConfig.Bootstrap.ServerTLSSkipVerify != nil {
 		spec.TLSSkipVerify = *serverConfig.Bootstrap.ServerTLSSkipVerify
@@ -849,7 +849,7 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		contextOptions.UserFunctions = config.UserFunctions
 		contextOptions.GraphQL = config.GraphQL
 	} else if config.UserQueries != nil || config.UserFunctions != nil || config.GraphQL != nil {
-		base.WarnfCtx(context.TODO(), `Database config options "queries", "functions", "graphql" ignored because unsupported.user_queries feature flag is not enabled`)
+		base.WarnfCtx(ctx, `Database config options "queries", "functions", "graphql" ignored because unsupported.user_queries feature flag is not enabled`)
 	}
 
 	return contextOptions, nil

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -430,7 +430,7 @@ func TestTLSSkipVerifyCombinations(t *testing.T) {
 				},
 			}
 
-			err := startupConfig.Validate(base.IsEnterpriseEdition())
+			err := startupConfig.Validate(base.TestCtx(t), base.IsEnterpriseEdition())
 			if test.expectError {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), errorText)
@@ -554,7 +554,7 @@ func TestUseTLSServer(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			sc := StartupConfig{Bootstrap: BootstrapConfig{Server: test.server, UseTLSServer: &test.useTLSServer}}
 
-			err := sc.Validate(base.IsEnterpriseEdition())
+			err := sc.Validate(base.TestCtx(t), base.IsEnterpriseEdition())
 
 			if test.expectedError != nil {
 				require.Error(t, err)

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -178,8 +178,8 @@ func TestServerlessSuspendDatabase(t *testing.T) {
 	}
 
 	// Get test bucket
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
+	ctx, tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
 
 	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, persistentConfig: true, serverless: true})
 	defer rt.Close()
@@ -219,7 +219,7 @@ func TestServerlessSuspendDatabase(t *testing.T) {
 	assert.NotNil(t, sc.dbConfigs["db"])
 
 	// Update config in bucket to see if unsuspending check for updates
-	cas, err := sc.BootstrapContext.Connection.UpdateConfig(tb.GetName(), sc.Config.Bootstrap.ConfigGroupID,
+	cas, err := sc.BootstrapContext.Connection.UpdateConfig(ctx, tb.GetName(), sc.Config.Bootstrap.ConfigGroupID,
 		func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
 			return json.Marshal(sc.dbConfigs["db"])
 		},
@@ -250,8 +250,8 @@ func TestServerlessUnsuspendFetchFallback(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
+	ctx, tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb,
@@ -296,8 +296,8 @@ func TestServerlessFetchConfigsLimited(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
+	ctx, tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb,
@@ -326,7 +326,7 @@ func TestServerlessFetchConfigsLimited(t *testing.T) {
 	require.NoError(t, err)
 
 	// Update database config in the bucket
-	newCas, err := sc.BootstrapContext.Connection.UpdateConfig(tb.GetName(), sc.Config.Bootstrap.ConfigGroupID,
+	newCas, err := sc.BootstrapContext.Connection.UpdateConfig(ctx, tb.GetName(), sc.Config.Bootstrap.ConfigGroupID,
 		func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
 			return json.Marshal(sc.dbConfigs["db"])
 		},
@@ -349,7 +349,7 @@ func TestServerlessFetchConfigsLimited(t *testing.T) {
 	sc.Config.Unsupported.Serverless.MinConfigFetchInterval = base.NewConfigDuration(time.Hour)
 
 	// Update database config in the bucket again to test caching disable case
-	newCas, err = sc.BootstrapContext.Connection.UpdateConfig(tb.GetName(), sc.Config.Bootstrap.ConfigGroupID,
+	newCas, err = sc.BootstrapContext.Connection.UpdateConfig(ctx, tb.GetName(), sc.Config.Bootstrap.ConfigGroupID,
 		func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
 			return json.Marshal(sc.dbConfigs["db"])
 		},
@@ -368,8 +368,8 @@ func TestServerlessUpdateSuspendedDb(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
+	ctx, tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb,
@@ -392,7 +392,7 @@ func TestServerlessUpdateSuspendedDb(t *testing.T) {
 	// Suspend the database
 	assert.NoError(t, sc.suspendDatabase(t, rt.Context(), "db"))
 	// Update database config
-	newCas, err := sc.BootstrapContext.Connection.UpdateConfig(tb.GetName(), sc.Config.Bootstrap.ConfigGroupID,
+	newCas, err := sc.BootstrapContext.Connection.UpdateConfig(ctx, tb.GetName(), sc.Config.Bootstrap.ConfigGroupID,
 		func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
 			return json.Marshal(sc.dbConfigs["db"])
 		},
@@ -455,8 +455,8 @@ func TestSuspendingFlags(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			tb := base.GetTestBucket(t)
-			defer tb.Close()
+			ctx, tb := base.GetTestBucket(t)
+			defer tb.Close(ctx)
 
 			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, persistentConfig: true, serverless: test.serverlessMode})
 			defer rt.Close()

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -19,8 +19,8 @@ func TestServerlessPollBuckets(t *testing.T) {
 	}
 
 	// Get test bucket
-	tb1 := base.GetTestBucket(t)
-	defer tb1.Close()
+	tbctx1, tb1 := base.GetTestBucket(t)
+	defer tb1.Close(tbctx1)
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1,
@@ -87,8 +87,8 @@ func TestServerlessDBSetupForceCreds(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	tb1 := base.GetTestBucket(t)
-	defer tb1.Close()
+	tbctx1, tb1 := base.GetTestBucket(t)
+	defer tb1.Close(tbctx1)
 
 	testCases := []struct {
 		name                  string
@@ -142,8 +142,8 @@ func TestServerlessBucketCredentialsFetchDatabases(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	tb1 := base.GetTestBucket(t)
-	defer tb1.Close()
+	tbctx1, tb1 := base.GetTestBucket(t)
+	defer tb1.Close(tbctx1)
 	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1, persistentConfig: true, serverless: true,
 		MutateStartupConfig: func(config *StartupConfig) {
 			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -192,7 +192,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 	}
 
 	// Allow EE-only config even in CE for testing using group IDs.
-	if err := sc.Validate(base.TestCtx(rt.tb), true); err != nil {
+	if err := sc.Validate(base.TestCtx(rt.TB), true); err != nil {
 		panic("invalid RestTester StartupConfig: " + err.Error())
 	}
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -192,7 +192,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 	}
 
 	// Allow EE-only config even in CE for testing using group IDs.
-	if err := sc.Validate(true); err != nil {
+	if err := sc.Validate(base.TestCtx(rt.tb), true); err != nil {
 		panic("invalid RestTester StartupConfig: " + err.Error())
 	}
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -110,12 +110,13 @@ func (rt *RestTester) Bucket() base.Bucket {
 	// If we have a TestBucket defined on the RestTesterConfig, use that instead of requesting a new one.
 	testBucket := rt.RestTesterConfig.CustomTestBucket
 	if testBucket == nil {
-		testBucket = base.GetTestBucket(rt.TB)
+		var ctx context.Context
+		ctx, testBucket = base.GetTestBucket(rt.TB)
 		if rt.leakyBucketConfig != nil {
 			leakyConfig := *rt.leakyBucketConfig
 			// Ignore closures to avoid double closing panics
 			leakyConfig.IgnoreClose = true
-			testBucket = testBucket.LeakyBucketClone(leakyConfig)
+			testBucket = testBucket.LeakyBucketClone(ctx, leakyConfig)
 		}
 	} else if rt.leakyBucketConfig != nil {
 		rt.TB.Fatalf("A passed in TestBucket cannot be used on the RestTester when defining a leakyBucketConfig")
@@ -450,7 +451,7 @@ func (rt *RestTester) Close() {
 		rt.RestTesterServerContext.Close(ctx)
 	}
 	if rt.TestBucket != nil {
-		rt.TestBucket.Close()
+		rt.TestBucket.Close(ctx)
 		rt.TestBucket = nil
 	}
 }

--- a/rest/view_api.go
+++ b/rest/view_api.go
@@ -38,7 +38,7 @@ func (h *handler) handleGetDesignDoc() error {
 		result = db.Body{"filters": db.Body{"bychannel": filter}}
 	} else {
 		var getErr error
-		result, getErr = h.db.GetDesignDoc(ddocID)
+		result, getErr = h.db.GetDesignDoc(h.ctx(), ddocID)
 		if getErr != nil {
 			return getErr
 		}
@@ -55,7 +55,7 @@ func (h *handler) handlePutDesignDoc() error {
 	if err != nil {
 		return err
 	}
-	if err = h.db.PutDesignDoc(ddocID, ddoc); err != nil {
+	if err = h.db.PutDesignDoc(h.ctx(), ddocID, ddoc); err != nil {
 		return err
 	}
 	h.writeStatus(http.StatusCreated, "OK")
@@ -65,7 +65,7 @@ func (h *handler) handlePutDesignDoc() error {
 // HTTP handler for DELETE _design/$ddoc
 func (h *handler) handleDeleteDesignDoc() error {
 	ddocID := h.PathVar("ddoc")
-	return h.db.DeleteDesignDoc(ddocID)
+	return h.db.DeleteDesignDoc(h.ctx(), ddocID)
 }
 
 // HTTP handler for GET _design/$ddoc/_view/$view
@@ -113,7 +113,7 @@ func (h *handler) handleView() error {
 
 	base.InfofCtx(h.ctx(), base.KeyHTTP, "JSON view %q/%q - opts %v", base.MD(ddocName), base.MD(viewName), base.MD(opts))
 
-	result, err := h.db.QueryDesignDoc(ddocName, viewName, opts)
+	result, err := h.db.QueryDesignDoc(h.ctx(), ddocName, viewName, opts)
 	if err != nil {
 		return err
 	}

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -624,22 +624,23 @@ func TestPostInstallCleanup(t *testing.T) {
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
+	ctx := rt.Context()
 
 	// Cleanup existing design docs
-	_, err := rt.GetDatabase().RemoveObsoleteDesignDocs(false)
+	_, err := rt.GetDatabase().RemoveObsoleteDesignDocs(ctx, false)
 	require.NoError(t, err)
 
 	bucket := rt.Bucket()
 	mapFunction := `function (doc, meta) { emit(); }`
 	// Create design docs in obsolete format
-	err = bucket.PutDDoc(db.DesignDocSyncGatewayPrefix, &sgbucket.DesignDoc{
+	err = bucket.PutDDoc(ctx, db.DesignDocSyncGatewayPrefix, &sgbucket.DesignDoc{
 		Views: sgbucket.ViewMap{
 			"channels": sgbucket.ViewDef{Map: mapFunction},
 		},
 	})
 	assert.NoError(t, err, "Unable to create design doc (DesignDocSyncGatewayPrefix)")
 
-	err = bucket.PutDDoc(db.DesignDocSyncHousekeepingPrefix, &sgbucket.DesignDoc{
+	err = bucket.PutDDoc(ctx, db.DesignDocSyncHousekeepingPrefix, &sgbucket.DesignDoc{
 		Views: sgbucket.ViewMap{
 			"all_docs": sgbucket.ViewDef{Map: mapFunction},
 		},


### PR DESCRIPTION
CBG-2295

Describe your PR here...
- This PR depends on update on sg-bucket and walrus, PRs:
https://github.com/couchbase/sg-bucket/pull/82
https://github.com/couchbaselabs/walrus/pull/68
- Adds loggingCtx to couchbaseHeartBeater and DCPWorker
- Leaves some context.TODOs for next round: 
-- KVStore (Update, Write, WriteCAS)
-- SubdocXattrStore (SubdocGetXattr, SubdocGetBodyAndXattr)
-- functions called from base/init() (cbgtRootCAsProvider, cbgtGetPoolsDefaultForBucket)
-- external dependencies (cbgt.RegisterPIndexImplType, cbgt.FeedType)
-- functions called from TestMain (tbpNumBuckets, tbpBucketQuotaMB)
-- GetExpiry (moved into KVStore, without ctx param)


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [x] Link upstream PRs
- [x] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/878/ (known /rest timeout)