### PR TITLE
CBG-2356 use a test name for GroupID

### DIFF
--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -181,7 +181,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 		// If running in persistent config mode, the database has to be manually created. If the db name is the same as a
 		// past tests db name, a db already exists error could happen if the past tests bucket is still flushing. Prevent this
 		// by setting the group ID as the current test bucket name by default.
-		sc.Bootstrap.ConfigGroupID = testBucket.GetName()
+		sc.Bootstrap.ConfigGroupID = rt.TB.Name()
 	}
 
 	sc.Unsupported.UserQueries = base.BoolPtr(rt.EnableUserQueries)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -13,6 +13,7 @@ package rest
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -180,8 +181,8 @@ func (rt *RestTester) Bucket() base.Bucket {
 	} else if rt.RestTesterConfig.persistentConfig {
 		// If running in persistent config mode, the database has to be manually created. If the db name is the same as a
 		// past tests db name, a db already exists error could happen if the past tests bucket is still flushing. Prevent this
-		// by setting the group ID as the current test bucket name by default.
-		sc.Bootstrap.ConfigGroupID = rt.TB.Name()
+		// by setting the group ID as the current test name by default.
+		sc.Bootstrap.ConfigGroupID = fmt.Sprintf("%x", sha256.Sum256([]byte(rt.TB.Name())))
 	}
 
 	sc.Unsupported.UserQueries = base.BoolPtr(rt.EnableUserQueries)


### PR DESCRIPTION
This allows for parametrized tests that might share a test bucket to use unique credentials, such as `TestServerlessDBSetupForceCreds`. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/877/ (fails due to #5782)