### PR TITLE
Fix collection manifest parsing

### DIFF
--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -77,7 +77,7 @@ func (il *importListener) StartImportFeed(ctx context.Context, bucket base.Bucke
 		for collName, collCtx := range dbContext.Scopes[scopeName].Collections {
 			collectionNamesByScope[scopeName] = append(collectionNamesByScope[scopeName], collName)
 
-			collID, ok := collectionManifest.GetIDForCollection(scopeName, collName)
+			collID, ok := base.GetIDForCollection(collectionManifest, scopeName, collName)
 			if !ok {
 				return fmt.Errorf("failed to find ID for collection %s.%s", base.MD(scopeName).Redact(), base.MD(collName).Redact())
 			}


### PR DESCRIPTION
Our alias for `gocbcore.Manifest` didn't carry over the custom `UnmarshalJSON` implementation. Replace it with the original `gocbcore.Manifest` and use it everywhere.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/879/