### PR TITLE
[Backport 3.0.4] CBG-2225: Backport CBG-2150: Added cluster aware functionality to the resync operation

### DIFF
--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -11,6 +11,7 @@ package db
 import (
 	"net/http"
 	"sync"
+	"testing"
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -388,10 +389,19 @@ func (b *BackgroundManager) setRunState(state BackgroundProcessState) {
 }
 
 // Currently only test
-func (b *BackgroundManager) GetRunState() BackgroundProcessState {
+func (b *BackgroundManager) GetRunState(t *testing.T) BackgroundProcessState {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 	return b.State
+}
+
+// For test use only
+// Returns empty string if background process is not cluster aware
+func (b *BackgroundManager) GetHeartbeatDocID(t *testing.T) string {
+	if b.isClusterAware() {
+		return b.clusterAwareOptions.HeartbeatDocID()
+	}
+	return ""
 }
 
 func (b *BackgroundManager) SetError(err error) {

--- a/db/database.go
+++ b/db/database.go
@@ -590,7 +590,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 		// No cleanup necessary, stop heartbeater above will take care of it
 	}
 
-	dbContext.ResyncManager = NewResyncManager()
+	dbContext.ResyncManager = NewResyncManager(bucket)
 	dbContext.TombstoneCompactionManager = NewTombstoneCompactionManager()
 	dbContext.AttachmentCompactionManager = NewAttachmentCompactionManager(bucket)
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2457,7 +2457,7 @@ func TestTombstoneCompactionStopWithManager(t *testing.T) {
 	assert.NoError(t, db.TombstoneCompactionManager.Start(map[string]interface{}{"database": db}))
 
 	waitAndAssertConditionWithOptions(t, func() bool {
-		return db.TombstoneCompactionManager.GetRunState() == BackgroundProcessStateStopped
+		return db.TombstoneCompactionManager.GetRunState(t) == BackgroundProcessStateStopped
 	}, 60, 1000)
 
 	var tombstoneCompactionStatus TombstoneManagerResponse

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -40,7 +40,7 @@ licenses/APL2.txt.
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="fc018ef7de83003867f1111968f2add63145c39c"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2ce555a2ee7ae25aa3420d96a576002d797809c8"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -3887,7 +3887,7 @@ func TestTombstoneCompaction(t *testing.T) {
 
 		err := rt.WaitForCondition(func() bool {
 			time.Sleep(1 * time.Second)
-			return rt.GetDatabase().TombstoneCompactionManager.GetRunState() == db.BackgroundProcessStateCompleted
+			return rt.GetDatabase().TombstoneCompactionManager.GetRunState(t) == db.BackgroundProcessStateCompleted
 		})
 		assert.NoError(t, err)
 


### PR DESCRIPTION
CBG-2225

- Backported CBG-2150: Added cluster aware functionality to the resync operation
- Made release branch on https://github.com/couchbaselabs/walrus with commit to allow testing of this change

- Tested resync functions locally through integration

https://github.com/couchbase/sync_gateway/pull/5781 fixes race condition in background manager code that gets triggered due to new test in this PR

## Dependencies
- [ ] https://github.com/couchbase/sync_gateway/pull/5790

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)