### PR TITLE
CBG-1893: DELETE attachment endpoint

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -434,7 +434,7 @@ New-revision:
       description: The ID of the document.
       type: string
     ok:
-      description: Wheather the request completed successfully.
+      description: Whether the request completed successfully.
       type: boolean
     rev:
       description: The revision of the document.

--- a/docs/api/paths/admin/{keyspace}~{docid}~{attach}.yaml
+++ b/docs/api/paths/admin/{keyspace}~{docid}~{attach}.yaml
@@ -164,7 +164,7 @@ delete:
       schema:
         type: string
   responses:
-    '201':
+    '200':
       description: Attachment removed from the document successfully
       headers:
         Etag:

--- a/docs/api/paths/admin/{keyspace}~{docid}~{attach}.yaml
+++ b/docs/api/paths/admin/{keyspace}~{docid}~{attach}.yaml
@@ -76,8 +76,6 @@ put:
 
     The maximum content size of an attachment is 20MB. The `Content-Type` header of the request specifies the content type of the attachment.
 
-    To remove an attachment from a document, omit the attachment in the `_attachments` object of the document in the `PUT /{db}/{docid}` request.
-
     Required Sync Gateway RBAC roles:
     * Sync Gateway Application
   parameters:
@@ -148,3 +146,44 @@ head:
     * Sync Gateway Application Read Only
   parameters:
     - $ref: ../../components/parameters.yaml#/rev
+delete:
+  summary: Delete an attachment on a document
+  description: |-
+    This request deletes an attachment associated with the document.
+
+    If the attachment exists, the attachment will be removed from the document.
+  parameters:
+    - name: Content-Type
+      in: header
+      description: The content type of the attachment.
+      schema:
+        type: string
+        default: application/octet-stream
+    - name: rev
+      in: query
+      description: The existing document revision ID to modify.
+      schema:
+        type: string
+    - name: If-Match
+      in: header
+      description: An alternative way of specifying the document revision ID.
+      schema:
+        type: string
+  responses:
+    '201':
+      description: Attachment removed from the document successfully
+      headers:
+        Etag:
+          schema:
+            type: string
+          description: The ID of the new revision.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas.yaml#/New-revision
+    '404':
+      $ref: ../../components/responses.yaml#/Not-found
+    '409':
+      $ref: ../../components/responses.yaml#/Conflict
+  tags:
+    - Document

--- a/docs/api/paths/admin/{keyspace}~{docid}~{attach}.yaml
+++ b/docs/api/paths/admin/{keyspace}~{docid}~{attach}.yaml
@@ -153,12 +153,6 @@ delete:
 
     If the attachment exists, the attachment will be removed from the document.
   parameters:
-    - name: Content-Type
-      in: header
-      description: The content type of the attachment.
-      schema:
-        type: string
-        default: application/octet-stream
     - name: rev
       in: query
       description: The existing document revision ID to modify.

--- a/docs/api/paths/public/{keyspace}~{docid}~{attach}.yaml
+++ b/docs/api/paths/public/{keyspace}~{docid}~{attach}.yaml
@@ -152,7 +152,7 @@ delete:
       schema:
         type: string
   responses:
-    '201':
+    '200':
       description: Attachment removed from the document successfully
       headers:
         Etag:

--- a/docs/api/paths/public/{keyspace}~{docid}~{attach}.yaml
+++ b/docs/api/paths/public/{keyspace}~{docid}~{attach}.yaml
@@ -141,12 +141,6 @@ delete:
 
     If the attachment exists, the attachment will be removed from the document.
   parameters:
-    - name: Content-Type
-      in: header
-      description: The content type of the attachment.
-      schema:
-        type: string
-        default: application/octet-stream
     - name: rev
       in: query
       description: The existing document revision ID to modify.

--- a/docs/api/paths/public/{keyspace}~{docid}~{attach}.yaml
+++ b/docs/api/paths/public/{keyspace}~{docid}~{attach}.yaml
@@ -71,8 +71,6 @@ put:
     If the attachment already exists, the data of the existing attachment will be replaced in the new revision.
 
     The maximum content size of an attachment is 20MB. The `Content-Type` header of the request specifies the content type of the attachment.
-
-    To remove an attachment from a document, omit the attachment in the `_attachments` object of the document in the `PUT /{db}/{docid}` request.
   parameters:
     - name: Content-Type
       in: header
@@ -136,3 +134,44 @@ head:
   description: This request check if the attachment exists on the specified document.
   parameters:
     - $ref: ../../components/parameters.yaml#/rev
+delete:
+  summary: Delete an attachment on a document
+  description: |-
+    This request deletes an attachment associated with the document.
+
+    If the attachment exists, the attachment will be removed from the document.
+  parameters:
+    - name: Content-Type
+      in: header
+      description: The content type of the attachment.
+      schema:
+        type: string
+        default: application/octet-stream
+    - name: rev
+      in: query
+      description: The existing document revision ID to modify.
+      schema:
+        type: string
+    - name: If-Match
+      in: header
+      description: An alternative way of specifying the document revision ID.
+      schema:
+        type: string
+  responses:
+    '201':
+      description: Attachment removed from the document successfully
+      headers:
+        Etag:
+          schema:
+            type: string
+          description: The ID of the new revision.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas.yaml#/New-revision
+    '404':
+      $ref: ../../components/responses.yaml#/Not-found
+    '409':
+      $ref: ../../components/responses.yaml#/Conflict
+  tags:
+    - Document

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -256,6 +256,10 @@ func TestDocAttachment(t *testing.T) {
 	assert.Equal(t, "bytes 5-6/30", response.Header().Get("Content-Range"))
 	assert.Equal(t, attachmentContentType, response.Header().Get("Content-Type"))
 
+	// attempt to delete an attachment that is not on the document
+	response = rt.SendRequestWithHeaders("DELETE", "/db/doc/attach2?rev="+revid, "", reqHeaders)
+	RequireStatus(t, response, 404)
+
 	// delete the attachment calling the delete attachment endpoint
 	response = rt.SendRequestWithHeaders("DELETE", "/db/doc/attach1?rev="+revid, "", reqHeaders)
 	RequireStatus(t, response, 201)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -260,9 +260,17 @@ func TestDocAttachment(t *testing.T) {
 	response = rt.SendRequest("DELETE", "/db/doc/attach2?rev="+revid, "")
 	RequireStatus(t, response, 404)
 
+	// attempt to delete attachment from non existing doc
+	response = rt.SendRequest("DELETE", "/db/doc1/attach1?rev=1-xzy", "")
+	RequireStatus(t, response, 404)
+
+	// attempt to delete attachment using incorrect revid
+	response = rt.SendRequest("DELETE", "/db/doc/attach1?rev=1-xzy", "")
+	RequireStatus(t, response, 409)
+
 	// delete the attachment calling the delete attachment endpoint
 	response = rt.SendRequest("DELETE", "/db/doc/attach1?rev="+revid, "")
-	RequireStatus(t, response, 201)
+	RequireStatus(t, response, 200)
 
 	// attempt to access deleted attachment (should return error)
 	response = rt.SendRequest("GET", "/db/doc/attach1", "")

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -257,11 +257,11 @@ func TestDocAttachment(t *testing.T) {
 	assert.Equal(t, attachmentContentType, response.Header().Get("Content-Type"))
 
 	// attempt to delete an attachment that is not on the document
-	response = rt.SendRequestWithHeaders("DELETE", "/db/doc/attach2?rev="+revid, "", reqHeaders)
+	response = rt.SendRequest("DELETE", "/db/doc/attach2?rev="+revid, "")
 	RequireStatus(t, response, 404)
 
 	// delete the attachment calling the delete attachment endpoint
-	response = rt.SendRequestWithHeaders("DELETE", "/db/doc/attach1?rev="+revid, "", reqHeaders)
+	response = rt.SendRequest("DELETE", "/db/doc/attach1?rev="+revid, "")
 	RequireStatus(t, response, 201)
 
 	// attempt to access deleted attachment (should return error)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -235,6 +235,8 @@ func TestDocAttachment(t *testing.T) {
 	// attach to existing document with correct rev (should succeed)
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc/attach1?rev="+revid, attachmentBody, reqHeaders)
 	RequireStatus(t, response, 201)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
+	revid = body["rev"].(string)
 
 	// retrieve attachment
 	response = rt.SendRequest("GET", "/db/doc/attach1", "")
@@ -253,6 +255,14 @@ func TestDocAttachment(t *testing.T) {
 	assert.Equal(t, "2", response.Header().Get("Content-Length"))
 	assert.Equal(t, "bytes 5-6/30", response.Header().Get("Content-Range"))
 	assert.Equal(t, attachmentContentType, response.Header().Get("Content-Type"))
+
+	// delete the attachment calling the delete attachment endpoint
+	response = rt.SendRequestWithHeaders("DELETE", "/db/doc/attach1?rev="+revid, "", reqHeaders)
+	RequireStatus(t, response, 201)
+
+	// attempt to access deleted attachment (should return error)
+	response = rt.SendRequest("GET", "/db/doc/attach1", "")
+	RequireStatus(t, response, 404)
 }
 
 func TestDocAttachmentMetaOption(t *testing.T) {

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -375,6 +375,10 @@ func (h *handler) handleDeleteAttachment() error {
 	body, err := h.db.Get1xRevBody(h.ctx(), docid, revid, false, nil)
 	if err != nil {
 		if base.IsDocNotFoundError(err) {
+			// Check here if error is relating to incorrect revid, if so return 409 code else return 404 code
+			if strings.Contains(err.Error(), "404 missing") {
+				return base.HTTPErrorf(http.StatusConflict, "Incorrect revision ID specified")
+			}
 			// Need to return an error if a document is not found
 			return base.HTTPErrorf(http.StatusNotFound, "Document specified is not found")
 		} else if err != nil {
@@ -403,7 +407,7 @@ func (h *handler) handleDeleteAttachment() error {
 	}
 	h.setEtag(newRev)
 
-	h.writeRawJSONStatus(http.StatusCreated, []byte(`{"id":`+base.ConvertToJSONString(docid)+`,"ok":true,"rev":"`+newRev+`"}`))
+	h.writeRawJSONStatus(http.StatusOK, []byte(`{"id":`+base.ConvertToJSONString(docid)+`,"ok":true,"rev":"`+newRev+`"}`))
 
 	return nil
 }

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -363,10 +363,6 @@ func (h *handler) handleDeleteAttachment() error {
 
 	docid := h.PathVar("docid")
 	attachmentName := h.PathVar("attach")
-	attachmentContentType := h.rq.Header.Get("Content-Type")
-	if attachmentContentType == "" {
-		attachmentContentType = "application/octet-stream"
-	}
 	revid := h.getQuery("rev")
 	if revid == "" {
 		var err error

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -380,7 +380,7 @@ func (h *handler) handleDeleteAttachment() error {
 	if err != nil {
 		if base.IsDocNotFoundError(err) {
 			// Need to return an error if a document is not found
-			base.HTTPErrorf(http.StatusNotFound, "Document specified is not found")
+			return base.HTTPErrorf(http.StatusNotFound, "Document specified is not found")
 		} else if err != nil {
 			return err
 		}

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -392,8 +392,12 @@ func (h *handler) handleDeleteAttachment() error {
 		}
 	}
 
-	// get document attachments and delete specified attachment from the map
+	// get document attachments and check if attachment exists
 	attachments := db.GetBodyAttachments(body)
+	if _, ok := attachments[attachmentName]; !ok {
+		return base.HTTPErrorf(http.StatusNotFound, "Attachment %s is not found", attachmentName)
+	}
+	// delete specified attachment from the map
 	delete(attachments, attachmentName)
 	body[db.BodyAttachments] = attachments
 

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -55,6 +55,7 @@ func createCommonRouter(sc *ServerContext, privs handlerPrivs) (root, db, keyspa
 
 	keyspace.Handle("/{docid:"+docRegex+"}/{attach}", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleGetAttachment)).Methods("GET", "HEAD")
 	keyspace.Handle("/{docid:"+docRegex+"}/{attach}", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handlePutAttachment)).Methods("PUT")
+	keyspace.Handle("/{docid:"+docRegex+"}/{attach}", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handleDeleteAttachment)).Methods("DELETE")
 
 	keyspace.Handle("/_local/{docid}", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleGetLocalDoc)).Methods("GET", "HEAD")
 	keyspace.Handle("/_local/{docid}", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handlePutLocalDoc)).Methods("PUT")


### PR DESCRIPTION

CBG-1893

- Added a new DELETE endpoint to give the functionality to delete an attachment from a document without going through the PUT attachment endpoint
- Added some more functionality to the existing test for testing document attachments
- Updated the api documentation to reflect the changes being made to the endpoints

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/886/