### PR TITLE
CBG-2434: Made running the RestTester with persistent config always use a unique group ID

### DIFF
--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -52,7 +52,7 @@ func TestServerlessPollBuckets(t *testing.T) {
 	assert.Empty(t, configs)
 
 	// Create a database
-	rt2 := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1, persistentConfig: true})
+	rt2 := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1, persistentConfig: true, groupID: &sc.Config.Bootstrap.ConfigGroupID})
 	defer rt2.Close()
 	// Create a new db on the RT to confirm fetch won't retrieve it (due to bucket not being in BucketCredentials)
 	resp := rt2.SendAdminRequest(http.MethodPut, "/db/", fmt.Sprintf(`{

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -27,14 +27,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
-
 	"github.com/couchbase/go-blip"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -13,7 +13,6 @@ package rest
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -183,7 +182,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 		// If running in persistent config mode, the database has to be manually created. If the db name is the same as a
 		// past tests db name, a db already exists error could happen if the past tests bucket is still flushing. Prevent this
 		// by using a unique group ID for each new rest tester.
-		sc.Bootstrap.ConfigGroupID = fmt.Sprintf("%x-%d", sha256.Sum256([]byte(rt.TB.Name()+rt.TestBucket.GetName())), rand.Uint64())
+		sc.Bootstrap.ConfigGroupID = fmt.Sprintf("%d-%d-%d", rand.Uint64(), rand.Uint64(), rand.Uint64())
 	}
 
 	sc.Unsupported.UserQueries = base.BoolPtr(rt.EnableUserQueries)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -181,8 +182,8 @@ func (rt *RestTester) Bucket() base.Bucket {
 	} else if rt.RestTesterConfig.persistentConfig {
 		// If running in persistent config mode, the database has to be manually created. If the db name is the same as a
 		// past tests db name, a db already exists error could happen if the past tests bucket is still flushing. Prevent this
-		// by setting the group ID as the current test name by default.
-		sc.Bootstrap.ConfigGroupID = fmt.Sprintf("%x", sha256.Sum256([]byte(rt.TB.Name())))
+		// by using a unique group ID for each new rest tester.
+		sc.Bootstrap.ConfigGroupID = fmt.Sprintf("%x-%d", sha256.Sum256([]byte(rt.TB.Name()+rt.TestBucket.GetName())), rand.Uint64())
 	}
 
 	sc.Unsupported.UserQueries = base.BoolPtr(rt.EnableUserQueries)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -27,6 +26,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/couchbase/go-blip"
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -182,7 +183,11 @@ func (rt *RestTester) Bucket() base.Bucket {
 		// If running in persistent config mode, the database has to be manually created. If the db name is the same as a
 		// past tests db name, a db already exists error could happen if the past tests bucket is still flushing. Prevent this
 		// by using a unique group ID for each new rest tester.
-		sc.Bootstrap.ConfigGroupID = fmt.Sprintf("%d-%d-%d", rand.Uint64(), rand.Uint64(), rand.Uint64())
+		uniqueUUID, err := uuid.NewRandom()
+		if err != nil {
+			rt.TB.Fatalf("Could not generate random config group ID UUID: %v", err)
+		}
+		sc.Bootstrap.ConfigGroupID = uniqueUUID.String()
 	}
 
 	sc.Unsupported.UserQueries = base.BoolPtr(rt.EnableUserQueries)


### PR DESCRIPTION
CBG-2434

CBG-2356 (https://github.com/couchbase/sync_gateway/pull/5778) made the rest tester use the test name as the group ID when running in persistent config mode. A problem that occurred due to this (and when using the bucket name) is running the same test with a high count would still cause the duplicate database error due to buckets not finishing flushing that have a database with the same group ID and name. More documented about the issue in CBG-2388.

This PR makes the group ID uses 3 random uint64s.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/904/