### PR TITLE
fix test failure, since scope and collection are created by bucket pool

### DIFF
--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -63,7 +63,6 @@ type RestTesterConfig struct {
 	useTLSServer                    bool // If true, TLS will be required for communications with CBS. Default: false
 	persistentConfig                bool
 	groupID                         *string
-	createScopesAndCollections      bool // If true, will automatically create any defined scopes and collections on startup.
 	serverless                      bool // Runs SG in serverless mode. Must be used in conjunction with persistent config
 }
 


### PR DESCRIPTION
- explicitly create scope/collection
- require xattrs for import test
- remove debug logging

Fixup for CBG-2400 + CBG-2313

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/893/ (fails with known issue)