### PR TITLE
CBD-5062: platform introspection fixes

### DIFF
--- a/service/sync_gateway_service_install.sh
+++ b/service/sync_gateway_service_install.sh
@@ -55,8 +55,12 @@ ostype() {
     OS=$(echo "${ID}" | sed "s/.*/\u&/")
     if [ "${OS}" = "Rhel" ]; then
       OS=RedHat
+      VER=$VERSION_ID
     elif [ "${OS}" = "Debian" ]; then
       VER=$(cat /etc/debian_version)
+    elif [ "${OS}" = "Centos" ]; then
+      OS=CentOS
+      VER=$VERSION_ID
     else
       VER=$VERSION_ID
     fi
@@ -288,7 +292,7 @@ RedHat* | CentOS | OracleServer)
     ;;
   esac
   ;;
-Amazon*)
+Amzn*)
   case $OS_MAJOR_VERSION in
   2)
   if [ "$SERVICE_CMD_ONLY" = true ]; then

--- a/service/sync_gateway_service_install.sh
+++ b/service/sync_gateway_service_install.sh
@@ -52,23 +52,17 @@ ostype() {
     VER=$(lsb_release -sr)
   elif [ -f /etc/os-release ]; then
     . /etc/os-release
-    OS=$(echo "${ID}" | sed "s/.*/\u&/")
-    if [ "${OS}" = "Rhel" ]; then
-      OS=RedHat
-      VER=$VERSION_ID
-    elif [ "${OS}" = "Debian" ]; then
+    OS=$(echo "${ID}")
+    if [ "${OS}" = "debian" ]; then
       VER=$(cat /etc/debian_version)
-    elif [ "${OS}" = "Centos" ]; then
-      OS=CentOS
-      VER=$VERSION_ID
     else
       VER=$VERSION_ID
     fi
   elif [ -f /etc/redhat-release ]; then
-    OS=RedHat
+    OS=rhel
     VER=$(cat /etc/redhat-release | sed s/.*release\ // | sed s/\ .*//)
   elif [ -f /etc/system-release ]; then
-    OS=RedHat
+    OS=rhel
     VER=5.0
   else
     OS=$(uname -s)
@@ -204,7 +198,7 @@ done
 
 #Install the service for the specific platform
 case $OS in
-Debian)
+debian)
   case 1:${OS_MAJOR_VERSION:--} in
   $((OS_MAJOR_VERSION >= 8))*)
     if [ "$SERVICE_CMD_ONLY" = true ]; then
@@ -219,7 +213,7 @@ Debian)
     ;;
   esac
   ;;
-Ubuntu)
+ubuntu)
   case 1:${OS_MAJOR_VERSION:--} in
   $((OS_MAJOR_VERSION >= 16))*)
     if [ "$SERVICE_CMD_ONLY" = true ]; then
@@ -247,7 +241,7 @@ Ubuntu)
     ;;
   esac
   ;;
-RedHat* | CentOS | OracleServer)
+RedHat* | rhel* | centos | ol)
   case $OS_MAJOR_VERSION in
   5)
     if [ "$SERVICE_CMD_ONLY" = true ]; then
@@ -292,7 +286,7 @@ RedHat* | CentOS | OracleServer)
     ;;
   esac
   ;;
-Amzn*)
+amzn*)
   case $OS_MAJOR_VERSION in
   2)
   if [ "$SERVICE_CMD_ONLY" = true ]; then

--- a/service/sync_gateway_service_uninstall.sh
+++ b/service/sync_gateway_service_uninstall.sh
@@ -41,23 +41,17 @@ ostype() {
     VER=$(lsb_release -sr)
   elif [ -f /etc/os-release ]; then
     . /etc/os-release
-    OS=$(echo "${ID}" | sed "s/.*/\u&/")
-    if [ "${OS}" = "Rhel" ]; then
-      OS=RedHat
-      VER=$VERSION_ID
-    elif [ "${OS}" = "Debian" ]; then
+    OS=$(echo "${ID}")
+    if [ "${OS}" = "debian" ]; then
       VER=$(cat /etc/debian_version)
-    elif [ "${OS}" = "Centos" ]; then
-      OS=CentOS
-      VER=$VERSION_ID
     else
       VER=$VERSION_ID
     fi
   elif [ -f /etc/redhat-release ]; then
-    OS=RedHat
+    OS=rhel
     VER=$(cat /etc/redhat-release | sed s/.*release\ // | sed s/\ .*//)
   elif [ -f /etc/system-release ]; then
-    OS=RedHat
+    OS=rhel
     VER=5.0
   else
     OS=$(uname -s)
@@ -67,6 +61,7 @@ ostype() {
   OS_MAJOR_VERSION=$(echo $VER | sed 's/\..*$//')
   OS_MINOR_VERSION=$(echo $VER | sed s/[0-9]*\.//)
 }
+
 #
 #script starts here
 #
@@ -89,7 +84,7 @@ fi
 
 #Install the service for the specific platform
 case $OS in
-Debian)
+debian)
   case 1:${OS_MAJOR_VERSION:--} in
   $((OS_MAJOR_VERSION >= 8))*)
     systemctl stop ${SERVICE_NAME}
@@ -101,7 +96,7 @@ Debian)
     ;;
   esac
   ;;
-Ubuntu)
+ubuntu)
   case 1:${OS_MAJOR_VERSION:--} in
   $((OS_MAJOR_VERSION >= 16))*)
     systemctl stop ${SERVICE_NAME}
@@ -124,7 +119,7 @@ Ubuntu)
     ;;
   esac
   ;;
-RedHat* | CentOS | OracleServer)
+RedHat* | rhel* | centos | ol)
   case $OS_MAJOR_VERSION in
   5)
     PATH=/usr/kerberos/sbin:/usr/kerberos/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
@@ -157,7 +152,7 @@ RedHat* | CentOS | OracleServer)
     ;;
   esac
   ;;
-Amzn*)
+amzn*)
   case $OS_MAJOR_VERSION in
   2)
     systemctl stop ${SERVICE_NAME}

--- a/service/sync_gateway_service_uninstall.sh
+++ b/service/sync_gateway_service_uninstall.sh
@@ -44,8 +44,12 @@ ostype() {
     OS=$(echo "${ID}" | sed "s/.*/\u&/")
     if [ "${OS}" = "Rhel" ]; then
       OS=RedHat
+      VER=$VERSION_ID
     elif [ "${OS}" = "Debian" ]; then
       VER=$(cat /etc/debian_version)
+    elif [ "${OS}" = "Centos" ]; then
+      OS=CentOS
+      VER=$VERSION_ID
     else
       VER=$VERSION_ID
     fi
@@ -63,7 +67,6 @@ ostype() {
   OS_MAJOR_VERSION=$(echo $VER | sed 's/\..*$//')
   OS_MINOR_VERSION=$(echo $VER | sed s/[0-9]*\.//)
 }
-
 #
 #script starts here
 #
@@ -154,7 +157,7 @@ RedHat* | CentOS | OracleServer)
     ;;
   esac
   ;;
-Amazon*)
+Amzn*)
   case $OS_MAJOR_VERSION in
   2)
     systemctl stop ${SERVICE_NAME}

--- a/service/sync_gateway_service_upgrade.sh
+++ b/service/sync_gateway_service_upgrade.sh
@@ -41,23 +41,17 @@ ostype() {
     VER=$(lsb_release -sr)
   elif [ -f /etc/os-release ]; then
     . /etc/os-release
-    OS=$(echo "${ID}" | sed "s/.*/\u&/")
-    if [ "${OS}" = "Rhel" ]; then
-      OS=RedHat
-      VER=$VERSION_ID
-    elif [ "${OS}" = "Debian" ]; then
+    OS=$(echo "${ID}")
+    if [ "${OS}" = "debian" ]; then
       VER=$(cat /etc/debian_version)
-    elif [ "${OS}" = "Centos" ]; then
-      OS=CentOS
-      VER=$VERSION_ID
     else
       VER=$VERSION_ID
     fi
   elif [ -f /etc/redhat-release ]; then
-    OS=RedHat
+    OS=rhel
     VER=$(cat /etc/redhat-release | sed s/.*release\ // | sed s/\ .*//)
   elif [ -f /etc/system-release ]; then
-    OS=RedHat
+    OS=rhel
     VER=5.0
   else
     OS=$(uname -s)
@@ -90,7 +84,7 @@ fi
 
 #Install the service for the specific platform
 case $OS in
-Debian)
+debian)
   case 1:${OS_MAJOR_VERSION:--} in
   $((OS_MAJOR_VERSION >= 8))*)
     systemctl stop ${SERVICE_NAME}
@@ -98,7 +92,7 @@ Debian)
     ;;
   esac
   ;;
-Ubuntu)
+ubuntu)
   case 1:${OS_MAJOR_VERSION:--} in
   $((OS_MAJOR_VERSION >= 16))*)
     systemctl stop ${SERVICE_NAME}
@@ -115,7 +109,7 @@ Ubuntu)
     ;;
   esac
   ;;
-RedHat* | CentOS | OracleServer)
+RedHat* | rhel* | centos | ol)
   case $OS_MAJOR_VERSION in
   5)
     PATH=/usr/kerberos/sbin:/usr/kerberos/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
@@ -137,7 +131,7 @@ RedHat* | CentOS | OracleServer)
     ;;
   esac
   ;;
-Amzn*)
+amzn*)
   case $OS_MAJOR_VERSION in
   2)
     systemctl stop ${SERVICE_NAME}

--- a/service/sync_gateway_service_upgrade.sh
+++ b/service/sync_gateway_service_upgrade.sh
@@ -44,8 +44,12 @@ ostype() {
     OS=$(echo "${ID}" | sed "s/.*/\u&/")
     if [ "${OS}" = "Rhel" ]; then
       OS=RedHat
+      VER=$VERSION_ID
     elif [ "${OS}" = "Debian" ]; then
       VER=$(cat /etc/debian_version)
+    elif [ "${OS}" = "Centos" ]; then
+      OS=CentOS
+      VER=$VERSION_ID
     else
       VER=$VERSION_ID
     fi
@@ -133,7 +137,7 @@ RedHat* | CentOS | OracleServer)
     ;;
   esac
   ;;
-Amazon*)
+Amzn*)
   case $OS_MAJOR_VERSION in
   2)
     systemctl stop ${SERVICE_NAME}


### PR DESCRIPTION
CBD-5062

Describe your PR here...
There was disparity between detected Centos and CentOS which caused issues in build 340, this PR simplifies things by leaving cases unchanged and comparing against lower case distro names, also fixes names for amazonlinux and oel.

## Pre-review checklist
- [n/a] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [n/a] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [n/a] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [n/a] Link upstream PRs
- [n/a] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/