### PR TITLE
CBG-2417: Investigate usages of prometheus.MustRegister

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -1733,7 +1733,7 @@ func (d *DbStats) InitQueryStats(useViews bool, queryNames ...string) error {
 	for _, queryName := range queryNames {
 		err := d._initQueryStat(useViews, queryName)
 		if err != nil {
-			return nil
+			return err
 		}
 	}
 	d.QueryStats.mutex.Unlock()

--- a/base/stats.go
+++ b/base/stats.go
@@ -103,11 +103,11 @@ func init() {
 	// Initialize Sync Gateway Stats
 
 	// All stats will be stored as part of this struct. Global variable accessible everywhere. To add stats see stats.go
-	sgwStats, err := NewSyncGatewayStats()
+	var err error
+	SyncGatewayStats, err = NewSyncGatewayStats()
 	if err != nil {
-		log.Fatalf("Fatal error: %v", err)
+		log.Fatalf("Fatal error attempting to instantiate sync gateway stats: %v", err)
 	}
-	SyncGatewayStats = sgwStats
 
 	// Publish our stats to expvars. This will run String method on SyncGatewayStats ( type SgwStats ) which will
 	// marshal the stats to JSON
@@ -228,11 +228,7 @@ func (s *SgwStats) initReplicationStats() error {
 	s.ReplicatorStats = &ReplicatorStats{
 		new(expvar.Map).Init(),
 	}
-	err := prometheus.Register(s.ReplicatorStats)
-	if err != nil {
-		return err
-	}
-	return nil
+	return prometheus.Register(s.ReplicatorStats)
 }
 
 func (s *SgwStats) ReplicationStats() *expvar.Map {
@@ -884,21 +880,18 @@ func (s *SgwStats) NewDBStats(name string, deltaSyncEnabled bool, importEnabled 
 	}
 
 	if viewsEnabled {
-		err := s.DbStats[name].InitQueryStats(
+		err = s.DbStats[name].InitQueryStats(
 			true,
 			queryNames...,
 		)
-		if err != nil {
-			return nil, err
-		}
 	} else {
-		err := s.DbStats[name].InitQueryStats(
+		err = s.DbStats[name].InitQueryStats(
 			false,
 			queryNames...,
 		)
-		if err != nil {
-			return nil, err
-		}
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	return s.DbStats[name], nil

--- a/base/stats.go
+++ b/base/stats.go
@@ -884,15 +884,21 @@ func (s *SgwStats) NewDBStats(name string, deltaSyncEnabled bool, importEnabled 
 	}
 
 	if viewsEnabled {
-		s.DbStats[name].InitQueryStats(
+		err := s.DbStats[name].InitQueryStats(
 			true,
 			queryNames...,
 		)
+		if err != nil {
+			return nil, err
+		}
 	} else {
-		s.DbStats[name].InitQueryStats(
+		err := s.DbStats[name].InitQueryStats(
 			false,
 			queryNames...,
 		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return s.DbStats[name], nil
@@ -1719,15 +1725,19 @@ func (d *DbStats) SharedBucketImport() *SharedBucketImportStats {
 	return d.SharedBucketImportStats
 }
 
-func (d *DbStats) InitQueryStats(useViews bool, queryNames ...string) {
+func (d *DbStats) InitQueryStats(useViews bool, queryNames ...string) error {
 	d.QueryStats = &QueryStats{
 		Stats: map[string]*QueryStat{},
 	}
 	d.QueryStats.mutex.Lock()
 	for _, queryName := range queryNames {
-		d._initQueryStat(useViews, queryName)
+		err := d._initQueryStat(useViews, queryName)
+		if err != nil {
+			return nil
+		}
 	}
 	d.QueryStats.mutex.Unlock()
+	return nil
 }
 
 func (d *DbStats) _initQueryStat(useViews bool, queryName string) error {

--- a/base/stats_test.go
+++ b/base/stats_test.go
@@ -14,6 +14,8 @@ import (
 	"expvar"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -65,7 +67,8 @@ func BenchmarkExpvarAddParallel(b *testing.B) {
 }
 
 func BenchmarkNewStatsMarshal(b *testing.B) {
-	sgwStats := NewSyncGatewayStats()
+	sgwStats, err := NewSyncGatewayStats()
+	require.NoError(b, err)
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -74,7 +77,8 @@ func BenchmarkNewStatsMarshal(b *testing.B) {
 }
 
 func BenchmarkNewStatAdd(b *testing.B) {
-	sgwStats := NewSyncGatewayStats()
+	sgwStats, err := NewSyncGatewayStats()
+	require.NoError(b, err)
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -83,7 +87,8 @@ func BenchmarkNewStatAdd(b *testing.B) {
 }
 
 func BenchmarkNewStatSet(b *testing.B) {
-	sgwStats := NewSyncGatewayStats()
+	sgwStats, err := NewSyncGatewayStats()
+	require.NoError(b, err)
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -92,7 +97,8 @@ func BenchmarkNewStatSet(b *testing.B) {
 }
 
 func BenchmarkNewStatGet(b *testing.B) {
-	sgwStats := NewSyncGatewayStats()
+	sgwStats, err := NewSyncGatewayStats()
+	require.NoError(b, err)
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -101,7 +107,8 @@ func BenchmarkNewStatGet(b *testing.B) {
 }
 
 func BenchmarkNewStatAddParallel(b *testing.B) {
-	sgwStats := NewSyncGatewayStats()
+	sgwStats, err := NewSyncGatewayStats()
+	require.NoError(b, err)
 
 	test := sgwStats.GlobalStats.ResourceUtilizationStats()
 	b.ResetTimer()
@@ -114,7 +121,8 @@ func BenchmarkNewStatAddParallel(b *testing.B) {
 }
 
 func TestSetIfMax(t *testing.T) {
-	sgwStats := NewSyncGatewayStats()
+	sgwStats, err := NewSyncGatewayStats()
+	require.NoError(t, err)
 
 	// Test an integer
 	sgwStats.GlobalStats.ResourceUtilization.ErrorCount.Set(10)

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -117,10 +117,12 @@ func TestLateSequenceHandling(t *testing.T) {
 	context, ctx := setupTestDBWithCacheOptions(t, DefaultCacheOptions())
 	defer context.Close(ctx)
 
-	stats := base.NewSyncGatewayStats()
-	cacheStats := stats.NewDBStats("", false, false, false).CacheStats
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
 
-	cache := newSingleChannelCache(context, "Test1", 0, cacheStats)
+	cache := newSingleChannelCache(context, "Test1", 0, dbstats.CacheStats)
 	assert.True(t, cache != nil)
 
 	// Empty late sequence cache should return empty set
@@ -188,10 +190,12 @@ func TestLateSequenceHandlingWithMultipleListeners(t *testing.T) {
 	require.NoError(t, err)
 	defer context.Close(ctx)
 
-	stats := base.NewSyncGatewayStats()
-	cacheStats := stats.NewDBStats("", false, false, false).CacheStats
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
 
-	cache := newSingleChannelCache(context, "Test1", 0, cacheStats)
+	cache := newSingleChannelCache(context, "Test1", 0, dbstats.CacheStats)
 	assert.True(t, cache != nil)
 
 	// Add Listener before late entries arrive

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -39,7 +39,7 @@ func TestDuplicateDocID(t *testing.T) {
 	require.NoError(t, err)
 
 	cache := newSingleChannelCache(context, "Test1", 0, dbstats.Cache())
-	assert.True(t, cache != nil)
+	assert.NotNil(t, cache)
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
@@ -94,7 +94,7 @@ func TestLateArrivingSequence(t *testing.T) {
 	require.NoError(t, err)
 
 	cache := newSingleChannelCache(context, "Test1", 0, dbstats.Cache())
-	assert.True(t, cache != nil)
+	assert.NotNil(t, cache)
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
@@ -135,7 +135,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	require.NoError(t, err)
 
 	cache := newSingleChannelCache(context, "Test1", 0, dbstats.Cache())
-	assert.True(t, cache != nil)
+	assert.NotNil(t, cache)
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(5, "doc1", "1-a"), false)
@@ -176,7 +176,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	require.NoError(t, err)
 
 	cache := newSingleChannelCache(context, "Test1", 0, dbstats.Cache())
-	assert.True(t, cache != nil)
+	assert.NotNil(t, cache)
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(10, "doc1", "1-a"), false)
@@ -259,7 +259,7 @@ func TestPrependChanges(t *testing.T) {
 	require.NoError(t, err)
 
 	cache := newSingleChannelCache(dbCtx, "PrependEmptyCache", 0, dbstats.Cache())
-	assert.True(t, cache != nil)
+	assert.NotNil(t, cache)
 
 	changesToPrepend := LogEntries{
 		testLogEntry(10, "doc3", "2-a"),
@@ -276,6 +276,10 @@ func TestPrependChanges(t *testing.T) {
 	require.Len(t, cachedChanges, 3)
 
 	// 2. Test prepend to populated cache, with overlap and duplicates
+	stats, err = base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err = stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
 	cache = newSingleChannelCache(dbCtx, "PrependPopulatedCache", 0, dbstats.Cache())
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
@@ -330,6 +334,10 @@ func TestPrependChanges(t *testing.T) {
 	require.Len(t, cachedChanges, 4)
 
 	// 3. Test prepend that exceeds cache capacity
+	stats, err = base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err = stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
 	cache = newSingleChannelCache(dbCtx, "PrependToFillCache", 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13
@@ -367,6 +375,10 @@ func TestPrependChanges(t *testing.T) {
 	}
 
 	// 4. Test prepend where all docids are already present in cache.  Cache entries shouldn't change, but validFrom is updated
+	stats, err = base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err = stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
 	cache = newSingleChannelCache(dbCtx, "PrependDuplicatesOnly", 0, dbstats.Cache())
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
@@ -397,6 +409,10 @@ func TestPrependChanges(t *testing.T) {
 	}
 
 	// 5. Test prepend for an already full cache
+	stats, err = base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err = stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
 	cache = newSingleChannelCache(dbCtx, "PrependFullCache", 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -277,7 +277,6 @@ func TestPrependChanges(t *testing.T) {
 
 	// 2. Test prepend to populated cache, with overlap and duplicates
 	cache = newSingleChannelCache(dbCtx, "PrependPopulatedCache", 0, dbstats.Cache())
-	//cache = newSingleChannelCache(dbCtx, "PrependPopulatedCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
 	cache.addToCache(testLogEntry(20, "doc2", "3-a"), false)
@@ -331,7 +330,6 @@ func TestPrependChanges(t *testing.T) {
 	require.Len(t, cachedChanges, 4)
 
 	// 3. Test prepend that exceeds cache capacity
-	//cache = newSingleChannelCache(dbCtx, "PrependToFillCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	cache = newSingleChannelCache(dbCtx, "PrependToFillCache", 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13
@@ -369,7 +367,6 @@ func TestPrependChanges(t *testing.T) {
 	}
 
 	// 4. Test prepend where all docids are already present in cache.  Cache entries shouldn't change, but validFrom is updated
-	//cache = newSingleChannelCache(dbCtx, "PrependDuplicatesOnly", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	cache = newSingleChannelCache(dbCtx, "PrependDuplicatesOnly", 0, dbstats.Cache())
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
@@ -400,7 +397,6 @@ func TestPrependChanges(t *testing.T) {
 	}
 
 	// 5. Test prepend for an already full cache
-	//cache = newSingleChannelCache(dbCtx, "PrependFullCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	cache = newSingleChannelCache(dbCtx, "PrependFullCache", 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -32,7 +32,14 @@ func TestDuplicateDocID(t *testing.T) {
 	require.NoError(t, err)
 	defer context.Close(ctx)
 
-	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
+
+	cache := newSingleChannelCache(context, "Test1", 0, dbstats.Cache())
+	assert.True(t, cache != nil)
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
@@ -80,7 +87,14 @@ func TestLateArrivingSequence(t *testing.T) {
 	require.NoError(t, err)
 	defer context.Close(ctx)
 
-	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
+
+	cache := newSingleChannelCache(context, "Test1", 0, dbstats.Cache())
+	assert.True(t, cache != nil)
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
@@ -114,7 +128,14 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	require.NoError(t, err)
 	defer context.Close(ctx)
 
-	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
+
+	cache := newSingleChannelCache(context, "Test1", 0, dbstats.Cache())
+	assert.True(t, cache != nil)
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(5, "doc1", "1-a"), false)
@@ -148,7 +169,14 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	require.NoError(t, err)
 	defer context.Close(ctx)
 
-	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
+
+	cache := newSingleChannelCache(context, "Test1", 0, dbstats.Cache())
+	assert.True(t, cache != nil)
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(10, "doc1", "1-a"), false)
@@ -224,7 +252,15 @@ func TestPrependChanges(t *testing.T) {
 	defer dbCtx.Close(ctx)
 
 	// 1. Test prepend to empty cache
-	cache := newSingleChannelCache(dbCtx, "PrependEmptyCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
+
+	cache := newSingleChannelCache(dbCtx, "PrependEmptyCache", 0, dbstats.Cache())
+	assert.True(t, cache != nil)
+
 	changesToPrepend := LogEntries{
 		testLogEntry(10, "doc3", "2-a"),
 		testLogEntry(12, "doc2", "2-a"),
@@ -240,7 +276,8 @@ func TestPrependChanges(t *testing.T) {
 	require.Len(t, cachedChanges, 3)
 
 	// 2. Test prepend to populated cache, with overlap and duplicates
-	cache = newSingleChannelCache(dbCtx, "PrependPopulatedCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+	cache = newSingleChannelCache(dbCtx, "PrependPopulatedCache", 0, dbstats.Cache())
+	//cache = newSingleChannelCache(dbCtx, "PrependPopulatedCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
 	cache.addToCache(testLogEntry(20, "doc2", "3-a"), false)
@@ -294,7 +331,8 @@ func TestPrependChanges(t *testing.T) {
 	require.Len(t, cachedChanges, 4)
 
 	// 3. Test prepend that exceeds cache capacity
-	cache = newSingleChannelCache(dbCtx, "PrependToFillCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+	//cache = newSingleChannelCache(dbCtx, "PrependToFillCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+	cache = newSingleChannelCache(dbCtx, "PrependToFillCache", 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
@@ -331,7 +369,8 @@ func TestPrependChanges(t *testing.T) {
 	}
 
 	// 4. Test prepend where all docids are already present in cache.  Cache entries shouldn't change, but validFrom is updated
-	cache = newSingleChannelCache(dbCtx, "PrependDuplicatesOnly", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+	//cache = newSingleChannelCache(dbCtx, "PrependDuplicatesOnly", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+	cache = newSingleChannelCache(dbCtx, "PrependDuplicatesOnly", 0, dbstats.Cache())
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
 	cache.addToCache(testLogEntry(20, "doc2", "3-a"), false)
@@ -361,7 +400,8 @@ func TestPrependChanges(t *testing.T) {
 	}
 
 	// 5. Test prepend for an already full cache
-	cache = newSingleChannelCache(dbCtx, "PrependFullCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+	//cache = newSingleChannelCache(dbCtx, "PrependFullCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+	cache = newSingleChannelCache(dbCtx, "PrependFullCache", 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
@@ -407,7 +447,14 @@ func TestChannelCacheRemove(t *testing.T) {
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close(ctx)
-	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
+
+	cache := newSingleChannelCache(context, "Test1", 0, dbstats.Cache())
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
@@ -447,7 +494,14 @@ func TestChannelCacheStats(t *testing.T) {
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close(ctx)
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
+
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
+
+	testStats := dbstats.Cache()
 	cache := newSingleChannelCache(context, "Test1", 0, testStats)
 
 	// Add some entries to cache
@@ -518,7 +572,14 @@ func TestChannelCacheStatsOnPrune(t *testing.T) {
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close(ctx)
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
+
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
+
+	testStats := dbstats.Cache()
 	cache := newSingleChannelCache(context, "Test1", 0, testStats)
 	cache.options.ChannelCacheMaxLength = 5
 
@@ -549,7 +610,14 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close(ctx)
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
+
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
+
+	testStats := dbstats.Cache()
 	cache := newSingleChannelCache(context, "Test1", 99, testStats)
 	cache.options.ChannelCacheMaxLength = 15
 
@@ -639,7 +707,14 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close(ctx)
-	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(b, err)
+
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(b, err)
+
+	cache := newSingleChannelCache(context, "Benchmark", 0, dbstats.Cache())
 	// generate doc IDs
 	docIDs := make([]string, b.N)
 	for i := 0; i < b.N; i++ {
@@ -659,7 +734,14 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close(ctx)
-	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(b, err)
+
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(b, err)
+
+	cache := newSingleChannelCache(context, "Benchmark", 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(5.0, b.N)
@@ -677,7 +759,12 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close(ctx)
-	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(b, err)
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(b, err)
+	cache := newSingleChannelCache(context, "Benchmark", 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(20.0, b.N)
@@ -695,7 +782,12 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close(ctx)
-	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(b, err)
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(b, err)
+	cache := newSingleChannelCache(context, "Benchmark", 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(50.0, b.N)
@@ -713,7 +805,12 @@ func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close(ctx)
-	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(b, err)
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(b, err)
+	cache := newSingleChannelCache(context, "Benchmark", 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(80.0, b.N)
@@ -731,7 +828,12 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close(ctx)
-	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(b, err)
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(b, err)
+	cache := newSingleChannelCache(context, "Benchmark", 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(95.0, b.N)
@@ -749,7 +851,12 @@ func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close(ctx)
-	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
+
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(b, err)
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(b, err)
+	cache := newSingleChannelCache(context, "Benchmark", 0, dbstats.Cache())
 	// generate docs
 	docs := make([]*LogEntry, b.N)
 	r := rand.New(rand.NewSource(99))

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -81,7 +81,11 @@ func TestChannelCacheSimpleCompact(t *testing.T) {
 	options := DefaultCacheOptions().ChannelCacheOptions
 	options.MaxNumChannels = 20
 
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
+	testStats := dbstats.Cache()
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
@@ -117,7 +121,10 @@ func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 	options.CompactHighWatermarkPercent = 90
 	options.CompactLowWatermarkPercent = 50
 
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	testStats := dbstats.Cache()
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
@@ -172,7 +179,11 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 	options.CompactHighWatermarkPercent = 90
 	options.CompactLowWatermarkPercent = 70
 
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
+	testStats := dbstats.Cache()
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
@@ -265,7 +276,11 @@ func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 	options.CompactHighWatermarkPercent = 90
 	options.CompactLowWatermarkPercent = 70
 
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
+	testStats := dbstats.Cache()
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
@@ -335,7 +350,11 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 	options.CompactHighWatermarkPercent = 90
 	options.CompactLowWatermarkPercent = 70
 
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
+	testStats := dbstats.Cache()
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
@@ -400,7 +419,11 @@ func TestChannelCacheBypass(t *testing.T) {
 	options.CompactHighWatermarkPercent = 100
 	options.CompactLowWatermarkPercent = 50
 
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
+	testStats := dbstats.Cache()
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
@@ -494,7 +517,11 @@ func TestChannelCacheBackgroundTaskWithIllegalTimeInterval(t *testing.T) {
 
 	// Specify illegal time interval for background task. Time interval should be > 0
 	options.ChannelCacheAge = 0
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err := stats.NewDBStats("", false, false, false)
+	require.NoError(t, err)
+	testStats := dbstats.Cache()
 
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}

--- a/db/database.go
+++ b/db/database.go
@@ -345,6 +345,11 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	// Register the cbgt pindex type for the configGroup
 	RegisterImportPindexImpl(ctx, options.GroupID)
 
+	dbStats, statsError := initDatabaseStats(dbName, autoImport, options)
+	if statsError != nil {
+		return nil, statsError
+	}
+
 	dbContext := &DatabaseContext{
 		Name:       dbName,
 		UUID:       cbgt.NewUUID(),
@@ -352,7 +357,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		StartTime:  time.Now(),
 		autoImport: autoImport,
 		Options:    options,
-		DbStats:    initDatabaseStats(dbName, autoImport, options),
+		DbStats:    dbStats,
 	}
 
 	cleanupFunctions = append(cleanupFunctions, func() {
@@ -1792,7 +1797,7 @@ func (context *DatabaseContext) FlushRevisionCacheForTest() {
 
 }
 
-func initDatabaseStats(dbName string, autoImport bool, options DatabaseContextOptions) *base.DbStats {
+func initDatabaseStats(dbName string, autoImport bool, options DatabaseContextOptions) (*base.DbStats, error) {
 
 	enabledDeltaSync := options.DeltaSyncOptions.Enabled
 	enabledImport := autoImport || options.EnableXattr

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -548,8 +548,7 @@ func TestDeltaSyncWhenFromRevIsChannelRemoval(t *testing.T) {
 	require.NoError(t, err, "Error creating user")
 
 	db.user = user
-	err = db.DbStats.InitDeltaSyncStats()
-	require.NoError(t, err)
+	require.NoError(t, db.DbStats.InitDeltaSyncStats())
 
 	delta, redactedRev, err := db.GetDelta(ctx, "doc1", rev2ID, rev3ID)
 	require.Equal(t, base.HTTPErrorf(404, "missing"), err)
@@ -562,8 +561,7 @@ func TestDeltaSyncWhenFromRevIsChannelRemoval(t *testing.T) {
 	require.NoError(t, err, "Error creating user")
 
 	db.user = user
-	err = db.DbStats.InitDeltaSyncStats()
-	require.NoError(t, err)
+	require.NoError(t, db.DbStats.InitDeltaSyncStats())
 
 	delta, redactedRev, err = db.GetDelta(ctx, "doc1", rev2ID, rev3ID)
 	require.Equal(t, base.HTTPErrorf(404, "missing"), err)
@@ -615,8 +613,7 @@ func TestDeltaSyncWhenToRevIsChannelRemoval(t *testing.T) {
 	require.NoError(t, err, "Error creating user")
 
 	db.user = user
-	err = db.DbStats.InitDeltaSyncStats()
-	require.NoError(t, err)
+	require.NoError(t, db.DbStats.InitDeltaSyncStats())
 
 	delta, redactedRev, err := db.GetDelta(ctx, "doc1", rev1ID, rev2ID)
 	require.NoError(t, err)
@@ -629,8 +626,7 @@ func TestDeltaSyncWhenToRevIsChannelRemoval(t *testing.T) {
 	require.NoError(t, err, "Error creating user")
 
 	db.user = user
-	err = db.DbStats.InitDeltaSyncStats()
-	require.NoError(t, err)
+	require.NoError(t, db.DbStats.InitDeltaSyncStats())
 
 	delta, redactedRev, err = db.GetDelta(ctx, "doc1", rev1ID, rev2ID)
 	require.Equal(t, base.HTTPErrorf(404, "missing"), err)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -548,7 +548,8 @@ func TestDeltaSyncWhenFromRevIsChannelRemoval(t *testing.T) {
 	require.NoError(t, err, "Error creating user")
 
 	db.user = user
-	db.DbStats.InitDeltaSyncStats()
+	err = db.DbStats.InitDeltaSyncStats()
+	require.NoError(t, err)
 
 	delta, redactedRev, err := db.GetDelta(ctx, "doc1", rev2ID, rev3ID)
 	require.Equal(t, base.HTTPErrorf(404, "missing"), err)
@@ -561,7 +562,8 @@ func TestDeltaSyncWhenFromRevIsChannelRemoval(t *testing.T) {
 	require.NoError(t, err, "Error creating user")
 
 	db.user = user
-	db.DbStats.InitDeltaSyncStats()
+	err = db.DbStats.InitDeltaSyncStats()
+	require.NoError(t, err)
 
 	delta, redactedRev, err = db.GetDelta(ctx, "doc1", rev2ID, rev3ID)
 	require.Equal(t, base.HTTPErrorf(404, "missing"), err)
@@ -613,7 +615,8 @@ func TestDeltaSyncWhenToRevIsChannelRemoval(t *testing.T) {
 	require.NoError(t, err, "Error creating user")
 
 	db.user = user
-	db.DbStats.InitDeltaSyncStats()
+	err = db.DbStats.InitDeltaSyncStats()
+	require.NoError(t, err)
 
 	delta, redactedRev, err := db.GetDelta(ctx, "doc1", rev1ID, rev2ID)
 	require.NoError(t, err)
@@ -626,7 +629,8 @@ func TestDeltaSyncWhenToRevIsChannelRemoval(t *testing.T) {
 	require.NoError(t, err, "Error creating user")
 
 	db.user = user
-	db.DbStats.InitDeltaSyncStats()
+	err = db.DbStats.InitDeltaSyncStats()
+	require.NoError(t, err)
 
 	delta, redactedRev, err = db.GetDelta(ctx, "doc1", rev1ID, rev2ID)
 	require.Equal(t, base.HTTPErrorf(404, "missing"), err)

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -25,8 +25,11 @@ func TestSequenceAllocator(t *testing.T) {
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
 
-	sgw := base.NewSyncGatewayStats()
-	testStats := sgw.NewDBStats("", false, false, false).Database()
+	sgw, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err := sgw.NewDBStats("", false, false, false)
+	require.NoError(t, err)
+	testStats := dbstats.Database()
 
 	// Create a sequence allocator without using constructor, to test without a releaseSequenceMonitor
 	//   - allows manually triggered release
@@ -90,8 +93,11 @@ func TestReleaseSequencesOnStop(t *testing.T) {
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
 
-	sgw := base.NewSyncGatewayStats()
-	testStats := sgw.NewDBStats("", false, false, false).Database()
+	sgw, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err := sgw.NewDBStats("", false, false, false)
+	require.NoError(t, err)
+	testStats := dbstats.Database()
 
 	oldFrequency := MaxSequenceIncrFrequency
 	defer func() { MaxSequenceIncrFrequency = oldFrequency }()
@@ -164,8 +170,11 @@ func TestSequenceAllocatorDeadlock(t *testing.T) {
 	bucket := base.NewLeakyBucket(base.GetTestBucket(t), base.LeakyBucketConfig{IncrCallback: incrCallback})
 	defer bucket.Close()
 
-	sgw := base.NewSyncGatewayStats()
-	testStats := sgw.NewDBStats("", false, false, false).Database()
+	sgw, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err := sgw.NewDBStats("", false, false, false)
+	require.NoError(t, err)
+	testStats := dbstats.Database()
 
 	oldFrequency := MaxSequenceIncrFrequency
 	defer func() { MaxSequenceIncrFrequency = oldFrequency }()
@@ -193,8 +202,11 @@ func TestReleaseSequenceWait(t *testing.T) {
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
 
-	sgw := base.NewSyncGatewayStats()
-	testStats := sgw.NewDBStats("", false, false, false).Database()
+	sgw, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err := sgw.NewDBStats("", false, false, false)
+	require.NoError(t, err)
+	testStats := dbstats.Database()
 
 	a, err := newSequenceAllocator(bucket, testStats)
 	require.NoError(t, err)

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -659,7 +659,10 @@ func (m *sgReplicateManager) InitializeReplication(config *ReplicationCfg) (repl
 	rc.checkpointPrefix = checkpointPrefix
 
 	// Retrieve or create an entry in db.replications expvar for this replication
-	allReplicationsStatsMap := m.dbContext.DbStats.DBReplicatorStats(rc.ID)
+	allReplicationsStatsMap, err := m.dbContext.DbStats.DBReplicatorStats(rc.ID)
+	if err != nil {
+		return nil, err
+	}
 	rc.ReplicationStatsMap = allReplicationsStatsMap
 
 	// disable recovered panic reporting (test only)

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4328,7 +4328,9 @@ func TestGroupIDReplications(t *testing.T) {
 			ctx := sc.SetContextLogID(base.TestCtx(t), sc.Config.Bootstrap.ConfigGroupID)
 			dbContext, err := sc.GetDatabase(ctx, "db")
 			require.NoError(t, err)
-			actualPushed, _ := base.WaitForStat(dbContext.DbStats.DBReplicatorStats("repl").NumDocPushed.Value, expectedPushed)
+			dbstats, err := dbContext.DbStats.DBReplicatorStats("repl")
+			require.NoError(t, err)
+			actualPushed, _ := base.WaitForStat(dbstats.NumDocPushed.Value, expectedPushed)
 			assert.Equal(t, expectedPushed, actualPushed)
 		}
 	}

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -4673,9 +4673,9 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 				`function(conflict) { return defaultPolicy(conflict); }`, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err, "Error creating custom conflict resolver")
 			sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
-			require.NoError(tt, err)
+			require.NoError(t, err)
 			dbstats, err := sgwStats.DBReplicatorStats(t.Name())
-			require.NoError(tt, err)
+			require.NoError(t, err)
 
 			config := db.ActiveReplicatorConfig{
 				ID:          t.Name(),

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -55,6 +55,10 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
+	stats, err := base.SyncGatewayStats.NewDBStats("test", false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	ar := db.NewActiveReplicator(ctx, &db.ActiveReplicatorConfig{
 		ID:                  t.Name(),
@@ -62,7 +66,7 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 		ActiveDB:            &db.Database{DatabaseContext: rt.GetDatabase()},
 		RemoteDBURL:         passiveDBURL,
 		Continuous:          true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats("test", false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 
 	startNumReplicationsTotal := rt.GetDatabase().DbStats.Database().NumReplicationsTotal.Value()
@@ -116,6 +120,10 @@ func TestActiveReplicatorHeartbeats(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	ar := db.NewActiveReplicator(ctx, &db.ActiveReplicatorConfig{
 		ID:                    t.Name(),
@@ -124,7 +132,7 @@ func TestActiveReplicatorHeartbeats(t *testing.T) {
 		RemoteDBURL:           passiveDBURL,
 		WebsocketPingInterval: time.Millisecond * 10,
 		Continuous:            true,
-		ReplicationStatsMap:   base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap:   dbstats,
 	})
 
 	pingCountStart := base.ExpvarVar2Int(expvar.Get("goblip").(*expvar.Map).Get("sender_ping_count"))
@@ -205,6 +213,11 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePull,
@@ -214,7 +227,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 		},
 		ChangesBatchSize:    200,
 		Continuous:          true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -295,6 +308,11 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePull,
@@ -304,7 +322,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 		},
 		ChangesBatchSize:    200,
 		Continuous:          true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -615,6 +633,11 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+
 	arConfig := db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePull,
@@ -624,7 +647,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 		},
 		Continuous:          true,
 		ChangesBatchSize:    changesBatchSize,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	}
 
 	// Create the first active replicator to pull from seq:0
@@ -786,6 +809,11 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 	require.NoError(t, err)
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+
 	arConfig := db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePull,
@@ -795,7 +823,7 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 		},
 		Continuous:          true,
 		ChangesBatchSize:    changesBatchSize,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	}
 
 	// Create the first active replicator to pull from seq:0
@@ -939,6 +967,11 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePull,
@@ -947,7 +980,7 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 			DatabaseContext: rt1.GetDatabase(),
 		},
 		ChangesBatchSize:    200,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -1032,6 +1065,10 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -1041,7 +1078,7 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 			DatabaseContext: rt1.GetDatabase(),
 		},
 		ChangesBatchSize:    200,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -1119,6 +1156,10 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -1129,7 +1170,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 		},
 		ChangesBatchSize:    200,
 		Continuous:          true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -1251,7 +1292,11 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	}
 
 	// Create the first active replicator to pull from seq:0
-	arConfig.ReplicationStatsMap = base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false).DBReplicatorStats(t.Name())
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+	arConfig.ReplicationStatsMap = dbstats
 	ar := db.NewActiveReplicator(ctx1, &arConfig)
 
 	startNumChangesRequestedFromZeroTotal := rt1.GetDatabase().DbStats.CBLReplicationPull().NumPullReplSinceZero.Value()
@@ -1303,7 +1348,11 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	}
 
 	// Create a new replicator using the same config, which should use the checkpoint set from the first.
-	arConfig.ReplicationStatsMap = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false).DBReplicatorStats(t.Name())
+	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false)
+	require.NoError(t, err)
+	dbstats, err = stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+	arConfig.ReplicationStatsMap = dbstats
 	ar = db.NewActiveReplicator(ctx1, &arConfig)
 	defer func() { assert.NoError(t, ar.Stop()) }()
 	assert.NoError(t, ar.Start(ctx1))
@@ -1414,7 +1463,10 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	arConfig.SetCheckpointPrefix(t, "cluster1:")
 
 	// Create the first active replicator to pull from seq:0
-	arConfig.ReplicationStatsMap = base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", false, false, false).DBReplicatorStats(t.Name())
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", false, false, false)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+	arConfig.ReplicationStatsMap = dbstats
 	edge1Replicator := db.NewActiveReplicator(ctx1, &arConfig)
 
 	startNumChangesRequestedFromZeroTotal := rt1.GetDatabase().DbStats.CBLReplicationPull().NumPullReplSinceZero.Value()
@@ -1471,7 +1523,11 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	ctx2 := edge2.Context()
 
 	// Create a new replicator using the same ID, which should NOT use the checkpoint set by the first edge.
-	arConfig.ReplicationStatsMap = base.SyncGatewayStats.NewDBStats(t.Name()+"edge2", false, false, false).DBReplicatorStats(t.Name())
+	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"edge2", false, false, false)
+	require.NoError(t, err)
+	dbstats, err = stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+	arConfig.ReplicationStatsMap = dbstats
 	arConfig.ActiveDB = &db.Database{
 		DatabaseContext: edge2.GetDatabase(),
 	}
@@ -1496,7 +1552,11 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	require.NoError(t, rt1.WaitForPendingChanges())
 
 	// run a replicator on edge1 again to make sure that edge2 didn't blow away its checkpoint
-	arConfig.ReplicationStatsMap = base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", false, false, false).DBReplicatorStats(t.Name())
+	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", false, false, false)
+	require.NoError(t, err)
+	dbstats, err = stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+	arConfig.ReplicationStatsMap = dbstats
 	arConfig.ActiveDB = &db.Database{
 		DatabaseContext: edge1.GetDatabase(),
 	}
@@ -1579,6 +1639,11 @@ func TestActiveReplicatorPushFromCheckpointIgnored(t *testing.T) {
 	require.NoError(t, err)
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+
 	arConfig := db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePush,
@@ -1588,7 +1653,7 @@ func TestActiveReplicatorPushFromCheckpointIgnored(t *testing.T) {
 		},
 		Continuous:          true,
 		ChangesBatchSize:    changesBatchSize,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	}
 
 	// Create the first active replicator to pull from seq:0
@@ -1713,6 +1778,11 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePush,
@@ -1721,7 +1791,7 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 			DatabaseContext: rt1.GetDatabase(),
 		},
 		ChangesBatchSize:    200,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -1806,6 +1876,11 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePull,
@@ -1815,7 +1890,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 		},
 		ChangesBatchSize:    200,
 		Continuous:          true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -1909,6 +1984,11 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePull,
@@ -1919,7 +1999,7 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 		ChangesBatchSize:    200,
 		Continuous:          true,
 		PurgeOnRemoval:      true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -2099,7 +2179,10 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 
 			customConflictResolver, err := db.NewCustomConflictResolver(test.conflictResolver, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err)
-			replicationStats := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name())
+			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+			replicationStats, err := stats.DBReplicatorStats(t.Name())
+			require.NoError(t, err)
+
 			ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 				ID:          t.Name(),
 				Direction:   db.ActiveReplicatorTypePull,
@@ -2337,6 +2420,12 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 
 			customConflictResolver, err := db.NewCustomConflictResolver(test.conflictResolver, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err)
+
+			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+			require.NoError(t, err)
+			dbstats, err := stats.DBReplicatorStats(t.Name())
+			require.NoError(t, err)
+
 			ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 				ID:          t.Name(),
 				Direction:   db.ActiveReplicatorTypePushAndPull,
@@ -2347,7 +2436,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 				ChangesBatchSize:     200,
 				ConflictResolverFunc: customConflictResolver,
 				Continuous:           true,
-				ReplicationStatsMap:  base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+				ReplicationStatsMap:  dbstats,
 			})
 			defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -2487,6 +2576,10 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -2497,7 +2590,7 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 		},
 		ChangesBatchSize:    200,
 		InsecureSkipVerify:  true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, ar.Stop()) }()
@@ -2564,6 +2657,10 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -2574,7 +2671,7 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 		},
 		ChangesBatchSize:    200,
 		InsecureSkipVerify:  false,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, ar.Stop()) }()
@@ -2630,6 +2727,10 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 		CustomTestBucket: base.GetTestBucket(t),
 	})
 	ctx1 := rt1.Context()
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	arConfig := db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -2639,7 +2740,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 			DatabaseContext: rt1.GetDatabase(),
 		},
 		Continuous:          true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	}
 
 	// Create the first active replicator to pull from seq:0
@@ -2800,7 +2901,11 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	}
 
 	// Create the first active replicator to pull from seq:0
-	arConfig.ReplicationStatsMap = base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false).DBReplicatorStats(t.Name())
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+	arConfig.ReplicationStatsMap = dbstats
 	ar := db.NewActiveReplicator(ctx1, &arConfig)
 	require.NoError(t, err)
 
@@ -2868,7 +2973,11 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	require.NoError(t, err)
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 	arConfig.RemoteDBURL = passiveDBURL
-	arConfig.ReplicationStatsMap = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false).DBReplicatorStats(t.Name())
+	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false)
+	require.NoError(t, err)
+	dbstats, err = stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+	arConfig.ReplicationStatsMap = dbstats
 
 	ar = db.NewActiveReplicator(ctx1, &arConfig)
 	require.NoError(t, err)
@@ -2962,6 +3071,10 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	RequireStatus(t, resp, http.StatusCreated)
 
 	assert.NoError(t, rt1.WaitForPendingChanges())
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	arConfig := db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -2971,7 +3084,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 			DatabaseContext: rt1.GetDatabase(),
 		},
 		Continuous:          true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	}
 
 	// Create the first active replicator to pull from seq:0
@@ -3112,6 +3225,10 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	arConfig := db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -3121,7 +3238,7 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 			DatabaseContext: rt1.GetDatabase(),
 		},
 		Continuous:          true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	}
 
 	// Create the first active replicator to pull from seq:0
@@ -3222,6 +3339,10 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -3232,7 +3353,7 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 		},
 		Continuous:          true,
 		ChangesBatchSize:    200,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -3335,6 +3456,10 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	arConfig := db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -3347,7 +3472,7 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 		ChangesBatchSize:    changesBatchSize,
 		Filter:              base.ByChannelFilter,
 		FilterChannels:      []string{"chan1"},
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	}
 
 	// Create the first active replicator to pull chan1 from seq:0
@@ -3541,6 +3666,11 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 					defer rt1.Close()
 					ctx1 := rt1.Context()
 
+					sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+					require.NoError(t, err)
+					dbstats, err := sgwStats.DBReplicatorStats(t.Name())
+					require.NoError(t, err)
+
 					id, err := base.GenerateRandomID()
 					require.NoError(t, err)
 					arConfig := db.ActiveReplicatorConfig{
@@ -3555,7 +3685,7 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 						InitialReconnectInterval: time.Millisecond,
 						MaxReconnectInterval:     time.Millisecond * 50,
 						TotalReconnectTimeout:    timeoutVal,
-						ReplicationStatsMap:      base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+						ReplicationStatsMap:      dbstats,
 					}
 
 					// Create the first active replicator to pull from seq:0
@@ -3631,6 +3761,11 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 
 	id, err := base.GenerateRandomID()
 	require.NoError(t, err)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+
 	arConfig := db.ActiveReplicatorConfig{
 		ID:          id,
 		Direction:   db.ActiveReplicatorTypePushAndPull,
@@ -3642,7 +3777,7 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 		// aggressive reconnect intervals for testing purposes
 		InitialReconnectInterval: time.Millisecond,
 		MaxReconnectInterval:     time.Millisecond * 50,
-		ReplicationStatsMap:      base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap:      dbstats,
 	}
 
 	// Create the first active replicator to pull from seq:0
@@ -3716,6 +3851,10 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	id, err := base.GenerateRandomID()
 	require.NoError(t, err)
@@ -3731,7 +3870,7 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 		InitialReconnectInterval: time.Millisecond,
 		MaxReconnectInterval:     time.Millisecond * 50,
 		TotalReconnectTimeout:    time.Second * 5,
-		ReplicationStatsMap:      base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap:      dbstats,
 	}
 
 	// Create the first active replicator to pull from seq:0
@@ -4059,7 +4198,11 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 
 			customConflictResolver, err := db.NewCustomConflictResolver(test.conflictResolver, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err)
-			replicationStats := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name())
+			dbstats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+			require.NoError(t, err)
+			replicationStats, err := dbstats.DBReplicatorStats(t.Name())
+			require.NoError(t, err)
+
 			ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 				ID:          t.Name(),
 				Direction:   db.ActiveReplicatorTypePull,
@@ -4528,6 +4671,10 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 			defaultConflictResolver, err := db.NewCustomConflictResolver(
 				`function(conflict) { return defaultPolicy(conflict); }`, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err, "Error creating custom conflict resolver")
+			sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+			require.NoError(tt, err)
+			dbstats, err := sgwStats.DBReplicatorStats(t.Name())
+			require.NoError(tt, err)
 
 			config := db.ActiveReplicatorConfig{
 				ID:          t.Name(),
@@ -4538,7 +4685,7 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 				},
 				Continuous:           true,
 				ConflictResolverFunc: defaultConflictResolver,
-				ReplicationStatsMap:  base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+				ReplicationStatsMap:  dbstats,
 			}
 
 			// Create the first revision of the document on rt1.
@@ -4683,6 +4830,10 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 			defaultConflictResolver, err := db.NewCustomConflictResolver(
 				`function(conflict) { return defaultPolicy(conflict); }`, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err, "Error creating custom conflict resolver")
+			sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+			require.NoError(t, err)
+			dbstats, err := sgwStats.DBReplicatorStats(t.Name())
+			require.NoError(t, err)
 
 			config := db.ActiveReplicatorConfig{
 				ID:          t.Name(),
@@ -4693,7 +4844,7 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 				},
 				Continuous:           true,
 				ConflictResolverFunc: defaultConflictResolver,
-				ReplicationStatsMap:  base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+				ReplicationStatsMap:  dbstats,
 			}
 
 			// Create the first revision of the document on rt2.
@@ -5015,6 +5166,10 @@ func TestSendChangesToNoConflictPreHydrogenTarget(t *testing.T) {
 
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          "test",
@@ -5025,7 +5180,7 @@ func TestSendChangesToNoConflictPreHydrogenTarget(t *testing.T) {
 		},
 		Continuous:          true,
 		InsecureSkipVerify:  true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 
 	defer func() {
@@ -5178,6 +5333,10 @@ func TestReplicatorRevocations(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "test")
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -5188,7 +5347,7 @@ func TestReplicatorRevocations(t *testing.T) {
 		},
 		Continuous:          false,
 		PurgeOnRemoval:      true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 
 	require.NoError(t, ar.Start(ctx1))
@@ -5232,6 +5391,10 @@ func TestReplicatorRevocationsNoRev(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "test")
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -5242,7 +5405,7 @@ func TestReplicatorRevocationsNoRev(t *testing.T) {
 		},
 		Continuous:          false,
 		PurgeOnRemoval:      true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 
 	require.NoError(t, ar.Start(ctx1))
@@ -5294,6 +5457,10 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "test")
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -5304,7 +5471,7 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 		},
 		Continuous:          false,
 		PurgeOnRemoval:      true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 
 	require.NoError(t, ar.Start(ctx1))
@@ -5348,6 +5515,10 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "test")
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -5358,7 +5529,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 		},
 		Continuous:          true,
 		PurgeOnRemoval:      true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 	require.NoError(t, ar.Start(ctx1))
 
@@ -5456,6 +5627,11 @@ func TestConflictResolveMergeWithMutatedRev(t *testing.T) {
 		}`, rt1.GetDatabase().Options.JavascriptTimeout)
 	require.NoError(t, err)
 
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePull,
@@ -5464,7 +5640,7 @@ func TestConflictResolveMergeWithMutatedRev(t *testing.T) {
 			DatabaseContext: rt1.GetDatabase(),
 		},
 		Continuous:             false,
-		ReplicationStatsMap:    base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap:    dbstats,
 		ConflictResolutionType: db.ConflictResolverCustom,
 		ConflictResolverFunc:   customConflictResolver,
 	})
@@ -5480,7 +5656,9 @@ func TestConflictResolveMergeWithMutatedRev(t *testing.T) {
 	require.NoError(t, ar.Start(ctx1))
 
 	val, found := base.WaitForStat(func() int64 {
-		return base.SyncGatewayStats.DbStats[t.Name()].DBReplicatorStats(ar.ID).PulledCount.Value()
+		dbRepStats, err := sgwStats.DBReplicatorStats(ar.ID)
+		require.NoError(t, err)
+		return dbRepStats.PulledCount.Value()
 	}, 1)
 	assert.True(t, found)
 	assert.Equal(t, int64(1), val)
@@ -5515,6 +5693,10 @@ func TestReplicatorRevocationsWithTombstoneResurrection(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "letmein")
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -5525,7 +5707,7 @@ func TestReplicatorRevocationsWithTombstoneResurrection(t *testing.T) {
 		},
 		Continuous:          true,
 		PurgeOnRemoval:      true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 
 	docARev := rt2.CreateDocReturnRev(t, "docA", "", map[string][]string{"channels": []string{"A"}})
@@ -5600,6 +5782,10 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "letmein")
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	activeReplCfg := &db.ActiveReplicatorConfig{
 		ID:          strings.ReplaceAll(t.Name(), "/", ""),
@@ -5610,7 +5796,7 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 		},
 		Continuous:          false,
 		PurgeOnRemoval:      true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	}
 
 	ar := db.NewActiveReplicator(ctx1, activeReplCfg)
@@ -5704,6 +5890,10 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "letmein")
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -5713,7 +5903,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 			DatabaseContext: rt1.GetDatabase(),
 		},
 		Continuous:          true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 
 	for i := 0; i < 10; i++ {
@@ -5759,6 +5949,10 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 
 	require.NoError(t, ar.Stop())
 	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
+	sgwStats, err = base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err = sgwStats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	ar = db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -5769,7 +5963,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 		},
 		Continuous:          true,
 		PurgeOnRemoval:      true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 
 	// Send a doc to act as a 'marker' so we know when replication has completed
@@ -5855,6 +6049,10 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 	// Set-up replicator //
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), true, false, false)
+	require.NoError(t, err)
+	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	ar := db.NewActiveReplicator(activeCtx, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -5866,7 +6064,7 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 		Continuous:          true,
 		ChangesBatchSize:    1,
 		DeltasEnabled:       true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), true, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 	assert.Equal(t, "", ar.GetStatus().LastSeqPush)
 	assert.NoError(t, ar.Start(activeCtx))
@@ -5957,6 +6155,10 @@ func TestUnprocessableDeltas(t *testing.T) {
 	// Set-up replicator //
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), true, false, false)
+	require.NoError(t, err)
+	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	ar := db.NewActiveReplicator(activeCtx, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -5968,7 +6170,7 @@ func TestUnprocessableDeltas(t *testing.T) {
 		Continuous:          true,
 		ChangesBatchSize:    200,
 		DeltasEnabled:       true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), true, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 	})
 	assert.Equal(t, "", ar.GetStatus().LastSeqPush)
 
@@ -6059,6 +6261,11 @@ func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
 
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+
 	ar := db.NewActiveReplicator(activeCtx, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePush,
@@ -6068,7 +6275,7 @@ func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 		},
 		Continuous:          false,
 		ChangesBatchSize:    200,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 		PurgeOnRemoval:      false,
 		Filter:              base.ByChannelFilter,
 		FilterChannels:      []string{"rev1chan"},
@@ -6107,6 +6314,10 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 	// Set-up replicator
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	require.NoError(t, err)
+	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
 
 	ar := db.NewActiveReplicator(activeCtx, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -6117,7 +6328,7 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 		},
 		Continuous:          true,
 		ChangesBatchSize:    200,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: dbstats,
 		PurgeOnRemoval:      false,
 	})
 	defer func() { require.NoError(t, ar.Stop()) }()

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -5657,7 +5657,7 @@ func TestConflictResolveMergeWithMutatedRev(t *testing.T) {
 	require.NoError(t, ar.Start(ctx1))
 
 	val, found := base.WaitForStat(func() int64 {
-		dbRepStats, err := sgwStats.DBReplicatorStats(ar.ID)
+		dbRepStats, err := base.SyncGatewayStats.DbStats[t.Name()].DBReplicatorStats(ar.ID)
 		require.NoError(t, err)
 		return dbRepStats.PulledCount.Value()
 	}, 1)

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -1464,6 +1464,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 
 	// Create the first active replicator to pull from seq:0
 	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", false, false, false)
+	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
 	arConfig.ReplicationStatsMap = dbstats


### PR DESCRIPTION
CBG-2417

Added some error handling for prometheus when swapping use of prometheus.MustRegister for prometheus.Register and passing errors up to be handled. Changes include a few changes to the way stats are set up in the tests due to adding the errors in. 


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/913/