### PR TITLE
CBG-2224 Support CBS < 7 GSI testing without collection support

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -89,7 +89,7 @@ func (tb *TestBucket) NoCloseClone() *TestBucket {
 }
 
 func getDefaultCollectionType() tbpCollectionType {
-	if TestUsingNamedCollection() {
+	if GTestBucketPool.usingCollections {
 		return tbpCollectionNamed
 	}
 	return tbpCollectionDefault

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -89,7 +89,7 @@ func (tb *TestBucket) NoCloseClone() *TestBucket {
 }
 
 func getDefaultCollectionType() tbpCollectionType {
-	if GTestBucketPool.usingCollections {
+	if GTestBucketPool.UsingNamedCollections() {
 		return tbpCollectionNamed
 	}
 	return tbpCollectionDefault


### PR DESCRIPTION
## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/923/
- [x] `GSI=true,xattrs=true` (for collections) https://jenkins.sgwdev.com/job/SyncGateway-Integration/924/ (passed modulo known failures)
