### PR TITLE
CBG-2418: Made a Runtime Database Config to explicitly track if a database is suspended

### DIFF
--- a/rest/api.go
+++ b/rest/api.go
@@ -211,7 +211,7 @@ func (h *handler) handleFlush() error {
 		h.server.RemoveDatabase(h.ctx(), name)
 
 		// Create a bucket connection spec from the database config
-		spec, err := GetBucketSpec(h.ctx(), config, h.server.Config)
+		spec, err := GetBucketSpec(h.ctx(), &config.DatabaseConfig, h.server.Config)
 		if err != nil {
 			return err
 		}
@@ -235,7 +235,7 @@ func (h *handler) handleFlush() error {
 		}
 
 		// Re-open database and add to Sync Gateway
-		_, err2 := h.server.AddDatabaseFromConfig(h.ctx(), *config)
+		_, err2 := h.server.AddDatabaseFromConfig(h.ctx(), config.DatabaseConfig)
 		if err2 != nil {
 			return err2
 		}
@@ -248,7 +248,7 @@ func (h *handler) handleFlush() error {
 		config := h.server.GetDatabaseConfig(name)
 		h.server.RemoveDatabase(h.ctx(), name)
 		err := bucket.CloseAndDelete()
-		_, err2 := h.server.AddDatabaseFromConfig(h.ctx(), *config)
+		_, err2 := h.server.AddDatabaseFromConfig(h.ctx(), config.DatabaseConfig)
 		if err == nil {
 			err = err2
 		}

--- a/rest/config.go
+++ b/rest/config.go
@@ -1440,7 +1440,7 @@ func (sc *ServerContext) fetchDatabase(ctx context.Context, dbName string) (foun
 
 // fetchConfigsSince returns database configs from the server context. These configs are refreshed before returning if
 // they are older than the refreshInterval. The refreshInterval defaults to DefaultMinConfigFetchInterval if nil.
-func (sc *ServerContext) fetchConfigsSince(ctx context.Context, refreshInterval *base.ConfigDuration) (dbNameConfigs map[string]*DatabaseConfig, err error) {
+func (sc *ServerContext) fetchConfigsSince(ctx context.Context, refreshInterval *base.ConfigDuration) (dbNameConfigs map[string]*RuntimeDatabaseConfig, err error) {
 	minInterval := DefaultMinConfigFetchInterval
 	if refreshInterval != nil {
 		minInterval = refreshInterval.Value()

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -14,6 +14,12 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 )
 
+// RuntimeDatabaseConfig is the non-persisted database config that has the persisted DatabaseConfig embedded
+type RuntimeDatabaseConfig struct {
+	DatabaseConfig
+	isSuspended bool
+}
+
 // DatabaseConfig is a 3.x/persisted database config that represents a config stored in the bucket.
 type DatabaseConfig struct {
 	// cas is the Couchbase Server CAS of the database config in the bucket

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -52,9 +52,9 @@ type ServerContext struct {
 	Config                 *StartupConfig // The current runtime configuration of the node
 	initialStartupConfig   *StartupConfig // The configuration at startup of the node. Built from config file + flags
 	persistentConfig       bool
-	bucketDbName           map[string]string              // bucketDbName is a map of bucket to database name
-	dbConfigs              map[string]*DatabaseConfig     // dbConfigs is a map of db name to DatabaseConfig
-	databases_             map[string]*db.DatabaseContext // databases_ is a map of dbname to db.DatabaseContext
+	bucketDbName           map[string]string                 // bucketDbName is a map of bucket to database name
+	dbConfigs              map[string]*RuntimeDatabaseConfig // dbConfigs is a map of db name to the RuntimeDatabaseConfig
+	databases_             map[string]*db.DatabaseContext    // databases_ is a map of dbname to db.DatabaseContext
 	lock                   sync.RWMutex
 	statsContext           *statsContext
 	BootstrapContext       *bootstrapContext
@@ -106,7 +106,7 @@ func NewServerContext(ctx context.Context, config *StartupConfig, persistentConf
 		Config:           config,
 		persistentConfig: persistentConfig,
 		bucketDbName:     map[string]string{},
-		dbConfigs:        map[string]*DatabaseConfig{},
+		dbConfigs:        map[string]*RuntimeDatabaseConfig{},
 		databases_:       map[string]*db.DatabaseContext{},
 		HTTPClient:       http.DefaultClient,
 		statsContext:     &statsContext{},
@@ -242,7 +242,7 @@ func (sc *ServerContext) GetDbConfig(name string) *DbConfig {
 	return nil
 }
 
-func (sc *ServerContext) GetDatabaseConfig(name string) *DatabaseConfig {
+func (sc *ServerContext) GetDatabaseConfig(name string) *RuntimeDatabaseConfig {
 	sc.lock.RLock()
 	config, ok := sc.dbConfigs[name]
 	sc.lock.RUnlock()
@@ -312,7 +312,7 @@ func (sc *ServerContext) PostUpgrade(ctx context.Context, preview bool) (postUpg
 func (sc *ServerContext) _reloadDatabase(ctx context.Context, reloadDbName string, failFast bool) (*db.DatabaseContext, error) {
 	sc._unloadDatabase(ctx, reloadDbName)
 	config := sc.dbConfigs[reloadDbName]
-	return sc._getOrAddDatabaseFromConfig(ctx, *config, true, db.GetConnectToBucketFn(failFast))
+	return sc._getOrAddDatabaseFromConfig(ctx, config.DatabaseConfig, true, db.GetConnectToBucketFn(failFast))
 }
 
 // Removes and re-adds a database to the ServerContext.
@@ -599,7 +599,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 
 	// Register it so HTTP handlers can find it:
 	sc.databases_[dbcontext.Name] = dbcontext
-	sc.dbConfigs[dbcontext.Name] = &config
+	sc.dbConfigs[dbcontext.Name] = &RuntimeDatabaseConfig{DatabaseConfig: config}
 	sc.bucketDbName[spec.BucketName] = dbName
 
 	if base.BoolDefault(config.StartOffline, false) {
@@ -1051,7 +1051,7 @@ func (sc *ServerContext) _removeDatabase(ctx context.Context, dbName string) boo
 }
 
 func (sc *ServerContext) _isDatabaseSuspended(dbName string) bool {
-	if _, loaded := sc.databases_[dbName]; !loaded && sc.dbConfigs[dbName] != nil {
+	if config, loaded := sc.dbConfigs[dbName]; loaded && config.isSuspended {
 		return true
 	}
 	return false
@@ -1063,7 +1063,8 @@ func (sc *ServerContext) _suspendDatabase(ctx context.Context, dbName string) er
 		return base.ErrNotFound
 	}
 
-	if config, exists := sc.dbConfigs[dbName]; exists && !base.BoolDefault(config.Suspendable, sc.Config.IsServerless()) {
+	config := sc.dbConfigs[dbName]
+	if config != nil && !base.BoolDefault(config.Suspendable, sc.Config.IsServerless()) {
 		return ErrSuspendingDisallowed
 	}
 
@@ -1073,6 +1074,8 @@ func (sc *ServerContext) _suspendDatabase(ctx context.Context, dbName string) er
 	if !sc._unloadDatabase(ctx, dbName) {
 		return base.ErrNotFound
 	}
+
+	config.isSuspended = true
 	return nil
 }
 
@@ -1091,8 +1094,11 @@ func (sc *ServerContext) _unsuspendDatabase(ctx context.Context, dbName string) 
 
 	// Check if database is in dbConfigs so no need to search through buckets
 	if dbConfig, ok := sc.dbConfigs[dbName]; ok {
+		if !dbConfig.isSuspended {
+			base.WarnfCtx(ctx, "attempting to unsuspend database %q that is not suspended", base.MD(dbName))
+		}
 		if !base.BoolDefault(dbConfig.Suspendable, sc.Config.IsServerless()) {
-			base.InfofCtx(context.TODO(), base.KeyAll, "attempting to unsuspend db %q while not configured to be suspendable", base.MD(dbName))
+			base.InfofCtx(ctx, base.KeyAll, "attempting to unsuspend db %q while not configured to be suspendable", base.MD(dbName))
 		}
 
 		bucket := dbName
@@ -1109,7 +1115,7 @@ func (sc *ServerContext) _unsuspendDatabase(ctx context.Context, dbName string) 
 			return nil, fmt.Errorf("unsuspending db %q failed due to an error while trying to retrieve latest config from bucket %q: %w", base.MD(dbName).Redact(), base.MD(bucket).Redact(), err)
 		}
 		dbConfig.cas = cas
-		dbCtx, err = sc._getOrAddDatabaseFromConfig(ctx, *dbConfig, false, db.GetConnectToBucketFn(false))
+		dbCtx, err = sc._getOrAddDatabaseFromConfig(ctx, dbConfig.DatabaseConfig, false, db.GetConnectToBucketFn(false))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
CBG-2418

- Made dbConfigs store a Runtime Database Config which contains the persistent db config embedded
- Store if the database is suspended without persisting it
- Set and check the `isSuspended` flag as appropriate
- Used ctx for logging in `_unsuspendDatabase`

`isSuspended` does not explicitly get set to false when unsuspending the database as `getOrAddDatabase` will replace the runtime database config causing it to be false anyway


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/926/
