### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -29,7 +29,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -484,7 +484,7 @@ func (op *OIDCProvider) fetchCustomProviderConfig(ctx context.Context, discovery
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode != http.StatusOK {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			err = fmt.Errorf("unsuccessful response and could not read returned response body: %w", err)
 		} else {
@@ -507,7 +507,7 @@ func (op *OIDCProvider) fetchCustomProviderConfig(ctx context.Context, discovery
 		ttl = MinProviderConfigSyncInterval
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return ProviderMetadata{}, MaxProviderConfigSyncInterval, false, err
 	}

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -15,7 +15,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -525,7 +524,7 @@ func getMaxTTL(store CouchbaseStore) (int, error) {
 
 	defer func() { _ = resp.Body.Close() }()
 
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return -1, err
 	}
@@ -546,7 +545,7 @@ func getServerUUID(store CouchbaseStore) (uuid string, err error) {
 
 	defer func() { _ = resp.Body.Close() }()
 
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -607,7 +606,7 @@ func retrievePurgeInterval(bucket CouchbaseStore, uri string) (time.Duration, er
 		return 0, errors.New(resp.Status)
 	}
 
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0, err
 	}

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -15,7 +15,6 @@ import (
 	"expvar"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -1306,7 +1305,7 @@ func putDDocForTombstones(name string, payload []byte, capiEps []string, client 
 
 	defer ensureBodyClosed(resp.Body)
 	if resp.StatusCode != 201 {
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -1635,7 +1634,7 @@ func (bucket *CouchbaseBucketGoCB) APIBucketItemCount() (itemCount int, err erro
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != 200 {
-		_, err := ioutil.ReadAll(resp.Body)
+		_, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return -1, err
 		}

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -12,7 +12,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -2145,7 +2144,7 @@ func tempX509Certs(t *testing.T) (certPath, keyPath string, cleanupFn func()) {
 	tmpDir := os.TempDir()
 
 	// The contents of these certificates was taken directly from Go's tls package examples.
-	certFile, err := ioutil.TempFile(tmpDir, "x509-cert")
+	certFile, err := os.CreateTemp(tmpDir, "x509-cert")
 	require.NoError(t, err)
 	_, err = certFile.Write([]byte(`-----BEGIN CERTIFICATE-----
 MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
@@ -2161,7 +2160,7 @@ Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
 	require.NoError(t, err)
 	_ = certFile.Close()
 
-	keyFile, err := ioutil.TempFile(tmpDir, "x509-key")
+	keyFile, err := os.CreateTemp(tmpDir, "x509-key")
 	require.NoError(t, err)
 	_, err = keyFile.Write([]byte(`-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIIrYSSNQFaA2Hwf1duRSxKtLYX5CB04fSeQ6tF1aY/PuoAoGCCqGSM49

--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -13,7 +13,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/couchbase/gocb/v2"
@@ -141,7 +141,7 @@ func getRootCAs(caCertPath string) (*x509.CertPool, error) {
 	if caCertPath != "" {
 		rootCAs := x509.NewCertPool()
 
-		caCert, err := ioutil.ReadFile(caCertPath)
+		caCert, err := os.ReadFile(caCertPath)
 		if err != nil {
 			return nil, err
 		}

--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -12,7 +12,7 @@ package base
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -102,7 +102,7 @@ func TestConsoleShouldLog(t *testing.T) {
 			LogKeys:  test.loggerKeys,
 			FileLoggerConfig: FileLoggerConfig{
 				Enabled: BoolPtr(true),
-				Output:  ioutil.Discard,
+				Output:  io.Discard,
 			}})
 
 		t.Run(name, func(ts *testing.T) {
@@ -123,7 +123,7 @@ func BenchmarkConsoleShouldLog(b *testing.B) {
 			LogKeys:  test.loggerKeys,
 			FileLoggerConfig: FileLoggerConfig{
 				Enabled: BoolPtr(true),
-				Output:  ioutil.Discard,
+				Output:  io.Discard,
 			}})
 
 		b.Run(name, func(bb *testing.B) {

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -273,7 +272,7 @@ func runLogDeletion(logDirectory string, logLevel string, sizeLimitMBLowWatermar
 	sizeLimitMBLowWatermark = sizeLimitMBLowWatermark * 1024 * 1024   // Convert MB input to bytes
 	sizeLimitMBHighWatermark = sizeLimitMBHighWatermark * 1024 * 1024 // Convert MB input to bytes
 
-	files, err := ioutil.ReadDir(logDirectory)
+	files, err := os.ReadDir(logDirectory)
 
 	if err != nil {
 		return errors.New(fmt.Sprintf("Error reading log directory: %v", err))
@@ -287,7 +286,12 @@ func runLogDeletion(logDirectory string, logLevel string, sizeLimitMBLowWatermar
 	for i := len(files) - 1; i >= 0; i-- {
 		file := files[i]
 		if strings.HasPrefix(file.Name(), logFilePrefix+logLevel) && strings.HasSuffix(file.Name(), ".log.gz") {
-			totalSize += int(file.Size())
+			fi, err := file.Info()
+			if err != nil {
+				continue
+			}
+
+			totalSize += int(fi.Size())
 			if totalSize > sizeLimitMBLowWatermark && indexDeletePoint == -1 {
 				indexDeletePoint = i
 			}

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -288,6 +288,7 @@ func runLogDeletion(logDirectory string, logLevel string, sizeLimitMBLowWatermar
 		if strings.HasPrefix(file.Name(), logFilePrefix+logLevel) && strings.HasSuffix(file.Name(), ".log.gz") {
 			fi, err := file.Info()
 			if err != nil {
+				InfofCtx(context.TODO(), KeyAll, "Couldn't get size of log file %q: %v - ignoring for cleanup calculation", file.Name(), err)
 				continue
 			}
 

--- a/base/logger_file_test.go
+++ b/base/logger_file_test.go
@@ -12,7 +12,7 @@ package base
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -76,8 +76,8 @@ func TestFileShouldLog(t *testing.T) {
 		l := FileLogger{
 			Enabled: AtomicBool{test.enabled},
 			level:   test.loggerLevel,
-			output:  ioutil.Discard,
-			logger:  log.New(ioutil.Discard, "", 0),
+			output:  io.Discard,
+			logger:  log.New(io.Discard, "", 0),
 		}
 
 		t.Run(name, func(ts *testing.T) {
@@ -96,8 +96,8 @@ func BenchmarkFileShouldLog(b *testing.B) {
 		l := FileLogger{
 			Enabled: AtomicBool{test.enabled},
 			level:   test.loggerLevel,
-			output:  ioutil.Discard,
-			logger:  log.New(ioutil.Discard, "", 0),
+			output:  io.Discard,
+			logger:  log.New(io.Discard, "", 0),
 		}
 
 		b.Run(name, func(bb *testing.B) {
@@ -109,7 +109,7 @@ func BenchmarkFileShouldLog(b *testing.B) {
 }
 
 func TestRotatedLogDeletion(t *testing.T) {
-	var dirContents []os.FileInfo
+	var dirContents []os.DirEntry
 
 	// Regular Test With multiple files above high and low watermark
 	dir := t.TempDir()
@@ -132,7 +132,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.NoError(t, err)
 	err = runLogDeletion(dir, "info", 5, 7)
 	assert.NoError(t, err)
-	dirContents, err = ioutil.ReadDir(dir)
+	dirContents, err = os.ReadDir(dir)
 	require.Len(t, dirContents, 3)
 
 	var fileNames = []string{}
@@ -153,7 +153,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.NoError(t, err)
 	err = runLogDeletion(dir, "error", 2, 4)
 	assert.NoError(t, err)
-	dirContents, err = ioutil.ReadDir(dir)
+	dirContents, err = os.ReadDir(dir)
 	require.Len(t, dirContents, 1)
 	assert.NoError(t, os.RemoveAll(dir))
 
@@ -163,7 +163,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.NoError(t, err)
 	err = runLogDeletion(dir, "error", 2, 4)
 	assert.NoError(t, err)
-	dirContents, err = ioutil.ReadDir(dir)
+	dirContents, err = os.ReadDir(dir)
 	assert.Empty(t, dirContents)
 	assert.NoError(t, os.RemoveAll(dir))
 
@@ -173,7 +173,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.NoError(t, err)
 	err = runLogDeletion(dir, "error", 2, 4)
 	assert.NoError(t, err)
-	dirContents, err = ioutil.ReadDir(dir)
+	dirContents, err = os.ReadDir(dir)
 	require.Len(t, dirContents, 1)
 	assert.NoError(t, os.RemoveAll(dir))
 
@@ -190,7 +190,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	err = runLogDeletion(dir, "error", 2, 3)
 	assert.NoError(t, err)
 
-	dirContents, err = ioutil.ReadDir(dir)
+	dirContents, err = os.ReadDir(dir)
 	require.Len(t, dirContents, 2)
 
 	fileNames = []string{}
@@ -210,7 +210,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	err = makeTestFile(1, logFilePrefix+"info", dir)
 	assert.NoError(t, err)
 
-	dirContents, err = ioutil.ReadDir(dir)
+	dirContents, err = os.ReadDir(dir)
 	require.Len(t, dirContents, 2)
 
 	fileNames = []string{}

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -16,7 +16,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"os"
@@ -125,7 +125,7 @@ func getTestBucket(t testing.TB, collectionType tbpCollectionType) *TestBucket {
 // Returns both the test bucket which is persisted and a function which can be used to remove the created temporary
 // directory once the test has finished with it.
 func GetPersistentWalrusBucket(t testing.TB) (*TestBucket, func()) {
-	tempDir, err := ioutil.TempDir("", "walrustemp")
+	tempDir, err := os.MkdirTemp("", "walrustemp")
 	require.NoError(t, err)
 
 	walrusFile := fmt.Sprintf("walrus:%s", tempDir)
@@ -583,7 +583,7 @@ func SetUpBenchmarkLogging(tb testing.TB, logLevel LogLevel, logKeys ...LogKey) 
 	teardownFnOrig := setTestLogging(logLevel, "", logKeys...)
 
 	// discard all logging output for benchmarking (but still execute logging as normal)
-	consoleLogger.logger.SetOutput(ioutil.Discard)
+	consoleLogger.logger.SetOutput(io.Discard)
 	tb.Cleanup(func() {
 		// revert back to original output
 		if consoleLogger != nil && consoleLogger.output != nil {

--- a/db/event_handler.go
+++ b/db/event_handler.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -140,7 +139,7 @@ func (wh *Webhook) HandleEvent(event Event) bool {
 		defer func() {
 			// Ensure we're closing the response, so it can be reused
 			if resp != nil && resp.Body != nil {
-				_, err := io.Copy(ioutil.Discard, resp.Body)
+				_, err := io.Copy(io.Discard, resp.Body)
 				if err != nil {
 					base.DebugfCtx(logCtx, base.KeyEvents, "Error copying response body: %v", err)
 				}

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -13,7 +13,7 @@ package db
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math"
 	"net"
@@ -396,7 +396,7 @@ func GetRouterWithHandler(wr *WebhookRequest) http.Handler {
 	})
 	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		_ = r.ParseForm()
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			log.Printf("Error trying to read body: %s", err)
 		}

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -10,8 +10,8 @@ package db
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -655,7 +655,7 @@ func TestPruneDisconnectedRevTreeWithLongWinningBranch(t *testing.T) {
 	revTree := getMultiBranchTestRevtree1(1, 15, branchSpecs)
 
 	if dumpRevTreeDotFiles {
-		err := ioutil.WriteFile("/tmp/TestPruneDisconnectedRevTreeWithLongWinningBranch_initial.dot", []byte(revTree.RenderGraphvizDot()), 0666)
+		err := os.WriteFile("/tmp/TestPruneDisconnectedRevTreeWithLongWinningBranch_initial.dot", []byte(revTree.RenderGraphvizDot()), 0666)
 		require.NoError(t, err)
 	}
 
@@ -664,7 +664,7 @@ func TestPruneDisconnectedRevTreeWithLongWinningBranch(t *testing.T) {
 	revTree.pruneRevisions(maxDepth, "")
 
 	if dumpRevTreeDotFiles {
-		err := ioutil.WriteFile("/tmp/TestPruneDisconnectedRevTreeWithLongWinningBranch_pruned1.dot", []byte(revTree.RenderGraphvizDot()), 0666)
+		err := os.WriteFile("/tmp/TestPruneDisconnectedRevTreeWithLongWinningBranch_pruned1.dot", []byte(revTree.RenderGraphvizDot()), 0666)
 		require.NoError(t, err)
 	}
 
@@ -679,14 +679,14 @@ func TestPruneDisconnectedRevTreeWithLongWinningBranch(t *testing.T) {
 	)
 
 	if dumpRevTreeDotFiles {
-		err := ioutil.WriteFile("/tmp/TestPruneDisconnectedRevTreeWithLongWinningBranch_add_winning_revs.dot", []byte(revTree.RenderGraphvizDot()), 0666)
+		err := os.WriteFile("/tmp/TestPruneDisconnectedRevTreeWithLongWinningBranch_add_winning_revs.dot", []byte(revTree.RenderGraphvizDot()), 0666)
 		require.NoError(t, err)
 	}
 
 	revTree.pruneRevisions(maxDepth, "")
 
 	if dumpRevTreeDotFiles {
-		err := ioutil.WriteFile("/tmp/TestPruneDisconnectedRevTreeWithLongWinningBranch_pruned_final.dot", []byte(revTree.RenderGraphvizDot()), 0666)
+		err := os.WriteFile("/tmp/TestPruneDisconnectedRevTreeWithLongWinningBranch_pruned_final.dot", []byte(revTree.RenderGraphvizDot()), 0666)
 		require.NoError(t, err)
 	}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -12,7 +12,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -458,13 +458,13 @@ func (h *handler) handlePutDbConfig() (err error) {
 		hasAuthPerm := h.permissionsResults[PermConfigureAuth.PermissionName]
 		hasSyncPerm := h.permissionsResults[PermConfigureSyncFn.PermissionName]
 
-		bodyContents, err := ioutil.ReadAll(h.requestBody)
+		bodyContents, err := io.ReadAll(h.requestBody)
 		if err != nil {
 			return err
 		}
 
 		var mapDbConfig map[string]interface{}
-		err = ReadJSONFromMIMERawErr(h.rq.Header, ioutil.NopCloser(bytes.NewReader(bodyContents)), &mapDbConfig)
+		err = ReadJSONFromMIMERawErr(h.rq.Header, io.NopCloser(bytes.NewReader(bodyContents)), &mapDbConfig)
 		if err != nil {
 			return err
 		}
@@ -481,7 +481,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 			return base.HTTPErrorf(http.StatusForbidden, "not authorized to update field: %s", strings.Join(unknownFileKeys, ","))
 		}
 
-		err = ReadJSONFromMIMERawErr(h.rq.Header, ioutil.NopCloser(bytes.NewReader(bodyContents)), &dbConfig)
+		err = ReadJSONFromMIMERawErr(h.rq.Header, io.NopCloser(bytes.NewReader(bodyContents)), &dbConfig)
 		if err != nil {
 			return err
 		}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"mime"
@@ -1750,7 +1749,7 @@ readerLoop:
 			t.Fatal(err)
 		}
 
-		partBytes, err := ioutil.ReadAll(part)
+		partBytes, err := io.ReadAll(part)
 		assert.NoError(t, err, "Unexpected error")
 
 		log.Printf("multipart part: %+v", string(partBytes))
@@ -3940,7 +3939,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 
 		}
 
-		partBytes, err := ioutil.ReadAll(part)
+		partBytes, err := io.ReadAll(part)
 		assert.NoError(t, err, "Unexpected error")
 
 		log.Printf("multipart part: %+v", string(partBytes))
@@ -4727,7 +4726,7 @@ func TestWebhookProperties(t *testing.T) {
 	wg := sync.WaitGroup{}
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		out, err := ioutil.ReadAll(r.Body)
+		out, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 		err = r.Body.Close()
 		assert.NoError(t, err)
@@ -4973,7 +4972,7 @@ func TestWebhookPropsWithAttachments(t *testing.T) {
 	wg := sync.WaitGroup{}
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		defer wg.Done()
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		require.NoError(t, err, "Error reading request body")
 		require.NoError(t, r.Body.Close(), "Error closing request body")
 
@@ -7616,7 +7615,7 @@ func TestMetricsHandler(t *testing.T) {
 	resp, err := httpClient.Get(srv.URL + "/_metrics")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	bodyString, err := ioutil.ReadAll(resp.Body)
+	bodyString, err := io.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.Contains(t, string(bodyString), `database="db"`)
 	err = resp.Body.Close()
@@ -7631,7 +7630,7 @@ func TestMetricsHandler(t *testing.T) {
 	resp, err = httpClient.Get(srv.URL + "/_metrics")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	bodyString, err = ioutil.ReadAll(resp.Body)
+	bodyString, err = io.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.Contains(t, string(bodyString), `database="db"`)
 	assert.Contains(t, string(bodyString), `database="db2"`)

--- a/rest/config.go
+++ b/rest/config.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	_ "net/http/pprof"
@@ -415,7 +414,7 @@ func loadJavaScript(path string, insecureSkipVerify bool) (js string, err error)
 		return "", err
 	}
 	defer func() { _ = rc.Close() }()
-	src, err := ioutil.ReadAll(rc)
+	src, err := io.ReadAll(rc)
 	if err != nil {
 		return "", err
 	}
@@ -1046,7 +1045,7 @@ func (config *DbConfig) redactInPlace() error {
 
 // DecodeAndSanitiseConfig will sanitise a config from an io.Reader and unmarshal it into the given config parameter.
 func DecodeAndSanitiseConfig(r io.Reader, config interface{}) (err error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -10,7 +10,6 @@ package rest
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -325,7 +324,7 @@ func TestLegacyGuestUserMigration(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	configPath := filepath.Join(tmpDir, "config.json")
-	err := ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
+	err := os.WriteFile(configPath, []byte(config), os.FileMode(0644))
 	require.NoError(t, err)
 
 	sc, _, _, _, err := automaticConfigUpgrade(configPath)
@@ -425,7 +424,7 @@ func TestLegacyConfigPrinciplesMigration(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	configPath := filepath.Join(tmpDir, "config.json")
-	err = ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
+	err = os.WriteFile(configPath, []byte(config), os.FileMode(0644))
 	require.NoError(t, err)
 
 	// Copy behaviour of serverMainPersistentConfig - upgrade config, pass legacy users and roles in to addLegacyPrinciples (after server context is created)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -835,7 +834,7 @@ func TestParseCommandLineWithBadConfigContent(t *testing.T) {
     	"databases":{"db":{"unknown_field":"walrus:data","users":{"GUEST":{"disabled":false,
 		"admin_channels":["*"]}}, "allow_conflicts":false,"revs_limit":20}}}`
 
-	configFile, err := ioutil.TempFile("", "sync_gateway.conf")
+	configFile, err := os.CreateTemp("", "sync_gateway.conf")
 	configFileName := configFile.Name()
 	require.NoError(t, err, "Couldn't create configuration file")
 	_, err = configFile.Write([]byte(content))
@@ -861,7 +860,7 @@ func TestParseCommandLineWithConfigContent(t *testing.T) {
         "certpath":"/etc/ssl/certs/cert.pem","cacertpath":"/etc/ssl/certs/ca.cert","keypath":"/etc/ssl/certs/key.pem",
         "users":{"GUEST":{"disabled":false,"admin_channels":["*"]}},"allow_conflicts":false,"revs_limit":20}}}`
 
-	configFile, err := ioutil.TempFile("", "sync_gateway.conf")
+	configFile, err := os.CreateTemp("", "sync_gateway.conf")
 	configFileName := configFile.Name()
 	require.NoError(t, err, "Couldn't create configuration file")
 	_, err = configFile.Write([]byte(content))
@@ -1307,7 +1306,7 @@ func TestExpandEnv(t *testing.T) {
 
 // createTempFile creates a temporary file with the given content.
 func createTempFile(t *testing.T, content []byte) *os.File {
-	file, err := ioutil.TempFile("", "*-sync_gateway.conf")
+	file, err := os.CreateTemp("", "*-sync_gateway.conf")
 	require.NoError(t, err, "Error creating temp file")
 	_, err = file.Write(content)
 	require.NoError(t, err, "Error writing bytes")
@@ -1495,7 +1494,7 @@ var errInternalServerError = &base.HTTPError{
 // given JavaScript source and returns a teardown function to remove the file after its use.
 func javaScriptFile(t *testing.T, js string) func() (path string, teardownFn func()) {
 	return func() (path string, teardownFn func()) {
-		file, err := ioutil.TempFile("", "*.js")
+		file, err := os.CreateTemp("", "*.js")
 		require.NoError(t, err, "Error creating JavaScript file")
 		_, err = file.Write([]byte(js))
 		require.NoError(t, err, "Error writing to JavaScript file")
@@ -1513,7 +1512,7 @@ func javaScriptFile(t *testing.T, js string) func() (path string, teardownFn fun
 // and returns a teardown function to remove the file after its use.
 func emptyJavaScriptFile(t *testing.T) func() (path string, teardownFn func()) {
 	return func() (path string, teardownFn func()) {
-		file, err := ioutil.TempFile("", "*.js")
+		file, err := os.CreateTemp("", "*.js")
 		require.NoError(t, err, "Error creating JavaScript file")
 		path = file.Name()
 		teardownFn = func() {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -16,7 +16,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"mime"
 	"mime/multipart"
@@ -412,7 +411,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 			}
 			// The above readBody() will end up clearing the body which the later handler will require. Re-populate this
 			// for the later handler.
-			h.requestBody = ioutil.NopCloser(bytes.NewReader(body))
+			h.requestBody = io.NopCloser(bytes.NewReader(body))
 			authScope, err = h.authScopeFunc(body)
 			if err != nil {
 				return base.HTTPErrorf(http.StatusInternalServerError, "Unable to read body: %v", err)
@@ -860,7 +859,7 @@ func (h *handler) getEtag(headerName string) (string, error) {
 
 // Returns the request body as a raw byte array.
 func (h *handler) readBody() ([]byte, error) {
-	return ioutil.ReadAll(h.requestBody)
+	return io.ReadAll(h.requestBody)
 }
 
 // Parses a JSON request body, returning it as a Body map.
@@ -885,7 +884,7 @@ func (h *handler) readSanitizeJSON(val interface{}) error {
 
 	// Read body bytes to sanitize the content and substitute environment variables.
 	defer func() { _ = input.Close() }()
-	content, err := ioutil.ReadAll(input)
+	content, err := io.ReadAll(input)
 	if err != nil {
 		return err
 	}
@@ -923,7 +922,7 @@ func (h *handler) readJavascript() (string, error) {
 	}
 
 	defer func() { _ = input.Close() }()
-	jsBytes, err := ioutil.ReadAll(input)
+	jsBytes, err := io.ReadAll(input)
 	if err != nil {
 		return "", err
 	}
@@ -959,7 +958,7 @@ func (h *handler) readDocument() (db.Body, error) {
 			reader := multipart.NewReader(bytes.NewReader(raw), attrs["boundary"])
 			body, err := ReadMultipartDocument(reader)
 			if err != nil {
-				_ = ioutil.WriteFile("GatewayPUT.mime", raw, 0600)
+				_ = os.WriteFile("GatewayPUT.mime", raw, 0600)
 				base.WarnfCtx(h.ctx(), "Error reading MIME data: copied to file GatewayPUT.mime")
 			}
 			return body, err

--- a/rest/main.go
+++ b/rest/main.go
@@ -15,7 +15,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -267,7 +266,7 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 	// Attempt to write over the old config with the new migrated config
 	// If we are able to write the config log success and continue
 	// Otherwise continue with startup but log warning
-	err = ioutil.WriteFile(configPath, jsonStartupConfig, 0644)
+	err = os.WriteFile(configPath, jsonStartupConfig, 0644)
 	if err != nil {
 		base.WarnfCtx(context.Background(), "Unable to write updated config file: %v -  but will continue with startup.", err)
 		return startupConfig, false, users, roles, nil

--- a/rest/multipart.go
+++ b/rest/multipart.go
@@ -18,7 +18,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
@@ -259,7 +258,7 @@ func ReadMultipartDocument(reader *multipart.Reader) (db.Body, error) {
 			}
 			return nil, err
 		}
-		data, err := ioutil.ReadAll(part)
+		data, err := io.ReadAll(part)
 		_ = part.Close()
 		if err != nil {
 			return nil, err

--- a/rest/multipart_test.go
+++ b/rest/multipart_test.go
@@ -14,7 +14,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"mime/multipart"
@@ -55,7 +55,7 @@ func TestReadJSONFromMIME(t *testing.T) {
 	header := http.Header{}
 	header.Add("MIME-Version", "1.0")
 	header.Add("Content-Type", "multipart/related; boundary=0123456789")
-	input := ioutil.NopCloser(strings.NewReader(`{"key":"foo","value":"bar"}`))
+	input := io.NopCloser(strings.NewReader(`{"key":"foo","value":"bar"}`))
 	var body db.Body
 	err := ReadJSONFromMIME(header, input, &body)
 	assert.Error(t, err, "Can't read JSON from MIME by specifying non-JSON content type")
@@ -65,7 +65,7 @@ func TestReadJSONFromMIME(t *testing.T) {
 	header = http.Header{}
 	header.Add("MIME-Version", "1.0")
 	header.Add("Content-Type", "application/json")
-	input = ioutil.NopCloser(strings.NewReader(`{"key":"foo","value":"bar"}`))
+	input = io.NopCloser(strings.NewReader(`{"key":"foo","value":"bar"}`))
 	err = ReadJSONFromMIME(header, input, &body)
 	assert.NoError(t, err, "Should read valid JSON from MIME")
 	assert.Equal(t, "foo", body["key"])
@@ -75,7 +75,7 @@ func TestReadJSONFromMIME(t *testing.T) {
 	header = http.Header{}
 	header.Add("MIME-Version", "1.0")
 	header.Add("Content-Type", "application/json")
-	input = ioutil.NopCloser(strings.NewReader(`"key":"foo","value":"bar"`))
+	input = io.NopCloser(strings.NewReader(`"key":"foo","value":"bar"`))
 	err = ReadJSONFromMIME(header, input, &body)
 	assert.Error(t, err, "Can't read JSON from MIME with illegal JSON body content")
 	assert.Contains(t, err.Error(), strconv.Itoa(http.StatusBadRequest))
@@ -85,7 +85,7 @@ func TestReadJSONFromMIME(t *testing.T) {
 	header.Add("MIME-Version", "1.0")
 	header.Add("Content-Type", "application/json")
 	header.Add("Content-Encoding", "gzip")
-	input = ioutil.NopCloser(strings.NewReader(`{"key":"foo","value":"bar"}`))
+	input = io.NopCloser(strings.NewReader(`{"key":"foo","value":"bar"}`))
 	err = ReadJSONFromMIME(header, input, &body)
 	assert.Error(t, err, "Can't read JSON from MIME with gzip content encoding and illegal content type")
 	assert.Contains(t, err.Error(), "invalid header")
@@ -94,7 +94,7 @@ func TestReadJSONFromMIME(t *testing.T) {
 	header = http.Header{}
 	header.Add("MIME-Version", "1.0")
 	header.Add("Content-Encoding", "zip")
-	input = ioutil.NopCloser(strings.NewReader(`{"key":"foo","value":"bar"}`))
+	input = io.NopCloser(strings.NewReader(`{"key":"foo","value":"bar"}`))
 	err = ReadJSONFromMIME(header, input, &body)
 	assert.Error(t, err, "Can't read JSON from MIME with unsupported content encoding")
 	assert.Contains(t, err.Error(), strconv.Itoa(http.StatusUnsupportedMediaType))
@@ -111,7 +111,7 @@ func TestReadJSONFromMIME(t *testing.T) {
 	assert.NoError(t, gz.Flush(), "Flushes any pending compressed data to the underlying writer")
 	assert.NoError(t, gz.Close(), "Closes the Writer by flushing any unwritten data")
 
-	input = ioutil.NopCloser(&buffer)
+	input = io.NopCloser(&buffer)
 	err = ReadJSONFromMIME(header, input, &body)
 	assert.NoError(t, err, "Should read JSON from MIME with gzip content encoding")
 	assert.Equal(t, "foo", body["key"])

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -17,7 +17,7 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -939,7 +939,7 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 
 // assertHttpResponse asserts the forceError against HTTP response.
 func assertHttpResponse(t *testing.T, response *http.Response, forceError forceError) {
-	bodyBytes, err := ioutil.ReadAll(response.Body)
+	bodyBytes, err := io.ReadAll(response.Body)
 	require.NoError(t, err, "error reading response body")
 	assert.Contains(t, string(bodyBytes), forceError.expectedErrorMessage)
 	assert.Equal(t, forceError.expectedErrorCode, response.StatusCode)

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -14,7 +14,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -183,7 +183,7 @@ func TestProviderOIDCAuthWithTlsSkipVerifyEnabled(t *testing.T) {
 	response, err := client.Do(request)
 	require.NoError(t, err, "Error sending request")
 	require.Equal(t, http.StatusOK, response.StatusCode)
-	bodyBytes, err := ioutil.ReadAll(response.Body)
+	bodyBytes, err := io.ReadAll(response.Body)
 	require.NoError(t, err, "Error reading response")
 	bodyString := string(bodyBytes)
 	require.NoError(t, response.Body.Close(), "Error closing response body")
@@ -239,7 +239,7 @@ func TestProviderOIDCAuthWithTlsSkipVerifyDisabled(t *testing.T) {
 	response, err := client.Do(request)
 	require.NoError(t, err, "Error sending request")
 	require.Equal(t, http.StatusInternalServerError, response.StatusCode)
-	bodyBytes, err := ioutil.ReadAll(response.Body)
+	bodyBytes, err := io.ReadAll(response.Body)
 	require.NoError(t, err, "Error reading response")
 	bodyString := string(bodyBytes)
 	assert.Contains(t, bodyString, "Unable to obtain client for provider")
@@ -331,7 +331,7 @@ func TestOpenIDConnectTestProviderWithRealWorldToken(t *testing.T) {
 			response, err := client.Do(request)
 			require.NoError(t, err, "Error sending request")
 			require.Equal(t, http.StatusOK, response.StatusCode)
-			bodyBytes, err := ioutil.ReadAll(response.Body)
+			bodyBytes, err := io.ReadAll(response.Body)
 			require.NoError(t, err, "Error reading response")
 			bodyString := string(bodyBytes)
 			require.NoError(t, response.Body.Close(), "Error closing response body")
@@ -433,7 +433,7 @@ func TestOIDCWithBasicAuthDisabled(t *testing.T) {
 	response, err := client.Do(request)
 	require.NoError(t, err, "Error sending request")
 	require.Equal(t, http.StatusOK, response.StatusCode)
-	bodyBytes, err := ioutil.ReadAll(response.Body)
+	bodyBytes, err := io.ReadAll(response.Body)
 	require.NoError(t, err, "Error reading response")
 	bodyString := string(bodyBytes)
 	require.NoError(t, response.Body.Close(), "Error closing response body")

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -11,7 +11,6 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -54,7 +53,7 @@ func TestAutomaticConfigUpgrade(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	configPath := filepath.Join(tmpDir, "config.json")
-	err := ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
+	err := os.WriteFile(configPath, []byte(config), os.FileMode(0644))
 	require.NoError(t, err)
 
 	startupConfig, _, _, _, err := automaticConfigUpgrade(configPath)
@@ -67,7 +66,7 @@ func TestAutomaticConfigUpgrade(t *testing.T) {
 	assert.Equal(t, ":4444", startupConfig.API.PublicInterface)
 	assert.Equal(t, ":4445", startupConfig.API.AdminInterface)
 
-	writtenNewFile, err := ioutil.ReadFile(configPath)
+	writtenNewFile, err := os.ReadFile(configPath)
 	require.NoError(t, err)
 
 	var writtenFileStartupConfig StartupConfig
@@ -91,7 +90,7 @@ func TestAutomaticConfigUpgrade(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	writtenBackupFile, err := ioutil.ReadFile(backupFileName)
+	writtenBackupFile, err := os.ReadFile(backupFileName)
 	require.NoError(t, err)
 
 	assert.Equal(t, config, string(writtenBackupFile))
@@ -153,7 +152,7 @@ func TestAutomaticConfigUpgradeError(t *testing.T) {
 			config := fmt.Sprintf(testCase.Config, base.TestTLSSkipVerify(), base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), tb.GetName())
 
 			configPath := filepath.Join(tmpDir, "config.json")
-			err := ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
+			err := os.WriteFile(configPath, []byte(config), os.FileMode(0644))
 			require.NoError(t, err)
 
 			_, _, _, _, err = automaticConfigUpgrade(configPath)
@@ -190,7 +189,7 @@ func TestAutomaticConfigUpgradeExistingConfigAndNewGroup(t *testing.T) {
 		tb.GetName(),
 	)
 	configPath := filepath.Join(tmpDir, "config.json")
-	err := ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
+	err := os.WriteFile(configPath, []byte(config), os.FileMode(0644))
 	require.NoError(t, err)
 
 	// Run migration once
@@ -216,7 +215,7 @@ func TestAutomaticConfigUpgradeExistingConfigAndNewGroup(t *testing.T) {
 		tb.GetName(),
 	)
 	updatedConfigPath := filepath.Join(tmpDir, "config-updated.json")
-	err = ioutil.WriteFile(updatedConfigPath, []byte(updatedConfig), os.FileMode(0644))
+	err = os.WriteFile(updatedConfigPath, []byte(updatedConfig), os.FileMode(0644))
 	require.NoError(t, err)
 
 	// Run migration again to ensure no error and validate it doesn't actually update db
@@ -258,7 +257,7 @@ func TestAutomaticConfigUpgradeExistingConfigAndNewGroup(t *testing.T) {
 		tb.GetName(),
 	)
 	importConfigPath := filepath.Join(tmpDir, "config-import.json")
-	err = ioutil.WriteFile(importConfigPath, []byte(importConfig), os.FileMode(0644))
+	err = os.WriteFile(importConfigPath, []byte(importConfig), os.FileMode(0644))
 	require.NoError(t, err)
 
 	startupConfig, _, _, _, err = automaticConfigUpgrade(importConfigPath)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -16,7 +16,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -1574,7 +1574,7 @@ func doHTTPAuthRequest(httpClient *http.Client, username, password, method, path
 		return 0, nil, fmt.Errorf("unexpected response type from doHTTPAuthRequest")
 	}
 
-	bodyString, err := ioutil.ReadAll(httpResponse.Body)
+	bodyString, err := io.ReadAll(httpResponse.Body)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -11,7 +11,7 @@ package rest
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -48,7 +48,7 @@ func MakeResponse(status int, headers map[string]string, body string) *http.Resp
 	return &http.Response{
 		StatusCode:    status,
 		Status:        fmt.Sprintf("%d", status),
-		Body:          ioutil.NopCloser(bytes.NewBufferString(body)),
+		Body:          io.NopCloser(bytes.NewBufferString(body)),
 		ContentLength: int64(len(body)),
 		Proto:         "HTTP/1.1",
 		ProtoMajor:    1,

--- a/rest/utilities_testing_bootstrap.go
+++ b/rest/utilities_testing_bootstrap.go
@@ -10,7 +10,7 @@ package rest
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"testing"
@@ -108,7 +108,7 @@ func doBootstrapAdminRequest(t *testing.T, method, host, path, body string, head
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 
-	rBody, err := ioutil.ReadAll(resp.Body)
+	rBody, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
 	require.NoError(t, resp.Body.Close())

--- a/rest/utilities_testing_user.go
+++ b/rest/utilities_testing_user.go
@@ -10,7 +10,7 @@ package rest
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -44,7 +44,7 @@ func MakeUser(t *testing.T, httpClient *http.Client, serverURL, username, passwo
 	require.NoError(t, err)
 
 	if resp.(*http.Response).StatusCode != http.StatusOK {
-		bodyResp, err := ioutil.ReadAll(resp.(*http.Response).Body)
+		bodyResp, err := io.ReadAll(resp.(*http.Response).Body)
 		assert.NoError(t, err)
 		fmt.Println(string(bodyResp))
 	}

--- a/rest/x509_utils_test.go
+++ b/rest/x509_utils_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net"
 	"net/http"
@@ -68,25 +68,25 @@ func saveX509Files(t *testing.T, ca *caPair, node *nodePair, sg *sgPair) {
 	dirName := t.TempDir()
 
 	caPEMFilepath := filepath.Join(dirName, "ca.pem")
-	err := ioutil.WriteFile(caPEMFilepath, ca.PEM.Bytes(), os.FileMode(0777))
+	err := os.WriteFile(caPEMFilepath, ca.PEM.Bytes(), os.FileMode(0777))
 	require.NoError(t, err)
 	ca.PEMFilepath = caPEMFilepath
 
 	chainPEMFilepath := filepath.Join(dirName, "chain.pem")
-	err = ioutil.WriteFile(chainPEMFilepath, node.PEM.Bytes(), os.FileMode(0777))
+	err = os.WriteFile(chainPEMFilepath, node.PEM.Bytes(), os.FileMode(0777))
 	require.NoError(t, err)
 	node.PEMFilepath = chainPEMFilepath
 	pkeyKeyFilepath := filepath.Join(dirName, "pkey.key")
-	err = ioutil.WriteFile(pkeyKeyFilepath, node.Key.Bytes(), os.FileMode(0777))
+	err = os.WriteFile(pkeyKeyFilepath, node.Key.Bytes(), os.FileMode(0777))
 	require.NoError(t, err)
 	node.KeyFilePath = pkeyKeyFilepath
 
 	sgPEMFilepath := filepath.Join(dirName, "sg.pem")
-	err = ioutil.WriteFile(sgPEMFilepath, sg.PEM.Bytes(), os.FileMode(0777))
+	err = os.WriteFile(sgPEMFilepath, sg.PEM.Bytes(), os.FileMode(0777))
 	require.NoError(t, err)
 	sg.PEMFilepath = sgPEMFilepath
 	sgKeyFilepath := filepath.Join(dirName, "sg.key")
-	err = ioutil.WriteFile(sgKeyFilepath, sg.Key.Bytes(), os.FileMode(0777))
+	err = os.WriteFile(sgKeyFilepath, sg.Key.Bytes(), os.FileMode(0777))
 	require.NoError(t, err)
 	sg.KeyFilePath = sgKeyFilepath
 }
@@ -320,7 +320,7 @@ func uploadCACertViaREST(couchbaseServerURL url.URL, ca *caPair) error {
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -336,7 +336,7 @@ func uploadCACertViaREST(couchbaseServerURL url.URL, ca *caPair) error {
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	respBody, err = ioutil.ReadAll(resp.Body)
+	respBody, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -414,7 +414,7 @@ func enableX509ClientCertsInCouchbaseServer(restAPIURL url.URL) error {
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo`)
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
- [ ] `GSI=true,xattrs=true` (for collections) https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
