### PR TITLE
Support long-lived connections for BootstrapConnection

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -326,6 +326,9 @@ func (cc *CouchbaseCluster) UpdateConfig(location, groupID string, updateCallbac
 // Close calls teardown for any cached buckets and removes from cachedBucketConnections
 func (cc *CouchbaseCluster) Close() {
 
+	cc.cachedConnectionLock.Lock()
+	defer cc.cachedConnectionLock.Unlock()
+
 	for bucketName, cachedBucket := range cc.cachedBucketConnections {
 		cachedBucket.teardownFn()
 		delete(cc.cachedBucketConnections, bucketName)

--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	"github.com/couchbase/gocb/v2"
@@ -30,15 +31,39 @@ type BootstrapConnection interface {
 	InsertConfig(bucket, groupID string, value interface{}) (newCAS uint64, err error)
 	// UpdateConfig updates an existing database config for a given bucket and config group ID. updateCallback can return nil to remove the config.
 	UpdateConfig(bucket, groupID string, updateCallback func(rawBucketConfig []byte) (updatedConfig []byte, err error)) (newCAS uint64, err error)
+	// Close releases any long-lived connections
+	Close()
 }
 
 // CouchbaseCluster is a GoCBv2 implementation of BootstrapConnection
 type CouchbaseCluster struct {
-	server             string
-	clusterOptions     gocb.ClusterOptions
-	forcePerBucketAuth bool // Forces perBucketAuth authenticators to be used to connect to the bucket
-	perBucketAuth      map[string]*gocb.Authenticator
+	server                  string
+	clusterOptions          gocb.ClusterOptions
+	forcePerBucketAuth      bool // Forces perBucketAuth authenticators to be used to connect to the bucket
+	perBucketAuth           map[string]*gocb.Authenticator
+	bucketConnectionMode    BucketConnectionMode     // Whether to cache cluster connections
+	cachedClusterConnection *gocb.Cluster            // Cached cluster connection, should only be used by GetConfigBuckets
+	cachedBucketConnections map[string]*cachedBucket // Per-bucket cached connections
+	cachedConnectionLock    sync.Mutex               // mutex for access to cachedBucketConnections
 }
+
+type BucketConnectionMode int
+
+const (
+	// CachedClusterConnections mode reuses a cached cluster connection.  Should be used for recurring operations
+	CachedClusterConnections BucketConnectionMode = iota
+	// PerUseClusterConnections mode establishes a new cluster connection per cluster operation.  Should be used for adhoc operations
+	PerUseClusterConnections
+)
+
+type cachedBucket struct {
+	bucket     *gocb.Bucket
+	teardownFn func()
+}
+
+// noopTeardown is returned by getBucket when using a cached bucket - these buckets are torn down
+// when CouchbaseCluster.Close is called.
+func noopTeardown() {}
 
 var _ BootstrapConnection = &CouchbaseCluster{}
 
@@ -46,7 +71,7 @@ var _ BootstrapConnection = &CouchbaseCluster{}
 func NewCouchbaseCluster(server, username, password,
 	x509CertPath, x509KeyPath, caCertPath string,
 	forcePerBucketAuth bool, perBucketCreds PerBucketCredentialsConfig,
-	tlsSkipVerify *bool) (*CouchbaseCluster, error) {
+	tlsSkipVerify *bool, bucketMode BucketConnectionMode) (*CouchbaseCluster, error) {
 
 	securityConfig, err := GoCBv2SecurityConfig(tlsSkipVerify, caCertPath)
 	if err != nil {
@@ -81,11 +106,17 @@ func NewCouchbaseCluster(server, username, password,
 	}
 
 	cbCluster := &CouchbaseCluster{
-		server:             server,
-		forcePerBucketAuth: forcePerBucketAuth,
-		perBucketAuth:      perBucketAuth,
-		clusterOptions:     clusterOptions,
+		server:               server,
+		forcePerBucketAuth:   forcePerBucketAuth,
+		perBucketAuth:        perBucketAuth,
+		clusterOptions:       clusterOptions,
+		bucketConnectionMode: bucketMode,
 	}
+
+	if bucketMode == CachedClusterConnections {
+		cbCluster.cachedBucketConnections = make(map[string]*cachedBucket)
+	}
+
 	return cbCluster, nil
 }
 
@@ -117,22 +148,46 @@ func (cc *CouchbaseCluster) connect(auth *gocb.Authenticator) (*gocb.Cluster, er
 	return cluster, nil
 }
 
+func (cc *CouchbaseCluster) getClusterConnection() (*gocb.Cluster, error) {
+
+	if cc.bucketConnectionMode == PerUseClusterConnections {
+		return cc.connect(nil)
+	}
+
+	cc.cachedConnectionLock.Lock()
+	defer cc.cachedConnectionLock.Unlock()
+	if cc.cachedClusterConnection != nil {
+		return cc.cachedClusterConnection, nil
+	}
+
+	clusterConnection, err := cc.connect(nil)
+	if err != nil {
+		return nil, err
+	}
+	cc.cachedClusterConnection = clusterConnection
+	return cc.cachedClusterConnection, nil
+
+}
+
 func (cc *CouchbaseCluster) GetConfigBuckets() ([]string, error) {
 	if cc == nil {
 		return nil, errors.New("nil CouchbaseCluster")
 	}
 
-	connection, err := cc.connect(nil)
+	connection, err := cc.getClusterConnection()
 	if err != nil {
 		return nil, err
 	}
 
 	defer func() {
-		_ = connection.Close(&gocb.ClusterCloseOptions{})
+		if cc.bucketConnectionMode == PerUseClusterConnections {
+			_ = connection.Close(nil)
+		}
 	}()
 
 	buckets, err := connection.Buckets().GetAllBuckets(nil)
 	if err != nil {
+		cc.cachedClusterConnection = nil
 		return nil, err
 	}
 
@@ -150,6 +205,7 @@ func (cc *CouchbaseCluster) GetConfig(location, groupID string, valuePtr interfa
 	}
 
 	b, teardown, err := cc.getBucket(location)
+
 	if err != nil {
 		return 0, err
 	}
@@ -267,8 +323,59 @@ func (cc *CouchbaseCluster) UpdateConfig(location, groupID string, updateCallbac
 
 }
 
-// getBucket returns the bucket after waiting for it to be ready.
+// Close calls teardown for any cached buckets and removes from cachedBucketConnections
+func (cc *CouchbaseCluster) Close() {
+
+	for bucketName, cachedBucket := range cc.cachedBucketConnections {
+		cachedBucket.teardownFn()
+		delete(cc.cachedBucketConnections, bucketName)
+	}
+	if cc.cachedClusterConnection != nil {
+		_ = cc.cachedClusterConnection.Close(nil)
+		cc.cachedClusterConnection = nil
+	}
+}
+
 func (cc *CouchbaseCluster) getBucket(bucketName string) (b *gocb.Bucket, teardownFn func(), err error) {
+
+	if cc.bucketConnectionMode != CachedClusterConnections {
+		return cc.connectToBucket(bucketName)
+	}
+
+	cc.cachedConnectionLock.Lock()
+	defer cc.cachedConnectionLock.Unlock()
+
+	cacheBucket, ok := cc.cachedBucketConnections[bucketName]
+	if ok {
+		return cacheBucket.bucket, noopTeardown, nil
+	}
+
+	// cached bucket not found, connect and add
+	newBucket, newTeardownFn, err := cc.connectToBucket(bucketName)
+	if err != nil {
+		return nil, nil, err
+	}
+	cc.cachedBucketConnections[bucketName] = &cachedBucket{
+		bucket:     newBucket,
+		teardownFn: newTeardownFn,
+	}
+	return newBucket, noopTeardown, nil
+}
+
+// For unrecoverable errors when using cached buckets, remove the bucket from the cache to trigger a new connection on next usage
+func (cc *CouchbaseCluster) onCachedBucketError(bucketName string) {
+
+	cc.cachedConnectionLock.Lock()
+	defer cc.cachedConnectionLock.Unlock()
+	cacheBucket, ok := cc.cachedBucketConnections[bucketName]
+	if ok {
+		cacheBucket.teardownFn()
+		delete(cc.cachedBucketConnections, bucketName)
+	}
+}
+
+// connectToBucket establishes a new connection to a bucket, and returns the bucket after waiting for it to be ready.
+func (cc *CouchbaseCluster) connectToBucket(bucketName string) (b *gocb.Bucket, teardownFn func(), err error) {
 	var connection *gocb.Cluster
 	if bucketAuth, set := cc.perBucketAuth[bucketName]; set {
 		connection, err = cc.connect(bucketAuth)

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -5083,7 +5083,7 @@ func TestPerDBCredsOverride(t *testing.T) {
 	}()
 	require.NoError(t, sc.WaitForRESTAPIs())
 
-	couchbaseCluster, err := rest.CreateCouchbaseClusterFromStartupConfig(sc.Config)
+	couchbaseCluster, err := rest.CreateCouchbaseClusterFromStartupConfig(sc.Config, base.PerUseClusterConnections)
 	require.NoError(t, err)
 	sc.BootstrapContext.Connection = couchbaseCluster
 

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
@@ -244,4 +245,54 @@ func TestBootstrapDuplicateDatabase(t *testing.T) {
 	resp = BootstrapAdminRequest(t, http.MethodGet, "/_expvar", "")
 	resp.RequireStatus(http.StatusOK)
 	assert.Contains(t, resp.Body, `"num_doc_writes":1`)
+}
+
+// Development-time test, expects locally running Couchbase Server and designed for long-running memory profiling
+func DevTestFetchConfigManual(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
+
+	serverErr := make(chan error, 0)
+
+	config := DefaultStartupConfig("")
+
+	logLevel := base.LevelInfo
+	config.Logging.Console = &base.ConsoleLoggerConfig{
+		LogLevel: &logLevel,
+		LogKeys:  []string{"HTTP", "Config", "CRUD", "DCP", "Sync"},
+	}
+
+	config.API.AdminInterfaceAuthentication = base.BoolPtr(false)
+
+	config.API.PublicInterface = "127.0.0.1:4984"
+	config.API.AdminInterface = "127.0.0.1:4985"
+	config.API.MetricsInterface = "127.0.0.1:4986"
+
+	config.Bootstrap.Server = "couchbase://localhost"
+	config.Bootstrap.Username = "configUser"
+	config.Bootstrap.Password = "password"
+	config.Bootstrap.ServerTLSSkipVerify = base.BoolPtr(true)
+	config.Bootstrap.UseTLSServer = base.BoolPtr(false)
+
+	// Start SG with no databases, high frequency polling
+	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(time.Second)
+
+	ctx := base.TestCtx(t)
+	sc, err := SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+
+	defer func() {
+		sc.Close(ctx)
+		require.NoError(t, <-serverErr)
+	}()
+
+	go func() {
+		serverErr <- StartServer(ctx, &config, sc)
+	}()
+	require.NoError(t, sc.WaitForRESTAPIs())
+
+	// Sleep to wait for bucket polling iterations, or allow manual modification to server accessibility
+
+	time.Sleep(900 * time.Second)
+
 }

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -293,6 +293,6 @@ func DevTestFetchConfigManual(t *testing.T) {
 
 	// Sleep to wait for bucket polling iterations, or allow manual modification to server accessibility
 
-	time.Sleep(900 * time.Second)
+	time.Sleep(15 * time.Second)
 
 }

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -331,7 +331,7 @@ func TestLegacyGuestUserMigration(t *testing.T) {
 	sc, _, _, _, err := automaticConfigUpgrade(configPath)
 	require.NoError(t, err)
 
-	cluster, err := CreateCouchbaseClusterFromStartupConfig(sc)
+	cluster, err := CreateCouchbaseClusterFromStartupConfig(sc, base.PerUseClusterConnections)
 	require.NoError(t, err)
 
 	var dbConfig DbConfig

--- a/rest/main.go
+++ b/rest/main.go
@@ -206,7 +206,7 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 	}
 
 	// Attempt to establish connection to server
-	cluster, err := CreateCouchbaseClusterFromStartupConfig(startupConfig)
+	cluster, err := CreateCouchbaseClusterFromStartupConfig(startupConfig, base.PerUseClusterConnections)
 	if err != nil {
 		return nil, false, nil, nil, err
 	}
@@ -365,10 +365,10 @@ func backupCurrentConfigFile(sourcePath string) (string, error) {
 	return backupPath, nil
 }
 
-func CreateCouchbaseClusterFromStartupConfig(config *StartupConfig) (*base.CouchbaseCluster, error) {
+func CreateCouchbaseClusterFromStartupConfig(config *StartupConfig, bucketConnectionMode base.BucketConnectionMode) (*base.CouchbaseCluster, error) {
 	cluster, err := base.NewCouchbaseCluster(config.Bootstrap.Server, config.Bootstrap.Username, config.Bootstrap.Password,
 		config.Bootstrap.X509CertPath, config.Bootstrap.X509KeyPath, config.Bootstrap.CACertPath,
-		config.IsServerless(), config.BucketCredentials, config.Bootstrap.ServerTLSSkipVerify)
+		config.IsServerless(), config.BucketCredentials, config.Bootstrap.ServerTLSSkipVerify, bucketConnectionMode)
 	if err != nil {
 		base.InfofCtx(context.Background(), base.KeyConfig, "Couldn't create couchbase cluster instance: %v", err)
 		return nil, err

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -96,7 +96,7 @@ func TestAutomaticConfigUpgrade(t *testing.T) {
 
 	assert.Equal(t, config, string(writtenBackupFile))
 
-	cbs, err := CreateCouchbaseClusterFromStartupConfig(startupConfig)
+	cbs, err := CreateCouchbaseClusterFromStartupConfig(startupConfig, base.PerUseClusterConnections)
 	require.NoError(t, err)
 
 	var dbConfig DbConfig
@@ -223,7 +223,7 @@ func TestAutomaticConfigUpgradeExistingConfigAndNewGroup(t *testing.T) {
 	startupConfig, _, _, _, err := automaticConfigUpgrade(updatedConfigPath)
 	require.NoError(t, err)
 
-	cbs, err := CreateCouchbaseClusterFromStartupConfig(startupConfig)
+	cbs, err := CreateCouchbaseClusterFromStartupConfig(startupConfig, base.PerUseClusterConnections)
 	require.NoError(t, err)
 
 	var dbConfig DbConfig

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -814,7 +814,7 @@ func (rt *RestTester) GetDocumentSequence(key string) (sequence uint64) {
 func (rt *RestTester) ReplacePerBucketCredentials(config base.PerBucketCredentialsConfig) {
 	rt.ServerContext().Config.BucketCredentials = config
 	// Update the CouchbaseCluster to include the new bucket credentials
-	couchbaseCluster, err := CreateCouchbaseClusterFromStartupConfig(rt.ServerContext().Config)
+	couchbaseCluster, err := CreateCouchbaseClusterFromStartupConfig(rt.ServerContext().Config, base.PerUseClusterConnections)
 	require.NoError(rt.TB, err)
 	rt.ServerContext().BootstrapContext.Connection = couchbaseCluster
 }


### PR DESCRIPTION
Optional caching for BootstrapConnection cluster and bucket connections. Avoids memory allocation and associated GC work for config monitoring.

Cached entries are removed on error, triggering reconnection on next request.

Clients using BootstrapConnection in cached connection mode are required to call Close to release connections.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` (for collections) https://jenkins.sgwdev.com/job/SyncGateway-Integration/931/
