### PR TITLE
Ignore skipped tests when running LongRunningTest logic

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -861,7 +861,7 @@ func LongRunningTest(t *testing.T) {
 	start := time.Now()
 	t.Cleanup(func() {
 		testDuration := time.Since(start)
-		if !t.Failed() && testDuration < shortTestThreshold {
+		if !t.Failed() && !t.Skipped() && testDuration < shortTestThreshold {
 			t.Logf("TEST: %q was marked as long running, but finished in %v (less than %v) - consider removing LongRunningTest", t.Name(), testDuration, shortTestThreshold)
 		}
 	})


### PR DESCRIPTION
This util function erroneously logged when a long running test was being skipped quickly.

e.g.
```
    util_testing.go:865: TEST: "TestDefaultConflictResolverWithTombstoneRemote" was marked as long running, but finished in 9.05µs (less than 1s) - consider removing LongRunningTest
--- SKIP: TestDefaultConflictResolverWithTombstoneRemote (0.00s)
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a