### PR TITLE
CBG-2453: Friendly error message when updating a config with a non-existing collection

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -760,18 +760,6 @@ func TestRequiresCollections(t *testing.T) {
 	}
 }
 
-func WaitUntilScopeAndCollectionExists(collection *gocb.Collection) error {
-	err, _ := RetryLoop("wait for scope and collection to exist", func() (shouldRetry bool, err error, value interface{}) {
-		_, err = collection.Exists("waitUntilScopeAndCollectionExists", nil)
-		if err != nil {
-			WarnfCtx(context.TODO(), "Error checking if collection exists: %v", err)
-			return true, err, nil
-		}
-		return false, nil, nil
-	}, CreateMaxDoublingSleeperFunc(30, 10, 1000))
-	return err
-}
-
 // CreateBucketScopesAndCollections will create the given scopes and collections within the given BucketSpec.
 func CreateBucketScopesAndCollections(ctx context.Context, bucketSpec BucketSpec, scopes map[string][]string) error {
 	atLeastOneScope := false

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -760,7 +760,7 @@ func TestRequiresCollections(t *testing.T) {
 	}
 }
 
-func waitUntilScopeAndCollectionExists(collection *gocb.Collection) error {
+func WaitUntilScopeAndCollectionExists(collection *gocb.Collection) error {
 	err, _ := RetryLoop("wait for scope and collection to exist", func() (shouldRetry bool, err error, value interface{}) {
 		_, err = collection.Exists("waitUntilScopeAndCollectionExists", nil)
 		if err != nil {
@@ -821,7 +821,7 @@ func CreateBucketScopesAndCollections(ctx context.Context, bucketSpec BucketSpec
 				return fmt.Errorf("failed to create collection %s in scope %s: %w", collectionName, scopeName, err)
 			}
 			DebugfCtx(ctx, KeySGTest, "Created collection %s.%s", scopeName, collectionName)
-			if err := waitUntilScopeAndCollectionExists(cluster.Bucket(bucketSpec.BucketName).Scope(scopeName).Collection(collectionName)); err != nil {
+			if err := WaitUntilScopeAndCollectionExists(cluster.Bucket(bucketSpec.BucketName).Scope(scopeName).Collection(collectionName)); err != nil {
 				return err
 			}
 			DebugfCtx(ctx, KeySGTest, "Collection now exists %s.%s", scopeName, collectionName)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -452,8 +452,8 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		if err != nil {
 			return nil, err
 		}
-		// Check if scope/collection specified exists
-		_, err = collection.Exists("waitUntilScopeAndCollectionExists", nil)
+		// Check if scope/collection specified exists. Will enter retry loop if connection unsuccessful
+		err = base.WaitUntilScopeAndCollectionExists(collection.Collection)
 		if err != nil {
 			return nil, fmt.Errorf("attempting to create/update database with a scope/collection that is not found")
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -448,12 +448,12 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 			return nil, errCollectionsUnsupported
 		}
 		// TODO: This needs changing when implementing Phase 2 collections: support for multiple collections
-		col, err := base.AsCollection(bucket)
+		collection, err := base.AsCollection(bucket)
 		if err != nil {
 			return nil, err
 		}
 		// Check if scope/collection specified exists
-		_, err = col.Exists("waitUntilScopeAndCollectionExists", nil)
+		_, err = collection.Exists("waitUntilScopeAndCollectionExists", nil)
 		if err != nil {
 			return nil, fmt.Errorf("attempting to create/update database with a scope/collection that is not found")
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -447,6 +447,16 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		if !bucket.IsSupported(sgbucket.DataStoreFeatureCollections) {
 			return nil, errCollectionsUnsupported
 		}
+		// TODO: This needs changing when implementing Phase 2 collections: support for multiple collections
+		col, err := base.AsCollection(bucket)
+		if err != nil {
+			return nil, err
+		}
+		// Check if scope/collection specified exists
+		_, err = col.Exists("waitUntilScopeAndCollectionExists", nil)
+		if err != nil {
+			return nil, fmt.Errorf("attempting to create/update database with a scope/collection that is not found")
+		}
 	}
 
 	// Initialize Views or GSI indexes for the bucket


### PR DESCRIPTION
CBG-2453

Simple change to return a more user friendly error message if a non existent scope/collection is specified in databse config update. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
- [ ] `GSI=true,xattrs=true` (for collections) https://jenkins.sgwdev.com/job/SyncGateway-Integration/933/
