### PR TITLE
Don't print out bucket contents with a type assertion.

### DIFF
--- a/base/collection.go
+++ b/base/collection.go
@@ -1106,7 +1106,7 @@ func AsCollection(bucket Bucket) (*Collection, error) {
 	case *TestBucket:
 		underlyingBucket = typedBucket.Bucket
 	default:
-		return nil, fmt.Errorf("bucket %+v has unrecognized type %T", bucket, bucket)
+		return nil, fmt.Errorf("bucket has unrecognized type %T", bucket)
 	}
 
 	return AsCollection(underlyingBucket)


### PR DESCRIPTION
These might be being modified while this printing is happening.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

