### PR TITLE
CBG-2282: Added timeout and change retry handling for GoCB v2 ops

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -102,7 +102,8 @@ func NewCouchbaseCluster(server, username, password,
 	clusterOptions := gocb.ClusterOptions{
 		Authenticator:  clusterAuthConfig,
 		SecurityConfig: securityConfig,
-		RetryStrategy:  &goCBv2FailFastRetryStrategy{},
+		TimeoutsConfig: GoCBv2TimeoutsConfig(nil, nil),
+		RetryStrategy:  gocb.NewBestEffortRetryStrategy(nil),
 	}
 
 	cbCluster := &CouchbaseCluster{

--- a/base/collection.go
+++ b/base/collection.go
@@ -126,7 +126,9 @@ func GetCollectionFromCluster(cluster *gocb.Cluster, spec BucketSpec, waitUntilR
 
 	// Connect to bucket
 	bucket := cluster.Bucket(spec.BucketName)
-	err := bucket.WaitUntilReady(time.Duration(waitUntilReadySeconds)*time.Second, nil)
+	err := bucket.WaitUntilReady(time.Duration(waitUntilReadySeconds)*time.Second, &gocb.WaitUntilReadyOptions{
+		RetryStrategy: &goCBv2FailFastRetryStrategy{},
+	})
 	if err != nil {
 		_ = cluster.Close(&gocb.ClusterCloseOptions{})
 		if errors.Is(err, gocb.ErrAuthenticationFailure) {

--- a/base/collection.go
+++ b/base/collection.go
@@ -67,7 +67,7 @@ func GetCouchbaseCollection(spec BucketSpec) (*Collection, error) {
 		Authenticator:  authenticator,
 		SecurityConfig: securityConfig,
 		TimeoutsConfig: timeoutsConfig,
-		RetryStrategy:  &goCBv2FailFastRetryStrategy{},
+		RetryStrategy:  gocb.NewBestEffortRetryStrategy(nil),
 	}
 
 	if spec.KvPoolSize > 0 {

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -133,8 +133,8 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 
 		"unsupported.user_queries": {&config.Unsupported.UserQueries, fs.Bool("unsupported.user_queries", false, "Whether user-query APIs are enabled")},
 
-		"database_credentials": {&config.DatabaseCredentials, fs.String("database_credentials", "null", "JSON-encoded per-database credentials, that can be used instead of the bootstrap ones. Cannot be used in conjunction with bucket_credentials.")},
-		"bucket_credentials":   {&config.BucketCredentials, fs.String("bucket_credentials", "null", "JSON-encoded per-bucket credentials, that can be used instead of the bootstrap ones. Cannot be used in conjunction with database_credentials.")},
+		"database_credentials": {&config.DatabaseCredentials, fs.String("database_credentials", "null", "JSON-encoded per-database credentials, that can be used instead of the bootstrap ones. This will override bucket_credentials that target the bucket that the database is in.")},
+		"bucket_credentials":   {&config.BucketCredentials, fs.String("bucket_credentials", "null", "JSON-encoded per-bucket credentials, that can be used instead of the bootstrap ones.")},
 
 		"max_file_descriptors": {&config.MaxFileDescriptors, fs.Uint64("max_file_descriptors", 0, "Max # of open file descriptors (RLIMIT_NOFILE)")},
 

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -78,8 +78,8 @@ type StartupConfig struct {
 	Replicator  ReplicatorConfig   `json:"replicator,omitempty"`
 	Unsupported UnsupportedConfig  `json:"unsupported,omitempty"`
 
-	DatabaseCredentials PerDatabaseCredentialsConfig    `json:"database_credentials,omitempty" help:"A map of database name to credentials, that can be used instead of the bootstrap ones. Cannot be used in conjunction with bucket_credentials."`
-	BucketCredentials   base.PerBucketCredentialsConfig `json:"bucket_credentials,omitempty" help:"A map of bucket names to credentials, that can be used instead of the bootstrap ones. Cannot be used in conjunction with database_credentials."`
+	DatabaseCredentials PerDatabaseCredentialsConfig    `json:"database_credentials,omitempty" help:"A map of database name to credentials, that can be used instead of the bootstrap ones. This will override bucket_credentials that target the bucket that the database is in."`
+	BucketCredentials   base.PerBucketCredentialsConfig `json:"bucket_credentials,omitempty" help:"A map of bucket names to credentials, that can be used instead of the bootstrap ones."`
 
 	MaxFileDescriptors         uint64 `json:"max_file_descriptors,omitempty" help:"Max # of open file descriptors (RLIMIT_NOFILE)"`
 	CouchbaseKeepaliveInterval *int   `json:"couchbase_keepalive_interval,omitempty" help:"TCP keep-alive interval between SG and Couchbase server"`


### PR DESCRIPTION
CBG-2282

### `initializeCouchbaseServerConnections`
`initializeGoCBAgent` has been left to fail fast due to SG handling the retry loop of it due to CBS and SG race conditioning happening when launching at the same time.

 The cluster connection now uses a best effort retry strategy so any operations that use the GoCB clusster connection will have best effort retry handling instead of failing fast. This is set up in `NewCouchbaseCluster`.

The best effort retry handling is not done when getting the configs (both for the initial launch and for the incremental config fetching) so that this can have an auth error instantly. If this fails fast for any other reason, it is not an issue as it will try again when doing the incremental fetch configs (as defined by `config_update_frequency`) which will load/reload the database depending on if it loaded successfully on startup or not. This is done in `(cc *CouchbaseCluster) connect(auth *gocb.Authenticator) (*gocb.Cluster, error)`.

The `WaitUntilReady` in `(cc *CouchbaseCluster) connectToBucket(bucketName string) (b *gocb.Bucket, teardownFn func(), err error)` did not get changed to use best effort retry handling so it can also report authentication failures instantly. Even though `(cc *CouchbaseCluster) connect(auth *gocb.Authenticator) (*gocb.Cluster, error)` will catch authentication errors, it does not try to authenticate with the bucket directly (only the cluster) so therefore the WaitUntilReady is left as a fail fast so it can be confirmed the user has access to that bucket (as RBAC may prevent this). This is useful for making sure per bucket authentication is successful without getting stuck in a retry loop unnecessarily.

I have added a timeout to the cluster options which will use the GoCB defaults. These defaults are 10 seconds for bucket ops, and 7.5 seconds for a view query op.

Testing was done to make sure authentication failures fail fast using: incorrect per bucket user details, per bucket user details that are valid but can't access the bucket (RBAC), and incorrect cluster details.

### `connectToBucket(ctx context.Context, spec base.BucketSpec) (base.Bucket, error)`
This function gets used when loading/adding a database to Sync Gateway. The cluster options here have been changed to use a best effort retry loop. 

This function implements it's own retry loop around connecting to the bucket so GoCB does not need to attempt to retry so the `WaitUntilReady` in `GetCouchbaseCollection(spec BucketSpec) (*Collection, error)` has been left as a fail fast. This means that authentication errors can be handled that where not handled by `initializeCouchbaseServerConnections` (such as because a database was created that used invalid per db credentials). Using a best effort retry in this `WaitUntilReady` would cause hanging on the PUT db endpoint, and then an unambiguous timeout error which is not helpful.
 
An appropriate timeout is already used for the cluster options which uses user defined options, or 10 seconds by default.

Testing was done using invalid per db credentials and then either creating the database with the same name, or having it already exist when SG is started. This failed fast as expected.

### `GetCollectionFromCluster`
I added a fast fail to the `WaitUntilReady` here so when an invalid bucket name is used, the operation will fast fail and the `PUT /{db}/` endpoint will not just timeout with an unknown error.

Tested using unit test `TestCreateDbOnNonExistentBucket`

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/945/
- [x] `xattrs=true gsi=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/951
