### PR TITLE
CBG-2469 Avoid race and support CE in TestDBReplicationStatsTeardown

### DIFF
--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -1743,7 +1743,7 @@ func TestDBReplicationStatsTeardown(t *testing.T) {
 		getResp := rt.SendAdminRequest("GET", "/db2/marker1", "")
 		return getResp.Code == http.StatusOK
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Force DB reload by modifying config
 	resp = rt.SendAdminRequest(http.MethodPost, "/db/_config", `{"import_docs": false}`)
@@ -1761,6 +1761,6 @@ func TestDBReplicationStatsTeardown(t *testing.T) {
 		getResp := rt.SendAdminRequest("GET", "/db2/marker2", "")
 		return getResp.Code == http.StatusOK
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 }


### PR DESCRIPTION
Wait for replications to replicate docs before restarting database, explicitly recreate replication under CE.

CBG-2469

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` (for collections) https://jenkins.sgwdev.com/job/SyncGateway-Integration/935/
  - unrelated failures:
  - [github.com/couchbase/sync_gateway/db.TestRemoveIndexesUseViewsTrueAndFalse](https://jenkins.sgwdev.com/job/SyncGateway-Integration/935/testReport/junit/github/com_couchbase_sync_gateway_db/TestRemoveIndexesUseViewsTrueAndFalse/)
  - [github.com/couchbase/sync_gateway/db/functions.TestUserGraphQLWithN1QL](https://jenkins.sgwdev.com/job/SyncGateway-Integration/935/testReport/junit/github/com_couchbase_sync_gateway_db_functions/TestUserGraphQLWithN1QL/)