### PR TITLE
CBG-2424: Allow databases to override CORS config

### DIFF
--- a/auth/cors.go
+++ b/auth/cors.go
@@ -1,0 +1,41 @@
+package auth
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Configuration for Cross-Origin Resource Sharing
+// <https://en.wikipedia.org/wiki/Cross-origin_resource_sharing>
+type CORSConfig struct {
+	Origin      []string `json:"origin,omitempty"       help:"List of allowed origins, use ['*'] to allow access from everywhere"`
+	LoginOrigin []string `json:"login_origin,omitempty" help:"List of allowed login origins"`
+	Headers     []string `json:"headers,omitempty"      help:"List of allowed headers"`
+	MaxAge      int      `json:"max_age,omitempty"      help:"Maximum age of the CORS Options request"`
+}
+
+// Adds Access-Control-Allow-Origin, Access-Control-Allow-Credentials, Access-Control-Allow-Headers headers to an HTTP response.
+func (cors *CORSConfig) AddResponseHeaders(request *http.Request, response http.ResponseWriter) {
+	if originHeader := request.Header["Origin"]; len(originHeader) > 0 {
+		origin := MatchedOrigin(cors.Origin, originHeader)
+		response.Header().Add("Access-Control-Allow-Origin", origin)
+		response.Header().Add("Access-Control-Allow-Credentials", "true")
+		response.Header().Add("Access-Control-Allow-Headers", strings.Join(cors.Headers, ", "))
+	}
+}
+
+func MatchedOrigin(allowOrigins []string, rqOrigins []string) string {
+	for _, rv := range rqOrigins {
+		for _, av := range allowOrigins {
+			if rv == av {
+				return av
+			}
+		}
+	}
+	for _, av := range allowOrigins {
+		if av == "*" {
+			return "*"
+		}
+	}
+	return ""
+}

--- a/db/database.go
+++ b/db/database.go
@@ -123,6 +123,7 @@ type DatabaseContext struct {
 	userFunctions                UserFunctions            // client-callable JavaScript functions
 	graphQL                      *GraphQL                 // GraphQL query evaluator
 	Scopes                       map[string]Scope         // A map keyed by scope name containing a set of scopes/collections. Nil if running with only _default._default
+	CORS                         *auth.CORSConfig         // Custom or inherited CORS config
 }
 
 type Scope struct {

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1397,19 +1397,19 @@ Database:
           username_claim:
             description: |-
               Allows a different OpenID Connect field to be specified instead of the Subject (`sub`).
-              
+
               The field name to use can be specified here.
             type: string
           roles_claim:
             description: |-
               If set, the value(s) of the given JSON Web Token claim will be added to the user's roles.
-              
+
               The value of this claim must be either a string or an array of strings, any other type will result in an error.
             type: string
           channels_claim:
             description: |-
               If set, the value(s) of the given JSON Web Token claim will be added to the user's channels.
-              
+
               The value of this claim must be either a string or an array of strings, any other type will result in an error.
             type: string
     oidc:
@@ -1438,7 +1438,7 @@ Database:
               callback_url:
                 description: |-
                   The URL that the OpenID Connect will redirect to after authentication.
-    
+
                   If not provided, a callback URL will be generated.
                 type: string
               disable_session:
@@ -1465,26 +1465,26 @@ Database:
               disable_callback_state:
                 description: |-
                   Controls whether to maintain state between the auth request and callback endpoints (`/_oidc` and `/_oidc_callback`).
-    
+
                   **This is not recommended as it would cause OpenID Connect authentication to be vulnerable to Cross-Site Request Forgery (CSRF, XSRF).**
                 type: boolean
                 default: false
               username_claim:
                 description: |-
                   Allows a different OpenID Connect field to be specified instead of the Subject (`sub`).
-    
+
                   The field name to use can be specified here.
                 type: string
               roles_claim:
                 description: |-
                   If set, the value(s) of the given OpenID Connect authentication token claim will be added to the user's roles.
-    
+
                   The value of this claim must be either a string or an array of strings, any other type will result in an error.
                 type: string
               channels_claim:
                 description: |-
                   If set, the value(s) of the given OpenID Connect authentication token claim will be added to the user's channels.
-    
+
                   The value of this claim must be either a string or an array of strings, any other type will result in an error.
                 type: string
               allow_unsigned_provider_tokens:
@@ -1630,11 +1630,33 @@ Database:
       default: 60
     suspendable:
       description: |-
-        Set to true to allow the database to be suspended. 
-        
+        Set to true to allow the database to be suspended.
+
         Defaults to true when running in serverless mode otherwise defaults to false.
       type: boolean
       default: false
+    cors:
+      description: CORS configuration for this database; if present, overrides server's config.
+      type: object
+      properties:
+        origin:
+          description: 'List of allowed origins, use [''*''] to allow access from everywhere'
+          type: array
+          items:
+            type: string
+        login_origin:
+          description: List of allowed login origins
+          type: array
+          items:
+            type: string
+        headers:
+          description: List of allowed headers
+          type: array
+          items:
+            type: string
+        max_age:
+          description: Maximum age of the CORS Options request
+          type: integer
   title: Database-config
 Event-config:
   type: object
@@ -1715,7 +1737,7 @@ Compact-status:
       description: |-
         **Applicable to attachment compaction only**
 
-        This is the number of references there are to legacy attachments. 
+        This is the number of references there are to legacy attachments.
       type: string
     purged_attachments:
       description: |-
@@ -1760,8 +1782,8 @@ Serverless:
       readOnly: true
     min_config_fetch_interval:
       description: |-
-        How long database configs should be kept for in Sync Gateway before refreshing. Set to 0 to fetch configs everytime. This is used for requested databases that SG does not know about. 
-        
+        How long database configs should be kept for in Sync Gateway before refreshing. Set to 0 to fetch configs everytime. This is used for requested databases that SG does not know about.
+
         This is a duration and therefore can be provided with units "h", "m", "s", "ms", "us", and "ns". For example, 5 hours, 20 minutes, and 30 seconds would be `5h20m30s`.
       type: string
       default: 1s

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -722,6 +722,54 @@ func TestCORSOrigin(t *testing.T) {
 	assert.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
 }
 
+func TestCORSOriginPerDatabase(t *testing.T) {
+	// Override the default (example.com) CORS configuration in the DbConfig for /db:
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				CORS: &auth.CORSConfig{
+					Origin:      []string{"http://couchbase.com", "http://staging.couchbase.com"},
+					LoginOrigin: []string{"http://couchbase.com"},
+					Headers:     []string{},
+					MaxAge:      1728000,
+				},
+			},
+		},
+	})
+	defer rt.Close()
+
+	reqHeaders := map[string]string{
+		"Origin": "http://couchbase.com",
+	}
+	response := rt.SendRequestWithHeaders("GET", "/db/", "", reqHeaders)
+	assert.Equal(t, "http://couchbase.com", response.Header().Get("Access-Control-Allow-Origin"))
+
+	// now test non-listed origins
+	reqHeaders = map[string]string{
+		"Origin": "http://example.com",
+	}
+	response = rt.SendRequestWithHeaders("GET", "/db/", "", reqHeaders)
+	assert.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+
+	reqHeaders = map[string]string{
+		"Origin": "http://hack0r.com",
+	}
+	response = rt.SendRequestWithHeaders("GET", "/db/", "", reqHeaders)
+	assert.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+
+	// The root URL should still be using the default example.com CORS:
+	reqHeaders = map[string]string{
+		"Origin": "http://couchbase.com",
+	}
+	response = rt.SendRequestWithHeaders("GET", "/", "", reqHeaders)
+	assert.Equal(t, "*", response.Header().Get("Access-Control-Allow-Origin"))
+	reqHeaders = map[string]string{
+		"Origin": "http://example.com",
+	}
+	response = rt.SendRequestWithHeaders("GET", "/", "", reqHeaders)
+	assert.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+}
+
 // assertGatewayStatus is like requireStatus but with StatusGatewayTimeout error checking for temporary network failures.
 func assertGatewayStatus(t *testing.T, response *TestResponse, expected int) {
 	if response.Code == http.StatusGatewayTimeout {
@@ -6661,22 +6709,22 @@ func (tester *ChannelRevocationTester) getChanges(sinceSeq interface{}, expected
 func InitScenario(t *testing.T, rtConfig *RestTesterConfig) (ChannelRevocationTester, *RestTester) {
 	defaultSyncFn := `
 			function (doc, oldDoc){
-				if (doc._id === 'userRoles'){				
+				if (doc._id === 'userRoles'){
 					for (var key in doc.roles){
 						role(key, doc.roles[key]);
 					}
 				}
-				if (doc._id === 'roleChannels'){				
+				if (doc._id === 'roleChannels'){
 					for (var key in doc.channels){
 						access(key, doc.channels[key]);
 					}
 				}
-				if (doc._id === 'userChannels'){				
+				if (doc._id === 'userChannels'){
 					for (var key in doc.channels){
 						access(key, doc.channels[key]);
 					}
 				}
-				if (doc._id.indexOf("doc") >= 0){				
+				if (doc._id.indexOf("doc") >= 0){
 					channel(doc.channels);
 				}
 			}`
@@ -8058,7 +8106,7 @@ func TestRevocationWithUserXattrs(t *testing.T) {
 						access(key, meta.xattrs.channelInfo.userChannels[key]);
 					}
 				}
-				if (doc._id.indexOf("doc") >= 0){				
+				if (doc._id.indexOf("doc") >= 0){
 					channel(doc.channels);
 				}
 			}`,

--- a/rest/config.go
+++ b/rest/config.go
@@ -179,6 +179,7 @@ type DbConfig struct {
 	GraphQL                          *functions.GraphQLConfig         `json:"graphql,omitempty"`                              // GraphQL configuration & resolver fns
 	UserFunctions                    functions.FunctionConfigMap      `json:"functions,omitempty"`                            // Named JS fns for clients to call
 	Suspendable                      *bool                            `json:"suspendable,omitempty"`                          // Allow the database to be suspended
+	CORS                             *auth.CORSConfig                 `json:"cors,omitempty"`
 }
 
 type ScopesConfig map[string]ScopeConfig

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -230,7 +230,7 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 	}
 
 	if lc.CORS != nil {
-		sc.API.CORS = &CORSConfig{
+		sc.API.CORS = &auth.CORSConfig{
 			Origin:      lc.CORS.Origin,
 			LoginOrigin: lc.CORS.LoginOrigin,
 			Headers:     lc.CORS.Headers,

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -121,21 +121,14 @@ type APIConfig struct {
 	CompressResponses  *bool `json:"compress_responses,omitempty"   help:"If false, disables compression of HTTP responses"`
 	HideProductVersion *bool `json:"hide_product_version,omitempty" help:"Whether product versions removed from Server headers and REST API responses"`
 
-	HTTPS HTTPSConfig `json:"https,omitempty"`
-	CORS  *CORSConfig `json:"cors,omitempty"`
+	HTTPS HTTPSConfig      `json:"https,omitempty"`
+	CORS  *auth.CORSConfig `json:"cors,omitempty"`
 }
 
 type HTTPSConfig struct {
 	TLSMinimumVersion string `json:"tls_minimum_version,omitempty" help:"The minimum allowable TLS version for the REST APIs"`
 	TLSCertPath       string `json:"tls_cert_path,omitempty"       help:"The TLS cert file to use for the REST APIs"`
 	TLSKeyPath        string `json:"tls_key_path,omitempty"        help:"The TLS key file to use for the REST APIs"`
-}
-
-type CORSConfig struct {
-	Origin      []string `json:"origin,omitempty"       help:"List of allowed origins, use ['*'] to allow access from everywhere"`
-	LoginOrigin []string `json:"login_origin,omitempty" help:"List of allowed login origins"`
-	Headers     []string `json:"headers,omitempty"      help:"List of allowed headers"`
-	MaxAge      int      `json:"max_age,omitempty"      help:"Maximum age of the CORS Options request"`
 }
 
 type AuthConfig struct {
@@ -219,7 +212,7 @@ func LoadStartupConfigFromPath(path string) (*StartupConfig, error) {
 func NewEmptyStartupConfig() StartupConfig {
 	return StartupConfig{
 		API: APIConfig{
-			CORS: &CORSConfig{},
+			CORS: &auth.CORSConfig{},
 		},
 		Logging: base.LoggingConfig{
 			Console: &base.ConsoleLoggerConfig{},

--- a/rest/config_startup_test.go
+++ b/rest/config_startup_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -92,15 +93,15 @@ func TestStartupConfigMerge(t *testing.T) {
 		},
 		{
 			name:     "Keep original *CORSconfig",
-			config:   StartupConfig{API: APIConfig{CORS: &CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
-			override: StartupConfig{API: APIConfig{CORS: &CORSConfig{}}},
-			expected: StartupConfig{API: APIConfig{CORS: &CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
+			config:   StartupConfig{API: APIConfig{CORS: &auth.CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
+			override: StartupConfig{API: APIConfig{CORS: &auth.CORSConfig{}}},
+			expected: StartupConfig{API: APIConfig{CORS: &auth.CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
 		},
 		{
-			name:     "Keep original *CORSConfig from override nil value",
-			config:   StartupConfig{API: APIConfig{CORS: &CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
+			name:     "Keep original *auth.CORSConfig from override nil value",
+			config:   StartupConfig{API: APIConfig{CORS: &auth.CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
 			override: StartupConfig{},
-			expected: StartupConfig{API: APIConfig{CORS: &CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
+			expected: StartupConfig{API: APIConfig{CORS: &auth.CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
 		},
 		{
 			name:     "Override unset ConfigDuration",

--- a/rest/facebook.go
+++ b/rest/facebook.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 )
 
@@ -28,7 +29,7 @@ func (h *handler) handleFacebookPOST() error {
 	// CORS not allowed for login #115 #762
 	originHeader := h.rq.Header["Origin"]
 	if len(originHeader) > 0 {
-		matched := matchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
+		matched := auth.MatchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
 		if matched == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
 		}

--- a/rest/google.go
+++ b/rest/google.go
@@ -13,6 +13,7 @@ package rest
 import (
 	"net/http"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 )
 
@@ -30,7 +31,7 @@ func (h *handler) handleGooglePOST() error {
 	// CORS not allowed for login #115 #762
 	originHeader := h.rq.Header["Origin"]
 	if len(originHeader) > 0 {
-		matched := matchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
+		matched := auth.MatchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
 		if matched == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
 		}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -292,6 +292,17 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 		}
 	}
 
+	// Now that we know the DB, add CORS headers to the response:
+	if h.privs != adminPrivs {
+		cors := h.server.Config.API.CORS
+		if dbContext != nil {
+			cors = dbContext.CORS
+		}
+		if cors != nil {
+			cors.AddResponseHeaders(h.rq, h.response)
+		}
+	}
+
 	// If this call is in the context of a DB make sure the DB is in a valid state
 	if dbContext != nil {
 		// Named collections handling

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -357,22 +357,18 @@ func wrapRouter(sc *ServerContext, privs handlerPrivs, router *mux.Router) http.
 	return http.HandlerFunc(func(response http.ResponseWriter, rq *http.Request) {
 		FixQuotedSlashes(rq)
 		var match mux.RouteMatch
-
-		// Inject CORS if enabled and requested and not admin port
-		originHeader := rq.Header["Origin"]
-		if privs != adminPrivs && sc.Config.API.CORS != nil && len(originHeader) > 0 {
-			origin := matchedOrigin(sc.Config.API.CORS.Origin, originHeader)
-			response.Header().Add("Access-Control-Allow-Origin", origin)
-			response.Header().Add("Access-Control-Allow-Credentials", "true")
-			response.Header().Add("Access-Control-Allow-Headers", strings.Join(sc.Config.API.CORS.Headers, ", "))
-		}
-
 		if router.Match(rq, &match) {
 			router.ServeHTTP(response, rq)
 		} else {
 			// Log the request
 			h := newHandler(sc, privs, response, rq, false)
 			h.logRequestLine()
+
+			// Inject CORS if enabled and requested and not admin port
+			cors := sc.Config.API.CORS
+			if privs != adminPrivs && cors != nil {
+				cors.AddResponseHeaders(rq, response)
+			}
 
 			// What methods would have matched?
 			var options []string
@@ -385,8 +381,8 @@ func wrapRouter(sc *ServerContext, privs handlerPrivs, router *mux.Router) http.
 				h.writeStatus(http.StatusNotFound, "unknown URL")
 			} else {
 				response.Header().Add("Allow", strings.Join(options, ", "))
-				if privs != adminPrivs && sc.Config.API.CORS != nil && len(originHeader) > 0 {
-					response.Header().Add("Access-Control-Max-Age", strconv.Itoa(sc.Config.API.CORS.MaxAge))
+				if privs != adminPrivs && cors != nil && len(rq.Header["Origin"]) > 0 {
+					response.Header().Add("Access-Control-Max-Age", strconv.Itoa(cors.MaxAge))
 					response.Header().Add("Access-Control-Allow-Methods", strings.Join(options, ", "))
 				}
 				if rq.Method != "OPTIONS" {
@@ -398,22 +394,6 @@ func wrapRouter(sc *ServerContext, privs handlerPrivs, router *mux.Router) http.
 			h.logDuration(true)
 		}
 	})
-}
-
-func matchedOrigin(allowOrigins []string, rqOrigins []string) string {
-	for _, rv := range rqOrigins {
-		for _, av := range allowOrigins {
-			if rv == av {
-				return av
-			}
-		}
-	}
-	for _, av := range allowOrigins {
-		if av == "*" {
-			return "*"
-		}
-	}
-	return ""
 }
 
 func FixQuotedSlashes(rq *http.Request) {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -556,6 +556,12 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	dbcontext.ServerContextHasStarted = sc.hasStarted
 	dbcontext.NoX509HTTPClient = sc.NoX509HTTPClient
 
+	if config.CORS != nil {
+		dbcontext.CORS = config.DbConfig.CORS
+	} else {
+		dbcontext.CORS = sc.Config.API.CORS
+	}
+
 	syncFn := ""
 	if config.Sync != nil {
 		syncFn = *config.Sync

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/db"
 
 	"github.com/couchbase/gocbcore/v10/connstr"
@@ -116,7 +117,7 @@ func TestAllDatabaseNames(t *testing.T) {
 	ctx := base.TestCtx(t)
 	serverConfig := &StartupConfig{
 		Bootstrap: BootstrapConfig{UseTLSServer: base.BoolPtr(base.ServerIsTLS(base.UnitTestUrl())), ServerTLSSkipVerify: base.BoolPtr(base.TestTLSSkipVerify())},
-		API:       APIConfig{CORS: &CORSConfig{}, AdminInterface: DefaultAdminInterface}}
+		API:       APIConfig{CORS: &auth.CORSConfig{}, AdminInterface: DefaultAdminInterface}}
 	serverContext := NewServerContext(ctx, serverConfig, false)
 	defer serverContext.Close(ctx)
 
@@ -158,7 +159,7 @@ func TestAllDatabaseNames(t *testing.T) {
 
 func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 	ctx := base.TestCtx(t)
-	serverConfig := &StartupConfig{API: APIConfig{CORS: &CORSConfig{}, AdminInterface: DefaultAdminInterface}}
+	serverConfig := &StartupConfig{API: APIConfig{CORS: &auth.CORSConfig{}, AdminInterface: DefaultAdminInterface}}
 	serverContext := NewServerContext(ctx, serverConfig, false)
 	defer serverContext.Close(ctx)
 
@@ -590,7 +591,7 @@ func TestServerContextSetupCollectionsSupport(t *testing.T) {
 			UseTLSServer:        base.BoolPtr(base.ServerIsTLS(base.UnitTestUrl())),
 			ServerTLSSkipVerify: base.BoolPtr(base.TestTLSSkipVerify()),
 		},
-		API: APIConfig{CORS: &CORSConfig{}, AdminInterface: DefaultAdminInterface},
+		API: APIConfig{CORS: &auth.CORSConfig{}, AdminInterface: DefaultAdminInterface},
 	}
 	serverContext := NewServerContext(ctx, serverConfig, false)
 	defer serverContext.Close(ctx)

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -41,7 +41,7 @@ func (h *handler) handleSessionPOST() error {
 	if len(originHeader) > 0 {
 		matched := ""
 		if h.server.Config.API.CORS != nil {
-			matched = matchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
+			matched = auth.MatchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
 		}
 		if matched == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
@@ -97,7 +97,7 @@ func (h *handler) handleSessionDELETE() error {
 	if len(originHeader) > 0 {
 		matched := ""
 		if h.server.Config.API.CORS != nil {
-			matched = matchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
+			matched = auth.MatchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
 		}
 		if matched == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -130,7 +130,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 		}
 	}
 
-	corsConfig := &CORSConfig{
+	corsConfig := &auth.CORSConfig{
 		Origin:      []string{"http://example.com", "*", "http://staging.example.com"},
 		LoginOrigin: []string{"http://example.com"},
 		Headers:     []string{},


### PR DESCRIPTION
CBG-2424

Allows a database to specify its own CORS configuration, overriding the server default.

- Added "cors" property to DbConfig (same schema as in server config.) If present, it overrides the server config for that database.
- Moved CORSConfig type and matchedOrigin func to auth package, to enable...
- Added a *CORSConfig to DatabaseContext struct.
- wrapRouter() fn no longer adds CORS headers to all requests.
- Instead, handler.invoke adds the headers as soon as it figures out which database (or none) the request targets.
- Added a unit test to make sure a per-db CORS config takes effect for requests for that db, but not for other requests.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
- [ ] `GSI=true,xattrs=true` (for collections) https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
