### PR TITLE
CBG-2411: Removed potential double decrement of wait group

### DIFF
--- a/base/collection.go
+++ b/base/collection.go
@@ -1041,7 +1041,6 @@ func (c *Collection) GetCollectionID() (uint32, error) {
 	}
 	wg.Wait()
 	if callbackErr != nil {
-		wg.Done()
 		return 0, fmt.Errorf("GetCollectionID for %s.%s, err: %w", scope, collection, callbackErr)
 	}
 	// cache value for future use


### PR DESCRIPTION
CBG-2411

- Removed wait group decrementing on callback error

This has been tested manually by making `callbackFunc` return an error through `callbackErr`. Could not be tested through a unit test.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/946/ 
