### PR TITLE
CBG-1971: Fix for flaking TestReplicationConcurrentPush

### DIFF
--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -955,8 +955,9 @@ func TestReplicationConcurrentPush(t *testing.T) {
 	defer teardown()
 	// Create push replications, verify running
 	activeRT.createReplication("rep_ABC", remoteURLString, db.ActiveReplicatorTypePush, []string{"ABC"}, true, db.ConflictResolverDefault)
-	activeRT.WaitForReplicationStatus("rep_ABC", db.ReplicationStateRunning)
 	activeRT.createReplication("rep_DEF", remoteURLString, db.ActiveReplicatorTypePush, []string{"DEF"}, true, db.ConflictResolverDefault)
+	activeRT.waitForAssignedReplications(2)
+	activeRT.WaitForReplicationStatus("rep_ABC", db.ReplicationStateRunning)
 	activeRT.WaitForReplicationStatus("rep_DEF", db.ReplicationStateRunning)
 
 	// Create docs on active


### PR DESCRIPTION
CBG-1971

Fix for a flaking test. The test when failing was not getting the local checkpoint successfully. So I added the line that waits for local checkpoints like other tests have in the file. This seems to have stopping it from failing when I've ran locally both against server and in Walrus. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/955/
