### PR TITLE
Raise watermark for intermittent failures

### DIFF
--- a/rest/adminapitest/main_test.go
+++ b/rest/adminapitest/main_test.go
@@ -17,6 +17,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	memWatermarkThresholdMB := uint64(4096)
+	memWatermarkThresholdMB := uint64(8192)
 	db.TestBucketPoolWithIndexes(m, memWatermarkThresholdMB)
 }


### PR DESCRIPTION
This intermittently fails in jenkins https://jenkins.sgwdev.com/job/SyncGateway-Integration/953/ and I don't know which test is causing it, but probably some test has never been good at cleaning itself up.
