### PR TITLE
CBG-2329 make mutation feed collection aware

### DIFF
--- a/auth/principal.go
+++ b/auth/principal.go
@@ -157,7 +157,7 @@ type User interface {
 	// to, annotated with the sequence number at which access was granted.
 	// Returns a string array containing any channels filtered out due to the user not having access
 	// to them.
-	FilterToAvailableChannels(channels base.Set) (filtered ch.TimedSet, removed []string)
+	FilterToAvailableChannels(channels ch.Set) (filtered ch.TimedSet, removed []string)
 
 	setRolesSince(ch.TimedSet)
 }

--- a/auth/user.go
+++ b/auth/user.go
@@ -20,6 +20,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 	ch "github.com/couchbase/sync_gateway/channels"
 )
 
@@ -588,15 +589,15 @@ func (user *userImpl) ExpandWildCardChannel(channels base.Set) base.Set {
 	return channels
 }
 
-func (user *userImpl) FilterToAvailableChannels(channels base.Set) (filtered ch.TimedSet, removed []string) {
+func (user *userImpl) FilterToAvailableChannels(channels channels.Set) (filtered ch.TimedSet, removed []string) {
 	filtered = ch.TimedSet{}
 	for channel := range channels {
-		if channel == ch.AllChannelWildcard {
+		if channel.Name == ch.AllChannelWildcard {
 			return user.InheritedChannels().Copy(), nil
 		}
-		added := filtered.AddChannel(channel, user.CanSeeChannelSince(channel))
+		added := filtered.AddChannel(channel.Name, user.CanSeeChannelSince(channel.Name))
 		if !added {
-			removed = append(removed, channel)
+			removed = append(removed, channel.Name)
 		}
 	}
 	return filtered, removed

--- a/auth/user.go
+++ b/auth/user.go
@@ -20,7 +20,6 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/channels"
 	ch "github.com/couchbase/sync_gateway/channels"
 )
 
@@ -589,7 +588,7 @@ func (user *userImpl) ExpandWildCardChannel(channels base.Set) base.Set {
 	return channels
 }
 
-func (user *userImpl) FilterToAvailableChannels(channels channels.Set) (filtered ch.TimedSet, removed []string) {
+func (user *userImpl) FilterToAvailableChannels(channels ch.Set) (filtered ch.TimedSet, removed []string) {
 	filtered = ch.TimedSet{}
 	for channel := range channels {
 		if channel.Name == ch.AllChannelWildcard {

--- a/base/collection.go
+++ b/base/collection.go
@@ -29,6 +29,7 @@ import (
 
 var ErrCollectionsUnsupported = errors.New("collections not supported")
 
+// DefaultCollectionID represents _default._default collection
 const DefaultCollectionID = 0x0
 
 var _ sgbucket.KVStore = &Collection{}

--- a/channels/active_channels.go
+++ b/channels/active_channels.go
@@ -17,6 +17,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
+// ChanngedChannels contains each modified channel with true if active, and false if inactive
 type ChangedChannels map[ID]bool
 
 // activeChannels is a concurrency-safe map of active replications per channel, modified via
@@ -101,7 +102,7 @@ func (ac *ActiveChannels) _incr(channel ID) {
 func (ac *ActiveChannels) _decr(channel ID) {
 	current, ok := ac.channelCounts[channel]
 	if !ok {
-		base.WarnfCtx(context.Background(), "Attempt made to decrement inactive channel %s - will be ignored", base.UD(channel.String()))
+		base.WarnfCtx(context.Background(), "Attempt made to decrement inactive channel %s - will be ignored", base.UD(channel))
 		return
 	}
 	if current <= 1 {

--- a/channels/active_channels.go
+++ b/channels/active_channels.go
@@ -56,19 +56,23 @@ func (ac *ActiveChannels) UpdateChanged(changedChannels ChangedChannels) {
 }
 
 // Active channel counts track channels being replicated by an active changes request.
-func (ac *ActiveChannels) IncrChannels(chans Set) {
+func (ac *ActiveChannels) IncrChannels(timedSetByCollection TimedSetByCollectionID) {
 	ac.lock.Lock()
 	defer ac.lock.Unlock()
-	for channelName, _ := range chans {
-		ac._incr(channelName)
+	for collectionID, timedSetByChannel := range timedSetByCollection {
+		for channelName, _ := range timedSetByChannel {
+			ac._incr(NewID(channelName, collectionID))
+		}
 	}
 }
 
-func (ac *ActiveChannels) DecrChannels(chans Set) {
+func (ac *ActiveChannels) DecrChannels(timedSetByCollection TimedSetByCollectionID) {
 	ac.lock.Lock()
 	defer ac.lock.Unlock()
-	for channel, _ := range chans {
-		ac._decr(channel)
+	for collectionID, timedSetByChannel := range timedSetByCollection {
+		for channelName, _ := range timedSetByChannel {
+			ac._decr(NewID(channelName, collectionID))
+		}
 	}
 }
 

--- a/channels/active_channels.go
+++ b/channels/active_channels.go
@@ -17,6 +17,8 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
+type ChangedChannels map[ID]bool
+
 // activeChannels is a concurrency-safe map of active replications per channel, modified via
 // incr/decr operations.
 // Incrementing a channel not already in the map adds it to the map.
@@ -25,27 +27,27 @@ import (
 // Note: private properties shouldn't be accessed directly, to support potential
 // refactoring of activeChannels to use a sharded map as needed.
 type ActiveChannels struct {
-	channelCounts map[string]uint64 // Count of active pull replications (changes) per channel
-	lock          sync.RWMutex      // Mutex for channelCounts map access
-	countStat     *base.SgwIntStat  // Channel count stat
+	channelCounts map[ID]uint64    // Count of active pull replications (changes) per channel
+	lock          sync.RWMutex     // Mutex for channelCounts map access
+	countStat     *base.SgwIntStat // Channel count stat
 }
 
 func NewActiveChannels(activeChannelCountStat *base.SgwIntStat) *ActiveChannels {
 	return &ActiveChannels{
-		channelCounts: make(map[string]uint64),
+		channelCounts: make(map[ID]uint64),
 		countStat:     activeChannelCountStat,
 	}
 }
 
 // Update changed increments/decrements active channel counts based on a set of changed channels.  Triggered
 // when the set of channels being replicated by a given replication changes.
-func (ac *ActiveChannels) UpdateChanged(changedChannels ChangedKeys) {
+func (ac *ActiveChannels) UpdateChanged(changedChannels ChangedChannels) {
 	ac.lock.Lock()
-	for channelName, isIncrement := range changedChannels {
+	for channel, isIncrement := range changedChannels {
 		if isIncrement {
-			ac._incr(channelName)
+			ac._incr(channel)
 		} else {
-			ac._decr(channelName)
+			ac._decr(channel)
 		}
 	}
 
@@ -53,59 +55,59 @@ func (ac *ActiveChannels) UpdateChanged(changedChannels ChangedKeys) {
 }
 
 // Active channel counts track channels being replicated by an active changes request.
-func (ac *ActiveChannels) IncrChannels(chans TimedSet) {
+func (ac *ActiveChannels) IncrChannels(chans Set) {
 	ac.lock.Lock()
+	defer ac.lock.Unlock()
 	for channelName, _ := range chans {
 		ac._incr(channelName)
 	}
-	ac.lock.Unlock()
 }
 
-func (ac *ActiveChannels) DecrChannels(chans TimedSet) {
+func (ac *ActiveChannels) DecrChannels(chans Set) {
 	ac.lock.Lock()
-	for channelName, _ := range chans {
-		ac._decr(channelName)
+	defer ac.lock.Unlock()
+	for channel, _ := range chans {
+		ac._decr(channel)
 	}
-	ac.lock.Unlock()
 }
 
-func (ac *ActiveChannels) IsActive(channelName string) bool {
+func (ac *ActiveChannels) IsActive(channel ID) bool {
 	ac.lock.RLock()
-	_, ok := ac.channelCounts[channelName]
+	_, ok := ac.channelCounts[channel]
 	ac.lock.RUnlock()
 	return ok
 }
 
-func (ac *ActiveChannels) IncrChannel(channelName string) {
+func (ac *ActiveChannels) IncrChannel(channel ID) {
 	ac.lock.Lock()
-	ac._incr(channelName)
+	ac._incr(channel)
 	ac.lock.Unlock()
 }
 
-func (ac *ActiveChannels) DecrChannel(channelName string) {
+func (ac *ActiveChannels) DecrChannel(channel ID) {
 	ac.lock.Lock()
-	ac._decr(channelName)
+	ac._decr(channel)
 	ac.lock.Unlock()
 }
 
-func (ac *ActiveChannels) _incr(channelName string) {
-	current, ok := ac.channelCounts[channelName]
+func (ac *ActiveChannels) _incr(channel ID) {
+	current, ok := ac.channelCounts[channel]
 	if !ok {
 		ac.countStat.Add(1)
 	}
-	ac.channelCounts[channelName] = current + 1
+	ac.channelCounts[channel] = current + 1
 }
 
-func (ac *ActiveChannels) _decr(channelName string) {
-	current, ok := ac.channelCounts[channelName]
+func (ac *ActiveChannels) _decr(channel ID) {
+	current, ok := ac.channelCounts[channel]
 	if !ok {
-		base.WarnfCtx(context.Background(), "Attempt made to decrement inactive channel %s - will be ignored", base.UD(channelName))
+		base.WarnfCtx(context.Background(), "Attempt made to decrement inactive channel %s - will be ignored", base.UD(channel.String()))
 		return
 	}
 	if current <= 1 {
-		delete(ac.channelCounts, channelName)
+		delete(ac.channelCounts, channel)
 		ac.countStat.Add(-1)
 	} else {
-		ac.channelCounts[channelName] = current - 1
+		ac.channelCounts[channel] = current - 1
 	}
 }

--- a/channels/active_channels_test.go
+++ b/channels/active_channels_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestActiveChannelsConcurrency(t *testing.T) {
@@ -23,21 +24,31 @@ func TestActiveChannelsConcurrency(t *testing.T) {
 	ac := NewActiveChannels(activeChannelStat)
 	var wg sync.WaitGroup
 
+	ABCChan := ID{Name: "ABC"}
+	DEFChan := ID{Name: "DEF"}
+	GHIChan := ID{Name: "GHI"}
+	JKLChan := ID{Name: "JKL"}
+	MNOChan := ID{Name: "MNO"}
 	// Concurrent Incr, Decr
 	for i := 0; i < 50; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			ac.IncrChannels(TimedSetFromString("ABC:1,DEF:2,GHI:3,JKL:1,MNO:1"))
-			ac.DecrChannels(TimedSetFromString("ABC:1,DEF:2"))
+			activeChans, err := SetOf(ABCChan, DEFChan, GHIChan, JKLChan, MNOChan)
+			require.NoError(t, err)
+			ac.IncrChannels(activeChans)
+			inactiveChans, err := SetOf(ABCChan, DEFChan)
+			require.NoError(t, err)
+
+			ac.DecrChannels(inactiveChans)
 		}()
 	}
 	wg.Wait()
-	assert.False(t, ac.IsActive("ABC"))
-	assert.False(t, ac.IsActive("DEF"))
-	assert.True(t, ac.IsActive("GHI"))
-	assert.True(t, ac.IsActive("JKL"))
-	assert.True(t, ac.IsActive("MNO"))
+	assert.False(t, ac.IsActive(ABCChan))
+	assert.False(t, ac.IsActive(DEFChan))
+	assert.True(t, ac.IsActive(GHIChan))
+	assert.True(t, ac.IsActive(JKLChan))
+	assert.True(t, ac.IsActive(MNOChan))
 	assert.Equal(t, int64(3), activeChannelStat.Value())
 
 	// Concurrent UpdateChanged
@@ -45,18 +56,18 @@ func TestActiveChannelsConcurrency(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			changedKeys := ChangedKeys{"ABC": true, "DEF": true, "GHI": false, "MNO": true}
+			changedKeys := ChangedChannels{ABCChan: true, DEFChan: true, GHIChan: false, MNOChan: true}
 			ac.UpdateChanged(changedKeys)
-			changedKeys = ChangedKeys{"DEF": false}
+			changedKeys = ChangedChannels{DEFChan: false}
 			ac.UpdateChanged(changedKeys)
 		}()
 	}
 	wg.Wait()
-	assert.True(t, ac.IsActive("ABC"))
-	assert.False(t, ac.IsActive("DEF"))
-	assert.False(t, ac.IsActive("GHI"))
-	assert.True(t, ac.IsActive("JKL"))
-	assert.True(t, ac.IsActive("MNO"))
+	assert.True(t, ac.IsActive(ABCChan))
+	assert.False(t, ac.IsActive(DEFChan))
+	assert.False(t, ac.IsActive(GHIChan))
+	assert.True(t, ac.IsActive(JKLChan))
+	assert.True(t, ac.IsActive(MNOChan))
 	assert.Equal(t, int64(3), activeChannelStat.Value())
 
 }

--- a/channels/active_channels_test.go
+++ b/channels/active_channels_test.go
@@ -34,13 +34,16 @@ func TestActiveChannelsConcurrency(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			const seqNo uint64 = 0
 			activeChans, err := SetOf(ABCChan, DEFChan, GHIChan, JKLChan, MNOChan)
 			require.NoError(t, err)
-			ac.IncrChannels(activeChans)
+			activeChansTimedSet := AtSequenceByCollection(activeChans, seqNo)
+			ac.IncrChannels(activeChansTimedSet)
 			inactiveChans, err := SetOf(ABCChan, DEFChan)
 			require.NoError(t, err)
+			inactiveChansTimedSet := AtSequenceByCollection(inactiveChans, seqNo)
 
-			ac.DecrChannels(inactiveChans)
+			ac.DecrChannels(inactiveChansTimedSet)
 		}()
 	}
 	wg.Wait()

--- a/channels/active_channels_test.go
+++ b/channels/active_channels_test.go
@@ -24,11 +24,11 @@ func TestActiveChannelsConcurrency(t *testing.T) {
 	ac := NewActiveChannels(activeChannelStat)
 	var wg sync.WaitGroup
 
-	ABCChan := ID{Name: "ABC"}
-	DEFChan := ID{Name: "DEF"}
-	GHIChan := ID{Name: "GHI"}
-	JKLChan := ID{Name: "JKL"}
-	MNOChan := ID{Name: "MNO"}
+	ABCChan := NewID("ABC", base.DefaultCollectionID)
+	DEFChan := NewID("DEF", base.DefaultCollectionID)
+	GHIChan := NewID("GHI", base.DefaultCollectionID)
+	JKLChan := NewID("JKL", base.DefaultCollectionID)
+	MNOChan := NewID("MNO", base.DefaultCollectionID)
 	// Concurrent Incr, Decr
 	for i := 0; i < 50; i++ {
 		wg.Add(1)

--- a/channels/log_entry.go
+++ b/channels/log_entry.go
@@ -54,6 +54,7 @@ type LogEntry struct {
 	Value        []byte       // Snapshot metadata (when Type=LogEntryCheckpoint)
 	PrevSequence uint64       // Sequence of previous active revision
 	IsPrincipal  bool         // Whether the log-entry is a tracking entry for a principal doc
+	CollectionID uint32       // Collection ID
 }
 
 func (l LogEntry) String() string {

--- a/channels/set.go
+++ b/channels/set.go
@@ -9,6 +9,8 @@
 package channels
 
 import (
+	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -163,4 +165,14 @@ func (s Set) UpdateWithSlice(slice []ID) Set {
 func (s Set) Contains(ch ID) bool {
 	_, exists := s[ch]
 	return exists
+}
+
+// Convert to String(), necessary for logging.
+func (s Set) String() string {
+	keys := make([]string, len(s))
+	for ch := range s {
+		keys = append(keys, ch.String())
+	}
+	sort.Strings(keys)
+	return fmt.Sprintf("{%s}", strings.Join(keys, ", "))
 }

--- a/channels/set.go
+++ b/channels/set.go
@@ -9,6 +9,7 @@
 package channels
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -26,6 +27,20 @@ const (
 const UserStarChannel = "*"     // user channel for "can access all docs"
 const DocumentStarChannel = "!" // doc channel for "visible to all users"
 const AllChannelWildcard = "*"  // wildcard for 'all channels'
+
+// ID represents a single channel inside a collection
+type ID struct {
+	Name         string // name of channel
+	CollectionID uint32 // collection it belongs to
+}
+
+func (c ID) String() string {
+	return fmt.Sprintf("%d.%s", c.CollectionID, c.Name)
+}
+
+type Set map[ID]present
+
+type present struct{}
 
 func illegalChannelError(name string) error {
 	return base.HTTPErrorf(400, "Illegal channel name %q", name)
@@ -54,6 +69,18 @@ func SetFromArray(names []string, mode StarMode) (base.Set, error) {
 	return result, nil
 }
 
+// SetOf creates a new Set. Returns an error if any names are invalid.
+func SetOf(chans ...ID) (Set, error) {
+	result := make(Set, len(chans))
+	for _, ch := range chans {
+		if !IsValidChannel(ch.Name) {
+			return nil, illegalChannelError(ch.Name)
+		}
+		result[ch] = present{}
+	}
+	return result, nil
+}
+
 // If the set contains "*", returns a set of only "*". Else returns the original set.
 func ExpandingStar(set base.Set) base.Set {
 	if _, exists := set[UserStarChannel]; exists {
@@ -65,4 +92,74 @@ func ExpandingStar(set base.Set) base.Set {
 // Returns a set with any "*" channel removed.
 func IgnoringStar(set base.Set) base.Set {
 	return set.Removing(UserStarChannel)
+}
+
+// SetFromArrayNoValidate creates a set of channels without validating they are valid names.
+func SetFromArrayNoValidate(chans []ID) Set {
+	result := make(Set, len(chans))
+	for _, ch := range chans {
+		result[ch] = present{}
+	}
+	return result
+}
+
+// SetOfNoValidate creates a new Set from inline channels.
+func SetOfNoValidate(chans ...ID) Set {
+	return SetFromArrayNoValidate(chans)
+}
+
+// SetOfFromSingleCollection creates a new Set from series of strings
+func SetOfFromSingleCollection(chans []string, collectionID uint32) Set {
+	result := make(Set, len(chans))
+	for _, chanName := range chans {
+		result[ID{Name: chanName, CollectionID: collectionID}] = present{}
+	}
+	return result
+}
+
+// Update adds all elements from other set and returns the union of the sets.
+func (s Set) Update(other Set) Set {
+	if len(s) == 0 {
+		return other
+	} else if len(other) == 0 {
+		return s
+	}
+	for ch := range other {
+		s[ch] = present{}
+	}
+	return s
+}
+
+// Add a channel to a set.
+func (s Set) Add(value ID) Set {
+	s[value] = present{}
+	return s
+}
+
+// UpdateWithSlice adds channels to a Set.
+func (s Set) UpdateWithSlice(slice []ID) Set {
+	if len(slice) == 0 {
+		return s
+	} else if len(s) == 0 {
+		s = make(Set, len(slice))
+	}
+	for _, ch := range slice {
+		s[ch] = present{}
+	}
+	return s
+}
+
+// Contains returns true if the set includes the channel.
+func (s Set) Contains(ch ID) bool {
+	_, exists := s[ch]
+	return exists
+}
+
+// ToSerializedStrings returns a base set with the serialized form of channel IDs.
+func (s Set) ToSerializedStrings() base.Set {
+	serializedChans := base.Set{}
+	for ch := range s {
+		serializedChans.Add(ch.String())
+	}
+	return serializedChans
 }

--- a/channels/set.go
+++ b/channels/set.go
@@ -164,12 +164,3 @@ func (s Set) Contains(ch ID) bool {
 	_, exists := s[ch]
 	return exists
 }
-
-// ToSerializedStrings returns a base set with the serialized form of channel IDs.
-func (s Set) GoString() base.Set {
-	serializedChans := base.Set{}
-	for ch := range s {
-		serializedChans.Add(ch.String())
-	}
-	return serializedChans
-}

--- a/channels/set_test.go
+++ b/channels/set_test.go
@@ -11,7 +11,9 @@ package channels
 import (
 	"testing"
 
+	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsValidChannel(t *testing.T) {
@@ -68,4 +70,347 @@ func TestSetFromArrayError(t *testing.T) {
 	assert.True(t, err != nil, "SetFromArray didn't return an error")
 	_, err = SetFromArray([]string{"chan1", "chan2", "bogus,name", "chan3"}, RemoveStar)
 	assert.True(t, err != nil, "SetFromArray didn't return an error")
+}
+
+func TestSetFromArrayNoValidate(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  []ID
+		output Set
+	}{
+		{
+			name:  "singleID",
+			input: []ID{ID{Name: "A", CollectionID: 1}},
+			output: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+			},
+		},
+		{
+			name: "twoIDs",
+			input: []ID{
+				ID{Name: "A", CollectionID: 1},
+				ID{Name: "A", CollectionID: 2},
+			},
+			output: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+				ID{Name: "A", CollectionID: 2}: present{},
+			},
+		},
+		{
+			name:  "illegalChannel",
+			input: []ID{ID{Name: ",", CollectionID: 1}},
+			output: Set{
+				ID{Name: ",", CollectionID: 1}: present{},
+			},
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.output, SetFromArrayNoValidate(test.input))
+		})
+	}
+}
+
+func TestSetFromSingleCollection(t *testing.T) {
+	testCases := []struct {
+		name         string
+		input        []string
+		collectionID uint32
+		output       Set
+	}{
+		{
+			name:         "singleChannel0",
+			input:        []string{"A"},
+			collectionID: 0,
+			output: Set{
+				ID{Name: "A", CollectionID: 0}: present{},
+			},
+		},
+
+		{
+			name:         "singleChannel1",
+			input:        []string{"A"},
+			collectionID: 1,
+			output: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+			},
+		},
+		{
+			name:         "multiChannel0",
+			input:        []string{"A", "B"},
+			collectionID: 0,
+			output: Set{
+				ID{Name: "A", CollectionID: 0}: present{},
+				ID{Name: "B", CollectionID: 0}: present{},
+			},
+		},
+
+		{
+			name:         "multiChannel1",
+			input:        []string{"A", "B"},
+			collectionID: 1,
+			output: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+				ID{Name: "B", CollectionID: 1}: present{},
+			},
+		},
+		{
+			name:         "illegalChannel",
+			input:        []string{","},
+			collectionID: 1,
+			output: Set{
+				ID{Name: ",", CollectionID: 1}: present{},
+			},
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.output, SetOfFromSingleCollection(test.input, test.collectionID))
+		})
+	}
+}
+
+func TestSetUpdate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		set1        Set
+		set2        Set
+		combinedSet Set
+	}{
+		{
+			name:        "emptysets",
+			set1:        Set{},
+			set2:        Set{},
+			combinedSet: Set{},
+		},
+		{
+			name: "set1empty",
+			set1: Set{},
+			set2: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+			},
+			combinedSet: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+			},
+		},
+		{
+			name: "set2empty",
+			set1: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+			},
+			set2: Set{},
+			combinedSet: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+			},
+		},
+		{
+			name: "samedata",
+			set1: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+				ID{Name: "B", CollectionID: 2}: present{},
+			},
+			set2: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+				ID{Name: "B", CollectionID: 2}: present{},
+			},
+			combinedSet: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+				ID{Name: "B", CollectionID: 2}: present{},
+			},
+		},
+		{
+			name: "somesamedata",
+			set1: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+				ID{Name: "B", CollectionID: 2}: present{},
+			},
+			set2: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+				ID{Name: "C", CollectionID: 1}: present{},
+			},
+			combinedSet: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+				ID{Name: "B", CollectionID: 2}: present{},
+				ID{Name: "C", CollectionID: 1}: present{},
+			},
+		},
+		{
+			name: "alldifferent",
+			set1: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+				ID{Name: "B", CollectionID: 2}: present{},
+			},
+			set2: Set{
+				ID{Name: "C", CollectionID: 1}: present{},
+				ID{Name: "D", CollectionID: 1}: present{},
+			},
+			combinedSet: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+				ID{Name: "B", CollectionID: 2}: present{},
+				ID{Name: "C", CollectionID: 1}: present{},
+				ID{Name: "D", CollectionID: 1}: present{},
+			},
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.combinedSet, test.set1.Update(test.set2))
+			chans := []ID{}
+			for ch := range test.set2 {
+				chans = append(chans, ch)
+			}
+			require.Equal(t, test.combinedSet, test.set1.UpdateWithSlice(chans))
+		})
+	}
+}
+
+func TestSetAdd(t *testing.T) {
+	testCases := []struct {
+		name     string
+		inputSet Set
+		inputID  ID
+		result   Set
+	}{
+		{
+			name:     "empty",
+			inputSet: Set{},
+			inputID:  ID{},
+			result:   Set{ID{}: present{}},
+		},
+		{
+			name:     "inputSetempty",
+			inputSet: Set{},
+			inputID:  ID{Name: "A", CollectionID: 1},
+			result: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+			},
+		},
+		{
+			name: "IDempty",
+			inputSet: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+			},
+			inputID: ID{},
+			result: Set{
+				ID{}:                           present{},
+				ID{Name: "A", CollectionID: 1}: present{},
+			},
+		},
+		{
+			name: "samedata",
+			inputSet: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+				ID{Name: "B", CollectionID: 2}: present{},
+			},
+			inputID: ID{Name: "A", CollectionID: 1},
+			result: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+				ID{Name: "B", CollectionID: 2}: present{},
+			},
+		},
+		{
+			name: "differenta",
+			inputSet: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+				ID{Name: "B", CollectionID: 2}: present{},
+			},
+			inputID: ID{Name: "C", CollectionID: 1},
+			result: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+				ID{Name: "B", CollectionID: 2}: present{},
+				ID{Name: "C", CollectionID: 1}: present{},
+			},
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.result, test.inputSet.Add(test.inputID))
+		})
+	}
+}
+
+func TestSetContains(t *testing.T) {
+	testCases := []struct {
+		name     string
+		inputSet Set
+		inputID  ID
+		contains bool
+	}{
+		{
+			name:     "empty,emptyID",
+			inputSet: Set{},
+			inputID:  ID{},
+			contains: false,
+		},
+		{
+			name:     "inputSetempty,realID",
+			inputSet: Set{},
+			inputID:  ID{Name: "A", CollectionID: 1},
+			contains: false,
+		},
+		{
+			name: "nonemptyset,emptyinput",
+			inputSet: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+				ID{Name: "B", CollectionID: 2}: present{},
+				ID{Name: "C", CollectionID: 1}: present{},
+			},
+			inputID:  ID{},
+			contains: false,
+		},
+		{
+			name: "somedatapresent",
+			inputSet: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+				ID{Name: "B", CollectionID: 2}: present{},
+				ID{Name: "C", CollectionID: 1}: present{},
+			},
+			inputID:  ID{Name: "A", CollectionID: 1},
+			contains: true,
+		},
+		{
+			name: "somedatanotpresent",
+			inputSet: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+				ID{Name: "B", CollectionID: 2}: present{},
+				ID{Name: "C", CollectionID: 1}: present{},
+			},
+			inputID:  ID{Name: "D", CollectionID: 1},
+			contains: false,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.contains, test.inputSet.Contains(test.inputID))
+		})
+	}
+}
+
+func TestSetToSerializedStrings(t *testing.T) {
+	testCases := []struct {
+		name     string
+		inputSet Set
+		output   base.Set
+	}{
+		{
+			name:     "empty",
+			inputSet: Set{},
+			output:   base.Set{},
+		},
+		{
+			name: "values",
+			inputSet: Set{
+				ID{Name: "A", CollectionID: 1}: present{},
+				ID{Name: "B", CollectionID: 2}: present{},
+				ID{Name: "C", CollectionID: 1}: present{},
+				ID{Name: "D"}:                  present{},
+			},
+			output: base.SetOf("1.A", "2.B", "1.C", "0.D"),
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.output, test.inputSet.ToSerializedStrings())
+		})
+	}
 }

--- a/channels/set_test.go
+++ b/channels/set_test.go
@@ -11,7 +11,6 @@ package channels
 import (
 	"testing"
 
-	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -382,35 +381,6 @@ func TestSetContains(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			require.Equal(t, test.contains, test.inputSet.Contains(test.inputID))
-		})
-	}
-}
-
-func TestSetString(t *testing.T) {
-	testCases := []struct {
-		name     string
-		inputSet Set
-		output   base.Set
-	}{
-		{
-			name:     "empty",
-			inputSet: Set{},
-			output:   base.Set{},
-		},
-		{
-			name: "values",
-			inputSet: Set{
-				NewID("A", 1):                        present{},
-				NewID("B", 2):                        present{},
-				NewID("C", 1):                        present{},
-				NewID("D", base.DefaultCollectionID): present{},
-			},
-			output: base.SetOf("1.A", "2.B", "1.C", "0.D"),
-		},
-	}
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			require.Equal(t, test.output, test.inputSet.GoString())
 		})
 	}
 }

--- a/channels/set_test.go
+++ b/channels/set_test.go
@@ -80,27 +80,27 @@ func TestSetFromArrayNoValidate(t *testing.T) {
 	}{
 		{
 			name:  "singleID",
-			input: []ID{ID{Name: "A", CollectionID: 1}},
+			input: []ID{NewID("A", 1)},
 			output: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
+				NewID("A", 1): present{},
 			},
 		},
 		{
 			name: "twoIDs",
 			input: []ID{
-				ID{Name: "A", CollectionID: 1},
-				ID{Name: "A", CollectionID: 2},
+				NewID("A", 1),
+				NewID("A", 2),
 			},
 			output: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
-				ID{Name: "A", CollectionID: 2}: present{},
+				NewID("A", 1): present{},
+				NewID("A", 2): present{},
 			},
 		},
 		{
 			name:  "illegalChannel",
-			input: []ID{ID{Name: ",", CollectionID: 1}},
+			input: []ID{NewID(",", 1)},
 			output: Set{
-				ID{Name: ",", CollectionID: 1}: present{},
+				NewID(",", 1): present{},
 			},
 		},
 	}
@@ -123,7 +123,7 @@ func TestSetFromSingleCollection(t *testing.T) {
 			input:        []string{"A"},
 			collectionID: 0,
 			output: Set{
-				ID{Name: "A", CollectionID: 0}: present{},
+				NewID("A", 0): present{},
 			},
 		},
 
@@ -132,7 +132,7 @@ func TestSetFromSingleCollection(t *testing.T) {
 			input:        []string{"A"},
 			collectionID: 1,
 			output: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
+				NewID("A", 1): present{},
 			},
 		},
 		{
@@ -140,8 +140,8 @@ func TestSetFromSingleCollection(t *testing.T) {
 			input:        []string{"A", "B"},
 			collectionID: 0,
 			output: Set{
-				ID{Name: "A", CollectionID: 0}: present{},
-				ID{Name: "B", CollectionID: 0}: present{},
+				NewID("A", 0): present{},
+				NewID("B", 0): present{},
 			},
 		},
 
@@ -150,8 +150,8 @@ func TestSetFromSingleCollection(t *testing.T) {
 			input:        []string{"A", "B"},
 			collectionID: 1,
 			output: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
-				ID{Name: "B", CollectionID: 1}: present{},
+				NewID("A", 1): present{},
+				NewID("B", 1): present{},
 			},
 		},
 		{
@@ -159,7 +159,7 @@ func TestSetFromSingleCollection(t *testing.T) {
 			input:        []string{","},
 			collectionID: 1,
 			output: Set{
-				ID{Name: ",", CollectionID: 1}: present{},
+				NewID(",", 1): present{},
 			},
 		},
 	}
@@ -187,68 +187,68 @@ func TestSetUpdate(t *testing.T) {
 			name: "set1empty",
 			set1: Set{},
 			set2: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
+				NewID("A", 1): present{},
 			},
 			combinedSet: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
+				NewID("A", 1): present{},
 			},
 		},
 		{
 			name: "set2empty",
 			set1: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
+				NewID("A", 1): present{},
 			},
 			set2: Set{},
 			combinedSet: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
+				NewID("A", 1): present{},
 			},
 		},
 		{
 			name: "samedata",
 			set1: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
-				ID{Name: "B", CollectionID: 2}: present{},
+				NewID("A", 1): present{},
+				NewID("B", 2): present{},
 			},
 			set2: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
-				ID{Name: "B", CollectionID: 2}: present{},
+				NewID("A", 1): present{},
+				NewID("B", 2): present{},
 			},
 			combinedSet: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
-				ID{Name: "B", CollectionID: 2}: present{},
+				NewID("A", 1): present{},
+				NewID("B", 2): present{},
 			},
 		},
 		{
 			name: "somesamedata",
 			set1: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
-				ID{Name: "B", CollectionID: 2}: present{},
+				NewID("A", 1): present{},
+				NewID("B", 2): present{},
 			},
 			set2: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
-				ID{Name: "C", CollectionID: 1}: present{},
+				NewID("A", 1): present{},
+				NewID("C", 1): present{},
 			},
 			combinedSet: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
-				ID{Name: "B", CollectionID: 2}: present{},
-				ID{Name: "C", CollectionID: 1}: present{},
+				NewID("A", 1): present{},
+				NewID("B", 2): present{},
+				NewID("C", 1): present{},
 			},
 		},
 		{
 			name: "alldifferent",
 			set1: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
-				ID{Name: "B", CollectionID: 2}: present{},
+				NewID("A", 1): present{},
+				NewID("B", 2): present{},
 			},
 			set2: Set{
-				ID{Name: "C", CollectionID: 1}: present{},
-				ID{Name: "D", CollectionID: 1}: present{},
+				NewID("C", 1): present{},
+				NewID("D", 1): present{},
 			},
 			combinedSet: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
-				ID{Name: "B", CollectionID: 2}: present{},
-				ID{Name: "C", CollectionID: 1}: present{},
-				ID{Name: "D", CollectionID: 1}: present{},
+				NewID("A", 1): present{},
+				NewID("B", 2): present{},
+				NewID("C", 1): present{},
+				NewID("D", 1): present{},
 			},
 		},
 	}
@@ -280,45 +280,45 @@ func TestSetAdd(t *testing.T) {
 		{
 			name:     "inputSetempty",
 			inputSet: Set{},
-			inputID:  ID{Name: "A", CollectionID: 1},
+			inputID:  NewID("A", 1),
 			result: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
+				NewID("A", 1): present{},
 			},
 		},
 		{
 			name: "IDempty",
 			inputSet: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
+				NewID("A", 1): present{},
 			},
 			inputID: ID{},
 			result: Set{
-				ID{}:                           present{},
-				ID{Name: "A", CollectionID: 1}: present{},
+				ID{}:          present{},
+				NewID("A", 1): present{},
 			},
 		},
 		{
 			name: "samedata",
 			inputSet: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
-				ID{Name: "B", CollectionID: 2}: present{},
+				NewID("A", 1): present{},
+				NewID("B", 2): present{},
 			},
-			inputID: ID{Name: "A", CollectionID: 1},
+			inputID: NewID("A", 1),
 			result: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
-				ID{Name: "B", CollectionID: 2}: present{},
+				NewID("A", 1): present{},
+				NewID("B", 2): present{},
 			},
 		},
 		{
 			name: "differenta",
 			inputSet: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
-				ID{Name: "B", CollectionID: 2}: present{},
+				NewID("A", 1): present{},
+				NewID("B", 2): present{},
 			},
-			inputID: ID{Name: "C", CollectionID: 1},
+			inputID: NewID("C", 1),
 			result: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
-				ID{Name: "B", CollectionID: 2}: present{},
-				ID{Name: "C", CollectionID: 1}: present{},
+				NewID("A", 1): present{},
+				NewID("B", 2): present{},
+				NewID("C", 1): present{},
 			},
 		},
 	}
@@ -345,15 +345,15 @@ func TestSetContains(t *testing.T) {
 		{
 			name:     "inputSetempty,realID",
 			inputSet: Set{},
-			inputID:  ID{Name: "A", CollectionID: 1},
+			inputID:  NewID("A", 1),
 			contains: false,
 		},
 		{
 			name: "nonemptyset,emptyinput",
 			inputSet: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
-				ID{Name: "B", CollectionID: 2}: present{},
-				ID{Name: "C", CollectionID: 1}: present{},
+				NewID("A", 1): present{},
+				NewID("B", 2): present{},
+				NewID("C", 1): present{},
 			},
 			inputID:  ID{},
 			contains: false,
@@ -361,21 +361,21 @@ func TestSetContains(t *testing.T) {
 		{
 			name: "somedatapresent",
 			inputSet: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
-				ID{Name: "B", CollectionID: 2}: present{},
-				ID{Name: "C", CollectionID: 1}: present{},
+				NewID("A", 1): present{},
+				NewID("B", 2): present{},
+				NewID("C", 1): present{},
 			},
-			inputID:  ID{Name: "A", CollectionID: 1},
+			inputID:  NewID("A", 1),
 			contains: true,
 		},
 		{
 			name: "somedatanotpresent",
 			inputSet: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
-				ID{Name: "B", CollectionID: 2}: present{},
-				ID{Name: "C", CollectionID: 1}: present{},
+				NewID("A", 1): present{},
+				NewID("B", 2): present{},
+				NewID("C", 1): present{},
 			},
-			inputID:  ID{Name: "D", CollectionID: 1},
+			inputID:  NewID("D", 1),
 			contains: false,
 		},
 	}
@@ -386,7 +386,7 @@ func TestSetContains(t *testing.T) {
 	}
 }
 
-func TestSetToSerializedStrings(t *testing.T) {
+func TestSetString(t *testing.T) {
 	testCases := []struct {
 		name     string
 		inputSet Set
@@ -400,17 +400,17 @@ func TestSetToSerializedStrings(t *testing.T) {
 		{
 			name: "values",
 			inputSet: Set{
-				ID{Name: "A", CollectionID: 1}: present{},
-				ID{Name: "B", CollectionID: 2}: present{},
-				ID{Name: "C", CollectionID: 1}: present{},
-				ID{Name: "D"}:                  present{},
+				NewID("A", 1):                        present{},
+				NewID("B", 2):                        present{},
+				NewID("C", 1):                        present{},
+				NewID("D", base.DefaultCollectionID): present{},
 			},
 			output: base.SetOf("1.A", "2.B", "1.C", "0.D"),
 		},
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			require.Equal(t, test.output, test.inputSet.ToSerializedStrings())
+			require.Equal(t, test.output, test.inputSet.GoString())
 		})
 	}
 }

--- a/channels/timed_set.go
+++ b/channels/timed_set.go
@@ -391,11 +391,12 @@ func TimedSetFromString(encoded string) TimedSet {
 	return set
 }
 
-type CollectionByTimedSet map[uint32]TimedSet
+// TimedSetByCollectionID is a map of kv collectionIDs to TimedSets
+type TimedSetByCollectionID map[uint32]TimedSet
 
 // AtSequenceByCollection creates a map of collectionID to a map of channel IDs to sequences.
-func AtSequenceByCollection(chans Set, sequence uint64) CollectionByTimedSet {
-	collectionByTimedSet := CollectionByTimedSet{}
+func AtSequenceByCollection(chans Set, sequence uint64) TimedSetByCollectionID {
+	collectionByTimedSet := TimedSetByCollectionID{}
 	for ch := range chans {
 		val, exists := collectionByTimedSet[ch.CollectionID]
 		if !exists {
@@ -409,11 +410,11 @@ func AtSequenceByCollection(chans Set, sequence uint64) CollectionByTimedSet {
 }
 
 // GetChannels returns the set of channel IDs.
-func (c CollectionByTimedSet) GetChannels() Set {
+func (c TimedSetByCollectionID) GetChannels() Set {
 	chans := Set{}
 	for collectionID, timedSet := range c {
 		for chanName := range timedSet {
-			chans.Add(ID{Name: chanName, CollectionID: collectionID})
+			chans.Add(NewID(chanName, collectionID))
 		}
 	}
 	return chans

--- a/channels/timed_set.go
+++ b/channels/timed_set.go
@@ -408,14 +408,3 @@ func AtSequenceByCollection(chans Set, sequence uint64) TimedSetByCollectionID {
 	}
 	return collectionByTimedSet
 }
-
-// GetChannels returns the set of channel IDs.
-func (c TimedSetByCollectionID) GetChannels() Set {
-	chans := Set{}
-	for collectionID, timedSet := range c {
-		for chanName := range timedSet {
-			chans.Add(NewID(chanName, collectionID))
-		}
-	}
-	return chans
-}

--- a/channels/timed_set.go
+++ b/channels/timed_set.go
@@ -390,3 +390,31 @@ func TimedSetFromString(encoded string) TimedSet {
 	}
 	return set
 }
+
+type CollectionByTimedSet map[uint32]TimedSet
+
+// AtSequenceByCollection creates a map of collectionID to a map of channel IDs to sequences.
+func AtSequenceByCollection(chans Set, sequence uint64) CollectionByTimedSet {
+	collectionByTimedSet := CollectionByTimedSet{}
+	for ch := range chans {
+		val, exists := collectionByTimedSet[ch.CollectionID]
+		if !exists {
+			val = make(TimedSet)
+		}
+		val[ch.Name] = NewVbSimpleSequence(sequence)
+		collectionByTimedSet[ch.CollectionID] = val
+
+	}
+	return collectionByTimedSet
+}
+
+// GetChannels returns the set of channel IDs.
+func (c CollectionByTimedSet) GetChannels() Set {
+	chans := Set{}
+	for collectionID, timedSet := range c {
+		for chanName := range timedSet {
+			chans.Add(ID{Name: chanName, CollectionID: collectionID})
+		}
+	}
+	return chans
+}

--- a/channels/timed_set_test.go
+++ b/channels/timed_set_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTimedSetMarshal(t *testing.T) {
@@ -167,4 +168,20 @@ func TestTimedSetCompareKeys(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCollectionByTimedSet(t *testing.T) {
+	chans, err := SetOf(
+		ID{Name: "A", CollectionID: 2},
+		ID{Name: "B", CollectionID: 2},
+		ID{Name: "B", CollectionID: 1},
+		ID{Name: "C", CollectionID: 1},
+	)
+	require.NoError(t, err)
+	collectionByTimedSet := AtSequenceByCollection(chans, 42)
+	require.Equal(t, CollectionByTimedSet{
+		1: TimedSetFromString("B:42,C:42"),
+		2: TimedSetFromString("A:42,B:42"),
+	}, collectionByTimedSet)
+	require.Equal(t, chans, collectionByTimedSet.GetChannels())
 }

--- a/channels/timed_set_test.go
+++ b/channels/timed_set_test.go
@@ -170,16 +170,16 @@ func TestTimedSetCompareKeys(t *testing.T) {
 	}
 }
 
-func TestCollectionByTimedSet(t *testing.T) {
+func TestTimedSetByCollectionID(t *testing.T) {
 	chans, err := SetOf(
-		ID{Name: "A", CollectionID: 2},
-		ID{Name: "B", CollectionID: 2},
-		ID{Name: "B", CollectionID: 1},
-		ID{Name: "C", CollectionID: 1},
+		NewID("A", 2),
+		NewID("B", 2),
+		NewID("B", 1),
+		NewID("C", 1),
 	)
 	require.NoError(t, err)
 	collectionByTimedSet := AtSequenceByCollection(chans, 42)
-	require.Equal(t, CollectionByTimedSet{
+	require.Equal(t, TimedSetByCollectionID{
 		1: TimedSetFromString("B:42,C:42"),
 		2: TimedSetFromString("A:42,B:42"),
 	}, collectionByTimedSet)

--- a/channels/timed_set_test.go
+++ b/channels/timed_set_test.go
@@ -183,5 +183,4 @@ func TestTimedSetByCollectionID(t *testing.T) {
 		1: TimedSetFromString("B:42,C:42"),
 		2: TimedSetFromString("A:42,B:42"),
 	}, collectionByTimedSet)
-	require.Equal(t, chans, collectionByTimedSet.GetChannels())
 }

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -110,6 +110,7 @@ func (bh *blipHandler) refreshUser() error {
 	if bc.userName != "" {
 		// Check whether user needs to be refreshed
 		bc.dbUserLock.Lock()
+		defer bc.dbUserLock.Unlock()
 		userChanged := bc.userChangeWaiter.RefreshUserCount()
 
 		// If changed, refresh the user and db while holding the lock
@@ -117,7 +118,6 @@ func (bh *blipHandler) refreshUser() error {
 			// Refresh the BlipSyncContext database
 			newUser, err := bc.blipContextDb.Authenticator(bh.loggingCtx).GetUser(bc.userName)
 			if err != nil {
-				bc.dbUserLock.Unlock()
 				return err
 			}
 			newUser.InitializeRoles()
@@ -127,7 +127,6 @@ func (bh *blipHandler) refreshUser() error {
 			// refresh the handler's database with the new BlipSyncContext database
 			bh.db = bh._copyContextDatabase()
 		}
-		bc.dbUserLock.Unlock()
 	}
 	return nil
 }

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1637,10 +1637,10 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 	//  Detect whether the 2nd was ignored using an notifyChange listener callback and make sure it was not added to the ABC channel
 	waitForOnChangeCallback := sync.WaitGroup{}
 	waitForOnChangeCallback.Add(1)
-	db.changeCache.notifyChange = func(chans base.Set) {
+	db.changeCache.notifyChange = func(chans channels.Set) {
 		expectedChan := channels.NewID("ABC", collectionID)
 		for ch := range chans {
-			if ch == expectedChan.String() {
+			if ch == expectedChan {
 				waitForOnChangeCallback.Done()
 			}
 		}
@@ -1827,9 +1827,9 @@ func TestNotifyForInactiveChannel(t *testing.T) {
 	// -------- Setup notifyChange callback ----------------
 
 	notifyChannel := make(chan struct{})
-	db.changeCache.notifyChange = func(chans base.Set) {
+	db.changeCache.notifyChange = func(chans channels.Set) {
 		expectedChan := channels.NewID("zero", collectionID)
-		if chans.Contains(expectedChan.String()) {
+		if chans.Contains(expectedChan) {
 			notifyChannel <- struct{}{}
 		}
 	}

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -58,12 +58,13 @@ func et(seq uint64, docid string, revid string) *LogEntry {
 	return entry
 }
 
-func logEntry(seq uint64, docid string, revid string, channelNames []string) *LogEntry {
+func logEntry(seq uint64, docid string, revid string, channelNames []string, collectionID uint32) *LogEntry {
 	entry := &LogEntry{
 		Sequence:     seq,
 		DocID:        docid,
 		RevID:        revid,
 		TimeReceived: time.Now(),
+		CollectionID: collectionID,
 	}
 	channelMap := make(channels.ChannelMap)
 	for _, channelName := range channelNames {
@@ -117,12 +118,15 @@ func TestLateSequenceHandling(t *testing.T) {
 	context, ctx := setupTestDBWithCacheOptions(t, DefaultCacheOptions())
 	defer context.Close(ctx)
 
+	collectionID, err := context.GetSingleCollectionID()
+	require.NoError(t, err)
+
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
-	cache := newSingleChannelCache(context, "Test1", 0, dbstats.CacheStats)
+	cache := newSingleChannelCache(context, channels.ID{Name: "Test1", CollectionID: collectionID}, 0, dbstats.CacheStats)
 	assert.True(t, cache != nil)
 
 	// Empty late sequence cache should return empty set
@@ -190,12 +194,15 @@ func TestLateSequenceHandlingWithMultipleListeners(t *testing.T) {
 	require.NoError(t, err)
 	defer context.Close(ctx)
 
+	collectionID, err := context.GetSingleCollectionID()
+	require.NoError(t, err)
+
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
-	cache := newSingleChannelCache(context, "Test1", 0, dbstats.CacheStats)
+	cache := newSingleChannelCache(context, channels.ID{Name: "Test1", CollectionID: collectionID}, 0, dbstats.CacheStats)
 	assert.True(t, cache != nil)
 
 	// Add Listener before late entries arrive
@@ -250,11 +257,14 @@ func TestLateSequenceErrorRecovery(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
+	base.SetUpTestLogging(t, base.LevelTrace, base.KeyChanges, base.KeyCache)
 
 	db, ctx := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close(ctx)
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
+
+	collectionID, err := db.GetSingleCollectionID()
+	require.NoError(t, err)
 
 	// Create a user with access to channel ABC
 	authenticator := db.Authenticator(ctx)
@@ -312,7 +322,7 @@ func TestLateSequenceErrorRecovery(t *testing.T) {
 	// Modify the cache's late logs to remove the changes feed's lateFeedHandler sequence from the
 	// cache's lateLogs.  This will trigger an error on the next feed iteration, which should trigger
 	// rollback to resend all changes since low sequence (1)
-	abcCache := db.changeCache.getChannelCache().getSingleChannelCache("ABC").(*singleChannelCacheImpl)
+	abcCache := db.changeCache.getChannelCache().getSingleChannelCache(channels.ID{Name: "ABC", CollectionID: collectionID}).(*singleChannelCacheImpl)
 	abcCache.lateLogs[0].logEntry.Sequence = 1
 
 	// Write sequence 3.  Error should trigger rollback that resends everything since low sequence (1)
@@ -551,13 +561,18 @@ func TestChannelCacheBufferingWithUserDoc(t *testing.T) {
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
+
+	collectionID, err := db.GetSingleCollectionID()
+	require.NoError(t, err)
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
 	// Simulate seq 1 (user doc) being delayed - write 2 first
 	WriteDirect(db, []string{"ABC"}, 2)
 
 	// Start wait for doc in ABC
-	waiter := db.mutationListener.NewWaiterWithChannels(channels.BaseSetOf(t, "ABC"), nil)
+	chans := channels.SetOfNoValidate(
+		channels.ID{Name: "ABC", CollectionID: collectionID})
+	waiter := db.mutationListener.NewWaiterWithChannels(chans, nil)
 
 	successChan := make(chan bool)
 	go func() {
@@ -619,17 +634,21 @@ func TestChannelCacheBackfill(t *testing.T) {
 	WriteDirect(db, []string{"ABC", "NBC", "PBS", "TBS"}, 3)
 	WriteDirect(db, []string{"CBS"}, 7)
 	require.NoError(t, db.changeCache.waitForSequence(ctx, 7, base.DefaultWaitForSequence))
+
+	collectionID, err := db.GetSingleCollectionID()
+	require.NoError(t, err)
+
 	// verify insert at start (PBS)
-	pbsCache := db.changeCache.getChannelCache().getSingleChannelCache("PBS").(*singleChannelCacheImpl)
+	pbsCache := db.changeCache.getChannelCache().getSingleChannelCache(channels.ID{Name: "PBS", CollectionID: collectionID}).(*singleChannelCacheImpl)
 	assert.True(t, verifyCacheSequences(pbsCache, []uint64{3, 5, 6}))
 	// verify insert at middle (ABC)
-	abcCache := db.changeCache.getChannelCache().getSingleChannelCache("ABC").(*singleChannelCacheImpl)
+	abcCache := db.changeCache.getChannelCache().getSingleChannelCache(channels.ID{Name: "ABC", CollectionID: collectionID}).(*singleChannelCacheImpl)
 	assert.True(t, verifyCacheSequences(abcCache, []uint64{1, 2, 3, 5, 6}))
 	// verify insert at end (NBC)
-	nbcCache := db.changeCache.getChannelCache().getSingleChannelCache("NBC").(*singleChannelCacheImpl)
+	nbcCache := db.changeCache.getChannelCache().getSingleChannelCache(channels.ID{Name: "NBC", CollectionID: collectionID}).(*singleChannelCacheImpl)
 	assert.True(t, verifyCacheSequences(nbcCache, []uint64{1, 3}))
 	// verify insert to empty cache (TBS)
-	tbsCache := db.changeCache.getChannelCache().getSingleChannelCache("TBS").(*singleChannelCacheImpl)
+	tbsCache := db.changeCache.getChannelCache().getSingleChannelCache(channels.ID{Name: "TBS", CollectionID: collectionID}).(*singleChannelCacheImpl)
 	assert.True(t, verifyCacheSequences(tbsCache, []uint64{3}))
 
 	// verify changes has three entries (needs to resend all since previous LowSeq, which
@@ -1314,7 +1333,11 @@ func TestSkippedViewRetrieval(t *testing.T) {
 
 	// Validate expected entries
 	require.NoError(t, db.changeCache.waitForSequence(ctx, 15, base.DefaultWaitForSequence))
-	entries, err := db.changeCache.GetChanges("ABC", getChangesOptionsWithSeq(SequenceID{Seq: 2}))
+
+	collectionID, err := db.GetSingleCollectionID()
+	require.NoError(t, err)
+
+	entries, err := db.changeCache.GetChanges(channels.ID{Name: "ABC", CollectionID: collectionID}, getChangesOptionsWithSeq(SequenceID{Seq: 2}))
 	assert.NoError(t, err, "Get Changes returned error")
 	assert.Equal(t, 6, len(entries))
 	log.Printf("entries: %v", entries)
@@ -1369,7 +1392,6 @@ func TestStopChangeCache(t *testing.T) {
 
 // Test size config
 func TestChannelCacheSize(t *testing.T) {
-
 	if base.TestUseXattrs() {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
@@ -1404,7 +1426,10 @@ func TestChannelCacheSize(t *testing.T) {
 	assert.Equal(t, 750, len(changes))
 
 	// Validate that cache stores the expected number of values
-	abcCache := db.changeCache.getChannelCache().getSingleChannelCache("ABC").(*singleChannelCacheImpl)
+	collectionID, err := db.GetSingleCollectionID()
+	require.NoError(t, err)
+
+	abcCache := db.changeCache.getChannelCache().getSingleChannelCache(channels.ID{Name: "ABC", CollectionID: collectionID}).(*singleChannelCacheImpl)
 	assert.Equal(t, 600, len(abcCache.logs))
 }
 
@@ -1604,17 +1629,20 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 	db, ctx := setupTestDBWithCacheOptions(t, options)
 	defer db.Close(ctx)
 
+	collectionID, err := db.GetSingleCollectionID()
+	require.NoError(t, err)
+
 	// -------- Setup notifyChange callback ----------------
 
 	//  Detect whether the 2nd was ignored using an notifyChange listener callback and make sure it was not added to the ABC channel
 	waitForOnChangeCallback := sync.WaitGroup{}
 	waitForOnChangeCallback.Add(1)
-	db.changeCache.notifyChange = func(channels base.Set) {
-		// defer waitForOnChangeCallback.Done()
-		log.Printf("channelsChanged: %v", channels)
-		// goassert.True(t, channels.Contains("ABC"))
-		if channels.Contains("ABC") {
-			waitForOnChangeCallback.Done()
+	db.changeCache.notifyChange = func(chans base.Set) {
+		expectedChan := channels.ID{Name: "ABC", CollectionID: collectionID}
+		for ch := range chans {
+			if ch == expectedChan.String() {
+				waitForOnChangeCallback.Done()
+			}
 		}
 
 	}
@@ -1793,19 +1821,22 @@ func TestNotifyForInactiveChannel(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
+	collectionID, err := db.GetSingleCollectionID()
+	require.NoError(t, err)
+
 	// -------- Setup notifyChange callback ----------------
 
 	notifyChannel := make(chan struct{})
-	db.changeCache.notifyChange = func(channels base.Set) {
-		log.Printf("channelsChanged: %v", channels)
-		if channels.Contains("zero") {
+	db.changeCache.notifyChange = func(chans base.Set) {
+		expectedChan := channels.ID{Name: "zero", CollectionID: collectionID}
+		if chans.Contains(expectedChan.String()) {
 			notifyChannel <- struct{}{}
 		}
 	}
 
 	// Write a document to channel zero
 	body := Body{"channels": []string{"zero"}}
-	_, _, err := db.Put(ctx, "inactiveCacheNotify", body)
+	_, _, err = db.Put(ctx, "inactiveCacheNotify", body)
 	assert.NoError(t, err)
 
 	// Wait for notify to arrive
@@ -1985,6 +2016,8 @@ func BenchmarkProcessEntry(b *testing.B) {
 			context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 			require.NoError(b, err)
 			defer context.Close(ctx)
+			collectionID, err := context.GetSingleCollectionID()
+			require.NoError(b, err)
 
 			ctx = context.AddDatabaseLogContext(ctx)
 			changeCache := &changeCache{}
@@ -2001,8 +2034,8 @@ func BenchmarkProcessEntry(b *testing.B) {
 
 			if bm.warmCacheCount > 0 {
 				for i := 0; i < bm.warmCacheCount; i++ {
-					channelName := fmt.Sprintf("channel_%d", i)
-					_, err := changeCache.GetChanges(channelName, getChangesOptionsWithZeroSeq())
+					channel := channels.ID{Name: fmt.Sprintf("channel_%d", i), CollectionID: collectionID}
+					_, err := changeCache.GetChanges(channel, getChangesOptionsWithZeroSeq())
 					if err != nil {
 						log.Printf("GetChanges failed for changeCache: %v", err)
 						b.Fail()
@@ -2214,6 +2247,9 @@ func BenchmarkDocChanged(b *testing.B) {
 			require.NoError(b, err)
 			defer context.Close(ctx)
 
+			collectionID, err := context.GetSingleCollectionID()
+			require.NoError(b, err)
+
 			ctx = context.AddDatabaseLogContext(ctx)
 			changeCache := &changeCache{}
 			if err := changeCache.Init(ctx, context, nil, nil); err != nil {
@@ -2228,8 +2264,8 @@ func BenchmarkDocChanged(b *testing.B) {
 
 			if bm.warmCacheCount > 0 {
 				for i := 0; i < bm.warmCacheCount; i++ {
-					channelName := fmt.Sprintf("channel_%d", i)
-					_, err := changeCache.GetChanges(channelName, getChangesOptionsWithZeroSeq())
+					channel := channels.ID{Name: fmt.Sprintf("channel_%d", i), CollectionID: collectionID}
+					_, err := changeCache.GetChanges(channel, getChangesOptionsWithZeroSeq())
 					if err != nil {
 						log.Printf("GetChanges failed for changeCache: %v", err)
 						b.Fail()

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -362,11 +362,14 @@ func (waiter *ChangeWaiter) RefreshUserCount() bool {
 }
 
 // Updates the set of channel keys in the ChangeWaiter (maintains the existing set of user keys)
-func (waiter *ChangeWaiter) UpdateChannels(chans channels.Set) {
-	initialCapacity := len(chans) + len(waiter.userKeys)
+func (waiter *ChangeWaiter) UpdateChannels(timedSetByCollectionID channels.TimedSetByCollectionID) {
+	// This capacity is not right can not accomodate channels without iteration.
+	initialCapacity := len(waiter.userKeys)
 	updatedKeys := make([]string, 0, initialCapacity)
-	for channel := range chans {
-		updatedKeys = append(updatedKeys, channel.String())
+	for collectionID, timedSetByChannel := range timedSetByCollectionID {
+		for channelName, _ := range timedSetByChannel {
+			updatedKeys = append(updatedKeys, channels.NewID(channelName, collectionID).String())
+		}
 	}
 	if len(waiter.userKeys) > 0 {
 		updatedKeys = append(updatedKeys, waiter.userKeys...)

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -300,7 +300,7 @@ func (listener *changeListener) NewWaiterWithChannels(chans channels.Set, user a
 	}
 	var userKeys []string
 	if user != nil {
-		userKeys = append(userKeys, base.UserPrefix+user.Name())
+		userKeys = []string{base.UserPrefix + user.Name()}
 		for role := range user.RoleNames() {
 			userKeys = append(userKeys, base.RolePrefix+role)
 		}

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -118,7 +118,7 @@ func (listener *changeListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool 
 			if listener.OnDocChanged != nil && event.Opcode == sgbucket.FeedOpMutation {
 				listener.OnDocChanged(event)
 			}
-			listener.notifyUser(key)
+			listener.notifyKey(key)
 		} else if strings.HasPrefix(key, base.UnusedSeqPrefix) || strings.HasPrefix(key, base.UnusedSeqRangePrefix) { // SG unused sequence marker docs
 			if listener.OnDocChanged != nil && event.Opcode == sgbucket.FeedOpMutation {
 				listener.OnDocChanged(event)
@@ -197,12 +197,12 @@ func (listener *changeListener) Notify(keys channels.Set) {
 	listener.tapNotifier.L.Unlock()
 }
 
-// Changes the counter, notifying waiting clients. Only use for single update is updating user, which might be collection scoped in the future.
-func (listener *changeListener) notifyUser(key string) {
+// Changes the counter, notifying waiting clients. Only use for a key update.
+func (listener *changeListener) notifyKey(key string) {
 	listener.tapNotifier.L.Lock()
 	listener.counter++
 	listener.keyCounts[key] = listener.counter
-	base.DebugfCtx(context.TODO(), base.KeyChanges, "Notifying that %q changed (keys=%q) count=%d",
+	base.DebugfCtx(context.TODO(), base.KeyChanges, "Notifying that %q changed (key=%q) count=%d",
 		base.MD(listener.bucketName), base.UD(key), listener.counter)
 	listener.tapNotifier.Broadcast()
 	listener.tapNotifier.L.Unlock()

--- a/db/changes.go
+++ b/db/changes.go
@@ -676,9 +676,8 @@ func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans channels.S
 		}
 
 		// Mark channel set as active, schedule defer
-		activeChannels := channelsSince.GetChannels()
-		db.activeChannels.IncrChannels(activeChannels)
-		defer db.activeChannels.DecrChannels(activeChannels)
+		db.activeChannels.IncrChannels(channelsSince)
+		defer db.activeChannels.DecrChannels(channelsSince)
 
 		// For a continuous feed, initialise the lateSequenceFeeds that track late-arriving sequences
 		// to the channel caches.
@@ -698,9 +697,9 @@ func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans channels.S
 		for {
 			// Updates the ChangeWaiter to the current set of available channels
 			if changeWaiter != nil {
-				changeWaiter.UpdateChannels(activeChannels)
+				changeWaiter.UpdateChannels(channelsSince)
 			}
-			base.DebugfCtx(ctx, base.KeyChanges, "MultiChangesFeed: channels expand to %#v ... %s", base.UD(activeChannels), base.UD(to))
+			base.DebugfCtx(ctx, base.KeyChanges, "MultiChangesFeed: channels expand to %#v ... %s", base.UD(channelsSince), base.UD(to))
 
 			// lowSequence is used to send composite keys to clients, so that they can obtain any currently
 			// skipped sequences in a future iteration or request.

--- a/db/changes.go
+++ b/db/changes.go
@@ -179,7 +179,7 @@ func (db *Database) AddDocInstanceToChangeEntry(ctx context.Context, entry *Chan
 // This is used in this function in 'wasDocInChannelAtSeq'.
 // revokeFrom: This is the point at which we should run the changes feed from to find the documents we should revoke. It
 // is calculated higher up based on whether we are resuming an interrupted feed or not.
-func (db *Database) buildRevokedFeed(ctx context.Context, channelName string, options ChangesOptions, revokedAt, revocationSinceSeq, revokeFrom uint64, to string) <-chan *ChangeEntry {
+func (db *Database) buildRevokedFeed(ctx context.Context, ch channels.ID, options ChangesOptions, revokedAt, revocationSinceSeq, revokeFrom uint64, to string) <-chan *ChangeEntry {
 	feed := make(chan *ChangeEntry, 1)
 	sinceVal := options.Since.Seq
 
@@ -195,7 +195,7 @@ func (db *Database) buildRevokedFeed(ctx context.Context, channelName string, op
 	paginationOptions.Since.Seq = revokeFrom
 
 	// Use a bypass channel cache for revocations (CBG-1695)
-	singleChannelCache := db.changeCache.getChannelCache().getBypassChannelCache(channelName)
+	singleChannelCache := db.changeCache.getChannelCache().getBypassChannelCache(ch)
 
 	go func() {
 		defer base.FatalPanicHandler()
@@ -217,17 +217,17 @@ func (db *Database) buildRevokedFeed(ctx context.Context, channelName string, op
 			}
 
 			// Get changes from 0 to latest seq
-			base.TracefCtx(ctx, base.KeyChanges, "Querying channel %q for revocation with options: %+v", base.UD(singleChannelCache.ChannelName()), paginationOptions)
+			base.TracefCtx(ctx, base.KeyChanges, "Querying channel %q for revocation with options: %+v", base.UD(singleChannelCache.ChannelID()), paginationOptions)
 			changes, err := singleChannelCache.GetChanges(paginationOptions)
 			if err != nil {
-				base.WarnfCtx(ctx, "Error retrieving changes for channel %q: %v", base.UD(singleChannelCache.ChannelName()), err)
+				base.WarnfCtx(ctx, "Error retrieving changes for channel %q: %v", base.UD(singleChannelCache.ChannelID()), err)
 				change := ChangeEntry{
 					Err: base.ErrChannelFeed,
 				}
 				feed <- &change
 				return
 			}
-			base.DebugfCtx(ctx, base.KeyChanges, "[revocationChangesFeed] Found %d changes for channel %q", len(changes), base.UD(singleChannelCache.ChannelName()))
+			base.DebugfCtx(ctx, base.KeyChanges, "[revocationChangesFeed] Found %d changes for channel %q", len(changes), base.UD(singleChannelCache.ChannelID()))
 
 			sentChanges := 0
 			for _, logEntry := range changes {
@@ -241,18 +241,19 @@ func (db *Database) buildRevokedFeed(ctx context.Context, channelName string, op
 				// Otherwise: we need to determine whether a previous revision of the document was in the channel prior
 				// to the since value, and only send a revocation if that was the case
 				if logEntry.Sequence > sinceVal {
-					requiresRevocation, err := db.wasDocInChannelPriorToRevocation(ctx, logEntry.DocID, singleChannelCache.ChannelName(), revocationSinceSeq)
+					// FIXME: should this be a channelID?
+					requiresRevocation, err := db.wasDocInChannelPriorToRevocation(ctx, logEntry.DocID, singleChannelCache.ChannelID().Name, revocationSinceSeq)
 					if err != nil {
 						change := ChangeEntry{
 							Err: base.ErrChannelFeed,
 						}
 						feed <- &change
-						base.WarnfCtx(ctx, "Error checking document history during revocation, seq: %v in channel %s, ending revocation feed. Error: %v", seqID, base.UD(singleChannelCache.ChannelName()), err)
+						base.WarnfCtx(ctx, "Error checking document history during revocation, seq: %v in channel %s, ending revocation feed. Error: %v", seqID, base.UD(singleChannelCache.ChannelID()), err)
 						return
 					}
 
 					if !requiresRevocation {
-						base.DebugfCtx(ctx, base.KeyChanges, "Channel feed processing revocation, seq: %v in channel %s does not require revocation", seqID, base.UD(singleChannelCache.ChannelName()))
+						base.DebugfCtx(ctx, base.KeyChanges, "Channel feed processing revocation, seq: %v in channel %s does not require revocation", seqID, base.UD(singleChannelCache.ChannelID()))
 						continue
 					}
 				}
@@ -271,10 +272,10 @@ func (db *Database) buildRevokedFeed(ctx context.Context, channelName string, op
 					continue
 				}
 
-				change := makeRevocationChangeEntry(logEntry, seqID, singleChannelCache.ChannelName())
+				change := makeRevocationChangeEntry(logEntry, seqID, singleChannelCache.ChannelID())
 				lastSeq = logEntry.Sequence
 
-				base.DebugfCtx(ctx, base.KeyChanges, "Channel feed processing revocation seq: %v in channel %s ", seqID, base.UD(singleChannelCache.ChannelName()))
+				base.DebugfCtx(ctx, base.KeyChanges, "Channel feed processing revocation seq: %v in channel %s ", seqID, base.UD(singleChannelCache.ChannelID()))
 
 				select {
 				case <-options.ChangesCtx.Done():
@@ -402,17 +403,17 @@ func (db *Database) changesFeed(ctx context.Context, singleChannelCache SingleCh
 			}
 
 			// TODO: pass db.Ctx down to changeCache?
-			base.TracefCtx(ctx, base.KeyChanges, "Querying channel %q with options: %+v", base.UD(singleChannelCache.ChannelName()), paginationOptions)
+			base.TracefCtx(ctx, base.KeyChanges, "Querying channel %q with options: %+v", base.UD(singleChannelCache.ChannelID()), paginationOptions)
 			changes, err := singleChannelCache.GetChanges(paginationOptions)
 			if err != nil {
-				base.WarnfCtx(ctx, "Error retrieving changes for channel %q: %v", base.UD(singleChannelCache.ChannelName()), err)
+				base.WarnfCtx(ctx, "Error retrieving changes for channel %q: %v", base.UD(singleChannelCache.ChannelID()), err)
 				change := ChangeEntry{
 					Err: base.ErrChannelFeed,
 				}
 				feed <- &change
 				return
 			}
-			base.DebugfCtx(ctx, base.KeyChanges, "[changesFeed] Found %d changes for channel %q", len(changes), base.UD(singleChannelCache.ChannelName()))
+			base.DebugfCtx(ctx, base.KeyChanges, "[changesFeed] Found %d changes for channel %q", len(changes), base.UD(singleChannelCache.ChannelID()))
 
 			// Now write each log entry to the 'feed' channel in turn:
 			sentChanges := 0
@@ -425,7 +426,7 @@ func (db *Database) changesFeed(ctx context.Context, singleChannelCache SingleCh
 					TriggeredBy: options.Since.TriggeredBy,
 				}
 
-				change := makeChangeEntry(logEntry, seqID, singleChannelCache.ChannelName())
+				change := makeChangeEntry(logEntry, seqID, singleChannelCache.ChannelID())
 				lastSeq = logEntry.Sequence
 
 				// Don't include deletes or removals during initial channel backfill
@@ -433,7 +434,7 @@ func (db *Database) changesFeed(ctx context.Context, singleChannelCache SingleCh
 					continue
 				}
 
-				base.DebugfCtx(ctx, base.KeyChanges, "Channel feed processing seq:%v in channel %s %s", seqID, base.UD(singleChannelCache.ChannelName()), base.UD(to))
+				base.DebugfCtx(ctx, base.KeyChanges, "Channel feed processing seq:%v in channel %s %s", seqID, base.UD(singleChannelCache.ChannelID()), base.UD(to))
 				select {
 				case <-options.ChangesCtx.Done():
 					base.DebugfCtx(ctx, base.KeyChanges, "Terminating channel feed %s", base.UD(to))
@@ -460,7 +461,7 @@ func (db *Database) changesFeed(ctx context.Context, singleChannelCache SingleCh
 	return feed
 }
 
-func makeChangeEntry(logEntry *LogEntry, seqID SequenceID, channelName string) ChangeEntry {
+func makeChangeEntry(logEntry *LogEntry, seqID SequenceID, channel channels.ID) ChangeEntry {
 	change := ChangeEntry{
 		Seq:          seqID,
 		ID:           logEntry.DocID,
@@ -471,14 +472,15 @@ func makeChangeEntry(logEntry *LogEntry, seqID SequenceID, channelName string) C
 	}
 
 	if logEntry.Flags&channels.Removed != 0 {
-		change.Removed = base.SetOf(channelName)
+		// FIXME: Because this corresponds to a DocID, do we implicitly know what this is? I'm loathe to change ChangeEntry because it looks like it is serialized
+		change.Removed = base.SetOf(channel.Name)
 	}
 
 	return change
 }
 
-func makeRevocationChangeEntry(logEntry *LogEntry, seqID SequenceID, channelName string) ChangeEntry {
-	entry := makeChangeEntry(logEntry, seqID, channelName)
+func makeRevocationChangeEntry(logEntry *LogEntry, seqID SequenceID, channel channels.ID) ChangeEntry {
+	entry := makeChangeEntry(logEntry, seqID, channel)
 	entry.Revoked = true
 
 	return entry
@@ -530,16 +532,17 @@ func (db *Database) MultiChangesFeed(ctx context.Context, chans base.Set, option
 	}
 
 	base.DebugfCtx(ctx, base.KeyChanges, "Int sequence multi changes feed...")
-	return db.SimpleMultiChangesFeed(ctx, chans, options)
+
+	collectionID, err := db.GetSingleCollectionID()
+	if err != nil {
+		return nil, err
+	}
+	return db.SimpleMultiChangesFeed(ctx, channels.SetOfFromSingleCollection(chans.ToArray(), collectionID), options)
 
 }
 
-func (db *Database) startChangeWaiter(chans base.Set) *ChangeWaiter {
-	waitChans := chans
-	if db.user != nil {
-		waitChans = db.user.ExpandWildCardChannel(chans)
-	}
-	return db.mutationListener.NewWaiterWithChannels(waitChans, db.user)
+func (db *Database) startChangeWaiter() *ChangeWaiter {
+	return db.mutationListener.NewWaiterWithChannels(channels.Set{}, db.user)
 }
 
 func (db *Database) appendUserFeed(feeds []<-chan *ChangeEntry, options ChangesOptions) []<-chan *ChangeEntry {
@@ -563,12 +566,13 @@ func (db *Database) appendUserFeed(feeds []<-chan *ChangeEntry, options ChangesO
 	return feeds
 }
 
-func (db *Database) checkForUserUpdates(ctx context.Context, userChangeCount uint64, changeWaiter *ChangeWaiter, isContinuous bool) (isChanged bool, newCount uint64, changedChannels channels.ChangedKeys, err error) {
+func (db *Database) checkForUserUpdates(ctx context.Context, userChangeCount uint64, changeWaiter *ChangeWaiter, isContinuous bool) (isChanged bool, newCount uint64, changedChannels channels.ChangedChannels, err error) {
 
 	newCount = changeWaiter.CurrentUserCount()
 	// If not continuous, we force user reload as a workaround for https://github.com/couchbase/sync_gateway/issues/2068.  For continuous, #2068 is handled by changedChannels check, and
 	// we can reload only when there's been a user change notification
 	if newCount > userChangeCount || !isContinuous {
+		changedChannels := channels.ChangedChannels{}
 		var previousChannels channels.TimedSet
 		base.DebugfCtx(ctx, base.KeyChanges, "MultiChangesFeed reloading user %+v", base.UD(db.user))
 		userChangeCount = newCount
@@ -581,7 +585,15 @@ func (db *Database) checkForUserUpdates(ctx context.Context, userChangeCount uin
 				return false, 0, nil, err
 			}
 			// check whether channel set has changed
-			changedChannels = db.user.InheritedChannels().CompareKeys(previousChannels)
+			singleCollectionChannels := db.user.InheritedChannels().CompareKeys(previousChannels)
+			singleCollectionID, err := db.GetSingleCollectionID()
+			if err != nil {
+				return false, 0, nil, err
+			}
+
+			for channelName, changed := range singleCollectionChannels {
+				changedChannels[channels.ID{Name: channelName, CollectionID: singleCollectionID}] = changed
+			}
 			if len(changedChannels) > 0 {
 				base.DebugfCtx(ctx, base.KeyChanges, "Modified channel set after user reload: %v", base.UD(changedChannels))
 			}
@@ -597,7 +609,7 @@ func (db *Database) checkForUserUpdates(ctx context.Context, userChangeCount uin
 }
 
 // Returns the (ordered) union of all of the changes made to multiple channels.
-func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans base.Set, options ChangesOptions) (<-chan *ChangeEntry, error) {
+func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans channels.Set, options ChangesOptions) (<-chan *ChangeEntry, error) {
 
 	to := ""
 	if db.user != nil && db.user.Name() != "" {
@@ -607,6 +619,10 @@ func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans base.Set, 
 	base.InfofCtx(ctx, base.KeyChanges, "MultiChangesFeed(channels: %s, options: %s) ... %s", base.UD(chans), options, base.UD(to))
 	output := make(chan *ChangeEntry, 50)
 
+	singleCollectionID, err := db.GetSingleCollectionID()
+	if err != nil {
+		return nil, err
+	}
 	go func() {
 
 		defer func() {
@@ -621,17 +637,18 @@ func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans base.Set, 
 		var changeWaiter *ChangeWaiter
 		var lowSequence uint64
 		var currentCachedSequence uint64
-		var lateSequenceFeeds map[string]*lateSequenceFeed
-		var userCounter uint64              // Wait counter used to identify changes to the user document
-		var changedChannels map[string]bool // Tracks channels added/removed to the user during changes processing.
-		var userChanged bool                // Whether the user document has changed in a given iteration loop
-		var deferredBackfill bool           // Whether there's a backfill identified in the user doc that's deferred while the SG cache catches up
+		var lateSequenceFeeds map[channels.ID]*lateSequenceFeed
+		var userCounter uint64                       // Wait counter used to identify changes to the user document
+		var changedChannels channels.ChangedChannels // Tracks channels added/removed to the user during changes processing.
+		var userChanged bool                         // Whether the user document has changed in a given iteration loop
+		var deferredBackfill bool                    // Whether there's a backfill identified in the user doc that's deferred while the SG cache catches up
 
 		// Retrieve the current max cached sequence - ensures there isn't a race between the subsequent channel cache queries
 		currentCachedSequence = db.changeCache.getChannelCache().GetHighCacheSequence()
 		if options.Wait {
 			options.Wait = false
-			changeWaiter = db.startChangeWaiter(base.Set{}) // Waiter is updated with the actual channel set (post-user reload) at the start of the outer changes loop
+
+			changeWaiter = db.startChangeWaiter() // Waiter is updated with the actual channel set (post-user reload) at the start of the outer changes loop
 			userCounter = changeWaiter.CurrentUserCount()
 			// Reload user to pick up user changes that happened between auth and the change waiter
 			// initialization.  Without this, notification for user doc changes in that window (a) won't be
@@ -649,25 +666,26 @@ func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans base.Set, 
 
 		// Restrict to available channels, expand wild-card, and find since when these channels
 		// have been available to the user:
-		var channelsSince channels.TimedSet
+		channelsSince := channels.CollectionByTimedSet{}
 		if db.user != nil {
-			var channelsRemoved []string
-			channelsSince, channelsRemoved = db.user.FilterToAvailableChannels(chans)
+			chansSince, channelsRemoved := db.user.FilterToAvailableChannels(chans)
 			if len(channelsRemoved) > 0 {
 				base.InfofCtx(ctx, base.KeyChanges, "Channels %s request without access by user %s", base.UD(channelsRemoved), base.UD(db.user.Name()))
 			}
+			channelsSince[singleCollectionID] = chansSince
 		} else {
-			channelsSince = channels.AtSequence(chans, 0)
+			channelsSince = channels.AtSequenceByCollection(chans, 0)
 		}
 
 		// Mark channel set as active, schedule defer
-		db.activeChannels.IncrChannels(channelsSince)
-		defer db.activeChannels.DecrChannels(channelsSince)
+		activeChannels := channelsSince.GetChannels()
+		db.activeChannels.IncrChannels(activeChannels)
+		defer db.activeChannels.DecrChannels(activeChannels)
 
 		// For a continuous feed, initialise the lateSequenceFeeds that track late-arriving sequences
 		// to the channel caches.
 		if options.Continuous {
-			lateSequenceFeeds = make(map[string]*lateSequenceFeed)
+			lateSequenceFeeds = make(map[channels.ID]*lateSequenceFeed)
 			defer db.closeLateFeeds(lateSequenceFeeds)
 		}
 
@@ -682,9 +700,9 @@ func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans base.Set, 
 		for {
 			// Updates the ChangeWaiter to the current set of available channels
 			if changeWaiter != nil {
-				changeWaiter.UpdateChannels(channelsSince)
+				changeWaiter.UpdateChannels(activeChannels)
 			}
-			base.DebugfCtx(ctx, base.KeyChanges, "MultiChangesFeed: channels expand to %#v ... %s", base.UD(channelsSince.String()), base.UD(to))
+			base.DebugfCtx(ctx, base.KeyChanges, "MultiChangesFeed: channels expand to %#v ... %s", base.UD(activeChannels.ToSerializedStrings()), base.UD(to))
 
 			// lowSequence is used to send composite keys to clients, so that they can obtain any currently
 			// skipped sequences in a future iteration or request.
@@ -713,116 +731,121 @@ func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans base.Set, 
 			// with access to both channels would see two versions on the feed.
 
 			deferredBackfill = false
-			for name, vbSeqAddedAt := range channelsSince {
-				chanOpts := options
+			for collectionID, chanSeq := range channelsSince {
+				for chanName, vbSeqAddedAt := range chanSeq {
+					chanOpts := options
 
-				// Obtain a SingleChannelCache instance to use for both normal and late feeds.  Required to ensure consistency
-				// if cache is evicted during processing
-				singleChannelCache := db.changeCache.getChannelCache().getSingleChannelCache(name)
+					chanID := channels.ID{Name: chanName, CollectionID: collectionID}
+					// Obtain a SingleChannelCache instance to use for both normal and late feeds.  Required to ensure consistency
+					// if cache is evicted during processing
+					singleChannelCache := db.changeCache.getChannelCache().getSingleChannelCache(chanID)
 
-				// Set up late sequence handling first, as we need to roll back the regular feed on error
-				// Handles previously skipped sequences prior to options.Since that
-				// have arrived in the channel cache since this changes request started.  Only needed for
-				// continuous feeds - one-off changes requests only require the standard channel cache.
-				if options.Continuous {
-					lateSequenceFeedHandler := lateSequenceFeeds[name]
-					if lateSequenceFeedHandler != nil {
-						latefeed, err := db.getLateFeed(lateSequenceFeedHandler, singleChannelCache)
-						if err != nil {
-							base.WarnfCtx(ctx, "MultiChangesFeed got error reading late sequence feed %q, rolling back channel changes feed to last sent low sequence #%d.", base.UD(name), lastSentLowSeq)
-							chanOpts.Since.LowSeq = lastSentLowSeq
-							if lateFeed := db.newLateSequenceFeed(singleChannelCache); lateFeed != nil {
-								lateSequenceFeeds[name] = lateFeed
+					// Set up late sequence handling first, as we need to roll back the regular feed on error
+					// Handles previously skipped sequences prior to options.Since that
+					// have arrived in the channel cache since this changes request started.  Only needed for
+					// continuous feeds - one-off changes requests only require the standard channel cache.
+					if options.Continuous {
+						lateSequenceFeedHandler := lateSequenceFeeds[chanID]
+						if lateSequenceFeedHandler != nil {
+							latefeed, err := db.getLateFeed(lateSequenceFeedHandler, singleChannelCache)
+							if err != nil {
+								base.WarnfCtx(ctx, "MultiChangesFeed got error reading late sequence feed %q, rolling back channel changes feed to last sent low sequence #%d.", base.UD(chanID.String()), lastSentLowSeq)
+								chanOpts.Since.LowSeq = lastSentLowSeq
+								if lateFeed := db.newLateSequenceFeed(singleChannelCache); lateFeed != nil {
+									lateSequenceFeeds[chanID] = lateFeed
+								}
+							} else {
+								// Mark feed as actively used in this iteration.  Used to remove lateSequenceFeeds
+								// when the user loses channel access
+								lateSequenceFeedHandler.active = true
+								feeds = append(feeds, latefeed)
 							}
 						} else {
-							// Mark feed as actively used in this iteration.  Used to remove lateSequenceFeeds
-							// when the user loses channel access
-							lateSequenceFeedHandler.active = true
-							feeds = append(feeds, latefeed)
-						}
-					} else {
-						// Initialize lateSequenceFeeds[name] for next iteration
-						if lateFeed := db.newLateSequenceFeed(singleChannelCache); lateFeed != nil {
-							lateSequenceFeeds[name] = lateFeed
-						}
-					}
-				}
-
-				seqAddedAt := vbSeqAddedAt.Sequence
-
-				// Check whether requires backfill based on changedChannels in this _changes feed
-				isNewChannel := false
-				if changedChannels != nil {
-					isNewChannel, _ = changedChannels[name]
-				}
-
-				// Check whether requires backfill based on current sequence, seqAddedAt
-				// Triggered by handling:
-				//   1. options.Since.TriggeredBy == seqAddedAt : We're in the middle of backfill for this channel, based
-				//    on the access grant in sequence options.Since.TriggeredBy.  Normally the entire backfill would be done in one
-				//    changes feed iteration, but this can be split over multiple iterations when 'limit' is used.
-				//   2. options.Since.TriggeredBy == 0 : Not currently doing a backfill
-				//   3. options.Since.TriggeredBy != 0 and <= seqAddedAt: We're in the middle of a backfill for another channel, but the backfill for
-				//     this channel is still pending.  Initiate the backfill for this channel - will be ordered below in the usual way (iterating over all channels)
-				//   4. options.Since.TriggeredBy !=0 and options.Since.TriggeredBy > seqAddedAt: We're in the
-				//  middle of a backfill for another channel.  This should issue normal (non-backfill) changes
-				//  request with  since= options.Since.TriggeredBy for the non-backfill channel.
-
-				// Backfill required when seqAddedAt is before current sequence
-				backfillRequired := seqAddedAt > 1 && options.Since.Before(SequenceID{Seq: seqAddedAt}) && seqAddedAt <= currentCachedSequence
-				if seqAddedAt > currentCachedSequence {
-					base.DebugfCtx(ctx, base.KeyChanges, "Grant for channel [%s] is after the current sequence - skipped for this iteration.  Grant:[%d] Current:[%d] %s", base.UD(name), seqAddedAt, currentCachedSequence, base.UD(to))
-					deferredBackfill = true
-					continue
-				}
-
-				// Ensure backfill isn't already in progress for this seqAddedAt
-				backfillPending := options.Since.TriggeredBy == 0 || options.Since.TriggeredBy < seqAddedAt
-
-				backfillInOtherChannel := options.Since.TriggeredBy != 0 && options.Since.TriggeredBy > seqAddedAt
-
-				if isNewChannel || (backfillRequired && backfillPending) {
-					// Newly added channel so initiate backfill:
-					chanOpts.Since = SequenceID{Seq: 0, TriggeredBy: seqAddedAt}
-				} else if backfillInOtherChannel {
-					chanOpts.Since = SequenceID{Seq: options.Since.TriggeredBy - 1}
-				}
-
-				feed := db.changesFeed(ctx, singleChannelCache, chanOpts, to)
-				feeds = append(feeds, feed)
-
-			}
-			// If the user object has changed, create a special pseudo-feed for it:
-			if db.user != nil {
-				feeds = db.appendUserFeed(feeds, options)
-			}
-
-			if options.Revocations && db.user != nil && !options.ActiveOnly {
-				channelsToRevoke := db.user.RevokedChannels(options.Since.Seq, options.Since.LowSeq, options.Since.TriggeredBy)
-				for channel, revokedSeq := range channelsToRevoke {
-					revocationSinceSeq := options.Since.SafeSequence()
-					revokeFrom := uint64(0)
-
-					// If we have a triggeredBy sequence:
-					// If channel access was lost at the triggeredBy sequence then replication may have been interrupted
-					// so we need to roll back one sequence to re-send the values with that previous triggeredBy as we
-					// cannot be sure that they were all sent. However, we can get changes from triggeredBy rather than
-					// 0 when finding docs to revoke.
-					// If channel access was after the triggeredBy then we can just use the triggeredBy and need to
-					// check for docs to revoke since 0.
-					if options.Since.TriggeredBy != 0 {
-						if revokedSeq == options.Since.TriggeredBy {
-							revocationSinceSeq = options.Since.TriggeredBy - 1
-							revokeFrom = options.Since.Seq
-						}
-						if revokedSeq > options.Since.TriggeredBy {
-							revocationSinceSeq = options.Since.TriggeredBy
-							revokeFrom = 0
+							// Initialize lateSequenceFeeds[name] for next iteration
+							if lateFeed := db.newLateSequenceFeed(singleChannelCache); lateFeed != nil {
+								lateSequenceFeeds[chanID] = lateFeed
+							}
 						}
 					}
 
-					feed := db.buildRevokedFeed(ctx, channel, options, revokedSeq, revocationSinceSeq, revokeFrom, to)
+					seqAddedAt := vbSeqAddedAt.Sequence
+
+					// Check whether requires backfill based on changedChannels in this _changes feed
+					isNewChannel := false
+					if changedChannels != nil {
+						// FIXME: doesn't seem right
+						isNewChannel, _ = changedChannels[chanID]
+					}
+
+					// Check whether requires backfill based on current sequence, seqAddedAt
+					// Triggered by handling:
+					//   1. options.Since.TriggeredBy == seqAddedAt : We're in the middle of backfill for this channel, based
+					//    on the access grant in sequence options.Since.TriggeredBy.  Normally the entire backfill would be done in one
+					//    changes feed iteration, but this can be split over multiple iterations when 'limit' is used.
+					//   2. options.Since.TriggeredBy == 0 : Not currently doing a backfill
+					//   3. options.Since.TriggeredBy != 0 and <= seqAddedAt: We're in the middle of a backfill for another channel, but the backfill for
+					//     this channel is still pending.  Initiate the backfill for this channel - will be ordered below in the usual way (iterating over all channels)
+					//   4. options.Since.TriggeredBy !=0 and options.Since.TriggeredBy > seqAddedAt: We're in the
+					//  middle of a backfill for another channel.  This should issue normal (non-backfill) changes
+					//  request with  since= options.Since.TriggeredBy for the non-backfill channel.
+
+					// Backfill required when seqAddedAt is before current sequence
+					backfillRequired := seqAddedAt > 1 && options.Since.Before(SequenceID{Seq: seqAddedAt}) && seqAddedAt <= currentCachedSequence
+					if seqAddedAt > currentCachedSequence {
+						base.DebugfCtx(ctx, base.KeyChanges, "Grant for channel [%s] is after the current sequence - skipped for this iteration.  Grant:[%d] Current:[%d] %s", base.UD(chanID.String()), seqAddedAt, currentCachedSequence, base.UD(to))
+						deferredBackfill = true
+						continue
+					}
+
+					// Ensure backfill isn't already in progress for this seqAddedAt
+					backfillPending := options.Since.TriggeredBy == 0 || options.Since.TriggeredBy < seqAddedAt
+
+					backfillInOtherChannel := options.Since.TriggeredBy != 0 && options.Since.TriggeredBy > seqAddedAt
+
+					if isNewChannel || (backfillRequired && backfillPending) {
+						// Newly added channel so initiate backfill:
+						chanOpts.Since = SequenceID{Seq: 0, TriggeredBy: seqAddedAt}
+					} else if backfillInOtherChannel {
+						chanOpts.Since = SequenceID{Seq: options.Since.TriggeredBy - 1}
+					}
+
+					feed := db.changesFeed(ctx, singleChannelCache, chanOpts, to)
 					feeds = append(feeds, feed)
+
+				}
+				// If the user object has changed, create a special pseudo-feed for it:
+				if db.user != nil {
+					feeds = db.appendUserFeed(feeds, options)
+				}
+
+				if options.Revocations && db.user != nil && !options.ActiveOnly {
+					channelsToRevoke := db.user.RevokedChannels(options.Since.Seq, options.Since.LowSeq, options.Since.TriggeredBy)
+					for channel, revokedSeq := range channelsToRevoke {
+						revocationSinceSeq := options.Since.SafeSequence()
+						revokeFrom := uint64(0)
+
+						// If we have a triggeredBy sequence:
+						// If channel access was lost at the triggeredBy sequence then replication may have been interrupted
+						// so we need to roll back one sequence to re-send the values with that previous triggeredBy as we
+						// cannot be sure that they were all sent. However, we can get changes from triggeredBy rather than
+						// 0 when finding docs to revoke.
+						// If channel access was after the triggeredBy then we can just use the triggeredBy and need to
+						// check for docs to revoke since 0.
+						if options.Since.TriggeredBy != 0 {
+							if revokedSeq == options.Since.TriggeredBy {
+								revocationSinceSeq = options.Since.TriggeredBy - 1
+								revokeFrom = options.Since.Seq
+							}
+							if revokedSeq > options.Since.TriggeredBy {
+								revocationSinceSeq = options.Since.TriggeredBy
+								revokeFrom = 0
+							}
+						}
+
+						// FIXME: multiple collections
+						feed := db.buildRevokedFeed(ctx, channels.ID{Name: channel, CollectionID: collectionID}, options, revokedSeq, revocationSinceSeq, revokeFrom, to)
+						feeds = append(feeds, feed)
+					}
 				}
 			}
 
@@ -940,7 +963,6 @@ func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans base.Set, 
 					}
 				}
 			}
-
 			if !options.Continuous && (sentSomething || changeWaiter == nil) {
 				break
 			}
@@ -1013,11 +1035,19 @@ func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans base.Set, 
 			}
 			if userChanged && db.user != nil {
 				newChannelsSince, _ := db.user.FilterToAvailableChannels(chans)
-				changedChannels = newChannelsSince.CompareKeys(channelsSince)
+				// change when we support multiple collections
+				singleCollectionChannels := newChannelsSince.CompareKeys(channelsSince[singleCollectionID])
+
+				for channelName, changed := range singleCollectionChannels {
+					changedChannels[channels.ID{Name: channelName, CollectionID: singleCollectionID}] = changed
+				}
+
 				if len(changedChannels) > 0 {
 					db.activeChannels.UpdateChanged(changedChannels)
 				}
-				channelsSince = newChannelsSince
+				// TOR: think it is safe to delete this, at the end of the loop
+				channelsSince = channels.CollectionByTimedSet{}
+				channelsSince[singleCollectionID] = newChannelsSince
 			}
 
 			// Clean up inactive lateSequenceFeeds (because user has lost access to the channel)
@@ -1076,9 +1106,9 @@ func (db *Database) GetChanges(ctx context.Context, channels base.Set, options C
 }
 
 // Returns the set of cached log entries for a given channel
-func (db *Database) GetChangeLog(channelName string, afterSeq uint64) (entries []*LogEntry) {
+func (db *Database) GetChangeLog(channel channels.ID, afterSeq uint64) (entries []*LogEntry) {
 
-	return db.changeCache.getChannelCache().GetCachedChanges(channelName)
+	return db.changeCache.getChannelCache().GetCachedChanges(channel)
 }
 
 // WaitForSequenceNotSkipped blocks until the given sequence has been received or skipped by the change cache.
@@ -1103,10 +1133,10 @@ func (dbc *DatabaseContext) WaitForPendingChanges(ctx context.Context) (err erro
 // Late Sequence Feed
 // Manages the changes feed interaction with a channels cache's set of late-arriving entries
 type lateSequenceFeed struct {
-	active           bool      // Whether the changes feed is still serving the channel this feed is associated with
-	lastSequence     uint64    // Last late sequence processed on the feed
-	channelName      string    // Channel Name
-	lateSequenceUUID uuid.UUID // Ensures cache doesn't change underneath us
+	active           bool        // Whether the changes feed is still serving the channel this feed is associated with
+	lastSequence     uint64      // Last late sequence processed on the feed
+	channel          channels.ID // Channel
+	lateSequenceUUID uuid.UUID   // Ensures cache doesn't change underneath us
 }
 
 // Returns a lateSequenceFeed for the channel, used to find late-arriving (previously
@@ -1121,7 +1151,7 @@ func (db *Database) newLateSequenceFeed(singleChannelCache SingleChannelCache) *
 	lsf := &lateSequenceFeed{
 		active:           true,
 		lateSequenceUUID: singleChannelCache.LateSequenceUUID(),
-		channelName:      singleChannelCache.ChannelName(),
+		channel:          singleChannelCache.ChannelID(),
 		lastSequence:     singleChannelCache.RegisterLateSequenceClient(),
 	}
 	return lsf
@@ -1168,7 +1198,7 @@ func (db *Database) getLateFeed(feedHandler *lateSequenceFeed, singleChannelCach
 			seqID := SequenceID{
 				Seq: logEntry.Sequence,
 			}
-			change := makeChangeEntry(logEntry, seqID, singleChannelCache.ChannelName())
+			change := makeChangeEntry(logEntry, seqID, singleChannelCache.ChannelID())
 			feed <- &change
 		}
 	}()
@@ -1179,7 +1209,7 @@ func (db *Database) getLateFeed(feedHandler *lateSequenceFeed, singleChannelCach
 
 // Closes a single late sequence feed.
 func (db *Database) closeLateFeed(feedHandler *lateSequenceFeed) {
-	singleChannelCache := db.changeCache.getChannelCache().getSingleChannelCache(feedHandler.channelName)
+	singleChannelCache := db.changeCache.getChannelCache().getSingleChannelCache(feedHandler.channel)
 	if !singleChannelCache.SupportsLateFeed() {
 		return
 	}
@@ -1189,7 +1219,7 @@ func (db *Database) closeLateFeed(feedHandler *lateSequenceFeed) {
 }
 
 // Closes set of feeds.  Invoked on changes termination
-func (db *Database) closeLateFeeds(feeds map[string]*lateSequenceFeed) {
+func (db *Database) closeLateFeeds(feeds map[channels.ID]*lateSequenceFeed) {
 	for _, feed := range feeds {
 		db.closeLateFeed(feed)
 	}

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -155,7 +155,7 @@ func newChannelCacheWithOptions(queryHandler ChannelQueryHandler, channel channe
 	}
 
 	base.DebugfCtx(context.Background(), base.KeyCache, "Initialized cache for channel %q with min:%v max:%v age:%v, validFrom: %d",
-		base.UD(cache.ChannelID), cache.options.ChannelCacheMinLength, cache.options.ChannelCacheMaxLength, cache.options.ChannelCacheAge, validFrom)
+		base.UD(cache.channelID), cache.options.ChannelCacheMinLength, cache.options.ChannelCacheMaxLength, cache.options.ChannelCacheAge, validFrom)
 
 	return cache
 }

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -92,7 +92,7 @@ import (
 type SingleChannelCache interface {
 	GetChanges(options ChangesOptions) ([]*LogEntry, error)
 	GetCachedChanges(options ChangesOptions) (validFrom uint64, result []*LogEntry)
-	ChannelName() string
+	ChannelID() channels.ID
 	SupportsLateFeed() bool
 	LateSequenceUUID() uuid.UUID
 	GetLateSequencesSince(sinceSequence uint64) (entries []*LogEntry, lastSequence uint64, err error)
@@ -101,7 +101,7 @@ type SingleChannelCache interface {
 }
 
 type singleChannelCacheImpl struct {
-	channelName      string               // The channel name, duh
+	channel          channels.ID          // The channel
 	queryHandler     ChannelQueryHandler  // Database connection (used for view queries)
 	logs             LogEntries           // Log entries in sequence order
 	validFrom        uint64               // First sequence that logs is valid for, not necessarily the seq number of a change entry.
@@ -117,8 +117,8 @@ type singleChannelCacheImpl struct {
 	cacheStats       *base.CacheStats     // Map used for cache stats
 }
 
-func newSingleChannelCache(queryHandler ChannelQueryHandler, channelName string, validFrom uint64, cacheStats *base.CacheStats) *singleChannelCacheImpl {
-	cache := &singleChannelCacheImpl{queryHandler: queryHandler, channelName: channelName, validFrom: validFrom}
+func newSingleChannelCache(queryHandler ChannelQueryHandler, channel channels.ID, validFrom uint64, cacheStats *base.CacheStats) *singleChannelCacheImpl {
+	cache := &singleChannelCacheImpl{queryHandler: queryHandler, channel: channel, validFrom: validFrom}
 	cache.initializeLateLogs()
 	cache.cachedDocIDs = make(map[string]struct{})
 	cache.cacheStats = cacheStats
@@ -134,8 +134,8 @@ func newSingleChannelCache(queryHandler ChannelQueryHandler, channelName string,
 	return cache
 }
 
-func newChannelCacheWithOptions(queryHandler ChannelQueryHandler, channelName string, validFrom uint64, options ChannelCacheOptions, cacheStats *base.CacheStats) *singleChannelCacheImpl {
-	cache := newSingleChannelCache(queryHandler, channelName, validFrom, cacheStats)
+func newChannelCacheWithOptions(queryHandler ChannelQueryHandler, channel channels.ID, validFrom uint64, options ChannelCacheOptions, cacheStats *base.CacheStats) *singleChannelCacheImpl {
+	cache := newSingleChannelCache(queryHandler, channel, validFrom, cacheStats)
 
 	// Update cache options when present
 	if options.ChannelCacheMinLength > 0 {
@@ -155,7 +155,7 @@ func newChannelCacheWithOptions(queryHandler ChannelQueryHandler, channelName st
 	}
 
 	base.DebugfCtx(context.Background(), base.KeyCache, "Initialized cache for channel %q with min:%v max:%v age:%v, validFrom: %d",
-		base.UD(cache.channelName), cache.options.ChannelCacheMinLength, cache.options.ChannelCacheMaxLength, cache.options.ChannelCacheAge, validFrom)
+		base.UD(cache.channel), cache.options.ChannelCacheMinLength, cache.options.ChannelCacheMaxLength, cache.options.ChannelCacheAge, validFrom)
 
 	return cache
 }
@@ -170,8 +170,8 @@ type ChannelCacheOptions struct {
 	ChannelQueryLimit           int           // Query limit
 }
 
-func (c *singleChannelCacheImpl) ChannelName() string {
-	return c.channelName
+func (c *singleChannelCacheImpl) ChannelID() channels.ID {
+	return c.channel
 }
 
 func (c *singleChannelCacheImpl) LateSequenceUUID() uuid.UUID {
@@ -189,7 +189,7 @@ func (c *singleChannelCacheImpl) addToCache(change *LogEntry, isRemoval bool) {
 
 	if c.wouldBeImmediatelyPruned(change) {
 		base.InfofCtx(context.TODO(), base.KeyCache, "Not adding change #%d doc %q / %q ==> channel %q, since it will be immediately pruned",
-			change.Sequence, base.UD(change.DocID), change.RevID, base.UD(c.channelName))
+			change.Sequence, base.UD(change.DocID), change.RevID, base.UD(c.channel))
 		return
 	}
 
@@ -246,7 +246,7 @@ func (c *singleChannelCacheImpl) Remove(docIDs []string, startTime time.Time) (c
 			// This is to ensure that resurrected documents do not accidentally get removed.
 			if c.logs[i].TimeReceived.After(startTime) {
 				base.DebugfCtx(logCtx, base.KeyCache, "Skipping removal of doc %q from cache %q - received after purge",
-					base.UD(docID), base.UD(c.channelName))
+					base.UD(docID), base.UD(c.channel))
 				continue
 			}
 
@@ -260,7 +260,7 @@ func (c *singleChannelCacheImpl) Remove(docIDs []string, startTime time.Time) (c
 			delete(c.cachedDocIDs, docID)
 			count++
 
-			base.TracefCtx(logCtx, base.KeyCache, "Removed doc %q from cache %q", base.UD(docID), base.UD(c.channelName))
+			base.TracefCtx(logCtx, base.KeyCache, "Removed doc %q from cache %q", base.UD(docID), base.UD(c.channel))
 		}
 	}
 
@@ -281,7 +281,7 @@ func (c *singleChannelCacheImpl) _pruneCacheLength() (pruned int) {
 	}
 
 	if pruned > 0 {
-		base.DebugfCtx(context.TODO(), base.KeyCache, "Pruned %d entries from channel %q", pruned, base.UD(c.channelName))
+		base.DebugfCtx(context.TODO(), base.KeyCache, "Pruned %d entries from channel %q", pruned, base.UD(c.channel))
 	}
 
 	return pruned
@@ -306,7 +306,7 @@ func (c *singleChannelCacheImpl) pruneCacheAge(ctx context.Context) {
 		c.logs = c.logs[1:]
 		pruned++
 	}
-	base.DebugfCtx(ctx, base.KeyCache, "Pruned %d old entries from channel %q", pruned, base.UD(c.channelName))
+	base.DebugfCtx(ctx, base.KeyCache, "Pruned %d old entries from channel %q", pruned, base.UD(c.channel))
 
 }
 
@@ -372,10 +372,10 @@ func (c *singleChannelCacheImpl) GetChanges(options ChangesOptions) ([]*LogEntry
 	numFromCache := len(resultFromCache)
 	if numFromCache > 0 {
 		base.InfofCtx(options.LoggingCtx, base.KeyCache, "GetCachedChanges(%q, %s) --> %d changes valid from #%d",
-			base.UD(c.channelName), options.Since.String(), numFromCache, cacheValidFrom)
+			base.UD(c.channel), options.Since.String(), numFromCache, cacheValidFrom)
 	} else {
 		base.DebugfCtx(options.LoggingCtx, base.KeyCache, "GetCachedChanges(%q, %s) --> nothing cached",
-			base.UD(c.channelName), options.Since.String())
+			base.UD(c.channel), options.Since.String())
 	}
 	startSeq := options.Since.SafeSequence() + 1
 	if cacheValidFrom <= startSeq {
@@ -396,7 +396,7 @@ func (c *singleChannelCacheImpl) GetChanges(options ChangesOptions) ([]*LogEntry
 	cacheValidFrom, resultFromCache = c.GetCachedChanges(options)
 	if len(resultFromCache) > numFromCache {
 		base.InfofCtx(options.LoggingCtx, base.KeyCache, "2nd GetCachedChanges(%q, %s) got %d more, valid from #%d!",
-			base.UD(c.channelName), options.Since.String(), len(resultFromCache)-numFromCache, cacheValidFrom)
+			base.UD(c.channel), options.Since.String(), len(resultFromCache)-numFromCache, cacheValidFrom)
 	}
 	if cacheValidFrom <= startSeq {
 		c.cacheStats.ChannelCacheHits.Add(1)
@@ -413,7 +413,8 @@ func (c *singleChannelCacheImpl) GetChanges(options ChangesOptions) ([]*LogEntry
 	// overlap, which helps confirm that we've got everything.
 	c.cacheStats.ChannelCacheMisses.Add(1)
 	endSeq := cacheValidFrom
-	resultFromQuery, err := c.queryHandler.getChangesInChannelFromQuery(options.LoggingCtx, c.channelName, startSeq, endSeq, options.Limit, options.ActiveOnly)
+	// TOR: make sure queryhandler knows what collection it needs
+	resultFromQuery, err := c.queryHandler.getChangesInChannelFromQuery(options.LoggingCtx, c.channel.Name, startSeq, endSeq, options.Limit, options.ActiveOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -445,7 +446,7 @@ func (c *singleChannelCacheImpl) GetChanges(options ChangesOptions) ([]*LogEntry
 		}
 		result = append(result, resultFromCache[0:n]...)
 	}
-	base.InfofCtx(options.LoggingCtx, base.KeyCache, "GetChangesInChannel(%q) --> %d rows", base.UD(c.channelName), len(result))
+	base.InfofCtx(options.LoggingCtx, base.KeyCache, "GetChangesInChannel(%q) --> %d rows", base.UD(c.channel), len(result))
 
 	return result, nil
 }
@@ -582,7 +583,7 @@ func (c *singleChannelCacheImpl) prependChanges(changes LogEntries, changesValid
 	if len(changes) == 0 {
 		if changesValidFrom < c.validFrom && changesValidTo >= c.validFrom {
 			base.DebugfCtx(logCtx, base.KeyCache, " changesValidFrom (%d) < c.validFrom < changesValidTo (%d), setting c.validFrom from %v -> %v for %q",
-				changesValidFrom, changesValidTo, c.validFrom, changesValidFrom, base.UD(c.channelName))
+				changesValidFrom, changesValidTo, c.validFrom, changesValidFrom, base.UD(c.channel))
 			c.validFrom = changesValidFrom
 		}
 		return 0
@@ -602,7 +603,7 @@ func (c *singleChannelCacheImpl) prependChanges(changes LogEntries, changesValid
 		c.logs = make(LogEntries, len(changes))
 		copy(c.logs, changes)
 		base.InfofCtx(logCtx, base.KeyCache, "  Initialized cache of %q with %d entries from query (#%d--#%d)",
-			base.UD(c.channelName), len(changes), changes[0].Sequence, changes[len(changes)-1].Sequence)
+			base.UD(c.channel), len(changes), changes[0].Sequence, changes[len(changes)-1].Sequence)
 
 		for _, change := range changes {
 			c.cachedDocIDs[change.DocID] = struct{}{}
@@ -657,7 +658,7 @@ func (c *singleChannelCacheImpl) prependChanges(changes LogEntries, changesValid
 	if numToPrepend > 0 {
 		c.logs = append(entriesToPrepend, c.logs...)
 		base.InfofCtx(logCtx, base.KeyCache, "  Added %d entries from query (#%d--#%d) to cache of %q",
-			numToPrepend, entriesToPrepend[0].Sequence, entriesToPrepend[numToPrepend-1].Sequence, base.UD(c.channelName))
+			numToPrepend, entriesToPrepend[0].Sequence, entriesToPrepend[numToPrepend-1].Sequence, base.UD(c.channel))
 	}
 	base.DebugfCtx(logCtx, base.KeyCache, " Backfill cache from query c.validFrom from %v -> %v",
 		c.validFrom, changesValidFrom)
@@ -827,7 +828,7 @@ func (c *singleChannelCacheImpl) _mostRecentLateLog() *lateLogEntry {
 
 // A bypassChannelCache serves GetChanges requests directly via query
 type bypassChannelCache struct {
-	channelName  string
+	channel      channels.ID
 	queryHandler ChannelQueryHandler
 }
 
@@ -836,7 +837,7 @@ type bypassChannelCache struct {
 func (b *bypassChannelCache) GetChanges(options ChangesOptions) ([]*LogEntry, error) {
 	startSeq := options.Since.SafeSequence() + 1
 	endSeq := uint64(math.MaxUint64)
-	return b.queryHandler.getChangesInChannelFromQuery(options.LoggingCtx, b.channelName, startSeq, endSeq, options.Limit, options.ActiveOnly)
+	return b.queryHandler.getChangesInChannelFromQuery(options.LoggingCtx, b.channel.Name, startSeq, endSeq, options.Limit, options.ActiveOnly)
 }
 
 // No cached changes for bypassChannelCache
@@ -844,8 +845,8 @@ func (b *bypassChannelCache) GetCachedChanges(options ChangesOptions) (validFrom
 	return math.MaxUint64, nil
 }
 
-func (b *bypassChannelCache) ChannelName() string {
-	return b.channelName
+func (b *bypassChannelCache) ChannelID() channels.ID {
+	return b.channel
 }
 
 func (b *bypassChannelCache) SupportsLateFeed() bool {

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -42,7 +42,7 @@ func TestDuplicateDocID(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
-	cache := newSingleChannelCache(context, channels.ID{Name: "Test1", CollectionID: collectionID}, 0, dbstats.Cache())
+	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	// Add some entries to cache
@@ -100,7 +100,7 @@ func TestLateArrivingSequence(t *testing.T) {
 	collectionID, err := context.GetSingleCollectionID()
 	require.NoError(t, err)
 
-	cache := newSingleChannelCache(context, channels.ID{Name: "Test1", CollectionID: collectionID}, 0, dbstats.Cache())
+	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	// Add some entries to cache
@@ -144,7 +144,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	collectionID, err := context.GetSingleCollectionID()
 	require.NoError(t, err)
 
-	cache := newSingleChannelCache(context, channels.ID{Name: "Test1", CollectionID: collectionID}, 0, dbstats.Cache())
+	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	// Add some entries to cache
@@ -188,7 +188,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	collectionID, err := context.GetSingleCollectionID()
 	require.NoError(t, err)
 
-	cache := newSingleChannelCache(context, channels.ID{Name: "Test1", CollectionID: collectionID}, 0, dbstats.Cache())
+	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	// Add some entries to cache
@@ -274,7 +274,7 @@ func TestPrependChanges(t *testing.T) {
 	collectionID, err := dbCtx.GetSingleCollectionID()
 	require.NoError(t, err)
 
-	cache := newSingleChannelCache(dbCtx, channels.ID{Name: "PrependEmptyCache", CollectionID: collectionID}, 0, dbstats.Cache())
+	cache := newSingleChannelCache(dbCtx, channels.NewID("PrependEmptyCache", collectionID), 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	changesToPrepend := LogEntries{
@@ -296,7 +296,7 @@ func TestPrependChanges(t *testing.T) {
 	require.NoError(t, err)
 	dbstats, err = stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
-	cache = newSingleChannelCache(dbCtx, channels.ID{Name: "PrependPopulatedCache", CollectionID: collectionID}, 0, dbstats.Cache())
+	cache = newSingleChannelCache(dbCtx, channels.NewID("PrependPopulatedCache", collectionID), 0, dbstats.Cache())
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
 	cache.addToCache(testLogEntry(20, "doc2", "3-a"), false)
@@ -354,7 +354,7 @@ func TestPrependChanges(t *testing.T) {
 	require.NoError(t, err)
 	dbstats, err = stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
-	cache = newSingleChannelCache(dbCtx, channels.ID{Name: "PrependToFillCache", CollectionID: collectionID}, 0, dbstats.Cache())
+	cache = newSingleChannelCache(dbCtx, channels.NewID("PrependToFillCache", collectionID), 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
@@ -395,7 +395,7 @@ func TestPrependChanges(t *testing.T) {
 	require.NoError(t, err)
 	dbstats, err = stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
-	cache = newSingleChannelCache(dbCtx, channels.ID{Name: "PrependDuplicatesOnly", CollectionID: collectionID}, 0, dbstats.Cache())
+	cache = newSingleChannelCache(dbCtx, channels.NewID("PrependDuplicatesOnly", collectionID), 0, dbstats.Cache())
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
 	cache.addToCache(testLogEntry(20, "doc2", "3-a"), false)
@@ -429,7 +429,7 @@ func TestPrependChanges(t *testing.T) {
 	require.NoError(t, err)
 	dbstats, err = stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
-	cache = newSingleChannelCache(dbCtx, channels.ID{Name: "PrependFullCache", CollectionID: collectionID}, 0, dbstats.Cache())
+	cache = newSingleChannelCache(dbCtx, channels.NewID("PrependFullCache", collectionID), 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
@@ -485,7 +485,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	collectionID, err := context.GetSingleCollectionID()
 	require.NoError(t, err)
 
-	cache := newSingleChannelCache(context, channels.ID{Name: "Test1", CollectionID: collectionID}, 0, dbstats.Cache())
+	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, dbstats.Cache())
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
@@ -536,7 +536,7 @@ func TestChannelCacheStats(t *testing.T) {
 	require.NoError(t, err)
 
 	testStats := dbstats.Cache()
-	cache := newSingleChannelCache(context, channels.ID{Name: "Test1", CollectionID: collectionID}, 0, testStats)
+	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, testStats)
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
@@ -617,7 +617,7 @@ func TestChannelCacheStatsOnPrune(t *testing.T) {
 	require.NoError(t, err)
 
 	testStats := dbstats.Cache()
-	cache := newSingleChannelCache(context, channels.ID{Name: "Test1", CollectionID: collectionID}, 0, testStats)
+	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, testStats)
 	cache.options.ChannelCacheMaxLength = 5
 
 	// Add more than ChannelCacheMaxLength entries to cache
@@ -658,7 +658,7 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	require.NoError(t, err)
 
 	testStats := dbstats.Cache()
-	cache := newSingleChannelCache(context, channels.ID{Name: "Test1", CollectionID: collectionID}, 99, testStats)
+	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 99, testStats)
 	cache.options.ChannelCacheMaxLength = 15
 
 	// Add 9 entries to cache, 3 of each type
@@ -726,7 +726,7 @@ func TestBypassSingleChannelCache(t *testing.T) {
 	}
 
 	bypassCache := &bypassChannelCache{
-		channel:      channels.ID{Name: "chan_1"},
+		channel:      channels.NewID("chan_1", base.DefaultCollectionID),
 		queryHandler: queryHandler,
 	}
 
@@ -757,7 +757,7 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 	collectionID, err := context.GetSingleCollectionID()
 	require.NoError(b, err)
 
-	cache := newSingleChannelCache(context, channels.ID{Name: "Benchmark", CollectionID: collectionID}, 0, dbstats.Cache())
+	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
 	docIDs := make([]string, b.N)
 	for i := 0; i < b.N; i++ {
@@ -787,7 +787,7 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 	collectionID, err := context.GetSingleCollectionID()
 	require.NoError(b, err)
 
-	cache := newSingleChannelCache(context, channels.ID{Name: "Benchmark", CollectionID: collectionID}, 0, dbstats.Cache())
+	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(5.0, b.N)
@@ -814,7 +814,7 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 	collectionID, err := context.GetSingleCollectionID()
 	require.NoError(b, err)
 
-	cache := newSingleChannelCache(context, channels.ID{Name: "Benchmark", CollectionID: collectionID}, 0, dbstats.Cache())
+	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(20.0, b.N)
@@ -841,7 +841,7 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 	collectionID, err := context.GetSingleCollectionID()
 	require.NoError(b, err)
 
-	cache := newSingleChannelCache(context, channels.ID{Name: "Benchmark", CollectionID: collectionID}, 0, dbstats.Cache())
+	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(50.0, b.N)
@@ -868,7 +868,7 @@ func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 	collectionID, err := context.GetSingleCollectionID()
 	require.NoError(b, err)
 
-	cache := newSingleChannelCache(context, channels.ID{Name: "Benchmark", CollectionID: collectionID}, 0, dbstats.Cache())
+	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(80.0, b.N)
@@ -895,7 +895,7 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 	collectionID, err := context.GetSingleCollectionID()
 	require.NoError(b, err)
 
-	cache := newSingleChannelCache(context, channels.ID{Name: "Benchmark", CollectionID: collectionID}, 0, dbstats.Cache())
+	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(95.0, b.N)
@@ -922,7 +922,7 @@ func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 	collectionID, err := context.GetSingleCollectionID()
 	require.NoError(b, err)
 
-	cache := newSingleChannelCache(context, channels.ID{Name: "Benchmark", CollectionID: collectionID}, 0, dbstats.Cache())
+	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate docs
 	docs := make([]*LogEntry, b.N)
 	r := rand.New(rand.NewSource(99))

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,13 +33,16 @@ func TestDuplicateDocID(t *testing.T) {
 	require.NoError(t, err)
 	defer context.Close(ctx)
 
+	collectionID, err := context.GetSingleCollectionID()
+	require.NoError(t, err)
+
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
-	cache := newSingleChannelCache(context, "Test1", 0, dbstats.Cache())
+	cache := newSingleChannelCache(context, channels.ID{Name: "Test1", CollectionID: collectionID}, 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	// Add some entries to cache
@@ -93,7 +97,10 @@ func TestLateArrivingSequence(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
-	cache := newSingleChannelCache(context, "Test1", 0, dbstats.Cache())
+	collectionID, err := context.GetSingleCollectionID()
+	require.NoError(t, err)
+
+	cache := newSingleChannelCache(context, channels.ID{Name: "Test1", CollectionID: collectionID}, 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	// Add some entries to cache
@@ -134,7 +141,10 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
-	cache := newSingleChannelCache(context, "Test1", 0, dbstats.Cache())
+	collectionID, err := context.GetSingleCollectionID()
+	require.NoError(t, err)
+
+	cache := newSingleChannelCache(context, channels.ID{Name: "Test1", CollectionID: collectionID}, 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	// Add some entries to cache
@@ -175,7 +185,10 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
-	cache := newSingleChannelCache(context, "Test1", 0, dbstats.Cache())
+	collectionID, err := context.GetSingleCollectionID()
+	require.NoError(t, err)
+
+	cache := newSingleChannelCache(context, channels.ID{Name: "Test1", CollectionID: collectionID}, 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	// Add some entries to cache
@@ -258,7 +271,10 @@ func TestPrependChanges(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
-	cache := newSingleChannelCache(dbCtx, "PrependEmptyCache", 0, dbstats.Cache())
+	collectionID, err := dbCtx.GetSingleCollectionID()
+	require.NoError(t, err)
+
+	cache := newSingleChannelCache(dbCtx, channels.ID{Name: "PrependEmptyCache", CollectionID: collectionID}, 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	changesToPrepend := LogEntries{
@@ -280,7 +296,7 @@ func TestPrependChanges(t *testing.T) {
 	require.NoError(t, err)
 	dbstats, err = stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
-	cache = newSingleChannelCache(dbCtx, "PrependPopulatedCache", 0, dbstats.Cache())
+	cache = newSingleChannelCache(dbCtx, channels.ID{Name: "PrependPopulatedCache", CollectionID: collectionID}, 0, dbstats.Cache())
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
 	cache.addToCache(testLogEntry(20, "doc2", "3-a"), false)
@@ -338,7 +354,7 @@ func TestPrependChanges(t *testing.T) {
 	require.NoError(t, err)
 	dbstats, err = stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
-	cache = newSingleChannelCache(dbCtx, "PrependToFillCache", 0, dbstats.Cache())
+	cache = newSingleChannelCache(dbCtx, channels.ID{Name: "PrependToFillCache", CollectionID: collectionID}, 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
@@ -379,7 +395,7 @@ func TestPrependChanges(t *testing.T) {
 	require.NoError(t, err)
 	dbstats, err = stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
-	cache = newSingleChannelCache(dbCtx, "PrependDuplicatesOnly", 0, dbstats.Cache())
+	cache = newSingleChannelCache(dbCtx, channels.ID{Name: "PrependDuplicatesOnly", CollectionID: collectionID}, 0, dbstats.Cache())
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
 	cache.addToCache(testLogEntry(20, "doc2", "3-a"), false)
@@ -413,7 +429,7 @@ func TestPrependChanges(t *testing.T) {
 	require.NoError(t, err)
 	dbstats, err = stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
-	cache = newSingleChannelCache(dbCtx, "PrependFullCache", 0, dbstats.Cache())
+	cache = newSingleChannelCache(dbCtx, channels.ID{Name: "PrependFullCache", CollectionID: collectionID}, 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
@@ -466,7 +482,10 @@ func TestChannelCacheRemove(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
-	cache := newSingleChannelCache(context, "Test1", 0, dbstats.Cache())
+	collectionID, err := context.GetSingleCollectionID()
+	require.NoError(t, err)
+
+	cache := newSingleChannelCache(context, channels.ID{Name: "Test1", CollectionID: collectionID}, 0, dbstats.Cache())
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
@@ -513,8 +532,11 @@ func TestChannelCacheStats(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
+	collectionID, err := context.GetSingleCollectionID()
+	require.NoError(t, err)
+
 	testStats := dbstats.Cache()
-	cache := newSingleChannelCache(context, "Test1", 0, testStats)
+	cache := newSingleChannelCache(context, channels.ID{Name: "Test1", CollectionID: collectionID}, 0, testStats)
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
@@ -591,8 +613,11 @@ func TestChannelCacheStatsOnPrune(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
+	collectionID, err := context.GetSingleCollectionID()
+	require.NoError(t, err)
+
 	testStats := dbstats.Cache()
-	cache := newSingleChannelCache(context, "Test1", 0, testStats)
+	cache := newSingleChannelCache(context, channels.ID{Name: "Test1", CollectionID: collectionID}, 0, testStats)
 	cache.options.ChannelCacheMaxLength = 5
 
 	// Add more than ChannelCacheMaxLength entries to cache
@@ -629,8 +654,11 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
+	collectionID, err := context.GetSingleCollectionID()
+	require.NoError(t, err)
+
 	testStats := dbstats.Cache()
-	cache := newSingleChannelCache(context, "Test1", 99, testStats)
+	cache := newSingleChannelCache(context, channels.ID{Name: "Test1", CollectionID: collectionID}, 99, testStats)
 	cache.options.ChannelCacheMaxLength = 15
 
 	// Add 9 entries to cache, 3 of each type
@@ -698,7 +726,7 @@ func TestBypassSingleChannelCache(t *testing.T) {
 	}
 
 	bypassCache := &bypassChannelCache{
-		channelName:  "chan_1",
+		channel:      channels.ID{Name: "chan_1"},
 		queryHandler: queryHandler,
 	}
 
@@ -726,7 +754,10 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(b, err)
 
-	cache := newSingleChannelCache(context, "Benchmark", 0, dbstats.Cache())
+	collectionID, err := context.GetSingleCollectionID()
+	require.NoError(b, err)
+
+	cache := newSingleChannelCache(context, channels.ID{Name: "Benchmark", CollectionID: collectionID}, 0, dbstats.Cache())
 	// generate doc IDs
 	docIDs := make([]string, b.N)
 	for i := 0; i < b.N; i++ {
@@ -753,7 +784,10 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(b, err)
 
-	cache := newSingleChannelCache(context, "Benchmark", 0, dbstats.Cache())
+	collectionID, err := context.GetSingleCollectionID()
+	require.NoError(b, err)
+
+	cache := newSingleChannelCache(context, channels.ID{Name: "Benchmark", CollectionID: collectionID}, 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(5.0, b.N)
@@ -776,7 +810,11 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 	require.NoError(b, err)
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(b, err)
-	cache := newSingleChannelCache(context, "Benchmark", 0, dbstats.Cache())
+
+	collectionID, err := context.GetSingleCollectionID()
+	require.NoError(b, err)
+
+	cache := newSingleChannelCache(context, channels.ID{Name: "Benchmark", CollectionID: collectionID}, 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(20.0, b.N)
@@ -799,7 +837,11 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 	require.NoError(b, err)
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(b, err)
-	cache := newSingleChannelCache(context, "Benchmark", 0, dbstats.Cache())
+
+	collectionID, err := context.GetSingleCollectionID()
+	require.NoError(b, err)
+
+	cache := newSingleChannelCache(context, channels.ID{Name: "Benchmark", CollectionID: collectionID}, 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(50.0, b.N)
@@ -822,7 +864,11 @@ func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 	require.NoError(b, err)
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(b, err)
-	cache := newSingleChannelCache(context, "Benchmark", 0, dbstats.Cache())
+
+	collectionID, err := context.GetSingleCollectionID()
+	require.NoError(b, err)
+
+	cache := newSingleChannelCache(context, channels.ID{Name: "Benchmark", CollectionID: collectionID}, 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(80.0, b.N)
@@ -845,7 +891,11 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 	require.NoError(b, err)
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(b, err)
-	cache := newSingleChannelCache(context, "Benchmark", 0, dbstats.Cache())
+
+	collectionID, err := context.GetSingleCollectionID()
+	require.NoError(b, err)
+
+	cache := newSingleChannelCache(context, channels.ID{Name: "Benchmark", CollectionID: collectionID}, 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(95.0, b.N)
@@ -868,7 +918,11 @@ func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 	require.NoError(b, err)
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(b, err)
-	cache := newSingleChannelCache(context, "Benchmark", 0, dbstats.Cache())
+
+	collectionID, err := context.GetSingleCollectionID()
+	require.NoError(b, err)
+
+	cache := newSingleChannelCache(context, channels.ID{Name: "Benchmark", CollectionID: collectionID}, 0, dbstats.Cache())
 	// generate docs
 	docs := make([]*LogEntry, b.N)
 	r := rand.New(rand.NewSource(99))

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -35,21 +35,24 @@ func TestChannelCacheMaxSize(t *testing.T) {
 	defer dbCtx.Close(ctx)
 	cache := dbCtx.changeCache.getChannelCache()
 
+	collectionID, err := dbCtx.GetSingleCollectionID()
+	require.NoError(t, err)
+
 	// Make channels active
-	_, err = cache.GetChanges("TestA", getChangesOptionsWithCtxOnly())
+	_, err = cache.GetChanges(channels.ID{Name: "TestA", CollectionID: collectionID}, getChangesOptionsWithCtxOnly())
 	require.NoError(t, err)
-	_, err = cache.GetChanges("TestB", getChangesOptionsWithCtxOnly())
+	_, err = cache.GetChanges(channels.ID{Name: "TestB", CollectionID: collectionID}, getChangesOptionsWithCtxOnly())
 	require.NoError(t, err)
-	_, err = cache.GetChanges("TestC", getChangesOptionsWithCtxOnly())
+	_, err = cache.GetChanges(channels.ID{Name: "TestC", CollectionID: collectionID}, getChangesOptionsWithCtxOnly())
 	require.NoError(t, err)
-	_, err = cache.GetChanges("TestD", getChangesOptionsWithCtxOnly())
+	_, err = cache.GetChanges(channels.ID{Name: "TestD", CollectionID: collectionID}, getChangesOptionsWithCtxOnly())
 	require.NoError(t, err)
 
 	// Add some entries to caches, leaving some empty caches
-	cache.AddToCache(logEntry(1, "doc1", "1-a", []string{"TestB", "TestC", "TestD"}))
-	cache.AddToCache(logEntry(2, "doc2", "1-a", []string{"TestB", "TestC", "TestD"}))
-	cache.AddToCache(logEntry(3, "doc3", "1-a", []string{"TestB", "TestC", "TestD"}))
-	cache.AddToCache(logEntry(4, "doc4", "1-a", []string{"TestC"}))
+	cache.AddToCache(logEntry(1, "doc1", "1-a", []string{"TestB", "TestC", "TestD"}, collectionID))
+	cache.AddToCache(logEntry(2, "doc2", "1-a", []string{"TestB", "TestC", "TestD"}, collectionID))
+	cache.AddToCache(logEntry(3, "doc3", "1-a", []string{"TestB", "TestC", "TestD"}, collectionID))
+	cache.AddToCache(logEntry(4, "doc4", "1-a", []string{"TestC"}, collectionID))
 
 	dbCtx.UpdateCalculatedStats()
 
@@ -93,16 +96,18 @@ func TestChannelCacheSimpleCompact(t *testing.T) {
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 	defer cache.Stop()
 
+	require.NoError(t, err)
+
 	// Add 16 channels to the cache.  Shouldn't trigger compaction (hwm is not exceeded)
 	for i := 1; i <= 16; i++ {
 		channelName := fmt.Sprintf("chan_%d", i)
-		cache.addChannelCache(channelName)
+		cache.addChannelCache(channels.ID{Name: channelName})
 	}
 	// Validate cache size
 	assert.Equal(t, 16, cache.channelCaches.Length())
 
 	// Add another channel to cache
-	cache.addChannelCache("chan_17")
+	cache.addChannelCache(channels.ID{Name: "chan_17"})
 
 	assert.True(t, waitForCompaction(cache), "Compaction didn't complete in expected time")
 
@@ -135,11 +140,11 @@ func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 	// Add 16 channels to the cache.  Mark odd channels as active, even channels as inactive.
 	// Shouldn't trigger compaction (hwm is not exceeded)
 	for i := 1; i <= 18; i++ {
-		channelName := fmt.Sprintf("chan_%d", i)
-		cache.addChannelCache(channelName)
+		channel := channels.ID{Name: fmt.Sprintf("chan_%d", i)}
+		cache.addChannelCache(channel)
 		if i%2 == 1 {
-			log.Printf("Marking channel %s as active", channelName)
-			activeChannels.IncrChannel(channelName)
+			log.Printf("Marking channel %q as active", channel)
+			activeChannels.IncrChannel(channel)
 		}
 	}
 	// Validate cache size
@@ -147,7 +152,7 @@ func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 
 	log.Printf("adding 19th element to cache...")
 	// Add another channel to cache, should trigger compaction
-	cache.addChannelCache("chan_19")
+	cache.addChannelCache(channels.ID{Name: "chan_19"})
 
 	assert.True(t, waitForCompaction(cache), "Compaction didn't complete in expected time")
 
@@ -156,12 +161,12 @@ func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 
 	// Validate active channels have been retained in cache
 	for i := 1; i <= 19; i++ {
-		channelName := fmt.Sprintf("chan_%d", i)
-		_, isCached := cache.channelCaches.Get(channelName)
+		channel := channels.ID{Name: fmt.Sprintf("chan_%d", i)}
+		_, isCached := cache.channelCaches.Get(channel.String())
 		if i%2 == 1 {
-			assert.True(t, isCached, fmt.Sprintf("Channel %s was active, should be retained in cache", channelName))
+			assert.True(t, isCached, fmt.Sprintf("Channel %q was active, should be retained in cache", channel))
 		} else {
-			assert.False(t, isCached, fmt.Sprintf("Channel %s was inactive, should be evicted from cache", channelName))
+			assert.False(t, isCached, fmt.Sprintf("Channel %q was inactive, should be evicted from cache", channel))
 		}
 	}
 
@@ -194,18 +199,18 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 	// Add 18 channels to the cache.  Mark channels 1-10 as active
 	// Shouldn't trigger compaction (hwm is not exceeded)
 	for i := 1; i <= 18; i++ {
-		channelName := fmt.Sprintf("chan_%d", i)
-		cache.addChannelCache(channelName)
+		channel := channels.ID{Name: fmt.Sprintf("chan_%d", i)}
+		cache.addChannelCache(channel)
 		if i <= 10 {
-			log.Printf("Marking channel %s as active", channelName)
-			activeChannels.IncrChannel(channelName)
+			log.Printf("Marking channel %q as active", channel)
+			activeChannels.IncrChannel(channel)
 		}
 	}
 	// Validate cache size
 	assert.Equal(t, 18, cache.channelCaches.Length())
 
 	// Add another channel to cache, should trigger compaction
-	cache.addChannelCache("chan_19")
+	cache.addChannelCache(channels.ID{Name: "chan_19"})
 	assert.True(t, waitForCompaction(cache), "Compaction didn't complete in expected time")
 
 	// Expect channels 1-10, 11-15 to be evicted, and all to be marked as NRU during compaction
@@ -213,20 +218,20 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 
 	// Validate recently used channels have been retained in cache
 	for i := 1; i <= 19; i++ {
-		channelName := fmt.Sprintf("chan_%d", i)
-		_, isCached := cache.channelCaches.Get(channelName)
+		channel := channels.ID{Name: fmt.Sprintf("chan_%d", i)}
+		_, isCached := cache.channelCaches.Get(channel.String())
 		if i <= 10 || i > 15 {
-			assert.True(t, isCached, fmt.Sprintf("Expected %s to be cached", channelName))
+			assert.True(t, isCached, fmt.Sprintf("Expected %q to be cached", channel))
 		} else {
-			assert.False(t, isCached, fmt.Sprintf("Expected %s to not be cached", channelName))
+			assert.False(t, isCached, fmt.Sprintf("Expected %q to not be cached", channel))
 		}
 	}
 
 	// Mark channels 1-5 as recently used
 	for i := 1; i <= 5; i++ {
-		channelName := fmt.Sprintf("chan_%d", i)
-		cacheElement, isCached := cache.channelCaches.Get(channelName)
-		assert.True(t, isCached, fmt.Sprintf("Expected %s to be cached during recently used update", channelName))
+		channel := channels.ID{Name: fmt.Sprintf("chan_%d", i)}
+		cacheElement, isCached := cache.channelCaches.Get(channel.String())
+		assert.True(t, isCached, fmt.Sprintf("Expected %s to be cached during recently used update", channel))
 		AsSingleChannelCache(cacheElement).recentlyUsed.Set(true)
 	}
 
@@ -235,12 +240,12 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 	//    Channels 6-14: inactive, not recently used
 	//    Channels 15-19: inactive, recently used (first compact since creation)
 	for i := 1; i <= 19; i++ {
-		channelName := fmt.Sprintf("chan_%d", i)
+		channel := channels.ID{Name: fmt.Sprintf("chan_%d", i)}
 		if i <= 10 {
-			log.Printf("Marking channel %s as inactive", channelName)
-			activeChannels.DecrChannel(channelName)
+			log.Printf("Marking channel %q as inactive", channel)
+			activeChannels.DecrChannel(channel)
 		} else {
-			cache.addChannelCache(channelName)
+			cache.addChannelCache(channel)
 		}
 	}
 
@@ -254,12 +259,12 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 	assert.Equal(t, 14, cache.channelCaches.Length())
 	// Validate recently used channels have been retained in cache
 	for i := 1; i <= 19; i++ {
-		channelName := fmt.Sprintf("chan_%d", i)
-		_, isCached := cache.channelCaches.Get(channelName)
+		channel := channels.ID{Name: fmt.Sprintf("chan_%d", i)}
+		_, isCached := cache.channelCaches.Get(channel.String())
 		if i <= 5 || i >= 11 {
-			assert.True(t, isCached, fmt.Sprintf("Expected %s to be cached", channelName))
+			assert.True(t, isCached, fmt.Sprintf("Expected %s to be cached", channel))
 		} else {
-			assert.False(t, isCached, fmt.Sprintf("Expected %s to not be cached", channelName))
+			assert.False(t, isCached, fmt.Sprintf("Expected %s to not be cached", channel))
 		}
 	}
 }
@@ -268,7 +273,7 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 // or equal to the CompactHighWatermark
 func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 
-	base.SetUpTestLogging(t, base.LevelWarn, base.KeyCache)
+	base.SetUpTestLogging(t, base.LevelTrace, base.KeyCache)
 
 	// Define cache with max channels 20, watermarks 50/90
 	options := DefaultCacheOptions().ChannelCacheOptions
@@ -315,13 +320,13 @@ func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 			changesSuccessCount := 0
 			for i := 0; i < getChangesCount; i++ {
 				channelNumber := rand.Intn(channelCount) + 1
-				channelName := fmt.Sprintf("chan_%d", channelNumber)
+				channel := channels.ID{Name: fmt.Sprintf("chan_%d", channelNumber)}
 				options := getChangesOptionsWithCtxOnly()
-				changes, err := cache.GetChanges(channelName, options)
+				changes, err := cache.GetChanges(channel, options)
 				if len(changes) == 1 {
 					changesSuccessCount++
 				}
-				assert.NoError(t, err, fmt.Sprintf("Error getting changes for channel %s", channelName))
+				assert.NoError(t, err, fmt.Sprintf("Error getting changes for channel %s", channel))
 				assert.True(t, len(changes) == 1, "Expected one change per channel")
 			}
 			assert.Equal(t, changesSuccessCount, getChangesCount)
@@ -389,13 +394,13 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 			changesSuccessCount := 0
 			for i := 0; i < getChangesCount; i++ {
 				channelNumber := rand.Intn(channelCount) + 1
-				channelName := fmt.Sprintf("chan_%d", channelNumber)
+				channel := channels.ID{Name: fmt.Sprintf("chan_%d", channelNumber)}
 				options := getChangesOptionsWithCtxOnly()
-				changes, err := cache.GetChanges(channelName, options)
+				changes, err := cache.GetChanges(channel, options)
 				if len(changes) == 1 {
 					changesSuccessCount++
 				}
-				assert.NoError(t, err, fmt.Sprintf("Error getting changes for channel %s", channelName))
+				assert.NoError(t, err, fmt.Sprintf("Error getting changes for channel %q", channel))
 				assert.True(t, len(changes) == 1, "Expected one change per channel")
 			}
 			assert.Equal(t, changesSuccessCount, getChangesCount)
@@ -449,10 +454,10 @@ func TestChannelCacheBypass(t *testing.T) {
 
 	// Issue queries for all channels.  First 20 should end up in the cache, remaining 80 should trigger bypass
 	for c := 1; c <= channelCount; c++ {
-		channelName := fmt.Sprintf("chan_%d", c)
+		channel := channels.ID{Name: fmt.Sprintf("chan_%d", c)}
 		options := getChangesOptionsWithCtxOnly()
-		changes, err := cache.GetChanges(channelName, options)
-		assert.NoError(t, err, fmt.Sprintf("Error getting changes for channel %s", channelName))
+		changes, err := cache.GetChanges(channel, options)
+		assert.NoError(t, err, fmt.Sprintf("Error getting changes for channel %q", channel))
 		assert.True(t, len(changes) == 1, "Expected one change per channel")
 	}
 
@@ -471,9 +476,6 @@ func waitForCompaction(cache *channelCacheImpl) (compactionComplete bool) {
 		}
 	}
 	return false
-}
-
-type testActiveChannels struct {
 }
 
 type testQueryHandler struct {

--- a/db/database.go
+++ b/db/database.go
@@ -1901,3 +1901,15 @@ func (dbCtx *DatabaseContext) AddDatabaseLogContext(ctx context.Context) context
 	}
 	return ctx
 }
+
+// GetSingleCollectionID returns a collectionID. This is a shim for single collections.
+func (dbCtx *DatabaseContext) GetSingleCollectionID() (uint32, error) {
+	collection, err := base.AsCollection(dbCtx.Bucket)
+	if err != nil {
+		return 0, nil
+	}
+	if !collection.IsSupported(sgbucket.DataStoreFeatureCollections) {
+		return 0, nil
+	}
+	return collection.GetCollectionID()
+}

--- a/db/database.go
+++ b/db/database.go
@@ -1902,7 +1902,7 @@ func (dbCtx *DatabaseContext) AddDatabaseLogContext(ctx context.Context) context
 	return ctx
 }
 
-// GetSingleCollectionID returns a collectionID. This is a shim for single collections.
+// GetSingleCollectionID returns a collectionID. This is a temporary shim for single collections, and will be removed when a database can support multiple collecitons.
 func (dbCtx *DatabaseContext) GetSingleCollectionID() (uint32, error) {
 	collection, err := base.AsCollection(dbCtx.Bucket)
 	if err != nil {

--- a/db/database.go
+++ b/db/database.go
@@ -414,7 +414,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	dbContext.changeCache = &changeCache{}
 
 	// Callback that is invoked whenever a set of channels is changed in the ChangeCache
-	notifyChange := func(changedChannels base.Set) {
+	notifyChange := func(changedChannels channels.Set) {
 		dbContext.mutationListener.Notify(changedChannels)
 	}
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -806,7 +806,7 @@ func TestAllDocsOnly(t *testing.T) {
 	require.NoError(t, err)
 
 	// Trigger creation of the channel cache for channel "all"
-	db.changeCache.getChannelCache().getSingleChannelCache(channels.ID{Name: "all", CollectionID: collectionID})
+	db.changeCache.getChannelCache().getSingleChannelCache(channels.NewID("all", collectionID))
 
 	ids := make([]AllDocsEntry, 100)
 	for i := 0; i < 100; i++ {
@@ -850,7 +850,7 @@ func TestAllDocsOnly(t *testing.T) {
 	err = db.changeCache.waitForSequence(ctx, 101, base.DefaultWaitForSequence)
 	require.NoError(t, err)
 
-	changeLog := db.GetChangeLog(channels.ID{Name: "all", CollectionID: collectionID}, 0)
+	changeLog := db.GetChangeLog(channels.NewID("all", collectionID), 0)
 	require.Len(t, changeLog, 50)
 	assert.Equal(t, "alldoc-51", changeLog[0].DocID)
 
@@ -984,7 +984,7 @@ func TestConflicts(t *testing.T) {
 	collectionID, err := db.GetSingleCollectionID()
 	require.NoError(t, err)
 
-	allChannel := channels.ID{Name: "all", CollectionID: collectionID}
+	allChannel := channels.NewID("all", collectionID)
 	db.changeCache.getChannelCache().getSingleChannelCache(allChannel)
 
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
@@ -997,7 +997,7 @@ func TestConflicts(t *testing.T) {
 	// Wait for rev to be cached
 	cacheWaiter.AddAndWait(1)
 
-	changeLog := db.GetChangeLog(channels.ID{Name: "all", CollectionID: collectionID}, 0)
+	changeLog := db.GetChangeLog(channels.NewID("all", collectionID), 0)
 	assert.Equal(t, 1, len(changeLog))
 
 	// Create two conflicting changes:

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 	ch "github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	pkgerrors "github.com/pkg/errors"
@@ -307,7 +308,11 @@ func (h *handler) handleDumpChannel() error {
 	since := h.getIntQuery("since", 0)
 	base.InfofCtx(h.ctx(), base.KeyHTTP, "Dump channel %q", base.UD(channelName))
 
-	chanLog := h.db.GetChangeLog(channelName, since)
+	collectionID, err := h.db.GetSingleCollectionID()
+	if err != nil {
+		return err
+	}
+	chanLog := h.db.GetChangeLog(channels.ID{Name: channelName, CollectionID: collectionID}, since)
 	if chanLog == nil {
 		return base.HTTPErrorf(http.StatusNotFound, "no such channel")
 	}

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/channels"
 	ch "github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	pkgerrors "github.com/pkg/errors"
@@ -312,7 +311,7 @@ func (h *handler) handleDumpChannel() error {
 	if err != nil {
 		return err
 	}
-	chanLog := h.db.GetChangeLog(channels.ID{Name: channelName, CollectionID: collectionID}, since)
+	chanLog := h.db.GetChangeLog(ch.NewID(channelName, collectionID), since)
 	if chanLog == nil {
 		return base.HTTPErrorf(http.StatusNotFound, "no such channel")
 	}


### PR DESCRIPTION
- Added a `channels.ID` type to go with a `channels.Set` type. At this time, `base.Set` and `timed.Set` are still used for user/role channel markings. I think some of TimedSet will have to take a channel ID.
- Renamed `channels.SetOf` which required taking a testing object to match behavior of `base.SetOf`, but returns an error condition.
- Assume that there's one collectionID -> Database, this will have to be changed. Normally we can get the collections from the user, but really this is used for a few things - what happens when user or role documents change? In a user specification, we have a list of channels, but we don't know what collection they are in. I expect this code to be removed in a future review. This also requires a bunch of functions to return an error condition.

There's one step left to do which is modify how the `*` channel is expanded, and write a test for this because this isn't covered by existing unit tests
 
## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/995/
- [x] `GSI=true,xattrs=true` (for collections) https://jenkins.sgwdev.com/job/SyncGateway-Integration/994/ (known test flake, reran failing tests again https://jenkins.sgwdev.com/job/SyncGateway-Integration/999/  with pass
