### PR TITLE
CBG-2003: Flaky test: TestInitializeCacheUnderLoad

### DIFF
--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -150,7 +150,7 @@ func (sw *StatWaiter) Wait() {
 		}
 	}
 
-	sw.tb.Errorf("StatWaiter.Wait timed out waiting for stat to reach %d (actual: %d) %s", sw.targetCount, actualCount, base.GetCallersName(2, true))
+	sw.tb.Fatalf("StatWaiter.Wait timed out waiting for stat to reach %d (actual: %d) %s", sw.targetCount, actualCount, base.GetCallersName(2, true))
 }
 
 func AssertEqualBodies(t *testing.T, expected, actual Body) {

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -133,7 +133,7 @@ func (sw *StatWaiter) AddAndWait(count int) {
 	sw.Wait()
 }
 
-// Wait uses backoff retry for up to ~27s
+// Wait uses backoff retry for up to ~33s
 func (sw *StatWaiter) Wait() {
 	actualCount := sw.stat.Value()
 	if actualCount >= sw.targetCount {
@@ -141,7 +141,7 @@ func (sw *StatWaiter) Wait() {
 	}
 
 	waitTime := 1 * time.Millisecond
-	for i := 0; i < 13; i++ {
+	for i := 0; i < 14; i++ {
 		waitTime = waitTime * 2
 		time.Sleep(waitTime)
 		actualCount = sw.stat.Value()


### PR DESCRIPTION
CBG-2003

Describe your PR here...
- Could not reproduce failure seen in CBG-2003, pre-emptive changes made to avoid it happening again
- Stat waiter now immediately fails after timing out, and the maximum wait time is increased from ~16s to ~33s

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/967/
