### PR TITLE
CBG-2468 [3.0.4 backport] Support long-lived connections for Bootstra…   …pConnection

### DIFF
--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -335,7 +335,7 @@ func assertResp(t *testing.T, resp *http.Response, status int, body string) {
 // Development-time test, expects locally running Couchbase Server and designed for long-running memory profiling
 func DevTestFetchConfigManual(t *testing.T) {
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
+	base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)
 
 	serverErr := make(chan error, 0)
 
@@ -362,22 +362,19 @@ func DevTestFetchConfigManual(t *testing.T) {
 	// Start SG with no databases, high frequency polling
 	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(time.Second)
 
-	ctx := base.TestCtx(t)
-	sc, err := SetupServerContext(ctx, &config, true)
+	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
 
 	defer func() {
-		sc.Close(ctx)
+		sc.Close()
 		require.NoError(t, <-serverErr)
 	}()
 
 	go func() {
-		serverErr <- StartServer(ctx, &config, sc)
+		serverErr <- startServer(&config, sc)
 	}()
-	require.NoError(t, sc.WaitForRESTAPIs())
+	require.NoError(t, sc.waitForRESTAPIs())
 
 	// Sleep to wait for bucket polling iterations, or allow manual modification to server accessibility
-
-	time.Sleep(15 * time.Second)
-
+	time.Sleep(900 * time.Second)
 }

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
@@ -329,4 +330,54 @@ func assertResp(t *testing.T, resp *http.Response, status int, body string) {
 	assert.Equal(t, status, resp.StatusCode)
 	b, _ := ioutil.ReadAll(resp.Body)
 	assert.Equal(t, body, string(b))
+}
+
+// Development-time test, expects locally running Couchbase Server and designed for long-running memory profiling
+func DevTestFetchConfigManual(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
+
+	serverErr := make(chan error, 0)
+
+	config := DefaultStartupConfig("")
+
+	logLevel := base.LevelInfo
+	config.Logging.Console = &base.ConsoleLoggerConfig{
+		LogLevel: &logLevel,
+		LogKeys:  []string{"HTTP", "Config", "CRUD", "DCP", "Sync"},
+	}
+
+	config.API.AdminInterfaceAuthentication = base.BoolPtr(false)
+
+	config.API.PublicInterface = "127.0.0.1:4984"
+	config.API.AdminInterface = "127.0.0.1:4985"
+	config.API.MetricsInterface = "127.0.0.1:4986"
+
+	config.Bootstrap.Server = "couchbase://localhost"
+	config.Bootstrap.Username = "configUser"
+	config.Bootstrap.Password = "password"
+	config.Bootstrap.ServerTLSSkipVerify = base.BoolPtr(true)
+	config.Bootstrap.UseTLSServer = base.BoolPtr(false)
+
+	// Start SG with no databases, high frequency polling
+	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(time.Second)
+
+	ctx := base.TestCtx(t)
+	sc, err := SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+
+	defer func() {
+		sc.Close(ctx)
+		require.NoError(t, <-serverErr)
+	}()
+
+	go func() {
+		serverErr <- StartServer(ctx, &config, sc)
+	}()
+	require.NoError(t, sc.WaitForRESTAPIs())
+
+	// Sleep to wait for bucket polling iterations, or allow manual modification to server accessibility
+
+	time.Sleep(15 * time.Second)
+
 }

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -325,7 +325,7 @@ func TestLegacyGuestUserMigration(t *testing.T) {
 	sc, _, _, _, err := automaticConfigUpgrade(configPath)
 	require.NoError(t, err)
 
-	cluster, err := createCouchbaseClusterFromStartupConfig(sc)
+	cluster, err := createCouchbaseClusterFromStartupConfig(sc, base.PerUseClusterConnections)
 	require.NoError(t, err)
 
 	var dbConfig DbConfig

--- a/rest/main.go
+++ b/rest/main.go
@@ -198,7 +198,7 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 	}
 
 	// Attempt to establish connection to server
-	cluster, err := createCouchbaseClusterFromStartupConfig(startupConfig)
+	cluster, err := createCouchbaseClusterFromStartupConfig(startupConfig, base.PerUseClusterConnections)
 	if err != nil {
 		return nil, false, nil, nil, err
 	}
@@ -355,10 +355,11 @@ func backupCurrentConfigFile(sourcePath string) (string, error) {
 	return backupPath, nil
 }
 
-func createCouchbaseClusterFromStartupConfig(config *StartupConfig) (*base.CouchbaseCluster, error) {
+func createCouchbaseClusterFromStartupConfig(config *StartupConfig, bucketConnectionMode base.BucketConnectionMode) (*base.CouchbaseCluster, error) {
 	cluster, err := base.NewCouchbaseCluster(config.Bootstrap.Server, config.Bootstrap.Username,
 		config.Bootstrap.Password, config.Bootstrap.X509CertPath, config.Bootstrap.X509KeyPath,
-		config.Bootstrap.CACertPath, config.Bootstrap.ServerTLSSkipVerify, config.Unsupported.UseXattrConfig)
+		config.Bootstrap.CACertPath, config.Bootstrap.ServerTLSSkipVerify, config.Unsupported.UseXattrConfig, bucketConnectionMode)
+
 	if err != nil {
 		base.Infof(base.KeyConfig, "Couldn't create couchbase cluster instance: %v", err)
 		return nil, err

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -89,7 +89,7 @@ func TestAutomaticConfigUpgrade(t *testing.T) {
 
 	assert.Equal(t, config, string(writtenBackupFile))
 
-	cbs, err := createCouchbaseClusterFromStartupConfig(startupConfig)
+	cbs, err := createCouchbaseClusterFromStartupConfig(startupConfig, base.PerUseClusterConnections)
 	require.NoError(t, err)
 
 	var dbConfig DbConfig
@@ -217,7 +217,7 @@ func TestAutomaticConfigUpgradeExistingConfigAndNewGroup(t *testing.T) {
 	startupConfig, _, _, _, err := automaticConfigUpgrade(updatedConfigPath)
 	require.NoError(t, err)
 
-	cbs, err := createCouchbaseClusterFromStartupConfig(startupConfig)
+	cbs, err := createCouchbaseClusterFromStartupConfig(startupConfig, base.PerUseClusterConnections)
 	require.NoError(t, err)
 
 	var dbConfig DbConfig

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1488,7 +1488,7 @@ func (sc *ServerContext) initializeCouchbaseServerConnections() error {
 
 	// Fetch database configs from bucket and start polling for new buckets and config updates.
 	if sc.persistentConfig {
-		couchbaseCluster, err := createCouchbaseClusterFromStartupConfig(sc.config)
+		couchbaseCluster, err := createCouchbaseClusterFromStartupConfig(sc.config, base.CachedClusterConnections)
 		if err != nil {
 			return err
 		}
@@ -1513,6 +1513,7 @@ func (sc *ServerContext) initializeCouchbaseServerConnections() error {
 			base.Infof(base.KeyConfig, "Starting background polling for new configs/buckets: %s", sc.config.Bootstrap.ConfigUpdateFrequency.Value().String())
 			go func() {
 				defer close(sc.bootstrapContext.doneChan)
+				defer sc.bootstrapContext.connection.Close()
 				t := time.NewTicker(sc.config.Bootstrap.ConfigUpdateFrequency.Value())
 				for {
 					select {


### PR DESCRIPTION
CBG-2468

Optional caching for BootstrapConnection cluster and bucket connections. Avoids memory allocation and associated GC work for config monitoring.

Cached entries are removed on error, triggering reconnection on next request.

Clients using BootstrapConnection in cached connection mode are required to call Close to release connections.

Additional note on 3.0.4 backport: running DevTestFetchConfigManual showed significantly higher allocs pre-fix than on the 3.1.x branch.

Allocated space for 5 minute test:
3.0.4 pre-fix: 37GB
3.1.0 pre-fix:  1.5GB

3.0.4 with fix: ~0.5 GB
3.1.0 with fix: ~0.3 GB

- [x] https://jenkins.sgwdev.com/job/SyncGateway-Integration-go1.16/5/