### PR TITLE
CBG-2277 Use current revision when performing 3.0 revocation access check

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -257,7 +257,7 @@ func (db *Database) buildRevokedFeed(ctx context.Context, channelName string, op
 					}
 				}
 
-				userHasAccessToDoc, err := UserHasDocAccess(ctx, db, logEntry.DocID, logEntry.RevID)
+				userHasAccessToDoc, err := UserHasDocAccess(ctx, db, logEntry.DocID)
 				if err != nil {
 					change := ChangeEntry{
 						Err: base.ErrChannelFeed,
@@ -302,8 +302,9 @@ func (db *Database) buildRevokedFeed(ctx context.Context, channelName string, op
 	return feed
 }
 
-func UserHasDocAccess(ctx context.Context, db *Database, docID, revID string) (bool, error) {
-	rev, err := db.revisionCache.Get(ctx, docID, revID, false, false)
+// UserHasDocAccess checks whether the user has access to the active revision of the document
+func UserHasDocAccess(ctx context.Context, db *Database, docID string) (bool, error) {
+	currentRev, err := db.revisionCache.GetActive(ctx, docID, false)
 	if err != nil {
 		if base.IsDocNotFoundError(err) {
 			return false, nil
@@ -311,12 +312,12 @@ func UserHasDocAccess(ctx context.Context, db *Database, docID, revID string) (b
 		return false, err
 	}
 
-	isAuthorized, _ := db.authorizeUserForChannels(rev.DocID, rev.RevID, rev.Channels, rev.Deleted, nil)
-	if isAuthorized {
+	if db.user == nil {
 		return true, nil
 	}
 
-	return false, nil
+	authErr := db.user.AuthorizeAnyChannel(currentRev.Channels)
+	return authErr == nil, nil
 }
 
 // Checks if a document needs to be revoked. This is used in the case where the since < doc sequence

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -7728,19 +7728,18 @@ func TestUserHasDocAccessDocNotFound(t *testing.T) {
 
 	resp := rt.SendAdminRequest("PUT", "/db/doc", `{"channels": ["A"]}`)
 	RequireStatus(t, resp, http.StatusCreated)
-	revID := RespRevID(t, resp)
 
 	database, err := db.CreateDatabase(rt.GetDatabase())
 	assert.NoError(t, err)
 
-	userHasDocAccess, err := db.UserHasDocAccess(ctx, database, "doc", revID)
+	userHasDocAccess, err := db.UserHasDocAccess(ctx, database, "doc")
 	assert.NoError(t, err)
 	assert.True(t, userHasDocAccess)
 
 	err = rt.GetDatabase().Bucket.Delete("doc")
 	assert.NoError(t, err)
 
-	userHasDocAccess, err = db.UserHasDocAccess(ctx, database, "doc", revID)
+	userHasDocAccess, err = db.UserHasDocAccess(ctx, database, "doc")
 	assert.NoError(t, err)
 	assert.False(t, userHasDocAccess)
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -7736,8 +7736,8 @@ func TestUserHasDocAccessDocNotFound(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, userHasDocAccess)
 
-	err = rt.GetDatabase().Bucket.Delete("doc")
-	assert.NoError(t, err)
+	// Purge the document from the bucket to force 'not found'
+	err = database.Purge(ctx, "doc")
 
 	userHasDocAccess, err = db.UserHasDocAccess(ctx, database, "doc")
 	assert.NoError(t, err)

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -3700,15 +3700,113 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	var messageBody []interface{}
 	err = highestSeqMsg.ReadJSONBody(&messageBody)
 	assert.NoError(t, err)
-	require.Len(t, messageBody, 2)
-	require.Len(t, messageBody[0], 4)
-	require.Len(t, messageBody[1], 3)
+	require.Len(t, messageBody, 3)
+	require.Len(t, messageBody[0], 4) // Rev 2 of doc, being sent as removal from channel A
+	require.Len(t, messageBody[1], 4) // Rev 3 of doc, being sent as removal from channel B
+	require.Len(t, messageBody[2], 3)
 
 	deletedFlags, err := messageBody[0].([]interface{})[3].(json.Number).Int64()
 	docID := messageBody[0].([]interface{})[1]
 	require.NoError(t, err)
 	assert.Equal(t, "doc", docID)
 	assert.Equal(t, int64(4), deletedFlags)
+}
+
+// TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication tests the following scenario:
+//   User has access to channel A and B
+//     Document rev 1 is in A and B
+//     Document rev 2 is in channel C
+//     Document rev 3 is in channel B
+//   User issues changes requests with since=0 for channel A
+//     Revocation should not be issued because the user currently has access to channel B, even though they didn't
+//     have access to the removal revision (rev 2).  CBG-2277
+
+func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	resp := rt.SendAdminRequest("PUT", "/db/_user/user", `{"admin_channels": ["A", "B"], "password": "test"}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+		Username:        "user",
+		Channels:        []string{"*"},
+		ClientDeltas:    false,
+		SendRevocations: true,
+	})
+	assert.NoError(t, err)
+	defer btc.Close()
+
+	docRevID := rt.CreateDocReturnRev(t, "doc", "", map[string]interface{}{"channels": []string{"A", "B"}})
+
+	changes, err := rt.WaitForChanges(1, "/db/_changes?since=0&revocations=true", "user", true)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(changes.Results))
+	assert.Equal(t, "doc", changes.Results[0].ID)
+	assert.Equal(t, "1-9b49fa26d87ad363b2b08de73ff029a9", changes.Results[0].Changes[0]["rev"])
+
+	err = btc.StartOneshotPull()
+	assert.NoError(t, err)
+
+	_, ok := btc.WaitForRev("doc", "1-9b49fa26d87ad363b2b08de73ff029a9")
+	assert.True(t, ok)
+
+	docRevID = rt.CreateDocReturnRev(t, "doc", docRevID, map[string]interface{}{"channels": []string{"C"}})
+
+	// At this point changes should send revocation, as document isn't in any of the user's channels
+	changes, err = rt.WaitForChanges(1, "/db/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(changes.Results))
+	assert.Equal(t, "doc", changes.Results[0].ID)
+	assert.Equal(t, docRevID, changes.Results[0].Changes[0]["rev"])
+
+	err = btc.StartOneshotPullFiltered("A")
+	assert.NoError(t, err)
+
+	_, ok = btc.WaitForRev("doc", docRevID)
+	assert.True(t, ok)
+
+	_ = rt.CreateDocReturnRev(t, "doc", docRevID, map[string]interface{}{"channels": []string{"B"}})
+	markerDocRevID := rt.CreateDocReturnRev(t, "docmarker", "", map[string]interface{}{"channels": []string{"A"}})
+
+	// Revocation should not be sent over blip, as document is now in user's channels - only marker document should be received
+	changes, err = rt.WaitForChanges(1, "/db/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
+	require.NoError(t, err)
+	assert.Len(t, changes.Results, 2) // _changes still gets two results, as we don't support 3.0 removal handling over REST API
+	assert.Equal(t, "doc", changes.Results[0].ID)
+	assert.Equal(t, "docmarker", changes.Results[1].ID)
+
+	err = btc.StartOneshotPullFiltered("A")
+	assert.NoError(t, err)
+
+	_, ok = btc.WaitForRev("docmarker", markerDocRevID)
+	assert.True(t, ok)
+
+	messages := btc.pullReplication.GetMessages()
+
+	var highestMsgSeq uint32
+	var highestSeqMsg blip.Message
+	// Grab most recent changes message
+	for _, message := range messages {
+		messageBody, err := message.Body()
+		require.NoError(t, err)
+		if message.Properties["Profile"] == db.MessageChanges && string(messageBody) != "null" {
+			if highestMsgSeq < uint32(message.SerialNumber()) {
+				highestMsgSeq = uint32(message.SerialNumber())
+				highestSeqMsg = message
+			}
+		}
+	}
+
+	var messageBody []interface{}
+	err = highestSeqMsg.ReadJSONBody(&messageBody)
+	assert.NoError(t, err)
+	require.Len(t, messageBody, 1)
+	require.Len(t, messageBody[0], 3) // marker doc
+	require.Equal(t, "docmarker", messageBody[0].([]interface{})[1])
 }
 
 func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {


### PR DESCRIPTION
CBG-2277

Modifies the handling in blip_handler.go to check per changes entry, instead of per rev per changes entry (since result will now be the same in both cases).

Switches UserHasDocAccess to call user.AuthorizeAnyChannel directly, since it's not using the change entry that authorizeUserForChannels builds.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` (for collections) https://jenkins.sgwdev.com/job/SyncGateway-Integration/970/
