### PR TITLE
Rename testing SetOf because it doesn't match behavior of base.SetOf

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -123,7 +123,7 @@ func TestSerializeUser(t *testing.T) {
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
-	user, _ := auth.NewUser("me", "letmein", ch.SetOf(t, "me", "public"))
+	user, _ := auth.NewUser("me", "letmein", ch.BaseSetOf(t, "me", "public"))
 	require.NoError(t, user.SetEmail("foo@example.com"))
 	encoded, _ := base.JSONMarshal(user)
 	assert.True(t, encoded != nil)
@@ -144,7 +144,7 @@ func TestSerializeRole(t *testing.T) {
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
-	role, _ := auth.NewRole("froods", ch.SetOf(t, "hoopy", "public"))
+	role, _ := auth.NewRole("froods", ch.BaseSetOf(t, "hoopy", "public"))
 	encoded, _ := base.JSONMarshal(role)
 	assert.True(t, encoded != nil)
 	log.Printf("Marshaled Role as: %s", encoded)
@@ -163,69 +163,69 @@ func TestUserAccess(t *testing.T) {
 	defer bucket.Close()
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 	user, _ := auth.NewUser("foo", "password", nil)
-	assert.Equal(t, ch.SetOf(t, "!"), user.ExpandWildCardChannel(ch.SetOf(t, "*")))
+	assert.Equal(t, ch.BaseSetOf(t, "!"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
 	assert.False(t, user.CanSeeChannel("x"))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf(t)))
-	assert.False(t, canSeeAllChannels(user, ch.SetOf(t, "x")))
-	assert.False(t, canSeeAllChannels(user, ch.SetOf(t, "x", "y")))
-	assert.False(t, canSeeAllChannels(user, ch.SetOf(t, "*")))
-	assert.False(t, user.AuthorizeAllChannels(ch.SetOf(t, "*")) == nil)
-	assert.False(t, user.AuthorizeAnyChannel(ch.SetOf(t, "x", "y")) == nil)
-	assert.False(t, user.AuthorizeAnyChannel(ch.SetOf(t)) == nil)
+	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t)))
+	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x")))
+	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x", "y")))
+	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "*")))
+	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
+	assert.False(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t)) == nil)
 
 	// User with access to one channel:
-	user.setChannels(ch.AtSequence(ch.SetOf(t, "x"), 1))
-	assert.Equal(t, ch.SetOf(t, "x"), user.ExpandWildCardChannel(ch.SetOf(t, "*")))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf(t)))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf(t, "x")))
-	assert.False(t, canSeeAllChannels(user, ch.SetOf(t, "x", "y")))
-	assert.False(t, user.AuthorizeAllChannels(ch.SetOf(t, "x", "y")) == nil)
-	assert.False(t, user.AuthorizeAllChannels(ch.SetOf(t, "*")) == nil)
-	assert.True(t, user.AuthorizeAnyChannel(ch.SetOf(t, "x", "y")) == nil)
-	assert.False(t, user.AuthorizeAnyChannel(ch.SetOf(t, "y")) == nil)
-	assert.False(t, user.AuthorizeAnyChannel(ch.SetOf(t)) == nil)
+	user.setChannels(ch.AtSequence(ch.BaseSetOf(t, "x"), 1))
+	assert.Equal(t, ch.BaseSetOf(t, "x"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
+	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t)))
+	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x")))
+	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x", "y")))
+	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
+	assert.True(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t, "y")) == nil)
+	assert.False(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t)) == nil)
 
 	// User with access to one channel and one derived channel:
-	user.setChannels(ch.AtSequence(ch.SetOf(t, "x", "z"), 1))
-	assert.Equal(t, ch.SetOf(t, "x", "z"), user.ExpandWildCardChannel(ch.SetOf(t, "*")))
-	assert.Equal(t, ch.SetOf(t, "x"), user.ExpandWildCardChannel(ch.SetOf(t, "x")))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf(t)))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf(t, "x")))
-	assert.False(t, canSeeAllChannels(user, ch.SetOf(t, "x", "y")))
-	assert.False(t, user.AuthorizeAllChannels(ch.SetOf(t, "x", "y")) == nil)
-	assert.False(t, user.AuthorizeAllChannels(ch.SetOf(t, "*")) == nil)
+	user.setChannels(ch.AtSequence(ch.BaseSetOf(t, "x", "z"), 1))
+	assert.Equal(t, ch.BaseSetOf(t, "x", "z"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
+	assert.Equal(t, ch.BaseSetOf(t, "x"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "x")))
+	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t)))
+	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x")))
+	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x", "y")))
+	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
 
 	// User with access to two channels:
-	user.setChannels(ch.AtSequence(ch.SetOf(t, "x", "z"), 1))
-	assert.Equal(t, ch.SetOf(t, "x", "z"), user.ExpandWildCardChannel(ch.SetOf(t, "*")))
-	assert.Equal(t, ch.SetOf(t, "x"), user.ExpandWildCardChannel(ch.SetOf(t, "x")))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf(t)))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf(t, "x")))
-	assert.False(t, canSeeAllChannels(user, ch.SetOf(t, "x", "y")))
-	assert.False(t, user.AuthorizeAllChannels(ch.SetOf(t, "x", "y")) == nil)
-	assert.False(t, user.AuthorizeAllChannels(ch.SetOf(t, "*")) == nil)
+	user.setChannels(ch.AtSequence(ch.BaseSetOf(t, "x", "z"), 1))
+	assert.Equal(t, ch.BaseSetOf(t, "x", "z"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
+	assert.Equal(t, ch.BaseSetOf(t, "x"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "x")))
+	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t)))
+	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x")))
+	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x", "y")))
+	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
 
-	user.setChannels(ch.AtSequence(ch.SetOf(t, "x", "y"), 1))
-	assert.Equal(t, ch.SetOf(t, "x", "y"), user.ExpandWildCardChannel(ch.SetOf(t, "*")))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf(t)))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf(t, "x")))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf(t, "x", "y")))
-	assert.False(t, canSeeAllChannels(user, ch.SetOf(t, "x", "y", "z")))
-	assert.True(t, user.AuthorizeAllChannels(ch.SetOf(t, "x", "y")) == nil)
-	assert.False(t, user.AuthorizeAllChannels(ch.SetOf(t, "*")) == nil)
+	user.setChannels(ch.AtSequence(ch.BaseSetOf(t, "x", "y"), 1))
+	assert.Equal(t, ch.BaseSetOf(t, "x", "y"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
+	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t)))
+	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x")))
+	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x", "y")))
+	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x", "y", "z")))
+	assert.True(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
 
 	// User with wildcard access:
-	user.setChannels(ch.AtSequence(ch.SetOf(t, "*", "q"), 1))
-	assert.Equal(t, ch.SetOf(t, "*", "q"), user.ExpandWildCardChannel(ch.SetOf(t, "*")))
+	user.setChannels(ch.AtSequence(ch.BaseSetOf(t, "*", "q"), 1))
+	assert.Equal(t, ch.BaseSetOf(t, "*", "q"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
 	assert.True(t, user.CanSeeChannel("*"))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf(t)))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf(t, "x")))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf(t, "x", "y")))
-	assert.True(t, user.AuthorizeAllChannels(ch.SetOf(t, "x", "y")) == nil)
-	assert.True(t, user.AuthorizeAllChannels(ch.SetOf(t, "*")) == nil)
-	assert.True(t, user.AuthorizeAnyChannel(ch.SetOf(t, "x")) == nil)
-	assert.True(t, user.AuthorizeAnyChannel(ch.SetOf(t, "*")) == nil)
-	assert.True(t, user.AuthorizeAnyChannel(ch.SetOf(t)) == nil)
+	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t)))
+	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x")))
+	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x", "y")))
+	assert.True(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.True(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
+	assert.True(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t, "x")) == nil)
+	assert.True(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t, "*")) == nil)
+	assert.True(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t)) == nil)
 }
 
 func TestGetMissingUser(t *testing.T) {
@@ -266,7 +266,7 @@ func TestSaveUsers(t *testing.T) {
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
-	user, _ := auth.NewUser("testUser", "password", ch.SetOf(t, "test"))
+	user, _ := auth.NewUser("testUser", "password", ch.BaseSetOf(t, "test"))
 	err := auth.Save(user)
 	assert.Equal(t, nil, err)
 
@@ -280,7 +280,7 @@ func TestSaveRoles(t *testing.T) {
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
-	role, _ := auth.NewRole("testRole", ch.SetOf(t, "test"))
+	role, _ := auth.NewRole("testRole", ch.BaseSetOf(t, "test"))
 	err := auth.Save(role)
 	assert.Equal(t, nil, err)
 
@@ -318,9 +318,9 @@ func (self *mockComputer) UseGlobalSequence() bool {
 func TestRebuildUserChannels(t *testing.T) {
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
-	computer := mockComputer{channels: ch.AtSequence(ch.SetOf(t, "derived1", "derived2"), 1)}
+	computer := mockComputer{channels: ch.AtSequence(ch.BaseSetOf(t, "derived1", "derived2"), 1)}
 	auth := NewAuthenticator(bucket, &computer, DefaultAuthenticatorOptions())
-	user, _ := auth.NewUser("testUser", "password", ch.SetOf(t, "explicit1"))
+	user, _ := auth.NewUser("testUser", "password", ch.BaseSetOf(t, "explicit1"))
 	err := auth.Save(user)
 	assert.NoError(t, err)
 
@@ -329,16 +329,16 @@ func TestRebuildUserChannels(t *testing.T) {
 
 	user2, err := auth.GetUser("testUser")
 	assert.NoError(t, err)
-	assert.Equal(t, ch.AtSequence(ch.SetOf(t, "explicit1", "derived1", "derived2", "!"), 1), user2.Channels())
+	assert.Equal(t, ch.AtSequence(ch.BaseSetOf(t, "explicit1", "derived1", "derived2", "!"), 1), user2.Channels())
 }
 
 func TestRebuildRoleChannels(t *testing.T) {
 
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
-	computer := mockComputer{roleChannels: ch.AtSequence(ch.SetOf(t, "derived1", "derived2"), 1)}
+	computer := mockComputer{roleChannels: ch.AtSequence(ch.BaseSetOf(t, "derived1", "derived2"), 1)}
 	auth := NewAuthenticator(bucket, &computer, DefaultAuthenticatorOptions())
-	role, err := auth.NewRole("testRole", ch.SetOf(t, "explicit1"))
+	role, err := auth.NewRole("testRole", ch.BaseSetOf(t, "explicit1"))
 	assert.NoError(t, err)
 	err = auth.Save(role)
 	assert.NoError(t, err)
@@ -348,7 +348,7 @@ func TestRebuildRoleChannels(t *testing.T) {
 
 	role2, err := auth.GetRole("testRole")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, ch.AtSequence(ch.SetOf(t, "explicit1", "derived1", "derived2", "!"), 1), role2.Channels())
+	assert.Equal(t, ch.AtSequence(ch.BaseSetOf(t, "explicit1", "derived1", "derived2", "!"), 1), role2.Channels())
 }
 
 func TestRebuildChannelsError(t *testing.T) {
@@ -357,7 +357,7 @@ func TestRebuildChannelsError(t *testing.T) {
 	defer bucket.Close()
 	computer := mockComputer{}
 	auth := NewAuthenticator(bucket, &computer, DefaultAuthenticatorOptions())
-	role, err := auth.NewRole("testRole2", ch.SetOf(t, "explicit1"))
+	role, err := auth.NewRole("testRole2", ch.BaseSetOf(t, "explicit1"))
 	assert.NoError(t, err)
 	err = auth.Save(role)
 	assert.NoError(t, err)
@@ -405,12 +405,12 @@ func TestRoleInheritance(t *testing.T) {
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
 	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
-	role, _ := auth.NewRole("square", ch.SetOf(t, "dull", "duller", "dullest"))
+	role, _ := auth.NewRole("square", ch.BaseSetOf(t, "dull", "duller", "dullest"))
 	assert.Equal(t, nil, auth.Save(role))
-	role, _ = auth.NewRole("frood", ch.SetOf(t, "hoopy", "hoopier", "hoopiest"))
+	role, _ = auth.NewRole("frood", ch.BaseSetOf(t, "hoopy", "hoopier", "hoopiest"))
 	assert.Equal(t, nil, auth.Save(role))
 
-	user, _ := auth.NewUser("arthur", "password", ch.SetOf(t, "britain"))
+	user, _ := auth.NewUser("arthur", "password", ch.BaseSetOf(t, "britain"))
 	user.(*userImpl).setRolesSince(ch.TimedSet{"square": ch.NewVbSimpleSequence(0x3), "nonexistent": ch.NewVbSimpleSequence(0x42), "frood": ch.NewVbSimpleSequence(0x4)})
 	assert.Equal(t, ch.TimedSet{"square": ch.NewVbSimpleSequence(0x3), "nonexistent": ch.NewVbSimpleSequence(0x42), "frood": ch.NewVbSimpleSequence(0x4)}, user.RoleNames())
 	require.NoError(t, auth.Save(user))
@@ -418,13 +418,13 @@ func TestRoleInheritance(t *testing.T) {
 	user2, err := auth.GetUser("arthur")
 	assert.Equal(t, nil, err)
 	log.Printf("Channels = %s", user2.Channels())
-	assert.Equal(t, ch.AtSequence(ch.SetOf(t, "!", "britain"), 1), user2.Channels())
+	assert.Equal(t, ch.AtSequence(ch.BaseSetOf(t, "!", "britain"), 1), user2.Channels())
 	assert.Equal(t, ch.TimedSet{"!": ch.NewVbSimpleSequence(0x1), "britain": ch.NewVbSimpleSequence(0x1), "dull": ch.NewVbSimpleSequence(0x3), "duller": ch.NewVbSimpleSequence(0x3), "dullest": ch.NewVbSimpleSequence(0x3), "hoopy": ch.NewVbSimpleSequence(0x4), "hoopier": ch.NewVbSimpleSequence(0x4), "hoopiest": ch.NewVbSimpleSequence(0x4)}, user2.InheritedChannels())
 
 	assert.True(t, user2.CanSeeChannel("britain"))
 	assert.True(t, user2.CanSeeChannel("duller"))
 	assert.True(t, user2.CanSeeChannel("hoopy"))
-	assert.Equal(t, nil, user2.AuthorizeAllChannels(ch.SetOf(t, "britain", "dull", "hoopiest")))
+	assert.Equal(t, nil, user2.AuthorizeAllChannels(ch.BaseSetOf(t, "britain", "dull", "hoopiest")))
 }
 
 func TestRegisterUser(t *testing.T) {
@@ -501,7 +501,7 @@ func TestCASUpdatePrincipal(t *testing.T) {
 	// Modify the bcrypt cost to test rehashPassword properly below
 	require.Error(t, auth.SetBcryptCost(5))
 
-	user, _ := auth.NewUser(username, password, ch.SetOf(t, "123", "456"))
+	user, _ := auth.NewUser(username, password, ch.BaseSetOf(t, "123", "456"))
 	user.SetExplicitRoles(ch.TimedSet{"role1": ch.NewVbSimpleSequence(1), "role2": ch.NewVbSimpleSequence(1)}, 1)
 	createErr := auth.Save(user)
 	if createErr != nil {
@@ -569,7 +569,7 @@ func TestConcurrentUserWrites(t *testing.T) {
 	// Modify the bcrypt cost to test rehashPassword properly below
 	require.Error(t, auth.SetBcryptCost(5))
 
-	user, _ := auth.NewUser(username, password, ch.SetOf(t, "123", "456"))
+	user, _ := auth.NewUser(username, password, ch.BaseSetOf(t, "123", "456"))
 	user.SetExplicitRoles(ch.TimedSet{"role1": ch.NewVbSimpleSequence(1), "role2": ch.NewVbSimpleSequence(1)}, 1)
 	createErr := auth.Save(user)
 	if createErr != nil {
@@ -1110,11 +1110,11 @@ func TestGetPrincipal(t *testing.T) {
 	)
 
 	// Create a new role named root with access to read, write and execute channels
-	role, _ := auth.NewRole(roleRoot, ch.SetOf(t, channelRead, channelWrite, channelExecute))
+	role, _ := auth.NewRole(roleRoot, ch.BaseSetOf(t, channelRead, channelWrite, channelExecute))
 	assert.Equal(t, nil, auth.Save(role))
 
 	// Create another role named user with access to read and execute channels; no write channel access.
-	role, _ = auth.NewRole(roleUser, ch.SetOf(t, channelRead, channelExecute))
+	role, _ = auth.NewRole(roleUser, ch.BaseSetOf(t, channelRead, channelExecute))
 	assert.Equal(t, nil, auth.Save(role))
 
 	// Get the principal against root role and verify the details.
@@ -1136,7 +1136,7 @@ func TestGetPrincipal(t *testing.T) {
 	assert.True(t, principal.CanSeeChannel(channelExecute))
 
 	// Create a new user with new set of channels and assign user role to the user.
-	user, err := auth.NewUser(username, password, ch.SetOf(
+	user, err := auth.NewUser(username, password, ch.BaseSetOf(
 		t, channelCreate, channelRead, channelUpdate, channelDelete))
 	user.(*userImpl).setRolesSince(ch.TimedSet{roleUser: ch.NewVbSimpleSequence(0x3)})
 	require.NoError(t, auth.Save(user))
@@ -1339,7 +1339,7 @@ func (m mockComputerV2) addRoleChannels(t *testing.T, auth *Authenticator, roleN
 		m.roleChannels[roleName] = ch.TimedSet{}
 	}
 
-	m.roleChannels[roleName].Add(ch.AtSequence(ch.SetOf(t, channelName), invalSeq))
+	m.roleChannels[roleName].Add(ch.AtSequence(ch.BaseSetOf(t, channelName), invalSeq))
 	err := auth.InvalidateChannels(roleName, false, invalSeq)
 	assert.NoError(t, err)
 }
@@ -1355,7 +1355,7 @@ func (m mockComputerV2) addRole(t *testing.T, auth *Authenticator, userName, rol
 		m.roles[userName] = ch.TimedSet{}
 	}
 
-	m.roles[userName].Add(ch.AtSequence(ch.SetOf(t, roleName), invalSeq))
+	m.roles[userName].Add(ch.AtSequence(ch.BaseSetOf(t, roleName), invalSeq))
 	err := auth.InvalidateRoles(userName, invalSeq)
 	assert.NoError(t, err)
 }
@@ -2450,7 +2450,7 @@ func TestRoleSoftDelete(t *testing.T) {
 	const roleName = "role"
 
 	// Instantiate role
-	role, err := auth.NewRole(roleName, ch.SetOf(t, "channel"))
+	role, err := auth.NewRole(roleName, ch.BaseSetOf(t, "channel"))
 	assert.NoError(t, err)
 	assert.NotNil(t, role)
 
@@ -2490,7 +2490,7 @@ func TestRoleSoftDelete(t *testing.T) {
 	assert.Nil(t, role)
 
 	// Re-create role
-	role, err = auth.NewRole(roleName, ch.SetOf(t, "channel2"))
+	role, err = auth.NewRole(roleName, ch.BaseSetOf(t, "channel2"))
 	assert.NoError(t, err)
 	assert.NotNil(t, role)
 
@@ -2563,7 +2563,7 @@ func TestObtainChannelsForDeletedRole(t *testing.T) {
 			const roleName = "role"
 
 			// Instantiate role
-			role, err := auth.NewRole(roleName, ch.SetOf(t, "channel"))
+			role, err := auth.NewRole(roleName, ch.BaseSetOf(t, "channel"))
 			assert.NoError(t, err)
 			assert.NotNil(t, role)
 

--- a/auth/role_test.go
+++ b/auth/role_test.go
@@ -24,7 +24,7 @@ func TestInitRole(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 	// Check initializing role with legal role name.
 	role := &roleImpl{}
-	assert.NoError(t, role.initRole("Music", channels.SetOf(t, "Spotify", "Youtube")))
+	assert.NoError(t, role.initRole("Music", channels.BaseSetOf(t, "Spotify", "Youtube")))
 	assert.Equal(t, "Music", role.Name_)
 	assert.Equal(t, channels.TimedSet{
 		"Spotify": channels.NewVbSimpleSequence(0x1),
@@ -32,11 +32,11 @@ func TestInitRole(t *testing.T) {
 
 	// Check initializing role with illegal role name.
 	role = &roleImpl{}
-	assert.Error(t, role.initRole("Music/", channels.SetOf(t, "Spotify", "Youtube")))
-	assert.Error(t, role.initRole("Music:", channels.SetOf(t, "Spotify", "Youtube")))
-	assert.Error(t, role.initRole("Music,", channels.SetOf(t, "Spotify", "Youtube")))
-	assert.Error(t, role.initRole(".", channels.SetOf(t, "Spotify", "Youtube")))
-	assert.Error(t, role.initRole("\xf7,", channels.SetOf(t, "Spotify", "Youtube")))
+	assert.Error(t, role.initRole("Music/", channels.BaseSetOf(t, "Spotify", "Youtube")))
+	assert.Error(t, role.initRole("Music:", channels.BaseSetOf(t, "Spotify", "Youtube")))
+	assert.Error(t, role.initRole("Music,", channels.BaseSetOf(t, "Spotify", "Youtube")))
+	assert.Error(t, role.initRole(".", channels.BaseSetOf(t, "Spotify", "Youtube")))
+	assert.Error(t, role.initRole("\xf7,", channels.BaseSetOf(t, "Spotify", "Youtube")))
 }
 
 func TestAuthorizeChannelsRole(t *testing.T) {
@@ -44,15 +44,15 @@ func TestAuthorizeChannelsRole(t *testing.T) {
 	defer testBucket.Close()
 	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
-	role, err := auth.NewRole("root", channels.SetOf(t, "superuser"))
+	role, err := auth.NewRole("root", channels.BaseSetOf(t, "superuser"))
 	assert.NoError(t, err)
 	err = auth.Save(role)
 	assert.NoError(t, err)
 
-	assert.NoError(t, role.AuthorizeAllChannels(channels.SetOf(t, "superuser")))
-	assert.Error(t, role.AuthorizeAllChannels(channels.SetOf(t, "unknown")))
-	assert.NoError(t, role.AuthorizeAnyChannel(channels.SetOf(t, "superuser", "unknown")))
-	assert.Error(t, role.AuthorizeAllChannels(channels.SetOf(t, "unknown1", "unknown2")))
+	assert.NoError(t, role.AuthorizeAllChannels(channels.BaseSetOf(t, "superuser")))
+	assert.Error(t, role.AuthorizeAllChannels(channels.BaseSetOf(t, "unknown")))
+	assert.NoError(t, role.AuthorizeAnyChannel(channels.BaseSetOf(t, "superuser", "unknown")))
+	assert.Error(t, role.AuthorizeAllChannels(channels.BaseSetOf(t, "unknown1", "unknown2")))
 }
 
 func BenchmarkIsValidPrincipalName(b *testing.B) {

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -255,11 +255,11 @@ func TestCanSeeChannelSince(t *testing.T) {
 	user, err := auth.NewUser("user", "password", freeChannels)
 	assert.Nil(t, err)
 
-	role, err := auth.NewRole("music", channels.SetOf(t, "Spotify", "Youtube"))
+	role, err := auth.NewRole("music", channels.BaseSetOf(t, "Spotify", "Youtube"))
 	assert.Nil(t, err)
 	assert.Equal(t, nil, auth.Save(role))
 
-	role, err = auth.NewRole("video", channels.SetOf(t, "Netflix", "Hulu"))
+	role, err = auth.NewRole("video", channels.BaseSetOf(t, "Netflix", "Hulu"))
 	assert.Nil(t, err)
 	assert.Equal(t, nil, auth.Save(role))
 
@@ -280,15 +280,15 @@ func TestGetAddedChannels(t *testing.T) {
 
 	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
-	role, err := auth.NewRole("music", channels.SetOf(t, "Spotify", "Youtube"))
+	role, err := auth.NewRole("music", channels.BaseSetOf(t, "Spotify", "Youtube"))
 	assert.Nil(t, err)
 	assert.Equal(t, nil, auth.Save(role))
 
-	role, err = auth.NewRole("video", channels.SetOf(t, "Netflix", "Hulu"))
+	role, err = auth.NewRole("video", channels.BaseSetOf(t, "Netflix", "Hulu"))
 	assert.Nil(t, err)
 	assert.Equal(t, nil, auth.Save(role))
 
-	user, err := auth.NewUser("alice", "password", channels.SetOf(t, "ESPN", "HBO", "FX", "AMC"))
+	user, err := auth.NewUser("alice", "password", channels.BaseSetOf(t, "ESPN", "HBO", "FX", "AMC"))
 	assert.Nil(t, err)
 	require.NoError(t, user.SetEmail("alice@couchbase.com"))
 
@@ -300,7 +300,7 @@ func TestGetAddedChannels(t *testing.T) {
 		"ESPN": channels.NewVbSimpleSequence(0x5),
 		"HBO":  channels.NewVbSimpleSequence(0x6)})
 
-	expectedChannels := channels.SetOf(t, "!", "AMC", "FX", "Hulu", "Netflix", "Spotify", "Youtube")
+	expectedChannels := channels.BaseSetOf(t, "!", "AMC", "FX", "Hulu", "Netflix", "Spotify", "Youtube")
 	log.Printf("Added Channels: %v", addedChannels)
 	assert.Equal(t, expectedChannels, addedChannels)
 }

--- a/channels/channelmapper_test.go
+++ b/channels/channelmapper_test.go
@@ -53,7 +53,7 @@ func TestJavaScriptWorks(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.x.concat(doc.y));}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"x":["abc"],"y":["xyz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
-	assert.Equal(t, SetOf(t, "abc", "xyz"), res.Channels)
+	assert.Equal(t, BaseSetOf(t, "abc", "xyz"), res.Channels)
 }
 
 // Just verify that the calls to the channel() fn show up in the output channel list.
@@ -61,7 +61,7 @@ func TestSyncFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel("foo", "bar"); channel("baz")}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
-	assert.Equal(t, SetOf(t, "foo", "bar", "baz"), res.Channels)
+	assert.Equal(t, BaseSetOf(t, "foo", "bar", "baz"), res.Channels)
 }
 
 // Just verify that the calls to the access() fn show up in the output channel list.
@@ -69,7 +69,7 @@ func TestAccessFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("foo", "bar"); access("foo", "baz")}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
-	assert.Equal(t, AccessMap{"foo": SetOf(t, "bar", "baz")}, res.Access)
+	assert.Equal(t, AccessMap{"foo": BaseSetOf(t, "bar", "baz")}, res.Access)
 }
 
 // Just verify that the calls to the channel() fn show up in the output channel list.
@@ -77,7 +77,7 @@ func TestSyncFunctionTakesArray(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(["foo", "bar ok","baz"])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
-	assert.Equal(t, SetOf(t, "foo", "bar ok", "baz"), res.Channels)
+	assert.Equal(t, BaseSetOf(t, "foo", "bar ok", "baz"), res.Channels)
 }
 
 // Calling channel() with an invalid channel name should return an error.
@@ -99,7 +99,7 @@ func TestAccessFunctionTakesArrayOfUsers(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(["foo","bar","baz"], "ginger")}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
-	assert.Equal(t, AccessMap{"bar": SetOf(t, "ginger"), "baz": SetOf(t, "ginger"), "foo": SetOf(t, "ginger")}, res.Access)
+	assert.Equal(t, AccessMap{"bar": BaseSetOf(t, "ginger"), "baz": BaseSetOf(t, "ginger"), "foo": BaseSetOf(t, "ginger")}, res.Access)
 }
 
 // Just verify that the calls to the access() fn show up in the output channel list.
@@ -107,15 +107,15 @@ func TestAccessFunctionTakesArrayOfChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", ["ginger", "earl_grey", "green"])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
-	assert.Equal(t, AccessMap{"lee": SetOf(t, "ginger", "earl_grey", "green")}, res.Access)
+	assert.Equal(t, AccessMap{"lee": BaseSetOf(t, "ginger", "earl_grey", "green")}, res.Access)
 }
 
 func TestAccessFunctionTakesArrayOfChannelsAndUsers(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(["lee", "nancy"], ["ginger", "earl_grey", "green"])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
-	assert.Equal(t, SetOf(t, "ginger", "earl_grey", "green"), res.Access["lee"])
-	assert.Equal(t, SetOf(t, "ginger", "earl_grey", "green"), res.Access["nancy"])
+	assert.Equal(t, BaseSetOf(t, "ginger", "earl_grey", "green"), res.Access["lee"])
+	assert.Equal(t, BaseSetOf(t, "ginger", "earl_grey", "green"), res.Access["nancy"])
 }
 
 func TestAccessFunctionTakesEmptyArrayUser(t *testing.T) {
@@ -150,7 +150,7 @@ func TestAccessFunctionTakesNonChannelsInArray(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", ["ginger", null, 5])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
-	assert.Equal(t, AccessMap{"lee": SetOf(t, "ginger")}, res.Access)
+	assert.Equal(t, AccessMap{"lee": BaseSetOf(t, "ginger")}, res.Access)
 }
 
 func TestAccessFunctionTakesUndefinedUser(t *testing.T) {
@@ -166,7 +166,7 @@ func TestRoleFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {role(["foo","bar","baz"], "role:froods")}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
-	assert.Equal(t, AccessMap{"bar": SetOf(t, "froods"), "baz": SetOf(t, "froods"), "foo": SetOf(t, "froods")}, res.Roles)
+	assert.Equal(t, AccessMap{"bar": BaseSetOf(t, "froods"), "baz": BaseSetOf(t, "froods"), "foo": BaseSetOf(t, "froods")}, res.Roles)
 }
 
 // Now just make sure the input comes through intact
@@ -174,7 +174,7 @@ func TestInputParse(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.channel);}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "foo"}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
-	assert.Equal(t, SetOf(t, "foo"), res.Channels)
+	assert.Equal(t, BaseSetOf(t, "foo"), res.Channels)
 }
 
 // A more realistic example
@@ -182,7 +182,7 @@ func TestDefaultChannelMapper(t *testing.T) {
 	mapper := NewDefaultChannelMapper()
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
-	assert.Equal(t, SetOf(t, "foo", "bar", "baz"), res.Channels)
+	assert.Equal(t, BaseSetOf(t, "foo", "bar", "baz"), res.Channels)
 
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"x": "y"}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
@@ -204,7 +204,7 @@ func TestChannelMapperUnderscoreLib(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(_.first(doc.channels));}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
-	assert.Equal(t, SetOf(t, "foo"), res.Channels)
+	assert.Equal(t, BaseSetOf(t, "foo"), res.Channels)
 }
 
 // Validation by calling reject()
@@ -235,7 +235,7 @@ func TestPublicChannelMapper(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.channels);}`, 0)
 	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
-	assert.Equal(t, SetOf(t, "foo", "bar", "baz"), output.Channels)
+	assert.Equal(t, BaseSetOf(t, "foo", "bar", "baz"), output.Channels)
 }
 
 // Test the userCtx name parameter
@@ -368,7 +368,7 @@ func TestSetFunction(t *testing.T) {
 	assert.NoError(t, err, "SetFunction failed")
 	output, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
-	assert.Equal(t, SetOf(t, "all"), output.Channels)
+	assert.Equal(t, BaseSetOf(t, "all"), output.Channels)
 }
 
 // Test that expiry function sets the expiry property
@@ -541,8 +541,8 @@ func TestNilMetaMap(t *testing.T) {
 }
 
 func TestChangedUsers(t *testing.T) {
-	a := AccessMap{"alice": SetOf(t, "x", "y"), "bita": SetOf(t, "z"), "claire": SetOf(t, "w")}
-	b := AccessMap{"alice": SetOf(t, "x", "z"), "bita": SetOf(t, "z"), "diana": SetOf(t, "w")}
+	a := AccessMap{"alice": BaseSetOf(t, "x", "y"), "bita": BaseSetOf(t, "z"), "claire": BaseSetOf(t, "w")}
+	b := AccessMap{"alice": BaseSetOf(t, "x", "z"), "bita": BaseSetOf(t, "z"), "diana": BaseSetOf(t, "w")}
 
 	changes := map[string]bool{}
 	ForChangedUsers(a, b, func(name string) {

--- a/channels/set_test.go
+++ b/channels/set_test.go
@@ -42,7 +42,7 @@ func TestSetFromArray(t *testing.T) {
 	for _, cas := range cases {
 		channels, err := SetFromArray(cas[0], RemoveStar)
 		assert.NoError(t, err, "SetFromArray failed")
-		assert.Equal(t, SetOf(t, cas[1]...), channels)
+		assert.Equal(t, BaseSetOf(t, cas[1]...), channels)
 	}
 }
 
@@ -59,7 +59,7 @@ func TestSetFromArrayWithStar(t *testing.T) {
 	for _, cas := range cases {
 		channels, err := SetFromArray(cas[0], ExpandStar)
 		assert.NoError(t, err, "SetFromArray failed")
-		assert.Equal(t, SetOf(t, cas[1]...), channels)
+		assert.Equal(t, BaseSetOf(t, cas[1]...), channels)
 	}
 }
 

--- a/channels/timed_set_test.go
+++ b/channels/timed_set_test.go
@@ -30,12 +30,12 @@ func TestTimedSetMarshal(t *testing.T) {
 	assert.NoError(t, err, "Marshal")
 	assert.Equal(t, `{"Channels":{}}`, string(bytes))
 
-	str.Channels = AtSequence(SetOf(t, "a"), 17)
+	str.Channels = AtSequence(BaseSetOf(t, "a"), 17)
 	bytes, err = base.JSONMarshal(str)
 	assert.NoError(t, err, "Marshal")
 	assert.Equal(t, `{"Channels":{"a":17}}`, string(bytes))
 
-	str.Channels = AtSequence(SetOf(t, "a", "b"), 17)
+	str.Channels = AtSequence(BaseSetOf(t, "a", "b"), 17)
 	bytes, err = base.JSONMarshal(str)
 	assert.NoError(t, err, "Marshal")
 	// Ordering of JSON keys can vary - so just check each channel is present with the correct sequence

--- a/channels/util_testing.go
+++ b/channels/util_testing.go
@@ -16,10 +16,10 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
-// Creates a set from zero or more inline string arguments.
+// BaseSetOf a set from zero or more inline string arguments.
 // Channel names must be valid, else the function will panic, so this should only be called
 // with hardcoded known-valid strings.
-func SetOf(tb testing.TB, names ...string) base.Set {
+func BaseSetOf(tb testing.TB, names ...string) base.Set {
 	set, err := SetFromArray(names, KeepStar)
 	if err != nil {
 		tb.Fatalf("channels.SetOf failed: %v", err)

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -259,7 +259,7 @@ func TestLateSequenceErrorRecovery(t *testing.T) {
 	// Create a user with access to channel ABC
 	authenticator := db.Authenticator(ctx)
 	require.NotNil(t, authenticator, "db.Authenticator(db.Ctx) returned nil")
-	user, err := authenticator.NewUser("naomi", "letmein", channels.SetOf(t, "ABC"))
+	user, err := authenticator.NewUser("naomi", "letmein", channels.BaseSetOf(t, "ABC"))
 	require.NoError(t, err, "Error creating new user")
 	require.NoError(t, authenticator.Save(user))
 
@@ -557,7 +557,7 @@ func TestChannelCacheBufferingWithUserDoc(t *testing.T) {
 	WriteDirect(db, []string{"ABC"}, 2)
 
 	// Start wait for doc in ABC
-	waiter := db.mutationListener.NewWaiterWithChannels(channels.SetOf(t, "ABC"), nil)
+	waiter := db.mutationListener.NewWaiterWithChannels(channels.BaseSetOf(t, "ABC"), nil)
 
 	successChan := make(chan bool)
 	go func() {
@@ -593,7 +593,7 @@ func TestChannelCacheBackfill(t *testing.T) {
 
 	// Create a user with access to channel ABC
 	authenticator := db.Authenticator(ctx)
-	user, _ := authenticator.NewUser("naomi", "letmein", channels.SetOf(t, "ABC", "PBS", "NBC", "TBS"))
+	user, _ := authenticator.NewUser("naomi", "letmein", channels.BaseSetOf(t, "ABC", "PBS", "NBC", "TBS"))
 	require.NoError(t, authenticator.Save(user))
 
 	// Simulate seq 3 being delayed - write 1,2,4,5
@@ -659,7 +659,7 @@ func TestContinuousChangesBackfill(t *testing.T) {
 
 	// Create a user with access to channel ABC
 	authenticator := db.Authenticator(ctx)
-	user, _ := authenticator.NewUser("naomi", "letmein", channels.SetOf(t, "ABC", "PBS", "NBC", "CBS"))
+	user, _ := authenticator.NewUser("naomi", "letmein", channels.BaseSetOf(t, "ABC", "PBS", "NBC", "CBS"))
 	require.NoError(t, authenticator.Save(user))
 
 	// Simulate seq 3 and 4 being delayed - write 1,2,5,6
@@ -761,7 +761,7 @@ func TestLowSequenceHandling(t *testing.T) {
 	// Create a user with access to channel ABC
 	authenticator := db.Authenticator(ctx)
 	assert.True(t, authenticator != nil, "db.Authenticator(ctx) returned nil")
-	user, err := authenticator.NewUser("naomi", "letmein", channels.SetOf(t, "ABC", "PBS", "NBC", "TBS"))
+	user, err := authenticator.NewUser("naomi", "letmein", channels.BaseSetOf(t, "ABC", "PBS", "NBC", "TBS"))
 	assert.NoError(t, err, fmt.Sprintf("Error creating new user: %v", err))
 	require.NoError(t, authenticator.Save(user))
 
@@ -826,7 +826,7 @@ func TestLowSequenceHandlingAcrossChannels(t *testing.T) {
 
 	// Create a user with access to channel ABC
 	authenticator := db.Authenticator(ctx)
-	user, err := authenticator.NewUser("naomi", "letmein", channels.SetOf(t, "ABC"))
+	user, err := authenticator.NewUser("naomi", "letmein", channels.BaseSetOf(t, "ABC"))
 	assert.NoError(t, err, fmt.Sprintf("db.Authenticator(db.Ctx) returned err: %v", err))
 	require.NoError(t, authenticator.Save(user))
 
@@ -880,7 +880,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 
 	// Create a user with access to channel ABC
 	authenticator := db.Authenticator(ctx)
-	user, _ := authenticator.NewUser("naomi", "letmein", channels.SetOf(t, "ABC"))
+	user, _ := authenticator.NewUser("naomi", "letmein", channels.BaseSetOf(t, "ABC"))
 	require.NoError(t, authenticator.Save(user))
 
 	// Simulate seq 3 and 4 being delayed - write 1,2,5,6
@@ -1084,7 +1084,7 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 	// Create a user with access to channel ABC
 	authenticator := db.Authenticator(ctx)
 	assert.True(t, authenticator != nil, "db.Authenticator(db.Ctx) returned nil")
-	user, err := authenticator.NewUser("naomi", "letmein", channels.SetOf(t, "ABC", "PBS", "NBC", "TBS"))
+	user, err := authenticator.NewUser("naomi", "letmein", channels.BaseSetOf(t, "ABC", "PBS", "NBC", "TBS"))
 	assert.NoError(t, err, fmt.Sprintf("Error creating new user: %v", err))
 	require.NoError(t, authenticator.Save(user))
 
@@ -1179,7 +1179,7 @@ func TestChannelRace(t *testing.T) {
 
 	// Create a user with access to channels "Odd", "Even"
 	authenticator := db.Authenticator(ctx)
-	user, _ := authenticator.NewUser("naomi", "letmein", channels.SetOf(t, "Even", "Odd"))
+	user, _ := authenticator.NewUser("naomi", "letmein", channels.BaseSetOf(t, "Even", "Odd"))
 	require.NoError(t, authenticator.Save(user))
 
 	// Write initial sequences
@@ -1388,7 +1388,7 @@ func TestChannelCacheSize(t *testing.T) {
 
 	// Create a user with access to channel ABC
 	authenticator := db.Authenticator(ctx)
-	user, _ := authenticator.NewUser("naomi", "letmein", channels.SetOf(t, "ABC"))
+	user, _ := authenticator.NewUser("naomi", "letmein", channels.BaseSetOf(t, "ABC"))
 	require.NoError(t, authenticator.Save(user))
 
 	// Write 750 docs to channel ABC
@@ -1702,7 +1702,7 @@ func TestInitializeEmptyCache(t *testing.T) {
 	}
 
 	// Issue getChanges for empty channel
-	changes, err := db.GetChanges(ctx, channels.SetOf(t, "zero"), getChangesOptionsWithCtxOnly())
+	changes, err := db.GetChanges(ctx, channels.BaseSetOf(t, "zero"), getChangesOptionsWithCtxOnly())
 	assert.NoError(t, err, "Couldn't GetChanges")
 	changesCount := len(changes)
 	assert.Equal(t, 0, changesCount)
@@ -1720,7 +1720,7 @@ func TestInitializeEmptyCache(t *testing.T) {
 	cacheWaiter.Add(docCount)
 	cacheWaiter.Wait()
 
-	changes, err = db.GetChanges(ctx, channels.SetOf(t, "zero"), getChangesOptionsWithCtxOnly())
+	changes, err = db.GetChanges(ctx, channels.BaseSetOf(t, "zero"), getChangesOptionsWithCtxOnly())
 	assert.NoError(t, err, "Couldn't GetChanges")
 	changesCount = len(changes)
 	assert.Equal(t, 10, changesCount)
@@ -1766,7 +1766,7 @@ func TestInitializeCacheUnderLoad(t *testing.T) {
 
 	// Wait for writes to be in progress, then getChanges for channel zero
 	writesInProgress.Wait()
-	changes, err := db.GetChanges(ctx, channels.SetOf(t, "zero"), getChangesOptionsWithCtxOnly())
+	changes, err := db.GetChanges(ctx, channels.BaseSetOf(t, "zero"), getChangesOptionsWithCtxOnly())
 	require.NoError(t, err, "Couldn't GetChanges")
 	firstChangesCount := len(changes)
 	var lastSeq SequenceID
@@ -1777,7 +1777,7 @@ func TestInitializeCacheUnderLoad(t *testing.T) {
 	// Wait for all writes to be cached, then getChanges again
 	cacheWaiter.Wait()
 
-	changes, err = db.GetChanges(ctx, channels.SetOf(t, "zero"), getChangesOptionsWithSeq(lastSeq))
+	changes, err = db.GetChanges(ctx, channels.BaseSetOf(t, "zero"), getChangesOptionsWithSeq(lastSeq))
 	require.NoError(t, err, "Couldn't GetChanges")
 	secondChangesCount := len(changes)
 	assert.Equal(t, docCount, firstChangesCount+secondChangesCount)
@@ -1862,7 +1862,7 @@ func TestChangeCache_InsertPendingEntries(t *testing.T) {
 
 	// Create a user with access to some channels
 	authenticator := db.Authenticator(ctx)
-	user, _ := authenticator.NewUser("naomi", "letmein", channels.SetOf(t, "ABC", "PBS", "NBC", "TBS"))
+	user, _ := authenticator.NewUser("naomi", "letmein", channels.BaseSetOf(t, "ABC", "PBS", "NBC", "TBS"))
 	require.NoError(t, authenticator.Save(user))
 
 	// Simulate seq 3 + 4 being delayed - write 1,2,5,6

--- a/db/change_listener_test.go
+++ b/db/change_listener_test.go
@@ -32,7 +32,7 @@ func TestUserWaiter(t *testing.T) {
 	username := "bob"
 	authenticator := db.Authenticator(ctx)
 	require.NotNil(t, authenticator, "db.Authenticator(db.Ctx) returned nil")
-	user, err := authenticator.NewUser(username, "letmein", channels.SetOf(t, "ABC"))
+	user, err := authenticator.NewUser(username, "letmein", channels.BaseSetOf(t, "ABC"))
 	require.NoError(t, err, "Error creating new user")
 
 	// Create the user waiter (note: user hasn't been saved yet)
@@ -75,7 +75,7 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 	roleName := "good_egg"
 	authenticator := db.Authenticator(ctx)
 	require.NotNil(t, authenticator, "db.Authenticator(ctx) returned nil")
-	role, err := authenticator.NewRole(roleName, channels.SetOf(t, "ABC"))
+	role, err := authenticator.NewRole(roleName, channels.BaseSetOf(t, "ABC"))
 	require.NoError(t, err, "Error creating new role")
 	require.NoError(t, authenticator.Save(role))
 

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -99,7 +99,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 
 	// Create a user with access to channel ABC
 	authenticator := db.Authenticator(base.TestCtx(t))
-	user, _ := authenticator.NewUser("naomi", "letmein", channels.SetOf(t, "ABC"))
+	user, _ := authenticator.NewUser("naomi", "letmein", channels.BaseSetOf(t, "ABC"))
 	require.NoError(t, authenticator.Save(user))
 
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
@@ -207,7 +207,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 
 	// Create a user with access to channel A
 	authenticator := db.Authenticator(base.TestCtx(t))
-	user, _ := authenticator.NewUser("alice", "letmein", channels.SetOf(t, "A"))
+	user, _ := authenticator.NewUser("alice", "letmein", channels.BaseSetOf(t, "A"))
 	require.NoError(t, authenticator.Save(user))
 
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
@@ -288,7 +288,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 
 	// Create a user with access to channel A
 	authenticator := db.Authenticator(base.TestCtx(t))
-	user, _ := authenticator.NewUser("alice", "letmein", channels.SetOf(t, "A"))
+	user, _ := authenticator.NewUser("alice", "letmein", channels.BaseSetOf(t, "A"))
 	require.NoError(t, authenticator.Save(user))
 
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -785,7 +785,7 @@ func TestSessionTtlGreaterThan30Days(t *testing.T) {
 	response := rt.SendRequest("PUT", "/db/doc", `{"hi": "there"}`)
 	rest.RequireStatus(t, response, 401)
 
-	user, err = a.NewUser("pupshaw", "letmein", channels.SetOf(t, "*"))
+	user, err = a.NewUser("pupshaw", "letmein", channels.BaseSetOf(t, "*"))
 	assert.NoError(t, a.Save(user))
 
 	// create a session with the maximum offset ttl value (30days) 2592000 seconds
@@ -2344,7 +2344,7 @@ func TestSessionExpirationDateTimeFormat(t *testing.T) {
 	defer rt.Close()
 
 	authenticator := auth.NewAuthenticator(rt.Bucket(), nil, auth.DefaultAuthenticatorOptions())
-	user, err := authenticator.NewUser("alice", "letMe!n", channels.SetOf(t, "*"))
+	user, err := authenticator.NewUser("alice", "letMe!n", channels.BaseSetOf(t, "*"))
 	assert.NoError(t, err, "Couldn't create new user")
 	assert.NoError(t, authenticator.Save(user), "Couldn't save new user")
 
@@ -2440,7 +2440,7 @@ func TestUserAndRoleResponseContentType(t *testing.T) {
 
 	// Create a new user and save to database to create user session.
 	authenticator := auth.NewAuthenticator(rt.Bucket(), nil, auth.DefaultAuthenticatorOptions())
-	user, err := authenticator.NewUser("eve", "cGFzc3dvcmQ=", channels.SetOf(t, "*"))
+	user, err := authenticator.NewUser("eve", "cGFzc3dvcmQ=", channels.BaseSetOf(t, "*"))
 	assert.NoError(t, err, "Couldn't create new user")
 	assert.NoError(t, authenticator.Save(user), "Couldn't save new user")
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -110,7 +110,7 @@ func TestDisablePublicBasicAuth(t *testing.T) {
 
 	// Double-check that even if we provide valid credentials we still won't be let in
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	user, err := a.NewUser("user1", "letmein", channels.SetOf(t, "foo"))
+	user, err := a.NewUser("user1", "letmein", channels.BaseSetOf(t, "foo"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(user))
 
@@ -365,7 +365,7 @@ func TestDocAttachmentOnRemovedRev(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create a test user
-	user, err = a.NewUser("user1", "letmein", channels.SetOf(t, "foo"))
+	user, err = a.NewUser("user1", "letmein", channels.BaseSetOf(t, "foo"))
 	assert.NoError(t, a.Save(user))
 
 	response := rt.Send(RequestByUser("PUT", "/db/doc", `{"prop":true, "channels":["foo"]}`, "user1"))
@@ -404,7 +404,7 @@ func TestDocumentUpdateWithNullBody(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create a test user
-	user, err = a.NewUser("user1", "letmein", channels.SetOf(t, "foo"))
+	user, err = a.NewUser("user1", "letmein", channels.BaseSetOf(t, "foo"))
 	assert.NoError(t, a.Save(user))
 	// Create document
 	response := rt.Send(RequestByUser("PUT", "/db/doc", `{"prop":true, "channels":["foo"]}`, "user1"))
@@ -491,7 +491,7 @@ func TestFunkyUsernames(t *testing.T) {
 			a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 
 			// Create a test user
-			user, err := a.NewUser(tc.UserName, "letmein", channels.SetOf(t, "foo"))
+			user, err := a.NewUser(tc.UserName, "letmein", channels.BaseSetOf(t, "foo"))
 			require.NoError(t, err)
 			require.NoError(t, a.Save(user))
 
@@ -552,7 +552,7 @@ func TestFunkyRoleNames(t *testing.T) {
 			a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 
 			// Create a test user
-			user, err := a.NewUser(username, "letmein", channels.SetOf(t))
+			user, err := a.NewUser(username, "letmein", channels.BaseSetOf(t))
 			require.NoError(t, err)
 			require.NoError(t, a.Save(user))
 
@@ -1943,7 +1943,7 @@ func TestLogin(t *testing.T) {
 	response := rt.SendRequest("PUT", "/db/doc", `{"hi": "there"}`)
 	RequireStatus(t, response, 401)
 
-	user, err = a.NewUser("pupshaw", "letmein", channels.SetOf(t, "*"))
+	user, err = a.NewUser("pupshaw", "letmein", channels.BaseSetOf(t, "*"))
 	assert.NoError(t, a.Save(user))
 
 	RequireStatus(t, rt.SendRequest("GET", "/db/_session", ""), 200)
@@ -2121,7 +2121,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create a user:
-	alice, err := a.NewUser("alice", "letmein", channels.SetOf(t, "Cinemax"))
+	alice, err := a.NewUser("alice", "letmein", channels.BaseSetOf(t, "Cinemax"))
 	assert.NoError(t, a.Save(alice))
 
 	// Get a single doc the user has access to:
@@ -2332,9 +2332,9 @@ func TestChannelAccessChanges(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create users:
-	alice, err := a.NewUser("alice", "letmein", channels.SetOf(t, "zero"))
+	alice, err := a.NewUser("alice", "letmein", channels.BaseSetOf(t, "zero"))
 	assert.NoError(t, a.Save(alice))
-	zegpold, err := a.NewUser("zegpold", "letmein", channels.SetOf(t, "zero"))
+	zegpold, err := a.NewUser("zegpold", "letmein", channels.BaseSetOf(t, "zero"))
 	assert.NoError(t, a.Save(zegpold))
 
 	// Create some docs that give users access:
@@ -2520,7 +2520,7 @@ func TestAccessOnTombstone(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create user:
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "zero"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "zero"))
 	assert.NoError(t, a.Save(bernard))
 
 	// Create doc that gives user access to its channel
@@ -3015,12 +3015,12 @@ func TestRoleAccessChanges(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/db/_role/hipster", `{"admin_channels":["gamma"]}`)
 	RequireStatus(t, response, 201)
 	/*
-		alice, err := a.NewUser("alice", "letmein", channels.SetOf(t, "alpha"))
+		alice, err := a.NewUser("alice", "letmein", channels.BaseSetOf(t, "alpha"))
 		assert.NoError(t, a.Save(alice))
-		zegpold, err := a.NewUser("zegpold", "letmein", channels.SetOf(t, "beta"))
+		zegpold, err := a.NewUser("zegpold", "letmein", channels.BaseSetOf(t, "beta"))
 		assert.NoError(t, a.Save(zegpold))
 
-		hipster, err := a.NewRole("hipster", channels.SetOf(t, "gamma"))
+		hipster, err := a.NewRole("hipster", channels.BaseSetOf(t, "gamma"))
 		assert.NoError(t, a.Save(hipster))
 	*/
 
@@ -3452,7 +3452,7 @@ func TestStarAccess(t *testing.T) {
 	//
 	// Part 1 - Tests for user with single channel access:
 	//
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "books"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "books"))
 	assert.NoError(t, a.Save(bernard))
 
 	// GET /db/docid - basic test for channel user has
@@ -3527,7 +3527,7 @@ func TestStarAccess(t *testing.T) {
 	//
 
 	// Create a user:
-	fran, err := a.NewUser("fran", "letmein", channels.SetOf(t, "*"))
+	fran, err := a.NewUser("fran", "letmein", channels.BaseSetOf(t, "*"))
 	assert.NoError(t, a.Save(fran))
 
 	// GET /db/docid - basic test for doc that has channel
@@ -4181,7 +4181,7 @@ func TestLongpollWithWildcard(t *testing.T) {
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 
 	// Create user:
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "PBS"))
 	assert.True(t, err == nil)
 	assert.NoError(t, a.Save(bernard))
 
@@ -4326,7 +4326,7 @@ func TestDocIDFilterResurrection(t *testing.T) {
 	// Create User
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	jacques, err := a.NewUser("jacques", "letmein", channels.SetOf(t, "A", "B"))
+	jacques, err := a.NewUser("jacques", "letmein", channels.BaseSetOf(t, "A", "B"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(jacques))
 
@@ -4667,7 +4667,7 @@ func TestNumAccessErrors(t *testing.T) {
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 
 	// Create a test user
-	user, err := a.NewUser("user", "letmein", channels.SetOf(t, "A"))
+	user, err := a.NewUser("user", "letmein", channels.BaseSetOf(t, "A"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(user))
 

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -36,7 +36,7 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 	// Create user:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "ABC"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
@@ -96,7 +96,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 
 	/*
 		a := it.ServerContext().Database("db").Authenticator(base.TestCtx(t))
-		bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t,"ABC"))
+		bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t,"ABC"))
 		goassert.True(t, err == nil)
 		a.Save(bernard)
 	*/

--- a/rest/changesttest/changes_api_test.go
+++ b/rest/changesttest/changes_api_test.go
@@ -43,7 +43,7 @@ func TestReproduce2383(t *testing.T) {
 
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	user, err := a.NewUser("ben", "letmein", channels.SetOf(t, "PBS"))
+	user, err := a.NewUser("ben", "letmein", channels.BaseSetOf(t, "PBS"))
 	assert.NoError(t, err, "Error creating new user")
 	assert.NoError(t, a.Save(user))
 
@@ -131,7 +131,7 @@ func TestDocDeletionFromChannel(t *testing.T) {
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 
 	// Create user:
-	alice, _ := a.NewUser("alice", "letmein", channels.SetOf(t, "zero"))
+	alice, _ := a.NewUser("alice", "letmein", channels.BaseSetOf(t, "zero"))
 	assert.NoError(t, a.Save(alice))
 
 	// Create a doc Alice can see:
@@ -200,7 +200,7 @@ func TestPostChanges(t *testing.T) {
 	// Create user:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "PBS"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
@@ -230,7 +230,7 @@ func TestPostChangesUserTiming(t *testing.T) {
 	// Create user:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "bernard"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "bernard"))
 	assert.True(t, err == nil)
 	assert.NoError(t, a.Save(bernard))
 
@@ -400,7 +400,7 @@ func postChangesChannelFilter(t *testing.T, rt *rest.RestTester) {
 	// Create user:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "PBS"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
@@ -460,7 +460,7 @@ func TestPostChangesAdminChannelGrant(t *testing.T) {
 	// Create user with access to channel ABC:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "ABC"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
@@ -546,7 +546,7 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 	// Create user with access to channel ABC:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "ABC"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
@@ -701,7 +701,7 @@ func TestPostChangesAdminChannelGrantRemovalWithLimit(t *testing.T) {
 	// Create user with access to channel ABC:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "ABC"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
@@ -772,12 +772,12 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	// Create user with access to channel NBC:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	alice, err := a.NewUser("alice", "letmein", channels.SetOf(t, "NBC"))
+	alice, err := a.NewUser("alice", "letmein", channels.BaseSetOf(t, "NBC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(alice))
 
 	// Create user with access to channel ABC:
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "ABC"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
@@ -1610,7 +1610,7 @@ func TestChangesActiveOnlyInteger(t *testing.T) {
 	// Create user:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS", "ABC"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "PBS", "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
@@ -2165,7 +2165,7 @@ func TestChangesViewBackfillFromQueryOnly(t *testing.T) {
 	// Create user:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "PBS"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
@@ -2238,7 +2238,7 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 	// Create user:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "PBS"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
@@ -2338,7 +2338,7 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 	// Create user:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "PBS"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
@@ -2423,7 +2423,7 @@ func TestChangesViewBackfillNoOverlap(t *testing.T) {
 	// Create user:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "PBS"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
@@ -2510,7 +2510,7 @@ func TestChangesViewBackfill(t *testing.T) {
 	// Create user:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS", "ABC"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "PBS", "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
@@ -2582,7 +2582,7 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 	// Create user:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "*"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "*"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
@@ -2772,7 +2772,7 @@ func TestChangesQueryBackfillWithLimit(t *testing.T) {
 			// Create user
 			username := "user_" + test.name
 			a := testDb.Authenticator(ctx)
-			testUser, err := a.NewUser(username, "letmein", channels.SetOf(t, test.name))
+			testUser, err := a.NewUser(username, "letmein", channels.BaseSetOf(t, test.name))
 			assert.NoError(t, err)
 			assert.NoError(t, a.Save(testUser))
 
@@ -2828,7 +2828,7 @@ func TestMultichannelChangesQueryBackfillWithLimit(t *testing.T) {
 	// Create user with access to three channels
 	username := "user_" + t.Name()
 	a := testDb.Authenticator(ctx)
-	testUser, err := a.NewUser(username, "letmein", channels.SetOf(t, "ch1", "ch2", "ch3"))
+	testUser, err := a.NewUser(username, "letmein", channels.BaseSetOf(t, "ch1", "ch2", "ch3"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(testUser))
 
@@ -2902,7 +2902,7 @@ func TestChangesQueryStarChannelBackfillLimit(t *testing.T) {
 	// Create user:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "*"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "*"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
@@ -2954,7 +2954,7 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 	// Create user:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "PBS"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
@@ -3062,7 +3062,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 
 	// Create user:
 	a := testDb.Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS", "ABC"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "PBS", "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 	cacheWaiter := testDb.NewDCPCachingCountWaiter(t)
@@ -3243,7 +3243,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	// Create user:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS", "ABC"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "PBS", "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
@@ -3447,7 +3447,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	// Create user:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS", "ABC"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "PBS", "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
@@ -3738,7 +3738,7 @@ func TestChangesAdminChannelGrantLongpollNotify(t *testing.T) {
 	// Create user with access to channel ABC:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "ABC"))
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -191,7 +191,7 @@ func TestViewQueryUserAccess(t *testing.T) {
 	// Create a user:
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	password := "123456"
-	testUser, _ := a.NewUser("testUser", password, channels.SetOf(t, "*"))
+	testUser, _ := a.NewUser("testUser", password, channels.BaseSetOf(t, "*"))
 	assert.NoError(t, a.Save(testUser))
 
 	result, err = rt.WaitForNUserViewResults(2, "/db/_design/foo/_view/bar?stale=false", testUser, password)
@@ -276,7 +276,7 @@ func TestUserViewQuery(t *testing.T) {
 
 	// Create a user:
 	password := "123456"
-	quinn, _ := a.NewUser("quinn", password, channels.SetOf(t, "Q", "q"))
+	quinn, _ := a.NewUser("quinn", password, channels.BaseSetOf(t, "Q", "q"))
 	assert.NoError(t, a.Save(quinn))
 
 	// Have the user query the view:
@@ -704,7 +704,7 @@ func TestViewQueryWrappers(t *testing.T) {
 	assert.Equal(t, 3, result.Len())
 
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
-	testUser, err := a.NewUser("testUser", "password", channels.SetOf(t, "userchannel"))
+	testUser, err := a.NewUser("testUser", "password", channels.BaseSetOf(t, "userchannel"))
 	assert.NoError(t, err)
 	err = a.Save(testUser)
 	assert.NoError(t, err)


### PR DESCRIPTION
For CBG-2329, we are going to create a `channels.Set`, making the behavior of this function not match the behavior of `base.Set` and requires `testing.TB`.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`