### PR TITLE
CBG-2381: Avoid logging document body on sync function error

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -2247,7 +2247,7 @@ func (db *Database) getChannelsAndAccess(ctx context.Context, doc *Document, bod
 			}
 
 		} else {
-			base.WarnfCtx(ctx, "Sync fn exception: %+v; doc_id = %s, rev_id = %s", err, base.UD(doc.ID), base.UD(doc.CurrentRev))
+			base.WarnfCtx(ctx, "Sync fn exception: %+v; doc_id = %s, rev_id = %s", err, base.MD(doc.ID), base.MD(doc.CurrentRev))
 			if errors.Is(err, sgbucket.ErrJSTimeout) {
 				err = base.HTTPErrorf(500, "JS sync function timed out")
 			} else {

--- a/db/crud.go
+++ b/db/crud.go
@@ -2247,7 +2247,7 @@ func (db *Database) getChannelsAndAccess(ctx context.Context, doc *Document, bod
 			}
 
 		} else {
-			base.WarnfCtx(ctx, "Sync fn exception: %+v; doc_id = %s, rev_id = %s", err, base.MD(doc.ID), base.MD(doc.CurrentRev))
+			base.WarnfCtx(ctx, "Sync fn exception: %+v; doc %q / %q", err, base.UD(doc.ID), base.MD(doc.CurrentRev))
 			if errors.Is(err, sgbucket.ErrJSTimeout) {
 				err = base.HTTPErrorf(500, "JS sync function timed out")
 			} else {

--- a/db/crud.go
+++ b/db/crud.go
@@ -2247,7 +2247,7 @@ func (db *Database) getChannelsAndAccess(ctx context.Context, doc *Document, bod
 			}
 
 		} else {
-			base.WarnfCtx(ctx, "Sync fn exception: %+v; doc = %s", err, base.UD(body))
+			base.WarnfCtx(ctx, "Sync fn exception: %+v; doc_id = %s, rev_id = %s", err, base.UD(doc.ID), base.UD(doc.CurrentRev))
 			if errors.Is(err, sgbucket.ErrJSTimeout) {
 				err = base.HTTPErrorf(500, "JS sync function timed out")
 			} else {


### PR DESCRIPTION
CBG-2381

Describe your PR here...
- Sync function exceptions were logging the body of the document in the warning message, which can have a size of up to 20 MB.
- Sync function exceptions now only log the document ID and the rev ID, i.e. 
`2022-10-18T17:30:49.217+01:00 [WRN] db:db c:#002 Sync fn exception: ReferenceError: 'doc1' is not defined; doc "<ud>doc1</ud>" / "1-cd809becc169215072fd567eebd8b8de" -- db.(*Database).getChannelsAndAccess() at crud.go:2250`

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`) (Tagged as Metadata)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/984/