### PR TITLE
CBG-2485: Backport CBG-2450: Do not send revisions that have a doc id starting with a null byte

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -894,6 +894,12 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 					}
 				}
 
+				// Check if document has a null byte prefixed to the doc id which will cause BLIP to stop replicating (CBG-2450)
+				if len(minEntry.ID) > 0 && minEntry.ID[0] == '\x00' {
+					base.Warnf("doc %q will not be included in the changes feed due to the id starting with a null character", base.UD(minEntry.ID))
+					continue
+				}
+
 				// Don't send any entries later than the cached sequence at the start of this iteration, unless they are part of a revocation triggered
 				// at or before the cached sequence
 				isValidRevocation := minEntry.Revoked == true && minEntry.Seq.TriggeredBy <= currentCachedSequence

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -415,6 +415,48 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 
 }
 
+// Make sure docs that have an ID prefixed with a null byte don't end up in the changes feed (CBG-2450)
+func TestDocIDNullCharPrefix(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	cacheWaiter := db.NewDCPCachingCountWaiter(t)
+
+	revid1, _, err := db.Put("before", Body{"doc": 1})
+	require.NoError(t, err)
+	cacheWaiter.AddAndWait(1)
+
+	_, _, err = db.Put("\x00during", Body{"doc": 2})
+	require.NoError(t, err)
+	cacheWaiter.AddAndWait(1)
+
+	revid3, _, err := db.Put("after", Body{"doc": 3})
+	require.NoError(t, err)
+	cacheWaiter.AddAndWait(1)
+
+	changes, err := db.GetChanges(base.SetOf("*"), getZeroSequence())
+	assert.NoError(t, err, "Couldn't GetChanges")
+	printChanges(changes)
+
+	assert.Equal(t, 2, len(changes))
+	expected := []*ChangeEntry{
+		{
+			Seq:     SequenceID{Seq: 1},
+			ID:      "before",
+			Changes: []ChangeRev{{"rev": revid1}},
+		},
+		{
+			Seq:     SequenceID{Seq: 3},
+			ID:      "after",
+			Changes: []ChangeRev{{"rev": revid3}},
+		},
+	}
+	assert.Equal(t, expected, changes)
+
+	lastSeq := getLastSeq(changes)
+	assert.Equal(t, "3", lastSeq.String())
+}
+
 // Benchmark to validate fix for https://github.com/couchbase/sync_gateway/issues/2428
 func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
 	defer base.SetUpBenchmarkLogging(base.LevelWarn, base.KeyHTTP)()


### PR DESCRIPTION
CBG-2485

Backport CBG-2450 - Do not send revisions that have a doc id starting with a null byte

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-go1.16/7/
