### PR TITLE
Revert CBG-2450: Do not send revisions that have a doc id starting with a null byte

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -896,12 +896,6 @@ func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans base.Set, 
 					}
 				}
 
-				// Check if document has a null byte prefixed to the doc id which will cause BLIP to stop replicating (CBG-2450)
-				if len(minEntry.ID) > 0 && minEntry.ID[0] == '\x00' {
-					base.WarnfCtx(ctx, "doc %q will not be included in the changes feed due to the id starting with a null character", base.UD(minEntry.ID))
-					continue
-				}
-
 				// Don't send any entries later than the cached sequence at the start of this iteration, unless they are part of a revocation triggered
 				// at or before the cached sequence
 				isValidRevocation := minEntry.Revoked == true && minEntry.Seq.TriggeredBy <= currentCachedSequence


### PR DESCRIPTION
CBG-2450

Reverts commit 7935878bc6f85d321e6c333eb25f831e7eb6bc50 for ticket CBG-2450

Reverting due to documents starting with a null byte should be cleaned up on the server side, rather than handling this edge case. Once the documents are cleaned up on the server side, this change will be unnecessary in SG and could have unintended side effects in the future. 
