### PR TITLE
CBG-2474: changing defaults in Jenkins builds to use GSI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,5 +13,4 @@ Describe your PR here...
 - [ ] Update Go module dependencies when merged
 
 ## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
-- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
-- [ ] `GSI=true,xattrs=true` (for collections) https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
+- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -28,7 +28,7 @@ if [ "${1:-}" == "-m" ]; then
     COUCHBASE_SERVER_VERSION="enterprise-7.0.3"
     SG_TEST_BUCKET_POOL_SIZE="3"
     SG_TEST_BUCKET_POOL_DEBUG="true"
-    GSI="false"
+    GSI="true"
     TLS_SKIP_VERIFY="false"
     SG_CBCOLLECT_ALWAYS="false"
 fi


### PR DESCRIPTION
CBG-2474

Small changes to make master integration tests use GSI by default to allow testing for collections support. Also made changes in Jenkins Integration configuration to make Integration tests use GSI by default. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] N/A
