### PR TITLE
CBG-2472: Create db should return error when dbname on path doesn't match body

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -48,13 +48,11 @@ func (h *handler) handleCreateDB() error {
 
 	validateOIDC := !h.getBoolQuery(paramDisableOIDCValidation)
 
-	if config.Name == "" {
-		config.Name = dbName
+	if dbName != config.Name && config.Name != "" {
+		return base.HTTPErrorf(http.StatusBadRequest, "Name in path (%s) is not the same name in the JSON body (%s).\nDatabase name in path (%s) must match name in body (%s) when provided", dbName, config.Name, dbName, config.Name)
 	}
 
-	if dbName != config.Name {
-		return base.HTTPErrorf(http.StatusBadRequest, "Name in path (%s) is not the same name in the JSON body (%s)", dbName, config.Name)
-	}
+	config.Name = dbName
 
 	if h.server.persistentConfig {
 		if err := config.validatePersistentDbConfig(); err != nil {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -48,6 +48,10 @@ func (h *handler) handleCreateDB() error {
 
 	validateOIDC := !h.getBoolQuery(paramDisableOIDCValidation)
 
+	if config.Name == "" {
+		config.Name = dbName
+	}
+
 	if dbName != config.Name {
 		return base.HTTPErrorf(http.StatusBadRequest, "Name in path (%s) is not the same name in the JSON body (%s)", dbName, config.Name)
 	}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -45,9 +45,12 @@ func (h *handler) handleCreateDB() error {
 	if err != nil {
 		return err
 	}
-	config.Name = dbName
 
 	validateOIDC := !h.getBoolQuery(paramDisableOIDCValidation)
+
+	if dbName != config.Name {
+		return base.HTTPErrorf(http.StatusBadRequest, "Name in path (%s) is not the same name in the JSON body (%s)", dbName, config.Name)
+	}
 
 	if h.server.persistentConfig {
 		if err := config.validatePersistentDbConfig(); err != nil {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -49,7 +49,7 @@ func (h *handler) handleCreateDB() error {
 	validateOIDC := !h.getBoolQuery(paramDisableOIDCValidation)
 
 	if dbName != config.Name && config.Name != "" {
-		return base.HTTPErrorf(http.StatusBadRequest, "Name in path (%s) is not the same name in the JSON body (%s).\nDatabase name in path (%s) must match name in body (%s) when provided", dbName, config.Name, dbName, config.Name)
+		return base.HTTPErrorf(http.StatusBadRequest, "When providing a name in the JSON body (%s), ensure it matches the name in the path (%s).", config.Name, dbName)
 	}
 
 	config.Name = dbName

--- a/rest/admin_functions_api_test.go
+++ b/rest/admin_functions_api_test.go
@@ -440,7 +440,7 @@ func newRestTesterForUserQueries(t *testing.T, queryConfig DbConfig) *RestTester
 	rt := NewRestTester(t, &RestTesterConfig{
 		groupID:           base.StringPtr(t.Name()), // Avoids race conditions between tests
 		EnableUserQueries: true,
-		persistentConfig:  true,
+		PersistentConfig:  true,
 	})
 
 	_ = rt.Bucket() // initializes the bucket as a side effect

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -2194,8 +2194,13 @@ func TestHandleCreateDBJsonName(t *testing.T) {
 				rest.RequireStatus(t, resp, http.StatusBadRequest)
 			} else {
 				rest.RequireStatus(t, resp, http.StatusCreated)
-				resp := rt.SendAdminRequest(http.MethodGet, "/db1/", "")
-				assert.Contains(t, resp.Body.String(), "\"db_name\":\"db1\"")
+				resp = rt.SendAdminRequest(http.MethodGet, "/db1/", "")
+				rest.RequireStatus(t, resp, http.StatusOK)
+
+				var dbStatus map[string]any
+				err := json.Unmarshal(resp.BodyBytes(), &dbStatus)
+				require.NoError(t, err)
+				assert.EqualValues(t, dbStatus["db_name"], "db1")
 			}
 		})
 	}

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -1709,7 +1709,7 @@ func TestDBReplicationStatsTeardown(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
 	rt := NewRestTester(t, &RestTesterConfig{
-		persistentConfig: true,
+		PersistentConfig: true,
 		CustomTestBucket: tb,
 	})
 	defer rt.Close()

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -106,7 +106,7 @@ func NewRestTesterCluster(t *testing.T, config *RestTesterClusterConfig) *RestTe
 		config.rtConfig.groupID = config.groupID
 	}
 	// only persistent mode is supported for a RestTesterCluster
-	config.rtConfig.persistentConfig = true
+	config.rtConfig.PersistentConfig = true
 
 	// Make all RestTesters share the same unclosable TestBucket
 	tb := config.testBucket

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -33,7 +33,7 @@ func TestServerlessPollBuckets(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1,
 		serverless:       true,
-		persistentConfig: true,
+		PersistentConfig: true,
 		MutateStartupConfig: func(config *StartupConfig) {
 			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0)
 		},
@@ -52,7 +52,7 @@ func TestServerlessPollBuckets(t *testing.T) {
 	assert.Empty(t, configs)
 
 	// Create a database
-	rt2 := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1, persistentConfig: true, groupID: &sc.Config.Bootstrap.ConfigGroupID})
+	rt2 := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1, PersistentConfig: true, groupID: &sc.Config.Bootstrap.ConfigGroupID})
 	defer rt2.Close()
 	// Create a new db on the RT to confirm fetch won't retrieve it (due to bucket not being in BucketCredentials)
 	resp := rt2.SendAdminRequest(http.MethodPut, "/db/", fmt.Sprintf(`{
@@ -124,7 +124,7 @@ func TestServerlessDBSetupForceCreds(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1, serverless: true, persistentConfig: true})
+			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1, serverless: true, PersistentConfig: true})
 			defer rt.Close()
 
 			if test.perBucketCreds != nil {
@@ -150,7 +150,7 @@ func TestServerlessBucketCredentialsFetchDatabases(t *testing.T) {
 
 	tb1 := base.GetTestBucket(t)
 	defer tb1.Close()
-	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1, persistentConfig: true, serverless: true,
+	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1, PersistentConfig: true, serverless: true,
 		MutateStartupConfig: func(config *StartupConfig) {
 			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0)
 		},
@@ -187,7 +187,7 @@ func TestServerlessSuspendDatabase(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
 
-	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, persistentConfig: true, serverless: true})
+	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, PersistentConfig: true, serverless: true})
 	defer rt.Close()
 
 	sc := rt.ServerContext()
@@ -262,7 +262,7 @@ func TestServerlessUnsuspendFetchFallback(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb,
 		serverless:       true,
-		persistentConfig: true,
+		PersistentConfig: true,
 		MutateStartupConfig: func(config *StartupConfig) {
 			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0)
 		},
@@ -307,7 +307,7 @@ func TestServerlessFetchConfigsLimited(t *testing.T) {
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb,
-		persistentConfig: true,
+		PersistentConfig: true,
 		MutateStartupConfig: func(config *StartupConfig) {
 			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0)
 		},
@@ -379,7 +379,7 @@ func TestServerlessUpdateSuspendedDb(t *testing.T) {
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb,
-		persistentConfig: true,
+		PersistentConfig: true,
 		MutateStartupConfig: func(config *StartupConfig) {
 			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0)
 		},
@@ -464,7 +464,7 @@ func TestSuspendingFlags(t *testing.T) {
 			tb := base.GetTestBucket(t)
 			defer tb.Close()
 
-			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, persistentConfig: true, serverless: test.serverlessMode})
+			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, PersistentConfig: true, serverless: test.serverlessMode})
 			defer rt.Close()
 
 			sc := rt.ServerContext()
@@ -507,7 +507,7 @@ func TestServerlessUnsuspendAPI(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
 
-	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, persistentConfig: true, serverless: true})
+	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, PersistentConfig: true, serverless: true})
 	defer rt.Close()
 
 	sc := rt.ServerContext()
@@ -544,7 +544,7 @@ func TestServerlessUnsuspendAdminAuth(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
 
-	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, persistentConfig: true, serverless: true, AdminInterfaceAuthentication: true})
+	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, PersistentConfig: true, serverless: true, AdminInterfaceAuthentication: true})
 	defer rt.Close()
 
 	sc := rt.ServerContext()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -61,7 +61,7 @@ type RestTesterConfig struct {
 	metricsInterfaceAuthentication  bool
 	enableAdminAuthPermissionsCheck bool
 	useTLSServer                    bool // If true, TLS will be required for communications with CBS. Default: false
-	persistentConfig                bool
+	PersistentConfig                bool
 	groupID                         *string
 	serverless                      bool // Runs SG in serverless mode. Must be used in conjunction with persistent config
 }
@@ -164,7 +164,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 	sc.Bootstrap.ServerTLSSkipVerify = base.BoolPtr(base.TestTLSSkipVerify())
 	sc.Unsupported.Serverless.Enabled = &rt.serverless
 	if rt.serverless {
-		if !rt.persistentConfig {
+		if !rt.PersistentConfig {
 			rt.TB.Fatalf("Persistent config must be used when running in serverless mode")
 		}
 		sc.BucketCredentials = map[string]*base.CredentialsConfig{
@@ -177,7 +177,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 	if rt.RestTesterConfig.groupID != nil {
 		sc.Bootstrap.ConfigGroupID = *rt.RestTesterConfig.groupID
-	} else if rt.RestTesterConfig.persistentConfig {
+	} else if rt.RestTesterConfig.PersistentConfig {
 		// If running in persistent config mode, the database has to be manually created. If the db name is the same as a
 		// past tests db name, a db already exists error could happen if the past tests bucket is still flushing. Prevent this
 		// by using a unique group ID for each new rest tester.
@@ -204,7 +204,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 	// Post-validation, we can lower the bcrypt cost beyond SG limits to reduce test runtime.
 	sc.Auth.BcryptCost = bcrypt.MinCost
 
-	rt.RestTesterServerContext = NewServerContext(base.TestCtx(rt.TB), &sc, rt.RestTesterConfig.persistentConfig)
+	rt.RestTesterServerContext = NewServerContext(base.TestCtx(rt.TB), &sc, rt.RestTesterConfig.PersistentConfig)
 	ctx := rt.Context()
 
 	if !base.ServerIsWalrus(sc.Bootstrap.Server) {
@@ -229,7 +229,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 	}
 
 	// tests must create their own databases in persistent mode
-	if !rt.persistentConfig {
+	if !rt.PersistentConfig {
 		useXattrs := base.TestUseXattrs()
 
 		if rt.DatabaseConfig == nil {


### PR DESCRIPTION
CBG-2472

- When creating a DB, the path name was used by default, even if the given JSON body contained a different name.
- Now if the JSON doesn't contain a name, it defaults to the name in the path. Otherwise it compares the path name and JSON name and if they're not the same it throws an HTTP Error 400, eg. ` 400 When providing a name in the JSON body (dummy), ensure it matches the name in the path (db1). `
- Added one unit test with 3 subtests.
- Exported persistentConfig in RestTesterConfig.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] 'xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/996/
