### PR TITLE
Support ad-hoc unit testing against existing Couchbase Server bucket

### DIFF
--- a/base/collection.go
+++ b/base/collection.go
@@ -95,7 +95,7 @@ func GetCouchbaseCollection(spec BucketSpec) (*Collection, error) {
 		return nil, err
 	}
 
-	return GetCollectionFromCluster(cluster, spec, 30)
+	return GetCollectionFromCluster(cluster, spec, time.Second*30)
 
 }
 
@@ -123,11 +123,11 @@ func getClusterVersion(cluster *gocb.Cluster) (int, int, error) {
 	return clusterCompatMajor, clusterCompatMinor, nil
 }
 
-func GetCollectionFromCluster(cluster *gocb.Cluster, spec BucketSpec, waitUntilReadySeconds int) (*Collection, error) {
+func GetCollectionFromCluster(cluster *gocb.Cluster, spec BucketSpec, waitUntilReady time.Duration) (*Collection, error) {
 
 	// Connect to bucket
 	bucket := cluster.Bucket(spec.BucketName)
-	err := bucket.WaitUntilReady(time.Duration(waitUntilReadySeconds)*time.Second, &gocb.WaitUntilReadyOptions{
+	err := bucket.WaitUntilReady(waitUntilReady, &gocb.WaitUntilReadyOptions{
 		RetryStrategy: &goCBv2FailFastRetryStrategy{},
 	})
 	if err != nil {

--- a/base/constants.go
+++ b/base/constants.go
@@ -51,6 +51,8 @@ const (
 	TestEnvSyncGatewayBackingStore = "SG_TEST_BACKING_STORE"
 	TestEnvBackingStoreCouchbase   = "Couchbase"
 
+	TestEnvUseExistingBucket = "SG_TEST_USE_EXISTING_BUCKET"
+
 	// Don't use Xattrs by default, but provide the test runner a way to specify Xattr usage
 	TestEnvSyncGatewayUseXattrs = "SG_TEST_USE_XATTRS"
 	TestEnvSyncGatewayTrue      = "True"

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -337,14 +337,13 @@ func (tbp *TestBucketPool) GetExistingBucket(t testing.TB) (b Bucket, s BucketSp
 	bucketSpec := getBucketSpec(bucketName, useNamedCollections)
 
 	bucket := bucketCluster.Bucket(bucketSpec.BucketName)
-	// TODO: Constant?
-	err = bucket.WaitUntilReady(10*time.Second, nil)
+	err = bucket.WaitUntilReady(waitForReadyBucketTimeout, nil)
 	if err != nil {
 		return nil, bucketSpec, nil
 	}
 	DebugfCtx(context.TODO(), KeySGTest, "opened bucket %s", bucketName)
 
-	bucketFromSpec, err := GetCollectionFromCluster(bucketCluster, bucketSpec, 10)
+	bucketFromSpec, err := GetCollectionFromCluster(bucketCluster, bucketSpec, waitForReadyBucketTimeout)
 	if err != nil {
 		tbp.Fatalf(testCtx, "couldn't get existing collection from cluster: %v", err)
 	}
@@ -587,7 +586,7 @@ func (tbp *TestBucketPool) createTestBuckets(numBuckets int, bucketQuotaMB int, 
 				tbp.Fatalf(ctx, "Couldn't create test bucket: %v", err)
 			}
 
-			namedCollection, defaultCollection, err := tbp.cluster.openTestBucket(tbpBucketName(bucketName), 10*numBuckets, tbp.UsingNamedCollections())
+			namedCollection, defaultCollection, err := tbp.cluster.openTestBucket(tbpBucketName(bucketName), waitForReadyBucketTimeout, tbp.UsingNamedCollections())
 			ctx = updateContextWithKeyspace(ctx, defaultCollection)
 			if err != nil {
 				tbp.Fatalf(ctx, "Timed out trying to open new bucket: %v", err)
@@ -683,7 +682,7 @@ loop:
 				defer tbp.bucketReadierWaitGroup.Done()
 
 				start := time.Now()
-				namedCollection, defaultCollection, err := tbp.cluster.openTestBucket(testBucketName, 5, tbp.UsingNamedCollections())
+				namedCollection, defaultCollection, err := tbp.cluster.openTestBucket(testBucketName, waitForReadyBucketTimeout, tbp.UsingNamedCollections())
 				ctx = updateContextWithKeyspace(ctx, defaultCollection)
 				if err != nil {
 					tbp.Logf(ctx, "Couldn't open bucket to get ready, got error: %v", err)

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -23,7 +23,7 @@ type tbpCluster interface {
 	getBucketNames() ([]string, error)
 	insertBucket(name string, quotaMB int) error
 	removeBucket(name string) error
-	openTestBucket(name tbpBucketName, waitUntilReadySeconds int, usingNamedCollections bool) (Bucket, Bucket, error)
+	openTestBucket(name tbpBucketName, waitUntilReady time.Duration, usingNamedCollections bool) (Bucket, Bucket, error)
 	supportsCollections() (bool, error)
 	close() error
 }
@@ -137,7 +137,7 @@ func (c *tbpClusterV2) removeBucket(name string) error {
 }
 
 // openTestBucket opens the bucket of the given name for the gocb cluster in the given TestBucketPool.
-func (c *tbpClusterV2) openTestBucket(testBucketName tbpBucketName, waitUntilReadySeconds int, usingNamedCollections bool) (Bucket, Bucket, error) {
+func (c *tbpClusterV2) openTestBucket(testBucketName tbpBucketName, waitUntilReady time.Duration, usingNamedCollections bool) (Bucket, Bucket, error) {
 
 	bucketCluster := initV2Cluster(c.server)
 
@@ -146,7 +146,7 @@ func (c *tbpClusterV2) openTestBucket(testBucketName tbpBucketName, waitUntilRea
 	// Create scope and collection on server, first drop any scope and collect in the bucket and then create
 	// new scope + collection
 	bucket := bucketCluster.Bucket(bucketSpec.BucketName)
-	err := bucket.WaitUntilReady(time.Duration(waitUntilReadySeconds*4)*time.Second, nil)
+	err := bucket.WaitUntilReady(waitUntilReady, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -156,7 +156,7 @@ func (c *tbpClusterV2) openTestBucket(testBucketName tbpBucketName, waitUntilRea
 		return nil, nil, err
 	}
 
-	bucketFromSpec, err := GetCollectionFromCluster(bucketCluster, bucketSpec, waitUntilReadySeconds)
+	bucketFromSpec, err := GetCollectionFromCluster(bucketCluster, bucketSpec, waitUntilReady)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -173,7 +173,7 @@ func (c *tbpClusterV2) openTestBucket(testBucketName tbpBucketName, waitUntilRea
 		defaultSpec := getBucketSpec(testBucketName, usingNamedCollections)
 		defaultSpec.Scope = nil
 		defaultSpec.Collection = nil
-		unnamedCollectionBucket, err := GetCollectionFromCluster(bucketCluster, defaultSpec, waitUntilReadySeconds)
+		unnamedCollectionBucket, err := GetCollectionFromCluster(bucketCluster, defaultSpec, waitUntilReady)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -238,6 +238,15 @@ func TestUseCouchbaseServer() bool {
 	return strings.ToLower(backingStore) == strings.ToLower(TestEnvBackingStoreCouchbase)
 }
 
+// Check the whether tests are being run with SG_TEST_BACKING_STORE=Couchbase
+func TestUseExistingBucket() bool {
+	return TestUseExistingBucketName() != ""
+}
+
+func TestUseExistingBucketName() string {
+	return os.Getenv(TestEnvUseExistingBucket)
+}
+
 type TestAuthenticator struct {
 	Username   string
 	Password   string

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -397,7 +397,7 @@ func (dbc *DatabaseContext) GetPrincipalForTest(tb testing.TB, name string, isUs
 	return
 }
 
-// TestBucketPoolWithIndexes runs a TestMain for packages that do not require creation of indexes
+// TestBucketPoolWithIndexes runs a TestMain for packages that require creation of indexes
 func TestBucketPoolWithIndexes(m *testing.M, memWatermarkThresholdMB uint64) {
 	base.TestBucketPoolMain(m, viewsAndGSIBucketReadier, viewsAndGSIBucketInit, memWatermarkThresholdMB)
 }


### PR DESCRIPTION
When running unit tests at dev time, there are scenarios where it's more efficient to test against an already provisioned bucket, instead of depending on the TestBucketPool to provision/flush the bucket.  To simplify this type of testing, this adds SG_TEST_USE_EXISTING_BUCKET environment variable which will bypass the bucket readier code, and instead attempt to establish a connection to the named bucket.
