### PR TITLE
CBG-2007: fix for flaking test TestReplicationRebalancePush

### DIFF
--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -811,22 +811,14 @@ func TestReplicationRebalancePush(t *testing.T) {
 	_ = activeRT.PutDoc(docABC1, `{"source":"activeRT","channels":["ABC"]}`)
 	_ = activeRT.PutDoc(docDEF1, `{"source":"activeRT","channels":["DEF"]}`)
 
+	// This seems to fix the flaking. Wait until the change-cache has caught up with the latest writes to the database.
+	require.NoError(t, activeRT.WaitForPendingChanges())
+
 	// Create push replications, verify running
 	activeRT.createReplication("rep_ABC", remoteURLString, db.ActiveReplicatorTypePush, []string{"ABC"}, true, db.ConflictResolverDefault)
 	activeRT.createReplication("rep_DEF", remoteURLString, db.ActiveReplicatorTypePush, []string{"DEF"}, true, db.ConflictResolverDefault)
 	activeRT.WaitForReplicationStatus("rep_ABC", db.ReplicationStateRunning)
 	activeRT.WaitForReplicationStatus("rep_DEF", db.ReplicationStateRunning)
-	// If replication not set up properly reset the replications. This seems to fix the flaking
-	success := activeRT.waitForAssignedReplicationWithRetry(2)
-	if !success {
-		activeRT.DeleteReplication("rep_ABC")
-		activeRT.DeleteReplication("rep_DEF")
-		activeRT.createReplication("rep_ABC", remoteURLString, db.ActiveReplicatorTypePush, []string{"ABC"}, true, db.ConflictResolverDefault)
-		activeRT.createReplication("rep_DEF", remoteURLString, db.ActiveReplicatorTypePush, []string{"DEF"}, true, db.ConflictResolverDefault)
-		activeRT.WaitForReplicationStatus("rep_ABC", db.ReplicationStateRunning)
-		activeRT.WaitForReplicationStatus("rep_DEF", db.ReplicationStateRunning)
-		activeRT.waitForAssignedReplications(2)
-	}
 
 	// wait for documents to be pushed to remote
 	changesResults := remoteRT.RequireWaitChanges(2, "0")

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -9,7 +9,6 @@
 package rest
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -129,18 +128,6 @@ func (rt *RestTester) waitForAssignedReplications(count int) {
 	require.NoError(rt.TB, rt.WaitForCondition(successFunc))
 }
 
-func (rt *RestTester) waitForAssignedReplicationWithRetry(count int) bool {
-	err, _ := base.RetryLoop("replicationWait", func() (shouldRetry bool, err error, value interface{}) {
-		replicationStatuses := rt.GetReplicationStatuses("?localOnly=true")
-		if !(len(replicationStatuses) == count) {
-			base.WarnfCtx(context.TODO(), "Error checking if local checkpoint exists")
-			return true, fmt.Errorf("error getting local checkpoint"), nil
-		}
-		return false, nil, nil
-	}, base.CreateMaxDoublingSleeperFunc(12, 10, 3000))
-	return err == nil
-}
-
 func (rt *RestTester) WaitForReplicationStatus(replicationID string, targetStatus string) {
 	successFunc := func() bool {
 		status := rt.GetReplicationStatus(replicationID)
@@ -168,9 +155,4 @@ func (rt *RestTester) GetReplicationStatuses(queryString string) (statuses []db.
 	RequireStatus(rt.TB, rawResponse, 200)
 	require.NoError(rt.TB, base.JSONUnmarshal(rawResponse.Body.Bytes(), &statuses))
 	return statuses
-}
-
-func (rt *RestTester) DeleteReplication(replicationID string) {
-	response := rt.SendAdminRequest("DELETE", "/db/_replication/"+replicationID, "")
-	RequireStatus(rt.TB, response, 200)
 }


### PR DESCRIPTION
CBG-2007

Test was flaking so initially added retry function to checkout this and then then reset the replications if local checkpoints are not found by deleting and recreating the replications needed. But realized Ben had made a fix to another test in the file with the same sort of flaking error that is much more efficient and seems to work for this test too so rolled over to that fix. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/993/
