### PR TITLE
CBG-2500: Reject requests for invalid keyspaces when running without collections

### DIFF
--- a/rest/handler.go
+++ b/rest/handler.go
@@ -322,7 +322,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 				return base.HTTPErrorf(http.StatusNotFound, "keyspace %s.%s.%s not found", base.MD(keyspaceDb), base.MD(base.StringDefault(keyspaceScope, "")), base.MD(base.StringDefault(keyspaceCollection, "")))
 			}
 		} else {
-			if keyspaceScope != nil || keyspaceCollection != nil {
+			if keyspaceScope != nil && *keyspaceScope != base.DefaultScope || keyspaceCollection != nil && *keyspaceCollection != base.DefaultCollection {
 				// request tried specifying a named collection on a non-named collections database
 				return base.HTTPErrorf(http.StatusNotFound, "keyspace %s.%s.%s not found", base.MD(keyspaceDb), base.MD(base.StringDefault(keyspaceScope, "")), base.MD(base.StringDefault(keyspaceCollection, "")))
 			}


### PR DESCRIPTION
CBG-2500

- Ensures that defined keyspaces are checked when SG is not running with collections, and not just blindly assume it's `_default._default`
- Tested both explicit and implicit keyspaces on a non-collection db
- Safe `*string` dereferencing in logging around keyspaces

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1001/
