### PR TITLE
Fix TestNoCollectionsPutDocWithKeyspace with GSI by forcing default collection

### DIFF
--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -115,7 +115,12 @@ func TestCollectionsPutDocInKeyspace(t *testing.T) {
 
 // TestNoCollectionsPutDocWithKeyspace ensures that a keyspace can't be used to insert a doc on a database not configured for collections.
 func TestNoCollectionsPutDocWithKeyspace(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	tb := base.GetTestBucketDefaultCollection(t)
+	defer tb.Close()
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		CustomTestBucket: tb,
+	})
 	defer rt.Close()
 
 	// can't put doc into invalid keyspaces


### PR DESCRIPTION
Fixes test added in #5838 which assumed `RestTester` used the default collection by default (it doesn't when running with GSI)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1003/
