### PR TITLE
CBG-2465: Sporadic failure when trying to access a document in a scope that's been renamed

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -540,7 +540,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 			}
 
-			bucketDbConfig.cas = rawBucketConfigCas
+			bucketDbConfig.cfgCas = rawBucketConfigCas
 
 			oldBucketDbConfig := bucketDbConfig.DbConfig
 
@@ -575,7 +575,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 			if err = base.DeepCopyInefficient(&tmpConfig, bucketDbConfig); err != nil {
 				return nil, err
 			}
-			tmpConfig.cas = rawBucketConfigCas
+			tmpConfig.cfgCas = rawBucketConfigCas
 			dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
 			bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
 			if err := tmpConfig.setup(dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -3568,6 +3568,76 @@ func TestPutDbConfigChangeName(t *testing.T) {
 	resp.RequireStatus(http.StatusBadRequest)
 }
 
+func TestSwitchDbConfigCollectionName(t *testing.T) {
+	base.TestRequiresCollections(t)
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
+	serverErr := make(chan error, 0)
+
+	// Start SG with no databases
+	ctx := base.TestCtx(t)
+	config := rest.BootstrapStartupConfigForTest(t)
+	sc, err := rest.SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+		require.NoError(t, <-serverErr)
+	}()
+
+	go func() {
+		serverErr <- rest.StartServer(ctx, &config, sc)
+	}()
+	require.NoError(t, sc.WaitForRESTAPIs())
+
+	// Get a test bucket, and add new scopes and collections to it.
+	tb := base.GetTestBucket(t)
+	defer func() {
+		log.Println("closing test bucket")
+		tb.Close()
+	}()
+
+	err = base.CreateBucketScopesAndCollections(base.TestCtx(t), tb.BucketSpec, map[string][]string{
+		"foo": {
+			"bar",
+			"baz",
+		},
+	})
+	require.NoError(t, err)
+
+	// create db
+	resp := rest.BootstrapAdminRequest(t, http.MethodPut, "/db/", fmt.Sprintf(
+		`{"bucket": "%s", "scopes": {"foo": {"collections": {"bar": {}}}}, "num_index_replicas": 0, "enable_shared_bucket_access": true, "use_views": false}`,
+		tb.GetName(),
+	))
+	resp.RequireStatus(http.StatusCreated)
+
+	// put a doc in db
+	resp = rest.BootstrapAdminRequest(t, http.MethodPut, "/db.foo.bar/10001", `{"type":"test_doc"}`)
+	resp.RequireStatus(http.StatusCreated)
+
+	// update config to another collection
+	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/db/_config", fmt.Sprintf(
+		`{"bucket": "%s", "scopes": {"foo": {"collections": {"baz": {}}}}, "num_index_replicas": 0, "enable_shared_bucket_access": true, "use_views": false}`,
+		tb.GetName(),
+	))
+	resp.RequireStatus(http.StatusCreated)
+
+	// put doc in new collection
+	resp = rest.BootstrapAdminRequest(t, http.MethodPut, "/db.foo.baz/10001", `{"type":"test_doc1"}`)
+	resp.RequireStatus(http.StatusCreated)
+
+	// update back to original collection config
+	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/db/_config", fmt.Sprintf(
+		`{"bucket": "%s", "scopes": {"foo": {"collections": {"bar": {}}}}, "num_index_replicas": 0, "enable_shared_bucket_access": true, "use_views": false}`,
+		tb.GetName(),
+	))
+	resp.RequireStatus(http.StatusCreated)
+
+	// put doc in original collection name
+	resp = rest.BootstrapAdminRequest(t, http.MethodPut, "/db.foo.bar/100", `{"type":"test_doc1"}`)
+	resp.RequireStatus(http.StatusCreated)
+}
+
 func TestPutDBConfigOIDC(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
@@ -4000,7 +4070,7 @@ func TestDbConfigPersistentSGVersions(t *testing.T) {
 	assertRevsLimit(sc, 123)
 
 	writeRevsLimitConfigWithVersion := func(sc *rest.ServerContext, version string, revsLimit uint32) error {
-		_, err = sc.BootstrapContext.Connection.UpdateConfig(tb.GetName(), t.Name(), func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
+		_, err = sc.BootstrapContext.Connection.UpdateConfig(tb.GetName(), t.Name(), func(rawBucketConfig []byte, rawBucketConfigCas uint64) (updatedConfig []byte, err error) {
 			var db rest.DatabaseConfig
 			if err := base.JSONUnmarshal(rawBucketConfig, &db); err != nil {
 				return nil, err

--- a/rest/handler_config_database.go
+++ b/rest/handler_config_database.go
@@ -49,7 +49,7 @@ func (h *handler) mutateDbConfig(mutator func(*DbConfig) error) error {
 		var updatedDbConfig *DatabaseConfig
 		cas, err := h.server.BootstrapContext.Connection.UpdateConfig(
 			bucket, h.server.Config.Bootstrap.ConfigGroupID,
-			func(rawBucketConfig []byte) (newConfig []byte, err error) {
+			func(rawBucketConfig []byte, rawBucketConfigCas uint64) (newConfig []byte, err error) {
 				var bucketDbConfig DatabaseConfig
 				if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {
 					return nil, err

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -226,7 +226,7 @@ func TestServerlessSuspendDatabase(t *testing.T) {
 
 	// Update config in bucket to see if unsuspending check for updates
 	cas, err := sc.BootstrapContext.Connection.UpdateConfig(tb.GetName(), sc.Config.Bootstrap.ConfigGroupID,
-		func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
+		func(rawBucketConfig []byte, rawBucketConfigCas uint64) (updatedConfig []byte, err error) {
 			return json.Marshal(sc.dbConfigs["db"])
 		},
 	)
@@ -333,7 +333,7 @@ func TestServerlessFetchConfigsLimited(t *testing.T) {
 
 	// Update database config in the bucket
 	newCas, err := sc.BootstrapContext.Connection.UpdateConfig(tb.GetName(), sc.Config.Bootstrap.ConfigGroupID,
-		func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
+		func(rawBucketConfig []byte, rawBucketConfigCas uint64) (updatedConfig []byte, err error) {
 			return json.Marshal(sc.dbConfigs["db"])
 		},
 	)
@@ -356,7 +356,7 @@ func TestServerlessFetchConfigsLimited(t *testing.T) {
 
 	// Update database config in the bucket again to test caching disable case
 	newCas, err = sc.BootstrapContext.Connection.UpdateConfig(tb.GetName(), sc.Config.Bootstrap.ConfigGroupID,
-		func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
+		func(rawBucketConfig []byte, rawBucketConfigCas uint64) (updatedConfig []byte, err error) {
 			return json.Marshal(sc.dbConfigs["db"])
 		},
 	)
@@ -399,7 +399,7 @@ func TestServerlessUpdateSuspendedDb(t *testing.T) {
 	assert.NoError(t, sc.suspendDatabase(t, rt.Context(), "db"))
 	// Update database config
 	newCas, err := sc.BootstrapContext.Connection.UpdateConfig(tb.GetName(), sc.Config.Bootstrap.ConfigGroupID,
-		func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
+		func(rawBucketConfig []byte, rawBucketConfigCas uint64) (updatedConfig []byte, err error) {
 			return json.Marshal(sc.dbConfigs["db"])
 		},
 	)


### PR DESCRIPTION
CBG-2465

There was a bug where the cas value for updating the config was being set to 0. Creating a race condition where updating the db config to point to another named collection on the bucket would be overwritten by an old config. This change forces the correct update of the cas value for the update of a config fixing the issue. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1009/
