### PR TITLE
Fix minor typo in graphQL unit test

### DIFF
--- a/db/functions/graphql_test.go
+++ b/db/functions/graphql_test.go
@@ -87,7 +87,7 @@ var kTestGraphQLConfig = GraphQLConfig{
 				Type: "javascript",
 				Code: `function(parent, args, context, info) {
 						if (Object.keys(parent).length != 0) throw "Unexpected parent";
-						if (Object.keys(args).length != 1) throw "Unexpected args";
+						if (Object.keys(args).length != 0) throw "Unexpected args";
 						if (Object.keys(info) != "selectedFieldNames") throw "Unexpected info";
 						if (!context.user) throw "Missing context.user";
 						if (!context.admin) throw "Missing context.admin";


### PR DESCRIPTION
CBG-0000

Describe your PR here...
- Resolve minor typo in GraphQLResolverConfig.
- The args length for toDo should be 0 and not 1.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
