### PR TITLE
CBG-2470: de duplicate wait for index code

### DIFF
--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -35,7 +35,6 @@ func TestN1qlQuery(t *testing.T) {
 
 	bucket := GetTestBucket(t)
 	defer bucket.Close()
-	col, err := AsCollection(bucket)
 
 	n1qlStore, ok := AsN1QLStore(bucket)
 	if !ok {
@@ -54,13 +53,13 @@ func TestN1qlQuery(t *testing.T) {
 	}
 
 	indexExpression := "val"
-	err = n1qlStore.CreateIndex("testIndex_value", indexExpression, "", testN1qlOptions)
+	err := n1qlStore.CreateIndex("testIndex_value", indexExpression, "", testN1qlOptions)
 	if err != nil && err != ErrAlreadyExists {
 		t.Errorf("Error creating index: %s", err)
 	}
 
 	// Wait for index readiness
-	onlineErr := col.WaitForIndexesOnline([]string{"testIndex_value"}, false)
+	onlineErr := n1qlStore.WaitForIndexesOnline([]string{"testIndex_value"}, false)
 	if onlineErr != nil {
 		t.Fatalf("Error waiting for index to come online: %v", err)
 	}
@@ -81,7 +80,7 @@ func TestN1qlQuery(t *testing.T) {
 		}
 	}()
 
-	readyErr := col.WaitForIndexesOnline([]string{"testIndex_value"}, false)
+	readyErr := n1qlStore.WaitForIndexesOnline([]string{"testIndex_value"}, false)
 	require.NoError(t, readyErr, "Error validating index online")
 
 	// Query the index
@@ -144,8 +143,6 @@ func TestN1qlFilterExpression(t *testing.T) {
 
 	bucket := GetTestBucket(t)
 	defer bucket.Close()
-	col, err := AsCollection(bucket)
-	require.NoError(t, err)
 	n1qlStore, ok := AsN1QLStore(bucket)
 	if !ok {
 		t.Fatalf("Requires bucket to be N1QLStore")
@@ -164,13 +161,13 @@ func TestN1qlFilterExpression(t *testing.T) {
 
 	indexExpression := "val"
 	filterExpression := "val < 3"
-	err = n1qlStore.CreateIndex("testIndex_filtered_value", indexExpression, filterExpression, testN1qlOptions)
+	err := n1qlStore.CreateIndex("testIndex_filtered_value", indexExpression, filterExpression, testN1qlOptions)
 	if err != nil {
 		t.Fatalf("Error creating index: %s", err)
 	}
 
 	// Wait for index readiness
-	readyErr := col.WaitForIndexesOnline([]string{"testIndex_filtered_value"}, false)
+	readyErr := n1qlStore.WaitForIndexesOnline([]string{"testIndex_filtered_value"}, false)
 	require.NoError(t, readyErr, "Error validating index online")
 
 	// Defer index teardown
@@ -223,8 +220,6 @@ func TestIndexMeta(t *testing.T) {
 
 	bucket := GetTestBucket(t)
 	defer bucket.Close()
-	col, err := AsCollection(bucket)
-	require.NoError(t, err)
 	n1qlStore, ok := AsN1QLStore(bucket)
 	if !ok {
 		t.Fatalf("Requires bucket to be N1QLStore")
@@ -241,7 +236,7 @@ func TestIndexMeta(t *testing.T) {
 		t.Fatalf("Error creating index: %s", err)
 	}
 
-	readyErr := col.WaitForIndexesOnline([]string{"testIndex_value"}, false)
+	readyErr := n1qlStore.WaitForIndexesOnline([]string{"testIndex_value"}, false)
 	require.NoError(t, readyErr, "Error validating index online")
 
 	// Defer index teardown
@@ -269,8 +264,6 @@ func TestMalformedN1qlQuery(t *testing.T) {
 
 	bucket := GetTestBucket(t)
 	defer bucket.Close()
-	col, err := AsCollection(bucket)
-	require.NoError(t, err)
 	n1qlStore, ok := AsN1QLStore(bucket)
 	if !ok {
 		t.Fatalf("Requires bucket to be N1QLStore")
@@ -288,12 +281,12 @@ func TestMalformedN1qlQuery(t *testing.T) {
 	}
 
 	indexExpression := "val"
-	err = n1qlStore.CreateIndex("testIndex_value_malformed", indexExpression, "", testN1qlOptions)
+	err := n1qlStore.CreateIndex("testIndex_value_malformed", indexExpression, "", testN1qlOptions)
 	if err != nil {
 		t.Fatalf("Error creating index: %s", err)
 	}
 
-	readyErr := col.WaitForIndexesOnline([]string{"testIndex_value_malformed"}, false)
+	readyErr := n1qlStore.WaitForIndexesOnline([]string{"testIndex_value_malformed"}, false)
 	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Defer index teardown
@@ -344,18 +337,16 @@ func TestCreateAndDropIndex(t *testing.T) {
 	bucket := GetTestBucket(t)
 	defer bucket.Close()
 	n1qlStore, ok := AsN1QLStore(bucket)
-	col, err := AsCollection(bucket)
-	require.NoError(t, err)
 	if !ok {
 		t.Fatalf("Requires bucket to be N1QLStore")
 	}
 
 	createExpression := SyncPropertyName + ".sequence"
-	err = n1qlStore.CreateIndex("testIndex_sequence", createExpression, "", testN1qlOptions)
+	err := n1qlStore.CreateIndex("testIndex_sequence", createExpression, "", testN1qlOptions)
 	if err != nil {
 		t.Fatalf("Error creating index: %s", err)
 	}
-	readyErr := col.WaitForIndexesOnline([]string{"testIndex_sequence"}, false)
+	readyErr := n1qlStore.WaitForIndexesOnline([]string{"testIndex_sequence"}, false)
 	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Drop the index
@@ -372,20 +363,18 @@ func TestCreateDuplicateIndex(t *testing.T) {
 
 	bucket := GetTestBucket(t)
 	defer bucket.Close()
-	col, err := AsCollection(bucket)
-	require.NoError(t, err)
 	n1qlStore, ok := AsN1QLStore(bucket)
 	if !ok {
 		t.Fatalf("Requires bucket to be N1QLStore")
 	}
 
 	createExpression := SyncPropertyName + ".sequence"
-	err = n1qlStore.CreateIndex("testIndexDuplicateSequence", createExpression, "", testN1qlOptions)
+	err := n1qlStore.CreateIndex("testIndexDuplicateSequence", createExpression, "", testN1qlOptions)
 	if err != nil {
 		t.Fatalf("Error creating index: %s", err)
 	}
 
-	readyErr := col.WaitForIndexesOnline([]string{"testIndexDuplicateSequence"}, false)
+	readyErr := n1qlStore.WaitForIndexesOnline([]string{"testIndexDuplicateSequence"}, false)
 	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Attempt to create duplicate, validate duplicate error
@@ -406,20 +395,18 @@ func TestCreateAndDropIndexSpecialCharacters(t *testing.T) {
 
 	bucket := GetTestBucket(t)
 	defer bucket.Close()
-	col, err := AsCollection(bucket)
-	require.NoError(t, err)
 	n1qlStore, ok := AsN1QLStore(bucket)
 	if !ok {
 		t.Fatalf("Requires bucket to be N1QLStore")
 	}
 
 	createExpression := SyncPropertyName + ".sequence"
-	err = n1qlStore.CreateIndex("testIndex-sequence", createExpression, "", testN1qlOptions)
+	err := n1qlStore.CreateIndex("testIndex-sequence", createExpression, "", testN1qlOptions)
 	if err != nil {
 		t.Fatalf("Error creating index: %s", err)
 	}
 
-	readyErr := col.WaitForIndexesOnline([]string{"testIndex-sequence"}, false)
+	readyErr := n1qlStore.WaitForIndexesOnline([]string{"testIndex-sequence"}, false)
 	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Drop the index
@@ -436,8 +423,6 @@ func TestDeferredCreateIndex(t *testing.T) {
 
 	bucket := GetTestBucket(t)
 	defer bucket.Close()
-	col, err := AsCollection(bucket)
-	require.NoError(t, err)
 	n1qlStore, ok := AsN1QLStore(bucket)
 	if !ok {
 		t.Fatalf("Requires bucket to be N1QLStore")
@@ -452,7 +437,7 @@ func TestDeferredCreateIndex(t *testing.T) {
 	}
 
 	createExpression := SyncPropertyName + ".sequence"
-	err = n1qlStore.CreateIndex(indexName, createExpression, "", deferN1qlOptions)
+	err := n1qlStore.CreateIndex(indexName, createExpression, "", deferN1qlOptions)
 	if err != nil {
 		t.Fatalf("Error creating index: %s", err)
 	}
@@ -468,7 +453,7 @@ func TestDeferredCreateIndex(t *testing.T) {
 	buildErr := buildIndexes(n1qlStore, []string{indexName})
 	assert.NoError(t, buildErr, "Error building indexes")
 
-	readyErr := col.WaitForIndexesOnline([]string{indexName}, false)
+	readyErr := n1qlStore.WaitForIndexesOnline([]string{indexName}, false)
 	assert.NoError(t, readyErr, "Error validating index online")
 
 }
@@ -480,8 +465,6 @@ func TestBuildDeferredIndexes(t *testing.T) {
 
 	bucket := GetTestBucket(t)
 	defer bucket.Close()
-	col, err := AsCollection(bucket)
-	require.NoError(t, err)
 	n1qlStore, ok := AsN1QLStore(bucket)
 	if !ok {
 		t.Fatalf("Requires bucket to be N1QLStore")
@@ -499,7 +482,7 @@ func TestBuildDeferredIndexes(t *testing.T) {
 
 	// Create a deferred and a non-deferred index
 	createExpression := SyncPropertyName + ".sequence"
-	err = n1qlStore.CreateIndex(deferredIndexName, createExpression, "", deferN1qlOptions)
+	err := n1qlStore.CreateIndex(deferredIndexName, createExpression, "", deferN1qlOptions)
 	if err != nil {
 		t.Errorf("Error creating index: %s", err)
 	}
@@ -527,9 +510,9 @@ func TestBuildDeferredIndexes(t *testing.T) {
 	buildErr := n1qlStore.BuildDeferredIndexes([]string{deferredIndexName, nonDeferredIndexName})
 	assert.NoError(t, buildErr, "Error building indexes")
 
-	readyErr := col.WaitForIndexesOnline([]string{deferredIndexName}, false)
+	readyErr := n1qlStore.WaitForIndexesOnline([]string{deferredIndexName}, false)
 	assert.NoError(t, readyErr, "Error validating index online")
-	readyErr = col.WaitForIndexesOnline([]string{nonDeferredIndexName}, false)
+	readyErr = n1qlStore.WaitForIndexesOnline([]string{nonDeferredIndexName}, false)
 	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Ensure no errors from no-op scenarios
@@ -547,8 +530,6 @@ func TestCreateAndDropIndexErrors(t *testing.T) {
 
 	bucket := GetTestBucket(t)
 	defer bucket.Close()
-	//col, err := AsCollection(bucket)
-	//require.NoError(t, err)
 	n1qlStore, ok := AsN1QLStore(bucket)
 	if !ok {
 		t.Fatalf("Requires bucket to be N1QLStore")
@@ -617,8 +598,6 @@ func TestWaitForBucketExistence(t *testing.T) {
 	defer bucket.Close()
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	col, err := AsCollection(bucket)
-	require.NoError(t, err)
 	n1qlStore, ok := AsN1QLStore(bucket)
 	if !ok {
 		t.Fatalf("Requires bucket to be N1QLStore")
@@ -646,10 +625,10 @@ func TestWaitForBucketExistence(t *testing.T) {
 		wg.Done()
 	}()
 	wg.Wait()
-	assert.NoError(t, col.WaitForIndexesOnline([]string{indexName}, false))
+	assert.NoError(t, n1qlStore.WaitForIndexesOnline([]string{indexName}, false))
 
 	// Drop the index;
-	err = n1qlStore.DropIndex(indexName)
+	err := n1qlStore.DropIndex(indexName)
 	assert.NoError(t, err, "Index should be removed from the bucket")
 }
 

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -465,7 +465,7 @@ func TestDeferredCreateIndex(t *testing.T) {
 		}
 	}()
 
-	buildErr := buildIndexes(bucket, n1qlStore, []string{indexName})
+	buildErr := buildIndexes(n1qlStore, []string{indexName})
 	assert.NoError(t, buildErr, "Error building indexes")
 
 	readyErr := col.WaitForIndexesOnline([]string{indexName}, false)

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -13,7 +13,6 @@ package base
 import (
 	"errors"
 	"fmt"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -596,8 +595,6 @@ func TestWaitForBucketExistence(t *testing.T) {
 
 	bucket := GetTestBucket(t)
 	defer bucket.Close()
-	wg := sync.WaitGroup{}
-	wg.Add(1)
 	n1qlStore, ok := AsN1QLStore(bucket)
 	if !ok {
 		t.Fatalf("Requires bucket to be N1QLStore")
@@ -622,9 +619,7 @@ func TestWaitForBucketExistence(t *testing.T) {
 
 		err = n1qlStore.CreateIndex(indexName, expression, filterExpression, options)
 		assert.NoError(t, err, "Index should be created in the bucket")
-		wg.Done()
 	}()
-	wg.Wait()
 	assert.NoError(t, n1qlStore.WaitForIndexesOnline([]string{indexName}, false))
 
 	// Drop the index;

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -60,7 +60,7 @@ func TestN1qlQuery(t *testing.T) {
 	}
 
 	// Wait for index readiness
-	onlineErr := col.WaitForIndexOnline([]string{"testIndex_value"}, false)
+	onlineErr := col.WaitForIndexesOnline([]string{"testIndex_value"}, false)
 	if onlineErr != nil {
 		t.Fatalf("Error waiting for index to come online: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestN1qlQuery(t *testing.T) {
 		}
 	}()
 
-	readyErr := col.WaitForIndexOnline([]string{"testIndex_value"}, false)
+	readyErr := col.WaitForIndexesOnline([]string{"testIndex_value"}, false)
 	require.NoError(t, readyErr, "Error validating index online")
 
 	// Query the index
@@ -170,7 +170,7 @@ func TestN1qlFilterExpression(t *testing.T) {
 	}
 
 	// Wait for index readiness
-	readyErr := col.WaitForIndexOnline([]string{"testIndex_filtered_value"}, false)
+	readyErr := col.WaitForIndexesOnline([]string{"testIndex_filtered_value"}, false)
 	require.NoError(t, readyErr, "Error validating index online")
 
 	// Defer index teardown
@@ -241,7 +241,7 @@ func TestIndexMeta(t *testing.T) {
 		t.Fatalf("Error creating index: %s", err)
 	}
 
-	readyErr := col.WaitForIndexOnline([]string{"testIndex_value"}, false)
+	readyErr := col.WaitForIndexesOnline([]string{"testIndex_value"}, false)
 	require.NoError(t, readyErr, "Error validating index online")
 
 	// Defer index teardown
@@ -293,7 +293,7 @@ func TestMalformedN1qlQuery(t *testing.T) {
 		t.Fatalf("Error creating index: %s", err)
 	}
 
-	readyErr := col.WaitForIndexOnline([]string{"testIndex_value_malformed"}, false)
+	readyErr := col.WaitForIndexesOnline([]string{"testIndex_value_malformed"}, false)
 	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Defer index teardown
@@ -355,7 +355,7 @@ func TestCreateAndDropIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating index: %s", err)
 	}
-	readyErr := col.WaitForIndexOnline([]string{"testIndex_sequence"}, false)
+	readyErr := col.WaitForIndexesOnline([]string{"testIndex_sequence"}, false)
 	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Drop the index
@@ -385,7 +385,7 @@ func TestCreateDuplicateIndex(t *testing.T) {
 		t.Fatalf("Error creating index: %s", err)
 	}
 
-	readyErr := col.WaitForIndexOnline([]string{"testIndexDuplicateSequence"}, false)
+	readyErr := col.WaitForIndexesOnline([]string{"testIndexDuplicateSequence"}, false)
 	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Attempt to create duplicate, validate duplicate error
@@ -419,7 +419,7 @@ func TestCreateAndDropIndexSpecialCharacters(t *testing.T) {
 		t.Fatalf("Error creating index: %s", err)
 	}
 
-	readyErr := col.WaitForIndexOnline([]string{"testIndex-sequence"}, false)
+	readyErr := col.WaitForIndexesOnline([]string{"testIndex-sequence"}, false)
 	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Drop the index
@@ -465,10 +465,10 @@ func TestDeferredCreateIndex(t *testing.T) {
 		}
 	}()
 
-	buildErr := buildIndexes(n1qlStore, []string{indexName})
+	buildErr := buildIndexes(bucket, n1qlStore, []string{indexName})
 	assert.NoError(t, buildErr, "Error building indexes")
 
-	readyErr := col.WaitForIndexOnline([]string{indexName}, false)
+	readyErr := col.WaitForIndexesOnline([]string{indexName}, false)
 	assert.NoError(t, readyErr, "Error validating index online")
 
 }
@@ -527,9 +527,9 @@ func TestBuildDeferredIndexes(t *testing.T) {
 	buildErr := n1qlStore.BuildDeferredIndexes([]string{deferredIndexName, nonDeferredIndexName})
 	assert.NoError(t, buildErr, "Error building indexes")
 
-	readyErr := col.WaitForIndexOnline([]string{deferredIndexName}, false)
+	readyErr := col.WaitForIndexesOnline([]string{deferredIndexName}, false)
 	assert.NoError(t, readyErr, "Error validating index online")
-	readyErr = col.WaitForIndexOnline([]string{nonDeferredIndexName}, false)
+	readyErr = col.WaitForIndexesOnline([]string{nonDeferredIndexName}, false)
 	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Ensure no errors from no-op scenarios
@@ -646,7 +646,7 @@ func TestWaitForBucketExistence(t *testing.T) {
 		wg.Done()
 	}()
 	wg.Wait()
-	assert.NoError(t, col.WaitForIndexOnline([]string{indexName}, false))
+	assert.NoError(t, col.WaitForIndexesOnline([]string{indexName}, false))
 
 	// Drop the index;
 	err = n1qlStore.DropIndex(indexName)

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -143,6 +143,7 @@ func (c *Collection) WaitForIndexOnline(indexNames []string, watchPrimary bool) 
 		waitChan = true
 		wg.Done()
 	}()
+	// create a separate goroutine to log periodically to console while waiting for watch indexes to complete
 	go func() {
 		for {
 			if !waitChan {

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -24,8 +24,6 @@ import (
 
 var _ N1QLStore = &Collection{}
 
-const waitTime = 5 * time.Second
-
 // IsDefaultScopeCollection returns true if the given Collection is on the _default._default scope and collection.
 func (c *Collection) IsDefaultScopeCollection() bool {
 	return c.ScopeName() == DefaultScope && c.Name() == DefaultCollection

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -141,8 +141,6 @@ func (c *Collection) WaitForIndexOnline(indexNames []string, watchPrimary bool) 
 	go func() {
 		waitErr = mgr.WatchIndexes(c.BucketName(), indexNames, waitTime, &watchOption)
 		waitChan = true
-		g, _ := mgr.GetAllIndexes(c.BucketName(), nil)
-		fmt.Println(g)
 		wg.Done()
 	}()
 	go func() {

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -135,6 +135,7 @@ func (c *Collection) WaitForIndexesOnline(indexNames []string, failfast bool) er
 	indexOption := gocb.GetAllQueryIndexesOptions{
 		ScopeName:      c.ScopeName(),
 		CollectionName: c.Name(),
+		RetryStrategy:  &goCBv2FailFastRetryStrategy{},
 	}
 
 	for {

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -43,7 +43,6 @@ type N1QLStore interface {
 	ExplainQuery(statement string, params map[string]interface{}) (plan map[string]interface{}, err error)
 	GetIndexMeta(indexName string) (exists bool, meta *IndexMeta, err error)
 	Query(statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (results sgbucket.QueryResultIterator, err error)
-	//WaitForIndexOnline(indexName string) error
 	IsErrNoResults(error) bool
 	EscapedKeyspace() string
 	IndexMetaBucketID() string

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -48,7 +48,7 @@ type N1QLStore interface {
 	IndexMetaBucketID() string
 	IndexMetaScopeID() string
 	IndexMetaKeyspaceID() string
-	WaitForIndexesOnline(indexNames []string, watchPrimary bool) error
+	WaitForIndexesOnline(indexNames []string, failfast bool) error
 
 	// executeQuery performs the specified query without any built-in retry handling and returns the resultset
 	executeQuery(statement string) (sgbucket.QueryResultIterator, error)
@@ -174,7 +174,7 @@ func waitForIndexExistence(store N1QLStore, indexName string, shouldExist bool) 
 }
 
 // BuildDeferredIndexes issues a build command for any deferred sync gateway indexes associated with the bucket.
-func BuildDeferredIndexes(bucket Bucket, s N1QLStore, indexSet []string) error {
+func BuildDeferredIndexes(s N1QLStore, indexSet []string) error {
 
 	if len(indexSet) == 0 {
 		return nil

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -240,11 +240,7 @@ func buildIndexes(s N1QLStore, indexNames []string) error {
 	if IsIndexerRetryBuildError(err) {
 		InfofCtx(context.TODO(), KeyQuery, "Indexer error creating index - waiting for background build.  Error:%v", err)
 		// Wait for bucket to be created in background before returning
-		waitErr := s.WaitForIndexesOnline(indexNames, false)
-		if waitErr != nil {
-			return waitErr
-		}
-		return nil
+		return s.WaitForIndexesOnline(indexNames, false)
 	}
 
 	return err

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -173,7 +173,7 @@ func waitForIndexExistence(store N1QLStore, indexName string, shouldExist bool) 
 }
 
 // BuildDeferredIndexes issues a build command for any deferred sync gateway indexes associated with the bucket.
-func BuildDeferredIndexes(s N1QLStore, indexSet []string) error {
+func BuildDeferredIndexes(bucket Bucket, s N1QLStore, indexSet []string) error {
 
 	if len(indexSet) == 0 {
 		return nil
@@ -217,33 +217,35 @@ func BuildDeferredIndexes(s N1QLStore, indexSet []string) error {
 	}
 
 	InfofCtx(context.TODO(), KeyQuery, "Building deferred indexes: %v", deferredIndexes)
-	buildErr := buildIndexes(s, deferredIndexes)
+	buildErr := buildIndexes(bucket, s, deferredIndexes)
 	return buildErr
 }
 
 // BuildIndexes executes a BUILD INDEX statement in the current bucket, using the form:
 //
 //	BUILD INDEX ON `bucket.Name`(`index1`, `index2`, ...)
-func buildIndexes(s N1QLStore, indexNames []string) error {
+func buildIndexes(bucket Bucket, s N1QLStore, indexNames []string) error {
 	if len(indexNames) == 0 {
 		return nil
+	}
+	col, err := AsCollection(bucket)
+	if err != nil {
+		return err
 	}
 
 	// Not using strings.Join because we want to escape each index name
 	indexNameList := StringSliceToN1QLArray(indexNames, "`")
 
 	buildStatement := fmt.Sprintf("BUILD INDEX ON %s(%s)", s.EscapedKeyspace(), indexNameList)
-	err := s.executeStatement(buildStatement)
+	err = s.executeStatement(buildStatement)
 
 	// If indexer reports build will be completed in the background, wait to validate build actually happens.
 	if IsIndexerRetryBuildError(err) {
 		InfofCtx(context.TODO(), KeyQuery, "Indexer error creating index - waiting for background build.  Error:%v", err)
 		// Wait for bucket to be created in background before returning
-		for _, indexName := range indexNames {
-			waitErr := WaitForIndexOnline(s, indexName)
-			if waitErr != nil {
-				return waitErr
-			}
+		waitErr := col.WaitForIndexesOnline(indexNames, false)
+		if waitErr != nil {
+			return waitErr
 		}
 		return nil
 	}
@@ -262,9 +264,9 @@ func WaitForIndexOnline(store N1QLStore, indexName string) error {
 	}
 
 	// Kick off retry loop
-	err, _ := RetryLoop("WaitForIndexOnline", worker, CreateMaxDoublingSleeperFunc(25, 100, 15000))
+	err, _ := RetryLoop("WaitForIndexesOnline", worker, CreateMaxDoublingSleeperFunc(25, 100, 15000))
 	if err != nil {
-		return pkgerrors.Wrapf(err, "WaitForIndexOnline for index %s", MD(indexName).Redact())
+		return pkgerrors.Wrapf(err, "WaitForIndexesOnline for index %s", MD(indexName).Redact())
 	}
 	return nil
 }

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -43,7 +43,7 @@ type N1QLStore interface {
 	ExplainQuery(statement string, params map[string]interface{}) (plan map[string]interface{}, err error)
 	GetIndexMeta(indexName string) (exists bool, meta *IndexMeta, err error)
 	Query(statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (results sgbucket.QueryResultIterator, err error)
-	WaitForIndexOnline(indexName string) error
+	//WaitForIndexOnline(indexName string) error
 	IsErrNoResults(error) bool
 	EscapedKeyspace() string
 	IndexMetaBucketID() string
@@ -241,7 +241,7 @@ func buildIndexes(s N1QLStore, indexNames []string) error {
 		InfofCtx(context.TODO(), KeyQuery, "Indexer error creating index - waiting for background build.  Error:%v", err)
 		// Wait for bucket to be created in background before returning
 		for _, indexName := range indexNames {
-			waitErr := s.WaitForIndexOnline(indexName)
+			waitErr := WaitForIndexOnline(s, indexName)
 			if waitErr != nil {
 				return waitErr
 			}

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -250,24 +250,6 @@ func buildIndexes(s N1QLStore, indexNames []string) error {
 	return err
 }
 
-// WaitForIndexOnline waits for index state to be online
-func WaitForIndexOnline(store N1QLStore, indexName string) error {
-	worker := func() (shouldRetry bool, err error, value interface{}) {
-		exists, indexMeta, getMetaErr := store.GetIndexMeta(indexName)
-		if exists && indexMeta.State == IndexStateOnline {
-			return false, nil, nil
-		}
-		return true, getMetaErr, nil
-	}
-
-	// Kick off retry loop
-	err, _ := RetryLoop("WaitForIndexesOnline", worker, CreateMaxDoublingSleeperFunc(25, 100, 15000))
-	if err != nil {
-		return pkgerrors.Wrapf(err, "WaitForIndexesOnline for index %s", MD(indexName).Redact())
-	}
-	return nil
-}
-
 // IndexMeta represents a Couchbase GSI index.
 type IndexMeta struct {
 	Name      string   `json:"name"`

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -560,7 +560,8 @@ func (b *LeakyBucket) BuildDeferredIndexes(indexSet []string) error {
 	if !ok {
 		return errors.New("Not N1QL Store")
 	}
-	return n1qlStore.BuildDeferredIndexes(indexSet)
+	bucket := b.GetUnderlyingBucket()
+	return BuildDeferredIndexes(bucket, n1qlStore, indexSet)
 }
 
 func (b *LeakyBucket) CreatePrimaryIndex(indexName string, options *N1qlIndexOptions) error {
@@ -577,7 +578,7 @@ func (b *LeakyBucket) WaitForIndexOnline(indexNames []string) error {
 	if err != nil {
 		return err
 	}
-	return col.WaitForIndexOnline(indexNames, false)
+	return col.WaitForIndexesOnline(indexNames, false)
 }
 
 func (b *LeakyBucket) GetIndexMeta(indexName string) (exists bool, meta *IndexMeta, err error) {

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -571,12 +571,13 @@ func (b *LeakyBucket) CreatePrimaryIndex(indexName string, options *N1qlIndexOpt
 	return n1qlStore.CreatePrimaryIndex(indexName, options)
 }
 
-func (b *LeakyBucket) WaitForIndexOnline(indexName string) error {
-	n1qlStore, ok := AsN1QLStore(b.bucket)
-	if !ok {
-		return errors.New("Not N1QL Store")
+func (b *LeakyBucket) WaitForIndexOnline(indexNames []string) error {
+	bucket := b.GetUnderlyingBucket()
+	col, err := AsCollection(bucket)
+	if err != nil {
+		return err
 	}
-	return n1qlStore.WaitForIndexOnline(indexName)
+	return col.WaitForIndexOnline(indexNames, false)
 }
 
 func (b *LeakyBucket) GetIndexMeta(indexName string) (exists bool, meta *IndexMeta, err error) {

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -282,13 +282,13 @@ func (b *LeakyBucket) GetWithXattr(k string, xattr string, userXattrKey string, 
 	return b.bucket.GetWithXattr(k, xattr, userXattrKey, rv, xv, uxv)
 }
 
-func (b *LeakyBucket) WaitForIndexesOnline(indexNames []string, watchPrimary bool) error {
+func (b *LeakyBucket) WaitForIndexesOnline(indexNames []string, failfast bool) error {
 	bucket := b.GetUnderlyingBucket()
 	col, err := AsCollection(bucket)
 	if err != nil {
 		return err
 	}
-	return col.WaitForIndexesOnline(indexNames, watchPrimary)
+	return col.WaitForIndexesOnline(indexNames, failfast)
 }
 
 func (b *LeakyBucket) DeleteWithXattr(k string, xattr string) error {
@@ -569,8 +569,7 @@ func (b *LeakyBucket) BuildDeferredIndexes(indexSet []string) error {
 	if !ok {
 		return errors.New("Not N1QL Store")
 	}
-	bucket := b.GetUnderlyingBucket()
-	return BuildDeferredIndexes(bucket, n1qlStore, indexSet)
+	return BuildDeferredIndexes(n1qlStore, indexSet)
 }
 
 func (b *LeakyBucket) CreatePrimaryIndex(indexName string, options *N1qlIndexOptions) error {
@@ -579,15 +578,6 @@ func (b *LeakyBucket) CreatePrimaryIndex(indexName string, options *N1qlIndexOpt
 		return errors.New("Not N1QL Store")
 	}
 	return n1qlStore.CreatePrimaryIndex(indexName, options)
-}
-
-func (b *LeakyBucket) WaitForIndexOnline(indexNames []string) error {
-	bucket := b.GetUnderlyingBucket()
-	col, err := AsCollection(bucket)
-	if err != nil {
-		return err
-	}
-	return col.WaitForIndexesOnline(indexNames, false)
 }
 
 func (b *LeakyBucket) GetIndexMeta(indexName string) (exists bool, meta *IndexMeta, err error) {

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -283,12 +283,11 @@ func (b *LeakyBucket) GetWithXattr(k string, xattr string, userXattrKey string, 
 }
 
 func (b *LeakyBucket) WaitForIndexesOnline(indexNames []string, failfast bool) error {
-	bucket := b.GetUnderlyingBucket()
-	col, err := AsCollection(bucket)
-	if err != nil {
-		return err
+	n1qlStore, ok := AsN1QLStore(b.bucket)
+	if !ok {
+		return errors.New("Not N1QL Store")
 	}
-	return col.WaitForIndexesOnline(indexNames, failfast)
+	return n1qlStore.WaitForIndexesOnline(indexNames, failfast)
 }
 
 func (b *LeakyBucket) DeleteWithXattr(k string, xattr string) error {

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -282,6 +282,15 @@ func (b *LeakyBucket) GetWithXattr(k string, xattr string, userXattrKey string, 
 	return b.bucket.GetWithXattr(k, xattr, userXattrKey, rv, xv, uxv)
 }
 
+func (b *LeakyBucket) WaitForIndexesOnline(indexNames []string, watchPrimary bool) error {
+	bucket := b.GetUnderlyingBucket()
+	col, err := AsCollection(bucket)
+	if err != nil {
+		return err
+	}
+	return col.WaitForIndexesOnline(indexNames, watchPrimary)
+}
+
 func (b *LeakyBucket) DeleteWithXattr(k string, xattr string) error {
 	return b.bucket.DeleteWithXattr(k, xattr)
 }

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -375,17 +375,13 @@ func InitializeIndexes(bucket base.N1QLStore, useXattrs bool, numReplicas uint, 
 	}
 
 	// Wait for initial readiness queries to complete
-	return waitForIndexes(bucket, useXattrs, failFast)
+	return waitForIndexes(n1QLStore, useXattrs, failFast)
 }
 
 // Issue a consistency=request_plus query against critical indexes to guarantee indexing is complete and indexes are ready.
-func waitForIndexes(bucket base.Bucket, useXattrs, failfast bool) error {
+func waitForIndexes(bucket base.N1QLStore, useXattrs, failfast bool) error {
 	logCtx := context.TODO()
 	base.InfofCtx(logCtx, base.KeyAll, "Verifying index availability for bucket %s...", base.MD(bucket.GetName()))
-	collection, err := base.AsCollection(bucket)
-	if err != nil {
-		return err
-	}
 	var indexes []string
 
 	for _, sgIndex := range sgIndexes {
@@ -396,7 +392,7 @@ func waitForIndexes(bucket base.Bucket, useXattrs, failfast bool) error {
 		indexes = append(indexes, fullIndexName)
 	}
 
-	err = collection.WaitForIndexesOnline(indexes, failfast)
+	err := bucket.WaitForIndexesOnline(indexes, failfast)
 	if err != nil {
 		return err
 	}

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -387,7 +387,7 @@ func waitForIndexes(bucket base.N1QLStore, useXattrs, isServerless, failfast boo
 		if sgIndex.isXattrOnly() && !useXattrs {
 			continue
 		}
-		if sgIndex.creationMode == Serverless && !isServerless {
+		if !sgIndex.shouldCreate(isServerless) {
 			continue
 		}
 		indexes = append(indexes, fullIndexName)

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -367,7 +367,7 @@ func InitializeIndexes(bucket base.N1QLStore, useXattrs bool, numReplicas uint, 
 
 	// Issue BUILD INDEX for any deferred indexes.
 	if len(deferredIndexes) > 0 {
-		buildErr := n1QLStore.BuildDeferredIndexes(deferredIndexes)
+		buildErr := base.BuildDeferredIndexes(bucket, n1QLStore, deferredIndexes)
 		if buildErr != nil {
 			base.InfofCtx(context.TODO(), base.KeyQuery, "Error building deferred indexes.  Error: %v", buildErr)
 			return buildErr
@@ -388,6 +388,9 @@ func waitForIndexes(bucket base.Bucket, useXattrs bool) error {
 	logCtx := context.TODO()
 	base.InfofCtx(logCtx, base.KeyAll, "Verifying index availability for bucket %s...", base.MD(bucket.GetName()))
 	collection, err := base.AsCollection(bucket)
+	if err != nil {
+		return err
+	}
 	var indexes []string
 
 	for _, sgIndex := range sgIndexes {
@@ -398,7 +401,7 @@ func waitForIndexes(bucket base.Bucket, useXattrs bool) error {
 		indexes = append(indexes, fullIndexName)
 	}
 
-	err = collection.WaitForIndexOnline(indexes, false)
+	err = collection.WaitForIndexesOnline(indexes, false)
 	if err != nil {
 		return err
 	}

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -220,16 +220,8 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 	if base.TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
-	col, _ := base.AsCollection(db.Bucket)
-	lol := col.GetCluster().QueryIndexes()
-	indexOption := gocb.GetAllQueryIndexesOptions{
-		ScopeName:      col.ScopeName(),
-		CollectionName: col.Name(),
-	}
-	fmt.Println(lol.GetAllIndexes(db.Bucket.GetName(), &indexOption))
 
 	require.True(t, db.Bucket.IsSupported(sgbucket.DataStoreFeatureN1ql))
 	n1QLStore, ok := base.AsN1QLStore(db.Bucket)

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -18,8 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/couchbase/gocb/v2"
-
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
@@ -83,14 +81,14 @@ func validateAllIndexesOnline(bucket base.Bucket, xattrs, isServerless bool) err
 	if err != nil {
 		return err
 	}
-	cluster := col.GetCluster()
-	mgr := cluster.QueryIndexes()
+	//cluster := col.GetCluster()
+	//mgr := cluster.QueryIndexes()
 
-	watchOption := gocb.WatchQueryIndexOptions{
-		WatchPrimary:   true,
-		ScopeName:      col.ScopeName(),
-		CollectionName: col.Name(),
-	}
+	//watchOption := gocb.WatchQueryIndexOptions{
+	//	WatchPrimary:   true,
+	//	ScopeName:      col.ScopeName(),
+	//	CollectionName: col.Name(),
+	//}
 	// Watch and wait some time for indexes to come online
 	err = mgr.WatchIndexes(bucket.GetName(), sgIndexNames(xattrs, isServerless), 10*time.Second, &watchOption)
 	if err != nil {

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -119,6 +119,7 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	if base.TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/couchbase/gocb/v2"
+
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
@@ -119,7 +120,6 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	if base.TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
@@ -220,8 +220,16 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 	if base.TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
+	col, _ := base.AsCollection(db.Bucket)
+	lol := col.GetCluster().QueryIndexes()
+	indexOption := gocb.GetAllQueryIndexesOptions{
+		ScopeName:      col.ScopeName(),
+		CollectionName: col.Name(),
+	}
+	fmt.Println(lol.GetAllIndexes(db.Bucket.GetName(), &indexOption))
 
 	require.True(t, db.Bucket.IsSupported(sgbucket.DataStoreFeatureN1ql))
 	n1QLStore, ok := base.AsN1QLStore(db.Bucket)

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -286,7 +286,7 @@ func TestCollectionsBasicIndexQuery(t *testing.T) {
 
 	idxName := t.Name() + "_primary"
 	require.NoError(t, n1qlStore.CreatePrimaryIndex(idxName, nil))
-	require.NoError(t, col.WaitForIndexOnline([]string{idxName}, true))
+	require.NoError(t, col.WaitForIndexesOnline([]string{idxName}, true))
 
 	res, err := n1qlStore.Query("SELECT keyspace_id, bucket_id, scope_id from system:indexes WHERE name = $idxName",
 		map[string]interface{}{"idxName": idxName}, base.RequestPlus, true)

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -281,12 +281,10 @@ func TestCollectionsBasicIndexQuery(t *testing.T) {
 	// use the rt.Bucket which has got the foo.bar scope/collection set up
 	n1qlStore, ok := base.AsN1QLStore(rt.Bucket())
 	require.True(t, ok)
-	col, err := base.AsCollection(rt.Bucket())
-	require.NoError(t, err)
 
 	idxName := t.Name() + "_primary"
 	require.NoError(t, n1qlStore.CreatePrimaryIndex(idxName, nil))
-	require.NoError(t, col.WaitForIndexesOnline([]string{idxName}, true))
+	require.NoError(t, n1qlStore.WaitForIndexesOnline([]string{idxName}, false))
 
 	res, err := n1qlStore.Query("SELECT keyspace_id, bucket_id, scope_id from system:indexes WHERE name = $idxName",
 		map[string]interface{}{"idxName": idxName}, base.RequestPlus, true)

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -281,10 +281,12 @@ func TestCollectionsBasicIndexQuery(t *testing.T) {
 	// use the rt.Bucket which has got the foo.bar scope/collection set up
 	n1qlStore, ok := base.AsN1QLStore(rt.Bucket())
 	require.True(t, ok)
+	col, err := base.AsCollection(rt.Bucket())
+	require.NoError(t, err)
 
 	idxName := t.Name() + "_primary"
 	require.NoError(t, n1qlStore.CreatePrimaryIndex(idxName, nil))
-	require.NoError(t, n1qlStore.WaitForIndexOnline(idxName))
+	require.NoError(t, col.WaitForIndexOnline([]string{idxName}, true))
 
 	res, err := n1qlStore.Query("SELECT keyspace_id, bucket_id, scope_id from system:indexes WHERE name = $idxName",
 		map[string]interface{}{"idxName": idxName}, base.RequestPlus, true)


### PR DESCRIPTION
CBG-2470

Gocb v2 has WatchIndexes function that will watch all index given to it till they come online. This PR will remove some of the duplicated code associated with waiting for indexes and replace it with the gocb v2 code available. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1055/
