### PR TITLE
Give server 6.6 a bit more time to get ready

### DIFF
--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -92,9 +92,10 @@ func initV2Cluster(server string) *gocb.Cluster {
 	if err != nil {
 		FatalfCtx(context.TODO(), "Couldn't connect to %q: %v", server, err)
 	}
-	err = cluster.WaitUntilReady(1*time.Minute, nil)
+	const clusterReadyTimeout = 90 * time.Second
+	err = cluster.WaitUntilReady(clusterReadyTimeout, nil)
 	if err != nil {
-		FatalfCtx(context.TODO(), "Cluster not ready: %v", err)
+		FatalfCtx(context.TODO(), "Cluster not ready after %ds: %v", int(clusterReadyTimeout.Seconds()), err)
 	}
 	return cluster
 }


### PR DESCRIPTION
I notice in server 6.6 the first package is not always ready in the given time, so the auth package will fail, but subsequent packages will succeed. https://jenkins.sgwdev.com/job/weekly-matrix/BACKING_STORE=enterprise-6.6.5,QUERY_PROVIDER=views,SYNC_STORE=xattrs,label=sgw-integration-ec2/
