### PR TITLE
CBG-2284: Allow >1 collection on a config despite only using one

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -855,8 +855,7 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 		for scopeName, scopeConfig := range dbConfig.Scopes {
 			// WIP: Collections Phase 1 - Only allow a single collection
 			if len(scopeConfig.Collections) != 1 {
-				multiError = multiError.Append(fmt.Errorf("WIP Collections Phase 1 only supports a single collection - had %d", len(scopeConfig.Collections)))
-				continue
+				base.WarnfCtx(ctx, "WIP Collections Phase 1 only supports a single collection - had %d", len(scopeConfig.Collections))
 			}
 
 			if len(scopeConfig.Collections) == 0 {


### PR DESCRIPTION
CBG-2284

Should unblock other development that relies on setting >1 collection despite not actually using more than 1 collection yet

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1025/
