### PR TITLE
CBG-2508: TestRemovingUserXattr SuspendSequenceBatching

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -6143,6 +6143,8 @@ func TestRemovingUserXattr(t *testing.T) {
 		t.Skipf("test is EE only - user xattrs")
 	}
 
+	defer db.SuspendSequenceBatching()()
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	testCases := []struct {


### PR DESCRIPTION
CBG-2508

Test relies on sequence numbers so we should disable sequence batching for determinism.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1029/
