### PR TITLE
CBG-1891: use dcp stream to resync docs

### DIFF
--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -47,6 +47,7 @@ const (
 // BackgroundManager this is the over-arching type which is exposed in DatabaseContext
 type BackgroundManager struct {
 	BackgroundManagerStatus
+	name                                   string
 	lastError                              error
 	terminator                             *base.SafeTerminator
 	backgroundManagerStatusUpdateWaitGroup sync.WaitGroup
@@ -94,6 +95,11 @@ type BackgroundManagerProcessI interface {
 }
 
 type updateStatusCallbackFunc func() error
+
+// GetName returns name of the background manager
+func (b *BackgroundManager) GetName() string {
+	return b.name
+}
 
 func (b *BackgroundManager) Start(ctx context.Context, options map[string]interface{}) error {
 	err := b.markStart()

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -390,8 +390,7 @@ func (b *BackgroundManager) setRunState(state BackgroundProcessState) {
 	b.State = state
 }
 
-// Currently only test
-func (b *BackgroundManager) GetRunState(t testing.TB) BackgroundProcessState {
+func (b *BackgroundManager) GetRunState() BackgroundProcessState {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 	return b.State

--- a/db/background_mgr_attachment_compaction.go
+++ b/db/background_mgr_attachment_compaction.go
@@ -35,6 +35,7 @@ var _ BackgroundManagerProcessI = &AttachmentCompactionManager{}
 
 func NewAttachmentCompactionManager(metadataStore base.DataStore) *BackgroundManager {
 	return &BackgroundManager{
+		name:    "attachment_compaction",
 		Process: &AttachmentCompactionManager{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
 			metadataStore: metadataStore,

--- a/db/background_mgr_resync.go
+++ b/db/background_mgr_resync.go
@@ -30,6 +30,7 @@ var _ BackgroundManagerProcessI = &ResyncManager{}
 
 func NewResyncManager(metadataStore base.DataStore) *BackgroundManager {
 	return &BackgroundManager{
+		name:    "resync",
 		Process: &ResyncManager{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
 			metadataStore: metadataStore,

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -137,8 +137,11 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 	if err != nil {
 		return err
 	}
-	collectionID := base.DefaultCollectionID
-	collectionIDs := []uint32{collectionID}
+
+	collectionIDs := make([]uint32, 0, len(db.CollectionByID))
+	for collectionID := range db.CollectionByID {
+		collectionIDs = append(collectionIDs, collectionID)
+	}
 
 	clientOptions, err := getReSyncDCPClientOptions(collectionIDs, db.Options.GroupID)
 	if err != nil {

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -1,0 +1,284 @@
+//  Copyright 2012-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/google/uuid"
+)
+
+// =====================================================================
+// Resync Implementation of Background Manager Process using DCP stream
+// =====================================================================
+
+type ResyncManagerDCP struct {
+	DocsProcessed base.AtomicInt
+	DocsChanged   base.AtomicInt
+	ResyncID      string
+	VBUUIDs       []uint64
+	lock          sync.Mutex
+}
+
+var _ BackgroundManagerProcessI = &ResyncManagerDCP{}
+
+func NewResyncManagerDCP(metadataStore base.DataStore) *BackgroundManager {
+	return &BackgroundManager{
+		Process: &ResyncManagerDCP{},
+		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+			metadataStore: metadataStore,
+			processSuffix: "resync",
+		},
+		terminator: base.NewSafeTerminator(),
+	}
+}
+
+func (r *ResyncManagerDCP) Init(ctx context.Context, options map[string]interface{}, clusterStatus []byte) error {
+	newRunInit := func() error {
+		uniqueUUID, err := uuid.NewRandom()
+		if err != nil {
+			return err
+		}
+
+		r.ResyncID = uniqueUUID.String()
+		base.InfofCtx(ctx, base.KeyAll, "Resync: Starting new resync run with resync ID: %q", r.ResyncID)
+		return nil
+	}
+
+	if clusterStatus != nil {
+		var statusDoc ResyncManagerStatusDocDCP
+		err := base.JSONUnmarshal(clusterStatus, &statusDoc)
+
+		reset, ok := options["reset"].(bool)
+		if reset && ok {
+			base.InfofCtx(ctx, base.KeyAll, "Resync: Resetting resync process. Will not  resume any "+
+				"partially completed process")
+		}
+
+		// If the previous run completed, or there was an error during unmarshalling the status we will start the
+		// process from scratch with a new resync ID. Otherwise, we should resume with the resync ID, stats specified in the doc.
+		if statusDoc.State == BackgroundProcessStateCompleted || err != nil || (reset && ok) {
+			return newRunInit()
+		} else {
+			r.ResyncID = statusDoc.ResyncID
+			r.DocsChanged.Set(int64(statusDoc.DocsChanged))
+			r.DocsProcessed.Set(int64(statusDoc.DocsProcessed))
+			r.VBUUIDs = statusDoc.VBUUIDs
+
+			base.InfofCtx(ctx, base.KeyAll, "Resync: Attempting to resume resync with resycn ID: %q", r.ResyncID)
+		}
+
+		return nil
+	}
+
+	return newRunInit()
+}
+
+func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface{}, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
+	db := options["database"].(*Database)
+	regenerateSequences := options["regenerateSequences"].(bool)
+
+	resyncLoggingID := "Resync: " + r.ResyncID
+
+	persistClusterStatus := func() {
+		err := persistClusterStatusCallback()
+		r.SetStats(int(r.DocsProcessed.Value()), int(r.DocsChanged.Value()))
+		if err != nil {
+			base.WarnfCtx(ctx, "[%s] Failed to persist cluster status on-demand for resync operation: %v", resyncLoggingID, err)
+		}
+	}
+	defer persistClusterStatus()
+
+	defer atomic.CompareAndSwapUint32(&db.State, DBResyncing, DBOffline)
+
+	callback := func(event sgbucket.FeedEvent) bool {
+		var err error
+		docID := string(event.Key)
+		key := realDocID(docID)
+		base.TracefCtx(ctx, base.KeyAll, "[%s] Received DCP event %d for doc %v", resyncLoggingID, event.Opcode, base.UD(docID))
+		// Don't want to process raw binary docs
+		// The binary check should suffice but for additional safety also check for empty bodies
+		if event.DataType == base.MemcachedDataTypeRaw || len(event.Value) == 0 {
+			return true
+		}
+
+		// We only want to process full docs. Not any sync docs.
+		if strings.HasPrefix(docID, base.SyncDocPrefix) {
+			return true
+		}
+
+		r.DocsProcessed.Add(1)
+
+		databaseCollection := db.CollectionByID[event.CollectionID]
+		_, unusedSequences, err := (&DatabaseCollectionWithUser{
+			DatabaseCollection: databaseCollection,
+		}).updateDocument(ctx, docID, key, regenerateSequences, []uint64{})
+
+		databaseCollection.releaseSequences(ctx, unusedSequences)
+
+		if err == nil {
+			r.DocsChanged.Add(1)
+		} else if err != base.ErrUpdateCancel {
+			base.WarnfCtx(ctx, "[%s] Error updating doc %q: %v", resyncLoggingID, base.UD(docID), err)
+		}
+		return true
+	}
+
+	collection, err := base.AsGocbV2Bucket(db.Bucket)
+	if err != nil {
+		return err
+	}
+	collectionID := base.DefaultCollectionID
+	collectionIDs := []uint32{collectionID}
+
+	clientOptions, err := getReSyncDCPClientOptions(collectionIDs, db.Options.GroupID)
+	if err != nil {
+		return err
+	}
+	clientOptions.InitialMetadata = base.BuildDCPMetadataSliceFromVBUUIDs(r.VBUUIDs)
+
+	dcpFeedKey := generateResyncDCPStreamName(r.ResyncID)
+	base.InfofCtx(ctx, base.KeyAll, "[%s] Starting DCP feed %q for resync", resyncLoggingID, dcpFeedKey)
+	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, *clientOptions, collection)
+	if err != nil {
+		base.WarnfCtx(ctx, "[%s] Failed to create resync DCP client! %v", resyncLoggingID, err)
+		return err
+	}
+
+	doneChan, err := dcpClient.Start()
+	if err != nil {
+		base.WarnfCtx(ctx, "[%s] Failed to start resync DCP feed! %v", resyncLoggingID, err)
+		_ = dcpClient.Close()
+		return err
+	}
+	base.DebugfCtx(ctx, base.KeyAll, "[%s] DCP client started.", resyncLoggingID)
+
+	select {
+	case <-doneChan:
+		base.InfofCtx(ctx, base.KeyAll, "[%s] Finished re-running sync function. %d/%d docs changed", resyncLoggingID, r.DocsChanged.Value(), r.DocsProcessed.Value())
+		err = dcpClient.Close()
+		if err != nil {
+			base.WarnfCtx(ctx, "[%s] Failed to close resync DCP client! %v", resyncLoggingID, err)
+			return err
+		}
+
+		if regenerateSequences {
+			var err error
+			for _, databaseCollection := range db.CollectionByID {
+				if updateErr := databaseCollection.updateAllPrincipalsSequences(ctx); updateErr != nil {
+					err = updateErr
+				}
+			}
+
+			if err != nil {
+				return err
+			}
+		}
+
+		if r.DocsChanged.Value() > 0 {
+			endSeq, err := db.sequences.getSequence()
+			if err != nil {
+				return err
+			}
+			for _, databaseCollection := range db.CollectionByID {
+				databaseCollection.invalidateAllPrincipalsCache(ctx, endSeq)
+			}
+
+		}
+	case <-terminator.Done():
+		base.DebugfCtx(ctx, base.KeyAll, "[%s] Terminator closed. Ending Resync process.", resyncLoggingID)
+		err = dcpClient.Close()
+		if err != nil {
+			base.WarnfCtx(ctx, "[%s] Failed to close resync DCP client! %v", resyncLoggingID, err)
+			return err
+		}
+
+		err = <-doneChan
+		if err != nil {
+			return err
+		}
+
+		base.InfofCtx(ctx, base.KeyAll, "[%s] resync was terminated. Docs changed: %d Docs Processed: %d", resyncLoggingID, r.DocsChanged.Value(), r.DocsProcessed.Value())
+	}
+
+	return nil
+}
+
+func (r *ResyncManagerDCP) ResetStatus() {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.DocsProcessed.Set(0)
+	r.DocsChanged.Set(0)
+}
+
+func (r *ResyncManagerDCP) SetStats(docsProcessed, docsChanged int) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.DocsProcessed.Set(int64(docsProcessed))
+	r.DocsChanged.Set(int64(docsChanged))
+}
+
+type ResyncManagerResponseDCP struct {
+	BackgroundManagerStatus
+	ResyncID      string `json:"resync_id"`
+	DocsChanged   int    `json:"docs_changed"`
+	DocsProcessed int    `json:"docs_processed"`
+}
+
+func (r *ResyncManagerDCP) GetProcessStatus(backgroundManagerStatus BackgroundManagerStatus) ([]byte, []byte, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	restStatus := ResyncManagerResponseDCP{
+		BackgroundManagerStatus: backgroundManagerStatus,
+		ResyncID:                r.ResyncID,
+		DocsChanged:             int(r.DocsChanged.Value()),
+		DocsProcessed:           int(r.DocsProcessed.Value()),
+	}
+
+	statusJSON, err := base.JSONMarshal(restStatus)
+	return statusJSON, nil, err
+}
+
+type ResyncManagerMeta struct {
+	VBUUIDs []uint64 `json:"vbuuids"`
+}
+
+type ResyncManagerStatusDocDCP struct {
+	ResyncManagerResponseDCP `json:"status"`
+	ResyncManagerMeta        `json:"meta"`
+}
+
+// getReSyncDCPClientOptions returns the default set of DCPClientOptions suitable for resync
+func getReSyncDCPClientOptions(collectionIDs []uint32, groupID string) (*base.DCPClientOptions, error) {
+	clientOptions := &base.DCPClientOptions{
+		OneShot:           true,
+		FailOnRollback:    true,
+		MetadataStoreType: base.DCPMetadataStoreCS,
+		GroupID:           groupID,
+		CollectionIDs:     collectionIDs,
+	}
+	return clientOptions, nil
+
+}
+
+func generateResyncDCPStreamName(resyncID string) string {
+	return fmt.Sprintf(
+		"sg-%v:resync:%v",
+		base.ProductAPIVersion,
+		resyncID)
+}

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -36,6 +36,7 @@ var _ BackgroundManagerProcessI = &ResyncManagerDCP{}
 
 func NewResyncManagerDCP(metadataStore base.DataStore) *BackgroundManager {
 	return &BackgroundManager{
+		name:    "resync",
 		Process: &ResyncManagerDCP{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
 			metadataStore: metadataStore,

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -63,8 +63,7 @@ func (r *ResyncManagerDCP) Init(ctx context.Context, options map[string]interfac
 
 		reset, ok := options["reset"].(bool)
 		if reset && ok {
-			base.InfofCtx(ctx, base.KeyAll, "Resync: Resetting resync process. Will not  resume any "+
-				"partially completed process")
+			base.InfofCtx(ctx, base.KeyAll, "Resync: Resetting resync process. Will not resume any partially completed process")
 		}
 
 		// If the previous run completed, or there was an error during unmarshalling the status we will start the
@@ -75,7 +74,7 @@ func (r *ResyncManagerDCP) Init(ctx context.Context, options map[string]interfac
 			r.ResyncID = statusDoc.ResyncID
 			r.SetStatus(statusDoc.DocsChanged, statusDoc.DocsProcessed)
 
-			base.InfofCtx(ctx, base.KeyAll, "Resync: Attempting to resume resync with resycn ID: %s", r.ResyncID)
+			base.InfofCtx(ctx, base.KeyAll, "Resync: Attempting to resume resync with resync ID: %s", r.ResyncID)
 		}
 
 		return nil
@@ -121,7 +120,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 		databaseCollection := db.CollectionByID[event.CollectionID]
 		_, unusedSequences, err := (&DatabaseCollectionWithUser{
 			DatabaseCollection: databaseCollection,
-		}).updateDocument(ctx, docID, key, regenerateSequences, []uint64{})
+		}).resyncDocument(ctx, docID, key, regenerateSequences, []uint64{})
 
 		databaseCollection.releaseSequences(ctx, unusedSequences)
 

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -1,0 +1,297 @@
+//  Copyright 2012-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResyncDCPInit(t *testing.T) {
+
+	testCases := []struct {
+		title               string
+		initialClusterState ResyncManagerStatusDocDCP
+		forceReset          bool
+		shouldCreateNewRun  bool
+	}{
+		{
+			title:              "Initialize new run with empty cluster state",
+			forceReset:         false,
+			shouldCreateNewRun: true,
+		},
+		{
+			title: "Reinitialize existing run",
+			initialClusterState: ResyncManagerStatusDocDCP{
+				ResyncManagerResponseDCP: ResyncManagerResponseDCP{
+					BackgroundManagerStatus: BackgroundManagerStatus{
+						State: BackgroundProcessStateStopped,
+					},
+					ResyncID:      uuid.NewString(),
+					DocsChanged:   10,
+					DocsProcessed: 20,
+				},
+				ResyncManagerMeta: ResyncManagerMeta{
+					VBUUIDs: []uint64{1},
+				},
+			},
+			forceReset:         false,
+			shouldCreateNewRun: false,
+		},
+		{
+			title: "Reinitialize completed run",
+			initialClusterState: ResyncManagerStatusDocDCP{
+				ResyncManagerResponseDCP: ResyncManagerResponseDCP{
+					BackgroundManagerStatus: BackgroundManagerStatus{
+						State: BackgroundProcessStateCompleted,
+					},
+					ResyncID:      uuid.NewString(),
+					DocsChanged:   10,
+					DocsProcessed: 20,
+				},
+				ResyncManagerMeta: ResyncManagerMeta{
+					VBUUIDs: []uint64{1},
+				},
+			},
+			forceReset:         false,
+			shouldCreateNewRun: true,
+		},
+		{
+			title: "Force restart existing run",
+			initialClusterState: ResyncManagerStatusDocDCP{
+				ResyncManagerResponseDCP: ResyncManagerResponseDCP{
+					BackgroundManagerStatus: BackgroundManagerStatus{
+						State: BackgroundProcessStateStopped,
+					},
+					ResyncID:      uuid.NewString(),
+					DocsChanged:   10,
+					DocsProcessed: 20,
+				},
+				ResyncManagerMeta: ResyncManagerMeta{
+					VBUUIDs: []uint64{1},
+				},
+			},
+			forceReset:         true,
+			shouldCreateNewRun: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.title, func(t *testing.T) {
+			db, ctx := setupTestDB(t)
+			defer db.Close(ctx)
+
+			resyncMrg := NewResyncManagerDCP(db.Bucket)
+			require.NotNil(t, resyncMrg)
+
+			// this gets called by background manager in each Start call.
+			// We have to manually call this for tests only to reset docsChanged/docsProcessed counters
+			defer resyncMrg.resetStatus()
+
+			options := make(map[string]interface{})
+			if testCase.forceReset {
+				options["reset"] = true
+			}
+
+			var clusterData []byte
+			var err error
+
+			// Only marshal initialClusterState if clusterState is set to non empty struct
+			// otherwise clusterData is zero value of ResyncManagerStatusDocDCP
+			// which make `Init` to reinitialize run from existing cluster data
+			if testCase.initialClusterState.ResyncID != "" {
+				clusterData, err = json.Marshal(testCase.initialClusterState)
+				require.NoError(t, err)
+			}
+
+			err = resyncMrg.Process.Init(context.TODO(), options, clusterData)
+			require.NoError(t, err)
+			rawStatus, err := resyncMrg.GetStatus()
+			require.NoError(t, err)
+
+			var response ResyncManagerResponseDCP
+			err = json.Unmarshal(rawStatus, &response)
+			assert.NoError(t, err)
+
+			assert.NotEmpty(t, response.ResyncID)
+
+			if testCase.shouldCreateNewRun {
+				assert.NotEqual(t, testCase.initialClusterState.ResyncID, response.ResyncID)
+				assert.Equal(t, 0, response.DocsChanged)
+				assert.Equal(t, 0, response.DocsProcessed)
+			} else {
+				assert.Equal(t, testCase.initialClusterState.ResyncID, response.ResyncID)
+				assert.Equal(t, testCase.initialClusterState.DocsChanged, response.DocsChanged)
+				assert.Equal(t, testCase.initialClusterState.DocsProcessed, response.DocsProcessed)
+			}
+		})
+	}
+}
+
+func TestResycnManagerDCPStopInMidWay(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Test requires Couchbase Server")
+	}
+	base.LongRunningTest(t)
+
+	docsToCreate := 10_000
+	db, ctx := setupTestDBForResyncWithDocs(t, docsToCreate, true)
+	defer db.Close(ctx)
+
+	resyncMrg := NewResyncManagerDCP(db.Bucket)
+	require.NotNil(t, resyncMrg)
+	defer resyncMrg.resetStatus()
+
+	options := make(map[string]interface{})
+	options["database"] = db
+	options["regenerateSequences"] = false
+
+	err := resyncMrg.Start(ctx, options)
+	require.NoError(t, err)
+	go func() {
+		time.Sleep(2 * time.Second)
+		_ = resyncMrg.Stop()
+	}()
+
+	err = WaitForConditionWithOptions(func() bool {
+		var status BackgroundManagerStatus
+		rawStatus, _ := resyncMrg.GetStatus()
+		_ = json.Unmarshal(rawStatus, &status)
+		return status.State == BackgroundProcessStateStopped
+	}, 2000, 10)
+	require.NoError(t, err)
+	// Give some time to persist stats
+	time.Sleep(1 * time.Second)
+
+	stats := getResyncStats(resyncMrg.Process)
+	assert.Less(t, stats.DocsProcessed, docsToCreate, "DocsProcessed is equal to docs created. Consider setting docsToCreate > %d.", docsToCreate)
+	assert.Less(t, stats.DocsChanged, docsToCreate)
+
+	assert.Less(t, int(db.DbStats.Database().SyncFunctionCount.Value()), docsToCreate)
+}
+
+func TestResycnManagerDCP(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Test requires Couchbase Server")
+	}
+	base.LongRunningTest(t)
+
+	t.Run("Resync without updating resync function", func(t *testing.T) {
+		docsToCreate := 100
+		db, ctx := setupTestDBForResyncWithDocs(t, docsToCreate, false)
+		defer db.Close(ctx)
+
+		resyncMrg := NewResyncManagerDCP(db.Bucket)
+		require.NotNil(t, resyncMrg)
+
+		options := make(map[string]interface{})
+		options["database"] = db
+		options["regenerateSequences"] = false
+
+		err := resyncMrg.Start(ctx, options)
+		require.NoError(t, err)
+
+		err = WaitForConditionWithOptions(func() bool {
+			var status BackgroundManagerStatus
+			rawStatus, _ := resyncMrg.GetStatus()
+			_ = json.Unmarshal(rawStatus, &status)
+			return status.State == BackgroundProcessStateCompleted
+		}, 20, 100)
+		require.NoError(t, err)
+
+		stats := getResyncStats(resyncMrg.Process)
+		assert.Equal(t, docsToCreate, stats.DocsProcessed)
+		assert.Equal(t, 0, stats.DocsChanged)
+
+		assert.Equal(t, int(db.DbStats.Database().SyncFunctionCount.Value()), docsToCreate)
+	})
+
+	t.Run("Resync with updated resync function", func(t *testing.T) {
+		docsToCreate := 100
+		db, ctx := setupTestDBForResyncWithDocs(t, docsToCreate, true)
+		defer db.Close(ctx)
+
+		resyncMrg := NewResyncManagerDCP(db.Bucket)
+		require.NotNil(t, resyncMrg)
+
+		options := make(map[string]interface{})
+		options["database"] = db
+		options["regenerateSequences"] = false
+
+		err := resyncMrg.Start(ctx, options)
+		require.NoError(t, err)
+
+		err = WaitForConditionWithOptions(func() bool {
+			var status BackgroundManagerStatus
+			rawStatus, _ := resyncMrg.GetStatus()
+			_ = json.Unmarshal(rawStatus, &status)
+			return status.State == BackgroundProcessStateCompleted
+		}, 20, 100)
+		require.NoError(t, err)
+
+		stats := getResyncStats(resyncMrg.Process)
+		assert.Equal(t, docsToCreate, stats.DocsProcessed)
+		assert.Equal(t, docsToCreate, stats.DocsChanged)
+
+		assert.Equal(t, docsToCreate, int(db.DbStats.Database().SyncFunctionCount.Value()))
+	})
+}
+
+func setupTestDBForResyncWithDocs(t *testing.T, docsToCreate int, updateResyncFuncAfterDocsAdded bool) (*Database, context.Context) {
+	db, ctx := setupTestDB(t)
+	db.Options.QueryPaginationLimit = 100
+	syncFn := `
+function sync(doc, oldDoc){
+	channel("channel." + "ABC");
+}
+`
+	_, err := db.UpdateSyncFun(ctx, syncFn)
+	require.NoError(t, err)
+
+	collection := db.GetSingleDatabaseCollectionWithUser()
+
+	// Create the docs that will be marked and not swept
+	body := map[string]interface{}{"foo": "bar"}
+	for i := 0; i < docsToCreate; i++ {
+		key := fmt.Sprintf("%s_%d", t.Name(), i)
+		_, _, err := collection.Put(ctx, key, body)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, docsToCreate, int(db.DbStats.Database().SyncFunctionCount.Value()))
+	db.DbStats.Database().SyncFunctionCount.Set(0)
+
+	if updateResyncFuncAfterDocsAdded {
+		syncFn = `
+function sync(doc, oldDoc){
+	channel("channel." + "ABC123");
+}
+`
+
+		_, err = db.UpdateSyncFun(ctx, syncFn)
+		require.NoError(t, err)
+	}
+	return db, ctx
+}
+
+// helper function to Unmarshal BackgroundProcess state into ResyncManagerResponseDCP
+func getResyncStats(resyncManager BackgroundManagerProcessI) ResyncManagerResponseDCP {
+	var resp ResyncManagerResponseDCP
+	rawStatus, _, _ := resyncManager.GetProcessStatus(BackgroundManagerStatus{})
+	_ = json.Unmarshal(rawStatus, &resp)
+	return resp
+}

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -207,7 +207,7 @@ func TestResycnManagerDCPStart(t *testing.T) {
 			rawStatus, _ := resyncMrg.GetStatus()
 			_ = json.Unmarshal(rawStatus, &status)
 			return status.State == BackgroundProcessStateCompleted
-		}, 20, 100)
+		}, 30, 100)
 		require.NoError(t, err)
 
 		stats := getResyncStats(resyncMrg.Process)
@@ -237,7 +237,7 @@ func TestResycnManagerDCPStart(t *testing.T) {
 			rawStatus, _ := resyncMrg.GetStatus()
 			_ = json.Unmarshal(rawStatus, &status)
 			return status.State == BackgroundProcessStateCompleted
-		}, 20, 100)
+		}, 30, 100)
 		require.NoError(t, err)
 
 		stats := getResyncStats(resyncMrg.Process)

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -138,7 +138,9 @@ func TestResyncDCPInit(t *testing.T) {
 	}
 }
 
-func TestResycnManagerDCPStopInMidWay(t *testing.T) {
+func TestResyncManagerDCPStopInMidWay(t *testing.T) {
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
+
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server")
 	}
@@ -189,10 +191,11 @@ func TestResycnManagerDCPStopInMidWay(t *testing.T) {
 }
 
 func TestResyncManagerDCPStart(t *testing.T) {
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
+
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server")
 	}
-	base.LongRunningTest(t)
 
 	t.Run("Resync without updating sync function", func(t *testing.T) {
 		docsToCreate := 100
@@ -215,7 +218,7 @@ func TestResyncManagerDCPStart(t *testing.T) {
 			rawStatus, _ := resycMgr.GetStatus()
 			_ = json.Unmarshal(rawStatus, &status)
 			return status.State == BackgroundProcessStateCompleted
-		}, 30, 200)
+		}, 200, 200)
 		require.NoError(t, err)
 
 		stats := getResyncStats(resycMgr.Process)
@@ -244,7 +247,7 @@ func TestResyncManagerDCPStart(t *testing.T) {
 			rawStatus, _ := resycMgr.GetStatus()
 			_ = json.Unmarshal(rawStatus, &status)
 			return status.State == BackgroundProcessStateCompleted
-		}, 30, 200)
+		}, 200, 200)
 		require.NoError(t, err)
 
 		stats := getResyncStats(resycMgr.Process)
@@ -256,7 +259,9 @@ func TestResyncManagerDCPStart(t *testing.T) {
 	})
 }
 
-func TestResycnManagerDCPRunTwice(t *testing.T) {
+func TestResyncManagerDCPRunTwice(t *testing.T) {
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
+
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server")
 	}
@@ -306,6 +311,8 @@ func TestResycnManagerDCPRunTwice(t *testing.T) {
 }
 
 func TestResycnManagerDCPResumeStoppedProcess(t *testing.T) {
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
+
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server")
 	}

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -97,6 +97,7 @@ func TestResyncDCPInit(t *testing.T) {
 
 			resyncMrg := NewResyncManagerDCP(db.Bucket)
 			require.NotNil(t, resyncMrg)
+			db.ResyncManager = resyncMrg
 
 			// this gets called by background manager in each Start call.
 			// We have to manually call this for tests only to reset docsChanged/docsProcessed counters
@@ -149,6 +150,7 @@ func TestResycnManagerDCPStopInMidWay(t *testing.T) {
 
 	resyncMrg := NewResyncManagerDCP(db.Bucket)
 	require.NotNil(t, resyncMrg)
+	db.ResyncManager = resyncMrg
 	defer resyncMrg.resetStatus()
 
 	options := make(map[string]interface{})
@@ -191,6 +193,7 @@ func TestResycnManagerDCPStart(t *testing.T) {
 
 		resyncMrg := NewResyncManagerDCP(db.Bucket)
 		require.NotNil(t, resyncMrg)
+		db.ResyncManager = resyncMrg
 
 		options := make(map[string]interface{})
 		options["database"] = db
@@ -257,6 +260,7 @@ func TestResycnManagerDCPRunTwice(t *testing.T) {
 
 	resyncMrg := NewResyncManagerDCP(db.Bucket)
 	require.NotNil(t, resyncMrg)
+	db.ResyncManager = resyncMrg
 
 	options := make(map[string]interface{})
 	options["database"] = db
@@ -306,6 +310,7 @@ func TestResycnManagerDCPResumeStoppedProcess(t *testing.T) {
 
 	resyncMrg := NewResyncManagerDCP(db.Bucket)
 	require.NotNil(t, resyncMrg)
+	db.ResyncManager = resyncMrg
 
 	options := make(map[string]interface{})
 	options["database"] = db

--- a/db/background_mgr_tombstone_compaction.go
+++ b/db/background_mgr_tombstone_compaction.go
@@ -28,6 +28,7 @@ var _ BackgroundManagerProcessI = &TombstoneCompactionManager{}
 
 func NewTombstoneCompactionManager() *BackgroundManager {
 	return &BackgroundManager{
+		name:       "tombstone_compaction",
 		Process:    &TombstoneCompactionManager{},
 		terminator: base.NewSafeTerminator(),
 	}

--- a/db/database.go
+++ b/db/database.go
@@ -210,17 +210,18 @@ type APIEndpoints struct {
 
 // UnsupportedOptions are not supported for external use
 type UnsupportedOptions struct {
-	UserViews                 *UserViewsOptions        `json:"user_views,omitempty"`                    // Config settings for user views
-	OidcTestProvider          *OidcTestProviderOptions `json:"oidc_test_provider,omitempty"`            // Config settings for OIDC Provider
-	APIEndpoints              *APIEndpoints            `json:"api_endpoints,omitempty"`                 // Config settings for API endpoints
-	WarningThresholds         *WarningThresholds       `json:"warning_thresholds,omitempty"`            // Warning thresholds related to _sync size
-	DisableCleanSkippedQuery  bool                     `json:"disable_clean_skipped_query,omitempty"`   // Clean skipped sequence processing bypasses final check
-	OidcTlsSkipVerify         bool                     `json:"oidc_tls_skip_verify,omitempty"`          // Config option to enable self-signed certs for OIDC testing.
-	SgrTlsSkipVerify          bool                     `json:"sgr_tls_skip_verify,omitempty"`           // Config option to enable self-signed certs for SG-Replicate testing.
-	RemoteConfigTlsSkipVerify bool                     `json:"remote_config_tls_skip_verify,omitempty"` // Config option to enable self signed certificates for external JavaScript load.
-	GuestReadOnly             bool                     `json:"guest_read_only,omitempty"`               // Config option to restrict GUEST document access to read-only
-	ForceAPIForbiddenErrors   bool                     `json:"force_api_forbidden_errors,omitempty"`    // Config option to force the REST API to return forbidden errors
-	ConnectedClient           bool                     `json:"connected_client,omitempty"`              // Enables BLIP connected-client APIs
+	UserViews                  *UserViewsOptions        `json:"user_views,omitempty"`                    // Config settings for user views
+	OidcTestProvider           *OidcTestProviderOptions `json:"oidc_test_provider,omitempty"`            // Config settings for OIDC Provider
+	APIEndpoints               *APIEndpoints            `json:"api_endpoints,omitempty"`                 // Config settings for API endpoints
+	WarningThresholds          *WarningThresholds       `json:"warning_thresholds,omitempty"`            // Warning thresholds related to _sync size
+	DisableCleanSkippedQuery   bool                     `json:"disable_clean_skipped_query,omitempty"`   // Clean skipped sequence processing bypasses final check
+	OidcTlsSkipVerify          bool                     `json:"oidc_tls_skip_verify,omitempty"`          // Config option to enable self-signed certs for OIDC testing.
+	SgrTlsSkipVerify           bool                     `json:"sgr_tls_skip_verify,omitempty"`           // Config option to enable self-signed certs for SG-Replicate testing.
+	RemoteConfigTlsSkipVerify  bool                     `json:"remote_config_tls_skip_verify,omitempty"` // Config option to enable self signed certificates for external JavaScript load.
+	GuestReadOnly              bool                     `json:"guest_read_only,omitempty"`               // Config option to restrict GUEST document access to read-only
+	ForceAPIForbiddenErrors    bool                     `json:"force_api_forbidden_errors,omitempty"`    // Config option to force the REST API to return forbidden errors
+	ConnectedClient            bool                     `json:"connected_client,omitempty"`              // Enables BLIP connected-client APIs
+	UseQueryBasedResyncManager bool                     `json:"use_query_resync_manager,omitempty"`      // Config option to use Query based resync manager to perform Resync op
 }
 
 type WarningThresholds struct {
@@ -676,7 +677,11 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		// No cleanup necessary, stop heartbeater above will take care of it
 	}
 
-	dbContext.ResyncManager = NewResyncManagerDCP(metadataStore)
+	if dbContext.UseQueryBasedResyncManager() {
+		dbContext.ResyncManager = NewResyncManager(metadataStore)
+	} else {
+		dbContext.ResyncManager = NewResyncManagerDCP(metadataStore)
+	}
 	dbContext.TombstoneCompactionManager = NewTombstoneCompactionManager()
 	dbContext.AttachmentCompactionManager = NewAttachmentCompactionManager(metadataStore)
 
@@ -2052,6 +2057,14 @@ func (context *DatabaseContext) UseXattrs() bool {
 
 func (context *DatabaseContext) UseViews() bool {
 	return context.Options.UseViews
+}
+
+// UseQueryBasedResyncManager returns if query bases resync manager should be used for Resync operation
+func (context *DatabaseContext) UseQueryBasedResyncManager() bool {
+	if context.Options.UnsupportedOptions != nil {
+		return context.Options.UnsupportedOptions.UseQueryBasedResyncManager
+	}
+	return false
 }
 
 func (context *DatabaseContext) DeltaSyncEnabled() bool {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2514,7 +2514,7 @@ func TestTombstoneCompactionStopWithManager(t *testing.T) {
 	assert.NoError(t, db.TombstoneCompactionManager.Start(ctx, map[string]interface{}{"database": db}))
 
 	waitAndAssertConditionWithOptions(t, func() bool {
-		return db.TombstoneCompactionManager.GetRunState(t) == BackgroundProcessStateStopped
+		return db.TombstoneCompactionManager.GetRunState() == BackgroundProcessStateStopped
 	}, 60, 1000)
 
 	var tombstoneCompactionStatus TombstoneManagerResponse

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2702,12 +2702,20 @@ func Test_invalidateAllPrincipalsCache(t *testing.T) {
 	err = collection.WaitForPendingChanges(ctx)
 	assert.NoError(t, err)
 
-	t.Logf("Datastore name: %s", collection.dataStore.GetName())
-
 	if base.TestsUseNamedCollections() {
 		dataStoreName := collection.dataStore.GetName()
-		dataStoreNameSlice := strings.Split(dataStoreName, ":")
-		scopeName, collectionName := dataStoreNameSlice[0], dataStoreNameSlice[1]
+		var scopeName, collectionName string
+		if base.UnitTestUrlIsWalrus() {
+			// Format: sg_test_0:sg_test_0
+			dataStoreNameSlice := strings.Split(dataStoreName, ":")
+			require.Len(t, dataStoreNameSlice, 2)
+			scopeName, collectionName = dataStoreNameSlice[0], dataStoreNameSlice[1]
+		} else {
+			// Format: sg_int_0_1671048846916047000.sg_test_0.sg_test_0
+			dataStoreNameSlice := strings.Split(dataStoreName, ".")
+			require.Len(t, dataStoreNameSlice, 3)
+			scopeName, collectionName = dataStoreNameSlice[1], dataStoreNameSlice[2]
+		}
 
 		// Example of Raw response when named collection is used
 		// Role {"name":"role0","all_channels":null,"sequence":1,

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -809,8 +809,8 @@ func TestResync(t *testing.T) {
 
 			assert.Equal(t, testCase.expectedSyncFnRuns, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
 
-			assert.Equal(t, testCase.docsCreated, resyncManagerStatus.DocsProcessed)
-			assert.Equal(t, 0, resyncManagerStatus.DocsChanged)
+			assert.Equal(t, testCase.docsCreated, int(resyncManagerStatus.DocsProcessed))
+			assert.Equal(t, 0, int(resyncManagerStatus.DocsChanged))
 		})
 	}
 
@@ -896,8 +896,8 @@ func TestResyncUsingDCPStream(t *testing.T) {
 
 			assert.Equal(t, testCase.docsCreated, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
 
-			assert.Equal(t, testCase.docsCreated, resyncManagerStatus.DocsProcessed)
-			assert.Equal(t, 0, resyncManagerStatus.DocsChanged)
+			assert.Equal(t, testCase.docsCreated, int(resyncManagerStatus.DocsProcessed))
+			assert.Equal(t, 0, int(resyncManagerStatus.DocsChanged))
 		})
 	}
 
@@ -1558,8 +1558,8 @@ func TestResyncRegenerateSequencesUsingDCPStream(t *testing.T) {
 	err = base.JSONUnmarshal(response.BodyBytes(), &resyncStatus)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resyncStatus.ResyncID)
-	assert.Equal(t, 12, resyncStatus.DocsChanged)
-	assert.Equal(t, 12, resyncStatus.DocsProcessed)
+	assert.Equal(t, 12, int(resyncStatus.DocsChanged))
+	assert.Equal(t, 12, int(resyncStatus.DocsProcessed))
 
 	response = rt.SendAdminRequest("POST", "/db/_online", "")
 	rest.RequireStatus(t, response, http.StatusOK)

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -983,7 +983,10 @@ func TestResyncErrorScenarios(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
 	rest.RequireStatus(t, response, http.StatusOK)
 
-	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted, rt.GetDatabase().ResyncManager.GetRunState)
+	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted,
+		func(t testing.TB) db.BackgroundProcessState {
+			return rt.GetDatabase().ResyncManager.GetRunState()
+		})
 	rest.WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
 
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
@@ -996,7 +999,10 @@ func TestResyncErrorScenarios(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/db/_resync", "")
 	rest.RequireStatus(t, response, http.StatusOK)
 
-	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted, rt.GetDatabase().ResyncManager.GetRunState)
+	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted,
+		func(t testing.TB) db.BackgroundProcessState {
+			return rt.GetDatabase().ResyncManager.GetRunState()
+		})
 	rest.WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
 
 	assert.True(t, callbackFired, "expecting callback to be fired")
@@ -1060,7 +1066,10 @@ func TestResyncErrorScenariosUsingDCPStream(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
 	rest.RequireStatus(t, response, http.StatusServiceUnavailable)
 
-	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted, rt.GetDatabase().ResyncManager.GetRunState)
+	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted,
+		func(t testing.TB) db.BackgroundProcessState {
+			return rt.GetDatabase().ResyncManager.GetRunState()
+		})
 	rest.WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
 
 	assert.Equal(t, numOfDocs, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
@@ -1075,7 +1084,10 @@ func TestResyncErrorScenariosUsingDCPStream(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/db/_resync", "")
 	rest.RequireStatus(t, response, http.StatusOK)
 
-	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted, rt.GetDatabase().ResyncManager.GetRunState)
+	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted,
+		func(t testing.TB) db.BackgroundProcessState {
+			return rt.GetDatabase().ResyncManager.GetRunState()
+		})
 	rest.WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
 }
 
@@ -1158,7 +1170,10 @@ func TestResyncStop(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
 	rest.RequireStatus(t, response, http.StatusOK)
 
-	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateStopped, rt.GetDatabase().ResyncManager.GetRunState)
+	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateStopped,
+		func(t testing.TB) db.BackgroundProcessState {
+			return rt.GetDatabase().ResyncManager.GetRunState()
+		})
 	rest.WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
 
 	assert.True(t, callbackFired, "expecting callback to be fired")
@@ -1214,12 +1229,18 @@ func TestResyncStopUsingDCPStream(t *testing.T) {
 
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
 	rest.RequireStatus(t, response, http.StatusOK)
-	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateRunning, rt.GetDatabase().ResyncManager.GetRunState)
+	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateRunning,
+		func(t testing.TB) db.BackgroundProcessState {
+			return rt.GetDatabase().ResyncManager.GetRunState()
+		})
 
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
 	rest.RequireStatus(t, response, http.StatusOK)
 
-	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateStopped, rt.GetDatabase().ResyncManager.GetRunState)
+	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateStopped,
+		func(t testing.TB) db.BackgroundProcessState {
+			return rt.GetDatabase().ResyncManager.GetRunState()
+		})
 	rest.WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
 
 	syncFnCount := int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
@@ -1340,7 +1361,10 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=start&regenerate_sequences=true", "")
 	rest.RequireStatus(t, response, http.StatusOK)
 
-	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted, rt.GetDatabase().ResyncManager.GetRunState)
+	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted,
+		func(t testing.TB) db.BackgroundProcessState {
+			return rt.GetDatabase().ResyncManager.GetRunState()
+		})
 	rest.WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
 
 	_, err = rt.Bucket().DefaultDataStore().Get(base.RolePrefix+"role1", &body)
@@ -1502,7 +1526,10 @@ func TestResyncRegenerateSequencesUsingDCPStream(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=start&regenerate_sequences=true", "")
 	rest.RequireStatus(t, response, http.StatusOK)
 
-	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted, rt.GetDatabase().ResyncManager.GetRunState)
+	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted,
+		func(t testing.TB) db.BackgroundProcessState {
+			return rt.GetDatabase().ResyncManager.GetRunState()
+		})
 	rest.WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
 
 	_, err = rt.Bucket().DefaultDataStore().Get(base.RolePrefix+"role1", &body)

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -553,7 +553,8 @@ func TestDBOfflinePostResync(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestADBOfflinePostResyncUsingDCPStream(t *testing.T) {
+func TestDBOfflinePostResyncUsingDCPStream(t *testing.T) {
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
 
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test doesn't work with walrus")
@@ -653,6 +654,8 @@ func TestDBOfflineSingleResync(t *testing.T) {
 }
 
 func TestDBOfflineSingleResyncUsingDCPStream(t *testing.T) {
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
+
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test doesn't works with walrus")
 	}
@@ -814,6 +817,8 @@ func TestResync(t *testing.T) {
 }
 
 func TestResyncUsingDCPStream(t *testing.T) {
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
+
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test doesn't works with walrus")
 	}
@@ -1006,6 +1011,7 @@ func TestResyncErrorScenarios(t *testing.T) {
 }
 
 func TestResyncErrorScenariosUsingDCPStream(t *testing.T) {
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
 
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test doesn't works with walrus")
@@ -1180,6 +1186,7 @@ func TestResyncStop(t *testing.T) {
 }
 
 func TestResyncStopUsingDCPStream(t *testing.T) {
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
 
 	if base.UnitTestUrlIsWalrus() {
 		// Walrus doesn't support Collections which is required to create DCP stream
@@ -1417,11 +1424,10 @@ func TestResyncRegenerateSequences(t *testing.T) {
 }
 
 func TestResyncRegenerateSequencesUsingDCPStream(t *testing.T) {
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
 
-	// FIXME: Fails for named collections
-	if base.TestsUseNamedCollections() {
-		t.Skip("need to fix this when using named collection")
-	}
+	// FIXME: PersistentWalrusBucket doesn't support collections yet
+	t.Skip("PersistentWalrusBucket doesn't support collections yet")
 
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test doesn't works with walrus")

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
@@ -519,6 +520,54 @@ func TestDBOfflinePostResync(t *testing.T) {
 	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
 
+	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManager)
+	if !ok {
+		t.Skip("This test only works when ResyncManager is used")
+	}
+
+	log.Printf("Taking DB offline")
+	response := rt.SendAdminRequest("GET", "/db/", "")
+	var body db.Body
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
+	assert.True(t, body["state"].(string) == "Online")
+
+	response = rt.SendAdminRequest("POST", "/db/_offline", "")
+	rest.RequireStatus(t, response, 200)
+
+	response = rt.SendAdminRequest("GET", "/db/", "")
+	body = nil
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
+	assert.True(t, body["state"].(string) == "Offline")
+
+	rest.RequireStatus(t, rt.SendAdminRequest("POST", "/db/_resync?action=start", ""), 200)
+	err := rt.WaitForCondition(func() bool {
+		response := rt.SendAdminRequest("GET", "/db/_resync", "")
+		var status db.ResyncManagerResponse
+		err := json.Unmarshal(response.BodyBytes(), &status)
+		assert.NoError(t, err)
+
+		var val interface{}
+		_, err = rt.Bucket().DefaultDataStore().Get(rt.GetDatabase().ResyncManager.GetHeartbeatDocID(t), &val)
+
+		return status.State == db.BackgroundProcessStateCompleted && base.IsDocNotFoundError(err)
+	})
+	assert.NoError(t, err)
+}
+
+func TestADBOfflinePostResyncUsingDCPStream(t *testing.T) {
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't work with walrus")
+	}
+
+	rt := rest.NewRestTester(t, nil)
+	defer rt.Close()
+
+	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
+	if !ok {
+		t.Skip("This test only works when ResyncManagerDCP is used")
+	}
+
 	log.Printf("Taking DB offline")
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
@@ -558,6 +607,10 @@ func TestDBOfflineSingleResync(t *testing.T) {
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: syncFn})
 	defer rt.Close()
 
+	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManager)
+	if !ok {
+		t.Skip("This test only works when ResyncManager is used")
+	}
 	// create documents in DB to cause resync to take a few seconds
 	for i := 0; i < 1000; i++ {
 		rt.CreateDoc(t, fmt.Sprintf("doc%v", i))
@@ -585,6 +638,65 @@ func TestDBOfflineSingleResync(t *testing.T) {
 	rest.RequireStatus(t, rt.SendAdminRequest("POST", "/db/_resync?action=start", ""), 503)
 
 	err := rt.WaitForCondition(func() bool {
+		response := rt.SendAdminRequest("GET", "/db/_resync", "")
+		var status db.ResyncManagerResponse
+		err := json.Unmarshal(response.BodyBytes(), &status)
+		assert.NoError(t, err)
+
+		var val interface{}
+		_, err = rt.Bucket().DefaultDataStore().Get(rt.GetDatabase().ResyncManager.GetHeartbeatDocID(t), &val)
+
+		return status.State == db.BackgroundProcessStateCompleted && base.IsDocNotFoundError(err)
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, int64(2000), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
+}
+
+func TestDBOfflineSingleResyncUsingDCPStream(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't works with walrus")
+	}
+	syncFn := `
+	function(doc) {
+		channel("x")
+	}`
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: syncFn})
+	defer rt.Close()
+
+	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
+	if !ok {
+		t.Skip("This test only works when ResyncManagerDCP is used")
+	}
+
+	// create documents in DB to cause resync to take a few seconds
+	for i := 0; i < 1000; i++ {
+		rt.CreateDoc(t, fmt.Sprintf("doc%v", i))
+	}
+	assert.Equal(t, int64(1000), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
+
+	log.Printf("Taking DB offline")
+	response := rt.SendAdminRequest("GET", "/db/", "")
+	var body db.Body
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
+	assert.True(t, body["state"].(string) == "Online")
+
+	response = rt.SendAdminRequest("POST", "/db/_offline", "")
+	rest.RequireStatus(t, response, 200)
+
+	response = rt.SendAdminRequest("GET", "/db/", "")
+	body = nil
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
+	assert.True(t, body["state"].(string) == "Offline")
+
+	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+
+	// Send a second _resync request.  This must return a 400 since the first one is blocked processing
+	rest.RequireStatus(t, rt.SendAdminRequest("POST", "/db/_resync?action=start", ""), 503)
+
+	err := rt.WaitForCondition(func() bool {
+		time.Sleep(time.Duration(rand.Intn(1500)) * time.Millisecond)
 		response := rt.SendAdminRequest("GET", "/db/_resync", "")
 		var status db.ResyncManagerResponse
 		err := json.Unmarshal(response.BodyBytes(), &status)
@@ -650,9 +762,18 @@ func TestResync(t *testing.T) {
 			)
 			defer rt.Close()
 
+			_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManager)
+			if !ok {
+				t.Skip("This test only works when ResyncManager is used")
+			}
+
 			for i := 0; i < testCase.docsCreated; i++ {
 				rt.CreateDoc(t, fmt.Sprintf("doc%d", i))
 			}
+			err := rt.WaitForCondition(func() bool {
+				return int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()) == testCase.docsCreated
+			})
+			assert.NoError(t, err)
 
 			response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
 			rest.RequireStatus(t, response, http.StatusServiceUnavailable)
@@ -669,7 +790,7 @@ func TestResync(t *testing.T) {
 			rest.RequireStatus(t, response, http.StatusOK)
 
 			var resyncManagerStatus db.ResyncManagerResponseDCP
-			err := rt.WaitForCondition(func() bool {
+			err = rt.WaitForCondition(func() bool {
 				response := rt.SendAdminRequest("GET", "/db/_resync", "")
 				err := json.Unmarshal(response.BodyBytes(), &resyncManagerStatus)
 				assert.NoError(t, err)
@@ -687,6 +808,93 @@ func TestResync(t *testing.T) {
 			assert.NoError(t, err)
 
 			assert.Equal(t, testCase.expectedSyncFnRuns, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
+
+			assert.Equal(t, testCase.docsCreated, resyncManagerStatus.DocsProcessed)
+			assert.Equal(t, 0, resyncManagerStatus.DocsChanged)
+		})
+	}
+
+}
+
+func TestResyncUsingDCPStream(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't works with walrus")
+	}
+	base.LongRunningTest(t)
+
+	testCases := []struct {
+		docsCreated int
+	}{
+		{
+			docsCreated: 0,
+		},
+		{
+			docsCreated: 1000,
+		},
+	}
+
+	syncFn := `
+	function(doc) {
+		channel("x")
+	}`
+
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("Docs %d", testCase.docsCreated), func(t *testing.T) {
+			rt := rest.NewRestTester(t,
+				&rest.RestTesterConfig{
+					SyncFn: syncFn,
+				},
+			)
+			defer rt.Close()
+
+			_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
+			if !ok {
+				t.Skip("This test only works when ResyncManagerDCP is used")
+			}
+
+			for i := 0; i < testCase.docsCreated; i++ {
+				rt.CreateDoc(t, fmt.Sprintf("doc%d", i))
+			}
+
+			err := rt.WaitForCondition(func() bool {
+				return int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()) == testCase.docsCreated
+			})
+			assert.NoError(t, err)
+			rt.GetDatabase().DbStats.Database().SyncFunctionCount.Set(0)
+
+			response := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+			rest.RequireStatus(t, response, http.StatusServiceUnavailable)
+
+			response = rt.SendAdminRequest("POST", "/db/_offline", "")
+			rest.RequireStatus(t, response, http.StatusOK)
+
+			rest.WaitAndAssertCondition(t, func() bool {
+				state := atomic.LoadUint32(&rt.GetDatabase().State)
+				return state == db.DBOffline
+			})
+
+			response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+			rest.RequireStatus(t, response, http.StatusOK)
+
+			var resyncManagerStatus db.ResyncManagerResponseDCP
+			err = rt.WaitForCondition(func() bool {
+				response := rt.SendAdminRequest("GET", "/db/_resync", "")
+				err := json.Unmarshal(response.BodyBytes(), &resyncManagerStatus)
+				assert.NoError(t, err)
+
+				var val interface{}
+				_, err = rt.Bucket().DefaultDataStore().Get(rt.GetDatabase().ResyncManager.GetHeartbeatDocID(t), &val)
+
+				if resyncManagerStatus.State == db.BackgroundProcessStateCompleted && base.IsDocNotFoundError(err) {
+					return true
+				} else {
+					t.Logf("resyncManagerStatus.State != %v: %v - err:%v", db.BackgroundProcessStateCompleted, resyncManagerStatus.State, err)
+					return false
+				}
+			})
+			assert.NoError(t, err)
+
+			assert.Equal(t, testCase.docsCreated, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
 
 			assert.Equal(t, testCase.docsCreated, resyncManagerStatus.DocsProcessed)
 			assert.Equal(t, 0, resyncManagerStatus.DocsChanged)
@@ -716,6 +924,11 @@ func TestResyncErrorScenarios(t *testing.T) {
 		},
 	)
 	defer rt.Close()
+
+	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManager)
+	if !ok {
+		t.Skip("This test only works when ResyncManager is used")
+	}
 
 	leakyDataStore, ok := base.AsLeakyDataStore(rt.TestBucket.GetSingleDataStore())
 	require.Truef(t, ok, "Wanted *base.LeakyBucket but got %T", leakyTestBucket.Bucket)
@@ -789,6 +1002,83 @@ func TestResyncErrorScenarios(t *testing.T) {
 	assert.True(t, callbackFired, "expecting callback to be fired")
 }
 
+func TestResyncErrorScenariosUsingDCPStream(t *testing.T) {
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't works with walrus")
+	}
+
+	syncFn := `
+	function(doc) {
+		channel("x")
+	}`
+
+	testBucket := base.GetTestBucket(t)
+
+	rt := rest.NewRestTester(t,
+		&rest.RestTesterConfig{
+			SyncFn:           syncFn,
+			CustomTestBucket: testBucket,
+		},
+	)
+	defer rt.Close()
+
+	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
+	if !ok {
+		t.Skip("This test only works when ResyncManagerDCP is used")
+	}
+
+	numOfDocs := 1000
+	for i := 0; i < numOfDocs; i++ {
+		rt.CreateDoc(t, fmt.Sprintf("doc%d", i))
+	}
+
+	assert.Equal(t, numOfDocs, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
+	rt.GetDatabase().DbStats.Database().SyncFunctionCount.Set(0)
+
+	response := rt.SendAdminRequest("GET", "/db/_resync", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+
+	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+	rest.RequireStatus(t, response, http.StatusServiceUnavailable)
+
+	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
+	rest.RequireStatus(t, response, http.StatusBadRequest)
+
+	response = rt.SendAdminRequest("POST", "/db/_offline", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+
+	rest.WaitAndAssertCondition(t, func() bool {
+		state := atomic.LoadUint32(&rt.GetDatabase().State)
+		return state == db.DBOffline
+	})
+
+	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+
+	// If processor is running, another start request should throw error
+	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+	rest.RequireStatus(t, response, http.StatusServiceUnavailable)
+
+	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted, rt.GetDatabase().ResyncManager.GetRunState)
+	rest.WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
+
+	assert.Equal(t, numOfDocs, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
+
+	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
+	rest.RequireStatus(t, response, http.StatusBadRequest)
+
+	response = rt.SendAdminRequest("POST", "/db/_resync?action=invalid", "")
+	rest.RequireStatus(t, response, http.StatusBadRequest)
+
+	// Test empty action, should default to start
+	response = rt.SendAdminRequest("POST", "/db/_resync", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+
+	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted, rt.GetDatabase().ResyncManager.GetRunState)
+	rest.WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
+}
+
 func TestResyncStop(t *testing.T) {
 
 	if !base.UnitTestUrlIsWalrus() {
@@ -813,6 +1103,11 @@ func TestResyncStop(t *testing.T) {
 		},
 	)
 	defer rt.Close()
+
+	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManager)
+	if !ok {
+		t.Skip("This test only works when ResyncManager is used")
+	}
 
 	leakyDataStore, ok := base.AsLeakyDataStore(rt.TestBucket.GetSingleDataStore())
 	require.Truef(t, ok, "Wanted *base.LeakyBucket but got %T", leakyTestBucket.Bucket)
@@ -872,6 +1167,65 @@ func TestResyncStop(t *testing.T) {
 	assert.True(t, syncFnCount < 2000, "Expected syncFnCount < 2000 but syncFnCount=%d", syncFnCount)
 }
 
+func TestResyncStopUsingDCPStream(t *testing.T) {
+
+	if base.UnitTestUrlIsWalrus() {
+		// Walrus doesn't support Collections which is required to create DCP stream
+		t.Skip("This test doesn't works with walrus")
+	}
+
+	syncFn := `
+	function(doc) {
+		channel("x")
+	}`
+
+	testBucket := base.GetTestBucket(t)
+
+	rt := rest.NewRestTester(t,
+		&rest.RestTesterConfig{
+			SyncFn:           syncFn,
+			CustomTestBucket: testBucket,
+		},
+	)
+	defer rt.Close()
+
+	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
+	if !ok {
+		t.Skip("This test only works when ResyncManagerDCP is used")
+	}
+
+	numOfDocs := 1000
+	for i := 0; i < numOfDocs; i++ {
+		rt.CreateDoc(t, fmt.Sprintf("doc%d", i))
+	}
+
+	err := rt.WaitForCondition(func() bool {
+		return int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()) == numOfDocs
+	})
+	assert.NoError(t, err)
+
+	response := rt.SendAdminRequest("POST", "/db/_offline", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+
+	rest.WaitAndAssertCondition(t, func() bool {
+		state := atomic.LoadUint32(&rt.GetDatabase().State)
+		return state == db.DBOffline
+	})
+
+	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateRunning, rt.GetDatabase().ResyncManager.GetRunState)
+
+	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+
+	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateStopped, rt.GetDatabase().ResyncManager.GetRunState)
+	rest.WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
+
+	syncFnCount := int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
+	assert.True(t, syncFnCount < 2000, "Expected syncFnCount < 2000 but syncFnCount=%d", syncFnCount)
+}
+
 func TestResyncRegenerateSequences(t *testing.T) {
 
 	base.LongRunningTest(t)
@@ -901,6 +1255,11 @@ func TestResyncRegenerateSequences(t *testing.T) {
 		},
 	)
 	defer rt.Close()
+
+	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManager)
+	if !ok {
+		t.Skip("This test only works when ResyncManager is used")
+	}
 
 	var response *rest.TestResponse
 	var docSeqArr []float64
@@ -1027,6 +1386,170 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	response = rt.Send(request)
 	rest.RequireStatus(t, response, http.StatusOK)
 	err = json.Unmarshal(response.BodyBytes(), &changesResp)
+	assert.NoError(t, err)
+	assert.Len(t, changesResp.Results, 3)
+	assert.True(t, changesRespContains(changesResp, "userdoc"))
+	assert.True(t, changesRespContains(changesResp, "userdoc2"))
+}
+
+func TestResyncRegenerateSequencesUsingDCPStream(t *testing.T) {
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't works with walrus")
+	}
+
+	base.LongRunningTest(t)
+	syncFn := `
+	function(doc) {
+		if (doc.userdoc){
+			channel("channel_1")
+		}
+	}`
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+
+	testBucket := base.GetTestBucket(t)
+
+	rt := rest.NewRestTester(t,
+		&rest.RestTesterConfig{
+			SyncFn:           syncFn,
+			CustomTestBucket: testBucket,
+		},
+	)
+	defer rt.Close()
+
+	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
+	if !ok {
+		t.Skip("This test only works when ResyncManagerDCP is used")
+	}
+
+	var response *rest.TestResponse
+	var docSeqArr []float64
+	var body db.Body
+
+	for i := 0; i < 10; i++ {
+		docID := fmt.Sprintf("doc%d", i)
+		rt.CreateDoc(t, docID)
+
+		response = rt.SendAdminRequest("GET", "/db/_raw/"+docID, "")
+		require.Equal(t, http.StatusOK, response.Code)
+
+		err := json.Unmarshal(response.BodyBytes(), &body)
+		require.NoError(t, err)
+
+		docSeqArr = append(docSeqArr, body["_sync"].(map[string]interface{})["sequence"].(float64))
+	}
+
+	role := "role1"
+	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_role/%s", role), fmt.Sprintf(`{"name":"%s", "admin_channels":["channel_1"]}`, role))
+	rest.RequireStatus(t, response, http.StatusCreated)
+
+	username := "user1"
+	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_user/%s", username), fmt.Sprintf(`{"name":"%s", "password":"letmein", "admin_channels":["channel_1"], "admin_roles": ["%s"]}`, username, role))
+	rest.RequireStatus(t, response, http.StatusCreated)
+
+	_, err := rt.Bucket().DefaultDataStore().Get(base.RolePrefix+"role1", &body)
+	assert.NoError(t, err)
+	role1SeqBefore := body["sequence"].(float64)
+
+	_, err = rt.Bucket().DefaultDataStore().Get(base.UserPrefix+"user1", &body)
+	assert.NoError(t, err)
+	user1SeqBefore := body["sequence"].(float64)
+
+	response = rt.SendAdminRequest("PUT", "/db/userdoc", `{"userdoc": true}`)
+	rest.RequireStatus(t, response, http.StatusCreated)
+
+	response = rt.SendAdminRequest("PUT", "/db/userdoc2", `{"userdoc": true}`)
+	rest.RequireStatus(t, response, http.StatusCreated)
+
+	// Let everything catch up before opening changes feed
+	require.NoError(t, rt.WaitForPendingChanges())
+
+	type ChangesResp struct {
+		Results []struct {
+			ID  string `json:"id"`
+			Seq int    `json:"seq"`
+		} `json:"results"`
+		LastSeq string `json:"last_seq"`
+	}
+
+	changesRespContains := func(changesResp ChangesResp, docid string) bool {
+		for _, resp := range changesResp.Results {
+			if resp.ID == docid {
+				return true
+			}
+		}
+		return false
+	}
+
+	var changesResp ChangesResp
+	request, _ := http.NewRequest("GET", "/db/_changes", nil)
+	request.SetBasicAuth("user1", "letmein")
+	response = rt.Send(request)
+	rest.RequireStatus(t, response, http.StatusOK)
+	err = json.Unmarshal(response.BodyBytes(), &changesResp)
+	assert.NoError(t, err)
+	assert.Len(t, changesResp.Results, 3)
+	assert.True(t, changesRespContains(changesResp, "userdoc"))
+	assert.True(t, changesRespContains(changesResp, "userdoc2"))
+
+	response = rt.SendAdminRequest("GET", "/db/_resync", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+
+	response = rt.SendAdminRequest("POST", "/db/_offline", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+
+	response = rt.SendAdminRequest("POST", "/db/_resync?action=start&regenerate_sequences=true", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+
+	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted, rt.GetDatabase().ResyncManager.GetRunState)
+	rest.WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
+
+	_, err = rt.Bucket().DefaultDataStore().Get(base.RolePrefix+"role1", &body)
+	assert.NoError(t, err)
+	role1SeqAfter := body["sequence"].(float64)
+
+	_, err = rt.Bucket().DefaultDataStore().Get(base.UserPrefix+"user1", &body)
+	assert.NoError(t, err)
+	user1SeqAfter := body["sequence"].(float64)
+
+	assert.True(t, role1SeqAfter > role1SeqBefore)
+	assert.True(t, user1SeqAfter > user1SeqBefore)
+
+	for i := 0; i < 10; i++ {
+		docID := fmt.Sprintf("doc%d", i)
+
+		doc, err := rt.GetDatabase().GetSingleDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
+		assert.NoError(t, err)
+
+		assert.True(t, float64(doc.Sequence) > docSeqArr[i])
+	}
+
+	response = rt.SendAdminRequest("GET", "/db/_resync", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+	var resyncStatus db.ResyncManagerResponseDCP
+	err = base.JSONUnmarshal(response.BodyBytes(), &resyncStatus)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, resyncStatus.ResyncID)
+	assert.Equal(t, 12, resyncStatus.DocsChanged)
+	assert.Equal(t, 12, resyncStatus.DocsProcessed)
+
+	response = rt.SendAdminRequest("POST", "/db/_online", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+
+	err = rt.WaitForCondition(func() bool {
+		state := atomic.LoadUint32(&rt.GetDatabase().State)
+		return state == db.DBOnline
+	})
+	assert.NoError(t, err)
+
+	// Data is wiped when brought back online
+	request, _ = http.NewRequest("GET", "/db/_changes?since="+changesResp.LastSeq, nil)
+	request.SetBasicAuth("user1", "letmein")
+	response = rt.Send(request)
+	rest.RequireStatus(t, response, http.StatusOK)
+	err = json.Unmarshal(response.BodyBytes(), &changesResp)
+	assert.NoError(t, err)
 	assert.Len(t, changesResp.Results, 3)
 	assert.True(t, changesRespContains(changesResp, "userdoc"))
 	assert.True(t, changesRespContains(changesResp, "userdoc2"))

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1249,6 +1249,9 @@ func TestResyncStopUsingDCPStream(t *testing.T) {
 
 func TestResyncRegenerateSequences(t *testing.T) {
 
+	// FIXME: PersistentWalrusBucket doesn't support collections yet
+	t.Skip("PersistentWalrusBucket doesn't support collections yet")
+
 	base.LongRunningTest(t)
 	syncFn := `
 	function(doc) {

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -3907,7 +3907,7 @@ func TestTombstoneCompaction(t *testing.T) {
 
 		err := rt.WaitForCondition(func() bool {
 			time.Sleep(1 * time.Second)
-			return rt.GetDatabase().TombstoneCompactionManager.GetRunState(t) == db.BackgroundProcessStateCompleted
+			return rt.GetDatabase().TombstoneCompactionManager.GetRunState() == db.BackgroundProcessStateCompleted
 		})
 		assert.NoError(t, err)
 

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -610,7 +610,10 @@ func TestResyncErrorScenarios(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/{{.keyspace}}/_resync?action=start", "")
 	RequireStatus(t, response, http.StatusOK)
 
-	WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted, rt.GetDatabase().ResyncManager.GetRunState)
+	WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted,
+		func(t testing.TB) db.BackgroundProcessState {
+			return rt.GetDatabase().ResyncManager.GetRunState()
+		})
 	WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
 
 	response = rt.SendAdminRequest("POST", "/{{.keyspace}}/_resync?action=stop", "")
@@ -623,7 +626,10 @@ func TestResyncErrorScenarios(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/{{.keyspace}}/_resync", "")
 	RequireStatus(t, response, http.StatusOK)
 
-	WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted, rt.GetDatabase().ResyncManager.GetRunState)
+	WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted,
+		func(t testing.TB) db.BackgroundProcessState {
+			return rt.GetDatabase().ResyncManager.GetRunState()
+		})
 	WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
 
 	assert.True(t, callbackFired, "expecting callback to be fired")
@@ -703,7 +709,10 @@ func TestResyncStop(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/{{.keyspace}}/_resync?action=start", "")
 	RequireStatus(t, response, http.StatusOK)
 
-	WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateStopped, rt.GetDatabase().ResyncManager.GetRunState)
+	WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateStopped,
+		func(t testing.TB) db.BackgroundProcessState {
+			return rt.GetDatabase().ResyncManager.GetRunState()
+		})
 	WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
 
 	assert.True(t, callbackFired, "expecting callback to be fired")
@@ -823,7 +832,10 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=start&regenerate_sequences=true", "")
 	RequireStatus(t, response, http.StatusOK)
 
-	WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted, rt.GetDatabase().ResyncManager.GetRunState)
+	WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted,
+		func(t testing.TB) db.BackgroundProcessState {
+			return rt.GetDatabase().ResyncManager.GetRunState()
+		})
 	WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
 
 	_, err = rt.MetadataStore().Get(base.RolePrefix+"role1", &body)

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -351,6 +351,11 @@ func TestDBOfflinePostResync(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
+	_, isDCPResync := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
+	if isDCPResync && base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't work with Walrus when ResyncManagerDCP is used")
+	}
+
 	log.Printf("Taking DB offline")
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
@@ -389,6 +394,11 @@ func TestDBOfflineSingleResync(t *testing.T) {
 	}`
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: syncFn})
 	defer rt.Close()
+
+	_, isDCPResync := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
+	if isDCPResync && base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't work with Walrus when ResyncManagerDCP is used")
+	}
 
 	// create documents in DB to cause resync to take a few seconds
 	for i := 0; i < 1000; i++ {
@@ -482,6 +492,11 @@ func TestResync(t *testing.T) {
 			)
 			defer rt.Close()
 
+			_, isDCPResync := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
+			if isDCPResync && base.UnitTestUrlIsWalrus() {
+				t.Skip("This test doesn't work with Walrus when ResyncManagerDCP is used")
+			}
+
 			for i := 0; i < testCase.docsCreated; i++ {
 				rt.CreateDoc(t, fmt.Sprintf("doc%d", i))
 			}
@@ -520,19 +535,20 @@ func TestResync(t *testing.T) {
 
 			assert.Equal(t, testCase.expectedSyncFnRuns, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
 
-			var queryName string
-			if base.TestsDisableGSI() {
-				queryName = fmt.Sprintf(base.StatViewFormat, db.DesignDocSyncGateway(), db.ViewChannels)
-			} else {
-				queryName = db.QueryTypeChannels
+			if !isDCPResync {
+				var queryName string
+				if base.TestsDisableGSI() {
+					queryName = fmt.Sprintf(base.StatViewFormat, db.DesignDocSyncGateway(), db.ViewChannels)
+				} else {
+					queryName = db.QueryTypeChannels
+				}
+				assert.Equal(t, testCase.expectedQueryCount, int(rt.GetDatabase().DbStats.Query(queryName).QueryCount.Value()))
 			}
 
-			assert.Equal(t, testCase.expectedQueryCount, int(rt.GetDatabase().DbStats.Query(queryName).QueryCount.Value()))
 			assert.Equal(t, testCase.docsCreated, resyncManagerStatus.DocsProcessed)
 			assert.Equal(t, 0, resyncManagerStatus.DocsChanged)
 		})
 	}
-
 }
 
 func TestResyncErrorScenarios(t *testing.T) {
@@ -556,6 +572,11 @@ func TestResyncErrorScenarios(t *testing.T) {
 		},
 	)
 	defer rt.Close()
+
+	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManager)
+	if !ok {
+		t.Skip("This test only works when ResyncManager is used")
+	}
 
 	leakyDataStore, ok := base.AsLeakyDataStore(rt.Bucket().DefaultDataStore())
 	require.Truef(t, ok, "Wanted *base.LeakyBucket but got %T", leakyTestBucket.Bucket)
@@ -635,6 +656,75 @@ func TestResyncErrorScenarios(t *testing.T) {
 	assert.True(t, callbackFired, "expecting callback to be fired")
 }
 
+func TestResyncErrorScenariosUsingDCPStream(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't work with walrus")
+	}
+
+	syncFn := `
+	function(doc) {
+		channel("x")
+	}`
+
+	rt := NewRestTester(t,
+		&RestTesterConfig{
+			SyncFn: syncFn,
+		},
+	)
+	defer rt.Close()
+
+	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
+	if !ok {
+		t.Skip("This test only works when ResyncManagerDCP is used")
+	}
+
+	for i := 0; i < 1000; i++ {
+		rt.CreateDoc(t, fmt.Sprintf("doc%d", i))
+	}
+
+	response := rt.SendAdminRequest("GET", "/db/_resync", "")
+	RequireStatus(t, response, http.StatusOK)
+
+	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+	RequireStatus(t, response, http.StatusServiceUnavailable)
+
+	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
+	RequireStatus(t, response, http.StatusBadRequest)
+
+	response = rt.SendAdminRequest("POST", "/db/_offline", "")
+	RequireStatus(t, response, http.StatusOK)
+
+	WaitAndAssertCondition(t, func() bool {
+		state := atomic.LoadUint32(&rt.GetDatabase().State)
+		return state == db.DBOffline
+	})
+
+	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+	RequireStatus(t, response, http.StatusOK)
+
+	WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted,
+		func(t testing.TB) db.BackgroundProcessState {
+			return rt.GetDatabase().ResyncManager.GetRunState()
+		})
+	WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
+
+	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
+	RequireStatus(t, response, http.StatusBadRequest)
+
+	response = rt.SendAdminRequest("POST", "/db/_resync?action=invalid", "")
+	RequireStatus(t, response, http.StatusBadRequest)
+
+	// Test empty action, should default to start
+	response = rt.SendAdminRequest("POST", "/db/_resync", "")
+	RequireStatus(t, response, http.StatusOK)
+
+	WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted,
+		func(t testing.TB) db.BackgroundProcessState {
+			return rt.GetDatabase().ResyncManager.GetRunState()
+		})
+	WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
+}
+
 func TestResyncStop(t *testing.T) {
 
 	if !base.UnitTestUrlIsWalrus() {
@@ -659,6 +749,11 @@ func TestResyncStop(t *testing.T) {
 		},
 	)
 	defer rt.Close()
+
+	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManager)
+	if !ok {
+		t.Skip("This test only works when ResyncManager is used")
+	}
 
 	leakyDataStore, ok := base.AsLeakyDataStore(rt.Bucket().DefaultDataStore())
 	require.Truef(t, ok, "Wanted *base.LeakyBucket but got %T", leakyTestBucket.Bucket)
@@ -721,6 +816,71 @@ func TestResyncStop(t *testing.T) {
 	assert.True(t, syncFnCount < 2000, "Expected syncFnCount < 2000 but syncFnCount=%d", syncFnCount)
 }
 
+func TestResyncStopUsingDCPStream(t *testing.T) {
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't work with walrus")
+	}
+
+	syncFn := `
+	function(doc) {
+		channel("x")
+	}`
+
+	rt := NewRestTester(t,
+		&RestTesterConfig{
+			SyncFn: syncFn,
+			DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+				QueryPaginationLimit: base.IntPtr(10),
+			}},
+		},
+	)
+	defer rt.Close()
+
+	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
+	if !ok {
+		t.Skip("This test only works when ResyncManagerDCP is used")
+	}
+
+	for i := 0; i < 1000; i++ {
+		rt.CreateDoc(t, fmt.Sprintf("doc%d", i))
+	}
+
+	err := rt.WaitForCondition(func() bool {
+		return int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()) == 1000
+	})
+	assert.NoError(t, err)
+
+	response := rt.SendAdminRequest("POST", "/db/_offline", "")
+	RequireStatus(t, response, http.StatusOK)
+
+	WaitAndAssertCondition(t, func() bool {
+		state := atomic.LoadUint32(&rt.GetDatabase().State)
+		return state == db.DBOffline
+	})
+
+	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+	RequireStatus(t, response, http.StatusOK)
+
+	WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateRunning,
+		func(t testing.TB) db.BackgroundProcessState {
+			return rt.GetDatabase().ResyncManager.GetRunState()
+		})
+
+	time.Sleep(500 * time.Microsecond)
+	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
+	RequireStatus(t, response, http.StatusOK)
+
+	WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateStopped,
+		func(t testing.TB) db.BackgroundProcessState {
+			return rt.GetDatabase().ResyncManager.GetRunState()
+		})
+	WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
+
+	syncFnCount := int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
+	assert.Less(t, syncFnCount, 2000, "Expected syncFnCount < 2000 but syncFnCount=%d", syncFnCount)
+}
+
 func TestResyncRegenerateSequences(t *testing.T) {
 
 	// FIXME: PersistentWalrusBucket doesn't support collections yet
@@ -753,6 +913,11 @@ func TestResyncRegenerateSequences(t *testing.T) {
 		},
 	)
 	defer rt.Close()
+
+	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
+	if ok && base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't works with Walrus when ResyncManagerDCP is used")
+	}
 
 	var response *TestResponse
 	var docSeqArr []float64

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -657,6 +657,8 @@ func TestResyncErrorScenarios(t *testing.T) {
 }
 
 func TestResyncErrorScenariosUsingDCPStream(t *testing.T) {
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
+
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test doesn't work with walrus")
 	}
@@ -817,6 +819,7 @@ func TestResyncStop(t *testing.T) {
 }
 
 func TestResyncStopUsingDCPStream(t *testing.T) {
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
 
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test doesn't work with walrus")


### PR DESCRIPTION
CBG-1891

Describe your PR here...
- Using one shot DCP stream for Resync Operation.

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1249/
