### PR TITLE
CBG-2505: Fix for race condition within test causing it to flake

### DIFF
--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -954,6 +954,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	// whether the user has already seen the documents on the channel previously, so it gets resent
 
 	changesCtxCancel()
+	require.NoError(t, authenticator.DeleteUser(user))
 }
 
 // Tests channel cache backfill with slow query, validates that a request that is terminated while


### PR DESCRIPTION
CBG-2505

There was a race when occasionally a goroutine was trying to reload the user on the database after the database context was closed. So added a line to remove this user before the database context is closed. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1056/
