### PR TITLE
CBG-2505: Fix for race condition within test causing it to flake

### DIFF
--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -278,7 +278,6 @@ func TestLateSequenceErrorRecovery(t *testing.T) {
 	options.Since = SequenceID{Seq: 0}
 	changesCtx, changesCtxCancel := context.WithCancel(context.Background())
 	options.ChangesCtx = changesCtx
-	defer changesCtxCancel()
 	options.Continuous = true
 	options.Wait = true
 	feed, err := db.MultiChangesFeed(ctx, base.SetOf("ABC"), options)
@@ -368,6 +367,9 @@ func TestLateSequenceErrorRecovery(t *testing.T) {
 	nextEvents = nextFeedIteration()
 	require.Equal(t, len(nextEvents), 1)
 	assert.Equal(t, nextEvents[0].Seq.String(), "9")
+
+	changesCtxCancel()
+	emptyChangesFeed(feed)
 
 }
 
@@ -696,7 +698,6 @@ func TestContinuousChangesBackfill(t *testing.T) {
 	options.ChangesCtx = changesCtx
 	options.Continuous = true
 	options.Wait = true
-	defer changesCtxCancel()
 
 	feed, err := db.MultiChangesFeed(ctx, base.SetOf("*"), options)
 	assert.True(t, err == nil)
@@ -761,6 +762,8 @@ func TestContinuousChangesBackfill(t *testing.T) {
 	}
 
 	assert.Equal(t, 0, len(expectedDocs))
+	changesCtxCancel()
+	emptyChangesFeed(feed)
 }
 
 // Test low sequence handling of late arriving sequences to a continuous changes feed
@@ -799,7 +802,6 @@ func TestLowSequenceHandling(t *testing.T) {
 	options.Since = SequenceID{Seq: 0}
 	changesCtx, changesCtxCancel := context.WithCancel(context.Background())
 	options.ChangesCtx = changesCtx
-	defer changesCtxCancel()
 	options.Continuous = true
 	options.Wait = true
 	feed, err := db.MultiChangesFeed(ctx, base.SetOf("*"), options)
@@ -825,6 +827,9 @@ func TestLowSequenceHandling(t *testing.T) {
 	WriteDirect(db, []string{"ABC", "PBS"}, 9)
 	_, err = verifySequencesInFeed(feed, []uint64{7, 8, 9})
 	assert.True(t, err == nil)
+
+	changesCtxCancel()
+	emptyChangesFeed(feed)
 
 }
 
@@ -880,6 +885,7 @@ func TestLowSequenceHandlingAcrossChannels(t *testing.T) {
 	assert.True(t, err == nil)
 
 	changesCtxCancel()
+	emptyChangesFeed(feed)
 }
 
 // Test low sequence handling of late arriving sequences to a continuous changes feed, when the
@@ -954,7 +960,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	// whether the user has already seen the documents on the channel previously, so it gets resent
 
 	changesCtxCancel()
-	require.NoError(t, authenticator.DeleteUser(user))
+	emptyChangesFeed(feed)
 }
 
 // Tests channel cache backfill with slow query, validates that a request that is terminated while
@@ -1123,7 +1129,6 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 	options.Since = SequenceID{Seq: 0}
 	changesCtx, changesCtxCancel := context.WithCancel(context.Background())
 	options.ChangesCtx = changesCtx
-	defer changesCtxCancel()
 	options.Continuous = true
 	options.Wait = true
 	feed, err := db.MultiChangesFeed(ctx, base.SetOf("*"), options)
@@ -1159,7 +1164,8 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 	require.NoError(t, db.changeCache.waitForSequence(ctx, 9, base.DefaultWaitForSequence))
 	require.NoError(t, appendFromFeed(&changes, feed, 5, base.DefaultWaitForSequence))
 	assert.True(t, verifyChangesSequencesIgnoreOrder(changes, []uint64{1, 2, 5, 6, 3, 4, 7, 8, 9}))
-
+	changesCtxCancel()
+	emptyChangesFeed(feed)
 }
 
 // Test race condition causing skipped sequences in changes feed.  Channel feeds are processed sequentially
@@ -1272,6 +1278,7 @@ func TestChannelRace(t *testing.T) {
 	fmt.Println("changes: ", changesString)
 
 	changesCtxCancel()
+	emptyChangesFeed(feed)
 }
 
 // Test retrieval of skipped sequence using view.  Unit test catches panic, but we don't currently have a way
@@ -2286,5 +2293,18 @@ func BenchmarkDocChanged(b *testing.B) {
 			// log.Printf("maxNumPending: %v", changeCache.context.DbStats.StatsCblReplicationPull().Get(base.StatKeyMaxPending))
 			// log.Printf("cachingCount: %v", changeCache.context.DbStats.StatsDatabase().Get(base.StatKeyDcpCachingCount))
 		})
+	}
+}
+
+func emptyChangesFeed(feed <-chan *ChangeEntry) {
+	done := false
+	for !done {
+		select {
+		case v, ok := <-feed:
+			log.Printf("Waiting for change entry feed to be empty %v %t", v, ok)
+		default:
+			log.Println("Change entry feed empty")
+			done = true
+		}
 	}
 }

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1610,7 +1610,6 @@ func readNextFromFeed(feed <-chan (*ChangeEntry), timeout time.Duration) (*Chang
 
 }
 
-/*
 // Repro SG #2633
 //
 // Create doc1 w/ unused sequences 1, actual sequence 3.
@@ -1712,8 +1711,6 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 	waitForOnChangeCallback.Wait()
 
 }
-
-*/
 
 // Trigger initialization of empty cache, then write and validate a subsequent changes request returns expected data.
 func TestInitializeEmptyCache(t *testing.T) {

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -954,6 +954,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	// whether the user has already seen the documents on the channel previously, so it gets resent
 
 	changesCtxCancel()
+	require.NoError(t, authenticator.DeleteUser(user))
 }
 
 // Tests channel cache backfill with slow query, validates that a request that is terminated while

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1610,6 +1610,7 @@ func readNextFromFeed(feed <-chan (*ChangeEntry), timeout time.Duration) (*Chang
 
 }
 
+/*
 // Repro SG #2633
 //
 // Create doc1 w/ unused sequences 1, actual sequence 3.
@@ -1711,6 +1712,8 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 	waitForOnChangeCallback.Wait()
 
 }
+
+*/
 
 // Trigger initialization of empty cache, then write and validate a subsequent changes request returns expected data.
 func TestInitializeEmptyCache(t *testing.T) {
@@ -2300,8 +2303,8 @@ func emptyChangesFeed(feed <-chan *ChangeEntry) {
 	done := false
 	for !done {
 		select {
-		case v, ok := <-feed:
-			log.Printf("Waiting for change entry feed to be empty %v %t", v, ok)
+		case v, _ := <-feed:
+			log.Printf("Waiting for change entry feed to be empty. Item coming off the feed: %v", v)
 		default:
 			log.Println("Change entry feed empty")
 			done = true


### PR DESCRIPTION
CBG-2505

There was a race when occasionally a goroutine was trying to reload the user on the database after the database context was closed. So added a line to remove this user before the database context is closed.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1049/
