### PR TITLE
CBG-2499: Fix for flake on TestReplicatorCheckpoint

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4815,14 +4815,9 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 	// Check checkpoint document was wrote to bucket with correct status
 	// _sync:local:checkpoint/sgr2cp:push:TestReplicatorCheckpointOnStop
 	expectedCheckpointName := base.SyncDocPrefix + "local:checkpoint/" + db.PushCheckpointID(t.Name())
-	val, _, err := activeRT.Bucket().GetRaw(expectedCheckpointName)
+	lastSeq, err := activeRT.WaitForCheckpointLastSequence(expectedCheckpointName)
 	require.NoError(t, err)
-	var config struct { // db.replicationCheckpoint
-		LastSeq string `json:"last_sequence"`
-	}
-	err = json.Unmarshal(val, &config)
-	require.NoError(t, err)
-	assert.Equal(t, seq, config.LastSeq)
+	assert.Equal(t, seq, lastSeq)
 
 	err = activeRT.GetDatabase().SGReplicateMgr.DeleteReplication(t.Name())
 	require.NoError(t, err)


### PR DESCRIPTION
CBG-2499

I was unable to reproduce this locally. But my analysis of the problem through the logs provided in the ticket and from running it passing locally, both integration and through walrus, is that the test was maybe executing too fast for the last_sequence field on the checkpoint document to be updated after the replication of the document. Thus I have added a WaitForCondition loop to allow for time for it to be updated if it was to occur again. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1068/
