### PR TITLE
CBG-2520: Modify TestWebhookBasic to avoid timing-sensitive tests

### DIFF
--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -520,7 +520,7 @@ func TestWebhookBasic(t *testing.T) {
 }
 
 func TestWebhookOverflows(t *testing.T) {
-	if true { // Modify conditions
+	if true { // Modify conditions or re-enable once CBG-2281 is fixed
 		t.Skip("Test skipped")
 	}
 	base.LongRunningTest(t)


### PR DESCRIPTION
CBG-2520

Describe your PR here...
- Flaky race-sensitive scenarios in TestWebhookBasic moved to TestWebhookOverflows and disabled until CBG-2281 is resolved.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1077/
