### PR TITLE
CBG-2466: adding trace logging for replication issue

### DIFF
--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -85,6 +85,7 @@ func NewCheckpointer(ctx context.Context, clientID string, configHash string, bl
 func (c *Checkpointer) AddAlreadyKnownSeq(seq ...string) {
 	select {
 	case <-c.ctx.Done():
+		base.TracefCtx(c.ctx, base.KeyReplicate, "Inside AddAlreadyKnownSeq and context has been cancelled")
 		// replicator already closed, bail out of checkpointing work
 		return
 	default:
@@ -102,6 +103,7 @@ func (c *Checkpointer) AddAlreadyKnownSeq(seq ...string) {
 func (c *Checkpointer) AddProcessedSeq(seq string) {
 	select {
 	case <-c.ctx.Done():
+		base.TracefCtx(c.ctx, base.KeyReplicate, "Inside AddProcessedSeq and context has been cancelled")
 		// replicator already closed, bail out of checkpointing work
 		return
 	default:
@@ -116,6 +118,7 @@ func (c *Checkpointer) AddProcessedSeq(seq string) {
 func (c *Checkpointer) AddProcessedSeqIDAndRev(seq string, idAndRev IDAndRev) {
 	select {
 	case <-c.ctx.Done():
+		base.TracefCtx(c.ctx, base.KeyReplicate, "Inside AddProcessedSeqIDAndRev and context has been cancelled")
 		// replicator already closed, bail out of checkpointing work
 		return
 	default:
@@ -144,6 +147,7 @@ func (c *Checkpointer) AddExpectedSeqs(seqs ...string) {
 	select {
 	case <-c.ctx.Done():
 		// replicator already closed, bail out of checkpointing work
+		base.TracefCtx(c.ctx, base.KeyReplicate, "Inside AddExpectedSeqs and context has been cancelled")
 		return
 	default:
 	}
@@ -163,6 +167,7 @@ func (c *Checkpointer) AddExpectedSeqIDAndRevs(seqs map[IDAndRev]string) {
 	select {
 	case <-c.ctx.Done():
 		// replicator already closed, bail out of checkpointing work
+		base.TracefCtx(c.ctx, base.KeyReplicate, "Inside AddExpectedSeqIDAndRevs and context has been cancelled")
 		return
 	default:
 	}
@@ -187,6 +192,7 @@ func (c *Checkpointer) Start() {
 			for {
 				select {
 				case <-ticker.C:
+					base.TracefCtx(c.ctx, base.KeyReplicate, "calling checkpoint now. context is not cancelled here")
 					c.CheckpointNow()
 				case <-c.ctx.Done():
 					base.DebugfCtx(c.ctx, base.KeyReplicate, "checkpointer goroutine stopped")
@@ -234,6 +240,7 @@ func (c *Checkpointer) Stats() CheckpointerStats {
 // _updateCheckpointLists determines the highest checkpointable sequence, and trims the processedSeqs/expectedSeqs lists up to this point.
 func (c *Checkpointer) _updateCheckpointLists() (safeSeq string) {
 	base.TracefCtx(c.ctx, base.KeyReplicate, "checkpointer: _updateCheckpointLists(expectedSeqs: %v, procssedSeqs: %v)", c.expectedSeqs, c.processedSeqs)
+	base.TracefCtx(c.ctx, base.KeyReplicate, "Inside update checkpoint lists")
 
 	maxI := c._calculateSafeExpectedSeqsIdx()
 	if maxI == -1 {
@@ -577,6 +584,7 @@ func (c *Checkpointer) waitForExpectedSequences() error {
 	waitCount := 0
 	for waitCount < 100 {
 		expectedCount, processedCount := c.getCounts()
+		base.TracefCtx(c.ctx, base.KeyReplicate, "Inside waitForExpectedSequences loop expected %d and processed %d", expectedCount, processedCount)
 		if expectedCount == 0 {
 			return nil
 		}
@@ -586,6 +594,7 @@ func (c *Checkpointer) waitForExpectedSequences() error {
 			// in case of bugs that result in expectedCount==processedCount, but the
 			// sets are not identical.  In that scenario, want to sleep before retrying
 			updatedExpectedCount, _ := c.getCounts()
+			base.TracefCtx(c.ctx, base.KeyReplicate, "Inside waitForExpectedSequences updated expected count %d", updatedExpectedCount)
 			if updatedExpectedCount == 0 {
 				return nil
 			}

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -74,6 +74,7 @@ func (apr *ActivePullReplicator) _connect() error {
 	apr.checkpointerCtx, apr.checkpointerCtxCancel = context.WithCancel(apr.ctx)
 	if err := apr._initCheckpointer(); err != nil {
 		// clean up anything we've opened so far
+		base.TracefCtx(apr.ctx, base.KeyReplicate, "Error initialising checkpoint in _connect. Closing everything.")
 		apr.checkpointerCtx = nil
 		apr.blipSender.Close()
 		apr.blipSyncContext.Close()
@@ -94,6 +95,7 @@ func (apr *ActivePullReplicator) _connect() error {
 
 	if err := subChangesRequest.Send(apr.blipSender); err != nil {
 		// clean up anything we've opened so far
+		base.TracefCtx(apr.ctx, base.KeyReplicate, "cancelling the checkpointer context inside _connect where we send blip request")
 		apr.checkpointerCtxCancel()
 		apr.checkpointerCtx = nil
 		apr.blipSender.Close()
@@ -118,14 +120,16 @@ func (apr *ActivePullReplicator) Complete() {
 		apr.lock.Unlock()
 		return
 	}
-
+	base.TracefCtx(apr.ctx, base.KeyReplicate, "Before calling waitForExpectedSequences in Complete()")
 	err := apr.Checkpointer.waitForExpectedSequences()
 	if err != nil {
 		base.InfofCtx(apr.ctx, base.KeyReplicate, "Timeout draining replication %s - stopping: %v", apr.config.ID, err)
 	}
+	base.TracefCtx(apr.ctx, base.KeyReplicate, "Before calling waitForExpectedSequences in Complete()")
 
 	apr._stop()
 
+	base.TracefCtx(apr.ctx, base.KeyReplicate, "Calling disconnect from Complete() in active replicator pull")
 	stopErr := apr._disconnect()
 	if stopErr != nil {
 		base.InfofCtx(apr.ctx, base.KeyReplicate, "Error attempting to stop replication %s: %v", apr.config.ID, stopErr)
@@ -225,6 +229,7 @@ func (apr *ActivePullReplicator) registerCheckpointerCallbacks() {
 		apr.blipSyncContext.emptyChangesMessageCallback = func() {
 			// Complete blocks waiting for pending rev messages, so needs
 			// it's own goroutine
+			base.TracefCtx(apr.ctx, base.KeyReplicate, "calling complete from registerCheckpointerCallbacks, because we have empty callback")
 			go apr.Complete()
 		}
 	}
@@ -232,6 +237,7 @@ func (apr *ActivePullReplicator) registerCheckpointerCallbacks() {
 
 // Stop stops the pull replication and waits for the sub changes goroutine to finish.
 func (apr *ActivePullReplicator) Stop() error {
+	base.TracefCtx(apr.ctx, base.KeyReplicate, "Calling stop and disconnect from Stop()")
 	if err := apr.stopAndDisconnect(); err != nil {
 		return err
 	}


### PR DESCRIPTION
CBG-2466

Hit a brickwall with understanding what is going on with the one time replication in the issue above. Adding trace logging all around the areas of interest and get QE to rerun the tests provided update logs and we can see what is happening. Please review and see if you think I need to add more logging/better messages or if there are any areas of interest I am missing. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
