### PR TITLE
CBG-2550 Principal Collection Access

### DIFF
--- a/auth/collection_access.go
+++ b/auth/collection_access.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package auth
 
 import (

--- a/auth/collection_access.go
+++ b/auth/collection_access.go
@@ -1,0 +1,95 @@
+package auth
+
+import (
+	"github.com/couchbase/sync_gateway/base"
+	ch "github.com/couchbase/sync_gateway/channels"
+	"time"
+)
+
+// PrincipalCollectionAccess defines the common interface for managing channel access for a role or user for
+// a single collection.
+type PrincipalCollectionAccess interface {
+
+	// Retrieve all channels for a collection
+	CollectionChannels(scope, collection string) ch.TimedSet
+
+	// Sets all channels for a collection.
+	setCollectionChannels(scope, collection string, channels ch.TimedSet)
+
+	// Retrieve admin-granted channels for a collection
+	CollectionExplicitChannels(scope, collection string) ch.TimedSet
+
+	// Set admin-granted channels for a collection
+	SetCollectionExplicitChannels(scope, collection string, channels ch.TimedSet, seq uint64)
+
+	// Retrieve channel history for a collection
+	CollectionChannelHistory(scope, collection string) TimedSetHistory
+
+	// Set channel history for a collection
+	SetCollectionChannelHistory(scope, collection string, history TimedSetHistory)
+
+	// Returns true if the Principal has access to the given channel.
+	CanSeeCollectionChannel(scope, collection, channel string) bool
+
+	// Retrieve invalidation sequence for a collection
+	getCollectionChannelInvalSeq(scope, collection string) uint64
+
+	// Set invalidation sequence for a collection
+	setCollectionChannelInvalSeq(scope, collection string, seq uint64)
+
+	// The set of invalidated channels for a collection
+	// Returns nil if not invalidated
+	collectionInvalidatedChannels(scope, collection string) ch.TimedSet
+
+	// If the Principal has access to the given collection's channel, returns the sequence number at which
+	// access was granted; else returns zero.
+	canSeeCollectionChannelSince(scope, collection, channel string) uint64
+
+	// Returns an error if the Principal does not have access to all the channels in the set, for the specified collection.
+	authorizeAllCollectionChannels(scope, collection string, channels base.Set) error
+
+	// Returns an error if the Principal does not have access to any of the channels in the set, for the specified collection
+	authorizeAnyCollectionChannel(scope, collection string, channels base.Set) error
+}
+
+// UserCollection defines the interface for managing channel access that is supported by users but not roles.
+type UserCollectionAccess interface {
+	// Retrieves JWT channels for a collection
+	CollectionJWTChannels(scope, collection string) ch.TimedSet
+
+	// Sets JWT channels for a collection
+	SetCollectionJWTChannels(scope, collection string, channels ch.TimedSet, seq uint64)
+
+	// Retrieves revoked channels for a collection, based on the given since value
+	RevokedCollectionChannels(scope, collection string, since uint64, lowSeq uint64, triggeredBy uint64) RevokedChannels
+
+	// Obtains the period over which the user had access to the given collection's channel. Either directly or via a role.
+	CollectionChannelGrantedPeriods(scope, collection, chanName string) ([]GrantHistorySequencePair, error)
+
+	// Every channel the user has access to in the collection, including those inherited from Roles.
+	InheritedCollectionChannels(scope, collection string) ch.TimedSet
+
+	// Returns a TimedSet containing only the channels from the input set that the user has access
+	// to for the collection, annotated with the sequence number at which access was granted.
+	// Returns a string array containing any channels filtered out due to the user not having access
+	// to them.
+	FilterToAvailableCollectionChannels(scope, collection string, channels ch.Set) (filtered ch.TimedSet, removed []string)
+
+	// If the input set contains the wildcard "*" channel, returns the user's InheritedChannels for the collection;
+	// else returns the input channel list unaltered.
+	expandCollectionWildCardChannel(scope, collection string, channels base.Set) base.Set
+}
+
+// Defines channel grants and history for a single collection
+type CollectionAccess struct {
+	ExplicitChannels_ ch.TimedSet     `json:"admin_channels,omitempty"`
+	Channels_         ch.TimedSet     `json:"all_channels,omitempty"`
+	ChannelHistory_   TimedSetHistory `json:"channel_history,omitempty"`   // Added to when a previously granted channel is revoked. Calculated inside of rebuildChannels.
+	ChannelInvalSeq   uint64          `json:"channel_inval_seq,omitempty"` // Sequence at which the channels were invalidated. Data remains in Channels_ for history calculation.
+	JWTChannels       ch.TimedSet     `json:"jwt_channels,omitempty"`      // TODO: JWT properties should only be populated for user but would like to share scope/collection map
+	JWTLastUpdated    *time.Time      `json:"jwt_last_updated,omitempty"`
+}
+
+func (ca *CollectionAccess) CanSeeChannel(channel string) bool {
+	return ca.Channels().Contains(channel) || ca.Channels().Contains(ch.UserStarChannel)
+}

--- a/auth/collection_access.go
+++ b/auth/collection_access.go
@@ -1,9 +1,10 @@
 package auth
 
 import (
+	"time"
+
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
-	"time"
 )
 
 // PrincipalCollectionAccess defines the common interface for managing channel access for a role or user for

--- a/auth/collection_access_test.go
+++ b/auth/collection_access_test.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package auth
 
 import (

--- a/auth/collection_access_test.go
+++ b/auth/collection_access_test.go
@@ -2,12 +2,13 @@ package auth
 
 import (
 	"bytes"
+	"log"
+	"testing"
+
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"log"
-	"testing"
 )
 
 func canSeeAllCollectionChannels(scope, collection string, princ Principal, channels base.Set) bool {

--- a/auth/collection_access_test.go
+++ b/auth/collection_access_test.go
@@ -1,0 +1,192 @@
+package auth
+
+import (
+	"bytes"
+	"github.com/couchbase/sync_gateway/base"
+	ch "github.com/couchbase/sync_gateway/channels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"log"
+	"testing"
+)
+
+func canSeeAllCollectionChannels(scope, collection string, princ Principal, channels base.Set) bool {
+	for channel := range channels {
+		if !princ.CanSeeCollectionChannel(scope, collection, channel) {
+			return false
+		}
+	}
+	return true
+}
+
+func TestUserCollectionAccess(t *testing.T) {
+
+	// User with no access:
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
+	user, _ := auth.NewUser("foo", "password", nil)
+	scope := "scope1"
+	collection := "collection1"
+	otherScope := "scope2"
+	otherCollection := "collection2"
+	nonMatchingCollections := [][2]string{{base.DefaultScope, base.DefaultCollection}, {scope, otherCollection}, {otherScope, collection}, {otherScope, otherCollection}}
+	// Default collection checks
+	assert.Equal(t, ch.BaseSetOf(t, "!"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
+	assert.False(t, user.CanSeeChannel("x"))
+	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t)))
+	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x")))
+	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x", "y")))
+	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "*")))
+	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
+	assert.False(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t)) == nil)
+	// Named collection checks
+	assert.Equal(t, ch.BaseSetOf(t, "!"), user.expandCollectionWildCardChannel(scope, collection, ch.BaseSetOf(t, "*")))
+	assert.True(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t)))
+	assert.False(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t, "x")))
+	assert.False(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t, "x", "y")))
+	assert.False(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t, "*")))
+	assert.False(t, user.authorizeAllCollectionChannels(scope, collection, ch.BaseSetOf(t, "*")) == nil)
+	assert.False(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t)) == nil)
+
+	// User with access to one channel in named collection:
+	user.setCollectionChannels(scope, collection, ch.AtSequence(ch.BaseSetOf(t, "x"), 1))
+	// Matching named collection checks
+	assert.Equal(t, ch.BaseSetOf(t, "x"), user.expandCollectionWildCardChannel(scope, collection, ch.BaseSetOf(t, "*")))
+	assert.True(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t)))
+	assert.True(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t, "x")))
+	assert.False(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t, "x", "y")))
+	assert.False(t, user.authorizeAllCollectionChannels(scope, collection, ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.authorizeAllCollectionChannels(scope, collection, ch.BaseSetOf(t, "*")) == nil)
+	assert.True(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "y")) == nil)
+	assert.False(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t)) == nil)
+	// Non-matching collection checks
+	for _, pair := range nonMatchingCollections {
+		s := pair[0]
+		c := pair[1]
+		assert.Equal(t, ch.BaseSetOf(t, "!"), user.expandCollectionWildCardChannel(s, c, ch.BaseSetOf(t, "*")))
+		assert.True(t, canSeeAllCollectionChannels(s, c, user, ch.BaseSetOf(t)))
+		assert.False(t, canSeeAllCollectionChannels(s, c, user, ch.BaseSetOf(t, "x")))
+		assert.False(t, canSeeAllCollectionChannels(s, c, user, ch.BaseSetOf(t, "x", "y")))
+		assert.False(t, user.authorizeAllCollectionChannels(s, c, ch.BaseSetOf(t, "x", "y")) == nil)
+		assert.False(t, user.authorizeAllCollectionChannels(s, c, ch.BaseSetOf(t, "*")) == nil)
+		assert.False(t, user.authorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t, "x", "y")) == nil)
+		assert.False(t, user.authorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t, "y")) == nil)
+		assert.False(t, user.authorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t)) == nil)
+	}
+
+	// User with access to two channels:
+	// User with access to one channel in named collection:
+	user.setCollectionChannels(scope, collection, ch.AtSequence(ch.BaseSetOf(t, "x", "y"), 1))
+	// Matching named collection checks
+	assert.Equal(t, ch.BaseSetOf(t, "x", "y"), user.expandCollectionWildCardChannel(scope, collection, ch.BaseSetOf(t, "*")))
+	assert.True(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t)))
+	assert.True(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t, "x")))
+	assert.True(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t, "x", "y")))
+	assert.False(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t, "x", "y", "z")))
+	assert.True(t, user.authorizeAllCollectionChannels(scope, collection, ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.authorizeAllCollectionChannels(scope, collection, ch.BaseSetOf(t, "*")) == nil)
+	assert.True(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.True(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "y")) == nil)
+	assert.False(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "z")) == nil)
+	assert.False(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t)) == nil)
+	// Non-matching collection checks
+	for _, pair := range nonMatchingCollections {
+		s := pair[0]
+		c := pair[1]
+		assert.Equal(t, ch.BaseSetOf(t, "!"), user.expandCollectionWildCardChannel(s, c, ch.BaseSetOf(t, "*")))
+		assert.True(t, canSeeAllCollectionChannels(s, c, user, ch.BaseSetOf(t)))
+		assert.False(t, canSeeAllCollectionChannels(s, c, user, ch.BaseSetOf(t, "x")))
+		assert.False(t, canSeeAllCollectionChannels(s, c, user, ch.BaseSetOf(t, "x", "y")))
+		assert.False(t, user.authorizeAllCollectionChannels(s, c, ch.BaseSetOf(t, "x", "y")) == nil)
+		assert.False(t, user.authorizeAllCollectionChannels(s, c, ch.BaseSetOf(t, "*")) == nil)
+		assert.False(t, user.authorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t, "x", "y")) == nil)
+		assert.False(t, user.authorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t, "y")) == nil)
+		assert.False(t, user.authorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t)) == nil)
+	}
+
+	// User with wildcard access:
+	user.setCollectionChannels(scope, collection, ch.AtSequence(ch.BaseSetOf(t, "*", "q"), 1))
+	// Legacy default collection checks
+	assert.Equal(t, ch.BaseSetOf(t, "!"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
+	assert.False(t, user.CanSeeChannel("*"))
+	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t)))
+	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x")))
+	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x", "y")))
+	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
+	assert.False(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t, "x")) == nil)
+	assert.False(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t, "*")) == nil)
+	assert.False(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t)) == nil)
+	// Matching named collection checks
+	assert.Equal(t, ch.BaseSetOf(t, "*", "q"), user.expandCollectionWildCardChannel(scope, collection, ch.BaseSetOf(t, "*")))
+	assert.True(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t)))
+	assert.True(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t, "x")))
+	assert.True(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t, "x", "y")))
+	assert.True(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t, "x", "y", "z")))
+	assert.True(t, user.authorizeAllCollectionChannels(scope, collection, ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.True(t, user.authorizeAllCollectionChannels(scope, collection, ch.BaseSetOf(t, "*")) == nil)
+	assert.True(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.True(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "y")) == nil)
+	assert.True(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "z")) == nil)
+	assert.True(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t)) == nil)
+	// Non-matching collection checks
+	for _, pair := range nonMatchingCollections {
+		s := pair[0]
+		c := pair[1]
+		assert.Equal(t, ch.BaseSetOf(t, "!"), user.expandCollectionWildCardChannel(s, c, ch.BaseSetOf(t, "*")))
+		assert.True(t, canSeeAllCollectionChannels(s, c, user, ch.BaseSetOf(t)))
+		assert.False(t, canSeeAllCollectionChannels(s, c, user, ch.BaseSetOf(t, "x")))
+		assert.False(t, canSeeAllCollectionChannels(s, c, user, ch.BaseSetOf(t, "x", "y")))
+		assert.False(t, user.authorizeAllCollectionChannels(s, c, ch.BaseSetOf(t, "x", "y")) == nil)
+		assert.False(t, user.authorizeAllCollectionChannels(s, c, ch.BaseSetOf(t, "*")) == nil)
+		assert.False(t, user.authorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t, "x", "y")) == nil)
+		assert.False(t, user.authorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t, "y")) == nil)
+		assert.False(t, user.authorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t)) == nil)
+	}
+}
+
+func TestSerializeUserWithCollections(t *testing.T) {
+
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
+	user, _ := auth.NewUser("me", "letmein", ch.BaseSetOf(t, "me", "public"))
+	encoded, err := base.JSONMarshal(user)
+	require.NoError(t, err)
+	assert.True(t, encoded != nil)
+
+	// Ensure empty scopes and collections aren't marshalled
+	assert.False(t, bytes.Contains(encoded, []byte("collection_access")))
+	scope := "testScope"
+	collection := "testCollection"
+	user.SetCollectionExplicitChannels(scope, collection, ch.AtSequence(ch.BaseSetOf(t, "x"), 1), 1)
+	encoded, err = base.JSONMarshal(user)
+	require.NoError(t, err)
+	log.Printf("Marshaled User as: %s", encoded)
+
+	resu := &userImpl{auth: auth}
+	err = base.JSONUnmarshal(encoded, resu)
+	require.NoError(t, err)
+	collectionAccess, ok := resu.getCollectionAccess(scope, collection)
+	require.True(t, ok)
+	ch, exists := collectionAccess.ExplicitChannels_["x"]
+	require.True(t, exists)
+	assert.True(t, ch.Sequence == 1)
+
+	// Remove all channels for scope and collection
+	user.SetCollectionExplicitChannels(scope, collection, nil, 2)
+	encoded, err = base.JSONMarshal(user)
+	require.NoError(t, err)
+	log.Printf("Marshaled User as: %s", encoded)
+	resu = &userImpl{auth: auth}
+	err = base.JSONUnmarshal(encoded, resu)
+	require.NoError(t, err)
+	collectionAccess, ok = resu.getCollectionAccess(scope, collection)
+	assert.True(t, ok)
+	assert.Equal(t, 0, len(collectionAccess.ExplicitChannels_))
+	assert.Equal(t, uint64(2), user.getCollectionChannelInvalSeq(scope, collection))
+}

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -79,6 +79,8 @@ type Principal interface {
 
 	setDeleted(bool)
 	IsDeleted() bool
+
+	PrincipalCollectionAccess
 }
 
 // Role is basically the same as Principal, just concrete. Users can inherit channels from Roles.
@@ -160,6 +162,8 @@ type User interface {
 	FilterToAvailableChannels(channels ch.Set) (filtered ch.TimedSet, removed []string)
 
 	setRolesSince(ch.TimedSet)
+
+	UserCollectionAccess
 }
 
 // PrincipalConfig represents a user/role as a JSON object.

--- a/auth/role_collection_access.go
+++ b/auth/role_collection_access.go
@@ -1,8 +1,16 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package auth
 
 import (
 	"fmt"
-	
+
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
 )

--- a/auth/role_collection_access.go
+++ b/auth/role_collection_access.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"fmt"
+	
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
 )

--- a/auth/role_collection_access.go
+++ b/auth/role_collection_access.go
@@ -1,0 +1,216 @@
+package auth
+
+import (
+	"fmt"
+	"github.com/couchbase/sync_gateway/base"
+	ch "github.com/couchbase/sync_gateway/channels"
+)
+
+var _ PrincipalCollectionAccess = &roleImpl{}
+
+// getCollectionAccess retrieves collection-specific access information for the roleImpl
+func (role *roleImpl) getCollectionAccess(scope, collection string) (*CollectionAccess, bool) {
+	ca, ok := role.CollectionsAccess[scope][collection]
+	return ca, ok
+}
+
+// Gets collection-specific access for the roleImpl.  Creates if not found
+func (role *roleImpl) getOrCreateCollectionAccess(scope, collection string) *CollectionAccess {
+
+	ca, ok := role.getCollectionAccess(scope, collection)
+	if ok {
+		return ca
+	}
+
+	// Get or create Scope map
+	var scopeAccess map[string]*CollectionAccess
+	scopeAccess, ok = role.CollectionsAccess[scope]
+	if !ok {
+		if role.CollectionsAccess == nil {
+			role.CollectionsAccess = make(map[string]map[string]*CollectionAccess)
+		}
+		scopeAccess = make(map[string]*CollectionAccess)
+		role.CollectionsAccess[scope] = scopeAccess
+	}
+
+	newCollectionAccess := &CollectionAccess{}
+	scopeAccess[collection] = newCollectionAccess
+	return newCollectionAccess
+}
+
+// Collection-aware role handlers
+func (role *roleImpl) CollectionChannels(scope, collection string) ch.TimedSet {
+	if base.IsDefaultCollection(scope, collection) {
+		return role.Channels()
+	}
+
+	if cc, ok := role.getCollectionAccess(scope, collection); ok {
+		if cc.ChannelInvalSeq != 0 {
+			return nil
+		}
+		return cc.Channels_
+	}
+	// Access always granted to public channel, even if channels aren't otherwise defined for the collection
+	// always grant access to the public document channel
+	return ch.TimedSet{ch.DocumentStarChannel: ch.NewVbSimpleSequence(1)}
+}
+
+func (role *roleImpl) CollectionExplicitChannels(scope, collection string) ch.TimedSet {
+	if base.IsDefaultCollection(scope, collection) {
+		return role.ExplicitChannels()
+	}
+
+	if cc, ok := role.getCollectionAccess(scope, collection); ok {
+		return cc.ExplicitChannels_
+	}
+	return nil
+}
+
+func (role *roleImpl) SetCollectionExplicitChannels(scope, collection string, channels ch.TimedSet, invalSeq uint64) {
+	if base.IsDefaultCollection(scope, collection) {
+		role.SetExplicitChannels(channels, invalSeq)
+		return
+	}
+
+	cc := role.getOrCreateCollectionAccess(scope, collection)
+	cc.ExplicitChannels_ = channels
+	cc.ChannelInvalSeq = invalSeq
+}
+
+func (role *roleImpl) setCollectionChannels(scope, collection string, channels ch.TimedSet) {
+	if base.IsDefaultCollection(scope, collection) {
+		role.setChannels(channels)
+		return
+	}
+	cc := role.getOrCreateCollectionAccess(scope, collection)
+	cc.Channels_ = channels
+}
+
+func (role *roleImpl) getCollectionChannelInvalSeq(scope, collection string) uint64 {
+	if base.IsDefaultCollection(scope, collection) {
+		return role.GetChannelInvalSeq()
+	}
+
+	if cc, ok := role.getCollectionAccess(scope, collection); ok {
+		return cc.ChannelInvalSeq
+	}
+	return 0
+}
+
+func (role *roleImpl) setCollectionChannelInvalSeq(scope, collection string, invalSeq uint64) {
+	if base.IsDefaultCollection(scope, collection) {
+		role.SetChannelInvalSeq(invalSeq)
+		return
+	}
+
+	cc := role.getOrCreateCollectionAccess(scope, collection)
+	cc.ChannelInvalSeq = invalSeq
+}
+
+func (role *roleImpl) collectionInvalidatedChannels(scope, collection string) ch.TimedSet {
+	if base.IsDefaultCollection(scope, collection) {
+		return role.InvalidatedChannels()
+	}
+
+	if cc, ok := role.getCollectionAccess(scope, collection); ok {
+		if cc.ChannelInvalSeq != 0 {
+			return cc.Channels_
+		}
+	}
+	return nil
+}
+
+func (role *roleImpl) CollectionChannelHistory(scope, collection string) TimedSetHistory {
+	if base.IsDefaultCollection(scope, collection) {
+		return role.ChannelHistory()
+	}
+
+	if cc, ok := role.getCollectionAccess(scope, collection); ok {
+		return cc.ChannelHistory_
+	}
+	return nil
+}
+
+func (role *roleImpl) SetCollectionChannelHistory(scope, collection string, history TimedSetHistory) {
+	if base.IsDefaultCollection(scope, collection) {
+		role.SetChannelHistory(history)
+		return
+	}
+
+	cc := role.getOrCreateCollectionAccess(scope, collection)
+	cc.ChannelHistory_ = history
+}
+
+// Returns true if the Role is allowed to access the channel.
+// A nil Role means access control is disabled, so the function will return true.
+func (role *roleImpl) CanSeeCollectionChannel(scope, collection, channel string) bool {
+	if base.IsDefaultCollection(scope, collection) {
+		return role.CanSeeChannel(channel)
+	}
+
+	if role == nil {
+		return true
+	}
+	if cc, ok := role.getCollectionAccess(scope, collection); ok {
+		return cc.Channels().Contains(channel) || cc.Channels().Contains(ch.UserStarChannel)
+	}
+	return false
+}
+
+// Returns the sequence number since which the Role has been able to access the channel, else zero.
+func (role *roleImpl) canSeeCollectionChannelSince(scope, collection, channel string) uint64 {
+	if base.IsDefaultCollection(scope, collection) {
+		return role.CanSeeChannelSince(channel)
+	}
+
+	if cc, ok := role.getCollectionAccess(scope, collection); ok {
+		seq := cc.Channels()[channel]
+		if seq.Sequence == 0 {
+			seq = cc.Channels()[ch.UserStarChannel]
+		}
+	}
+	return 0
+}
+
+func (role *roleImpl) authorizeAllCollectionChannels(scope, collection string, channels base.Set) error {
+	if base.IsDefaultCollection(scope, collection) {
+		return role.AuthorizeAllChannels(channels)
+	}
+
+	if ca, ok := role.getCollectionAccess(scope, collection); ok {
+		var forbidden []string
+		for channel := range channels {
+			if !ca.CanSeeChannel(channel) {
+				if forbidden == nil {
+					forbidden = make([]string, 0, len(channels))
+				}
+				forbidden = append(forbidden, channel)
+			}
+		}
+		if forbidden != nil {
+			return role.UnauthError(fmt.Sprintf("You are not allowed to see channels %v", forbidden))
+		}
+		return nil
+	}
+	return role.UnauthError(fmt.Sprintf("Unauthorized to see channels %v", channels))
+}
+
+// Returns an error if the Principal does not have access to any of the channels in the set.
+func (role *roleImpl) authorizeAnyCollectionChannel(scope, collection string, channels base.Set) error {
+	if base.IsDefaultCollection(scope, collection) {
+		return role.AuthorizeAnyChannel(channels)
+	}
+
+	if ca, ok := role.getCollectionAccess(scope, collection); ok {
+		if len(channels) > 0 {
+			for channel := range channels {
+				if ca.CanSeeChannel(channel) {
+					return nil
+				}
+			}
+		} else if ca.Channels().Contains(ch.UserStarChannel) {
+			return nil
+		}
+	}
+	return role.UnauthError("You are not allowed to see this")
+}

--- a/auth/user.go
+++ b/auth/user.go
@@ -242,7 +242,11 @@ func (revokedChannels RevokedChannels) add(chanName string, triggeredBy uint64) 
 	}
 }
 
-// RevokedChannels returns a map of revoked channels => most recent sequence at which access to that channel was lost
+func (user *userImpl) RevokedChannels(since uint64, lowSeq uint64, triggeredBy uint64) RevokedChannels {
+	return user.RevokedCollectionChannels(base.DefaultScope, base.DefaultCollection, since, lowSeq, triggeredBy)
+}
+
+// RevokedCollectionChannels returns a map of revoked channels for the collection => most recent sequence at which access to that channel was lost
 // Steps:
 // Get revoked roles and for each:
 //   - Revoke the current channels if the role is deleted
@@ -253,7 +257,7 @@ func (revokedChannels RevokedChannels) add(chanName string, triggeredBy uint64) 
 //
 // Get user:
 //   - Revoke users revoked channels
-func (user *userImpl) RevokedChannels(since uint64, lowSeq uint64, triggeredBy uint64) RevokedChannels {
+func (user *userImpl) RevokedCollectionChannels(scope string, collection string, since uint64, lowSeq uint64, triggeredBy uint64) RevokedChannels {
 	// checkSeq represents the value that we use to 'diff' against ie. What channels did the user have at checkSeq but
 	// no longer has.
 	// In the event we have a lowSeq that will be used.
@@ -274,7 +278,7 @@ func (user *userImpl) RevokedChannels(since uint64, lowSeq uint64, triggeredBy u
 	// If there has been a revocation somewhere after the since value or we're in an interrupted revocation backfill
 	// at the point a revocation occurred we should return this as a channel to revoke.
 
-	accessibleChannels := user.InheritedChannels()
+	accessibleChannels := user.InheritedCollectionChannels(scope, collection)
 	// Get revoked roles
 	rolesToRevoke := map[string]uint64{}
 	roleHistory := user.RoleHistory()
@@ -295,7 +299,7 @@ func (user *userImpl) RevokedChannels(since uint64, lowSeq uint64, triggeredBy u
 
 	// revokeChannelHistoryProcessing iterates over a principals channel history and if not accessible add to combined
 	revokeChannelHistoryProcessing := func(princ Principal) {
-		for chanName, history := range princ.ChannelHistory() {
+		for chanName, history := range princ.CollectionChannelHistory(scope, collection) {
 			if !accessibleChannels.Contains(chanName) {
 				for _, entry := range history.Entries {
 					if entry.EndSeq > checkSeq || entry.EndSeq == triggeredBy {
@@ -319,7 +323,7 @@ func (user *userImpl) RevokedChannels(since uint64, lowSeq uint64, triggeredBy u
 		// First check 'current channels' if role isn't deleted
 		// Current roles should be invalidated on deleted anyway but for safety
 		if !role.IsDeleted() {
-			for _, chanName := range role.Channels().AllKeys() {
+			for _, chanName := range role.CollectionChannels(scope, collection).AllKeys() {
 				if !accessibleChannels.Contains(chanName) {
 					combinedRevokedChannels.add(chanName, roleRevokeSeq)
 				}
@@ -327,7 +331,7 @@ func (user *userImpl) RevokedChannels(since uint64, lowSeq uint64, triggeredBy u
 		}
 
 		// Second check the channel history and add any revoked channels
-		for chanName, history := range role.ChannelHistory() {
+		for chanName, history := range role.CollectionChannelHistory(scope, collection) {
 			if !accessibleChannels.Contains(chanName) {
 				for _, channelEntry := range history.Entries {
 					if channelEntry.EndSeq > checkSeq || channelEntry.EndSeq == triggeredBy {
@@ -359,18 +363,22 @@ func (user *userImpl) RevokedChannels(since uint64, lowSeq uint64, triggeredBy u
 	return combinedRevokedChannels
 }
 
-// Calculate periods where user had access to the given channel either directly or via a role
 func (user *userImpl) ChannelGrantedPeriods(chanName string) ([]GrantHistorySequencePair, error) {
+	return user.CollectionChannelGrantedPeriods(base.DefaultScope, base.DefaultCollection, chanName)
+}
+
+// Calculate periods where user had access to the given channel either directly or via a role
+func (user *userImpl) CollectionChannelGrantedPeriods(scope, collection, chanName string) ([]GrantHistorySequencePair, error) {
 	var resultPairs []GrantHistorySequencePair
 
 	// Grab user history and use this to begin the resultPairs
-	userChannelHistory, ok := user.ChannelHistory()[chanName]
+	userChannelHistory, ok := user.CollectionChannelHistory(scope, collection)[chanName]
 	if ok {
 		resultPairs = userChannelHistory.Entries
 	}
 
 	// Iterate over current user channels and add to resultPairs
-	for channelName, chanInfo := range user.Channels() {
+	for channelName, chanInfo := range user.CollectionChannels(scope, collection) {
 		if channelName != chanName {
 			continue
 		}
@@ -396,7 +404,7 @@ func (user *userImpl) ChannelGrantedPeriods(chanName string) ([]GrantHistorySequ
 	for _, currentRole := range user.GetRoles() {
 
 		// Grab pairs from channel history on current roles
-		roleChannelHistory, ok := currentRole.ChannelHistory()[chanName]
+		roleChannelHistory, ok := currentRole.CollectionChannelHistory(scope, collection)[chanName]
 		if ok {
 			for _, roleChannelHistoryEntry := range roleChannelHistory.Entries {
 				roleGrantedAt := user.RolesSince_[currentRole.Name()].Sequence
@@ -405,8 +413,8 @@ func (user *userImpl) ChannelGrantedPeriods(chanName string) ([]GrantHistorySequ
 		}
 
 		// Grab pairs from current channels on current roles
-		if currentRole.Channels().Contains(chanName) {
-			for _, channelInfo := range currentRole.Channels() {
+		if currentRole.CollectionChannels(scope, collection).Contains(chanName) {
+			for _, channelInfo := range currentRole.CollectionChannels(scope, collection) {
 				resultPairs = append(resultPairs, GrantHistorySequencePair{
 					StartSeq: channelInfo.Sequence,
 					EndSeq:   math.MaxUint64,
@@ -431,7 +439,7 @@ func (user *userImpl) ChannelGrantedPeriods(chanName string) ([]GrantHistorySequ
 		}
 
 		// Iterate over channel history on old roles
-		roleChannelHistory, ok := role.ChannelHistory()[chanName]
+		roleChannelHistory, ok := role.CollectionChannelHistory(scope, collection)[chanName]
 		if ok {
 			for _, roleChannelHistoryEntry := range roleChannelHistory.Entries {
 				for _, roleHistoryEntry := range historyEntry.Entries {
@@ -441,8 +449,8 @@ func (user *userImpl) ChannelGrantedPeriods(chanName string) ([]GrantHistorySequ
 		}
 
 		// Iterate over current channels on old roles
-		if role.Channels().Contains(chanName) {
-			for _, activeChannel := range role.Channels() {
+		if role.CollectionChannels(scope, collection).Contains(chanName) {
+			for _, activeChannel := range role.CollectionChannels(scope, collection) {
 				for _, roleHistoryEntry := range historyEntry.Entries {
 					compareAndAddPair(activeChannel.Sequence, roleHistoryEntry.StartSeq, math.MaxUint64, roleHistoryEntry.EndSeq)
 				}
@@ -582,19 +590,27 @@ func (user *userImpl) InheritedChannels() ch.TimedSet {
 
 // If a channel list contains the all-channel wildcard, replace it with all the user's accessible channels.
 func (user *userImpl) ExpandWildCardChannel(channels base.Set) base.Set {
+	return user.expandCollectionWildCardChannel(base.DefaultScope, base.DefaultCollection, channels)
+}
+
+func (user *userImpl) expandCollectionWildCardChannel(scope, collection string, channels base.Set) base.Set {
 	if channels.Contains(ch.AllChannelWildcard) {
-		channels = user.InheritedChannels().AsSet()
+		channels = user.InheritedCollectionChannels(scope, collection).AsSet()
 	}
 	return channels
 }
 
 func (user *userImpl) FilterToAvailableChannels(channels ch.Set) (filtered ch.TimedSet, removed []string) {
+	return user.FilterToAvailableCollectionChannels(base.DefaultScope, base.DefaultCollection, channels)
+}
+
+func (user *userImpl) FilterToAvailableCollectionChannels(scope, collection string, channels ch.Set) (filtered ch.TimedSet, removed []string) {
 	filtered = ch.TimedSet{}
 	for channel := range channels {
 		if channel.Name == ch.AllChannelWildcard {
-			return user.InheritedChannels().Copy(), nil
+			return user.InheritedCollectionChannels(scope, collection).Copy(), nil
 		}
-		added := filtered.AddChannel(channel.Name, user.CanSeeChannelSince(channel.Name))
+		added := filtered.AddChannel(channel.Name, user.canSeeCollectionChannelSince(scope, collection, channel.Name))
 		if !added {
 			removed = append(removed, channel.Name)
 		}

--- a/auth/user_collection_access.go
+++ b/auth/user_collection_access.go
@@ -1,3 +1,11 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package auth
 
 import (

--- a/auth/user_collection_access.go
+++ b/auth/user_collection_access.go
@@ -1,0 +1,65 @@
+package auth
+
+import (
+	"github.com/couchbase/sync_gateway/base"
+	ch "github.com/couchbase/sync_gateway/channels"
+)
+
+var _ UserCollectionAccess = &userImpl{}
+
+func (user *userImpl) CollectionJWTChannels(scope, collection string) ch.TimedSet {
+	if base.IsDefaultCollection(scope, collection) {
+		return user.JWTChannels()
+	}
+
+	if cc, ok := user.getCollectionAccess(scope, collection); ok {
+		return cc.JWTChannels
+	}
+	return nil
+}
+
+func (user *userImpl) SetCollectionJWTChannels(scope, collection string, channels ch.TimedSet, invalSeq uint64) {
+	if base.IsDefaultCollection(scope, collection) {
+		user.SetJWTChannels(channels, invalSeq)
+		return
+	}
+
+	cc := user.getOrCreateCollectionAccess(scope, collection)
+	cc.JWTChannels = channels
+	cc.ChannelInvalSeq = invalSeq
+}
+
+func (user *userImpl) CanSeeCollectionChannel(scope, collection, channel string) bool {
+	if user.roleImpl.CanSeeCollectionChannel(scope, collection, channel) {
+		return true
+	}
+	for _, role := range user.GetRoles() {
+		if role.CanSeeCollectionChannel(scope, collection, channel) {
+			return true
+		}
+	}
+	return false
+}
+
+func (user *userImpl) InheritedCollectionChannels(scope, collection string) ch.TimedSet {
+
+	channels := user.CollectionChannels(scope, collection).Copy()
+	for _, role := range user.GetRoles() {
+		roleSince := user.RoleNames()[role.Name()]
+		channels.AddAtSequence(role.CollectionChannels(scope, collection), roleSince.Sequence)
+	}
+
+	// TODO: should warning threshold be per-collection, or cross-collection?  If the latter, hard to compute, as
+	//  we lazily fetch channels per collection
+	user.warnChanThresholdOnce.Do(func() {
+		if channelsPerUserThreshold := user.auth.ChannelsWarningThreshold; channelsPerUserThreshold != nil {
+			channelCount := len(channels)
+			if uint32(channelCount) >= *channelsPerUserThreshold {
+				base.WarnfCtx(user.auth.LogCtx, "User ID: %v channel count: %d exceeds %d for channels per user warning threshold",
+					base.UD(user.Name()), channelCount, *channelsPerUserThreshold)
+			}
+		}
+	})
+
+	return channels
+}

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -26,7 +26,11 @@ var _ N1QLStore = &Collection{}
 
 // IsDefaultScopeCollection returns true if the given Collection is on the _default._default scope and collection.
 func (c *Collection) IsDefaultScopeCollection() bool {
-	return c.ScopeName() == DefaultScope && c.Name() == DefaultCollection
+	return IsDefaultCollection(c.ScopeName(), c.Name())
+}
+
+func IsDefaultCollection(scope, collection string) bool {
+	return scope == DefaultScope && collection == DefaultCollection
 }
 
 // EscapedKeyspace returns the escaped fully-qualified identifier for the keyspace (e.g. `bucket`.`scope`.`collection`)


### PR DESCRIPTION
CBG-2550

Principal Collection Access

Adds storage for non-default collection channel access to principals. Access for the default collection uses the existing root-level storage for backward compatibility, named collections are stored in nested map by scope, collection.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1099/
