### PR TITLE
Make GetCollectionID not return an error

### DIFF
--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -61,9 +61,7 @@ func TestOneShotDCP(t *testing.T) {
 	require.NoError(t, err)
 	var collectionIDs []uint32
 	if collection.IsSupported(sgbucket.DataStoreFeatureCollections) {
-		collectionID, err := collection.GetCollectionID()
-		require.NoError(t, err)
-		collectionIDs = append(collectionIDs, collectionID)
+		collectionIDs = append(collectionIDs, collection.GetCollectionID())
 	}
 
 	clientOptions := DCPClientOptions{
@@ -230,9 +228,7 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 			require.NoError(t, err)
 			var collectionIDs []uint32
 			if collection.IsSupported(sgbucket.DataStoreFeatureCollections) {
-				collectionID, err := collection.GetCollectionID()
-				require.NoError(t, err)
-				collectionIDs = append(collectionIDs, collectionID)
+				collectionIDs = append(collectionIDs, collection.GetCollectionID())
 			}
 
 			// Perform first one-shot DCP feed - normal one-shot
@@ -358,9 +354,7 @@ func TestResumeStoppedFeed(t *testing.T) {
 	require.NoError(t, err)
 	var collectionIDs []uint32
 	if collection.IsSupported(sgbucket.DataStoreFeatureCollections) {
-		collectionID, err := collection.GetCollectionID()
-		require.NoError(t, err)
-		collectionIDs = append(collectionIDs, collectionID)
+		collectionIDs = append(collectionIDs, collection.GetCollectionID())
 	}
 
 	dcpClientOpts := DCPClientOptions{

--- a/base/gocb_dcp_feed.go
+++ b/base/gocb_dcp_feed.go
@@ -59,11 +59,7 @@ func StartGocbDCPFeed(collection *Collection, bucketName string, args sgbucket.F
 	}
 	var collectionIDs []uint32
 	if collection.IsSupported(sgbucket.DataStoreFeatureCollections) {
-		collectionID, err := collection.GetCollectionID()
-		if err != nil {
-			return err
-		}
-		collectionIDs = append(collectionIDs, collectionID)
+		collectionIDs = append(collectionIDs, collection.GetCollectionID())
 	}
 	dcpClient, err := NewDCPClient(
 		feedName,

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -551,11 +551,7 @@ func getCompactionIDSubDocPath(compactionID string) string {
 func getCompactionDCPClientOptions(collection *base.Collection, groupID string) (*base.DCPClientOptions, error) {
 	var collectionIDs []uint32
 	if collection.IsSupported(sgbucket.DataStoreFeatureCollections) {
-		collectionID, err := collection.GetCollectionID()
-		if err != nil {
-			return nil, err
-		}
-		collectionIDs = append(collectionIDs, collectionID)
+		collectionIDs = append(collectionIDs, collection.GetCollectionID())
 	}
 
 	clientOptions := &base.DCPClientOptions{

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -118,8 +118,8 @@ func TestLateSequenceHandling(t *testing.T) {
 	context, ctx := setupTestDBWithCacheOptions(t, DefaultCacheOptions())
 	defer context.Close(ctx)
 
-	collectionID, err := context.GetSingleCollectionID()
-	require.NoError(t, err)
+	collection := context.GetSingleDatabaseCollection()
+	collectionID := collection.GetCollectionID()
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
@@ -194,8 +194,8 @@ func TestLateSequenceHandlingWithMultipleListeners(t *testing.T) {
 	require.NoError(t, err)
 	defer context.Close(ctx)
 
-	collectionID, err := context.GetSingleCollectionID()
-	require.NoError(t, err)
+	collection := context.GetSingleDatabaseCollection()
+	collectionID := collection.GetCollectionID()
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
@@ -263,8 +263,8 @@ func TestLateSequenceErrorRecovery(t *testing.T) {
 	defer db.Close(ctx)
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
-	collectionID, err := db.GetSingleCollectionID()
-	require.NoError(t, err)
+	collection := db.GetSingleDatabaseCollection()
+	collectionID := collection.GetCollectionID()
 
 	// Create a user with access to channel ABC
 	authenticator := db.Authenticator(ctx)
@@ -564,8 +564,8 @@ func TestChannelCacheBufferingWithUserDoc(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
-	collectionID, err := db.GetSingleCollectionID()
-	require.NoError(t, err)
+	collection := db.GetSingleDatabaseCollection()
+	collectionID := collection.GetCollectionID()
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
 	// Simulate seq 1 (user doc) being delayed - write 2 first
@@ -637,8 +637,8 @@ func TestChannelCacheBackfill(t *testing.T) {
 	WriteDirect(db, []string{"CBS"}, 7)
 	require.NoError(t, db.changeCache.waitForSequence(ctx, 7, base.DefaultWaitForSequence))
 
-	collectionID, err := db.GetSingleCollectionID()
-	require.NoError(t, err)
+	collection := db.GetSingleDatabaseCollection()
+	collectionID := collection.GetCollectionID()
 
 	// verify insert at start (PBS)
 	pbsCache := db.changeCache.getChannelCache().getSingleChannelCache(channels.NewID("PBS", collectionID)).(*singleChannelCacheImpl)
@@ -1343,8 +1343,8 @@ func TestSkippedViewRetrieval(t *testing.T) {
 	// Validate expected entries
 	require.NoError(t, db.changeCache.waitForSequence(ctx, 15, base.DefaultWaitForSequence))
 
-	collectionID, err := db.GetSingleCollectionID()
-	require.NoError(t, err)
+	collection := db.GetSingleDatabaseCollection()
+	collectionID := collection.GetCollectionID()
 
 	entries, err := db.changeCache.GetChanges(channels.NewID("ABC", collectionID), getChangesOptionsWithSeq(SequenceID{Seq: 2}))
 	assert.NoError(t, err, "Get Changes returned error")
@@ -1435,8 +1435,8 @@ func TestChannelCacheSize(t *testing.T) {
 	assert.Equal(t, 750, len(changes))
 
 	// Validate that cache stores the expected number of values
-	collectionID, err := db.GetSingleCollectionID()
-	require.NoError(t, err)
+	collection := db.GetSingleDatabaseCollection()
+	collectionID := collection.GetCollectionID()
 
 	abcCache := db.changeCache.getChannelCache().getSingleChannelCache(channels.NewID("ABC", collectionID)).(*singleChannelCacheImpl)
 	assert.Equal(t, 600, len(abcCache.logs))
@@ -1638,8 +1638,8 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 	db, ctx := setupTestDBWithCacheOptions(t, options)
 	defer db.Close(ctx)
 
-	collectionID, err := db.GetSingleCollectionID()
-	require.NoError(t, err)
+	collection := db.GetSingleDatabaseCollection()
+	collectionID := collection.GetCollectionID()
 
 	// -------- Setup notifyChange callback ----------------
 
@@ -1833,10 +1833,9 @@ func TestNotifyForInactiveChannel(t *testing.T) {
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
-	collection := db.GetSingleDatabaseCollectionWithUser()
 
-	collectionID, err := db.GetSingleCollectionID()
-	require.NoError(t, err)
+	collection := db.GetSingleDatabaseCollectionWithUser()
+	collectionID := collection.GetCollectionID()
 
 	// -------- Setup notifyChange callback ----------------
 
@@ -1850,7 +1849,7 @@ func TestNotifyForInactiveChannel(t *testing.T) {
 
 	// Write a document to channel zero
 	body := Body{"channels": []string{"zero"}}
-	_, _, err = collection.Put(ctx, "inactiveCacheNotify", body)
+	_, _, err := collection.Put(ctx, "inactiveCacheNotify", body)
 	assert.NoError(t, err)
 
 	// Wait for notify to arrive
@@ -2030,8 +2029,9 @@ func BenchmarkProcessEntry(b *testing.B) {
 			context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 			require.NoError(b, err)
 			defer context.Close(ctx)
-			collectionID, err := context.GetSingleCollectionID()
-			require.NoError(b, err)
+
+			collection := context.GetSingleDatabaseCollection()
+			collectionID := collection.GetCollectionID()
 
 			ctx = context.AddDatabaseLogContext(ctx)
 			changeCache := &changeCache{}
@@ -2261,8 +2261,8 @@ func BenchmarkDocChanged(b *testing.B) {
 			require.NoError(b, err)
 			defer context.Close(ctx)
 
-			collectionID, err := context.GetSingleCollectionID()
-			require.NoError(b, err)
+			collection := context.GetSingleDatabaseCollection()
+			collectionID := collection.GetCollectionID()
 
 			ctx = context.AddDatabaseLogContext(ctx)
 			changeCache := &changeCache{}

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -111,16 +111,14 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(ctx context.Context, ch
 
 		// Convert the output to LogEntries.  Channel query and view result rows have different structure, so need to unmarshal independently.
 		highSeq := uint64(0)
+		collection := dbc.GetSingleDatabaseCollection()
+		collectionID := collection.GetCollectionID()
 		for {
 			var entry *LogEntry
 			var found bool
 			if usingViews {
 				entry, found = nextChannelViewEntry(queryResults)
 			} else {
-				collectionID, err := dbc.GetSingleCollectionID()
-				if err != nil {
-					return nil, err
-				}
 				entry, found = nextChannelQueryEntry(queryResults, collectionID)
 			}
 
@@ -204,10 +202,8 @@ func (dbc *DatabaseContext) getChangesForSequences(ctx context.Context, sequence
 	if err != nil {
 		return nil, err
 	}
-	collectionID, err := dbc.GetSingleCollectionID()
-	if err != nil {
-		return nil, err
-	}
+	collection := dbc.GetSingleDatabaseCollection()
+	collectionID := collection.GetCollectionID()
 
 	// Convert the output to LogEntries.  Channel query and view result rows have different structure, so need to unmarshal independently.
 	for {

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -33,8 +33,7 @@ func TestDuplicateDocID(t *testing.T) {
 	require.NoError(t, err)
 	defer context.Close(ctx)
 
-	collectionID, err := context.GetSingleCollectionID()
-	require.NoError(t, err)
+	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
@@ -97,8 +96,7 @@ func TestLateArrivingSequence(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
-	collectionID, err := context.GetSingleCollectionID()
-	require.NoError(t, err)
+	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
 	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, dbstats.Cache())
 	assert.NotNil(t, cache)
@@ -141,8 +139,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
-	collectionID, err := context.GetSingleCollectionID()
-	require.NoError(t, err)
+	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
 	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, dbstats.Cache())
 	assert.NotNil(t, cache)
@@ -185,8 +182,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
-	collectionID, err := context.GetSingleCollectionID()
-	require.NoError(t, err)
+	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
 	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, dbstats.Cache())
 	assert.NotNil(t, cache)
@@ -271,8 +267,7 @@ func TestPrependChanges(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
-	collectionID, err := dbCtx.GetSingleCollectionID()
-	require.NoError(t, err)
+	collectionID := dbCtx.GetSingleDatabaseCollection().GetCollectionID()
 
 	cache := newSingleChannelCache(dbCtx, channels.NewID("PrependEmptyCache", collectionID), 0, dbstats.Cache())
 	assert.NotNil(t, cache)
@@ -482,8 +477,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
-	collectionID, err := context.GetSingleCollectionID()
-	require.NoError(t, err)
+	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
 	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, dbstats.Cache())
 
@@ -532,8 +526,7 @@ func TestChannelCacheStats(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
-	collectionID, err := context.GetSingleCollectionID()
-	require.NoError(t, err)
+	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
 	testStats := dbstats.Cache()
 	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, testStats)
@@ -613,8 +606,7 @@ func TestChannelCacheStatsOnPrune(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
-	collectionID, err := context.GetSingleCollectionID()
-	require.NoError(t, err)
+	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
 	testStats := dbstats.Cache()
 	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, testStats)
@@ -654,8 +646,7 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
-	collectionID, err := context.GetSingleCollectionID()
-	require.NoError(t, err)
+	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
 	testStats := dbstats.Cache()
 	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 99, testStats)
@@ -754,8 +745,7 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(b, err)
 
-	collectionID, err := context.GetSingleCollectionID()
-	require.NoError(b, err)
+	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
 	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
@@ -784,8 +774,7 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(b, err)
 
-	collectionID, err := context.GetSingleCollectionID()
-	require.NoError(b, err)
+	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
 	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
@@ -811,8 +800,7 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(b, err)
 
-	collectionID, err := context.GetSingleCollectionID()
-	require.NoError(b, err)
+	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
 	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
@@ -838,8 +826,7 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(b, err)
 
-	collectionID, err := context.GetSingleCollectionID()
-	require.NoError(b, err)
+	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
 	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
@@ -865,8 +852,7 @@ func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(b, err)
 
-	collectionID, err := context.GetSingleCollectionID()
-	require.NoError(b, err)
+	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
 	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
@@ -892,8 +878,7 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(b, err)
 
-	collectionID, err := context.GetSingleCollectionID()
-	require.NoError(b, err)
+	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
 	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
@@ -919,8 +904,7 @@ func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(b, err)
 
-	collectionID, err := context.GetSingleCollectionID()
-	require.NoError(b, err)
+	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
 	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate docs
@@ -988,8 +972,7 @@ func verifyChannelDocIDs(entries []*LogEntry, docIDs []string) bool {
 	}
 	for index, docID := range docIDs {
 		if entries[index].DocID != docID {
-			log.Printf("verifyChannelDocIDs: DocID mismatch at index %v, entries=%s, DocIDs=%s",
-				index, entries[index].DocID, docID)
+			log.Printf("verifyChannelDocIDs: DocID mismatch at index %v, entries=%s, DocIDs=%s", index, entries[index].DocID, docID)
 			return false
 		}
 	}

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -35,8 +35,7 @@ func TestChannelCacheMaxSize(t *testing.T) {
 	defer dbCtx.Close(ctx)
 	cache := dbCtx.changeCache.getChannelCache()
 
-	collectionID, err := dbCtx.GetSingleCollectionID()
-	require.NoError(t, err)
+	collectionID := dbCtx.GetSingleDatabaseCollection().GetCollectionID()
 
 	// Make channels active
 	_, err = cache.GetChanges(channels.NewID("TestA", collectionID), getChangesOptionsWithCtxOnly())

--- a/db/database.go
+++ b/db/database.go
@@ -412,14 +412,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 				dbCollection := newDatabaseCollection(dbContext, bucket)
 				dbContext.Scopes[scopeName].Collections[collName] = dbCollection
 
-				collection, err := base.AsCollection(dbCollection.Bucket)
-				if err != nil {
-					return nil, err
-				}
-				collectionID, err := collection.GetCollectionID()
-				if err != nil {
-					return nil, err
-				}
+				collectionID := dbCollection.GetCollectionID()
 				dbContext.CollectionByID[collectionID] = dbCollection
 				dbContext.singleCollection = dbCollection
 			}
@@ -2029,18 +2022,6 @@ func (dbCtx *DatabaseContext) onlyDefaultCollection() bool {
 	}
 	_, exists := dbCtx.CollectionByID[base.DefaultCollectionID]
 	return exists
-}
-
-// GetSingleCollectionID returns a collectionID. This is a temporary shim for single collections, and will be removed when a database can support multiple collecitons.
-func (dbCtx *DatabaseContext) GetSingleCollectionID() (uint32, error) {
-	collection, err := base.AsCollection(dbCtx.Bucket)
-	if err != nil {
-		return 0, nil
-	}
-	if !collection.IsSupported(sgbucket.DataStoreFeatureCollections) {
-		return 0, nil
-	}
-	return collection.GetCollectionID()
 }
 
 // GetDefaultDatabaseCollectionWithUser will return the default collection if the default collection is supplied in the database config.

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -79,6 +79,15 @@ func (c *DatabaseCollection) eventMgr() *EventManager {
 	return c.dbCtx.EventMgr
 }
 
+// GetCollectionID returns a collectionID. If couchbase server does not return collections, it will return base.DefaultCollectionID, like the default collection for a Couchbase Server that does support collections.
+func (c *DatabaseCollection) GetCollectionID() uint32 {
+	collection, err := base.AsCollection(c.Bucket)
+	if err != nil {
+		return base.DefaultCollectionID
+	}
+	return collection.GetCollectionID()
+}
+
 // GetReivisonCacheForTest allow accessing a copy of revision cache.
 func (context *DatabaseCollection) GetRevisionCacheForTest() RevisionCache {
 	return context.revisionCache

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -804,8 +804,7 @@ func TestAllDocsOnly(t *testing.T) {
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
-	collectionID, err := db.GetSingleCollectionID()
-	require.NoError(t, err)
+	collectionID := collection.GetCollectionID()
 
 	// Trigger creation of the channel cache for channel "all"
 	db.changeCache.getChannelCache().getSingleChannelCache(channels.NewID("all", collectionID))
@@ -985,8 +984,7 @@ func TestConflicts(t *testing.T) {
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
 	// Instantiate channel cache for channel 'all'
-	collectionID, err := db.GetSingleCollectionID()
-	require.NoError(t, err)
+	collectionID := collection.GetCollectionID()
 
 	allChannel := channels.NewID("all", collectionID)
 	db.changeCache.getChannelCache().getSingleChannelCache(allChannel)
@@ -995,7 +993,7 @@ func TestConflicts(t *testing.T) {
 
 	// Create rev 1 of "doc":
 	body := Body{"n": 1, "channels": []string{"all", "1"}}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-a"}, false)
 	assert.NoError(t, err, "add 1-a")
 
 	// Wait for rev to be cached

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -308,10 +308,8 @@ func (h *handler) handleDumpChannel() error {
 	since := h.getIntQuery("since", 0)
 	base.InfofCtx(h.ctx(), base.KeyHTTP, "Dump channel %q", base.UD(channelName))
 
-	collectionID, err := h.db.GetSingleCollectionID()
-	if err != nil {
-		return err
-	}
+	collection := h.db.GetSingleDatabaseCollection()
+	collectionID := collection.GetCollectionID()
 	chanLog := h.db.GetChangeLog(ch.NewID(channelName, collectionID), since)
 	if chanLog == nil {
 		return base.HTTPErrorf(http.StatusNotFound, "no such channel")


### PR DESCRIPTION
This makes this API a bit easier to use.  Removed the call on the database itself, and require this to be done on `DatabaseCollection.GetCollectionID`. After https://github.com/couchbase/sync_gateway/pull/5832, this could be changed to `DatabaseCollection.DataStore.GetCollectionID` if more ergonomic.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1084/
