### PR TITLE
CBG-2327 fix non xattr tests

### DIFF
--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -623,12 +623,18 @@ func TestChannelCacheBackfill(t *testing.T) {
 	require.NoError(t, db.changeCache.waitForSequence(ctx, 6, base.DefaultWaitForSequence))
 	db.user, _ = authenticator.GetUser("naomi")
 	changes, err := db.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq())
+
 	assert.NoError(t, err, "Couldn't GetChanges")
 	assert.Equal(t, 4, len(changes))
+
+	collection := db.GetSingleDatabaseCollection()
+	collectionID := collection.GetCollectionID()
+
 	assert.Equal(t, &ChangeEntry{
-		Seq:     SequenceID{Seq: 1, TriggeredBy: 0, LowSeq: 2},
-		ID:      "doc-1",
-		Changes: []ChangeRev{{"rev": "1-a"}}}, changes[0])
+		Seq:          SequenceID{Seq: 1, TriggeredBy: 0, LowSeq: 2},
+		ID:           "doc-1",
+		Changes:      []ChangeRev{{"rev": "1-a"}},
+		collectionID: collectionID}, changes[0])
 
 	lastSeq := changes[len(changes)-1].Seq
 
@@ -636,9 +642,6 @@ func TestChannelCacheBackfill(t *testing.T) {
 	WriteDirect(db, []string{"ABC", "NBC", "PBS", "TBS"}, 3)
 	WriteDirect(db, []string{"CBS"}, 7)
 	require.NoError(t, db.changeCache.waitForSequence(ctx, 7, base.DefaultWaitForSequence))
-
-	collection := db.GetSingleDatabaseCollection()
-	collectionID := collection.GetCollectionID()
 
 	// verify insert at start (PBS)
 	pbsCache := db.changeCache.getChannelCache().getSingleChannelCache(channels.NewID("PBS", collectionID)).(*singleChannelCacheImpl)
@@ -658,9 +661,11 @@ func TestChannelCacheBackfill(t *testing.T) {
 	changes, err = db.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithSeq(lastSeq))
 	assert.Equal(t, 3, len(changes))
 	assert.Equal(t, &ChangeEntry{
-		Seq:     SequenceID{Seq: 3, LowSeq: 3},
-		ID:      "doc-3",
-		Changes: []ChangeRev{{"rev": "1-a"}}}, changes[0])
+		Seq:          SequenceID{Seq: 3, LowSeq: 3},
+		ID:           "doc-3",
+		Changes:      []ChangeRev{{"rev": "1-a"}},
+		collectionID: collectionID,
+	}, changes[0])
 
 }
 
@@ -810,10 +815,15 @@ func TestLowSequenceHandling(t *testing.T) {
 	changes, err := verifySequencesInFeed(feed, []uint64{1, 2, 5, 6})
 	assert.True(t, err == nil)
 	require.Len(t, changes, 4)
-	assert.Equal(t, &ChangeEntry{
-		Seq:     SequenceID{Seq: 1, TriggeredBy: 0, LowSeq: 2},
-		ID:      "doc-1",
-		Changes: []ChangeRev{{"rev": "1-a"}}}, changes[0])
+
+	collection := db.GetSingleDatabaseCollection()
+	collectionID := collection.GetCollectionID()
+
+	require.Equal(t, &ChangeEntry{
+		Seq:          SequenceID{Seq: 1, TriggeredBy: 0, LowSeq: 2},
+		ID:           "doc-1",
+		Changes:      []ChangeRev{{"rev": "1-a"}},
+		collectionID: collectionID}, changes[0])
 
 	// Test backfill clear - sequence numbers go back to standard handling
 	WriteDirect(db, []string{"ABC", "NBC", "PBS", "TBS"}, 3)

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -107,7 +107,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
 
 	// Create a doc on two channels (sequence 1):
-	revid, _, err := collection.Put(ctx, "doc1", Body{"channels": []string{"ABC", "PBS"}})
+	_, _, err := collection.Put(ctx, "doc1", Body{"channels": []string{"ABC", "PBS"}})
 	require.NoError(t, err)
 	cacheWaiter.AddAndWait(1)
 
@@ -145,7 +145,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	lastSeq, _ = ParseSequenceID(lastSeq.String())
 
 	// Add a new doc (sequence 3):
-	revid, _, err = collection.Put(ctx, "doc2", Body{"channels": []string{"PBS"}})
+	revid, _, err := collection.Put(ctx, "doc2", Body{"channels": []string{"PBS"}})
 	require.NoError(t, err)
 
 	// Check the _changes feed -- this is to make sure the changeCache properly received
@@ -225,10 +225,12 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	assert.NoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)
 	assert.Equal(t, 1, len(changes))
-	assert.Equal(t, &ChangeEntry{
-		Seq:     SequenceID{Seq: 1},
-		ID:      "alpha",
-		Changes: []ChangeRev{{"rev": revid}}}, changes[0])
+	collectionID := collection.GetCollectionID()
+	require.Equal(t, &ChangeEntry{
+		Seq:          SequenceID{Seq: 1},
+		ID:           "alpha",
+		Changes:      []ChangeRev{{"rev": revid}},
+		collectionID: collectionID}, changes[0])
 
 	lastSeq := getLastSeq(changes)
 	lastSeq, _ = ParseSequenceID(lastSeq.String())
@@ -269,11 +271,12 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 
 	assert.Equal(t, 1, len(changes))
 	assert.Equal(t, &ChangeEntry{
-		Seq:        SequenceID{Seq: 2},
-		ID:         "alpha",
-		Removed:    base.SetOf("A"),
-		allRemoved: true,
-		Changes:    []ChangeRev{{"rev": "2-e99405a23fa102238fa8c3fd499b15bc"}}}, changes[0])
+		Seq:          SequenceID{Seq: 2},
+		ID:           "alpha",
+		Removed:      base.SetOf("A"),
+		allRemoved:   true,
+		Changes:      []ChangeRev{{"rev": "2-e99405a23fa102238fa8c3fd499b15bc"}},
+		collectionID: collectionID}, changes[0])
 
 	printChanges(changes)
 }
@@ -307,11 +310,13 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	assert.NoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)
 
+	collectionID := collection.GetCollectionID()
 	assert.Equal(t, 1, len(changes))
-	assert.Equal(t, &ChangeEntry{
-		Seq:     SequenceID{Seq: 1},
-		ID:      "alpha",
-		Changes: []ChangeRev{{"rev": revid}}}, changes[0])
+	require.Equal(t, &ChangeEntry{
+		Seq:          SequenceID{Seq: 1},
+		ID:           "alpha",
+		Changes:      []ChangeRev{{"rev": revid}},
+		collectionID: collectionID}, changes[0])
 
 	lastSeq := getLastSeq(changes)
 	lastSeq, _ = ParseSequenceID(lastSeq.String())
@@ -348,10 +353,11 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	assert.NoError(t, err, "Couldn't GetChanges (2nd)")
 
 	assert.Equal(t, 1, len(changes))
-	assert.Equal(t, &ChangeEntry{
-		Seq:     SequenceID{Seq: 3},
-		ID:      "alpha",
-		Changes: []ChangeRev{{"rev": "3-e99405a23fa102238fa8c3fd499b15bc"}}}, changes[0])
+	require.Equal(t, &ChangeEntry{
+		Seq:          SequenceID{Seq: 3},
+		ID:           "alpha",
+		Changes:      []ChangeRev{{"rev": "3-e99405a23fa102238fa8c3fd499b15bc"}},
+		collectionID: collectionID}, changes[0])
 
 	printChanges(changes)
 }


### PR DESCRIPTION
I made an attempt to change `WriteDirect` to work with xattrs tests but I was not successful.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1079/
