### PR TITLE
CBG-2522: Change log level for does not require revocation

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -259,7 +259,7 @@ func (db *Database) buildRevokedFeed(ctx context.Context, ch channels.ID, option
 					}
 
 					if !requiresRevocation {
-						base.DebugfCtx(ctx, base.KeyChanges, "Channel feed processing revocation, seq: %v in channel %s does not require revocation", seqID, base.UD(singleChannelCache.ChannelID()))
+						base.TracefCtx(ctx, base.KeyChanges, "Channel feed processing revocation, seq: %v in channel %s does not require revocation", seqID, base.UD(singleChannelCache.ChannelID()))
 						continue
 					}
 				}


### PR DESCRIPTION
CBG-2522

Dropping the 'does not require revocation' logging to trace level as the debug logs get clogged up with the messages making it hard to debug CBSE's.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] N/A
