### PR TITLE
CBG-2506: Tuning import partitions for when in serverless mode

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -28,6 +28,7 @@ import (
 
 const CBGTIndexTypeSyncGatewayImport = "syncGateway-import-"
 const DefaultImportPartitions = 16
+const DefaultImportPartitionsServerless = 6
 
 // firstVersionToSupportCollections represents the earliest Sync Gateway release that supports collections.
 var firstVersionToSupportCollections = &ComparableVersion{

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -679,3 +679,11 @@ func RemoveDestFactory(destKey string) {
 	delete(cbgtDestFactories, destKey)
 	cbgtDestFactoriesLock.Unlock()
 }
+
+func GetDefaultImportPartitions(serverless bool) uint16 {
+	if serverless {
+		return DefaultImportPartitionsServerless
+	} else {
+		return DefaultImportPartitions
+	}
+}

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -87,12 +87,6 @@ func MergeDatabaseConfigWithDefaults(sc *StartupConfig, dbConfig *DbConfig) (*Db
 // to provide defaults to  include_runtime config endpoints.
 // Note that this does not include unsupported options
 func DefaultDbConfig(sc *StartupConfig) *DbConfig {
-	var importPartitions uint16
-	if sc.IsServerless() {
-		importPartitions = base.DefaultImportPartitionsServerless
-	} else {
-		importPartitions = base.DefaultImportPartitions
-	}
 	dbConfig := DbConfig{
 		BucketConfig:       BucketConfig{},
 		Name:               "",
@@ -101,7 +95,7 @@ func DefaultDbConfig(sc *StartupConfig) *DbConfig {
 		Roles:              nil,
 		RevsLimit:          nil, // Set this below struct
 		AutoImport:         base.BoolPtr(base.DefaultAutoImport),
-		ImportPartitions:   base.Uint16Ptr(importPartitions),
+		ImportPartitions:   base.Uint16Ptr(base.GetDefaultImportPartitions(sc.IsServerless())),
 		ImportFilter:       nil,
 		ImportBackupOldRev: base.BoolPtr(false),
 		EventHandlers:      nil,

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -87,6 +87,12 @@ func MergeDatabaseConfigWithDefaults(sc *StartupConfig, dbConfig *DbConfig) (*Db
 // to provide defaults to  include_runtime config endpoints.
 // Note that this does not include unsupported options
 func DefaultDbConfig(sc *StartupConfig) *DbConfig {
+	var importPartitions uint16
+	if sc.IsServerless() {
+		importPartitions = base.DefaultImportPartitionsServerless
+	} else {
+		importPartitions = base.DefaultImportPartitions
+	}
 	dbConfig := DbConfig{
 		BucketConfig:       BucketConfig{},
 		Name:               "",
@@ -95,7 +101,7 @@ func DefaultDbConfig(sc *StartupConfig) *DbConfig {
 		Roles:              nil,
 		RevsLimit:          nil, // Set this below struct
 		AutoImport:         base.BoolPtr(base.DefaultAutoImport),
-		ImportPartitions:   base.Uint16Ptr(base.DefaultImportPartitions),
+		ImportPartitions:   base.Uint16Ptr(importPartitions),
 		ImportFilter:       nil,
 		ImportBackupOldRev: base.BoolPtr(false),
 		EventHandlers:      nil,

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -655,10 +655,8 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 	}
 	importOptions.BackupOldRev = base.BoolDefault(config.ImportBackupOldRev, false)
 
-	if config.ImportPartitions == nil && sc.Config.IsServerless() {
-		importOptions.ImportPartitions = base.DefaultImportPartitionsServerless
-	} else if config.ImportPartitions == nil {
-		importOptions.ImportPartitions = base.DefaultImportPartitions
+	if config.ImportPartitions == nil {
+		importOptions.ImportPartitions = base.GetDefaultImportPartitions(sc.Config.IsServerless())
 	} else {
 		importOptions.ImportPartitions = *config.ImportPartitions
 	}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -655,7 +655,9 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 	}
 	importOptions.BackupOldRev = base.BoolDefault(config.ImportBackupOldRev, false)
 
-	if config.ImportPartitions == nil {
+	if config.ImportPartitions == nil && sc.Config.IsServerless() {
+		importOptions.ImportPartitions = base.DefaultImportPartitionsServerless
+	} else if config.ImportPartitions == nil {
 		importOptions.ImportPartitions = base.DefaultImportPartitions
 	} else {
 		importOptions.ImportPartitions = *config.ImportPartitions


### PR DESCRIPTION
CBG-2506

Small PR to tune the import partitions for when running sync gateway in serverless mode. Also added a unit test to test the functionality with one case proving the default is set in serverless mode and another proving the value is not overwritten when import partitions are specified in the config. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1102/
