### PR TITLE
Add basic benchmarks for parseIntegerSequenceID and c._updateCheckpointLists

### DIFF
--- a/db/sequence_id_test.go
+++ b/db/sequence_id_test.go
@@ -52,6 +52,31 @@ func TestParseSequenceID(t *testing.T) {
 	assert.True(t, err != nil)
 }
 
+func BenchmarkParseSequenceID(b *testing.B) {
+	tests := []string{
+		"1234",
+		"5678:1234",
+		"",
+		"123:456:789",
+		"123::789",
+		"foo",
+		":",
+		":1",
+		"::1",
+		"10:11:12:13",
+		"123:ggg",
+	}
+
+	for _, test := range tests {
+		b.Run(test, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _ = parseIntegerSequenceID(test)
+			}
+		})
+	}
+}
+
 func TestMarshalSequenceID(t *testing.T) {
 	s := SequenceID{Seq: 1234}
 	assert.Equal(t, "1234", s.String())


### PR DESCRIPTION
Basic benchmarks to baseline these two functions ahead of potential refactors: CBG-2556

```
> go test -run=- -bench='^(BenchmarkParseSequenceID|BenchmarkCheckpointerUpdateCheckpointLists)$' -v ./db
goos: darwin
goarch: amd64
pkg: github.com/couchbase/sync_gateway/db
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkCheckpointerUpdateCheckpointLists
BenchmarkCheckpointerUpdateCheckpointLists/expectedSeqsLen=1,processedSeqsLen=1
BenchmarkCheckpointerUpdateCheckpointLists/expectedSeqsLen=1,processedSeqsLen=1-12         	12899390	        88.36 ns/op	      48 B/op	       2 allocs/op
BenchmarkCheckpointerUpdateCheckpointLists/expectedSeqsLen=10,processedSeqsLen=10
BenchmarkCheckpointerUpdateCheckpointLists/expectedSeqsLen=10,processedSeqsLen=10-12       	 1291018	       925.5 ns/op	     368 B/op	      21 allocs/op
BenchmarkCheckpointerUpdateCheckpointLists/expectedSeqsLen=100,processedSeqsLen=100
BenchmarkCheckpointerUpdateCheckpointLists/expectedSeqsLen=100,processedSeqsLen=100-12     	  123985	      9815 ns/op	    3632 B/op	     225 allocs/op
BenchmarkCheckpointerUpdateCheckpointLists/expectedSeqsLen=500,processedSeqsLen=500
BenchmarkCheckpointerUpdateCheckpointLists/expectedSeqsLen=500,processedSeqsLen=500-12     	   26572	     45381 ns/op	   16432 B/op	    1025 allocs/op
BenchmarkCheckpointerUpdateCheckpointLists/expectedSeqsLen=1000,processedSeqsLen=1000
BenchmarkCheckpointerUpdateCheckpointLists/expectedSeqsLen=1000,processedSeqsLen=1000-12   	   13393	     89522 ns/op	   32433 B/op	    2025 allocs/op
BenchmarkCheckpointerUpdateCheckpointLists/expectedSeqsLen=10000,processedSeqsLen=10000
BenchmarkCheckpointerUpdateCheckpointLists/expectedSeqsLen=10000,processedSeqsLen=10000-12 	    1244	    922636 ns/op	  320561 B/op	   20033 allocs/op
BenchmarkCheckpointerUpdateCheckpointLists/expectedSeqsLen=50000,processedSeqsLen=50000
BenchmarkCheckpointerUpdateCheckpointLists/expectedSeqsLen=50000,processedSeqsLen=50000-12 	     243	   4866421 ns/op	 1603728 B/op	  100230 allocs/op
BenchmarkCheckpointerUpdateCheckpointLists/expectedSeqsLen=100000,processedSeqsLen=100000
BenchmarkCheckpointerUpdateCheckpointLists/expectedSeqsLen=100000,processedSeqsLen=100000-12         	     120	   9635134 ns/op	 3213770 B/op	  200858 allocs/op
BenchmarkParseSequenceID
BenchmarkParseSequenceID/1234
BenchmarkParseSequenceID/1234-12                                                                     	26842696	        46.01 ns/op	      16 B/op	       1 allocs/op
BenchmarkParseSequenceID/5678:1234
BenchmarkParseSequenceID/5678:1234-12                                                                	13113302	        91.52 ns/op	      32 B/op	       1 allocs/op
BenchmarkParseSequenceID/#00
BenchmarkParseSequenceID/#00-12                                                                      	664689801	         1.753 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseSequenceID/123:456:789
BenchmarkParseSequenceID/123:456:789-12                                                              	10635332	       114.1 ns/op	      48 B/op	       1 allocs/op
BenchmarkParseSequenceID/123::789
BenchmarkParseSequenceID/123::789-12                                                                 	11406752	       107.0 ns/op	      48 B/op	       1 allocs/op
BenchmarkParseSequenceID/foo
BenchmarkParseSequenceID/foo-12                                                                      	 6432093	       181.5 ns/op	     104 B/op	       4 allocs/op
BenchmarkParseSequenceID/:
BenchmarkParseSequenceID/:-12                                                                        	10506771	       111.4 ns/op	      80 B/op	       2 allocs/op
BenchmarkParseSequenceID/:1
BenchmarkParseSequenceID/:1-12                                                                       	10777508	       112.2 ns/op	      80 B/op	       2 allocs/op
BenchmarkParseSequenceID/::1
BenchmarkParseSequenceID/::1-12                                                                      	 9959919	       120.8 ns/op	      96 B/op	       2 allocs/op
BenchmarkParseSequenceID/10:11:12:13
BenchmarkParseSequenceID/10:11:12:13-12                                                              	 4365763	       291.3 ns/op	     144 B/op	       5 allocs/op
BenchmarkParseSequenceID/123:ggg
BenchmarkParseSequenceID/123:ggg-12                                                                  	 9013809	       129.0 ns/op	      80 B/op	       2 allocs/op
PASS
ok  	github.com/couchbase/sync_gateway/db	28.423s
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a