### PR TITLE
CBG-2332 move changes feed calls down to collection level

### DIFF
--- a/db/background_mgr_resync.go
+++ b/db/background_mgr_resync.go
@@ -61,9 +61,13 @@ func (r *ResyncManager) Run(ctx context.Context, options map[string]interface{},
 		persistClusterStatus()
 	}
 
-	_, err := database.UpdateAllDocChannels(ctx, regenerateSequences, callback, terminator)
-	if err != nil {
-		return err
+	for _, collection := range database.CollectionByID {
+		_, err := (&DatabaseCollectionWithUser{
+			DatabaseCollection: collection,
+		}).UpdateAllDocChannels(ctx, regenerateSequences, callback, terminator)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -401,7 +401,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 
 	// Create a distinct database instance for changes, to avoid races between reloadUser invocation in changes.go
 	// and BlipSyncContext user access.
-	changesDb := bh.copyContextDatabase()
+	changesDb := bh.copyDatabaseCollectionWithUser(bh.collectionIdx)
 	_, forceClose := generateBlipSyncChanges(bh.loggingCtx, changesDb, channelSet, options, opts.docIDs, func(changes []*ChangeEntry) error {
 		base.DebugfCtx(bh.loggingCtx, base.KeySync, "    Sending %d changes", len(changes))
 		for _, change := range changes {
@@ -416,7 +416,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 					}
 
 					// If the user has access to the doc through another channel don't send change
-					userHasAccessToDoc, err := UserHasDocAccess(bh.loggingCtx, changesDb.GetSingleDatabaseCollectionWithUser(), change.ID)
+					userHasAccessToDoc, err := UserHasDocAccess(bh.loggingCtx, changesDb, change.ID)
 					if err == nil && userHasAccessToDoc {
 						continue
 					}

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -237,6 +237,21 @@ func (bsc *BlipSyncContext) copyContextDatabase() *Database {
 	return databaseCopy
 }
 
+func (bsc *BlipSyncContext) copyDatabaseCollectionWithUser(collectionIdx *int) *DatabaseCollectionWithUser {
+	bsc.dbUserLock.RLock()
+	defer bsc.dbUserLock.RUnlock()
+	user := bsc.blipContextDb.User()
+	if collectionIdx != nil {
+		return &DatabaseCollectionWithUser{DatabaseCollection: bsc.collectionMapping[*collectionIdx], user: user}
+	}
+	// There is a panic handler on the calling function but no way to pass error
+	c, err := bsc.blipContextDb.GetDefaultDatabaseCollection()
+	if err != nil {
+		panic(err)
+	}
+	return &DatabaseCollectionWithUser{DatabaseCollection: c, user: user}
+}
+
 func (bsc *BlipSyncContext) _copyContextDatabase() *Database {
 	databaseCopy, _ := GetDatabase(bsc.blipContextDb.DatabaseContext, bsc.blipContextDb.User())
 	return databaseCopy

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -244,11 +244,14 @@ func (bsc *BlipSyncContext) copyDatabaseCollectionWithUser(collectionIdx *int) *
 	if collectionIdx != nil {
 		return &DatabaseCollectionWithUser{DatabaseCollection: bsc.collectionMapping[*collectionIdx], user: user}
 	}
+	/* put into place in CBG-2527
 	// There is a panic handler on the calling function but no way to pass error
 	c, err := bsc.blipContextDb.GetDefaultDatabaseCollection()
 	if err != nil {
 		panic(err)
 	}
+	*/
+	c := bsc.blipContextDb.GetSingleDatabaseCollection()
 	return &DatabaseCollectionWithUser{DatabaseCollection: c, user: user}
 }
 

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -178,7 +178,7 @@ func (c *changeCache) Init(logCtx context.Context, collection *DatabaseCollectio
 
 	c.channelCache = channelCache
 
-	base.InfofCtx(c.logCtx, base.KeyCache, "Initializing changes cache for %s.%s.%s with options %+v", base.UD(collection.ScopeName()), base.UD(collection.Name()), c.options)
+	base.InfofCtx(c.logCtx, base.KeyCache, "Initializing changes cache for %s.%s.%s with options %+v", base.UD(collection.bucketName()), base.UD(collection.ScopeName()), base.UD(collection.Name()), c.options)
 
 	heap.Init(&c.pendingLogs)
 

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -583,8 +583,8 @@ type cachePrincipal struct {
 	Sequence uint64 `json:"sequence"`
 }
 
-func (c *changeCache) Remove(docIDs []string, startTime time.Time) (count int) {
-	return c.channelCache.Remove(docIDs, startTime)
+func (c *changeCache) Remove(collectionID uint32, docIDs []string, startTime time.Time) (count int) {
+	return c.channelCache.Remove(collectionID, docIDs, startTime)
 }
 
 // Principals unmarshalled during caching don't need to instantiate a real principal - we're just using name and seq from the document

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -157,7 +157,7 @@ func DefaultCacheOptions() CacheOptions {
 // notifyChange is an optional function that will be called to notify of channel changes.
 // After calling Init(), you must call .Start() to start useing the cache, otherwise it will be in a locked state
 // and callers will block on trying to obtain the lock.
-func (c *changeCache) Init(logCtx context.Context, collection *DatabaseCollection, channelCache ChannelCache, notifyChange func(channels.Set), options *CacheOptions, groupID string) error {
+func (c *changeCache) Init(logCtx context.Context, collection *DatabaseCollection, channelCache ChannelCache, notifyChange func(channels.Set), options *CacheOptions) error {
 	c.collection = collection
 	c.logCtx = logCtx
 
@@ -167,7 +167,7 @@ func (c *changeCache) Init(logCtx context.Context, collection *DatabaseCollectio
 	c.initTime = time.Now()
 	c.skippedSeqs = NewSkippedSequenceList()
 	c.lastAddPendingTime = time.Now().UnixNano()
-	c.sgCfgPrefix = base.SGCfgPrefixWithGroupID(groupID)
+	c.sgCfgPrefix = base.SGCfgPrefixWithGroupID(collection.groupID())
 
 	// init cache options
 	if options != nil {
@@ -178,7 +178,7 @@ func (c *changeCache) Init(logCtx context.Context, collection *DatabaseCollectio
 
 	c.channelCache = channelCache
 
-	base.InfofCtx(c.logCtx, base.KeyCache, "Initializing changes cache for collection %s.%s with options %+v", base.UD(collection.ScopeName()), base.UD(collection.Name()), c.options)
+	base.InfofCtx(c.logCtx, base.KeyCache, "Initializing changes cache for %s.%s.%s with options %+v", base.UD(collection.ScopeName()), base.UD(collection.Name()), c.options)
 
 	heap.Init(&c.pendingLogs)
 

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -49,7 +49,7 @@ var EnableStarChannelLog = true
 //   - Perform sequence buffering to ensure documents are received in sequence order
 //   - Propagating DCP changes down to appropriate channel caches
 type changeCache struct {
-	context            *DatabaseContext
+	collection         *DatabaseCollection
 	logCtx             context.Context
 	logsDisabled       bool                    // If true, ignore incoming tap changes
 	nextSequence       uint64                  // Next consecutive sequence number to add.  State variable for sequence buffering tracking.  Should use getNextSequence() rather than accessing directly.
@@ -81,10 +81,10 @@ func (c *changeCache) updateStats() {
 
 	c.lock.Lock()
 
-	c.context.DbStats.Database().HighSeqFeed.SetIfMax(int64(c.internalStats.highSeqFeed))
-	c.context.DbStats.Cache().PendingSeqLen.Set(int64(c.internalStats.pendingSeqLen))
-	c.context.DbStats.CBLReplicationPull().MaxPending.SetIfMax(int64(c.internalStats.maxPending))
-	c.context.DbStats.Cache().HighSeqStable.Set(int64(c._getMaxStableCached()))
+	c.collection.dbStats().Database().HighSeqFeed.SetIfMax(int64(c.internalStats.highSeqFeed))
+	c.collection.dbStats().Cache().PendingSeqLen.Set(int64(c.internalStats.pendingSeqLen))
+	c.collection.dbStats().CBLReplicationPull().MaxPending.SetIfMax(int64(c.internalStats.maxPending))
+	c.collection.dbStats().Cache().HighSeqStable.Set(int64(c._getMaxStableCached()))
 
 	c.lock.Unlock()
 }
@@ -157,8 +157,8 @@ func DefaultCacheOptions() CacheOptions {
 // notifyChange is an optional function that will be called to notify of channel changes.
 // After calling Init(), you must call .Start() to start useing the cache, otherwise it will be in a locked state
 // and callers will block on trying to obtain the lock.
-func (c *changeCache) Init(logCtx context.Context, dbcontext *DatabaseContext, notifyChange func(channels.Set), options *CacheOptions) error {
-	c.context = dbcontext
+func (c *changeCache) Init(logCtx context.Context, collection *DatabaseCollection, channelCache ChannelCache, notifyChange func(channels.Set), options *CacheOptions, groupID string) error {
+	c.collection = collection
 	c.logCtx = logCtx
 
 	c.notifyChange = notifyChange
@@ -167,7 +167,7 @@ func (c *changeCache) Init(logCtx context.Context, dbcontext *DatabaseContext, n
 	c.initTime = time.Now()
 	c.skippedSeqs = NewSkippedSequenceList()
 	c.lastAddPendingTime = time.Now().UnixNano()
-	c.sgCfgPrefix = base.SGCfgPrefixWithGroupID(dbcontext.Options.GroupID)
+	c.sgCfgPrefix = base.SGCfgPrefixWithGroupID(groupID)
 
 	// init cache options
 	if options != nil {
@@ -176,24 +176,20 @@ func (c *changeCache) Init(logCtx context.Context, dbcontext *DatabaseContext, n
 		c.options = DefaultCacheOptions()
 	}
 
-	channelCache, err := NewChannelCacheForContext(c.options.ChannelCacheOptions, c.context)
-	if err != nil {
-		return err
-	}
 	c.channelCache = channelCache
 
-	base.InfofCtx(c.logCtx, base.KeyCache, "Initializing changes cache for database %s with options %+v", base.UD(dbcontext.Name), c.options)
+	base.InfofCtx(c.logCtx, base.KeyCache, "Initializing changes cache for collection %s.%s with options %+v", base.UD(collection.ScopeName()), base.UD(collection.Name()), c.options)
 
 	heap.Init(&c.pendingLogs)
 
 	// background tasks that perform housekeeping duties on the cache
-	bgt, err := NewBackgroundTask("InsertPendingEntries", c.context.Name, c.InsertPendingEntries, c.options.CachePendingSeqMaxWait/2, c.terminator)
+	bgt, err := NewBackgroundTask("InsertPendingEntries", c.collection.Name(), c.InsertPendingEntries, c.options.CachePendingSeqMaxWait/2, c.terminator)
 	if err != nil {
 		return err
 	}
 	c.backgroundTasks = append(c.backgroundTasks, bgt)
 
-	bgt, err = NewBackgroundTask("CleanSkippedSequenceQueue", c.context.Name, c.CleanSkippedSequenceQueue, c.options.CacheSkippedSeqMaxWait/2, c.terminator)
+	bgt, err = NewBackgroundTask("CleanSkippedSequenceQueue", c.collection.Name(), c.CleanSkippedSequenceQueue, c.options.CacheSkippedSeqMaxWait/2, c.terminator)
 	if err != nil {
 		return err
 	}
@@ -230,7 +226,7 @@ func (c *changeCache) Stop() {
 	close(c.terminator)
 
 	// Wait for changeCache background tasks to finish.
-	waitForBGTCompletion(context.TODO(), BGTCompletionMaxWait, c.backgroundTasks, c.context.Name)
+	waitForBGTCompletion(context.TODO(), BGTCompletionMaxWait, c.backgroundTasks, c.collection.Name())
 
 	// Stop the channel cache and it's background tasks.
 	c.channelCache.Stop()
@@ -265,7 +261,7 @@ func (c *changeCache) Clear() error {
 	// the point at which the change cache was initialized / re-initialized.
 	// No need to touch c.nextSequence here, because we don't want to touch the sequence buffering state.
 	var err error
-	c.initialSequence, err = c.context.LastSequence()
+	c.initialSequence, err = c.collection.LastSequence()
 	if err != nil {
 		return err
 	}
@@ -317,12 +313,12 @@ func (c *changeCache) CleanSkippedSequenceQueue(ctx context.Context) error {
 		return nil
 	}
 
-	base.InfofCtx(ctx, base.KeyCache, "Starting CleanSkippedSequenceQueue, found %d skipped sequences older than max wait for database %s", len(oldSkippedSequences), base.MD(c.context.Name))
+	base.InfofCtx(ctx, base.KeyCache, "Starting CleanSkippedSequenceQueue, found %d skipped sequences older than max wait for database %s", len(oldSkippedSequences), base.MD(c.collection.Name()))
 
 	var foundEntries []*LogEntry
 	var pendingRemovals []uint64
 
-	if c.context.Options.UnsupportedOptions != nil && c.context.Options.UnsupportedOptions.DisableCleanSkippedQuery {
+	if c.collection.unsupportedOptions() != nil && c.collection.unsupportedOptions().DisableCleanSkippedQuery {
 		pendingRemovals = append(pendingRemovals, oldSkippedSequences...)
 		oldSkippedSequences = nil
 	}
@@ -337,12 +333,12 @@ func (c *changeCache) CleanSkippedSequenceQueue(ctx context.Context) error {
 			oldSkippedSequences = nil
 		}
 
-		base.InfofCtx(ctx, base.KeyCache, "Issuing skipped sequence clean query for %d sequences, %d remain pending (db:%s).", len(skippedSeqBatch), len(oldSkippedSequences), base.MD(c.context.Name))
+		base.InfofCtx(ctx, base.KeyCache, "Issuing skipped sequence clean query for %d sequences, %d remain pending (db:%s).", len(skippedSeqBatch), len(oldSkippedSequences), base.MD(c.collection.Name()))
 		// Note: The view query is only going to hit for active revisions - sequences associated with inactive revisions
 		//       aren't indexed by the channel view.  This means we can potentially miss channel removals:
 		//       when an older revision is missed by the TAP feed, and a channel is removed in that revision,
 		//       the doc won't be flagged as removed from that channel in the in-memory channel cache.
-		entries, err := c.context.getChangesForSequences(ctx, skippedSeqBatch)
+		entries, err := c.collection.getChangesForSequences(ctx, skippedSeqBatch)
 		if err != nil {
 			base.WarnfCtx(ctx, "Error retrieving sequences via query during skipped sequence clean - #%d sequences treated as not found: %v", len(skippedSeqBatch), err)
 			continue
@@ -370,7 +366,7 @@ func (c *changeCache) CleanSkippedSequenceQueue(ctx context.Context) error {
 		entry.Skipped = true
 		// Need to populate the actual channels for this entry - the entry returned from the * channel
 		// view will only have the * channel
-		doc, err := c.context.GetSingleDatabaseCollection().GetDocument(ctx, entry.DocID, DocUnmarshalNoHistory)
+		doc, err := c.collection.GetDocument(ctx, entry.DocID, DocUnmarshalNoHistory)
 		if err != nil {
 			base.WarnfCtx(ctx, "Unable to retrieve doc when processing skipped document %q: abandoning sequence %d", base.UD(entry.DocID), entry.Sequence)
 			continue
@@ -389,9 +385,9 @@ func (c *changeCache) CleanSkippedSequenceQueue(ctx context.Context) error {
 
 	// Purge sequences not found from the skipped sequence queue
 	numRemoved := c.RemoveSkippedSequences(ctx, pendingRemovals)
-	c.context.DbStats.Cache().AbandonedSeqs.Add(numRemoved)
+	c.collection.dbStats().Cache().AbandonedSeqs.Add(numRemoved)
 
-	base.InfofCtx(ctx, base.KeyCache, "CleanSkippedSequenceQueue complete.  Found:%d, Not Found:%d for database %s.", len(foundEntries), len(pendingRemovals), base.MD(c.context.Name))
+	base.InfofCtx(ctx, base.KeyCache, "CleanSkippedSequenceQueue complete.  Found:%d, Not Found:%d for database %s.", len(foundEntries), len(pendingRemovals), base.MD(c.collection.Name()))
 	return nil
 }
 
@@ -441,12 +437,12 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 	// If this is a binary document (and not one of the above types), we can ignore.  Currently only performing this check when xattrs
 	// are enabled, because walrus doesn't support DataType on feed.
-	if c.context.UseXattrs() && event.DataType == base.MemcachedDataTypeRaw {
+	if c.collection.UseXattrs() && event.DataType == base.MemcachedDataTypeRaw {
 		return
 	}
 
 	// First unmarshal the doc (just its metadata, to save time/memory):
-	syncData, rawBody, _, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, c.context.Options.UserXattrKey, false)
+	syncData, rawBody, _, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, c.collection.userXattrKey(), false)
 	if err != nil {
 		// Avoid log noise related to failed unmarshaling of binary documents.
 		if event.DataType != base.MemcachedDataTypeRaw {
@@ -459,7 +455,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	}
 
 	// If using xattrs and this isn't an SG write, we shouldn't attempt to cache.
-	if c.context.UseXattrs() {
+	if c.collection.UseXattrs() {
 		if syncData == nil {
 			return
 		}
@@ -471,15 +467,14 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 	// If not using xattrs and no sync metadata found, check whether we're mid-upgrade and attempting to read a doc w/ metadata stored in xattr
 	// before ignoring the mutation.
-	if !c.context.UseXattrs() && !syncData.HasValidSyncData() {
-		dbCollection := c.context.GetSingleDatabaseCollection()
-		migratedDoc, _ := dbCollection.checkForUpgrade(docID, DocUnmarshalNoHistory)
+	if !c.collection.UseXattrs() && !syncData.HasValidSyncData() {
+		migratedDoc, _ := c.collection.checkForUpgrade(docID, DocUnmarshalNoHistory)
 		if migratedDoc != nil && migratedDoc.Cas == event.Cas {
 			base.InfofCtx(c.logCtx, base.KeyCache, "Found mobile xattr on doc %q without %s property - caching, assuming upgrade in progress.", base.UD(docID), base.SyncPropertyName)
 			syncData = &migratedDoc.SyncData
 		} else {
 			base.InfofCtx(c.logCtx, base.KeyCache, "changeCache: Doc %q does not have valid sync data.", base.UD(docID))
-			c.context.DbStats.Cache().NonMobileIgnoredCount.Add(1)
+			c.collection.dbStats().Cache().NonMobileIgnoredCount.Add(1)
 			return
 		}
 	}
@@ -499,10 +494,10 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 		// Record latency when greater than zero
 		feedNano := feedLatency.Nanoseconds()
 		if feedNano > 0 {
-			c.context.DbStats.Database().DCPReceivedTime.Add(feedNano)
+			c.collection.dbStats().Database().DCPReceivedTime.Add(feedNano)
 		}
 	}
-	c.context.DbStats.Database().DCPReceivedCount.Add(1)
+	c.collection.dbStats().Database().DCPReceivedCount.Add(1)
 
 	// If the doc update wasted any sequences due to conflicts, add empty entries for them:
 	for _, seq := range syncData.UnusedSequences {
@@ -790,8 +785,8 @@ func (c *changeCache) _addToCache(change *LogEntry) []channels.ID {
 	}
 
 	if !change.TimeReceived.IsZero() {
-		c.context.DbStats.Database().DCPCachingCount.Add(1)
-		c.context.DbStats.Database().DCPCachingTime.Add(time.Since(change.TimeReceived).Nanoseconds())
+		c.collection.dbStats().Database().DCPCachingCount.Add(1)
+		c.collection.dbStats().Database().DCPCachingTime.Add(time.Since(change.TimeReceived).Nanoseconds())
 	}
 
 	return updatedChannels
@@ -810,7 +805,7 @@ func (c *changeCache) _addPendingLogs() channels.Set {
 			heap.Pop(&c.pendingLogs)
 			changedChannels = changedChannels.UpdateWithSlice(c._addToCache(change))
 		} else if len(c.pendingLogs) > c.options.CachePendingSeqMaxNum || time.Since(c.pendingLogs[0].TimeReceived) >= c.options.CachePendingSeqMaxWait {
-			c.context.DbStats.Cache().NumSkippedSeqs.Add(1)
+			c.collection.dbStats().Cache().NumSkippedSeqs.Add(1)
 			c.PushSkipped(c.nextSequence)
 			c.nextSequence++
 		} else {
@@ -902,14 +897,14 @@ func (h *LogPriorityQueue) Pop() interface{} {
 
 func (c *changeCache) RemoveSkipped(x uint64) error {
 	err := c.skippedSeqs.Remove(x)
-	c.context.DbStats.Cache().SkippedSeqLen.Set(int64(c.skippedSeqs.skippedList.Len()))
+	c.collection.dbStats().Cache().SkippedSeqLen.Set(int64(c.skippedSeqs.skippedList.Len()))
 	return err
 }
 
 // Removes a set of sequences.  Logs warning on removal error, returns count of successfully removed.
 func (c *changeCache) RemoveSkippedSequences(ctx context.Context, sequences []uint64) (removedCount int64) {
 	numRemoved := c.skippedSeqs.RemoveSequences(ctx, sequences)
-	c.context.DbStats.Cache().SkippedSeqLen.Set(int64(c.skippedSeqs.skippedList.Len()))
+	c.collection.dbStats().Cache().SkippedSeqLen.Set(int64(c.skippedSeqs.skippedList.Len()))
 	return numRemoved
 }
 
@@ -923,7 +918,7 @@ func (c *changeCache) PushSkipped(sequence uint64) {
 		base.InfofCtx(c.logCtx, base.KeyCache, "Error pushing skipped sequence: %d, %v", sequence, err)
 		return
 	}
-	c.context.DbStats.Cache().SkippedSeqLen.Set(int64(c.skippedSeqs.skippedList.Len()))
+	c.collection.dbStats().Cache().SkippedSeqLen.Set(int64(c.skippedSeqs.skippedList.Len()))
 }
 
 func (c *changeCache) GetSkippedSequencesOlderThanMaxWait() (oldSequences []uint64) {

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -2058,7 +2058,7 @@ func BenchmarkProcessEntry(b *testing.B) {
 
 			ctx = context.AddDatabaseLogContext(ctx)
 			changeCache := &changeCache{}
-			if err := changeCache.Init(ctx, collection, context.channelCache, nil, nil, ""); err != nil {
+			if err := changeCache.Init(ctx, collection, context.channelCache, nil, nil); err != nil {
 				log.Printf("Init failed for changeCache: %v", err)
 				b.Fail()
 			}
@@ -2290,7 +2290,7 @@ func BenchmarkDocChanged(b *testing.B) {
 
 			ctx = context.AddDatabaseLogContext(ctx)
 			changeCache := &changeCache{}
-			if err := changeCache.Init(ctx, collection, context.channelCache, nil, nil, ""); err != nil {
+			if err := changeCache.Init(ctx, collection, context.channelCache, nil, nil); err != nil {
 				log.Printf("Init failed for changeCache: %v", err)
 				b.Fail()
 			}

--- a/db/changes.go
+++ b/db/changes.go
@@ -79,12 +79,12 @@ type ViewDoc struct {
 	Json json.RawMessage // should be type 'document', but that fails to unmarshal correctly
 }
 
-func (db *Database) AddDocToChangeEntry(ctx context.Context, entry *ChangeEntry, options ChangesOptions) {
+func (db *DatabaseCollectionWithUser) AddDocToChangeEntry(ctx context.Context, entry *ChangeEntry, options ChangesOptions) {
 	db.addDocToChangeEntry(ctx, entry, options)
 }
 
 // Adds a document body and/or its conflicts to a ChangeEntry
-func (db *Database) addDocToChangeEntry(ctx context.Context, entry *ChangeEntry, options ChangesOptions) {
+func (db *DatabaseCollectionWithUser) addDocToChangeEntry(ctx context.Context, entry *ChangeEntry, options ChangesOptions) {
 
 	includeConflicts := options.Conflicts && entry.branched
 	if !options.IncludeDocs && !includeConflicts {
@@ -96,11 +96,6 @@ func (db *Database) addDocToChangeEntry(ctx context.Context, entry *ChangeEntry,
 		return
 	}
 
-	dbCollection, ok := db.CollectionByID[entry.collectionID]
-	if !ok {
-		base.WarnfCtx(ctx, "Changes feed: could not determine collection from doc %q", base.UD(entry.ID))
-		return
-	}
 	// Three options for retrieving document content, depending on what's required:
 	//   includeConflicts only:
 	//      - Retrieve document metadata from bucket (required to identify current set of conflicts)
@@ -112,7 +107,7 @@ func (db *Database) addDocToChangeEntry(ctx context.Context, entry *ChangeEntry,
 
 	if options.IncludeDocs && includeConflicts {
 		// Load doc body + metadata
-		doc, err := dbCollection.GetDocument(ctx, entry.ID, DocUnmarshalAll)
+		doc, err := db.GetDocument(ctx, entry.ID, DocUnmarshalAll)
 		if err != nil {
 			base.WarnfCtx(ctx, "Changes feed: error getting doc %q: %v", base.UD(entry.ID), err)
 			return
@@ -123,7 +118,7 @@ func (db *Database) addDocToChangeEntry(ctx context.Context, entry *ChangeEntry,
 		// Load doc metadata only
 		doc := &Document{}
 		var err error
-		doc.SyncData, err = dbCollection.GetDocSyncData(ctx, entry.ID)
+		doc.SyncData, err = db.GetDocSyncData(ctx, entry.ID)
 		if err != nil {
 			base.WarnfCtx(ctx, "Changes feed: error getting doc sync data %q: %v", base.UD(entry.ID), err)
 			return
@@ -141,18 +136,17 @@ func (db *Database) addDocToChangeEntry(ctx context.Context, entry *ChangeEntry,
 
 }
 
-func (db *Database) AddDocToChangeEntryUsingRevCache(ctx context.Context, entry *ChangeEntry, revID string) (err error) {
-	dbCollectionWithUser := db.GetSingleDatabaseCollectionWithUser()
-	rev, err := dbCollectionWithUser.getRev(ctx, entry.ID, revID, 0, nil, RevCacheIncludeBody)
+func (db *DatabaseCollectionWithUser) AddDocToChangeEntryUsingRevCache(ctx context.Context, entry *ChangeEntry, revID string) (err error) {
+	rev, err := db.getRev(ctx, entry.ID, revID, 0, nil, RevCacheIncludeBody)
 	if err != nil {
 		return err
 	}
-	entry.Doc, err = rev.As1xBytes(dbCollectionWithUser, nil, nil, false)
+	entry.Doc, err = rev.As1xBytes(db, nil, nil, false)
 	return err
 }
 
 // Adds a document body and/or its conflicts to a ChangeEntry
-func (db *Database) AddDocInstanceToChangeEntry(ctx context.Context, entry *ChangeEntry, doc *Document, options ChangesOptions) {
+func (db *DatabaseCollectionWithUser) AddDocInstanceToChangeEntry(ctx context.Context, entry *ChangeEntry, doc *Document, options ChangesOptions) {
 
 	includeConflicts := options.Conflicts && entry.branched
 
@@ -171,8 +165,8 @@ func (db *Database) AddDocInstanceToChangeEntry(ctx context.Context, entry *Chan
 	}
 	if options.IncludeDocs {
 		var err error
-		entry.Doc, _, err = db.GetSingleDatabaseCollectionWithUser().get1xRevFromDoc(ctx, doc, revID, false)
-		db.DbStats.Database().NumDocReadsRest.Add(1)
+		entry.Doc, _, err = db.get1xRevFromDoc(ctx, doc, revID, false)
+		db.dbStats().Database().NumDocReadsRest.Add(1)
 		if err != nil {
 			base.WarnfCtx(ctx, "Changes feed: error getting doc %q/%q: %v", base.UD(doc.ID), revID, err)
 		}
@@ -186,11 +180,11 @@ func (db *Database) AddDocInstanceToChangeEntry(ctx context.Context, entry *Chan
 // This is used in this function in 'wasDocInChannelAtSeq'.
 // revokeFrom: This is the point at which we should run the changes feed from to find the documents we should revoke. It
 // is calculated higher up based on whether we are resuming an interrupted feed or not.
-func (db *Database) buildRevokedFeed(ctx context.Context, ch channels.ID, options ChangesOptions, revokedAt, revocationSinceSeq, revokeFrom uint64, to string) <-chan *ChangeEntry {
+func (db *DatabaseCollectionWithUser) buildRevokedFeed(ctx context.Context, ch channels.ID, options ChangesOptions, revokedAt, revocationSinceSeq, revokeFrom uint64, to string) <-chan *ChangeEntry {
 	feed := make(chan *ChangeEntry, 1)
 	sinceVal := options.Since.Seq
 
-	queryLimit := db.Options.CacheOptions.ChannelQueryLimit
+	queryLimit := db.channelQueryLimit()
 	requestLimit := options.Limit
 
 	paginationOptions := options
@@ -202,7 +196,7 @@ func (db *Database) buildRevokedFeed(ctx context.Context, ch channels.ID, option
 	paginationOptions.Since.Seq = revokeFrom
 
 	// Use a bypass channel cache for revocations (CBG-1695)
-	singleChannelCache := db.changeCache.getChannelCache().getBypassChannelCache(ch)
+	singleChannelCache := db.ChangeCache().getChannelCache().getBypassChannelCache(ch)
 
 	go func() {
 		defer base.FatalPanicHandler()
@@ -248,7 +242,7 @@ func (db *Database) buildRevokedFeed(ctx context.Context, ch channels.ID, option
 				// Otherwise: we need to determine whether a previous revision of the document was in the channel prior
 				// to the since value, and only send a revocation if that was the case
 				if logEntry.Sequence > sinceVal {
-					requiresRevocation, err := db.GetSingleDatabaseCollectionWithUser().wasDocInChannelPriorToRevocation(ctx, logEntry.DocID, singleChannelCache.ChannelID().Name, revocationSinceSeq)
+					requiresRevocation, err := db.wasDocInChannelPriorToRevocation(ctx, logEntry.DocID, singleChannelCache.ChannelID().Name, revocationSinceSeq)
 					if err != nil {
 						change := ChangeEntry{
 							Err: base.ErrChannelFeed,
@@ -264,7 +258,7 @@ func (db *Database) buildRevokedFeed(ctx context.Context, ch channels.ID, option
 					}
 				}
 
-				userHasAccessToDoc, err := UserHasDocAccess(ctx, db.GetSingleDatabaseCollectionWithUser(), logEntry.DocID)
+				userHasAccessToDoc, err := UserHasDocAccess(ctx, db, logEntry.DocID)
 				if err != nil {
 					change := ChangeEntry{
 						Err: base.ErrChannelFeed,
@@ -376,11 +370,11 @@ func (db *DatabaseCollectionWithUser) wasDocInChannelPriorToRevocation(ctx conte
 
 // Creates a Go-channel of all the changes made on a channel.
 // Does NOT handle the Wait option. Does NOT check authorization.
-func (db *Database) changesFeed(ctx context.Context, singleChannelCache SingleChannelCache, options ChangesOptions, to string) <-chan *ChangeEntry {
+func (db *DatabaseCollectionWithUser) changesFeed(ctx context.Context, singleChannelCache SingleChannelCache, options ChangesOptions, to string) <-chan *ChangeEntry {
 
 	feed := make(chan *ChangeEntry, 1)
 
-	queryLimit := db.Options.CacheOptions.ChannelQueryLimit
+	queryLimit := db.channelQueryLimit()
 	requestLimit := options.Limit
 
 	// Make a copy of the changesOptions so that query pagination can modify since and limit.  Pagination uses safe sequence
@@ -527,7 +521,7 @@ func makeErrorEntry(message string) ChangeEntry {
 	return change
 }
 
-func (db *Database) MultiChangesFeed(ctx context.Context, chans base.Set, options ChangesOptions) (<-chan *ChangeEntry, error) {
+func (db *DatabaseCollectionWithUser) MultiChangesFeed(ctx context.Context, chans base.Set, options ChangesOptions) (<-chan *ChangeEntry, error) {
 	if len(chans) == 0 {
 		return nil, nil
 	}
@@ -538,16 +532,15 @@ func (db *Database) MultiChangesFeed(ctx context.Context, chans base.Set, option
 
 	base.DebugfCtx(ctx, base.KeyChanges, "Int sequence multi changes feed...")
 
-	collection := db.GetSingleDatabaseCollection()
-	return db.SimpleMultiChangesFeed(ctx, channels.SetOfFromSingleCollection(chans.ToArray(), collection.GetCollectionID()), options)
+	return db.SimpleMultiChangesFeed(ctx, channels.SetOfFromSingleCollection(chans.ToArray(), db.GetCollectionID()), options)
 
 }
 
-func (db *Database) startChangeWaiter() *ChangeWaiter {
-	return db.mutationListener.NewWaiterWithChannels(channels.Set{}, db.user)
+func (db *DatabaseCollectionWithUser) startChangeWaiter() *ChangeWaiter {
+	return db.mutationListener().NewWaiterWithChannels(channels.Set{}, db.user)
 }
 
-func (db *Database) appendUserFeed(feeds []<-chan *ChangeEntry, options ChangesOptions) []<-chan *ChangeEntry {
+func (db *DatabaseCollectionWithUser) appendUserFeed(feeds []<-chan *ChangeEntry, options ChangesOptions) []<-chan *ChangeEntry {
 	userSeq := SequenceID{Seq: db.user.Sequence()}
 	if options.Since.Before(userSeq) {
 		name := db.user.Name()
@@ -568,7 +561,7 @@ func (db *Database) appendUserFeed(feeds []<-chan *ChangeEntry, options ChangesO
 	return feeds
 }
 
-func (db *Database) checkForUserUpdates(ctx context.Context, userChangeCount uint64, changeWaiter *ChangeWaiter, isContinuous bool) (isChanged bool, newCount uint64, changedChannels channels.ChangedChannels, err error) {
+func (db *DatabaseCollectionWithUser) checkForUserUpdates(ctx context.Context, userChangeCount uint64, changeWaiter *ChangeWaiter, isContinuous bool) (isChanged bool, newCount uint64, changedChannels channels.ChangedChannels, err error) {
 
 	newCount = changeWaiter.CurrentUserCount()
 	// If not continuous, we force user reload as a workaround for https://github.com/couchbase/sync_gateway/issues/2068.  For continuous, #2068 is handled by changedChannels check, and
@@ -588,8 +581,7 @@ func (db *Database) checkForUserUpdates(ctx context.Context, userChangeCount uin
 			}
 			// check whether channel set has changed
 			singleCollectionChannels := db.user.InheritedChannels().CompareKeys(previousChannels)
-			collection := db.GetSingleDatabaseCollection()
-			collectionID := collection.GetCollectionID()
+			collectionID := db.GetCollectionID()
 
 			for channelName, changed := range singleCollectionChannels {
 				changedChannels[channels.NewID(channelName, collectionID)] = changed
@@ -609,7 +601,7 @@ func (db *Database) checkForUserUpdates(ctx context.Context, userChangeCount uin
 }
 
 // Returns the (ordered) union of all of the changes made to multiple channels.
-func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans channels.Set, options ChangesOptions) (<-chan *ChangeEntry, error) {
+func (db *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Context, chans channels.Set, options ChangesOptions) (<-chan *ChangeEntry, error) {
 
 	to := ""
 	if db.user != nil && db.user.Name() != "" {
@@ -619,8 +611,7 @@ func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans channels.S
 	base.InfofCtx(ctx, base.KeyChanges, "MultiChangesFeed(channels: %s, options: %s) ... %s", base.UD(chans), options, base.UD(to))
 	output := make(chan *ChangeEntry, 50)
 
-	collection := db.GetSingleDatabaseCollection()
-	singleCollectionID := collection.GetCollectionID()
+	singleCollectionID := db.GetCollectionID()
 	go func() {
 
 		defer func() {
@@ -642,7 +633,7 @@ func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans channels.S
 		var deferredBackfill bool                    // Whether there's a backfill identified in the user doc that's deferred while the SG cache catches up
 
 		// Retrieve the current max cached sequence - ensures there isn't a race between the subsequent channel cache queries
-		currentCachedSequence = db.changeCache.getChannelCache().GetHighCacheSequence()
+		currentCachedSequence = db.ChangeCache().getChannelCache().GetHighCacheSequence()
 		if options.Wait {
 			options.Wait = false
 
@@ -676,8 +667,8 @@ func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans channels.S
 		}
 
 		// Mark channel set as active, schedule defer
-		db.activeChannels.IncrChannels(channelsSince)
-		defer db.activeChannels.DecrChannels(channelsSince)
+		db.activeChannels().IncrChannels(channelsSince)
+		defer db.activeChannels().DecrChannels(channelsSince)
 
 		// For a continuous feed, initialise the lateSequenceFeeds that track late-arriving sequences
 		// to the channel caches.
@@ -703,7 +694,7 @@ func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans channels.S
 
 			// lowSequence is used to send composite keys to clients, so that they can obtain any currently
 			// skipped sequences in a future iteration or request.
-			oldestSkipped := db.changeCache.getOldestSkippedSequence()
+			oldestSkipped := db.ChangeCache().getOldestSkippedSequence()
 			if oldestSkipped > 0 {
 				lowSequence = oldestSkipped - 1
 				base.InfofCtx(ctx, base.KeyChanges, "%d is the oldest skipped sequence, using stable sequence number of %d for this feed %s", oldestSkipped, lowSequence, base.UD(to))
@@ -735,7 +726,7 @@ func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans channels.S
 					chanID := channels.NewID(chanName, collectionID)
 					// Obtain a SingleChannelCache instance to use for both normal and late feeds.  Required to ensure consistency
 					// if cache is evicted during processing
-					singleChannelCache := db.changeCache.getChannelCache().getSingleChannelCache(chanID)
+					singleChannelCache := db.ChangeCache().getChannelCache().getSingleChannelCache(chanID)
 
 					// Set up late sequence handling first, as we need to roll back the regular feed on error
 					// Handles previously skipped sequences prior to options.Since that
@@ -993,10 +984,10 @@ func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans channels.S
 					break waitForChanges
 				}
 
-				db.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Add(1)
-				db.DbStats.CBLReplicationPull().NumPullReplCaughtUp.Add(1)
+				db.dbStats().CBLReplicationPull().NumPullReplTotalCaughtUp.Add(1)
+				db.dbStats().CBLReplicationPull().NumPullReplCaughtUp.Add(1)
 				waitResponse := changeWaiter.Wait()
-				db.DbStats.CBLReplicationPull().NumPullReplCaughtUp.Add(-1)
+				db.dbStats().CBLReplicationPull().NumPullReplCaughtUp.Add(-1)
 
 				if waitResponse == WaiterClosed {
 					break outer
@@ -1017,7 +1008,7 @@ func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans channels.S
 				}
 			}
 			// Update the current max cached sequence for the next changes iteration
-			currentCachedSequence = db.changeCache.getChannelCache().GetHighCacheSequence()
+			currentCachedSequence = db.ChangeCache().getChannelCache().GetHighCacheSequence()
 
 			// Check whether user channel access has changed while waiting:
 			var err error
@@ -1038,7 +1029,7 @@ func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans channels.S
 				}
 
 				if len(changedChannels) > 0 {
-					db.activeChannels.UpdateChanged(changedChannels)
+					db.activeChannels().UpdateChanged(changedChannels)
 				}
 				channelsSince = channels.TimedSetByCollectionID{}
 				channelsSince[singleCollectionID] = newChannelsSince
@@ -1060,7 +1051,7 @@ func (db *Database) SimpleMultiChangesFeed(ctx context.Context, chans channels.S
 	return output, nil
 }
 
-func (db *Database) waitForCacheUpdate(ctx context.Context, currentCachedSequence uint64) (cancelled bool) {
+func (db *DatabaseCollectionWithUser) waitForCacheUpdate(ctx context.Context, currentCachedSequence uint64) (cancelled bool) {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	for retry := 0; retry <= 50; retry++ {
@@ -1069,7 +1060,7 @@ func (db *Database) waitForCacheUpdate(ctx context.Context, currentCachedSequenc
 		case <-ctx.Done():
 			return true
 		case <-ticker.C:
-			if db.changeCache.getChannelCache().GetHighCacheSequence() != currentCachedSequence {
+			if db.ChangeCache().getChannelCache().GetHighCacheSequence() != currentCachedSequence {
 				return false
 			}
 		}
@@ -1079,7 +1070,7 @@ func (db *Database) waitForCacheUpdate(ctx context.Context, currentCachedSequenc
 
 // FOR TEST USE ONLY: Synchronous convenience function that returns all changes as a simple array,
 // Returns error if initial feed creation fails, or if an error is returned with the changes entries
-func (db *Database) GetChanges(ctx context.Context, channels base.Set, options ChangesOptions) ([]*ChangeEntry, error) {
+func (db *DatabaseCollectionWithUser) GetChanges(ctx context.Context, channels base.Set, options ChangesOptions) ([]*ChangeEntry, error) {
 	if options.ChangesCtx == nil {
 		changesCtx, changesCtxCancel := context.WithCancel(context.Background())
 		options.ChangesCtx = changesCtx
@@ -1100,28 +1091,28 @@ func (db *Database) GetChanges(ctx context.Context, channels base.Set, options C
 }
 
 // Returns the set of cached log entries for a given channel
-func (db *Database) GetChangeLog(channel channels.ID, afterSeq uint64) (entries []*LogEntry) {
+func (db *DatabaseCollection) GetChangeLog(channel channels.ID, afterSeq uint64) (entries []*LogEntry) {
 
-	return db.changeCache.getChannelCache().GetCachedChanges(channel)
+	return db.ChangeCache().getChannelCache().GetCachedChanges(channel)
 }
 
 // WaitForSequenceNotSkipped blocks until the given sequence has been received or skipped by the change cache.
-func (dbc *DatabaseContext) WaitForSequence(ctx context.Context, sequence uint64) (err error) {
+func (dbc *DatabaseCollection) WaitForSequence(ctx context.Context, sequence uint64) (err error) {
 	base.DebugfCtx(ctx, base.KeyChanges, "Waiting for sequence: %d", sequence)
-	return dbc.changeCache.waitForSequence(ctx, sequence, base.DefaultWaitForSequence)
+	return dbc.ChangeCache().waitForSequence(ctx, sequence, base.DefaultWaitForSequence)
 }
 
 // WaitForSequenceNotSkipped blocks until the given sequence has been received by the change cache without being skipped.
-func (dbc *DatabaseContext) WaitForSequenceNotSkipped(ctx context.Context, sequence uint64) (err error) {
+func (dbc *DatabaseCollection) WaitForSequenceNotSkipped(ctx context.Context, sequence uint64) (err error) {
 	base.DebugfCtx(ctx, base.KeyChanges, "Waiting for sequence: %d", sequence)
-	return dbc.changeCache.waitForSequenceNotSkipped(ctx, sequence, base.DefaultWaitForSequence)
+	return dbc.ChangeCache().waitForSequenceNotSkipped(ctx, sequence, base.DefaultWaitForSequence)
 }
 
 // WaitForPendingChanges blocks until the change-cache has caught up with the latest writes to the database.
-func (dbc *DatabaseContext) WaitForPendingChanges(ctx context.Context) (err error) {
+func (dbc *DatabaseCollection) WaitForPendingChanges(ctx context.Context) (err error) {
 	lastSequence, err := dbc.LastSequence()
 	base.DebugfCtx(ctx, base.KeyChanges, "Waiting for sequence: %d", lastSequence)
-	return dbc.changeCache.waitForSequence(ctx, lastSequence, base.DefaultWaitForSequence)
+	return dbc.ChangeCache().waitForSequence(ctx, lastSequence, base.DefaultWaitForSequence)
 }
 
 // Late Sequence Feed
@@ -1136,7 +1127,7 @@ type lateSequenceFeed struct {
 // Returns a lateSequenceFeed for the channel, used to find late-arriving (previously
 // skipped) sequences that have been sent to the channel cache.  The lateSequenceFeed stores the last (late)
 // sequence seen by this particular _changes feed to support continuous changes.
-func (db *Database) newLateSequenceFeed(singleChannelCache SingleChannelCache) *lateSequenceFeed {
+func (db *DatabaseCollectionWithUser) newLateSequenceFeed(singleChannelCache SingleChannelCache) *lateSequenceFeed {
 
 	if !singleChannelCache.SupportsLateFeed() {
 		return nil
@@ -1153,7 +1144,7 @@ func (db *Database) newLateSequenceFeed(singleChannelCache SingleChannelCache) *
 
 // Feed to process late sequences for the channel.  Updates lastSequence as it works the feed.  Error indicates
 // previous position in late sequence feed isn't available, and caller should reset to low sequence.
-func (db *Database) getLateFeed(feedHandler *lateSequenceFeed, singleChannelCache SingleChannelCache) (<-chan *ChangeEntry, error) {
+func (db *DatabaseCollectionWithUser) getLateFeed(feedHandler *lateSequenceFeed, singleChannelCache SingleChannelCache) (<-chan *ChangeEntry, error) {
 
 	if !singleChannelCache.SupportsLateFeed() {
 		return nil, errors.New("Cache doesn't support late feeds")
@@ -1202,8 +1193,8 @@ func (db *Database) getLateFeed(feedHandler *lateSequenceFeed, singleChannelCach
 }
 
 // Closes a single late sequence feed.
-func (db *Database) closeLateFeed(feedHandler *lateSequenceFeed) {
-	singleChannelCache := db.changeCache.getChannelCache().getSingleChannelCache(feedHandler.channel)
+func (db *DatabaseCollectionWithUser) closeLateFeed(feedHandler *lateSequenceFeed) {
+	singleChannelCache := db.ChangeCache().getChannelCache().getSingleChannelCache(feedHandler.channel)
 	if !singleChannelCache.SupportsLateFeed() {
 		return
 	}
@@ -1213,7 +1204,7 @@ func (db *Database) closeLateFeed(feedHandler *lateSequenceFeed) {
 }
 
 // Closes set of feeds.  Invoked on changes termination
-func (db *Database) closeLateFeeds(feeds map[channels.ID]*lateSequenceFeed) {
+func (db *DatabaseCollectionWithUser) closeLateFeeds(feeds map[channels.ID]*lateSequenceFeed) {
 	for _, feed := range feeds {
 		db.closeLateFeed(feed)
 	}
@@ -1221,7 +1212,7 @@ func (db *Database) closeLateFeeds(feeds map[channels.ID]*lateSequenceFeed) {
 
 // Generate the changes for a specific list of doc ID's, only documents accessible to the user will generate
 // results. Only supports non-continuous changes, closes buffered channel before returning.
-func (db *Database) DocIDChangesFeed(ctx context.Context, userChannels base.Set, explicitDocIds []string, options ChangesOptions) (<-chan *ChangeEntry, error) {
+func (db *DatabaseCollectionWithUser) DocIDChangesFeed(ctx context.Context, userChannels base.Set, explicitDocIds []string, options ChangesOptions) (<-chan *ChangeEntry, error) {
 
 	// Subroutine that creates a response row for a document:
 	output := make(chan *ChangeEntry, len(explicitDocIds))
@@ -1255,10 +1246,10 @@ func (db *Database) DocIDChangesFeed(ctx context.Context, userChannels base.Set,
 }
 
 // createChangesEntry is used when creating a doc ID filtered changes feed
-func createChangesEntry(ctx context.Context, docid string, db *Database, options ChangesOptions) *ChangeEntry {
+func createChangesEntry(ctx context.Context, docid string, db *DatabaseCollectionWithUser, options ChangesOptions) *ChangeEntry {
 	row := &ChangeEntry{ID: docid}
 
-	populatedDoc, err := db.GetSingleDatabaseCollectionWithUser().GetDocument(ctx, docid, DocUnmarshalSync)
+	populatedDoc, err := db.GetDocument(ctx, docid, DocUnmarshalSync)
 	if err != nil {
 		base.InfofCtx(ctx, base.KeyChanges, "Unable to get changes for docID %v, caused by %v", base.UD(docid), err)
 		return nil
@@ -1328,7 +1319,7 @@ func (options ChangesOptions) String() string {
 }
 
 // Used by BLIP connections for changes.  Supports both one-shot and continuous changes.
-func generateBlipSyncChanges(ctx context.Context, database *Database, inChannels base.Set, options ChangesOptions, docIDFilter []string, send func([]*ChangeEntry) error) (err error, forceClose bool) {
+func generateBlipSyncChanges(ctx context.Context, database *DatabaseCollectionWithUser, inChannels base.Set, options ChangesOptions, docIDFilter []string, send func([]*ChangeEntry) error) (err error, forceClose bool) {
 
 	// Store one-shot here to protect
 	isOneShot := !options.Continuous
@@ -1351,7 +1342,7 @@ type ChangesSendErr struct{ error }
 // Shell of the continuous changes feed -- calls out to a `send` function to deliver the change.
 // This is called from BLIP connections as well as HTTP handlers, which is why this is not a
 // method on `handler`.
-func GenerateChanges(ctx context.Context, cancelCtx context.Context, database *Database, inChannels base.Set, options ChangesOptions, docIDFilter []string, send func([]*ChangeEntry) error) (err error, forceClose bool) {
+func GenerateChanges(ctx context.Context, cancelCtx context.Context, database *DatabaseCollectionWithUser, inChannels base.Set, options ChangesOptions, docIDFilter []string, send func([]*ChangeEntry) error) (err error, forceClose bool) {
 	// Set up heartbeat/timeout
 	var timeoutInterval time.Duration
 	var timer *time.Timer
@@ -1374,7 +1365,7 @@ func GenerateChanges(ctx context.Context, cancelCtx context.Context, database *D
 	}
 
 	if !options.Since.IsNonZero() {
-		database.DatabaseContext.DbStats.CBLReplicationPull().NumPullReplSinceZero.Add(1)
+		database.dbStats().CBLReplicationPull().NumPullReplSinceZero.Add(1)
 	}
 
 	var lastSeq SequenceID
@@ -1479,7 +1470,7 @@ loop:
 		case <-timeout:
 			forceClose = true
 			break loop
-		case <-database.ExitChanges:
+		case <-database.exitChanges():
 			forceClose = true
 			break loop
 		case <-cancelCtx.Done():

--- a/db/changes.go
+++ b/db/changes.go
@@ -196,7 +196,7 @@ func (db *DatabaseCollectionWithUser) buildRevokedFeed(ctx context.Context, ch c
 	paginationOptions.Since.Seq = revokeFrom
 
 	// Use a bypass channel cache for revocations (CBG-1695)
-	singleChannelCache := db.ChangeCache().getChannelCache().getBypassChannelCache(ch)
+	singleChannelCache := db.changeCache.getChannelCache().getBypassChannelCache(ch)
 
 	go func() {
 		defer base.FatalPanicHandler()
@@ -633,7 +633,7 @@ func (db *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Context
 		var deferredBackfill bool                    // Whether there's a backfill identified in the user doc that's deferred while the SG cache catches up
 
 		// Retrieve the current max cached sequence - ensures there isn't a race between the subsequent channel cache queries
-		currentCachedSequence = db.ChangeCache().getChannelCache().GetHighCacheSequence()
+		currentCachedSequence = db.changeCache.getChannelCache().GetHighCacheSequence()
 		if options.Wait {
 			options.Wait = false
 
@@ -694,7 +694,7 @@ func (db *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Context
 
 			// lowSequence is used to send composite keys to clients, so that they can obtain any currently
 			// skipped sequences in a future iteration or request.
-			oldestSkipped := db.ChangeCache().getOldestSkippedSequence()
+			oldestSkipped := db.changeCache.getOldestSkippedSequence()
 			if oldestSkipped > 0 {
 				lowSequence = oldestSkipped - 1
 				base.InfofCtx(ctx, base.KeyChanges, "%d is the oldest skipped sequence, using stable sequence number of %d for this feed %s", oldestSkipped, lowSequence, base.UD(to))
@@ -726,7 +726,7 @@ func (db *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Context
 					chanID := channels.NewID(chanName, collectionID)
 					// Obtain a SingleChannelCache instance to use for both normal and late feeds.  Required to ensure consistency
 					// if cache is evicted during processing
-					singleChannelCache := db.ChangeCache().getChannelCache().getSingleChannelCache(chanID)
+					singleChannelCache := db.changeCache.getChannelCache().getSingleChannelCache(chanID)
 
 					// Set up late sequence handling first, as we need to roll back the regular feed on error
 					// Handles previously skipped sequences prior to options.Since that
@@ -1008,7 +1008,7 @@ func (db *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Context
 				}
 			}
 			// Update the current max cached sequence for the next changes iteration
-			currentCachedSequence = db.ChangeCache().getChannelCache().GetHighCacheSequence()
+			currentCachedSequence = db.changeCache.getChannelCache().GetHighCacheSequence()
 
 			// Check whether user channel access has changed while waiting:
 			var err error
@@ -1060,7 +1060,7 @@ func (db *DatabaseCollectionWithUser) waitForCacheUpdate(ctx context.Context, cu
 		case <-ctx.Done():
 			return true
 		case <-ticker.C:
-			if db.ChangeCache().getChannelCache().GetHighCacheSequence() != currentCachedSequence {
+			if db.changeCache.getChannelCache().GetHighCacheSequence() != currentCachedSequence {
 				return false
 			}
 		}
@@ -1093,26 +1093,26 @@ func (db *DatabaseCollectionWithUser) GetChanges(ctx context.Context, channels b
 // Returns the set of cached log entries for a given channel
 func (db *DatabaseCollection) GetChangeLog(channel channels.ID, afterSeq uint64) (entries []*LogEntry) {
 
-	return db.ChangeCache().getChannelCache().GetCachedChanges(channel)
+	return db.changeCache.getChannelCache().GetCachedChanges(channel)
 }
 
 // WaitForSequenceNotSkipped blocks until the given sequence has been received or skipped by the change cache.
 func (dbc *DatabaseCollection) WaitForSequence(ctx context.Context, sequence uint64) (err error) {
 	base.DebugfCtx(ctx, base.KeyChanges, "Waiting for sequence: %d", sequence)
-	return dbc.ChangeCache().waitForSequence(ctx, sequence, base.DefaultWaitForSequence)
+	return dbc.changeCache.waitForSequence(ctx, sequence, base.DefaultWaitForSequence)
 }
 
 // WaitForSequenceNotSkipped blocks until the given sequence has been received by the change cache without being skipped.
 func (dbc *DatabaseCollection) WaitForSequenceNotSkipped(ctx context.Context, sequence uint64) (err error) {
 	base.DebugfCtx(ctx, base.KeyChanges, "Waiting for sequence: %d", sequence)
-	return dbc.ChangeCache().waitForSequenceNotSkipped(ctx, sequence, base.DefaultWaitForSequence)
+	return dbc.changeCache.waitForSequenceNotSkipped(ctx, sequence, base.DefaultWaitForSequence)
 }
 
 // WaitForPendingChanges blocks until the change-cache has caught up with the latest writes to the database.
 func (dbc *DatabaseCollection) WaitForPendingChanges(ctx context.Context) (err error) {
 	lastSequence, err := dbc.LastSequence()
 	base.DebugfCtx(ctx, base.KeyChanges, "Waiting for sequence: %d", lastSequence)
-	return dbc.ChangeCache().waitForSequence(ctx, lastSequence, base.DefaultWaitForSequence)
+	return dbc.changeCache.waitForSequence(ctx, lastSequence, base.DefaultWaitForSequence)
 }
 
 // Late Sequence Feed
@@ -1194,7 +1194,7 @@ func (db *DatabaseCollectionWithUser) getLateFeed(feedHandler *lateSequenceFeed,
 
 // Closes a single late sequence feed.
 func (db *DatabaseCollectionWithUser) closeLateFeed(feedHandler *lateSequenceFeed) {
-	singleChannelCache := db.ChangeCache().getChannelCache().getSingleChannelCache(feedHandler.channel)
+	singleChannelCache := db.changeCache.getChannelCache().getSingleChannelCache(feedHandler.channel)
 	if !singleChannelCache.SupportsLateFeed() {
 		return
 	}

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -67,13 +67,13 @@ func TestFilterToAvailableChannels(t *testing.T) {
 				_, _, err = collection.Put(ctx, "doc"+id, Body{"channels": []string{"ch" + id}})
 				require.NoError(t, err)
 			}
-			err = db.WaitForPendingChanges(base.TestCtx(t))
+			err = collection.WaitForPendingChanges(base.TestCtx(t))
 			require.NoError(t, err)
 
-			db.user, err = auth.GetUser("test")
+			collection.user, err = auth.GetUser("test")
 			require.NoError(t, err)
 
-			ch, err := db.GetChanges(ctx, testCase.accessChans, getChangesOptionsWithZeroSeq())
+			ch, err := collection.GetChanges(ctx, testCase.accessChans, getChangesOptionsWithZeroSeq())
 			require.NoError(t, err)
 			require.Len(t, ch, len(testCase.expectedDocsReturned))
 
@@ -118,12 +118,12 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	_, err = db.UpdatePrincipal(base.TestCtx(t), userInfo, true, true)
 	assert.NoError(t, err, "UpdatePrincipal failed")
 
-	err = db.WaitForPendingChanges(base.TestCtx(t))
+	err = collection.WaitForPendingChanges(base.TestCtx(t))
 	assert.NoError(t, err)
 
 	// Check the _changes feed:
-	db.user, _ = authenticator.GetUser("naomi")
-	changes, err := db.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq())
+	collection.user, _ = authenticator.GetUser("naomi")
+	changes, err := collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq())
 	assert.NoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)
 	require.Len(t, changes, 3)
@@ -151,7 +151,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	// Check the _changes feed -- this is to make sure the changeCache properly received
 	// sequence 2 (the user doc) and isn't stuck waiting for it.
 	cacheWaiter.AddAndWait(1)
-	changes, err = db.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithSeq(lastSeq))
+	changes, err = collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithSeq(lastSeq))
 
 	assert.NoError(t, err, "Couldn't GetChanges (2nd)")
 
@@ -160,7 +160,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	assert.Equal(t, []ChangeRev{{"rev": revid}}, changes[0].Changes)
 
 	// validate from zero
-	changes, err = db.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq())
+	changes, err = collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq())
 	assert.NoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)
 
@@ -220,8 +220,8 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	require.NoError(t, err)
 	cacheWaiter.AddAndWait(1)
 
-	db.user, _ = authenticator.GetUser("alice")
-	changes, err := db.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq())
+	collection.user, _ = authenticator.GetUser("alice")
+	changes, err := collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq())
 	assert.NoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)
 	assert.Equal(t, 1, len(changes))
@@ -265,7 +265,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	// Check the _changes feed -- this is to make sure the changeCache properly received
 	// sequence 3 and isn't stuck waiting for it.
 	cacheWaiter.AddAndWait(1)
-	changes, err = db.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithSeq(lastSeq))
+	changes, err = collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithSeq(lastSeq))
 
 	assert.NoError(t, err, "Couldn't GetChanges (2nd)")
 
@@ -305,8 +305,8 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	require.NoError(t, err)
 	cacheWaiter.AddAndWait(1)
 
-	db.user, _ = authenticator.GetUser("alice")
-	changes, err := db.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq())
+	collection.user, _ = authenticator.GetUser("alice")
+	changes, err := collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq())
 	assert.NoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)
 
@@ -348,7 +348,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	// sequence 3 (the modified document) and isn't stuck waiting for it.
 	cacheWaiter.AddAndWait(1)
 
-	changes, err = db.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithSeq(lastSeq))
+	changes, err = collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithSeq(lastSeq))
 
 	assert.NoError(t, err, "Couldn't GetChanges (2nd)")
 
@@ -386,7 +386,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 		require.NoError(t, err, "Couldn't delete document")
 	}
 
-	waitErr := db.WaitForPendingChanges(base.TestCtx(t))
+	waitErr := collection.WaitForPendingChanges(base.TestCtx(t))
 	assert.NoError(t, waitErr)
 
 	changesOptions := ChangesOptions{
@@ -398,7 +398,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 	initQueryCount := db.DbStats.Cache().ViewQueries.Value()
 
 	// Get changes with active_only=true
-	activeChanges, err := db.GetChanges(ctx, base.SetOf("*"), changesOptions)
+	activeChanges, err := collection.GetChanges(ctx, base.SetOf("*"), changesOptions)
 	require.NoError(t, err, "Error getting changes with active_only true")
 	require.Equal(t, 5, len(activeChanges))
 
@@ -408,7 +408,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 
 	// Get changes with active_only=false, validate that triggers a new query
 	changesOptions.ActiveOnly = false
-	allChanges, err := db.GetChanges(ctx, base.SetOf("*"), changesOptions)
+	allChanges, err := collection.GetChanges(ctx, base.SetOf("*"), changesOptions)
 	require.NoError(t, err, "Error getting changes with active_only true")
 	require.Equal(t, 10, len(allChanges))
 
@@ -417,7 +417,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 
 	// Get changes with active_only=false again, verify results are served from the cache
 	changesOptions.ActiveOnly = false
-	allChanges, err = db.GetChanges(ctx, base.SetOf("*"), changesOptions)
+	allChanges, err = collection.GetChanges(ctx, base.SetOf("*"), changesOptions)
 	require.NoError(t, err, "Error getting changes with active_only true")
 	require.Equal(t, 10, len(allChanges))
 
@@ -496,7 +496,7 @@ func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
 
 		changesCtx, changesCtxCancel := context.WithCancel(context.Background())
 		options.ChangesCtx = changesCtx
-		feed, err := db.MultiChangesFeed(ctx, base.SetOf("*"), options)
+		feed, err := collection.MultiChangesFeed(ctx, base.SetOf("*"), options)
 		if err != nil {
 			b.Fatalf("Error getting changes feed: %v", err)
 		}

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -18,6 +18,7 @@ import (
 	"github.com/couchbase/go-couchbase"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 )
 
 // Unmarshaled JSON structure for "changes" view results
@@ -85,13 +86,19 @@ func nextChannelQueryEntry(results sgbucket.QueryResultIterator, collectionID ui
 }
 
 // Queries the 'channels' view to get a range of sequences of a single channel as LogEntries.
-func (dbc *DatabaseContext) getChangesInChannelFromQuery(ctx context.Context, channelName string, startSeq, endSeq uint64, limit int, activeOnly bool) (LogEntries, error) {
+func (dbc *DatabaseContext) getChangesInChannelFromQuery(ctx context.Context, channel channels.ID, startSeq, endSeq uint64, limit int, activeOnly bool) (LogEntries, error) {
+	collection := dbc.GetSingleDatabaseCollection()
+	return collection.getChangesInChannelFromQuery(ctx, channel.Name, startSeq, endSeq, limit, activeOnly)
+
+}
+
+// Queries the 'channels' view to get a range of sequences of a single channel as LogEntries.
+func (dbc *DatabaseCollection) getChangesInChannelFromQuery(ctx context.Context, channelName string, startSeq, endSeq uint64, limit int, activeOnly bool) (LogEntries, error) {
 	if dbc.Bucket == nil {
 		return nil, errors.New("No bucket available for channel query")
 	}
 	start := time.Now()
-	usingViews := dbc.Options.UseViews
-
+	usingViews := dbc.useViews()
 	entries := make(LogEntries, 0)
 	activeEntryCount := 0
 
@@ -100,6 +107,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(ctx context.Context, ch
 	// Loop for active-only and limit handling.
 	// The set of changes we get back from the query applies the limit, but includes both active and non-active entries.  When retrieving changes w/ activeOnly=true and a limit,
 	// this means we may need multiple view calls to get a total of [limit] active entries.
+	collectionID := dbc.GetCollectionID()
 	for {
 
 		// Query the view or index
@@ -111,8 +119,6 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(ctx context.Context, ch
 
 		// Convert the output to LogEntries.  Channel query and view result rows have different structure, so need to unmarshal independently.
 		highSeq := uint64(0)
-		collection := dbc.GetSingleDatabaseCollection()
-		collectionID := collection.GetCollectionID()
 		for {
 			var entry *LogEntry
 			var found bool
@@ -182,18 +188,18 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(ctx context.Context, ch
 		base.InfofCtx(ctx, base.KeyAll, "Channel query took %v to return %d rows.  Channel: %s StartSeq: %d EndSeq: %d Limit: %d",
 			elapsed, len(entries), base.UD(channelName), startSeq, endSeq, limit)
 	}
-	dbc.DbStats.Cache().ViewQueries.Add(1)
+	dbc.dbStats().Cache().ViewQueries.Add(1)
 	return entries, nil
 }
 
 // Queries the 'channels' view to get changes from a channel for the specified sequence.  Used for skipped sequence check
 // before abandoning.
-func (dbc *DatabaseContext) getChangesForSequences(ctx context.Context, sequences []uint64) (LogEntries, error) {
+func (dbc *DatabaseCollection) getChangesForSequences(ctx context.Context, sequences []uint64) (LogEntries, error) {
 	if dbc.Bucket == nil {
 		return nil, errors.New("No bucket available for sequence query")
 	}
 	start := time.Now()
-	usingViews := dbc.Options.UseViews
+	usingViews := dbc.useViews()
 
 	entries := make(LogEntries, 0)
 
@@ -202,8 +208,7 @@ func (dbc *DatabaseContext) getChangesForSequences(ctx context.Context, sequence
 	if err != nil {
 		return nil, err
 	}
-	collection := dbc.GetSingleDatabaseCollection()
-	collectionID := collection.GetCollectionID()
+	collectionID := dbc.GetCollectionID()
 
 	// Convert the output to LogEntries.  Channel query and view result rows have different structure, so need to unmarshal independently.
 	for {

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -255,7 +255,9 @@ func (c *channelCacheImpl) Remove(collectionID uint32, docIDs []string, startTim
 		if channelCache == nil {
 			return false
 		}
-
+		if channelCache.ChannelID().CollectionID != collectionID {
+			return true
+		}
 		count += channelCache.Remove(collectionID, docIDs, startTime)
 		return true
 	}

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -45,7 +45,7 @@ type ChannelCache interface {
 	AddPrincipal(change *LogEntry)
 
 	// Remove purges the given doc IDs from all channel caches and returns the number of items removed.
-	Remove(docIDs []string, startTime time.Time) (count int)
+	Remove(collectionID uint32, docIDs []string, startTime time.Time) (count int)
 
 	// Returns set of changes for a given channel, within the bounds specified in options
 	GetChanges(ch channels.ID, options ChangesOptions) ([]*LogEntry, error)
@@ -244,7 +244,7 @@ func (c *channelCacheImpl) AddToCache(change *LogEntry) (updatedChannels []chann
 
 // Remove purges the given doc IDs from all channel caches and returns the number of items removed.
 // count will be larger than the input slice if the same document is removed from multiple channel caches.
-func (c *channelCacheImpl) Remove(docIDs []string, startTime time.Time) (count int) {
+func (c *channelCacheImpl) Remove(collectionID uint32, docIDs []string, startTime time.Time) (count int) {
 	// Exit early if there's no work to do
 	if len(docIDs) == 0 {
 		return 0
@@ -256,7 +256,7 @@ func (c *channelCacheImpl) Remove(docIDs []string, startTime time.Time) (count i
 			return false
 		}
 
-		count += channelCache.Remove(docIDs, startTime)
+		count += channelCache.Remove(collectionID, docIDs, startTime)
 		return true
 	}
 

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -75,7 +75,7 @@ type ChannelCache interface {
 
 // ChannelQueryHandler interface is implemented by databaseContext.
 type ChannelQueryHandler interface {
-	getChangesInChannelFromQuery(ctx context.Context, channelName string, startSeq, endSeq uint64, limit int, activeOnly bool) (LogEntries, error)
+	getChangesInChannelFromQuery(ctx context.Context, channelName channels.ID, startSeq, endSeq uint64, limit int, activeOnly bool) (LogEntries, error)
 }
 
 type StableSequenceCallbackFunc func() uint64

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -413,7 +413,7 @@ func (c *singleChannelCacheImpl) GetChanges(options ChangesOptions) ([]*LogEntry
 	// overlap, which helps confirm that we've got everything.
 	c.cacheStats.ChannelCacheMisses.Add(1)
 	endSeq := cacheValidFrom
-	resultFromQuery, err := c.queryHandler.getChangesInChannelFromQuery(options.LoggingCtx, c.channelID.Name, startSeq, endSeq, options.Limit, options.ActiveOnly)
+	resultFromQuery, err := c.queryHandler.getChangesInChannelFromQuery(options.LoggingCtx, c.channelID, startSeq, endSeq, options.Limit, options.ActiveOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -836,7 +836,7 @@ type bypassChannelCache struct {
 func (b *bypassChannelCache) GetChanges(options ChangesOptions) ([]*LogEntry, error) {
 	startSeq := options.Since.SafeSequence() + 1
 	endSeq := uint64(math.MaxUint64)
-	return b.queryHandler.getChangesInChannelFromQuery(options.LoggingCtx, b.channel.Name, startSeq, endSeq, options.Limit, options.ActiveOnly)
+	return b.queryHandler.getChangesInChannelFromQuery(options.LoggingCtx, b.channel, startSeq, endSeq, options.Limit, options.ActiveOnly)
 }
 
 // No cached changes for bypassChannelCache

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -218,7 +218,7 @@ func (c *singleChannelCacheImpl) wouldBeImmediatelyPruned(change *LogEntry) bool
 }
 
 // Remove purges the given doc IDs from the channel cache and returns the number of items removed.
-func (c *singleChannelCacheImpl) Remove(docIDs []string, startTime time.Time) (count int) {
+func (c *singleChannelCacheImpl) Remove(collectionID uint32, docIDs []string, startTime time.Time) (count int) {
 	// Exit early if there's no work to do
 	if len(docIDs) == 0 {
 		return 0
@@ -239,6 +239,9 @@ func (c *singleChannelCacheImpl) Remove(docIDs []string, startTime time.Time) (c
 	// Do the removals in one sweep of the channel cache
 	end := len(c.logs) - 1
 	for i := end; i >= 0; i-- {
+		if c.ChannelID().CollectionID != collectionID {
+			continue
+		}
 		if _, ok := foundDocs[c.logs[i].DocID]; ok {
 			docID := c.logs[i].DocID
 

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -239,9 +239,6 @@ func (c *singleChannelCacheImpl) Remove(collectionID uint32, docIDs []string, st
 	// Do the removals in one sweep of the channel cache
 	end := len(c.logs) - 1
 	for i := end; i >= 0; i-- {
-		if c.ChannelID().CollectionID != collectionID {
-			continue
-		}
 		if _, ok := foundDocs[c.logs[i].DocID]; ok {
 			docID := c.logs[i].DocID
 

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -493,7 +493,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	assert.True(t, err == nil)
 
 	// Now remove doc1
-	cache.Remove([]string{"doc1"}, time.Now())
+	cache.Remove(collectionID, []string{"doc1"}, time.Now())
 	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 2)
 	assert.True(t, verifyChannelSequences(entries, []uint64{2, 3}))
@@ -503,7 +503,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	// Try to remove doc5 with a startTime before it was added to ensure it's not removed
 	// This will print a debug level log:
 	// [DBG] Cache+: Skipping removal of doc "doc5" from cache "Test1" - received after purge
-	cache.Remove([]string{"doc5"}, time.Now().Add(-time.Second*5))
+	cache.Remove(collectionID, []string{"doc5"}, time.Now().Add(-time.Second*5))
 	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 2)
 	assert.True(t, verifyChannelSequences(entries, []uint64{2, 3}))

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -24,11 +24,8 @@ import (
 )
 
 func TestChannelCacheMaxSize(t *testing.T) {
-	t.Skip("fIXME: stats")
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	bucket := base.GetTestBucket(t)
-
+	bucket := base.GetTestBucketDefaultCollection(t)
 	ctx := base.TestCtx(t)
 	dbCtx, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(t, err)

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -32,7 +32,7 @@ func TestChannelCacheMaxSize(t *testing.T) {
 	defer dbCtx.Close(ctx)
 
 	collection := dbCtx.GetSingleDatabaseCollection()
-	cache := collection.ChangeCache().getChannelCache()
+	cache := collection.changeCache.getChannelCache()
 
 	collectionID := dbCtx.GetSingleDatabaseCollection().GetCollectionID()
 

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestChannelCacheMaxSize(t *testing.T) {
-
+	t.Skip("fIXME: stats")
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
 	bucket := base.GetTestBucket(t)
@@ -33,7 +33,9 @@ func TestChannelCacheMaxSize(t *testing.T) {
 	dbCtx, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer dbCtx.Close(ctx)
-	cache := dbCtx.changeCache.getChannelCache()
+
+	collection := dbCtx.GetSingleDatabaseCollection()
+	cache := collection.ChangeCache().getChannelCache()
 
 	collectionID := dbCtx.GetSingleDatabaseCollection().GetCollectionID()
 
@@ -483,11 +485,11 @@ type testQueryHandler struct {
 	lock       sync.RWMutex
 }
 
-func (qh *testQueryHandler) getChangesInChannelFromQuery(ctx context.Context, channelName string, startSeq, endSeq uint64, limit int, activeOnly bool) (LogEntries, error) {
+func (qh *testQueryHandler) getChangesInChannelFromQuery(ctx context.Context, channel channels.ID, startSeq, endSeq uint64, limit int, activeOnly bool) (LogEntries, error) {
 	queryEntries := make(LogEntries, 0)
 	qh.lock.RLock()
 	for _, entry := range qh.entries {
-		_, ok := entry.Channels[channelName]
+		_, ok := entry.Channels[channel.Name]
 		if ok {
 			if activeOnly && !entry.IsActive() {
 				continue

--- a/db/crud.go
+++ b/db/crud.go
@@ -1567,7 +1567,7 @@ func (db *DatabaseCollectionWithUser) assignSequence(ctx context.Context, docSeq
 		// on the feed is small - sub-second, so we usually shouldn't care about more than
 		// a few recent sequences.  However, the pruning has some overhead (read lock on nextSequence),
 		// so we're allowing more 'recent sequences' on the doc (20) before attempting pruning
-		stableSequence := db.changeCache().GetStableSequence(doc.ID).Seq
+		stableSequence := db.ChangeCache().GetStableSequence(doc.ID).Seq
 		count := 0
 		for _, seq := range doc.RecentSequences {
 			// Only remove sequences if they are higher than a sequence that's been seen on the

--- a/db/crud.go
+++ b/db/crud.go
@@ -1567,7 +1567,7 @@ func (db *DatabaseCollectionWithUser) assignSequence(ctx context.Context, docSeq
 		// on the feed is small - sub-second, so we usually shouldn't care about more than
 		// a few recent sequences.  However, the pruning has some overhead (read lock on nextSequence),
 		// so we're allowing more 'recent sequences' on the doc (20) before attempting pruning
-		stableSequence := db.ChangeCache().GetStableSequence(doc.ID).Seq
+		stableSequence := db.changeCache.GetStableSequence(doc.ID).Seq
 		count := 0
 		for _, seq := range doc.RecentSequences {
 			// Only remove sequences if they are higher than a sequence that's been seen on the

--- a/db/database.go
+++ b/db/database.go
@@ -2007,7 +2007,7 @@ func (dbCtx *DatabaseContext) onlyDefaultCollection() bool {
 }
 
 // GetDefaultDatabaseCollection will return the default collection if the default collection is supplied in the database config.
-func (dbc *Database) GetDefaultDatabaseCollection() (*DatabaseCollection, error) {
+func (dbc *DatabaseContext) GetDefaultDatabaseCollection() (*DatabaseCollection, error) {
 	col, exists := dbc.CollectionByID[base.DefaultCollectionID]
 	if !exists {
 		return nil, fmt.Errorf("default collection is not configured on this database")

--- a/db/database.go
+++ b/db/database.go
@@ -94,12 +94,12 @@ type DatabaseContext struct {
 	StartTime                   time.Time               // Timestamp when context was instantiated
 	RevsLimit                   uint32                  // Max depth a document's revision tree can grow to
 	autoImport                  bool                    // Add sync data to new untracked couchbase server docs?  (Xattr mode specific)
-	changeCache                 *changeCache            // Cache of recently-access channels
-	EventMgr                    *EventManager           // Manages notification events
-	AllowEmptyPassword          bool                    // Allow empty passwords?  Defaults to false
-	Options                     DatabaseContextOptions  // Database Context Options
-	AccessLock                  sync.RWMutex            // Allows DB offline to block until synchronous calls have completed
-	State                       uint32                  // The runtime state of the DB from a service perspective
+	channelCache                ChannelCache
+	EventMgr                    *EventManager          // Manages notification events
+	AllowEmptyPassword          bool                   // Allow empty passwords?  Defaults to false
+	Options                     DatabaseContextOptions // Database Context Options
+	AccessLock                  sync.RWMutex           // Allows DB offline to block until synchronous calls have completed
+	State                       uint32                 // The runtime state of the DB from a service perspective
 	ResyncManager               *BackgroundManager
 	TombstoneCompactionManager  *BackgroundManager
 	AttachmentCompactionManager *BackgroundManager
@@ -390,16 +390,31 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	}
 	initialSequenceTime := time.Now()
 
-	// In-memory channel cache
-	dbContext.changeCache = &changeCache{}
-
-	// Callback that is invoked whenever a set of channels is changed in the ChangeCache
-	notifyChange := func(changedChannels channels.Set) {
-		dbContext.mutationListener.Notify(changedChannels)
-	}
-
 	// Initialize the active channel counter
 	dbContext.activeChannels = channels.NewActiveChannels(dbContext.DbStats.Cache().NumActiveChannels)
+
+	cacheOptions := options.CacheOptions
+	if cacheOptions == nil {
+		defaultOpts := DefaultCacheOptions()
+		cacheOptions = &defaultOpts
+	}
+	channelCache, err := NewChannelCacheForContext(cacheOptions.ChannelCacheOptions, dbContext)
+	if err != nil {
+		return nil, err
+	}
+	dbContext.channelCache = channelCache
+
+	// Initialize sg cluster config.  Required even if import and sgreplicate are disabled
+	// on this node, to support replication REST API calls
+	if base.IsEnterpriseEdition() {
+		sgCfg, err := base.NewCfgSG(dbContext.Bucket, dbContext.Options.GroupID)
+		if err != nil {
+			return nil, err
+		}
+		dbContext.CfgSG = sgCfg
+	} else {
+		dbContext.CfgSG = cbgt.NewCfgMem()
+	}
 
 	if len(options.Scopes) > 0 {
 		dbContext.Scopes = make(map[string]Scope, len(options.Scopes))
@@ -409,7 +424,10 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 			}
 			for collName := range scope.Collections {
 
-				dbCollection := newDatabaseCollection(dbContext, bucket)
+				dbCollection, err := newDatabaseCollection(ctx, dbContext, bucket)
+				if err != nil {
+					return nil, err
+				}
 				dbContext.Scopes[scopeName].Collections[collName] = dbCollection
 
 				collectionID := dbCollection.GetCollectionID()
@@ -418,41 +436,17 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 			}
 		}
 	} else {
-		dbCollection := newDatabaseCollection(dbContext, bucket)
+		dbCollection, err := newDatabaseCollection(ctx, dbContext, bucket)
+		if err != nil {
+			return nil, err
+		}
 
 		dbContext.CollectionByID[base.DefaultCollectionID] = dbCollection
 		dbContext.singleCollection = dbCollection
 	}
 
-	// Initialize the ChangeCache.  Will be locked and unusable until .Start() is called (SG #3558)
-	err = dbContext.changeCache.Init(
-		ctx,
-		dbContext,
-		notifyChange,
-		options.CacheOptions,
-	)
-	if err != nil {
-		base.DebugfCtx(ctx, base.KeyDCP, "Error initializing the change cache", err)
-	}
-
-	// Set the DB Context notifyChange callback to call back the changecache DocChanged callback
-	dbContext.SetOnChangeCallback(dbContext.changeCache.DocChanged)
-
 	// Initialize the tap Listener for notify handling
 	dbContext.mutationListener.Init(bucket.GetName(), options.GroupID)
-
-	// Initialize sg cluster config.  Required even if import and sgreplicate are disabled
-	// on this node, to support replication REST API calls
-	if base.IsEnterpriseEdition() {
-		sgCfg, err := base.NewCfgSG(dbContext.Bucket, dbContext.Options.GroupID)
-		if err != nil {
-			return nil, err
-		}
-		dbContext.changeCache.cfgEventCallback = sgCfg.FireEvent
-		dbContext.CfgSG = sgCfg
-	} else {
-		dbContext.CfgSG = cbgt.NewCfgMem()
-	}
 
 	// Initialize sg-replicate manager
 	dbContext.SGReplicateMgr, err = NewSGReplicateManager(ctx, dbContext, dbContext.CfgSG)
@@ -502,7 +496,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 
 	// Check if there is an error starting the DCP feed
 	if err != nil {
-		dbContext.changeCache = nil
+		dbContext.channelCache = nil
 		return nil, err
 	}
 
@@ -516,14 +510,15 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		_ = dbContext.sequences.waitForReleasedSequences(initialSequenceTime)
 	}
 
-	err = dbContext.changeCache.Start(initialSequence)
-	if err != nil {
-		return nil, err
+	for _, collection := range dbContext.CollectionByID {
+		err = collection.ChangeCache().Start(initialSequence)
+		if err != nil {
+			return nil, err
+		}
+		cleanupFunctions = append(cleanupFunctions, func() {
+			collection.ChangeCache().Stop()
+		})
 	}
-
-	cleanupFunctions = append(cleanupFunctions, func() {
-		dbContext.changeCache.Stop()
-	})
 
 	// If this is an xattr import node, start import feed.  Must be started after the caching DCP feed, as import cfg
 	// subscription relies on the caching feed.
@@ -699,11 +694,6 @@ func (dbCtx *DatabaseContext) GetServerUUID(ctx context.Context) string {
 	return dbCtx.serverUUID
 }
 
-// Utility function to support cache testing from outside db package
-func (context *DatabaseContext) GetChangeCache() *changeCache {
-	return context.changeCache
-}
-
 func (context *DatabaseContext) Close(ctx context.Context) {
 	context.BucketLock.Lock()
 	defer context.BucketLock.Unlock()
@@ -714,7 +704,7 @@ func (context *DatabaseContext) Close(ctx context.Context) {
 	waitForBGTCompletion(ctx, BGTCompletionMaxWait, context.backgroundTasks, context.Name)
 	context.sequences.Stop()
 	context.mutationListener.Stop()
-	context.changeCache.Stop()
+	context.stopChangeCaches()
 	context.ImportListener.Stop()
 	if context.Heartbeater != nil {
 		context.Heartbeater.Stop()
@@ -765,12 +755,6 @@ func (context *DatabaseContext) RestartListener() error {
 	return nil
 }
 
-// Cache flush support.  Currently test-only - added for unit test access from rest package
-func (dbCtx *DatabaseContext) FlushChannelCache(ctx context.Context) error {
-	base.InfofCtx(ctx, base.KeyCache, "Flushing channel cache")
-	return dbCtx.changeCache.Clear()
-}
-
 // Removes previous versions of Sync Gateway's design docs found on the server
 func (context *DatabaseContext) RemoveObsoleteDesignDocs(previewOnly bool) (removedDesignDocs []string, err error) {
 	return removeObsoleteDesignDocs(context.Bucket, previewOnly, context.UseViews())
@@ -810,7 +794,7 @@ func (dc *DatabaseContext) TakeDbOffline(ctx context.Context, reason string) err
 		dc.AccessLock.Lock()
 		defer dc.AccessLock.Unlock()
 
-		dc.changeCache.Stop()
+		dc.stopChangeCaches()
 
 		// set DB state to Offline
 		atomic.StoreUint32(&dc.State, DBOffline)
@@ -932,7 +916,7 @@ type ForEachDocIDOptions struct {
 type ForEachDocIDFunc func(id IDRevAndSequence, channels []string) (bool, error)
 
 // Iterates over all documents in the database, calling the callback function on each
-func (db *Database) ForEachDocID(ctx context.Context, callback ForEachDocIDFunc, resultsOpts ForEachDocIDOptions) error {
+func (db *DatabaseCollection) ForEachDocID(ctx context.Context, callback ForEachDocIDFunc, resultsOpts ForEachDocIDOptions) error {
 
 	results, err := db.QueryAllDocs(ctx, resultsOpts.Startkey, resultsOpts.Endkey)
 	if err != nil {
@@ -947,7 +931,7 @@ func (db *Database) ForEachDocID(ctx context.Context, callback ForEachDocIDFunc,
 }
 
 // Iterate over the results of an AllDocs query, performing ForEachDocID handling for each row
-func (db *Database) processForEachDocIDResults(callback ForEachDocIDFunc, limit uint64, results sgbucket.QueryResultIterator) error {
+func (db *DatabaseCollection) processForEachDocIDResults(callback ForEachDocIDFunc, limit uint64, results sgbucket.QueryResultIterator) error {
 
 	count := uint64(0)
 	for {
@@ -956,7 +940,7 @@ func (db *Database) processForEachDocIDResults(callback ForEachDocIDFunc, limit 
 		var docid, revid string
 		var seq uint64
 		var channels []string
-		if db.Options.UseViews {
+		if db.useViews() {
 			var viewRow AllDocsViewQueryRow
 			found = results.Next(&viewRow)
 			if found {
@@ -1473,7 +1457,7 @@ func (db *Database) Compact(ctx context.Context, skipRunningStateCheck bool, cal
 		count := len(purgedDocs)
 		purgedDocCount += count
 		if count > 0 {
-			db.changeCache.Remove(purgedDocs, startTime)
+			db.GetSingleDatabaseCollection().ChangeCache().Remove(purgedDocs, startTime)
 			db.DbStats.Database().NumTombstonesCompacted.Add(int64(count))
 		}
 		base.DebugfCtx(ctx, base.KeyAll, "Compacted %v tombstones", count)
@@ -1546,13 +1530,13 @@ func (db *Database) UpdateSyncFun(ctx context.Context, syncFun string) (changed 
 // To be used when the JavaScript sync function changes.
 type updateAllDocChannelsCallbackFunc func(docsProcessed, docsChanged *int)
 
-func (db *Database) UpdateAllDocChannels(ctx context.Context, regenerateSequences bool, callback updateAllDocChannelsCallbackFunc, terminator *base.SafeTerminator) (int, error) {
+func (db *DatabaseCollectionWithUser) UpdateAllDocChannels(ctx context.Context, regenerateSequences bool, callback updateAllDocChannelsCallbackFunc, terminator *base.SafeTerminator) (int, error) {
 	base.InfofCtx(ctx, base.KeyAll, "Recomputing document channels...")
 	base.InfofCtx(ctx, base.KeyAll, "Re-running sync function on all documents...")
 
-	queryLimit := db.Options.QueryPaginationLimit
+	queryLimit := db.queryPaginationLimit()
 	startSeq := uint64(0)
-	endSeq, err := db.sequences.getSequence()
+	endSeq, err := db.sequences().getSequence()
 	if err != nil {
 		return 0, err
 	}
@@ -1606,8 +1590,7 @@ func (db *Database) UpdateAllDocChannels(ctx context.Context, regenerateSequence
 				// Run the sync fn over each current/leaf revision, in case there are conflicts:
 				changed := 0
 				doc.History.forEachLeaf(func(rev *RevInfo) {
-					collection := db.GetSingleDatabaseCollectionWithUser()
-					bodyBytes, _, err := collection.get1xRevFromDoc(ctx, doc, rev.ID, false)
+					bodyBytes, _, err := db.get1xRevFromDoc(ctx, doc, rev.ID, false)
 					if err != nil {
 						base.WarnfCtx(ctx, "Error getting rev from doc %s/%s %s", base.UD(docid), rev.ID, err)
 					}
@@ -1616,11 +1599,11 @@ func (db *Database) UpdateAllDocChannels(ctx context.Context, regenerateSequence
 						base.WarnfCtx(ctx, "Error unmarshalling body %s/%s for sync function %s", base.UD(docid), rev.ID, err)
 						return
 					}
-					metaMap, err := doc.GetMetaMap(db.Options.UserXattrKey)
+					metaMap, err := doc.GetMetaMap(db.userXattrKey())
 					if err != nil {
 						return
 					}
-					channels, access, roles, syncExpiry, _, err := collection.getChannelsAndAccess(ctx, doc, body, metaMap, rev.ID)
+					channels, access, roles, syncExpiry, _, err := db.getChannelsAndAccess(ctx, doc, body, metaMap, rev.ID)
 					if err != nil {
 						// Probably the validator rejected the doc
 						base.WarnfCtx(ctx, "Error calling sync() on doc %q: %v", base.UD(docid), err)
@@ -1632,7 +1615,7 @@ func (db *Database) UpdateAllDocChannels(ctx context.Context, regenerateSequence
 					if rev.ID == doc.CurrentRev {
 
 						if regenerateSequences {
-							unusedSequences, err = collection.assignSequence(ctx, 0, doc, unusedSequences)
+							unusedSequences, err = db.assignSequence(ctx, 0, doc, unusedSequences)
 							if err != nil {
 								base.WarnfCtx(ctx, "Unable to assign a sequence number: %v", err)
 							}
@@ -1686,7 +1669,7 @@ func (db *Database) UpdateAllDocChannels(ctx context.Context, regenerateSequence
 						return nil, nil, deleteDoc, nil, base.ErrUpdateCancel
 					}
 				}
-				_, err = db.Bucket.WriteUpdateWithXattr(key, base.SyncXattrName, db.Options.UserXattrKey, 0, nil, nil, writeUpdateFunc)
+				_, err = db.Bucket.WriteUpdateWithXattr(key, base.SyncXattrName, db.userXattrKey(), 0, nil, nil, writeUpdateFunc)
 			} else {
 				_, err = db.Bucket.Update(key, 0, func(currentValue []byte) ([]byte, *uint32, bool, error) {
 					// Be careful: this block can be invoked multiple times if there are races!
@@ -1736,21 +1719,21 @@ func (db *Database) UpdateAllDocChannels(ctx context.Context, regenerateSequence
 	}
 
 	for _, sequence := range unusedSequences {
-		err := db.sequences.releaseSequence(sequence)
+		err := db.sequences().releaseSequence(sequence)
 		if err != nil {
 			base.WarnfCtx(ctx, "Error attempting to release sequence %d. Error %v", sequence, err)
 		}
 	}
 
 	if regenerateSequences {
-		users, roles, err := db.AllPrincipalIDs(ctx)
+		users, roles, err := db.allPrincipalIDs(ctx)
 		if err != nil {
 			return docsChanged, err
 		}
 
 		authr := db.Authenticator(ctx)
 		regeneratePrincipalSequences := func(princ auth.Principal) error {
-			nextSeq, err := db.DatabaseContext.sequences.nextSequence()
+			nextSeq, err := db.sequences().nextSequence()
 			if err != nil {
 				return err
 			}
@@ -1792,13 +1775,12 @@ func (db *Database) UpdateAllDocChannels(ctx context.Context, regenerateSequence
 	if docsChanged > 0 {
 		// Now invalidate channel cache of all users/roles:
 		base.InfofCtx(ctx, base.KeyAll, "Invalidating channel caches of users/roles...")
-		collection := db.GetSingleDatabaseCollection()
-		users, roles, _ := db.AllPrincipalIDs(ctx)
+		users, roles, _ := db.allPrincipalIDs(ctx)
 		for _, name := range users {
-			collection.invalUserChannels(ctx, name, endSeq)
+			db.invalUserChannels(ctx, name, endSeq)
 		}
 		for _, name := range roles {
-			collection.invalRoleChannels(ctx, name, endSeq)
+			db.invalRoleChannels(ctx, name, endSeq)
 		}
 	}
 	return docsChanged, nil
@@ -2024,11 +2006,20 @@ func (dbCtx *DatabaseContext) onlyDefaultCollection() bool {
 	return exists
 }
 
-// GetDefaultDatabaseCollectionWithUser will return the default collection if the default collection is supplied in the database config.
-func (dbc *Database) GetDefaultDatabaseCollectionWithUser() (*DatabaseCollectionWithUser, error) {
+// GetDefaultDatabaseCollection will return the default collection if the default collection is supplied in the database config.
+func (dbc *Database) GetDefaultDatabaseCollection() (*DatabaseCollection, error) {
 	col, exists := dbc.CollectionByID[base.DefaultCollectionID]
 	if !exists {
 		return nil, fmt.Errorf("default collection is not configured on this database")
+	}
+	return col, nil
+}
+
+// GetDefaultDatabaseCollectionWithUser will return the default collection if the default collection is supplied in the database config.
+func (dbc *Database) GetDefaultDatabaseCollectionWithUser() (*DatabaseCollectionWithUser, error) {
+	col, err := dbc.GetDefaultDatabaseCollection()
+	if err != nil {
+		return nil, err
 	}
 	return &DatabaseCollectionWithUser{
 		DatabaseCollection: col,
@@ -2050,15 +2041,50 @@ func (dbc *Database) GetSingleDatabaseCollectionWithUser() *DatabaseCollectionWi
 }
 
 // newDatabaseCollection returns a collection which inherits values from the database but is specific to a given Bucket.
-func newDatabaseCollection(dbContext *DatabaseContext, bucket base.Bucket) *DatabaseCollection {
+func newDatabaseCollection(ctx context.Context, dbContext *DatabaseContext, bucket base.Bucket) (*DatabaseCollection, error) {
 	dbCollection := &DatabaseCollection{
-		Bucket: bucket,
-		dbCtx:  dbContext,
+		Bucket:      bucket,
+		dbCtx:       dbContext,
+		changeCache: &changeCache{},
 	}
 	dbCollection.revisionCache = NewRevisionCache(
 		dbContext.Options.RevisionCacheOptions,
 		dbCollection,
 		dbContext.DbStats.Cache(),
 	)
-	return dbCollection
+	// Callback that is invoked whenever a set of channels is changed in the ChangeCache
+	notifyChange := func(changedChannels channels.Set) {
+		dbContext.mutationListener.Notify(changedChannels)
+	}
+
+	// Initialize the ChangeCache.  Will be locked and unusable until .Start() is called (SG #3558)
+	err := dbCollection.ChangeCache().Init(
+		ctx,
+		dbCollection,
+		dbContext.channelCache,
+		notifyChange,
+		dbContext.Options.CacheOptions,
+		dbContext.Options.GroupID,
+	)
+	if err != nil {
+		base.DebugfCtx(ctx, base.KeyDCP, "Error initializing the change cache", err)
+		return nil, err
+	}
+	// Set the DB Context notifyChange callback to call back the changecache DocChanged callback
+	dbContext.SetOnChangeCallback(dbCollection.ChangeCache().DocChanged)
+
+	if base.IsEnterpriseEdition() {
+		cfgSG, ok := dbContext.CfgSG.(*base.CfgSG)
+		if !ok {
+			return nil, fmt.Errorf("Could not cast %V to CfgSG", dbContext.CfgSG)
+		}
+		dbCollection.ChangeCache().cfgEventCallback = cfgSG.FireEvent
+	}
+	return dbCollection, nil
+}
+
+func (dbc *DatabaseContext) stopChangeCaches() {
+	for _, collection := range dbc.CollectionByID {
+		collection.ChangeCache().Stop()
+	}
 }

--- a/db/database.go
+++ b/db/database.go
@@ -2065,7 +2065,6 @@ func newDatabaseCollection(ctx context.Context, dbContext *DatabaseContext, buck
 		dbContext.channelCache,
 		notifyChange,
 		dbContext.Options.CacheOptions,
-		dbContext.Options.GroupID,
 	)
 	if err != nil {
 		base.DebugfCtx(ctx, base.KeyDCP, "Error initializing the change cache", err)

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -62,6 +62,12 @@ func (c *DatabaseCollection) backupOldRev() bool {
 
 }
 
+// bucketName returns the name of the bucket this collection is stored in.
+func (c *DatabaseCollection) bucketName() string {
+	return c.Bucket.GetName()
+
+}
+
 // channelMapper runs the javascript sync function. This is currently at the database level.
 func (c *DatabaseCollection) channelMapper() *channels.ChannelMapper {
 	return c.dbCtx.ChannelMapper
@@ -198,10 +204,9 @@ func (c *DatabaseCollectionWithUser) ReloadUser(ctx context.Context) error {
 	}
 	if user == nil {
 		return fmt.Errorf("User not found during reload")
-	} else {
-		c.user = user
-		return nil
 	}
+	c.user = user
+	return nil
 }
 
 // Name returns the name of the scope the collection is in. If couchbase server is not aware of collections, it will return _default.

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -62,11 +62,6 @@ func (c *DatabaseCollection) backupOldRev() bool {
 
 }
 
-// ChangeCache returns the set of channels in memory. This is currently at the database level.
-func (c *DatabaseCollection) ChangeCache() *changeCache {
-	return c.changeCache
-}
-
 // channelMapper runs the javascript sync function. This is currently at the database level.
 func (c *DatabaseCollection) channelMapper() *channels.ChannelMapper {
 	return c.dbCtx.ChannelMapper
@@ -112,8 +107,8 @@ func (c *DatabaseCollection) GetCollectionID() uint32 {
 }
 
 // GetReivisonCacheForTest allow accessing a copy of revision cache.
-func (context *DatabaseCollection) GetRevisionCacheForTest() RevisionCache {
-	return context.revisionCache
+func (c *DatabaseCollection) GetRevisionCacheForTest() RevisionCache {
+	return c.revisionCache
 }
 
 // FlushChannelCache flush support. Currently test-only - added for unit test access from rest package
@@ -211,6 +206,11 @@ func (c *DatabaseCollection) ScopeName() string {
 		return base.DefaultScope
 	}
 	return collection.ScopeName()
+}
+
+// RemoveFromChangeCache removes select documents from all channel caches and returns the number of documents removed.
+func (c *DatabaseCollection) RemoveFromChangeCache(docIDs []string, startTime time.Time) int {
+	return c.changeCache.Remove(c.GetCollectionID(), docIDs, startTime)
 }
 
 // revsLimit is the max depth a document's revision tree can grow to. This is controlled at a database level.

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -106,9 +106,14 @@ func (c *DatabaseCollection) GetCollectionID() uint32 {
 	return collection.GetCollectionID()
 }
 
-// GetReivisonCacheForTest allow accessing a copy of revision cache.
+// GetRevisionCacheForTest allow accessing a copy of revision cache.
 func (c *DatabaseCollection) GetRevisionCacheForTest() RevisionCache {
 	return c.revisionCache
+}
+
+// groupID return the GroupID defined at a database level.
+func (c *DatabaseCollection) groupID() string {
+	return c.dbCtx.Options.GroupID
 }
 
 // FlushChannelCache flush support. Currently test-only - added for unit test access from rest package

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -41,6 +41,11 @@ func (c *DatabaseCollection) AllowConflicts() bool {
 	return base.DefaultAllowConflicts
 }
 
+// allPrincipalIDs returns the IDs of all users and roles, including deleted Roles
+func (c *DatabaseCollection) allPrincipalIDs(ctx context.Context) (users, roles []string, err error) {
+	return c.dbCtx.AllPrincipalIDs(ctx)
+}
+
 // Authenticator returns authentication options associated with the collection's database.
 func (c *DatabaseCollection) Authenticator(ctx context.Context) *auth.Authenticator {
 	return c.dbCtx.Authenticator(ctx)
@@ -62,9 +67,14 @@ func (c *DatabaseCollection) ChangeCache() *changeCache {
 	return c.changeCache
 }
 
-// channelMapper runs the javascript sync function. The is currently at the database level.
+// channelMapper runs the javascript sync function. This is currently at the database level.
 func (c *DatabaseCollection) channelMapper() *channels.ChannelMapper {
 	return c.dbCtx.ChannelMapper
+}
+
+// channelQueryLimit returns the pagination for the number of channels returned in a query. This is a database level property.
+func (c *DatabaseCollection) channelQueryLimit() int {
+	return c.dbCtx.Options.CacheOptions.ChannelQueryLimit
 }
 
 // DbStats are stats that correspond to database level collections.
@@ -87,6 +97,11 @@ func (c *DatabaseCollection) eventMgr() *EventManager {
 	return c.dbCtx.EventMgr
 }
 
+// exitChanges will close active _changes feeds on the DB. This is a database level close.
+func (c *DatabaseCollection) exitChanges() chan struct{} {
+	return c.dbCtx.ExitChanges
+}
+
 // GetCollectionID returns a collectionID. If couchbase server does not return collections, it will return base.DefaultCollectionID, like the default collection for a Couchbase Server that does support collections.
 func (c *DatabaseCollection) GetCollectionID() uint32 {
 	collection, err := base.AsCollection(c.Bucket)
@@ -99,6 +114,12 @@ func (c *DatabaseCollection) GetCollectionID() uint32 {
 // GetReivisonCacheForTest allow accessing a copy of revision cache.
 func (context *DatabaseCollection) GetRevisionCacheForTest() RevisionCache {
 	return context.revisionCache
+}
+
+// FlushChannelCache flush support. Currently test-only - added for unit test access from rest package
+func (c *DatabaseCollection) FlushChannelCache(ctx context.Context) error {
+	base.InfofCtx(ctx, base.KeyCache, "Flushing channel cache")
+	return c.changeCache.Clear()
 }
 
 // FlushRevisionCacheForTest creates a new revision cache. This is currently at the database level. Only use this in test code.
@@ -119,6 +140,11 @@ func (c *DatabaseCollection) ForceAPIForbiddenErrors() bool {
 // importFilter returns the sync function.
 func (c *DatabaseCollection) importFilter() *ImportFilterFunction {
 	return c.dbCtx.Options.ImportOptions.ImportFilter
+}
+
+// IsClosed returns true if the underlying collection has been closed.
+func (c *DatabaseCollection) IsClosed() bool {
+	return c.Bucket == nil
 }
 
 // isGuestReadOnly returns true if the guest user can only perform read operations. This is controlled at the database level.
@@ -156,6 +182,28 @@ func (c *DatabaseCollection) oldRevExpirySeconds() uint32 {
 	return c.dbCtx.Options.OldRevExpirySeconds
 }
 
+// queryPaginationLimit limits the size of large queries. This is is controlled at a database level.
+func (c *DatabaseCollection) queryPaginationLimit() int {
+	return c.dbCtx.Options.QueryPaginationLimit
+}
+
+// ReloadUser the User object, in case its persistent properties have been changed. This code does not lock and is not safe to call from concurrent goroutines.
+func (c *DatabaseCollectionWithUser) ReloadUser(ctx context.Context) error {
+	if c.user == nil {
+		return nil
+	}
+	user, err := c.Authenticator(ctx).GetUser(c.user.Name())
+	if err != nil {
+		return err
+	}
+	if user == nil {
+		return fmt.Errorf("User not found during reload")
+	} else {
+		c.user = user
+		return nil
+	}
+}
+
 // Name returns the name of the scope the collection is in. If couchbase server is not aware of collections, it will return _default.
 func (c *DatabaseCollection) ScopeName() string {
 	collection, err := base.AsCollection(c.Bucket)
@@ -175,6 +223,11 @@ func (c *DatabaseCollection) sequences() *sequenceAllocator {
 	return c.dbCtx.sequences
 }
 
+// slowQueryWarningThreshold is the duration of N1QL query to log as slow. This is controlled at a database level.
+func (c *DatabaseCollection) slowQueryWarningThreshold() time.Duration {
+	return c.dbCtx.Options.SlowQueryWarningThreshold
+}
+
 // unsupportedOptions returns options that are potentially unstable. This is controlled at a database level.
 func (c *DatabaseCollection) unsupportedOptions() *UnsupportedOptions {
 	return c.dbCtx.Options.UnsupportedOptions
@@ -190,59 +243,12 @@ func (c *DatabaseCollection) UseXattrs() bool {
 	return c.dbCtx.Options.EnableXattr
 }
 
-// Reloads the database's User object, in case its persistent properties have been changed.
-func (c *DatabaseCollectionWithUser) ReloadUser(ctx context.Context) error {
-	if c.user == nil {
-		return nil
-	}
-	user, err := c.Authenticator(ctx).GetUser(c.user.Name())
-	if err != nil {
-		return err
-	}
-	if user == nil {
-		return fmt.Errorf("User not found during reload")
-	} else {
-		c.user = user
-		return nil
-	}
-}
-
+// User will return the user object.
 func (c *DatabaseCollectionWithUser) User() auth.User {
 	return c.user
 }
 
-func (c *DatabaseCollection) channelQueryLimit() int {
-	return c.dbCtx.Options.CacheOptions.ChannelQueryLimit
-}
-
-func (c *DatabaseCollection) IsClosed() bool {
-	return c.Bucket == nil
-}
-
-// exitChanges will close active _changes feeds on the DB. This is a database level close.
-func (c *DatabaseCollection) exitChanges() chan struct{} {
-	return c.dbCtx.ExitChanges
-}
-
-// Cache flush support.  Currently test-only - added for unit test access from rest package
-func (c *DatabaseCollection) FlushChannelCache(ctx context.Context) error {
-	base.InfofCtx(ctx, base.KeyCache, "Flushing channel cache")
-	return c.changeCache.Clear()
-}
-
+// useViews will return whether the bucket is configured using views.
 func (c *DatabaseCollection) useViews() bool {
 	return c.dbCtx.Options.UseViews
-}
-
-func (c *DatabaseCollection) slowQueryWarningThreshold() time.Duration {
-	return c.dbCtx.Options.SlowQueryWarningThreshold
-}
-
-func (c *DatabaseCollection) queryPaginationLimit() int {
-	return c.dbCtx.Options.QueryPaginationLimit
-}
-
-// allPrincipalIDs returns the IDs of all users and roles, including deleted Roles
-func (c *DatabaseCollection) allPrincipalIDs(ctx context.Context) (users, roles []string, err error) {
-	return c.dbCtx.AllPrincipalIDs(ctx)
 }

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -21,12 +21,14 @@ package db
 
 // Update database-specific stats that are more efficiently calculated at stats collection time
 func (db *DatabaseContext) UpdateCalculatedStats() {
-
+	return
+	/* FIXME
 	if db.changeCache != nil {
 		db.changeCache.updateStats()
 		channelCache := db.changeCache.getChannelCache()
 		db.DbStats.Cache().ChannelCacheMaxEntries.Set(int64(channelCache.MaxCacheSize()))
 		db.DbStats.Cache().HighSeqCached.Set(int64(channelCache.GetHighCacheSequence()))
 	}
+	*/
 
 }

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -21,14 +21,18 @@ package db
 
 // Update database-specific stats that are more efficiently calculated at stats collection time
 func (db *DatabaseContext) UpdateCalculatedStats() {
-	return
-	/* FIXME
-	if db.changeCache != nil {
-		db.changeCache.updateStats()
-		channelCache := db.changeCache.getChannelCache()
+	if !db.onlyDefaultCollection() {
+		return
+	}
+	defaultCollection, err := db.GetDefaultDatabaseCollection()
+	if err != nil {
+		return
+	}
+	if defaultCollection.changeCache != nil {
+		defaultCollection.changeCache.updateStats()
+		channelCache := defaultCollection.changeCache.getChannelCache()
 		db.DbStats.Cache().ChannelCacheMaxEntries.Set(int64(channelCache.MaxCacheSize()))
 		db.DbStats.Cache().HighSeqCached.Set(int64(channelCache.GetHighCacheSequence()))
 	}
-	*/
 
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -807,7 +807,7 @@ func TestAllDocsOnly(t *testing.T) {
 	collectionID := collection.GetCollectionID()
 
 	// Trigger creation of the channel cache for channel "all"
-	collection.ChangeCache().getChannelCache().getSingleChannelCache(channels.NewID("all", collectionID))
+	collection.changeCache.getChannelCache().getSingleChannelCache(channels.NewID("all", collectionID))
 
 	ids := make([]AllDocsEntry, 100)
 	for i := 0; i < 100; i++ {
@@ -848,7 +848,7 @@ func TestAllDocsOnly(t *testing.T) {
 
 	// Inspect the channel log to confirm that it's only got the last 50 sequences.
 	// There are 101 sequences overall, so the 1st one it has should be #52.
-	err = collection.ChangeCache().waitForSequence(ctx, 101, base.DefaultWaitForSequence)
+	err = collection.changeCache.waitForSequence(ctx, 101, base.DefaultWaitForSequence)
 	require.NoError(t, err)
 
 	changeLog := collection.GetChangeLog(channels.NewID("all", collectionID), 0)
@@ -987,7 +987,7 @@ func TestConflicts(t *testing.T) {
 	collectionID := collection.GetCollectionID()
 
 	allChannel := channels.NewID("all", collectionID)
-	collection.ChangeCache().getChannelCache().getSingleChannelCache(allChannel)
+	collection.changeCache.getChannelCache().getSingleChannelCache(allChannel)
 
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
 
@@ -1656,7 +1656,7 @@ func TestRecentSequenceHistory(t *testing.T) {
 	// Recent sequence pruning only prunes entries older than what's been seen over DCP
 	// (to ensure it's not pruning something that may still be coalesced).  Because of this, test waits
 	// for caching before attempting to trigger pruning.
-	err = collection.ChangeCache().waitForSequence(ctx, seqTracker, base.DefaultWaitForSequence)
+	err = collection.changeCache.waitForSequence(ctx, seqTracker, base.DefaultWaitForSequence)
 	require.NoError(t, err)
 
 	// Add another sequence to validate pruning when past max (20)
@@ -1682,7 +1682,7 @@ func TestRecentSequenceHistory(t *testing.T) {
 		seqTracker++
 	}
 
-	err = collection.ChangeCache().waitForSequence(ctx, seqTracker, base.DefaultWaitForSequence) //
+	err = collection.changeCache.waitForSequence(ctx, seqTracker, base.DefaultWaitForSequence) //
 	require.NoError(t, err)
 	revid, doc, err = collection.Put(ctx, "doc1", body)
 	body[BodyId] = doc.ID

--- a/db/dcp_sharded_upgrade_test.go
+++ b/db/dcp_sharded_upgrade_test.go
@@ -263,14 +263,14 @@ func TestShardedDCPUpgrade(t *testing.T) {
 	require.NoError(t, err)
 
 	// assert that the doc we created before starting this node gets imported once all the pindexes are reassigned
-	require.NoError(t, db.WaitForPendingChanges(ctx))
+	require.NoError(t, collection.WaitForPendingChanges(ctx))
 	doc, err := collection.GetDocument(ctx, testDoc1, DocUnmarshalAll)
 	require.NoError(t, err, "GetDocument 1")
 	require.NotNil(t, doc, "GetDocument 1")
 
 	// Write a doc to the test bucket to check that import still works
 	require.NoError(t, tb.SetRaw(testDoc2, 0, nil, []byte(`{}`)))
-	require.NoError(t, db.WaitForPendingChanges(ctx))
+	require.NoError(t, collection.WaitForPendingChanges(ctx))
 	doc, err = collection.GetDocument(ctx, testDoc2, DocUnmarshalAll)
 	require.NoError(t, err, "GetDocument 2")
 	require.NotNil(t, doc, "GetDocument 2")

--- a/db/functions/n1ql_function.go
+++ b/db/functions/n1ql_function.go
@@ -53,8 +53,8 @@ func (fn *n1qlInvocation) Iterate() (sgbucket.QueryResultIterator, error) {
 	fn.n1qlArgs["user"] = &userArg
 
 	// Run the N1QL query:
-	iter, err := fn.db.N1QLQueryWithStats(fn.ctx, db.QueryTypeUserFunctionPrefix+fn.name, fn.Code, fn.n1qlArgs,
-		base.RequestPlus, false)
+	iter, err := db.N1QLQueryWithStats(fn.ctx, fn.db.Bucket, db.QueryTypeUserFunctionPrefix+fn.name, fn.Code, fn.n1qlArgs,
+		base.RequestPlus, false, fn.db.DbStats, fn.db.Options.SlowQueryWarningThreshold)
 
 	if err != nil {
 		// Return a friendlier error:

--- a/db/query.go
+++ b/db/query.go
@@ -385,14 +385,14 @@ const (
 )
 
 // N1QlQueryWithStats is a wrapper for gocbBucket.Query that performs additional diagnostic processing (expvars, slow query logging)
-func (context *DatabaseContext) N1QLQueryWithStats(ctx context.Context, queryName string, statement string, params map[string]interface{}, consistency base.ConsistencyMode, adhoc bool) (results sgbucket.QueryResultIterator, err error) {
+func N1QLQueryWithStats(ctx context.Context, dataStore base.Bucket, queryName string, statement string, params map[string]interface{}, consistency base.ConsistencyMode, adhoc bool, dbStats *base.DbStats, slowQueryWarningThreshold time.Duration) (results sgbucket.QueryResultIterator, err error) {
 
 	startTime := time.Now()
-	if threshold := context.Options.SlowQueryWarningThreshold; threshold > 0 {
+	if threshold := slowQueryWarningThreshold; threshold > 0 {
 		defer base.SlowQueryLog(ctx, startTime, threshold, "N1QL Query(%q)", queryName)
 	}
 
-	n1QLStore, ok := base.AsN1QLStore(context.Bucket)
+	n1QLStore, ok := base.AsN1QLStore(dataStore)
 	if !ok {
 		return nil, errors.New("Cannot perform N1QL query on non-Couchbase bucket.")
 	}
@@ -400,7 +400,7 @@ func (context *DatabaseContext) N1QLQueryWithStats(ctx context.Context, queryNam
 	results, err = n1QLStore.Query(statement, params, consistency, adhoc)
 
 	if len(queryName) > 0 {
-		queryStat := context.DbStats.Query(queryName)
+		queryStat := dbStats.Query(queryName)
 		if queryStat == nil {
 			// This panic is more recognizable than the one that will otherwise occur below
 			panic(fmt.Sprintf("DbStats has no entry for query %q", queryName))
@@ -414,7 +414,7 @@ func (context *DatabaseContext) N1QLQueryWithStats(ctx context.Context, queryNam
 	return results, err
 }
 
-// N1QlQueryWithStats is a wrapper for gocbBucket.Query that performs additional diagnostic processing (expvars, slow query logging)
+// ViewQueryWithStats is a wrapper for gocbBucket.Query that performs additional diagnostic processing (expvars, slow query logging)
 func (context *DatabaseContext) ViewQueryWithStats(ctx context.Context, ddoc string, viewName string, params map[string]interface{}) (results sgbucket.QueryResultIterator, err error) {
 
 	startTime := time.Now()
@@ -452,7 +452,7 @@ func (context *DatabaseContext) QueryAccess(ctx context.Context, username string
 	params := make(map[string]interface{}, 0)
 	params[QueryParamUserName] = username
 
-	return context.N1QLQueryWithStats(ctx, QueryAccess.name, accessQueryStatement, params, base.RequestPlus, QueryAccess.adhoc)
+	return N1QLQueryWithStats(ctx, context.Bucket, QueryAccess.name, accessQueryStatement, params, base.RequestPlus, QueryAccess.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
 
 // Builds the query statement for an access N1QL query.
@@ -484,7 +484,7 @@ func (context *DatabaseContext) QueryRoleAccess(ctx context.Context, username st
 	accessQueryStatement := context.buildRoleAccessQuery(username)
 	params := make(map[string]interface{}, 0)
 	params[QueryParamUserName] = username
-	return context.N1QLQueryWithStats(ctx, QueryTypeRoleAccess, accessQueryStatement, params, base.RequestPlus, QueryRoleAccess.adhoc)
+	return N1QLQueryWithStats(ctx, context.Bucket, QueryTypeRoleAccess, accessQueryStatement, params, base.RequestPlus, QueryRoleAccess.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
 
 // Builds the query statement for a roleAccess N1QL query.
@@ -499,11 +499,11 @@ func (context *DatabaseContext) buildRoleAccessQuery(username string) string {
 }
 
 // Query to compute the set of documents assigned to the specified channel within the sequence range
-func (context *DatabaseContext) QueryChannels(ctx context.Context, channelName string, startSeq uint64, endSeq uint64, limit int, activeOnly bool) (sgbucket.QueryResultIterator, error) {
+func (context *DatabaseCollection) QueryChannels(ctx context.Context, channelName string, startSeq uint64, endSeq uint64, limit int, activeOnly bool) (sgbucket.QueryResultIterator, error) {
 
-	if context.Options.UseViews {
+	if context.useViews() {
 		opts := changesViewOptions(channelName, startSeq, endSeq, limit)
-		return context.ViewQueryWithStats(ctx, DesignDocSyncGateway(), ViewChannels, opts)
+		return context.dbCtx.ViewQueryWithStats(ctx, DesignDocSyncGateway(), ViewChannels, opts)
 	}
 
 	// N1QL Query
@@ -512,19 +512,19 @@ func (context *DatabaseContext) QueryChannels(ctx context.Context, channelName s
 	// QueryChannels result schema (removal handling isn't needed for the star channel).
 	channelQueryStatement, params := context.buildChannelsQuery(channelName, startSeq, endSeq, limit, activeOnly)
 
-	return context.N1QLQueryWithStats(ctx, QueryChannels.name, channelQueryStatement, params, base.RequestPlus, QueryChannels.adhoc)
+	return N1QLQueryWithStats(ctx, context.Bucket, QueryChannels.name, channelQueryStatement, params, base.RequestPlus, QueryChannels.adhoc, context.dbStats(), context.slowQueryWarningThreshold())
 }
 
 // Query to retrieve keys for the specified sequences.  View query uses star channel, N1QL query uses IndexAllDocs
-func (context *DatabaseContext) QuerySequences(ctx context.Context, sequences []uint64) (sgbucket.QueryResultIterator, error) {
+func (context *DatabaseCollection) QuerySequences(ctx context.Context, sequences []uint64) (sgbucket.QueryResultIterator, error) {
 
 	if len(sequences) == 0 {
 		return nil, errors.New("No sequences specified for QueryChannelsForSequences")
 	}
 
-	if context.Options.UseViews {
+	if context.useViews() {
 		opts := changesViewForSequencesOptions(sequences)
-		return context.ViewQueryWithStats(ctx, DesignDocSyncGateway(), ViewChannels, opts)
+		return context.dbCtx.ViewQueryWithStats(ctx, DesignDocSyncGateway(), ViewChannels, opts)
 	}
 
 	// N1QL Query
@@ -534,12 +534,12 @@ func (context *DatabaseContext) QuerySequences(ctx context.Context, sequences []
 	params := make(map[string]interface{})
 	params[QueryParamInSequences] = sequences
 
-	return context.N1QLQueryWithStats(ctx, QuerySequences.name, sequenceQueryStatement, params, base.RequestPlus, QueryChannels.adhoc)
+	return N1QLQueryWithStats(ctx, context.Bucket, QuerySequences.name, sequenceQueryStatement, params, base.RequestPlus, QueryChannels.adhoc, context.dbStats(), context.slowQueryWarningThreshold())
 }
 
-// Builds the query statement and query parameters for a channels N1QL query.  Also used by unit tests to validate
+// buildsChannelsQuery constructs the query statement and query parameters for a channels N1QL query.  Also used by unit tests to validate
 // query is covering.
-func (context *DatabaseContext) buildChannelsQuery(channelName string, startSeq uint64, endSeq uint64, limit int, activeOnly bool) (statement string, params map[string]interface{}) {
+func (context *DatabaseCollection) buildChannelsQuery(channelName string, startSeq uint64, endSeq uint64, limit int, activeOnly bool) (statement string, params map[string]interface{}) {
 
 	channelQuery := QueryChannels
 	index := sgIndexes[IndexChannels]
@@ -571,7 +571,7 @@ func (context *DatabaseContext) buildChannelsQuery(channelName string, startSeq 
 	return channelQueryStatement, params
 }
 
-func (context *DatabaseContext) QueryResync(ctx context.Context, limit int, startSeq, endSeq uint64) (sgbucket.QueryResultIterator, error) {
+func (context *DatabaseCollection) QueryResync(ctx context.Context, limit int, startSeq, endSeq uint64) (sgbucket.QueryResultIterator, error) {
 	return context.QueryChannels(ctx, channels.UserStarChannel, startSeq, endSeq, limit, false)
 }
 
@@ -603,7 +603,7 @@ func (context *DatabaseContext) QueryPrincipals(ctx context.Context, startKey st
 	}
 
 	// N1QL Query
-	return context.N1QLQueryWithStats(ctx, QueryPrincipals.name, queryStatement, params, base.RequestPlus, QueryPrincipals.adhoc)
+	return N1QLQueryWithStats(ctx, context.Bucket, QueryPrincipals.name, queryStatement, params, base.RequestPlus, QueryPrincipals.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
 
 // Query to retrieve user details, using the syncDocs or users index
@@ -617,7 +617,7 @@ func (context *DatabaseContext) QueryUsers(ctx context.Context, startKey string,
 	queryStatement, params := context.BuildUsersQuery(startKey, limit)
 
 	// N1QL Query
-	return context.N1QLQueryWithStats(ctx, QueryTypeUsers, queryStatement, params, base.RequestPlus, QueryUsers.adhoc)
+	return N1QLQueryWithStats(ctx, context.Bucket, QueryTypeUsers, queryStatement, params, base.RequestPlus, QueryUsers.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
 
 // BuildUsersQuery builds the query statement and query parameters for a Users N1QL query. Also used by unit tests to validate
@@ -660,7 +660,7 @@ func (context *DatabaseContext) QueryRoles(ctx context.Context, startKey string,
 	queryStatement, params := context.BuildRolesQuery(startKey, limit)
 
 	// N1QL Query
-	return context.N1QLQueryWithStats(ctx, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc)
+	return N1QLQueryWithStats(ctx, context.Bucket, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
 
 // BuildRolesQuery builds the query statement and query parameters for a Roles N1QL query. Also used by unit tests to validate
@@ -707,7 +707,7 @@ func (context *DatabaseContext) QueryAllRoles(ctx context.Context, startKey stri
 	}
 
 	// N1QL Query
-	return context.N1QLQueryWithStats(ctx, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc)
+	return N1QLQueryWithStats(ctx, context.Bucket, QueryRolesExcludeDeleted.name, queryStatement, params, base.RequestPlus, QueryRolesExcludeDeleted.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
 
 // Query to retrieve the set of sessions, using the syncDocs index
@@ -722,7 +722,7 @@ func (context *DatabaseContext) QuerySessions(ctx context.Context, userName stri
 	}
 
 	queryStatement, params := context.BuildSessionsQuery(userName)
-	return context.N1QLQueryWithStats(ctx, QueryTypeSessions, queryStatement, params, base.RequestPlus, QuerySessions.adhoc)
+	return N1QLQueryWithStats(ctx, context.Bucket, QueryTypeSessions, queryStatement, params, base.RequestPlus, QuerySessions.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
 
 // BuildSessionsQuery builds the query statement and query parameters for a Sessions N1QL query. Also used by unit tests to validate
@@ -757,10 +757,10 @@ type AllDocsIndexQueryRow struct {
 }
 
 // AllDocs returns all non-deleted documents in the bucket between startKey and endKey
-func (context *DatabaseContext) QueryAllDocs(ctx context.Context, startKey string, endKey string) (sgbucket.QueryResultIterator, error) {
+func (context *DatabaseCollection) QueryAllDocs(ctx context.Context, startKey string, endKey string) (sgbucket.QueryResultIterator, error) {
 
 	// View Query
-	if context.Options.UseViews {
+	if context.useViews() {
 		opts := Body{"stale": false, "reduce": false}
 		if startKey != "" {
 			opts[QueryParamStartKey] = startKey
@@ -768,7 +768,7 @@ func (context *DatabaseContext) QueryAllDocs(ctx context.Context, startKey strin
 		if endKey != "" {
 			opts[QueryParamEndKey] = endKey
 		}
-		return context.ViewQueryWithStats(ctx, DesignDocSyncHousekeeping(), ViewAllDocs, opts)
+		return context.dbCtx.ViewQueryWithStats(ctx, DesignDocSyncHousekeeping(), ViewAllDocs, opts)
 	}
 
 	// N1QL Query
@@ -790,7 +790,7 @@ func (context *DatabaseContext) QueryAllDocs(ctx context.Context, startKey strin
 	allDocsQueryStatement = fmt.Sprintf("%s ORDER BY META(%s).id",
 		allDocsQueryStatement, base.KeyspaceQueryAlias)
 
-	return context.N1QLQueryWithStats(ctx, QueryTypeAllDocs, allDocsQueryStatement, params, base.RequestPlus, QueryAllDocs.adhoc)
+	return N1QLQueryWithStats(ctx, context.Bucket, QueryTypeAllDocs, allDocsQueryStatement, params, base.RequestPlus, QueryAllDocs.adhoc, context.dbStats(), context.slowQueryWarningThreshold())
 }
 
 func (context *DatabaseContext) QueryTombstones(ctx context.Context, olderThan time.Time, limit int) (sgbucket.QueryResultIterator, error) {
@@ -819,7 +819,7 @@ func (context *DatabaseContext) QueryTombstones(ctx context.Context, olderThan t
 		QueryParamOlderThan: olderThan.Unix(),
 	}
 
-	return context.N1QLQueryWithStats(ctx, QueryTypeTombstones, tombstoneQueryStatement, params, base.RequestPlus, QueryTombstones.adhoc)
+	return N1QLQueryWithStats(ctx, context.Bucket, QueryTypeTombstones, tombstoneQueryStatement, params, base.RequestPlus, QueryTombstones.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
 }
 
 func changesViewOptions(channelName string, startSeq, endSeq uint64, limit int) map[string]interface{} {

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -55,7 +55,7 @@ func TestQueryChannelsStatsView(t *testing.T) {
 	channelQueryErrorCountBefore := db.DbStats.Query(queryExpvar).QueryErrorCount.Value()
 
 	// Issue channels query
-	results, queryErr := db.QueryChannels(base.TestCtx(t), "ABC", docSeqMap["queryTestDoc1"], docSeqMap["queryTestDoc3"], 100, false)
+	results, queryErr := collection.QueryChannels(base.TestCtx(t), "ABC", docSeqMap["queryTestDoc1"], docSeqMap["queryTestDoc3"], 100, false)
 	assert.NoError(t, queryErr, "Query error")
 
 	assert.Equal(t, 3, countQueryResults(results))
@@ -108,7 +108,7 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 	channelQueryErrorCountBefore := db.DbStats.Query(QueryTypeChannels).QueryErrorCount.Value()
 
 	// Issue channels query
-	results, queryErr := db.QueryChannels(base.TestCtx(t), "ABC", docSeqMap["queryTestDoc1"], docSeqMap["queryTestDoc3"], 100, false)
+	results, queryErr := collection.QueryChannels(base.TestCtx(t), "ABC", docSeqMap["queryTestDoc1"], docSeqMap["queryTestDoc3"], 100, false)
 	assert.NoError(t, queryErr, "Query error")
 
 	assert.Equal(t, 3, countQueryResults(results))
@@ -156,7 +156,7 @@ func TestQuerySequencesStatsView(t *testing.T) {
 	channelQueryErrorCountBefore := db.DbStats.Query(queryExpvar).QueryErrorCount.Value()
 
 	// Issue channels query
-	results, queryErr := db.QuerySequences(base.TestCtx(t), []uint64{
+	results, queryErr := collection.QuerySequences(base.TestCtx(t), []uint64{
 		docSeqMap["queryTestDoc3"], docSeqMap["queryTestDoc4"],
 		docSeqMap["queryTestDoc6"], docSeqMap["queryTestDoc8"],
 	})
@@ -166,21 +166,21 @@ func TestQuerySequencesStatsView(t *testing.T) {
 	assert.NoError(t, closeErr, "Close error")
 
 	// Issue query with single key
-	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{docSeqMap["queryTestDoc2"]})
+	results, queryErr = collection.QuerySequences(base.TestCtx(t), []uint64{docSeqMap["queryTestDoc2"]})
 	assert.NoError(t, queryErr, "Query error")
 	assert.Equal(t, 1, countQueryResults(results))
 	closeErr = results.Close()
 	assert.NoError(t, closeErr, "Close error")
 
 	// Issue query with key outside keyset range
-	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{100})
+	results, queryErr = collection.QuerySequences(base.TestCtx(t), []uint64{100})
 	assert.NoError(t, queryErr, "Query error")
 	assert.Equal(t, 0, countQueryResults(results))
 	closeErr = results.Close()
 	assert.NoError(t, closeErr, "Close error")
 
 	// Issue query with empty keys
-	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{})
+	results, queryErr = collection.QuerySequences(base.TestCtx(t), []uint64{})
 	assert.Error(t, queryErr, "Expect empty sequence error")
 
 	channelQueryCountAfter := db.DbStats.Query(queryExpvar).QueryCount.Value()
@@ -197,7 +197,7 @@ func TestQuerySequencesStatsView(t *testing.T) {
 		docSeqMap[docID] = doc.Sequence
 	}
 	// Issue channels query
-	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{
+	results, queryErr = collection.QuerySequences(base.TestCtx(t), []uint64{
 		docSeqMap["queryTestDoc3"], docSeqMap["queryTestDoc4"],
 		docSeqMap["queryTestDoc6"], docSeqMap["queryTestDoc8"],
 		docSeqMap["queryTestDocChanneled5"],
@@ -208,7 +208,7 @@ func TestQuerySequencesStatsView(t *testing.T) {
 	assert.NoError(t, closeErr, "Close error")
 
 	// Issue query with single key
-	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{docSeqMap["queryTestDoc2"]})
+	results, queryErr = collection.QuerySequences(base.TestCtx(t), []uint64{docSeqMap["queryTestDoc2"]})
 	assert.NoError(t, queryErr, "Query error")
 	assert.Equal(t, 1, countQueryResults(results))
 	closeErr = results.Close()
@@ -216,7 +216,7 @@ func TestQuerySequencesStatsView(t *testing.T) {
 
 	// Issue query with key outside sequence range.  Note that this isn't outside the entire view key range, as
 	// [*, 25] is sorted before ["ABC1", 11]
-	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{100})
+	results, queryErr = collection.QuerySequences(base.TestCtx(t), []uint64{100})
 	assert.NoError(t, queryErr, "Query error")
 	assert.Equal(t, 0, countQueryResults(results))
 	closeErr = results.Close()
@@ -250,7 +250,7 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 	channelQueryErrorCountBefore := db.DbStats.Query(QueryTypeSequences).QueryErrorCount.Value()
 
 	// Issue channels query
-	results, queryErr := db.QuerySequences(base.TestCtx(t), []uint64{
+	results, queryErr := collection.QuerySequences(base.TestCtx(t), []uint64{
 		docSeqMap["queryTestDoc3"], docSeqMap["queryTestDoc4"],
 		docSeqMap["queryTestDoc6"], docSeqMap["queryTestDoc8"],
 	})
@@ -260,21 +260,21 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 	assert.NoError(t, closeErr, "Close error")
 
 	// Issue query with single key
-	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{docSeqMap["queryTestDoc2"]})
+	results, queryErr = collection.QuerySequences(base.TestCtx(t), []uint64{docSeqMap["queryTestDoc2"]})
 	assert.NoError(t, queryErr, "Query error")
 	assert.Equal(t, 1, countQueryResults(results))
 	closeErr = results.Close()
 	assert.NoError(t, closeErr, "Close error")
 
 	// Issue query with key outside keyset range
-	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{100})
+	results, queryErr = collection.QuerySequences(base.TestCtx(t), []uint64{100})
 	assert.NoError(t, queryErr, "Query error")
 	assert.Equal(t, 0, countQueryResults(results))
 	closeErr = results.Close()
 	assert.NoError(t, closeErr, "Close error")
 
 	// Issue query with empty keys
-	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{})
+	results, queryErr = collection.QuerySequences(base.TestCtx(t), []uint64{})
 	assert.Error(t, queryErr, "Expect empty sequence error")
 
 	channelQueryCountAfter := db.DbStats.Query(QueryTypeSequences).QueryCount.Value()
@@ -292,7 +292,7 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 	}
 
 	// Issue channels query
-	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{
+	results, queryErr = collection.QuerySequences(base.TestCtx(t), []uint64{
 		docSeqMap["queryTestDoc3"], docSeqMap["queryTestDoc4"],
 		docSeqMap["queryTestDoc6"], docSeqMap["queryTestDoc8"],
 		docSeqMap["queryTestDocChanneled5"],
@@ -303,7 +303,7 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 	assert.NoError(t, closeErr, "Close error")
 
 	// Issue query with single key
-	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{docSeqMap["queryTestDoc2"]})
+	results, queryErr = collection.QuerySequences(base.TestCtx(t), []uint64{docSeqMap["queryTestDoc2"]})
 	assert.NoError(t, queryErr, "Query error")
 	assert.Equal(t, 1, countQueryResults(results))
 	closeErr = results.Close()
@@ -311,7 +311,7 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 
 	// Issue query with key outside sequence range.  Note that this isn't outside the entire view key range, as
 	// [*, 25] is sorted before ["ABC1", 11]
-	results, queryErr = db.QuerySequences(base.TestCtx(t), []uint64{100})
+	results, queryErr = collection.QuerySequences(base.TestCtx(t), []uint64{100})
 	assert.NoError(t, queryErr, "Query error")
 	assert.Equal(t, 0, countQueryResults(results))
 	closeErr = results.Close()
@@ -332,8 +332,9 @@ func TestCoveringQueries(t *testing.T) {
 		t.Errorf("Unable to get n1QLStore for testBucket")
 	}
 
+	collection := db.GetSingleDatabaseCollection()
 	// channels
-	channelsStatement, params := db.buildChannelsQuery("ABC", 0, 10, 100, false)
+	channelsStatement, params := collection.buildChannelsQuery("ABC", 0, 10, 100, false)
 	plan, explainErr := n1QLStore.ExplainQuery(channelsStatement, params)
 	assert.NoError(t, explainErr, "Error generating explain for channels query")
 	covered := IsCovered(plan)
@@ -342,7 +343,7 @@ func TestCoveringQueries(t *testing.T) {
 	assert.True(t, covered, "Channel query isn't covered by index: %s", planJSON)
 
 	// star channel
-	channelStarStatement, params := db.buildChannelsQuery("*", 0, 10, 100, false)
+	channelStarStatement, params := collection.buildChannelsQuery("*", 0, 10, 100, false)
 	plan, explainErr = n1QLStore.ExplainQuery(channelStarStatement, params)
 	assert.NoError(t, explainErr, "Error generating explain for star channel query")
 	covered = IsCovered(plan)
@@ -391,7 +392,7 @@ func TestAllDocsQuery(t *testing.T) {
 	// Standard query
 	startKey := "a"
 	endKey := ""
-	results, queryErr := db.QueryAllDocs(base.TestCtx(t), startKey, endKey)
+	results, queryErr := collection.QueryAllDocs(base.TestCtx(t), startKey, endKey)
 	assert.NoError(t, queryErr, "Query error")
 	var row map[string]interface{}
 	rowCount := 0
@@ -404,7 +405,7 @@ func TestAllDocsQuery(t *testing.T) {
 	// Attempt to invalidate standard query
 	startKey = "a' AND 1=0\x00"
 	endKey = ""
-	results, queryErr = db.QueryAllDocs(base.TestCtx(t), startKey, endKey)
+	results, queryErr = collection.QueryAllDocs(base.TestCtx(t), startKey, endKey)
 	assert.NoError(t, queryErr, "Query error")
 	rowCount = 0
 	for results.Next(&row) {
@@ -416,7 +417,7 @@ func TestAllDocsQuery(t *testing.T) {
 	// Attempt to invalidate statement to add row to resultset
 	startKey = `a' UNION ALL SELECT TOSTRING(BASE64_DECODE("SW52YWxpZERhdGE=")) as id;` + "\x00"
 	endKey = ""
-	results, queryErr = db.QueryAllDocs(base.TestCtx(t), startKey, endKey)
+	results, queryErr = collection.QueryAllDocs(base.TestCtx(t), startKey, endKey)
 	assert.NoError(t, queryErr, "Query error")
 	rowCount = 0
 	for results.Next(&row) {
@@ -429,7 +430,7 @@ func TestAllDocsQuery(t *testing.T) {
 	// Attempt to create syntax error
 	startKey = `a'1`
 	endKey = ""
-	results, queryErr = db.QueryAllDocs(base.TestCtx(t), startKey, endKey)
+	results, queryErr = collection.QueryAllDocs(base.TestCtx(t), startKey, endKey)
 	assert.NoError(t, queryErr, "Query error")
 	rowCount = 0
 	for results.Next(&row) {
@@ -677,49 +678,51 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	// 20 Deleted documents (10 deleted + 10 branched|deleted)
 
 	// Get changes from channel "ABC" with limit and activeOnly true
-	entries, err := db.getChangesInChannelFromQuery(base.TestCtx(t), "ABC", startSeq, endSeq, 25, true)
+
+	collectionID := collection.GetCollectionID()
+	entries, err := db.getChangesInChannelFromQuery(base.TestCtx(t), channels.ID{Name: "ABC", CollectionID: collectionID}, startSeq, endSeq, 25, true)
 	require.NoError(t, err, "Couldn't query active docs from channel ABC with limit")
 	require.Len(t, entries, 25)
 	checkFlags(entries)
 
 	// Get changes from channel "*" with limit and activeOnly true
-	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), "*", startSeq, endSeq, 25, true)
+	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), channels.ID{Name: "*", CollectionID: collectionID}, startSeq, endSeq, 25, true)
 	require.NoError(t, err, "Couldn't query active docs from channel * with limit")
 	require.Len(t, entries, 25)
 	checkFlags(entries)
 
 	// Get changes from channel "ABC" without limit and activeOnly true
-	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), "ABC", startSeq, endSeq, 0, true)
+	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), channels.ID{Name: "ABC", CollectionID: collectionID}, startSeq, endSeq, 0, true)
 	require.NoError(t, err, "Couldn't query active docs from channel ABC with limit")
 	require.Len(t, entries, 30)
 	checkFlags(entries)
 
 	// Get changes from channel "*" without limit and activeOnly true
-	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), "*", startSeq, endSeq, 0, true)
+	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), channels.ID{Name: "*", CollectionID: collectionID}, startSeq, endSeq, 0, true)
 	require.NoError(t, err, "Couldn't query active docs from channel * with limit")
 	require.Len(t, entries, 30)
 	checkFlags(entries)
 
 	// Get changes from channel "ABC" with limit and activeOnly false
-	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), "ABC", startSeq, endSeq, 45, false)
+	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), channels.ID{Name: "ABC", CollectionID: collectionID}, startSeq, endSeq, 45, false)
 	require.NoError(t, err, "Couldn't query active docs from channel ABC with limit")
 	require.Len(t, entries, 45)
 	checkFlags(entries)
 
 	// Get changes from channel "*" with limit and activeOnly false
-	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), "*", startSeq, endSeq, 45, false)
+	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), channels.ID{Name: "*", CollectionID: collectionID}, startSeq, endSeq, 45, false)
 	require.NoError(t, err, "Couldn't query active docs from channel * with limit")
 	require.Len(t, entries, 45)
 	checkFlags(entries)
 
 	// Get changes from channel "ABC" without limit and activeOnly false
-	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), "ABC", startSeq, endSeq, 0, false)
+	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), channels.ID{Name: "ABC", CollectionID: collectionID}, startSeq, endSeq, 0, false)
 	require.NoError(t, err, "Couldn't query active docs from channel ABC with limit")
 	require.Len(t, entries, 50)
 	checkFlags(entries)
 
 	// Get changes from channel "*" without limit and activeOnly true
-	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), "*", startSeq, endSeq, 0, false)
+	entries, err = db.getChangesInChannelFromQuery(base.TestCtx(t), channels.ID{Name: "*", CollectionID: collectionID}, startSeq, endSeq, 0, false)
 	require.NoError(t, err, "Couldn't query active docs from channel * with limit")
 	require.Len(t, entries, 50)
 	checkFlags(entries)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -79,7 +79,7 @@ func isIndexEmpty(store base.N1QLStore, useXattrs bool) (bool, error) {
 
 func (db *DatabaseContext) CacheCompactActive() bool {
 	for _, collection := range db.CollectionByID {
-		channelCache := collection.ChangeCache().getChannelCache()
+		channelCache := collection.changeCache.getChannelCache()
 		compactingCache, ok := channelCache.(*channelCacheImpl)
 		if !ok {
 			return false

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1499,7 +1499,7 @@ func (h *handler) handlePurge() error {
 	}
 
 	if len(docIDs) > 0 {
-		count := h.db.GetChangeCache().Remove(docIDs, startTime)
+		count := collection.ChangeCache().Remove(docIDs, startTime)
 		base.DebugfCtx(h.ctx(), base.KeyCache, "Purged %d items from caches", count)
 	}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1499,7 +1499,7 @@ func (h *handler) handlePurge() error {
 	}
 
 	if len(docIDs) > 0 {
-		count := collection.ChangeCache().Remove(docIDs, startTime)
+		count := collection.RemoveFromChangeCache(docIDs, startTime)
 		base.DebugfCtx(h.ctx(), base.KeyCache, "Purged %d items from caches", count)
 	}
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1750,10 +1750,12 @@ func TestChannelAccessChanges(t *testing.T) {
 	dbc := rt.ServerContext().Database(ctx, "db")
 	database, _ := db.GetDatabase(dbc, nil)
 
+	collection := database.GetSingleDatabaseCollectionWithUser()
+
 	changed, err := database.UpdateSyncFun(ctx, `function(doc) {access("alice", "beta");channel("beta");}`)
 	assert.NoError(t, err)
 	assert.True(t, changed)
-	changeCount, err := database.UpdateAllDocChannels(ctx, false, func(docsProcessed, docsChanged *int) {}, base.NewSafeTerminator())
+	changeCount, err := collection.UpdateAllDocChannels(ctx, false, func(docsProcessed, docsChanged *int) {}, base.NewSafeTerminator())
 	assert.NoError(t, err)
 	assert.Equal(t, 9, changeCount)
 

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1713,7 +1713,7 @@ func TestGetRemovedDoc(t *testing.T) {
 	assert.NoError(t, err)                         // no error
 	assert.Empty(t, resp.Properties["Error-Code"]) // no error
 
-	require.NoError(t, rt.GetDatabase().WaitForPendingChanges(base.TestCtx(t)))
+	require.NoError(t, rt.GetDatabase().GetSingleDatabaseCollection().WaitForPendingChanges(base.TestCtx(t)))
 
 	// Try to get rev 2 via BLIP API and assert that _removed == false
 	resultDoc, err := bt.GetDocAtRev("foo", "2-bcd")
@@ -1734,7 +1734,7 @@ func TestGetRemovedDoc(t *testing.T) {
 	assert.NoError(t, err)                         // no error
 	assert.Empty(t, resp.Properties["Error-Code"]) // no error
 
-	require.NoError(t, rt.GetDatabase().WaitForPendingChanges(base.TestCtx(t)))
+	require.NoError(t, rt.GetDatabase().GetSingleDatabaseCollection().WaitForPendingChanges(base.TestCtx(t)))
 
 	// Flush rev cache in case this prevents the bug from showing up (didn't make a difference)
 	rt.GetDatabase().GetSingleDatabaseCollection().FlushRevisionCacheForTest()

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -217,7 +217,7 @@ func (h *handler) handleAllDocs() error {
 
 		}
 	} else {
-		if err := h.db.ForEachDocID(h.ctx(), writeDoc, options); err != nil {
+		if err := h.db.GetSingleDatabaseCollection().ForEachDocID(h.ctx(), writeDoc, options); err != nil {
 			return err
 		}
 	}
@@ -310,7 +310,7 @@ func (h *handler) handleDumpChannel() error {
 
 	collection := h.db.GetSingleDatabaseCollection()
 	collectionID := collection.GetCollectionID()
-	chanLog := h.db.GetChangeLog(ch.NewID(channelName, collectionID), since)
+	chanLog := collection.GetChangeLog(ch.NewID(channelName, collectionID), since)
 	if chanLog == nil {
 		return base.HTTPErrorf(http.StatusNotFound, "no such channel")
 	}

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -342,9 +342,9 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 	var feed <-chan *db.ChangeEntry
 	var err error
 	if len(docids) > 0 {
-		feed, err = h.db.DocIDChangesFeed(h.ctx(), channels, docids, options)
+		feed, err = h.db.GetSingleDatabaseCollectionWithUser().DocIDChangesFeed(h.ctx(), channels, docids, options)
 	} else {
-		feed, err = h.db.MultiChangesFeed(h.ctx(), channels, options)
+		feed, err = h.db.GetSingleDatabaseCollectionWithUser().MultiChangesFeed(h.ctx(), channels, options)
 	}
 	if err != nil {
 		return err, false
@@ -444,7 +444,7 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 func (h *handler) generateContinuousChanges(inChannels base.Set, options db.ChangesOptions, send func([]*db.ChangeEntry) error) (error, bool) {
 	// Ensure continuous is set, since generateChanges now supports both continuous and one-shot
 	options.Continuous = true
-	err, forceClose := db.GenerateChanges(h.ctx(), h.rq.Context(), h.db, inChannels, options, nil, send)
+	err, forceClose := db.GenerateChanges(h.ctx(), h.rq.Context(), h.db.GetSingleDatabaseCollectionWithUser(), inChannels, options, nil, send)
 	if sendErr, ok := err.(*db.ChangesSendErr); ok {
 		h.logStatus(http.StatusOK, fmt.Sprintf("0Write error: %v", sendErr))
 		return nil, forceClose // error is probably because the client closed the connection

--- a/rest/changesttest/changes_api_test.go
+++ b/rest/changesttest/changes_api_test.go
@@ -60,7 +60,7 @@ func TestReproduce2383(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 
 	cacheWaiter.Wait()
-	assert.NoError(t, testDb.FlushChannelCache(ctx))
+	assert.NoError(t, testDb.GetSingleDatabaseCollection().FlushChannelCache(ctx))
 
 	var changes struct {
 		Results  []db.ChangeEntry
@@ -991,7 +991,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 2)
 	WriteDirect(testDb, []string{"PBS"}, 5)
 	WriteDirect(testDb, []string{"PBS"}, 6)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 6))
+	require.NoError(t, testDb.GetSingleDatabaseCollection().WaitForSequenceNotSkipped(ctx, 6))
 
 	// Check the _changes feed:
 	var changes struct {
@@ -1030,7 +1030,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 
 	// Send a later doc - low sequence still 3, high sequence goes to 7
 	WriteDirect(testDb, []string{"PBS"}, 7)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 7))
+	require.NoError(t, testDb.GetSingleDatabaseCollection().WaitForSequenceNotSkipped(ctx, 7))
 
 	// Send another changes request with the same since ("2::6") to ensure we see data once there are changes
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1084,7 +1084,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 3)
 	WriteDirect(testDb, []string{"PBS"}, 4)
 	WriteDirect(testDb, []string{"PBS"}, 5)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 5))
+	require.NoError(t, testDb.GetSingleDatabaseCollection().WaitForSequenceNotSkipped(ctx, 5))
 
 	// Check the _changes feed:
 	var changes struct {
@@ -1104,7 +1104,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 8)
 	WriteDirect(testDb, []string{"PBS"}, 9)
 	WriteDirect(testDb, []string{"PBS"}, 10)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 10))
+	require.NoError(t, testDb.GetSingleDatabaseCollection().WaitForSequenceNotSkipped(ctx, 10))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1118,7 +1118,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	// Write a few more docs
 	WriteDirect(testDb, []string{"PBS"}, 11)
 	WriteDirect(testDb, []string{"PBS"}, 12)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 12))
+	require.NoError(t, testDb.GetSingleDatabaseCollection().WaitForSequenceNotSkipped(ctx, 12))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1215,7 +1215,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 3)
 	WriteDirect(testDb, []string{"PBS"}, 4)
 	WriteDirect(testDb, []string{"PBS"}, 5)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 5))
+	require.NoError(t, testDb.GetSingleDatabaseCollection().WaitForSequenceNotSkipped(ctx, 5))
 
 	// Check the _changes feed:
 	var changes struct {
@@ -1235,7 +1235,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 8)
 	WriteDirect(testDb, []string{"PBS"}, 9)
 	WriteDirect(testDb, []string{"PBS"}, 10)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 10))
+	require.NoError(t, testDb.GetSingleDatabaseCollection().WaitForSequenceNotSkipped(ctx, 10))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1249,7 +1249,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	// Write a few more docs
 	WriteDirect(testDb, []string{"PBS"}, 11)
 	WriteDirect(testDb, []string{"PBS"}, 12)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 12))
+	require.NoError(t, testDb.GetSingleDatabaseCollection().WaitForSequenceNotSkipped(ctx, 12))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1351,7 +1351,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 3)
 	WriteDirect(testDb, []string{"PBS"}, 4)
 	WriteDirect(testDb, []string{"PBS"}, 5)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 5))
+	require.NoError(t, testDb.GetSingleDatabaseCollection().WaitForSequenceNotSkipped(ctx, 5))
 
 	// Check the _changes feed:
 	var changes struct {
@@ -1371,7 +1371,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 8)
 	WriteDirect(testDb, []string{"PBS"}, 9)
 	WriteDirect(testDb, []string{"PBS"}, 10)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 10))
+	require.NoError(t, testDb.GetSingleDatabaseCollection().WaitForSequenceNotSkipped(ctx, 10))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1385,7 +1385,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	// Write a few more docs
 	WriteDirect(testDb, []string{"PBS"}, 11)
 	WriteDirect(testDb, []string{"PBS"}, 12)
-	require.NoError(t, testDb.WaitForSequenceNotSkipped(ctx, 12))
+	require.NoError(t, testDb.GetSingleDatabaseCollection().WaitForSequenceNotSkipped(ctx, 12))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -2188,7 +2188,7 @@ func TestChangesViewBackfillFromQueryOnly(t *testing.T) {
 	cacheWaiter.Wait()
 
 	// Flush the channel cache
-	assert.NoError(t, testDb.FlushChannelCache(ctx))
+	assert.NoError(t, testDb.GetSingleDatabaseCollection().FlushChannelCache(ctx))
 
 	var changes struct {
 		Results  []db.ChangeEntry
@@ -2261,7 +2261,7 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 	cacheWaiter.Wait()
 
 	// Flush the channel cache
-	assert.NoError(t, testDb.FlushChannelCache(ctx))
+	assert.NoError(t, testDb.GetSingleDatabaseCollection().FlushChannelCache(ctx))
 
 	// Issue a since=0 changes request, with limit less than the number of PBS documents
 	var changes struct {
@@ -2362,7 +2362,7 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 	cacheWaiter.Wait()
 
 	// Flush the channel cache
-	assert.NoError(t, testDb.FlushChannelCache(ctx))
+	assert.NoError(t, testDb.GetSingleDatabaseCollection().FlushChannelCache(ctx))
 
 	// Issue a since=n changes request, where n > 0 and is a non-PBS sequence.  Validate that there's a view-based backfill
 	var changes struct {
@@ -2447,7 +2447,7 @@ func TestChangesViewBackfillNoOverlap(t *testing.T) {
 	cacheWaiter.Wait()
 
 	// Flush the channel cache
-	assert.NoError(t, testDb.FlushChannelCache(ctx))
+	assert.NoError(t, testDb.GetSingleDatabaseCollection().FlushChannelCache(ctx))
 
 	// Write some more docs to the bucket, with a gap before the first PBS sequence
 	response := rt.SendAdminRequest("PUT", "/db/abc11", `{"channels":["ABC"]}`)
@@ -2528,7 +2528,7 @@ func TestChangesViewBackfill(t *testing.T) {
 	cacheWaiter.AddAndWait(3)
 
 	// Flush the channel cache
-	assert.NoError(t, testDb.FlushChannelCache(ctx))
+	assert.NoError(t, testDb.GetSingleDatabaseCollection().FlushChannelCache(ctx))
 
 	// Add a few more docs (to increment the channel cache's validFrom)
 	response = rt.SendAdminRequest("PUT", "/db/doc4", `{"channels":["PBS"]}`)
@@ -2600,7 +2600,7 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 	cacheWaiter.Wait()
 
 	// Flush the channel cache
-	assert.NoError(t, testDb.FlushChannelCache(ctx))
+	assert.NoError(t, testDb.GetSingleDatabaseCollection().FlushChannelCache(ctx))
 
 	// Add a few more docs (to increment the channel cache's validFrom)
 	response = rt.SendAdminRequest("PUT", "/db/doc2", `{"channels":["PBS"]}`)
@@ -2788,7 +2788,7 @@ func TestChangesQueryBackfillWithLimit(t *testing.T) {
 			cacheWaiter.AddAndWait(test.totalDocuments * 2)
 
 			// Flush the channel cache
-			assert.NoError(t, testDb.FlushChannelCache(ctx))
+			assert.NoError(t, testDb.GetSingleDatabaseCollection().FlushChannelCache(ctx))
 			startQueryCount := testDb.GetChannelQueryCount()
 
 			// Issue a since=0 changes request.
@@ -2852,7 +2852,7 @@ func TestMultichannelChangesQueryBackfillWithLimit(t *testing.T) {
 	cacheWaiter.AddAndWait(50)
 
 	// Flush the channel cache
-	assert.NoError(t, testDb.FlushChannelCache(ctx))
+	assert.NoError(t, testDb.GetSingleDatabaseCollection().FlushChannelCache(ctx))
 
 	// 1. Issue a since=0 changes request, validate results
 	var changes struct {
@@ -2872,7 +2872,7 @@ func TestMultichannelChangesQueryBackfillWithLimit(t *testing.T) {
 	}
 
 	// 2. Same again, but with limit on the changes request
-	assert.NoError(t, testDb.FlushChannelCache(ctx))
+	assert.NoError(t, testDb.GetSingleDatabaseCollection().FlushChannelCache(ctx))
 	changes.Results = nil
 	changesJSON = fmt.Sprintf(`{"since":0, "limit":25}`)
 	changes.Results = nil
@@ -2919,7 +2919,7 @@ func TestChangesQueryStarChannelBackfillLimit(t *testing.T) {
 	cacheWaiter.AddAndWait(10)
 
 	// Flush the channel cache
-	assert.NoError(t, testDb.FlushChannelCache(ctx))
+	assert.NoError(t, testDb.GetSingleDatabaseCollection().FlushChannelCache(ctx))
 	startQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 
 	// Issue a since=0 changes request.  Validate that there's a view-based backfill
@@ -2973,7 +2973,7 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 	cacheWaiter.Wait()
 
 	// Flush the channel cache
-	assert.NoError(t, testDb.FlushChannelCache(ctx))
+	assert.NoError(t, testDb.GetSingleDatabaseCollection().FlushChannelCache(ctx))
 
 	// Write another doc, to initialize the cache (and guarantee overlap)
 	response = rt.SendAdminRequest("PUT", "/db/doc2", `{"channels":["PBS"]}`)
@@ -3336,7 +3336,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 
 	// Active only NO Limit, POST
 	testDb := rt.ServerContext().Database(ctx, "db")
-	assert.NoError(t, testDb.FlushChannelCache(ctx))
+	assert.NoError(t, testDb.GetSingleDatabaseCollection().FlushChannelCache(ctx))
 
 	changesJSON = `{"style":"all_docs", "active_only":true}`
 	changes.Results = nil
@@ -3353,7 +3353,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	}
 
 	// Active only with Limit, POST
-	assert.NoError(t, testDb.FlushChannelCache(ctx))
+	assert.NoError(t, testDb.GetSingleDatabaseCollection().FlushChannelCache(ctx))
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":5}`
 	changes.Results = nil
 	changesResponse = rt.Send(rest.RequestByUser("POST", "/db/_changes", changesJSON, "bernard"))
@@ -3369,7 +3369,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	}
 
 	// Active only with Limit, GET
-	assert.NoError(t, testDb.FlushChannelCache(ctx))
+	assert.NoError(t, testDb.GetSingleDatabaseCollection().FlushChannelCache(ctx))
 	changes.Results = nil
 	changesResponse = rt.Send(rest.RequestByUser("GET", "/db/_changes?style=all_docs&active_only=true&limit=5", "", "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
@@ -3383,7 +3383,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	}
 
 	// Active only with Limit set higher than number of revisions, POST
-	assert.NoError(t, testDb.FlushChannelCache(ctx))
+	assert.NoError(t, testDb.GetSingleDatabaseCollection().FlushChannelCache(ctx))
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":15}`
 	changes.Results = nil
 	changesResponse = rt.Send(rest.RequestByUser("POST", "/db/_changes", changesJSON, "bernard"))
@@ -3399,7 +3399,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	}
 
 	// No limit active only, GET, followed by normal (https://github.com/couchbase/sync_gateway/issues/2955)
-	assert.NoError(t, testDb.FlushChannelCache(ctx))
+	assert.NoError(t, testDb.GetSingleDatabaseCollection().FlushChannelCache(ctx))
 	changes.Results = nil
 	changesResponse = rt.Send(rest.RequestByUser("GET", "/db/_changes?style=all_docs&active_only=true", "", "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -484,7 +484,8 @@ func (h *handler) handlePutDoc() error {
 	}
 
 	if doc != nil && roundTrip {
-		if err := h.db.WaitForSequenceNotSkipped(h.ctx(), doc.Sequence); err != nil {
+		collection := h.db.GetSingleDatabaseCollection()
+		if err := collection.WaitForSequenceNotSkipped(h.ctx(), doc.Sequence); err != nil {
 			return err
 		}
 	}
@@ -562,7 +563,7 @@ func (h *handler) handlePutDocReplicator2(docid string, roundTrip bool) (err err
 	}
 
 	if doc != nil && roundTrip {
-		if err := h.db.WaitForSequenceNotSkipped(h.ctx(), doc.Sequence); err != nil {
+		if err := collection.WaitForSequenceNotSkipped(h.ctx(), doc.Sequence); err != nil {
 			return err
 		}
 	}
@@ -590,7 +591,7 @@ func (h *handler) handlePostDoc() error {
 	}
 
 	if doc != nil && roundTrip {
-		err := h.db.WaitForSequenceNotSkipped(h.ctx(), doc.Sequence)
+		err := collection.WaitForSequenceNotSkipped(h.ctx(), doc.Sequence)
 		if err != nil {
 			return err
 		}

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -4616,7 +4616,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	err = rt2db.GetSingleDatabaseCollectionWithUser().Purge(ctx2, docID+"2")
 	assert.NoError(t, err)
 
-	require.NoError(t, rt2.GetDatabase().FlushChannelCache(ctx2))
+	require.NoError(t, rt2.GetDatabase().GetSingleDatabaseCollection().FlushChannelCache(ctx2))
 	rt2.GetDatabase().GetSingleDatabaseCollection().FlushRevisionCacheForTest()
 
 	assert.NoError(t, ar.Start(ctx1))

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -417,7 +417,7 @@ func (rt *RestTester) WaitForSequence(seq uint64) error {
 	if database == nil {
 		return fmt.Errorf("No database found")
 	}
-	return database.WaitForSequence(base.TestCtx(rt.TB), seq)
+	return database.GetSingleDatabaseCollection().WaitForSequence(base.TestCtx(rt.TB), seq)
 }
 
 func (rt *RestTester) WaitForPendingChanges() error {
@@ -425,7 +425,7 @@ func (rt *RestTester) WaitForPendingChanges() error {
 	if database == nil {
 		return fmt.Errorf("No database found")
 	}
-	return database.WaitForPendingChanges(base.TestCtx(rt.TB))
+	return database.GetSingleDatabaseCollection().WaitForPendingChanges(base.TestCtx(rt.TB))
 }
 
 func (rt *RestTester) SetAdminParty(partyTime bool) error {


### PR DESCRIPTION
Starting with `SimpleMultiChangesFeed`, moved all callers to `DatabaseCollection`.

- Changed `N1QLQueryWithStats` to be a free function so it can work on `DatabaseCollection` and Database for principal objects.

Future work didn't push this into this PR because it's already quite long:

-  `ChangeEntry` doesn't have to track collectionID, and then probably be able to remove `TimedSetByCollectionID`. This might depend on principal changes.
-  Force blip to require collection property (this breaks both ISGR tests and blip unit tests).

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1103/
- [x] `GSI=false,xattrs=true`https://jenkins.sgwdev.com/job/SyncGateway-Integration/1104/
