### PR TITLE
CBG-2548 use collection in rest handler

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2698,7 +2698,7 @@ func TestGetDatabaseCollectionWithUserDefaultCollection(t *testing.T) {
 			collection: base.DefaultCollection,
 			err:        false,
 		},
-		/* This test passes under walrus/views but not GSI, needs to be fixed when making walrus collection aware.
+		/* CBG-2568 This test passes under walrus/views but not GSI, needs to be fixed when making walrus collection aware.
 		{
 			name:       "_default._default-not-in-config",
 			scope:      base.DefaultScope,

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -952,8 +952,7 @@ func (h *handler) handleGetRawDoc() error {
 		includeDoc = false
 	}
 
-	collection := h.db.GetSingleDatabaseCollectionWithUser()
-	doc, err := collection.GetDocument(h.ctx(), docid, db.DocUnmarshalSync)
+	doc, err := h.collection.GetDocument(h.ctx(), docid, db.DocUnmarshalSync)
 	if err != nil {
 		return err
 	}
@@ -1004,8 +1003,7 @@ func (h *handler) handleGetRawDoc() error {
 func (h *handler) handleGetRevTree() error {
 	h.assertAdminOnly()
 	docid := h.PathVar("docid")
-	collection := h.db.GetSingleDatabaseCollectionWithUser()
-	doc, err := collection.GetDocument(h.ctx(), docid, db.DocUnmarshalAll)
+	doc, err := h.collection.GetDocument(h.ctx(), docid, db.DocUnmarshalAll)
 
 	if doc != nil {
 		h.writeText([]byte(doc.History.RenderGraphvizDot()))
@@ -1453,7 +1451,6 @@ func (h *handler) handlePurge() error {
 	h.setHeader("Cache-Control", "private, max-age=0, no-cache, no-store")
 	_, _ = h.response.Write([]byte("{\"purged\":{\r\n"))
 	var first bool = true
-	collection := h.db.GetSingleDatabaseCollectionWithUser()
 
 	for key, value := range input {
 		// For each one validate that the revision list is set to ["*"], otherwise skip doc and log warning
@@ -1473,7 +1470,7 @@ func (h *handler) handlePurge() error {
 			}
 
 			// Attempt to delete document, if successful add to response, otherwise log warning
-			err = collection.Purge(h.ctx(), key)
+			err = h.collection.Purge(h.ctx(), key)
 			if err == nil {
 
 				docIDs = append(docIDs, key)
@@ -1499,7 +1496,7 @@ func (h *handler) handlePurge() error {
 	}
 
 	if len(docIDs) > 0 {
-		count := collection.RemoveFromChangeCache(docIDs, startTime)
+		count := h.collection.RemoveFromChangeCache(docIDs, startTime)
 		base.DebugfCtx(h.ctx(), base.KeyCache, "Purged %d items from caches", count)
 	}
 

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -46,9 +46,8 @@ func (h *handler) handleRevsDiff() error {
 
 	_, _ = h.response.Write([]byte("{"))
 	first := true
-	collection := h.db.GetSingleDatabaseCollectionWithUser()
 	for docid, revs := range input {
-		missing, possible := collection.RevDiff(h.ctx(), docid, revs)
+		missing, possible := h.collection.RevDiff(h.ctx(), docid, revs)
 		if missing != nil {
 			docOutput := map[string]interface{}{"missing": missing}
 			if possible != nil {

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -65,23 +65,22 @@ func (h *handler) handleGetDoc() error {
 		}
 	}
 
-	collection := h.db.GetSingleDatabaseCollectionWithUser()
 	if openRevs == "" {
 		// Single-revision GET:
-		value, err := collection.Get1xRevBodyWithHistory(h.ctx(), docid, revid, revsLimit, revsFrom, attachmentsSince, showExp)
+		value, err := h.collection.Get1xRevBodyWithHistory(h.ctx(), docid, revid, revsLimit, revsFrom, attachmentsSince, showExp)
 		if err != nil {
 			if err == base.ErrImportCancelledPurged {
 				base.DebugfCtx(h.ctx(), base.KeyImport, fmt.Sprintf("Import cancelled as document %v is purged", base.UD(docid)))
 				return nil
 			}
-			if collection.ForceAPIForbiddenErrors() && base.IsDocNotFoundError(err) {
+			if h.collection.ForceAPIForbiddenErrors() && base.IsDocNotFoundError(err) {
 				base.InfofCtx(h.ctx(), base.KeyCRUD, "Doc %q not found: %v", base.UD(docid), err)
 				return db.ErrForbidden
 			}
 			return err
 		}
 		if value == nil {
-			if collection.ForceAPIForbiddenErrors() {
+			if h.collection.ForceAPIForbiddenErrors() {
 				base.InfofCtx(h.ctx(), base.KeyCRUD, "Doc %q missing", base.UD(docid))
 				return db.ErrForbidden
 			}
@@ -106,7 +105,7 @@ func (h *handler) handleGetDoc() error {
 
 		if openRevs == "all" {
 			// open_revs=all
-			doc, err := collection.GetDocument(h.ctx(), docid, db.DocUnmarshalSync)
+			doc, err := h.collection.GetDocument(h.ctx(), docid, db.DocUnmarshalSync)
 			if err != nil {
 				return err
 			}
@@ -125,7 +124,7 @@ func (h *handler) handleGetDoc() error {
 		if h.requestAccepts("multipart/") {
 			err := h.writeMultipart("mixed", func(writer *multipart.Writer) error {
 				for _, revid := range revids {
-					revBody, err := collection.Get1xRevBodyWithHistory(h.ctx(), docid, revid, revsLimit, revsFrom, attachmentsSince, showExp)
+					revBody, err := h.collection.Get1xRevBodyWithHistory(h.ctx(), docid, revid, revsLimit, revsFrom, attachmentsSince, showExp)
 					if err != nil {
 						revBody = db.Body{"missing": revid} // TODO: More specific error
 					}
@@ -141,7 +140,7 @@ func (h *handler) handleGetDoc() error {
 			_, _ = h.response.Write([]byte(`[` + "\n"))
 			separator := []byte(``)
 			for _, revid := range revids {
-				revBody, err := collection.Get1xRevBodyWithHistory(h.ctx(), docid, revid, revsLimit, revsFrom, attachmentsSince, showExp)
+				revBody, err := h.collection.Get1xRevBodyWithHistory(h.ctx(), docid, revid, revsLimit, revsFrom, attachmentsSince, showExp)
 				if err != nil {
 					revBody = db.Body{"missing": revid} // TODO: More specific error
 				} else {
@@ -166,8 +165,7 @@ func (h *handler) handleGetDocReplicator2(docid, revid string) error {
 		return base.HTTPErrorf(http.StatusNotImplemented, "replicator2 endpoints are only supported in EE")
 	}
 
-	collection := h.db.GetSingleDatabaseCollectionWithUser()
-	rev, err := collection.GetRev(h.ctx(), docid, revid, true, nil)
+	rev, err := h.collection.GetRev(h.ctx(), docid, revid, true, nil)
 	if err != nil {
 		return err
 	}
@@ -193,8 +191,7 @@ func (h *handler) handleGetAttachment() error {
 	docid := h.PathVar("docid")
 	attachmentName := h.PathVar("attach")
 	revid := h.getQuery("rev")
-	collection := h.db.GetSingleDatabaseCollectionWithUser()
-	rev, err := collection.GetRev(h.ctx(), docid, revid, false, nil)
+	rev, err := h.collection.GetRev(h.ctx(), docid, revid, false, nil)
 	if err != nil {
 		return err
 	}
@@ -212,7 +209,7 @@ func (h *handler) handleGetAttachment() error {
 		return db.ErrAttachmentVersion
 	}
 	attachmentKey := db.MakeAttachmentKey(version, docid, digest)
-	data, err := collection.GetAttachment(attachmentKey)
+	data, err := h.collection.GetAttachment(attachmentKey)
 	if err != nil {
 		return err
 	}
@@ -317,8 +314,7 @@ func (h *handler) handlePutAttachment() error {
 		return err
 	}
 
-	collection := h.db.GetSingleDatabaseCollectionWithUser()
-	body, err := collection.Get1xRevBody(h.ctx(), docid, revid, false, nil)
+	body, err := h.collection.Get1xRevBody(h.ctx(), docid, revid, false, nil)
 	if err != nil {
 		if base.IsDocNotFoundError(err) {
 			// couchdb creates empty body on attachment PUT
@@ -350,7 +346,7 @@ func (h *handler) handlePutAttachment() error {
 	attachments[attachmentName] = attachment
 	body[db.BodyAttachments] = attachments
 
-	newRev, _, err := collection.Put(h.ctx(), docid, body)
+	newRev, _, err := h.collection.Put(h.ctx(), docid, body)
 	if err != nil {
 		return err
 	}
@@ -376,8 +372,7 @@ func (h *handler) handleDeleteAttachment() error {
 		}
 	}
 
-	collection := h.db.GetSingleDatabaseCollectionWithUser()
-	body, err := collection.Get1xRevBody(h.ctx(), docid, revid, false, nil)
+	body, err := h.collection.Get1xRevBody(h.ctx(), docid, revid, false, nil)
 	if err != nil {
 		if base.IsDocNotFoundError(err) {
 			// Check here if error is relating to incorrect revid, if so return 409 code else return 404 code
@@ -406,7 +401,7 @@ func (h *handler) handleDeleteAttachment() error {
 	delete(attachments, attachmentName)
 	body[db.BodyAttachments] = attachments
 
-	newRev, _, err := collection.Put(h.ctx(), docid, body)
+	newRev, _, err := h.collection.Put(h.ctx(), docid, body)
 	if err != nil {
 		return err
 	}
@@ -453,7 +448,6 @@ func (h *handler) handlePutDoc() error {
 	var newRev string
 	var doc *db.Document
 
-	collection := h.db.GetSingleDatabaseCollectionWithUser()
 	if h.getQuery("new_edits") != "false" {
 		// Regular PUT:
 		bodyRev := body[db.BodyRev]
@@ -466,7 +460,7 @@ func (h *handler) handlePutDoc() error {
 			return base.HTTPErrorf(http.StatusBadRequest, "Revision IDs provided do not match")
 		}
 
-		newRev, doc, err = collection.Put(h.ctx(), docid, body)
+		newRev, doc, err = h.collection.Put(h.ctx(), docid, body)
 		if err != nil {
 			return err
 		}
@@ -477,7 +471,7 @@ func (h *handler) handlePutDoc() error {
 		if revisions == nil {
 			return base.HTTPErrorf(http.StatusBadRequest, "Bad _revisions")
 		}
-		doc, newRev, err = collection.PutExistingRevWithBody(h.ctx(), docid, body, revisions, false)
+		doc, newRev, err = h.collection.PutExistingRevWithBody(h.ctx(), docid, body, revisions, false)
 		if err != nil {
 			return err
 		}
@@ -555,15 +549,14 @@ func (h *handler) handlePutDocReplicator2(docid string, roundTrip bool) (err err
 		newDoc.UpdateBody(body)
 	}
 
-	collection := h.db.GetSingleDatabaseCollectionWithUser()
-	doc, rev, err := collection.PutExistingRev(h.ctx(), newDoc, history, true, false, nil)
+	doc, rev, err := h.collection.PutExistingRev(h.ctx(), newDoc, history, true, false, nil)
 
 	if err != nil {
 		return err
 	}
 
 	if doc != nil && roundTrip {
-		if err := collection.WaitForSequenceNotSkipped(h.ctx(), doc.Sequence); err != nil {
+		if err := h.collection.WaitForSequenceNotSkipped(h.ctx(), doc.Sequence); err != nil {
 			return err
 		}
 	}
@@ -584,14 +577,13 @@ func (h *handler) handlePostDoc() error {
 		return err
 	}
 
-	collection := h.db.GetSingleDatabaseCollectionWithUser()
-	docid, newRev, doc, err := collection.Post(h.ctx(), body)
+	docid, newRev, doc, err := h.collection.Post(h.ctx(), body)
 	if err != nil {
 		return err
 	}
 
 	if doc != nil && roundTrip {
-		err := collection.WaitForSequenceNotSkipped(h.ctx(), doc.Sequence)
+		err := h.collection.WaitForSequenceNotSkipped(h.ctx(), doc.Sequence)
 		if err != nil {
 			return err
 		}
@@ -614,8 +606,7 @@ func (h *handler) handleDeleteDoc() error {
 			return err
 		}
 	}
-	collection := h.db.GetSingleDatabaseCollectionWithUser()
-	newRev, err := collection.DeleteDoc(h.ctx(), docid, revid)
+	newRev, err := h.collection.DeleteDoc(h.ctx(), docid, revid)
 	if err == nil {
 		h.writeRawJSONStatus(http.StatusOK, []byte(`{"id":`+base.ConvertToJSONString(docid)+`,"ok":true,"rev":"`+newRev+`"}`))
 	}
@@ -627,8 +618,7 @@ func (h *handler) handleDeleteDoc() error {
 // HTTP handler for a GET of a _local document
 func (h *handler) handleGetLocalDoc() error {
 	docid := h.PathVar("docid")
-	collection := h.db.GetSingleDatabaseCollectionWithUser()
-	value, err := collection.GetSpecial(db.DocTypeLocal, docid)
+	value, err := h.collection.GetSpecial(db.DocTypeLocal, docid)
 	if err != nil {
 		return err
 	}
@@ -645,9 +635,8 @@ func (h *handler) handlePutLocalDoc() error {
 	docid := h.PathVar("docid")
 	body, err := h.readJSON()
 	if err == nil {
-		collection := h.db.GetSingleDatabaseCollectionWithUser()
 		var revid string
-		revid, err = collection.PutSpecial(db.DocTypeLocal, docid, body)
+		revid, err = h.collection.PutSpecial(db.DocTypeLocal, docid, body)
 		if err == nil {
 			h.writeRawJSONStatus(http.StatusCreated, []byte(`{"id":`+base.ConvertToJSONString("_local/"+docid)+`,"ok":true,"rev":"`+revid+`"}`))
 		}
@@ -658,8 +647,7 @@ func (h *handler) handlePutLocalDoc() error {
 // HTTP handler for a DELETE of a _local document
 func (h *handler) handleDelLocalDoc() error {
 	docid := h.PathVar("docid")
-	collection := h.db.GetSingleDatabaseCollectionWithUser()
-	return collection.DeleteSpecial(db.DocTypeLocal, docid, h.getQuery("rev"))
+	return h.collection.DeleteSpecial(db.DocTypeLocal, docid, h.getQuery("rev"))
 }
 
 // helper for read only check

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -88,6 +88,7 @@ type handler struct {
 	statusMessage         string
 	requestBody           io.ReadCloser
 	db                    *db.Database
+	collection            *db.DatabaseCollectionWithUser
 	keyspaceScope         string
 	keyspaceCollection    string
 	user                  auth.User
@@ -463,6 +464,10 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 	if dbContext != nil {
 		h.keyspaceScope, h.keyspaceCollection = *keyspaceScope, *keyspaceCollection
 		h.db, err = db.GetDatabase(dbContext, h.user)
+		if err != nil {
+			return err
+		}
+		h.collection, err = h.db.GetDatabaseCollectionWithUser(h.keyspaceScope, h.keyspaceCollection)
 		if err != nil {
 			return err
 		}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -89,8 +89,6 @@ type handler struct {
 	requestBody           io.ReadCloser
 	db                    *db.Database
 	collection            *db.DatabaseCollectionWithUser
-	keyspaceScope         string
-	keyspaceCollection    string
 	user                  auth.User
 	authorizedAdminUser   string
 	privs                 handlerPrivs
@@ -462,12 +460,11 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 
 	// Now set the request's Database (i.e. context + user)
 	if dbContext != nil {
-		h.keyspaceScope, h.keyspaceCollection = *keyspaceScope, *keyspaceCollection
 		h.db, err = db.GetDatabase(dbContext, h.user)
 		if err != nil {
 			return err
 		}
-		h.collection, err = h.db.GetDatabaseCollectionWithUser(h.keyspaceScope, h.keyspaceCollection)
+		h.collection, err = h.db.GetDatabaseCollectionWithUser(*keyspaceScope, *keyspaceCollection)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
One test has divergent behavior in walrus vs GSI and I've commented it out, maybe I should create a ticket that is specifically re-enable this test after https://github.com/couchbase/sync_gateway/pull/5832 is merged.

Should I log bucket name in the error conditions, or not because it's already shown in the logging context? Should keyspace by escaped by `base.MD` vs `base.UD` ?

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1112/
