### PR TITLE
Revert "CBG-2505: Fix for race condition within test causing it to flake"

### DIFF
--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -279,6 +279,7 @@ func TestLateSequenceErrorRecovery(t *testing.T) {
 	options.Since = SequenceID{Seq: 0}
 	changesCtx, changesCtxCancel := context.WithCancel(context.Background())
 	options.ChangesCtx = changesCtx
+	defer changesCtxCancel()
 	options.Continuous = true
 	options.Wait = true
 	feed, err := dbCollection.MultiChangesFeed(ctx, base.SetOf("ABC"), options)
@@ -368,9 +369,6 @@ func TestLateSequenceErrorRecovery(t *testing.T) {
 	nextEvents = nextFeedIteration()
 	require.Equal(t, len(nextEvents), 1)
 	assert.Equal(t, nextEvents[0].Seq.String(), "9")
-
-	changesCtxCancel()
-	emptyChangesFeed(feed)
 
 }
 
@@ -704,6 +702,7 @@ func TestContinuousChangesBackfill(t *testing.T) {
 	options.ChangesCtx = changesCtx
 	options.Continuous = true
 	options.Wait = true
+	defer changesCtxCancel()
 
 	dbCollection := db.GetSingleDatabaseCollectionWithUser()
 	feed, err := dbCollection.MultiChangesFeed(ctx, base.SetOf("*"), options)
@@ -769,8 +768,6 @@ func TestContinuousChangesBackfill(t *testing.T) {
 	}
 
 	assert.Equal(t, 0, len(expectedDocs))
-	changesCtxCancel()
-	emptyChangesFeed(feed)
 }
 
 // Test low sequence handling of late arriving sequences to a continuous changes feed
@@ -810,6 +807,7 @@ func TestLowSequenceHandling(t *testing.T) {
 	options.Since = SequenceID{Seq: 0}
 	changesCtx, changesCtxCancel := context.WithCancel(context.Background())
 	options.ChangesCtx = changesCtx
+	defer changesCtxCancel()
 	options.Continuous = true
 	options.Wait = true
 	feed, err := dbCollection.MultiChangesFeed(ctx, base.SetOf("*"), options)
@@ -840,9 +838,6 @@ func TestLowSequenceHandling(t *testing.T) {
 	WriteDirect(db, []string{"ABC", "PBS"}, 9)
 	_, err = verifySequencesInFeed(feed, []uint64{7, 8, 9})
 	assert.True(t, err == nil)
-
-	changesCtxCancel()
-	emptyChangesFeed(feed)
 
 }
 
@@ -900,7 +895,6 @@ func TestLowSequenceHandlingAcrossChannels(t *testing.T) {
 	assert.True(t, err == nil)
 
 	changesCtxCancel()
-	emptyChangesFeed(feed)
 }
 
 // Test low sequence handling of late arriving sequences to a continuous changes feed, when the
@@ -977,7 +971,6 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	// whether the user has already seen the documents on the channel previously, so it gets resent
 
 	changesCtxCancel()
-	emptyChangesFeed(feed)
 }
 
 // Tests channel cache backfill with slow query, validates that a request that is terminated while
@@ -1148,6 +1141,7 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 	options.Since = SequenceID{Seq: 0}
 	changesCtx, changesCtxCancel := context.WithCancel(context.Background())
 	options.ChangesCtx = changesCtx
+	defer changesCtxCancel()
 	options.Continuous = true
 	options.Wait = true
 	dbCollection := db.GetSingleDatabaseCollectionWithUser()
@@ -1184,8 +1178,7 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 	require.NoError(t, collection.changeCache.waitForSequence(ctx, 9, base.DefaultWaitForSequence))
 	require.NoError(t, appendFromFeed(&changes, feed, 5, base.DefaultWaitForSequence))
 	assert.True(t, verifyChangesSequencesIgnoreOrder(changes, []uint64{1, 2, 5, 6, 3, 4, 7, 8, 9}))
-	changesCtxCancel()
-	emptyChangesFeed(feed)
+
 }
 
 // Test race condition causing skipped sequences in changes feed.  Channel feeds are processed sequentially
@@ -1300,7 +1293,6 @@ func TestChannelRace(t *testing.T) {
 	fmt.Println("changes: ", changesString)
 
 	changesCtxCancel()
-	emptyChangesFeed(feed)
 }
 
 // Test retrieval of skipped sequence using view.  Unit test catches panic, but we don't currently have a way
@@ -2324,18 +2316,5 @@ func BenchmarkDocChanged(b *testing.B) {
 			// log.Printf("maxNumPending: %v", changeCache.context.DbStats.StatsCblReplicationPull().Get(base.StatKeyMaxPending))
 			// log.Printf("cachingCount: %v", changeCache.context.DbStats.StatsDatabase().Get(base.StatKeyDcpCachingCount))
 		})
-	}
-}
-
-func emptyChangesFeed(feed <-chan *ChangeEntry) {
-	done := false
-	for !done {
-		select {
-		case v, _ := <-feed:
-			log.Printf("Waiting for change entry feed to be empty. Item coming off the feed: %v", v)
-		default:
-			log.Println("Change entry feed empty")
-			done = true
-		}
 	}
 }


### PR DESCRIPTION
Reverts couchbase/sync_gateway#5879

Reverting this fix for now as emptyChangesFeed can race and end up in an infinite loop if the feed is closed.   