### PR TITLE
CBG-2333 move principal sequence handling to outside DatabaseCollection

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1535,14 +1535,14 @@ func (db *DatabaseCollectionWithUser) assignSequence(ctx context.Context, docSeq
 		}
 
 		for {
-			if docSequence, err = db.sequences().nextSequence(); err != nil {
+			if docSequence, err = db.sequences.nextSequence(); err != nil {
 				return unusedSequences, err
 			}
 
 			if docSequence > doc.Sequence {
 				break
 			} else {
-				releaseErr := db.sequences().releaseSequence(docSequence)
+				releaseErr := db.sequences.releaseSequence(docSequence)
 				if releaseErr != nil {
 					base.WarnfCtx(ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", docSequence, err)
 				}
@@ -1891,13 +1891,13 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 	// If the WriteUpdate didn't succeed, check whether there are unused, allocated sequences that need to be accounted for
 	if err != nil {
 		if docSequence > 0 {
-			if seqErr := db.sequences().releaseSequence(docSequence); seqErr != nil {
+			if seqErr := db.sequences.releaseSequence(docSequence); seqErr != nil {
 				base.WarnfCtx(ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", docSequence, seqErr)
 			}
 
 		}
 		for _, sequence := range unusedSequences {
-			if seqErr := db.sequences().releaseSequence(sequence); seqErr != nil {
+			if seqErr := db.sequences.releaseSequence(sequence); seqErr != nil {
 				base.WarnfCtx(ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", sequence, seqErr)
 			}
 		}

--- a/db/database.go
+++ b/db/database.go
@@ -89,7 +89,7 @@ type DatabaseContext struct {
 	BucketLock                  sync.RWMutex            // Control Access to the underlying bucket object
 	mutationListener            changeListener          // Caching feed listener
 	ImportListener              *importListener         // Import feed listener
-	sequences                   *sequenceAllocator      // Source of new sequence numbers
+	principalSequences          *sequenceAllocator      // Source of new sequence numbers
 	ChannelMapper               *channels.ChannelMapper // Runs JS 'sync' function
 	StartTime                   time.Time               // Timestamp when context was instantiated
 	RevsLimit                   uint32                  // Max depth a document's revision tree can grow to
@@ -373,23 +373,6 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 
 	dbContext.EventMgr = NewEventManager(dbContext.terminator)
 
-	var err error
-	dbContext.sequences, err = newSequenceAllocator(bucket, dbContext.DbStats.Database())
-	if err != nil {
-		return nil, err
-	}
-
-	cleanupFunctions = append(cleanupFunctions, func() {
-		dbContext.sequences.Stop()
-	})
-
-	// Get current value of _sync:seq
-	initialSequence, seqErr := dbContext.sequences.lastSequence()
-	if seqErr != nil {
-		return nil, seqErr
-	}
-	initialSequenceTime := time.Now()
-
 	// Initialize the active channel counter
 	dbContext.activeChannels = channels.NewActiveChannels(dbContext.DbStats.Cache().NumActiveChannels)
 
@@ -444,6 +427,8 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		dbContext.CollectionByID[base.DefaultCollectionID] = dbCollection
 		dbContext.singleCollection = dbCollection
 	}
+
+	dbContext.principalSequences = dbContext.singleCollection.sequences
 
 	// Initialize the tap Listener for notify handling
 	dbContext.mutationListener.Init(bucket.GetName(), options.GroupID)
@@ -504,20 +489,9 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		dbContext.mutationListener.Stop()
 	})
 
-	// Unlock change cache.  Validate that any allocated sequences on other nodes have either been assigned or released
-	// before starting
-	if initialSequence > 0 {
-		_ = dbContext.sequences.waitForReleasedSequences(initialSequenceTime)
-	}
-
-	for _, collection := range dbContext.CollectionByID {
-		err = collection.changeCache.Start(initialSequence)
-		if err != nil {
-			return nil, err
-		}
-		cleanupFunctions = append(cleanupFunctions, func() {
-			collection.changeCache.Stop()
-		})
+	err = startChangeCaches(dbContext, cleanupFunctions)
+	if err != nil {
+		return nil, err
 	}
 
 	// If this is an xattr import node, start import feed.  Must be started after the caching DCP feed, as import cfg
@@ -702,7 +676,7 @@ func (context *DatabaseContext) Close(ctx context.Context) {
 	close(context.terminator)
 	// Wait for database background tasks to finish.
 	waitForBGTCompletion(ctx, BGTCompletionMaxWait, context.backgroundTasks, context.Name)
-	context.sequences.Stop()
+	context.stopSequenceAllocators()
 	context.mutationListener.Stop()
 	context.stopChangeCaches()
 	context.ImportListener.Stop()
@@ -1537,7 +1511,7 @@ func (db *DatabaseCollectionWithUser) UpdateAllDocChannels(ctx context.Context, 
 
 	queryLimit := db.queryPaginationLimit()
 	startSeq := uint64(0)
-	endSeq, err := db.sequences().getSequence()
+	endSeq, err := db.sequences.getSequence()
 	if err != nil {
 		return 0, err
 	}
@@ -1720,7 +1694,7 @@ func (db *DatabaseCollectionWithUser) UpdateAllDocChannels(ctx context.Context, 
 	}
 
 	for _, sequence := range unusedSequences {
-		err := db.sequences().releaseSequence(sequence)
+		err := db.sequences.releaseSequence(sequence)
 		if err != nil {
 			base.WarnfCtx(ctx, "Error attempting to release sequence %d. Error %v", sequence, err)
 		}
@@ -1734,7 +1708,7 @@ func (db *DatabaseCollectionWithUser) UpdateAllDocChannels(ctx context.Context, 
 
 		authr := db.Authenticator(ctx)
 		regeneratePrincipalSequences := func(princ auth.Principal) error {
-			nextSeq, err := db.sequences().nextSequence()
+			nextSeq, err := db.principalSequences().nextSequence()
 			if err != nil {
 				return err
 			}
@@ -1952,12 +1926,6 @@ func (context *DatabaseContext) AllowFlushNonCouchbaseBuckets() bool {
 	return false
 }
 
-// ////// SEQUENCE ALLOCATION:
-
-func (context *DatabaseContext) LastSequence() (uint64, error) {
-	return context.sequences.lastSequence()
-}
-
 // Helpers for unsupported options
 func (context *DatabaseContext) IsGuestReadOnly() bool {
 	return context.Options.UnsupportedOptions != nil && context.Options.UnsupportedOptions.GuestReadOnly
@@ -1998,8 +1966,8 @@ func (dbCtx *DatabaseContext) AddDatabaseLogContext(ctx context.Context) context
 	return ctx
 }
 
-// onlyDefaultCollection is true if the database is only configured with default collection.
-func (dbCtx *DatabaseContext) onlyDefaultCollection() bool {
+// OnlyDefaultCollection is true if the database is only configured with default collection.
+func (dbCtx *DatabaseContext) OnlyDefaultCollection() bool {
 	if len(dbCtx.CollectionByID) > 1 {
 		return false
 	}
@@ -2009,7 +1977,7 @@ func (dbCtx *DatabaseContext) onlyDefaultCollection() bool {
 
 // GetDatabaseCollectionWithUser returns a collection if one exists, otherwise error.
 func (dbc *Database) GetDatabaseCollectionWithUser(scopeName, collectionName string) (*DatabaseCollectionWithUser, error) {
-	if base.IsDefaultCollection(scopeName, collectionName) && dbc.onlyDefaultCollection() {
+	if base.IsDefaultCollection(scopeName, collectionName) && dbc.OnlyDefaultCollection() {
 		return dbc.GetDefaultDatabaseCollectionWithUser()
 	}
 	if dbc.Scopes == nil {
@@ -2101,11 +2069,48 @@ func newDatabaseCollection(ctx context.Context, dbContext *DatabaseContext, buck
 		}
 		dbCollection.changeCache.cfgEventCallback = cfgSG.FireEvent
 	}
+	dbCollection.sequences, err = newSequenceAllocator(bucket, dbCollection.dbStats().Database())
+	if err != nil {
+		return nil, err
+	}
+
 	return dbCollection, nil
+}
+
+func startChangeCaches(dbContext *DatabaseContext, cleanupFunctions []func()) error {
+	for _, collection := range dbContext.CollectionByID {
+		// Get current value of _sync:seq
+		initialSequence, seqErr := collection.LastSequence()
+		if seqErr != nil {
+			return seqErr
+		}
+		initialSequenceTime := time.Now()
+
+		// Unlock change cache.  Validate that any allocated sequences on other nodes have either been assigned or released
+		// before starting
+		if initialSequence > 0 {
+			_ = collection.sequences.waitForReleasedSequences(initialSequenceTime)
+		}
+
+		err := collection.changeCache.Start(initialSequence)
+		if err != nil {
+			return err
+		}
+		cleanupFunctions = append(cleanupFunctions, func() {
+			collection.changeCache.Stop()
+		})
+	}
+	return nil
 }
 
 func (dbc *DatabaseContext) stopChangeCaches() {
 	for _, collection := range dbc.CollectionByID {
 		collection.changeCache.Stop()
+	}
+}
+
+func (dbc *DatabaseContext) stopSequenceAllocators() {
+	for _, collection := range dbc.CollectionByID {
+		collection.sequences.Stop()
 	}
 }

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -21,7 +21,7 @@ package db
 
 // Update database-specific stats that are more efficiently calculated at stats collection time
 func (db *DatabaseContext) UpdateCalculatedStats() {
-	if !db.onlyDefaultCollection() {
+	if !db.OnlyDefaultCollection() {
 		return
 	}
 	defaultCollection, err := db.GetDefaultDatabaseCollection()

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -924,7 +924,7 @@ func TestUpdatePrincipal(t *testing.T) {
 	_, err = db.UpdatePrincipal(ctx, userInfo, true, true)
 	assert.NoError(t, err, "Unable to update principal")
 
-	nextSeq, err := db.sequences.nextSequence()
+	nextSeq, err := db.principalSequences.nextSequence()
 	assert.Equal(t, uint64(1), nextSeq)
 
 	// Validate that a call to UpdatePrincipals with changes to the user does allocate a sequence
@@ -933,7 +933,7 @@ func TestUpdatePrincipal(t *testing.T) {
 	_, err = db.UpdatePrincipal(ctx, userInfo, true, true)
 	assert.NoError(t, err, "Unable to update principal")
 
-	nextSeq, err = db.sequences.nextSequence()
+	nextSeq, err = db.principalSequences.nextSequence()
 	assert.Equal(t, uint64(3), nextSeq)
 }
 

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -63,7 +63,7 @@ func (il *importListener) StartImportFeed(ctx context.Context, bucket base.Bucke
 		scopeName = sn
 	}
 
-	if !dbContext.onlyDefaultCollection() {
+	if !dbContext.OnlyDefaultCollection() {
 		coll, err := base.AsCollection(bucket)
 		if err != nil {
 			return fmt.Errorf("configured with named collections, but bucket is not collection: %w", err)

--- a/db/users.go
+++ b/db/users.go
@@ -32,7 +32,7 @@ func (db *DatabaseContext) DeleteRole(ctx context.Context, name string, purge bo
 		return base.ErrNotFound
 	}
 
-	seq, err := db.sequences.nextSequence()
+	seq, err := db.principalSequences.nextSequence()
 	if err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		// Update the persistent sequence number of this principal (only allocate a sequence when needed - issue #673):
 		nextSeq := uint64(0)
 		var err error
-		nextSeq, err = dbc.sequences.nextSequence()
+		nextSeq, err = dbc.principalSequences.nextSequence()
 		if err != nil {
 			return replaced, err
 		}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1051,7 +1051,13 @@ func (h *handler) handleGetStatus() error {
 
 		// Don't bother trying to lookup LastSequence() if offline
 		if runState != db.RunStateString[db.DBOffline] {
-			lastSeq, _ = database.LastSequence()
+			if database.OnlyDefaultCollection() {
+				collection, err := database.GetDefaultDatabaseCollection()
+				if err != nil {
+					return err
+				}
+				lastSeq, _ = collection.LastSequence()
+			}
 		}
 
 		replicationsStatus, err := database.SGReplicateMgr.GetReplicationStatusAll(db.DefaultReplicationStatusOptions())

--- a/rest/api.go
+++ b/rest/api.go
@@ -391,8 +391,10 @@ func (h *handler) handleGetDB() error {
 	// Don't bother trying to lookup LastSequence() if offline
 	runState := db.RunStateString[atomic.LoadUint32(&h.db.State)]
 	if runState != db.RunStateString[db.DBOffline] {
-		lastSeq, _ := h.db.LastSequence()
-		defaultCollectionLastSeq = &lastSeq
+		if h.db.OnlyDefaultCollection() {
+			lastSeq, _ := h.collection.LastSequence()
+			defaultCollectionLastSeq = &lastSeq
+		}
 	}
 
 	var response = DatabaseRoot{

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -199,7 +199,7 @@ func (h *handler) handleAllDocs() error {
 	options.Limit = h.getIntQuery("limit", 0)
 
 	// Now it's time to actually write the response!
-	lastSeq, _ := h.db.LastSequence()
+	lastSeq, _ := h.collection.LastSequence()
 	h.setHeader("Content-Type", "application/json")
 	// response.Write below would set Status OK implicitly. We manually do it here to ensure that our handler knows
 	//that the header has been written to, meaning we can prevent it from attempting to set the header again later on.

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -111,7 +111,7 @@ func (tester *ChannelRevocationTester) removeUserChannel(user, channel string) {
 }
 
 func (tester *ChannelRevocationTester) fillToSeq(seq uint64) {
-	currentSeq, err := tester.restTester.GetDatabase().LastSequence()
+	currentSeq, err := tester.restTester.GetDatabase().GetSingleDatabaseCollection().LastSequence()
 	require.NoError(tester.test, err)
 
 	loopCount := seq - currentSeq


### PR DESCRIPTION
Since currently there can only be a single collection, the sequence allocator is shared between singleCollection.

An idea I had was to have two sequence allocators (regardless if there are multiple collections or not):

(1) the principal sequence allocator
(2) the collection sequence allocator

This approach has some consequences - lastSequenceNumber from rest API/stats will be different. I'd assumed we'd ignore the principal sequences in reporting or report separately. (Current calls `LastSequence`).

To use an actual separate sequence handler and have the tests pass, I need `DatabaseCollection.WaitForPendingChanges` to wait for principal sequences and non principal sequences. If I want to wait on a seqno, I'd have to have a changeCache, and the changeCache is backed by a DatabaseCollection, which we don't have for MetadataStore. We could refactor this to be backed by a DataStore, if we do need to keep track of these sequences.

Other considerations are to be backed by a different doc key `_sync:seq` being now overloaded.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1115/
