### PR TITLE
CBG-2570 use unique UUIDs for replication

### DIFF
--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -282,10 +283,9 @@ func TestGroupIDReplications(t *testing.T) {
 		config.API.PublicInterface = fmt.Sprintf("127.0.0.1:%d", 4984+BootstrapTestPortOffset+portOffset)
 		config.API.AdminInterface = adminInterface
 		config.API.MetricsInterface = fmt.Sprintf("127.0.0.1:%d", 4986+BootstrapTestPortOffset+portOffset)
-		config.Bootstrap.ConfigGroupID = group
-		if group == "" {
-			config.Bootstrap.ConfigGroupID = PersistentConfigDefaultGroupID
-		}
+		uniqueUUID, err := uuid.NewRandom()
+		require.NoError(t, err)
+		config.Bootstrap.ConfigGroupID = group + uniqueUUID.String()
 
 		ctx := base.TestCtx(t)
 		sc, err := SetupServerContext(ctx, &config, true)


### PR DESCRIPTION
This drops using `default` as a groupID but I don't think this breaks the test, and allows running this test `-count=1`

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1120/
