### PR TITLE
CBG-2554 Channel computation and invalidation for collections

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -840,7 +840,7 @@ func (auth *Authenticator) RegisterNewUser(username, email string) (User, error)
 		return nil, err
 	}
 
-	user, err := auth.NewUser(username, secret, base.Set{})
+	user, err := auth.NewUserNoChannels(username, secret)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -380,7 +380,7 @@ func TestRebuildUserChannels(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = auth.InvalidateDefaultChannels("testUser", true, 2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	user2, err := auth.GetUser("testUser")
 	assert.NoError(t, err)

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -313,18 +313,51 @@ func TestSaveRoles(t *testing.T) {
 }
 
 type mockComputer struct {
-	channels     ch.TimedSet
+	channels     map[string]map[string]ch.TimedSet
 	roles        ch.TimedSet
-	roleChannels ch.TimedSet
+	roleChannels map[string]map[string]ch.TimedSet
 	err          error
 }
 
-func (self *mockComputer) ComputeChannelsForPrincipal(ctx context.Context, p Principal) (ch.TimedSet, error) {
+func (mc *mockComputer) AddChannelsForCollection(scope, collection string, channels ch.TimedSet) {
+	if mc.channels == nil {
+		mc.channels = make(map[string]map[string]ch.TimedSet)
+	}
+	collectionMap, ok := mc.channels[scope]
+	if !ok {
+		collectionMap = make(map[string]ch.TimedSet)
+		mc.channels[scope] = collectionMap
+	}
+	collectionMap[collection] = channels
+}
+
+func (mc *mockComputer) AddRoleChannelsForCollection(scope, collection string, channels ch.TimedSet) {
+	if mc.roleChannels == nil {
+		mc.roleChannels = make(map[string]map[string]ch.TimedSet)
+	}
+	collectionMap, ok := mc.roleChannels[scope]
+	if !ok {
+		collectionMap = make(map[string]ch.TimedSet)
+		mc.roleChannels[scope] = collectionMap
+	}
+	collectionMap[collection] = channels
+}
+
+func (self *mockComputer) ComputeChannelsForPrincipal(ctx context.Context, p Principal, scope, collection string) (ch.TimedSet, error) {
+
 	switch p.(type) {
 	case User:
-		return self.channels, self.err
+		channels, ok := self.channels[scope][collection]
+		if !ok {
+			return ch.TimedSet{}, self.err
+		}
+		return channels, self.err
 	case Role:
-		return self.roleChannels, self.err
+		channels, ok := self.roleChannels[scope][collection]
+		if !ok {
+			return ch.TimedSet{}, self.err
+		}
+		return channels, self.err
 	default:
 		return nil, self.err
 	}
@@ -334,21 +367,19 @@ func (self *mockComputer) ComputeRolesForUser(context.Context, User) (ch.TimedSe
 	return self.roles, self.err
 }
 
-func (self *mockComputer) UseGlobalSequence() bool {
-	return true
-}
-
 func TestRebuildUserChannels(t *testing.T) {
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
+
 	dataStore := bucket.GetSingleDataStore()
-	computer := mockComputer{channels: ch.AtSequence(ch.BaseSetOf(t, "derived1", "derived2"), 1)}
+	computer := mockComputer{}
+	computer.AddChannelsForCollection(base.DefaultScope, base.DefaultCollection, ch.AtSequence(ch.BaseSetOf(t, "derived1", "derived2"), 1))
 	auth := NewAuthenticator(dataStore, &computer, DefaultAuthenticatorOptions())
 	user, _ := auth.NewUser("testUser", "password", ch.BaseSetOf(t, "explicit1"))
 	err := auth.Save(user)
 	assert.NoError(t, err)
 
-	err = auth.InvalidateChannels("testUser", true, 2)
+	err = auth.InvalidateDefaultChannels("testUser", true, 2)
 	assert.NoError(t, err)
 
 	user2, err := auth.GetUser("testUser")
@@ -356,19 +387,80 @@ func TestRebuildUserChannels(t *testing.T) {
 	assert.Equal(t, ch.AtSequence(ch.BaseSetOf(t, "explicit1", "derived1", "derived2", "!"), 1), user2.Channels())
 }
 
+func TestRebuildUserChannelsMultiCollection(t *testing.T) {
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+	dataStore := bucket.GetSingleDataStore()
+	computer := mockComputer{}
+	computer.AddChannelsForCollection(base.DefaultScope, base.DefaultCollection, ch.AtSequence(ch.BaseSetOf(t, "derived1", "derived2"), 1))
+	computer.AddChannelsForCollection("scope1", "collection1", ch.AtSequence(ch.BaseSetOf(t, "derived3", "derived4"), 1))
+
+	options := DefaultAuthenticatorOptions()
+	options.Collections = map[string]map[string]struct{}{
+		base.DefaultScope: {base.DefaultCollection: struct{}{}},
+		"scope1":          {"collection1": struct{}{}},
+	}
+	auth := NewAuthenticator(dataStore, &computer, options)
+	user, _ := auth.NewUser("testUser", "password", ch.BaseSetOf(t, "explicit1"))
+	user.SetCollectionExplicitChannels("scope1", "collection1", ch.AtSequence(ch.BaseSetOf(t, "explicit2"), 1), 0)
+	err := auth.Save(user)
+	assert.NoError(t, err)
+
+	err = auth.InvalidateChannels("testUser", true, "scope1", "collection1", 2)
+	assert.NoError(t, err)
+
+	user2, err := auth.GetUser("testUser")
+	assert.NoError(t, err)
+	assert.Equal(t, ch.AtSequence(ch.BaseSetOf(t, "explicit1", "derived1", "derived2", "!"), 1), user2.Channels())
+	assert.Equal(t, ch.AtSequence(ch.BaseSetOf(t, "explicit2", "derived3", "derived4", "!"), 1), user2.CollectionChannels("scope1", "collection1"))
+}
+
+func TestRebuildUserChannelsNamedCollection(t *testing.T) {
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+	dataStore := bucket.GetSingleDataStore()
+	computer := mockComputer{}
+	computer.AddChannelsForCollection("scope1", "collection1", ch.AtSequence(ch.BaseSetOf(t, "derived3", "derived4"), 1))
+
+	options := DefaultAuthenticatorOptions()
+	options.Collections = map[string]map[string]struct{}{
+		"scope1": {"collection1": struct{}{}},
+	}
+	auth := NewAuthenticator(dataStore, &computer, options)
+	user, _ := auth.NewUser("testUser", "password", nil)
+	user.SetCollectionExplicitChannels("scope1", "collection1", ch.AtSequence(ch.BaseSetOf(t, "explicit2"), 1), 0)
+	err := auth.Save(user)
+	assert.NoError(t, err)
+
+	err = auth.InvalidateChannels("testUser", true, "scope1", "collection1", 2)
+	assert.NoError(t, err)
+
+	user2, err := auth.GetUser("testUser")
+	assert.NoError(t, err)
+	assert.Equal(t, ch.TimedSet(nil), user2.Channels())
+	assert.Equal(t, ch.AtSequence(ch.BaseSetOf(t, "explicit2", "derived3", "derived4", "!"), 1), user2.CollectionChannels("scope1", "collection1"))
+}
+
+// Test cases
+//   multiple collections
+//   single non-default
+//   single plus default
+
 func TestRebuildRoleChannels(t *testing.T) {
 
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
+
 	dataStore := bucket.GetSingleDataStore()
-	computer := mockComputer{roleChannels: ch.AtSequence(ch.BaseSetOf(t, "derived1", "derived2"), 1)}
+	computer := mockComputer{}
+	computer.AddRoleChannelsForCollection(base.DefaultScope, base.DefaultCollection, ch.AtSequence(ch.BaseSetOf(t, "derived1", "derived2"), 1))
 	auth := NewAuthenticator(dataStore, &computer, DefaultAuthenticatorOptions())
 	role, err := auth.NewRole("testRole", ch.BaseSetOf(t, "explicit1"))
 	assert.NoError(t, err)
 	err = auth.Save(role)
 	assert.NoError(t, err)
 
-	err = auth.InvalidateChannels("testRole", false, 1)
+	err = auth.InvalidateDefaultChannels("testRole", false, 1)
 	assert.Equal(t, nil, err)
 
 	role2, err := auth.GetRole("testRole")
@@ -388,7 +480,7 @@ func TestRebuildChannelsError(t *testing.T) {
 	err = auth.Save(role)
 	assert.NoError(t, err)
 
-	assert.Equal(t, nil, auth.InvalidateChannels("testRole2", false, 1))
+	assert.Equal(t, nil, auth.InvalidateDefaultChannels("testRole2", false, 1))
 
 	computer.err = errors.New("I'm sorry, Dave.")
 
@@ -634,7 +726,7 @@ func TestConcurrentUserWrites(t *testing.T) {
 			t.Errorf("User is nil prior to invalidate channels, error: %v", getErr)
 		}
 
-		invalidateErr := auth.InvalidateChannels(username, true, 1)
+		invalidateErr := auth.InvalidateDefaultChannels(username, true, 1)
 		if invalidateErr != nil {
 			t.Errorf("Error invalidating user's channels: %v", invalidateErr)
 		}
@@ -1361,7 +1453,7 @@ type mockComputerV2 struct {
 	err          error
 }
 
-func (m mockComputerV2) ComputeChannelsForPrincipal(ctx context.Context, principal Principal) (ch.TimedSet, error) {
+func (m mockComputerV2) ComputeChannelsForPrincipal(ctx context.Context, principal Principal, scope, collection string) (ch.TimedSet, error) {
 	if user, ok := principal.(User); ok {
 		return m.channels[user.Name()].Copy(), nil
 	} else {
@@ -1379,13 +1471,13 @@ func (m mockComputerV2) addRoleChannels(t *testing.T, auth *Authenticator, roleN
 	}
 
 	m.roleChannels[roleName].Add(ch.AtSequence(ch.BaseSetOf(t, channelName), invalSeq))
-	err := auth.InvalidateChannels(roleName, false, invalSeq)
+	err := auth.InvalidateDefaultChannels(roleName, false, invalSeq)
 	assert.NoError(t, err)
 }
 
 func (m mockComputerV2) removeRoleChannel(t *testing.T, auth *Authenticator, roleName, channelName string, invalSeq uint64) {
 	delete(m.roleChannels[roleName], channelName)
-	err := auth.InvalidateChannels(roleName, false, invalSeq)
+	err := auth.InvalidateDefaultChannels(roleName, false, invalSeq)
 	assert.NoError(t, err)
 }
 
@@ -2743,7 +2835,7 @@ func TestInvalidateChannels(t *testing.T) {
 			auth := NewAuthenticator(leakyDataStore, nil, DefaultAuthenticatorOptions())
 
 			// Invalidate channels on non-existent user / role and ensure no error
-			err := auth.InvalidateChannels(testCase.name, testCase.isUser, 0)
+			err := auth.InvalidateDefaultChannels(testCase.name, testCase.isUser, 0)
 			assert.NoError(t, err)
 
 			// Create user / role
@@ -2762,7 +2854,7 @@ func TestInvalidateChannels(t *testing.T) {
 			enableRetry := false
 			// If subdoc operations are supported, perform an initial invalidation at seq 5
 			if leakyBucket.IsSupported(sgbucket.BucketStoreFeatureSubdocOperations) {
-				err := auth.InvalidateChannels(testCase.name, testCase.isUser, 5)
+				err := auth.InvalidateDefaultChannels(testCase.name, testCase.isUser, 5)
 				assert.NoError(t, err)
 
 			} else {
@@ -2770,14 +2862,14 @@ func TestInvalidateChannels(t *testing.T) {
 				leakyDataStore.SetUpdateCallback(func(key string) {
 					if enableRetry {
 						enableRetry = false
-						err = auth.InvalidateChannels(testCase.name, testCase.isUser, 5)
+						err = auth.InvalidateDefaultChannels(testCase.name, testCase.isUser, 5)
 						assert.NoError(t, err)
 					}
 				})
 			}
 
 			enableRetry = true
-			err = auth.InvalidateChannels(testCase.name, testCase.isUser, 10)
+			err = auth.InvalidateDefaultChannels(testCase.name, testCase.isUser, 10)
 			assert.NoError(t, err)
 
 			// Ensure the inval seq was set to 5 (raw get to avoid rebuild)
@@ -2797,7 +2889,7 @@ func TestInvalidateChannels(t *testing.T) {
 			assert.Equal(t, expectedValue, princCheck.GetChannelInvalSeq())
 
 			// Invalidate again and ensure existing value remains
-			err = auth.InvalidateChannels(testCase.name, testCase.isUser, 20)
+			err = auth.InvalidateDefaultChannels(testCase.name, testCase.isUser, 20)
 			assert.NoError(t, err)
 
 			_, err = leakyDataStore.Get(docID, &princCheck)

--- a/auth/collection_access.go
+++ b/auth/collection_access.go
@@ -15,9 +15,9 @@ import (
 	ch "github.com/couchbase/sync_gateway/channels"
 )
 
-// PrincipalCollectionAccess defines the common interface for managing channel access for a role or user for
-// a single collection.
-type PrincipalCollectionAccess interface {
+// CollectionChannelAPI defines helper functions for interacting with a principal's CollectionAccess set using
+// scope and collection name.  Mirrors the default collection functionality defined on Principal
+type CollectionChannelAPI interface {
 
 	// Retrieve all channels for a collection
 	CollectionChannels(scope, collection string) ch.TimedSet
@@ -58,11 +58,14 @@ type PrincipalCollectionAccess interface {
 	authorizeAllCollectionChannels(scope, collection string, channels base.Set) error
 
 	// Returns an error if the Principal does not have access to any of the channels in the set, for the specified collection
-	authorizeAnyCollectionChannel(scope, collection string, channels base.Set) error
+	AuthorizeAnyCollectionChannel(scope, collection string, channels base.Set) error
+
+	// Retrieves or creates collection access entry on principal for specified scope and collection
+	getOrCreateCollectionAccess(scope, collection string) *CollectionAccess
 }
 
-// UserCollection defines the interface for managing channel access that is supported by users but not roles.
-type UserCollectionAccess interface {
+// UserCollectionChannelAPI defines the interface for managing channel access that is supported by users but not roles.
+type UserCollectionChannelAPI interface {
 	// Retrieves JWT channels for a collection
 	CollectionJWTChannels(scope, collection string) ch.TimedSet
 
@@ -89,16 +92,101 @@ type UserCollectionAccess interface {
 	expandCollectionWildCardChannel(scope, collection string, channels base.Set) base.Set
 }
 
+// PrincipalCollectionAccess defines a common interface for principal access control.  This interface is
+// implemented by CollectionAccess for named collection access,
+// and by roleImpl for the _default._default collection.
+type PrincipalCollectionAccess interface {
+	// The set of channels the Principal belongs to for the channel, and what sequence access was granted.
+	// Returns nil if invalidated.
+	// For both roles and users, the set of channels is the union of ExplicitChannels, JWTChannels, and any channels
+	// they are granted through a sync function.
+	//
+	// NOTE: channels a user has access to through a role are *not* included in Channels(), so the user could have
+	// access to more documents than included in Channels. CanSeeChannel will also check against the user's roles.
+	Channels() ch.TimedSet
+
+	// Sets the explicit channels the Principal has access to.
+	SetExplicitChannels(ch.TimedSet, uint64)
+
+	// The channels the Principal was explicitly granted access to thru the admin API.
+	ExplicitChannels() ch.TimedSet
+
+	// sets the computed channels for the collection
+	setChannels(ch.TimedSet)
+
+	// The set of invalidated channels
+	// Returns nil if not invalidated
+	InvalidatedChannels() ch.TimedSet
+
+	GetChannelInvalSeq() uint64
+	SetChannelInvalSeq(invalSeq uint64)
+	ChannelHistory() TimedSetHistory
+	SetChannelHistory(h TimedSetHistory)
+}
+
+// UserCollectionAccess functions the same as PrincipalCollectionAccess, but for user-specific properties.
+type UserCollectionAccess interface {
+	JWTChannels() ch.TimedSet
+	SetJWTChannels(ch.TimedSet, uint64)
+}
+
 // Defines channel grants and history for a single collection
 type CollectionAccess struct {
 	ExplicitChannels_ ch.TimedSet     `json:"admin_channels,omitempty"`
 	Channels_         ch.TimedSet     `json:"all_channels,omitempty"`
 	ChannelHistory_   TimedSetHistory `json:"channel_history,omitempty"`   // Added to when a previously granted channel is revoked. Calculated inside of rebuildChannels.
 	ChannelInvalSeq   uint64          `json:"channel_inval_seq,omitempty"` // Sequence at which the channels were invalidated. Data remains in Channels_ for history calculation.
-	JWTChannels       ch.TimedSet     `json:"jwt_channels,omitempty"`      // TODO: JWT properties should only be populated for user but would like to share scope/collection map
+	JWTChannels_      ch.TimedSet     `json:"jwt_channels,omitempty"`      // TODO: JWT properties should only be populated for user but would like to share scope/collection map
 	JWTLastUpdated    *time.Time      `json:"jwt_last_updated,omitempty"`
+}
+
+func (ca *CollectionAccess) ExplicitChannels() ch.TimedSet {
+	return ca.ExplicitChannels_
+}
+
+func (ca *CollectionAccess) SetExplicitChannels(channels ch.TimedSet, invalSeq uint64) {
+	ca.ExplicitChannels_ = channels
+	ca.SetChannelInvalSeq(invalSeq)
+}
+
+func (ca *CollectionAccess) JWTChannels() ch.TimedSet {
+	return ca.JWTChannels_
+}
+
+func (ca *CollectionAccess) GetChannelInvalSeq() uint64 {
+	return ca.ChannelInvalSeq
+}
+
+func (ca *CollectionAccess) InvalidatedChannels() ch.TimedSet {
+	if ca.ChannelInvalSeq != 0 {
+		return ca.Channels_
+	}
+	return nil
+}
+
+func (ca *CollectionAccess) ChannelHistory() TimedSetHistory {
+	return ca.ChannelHistory_
+}
+
+func (ca *CollectionAccess) SetChannelHistory(history TimedSetHistory) {
+	ca.ChannelHistory_ = history
+}
+
+func (ca *CollectionAccess) SetChannelInvalSeq(invalSeq uint64) {
+	ca.ChannelInvalSeq = invalSeq
+}
+
+func (ca *CollectionAccess) setChannels(channels ch.TimedSet) {
+	ca.Channels_ = channels
 }
 
 func (ca *CollectionAccess) CanSeeChannel(channel string) bool {
 	return ca.Channels().Contains(channel) || ca.Channels().Contains(ch.UserStarChannel)
+}
+
+func (ca *CollectionAccess) Channels() ch.TimedSet {
+	if ca.ChannelInvalSeq != 0 {
+		return nil
+	}
+	return ca.Channels_
 }

--- a/auth/collection_access_test.go
+++ b/auth/collection_access_test.go
@@ -33,16 +33,23 @@ func TestUserCollectionAccess(t *testing.T) {
 	// User with no access:
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
-	auth := NewAuthenticator(bucket.GetSingleDataStore(), nil, DefaultAuthenticatorOptions())
+	options := DefaultAuthenticatorOptions()
+	options.Collections = map[string]map[string]struct{}{
+		"scope1": {
+			"collection1": struct{}{},
+		},
+	}
+	auth := NewAuthenticator(bucket.GetSingleDataStore(), nil, options)
 	user, _ := auth.NewUser("foo", "password", nil)
 	scope := "scope1"
 	collection := "collection1"
 	otherScope := "scope2"
 	otherCollection := "collection2"
 	nonMatchingCollections := [][2]string{{base.DefaultScope, base.DefaultCollection}, {scope, otherCollection}, {otherScope, collection}, {otherScope, otherCollection}}
-	// Default collection checks
-	assert.Equal(t, ch.BaseSetOf(t, "!"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
+	// Default collection checks - should not have access based on authenticator
+	assert.Equal(t, ch.BaseSetOf(t), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
 	assert.False(t, user.CanSeeChannel("x"))
+	assert.False(t, user.CanSeeChannel("!"))
 	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t)))
 	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x")))
 	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x", "y")))
@@ -57,8 +64,8 @@ func TestUserCollectionAccess(t *testing.T) {
 	assert.False(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t, "x", "y")))
 	assert.False(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t, "*")))
 	assert.False(t, user.authorizeAllCollectionChannels(scope, collection, ch.BaseSetOf(t, "*")) == nil)
-	assert.False(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "x", "y")) == nil)
-	assert.False(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t)) == nil)
+	assert.False(t, user.AuthorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.AuthorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t)) == nil)
 
 	// User with access to one channel in named collection:
 	user.setCollectionChannels(scope, collection, ch.AtSequence(ch.BaseSetOf(t, "x"), 1))
@@ -69,22 +76,23 @@ func TestUserCollectionAccess(t *testing.T) {
 	assert.False(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t, "x", "y")))
 	assert.False(t, user.authorizeAllCollectionChannels(scope, collection, ch.BaseSetOf(t, "x", "y")) == nil)
 	assert.False(t, user.authorizeAllCollectionChannels(scope, collection, ch.BaseSetOf(t, "*")) == nil)
-	assert.True(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "x", "y")) == nil)
-	assert.False(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "y")) == nil)
-	assert.False(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t)) == nil)
+	assert.True(t, user.AuthorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.AuthorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "y")) == nil)
+	assert.False(t, user.AuthorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t)) == nil)
+
 	// Non-matching collection checks
 	for _, pair := range nonMatchingCollections {
 		s := pair[0]
 		c := pair[1]
-		assert.Equal(t, ch.BaseSetOf(t, "!"), user.expandCollectionWildCardChannel(s, c, ch.BaseSetOf(t, "*")))
+		assert.Equal(t, ch.BaseSetOf(t), user.expandCollectionWildCardChannel(s, c, ch.BaseSetOf(t, "*")))
 		assert.True(t, canSeeAllCollectionChannels(s, c, user, ch.BaseSetOf(t)))
 		assert.False(t, canSeeAllCollectionChannels(s, c, user, ch.BaseSetOf(t, "x")))
 		assert.False(t, canSeeAllCollectionChannels(s, c, user, ch.BaseSetOf(t, "x", "y")))
 		assert.False(t, user.authorizeAllCollectionChannels(s, c, ch.BaseSetOf(t, "x", "y")) == nil)
 		assert.False(t, user.authorizeAllCollectionChannels(s, c, ch.BaseSetOf(t, "*")) == nil)
-		assert.False(t, user.authorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t, "x", "y")) == nil)
-		assert.False(t, user.authorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t, "y")) == nil)
-		assert.False(t, user.authorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t)) == nil)
+		assert.False(t, user.AuthorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t, "x", "y")) == nil)
+		assert.False(t, user.AuthorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t, "y")) == nil)
+		assert.False(t, user.AuthorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t)) == nil)
 	}
 
 	// User with access to two channels:
@@ -98,29 +106,29 @@ func TestUserCollectionAccess(t *testing.T) {
 	assert.False(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t, "x", "y", "z")))
 	assert.True(t, user.authorizeAllCollectionChannels(scope, collection, ch.BaseSetOf(t, "x", "y")) == nil)
 	assert.False(t, user.authorizeAllCollectionChannels(scope, collection, ch.BaseSetOf(t, "*")) == nil)
-	assert.True(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "x", "y")) == nil)
-	assert.True(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "y")) == nil)
-	assert.False(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "z")) == nil)
-	assert.False(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t)) == nil)
+	assert.True(t, user.AuthorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.True(t, user.AuthorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "y")) == nil)
+	assert.False(t, user.AuthorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "z")) == nil)
+	assert.False(t, user.AuthorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t)) == nil)
 	// Non-matching collection checks
 	for _, pair := range nonMatchingCollections {
 		s := pair[0]
 		c := pair[1]
-		assert.Equal(t, ch.BaseSetOf(t, "!"), user.expandCollectionWildCardChannel(s, c, ch.BaseSetOf(t, "*")))
+		assert.Equal(t, ch.BaseSetOf(t), user.expandCollectionWildCardChannel(s, c, ch.BaseSetOf(t, "*")))
 		assert.True(t, canSeeAllCollectionChannels(s, c, user, ch.BaseSetOf(t)))
 		assert.False(t, canSeeAllCollectionChannels(s, c, user, ch.BaseSetOf(t, "x")))
 		assert.False(t, canSeeAllCollectionChannels(s, c, user, ch.BaseSetOf(t, "x", "y")))
 		assert.False(t, user.authorizeAllCollectionChannels(s, c, ch.BaseSetOf(t, "x", "y")) == nil)
 		assert.False(t, user.authorizeAllCollectionChannels(s, c, ch.BaseSetOf(t, "*")) == nil)
-		assert.False(t, user.authorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t, "x", "y")) == nil)
-		assert.False(t, user.authorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t, "y")) == nil)
-		assert.False(t, user.authorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t)) == nil)
+		assert.False(t, user.AuthorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t, "x", "y")) == nil)
+		assert.False(t, user.AuthorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t, "y")) == nil)
+		assert.False(t, user.AuthorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t)) == nil)
 	}
 
 	// User with wildcard access:
 	user.setCollectionChannels(scope, collection, ch.AtSequence(ch.BaseSetOf(t, "*", "q"), 1))
 	// Legacy default collection checks
-	assert.Equal(t, ch.BaseSetOf(t, "!"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
+	assert.Equal(t, ch.BaseSetOf(t), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
 	assert.False(t, user.CanSeeChannel("*"))
 	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t)))
 	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x")))
@@ -138,23 +146,23 @@ func TestUserCollectionAccess(t *testing.T) {
 	assert.True(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t, "x", "y", "z")))
 	assert.True(t, user.authorizeAllCollectionChannels(scope, collection, ch.BaseSetOf(t, "x", "y")) == nil)
 	assert.True(t, user.authorizeAllCollectionChannels(scope, collection, ch.BaseSetOf(t, "*")) == nil)
-	assert.True(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "x", "y")) == nil)
-	assert.True(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "y")) == nil)
-	assert.True(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "z")) == nil)
-	assert.True(t, user.authorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t)) == nil)
+	assert.True(t, user.AuthorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.True(t, user.AuthorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "y")) == nil)
+	assert.True(t, user.AuthorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t, "z")) == nil)
+	assert.True(t, user.AuthorizeAnyCollectionChannel(scope, collection, ch.BaseSetOf(t)) == nil)
 	// Non-matching collection checks
 	for _, pair := range nonMatchingCollections {
 		s := pair[0]
 		c := pair[1]
-		assert.Equal(t, ch.BaseSetOf(t, "!"), user.expandCollectionWildCardChannel(s, c, ch.BaseSetOf(t, "*")))
+		assert.Equal(t, ch.BaseSetOf(t), user.expandCollectionWildCardChannel(s, c, ch.BaseSetOf(t, "*")))
 		assert.True(t, canSeeAllCollectionChannels(s, c, user, ch.BaseSetOf(t)))
 		assert.False(t, canSeeAllCollectionChannels(s, c, user, ch.BaseSetOf(t, "x")))
 		assert.False(t, canSeeAllCollectionChannels(s, c, user, ch.BaseSetOf(t, "x", "y")))
 		assert.False(t, user.authorizeAllCollectionChannels(s, c, ch.BaseSetOf(t, "x", "y")) == nil)
 		assert.False(t, user.authorizeAllCollectionChannels(s, c, ch.BaseSetOf(t, "*")) == nil)
-		assert.False(t, user.authorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t, "x", "y")) == nil)
-		assert.False(t, user.authorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t, "y")) == nil)
-		assert.False(t, user.authorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t)) == nil)
+		assert.False(t, user.AuthorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t, "x", "y")) == nil)
+		assert.False(t, user.AuthorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t, "y")) == nil)
+		assert.False(t, user.AuthorizeAnyCollectionChannel(s, c, ch.BaseSetOf(t)) == nil)
 	}
 }
 

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -1243,7 +1243,8 @@ func TestJWTRolesChannels(t *testing.T) {
 				user.SetJWTLastUpdated(*updates.JWTLastUpdated)
 
 				require.NoError(t, auth.rebuildRoles(user))
-				require.NoError(t, auth.rebuildChannels(user))
+				_, rebuildErr := auth.rebuildChannels(user)
+				require.NoError(t, rebuildErr)
 
 				if user.RoleNames() == nil {
 					require.Empty(t, login.expectedRoles, "user's roles were nil when we expected roles")

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -24,33 +24,6 @@ type Principal interface {
 	Sequence() uint64
 	SetSequence(sequence uint64)
 
-	// The set of channels the Principal belongs to, and what sequence access was granted.
-	// Returns nil if invalidated.
-	// For both roles and users, the set of channels is the union of ExplicitChannels, JWTChannels, and any channels
-	// they are granted through a sync function.
-	//
-	// NOTE: channels a user has access to through a role are *not* included in Channels(), so the user could have
-	// access to more documents than included in Channels. CanSeeChannel will also check against the user's roles.
-	Channels() ch.TimedSet
-
-	// The channels the Principal was explicitly granted access to thru the admin API.
-	ExplicitChannels() ch.TimedSet
-
-	// Sets the explicit channels the Principal has access to.
-	SetExplicitChannels(ch.TimedSet, uint64)
-
-	GetChannelInvalSeq() uint64
-
-	SetChannelInvalSeq(uint64)
-
-	// The set of invalidated channels
-	// Returns nil if not invalidated
-	InvalidatedChannels() ch.TimedSet
-
-	ChannelHistory() TimedSetHistory
-
-	SetChannelHistory(history TimedSetHistory)
-
 	// Returns true if the Principal has access to the given channel.
 	CanSeeChannel(channel string) bool
 
@@ -71,7 +44,6 @@ type Principal interface {
 	DocID() string
 	accessViewKey() string
 	validate() error
-	setChannels(ch.TimedSet)
 
 	// Cas value for the associated principal document in the bucket
 	Cas() uint64
@@ -80,7 +52,13 @@ type Principal interface {
 	setDeleted(bool)
 	IsDeleted() bool
 
+	// Principal includes the PrincipalCollectionAccess interface for operations against
+	// the _default._default collection (stored directly on the principal for backward
+	// compatibility)
 	PrincipalCollectionAccess
+
+	// Principals implement the CollectionChannelAPI for collection-scoped operations
+	CollectionChannelAPI
 }
 
 // Role is basically the same as Principal, just concrete. Users can inherit channels from Roles.
@@ -122,8 +100,6 @@ type User interface {
 
 	JWTRoles() ch.TimedSet
 	SetJWTRoles(ch.TimedSet, uint64)
-	JWTChannels() ch.TimedSet
-	SetJWTChannels(ch.TimedSet, uint64)
 	JWTIssuer() string
 	SetJWTIssuer(string)
 	JWTLastUpdated() time.Time
@@ -162,6 +138,8 @@ type User interface {
 	FilterToAvailableChannels(channels ch.Set) (filtered ch.TimedSet, removed []string)
 
 	setRolesSince(ch.TimedSet)
+
+	UserCollectionChannelAPI
 
 	UserCollectionAccess
 }

--- a/auth/role.go
+++ b/auth/role.go
@@ -96,10 +96,23 @@ func (pair *GrantHistorySequencePair) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (role *roleImpl) initRole(name string, channels base.Set) error {
-	channels = ch.ExpandingStar(channels)
+func (role *roleImpl) initRole(name string, channels base.Set, collections map[string]map[string]struct{}) error {
 	role.Name_ = name
-	role.ExplicitChannels_ = ch.AtSequence(channels, 1)
+	// Grant the user the specified channels for all specified collections.  If none are
+	// specified, grant to the default collection.
+	if len(collections) == 0 {
+		if err := role.initChannels(base.DefaultScope, base.DefaultCollection, channels); err != nil {
+			return err
+		}
+	} else {
+		for scopeName, scope := range collections {
+			for collectionName, _ := range scope {
+				if err := role.initChannels(scopeName, collectionName, channels); err != nil {
+					return err
+				}
+			}
+		}
+	}
 	return role.validate()
 }
 
@@ -204,7 +217,29 @@ func (auth *Authenticator) NewRole(name string, channels base.Set) (Role, error)
 		role.SetChannelHistory(existingRole.ChannelHistory())
 	}
 
-	if err := role.initRole(name, channels); err != nil {
+	if err := role.initRole(name, channels, auth.Collections); err != nil {
+		return nil, err
+	}
+	if _, err := auth.rebuildChannels(role); err != nil {
+		return nil, err
+	}
+	return role, nil
+}
+
+// Creates a new Role object.
+func (auth *Authenticator) NewRoleNoChannels(name string) (Role, error) {
+	role := &roleImpl{}
+	existingRole, err := auth.GetRoleIncDeleted(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if existingRole != nil && existingRole.IsDeleted() {
+		role.SetCas(existingRole.Cas())
+		role.SetChannelHistory(existingRole.ChannelHistory())
+	}
+
+	if err := role.initRole(name, nil, nil); err != nil {
 		return nil, err
 	}
 	if _, err := auth.rebuildChannels(role); err != nil {

--- a/auth/role.go
+++ b/auth/role.go
@@ -207,7 +207,7 @@ func (auth *Authenticator) NewRole(name string, channels base.Set) (Role, error)
 	if err := role.initRole(name, channels); err != nil {
 		return nil, err
 	}
-	if err := auth.rebuildChannels(role); err != nil {
+	if _, err := auth.rebuildChannels(role); err != nil {
 		return nil, err
 	}
 	return role, nil
@@ -369,11 +369,4 @@ func authorizeAnyChannel(princ Principal, channels base.Set) error {
 		return nil
 	}
 	return princ.UnauthError("You are not allowed to see this")
-}
-
-func (ca *CollectionAccess) Channels() ch.TimedSet {
-	if ca.ChannelInvalSeq != 0 {
-		return nil
-	}
-	return ca.Channels_
 }

--- a/auth/role_collection_access.go
+++ b/auth/role_collection_access.go
@@ -60,7 +60,6 @@ func (role *roleImpl) CollectionChannels(scope, collection string) ch.TimedSet {
 		return cc.Channels_
 	}
 	return nil
-	
 }
 
 func (role *roleImpl) CollectionExplicitChannels(scope, collection string) ch.TimedSet {
@@ -175,6 +174,7 @@ func (role *roleImpl) canSeeCollectionChannelSince(scope, collection, channel st
 		if seq.Sequence == 0 {
 			seq = cc.Channels()[ch.UserStarChannel]
 		}
+		return seq.Sequence
 	}
 	return 0
 }
@@ -220,4 +220,12 @@ func (role *roleImpl) AuthorizeAnyCollectionChannel(scope, collection string, ch
 		}
 	}
 	return role.UnauthError("You are not allowed to see this")
+}
+
+// initChannels grants the specified channels to the role as an admin grant, and performs
+// validation on the channel set.
+func (role *roleImpl) initChannels(scopeName, collectionName string, channels base.Set) error {
+	channels = ch.ExpandingStar(channels)
+	role.SetCollectionExplicitChannels(scopeName, collectionName, ch.AtSequence(channels, 1), 0)
+	return role.CollectionExplicitChannels(scopeName, collectionName).Validate()
 }

--- a/auth/role_collection_access.go
+++ b/auth/role_collection_access.go
@@ -58,9 +58,9 @@ func (role *roleImpl) CollectionChannels(scope, collection string) ch.TimedSet {
 			return nil
 		}
 		return cc.Channels_
-	} else {
-		return nil
 	}
+	return nil
+	
 }
 
 func (role *roleImpl) CollectionExplicitChannels(scope, collection string) ch.TimedSet {

--- a/auth/role_test.go
+++ b/auth/role_test.go
@@ -24,7 +24,7 @@ func TestInitRole(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 	// Check initializing role with legal role name.
 	role := &roleImpl{}
-	assert.NoError(t, role.initRole("Music", channels.BaseSetOf(t, "Spotify", "Youtube")))
+	assert.NoError(t, role.initRole("Music", channels.BaseSetOf(t, "Spotify", "Youtube"), nil))
 	assert.Equal(t, "Music", role.Name_)
 	assert.Equal(t, channels.TimedSet{
 		"Spotify": channels.NewVbSimpleSequence(0x1),
@@ -32,11 +32,11 @@ func TestInitRole(t *testing.T) {
 
 	// Check initializing role with illegal role name.
 	role = &roleImpl{}
-	assert.Error(t, role.initRole("Music/", channels.BaseSetOf(t, "Spotify", "Youtube")))
-	assert.Error(t, role.initRole("Music:", channels.BaseSetOf(t, "Spotify", "Youtube")))
-	assert.Error(t, role.initRole("Music,", channels.BaseSetOf(t, "Spotify", "Youtube")))
-	assert.Error(t, role.initRole(".", channels.BaseSetOf(t, "Spotify", "Youtube")))
-	assert.Error(t, role.initRole("\xf7,", channels.BaseSetOf(t, "Spotify", "Youtube")))
+	assert.Error(t, role.initRole("Music/", channels.BaseSetOf(t, "Spotify", "Youtube"), nil))
+	assert.Error(t, role.initRole("Music:", channels.BaseSetOf(t, "Spotify", "Youtube"), nil))
+	assert.Error(t, role.initRole("Music,", channels.BaseSetOf(t, "Spotify", "Youtube"), nil))
+	assert.Error(t, role.initRole(".", channels.BaseSetOf(t, "Spotify", "Youtube"), nil))
+	assert.Error(t, role.initRole("\xf7,", channels.BaseSetOf(t, "Spotify", "Youtube"), nil))
 }
 
 func TestAuthorizeChannelsRole(t *testing.T) {

--- a/auth/user.go
+++ b/auth/user.go
@@ -86,7 +86,7 @@ func (auth *Authenticator) NewUser(username string, password string, channels ba
 	if err := user.initRole(username, channels); err != nil {
 		return nil, err
 	}
-	if err := auth.rebuildChannels(user); err != nil {
+	if _, err := auth.rebuildChannels(user); err != nil {
 		return nil, err
 	}
 

--- a/auth/user.go
+++ b/auth/user.go
@@ -86,24 +86,8 @@ func (auth *Authenticator) NewUser(username string, password string, channels ba
 		auth:         auth,
 		userImplBody: userImplBody{RolesSince_: ch.TimedSet{}},
 	}
-	if err := user.initRole(username, channels); err != nil {
+	if err := user.initRole(username, channels, auth.Collections); err != nil {
 		return nil, err
-	}
-
-	// Grant the user the specified channels for all collections on the authenticator.  If none are
-	// specified, grant to the default collection.
-	if len(auth.Collections) == 0 {
-		if err := user.initChannels(base.DefaultScope, base.DefaultCollection, channels); err != nil {
-			return nil, err
-		}
-	} else {
-		for scopeName, scope := range auth.Collections {
-			for collectionName, _ := range scope {
-				if err := user.initChannels(scopeName, collectionName, channels); err != nil {
-					return nil, err
-				}
-			}
-		}
 	}
 
 	if _, err := auth.rebuildChannels(user); err != nil {
@@ -129,7 +113,7 @@ func (auth *Authenticator) NewUserNoChannels(username string, password string) (
 		auth:         auth,
 		userImplBody: userImplBody{RolesSince_: ch.TimedSet{}},
 	}
-	if err := user.initRole(username, nil); err != nil {
+	if err := user.initRole(username, nil, nil); err != nil {
 		return nil, err
 	}
 	if _, err := auth.rebuildChannels(user); err != nil {

--- a/auth/user_collection_access.go
+++ b/auth/user_collection_access.go
@@ -21,7 +21,7 @@ func (user *userImpl) CollectionJWTChannels(scope, collection string) ch.TimedSe
 	}
 
 	if cc, ok := user.getCollectionAccess(scope, collection); ok {
-		return cc.JWTChannels
+		return cc.JWTChannels()
 	}
 	return nil
 }
@@ -33,7 +33,7 @@ func (user *userImpl) SetCollectionJWTChannels(scope, collection string, channel
 	}
 
 	cc := user.getOrCreateCollectionAccess(scope, collection)
-	cc.JWTChannels = channels
+	cc.JWTChannels_ = channels
 	cc.ChannelInvalSeq = invalSeq
 }
 
@@ -57,8 +57,7 @@ func (user *userImpl) InheritedCollectionChannels(scope, collection string) ch.T
 		channels.AddAtSequence(role.CollectionChannels(scope, collection), roleSince.Sequence)
 	}
 
-	// TODO: should warning threshold be per-collection, or cross-collection?  If the latter, hard to compute, as
-	//  we lazily fetch channels per collection
+	// Warning threshold is per-collection, as we lazily load per-collection channel information
 	user.warnChanThresholdOnce.Do(func() {
 		if channelsPerUserThreshold := user.auth.ChannelsWarningThreshold; channelsPerUserThreshold != nil {
 			channelCount := len(channels)
@@ -70,4 +69,34 @@ func (user *userImpl) InheritedCollectionChannels(scope, collection string) ch.T
 	})
 
 	return channels
+}
+
+// Checks for user access to any channel in the set, including access inherited via roles
+func (user *userImpl) AuthorizeAnyCollectionChannel(scope, collection string, channels base.Set) error {
+
+	if base.IsDefaultCollection(scope, collection) {
+		return user.AuthorizeAnyChannel(channels)
+	}
+
+	// User access
+	if ca, ok := user.getCollectionAccess(scope, collection); ok {
+		if len(channels) > 0 {
+			for channel := range channels {
+				if ca.CanSeeChannel(channel) {
+					return nil
+				}
+			}
+		} else if ca.Channels().Contains(ch.UserStarChannel) {
+			return nil
+		}
+	}
+
+	// Inherited role access
+	for _, role := range user.GetRoles() {
+		if role.AuthorizeAnyCollectionChannel(scope, collection, channels) == nil {
+			return nil
+		}
+	}
+
+	return user.UnauthError("You are not allowed to see this")
 }

--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -364,6 +364,10 @@ func (c *Collection) SubdocInsert(k string, fieldPath string, cas uint64, value 
 		return ErrAlreadyExists
 	}
 
+	if errors.Is(mutateErr, gocbcore.ErrPathNotFound) {
+		return ErrPathNotFound
+	}
+
 	return mutateErr
 
 }

--- a/base/error.go
+++ b/base/error.go
@@ -46,7 +46,7 @@ var (
 	ErrChannelFeed           = &sgError{"Error while building channel feed"}
 	ErrXattrNotFound         = &sgError{"Xattr Not Found"}
 	ErrTimeout               = &sgError{"Operation timed out"}
-	ErrPathNotFound          = &sgError{"Subdoc path not found"}
+	ErrPathNotFound          = &sgError{"Path not found"}
 
 	// ErrPartialViewErrors is returned if the view call contains any partial errors.
 	// This is more of a warning, and inspecting ViewResult.Errors is required for detail.

--- a/base/error.go
+++ b/base/error.go
@@ -46,6 +46,7 @@ var (
 	ErrChannelFeed           = &sgError{"Error while building channel feed"}
 	ErrXattrNotFound         = &sgError{"Xattr Not Found"}
 	ErrTimeout               = &sgError{"Operation timed out"}
+	ErrPathNotFound          = &sgError{"Subdoc path not found"}
 
 	// ErrPartialViewErrors is returned if the view call contains any partial errors.
 	// This is more of a warning, and inspecting ViewResult.Errors is required for detail.

--- a/db/access_test.go
+++ b/db/access_test.go
@@ -1,0 +1,73 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDynamicChannelGrant(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAccess)
+
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+	dbCollection := db.GetSingleDatabaseCollectionWithUser()
+
+	db.ChannelMapper = channels.NewChannelMapper(`
+	function(doc) {
+		if(doc.type == "setaccess") {
+			channel(doc.channel);
+			access(doc.owner, doc.channel);
+		} else { 
+			channel(doc.channel)
+		}
+	}`, 0)
+
+	a := dbCollection.Authenticator(ctx)
+	user, err := a.NewUser("user1", "letmein", nil)
+	assert.NoError(t, err)
+	assert.NoError(t, a.Save(user))
+	dbCollection.user = user
+
+	// Create a document in channel chan1
+	doc1Body := Body{"channel": "chan1", "greeting": "hello"}
+	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "doc1", doc1Body, []string{"1-a"}, false)
+	require.NoError(t, err)
+
+	// Verify user cannot access document
+	existingBody, err := dbCollection.Get1xBody(ctx, "doc1")
+	require.Error(t, err)
+
+	// Write access granting document
+	grantingBody := Body{"type": "setaccess", "owner": "user1", "channel": "chan1"}
+	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "grant1", grantingBody, []string{"1-a"}, false)
+	require.NoError(t, err)
+
+	// Verify reloaded user can access document
+	require.NoError(t, dbCollection.ReloadUser(ctx))
+	existingBody, err = dbCollection.Get1xBody(ctx, "doc1")
+	require.NoError(t, err)
+	require.NotNil(t, existingBody)
+	assert.Equal(t, "hello", existingBody["greeting"])
+
+	// Create a document in channel chan2
+	doc2Body := Body{"channel": "chan2", "greeting": "hello"}
+	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "doc2", doc2Body, []string{"1-a"}, false)
+	require.NoError(t, err)
+
+	// Write access granting document for chan2 (tests invalidation when channels/inval_seq exists)
+	grantingBody = Body{"type": "setaccess", "owner": "user1", "channel": "chan2"}
+	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "grant2", grantingBody, []string{"1-a"}, false)
+	require.NoError(t, err)
+
+	// Verify user can now access both documents
+	require.NoError(t, dbCollection.ReloadUser(ctx))
+	existingBody, err = dbCollection.Get1xBody(ctx, "doc1")
+	require.NoError(t, err)
+	existingBody, err = dbCollection.Get1xBody(ctx, "doc2")
+	require.NoError(t, err)
+}

--- a/db/access_test.go
+++ b/db/access_test.go
@@ -1,3 +1,11 @@
+//  Copyright 2022-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
 package db
 
 import (

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -906,7 +906,7 @@ func TestLowSequenceHandlingAcrossChannels(t *testing.T) {
 func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 
 	if !base.TestsUseDefaultCollection() {
-		t.Skip("Disabled for non-default collection until CBG-2554")
+		t.Skip("Disabled for non-default collection based on use of GetPrincipalForTest")
 	}
 
 	if base.TestUseXattrs() {

--- a/db/changes.go
+++ b/db/changes.go
@@ -657,7 +657,7 @@ func (db *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Context
 		// have been available to the user:
 		channelsSince := channels.TimedSetByCollectionID{}
 		if db.user != nil {
-			chansSince, channelsRemoved := db.user.FilterToAvailableChannels(chans)
+			chansSince, channelsRemoved := db.user.FilterToAvailableCollectionChannels(db.ScopeName(), db.Name(), chans)
 			if len(channelsRemoved) > 0 {
 				base.InfofCtx(ctx, base.KeyChanges, "Channels %s request without access by user %s", base.UD(channelsRemoved), base.UD(db.user.Name()))
 			}
@@ -1020,7 +1020,7 @@ func (db *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Context
 				return
 			}
 			if userChanged && db.user != nil {
-				newChannelsSince, _ := db.user.FilterToAvailableChannels(chans)
+				newChannelsSince, _ := db.user.FilterToAvailableCollectionChannels(db.ScopeName(), db.Name(), chans)
 				// change when we support multiple collections
 				singleCollectionChannels := newChannelsSince.CompareKeys(channelsSince[singleCollectionID])
 

--- a/db/changes.go
+++ b/db/changes.go
@@ -317,7 +317,7 @@ func UserHasDocAccess(ctx context.Context, db *DatabaseCollectionWithUser, docID
 		return true, nil
 	}
 
-	authErr := db.user.AuthorizeAnyChannel(currentRev.Channels)
+	authErr := db.user.AuthorizeAnyCollectionChannel(db.ScopeName(), db.Name(), currentRev.Channels)
 	return authErr == nil, nil
 }
 

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -91,6 +91,10 @@ func TestFilterToAvailableChannels(t *testing.T) {
 // Unit test for bug #314
 func TestChangesAfterChannelAdded(t *testing.T) {
 
+	if !base.TestsUseDefaultCollection() {
+		t.Skip("Disabled for non-default collection based on use of GetPrincipalForTest")
+	}
+
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := db.GetSingleDatabaseCollectionWithUser()
@@ -115,6 +119,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	userInfo, err := db.GetPrincipalForTest(t, "naomi", true)
 	assert.True(t, userInfo != nil)
 	userInfo.ExplicitChannels = base.SetOf("ABC", "PBS")
+
 	_, err = db.UpdatePrincipal(base.TestCtx(t), userInfo, true, true)
 	assert.NoError(t, err, "UpdatePrincipal failed")
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -2320,7 +2320,12 @@ func (context *DatabaseContext) ComputeChannelsForPrincipal(ctx context.Context,
 		key = channels.RoleAccessPrefix + key // Roles are identified in access view by a "role:" prefix
 	}
 
-	results, err := context.QueryAccess(ctx, key)
+	dbCollection, err := context.GetDatabaseCollection(scope, collection)
+	if err != nil {
+		return nil, err
+	}
+
+	results, err := dbCollection.QueryAccess(ctx, key)
 	if err != nil {
 		base.WarnfCtx(ctx, "QueryAccess returned error: %v", err)
 		return nil, err

--- a/db/database.go
+++ b/db/database.go
@@ -127,6 +127,7 @@ type DatabaseContext struct {
 	Scopes                       map[string]Scope               // A map keyed by scope name containing a set of scopes/collections. Nil if running with only _default._default
 	singleCollection             *DatabaseCollection            // Temporary collection
 	CollectionByID               map[uint32]*DatabaseCollection // A map keyed by collection ID to Collection
+	CollectionNames              map[string]map[string]struct{} // Map of scope, collection names
 }
 
 type Scope struct {
@@ -429,10 +430,12 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 
 	if len(options.Scopes) > 0 {
 		dbContext.Scopes = make(map[string]Scope, len(options.Scopes))
+		dbContext.CollectionNames = make(map[string]map[string]struct{}, len(options.Scopes))
 		for scopeName, scope := range options.Scopes {
 			dbContext.Scopes[scopeName] = Scope{
 				Collections: make(map[string]*DatabaseCollection, len(scope.Collections)),
 			}
+			collectionNameMap := make(map[string]struct{}, len(scope.Collections))
 			for collName := range scope.Collections {
 				dataStore := bucket.NamedDataStore(base.ScopeAndCollectionName{Scope: scopeName, Collection: collName})
 				dbCollection, err := newDatabaseCollection(ctx, dbContext, dataStore)
@@ -444,7 +447,9 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 				collectionID := dbCollection.GetCollectionID()
 				dbContext.CollectionByID[collectionID] = dbCollection
 				dbContext.singleCollection = dbCollection
+				collectionNameMap[collName] = struct{}{}
 			}
+			dbContext.CollectionNames[scopeName] = collectionNameMap
 		}
 	} else {
 		dataStore := bucket.DefaultDataStore()
@@ -868,6 +873,7 @@ func (context *DatabaseContext) Authenticator(ctx context.Context) *auth.Authent
 		SessionCookieName:        sessionCookieName,
 		BcryptCost:               context.Options.BcryptCost,
 		LogCtx:                   ctx,
+		Collections:              context.CollectionNames,
 	})
 
 	return authenticator
@@ -1821,14 +1827,14 @@ func (db *DatabaseCollection) invalUserRoles(ctx context.Context, username strin
 
 func (db *DatabaseCollection) invalUserChannels(ctx context.Context, username string, invalSeq uint64) {
 	authr := db.Authenticator(ctx)
-	if err := authr.InvalidateChannels(username, true, invalSeq); err != nil {
+	if err := authr.InvalidateChannels(username, true, db.ScopeName(), db.Name(), invalSeq); err != nil {
 		base.WarnfCtx(ctx, "Error invalidating channels for user %s: %v", base.UD(username), err)
 	}
 }
 
 func (db *DatabaseCollection) invalRoleChannels(ctx context.Context, rolename string, invalSeq uint64) {
 	authr := db.Authenticator(ctx)
-	if err := authr.InvalidateChannels(rolename, false, invalSeq); err != nil {
+	if err := authr.InvalidateChannels(rolename, false, db.ScopeName(), db.Name(), invalSeq); err != nil {
 		base.WarnfCtx(ctx, "Error invalidating channels for role %s: %v", base.UD(rolename), err)
 	}
 }
@@ -2032,10 +2038,22 @@ func (dbCtx *DatabaseContext) onlyDefaultCollection() bool {
 	return exists
 }
 
-// GetDatabaseCollectionWithUser returns a collection if one exists, otherwise error.
+// GetDatabaseCollectionWithUser returns a DatabaseCollectionWithUser if the collection exists on the database, otherwise error.
 func (dbc *Database) GetDatabaseCollectionWithUser(scopeName, collectionName string) (*DatabaseCollectionWithUser, error) {
+	collection, err := dbc.GetDatabaseCollection(scopeName, collectionName)
+	if err != nil {
+		return nil, err
+	}
+	return &DatabaseCollectionWithUser{
+		DatabaseCollection: collection,
+		user:               dbc.user,
+	}, nil
+}
+
+// GetDatabaseCollection returns a collection if one exists, otherwise error.
+func (dbc *DatabaseContext) GetDatabaseCollection(scopeName, collectionName string) (*DatabaseCollection, error) {
 	if base.IsDefaultCollection(scopeName, collectionName) && dbc.onlyDefaultCollection() {
-		return dbc.GetDefaultDatabaseCollectionWithUser()
+		return dbc.GetDefaultDatabaseCollection()
 	}
 	if dbc.Scopes == nil {
 		return nil, fmt.Errorf("scope %s does not exist on this database", base.UD(scopeName))
@@ -2048,10 +2066,7 @@ func (dbc *Database) GetDatabaseCollectionWithUser(scopeName, collectionName str
 	if !exists {
 		return nil, fmt.Errorf("collection %s.%s is not configured on this database", base.UD(scopeName), base.UD(collectionName))
 	}
-	return &DatabaseCollectionWithUser{
-		DatabaseCollection: collection,
-		user:               dbc.user,
-	}, nil
+	return collection, nil
 }
 
 func (dbc *DatabaseContext) GetDefaultDatabaseCollection() (*DatabaseCollection, error) {

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -170,14 +170,12 @@ func (c *DatabaseCollection) mutationListener() *changeListener {
 	return &c.dbCtx.mutationListener
 }
 
-// Name returns the name of the collection. If couchbase server is not aware of collections, it will return _default.
+// Name returns the name of the collection. If datastore is not aware of collections, it will return _default.
 func (c *DatabaseCollection) Name() string {
-	collection, err := base.AsCollection(c.dataStore)
-	if err != nil {
-		return base.DefaultCollection
+	if metadataStoreName, ok := base.AsDataStoreName(c.dataStore); ok {
+		return metadataStoreName.CollectionName()
 	}
-	return collection.CollectionName()
-
+	return base.DefaultCollection
 }
 
 // oldRevExpirySeconds is the number of seconds before old revisions are removed from Couchbase server. This is controlled at a database level.
@@ -206,13 +204,12 @@ func (c *DatabaseCollectionWithUser) ReloadUser(ctx context.Context) error {
 	return nil
 }
 
-// Name returns the name of the scope the collection is in. If couchbase server is not aware of collections, it will return _default.
+// Name returns the name of the scope the collection is in. If datastore is not aware of collections, it will return _default.
 func (c *DatabaseCollection) ScopeName() string {
-	collection, err := base.AsCollection(c.dataStore)
-	if err != nil {
-		return base.DefaultScope
+	if metadataStoreName, ok := base.AsDataStoreName(c.dataStore); ok {
+		return metadataStoreName.ScopeName()
 	}
-	return collection.ScopeName()
+	return base.DefaultScope
 }
 
 // RemoveFromChangeCache removes select documents from all channel caches and returns the number of documents removed.

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -406,7 +406,7 @@ func TestGetRemovalMultiChannel(t *testing.T) {
 	defer db.Close(ctx)
 	collection := db.GetSingleDatabaseCollectionWithUser()
 
-	auth := auth.NewAuthenticator(db.MetadataStore, db, auth.DefaultAuthenticatorOptions())
+	auth := db.Authenticator(base.TestCtx(t))
 
 	// Create a user who have access to both channel ABC and NBC.
 	userAlice, err := auth.NewUser("alice", "pass", base.SetOf("ABC", "NBC"))
@@ -544,7 +544,7 @@ func TestDeltaSyncWhenFromRevIsChannelRemoval(t *testing.T) {
 
 	// Request delta between rev2ID and rev3ID (toRevision "rev2ID" is channel removal)
 	// as a user who doesn't have access to the removed revision via any other channel.
-	authenticator := auth.NewAuthenticator(db.MetadataStore, db, auth.DefaultAuthenticatorOptions())
+	authenticator := db.Authenticator(ctx)
 	user, err := authenticator.NewUser("alice", "pass", base.SetOf("NBC"))
 	require.NoError(t, err, "Error creating user")
 
@@ -610,7 +610,7 @@ func TestDeltaSyncWhenToRevIsChannelRemoval(t *testing.T) {
 
 	// Request delta between rev1ID and rev2ID (toRevision "rev2ID" is channel removal)
 	// as a user who doesn't have access to the removed revision via any other channel.
-	authenticator := auth.NewAuthenticator(db.MetadataStore, db, auth.DefaultAuthenticatorOptions())
+	authenticator := db.Authenticator(ctx)
 	user, err := authenticator.NewUser("alice", "pass", base.SetOf("NBC"))
 	require.NoError(t, err, "Error creating user")
 
@@ -908,6 +908,10 @@ func TestAllDocsOnly(t *testing.T) {
 
 // Unit test for bug #673
 func TestUpdatePrincipal(t *testing.T) {
+
+	if !base.TestsUseDefaultCollection() {
+		t.Skip("Disabled for non-default collection based on use of GetPrincipalForTest")
+	}
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 

--- a/db/functions/function_test.go
+++ b/db/functions/function_test.go
@@ -133,7 +133,7 @@ var kUserFunctionConfig = FunctionConfigMap{
 // Adds a user "alice" to the database, with role "hero"
 // and access to channels "wonderland" and "lookingglass".
 func addUserAlice(t *testing.T, db *db.Database) auth.User {
-	authenticator := auth.NewAuthenticator(db.MetadataStore, db, auth.DefaultAuthenticatorOptions())
+	authenticator := db.Authenticator(base.TestCtx(t))
 	hero, err := authenticator.NewRole("hero", base.SetOf("heroes"))
 	require.NoError(t, err)
 	require.NoError(t, authenticator.Save(hero))

--- a/db/functions/n1ql_function_test.go
+++ b/db/functions/n1ql_function_test.go
@@ -96,6 +96,10 @@ func TestUserN1QLQueries(t *testing.T) {
 		t.Skip("This test is Couchbase Server only (requires N1QL)")
 	}
 
+	if !base.TestsUseDefaultCollection() {
+		t.Skip("Requires collection-aware function security (CBG-2597)")
+	}
+
 	//base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	db, ctx := setupTestDBWithFunctions(t, kUserN1QLFunctionsConfig, nil)
 	defer db.Close(ctx)

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -27,6 +27,10 @@ func TestRoleQuery(t *testing.T) {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
+	if !base.TestsUseDefaultCollection() {
+		t.Skip("This test doesn't initialize indexes for non-default collections, needed for NewRole")
+	}
+
 	testCases := []struct {
 		isServerless bool
 	}{
@@ -219,6 +223,9 @@ func TestQueryAllRoles(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
+	if !base.TestsUseDefaultCollection() {
+		t.Skip("This test doesn't initialize indexes for non-default collections, needed for NewRole")
+	}
 
 	testCases := []struct {
 		isServerless bool
@@ -281,6 +288,9 @@ func TestQueryAllRoles(t *testing.T) {
 func TestAllPrincipalIDs(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
+	}
+	if !base.TestsUseDefaultCollection() {
+		t.Skip("This test package doesn't initialize indexes for non-default collections, needed for NewRole")
 	}
 
 	testCases := []struct {
@@ -356,6 +366,10 @@ func TestAllPrincipalIDs(t *testing.T) {
 func TestGetRoleIDs(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
+	}
+
+	if !base.TestsUseDefaultCollection() {
+		t.Skip("This test package doesn't initialize indexes for non-default collections, needed for NewRole")
 	}
 
 	testCases := []struct {

--- a/db/query.go
+++ b/db/query.go
@@ -440,12 +440,12 @@ func (context *DatabaseContext) ViewQueryWithStats(ctx context.Context, dataStor
 }
 
 // Query to compute the set of channels granted to the specified user via the Sync Function
-func (context *DatabaseContext) QueryAccess(ctx context.Context, username string) (sgbucket.QueryResultIterator, error) {
+func (dbCollection *DatabaseCollection) QueryAccess(ctx context.Context, username string) (sgbucket.QueryResultIterator, error) {
 
 	// View Query
-	if context.Options.UseViews {
+	if dbCollection.useViews() {
 		opts := map[string]interface{}{"stale": false, "key": username}
-		return context.ViewQueryWithStats(ctx, context.MetadataStore, DesignDocSyncGateway(), ViewAccess, opts)
+		return dbCollection.dbCtx.ViewQueryWithStats(ctx, dbCollection.dataStore, DesignDocSyncGateway(), ViewAccess, opts)
 	}
 
 	// N1QL Query
@@ -453,36 +453,31 @@ func (context *DatabaseContext) QueryAccess(ctx context.Context, username string
 		base.WarnfCtx(ctx, "QueryAccess called with empty username - returning empty result iterator")
 		return &EmptyResultIterator{}, nil
 	}
-	accessQueryStatement := context.buildAccessQuery(username)
+	accessQueryStatement := dbCollection.buildAccessQuery(username)
 	params := make(map[string]interface{}, 0)
 	params[QueryParamUserName] = username
 
-	return N1QLQueryWithStats(ctx, context.MetadataStore, QueryAccess.name, accessQueryStatement, params, base.RequestPlus, QueryAccess.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
+	return N1QLQueryWithStats(ctx, dbCollection.dataStore, QueryAccess.name, accessQueryStatement, params, base.RequestPlus, QueryAccess.adhoc, dbCollection.dbStats(), dbCollection.slowQueryWarningThreshold())
 }
 
 // Builds the query statement for an access N1QL query.
-func (context *DatabaseContext) buildAccessQuery(username string) string {
-	statement := replaceSyncTokensQuery(QueryAccess.statement, context.UseXattrs())
+func (dbCollection *DatabaseCollection) buildAccessQuery(username string) string {
+	statement := replaceSyncTokensQuery(QueryAccess.statement, dbCollection.UseXattrs())
 
 	// SG usernames don't allow back tick, but guard username in select clause for additional safety
 	username = strings.Replace(username, "`", "``", -1)
 	statement = strings.Replace(statement, QuerySelectUserName, username, -1)
-	statement = replaceIndexTokensQuery(statement, sgIndexes[IndexAccess], context.UseXattrs())
+	statement = replaceIndexTokensQuery(statement, sgIndexes[IndexAccess], dbCollection.UseXattrs())
 	return statement
 }
 
-// TODO: Remove when multi-collection support is in place
-func (context *DatabaseContext) QueryRoleAccess(ctx context.Context, username string) (sgbucket.QueryResultIterator, error) {
-	return context.GetSingleDatabaseCollection().QueryRoleAccess(ctx, username)
-}
-
 // Query to compute the set of roles granted to the specified user via the Sync Function
-func (context *DatabaseCollection) QueryRoleAccess(ctx context.Context, username string) (sgbucket.QueryResultIterator, error) {
+func (dbCollection *DatabaseCollection) QueryRoleAccess(ctx context.Context, username string) (sgbucket.QueryResultIterator, error) {
 
 	// View Query
-	if context.useViews() {
+	if dbCollection.useViews() {
 		opts := map[string]interface{}{"stale": false, "key": username}
-		return context.dbCtx.ViewQueryWithStats(ctx, context.dataStore, DesignDocSyncGateway(), ViewRoleAccess, opts)
+		return dbCollection.dbCtx.ViewQueryWithStats(ctx, dbCollection.dataStore, DesignDocSyncGateway(), ViewRoleAccess, opts)
 	}
 
 	// N1QL Query
@@ -491,10 +486,10 @@ func (context *DatabaseCollection) QueryRoleAccess(ctx context.Context, username
 		return &EmptyResultIterator{}, nil
 	}
 
-	accessQueryStatement := context.buildRoleAccessQuery(username)
+	accessQueryStatement := dbCollection.buildRoleAccessQuery(username)
 	params := make(map[string]interface{}, 0)
 	params[QueryParamUserName] = username
-	return N1QLQueryWithStats(ctx, context.dataStore, QueryTypeRoleAccess, accessQueryStatement, params, base.RequestPlus, QueryRoleAccess.adhoc, context.dbStats(), context.slowQueryWarningThreshold())
+	return N1QLQueryWithStats(ctx, dbCollection.dataStore, QueryTypeRoleAccess, accessQueryStatement, params, base.RequestPlus, QueryRoleAccess.adhoc, dbCollection.dbStats(), dbCollection.slowQueryWarningThreshold())
 }
 
 // TODO: Remove

--- a/db/query.go
+++ b/db/query.go
@@ -471,13 +471,18 @@ func (context *DatabaseContext) buildAccessQuery(username string) string {
 	return statement
 }
 
-// Query to compute the set of roles granted to the specified user via the Sync Function
+// TODO: Remove when multi-collection support is in place
 func (context *DatabaseContext) QueryRoleAccess(ctx context.Context, username string) (sgbucket.QueryResultIterator, error) {
+	return context.GetSingleDatabaseCollection().QueryRoleAccess(ctx, username)
+}
+
+// Query to compute the set of roles granted to the specified user via the Sync Function
+func (context *DatabaseCollection) QueryRoleAccess(ctx context.Context, username string) (sgbucket.QueryResultIterator, error) {
 
 	// View Query
-	if context.Options.UseViews {
+	if context.useViews() {
 		opts := map[string]interface{}{"stale": false, "key": username}
-		return context.ViewQueryWithStats(ctx, context.MetadataStore, DesignDocSyncGateway(), ViewRoleAccess, opts)
+		return context.dbCtx.ViewQueryWithStats(ctx, context.dataStore, DesignDocSyncGateway(), ViewRoleAccess, opts)
 	}
 
 	// N1QL Query
@@ -489,11 +494,16 @@ func (context *DatabaseContext) QueryRoleAccess(ctx context.Context, username st
 	accessQueryStatement := context.buildRoleAccessQuery(username)
 	params := make(map[string]interface{}, 0)
 	params[QueryParamUserName] = username
-	return N1QLQueryWithStats(ctx, context.MetadataStore, QueryTypeRoleAccess, accessQueryStatement, params, base.RequestPlus, QueryRoleAccess.adhoc, context.DbStats, context.Options.SlowQueryWarningThreshold)
+	return N1QLQueryWithStats(ctx, context.dataStore, QueryTypeRoleAccess, accessQueryStatement, params, base.RequestPlus, QueryRoleAccess.adhoc, context.dbStats(), context.slowQueryWarningThreshold())
+}
+
+// TODO: Remove
+func (context *DatabaseContext) buildRoleAccessQuery(username string) string {
+	return context.GetSingleDatabaseCollection().buildRoleAccessQuery(username)
 }
 
 // Builds the query statement for a roleAccess N1QL query.
-func (context *DatabaseContext) buildRoleAccessQuery(username string) string {
+func (context *DatabaseCollection) buildRoleAccessQuery(username string) string {
 	statement := replaceSyncTokensQuery(QueryRoleAccess.statement, context.UseXattrs())
 
 	// SG usernames don't allow back tick, but guard username in select clause for additional safety

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -354,7 +354,7 @@ func TestCoveringQueries(t *testing.T) {
 	// Access and roleAccess currently aren't covering, because of the need to target the user property by name
 	// in the SELECT.
 	// Including here for ease-of-conversion when we get an indexing enhancement to support covered queries.
-	accessStatement := db.buildAccessQuery("user1")
+	accessStatement := collection.buildAccessQuery("user1")
 	plan, explainErr = n1QLStore.ExplainQuery(accessStatement, nil)
 	assert.NoError(t, explainErr, "Error generating explain for access query")
 	covered = IsCovered(plan)
@@ -447,10 +447,6 @@ func TestAllDocsQuery(t *testing.T) {
 
 func TestAccessQuery(t *testing.T) {
 
-	if !base.TestsUseDefaultCollection() {
-		t.Skip("Disabled for non-default collection until CBG-2554")
-	}
-
 	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
@@ -470,7 +466,7 @@ func TestAccessQuery(t *testing.T) {
 
 	// Standard query
 	username := "user1"
-	results, queryErr := db.QueryAccess(base.TestCtx(t), username)
+	results, queryErr := collection.QueryAccess(base.TestCtx(t), username)
 	assert.NoError(t, queryErr, "Query error")
 	var row map[string]interface{}
 	rowCount := 0
@@ -485,7 +481,7 @@ func TestAccessQuery(t *testing.T) {
 	usernames := []string{"user1'", "user1?", "user1 ! user2$"}
 	// usernames = append(usernames, "user1`AND") // TODO: MB-50619 - broken until Server 7.1.0
 	for _, username := range usernames {
-		results, queryErr = db.QueryAccess(base.TestCtx(t), username)
+		results, queryErr = collection.QueryAccess(base.TestCtx(t), username)
 		assert.NoError(t, queryErr, "Query error")
 		rowCount = 0
 		for results.Next(&row) {
@@ -497,10 +493,6 @@ func TestAccessQuery(t *testing.T) {
 }
 
 func TestRoleAccessQuery(t *testing.T) {
-
-	if !base.TestsUseDefaultCollection() {
-		t.Skip("Disabled for non-default collection until CBG-2554")
-	}
 
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test is Couchbase Server only")

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -521,7 +521,7 @@ func TestRoleAccessQuery(t *testing.T) {
 
 	// Standard query
 	username := "user1"
-	results, queryErr := db.QueryRoleAccess(base.TestCtx(t), username)
+	results, queryErr := collection.QueryRoleAccess(base.TestCtx(t), username)
 	assert.NoError(t, queryErr, "Query error")
 	var row map[string]interface{}
 	rowCount := 0
@@ -536,7 +536,7 @@ func TestRoleAccessQuery(t *testing.T) {
 	usernames := []string{"user1'", "user1?", "user1 ! user2$"}
 	// usernames = append(usernames, "user1`AND") // TODO: MB-50619 - broken until Server 7.1.0
 	for _, username := range usernames {
-		results, queryErr = db.QueryRoleAccess(base.TestCtx(t), username)
+		results, queryErr = collection.QueryRoleAccess(base.TestCtx(t), username)
 		assert.NoError(t, queryErr, "Query error")
 		rowCount = 0
 		for results.Next(&row) {

--- a/db/users.go
+++ b/db/users.go
@@ -78,7 +78,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 					err = base.HTTPErrorf(http.StatusBadRequest, "Error creating user: %s", reason)
 					return replaced, err
 				}
-				user, err = authenticator.NewUser(*updates.Name, "", nil)
+				user, err = authenticator.NewUserNoChannels(*updates.Name, "")
 				princ = user
 			} else {
 				princ, err = authenticator.NewRole(*updates.Name, nil)

--- a/db/users.go
+++ b/db/users.go
@@ -81,7 +81,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 				user, err = authenticator.NewUserNoChannels(*updates.Name, "")
 				princ = user
 			} else {
-				princ, err = authenticator.NewRole(*updates.Name, nil)
+				princ, err = authenticator.NewRoleNoChannels(*updates.Name)
 			}
 			if err != nil {
 				return replaced, fmt.Errorf("Error creating user/role: %w", err)

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -1062,12 +1062,12 @@ func TestDynamicChannelGrant(t *testing.T) {
 	assert.NoError(t, err)
 	user.SetDisabled(true)
 	err = a.Save(user)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Create a test user
 	user, err = a.NewUser("user1", "letmein", nil)
-	assert.NoError(t, err)
-	assert.NoError(t, a.Save(user))
+	require.NoError(t, err)
+	require.NoError(t, a.Save(user))
 
 	collection := rt.GetDatabase().GetSingleDatabaseCollection()
 	keyspace := fmt.Sprintf("%s.%s.%s", "db", collection.ScopeName(), collection.Name())
@@ -1128,19 +1128,19 @@ func TestRoleChannelGrantInheritance(t *testing.T) {
 	assert.NoError(t, err)
 	user.SetDisabled(true)
 	err = a.Save(user)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Create a role with admin grant of chan1
 	role, err := a.NewRole("role1", nil)
 	role.SetCollectionExplicitChannels(scopeName, collectionName, channels.TimedSet{"chan1": channels.NewVbSimpleSequence(1)}, 1)
-	assert.NoError(t, err)
-	assert.NoError(t, a.Save(role))
+	require.NoError(t, err)
+	require.NoError(t, a.Save(role))
 
 	// Create a test user with access to the role
 	user, err = a.NewUser("user1", "letmein", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	user.SetExplicitRoles(channels.TimedSet{"role1": channels.NewVbSimpleSequence(1)}, 1)
-	assert.NoError(t, a.Save(user))
+	require.NoError(t, a.Save(user))
 
 	// Create documents in channels chan1, chan2, chan3
 	response := rt.Send(RequestByUser("PUT", "/"+keyspace+"/doc1", `{"channel":"chan1", "greeting":"hello"}`, "user1"))
@@ -1217,15 +1217,15 @@ func TestPublicChannel(t *testing.T) {
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	user, err := a.GetUser("")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	user.SetDisabled(true)
 	err = a.Save(user)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Create a test user
 	user, err = a.NewUser("user1", "letmein", nil)
-	assert.NoError(t, err)
-	assert.NoError(t, a.Save(user))
+	require.NoError(t, err)
+	require.NoError(t, a.Save(user))
 
 	collection := rt.GetDatabase().GetSingleDatabaseCollection()
 	keyspace := fmt.Sprintf("%s.%s.%s", "db", collection.ScopeName(), collection.Name())

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -1047,3 +1047,200 @@ func TestAccessOnTombstone(t *testing.T) {
 	}
 
 }
+
+func TestDynamicChannelGrant(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAccess)
+
+	rtConfig := RestTesterConfig{SyncFn: `function(doc) {if(doc.type == "setaccess") {channel(doc.channel); access(doc.owner, doc.channel);} else { channel(doc.channel)}}`}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
+	user, err := a.GetUser("")
+	assert.NoError(t, err)
+	user.SetDisabled(true)
+	err = a.Save(user)
+	assert.NoError(t, err)
+
+	// Create a test user
+	user, err = a.NewUser("user1", "letmein", nil)
+	assert.NoError(t, err)
+	assert.NoError(t, a.Save(user))
+
+	collection := rt.GetDatabase().GetSingleDatabaseCollection()
+	keyspace := fmt.Sprintf("%s.%s.%s", "db", collection.ScopeName(), collection.Name())
+
+	// Create a document in channel chan1
+	response := rt.Send(RequestByUser("PUT", "/"+keyspace+"/doc1", `{"channel":"chan1", "greeting":"hello"}`, "user1"))
+	RequireStatus(t, response, 201)
+
+	// Verify user cannot access document
+	response = rt.Send(RequestByUser("GET", "/"+keyspace+"/doc1", "", "user1"))
+	RequireStatus(t, response, 403)
+
+	// Write access granting document
+	response = rt.Send(RequestByUser("PUT", "/"+keyspace+"/grant1", `{"type":"setaccess", "owner":"user1", "channel":"chan1"}`, "user1"))
+	RequireStatus(t, response, 201)
+
+	// Verify user can access document
+	response = rt.Send(RequestByUser("GET", "/"+keyspace+"/doc1", "", "user1"))
+	RequireStatus(t, response, 200)
+
+	var body db.Body
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
+	assert.Equal(t, "hello", body["greeting"])
+
+	// Create a document in channel chan2
+	response = rt.Send(RequestByUser("PUT", "/"+keyspace+"/doc2", `{"channel":"chan2", "greeting":"hello"}`, "user1"))
+	RequireStatus(t, response, 201)
+
+	// Write access granting document for chan2 (tests invalidation when channels/inval_seq exists)
+	response = rt.Send(RequestByUser("PUT", "/"+keyspace+"/grant2", `{"type":"setaccess", "owner":"user1", "channel":"chan2"}`, "user1"))
+	RequireStatus(t, response, 201)
+
+	// Verify user can now access both documents
+	response = rt.Send(RequestByUser("GET", "/"+keyspace+"/doc1", "", "user1"))
+	RequireStatus(t, response, 200)
+	response = rt.Send(RequestByUser("GET", "/"+keyspace+"/doc2", "", "user1"))
+	RequireStatus(t, response, 200)
+}
+
+// Verify a dynamic grant of a channel to a role is inherited by a user with that role
+func TestRoleChannelGrantInheritance(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAccess)
+
+	rtConfig := RestTesterConfig{SyncFn: `function(doc) {if(doc.type == "setaccess") {channel(doc.channel); access(doc.owner, doc.channel);} else { channel(doc.channel)}}`}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
+
+	collection := rt.GetDatabase().GetSingleDatabaseCollection()
+	scopeName := collection.ScopeName()
+	collectionName := collection.Name()
+	keyspace := fmt.Sprintf("%s.%s.%s", "db", scopeName, collectionName)
+
+	user, err := a.GetUser("")
+	assert.NoError(t, err)
+	user.SetDisabled(true)
+	err = a.Save(user)
+	assert.NoError(t, err)
+
+	// Create a role with admin grant of chan1
+	role, err := a.NewRole("role1", nil)
+	role.SetCollectionExplicitChannels(scopeName, collectionName, channels.TimedSet{"chan1": channels.NewVbSimpleSequence(1)}, 1)
+	assert.NoError(t, err)
+	assert.NoError(t, a.Save(role))
+
+	// Create a test user with access to the role
+	user, err = a.NewUser("user1", "letmein", nil)
+	assert.NoError(t, err)
+	user.SetExplicitRoles(channels.TimedSet{"role1": channels.NewVbSimpleSequence(1)}, 1)
+	assert.NoError(t, a.Save(user))
+
+	// Create documents in channels chan1, chan2, chan3
+	response := rt.Send(RequestByUser("PUT", "/"+keyspace+"/doc1", `{"channel":"chan1", "greeting":"hello"}`, "user1"))
+	RequireStatus(t, response, 201)
+	response = rt.Send(RequestByUser("PUT", "/"+keyspace+"/doc2", `{"channel":"chan2", "greeting":"hello"}`, "user1"))
+	RequireStatus(t, response, 201)
+	response = rt.Send(RequestByUser("PUT", "/"+keyspace+"/doc3", `{"channel":"chan3", "greeting":"hello"}`, "user1"))
+	RequireStatus(t, response, 201)
+
+	// Verify user can access document in admin role channel (chan1)
+	response = rt.Send(RequestByUser("GET", "/"+keyspace+"/doc1", "", "user1"))
+	RequireStatus(t, response, 200)
+
+	// Verify user cannot access other documents
+	response = rt.Send(RequestByUser("GET", "/"+keyspace+"/doc2", "", "user1"))
+	RequireStatus(t, response, 403)
+	response = rt.Send(RequestByUser("GET", "/"+keyspace+"/doc3", "", "user1"))
+	RequireStatus(t, response, 403)
+
+	// Write access granting document (grants chan2 to role role1)
+	response = rt.Send(RequestByUser("PUT", "/"+keyspace+"/grant1", `{"type":"setaccess", "owner":"role:role1", "channel":"chan2"}`, "user1"))
+	RequireStatus(t, response, 201)
+	grant1Rev := RespRevID(t, response)
+
+	// Verify user can access document
+	response = rt.Send(RequestByUser("GET", "/"+keyspace+"/doc2", "", "user1"))
+	RequireStatus(t, response, 200)
+
+	var body db.Body
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
+	assert.Equal(t, "hello", body["greeting"])
+
+	// Write access granting document for chan2 (tests invalidation when channels/inval_seq exists)
+	response = rt.Send(RequestByUser("PUT", "/"+keyspace+"/grant2", `{"type":"setaccess", "owner":"role:role1", "channel":"chan3"}`, "user1"))
+	RequireStatus(t, response, 201)
+
+	// Verify user can now access all three documents
+	response = rt.Send(RequestByUser("GET", "/"+keyspace+"/doc1", "", "user1"))
+	RequireStatus(t, response, 200)
+	response = rt.Send(RequestByUser("GET", "/"+keyspace+"/doc2", "", "user1"))
+	RequireStatus(t, response, 200)
+	response = rt.Send(RequestByUser("GET", "/"+keyspace+"/doc3", "", "user1"))
+	RequireStatus(t, response, 200)
+
+	// Revoke access to chan2 (dynamic)
+	response = rt.Send(RequestByUser("PUT", "/"+keyspace+"/grant1?rev="+grant1Rev, `{"type":"setaccess", "owner":"none", "channel":"chan2"}`, "user1"))
+	RequireStatus(t, response, 201)
+
+	// Verify user cannot access doc in revoked channel, but can successfully access remaining documents
+	response = rt.Send(RequestByUser("GET", "/"+keyspace+"/doc2", "", "user1"))
+	RequireStatus(t, response, 403)
+	response = rt.Send(RequestByUser("GET", "/"+keyspace+"/doc1", "", "user1"))
+	RequireStatus(t, response, 200)
+	response = rt.Send(RequestByUser("GET", "/"+keyspace+"/doc3", "", "user1"))
+	RequireStatus(t, response, 200)
+
+}
+
+func TestPublicChannel(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAccess, base.KeyHTTP, base.KeyHTTPResp)
+
+	rtConfig := RestTesterConfig{SyncFn: `
+           function(doc) {
+              if(doc.type == "public") {
+                 channel("!")
+              } else { 
+                 channel(doc.channel)
+              }
+           }`}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
+	user, err := a.GetUser("")
+	assert.NoError(t, err)
+	user.SetDisabled(true)
+	err = a.Save(user)
+	assert.NoError(t, err)
+
+	// Create a test user
+	user, err = a.NewUser("user1", "letmein", nil)
+	assert.NoError(t, err)
+	assert.NoError(t, a.Save(user))
+
+	collection := rt.GetDatabase().GetSingleDatabaseCollection()
+	keyspace := fmt.Sprintf("%s.%s.%s", "db", collection.ScopeName(), collection.Name())
+
+	// Create a document in public channel
+	response := rt.Send(RequestByUser("PUT", "/"+keyspace+"/publicDoc", `{"type":"public", "greeting":"hello"}`, "user1"))
+	RequireStatus(t, response, 201)
+
+	// Create a document in non-public channel
+	response = rt.Send(RequestByUser("PUT", "/"+keyspace+"/privateDoc", `{"channel":"restricted", "greeting":"hello"}`, "user1"))
+	RequireStatus(t, response, 201)
+
+	// Verify user can access public document, cannot access non-public document
+	response = rt.Send(RequestByUser("GET", "/"+keyspace+"/publicDoc", "", "user1"))
+	RequireStatus(t, response, 200)
+	response = rt.Send(RequestByUser("GET", "/"+keyspace+"/privateDoc", "", "user1"))
+	RequireStatus(t, response, 403)
+}

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -334,6 +334,7 @@ func TestCollectionsBasicIndexQuery(t *testing.T) {
 // TestCollectionsSGIndexQuery is more of an end-to-end test to ensure SG indexes are built correctly,
 // and the channel access query is able to run when pulling a document as a user, and backfill the channel cache.
 func TestCollectionsSGIndexQuery(t *testing.T) {
+	t.Skip("Requires config-based collection channel assignment (pending CBG-2551)")
 	base.TestRequiresCollections(t)
 
 	// force GSI for this one test

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -436,7 +436,16 @@ func (rt *RestTester) SetAdminParty(partyTime bool) error {
 	if partyTime {
 		chans = channels.AtSequence(base.SetOf(channels.UserStarChannel), 1)
 	}
-	guest.SetExplicitChannels(chans, 1)
+
+	if len(a.Collections) == 0 {
+		guest.SetExplicitChannels(chans, 1)
+	} else {
+		for scopeName, scope := range a.Collections {
+			for collectionName, _ := range scope {
+				guest.SetCollectionExplicitChannels(scopeName, collectionName, chans, 1)
+			}
+		}
+	}
 	return a.Save(guest)
 }
 


### PR DESCRIPTION
CBG-2554

Extends the Principal and User interface to add collection-scoped API.

Adds Collections property to Authenticator config to allow callers to specify the set of collections that should be evaluated when channels are rebuilt.

Defines a new PrincipalCollectionAccess interface as a common interface for interaction with a collection's channel information that can be used for the default collection (stored on the principal root) or a named collection (stored in collection_access).

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1193/ (use default=false)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1194/ (use default=true)
