### PR TITLE
CBG-2505: New approach after mistake with previous PR on the same issue

### DIFF
--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -904,7 +904,6 @@ func TestLowSequenceHandlingAcrossChannels(t *testing.T) {
 	_, err = verifySequencesInFeed(feed, []uint64{9})
 	assert.True(t, err == nil)
 
-	//changesCtxCancel()
 }
 
 // Test low sequence handling of late arriving sequences to a continuous changes feed, when the
@@ -984,7 +983,6 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	// 2. The duplicate send of sequence '6' is the standard behaviour when a channel is added - we don't know
 	// whether the user has already seen the documents on the channel previously, so it gets resent
 
-	//changesCtxCancel()
 }
 
 // Tests channel cache backfill with slow query, validates that a request that is terminated while

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -2340,7 +2340,6 @@ func emptyChangesFeed(t *testing.T, feed <-chan *ChangeEntry) {
 	for {
 		select {
 		case v := <-feed:
-			log.Println(v)
 			if v == nil {
 				return
 			}


### PR DESCRIPTION
CBG-2505

New approach to this flaking test issue after last approach filled disk with logs. *Still want to test more on this to ensure there is nothing i have missed on this.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1135/
