### PR TITLE
Avoid creating colllections

### DIFF
--- a/base/main_test.go
+++ b/base/main_test.go
@@ -11,10 +11,13 @@ licenses/APL2.txt.
 package base
 
 import (
+	"os"
 	"testing"
 )
 
 func TestMain(m *testing.M) {
 	memWatermarkThresholdMB := uint64(2048)
+
+	_ = os.Setenv(tbpUseDefaultCollection, "false")
 	TestBucketPoolNoIndexes(m, memWatermarkThresholdMB)
 }


### PR DESCRIPTION
Temporary workaround for `TestOneShotDCP` failure.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1143
