### PR TITLE
Initialize default collection when using walrus tbp

### DIFF
--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -196,6 +196,9 @@ func (tbp *TestBucketPool) GetWalrusTestBucket(t testing.TB, url string) (b Buck
 
 	tbp.createCollections(ctx, walrusBucket)
 
+	// Create default collection here so that it gets initialized by bucketInitFunc
+	_ = walrusBucket.DefaultDataStore()
+
 	initFuncStart := time.Now()
 	err = tbp.bucketInitFunc(ctx, b, tbp)
 	if err != nil {


### PR DESCRIPTION
Avoids authenticator errors trying to run queries on default collection.
