### PR TITLE
Attachment markup extra logging

### DIFF
--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -123,8 +123,7 @@ func attachmentCompactMarkPhase(ctx context.Context, db *Database, compactionID 
 			if err != nil {
 				return failProcess(err, "[%s] Failed to mark attachment %s from doc %s with attachment docID %s. Err: %v", compactionLoggingID, base.UD(attachmentName), base.UD(docID), base.UD(attachmentDocID), err)
 			}
-			base.TracefCtx(ctx, base.KeyAll, "[%s] Received EVENT CAS %d for doc %v", compactionLoggingID, event.Cas, base.UD(docID))
-			base.DebugfCtx(ctx, base.KeyAll, "[%s] Marked attachment %s from doc %s with attachment docID %s", compactionLoggingID, base.UD(attachmentName), base.UD(docID), base.UD(attachmentDocID))
+			base.DebugfCtx(ctx, base.KeyAll, "[%s] Marked attachment %s from doc %s with attachment docID %s ; Event CAS: %s", compactionLoggingID, base.UD(attachmentName), base.UD(docID), base.UD(attachmentDocID), event.Cas)
 			markedAttachmentCount.Add(1)
 		}
 		return true

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -123,7 +123,7 @@ func attachmentCompactMarkPhase(ctx context.Context, db *Database, compactionID 
 			if err != nil {
 				return failProcess(err, "[%s] Failed to mark attachment %s from doc %s with attachment docID %s. Err: %v", compactionLoggingID, base.UD(attachmentName), base.UD(docID), base.UD(attachmentDocID), err)
 			}
-
+			base.TracefCtx(ctx, base.KeyAll, "[%s] Received EVENT CAS %d for doc %v", compactionLoggingID, event.Cas, base.UD(docID))
 			base.DebugfCtx(ctx, base.KeyAll, "[%s] Marked attachment %s from doc %s with attachment docID %s", compactionLoggingID, base.UD(attachmentName), base.UD(docID), base.UD(attachmentDocID))
 			markedAttachmentCount.Add(1)
 		}


### PR DESCRIPTION
Describe your PR here...
- Log event CAS when marking attachments, to get more info on TestAttachmentMarkAndSweepAndCleanup flake

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1153/
