### PR TITLE
Fixes for running with non-default collection

### DIFF
--- a/base/collection.go
+++ b/base/collection.go
@@ -25,6 +25,7 @@ import (
 	"github.com/couchbase/gocb/v2"
 	"github.com/couchbase/gocbcore/v10"
 	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbaselabs/walrus"
 	pkgerrors "github.com/pkg/errors"
 )
 
@@ -625,4 +626,17 @@ func (b *GocbV2Bucket) NamedDataStore(name sgbucket.DataStoreName) sgbucket.Data
 		panic(err)
 	}
 	return c
+}
+
+func GetCollectionID(dataStore DataStore) uint32 {
+	switch c := dataStore.(type) {
+	case (*Collection):
+		return c.GetCollectionID()
+	case (*walrus.WalrusCollection):
+		return c.CollectionID
+	case WrappingDatastore:
+		return GetCollectionID(c.GetUnderlyingDataStore())
+	default:
+		return DefaultCollectionID
+	}
 }

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -228,9 +228,6 @@ func (c *changeCache) Stop() {
 	// Wait for changeCache background tasks to finish.
 	waitForBGTCompletion(context.TODO(), BGTCompletionMaxWait, c.backgroundTasks, c.collection.Name())
 
-	// Stop the channel cache and it's background tasks.
-	c.channelCache.Stop()
-
 	c.lock.Lock()
 	c.logsDisabled = true
 	c.lock.Unlock()

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -38,7 +38,7 @@ type channelsViewRow struct {
 	}
 }
 
-func nextChannelViewEntry(results sgbucket.QueryResultIterator) (*LogEntry, bool) {
+func nextChannelViewEntry(results sgbucket.QueryResultIterator, collectionID uint32) (*LogEntry, bool) {
 
 	var viewRow channelsViewRow
 	found := results.Next(&viewRow)
@@ -53,6 +53,7 @@ func nextChannelViewEntry(results sgbucket.QueryResultIterator) (*LogEntry, bool
 		RevID:        viewRow.Value.Rev,
 		Flags:        viewRow.Value.Flags,
 		TimeReceived: time.Now(),
+		CollectionID: collectionID,
 	}
 	return entry, true
 
@@ -123,7 +124,7 @@ func (dbc *DatabaseCollection) getChangesInChannelFromQuery(ctx context.Context,
 			var entry *LogEntry
 			var found bool
 			if usingViews {
-				entry, found = nextChannelViewEntry(queryResults)
+				entry, found = nextChannelViewEntry(queryResults, collectionID)
 			} else {
 				entry, found = nextChannelQueryEntry(queryResults, collectionID)
 			}
@@ -215,7 +216,7 @@ func (dbc *DatabaseCollection) getChangesForSequences(ctx context.Context, seque
 		var entry *LogEntry
 		var found bool
 		if usingViews {
-			entry, found = nextChannelViewEntry(queryResults)
+			entry, found = nextChannelViewEntry(queryResults, collectionID)
 		} else {
 			entry, found = nextChannelQueryEntry(queryResults, collectionID)
 		}

--- a/db/database.go
+++ b/db/database.go
@@ -504,7 +504,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	// Start DCP feed
 	base.InfofCtx(ctx, base.KeyDCP, "Starting mutation feed on bucket %v due to either channel cache mode or doc tracking (auto-import)", base.MD(bucket.GetName()))
 	cacheFeedStatsMap := dbContext.DbStats.Database().CacheFeedMapStats
-	err = dbContext.mutationListener.Start(bucket, cacheFeedStatsMap.Map)
+	err = dbContext.mutationListener.Start(bucket, cacheFeedStatsMap.Map, dbContext.Scopes, dbContext.MetadataStore)
 
 	// Check if there is an error starting the DCP feed
 	if err != nil {
@@ -761,7 +761,7 @@ func (context *DatabaseContext) RestartListener() error {
 	time.Sleep(2 * time.Second)
 	context.mutationListener.Init(context.Bucket.GetName(), context.Options.GroupID)
 	cacheFeedStatsMap := context.DbStats.Database().CacheFeedMapStats
-	if err := context.mutationListener.Start(context.Bucket, cacheFeedStatsMap.Map); err != nil {
+	if err := context.mutationListener.Start(context.Bucket, cacheFeedStatsMap.Map, context.Scopes, context.MetadataStore); err != nil {
 		return err
 	}
 	return nil

--- a/db/database.go
+++ b/db/database.go
@@ -717,6 +717,8 @@ func (context *DatabaseContext) Close(ctx context.Context) {
 	context.sequences.Stop()
 	context.mutationListener.Stop()
 	context.stopChangeCaches()
+	// Stop the channel cache and it's background tasks.
+	context.channelCache.Stop()
 	context.ImportListener.Stop()
 	if context.Heartbeater != nil {
 		context.Heartbeater.Stop()

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -106,11 +106,7 @@ func (c *DatabaseCollection) exitChanges() chan struct{} {
 // GetCollectionID returns a collectionID. If couchbase server does not return collections, it will return base.DefaultCollectionID, like the default collection for a Couchbase Server that does support collections.
 func (c *DatabaseCollection) GetCollectionID() uint32 {
 	ds := base.GetBaseDataStore(c.dataStore)
-	collection, err := base.AsCollection(ds)
-	if err != nil {
-		return base.DefaultCollectionID
-	}
-	return collection.GetCollectionID()
+	return base.GetCollectionID(ds)
 }
 
 // GetRevisionCacheForTest allow accessing a copy of revision cache.

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1434,6 +1434,10 @@ func TestAccessFunctionValidation(t *testing.T) {
 
 func TestAccessFunctionDb(t *testing.T) {
 
+	if !base.TestsUseDefaultCollection() {
+		t.Skip("Disabled for non-default collection until CBG-2554")
+	}
+
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := db.GetSingleDatabaseCollectionWithUser()


### PR DESCRIPTION
Starts DCP with list of collections, including metadata collection. Fixes retrieval of collectionID for walrusCollections.

Also disables test that's pending CBG-2554.


