### PR TITLE
use collection specified by handler

### DIFF
--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -216,7 +216,7 @@ func (h *handler) handleAllDocs() error {
 
 		}
 	} else {
-		if err := h.db.GetSingleDatabaseCollection().ForEachDocID(h.ctx(), writeDoc, options); err != nil {
+		if err := h.collection.ForEachDocID(h.ctx(), writeDoc, options); err != nil {
 			return err
 		}
 	}

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -341,9 +341,9 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 	var feed <-chan *db.ChangeEntry
 	var err error
 	if len(docids) > 0 {
-		feed, err = h.db.GetSingleDatabaseCollectionWithUser().DocIDChangesFeed(h.ctx(), channels, docids, options)
+		feed, err = h.collection.DocIDChangesFeed(h.ctx(), channels, docids, options)
 	} else {
-		feed, err = h.db.GetSingleDatabaseCollectionWithUser().MultiChangesFeed(h.ctx(), channels, options)
+		feed, err = h.collection.MultiChangesFeed(h.ctx(), channels, options)
 	}
 	if err != nil {
 		return err, false
@@ -443,7 +443,7 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 func (h *handler) generateContinuousChanges(inChannels base.Set, options db.ChangesOptions, send func([]*db.ChangeEntry) error) (error, bool) {
 	// Ensure continuous is set, since generateChanges now supports both continuous and one-shot
 	options.Continuous = true
-	err, forceClose := db.GenerateChanges(h.ctx(), h.rq.Context(), h.db.GetSingleDatabaseCollectionWithUser(), inChannels, options, nil, send)
+	err, forceClose := db.GenerateChanges(h.ctx(), h.rq.Context(), h.collection, inChannels, options, nil, send)
 	if sendErr, ok := err.(*db.ChangesSendErr); ok {
 		h.logStatus(http.StatusOK, fmt.Sprintf("0Write error: %v", sendErr))
 		return nil, forceClose // error is probably because the client closed the connection


### PR DESCRIPTION
Found by grep `GetSingleDatabaseCollection` on files that aren't `test.*\.go` in rest package.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1222/
