### PR TITLE
Make TestProcessRevIncrementsStat wait for stat

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2440,7 +2440,8 @@ func TestProcessRevIncrementsStat(t *testing.T) {
 	err = activeRT.WaitForRev("doc", rev)
 	require.NoError(t, err)
 
-	assert.EqualValues(t, 1, pullStats.HandleRevCount.Value())
+	_, ok := base.WaitForStat(pullStats.HandleRevCount.Value, 1)
+	require.True(t, ok)
 	assert.NotEqualValues(t, 0, pullStats.HandleRevBytes.Value())
 	// Confirm connected client count has not increased, which uses same processRev code
 	assert.EqualValues(t, 0, pullStats.HandlePutRevCount.Value())


### PR DESCRIPTION
Flaked in Jenkins pipeline - I think test raced between rev being recieved and the stat being set (which is in a defer at the end of `handleRev`)

https://jenkins.sgwdev.com/job/Sync%20Gateway%20Pipeline/job/master/395

```
2022-12-05T18:04:42.564Z [INF] HTTP: db:db c:#3376 GET /db/_blipsync?client=sgr2 (as <ud>alice</ud>)
2022-12-05T18:04:42.609Z [INF] HTTP: db:db c:#3377 GET http://localhost/db/<ud>doc</ud> (as ADMIN)
    blip_api_crud_test.go:2443: 
        	Error Trace:	blip_api_crud_test.go:2443
        	Error:      	Not equal: 
        	            	expected: int(1)
        	            	actual  : int64(0)
        	Test:       	TestProcessRevIncrementsStat
2022-12-05T18:04:42.669Z [INF] HTTP: db:db c:[7b8f2a08] #3376:    --> BLIP+WebSocket connection closed
--- FAIL: TestProcessRevIncrementsStat (0.30s)
```