### PR TITLE
WIP CBG-2333 multiple collection sequence allocators

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -49,26 +49,28 @@ var EnableStarChannelLog = true
 //   - Perform sequence buffering to ensure documents are received in sequence order
 //   - Propagating DCP changes down to appropriate channel caches
 type changeCache struct {
-	collection         *DatabaseCollection
-	logCtx             context.Context
-	logsDisabled       bool                    // If true, ignore incoming tap changes
-	nextSequence       uint64                  // Next consecutive sequence number to add.  State variable for sequence buffering tracking.  Should use getNextSequence() rather than accessing directly.
-	initialSequence    uint64                  // DB's current sequence at startup time. Should use getInitialSequence() rather than accessing directly.
-	receivedSeqs       map[uint64]struct{}     // Set of all sequences received
-	pendingLogs        LogPriorityQueue        // Out-of-sequence entries waiting to be cached
-	notifyChange       func(channels.Set)      // Client callback that notifies of channel changes
-	stopped            bool                    // Set by the Stop method
-	skippedSeqs        *SkippedSequenceList    // Skipped sequences still pending on the TAP feed
-	lock               sync.RWMutex            // Coordinates access to struct fields
-	options            CacheOptions            // Cache config
-	terminator         chan bool               // Signal termination of background goroutines
-	backgroundTasks    []BackgroundTask        // List of background tasks.
-	initTime           time.Time               // Cache init time - used for latency calculations
-	channelCache       ChannelCache            // Underlying channel cache
-	lastAddPendingTime int64                   // The most recent time _addPendingLogs was run, as epoch time
-	internalStats      changeCacheStats        // Running stats for the change cache.  Only applied to expvars on a call to changeCache.updateStats
-	cfgEventCallback   base.CfgEventNotifyFunc // Callback for Cfg updates recieved over the caching feed
-	sgCfgPrefix        string                  // Prefix for SG Cfg doc keys
+	dataStoreWithSequence    DataStoreWithSequence
+	logCtx                   context.Context
+	logsDisabled             bool                    // If true, ignore incoming tap changes
+	nextSequence             uint64                  // Next consecutive sequence number to add.  State variable for sequence buffering tracking.  Should use getNextSequence() rather than accessing directly.
+	initialSequence          uint64                  // DB's current sequence at startup time. Should use getInitialSequence() rather than accessing directly.
+	receivedSeqs             map[uint64]struct{}     // Set of all sequences received
+	pendingLogs              LogPriorityQueue        // Out-of-sequence entries waiting to be cached
+	notifyChange             func(channels.Set)      // Client callback that notifies of channel changes
+	stopped                  bool                    // Set by the Stop method
+	skippedSeqs              *SkippedSequenceList    // Skipped sequences still pending on the TAP feed
+	lock                     sync.RWMutex            // Coordinates access to struct fields
+	options                  CacheOptions            // Cache config
+	terminator               chan bool               // Signal termination of background goroutines
+	backgroundTasks          []BackgroundTask        // List of background tasks.
+	initTime                 time.Time               // Cache init time - used for latency calculations
+	channelCache             ChannelCache            // Underlying channel cache
+	lastAddPendingTime       int64                   // The most recent time _addPendingLogs was run, as epoch time
+	internalStats            changeCacheStats        // Running stats for the change cache.  Only applied to expvars on a call to changeCache.updateStats
+	cfgEventCallback         base.CfgEventNotifyFunc // Callback for Cfg updates recieved over the caching feed
+	sgCfgPrefix              string                  // Prefix for SG Cfg doc keys
+	disableCleanSkippedQuery bool
+	principalOnly            bool // in principal only mode, finding channels is not necessary
 }
 
 type changeCacheStats struct {
@@ -81,10 +83,10 @@ func (c *changeCache) updateStats() {
 
 	c.lock.Lock()
 
-	c.collection.dbStats().Database().HighSeqFeed.SetIfMax(int64(c.internalStats.highSeqFeed))
-	c.collection.dbStats().Cache().PendingSeqLen.Set(int64(c.internalStats.pendingSeqLen))
-	c.collection.dbStats().CBLReplicationPull().MaxPending.SetIfMax(int64(c.internalStats.maxPending))
-	c.collection.dbStats().Cache().HighSeqStable.Set(int64(c._getMaxStableCached()))
+	c.dataStoreWithSequence.dbStats().Database().HighSeqFeed.SetIfMax(int64(c.internalStats.highSeqFeed))
+	c.dataStoreWithSequence.dbStats().Cache().PendingSeqLen.Set(int64(c.internalStats.pendingSeqLen))
+	c.dataStoreWithSequence.dbStats().CBLReplicationPull().MaxPending.SetIfMax(int64(c.internalStats.maxPending))
+	c.dataStoreWithSequence.dbStats().Cache().HighSeqStable.Set(int64(c._getMaxStableCached()))
 
 	c.lock.Unlock()
 }
@@ -157,17 +159,17 @@ func DefaultCacheOptions() CacheOptions {
 // notifyChange is an optional function that will be called to notify of channel changes.
 // After calling Init(), you must call .Start() to start useing the cache, otherwise it will be in a locked state
 // and callers will block on trying to obtain the lock.
-func (c *changeCache) Init(logCtx context.Context, collection *DatabaseCollection, channelCache ChannelCache, notifyChange func(channels.Set), options *CacheOptions) error {
-	c.collection = collection
+func (c *changeCache) Init(logCtx context.Context, dataStoreWithSequence DataStoreWithSequence, channelCache ChannelCache, notifyChange func(channels.Set), options *CacheOptions, principalOnly bool) error {
 	c.logCtx = logCtx
-
+	c.dataStoreWithSequence = dataStoreWithSequence
 	c.notifyChange = notifyChange
 	c.receivedSeqs = make(map[uint64]struct{})
 	c.terminator = make(chan bool)
 	c.initTime = time.Now()
 	c.skippedSeqs = NewSkippedSequenceList()
 	c.lastAddPendingTime = time.Now().UnixNano()
-	c.sgCfgPrefix = base.SGCfgPrefixWithGroupID(collection.groupID())
+	c.sgCfgPrefix = base.SGCfgPrefixWithGroupID(dataStoreWithSequence.groupID())
+	c.principalOnly = principalOnly
 
 	// init cache options
 	if options != nil {
@@ -178,18 +180,18 @@ func (c *changeCache) Init(logCtx context.Context, collection *DatabaseCollectio
 
 	c.channelCache = channelCache
 
-	base.InfofCtx(c.logCtx, base.KeyCache, "Initializing changes cache for %s.%s.%s with options %+v", base.UD(collection.bucketName()), base.UD(collection.ScopeName()), base.UD(collection.Name()), c.options)
+	base.InfofCtx(c.logCtx, base.KeyCache, "Initializing changes cache for %s with options %+v", base.UD(c.dataStoreWithSequence.keyspace()), c.options)
 
 	heap.Init(&c.pendingLogs)
 
 	// background tasks that perform housekeeping duties on the cache
-	bgt, err := NewBackgroundTask("InsertPendingEntries", c.collection.Name(), c.InsertPendingEntries, c.options.CachePendingSeqMaxWait/2, c.terminator)
+	bgt, err := NewBackgroundTask("InsertPendingEntries", c.dataStoreWithSequence.keyspace(), c.InsertPendingEntries, c.options.CachePendingSeqMaxWait/2, c.terminator)
 	if err != nil {
 		return err
 	}
 	c.backgroundTasks = append(c.backgroundTasks, bgt)
 
-	bgt, err = NewBackgroundTask("CleanSkippedSequenceQueue", c.collection.Name(), c.CleanSkippedSequenceQueue, c.options.CacheSkippedSeqMaxWait/2, c.terminator)
+	bgt, err = NewBackgroundTask("CleanSkippedSequenceQueue", c.dataStoreWithSequence.keyspace(), c.CleanSkippedSequenceQueue, c.options.CacheSkippedSeqMaxWait/2, c.terminator)
 	if err != nil {
 		return err
 	}
@@ -226,7 +228,7 @@ func (c *changeCache) Stop() {
 	close(c.terminator)
 
 	// Wait for changeCache background tasks to finish.
-	waitForBGTCompletion(context.TODO(), BGTCompletionMaxWait, c.backgroundTasks, c.collection.Name())
+	waitForBGTCompletion(context.TODO(), BGTCompletionMaxWait, c.backgroundTasks, c.dataStoreWithSequence.keyspace())
 
 	c.lock.Lock()
 	c.logsDisabled = true
@@ -258,7 +260,7 @@ func (c *changeCache) Clear() error {
 	// the point at which the change cache was initialized / re-initialized.
 	// No need to touch c.nextSequence here, because we don't want to touch the sequence buffering state.
 	var err error
-	c.initialSequence, err = c.collection.LastSequence()
+	c.initialSequence, err = c.dataStoreWithSequence.LastSequence()
 	if err != nil {
 		return err
 	}
@@ -310,12 +312,12 @@ func (c *changeCache) CleanSkippedSequenceQueue(ctx context.Context) error {
 		return nil
 	}
 
-	base.InfofCtx(ctx, base.KeyCache, "Starting CleanSkippedSequenceQueue, found %d skipped sequences older than max wait for database %s", len(oldSkippedSequences), base.MD(c.collection.Name()))
+	base.InfofCtx(ctx, base.KeyCache, "Starting CleanSkippedSequenceQueue, found %d skipped sequences older than max wait for database %s", len(oldSkippedSequences), base.MD(c.dataStoreWithSequence.keyspace()))
 
 	var foundEntries []*LogEntry
 	var pendingRemovals []uint64
 
-	if c.collection.unsupportedOptions() != nil && c.collection.unsupportedOptions().DisableCleanSkippedQuery {
+	if c.disableCleanSkippedQuery {
 		pendingRemovals = append(pendingRemovals, oldSkippedSequences...)
 		oldSkippedSequences = nil
 	}
@@ -330,12 +332,12 @@ func (c *changeCache) CleanSkippedSequenceQueue(ctx context.Context) error {
 			oldSkippedSequences = nil
 		}
 
-		base.InfofCtx(ctx, base.KeyCache, "Issuing skipped sequence clean query for %d sequences, %d remain pending (db:%s).", len(skippedSeqBatch), len(oldSkippedSequences), base.MD(c.collection.Name()))
+		base.InfofCtx(ctx, base.KeyCache, "Issuing skipped sequence clean query for %d sequences, %d remain pending (db:%s).", len(skippedSeqBatch), len(oldSkippedSequences), base.MD(c.dataStoreWithSequence.keyspace()))
 		// Note: The view query is only going to hit for active revisions - sequences associated with inactive revisions
 		//       aren't indexed by the channel view.  This means we can potentially miss channel removals:
 		//       when an older revision is missed by the TAP feed, and a channel is removed in that revision,
 		//       the doc won't be flagged as removed from that channel in the in-memory channel cache.
-		entries, err := c.collection.getChangesForSequences(ctx, skippedSeqBatch)
+		entries, err := c.dataStoreWithSequence.getChangesForSequences(ctx, skippedSeqBatch)
 		if err != nil {
 			base.WarnfCtx(ctx, "Error retrieving sequences via query during skipped sequence clean - #%d sequences treated as not found: %v", len(skippedSeqBatch), err)
 			continue
@@ -363,7 +365,7 @@ func (c *changeCache) CleanSkippedSequenceQueue(ctx context.Context) error {
 		entry.Skipped = true
 		// Need to populate the actual channels for this entry - the entry returned from the * channel
 		// view will only have the * channel
-		doc, err := c.collection.GetDocument(ctx, entry.DocID, DocUnmarshalNoHistory)
+		doc, err := c.dataStoreWithSequence.GetDocument(ctx, entry.DocID, DocUnmarshalNoHistory)
 		if err != nil {
 			base.WarnfCtx(ctx, "Unable to retrieve doc when processing skipped document %q: abandoning sequence %d", base.UD(entry.DocID), entry.Sequence)
 			continue
@@ -382,9 +384,9 @@ func (c *changeCache) CleanSkippedSequenceQueue(ctx context.Context) error {
 
 	// Purge sequences not found from the skipped sequence queue
 	numRemoved := c.RemoveSkippedSequences(ctx, pendingRemovals)
-	c.collection.dbStats().Cache().AbandonedSeqs.Add(numRemoved)
+	c.dataStoreWithSequence.dbStats().Cache().AbandonedSeqs.Add(numRemoved)
 
-	base.InfofCtx(ctx, base.KeyCache, "CleanSkippedSequenceQueue complete.  Found:%d, Not Found:%d for database %s.", len(foundEntries), len(pendingRemovals), base.MD(c.collection.Name()))
+	base.InfofCtx(ctx, base.KeyCache, "CleanSkippedSequenceQueue complete.  Found:%d, Not Found:%d for database %s.", len(foundEntries), len(pendingRemovals), base.MD(c.dataStoreWithSequence.keyspace()))
 	return nil
 }
 
@@ -434,12 +436,12 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 	// If this is a binary document (and not one of the above types), we can ignore.  Currently only performing this check when xattrs
 	// are enabled, because walrus doesn't support DataType on feed.
-	if c.collection.UseXattrs() && event.DataType == base.MemcachedDataTypeRaw {
+	if c.dataStoreWithSequence.UseXattrs() && event.DataType == base.MemcachedDataTypeRaw {
 		return
 	}
 
 	// First unmarshal the doc (just its metadata, to save time/memory):
-	syncData, rawBody, _, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, c.collection.userXattrKey(), false)
+	syncData, rawBody, _, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, c.dataStoreWithSequence.userXattrKey(), false)
 	if err != nil {
 		// Avoid log noise related to failed unmarshaling of binary documents.
 		if event.DataType != base.MemcachedDataTypeRaw {
@@ -452,7 +454,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	}
 
 	// If using xattrs and this isn't an SG write, we shouldn't attempt to cache.
-	if c.collection.UseXattrs() {
+	if c.dataStoreWithSequence.UseXattrs() {
 		if syncData == nil {
 			return
 		}
@@ -464,14 +466,14 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 	// If not using xattrs and no sync metadata found, check whether we're mid-upgrade and attempting to read a doc w/ metadata stored in xattr
 	// before ignoring the mutation.
-	if !c.collection.UseXattrs() && !syncData.HasValidSyncData() {
-		migratedDoc, _ := c.collection.checkForUpgrade(docID, DocUnmarshalNoHistory)
+	if !c.dataStoreWithSequence.UseXattrs() && !syncData.HasValidSyncData() {
+		migratedDoc, _ := c.dataStoreWithSequence.checkForUpgrade(docID, DocUnmarshalNoHistory)
 		if migratedDoc != nil && migratedDoc.Cas == event.Cas {
 			base.InfofCtx(c.logCtx, base.KeyCache, "Found mobile xattr on doc %q without %s property - caching, assuming upgrade in progress.", base.UD(docID), base.SyncPropertyName)
 			syncData = &migratedDoc.SyncData
 		} else {
 			base.InfofCtx(c.logCtx, base.KeyCache, "changeCache: Doc %q does not have valid sync data.", base.UD(docID))
-			c.collection.dbStats().Cache().NonMobileIgnoredCount.Add(1)
+			c.dataStoreWithSequence.dbStats().Cache().NonMobileIgnoredCount.Add(1)
 			return
 		}
 	}
@@ -491,10 +493,10 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 		// Record latency when greater than zero
 		feedNano := feedLatency.Nanoseconds()
 		if feedNano > 0 {
-			c.collection.dbStats().Database().DCPReceivedTime.Add(feedNano)
+			c.dataStoreWithSequence.dbStats().Database().DCPReceivedTime.Add(feedNano)
 		}
 	}
-	c.collection.dbStats().Database().DCPReceivedCount.Add(1)
+	c.dataStoreWithSequence.dbStats().Database().DCPReceivedCount.Add(1)
 
 	// If the doc update wasted any sequences due to conflicts, add empty entries for them:
 	for _, seq := range syncData.UnusedSequences {
@@ -782,8 +784,8 @@ func (c *changeCache) _addToCache(change *LogEntry) []channels.ID {
 	}
 
 	if !change.TimeReceived.IsZero() {
-		c.collection.dbStats().Database().DCPCachingCount.Add(1)
-		c.collection.dbStats().Database().DCPCachingTime.Add(time.Since(change.TimeReceived).Nanoseconds())
+		c.dataStoreWithSequence.dbStats().Database().DCPCachingCount.Add(1)
+		c.dataStoreWithSequence.dbStats().Database().DCPCachingTime.Add(time.Since(change.TimeReceived).Nanoseconds())
 	}
 
 	return updatedChannels
@@ -802,7 +804,7 @@ func (c *changeCache) _addPendingLogs() channels.Set {
 			heap.Pop(&c.pendingLogs)
 			changedChannels = changedChannels.UpdateWithSlice(c._addToCache(change))
 		} else if len(c.pendingLogs) > c.options.CachePendingSeqMaxNum || time.Since(c.pendingLogs[0].TimeReceived) >= c.options.CachePendingSeqMaxWait {
-			c.collection.dbStats().Cache().NumSkippedSeqs.Add(1)
+			c.dataStoreWithSequence.dbStats().Cache().NumSkippedSeqs.Add(1)
 			c.PushSkipped(c.nextSequence)
 			c.nextSequence++
 		} else {
@@ -894,14 +896,14 @@ func (h *LogPriorityQueue) Pop() interface{} {
 
 func (c *changeCache) RemoveSkipped(x uint64) error {
 	err := c.skippedSeqs.Remove(x)
-	c.collection.dbStats().Cache().SkippedSeqLen.Set(int64(c.skippedSeqs.skippedList.Len()))
+	c.dataStoreWithSequence.dbStats().Cache().SkippedSeqLen.Set(int64(c.skippedSeqs.skippedList.Len()))
 	return err
 }
 
 // Removes a set of sequences.  Logs warning on removal error, returns count of successfully removed.
 func (c *changeCache) RemoveSkippedSequences(ctx context.Context, sequences []uint64) (removedCount int64) {
 	numRemoved := c.skippedSeqs.RemoveSequences(ctx, sequences)
-	c.collection.dbStats().Cache().SkippedSeqLen.Set(int64(c.skippedSeqs.skippedList.Len()))
+	c.dataStoreWithSequence.dbStats().Cache().SkippedSeqLen.Set(int64(c.skippedSeqs.skippedList.Len()))
 	return numRemoved
 }
 
@@ -915,7 +917,7 @@ func (c *changeCache) PushSkipped(sequence uint64) {
 		base.InfofCtx(c.logCtx, base.KeyCache, "Error pushing skipped sequence: %d, %v", sequence, err)
 		return
 	}
-	c.collection.dbStats().Cache().SkippedSeqLen.Set(int64(c.skippedSeqs.skippedList.Len()))
+	c.dataStoreWithSequence.dbStats().Cache().SkippedSeqLen.Set(int64(c.skippedSeqs.skippedList.Len()))
 }
 
 func (c *changeCache) GetSkippedSequencesOlderThanMaxWait() (oldSequences []uint64) {

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -2071,7 +2071,7 @@ func BenchmarkProcessEntry(b *testing.B) {
 
 			ctx = context.AddDatabaseLogContext(ctx)
 			changeCache := &changeCache{}
-			if err := changeCache.Init(ctx, collection, context.channelCache, nil, nil); err != nil {
+			if err := changeCache.Init(ctx, collection, context.channelCache, nil, nil, false); err != nil {
 				log.Printf("Init failed for changeCache: %v", err)
 				b.Fail()
 			}
@@ -2303,7 +2303,7 @@ func BenchmarkDocChanged(b *testing.B) {
 
 			ctx = context.AddDatabaseLogContext(ctx)
 			changeCache := &changeCache{}
-			if err := changeCache.Init(ctx, collection, context.channelCache, nil, nil); err != nil {
+			if err := changeCache.Init(ctx, collection, context.channelCache, nil, nil, false); err != nil {
 				log.Printf("Init failed for changeCache: %v", err)
 				b.Fail()
 			}

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -196,50 +196,12 @@ func (dbc *DatabaseCollection) getChangesInChannelFromQuery(ctx context.Context,
 // Queries the 'channels' view to get changes from a channel for the specified sequence.  Used for skipped sequence check
 // before abandoning.
 func (dbc *DatabaseCollection) getChangesForSequences(ctx context.Context, sequences []uint64) (LogEntries, error) {
-	if dbc.dataStore == nil {
-		return nil, errors.New("No data store available for sequence query")
-	}
-	start := time.Now()
-	usingViews := dbc.useViews()
-
-	entries := make(LogEntries, 0)
-
-	// Query the view or index
-	queryResults, err := dbc.QuerySequences(ctx, sequences)
-	if err != nil {
-		return nil, err
-	}
-	collectionID := dbc.GetCollectionID()
-
-	// Convert the output to LogEntries.  Channel query and view result rows have different structure, so need to unmarshal independently.
-	for {
-		var entry *LogEntry
-		var found bool
-		if usingViews {
-			entry, found = nextChannelViewEntry(queryResults, collectionID)
-		} else {
-			entry, found = nextChannelQueryEntry(queryResults, collectionID)
-		}
-
-		if !found {
-			break
-		}
-		entries = append(entries, entry)
+	options := querySequencesOptions{
+		dbStats:                   dbc.dbStats(),
+		useViews:                  dbc.useViews(),
+		useXattrs:                 dbc.UseXattrs(),
+		slowQueryWarningThreshold: dbc.slowQueryWarningThreshold(),
 	}
 
-	// Close query results
-	closeErr := queryResults.Close()
-	if closeErr != nil {
-		return nil, closeErr
-	}
-
-	base.InfofCtx(ctx, base.KeyCache, "Got rows from sequence query: #%d sequences found/#%d sequences queried",
-		len(entries), len(sequences))
-
-	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
-		base.InfofCtx(ctx, base.KeyAll, "Sequences query took %v to return %d rows. #sequences queried: %d",
-			elapsed, len(entries), len(sequences))
-	}
-
-	return entries, nil
+	return getChangesForSequences(ctx, dbc.dbCtx, dbc.dataStore, sequences, options)
 }

--- a/db/database.go
+++ b/db/database.go
@@ -90,7 +90,7 @@ type DatabaseContext struct {
 	BucketLock                  sync.RWMutex            // Control Access to the underlying bucket object
 	mutationListener            changeListener          // Caching feed listener
 	ImportListener              *importListener         // Import feed listener
-	sequences                   *sequenceAllocator      // Source of new sequence numbers
+	principalSequences          *principalSequences     // Manager of principal sequence numbers
 	ChannelMapper               *channels.ChannelMapper // Runs JS 'sync' function
 	StartTime                   time.Time               // Timestamp when context was instantiated
 	RevsLimit                   uint32                  // Max depth a document's revision tree can grow to
@@ -384,23 +384,6 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 
 	dbContext.EventMgr = NewEventManager(dbContext.terminator)
 
-	var err error
-	dbContext.sequences, err = newSequenceAllocator(metadataStore, dbContext.DbStats.Database())
-	if err != nil {
-		return nil, err
-	}
-
-	cleanupFunctions = append(cleanupFunctions, func() {
-		dbContext.sequences.Stop()
-	})
-
-	// Get current value of _sync:seq
-	initialSequence, seqErr := dbContext.sequences.lastSequence()
-	if seqErr != nil {
-		return nil, seqErr
-	}
-	initialSequenceTime := time.Now()
-
 	// Initialize the active channel counter
 	dbContext.activeChannels = channels.NewActiveChannels(dbContext.DbStats.Cache().NumActiveChannels)
 
@@ -455,6 +438,11 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 
 		dbContext.CollectionByID[base.DefaultCollectionID] = dbCollection
 		dbContext.singleCollection = dbCollection
+	}
+
+	dbContext.principalSequences, err = newPrincipalSequences(ctx, dbContext)
+	if err != nil {
+		return nil, err
 	}
 
 	// Initialize the tap Listener for notify handling
@@ -516,20 +504,9 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		dbContext.mutationListener.Stop()
 	})
 
-	// Unlock change cache.  Validate that any allocated sequences on other nodes have either been assigned or released
-	// before starting
-	if initialSequence > 0 {
-		_ = dbContext.sequences.waitForReleasedSequences(initialSequenceTime)
-	}
-
-	for _, collection := range dbContext.CollectionByID {
-		err = collection.changeCache.Start(initialSequence)
-		if err != nil {
-			return nil, err
-		}
-		cleanupFunctions = append(cleanupFunctions, func() {
-			collection.changeCache.Stop()
-		})
+	err = startChangeCaches(dbContext, cleanupFunctions)
+	if err != nil {
+		return nil, err
 	}
 
 	// If this is an xattr import node, start import feed.  Must be started after the caching DCP feed, as import cfg
@@ -714,7 +691,7 @@ func (context *DatabaseContext) Close(ctx context.Context) {
 	close(context.terminator)
 	// Wait for database background tasks to finish.
 	waitForBGTCompletion(ctx, BGTCompletionMaxWait, context.backgroundTasks, context.Name)
-	context.sequences.Stop()
+	context.stopSequenceAllocators()
 	context.mutationListener.Stop()
 	context.stopChangeCaches()
 	// Stop the channel cache and it's background tasks.
@@ -1562,7 +1539,7 @@ func (db *DatabaseCollectionWithUser) UpdateAllDocChannels(ctx context.Context, 
 
 	queryLimit := db.queryPaginationLimit()
 	startSeq := uint64(0)
-	endSeq, err := db.sequences().getSequence()
+	endSeq, err := db.sequences.getSequence()
 	if err != nil {
 		return 0, err
 	}
@@ -1745,7 +1722,7 @@ func (db *DatabaseCollectionWithUser) UpdateAllDocChannels(ctx context.Context, 
 	}
 
 	for _, sequence := range unusedSequences {
-		err := db.sequences().releaseSequence(sequence)
+		err := db.sequences.releaseSequence(sequence)
 		if err != nil {
 			base.WarnfCtx(ctx, "Error attempting to release sequence %d. Error %v", sequence, err)
 		}
@@ -1759,7 +1736,7 @@ func (db *DatabaseCollectionWithUser) UpdateAllDocChannels(ctx context.Context, 
 
 		authr := db.Authenticator(ctx)
 		regeneratePrincipalSequences := func(princ auth.Principal) error {
-			nextSeq, err := db.sequences().nextSequence()
+			nextSeq, err := db.principalSequences().nextSequence()
 			if err != nil {
 				return err
 			}
@@ -1977,12 +1954,6 @@ func (context *DatabaseContext) AllowFlushNonCouchbaseBuckets() bool {
 	return false
 }
 
-// ////// SEQUENCE ALLOCATION:
-
-func (context *DatabaseContext) LastSequence() (uint64, error) {
-	return context.sequences.lastSequence()
-}
-
 // Helpers for unsupported options
 func (context *DatabaseContext) IsGuestReadOnly() bool {
 	return context.Options.UnsupportedOptions != nil && context.Options.UnsupportedOptions.GuestReadOnly
@@ -2023,8 +1994,8 @@ func (dbCtx *DatabaseContext) AddDatabaseLogContext(ctx context.Context) context
 	return ctx
 }
 
-// onlyDefaultCollection is true if the database is only configured with default collection.
-func (dbCtx *DatabaseContext) onlyDefaultCollection() bool {
+// OnlyDefaultCollection is true if the database is only configured with default collection.
+func (dbCtx *DatabaseContext) OnlyDefaultCollection() bool {
 	if len(dbCtx.CollectionByID) > 1 {
 		return false
 	}
@@ -2034,7 +2005,7 @@ func (dbCtx *DatabaseContext) onlyDefaultCollection() bool {
 
 // GetDatabaseCollectionWithUser returns a collection if one exists, otherwise error.
 func (dbc *Database) GetDatabaseCollectionWithUser(scopeName, collectionName string) (*DatabaseCollectionWithUser, error) {
-	if base.IsDefaultCollection(scopeName, collectionName) && dbc.onlyDefaultCollection() {
+	if base.IsDefaultCollection(scopeName, collectionName) && dbc.OnlyDefaultCollection() {
 		return dbc.GetDefaultDatabaseCollectionWithUser()
 	}
 	if dbc.Scopes == nil {
@@ -2111,6 +2082,7 @@ func newDatabaseCollection(ctx context.Context, dbContext *DatabaseContext, data
 		dbContext.channelCache,
 		notifyChange,
 		dbContext.Options.CacheOptions,
+		false,
 	)
 	if err != nil {
 		base.DebugfCtx(ctx, base.KeyDCP, "Error initializing the change cache", err)
@@ -2126,11 +2098,49 @@ func newDatabaseCollection(ctx context.Context, dbContext *DatabaseContext, data
 		}
 		dbCollection.changeCache.cfgEventCallback = cfgSG.FireEvent
 	}
+	dbCollection.sequences, err = newSequenceAllocator(dbCollection.dataStore, dbCollection.dbStats().Database())
+	if err != nil {
+		return nil, err
+	}
+
 	return dbCollection, nil
+}
+
+func startChangeCaches(dbContext *DatabaseContext, cleanupFunctions []func()) error {
+	for _, collection := range dbContext.CollectionByID {
+		// Get current value of _sync:seq
+		initialSequence, seqErr := collection.LastSequence()
+		if seqErr != nil {
+			return seqErr
+		}
+		initialSequenceTime := time.Now()
+
+		// Unlock change cache.  Validate that any allocated sequences on other nodes have either been assigned or released
+		// before starting
+		if initialSequence > 0 {
+			_ = collection.sequences.waitForReleasedSequences(initialSequenceTime)
+		}
+
+		err := collection.changeCache.Start(initialSequence)
+		if err != nil {
+			return err
+		}
+		cleanupFunctions = append(cleanupFunctions, func() {
+			collection.changeCache.Stop()
+		})
+	}
+	return nil
 }
 
 func (dbc *DatabaseContext) stopChangeCaches() {
 	for _, collection := range dbc.CollectionByID {
 		collection.changeCache.Stop()
 	}
+}
+
+func (dbc *DatabaseContext) stopSequenceAllocators() {
+	for _, collection := range dbc.CollectionByID {
+		collection.sequences.Stop()
+	}
+	dbc.principalSequences.sequences.Stop()
 }

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -21,7 +21,7 @@ package db
 
 // Update database-specific stats that are more efficiently calculated at stats collection time
 func (db *DatabaseContext) UpdateCalculatedStats() {
-	if !db.onlyDefaultCollection() {
+	if !db.OnlyDefaultCollection() {
 		return
 	}
 	defaultCollection, err := db.GetDefaultDatabaseCollection()

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -927,7 +927,7 @@ func TestUpdatePrincipal(t *testing.T) {
 	_, err = db.UpdatePrincipal(ctx, userInfo, true, true)
 	assert.NoError(t, err, "Unable to update principal")
 
-	nextSeq, err := db.sequences.nextSequence()
+	nextSeq, err := db.principalSequences.sequences.nextSequence()
 	assert.Equal(t, uint64(1), nextSeq)
 
 	// Validate that a call to UpdatePrincipals with changes to the user does allocate a sequence
@@ -936,7 +936,7 @@ func TestUpdatePrincipal(t *testing.T) {
 	_, err = db.UpdatePrincipal(ctx, userInfo, true, true)
 	assert.NoError(t, err, "Unable to update principal")
 
-	nextSeq, err = db.sequences.nextSequence()
+	nextSeq, err = db.principalSequences.sequences.nextSequence()
 	assert.Equal(t, uint64(3), nextSeq)
 }
 

--- a/db/datastore_sequences.go
+++ b/db/datastore_sequences.go
@@ -1,0 +1,103 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sync_gateway/base"
+)
+
+type DataStoreWithSequence interface {
+	GetDocument(ctx context.Context, docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error)
+	LastSequence() (uint64, error)
+	groupID() string
+	QuerySequences(ctx context.Context, sequences []uint64) (sgbucket.QueryResultIterator, error)
+	UseXattrs() bool
+	checkForUpgrade(key string, unmarshalLevel DocumentUnmarshalLevel) (*Document, *sgbucket.BucketDocument)
+	dbStats() *base.DbStats
+	getChangesForSequences(ctx context.Context, sequences []uint64) (LogEntries, error)
+	keyspace() string
+	userXattrKey() string
+}
+
+type querySequencesOptions struct {
+	dbStats                   *base.DbStats
+	useViews                  bool
+	useXattrs                 bool
+	slowQueryWarningThreshold time.Duration
+}
+
+// Queries the 'channels' view to get changes from a channel for the specified sequence.  Used for skipped sequence check
+// before abandoning.
+func getChangesForSequences(ctx context.Context, dbContext *DatabaseContext, dataStore base.DataStore, sequences []uint64, options querySequencesOptions) (LogEntries, error) {
+	if dataStore == nil {
+		return nil, errors.New("No data store available for sequence query")
+	}
+
+	start := time.Now()
+
+	entries := make(LogEntries, 0)
+
+	// Query the view or index
+	queryResults, err := querySequences(ctx, dbContext, dataStore, sequences, options)
+	if err != nil {
+		return nil, err
+	}
+	collectionID := base.GetCollectionID(dataStore)
+
+	// Convert the output to LogEntries.  Channel query and view result rows have different structure, so need to unmarshal independently.
+	for {
+		var entry *LogEntry
+		var found bool
+		if options.useViews {
+			entry, found = nextChannelViewEntry(queryResults, collectionID)
+		} else {
+			entry, found = nextChannelQueryEntry(queryResults, collectionID)
+		}
+
+		if !found {
+			break
+		}
+		entries = append(entries, entry)
+	}
+
+	// Close query results
+	closeErr := queryResults.Close()
+	if closeErr != nil {
+		return nil, closeErr
+	}
+
+	base.InfofCtx(ctx, base.KeyCache, "Got rows from sequence query: #%d sequences found/#%d sequences queried",
+		len(entries), len(sequences))
+
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		base.InfofCtx(ctx, base.KeyAll, "Sequences query took %v to return %d rows. #sequences queried: %d",
+			elapsed, len(entries), len(sequences))
+	}
+
+	return entries, nil
+}
+
+// Query to retrieve keys for the specified sequences.  View query uses star channel, N1QL query uses IndexAllDocs
+func querySequences(ctx context.Context, dbContext *DatabaseContext, dataStore base.DataStore, sequences []uint64, options querySequencesOptions) (sgbucket.QueryResultIterator, error) {
+
+	if len(sequences) == 0 {
+		return nil, errors.New("No sequences specified for QueryChannelsForSequences")
+	}
+
+	if options.useViews {
+		opts := changesViewForSequencesOptions(sequences)
+		return dbContext.ViewQueryWithStats(ctx, dataStore, DesignDocSyncGateway(), ViewChannels, opts)
+	}
+
+	// N1QL Query
+	sequenceQueryStatement := replaceSyncTokensQuery(QuerySequences.statement, options.useXattrs)
+	sequenceQueryStatement = replaceIndexTokensQuery(sequenceQueryStatement, sgIndexes[IndexAllDocs], options.useXattrs)
+
+	params := make(map[string]interface{})
+	params[QueryParamInSequences] = sequences
+
+	return N1QLQueryWithStats(ctx, dataStore, QuerySequences.name, sequenceQueryStatement, params, base.RequestPlus, QueryChannels.adhoc, options.dbStats, dbContext.Options.SlowQueryWarningThreshold)
+}

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -63,7 +63,7 @@ func (il *importListener) StartImportFeed(ctx context.Context, bucket base.Bucke
 		scopeName = sn
 	}
 
-	if !dbContext.onlyDefaultCollection() {
+	if !dbContext.OnlyDefaultCollection() {
 		gocbv2Bucket, err := base.AsGocbV2Bucket(bucket)
 		if err != nil {
 			return err

--- a/db/principal_sequences.go
+++ b/db/principal_sequences.go
@@ -1,0 +1,112 @@
+package db
+
+import (
+	"context"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
+)
+
+type principalSequences struct {
+	dbCtx       *DatabaseContext
+	sequences   *sequenceAllocator // Source of new sequence numbers for prinicipals
+	changeCache *changeCache       // Buffering of seqnos for principals
+}
+
+func newPrincipalSequences(ctx context.Context, dbCtx *DatabaseContext) (*principalSequences, error) {
+	ps := &principalSequences{
+		dbCtx:       dbCtx,
+		changeCache: &changeCache{},
+	}
+	var err error
+	ps.sequences, err = newSequenceAllocator(dbCtx.MetadataStore, dbCtx.DbStats.Database())
+	if err != nil {
+		return nil, err
+	}
+	// Callback that is invoked whenever a set of channels is changed in the ChangeCache
+	notifyChange := func(changedChannels channels.Set) {
+		dbCtx.mutationListener.Notify(changedChannels)
+	}
+
+	err = ps.changeCache.Init(
+		ctx,
+		ps,
+		dbCtx.channelCache,
+		notifyChange,
+		dbCtx.Options.CacheOptions,
+		true,
+	)
+	if err != nil {
+		base.DebugfCtx(ctx, base.KeyDCP, "Error initializing the change cache for prinicpal storage", err)
+		return nil, err
+	}
+
+	return ps, nil
+}
+
+func (ps *principalSequences) getDocOptions() getDocumentOptions {
+	return getDocumentOptions{
+		useXattrs:    ps.dbCtx.UseXattrs(),
+		userXattrKey: ps.dbCtx.Options.UserXattrKey,
+		dbStats:      ps.dbCtx.DbStats,
+	}
+}
+
+func (ps *principalSequences) GetDocument(ctx context.Context, docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
+	return getDocument(ctx, nil, ps.dbCtx.MetadataStore, docid, unmarshalLevel, ps.getDocOptions())
+}
+
+func (ps *principalSequences) LastSequence() (uint64, error) {
+	return ps.sequences.lastSequence()
+}
+func (ps *principalSequences) groupID() string {
+	return ps.dbCtx.Options.GroupID
+}
+
+func (ps *principalSequences) QuerySequences(ctx context.Context, sequences []uint64) (sgbucket.QueryResultIterator, error) {
+	return querySequences(ctx, ps.dbCtx, ps.dbCtx.MetadataStore, sequences, ps.getQuerySequenceOptions())
+}
+
+func (ps *principalSequences) UseXattrs() bool {
+	return ps.dbCtx.Options.EnableXattr
+}
+
+func (ps *principalSequences) checkForUpgrade(key string, unmarshalLevel DocumentUnmarshalLevel) (*Document, *sgbucket.BucketDocument) {
+	// If we are using xattrs or Couchbase Server doesn't support them, an upgrade isn't going to be in progress
+	if ps.UseXattrs() || !ps.dbCtx.MetadataStore.IsSupported(sgbucket.BucketStoreFeatureXattrs) {
+		return nil, nil
+	}
+
+	doc, rawDocument, err := getDocWithXattr(ps.dbCtx.MetadataStore, key, unmarshalLevel, ps.userXattrKey())
+	if err != nil || doc == nil || !doc.HasValidSyncData() {
+		return nil, nil
+	}
+	return doc, rawDocument
+}
+
+func (ps *principalSequences) dbStats() *base.DbStats {
+	return ps.dbCtx.DbStats
+}
+
+func (ps *principalSequences) getChangesForSequences(ctx context.Context, sequences []uint64) (LogEntries, error) {
+	return getChangesForSequences(ctx, ps.dbCtx, ps.dbCtx.MetadataStore, sequences, ps.getQuerySequenceOptions())
+}
+
+func (ps *principalSequences) keyspace() string {
+	return ps.dbCtx.Name
+}
+
+func (ps *principalSequences) userXattrKey() string {
+	return ps.dbCtx.Options.UserXattrKey
+}
+
+func (ps *principalSequences) getQuerySequenceOptions() querySequencesOptions {
+	return querySequencesOptions{
+		dbStats:                   ps.dbCtx.DbStats,
+		useViews:                  ps.dbCtx.Options.UseViews,
+		useXattrs:                 ps.UseXattrs(),
+		slowQueryWarningThreshold: ps.dbCtx.Options.SlowQueryWarningThreshold,
+	}
+
+}

--- a/db/users.go
+++ b/db/users.go
@@ -32,7 +32,7 @@ func (db *DatabaseContext) DeleteRole(ctx context.Context, name string, purge bo
 		return base.ErrNotFound
 	}
 
-	seq, err := db.sequences.nextSequence()
+	seq, err := db.principalSequences.sequences.nextSequence()
 	if err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		// Update the persistent sequence number of this principal (only allocate a sequence when needed - issue #673):
 		nextSeq := uint64(0)
 		var err error
-		nextSeq, err = dbc.sequences.nextSequence()
+		nextSeq, err = dbc.principalSequences.sequences.nextSequence()
 		if err != nil {
 			return replaced, err
 		}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1051,7 +1051,13 @@ func (h *handler) handleGetStatus() error {
 
 		// Don't bother trying to lookup LastSequence() if offline
 		if runState != db.RunStateString[db.DBOffline] {
-			lastSeq, _ = database.LastSequence()
+			if database.OnlyDefaultCollection() {
+				collection, err := database.GetDefaultDatabaseCollection()
+				if err != nil {
+					return err
+				}
+				lastSeq, _ = collection.LastSequence()
+			}
 		}
 
 		replicationsStatus, err := database.SGReplicateMgr.GetReplicationStatusAll(db.DefaultReplicationStatusOptions())

--- a/rest/api.go
+++ b/rest/api.go
@@ -391,8 +391,10 @@ func (h *handler) handleGetDB() error {
 	// Don't bother trying to lookup LastSequence() if offline
 	runState := db.RunStateString[atomic.LoadUint32(&h.db.State)]
 	if runState != db.RunStateString[db.DBOffline] {
-		lastSeq, _ := h.db.LastSequence()
-		defaultCollectionLastSeq = &lastSeq
+		if h.db.OnlyDefaultCollection() {
+			lastSeq, _ := h.collection.LastSequence()
+			defaultCollectionLastSeq = &lastSeq
+		}
 	}
 
 	var response = DatabaseRoot{

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -199,7 +199,7 @@ func (h *handler) handleAllDocs() error {
 	options.Limit = h.getIntQuery("limit", 0)
 
 	// Now it's time to actually write the response!
-	lastSeq, _ := h.db.LastSequence()
+	lastSeq, _ := h.collection.LastSequence()
 	h.setHeader("Content-Type", "application/json")
 	// response.Write below would set Status OK implicitly. We manually do it here to ensure that our handler knows
 	// that the header has been written to, meaning we can prevent it from attempting to set the header again later on.

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -111,7 +111,7 @@ func (tester *ChannelRevocationTester) removeUserChannel(user, channel string) {
 }
 
 func (tester *ChannelRevocationTester) fillToSeq(seq uint64) {
-	currentSeq, err := tester.restTester.GetDatabase().LastSequence()
+	currentSeq, err := tester.restTester.GetDatabase().GetSingleDatabaseCollection().LastSequence()
 	require.NoError(tester.test, err)
 
 	loopCount := seq - currentSeq


### PR DESCRIPTION
Create `DataStoreWithSequence` interface which is implemented on `DatabaseCollection` and contains all the functions necessary for `sequenceAllocator` and `changeCache`.

Since `DatabaseContext.MetadataStore` is not a collection, use new interface `DataStoreWithSequence` to allow using on a generic `DataStore` interface. This means I had to move some CRUD/query operations out of `DatabaseCollection` to free functions which take a `DataStore` object.

The walrus tests do not currently pass.

- [] make walrus tests pass
- [] understand why getDocument can trigger a db import, and decide if this is required for `MetadataStore`. There is a FIXME on this code.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
