### PR TITLE
CBG-2551 Collection access for _user REST API

### DIFF
--- a/auth/collection_access.go
+++ b/auth/collection_access.go
@@ -62,6 +62,9 @@ type CollectionChannelAPI interface {
 
 	// Retrieves or creates collection access entry on principal for specified scope and collection
 	getOrCreateCollectionAccess(scope, collection string) *CollectionAccess
+
+	// Returns the CollectionAccess map
+	GetCollectionsAccess() map[string]map[string]*CollectionAccess
 }
 
 // UserCollectionChannelAPI defines the interface for managing channel access that is supported by users but not roles.

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -150,7 +150,7 @@ type User interface {
 type PrincipalConfig struct {
 	Name             *string                                       `json:"name,omitempty"`
 	ExplicitChannels base.Set                                      `json:"admin_channels,omitempty"`
-	CollectionAccess map[string]map[string]*CollectionAccessConfig `json:"collection_access"`
+	CollectionAccess map[string]map[string]*CollectionAccessConfig `json:"collection_access,omitempty"`
 	// Fields below only apply to Users, not Roles:
 	Email             *string  `json:"email,omitempty"`
 	Disabled          *bool    `json:"disabled,omitempty"`

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -148,8 +148,9 @@ type User interface {
 // Used to define a user/role within DbConfig, and structures the request/response body in the admin REST API
 // for /db/_user/*
 type PrincipalConfig struct {
-	Name             *string  `json:"name,omitempty"`
-	ExplicitChannels base.Set `json:"admin_channels,omitempty"`
+	Name             *string                                       `json:"name,omitempty"`
+	ExplicitChannels base.Set                                      `json:"admin_channels,omitempty"`
+	CollectionAccess map[string]map[string]*CollectionAccessConfig `json:"collection_access"`
 	// Fields below only apply to Users, not Roles:
 	Email             *string  `json:"email,omitempty"`
 	Disabled          *bool    `json:"disabled,omitempty"`
@@ -161,6 +162,14 @@ type PrincipalConfig struct {
 	JWTIssuer      *string    `json:"jwt_issuer,omitempty"`
 	JWTRoles       base.Set   `json:"jwt_roles,omitempty"`
 	JWTChannels    base.Set   `json:"jwt_channels,omitempty"`
+	JWTLastUpdated *time.Time `json:"jwt_last_updated,omitempty"`
+}
+
+type CollectionAccessConfig struct {
+	ExplicitChannels_ base.Set `json:"admin_channels,omitempty"`
+	// read-only
+	Channels_      base.Set   `json:"all_channels,omitempty"`
+	JWTChannels_   base.Set   `json:"jwt_channels,omitempty"` // TODO: JWT properties should only be populated for user but would like to share scope/collection map
 	JWTLastUpdated *time.Time `json:"jwt_last_updated,omitempty"`
 }
 

--- a/auth/role_collection_access.go
+++ b/auth/role_collection_access.go
@@ -229,3 +229,7 @@ func (role *roleImpl) initChannels(scopeName, collectionName string, channels ba
 	role.SetCollectionExplicitChannels(scopeName, collectionName, ch.AtSequence(channels, 1), 0)
 	return role.CollectionExplicitChannels(scopeName, collectionName).Validate()
 }
+
+func (role *roleImpl) GetCollectionsAccess() map[string]map[string]*CollectionAccess {
+	return role.CollectionsAccess
+}


### PR DESCRIPTION
CBG-2551

Adds basic read/write of collection explicit channels for /db/_user endpoint.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1197/
