### PR TITLE
CBG-2266 cleanup collections

### DIFF
--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -432,7 +432,7 @@ func TestCollectionsChangeConfigScope(t *testing.T) {
 	require.NoError(t, err)
 	defer func() {
 		collection, err := base.AsCollection(tb.DefaultDataStore())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		cm := collection.Collection.Bucket().Collections()
 		for scope := range scopesAndCollections {
 			assert.NoError(t, cm.DropScope(scope, nil))


### PR DESCRIPTION
Without explicitly deleting these scopes, the bucket emptier function will fail because it tries to drop the scope with a primary index and once this test is run, we'll lose access to this bucket.

An example, using 1 bucket with this test and the subsequent test will show the failure:

```
env SG_TEST_COLLECTION_POOL_SIZE=2 SG_TEST_BUCKET_POOL_SIZE=1 SG_TEST_BUCKET_POOL_PRESERVE=true SG_TEST_BUCKET_POOL_DEBUG=true SG_TEST_USE_GSI=true SG_TEST_BACKING_STORE=couchbase go test -tags cb_sg_enterprise ./rest -run '(TestCollectionsChangeConfigScope|TestRoot)'  -v -failfast
```

will produce

```
2022-12-06T11:10:05.630-05:00 TEST: b:sg_int_0_1670342845169039014 Running bucket through readier function
2022-12-06T11:10:05.630-05:00 TEST: b:sg_int_0_1670342845169039014 emptying bucket via N1QL, readying views and indexes
2022-12-06T11:10:05.641-05:00 TEST: b:sg_int_0_1670342845169039014 Couldn't ready bucket, got error: bucket does not have primary index, so can't empty bucket using N1QL - Retrying
```

and not ready the bucket ever.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1199/
