### PR TITLE
Fixed TestsUseDefaultCollection/tbp.shouldUseCollections inconsistency for unset env var

### DIFF
--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -28,7 +28,7 @@ const oneShotDCPTimeout = 5 * time.Minute
 
 func TestOneShotDCP(t *testing.T) {
 
-	DisableTestWithCollections(t)
+	TemporarilyDisableTestUsingDCPWithCollections(t)
 
 	if UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
@@ -189,7 +189,7 @@ func TestTerminateDCPFeed(t *testing.T) {
 // changes in the VbUUID
 func TestDCPClientMultiFeedConsistency(t *testing.T) {
 
-	DisableTestWithCollections(t)
+	TemporarilyDisableTestUsingDCPWithCollections(t)
 
 	if UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
@@ -326,7 +326,7 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 // TestResumeInterruptedFeed uses persisted metadata to resume the feed
 func TestResumeStoppedFeed(t *testing.T) {
 
-	DisableTestWithCollections(t)
+	TemporarilyDisableTestUsingDCPWithCollections(t)
 
 	if UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -28,10 +28,7 @@ const oneShotDCPTimeout = 5 * time.Minute
 
 func TestOneShotDCP(t *testing.T) {
 
-	if !TestsUseDefaultCollection() {
-		// FIXME MB-53448 cannot close if high seqno is in another collection
-		t.Skip("MB-53448 - One Shot DCP cannot close if high seqno is in another collection (fix in 7.2)")
-	}
+	DisableTestWithCollections(t)
 
 	if UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
@@ -109,11 +106,11 @@ func TestOneShotDCP(t *testing.T) {
 	select {
 	case err := <-doneChan:
 		require.NoError(t, err)
-		if TestsUseDefaultCollection() {
-			require.Equal(t, numDocs, int(mutationCount))
-		} else {
+		if TestsUseNamedCollections() {
 			// CBG-2454, sometimes we get extra docs from TO_LATEST with collections
 			require.LessOrEqual(t, numDocs, int(mutationCount))
+		} else {
+			require.Equal(t, numDocs, int(mutationCount))
 		}
 	case <-timeout:
 		require.Fail(t, "timeout waiting for one-shot feed to complete")
@@ -192,10 +189,7 @@ func TestTerminateDCPFeed(t *testing.T) {
 // changes in the VbUUID
 func TestDCPClientMultiFeedConsistency(t *testing.T) {
 
-	if !TestsUseDefaultCollection() {
-		// FIXME MB-53448 cannot close if high seqno is in another collection
-		t.Skip("MB-53448 - One Shot DCP cannot close if high seqno is in another collection (fix in 7.2)")
-	}
+	DisableTestWithCollections(t)
 
 	if UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
@@ -332,10 +326,7 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 // TestResumeInterruptedFeed uses persisted metadata to resume the feed
 func TestResumeStoppedFeed(t *testing.T) {
 
-	if !TestsUseDefaultCollection() {
-		// FIXME MB-53448 cannot close if high seqno is in another collection
-		t.Skip("MB-53448 - One Shot DCP cannot close if high seqno is in another collection (fix in 7.2)")
-	}
+	DisableTestWithCollections(t)
 
 	if UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -105,7 +105,7 @@ func NewTestBucketPool(bucketReadierFunc TBPBucketReadierFunc, bucketInitFunc TB
 
 	tbp.cluster = newTestCluster(UnitTestUrl(), tbp.Logf)
 
-	useCollections, err := tbp.shouldUseCollections()
+	useCollections, err := tbp.canUseNamedCollections()
 	if err != nil {
 		tbp.Fatalf(ctx, "%s", err)
 	}

--- a/base/main_test_bucket_pool_config.go
+++ b/base/main_test_bucket_pool_config.go
@@ -65,17 +65,14 @@ var tbpDefaultBucketSpec = BucketSpec{
 	UseXattrs: TestUseXattrs(),
 }
 
-func TestsUseDefaultCollection() bool {
-	val, isSet := os.LookupEnv(tbpEnvUseDefaultCollection)
-	if !isSet {
-		return true
-	}
-	useDefault, _ := strconv.ParseBool(val)
-	return useDefault
+// TestsUseNamedCollections returns true if the tests use named collections.
+func TestsUseNamedCollections() bool {
+	ok, err := GTestBucketPool.canUseNamedCollections()
+	return err == nil && ok
 }
 
-// shouldUseCollections returns true if cluster will be created with named collections
-func (tbp *TestBucketPool) shouldUseCollections() (bool, error) {
+// canUseNamedCollections returns true if the cluster supports named collections, and they are also requested
+func (tbp *TestBucketPool) canUseNamedCollections() (bool, error) {
 	// walrus supports collections, but we need to query the server's version for capability check
 	clusterSupport := true
 	if tbp.cluster != nil {

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -705,11 +705,15 @@ func TestRequiresCollections(t *testing.T) {
 	}
 }
 
+// TemporarilyDisableTestUsingDCPWithCollections will skip the current test if using named collections to avoid MB-53448 prior to CB 7.2 until we've implemented a SG-side workaround (CBG-2605)
+func TemporarilyDisableTestUsingDCPWithCollections(t *testing.T) {
+	DisableTestWithCollections(t)
+}
+
 // DisableTestWithCollections will skip the current test if using named collections.
-// This should be temporary until DCP feed close issues are resolved in MB-53448
 func DisableTestWithCollections(t *testing.T) {
 	if TestsUseNamedCollections() {
-		t.Skip("WARNING: MB-53448 - Skipping test because collections are enabled - DCP cannot close if high seqno is in another collection (fix coming in 7.2)")
+		t.Skip("Skipping test because collections are enabled")
 	}
 }
 

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -28,7 +28,7 @@ func TestAttachmentMark(t *testing.T) {
 		t.Skip("Requires CBS")
 	}
 
-	base.DisableTestWithCollections(t)
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
 
 	testDb, ctx := setupTestDB(t)
 	defer testDb.Close(ctx)
@@ -82,7 +82,7 @@ func TestAttachmentMark(t *testing.T) {
 
 func TestAttachmentSweep(t *testing.T) {
 
-	base.DisableTestWithCollections(t)
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
 
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Requires CBS")
@@ -134,7 +134,7 @@ func TestAttachmentCleanup(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Requires CBS")
 	}
-	base.DisableTestWithCollections(t)
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
 	testDb, ctx := setupTestDB(t)
 	defer testDb.Close(ctx)
 	collection := testDb.GetSingleDatabaseCollection()
@@ -242,7 +242,7 @@ func TestAttachmentMarkAndSweepAndCleanup(t *testing.T) {
 		t.Skip("Requires CBS")
 	}
 
-	base.DisableTestWithCollections(t)
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
 
 	testDb, ctx := setupTestDB(t)
 	defer testDb.Close(ctx)
@@ -315,7 +315,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	base.DisableTestWithCollections(t)
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
 
 	b := base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{})
 	defer b.Close()
@@ -463,7 +463,7 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	base.DisableTestWithCollections(t)
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
 	b := base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{})
 	defer b.Close()
 
@@ -567,7 +567,7 @@ func TestAttachmentProcessError(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	base.DisableTestWithCollections(t)
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
 
 	b := base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{
 		SetXattrCallback: func(key string) error {
@@ -608,7 +608,7 @@ func TestAttachmentDifferentVBUUIDsBetweenPhases(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	base.DisableTestWithCollections(t)
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
 	testDB, ctx := setupTestDB(t)
 	defer testDB.Close(ctx)
 	dataStore := testDB.Bucket.DefaultDataStore()
@@ -851,7 +851,7 @@ func createDocWithInBodyAttachment(t *testing.T, ctx context.Context, docID stri
 func TestAttachmentCompactIncorrectStat(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.DisableTestWithCollections(t)
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
 
 	const docsToCreate = 10_000
 	if base.UnitTestUrlIsWalrus() {

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -28,10 +28,7 @@ func TestAttachmentMark(t *testing.T) {
 		t.Skip("Requires CBS")
 	}
 
-	if !base.TestsUseDefaultCollection() {
-		// FIXME MB-53448 cannot close if high seqno is in another collection
-		t.Skip("MB-53448 - One Shot DCP cannot close if high seqno is in another collection (fix in 7.2)")
-	}
+	base.DisableTestWithCollections(t)
 
 	testDb, ctx := setupTestDB(t)
 	defer testDb.Close(ctx)
@@ -85,10 +82,7 @@ func TestAttachmentMark(t *testing.T) {
 
 func TestAttachmentSweep(t *testing.T) {
 
-	if !base.TestsUseDefaultCollection() {
-		// FIXME MB-53448 cannot close if high seqno is in another collection
-		t.Skip("MB-53448 - One Shot DCP cannot close if high seqno is in another collection (fix in 7.2)")
-	}
+	base.DisableTestWithCollections(t)
 
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Requires CBS")
@@ -140,10 +134,7 @@ func TestAttachmentCleanup(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Requires CBS")
 	}
-	if !base.TestsUseDefaultCollection() {
-		// FIXME MB-53448 cannot close if high seqno is in another collection
-		t.Skip("MB-53448 - One Shot DCP cannot close if high seqno is in another collection (fix in 7.2)")
-	}
+	base.DisableTestWithCollections(t)
 	testDb, ctx := setupTestDB(t)
 	defer testDb.Close(ctx)
 	collection := testDb.GetSingleDatabaseCollection()
@@ -251,10 +242,7 @@ func TestAttachmentMarkAndSweepAndCleanup(t *testing.T) {
 		t.Skip("Requires CBS")
 	}
 
-	if !base.TestsUseDefaultCollection() {
-		// FIXME MB-53448 cannot close if high seqno is in another collection
-		t.Skip("MB-53448 - One Shot DCP cannot close if high seqno is in another collection (fix in 7.2)")
-	}
+	base.DisableTestWithCollections(t)
 
 	testDb, ctx := setupTestDB(t)
 	defer testDb.Close(ctx)
@@ -327,10 +315,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	if !base.TestsUseDefaultCollection() {
-		// FIXME MB-53448 cannot close if high seqno is in another collection
-		t.Skip("MB-53448 - One Shot DCP cannot close if high seqno is in another collection (fix in 7.2)")
-	}
+	base.DisableTestWithCollections(t)
 
 	b := base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{})
 	defer b.Close()
@@ -478,10 +463,7 @@ func TestAttachmentCompactionStopImmediateStart(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	if !base.TestsUseDefaultCollection() {
-		// FIXME MB-53448 cannot close if high seqno is in another collection
-		t.Skip("MB-53448 - One Shot DCP cannot close if high seqno is in another collection (fix in 7.2)")
-	}
+	base.DisableTestWithCollections(t)
 	b := base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{})
 	defer b.Close()
 
@@ -585,10 +567,7 @@ func TestAttachmentProcessError(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	if !base.TestsUseDefaultCollection() {
-		// FIXME MB-53448 cannot close if high seqno is in another collection
-		t.Skip("MB-53448 - One Shot DCP cannot close if high seqno is in another collection (fix in 7.2)")
-	}
+	base.DisableTestWithCollections(t)
 
 	b := base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{
 		SetXattrCallback: func(key string) error {
@@ -629,10 +608,7 @@ func TestAttachmentDifferentVBUUIDsBetweenPhases(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	if !base.TestsUseDefaultCollection() {
-		// FIXME MB-53448 cannot close if high seqno is in another collection
-		t.Skip("MB-53448 - One Shot DCP cannot close if high seqno is in another collection (fix in 7.2)")
-	}
+	base.DisableTestWithCollections(t)
 	testDB, ctx := setupTestDB(t)
 	defer testDB.Close(ctx)
 	dataStore := testDB.Bucket.DefaultDataStore()
@@ -875,10 +851,7 @@ func createDocWithInBodyAttachment(t *testing.T, ctx context.Context, docID stri
 func TestAttachmentCompactIncorrectStat(t *testing.T) {
 	base.LongRunningTest(t)
 
-	if !base.TestsUseDefaultCollection() {
-		// FIXME MB-53448 cannot close if high seqno is in another collection
-		t.Skip("MB-53448 - One Shot DCP cannot close if high seqno is in another collection (fix in 7.2)")
-	}
+	base.DisableTestWithCollections(t)
 
 	const docsToCreate = 10_000
 	if base.UnitTestUrlIsWalrus() {

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -905,7 +905,7 @@ func TestLowSequenceHandlingAcrossChannels(t *testing.T) {
 // user gets added to a new channel with existing entries (and existing backfill)
 func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 
-	if !base.TestsUseDefaultCollection() {
+	if base.TestsUseNamedCollections() {
 		t.Skip("Disabled for non-default collection based on use of GetPrincipalForTest")
 	}
 

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -91,7 +91,7 @@ func TestFilterToAvailableChannels(t *testing.T) {
 // Unit test for bug #314
 func TestChangesAfterChannelAdded(t *testing.T) {
 
-	if !base.TestsUseDefaultCollection() {
+	if base.TestsUseNamedCollections() {
 		t.Skip("Disabled for non-default collection based on use of GetPrincipalForTest")
 	}
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -909,7 +909,7 @@ func TestAllDocsOnly(t *testing.T) {
 // Unit test for bug #673
 func TestUpdatePrincipal(t *testing.T) {
 
-	if !base.TestsUseDefaultCollection() {
+	if base.TestsUseNamedCollections() {
 		t.Skip("Disabled for non-default collection based on use of GetPrincipalForTest")
 	}
 
@@ -1438,7 +1438,7 @@ func TestAccessFunctionValidation(t *testing.T) {
 
 func TestAccessFunctionDb(t *testing.T) {
 
-	if !base.TestsUseDefaultCollection() {
+	if base.TestsUseNamedCollections() {
 		t.Skip("Disabled for non-default collection until CBG-2554")
 	}
 
@@ -1515,7 +1515,7 @@ func TestDocIDs(t *testing.T) {
 
 func TestUpdateDesignDoc(t *testing.T) {
 
-	if !base.TestsUseDefaultCollection() {
+	if base.TestsUseNamedCollections() {
 		t.Skip("Design docs not supported for non-default collection")
 	}
 

--- a/db/functions/graphql_test.go
+++ b/db/functions/graphql_test.go
@@ -366,10 +366,7 @@ type Body = db.Body
 // Unit test for GraphQL queries.
 func TestUserGraphQLWithN1QL(t *testing.T) {
 
-	if !base.TestsUseDefaultCollection() {
-		// FIXME MB-53448 cannot close if high seqno is in another collection
-		t.Skip("MB-53448 - One Shot DCP cannot close if high seqno is in another collection (fix in 7.2)")
-	}
+	base.DisableTestWithCollections(t)
 
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test is Couchbase Server only (requires N1QL)")

--- a/db/functions/n1ql_function_test.go
+++ b/db/functions/n1ql_function_test.go
@@ -96,11 +96,11 @@ func TestUserN1QLQueries(t *testing.T) {
 		t.Skip("This test is Couchbase Server only (requires N1QL)")
 	}
 
-	if !base.TestsUseDefaultCollection() {
+	if base.TestsUseNamedCollections() {
 		t.Skip("Requires collection-aware function security (CBG-2597)")
 	}
 
-	//base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	// base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	db, ctx := setupTestDBWithFunctions(t, kUserN1QLFunctionsConfig, nil)
 	defer db.Close(ctx)
 

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -204,7 +204,7 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 
 func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 
-	if !base.TestsUseDefaultCollection() {
+	if base.TestsUseNamedCollections() {
 		// we could push the restriction up into SG such that views + non-default is disallowed for CBS and allowed for Walrus?
 		t.Skip("InitializeViews only works on default collection")
 	}

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -27,7 +27,7 @@ func TestRoleQuery(t *testing.T) {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
-	if !base.TestsUseDefaultCollection() {
+	if base.TestsUseNamedCollections() {
 		t.Skip("This test doesn't initialize indexes for non-default collections, needed for NewRole")
 	}
 
@@ -223,7 +223,7 @@ func TestQueryAllRoles(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
-	if !base.TestsUseDefaultCollection() {
+	if base.TestsUseNamedCollections() {
 		t.Skip("This test doesn't initialize indexes for non-default collections, needed for NewRole")
 	}
 
@@ -289,7 +289,7 @@ func TestAllPrincipalIDs(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
-	if !base.TestsUseDefaultCollection() {
+	if base.TestsUseNamedCollections() {
 		t.Skip("This test package doesn't initialize indexes for non-default collections, needed for NewRole")
 	}
 
@@ -368,7 +368,7 @@ func TestGetRoleIDs(t *testing.T) {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
-	if !base.TestsUseDefaultCollection() {
+	if base.TestsUseNamedCollections() {
 		t.Skip("This test package doesn't initialize indexes for non-default collections, needed for NewRole")
 	}
 

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -496,7 +496,7 @@ func SetupTestDBForDataStoreWithOptions(t testing.TB, tBucket *base.TestBucket, 
 	ctx := base.TestCtx(t)
 	AddOptionsFromEnvironmentVariables(&dbcOptions)
 
-	if !base.TestsUseDefaultCollection() {
+	if base.TestsUseNamedCollections() {
 		dataStore := tBucket.GetSingleDataStore()
 		dsn, ok := base.AsDataStoreName(dataStore)
 		if !ok {


### PR DESCRIPTION
- Reduce negation by swapping from `TestsUseDefaultCollection` to `TestsUseNamedCollections`
- Fix inconsistency between `TestsUseDefaultCollection`/`tbp.shouldUseCollections` when the collection env var is not set
- Replace if/skip with temporary helper function

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `collection=unset,GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1200/
- [x] `collection=true,GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1201/
- [x] `collection=false,GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1202/
  - [x] known `TestResync` flake