### PR TITLE
CBG-2266 make rest tests run with non default collections by default

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -120,7 +120,7 @@ func getTestBucket(t testing.TB) *TestBucket {
 
 // GetNamedDataStore returns a named datastore from the TestBucket. Each number (starting from 0, indicates which data store you'll get.
 func (tb *TestBucket) GetNamedDataStore(count int) DataStore {
-	dataStoreNames := tb.getNonDefaultDatastoreNames()
+	dataStoreNames := tb.GetNonDefaultDatastoreNames()
 	if count > len(dataStoreNames) {
 		tb.t.Errorf("You are requesting more datastores %d than are available on this test instance %d", dataStoreNames, count)
 	}
@@ -128,7 +128,7 @@ func (tb *TestBucket) GetNamedDataStore(count int) DataStore {
 }
 
 // Return a sorted list of data store names
-func (tb *TestBucket) getNonDefaultDatastoreNames() []sgbucket.DataStoreName {
+func (tb *TestBucket) GetNonDefaultDatastoreNames() []sgbucket.DataStoreName {
 	allDataStoreNames, err := tb.ListDataStores()
 	require.NoError(tb.t, err)
 	var nonDefaultDataStoreNames []sgbucket.DataStoreName

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -118,25 +118,34 @@ func getTestBucket(t testing.TB) *TestBucket {
 	}
 }
 
-// GetNamedDataStore returns a named datastore from the TestBucket.
-func (tb *TestBucket) GetNamedDataStore() DataStore {
-	dataStoreNames, err := tb.ListDataStores()
+// GetNamedDataStore returns a named datastore from the TestBucket. Each number (starting from 0, indicates which data store you'll get.
+func (tb *TestBucket) GetNamedDataStore(count int) DataStore {
+	dataStoreNames := tb.getNonDefaultDatastoreNames()
+	if count > len(dataStoreNames) {
+		tb.t.Errorf("You are requesting more datastores %d than are available on this test instance %d", dataStoreNames, count)
+	}
+	return tb.Bucket.NamedDataStore(dataStoreNames[count-1])
+}
+
+// Return a sorted list of data store names
+func (tb *TestBucket) getNonDefaultDatastoreNames() []sgbucket.DataStoreName {
+	allDataStoreNames, err := tb.ListDataStores()
 	require.NoError(tb.t, err)
-	for _, name := range dataStoreNames {
+	var nonDefaultDataStoreNames []sgbucket.DataStoreName
+	for _, name := range allDataStoreNames {
 		if IsDefaultCollection(name.ScopeName(), name.CollectionName()) {
 			continue
 		}
-		return tb.Bucket.NamedDataStore(name)
+		nonDefaultDataStoreNames = append(nonDefaultDataStoreNames, name)
 	}
-	tb.t.Error("Could not find a named collection")
-	return nil
+	return nonDefaultDataStoreNames
 }
 
 // GetSingleDataStore returns a DataStore that can be used for testing.
 // This may be the default collection, or a named collection depending on whether SG_TEST_USE_DEFAULT_COLLECTION is set.
 func (b *TestBucket) GetSingleDataStore() sgbucket.DataStore {
 	if TestsUseNamedCollections() {
-		return b.GetNamedDataStore()
+		return b.GetNamedDataStore(1)
 	}
 	return b.Bucket.DefaultDataStore()
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2704,7 +2704,7 @@ func TestGetDatabaseCollectionWithUserDefaultCollection(t *testing.T) {
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
 
-	ds := bucket.GetNamedDataStore()
+	ds := bucket.GetNamedDataStore(1)
 	require.NotNil(t, ds)
 
 	dataStoreName, ok := base.AsDataStoreName(ds)

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -79,7 +79,9 @@ func TestStarAccess(t *testing.T) {
 	}
 
 	// Create some docs:
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{}, // make scopes/collections aware by using collection access in channel grant
+	})
 	defer rt.Close()
 
 	a := auth.NewAuthenticator(rt.MetadataStore(), nil, auth.DefaultAuthenticatorOptions())
@@ -526,7 +528,10 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAccess)
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {if(doc.type == "setaccess") {channel(doc.channel); access(doc.owner, doc.channel);} else { requireAccess(doc.channel)}}`}
+	rtConfig := RestTesterConfig{
+		SyncFn:         `function(doc) {if(doc.type == "setaccess") {channel(doc.channel); access(doc.owner, doc.channel);} else { requireAccess(doc.channel)}}`,
+		DatabaseConfig: &DatabaseConfig{}, // make scopes/collections aware by using collection access in channel grant
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -559,8 +564,9 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 
 // Test _all_docs API call under different security scenarios
 func TestAllDocsAccessControl(t *testing.T) {
-	// restTester := initRestTester(db.IntSequenceType, `function(doc) {channel(doc.channels);}`)
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{}, // make scopes/collections aware by using collection access in channel grant
+	})
 	defer rt.Close()
 	type allDocsRow struct {
 		ID    string `json:"id"`
@@ -795,7 +801,10 @@ func TestChannelAccessChanges(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyCRUD)
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {access(doc.owner, doc._id);channel(doc.channel)}`}
+	rtConfig := RestTesterConfig{
+		SyncFn:         `function(doc) {access(doc.owner, doc._id);channel(doc.channel)}`,
+		DatabaseConfig: &DatabaseConfig{}, // make scopes/collections aware by using collection access in channel grant
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -3016,7 +3016,7 @@ func TestApiInternalPropertiesHandling(t *testing.T) {
 			rest.RequireStatus(t, resp, http.StatusCreated)
 
 			var bucketDoc map[string]interface{}
-			_, err = rt.GetSingleTestDataStore().Get(docID, &bucketDoc)
+			_, err = rt.GetSingleDataStore().Get(docID, &bucketDoc)
 			assert.NoError(t, err)
 			body := rt.GetDoc(docID)
 			// Confirm input body is in the bucket doc

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -2979,7 +2979,7 @@ func TestApiInternalPropertiesHandling(t *testing.T) {
 			rest.RequireStatus(t, resp, http.StatusCreated)
 
 			var bucketDoc map[string]interface{}
-			_, err = rt.Bucket().DefaultDataStore().Get(docID, &bucketDoc)
+			_, err = rt.GetSingleTestDataStore().Get(docID, &bucketDoc)
 			assert.NoError(t, err)
 			body := rt.GetDoc(docID)
 			// Confirm input body is in the bucket doc

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -45,7 +45,7 @@ func TestCollectionsPutDocInKeyspace(t *testing.T) {
 	})
 	defer rt.Close()
 
-	ds := rt.GetSingleTestDataStore()
+	ds := rt.GetSingleDataStore()
 	dataStoreName, ok := base.AsDataStoreName(ds)
 	require.True(t, ok)
 	tests := []struct {
@@ -261,7 +261,7 @@ func TestCollectionsBasicIndexQuery(t *testing.T) {
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// use the rt.Bucket which has got the foo.bar scope/collection set up
-	ds := rt.GetSingleTestDataStore()
+	ds := rt.GetSingleDataStore()
 	n1qlStore, ok := base.AsN1QLStore(ds)
 	require.True(t, ok)
 

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -123,8 +123,14 @@ func TestNoCollectionsPutDocWithKeyspace(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
 
+	// Force use of no scopes
 	rt := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				AutoImport: true,
+			},
+		},
 	})
 	defer rt.Close()
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1803,7 +1803,7 @@ func TestWebhookProperties(t *testing.T) {
 		wg.Add(1)
 		body := make(map[string]interface{})
 		body["foo"] = "bar"
-		added, err := rt.Bucket().DefaultDataStore().Add("doc2", 0, body)
+		added, err := rt.GetSingleTestDataStore().Add("doc2", 0, body)
 		assert.True(t, added)
 		assert.NoError(t, err)
 	}
@@ -2310,7 +2310,8 @@ func TestTombstonedBulkDocsWithPriorPurge(t *testing.T) {
 		t.Skip("Requires Couchbase bucket")
 	}
 
-	_, err := bucket.DefaultDataStore().Add(t.Name(), 0, map[string]interface{}{"val": "val"})
+	dataStore := rt.GetSingleTestDataStore()
+	_, err := dataStore.Add(t.Name(), 0, map[string]interface{}{"val": "val"})
 	require.NoError(t, err)
 
 	resp := rt.SendAdminRequest("POST", "/db/_purge", `{"`+t.Name()+`": ["*"]}`)
@@ -2320,7 +2321,7 @@ func TestTombstonedBulkDocsWithPriorPurge(t *testing.T) {
 	RequireStatus(t, response, http.StatusCreated)
 
 	var body map[string]interface{}
-	_, err = rt.GetDatabase().Bucket.DefaultDataStore().Get(t.Name(), &body)
+	_, err = dataStore.Get(t.Name(), &body)
 
 	assert.Error(t, err)
 	assert.True(t, base.IsDocNotFoundError(err))

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1051,7 +1051,8 @@ func TestLocalDocExpiry(t *testing.T) {
 	RequireStatus(t, response, 201)
 
 	localDocKey := db.RealSpecialDocID(db.DocTypeLocal, "loc1")
-	expiry, getMetaError := rt.Bucket().DefaultDataStore().GetExpiry(localDocKey)
+	dataStore := rt.GetSingleTestDataStore()
+	expiry, getMetaError := dataStore.GetExpiry(localDocKey)
 	log.Printf("Expiry after PUT is %v", expiry)
 	assert.True(t, expiry > timeNow, "expiry is not greater than current time")
 	assert.True(t, expiry < oneMoreHour, "expiry is not greater than current time")
@@ -1060,7 +1061,7 @@ func TestLocalDocExpiry(t *testing.T) {
 	// Retrieve local doc, ensure non-zero expiry is preserved
 	response = rt.SendAdminRequest("GET", "/db/_local/loc1", "")
 	RequireStatus(t, response, 200)
-	expiry, getMetaError = rt.Bucket().DefaultDataStore().GetExpiry(localDocKey)
+	expiry, getMetaError = dataStore.GetExpiry(localDocKey)
 	log.Printf("Expiry after GET is %v", expiry)
 	assert.True(t, expiry > timeNow, "expiry is not greater than current time")
 	assert.True(t, expiry < oneMoreHour, "expiry is not greater than current time")
@@ -1531,8 +1532,7 @@ func TestWriteTombstonedDocUsingXattrs(t *testing.T) {
 	}
 
 	// Fetch the xattr and make sure it contains the above value
-	baseBucket := rt.GetDatabase().Bucket
-	subdocXattrStore, _ := base.AsSubdocXattrStore(baseBucket.DefaultDataStore())
+	subdocXattrStore, _ := base.AsSubdocXattrStore(rt.GetSingleTestDataStore())
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
 	_, err = subdocXattrStore.SubdocGetBodyAndXattr("-21SK00U-ujxUO9fU2HezxL", base.SyncXattrName, "", &retrievedVal, &retrievedXattr, nil)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1051,7 +1051,7 @@ func TestLocalDocExpiry(t *testing.T) {
 	RequireStatus(t, response, 201)
 
 	localDocKey := db.RealSpecialDocID(db.DocTypeLocal, "loc1")
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 	expiry, getMetaError := dataStore.GetExpiry(localDocKey)
 	log.Printf("Expiry after PUT is %v", expiry)
 	assert.True(t, expiry > timeNow, "expiry is not greater than current time")
@@ -1532,7 +1532,7 @@ func TestWriteTombstonedDocUsingXattrs(t *testing.T) {
 	}
 
 	// Fetch the xattr and make sure it contains the above value
-	subdocXattrStore, _ := base.AsSubdocXattrStore(rt.GetSingleTestDataStore())
+	subdocXattrStore, _ := base.AsSubdocXattrStore(rt.GetSingleDataStore())
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
 	_, err = subdocXattrStore.SubdocGetBodyAndXattr("-21SK00U-ujxUO9fU2HezxL", base.SyncXattrName, "", &retrievedVal, &retrievedXattr, nil)
@@ -1803,7 +1803,7 @@ func TestWebhookProperties(t *testing.T) {
 		wg.Add(1)
 		body := make(map[string]interface{})
 		body["foo"] = "bar"
-		added, err := rt.GetSingleTestDataStore().Add("doc2", 0, body)
+		added, err := rt.GetSingleDataStore().Add("doc2", 0, body)
 		assert.True(t, added)
 		assert.NoError(t, err)
 	}
@@ -2212,7 +2212,7 @@ func TestDeleteNonExistentDoc(t *testing.T) {
 	RequireStatus(t, response, http.StatusNotFound)
 
 	var body map[string]interface{}
-	_, err := rt.GetSingleTestDataStore().Get("fake", &body)
+	_, err := rt.GetSingleDataStore().Get("fake", &body)
 
 	if base.TestUseXattrs() {
 		assert.Error(t, err)
@@ -2241,7 +2241,7 @@ func TestDeleteEmptyBodyDoc(t *testing.T) {
 	RequireStatus(t, response, http.StatusNotFound)
 
 	var doc map[string]interface{}
-	_, err := rt.GetSingleTestDataStore().Get("doc1", &doc)
+	_, err := rt.GetSingleDataStore().Get("doc1", &doc)
 
 	if base.TestUseXattrs() {
 		assert.Error(t, err)
@@ -2278,7 +2278,7 @@ func TestTombstonedBulkDocs(t *testing.T) {
 	RequireStatus(t, response, http.StatusCreated)
 
 	var body map[string]interface{}
-	_, err := rt.GetSingleTestDataStore().Get(t.Name(), &body)
+	_, err := rt.GetSingleDataStore().Get(t.Name(), &body)
 
 	if base.TestUseXattrs() {
 		assert.Error(t, err)
@@ -2310,7 +2310,7 @@ func TestTombstonedBulkDocsWithPriorPurge(t *testing.T) {
 		t.Skip("Requires Couchbase bucket")
 	}
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 	_, err := dataStore.Add(t.Name(), 0, map[string]interface{}{"val": "val"})
 	require.NoError(t, err)
 
@@ -2475,7 +2475,7 @@ func TestChannelHistoryLegacyDoc(t *testing.T) {
 	}`
 
 	// Insert raw 'legacy' doc with no channel history info
-	err := rt.GetSingleTestDataStore().Set("doc1", 0, nil, []byte(docData))
+	err := rt.GetSingleDataStore().Set("doc1", 0, nil, []byte(docData))
 	assert.NoError(t, err)
 
 	var body db.Body

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2212,7 +2212,7 @@ func TestDeleteNonExistentDoc(t *testing.T) {
 	RequireStatus(t, response, http.StatusNotFound)
 
 	var body map[string]interface{}
-	_, err := rt.GetDatabase().Bucket.DefaultDataStore().Get("fake", &body)
+	_, err := rt.GetSingleTestDataStore().Get("fake", &body)
 
 	if base.TestUseXattrs() {
 		assert.Error(t, err)
@@ -2241,7 +2241,7 @@ func TestDeleteEmptyBodyDoc(t *testing.T) {
 	RequireStatus(t, response, http.StatusNotFound)
 
 	var doc map[string]interface{}
-	_, err := rt.GetDatabase().Bucket.DefaultDataStore().Get("doc1", &doc)
+	_, err := rt.GetSingleTestDataStore().Get("doc1", &doc)
 
 	if base.TestUseXattrs() {
 		assert.Error(t, err)
@@ -2278,7 +2278,7 @@ func TestTombstonedBulkDocs(t *testing.T) {
 	RequireStatus(t, response, http.StatusCreated)
 
 	var body map[string]interface{}
-	_, err := rt.GetDatabase().Bucket.DefaultDataStore().Get(t.Name(), &body)
+	_, err := rt.GetSingleTestDataStore().Get(t.Name(), &body)
 
 	if base.TestUseXattrs() {
 		assert.Error(t, err)
@@ -2474,7 +2474,7 @@ func TestChannelHistoryLegacyDoc(t *testing.T) {
 	}`
 
 	// Insert raw 'legacy' doc with no channel history info
-	err := rt.GetDatabase().Bucket.DefaultDataStore().Set("doc1", 0, nil, []byte(docData))
+	err := rt.GetSingleTestDataStore().Set("doc1", 0, nil, []byte(docData))
 	assert.NoError(t, err)
 
 	var body db.Body

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -82,7 +82,10 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
-	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
+	rt := NewRestTester(t, &RestTesterConfig{
+		SyncFn:         `function(doc) {channel(doc.channel);}`,
+		DatabaseConfig: &DatabaseConfig{}, // make scopes/collections aware by using collection access in channel grant
+	})
 	defer rt.Close()
 
 	// Create user:

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -30,7 +30,8 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
-	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel);}`})
+	rt := NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+		&RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel);}`})
 	defer rt.Close()
 
 	// Create user:
@@ -82,10 +83,10 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
-	rt := NewRestTester(t, &RestTesterConfig{
-		SyncFn:         `function(doc) {channel(doc.channel);}`,
-		DatabaseConfig: &DatabaseConfig{}, // make scopes/collections aware by using collection access in channel grant
-	})
+	rt := NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+		&RestTesterConfig{
+			SyncFn: `function(doc) {channel(doc.channel);}`,
+		})
 	defer rt.Close()
 
 	// Create user:

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -717,8 +717,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 
 	// Get the couchbase doc
 	couchbaseDoc := db.Body{}
-	bucket := rt.Bucket()
-	_, err := bucket.DefaultDataStore().Get(docIdDoc1, &couchbaseDoc)
+	_, err := rt.GetSingleTestDataStore().Get(docIdDoc1, &couchbaseDoc)
 	assert.NoError(t, err, "Error getting couchbaseDoc")
 	log.Printf("couchbase doc: %+v", couchbaseDoc)
 
@@ -769,7 +768,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 	*/
 
 	// Put the doc back into couchbase
-	err = bucket.DefaultDataStore().Set(docIdDoc1, 0, nil, couchbaseDoc)
+	err = rt.GetSingleTestDataStore().Set(docIdDoc1, 0, nil, couchbaseDoc)
 	assert.NoError(t, err, "Error putting couchbaseDoc")
 
 	// Flush rev cache so that the _bulk_get request is forced to go back to the bucket to load the doc
@@ -944,7 +943,7 @@ func TestAttachmentRevposPre25Metadata(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	ok, err := rt.GetDatabase().Bucket.DefaultDataStore().Add("doc1", 0, []byte(`{"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1,"stub":true}},"_sync":{"rev":"1-6e5a9ed9e2e8637d495ac5dd2fa90479","sequence":2,"recent_sequences":[2],"history":{"revs":["1-6e5a9ed9e2e8637d495ac5dd2fa90479"],"parents":[-1],"channels":[null]},"cas":"","time_saved":"2019-12-06T20:02:25.523013Z"},"test":true}`))
+	ok, err := rt.GetSingleTestDataStore().Add("doc1", 0, []byte(`{"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1,"stub":true}},"_sync":{"rev":"1-6e5a9ed9e2e8637d495ac5dd2fa90479","sequence":2,"recent_sequences":[2],"history":{"revs":["1-6e5a9ed9e2e8637d495ac5dd2fa90479"],"parents":[-1],"channels":[null]},"cas":"","time_saved":"2019-12-06T20:02:25.523013Z"},"test":true}`))
 	require.NoError(t, err)
 	require.True(t, ok)
 
@@ -2574,7 +2573,7 @@ func TestAttachmentDeleteOnPurge(t *testing.T) {
 	assert.True(t, ok)
 
 	// Ensure we can get the attachment doc
-	_, _, err = rt.GetDatabase().Bucket.DefaultDataStore().GetRaw(key)
+	_, _, err = rt.GetSingleTestDataStore().GetRaw(key)
 	assert.NoError(t, err)
 
 	// Purge the document
@@ -2595,6 +2594,8 @@ func TestAttachmentDeleteOnExpiry(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
+	dataStore := rt.GetSingleTestDataStore()
+
 	// Create doc with attachment and expiry
 	resp := rt.SendAdminRequest("PUT", "/db/"+t.Name(), `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}, "_exp": 2}`)
 	RequireStatus(t, resp, http.StatusCreated)
@@ -2603,7 +2604,7 @@ func TestAttachmentDeleteOnExpiry(t *testing.T) {
 
 	// Wait for document to be expired - this bucket get should also trigger the expiry purge interval
 	err = rt.WaitForCondition(func() bool {
-		_, _, err = rt.GetDatabase().Bucket.DefaultDataStore().GetRaw(t.Name())
+		_, _, err = dataStore.GetRaw(t.Name())
 		return base.IsDocNotFoundError(err)
 	})
 	assert.NoError(t, err)
@@ -2616,7 +2617,7 @@ func TestAttachmentDeleteOnExpiry(t *testing.T) {
 
 	// With xattrs doc will be imported and will be captured as tombstone and therefore purge attachments
 	// Otherwise attachment will not be purged
-	_, _, err = rt.GetDatabase().Bucket.DefaultDataStore().GetRaw(att2Key)
+	_, _, err = dataStore.GetRaw(att2Key)
 	if base.TestUseXattrs() {
 		assert.Error(t, err)
 		assert.True(t, base.IsDocNotFoundError(err))
@@ -3046,16 +3047,17 @@ func TestCBLRevposHandling(t *testing.T) {
 
 // Helper_Functions
 func CreateDocWithLegacyAttachment(t *testing.T, rt *RestTester, docID string, rawDoc []byte, attKey string, attBody []byte) {
-	// Write attachment directly to the bucket.
-	_, err := rt.Bucket().DefaultDataStore().Add(attKey, 0, attBody)
+	// Write attachment directly to the datastore.
+	dataStore := rt.GetSingleTestDataStore()
+	_, err := dataStore.Add(attKey, 0, attBody)
 	require.NoError(t, err)
 
 	body := db.Body{}
 	err = body.Unmarshal(rawDoc)
 	require.NoError(t, err, "Error unmarshalling body")
 
-	// Write raw document to the bucket.
-	_, err = rt.Bucket().DefaultDataStore().Add(docID, 0, rawDoc)
+	// Write raw document to the datastore.
+	_, err = dataStore.Add(docID, 0, rawDoc)
 	require.NoError(t, err)
 
 	// Migrate document metadata from document body to system xattr.

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -1363,9 +1363,10 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		return attachments
 	}
 
+	dataStore := rt.GetSingleTestDataStore()
 	requireAttachmentFound := func(attKey string, attBodyExpected []byte) {
 		var attBodyActual []byte
-		_, err := rt.Bucket().DefaultDataStore().Get(attKey, &attBodyActual)
+		_, err := dataStore.Get(attKey, &attBodyActual)
 		require.NoError(t, err)
 		assert.Equal(t, attBodyExpected, attBodyActual)
 	}
@@ -2032,7 +2033,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		require.NotEmpty(t, attKey)
 
 		// Delete/tombstone the document via SDK.
-		err := rt.Bucket().DefaultDataStore().Delete(docID)
+		err := dataStore.Delete(docID)
 		require.NoError(t, err, "Unable to delete doc %q", docID)
 
 		// Wait until the "delete" mutation appears on the changes feed.
@@ -2085,7 +2086,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		require.NotEmpty(t, attKey)
 
 		// Update the document via SDK.
-		err := rt.Bucket().DefaultDataStore().Set(docID, 0, nil, []byte(`{"prop": false}`))
+		err := dataStore.Set(docID, 0, nil, []byte(`{"prop": false}`))
 		require.NoError(t, err, "Error updating the document")
 
 		// Wait until the "update" mutation appears on the changes feed.
@@ -2496,7 +2497,7 @@ func TestAttachmentRemovalWithConflicts(t *testing.T) {
 	resp = rt.SendAdminRequest("DELETE", "/db/doc?rev="+losingRev3, "")
 	RequireStatus(t, resp, http.StatusOK)
 
-	_, _, err = rt.GetDatabase().Bucket.DefaultDataStore().GetRaw(attachmentKey)
+	_, _, err = rt.GetSingleTestDataStore().GetRaw(attachmentKey)
 	assert.Error(t, err)
 	assert.True(t, base.IsDocNotFoundError(err))
 }

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -717,7 +717,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 
 	// Get the couchbase doc
 	couchbaseDoc := db.Body{}
-	_, err := rt.GetSingleTestDataStore().Get(docIdDoc1, &couchbaseDoc)
+	_, err := rt.GetSingleDataStore().Get(docIdDoc1, &couchbaseDoc)
 	assert.NoError(t, err, "Error getting couchbaseDoc")
 	log.Printf("couchbase doc: %+v", couchbaseDoc)
 
@@ -768,7 +768,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 	*/
 
 	// Put the doc back into couchbase
-	err = rt.GetSingleTestDataStore().Set(docIdDoc1, 0, nil, couchbaseDoc)
+	err = rt.GetSingleDataStore().Set(docIdDoc1, 0, nil, couchbaseDoc)
 	assert.NoError(t, err, "Error putting couchbaseDoc")
 
 	// Flush rev cache so that the _bulk_get request is forced to go back to the bucket to load the doc
@@ -943,7 +943,7 @@ func TestAttachmentRevposPre25Metadata(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	ok, err := rt.GetSingleTestDataStore().Add("doc1", 0, []byte(`{"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1,"stub":true}},"_sync":{"rev":"1-6e5a9ed9e2e8637d495ac5dd2fa90479","sequence":2,"recent_sequences":[2],"history":{"revs":["1-6e5a9ed9e2e8637d495ac5dd2fa90479"],"parents":[-1],"channels":[null]},"cas":"","time_saved":"2019-12-06T20:02:25.523013Z"},"test":true}`))
+	ok, err := rt.GetSingleDataStore().Add("doc1", 0, []byte(`{"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1,"stub":true}},"_sync":{"rev":"1-6e5a9ed9e2e8637d495ac5dd2fa90479","sequence":2,"recent_sequences":[2],"history":{"revs":["1-6e5a9ed9e2e8637d495ac5dd2fa90479"],"parents":[-1],"channels":[null]},"cas":"","time_saved":"2019-12-06T20:02:25.523013Z"},"test":true}`))
 	require.NoError(t, err)
 	require.True(t, ok)
 
@@ -1363,7 +1363,7 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		return attachments
 	}
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 	requireAttachmentFound := func(attKey string, attBodyExpected []byte) {
 		var attBodyActual []byte
 		_, err := dataStore.Get(attKey, &attBodyActual)
@@ -2497,7 +2497,7 @@ func TestAttachmentRemovalWithConflicts(t *testing.T) {
 	resp = rt.SendAdminRequest("DELETE", "/db/doc?rev="+losingRev3, "")
 	RequireStatus(t, resp, http.StatusOK)
 
-	_, _, err = rt.GetSingleTestDataStore().GetRaw(attachmentKey)
+	_, _, err = rt.GetSingleDataStore().GetRaw(attachmentKey)
 	assert.Error(t, err)
 	assert.True(t, base.IsDocNotFoundError(err))
 }
@@ -2574,7 +2574,7 @@ func TestAttachmentDeleteOnPurge(t *testing.T) {
 	assert.True(t, ok)
 
 	// Ensure we can get the attachment doc
-	_, _, err = rt.GetSingleTestDataStore().GetRaw(key)
+	_, _, err = rt.GetSingleDataStore().GetRaw(key)
 	assert.NoError(t, err)
 
 	// Purge the document
@@ -2595,7 +2595,7 @@ func TestAttachmentDeleteOnExpiry(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	// Create doc with attachment and expiry
 	resp := rt.SendAdminRequest("PUT", "/db/"+t.Name(), `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}, "_exp": 2}`)
@@ -3049,7 +3049,7 @@ func TestCBLRevposHandling(t *testing.T) {
 // Helper_Functions
 func CreateDocWithLegacyAttachment(t *testing.T, rt *RestTester, docID string, rawDoc []byte, attKey string, attBody []byte) {
 	// Write attachment directly to the datastore.
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 	_, err := dataStore.Add(attKey, 0, attBody)
 	require.NoError(t, err)
 

--- a/rest/attachmentcompactiontest/attachment_compaction_api_test.go
+++ b/rest/attachmentcompactiontest/attachment_compaction_api_test.go
@@ -28,11 +28,9 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{}, // need default collection until CBG-2605
-		},
-	})
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
+
+	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
 
 	// Perform GET before compact has been ran, ensure it starts in valid 'stopped' state
@@ -220,11 +218,7 @@ func TestAttachmentCompactionDryRun(t *testing.T) {
 
 	base.TemporarilyDisableTestUsingDCPWithCollections(t)
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{}, // need default collection until CBG-2605
-		},
-	})
+	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
 
 	dataStore := rt.GetSingleTestDataStore()
@@ -309,11 +303,7 @@ func TestAttachmentCompactionInvalidDocs(t *testing.T) {
 
 	base.TemporarilyDisableTestUsingDCPWithCollections(t)
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{}, // need default collection until CBG-2605
-		},
-	})
+	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
 	ctx := rt.Context()
 

--- a/rest/attachmentcompactiontest/attachment_compaction_api_test.go
+++ b/rest/attachmentcompactiontest/attachment_compaction_api_test.go
@@ -68,7 +68,7 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 	collection := &db.DatabaseCollectionWithUser{
 		DatabaseCollection: rt.GetSingleTestDatabaseCollection(),
 	}
@@ -221,7 +221,7 @@ func TestAttachmentCompactionDryRun(t *testing.T) {
 	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 	// Create some 'unmarked' attachments
 	makeUnmarkedDoc := func(docid string) {
 		err := dataStore.SetRaw(docid, 0, nil, []byte("{}"))
@@ -307,7 +307,7 @@ func TestAttachmentCompactionInvalidDocs(t *testing.T) {
 	defer rt.Close()
 	ctx := rt.Context()
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 	// Create a raw binary doc
 	_, err := dataStore.AddRaw("binary", 0, []byte("binary doc"))
 	assert.NoError(t, err)
@@ -391,7 +391,7 @@ func TestAttachmentCompactionAbort(t *testing.T) {
 	defer rt.Close()
 	ctx := rt.Context()
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 	collection := &db.DatabaseCollectionWithUser{
 		DatabaseCollection: rt.GetSingleTestDatabaseCollection(),
 	}

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -360,7 +360,7 @@ func TestPutAttachmentViaBlipGetViaRest(t *testing.T) {
 
 }
 func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
-
+	t.Skip("here")
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	// Create blip tester
@@ -433,7 +433,7 @@ func TestBlipAttachNameChange(t *testing.T) {
 
 	// Confirm attachment is in the bucket
 	attachmentAKey := db.MakeAttachmentKey(2, "doc", digest)
-	bucketAttachmentA, _, err := rt.Bucket().DefaultDataStore().GetRaw(attachmentAKey)
+	bucketAttachmentA, _, err := rt.GetSingleTestDataStore().GetRaw(attachmentAKey)
 	require.NoError(t, err)
 	require.EqualValues(t, bucketAttachmentA, attachmentA)
 
@@ -445,7 +445,7 @@ func TestBlipAttachNameChange(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check if attachment is still in bucket
-	bucketAttachmentA, _, err = rt.Bucket().DefaultDataStore().GetRaw(attachmentAKey)
+	bucketAttachmentA, _, err = rt.GetSingleTestDataStore().GetRaw(attachmentAKey)
 	assert.NoError(t, err)
 	assert.Equal(t, bucketAttachmentA, attachmentA)
 
@@ -490,7 +490,7 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 
 	// Confirm attachment is in the bucket
 	attachmentAKey := db.MakeAttachmentKey(1, "doc", digest)
-	bucketAttachmentA, _, err := rt.Bucket().DefaultDataStore().GetRaw(attachmentAKey)
+	bucketAttachmentA, _, err := rt.GetSingleTestDataStore().GetRaw(attachmentAKey)
 	require.NoError(t, err)
 	require.EqualValues(t, bucketAttachmentA, attBody)
 
@@ -543,7 +543,8 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 
 	// Confirm attachment is in the bucket
 	attachmentAKey := db.MakeAttachmentKey(1, "doc", digest)
-	bucketAttachmentA, _, err := rt.Bucket().DefaultDataStore().GetRaw(attachmentAKey)
+	dataStore := rt.GetSingleTestDataStore()
+	bucketAttachmentA, _, err := dataStore.GetRaw(attachmentAKey)
 	require.NoError(t, err)
 	require.EqualValues(t, bucketAttachmentA, attBody)
 
@@ -559,12 +560,12 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 
 	// Validate that the attachment hasn't been migrated to V2
 	v1Key := db.MakeAttachmentKey(1, "doc", digest)
-	v1Body, _, err := rt.Bucket().DefaultDataStore().GetRaw(v1Key)
+	v1Body, _, err := dataStore.GetRaw(v1Key)
 	require.NoError(t, err)
 	require.EqualValues(t, attBody, v1Body)
 
 	v2Key := db.MakeAttachmentKey(2, "doc", digest)
-	_, _, err = rt.Bucket().DefaultDataStore().GetRaw(v2Key)
+	_, _, err = dataStore.GetRaw(v2Key)
 	require.Error(t, err)
 	// Confirm correct type of error for both integration test and Walrus
 	if !errors.Is(err, sgbucket.MissingError{Key: v2Key}) {

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -360,7 +360,6 @@ func TestPutAttachmentViaBlipGetViaRest(t *testing.T) {
 
 }
 func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
-	t.Skip("here")
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	// Create blip tester

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -431,7 +431,7 @@ func TestBlipAttachNameChange(t *testing.T) {
 
 	// Confirm attachment is in the bucket
 	attachmentAKey := db.MakeAttachmentKey(2, "doc", digest)
-	bucketAttachmentA, _, err := rt.GetSingleTestDataStore().GetRaw(attachmentAKey)
+	bucketAttachmentA, _, err := rt.GetSingleDataStore().GetRaw(attachmentAKey)
 	require.NoError(t, err)
 	require.EqualValues(t, bucketAttachmentA, attachmentA)
 
@@ -443,7 +443,7 @@ func TestBlipAttachNameChange(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check if attachment is still in bucket
-	bucketAttachmentA, _, err = rt.GetSingleTestDataStore().GetRaw(attachmentAKey)
+	bucketAttachmentA, _, err = rt.GetSingleDataStore().GetRaw(attachmentAKey)
 	assert.NoError(t, err)
 	assert.Equal(t, bucketAttachmentA, attachmentA)
 
@@ -488,7 +488,7 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 
 	// Confirm attachment is in the bucket
 	attachmentAKey := db.MakeAttachmentKey(1, "doc", digest)
-	bucketAttachmentA, _, err := rt.GetSingleTestDataStore().GetRaw(attachmentAKey)
+	bucketAttachmentA, _, err := rt.GetSingleDataStore().GetRaw(attachmentAKey)
 	require.NoError(t, err)
 	require.EqualValues(t, bucketAttachmentA, attBody)
 
@@ -541,7 +541,7 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 
 	// Confirm attachment is in the bucket
 	attachmentAKey := db.MakeAttachmentKey(1, "doc", digest)
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 	bucketAttachmentA, _, err := dataStore.GetRaw(attachmentAKey)
 	require.NoError(t, err)
 	require.EqualValues(t, bucketAttachmentA, attBody)

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -363,12 +363,11 @@ func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	// Create blip tester
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt := NewBlipTesterDefaultCollectionFromSpec(t, BlipTesterSpec{
 		connectingUsername:          "user1",
 		connectingPassword:          "1234",
 		connectingUserChannelGrants: []string{"*"}, // All channels
 	})
-	require.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
 	attachmentBody := "attach"

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -319,11 +319,11 @@ func TestPutAttachmentViaBlipGetViaRest(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	// Create blip tester
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
-		connectingUsername: "user1",
-		connectingPassword: "1234",
-	})
-	require.NoError(t, err, "Unexpected error creating BlipTester")
+	bt := NewBlipTesterDefaultCollectionFromSpec(t, // CBG-2619 // make collection aware
+		BlipTesterSpec{
+			connectingUsername: "user1",
+			connectingPassword: "1234",
+		})
 	defer bt.Close()
 
 	attachmentBody := "attach"

--- a/rest/blip_api_collections_test.go
+++ b/rest/blip_api_collections_test.go
@@ -11,6 +11,7 @@ package rest
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/couchbase/go-blip"
@@ -26,32 +27,9 @@ func TestBlipGetCollections(t *testing.T) {
 
 	// checkpointIDWithError := "checkpointError"
 
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
-
-	ds := tb.GetNamedDataStore()
-	dataStoreName, ok := base.AsDataStoreName(ds)
-	require.True(t, ok)
-
-	scopeName := dataStoreName.ScopeName()
-	collectionName := dataStoreName.CollectionName()
-
-	scopeAndCollection := fmt.Sprintf("%s.%s", scopeName, collectionName)
 	const defaultScopeAndCollection = "_default._default"
 	rt := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: tb.NoCloseClone(),
-		GuestEnabled:     true,
-		DatabaseConfig: &DatabaseConfig{
-			DbConfig: DbConfig{
-				Scopes: ScopesConfig{
-					scopeName: ScopeConfig{
-						Collections: map[string]CollectionConfig{
-							collectionName: {},
-						},
-					},
-				},
-			},
-		},
+		GuestEnabled: true,
 		// leakyBucketConfig: &base.LeakyBucketConfig{
 		//	GetRawCallback: func(key string) error {
 		//		if key == db.CheckpointDocIDPrefix+checkpointIDWithError {
@@ -69,8 +47,9 @@ func TestBlipGetCollections(t *testing.T) {
 
 	checkpointID1 := "checkpoint1"
 	checkpoint1Body := db.Body{"seq": "123"}
-	dbInstance := db.Database{DatabaseContext: rt.GetDatabase()}
-	revID, err := dbInstance.GetSingleDatabaseCollection().PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
+	collection := rt.GetSingleTestDatabaseCollection()
+	scopeAndCollection := fmt.Sprintf("%s.%s", collection.ScopeName(), collection.Name())
+	revID, err := collection.PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
 	require.NoError(t, err)
 	checkpoint1RevID := "0-1"
 	require.Equal(t, checkpoint1RevID, revID)
@@ -174,31 +153,9 @@ func TestBlipGetCollections(t *testing.T) {
 func TestBlipGetCollectionsAndSetCheckpoint(t *testing.T) {
 	base.TestRequiresCollections(t)
 
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
-
-	ds := tb.GetSingleDataStore()
-	namedDataStore, ok := base.AsDataStoreName(ds)
-	require.True(t, ok)
-
-	scopeName := namedDataStore.ScopeName()
-	collectionName := namedDataStore.CollectionName()
-
 	rt := NewRestTester(t, &RestTesterConfig{
 		GuestEnabled: true,
-		DatabaseConfig: &DatabaseConfig{
-			DbConfig: DbConfig{
-				Scopes: ScopesConfig{
-					scopeName: ScopeConfig{
-						Collections: map[string]CollectionConfig{
-							collectionName: {},
-						},
-					},
-				},
-			},
-		},
 	})
-
 	defer rt.Close()
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
@@ -207,14 +164,14 @@ func TestBlipGetCollectionsAndSetCheckpoint(t *testing.T) {
 
 	checkpointID1 := "checkpoint1"
 	checkpoint1Body := db.Body{"seq": "123"}
-	dbInstance := db.Database{DatabaseContext: rt.GetDatabase()}
-	revID, err := dbInstance.GetSingleDatabaseCollection().PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
+	collection := rt.GetSingleTestDatabaseCollection()
+	revID, err := collection.PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
 	require.NoError(t, err)
 	checkpoint1RevID := "0-1"
 	require.Equal(t, checkpoint1RevID, revID)
 	getCollectionsRequest, err := db.NewGetCollectionsMessage(db.GetCollectionsRequestBody{
 		CheckpointIDs: []string{checkpointID1},
-		Collections:   []string{fmt.Sprintf("%s.%s", scopeName, collectionName)},
+		Collections:   []string{fmt.Sprintf("%s.%s", collection.ScopeName(), collection.Name())},
 	})
 
 	require.NoError(t, err)
@@ -255,27 +212,8 @@ func TestBlipGetCollectionsAndSetCheckpoint(t *testing.T) {
 func TestCollectionsPeerDoesNotHave(t *testing.T) {
 	base.TestRequiresCollections(t)
 
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
-
-	ds := tb.GetSingleDataStore()
-	namedDataStore, ok := base.AsDataStoreName(ds)
-	require.True(t, ok)
-
 	rt := NewRestTester(t, &RestTesterConfig{
-		GuestEnabled:     true,
-		CustomTestBucket: tb,
-		DatabaseConfig: &DatabaseConfig{
-			DbConfig: DbConfig{
-				Scopes: ScopesConfig{
-					namedDataStore.ScopeName(): ScopeConfig{
-						Collections: map[string]CollectionConfig{
-							namedDataStore.CollectionName(): {},
-						},
-					},
-				},
-			},
-		},
+		GuestEnabled: true,
 	})
 	defer rt.Close()
 
@@ -293,32 +231,13 @@ func TestCollectionsReplication(t *testing.T) {
 		t.Skip("only works with GSI")
 	}
 
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
-
-	tc, err := base.AsCollection(tb.GetSingleDataStore())
-	require.NoError(t, err)
-
-	scopeKey := tc.ScopeName()
-	collectionKey := tc.CollectionName()
-
-	scopeAndCollectionKey := scopeKey + "." + collectionKey
-
 	rt := NewRestTester(t, &RestTesterConfig{
 		GuestEnabled: true,
-		DatabaseConfig: &DatabaseConfig{
-			DbConfig: DbConfig{
-				Scopes: ScopesConfig{
-					scopeKey: ScopeConfig{
-						Collections: map[string]CollectionConfig{
-							collectionKey: {},
-						},
-					},
-				},
-			},
-		},
 	})
 	defer rt.Close()
+
+	collection := rt.GetSingleTestDatabaseCollection()
+	scopeAndCollectionKey := strings.Join([]string{collection.ScopeName(), collection.Name()}, base.ScopeCollectionSeparator)
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
 		Collections: []string{scopeAndCollectionKey},

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -755,10 +755,11 @@ func TestPublicPortAuthentication(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	// Create bliptester that is connected as user1, with access to the user1 channel
-	btUser1 := NewBlipTesterDefaultCollectionFromSpec(t, BlipTesterSpec{
-		connectingUsername: "user1",
-		connectingPassword: "1234",
-	})
+	btUser1 := NewBlipTesterDefaultCollectionFromSpec(t, // CBG-2619: make collection aware
+		BlipTesterSpec{
+			connectingUsername: "user1",
+			connectingPassword: "1234",
+		})
 	defer btUser1.Close()
 
 	// Send the user1 doc
@@ -818,10 +819,9 @@ function(doc, oldDoc) {
 
 `
 	rtConfig := RestTesterConfig{
-		SyncFn:         syncFunction,
-		DatabaseConfig: &DatabaseConfig{}, // does not work with scopes/collections
+		SyncFn: syncFunction,
 	}
-	var rt = NewRestTester(t, &rtConfig)
+	var rt = NewRestTesterDefaultCollection(t, &rtConfig) // CBG-2619: make collection aware
 	defer rt.Close()
 	ctx := rt.Context()
 
@@ -1312,10 +1312,9 @@ func TestReloadUser(t *testing.T) {
 
 	// Setup
 	rtConfig := RestTesterConfig{
-		SyncFn:         syncFn,
-		DatabaseConfig: &DatabaseConfig{}, // does not work with scopes/collections
+		SyncFn: syncFn,
 	}
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTesterDefaultCollection(t, &rtConfig) // CBG-2619: make collection aware
 	defer rt.Close()
 	ctx := rt.Context()
 	bt, err := NewBlipTesterFromSpecWithRT(t, &BlipTesterSpec{
@@ -1675,9 +1674,7 @@ func TestGetRemovedDoc(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
-	rt := NewRestTester(t, &RestTesterConfig{
-		DatabaseConfig: &DatabaseConfig{}, // does not work with scopes/collections
-	})
+	rt := NewRestTesterDefaultCollection(t, nil) // CBG-2619: make collection aware
 	defer rt.Close()
 	btSpec := BlipTesterSpec{
 		connectingUsername: "user1",
@@ -1950,9 +1947,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	rt := NewRestTester(t, &RestTesterConfig{
-		DatabaseConfig: &DatabaseConfig{}, // does not work with scopes/collections
-	})
+	rt := NewRestTesterDefaultCollection(t, nil) // CBG-2619: make collection aware
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/_user/user", `{"admin_channels": ["A", "B"], "password": "test"}`)
@@ -2058,9 +2053,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 	defer db.SuspendSequenceBatching()()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	rt := NewRestTester(t, &RestTesterConfig{
-		DatabaseConfig: &DatabaseConfig{}, // does not work with scopes/collections
-	})
+	rt := NewRestTesterDefaultCollection(t, nil) // CBG-2619: make collection aware
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/_user/user", `{"admin_channels": ["A", "B"], "password": "test"}`)
@@ -2362,10 +2355,10 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 	}
 
 	// Setup
-	rt := NewRestTester(t, &RestTesterConfig{
-		GuestEnabled:   true,
-		DatabaseConfig: &DatabaseConfig{}, // does not work with scopes/collections
-	})
+	rt := NewRestTesterDefaultCollection(t, // CBG-2619: make collection aware
+		&RestTesterConfig{
+			GuestEnabled: true,
+		})
 	defer rt.Close()
 
 	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -34,14 +34,15 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 
 	const docID = "pushAttachmentDoc"
 
-	rt := NewRestTester(t, &RestTesterConfig{
-		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			DeltaSync: &DeltaSyncConfig{
-				Enabled: base.BoolPtr(true),
-			},
-		}},
-		GuestEnabled: true,
-	})
+	rt := NewRestTesterDefaultCollection(t, // CBG-2619: make collection aware
+		&RestTesterConfig{
+			DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+				DeltaSync: &DeltaSyncConfig{
+					Enabled: base.BoolPtr(true),
+				},
+			}},
+			GuestEnabled: true,
+		})
 	defer rt.Close()
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
@@ -425,7 +426,8 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTesterDefaultCollection(t, // CBG-2619: make collection aware
+		&rtConfig)
 	defer rt.Close()
 
 	client, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
@@ -480,7 +482,8 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTesterDefaultCollection(t, // CBG-2619: make collection aware
+		&rtConfig)
 	defer rt.Close()
 
 	var deltaCacheHitsStart int64
@@ -575,7 +578,9 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTesterDefaultCollection(t, // CBG-2619: make collection aware
+		&rtConfig)
+
 	defer rt.Close()
 
 	var deltaCacheHitsStart int64

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -89,7 +89,10 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache, base.KeyAccess, base.KeyCRUD, base.KeyChanges)
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channels)}`}
+	rtConfig := RestTesterConfig{
+		SyncFn:         `function(doc) {channel(doc.channels)}`,
+		DatabaseConfig: &DatabaseConfig{}, // does not work with scopes/collections
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -90,10 +90,9 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache, base.KeyAccess, base.KeyCRUD, base.KeyChanges)
 
 	rtConfig := RestTesterConfig{
-		SyncFn:         `function(doc) {channel(doc.channels)}`,
-		DatabaseConfig: &DatabaseConfig{}, // does not work with scopes/collections
+		SyncFn: `function(doc) {channel(doc.channels)}`,
 	}
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTesterDefaultCollection(t, &rtConfig) // CBG-2618: fix collection channel access
 	defer rt.Close()
 
 	ctx := rt.Context()

--- a/rest/changesttest/changes_api_test.go
+++ b/rest/changesttest/changes_api_test.go
@@ -282,7 +282,10 @@ func TestPostChangesSinceInteger(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		SyncFn:         `function(doc) {channel(doc.channel);}`,
+		DatabaseConfig: &rest.DatabaseConfig{}, // force use of default scope and collection
+	})
 	defer rt.Close()
 
 	postChangesSince(t, rt)

--- a/rest/changesttest/changes_api_test.go
+++ b/rest/changesttest/changes_api_test.go
@@ -457,7 +457,10 @@ func TestPostChangesAdminChannelGrant(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		SyncFn:         `function(doc) {channel(doc.channel);}`,
+		DatabaseConfig: &rest.DatabaseConfig{}, // does not work with collections yet
+	})
 	defer rt.Close()
 
 	// Create user with access to channel ABC:
@@ -543,7 +546,9 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 	// Disable sequence batching for multi-RT tests (pending CBG-1000)
 	defer db.SuspendSequenceBatching()()
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`,
+		DatabaseConfig: &rest.DatabaseConfig{}, // does not work with collections yet
+	})
 	defer rt.Close()
 
 	// Create user with access to channel ABC:
@@ -698,7 +703,9 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 func TestPostChangesAdminChannelGrantRemovalWithLimit(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`,
+		DatabaseConfig: &rest.DatabaseConfig{}, // does not work with collections yet
+	})
 	defer rt.Close()
 
 	// Create user with access to channel ABC:
@@ -1729,7 +1736,10 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 
 	defer db.SuspendSequenceBatching()()
 
-	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channels)}`}
+	rtConfig := rest.RestTesterConfig{
+		SyncFn:         `function(doc) {channel(doc.channels)}`,
+		DatabaseConfig: &rest.DatabaseConfig{}, // does not work with collections yet
+	}
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -1932,7 +1942,10 @@ func TestChangesIncludeDocs(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyNone)
 
-	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channels)}`}
+	rtConfig := rest.RestTesterConfig{
+		SyncFn:         `function(doc) {channel(doc.channels)}`,
+		DatabaseConfig: &rest.DatabaseConfig{}, // does not work with collections yet
+	}
 	rt := rest.NewRestTester(t, &rtConfig)
 	testDB := rt.GetDatabase()
 	testDB.RevsLimit = 3
@@ -3681,7 +3694,9 @@ func TestIncludeDocsWithPrincipals(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
-	rt := rest.NewRestTester(t, nil)
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		DatabaseConfig: &rest.DatabaseConfig{}, // force use of default scope and collection
+	})
 	defer rt.Close()
 
 	ctx := rt.Context()
@@ -3736,7 +3751,9 @@ func TestChangesAdminChannelGrantLongpollNotify(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
-	rt := rest.NewRestTester(t, nil)
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		DatabaseConfig: &rest.DatabaseConfig{}, // force use of default scope and collection
+	})
 	defer rt.Close()
 
 	// Create user with access to channel ABC:

--- a/rest/changesttest/changes_api_test.go
+++ b/rest/changesttest/changes_api_test.go
@@ -282,17 +282,19 @@ func TestPostChangesSinceInteger(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
-		SyncFn:         `function(doc) {channel(doc.channel);}`,
-		DatabaseConfig: &rest.DatabaseConfig{}, // force use of default scope and collection
-	})
+	rt := rest.NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+		&rest.RestTesterConfig{
+			SyncFn:         `function(doc) {channel(doc.channel);}`,
+			DatabaseConfig: &rest.DatabaseConfig{}, // force use of default scope and collection
+		})
 	defer rt.Close()
 
 	postChangesSince(t, rt)
 }
 
 func TestPostChangesWithQueryString(t *testing.T) {
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
+	rt := rest.NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+		&rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
 
 	// Put several documents
@@ -457,10 +459,10 @@ func TestPostChangesAdminChannelGrant(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
-		SyncFn:         `function(doc) {channel(doc.channel);}`,
-		DatabaseConfig: &rest.DatabaseConfig{}, // does not work with collections yet
-	})
+	rt := rest.NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+		&rest.RestTesterConfig{
+			SyncFn: `function(doc) {channel(doc.channel);}`,
+		})
 	defer rt.Close()
 
 	// Create user with access to channel ABC:
@@ -546,9 +548,8 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 	// Disable sequence batching for multi-RT tests (pending CBG-1000)
 	defer db.SuspendSequenceBatching()()
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`,
-		DatabaseConfig: &rest.DatabaseConfig{}, // does not work with collections yet
-	})
+	rt := rest.NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+		&rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
 
 	// Create user with access to channel ABC:
@@ -703,9 +704,8 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 func TestPostChangesAdminChannelGrantRemovalWithLimit(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`,
-		DatabaseConfig: &rest.DatabaseConfig{}, // does not work with collections yet
-	})
+	rt := rest.NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+		&rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
 
 	// Create user with access to channel ABC:
@@ -986,7 +986,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 		NumIndexReplicas: &numIndexReplicas,
 	}}
 	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`, DatabaseConfig: shortWaitConfig}
-	rt := rest.NewRestTester(t, &rtConfig)
+	rt := rest.NewRestTesterDefaultCollection(t, &rtConfig) // CBG-2618: fix collection channel access
 	defer rt.Close()
 
 	ctx := rt.Context()
@@ -1078,7 +1078,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 		NumIndexReplicas: &numIndexReplicas,
 	}}
 	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`, DatabaseConfig: shortWaitConfig}
-	rt := rest.NewRestTester(t, &rtConfig)
+	rt := rest.NewRestTesterDefaultCollection(t, &rtConfig) // CBG-2618: fix collection channel access
 	defer rt.Close()
 
 	ctx := rt.Context()
@@ -1213,7 +1213,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 		NumIndexReplicas: &numIndexReplicas,
 	}}
 	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`, DatabaseConfig: shortWaitConfig}
-	rt := rest.NewRestTester(t, &rtConfig)
+	rt := rest.NewRestTesterDefaultCollection(t, &rtConfig) // CBG-2618: fix collection channel access
 	defer rt.Close()
 
 	ctx := rt.Context()
@@ -1345,7 +1345,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 		NumIndexReplicas: &numIndexReplicas,
 	}}
 	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`, DatabaseConfig: shortWaitConfig}
-	rt := rest.NewRestTester(t, &rtConfig)
+	rt := rest.NewRestTesterDefaultCollection(t, &rtConfig) // CBG-2618: fix collection channel access
 	defer rt.Close()
 
 	ctx := rt.Context()
@@ -1737,10 +1737,9 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
 	rtConfig := rest.RestTesterConfig{
-		SyncFn:         `function(doc) {channel(doc.channels)}`,
-		DatabaseConfig: &rest.DatabaseConfig{}, // does not work with collections yet
+		SyncFn: `function(doc) {channel(doc.channels)}`,
 	}
-	rt := rest.NewRestTester(t, &rtConfig)
+	rt := rest.NewRestTesterDefaultCollection(t, &rtConfig) // CBG-2618: fix collection channel access
 	defer rt.Close()
 
 	// Create user1
@@ -1943,10 +1942,9 @@ func TestChangesIncludeDocs(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyNone)
 
 	rtConfig := rest.RestTesterConfig{
-		SyncFn:         `function(doc) {channel(doc.channels)}`,
-		DatabaseConfig: &rest.DatabaseConfig{}, // does not work with collections yet
+		SyncFn: `function(doc) {channel(doc.channels)}`,
 	}
-	rt := rest.NewRestTester(t, &rtConfig)
+	rt := rest.NewRestTesterDefaultCollection(t, &rtConfig) // CBG-2618: fix collection channel access
 	testDB := rt.GetDatabase()
 	testDB.RevsLimit = 3
 	defer rt.Close()
@@ -3694,9 +3692,7 @@ func TestIncludeDocsWithPrincipals(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
-		DatabaseConfig: &rest.DatabaseConfig{}, // force use of default scope and collection
-	})
+	rt := rest.NewRestTesterDefaultCollection(t, nil) // CBG-2618: fix collection channel access
 	defer rt.Close()
 
 	ctx := rt.Context()
@@ -3751,9 +3747,7 @@ func TestChangesAdminChannelGrantLongpollNotify(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
-		DatabaseConfig: &rest.DatabaseConfig{}, // force use of default scope and collection
-	})
+	rt := rest.NewRestTesterDefaultCollection(t, nil) // CBG-2618: fix collection channel access
 	defer rt.Close()
 
 	// Create user with access to channel ABC:

--- a/rest/changesttest/changes_collection_test.go
+++ b/rest/changesttest/changes_collection_test.go
@@ -10,6 +10,7 @@ package changestest
 
 import (
 	"log"
+	"strings"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/channels"
@@ -389,11 +390,11 @@ func TestMultiCollectionChangesCustomSyncFunctions(t *testing.T) {
 		},
 	}
 
-	rt, keyspaces := rest.NewRestTesterMultipleCollections(t, rtConfig, numCollections)
+	rt, _ := rest.NewRestTesterMultipleCollections(t, rtConfig, numCollections)
 	defer rt.Close()
 
-	c1Keyspace := keyspaces[0]
-	c2Keyspace := keyspaces[1]
+	c1Keyspace := strings.Join([]string{rt.GetDatabase().Name, dataStoreNames[0].ScopeName(), dataStoreNames[0].CollectionName()}, base.ScopeCollectionSeparator)
+	c2Keyspace := strings.Join([]string{rt.GetDatabase().Name, dataStoreNames[1].ScopeName(), dataStoreNames[1].CollectionName()}, base.ScopeCollectionSeparator)
 
 	// Create user with access to channel collection1 in both collections
 	ctx := rt.Context()

--- a/rest/changesttest/changes_collection_test.go
+++ b/rest/changesttest/changes_collection_test.go
@@ -10,7 +10,6 @@ package changestest
 
 import (
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/channels"
@@ -390,11 +389,11 @@ func TestMultiCollectionChangesCustomSyncFunctions(t *testing.T) {
 		},
 	}
 
-	rt, _ := rest.NewRestTesterMultipleCollections(t, rtConfig, numCollections)
+	rt, keyspaces := rest.NewRestTesterMultipleCollections(t, rtConfig, numCollections)
 	defer rt.Close()
 
-	c1Keyspace := strings.Join([]string{rt.GetDatabase().Name, dataStoreNames[0].ScopeName(), dataStoreNames[0].CollectionName()}, base.ScopeCollectionSeparator)
-	c2Keyspace := strings.Join([]string{rt.GetDatabase().Name, dataStoreNames[1].ScopeName(), dataStoreNames[1].CollectionName()}, base.ScopeCollectionSeparator)
+	c1Keyspace := keyspaces[0]
+	c2Keyspace := keyspaces[1]
 
 	// Create user with access to channel collection1 in both collections
 	ctx := rt.Context()

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -68,7 +68,7 @@ func TestXattrImportOldDoc(t *testing.T) {
 		&rtConfig)
 	defer rt.Close()
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
@@ -97,7 +97,7 @@ func TestXattrImportOldDoc(t *testing.T) {
 	updatedBody["test"] = "TestImportDelete"
 	updatedBody["channels"] = "HBO"
 
-	err = rt.GetSingleTestDataStore().Set(key, 0, nil, updatedBody)
+	err = rt.GetSingleDataStore().Set(key, 0, nil, updatedBody)
 	assert.NoError(t, err, "Unable to update doc TestImportDelete")
 
 	// Attempt to get the document via Sync Gateway, to trigger import.  On import of a create, oldDoc should be nil.
@@ -151,7 +151,7 @@ func TestXattrImportOldDocRevHistory(t *testing.T) {
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
 	// 1. Create revision with history
@@ -201,7 +201,7 @@ func TestXattrSGTombstone(t *testing.T) {
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
@@ -247,7 +247,7 @@ func TestXattrImportOnCasFailure(t *testing.T) {
 	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport)
 
 	// 1. SG Write
@@ -367,7 +367,7 @@ func TestXattrResurrectViaSDK(t *testing.T) {
 	docBody["test"] = key
 	docBody["channels"] = "ABC"
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	_, err := dataStore.Add(key, 0, docBody)
 	assert.NoError(t, err, "Unable to insert doc TestResurrectViaSDK")
@@ -442,7 +442,7 @@ func TestXattrDoubleDelete(t *testing.T) {
 
 	// 2. Delete the doc through the SDK
 	log.Printf("...............Delete through SDK.....................................")
-	deleteErr := rt.GetSingleTestDataStore().Delete(key)
+	deleteErr := rt.GetSingleDataStore().Delete(key)
 	assert.NoError(t, deleteErr, "Couldn't delete via SDK")
 
 	log.Printf("...............Delete through SG.......................................")
@@ -475,7 +475,7 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport)
 
@@ -550,7 +550,7 @@ func TestXattrImportFilterOptIn(t *testing.T) {
 	}
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
@@ -606,7 +606,7 @@ func TestImportFilterLogging(t *testing.T) {
 	body := make(map[string]interface{})
 	body["type"] = "mobile"
 	body["channels"] = "A"
-	ok, err := rt.GetSingleTestDataStore().Add(key, 0, body)
+	ok, err := rt.GetSingleDataStore().Add(key, 0, body)
 	assert.NoError(t, err)
 	assert.True(t, ok)
 
@@ -641,7 +641,7 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 	}
 	rt := rest.NewRestTesterDefaultCollection(t, &rtConfig) // CBG-2618: fix collection channel access
 	defer rt.Close()
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
@@ -697,7 +697,7 @@ func TestXattrImportMultipleActorOnDemandPut(t *testing.T) {
 	}
 	rt := rest.NewRestTesterDefaultCollection(t, &rtConfig) // CBG-2618: fix collection channel access
 	defer rt.Close()
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
@@ -756,7 +756,7 @@ func TestXattrImportMultipleActorOnDemandFeed(t *testing.T) {
 
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
@@ -837,7 +837,7 @@ func TestXattrImportLargeNumbers(t *testing.T) {
 	mobileBody := make(map[string]interface{})
 	mobileBody["channels"] = "ABC"
 	mobileBody["largeNumber"] = uint64(9223372036854775807)
-	_, err := rt.GetSingleTestDataStore().Add(mobileKey, 0, mobileBody)
+	_, err := rt.GetSingleDataStore().Add(mobileKey, 0, mobileBody)
 	assert.NoError(t, err, "Error writing SDK doc")
 
 	// 2. Attempt to get the document via Sync Gateway.  Will trigger on-demand import.
@@ -915,7 +915,7 @@ func TestMigrateLargeInlineRevisions(t *testing.T) {
 	largeBodyString := fmt.Sprintf(bodyString, largeProperty, largeProperty, largeProperty)
 
 	// Create via the SDK with sync metadata intact
-	_, err := rt.GetSingleTestDataStore().Add(key, 0, []byte(largeBodyString))
+	_, err := rt.GetSingleDataStore().Add(key, 0, []byte(largeBodyString))
 	assert.NoError(t, err, "Error writing doc w/ large inline revisions")
 
 	// Attempt to get the documents via Sync Gateway.  Will trigger on-demand migrate.
@@ -983,7 +983,7 @@ func TestMigrateTombstone(t *testing.T) {
 }`
 
 	// Create via the SDK with sync metadata intact
-	_, err := rt.GetSingleTestDataStore().Add(key, 0, []byte(bodyString))
+	_, err := rt.GetSingleDataStore().Add(key, 0, []byte(bodyString))
 	assert.NoError(t, err, "Error writing tombstoned doc")
 
 	// Attempt to get the documents via Sync Gateway.  Will trigger on-demand migrate.
@@ -1053,7 +1053,7 @@ func TestMigrateWithExternalRevisions(t *testing.T) {
 	largeBodyString := fmt.Sprintf(bodyString, largeProperty, largeProperty)
 
 	// Create via the SDK with sync metadata intact
-	_, err := rt.GetSingleTestDataStore().Add(key, 0, []byte(largeBodyString))
+	_, err := rt.GetSingleDataStore().Add(key, 0, []byte(largeBodyString))
 	assert.NoError(t, err, "Error writing doc w/ large inline revisions")
 
 	// Attempt to get the documents via Sync Gateway.  Will trigger on-demand migrate.
@@ -1088,7 +1088,7 @@ func TestCheckForUpgradeOnRead(t *testing.T) {
 	}
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
@@ -1167,7 +1167,7 @@ func TestCheckForUpgradeOnWrite(t *testing.T) {
 	}
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD, base.KeyCache)
 
@@ -1250,7 +1250,7 @@ func TestCheckForUpgradeFeed(t *testing.T) {
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD, base.KeyCache)
 
@@ -1313,7 +1313,7 @@ func TestXattrFeedBasedImportPreservesExpiry(t *testing.T) {
 	}
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
@@ -1374,7 +1374,7 @@ func TestFeedBasedMigrateWithExpiry(t *testing.T) {
 	}
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
@@ -1423,7 +1423,7 @@ func TestOnDemandWriteImportReplacingNullDoc(t *testing.T) {
 	}
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
@@ -1495,7 +1495,7 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 			}
 			rt := rest.NewRestTester(t, &rtConfig)
 			defer rt.Close()
-			dataStore := rt.GetSingleTestDataStore()
+			dataStore := rt.GetSingleDataStore()
 
 			base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
@@ -1578,7 +1578,7 @@ func TestOnDemandMigrateWithExpiry(t *testing.T) {
 			}
 			rt := rest.NewRestTester(t, &rtConfig)
 			defer rt.Close()
-			dataStore := rt.GetSingleTestDataStore()
+			dataStore := rt.GetSingleDataStore()
 
 			base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
@@ -1624,7 +1624,7 @@ func TestXattrSGWriteOfNonImportedDoc(t *testing.T) {
 
 	log.Printf("Starting get bucket....")
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
@@ -1672,7 +1672,7 @@ func TestImportBinaryDoc(t *testing.T) {
 
 	log.Printf("Starting get bucket....")
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD, base.KeyCache)
 
@@ -1701,7 +1701,7 @@ func TestImportZeroValueDecimalPlaces(t *testing.T) {
 
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	const minDecimalPlaces = 0
 	const maxDecimalPlaces = 20
@@ -1768,7 +1768,7 @@ func TestImportZeroValueDecimalPlacesScientificNotation(t *testing.T) {
 	const minDecimalPlaces = 0
 	const maxDecimalPlaces = 20
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	for i := minDecimalPlaces; i <= maxDecimalPlaces; i++ {
 		var docNumber string
@@ -1828,7 +1828,7 @@ func TestImportRevisionCopy(t *testing.T) {
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport)
 
 	key := "TestImportRevisionCopy"
@@ -1889,7 +1889,7 @@ func TestImportRevisionCopyUnavailable(t *testing.T) {
 		t.Skipf("Skipping TestImportRevisionCopyUnavailable when delta sync enabled, delta revision backup handling invalidates test")
 	}
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport)
 
 	key := "TestImportRevisionCopy"
@@ -1950,7 +1950,7 @@ func TestImportRevisionCopyDisabled(t *testing.T) {
 		t.Skipf("Skipping TestImportRevisionCopyDisabled when delta sync enabled, delta revision backup handling invalidates test")
 	}
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport)
 
 	key := "TestImportRevisionCopy"
@@ -2003,7 +2003,7 @@ func TestDcpBackfill(t *testing.T) {
 
 	log.Printf("Starting get bucket....")
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	// Write enough documents directly to the bucket to ensure multiple docs per vbucket (on average)
 	docBody := make(map[string]interface{})
@@ -2027,7 +2027,7 @@ func TestDcpBackfill(t *testing.T) {
 	newRt := rest.NewRestTester(t, &newRtConfig)
 	defer newRt.Close()
 	log.Printf("Poke the rest tester so it starts DCP processing:")
-	dataStore = newRt.GetSingleTestDataStore()
+	dataStore = newRt.GetSingleDataStore()
 
 	backfillComplete := false
 	var expectedBackfill, completedBackfill int
@@ -2063,7 +2063,7 @@ func TestUnexpectedBodyOnTombstone(t *testing.T) {
 	}
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
@@ -2173,7 +2173,7 @@ func TestDeletedEmptyDocumentImport(t *testing.T) {
 	assert.Equal(t, "1-ca9ad22802b66f662ff171f226211d5c", body["rev"])
 
 	// Delete the document through SDK
-	err := rt.GetSingleTestDataStore().Delete(docId)
+	err := rt.GetSingleDataStore().Delete(docId)
 	assert.NoError(t, err, "Unable to delete doc %s", docId)
 
 	// Get the doc and check deleted revision is getting imported
@@ -2206,7 +2206,7 @@ func TestDeletedDocumentImportWithImportFilter(t *testing.T) {
 	}
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD, base.KeyJavascript)
 
 	// Create document via SDK
@@ -2341,7 +2341,7 @@ func TestImportInternalPropertiesHandling(t *testing.T) {
 	for i, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			docID := fmt.Sprintf("test%d", i)
-			added, err := rt.GetSingleTestDataStore().Add(docID, 0, test.importBody)
+			added, err := rt.GetSingleDataStore().Add(docID, 0, test.importBody)
 			require.True(t, added)
 			require.NoError(t, err)
 
@@ -2391,7 +2391,7 @@ func TestImportTouch(t *testing.T) {
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	// 1. Create a document
 	key := "TestImportTouch"
@@ -2435,7 +2435,7 @@ func TestImportingPurgedDocument(t *testing.T) {
 	defer rt.Close()
 
 	body := `{"_purged": true, "foo": "bar"}`
-	ok, err := rt.GetSingleTestDataStore().Add("key", 0, []byte(body))
+	ok, err := rt.GetSingleDataStore().Add("key", 0, []byte(body))
 	assert.NoError(t, err)
 	assert.True(t, ok)
 
@@ -2461,7 +2461,7 @@ func TestNonImportedDuplicateID(t *testing.T) {
 	defer rt.Close()
 
 	body := `{"foo":"bar"}`
-	ok, err := rt.GetSingleTestDataStore().Add("key", 0, []byte(body))
+	ok, err := rt.GetSingleDataStore().Add("key", 0, []byte(body))
 
 	assert.True(t, ok)
 	assert.Nil(t, err)
@@ -2485,7 +2485,7 @@ func TestImportOnWriteMigration(t *testing.T) {
 	// Put doc with sync data / non-xattr
 	key := "doc1"
 	body := []byte(`{"_sync": { "rev": "1-fc2cf22c5e5007bd966869ebfe9e276a", "sequence": 1, "recent_sequences": [ 1 ], "history": { "revs": [ "1-fc2cf22c5e5007bd966869ebfe9e276a" ], "parents": [ -1], "channels": [ null ] }, "cas": "","value_crc32c": "", "time_saved": "2019-04-10T12:40:04.490083+01:00" }, "value": "foo"}`)
-	ok, err := rt.GetSingleTestDataStore().Add(key, 0, body)
+	ok, err := rt.GetSingleDataStore().Add(key, 0, body)
 	assert.NoError(t, err)
 	assert.True(t, ok)
 
@@ -2533,7 +2533,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 
 	defer rt.Close()
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 	userXattrStore, ok := base.AsUserXattrStore(dataStore)
 	if !ok {
 		t.Skip("Test requires Couchbase Bucket")
@@ -2656,7 +2656,7 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 
 	defer rt.Close()
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	userXattrStore, ok := base.AsUserXattrStore(dataStore)
 	if !ok {
@@ -2758,7 +2758,7 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 
 	defer rt.Close()
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	userXattrStore, ok := base.AsUserXattrStore(dataStore)
 	if !ok {
@@ -2823,7 +2823,7 @@ func TestImportFilterTimeout(t *testing.T) {
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	added, err := rt.GetSingleTestDataStore().AddRaw("doc", 0, []byte(fmt.Sprintf(`{"foo": "bar"}`)))
+	added, err := rt.GetSingleDataStore().AddRaw("doc", 0, []byte(fmt.Sprintf(`{"foo": "bar"}`)))
 	require.True(t, added)
 	require.NoError(t, err)
 

--- a/rest/jwt_auth_test.go
+++ b/rest/jwt_auth_test.go
@@ -449,7 +449,7 @@ func TestLocalJWTRolesChannels(t *testing.T) {
 	restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{LocalJWTConfig: auth.LocalJWTConfig{
 		testProviderName: baseProvider,
 	}}}}
-	restTester := NewRestTester(t, &restTesterConfig)
+	restTester := NewRestTesterDefaultCollection(t, &restTesterConfig) // CBG-2618: fix collection channel access
 	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -1044,7 +1044,7 @@ func TestOpenIDConnectImplicitFlow(t *testing.T) {
 
 			opts := auth.OIDCOptions{Providers: tc.providers, DefaultProvider: &tc.defaultProvider}
 			restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{OIDCConfig: &opts}}}
-			restTester := NewRestTester(t, &restTesterConfig)
+			restTester := NewRestTesterDefaultCollection(t, &restTesterConfig) // CBG-2618: fix collection channel access
 			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
 
@@ -1114,7 +1114,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 
 	opts := auth.OIDCOptions{Providers: providers, DefaultProvider: &defaultProvider}
 	restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{OIDCConfig: &opts}}}
-	restTester := NewRestTester(t, &restTesterConfig)
+	restTester := NewRestTesterDefaultCollection(t, &restTesterConfig) // CBG-2618: fix collection channel access
 	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 
@@ -2110,7 +2110,7 @@ func TestEventuallyReachableOIDCClient(t *testing.T) {
 
 			opts := auth.OIDCOptions{Providers: tc.providers, DefaultProvider: &tc.defaultProvider}
 			restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{OIDCConfig: &opts}}}
-			restTester := NewRestTester(t, &restTesterConfig)
+			restTester := NewRestTesterDefaultCollection(t, &restTesterConfig) // CBG-2618: fix collection channel access
 			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
 
@@ -2217,7 +2217,7 @@ func TestOpenIDConnectRolesChannelsClaims(t *testing.T) {
 					OIDCConfig: &opts,
 				}},
 			}
-			restTester := NewRestTester(t, &restTesterConfig)
+			restTester := NewRestTesterDefaultCollection(t, &restTesterConfig) // CBG-2618: fix collection channel access
 			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
 
@@ -2450,20 +2450,21 @@ func TestOpenIDConnectIssuerChange(t *testing.T) {
 		DatabaseConfig:   &DatabaseConfig{DbConfig: DbConfig{}},
 		CustomTestBucket: tb1,
 	}
-	rt1 := NewRestTester(t, &rt1Config)
+	rt1 := NewRestTesterDefaultCollection(t, &rt1Config) // CBG-2618: fix collection channel access
 	require.NoError(t, rt1.SetAdminParty(false))
 	defer rt1.Close()
 
 	msg1 := httptest.NewServer(rt1.TestPublicHandler())
 	defer msg1.Close()
 
-	rt2 := NewRestTester(t, &RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-		Unsupported: &db.UnsupportedOptions{
-			OidcTestProvider: &db.OidcTestProviderOptions{
-				Enabled: true,
+	rt2 := NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+		&RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			Unsupported: &db.UnsupportedOptions{
+				OidcTestProvider: &db.OidcTestProviderOptions{
+					Enabled: true,
+				},
 			},
-		},
-	}}})
+		}}})
 	defer rt2.Close()
 	msg2 := httptest.NewServer(rt2.TestPublicHandler())
 	defer msg2.Close()

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -307,7 +307,8 @@ func TestOpenIDConnectTestProviderWithRealWorldToken(t *testing.T) {
 						},
 					},
 				}}}
-			restTester := NewRestTester(t, &restTesterConfig)
+			restTester := NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+				&restTesterConfig)
 			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
 
@@ -409,7 +410,8 @@ func TestOIDCWithBasicAuthDisabled(t *testing.T) {
 			},
 			DisablePasswordAuth: base.BoolPtr(true),
 		}}}
-	restTester := NewRestTester(t, &restTesterConfig)
+	restTester := NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+		&restTesterConfig)
 	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -197,9 +197,7 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 	adminSrv := httptest.NewServer(passiveRT.TestAdminHandler())
 	defer adminSrv.Close()
 
-	activeRT := NewRestTester(t, &RestTesterConfig{
-		DatabaseConfig: &DatabaseConfig{}, // replicator requires default collection
-	})
+	activeRT := NewRestTesterDefaultCollection(t, nil) //  CBG-2319: replicator currently requires default collection
 	defer activeRT.Close()
 	activeCtx := activeRT.Context()
 
@@ -438,7 +436,7 @@ function (doc) {
 				}},
 			}
 			// Set up buckets, rest testers, and set up servers
-			passiveRT := NewRestTester(t, rtConfig)
+			passiveRT := NewRestTesterDefaultCollection(t, rtConfig) //  CBG-2319: replicator currently requires default collection
 			defer passiveRT.Close()
 
 			publicSrv := httptest.NewServer(passiveRT.TestPublicHandler())
@@ -447,7 +445,7 @@ function (doc) {
 			adminSrv := httptest.NewServer(passiveRT.TestAdminHandler())
 			defer adminSrv.Close()
 
-			activeRT := NewRestTester(t, rtConfig)
+			activeRT := NewRestTesterDefaultCollection(t, rtConfig) //  CBG-2319: replicator currently requires default collection
 			defer activeRT.Close()
 
 			// Change RT depending on direction

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -189,13 +189,17 @@ func TestReplicatorDeprecatedCredentials(t *testing.T) {
 func TestReplicatorCheckpointOnStop(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
-	passiveRT := NewRestTester(t, nil)
+	passiveRT := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{}, // replicator requires default collection
+	})
 	defer passiveRT.Close()
 
 	adminSrv := httptest.NewServer(passiveRT.TestAdminHandler())
 	defer adminSrv.Close()
 
-	activeRT := NewRestTester(t, nil)
+	activeRT := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{}, // replicator requires default collection
+	})
 	defer activeRT.Close()
 	activeCtx := activeRT.Context()
 

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -639,7 +639,6 @@ func TestReplicationStatusActions(t *testing.T) {
 //   - adds another active node
 //   - Creates more documents, validates they are replicated
 func TestReplicationRebalancePull(t *testing.T) {
-
 	if !base.IsEnterpriseEdition() {
 		t.Skipf("test is EE only (replication rebalance)")
 	}
@@ -729,7 +728,6 @@ func TestReplicationRebalancePull(t *testing.T) {
 //   - adds another active node
 //   - Creates more documents, validates they are replicated
 func TestReplicationRebalancePush(t *testing.T) {
-
 	if !base.IsEnterpriseEdition() {
 		t.Skipf("test is EE only (replication rebalance)")
 	}

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1553,6 +1553,7 @@ func TestDBReplicationStatsTeardown(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}
+	base.RequireNumTestBuckets(t, 2)
 	// Test tests Prometheus stat registration
 	base.SkipPrometheusStatsRegistration = false
 	defer func() {
@@ -5807,6 +5808,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 			passiveBucket := base.GetTestBucket(t)
 			remotePassiveRT := rest.NewRestTester(t, &rest.RestTesterConfig{
 				CustomTestBucket: passiveBucket,
+				DatabaseConfig:   &rest.DatabaseConfig{}, // force use of default scope and collection
 			})
 			defer remotePassiveRT.Close()
 
@@ -5818,6 +5820,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 			localActiveRT := rest.NewRestTester(t, &rest.RestTesterConfig{
 				CustomTestBucket:   activeBucket,
 				SgReplicateEnabled: true,
+				DatabaseConfig:     &rest.DatabaseConfig{}, // force use of default scope and collection
 			})
 			defer localActiveRT.Close()
 
@@ -7025,6 +7028,7 @@ func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 	passiveBucket := base.GetTestBucket(t)
 	passiveRT := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: passiveBucket,
+		DatabaseConfig:   &rest.DatabaseConfig{}, // force use of default scope and collection
 	})
 	defer passiveRT.Close()
 
@@ -7036,6 +7040,7 @@ func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 	activeBucket := base.GetTestBucket(t)
 	activeRT := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: activeBucket,
+		DatabaseConfig:   &rest.DatabaseConfig{}, // force use of default scope and collection
 	})
 	defer activeRT.Close()
 	activeCtx := activeRT.Context()

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1880,23 +1880,24 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 		password = "pa$$w*rD!"
 	)
 
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb2,
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				username: {
-					Password:         base.StringPtr(password),
-					ExplicitChannels: base.SetOf(username),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb2,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					username: {
+						Password:         base.StringPtr(password),
+						ExplicitChannels: base.SetOf(username),
+					},
 				},
-			},
-			CacheConfig: &rest.CacheConfig{
-				// shorten pending sequence handling to speed up test
-				ChannelCacheConfig: &rest.ChannelCacheConfig{
-					MaxWaitPending: base.Uint32Ptr(1),
+				CacheConfig: &rest.CacheConfig{
+					// shorten pending sequence handling to speed up test
+					ChannelCacheConfig: &rest.ChannelCacheConfig{
+						MaxWaitPending: base.Uint32Ptr(1),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
@@ -1912,9 +1913,10 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	// Active
 	tb1 := base.GetTestBucket(t)
 
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb1,
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -36,10 +36,7 @@ import (
 
 func TestReplicationAPI(t *testing.T) {
 
-	var rt = rest.NewRestTester(t, nil)
-	// if rt == nil {
-	// 	return
-	// }
+	rt := rest.NewRestTesterDefaultCollection(t, nil) // CBG-2319: replicator currently requires default collection
 	defer rt.Close()
 
 	replicationConfig := db.ReplicationConfig{
@@ -108,7 +105,7 @@ func TestReplicationAPI(t *testing.T) {
 }
 func TestValidateReplicationAPI(t *testing.T) {
 
-	var rt = rest.NewRestTester(t, nil)
+	rt := rest.NewRestTesterDefaultCollection(t, nil) // CBG-2319: replicator currently requires default collection
 	defer rt.Close()
 
 	tests := []struct {
@@ -183,7 +180,7 @@ func TestValidateReplicationAPI(t *testing.T) {
 
 func TestReplicationStatusAPI(t *testing.T) {
 
-	var rt = rest.NewRestTester(t, nil)
+	rt := rest.NewRestTesterDefaultCollection(t, nil) // CBG-2319: replicator currently requires default collection
 	defer rt.Close()
 
 	// GET replication status for non-existent replication ID
@@ -239,7 +236,7 @@ func TestReplicationStatusAPI(t *testing.T) {
 
 func TestReplicationStatusStopAdhoc(t *testing.T) {
 
-	var rt = rest.NewRestTester(t, nil)
+	rt := rest.NewRestTesterDefaultCollection(t, nil) // CBG-2319: replicator currently requires default collection
 	defer rt.Close()
 
 	// GET replication status for non-existent replication ID
@@ -307,7 +304,7 @@ func TestReplicationStatusStopAdhoc(t *testing.T) {
 
 func TestReplicationStatusAPIIncludeConfig(t *testing.T) {
 
-	var rt = rest.NewRestTester(t, nil)
+	rt := rest.NewRestTesterDefaultCollection(t, nil) // CBG-2319: replicator currently requires default collection
 	defer rt.Close()
 
 	// GET replication status for non-existent replication ID
@@ -428,7 +425,8 @@ func TestReplicationsFromConfig(t *testing.T) {
 				dbConfig.Replications[rc.ID] = rc
 			}
 
-			rt := rest.NewRestTester(t, &rest.RestTesterConfig{DatabaseConfig: dbConfig})
+			rt := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+				&rest.RestTesterConfig{DatabaseConfig: dbConfig})
 			defer rt.Close()
 
 			// Retrieve replications
@@ -642,7 +640,6 @@ func TestReplicationRebalancePull(t *testing.T) {
 	if !base.IsEnterpriseEdition() {
 		t.Skipf("test is EE only (replication rebalance)")
 	}
-
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
@@ -947,7 +944,7 @@ func TestReplicationConcurrentPush(t *testing.T) {
 
 }
 func TestReplicationAPIWithAuthCredentials(t *testing.T) {
-	var rt = rest.NewRestTester(t, nil)
+	rt := rest.NewRestTesterDefaultCollection(t, nil) // CBG-2319: replicator currently requires default collection
 	defer rt.Close()
 
 	// Create replication with explicitly defined auth credentials in replication config
@@ -1226,7 +1223,7 @@ func TestValidateReplicationWithInvalidURL(t *testing.T) {
 }
 
 func TestGetStatusWithReplication(t *testing.T) {
-	var rt = rest.NewRestTester(t, nil)
+	rt := rest.NewRestTesterDefaultCollection(t, nil) // CBG-2319: replicator currently requires default collection
 	defer rt.Close()
 
 	// Create a replication
@@ -1314,7 +1311,7 @@ func TestGetStatusWithReplication(t *testing.T) {
 func TestRequireReplicatorStoppedBeforeUpsert(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyHTTPResp)
 
-	rt := rest.NewRestTester(t, nil)
+	rt := rest.NewRestTesterDefaultCollection(t, nil) // CBG-2319: replicator currently requires default collection
 	defer rt.Close()
 
 	// Make rt listen on an actual HTTP port, so it can receive the blipsync request.
@@ -1560,10 +1557,11 @@ func TestDBReplicationStatsTeardown(t *testing.T) {
 
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
-		PersistentConfig: true,
-		CustomTestBucket: tb,
-	})
+	rt := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			PersistentConfig: true,
+			CustomTestBucket: tb,
+		})
 	defer rt.Close()
 
 	srv := httptest.NewServer(rt.TestAdminHandler())
@@ -1700,13 +1698,14 @@ func TestPushReplicationAPIUpdateDatabase(t *testing.T) {
 func TestActiveReplicatorHeartbeats(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyWebSocket, base.KeyWebSocketFrame)
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {Password: base.StringPtr("pass")},
-			},
-		}},
-	})
+	rt := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {Password: base.StringPtr("pass")},
+				},
+			}},
+		})
 	defer rt.Close()
 	ctx := rt.Context()
 
@@ -1772,17 +1771,18 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 		password = "pa$$w*rD!"
 	)
 
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb2,
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				username: {
-					Password:         base.StringPtr(password),
-					ExplicitChannels: base.SetOf(username),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb2,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					username: {
+						Password:         base.StringPtr(password),
+						ExplicitChannels: base.SetOf(username),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	docID := t.Name() + "rt2doc1"
@@ -1806,9 +1806,10 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	// Active
 	tb1 := base.GetTestBucket(t)
 
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb1,
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
@@ -1868,17 +1869,18 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	// Passive
 	tb2 := base.GetTestBucket(t)
 
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb2,
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb2,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	attachment := `"_attachments":{"hi.txt":{"data":"aGk=","content_type":"text/plain"}}`
@@ -1901,9 +1903,10 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	// Active
 	tb1 := base.GetTestBucket(t)
 
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb1,
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
@@ -2056,16 +2059,17 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 			defer db.SuspendSequenceBatching()()
 
 			// Passive
-			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-					Users: map[string]*auth.PrincipalConfig{
-						"alice": {
-							Password:         base.StringPtr("pass"),
-							ExplicitChannels: base.SetOf("alice"),
+			rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+				&rest.RestTesterConfig{
+					DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+						Users: map[string]*auth.PrincipalConfig{
+							"alice": {
+								Password:         base.StringPtr("pass"),
+								ExplicitChannels: base.SetOf("alice"),
+							},
 						},
-					},
-				}},
-			})
+					}},
+				})
 			defer rt2.Close()
 
 			// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
@@ -2079,15 +2083,16 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 			passiveDBURL.User = url.UserPassword("alice", "pass")
 
 			// Active
-			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-					Replications: map[string]*db.ReplicationConfig{
-						"repl1": {
-							Remote:                 passiveDBURL.String(),
-							Direction:              db.ActiveReplicatorTypePull,
-							Continuous:             true,
-							ConflictResolutionType: db.ConflictResolverCustom,
-							ConflictResolutionFn: `
+			rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+				&rest.RestTesterConfig{
+					DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+						Replications: map[string]*db.ReplicationConfig{
+							"repl1": {
+								Remote:                 passiveDBURL.String(),
+								Direction:              db.ActiveReplicatorTypePull,
+								Continuous:             true,
+								ConflictResolutionType: db.ConflictResolverCustom,
+								ConflictResolutionFn: `
 					function(conflict) {
 						var mergedDoc = new Object();
 						mergedDoc.source = "merged";
@@ -2107,10 +2112,10 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 
 						return mergedDoc;
 					}`},
-					},
-				}},
-				SgReplicateEnabled: true,
-			})
+						},
+					}},
+					SgReplicateEnabled: true,
+				})
 			defer rt1.Close()
 
 			rt1.WaitForAssignedReplications(1)
@@ -2195,17 +2200,18 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb2,
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb2,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	// Create first batch of docs
@@ -2226,9 +2232,10 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 
 	// Active
 	tb1 := base.GetTestBucket(t)
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb1,
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
@@ -2366,24 +2373,26 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb2,
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb2,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	// Active
 	tb1 := base.GetTestBucket(t)
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb1,
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
@@ -2526,17 +2535,18 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 	// Passive
 	tb2 := base.GetTestBucket(t)
 
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb2,
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb2,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	docID := t.Name() + "rt2doc1"
@@ -2560,9 +2570,10 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 	// Active
 	tb1 := base.GetTestBucket(t)
 
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb1,
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
@@ -2625,25 +2636,27 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 	// Passive
 	tb2 := base.GetTestBucket(t)
 
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb2,
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb2,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	// Active
 	tb1 := base.GetTestBucket(t)
 
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb1,
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
@@ -2718,25 +2731,27 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 
 	// Active
 	tb1 := base.GetTestBucket(t)
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb1,
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb2,
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb2,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	attachment := `"_attachments":{"hi.txt":{"data":"aGk=","content_type":"text/plain"}}`
@@ -2842,9 +2857,10 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 
 	// Active
 	tb1 := base.GetTestBucket(t)
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb1,
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
@@ -2857,17 +2873,18 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb2,
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb2,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
@@ -3012,17 +3029,18 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 
 	// Central cluster
 	tb1 := base.GetTestBucket(t)
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb1,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt1.Close()
 
 	// Create first batch of docs
@@ -3043,9 +3061,10 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 
 	// Edge 1
 	edge1Bucket := base.GetTestBucket(t)
-	edge1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: edge1Bucket,
-	})
+	edge1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: edge1Bucket,
+		})
 	defer edge1.Close()
 	ctx1 := edge1.Context()
 
@@ -3116,9 +3135,10 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 
 	// Edge 2
 	edge2Bucket := base.GetTestBucket(t)
-	edge2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: edge2Bucket,
-	})
+	edge2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: edge2Bucket,
+		})
 	defer edge2.Close()
 	ctx2 := edge2.Context()
 
@@ -3192,25 +3212,27 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 	// Passive
 	tb2 := base.GetTestBucket(t)
 
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb2,
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb2,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	// Active
 	tb1 := base.GetTestBucket(t)
 
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb1,
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
@@ -3293,17 +3315,18 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	// Passive
 	tb2 := base.GetTestBucket(t)
 
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb2,
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb2,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	docID := t.Name() + "rt2doc1"
@@ -3324,9 +3347,10 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	// Active
 	tb1 := base.GetTestBucket(t)
 
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb1,
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
@@ -3401,17 +3425,18 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 	// Passive
 	tb2 := base.GetTestBucket(t)
 
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb2,
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb2,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	docID := t.Name() + "rt2doc1"
@@ -3432,9 +3457,10 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 	// Active
 	tb1 := base.GetTestBucket(t)
 
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb1,
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
@@ -3584,17 +3610,18 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			// Passive
 			tb2 := base.GetTestBucket(t)
 
-			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				CustomTestBucket: tb2,
-				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-					Users: map[string]*auth.PrincipalConfig{
-						"alice": {
-							Password:         base.StringPtr("pass"),
-							ExplicitChannels: base.SetOf("*"),
+			rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+				&rest.RestTesterConfig{
+					CustomTestBucket: tb2,
+					DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+						Users: map[string]*auth.PrincipalConfig{
+							"alice": {
+								Password:         base.StringPtr("pass"),
+								ExplicitChannels: base.SetOf("*"),
+							},
 						},
-					},
-				}},
-			})
+					}},
+				})
 			defer rt2.Close()
 
 			// Create revision on rt2 (remote)
@@ -3618,9 +3645,10 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			// Active
 			tb1 := base.GetTestBucket(t)
 
-			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				CustomTestBucket: tb1,
-			})
+			rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+				&rest.RestTesterConfig{
+					CustomTestBucket: tb1,
+				})
 			defer rt1.Close()
 			ctx1 := rt1.Context()
 
@@ -3795,17 +3823,18 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD)
 
 			// Passive
-			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				CustomTestBucket: base.GetTestBucket(t),
-				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-					Users: map[string]*auth.PrincipalConfig{
-						"alice": {
-							Password:         base.StringPtr("pass"),
-							ExplicitChannels: base.SetOf("*"),
+			rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+				&rest.RestTesterConfig{
+					CustomTestBucket: base.GetTestBucket(t),
+					DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+						Users: map[string]*auth.PrincipalConfig{
+							"alice": {
+								Password:         base.StringPtr("pass"),
+								ExplicitChannels: base.SetOf("*"),
+							},
 						},
-					},
-				}},
-			})
+					}},
+				})
 			defer rt2.Close()
 
 			var localRevisionBody db.Body
@@ -3848,9 +3877,10 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			passiveDBURL.User = url.UserPassword("alice", "pass")
 
 			// Active
-			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				CustomTestBucket: base.GetTestBucket(t),
-			})
+			rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+				&rest.RestTesterConfig{
+					CustomTestBucket: base.GetTestBucket(t),
+				})
 			defer rt1.Close()
 			ctx1 := rt1.Context()
 
@@ -3996,23 +4026,25 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Passive
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: base.GetTestBucket(t),
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	// Active
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: base.GetTestBucket(t),
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
@@ -4078,23 +4110,25 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Passive
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: base.GetTestBucket(t),
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	// Active
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: base.GetTestBucket(t),
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
@@ -4147,17 +4181,18 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	// Passive
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: base.GetTestBucket(t),
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	// Create doc on rt2
@@ -4177,9 +4212,10 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	// Active
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: base.GetTestBucket(t),
+		})
 	ctx1 := rt1.Context()
 	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
 	require.NoError(t, err)
@@ -4243,9 +4279,10 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	rt1.Close()
 
 	// recreate rt1 with a new bucket
-	rt1 = rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
-	})
+	rt1 = rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: base.GetTestBucket(t),
+		})
 	defer rt1.Close()
 	ctx1 = rt1.Context()
 
@@ -4308,17 +4345,18 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb2,
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb2,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
 	srv := httptest.NewServer(rt2.TestPublicHandler())
@@ -4331,9 +4369,10 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 
 	// Active
 	tb1 := base.GetTestBucket(t)
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb1,
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
@@ -4408,17 +4447,18 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	rt2.Close()
 
 	// recreate rt2 with a new bucket, http server and update target URL in the replicator
-	rt2 = rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt2 = rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: base.GetTestBucket(t),
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	srv.Config.Handler = rt2.TestPublicHandler()
@@ -4489,17 +4529,18 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyBucket, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	// Passive
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: base.GetTestBucket(t),
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 	ctx2 := rt2.Context()
 
@@ -4513,9 +4554,10 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	// Active
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: base.GetTestBucket(t),
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
@@ -4651,17 +4693,18 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyBucket, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
 	// Passive
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: base.GetTestBucket(t),
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
@@ -4674,9 +4717,10 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	// Active
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: base.GetTestBucket(t),
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
@@ -4755,27 +4799,29 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Passive
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			AllowConflicts: base.BoolPtr(false),
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: base.GetTestBucket(t),
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				AllowConflicts: base.BoolPtr(false),
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	// Active
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			AllowConflicts: base.BoolPtr(false),
-		}},
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: base.GetTestBucket(t),
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				AllowConflicts: base.BoolPtr(false),
+			}},
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
@@ -4874,17 +4920,18 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb2,
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("chan1", "chan2"),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb2,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("chan1", "chan2"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	// Create first batch of docs, creating numRT2DocsInitial in each channel
@@ -4905,9 +4952,10 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 
 	// Active
 	tb1 := base.GetTestBucket(t)
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb1,
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
@@ -5080,17 +5128,18 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 
 					// Passive
 					tb2 := base.GetTestBucket(t)
-					rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-						CustomTestBucket: tb2,
-						DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-							Users: map[string]*auth.PrincipalConfig{
-								"alice": {
-									Password:         base.StringPtr("pass"),
-									ExplicitChannels: base.SetOf("alice"),
+					rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+						&rest.RestTesterConfig{
+							CustomTestBucket: tb2,
+							DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+								Users: map[string]*auth.PrincipalConfig{
+									"alice": {
+										Password:         base.StringPtr("pass"),
+										ExplicitChannels: base.SetOf("alice"),
+									},
 								},
-							},
-						}},
-					})
+							}},
+						})
 					defer rt2.Close()
 
 					// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
@@ -5114,9 +5163,10 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 
 					// Active
 					tb1 := base.GetTestBucket(t)
-					rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-						CustomTestBucket: tb1,
-					})
+					rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+						&rest.RestTesterConfig{
+							CustomTestBucket: tb1,
+						})
 					defer rt1.Close()
 					ctx1 := rt1.Context()
 
@@ -5189,9 +5239,10 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb2,
-	})
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb2,
+		})
 	defer rt2.Close()
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
@@ -5207,9 +5258,10 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 
 	// Active
 	tb1 := base.GetTestBucket(t)
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb1,
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
@@ -5274,17 +5326,18 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb2,
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb2,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("alice"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	defer rt2.Close()
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
@@ -5300,9 +5353,10 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 
 	// Active
 	tb1 := base.GetTestBucket(t)
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb1,
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
@@ -5568,17 +5622,18 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 			// Passive
 			tb2 := base.GetTestBucket(t)
 
-			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				CustomTestBucket: tb2,
-				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-					Users: map[string]*auth.PrincipalConfig{
-						"alice": {
-							Password:         base.StringPtr("pass"),
-							ExplicitChannels: base.SetOf("*"),
+			rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+				&rest.RestTesterConfig{
+					CustomTestBucket: tb2,
+					DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+						Users: map[string]*auth.PrincipalConfig{
+							"alice": {
+								Password:         base.StringPtr("pass"),
+								ExplicitChannels: base.SetOf("*"),
+							},
 						},
-					},
-				}},
-			})
+					}},
+				})
 			defer rt2.Close()
 
 			// Create revision on rt2 (remote)
@@ -5606,9 +5661,10 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 			// Active
 			tb1 := base.GetTestBucket(t)
 
-			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				CustomTestBucket: tb1,
-			})
+			rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+				&rest.RestTesterConfig{
+					CustomTestBucket: tb1,
+				})
 			defer rt1.Close()
 			ctx1 := rt1.Context()
 
@@ -5804,10 +5860,10 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 
 			// Passive
 			passiveBucket := base.GetTestBucket(t)
-			remotePassiveRT := rest.NewRestTester(t, &rest.RestTesterConfig{
-				CustomTestBucket: passiveBucket,
-				DatabaseConfig:   &rest.DatabaseConfig{}, // force use of default scope and collection
-			})
+			remotePassiveRT := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+				&rest.RestTesterConfig{
+					CustomTestBucket: passiveBucket,
+				})
 			defer remotePassiveRT.Close()
 
 			srv := httptest.NewServer(remotePassiveRT.TestAdminHandler())
@@ -5815,11 +5871,11 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 
 			// Active
 			activeBucket := base.GetTestBucket(t)
-			localActiveRT := rest.NewRestTester(t, &rest.RestTesterConfig{
-				CustomTestBucket:   activeBucket,
-				SgReplicateEnabled: true,
-				DatabaseConfig:     &rest.DatabaseConfig{}, // force use of default scope and collection
-			})
+			localActiveRT := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+				&rest.RestTesterConfig{
+					CustomTestBucket:   activeBucket,
+					SgReplicateEnabled: true,
+				})
 			defer localActiveRT.Close()
 
 			replConf := `
@@ -6070,17 +6126,18 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 	for _, test := range defaultConflictResolverWithTombstoneTests {
 		t.Run(test.name, func(tt *testing.T) {
 			// Passive
-			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				CustomTestBucket: base.GetTestBucket(t),
-				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-					Users: map[string]*auth.PrincipalConfig{
-						"alice": {
-							Password:         base.StringPtr("pass"),
-							ExplicitChannels: base.SetOf("alice"),
+			rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+				&rest.RestTesterConfig{
+					CustomTestBucket: base.GetTestBucket(t),
+					DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+						Users: map[string]*auth.PrincipalConfig{
+							"alice": {
+								Password:         base.StringPtr("pass"),
+								ExplicitChannels: base.SetOf("alice"),
+							},
 						},
-					},
-				}},
-			})
+					}},
+				})
 			defer rt2.Close()
 
 			// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
@@ -6093,9 +6150,10 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 			passiveDBURL.User = url.UserPassword("alice", "pass")
 
 			// Active
-			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				CustomTestBucket: base.GetTestBucket(t),
-			})
+			rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+				&rest.RestTesterConfig{
+					CustomTestBucket: base.GetTestBucket(t),
+				})
 			defer rt1.Close()
 			ctx1 := rt1.Context()
 
@@ -6229,17 +6287,18 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 	for _, test := range defaultConflictResolverWithTombstoneTests {
 		t.Run(test.name, func(t *testing.T) {
 			// Passive
-			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				CustomTestBucket: base.GetTestBucket(t),
-				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-					Users: map[string]*auth.PrincipalConfig{
-						"alice": {
-							Password:         base.StringPtr("pass"),
-							ExplicitChannels: base.SetOf("alice"),
+			rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+				&rest.RestTesterConfig{
+					CustomTestBucket: base.GetTestBucket(t),
+					DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+						Users: map[string]*auth.PrincipalConfig{
+							"alice": {
+								Password:         base.StringPtr("pass"),
+								ExplicitChannels: base.SetOf("alice"),
+							},
 						},
-					},
-				}},
-			})
+					}},
+				})
 			defer rt2.Close()
 
 			// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
@@ -6252,9 +6311,10 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 			passiveDBURL.User = url.UserPassword("alice", "pass")
 
 			// Active
-			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				CustomTestBucket: base.GetTestBucket(t),
-			})
+			rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+				&rest.RestTesterConfig{
+					CustomTestBucket: base.GetTestBucket(t),
+				})
 			defer rt1.Close()
 			ctx1 := rt1.Context()
 
@@ -6577,17 +6637,19 @@ func TestSendChangesToNoConflictPreHydrogenTarget(t *testing.T) {
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb2,
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			AllowConflicts: base.BoolPtr(false),
-		}},
-	})
+	rt2 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: tb2,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				AllowConflicts: base.BoolPtr(false),
+			}},
+		})
 	defer rt2.Close()
 
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: base.GetTestBucket(t),
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
@@ -6741,13 +6803,14 @@ func TestConflictResolveMergeWithMutatedRev(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
 	// Passive
-	rt2 := rest.NewRestTester(t, nil)
+	rt2 := rest.NewRestTesterDefaultCollection(t, nil) // CBG-2319: replicator currently requires default collection
 	defer rt2.Close()
 
 	// Active
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: base.GetTestBucket(t),
-	})
+	rt1 := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: base.GetTestBucket(t),
+		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
@@ -6818,16 +6881,17 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 
 	// Passive //
 	passiveBucket := base.GetTestBucket(t)
-	passiveRT := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: passiveBucket,
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{
-				DeltaSync: &rest.DeltaSyncConfig{
-					Enabled: base.BoolPtr(true),
+	passiveRT := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: passiveBucket,
+			DatabaseConfig: &rest.DatabaseConfig{
+				DbConfig: rest.DbConfig{
+					DeltaSync: &rest.DeltaSyncConfig{
+						Enabled: base.BoolPtr(true),
+					},
 				},
 			},
-		},
-	})
+		})
 	defer passiveRT.Close()
 
 	// Make passive RT listen on an actual HTTP port, so it can receive the blipsync request from the active replicator.
@@ -6836,16 +6900,17 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 
 	// Active //
 	activeBucket := base.GetTestBucket(t)
-	activeRT := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: activeBucket,
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{
-				DeltaSync: &rest.DeltaSyncConfig{
-					Enabled: base.BoolPtr(true),
+	activeRT := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: activeBucket,
+			DatabaseConfig: &rest.DatabaseConfig{
+				DbConfig: rest.DbConfig{
+					DeltaSync: &rest.DeltaSyncConfig{
+						Enabled: base.BoolPtr(true),
+					},
 				},
 			},
-		},
-	})
+		})
 	defer activeRT.Close()
 	activeCtx := activeRT.Context()
 
@@ -6924,16 +6989,17 @@ func TestUnprocessableDeltas(t *testing.T) {
 
 	// Passive //
 	passiveBucket := base.GetTestBucket(t)
-	passiveRT := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: passiveBucket,
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{
-				DeltaSync: &rest.DeltaSyncConfig{
-					Enabled: base.BoolPtr(true),
+	passiveRT := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: passiveBucket,
+			DatabaseConfig: &rest.DatabaseConfig{
+				DbConfig: rest.DbConfig{
+					DeltaSync: &rest.DeltaSyncConfig{
+						Enabled: base.BoolPtr(true),
+					},
 				},
 			},
-		},
-	})
+		})
 	defer passiveRT.Close()
 
 	// Make passive RT listen on an actual HTTP port, so it can receive the blipsync request from the active replicator.
@@ -6942,16 +7008,17 @@ func TestUnprocessableDeltas(t *testing.T) {
 
 	// Active //
 	activeBucket := base.GetTestBucket(t)
-	activeRT := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: activeBucket,
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{
-				DeltaSync: &rest.DeltaSyncConfig{
-					Enabled: base.BoolPtr(true),
+	activeRT := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: activeBucket,
+			DatabaseConfig: &rest.DatabaseConfig{
+				DbConfig: rest.DbConfig{
+					DeltaSync: &rest.DeltaSyncConfig{
+						Enabled: base.BoolPtr(true),
+					},
 				},
 			},
-		},
-	})
+		})
 	defer activeRT.Close()
 	activeCtx := activeRT.Context()
 
@@ -7024,10 +7091,10 @@ func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 
 	// Passive //
 	passiveBucket := base.GetTestBucket(t)
-	passiveRT := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: passiveBucket,
-		DatabaseConfig:   &rest.DatabaseConfig{}, // force use of default scope and collection
-	})
+	passiveRT := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: passiveBucket,
+		})
 	defer passiveRT.Close()
 
 	// Make passive RT listen on an actual HTTP port, so it can receive the blipsync request from the active replicator
@@ -7036,10 +7103,10 @@ func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 
 	// Active //
 	activeBucket := base.GetTestBucket(t)
-	activeRT := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: activeBucket,
-		DatabaseConfig:   &rest.DatabaseConfig{}, // force use of default scope and collection
-	})
+	activeRT := rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket: activeBucket,
+		})
 	defer activeRT.Close()
 	activeCtx := activeRT.Context()
 
@@ -7106,7 +7173,7 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
 	// Passive //
-	passiveRT := rest.NewRestTester(t, nil)
+	passiveRT := rest.NewRestTesterDefaultCollection(t, nil) // CBG-2319: replicator currently requires default collection
 	defer passiveRT.Close()
 
 	// Make passive RT listen on an actual HTTP port, so it can receive the blipsync request from the active replicator
@@ -7114,7 +7181,7 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 	defer srv.Close()
 
 	// Active //
-	activeRT := rest.NewRestTester(t, nil)
+	activeRT := rest.NewRestTesterDefaultCollection(t, nil) // CBG-2319: replicator currently requires default collection
 	defer activeRT.Close()
 	activeCtx := activeRT.Context()
 

--- a/rest/replicatortest/replicator_test_helper.go
+++ b/rest/replicatortest/replicator_test_helper.go
@@ -39,6 +39,11 @@ func addActiveRT(t *testing.T, testBucket *base.TestBucket) (activeRT *rest.Rest
 	activeRT = rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket:   testBucket.NoCloseClone(),
 		SgReplicateEnabled: true,
+		DatabaseConfig: &rest.DatabaseConfig{
+			DbConfig: rest.DbConfig{
+				Scopes: nil, // no non default collections for ISGR yet
+			},
+		},
 	})
 
 	// If this is a walrus bucket, we need to jump through some hoops to ensure the shared in-memory walrus bucket isn't

--- a/rest/replicatortest/replicator_test_helper.go
+++ b/rest/replicatortest/replicator_test_helper.go
@@ -36,15 +36,11 @@ func reduceTestCheckpointInterval(interval time.Duration) func() {
 func addActiveRT(t *testing.T, testBucket *base.TestBucket) (activeRT *rest.RestTester) {
 
 	// Create a new rest tester, using a NoCloseClone of testBucket, which disables the TestBucketPool teardown
-	activeRT = rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket:   testBucket.NoCloseClone(),
-		SgReplicateEnabled: true,
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{
-				Scopes: nil, // no non default collections for ISGR yet
-			},
-		},
-	})
+	activeRT = rest.NewRestTesterDefaultCollection(t, // CBG-2319: replicator currently requires default collection
+		&rest.RestTesterConfig{
+			CustomTestBucket:   testBucket.NoCloseClone(),
+			SgReplicateEnabled: true,
+		})
 
 	// If this is a walrus bucket, we need to jump through some hoops to ensure the shared in-memory walrus bucket isn't
 	// deleted when bucket.Close() is called during DatabaseContext.Close().

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -179,7 +179,8 @@ func InitScenario(t *testing.T, rtConfig *RestTesterConfig) (ChannelRevocationTe
 
 	if rtConfig == nil {
 		rtConfig = &RestTesterConfig{
-			SyncFn: defaultSyncFn,
+			SyncFn:         defaultSyncFn,
+			DatabaseConfig: &DatabaseConfig{}, // revocation requires collection specific channel access
 		}
 	} else {
 		if rtConfig.SyncFn == "" {
@@ -889,7 +890,9 @@ func TestEnsureRevocationUsingDocHistory(t *testing.T) {
 func TestRevocationWithAdminChannels(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{}, // revocation requires collection specific channel access
+	})
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/_user/user", `{"admin_channels": ["A"], "password": "letmein"}`)
@@ -919,7 +922,9 @@ func TestRevocationWithAdminChannels(t *testing.T) {
 func TestRevocationWithAdminRoles(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{}, // revocation requires collection specific channel access
+	})
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/_role/role", `{"admin_channels": ["A"]}`)

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -179,8 +179,7 @@ func InitScenario(t *testing.T, rtConfig *RestTesterConfig) (ChannelRevocationTe
 
 	if rtConfig == nil {
 		rtConfig = &RestTesterConfig{
-			SyncFn:         defaultSyncFn,
-			DatabaseConfig: &DatabaseConfig{}, // revocation requires collection specific channel access
+			SyncFn: defaultSyncFn,
 		}
 	} else {
 		if rtConfig.SyncFn == "" {
@@ -188,7 +187,7 @@ func InitScenario(t *testing.T, rtConfig *RestTesterConfig) (ChannelRevocationTe
 		}
 	}
 
-	rt := NewRestTester(t, rtConfig)
+	rt := NewRestTesterDefaultCollection(t, rtConfig) // CBG-2618: fix collection channel access
 
 	revocationTester := ChannelRevocationTester{
 		test:       t,
@@ -890,9 +889,7 @@ func TestEnsureRevocationUsingDocHistory(t *testing.T) {
 func TestRevocationWithAdminChannels(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	rt := NewRestTester(t, &RestTesterConfig{
-		DatabaseConfig: &DatabaseConfig{}, // revocation requires collection specific channel access
-	})
+	rt := NewRestTesterDefaultCollection(t, nil) // CBG-2618: fix collection channel access
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/_user/user", `{"admin_channels": ["A"], "password": "letmein"}`)
@@ -922,9 +919,7 @@ func TestRevocationWithAdminChannels(t *testing.T) {
 func TestRevocationWithAdminRoles(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	rt := NewRestTester(t, &RestTesterConfig{
-		DatabaseConfig: &DatabaseConfig{}, // revocation requires collection specific channel access
-	})
+	rt := NewRestTesterDefaultCollection(t, nil) // CBG-2618: fix collection channel access
 	defer rt.Close()
 
 	resp := rt.SendAdminRequest("PUT", "/db/_role/role", `{"admin_channels": ["A"]}`)

--- a/rest/role_api_test.go
+++ b/rest/role_api_test.go
@@ -139,7 +139,8 @@ func TestFunkyRoleNames(t *testing.T) {
 			const username = "user1"
 			syncFn := fmt.Sprintf(`function(doc) {channel(doc.channels); role("%s", %s);}`, username, string(roleNameJSON))
 			rt := NewRestTester(t, &RestTesterConfig{
-				SyncFn: syncFn,
+				SyncFn:         syncFn,
+				DatabaseConfig: &DatabaseConfig{}, // revocation requires collection specific channel access
 			})
 			defer rt.Close()
 
@@ -177,7 +178,9 @@ func TestBulkDocsChangeToRoleAccess(t *testing.T) {
 			} else {
 				requireAccess(doc.mustHaveAccess)
 			}
-		}`}
+		}`,
+		DatabaseConfig: &DatabaseConfig{}, // revocation requires collection specific channel access
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	ctx := rt.Context()
@@ -222,7 +225,9 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAccess, base.KeyCRUD, base.KeyChanges)
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {role(doc.user, doc.role);channel(doc.channel)}`}
+	rtConfig := RestTesterConfig{SyncFn: `function(doc) {role(doc.user, doc.role);channel(doc.channel)}`,
+		DatabaseConfig: &DatabaseConfig{}, // revocation requires collection specific channel access
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -268,7 +273,9 @@ func TestRoleAccessChanges(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAccess, base.KeyCRUD, base.KeyChanges)
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {role(doc.user, doc.role);channel(doc.channel)}`}
+	rtConfig := RestTesterConfig{SyncFn: `function(doc) {role(doc.user, doc.role);channel(doc.channel)}`,
+		DatabaseConfig: &DatabaseConfig{}, // revocation requires collection specific channel access
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 

--- a/rest/role_api_test.go
+++ b/rest/role_api_test.go
@@ -138,10 +138,10 @@ func TestFunkyRoleNames(t *testing.T) {
 			require.NoError(t, err)
 			const username = "user1"
 			syncFn := fmt.Sprintf(`function(doc) {channel(doc.channels); role("%s", %s);}`, username, string(roleNameJSON))
-			rt := NewRestTester(t, &RestTesterConfig{
-				SyncFn:         syncFn,
-				DatabaseConfig: &DatabaseConfig{}, // revocation requires collection specific channel access
-			})
+			rt := NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+				&RestTesterConfig{
+					SyncFn: syncFn,
+				})
 			defer rt.Close()
 
 			ctx := rt.Context()
@@ -181,7 +181,8 @@ func TestBulkDocsChangeToRoleAccess(t *testing.T) {
 		}`,
 		DatabaseConfig: &DatabaseConfig{}, // revocation requires collection specific channel access
 	}
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+		&rtConfig)
 	defer rt.Close()
 	ctx := rt.Context()
 
@@ -228,7 +229,8 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {role(doc.user, doc.role);channel(doc.channel)}`,
 		DatabaseConfig: &DatabaseConfig{}, // revocation requires collection specific channel access
 	}
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+		&rtConfig)
 	defer rt.Close()
 
 	ctx := rt.Context()
@@ -273,10 +275,9 @@ func TestRoleAccessChanges(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAccess, base.KeyCRUD, base.KeyChanges)
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {role(doc.user, doc.role);channel(doc.channel)}`,
-		DatabaseConfig: &DatabaseConfig{}, // revocation requires collection specific channel access
-	}
-	rt := NewRestTester(t, &rtConfig)
+	rtConfig := RestTesterConfig{SyncFn: `function(doc) {role(doc.user, doc.role);channel(doc.channel)}`}
+	rt := NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+		&rtConfig)
 	defer rt.Close()
 
 	ctx := rt.Context()

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -144,11 +144,7 @@ func TestInvalidSession(t *testing.T) {
 // Test for issue 758 - basic auth with stale session cookie
 func TestBasicAuthWithSessionCookie(t *testing.T) {
 
-	rt := NewRestTester(t,
-		&RestTesterConfig{
-			DatabaseConfig: &DatabaseConfig{}, // needs channel changes for non default scope/collections
-		},
-	)
+	rt := NewRestTesterDefaultCollection(t, nil) // CBG-2618: fix collection channel access
 	defer rt.Close()
 
 	// Create two users

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -144,7 +144,11 @@ func TestInvalidSession(t *testing.T) {
 // Test for issue 758 - basic auth with stale session cookie
 func TestBasicAuthWithSessionCookie(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t,
+		&RestTesterConfig{
+			DatabaseConfig: &DatabaseConfig{}, // needs channel changes for non default scope/collections
+		},
+	)
 	defer rt.Close()
 
 	// Create two users

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -261,7 +261,11 @@ func TestUsersAPIDetailsWithLimit(t *testing.T) {
 func TestUserAPI(t *testing.T) {
 
 	// PUT a user
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t,
+		&RestTesterConfig{
+			DatabaseConfig: &DatabaseConfig{}, // needs channel changes for non default scope/collections
+		},
+	)
 	defer rt.Close()
 	ctx := rt.Context()
 
@@ -625,6 +629,7 @@ func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
 				}
 			}
 		`,
+				DatabaseConfig: &DatabaseConfig{}, // needs channel changes for non default scope/collections
 			})
 			defer rt.Close()
 
@@ -842,7 +847,10 @@ function(doc, oldDoc) {
 }
 
 `
-	rtConfig := RestTesterConfig{SyncFn: syncFunction}
+	rtConfig := RestTesterConfig{
+		SyncFn:         syncFunction,
+		DatabaseConfig: &DatabaseConfig{}, // needs channel changes for non default scope/collections
+	}
 	var rt = NewRestTester(t, &rtConfig)
 	defer rt.Close()
 

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1231,7 +1231,7 @@ func TestRemovingUserXattr(t *testing.T) {
 
 			// Get sync data for doc and ensure user xattr has been used correctly to set channel
 			var syncData db.SyncData
-			subdocStore, ok := base.AsSubdocXattrStore(rt.Bucket().DefaultDataStore())
+			subdocStore, ok := base.AsSubdocXattrStore(rt.GetSingleTestDataStore())
 			require.True(t, ok)
 			_, err = subdocStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
 			assert.NoError(t, err)

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -564,7 +564,7 @@ func TestUserXattrsRawGet(t *testing.T) {
 	})
 	defer rt.Close()
 
-	userXattrStore, ok := base.AsUserXattrStore(rt.Bucket().DefaultDataStore())
+	userXattrStore, ok := base.AsUserXattrStore(rt.GetSingleTestDataStore())
 	if !ok {
 		t.Skip("Test requires Couchbase Bucket")
 	}
@@ -1209,7 +1209,7 @@ func TestRemovingUserXattr(t *testing.T) {
 
 			defer rt.Close()
 
-			gocbBucket, ok := base.AsUserXattrStore(rt.Bucket().DefaultDataStore())
+			gocbBucket, ok := base.AsUserXattrStore(rt.GetSingleTestDataStore())
 			if !ok {
 				t.Skip("Test requires Couchbase Bucket")
 			}

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -43,7 +43,8 @@ func TestUsersAPI(t *testing.T) {
 			},
 		},
 	}
-	rt := NewRestTester(t, rtConfig)
+	rt := NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+		rtConfig)
 	defer rt.Close()
 
 	// Validate the zero user case
@@ -261,11 +262,7 @@ func TestUsersAPIDetailsWithLimit(t *testing.T) {
 func TestUserAPI(t *testing.T) {
 
 	// PUT a user
-	rt := NewRestTester(t,
-		&RestTesterConfig{
-			DatabaseConfig: &DatabaseConfig{}, // needs channel changes for non default scope/collections
-		},
-	)
+	rt := NewRestTesterDefaultCollection(t, nil) // CBG-2618: fix collection channel access
 	defer rt.Close()
 	ctx := rt.Context()
 
@@ -618,8 +615,9 @@ func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			rt := NewRestTester(t, &RestTesterConfig{
-				SyncFn: `
+			rt := NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+				&RestTesterConfig{
+					SyncFn: `
 			function(doc, oldDoc){
 				if (doc._id === 'roleChannels'){
 					access('role:role', doc.channels)
@@ -629,8 +627,7 @@ func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
 				}
 			}
 		`,
-				DatabaseConfig: &DatabaseConfig{}, // needs channel changes for non default scope/collections
-			})
+				})
 			defer rt.Close()
 
 			// Create role
@@ -848,10 +845,10 @@ function(doc, oldDoc) {
 
 `
 	rtConfig := RestTesterConfig{
-		SyncFn:         syncFunction,
-		DatabaseConfig: &DatabaseConfig{}, // needs channel changes for non default scope/collections
+		SyncFn: syncFunction,
 	}
-	var rt = NewRestTester(t, &rtConfig)
+	rt := NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+		&rtConfig)
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", `{"name":"bernard", "password":"letmein", "admin_channels":["profile-bernard"]}`)

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1294,12 +1294,13 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 
 	defer rt.Close()
 
-	userXattrStore, ok := base.AsUserXattrStore(rt.Bucket().DefaultDataStore())
+	dataStore := rt.GetSingleTestDataStore()
+	userXattrStore, ok := base.AsUserXattrStore(dataStore)
 	if !ok {
 		t.Skip("Test requires Couchbase Bucket")
 	}
 
-	subdocXattrStore, ok := base.AsSubdocXattrStore(rt.Bucket().DefaultDataStore())
+	subdocXattrStore, ok := base.AsSubdocXattrStore(dataStore)
 	require.True(t, ok)
 
 	// Initial PUT
@@ -1342,7 +1343,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	assert.Equal(t, []string{channelName}, syncData2.Channels.KeySet())
 	assert.Equal(t, syncData2.Channels.KeySet(), docRev2.Channels.ToArray())
 
-	err = rt.Bucket().DefaultDataStore().Set(docKey, 0, nil, []byte(`{"update": "update"}`))
+	err = rt.GetSingleTestDataStore().Set(docKey, 0, nil, []byte(`{"update": "update"}`))
 	assert.NoError(t, err)
 
 	err = rt.WaitForCondition(func() bool {

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -564,7 +564,7 @@ func TestUserXattrsRawGet(t *testing.T) {
 	})
 	defer rt.Close()
 
-	userXattrStore, ok := base.AsUserXattrStore(rt.GetSingleTestDataStore())
+	userXattrStore, ok := base.AsUserXattrStore(rt.GetSingleDataStore())
 	if !ok {
 		t.Skip("Test requires Couchbase Bucket")
 	}
@@ -1209,7 +1209,7 @@ func TestRemovingUserXattr(t *testing.T) {
 
 			defer rt.Close()
 
-			gocbBucket, ok := base.AsUserXattrStore(rt.GetSingleTestDataStore())
+			gocbBucket, ok := base.AsUserXattrStore(rt.GetSingleDataStore())
 			if !ok {
 				t.Skip("Test requires Couchbase Bucket")
 			}
@@ -1231,7 +1231,7 @@ func TestRemovingUserXattr(t *testing.T) {
 
 			// Get sync data for doc and ensure user xattr has been used correctly to set channel
 			var syncData db.SyncData
-			subdocStore, ok := base.AsSubdocXattrStore(rt.GetSingleTestDataStore())
+			subdocStore, ok := base.AsSubdocXattrStore(rt.GetSingleDataStore())
 			require.True(t, ok)
 			_, err = subdocStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
 			assert.NoError(t, err)
@@ -1294,7 +1294,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 
 	defer rt.Close()
 
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 	userXattrStore, ok := base.AsUserXattrStore(dataStore)
 	if !ok {
 		t.Skip("Test requires Couchbase Bucket")
@@ -1343,7 +1343,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	assert.Equal(t, []string{channelName}, syncData2.Channels.KeySet())
 	assert.Equal(t, syncData2.Channels.KeySet(), docRev2.Channels.ToArray())
 
-	err = rt.GetSingleTestDataStore().Set(docKey, 0, nil, []byte(`{"update": "update"}`))
+	err = rt.GetSingleDataStore().Set(docKey, 0, nil, []byte(`{"update": "update"}`))
 	assert.NoError(t, err)
 
 	err = rt.WaitForCondition(func() bool {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -369,11 +369,24 @@ func (rt *RestTester) UpsertDbConfig(dbName string, config DbConfig) (*TestRespo
 	return resp, nil
 }
 
-// Returns first database found for server context.
+// GetDatabase Returns first database found for server context.
 func (rt *RestTester) GetDatabase() *db.DatabaseContext {
 
 	for _, database := range rt.ServerContext().AllDatabases() {
 		return database
+	}
+	return nil
+}
+
+// GetSingleTestDataStore will return a datastore if there is only one collection configured on the RestTester database.
+func (rt *RestTester) GetSingleTestDataStore() base.DataStore {
+	database := rt.GetDatabase()
+	require.Equal(rt.TB, 1, len(database.CollectionByID))
+	for _, collection := range database.CollectionByID {
+		return database.Bucket.NamedDataStore(base.ScopeAndCollectionName{
+			Scope:      collection.ScopeName(),
+			Collection: collection.Name(),
+		})
 	}
 	return nil
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -272,7 +272,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 		if rt.DatabaseConfig.UseViews == nil {
 			rt.DatabaseConfig.UseViews = base.BoolPtr(base.TestsDisableGSI())
 		}
-		if rt.collectionConfig != useSingleCollectionDefaultOnly && (!*rt.DatabaseConfig.UseViews || base.UnitTestUrlIsWalrus()) {
+		if base.TestsUseNamedCollections() && rt.collectionConfig != useSingleCollectionDefaultOnly && (!*rt.DatabaseConfig.UseViews || base.UnitTestUrlIsWalrus()) {
 			// If scopes is already set, assume the caller has a plan
 			if rt.DatabaseConfig.Scopes == nil {
 				// Configure non default collections by default
@@ -1097,9 +1097,6 @@ type BlipTesterSpec struct {
 
 	// Supported blipProtocols for the client to use in order of preference
 	blipProtocols []string
-
-	// If true, only run the default collection
-	onlyDefaultCollection bool
 }
 
 // State associated with a BlipTester
@@ -1155,8 +1152,7 @@ func getDefaultBlipTesterSpec() BlipTesterSpec {
 func NewBlipTesterFromSpecWithRT(tb testing.TB, spec *BlipTesterSpec, rt *RestTester) (blipTester *BlipTester, err error) {
 	blipTesterSpec := spec
 	if spec == nil {
-		spec := getDefaultBlipTesterSpec()
-		blipTesterSpec = &spec
+		blipTesterSpec = &BlipTesterSpec{}
 	}
 	blipTester, err = createBlipTesterWithSpec(tb, *blipTesterSpec, rt)
 	if err != nil {
@@ -1169,7 +1165,7 @@ func NewBlipTesterFromSpecWithRT(tb testing.TB, spec *BlipTesterSpec, rt *RestTe
 
 // NewBlipTesterDefaultCollection creates a blip tester that has a RestTester only using a single database and `_default._default` collection.
 func NewBlipTesterDefaultCollection(tb testing.TB) *BlipTester {
-	return NewBlipTesterDefaultCollectionFromSpec(tb, BlipTesterSpec{GuestEnabled: true, onlyDefaultCollection: true})
+	return NewBlipTesterDefaultCollectionFromSpec(tb, BlipTesterSpec{GuestEnabled: true})
 }
 
 // NewBlipTesterDefaultCollectionFromSpec creates a blip tester that has a RestTester only using a single database and `_default._default` collection.

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1072,11 +1072,17 @@ func (bt BlipTester) DatabaseContext() *db.DatabaseContext {
 	return nil
 }
 
+// getBlipTesterSpec returns a default tester specification.
+func getDefaultBlipTesterSpec() BlipTesterSpec {
+	return BlipTesterSpec{GuestEnabled: true}
+}
+
+// NewBlipTesterFromSpecWithRT creates a blip tester from an existing rest tester
 func NewBlipTesterFromSpecWithRT(tb testing.TB, spec *BlipTesterSpec, rt *RestTester) (blipTester *BlipTester, err error) {
 	blipTesterSpec := spec
 	if spec == nil {
-		// Default spec
-		blipTesterSpec = &BlipTesterSpec{}
+		spec := getDefaultBlipTesterSpec()
+		blipTesterSpec = &spec
 	}
 	blipTester, err = createBlipTesterWithSpec(tb, *blipTesterSpec, rt)
 	if err != nil {
@@ -1087,10 +1093,27 @@ func NewBlipTesterFromSpecWithRT(tb testing.TB, spec *BlipTesterSpec, rt *RestTe
 	return blipTester, err
 }
 
+// NewBlipTesterDefaultCollection creates a blip tester that has a RestTester only using a single database and `_default._default` collection.
+func NewBlipTesterDefaultCollection(tb testing.TB) *BlipTester {
+	return NewBlipTesterDefaultCollectionFromSpec(tb, BlipTesterSpec{GuestEnabled: true})
+}
+
+// NewBlipTesterDefaultCollectionFromSpec creates a blip tester that has a RestTester only using a single database and `_default._default` collection.
+func NewBlipTesterDefaultCollectionFromSpec(tb testing.TB, spec BlipTesterSpec) *BlipTester {
+	rtConfig := RestTesterConfig{
+		EnableNoConflictsMode: spec.noConflictsMode,
+		GuestEnabled:          spec.GuestEnabled,
+		DatabaseConfig:        &DatabaseConfig{},
+	}
+	rt := NewRestTester(tb, &rtConfig)
+	bt, err := createBlipTesterWithSpec(tb, spec, rt)
+	require.NoError(tb, err)
+	return bt
+}
+
 // Create a BlipTester using the default spec
 func NewBlipTester(tb testing.TB) (*BlipTester, error) {
-	defaultSpec := BlipTesterSpec{GuestEnabled: true}
-	return NewBlipTesterFromSpec(tb, defaultSpec)
+	return NewBlipTesterFromSpec(tb, getDefaultBlipTesterSpec())
 }
 
 func NewBlipTesterFromSpec(tb testing.TB, spec BlipTesterSpec) (*BlipTester, error) {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -452,8 +452,8 @@ func (rt *RestTester) GetSingleTestDatabaseCollection() *db.DatabaseCollection {
 	return nil
 }
 
-// GetSingleTestDataStore will return a datastore if there is only one collection configured on the RestTester database.
-func (rt *RestTester) GetSingleTestDataStore() base.DataStore {
+// GetSingleDataStore will return a datastore if there is only one collection configured on the RestTester database.
+func (rt *RestTester) GetSingleDataStore() base.DataStore {
 	collection := rt.GetSingleTestDatabaseCollection()
 	fmt.Println(collection.ScopeName())
 	return rt.GetDatabase().Bucket.NamedDataStore(base.ScopeAndCollectionName{

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -378,17 +378,24 @@ func (rt *RestTester) GetDatabase() *db.DatabaseContext {
 	return nil
 }
 
-// GetSingleTestDataStore will return a datastore if there is only one collection configured on the RestTester database.
-func (rt *RestTester) GetSingleTestDataStore() base.DataStore {
+// GetSingleTestDatabaseCollection will return a DatabaseCollection if there is only one. Depending on test environment configuration, it may or may not be the default collection.
+func (rt *RestTester) GetSingleTestDatabaseCollection() *db.DatabaseCollection {
 	database := rt.GetDatabase()
 	require.Equal(rt.TB, 1, len(database.CollectionByID))
 	for _, collection := range database.CollectionByID {
-		return database.Bucket.NamedDataStore(base.ScopeAndCollectionName{
-			Scope:      collection.ScopeName(),
-			Collection: collection.Name(),
-		})
+		return collection
 	}
 	return nil
+}
+
+// GetSingleTestDataStore will return a datastore if there is only one collection configured on the RestTester database.
+func (rt *RestTester) GetSingleTestDataStore() base.DataStore {
+	collection := rt.GetSingleTestDatabaseCollection()
+	fmt.Println(collection.ScopeName())
+	return rt.GetDatabase().Bucket.NamedDataStore(base.ScopeAndCollectionName{
+		Scope:      collection.ScopeName(),
+		Collection: collection.Name(),
+	})
 }
 
 func (rt *RestTester) MustWaitForDoc(docid string, t testing.TB) {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -268,12 +268,12 @@ func (rt *RestTester) Bucket() base.Bucket {
 			// If no db config was passed in, create one
 			rt.DatabaseConfig = &DatabaseConfig{}
 		}
-		if rt.collectionConfig != useSingleCollectionDefaultOnly {
-			// Configure non default collections by default
-			rt.DatabaseConfig.Scopes = getCollectionsConfig(rt.TB, testBucket, rt.numCollections)
-		}
 		if rt.DatabaseConfig.UseViews == nil {
 			rt.DatabaseConfig.UseViews = base.BoolPtr(base.TestsDisableGSI())
+		}
+		if rt.collectionConfig != useSingleCollectionDefaultOnly && *rt.DatabaseConfig.UseViews == false {
+			// Configure non default collections by default
+			rt.DatabaseConfig.Scopes = getCollectionsConfig(rt.TB, testBucket, rt.numCollections)
 		}
 
 		// numReplicas set to 0 for test buckets, since it should assume that there may only be one indexing node.
@@ -339,7 +339,7 @@ func (rt *RestTester) MetadataStore() base.DataStore {
 func getCollectionsConfig(t testing.TB, testBucket *base.TestBucket, numCollections int) ScopesConfig {
 	// Get a datastore as provided by the test
 	stores := testBucket.GetNonDefaultDatastoreNames()
-	require.GreaterOrEqual(t, len(stores), numCollections, "Requested more collections than found on testBucket")
+	require.True(t, len(stores) >= numCollections, "Requested more collections %d than found on testBucket %d", numCollections, len(stores))
 
 	scopesConfig := ScopesConfig{}
 	for i := 0; i < numCollections; i++ {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -271,7 +271,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 		if rt.DatabaseConfig.UseViews == nil {
 			rt.DatabaseConfig.UseViews = base.BoolPtr(base.TestsDisableGSI())
 		}
-		if rt.collectionConfig != useSingleCollectionDefaultOnly && *rt.DatabaseConfig.UseViews == false {
+		if rt.collectionConfig != useSingleCollectionDefaultOnly && (*rt.DatabaseConfig.UseViews != false || base.UnitTestUrlIsWalrus()) {
 			// Configure non default collections by default
 			rt.DatabaseConfig.Scopes = getCollectionsConfig(rt.TB, testBucket, rt.numCollections)
 		}

--- a/rest/utilities_testing_attachment.go
+++ b/rest/utilities_testing_attachment.go
@@ -35,26 +35,24 @@ func (rt *RestTester) WaitForAttachmentCompactionStatus(t *testing.T, state db.B
 	return response
 }
 
-func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, testDB *db.Database, docID string, body []byte, attID string, attBody []byte) string {
+func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, collection *db.DatabaseCollectionWithUser, dataStore base.DataStore, docID string, body []byte, attID string, attBody []byte) string {
 	if !base.TestUseXattrs() {
 		t.Skip("Requires xattrs")
 	}
-
 	attDigest := db.Sha1DigestKey(attBody)
 
 	attDocID := db.MakeAttachmentKey(db.AttVersion1, docID, attDigest)
-	_, err := testDB.Bucket.DefaultDataStore().AddRaw(attDocID, 0, attBody)
+	_, err := dataStore.AddRaw(attDocID, 0, attBody)
 	require.NoError(t, err)
 
 	var unmarshalledBody db.Body
 	err = base.JSONUnmarshal(body, &unmarshalledBody)
 	require.NoError(t, err)
 
-	collection := testDB.GetSingleDatabaseCollectionWithUser()
 	_, _, err = collection.Put(ctx, docID, unmarshalledBody)
 	require.NoError(t, err)
 
-	_, err = testDB.Bucket.DefaultDataStore().WriteUpdateWithXattr(docID, base.SyncXattrName, "", 0, nil, nil, func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, err error) {
+	_, err = dataStore.WriteUpdateWithXattr(docID, base.SyncXattrName, "", 0, nil, nil, func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, err error) {
 		attachmentSyncData := map[string]interface{}{
 			attID: map[string]interface{}{
 				"content_type": "application/json",

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -215,6 +215,11 @@ func SetupSGRPeers(t *testing.T) (activeRT *RestTester, passiveRT *RestTester, r
 	activeRT = NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket:   activeTestBucket.NoCloseClone(),
 		SgReplicateEnabled: true,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				Scopes: nil, // no non default collections for ISGR yet
+			},
+		},
 	})
 	// Initalize RT and bucket
 	_ = activeRT.Bucket()

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -189,17 +189,18 @@ func (rt *RestTester) GetReplicationStatuses(queryString string) (statuses []db.
 func SetupSGRPeers(t *testing.T) (activeRT *RestTester, passiveRT *RestTester, remoteDBURLString string, teardown func()) {
 	// Set up passive RestTester (rt2)
 	passiveTestBucket := base.GetTestBucket(t)
-	passiveRT = NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: passiveTestBucket.NoCloseClone(),
-		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Users: map[string]*auth.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("*"),
+	passiveRT = NewRestTesterDefaultCollection(t, // CBG-2619: make collection aware
+		&RestTesterConfig{
+			CustomTestBucket: passiveTestBucket.NoCloseClone(),
+			DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+				Users: map[string]*auth.PrincipalConfig{
+					"alice": {
+						Password:         base.StringPtr("pass"),
+						ExplicitChannels: base.SetOf("*"),
+					},
 				},
-			},
-		}},
-	})
+			}},
+		})
 	// Initalize RT and bucket
 	_ = passiveRT.Bucket()
 
@@ -212,15 +213,11 @@ func SetupSGRPeers(t *testing.T) (activeRT *RestTester, passiveRT *RestTester, r
 
 	// Set up active RestTester (rt1)
 	activeTestBucket := base.GetTestBucket(t)
-	activeRT = NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket:   activeTestBucket.NoCloseClone(),
-		SgReplicateEnabled: true,
-		DatabaseConfig: &DatabaseConfig{
-			DbConfig: DbConfig{
-				Scopes: nil, // no non default collections for ISGR yet
-			},
-		},
-	})
+	activeRT = NewRestTesterDefaultCollection(t, // CBG-2619: make collection aware
+		&RestTesterConfig{
+			CustomTestBucket:   activeTestBucket.NoCloseClone(),
+			SgReplicateEnabled: true,
+		})
 	// Initalize RT and bucket
 	_ = activeRT.Bucket()
 

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -22,7 +22,14 @@ import (
 )
 
 func TestDesignDocs(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{
+		GuestEnabled: true,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				Scopes: nil, // no scopes for views tests
+			},
+		},
+	})
 	defer rt.Close()
 
 	response := rt.SendRequest(http.MethodGet, "/db/_design/foo", "")
@@ -53,7 +60,13 @@ func TestDesignDocs(t *testing.T) {
 }
 
 func TestViewQuery(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				Scopes: nil, // no scopes for views tests
+			},
+		},
+	})
 	defer rt.Close()
 
 	if !base.TestsDisableGSI() {
@@ -100,7 +113,13 @@ func TestViewQueryMultipleViews(t *testing.T) {
 		t.Skip("views tests are not applicable under GSI")
 	}
 
-	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				Scopes: nil, // no scopes for views tests
+			},
+		},
+	})
 	defer rt.Close()
 
 	// Define three views
@@ -133,7 +152,13 @@ func TestViewQueryWithParams(t *testing.T) {
 		t.Skip("views tests are not applicable under GSI")
 	}
 
-	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				Scopes: nil, // no scopes for views tests
+			},
+		},
+	})
 	defer rt.Close()
 
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_design/foodoc", `{"views": {"foobarview": {"map": "function(doc, meta) {if (doc.value == \"foo\") {emit(doc.key, null);}}"}}}`)
@@ -161,7 +186,13 @@ func TestViewQueryUserAccess(t *testing.T) {
 		t.Skip("views tests are not applicable under GSI")
 	}
 
-	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				Scopes: nil, // no scopes for views tests
+			},
+		},
+	})
 	defer rt.Close()
 
 	ctx := rt.Context()
@@ -256,7 +287,13 @@ func TestUserViewQuery(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
 		GuestEnabled: true,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				Scopes: nil, // no scopes for views tests
+			},
+		},
 	}
+
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -334,6 +371,11 @@ func TestAdminReduceViewQuery(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
 		GuestEnabled: true,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				Scopes: nil, // no scopes for views tests
+			},
+		},
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -389,6 +431,11 @@ func TestAdminReduceSumQuery(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
 		GuestEnabled: true,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				Scopes: nil, // no scopes for views tests
+			},
+		},
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -429,6 +476,11 @@ func TestAdminGroupReduceSumQuery(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
 		GuestEnabled: true,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				Scopes: nil, // no scopes for views tests
+			},
+		},
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -469,7 +521,14 @@ func TestViewQueryWithKeys(t *testing.T) {
 		t.Skip("views tests are not applicable under GSI")
 	}
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
+	rtConfig := RestTesterConfig{
+		SyncFn: `function(doc) {channel(doc.channel)}`,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				Scopes: nil, // no scopes for views tests
+			},
+		},
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -590,6 +649,11 @@ func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
 		GuestEnabled: true,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				Scopes: nil, // no scopes for views tests
+			},
+		},
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -621,7 +685,14 @@ func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
 }
 
 func TestPostInstallCleanup(t *testing.T) {
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
+	rtConfig := RestTesterConfig{
+		SyncFn: `function(doc) {channel(doc.channel)}`,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				Scopes: nil, // no scopes for views tests
+			},
+		},
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -687,7 +758,13 @@ func TestViewQueryWrappers(t *testing.T) {
 	if !base.TestsDisableGSI() {
 		t.Skip("views tests are not applicable under GSI")
 	}
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				Scopes: nil, // no scopes for views tests
+			},
+		},
+	})
 	defer rt.Close()
 
 	ctx := rt.Context()

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -22,14 +22,7 @@ import (
 )
 
 func TestDesignDocs(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{
-		GuestEnabled: true,
-		DatabaseConfig: &DatabaseConfig{
-			DbConfig: DbConfig{
-				Scopes: nil, // no scopes for views tests
-			},
-		},
-	})
+	rt := NewRestTesterDefaultCollection(t, &RestTesterConfig{GuestEnabled: true}) // views only use default collection
 	defer rt.Close()
 
 	response := rt.SendRequest(http.MethodGet, "/db/_design/foo", "")
@@ -60,13 +53,7 @@ func TestDesignDocs(t *testing.T) {
 }
 
 func TestViewQuery(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true,
-		DatabaseConfig: &DatabaseConfig{
-			DbConfig: DbConfig{
-				Scopes: nil, // no scopes for views tests
-			},
-		},
-	})
+	rt := NewRestTesterDefaultCollection(t, &RestTesterConfig{GuestEnabled: true}) // views only use default collection
 	defer rt.Close()
 
 	if !base.TestsDisableGSI() {
@@ -113,13 +100,7 @@ func TestViewQueryMultipleViews(t *testing.T) {
 		t.Skip("views tests are not applicable under GSI")
 	}
 
-	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true,
-		DatabaseConfig: &DatabaseConfig{
-			DbConfig: DbConfig{
-				Scopes: nil, // no scopes for views tests
-			},
-		},
-	})
+	rt := NewRestTesterDefaultCollection(t, &RestTesterConfig{GuestEnabled: true}) // views only use default collection
 	defer rt.Close()
 
 	// Define three views
@@ -152,13 +133,7 @@ func TestViewQueryWithParams(t *testing.T) {
 		t.Skip("views tests are not applicable under GSI")
 	}
 
-	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true,
-		DatabaseConfig: &DatabaseConfig{
-			DbConfig: DbConfig{
-				Scopes: nil, // no scopes for views tests
-			},
-		},
-	})
+	rt := NewRestTesterDefaultCollection(t, &RestTesterConfig{GuestEnabled: true}) // views only use default collection
 	defer rt.Close()
 
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_design/foodoc", `{"views": {"foobarview": {"map": "function(doc, meta) {if (doc.value == \"foo\") {emit(doc.key, null);}}"}}}`)
@@ -186,13 +161,7 @@ func TestViewQueryUserAccess(t *testing.T) {
 		t.Skip("views tests are not applicable under GSI")
 	}
 
-	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true,
-		DatabaseConfig: &DatabaseConfig{
-			DbConfig: DbConfig{
-				Scopes: nil, // no scopes for views tests
-			},
-		},
-	})
+	rt := NewRestTesterDefaultCollection(t, &RestTesterConfig{GuestEnabled: true}) // views only use default collection
 	defer rt.Close()
 
 	ctx := rt.Context()
@@ -287,14 +256,9 @@ func TestUserViewQuery(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
 		GuestEnabled: true,
-		DatabaseConfig: &DatabaseConfig{
-			DbConfig: DbConfig{
-				Scopes: nil, // no scopes for views tests
-			},
-		},
 	}
 
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTesterDefaultCollection(t, &rtConfig) // views only use default collection
 	defer rt.Close()
 
 	ctx := rt.Context()
@@ -371,13 +335,8 @@ func TestAdminReduceViewQuery(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
 		GuestEnabled: true,
-		DatabaseConfig: &DatabaseConfig{
-			DbConfig: DbConfig{
-				Scopes: nil, // no scopes for views tests
-			},
-		},
 	}
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTesterDefaultCollection(t, &rtConfig) // views only use default collection
 	defer rt.Close()
 
 	// Create a view with a reduce:
@@ -431,13 +390,8 @@ func TestAdminReduceSumQuery(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
 		GuestEnabled: true,
-		DatabaseConfig: &DatabaseConfig{
-			DbConfig: DbConfig{
-				Scopes: nil, // no scopes for views tests
-			},
-		},
 	}
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTesterDefaultCollection(t, &rtConfig) // views only use default collection
 	defer rt.Close()
 
 	// Create a view with a reduce:
@@ -476,13 +430,8 @@ func TestAdminGroupReduceSumQuery(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
 		GuestEnabled: true,
-		DatabaseConfig: &DatabaseConfig{
-			DbConfig: DbConfig{
-				Scopes: nil, // no scopes for views tests
-			},
-		},
 	}
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTesterDefaultCollection(t, &rtConfig) // views only use default collection
 	defer rt.Close()
 
 	// Create a view with a reduce:
@@ -523,13 +472,8 @@ func TestViewQueryWithKeys(t *testing.T) {
 
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc) {channel(doc.channel)}`,
-		DatabaseConfig: &DatabaseConfig{
-			DbConfig: DbConfig{
-				Scopes: nil, // no scopes for views tests
-			},
-		},
 	}
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTesterDefaultCollection(t, &rtConfig) // views only use default collection
 	defer rt.Close()
 
 	// Create a view
@@ -570,7 +514,7 @@ func TestViewQueryWithCompositeKeys(t *testing.T) {
 	}
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTesterDefaultCollection(t, &rtConfig) // views only use default collection
 	defer rt.Close()
 
 	// Create a view
@@ -610,7 +554,7 @@ func TestViewQueryWithIntKeys(t *testing.T) {
 	}
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTesterDefaultCollection(t, &rtConfig) // views only use default collection
 	defer rt.Close()
 
 	// Create a view
@@ -649,13 +593,8 @@ func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
 		GuestEnabled: true,
-		DatabaseConfig: &DatabaseConfig{
-			DbConfig: DbConfig{
-				Scopes: nil, // no scopes for views tests
-			},
-		},
 	}
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTesterDefaultCollection(t, &rtConfig) // views only use default collection
 	defer rt.Close()
 
 	// Create a view with a reduce:
@@ -687,11 +626,6 @@ func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
 func TestPostInstallCleanup(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc) {channel(doc.channel)}`,
-		DatabaseConfig: &DatabaseConfig{
-			DbConfig: DbConfig{
-				Scopes: nil, // no scopes for views tests
-			},
-		},
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -758,13 +692,7 @@ func TestViewQueryWrappers(t *testing.T) {
 	if !base.TestsDisableGSI() {
 		t.Skip("views tests are not applicable under GSI")
 	}
-	rt := NewRestTester(t, &RestTesterConfig{
-		DatabaseConfig: &DatabaseConfig{
-			DbConfig: DbConfig{
-				Scopes: nil, // no scopes for views tests
-			},
-		},
-	})
+	rt := NewRestTesterDefaultCollection(t, nil) // views only use default collection
 	defer rt.Close()
 
 	ctx := rt.Context()

--- a/rest/x509_test.go
+++ b/rest/x509_test.go
@@ -99,7 +99,7 @@ func TestAttachmentCompactionRun(t *testing.T) {
 	collection := &db.DatabaseCollectionWithUser{
 		DatabaseCollection: rt.GetSingleTestDatabaseCollection(),
 	}
-	dataStore := rt.GetSingleTestDataStore()
+	dataStore := rt.GetSingleDataStore()
 
 	for i := 0; i < 20; i++ {
 		docID := fmt.Sprintf("testDoc-%d", i)

--- a/rest/x509_test.go
+++ b/rest/x509_test.go
@@ -96,13 +96,18 @@ func TestAttachmentCompactionRun(t *testing.T) {
 	defer rt.Close()
 	ctx := rt.Context()
 
+	collection := &db.DatabaseCollectionWithUser{
+		DatabaseCollection: rt.GetSingleTestDatabaseCollection(),
+	}
+	dataStore := rt.GetSingleTestDataStore()
+
 	for i := 0; i < 20; i++ {
 		docID := fmt.Sprintf("testDoc-%d", i)
 		attID := fmt.Sprintf("testAtt-%d", i)
 		attBody := map[string]interface{}{"value": strconv.Itoa(i)}
 		attJSONBody, err := base.JSONMarshal(attBody)
 		assert.NoError(t, err)
-		CreateLegacyAttachmentDoc(t, ctx, &db.Database{DatabaseContext: rt.GetDatabase()}, docID, []byte("{}"), attID, attJSONBody)
+		CreateLegacyAttachmentDoc(t, ctx, collection, dataStore, docID, []byte("{}"), attID, attJSONBody)
 	}
 
 	resp := rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")


### PR DESCRIPTION
To facilitate testing collections across the rest packages, several variants of `NewRestTester` have been created:

* `NewRestTester` itself has modified behavior. Under `SG_TEST_USE_DEFAULT_COLLECTION=false` it will now create a Database with a single named collection on it with walrus or GSI. With `SG_TEST_USE_DEFAULT_COLLECTION=true` it will maintain the existing behavior, of database backed by default collection.
* `NewRestTesterDefaultCollection` will always use a default collection. These are tagged with jira tickets where we want to modify the behavior to work with a named collection (e.g. replication or channel access).
* `NewRestTesterMultipleCollections` creates a rest tester with 1 database and N named collections. This is limited to GSI/walrus.

Subsequent changes that occur are modifying use of `DefaultDataStore` to the datastore off a collection.

I also modified `TestBucket.GetNamedDataStore` to return datastores in particular order. It was ordered under walrus but map iteration under GSI. This is test only code.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true,single named collection` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1221/
- [x] `GSI=true,xattrs=true,default colleciton only collection` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1213/