### PR TITLE
Collection channel feed support

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -196,7 +196,16 @@ func (db *DatabaseCollectionWithUser) buildRevokedFeed(ctx context.Context, ch c
 	paginationOptions.Since.Seq = revokeFrom
 
 	// Use a bypass channel cache for revocations (CBG-1695)
-	singleChannelCache := db.changeCache.getChannelCache().getBypassChannelCache(ch)
+	singleChannelCache, err := db.changeCache.getChannelCache().getBypassChannelCache(ch)
+	if err != nil {
+		base.WarnfCtx(ctx, "Error obtaining channel cache for channel %q: %v", base.UD(singleChannelCache.ChannelID()), err)
+		change := ChangeEntry{
+			Err: base.ErrChannelFeed,
+		}
+		feed <- &change
+		close(feed)
+		return feed
+	}
 
 	go func() {
 		defer base.FatalPanicHandler()
@@ -726,7 +735,13 @@ func (db *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Context
 					chanID := channels.NewID(chanName, collectionID)
 					// Obtain a SingleChannelCache instance to use for both normal and late feeds.  Required to ensure consistency
 					// if cache is evicted during processing
-					singleChannelCache := db.changeCache.getChannelCache().getSingleChannelCache(chanID)
+					singleChannelCache, err := db.changeCache.getChannelCache().getSingleChannelCache(chanID)
+					if err != nil {
+						base.WarnfCtx(ctx, "Unable to obtain channel cache for %v, terminating feed", chanID)
+						change := makeErrorEntry("Channel cache unavailable, terminating feed")
+						output <- &change
+						return
+					}
 
 					// Set up late sequence handling first, as we need to roll back the regular feed on error
 					// Handles previously skipped sequences prior to options.Since that
@@ -1091,8 +1106,7 @@ func (db *DatabaseCollectionWithUser) GetChanges(ctx context.Context, channels b
 }
 
 // Returns the set of cached log entries for a given channel
-func (db *DatabaseCollection) GetChangeLog(channel channels.ID, afterSeq uint64) (entries []*LogEntry) {
-
+func (db *DatabaseCollection) GetChangeLog(channel channels.ID, afterSeq uint64) (entries []*LogEntry, err error) {
 	return db.changeCache.getChannelCache().GetCachedChanges(channel)
 }
 
@@ -1194,8 +1208,8 @@ func (db *DatabaseCollectionWithUser) getLateFeed(feedHandler *lateSequenceFeed,
 
 // Closes a single late sequence feed.
 func (db *DatabaseCollectionWithUser) closeLateFeed(feedHandler *lateSequenceFeed) {
-	singleChannelCache := db.changeCache.getChannelCache().getSingleChannelCache(feedHandler.channel)
-	if !singleChannelCache.SupportsLateFeed() {
+	singleChannelCache, err := db.changeCache.getChannelCache().getSingleChannelCache(feedHandler.channel)
+	if err != nil || !singleChannelCache.SupportsLateFeed() {
 		return
 	}
 	if singleChannelCache.LateSequenceUUID() == feedHandler.lateSequenceUUID {

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -13,6 +13,7 @@ package db
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/couchbase/go-couchbase"
@@ -91,6 +92,15 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(ctx context.Context, ch
 	collection := dbc.GetSingleDatabaseCollection()
 	return collection.getChangesInChannelFromQuery(ctx, channel.Name, startSeq, endSeq, limit, activeOnly)
 
+}
+
+// Queries the 'channels' view to get a range of sequences of a single channel as LogEntries.
+func (dbc *DatabaseContext) getQueryHandlerForCollection(collectionID uint32) (ChannelQueryHandler, error) {
+	collection, ok := dbc.CollectionByID[collectionID]
+	if !ok {
+		return nil, fmt.Errorf("Query handler requested for unknown collectionID: %d", collectionID)
+	}
+	return collection, nil
 }
 
 // Queries the 'channels' view to get a range of sequences of a single channel as LogEntries.

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -51,7 +51,7 @@ type ChannelCache interface {
 	GetChanges(ch channels.ID, options ChangesOptions) ([]*LogEntry, error)
 
 	// Returns the set of all cached data for a given channel (intended for diagnostic usage)
-	GetCachedChanges(ch channels.ID) []*LogEntry
+	GetCachedChanges(ch channels.ID) ([]*LogEntry, error)
 
 	// Clear reinitializes the cache to an empty state
 	Clear()
@@ -64,24 +64,28 @@ type ChannelCache interface {
 	GetHighCacheSequence() uint64
 
 	// Access to individual channel cache
-	getSingleChannelCache(ch channels.ID) SingleChannelCache
+	getSingleChannelCache(ch channels.ID) (SingleChannelCache, error)
 
 	// Access to individual bypass channel cache
-	getBypassChannelCache(ch channels.ID) SingleChannelCache
+	getBypassChannelCache(ch channels.ID) (SingleChannelCache, error)
 
 	// Stop stops the channel cache and it's background tasks.
 	Stop()
 }
 
-// ChannelQueryHandler interface is implemented by databaseContext.
+// ChannelQueryHandler interface is implemented by databaseContext and databaseCollection.
 type ChannelQueryHandler interface {
-	getChangesInChannelFromQuery(ctx context.Context, channelName channels.ID, startSeq, endSeq uint64, limit int, activeOnly bool) (LogEntries, error)
+	getChangesInChannelFromQuery(ctx context.Context, channelName string, startSeq, endSeq uint64, limit int, activeOnly bool) (LogEntries, error)
 }
+
+// Function that returns a ChannelQueryHandlerFunc for the specified collectionID
+type ChannelQueryHandlerFactory func(collectionID uint32) (ChannelQueryHandler, error)
 
 type StableSequenceCallbackFunc func() uint64
 
 type channelCacheImpl struct {
-	queryHandler         ChannelQueryHandler           // Passed to singleChannelCacheImpl for view queries.
+	//queryHandler         ChannelQueryHandler           // Passed to singleChannelCacheImpl for view queries.
+	queryHandlerFactory  ChannelQueryHandlerFactory    // Factory to look up ChannelQueryHandler for a collectionID
 	channelCaches        *channels.RangeSafeCollection // A collection of singleChannelCaches
 	backgroundTasks      []BackgroundTask              // List of background tasks specific to channel cache.
 	dbName               string                        // Name of the database associated with the channel cache.
@@ -100,14 +104,14 @@ type channelCacheImpl struct {
 }
 
 func NewChannelCacheForContext(options ChannelCacheOptions, context *DatabaseContext) (*channelCacheImpl, error) {
-	return newChannelCache(context.Name, options, context, context.activeChannels, context.DbStats.Cache())
+	return newChannelCache(context.Name, options, context.getQueryHandlerForCollection, context.activeChannels, context.DbStats.Cache())
 }
 
-func newChannelCache(dbName string, options ChannelCacheOptions, queryHandler ChannelQueryHandler,
+func newChannelCache(dbName string, options ChannelCacheOptions, queryHandlerFactory ChannelQueryHandlerFactory,
 	activeChannels *channels.ActiveChannels, cacheStats *base.CacheStats) (*channelCacheImpl, error) {
 
 	channelCache := &channelCacheImpl{
-		queryHandler:         queryHandler,
+		queryHandlerFactory:  queryHandlerFactory,
 		channelCaches:        channels.NewRangeSafeCollection(),
 		dbName:               dbName,
 		terminator:           make(chan bool),
@@ -174,7 +178,7 @@ func (c *channelCacheImpl) updateHighCacheSequence(sequence uint64) {
 
 // GetSingleChannelCache will create the cache for the channel if it doesn't exist.  If the cache is at
 // capacity, will return a bypass channel cache.
-func (c *channelCacheImpl) getSingleChannelCache(ch channels.ID) SingleChannelCache {
+func (c *channelCacheImpl) getSingleChannelCache(ch channels.ID) (SingleChannelCache, error) {
 
 	return c.getChannelCache(ch)
 }
@@ -269,13 +273,21 @@ func (c *channelCacheImpl) Remove(collectionID uint32, docIDs []string, startTim
 
 func (c *channelCacheImpl) GetChanges(ch channels.ID, options ChangesOptions) ([]*LogEntry, error) {
 
-	return c.getChannelCache(ch).GetChanges(options)
+	cache, err := c.getChannelCache(ch)
+	if err != nil {
+		return nil, err
+	}
+	return cache.GetChanges(options)
 }
 
-func (c *channelCacheImpl) GetCachedChanges(channel channels.ID) []*LogEntry {
+func (c *channelCacheImpl) GetCachedChanges(channel channels.ID) ([]*LogEntry, error) {
 	options := ChangesOptions{Since: SequenceID{Seq: 0}}
-	_, changes := c.getChannelCache(channel).GetCachedChanges(options)
-	return changes
+	cache, err := c.getChannelCache(channel)
+	if err != nil {
+		return nil, err
+	}
+	_, changes := cache.GetCachedChanges(options)
+	return changes, nil
 }
 
 // CleanAgedItems prunes the caches based on age of items. Error returned to fulfill BackgroundTaskFunc signature.
@@ -294,34 +306,43 @@ func (c *channelCacheImpl) cleanAgedItems(ctx context.Context) error {
 	return nil
 }
 
-func (c *channelCacheImpl) getChannelCache(channel channels.ID) SingleChannelCache {
+func (c *channelCacheImpl) getChannelCache(channel channels.ID) (SingleChannelCache, error) {
 
 	cacheValue, found := c.channelCaches.Get(channel)
 	if found {
-		return AsSingleChannelCache(cacheValue)
+		return AsSingleChannelCache(cacheValue), nil
 	}
 
 	// Attempt to add a singleChannelCache for the channel name.  If unsuccessful, return a bypass channel cache
 	singleChannelCache, ok := c.addChannelCache(channel)
 	if ok {
-		return singleChannelCache
+		return singleChannelCache, nil
+	}
+
+	queryHandler, err := c.queryHandlerFactory(channel.CollectionID)
+	if err != nil {
+		return nil, err
 	}
 
 	bypassChannelCache := &bypassChannelCache{
 		channel:      channel,
-		queryHandler: c.queryHandler,
+		queryHandler: queryHandler,
 	}
 	c.cacheStats.ChannelCacheBypassCount.Add(1)
-	return bypassChannelCache
+	return bypassChannelCache, nil
 
 }
 
-func (c *channelCacheImpl) getBypassChannelCache(ch channels.ID) SingleChannelCache {
+func (c *channelCacheImpl) getBypassChannelCache(ch channels.ID) (SingleChannelCache, error) {
+	queryHandler, err := c.queryHandlerFactory(ch.CollectionID)
+	if err != nil {
+		return nil, err
+	}
 	bypassChannelCache := &bypassChannelCache{
 		channel:      ch,
-		queryHandler: c.queryHandler,
+		queryHandler: queryHandler,
 	}
-	return bypassChannelCache
+	return bypassChannelCache, nil
 }
 
 // Converts an RangeSafeCollection value to a singleChannelCacheImpl.  On type
@@ -350,12 +371,19 @@ func (c *channelCacheImpl) addChannelCache(channel channels.ID) (*singleChannelC
 		return nil, false
 	}
 
+	// Return nil if a queryHandler can't be obtained for the collectionID
+	queryHandler, err := c.queryHandlerFactory(channel.CollectionID)
+	if err != nil {
+		return nil, false
+	}
+
 	c.validFromLock.Lock()
 
 	// Everything after the current high sequence will be added to the cache via the feed
 	validFrom := c.GetHighCacheSequence() + 1
 
-	singleChannelCache := newChannelCacheWithOptions(c.queryHandler, channel, validFrom, c.options, c.cacheStats)
+	singleChannelCache :=
+		newChannelCacheWithOptions(queryHandler, channel, validFrom, c.options, c.cacheStats)
 	cacheValue, created, cacheSize := c.channelCaches.GetOrInsert(channel, singleChannelCache)
 	c.validFromLock.Unlock()
 

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -84,7 +84,6 @@ type ChannelQueryHandlerFactory func(collectionID uint32) (ChannelQueryHandler, 
 type StableSequenceCallbackFunc func() uint64
 
 type channelCacheImpl struct {
-	//queryHandler         ChannelQueryHandler           // Passed to singleChannelCacheImpl for view queries.
 	queryHandlerFactory  ChannelQueryHandlerFactory    // Factory to look up ChannelQueryHandler for a collectionID
 	channelCaches        *channels.RangeSafeCollection // A collection of singleChannelCaches
 	backgroundTasks      []BackgroundTask              // List of background tasks specific to channel cache.

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -102,7 +102,7 @@ type SingleChannelCache interface {
 
 type singleChannelCacheImpl struct {
 	channelID        channels.ID          // The channel
-	queryHandler     ChannelQueryHandler  // Database connection (used for view queries)
+	queryHandler     ChannelQueryHandler  // Channel query function
 	logs             LogEntries           // Log entries in sequence order
 	validFrom        uint64               // First sequence that logs is valid for, not necessarily the seq number of a change entry.
 	lock             sync.RWMutex         // Controls access to logs, validFrom
@@ -413,7 +413,7 @@ func (c *singleChannelCacheImpl) GetChanges(options ChangesOptions) ([]*LogEntry
 	// overlap, which helps confirm that we've got everything.
 	c.cacheStats.ChannelCacheMisses.Add(1)
 	endSeq := cacheValidFrom
-	resultFromQuery, err := c.queryHandler.getChangesInChannelFromQuery(options.LoggingCtx, c.channelID, startSeq, endSeq, options.Limit, options.ActiveOnly)
+	resultFromQuery, err := c.queryHandler.getChangesInChannelFromQuery(options.LoggingCtx, c.channelID.Name, startSeq, endSeq, options.Limit, options.ActiveOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -836,7 +836,7 @@ type bypassChannelCache struct {
 func (b *bypassChannelCache) GetChanges(options ChangesOptions) ([]*LogEntry, error) {
 	startSeq := options.Since.SafeSequence() + 1
 	endSeq := uint64(math.MaxUint64)
-	return b.queryHandler.getChangesInChannelFromQuery(options.LoggingCtx, b.channel, startSeq, endSeq, options.Limit, options.ActiveOnly)
+	return b.queryHandler.getChangesInChannelFromQuery(options.LoggingCtx, b.channel.Name, startSeq, endSeq, options.Limit, options.ActiveOnly)
 }
 
 // No cached changes for bypassChannelCache

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -41,7 +41,7 @@ func TestDuplicateDocID(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 
-	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	// Add some entries to cache
@@ -98,7 +98,7 @@ func TestLateArrivingSequence(t *testing.T) {
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	// Add some entries to cache
@@ -141,7 +141,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	// Add some entries to cache
@@ -184,7 +184,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	// Add some entries to cache
@@ -269,7 +269,7 @@ func TestPrependChanges(t *testing.T) {
 
 	collectionID := dbCtx.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(dbCtx, channels.NewID("PrependEmptyCache", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(dbCtx.GetSingleDatabaseCollection(), channels.NewID("PrependEmptyCache", collectionID), 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	changesToPrepend := LogEntries{
@@ -291,7 +291,7 @@ func TestPrependChanges(t *testing.T) {
 	require.NoError(t, err)
 	dbstats, err = stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
-	cache = newSingleChannelCache(dbCtx, channels.NewID("PrependPopulatedCache", collectionID), 0, dbstats.Cache())
+	cache = newSingleChannelCache(dbCtx.GetSingleDatabaseCollection(), channels.NewID("PrependPopulatedCache", collectionID), 0, dbstats.Cache())
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
 	cache.addToCache(testLogEntry(20, "doc2", "3-a"), false)
@@ -349,7 +349,7 @@ func TestPrependChanges(t *testing.T) {
 	require.NoError(t, err)
 	dbstats, err = stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
-	cache = newSingleChannelCache(dbCtx, channels.NewID("PrependToFillCache", collectionID), 0, dbstats.Cache())
+	cache = newSingleChannelCache(dbCtx.GetSingleDatabaseCollection(), channels.NewID("PrependToFillCache", collectionID), 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
@@ -390,7 +390,7 @@ func TestPrependChanges(t *testing.T) {
 	require.NoError(t, err)
 	dbstats, err = stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
-	cache = newSingleChannelCache(dbCtx, channels.NewID("PrependDuplicatesOnly", collectionID), 0, dbstats.Cache())
+	cache = newSingleChannelCache(dbCtx.GetSingleDatabaseCollection(), channels.NewID("PrependDuplicatesOnly", collectionID), 0, dbstats.Cache())
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
 	cache.addToCache(testLogEntry(20, "doc2", "3-a"), false)
@@ -424,7 +424,7 @@ func TestPrependChanges(t *testing.T) {
 	require.NoError(t, err)
 	dbstats, err = stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
-	cache = newSingleChannelCache(dbCtx, channels.NewID("PrependFullCache", collectionID), 0, dbstats.Cache())
+	cache = newSingleChannelCache(dbCtx.GetSingleDatabaseCollection(), channels.NewID("PrependFullCache", collectionID), 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
@@ -479,7 +479,7 @@ func TestChannelCacheRemove(t *testing.T) {
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, dbstats.Cache())
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
@@ -529,7 +529,7 @@ func TestChannelCacheStats(t *testing.T) {
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
 	testStats := dbstats.Cache()
-	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, testStats)
+	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, testStats)
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
@@ -609,7 +609,7 @@ func TestChannelCacheStatsOnPrune(t *testing.T) {
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
 	testStats := dbstats.Cache()
-	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 0, testStats)
+	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, testStats)
 	cache.options.ChannelCacheMaxLength = 5
 
 	// Add more than ChannelCacheMaxLength entries to cache
@@ -649,7 +649,7 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
 	testStats := dbstats.Cache()
-	cache := newSingleChannelCache(context, channels.NewID("Test1", collectionID), 99, testStats)
+	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 99, testStats)
 	cache.options.ChannelCacheMaxLength = 15
 
 	// Add 9 entries to cache, 3 of each type
@@ -747,7 +747,7 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
 	docIDs := make([]string, b.N)
 	for i := 0; i < b.N; i++ {
@@ -776,7 +776,7 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(5.0, b.N)
@@ -802,7 +802,7 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(20.0, b.N)
@@ -828,7 +828,7 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(50.0, b.N)
@@ -854,7 +854,7 @@ func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(80.0, b.N)
@@ -880,7 +880,7 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(95.0, b.N)
@@ -906,7 +906,7 @@ func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context, channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate docs
 	docs := make([]*LogEntry, b.N)
 	r := rand.New(rand.NewSource(99))

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -87,10 +87,9 @@ func TestChannelCacheSimpleCompact(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
-	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", options, testQueryHandlerFactory, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 	defer cache.Stop()
 
@@ -128,10 +127,9 @@ func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 	require.NoError(t, err)
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	testStats := dbstats.Cache()
-	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", options, testQueryHandlerFactory, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 	defer cache.Stop()
 
@@ -187,10 +185,9 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
-	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", options, testQueryHandlerFactory, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 	defer cache.Stop()
 
@@ -287,7 +284,7 @@ func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", options, queryHandler.asFactory, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 	defer cache.Stop()
 
@@ -361,7 +358,7 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", options, queryHandler.asFactory, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 	defer cache.Stop()
 
@@ -430,7 +427,7 @@ func TestChannelCacheBypass(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", options, queryHandler.asFactory, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 	defer cache.Stop()
 
@@ -476,17 +473,27 @@ func waitForCompaction(cache *channelCacheImpl) (compactionComplete bool) {
 	return false
 }
 
+// Used for singleChannelCache testing with non-shared testQueryHandler
+func testQueryHandlerFactory(collectionID uint32) (ChannelQueryHandler, error) {
+	return &testQueryHandler{}, nil
+}
+
 type testQueryHandler struct {
 	entries    LogEntries
 	queryCount int
 	lock       sync.RWMutex
 }
 
-func (qh *testQueryHandler) getChangesInChannelFromQuery(ctx context.Context, channel channels.ID, startSeq, endSeq uint64, limit int, activeOnly bool) (LogEntries, error) {
+// Used to initialize channel cache with a shared, single TestQueryHandler
+func (qh *testQueryHandler) asFactory(collectionID uint32) (ChannelQueryHandler, error) {
+	return qh, nil
+}
+
+func (qh *testQueryHandler) getChangesInChannelFromQuery(ctx context.Context, channel string, startSeq, endSeq uint64, limit int, activeOnly bool) (LogEntries, error) {
 	queryEntries := make(LogEntries, 0)
 	qh.lock.RLock()
 	for _, entry := range qh.entries {
-		_, ok := entry.Channels[channel.Name]
+		_, ok := entry.Channels[channel]
 		if ok {
 			if activeOnly && !entry.IsActive() {
 				continue
@@ -527,7 +534,7 @@ func TestChannelCacheBackgroundTaskWithIllegalTimeInterval(t *testing.T) {
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
 
-	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", options, queryHandler.asFactory, activeChannels, testStats)
 	assert.Error(t, err, "Background task error whilst creating channel cache")
 	assert.Nil(t, cache)
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -810,7 +810,8 @@ func TestAllDocsOnly(t *testing.T) {
 	collectionID := collection.GetCollectionID()
 
 	// Trigger creation of the channel cache for channel "all"
-	collection.changeCache.getChannelCache().getSingleChannelCache(channels.NewID("all", collectionID))
+	_, err := collection.changeCache.getChannelCache().getSingleChannelCache(channels.NewID("all", collectionID))
+	require.NoError(t, err)
 
 	ids := make([]AllDocsEntry, 100)
 	for i := 0; i < 100; i++ {
@@ -995,7 +996,8 @@ func TestConflicts(t *testing.T) {
 	collectionID := collection.GetCollectionID()
 
 	allChannel := channels.NewID("all", collectionID)
-	collection.changeCache.getChannelCache().getSingleChannelCache(allChannel)
+	_, err := collection.changeCache.getChannelCache().getSingleChannelCache(allChannel)
+	require.NoError(t, err)
 
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -854,7 +854,8 @@ func TestAllDocsOnly(t *testing.T) {
 	err = collection.changeCache.waitForSequence(ctx, 101, base.DefaultWaitForSequence)
 	require.NoError(t, err)
 
-	changeLog := collection.GetChangeLog(channels.NewID("all", collectionID), 0)
+	changeLog, err := collection.GetChangeLog(channels.NewID("all", collectionID), 0)
+	require.NoError(t, err)
 	require.Len(t, changeLog, 50)
 	assert.Equal(t, "alldoc-51", changeLog[0].DocID)
 
@@ -1006,7 +1007,8 @@ func TestConflicts(t *testing.T) {
 	// Wait for rev to be cached
 	cacheWaiter.AddAndWait(1)
 
-	changeLog := collection.GetChangeLog(channels.NewID("all", collectionID), 0)
+	changeLog, err := collection.GetChangeLog(channels.NewID("all", collectionID), 0)
+	require.NoError(t, err)
 	assert.Equal(t, 1, len(changeLog))
 
 	// Create two conflicting changes:
@@ -1040,7 +1042,8 @@ func TestConflicts(t *testing.T) {
 
 	// Verify the change-log of the "all" channel:
 	cacheWaiter.Wait()
-	changeLog = collection.GetChangeLog(allChannel, 0)
+	changeLog, err = collection.GetChangeLog(allChannel, 0)
+	require.NoError(t, err)
 	assert.Equal(t, 1, len(changeLog))
 	assert.Equal(t, uint64(3), changeLog[0].Sequence)
 	assert.Equal(t, "doc", changeLog[0].DocID)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1003,7 +1003,7 @@ func TestConflicts(t *testing.T) {
 
 	// Create rev 1 of "doc":
 	body := Body{"n": 1, "channels": []string{"all", "1"}}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-a"}, false)
 	assert.NoError(t, err, "add 1-a")
 
 	// Wait for rev to be cached

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -315,7 +315,7 @@ func (h *handler) handleDumpChannel() error {
 	since := h.getIntQuery("since", 0)
 	base.InfofCtx(h.ctx(), base.KeyHTTP, "Dump channel %q", base.UD(channelName))
 
-	chanLog := h.collection.GetChangeLog(ch.NewID(channelName, h.collection.GetCollectionID()), since)
+	chanLog, _ := h.collection.GetChangeLog(ch.NewID(channelName, h.collection.GetCollectionID()), since)
 	if chanLog == nil {
 		return base.HTTPErrorf(http.StatusNotFound, "no such channel")
 	}

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -341,9 +341,9 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 	var feed <-chan *db.ChangeEntry
 	var err error
 	if len(docids) > 0 {
-		feed, err = h.db.GetSingleDatabaseCollectionWithUser().DocIDChangesFeed(h.ctx(), channels, docids, options)
+		feed, err = h.collection.DocIDChangesFeed(h.ctx(), channels, docids, options)
 	} else {
-		feed, err = h.db.GetSingleDatabaseCollectionWithUser().MultiChangesFeed(h.ctx(), channels, options)
+		feed, err = h.collection.MultiChangesFeed(h.ctx(), channels, options)
 	}
 	if err != nil {
 		return err, false

--- a/rest/changesttest/changes_api_test.go
+++ b/rest/changesttest/changes_api_test.go
@@ -2228,6 +2228,7 @@ func TestChangesViewBackfillFromQueryOnly(t *testing.T) {
 
 // Validate that non-contiguous query results (due to limit) are not prepended to the cache
 func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)
 

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -64,12 +64,12 @@ func createCommonRouter(sc *ServerContext, privs handlerPrivs) (root, db, keyspa
 	keyspace.Handle("/_bulk_docs", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handleBulkDocs)).Methods("POST")
 	keyspace.Handle("/_bulk_get", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleBulkGet)).Methods("POST")
 	keyspace.Handle("/_revs_diff", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handleRevsDiff)).Methods("POST")
+	keyspace.Handle("/_changes", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleChanges)).Methods("GET", "HEAD", "POST")
 
 	// Database operations (i.e. multi-collection):
 	dbr := root.PathPrefix("/{db:" + dbRegex + "}/").Subrouter()
 	dbr.StrictSlash(true)
 	dbr.Handle("/_all_docs", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleAllDocs)).Methods("GET", "HEAD", "POST")
-	dbr.Handle("/_changes", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleChanges)).Methods("GET", "HEAD", "POST")
 	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleGetDesignDoc)).Methods("GET", "HEAD")
 	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handlePutDesignDoc)).Methods("PUT")
 	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handleDeleteDesignDoc)).Methods("DELETE")


### PR DESCRIPTION
Moves _changes to keyspace, and assigns collection-specific QueryHandler to singleChannelCaches.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1206/
