### PR TITLE
CBG-2556: Make ISGR checkpointer callbacks deal with pre-parsed SequenceID

### DIFF
--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -59,7 +59,9 @@ type statusFunc func(lastSeq string) *ReplicationStatus
 
 type CheckpointerStats struct {
 	ExpectedSequenceCount     int64
+	ExpectedSequenceLen       int
 	ProcessedSequenceCount    int64
+	ProcessedSequenceLen      int
 	AlreadyKnownSequenceCount int64
 	SetCheckpointCount        int64
 	GetCheckpointHitCount     int64
@@ -252,6 +254,9 @@ func (c *Checkpointer) _updateCheckpointLists() (safeSeq string) {
 
 	// trim expectedSeqs list for all processed seqs
 	c.expectedSeqs = c.expectedSeqs[maxI+1:]
+
+	c.stats.ExpectedSequenceLen = len(c.expectedSeqs)
+	c.stats.ProcessedSequenceLen = len(c.processedSeqs)
 
 	return safeSeq
 }

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -83,7 +83,7 @@ func (apr *ActivePullReplicator) _connect() error {
 	subChangesRequest := SubChangesRequest{
 		Continuous:     apr.config.Continuous,
 		Batch:          apr.config.ChangesBatchSize,
-		Since:          apr.Checkpointer.lastCheckpointSeq,
+		Since:          apr.Checkpointer.lastCheckpointSeq.String(),
 		Filter:         apr.config.Filter,
 		FilterChannels: apr.config.FilterChannels,
 		DocIDs:         apr.config.DocIDs,
@@ -173,7 +173,7 @@ func (apr *ActivePullReplicator) GetStatus() *ReplicationStatus {
 	apr.lock.RLock()
 	defer apr.lock.RUnlock()
 	if apr.Checkpointer != nil {
-		lastSeqPulled = apr.Checkpointer.calculateSafeProcessedSeq()
+		lastSeqPulled = apr.Checkpointer.calculateSafeProcessedSeq().String()
 	}
 	status := apr.getPullStatus(lastSeqPulled)
 	return status

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -241,7 +241,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 		seq, err := bh.collection.LastSequence()
 		return SequenceID{Seq: seq}, err
 	}
-	subChangesParams, err := NewSubChangesParams(bh.loggingCtx, rq, defaultSince, latestSeq, ParseSequenceID)
+	subChangesParams, err := NewSubChangesParams(bh.loggingCtx, rq, defaultSince, latestSeq, ParseJSONSequenceID)
 	if err != nil {
 		return base.HTTPErrorf(http.StatusBadRequest, "Invalid subChanges parameters")
 	}
@@ -606,8 +606,8 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 	}()
 
 	// DocID+RevID -> SeqNo
-	expectedSeqs := make(map[IDAndRev]string, 0)
-	alreadyKnownSeqs := make([]string, 0)
+	expectedSeqs := make(map[IDAndRev]SequenceID, 0)
+	alreadyKnownSeqs := make([]SequenceID, 0)
 
 	for _, change := range changeList {
 		docID := change[1].(string)
@@ -651,7 +651,11 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 			// already have this rev, tell the peer to skip sending it
 			output.Write([]byte("0"))
 			if bh.sgr2PullAlreadyKnownSeqsCallback != nil {
-				alreadyKnownSeqs = append(alreadyKnownSeqs, seqStr(change[0]))
+				seq, err := ParseJSONSequenceID(seqStr(change[0]))
+				if err != nil {
+					base.FatalfCtx(bh.loggingCtx, "bbrks - Unable to parse sequence ID from changes message: %v", err)
+				}
+				alreadyKnownSeqs = append(alreadyKnownSeqs, seq)
 			}
 		} else {
 			// we want this rev, send possible ancestors to the peer
@@ -667,7 +671,11 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 
 			// skip parsing seqno if we're not going to use it (no callback defined)
 			if bh.sgr2PullAddExpectedSeqsCallback != nil {
-				expectedSeqs[IDAndRev{DocID: docID, RevID: revID}] = seqStr(change[0])
+				seq, err := ParseJSONSequenceID(seqStr(change[0]))
+				if err != nil {
+					base.FatalfCtx(bh.loggingCtx, "bbrks - Error parsing sequence: %v", err)
+				}
+				expectedSeqs[IDAndRev{DocID: docID, RevID: revID}] = seq
 			}
 		}
 		nWritten++
@@ -690,17 +698,6 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 	}
 
 	return nil
-}
-
-func seqStr(seq interface{}) string {
-	switch seq := seq.(type) {
-	case string:
-		return seq
-	case json.Number:
-		return seq.String()
-	}
-	base.WarnfCtx(context.Background(), "unknown seq type: %T", seq)
-	return ""
 }
 
 // Handles a "proposeChanges" request, similar to "changes" but in no-conflicts mode
@@ -827,11 +824,17 @@ func (bh *blipHandler) handleNoRev(rq *blip.Message) error {
 		rq.String(), base.UD(rq.Properties[NorevMessageId]), rq.Properties[NorevMessageRev], rq.Properties[NorevMessageError], rq.Properties[NorevMessageReason])
 
 	if bh.sgr2PullProcessedSeqCallback != nil {
+		var seqStr string
 		if bh.blipContext.ActiveSubprotocol() == BlipCBMobileReplicationV2 && bh.clientType == BLIPClientTypeSGR2 {
-			bh.sgr2PullProcessedSeqCallback(rq.Properties[NorevMessageSeq], IDAndRev{DocID: rq.Properties[NorevMessageId], RevID: rq.Properties[NorevMessageRev]})
+			seqStr = rq.Properties[NorevMessageSeq]
 		} else {
-			bh.sgr2PullProcessedSeqCallback(rq.Properties[NorevMessageSequence], IDAndRev{DocID: rq.Properties[NorevMessageId], RevID: rq.Properties[NorevMessageRev]})
+			seqStr = rq.Properties[NorevMessageSequence]
 		}
+		seq, err := ParseJSONSequenceID(seqStr)
+		if err != nil {
+			base.FatalfCtx(bh.loggingCtx, "bbrks - Error parsing sequence %q from norev message: %v", base.UD(seqStr), err)
+		}
+		bh.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: rq.Properties[NorevMessageId], RevID: rq.Properties[NorevMessageRev]})
 	}
 
 	// Couchbase Lite always sends noreply=true for norev profiles
@@ -903,7 +906,11 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 			}
 			stats.docsPurgedCount.Add(1)
 			if bh.sgr2PullProcessedSeqCallback != nil {
-				bh.sgr2PullProcessedSeqCallback(rq.Properties[RevMessageSequence], IDAndRev{DocID: docID, RevID: revID})
+				seq, err := ParseJSONSequenceID(rq.Properties[RevMessageSequence])
+				if err != nil {
+					base.FatalfCtx(bh.loggingCtx, "bbrks - Error parsing sequence %q from rev message: %v", base.UD(rq.Properties[RevMessageSequence]), err)
+				}
+				bh.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: revID})
 			}
 			return nil
 		}
@@ -1113,7 +1120,12 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	}
 
 	if bh.sgr2PullProcessedSeqCallback != nil {
-		bh.sgr2PullProcessedSeqCallback(rq.Properties[RevMessageSequence], IDAndRev{DocID: docID, RevID: revID})
+		seqProperty := rq.Properties[RevMessageSequence]
+		seq, err := ParseJSONSequenceID(seqProperty)
+		if err != nil {
+			base.FatalfCtx(bh.loggingCtx, "bbrks - Error parsing sequence ID from rev message %q: %v", seqProperty, err)
+		}
+		bh.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: revID})
 	}
 
 	return nil

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -677,8 +677,9 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 				if err != nil {
 					// We've already asked for the doc/rev for the sequence so assume we're going to receive it... Just log this and carry on
 					base.WarnfCtx(bh.loggingCtx, "Unable to parse expected sequence %q for %q/%q: %v", change[0], base.UD(docID), revID, err)
+				} else {
+					expectedSeqs[IDAndRev{DocID: docID, RevID: revID}] = seq
 				}
-				expectedSeqs[IDAndRev{DocID: docID, RevID: revID}] = seq
 			}
 		}
 		nWritten++

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -87,24 +87,24 @@ type BlipSyncContext struct {
 	dbUserLock                       sync.RWMutex    // Must be held when refreshing the db user
 	allowedAttachments               map[string]AllowedAttachment
 	allowedAttachmentsLock           sync.Mutex
-	handlerSerialNumber              uint64                                    // Each handler within a context gets a unique serial number for logging
-	terminatorOnce                   sync.Once                                 // Used to ensure the terminator channel below is only ever closed once.
-	terminator                       chan bool                                 // Closed during BlipSyncContext.close(). Ensures termination of async goroutines.
-	activeSubChanges                 base.AtomicBool                           // Flag for whether there is a subChanges subscription currently active.  Atomic access
-	useDeltas                        bool                                      // Whether deltas can be used for this connection - This should be set via setUseDeltas()
-	sgCanUseDeltas                   bool                                      // Whether deltas can be used by Sync Gateway for this connection
-	userChangeWaiter                 *ChangeWaiter                             // Tracks whether the users/roles associated with the replication have changed
-	userName                         string                                    // Avoid contention on db.user during userChangeWaiter user lookup
-	sgr2PullAddExpectedSeqsCallback  func(expectedSeqs map[IDAndRev]string)    // sgr2PullAddExpectedSeqsCallback is called after successfully handling an incoming changes message
-	sgr2PullProcessedSeqCallback     func(remoteSeq string, idAndRev IDAndRev) // sgr2PullProcessedSeqCallback is called after successfully handling an incoming rev message
-	sgr2PullAlreadyKnownSeqsCallback func(alreadyKnownSeqs ...string)          // sgr2PullAlreadyKnownSeqsCallback is called to mark the sequences as being immediately processed
-	sgr2PushAddExpectedSeqsCallback  func(expectedSeqs ...string)              // sgr2PushAddExpectedSeqsCallback is called after sync gateway has sent a revision, but is still awaiting an acknowledgement
-	sgr2PushProcessedSeqCallback     func(remoteSeq string)                    // sgr2PushProcessedSeqCallback is called after receiving acknowledgement of a sent revision
-	sgr2PushAlreadyKnownSeqsCallback func(alreadyKnownSeqs ...string)          // sgr2PushAlreadyKnownSeqsCallback is called to mark the sequence as being immediately processed
-	emptyChangesMessageCallback      func()                                    // emptyChangesMessageCallback is called when an empty changes message is received
-	replicationStats                 *BlipSyncStats                            // Replication stats
-	purgeOnRemoval                   bool                                      // Purges the document when we pull a _removed:true revision.
-	conflictResolver                 *ConflictResolver                         // Conflict resolver for active replications
+	handlerSerialNumber              uint64                                         // Each handler within a context gets a unique serial number for logging
+	terminatorOnce                   sync.Once                                      // Used to ensure the terminator channel below is only ever closed once.
+	terminator                       chan bool                                      // Closed during BlipSyncContext.close(). Ensures termination of async goroutines.
+	activeSubChanges                 base.AtomicBool                                // Flag for whether there is a subChanges subscription currently active.  Atomic access
+	useDeltas                        bool                                           // Whether deltas can be used for this connection - This should be set via setUseDeltas()
+	sgCanUseDeltas                   bool                                           // Whether deltas can be used by Sync Gateway for this connection
+	userChangeWaiter                 *ChangeWaiter                                  // Tracks whether the users/roles associated with the replication have changed
+	userName                         string                                         // Avoid contention on db.user during userChangeWaiter user lookup
+	sgr2PullAddExpectedSeqsCallback  func(expectedSeqs map[IDAndRev]SequenceID)     // sgr2PullAddExpectedSeqsCallback is called after successfully handling an incoming changes message
+	sgr2PullProcessedSeqCallback     func(remoteSeq *SequenceID, idAndRev IDAndRev) // sgr2PullProcessedSeqCallback is called after successfully handling an incoming rev message
+	sgr2PullAlreadyKnownSeqsCallback func(alreadyKnownSeqs ...SequenceID)           // sgr2PullAlreadyKnownSeqsCallback is called to mark the sequences as being immediately processed
+	sgr2PushAddExpectedSeqsCallback  func(expectedSeqs ...SequenceID)               // sgr2PushAddExpectedSeqsCallback is called after sync gateway has sent a revision, but is still awaiting an acknowledgement
+	sgr2PushProcessedSeqCallback     func(remoteSeq SequenceID)                     // sgr2PushProcessedSeqCallback is called after receiving acknowledgement of a sent revision
+	sgr2PushAlreadyKnownSeqsCallback func(alreadyKnownSeqs ...SequenceID)           // sgr2PushAlreadyKnownSeqsCallback is called to mark the sequence as being immediately processed
+	emptyChangesMessageCallback      func()                                         // emptyChangesMessageCallback is called when an empty changes message is received
+	replicationStats                 *BlipSyncStats                                 // Replication stats
+	purgeOnRemoval                   bool                                           // Purges the document when we pull a _removed:true revision.
+	conflictResolver                 *ConflictResolver                              // Conflict resolver for active replications
 	changesCtxLock                   sync.Mutex
 	changesCtx                       context.Context    // Used for the unsub changes Blip message to check if the subChanges feed should stop
 	changesCtxCancel                 context.CancelFunc // Cancel function for changesCtx to cancel subChanges being sent
@@ -312,8 +312,8 @@ func (bsc *BlipSyncContext) handleChangesResponse(sender *blip.Sender, response 
 	// placeholder (probably 0). The item numbers match those of changeArray.
 	var revSendTimeLatency int64
 	var revSendCount int64
-	sentSeqs := make([]string, 0)
-	alreadyKnownSeqs := make([]string, 0)
+	sentSeqs := make([]SequenceID, 0)
+	alreadyKnownSeqs := make([]SequenceID, 0)
 
 	for i, knownRevsArrayInterface := range answer {
 		seq := changeArray[i][0].(SequenceID)
@@ -359,12 +359,12 @@ func (bsc *BlipSyncContext) handleChangesResponse(sender *blip.Sender, response 
 			revSendCount++
 
 			if bsc.sgr2PushAddExpectedSeqsCallback != nil {
-				sentSeqs = append(sentSeqs, seq.String())
+				sentSeqs = append(sentSeqs, seq)
 			}
 		} else {
 			base.DebugfCtx(bsc.loggingCtx, base.KeySync, "Peer didn't want revision %s / %s (seq:%v)", base.UD(docID), revID, seq)
 			if bsc.sgr2PushAlreadyKnownSeqsCallback != nil {
-				alreadyKnownSeqs = append(alreadyKnownSeqs, seq.String())
+				alreadyKnownSeqs = append(alreadyKnownSeqs, seq)
 			}
 		}
 	}
@@ -481,7 +481,7 @@ func (bsc *BlipSyncContext) sendRevisionWithProperties(sender *blip.Sender, docI
 			bsc.removeAllowedAttachments(docID, attMeta, activeSubprotocol)
 
 			if bsc.sgr2PushProcessedSeqCallback != nil {
-				bsc.sgr2PushProcessedSeqCallback(seq.String())
+				bsc.sgr2PushProcessedSeqCallback(seq)
 			}
 		}(activeSubprotocol)
 	}
@@ -577,7 +577,7 @@ func (bsc *BlipSyncContext) sendNoRev(sender *blip.Sender, docID, revID string, 
 	}
 
 	if bsc.sgr2PushProcessedSeqCallback != nil {
-		bsc.sgr2PushProcessedSeqCallback(seq.String())
+		bsc.sgr2PushProcessedSeqCallback(seq)
 	}
 
 	return nil

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -166,7 +166,7 @@ func NewSubChangesParams(logCtx context.Context, rq *blip.Message, zeroSeq Seque
 	if rq.Properties["future"] == trueProperty {
 		sinceSequenceId, err = latestSeq()
 	} else if sinceStr, found := rq.Properties[SubChangesSince]; found {
-		if sinceSequenceId, err = sequenceIDParser(base.ConvertJSONString(sinceStr)); err != nil {
+		if sinceSequenceId, err = sequenceIDParser(sinceStr); err != nil {
 			base.InfofCtx(logCtx, base.KeySync, "%s: Invalid sequence ID in 'since': %s", rq, sinceStr)
 		}
 	}

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -147,7 +147,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	assert.True(t, changes[2].principalDoc)
 
 	lastSeq := getLastSeq(changes)
-	lastSeq, _ = ParseSequenceID(lastSeq.String())
+	lastSeq, _ = ParsePlainSequenceID(lastSeq.String())
 
 	// Add a new doc (sequence 3):
 	revid, _, err := collection.Put(ctx, "doc2", Body{"channels": []string{"PBS"}})
@@ -238,7 +238,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 		collectionID: collectionID}, changes[0])
 
 	lastSeq := getLastSeq(changes)
-	lastSeq, _ = ParseSequenceID(lastSeq.String())
+	lastSeq, _ = ParsePlainSequenceID(lastSeq.String())
 
 	// Get raw document from the bucket
 	rv, _, _ := collection.dataStore.GetRaw("alpha") // cas, err
@@ -324,7 +324,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 		collectionID: collectionID}, changes[0])
 
 	lastSeq := getLastSeq(changes)
-	lastSeq, _ = ParseSequenceID(lastSeq.String())
+	lastSeq, _ = ParsePlainSequenceID(lastSeq.String())
 
 	// Get raw document from the bucket
 	rv, _, _ := collection.dataStore.GetRaw("alpha") // cas, err

--- a/db/sequence_id.go
+++ b/db/sequence_id.go
@@ -185,6 +185,10 @@ func (s SequenceID) Equals(s2 SequenceID) bool {
 func (s SequenceID) Before(s2 SequenceID) bool {
 	// using SafeSequence for comparison, which takes the lower of LowSeq and Seq
 	if s.TriggeredBy == s2.TriggeredBy {
+		if s.SafeSequence() == s2.SafeSequence() {
+			// If both are equal, one sequence must be a non-zero LowSeq - sort those after the actual sequence.
+			return s.Seq < s2.Seq
+		}
 		return s.SafeSequence() < s2.SafeSequence() // the simple case: untriggered, or triggered by same sequence
 	} else if s.TriggeredBy == 0 {
 		return s.SafeSequence() < s2.TriggeredBy // s2 triggered but not s

--- a/db/sequence_id.go
+++ b/db/sequence_id.go
@@ -11,6 +11,8 @@ licenses/APL2.txt.
 package db
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
@@ -66,9 +68,26 @@ func (s SequenceID) intSeqToString() string {
 	}
 }
 
-// Currently accepts a plain string, but in the future might accept generic JSON objects.
-// Calling this with a JSON string will result in an error.
-func ParseSequenceID(str string) (s SequenceID, err error) {
+func seqStr(seq interface{}) string {
+	switch seq := seq.(type) {
+	case string:
+		return seq
+	case json.Number:
+		return seq.String()
+	}
+	base.WarnfCtx(context.Background(), "unknown seq type: %T", seq)
+	return ""
+}
+
+// ParseJSONSequenceID will parse a JSON string sequence ID. (e.g. accepts: `"1::3"`, `2`, and also a plain sequence like `1::3`)
+func ParseJSONSequenceID(str string) (SequenceID, error) {
+	plainStr := base.ConvertJSONString(str)
+	return ParsePlainSequenceID(plainStr)
+}
+
+// ParsePlainSequenceID will parse a plain sequence string - but not a JSON sequence string (e.g. accepts: `1::3` but not `"1::3"`)
+// Calling this with a JSON string will result in an error. Use ParseJSONSequenceID instead.
+func ParsePlainSequenceID(str string) (s SequenceID, err error) {
 	return parseIntegerSequenceID(str)
 }
 

--- a/db/sequence_id_test.go
+++ b/db/sequence_id_test.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -156,6 +157,24 @@ func TestCompareSequenceIDs(t *testing.T) {
 	for i := 0; i < len(orderedSeqs); i++ {
 		for j := 0; j < len(orderedSeqs); j++ {
 			assert.Equal(t, i < j, orderedSeqs[i].Before(orderedSeqs[j]))
+		}
+	}
+}
+
+func TestCompareSequenceIDsLowSeq(t *testing.T) {
+	orderedSeqs := []SequenceID{
+		{LowSeq: 1200, Seq: 1233},
+		{LowSeq: 1205, Seq: 1234},
+		{Seq: 1234},
+		{LowSeq: 1234, Seq: 5677},
+		{LowSeq: 1234, Seq: 5678},
+	}
+
+	for i := 0; i < len(orderedSeqs); i++ {
+		for j := 0; j < len(orderedSeqs); j++ {
+			t.Run(fmt.Sprintf("%v<%v==%v", orderedSeqs[i], orderedSeqs[j], i < j), func(t *testing.T) {
+				assert.Equalf(t, i < j, orderedSeqs[i].Before(orderedSeqs[j]), "expected %v < %v", orderedSeqs[i], orderedSeqs[j])
+			})
 		}
 	}
 }

--- a/rest/blip_sync_messages_test.go
+++ b/rest/blip_sync_messages_test.go
@@ -80,7 +80,7 @@ func TestSubChangesSince(t *testing.T) {
 	rq := blip.NewRequest()
 	rq.Properties["since"] = `"1"`
 
-	subChangesParams, err := db.NewSubChangesParams(base.TestCtx(t), rq, db.SequenceID{}, nil, db.ParseSequenceID)
+	subChangesParams, err := db.NewSubChangesParams(base.TestCtx(t), rq, db.SequenceID{}, nil, db.ParseJSONSequenceID)
 	require.NoError(t, err)
 
 	seqID := subChangesParams.Since()
@@ -102,7 +102,7 @@ func TestSubChangesFuture(t *testing.T) {
 	rq.Properties["future"] = "true"
 	rq.Properties["since"] = `"1"`
 
-	subChangesParams, err := db.NewSubChangesParams(base.TestCtx(t), rq, db.SequenceID{}, latestSeq, db.ParseSequenceID)
+	subChangesParams, err := db.NewSubChangesParams(base.TestCtx(t), rq, db.SequenceID{}, latestSeq, db.ParseJSONSequenceID)
 	require.NoError(t, err)
 
 	seqID := subChangesParams.Since()

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -84,7 +84,7 @@ func (h *handler) updateChangesOptionsFromQuery(feed *string, options *db.Change
 	}
 
 	if _, ok := values["since"]; ok {
-		if options.Since, err = db.ParseSequenceID(h.getJSONStringQuery("since")); err != nil {
+		if options.Since, err = db.ParsePlainSequenceID(h.getJSONStringQuery("since")); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -127,7 +127,7 @@ func (h *handler) updateChangesOptionsFromQuery(feed *string, options *db.Change
 				}
 			} else {
 				// This is not a JSON array so treat as a simple
-				//comma separated list of doc id's
+				// comma separated list of doc id's
 				docIdsArray = strings.Split(docidsParam, ",")
 			}
 		}
@@ -172,7 +172,7 @@ func (h *handler) handleChanges() error {
 		// GET request has parameters in URL:
 		feed = h.getQuery("feed")
 		var err error
-		if options.Since, err = db.ParseSequenceID(h.getJSONStringQuery("since")); err != nil {
+		if options.Since, err = db.ParsePlainSequenceID(h.getJSONStringQuery("since")); err != nil {
 			return err
 		}
 		options.Limit = int(h.getIntQuery("limit", 0))
@@ -196,7 +196,7 @@ func (h *handler) handleChanges() error {
 				}
 			} else {
 				// This is not a JSON array so treat as a simple
-				//comma separated list of doc id's
+				// comma separated list of doc id's
 				docIdsArray = strings.Split(docidsParam, ",")
 			}
 		}
@@ -509,8 +509,8 @@ func (h *handler) sendContinuousChangesByWebSocket(inChannels base.Set, options 
 		}
 
 		// Copy options.ChangesCtx to new WebSocket options
-		//options.ChangesCtx will be cancelled automatically when
-		//changes feed completes
+		// options.ChangesCtx will be cancelled automatically when
+		// changes feed completes
 		wsoptions.ChangesCtx = options.ChangesCtx
 
 		// Set up GZip compression

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1957,8 +1957,10 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().AlreadyKnownSequenceCount)
 	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ProcessedSequenceCount)
 
-	assert.Equal(t, 0, ar.Pull.Checkpointer.Stats().ExpectedSequenceLen)
-	assert.Equal(t, 0, ar.Pull.Checkpointer.Stats().ProcessedSequenceLen)
+	assert.Equal(t, 1, ar.Pull.Checkpointer.Stats().ExpectedSequenceLen)
+	assert.Equal(t, 1, ar.Pull.Checkpointer.Stats().ProcessedSequenceLen)
+	assert.Equal(t, 0, ar.Pull.Checkpointer.Stats().ExpectedSequenceLenPostCleanup)
+	assert.Equal(t, 0, ar.Pull.Checkpointer.Stats().ProcessedSequenceLenPostCleanup)
 
 	docID2 := docIDPrefix + "2"
 	resp = rt2.SendAdminRequest(http.MethodPut, "/db/"+docID2, `{"source":"rt2","channels":["`+username+`"]}`)
@@ -1986,8 +1988,10 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().AlreadyKnownSequenceCount)
 	assert.Equal(t, int64(2), ar.Pull.Checkpointer.Stats().ProcessedSequenceCount)
 
-	assert.Equal(t, 0, ar.Pull.Checkpointer.Stats().ExpectedSequenceLen)
-	assert.Equal(t, 0, ar.Pull.Checkpointer.Stats().ProcessedSequenceLen)
+	assert.Equal(t, 2, ar.Pull.Checkpointer.Stats().ExpectedSequenceLen)
+	assert.Equal(t, 2, ar.Pull.Checkpointer.Stats().ProcessedSequenceLen)
+	assert.Equal(t, 0, ar.Pull.Checkpointer.Stats().ExpectedSequenceLenPostCleanup)
+	assert.Equal(t, 0, ar.Pull.Checkpointer.Stats().ProcessedSequenceLenPostCleanup)
 
 	docID4 := docIDPrefix + "4"
 	resp = rt2.SendAdminRequest(http.MethodPut, "/db/"+docID4, `{"source":"rt2","channels":["`+username+`"]}`)
@@ -2005,8 +2009,10 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().AlreadyKnownSequenceCount)
 	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ProcessedSequenceCount)
 
-	assert.Equal(t, 0, ar.Pull.Checkpointer.Stats().ExpectedSequenceLen)
-	assert.Equal(t, 0, ar.Pull.Checkpointer.Stats().ProcessedSequenceLen)
+	assert.Equal(t, 1, ar.Pull.Checkpointer.Stats().ExpectedSequenceLen)
+	assert.Equal(t, 1, ar.Pull.Checkpointer.Stats().ProcessedSequenceLen)
+	assert.Equal(t, 0, ar.Pull.Checkpointer.Stats().ExpectedSequenceLenPostCleanup)
+	assert.Equal(t, 0, ar.Pull.Checkpointer.Stats().ProcessedSequenceLenPostCleanup)
 }
 
 // TestActiveReplicatorPullAttachments:

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -2002,7 +2002,7 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 
 	require.NoError(t, ar.Stop())
 	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ExpectedSequenceCount)
-	assert.Equal(t, int64(2), ar.Pull.Checkpointer.Stats().AlreadyKnownSequenceCount)
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().AlreadyKnownSequenceCount)
 	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ProcessedSequenceCount)
 
 	assert.Equal(t, 0, ar.Pull.Checkpointer.Stats().ExpectedSequenceLen)


### PR DESCRIPTION
CBG-2556: Make ISGR checkpointer callbacks deal with pre-parsed `SequenceID`s
- The checkpoint format has not changed. That remains a plain non-JSON-encoded string.

This has two benefits:
1. efficiency gains due to not re-parsing sequence numbers whenever we run a checkpoint
2. consistency for sequence number formatting across checkpointer expected/processed lists

@adamcfraser I would like a review especially around testing of this (I added 4 internal checkpointer stats to track lengths of sequence sets, but I'm not sure this is ideal)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true,gsi=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1211/