### PR TITLE
CBG-2333 Support multi-collection changesCache and _changes

### DIFF
--- a/auth/collection_access_test.go
+++ b/auth/collection_access_test.go
@@ -207,3 +207,70 @@ func TestSerializeUserWithCollections(t *testing.T) {
 	assert.Equal(t, 0, len(collectionAccess.ExplicitChannels_))
 	assert.Equal(t, uint64(2), user.getCollectionChannelInvalSeq(scope, collection))
 }
+
+func TestPrincipalConfigSetExplicitChannels(t *testing.T) {
+
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+
+	userName := "bernard"
+	config := &PrincipalConfig{
+		Name: &userName,
+	}
+
+	config.SetExplicitChannels("scope1", "collection1", "ABC", "DEF")
+	assert.Equal(t, config.CollectionAccess, map[string]map[string]*CollectionAccessConfig{
+		"scope1": {
+			"collection1": &CollectionAccessConfig{
+				ExplicitChannels_: base.SetOf("ABC", "DEF"),
+			},
+		},
+	})
+
+	config.SetExplicitChannels("scope2", "collection1", "GHI")
+	assert.Equal(t, config.CollectionAccess, map[string]map[string]*CollectionAccessConfig{
+		"scope1": {
+			"collection1": &CollectionAccessConfig{
+				ExplicitChannels_: base.SetOf("ABC", "DEF"),
+			},
+		},
+		"scope2": {
+			"collection1": &CollectionAccessConfig{
+				ExplicitChannels_: base.SetOf("GHI"),
+			},
+		},
+	})
+	config.SetExplicitChannels("scope1", "collection2", "JKL")
+	assert.Equal(t, config.CollectionAccess, map[string]map[string]*CollectionAccessConfig{
+		"scope1": {
+			"collection1": &CollectionAccessConfig{
+				ExplicitChannels_: base.SetOf("ABC", "DEF"),
+			},
+			"collection2": &CollectionAccessConfig{
+				ExplicitChannels_: base.SetOf("JKL"),
+			},
+		},
+		"scope2": {
+			"collection1": &CollectionAccessConfig{
+				ExplicitChannels_: base.SetOf("GHI"),
+			},
+		},
+	})
+	config.SetExplicitChannels("scope1", "collection1", "MNO")
+	assert.Equal(t, config.CollectionAccess, map[string]map[string]*CollectionAccessConfig{
+		"scope1": {
+			"collection1": &CollectionAccessConfig{
+				ExplicitChannels_: base.SetOf("MNO"),
+			},
+			"collection2": &CollectionAccessConfig{
+				ExplicitChannels_: base.SetOf("JKL"),
+			},
+		},
+		"scope2": {
+			"collection1": &CollectionAccessConfig{
+				ExplicitChannels_: base.SetOf("GHI"),
+			},
+		},
+	})
+
+}

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -222,3 +222,33 @@ func (u PrincipalConfig) Merge(other PrincipalConfig) PrincipalConfig {
 		JWTLastUpdated:    base.Coalesce(other.JWTLastUpdated, u.JWTLastUpdated),
 	}
 }
+
+// Helper function to set explicit channels for a collection
+func (u *PrincipalConfig) SetExplicitChannels(scopeName, collectionName string, channels ...string) {
+	channelSet := base.SetFromArray(channels)
+	if u.CollectionAccess == nil {
+		u.CollectionAccess = map[string]map[string]*CollectionAccessConfig{
+			scopeName: {
+				collectionName: {
+					ExplicitChannels_: channelSet,
+				},
+			},
+		}
+		return
+	}
+	if scope, ok := u.CollectionAccess[scopeName]; !ok {
+		u.CollectionAccess[scopeName] = map[string]*CollectionAccessConfig{
+			collectionName: {
+				ExplicitChannels_: channelSet,
+			},
+		}
+	} else {
+		if collection, ok := scope[collectionName]; !ok {
+			scope[collectionName] = &CollectionAccessConfig{
+				ExplicitChannels_: channelSet,
+			}
+		} else {
+			collection.ExplicitChannels_ = channelSet
+		}
+	}
+}

--- a/auth/user.go
+++ b/auth/user.go
@@ -79,7 +79,7 @@ func (auth *Authenticator) defaultGuestUser() User {
 
 // Creates a new User object. Intended for test usage, for simplified channel assignment.
 // The specified channels are granted to the user as admin grants for
-// all collections defined in the authenticator.  If no collections are defined, the channels
+// all collections defined in the authenticator, at sequence 1.  If no collections are defined, the channels
 // are granted for the default collection.
 func (auth *Authenticator) NewUser(username string, password string, channels base.Set) (User, error) {
 	user := &userImpl{

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -774,6 +774,11 @@ func (c *changeCache) _addToCache(change *LogEntry) []channels.ID {
 		return nil
 	}
 
+	// FIXME: Until CBG-2333, changeCache will perform sequence buffering for all collections, but should not cache
+	if change.CollectionID != c.collection.GetCollectionID() {
+		return nil
+	}
+
 	// updatedChannels tracks the set of channels that should be notified of the change.  This includes
 	// the change's active channels, as well as any channel removals for the active revision.
 	updatedChannels := c.channelCache.AddToCache(change)

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -231,7 +231,7 @@ func (listener *changeListener) Stop() {
 	}
 }
 
-func (listener changeListener) TapFeed() base.TapFeed {
+func (listener *changeListener) TapFeed() base.TapFeed {
 	return listener.tapFeed
 }
 

--- a/db/database.go
+++ b/db/database.go
@@ -682,8 +682,8 @@ func (context *DatabaseContext) GetOIDCProvider(providerName string) (*auth.OIDC
 }
 
 // Registers an on change callback.  Each change cache (per collection) will register here
-func (context *DatabaseContext) RegisterOnChangeCallback(collectionID uint32, callback DocChangedFunc) {
-	context.mutationListener.RegisterOnChangeCallback(collectionID, callback)
+func (context *DatabaseContext) RegisterOnChangeCallback(collectionID uint32, callback DocChangedFunc) error {
+	return context.mutationListener.RegisterOnChangeCallback(collectionID, callback)
 }
 
 func (dbCtx *DatabaseContext) GetServerUUID(ctx context.Context) string {
@@ -2133,7 +2133,10 @@ func newDatabaseCollection(ctx context.Context, dbContext *DatabaseContext, data
 		return nil, err
 	}
 	// Set the DB Context notifyChange callback to call back the changecache DocChanged callback
-	dbContext.RegisterOnChangeCallback(dbCollection.GetCollectionID(), dbCollection.changeCache.DocChanged)
+	err = dbContext.RegisterOnChangeCallback(dbCollection.GetCollectionID(), dbCollection.changeCache.DocChanged)
+	if err != nil {
+		base.DebugfCtx(ctx, base.KeyDCP, "Error registering the listener callback for collection %s: %v", dbCollection.GetCollectionID(), err)
+	}
 
 	if base.IsEnterpriseEdition() {
 		cfgSG, ok := dbContext.CfgSG.(*base.CfgSG)

--- a/db/database.go
+++ b/db/database.go
@@ -2136,6 +2136,7 @@ func newDatabaseCollection(ctx context.Context, dbContext *DatabaseContext, data
 	err = dbContext.RegisterOnChangeCallback(dbCollection.GetCollectionID(), dbCollection.changeCache.DocChanged)
 	if err != nil {
 		base.DebugfCtx(ctx, base.KeyDCP, "Error registering the listener callback for collection %s: %v", dbCollection.GetCollectionID(), err)
+		return nil, err
 	}
 
 	if base.IsEnterpriseEdition() {

--- a/rest/changesttest/changes_collection_test.go
+++ b/rest/changesttest/changes_collection_test.go
@@ -73,6 +73,7 @@ func TestMultiCollectionChangesAdmin(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/"+c2Keyspace+"/abc2", `{"value":1, "channels":["ABC"]}`)
 	rest.RequireStatus(t, response, 201)
+	_ = rt.WaitForPendingChanges()
 
 	changesResponse = rt.SendAdminRequest("GET", "/"+c1Keyspace+"/_changes?since=0", "")
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
@@ -112,7 +113,6 @@ func TestMultiCollectionChangesAdminSameChannelName(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/"+c2Keyspace+"/pbs1_c2", `{"value":1, "channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-
 	_ = rt.WaitForPendingChanges()
 
 	var changes struct {
@@ -138,6 +138,7 @@ func TestMultiCollectionChangesAdminSameChannelName(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/"+c2Keyspace+"/pbs2_c2", `{"value":1, "channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
+	_ = rt.WaitForPendingChanges()
 
 	changesResponse = rt.SendAdminRequest("GET", "/"+c1Keyspace+"/_changes?since=0", "")
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
@@ -184,7 +185,6 @@ func TestMultiCollectionChangesUser(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/"+c2Keyspace+"/pbs1_c2", `{"value":1, "channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-
 	_ = rt.WaitForPendingChanges()
 
 	var changes struct {
@@ -210,6 +210,7 @@ func TestMultiCollectionChangesUser(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/"+c2Keyspace+"/pbs2_c2", `{"value":1, "channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
+	_ = rt.WaitForPendingChanges()
 
 	changesResponse = rt.SendUserRequest("GET", "/"+c1Keyspace+"/_changes?since=0", "", "bernard")
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
@@ -262,7 +263,6 @@ func TestMultiCollectionChangesUserDynamicGrant(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/"+c2Keyspace+"/abc1_c2", `{"value":1, "channels":["ABC"]}`)
 	rest.RequireStatus(t, response, 201)
-
 	_ = rt.WaitForPendingChanges()
 
 	var changes struct {
@@ -341,7 +341,6 @@ func TestMultiCollectionChangesUserDynamicGrantDCP(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/"+c2Keyspace+"/abc1_c2", `{"value":1, "channels":["ABC"]}`)
 	rest.RequireStatus(t, response, 201)
-
 	_ = rt.WaitForPendingChanges()
 
 	var changes struct {

--- a/rest/changesttest/changes_collection_test.go
+++ b/rest/changesttest/changes_collection_test.go
@@ -1,0 +1,456 @@
+//  Copyright 2022-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+package changestest
+
+import (
+	"log"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/channels"
+
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/rest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiCollectionChangesAdmin(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyChanges, base.KeyCache)
+	testBucket := base.GetTestBucket(t)
+	scopesConfig, keyspaces := getMultiCollectionConfig(t, testBucket, 2)
+	rtConfig := &rest.RestTesterConfig{
+		CustomTestBucket: testBucket,
+		DatabaseConfig: &rest.DatabaseConfig{
+			DbConfig: rest.DbConfig{
+				Scopes: scopesConfig,
+			},
+		},
+	}
+
+	c1Keyspace := keyspaces[0]
+	c2Keyspace := keyspaces[1]
+
+	rt := rest.NewRestTester(t, rtConfig)
+	defer rt.Close()
+
+	// Put several documents, will be retrieved via query
+	response := rt.SendAdminRequest("PUT", "/"+c1Keyspace+"/pbs1", `{"value":1, "channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/"+c2Keyspace+"/abc1", `{"value":1, "channel":["ABC"]}`)
+	rest.RequireStatus(t, response, 201)
+
+	_ = rt.WaitForPendingChanges()
+
+	var changes struct {
+		Results  []db.ChangeEntry
+		Last_Seq db.SequenceID
+	}
+
+	// Issue changes request.  Will initialize cache for channels, and return docs via query
+	changesResponse := rt.SendAdminRequest("GET", "/"+c1Keyspace+"/_changes?since=0", "")
+	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 1)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+
+	changesResponse = rt.SendAdminRequest("GET", "/"+c2Keyspace+"/_changes?since=0", "")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 1)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+
+	// Put more documents, should be served via DCP/cache
+	response = rt.SendAdminRequest("PUT", "/"+c1Keyspace+"/pbs2", `{"value":1, "channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/"+c2Keyspace+"/abc2", `{"value":1, "channel":["ABC"]}`)
+	rest.RequireStatus(t, response, 201)
+
+	changesResponse = rt.SendAdminRequest("GET", "/"+c1Keyspace+"/_changes?since=0", "")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 2)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+
+	changesResponse = rt.SendAdminRequest("GET", "/"+c2Keyspace+"/_changes?since=0", "")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 2)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+}
+
+func TestMultiCollectionChangesAdminSameChannelName(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyChanges, base.KeyCache)
+	testBucket := base.GetTestBucket(t)
+	scopesConfig, keyspaces := getMultiCollectionConfig(t, testBucket, 2)
+	rtConfig := &rest.RestTesterConfig{
+		CustomTestBucket: testBucket,
+		DatabaseConfig: &rest.DatabaseConfig{
+			DbConfig: rest.DbConfig{
+				Scopes: scopesConfig,
+			},
+		},
+	}
+
+	c1Keyspace := keyspaces[0]
+	c2Keyspace := keyspaces[1]
+
+	rt := rest.NewRestTester(t, rtConfig)
+	defer rt.Close()
+
+	// Put several documents, will be retrieved via query
+	response := rt.SendAdminRequest("PUT", "/"+c1Keyspace+"/pbs1_c1", `{"value":1, "channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/"+c2Keyspace+"/pbs1_c2", `{"value":1, "channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+
+	_ = rt.WaitForPendingChanges()
+
+	var changes struct {
+		Results  []db.ChangeEntry
+		Last_Seq db.SequenceID
+	}
+
+	// Issue changes request.  Will initialize cache for channels, and return docs via query
+	changesResponse := rt.SendAdminRequest("GET", "/"+c1Keyspace+"/_changes?since=0", "")
+	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 1)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+
+	changesResponse = rt.SendAdminRequest("GET", "/"+c2Keyspace+"/_changes?since=0", "")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 1)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+
+	// Put more documents, should be served via DCP/cache
+	response = rt.SendAdminRequest("PUT", "/"+c1Keyspace+"/pbs2_c1", `{"value":1, "channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/"+c2Keyspace+"/pbs2_c2", `{"value":1, "channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+
+	changesResponse = rt.SendAdminRequest("GET", "/"+c1Keyspace+"/_changes?since=0", "")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 2)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+
+	changesResponse = rt.SendAdminRequest("GET", "/"+c2Keyspace+"/_changes?since=0", "")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 2)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+}
+
+func TestMultiCollectionChangesUser(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyChanges, base.KeyCache, base.KeyCRUD)
+	testBucket := base.GetTestBucket(t)
+	scopesConfig, keyspaces := getMultiCollectionConfig(t, testBucket, 2)
+	rtConfig := &rest.RestTesterConfig{
+		CustomTestBucket: testBucket,
+		DatabaseConfig: &rest.DatabaseConfig{
+			DbConfig: rest.DbConfig{
+				Scopes: scopesConfig,
+			},
+		},
+	}
+
+	c1Keyspace := keyspaces[0]
+	c2Keyspace := keyspaces[1]
+
+	rt := rest.NewRestTester(t, rtConfig)
+	defer rt.Close()
+
+	// Create user with access to channel PBS in both collections
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "PBS"))
+	assert.NoError(t, err)
+	assert.NoError(t, a.Save(bernard))
+
+	// Put several documents, will be retrieved via query
+	response := rt.SendAdminRequest("PUT", "/"+c1Keyspace+"/pbs1_c1", `{"value":1, "channels":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/"+c2Keyspace+"/pbs1_c2", `{"value":1, "channels":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+
+	_ = rt.WaitForPendingChanges()
+
+	var changes struct {
+		Results  []db.ChangeEntry
+		Last_Seq db.SequenceID
+	}
+
+	// Issue changes request.  Will initialize cache for channels, and return docs via query
+	changesResponse := rt.SendUserRequest("GET", "/"+c1Keyspace+"/_changes?since=0", "", "bernard")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 1)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+
+	changesResponse = rt.SendUserRequest("GET", "/"+c2Keyspace+"/_changes?since=0", "", "bernard")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 1)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+
+	// Put more documents, should be served via DCP/cache
+	response = rt.SendAdminRequest("PUT", "/"+c1Keyspace+"/pbs2_c1", `{"value":1, "channels":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/"+c2Keyspace+"/pbs2_c2", `{"value":1, "channels":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+
+	changesResponse = rt.SendUserRequest("GET", "/"+c1Keyspace+"/_changes?since=0", "", "bernard")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 2)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+
+	changesResponse = rt.SendUserRequest("GET", "/"+c2Keyspace+"/_changes?since=0", "", "bernard")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 2)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+}
+
+// TestMultiCollectionChangesUserDynamicGrant tests a dynamic channel grant when that channel is not already resident
+// in the cache (post-grant changes triggers query backfill of the cache)
+func TestMultiCollectionChangesUserDynamicGrant(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyChanges, base.KeyCache, base.KeyCRUD)
+	testBucket := base.GetTestBucket(t)
+	scopesConfig, keyspaces := getMultiCollectionConfig(t, testBucket, 2)
+	rtConfig := &rest.RestTesterConfig{
+		CustomTestBucket: testBucket,
+		DatabaseConfig: &rest.DatabaseConfig{
+			DbConfig: rest.DbConfig{
+				Scopes: scopesConfig,
+			},
+		},
+	}
+
+	c1Keyspace := keyspaces[0]
+	c2Keyspace := keyspaces[1]
+
+	rt := rest.NewRestTester(t, rtConfig)
+	defer rt.Close()
+
+	// Create user with access to channel PBS in both collections
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "PBS"))
+	assert.NoError(t, err)
+	assert.NoError(t, a.Save(bernard))
+
+	// Put several documents
+	response := rt.SendAdminRequest("PUT", "/"+c1Keyspace+"/pbs1_c1", `{"value":1, "channels":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/"+c1Keyspace+"/abc1_c1", `{"value":1, "channels":["ABC"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/"+c2Keyspace+"/pbs1_c2", `{"value":1, "channels":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/"+c2Keyspace+"/abc1_c2", `{"value":1, "channels":["ABC"]}`)
+	rest.RequireStatus(t, response, 201)
+
+	_ = rt.WaitForPendingChanges()
+
+	var changes struct {
+		Results  []db.ChangeEntry
+		Last_Seq db.SequenceID
+	}
+
+	// Issue changes request.  Will initialize cache for channels, and return docs via query
+	changesResponse := rt.SendUserRequest("GET", "/"+c1Keyspace+"/_changes?since=0", "", "bernard")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 1)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+
+	changesResponse = rt.SendUserRequest("GET", "/"+c2Keyspace+"/_changes?since=0", "", "bernard")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 1)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+	lastSeq := changes.Last_Seq
+
+	// Grant user access to channel ABC in collection 1
+	err = rt.SetAdminChannels("bernard", c1Keyspace, "ABC", "PBS")
+	require.NoError(t, err)
+
+	// confirm that change from c1 is sent, along with user doc
+	changesResponse = rt.SendUserRequest("GET", "/"+c1Keyspace+"/_changes?since="+lastSeq.String(), "", "bernard")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 2)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+
+	// Confirm that access hasn't been granted in c2, expect only user doc
+	changesResponse = rt.SendUserRequest("GET", "/"+c2Keyspace+"/_changes?since="+lastSeq.String(), "", "bernard")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 1)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+}
+
+// TestMultiCollectionChangesUserDynamicGrant tests a dynamic channel grant when that channel is resident
+// in the cache (verifies cache buffering of principals)
+func TestMultiCollectionChangesUserDynamicGrantDCP(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyChanges, base.KeyCache, base.KeyCRUD)
+	testBucket := base.GetTestBucket(t)
+	scopesConfig, keyspaces := getMultiCollectionConfig(t, testBucket, 2)
+	rtConfig := &rest.RestTesterConfig{
+		CustomTestBucket: testBucket,
+		DatabaseConfig: &rest.DatabaseConfig{
+			DbConfig: rest.DbConfig{
+				Scopes: scopesConfig,
+			},
+		},
+	}
+
+	c1Keyspace := keyspaces[0]
+	c2Keyspace := keyspaces[1]
+
+	rt := rest.NewRestTester(t, rtConfig)
+	defer rt.Close()
+
+	// Create user with access to channel PBS in both collections
+	ctx := rt.Context()
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
+	bernard, err := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "PBS"))
+	assert.NoError(t, err)
+	assert.NoError(t, a.Save(bernard))
+
+	// Put several documents
+	response := rt.SendAdminRequest("PUT", "/"+c1Keyspace+"/pbs1_c1", `{"value":1, "channels":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/"+c1Keyspace+"/abc1_c1", `{"value":1, "channels":["ABC"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/"+c2Keyspace+"/pbs1_c2", `{"value":1, "channels":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/"+c2Keyspace+"/abc1_c2", `{"value":1, "channels":["ABC"]}`)
+	rest.RequireStatus(t, response, 201)
+
+	_ = rt.WaitForPendingChanges()
+
+	var changes struct {
+		Results  []db.ChangeEntry
+		Last_Seq db.SequenceID
+	}
+
+	// Issue changes request.  Will initialize cache for user channel (PBS), and return docs via query
+	changesResponse := rt.SendUserRequest("GET", "/"+c1Keyspace+"/_changes?since=0", "", "bernard")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 1)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+
+	changesResponse = rt.SendUserRequest("GET", "/"+c2Keyspace+"/_changes?since=0", "", "bernard")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 1)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+	lastSeq := changes.Last_Seq
+
+	// Issue admin changes request for channel ABC, to initialize cache for that channel in each collection
+	changesResponse = rt.SendAdminRequest("GET", "/"+c1Keyspace+"/_changes?filter=sync_gateway/bychannel&channels=ABC", "")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 1)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+
+	changesResponse = rt.SendAdminRequest("GET", "/"+c2Keyspace+"/_changes?filter=sync_gateway/bychannel&channels=ABC", "")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, 1)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+
+	// Grant user access to channel ABC in collection 1
+	err = rt.SetAdminChannels("bernard", c1Keyspace, "ABC", "PBS")
+	require.NoError(t, err)
+
+	// Write additional docs to the cached channels, should be served via DCP/cache
+	response = rt.SendAdminRequest("PUT", "/"+c1Keyspace+"/abc2_c1", `{"value":1, "channel":["ABC"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/"+c2Keyspace+"/abc2_c2", `{"value":1, "channel":["ABC"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/"+c1Keyspace+"/pbs2_c1", `{"value":1, "channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/"+c2Keyspace+"/pbs2_c2", `{"value":1, "channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+
+	// Expect 5 documents in collection with ABC grant:
+	//  - backfill of 2 docs written prior to lastSeq
+	//  - user doc
+	//  - 1 PBS docs after lastSeq
+	//  - 1 ABC docs after lastSeq
+	changesResponse = rt.SendUserRequest("GET", "/"+c1Keyspace+"/_changes?since="+lastSeq.String(), "", "bernard")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	assert.Len(t, changes.Results, 5)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+
+	// Expect 2 documents in collection without ABC grant
+	//  - user doc
+	//  - 1 PBS doc after lastSeq
+	changesResponse = rt.SendUserRequest("GET", "/"+c2Keyspace+"/_changes?since="+lastSeq.String(), "", "bernard")
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	assert.Len(t, changes.Results, 2)
+	logChangesResponse(t, changesResponse.Body.Bytes())
+}
+
+func logChangesResponse(t *testing.T, response []byte) {
+	var changes struct {
+		Results  []db.ChangeEntry
+		Last_Seq db.SequenceID
+	}
+
+	err := base.JSONUnmarshal(response, &changes)
+	require.NoError(t, err, "unable to marshal changes for logging")
+
+	for _, entry := range changes.Results {
+		log.Printf("changes Response entry: %+v", entry)
+	}
+	return
+}
+
+// getScopesConfig sets up a ScopesConfig from a TestBucket and uses a non default collection if available.
+func getMultiCollectionConfig(t testing.TB, testBucket *base.TestBucket, numCollections int) (rest.ScopesConfig, []string) {
+	// Get a datastore as provided by the test
+	stores, err := testBucket.ListDataStores()
+	require.NoError(t, err)
+	require.True(t, len(stores) >= numCollections, "Requested more collections than found on testBucket")
+
+	scopesConfig := rest.ScopesConfig{}
+	keyspaces := make([]string, numCollections)
+	for i := 0; i < numCollections; i++ {
+		dataStoreName := stores[i]
+		keyspaces[i] = "db." + dataStoreName.ScopeName() + "." + dataStoreName.CollectionName()
+		if scopeConfig, ok := scopesConfig[dataStoreName.ScopeName()]; ok {
+			if _, ok := scopeConfig.Collections[dataStoreName.CollectionName()]; ok {
+				// already present
+			} else {
+				scopeConfig.Collections[dataStoreName.CollectionName()] = rest.CollectionConfig{}
+			}
+		} else {
+			scopesConfig[dataStoreName.ScopeName()] = rest.ScopeConfig{
+				Collections: map[string]rest.CollectionConfig{
+					dataStoreName.CollectionName(): {},
+				}}
+		}
+
+	}
+	return scopesConfig, keyspaces
+}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -254,7 +254,8 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 	var keyspaceScope, keyspaceCollection *string
 
 	// If there is a "keyspace" path variable in the route, parse the keyspace:
-	if ks := h.PathVar("keyspace"); ks != "" {
+	ks := h.PathVar("keyspace")
+	if ks != "" {
 		keyspaceDb, keyspaceScope, keyspaceCollection, err = parseKeyspace(ks)
 		if err != nil {
 			return err
@@ -293,49 +294,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 
 	// If this call is in the context of a DB make sure the DB is in a valid state
 	if dbContext != nil {
-		// Named collections handling
-		if dbContext.Scopes != nil {
-			// Allow an empty scope to refer to the one SG is running with, rather than falling back to _default
-			if keyspaceScope == nil {
-				// TODO: There could be a configurable dbContext.defaultNamedScope if we allow >1 scope
-				//       for now we don't need it - just use the one we're running with.
-				for scopeName := range dbContext.Scopes {
-					keyspaceScope = &scopeName
-					break
-				}
-			}
-			scope, foundScope := dbContext.Scopes[*keyspaceScope]
-			if !foundScope {
-				return base.HTTPErrorf(http.StatusNotFound, "keyspace %s.%s.%s not found", base.MD(keyspaceDb), base.MD(base.StringDefault(keyspaceScope, "")), base.MD(base.StringDefault(keyspaceCollection, "")))
-			}
-
-			if keyspaceCollection == nil {
-				if len(scope.Collections) > 1 {
-					// _default doesn't exist for a non-default scope - so make it a required element if it's ambiguous
-					return base.HTTPErrorf(http.StatusBadRequest, "Ambiguous keyspace: %s.%s", base.MD(keyspaceDb), base.MD(base.StringDefault(keyspaceScope, "")))
-				}
-				// one collection only - use that one
-				for collectionName := range scope.Collections {
-					keyspaceCollection = &collectionName
-					break
-				}
-			}
-			_, foundCollection := scope.Collections[*keyspaceCollection]
-			if !foundCollection {
-				return base.HTTPErrorf(http.StatusNotFound, "keyspace %s.%s.%s not found", base.MD(keyspaceDb), base.MD(base.StringDefault(keyspaceScope, "")), base.MD(base.StringDefault(keyspaceCollection, "")))
-			}
-		} else {
-			if keyspaceScope != nil && *keyspaceScope != base.DefaultScope || keyspaceCollection != nil && *keyspaceCollection != base.DefaultCollection {
-				// request tried specifying a named collection on a non-named collections database
-				return base.HTTPErrorf(http.StatusNotFound, "keyspace %s.%s.%s not found", base.MD(keyspaceDb), base.MD(base.StringDefault(keyspaceScope, "")), base.MD(base.StringDefault(keyspaceCollection, "")))
-			}
-			// Set these for handlers that expect a scope/collection to be set, even if not using named collections.
-			keyspaceScope = base.StringPtr(base.DefaultScope)
-			keyspaceCollection = base.StringPtr(base.DefaultCollection)
-		}
-
 		if !h.runOffline {
-
 			// get a read lock on the dbContext
 			// When the lock is returned we know that the db state will not be changed by
 			// any other call
@@ -459,6 +418,49 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 		}
 	}
 
+	// Collection keyspace handling
+	if ks != "" {
+		if dbContext.Scopes != nil {
+			// If scopes are defined on the database but not in th an empty scope to refer to the one SG is running with, rather than falling back to _default
+			if keyspaceScope == nil {
+				// TODO: There could be a configurable dbContext.defaultNamedScope if we allow >1 scope
+				//       for now we don't need it - just use the one we're running with.
+				for scopeName := range dbContext.Scopes {
+					keyspaceScope = &scopeName
+					break
+				}
+			}
+			scope, foundScope := dbContext.Scopes[*keyspaceScope]
+			if !foundScope {
+				return base.HTTPErrorf(http.StatusNotFound, "keyspace %s.%s.%s not found", base.MD(keyspaceDb), base.MD(base.StringDefault(keyspaceScope, "")), base.MD(base.StringDefault(keyspaceCollection, "")))
+			}
+
+			if keyspaceCollection == nil {
+				if len(scope.Collections) > 1 {
+					// _default doesn't exist for a non-default scope - so make it a required element if it's ambiguous
+					return base.HTTPErrorf(http.StatusBadRequest, "Ambiguous keyspace: %s.%s", base.MD(keyspaceDb), base.MD(base.StringDefault(keyspaceScope, "")))
+				}
+				// one collection only - use that one
+				for collectionName := range scope.Collections {
+					keyspaceCollection = &collectionName
+					break
+				}
+			}
+			_, foundCollection := scope.Collections[*keyspaceCollection]
+			if !foundCollection {
+				return base.HTTPErrorf(http.StatusNotFound, "keyspace %s.%s.%s not found", base.MD(keyspaceDb), base.MD(base.StringDefault(keyspaceScope, "")), base.MD(base.StringDefault(keyspaceCollection, "")))
+			}
+		} else {
+			if keyspaceScope != nil && *keyspaceScope != base.DefaultScope || keyspaceCollection != nil && *keyspaceCollection != base.DefaultCollection {
+				// request tried specifying a named collection on a non-named collections database
+				return base.HTTPErrorf(http.StatusNotFound, "keyspace %s.%s.%s not found", base.MD(keyspaceDb), base.MD(base.StringDefault(keyspaceScope, "")), base.MD(base.StringDefault(keyspaceCollection, "")))
+			}
+			// Set these for handlers that expect a scope/collection to be set, even if not using named collections.
+			keyspaceScope = base.StringPtr(base.DefaultScope)
+			keyspaceCollection = base.StringPtr(base.DefaultCollection)
+		}
+	}
+
 	h.logRequestLine()
 	isRequestLogged = true
 
@@ -468,9 +470,11 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 		if err != nil {
 			return err
 		}
-		h.collection, err = h.db.GetDatabaseCollectionWithUser(*keyspaceScope, *keyspaceCollection)
-		if err != nil {
-			return err
+		if ks != "" {
+			h.collection, err = h.db.GetDatabaseCollectionWithUser(*keyspaceScope, *keyspaceCollection)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -161,6 +161,8 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleCompact)).Methods("POST")
 	keyspace.Handle("/_compact",
 		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetCompact)).Methods("GET")
+	keyspace.Handle("/_dumpchannel/{channel}",
+		makeHandler(sc, adminPrivs, []Permission{PermReadAppData}, nil, (*handler).handleDumpChannel)).Methods("GET")
 
 	// Database handlers (multi collection):
 	dbr.Handle("/_session",
@@ -242,8 +244,6 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeHandler(sc, adminPrivs, []Permission{PermReadAppData}, nil, (*handler).handleDump)).Methods("GET")
 	dbr.Handle("/_view/{view}", // redundant; just for backward compatibility with 1.0
 		makeHandler(sc, adminPrivs, []Permission{PermReadAppData}, nil, (*handler).handleView)).Methods("GET")
-	dbr.Handle("/_dumpchannel/{channel}",
-		makeHandler(sc, adminPrivs, []Permission{PermReadAppData}, nil, (*handler).handleDumpChannel)).Methods("GET")
 	dbr.Handle("/_repair",
 		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleRepair)).Methods("POST")
 

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -44,7 +44,7 @@ func createCommonRouter(sc *ServerContext, privs handlerPrivs) (root, db, keyspa
 
 	// Operations on databases:
 	root.Handle("/{db:"+dbRegex+"}/", makeOfflineHandler(sc, privs, []Permission{PermDevOps}, nil, (*handler).handleGetDB)).Methods("GET", "HEAD")
-	root.Handle("/{db:"+dbRegex+"}/", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handlePostDoc)).Methods("POST")
+	root.Handle("/{keyspace:"+dbRegex+"}/", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handlePostDoc)).Methods("POST")
 
 	// Keyspace operations (i.e. collection-specific):
 	keyspace = root.PathPrefix("/{keyspace:" + dbRegex + "}/").Subrouter()
@@ -65,11 +65,11 @@ func createCommonRouter(sc *ServerContext, privs handlerPrivs) (root, db, keyspa
 	keyspace.Handle("/_bulk_get", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleBulkGet)).Methods("POST")
 	keyspace.Handle("/_revs_diff", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handleRevsDiff)).Methods("POST")
 	keyspace.Handle("/_changes", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleChanges)).Methods("GET", "HEAD", "POST")
+	keyspace.Handle("/_all_docs", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleAllDocs)).Methods("GET", "HEAD", "POST")
 
 	// Database operations (i.e. multi-collection):
 	dbr := root.PathPrefix("/{db:" + dbRegex + "}/").Subrouter()
 	dbr.StrictSlash(true)
-	dbr.Handle("/_all_docs", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleAllDocs)).Methods("GET", "HEAD", "POST")
 	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleGetDesignDoc)).Methods("GET", "HEAD")
 	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handlePutDesignDoc)).Methods("PUT")
 	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handleDeleteDesignDoc)).Methods("DELETE")

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -649,6 +649,10 @@ func (rt *RestTester) SendAdminRequest(method, resource string, body string) *Te
 	return response
 }
 
+func (rt *RestTester) SendUserRequest(method, resource string, body string, username string) *TestResponse {
+	return rt.Send(RequestByUser(method, resource, body, username))
+}
+
 func (rt *RestTester) WaitForNUserViewResults(numResultsExpected int, viewUrlPath string, user auth.User, password string) (viewResult sgbucket.ViewResult, err error) {
 	return rt.WaitForNViewResults(numResultsExpected, viewUrlPath, user, password)
 }
@@ -796,6 +800,40 @@ func (rt *RestTester) PutDocumentWithRevID(docID string, newRevID string, parent
 	}
 	resp := rt.SendAdminRequest(http.MethodPut, "/db/"+docID+"?new_edits=false", string(requestBytes))
 	return resp, nil
+}
+
+func (rt *RestTester) SetAdminChannels(username string, keyspace string, channels ...string) error {
+
+	dbName, scopeName, collectionName := SplitKeyspace(keyspace)
+	// Get the current user document
+	userResponse := rt.SendAdminRequest("GET", "/"+dbName+"/_user/"+username, "")
+	if userResponse.Code != 200 {
+		return fmt.Errorf("User %s not found", username)
+	}
+
+	var currentConfig auth.PrincipalConfig
+	if err := base.JSONUnmarshal(userResponse.Body.Bytes(), &currentConfig); err != nil {
+		return err
+	}
+
+	currentConfig.SetExplicitChannels(scopeName, collectionName, channels...)
+	newConfigBytes, _ := base.JSONMarshal(currentConfig)
+
+	userResponse = rt.SendAdminRequest("PUT", "/"+dbName+"/_user/"+username, string(newConfigBytes))
+	if userResponse.Code != 200 {
+		return fmt.Errorf("User update failed: %s", userResponse.Body.Bytes())
+	}
+	return nil
+}
+
+func SplitKeyspace(keyspace string) (dbName, scopeName, channelName string) {
+	results := strings.Split(keyspace, ".")
+	if len(results) == 1 {
+		return results[0], base.DefaultScope, base.DefaultCollection
+	} else if len(results) == 3 {
+		return results[0], results[1], results[2]
+	}
+	panic(fmt.Sprintf("malformed keyspace: %v", keyspace))
 }
 
 type SimpleSync struct {


### PR DESCRIPTION
CBG-2333

Send all DCP events to all change caches for sequence buffering, only add to channel cache when collection matches.  Switches changeListener's OnDocChanged to a subscription model, so that each collection's changeCache can be notified.

Also reworks to handler.invoke to only perform default scope/collection check in handler for keyspace paths, and to perform that check after auth.

Fix to keyspace routing meant two additional routes had to be switched to keyspace:
 - all_docs to support include_docs=true
 - root document POST

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1215/
