### PR TITLE
CBG-2524: Update API docs to reflect db->keyspace changes

### DIFF
--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -114,8 +114,8 @@ paths:
     $ref: './paths/admin/{db}~_dump~{view}.yaml'
   '/{db}/_view/{view}':
     $ref: './paths/admin/{db}~_view~{view}.yaml'
-  '/{db}/_dumpchannel/{channel}':
-    $ref: './paths/admin/{db}~_dumpchannel~{channel}.yaml'
+  '/{keyspace}/_dumpchannel/{channel}':
+    $ref: './paths/admin/{keyspace}~_dumpchannel~{channel}.yaml'
   '/{db}/_repair':
     $ref: './paths/admin/{db}~_repair.yaml'
   /_all_dbs:
@@ -130,14 +130,14 @@ paths:
     $ref: ./paths/admin/_expvar.yaml
   /:
     $ref: ./paths/admin/~.yaml
-  '/{db}/_all_docs':
-    $ref: './paths/admin/{db}~_all_docs.yaml'
+  '/{keyspace}/_all_docs':
+    $ref: './paths/admin/{keyspace}~_all_docs.yaml'
   '/{keyspace}/_bulk_docs':
     $ref: './paths/admin/{keyspace}~_bulk_docs.yaml'
   '/{keyspace}/_bulk_get':
     $ref: './paths/admin/{keyspace}~_bulk_get.yaml'
-  '/{db}/_changes':
-    $ref: './paths/admin/{db}~_changes.yaml'
+  '/{keyspace}/_changes':
+    $ref: './paths/admin/{keyspace}~_changes.yaml'
   '/{db}/_design/{ddoc}':
     $ref: './paths/admin/{db}~_design~{ddoc}.yaml'
   '/{db}/_design/{ddoc}/_view/{view}':

--- a/docs/api/paths/admin/{keyspace}~_all_docs.yaml
+++ b/docs/api/paths/admin/{keyspace}~_all_docs.yaml
@@ -7,7 +7,7 @@
 # the file licenses/APL2.txt.
 
 parameters:
-  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/keyspace
 get:
   summary: Gets all the documents in the database with the given parameters
   description: |-

--- a/docs/api/paths/admin/{keyspace}~_changes.yaml
+++ b/docs/api/paths/admin/{keyspace}~_changes.yaml
@@ -7,7 +7,7 @@
 # the file licenses/APL2.txt.
 
 parameters:
-  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/keyspace
 get:
   summary: Get changes list
   description: |-

--- a/docs/api/paths/admin/{keyspace}~_dumpchannel~{channel}.yaml
+++ b/docs/api/paths/admin/{keyspace}~_dumpchannel~{channel}.yaml
@@ -7,7 +7,7 @@
 # the file licenses/APL2.txt.
 
 parameters:
-  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/keyspace
   - name: channel
     in: path
     description: The channel to dump all the documents from.

--- a/docs/api/paths/public/{keyspace}~_all_docs.yaml
+++ b/docs/api/paths/public/{keyspace}~_all_docs.yaml
@@ -7,7 +7,7 @@
 # the file licenses/APL2.txt.
 
 parameters:
-  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/keyspace
 get:
   summary: Gets all the documents in the database with the given parameters
   description: Returns all documents in the databased based on the specified parameters.

--- a/docs/api/paths/public/{keyspace}~_changes.yaml
+++ b/docs/api/paths/public/{keyspace}~_changes.yaml
@@ -7,7 +7,7 @@
 # the file licenses/APL2.txt.
 
 parameters:
-  - $ref: ../../components/parameters.yaml#/db
+  - $ref: ../../components/parameters.yaml#/keyspace
 get:
   summary: Get changes list
   description: |-

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -38,14 +38,14 @@ paths:
     $ref: ./paths/public/~.yaml
   '/{keyspace}/':
     $ref: './paths/admin/{keyspace}~.yaml'
-  '/{db}/_all_docs':
-    $ref: './paths/public/{db}~_all_docs.yaml'
+  '/{keyspace}/_all_docs':
+    $ref: './paths/public/{keyspace}~_all_docs.yaml'
   '/{keyspace}/_bulk_docs':
     $ref: './paths/public/{keyspace}~_bulk_docs.yaml'
   '/{keyspace}/_bulk_get':
     $ref: './paths/public/{keyspace}~_bulk_get.yaml'
-  '/{db}/_changes':
-    $ref: './paths/public/{db}~_changes.yaml'
+  '/{keyspace}/_changes':
+    $ref: './paths/public/{keyspace}~_changes.yaml'
   '/{db}/_design/{ddoc}':
     $ref: './paths/public/{db}~_design~{ddoc}.yaml'
   '/{db}/_design/{ddoc}/_view/{view}':


### PR DESCRIPTION
CBG-2524

Describes API changes made in #5958 and #5956 to move routes from `db` to `keyspace`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a