### PR TITLE
reuse existing datastores

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -839,11 +839,6 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 		}
 
 		for scopeName, scopeConfig := range dbConfig.Scopes {
-			// WIP: Collections Phase 1 - Only allow a single collection
-			if len(scopeConfig.Collections) != 1 {
-				base.WarnfCtx(ctx, "WIP Collections Phase 1 only supports a single collection - had %d", len(scopeConfig.Collections))
-			}
-
 			if len(scopeConfig.Collections) == 0 {
 				multiError = multiError.Append(fmt.Errorf("must specify at least one collection in scope %v", scopeName))
 				continue


### PR DESCRIPTION
Creating datastores without primary indexes renders them unrecoverable by bucket readierCBG-0000

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1229/
