### PR TITLE
CBG-2316 followup - Add collection test for public channel

### DIFF
--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -106,14 +106,10 @@ func TestCollectionsPutDocInKeyspace(t *testing.T) {
 
 // TestCollectionsPublicChannel ensures that a doc routed to the public channel is accessible by a user with no other access.
 func TestCollectionsPublicChannel(t *testing.T) {
-	base.TestRequiresCollections(t)
-
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
 
-	// dbName is the default name from RestTester
-
-	ds := tb.GetNamedDataStore(1)
+	ds := tb.GetSingleDataStore()
 	dataStoreName, ok := base.AsDataStoreName(ds)
 	require.True(t, ok)
 	keyspaceName := "db" + "." + dataStoreName.ScopeName() + "." + dataStoreName.CollectionName()

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -56,7 +56,7 @@ func (h *handler) handleAllDocs() error {
 	// Get the set of channels the user has access to; nil if user is admin or has access to user "*"
 	var availableChannels ch.TimedSet
 	if h.user != nil {
-		availableChannels = h.user.InheritedChannels()
+		availableChannels = h.user.InheritedCollectionChannels(h.collection.ScopeName(), h.collection.Name())
 		if availableChannels == nil {
 			// TODO: CBG-1948
 			panic("no channels for user?")

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2077,7 +2077,7 @@ func getRESTKeyspace(_ testing.TB, dbName string, collection *db.DatabaseCollect
 	return strings.Join([]string{dbName, collection.ScopeName(), collection.Name()}, base.ScopeCollectionSeparator)
 }
 
-// Return the names of all the keyspaces on the rest tester. Currently assumes a single database.
+// getKeyspaces returns the names of all the keyspaces on the rest tester. Currently assumes a single database.
 func (rt *RestTester) getKeyspaces() []string {
 	db := rt.GetDatabase()
 	var keyspaces []string
@@ -2086,4 +2086,14 @@ func (rt *RestTester) getKeyspaces() []string {
 	}
 	sort.Strings(keyspaces)
 	return keyspaces
+}
+
+// getKeyspace return the name of a single keyspace if the rest tester is configured with one database and one collection.
+func (rt *RestTester) getKeyspace() string {
+	db := rt.GetDatabase()
+	require.Equal(rt.TB, 1, len(db.CollectionByID), "getKeyspace can only be called if the database has a single collection")
+	for _, collection := range db.CollectionByID {
+		return getRESTKeyspace(rt.TB, db.Name, collection)
+	}
+	return ""
 }


### PR DESCRIPTION
CBG-2316

- Ensures public channel docs are visible on a collection - and also seen on `/_all_docs`

Failing due to issue with `/_all_docs`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
