### PR TITLE
Include gocb's sched logging level as trace

### DIFF
--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -55,7 +55,7 @@ func (GoCBLogger) Log(level gocb.LogLevel, offset int, format string, v ...inter
 		logTo(context.TODO(), LevelWarn, KeyAll, KeyGoCB.String()+": "+format, v...)
 	case gocb.LogInfo:
 		logTo(context.TODO(), LevelDebug, KeyGoCB, format, v...)
-	case gocb.LogDebug, gocb.LogTrace:
+	case gocb.LogDebug, gocb.LogTrace, gocb.LogSched:
 		logTo(context.TODO(), LevelTrace, KeyGoCB, format, v...)
 	}
 	return nil


### PR DESCRIPTION
gocb/gocbcore don't really use trace level logs, everything overly-verbose is either debug or sched (which are both approximately our equivalent of trace)