### PR TITLE
do not create allDocs index when starChannel is disabled

### DIFF
--- a/channels/channelmapper.go
+++ b/channels/channelmapper.go
@@ -53,7 +53,7 @@ func NewDefaultChannelMapper() *ChannelMapper {
 	return NewChannelMapper(DefaultSyncFunction, time.Duration(base.DefaultJavascriptTimeoutSecs)*time.Second)
 }
 
-func (mapper *ChannelMapper) MapToChannelsAndAccess(body map[string]interface{}, oldBodyJSON string, metaMap map[string]interface{}, userCtx map[string]interface{}) (*ChannelMapperOutput, error) {
+func (mapper *ChannelMapper) MapToChannelsAndAccess(body map[string]interface{}, oldBodyJSON string, metaMap map[string]interface{}, userCtx map[string]interface{}, includeStarChannel bool) (*ChannelMapperOutput, error) {
 	numberFixBody := ConvertJSONNumbers(body)
 	numberFixMetaMap := ConvertJSONNumbers(metaMap)
 
@@ -62,6 +62,9 @@ func (mapper *ChannelMapper) MapToChannelsAndAccess(body map[string]interface{},
 		return nil, err
 	}
 	output := result1.(*ChannelMapperOutput)
+	if includeStarChannel {
+		output.Channels.Add(UserStarChannel)
+	}
 	return output, nil
 }
 
@@ -122,10 +125,14 @@ func ForChangedUsers(a, b AccessMap, fn func(user string)) {
 	}
 }
 
-func (runner *SyncRunner) MapToChannelsAndAccess(body map[string]interface{}, oldBodyJSON string, userCtx map[string]interface{}) (*ChannelMapperOutput, error) {
+func (runner *SyncRunner) MapToChannelsAndAccess(body map[string]interface{}, oldBodyJSON string, userCtx map[string]interface{}, includeStarChannel bool) (*ChannelMapperOutput, error) {
 	result, err := runner.Call(body, sgbucket.JSONString(oldBodyJSON), userCtx)
 	if err != nil {
 		return nil, err
 	}
-	return result.(*ChannelMapperOutput), nil
+	output := result.(*ChannelMapperOutput)
+	if includeStarChannel {
+		output.Channels.Add(UserStarChannel)
+	}
+	return output, nil
 }

--- a/channels/channelmapper_test.go
+++ b/channels/channelmapper_test.go
@@ -51,7 +51,7 @@ func TestOttoValueToStringArray(t *testing.T) {
 // verify that our version of Otto treats JSON parsed arrays like real arrays
 func TestJavaScriptWorks(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.x.concat(doc.y));}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"x":["abc"],"y":["xyz"]}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"x":["abc"],"y":["xyz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "abc", "xyz"), res.Channels)
 }
@@ -59,7 +59,7 @@ func TestJavaScriptWorks(t *testing.T) {
 // Just verify that the calls to the channel() fn show up in the output channel list.
 func TestSyncFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel("foo", "bar"); channel("baz")}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo", "bar", "baz"), res.Channels)
 }
@@ -67,7 +67,7 @@ func TestSyncFunction(t *testing.T) {
 // Just verify that the calls to the access() fn show up in the output channel list.
 func TestAccessFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("foo", "bar"); access("foo", "baz")}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"foo": BaseSetOf(t, "bar", "baz")}, res.Access)
 }
@@ -75,7 +75,7 @@ func TestAccessFunction(t *testing.T) {
 // Just verify that the calls to the channel() fn show up in the output channel list.
 func TestSyncFunctionTakesArray(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(["foo", "bar ok","baz"])}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo", "bar ok", "baz"), res.Channels)
 }
@@ -83,21 +83,21 @@ func TestSyncFunctionTakesArray(t *testing.T) {
 // Calling channel() with an invalid channel name should return an error.
 func TestSyncFunctionRejectsInvalidChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(["foo", "bad,name","baz"])}`, 0)
-	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser)
+	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.True(t, err != nil)
 }
 
 // Calling access() with an invalid channel name should return an error.
 func TestAccessFunctionRejectsInvalidChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("foo", "bad,name");}`, 0)
-	_, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	_, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.True(t, err != nil)
 }
 
 // Just verify that the calls to the access() fn show up in the output channel list.
 func TestAccessFunctionTakesArrayOfUsers(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(["foo","bar","baz"], "ginger")}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"bar": BaseSetOf(t, "ginger"), "baz": BaseSetOf(t, "ginger"), "foo": BaseSetOf(t, "ginger")}, res.Access)
 }
@@ -105,14 +105,14 @@ func TestAccessFunctionTakesArrayOfUsers(t *testing.T) {
 // Just verify that the calls to the access() fn show up in the output channel list.
 func TestAccessFunctionTakesArrayOfChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", ["ginger", "earl_grey", "green"])}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"lee": BaseSetOf(t, "ginger", "earl_grey", "green")}, res.Access)
 }
 
 func TestAccessFunctionTakesArrayOfChannelsAndUsers(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(["lee", "nancy"], ["ginger", "earl_grey", "green"])}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "ginger", "earl_grey", "green"), res.Access["lee"])
 	assert.Equal(t, BaseSetOf(t, "ginger", "earl_grey", "green"), res.Access["nancy"])
@@ -120,42 +120,42 @@ func TestAccessFunctionTakesArrayOfChannelsAndUsers(t *testing.T) {
 
 func TestAccessFunctionTakesEmptyArrayUser(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access([], ["ginger", "earl grey", "green"])}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
 }
 
 func TestAccessFunctionTakesEmptyArrayChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", [])}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
 }
 
 func TestAccessFunctionTakesNullUser(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(null, ["ginger", "earl grey", "green"])}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
 }
 
 func TestAccessFunctionTakesNullChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", null)}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
 }
 
 func TestAccessFunctionTakesNonChannelsInArray(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", ["ginger", null, 5])}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"lee": BaseSetOf(t, "ginger")}, res.Access)
 }
 
 func TestAccessFunctionTakesUndefinedUser(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {var x = {}; access(x.nothing, ["ginger", "earl grey", "green"])}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
 }
@@ -164,7 +164,7 @@ func TestAccessFunctionTakesUndefinedUser(t *testing.T) {
 // implementation with access(), so most of the above tests also apply to it.)
 func TestRoleFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {role(["foo","bar","baz"], "role:froods")}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"bar": BaseSetOf(t, "froods"), "baz": BaseSetOf(t, "froods"), "foo": BaseSetOf(t, "froods")}, res.Roles)
 }
@@ -172,7 +172,7 @@ func TestRoleFunction(t *testing.T) {
 // Now just make sure the input comes through intact
 func TestInputParse(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.channel);}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "foo"}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "foo"}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo"), res.Channels)
 }
@@ -180,11 +180,11 @@ func TestInputParse(t *testing.T) {
 // A more realistic example
 func TestDefaultChannelMapper(t *testing.T) {
 	mapper := NewDefaultChannelMapper()
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo", "bar", "baz"), res.Channels)
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"x": "y"}`), `{}`, emptyMetaMap(), noUser)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"x": "y"}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.Set{}, res.Channels)
 }
@@ -192,7 +192,7 @@ func TestDefaultChannelMapper(t *testing.T) {
 // Empty/no-op channel mapper fn
 func TestEmptyChannelMapper(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.Set{}, res.Channels)
 }
@@ -202,7 +202,7 @@ func TestChannelMapperUnderscoreLib(t *testing.T) {
 	underscore.Enable() // It really slows down unit tests (by making otto.New take a lot longer)
 	defer underscore.Disable()
 	mapper := NewChannelMapper(`function(doc) {channel(_.first(doc.channels));}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo"), res.Channels)
 }
@@ -210,7 +210,7 @@ func TestChannelMapperUnderscoreLib(t *testing.T) {
 // Validation by calling reject()
 func TestChannelMapperReject(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {reject(403, "bad");}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, "bad"), res.Rejection)
 }
@@ -218,7 +218,7 @@ func TestChannelMapperReject(t *testing.T) {
 // Rejection by calling throw()
 func TestChannelMapperThrow(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {throw({forbidden:"bad"});}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, "bad"), res.Rejection)
 }
@@ -226,14 +226,14 @@ func TestChannelMapperThrow(t *testing.T) {
 // Test other runtime exception
 func TestChannelMapperException(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {(nil)[5];}`, 0)
-	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
+	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.True(t, err != nil)
 }
 
 // Test the public API
 func TestPublicChannelMapper(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.channels);}`, 0)
-	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
+	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo", "bar", "baz"), output.Channels)
 }
@@ -244,16 +244,16 @@ func TestCheckUser(t *testing.T) {
 			requireUser(doc.owner);
 		}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "channels": []string{}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, emptyMetaMap(), sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, emptyMetaMap(), sally, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 
 	var linus = map[string]interface{}{"name": "linus", "channels": []string{}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, emptyMetaMap(), linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, emptyMetaMap(), linus, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, base.SyncFnErrorWrongUser), res.Rejection)
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, emptyMetaMap(), nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, emptyMetaMap(), nil, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 }
@@ -264,16 +264,16 @@ func TestCheckUserArray(t *testing.T) {
 			requireUser(doc.owners);
 		}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "channels": []string{}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, emptyMetaMap(), sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, emptyMetaMap(), sally, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 
 	var linus = map[string]interface{}{"name": "linus", "channels": []string{}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, emptyMetaMap(), linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, emptyMetaMap(), linus, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, base.SyncFnErrorWrongUser), res.Rejection)
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally"]}`), `{}`, emptyMetaMap(), nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally"]}`), `{}`, emptyMetaMap(), nil, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 }
@@ -284,16 +284,16 @@ func TestCheckRole(t *testing.T) {
 			requireRole(doc.role);
 		}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "roles": map[string]int{"girl": 1, "5yo": 1}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, emptyMetaMap(), sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, emptyMetaMap(), sally, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": []string{"boy", "musician"}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, emptyMetaMap(), linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, emptyMetaMap(), linus, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, base.SyncFnErrorMissingRole), res.Rejection)
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, emptyMetaMap(), nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, emptyMetaMap(), nil, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 }
@@ -304,16 +304,16 @@ func TestCheckRoleArray(t *testing.T) {
 			requireRole(doc.roles);
 		}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "roles": map[string]int{"girl": 1, "5yo": 1}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"roles": ["kid","girl"]}`), `{}`, emptyMetaMap(), sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"roles": ["kid","girl"]}`), `{}`, emptyMetaMap(), sally, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": map[string]int{"boy": 1, "musician": 1}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, emptyMetaMap(), linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, emptyMetaMap(), linus, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, base.SyncFnErrorMissingRole), res.Rejection)
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, emptyMetaMap(), nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, emptyMetaMap(), nil, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 }
@@ -324,16 +324,16 @@ func TestCheckAccess(t *testing.T) {
 		requireAccess(doc.channel)
 	}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "roles": []string{"girl", "5yo"}, "channels": []string{"party", "school"}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "party"}`), `{}`, emptyMetaMap(), sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "party"}`), `{}`, emptyMetaMap(), sally, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": []string{"boy", "musician"}, "channels": []string{"party", "school"}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "work"}`), `{}`, emptyMetaMap(), linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "work"}`), `{}`, emptyMetaMap(), linus, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, base.SyncFnErrorMissingChannelAccess), res.Rejection)
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "magic"}`), `{}`, emptyMetaMap(), nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "magic"}`), `{}`, emptyMetaMap(), nil, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 }
@@ -344,16 +344,16 @@ func TestCheckAccessArray(t *testing.T) {
 		requireAccess(doc.channels)
 	}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "roles": []string{"girl", "5yo"}, "channels": []string{"party", "school"}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["swim","party"]}`), `{}`, emptyMetaMap(), sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["swim","party"]}`), `{}`, emptyMetaMap(), sally, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": []string{"boy", "musician"}, "channels": []string{"party", "school"}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["work"]}`), `{}`, emptyMetaMap(), linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["work"]}`), `{}`, emptyMetaMap(), linus, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, base.SyncFnErrorMissingChannelAccess), res.Rejection)
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["magic"]}`), `{}`, emptyMetaMap(), nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["magic"]}`), `{}`, emptyMetaMap(), nil, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 }
@@ -361,12 +361,12 @@ func TestCheckAccessArray(t *testing.T) {
 // Test changing the function
 func TestSetFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.channels);}`, 0)
-	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
+	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	changed, err := mapper.SetFunction(`function(doc) {channel("all");}`)
 	assert.True(t, changed, "SetFunction failed")
 	assert.NoError(t, err, "SetFunction failed")
-	output, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
+	output, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "all"), output.Channels)
 }
@@ -374,98 +374,98 @@ func TestSetFunction(t *testing.T) {
 // Test that expiry function sets the expiry property
 func TestExpiryFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {expiry(doc.expiry);}`, 0)
-	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, emptyMetaMap(), noUser)
+	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(100), *res1.Expiry)
 
-	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, emptyMetaMap(), noUser)
+	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(500), *res2.Expiry)
 
-	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"2105-01-01T00:00:00.000+00:00"}`), `{}`, emptyMetaMap(), noUser)
+	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"2105-01-01T00:00:00.000+00:00"}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(4260211200), *res_stringDate.Expiry)
 
 	// Validate invalid expiry values log warning and don't set expiry
-	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, emptyMetaMap(), noUser)
+	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:abc")
 	assert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
-	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, emptyMetaMap(), noUser)
+	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as array")
 	assert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
-	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, emptyMetaMap(), noUser)
+	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as negative value")
 	assert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
-	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, emptyMetaMap(), noUser)
+	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry > unit32")
 	assert.True(t, res6.Expiry == nil)
 
 	// Invalid - non-unix date
-	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"1805-01-01T00:00:00.000+00:00"}`), `{}`, emptyMetaMap(), noUser)
+	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"1805-01-01T00:00:00.000+00:00"}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:1805-01-01T00:00:00.000+00:00")
 	assert.True(t, resInvalidDate.Expiry == nil)
 
 	// No expiry specified
-	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, emptyMetaMap(), noUser)
+	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry not specified")
 	assert.True(t, res7.Expiry == nil)
 }
 
 func TestExpiryFunctionConstantValue(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {expiry(100);}`, 0)
-	res1, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res1, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(100), *res1.Expiry)
 
 	mapper = NewChannelMapper(`function(doc) {expiry("500");}`, 0)
-	res2, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res2, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(500), *res2.Expiry)
 
 	mapper = NewChannelMapper(`function(doc) {expiry("2105-01-01T00:00:00.000+00:00");}`, 0)
-	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(4260211200), *res_stringDate.Expiry)
 
 	// Validate invalid expiry values log warning and don't set expiry
 	mapper = NewChannelMapper(`function(doc) {expiry("abc");}`, 0)
-	res3, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res3, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:abc")
 	assert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
 	mapper = NewChannelMapper(`function(doc) {expiry(["100", "200"]);}`, 0)
-	res4, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res4, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as array")
 	assert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
 	mapper = NewChannelMapper(`function(doc) {expiry(-100);}`, 0)
-	res5, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res5, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as negative value")
 	assert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
 	mapper = NewChannelMapper(`function(doc) {expiry(123456789012345);}`, 0)
-	res6, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res6, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as > unit32")
 	assert.True(t, res6.Expiry == nil)
 
 	// Invalid - non-unix date
 	mapper = NewChannelMapper(`function(doc) {expiry("1805-01-01T00:00:00.000+00:00");}`, 0)
-	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:1805-01-01T00:00:00.000+00:00")
 	assert.True(t, resInvalidDate.Expiry == nil)
 
 	// No expiry specified
 	mapper = NewChannelMapper(`function(doc) {expiry();}`, 0)
-	res7, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res7, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry not specified")
 	assert.True(t, res7.Expiry == nil)
 }
@@ -473,36 +473,36 @@ func TestExpiryFunctionConstantValue(t *testing.T) {
 // Test that expiry function when invoked more than once by sync function
 func TestExpiryFunctionMultipleInvocation(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {expiry(doc.expiry); expiry(doc.secondExpiry)}`, 0)
-	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, emptyMetaMap(), noUser)
+	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, uint32(100), *res1.Expiry)
 
-	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, emptyMetaMap(), noUser)
+	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, uint32(500), *res2.Expiry)
 
 	// Validate invalid expiry values log warning and don't set expiry
-	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, emptyMetaMap(), noUser)
+	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry:abc")
 	assert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
-	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, emptyMetaMap(), noUser)
+	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	assert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
-	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, emptyMetaMap(), noUser)
+	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	assert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
-	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, emptyMetaMap(), noUser)
+	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	assert.True(t, res6.Expiry == nil)
 
 	// No expiry specified
-	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, emptyMetaMap(), noUser)
+	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	assert.True(t, res7.Expiry == nil)
 }
@@ -520,7 +520,7 @@ func TestMetaMap(t *testing.T) {
 		},
 	}
 
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, metaMap, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, metaMap, noUser, false)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, res.Channels.ToArray(), channels)
 }
@@ -535,7 +535,7 @@ func TestNilMetaMap(t *testing.T) {
 		},
 	}
 
-	_, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, metaMap, noUser)
+	_, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, metaMap, noUser, false)
 	require.Error(t, err)
 	assert.True(t, err.Error() == "TypeError: Cannot access member 'val' of undefined")
 }

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -39,7 +39,7 @@ var SkippedSeqCleanViewBatch = 50 // Max number of sequences checked per query d
 
 // Enable keeping a channel-log for the "*" channel (channel.UserStarChannel). The only time this channel is needed is if
 // someone has access to "*" (e.g. admin-party) and tracks its changes feed.
-var EnableStarChannelLog = false
+var EnableStarChannelLog = true
 
 // Manages a cache of the recent change history of all channels.
 //

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -155,7 +155,7 @@ func DefaultCacheOptions() CacheOptions {
 // Initializes a new changeCache.
 // lastSequence is the last known database sequence assigned.
 // notifyChange is an optional function that will be called to notify of channel changes.
-// After calling Init(), you must call .Start() to start useing the cache, otherwise it will be in a locked state
+// After calling Init(), you must call .Start() to start using the cache, otherwise it will be in a locked state
 // and callers will block on trying to obtain the lock.
 func (c *changeCache) Init(logCtx context.Context, collection *DatabaseCollection, channelCache ChannelCache, notifyChange func(channels.Set), options *CacheOptions) error {
 	c.collection = collection

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -39,7 +39,7 @@ var SkippedSeqCleanViewBatch = 50 // Max number of sequences checked per query d
 
 // Enable keeping a channel-log for the "*" channel (channel.UserStarChannel). The only time this channel is needed is if
 // someone has access to "*" (e.g. admin-party) and tracks its changes feed.
-var EnableStarChannelLog = true
+var EnableStarChannelLog = false
 
 // Manages a cache of the recent change history of all channels.
 //

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -368,13 +368,13 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 }
 
 func TestActiveOnlyCacheUpdate(t *testing.T) {
-	if !EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
-
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := db.GetSingleDatabaseCollectionWithUser()
+
+	if !db.Options.EnableStarChannel {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
 	// Create 10 documents

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -368,6 +368,9 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 }
 
 func TestActiveOnlyCacheUpdate(t *testing.T) {
+	if !EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)

--- a/db/crud.go
+++ b/db/crud.go
@@ -2225,7 +2225,7 @@ func (db *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context, 
 
 		var output *channels.ChannelMapperOutput
 		output, err = db.channelMapper().MapToChannelsAndAccess(body, oldJson, metaMap,
-			MakeUserCtx(db.user, db.ScopeName(), db.Name()), !EnableStarChannelLog)
+			MakeUserCtx(db.user, db.ScopeName(), db.Name()), db.dbCtx.Options.EnableStarChannel)
 
 		db.dbStats().Database().SyncFunctionTime.Add(time.Since(startTime).Nanoseconds())
 
@@ -2264,7 +2264,7 @@ func (db *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context, 
 				base.WarnfCtx(ctx, "Channel names must be string values only. Ignoring non-string channels: %s", base.UD(nonStrings))
 			}
 
-			if !EnableStarChannelLog {
+			if !db.dbCtx.Options.EnableStarChannel {
 				array = append(array, channels.UserStarChannel)
 			}
 			result, err = channels.SetFromArray(array, channels.KeepStar)

--- a/db/crud.go
+++ b/db/crud.go
@@ -2225,7 +2225,7 @@ func (db *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context, 
 
 		var output *channels.ChannelMapperOutput
 		output, err = db.channelMapper().MapToChannelsAndAccess(body, oldJson, metaMap,
-			MakeUserCtx(db.user, db.ScopeName(), db.Name()))
+			MakeUserCtx(db.user, db.ScopeName(), db.Name()), !EnableStarChannelLog)
 
 		db.dbStats().Database().SyncFunctionTime.Add(time.Since(startTime).Nanoseconds())
 
@@ -2262,6 +2262,10 @@ func (db *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context, 
 			array, nonStrings := base.ValueToStringArray(value)
 			if nonStrings != nil {
 				base.WarnfCtx(ctx, "Channel names must be string values only. Ignoring non-string channels: %s", base.UD(nonStrings))
+			}
+
+			if !EnableStarChannelLog {
+				array = append(array, channels.UserStarChannel)
 			}
 			result, err = channels.SetFromArray(array, channels.KeepStar)
 		}

--- a/db/database.go
+++ b/db/database.go
@@ -170,6 +170,7 @@ type DatabaseContextOptions struct {
 	skipRegisterImportPIndex      bool                  // if set, skips the global gocb PIndex registration
 	MetadataStore                 base.DataStore        // If set, use this location/connection for SG metadata storage - if not set, metadata is stored using the same location/connection as the bucket used for data storage.
 	DefaultCollectionImportFilter *ImportFilterFunction // Opt-in filter for document import, for when collections are not supported
+	EnableStarChannel             bool
 }
 
 type ScopesOptions map[string]ScopeOptions

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -794,6 +794,9 @@ func allDocIDs(ctx context.Context, collection *DatabaseCollection) (docs []AllD
 }
 
 func TestAllDocsOnly(t *testing.T) {
+	if !EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
@@ -1358,6 +1361,9 @@ func TestAllowConflictsFalseTombstoneExistingConflictNewEditsFalse(t *testing.T)
 }
 
 func TestSyncFnOnPush(t *testing.T) {
+	if !EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
@@ -1715,6 +1721,9 @@ func TestRecentSequenceHistory(t *testing.T) {
 }
 
 func TestChannelView(t *testing.T) {
+	if !EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -794,10 +794,6 @@ func allDocIDs(ctx context.Context, collection *DatabaseCollection) (docs []AllD
 }
 
 func TestAllDocsOnly(t *testing.T) {
-	if !EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
-
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
 	// Lower the log max length so no more than 50 items will be kept.
@@ -806,6 +802,11 @@ func TestAllDocsOnly(t *testing.T) {
 
 	db, ctx := setupTestDBWithCacheOptions(t, cacheOptions)
 	defer db.Close(ctx)
+
+	if !db.Options.EnableStarChannel {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
+
 	collection := db.GetSingleDatabaseCollectionWithUser()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
@@ -1361,14 +1362,15 @@ func TestAllowConflictsFalseTombstoneExistingConflictNewEditsFalse(t *testing.T)
 }
 
 func TestSyncFnOnPush(t *testing.T) {
-	if !EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
-	collection := db.GetSingleDatabaseCollectionWithUser()
 
+	if !db.Options.EnableStarChannel {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
+
+	collection := db.GetSingleDatabaseCollectionWithUser()
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {
 		log("doc _id = "+doc._id+", _rev = "+doc._rev);
 		if (oldDoc)
@@ -1721,12 +1723,13 @@ func TestRecentSequenceHistory(t *testing.T) {
 }
 
 func TestChannelView(t *testing.T) {
-	if !EnableStarChannelLog {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	if !db.Options.EnableStarChannel {
 		t.Skip("This test requires StarChannel to be enabled")
 	}
 
-	db, ctx := setupTestDB(t)
-	defer db.Close(ctx)
 	collection := db.GetSingleDatabaseCollectionWithUser()
 	collectionID := collection.GetCollectionID()
 

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -342,7 +342,7 @@ func stripSyncProperty(row *sgbucket.ViewRow) {
 	}
 }
 
-func InitializeViews(ctx context.Context, ds sgbucket.DataStore) error {
+func InitializeViews(ctx context.Context, ds sgbucket.DataStore, enableStarChannel bool) error {
 	collection, ok := ds.(*base.Collection)
 	if ok && !collection.IsDefaultScopeCollection() {
 		return fmt.Errorf("Can not initialize views on a non default collection")
@@ -359,7 +359,7 @@ func InitializeViews(ctx context.Context, ds sgbucket.DataStore) error {
 	// If not present, install design docs and views
 	if !ddocsExist {
 		base.InfofCtx(ctx, base.KeyAll, "Design docs for current view version (%s) do not exist - creating...", DesignDocVersion)
-		if err := installViews(ctx, viewStore); err != nil {
+		if err := installViews(ctx, viewStore, enableStarChannel); err != nil {
 			return err
 		}
 	}
@@ -385,7 +385,7 @@ func checkExistingDDocs(ctx context.Context, viewStore sgbucket.ViewStore) bool 
 	return false
 }
 
-func installViews(ctx context.Context, viewStore sgbucket.ViewStore) error {
+func installViews(ctx context.Context, viewStore sgbucket.ViewStore, enableStarChannel bool) error {
 
 	// syncData specifies the path to Sync Gateway sync metadata used in the map function -
 	// in the document body when xattrs available, in the mobile xattr when xattrs enabled.
@@ -492,7 +492,7 @@ func installViews(ctx context.Context, viewStore sgbucket.ViewStore) error {
 						}
 					}`
 
-	channels_map = fmt.Sprintf(channels_map, syncData, base.SyncDocPrefix, ch.Deleted, EnableStarChannelLog,
+	channels_map = fmt.Sprintf(channels_map, syncData, base.SyncDocPrefix, ch.Deleted, enableStarChannel,
 		ch.Removed|ch.Deleted, ch.Removed)
 
 	// Channel access view, used by ComputeChannelsForPrincipal()

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -345,7 +345,7 @@ func isAllDocsIndex(i SGIndex) bool {
 }
 
 // Initializes Sync Gateway indexes for bucket.  Creates required indexes if not found, then waits for index readiness.
-func InitializeIndexes(n1QLStore base.N1QLStore, useXattrs bool, numReplicas uint, failFast bool, isServerless bool) error {
+func InitializeIndexes(n1QLStore base.N1QLStore, useXattrs bool, numReplicas uint, failFast bool, isServerless bool, enableStarChannel bool) error {
 
 	base.InfofCtx(context.TODO(), base.KeyAll, "Initializing indexes with numReplicas: %d...", numReplicas)
 
@@ -353,8 +353,8 @@ func InitializeIndexes(n1QLStore base.N1QLStore, useXattrs bool, numReplicas uin
 	deferredIndexes := make([]string, 0)
 	for _, sgIndex := range sgIndexes {
 
-		// only create allDocs Index if EnableStarChannel is set to true
-		if isAllDocsIndex(sgIndex) && !EnableStarChannelLog {
+		// only create allDocs Index if enableStarChannel is set to true
+		if isAllDocsIndex(sgIndex) && !enableStarChannel {
 			base.DebugfCtx(context.TODO(), base.KeyAll, "Skipping index: %s because EnableStarChannel is set to %t...", sgIndex.simpleName, EnableStarChannelLog)
 			continue
 		}

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -457,7 +457,7 @@ func setupN1QLStore(bucket base.Bucket, isServerless bool) ([]base.N1QLStore, re
 			return nil, nil, fmt.Errorf("Unable to get n1QLStore for testBucket")
 		}
 
-		if err := db.InitializeIndexes(n1QLStore, base.TestUseXattrs(), 0, false, isServerless); err != nil {
+		if err := db.InitializeIndexes(n1QLStore, base.TestUseXattrs(), 0, false, isServerless, true); err != nil {
 			return nil, nil, err
 		}
 		outN1QLStores = append(outN1QLStores, n1QLStore)

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -133,6 +133,9 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 
 // Validate query and stats for sequence view query
 func TestQuerySequencesStatsView(t *testing.T) {
+	if !EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	db, ctx := setupTestDBWithViewsEnabled(t)
 	defer db.Close(ctx)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -335,7 +335,7 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 			return err
 		}
 		tbp.Logf(ctx, "creating SG bucket indexes")
-		if err := InitializeIndexes(n1qlStore, base.TestUseXattrs(), 0, false, false); err != nil {
+		if err := InitializeIndexes(n1qlStore, base.TestUseXattrs(), 0, false, false, true); err != nil {
 			return err
 		}
 
@@ -367,7 +367,7 @@ func viewBucketReadier(ctx context.Context, dataStore base.DataStore, tbp *base.
 	}
 
 	tbp.Logf(ctx, "initializing bucket views")
-	err = InitializeViews(ctx, dataStore)
+	err = InitializeViews(ctx, dataStore, true)
 	if err != nil {
 		return err
 	}

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -60,6 +60,10 @@ func TestPublicChanGuestAccess(t *testing.T) {
 
 func TestStarAccess(t *testing.T) {
 
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges)
 
 	type allDocsRow struct {
@@ -561,6 +565,10 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 
 // Test _all_docs API call under different security scenarios
 func TestAllDocsAccessControl(t *testing.T) {
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
+
 	rt := NewRestTesterDefaultCollection(t, nil) // CBG-2618: fix collection channel access
 	defer rt.Close()
 	type allDocsRow struct {

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -60,10 +60,6 @@ func TestPublicChanGuestAccess(t *testing.T) {
 
 func TestStarAccess(t *testing.T) {
 
-	if !db.EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
-
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges)
 
 	type allDocsRow struct {
@@ -86,6 +82,11 @@ func TestStarAccess(t *testing.T) {
 	// Create some docs:
 	rt := NewRestTesterDefaultCollection(t, nil) // CBG-2618: fix collection channel access
 	defer rt.Close()
+
+	database := rt.ServerContext().Database(rt.Context(), "db")
+	if !database.Options.EnableStarChannel {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	a := auth.NewAuthenticator(rt.MetadataStore(), nil, auth.DefaultAuthenticatorOptions())
 	var changes struct {
@@ -565,12 +566,15 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 
 // Test _all_docs API call under different security scenarios
 func TestAllDocsAccessControl(t *testing.T) {
-	if !db.EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
 
 	rt := NewRestTesterDefaultCollection(t, nil) // CBG-2618: fix collection channel access
 	defer rt.Close()
+
+	database := rt.ServerContext().Database(rt.Context(), "db")
+	if !database.Options.EnableStarChannel {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
+
 	type allDocsRow struct {
 		ID    string `json:"id"`
 		Key   string `json:"key"`

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -870,6 +870,10 @@ func TestPurgeWithSomeInvalidDocs(t *testing.T) {
 }
 
 func TestRawRedaction(t *testing.T) {
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
+
 	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
 

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -870,12 +870,14 @@ func TestPurgeWithSomeInvalidDocs(t *testing.T) {
 }
 
 func TestRawRedaction(t *testing.T) {
-	if !db.EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
 
 	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
+
+	database := rt.ServerContext().Database(rt.Context(), "db")
+	if !database.Options.EnableStarChannel {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	res := rt.SendAdminRequest("PUT", "/db/testdoc", `{"foo":"bar", "channels": ["achannel"]}`)
 	rest.RequireStatus(t, res, http.StatusCreated)

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/couchbase/gocb/v2"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -107,6 +108,10 @@ func TestCollectionsPutDocInKeyspace(t *testing.T) {
 
 // TestCollectionsPublicChannel ensures that a doc routed to the public channel is accessible by a user with no other access.
 func TestCollectionsPublicChannel(t *testing.T) {
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
+
 	const (
 		username = "alice"
 		password = "pass"

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/couchbase/gocb/v2"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -108,9 +107,6 @@ func TestCollectionsPutDocInKeyspace(t *testing.T) {
 
 // TestCollectionsPublicChannel ensures that a doc routed to the public channel is accessible by a user with no other access.
 func TestCollectionsPublicChannel(t *testing.T) {
-	if !db.EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
 
 	const (
 		username = "alice"
@@ -127,6 +123,11 @@ func TestCollectionsPublicChannel(t *testing.T) {
 		},
 	})
 	defer rt.Close()
+
+	database := rt.ServerContext().Database(rt.Context(), "db")
+	if !database.Options.EnableStarChannel {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	keyspace := rt.getKeyspace()
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1094,6 +1094,9 @@ func TestResponseEncoding(t *testing.T) {
 }
 
 func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	type allDocsRow struct {
 		ID    string `json:"id"`

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2628,6 +2628,10 @@ func TestAttachmentDeleteOnExpiry(t *testing.T) {
 
 }
 func TestUpdateExistingAttachment(t *testing.T) {
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
+
 	rt := NewRestTester(t, &RestTesterConfig{
 		GuestEnabled: true,
 	})
@@ -2697,6 +2701,9 @@ func TestUpdateExistingAttachment(t *testing.T) {
 // TestPushUnknownAttachmentAsStub sets revpos to an older generation, for an attachment that doesn't exist on the server.
 // Verifies that getAttachment is triggered, and attachment is properly persisted.
 func TestPushUnknownAttachmentAsStub(t *testing.T) {
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 	rt := NewRestTester(t, &RestTesterConfig{
 		GuestEnabled: true,
 	})
@@ -2746,6 +2753,10 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 }
 
 func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rt := NewRestTester(t, &RestTesterConfig{
 		GuestEnabled: true,
@@ -2787,6 +2798,10 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 	assert.Equal(t, proveAttachmentBefore, proveAttachmentAfter)
 }
 func TestAttachmentWithErroneousRevPos(t *testing.T) {
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
+
 	rt := NewRestTester(t, &RestTesterConfig{
 		GuestEnabled: true,
 	})
@@ -2964,6 +2979,10 @@ func TestPutInvalidAttachment(t *testing.T) {
 // validates that proveAttachment isn't being invoked when the attachment is already present and the
 // digest doesn't change, regardless of revpos.
 func TestCBLRevposHandling(t *testing.T) {
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
+
 	rt := NewRestTester(t, &RestTesterConfig{
 		GuestEnabled: true,
 	})

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2628,15 +2628,16 @@ func TestAttachmentDeleteOnExpiry(t *testing.T) {
 
 }
 func TestUpdateExistingAttachment(t *testing.T) {
-	if !db.EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		GuestEnabled: true,
 	})
 	defer rt.Close()
 
+	database := rt.ServerContext().Database(rt.Context(), "db")
+	if !database.Options.EnableStarChannel {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 	btc, err := NewBlipTesterClient(t, rt)
 	assert.NoError(t, err)
 	defer btc.Close()
@@ -2701,13 +2702,16 @@ func TestUpdateExistingAttachment(t *testing.T) {
 // TestPushUnknownAttachmentAsStub sets revpos to an older generation, for an attachment that doesn't exist on the server.
 // Verifies that getAttachment is triggered, and attachment is properly persisted.
 func TestPushUnknownAttachmentAsStub(t *testing.T) {
-	if !db.EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
+
 	rt := NewRestTester(t, &RestTesterConfig{
 		GuestEnabled: true,
 	})
 	defer rt.Close()
+
+	database := rt.ServerContext().Database(rt.Context(), "db")
+	if !database.Options.EnableStarChannel {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	btc, err := NewBlipTesterClient(t, rt)
 	assert.NoError(t, err)
@@ -2753,10 +2757,6 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 }
 
 func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
-	if !db.EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
-
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rt := NewRestTester(t, &RestTesterConfig{
 		GuestEnabled: true,
@@ -2767,6 +2767,11 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 		},
 	})
 	defer rt.Close()
+
+	database := rt.ServerContext().Database(rt.Context(), "db")
+	if !database.Options.EnableStarChannel {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
 	require.NoError(t, err)
@@ -2798,14 +2803,15 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 	assert.Equal(t, proveAttachmentBefore, proveAttachmentAfter)
 }
 func TestAttachmentWithErroneousRevPos(t *testing.T) {
-	if !db.EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
-
 	rt := NewRestTester(t, &RestTesterConfig{
 		GuestEnabled: true,
 	})
 	defer rt.Close()
+
+	database := rt.ServerContext().Database(rt.Context(), "db")
+	if !database.Options.EnableStarChannel {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
 	require.NoError(t, err)
@@ -2979,14 +2985,16 @@ func TestPutInvalidAttachment(t *testing.T) {
 // validates that proveAttachment isn't being invoked when the attachment is already present and the
 // digest doesn't change, regardless of revpos.
 func TestCBLRevposHandling(t *testing.T) {
-	if !db.EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		GuestEnabled: true,
 	})
 	defer rt.Close()
+
+	database := rt.ServerContext().Database(rt.Context(), "db")
+	if !database.Options.EnableStarChannel {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	btc, err := NewBlipTesterClient(t, rt)
 	assert.NoError(t, err)

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -33,6 +33,10 @@ import (
 // 4. Update doc in the test client and keep the same attachment stub.
 // 5. Have that update pushed via the continuous replication started in step 2
 func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{
@@ -111,6 +115,10 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 // 4. Update doc in the test client and keep the same attachment stub.
 // 5. Have that update pushed via the continuous replication started in step 2
 func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -33,9 +33,6 @@ import (
 // 4. Update doc in the test client and keep the same attachment stub.
 // 5. Have that update pushed via the continuous replication started in step 2
 func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
-	if !db.EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
@@ -50,6 +47,11 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
+
+	database := rt.ServerContext().Database(rt.Context(), "db")
+	if !database.Options.EnableStarChannel {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	opts := &BlipTesterClientOpts{}
 	opts.SupportedBLIPProtocols = []string{db.BlipCBMobileReplicationV2}
@@ -115,9 +117,6 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 // 4. Update doc in the test client and keep the same attachment stub.
 // 5. Have that update pushed via the continuous replication started in step 2
 func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
-	if !db.EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
@@ -132,6 +131,11 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
+
+	database := rt.ServerContext().Database(rt.Context(), "db")
+	if !database.Options.EnableStarChannel {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
 	require.NoError(t, err)

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -28,7 +28,9 @@ import (
 // HTTP handler for _all_docs
 func (h *handler) handleAllDocs() error {
 
-	if !db.EnableStarChannelLog {
+	dbName := h.db.Bucket.GetName()
+
+	if h.server.databases_[dbName] != nil && !h.server.databases_[dbName].Options.EnableStarChannel {
 		return base.HTTPErrorf(http.StatusBadRequest, "_all_docs endpoint is only available when '*' Channel is enabled. set 'cache.channel_cache.enable_star_channel':true in Sync Gateway's database config.")
 	}
 

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -29,7 +29,7 @@ import (
 func (h *handler) handleAllDocs() error {
 
 	if !db.EnableStarChannelLog {
-		return base.HTTPErrorf(http.StatusBadRequest, "_all_docs endpoint is only available when `enable_star_channel` is true")
+		return base.HTTPErrorf(http.StatusBadRequest, "_all_docs endpoint is only available when '*' Channel is enabled. set 'cache.channel_cache.enable_star_channel':true in Sync Gateway's database config.")
 	}
 
 	// http://wiki.apache.org/couchdb/HTTP_Bulk_Document_API

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -27,6 +27,11 @@ import (
 
 // HTTP handler for _all_docs
 func (h *handler) handleAllDocs() error {
+
+	if !db.EnableStarChannelLog {
+		return base.HTTPErrorf(http.StatusBadRequest, "_all_docs endpoint is only available when `enable_star_channel` is true")
+	}
+
 	// http://wiki.apache.org/couchdb/HTTP_Bulk_Document_API
 	includeDocs := h.getBoolQuery("include_docs")
 	includeChannels := h.getBoolQuery("channels")

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -879,6 +879,10 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 // Reproduces CBG-1113 and #1329 (even with the fix in PR #1360)
 // Tests all combinations of HTTP feed types, admin/non-admin, and with and without a manual notify to wake up.
 func TestChangeWaiterExitOnChangesTermination(t *testing.T) {
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
+
 	base.LongRunningTest(t)
 
 	const username = "bernard"
@@ -1191,6 +1195,9 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 // subsequent requests for the current low sequence value don't return results (avoids loops for
 // longpoll as well as clients doing repeated one-off changes requests - see #1309)
 func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	if base.TestUseXattrs() {
 		t.Skip("This test cannot run in xattr mode until WriteDirect() is updated.  See https://github.com/couchbase/sync_gateway/issues/2666#issuecomment-311183219")

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -3685,6 +3685,10 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 //   - Publishes the REST API on a httptest server for the passive node (so the active can connect to it)
 //   - Uses an ActiveReplicator configured for pull to start pulling changes from rt2.
 func TestActiveReplicatorPullConflict(t *testing.T) {
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
+
 	base.LongRunningTest(t)
 
 	// scenarios
@@ -3917,6 +3921,9 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 //   - Uses an ActiveReplicator configured for pushAndPull from rt2.
 //   - verifies expected conflict resolution, and that expected result is replicated to both peers
 func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	base.LongRunningTest(t)
 
@@ -5592,6 +5599,9 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 //   - Publishes the REST API on a httptest server for the passive node (so the active can connect to it)
 //   - Uses an ActiveReplicator configured for pull to start pulling changes from rt2.
 func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	base.LongRunningTest(t)
 
@@ -5907,6 +5917,10 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 	}
 }
 func TestSGR2TombstoneConflictHandling(t *testing.T) {
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
+
 	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
@@ -6961,6 +6975,10 @@ func TestReplicatorConflictAttachment(t *testing.T) {
 	}
 }
 func TestConflictResolveMergeWithMutatedRev(t *testing.T) {
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	base.RequireNumTestBuckets(t, 2)
@@ -7333,6 +7351,10 @@ func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 // CBG-1995: Test the support for using an underscore prefix in the top-level body of a document
 // Tests replication and Rest API
 func TestUnderscorePrefixSupport(t *testing.T) {
+	if !db.EnableStarChannelLog {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
+
 	base.RequireNumTestBuckets(t, 2)
 
 	// Passive //

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -3685,9 +3685,6 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 //   - Publishes the REST API on a httptest server for the passive node (so the active can connect to it)
 //   - Uses an ActiveReplicator configured for pull to start pulling changes from rt2.
 func TestActiveReplicatorPullConflict(t *testing.T) {
-	if !db.EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
 
 	base.LongRunningTest(t)
 
@@ -3819,6 +3816,11 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			defer rt1.Close()
 			ctx1 := rt1.Context()
 
+			database := rt1.ServerContext().Database(ctx1, "db")
+			if !database.Options.EnableStarChannel {
+				t.Skip("This test requires StarChannel to be enabled")
+			}
+
 			// Create revision on rt1 (local)
 			resp, err = rt1.PutDocumentWithRevID(docID, test.localRevID, "", test.localRevisionBody)
 			assert.NoError(t, err)
@@ -3921,10 +3923,6 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 //   - Uses an ActiveReplicator configured for pushAndPull from rt2.
 //   - verifies expected conflict resolution, and that expected result is replicated to both peers
 func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
-	if !db.EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
-
 	base.LongRunningTest(t)
 
 	// scenarios
@@ -4053,6 +4051,11 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 				})
 			defer rt1.Close()
 			ctx1 := rt1.Context()
+
+			database := rt1.ServerContext().Database(ctx1, "db")
+			if !database.Options.EnableStarChannel {
+				t.Skip("This test requires StarChannel to be enabled")
+			}
 
 			// Create revision on rt1 (local)
 			if test.commonAncestorRevID != "" {
@@ -5599,10 +5602,6 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 //   - Publishes the REST API on a httptest server for the passive node (so the active can connect to it)
 //   - Uses an ActiveReplicator configured for pull to start pulling changes from rt2.
 func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
-	if !db.EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
-
 	base.LongRunningTest(t)
 
 	createRevID := func(generation int, parentRevID string, body db.Body) string {
@@ -5917,10 +5916,6 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 	}
 }
 func TestSGR2TombstoneConflictHandling(t *testing.T) {
-	if !db.EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
-
 	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
@@ -6054,6 +6049,11 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 					SgReplicateEnabled: true,
 				})
 			defer localActiveRT.Close()
+
+			database := localActiveRT.ServerContext().Database(localActiveRT.Context(), "db")
+			if !database.Options.EnableStarChannel {
+				t.Skip("This test requires StarChannel to be enabled")
+			}
 
 			replConf := `
 			{
@@ -6975,10 +6975,6 @@ func TestReplicatorConflictAttachment(t *testing.T) {
 	}
 }
 func TestConflictResolveMergeWithMutatedRev(t *testing.T) {
-	if !db.EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
-
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	base.RequireNumTestBuckets(t, 2)
@@ -6994,6 +6990,11 @@ func TestConflictResolveMergeWithMutatedRev(t *testing.T) {
 		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
+
+	database := rt1.ServerContext().Database(ctx1, "db")
+	if !database.Options.EnableStarChannel {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	srv := httptest.NewServer(rt2.TestAdminHandler())
 	defer srv.Close()
@@ -7351,10 +7352,6 @@ func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 // CBG-1995: Test the support for using an underscore prefix in the top-level body of a document
 // Tests replication and Rest API
 func TestUnderscorePrefixSupport(t *testing.T) {
-	if !db.EnableStarChannelLog {
-		t.Skip("This test requires StarChannel to be enabled")
-	}
-
 	base.RequireNumTestBuckets(t, 2)
 
 	// Passive //
@@ -7369,6 +7366,11 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 	activeRT := rest.NewRestTesterDefaultCollection(t, nil) // CBG-2319: replicator currently requires default collection
 	defer activeRT.Close()
 	activeCtx := activeRT.Context()
+
+	database := activeRT.ServerContext().Database(activeCtx, "db")
+	if !database.Options.EnableStarChannel {
+		t.Skip("This test requires StarChannel to be enabled")
+	}
 
 	// Create the document
 	docID := t.Name()

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1115,7 +1115,8 @@ func TestFunkyUsernames(t *testing.T) {
 			defer rt.Close()
 
 			ctx := rt.Context()
-			a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
+			database := rt.ServerContext().Database(ctx, "db")
+			a := database.Authenticator(ctx)
 
 			// Create a test user
 			user, err := a.NewUser(tc.UserName, "letmein", channels.BaseSetOf(t, "foo"))
@@ -1126,7 +1127,7 @@ func TestFunkyUsernames(t *testing.T) {
 			RequireStatus(t, response, 201)
 
 			// _all_docs only works when EnableStarChannelLog is set to true
-			if db.EnableStarChannelLog {
+			if database.Options.EnableStarChannel {
 				response = rt.Send(RequestByUser("GET", "/db/_all_docs", "", tc.UserName))
 				RequireStatus(t, response, 200)
 			}

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1125,8 +1125,11 @@ func TestFunkyUsernames(t *testing.T) {
 			response := rt.Send(RequestByUser("PUT", "/db/AC+DC", `{"foo":"bar", "channels": ["foo"]}`, tc.UserName))
 			RequireStatus(t, response, 201)
 
-			response = rt.Send(RequestByUser("GET", "/db/_all_docs", "", tc.UserName))
-			RequireStatus(t, response, 200)
+			// _all_docs only works when EnableStarChannelLog is set to true
+			if db.EnableStarChannelLog {
+				response = rt.Send(RequestByUser("GET", "/db/_all_docs", "", tc.UserName))
+				RequireStatus(t, response, 200)
+			}
 
 			response = rt.Send(RequestByUser("GET", "/db/AC+DC", "", tc.UserName))
 			RequireStatus(t, response, 200)


### PR DESCRIPTION
CBG-0000

Describe your PR here...
- When starChannel is not enable, we do not create allDocs index anymore
-  Returns error message when _all_docs endpoint is called but allDocs index doesn't exist because starChannel was disabled


## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
