### PR TITLE
Start counting datastores at zero

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -105,6 +105,7 @@ func (tb *TestBucket) NoCloseClone() *TestBucket {
 
 // GetTestBucket returns a test bucket from a pool.
 func GetTestBucket(t testing.TB) *TestBucket {
+	//debug.PrintStack()
 	return getTestBucket(t)
 }
 
@@ -125,7 +126,7 @@ func (tb *TestBucket) GetNamedDataStore(count int) DataStore {
 	if count > len(dataStoreNames) {
 		tb.t.Errorf("You are requesting more datastores %d than are available on this test instance %d", dataStoreNames, count)
 	}
-	return tb.Bucket.NamedDataStore(dataStoreNames[count-1])
+	return tb.Bucket.NamedDataStore(dataStoreNames[count])
 }
 
 // Return a sorted list of data store names
@@ -155,7 +156,7 @@ func (tb *TestBucket) GetNonDefaultDatastoreNames() []sgbucket.DataStoreName {
 // This may be the default collection, or a named collection depending on whether SG_TEST_USE_DEFAULT_COLLECTION is set.
 func (b *TestBucket) GetSingleDataStore() sgbucket.DataStore {
 	if TestsUseNamedCollections() {
-		return b.GetNamedDataStore(1)
+		return b.GetNamedDataStore(0)
 	}
 	return b.Bucket.DefaultDataStore()
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1104,31 +1104,33 @@ func TestConflicts(t *testing.T) {
 
 }
 
-func TestConflictRevLimit(t *testing.T) {
+func TestConflictRevLimitDefault(t *testing.T) {
 
 	// Test Default Is the higher of the two
 	db, ctx := setupTestDB(t)
-	assert.Equal(t, uint32(DefaultRevsLimitConflicts), db.RevsLimit)
 	defer db.Close(ctx)
+	assert.Equal(t, uint32(DefaultRevsLimitConflicts), db.RevsLimit)
+}
 
+func TestConflictRevLimitAllowConflictsTrue(t *testing.T) {
 	// Test AllowConflicts
 	dbOptions := DatabaseContextOptions{
 		AllowConflicts: base.BoolPtr(true),
 	}
 
-	db, ctx = SetupTestDBWithOptions(t, dbOptions)
-	assert.Equal(t, uint32(DefaultRevsLimitConflicts), db.RevsLimit)
+	db, ctx := SetupTestDBWithOptions(t, dbOptions)
 	defer db.Close(ctx)
+	assert.Equal(t, uint32(DefaultRevsLimitConflicts), db.RevsLimit)
+}
 
-	// Test AllowConflicts false
-	dbOptions = DatabaseContextOptions{
+func TestConflictRevLimitAllowConflictsFalse(t *testing.T) {
+	dbOptions := DatabaseContextOptions{
 		AllowConflicts: base.BoolPtr(false),
 	}
 
-	db, ctx = SetupTestDBWithOptions(t, dbOptions)
-	assert.Equal(t, uint32(DefaultRevsLimitNoConflicts), db.RevsLimit)
+	db, ctx := SetupTestDBWithOptions(t, dbOptions)
 	defer db.Close(ctx)
-
+	assert.Equal(t, uint32(DefaultRevsLimitNoConflicts), db.RevsLimit)
 }
 
 func TestNoConflictsMode(t *testing.T) {
@@ -2700,11 +2702,12 @@ func TestGetDatabaseCollectionWithUserNoScopesConfigured(t *testing.T) {
 
 func TestGetDatabaseCollectionWithUserDefaultCollection(t *testing.T) {
 	base.TestRequiresCollections(t)
+	base.RequireNumTestDataStores(t, 1)
 
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
 
-	ds := bucket.GetNamedDataStore(1)
+	ds := bucket.GetNamedDataStore(0)
 	require.NotNil(t, ds)
 
 	dataStoreName, ok := base.AsDataStoreName(ds)

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -2080,6 +2080,8 @@ func TestSwitchDbConfigCollectionName(t *testing.T) {
 	}
 	base.TestRequiresCollections(t)
 
+	base.RequireNumTestDataStores(t, 2)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 	serverErr := make(chan error, 0)
 
@@ -2105,10 +2107,10 @@ func TestSwitchDbConfigCollectionName(t *testing.T) {
 		tb.Close()
 	}()
 
-	dataStore1 := tb.GetNamedDataStore(1)
+	dataStore1 := tb.GetNamedDataStore(0)
 	dataStore1Name, ok := base.AsDataStoreName(dataStore1)
 	require.True(t, ok)
-	dataStore2 := tb.GetNamedDataStore(2)
+	dataStore2 := tb.GetNamedDataStore(1)
 	dataStore2Name, ok := base.AsDataStoreName(dataStore2)
 	require.True(t, ok)
 	keyspace1 := fmt.Sprintf("%s.%s.%s", "db", dataStore1Name.ScopeName(), dataStore1Name.CollectionName())

--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -21,6 +21,9 @@ import (
 func TestCollectionsSyncImportFunctions(t *testing.T) {
 	base.SkipImportTestsIfNotEnabled(t)
 
+	numCollections := 2
+	base.RequireNumTestDataStores(t, numCollections)
+
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
 
@@ -35,10 +38,10 @@ func TestCollectionsSyncImportFunctions(t *testing.T) {
 	syncFunction1 := `function (doc) { console.log('syncFunction1'); return true }`
 	syncFunction2 := `function (doc) { console.log('syncFunction2'); return doc.type == 'onprem'}`
 
-	dataStore1 := tb.GetNamedDataStore(1)
+	dataStore1 := tb.GetNamedDataStore(0)
 	dataStore1Name, ok := base.AsDataStoreName(dataStore1)
 	require.True(t, ok)
-	dataStore2 := tb.GetNamedDataStore(2)
+	dataStore2 := tb.GetNamedDataStore(1)
 	dataStore2Name, ok := base.AsDataStoreName(dataStore2)
 	require.True(t, ok)
 	keyspace1 := fmt.Sprintf("%s.%s.%s", "db", dataStore1Name.ScopeName(), dataStore1Name.CollectionName())

--- a/rest/changestest/changes_collection_test.go
+++ b/rest/changestest/changes_collection_test.go
@@ -26,7 +26,9 @@ func TestMultiCollectionChangesAdmin(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyChanges, base.KeyCache)
 
-	rt, keyspaces := rest.NewRestTesterMultipleCollections(t, nil, 2)
+	numCollections := 2
+	base.RequireNumTestDataStores(t, numCollections)
+	rt, keyspaces := rest.NewRestTesterMultipleCollections(t, nil, numCollections)
 	defer rt.Close()
 
 	c1Keyspace := keyspaces[0]
@@ -82,7 +84,9 @@ func TestMultiCollectionChangesAdminSameChannelName(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyChanges, base.KeyCache)
 
-	rt, keyspaces := rest.NewRestTesterMultipleCollections(t, nil, 2)
+	numCollections := 2
+	base.RequireNumTestDataStores(t, numCollections)
+	rt, keyspaces := rest.NewRestTesterMultipleCollections(t, nil, numCollections)
 	defer rt.Close()
 
 	c1Keyspace := keyspaces[0]
@@ -136,8 +140,9 @@ func TestMultiCollectionChangesAdminSameChannelName(t *testing.T) {
 func TestMultiCollectionChangesUser(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyChanges, base.KeyCache, base.KeyCRUD)
-
-	rt, keyspaces := rest.NewRestTesterMultipleCollections(t, nil, 2)
+	numCollections := 2
+	base.RequireNumTestDataStores(t, numCollections)
+	rt, keyspaces := rest.NewRestTesterMultipleCollections(t, nil, numCollections)
 	defer rt.Close()
 
 	c1Keyspace := keyspaces[0]
@@ -200,8 +205,9 @@ func TestMultiCollectionChangesUser(t *testing.T) {
 func TestMultiCollectionChangesUserDynamicGrant(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyChanges, base.KeyCache, base.KeyCRUD)
-
-	rt, keyspaces := rest.NewRestTesterMultipleCollections(t, nil, 2)
+	numCollections := 2
+	base.RequireNumTestDataStores(t, numCollections)
+	rt, keyspaces := rest.NewRestTesterMultipleCollections(t, nil, numCollections)
 	defer rt.Close()
 
 	c1Keyspace := keyspaces[0]
@@ -268,8 +274,9 @@ func TestMultiCollectionChangesUserDynamicGrant(t *testing.T) {
 func TestMultiCollectionChangesUserDynamicGrantDCP(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyChanges, base.KeyCache, base.KeyCRUD)
-
-	rt, keyspaces := rest.NewRestTesterMultipleCollections(t, nil, 2)
+	numCollections := 2
+	base.RequireNumTestDataStores(t, numCollections)
+	rt, keyspaces := rest.NewRestTesterMultipleCollections(t, nil, numCollections)
 	defer rt.Close()
 
 	c1Keyspace := keyspaces[0]
@@ -364,8 +371,10 @@ func TestMultiCollectionChangesUserDynamicGrantDCP(t *testing.T) {
 func TestMultiCollectionChangesCustomSyncFunctions(t *testing.T) {
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyChanges, base.KeyCache, base.KeyCRUD)
-	testBucket := base.GetTestBucket(t)
 	numCollections := 2
+	base.RequireNumTestDataStores(t, numCollections)
+
+	testBucket := base.GetTestBucket(t)
 	scopesConfig := rest.GetCollectionsConfig(t, testBucket, numCollections)
 	dataStoreNames := rest.GetDataStoreNamesFromScopesConfig(scopesConfig)
 


### PR DESCRIPTION
- place requirements for number of datastores

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1235/
