### PR TITLE
CBG-2553 Make principal API for default collection access control non-public

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -29,7 +29,7 @@ import (
 
 func canSeeAllChannels(princ Principal, channels base.Set) bool {
 	for channel := range channels {
-		if !princ.CanSeeChannel(channel) {
+		if !princ.canSeeChannel(channel) {
 			return false
 		}
 	}
@@ -182,69 +182,69 @@ func TestUserAccess(t *testing.T) {
 	dataStore := bucket.GetSingleDataStore()
 	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions())
 	user, _ := auth.NewUser("foo", "password", nil)
-	assert.Equal(t, ch.BaseSetOf(t, "!"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
-	assert.False(t, user.CanSeeChannel("x"))
+	assert.Equal(t, ch.BaseSetOf(t, "!"), user.expandWildCardChannel(ch.BaseSetOf(t, "*")))
+	assert.False(t, user.canSeeChannel("x"))
 	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t)))
 	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x")))
 	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x", "y")))
 	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "*")))
-	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
-	assert.False(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t, "x", "y")) == nil)
-	assert.False(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t)) == nil)
+	assert.False(t, user.authorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
+	assert.False(t, user.authorizeAnyChannel(ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.authorizeAnyChannel(ch.BaseSetOf(t)) == nil)
 
 	// User with access to one channel:
 	user.setChannels(ch.AtSequence(ch.BaseSetOf(t, "x"), 1))
-	assert.Equal(t, ch.BaseSetOf(t, "x"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
+	assert.Equal(t, ch.BaseSetOf(t, "x"), user.expandWildCardChannel(ch.BaseSetOf(t, "*")))
 	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t)))
 	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x")))
 	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x", "y")))
-	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "x", "y")) == nil)
-	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
-	assert.True(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t, "x", "y")) == nil)
-	assert.False(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t, "y")) == nil)
-	assert.False(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t)) == nil)
+	assert.False(t, user.authorizeAllChannels(ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.authorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
+	assert.True(t, user.authorizeAnyChannel(ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.authorizeAnyChannel(ch.BaseSetOf(t, "y")) == nil)
+	assert.False(t, user.authorizeAnyChannel(ch.BaseSetOf(t)) == nil)
 
 	// User with access to one channel and one derived channel:
 	user.setChannels(ch.AtSequence(ch.BaseSetOf(t, "x", "z"), 1))
-	assert.Equal(t, ch.BaseSetOf(t, "x", "z"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
-	assert.Equal(t, ch.BaseSetOf(t, "x"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "x")))
+	assert.Equal(t, ch.BaseSetOf(t, "x", "z"), user.expandWildCardChannel(ch.BaseSetOf(t, "*")))
+	assert.Equal(t, ch.BaseSetOf(t, "x"), user.expandWildCardChannel(ch.BaseSetOf(t, "x")))
 	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t)))
 	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x")))
 	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x", "y")))
-	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "x", "y")) == nil)
-	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
+	assert.False(t, user.authorizeAllChannels(ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.authorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
 
 	// User with access to two channels:
 	user.setChannels(ch.AtSequence(ch.BaseSetOf(t, "x", "z"), 1))
-	assert.Equal(t, ch.BaseSetOf(t, "x", "z"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
-	assert.Equal(t, ch.BaseSetOf(t, "x"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "x")))
+	assert.Equal(t, ch.BaseSetOf(t, "x", "z"), user.expandWildCardChannel(ch.BaseSetOf(t, "*")))
+	assert.Equal(t, ch.BaseSetOf(t, "x"), user.expandWildCardChannel(ch.BaseSetOf(t, "x")))
 	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t)))
 	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x")))
 	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x", "y")))
-	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "x", "y")) == nil)
-	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
+	assert.False(t, user.authorizeAllChannels(ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.authorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
 
 	user.setChannels(ch.AtSequence(ch.BaseSetOf(t, "x", "y"), 1))
-	assert.Equal(t, ch.BaseSetOf(t, "x", "y"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
+	assert.Equal(t, ch.BaseSetOf(t, "x", "y"), user.expandWildCardChannel(ch.BaseSetOf(t, "*")))
 	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t)))
 	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x")))
 	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x", "y")))
 	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x", "y", "z")))
-	assert.True(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "x", "y")) == nil)
-	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
+	assert.True(t, user.authorizeAllChannels(ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.authorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
 
 	// User with wildcard access:
 	user.setChannels(ch.AtSequence(ch.BaseSetOf(t, "*", "q"), 1))
-	assert.Equal(t, ch.BaseSetOf(t, "*", "q"), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
-	assert.True(t, user.CanSeeChannel("*"))
+	assert.Equal(t, ch.BaseSetOf(t, "*", "q"), user.expandWildCardChannel(ch.BaseSetOf(t, "*")))
+	assert.True(t, user.canSeeChannel("*"))
 	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t)))
 	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x")))
 	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x", "y")))
-	assert.True(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "x", "y")) == nil)
-	assert.True(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
-	assert.True(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t, "x")) == nil)
-	assert.True(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t, "*")) == nil)
-	assert.True(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t)) == nil)
+	assert.True(t, user.authorizeAllChannels(ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.True(t, user.authorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
+	assert.True(t, user.authorizeAnyChannel(ch.BaseSetOf(t, "x")) == nil)
+	assert.True(t, user.authorizeAnyChannel(ch.BaseSetOf(t, "*")) == nil)
+	assert.True(t, user.authorizeAnyChannel(ch.BaseSetOf(t)) == nil)
 }
 
 func TestGetMissingUser(t *testing.T) {
@@ -539,12 +539,12 @@ func TestRoleInheritance(t *testing.T) {
 	assert.Equal(t, nil, err)
 	log.Printf("Channels = %s", user2.Channels())
 	assert.Equal(t, ch.AtSequence(ch.BaseSetOf(t, "!", "britain"), 1), user2.Channels())
-	assert.Equal(t, ch.TimedSet{"!": ch.NewVbSimpleSequence(0x1), "britain": ch.NewVbSimpleSequence(0x1), "dull": ch.NewVbSimpleSequence(0x3), "duller": ch.NewVbSimpleSequence(0x3), "dullest": ch.NewVbSimpleSequence(0x3), "hoopy": ch.NewVbSimpleSequence(0x4), "hoopier": ch.NewVbSimpleSequence(0x4), "hoopiest": ch.NewVbSimpleSequence(0x4)}, user2.InheritedChannels())
+	assert.Equal(t, ch.TimedSet{"!": ch.NewVbSimpleSequence(0x1), "britain": ch.NewVbSimpleSequence(0x1), "dull": ch.NewVbSimpleSequence(0x3), "duller": ch.NewVbSimpleSequence(0x3), "dullest": ch.NewVbSimpleSequence(0x3), "hoopy": ch.NewVbSimpleSequence(0x4), "hoopier": ch.NewVbSimpleSequence(0x4), "hoopiest": ch.NewVbSimpleSequence(0x4)}, user2.inheritedChannels())
 
-	assert.True(t, user2.CanSeeChannel("britain"))
-	assert.True(t, user2.CanSeeChannel("duller"))
-	assert.True(t, user2.CanSeeChannel("hoopy"))
-	assert.Equal(t, nil, user2.AuthorizeAllChannels(ch.BaseSetOf(t, "britain", "dull", "hoopiest")))
+	assert.True(t, user2.canSeeChannel("britain"))
+	assert.True(t, user2.canSeeChannel("duller"))
+	assert.True(t, user2.canSeeChannel("hoopy"))
+	assert.Equal(t, nil, user2.authorizeAllChannels(ch.BaseSetOf(t, "britain", "dull", "hoopiest")))
 }
 
 func TestRegisterUser(t *testing.T) {
@@ -1252,18 +1252,18 @@ func TestGetPrincipal(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, roleRoot, principal.Name())
 	assert.Equal(t, accessViewKeyRoot, principal.accessViewKey())
-	assert.True(t, principal.CanSeeChannel(channelRead))
-	assert.True(t, principal.CanSeeChannel(channelWrite))
-	assert.True(t, principal.CanSeeChannel(channelExecute))
+	assert.True(t, principal.canSeeChannel(channelRead))
+	assert.True(t, principal.canSeeChannel(channelWrite))
+	assert.True(t, principal.canSeeChannel(channelExecute))
 
 	// Get the principal against user role and verify the details.
 	principal, err = auth.GetPrincipal(roleUser, false)
 	assert.NoError(t, err)
 	assert.Equal(t, roleUser, principal.Name())
 	assert.Equal(t, accessViewKeyUser, principal.accessViewKey())
-	assert.True(t, principal.CanSeeChannel(channelRead))
-	assert.False(t, principal.CanSeeChannel(channelWrite))
-	assert.True(t, principal.CanSeeChannel(channelExecute))
+	assert.True(t, principal.canSeeChannel(channelRead))
+	assert.False(t, principal.canSeeChannel(channelWrite))
+	assert.True(t, principal.canSeeChannel(channelExecute))
 
 	// Create a new user with new set of channels and assign user role to the user.
 	user, err := auth.NewUser(username, password, ch.BaseSetOf(
@@ -1276,12 +1276,12 @@ func TestGetPrincipal(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, username, principal.Name())
 	assert.Equal(t, username, principal.accessViewKey())
-	assert.True(t, principal.CanSeeChannel(channelRead))
-	assert.False(t, principal.CanSeeChannel(channelWrite))
-	assert.True(t, principal.CanSeeChannel(channelExecute))
-	assert.True(t, principal.CanSeeChannel(channelCreate))
-	assert.True(t, principal.CanSeeChannel(channelUpdate))
-	assert.True(t, principal.CanSeeChannel(channelDelete))
+	assert.True(t, principal.canSeeChannel(channelRead))
+	assert.False(t, principal.canSeeChannel(channelWrite))
+	assert.True(t, principal.canSeeChannel(channelExecute))
+	assert.True(t, principal.canSeeChannel(channelCreate))
+	assert.True(t, principal.canSeeChannel(channelUpdate))
+	assert.True(t, principal.canSeeChannel(channelDelete))
 }
 
 // Encode the given string to base64.
@@ -1565,11 +1565,11 @@ func TestRevocationScenario1(t *testing.T) {
 	// Ensure user can see ch1 (via role)
 	// Verify history
 	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
-	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
+	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	// Get Principals / Rebuild Seq 40
@@ -1578,11 +1578,11 @@ func TestRevocationScenario1(t *testing.T) {
 	// Ensure user can see ch1 (via role)
 	// Verify history
 	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
-	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(25, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -1597,11 +1597,11 @@ func TestRevocationScenario1(t *testing.T) {
 	// Ensure user can see ch1 (via role)
 	// Verify history
 	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
-	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(40, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(40, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
@@ -1612,14 +1612,14 @@ func TestRevocationScenario1(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 75, EndSeq: 85}, channelHistory.Entries[0])
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(80, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 }
@@ -1659,11 +1659,11 @@ func TestRevocationScenario2(t *testing.T) {
 	// Ensure user can see ch1 (via role)
 	// Verify history
 	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
-	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
+	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -1673,13 +1673,13 @@ func TestRevocationScenario2(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(25, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(45), revokedChannelsCombined["ch1"])
 
@@ -1692,11 +1692,11 @@ func TestRevocationScenario2(t *testing.T) {
 
 	// Ensure user can see ch1 (via role)
 	// Verify history
-	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(50, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(50, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
@@ -1707,7 +1707,7 @@ func TestRevocationScenario2(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	userRoleHistory, ok = aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
@@ -1719,7 +1719,7 @@ func TestRevocationScenario2(t *testing.T) {
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(80, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 }
@@ -1759,11 +1759,11 @@ func TestRevocationScenario3(t *testing.T) {
 	// Ensure user can see ch1 (via role)
 	// Verify history
 	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
-	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(55, 0, 0)
+	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(55, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -1774,7 +1774,7 @@ func TestRevocationScenario3(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
@@ -1785,7 +1785,7 @@ func TestRevocationScenario3(t *testing.T) {
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(25, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(45), revokedChannelsCombined["ch1"])
 
@@ -1797,12 +1797,12 @@ func TestRevocationScenario3(t *testing.T) {
 
 	// Ensure user can see ch1 (via role)
 	// Verify history
-	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 1, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 1, len(fooPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(60, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(60, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
@@ -1813,7 +1813,7 @@ func TestRevocationScenario3(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 
 	userRoleHistory, ok = aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
@@ -1828,7 +1828,7 @@ func TestRevocationScenario3(t *testing.T) {
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(80, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 }
@@ -1868,11 +1868,11 @@ func TestRevocationScenario4(t *testing.T) {
 	// Ensure user can see ch1 (via role)
 	// Verify history
 	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
-	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
+	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -1885,13 +1885,13 @@ func TestRevocationScenario4(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(25, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(55), revokedChannelsCombined["ch1"])
 
@@ -1902,11 +1902,11 @@ func TestRevocationScenario4(t *testing.T) {
 
 	// Ensure user can see ch1 (via role)
 	// Verify history
-	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 1, len(fooPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(70, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(70, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
@@ -1917,7 +1917,7 @@ func TestRevocationScenario4(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
@@ -1926,7 +1926,7 @@ func TestRevocationScenario4(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 75, EndSeq: 85}, channelHistory.Entries[1])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(80, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 }
@@ -1964,11 +1964,11 @@ func TestRevocationScenario5(t *testing.T) {
 	// Ensure user can see ch1 (via role)
 	// Verify history
 	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
-	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
+	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -1982,11 +1982,11 @@ func TestRevocationScenario5(t *testing.T) {
 
 	// Ensure user can see ch1 (via role)
 	// Verify history
-	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(25, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
@@ -1997,7 +1997,7 @@ func TestRevocationScenario5(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
@@ -2006,7 +2006,7 @@ func TestRevocationScenario5(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 75, EndSeq: 85}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(80, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 }
@@ -2044,11 +2044,11 @@ func TestRevocationScenario6(t *testing.T) {
 	// Ensure user can see ch1 (via role)
 	// Verify history
 	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
-	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
+	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	require.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -2064,13 +2064,13 @@ func TestRevocationScenario6(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(25, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(55), revokedChannelsCombined["ch1"])
 
@@ -2081,7 +2081,7 @@ func TestRevocationScenario6(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
@@ -2090,7 +2090,7 @@ func TestRevocationScenario6(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(25, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 1)
 	assert.Equal(t, uint64(55), revokedChannelsCombined["ch1"])
 }
@@ -2128,11 +2128,11 @@ func TestRevocationScenario7(t *testing.T) {
 	// Ensure user can see ch1 (via role)
 	// Verify history
 	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
-	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
+	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -2149,7 +2149,7 @@ func TestRevocationScenario7(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
@@ -2160,7 +2160,7 @@ func TestRevocationScenario7(t *testing.T) {
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(25, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(45), revokedChannelsCombined["ch1"])
 
@@ -2169,12 +2169,12 @@ func TestRevocationScenario7(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 
 	assert.Equal(t, 1, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 1, len(fooPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(100, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(100, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -2210,11 +2210,11 @@ func TestRevocationScenario8(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(50, 0, 0)
+	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(50, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 55)
@@ -2230,13 +2230,13 @@ func TestRevocationScenario8(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(50, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(50, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -2273,11 +2273,11 @@ func TestRevocationScenario9(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
+	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.addRole(t, auth, "alice", "foo", 65)
@@ -2291,11 +2291,11 @@ func TestRevocationScenario9(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(60, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(60, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -2334,11 +2334,11 @@ func TestRevocationScenario10(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
+	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 75)
@@ -2351,13 +2351,13 @@ func TestRevocationScenario10(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(70, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(70, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -2397,11 +2397,11 @@ func TestRevocationScenario11(t *testing.T) {
 
 	// Ensure user can see ch1 (via role)
 	// Verify history
-	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
+	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
@@ -2412,7 +2412,7 @@ func TestRevocationScenario11(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
@@ -2424,7 +2424,7 @@ func TestRevocationScenario11(t *testing.T) {
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(80, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 }
@@ -2467,11 +2467,11 @@ func TestRevocationScenario12(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
+	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 95)
@@ -2481,13 +2481,13 @@ func TestRevocationScenario12(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(90, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(90, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -2530,11 +2530,11 @@ func TestRevocationScenario13(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
+	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	// Rebuild seq 110
@@ -2542,11 +2542,11 @@ func TestRevocationScenario13(t *testing.T) {
 
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
-	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(100, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(100, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -2588,15 +2588,15 @@ func TestRevocationScenario14(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 
 	// Ensure that a since 25 shows the revocation
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(25, 0, 0)
+	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(25, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(45), revokedChannelsCombined["ch1"])
 
 	// Ensure that the user cannot see the channel at this point (after 45)
-	aliceUserPrincipal.CanSeeChannel("ch1")
+	aliceUserPrincipal.canSeeChannel("ch1")
 
 	// Ensure a pull from 45 (same seq as revocation) wouldn't send message
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(45, 0, 0)
+	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(45, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 }
@@ -2690,7 +2690,7 @@ func TestObtainChannelsForDeletedRole(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Successfully able to get inherited channels even though role is missing
-			assert.Equal(t, []string{"!"}, user.InheritedChannels().AllKeys())
+			assert.Equal(t, []string{"!"}, user.inheritedChannels().AllKeys())
 		},
 	},
 		{
@@ -2705,7 +2705,7 @@ func TestObtainChannelsForDeletedRole(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Successfully able to get inherited channels even though role is missing
-				assert.Equal(t, []string{"!"}, user.InheritedChannels().AllKeys())
+				assert.Equal(t, []string{"!"}, user.inheritedChannels().AllKeys())
 			},
 		},
 	}

--- a/auth/collection_access.go
+++ b/auth/collection_access.go
@@ -90,7 +90,7 @@ type UserCollectionChannelAPI interface {
 	// to them.
 	FilterToAvailableCollectionChannels(scope, collection string, channels ch.Set) (filtered ch.TimedSet, removed []string)
 
-	// If the input set contains the wildcard "*" channel, returns the user's InheritedChannels for the collection;
+	// If the input set contains the wildcard "*" channel, returns the user's inheritedChannels for the collection;
 	// else returns the input channel list unaltered.
 	expandCollectionWildCardChannel(scope, collection string, channels base.Set) base.Set
 }
@@ -105,7 +105,7 @@ type PrincipalCollectionAccess interface {
 	// they are granted through a sync function.
 	//
 	// NOTE: channels a user has access to through a role are *not* included in Channels(), so the user could have
-	// access to more documents than included in Channels. CanSeeChannel will also check against the user's roles.
+	// access to more documents than included in Channels. canSeeChannel will also check against the user's roles.
 	Channels() ch.TimedSet
 
 	// Sets the explicit channels the Principal has access to.

--- a/auth/collection_access_test.go
+++ b/auth/collection_access_test.go
@@ -47,16 +47,16 @@ func TestUserCollectionAccess(t *testing.T) {
 	otherCollection := "collection2"
 	nonMatchingCollections := [][2]string{{base.DefaultScope, base.DefaultCollection}, {scope, otherCollection}, {otherScope, collection}, {otherScope, otherCollection}}
 	// Default collection checks - should not have access based on authenticator
-	assert.Equal(t, ch.BaseSetOf(t), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
-	assert.False(t, user.CanSeeChannel("x"))
-	assert.False(t, user.CanSeeChannel("!"))
+	assert.Equal(t, ch.BaseSetOf(t), user.expandWildCardChannel(ch.BaseSetOf(t, "*")))
+	assert.False(t, user.canSeeChannel("x"))
+	assert.False(t, user.canSeeChannel("!"))
 	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t)))
 	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x")))
 	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x", "y")))
 	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "*")))
-	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
-	assert.False(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t, "x", "y")) == nil)
-	assert.False(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t)) == nil)
+	assert.False(t, user.authorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
+	assert.False(t, user.authorizeAnyChannel(ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.authorizeAnyChannel(ch.BaseSetOf(t)) == nil)
 	// Named collection checks
 	assert.Equal(t, ch.BaseSetOf(t, "!"), user.expandCollectionWildCardChannel(scope, collection, ch.BaseSetOf(t, "*")))
 	assert.True(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t)))
@@ -128,16 +128,16 @@ func TestUserCollectionAccess(t *testing.T) {
 	// User with wildcard access:
 	user.setCollectionChannels(scope, collection, ch.AtSequence(ch.BaseSetOf(t, "*", "q"), 1))
 	// Legacy default collection checks
-	assert.Equal(t, ch.BaseSetOf(t), user.ExpandWildCardChannel(ch.BaseSetOf(t, "*")))
-	assert.False(t, user.CanSeeChannel("*"))
+	assert.Equal(t, ch.BaseSetOf(t), user.expandWildCardChannel(ch.BaseSetOf(t, "*")))
+	assert.False(t, user.canSeeChannel("*"))
 	assert.True(t, canSeeAllChannels(user, ch.BaseSetOf(t)))
 	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x")))
 	assert.False(t, canSeeAllChannels(user, ch.BaseSetOf(t, "x", "y")))
-	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "x", "y")) == nil)
-	assert.False(t, user.AuthorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
-	assert.False(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t, "x")) == nil)
-	assert.False(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t, "*")) == nil)
-	assert.False(t, user.AuthorizeAnyChannel(ch.BaseSetOf(t)) == nil)
+	assert.False(t, user.authorizeAllChannels(ch.BaseSetOf(t, "x", "y")) == nil)
+	assert.False(t, user.authorizeAllChannels(ch.BaseSetOf(t, "*")) == nil)
+	assert.False(t, user.authorizeAnyChannel(ch.BaseSetOf(t, "x")) == nil)
+	assert.False(t, user.authorizeAnyChannel(ch.BaseSetOf(t, "*")) == nil)
+	assert.False(t, user.authorizeAnyChannel(ch.BaseSetOf(t)) == nil)
 	// Matching named collection checks
 	assert.Equal(t, ch.BaseSetOf(t, "*", "q"), user.expandCollectionWildCardChannel(scope, collection, ch.BaseSetOf(t, "*")))
 	assert.True(t, canSeeAllCollectionChannels(scope, collection, user, ch.BaseSetOf(t)))

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -25,17 +25,17 @@ type Principal interface {
 	SetSequence(sequence uint64)
 
 	// Returns true if the Principal has access to the given channel.
-	CanSeeChannel(channel string) bool
+	canSeeChannel(channel string) bool
 
 	// If the Principal has access to the given channel, returns the sequence number at which
 	// access was granted; else returns zero.
-	CanSeeChannelSince(channel string) uint64
+	canSeeChannelSince(channel string) uint64
 
 	// Returns an error if the Principal does not have access to all the channels in the set.
-	AuthorizeAllChannels(channels base.Set) error
+	authorizeAllChannels(channels base.Set) error
 
 	// Returns an error if the Principal does not have access to any of the channels in the set.
-	AuthorizeAnyChannel(channels base.Set) error
+	authorizeAnyChannel(channels base.Set) error
 
 	// Returns an appropriate HTTPError for unauthorized access -- a 401 if the receiver is
 	// the guest user, else 403.
@@ -119,23 +119,23 @@ type User interface {
 
 	InitializeRoles()
 
-	RevokedChannels(since uint64, lowSeq uint64, triggeredBy uint64) RevokedChannels
+	revokedChannels(since uint64, lowSeq uint64, triggeredBy uint64) RevokedChannels
 
 	// Obtains the period over which the user had access to the given channel. Either directly or via a role.
-	ChannelGrantedPeriods(chanName string) ([]GrantHistorySequencePair, error)
+	channelGrantedPeriods(chanName string) ([]GrantHistorySequencePair, error)
 
 	// Every channel the user has access to, including those inherited from Roles.
-	InheritedChannels() ch.TimedSet
+	inheritedChannels() ch.TimedSet
 
 	// If the input set contains the wildcard "*" channel, returns the user's InheritedChannels;
 	// else returns the input channel list unaltered.
-	ExpandWildCardChannel(channels base.Set) base.Set
+	expandWildCardChannel(channels base.Set) base.Set
 
 	// Returns a TimedSet containing only the channels from the input set that the user has access
 	// to, annotated with the sequence number at which access was granted.
 	// Returns a string array containing any channels filtered out due to the user not having access
 	// to them.
-	FilterToAvailableChannels(channels ch.Set) (filtered ch.TimedSet, removed []string)
+	filterToAvailableChannels(channels ch.Set) (filtered ch.TimedSet, removed []string)
 
 	setRolesSince(ch.TimedSet)
 

--- a/auth/role.go
+++ b/auth/role.go
@@ -352,12 +352,12 @@ func (role *roleImpl) UnauthError(message string) error {
 
 // Returns true if the Role is allowed to access the channel.
 // A nil Role means access control is disabled, so the function will return true.
-func (role *roleImpl) CanSeeChannel(channel string) bool {
+func (role *roleImpl) canSeeChannel(channel string) bool {
 	return role == nil || role.Channels().Contains(channel) || role.Channels().Contains(ch.UserStarChannel)
 }
 
 // Returns the sequence number since which the Role has been able to access the channel, else zero.
-func (role *roleImpl) CanSeeChannelSince(channel string) uint64 {
+func (role *roleImpl) canSeeChannelSince(channel string) uint64 {
 	seq := role.Channels()[channel]
 	if seq.Sequence == 0 {
 		seq = role.Channels()[ch.UserStarChannel]
@@ -365,11 +365,11 @@ func (role *roleImpl) CanSeeChannelSince(channel string) uint64 {
 	return seq.Sequence
 }
 
-func (role *roleImpl) AuthorizeAllChannels(channels base.Set) error {
+func (role *roleImpl) authorizeAllChannels(channels base.Set) error {
 	return authorizeAllChannels(role, channels)
 }
 
-func (role *roleImpl) AuthorizeAnyChannel(channels base.Set) error {
+func (role *roleImpl) authorizeAnyChannel(channels base.Set) error {
 	return authorizeAnyChannel(role, channels)
 }
 
@@ -378,7 +378,7 @@ func (role *roleImpl) AuthorizeAnyChannel(channels base.Set) error {
 func authorizeAllChannels(princ Principal, channels base.Set) error {
 	var forbidden []string
 	for channel := range channels {
-		if !princ.CanSeeChannel(channel) {
+		if !princ.canSeeChannel(channel) {
 			if forbidden == nil {
 				forbidden = make([]string, 0, len(channels))
 			}
@@ -396,7 +396,7 @@ func authorizeAllChannels(princ Principal, channels base.Set) error {
 func authorizeAnyChannel(princ Principal, channels base.Set) error {
 	if len(channels) > 0 {
 		for channel := range channels {
-			if princ.CanSeeChannel(channel) {
+			if princ.canSeeChannel(channel) {
 				return nil
 			}
 		}

--- a/auth/role_collection_access.go
+++ b/auth/role_collection_access.go
@@ -151,7 +151,7 @@ func (role *roleImpl) SetCollectionChannelHistory(scope, collection string, hist
 // A nil Role means access control is disabled, so the function will return true.
 func (role *roleImpl) CanSeeCollectionChannel(scope, collection, channel string) bool {
 	if base.IsDefaultCollection(scope, collection) {
-		return role.CanSeeChannel(channel)
+		return role.canSeeChannel(channel)
 	}
 
 	if role == nil {
@@ -166,7 +166,7 @@ func (role *roleImpl) CanSeeCollectionChannel(scope, collection, channel string)
 // Returns the sequence number since which the Role has been able to access the channel, else zero.
 func (role *roleImpl) canSeeCollectionChannelSince(scope, collection, channel string) uint64 {
 	if base.IsDefaultCollection(scope, collection) {
-		return role.CanSeeChannelSince(channel)
+		return role.canSeeChannelSince(channel)
 	}
 
 	if cc, ok := role.getCollectionAccess(scope, collection); ok {
@@ -181,7 +181,7 @@ func (role *roleImpl) canSeeCollectionChannelSince(scope, collection, channel st
 
 func (role *roleImpl) authorizeAllCollectionChannels(scope, collection string, channels base.Set) error {
 	if base.IsDefaultCollection(scope, collection) {
-		return role.AuthorizeAllChannels(channels)
+		return role.authorizeAllChannels(channels)
 	}
 
 	if ca, ok := role.getCollectionAccess(scope, collection); ok {
@@ -205,7 +205,7 @@ func (role *roleImpl) authorizeAllCollectionChannels(scope, collection string, c
 // Returns an error if the Principal does not have access to any of the channels in the set.
 func (role *roleImpl) AuthorizeAnyCollectionChannel(scope, collection string, channels base.Set) error {
 	if base.IsDefaultCollection(scope, collection) {
-		return role.AuthorizeAnyChannel(channels)
+		return role.authorizeAnyChannel(channels)
 	}
 
 	if ca, ok := role.getCollectionAccess(scope, collection); ok {

--- a/auth/role_test.go
+++ b/auth/role_test.go
@@ -50,10 +50,10 @@ func TestAuthorizeChannelsRole(t *testing.T) {
 	err = auth.Save(role)
 	assert.NoError(t, err)
 
-	assert.NoError(t, role.AuthorizeAllChannels(channels.BaseSetOf(t, "superuser")))
-	assert.Error(t, role.AuthorizeAllChannels(channels.BaseSetOf(t, "unknown")))
-	assert.NoError(t, role.AuthorizeAnyChannel(channels.BaseSetOf(t, "superuser", "unknown")))
-	assert.Error(t, role.AuthorizeAllChannels(channels.BaseSetOf(t, "unknown1", "unknown2")))
+	assert.NoError(t, role.authorizeAllChannels(channels.BaseSetOf(t, "superuser")))
+	assert.Error(t, role.authorizeAllChannels(channels.BaseSetOf(t, "unknown")))
+	assert.NoError(t, role.authorizeAnyChannel(channels.BaseSetOf(t, "superuser", "unknown")))
+	assert.Error(t, role.authorizeAllChannels(channels.BaseSetOf(t, "unknown1", "unknown2")))
 }
 
 func BenchmarkIsValidPrincipalName(b *testing.B) {

--- a/auth/user.go
+++ b/auth/user.go
@@ -272,7 +272,7 @@ func (revokedChannels RevokedChannels) add(chanName string, triggeredBy uint64) 
 	}
 }
 
-func (user *userImpl) RevokedChannels(since uint64, lowSeq uint64, triggeredBy uint64) RevokedChannels {
+func (user *userImpl) revokedChannels(since uint64, lowSeq uint64, triggeredBy uint64) RevokedChannels {
 	return user.RevokedCollectionChannels(base.DefaultScope, base.DefaultCollection, since, lowSeq, triggeredBy)
 }
 
@@ -393,7 +393,7 @@ func (user *userImpl) RevokedCollectionChannels(scope string, collection string,
 	return combinedRevokedChannels
 }
 
-func (user *userImpl) ChannelGrantedPeriods(chanName string) ([]GrantHistorySequencePair, error) {
+func (user *userImpl) channelGrantedPeriods(chanName string) ([]GrantHistorySequencePair, error) {
 	return user.CollectionChannelGrantedPeriods(base.DefaultScope, base.DefaultCollection, chanName)
 }
 
@@ -568,37 +568,37 @@ func (user *userImpl) InitializeRoles() {
 	_ = user.GetRoles()
 }
 
-func (user *userImpl) CanSeeChannel(channel string) bool {
-	if user.roleImpl.CanSeeChannel(channel) {
+func (user *userImpl) canSeeChannel(channel string) bool {
+	if user.roleImpl.canSeeChannel(channel) {
 		return true
 	}
 	for _, role := range user.GetRoles() {
-		if role.CanSeeChannel(channel) {
+		if role.canSeeChannel(channel) {
 			return true
 		}
 	}
 	return false
 }
 
-func (user *userImpl) CanSeeChannelSince(channel string) uint64 {
-	minSeq := user.roleImpl.CanSeeChannelSince(channel)
+func (user *userImpl) canSeeChannelSince(channel string) uint64 {
+	minSeq := user.roleImpl.canSeeChannelSince(channel)
 	for _, role := range user.GetRoles() {
-		if seq := role.CanSeeChannelSince(channel); seq > 0 && (seq < minSeq || minSeq == 0) {
+		if seq := role.canSeeChannelSince(channel); seq > 0 && (seq < minSeq || minSeq == 0) {
 			minSeq = seq
 		}
 	}
 	return minSeq
 }
 
-func (user *userImpl) AuthorizeAllChannels(channels base.Set) error {
+func (user *userImpl) authorizeAllChannels(channels base.Set) error {
 	return authorizeAllChannels(user, channels)
 }
 
-func (user *userImpl) AuthorizeAnyChannel(channels base.Set) error {
+func (user *userImpl) authorizeAnyChannel(channels base.Set) error {
 	return authorizeAnyChannel(user, channels)
 }
 
-func (user *userImpl) InheritedChannels() ch.TimedSet {
+func (user *userImpl) inheritedChannels() ch.TimedSet {
 	channels := user.Channels().Copy()
 	for _, role := range user.GetRoles() {
 		roleSince := user.RoleNames()[role.Name()]
@@ -619,7 +619,7 @@ func (user *userImpl) InheritedChannels() ch.TimedSet {
 }
 
 // If a channel list contains the all-channel wildcard, replace it with all the user's accessible channels.
-func (user *userImpl) ExpandWildCardChannel(channels base.Set) base.Set {
+func (user *userImpl) expandWildCardChannel(channels base.Set) base.Set {
 	return user.expandCollectionWildCardChannel(base.DefaultScope, base.DefaultCollection, channels)
 }
 
@@ -630,7 +630,7 @@ func (user *userImpl) expandCollectionWildCardChannel(scope, collection string, 
 	return channels
 }
 
-func (user *userImpl) FilterToAvailableChannels(channels ch.Set) (filtered ch.TimedSet, removed []string) {
+func (user *userImpl) filterToAvailableChannels(channels ch.Set) (filtered ch.TimedSet, removed []string) {
 	return user.FilterToAvailableCollectionChannels(base.DefaultScope, base.DefaultCollection, channels)
 }
 
@@ -650,7 +650,7 @@ func (user *userImpl) FilterToAvailableCollectionChannels(scope, collection stri
 
 func (user *userImpl) GetAddedChannels(channels ch.TimedSet) base.Set {
 	output := base.Set{}
-	for userChannel := range user.InheritedChannels() {
+	for userChannel := range user.inheritedChannels() {
 		_, found := channels[userChannel]
 		if !found {
 			output[userChannel] = struct{}{}

--- a/auth/user_collection_access.go
+++ b/auth/user_collection_access.go
@@ -75,7 +75,7 @@ func (user *userImpl) InheritedCollectionChannels(scope, collection string) ch.T
 func (user *userImpl) AuthorizeAnyCollectionChannel(scope, collection string, channels base.Set) error {
 
 	if base.IsDefaultCollection(scope, collection) {
-		return user.AuthorizeAnyChannel(channels)
+		return user.authorizeAnyChannel(channels)
 	}
 
 	// User access

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -268,9 +268,9 @@ func TestCanSeeChannelSince(t *testing.T) {
 		"video": channels.NewVbSimpleSequence(1)})
 
 	for channel := range freeChannels {
-		assert.Equal(t, uint64(1), user.CanSeeChannelSince(channel))
+		assert.Equal(t, uint64(1), user.canSeeChannelSince(channel))
 	}
-	assert.Equal(t, uint64(0), user.CanSeeChannelSince("unknown"))
+	assert.Equal(t, uint64(0), user.canSeeChannelSince("unknown"))
 }
 
 func TestGetAddedChannels(t *testing.T) {

--- a/db/changes.go
+++ b/db/changes.go
@@ -339,7 +339,7 @@ func (db *DatabaseCollectionWithUser) wasDocInChannelPriorToRevocation(ctx conte
 	}
 
 	// Obtain periods where the channel we're interested in was accessible by the user
-	channelAccessPeriods, err := db.user.ChannelGrantedPeriods(chanName)
+	channelAccessPeriods, err := db.user.CollectionChannelGrantedPeriods(db.ScopeName(), db.Name(), chanName)
 	if err != nil {
 		return false, err
 	}
@@ -582,14 +582,14 @@ func (db *DatabaseCollectionWithUser) checkForUserUpdates(ctx context.Context, u
 		userChangeCount = newCount
 
 		if db.user != nil {
-			previousChannels = db.user.InheritedChannels()
+			previousChannels = db.user.InheritedCollectionChannels(db.ScopeName(), db.Name())
 			previousRoles := db.user.RoleNames()
 			if err := db.ReloadUser(ctx); err != nil {
 				base.WarnfCtx(ctx, "Error reloading user %q: %v", base.UD(db.user.Name()), err)
 				return false, 0, nil, err
 			}
 			// check whether channel set has changed
-			singleCollectionChannels := db.user.InheritedChannels().CompareKeys(previousChannels)
+			singleCollectionChannels := db.user.InheritedCollectionChannels(db.ScopeName(), db.Name()).CompareKeys(previousChannels)
 			collectionID := db.GetCollectionID()
 
 			for channelName, changed := range singleCollectionChannels {
@@ -821,7 +821,7 @@ func (db *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Context
 				}
 
 				if options.Revocations && db.user != nil && !options.ActiveOnly {
-					channelsToRevoke := db.user.RevokedChannels(options.Since.Seq, options.Since.LowSeq, options.Since.TriggeredBy)
+					channelsToRevoke := db.user.RevokedCollectionChannels(db.ScopeName(), db.Name(), options.Since.Seq, options.Since.LowSeq, options.Since.TriggeredBy)
 					for channel, revokedSeq := range channelsToRevoke {
 						revocationSinceSeq := options.Since.SafeSequence()
 						revokeFrom := uint64(0)

--- a/db/crud.go
+++ b/db/crud.go
@@ -2225,7 +2225,7 @@ func (db *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context, 
 
 		var output *channels.ChannelMapperOutput
 		output, err = db.channelMapper().MapToChannelsAndAccess(body, oldJson, metaMap,
-			MakeUserCtx(db.user))
+			MakeUserCtx(db.user, db.ScopeName(), db.Name()))
 
 		db.dbStats().Database().SyncFunctionTime.Add(time.Since(startTime).Nanoseconds())
 
@@ -2270,14 +2270,14 @@ func (db *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context, 
 }
 
 // Creates a userCtx object to be passed to the sync function
-func MakeUserCtx(user auth.User) map[string]interface{} {
+func MakeUserCtx(user auth.User, scopeName string, collectionName string) map[string]interface{} {
 	if user == nil {
 		return nil
 	}
 	return map[string]interface{}{
 		"name":     user.Name(),
 		"roles":    user.RoleNames(),
-		"channels": user.InheritedChannels().AllKeys(),
+		"channels": user.InheritedCollectionChannels(scopeName, collectionName).AllKeys(),
 	}
 }
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1450,7 +1450,6 @@ func TestAccessFunctionDb(t *testing.T) {
 	collection := db.GetSingleDatabaseCollectionWithUser()
 
 	authenticator := db.Authenticator(ctx)
-	//authenticator := auth.NewAuthenticator(db.MetadataStore, db, auth.DefaultAuthenticatorOptions())
 
 	var err error
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc){access(doc.users,doc.userChannels);}`, 0)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1445,20 +1445,18 @@ func TestAccessFunctionValidation(t *testing.T) {
 
 func TestAccessFunctionDb(t *testing.T) {
 
-	if base.TestsUseNamedCollections() {
-		t.Skip("Disabled for non-default collection until CBG-2554")
-	}
-
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := db.GetSingleDatabaseCollectionWithUser()
 
-	authenticator := auth.NewAuthenticator(db.MetadataStore, db, auth.DefaultAuthenticatorOptions())
+	authenticator := db.Authenticator(ctx)
+	//authenticator := auth.NewAuthenticator(db.MetadataStore, db, auth.DefaultAuthenticatorOptions())
 
 	var err error
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc){access(doc.users,doc.userChannels);}`, 0)
 
-	user, _ := authenticator.NewUser("naomi", "letmein", channels.BaseSetOf(t, "Netflix"))
+	user, err := authenticator.NewUser("naomi", "letmein", channels.BaseSetOf(t, "Netflix"))
+	require.NoError(t, err)
 	user.SetExplicitRoles(channels.TimedSet{"animefan": channels.NewVbSimpleSequence(1), "tumblr": channels.NewVbSimpleSequence(1)}, 1)
 	assert.NoError(t, authenticator.Save(user), "Save")
 
@@ -1478,10 +1476,10 @@ func TestAccessFunctionDb(t *testing.T) {
 	user, err = authenticator.GetUser("naomi")
 	assert.NoError(t, err, "GetUser")
 	expected := channels.AtSequence(channels.BaseSetOf(t, "Hulu", "Netflix", "!"), 1)
-	assert.Equal(t, expected, user.Channels())
+	assert.Equal(t, expected, user.CollectionChannels(collection.ScopeName(), collection.Name()))
 
 	expected.AddChannel("CrunchyRoll", 2)
-	assert.Equal(t, expected, user.InheritedChannels())
+	assert.Equal(t, expected, user.InheritedCollectionChannels(collection.ScopeName(), collection.Name()))
 }
 
 func TestDocIDs(t *testing.T) {

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -279,7 +279,8 @@ func filterViewResult(input sgbucket.ViewResult, user auth.User, applyChannelFil
 	hasStarChannel := false
 	var visibleChannels ch.TimedSet
 	if user != nil {
-		visibleChannels = user.InheritedChannels()
+		// Views only support default collection, so filter based on default collection channels
+		visibleChannels = user.InheritedCollectionChannels(base.DefaultScope, base.DefaultCollection)
 		hasStarChannel = !visibleChannels.Contains("*")
 		if !applyChannelFiltering {
 			return // this is an error

--- a/db/functions/function.go
+++ b/db/functions/function.go
@@ -235,7 +235,7 @@ func (fn *functionImpl) authorize(user auth.User, args map[string]any) error {
 				return nil
 			} else if channel, err := allow.expandPattern(channelPattern, args, user); err != nil {
 				return err
-			} else if user.CanSeeChannel(channel) {
+			} else if user.CanSeeCollectionChannel(base.DefaultScope, base.DefaultCollection, channel) {
 				return nil // User has access to one of the allowed channels
 			}
 		}

--- a/db/functions/js_function.go
+++ b/db/functions/js_function.go
@@ -14,6 +14,8 @@ import (
 	"context"
 	_ "embed"
 
+	"github.com/couchbase/sync_gateway/base"
+
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/graphql-go/graphql"
@@ -34,16 +36,16 @@ func (fn *jsInvocation) Iterate() (sgbucket.QueryResultIterator, error) {
 }
 
 func (fn *jsInvocation) Run() (any, error) {
-	return fn.call(db.MakeUserCtx(fn.db.User()), fn.args)
+	return fn.call(db.MakeUserCtx(fn.db.User(), base.DefaultScope, base.DefaultCollection), fn.args)
 }
 
 func (fn *jsInvocation) Resolve(params graphql.ResolveParams) (any, error) {
-	return fn.call(db.MakeUserCtx(fn.db.User()), params.Args, params.Source, resolverInfo(params))
+	return fn.call(db.MakeUserCtx(fn.db.User(), base.DefaultScope, base.DefaultCollection), params.Args, params.Source, resolverInfo(params))
 }
 
 func (fn *jsInvocation) ResolveType(params graphql.ResolveTypeParams) (any, error) {
 	info := map[string]any{}
-	return fn.call(db.MakeUserCtx(fn.db.User()), params.Value, info)
+	return fn.call(db.MakeUserCtx(fn.db.User(), base.DefaultScope, base.DefaultCollection), params.Value, info)
 }
 
 func (fn *jsInvocation) call(jsArgs ...any) (any, error) {

--- a/db/users.go
+++ b/db/users.go
@@ -108,7 +108,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 			}
 		}
 
-		updatedExplicitChannels := princ.ExplicitChannels()
+		updatedExplicitChannels := princ.CollectionExplicitChannels(base.DefaultScope, base.DefaultCollection)
 		if updatedExplicitChannels == nil {
 			updatedExplicitChannels = ch.TimedSet{}
 		}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -423,9 +423,9 @@ func (dbc *DatabaseContext) GetPrincipalForTest(tb testing.TB, name string, isUs
 	}
 	info = new(auth.PrincipalConfig)
 	info.Name = &name
-	info.ExplicitChannels = princ.ExplicitChannels().AsSet()
+	info.ExplicitChannels = princ.CollectionExplicitChannels(base.DefaultScope, base.DefaultCollection).AsSet()
 	if user, ok := princ.(auth.User); ok {
-		info.Channels = user.InheritedChannels().AsSet()
+		info.Channels = user.InheritedCollectionChannels(base.DefaultScope, base.DefaultCollection).AsSet()
 		email := user.Email()
 		info.Email = &email
 		info.Disabled = base.BoolPtr(user.Disabled())

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1288,7 +1288,7 @@ func marshalPrincipal(princ auth.Principal, includeDynamicGrantInfo bool) auth.P
 		info.Disabled = base.BoolPtr(user.Disabled())
 		info.ExplicitRoleNames = user.ExplicitRoles().AsSet()
 		if includeDynamicGrantInfo {
-			info.Channels = user.InheritedChannels().AsSet()
+			info.Channels = user.InheritedCollectionChannels(base.DefaultScope, base.DefaultCollection).AsSet()
 			info.RoleNames = user.RoleNames().AllKeys()
 			info.JWTIssuer = base.StringPtr(user.JWTIssuer())
 			info.JWTRoles = user.JWTRoles().AsSet()

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -1734,7 +1734,7 @@ func TestChangesActiveOnlyInteger(t *testing.T) {
 // If scope and collection are non-zero, builds collection access string for the collection
 func adminChannelGrant(scopeName, collectionName, adminChannels string) (collectionAdminChannels string) {
 
-	if scopeName == base.DefaultScope && collectionName == base.DefaultCollection {
+	if base.IsDefaultCollection(scopeName, collectionName) {
 		return adminChannels
 	}
 

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1263,8 +1263,8 @@ func TestWasDocInChannelAtSeq(t *testing.T) {
 	assert.Len(t, changes.Results, 1)
 }
 
-// Test does not directly run ChannelGrantedPeriods but aims to test this through performing revocation operations
-// that will hit the various cases that ChannelGrantedPeriods will handle
+// Test does not directly run channelGrantedPeriods but aims to test this through performing revocation operations
+// that will hit the various cases that channelGrantedPeriods will handle
 func TestChannelGrantedPeriods(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 	revocationTester, rt := InitScenario(t, nil)

--- a/rest/role_api_test.go
+++ b/rest/role_api_test.go
@@ -335,7 +335,7 @@ func TestRoleAccessChanges(t *testing.T) {
 			"!":     channels.NewVbSimpleSequence(1),
 			"alpha": channels.NewVbSimpleSequence(alice.Sequence()),
 			"gamma": channels.NewVbSimpleSequence(roleGrantSequence),
-		}, alice.InheritedChannels())
+		}, alice.InheritedCollectionChannels(base.DefaultScope, base.DefaultCollection))
 
 	assert.Equal(t,
 
@@ -350,7 +350,7 @@ func TestRoleAccessChanges(t *testing.T) {
 		channels.TimedSet{
 			"!":    channels.NewVbSimpleSequence(1),
 			"beta": channels.NewVbSimpleSequence(zegpold.Sequence()),
-		}, zegpold.InheritedChannels())
+		}, zegpold.InheritedCollectionChannels(base.DefaultScope, base.DefaultCollection))
 
 	assert.Equal(t, channels.TimedSet{}, zegpold.RoleNames())
 
@@ -391,7 +391,7 @@ func TestRoleAccessChanges(t *testing.T) {
 		channels.TimedSet{
 			"!":     channels.NewVbSimpleSequence(0x1),
 			"alpha": channels.NewVbSimpleSequence(alice.Sequence()),
-		}, alice.InheritedChannels())
+		}, alice.InheritedCollectionChannels(base.DefaultScope, base.DefaultCollection))
 
 	zegpold, _ = a.GetUser("zegpold")
 	assert.Equal(t,
@@ -400,7 +400,7 @@ func TestRoleAccessChanges(t *testing.T) {
 			"!":     channels.NewVbSimpleSequence(0x1),
 			"beta":  channels.NewVbSimpleSequence(zegpold.Sequence()),
 			"gamma": channels.NewVbSimpleSequence(updatedRoleGrantSequence),
-		}, zegpold.InheritedChannels())
+		}, zegpold.InheritedCollectionChannels(base.DefaultScope, base.DefaultCollection))
 
 	// The complete _changes feed for zegpold contains docs g1 and b1:
 	cacheWaiter.Wait()

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -290,7 +290,7 @@ func TestUserAPI(t *testing.T) {
 	user, _ := rt.ServerContext().Database(ctx, "db").Authenticator(ctx).GetUser("snej")
 	assert.Equal(t, "snej", user.Name())
 	assert.Equal(t, "jens@couchbase.com", user.Email())
-	assert.Equal(t, channels.TimedSet{"bar": channels.NewVbSimpleSequence(0x1), "foo": channels.NewVbSimpleSequence(0x1)}, user.ExplicitChannels())
+	assert.Equal(t, channels.TimedSet{"bar": channels.NewVbSimpleSequence(0x1), "foo": channels.NewVbSimpleSequence(0x1)}, user.CollectionExplicitChannels(base.DefaultScope, base.DefaultCollection))
 	assert.True(t, user.Authenticate("letmein"))
 
 	// Change the password and verify it:
@@ -398,7 +398,7 @@ func TestGuestUser(t *testing.T) {
 	ctx := rt.Context()
 	user, _ := rt.ServerContext().Database(ctx, "db").Authenticator(ctx).GetUser("")
 	assert.Empty(t, user.Name())
-	assert.Nil(t, user.ExplicitChannels())
+	assert.Nil(t, user.CollectionExplicitChannels(base.DefaultScope, base.DefaultCollection))
 	assert.True(t, user.Disabled())
 
 	// We can't delete the guest user, but we should get a reasonable error back.
@@ -608,7 +608,7 @@ func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
 			true,
 		},
 		{
-			"Delete On InheritedChannels",
+			"Delete On inheritedChannels",
 			false,
 		},
 	}
@@ -670,7 +670,7 @@ func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
 				triggerCallback = true
 			}
 
-			assert.Equal(t, []string{"!"}, user.InheritedChannels().AllKeys())
+			assert.Equal(t, []string{"!"}, user.InheritedCollectionChannels(base.DefaultScope, base.DefaultCollection).AllKeys())
 
 			// Ensure callback ran
 			assert.False(t, triggerCallback)


### PR DESCRIPTION
The API for interacting with the default collection is still used internally to interact with the top-level access control properties, but external callers should use the collection-scoped API (which will be routed appropriately by the auth package when using the default collection).

CBG-2553

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1239/ (named collection)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1240/ (default collection)
