### PR TITLE
Update list of golangci-linters

### DIFF
--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -10,71 +10,108 @@
 
 linters:
   enable:
-    #- bodyclose # checks whether HTTP response body is closed successfully
-    #- dupl # Tool for code clone detection
-    - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
-    #- goconst # Finds repeated strings that could be replaced by a constant
-    #- gocritic # The most opinionated Go source code linter
-    - goimports # Goimports does everything that gofmt does. Additionally it checks unused imports
-    #- goprintffuncname # Checks that printf-like functions are named with `f` at the end
-    #- gosec # (gas) Inspects source code for security problems
-    #- gosimple # (megacheck) Linter for Go source code that specializes in simplifying a code
-    - govet # (vet, vetshadow) Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
-    #- ineffassign # Detects when assignments to existing variables are not used
-    #- nakedret # Finds naked returns in functions greater than a specified function length
-    #- prealloc # Finds slice declarations that could potentially be preallocated
-    #- revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
-    #- staticcheck # (megacheck) Staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    #- structcheck # Finds unused struct fields
-    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
-    #- unconvert # Remove unnecessary type conversions
-    #- unparam # Reports unused function parameters
-    #- unused # (megacheck) Checks Go code for unused constants, variables, functions and types
+    - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases [fast: false, auto-fix: false]
+    - goimports # In addition to fixing imports, goimports also formats your code in the same style as gofmt. [fast: true, auto-fix: true]
+    - govet #(vet, vetshadow): Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string [fast: false, auto-fix: false]
+    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code [fast: false, auto-fix: false]
   disable:
-    - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
-    - depguard # Go linter that checks if package imports are in a list of acceptable packages
-    - dogsled # Checks assignments with too many blank identifiers # (e.g. x, _, _, _, := f())
-    - funlen # Tool for detection of long functions
-    - gochecknoglobals # Checks that no globals are present in Go code
-    - gochecknoinits # Checks that no init functions are present in Go code
-    - gocognit # Computes and checks the cognitive complexity of functions
-    - gocyclo # Computes and checks the cyclomatic complexity of functions
-    - godot # Check if comments end in a period
-    - godox # Tool for detection of FIXME, TODO and other comment keywords
-    - goerr113 # Golang linter to check the errors handling expressions
-    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    - gomnd # An analyzer to detect magic numbers.
-    - gomodguard # Allow and block list linter for direct Go module dependencies.
-    - interfacer # Linter that suggests narrower interface types
-    - lll # Reports long lines
-    - misspell # Finds commonly misspelled English words in comments
-    - nestif # Reports deeply nested if statements
-    - nolintlint # Reports ill-formed or insufficient nolint directives
-    - rowserrcheck # checks whether Err of rows is checked successfully
-    - scopelint # Scopelint checks for unpinned variables in go programs
-    - stylecheck # Stylecheck is a replacement for golint
-    - testpackage # linter that makes you use a separate _test package
-    - unused # (megacheck) Checks Go code for unused constants, variables, functions and types
-    - whitespace # Tool for detection of leading and trailing whitespace
-    - wsl # Whitespace Linter - Forces you to use empty lines!
-    # Once fixed, should enable
-    - bodyclose # checks whether HTTP response body is closed successfully
-    - deadcode # Finds unused code
-    - dupl # Tool for code clone detection
-    - goconst # Finds repeated strings that could be replaced by a constant
-    - gocritic # The most opinionated Go source code linter
-    - goprintffuncname # Checks that printf-like functions are named with `f` at the end
-    - gosec # (gas) Inspects source code for security problems
-    - gosimple # (megacheck) Linter for Go source code that specializes in simplifying a code
-    - ineffassign # Detects when assignments to existing variables are not used
-    - nakedret # Finds naked returns in functions greater than a specified function length
-    - prealloc # Finds slice declarations that could potentially be preallocated
-    - revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
-    - staticcheck # (megacheck) Staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    - structcheck # Finds unused struct fields
-    - unconvert # Remove unnecessary type conversions
-    - unparam # Reports unused function parameters
-    - varcheck # Finds unused global variables and constants
+    - asasalint # check for pass []any as any in variadic func(...any) [fast: false, auto-fix: false]
+    - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers [fast: true, auto-fix: false]
+    - bidichk # Checks for dangerous unicode character sequences [fast: true, auto-fix: false]
+    - containedctx # containedctx is a linter that detects struct contained context.Context field [fast: true, auto-fix: false]
+    - contextcheck # check whether the function uses a non-inherited context [fast: false, auto-fix: false]
+    - cyclop # checks function and package cyclomatic complexity [fast: false, auto-fix: false]
+    - deadcode #[deprecated]: Finds unused code [fast: false, auto-fix: false]
+    - decorder # check declaration order and count of types, constants, variables and functions [fast: true, auto-fix: false]
+    - depguard # Go linter that checks if package imports are in a list of acceptable packages [fast: true, auto-fix: false]
+    - dogsled # Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f()) [fast: true, auto-fix: false]
+    - dupword # checks for duplicate words in the source code [fast: true, auto-fix: true]
+    - durationcheck # check for two durations multiplied together [fast: false, auto-fix: false]
+    - errchkjson # Checks types passed to the json encoding functions. Reports unsupported types and optionally reports occasions, where the check for the returned error can be omitted. [fast: false, auto-fix: false]
+    - errname # Checks that sentinel errors are prefixed with the `Err` and error types are suffixed with the `Error`. [fast: false, auto-fix: false]
+    - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13. [fast: false, auto-fix: false]
+    - execinquery # execinquery is a linter about query string checker in Query function which reads your Go src files and warning it finds [fast: false, auto-fix: false]
+    - exhaustive # check exhaustiveness of enum switch statements and map literals [fast: false, auto-fix: false]
+    - exhaustivestruct #[deprecated]: Checks if all struct's fields are initialized [fast: false, auto-fix: false]
+    - exhaustruct # Checks if all structure fields are initialized [fast: false, auto-fix: false]
+    - exportloopref # checks for pointers to enclosing loop variables [fast: false, auto-fix: false]
+    - forbidigo # Forbids identifiers [fast: true, auto-fix: false]
+    - forcetypeassert # finds forced type assertions [fast: true, auto-fix: false]
+    - funlen # Tool for detection of long functions [fast: true, auto-fix: false]
+    - gci # Gci controls golang package import order and makes it always deterministic. [fast: true, auto-fix: false]
+    - gochecknoglobals # check that no global variables exist [fast: true, auto-fix: false]
+    - gochecknoinits # Checks that no init functions are present in Go code [fast: true, auto-fix: false]
+    - gocognit # Computes and checks the cognitive complexity of functions [fast: true, auto-fix: false]
+    - gocyclo # Computes and checks the cyclomatic complexity of functions [fast: true, auto-fix: false]
+    - godot # Check if comments end in a period [fast: true, auto-fix: true]
+    - godox # Tool for detection of FIXME, TODO and other comment keywords [fast: true, auto-fix: false]
+    - goerr113 # Golang linter to check the errors handling expressions [fast: false, auto-fix: false]
+    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification [fast: true, auto-fix: true]
+    - goheader # Checks is file header matches to pattern [fast: true, auto-fix: false]
+    - golint #[deprecated]: Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes [fast: false, auto-fix: false]
+    - gomnd # An analyzer to detect magic numbers. [fast: true, auto-fix: false]
+    - gomoddirectives # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod. [fast: true, auto-fix: false]
+    - gomodguard # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations. [fast: true, auto-fix: false]
+    - grouper # An analyzer to analyze expression groups. [fast: true, auto-fix: false]
+    - ifshort #[deprecated]: Checks that your code uses short syntax for if-statements whenever possible [fast: true, auto-fix: false]
+    - importas # Enforces consistent import aliases [fast: false, auto-fix: false]
+    - interfacebloat # A linter that checks the number of methods inside an interface. [fast: true, auto-fix: false]
+    - interfacer #[deprecated]: Linter that suggests narrower interface types [fast: false, auto-fix: false]
+    - ireturn # Accept Interfaces, Return Concrete Types [fast: false, auto-fix: false]
+    - lll # Reports long lines [fast: true, auto-fix: false]
+    - loggercheck #(logrlint): Checks key valur pairs for common logger libraries (kitlog,klog,logr,zap). [fast: false, auto-fix: false]
+    - maintidx # maintidx measures the maintainability index of each function. [fast: true, auto-fix: false]
+    - makezero # Finds slice declarations with non-zero initial length [fast: false, auto-fix: false]
+    - maligned #[deprecated]: Tool to detect Go structs that would take less memory if their fields were sorted [fast: false, auto-fix: false]
+    - misspell # Finds commonly misspelled English words in comments [fast: true, auto-fix: true]
+    - nestif # Reports deeply nested if statements [fast: true, auto-fix: false]
+    - nilerr # Finds the code that returns nil even if it checks that the error is not nil. [fast: false, auto-fix: false]
+    - nilnil # Checks that there is no simultaneous return of `nil` error and an invalid value. [fast: false, auto-fix: false]
+    - nlreturn # nlreturn checks for a new line before return and branch statements to increase code clarity [fast: true, auto-fix: false]
+    - noctx # noctx finds sending http request without context.Context [fast: false, auto-fix: false]
+    - nolintlint # Reports ill-formed or insufficient nolint directives [fast: true, auto-fix: false]
+    - nonamedreturns # Reports all named returns [fast: false, auto-fix: false]
+    - nosnakecase #[deprecated]: nosnakecase is a linter that detects snake case of variable naming and function name. [fast: true, auto-fix: false]
+    - nosprintfhostport # Checks for misuse of Sprintf to construct a host with port in a URL. [fast: true, auto-fix: false]
+    - paralleltest # paralleltest detects missing usage of t.Parallel() method in your Go test [fast: false, auto-fix: false]
+    - predeclared # find code that shadows one of Go's predeclared identifiers [fast: true, auto-fix: false]
+    - promlinter # Check Prometheus metrics naming via promlint [fast: true, auto-fix: false]
+    - reassign # Checks that package variables are not reassigned [fast: false, auto-fix: false]
+    - rowserrcheck # checks whether Err of rows is checked successfully [fast: false, auto-fix: false]
+    - scopelint #[deprecated]: Scopelint checks for unpinned variables in go programs [fast: true, auto-fix: false]
+    - sqlclosecheck # Checks that sql.Rows and sql.Stmt are closed. [fast: false, auto-fix: false]
+    - structcheck #[deprecated]: Finds unused struct fields [fast: false, auto-fix: false]
+    - stylecheck # Stylecheck is a replacement for golint [fast: false, auto-fix: false]
+    - tagliatelle # Checks the struct tags. [fast: true, auto-fix: false]
+    - tenv # tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17 [fast: false, auto-fix: false]
+    - testableexamples # linter checks if examples are testable (have an expected output) [fast: true, auto-fix: false]
+    - testpackage # linter that makes you use a separate _test package [fast: true, auto-fix: false]
+    - thelper # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers [fast: false, auto-fix: false]
+    - tparallel # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes [fast: false, auto-fix: false]
+    - usestdlibvars # A linter that detect the possibility to use variables/constants from the Go standard library. [fast: true, auto-fix: false]
+    - varcheck #[deprecated]: Finds unused global variables and constants [fast: false, auto-fix: false]
+    - varnamelen # checks that the length of a variable's name matches its scope [fast: false, auto-fix: false]
+    - wastedassign # wastedassign finds wasted assignment statements. [fast: false, auto-fix: false]
+    - whitespace # Tool for detection of leading and trailing whitespace [fast: true, auto-fix: true]
+    - wrapcheck # Checks that errors returned from external packages are wrapped [fast: false, auto-fix: false]
+    - wsl # Whitespace Linter - Forces you to use empty lines! [fast: true, auto-fix: false]
+    # Once fixed, should enable (list of enabled linters in .golangci.yml)
+    - bodyclose # checks whether HTTP response body is closed successfully [fast: false, auto-fix: false]
+    - dupl # Tool for code clone detection [fast: true, auto-fix: false]
+    - goconst # Finds repeated strings that could be replaced by a constant [fast: true, auto-fix: false]
+    - gocritic # Provides diagnostics that check for bugs, performance and style issues. [fast: false, auto-fix: false]
+    - gofumpt # Gofumpt checks whether code was gofumpt-ed. [fast: true, auto-fix: true]
+    - goprintffuncname # Checks that printf-like functions are named with `f` at the end [fast: true, auto-fix: false]
+    - gosec #(gas): Inspects source code for security problems [fast: false, auto-fix: false]
+    - gosimple #(megacheck): Linter for Go source code that specializes in simplifying code [fast: false, auto-fix: false]
+    - ineffassign # Detects when assignments to existing variables are not used [fast: true, auto-fix: false]
+    - nakedret # Finds naked returns in functions greater than a specified function length [fast: true, auto-fix: false]
+    - prealloc # Finds slice declarations that could potentially be pre-allocated [fast: true, auto-fix: false]
+    - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint. [fast: false, auto-fix: false]
+    - staticcheck #(megacheck): It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint. [fast: false, auto-fix: false]
+    - unconvert # Remove unnecessary type conversions [fast: false, auto-fix: false]
+    - unparam # Reports unused function parameters [fast: false, auto-fix: false]
+    - unused #(megacheck): Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]
 
 # Don't enable fieldalignment, changing the field alignment requires checking to see if anyone uses constructors
 # without names. If there is a memory issue on a specific field, that is best found with a heap profile.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,52 +10,107 @@
 
 linters:
   enable:
-    - bodyclose # checks whether HTTP response body is closed successfully
-    - dupl # Tool for code clone detection
-    - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
-    - goconst # Finds repeated strings that could be replaced by a constant
-    - gocritic # The most opinionated Go source code linter
-    - goimports # Goimports does everything that gofmt does. Additionally it checks unused imports
-    - goprintffuncname # Checks that printf-like functions are named with `f` at the end
-    - gosec # (gas) Inspects source code for security problems
-    - gosimple # (megacheck) Linter for Go source code that specializes in simplifying a code
-    - govet # (vet, vetshadow) Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
-    - ineffassign # Detects when assignments to existing variables are not used
-    - nakedret # Finds naked returns in functions greater than a specified function length
-    - prealloc # Finds slice declarations that could potentially be preallocated
-    - revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
-    - staticcheck # (megacheck) Staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
-    - unconvert # Remove unnecessary type conversions
-    - unparam # Reports unused function parameters
-    - unused # (megacheck) Checks Go code for unused constants, variables, functions and types
+    - bodyclose # checks whether HTTP response body is closed successfully [fast: false, auto-fix: false]
+    - dupl # Tool for code clone detection [fast: true, auto-fix: false]
+    - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases [fast: false, auto-fix: false]
+    - goconst # Finds repeated strings that could be replaced by a constant [fast: true, auto-fix: false]
+    - gocritic # Provides diagnostics that check for bugs, performance and style issues. [fast: false, auto-fix: false]
+    - goimports # In addition to fixing imports, goimports also formats your code in the same style as gofmt. [fast: true, auto-fix: true]
+    - gofumpt # Gofumpt checks whether code was gofumpt-ed. [fast: true, auto-fix: true]
+    - goprintffuncname # Checks that printf-like functions are named with `f` at the end [fast: true, auto-fix: false]
+    - gosec #(gas): Inspects source code for security problems [fast: false, auto-fix: false]
+    - gosimple #(megacheck): Linter for Go source code that specializes in simplifying code [fast: false, auto-fix: false]
+    - govet #(vet, vetshadow): Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string [fast: false, auto-fix: false]
+    - ineffassign # Detects when assignments to existing variables are not used [fast: true, auto-fix: false]
+    - nakedret # Finds naked returns in functions greater than a specified function length [fast: true, auto-fix: false]
+    - prealloc # Finds slice declarations that could potentially be pre-allocated [fast: true, auto-fix: false]
+    - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint. [fast: false, auto-fix: false]
+    - staticcheck #(megacheck): It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint. [fast: false, auto-fix: false]
+    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code [fast: false, auto-fix: false]
+    - unconvert # Remove unnecessary type conversions [fast: false, auto-fix: false]
+    - unparam # Reports unused function parameters [fast: false, auto-fix: false]
+    - unused #(megacheck): Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]
   disable:
-    - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
-    - depguard # Go linter that checks if package imports are in a list of acceptable packages
-    - dogsled # Checks assignments with too many blank identifiers # (e.g. x, _, _, _, := f())
-    - funlen # Tool for detection of long functions
-    - gochecknoglobals # Checks that no globals are present in Go code
-    - gochecknoinits # Checks that no init functions are present in Go code
-    - gocognit # Computes and checks the cognitive complexity of functions
-    - gocyclo # Computes and checks the cyclomatic complexity of functions
-    - godot # Check if comments end in a period
-    - godox # Tool for detection of FIXME, TODO and other comment keywords
-    - goerr113 # Golang linter to check the errors handling expressions
-    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    - gomnd # An analyzer to detect magic numbers.
-    - gomodguard # Allow and block list linter for direct Go module dependencies.
-    - interfacer # Linter that suggests narrower interface types
-    - lll # Reports long lines
-    - misspell # Finds commonly misspelled English words in comments
-    - nestif # Reports deeply nested if statements
-    - nolintlint # Reports ill-formed or insufficient nolint directives
-    - rowserrcheck # checks whether Err of rows is checked successfully
-    - scopelint # Scopelint checks for unpinned variables in go programs
-    - stylecheck # Stylecheck is a replacement for golint
-    - testpackage # linter that makes you use a separate _test package
-    - whitespace # Tool for detection of leading and trailing whitespace
-    - wsl # Whitespace Linter - Forces you to use empty lines!
-
+    - asasalint # check for pass []any as any in variadic func(...any) [fast: false, auto-fix: false]
+    - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers [fast: true, auto-fix: false]
+    - bidichk # Checks for dangerous unicode character sequences [fast: true, auto-fix: false]
+    - containedctx # containedctx is a linter that detects struct contained context.Context field [fast: true, auto-fix: false]
+    - contextcheck # check whether the function uses a non-inherited context [fast: false, auto-fix: false]
+    - cyclop # checks function and package cyclomatic complexity [fast: false, auto-fix: false]
+    - deadcode #[deprecated]: Finds unused code [fast: false, auto-fix: false]
+    - decorder # check declaration order and count of types, constants, variables and functions [fast: true, auto-fix: false]
+    - depguard # Go linter that checks if package imports are in a list of acceptable packages [fast: true, auto-fix: false]
+    - dogsled # Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f()) [fast: true, auto-fix: false]
+    - dupword # checks for duplicate words in the source code [fast: true, auto-fix: true]
+    - durationcheck # check for two durations multiplied together [fast: false, auto-fix: false]
+    - errchkjson # Checks types passed to the json encoding functions. Reports unsupported types and optionally reports occasions, where the check for the returned error can be omitted. [fast: false, auto-fix: false]
+    - errname # Checks that sentinel errors are prefixed with the `Err` and error types are suffixed with the `Error`. [fast: false, auto-fix: false]
+    - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13. [fast: false, auto-fix: false]
+    - execinquery # execinquery is a linter about query string checker in Query function which reads your Go src files and warning it finds [fast: false, auto-fix: false]
+    - exhaustive # check exhaustiveness of enum switch statements and map literals [fast: false, auto-fix: false]
+    - exhaustivestruct #[deprecated]: Checks if all struct's fields are initialized [fast: false, auto-fix: false]
+    - exhaustruct # Checks if all structure fields are initialized [fast: false, auto-fix: false]
+    - exportloopref # checks for pointers to enclosing loop variables [fast: false, auto-fix: false]
+    - forbidigo # Forbids identifiers [fast: true, auto-fix: false]
+    - forcetypeassert # finds forced type assertions [fast: true, auto-fix: false]
+    - funlen # Tool for detection of long functions [fast: true, auto-fix: false]
+    - gci # Gci controls golang package import order and makes it always deterministic. [fast: true, auto-fix: false]
+    - gochecknoglobals # check that no global variables exist [fast: true, auto-fix: false]
+    - gochecknoinits # Checks that no init functions are present in Go code [fast: true, auto-fix: false]
+    - gocognit # Computes and checks the cognitive complexity of functions [fast: true, auto-fix: false]
+    - gocyclo # Computes and checks the cyclomatic complexity of functions [fast: true, auto-fix: false]
+    - godot # Check if comments end in a period [fast: true, auto-fix: true]
+    - godox # Tool for detection of FIXME, TODO and other comment keywords [fast: true, auto-fix: false]
+    - goerr113 # Golang linter to check the errors handling expressions [fast: false, auto-fix: false]
+    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification [fast: true, auto-fix: true]
+    - goheader # Checks is file header matches to pattern [fast: true, auto-fix: false]
+    - golint #[deprecated]: Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes [fast: false, auto-fix: false]
+    - gomnd # An analyzer to detect magic numbers. [fast: true, auto-fix: false]
+    - gomoddirectives # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod. [fast: true, auto-fix: false]
+    - gomodguard # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations. [fast: true, auto-fix: false]
+    - grouper # An analyzer to analyze expression groups. [fast: true, auto-fix: false]
+    - ifshort #[deprecated]: Checks that your code uses short syntax for if-statements whenever possible [fast: true, auto-fix: false]
+    - importas # Enforces consistent import aliases [fast: false, auto-fix: false]
+    - interfacebloat # A linter that checks the number of methods inside an interface. [fast: true, auto-fix: false]
+    - interfacer #[deprecated]: Linter that suggests narrower interface types [fast: false, auto-fix: false]
+    - ireturn # Accept Interfaces, Return Concrete Types [fast: false, auto-fix: false]
+    - lll # Reports long lines [fast: true, auto-fix: false]
+    - loggercheck #(logrlint): Checks key valur pairs for common logger libraries (kitlog,klog,logr,zap). [fast: false, auto-fix: false]
+    - maintidx # maintidx measures the maintainability index of each function. [fast: true, auto-fix: false]
+    - makezero # Finds slice declarations with non-zero initial length [fast: false, auto-fix: false]
+    - maligned #[deprecated]: Tool to detect Go structs that would take less memory if their fields were sorted [fast: false, auto-fix: false]
+    - misspell # Finds commonly misspelled English words in comments [fast: true, auto-fix: true]
+    - nestif # Reports deeply nested if statements [fast: true, auto-fix: false]
+    - nilerr # Finds the code that returns nil even if it checks that the error is not nil. [fast: false, auto-fix: false]
+    - nilnil # Checks that there is no simultaneous return of `nil` error and an invalid value. [fast: false, auto-fix: false]
+    - nlreturn # nlreturn checks for a new line before return and branch statements to increase code clarity [fast: true, auto-fix: false]
+    - noctx # noctx finds sending http request without context.Context [fast: false, auto-fix: false]
+    - nolintlint # Reports ill-formed or insufficient nolint directives [fast: true, auto-fix: false]
+    - nonamedreturns # Reports all named returns [fast: false, auto-fix: false]
+    - nosnakecase #[deprecated]: nosnakecase is a linter that detects snake case of variable naming and function name. [fast: true, auto-fix: false]
+    - nosprintfhostport # Checks for misuse of Sprintf to construct a host with port in a URL. [fast: true, auto-fix: false]
+    - paralleltest # paralleltest detects missing usage of t.Parallel() method in your Go test [fast: false, auto-fix: false]
+    - predeclared # find code that shadows one of Go's predeclared identifiers [fast: true, auto-fix: false]
+    - promlinter # Check Prometheus metrics naming via promlint [fast: true, auto-fix: false]
+    - reassign # Checks that package variables are not reassigned [fast: false, auto-fix: false]
+    - rowserrcheck # checks whether Err of rows is checked successfully [fast: false, auto-fix: false]
+    - scopelint #[deprecated]: Scopelint checks for unpinned variables in go programs [fast: true, auto-fix: false]
+    - sqlclosecheck # Checks that sql.Rows and sql.Stmt are closed. [fast: false, auto-fix: false]
+    - structcheck #[deprecated]: Finds unused struct fields [fast: false, auto-fix: false]
+    - stylecheck # Stylecheck is a replacement for golint [fast: false, auto-fix: false]
+    - tagliatelle # Checks the struct tags. [fast: true, auto-fix: false]
+    - tenv # tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17 [fast: false, auto-fix: false]
+    - testableexamples # linter checks if examples are testable (have an expected output) [fast: true, auto-fix: false]
+    - testpackage # linter that makes you use a separate _test package [fast: true, auto-fix: false]
+    - thelper # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers [fast: false, auto-fix: false]
+    - tparallel # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes [fast: false, auto-fix: false]
+    - usestdlibvars # A linter that detect the possibility to use variables/constants from the Go standard library. [fast: true, auto-fix: false]
+    - varcheck #[deprecated]: Finds unused global variables and constants [fast: false, auto-fix: false]
+    - varnamelen # checks that the length of a variable's name matches its scope [fast: false, auto-fix: false]
+    - wastedassign # wastedassign finds wasted assignment statements. [fast: false, auto-fix: false]
+    - whitespace # Tool for detection of leading and trailing whitespace [fast: true, auto-fix: true]
+    - wrapcheck # Checks that errors returned from external packages are wrapped [fast: false, auto-fix: false]
+    - wsl # Whitespace Linter - Forces you to use empty lines! [fast: true, auto-fix: false]
 linters-settings:
   govet:
     enable:


### PR DESCRIPTION
Auto-generated linter list using:
```
$ golangci-lint --version
golangci-lint has version 1.50.1 built from 8926a95 on 2022-10-22T10:48:48Z
$ golangci-lint linters --no-config --enable-all > linters.txt
```

- Preserved enabled linters
- New linters disabled for now

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a