### PR TITLE
CBG-2533 make _post_upgrade multi-collection aware

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -805,33 +805,59 @@ func (dbCtx *DatabaseContext) RemoveObsoleteDesignDocs(previewOnly bool) (remove
 	return removeObsoleteDesignDocs(context.TODO(), viewStore, previewOnly, dbCtx.UseViews())
 }
 
+// getDataStores returns all datastores on the database, including metadatastore
+func (dbCtx *DatabaseContext) getDataStores() []sgbucket.DataStore {
+	datastores := make([]sgbucket.DataStore, 0, len(dbCtx.CollectionByID))
+	for _, collection := range dbCtx.CollectionByID {
+		datastores = append(datastores, collection.dataStore)
+	}
+	_, hasDefaultCollection := dbCtx.CollectionByID[base.DefaultCollectionID]
+	if !hasDefaultCollection {
+		datastores = append(datastores, dbCtx.MetadataStore)
+	}
+	return datastores
+}
+
 // Removes previous versions of Sync Gateway's indexes found on the server. Returns a map of indexes removed by collection name.
-func (dbCtx *DatabaseContext) RemoveObsoleteIndexes(ctx context.Context, previewOnly bool) (map[string][]string, error) {
+func (dbCtx *DatabaseContext) RemoveObsoleteIndexes(ctx context.Context, previewOnly bool) ([]string, error) {
 
 	if !dbCtx.Bucket.IsSupported(sgbucket.BucketStoreFeatureN1ql) {
 		return nil, nil
 	}
-
-	removedIndexesByCollection := make(map[string][]string)
 	var errs *base.MultiError
-	for _, collection := range dbCtx.CollectionByID {
-		collectionName := fmt.Sprintf("%s.%s", collection.ScopeName(), collection.Name())
-		n1qlStore, ok := base.AsN1QLStore(collection.dataStore)
+	var removedIndexes []string
+	for _, dataStore := range dbCtx.getDataStores() {
+		dsName, ok := base.AsDataStoreName(dataStore)
 		if !ok {
-			err := fmt.Sprintf("Cannot remove obsolete indexes for non-gocb collection %s - skipping.", collectionName)
+			err := fmt.Sprintf("Cannot get datastore name from %s", dataStore)
 			base.WarnfCtx(ctx, err)
 			errs = errs.Append(errors.New(err))
 			continue
 		}
-
-		removedIndexes, err := removeObsoleteIndexes(n1qlStore, previewOnly, dbCtx.UseXattrs(), dbCtx.UseViews(), sgIndexes)
+		collectionName := fmt.Sprintf("`%s`.`%s`", dsName.ScopeName(), dsName.CollectionName())
+		n1qlStore, ok := base.AsN1QLStore(dataStore)
+		if !ok {
+			err := fmt.Sprintf("Cannot remove obsolete indexes for non-gocb collection %s - skipping.", base.MD(collectionName))
+			base.WarnfCtx(ctx, err)
+			errs = errs.Append(errors.New(err))
+			continue
+		}
+		collectionRemovedIndexes, err := removeObsoleteIndexes(n1qlStore, previewOnly, dbCtx.UseXattrs(), dbCtx.UseViews(), sgIndexes)
 		if err != nil {
 			errs = errs.Append(err)
 			continue
 		}
-		removedIndexesByCollection[collectionName] = removedIndexes
+		onlyDefaultCollection := dbCtx.onlyDefaultCollection()
+		for _, idxName := range collectionRemovedIndexes {
+			if onlyDefaultCollection {
+				removedIndexes = append(removedIndexes, idxName)
+			} else {
+				removedIndexes = append(removedIndexes,
+					fmt.Sprintf("%s.%s", collectionName, idxName))
+			}
+		}
 	}
-	return removedIndexesByCollection, errs.ErrorOrNil()
+	return removedIndexes, errs.ErrorOrNil()
 }
 
 // Trigger terminate check handling for connected continuous replications.

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -162,9 +162,6 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	if base.TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
-	if !base.TestUseXattrs() {
-		t.Skip("This test has expectation of starting with xattrs=true")
-	}
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -162,6 +162,9 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	if base.TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
+	if !base.TestUseXattrs() {
+		t.Skip("This test has expectation of starting with xattrs=true")
+	}
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
@@ -200,6 +203,52 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false, db.IsServerless())
 	assert.NoError(t, err)
 
+}
+
+func TestPostUpgradeMultipleCollections(t *testing.T) {
+	if base.TestsDisableGSI() {
+		t.Skip("This test only works with Couchbase Server and UseViews=false")
+	}
+
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+
+	dbOptions := DatabaseContextOptions{}
+	if base.TestsUseNamedCollections() {
+		numCollections := 2
+		base.RequireNumTestDataStores(t, numCollections)
+		dbOptions.Scopes = getScopesOptions(t, tb, numCollections)
+	}
+
+	db, ctx := SetupTestDBForDataStoreWithOptions(t, tb, dbOptions)
+	defer db.Close(ctx)
+
+	// make sure RemoveObsoleteIndexes is a no-op before adding obsolete indexes
+	for _, preview := range []bool{true, false} {
+		removedIndexes, removeErr := db.RemoveObsoleteIndexes(base.TestCtx(t), preview)
+		require.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in no-op case")
+		require.Equal(t, 0, len(removedIndexes))
+	}
+	useXattrs := false
+	serverless := false
+
+	for _, dataStore := range db.getDataStores() {
+		n1qlStore, ok := base.AsN1QLStore(dataStore)
+		assert.True(t, ok)
+		err := InitializeIndexes(n1qlStore, useXattrs, 0, false, false)
+		require.NoError(t, err)
+	}
+
+	nonXattrsIndexesPerCollection := len(GetIndexesName(useXattrs, serverless))
+	obsoleteIndexCount := nonXattrsIndexesPerCollection * len(db.getDataStores())
+
+	// make sure RemoveObsoleteIndexes is a no-op before adding obsolete indexes
+	for _, preview := range []bool{true, false} {
+		removedIndexes, removeErr := db.RemoveObsoleteIndexes(base.TestCtx(t), preview)
+		fmt.Println(removedIndexes)
+		require.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in no-op case")
+		require.Equal(t, obsoleteIndexCount, len(removedIndexes))
+	}
 }
 
 func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {


### PR DESCRIPTION
- Didn't change the behavior of this function. This function could actually take a long time, dropping index is going to be synchronous for up to 2 minutes and might take longer. In practice, I think this would end up in a gateway timeout from the caller and this should probably be asynchronous cleanup. 
- Didn't add new tests for error behavior or tests in rest package because adding indexing tests stresses the GSI test harness and we can't do with walrus.
- Allow multi collection tests with default `db` tester which uses `DatabaseContextOptionsDirectly`.

I do feel like I short changed this PR by not writing tests for error conditions on the upgrade, but I'm not sure how to simulate index errors, and not sure if doing this is going to cause more stress on the test harness than we would benefit via test coverage.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1261/
