### PR TITLE
CBG-2645: Compact intermediate sequences in ISGR checkpointer expected lists

### DIFF
--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -280,17 +280,15 @@ func (c *Checkpointer) _updateCheckpointLists() (safeSeq *SequenceID) {
 	// if we have many remaining expectedSeqs, see if we can shrink the lists even more
 	// compact contiguous blocks of sequences by keeping only the last processed sequence in both lists
 	if len(c.expectedSeqs) > c.expectedSeqCompactionThreshold {
-		// compact processed sequences up to but not including the last one to ensure
-		// we're not keeping large amounts of intermediate sequence numbers in memory
+		// start at the one before the end of the list (since we know we need to retain that one anyway, if it's processed)
 		for i := len(c.expectedSeqs) - 2; i >= 0; i-- {
 			current := c.expectedSeqs[i]
 			next := c.expectedSeqs[i+1]
 			_, processedCurrent := c.processedSeqs[current]
 			_, processedNext := c.processedSeqs[next]
 			if processedCurrent && processedNext {
-				// remove the current sequence from both sets, since we know we've also processed the next sequence
+				// remove the current sequence from both sets, since we know we've also processed the next sequence and are able to checkpoint that
 				delete(c.processedSeqs, current)
-				// remove i from expectedSeqs
 				c.expectedSeqs = append(c.expectedSeqs[:i], c.expectedSeqs[i+1:]...)
 			}
 		}

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -22,6 +22,8 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
+const defaultExpectedSeqCompactionThreshold = 100
+
 // Checkpointer implements replicator checkpointing, by keeping two lists of sequences. Those which we expect to be processing revs for (either push or pull), and a map for those which we have done so on.
 // Periodically (based on a time interval), these two lists are used to calculate the highest sequence number which we've not had a gap for yet, and send a SetCheckpoint message for this sequence.
 type Checkpointer struct {
@@ -87,7 +89,7 @@ func NewCheckpointer(ctx context.Context, clientID string, configHash string, bl
 		ctx:                            ctx,
 		stats:                          CheckpointerStats{},
 		statusCallback:                 statusCallback,
-		expectedSeqCompactionThreshold: 100,
+		expectedSeqCompactionThreshold: defaultExpectedSeqCompactionThreshold,
 	}
 }
 

--- a/db/active_replicator_checkpointer_test.go
+++ b/db/active_replicator_checkpointer_test.go
@@ -17,7 +17,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func genExpectedForTest(t testing.TB, seqs ...string) []SequenceID {
+	result := make([]SequenceID, 0, len(seqs))
+	for _, seq := range seqs {
+		s, err := ParsePlainSequenceID(seq)
+		if err != nil {
+			t.Fatalf("Error parsing sequence %q for test setup: %v", seq, err)
+		}
+		result = append(result, s)
+	}
+	return result
+}
+
+func genProcessedForTest(t testing.TB, seqs ...string) map[SequenceID]struct{} {
+	result := make(map[SequenceID]struct{}, len(seqs))
+	for _, seq := range seqs {
+		s, err := ParsePlainSequenceID(seq)
+		if err != nil {
+			t.Fatalf("Error parsing sequence %q for test setup: %v", seq, err)
+		}
+		result[s] = struct{}{}
+	}
+	return result
+}
+
 func TestCheckpointerSafeSeq(t *testing.T) {
+
 	tests := []struct {
 		name                    string
 		c                       *Checkpointer
@@ -29,113 +54,133 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 		{
 			name: "empty",
 			c: &Checkpointer{
-				expectedSeqs:  []SequenceID{},
-				processedSeqs: map[SequenceID]struct{}{},
+				expectedSeqs:  genExpectedForTest(t),
+				processedSeqs: genProcessedForTest(t),
 			},
 			expectedSafeSeq:         nil,
 			expectedExpectedSeqsIdx: -1,
-			expectedExpectedSeqs:    []SequenceID{},
-			expectedProcessedSeqs:   map[SequenceID]struct{}{},
+			expectedExpectedSeqs:    genExpectedForTest(t),
+			expectedProcessedSeqs:   genProcessedForTest(t),
 		},
 		{
 			name: "none processed",
 			c: &Checkpointer{
-				expectedSeqs:  []SequenceID{{Seq: 1}, {Seq: 2}, {Seq: 3}},
-				processedSeqs: map[SequenceID]struct{}{},
+				expectedSeqs:  genExpectedForTest(t, "1", "2", "3"),
+				processedSeqs: genProcessedForTest(t),
 			},
 			expectedSafeSeq:         nil,
 			expectedExpectedSeqsIdx: -1,
-			expectedExpectedSeqs:    []SequenceID{{Seq: 1}, {Seq: 2}, {Seq: 3}},
-			expectedProcessedSeqs:   map[SequenceID]struct{}{},
+			expectedExpectedSeqs:    genExpectedForTest(t, "1", "2", "3"),
+			expectedProcessedSeqs:   genProcessedForTest(t),
 		},
 		{
 			name: "partial processed",
 			c: &Checkpointer{
-				expectedSeqs:  []SequenceID{{Seq: 1}, {Seq: 2}, {Seq: 3}},
-				processedSeqs: map[SequenceID]struct{}{{Seq: 1}: {}},
+				expectedSeqs:  genExpectedForTest(t, "1", "2", "3"),
+				processedSeqs: genProcessedForTest(t, "1"),
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 1},
 			expectedExpectedSeqsIdx: 0,
-			expectedExpectedSeqs:    []SequenceID{{Seq: 2}, {Seq: 3}},
-			expectedProcessedSeqs:   map[SequenceID]struct{}{},
+			expectedExpectedSeqs:    genExpectedForTest(t, "2", "3"),
+			expectedProcessedSeqs:   genProcessedForTest(t),
 		},
 		{
 			name: "partial processed with gap",
 			c: &Checkpointer{
-				expectedSeqs:  []SequenceID{{Seq: 1}, {Seq: 2}, {Seq: 3}},
-				processedSeqs: map[SequenceID]struct{}{{Seq: 1}: {}, {Seq: 3}: {}},
+				expectedSeqs:  genExpectedForTest(t, "1", "2", "3"),
+				processedSeqs: genProcessedForTest(t, "1", "3"),
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 1},
 			expectedExpectedSeqsIdx: 0,
-			expectedExpectedSeqs:    []SequenceID{{Seq: 2}, {Seq: 3}},
-			expectedProcessedSeqs:   map[SequenceID]struct{}{{Seq: 3}: {}},
+			expectedExpectedSeqs:    genExpectedForTest(t, "2", "3"),
+			expectedProcessedSeqs:   genProcessedForTest(t, "3"),
 		},
 		{
 			name: "fully processed",
 			c: &Checkpointer{
-				expectedSeqs:  []SequenceID{{Seq: 1}, {Seq: 2}, {Seq: 3}},
-				processedSeqs: map[SequenceID]struct{}{{Seq: 1}: {}, {Seq: 2}: {}, {Seq: 3}: {}},
+				expectedSeqs:  genExpectedForTest(t, "1", "2", "3"),
+				processedSeqs: genProcessedForTest(t, "1", "2", "3"),
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 3},
 			expectedExpectedSeqsIdx: 2,
-			expectedExpectedSeqs:    []SequenceID{},
-			expectedProcessedSeqs:   map[SequenceID]struct{}{},
+			expectedExpectedSeqs:    genExpectedForTest(t),
+			expectedProcessedSeqs:   genProcessedForTest(t),
 		},
 		{
 			name: "extra processed",
 			c: &Checkpointer{
-				expectedSeqs:  []SequenceID{{Seq: 1}, {Seq: 2}, {Seq: 3}},
-				processedSeqs: map[SequenceID]struct{}{{Seq: 1}: {}, {Seq: 2}: {}, {Seq: 3}: {}, {Seq: 4}: {}, {Seq: 5}: {}},
+				expectedSeqs:  genExpectedForTest(t, "1", "2", "3"),
+				processedSeqs: genProcessedForTest(t, "1", "2", "3", "4", "5"),
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 3},
 			expectedExpectedSeqsIdx: 2,
-			expectedExpectedSeqs:    []SequenceID{},
-			expectedProcessedSeqs:   map[SequenceID]struct{}{{Seq: 4}: {}, {Seq: 5}: {}},
+			expectedExpectedSeqs:    genExpectedForTest(t),
+			expectedProcessedSeqs:   genProcessedForTest(t, "4", "5"),
 		},
 		{
 			name: "out of order expected seqs",
 			c: &Checkpointer{
-				expectedSeqs:  []SequenceID{{Seq: 3}, {Seq: 2}, {Seq: 1}},
-				processedSeqs: map[SequenceID]struct{}{{Seq: 1}: {}, {Seq: 2}: {}, {Seq: 3}: {}},
+				expectedSeqs:  genExpectedForTest(t, "3", "2", "1"),
+				processedSeqs: genProcessedForTest(t, "1", "2", "3"),
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 3},
 			expectedExpectedSeqsIdx: 2,
-			expectedExpectedSeqs:    []SequenceID{},
-			expectedProcessedSeqs:   map[SequenceID]struct{}{},
+			expectedExpectedSeqs:    genExpectedForTest(t),
+			expectedProcessedSeqs:   genProcessedForTest(t),
 		},
 		{
 			name: "compound sequence",
 			c: &Checkpointer{
-				expectedSeqs:  []SequenceID{{Seq: 1}, {Seq: 3, LowSeq: 1}},
-				processedSeqs: map[SequenceID]struct{}{{Seq: 1}: {}, {Seq: 3, LowSeq: 1}: {}},
+				expectedSeqs:  genExpectedForTest(t, "1", "1::3"),
+				processedSeqs: genProcessedForTest(t, "1", "1::3"),
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 3, LowSeq: 1},
 			expectedExpectedSeqsIdx: 1,
-			expectedExpectedSeqs:    []SequenceID{},
-			expectedProcessedSeqs:   map[SequenceID]struct{}{},
+			expectedExpectedSeqs:    genExpectedForTest(t),
+			expectedProcessedSeqs:   genProcessedForTest(t),
 		},
 		{
 			name: "compound sequence triggered by",
 			c: &Checkpointer{
-				expectedSeqs:  []SequenceID{{Seq: 1}, {Seq: 3, LowSeq: 1}, {Seq: 2, TriggeredBy: 4}},
-				processedSeqs: map[SequenceID]struct{}{{Seq: 1}: {}, {Seq: 3, LowSeq: 1}: {}, {Seq: 2, TriggeredBy: 4}: {}},
+				expectedSeqs:  genExpectedForTest(t, "1", "1::3", "4:2"),
+				processedSeqs: genProcessedForTest(t, "1", "1::3", "4:2"),
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 2, TriggeredBy: 4},
 			expectedExpectedSeqsIdx: 2,
-			expectedExpectedSeqs:    []SequenceID{},
-			expectedProcessedSeqs:   map[SequenceID]struct{}{},
+			expectedExpectedSeqs:    genExpectedForTest(t),
+			expectedProcessedSeqs:   genProcessedForTest(t),
 		},
 		{
-			name: "skipped with many intermediate processed",
+			// ensure we maintain enough sequences that we can checkpoint expected but not yet processed without retaining the full list of processed sequences
+			// in most cases this will be keeping the last processed sequence and removing all prior ones, until the missing sequence in the list.
+			// e.g.
+			//    expected:  [2 3 4 5 6]
+			//    processed: [  3 4 5  ]
+			// can be safely compacted to:
+			//    expected:  [2 5 6]
+			//    processed: [  5  ]
+			name: "processed compaction",
 			c: &Checkpointer{
-				expectedSeqs:                   []SequenceID{{Seq: 1}, {Seq: 2}, {Seq: 3}, {Seq: 4}, {Seq: 5}, {Seq: 6}, {Seq: 7}, {Seq: 8}, {Seq: 9}, {Seq: 10}, {Seq: 11}, {Seq: 12}, {Seq: 13}, {Seq: 14}, {Seq: 15}, {Seq: 16}},
-				processedSeqs:                  map[SequenceID]struct{}{{Seq: 1}: {}, {Seq: 2}: {}, {Seq: 4}: {}, {Seq: 5}: {}, {Seq: 6}: {}, {Seq: 8}: {}, {Seq: 9}: {}, {Seq: 10}: {}, {Seq: 11}: {}, {Seq: 12}: {}, {Seq: 13}: {}, {Seq: 14}: {}},
+				expectedSeqs:                   genExpectedForTest(t, "1", "2", "3", "4", "5", "6"),
+				processedSeqs:                  genProcessedForTest(t, "1", "3", "4", "5"),
+				expectedSeqCompactionThreshold: 3, // this many expected seqs to trigger compaction
+			},
+			expectedSafeSeq:         &SequenceID{Seq: 1},
+			expectedExpectedSeqsIdx: 0,
+			expectedExpectedSeqs:    genExpectedForTest(t, "2", "5", "6"),
+			expectedProcessedSeqs:   genProcessedForTest(t, "5"),
+		},
+		{
+			name: "multiple skipped processed compaction",
+			c: &Checkpointer{
+				expectedSeqs:                   genExpectedForTest(t, "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20"),
+				processedSeqs:                  genProcessedForTest(t, "1", "2", "4", "5", "7", "8", "9", "11", "12", "13", "15", "16", "17", "19"),
 				expectedSeqCompactionThreshold: 5, // this many expected seqs to trigger compaction
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 2},
 			expectedExpectedSeqsIdx: 1,
-			expectedExpectedSeqs:    []SequenceID{{Seq: 3}, {Seq: 6}, {Seq: 7}, {Seq: 14}, {Seq: 15}, {Seq: 16}},
-			expectedProcessedSeqs:   map[SequenceID]struct{}{{Seq: 6}: {}, {Seq: 14}: {}},
+			expectedExpectedSeqs:    genExpectedForTest(t, "3", "5", "6", "9", "10", "13", "14", "17", "18", "19", "20"),
+			expectedProcessedSeqs:   genProcessedForTest(t, "5", "9", "13", "17", "19"),
 		},
 	}
 	for _, tt := range tests {
@@ -172,29 +217,49 @@ func BenchmarkCheckpointerUpdateCheckpointLists(b *testing.B) {
 		processedSeqsLen int
 	}{
 		{expectedSeqsLen: 1, processedSeqsLen: 1},
-		{expectedSeqsLen: 100, processedSeqsLen: 100},
-		{expectedSeqsLen: 500, processedSeqsLen: 500},
+		{expectedSeqsLen: 50, processedSeqsLen: 50},
+		{expectedSeqsLen: 400, processedSeqsLen: 400}, // ~expected size (2x changes batch)
 		{expectedSeqsLen: 1000, processedSeqsLen: 1000},
-		{expectedSeqsLen: 10000, processedSeqsLen: 10000},
-		{expectedSeqsLen: 50000, processedSeqsLen: 50000},
+		{expectedSeqsLen: 1000, processedSeqsLen: 10000},
 		{expectedSeqsLen: 100000, processedSeqsLen: 100000},
+		{expectedSeqsLen: 1000000, processedSeqsLen: 1000000},
 	}
 	for _, test := range tests {
-		b.Run(fmt.Sprintf("expectedSeqsLen=%d,processedSeqsLen=%d", test.expectedSeqsLen, test.processedSeqsLen), func(b *testing.B) {
-			expectedSeqs := make([]SequenceID, 0, test.expectedSeqsLen)
-			for i := 0; i < test.expectedSeqsLen; i++ {
-				expectedSeqs = append(expectedSeqs, SequenceID{Seq: uint64(i)})
+		// -1    no skip
+		//  0    skip first
+		//  1    skip last
+		for _, numCheckpoints := range []int{1, 10} {
+			for _, skipSeq := range []int{-1, 0, 1} {
+				bFunc := func(skipSeq, numCheckpoints int) func(b *testing.B) {
+					return func(b *testing.B) {
+						expectedSeqs := make([]SequenceID, 0, test.expectedSeqsLen)
+						for i := 0; i < test.expectedSeqsLen; i++ {
+							expectedSeqs = append(expectedSeqs, SequenceID{Seq: uint64(i)})
+						}
+						processedSeqs := make(map[SequenceID]struct{}, test.processedSeqsLen)
+						for i := 0; i < test.processedSeqsLen; i++ {
+							if (skipSeq == 0 && i == 0) || (skipSeq == 1 && i == test.processedSeqsLen-1) {
+								continue
+							}
+							processedSeqs[SequenceID{Seq: uint64(i)}] = struct{}{}
+						}
+						b.ReportAllocs()
+						b.ResetTimer()
+						for i := 0; i < b.N; i++ {
+							c := &Checkpointer{expectedSeqs: expectedSeqs, processedSeqs: processedSeqs, expectedSeqCompactionThreshold: 100}
+							// run checkpointing multiple times to test pruning speedup
+							for j := 0; j < numCheckpoints; j++ {
+								_ = c._updateCheckpointLists()
+							}
+						}
+					}
+				}
+				b.Run(
+					fmt.Sprintf("expectedSeqsLen=%d,processedSeqsLen=%d,skipSeq=%d,numCheckpoints=%d",
+						test.expectedSeqsLen, test.processedSeqsLen, skipSeq, numCheckpoints),
+					bFunc(skipSeq, numCheckpoints),
+				)
 			}
-			processedSeqs := make(map[SequenceID]struct{}, test.processedSeqsLen)
-			for i := 0; i < test.processedSeqsLen; i++ {
-				processedSeqs[SequenceID{Seq: uint64(i)}] = struct{}{}
-			}
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				c := &Checkpointer{expectedSeqs: expectedSeqs, processedSeqs: processedSeqs}
-				_ = c._updateCheckpointLists()
-			}
-		})
+		}
 	}
 }

--- a/db/active_replicator_checkpointer_test.go
+++ b/db/active_replicator_checkpointer_test.go
@@ -177,8 +177,8 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			//    expected:  [2 4 6 8 9]
 			//    processed: [  4 6 8  ]
 			// can be safely compacted to:
-			//    expected:  [2 6 9]
-			//    processed: [  6  ]
+			//    expected:  [2 8 9]
+			//    processed: [  8  ]
 			name: "processed compaction non-sequential (out of order)",
 			c: &Checkpointer{
 				expectedSeqs:                   genExpectedForTest(t, "2", "1", "6", "8", "4", "9"),
@@ -187,8 +187,8 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 1},
 			expectedExpectedSeqsIdx: 0,
-			expectedExpectedSeqs:    genExpectedForTest(t, "2", "6", "9"),
-			expectedProcessedSeqs:   genProcessedForTest(t, "6"),
+			expectedExpectedSeqs:    genExpectedForTest(t, "2", "8", "9"),
+			expectedProcessedSeqs:   genProcessedForTest(t, "8"),
 		},
 		{
 			name: "multiple skipped processed compaction",

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -653,7 +653,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 			if bh.sgr2PullAlreadyKnownSeqsCallback != nil {
 				seq, err := ParseJSONSequenceID(seqStr(change[0]))
 				if err != nil {
-					base.WarnfCtx(bh.loggingCtx, "Unable to parse known sequence %q for %q/%q: %v", change[0], base.UD(docID), revID, err)
+					base.WarnfCtx(bh.loggingCtx, "Unable to parse known sequence %q for %q / %q: %v", change[0], base.UD(docID), revID, err)
 				} else {
 					// we're not able to checkpoint a sequence we can't parse and aren't expecting so just skip the callback if we errored
 					alreadyKnownSeqs = append(alreadyKnownSeqs, seq)
@@ -676,7 +676,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 				seq, err := ParseJSONSequenceID(seqStr(change[0]))
 				if err != nil {
 					// We've already asked for the doc/rev for the sequence so assume we're going to receive it... Just log this and carry on
-					base.WarnfCtx(bh.loggingCtx, "Unable to parse expected sequence %q for %q/%q: %v", change[0], base.UD(docID), revID, err)
+					base.WarnfCtx(bh.loggingCtx, "Unable to parse expected sequence %q for %q / %q: %v", change[0], base.UD(docID), revID, err)
 				} else {
 					expectedSeqs[IDAndRev{DocID: docID, RevID: revID}] = seq
 				}
@@ -825,16 +825,16 @@ func (bsc *BlipSyncContext) sendRevAsDelta(sender *blip.Sender, docID, revID str
 
 func (bh *blipHandler) handleNoRev(rq *blip.Message) error {
 	docID, revID := rq.Properties[NorevMessageId], rq.Properties[NorevMessageRev]
-	base.InfofCtx(bh.loggingCtx, base.KeySyncMsg, "%s: norev for doc %q / %q - error: %q - reason: %q",
-		rq.String(), base.UD(docID), revID, rq.Properties[NorevMessageError], rq.Properties[NorevMessageReason])
+	var seqStr string
+	if bh.blipContext.ActiveSubprotocol() == BlipCBMobileReplicationV2 && bh.clientType == BLIPClientTypeSGR2 {
+		seqStr = rq.Properties[NorevMessageSeq]
+	} else {
+		seqStr = rq.Properties[NorevMessageSequence]
+	}
+	base.InfofCtx(bh.loggingCtx, base.KeySyncMsg, "%s: norev for doc %q / %q seq:%q - error: %q - reason: %q",
+		rq.String(), base.UD(docID), revID, seqStr, rq.Properties[NorevMessageError], rq.Properties[NorevMessageReason])
 
 	if bh.sgr2PullProcessedSeqCallback != nil {
-		var seqStr string
-		if bh.blipContext.ActiveSubprotocol() == BlipCBMobileReplicationV2 && bh.clientType == BLIPClientTypeSGR2 {
-			seqStr = rq.Properties[NorevMessageSeq]
-		} else {
-			seqStr = rq.Properties[NorevMessageSequence]
-		}
 		seq, err := ParseJSONSequenceID(seqStr)
 		if err != nil {
 			base.WarnfCtx(bh.loggingCtx, "Unable to parse sequence %q from norev message: %w - not tracking for checkpointing", seqStr, err)


### PR DESCRIPTION
CBG-2645

- Iterates backwards over expected sequences and removes those which we know we're able to checkpoint past, if the list of expected sequences grows beyond 100 (`c.expectedSeqCompactionThreshold`)
- Logging improvements for `idAndRevLookup` failure and `norev` handling

Would like a keen eye on the iteration/cleanup logic in `_updateCheckpointLists` and the test case.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1277/