### PR TITLE
CBG-2618: Update tests to use collection access for channels

### DIFF
--- a/auth/principal.go
+++ b/auth/principal.go
@@ -252,3 +252,17 @@ func (u *PrincipalConfig) SetExplicitChannels(scopeName, collectionName string, 
 		}
 	}
 }
+
+func (u *PrincipalConfig) GetExplicitChannels(scopeName, collectionName string) base.Set {
+	if base.IsDefaultCollection(scopeName, collectionName) {
+		return u.ExplicitChannels
+	}
+	return u.CollectionAccess[scopeName][collectionName].ExplicitChannels_
+}
+
+func (u *PrincipalConfig) GetChannels(scopeName, collectionName string) base.Set {
+	if base.IsDefaultCollection(scopeName, collectionName) {
+		return u.Channels
+	}
+	return u.CollectionAccess[scopeName][collectionName].Channels_
+}

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -43,6 +43,10 @@ func (c *DatabaseCollection) AllowConflicts() bool {
 	return base.DefaultAllowConflicts
 }
 
+func (c *DatabaseCollection) GetCollectionDatastore() base.DataStore {
+	return c.dataStore
+}
+
 // allPrincipalIDs returns the IDs of all users and roles, including deleted Roles
 func (c *DatabaseCollection) allPrincipalIDs(ctx context.Context) (users, roles []string, err error) {
 	return c.dbCtx.AllPrincipalIDs(ctx)

--- a/db/query.go
+++ b/db/query.go
@@ -523,6 +523,8 @@ func (context *DatabaseCollection) QueryChannels(ctx context.Context, channelNam
 	// Standard channel index/query doesn't support the star channel.  For star channel queries, QueryStarChannel
 	// (which is backed by IndexAllDocs) is used.  The QueryStarChannel result schema is a subset of the
 	// QueryChannels result schema (removal handling isn't needed for the star channel).
+	//startSeq1 := int64(1)
+	endSeq = 9223372036854775807
 	channelQueryStatement, params := context.buildChannelsQuery(channelName, startSeq, endSeq, limit, activeOnly)
 	return N1QLQueryWithStats(ctx, context.dataStore, QueryChannels.name, channelQueryStatement, params, base.RequestPlus, QueryChannels.adhoc, context.dbStats(), context.slowQueryWarningThreshold())
 }

--- a/db/query.go
+++ b/db/query.go
@@ -523,8 +523,6 @@ func (context *DatabaseCollection) QueryChannels(ctx context.Context, channelNam
 	// Standard channel index/query doesn't support the star channel.  For star channel queries, QueryStarChannel
 	// (which is backed by IndexAllDocs) is used.  The QueryStarChannel result schema is a subset of the
 	// QueryChannels result schema (removal handling isn't needed for the star channel).
-	//startSeq1 := int64(1)
-	endSeq = 9223372036854775807
 	channelQueryStatement, params := context.buildChannelsQuery(channelName, startSeq, endSeq, limit, activeOnly)
 	return N1QLQueryWithStats(ctx, context.dataStore, QueryChannels.name, channelQueryStatement, params, base.RequestPlus, QueryChannels.adhoc, context.dbStats(), context.slowQueryWarningThreshold())
 }

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -151,7 +151,7 @@ func TestStarAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	// GET /db/_changes
-	response = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
+	response = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?since=0", "", "bernard")
 	RequireStatus(t, response, 200)
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -120,6 +120,7 @@ func TestStarAccess(t *testing.T) {
 	response := rt.SendAdminRequest("GET", "/{{.db}}/_user/bernard", ``)
 	RequireStatus(t, response, 200)
 	fmt.Println(response.Body)
+	fmt.Println("after user")
 
 	// GET /db/docid - basic test for channel user has
 	response = rt.SendUserRequest("GET", "/{{.keyspace}}/doc1", "", "bernard")

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -397,11 +397,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			c := collection.Name()
 			s := collection.ScopeName()
 
-			pass := "password"
-			userConfig := auth.PrincipalConfig{
-				Password: &pass,
-			}
-			payload, err := AdminChannelGrant(userConfig, collection, []string{"chan"})
+			payload, err := GetUserPayload("Perms", "password", "", collection, []string{"chan"}, nil)
 			require.NoError(t, err)
 			resp := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/Perms", payload)
 			RequireStatus(t, resp, http.StatusOK)

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -485,7 +485,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			var allChannels struct {
 				Channels []string `json:"all_channels"`
 			}
-			if base.TestsDisableGSI() {
+			if base.IsDefaultCollection(collection.Name(), collection.ScopeName()) {
 				err := json.Unmarshal(resp.BodyBytes(), &allChannels)
 				require.NoError(t, err)
 				assert.NotContains(t, allChannels.Channels, "chan2")
@@ -497,7 +497,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			resp = rt.SendAdminRequest(http.MethodGet, "/db/_user/Perms", ``)
 			RequireStatus(t, resp, http.StatusOK)
 
-			if base.TestsDisableGSI() {
+			if base.IsDefaultCollection(collection.Name(), collection.ScopeName()) {
 				err = json.Unmarshal(resp.BodyBytes(), &allChannels)
 				require.NoError(t, err)
 				assert.NotContains(t, allChannels.Channels, "chan2")
@@ -515,7 +515,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			// Make sure channel access grant was successful
 			resp = rt.SendAdminRequest(http.MethodGet, "/db/_user/Perms", ``)
 			RequireStatus(t, resp, http.StatusOK)
-			if base.TestsDisableGSI() {
+			if base.IsDefaultCollection(collection.Name(), collection.ScopeName()) {
 				err = json.Unmarshal(resp.BodyBytes(), &allChannels)
 				require.NoError(t, err)
 				assert.Contains(t, allChannels.Channels, "chan2")

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -51,9 +51,13 @@ func TestPublicChanGuestAccess(t *testing.T) {
 	resp = rt.SendAdminRequest(http.MethodGet, "/db/_user/GUEST", ``)
 	RequireStatus(t, resp, http.StatusOK)
 	fmt.Println("GUEST user:", resp.Body.String())
-	expected := fmt.Sprintf(`map[%s:map[%s:map[all_channels:[!]]]]`, s, c)
-	collectionAccess := resp.GetRestDocument()["collection_access"]
-	assert.EqualValues(t, expected, fmt.Sprint(collectionAccess))
+	if base.IsDefaultCollection(s, c) {
+		assert.EqualValues(t, []interface{}{"!"}, resp.GetRestDocument()["all_channels"])
+	} else {
+		expected := fmt.Sprintf(`map[%s:map[%s:map[all_channels:[!]]]]`, s, c)
+		collectionAccess := resp.GetRestDocument()["collection_access"]
+		assert.EqualValues(t, expected, fmt.Sprint(collectionAccess))
+	}
 
 	// Confirm guest user cannot access other channels it has no access too
 	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/docNoAccess", `{"channels": ["cookie"], "foo": "bar"}`)

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -862,7 +862,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	rt.MustWaitForDoc("g1", t)
 
 	changes := ChangesResults{}
-	response = rt.SendUserRequest("GET", "/db."+s+"."+c+"/_changes", "", "zegpold")
+	response = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "zegpold")
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 
 	assert.NoError(t, err)
@@ -936,7 +936,7 @@ func TestChannelAccessChanges(t *testing.T) {
 
 	// Look at alice's _changes feed:
 	changes = ChangesResults{}
-	response = rt.SendUserRequest("GET", "/db."+s+"."+c+"/_changes", "", "alice")
+	response = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "alice")
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Len(t, changes.Results, 1)
 	assert.NoError(t, err)
@@ -944,7 +944,7 @@ func TestChannelAccessChanges(t *testing.T) {
 
 	// The complete _changes feed for zegpold contains docs a1 and g1:
 	changes = ChangesResults{}
-	response = rt.SendUserRequest("GET", "/db."+s+"."+c+"/_changes", "", "zegpold")
+	response = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "zegpold")
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	assert.NoError(t, err)
 	require.Len(t, changes.Results, 2)
@@ -956,7 +956,7 @@ func TestChannelAccessChanges(t *testing.T) {
 
 	// Changes feed with since=gamma:8 would ordinarily be empty, but zegpold got access to channel
 	// alpha after sequence 8, so the pre-existing docs in that channel are included:
-	response = rt.SendUserRequest("GET", fmt.Sprintf("/db."+s+"."+c+"/_changes?since=\"%s\"", since),
+	response = rt.SendUserRequest("GET", fmt.Sprintf("/{{.keyspace}}/_changes?since=\"%s\"", since),
 		"", "zegpold")
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	changes.Results = nil

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -117,13 +117,9 @@ func TestStarAccess(t *testing.T) {
 	//
 	bernard, _ := a.NewUser("bernard", "letmein", channels.BaseSetOf(t, "books"))
 	assert.NoError(t, a.Save(bernard))
-	response := rt.SendAdminRequest("GET", "/{{.db}}/_user/bernard", ``)
-	RequireStatus(t, response, 200)
-	fmt.Println(response.Body)
-	fmt.Println("after user")
 
 	// GET /db/docid - basic test for channel user has
-	response = rt.SendUserRequest("GET", "/{{.keyspace}}/doc1", "", "bernard")
+	response := rt.SendUserRequest("GET", "/{{.keyspace}}/doc1", "", "bernard")
 	RequireStatus(t, response, 200)
 
 	// GET /db/docid - negative test for channel user doesn't have

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"sort"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/auth"
@@ -53,7 +54,9 @@ func TestPublicChanGuestAccess(t *testing.T) {
 	fmt.Println("GUEST user:", resp.Body.String())
 	err := json.Unmarshal(resp.BodyBytes(), &user)
 	require.NoError(t, err)
-	assert.EqualValues(t, []string{"!"}, user.GetChannels(s, c).ToArray())
+	allChans := user.GetChannels(s, c).ToArray()
+	sort.Strings(allChans)
+	assert.EqualValues(t, []string{"!"}, allChans)
 
 	// Confirm guest user cannot access other channels it has no access too
 	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/docNoAccess", `{"channels": ["cookie"], "foo": "bar"}`)

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -954,7 +954,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	dbc := rt.ServerContext().Database(ctx, "db")
 	database, _ := db.GetDatabase(dbc, nil)
 
-	collectionWithUser := database.GetSingleDatabaseCollectionWithUser()
+	collectionWithUser := db.GetSingleDatabaseCollectionWithUser(t, database)
 
 	changed, err := database.UpdateSyncFun(ctx, `function(doc) {access("alice", "beta");channel("beta");}`)
 	assert.NoError(t, err)

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -147,10 +147,12 @@ func TestStarAccess(t *testing.T) {
 
 	// Ensure docs have been processed before issuing changes requests
 	expectedSeq := uint64(6)
-	_ = rt.WaitForSequence(expectedSeq)
+	err = rt.WaitForSequence(expectedSeq)
+	require.NoError(t, err)
 
 	// GET /db/_changes
 	response = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
+	RequireStatus(t, response, 200)
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -397,9 +397,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			c := collection.Name()
 			s := collection.ScopeName()
 
-			payload, err := GetUserPayload("Perms", "password", "", collection, []string{"chan"}, nil)
-			require.NoError(t, err)
-			resp := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/Perms", payload)
+			resp := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/Perms", GetUserPayload(t, "Perms", "password", "", collection, []string{"chan"}, nil))
 			RequireStatus(t, resp, http.StatusOK)
 
 			// Create the initial document
@@ -486,7 +484,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			RequireStatus(t, resp, http.StatusOK)
 
 			user := auth.PrincipalConfig{}
-			err = json.Unmarshal(resp.BodyBytes(), &user)
+			err := json.Unmarshal(resp.BodyBytes(), &user)
 			require.NoError(t, err)
 			assert.NotContains(t, user.GetChannels(s, c).ToArray(), "chan2")
 

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
@@ -93,13 +92,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 	collection := rt.GetSingleTestDatabaseCollection()
 
 	// Create user:
-	name := "bernard"
-	password := "letmein"
-	bernard := auth.PrincipalConfig{
-		Name:     &name,
-		Password: &password,
-	}
-	payload, err := AdminChannelGrant(bernard, collection, []string{"ABC"})
+	payload, err := GetUserPayload("bernard", "letmein", "", collection, []string{"ABC"}, nil)
 	require.NoError(t, err)
 	userResponse := rt.SendAdminRequest("PUT", "/db/_user/bernard", payload)
 	RequireStatus(t, userResponse, 201)

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -16,11 +16,11 @@ package rest
 
 import (
 	"fmt"
-	"github.com/couchbase/sync_gateway/channels"
 	"sync"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,12 +30,9 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
-	rt := NewRestTester(t, // CBG-2618: fix collection channel access
+	rt := NewRestTester(t,
 		&RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel);}`})
 	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
-	c := collection.Name()
-	s := collection.ScopeName()
 
 	// Create user:
 	ctx := rt.Context()
@@ -45,7 +42,7 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 	assert.NoError(t, a.Save(bernard))
 
 	// Put several documents in channel PBS
-	response := rt.SendAdminRequest("PUT", "/db."+s+"."+c+"/pbs1", `{"value":1, "channel":["PBS"]}`)
+	response := rt.SendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
 	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/db/pbs2", `{"value":2, "channel":["PBS"]}`)
 	RequireStatus(t, response, 201)
@@ -63,7 +60,7 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 			Last_Seq db.SequenceID
 		}
 		changesJSON := `{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"0"}`
-		changesResponse := rt.Send(RequestByUser("POST", "/db."+s+"."+c+"/_changes", changesJSON, "bernard"))
+		changesResponse := rt.Send(RequestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 		err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 		assert.NoError(t, err)
 		assert.Equal(t, 3, len(changes.Results))

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -92,9 +92,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 	collection := rt.GetSingleTestDatabaseCollection()
 
 	// Create user:
-	payload, err := GetUserPayload("bernard", "letmein", "", collection, []string{"ABC"}, nil)
-	require.NoError(t, err)
-	userResponse := rt.SendAdminRequest("PUT", "/db/_user/bernard", payload)
+	userResponse := rt.SendAdminRequest("PUT", "/db/_user/bernard", GetUserPayload(t, "bernard", "letmein", "", collection, []string{"ABC"}, nil))
 	RequireStatus(t, userResponse, 201)
 
 	// Get user, to trigger all_channels calculation and bump the user change count BEFORE we write the PBS docs - otherwise the user key count
@@ -131,7 +129,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 					 "channels":"ABC,PBS"}`
 	sinceZeroJSON := fmt.Sprintf(changesJSON, "0")
 	changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", sinceZeroJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &initialChanges)
+	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &initialChanges)
 	assert.NoError(t, err, "Unexpected error unmarshalling initialChanges")
 	lastSeq := initialChanges.Last_Seq.String()
 	assert.Equal(t, "1", lastSeq)

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -33,6 +33,9 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 	rt := NewRestTester(t,
 		&RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel);}`})
 	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
+	c := collection.Name()
+	s := collection.ScopeName()
 
 	// Create user:
 	ctx := rt.Context()
@@ -42,11 +45,11 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 	assert.NoError(t, a.Save(bernard))
 
 	// Put several documents in channel PBS
-	response := rt.SendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
+	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs1", `{"value":1, "channel":["PBS"]}`)
 	RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/pbs2", `{"value":2, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs2", `{"value":2, "channel":["PBS"]}`)
 	RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/pbs3", `{"value":3, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs3", `{"value":3, "channel":["PBS"]}`)
 	RequireStatus(t, response, 201)
 
 	caughtUpWaiter := rt.GetDatabase().NewPullReplicationCaughtUpWaiter(t)
@@ -60,7 +63,7 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 			Last_Seq db.SequenceID
 		}
 		changesJSON := `{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"0"}`
-		changesResponse := rt.Send(RequestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+		changesResponse := rt.Send(RequestByUser("POST", "/db."+s+"."+c+"/_changes", changesJSON, "bernard"))
 		err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 		assert.NoError(t, err)
 		assert.Equal(t, 3, len(changes.Results))
@@ -70,7 +73,7 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 	caughtUpWaiter.AddAndWait(1)
 
 	// Put document that triggers access grant for user, PBS
-	response = rt.SendAdminRequest("PUT", "/db/access1", `{"accessUser":"bernard", "accessChannel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/access1", `{"accessUser":"bernard", "accessChannel":["PBS"]}`)
 	RequireStatus(t, response, 201)
 
 	wg.Wait()
@@ -110,11 +113,11 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 	*/
 
 	// Put several documents in channel PBS
-	response := rt.SendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
+	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs1", `{"value":1, "channel":["PBS"]}`)
 	RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/pbs2", `{"value":2, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs2", `{"value":2, "channel":["PBS"]}`)
 	RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/pbs3", `{"value":3, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs3", `{"value":3, "channel":["PBS"]}`)
 	RequireStatus(t, response, 201)
 
 	// Run an initial changes request to get the user doc, and update since based on last_seq:
@@ -130,7 +133,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 					 "filter":"` + base.ByChannelFilter + `",
 					 "channels":"ABC,PBS"}`
 	sinceZeroJSON := fmt.Sprintf(changesJSON, "0")
-	changesResponse := rt.Send(RequestByUser("POST", "/db/_changes", sinceZeroJSON, "bernard"))
+	changesResponse := rt.Send(RequestByUser("POST", "/db."+s+"."+c+"/_changes", sinceZeroJSON, "bernard"))
 	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &initialChanges)
 	assert.NoError(t, err, "Unexpected error unmarshalling initialChanges")
 	lastSeq := initialChanges.Last_Seq.String()
@@ -148,7 +151,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 			Last_Seq db.SequenceID
 		}
 		sinceLastJSON := fmt.Sprintf(changesJSON, lastSeq)
-		changesResponse := rt.Send(RequestByUser("POST", "/db/_changes", sinceLastJSON, "bernard"))
+		changesResponse := rt.Send(RequestByUser("POST", "/db."+s+"."+c+"/_changes", sinceLastJSON, "bernard"))
 		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 		assert.Equal(t, 1, len(changes.Results))
 	}()
@@ -157,7 +160,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 	caughtUpWaiter.Wait()
 
 	// Put public document that triggers termination of the longpoll
-	response = rt.SendAdminRequest("PUT", "/db/abc1", `{"value":3, "channel":["ABC"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/abc1", `{"value":3, "channel":["ABC"]}`)
 	RequireStatus(t, response, 201)
 	wg.Wait()
 }

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1959,7 +1959,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	c := collection.Name()
 	s := collection.ScopeName()
 
-	resp := rt.SendAdminRequest("PUT", "/db/_user/user", `{`+AdminChannelGrant(s, c, `"admin_channels": ["A", "B"]`)+`"password": "test"}`)
+	resp := rt.SendAdminRequest("PUT", "/db/_user/user", `{`+AdminChannelGrant(s, c, `"admin_channels": ["A", "B"]`)+`, "password": "test"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -825,8 +825,6 @@ function(doc, oldDoc) {
 	defer rt.Close()
 	ctx := rt.Context()
 	collection := rt.GetSingleTestDatabaseCollection()
-	c := collection.Name()
-	s := collection.ScopeName()
 
 	// Create bliptester that is connected as user1, with no access to channel ABC
 	bt, err := NewBlipTesterFromSpecWithRT(t, &BlipTesterSpec{
@@ -855,7 +853,7 @@ function(doc, oldDoc) {
 	userWaiter := userDb.NewUserWaiter()
 
 	// Update the user to grant them access to ABC
-	response := rt.SendAdminRequest("PUT", "/db/_user/user1", `{`+AdminChannelGrant(s, c, `"admin_channels":["ABC"]`)+`}`)
+	response := rt.SendAdminRequest("PUT", "/db/_user/user1", `{`+AdminChannelGrant(collection, `"admin_channels":["ABC"]`)+`}`)
 	RequireStatus(t, response, 200)
 
 	// Wait for notification
@@ -1422,9 +1420,7 @@ func TestAccessGrantViaAdminApi(t *testing.T) {
 		connectingPassword: "1234",
 	})
 	defer bt.Close()
-	collection := bt.DatabaseContext().GetSingleDatabaseCollection()
-	c := collection.Name()
-	s := collection.ScopeName()
+	collection := bt.restTester.GetSingleTestDatabaseCollection()
 
 	// Add a doc in the PBS channel
 	_, _, _, _ = bt.SendRev(
@@ -1435,7 +1431,7 @@ func TestAccessGrantViaAdminApi(t *testing.T) {
 	)
 
 	// Update the user doc to grant access to PBS
-	response := bt.restTester.SendAdminRequest("PUT", "/db/_user/user1", `{`+AdminChannelGrant(s, c, `"admin_channels":["user1", "PBS"]`)+`}`)
+	response := bt.restTester.SendAdminRequest("PUT", "/db/_user/user1", `{`+AdminChannelGrant(collection, `"admin_channels":["user1", "PBS"]`)+`}`)
 	RequireStatus(t, response, 200)
 
 	// Add another doc in the PBS channel
@@ -1956,10 +1952,8 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	rt := NewRestTesterDefaultCollection(t, nil) // CBG-2619: make collection aware
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
-	c := collection.Name()
-	s := collection.ScopeName()
 
-	resp := rt.SendAdminRequest("PUT", "/db/_user/user", `{`+AdminChannelGrant(s, c, `"admin_channels": ["A", "B"]`)+`, "password": "test"}`)
+	resp := rt.SendAdminRequest("PUT", "/db/_user/user", `{`+AdminChannelGrant(collection, `"admin_channels": ["A", "B"]`)+`, "password": "test"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
@@ -2065,10 +2059,8 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 	rt := NewRestTesterDefaultCollection(t, nil) // CBG-2619: make collection aware
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
-	c := collection.Name()
-	s := collection.ScopeName()
 
-	resp := rt.SendAdminRequest("PUT", "/db/_user/user", `{`+AdminChannelGrant(s, c, `"admin_channels": ["A", "B"]`)+`, "password": "test"}`)
+	resp := rt.SendAdminRequest("PUT", "/db/_user/user", `{`+AdminChannelGrant(collection, `"admin_channels": ["A", "B"]`)+`, "password": "test"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -14,7 +14,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/couchbase/sync_gateway/auth"
 	"log"
 	"net/http"
 	"net/url"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/gocb/v2"
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -853,9 +853,7 @@ function(doc, oldDoc) {
 	userWaiter := userDb.NewUserWaiter()
 
 	// Update the user to grant them access to ABC
-	payload, err := GetUserPayload("user1", "", "", collection, []string{"ABC"}, nil)
-	require.NoError(t, err)
-	response := rt.SendAdminRequest("PUT", "/db/_user/user1", payload)
+	response := rt.SendAdminRequest("PUT", "/db/_user/user1", GetUserPayload(t, "user1", "", "", collection, []string{"ABC"}, nil))
 	RequireStatus(t, response, 200)
 
 	// Wait for notification
@@ -1433,9 +1431,7 @@ func TestAccessGrantViaAdminApi(t *testing.T) {
 	)
 
 	// Update the user doc to grant access to PBS
-	payload, err := GetUserPayload("user1", "", "", collection, []string{"user1", "PBS"}, nil)
-	require.NoError(t, err)
-	response := bt.restTester.SendAdminRequest("PUT", "/db/_user/user1", payload)
+	response := bt.restTester.SendAdminRequest("PUT", "/db/_user/user1", GetUserPayload(t, "user1", "", "", collection, []string{"user1", "PBS"}, nil))
 	RequireStatus(t, response, 200)
 
 	// Add another doc in the PBS channel
@@ -1957,9 +1953,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 
-	payload, err := GetUserPayload("user", "test", "", collection, []string{"A", "B"}, nil)
-	require.NoError(t, err)
-	resp := rt.SendAdminRequest("PUT", "/db/_user/user", payload)
+	resp := rt.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "test", "", collection, []string{"A", "B"}, nil))
 	RequireStatus(t, resp, http.StatusCreated)
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
@@ -2066,8 +2060,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 
-	payload, err := GetUserPayload("user", "test", "", collection, []string{"A", "B"}, nil)
-	resp := rt.SendAdminRequest("PUT", "/db/_user/user", payload)
+	resp := rt.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "test", "", collection, []string{"A", "B"}, nil))
 	RequireStatus(t, resp, http.StatusCreated)
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/gocb/v2"
-	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
@@ -854,8 +853,7 @@ function(doc, oldDoc) {
 	userWaiter := userDb.NewUserWaiter()
 
 	// Update the user to grant them access to ABC
-	userConfig := auth.PrincipalConfig{}
-	payload, err := AdminChannelGrant(userConfig, collection, []string{"ABC"})
+	payload, err := GetUserPayload("user1", "", "", collection, []string{"ABC"}, nil)
 	require.NoError(t, err)
 	response := rt.SendAdminRequest("PUT", "/db/_user/user1", payload)
 	RequireStatus(t, response, 200)
@@ -1435,8 +1433,7 @@ func TestAccessGrantViaAdminApi(t *testing.T) {
 	)
 
 	// Update the user doc to grant access to PBS
-	userConfig := auth.PrincipalConfig{}
-	payload, err := AdminChannelGrant(userConfig, collection, []string{"user1", "PBS"})
+	payload, err := GetUserPayload("user1", "", "", collection, []string{"user1", "PBS"}, nil)
 	require.NoError(t, err)
 	response := bt.restTester.SendAdminRequest("PUT", "/db/_user/user1", payload)
 	RequireStatus(t, response, 200)
@@ -1960,11 +1957,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 
-	pass := "test"
-	userConfig := auth.PrincipalConfig{
-		Password: &pass,
-	}
-	payload, err := AdminChannelGrant(userConfig, collection, []string{"A", "B"})
+	payload, err := GetUserPayload("user", "test", "", collection, []string{"A", "B"}, nil)
 	require.NoError(t, err)
 	resp := rt.SendAdminRequest("PUT", "/db/_user/user", payload)
 	RequireStatus(t, resp, http.StatusCreated)
@@ -2073,11 +2066,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 
-	pass := "test"
-	userConfig := auth.PrincipalConfig{
-		Password: &pass,
-	}
-	payload, err := AdminChannelGrant(userConfig, collection, []string{"A", "B"})
+	payload, err := GetUserPayload("user", "test", "", collection, []string{"A", "B"}, nil)
 	resp := rt.SendAdminRequest("PUT", "/db/_user/user", payload)
 	RequireStatus(t, resp, http.StatusCreated)
 

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -92,8 +92,11 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc) {channel(doc.channels)}`,
 	}
-	rt := NewRestTesterDefaultCollection(t, &rtConfig) // CBG-2618: fix collection channel access
+	rt := NewRestTester(t, &rtConfig) // CBG-2618: fix collection channel access
 	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
+	c := collection.Name()
+	s := collection.ScopeName()
 
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
@@ -103,7 +106,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.NoError(t, a.Save(guest))
 
 	// Create user1
-	response := rt.SendAdminRequest("PUT", "/db/_user/user1", `{"email":"user1@couchbase.com", "password":"letmein", "admin_channels":["alpha"]}`)
+	response := rt.SendAdminRequest("PUT", "/db/_user/user1", `{"email":"user1@couchbase.com", "password":"letmein",`+AdminChannelGrant(s, c, `"admin_channels":["alpha"]`)+`}`)
 	RequireStatus(t, response, 201)
 
 	// Create 100 docs
@@ -127,7 +130,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, "doc98", changesResults.Results[49].ID)
 
 	// Create user2
-	response = rt.SendAdminRequest("PUT", "/db/_user/user2", `{"email":"user2@couchbase.com", "password":"letmein", "admin_channels":["alpha"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/_user/user2", `{"email":"user2@couchbase.com", "password":"letmein",`+AdminChannelGrant(s, c, `"admin_channels":["alpha"]`)+`}`)
 	RequireStatus(t, response, 201)
 
 	// Retrieve all changes for user2 with no limits
@@ -137,7 +140,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, "doc99", changesResults.Results[99].ID)
 
 	// Create user3
-	response = rt.SendAdminRequest("PUT", "/db/_user/user3", `{"email":"user3@couchbase.com", "password":"letmein", "admin_channels":["alpha"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/_user/user3", `{"email":"user3@couchbase.com", "password":"letmein",`+AdminChannelGrant(s, c, `"admin_channels":["alpha"]`)+`}`)
 	RequireStatus(t, response, 201)
 
 	getUserResponse := rt.SendAdminRequest("GET", "/db/_user/user3", "")
@@ -163,7 +166,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, "doc99", changesResults.Results[49].ID)
 
 	// Create user4
-	response = rt.SendAdminRequest("PUT", "/db/_user/user4", `{"email":"user4@couchbase.com", "password":"letmein", "admin_channels":["alpha"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/_user/user4", `{"email":"user4@couchbase.com", "password":"letmein",`+AdminChannelGrant(s, c, `"admin_channels":["alpha"]`)+`}`)
 	RequireStatus(t, response, 201)
 	// Get the sequence from the user doc to validate against the triggered by value in the changes results
 	user4, _ := rt.GetDatabase().Authenticator(base.TestCtx(t)).GetUser("user4")

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -92,7 +92,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc) {channel(doc.channels)}`,
 	}
-	rt := NewRestTester(t, &rtConfig) // CBG-2618: fix collection channel access
+	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 	c := collection.Name()

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -111,19 +111,19 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 
 	// Create 100 docs
 	for i := 0; i < 100; i++ {
-		docpath := fmt.Sprintf("/db/doc%d", i)
+		docpath := fmt.Sprintf("/db."+s+"."+c+"/doc%d", i)
 		RequireStatus(t, rt.Send(Request("PUT", docpath, `{"foo": "bar", "channels":["alpha"]}`)), 201)
 	}
 
 	limit := 50
-	changesResults, err := rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user1", false)
+	changesResults, err := rt.WaitForChanges(50, fmt.Sprintf("/{{.keyspace}}/_changes?limit=%d", limit), "user1", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 50)
 	since := changesResults.Results[49].Seq
 	assert.Equal(t, "doc48", changesResults.Results[49].ID)
 
 	// // Check the _changes feed with  since and limit, to get second half of feed
-	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?since=\"%s\"&limit=%d", since, limit), "user1", false)
+	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/{{.keyspace}}/_changes?since=\"%s\"&limit=%d", since, limit), "user1", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 50)
 	since = changesResults.Results[49].Seq
@@ -134,7 +134,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	RequireStatus(t, response, 201)
 
 	// Retrieve all changes for user2 with no limits
-	changesResults, err = rt.WaitForChanges(101, fmt.Sprintf("/db/_changes"), "user2", false)
+	changesResults, err = rt.WaitForChanges(101, fmt.Sprintf("/{{.keyspace}}/_changes"), "user2", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 101)
 	assert.Equal(t, "doc99", changesResults.Results[99].ID)
@@ -152,7 +152,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	userSequence := user3.Sequence()
 
 	// Get first 50 document changes.
-	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user3", false)
+	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/{{.keyspace}}/_changes?limit=%d", limit), "user3", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 50)
 	since = changesResults.Results[49].Seq
@@ -160,7 +160,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, userSequence, since.TriggeredBy)
 
 	// // Get remainder of changes i.e. no limit parameter
-	changesResults, err = rt.WaitForChanges(51, fmt.Sprintf("/db/_changes?since=\"%s\"", since), "user3", false)
+	changesResults, err = rt.WaitForChanges(51, fmt.Sprintf("/{{.keyspace}}/_changes?since=\"%s\"", since), "user3", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 51)
 	assert.Equal(t, "doc99", changesResults.Results[49].ID)
@@ -172,7 +172,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	user4, _ := rt.GetDatabase().Authenticator(base.TestCtx(t)).GetUser("user4")
 	user4Sequence := user4.Sequence()
 
-	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user4", false)
+	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/{{.keyspace}}/_changes?limit=%d", limit), "user4", false)
 	assert.NoError(t, err, "Unexpected error")
 	require.Len(t, changesResults.Results, 50)
 	since = changesResults.Results[49].Seq
@@ -180,7 +180,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, user4Sequence, since.TriggeredBy)
 
 	// // Check the _changes feed with  since and limit, to get second half of feed
-	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?since=%s&limit=%d", since, limit), "user4", false)
+	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&limit=%d", since, limit), "user4", false)
 	assert.Equal(t, nil, err)
 	require.Len(t, changesResults.Results, 50)
 	assert.Equal(t, "doc99", changesResults.Results[49].ID)

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -10,7 +10,6 @@ package rest
 
 import (
 	"fmt"
-	"github.com/couchbase/sync_gateway/auth"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -104,9 +104,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.NoError(t, a.Save(guest))
 
 	// Create user1
-	payload, err := GetUserPayload("user1", "letmein", "user1@couchbase.com", collection, []string{"alpha"}, nil)
-	require.NoError(t, err)
-	response := rt.SendAdminRequest("PUT", "/db/_user/user1", payload)
+	response := rt.SendAdminRequest("PUT", "/db/_user/user1", GetUserPayload(t, "user1", "letmein", "user1@couchbase.com", collection, []string{"alpha"}, nil))
 	RequireStatus(t, response, 201)
 
 	// Create 100 docs
@@ -130,9 +128,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, "doc98", changesResults.Results[49].ID)
 
 	// Create user2
-	payload, err = GetUserPayload("user2", "letmein", "user2@couchbase.com", collection, []string{"alpha"}, nil)
-	require.NoError(t, err)
-	response = rt.SendAdminRequest("PUT", "/db/_user/user2", payload)
+	response = rt.SendAdminRequest("PUT", "/db/_user/user2", GetUserPayload(t, "user2", "letmein", "user2@couchbase.com", collection, []string{"alpha"}, nil))
 	RequireStatus(t, response, 201)
 
 	// Retrieve all changes for user2 with no limits
@@ -142,8 +138,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, "doc99", changesResults.Results[99].ID)
 
 	// Create user3
-	payload, err = GetUserPayload("user3", "letmein", "user3@couchbase.com", collection, []string{"alpha"}, nil)
-	response = rt.SendAdminRequest("PUT", "/db/_user/user3", payload)
+	response = rt.SendAdminRequest("PUT", "/db/_user/user3", GetUserPayload(t, "user3", "letmein", "user3@couchbase.com", collection, []string{"alpha"}, nil))
 	RequireStatus(t, response, 201)
 
 	getUserResponse := rt.SendAdminRequest("GET", "/db/_user/user3", "")
@@ -169,9 +164,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, "doc99", changesResults.Results[49].ID)
 
 	// Create user4
-	payload, err = GetUserPayload("user4", "letmein", "user4@couchbase.com", collection, []string{"alpha"}, nil)
-	require.NoError(t, err)
-	response = rt.SendAdminRequest("PUT", "/db/_user/user4", payload)
+	response = rt.SendAdminRequest("PUT", "/db/_user/user4", GetUserPayload(t, "user4", "letmein", "user4@couchbase.com", collection, []string{"alpha"}, nil))
 	RequireStatus(t, response, 201)
 	// Get the sequence from the user doc to validate against the triggered by value in the changes results
 	user4, _ := rt.GetDatabase().Authenticator(base.TestCtx(t)).GetUser("user4")

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
@@ -105,13 +104,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.NoError(t, a.Save(guest))
 
 	// Create user1
-	email := "user1@couchbase.com"
-	pass := "letmein"
-	userConfig := auth.PrincipalConfig{
-		Password: &pass,
-		Email:    &email,
-	}
-	payload, err := AdminChannelGrant(userConfig, collection, []string{"alpha"})
+	payload, err := GetUserPayload("user1", "letmein", "user1@couchbase.com", collection, []string{"alpha"}, nil)
 	require.NoError(t, err)
 	response := rt.SendAdminRequest("PUT", "/db/_user/user1", payload)
 	RequireStatus(t, response, 201)
@@ -137,9 +130,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, "doc98", changesResults.Results[49].ID)
 
 	// Create user2
-	email = "user2@couchbase.com"
-	userConfig.Email = &email
-	payload, err = AdminChannelGrant(userConfig, collection, []string{"alpha"})
+	payload, err = GetUserPayload("user2", "letmein", "user2@couchbase.com", collection, []string{"alpha"}, nil)
 	require.NoError(t, err)
 	response = rt.SendAdminRequest("PUT", "/db/_user/user2", payload)
 	RequireStatus(t, response, 201)
@@ -151,9 +142,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, "doc99", changesResults.Results[99].ID)
 
 	// Create user3
-	email = "user3@couchbase.com"
-	userConfig.Email = &email
-	payload, err = AdminChannelGrant(userConfig, collection, []string{"alpha"})
+	payload, err = GetUserPayload("user3", "letmein", "user3@couchbase.com", collection, []string{"alpha"}, nil)
 	response = rt.SendAdminRequest("PUT", "/db/_user/user3", payload)
 	RequireStatus(t, response, 201)
 
@@ -180,9 +169,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, "doc99", changesResults.Results[49].ID)
 
 	// Create user4
-	email = "user4@couchbase.com"
-	userConfig.Email = &email
-	payload, err = AdminChannelGrant(userConfig, collection, []string{"alpha"})
+	payload, err = GetUserPayload("user4", "letmein", "user4@couchbase.com", collection, []string{"alpha"}, nil)
 	require.NoError(t, err)
 	response = rt.SendAdminRequest("PUT", "/db/_user/user4", payload)
 	RequireStatus(t, response, 201)

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -10,6 +10,7 @@ package rest
 
 import (
 	"fmt"
+	"github.com/couchbase/sync_gateway/auth"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -104,7 +105,15 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.NoError(t, a.Save(guest))
 
 	// Create user1
-	response := rt.SendAdminRequest("PUT", "/db/_user/user1", `{"email":"user1@couchbase.com", "password":"letmein",`+AdminChannelGrant(collection, `"admin_channels":["alpha"]`)+`}`)
+	email := "user1@couchbase.com"
+	pass := "letmein"
+	userConfig := auth.PrincipalConfig{
+		Password: &pass,
+		Email:    &email,
+	}
+	payload, err := AdminChannelGrant(userConfig, collection, []string{"alpha"})
+	require.NoError(t, err)
+	response := rt.SendAdminRequest("PUT", "/db/_user/user1", payload)
 	RequireStatus(t, response, 201)
 
 	// Create 100 docs
@@ -128,7 +137,11 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, "doc98", changesResults.Results[49].ID)
 
 	// Create user2
-	response = rt.SendAdminRequest("PUT", "/db/_user/user2", `{"email":"user2@couchbase.com", "password":"letmein",`+AdminChannelGrant(collection, `"admin_channels":["alpha"]`)+`}`)
+	email = "user2@couchbase.com"
+	userConfig.Email = &email
+	payload, err = AdminChannelGrant(userConfig, collection, []string{"alpha"})
+	require.NoError(t, err)
+	response = rt.SendAdminRequest("PUT", "/db/_user/user2", payload)
 	RequireStatus(t, response, 201)
 
 	// Retrieve all changes for user2 with no limits
@@ -138,7 +151,10 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, "doc99", changesResults.Results[99].ID)
 
 	// Create user3
-	response = rt.SendAdminRequest("PUT", "/db/_user/user3", `{"email":"user3@couchbase.com", "password":"letmein",`+AdminChannelGrant(collection, `"admin_channels":["alpha"]`)+`}`)
+	email = "user3@couchbase.com"
+	userConfig.Email = &email
+	payload, err = AdminChannelGrant(userConfig, collection, []string{"alpha"})
+	response = rt.SendAdminRequest("PUT", "/db/_user/user3", payload)
 	RequireStatus(t, response, 201)
 
 	getUserResponse := rt.SendAdminRequest("GET", "/db/_user/user3", "")
@@ -164,7 +180,11 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equal(t, "doc99", changesResults.Results[49].ID)
 
 	// Create user4
-	response = rt.SendAdminRequest("PUT", "/db/_user/user4", `{"email":"user4@couchbase.com", "password":"letmein",`+AdminChannelGrant(collection, `"admin_channels":["alpha"]`)+`}`)
+	email = "user4@couchbase.com"
+	userConfig.Email = &email
+	payload, err = AdminChannelGrant(userConfig, collection, []string{"alpha"})
+	require.NoError(t, err)
+	response = rt.SendAdminRequest("PUT", "/db/_user/user4", payload)
 	RequireStatus(t, response, 201)
 	// Get the sequence from the user doc to validate against the triggered by value in the changes results
 	user4, _ := rt.GetDatabase().Authenticator(base.TestCtx(t)).GetUser("user4")

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -1268,7 +1268,6 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	WriteDirect([]string{"PBS"}, 5, collection)
 	require.NoError(t, testDb.GetSingleDatabaseCollection().WaitForSequenceNotSkipped(ctx, 5))
 	resp := rt.SendAdminRequest("GET", "/db/_all_docs", "")
-	fmt.Println(resp.Body)
 	// Check the _changes feed:
 	var changes struct {
 		Results  []db.ChangeEntry

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -297,13 +297,13 @@ func TestPostChangesWithQueryString(t *testing.T) {
 	defer rt.Close()
 
 	// Put several documents
-	response := rt.SendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
+	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs1", `{"value":1, "channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/abc1", `{"value":1, "channel":["ABC"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/abc1", `{"value":1, "channel":["ABC"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/pbs2", `{"value":2, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs2", `{"value":2, "channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/pbs3", `{"value":3, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs3", `{"value":3, "channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
 
 	_ = rt.WaitForPendingChanges()
@@ -315,7 +315,7 @@ func TestPostChangesWithQueryString(t *testing.T) {
 
 	// Test basic properties
 	changesJSON := `{"heartbeat":50, "feed":"normal", "limit":1, "since":"3"}`
-	changesResponse := rt.SendAdminRequest("POST", "/db/_changes?feed=longpoll&limit=10&since=0&heartbeat=50000", changesJSON)
+	changesResponse := rt.SendAdminRequest("POST", "/{{.keyspace}}/_changes?feed=longpoll&limit=10&since=0&heartbeat=50000", changesJSON)
 
 	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
@@ -327,7 +327,7 @@ func TestPostChangesWithQueryString(t *testing.T) {
 		Last_Seq db.SequenceID
 	}
 	changesJSON = `{"feed":"longpoll"}`
-	changesResponse = rt.SendAdminRequest("POST", "/db/_changes?feed=longpoll&filter=sync_gateway/bychannel&channels=ABC", changesJSON)
+	changesResponse = rt.SendAdminRequest("POST", "/{{.keyspace}}/_changes?feed=longpoll&filter=sync_gateway/bychannel&channels=ABC", changesJSON)
 
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &filteredChanges)
 	assert.NoError(t, err, "Error unmarshalling changes response")
@@ -347,15 +347,15 @@ func postChangesSince(t *testing.T, rt *rest.RestTester) {
 	cacheWaiter := rt.GetDatabase().NewDCPCachingCountWaiter(t)
 
 	// Put several documents
-	response = rt.SendAdminRequest("PUT", "/db/pbs1-0000609", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs1-0000609", `{"channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/samevbdiffchannel-0000609", `{"channel":["ABC"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/samevbdiffchannel-0000609", `{"channel":["ABC"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/samevbdiffchannel-0000799", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/samevbdiffchannel-0000799", `{"channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/pbs2-0000609", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs2-0000609", `{"channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/pbs3-0000609", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs3-0000609", `{"channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
 	cacheWaiter.AddAndWait(5)
 
@@ -364,7 +364,7 @@ func postChangesSince(t *testing.T, rt *rest.RestTester) {
 		Last_Seq interface{}
 	}
 	changesJSON := `{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"0"}`
-	changesResponse := rt.SendUserRequest("POST", "/db/_changes", changesJSON, "bernard")
+	changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
 
 	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	log.Printf("Changes:%s", changesResponse.Body.Bytes())
@@ -372,18 +372,18 @@ func postChangesSince(t *testing.T, rt *rest.RestTester) {
 	require.Len(t, changes.Results, 5)
 
 	// Put several more documents, some to the same vbuckets
-	response = rt.SendAdminRequest("PUT", "/db/pbs1-0000799", `{"value":1, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs1-0000799", `{"value":1, "channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/abc1-0000609", `{"value":1, "channel":["ABC"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/abc1-0000609", `{"value":1, "channel":["ABC"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/pbs2-0000799", `{"value":2, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs2-0000799", `{"value":2, "channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/pbs4", `{"value":4, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs4", `{"value":4, "channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
 	cacheWaiter.AddAndWait(4)
 
 	changesJSON = fmt.Sprintf(`{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"%s"}`, changes.Last_Seq)
-	changesResponse = rt.SendUserRequest("POST", "/db/_changes", changesJSON, "bernard")
+	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	log.Printf("Changes:%s", changesResponse.Body.Bytes())
 	assert.NoError(t, err, "Error unmarshalling changes response")
@@ -480,15 +480,15 @@ func TestPostChangesAdminChannelGrant(t *testing.T) {
 	cacheWaiter := rt.GetDatabase().NewDCPCachingCountWaiter(t)
 
 	// Put several documents in channel ABC and PBS
-	response := rt.SendAdminRequest("PUT", "/db/pbs-1", `{"channel":["PBS"]}`)
+	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-1", `{"channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/pbs-2", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-2", `{"channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/pbs-3", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-3", `{"channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/pbs-4", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-4", `{"channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/abc-1", `{"channel":["ABC"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/abc-1", `{"channel":["ABC"]}`)
 	rest.RequireStatus(t, response, 201)
 	cacheWaiter.AddAndWait(5)
 
@@ -498,7 +498,7 @@ func TestPostChangesAdminChannelGrant(t *testing.T) {
 	}
 
 	// Issue simple changes request
-	changesResponse := rt.SendUserRequest("GET", "/db/_changes", "", "bernard")
+	changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
 	rest.RequireStatus(t, changesResponse, 200)
 
 	log.Printf("Response:%+v", changesResponse.Body)
@@ -513,7 +513,7 @@ func TestPostChangesAdminChannelGrant(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	// Issue a new changes request with since=last_seq ensure that user receives all records for channel PBS
-	changesResponse = rt.SendUserRequest("GET", fmt.Sprintf("/db/_changes?since=%s", changes.Last_Seq),
+	changesResponse = rt.SendUserRequest("GET", fmt.Sprintf("/{{.keyspace}}/_changes?since=%s", changes.Last_Seq),
 		"", "bernard")
 	rest.RequireStatus(t, changesResponse, 200)
 
@@ -526,15 +526,15 @@ func TestPostChangesAdminChannelGrant(t *testing.T) {
 	require.Len(t, changes.Results, 5) // 4 PBS docs, plus the updated user doc
 
 	// Write a few more docs
-	response = rt.SendAdminRequest("PUT", "/db/pbs-5", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-5", `{"channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/abc-2", `{"channel":["ABC"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/abc-2", `{"channel":["ABC"]}`)
 	rest.RequireStatus(t, response, 201)
 
 	cacheWaiter.AddAndWait(2)
 
 	// Issue another changes request - ensure we don't backfill again
-	changesResponse = rt.SendUserRequest("GET", fmt.Sprintf("/db/_changes?since=%s", changes.Last_Seq),
+	changesResponse = rt.SendUserRequest("GET", fmt.Sprintf("/{{.keyspace}}/_changes?since=%s", changes.Last_Seq),
 		"", "bernard")
 	rest.RequireStatus(t, changesResponse, 200)
 	log.Printf("Response:%+v", changesResponse.Body)
@@ -631,7 +631,7 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 		`{"seq":26,"id":"abc-2","deleted":true,"removed":["ABC"],"changes":[{"rev":"2-6055be21d970eb690f48452505ea02ed"}]}`,
 		`{"seq":27,"id":"abc-3","removed":["ABC"],"changes":[{"rev":"2-09b89154aa9a0e1620da0d86528d406a"}]}`,
 	}
-	changes, err := rt.WaitForChanges(len(expectedResults), "/db/_changes", "bernard", false)
+	changes, err := rt.WaitForChanges(len(expectedResults), "/{{.keyspace}}/_changes", "bernard", false)
 	require.NoError(t, err, "Error retrieving changes results")
 
 	for index, result := range changes.Results {
@@ -660,7 +660,7 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 		`{"seq":28,"id":"_user/bernard","changes":[]}`,
 	}
 	changes, err = rt.WaitForChanges(len(expectedResults),
-		fmt.Sprintf("/db/_changes?since=%s", changes.Last_Seq), "bernard", false)
+		fmt.Sprintf("/{{.keyspace}}/_changes?since=%s", changes.Last_Seq), "bernard", false)
 	require.NoError(t, err, "Error retrieving changes results")
 
 	for index, result := range changes.Results {
@@ -695,7 +695,7 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 		`{"seq":32,"id":"mix-7","changes":[{"rev":"1-32f69cdbf1772a8e064f15e928a18f85"}]}`,
 	}
 	changes, err = rt.WaitForChanges(len(expectedResults),
-		fmt.Sprintf("/db/_changes?since=28:5"), "bernard", false)
+		fmt.Sprintf("/{{.keyspace}}/_changes?since=28:5"), "bernard", false)
 	require.NoError(t, err, "Error retrieving changes results")
 
 	for index, result := range changes.Results {
@@ -758,7 +758,7 @@ func TestPostChangesAdminChannelGrantRemovalWithLimit(t *testing.T) {
 	cacheWaiter.AddAndWait(3)
 
 	// Issue changes request with limit less than 5.  Expect to get pbs-5, user doc, and abc-1
-	changes, err := rt.WaitForChanges(0, "/db/_changes?limit=3", "bernard", false)
+	changes, err := rt.WaitForChanges(0, "/{{.keyspace}}/_changes?limit=3", "bernard", false)
 	assert.NoError(t, err)
 	require.Equal(t, len(changes.Results), 3)
 	assert.Equal(t, "pbs-5", changes.Results[0].ID)
@@ -767,7 +767,7 @@ func TestPostChangesAdminChannelGrantRemovalWithLimit(t *testing.T) {
 	lastSeq := changes.Last_Seq
 
 	// Issue a second changes request, expect to see last 2 documents.
-	moreChanges, err := rt.WaitForChanges(0, fmt.Sprintf("/db/_changes?limit=3&since=%s", lastSeq), "bernard", false)
+	moreChanges, err := rt.WaitForChanges(0, fmt.Sprintf("/{{.keyspace}}/_changes?limit=3&since=%s", lastSeq), "bernard", false)
 	assert.NoError(t, err)
 	require.Equal(t, 2, len(moreChanges.Results))
 	assert.Equal(t, "abc-2", moreChanges.Results[0].ID)
@@ -1022,7 +1022,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 		Results  []db.ChangeEntry
 		Last_Seq db.SequenceID
 	}
-	response = rt.SendUserRequest("GET", "/db/_changes", "", "bernard")
+	response = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Equal(t, 4, len(changes.Results))
@@ -1033,7 +1033,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	// Send another changes request before any changes, with the last_seq received from the last changes ("2::6")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendUserRequest("POST", "/db/_changes", changesJSON, "bernard")
+	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Len(t, changes.Results, 0)
@@ -1047,7 +1047,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Send another changes request with the same since ("2::6") to ensure we see data once there are changes
-	response = rt.SendUserRequest("POST", "/db/_changes", changesJSON, "bernard")
+	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Len(t, changes.Results, 3)
@@ -1059,7 +1059,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	// Send another changes request with the same since ("2::6") to ensure we see data once there are changes
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendUserRequest("POST", "/db/_changes", changesJSON, "bernard")
+	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Len(t, changes.Results, 1)
@@ -1118,7 +1118,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 		Results  []db.ChangeEntry
 		Last_Seq string
 	}
-	response = rt.SendUserRequest("GET", "/db/_changes", "", "bernard")
+	response = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
 	log.Printf("_changes 1 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Len(t, changes.Results, 5) // Includes user doc
@@ -1136,7 +1136,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendUserRequest("POST", "/db/_changes", changesJSON, "bernard")
+	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
 	log.Printf("_changes 2 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Len(t, changes.Results, 4)
@@ -1150,7 +1150,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendUserRequest("POST", "/db/_changes", changesJSON, "bernard")
+	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
 	log.Printf("_changes 3 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Len(t, changes.Results, 2)
@@ -1163,7 +1163,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendUserRequest("POST", "/db/_changes", changesJSON, "bernard")
+	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
 	log.Printf("_changes 4 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 
@@ -1253,7 +1253,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 		Results  []db.ChangeEntry
 		Last_Seq string
 	}
-	response := rt.SendAdminRequest("GET", "/db/_changes", "")
+	response := rt.SendAdminRequest("GET", "/{{.keyspace}}/_changes", "")
 	log.Printf("_changes 1 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Len(t, changes.Results, 5)
@@ -1271,7 +1271,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendAdminRequest("POST", "/db/_changes", changesJSON)
+	response = rt.SendAdminRequest("POST", "/{{.keyspace}}/_changes", changesJSON)
 	log.Printf("_changes 2 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Len(t, changes.Results, 4)
@@ -1285,7 +1285,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendAdminRequest("POST", "/db/_changes", changesJSON)
+	response = rt.SendAdminRequest("POST", "/{{.keyspace}}/_changes", changesJSON)
 	log.Printf("_changes 3 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Len(t, changes.Results, 2)
@@ -1298,7 +1298,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendAdminRequest("POST", "/db/_changes", changesJSON)
+	response = rt.SendAdminRequest("POST", "/{{.keyspace}}/_changes", changesJSON)
 	log.Printf("_changes 4 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 
@@ -1392,7 +1392,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 		Results  []db.ChangeEntry
 		Last_Seq string
 	}
-	response = rt.SendUserRequest("GET", "/db/_changes", "", "bernard")
+	response = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
 	log.Printf("_changes 1 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Len(t, changes.Results, 5) // Includes user doc
@@ -1410,7 +1410,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendUserRequest("POST", "/db/_changes", changesJSON, "bernard")
+	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
 	log.Printf("_changes 2 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Len(t, changes.Results, 4)
@@ -1424,7 +1424,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendUserRequest("POST", "/db/_changes", changesJSON, "bernard")
+	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
 	log.Printf("_changes 3 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Len(t, changes.Results, 2)
@@ -1438,7 +1438,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 		defer longpollWg.Done()
 		longpollChangesJSON := fmt.Sprintf(`{"since":"%s", "feed":"longpoll"}`, changes.Last_Seq)
 		log.Printf("starting longpoll changes w/ JSON: %s", longpollChangesJSON)
-		longPollResponse := rt.SendUserRequest("POST", "/db/_changes", longpollChangesJSON, "bernard")
+		longPollResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", longpollChangesJSON, "bernard")
 		log.Printf("longpoll changes looks like: %s", longPollResponse.Body.Bytes())
 		assert.NoError(t, base.JSONUnmarshal(longPollResponse.Body.Bytes(), &changes))
 		// Expect to get 6 through 12
@@ -1920,7 +1920,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 }
 
 func updateTestDoc(rt *rest.RestTester, docid string, revid string, body string) (newRevId string, err error) {
-	path := fmt.Sprintf("/db/%s", docid)
+	path := fmt.Sprintf("/{{.keyspace}}/%s", docid)
 	if revid != "" {
 		path = fmt.Sprintf("%s?rev=%s", path, revid)
 	}
@@ -1969,7 +1969,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	// Tombstoned
 	revid, err = updateTestDoc(rt, "doc_tombstone", "", `{"type": "tombstone", "channels":["alpha"]}`)
 	assert.NoError(t, err, "Error updating doc")
-	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/doc_tombstone?rev=%s", revid), "")
+	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/{{.keyspace}}/doc_tombstone?rev=%s", revid), "")
 	rest.RequireStatus(t, response, 200)
 
 	// Removed
@@ -2005,7 +2005,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	reqHeaders := map[string]string{
 		"Content-Type": attachmentContentType,
 	}
-	response = rt.SendAdminRequestWithHeaders("PUT", fmt.Sprintf("/db/doc_attachment/attach1?rev=%s", revid),
+	response = rt.SendAdminRequestWithHeaders("PUT", fmt.Sprintf("/{{.keyspace}}/doc_attachment/attach1?rev=%s", revid),
 		attachmentBody, reqHeaders)
 	rest.RequireStatus(t, response, 201)
 
@@ -2020,7 +2020,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	assert.NoError(t, err)
 	newEdits_conflict := `{"type": "conflict", "channels":["alpha"],
                    "_revisions": {"start": 2, "ids": ["conflicting_rev", "19a316235cdd9d695d73765dc527d903"]}}`
-	response = rt.SendAdminRequest("PUT", "/db/doc_conflict?new_edits=false", newEdits_conflict)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc_conflict?new_edits=false", newEdits_conflict)
 	rest.RequireStatus(t, response, 201)
 
 	// Resolved conflict
@@ -2030,9 +2030,9 @@ func TestChangesIncludeDocs(t *testing.T) {
 	assert.NoError(t, err)
 	newEdits_conflict = `{"type": "resolved_conflict", "channels":["alpha"],
                    "_revisions": {"start": 2, "ids": ["conflicting_rev", "4e123c0497a1a6975540977ec127c06c"]}}`
-	response = rt.SendAdminRequest("PUT", "/db/doc_resolved_conflict?new_edits=false", newEdits_conflict)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc_resolved_conflict?new_edits=false", newEdits_conflict)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("DELETE", "/db/doc_resolved_conflict?rev=2-conflicting_rev", "")
+	response = rt.SendAdminRequest("DELETE", "/{{.keyspace}}/doc_resolved_conflict?rev=2-conflicting_rev", "")
 	rest.RequireStatus(t, response, 200)
 
 	require.NoError(t, rt.WaitForPendingChanges())
@@ -2048,7 +2048,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	expectedResults[7] = `{"seq":19,"id":"doc_large_numbers","doc":{"_id":"doc_large_numbers","_rev":"1-2721633d9000e606e9c642e98f2f5ae7","channels":["alpha"],"largefloat":1234567890.1234,"largeint":1234567890,"type":"large_numbers"},"changes":[{"rev":"1-2721633d9000e606e9c642e98f2f5ae7"}]}`
 	expectedResults[8] = `{"seq":22,"id":"doc_conflict","doc":{"_id":"doc_conflict","_rev":"2-conflicting_rev","channels":["alpha"],"type":"conflict"},"changes":[{"rev":"2-conflicting_rev"}]}`
 	expectedResults[9] = `{"seq":26,"id":"doc_resolved_conflict","doc":{"_id":"doc_resolved_conflict","_rev":"2-251ba04e5889887152df5e7a350745b4","channels":["alpha"],"type":"resolved_conflict"},"changes":[{"rev":"2-251ba04e5889887152df5e7a350745b4"}]}`
-	changesResponse := rt.SendUserRequest("GET", "/db/_changes?include_docs=true", "", "user1")
+	changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?include_docs=true", "", "user1")
 
 	var changes rest.ChangesResults
 	assert.NoError(t, base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes))
@@ -2087,7 +2087,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 		}
 	}
 
-	postFlushChangesResponse := rt.SendUserRequest("GET", "/db/_changes?include_docs=true", "", "user1")
+	postFlushChangesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?include_docs=true", "", "user1")
 
 	var postFlushChanges rest.ChangesResults
 	assert.NoError(t, base.JSONUnmarshal(postFlushChangesResponse.Body.Bytes(), &postFlushChanges))
@@ -2129,7 +2129,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	expectedStyleAllDocs[8] = `{"seq":22,"id":"doc_conflict","changes":[{"rev":"2-conflicting_rev"},{"rev":"2-869a7167ccbad634753105568055bd61"}]}`
 	expectedStyleAllDocs[9] = `{"seq":26,"id":"doc_resolved_conflict","changes":[{"rev":"2-251ba04e5889887152df5e7a350745b4"},{"rev":"3-f25ad98ef169791adec6c1d385717b84"}]}`
 
-	styleAllDocsChangesResponse := rt.SendUserRequest("GET", "/db/_changes?style=all_docs", "", "user1")
+	styleAllDocsChangesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?style=all_docs", "", "user1")
 	var allDocsChanges struct {
 		Results []*json.RawMessage
 	}
@@ -2144,7 +2144,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	expectedResults[8] = `{"seq":22,"id":"doc_conflict","doc":{"_id":"doc_conflict","_rev":"2-conflicting_rev","channels":["alpha"],"type":"conflict"},"changes":[{"rev":"2-conflicting_rev"},{"rev":"2-869a7167ccbad634753105568055bd61"}]}`
 	expectedResults[9] = `{"seq":26,"id":"doc_resolved_conflict","doc":{"_id":"doc_resolved_conflict","_rev":"2-251ba04e5889887152df5e7a350745b4","channels":["alpha"],"type":"resolved_conflict"},"changes":[{"rev":"2-251ba04e5889887152df5e7a350745b4"},{"rev":"3-f25ad98ef169791adec6c1d385717b84"}]}`
 
-	combinedChangesResponse := rt.SendUserRequest("GET", "/db/_changes?style=all_docs&include_docs=true", "", "user1")
+	combinedChangesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?style=all_docs&include_docs=true", "", "user1")
 	var combinedChanges rest.ChangesResults
 	assert.NoError(t, base.JSONUnmarshal(combinedChangesResponse.Body.Bytes(), &combinedChanges))
 	assert.Equal(t, len(expectedResults), len(combinedChanges.Results))
@@ -3717,11 +3717,11 @@ func TestIncludeDocsWithPrincipals(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 
 	// Put several documents
-	response = rt.SendAdminRequest("PUT", "/db/doc1", `{"channels":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/doc2", `{"channels":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc2", `{"channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/doc3", `{"channels":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc3", `{"channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
 
 	cacheWaiter.AddAndWait(3)
@@ -3733,7 +3733,7 @@ func TestIncludeDocsWithPrincipals(t *testing.T) {
 
 	// Get as admin
 	changes.Results = nil
-	changesResponse := rt.SendAdminRequest("GET", "/db/_changes?include_docs=true", "")
+	changesResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/_changes?include_docs=true", "")
 	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	log.Printf("admin response: %s", changesResponse.Body.Bytes())
 	assert.NoError(t, err, "Error unmarshalling changes response")
@@ -3742,7 +3742,7 @@ func TestIncludeDocsWithPrincipals(t *testing.T) {
 
 	// Get as user
 	changes.Results = nil
-	userChangesResponse := rt.SendUserRequest("GET", "/db/_changes?include_docs=true", "", "includeDocsUser")
+	userChangesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?include_docs=true", "", "includeDocsUser")
 	err = base.JSONUnmarshal(userChangesResponse.Body.Bytes(), &changes)
 	log.Printf("userChangesResponse: %s", userChangesResponse.Body.Bytes())
 	assert.NoError(t, err, "Error unmarshalling changes response")
@@ -3770,13 +3770,13 @@ func TestChangesAdminChannelGrantLongpollNotify(t *testing.T) {
 	assert.NoError(t, a.Save(bernard))
 
 	// Put several documents in channel PBS
-	response := rt.SendAdminRequest("PUT", "/db/pbs-1", `{"channels":["PBS"]}`)
+	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-1", `{"channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/pbs-2", `{"channels":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-2", `{"channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/pbs-3", `{"channels":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-3", `{"channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/pbs-4", `{"channels":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-4", `{"channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
 
 	var changes struct {
@@ -3792,7 +3792,7 @@ func TestChangesAdminChannelGrantLongpollNotify(t *testing.T) {
 	go func() {
 		defer longpollWg.Done()
 		longpollChangesJSON := `{"since":0, "feed":"longpoll"}`
-		longPollResponse := rt.SendUserRequest("POST", "/db/_changes", longpollChangesJSON, "bernard")
+		longPollResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", longpollChangesJSON, "bernard")
 		log.Printf("longpoll changes response looks like: %s", longPollResponse.Body.Bytes())
 		assert.NoError(t, base.JSONUnmarshal(longPollResponse.Body.Bytes(), &changes))
 		// Expect to get 4 docs plus user doc

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -364,7 +364,7 @@ func postChangesSince(t *testing.T, rt *rest.RestTester) {
 	changesJSON := `{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"0"}`
 	changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
 
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	log.Printf("Changes:%s", changesResponse.Body.Bytes())
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, 5)
@@ -1934,7 +1934,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 
 	// Create docs for each scenario
 	// Active
-	_, err = updateTestDoc(rt, "doc_active", "", `{"type": "active", "channels":["alpha"]}`)
+	_, err := updateTestDoc(rt, "doc_active", "", `{"type": "active", "channels":["alpha"]}`)
 	assert.NoError(t, err, "Error updating doc")
 
 	// Multi-revision
@@ -3706,7 +3706,7 @@ func TestIncludeDocsWithPrincipals(t *testing.T) {
 	// Get as admin
 	changes.Results = nil
 	changesResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/_changes?include_docs=true", "")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	log.Printf("admin response: %s", changesResponse.Body.Bytes())
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	// Expect three docs, no user docs

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -1777,15 +1777,15 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	s := collection.ScopeName()
 
 	// Create user1
-	response := rt.SendAdminRequest("PUT", "/db/_user/user1", `{"email":"user1@couchbase.com", "password":"letmein", `+rest.AdminChannelGrant(s, c, `"admin_channels":["alpha"]`)+`}`)
+	response := rt.SendAdminRequest("PUT", "/{{.db}}/_user/user1", `{"email":"user1@couchbase.com", "password":"letmein", `+rest.AdminChannelGrant(s, c, `"admin_channels":["alpha"]`)+`}`)
 	rest.RequireStatus(t, response, 201)
 
 	// Create user2
-	response = rt.SendAdminRequest("PUT", "/db/_user/user2", `{"email":"user2@couchbase.com", "password":"letmein", `+rest.AdminChannelGrant(s, c, `"admin_channels":["beta"]`)+`}`)
+	response = rt.SendAdminRequest("PUT", "/{{.db}}/_user/user2", `{"email":"user2@couchbase.com", "password":"letmein", `+rest.AdminChannelGrant(s, c, `"admin_channels":["beta"]`)+`}`)
 	rest.RequireStatus(t, response, 201)
 
 	// Create user3
-	response = rt.SendAdminRequest("PUT", "/db/_user/user3", `{"email":"user3@couchbase.com", "password":"letmein", `+rest.AdminChannelGrant(s, c, `"admin_channels":["alpha","beta"]`)+`}`)
+	response = rt.SendAdminRequest("PUT", "/{{.db}}/_user/user3", `{"email":"user3@couchbase.com", "password":"letmein", `+rest.AdminChannelGrant(s, c, `"admin_channels":["alpha","beta"]`)+`}`)
 	rest.RequireStatus(t, response, 201)
 
 	// Create user4
@@ -1793,7 +1793,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 
 	// Create user5
-	response = rt.SendAdminRequest("PUT", "/db/_user/user5", `{"email":"user5@couchbase.com", "password":"letmein", `+rest.AdminChannelGrant(s, c, `"admin_channels":["*"]`)+`}`)
+	response = rt.SendAdminRequest("PUT", "/{{.db}}/_user/user5", `{"email":"user5@couchbase.com", "password":"letmein", `+rest.AdminChannelGrant(s, c, `"admin_channels":["*"]`)+`}`)
 	rest.RequireStatus(t, response, 201)
 
 	// Create docs

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -1267,7 +1267,6 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	WriteDirect([]string{"PBS"}, 4, collection)
 	WriteDirect([]string{"PBS"}, 5, collection)
 	require.NoError(t, testDb.GetSingleDatabaseCollection().WaitForSequenceNotSkipped(ctx, 5))
-	resp := rt.SendAdminRequest("GET", "/db/_all_docs", "")
 	// Check the _changes feed:
 	var changes struct {
 		Results  []db.ChangeEntry

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -339,9 +339,7 @@ func postChangesSince(t *testing.T, rt *rest.RestTester) {
 	collection := rt.GetSingleTestDatabaseCollection()
 
 	// Create user
-	payload, err := rest.GetUserPayload("", "letmein", "bernard@bb.com", collection, []string{"PBS"}, nil)
-	require.NoError(t, err)
-	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", payload)
+	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", rest.GetUserPayload(t, "", "letmein", "bernard@bb.com", collection, []string{"PBS"}, nil))
 	rest.RequireStatus(t, response, 201)
 
 	cacheWaiter := rt.GetDatabase().NewDCPCachingCountWaiter(t)
@@ -505,9 +503,7 @@ func TestPostChangesAdminChannelGrant(t *testing.T) {
 	require.Len(t, changes.Results, 1)
 
 	// Update the user doc to grant access to PBS
-	payload, err := rest.GetUserPayload("", "", "", collection, []string{"ABC", "PBS"}, nil)
-	require.NoError(t, err)
-	response = rt.SendAdminRequest("PUT", "/db/_user/bernard", payload)
+	response = rt.SendAdminRequest("PUT", "/db/_user/bernard", rest.GetUserPayload(t, "", "", "", collection, []string{"ABC", "PBS"}, nil))
 	rest.RequireStatus(t, response, 200)
 
 	time.Sleep(500 * time.Millisecond)
@@ -643,10 +639,7 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 	}
 
 	// Update the user doc to grant access to PBS, HBO in addition to ABC
-	require.NoError(t, err)
-	payload, err := rest.GetUserPayload("", "", "", collection, []string{"ABC", "PBS", "HBO"}, nil)
-	require.NoError(t, err)
-	response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/bernard", payload)
+	response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/bernard", rest.GetUserPayload(t, "", "", "", collection, []string{"ABC", "PBS", "HBO"}, nil))
 	rest.RequireStatus(t, response, http.StatusOK)
 
 	// Issue a new changes request with since=last_seq ensure that user receives all records for channels PBS, HBO.
@@ -747,9 +740,7 @@ func TestPostChangesAdminChannelGrantRemovalWithLimit(t *testing.T) {
 	cacheWaiter.AddAndWait(1)
 
 	// Grant user access to channel PBS
-	payload, err := rest.GetUserPayload("", "", "", collection, []string{"ABC", "PBS"}, nil)
-	require.NoError(t, err)
-	userResponse := rt.SendAdminRequest("PUT", "/{{.db}}/_user/bernard", payload)
+	userResponse := rt.SendAdminRequest("PUT", "/{{.db}}/_user/bernard", rest.GetUserPayload(t, "", "", "", collection, []string{"ABC", "PBS"}, nil))
 	rest.RequireStatus(t, userResponse, 200)
 
 	// Put several documents in channel ABC
@@ -1006,10 +997,8 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	collection := testDb.GetSingleDatabaseCollection()
 
 	// Create user:
-	payload, err := rest.GetUserPayload("", "letmein", "bernard@couchbase.com", collection, []string{"PBS"}, nil)
-	require.NoError(t, err)
 	rest.RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/bernard", ""), 404)
-	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", payload)
+	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", rest.GetUserPayload(t, "", "letmein", "bernard@couchbase.com", collection, []string{"PBS"}, nil))
 	rest.RequireStatus(t, response, 201)
 
 	// Simulate seq 3 and 4 being delayed - write 1,2,5,6
@@ -1102,9 +1091,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 
 	// Create user:
 	rest.RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/bernard", ""), 404)
-	payload, err := rest.GetUserPayload("", "letmein", "bernard@couchbase.com", collection, []string{"PBS"}, nil)
-	require.NoError(t, err)
-	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", payload)
+	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", rest.GetUserPayload(t, "", "letmein", "bernard@couchbase.com", collection, []string{"PBS"}, nil))
 	rest.RequireStatus(t, response, 201)
 
 	// Simulate 4 non-skipped writes (seq 2,3,4,5)
@@ -1372,9 +1359,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 
 	// Create user:
 	rest.RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/bernard", ""), 404)
-	payload, err := rest.GetUserPayload("", "letmein", "bernard@couchbase.com", collection, []string{"PBS"}, nil)
-	require.NoError(t, err)
-	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", payload)
+	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", rest.GetUserPayload(t, "", "letmein", "bernard@couchbase.com", collection, []string{"PBS"}, nil))
 	rest.RequireStatus(t, response, 201)
 
 	// Simulate 4 non-skipped writes (seq 2,3,4,5)
@@ -1772,21 +1757,15 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	collection := rt.GetSingleTestDatabaseCollection()
 
 	// Create user1
-	payload, err := rest.GetUserPayload("", "letmein", "user1@couchbase.com", collection, []string{"alpha"}, nil)
-	require.NoError(t, err)
-	response := rt.SendAdminRequest("PUT", "/{{.db}}/_user/user1", payload)
+	response := rt.SendAdminRequest("PUT", "/{{.db}}/_user/user1", rest.GetUserPayload(t, "", "letmein", "user1@couchbase.com", collection, []string{"alpha"}, nil))
 	rest.RequireStatus(t, response, 201)
 
 	// Create user2
-	payload, err = rest.GetUserPayload("", "letmein", "user2@couchbase.com", collection, []string{"beta"}, nil)
-	require.NoError(t, err)
-	response = rt.SendAdminRequest("PUT", "/{{.db}}/_user/user2", payload)
+	response = rt.SendAdminRequest("PUT", "/{{.db}}/_user/user2", rest.GetUserPayload(t, "", "letmein", "user2@couchbase.com", collection, []string{"beta"}, nil))
 	rest.RequireStatus(t, response, 201)
 
 	// Create user3
-	payload, err = rest.GetUserPayload("", "letmein", "user3@couchbase.com", collection, []string{"alpha", "beta"}, nil)
-	require.NoError(t, err)
-	response = rt.SendAdminRequest("PUT", "/{{.db}}/_user/user3", payload)
+	response = rt.SendAdminRequest("PUT", "/{{.db}}/_user/user3", rest.GetUserPayload(t, "", "letmein", "user3@couchbase.com", collection, []string{"alpha", "beta"}, nil))
 	rest.RequireStatus(t, response, 201)
 
 	// Create user4
@@ -1794,9 +1773,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 
 	// Create user5
-	payload, err = rest.GetUserPayload("", "letmein", "user5@couchbase.com", collection, []string{"*"}, nil)
-	require.NoError(t, err)
-	response = rt.SendAdminRequest("PUT", "/{{.db}}/_user/user5", payload)
+	response = rt.SendAdminRequest("PUT", "/{{.db}}/_user/user5", rest.GetUserPayload(t, "", "letmein", "user5@couchbase.com", collection, []string{"*"}, nil))
 	rest.RequireStatus(t, response, 201)
 
 	// Create docs
@@ -1952,9 +1929,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	collection := testDB.GetSingleDatabaseCollection()
 
 	// Create user1
-	payload, err := rest.GetUserPayload("", "letmein", "user1@couchbase.com", collection, []string{"alpha", "beta"}, nil)
-	require.NoError(t, err)
-	response := rt.SendAdminRequest("PUT", "/db/_user/user1", payload)
+	response := rt.SendAdminRequest("PUT", "/db/_user/user1", rest.GetUserPayload(t, "", "letmein", "user1@couchbase.com", collection, []string{"alpha", "beta"}, nil))
 	rest.RequireStatus(t, response, 201)
 
 	// Create docs for each scenario
@@ -3707,14 +3682,10 @@ func TestIncludeDocsWithPrincipals(t *testing.T) {
 	cacheWaiter := testDb.NewDCPCachingCountWaiter(t)
 
 	// Put users
-	payload, err := rest.GetUserPayload("includeDocsUser", "letmein", "", collection, []string{"*"}, nil)
-	require.NoError(t, err)
-	response := rt.SendAdminRequest("PUT", "/db/_user/includeDocsUser", payload)
+	response := rt.SendAdminRequest("PUT", "/db/_user/includeDocsUser", rest.GetUserPayload(t, "includeDocsUser", "letmein", "", collection, []string{"*"}, nil))
 	rest.RequireStatus(t, response, 201)
 
-	payload, err = rest.GetUserPayload("includeDocsUser2", "letmein", "", collection, []string{"*"}, nil)
-	require.NoError(t, err)
-	response = rt.SendAdminRequest("PUT", "/db/_user/includeDocsUser2", payload)
+	response = rt.SendAdminRequest("PUT", "/db/_user/includeDocsUser2", rest.GetUserPayload(t, "includeDocsUser2", "letmein", "", collection, []string{"*"}, nil))
 	rest.RequireStatus(t, response, 201)
 
 	// Put several documents
@@ -3801,9 +3772,7 @@ func TestChangesAdminChannelGrantLongpollNotify(t *testing.T) {
 	require.NoError(t, rt.GetDatabase().WaitForCaughtUp(caughtUpCount+1))
 
 	// Update the user doc to grant access to PBS
-	payload, err := rest.GetUserPayload("", "", "", collection, []string{"ABC", "PBS"}, nil)
-	require.NoError(t, err)
-	response = rt.SendAdminRequest("PUT", "/db/_user/bernard", payload)
+	response = rt.SendAdminRequest("PUT", "/db/_user/bernard", rest.GetUserPayload(t, "", "", "", collection, []string{"ABC", "PBS"}, nil))
 	rest.RequireStatus(t, response, 200)
 
 	// Wait for longpoll to return

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -281,7 +281,7 @@ func TestPostChangesSinceInteger(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
-	rt := rest.NewRestTester(t, // CBG-2618: fix collection channel access
+	rt := rest.NewRestTester(t,
 		&rest.RestTesterConfig{
 			SyncFn:         `function(doc) {channel(doc.channel);}`,
 			DatabaseConfig: &rest.DatabaseConfig{}, // force use of default scope and collection
@@ -292,7 +292,7 @@ func TestPostChangesSinceInteger(t *testing.T) {
 }
 
 func TestPostChangesWithQueryString(t *testing.T) {
-	rt := rest.NewRestTester(t, // CBG-2618: fix collection channel access
+	rt := rest.NewRestTester(t,
 		&rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
 
@@ -461,7 +461,7 @@ func TestPostChangesAdminChannelGrant(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
-	rt := rest.NewRestTester(t, // CBG-2618: fix collection channel access
+	rt := rest.NewRestTester(t,
 		&rest.RestTesterConfig{
 			SyncFn: `function(doc) {channel(doc.channel);}`,
 		})
@@ -553,7 +553,7 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 	// Disable sequence batching for multi-RT tests (pending CBG-1000)
 	defer db.SuspendSequenceBatching()()
 
-	rt := rest.NewRestTester(t, // CBG-2618: fix collection channel access
+	rt := rest.NewRestTester(t,
 		&rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
@@ -712,7 +712,7 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 func TestPostChangesAdminChannelGrantRemovalWithLimit(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
-	rt := rest.NewRestTester(t, // CBG-2618: fix collection channel access
+	rt := rest.NewRestTester(t,
 		&rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
@@ -997,7 +997,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 		NumIndexReplicas: &numIndexReplicas,
 	}}
 	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`, DatabaseConfig: shortWaitConfig}
-	rt := rest.NewRestTester(t, &rtConfig) // CBG-2618: fix collection channel access
+	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	ctx := rt.Context()
@@ -1092,7 +1092,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 		NumIndexReplicas: &numIndexReplicas,
 	}}
 	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`, DatabaseConfig: shortWaitConfig}
-	rt := rest.NewRestTester(t, &rtConfig) // CBG-2618: fix collection channel access
+	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	ctx := rt.Context()
@@ -1230,7 +1230,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 		NumIndexReplicas: &numIndexReplicas,
 	}}
 	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`, DatabaseConfig: shortWaitConfig}
-	rt := rest.NewRestTester(t, &rtConfig) // CBG-2618: fix collection channel access
+	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 	c := collection.Name()
@@ -1253,7 +1253,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 		Results  []db.ChangeEntry
 		Last_Seq string
 	}
-	response := rt.SendAdminRequest("GET", "/db."+s+"."+c+"/_changes", "")
+	response := rt.SendAdminRequest("GET", "/db/_changes", "")
 	log.Printf("_changes 1 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Len(t, changes.Results, 5)
@@ -1366,7 +1366,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 		NumIndexReplicas: &numIndexReplicas,
 	}}
 	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`, DatabaseConfig: shortWaitConfig}
-	rt := rest.NewRestTester(t, &rtConfig) // CBG-2618: fix collection channel access
+	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	ctx := rt.Context()
@@ -1754,20 +1754,6 @@ func TestChangesActiveOnlyInteger(t *testing.T) {
 	}
 }
 
-/*
-// Expects adminChannels of the form `admin_channels":["alpha"]`
-// If scope and collection are non-zero, builds collection access string for the collection
-func AdminChannelGrant(scopeName, collectionName, adminChannels string) (collectionAdminChannels string) {
-
-	if base.IsDefaultCollection(scopeName, collectionName) {
-		return adminChannels
-	}
-
-	return fmt.Sprintf(`"collection_access":{%q: {%q: {%s}}}`, scopeName, collectionName, adminChannels)
-}
-
-*/
-
 func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyNone)
@@ -1956,7 +1942,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	rtConfig := rest.RestTesterConfig{
 		SyncFn: `function(doc) {channel(doc.channels)}`,
 	}
-	rt := rest.NewRestTester(t, &rtConfig) // CBG-2618: fix collection channel access
+	rt := rest.NewRestTester(t, &rtConfig)
 	testDB := rt.GetDatabase()
 	testDB.RevsLimit = 3
 	defer rt.Close()
@@ -3712,7 +3698,7 @@ func TestIncludeDocsWithPrincipals(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
-	rt := rest.NewRestTester(t, nil) // CBG-2618: fix collection channel access
+	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
 
 	ctx := rt.Context()
@@ -3770,7 +3756,7 @@ func TestChangesAdminChannelGrantLongpollNotify(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
-	rt := rest.NewRestTester(t, nil) // CBG-2618: fix collection channel access
+	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 	c := collection.Name()

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -71,7 +71,7 @@ func TestXattrImportOldDoc(t *testing.T) {
 	assert.NoError(t, err, "Unable to insert doc TestImportDelete")
 
 	// Attempt to get the document via Sync Gateway, to trigger import.  On import of a create, oldDoc should be nil.
-	response := rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete?redact=false", "")
+	response := rt.SendAdminRequest("GET", "/{{.keyspace}}/_raw/TestImportDelete?redact=false", "")
 	assert.Equal(t, 200, response.Code)
 	var rawInsertResponse rest.RawResponse
 	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
@@ -90,7 +90,7 @@ func TestXattrImportOldDoc(t *testing.T) {
 	assert.NoError(t, err, "Unable to update doc TestImportDelete")
 
 	// Attempt to get the document via Sync Gateway, to trigger import.  On import of a create, oldDoc should be nil.
-	response = rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete?redact=false", "")
+	response = rt.SendAdminRequest("GET", "/{{.keyspace}}/_raw/TestImportDelete?redact=false", "")
 	assert.Equal(t, 200, response.Code)
 	var rawUpdateResponse rest.RawResponse
 	err = base.JSONUnmarshal(response.Body.Bytes(), &rawUpdateResponse)
@@ -108,7 +108,7 @@ func TestXattrImportOldDoc(t *testing.T) {
 	err = dataStore.Delete(key)
 	assert.NoError(t, err, "Unable to delete doc TestImportDelete")
 
-	response = rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete?redact=false", "")
+	response = rt.SendAdminRequest("GET", "/{{.keyspace}}/_raw/TestImportDelete?redact=false", "")
 	assert.Equal(t, 200, response.Code)
 	var rawDeleteResponse rest.RawResponse
 	err = base.JSONUnmarshal(response.Body.Bytes(), &rawDeleteResponse)
@@ -638,7 +638,7 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 	assert.NoError(t, err, "Error writing SDK doc")
 
 	// Attempt to get the document via Sync Gateway.  Will trigger on-demand import.
-	response := rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
+	response := rt.SendAdminRequest("GET", "/{{.keyspace}}/"+mobileKey, "")
 	assert.Equal(t, 200, response.Code)
 	// Extract rev from response for comparison with second GET below
 	var body db.Body
@@ -660,7 +660,7 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 	assert.NoError(t, mutateErr, "Error updating non-mobile xattr for multi-actor document")
 
 	// Attempt to get the document again via Sync Gateway.  Should not trigger import.
-	response = rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
+	response = rt.SendAdminRequest("GET", "/{{.keyspace}}/"+mobileKey, "")
 	assert.Equal(t, 200, response.Code)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	newRevId := body[db.BodyRev].(string)

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -53,7 +53,7 @@ func TestXattrImportOldDoc(t *testing.T) {
 			AutoImport: false,
 		}},
 	}
-	rt := rest.NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+	rt := rest.NewRestTester(t, // CBG-2618: fix collection channel access
 		&rtConfig)
 	defer rt.Close()
 
@@ -624,7 +624,7 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 			AutoImport: false,
 		}},
 	}
-	rt := rest.NewRestTesterDefaultCollection(t, &rtConfig) // CBG-2618: fix collection channel access
+	rt := rest.NewRestTester(t, &rtConfig) // CBG-2618: fix collection channel access
 	defer rt.Close()
 	dataStore := rt.GetSingleDataStore()
 
@@ -680,7 +680,7 @@ func TestXattrImportMultipleActorOnDemandPut(t *testing.T) {
 			AutoImport: false,
 		}},
 	}
-	rt := rest.NewRestTesterDefaultCollection(t, &rtConfig) // CBG-2618: fix collection channel access
+	rt := rest.NewRestTester(t, &rtConfig) // CBG-2618: fix collection channel access
 	defer rt.Close()
 	dataStore := rt.GetSingleDataStore()
 

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -53,7 +53,7 @@ func TestXattrImportOldDoc(t *testing.T) {
 			AutoImport: false,
 		}},
 	}
-	rt := rest.NewRestTester(t, // CBG-2618: fix collection channel access
+	rt := rest.NewRestTester(t,
 		&rtConfig)
 	defer rt.Close()
 
@@ -624,7 +624,7 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 			AutoImport: false,
 		}},
 	}
-	rt := rest.NewRestTester(t, &rtConfig) // CBG-2618: fix collection channel access
+	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	dataStore := rt.GetSingleDataStore()
 
@@ -680,7 +680,7 @@ func TestXattrImportMultipleActorOnDemandPut(t *testing.T) {
 			AutoImport: false,
 		}},
 	}
-	rt := rest.NewRestTester(t, &rtConfig) // CBG-2618: fix collection channel access
+	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	dataStore := rt.GetSingleDataStore()
 

--- a/rest/jwt_auth_test.go
+++ b/rest/jwt_auth_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
-	ch "github.com/couchbase/sync_gateway/channels"
+	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -480,7 +480,7 @@ func TestLocalJWTRolesChannels(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, user)
 
-	user.SetCollectionJWTChannels(s, c, ch.AtSequence(ch.BaseSetOf(t, "jwt_only_channel"), 1), 1)
+	user.SetCollectionJWTChannels(s, c, channels.AtSequence(channels.BaseSetOf(t, "jwt_only_channel"), 1), 1)
 
 	assert.Contains(t, user.RoleNames(), "jwt_only_role")
 	assert.Contains(t, user.CollectionJWTChannels(s, c).AllKeys(), "jwt_only_channel")

--- a/rest/jwt_auth_test.go
+++ b/rest/jwt_auth_test.go
@@ -481,7 +481,6 @@ func TestLocalJWTRolesChannels(t *testing.T) {
 	require.NotNil(t, user)
 
 	user.SetCollectionJWTChannels(s, c, ch.AtSequence(ch.BaseSetOf(t, "jwt_only_channel"), 1), 1)
-	fmt.Println(user.CollectionJWTChannels(s, c))
 
 	assert.Contains(t, user.RoleNames(), "jwt_only_role")
 	assert.Contains(t, user.CollectionJWTChannels(s, c).AllKeys(), "jwt_only_channel")

--- a/rest/jwt_auth_test.go
+++ b/rest/jwt_auth_test.go
@@ -450,7 +450,7 @@ func TestLocalJWTRolesChannels(t *testing.T) {
 	restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{LocalJWTConfig: auth.LocalJWTConfig{
 		testProviderName: baseProvider,
 	}}}}
-	restTester := NewRestTester(t, &restTesterConfig) // CBG-2618: fix collection channel access
+	restTester := NewRestTester(t, &restTesterConfig)
 	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 	collection := restTester.GetSingleTestDatabaseCollection()

--- a/rest/jwt_auth_test.go
+++ b/rest/jwt_auth_test.go
@@ -16,7 +16,6 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
-	ch "github.com/couchbase/sync_gateway/channels"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
+	ch "github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -188,7 +188,7 @@ func InitScenario(t *testing.T, rtConfig *RestTesterConfig) (ChannelRevocationTe
 		}
 	}
 
-	rt := NewRestTester(t, rtConfig) // CBG-2618: fix collection channel access
+	rt := NewRestTester(t, rtConfig)
 
 	revocationTester := ChannelRevocationTester{
 		test:       t,
@@ -890,7 +890,7 @@ func TestEnsureRevocationUsingDocHistory(t *testing.T) {
 func TestRevocationWithAdminChannels(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	rt := NewRestTester(t, nil) // CBG-2618: fix collection channel access
+	rt := NewRestTester(t, nil)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 	c := collection.Name()
@@ -902,7 +902,7 @@ func TestRevocationWithAdminChannels(t *testing.T) {
 	resp = rt.SendAdminRequest("PUT", "/db/doc", `{"channels": ["A"]}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
-	changes, err := rt.WaitForChanges(2, "/db."+s+"."+c+"/_changes?since=0&revocations=true", "user", false)
+	changes, err := rt.WaitForChanges(2, "/db/_changes?since=0&revocations=true", "user", false)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(changes.Results))
 
@@ -912,7 +912,7 @@ func TestRevocationWithAdminChannels(t *testing.T) {
 	resp = rt.SendAdminRequest("PUT", "/db/_user/user", `{`+AdminChannelGrant(s, c, `"admin_channels": []`)+`, "password": "letmein"}`)
 	RequireStatus(t, resp, http.StatusOK)
 
-	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/db."+s+"."+c+"/_changes?since=%d&revocations=true", 2), "user", false)
+	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/db/_changes?since=%d&revocations=true", 2), "user", false)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(changes.Results))
 
@@ -923,7 +923,7 @@ func TestRevocationWithAdminChannels(t *testing.T) {
 func TestRevocationWithAdminRoles(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	rt := NewRestTester(t, nil) // CBG-2618: fix collection channel access
+	rt := NewRestTester(t, nil)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 	c := collection.Name()
@@ -938,7 +938,7 @@ func TestRevocationWithAdminRoles(t *testing.T) {
 	resp = rt.SendAdminRequest("PUT", "/db/doc", `{"channels": ["A"]}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
-	changes, err := rt.WaitForChanges(2, "/db."+s+"."+c+"/_changes?since=0&revocations=true", "user", false)
+	changes, err := rt.WaitForChanges(2, "/db/_changes?since=0&revocations=true", "user", false)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(changes.Results))
 
@@ -948,7 +948,7 @@ func TestRevocationWithAdminRoles(t *testing.T) {
 	resp = rt.SendAdminRequest("PUT", "/db/_user/user", `{"admin_roles": []}`)
 	RequireStatus(t, resp, http.StatusOK)
 
-	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/db."+s+"."+c+"/_changes?since=%d&revocations=true", 3), "user", false)
+	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/db/_changes?since=%d&revocations=true", 3), "user", false)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(changes.Results))
 

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -10,7 +10,6 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
-	sgbucket "github.com/couchbase/sg-bucket"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -20,6 +19,7 @@ import (
 	"time"
 
 	"github.com/couchbase/go-blip"
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1222,7 +1222,12 @@ func TestRevocationUserHasDocAccessDocNotFound(t *testing.T) {
 	require.NoError(t, err)
 	dataName := GetNamedDatastore(dataStores, collection)
 	data := rt.Bucket().NamedDataStore(dataName)
-	require.NoError(t, data.Delete("doc"))
+	leakyDataStore, ok := base.AsLeakyDataStore(data)
+	require.True(t, ok)
+	leakyDataStore.SetGetRawCallback(func(s string) error {
+		require.NoError(t, leakyDataStore.Delete("doc"))
+		return nil
+	})
 
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	require.Len(t, changes.Results, 1)

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -116,7 +116,7 @@ func (tester *ChannelRevocationTester) fillToSeq(seq uint64) {
 
 	loopCount := seq - currentSeq
 	for i := 0; i < int(loopCount); i++ {
-		requestURL := "/db/fillerDoc"
+		requestURL := "/{{.keyspace}}/fillerDoc"
 		if tester.fillerDocRev != "" {
 			requestURL += "?rev=" + tester.fillerDocRev
 		}
@@ -139,7 +139,7 @@ func (tester *ChannelRevocationTester) getChanges(sinceSeq interface{}, expected
 	assert.NoError(tester.test, err)
 
 	err = tester.restTester.WaitForCondition(func() bool {
-		resp := tester.restTester.SendUserRequestWithHeaders("GET", fmt.Sprintf("/db/_changes?since=%v&revocations=true", sinceSeq), "", nil, "user", "test")
+		resp := tester.restTester.SendUserRequestWithHeaders("GET", fmt.Sprintf("/{{.keyspace}}/_changes?since=%v&revocations=true", sinceSeq), "", nil, "user", "test")
 		require.Equal(tester.test, http.StatusOK, resp.Code)
 		err := json.Unmarshal(resp.BodyBytes(), &changes)
 		require.NoError(tester.test, err)
@@ -210,7 +210,7 @@ func TestRevocationScenario1(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
+	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "ch1"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
@@ -261,7 +261,7 @@ func TestRevocationScenario2(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
+	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "ch1"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
@@ -313,7 +313,7 @@ func TestRevocationScenario3(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
+	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "ch1"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
@@ -365,7 +365,7 @@ func TestRevocationScenario4(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
+	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "ch1"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
@@ -417,7 +417,7 @@ func TestRevocationScenario5(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
+	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "ch1"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
@@ -463,7 +463,7 @@ func TestRevocationScenario6(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
+	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "ch1"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
@@ -510,7 +510,7 @@ func TestRevocationScenario7(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
+	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "ch1"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
@@ -557,7 +557,7 @@ func TestRevocationScenario8(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
+	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "ch1"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
@@ -597,7 +597,7 @@ func TestRevocationScenario9(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
+	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "ch1"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
@@ -637,7 +637,7 @@ func TestRevocationScenario10(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
+	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "ch1"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
@@ -677,7 +677,7 @@ func TestRevocationScenario11(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
+	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "ch1"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
@@ -718,7 +718,7 @@ func TestRevocationScenario12(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
+	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "ch1"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
@@ -758,7 +758,7 @@ func TestRevocationScenario13(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
+	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "ch1"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
@@ -797,7 +797,7 @@ func TestRevocationScenario14(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": "ch1"}`)
+	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "ch1"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	revocationTester.fillToSeq(4)
@@ -899,10 +899,10 @@ func TestRevocationWithAdminChannels(t *testing.T) {
 	resp := rt.SendAdminRequest("PUT", "/db/_user/user", `{`+AdminChannelGrant(s, c, `"admin_channels": ["A"]`)+`, "password": "letmein"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
-	resp = rt.SendAdminRequest("PUT", "/db/doc", `{"channels": ["A"]}`)
+	resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc", `{"channels": ["A"]}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
-	changes, err := rt.WaitForChanges(2, "/db/_changes?since=0&revocations=true", "user", false)
+	changes, err := rt.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", false)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(changes.Results))
 
@@ -912,7 +912,7 @@ func TestRevocationWithAdminChannels(t *testing.T) {
 	resp = rt.SendAdminRequest("PUT", "/db/_user/user", `{`+AdminChannelGrant(s, c, `"admin_channels": []`)+`, "password": "letmein"}`)
 	RequireStatus(t, resp, http.StatusOK)
 
-	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/db/_changes?since=%d&revocations=true", 2), "user", false)
+	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d&revocations=true", 2), "user", false)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(changes.Results))
 
@@ -935,10 +935,10 @@ func TestRevocationWithAdminRoles(t *testing.T) {
 	resp = rt.SendAdminRequest("PUT", "/db/_user/user", `{"admin_roles": ["role"], "password": "letmein"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
-	resp = rt.SendAdminRequest("PUT", "/db/doc", `{"channels": ["A"]}`)
+	resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc", `{"channels": ["A"]}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
-	changes, err := rt.WaitForChanges(2, "/db/_changes?since=0&revocations=true", "user", false)
+	changes, err := rt.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", false)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(changes.Results))
 
@@ -948,7 +948,7 @@ func TestRevocationWithAdminRoles(t *testing.T) {
 	resp = rt.SendAdminRequest("PUT", "/db/_user/user", `{"admin_roles": []}`)
 	RequireStatus(t, resp, http.StatusOK)
 
-	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/db/_changes?since=%d&revocations=true", 3), "user", false)
+	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d&revocations=true", 3), "user", false)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(changes.Results))
 
@@ -1169,7 +1169,7 @@ func TestRevocationsWithQueryLimitChangesLimit(t *testing.T) {
 	waitForUserChangesWithLimit := func(sinceVal interface{}, limit int) ChangesResults {
 		var changesRes ChangesResults
 		err := rt.WaitForCondition(func() bool {
-			resp := rt.SendUserRequestWithHeaders("GET", fmt.Sprintf("/db/_changes?since=%v&revocations=true&limit=%d", sinceVal, limit), "", nil, "user", "test")
+			resp := rt.SendUserRequestWithHeaders("GET", fmt.Sprintf("/{{.keyspace}}/_changes?since=%v&revocations=true&limit=%d", sinceVal, limit), "", nil, "user", "test")
 			require.Equal(t, http.StatusOK, resp.Code)
 			err := json.Unmarshal(resp.BodyBytes(), &changesRes)
 			require.NoError(t, err)
@@ -1207,11 +1207,14 @@ func TestRevocationUserHasDocAccessDocNotFound(t *testing.T) {
 		}},
 	})
 	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
+	c := collection.Name()
+	s := collection.ScopeName()
 
 	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "A")
 
-	resp := rt.SendAdminRequest("PUT", "/db/doc", `{"channels": ["A"]}`)
+	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc", `{"channels": ["A"]}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	changes := revocationTester.getChanges(0, 2)
@@ -1220,13 +1223,16 @@ func TestRevocationUserHasDocAccessDocNotFound(t *testing.T) {
 	revocationTester.removeRoleChannel("foo", "A")
 	require.NoError(t, rt.WaitForPendingChanges())
 
-	leakyDataStore, ok := base.AsLeakyDataStore(rt.Bucket().DefaultDataStore())
-	require.True(t, ok)
-
-	leakyDataStore.SetGetRawCallback(func(s string) error {
-		require.NoError(t, leakyDataStore.Delete("doc"))
-		return nil
-	})
+	dataStores, err := rt.Bucket().ListDataStores()
+	require.NoError(t, err)
+	for _, dataStoreName := range dataStores {
+		if dataStoreName.ScopeName() == s && dataStoreName.CollectionName() == c {
+			fmt.Println(dataStoreName.CollectionName())
+			fmt.Println(dataStoreName)
+			data := rt.Bucket().NamedDataStore(dataStoreName)
+			require.NoError(t, data.Delete("doc"))
+		}
+	}
 
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	require.Len(t, changes.Results, 1)
@@ -1316,11 +1322,14 @@ func TestChannelHistoryPruning(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
+	c := collection.Name()
+	s := collection.ScopeName()
 
 	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "a")
 
-	resp := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels": ["a"]}`)
+	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": ["a"]}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// Enter a load of history by looping over adding and removing a channel. Needs a get changes in there to trigger
@@ -1339,13 +1348,13 @@ func TestChannelHistoryPruning(t *testing.T) {
 	authenticator := rt.GetDatabase().Authenticator(base.TestCtx(t))
 	role, err := authenticator.GetRole("foo")
 	assert.NoError(t, err)
-	require.Contains(t, role.ChannelHistory(), "a")
-	require.Len(t, role.ChannelHistory()["a"].Entries, 10)
-	assert.Equal(t, role.ChannelHistory()["a"].Entries[0], auth.GrantHistorySequencePair{StartSeq: 4, EndSeq: 26})
+	require.Contains(t, role.CollectionChannelHistory(s, c), "a")
+	require.Len(t, role.CollectionChannelHistory(s, c)["a"].Entries, 10)
+	assert.Equal(t, role.CollectionChannelHistory(s, c)["a"].Entries[0], auth.GrantHistorySequencePair{StartSeq: 4, EndSeq: 26})
 
 	// Add an additional channel to ensure only the latter one is pruned
 	revocationTester.addRoleChannel("foo", "b")
-	resp = rt.SendAdminRequest("PUT", "/db/doc2", `{"channels": ["b"]}`)
+	resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc2", `{"channels": ["b"]}`)
 	RequireStatus(t, resp, http.StatusCreated)
 	changes = revocationTester.getChanges(changes.Last_Seq, 2)
 	assert.Len(t, changes.Results, 2)
@@ -1357,7 +1366,7 @@ func TestChannelHistoryPruning(t *testing.T) {
 	// pruning those entries.
 	role, err = authenticator.GetRole("foo")
 	assert.NoError(t, err)
-	channelHistory := role.ChannelHistory()
+	channelHistory := role.CollectionChannelHistory(s, c)
 	aHistory := channelHistory["a"]
 	aHistory.UpdatedAt = time.Now().Add(-31 * time.Hour * 24).Unix()
 	channelHistory["a"] = aHistory
@@ -1368,7 +1377,7 @@ func TestChannelHistoryPruning(t *testing.T) {
 
 	// Add another so we have something to wait on
 	revocationTester.addRoleChannel("foo", "random")
-	resp = rt.SendAdminRequest("PUT", "/db/doc3", `{"channels": ["random"]}`)
+	resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc3", `{"channels": ["random"]}`)
 
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
@@ -1376,8 +1385,8 @@ func TestChannelHistoryPruning(t *testing.T) {
 	role, err = authenticator.GetRole("foo")
 	assert.NoError(t, err)
 
-	assert.NotContains(t, role.ChannelHistory(), "a")
-	assert.Contains(t, role.ChannelHistory(), "b")
+	assert.NotContains(t, role.CollectionChannelHistory(s, c), "a")
+	assert.Contains(t, role.CollectionChannelHistory(s, c), "b")
 }
 
 func TestChannelRevocationWithContiguousSequences(t *testing.T) {
@@ -1491,7 +1500,7 @@ func TestReplicatorRevocations(t *testing.T) {
 	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "chanA")
 
-	resp := rt2.SendAdminRequest("PUT", "/db/doc1", `{"channels": "chanA"}`)
+	resp := rt2.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "chanA"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	srv := httptest.NewServer(rt2.TestPublicHandler())
@@ -1521,7 +1530,7 @@ func TestReplicatorRevocations(t *testing.T) {
 	require.NoError(t, ar.Start(ctx1))
 	rt1.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
 
-	resp = rt1.SendAdminRequest("GET", "/db/doc1", "")
+	resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
 	RequireStatus(t, resp, http.StatusOK)
 
 	revocationTester.removeRole("user", "foo")
@@ -1529,7 +1538,7 @@ func TestReplicatorRevocations(t *testing.T) {
 	require.NoError(t, ar.Start(ctx1))
 	rt1.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
 
-	resp = rt1.SendAdminRequest("GET", "/db/doc1", "")
+	resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
 	RequireStatus(t, resp, http.StatusNotFound)
 }
 
@@ -1843,10 +1852,10 @@ func TestReplicatorRevocationsWithTombstoneResurrection(t *testing.T) {
 	require.NoError(t, ar.Stop())
 	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
 
-	resp = rt2.SendAdminRequest("DELETE", "/db/docA?rev="+docARev, "")
+	resp = rt2.SendAdminRequest("DELETE", "/{{.keyspace}}/docA?rev="+docARev, "")
 	RequireStatus(t, resp, http.StatusOK)
 
-	resp = rt2.SendAdminRequest("DELETE", "/db/docA1?rev="+docA1Rev, "")
+	resp = rt2.SendAdminRequest("DELETE", "/{{.keyspace}}/docA1?rev="+docA1Rev, "")
 	RequireStatus(t, resp, http.StatusOK)
 
 	resp = rt2.SendAdminRequest("PUT", "/db/_user/user", `{"name": "user", "password": "letmein",`+AdminChannelGrant(rt2_Scope, rt2_collectionName, `"admin_channels": ["B"]`)+`}`)
@@ -1885,6 +1894,9 @@ func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
 	// Passive
 	_, rt2 := InitScenario(t, nil)
 	defer rt2.Close()
+	rt2_collection := rt2.GetSingleTestDatabaseCollection()
+	rt2_collectionName := rt2_collection.Name()
+	rt2_Scope := rt2_collection.ScopeName()
 
 	// Active
 	rt1 := NewRestTesterDefaultCollection(t, //  CBG-2319: replicator currently requires default collection
@@ -1925,7 +1937,7 @@ func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: dbstats,
 	})
-	resp := rt2.SendAdminRequest("PUT", "/db/_user/user", `{"name": "user", "password": "test", "admin_channels": ["*"]}`)
+	resp := rt2.SendAdminRequest("PUT", "/db/_user/user", `{"name": "user", "password": "test", `+AdminChannelGrant(rt2_Scope, rt2_collectionName, `"admin_channels": ["*"]`)+`}`)
 	RequireStatus(t, resp, http.StatusOK)
 
 	require.NoError(t, ar.Start(ctx1))
@@ -1935,12 +1947,12 @@ func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
 	}()
 
 	// Wait for docs to turn up on local / rt1
-	changesResults, err := rt1.WaitForChanges(5, "/db/_changes?since=0", "", true)
+	changesResults, err := rt1.WaitForChanges(5, "/{{.keyspace}}/_changes?since=0", "", true)
 	require.NoError(t, err)
 	assert.Len(t, changesResults.Results, 5)
 
 	// Revoke A and ensure docA, docAB, docABC get purged from local
-	resp = rt2.SendAdminRequest("PUT", "/db/_user/user", `{"name": "user", "password": "test", "admin_channels": []}`)
+	resp = rt2.SendAdminRequest("PUT", "/db/_user/user", `{"name": "user", "password": "test", `+AdminChannelGrant(rt2_Scope, rt2_collectionName, `"admin_channels": []`)+`}`)
 	RequireStatus(t, resp, http.StatusOK)
 
 	assert.NoError(t, ar.Stop())
@@ -1948,19 +1960,19 @@ func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
 	require.NoError(t, ar.Start(ctx1))
 
 	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/db/docA", "")
+		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA", "")
 		return resp.Code == http.StatusNotFound
 	})
 	assert.NoError(t, err)
 
 	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/db/docAB", "")
+		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docAB", "")
 		return resp.Code == http.StatusNotFound
 	})
 	assert.NoError(t, err)
 
 	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/db/docABC", "")
+		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docABC", "")
 		return resp.Code == http.StatusNotFound
 	})
 	assert.NoError(t, err)
@@ -1979,7 +1991,7 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 	rt2_Scope := rt2_collection.ScopeName()
 
 	// Active
-	rt1 := NewRestTesterDefaultCollection(t, //  CBG-2319: replicator currently requires default collection
+	rt1 := NewRestTester(t, //  CBG-2319: replicator currently requires default collection
 		&RestTesterConfig{
 			CustomTestBucket: base.GetTestBucket(t),
 		})

--- a/rest/role_api_test.go
+++ b/rest/role_api_test.go
@@ -31,9 +31,7 @@ func TestRolePurge(t *testing.T) {
 	collection := rt.GetSingleTestDatabaseCollection()
 
 	// Create role
-	payload, err := GetRolePayload("", "", collection, []string{"channel"})
-	require.NoError(t, err)
-	resp := rt.SendAdminRequest("PUT", "/db/_role/role", payload)
+	resp := rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", "", collection, []string{"channel"}))
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// Delete role
@@ -50,8 +48,7 @@ func TestRolePurge(t *testing.T) {
 	assert.NotNil(t, role)
 
 	// Re-create role
-	payload, err = GetRolePayload("", "", collection, []string{"channel"})
-	resp = rt.SendAdminRequest("PUT", "/db/_role/role", payload)
+	resp = rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", "", collection, []string{"channel"}))
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// Delete role again but with purge flag
@@ -72,16 +69,13 @@ func TestRoleAPI(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
-	payload, err := GetRolePayload("", "", collection, []string{"fedoras", "fixies"})
-	require.NoError(t, err)
 
 	// PUT a role
 	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_role/hipster", ""), 404)
-	response := rt.SendAdminRequest("PUT", "/db/_role/hipster", payload)
+	response := rt.SendAdminRequest("PUT", "/db/_role/hipster", GetRolePayload(t, "", "", collection, []string{"fedoras", "fixies"}))
 	RequireStatus(t, response, 201)
-	payload, err = GetRolePayload("", "", collection, []string{"fedoras", "fixies"})
-	require.NoError(t, err)
-	response = rt.SendAdminRequest("PUT", "/db/_role/testdeleted", payload)
+
+	response = rt.SendAdminRequest("PUT", "/db/_role/testdeleted", GetRolePayload(t, "", "", collection, []string{"fedoras", "fixies"}))
 	RequireStatus(t, response, 201)
 	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_role/testdeleted", ""), 200)
 
@@ -103,11 +97,9 @@ func TestRoleAPI(t *testing.T) {
 	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_role/hipster", ""), 404)
 
 	// POST a role
-	payload, err = GetRolePayload("hipster", "", collection, []string{"fedoras", "fixies"})
-	require.NoError(t, err)
-	response = rt.SendAdminRequest("POST", "/db/_role", payload)
+	response = rt.SendAdminRequest("POST", "/db/_role", GetRolePayload(t, "hipster", "", collection, []string{"fedoras", "fixies"}))
 	RequireStatus(t, response, 301)
-	response = rt.SendAdminRequest("POST", "/db/_role/", payload)
+	response = rt.SendAdminRequest("POST", "/db/_role/", GetRolePayload(t, "hipster", "", collection, []string{"fedoras", "fixies"}))
 	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/_role/hipster", "")
 	RequireStatus(t, response, 200)
@@ -165,9 +157,7 @@ func TestFunkyRoleNames(t *testing.T) {
 			require.NoError(t, a.Save(user))
 
 			// Create role
-			payload, err := GetRolePayload("", "", collection, []string{"testchannel"})
-			require.NoError(t, err)
-			response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_role/%s", url.PathEscape(tc.RoleName)), payload)
+			response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_role/%s", url.PathEscape(tc.RoleName)), GetRolePayload(t, "", "", collection, []string{"testchannel"}))
 			RequireStatus(t, response, 201)
 
 			// Create test document
@@ -259,9 +249,7 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 	assert.NoError(t, err)
 
 	// POST a role
-	payload, err := GetRolePayload("role1", "", collection, []string{"chan1"})
-	require.NoError(t, err)
-	response := rt.SendAdminRequest("POST", "/db/_role/", payload)
+	response := rt.SendAdminRequest("POST", "/db/_role/", GetRolePayload(t, "role1", "", collection, []string{"chan1"}))
 	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/_role/role1", "")
 	RequireStatus(t, response, 200)
@@ -314,19 +302,13 @@ func TestRoleAccessChanges(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create users:
-	payload, err := GetUserPayload("alice", "letmein", "", collection, []string{"alpha"}, nil)
-	require.NoError(t, err)
-	response := rt.SendAdminRequest("PUT", "/db/_user/alice", payload)
+	response := rt.SendAdminRequest("PUT", "/db/_user/alice", GetUserPayload(t, "alice", "letmein", "", collection, []string{"alpha"}, nil))
 	RequireStatus(t, response, 201)
 
-	payload, err = GetUserPayload("zegpold", "letmein", "", collection, []string{"beta"}, nil)
-	require.NoError(t, err)
-	response = rt.SendAdminRequest("PUT", "/db/_user/zegpold", payload)
+	response = rt.SendAdminRequest("PUT", "/db/_user/zegpold", GetUserPayload(t, "zegpold", "letmein", "", collection, []string{"beta"}, nil))
 	RequireStatus(t, response, 201)
 
-	payload, err = GetRolePayload("hipster", "", collection, []string{"gamma"})
-	require.NoError(t, err)
-	response = rt.SendAdminRequest("PUT", "/db/_role/hipster", payload)
+	response = rt.SendAdminRequest("PUT", "/db/_role/hipster", GetRolePayload(t, "hipster", "", collection, []string{"gamma"}))
 	RequireStatus(t, response, 201)
 	/*
 		alice, err := a.NewUser("alice", "letmein", channels.BaseSetOf(t, "alpha"))

--- a/rest/role_api_test.go
+++ b/rest/role_api_test.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"sort"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/auth"
@@ -292,7 +293,9 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &user))
 	assert.Equal(t, "user1", *user.Name)
 	assert.Equal(t, []string{"role1"}, user.RoleNames)
-	assert.Equal(t, []string{"!", "chan1"}, user.GetChannels(s, c).ToArray())
+	allChans := user.GetChannels(s, c).ToArray()
+	sort.Strings(allChans)
+	assert.Equal(t, []string{"!", "chan1"}, allChans)
 
 	// goassert.DeepEquals(t, body["admin_roles"], []interface{}{"hipster"})
 	// goassert.DeepEquals(t, body["all_channels"], []interface{}{"bar", "fedoras", "fixies", "foo"})

--- a/rest/role_api_test.go
+++ b/rest/role_api_test.go
@@ -145,7 +145,7 @@ func TestFunkyRoleNames(t *testing.T) {
 			require.NoError(t, err)
 			const username = "user1"
 			syncFn := fmt.Sprintf(`function(doc) {channel(doc.channels); role("%s", %s);}`, username, string(roleNameJSON))
-			rt := NewRestTester(t, // CBG-2618: fix collection channel access
+			rt := NewRestTester(t,
 				&RestTesterConfig{
 					SyncFn: syncFn,
 				})
@@ -191,7 +191,7 @@ func TestBulkDocsChangeToRoleAccess(t *testing.T) {
 		}`,
 		DatabaseConfig: &DatabaseConfig{}, // revocation requires collection specific channel access
 	}
-	rt := NewRestTester(t, // CBG-2618: fix collection channel access
+	rt := NewRestTester(t,
 		&rtConfig)
 	defer rt.Close()
 	ctx := rt.Context()
@@ -239,7 +239,7 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {role(doc.user, doc.role);channel(doc.channel)}`,
 		DatabaseConfig: &DatabaseConfig{}, // revocation requires collection specific channel access
 	}
-	rt := NewRestTester(t, // CBG-2618: fix collection channel access
+	rt := NewRestTester(t,
 		&rtConfig)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
@@ -290,7 +290,7 @@ func TestRoleAccessChanges(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAccess, base.KeyCRUD, base.KeyChanges)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {role(doc.user, doc.role);channel(doc.channel)}`}
-	rt := NewRestTester(t, // CBG-2618: fix collection channel access
+	rt := NewRestTester(t,
 		&rtConfig)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()

--- a/rest/role_api_test.go
+++ b/rest/role_api_test.go
@@ -372,7 +372,6 @@ func TestRoleAccessChanges(t *testing.T) {
 	fashionRevID := body["rev"].(string)
 
 	roleGrantSequence := rt.GetDocumentSequence("fashion")
-	fmt.Println("current role grant sequence", roleGrantSequence)
 
 	cacheWaiter.Add(4)
 	RequireStatus(t, rt.SendRequest("PUT", "/{{.keyspace}}/g1", `{"channel":"gamma"}`), 201)

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -9,16 +9,17 @@ package rest
 
 import (
 	"fmt"
+	"log"
+	"net/http"
+	"testing"
+	"time"
+
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"log"
-	"net/http"
-	"testing"
-	"time"
 )
 
 func TestCORSLoginOriginOnSessionPost(t *testing.T) {

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -9,17 +9,16 @@ package rest
 
 import (
 	"fmt"
-	"log"
-	"net/http"
-	"testing"
-	"time"
-
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"log"
+	"net/http"
+	"testing"
+	"time"
 )
 
 func TestCORSLoginOriginOnSessionPost(t *testing.T) {
@@ -149,9 +148,24 @@ func TestBasicAuthWithSessionCookie(t *testing.T) {
 	collection := rt.GetSingleTestDatabaseCollection()
 
 	// Create two users
-	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", `{"name":"bernard", "password":"letmein",`+AdminChannelGrant(collection, `"admin_channels":["bernard"]`)+`}`)
+	name := "bernard"
+	pass := "letmein"
+	bernard := auth.PrincipalConfig{
+		Name:     &name,
+		Password: &pass,
+	}
+	payload, err := AdminChannelGrant(bernard, collection, []string{"bernard"})
+	require.NoError(t, err)
+	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", payload)
 	RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/_user/manny", `{"name":"manny", "password":"letmein",`+AdminChannelGrant(collection, `"admin_channels":["manny"]`)+`}`)
+	name = "manny"
+	manny := auth.PrincipalConfig{
+		Name:     &name,
+		Password: &pass,
+	}
+	payload, err = AdminChannelGrant(manny, collection, []string{"manny"})
+	require.NoError(t, err)
+	response = rt.SendAdminRequest("PUT", "/db/_user/manny", payload)
 	RequireStatus(t, response, 201)
 
 	// Create a session for the first user
@@ -192,7 +206,15 @@ func TestSessionFail(t *testing.T) {
 	collection := rt.GetSingleTestDatabaseCollection()
 
 	// Create user
-	response := rt.SendAdminRequest("PUT", "/db/_user/user1", `{"name":"user1", "password":"letmein",`+AdminChannelGrant(collection, `"admin_channels":["user1"]`)+`}`)
+	name := "user1"
+	pass := "letmein"
+	user1 := auth.PrincipalConfig{
+		Name:     &name,
+		Password: &pass,
+	}
+	payload, err := AdminChannelGrant(user1, collection, []string{"user1"})
+	require.NoError(t, err)
+	response := rt.SendAdminRequest("PUT", "/db/_user/user1", payload)
 	RequireStatus(t, response, http.StatusCreated)
 
 	id, err := base.GenerateRandomSecret()

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -167,23 +167,23 @@ func TestBasicAuthWithSessionCookie(t *testing.T) {
 	reqHeaders := map[string]string{
 		"Cookie": cookie,
 	}
-	response = rt.SendRequestWithHeaders("PUT", "/db/bernardDoc", `{"hi": "there", "channels":["bernard"]}`, reqHeaders)
+	response = rt.SendRequestWithHeaders("PUT", "/{{.keyspace}}/bernardDoc", `{"hi": "there", "channels":["bernard"]}`, reqHeaders)
 	RequireStatus(t, response, 201)
-	response = rt.SendRequestWithHeaders("GET", "/db/bernardDoc", "", reqHeaders)
+	response = rt.SendRequestWithHeaders("GET", "/{{.keyspace}}/bernardDoc", "", reqHeaders)
 	RequireStatus(t, response, 200)
 
 	// Create a doc as the second user, with basic auth, channel-restricted to the second user
-	response = rt.Send(RequestByUser("PUT", "/db/mannyDoc", `{"hi": "there", "channels":["manny"]}`, "manny"))
+	response = rt.Send(RequestByUser("PUT", "/db."+s+"."+c+"/mannyDoc", `{"hi": "there", "channels":["manny"]}`, "manny"))
 	RequireStatus(t, response, 201)
-	response = rt.Send(RequestByUser("GET", "/db/mannyDoc", "", "manny"))
+	response = rt.Send(RequestByUser("GET", "/db."+s+"."+c+"/mannyDoc", "", "manny"))
 	RequireStatus(t, response, 200)
-	response = rt.Send(RequestByUser("GET", "/db/bernardDoc", "", "manny"))
+	response = rt.Send(RequestByUser("GET", "/db."+s+"."+c+"/bernardDoc", "", "manny"))
 	RequireStatus(t, response, 403)
 
 	// Attempt to retrieve the docs with the first user's cookie, second user's basic auth credentials.  Basic Auth should take precedence
-	response = rt.SendUserRequestWithHeaders("GET", "/db/bernardDoc", "", reqHeaders, "manny", "letmein")
+	response = rt.SendUserRequestWithHeaders("GET", "/{{.keyspace}}/bernardDoc", "", reqHeaders, "manny", "letmein")
 	RequireStatus(t, response, 403)
-	response = rt.SendUserRequestWithHeaders("GET", "/db/mannyDoc", "", reqHeaders, "manny", "letmein")
+	response = rt.SendUserRequestWithHeaders("GET", "/{{.keyspace}}/mannyDoc", "", reqHeaders, "manny", "letmein")
 	RequireStatus(t, response, 200)
 }
 

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -149,14 +149,10 @@ func TestBasicAuthWithSessionCookie(t *testing.T) {
 	collection := rt.GetSingleTestDatabaseCollection()
 
 	// Create two users
-	payload, err := GetUserPayload("bernard", "letmein", "", collection, []string{"bernard"}, nil)
-	require.NoError(t, err)
-	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", payload)
+	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", GetUserPayload(t, "bernard", "letmein", "", collection, []string{"bernard"}, nil))
 	RequireStatus(t, response, 201)
 
-	payload, err = GetUserPayload("manny", "letmein", "", collection, []string{"manny"}, nil)
-	require.NoError(t, err)
-	response = rt.SendAdminRequest("PUT", "/db/_user/manny", payload)
+	response = rt.SendAdminRequest("PUT", "/db/_user/manny", GetUserPayload(t, "manny", "letmein", "", collection, []string{"manny"}, nil))
 	RequireStatus(t, response, 201)
 
 	// Create a session for the first user
@@ -197,9 +193,7 @@ func TestSessionFail(t *testing.T) {
 	collection := rt.GetSingleTestDatabaseCollection()
 
 	// Create user
-	payload, err := GetUserPayload("user1", "letmein", "", collection, []string{"user1"}, nil)
-	require.NoError(t, err)
-	response := rt.SendAdminRequest("PUT", "/db/_user/user1", payload)
+	response := rt.SendAdminRequest("PUT", "/db/_user/user1", GetUserPayload(t, "user1", "letmein", "", collection, []string{"user1"}, nil))
 	RequireStatus(t, response, http.StatusCreated)
 
 	id, err := base.GenerateRandomSecret()

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -144,7 +144,7 @@ func TestInvalidSession(t *testing.T) {
 // Test for issue 758 - basic auth with stale session cookie
 func TestBasicAuthWithSessionCookie(t *testing.T) {
 
-	rt := NewRestTester(t, nil) // CBG-2618: fix collection channel access
+	rt := NewRestTester(t, nil)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 	c := collection.Name()

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -149,22 +149,12 @@ func TestBasicAuthWithSessionCookie(t *testing.T) {
 	collection := rt.GetSingleTestDatabaseCollection()
 
 	// Create two users
-	name := "bernard"
-	pass := "letmein"
-	bernard := auth.PrincipalConfig{
-		Name:     &name,
-		Password: &pass,
-	}
-	payload, err := AdminChannelGrant(bernard, collection, []string{"bernard"})
+	payload, err := GetUserPayload("bernard", "letmein", "", collection, []string{"bernard"}, nil)
 	require.NoError(t, err)
 	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", payload)
 	RequireStatus(t, response, 201)
-	name = "manny"
-	manny := auth.PrincipalConfig{
-		Name:     &name,
-		Password: &pass,
-	}
-	payload, err = AdminChannelGrant(manny, collection, []string{"manny"})
+
+	payload, err = GetUserPayload("manny", "letmein", "", collection, []string{"manny"}, nil)
 	require.NoError(t, err)
 	response = rt.SendAdminRequest("PUT", "/db/_user/manny", payload)
 	RequireStatus(t, response, 201)
@@ -207,13 +197,7 @@ func TestSessionFail(t *testing.T) {
 	collection := rt.GetSingleTestDatabaseCollection()
 
 	// Create user
-	name := "user1"
-	pass := "letmein"
-	user1 := auth.PrincipalConfig{
-		Name:     &name,
-		Password: &pass,
-	}
-	payload, err := AdminChannelGrant(user1, collection, []string{"user1"})
+	payload, err := GetUserPayload("user1", "letmein", "", collection, []string{"user1"}, nil)
 	require.NoError(t, err)
 	response := rt.SendAdminRequest("PUT", "/db/_user/user1", payload)
 	RequireStatus(t, response, http.StatusCreated)

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -144,13 +144,16 @@ func TestInvalidSession(t *testing.T) {
 // Test for issue 758 - basic auth with stale session cookie
 func TestBasicAuthWithSessionCookie(t *testing.T) {
 
-	rt := NewRestTesterDefaultCollection(t, nil) // CBG-2618: fix collection channel access
+	rt := NewRestTester(t, nil) // CBG-2618: fix collection channel access
 	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
+	c := collection.Name()
+	s := collection.ScopeName()
 
 	// Create two users
-	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", `{"name":"bernard", "password":"letmein", "admin_channels":["bernard"]}`)
+	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", `{"name":"bernard", "password":"letmein",`+AdminChannelGrant(s, c, `"admin_channels":["bernard"]`)+`}`)
 	RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/_user/manny", `{"name":"manny", "password":"letmein","admin_channels":["manny"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/_user/manny", `{"name":"manny", "password":"letmein",`+AdminChannelGrant(s, c, `"admin_channels":["manny"]`)+`}`)
 	RequireStatus(t, response, 201)
 
 	// Create a session for the first user
@@ -188,9 +191,12 @@ func TestBasicAuthWithSessionCookie(t *testing.T) {
 func TestSessionFail(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
+	c := collection.Name()
+	s := collection.ScopeName()
 
 	// Create user
-	response := rt.SendAdminRequest("PUT", "/db/_user/user1", `{"name":"user1", "password":"letmein", "admin_channels":["user1"]}`)
+	response := rt.SendAdminRequest("PUT", "/db/_user/user1", `{"name":"user1", "password":"letmein",`+AdminChannelGrant(s, c, `"admin_channels":["user1"]`)+`}`)
 	RequireStatus(t, response, http.StatusCreated)
 
 	id, err := base.GenerateRandomSecret()

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -11,7 +11,6 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/couchbase/sync_gateway/auth"
 	"log"
 	"net/http"
 	"strconv"
@@ -20,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -912,6 +912,9 @@ func TestResyncRegenerateSequences(t *testing.T) {
 		},
 	)
 	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
+	c := collection.Name()
+	s := collection.ScopeName()
 
 	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
 	if ok && base.UnitTestUrlIsWalrus() {
@@ -936,11 +939,11 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	}
 
 	role := "role1"
-	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_role/%s", role), fmt.Sprintf(`{"name":"%s", "admin_channels":["channel_1"]}`, role))
+	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_role/%s", role), fmt.Sprintf(`{"name":"%s",`+AdminChannelGrant(s, c, `"admin_channels":["channel_1"]`)+`}`, role))
 	RequireStatus(t, response, http.StatusCreated)
 
 	username := "user1"
-	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_user/%s", username), fmt.Sprintf(`{"name":"%s", "password":"letmein", "admin_channels":["channel_1"], "admin_roles": ["%s"]}`, username, role))
+	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_user/%s", username), fmt.Sprintf(`{"name":"%s", "password":"letmein", `+AdminChannelGrant(s, c, `"admin_channels":["channel_1"]`)+`, "admin_roles": ["%s"]}`, username, role))
 	RequireStatus(t, response, http.StatusCreated)
 
 	_, err := rt.MetadataStore().Get(base.RolePrefix+"role1", &body)

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -929,7 +929,7 @@ func TestResyncRegenerateSequences(t *testing.T) {
 		docID := fmt.Sprintf("doc%d", i)
 		rt.CreateDoc(t, docID)
 
-		response = rt.SendAdminRequest("GET", "/db/_raw/"+docID, "")
+		response = rt.SendAdminRequest("GET", "/{{.keyspace}}/_raw/"+docID, "")
 		require.Equal(t, http.StatusOK, response.Code)
 
 		err := json.Unmarshal(response.BodyBytes(), &body)
@@ -939,7 +939,7 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	}
 
 	role := "role1"
-	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_role/%s", role), fmt.Sprintf(`{"name":"%s",`+AdminChannelGrant(s, c, `"admin_channels":["channel_1"]`)+`}`, role))
+	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/{{.keyspace}}/_role/%s", role), fmt.Sprintf(`{"name":"%s",`+AdminChannelGrant(s, c, `"admin_channels":["channel_1"]`)+`}`, role))
 	RequireStatus(t, response, http.StatusCreated)
 
 	username := "user1"
@@ -954,10 +954,10 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	assert.NoError(t, err)
 	user1SeqBefore := body["sequence"].(float64)
 
-	response = rt.SendAdminRequest("PUT", "/db/userdoc", `{"userdoc": true}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/userdoc", `{"userdoc": true}`)
 	RequireStatus(t, response, http.StatusCreated)
 
-	response = rt.SendAdminRequest("PUT", "/db/userdoc2", `{"userdoc": true}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/userdoc2", `{"userdoc": true}`)
 	RequireStatus(t, response, http.StatusCreated)
 
 	// Let everything catch up before opening changes feed
@@ -981,7 +981,7 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	}
 
 	var changesResp ChangesResp
-	request, _ := http.NewRequest("GET", "/db/_changes", nil)
+	request, _ := http.NewRequest("GET", "/{{.keyspace}}/_changes", nil)
 	request.SetBasicAuth("user1", "letmein")
 	response = rt.Send(request)
 	RequireStatus(t, response, http.StatusOK)
@@ -1043,7 +1043,7 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Data is wiped from walrus when brought back online
-	request, err = http.NewRequest("GET", "/db/_changes?since="+changesResp.LastSeq, nil)
+	request, err = http.NewRequest("GET", "/{{.keyspace}}/_changes?since="+changesResp.LastSeq, nil)
 	require.NoError(t, err)
 	request.SetBasicAuth("user1", "letmein")
 	response = rt.Send(request)

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
@@ -937,23 +936,14 @@ func TestResyncRegenerateSequences(t *testing.T) {
 		docSeqArr = append(docSeqArr, body["_sync"].(map[string]interface{})["sequence"].(float64))
 	}
 
-	role := "role1"
-	princConfig := auth.PrincipalConfig{
-		Name: &role,
-	}
-	payload, err := AdminChannelGrant(princConfig, collection, []string{"channel_1"})
+	payload, err := GetRolePayload("role1", "", collection, []string{"channel_1"})
 	require.NoError(t, err)
-	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/{{.keyspace}}/_role/%s", role), payload)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/_role/role1", payload)
 	RequireStatus(t, response, http.StatusCreated)
 
-	username := "user1"
-	pass := "letmein"
-	princConfig.Name = &username
-	princConfig.Password = &pass
-	princConfig.ExplicitRoleNames = base.SetOf("role1")
-	payload, err = AdminChannelGrant(princConfig, collection, []string{"channel_1"})
+	payload, err = GetUserPayload("user1", "letmein", "", collection, []string{"channel_1"}, []string{"role1"})
 	require.NoError(t, err)
-	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_user/%s", username), payload)
+	response = rt.SendAdminRequest("PUT", "/db/_user/user1", payload)
 	RequireStatus(t, response, http.StatusCreated)
 
 	_, err = rt.MetadataStore().Get(base.RolePrefix+"role1", &body)

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -913,8 +913,6 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
-	c := collection.Name()
-	s := collection.ScopeName()
 
 	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
 	if ok && base.UnitTestUrlIsWalrus() {
@@ -939,11 +937,11 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	}
 
 	role := "role1"
-	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/{{.keyspace}}/_role/%s", role), fmt.Sprintf(`{"name":"%s",`+AdminChannelGrant(s, c, `"admin_channels":["channel_1"]`)+`}`, role))
+	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/{{.keyspace}}/_role/%s", role), fmt.Sprintf(`{"name":"%s",`+AdminChannelGrant(collection, `"admin_channels":["channel_1"]`)+`}`, role))
 	RequireStatus(t, response, http.StatusCreated)
 
 	username := "user1"
-	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_user/%s", username), fmt.Sprintf(`{"name":"%s", "password":"letmein", `+AdminChannelGrant(s, c, `"admin_channels":["channel_1"]`)+`, "admin_roles": ["%s"]}`, username, role))
+	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_user/%s", username), fmt.Sprintf(`{"name":"%s", "password":"letmein", `+AdminChannelGrant(collection, `"admin_channels":["channel_1"]`)+`, "admin_roles": ["%s"]}`, username, role))
 	RequireStatus(t, response, http.StatusCreated)
 
 	_, err := rt.MetadataStore().Get(base.RolePrefix+"role1", &body)

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -936,17 +936,13 @@ func TestResyncRegenerateSequences(t *testing.T) {
 		docSeqArr = append(docSeqArr, body["_sync"].(map[string]interface{})["sequence"].(float64))
 	}
 
-	payload, err := GetRolePayload("role1", "", collection, []string{"channel_1"})
-	require.NoError(t, err)
-	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/_role/role1", payload)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/_role/role1", GetRolePayload(t, "role1", "", collection, []string{"channel_1"}))
 	RequireStatus(t, response, http.StatusCreated)
 
-	payload, err = GetUserPayload("user1", "letmein", "", collection, []string{"channel_1"}, []string{"role1"})
-	require.NoError(t, err)
-	response = rt.SendAdminRequest("PUT", "/db/_user/user1", payload)
+	response = rt.SendAdminRequest("PUT", "/db/_user/user1", GetUserPayload(t, "user1", "letmein", "", collection, []string{"channel_1"}, []string{"role1"}))
 	RequireStatus(t, response, http.StatusCreated)
 
-	_, err = rt.MetadataStore().Get(base.RolePrefix+"role1", &body)
+	_, err := rt.MetadataStore().Get(base.RolePrefix+"role1", &body)
 	assert.NoError(t, err)
 	role1SeqBefore := body["sequence"].(float64)
 

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -43,7 +43,7 @@ func TestUsersAPI(t *testing.T) {
 			},
 		},
 	}
-	rt := NewRestTester(t, // CBG-2618: fix collection channel access
+	rt := NewRestTester(t,
 		rtConfig)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
@@ -268,7 +268,7 @@ func TestUsersAPIDetailsWithLimit(t *testing.T) {
 func TestUserAPI(t *testing.T) {
 
 	// PUT a user
-	rt := NewRestTester(t, nil) // CBG-2618: fix collection channel access
+	rt := NewRestTester(t, nil)
 	defer rt.Close()
 	ctx := rt.Context()
 	collection := rt.GetSingleTestDatabaseCollection()
@@ -627,7 +627,7 @@ func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			rt := NewRestTester(t, // CBG-2618: fix collection channel access
+			rt := NewRestTester(t,
 				&RestTesterConfig{
 					SyncFn: `
 			function(doc, oldDoc){
@@ -865,7 +865,7 @@ function(doc, oldDoc) {
 	rtConfig := RestTesterConfig{
 		SyncFn: syncFunction,
 	}
-	rt := NewRestTester(t, // CBG-2618: fix collection channel access
+	rt := NewRestTester(t,
 		&rtConfig)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -47,8 +47,6 @@ func TestUsersAPI(t *testing.T) {
 		rtConfig)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
-	c := collection.Name()
-	s := collection.ScopeName()
 
 	// Validate the zero user case
 	var responseUsers []string
@@ -61,7 +59,7 @@ func TestUsersAPI(t *testing.T) {
 	// Test for user counts going from 1 to a few multiples of QueryPaginationLimit to check boundary conditions
 	for i := 1; i < 13; i++ {
 		userName := fmt.Sprintf("user%d", i)
-		response := rt.SendAdminRequest("PUT", "/db/_user/"+userName, `{"password":"letmein", `+AdminChannelGrant(s, c, `"admin_channels":["foo", "bar"]`)+`}`)
+		response := rt.SendAdminRequest("PUT", "/db/_user/"+userName, `{"password":"letmein", `+AdminChannelGrant(collection, `"admin_channels":["foo", "bar"]`)+`}`)
 		RequireStatus(t, response, 201)
 
 		// check user count
@@ -181,8 +179,6 @@ func TestUsersAPIDetailsWithLimit(t *testing.T) {
 	rt := NewRestTester(t, rtConfig)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
-	c := collection.Name()
-	s := collection.ScopeName()
 
 	// Validate the zero user case with limit
 	var responseUsers []auth.PrincipalConfig
@@ -196,7 +192,7 @@ func TestUsersAPIDetailsWithLimit(t *testing.T) {
 	numUsers := 12
 	for i := 1; i <= numUsers; i++ {
 		userName := fmt.Sprintf("user%d", i)
-		response := rt.SendAdminRequest("PUT", "/db/_user/"+userName, `{"password":"letmein",`+AdminChannelGrant(s, c, `"admin_channels":["foo", "bar"]`)+`}`)
+		response := rt.SendAdminRequest("PUT", "/db/_user/"+userName, `{"password":"letmein",`+AdminChannelGrant(collection, `"admin_channels":["foo", "bar"]`)+`}`)
 		RequireStatus(t, response, 201)
 	}
 
@@ -276,7 +272,7 @@ func TestUserAPI(t *testing.T) {
 	s := collection.ScopeName()
 
 	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/snej", ""), 404)
-	response := rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"letmein", `+AdminChannelGrant(s, c, `"admin_channels":["foo", "bar"]`)+`}`)
+	response := rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"letmein", `+AdminChannelGrant(collection, `"admin_channels":["foo", "bar"]`)+`}`)
 	RequireStatus(t, response, 201)
 
 	user, err := rt.ServerContext().Database(ctx, "db").Authenticator(ctx).GetUser("snej")
@@ -305,7 +301,7 @@ func TestUserAPI(t *testing.T) {
 	assert.True(t, user.Authenticate("letmein"))
 
 	// Change the password and verify it:
-	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"123", `+AdminChannelGrant(s, c, `"admin_channels":["foo", "bar"]`)+`}`)
+	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"123", `+AdminChannelGrant(collection, `"admin_channels":["foo", "bar"]`)+`}`)
 	RequireStatus(t, response, 200)
 
 	user, _ = rt.ServerContext().Database(ctx, "db").Authenticator(ctx).GetUser("snej")
@@ -316,10 +312,10 @@ func TestUserAPI(t *testing.T) {
 	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/snej", ""), 404)
 
 	// POST a user
-	response = rt.SendAdminRequest("POST", "/db/_user", `{"name":"snej", "password":"letmein", `+AdminChannelGrant(s, c, `"admin_channels":["foo", "bar"]`)+`}`)
+	response = rt.SendAdminRequest("POST", "/db/_user", `{"name":"snej", "password":"letmein", `+AdminChannelGrant(collection, `"admin_channels":["foo", "bar"]`)+`}`)
 	RequireStatus(t, response, 301)
 
-	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"snej", "password":"letmein", `+AdminChannelGrant(s, c, `"admin_channels":["foo", "bar"]`)+`}`)
+	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"snej", "password":"letmein", `+AdminChannelGrant(collection, `"admin_channels":["foo", "bar"]`)+`}`)
 	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/_user/snej", "")
 	RequireStatus(t, response, 200)
@@ -329,11 +325,11 @@ func TestUserAPI(t *testing.T) {
 
 	// Create a role
 	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_role/hipster", ""), 404)
-	response = rt.SendAdminRequest("PUT", "/db/_role/hipster", `{`+AdminChannelGrant(s, c, `"admin_channels":["fedoras", "fixies"]`)+`}`)
+	response = rt.SendAdminRequest("PUT", "/db/_role/hipster", `{`+AdminChannelGrant(collection, `"admin_channels":["fedoras", "fixies"]`)+`}`)
 	RequireStatus(t, response, 201)
 
 	// Give the user that role
-	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{`+AdminChannelGrant(s, c, `"admin_channels":["foo", "bar"]`)+`, "admin_roles":["hipster"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{`+AdminChannelGrant(collection, `"admin_channels":["foo", "bar"]`)+`, "admin_roles":["hipster"]}`)
 	RequireStatus(t, response, 200)
 
 	// GET the user and verify that it shows the channels inherited from the role
@@ -349,7 +345,7 @@ func TestUserAPI(t *testing.T) {
 	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/snej", ""), 200)
 
 	// POST a user with URL encoded '|' in name see #2870
-	RequireStatus(t, rt.SendAdminRequest("POST", "/db/_user/", `{"name":"0%7C59", "password":"letmein", `+AdminChannelGrant(s, c, `"admin_channels":["foo", "bar"]`+`}`)), 201)
+	RequireStatus(t, rt.SendAdminRequest("POST", "/db/_user/", `{"name":"0%7C59", "password":"letmein", `+AdminChannelGrant(collection, `"admin_channels":["foo", "bar"]`+`}`)), 201)
 
 	// GET the user, will fail
 	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/0%7C59", ""), 404)
@@ -364,7 +360,7 @@ func TestUserAPI(t *testing.T) {
 	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/0%257C59", ""), 200)
 
 	// POST a user with URL encoded '|' and non-encoded @ in name see #2870
-	RequireStatus(t, rt.SendAdminRequest("POST", "/db/_user/", `{"name":"0%7C@59", "password":"letmein", `+AdminChannelGrant(s, c, `"admin_channels":["foo", "bar"]`+`}`)), 201)
+	RequireStatus(t, rt.SendAdminRequest("POST", "/db/_user/", `{"name":"0%7C@59", "password":"letmein", `+AdminChannelGrant(collection, `"admin_channels":["foo", "bar"]`+`}`)), 201)
 
 	// GET the user, will fail
 	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/0%7C@59", ""), 404)
@@ -422,8 +418,6 @@ func TestUserAndRoleResponseContentType(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
-	c := collection.Name()
-	s := collection.ScopeName()
 
 	// Create a user 'christopher' through PUT request with empty request body.
 	var responseBody db.Body
@@ -441,13 +435,13 @@ func TestUserAndRoleResponseContentType(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &responseBody))
 
 	// Create a user 'alice' through PUT request.
-	body = `{"email":"alice@couchbase.com","password":"cGFzc3dvcmQ=",` + AdminChannelGrant(s, c, `"admin_channels":["foo", "bar"]`) + `}`
+	body = `{"email":"alice@couchbase.com","password":"cGFzc3dvcmQ=",` + AdminChannelGrant(collection, `"admin_channels":["foo", "bar"]`) + `}`
 	response = rt.SendAdminRequest(http.MethodPut, "/db/_user/alice", body)
 	assert.Equal(t, http.StatusCreated, response.Code)
 	assert.Empty(t, response.Header().Get("Content-Type"))
 
 	// Create another user 'bob' through POST request.
-	body = `{"name":"bob","email":"bob@couchbase.com","password":"cGFzc3dvcmQ=",` + AdminChannelGrant(s, c, `"admin_channels":["foo", "bar"]`) + `}`
+	body = `{"name":"bob","email":"bob@couchbase.com","password":"cGFzc3dvcmQ=",` + AdminChannelGrant(collection, `"admin_channels":["foo", "bar"]`) + `}`
 	response = rt.SendAdminRequest(http.MethodPost, "/db/_user/", body)
 	assert.Equal(t, http.StatusCreated, response.Code)
 	assert.Empty(t, response.Header().Get("Content-Type"))
@@ -521,13 +515,13 @@ func TestUserAndRoleResponseContentType(t *testing.T) {
 	assert.Empty(t, response.Header().Get("Content-Type"))
 
 	// Create a role 'developer' through POST request
-	body = `{"name":"developer",` + AdminChannelGrant(s, c, `"admin_channels":["channel1", "channel2"]`) + `}`
+	body = `{"name":"developer",` + AdminChannelGrant(collection, `"admin_channels":["channel1", "channel2"]`) + `}`
 	response = rt.SendAdminRequest(http.MethodPost, "/db/_role/", body)
 	assert.Equal(t, http.StatusCreated, response.Code)
 	assert.Empty(t, response.Header().Get("Content-Type"))
 
 	// Create another role 'coder' through PUT request.
-	body = `{` + AdminChannelGrant(s, c, `"admin_channels":["channel3", "channel4"]`) + `}`
+	body = `{` + AdminChannelGrant(collection, `"admin_channels":["channel3", "channel4"]`) + `}`
 	response = rt.SendAdminRequest(http.MethodPut, "/db/_role/coder", body)
 	assert.Equal(t, http.StatusCreated, response.Code)
 	assert.Empty(t, response.Header().Get("Content-Type"))
@@ -649,7 +643,7 @@ func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
 			s := collection.ScopeName()
 
 			// Create role
-			resp := rt.SendAdminRequest("PUT", "/db/_role/role", `{`+AdminChannelGrant(s, c, `"admin_channels":["channel"]`)+`}`)
+			resp := rt.SendAdminRequest("PUT", "/db/_role/role", `{`+AdminChannelGrant(collection, `"admin_channels":["channel"]`)+`}`)
 			RequireStatus(t, resp, http.StatusCreated)
 
 			// Create user
@@ -703,34 +697,32 @@ func TestUserPasswordValidation(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
-	c := collection.Name()
-	s := collection.ScopeName()
 
-	response := rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"letmein", `+AdminChannelGrant(s, c, `"admin_channels":["foo", "bar"]`)+`}`)
+	response := rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"letmein", `+AdminChannelGrant(collection, `"admin_channels":["foo", "bar"]`)+`}`)
 	RequireStatus(t, response, 201)
 
 	// PUT a user without a password, should fail
-	response = rt.SendAdminRequest("PUT", "/db/_user/ajresnopassword", `{"email":"ajres@couchbase.com", `+AdminChannelGrant(s, c, `"admin_channels":["foo", "bar"]`)+`}`)
+	response = rt.SendAdminRequest("PUT", "/db/_user/ajresnopassword", `{"email":"ajres@couchbase.com", `+AdminChannelGrant(collection, `"admin_channels":["foo", "bar"]`)+`}`)
 	RequireStatus(t, response, 400)
 
 	// POST a user without a password, should fail
-	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"ajresnopassword", "email":"ajres@couchbase.com", `+AdminChannelGrant(s, c, `"admin_channels":["foo", "bar"]`)+`}`)
+	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"ajresnopassword", "email":"ajres@couchbase.com", `+AdminChannelGrant(collection, `"admin_channels":["foo", "bar"]`)+`}`)
 	RequireStatus(t, response, 400)
 
 	// PUT a user with a two character password, should fail
-	response = rt.SendAdminRequest("PUT", "/db/_user/ajresnopassword", `{"email":"ajres@couchbase.com", "password":"in", `+AdminChannelGrant(s, c, `"admin_channels":["foo", "bar"]`)+`}`)
+	response = rt.SendAdminRequest("PUT", "/db/_user/ajresnopassword", `{"email":"ajres@couchbase.com", "password":"in", `+AdminChannelGrant(collection, `"admin_channels":["foo", "bar"]`)+`}`)
 	RequireStatus(t, response, 400)
 
 	// POST a user with a two character password, should fail
-	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"ajresnopassword", "email":"ajres@couchbase.com", "password":"an", `+AdminChannelGrant(s, c, `"admin_channels":["foo", "bar"]`)+`}`)
+	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"ajresnopassword", "email":"ajres@couchbase.com", "password":"an", `+AdminChannelGrant(collection, `"admin_channels":["foo", "bar"]`)+`}`)
 	RequireStatus(t, response, 400)
 
 	// PUT a user with a zero character password, should fail
-	response = rt.SendAdminRequest("PUT", "/db/_user/ajresnopassword", `{"email":"ajres@couchbase.com", "password":"", `+AdminChannelGrant(s, c, `"admin_channels":["foo", "bar"]`)+`}`)
+	response = rt.SendAdminRequest("PUT", "/db/_user/ajresnopassword", `{"email":"ajres@couchbase.com", "password":"", `+AdminChannelGrant(collection, `"admin_channels":["foo", "bar"]`)+`}`)
 	RequireStatus(t, response, 400)
 
 	// POST a user with a zero character password, should fail
-	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"ajresnopassword", "email":"ajres@couchbase.com", "password":"", `+AdminChannelGrant(s, c, `"admin_channels":["foo", "bar"]`)+`}`)
+	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"ajresnopassword", "email":"ajres@couchbase.com", "password":"", `+AdminChannelGrant(collection, `"admin_channels":["foo", "bar"]`)+`}`)
 	RequireStatus(t, response, 400)
 
 	// PUT update a user with a two character password, should fail
@@ -872,10 +864,8 @@ function(doc, oldDoc) {
 		&rtConfig)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
-	c := collection.Name()
-	s := collection.ScopeName()
 
-	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", `{"name":"bernard", "password":"letmein",`+AdminChannelGrant(s, c, `"admin_channels":["profile-bernard"]`)+`}`)
+	response := rt.SendAdminRequest("PUT", "/{{.db}}/_user/bernard", `{"name":"bernard", "password":"letmein",`+AdminChannelGrant(collection, `"admin_channels":["profile-bernard"]`)+`}`)
 	RequireStatus(t, response, 201)
 
 	// Try to force channel initialisation for user bernard
@@ -893,7 +883,7 @@ function(doc, oldDoc) {
 		input = input + fmt.Sprintf(`{"_id":"%s", "type":"list"}`, docId)
 	}
 	input = input + `]}`
-	response = rt.SendAdminRequest("POST", "/db."+s+"."+c+"/_bulk_docs", input)
+	response = rt.SendAdminRequest("POST", "/{{.keyspace}}/_bulk_docs", input)
 
 	// Start changes feed
 	var wg sync.WaitGroup
@@ -920,7 +910,7 @@ function(doc, oldDoc) {
 			// Timeout allows us to read continuous changes after processing is complete.  Needs to be long enough to
 			// ensure it doesn't terminate before the first change is sent.
 			log.Printf("Invoking _changes?feed=continuous&since=%s&timeout=2000", since)
-			changesResponse := rt.Send(RequestByUser("GET", fmt.Sprintf("/db."+s+"."+c+"/_changes?feed=continuous&since=%s&timeout=2000", since), "", "bernard"))
+			changesResponse := rt.SendUserRequest("GET", fmt.Sprintf("/{{.keyspace}}/_changes?feed=continuous&since=%s&timeout=2000", since), "", "bernard")
 
 			changes, err := readContinuousChanges(changesResponse)
 			assert.NoError(t, err)
@@ -965,7 +955,7 @@ function(doc, oldDoc) {
 		input = input + `]}`
 
 		log.Printf("Sending 2nd round of _bulk_docs")
-		response = rt.Send(RequestByUser("POST", "/db."+s+"."+c+"/_bulk_docs", input, "bernard"))
+		response = rt.SendUserRequest("POST", "/{{.keyspace}}/_bulk_docs", input, "bernard")
 		log.Printf("Sent 2nd round of _bulk_docs")
 
 	}

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -386,9 +386,9 @@ func TestUserAPI(t *testing.T) {
 	princConfig := auth.PrincipalConfig{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &princConfig))
 	assert.Equal(t, []string{"hipster"}, princConfig.ExplicitRoleNames.ToArray())
-	channels := princConfig.GetChannels(s, c).ToArray()
-	sort.Strings(channels)
-	assert.Equal(t, []string{"!", "bar", "fedoras", "fixies", "foo"}, channels)
+	allChans = princConfig.GetChannels(s, c).ToArray()
+	sort.Strings(allChans)
+	assert.Equal(t, []string{"!", "bar", "fedoras", "fixies", "foo"}, allChans)
 
 	// DELETE the user
 	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/snej", ""), 200)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1388,8 +1388,7 @@ func (bt *BlipTester) SendRev(docId, docRev string, body []byte, properties blip
 
 }
 
-// Expects adminChannels of the form `admin_channels":["alpha"]`
-// If scope and collection are non-zero, builds collection access string for the collection
+// AdminChannelGrant takes a set of channels and will allocate the channels to user/role based on whether you are using named collections or not
 func AdminChannelGrant(princ auth.PrincipalConfig, collection *db.DatabaseCollection, adminChannels []string) (string, error) {
 	collectionName := collection.Name()
 	scopeName := collection.ScopeName()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1388,6 +1388,8 @@ func (bt *BlipTester) SendRev(docId, docRev string, body []byte, properties blip
 
 }
 
+// Expects adminChannels of the form `admin_channels":["alpha"]`
+// If scope and collection are non-zero, builds collection access string for the collection
 func AdminChannelGrant(collection *db.DatabaseCollection, adminChannels string) (collectionAdminChannels string) {
 	collectionName := collection.Name()
 	scopeName := collection.ScopeName()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1395,7 +1395,11 @@ func AdminChannelGrant(princ auth.PrincipalConfig, collection *db.DatabaseCollec
 	scopeName := collection.ScopeName()
 
 	if base.IsDefaultCollection(scopeName, collectionName) {
-		princ.ExplicitChannels = base.SetFromArray(adminChannels)
+		if len(adminChannels) == 0 {
+			princ.ExplicitChannels = base.SetOf("[]")
+		} else {
+			princ.ExplicitChannels = base.SetFromArray(adminChannels)
+		}
 	} else {
 		princ.SetExplicitChannels(scopeName, collectionName, adminChannels...)
 	}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -954,7 +954,7 @@ type RawResponse struct {
 // GetDocumentSequence looks up the sequence for a document using the _raw endpoint.
 // Used by tests that need to validate sequences (for grants, etc)
 func (rt *RestTester) GetDocumentSequence(key string) (sequence uint64) {
-	response := rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s", key), "")
+	response := rt.SendAdminRequest("GET", fmt.Sprintf("/{{.keyspace}}/_raw/%s", key), "")
 	if response.Code != 200 {
 		return 0
 	}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1404,7 +1404,6 @@ func AdminChannelGrant(princ auth.PrincipalConfig, collection *db.DatabaseCollec
 	if err != nil {
 		return "", err
 	}
-	fmt.Println(string(payload))
 
 	return string(payload), nil
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1388,13 +1388,27 @@ func (bt *BlipTester) SendRev(docId, docRev string, body []byte, properties blip
 
 }
 
-func AdminChannelGrant(scopeName, collectionName, adminChannels string) (collectionAdminChannels string) {
-
+func AdminChannelGrant(collection *db.DatabaseCollection, adminChannels string) (collectionAdminChannels string) {
+	collectionName := collection.Name()
+	scopeName := collection.ScopeName()
 	if base.IsDefaultCollection(scopeName, collectionName) {
 		return adminChannels
 	}
 
 	return fmt.Sprintf(`"collection_access":{%q: {%q: {%s}}}`, scopeName, collectionName, adminChannels)
+}
+
+func GetNamedDatastore(dataStores []sgbucket.DataStoreName, collection *db.DatabaseCollection) sgbucket.DataStoreName {
+	var data sgbucket.DataStoreName
+	c := collection.Name()
+	s := collection.ScopeName()
+	for _, dataStoreName := range dataStores {
+		if dataStoreName.ScopeName() == s && dataStoreName.CollectionName() == c {
+			data = dataStoreName
+			return data
+		}
+	}
+	return nil
 }
 
 func getChangesHandler(changesFinishedWg, revsFinishedWg *sync.WaitGroup) func(request *blip.Message) {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1388,7 +1388,8 @@ func (bt *BlipTester) SendRev(docId, docRev string, body []byte, properties blip
 
 }
 
-func GetUserPayload(username, password, email string, collection *db.DatabaseCollection, chans, roles []string) (string, error) {
+// GetUserPayload will take username, password, email, channels and roles you want to assign a user and create the appropriate payload for the _user endpoint
+func GetUserPayload(t *testing.T, username, password, email string, collection *db.DatabaseCollection, chans, roles []string) string {
 	config := auth.PrincipalConfig{}
 	if username != "" {
 		config.Name = &username
@@ -1403,13 +1404,12 @@ func GetUserPayload(username, password, email string, collection *db.DatabaseCol
 		config.ExplicitRoleNames = base.SetOf(roles...)
 	}
 	marshalledConfig, err := addChannelsToPrincipal(config, collection, chans)
-	if err != nil {
-		return "", err
-	}
-	return string(marshalledConfig), nil
+	require.NoError(t, err)
+	return string(marshalledConfig)
 }
 
-func GetRolePayload(roleName, password string, collection *db.DatabaseCollection, chans []string) (string, error) {
+// GetRolePayload will take roleName, password and channels you want to assign a particular role and return the appropriate payload for the _role endpoint
+func GetRolePayload(t *testing.T, roleName, password string, collection *db.DatabaseCollection, chans []string) string {
 	config := auth.PrincipalConfig{}
 	if roleName != "" {
 		config.Name = &roleName
@@ -1418,12 +1418,11 @@ func GetRolePayload(roleName, password string, collection *db.DatabaseCollection
 		config.Password = &password
 	}
 	marshalledConfig, err := addChannelsToPrincipal(config, collection, chans)
-	if err != nil {
-		return "", err
-	}
-	return string(marshalledConfig), nil
+	require.NoError(t, err)
+	return string(marshalledConfig)
 }
 
+// add channels to principal depending if running with collections or not. then marshal the principal config
 func addChannelsToPrincipal(config auth.PrincipalConfig, collection *db.DatabaseCollection, chans []string) ([]byte, error) {
 	if base.IsDefaultCollection(collection.ScopeName(), collection.Name()) {
 		if len(chans) == 0 {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1388,6 +1388,15 @@ func (bt *BlipTester) SendRev(docId, docRev string, body []byte, properties blip
 
 }
 
+func AdminChannelGrant(scopeName, collectionName, adminChannels string) (collectionAdminChannels string) {
+
+	if base.IsDefaultCollection(scopeName, collectionName) {
+		return adminChannels
+	}
+
+	return fmt.Sprintf(`"collection_access":{%q: {%q: {%s}}}`, scopeName, collectionName, adminChannels)
+}
+
 func getChangesHandler(changesFinishedWg, revsFinishedWg *sync.WaitGroup) func(request *blip.Message) {
 	return func(request *blip.Message) {
 		// Send a response telling the other side we want ALL revisions


### PR DESCRIPTION
CBG-2618

Changes to make all tests that use channels collection aware though using the "collection_access" api field. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1402/
- [x]  `GSI=true. xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1361/
- [x]  `GSI=false, xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1359/
- [x]  `GSI=false, xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1403/
