### PR TITLE
Skip all docs index creation

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -128,6 +128,7 @@ type DatabaseContext struct {
 	singleCollection             *DatabaseCollection            // Temporary collection
 	CollectionByID               map[uint32]*DatabaseCollection // A map keyed by collection ID to Collection
 	CollectionNames              map[string]map[string]struct{} // Map of scope, collection names
+	AllDocsIndexExists           bool
 }
 
 type Scope struct {

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -135,7 +135,7 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	log.Printf("removedIndexes: %+v", removedIndexes)
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in setup case")
 
-	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false, db.IsServerless())
+	_, err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false, db.IsServerless())
 	assert.NoError(t, err)
 
 	// Running w/ opposite xattrs flag should preview removal of the indexes associated with this db context
@@ -154,7 +154,7 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in post-cleanup no-op")
 
 	// Restore indexes after test
-	err = InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false, db.IsServerless())
+	_, err = InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false, db.IsServerless())
 	assert.NoError(t, err)
 }
 
@@ -197,7 +197,7 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes with hacked sgIndexes")
 
 	// Restore indexes after test
-	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false, db.IsServerless())
+	_, err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false, db.IsServerless())
 	assert.NoError(t, err)
 
 }
@@ -311,7 +311,7 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Restore indexes after test
-	err = InitializeIndexes(n1QLStore, db.UseXattrs(), 0, false, db.IsServerless())
+	_, err = InitializeIndexes(n1QLStore, db.UseXattrs(), 0, false, db.IsServerless())
 	assert.NoError(t, err)
 }
 
@@ -334,7 +334,7 @@ func TestRemoveObsoleteIndexOnError(t *testing.T) {
 		// Restore indexes after test
 		n1qlStore, ok := base.AsN1QLStore(dataStore)
 		assert.True(t, ok)
-		err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false, db.IsServerless())
+		_, err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false, db.IsServerless())
 		assert.NoError(t, err)
 
 	}()
@@ -387,7 +387,7 @@ func dropAndInitializeIndexes(ctx context.Context, n1qlStore base.N1QLStore, xat
 		return dropErr
 	}
 
-	initErr := InitializeIndexes(n1qlStore, xattrs, 0, false, isServerless)
+	_, initErr := InitializeIndexes(n1qlStore, xattrs, 0, false, isServerless)
 	if initErr != nil {
 		return initErr
 	}

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -273,6 +273,7 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 
 	_, err := removeObsoleteDesignDocs(ctx, viewStore, !db.UseXattrs(), db.UseViews())
 	assert.NoError(t, err)
+
 	_, err = removeObsoleteDesignDocs(ctx, viewStore, !db.UseXattrs(), !db.UseViews())
 	assert.NoError(t, err)
 

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -457,7 +457,7 @@ func setupN1QLStore(bucket base.Bucket, isServerless bool) ([]base.N1QLStore, re
 			return nil, nil, fmt.Errorf("Unable to get n1QLStore for testBucket")
 		}
 
-		if err := db.InitializeIndexes(n1QLStore, base.TestUseXattrs(), 0, false, isServerless); err != nil {
+		if _, err := db.InitializeIndexes(n1QLStore, base.TestUseXattrs(), 0, false, isServerless); err != nil {
 			return nil, nil, err
 		}
 		outN1QLStores = append(outN1QLStores, n1QLStore)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -335,7 +335,7 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 			return err
 		}
 		tbp.Logf(ctx, "creating SG bucket indexes")
-		if err := InitializeIndexes(n1qlStore, base.TestUseXattrs(), 0, false, false); err != nil {
+		if _, err := InitializeIndexes(n1qlStore, base.TestUseXattrs(), 0, false, false); err != nil {
 			return err
 		}
 

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -83,6 +83,8 @@ func TestStarAccess(t *testing.T) {
 	rt := NewRestTesterDefaultCollection(t, nil) // CBG-2618: fix collection channel access
 	defer rt.Close()
 
+	isAllDocsIndexExist := rt.ServerContext().IsAllDocsIndexExistFor(rt.GetDatabase().Name)
+
 	a := auth.NewAuthenticator(rt.MetadataStore(), nil, auth.DefaultAuthenticatorOptions())
 	var changes struct {
 		Results []db.ChangeEntry
@@ -125,16 +127,20 @@ func TestStarAccess(t *testing.T) {
 	// GET /db/_all_docs?channels=true
 	// Check that _all_docs returns the docs the user has access to:
 	response = rt.SendUserRequest("GET", "/db/_all_docs?channels=true", "", "bernard")
-	RequireStatus(t, response, 200)
+	if isAllDocsIndexExist {
+		RequireStatus(t, response, 200)
 
-	log.Printf("Response = %s", response.Body.Bytes())
-	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.NoError(t, err)
-	assert.Equal(t, 3, len(allDocsResult.Rows))
-	assert.Equal(t, "doc1", allDocsResult.Rows[0].ID)
-	assert.Equal(t, []string{"books"}, allDocsResult.Rows[0].Value.Channels)
-	assert.Equal(t, "doc3", allDocsResult.Rows[1].ID)
-	assert.Equal(t, []string{"!"}, allDocsResult.Rows[1].Value.Channels)
+		log.Printf("Response = %s", response.Body.Bytes())
+		err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, len(allDocsResult.Rows))
+		assert.Equal(t, "doc1", allDocsResult.Rows[0].ID)
+		assert.Equal(t, []string{"books"}, allDocsResult.Rows[0].Value.Channels)
+		assert.Equal(t, "doc3", allDocsResult.Rows[1].ID)
+		assert.Equal(t, []string{"!"}, allDocsResult.Rows[1].Value.Channels)
+	} else {
+		RequireStatus(t, response, 400)
+	}
 
 	// Ensure docs have been processed before issuing changes requests
 	expectedSeq := uint64(6)
@@ -196,15 +202,18 @@ func TestStarAccess(t *testing.T) {
 	// GET /db/_all_docs?channels=true
 	// Check that _all_docs returns all docs (based on user * channel)
 	response = rt.SendUserRequest("GET", "/db/_all_docs?channels=true", "", "fran")
-	RequireStatus(t, response, 200)
+	if isAllDocsIndexExist {
+		RequireStatus(t, response, 200)
 
-	log.Printf("Response = %s", response.Body.Bytes())
-	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.NoError(t, err)
-	assert.Equal(t, 6, len(allDocsResult.Rows))
-	assert.Equal(t, "doc1", allDocsResult.Rows[0].ID)
-	assert.Equal(t, []string{"books"}, allDocsResult.Rows[0].Value.Channels)
-
+		log.Printf("Response = %s", response.Body.Bytes())
+		err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
+		assert.NoError(t, err)
+		assert.Equal(t, 6, len(allDocsResult.Rows))
+		assert.Equal(t, "doc1", allDocsResult.Rows[0].ID)
+		assert.Equal(t, []string{"books"}, allDocsResult.Rows[0].Value.Channels)
+	} else {
+		RequireStatus(t, response, 400)
+	}
 	// GET /db/_changes
 	response = rt.SendUserRequest("GET", "/db/_changes", "", "fran")
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
@@ -243,13 +252,16 @@ func TestStarAccess(t *testing.T) {
 	// GET /db/_all_docs?channels=true
 	// Check that _all_docs only returns ! docs (based on doc ! channel)
 	response = rt.SendUserRequest("GET", "/db/_all_docs?channels=true", "", "manny")
-	RequireStatus(t, response, 200)
-	log.Printf("Response = %s", response.Body.Bytes())
-	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(allDocsResult.Rows))
-	assert.Equal(t, "doc3", allDocsResult.Rows[0].ID)
-
+	if isAllDocsIndexExist {
+		RequireStatus(t, response, 200)
+		log.Printf("Response = %s", response.Body.Bytes())
+		err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(allDocsResult.Rows))
+		assert.Equal(t, "doc3", allDocsResult.Rows[0].ID)
+	} else {
+		RequireStatus(t, response, 400)
+	}
 	// GET /db/_changes
 	response = rt.SendUserRequest("GET", "/db/_changes", "", "manny")
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
@@ -563,6 +575,11 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 func TestAllDocsAccessControl(t *testing.T) {
 	rt := NewRestTesterDefaultCollection(t, nil) // CBG-2618: fix collection channel access
 	defer rt.Close()
+
+	if !rt.ServerContext().IsAllDocsIndexExistFor(rt.GetDatabase().Name) {
+		t.Skip("This test requires AllDocs index to be present")
+	}
+
 	type allDocsRow struct {
 		ID    string `json:"id"`
 		Key   string `json:"key"`

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -120,6 +120,10 @@ func TestCollectionsPublicChannel(t *testing.T) {
 	})
 	defer rt.Close()
 
+	if !rt.ServerContext().IsAllDocsIndexExistFor(rt.GetDatabase().Name) {
+		t.Skip("This test requires AllDocs index to be present")
+	}
+
 	pathPublic := "/{{.keyspace}}/docpublic"
 	resp := rt.SendAdminRequest(http.MethodPut, pathPublic, `{"channels":["!"]}`)
 	RequireStatus(t, resp, http.StatusCreated)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1116,6 +1116,10 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
+	if !rt.ServerContext().IsAllDocsIndexExistFor(rt.GetDatabase().Name) {
+		t.Skip("This test requires AllDocs index to be present")
+	}
+
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	guest, err := a.GetUser("")

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -27,6 +27,16 @@ import (
 
 // HTTP handler for _all_docs
 func (h *handler) handleAllDocs() error {
+	dbName := h.db.Bucket.GetName()
+
+	if h.server.databases_[dbName] == nil {
+		return base.HTTPErrorf(http.StatusInternalServerError, "could not find database context for %s", dbName)
+	}
+
+	if !h.server.databases_[dbName].AllDocsIndexExists {
+		return base.HTTPErrorf(http.StatusBadRequest, "_all_docs endpoint is only available when '*' Channel is enabled. set 'cache.channel_cache.enable_star_channel':true in Sync Gateway's database config.")
+	}
+
 	// http://wiki.apache.org/couchdb/HTTP_Bulk_Document_API
 	includeDocs := h.getBoolQuery("include_docs")
 	includeChannels := h.getBoolQuery("channels")

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -27,13 +27,13 @@ import (
 
 // HTTP handler for _all_docs
 func (h *handler) handleAllDocs() error {
-	dbName := h.db.Bucket.GetName()
+	dbName := h.db.Name
 
 	if h.server.databases_[dbName] == nil {
 		return base.HTTPErrorf(http.StatusInternalServerError, "could not find database context for %s", dbName)
 	}
 
-	if !h.server.databases_[dbName].AllDocsIndexExists {
+	if !h.server.IsAllDocsIndexExistFor(dbName) {
 		return base.HTTPErrorf(http.StatusBadRequest, "_all_docs endpoint is only available when '*' Channel is enabled. set 'cache.channel_cache.enable_star_channel':true in Sync Gateway's database config.")
 	}
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -156,6 +156,11 @@ func (sc *ServerContext) PostStartup() {
 	close(sc.hasStarted)
 }
 
+// IsAllDocsIndexExistFor returns if AllDocs index exists for given db
+func (sc *ServerContext) IsAllDocsIndexExistFor(dbName string) bool {
+	return sc.databases_[dbName] != nil && sc.databases_[dbName].AllDocsIndexExists
+}
+
 // serverContextStopMaxWait is the maximum amount of time to wait for
 // background goroutines to terminate before the server is stopped.
 const serverContextStopMaxWait = 30 * time.Second
@@ -453,7 +458,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	// initDataStore is a function to initialize Views or GSI indexes for a datastore
 	initDataStore := func(ds base.DataStore) (bool, error) {
 		if useViews {
-			return true, db.InitializeViews(ctx, ds)
+			return false, db.InitializeViews(ctx, ds)
 		}
 
 		gsiSupported := bucket.IsSupported(sgbucket.BucketStoreFeatureN1ql)

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1117,6 +1117,8 @@ func TestFunkyUsernames(t *testing.T) {
 			ctx := rt.Context()
 			a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 
+			isAllDocsIndexExist := rt.ServerContext().IsAllDocsIndexExistFor(rt.GetDatabase().Name)
+
 			// Create a test user
 			user, err := a.NewUser(tc.UserName, "letmein", channels.BaseSetOf(t, "foo"))
 			require.NoError(t, err)
@@ -1125,8 +1127,10 @@ func TestFunkyUsernames(t *testing.T) {
 			response := rt.SendUserRequest("PUT", "/{{.keyspace}}/AC+DC", `{"foo":"bar", "channels": ["foo"]}`, tc.UserName)
 			RequireStatus(t, response, 201)
 
-			response = rt.SendUserRequest("GET", "/{{.keyspace}}/_all_docs", "", tc.UserName)
-			RequireStatus(t, response, 200)
+			if isAllDocsIndexExist {
+				response = rt.SendUserRequest("GET", "/{{.keyspace}}/_all_docs", "", tc.UserName)
+				RequireStatus(t, response, 200)
+			}
 
 			response = rt.SendUserRequest("GET", "/{{.keyspace}}/AC+DC", "", tc.UserName)
 			RequireStatus(t, response, 200)


### PR DESCRIPTION
CBG-0000

Describe your PR here...
- Don't create AllDocs index if it doesn't exist already. 
  - This will not create AllDocs index for new deployments
  -  Disable _all_docs endpoint if AllDocs index isn't present

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
