### PR TITLE
Skip all docs index creation for new deployment

### DIFF
--- a/channels/channelmapper.go
+++ b/channels/channelmapper.go
@@ -53,7 +53,7 @@ func NewDefaultChannelMapper() *ChannelMapper {
 	return NewChannelMapper(DefaultSyncFunction, time.Duration(base.DefaultJavascriptTimeoutSecs)*time.Second)
 }
 
-func (mapper *ChannelMapper) MapToChannelsAndAccess(body map[string]interface{}, oldBodyJSON string, metaMap map[string]interface{}, userCtx map[string]interface{}) (*ChannelMapperOutput, error) {
+func (mapper *ChannelMapper) MapToChannelsAndAccess(body map[string]interface{}, oldBodyJSON string, metaMap map[string]interface{}, userCtx map[string]interface{}, shouldAddStarChannel bool) (*ChannelMapperOutput, error) {
 	numberFixBody := ConvertJSONNumbers(body)
 	numberFixMetaMap := ConvertJSONNumbers(metaMap)
 
@@ -62,6 +62,10 @@ func (mapper *ChannelMapper) MapToChannelsAndAccess(body map[string]interface{},
 		return nil, err
 	}
 	output := result1.(*ChannelMapperOutput)
+
+	if shouldAddStarChannel {
+		output.Channels.Add(UserStarChannel)
+	}
 	return output, nil
 }
 
@@ -122,10 +126,15 @@ func ForChangedUsers(a, b AccessMap, fn func(user string)) {
 	}
 }
 
-func (runner *SyncRunner) MapToChannelsAndAccess(body map[string]interface{}, oldBodyJSON string, userCtx map[string]interface{}) (*ChannelMapperOutput, error) {
+func (runner *SyncRunner) MapToChannelsAndAccess(body map[string]interface{}, oldBodyJSON string, userCtx map[string]interface{}, shouldAddStarChannel bool) (*ChannelMapperOutput, error) {
 	result, err := runner.Call(body, sgbucket.JSONString(oldBodyJSON), userCtx)
 	if err != nil {
 		return nil, err
 	}
-	return result.(*ChannelMapperOutput), nil
+	output := result.(*ChannelMapperOutput)
+
+	if shouldAddStarChannel {
+		output.Channels.Add(UserStarChannel)
+	}
+	return output, nil
 }

--- a/channels/channelmapper_test.go
+++ b/channels/channelmapper_test.go
@@ -51,7 +51,7 @@ func TestOttoValueToStringArray(t *testing.T) {
 // verify that our version of Otto treats JSON parsed arrays like real arrays
 func TestJavaScriptWorks(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.x.concat(doc.y));}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"x":["abc"],"y":["xyz"]}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"x":["abc"],"y":["xyz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "abc", "xyz"), res.Channels)
 }
@@ -59,7 +59,7 @@ func TestJavaScriptWorks(t *testing.T) {
 // Just verify that the calls to the channel() fn show up in the output channel list.
 func TestSyncFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel("foo", "bar"); channel("baz")}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo", "bar", "baz"), res.Channels)
 }
@@ -67,7 +67,7 @@ func TestSyncFunction(t *testing.T) {
 // Just verify that the calls to the access() fn show up in the output channel list.
 func TestAccessFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("foo", "bar"); access("foo", "baz")}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"foo": BaseSetOf(t, "bar", "baz")}, res.Access)
 }
@@ -75,7 +75,7 @@ func TestAccessFunction(t *testing.T) {
 // Just verify that the calls to the channel() fn show up in the output channel list.
 func TestSyncFunctionTakesArray(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(["foo", "bar ok","baz"])}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo", "bar ok", "baz"), res.Channels)
 }
@@ -83,21 +83,21 @@ func TestSyncFunctionTakesArray(t *testing.T) {
 // Calling channel() with an invalid channel name should return an error.
 func TestSyncFunctionRejectsInvalidChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(["foo", "bad,name","baz"])}`, 0)
-	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser)
+	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.True(t, err != nil)
 }
 
 // Calling access() with an invalid channel name should return an error.
 func TestAccessFunctionRejectsInvalidChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("foo", "bad,name");}`, 0)
-	_, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	_, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.True(t, err != nil)
 }
 
 // Just verify that the calls to the access() fn show up in the output channel list.
 func TestAccessFunctionTakesArrayOfUsers(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(["foo","bar","baz"], "ginger")}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"bar": BaseSetOf(t, "ginger"), "baz": BaseSetOf(t, "ginger"), "foo": BaseSetOf(t, "ginger")}, res.Access)
 }
@@ -105,14 +105,14 @@ func TestAccessFunctionTakesArrayOfUsers(t *testing.T) {
 // Just verify that the calls to the access() fn show up in the output channel list.
 func TestAccessFunctionTakesArrayOfChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", ["ginger", "earl_grey", "green"])}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"lee": BaseSetOf(t, "ginger", "earl_grey", "green")}, res.Access)
 }
 
 func TestAccessFunctionTakesArrayOfChannelsAndUsers(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(["lee", "nancy"], ["ginger", "earl_grey", "green"])}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "ginger", "earl_grey", "green"), res.Access["lee"])
 	assert.Equal(t, BaseSetOf(t, "ginger", "earl_grey", "green"), res.Access["nancy"])
@@ -120,42 +120,42 @@ func TestAccessFunctionTakesArrayOfChannelsAndUsers(t *testing.T) {
 
 func TestAccessFunctionTakesEmptyArrayUser(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access([], ["ginger", "earl grey", "green"])}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
 }
 
 func TestAccessFunctionTakesEmptyArrayChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", [])}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
 }
 
 func TestAccessFunctionTakesNullUser(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(null, ["ginger", "earl grey", "green"])}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
 }
 
 func TestAccessFunctionTakesNullChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", null)}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
 }
 
 func TestAccessFunctionTakesNonChannelsInArray(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", ["ginger", null, 5])}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"lee": BaseSetOf(t, "ginger")}, res.Access)
 }
 
 func TestAccessFunctionTakesUndefinedUser(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {var x = {}; access(x.nothing, ["ginger", "earl grey", "green"])}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
 }
@@ -164,7 +164,7 @@ func TestAccessFunctionTakesUndefinedUser(t *testing.T) {
 // implementation with access(), so most of the above tests also apply to it.)
 func TestRoleFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {role(["foo","bar","baz"], "role:froods")}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"bar": BaseSetOf(t, "froods"), "baz": BaseSetOf(t, "froods"), "foo": BaseSetOf(t, "froods")}, res.Roles)
 }
@@ -172,7 +172,7 @@ func TestRoleFunction(t *testing.T) {
 // Now just make sure the input comes through intact
 func TestInputParse(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.channel);}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "foo"}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "foo"}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo"), res.Channels)
 }
@@ -180,11 +180,11 @@ func TestInputParse(t *testing.T) {
 // A more realistic example
 func TestDefaultChannelMapper(t *testing.T) {
 	mapper := NewDefaultChannelMapper()
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo", "bar", "baz"), res.Channels)
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"x": "y"}`), `{}`, emptyMetaMap(), noUser)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"x": "y"}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.Set{}, res.Channels)
 }
@@ -192,7 +192,7 @@ func TestDefaultChannelMapper(t *testing.T) {
 // Empty/no-op channel mapper fn
 func TestEmptyChannelMapper(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.Set{}, res.Channels)
 }
@@ -202,7 +202,7 @@ func TestChannelMapperUnderscoreLib(t *testing.T) {
 	underscore.Enable() // It really slows down unit tests (by making otto.New take a lot longer)
 	defer underscore.Disable()
 	mapper := NewChannelMapper(`function(doc) {channel(_.first(doc.channels));}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo"), res.Channels)
 }
@@ -210,7 +210,7 @@ func TestChannelMapperUnderscoreLib(t *testing.T) {
 // Validation by calling reject()
 func TestChannelMapperReject(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {reject(403, "bad");}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, "bad"), res.Rejection)
 }
@@ -218,7 +218,7 @@ func TestChannelMapperReject(t *testing.T) {
 // Rejection by calling throw()
 func TestChannelMapperThrow(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {throw({forbidden:"bad"});}`, 0)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, "bad"), res.Rejection)
 }
@@ -226,14 +226,14 @@ func TestChannelMapperThrow(t *testing.T) {
 // Test other runtime exception
 func TestChannelMapperException(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {(nil)[5];}`, 0)
-	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
+	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.True(t, err != nil)
 }
 
 // Test the public API
 func TestPublicChannelMapper(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.channels);}`, 0)
-	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
+	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo", "bar", "baz"), output.Channels)
 }
@@ -244,16 +244,16 @@ func TestCheckUser(t *testing.T) {
 			requireUser(doc.owner);
 		}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "channels": []string{}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, emptyMetaMap(), sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, emptyMetaMap(), sally, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 
 	var linus = map[string]interface{}{"name": "linus", "channels": []string{}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, emptyMetaMap(), linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, emptyMetaMap(), linus, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, base.SyncFnErrorWrongUser), res.Rejection)
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, emptyMetaMap(), nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, emptyMetaMap(), nil, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 }
@@ -264,16 +264,16 @@ func TestCheckUserArray(t *testing.T) {
 			requireUser(doc.owners);
 		}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "channels": []string{}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, emptyMetaMap(), sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, emptyMetaMap(), sally, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 
 	var linus = map[string]interface{}{"name": "linus", "channels": []string{}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, emptyMetaMap(), linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, emptyMetaMap(), linus, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, base.SyncFnErrorWrongUser), res.Rejection)
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally"]}`), `{}`, emptyMetaMap(), nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally"]}`), `{}`, emptyMetaMap(), nil, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 }
@@ -284,16 +284,16 @@ func TestCheckRole(t *testing.T) {
 			requireRole(doc.role);
 		}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "roles": map[string]int{"girl": 1, "5yo": 1}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, emptyMetaMap(), sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, emptyMetaMap(), sally, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": []string{"boy", "musician"}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, emptyMetaMap(), linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, emptyMetaMap(), linus, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, base.SyncFnErrorMissingRole), res.Rejection)
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, emptyMetaMap(), nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, emptyMetaMap(), nil, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 }
@@ -304,16 +304,16 @@ func TestCheckRoleArray(t *testing.T) {
 			requireRole(doc.roles);
 		}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "roles": map[string]int{"girl": 1, "5yo": 1}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"roles": ["kid","girl"]}`), `{}`, emptyMetaMap(), sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"roles": ["kid","girl"]}`), `{}`, emptyMetaMap(), sally, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": map[string]int{"boy": 1, "musician": 1}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, emptyMetaMap(), linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, emptyMetaMap(), linus, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, base.SyncFnErrorMissingRole), res.Rejection)
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, emptyMetaMap(), nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, emptyMetaMap(), nil, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 }
@@ -324,16 +324,16 @@ func TestCheckAccess(t *testing.T) {
 		requireAccess(doc.channel)
 	}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "roles": []string{"girl", "5yo"}, "channels": []string{"party", "school"}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "party"}`), `{}`, emptyMetaMap(), sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "party"}`), `{}`, emptyMetaMap(), sally, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": []string{"boy", "musician"}, "channels": []string{"party", "school"}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "work"}`), `{}`, emptyMetaMap(), linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "work"}`), `{}`, emptyMetaMap(), linus, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, base.SyncFnErrorMissingChannelAccess), res.Rejection)
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "magic"}`), `{}`, emptyMetaMap(), nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "magic"}`), `{}`, emptyMetaMap(), nil, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 }
@@ -344,16 +344,16 @@ func TestCheckAccessArray(t *testing.T) {
 		requireAccess(doc.channels)
 	}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "roles": []string{"girl", "5yo"}, "channels": []string{"party", "school"}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["swim","party"]}`), `{}`, emptyMetaMap(), sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["swim","party"]}`), `{}`, emptyMetaMap(), sally, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": []string{"boy", "musician"}, "channels": []string{"party", "school"}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["work"]}`), `{}`, emptyMetaMap(), linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["work"]}`), `{}`, emptyMetaMap(), linus, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, base.SyncFnErrorMissingChannelAccess), res.Rejection)
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["magic"]}`), `{}`, emptyMetaMap(), nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["magic"]}`), `{}`, emptyMetaMap(), nil, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, nil, res.Rejection)
 }
@@ -361,111 +361,127 @@ func TestCheckAccessArray(t *testing.T) {
 // Test changing the function
 func TestSetFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.channels);}`, 0)
-	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
+	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
+	assert.Equal(t, BaseSetOf(t, "foo", "bar", "baz"), output.Channels)
+
 	changed, err := mapper.SetFunction(`function(doc) {channel("all");}`)
 	assert.True(t, changed, "SetFunction failed")
 	assert.NoError(t, err, "SetFunction failed")
-	output, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
+	output, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "all"), output.Channels)
+}
+
+func TestMapToChannelsAndAccessAddStarChannel(t *testing.T) {
+	mapper := NewChannelMapper(`function(doc) {channel(doc.channels);}`, 0)
+	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, true)
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
+	assert.Equal(t, BaseSetOf(t, "foo", "bar", "baz", "*"), output.Channels)
+
+	changed, err := mapper.SetFunction(`function(doc) {channel("all");}`)
+	assert.True(t, changed, "SetFunction failed")
+	assert.NoError(t, err, "SetFunction failed")
+	output, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser, true)
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
+	assert.Equal(t, BaseSetOf(t, "all", "*"), output.Channels)
 }
 
 // Test that expiry function sets the expiry property
 func TestExpiryFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {expiry(doc.expiry);}`, 0)
-	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, emptyMetaMap(), noUser)
+	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(100), *res1.Expiry)
 
-	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, emptyMetaMap(), noUser)
+	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(500), *res2.Expiry)
 
-	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"2105-01-01T00:00:00.000+00:00"}`), `{}`, emptyMetaMap(), noUser)
+	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"2105-01-01T00:00:00.000+00:00"}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(4260211200), *res_stringDate.Expiry)
 
 	// Validate invalid expiry values log warning and don't set expiry
-	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, emptyMetaMap(), noUser)
+	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:abc")
 	assert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
-	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, emptyMetaMap(), noUser)
+	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as array")
 	assert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
-	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, emptyMetaMap(), noUser)
+	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as negative value")
 	assert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
-	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, emptyMetaMap(), noUser)
+	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry > unit32")
 	assert.True(t, res6.Expiry == nil)
 
 	// Invalid - non-unix date
-	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"1805-01-01T00:00:00.000+00:00"}`), `{}`, emptyMetaMap(), noUser)
+	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"1805-01-01T00:00:00.000+00:00"}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:1805-01-01T00:00:00.000+00:00")
 	assert.True(t, resInvalidDate.Expiry == nil)
 
 	// No expiry specified
-	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, emptyMetaMap(), noUser)
+	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry not specified")
 	assert.True(t, res7.Expiry == nil)
 }
 
 func TestExpiryFunctionConstantValue(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {expiry(100);}`, 0)
-	res1, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res1, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(100), *res1.Expiry)
 
 	mapper = NewChannelMapper(`function(doc) {expiry("500");}`, 0)
-	res2, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res2, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(500), *res2.Expiry)
 
 	mapper = NewChannelMapper(`function(doc) {expiry("2105-01-01T00:00:00.000+00:00");}`, 0)
-	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(4260211200), *res_stringDate.Expiry)
 
 	// Validate invalid expiry values log warning and don't set expiry
 	mapper = NewChannelMapper(`function(doc) {expiry("abc");}`, 0)
-	res3, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res3, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:abc")
 	assert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
 	mapper = NewChannelMapper(`function(doc) {expiry(["100", "200"]);}`, 0)
-	res4, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res4, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as array")
 	assert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
 	mapper = NewChannelMapper(`function(doc) {expiry(-100);}`, 0)
-	res5, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res5, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as negative value")
 	assert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
 	mapper = NewChannelMapper(`function(doc) {expiry(123456789012345);}`, 0)
-	res6, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res6, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as > unit32")
 	assert.True(t, res6.Expiry == nil)
 
 	// Invalid - non-unix date
 	mapper = NewChannelMapper(`function(doc) {expiry("1805-01-01T00:00:00.000+00:00");}`, 0)
-	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:1805-01-01T00:00:00.000+00:00")
 	assert.True(t, resInvalidDate.Expiry == nil)
 
 	// No expiry specified
 	mapper = NewChannelMapper(`function(doc) {expiry();}`, 0)
-	res7, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
+	res7, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry not specified")
 	assert.True(t, res7.Expiry == nil)
 }
@@ -473,36 +489,36 @@ func TestExpiryFunctionConstantValue(t *testing.T) {
 // Test that expiry function when invoked more than once by sync function
 func TestExpiryFunctionMultipleInvocation(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {expiry(doc.expiry); expiry(doc.secondExpiry)}`, 0)
-	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, emptyMetaMap(), noUser)
+	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, uint32(100), *res1.Expiry)
 
-	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, emptyMetaMap(), noUser)
+	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, uint32(500), *res2.Expiry)
 
 	// Validate invalid expiry values log warning and don't set expiry
-	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, emptyMetaMap(), noUser)
+	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry:abc")
 	assert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
-	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, emptyMetaMap(), noUser)
+	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	assert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
-	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, emptyMetaMap(), noUser)
+	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	assert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
-	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, emptyMetaMap(), noUser)
+	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	assert.True(t, res6.Expiry == nil)
 
 	// No expiry specified
-	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, emptyMetaMap(), noUser)
+	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, emptyMetaMap(), noUser, false)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	assert.True(t, res7.Expiry == nil)
 }
@@ -520,7 +536,7 @@ func TestMetaMap(t *testing.T) {
 		},
 	}
 
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, metaMap, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, metaMap, noUser, false)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, res.Channels.ToArray(), channels)
 }
@@ -535,7 +551,7 @@ func TestNilMetaMap(t *testing.T) {
 		},
 	}
 
-	_, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, metaMap, noUser)
+	_, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, metaMap, noUser, false)
 	require.Error(t, err)
 	assert.True(t, err.Error() == "TypeError: Cannot access member 'val' of undefined")
 }

--- a/db/background_mgr_resync.go
+++ b/db/background_mgr_resync.go
@@ -48,6 +48,7 @@ func (r *ResyncManager) Run(ctx context.Context, options map[string]interface{},
 	database := options["database"].(*Database)
 	regenerateSequences := options["regenerateSequences"].(bool)
 	resyncCollections := options["collections"].(ResyncCollections)
+	shouldAddStarChannel := options["shouldAddStarChannel"].(bool)
 
 	persistClusterStatus := func() {
 		err := persistClusterStatusCallback()
@@ -76,7 +77,7 @@ func (r *ResyncManager) Run(ctx context.Context, options map[string]interface{},
 	for _, collectionID := range collectionIDs {
 		_, err := (&DatabaseCollectionWithUser{
 			DatabaseCollection: database.CollectionByID[collectionID],
-		}).UpdateAllDocChannels(ctx, regenerateSequences, callback, terminator)
+		}).UpdateAllDocChannels(ctx, regenerateSequences, callback, terminator, shouldAddStarChannel)
 		if err != nil {
 			return err
 		}

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -91,6 +91,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 	db := options["database"].(*Database)
 	regenerateSequences := options["regenerateSequences"].(bool)
 	resyncCollections := options["collections"].(ResyncCollections)
+	shouldAddStarChannel := options["shouldAddStarChannel"].(bool)
 
 	resyncLoggingID := "Resync: " + r.ResyncID
 
@@ -125,7 +126,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 		databaseCollection := db.CollectionByID[event.CollectionID]
 		_, unusedSequences, err := (&DatabaseCollectionWithUser{
 			DatabaseCollection: databaseCollection,
-		}).resyncDocument(ctx, docID, key, regenerateSequences, []uint64{})
+		}).resyncDocument(ctx, docID, key, regenerateSequences, []uint64{}, shouldAddStarChannel)
 
 		databaseCollection.releaseSequences(ctx, unusedSequences)
 

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -109,7 +109,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 		var err error
 		docID := string(event.Key)
 		key := realDocID(docID)
-		base.TracefCtx(ctx, base.KeyAll, "[%s] Received DCP event %d for doc %v", resyncLoggingID, event.Opcode, base.UD(docID))
+		base.DebugfCtx(ctx, base.KeyAll, "[%s] Received DCP event %d for doc %v", resyncLoggingID, event.Opcode, base.UD(docID))
 		// Don't want to process raw binary docs
 		// The binary check should suffice but for additional safety also check for empty bodies
 		if event.DataType == base.MemcachedDataTypeRaw || len(event.Value) == 0 {

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -155,9 +155,10 @@ func TestResyncManagerDCPStopInMidWay(t *testing.T) {
 	defer resycMgr.resetStatus()
 
 	options := map[string]interface{}{
-		"database":            db,
-		"regenerateSequences": false,
-		"collections":         ResyncCollections{},
+		"database":             db,
+		"regenerateSequences":  false,
+		"collections":          ResyncCollections{},
+		"shouldAddStarChannel": true,
 	}
 
 	err := resycMgr.Start(ctx, options)
@@ -208,9 +209,10 @@ func TestResyncManagerDCPStart(t *testing.T) {
 		db.ResyncManager = resyncMgr
 
 		options := map[string]interface{}{
-			"database":            db,
-			"regenerateSequences": false,
-			"collections":         ResyncCollections{},
+			"database":             db,
+			"regenerateSequences":  false,
+			"collections":          ResyncCollections{},
+			"shouldAddStarChannel": true,
 		}
 		err := resyncMgr.Start(ctx, options)
 		require.NoError(t, err)
@@ -242,9 +244,10 @@ func TestResyncManagerDCPStart(t *testing.T) {
 		log.Printf("initialStats: processed[%v] changed[%v]", initialStats.DocsProcessed, initialStats.DocsChanged)
 
 		options := map[string]interface{}{
-			"database":            db,
-			"regenerateSequences": false,
-			"collections":         ResyncCollections{},
+			"database":             db,
+			"regenerateSequences":  false,
+			"collections":          ResyncCollections{},
+			"shouldAddStarChannel": true,
 		}
 
 		err := resyncMgr.Start(ctx, options)
@@ -282,9 +285,10 @@ func TestResyncManagerDCPRunTwice(t *testing.T) {
 	db.ResyncManager = resycMgr
 
 	options := map[string]interface{}{
-		"database":            db,
-		"regenerateSequences": false,
-		"collections":         ResyncCollections{},
+		"database":             db,
+		"regenerateSequences":  false,
+		"collections":          ResyncCollections{},
+		"shouldAddStarChannel": true,
 	}
 
 	err := resycMgr.Start(ctx, options)
@@ -333,9 +337,10 @@ func TestResycnManagerDCPResumeStoppedProcess(t *testing.T) {
 	db.ResyncManager = resycMgr
 
 	options := map[string]interface{}{
-		"database":            db,
-		"regenerateSequences": false,
-		"collections":         ResyncCollections{},
+		"database":             db,
+		"regenerateSequences":  false,
+		"collections":          ResyncCollections{},
+		"shouldAddStarChannel": true,
 	}
 
 	err := resycMgr.Start(ctx, options)

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -322,7 +322,7 @@ func TestResyncManagerDCPRunTwice(t *testing.T) {
 	assert.Equal(t, db.DbStats.Database().SyncFunctionCount.Value(), int64(docsToCreate))
 }
 
-func TestResycnManagerDCPResumeStoppedProcess(t *testing.T) {
+func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server")
 	}

--- a/db/database.go
+++ b/db/database.go
@@ -128,6 +128,7 @@ type DatabaseContext struct {
 	singleCollection             *DatabaseCollection            // Temporary collection
 	CollectionByID               map[uint32]*DatabaseCollection // A map keyed by collection ID to Collection
 	CollectionNames              map[string]map[string]struct{} // Map of scope, collection names
+	AllDocsIndexExists           bool
 }
 
 type Scope struct {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2456,7 +2456,7 @@ func TestResyncUpdateAllDocChannels(t *testing.T) {
 		return state == DBOffline
 	})
 
-	_, err = collection.UpdateAllDocChannels(ctx, false, func(docsProcessed, docsChanged *int) {}, base.NewSafeTerminator())
+	_, err = collection.UpdateAllDocChannels(ctx, false, func(docsProcessed, docsChanged *int) {}, base.NewSafeTerminator(), false)
 	assert.NoError(t, err)
 
 	syncFnCount := int(db.DbStats.Database().SyncFunctionCount.Value())
@@ -2809,7 +2809,7 @@ func Test_resyncDocument(t *testing.T) {
 			_, err = db.UpdateSyncFun(ctx, syncFn)
 			require.NoError(t, err)
 
-			_, _, err = collection.resyncDocument(ctx, docID, realDocID(docID), false, []uint64{10})
+			_, _, err = collection.resyncDocument(ctx, docID, realDocID(docID), false, []uint64{10}, false)
 			require.NoError(t, err)
 			err = collection.WaitForPendingChanges(ctx)
 			require.NoError(t, err)
@@ -2854,7 +2854,7 @@ func Test_getUpdatedDocument(t *testing.T) {
 		require.NoError(t, err)
 
 		collection := GetSingleDatabaseCollectionWithUser(t, db)
-		_, _, _, _, _, err = collection.getResyncedDocument(ctx, doc, false, []uint64{})
+		_, _, _, _, _, err = collection.getResyncedDocument(ctx, doc, false, []uint64{}, false)
 		assert.Equal(t, base.ErrUpdateCancel, err)
 	})
 
@@ -2888,14 +2888,14 @@ func Test_getUpdatedDocument(t *testing.T) {
 		_, err = db.UpdateSyncFun(ctx, syncFn)
 		require.NoError(t, err)
 
-		updatedDoc, shouldUpdate, _, highSeq, _, err := collection.getResyncedDocument(ctx, doc, false, []uint64{})
+		updatedDoc, shouldUpdate, _, highSeq, _, err := collection.getResyncedDocument(ctx, doc, false, []uint64{}, false)
 		require.NoError(t, err)
 		assert.True(t, shouldUpdate)
 		assert.Equal(t, doc.Sequence, highSeq)
 		assert.Equal(t, 2, int(db.DbStats.Database().SyncFunctionCount.Value()))
 
 		// Rerunning same resync function should mark doc not to be updated
-		_, shouldUpdate, _, _, _, err = collection.getResyncedDocument(ctx, updatedDoc, false, []uint64{})
+		_, shouldUpdate, _, _, _, err = collection.getResyncedDocument(ctx, updatedDoc, false, []uint64{}, false)
 		require.NoError(t, err)
 		assert.False(t, shouldUpdate)
 		assert.Equal(t, 3, int(db.DbStats.Database().SyncFunctionCount.Value()))

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2813,7 +2813,7 @@ func Test_resyncDocument(t *testing.T) {
 			_, err = db.UpdateSyncFun(ctx, syncFn)
 			require.NoError(t, err)
 
-			_, _, err = collection.resyncDocument(ctx, docID, realDocID(docID), false, []uint64{10}, false)
+			_, _, err = collection.resyncDocument(ctx, docID, realDocID(docID), false, []uint64{10}, true)
 			require.NoError(t, err)
 			err = collection.WaitForPendingChanges(ctx)
 			require.NoError(t, err)
@@ -2821,8 +2821,8 @@ func Test_resyncDocument(t *testing.T) {
 			syncData, err := collection.GetDocSyncData(ctx, docID)
 			assert.NoError(t, err)
 
-			assert.Len(t, syncData.ChannelSet, 2)
-			assert.Len(t, syncData.Channels, 2)
+			assert.Len(t, syncData.ChannelSet, 3)
+			assert.Len(t, syncData.Channels, 3)
 			found := false
 
 			for _, chSet := range syncData.ChannelSet {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -824,7 +824,10 @@ func TestAllDocsOnly(t *testing.T) {
 		revid, _, err := collection.Put(ctx, ids[i].DocID, body)
 		ids[i].RevID = revid
 		ids[i].Sequence = uint64(i + 1)
-		ids[i].Channels = channels
+		// `*` channels gets added to docs for new creation.
+		// add `*` channel to expected channels
+		ids[i].Channels = append(channels, "*")
+
 		assert.NoError(t, err, "Couldn't create document")
 	}
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1389,11 +1389,12 @@ func TestSyncFnOnPush(t *testing.T) {
 	// Check that the doc has the correct channel (test for issue #300)
 	doc, err := collection.GetDocument(ctx, "doc1", DocUnmarshalAll)
 	assert.Equal(t, channels.ChannelMap{
+		"*":      nil,
 		"clibup": nil,
 		"public": &channels.ChannelRemoval{Seq: 2, RevID: "4-four"},
 	}, doc.Channels)
 
-	assert.Equal(t, base.SetOf("clibup"), doc.History["4-four"].Channels)
+	assert.Equal(t, base.SetOf("*", "clibup"), doc.History["4-four"].Channels)
 }
 
 func TestInvalidChannel(t *testing.T) {
@@ -2456,7 +2457,7 @@ func TestResyncUpdateAllDocChannels(t *testing.T) {
 		return state == DBOffline
 	})
 
-	_, err = collection.UpdateAllDocChannels(ctx, false, func(docsProcessed, docsChanged *int) {}, base.NewSafeTerminator(), false)
+	_, err = collection.UpdateAllDocChannels(ctx, false, func(docsProcessed, docsChanged *int) {}, base.NewSafeTerminator(), !db.AllDocsIndexExists)
 	assert.NoError(t, err)
 
 	syncFnCount := int(db.DbStats.Database().SyncFunctionCount.Value())

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -329,7 +329,7 @@ func filterViewResult(input sgbucket.ViewResult, user auth.User, applyChannelFil
 // Is any item of channels found in visibleChannels?
 func channelsIntersect(visibleChannels ch.TimedSet, channels []interface{}) bool {
 	for _, channel := range channels {
-		if visibleChannels.Contains(channel.(string)) || channel == "*" {
+		if visibleChannels.Contains(channel.(string)) {
 			return true
 		}
 	}

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -482,9 +482,13 @@ func installViews(ctx context.Context, viewStore sgbucket.ViewStore) error {
 						if (channels) {
 							for (var name in channels) {
 								removed = channels[name];
-								if (!removed)
+								// if EnableStarChannelLog= true and "*" is added because AllDocs index isn't created
+								// Skip emiting "*" again as above lines has emitted "*" channel
+								if (name == "*" && %v) // EnableStarChannelLog
+									continue
+								if (!removed) {
 									emit([name, sequence], value);
-								else {
+								} else {
 									var flags = removed.del ? %d : %d; // channels.Removed/Deleted
 									emit([name, removed.seq], {rev:removed.rev, flags: flags});
 								}
@@ -492,7 +496,7 @@ func installViews(ctx context.Context, viewStore sgbucket.ViewStore) error {
 						}
 					}`
 
-	channels_map = fmt.Sprintf(channels_map, syncData, base.SyncDocPrefix, ch.Deleted, EnableStarChannelLog,
+	channels_map = fmt.Sprintf(channels_map, syncData, base.SyncDocPrefix, ch.Deleted, EnableStarChannelLog, EnableStarChannelLog,
 		ch.Removed|ch.Deleted, ch.Removed)
 
 	// Channel access view, used by ComputeChannelsForPrincipal()

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -135,7 +135,7 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	log.Printf("removedIndexes: %+v", removedIndexes)
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in setup case")
 
-	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false, db.IsServerless())
+	_, err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false, db.IsServerless())
 	assert.NoError(t, err)
 
 	// Running w/ opposite xattrs flag should preview removal of the indexes associated with this db context
@@ -154,7 +154,7 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in post-cleanup no-op")
 
 	// Restore indexes after test
-	err = InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false, db.IsServerless())
+	_, err = InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false, db.IsServerless())
 	assert.NoError(t, err)
 }
 
@@ -197,7 +197,7 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes with hacked sgIndexes")
 
 	// Restore indexes after test
-	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false, db.IsServerless())
+	_, err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false, db.IsServerless())
 	assert.NoError(t, err)
 
 }
@@ -311,7 +311,7 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Restore indexes after test
-	err = InitializeIndexes(n1QLStore, db.UseXattrs(), 0, false, db.IsServerless())
+	_, err = InitializeIndexes(n1QLStore, db.UseXattrs(), 0, false, db.IsServerless())
 	assert.NoError(t, err)
 }
 
@@ -334,7 +334,7 @@ func TestRemoveObsoleteIndexOnError(t *testing.T) {
 		// Restore indexes after test
 		n1qlStore, ok := base.AsN1QLStore(dataStore)
 		assert.True(t, ok)
-		err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false, db.IsServerless())
+		_, err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0, false, db.IsServerless())
 		assert.NoError(t, err)
 
 	}()
@@ -387,7 +387,7 @@ func dropAndInitializeIndexes(ctx context.Context, n1qlStore base.N1QLStore, xat
 		return dropErr
 	}
 
-	initErr := InitializeIndexes(n1qlStore, xattrs, 0, false, isServerless)
+	_, initErr := InitializeIndexes(n1qlStore, xattrs, 0, false, isServerless)
 	if initErr != nil {
 		return initErr
 	}

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -232,7 +232,7 @@ func TestPostUpgradeMultipleCollections(t *testing.T) {
 	for _, dataStore := range db.getDataStores() {
 		n1qlStore, ok := base.AsN1QLStore(dataStore)
 		assert.True(t, ok)
-		err := InitializeIndexes(n1qlStore, useXattrs, 0, false, false)
+		_, err := InitializeIndexes(n1qlStore, useXattrs, 0, false, false)
 		require.NoError(t, err)
 	}
 

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -459,7 +459,7 @@ func setupN1QLStore(bucket base.Bucket, isServerless bool) ([]base.N1QLStore, re
 			return nil, nil, fmt.Errorf("Unable to get n1QLStore for testBucket")
 		}
 
-		if err := db.InitializeIndexes(n1QLStore, base.TestUseXattrs(), 0, false, isServerless); err != nil {
+		if _, err := db.InitializeIndexes(n1QLStore, base.TestUseXattrs(), 0, false, isServerless); err != nil {
 			return nil, nil, err
 		}
 		outN1QLStores = append(outN1QLStores, n1QLStore)

--- a/db/query.go
+++ b/db/query.go
@@ -555,7 +555,7 @@ func (context *DatabaseCollection) buildChannelsQuery(channelName string, startS
 
 	channelQuery := QueryChannels
 	index := sgIndexes[IndexChannels]
-	if channelName == channels.UserStarChannel {
+	if channelName == channels.UserStarChannel && context.dbCtx.AllDocsIndexExists {
 		channelQuery = QueryStarChannel
 		index = sgIndexes[IndexAllDocs]
 	}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -344,7 +344,7 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 			return err
 		}
 		tbp.Logf(ctx, "creating SG bucket indexes")
-		if err := InitializeIndexes(n1qlStore, base.TestUseXattrs(), 0, false, false); err != nil {
+		if _, err := InitializeIndexes(n1qlStore, base.TestUseXattrs(), 0, false, false); err != nil {
 			return err
 		}
 

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -138,7 +138,7 @@ func TestStarAccess(t *testing.T) {
 
 	// GET /db/_all_docs?channels=true
 	// Check that _all_docs returns the docs the user has access to:
-	response = rt.SendUserRequest("GET", "/db/_all_docs?channels=true", "", "bernard")
+	response = rt.SendUserRequest("GET", "/{{.keyspace}}/_all_docs?channels=true", "", "bernard")
 	if isAllDocsIndexExist {
 		RequireStatus(t, response, 200)
 
@@ -216,7 +216,7 @@ func TestStarAccess(t *testing.T) {
 
 	// GET /db/_all_docs?channels=true
 	// Check that _all_docs returns all docs (based on user * channel)
-	response = rt.SendUserRequest("GET", "/db/_all_docs?channels=true", "", "fran")
+	response = rt.SendUserRequest("GET", "/{{.keyspace}}/_all_docs?channels=true", "", "fran")
 	if isAllDocsIndexExist {
 		RequireStatus(t, response, 200)
 
@@ -266,7 +266,7 @@ func TestStarAccess(t *testing.T) {
 
 	// GET /db/_all_docs?channels=true
 	// Check that _all_docs only returns ! docs (based on doc ! channel)
-	response = rt.SendUserRequest("GET", "/db/_all_docs?channels=true", "", "manny")
+	response = rt.SendUserRequest("GET", "/{{.keyspace}}/_all_docs?channels=true", "", "manny")
 	if isAllDocsIndexExist {
 		RequireStatus(t, response, 200)
 		log.Printf("Response = %s", response.Body.Bytes())

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -973,7 +973,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	changed, err := database.UpdateSyncFun(ctx, `function(doc) {access("alice", "beta");channel("beta");}`)
 	assert.NoError(t, err)
 	assert.True(t, changed)
-	changeCount, err := collectionWithUser.UpdateAllDocChannels(ctx, false, func(docsProcessed, docsChanged *int) {}, base.NewSafeTerminator())
+	changeCount, err := collectionWithUser.UpdateAllDocChannels(ctx, false, func(docsProcessed, docsChanged *int) {}, base.NewSafeTerminator(), false)
 	assert.NoError(t, err)
 	assert.Equal(t, 9, changeCount)
 

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -2223,8 +2223,8 @@ func TestRawRedaction(t *testing.T) {
 	err := base.JSONUnmarshal(res.Body.Bytes(), &body)
 	assert.NoError(t, err)
 	syncData := body[base.SyncPropertyName]
-	assert.Equal(t, map[string]interface{}{"achannel": nil}, syncData.(map[string]interface{})["channels"])
-	assert.Equal(t, []interface{}([]interface{}{[]interface{}{"achannel"}}), syncData.(map[string]interface{})["history"].(map[string]interface{})["channels"])
+	assert.Equal(t, map[string]interface{}{"achannel": nil, "*": nil}, syncData.(map[string]interface{})["channels"])
+	assert.Equal(t, []interface{}([]interface{}{[]interface{}{"*", "achannel"}}), syncData.(map[string]interface{})["history"].(map[string]interface{})["channels"])
 
 	// Test redacted
 	body = map[string]interface{}{}

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -120,6 +120,10 @@ func TestCollectionsPublicChannel(t *testing.T) {
 	})
 	defer rt.Close()
 
+	if !rt.ServerContext().IsAllDocsIndexExistFor(rt.GetDatabase().Name) {
+		t.Skip("This test requires AllDocs index to be present")
+	}
+
 	pathPublic := "/{{.keyspace}}/docpublic"
 	resp := rt.SendAdminRequest(http.MethodPut, pathPublic, `{"channels":["!"]}`)
 	RequireStatus(t, resp, http.StatusCreated)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1116,6 +1116,10 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
+	if !rt.ServerContext().IsAllDocsIndexExistFor(rt.GetDatabase().Name) {
+		t.Skip("This test requires AllDocs index to be present")
+	}
+
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 	guest, err := a.GetUser("")

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -27,6 +27,16 @@ import (
 
 // HTTP handler for _all_docs
 func (h *handler) handleAllDocs() error {
+	dbName := h.db.Bucket.GetName()
+
+	if h.server.databases_[dbName] == nil {
+		return base.HTTPErrorf(http.StatusInternalServerError, "could not find database context for %s", dbName)
+	}
+
+	if !h.server.databases_[dbName].AllDocsIndexExists {
+		return base.HTTPErrorf(http.StatusBadRequest, "_all_docs endpoint is only available when '*' Channel is enabled. set 'cache.channel_cache.enable_star_channel':true in Sync Gateway's database config.")
+	}
+
 	// http://wiki.apache.org/couchdb/HTTP_Bulk_Document_API
 	includeDocs := h.getBoolQuery("include_docs")
 	includeChannels := h.getBoolQuery("channels")

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -27,14 +27,14 @@ import (
 
 // HTTP handler for _all_docs
 func (h *handler) handleAllDocs() error {
-	dbName := h.db.Bucket.GetName()
+	dbName := h.db.Name
 
 	if h.server.databases_[dbName] == nil {
 		return base.HTTPErrorf(http.StatusInternalServerError, "could not find database context for %s", dbName)
 	}
 
-	if !h.server.databases_[dbName].AllDocsIndexExists {
-		return base.HTTPErrorf(http.StatusBadRequest, "_all_docs endpoint is only available when '*' Channel is enabled. set 'cache.channel_cache.enable_star_channel':true in Sync Gateway's database config.")
+	if !h.server.IsAllDocsIndexExistFor(dbName) {
+		return base.HTTPErrorf(http.StatusBadRequest, "all_docs endpoint is not available for db %s", dbName)
 	}
 
 	// http://wiki.apache.org/couchdb/HTTP_Bulk_Document_API

--- a/rest/doc_api_test.go
+++ b/rest/doc_api_test.go
@@ -105,6 +105,8 @@ func TestDocumentNumbers(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
+	shouldExpectStarChannel := !rt.GetDatabase().AllDocsIndexExists
+
 	for _, test := range tests {
 		t.Run(test.name, func(ts *testing.T) {
 			// Create document
@@ -126,7 +128,11 @@ func TestDocumentNumbers(t *testing.T) {
 			var rawResponse RawResponse
 			require.NoError(ts, base.JSONUnmarshal(getRawResponse.Body.Bytes(), &rawResponse))
 			log.Printf("raw response: %s", getRawResponse.Body.Bytes())
-			assert.Equal(ts, 1, len(rawResponse.Sync.Channels))
+			if shouldExpectStarChannel {
+				assert.Equal(ts, 2, len(rawResponse.Sync.Channels))
+			} else {
+				assert.Equal(ts, 1, len(rawResponse.Sync.Channels))
+			}
 			assert.True(ts, HasActiveChannel(rawResponse.Sync.Channels, test.expectedFormatChannel), fmt.Sprintf("Expected channel %s was not found in document channels (%s)", test.expectedFormatChannel, test.name))
 
 		})

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -467,15 +467,16 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		useViews = true
 	}
 
+	isAllDocsIndexCreated := false
 	// initDataStore is a function to initialize Views or GSI indexes for a datastore
-	initDataStore := func(ds base.DataStore) error {
+	initDataStore := func(ds base.DataStore) (bool, error) {
 		if useViews {
-			return db.InitializeViews(ctx, ds)
+			return true, db.InitializeViews(ctx, ds)
 		}
 
 		gsiSupported := bucket.IsSupported(sgbucket.BucketStoreFeatureN1ql)
 		if !gsiSupported {
-			return errors.New("Sync Gateway was unable to connect to a query node on the provided Couchbase Server cluster.  Ensure a query node is accessible, or set 'use_views':true in Sync Gateway's database config.")
+			return false, errors.New("Sync Gateway was unable to connect to a query node on the provided Couchbase Server cluster.  Ensure a query node is accessible, or set 'use_views':true in Sync Gateway's database config.")
 		}
 
 		numReplicas := DefaultNumIndexReplicas
@@ -484,15 +485,15 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		}
 		n1qlStore, ok := base.AsN1QLStore(ds)
 		if !ok {
-			return errors.New("Cannot create indexes on non-Couchbase data store.")
+			return false, errors.New("Cannot create indexes on non-Couchbase data store.")
 
 		}
-		indexErr := db.InitializeIndexes(n1qlStore, config.UseXattrs(), numReplicas, false, sc.Config.IsServerless())
+		isAllDocsIndexCreated, indexErr := db.InitializeIndexes(n1qlStore, config.UseXattrs(), numReplicas, false, sc.Config.IsServerless())
 		if indexErr != nil {
-			return indexErr
+			return false, indexErr
 		}
 
-		return nil
+		return isAllDocsIndexCreated, nil
 	}
 
 	if len(config.Scopes) > 0 {
@@ -515,14 +516,14 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 					return nil, fmt.Errorf("attempting to create/update database with a scope/collection that is not found")
 				}
 
-				if err := initDataStore(dataStore); err != nil {
+				if isAllDocsIndexCreated, err = initDataStore(dataStore); err != nil {
 					return nil, err
 				}
 			}
 		}
 	} else {
 		// no scopes configured - init the default data store
-		if err := initDataStore(bucket.DefaultDataStore()); err != nil {
+		if isAllDocsIndexCreated, err = initDataStore(bucket.DefaultDataStore()); err != nil {
 			return nil, err
 		}
 	}
@@ -624,6 +625,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	dbcontext.BucketSpec = spec
 	dbcontext.ServerContextHasStarted = sc.hasStarted
 	dbcontext.NoX509HTTPClient = sc.NoX509HTTPClient
+	dbcontext.AllDocsIndexExists = isAllDocsIndexCreated
 
 	syncFn := ""
 	if config.Sync != nil {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -156,6 +156,11 @@ func (sc *ServerContext) PostStartup() {
 	close(sc.hasStarted)
 }
 
+// IsAllDocsIndexExistFor returns if AllDocs index exists for given db
+func (sc *ServerContext) IsAllDocsIndexExistFor(dbName string) bool {
+	return sc.databases_[dbName] != nil && sc.databases_[dbName].AllDocsIndexExists
+}
+
 // serverContextStopMaxWait is the maximum amount of time to wait for
 // background goroutines to terminate before the server is stopped.
 const serverContextStopMaxWait = 30 * time.Second
@@ -471,7 +476,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	// initDataStore is a function to initialize Views or GSI indexes for a datastore
 	initDataStore := func(ds base.DataStore) (bool, error) {
 		if useViews {
-			return true, db.InitializeViews(ctx, ds)
+			return false, db.InitializeViews(ctx, ds)
 		}
 
 		gsiSupported := bucket.IsSupported(sgbucket.BucketStoreFeatureN1ql)

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -42,6 +42,7 @@ func TestSyncFnBodyProperties(t *testing.T) {
 		testdataKey,
 		db.BodyId,
 		db.BodyRev,
+		"*",
 	}
 
 	// This sync function routes into channels based on top-level properties contained in doc
@@ -84,6 +85,7 @@ func TestSyncFnBodyPropertiesTombstone(t *testing.T) {
 		db.BodyId,
 		db.BodyRev,
 		db.BodyDeleted,
+		"*",
 	}
 
 	// This sync function routes into channels based on top-level properties contained in doc
@@ -131,6 +133,7 @@ func TestSyncFnOldDocBodyProperties(t *testing.T) {
 	expectedProperties := []string{
 		testdataKey,
 		db.BodyId,
+		"*",
 	}
 
 	// This sync function routes into channels based on top-level properties contained in oldDoc
@@ -180,6 +183,7 @@ func TestSyncFnOldDocBodyPropertiesTombstoneResurrect(t *testing.T) {
 		testdataKey,
 		db.BodyId,
 		db.BodyDeleted,
+		"*",
 	}
 
 	// This sync function routes into channels based on top-level properties contained in oldDoc

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1133,6 +1133,8 @@ func TestFunkyUsernames(t *testing.T) {
 			ctx := rt.Context()
 			a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 
+			isAllDocsIndexExist := rt.ServerContext().IsAllDocsIndexExistFor(rt.GetDatabase().Name)
+
 			// Create a test user
 			user, err := a.NewUser(tc.UserName, "letmein", channels.BaseSetOf(t, "foo"))
 			require.NoError(t, err)
@@ -1141,8 +1143,10 @@ func TestFunkyUsernames(t *testing.T) {
 			response := rt.SendUserRequest("PUT", "/{{.keyspace}}/AC+DC", `{"foo":"bar", "channels": ["foo"]}`, tc.UserName)
 			RequireStatus(t, response, 201)
 
-			response = rt.SendUserRequest("GET", "/{{.keyspace}}/_all_docs", "", tc.UserName)
-			RequireStatus(t, response, 200)
+			if isAllDocsIndexExist {
+				response = rt.SendUserRequest("GET", "/{{.keyspace}}/_all_docs", "", tc.UserName)
+				RequireStatus(t, response, 200)
+			}
 
 			response = rt.SendUserRequest("GET", "/{{.keyspace}}/AC+DC", "", tc.UserName)
 			RequireStatus(t, response, 200)


### PR DESCRIPTION
CBG-0000

Describe your PR here...

 - When starChannel is not enable, we do not create allDocs index anymore
 -  Returns error message when _all_docs endpoint is called but allDocs index doesn't exist because starChannel was disabled


## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1292/
