### PR TITLE
Turn off TCP 'NODELAY' option for WebSockets

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -237,7 +237,7 @@ func blipSync(target url.URL, blipContext *blip.Context, insecureSkipVerify bool
 	if err != nil {
 		return nil, err
 	}
-	client := base.GetHttpClient(insecureSkipVerify)
+	client := base.GetHttpClientForWebSocket(insecureSkipVerify)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Go's 'net' package sneakily(?) turns on the TCP 'NODELAY' option by default, because it improves throughput in sockets that issue large writes.

However, NODELAY isn't so good with our replicator protocol because there are a lot of small messages, and it causes each one to be sent as a separate packet. This is especially noticeable with the replies to BLIP "rev" messages, which are numerous and tiny.

This commit calls TCPConn.SetNoDelay(false) on sockets used for WebSockets. It's a bit awkward to do because the TCP sockets are opened for us by the 'net/http' package, but fortunately there are hooks to get access to the underlying TCPConn.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [x] Link upstream PRs
- [x] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
