### PR TITLE
Make rt.GetSingleKeyspace return only db name when default collection for regression testing

### DIFF
--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -30,7 +30,8 @@ func (c *Collection) IsDefaultScopeCollection() bool {
 }
 
 func IsDefaultCollection(scope, collection string) bool {
-	return scope == DefaultScope && collection == DefaultCollection
+	// check collection first to early exit non-default collection
+	return collection == DefaultCollection && scope == DefaultScope
 }
 
 // EscapedKeyspace returns the escaped fully-qualified identifier for the keyspace (e.g. `bucket`.`scope`.`collection`)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2117,13 +2117,19 @@ func (rt *RestTester) GetKeyspaces() []string {
 	return keyspaces
 }
 
-// getSingleKeyspace the name of the keyspace if there is only one test collection on one database.
+// GetSingleKeyspace the name of the keyspace if there is only one test collection on one database.
 func (rt *RestTester) GetSingleKeyspace() string {
 	db := rt.GetDatabase()
-	require.Equal(rt.TB, 1, len(db.CollectionByID), "Database is configured with more collection")
-	for _, collection := range db.CollectionByID {
+	require.Equal(rt.TB, 1, len(db.CollectionByID), "Database must be configured with only one collection to use this function")
+	for id, collection := range db.CollectionByID {
+		if id == base.DefaultCollectionID {
+			// for backwards compatibility (and user-friendliness),
+			// we can optionally just use `/db/` instead of `/db._default._default/`
+			// Return this format to get coverage of both formats.
+			return db.Name
+		}
 		return getRESTKeyspace(rt.TB, db.Name, collection)
 	}
-	rt.TB.Error("Could not find any collections")
+	rt.TB.Fatal("Had no collection to return a keyspace for") // should be unreachable given length check above
 	return ""
 }


### PR DESCRIPTION
Not strictly nessesary, as SG should handle both `/db/` and `/db._default._default/` equally, but doing this covers backwards compatibility/regression for utils using `rt.GetSingleKeyspace` (e.g. `rt.PutDoc`)

The only additional coverage we could do on top of this is to make this return _both_ formats for the default case.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a (testing only)