### PR TITLE
Fix incorrect {{.keyspace}} usage in TestTombstoneCompaction

### DIFF
--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -3898,7 +3898,7 @@ func TestTombstoneCompaction(t *testing.T) {
 				revId := body["rev"].(string)
 				docId := body["id"].(string)
 
-				response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docId, revId), "")
+				response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/%s/%s?rev=%s", keyspace, docId, revId), "")
 				assert.Equal(t, 200, response.Code)
 			}
 		}


### PR DESCRIPTION
This test was incorrectly using `{{.keyspace}}` rather than a numbered keyspace or the loop variable when run with multiple collections.

Seen fail here:
https://jenkins.sgwdev.com/job/SyncGateway-Integration/1301/

```
2023-01-03T14:33:21.464Z [INF] HTTP: db:db c:#1209 POST http://localhost/db.sg_test_0.sg_test_0/ (as ADMIN)
2023-01-03T14:33:21.465Z [INF] HTTP: db:<no value> c:#1210 DELETE http://localhost/<no value>/<ud>47573dc8b6dca6fdc350565401cb17c1</ud>?rev=1-cd809becc169215072fd567eebd8b8de (as ADMIN)
2023-01-03T14:33:21.465Z [INF] HTTP: db:<no value> c:#1210 #1210:     --> 400 invalid database name "<no value>"  (0.1 ms)
    changes_api_test.go:3902: 
        	Error Trace:	changes_api_test.go:3902
        	            				changes_api_test.go:3929
        	Error:      	Not equal: 
        	            	expected: 200
        	            	actual  : 400
        	Test:       	TestTombstoneCompaction
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `rest/changestest/^TestTombstoneCompaction$,GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1303/
