### PR TITLE
Avoid closing test bucket before database context is closed

### DIFF
--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -1442,13 +1442,13 @@ func TestCreateDBSpecificBucketPerm(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+
 	rt := NewRestTester(t, &RestTesterConfig{
 		AdminInterfaceAuthentication: true,
 	})
 	defer rt.Close()
-
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
 
 	eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
 	require.NoError(t, err)

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -3361,6 +3361,13 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 
 	serverErr := make(chan error, 0)
 
+	// Get a test bucket, to use to create the database.
+	tb := base.GetTestBucket(t)
+	defer func() {
+		fmt.Println("closing test bucket")
+		tb.Close()
+	}()
+
 	// Start SG with no databases
 	ctx := base.TestCtx(t)
 	config := rest.BootstrapStartupConfigForTest(t)
@@ -3376,12 +3383,6 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 	}()
 	require.NoError(t, sc.WaitForRESTAPIs())
 
-	// Get a test bucket, and use it to create the database.
-	tb := base.GetTestBucket(t)
-	defer func() {
-		fmt.Println("closing test bucket")
-		tb.Close()
-	}()
 	resp := rest.BootstrapAdminRequest(t, http.MethodPut, "/db/",
 		fmt.Sprintf(
 			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -356,6 +356,10 @@ func TestDBOfflinePostResync(t *testing.T) {
 		t.Skip("This test doesn't work with Walrus when ResyncManagerDCP is used")
 	}
 
+	if isDCPResync {
+		base.TemporarilyDisableTestUsingDCPWithCollections(t)
+	}
+
 	log.Printf("Taking DB offline")
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
@@ -398,6 +402,9 @@ func TestDBOfflineSingleResync(t *testing.T) {
 	_, isDCPResync := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
 	if isDCPResync && base.UnitTestUrlIsWalrus() {
 		t.Skip("This test doesn't work with Walrus when ResyncManagerDCP is used")
+	}
+	if isDCPResync {
+		base.TemporarilyDisableTestUsingDCPWithCollections(t)
 	}
 
 	// create documents in DB to cause resync to take a few seconds
@@ -495,6 +502,9 @@ func TestResync(t *testing.T) {
 			_, isDCPResync := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
 			if isDCPResync && base.UnitTestUrlIsWalrus() {
 				t.Skip("This test doesn't work with Walrus when ResyncManagerDCP is used")
+			}
+			if isDCPResync {
+				base.TemporarilyDisableTestUsingDCPWithCollections(t)
 			}
 
 			for i := 0; i < testCase.docsCreated; i++ {
@@ -1060,6 +1070,8 @@ func TestResyncPersistence(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}
+
+	base.TemporarilyDisableTestUsingDCPWithCollections(t)
 
 	tb := base.GetTestBucket(t)
 	noCloseTB := tb.NoCloseClone()


### PR DESCRIPTION

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1309/
