### PR TITLE
CBG-2658: REST API docs for principal collection_access

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -222,19 +222,27 @@ User:
         Mandatory. unless `allow_empty_password` is `true` in the database configs.
       type: string
     admin_channels:
-      description: A list of channels to explicitly grant to the user.
+      description: A list of channels to explicitly grant to the user for the default collection.
       type: array
       items:
         type: string
     all_channels:
       description: |-
-        All the channels that the user has been granted access to.
+        All the channels that the user has been granted access to for the default collection.
 
         Access could have been granted through the sync function, roles, or explicitly on the user under the `admin_channels` property.
       type: array
       items:
         type: string
       readOnly: true
+    collection_access:
+      description: A set of access grants by scope and collection.
+      type: object
+      additionalProperties:
+        description: An object keyed by scope, containing a set of collections.
+        type: object
+        additionalProperties:
+          $ref: '#/CollectionAccessConfig'
     email:
       description: The email address of the user.
       type: string
@@ -277,6 +285,35 @@ User:
       format: date-time
       readOnly: true
   title: User
+CollectionAccessConfig:
+  description: An object keyed by collection name, defines access for the collection.
+  type: object
+  properties:
+    admin_channels:
+      description: A list of channels to explicitly grant to the user.
+      type: array
+      items:
+        type: string
+    all_channels:
+      description: |-
+        All the channels that the user has been granted access to.
+
+        Access could have been granted through the sync function, roles, or explicitly on the user under the `admin_channels` property.
+      type: array
+      items:
+        type: string
+      readOnly: true
+    jwt_channels:
+      description: The channels that the user has been granted access to through channels_claim.
+      type: array
+      items:
+        type: string
+      readOnly: true
+    jwt_last_updated:
+      description: The last time that the user's JWT roles/channels were updated.
+      type: string
+      format: date-time
+      readOnly: true
 Role:
   description: Properties associated with a role
   type: object
@@ -288,19 +325,27 @@ Role:
         Role names can only have alphanumeric ASCII characters and underscores.
       type: string
     admin_channels:
-      description: The channels that users in the role are able to access.
+      description: The channels that users in the role are able to access for the default collection.
       type: array
       items:
         type: string
     all_channels:
       description: |-
-        The channels that the role grants access to.
+        The channels that the role grants access to for the default collection.
 
         These channels could have been assigned by the Sync function or using the `admin_channels` property.
       type: array
       items:
         type: string
       readOnly: true
+    collection_access:
+      description: A set of access grants by scope and collection.
+      type: object
+      additionalProperties:
+        description: An object keyed by scope, containing a set of collections.
+        type: object
+        additionalProperties:
+          $ref: '#/CollectionAccessConfig'
   title: Role
 User-session-information:
   type: object


### PR DESCRIPTION
CBG-2658

Documents the `collection_access` changes to the `/_user` and `/_role` APIs added in #5901 

Preview:
![Screenshot 2023-01-05 at 14 29 59](https://user-images.githubusercontent.com/1525809/210803966-9e80307d-0759-4fb2-a46f-2a103d3b625f.png)
![Screenshot 2023-01-05 at 14 29 43](https://user-images.githubusercontent.com/1525809/210803975-c522b11b-88c2-415f-a411-1519276aa446.png)
![Screenshot 2023-01-05 at 14 30 17](https://user-images.githubusercontent.com/1525809/210803959-15734441-77d9-4c99-a9de-918fb0df66ee.png)
![Screenshot 2023-01-05 at 14 30 35](https://user-images.githubusercontent.com/1525809/210803953-57480aac-ca80-408e-bb52-fe20824ce7ae.png)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a