### PR TITLE
CBG-2276: Set default Javascript timeout to zero (disable timeout)

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -146,7 +146,8 @@ const (
 	RedactedStr = "xxxxx"
 
 	// DefaultJavascriptTimeoutSecs is number of seconds before Javascript functions (i.e. the sync function or import filter) timeout
-	DefaultJavascriptTimeoutSecs = uint32(60)
+	// If set to zero, timeout is disabled.
+	DefaultJavascriptTimeoutSecs = uint32(0)
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.1.5-0.20220809160836-bf53e9527651
 	github.com/couchbase/gomemcached v0.1.4
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20221205193604-510d1305f14d
+	github.com/couchbase/sg-bucket v0.0.0-20230105145143-d9293172e6f1
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f
 	github.com/couchbaselabs/walrus v0.0.0-20221216132452-df0cbd8e1f7b
 	github.com/elastic/gosigar v0.14.2

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.1.5-0.20220809160836-bf53e9527651
 	github.com/couchbase/gomemcached v0.1.4
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20230105145143-d9293172e6f1
+	github.com/couchbase/sg-bucket v0.0.0-20230105171927-06b0d8a5a561
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f
 	github.com/couchbaselabs/walrus v0.0.0-20221216132452-df0cbd8e1f7b
 	github.com/elastic/gosigar v0.14.2

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9B
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
 github.com/couchbase/sg-bucket v0.0.0-20221205193604-510d1305f14d h1:doWrdlRlQcxHqIdEmhfvTAZXwGSyADsmvT1nqg9e3gE=
 github.com/couchbase/sg-bucket v0.0.0-20221205193604-510d1305f14d/go.mod h1:9XQoB1t+elPP+yEjHGOX3xcC3Z0/qDgOI7h/fc9XjlU=
+github.com/couchbase/sg-bucket v0.0.0-20230105145143-d9293172e6f1 h1:IKoXYw+WJq82weLCGiVCyK23AaJ9k6VUOahNtOwlcoI=
+github.com/couchbase/sg-bucket v0.0.0-20230105145143-d9293172e6f1/go.mod h1:9XQoB1t+elPP+yEjHGOX3xcC3Z0/qDgOI7h/fc9XjlU=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f h1:al5DxXEBAUmINnP5dR950gL47424WzncuRpNdg0TWR0=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f/go.mod h1:daOs69VstinwoALl3wwWxjBf1nD4lIe3wwYhKHKDapY=
 github.com/couchbaselabs/gocaves/client v0.0.0-20220223122017-22859b310bd2 h1:UlwJ2GWpZQAQCLHyO3xHKcqAjUUcX2w7FKpbxCIUQks=

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/couchbase/sg-bucket v0.0.0-20221205193604-510d1305f14d h1:doWrdlRlQcx
 github.com/couchbase/sg-bucket v0.0.0-20221205193604-510d1305f14d/go.mod h1:9XQoB1t+elPP+yEjHGOX3xcC3Z0/qDgOI7h/fc9XjlU=
 github.com/couchbase/sg-bucket v0.0.0-20230105145143-d9293172e6f1 h1:IKoXYw+WJq82weLCGiVCyK23AaJ9k6VUOahNtOwlcoI=
 github.com/couchbase/sg-bucket v0.0.0-20230105145143-d9293172e6f1/go.mod h1:9XQoB1t+elPP+yEjHGOX3xcC3Z0/qDgOI7h/fc9XjlU=
+github.com/couchbase/sg-bucket v0.0.0-20230105171927-06b0d8a5a561 h1:95njJUhJKka06WdBvS7GPjbll63RE886v2Hk3v1vJ3o=
+github.com/couchbase/sg-bucket v0.0.0-20230105171927-06b0d8a5a561/go.mod h1:9XQoB1t+elPP+yEjHGOX3xcC3Z0/qDgOI7h/fc9XjlU=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f h1:al5DxXEBAUmINnP5dR950gL47424WzncuRpNdg0TWR0=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f/go.mod h1:daOs69VstinwoALl3wwWxjBf1nD4lIe3wwYhKHKDapY=
 github.com/couchbaselabs/gocaves/client v0.0.0-20220223122017-22859b310bd2 h1:UlwJ2GWpZQAQCLHyO3xHKcqAjUUcX2w7FKpbxCIUQks=


### PR DESCRIPTION
CBG-2276

Soft revert of #5639 (disable timeout by default)

## TODO
- [x] Merge and bump mod for https://github.com/couchbase/sg-bucket/pull/86

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1325/
