### PR TITLE
Make ChannelRevocationTester.getChanges require expected length to avoid panics in tests using result

### DIFF
--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -146,7 +146,7 @@ func (tester *ChannelRevocationTester) getChanges(sinceSeq interface{}, expected
 
 		return len(changes.Results) == expectedLength
 	})
-	assert.NoError(tester.test, err, fmt.Sprintf("Unexpected: %d. Expected %d", len(changes.Results), expectedLength))
+	require.NoError(tester.test, err, fmt.Sprintf("Unexpected: %d. Expected %d", len(changes.Results), expectedLength))
 
 	err = tester.restTester.WaitForPendingChanges()
 	assert.NoError(tester.test, err)


### PR DESCRIPTION
Revocation tests use `getChanges` to assert on a length before using the result.
The tests do not make sure the length of changes is adequate before accessing elements, resulting in panics for test failures.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1326/
