### PR TITLE
CBG-2621: Add keyspace logging context from h.invoke/blipHandler

### DIFF
--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -102,10 +102,11 @@ func bucketNameCtx(parent context.Context, bucketName string) context.Context {
 	return LogContextWith(parent, &newCtx)
 }
 
-// CollectionNameCtx extends the parent context with a bucket name.
-func CollectionNameCtx(parent context.Context, collectionName string) context.Context {
+// KeyspaceCtx extends the parent context with a collection name.
+func KeyspaceCtx(parent context.Context, scopeName, collectionName string) context.Context {
 	newCtx := KeyspaceLogContext{
-		Keyspace: collectionName,
+		Scope:      scopeName,
+		Collection: collectionName,
 	}
 	return LogContextWith(parent, &newCtx)
 }
@@ -182,18 +183,19 @@ func (c *DatabaseLogContext) addContext(format string) string {
 	return format
 }
 
-// KeyspaceLogContext provides database context data for logging
+// KeyspaceLogContext provides keyspace context data for logging
 type KeyspaceLogContext struct {
-	Keyspace string
+	Scope      string
+	Collection string
 }
 
 func (c *KeyspaceLogContext) getContextKey() LogContextKey {
-	return databaseLogContextKey
+	return keyspaceLogContextKey
 }
 
 func (c *KeyspaceLogContext) addContext(format string) string {
-	if c.Keyspace != "" {
-		format = "ks:" + c.Keyspace + " " + format
+	if c.Scope != "" || c.Collection != "" {
+		format = "ks:" + c.Scope + "." + c.Collection + " " + format
 
 	}
 	return format

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -102,10 +102,9 @@ func bucketNameCtx(parent context.Context, bucketName string) context.Context {
 	return LogContextWith(parent, &newCtx)
 }
 
-// KeyspaceCtx extends the parent context with a collection name.
-func KeyspaceCtx(parent context.Context, scopeName, collectionName string) context.Context {
-	newCtx := KeyspaceLogContext{
-		Scope:      scopeName,
+// CollectionCtx extends the parent context with a collection name.
+func CollectionCtx(parent context.Context, collectionName string) context.Context {
+	newCtx := CollectionLogContext{
 		Collection: collectionName,
 	}
 	return LogContextWith(parent, &newCtx)
@@ -183,19 +182,18 @@ func (c *DatabaseLogContext) addContext(format string) string {
 	return format
 }
 
-// KeyspaceLogContext provides keyspace context data for logging
-type KeyspaceLogContext struct {
-	Scope      string
+// CollectionLogContext provides collection context data for logging
+type CollectionLogContext struct {
 	Collection string
 }
 
-func (c *KeyspaceLogContext) getContextKey() LogContextKey {
+func (c *CollectionLogContext) getContextKey() LogContextKey {
 	return keyspaceLogContextKey
 }
 
-func (c *KeyspaceLogContext) addContext(format string) string {
-	if c.Scope != "" || c.Collection != "" {
-		format = "ks:" + c.Scope + "." + c.Collection + " " + format
+func (c *CollectionLogContext) addContext(format string) string {
+	if c.Collection != "" {
+		format = "col:" + c.Collection + " " + format
 
 	}
 	return format

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -168,7 +168,7 @@ func collectionBlipHandler(next blipHandlerFunc) blipHandlerFunc {
 		if collection == nil {
 			return base.HTTPErrorf(http.StatusBadRequest, "Collection index %d does not match a valid collection from GetCollections", collectionIndex)
 		}
-		bh.loggingCtx = base.KeyspaceCtx(bh.BlipSyncContext.loggingCtx, collection.ScopeName(), collection.Name())
+		bh.loggingCtx = base.CollectionCtx(bh.BlipSyncContext.loggingCtx, collection.Name())
 		bh.collection = &DatabaseCollectionWithUser{
 			DatabaseCollection: bh.collectionMapping[collectionIndex],
 			user:               bh.db.user,

--- a/db/blip_handler_test.go
+++ b/db/blip_handler_test.go
@@ -133,9 +133,13 @@ func TestCollectionBlipHandler(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			ctx := base.TestCtx(t)
 			bh := blipHandler{
-				db:              allDB,
-				BlipSyncContext: &BlipSyncContext{collectionMapping: testCase.collectionMapping},
+				db: allDB,
+				BlipSyncContext: &BlipSyncContext{
+					loggingCtx:        ctx,
+					collectionMapping: testCase.collectionMapping,
+				},
 			}
 
 			passedMiddleware := false

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -428,7 +428,7 @@ func (c *singleChannelCacheImpl) GetChanges(options ChangesOptions) ([]*LogEntry
 			resultValidTo = resultFromQuery[numResults-1].Sequence
 		}
 		if len(resultFromCache) < c.options.ChannelCacheMaxLength {
-			c.prependChanges(resultFromQuery, startSeq, resultValidTo)
+			c.prependChanges(options.LoggingCtx, resultFromQuery, startSeq, resultValidTo)
 		}
 	}
 
@@ -573,10 +573,9 @@ func (c *singleChannelCacheImpl) insertChange(log *LogEntries, change *LogEntry)
 // the cache.
 //
 // Returns the number of entries actually prepended.
-func (c *singleChannelCacheImpl) prependChanges(changes LogEntries, changesValidFrom uint64, changesValidTo uint64) int {
+func (c *singleChannelCacheImpl) prependChanges(logCtx context.Context, changes LogEntries, changesValidFrom uint64, changesValidTo uint64) int {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	logCtx := context.TODO()
 
 	// If set of changes to prepend is empty, check whether validFrom should be updated
 	if len(changes) == 0 {

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -278,7 +278,7 @@ func TestPrependChanges(t *testing.T) {
 		testLogEntry(14, "doc1", "2-a"),
 	}
 
-	numPrepended := cache.prependChanges(changesToPrepend, 5, 14)
+	numPrepended := cache.prependChanges(ctx, changesToPrepend, 5, 14)
 	assert.Equal(t, 3, numPrepended)
 
 	// Validate cache
@@ -304,7 +304,7 @@ func TestPrependChanges(t *testing.T) {
 		testLogEntry(14, "doc1", "2-a"),
 	}
 
-	numPrepended = cache.prependChanges(changesToPrepend, 5, 14)
+	numPrepended = cache.prependChanges(ctx, changesToPrepend, 5, 14)
 	assert.Equal(t, 2, numPrepended)
 
 	// Validate cache
@@ -339,7 +339,7 @@ func TestPrependChanges(t *testing.T) {
 	}
 
 	// Prepend empty set, validate validFrom update
-	cache.prependChanges(LogEntries{}, 5, 14)
+	cache.prependChanges(ctx, LogEntries{}, 5, 14)
 	validFrom, cachedChanges = cache.GetCachedChanges(getChangesOptionsWithCtxOnly())
 	assert.Equal(t, uint64(5), validFrom)
 	require.Len(t, cachedChanges, 4)
@@ -365,7 +365,7 @@ func TestPrependChanges(t *testing.T) {
 		testLogEntry(14, "doc1", "2-a"),
 	}
 
-	numPrepended = cache.prependChanges(changesToPrepend, 5, 14)
+	numPrepended = cache.prependChanges(ctx, changesToPrepend, 5, 14)
 	assert.Equal(t, 1, numPrepended)
 
 	// Validate cache
@@ -403,7 +403,7 @@ func TestPrependChanges(t *testing.T) {
 		testLogEntry(12, "doc4", "2-a"),
 		testLogEntry(14, "doc1", "2-a"),
 	}
-	numPrepended = cache.prependChanges(changesToPrepend, 5, 14)
+	numPrepended = cache.prependChanges(ctx, changesToPrepend, 5, 14)
 	assert.Equal(t, 0, numPrepended)
 	validFrom, cachedChanges = cache.GetCachedChanges(getChangesOptionsWithCtxOnly())
 	assert.Equal(t, uint64(5), validFrom)
@@ -441,7 +441,7 @@ func TestPrependChanges(t *testing.T) {
 		testLogEntry(14, "doc1", "2-a"),
 	}
 
-	numPrepended = cache.prependChanges(changesToPrepend, 6, 14)
+	numPrepended = cache.prependChanges(ctx, changesToPrepend, 6, 14)
 	assert.Equal(t, 0, numPrepended)
 
 	// Validate cache
@@ -675,7 +675,7 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	prependDuplicatesSet[2] = (testLogEntry(52, "removal1", "1-a"))
 	prependDuplicatesSet[3] = (et(53, "tombstone1", "1-a"))
 	prependDuplicatesSet[4] = (testLogEntry(54, "tombstone3", "1-a"))
-	cache.prependChanges(prependDuplicatesSet, 50, 99)
+	cache.prependChanges(ctx, prependDuplicatesSet, 50, 99)
 
 	active, tombstones, removals = getCacheUtilization(testStats)
 	assert.Equal(t, 3, active)
@@ -695,7 +695,7 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	prependSet[8] = (testLogEntry(48, "new9", "1-a"))
 	prependSet[9] = (et(49, "new10", "1-a"))
 	prependSet[10] = (et(50, "active1", "1-a"))
-	cache.prependChanges(prependSet, 40, 50)
+	cache.prependChanges(ctx, prependSet, 40, 50)
 	active, tombstones, removals = getCacheUtilization(testStats)
 	assert.Equal(t, 6, active)
 	assert.Equal(t, 6, tombstones)

--- a/db/database.go
+++ b/db/database.go
@@ -444,9 +444,9 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 			}
 			collectionNameMap := make(map[string]struct{}, len(scope.Collections))
 			for collName, collOpts := range scope.Collections {
-				ksCtx := base.KeyspaceCtx(ctx, scopeName, collName)
+				ctx := base.KeyspaceCtx(ctx, scopeName, collName)
 				dataStore := bucket.NamedDataStore(base.ScopeAndCollectionName{Scope: scopeName, Collection: collName})
-				dbCollection, err := newDatabaseCollection(ksCtx, dbContext, dataStore)
+				dbCollection, err := newDatabaseCollection(ctx, dbContext, dataStore)
 				if err != nil {
 					return nil, err
 				}

--- a/db/database.go
+++ b/db/database.go
@@ -444,8 +444,9 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 			}
 			collectionNameMap := make(map[string]struct{}, len(scope.Collections))
 			for collName, collOpts := range scope.Collections {
+				ksCtx := base.KeyspaceCtx(ctx, scopeName, collName)
 				dataStore := bucket.NamedDataStore(base.ScopeAndCollectionName{Scope: scopeName, Collection: collName})
-				dbCollection, err := newDatabaseCollection(ctx, dbContext, dataStore)
+				dbCollection, err := newDatabaseCollection(ksCtx, dbContext, dataStore)
 				if err != nil {
 					return nil, err
 				}
@@ -2287,13 +2288,7 @@ func (dbc *Database) GetSingleDatabaseCollectionWithUser() *DatabaseCollectionWi
 }
 
 // newDatabaseCollection returns a collection which inherits values from the database but is specific to a given DataStore.
-func newDatabaseCollection(dbCtx context.Context, dbContext *DatabaseContext, dataStore base.DataStore) (*DatabaseCollection, error) {
-	dsn, ok := base.AsDataStoreName(dataStore)
-	if !ok {
-		return nil, fmt.Errorf("unable to get datastore name from dataStore")
-	}
-	ctx := base.KeyspaceCtx(dbCtx, dsn.ScopeName(), dsn.CollectionName())
-
+func newDatabaseCollection(ctx context.Context, dbContext *DatabaseContext, dataStore base.DataStore) (*DatabaseCollection, error) {
 	dbCollection := &DatabaseCollection{
 		dataStore:   dataStore,
 		dbCtx:       dbContext,

--- a/db/database.go
+++ b/db/database.go
@@ -444,7 +444,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 			}
 			collectionNameMap := make(map[string]struct{}, len(scope.Collections))
 			for collName, collOpts := range scope.Collections {
-				ctx := base.KeyspaceCtx(ctx, scopeName, collName)
+				ctx := base.CollectionCtx(ctx, collName)
 				dataStore := bucket.NamedDataStore(base.ScopeAndCollectionName{Scope: scopeName, Collection: collName})
 				dbCollection, err := newDatabaseCollection(ctx, dbContext, dataStore)
 				if err != nil {
@@ -1579,7 +1579,7 @@ func (db *Database) Compact(ctx context.Context, skipRunningStateCheck bool, cal
 	purgeBody := Body{"_purged": true}
 	for _, c := range db.CollectionByID {
 		// shadow ctx, sot that we can't misuse the parent's inside the loop
-		ctx := base.KeyspaceCtx(ctx, c.ScopeName(), c.Name())
+		ctx := base.CollectionCtx(ctx, c.Name())
 
 		// create admin collection interface
 		collection, err := db.GetDatabaseCollectionWithUser(c.ScopeName(), c.Name())

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -183,9 +183,9 @@ func (h *handler) addDatabaseLogContext(dbName string) {
 	}
 }
 
-func (h *handler) addKeyspaceContext(scopeName, collectionName string) {
-	if scopeName != "" || collectionName != "" {
-		h.rqCtx = base.LogContextWith(h.ctx(), &base.KeyspaceLogContext{Scope: scopeName, Collection: collectionName})
+func (h *handler) addCollectionLogContext(collectionName string) {
+	if collectionName != "" {
+		h.rqCtx = base.LogContextWith(h.ctx(), &base.CollectionLogContext{Collection: collectionName})
 	}
 }
 
@@ -266,8 +266,8 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 		if err != nil {
 			return err
 		}
-		if keyspaceScope != nil && keyspaceCollection != nil {
-			h.addKeyspaceContext(*keyspaceScope, *keyspaceCollection)
+		if keyspaceCollection != nil {
+			h.addCollectionLogContext(*keyspaceCollection)
 		}
 	}
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -266,7 +266,9 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 		if err != nil {
 			return err
 		}
-		h.addKeyspaceContext(*keyspaceScope, *keyspaceCollection)
+		if keyspaceScope != nil && keyspaceCollection != nil {
+			h.addKeyspaceContext(*keyspaceScope, *keyspaceCollection)
+		}
 	}
 
 	// look up the database context:

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -183,6 +183,12 @@ func (h *handler) addDatabaseLogContext(dbName string) {
 	}
 }
 
+func (h *handler) addKeyspaceContext(scopeName, collectionName string) {
+	if scopeName != "" || collectionName != "" {
+		h.rqCtx = base.LogContextWith(h.ctx(), &base.KeyspaceLogContext{Scope: scopeName, Collection: collectionName})
+	}
+}
+
 // ParseKeyspace will return a db, scope and collection for a given '.' separated keyspace string.
 // Returns nil for scope and/or collection if not present in the keyspace string.
 func ParseKeyspace(ks string) (db string, scope, collection *string, err error) {
@@ -260,6 +266,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 		if err != nil {
 			return err
 		}
+		h.addKeyspaceContext(*keyspaceScope, *keyspaceCollection)
 	}
 
 	// look up the database context:


### PR DESCRIPTION
CBG-2621

- Set keyspace (collection only) log context from `h.invoke` for keyspace requests
- Remove `context.TODO()` in channel cache by passing through context

Example output (from `TestCollectionsReplication`):
```
2023-01-05T15:48:58.277Z [INF] HTTP: db:db c:#002 GET /db/_blipsync (as GUEST)
2023-01-05T15:48:58.277Z [INF] HTTP+: db:db c:[3c887e56] #002:     --> 101 [3c887e56] Upgraded to WebSocket protocol BLIP_3+ (as GUEST)  (0.0 ms)
2023-01-05T15:48:58.277Z [INF] WS: db:db c:#002 Accepted connection for WS protocol: BLIP_3+CBMobile_3
2023-01-05T15:48:58.277Z [INF] WS: db:db c:#002 Start BLIP/Websocket handler
2023-01-05T15:48:58.277Z [DBG] WSFrame+: db:db c:#002 Sender starting
2023-01-05T15:48:58.277Z [DBG] WSFrame+: t:TestCollectionsReplication Sender starting
2023-01-05T15:48:58.277Z [DBG] WS+: t:TestCollectionsReplication Queued MSG#1
2023-01-05T15:48:58.277Z [DBG] WSFrame+: t:TestCollectionsReplication Push MSG#1
2023-01-05T15:48:58.278Z [DBG] WSFrame+: t:TestCollectionsReplication Sending frame: MSG#1 (flags=       0, size=  125)
2023-01-05T15:48:58.278Z [DBG] WSFrame+: db:db c:#002 Received frame: MSG#1 (flags=       0, length=125)
2023-01-05T15:48:58.278Z [DBG] WS+: db:db c:#002 Incoming BLIP Request: MSG#1
2023-01-05T15:48:58.278Z [INF] SyncMsg: #1: Type:getCollections Collections: [sg_test_0.sg_test_0], CheckpointIds: [pull9763ebc0-beae-48fa-b420-77ce15e341c5]
2023-01-05T15:48:58.278Z [DBG] SyncMsg+: db:db c:[3c887e56] #1: Type:getCollections   --> OK Time:82.578µs
2023-01-05T15:48:58.278Z [DBG] WSFrame+: db:db c:#002 Push RPY#1~
2023-01-05T15:48:58.278Z [DBG] WSFrame+: db:db c:#002 Sending frame: RPY#1~ (flags=    1001, size=   35)
2023-01-05T15:48:58.278Z [DBG] WSFrame+: t:TestCollectionsReplication Received frame: RPY#1~ (flags=    1001, length=41)
2023-01-05T15:48:58.280Z [INF] HTTP: ks:sg_test_0.sg_test_0 db:db c:#003 PUT http://localhost/db.sg_test_0.sg_test_0/<ud>doc1</ud> (as ADMIN)
2023-01-05T15:48:58.280Z [DBG] CRUD+: ks:sg_test_0.sg_test_0 db:db c:#003 Invoking sync on doc "<ud>doc1</ud>" rev 1-ca9ad22802b66f662ff171f226211d5c
2023-01-05T15:48:58.281Z [DBG] CRUD+: ks:sg_test_0.sg_test_0 db:db c:#003 Saving doc (seq: #1, id: <ud>doc1</ud> rev: 1-ca9ad22802b66f662ff171f226211d5c)
2023-01-05T15:48:58.281Z [DBG] CRUD+: ks:sg_test_0.sg_test_0 db:db c:#003 Stored doc "<ud>doc1</ud>" / "1-ca9ad22802b66f662ff171f226211d5c" as #1
2023-01-05T15:48:58.281Z [INF] HTTP+: ks:sg_test_0.sg_test_0 db:db c:#003 #003:     --> 201   (0.4 ms)
2023-01-05T15:48:58.281Z [DBG] Changes+: t:TestCollectionsReplication Waiting for sequence: 1
2023-01-05T15:48:58.281Z [DBG] RetryLoop retrying waitForSequence(1) after 1 ms.
2023-01-05T15:48:58.281Z [DBG] DCP+: ks:sg_test_0.sg_test_0 db:db t:TestCollectionsReplication Received #1 after   0ms ("<ud>doc1</ud>" / "1-ca9ad22802b66f662ff171f226211d5c")
2023-01-05T15:48:58.281Z [DBG] DCP+: ks:sg_test_0.sg_test_0 db:db t:TestCollectionsReplication  #1 ==> channels [ <ud>1.*</ud> ]
2023-01-05T15:48:58.281Z [DBG] Changes+: Notifying that "sg_int_walrus_702648254efead1205f02851ba02a0a9" changed (keys="<ud>{, 1.*}</ud>") count=4
2023-01-05T15:48:58.282Z [DBG] Cache+: t:TestCollectionsReplication waitForSequence(1) took 1.151329ms
2023-01-05T15:48:58.282Z [DBG] WS+: t:TestCollectionsReplication Queued MSG#2
2023-01-05T15:48:58.282Z [DBG] WSFrame+: t:TestCollectionsReplication Push MSG#2
2023-01-05T15:48:58.282Z [DBG] WSFrame+: t:TestCollectionsReplication Sending frame: MSG#2 (flags=  100000, size=   75)
2023-01-05T15:48:58.282Z [DBG] WSFrame+: db:db c:#002 Received frame: MSG#2 (flags=  100000, length=75)
2023-01-05T15:48:58.282Z [DBG] WS+: db:db c:#002 Incoming BLIP Request: MSG#2
2023-01-05T15:48:58.282Z [INF] SyncMsg: ks:sg_test_0.sg_test_0 db:db c:[3c887e56] #2: Type:subChanges Since:0 
2023-01-05T15:48:58.282Z [INF] Sync: ks:sg_test_0.sg_test_0 db:db c:[3c887e56] Sending changes since 0
2023-01-05T15:48:58.282Z [DBG] Changes+: ks:sg_test_0.sg_test_0 db:db c:[3c887e56] Int sequence multi changes feed...
2023-01-05T15:48:58.282Z [INF] Changes: ks:sg_test_0.sg_test_0 db:db c:[3c887e56] MultiChangesFeed(channels: <ud>{, 1.*}</ud>, options: {Since: 0, Limit: 0, Conflicts: false, IncludeDocs: false, Wait: false, Continuous: false, HeartbeatMs: 0, TimeoutMs: 0, ActiveOnly: false}) ... <ud></ud>
2023-01-05T15:48:58.282Z [DBG] Changes+: ks:sg_test_0.sg_test_0 db:db c:[3c887e56] MultiChangesFeed: channels expand to "<ud>map[1:!:1,*:1]</ud>" ... <ud></ud>
2023-01-05T15:48:58.282Z [DBG] Cache+: Initialized cache for channel "<ud>1.!</ud>" with min:50 max:500 age:1m0s, validFrom: 2
2023-01-05T15:48:58.282Z [DBG] Cache+: Initialized cache for channel "<ud>1.*</ud>" with min:50 max:500 age:1m0s, validFrom: 2
2023-01-05T15:48:58.282Z [DBG] Cache+: ks:sg_test_0.sg_test_0 db:db c:[3c887e56] GetCachedChanges("<ud>1.!</ud>", 0) --> nothing cached
2023-01-05T15:48:58.282Z [DBG] Cache+: ks:sg_test_0.sg_test_0 db:db c:[3c887e56] GetCachedChanges("<ud>1.*</ud>", 0) --> nothing cached
2023-01-05T15:48:58.282Z [INF] Cache: ks:sg_test_0.sg_test_0 db:db c:[3c887e56]   Querying 'channels' for "<ud>!</ud>" (start=#1, end=#2, limit=5000)
2023-01-05T15:48:58.282Z [INF] Cache: ks:sg_test_0.sg_test_0 db:db c:[3c887e56]   Querying 'channels' for "<ud>*</ud>" (start=#1, end=#2, limit=5000)
2023/01/05 15:48:58 SG-Bucket: 	... view returned 1 rows
2023/01/05 15:48:58 SG-Bucket: 	... view returned 0 rows
2023-01-05T15:48:58.283Z [INF] Cache: ks:sg_test_0.sg_test_0 db:db c:[3c887e56]     Got no rows from query for channel:"<ud>!</ud>"
2023-01-05T15:48:58.284Z [DBG] Cache+: ks:sg_test_0.sg_test_0 db:db c:[3c887e56]  changesValidFrom (1) < c.validFrom < changesValidTo (2), setting c.validFrom from 2 -> 1 for "<ud>1.!</ud>"
2023-01-05T15:48:58.284Z [INF] Cache: ks:sg_test_0.sg_test_0 db:db c:[3c887e56] GetChangesInChannel("<ud>1.!</ud>") --> 0 rows
2023-01-05T15:48:58.284Z [DBG] Changes+: ks:sg_test_0.sg_test_0 db:db c:[3c887e56] [changesFeed] Found 0 changes for channel "<ud>1.!</ud>"
2023-01-05T15:48:58.284Z [INF] Cache: ks:sg_test_0.sg_test_0 db:db c:[3c887e56]     Got 1 rows from query for "<ud>*</ud>": #1 ... #1
2023-01-05T15:48:58.284Z [INF] Cache: ks:sg_test_0.sg_test_0 db:db c:[3c887e56]   Initialized cache of "<ud>1.*</ud>" with 1 entries from query (#1--#1)
2023-01-05T15:48:58.284Z [INF] Cache: ks:sg_test_0.sg_test_0 db:db c:[3c887e56] GetChangesInChannel("<ud>1.*</ud>") --> 1 rows
2023-01-05T15:48:58.284Z [DBG] Changes+: ks:sg_test_0.sg_test_0 db:db c:[3c887e56] [changesFeed] Found 1 changes for channel "<ud>1.*</ud>"
2023-01-05T15:48:58.284Z [DBG] Changes+: ks:sg_test_0.sg_test_0 db:db c:[3c887e56] Channel feed processing seq:1 in channel <ud>1.*</ud> <ud></ud>
2023-01-05T15:48:58.284Z [DBG] Changes+: ks:sg_test_0.sg_test_0 db:db c:[3c887e56] MultiChangesFeed sending <ud>{Seq:1, ID:doc1, Changes:[map[rev:1-ca9ad22802b66f662ff171f226211d5c]]}</ud> <ud></ud>
2023-01-05T15:48:58.284Z [INF] Changes: ks:sg_test_0.sg_test_0 db:db c:[3c887e56] MultiChangesFeed done <ud></ud>
2023-01-05T15:48:58.284Z [DBG] Sync+: ks:sg_test_0.sg_test_0 db:db c:[3c887e56]     Sending 1 changes
2023-01-05T15:48:58.284Z [DBG] Sync+: ks:sg_test_0.sg_test_0 db:db c:[3c887e56]     Sending 0 changes
2023-01-05T15:48:58.284Z [DBG] WS+: db:db c:#002 Queued MSG#1~
2023-01-05T15:48:58.284Z [DBG] WSFrame+: db:db c:#002 Push MSG#1~
2023-01-05T15:48:58.284Z [DBG] WSFrame+: db:db c:#002 Sending frame: MSG#1~ (flags=    1000, size=  109)
2023-01-05T15:48:58.284Z [DBG] WSFrame+: t:TestCollectionsReplication Received frame: MSG#1~ (flags=    1000, length=115)
2023-01-05T15:48:58.284Z [DBG] WS+: t:TestCollectionsReplication Incoming BLIP Request: MSG#1~
2023-01-05T15:48:58.284Z [DBG] WSFrame+: t:TestCollectionsReplication Push RPY#1
2023-01-05T15:48:58.284Z [DBG] WSFrame+: t:TestCollectionsReplication Sending frame: RPY#1 (flags=       1, size=    5)
2023-01-05T15:48:58.284Z [DBG] WSFrame+: db:db c:#002 Received frame: RPY#1 (flags=       1, length=5)
2023-01-05T15:48:58.284Z [INF] Sync: ks:sg_test_0.sg_test_0 db:db c:[3c887e56] Sent 1 changes to client, from seq 1
2023-01-05T15:48:58.284Z [DBG] WS+: db:db c:#002 Queued MSG#2~
2023-01-05T15:48:58.284Z [DBG] WSFrame+: db:db c:#002 Push MSG#2~
2023-01-05T15:48:58.284Z [INF] Sync: ks:sg_test_0.sg_test_0 db:db c:[3c887e56] Sent all changes to client
2023-01-05T15:48:58.284Z [DBG] SyncMsg+: ks:sg_test_0.sg_test_0 db:db c:[3c887e56] #2: Type:subChanges   --> Time:1.907314ms
2023-01-05T15:48:58.284Z [DBG] WSFrame+: db:db c:#002 Sending frame: MSG#2~ (flags=  101000, size=   64)
2023-01-05T15:48:58.284Z [DBG] Sync+: db:db c:[3c887e56] Sending rev "<ud>doc1</ud>" 1-ca9ad22802b66f662ff171f226211d5c based on 0 known, digests: []
2023-01-05T15:48:58.284Z [DBG] WSFrame+: t:TestCollectionsReplication Received frame: MSG#2~ (flags=  101000, length=70)
2023-01-05T15:48:58.284Z [DBG] WS+: db:db c:#002 Queued MSG#3~
2023-01-05T15:48:58.284Z [DBG] WSFrame+: db:db c:#002 Push MSG#3~
2023-01-05T15:48:58.284Z [DBG] WS+: t:TestCollectionsReplication Incoming BLIP Request: MSG#2~
2023-01-05T15:48:58.284Z [DBG] WSFrame+: db:db c:#002 Sending frame: MSG#3~ (flags=  101000, size=  116)
2023-01-05T15:48:58.284Z [DBG] WSFrame+: t:TestCollectionsReplication Received frame: MSG#3~ (flags=  101000, length=122)
2023-01-05T15:48:58.284Z [DBG] WS+: t:TestCollectionsReplication Incoming BLIP Request: MSG#3~
2023-01-05T15:48:58.332Z [DBG] WSFrame+: t:TestCollectionsReplication Sender stopped
2023-01-05T15:48:58.333Z [DBG] WSFrame+: db:db c:#002 receiveLoop stopped: failed to get reader: received close frame: status = StatusNormalClosure and reason = ""
2023-01-05T15:48:58.333Z [DBG] WSFrame+: db:db c:#002 Sender stopped
2023-01-05T15:48:58.333Z [DBG] WSFrame+: db:db c:#002 parseLoop stopped
2023-01-05T15:48:58.333Z [DBG] WSFrame+: t:TestCollectionsReplication receiveLoop stopped: failed to get reader: received close frame: status = StatusNormalClosure and reason = ""
2023-01-05T15:48:58.333Z [DBG] WSFrame+: t:TestCollectionsReplication BLIP/Websocket receiveLoop exited: failed to get reader: received close frame: status = StatusNormalClosure and reason = ""
2023-01-05T15:48:58.333Z [DBG] WSFrame+: t:TestCollectionsReplication parseLoop stopped
2023-01-05T15:48:58.383Z [INF] HTTP: db:db c:[3c887e56] #002:    --> BLIP+WebSocket connection closed

```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
