### PR TITLE
make resync endpoints per db

### DIFF
--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -696,11 +696,11 @@ func TestAdminAPIAuth(t *testing.T) {
 		},
 		{
 			Method:   "GET",
-			Endpoint: "/{{.keyspace}}/_resync",
+			Endpoint: "/{{.db}}/_resync",
 		},
 		{
 			Method:   "POST",
-			Endpoint: "/{{.keyspace}}/_resync",
+			Endpoint: "/{{.db}}/_resync",
 		},
 		{
 			Method:   "POST",

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -147,10 +147,6 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	r, dbr, keyspace := createCommonRouter(sc, adminPrivs)
 
 	// Keyspace handlers (single collection):
-	keyspace.Handle("/_resync",
-		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetResync)).Methods("GET")
-	keyspace.Handle("/_resync",
-		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handlePostResync)).Methods("POST")
 	keyspace.Handle("/_purge",
 		makeHandler(sc, adminPrivs, []Permission{PermWriteAppData}, nil, (*handler).handlePurge)).Methods("POST")
 	keyspace.Handle("/_raw/{docid:"+docRegex+"}",
@@ -161,6 +157,10 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeHandler(sc, adminPrivs, []Permission{PermReadAppData}, nil, (*handler).handleDumpChannel)).Methods("GET")
 
 	// Database handlers (multi collection):
+	dbr.Handle("/_resync",
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetResync)).Methods("GET")
+	dbr.Handle("/_resync",
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handlePostResync)).Methods("POST")
 	dbr.Handle("/_compact",
 		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleCompact)).Methods("POST")
 	dbr.Handle("/_compact",


### PR DESCRIPTION
CBG-0000

Describe your PR here...

Resync endpoints are moved to db level from keyspace level. When running resync, resync changes db state to resyncing and then start the process. This restricts to have multiple resync running for multiple collection for single db. Hence, endpoints are moved to db level.


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [x] Link upstream PRs
- [x] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1329/
  -  [x] failed test `rest/TestAdminAPIAuth` is rerun in https://jenkins.sgwdev.com/job/SyncGateway-Integration/1331/ 