### PR TITLE
CBG-2666 Avoid query issues related to MaxInt64 named parameters

### DIFF
--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -56,7 +55,7 @@ func isIndexEmpty(store base.N1QLStore, useXattrs bool) (bool, error) {
 	starChannelQueryStatement = replaceIndexTokensQuery(starChannelQueryStatement, sgIndexes[IndexAllDocs], useXattrs)
 	params := map[string]interface{}{}
 	params[QueryParamStartSeq] = 0
-	params[QueryParamEndSeq] = math.MaxInt64
+	params[QueryParamEndSeq] = N1QLMaxInt64
 
 	// Execute the query
 	results, err := store.Query(starChannelQueryStatement, params, base.RequestPlus, true)

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -156,7 +156,6 @@ func (tester *ChannelRevocationTester) getChanges(sinceSeq interface{}, expected
 
 func InitScenario(t *testing.T, rtConfig *RestTesterConfig) (ChannelRevocationTester, *RestTester) {
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	defaultSyncFn := `
 			function (doc, oldDoc){
 				if (doc._id === 'userRoles'){				

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -155,6 +155,8 @@ func (tester *ChannelRevocationTester) getChanges(sinceSeq interface{}, expected
 }
 
 func InitScenario(t *testing.T, rtConfig *RestTesterConfig) (ChannelRevocationTester, *RestTester) {
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	defaultSyncFn := `
 			function (doc, oldDoc){
 				if (doc._id === 'userRoles'){				


### PR DESCRIPTION
CBG-2666

To avoid query service issues in 7.0.x, use a value for MaxInt64 that won't round to something greater than MaxInt64 as the maximum allowed value for named query parameters.  

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1336/ (full suite, 7.0.3)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1335/ (revocation tests, 7.0.3)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1334/ (revocation tests, 7.0.5)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1333/ (revocation tests, 7.1.2)
