### PR TITLE
CBG-2619: make blip tests in rest package single named collection aware

### DIFF
--- a/rest/api_test_helpers.go
+++ b/rest/api_test_helpers.go
@@ -59,7 +59,7 @@ func (rt *RestTester) PutNewEditsFalse(docID string, newRevID string, parentRevI
 }
 
 func (rt *RestTester) RequireWaitChanges(numChangesExpected int, since string) ChangesResults {
-	changesResults, err := rt.WaitForChanges(numChangesExpected, "/db/_changes?since="+since, "", true)
+	changesResults, err := rt.WaitForChanges(numChangesExpected, "/{{.keyspace}}/_changes?since="+since, "", true)
 	require.NoError(rt.TB, err)
 	require.Len(rt.TB, changesResults.Results, numChangesExpected)
 	return changesResults

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2627,7 +2627,7 @@ func TestAttachmentDeleteOnExpiry(t *testing.T) {
 
 }
 func TestUpdateExistingAttachment(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{ // CBG-2619
+	rt := NewRestTester(t, &RestTesterConfig{
 		GuestEnabled: true,
 	})
 	defer rt.Close()
@@ -2698,7 +2698,7 @@ func TestUpdateExistingAttachment(t *testing.T) {
 // TestPushUnknownAttachmentAsStub sets revpos to an older generation, for an attachment that doesn't exist on the server.
 // Verifies that getAttachment is triggered, and attachment is properly persisted.
 func TestPushUnknownAttachmentAsStub(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{ // CBG-2619
+	rt := NewRestTester(t, &RestTesterConfig{
 		GuestEnabled: true,
 	})
 	defer rt.Close()
@@ -2967,7 +2967,7 @@ func TestPutInvalidAttachment(t *testing.T) {
 // validates that proveAttachment isn't being invoked when the attachment is already present and the
 // digest doesn't change, regardless of revpos.
 func TestCBLRevposHandling(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{ // CBG-2619
+	rt := NewRestTester(t, &RestTesterConfig{
 		GuestEnabled: true,
 	})
 	defer rt.Close()

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2631,12 +2631,11 @@ func TestUpdateExistingAttachment(t *testing.T) {
 		GuestEnabled: true,
 	})
 	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
 
-	btc, err := BlipClientInitialization(t, rt, collection, nil)
+	btc, btcCollection, err := BlipClientInitialization(t, rt, nil)
 	assert.NoError(t, err)
 	defer btc.Close()
-	btcCollection, err := btc.BlipClientCollectionSetup(collection)
+	_, err = btc.pushReplication.bt.BlipCollectionSetup(rt)
 	require.NoError(t, err)
 
 	var doc1Body db.Body
@@ -2702,12 +2701,11 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 		GuestEnabled: true,
 	})
 	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
 
-	btc, err := BlipClientInitialization(t, rt, collection, nil)
+	btc, btcCollection, err := BlipClientInitialization(t, rt, nil)
 	assert.NoError(t, err)
 	defer btc.Close()
-	btcCollection, err := btc.BlipClientCollectionSetup(collection)
+	_, err = btc.pushReplication.bt.BlipCollectionSetup(rt)
 	require.NoError(t, err)
 
 	var doc1Body db.Body
@@ -2770,7 +2768,7 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Replicate data to client and ensure doc arrives
-	err = btc.StartOneshotPull()
+	err = btc.DefaultCollection().StartOneshotPull()
 	assert.NoError(t, err)
 	_, found := btc.WaitForRev("doc", initialRevID)
 	assert.True(t, found)
@@ -2805,7 +2803,7 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Pull rev and attachment down to client
-	err = btc.StartOneshotPull()
+	err = btc.DefaultCollection().StartOneshotPull()
 	assert.NoError(t, err)
 	_, found := btc.WaitForRev("doc", revid)
 	assert.True(t, found)
@@ -2971,12 +2969,11 @@ func TestCBLRevposHandling(t *testing.T) {
 		GuestEnabled: true,
 	})
 	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
 
-	btc, err := BlipClientInitialization(t, rt, collection, nil)
+	btc, btcCollection, err := BlipClientInitialization(t, rt, nil)
 	assert.NoError(t, err)
 	defer btc.Close()
-	btcCollection, err := btc.BlipClientCollectionSetup(collection)
+	_, err = btc.pushReplication.bt.BlipCollectionSetup(rt)
 	require.NoError(t, err)
 
 	var doc1Body db.Body

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -344,8 +344,8 @@ func TestPutAttachmentViaBlipGetViaRest(t *testing.T) {
 	getAttachmentRequest := bt.newRequest()
 	getAttachmentRequest.SetProfile(db.MessageGetAttachment)
 	getAttachmentRequest.Properties[db.GetAttachmentDigest] = input.attachmentDigest
-	sent := bt.sender.Send(getAttachmentRequest)
 	getAttachmentRequest.Properties[db.GetAttachmentID] = input.docId
+	sent := bt.sender.Send(getAttachmentRequest)
 	if !sent {
 		panic(fmt.Sprintf("Failed to send request for doc: %v", input.docId))
 	}

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -327,7 +327,7 @@ func TestPutAttachmentViaBlipGetViaRest(t *testing.T) {
 	require.NoError(t, err)
 	defer bt.Close()
 	collection := bt.restTester.GetSingleTestDatabaseCollection()
-	properties, err := bt.BlipCollectionSetup(collection)
+	properties, err := bt.BlipCollectionSetup(bt.restTester)
 	require.NoError(t, err)
 
 	attachmentBody := "attach"
@@ -377,8 +377,7 @@ func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 	})
 	require.NoError(t, err)
 	defer bt.Close()
-	collection := bt.restTester.GetSingleTestDatabaseCollection()
-	properties, err := bt.BlipCollectionSetup(collection)
+	properties, err := bt.BlipCollectionSetup(bt.restTester)
 	require.NoError(t, err)
 
 	attachmentBody := "attach"
@@ -426,9 +425,8 @@ func TestBlipAttachNameChange(t *testing.T) {
 		GuestEnabled: true,
 	})
 	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
 
-	client1, err := BlipClientInitialization(t, rt, collection, nil)
+	client1, btcCollection, err := BlipClientInitialization(t, rt, nil)
 	require.NoError(t, err)
 	defer client1.Close()
 	base.SetUpTestLogging(t, base.LevelTrace, base.KeySync, base.KeySyncMsg, base.KeyWebSocket, base.KeyWebSocketFrame, base.KeyHTTP, base.KeyCRUD)
@@ -436,7 +434,7 @@ func TestBlipAttachNameChange(t *testing.T) {
 	attachmentA := []byte("attachmentA")
 	attachmentAData := base64.StdEncoding.EncodeToString(attachmentA)
 	digest := db.Sha1DigestKey(attachmentA)
-	btcCollection, err := client1.BlipClientCollectionSetup(collection)
+	_, err = client1.pushReplication.bt.BlipCollectionSetup(rt)
 	require.NoError(t, err)
 
 	// Push initial attachment data
@@ -472,13 +470,12 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 		GuestEnabled: true,
 	})
 	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
-	client1, err := BlipClientInitialization(t, rt, collection, nil)
+	client1, btcCollection, err := BlipClientInitialization(t, rt, nil)
 	require.NoError(t, err)
 	defer client1.Close()
 	base.SetUpTestLogging(t, base.LevelTrace, base.KeySync, base.KeySyncMsg, base.KeyWebSocket, base.KeyWebSocketFrame, base.KeyHTTP, base.KeyCRUD)
 
-	btcCollection, err := client1.BlipClientCollectionSetup(collection)
+	_, err = client1.pushReplication.bt.BlipCollectionSetup(rt)
 	require.NoError(t, err)
 	// Create document in the bucket with a legacy attachment
 	docID := "doc"
@@ -527,12 +524,11 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 		GuestEnabled: true,
 	})
 	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
-	client1, err := BlipClientInitialization(t, rt, collection, nil)
+	client1, btcCollection, err := BlipClientInitialization(t, rt, nil)
 	require.NoError(t, err)
 	defer client1.Close()
 	base.SetUpTestLogging(t, base.LevelTrace, base.KeySync, base.KeySyncMsg, base.KeyWebSocket, base.KeyWebSocketFrame, base.KeyHTTP, base.KeyCRUD)
-	btcCollection, err := client1.BlipClientCollectionSetup(collection)
+	_, err = client1.pushReplication.bt.BlipCollectionSetup(rt)
 	require.NoError(t, err)
 
 	// Create document in the bucket with a legacy attachment.  Properties here align with rawDocWithAttachmentAndSyncMeta

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -349,7 +349,9 @@ func TestPutAttachmentViaBlipGetViaRest(t *testing.T) {
 	getAttachmentRequest.SetProfile(db.MessageGetAttachment)
 	getAttachmentRequest.Properties[db.GetAttachmentDigest] = input.attachmentDigest
 	getAttachmentRequest.Properties[db.GetAttachmentID] = input.docId
-	getAttachmentRequest.Properties[db.BlipCollection] = "0"
+	if !base.IsDefaultCollection(collection.ScopeName(), collection.Name()) {
+		getAttachmentRequest.Properties[db.BlipCollection] = "0"
+	}
 	sent := bt.sender.Send(getAttachmentRequest)
 	if !sent {
 		panic(fmt.Sprintf("Failed to send request for doc: %v", input.docId))

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -420,7 +420,7 @@ func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 
 // TestBlipAttachNameChange tests CBL handling - attachments with changed names are sent as stubs, and not new attachments
 func TestBlipAttachNameChange(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{ // CBG-2619
+	rt := NewRestTester(t, &RestTesterConfig{
 		GuestEnabled: true,
 	})
 	defer rt.Close()
@@ -466,7 +466,7 @@ func TestBlipAttachNameChange(t *testing.T) {
 
 // TestBlipLegacyAttachNameChange ensures that CBL name changes for legacy attachments are handled correctly
 func TestBlipLegacyAttachNameChange(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{ // CBG-2619
+	rt := NewRestTester(t, &RestTesterConfig{
 		GuestEnabled: true,
 	})
 	defer rt.Close()
@@ -521,7 +521,7 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 
 // TestBlipLegacyAttachDocUpdate ensures that CBL updates for documents associated with legacy attachments are handled correctly
 func TestBlipLegacyAttachDocUpdate(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{ // CBG-2619
+	rt := NewRestTester(t, &RestTesterConfig{
 		GuestEnabled: true,
 	})
 	defer rt.Close()

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2175,7 +2175,8 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
-	bt := NewBlipTesterDefaultCollection(t)
+	bt, err := NewBlipTester(t)
+	require.NoError(t, err)
 	defer bt.Close()
 
 	bt.blipContext.HandlerForProfile["changes"] = func(request *blip.Message) {

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -434,7 +434,6 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 	bt, err := NewBlipTester(t)
 	require.NoError(t, err)
 	defer bt.Close()
-	collection := bt.restTester.GetSingleTestDatabaseCollection()
 	// Counter/Waitgroup to help ensure that all callbacks on continuous changes handler are received
 	receivedChangesWg := sync.WaitGroup{}
 	receivedCaughtUpChange := false
@@ -553,9 +552,6 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 	subChangesRequest.SetProfile("subChanges")
 	subChangesRequest.Properties["continuous"] = "false"
 	subChangesRequest.Properties["batch"] = "10" // default batch size is 200, lower this to 5 to make sure we get multiple batches
-	if !base.IsDefaultCollection(collection.ScopeName(), collection.Name()) {
-		subChangesRequest.Properties[db.BlipCollection] = "0"
-	}
 	subChangesRequest.SetCompressed(false)
 
 	body := db.SubChangesBody{DocIDs: docIDsExpected}
@@ -897,7 +893,6 @@ function(doc, oldDoc) {
 	rtConfig := RestTesterConfig{SyncFn: syncFunction}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
 
 	// Create bliptester that is connected as user1, with no access to channel ABC
 	bt, err := NewBlipTesterFromSpecWithRT(t, &BlipTesterSpec{
@@ -984,9 +979,6 @@ function(doc, oldDoc) {
 	subChangesRequest.SetProfile("subChanges")
 	subChangesRequest.Properties["continuous"] = "true"
 	subChangesRequest.Properties["batch"] = "10" // default batch size is 200, lower this to 10 to make sure we get multiple batches
-	if !base.IsDefaultCollection(collection.ScopeName(), collection.Name()) {
-		subChangesRequest.Properties[db.BlipCollection] = "0"
-	}
 	subChangesRequest.SetCompressed(false)
 	sent := bt.sender.Send(subChangesRequest)
 	assert.True(t, sent)

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2175,8 +2175,8 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
-	bt, err := NewBlipTester(t)
-	require.NoError(t, err)
+	// TODO: CBG-2653: change this to use NewBlipTester
+	bt := NewBlipTesterDefaultCollection(t)
 	defer bt.Close()
 
 	bt.blipContext.HandlerForProfile["changes"] = func(request *blip.Message) {

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -762,7 +762,7 @@ func TestPublicPortAuthentication(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	// Create bliptester that is connected as user1, with access to the user1 channel
-	btUser1, err := NewBlipTesterFromSpec(t, // CBG-2619: make collection aware
+	btUser1, err := NewBlipTesterFromSpec(t,
 		BlipTesterSpec{
 			connectingUsername: "user1",
 			connectingPassword: "1234",

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -844,13 +844,8 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 	assert.Equal(t, "2-abc", newRev)
 
 	// Check EE is delta, and CE is full-body replication
-	if base.IsDefaultCollection(collection.ScopeName(), collection.Name()) {
-		msg, ok = client.pushReplication.WaitForMessage(2)
-		assert.True(t, ok)
-	} else {
-		msg, ok = client.pushReplication.WaitForMessage(3)
-		assert.True(t, ok)
-	}
+	msg, found := client.waitForReplicationMessage(collection, 2)
+	assert.True(t, found)
 
 	if base.IsEnterpriseEdition() {
 		// Check the request was sent with the correct deltaSrc property
@@ -963,13 +958,8 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "2-abc", newRev)
 	// Check EE is delta, and CE is full-body replication
-	if base.IsDefaultCollection(collection.ScopeName(), collection.Name()) {
-		msg, ok = client.pushReplication.WaitForMessage(2)
-		assert.True(t, ok)
-	} else {
-		msg, ok = client.pushReplication.WaitForMessage(3)
-		assert.True(t, ok)
-	}
+	msg, found := client.waitForReplicationMessage(collection, 2)
+	assert.True(t, found)
 
 	// Check the request was NOT sent with a deltaSrc property
 	assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -33,8 +33,10 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 	}
 
 	const docID = "pushAttachmentDoc"
+	var revID string
+	var body []byte
 
-	rt := NewRestTesterDefaultCollection(t, // CBG-2619: make collection aware
+	rt := NewRestTester(t, // CBG-2619: make collection aware
 		&RestTesterConfig{
 			DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 				DeltaSync: &DeltaSyncConfig{
@@ -44,19 +46,32 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 			GuestEnabled: true,
 		})
 	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
+	btc, isDefault, err := BlipClientInitialization(t, rt, collection, nil)
 	require.NoError(t, err)
 	defer btc.Close()
+	btcCollection, err := btc.BlipClientCollectionSetup(collection)
+	require.NoError(t, err)
 
 	// Push first rev
-	revID, err := btc.PushRev(docID, "", []byte(`{"key":"val"}`))
-	require.NoError(t, err)
+	if isDefault {
+		revID, err = btc.PushRev(docID, "", []byte(`{"key":"val"}`))
+		require.NoError(t, err)
+	} else {
+		revID, err = btcCollection.PushRev(docID, "", []byte(`{"key":"val"}`))
+		require.NoError(t, err)
+	}
 
 	// Push second rev with an attachment (no delta yet)
 	attData := base64.StdEncoding.EncodeToString([]byte("attach"))
-	revID, err = btc.PushRev(docID, revID, []byte(`{"key":"val","_attachments":{"myAttachment":{"data":"`+attData+`"}}}`))
-	require.NoError(t, err)
+	if isDefault {
+		revID, err = btc.PushRev(docID, revID, []byte(`{"key":"val","_attachments":{"myAttachment":{"data":"`+attData+`"}}}`))
+		require.NoError(t, err)
+	} else {
+		revID, err = btcCollection.PushRev(docID, revID, []byte(`{"key":"val","_attachments":{"myAttachment":{"data":"`+attData+`"}}}`))
+		require.NoError(t, err)
+	}
 
 	syncData, err := rt.GetDatabase().GetSingleDatabaseCollection().GetDocSyncData(base.TestCtx(t), docID)
 	require.NoError(t, err)
@@ -69,12 +84,22 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 	btc.ClientDeltas = true
 
 	// Get existing body with the stub attachment, insert a new property and push as delta.
-	body, found := btc.GetRev(docID, revID)
-	require.True(t, found)
+	if isDefault {
+		body, found = btc.GetRev(docID, revID)
+		require.True(t, found)
+	} else {
+		body, found = btcCollection.GetRev(docID, revID)
+		require.True(t, found)
+	}
 	newBody, err := base.InjectJSONPropertiesFromBytes(body, base.KVPairBytes{Key: "update", Val: []byte(`true`)})
 	require.NoError(t, err)
-	revID, err = btc.PushRev(docID, revID, newBody)
-	require.NoError(t, err)
+	if isDefault {
+		revID, err = btc.PushRev(docID, revID, newBody)
+		require.NoError(t, err)
+	} else {
+		revID, err = btcCollection.PushRev(docID, revID, newBody)
+		require.NoError(t, err)
+	}
 
 	syncData, err = rt.GetDatabase().GetSingleDatabaseCollection().GetDocSyncData(base.TestCtx(t), docID)
 	require.NoError(t, err)
@@ -282,42 +307,64 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTesterDefaultCollection(t, // CBG-2619: make collection aware
+	rt := NewRestTester(t, // CBG-2619: make collection aware
 		&rtConfig)
 	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
 
 	var deltaSentCount int64
+	var msg *blip.Message
 
 	if rt.GetDatabase().DbStats.DeltaSync() != nil {
 		deltaSentCount = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 	}
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
+	client, isDefault, err := BlipClientInitialization(t, rt, collection, nil)
 	require.NoError(t, err)
 	defer client.Close()
+	btcCollection, err := client.BlipClientCollectionSetup(collection)
+	require.NoError(t, err)
 
 	client.ClientDeltas = true
-	err = client.StartPull()
-	assert.NoError(t, err)
+	if isDefault {
+		err = client.StartPull()
+		assert.NoError(t, err)
+	} else {
+		err = btcCollection.StartPull()
+		assert.NoError(t, err)
+	}
 
 	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 	assert.Equal(t, http.StatusCreated, resp.Code)
 
-	data, ok := client.WaitForRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4")
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+	if isDefault {
+		data, ok := client.WaitForRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4")
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+	} else {
+		data, ok := btcCollection.WaitForRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4")
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+	}
 
 	// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
-	resp = rt.SendAdminRequest(http.MethodPut, "/db/doc1?rev=1-0335a345b6ffed05707ccc4cbc1b67f4", `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1?rev=1-0335a345b6ffed05707ccc4cbc1b67f4", `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
 	assert.Equal(t, http.StatusCreated, resp.Code)
 
-	data, ok = client.WaitForRev("doc1", "2-26359894b20d89c97638e71c40482f28")
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
-
-	msg, ok := client.WaitForBlipRevMessage("doc1", "2-26359894b20d89c97638e71c40482f28")
-	assert.True(t, ok)
+	if isDefault {
+		data, ok := client.WaitForRev("doc1", "2-26359894b20d89c97638e71c40482f28")
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
+		msg, ok = client.WaitForBlipRevMessage("doc1", "2-26359894b20d89c97638e71c40482f28")
+		assert.True(t, ok)
+	} else {
+		data, ok := btcCollection.WaitForRev("doc1", "2-26359894b20d89c97638e71c40482f28")
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
+		msg, ok = btcCollection.WaitForBlipRevMessage("doc1", "2-26359894b20d89c97638e71c40482f28")
+		assert.True(t, ok)
+	}
 
 	// Check EE is delta, and CE is full-body replication
 	if base.IsEnterpriseEdition() {
@@ -363,9 +410,10 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTesterDefaultCollection(t, // CBG-2619: make collection aware
+	rt := NewRestTester(t, // CBG-2619: make collection aware
 		&rtConfig)
 	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
 
 	// create doc1 rev 1
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
@@ -374,29 +422,44 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 
 	deltaSentCount := rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
+	client, isDefault, err := BlipClientInitialization(t, rt, collection, nil)
 	require.NoError(t, err)
 	defer client.Close()
+	btcCollection, err := client.BlipClientCollectionSetup(collection)
+	require.NoError(t, err)
 
 	// reject deltas built ontop of rev 1
 	client.rejectDeltasForSrcRev = rev1ID
 
 	client.ClientDeltas = true
-	err = client.StartPull()
-	assert.NoError(t, err)
-
-	data, ok := client.WaitForRev("doc1", rev1ID)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+	if isDefault {
+		err = client.StartPull()
+		assert.NoError(t, err)
+		data, ok := client.WaitForRev("doc1", rev1ID)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+	} else {
+		err = btcCollection.StartPull()
+		assert.NoError(t, err)
+		data, ok := btcCollection.WaitForRev("doc1", rev1ID)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+	}
 
 	// create doc1 rev 2
-	resp = rt.SendAdminRequest(http.MethodPut, "/db/doc1?rev="+rev1ID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1?rev="+rev1ID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
 	assert.Equal(t, http.StatusCreated, resp.Code)
 	rev2ID := RespRevID(t, resp)
 
-	data, ok = client.WaitForRev("doc1", rev2ID)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
+	if isDefault {
+		data, ok := client.WaitForRev("doc1", rev2ID)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
+	} else {
+		data, ok := btcCollection.WaitForRev("doc1", rev2ID)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
+	}
 
 	msg, ok := client.pullReplication.WaitForMessage(5)
 	assert.True(t, ok)
@@ -409,8 +472,13 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 	assert.Equal(t, `{"greetings":{"2-":[{"howdy":12345678901234567890}]}}`, string(msgBody))
 	assert.Equal(t, deltaSentCount+1, rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
 
-	msg, ok = client.WaitForBlipRevMessage("doc1", "2-26359894b20d89c97638e71c40482f28")
-	assert.True(t, ok)
+	if isDefault {
+		msg, ok = client.WaitForBlipRevMessage("doc1", "2-26359894b20d89c97638e71c40482f28")
+		assert.True(t, ok)
+	} else {
+		msg, ok = btcCollection.WaitForBlipRevMessage("doc1", "2-26359894b20d89c97638e71c40482f28")
+		assert.True(t, ok)
+	}
 
 	// Check the resent request was NOT sent with a deltaSrc property
 	assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
@@ -428,11 +496,12 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
-	rt := NewRestTesterDefaultCollection(t, // CBG-2619: make collection aware
+	rt := NewRestTester(t, // CBG-2619: make collection aware
 		&rtConfig)
 	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+	client, isDefault, err := BlipClientInitialization(t, rt, collection, &BlipTesterClientOpts{
 		Username:               "alice",
 		Channels:               []string{"public"},
 		ClientDeltas:           true,
@@ -440,26 +509,46 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 	})
 	require.NoError(t, err)
 	defer client.Close()
+	btcCollection, err := client.BlipClientCollectionSetup(collection)
+	require.NoError(t, err)
 
-	err = client.StartPull()
-	assert.NoError(t, err)
+	if isDefault {
+		err = client.StartPull()
+		assert.NoError(t, err)
+	} else {
+		err = btcCollection.StartPull()
+		assert.NoError(t, err)
+	}
 
 	// create doc1 rev 1-1513b53e2738671e634d9dd111f48de0
-	resp := rt.SendAdminRequest(http.MethodPut, "/db/doc1", `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
 	assert.Equal(t, http.StatusCreated, resp.Code)
 
-	data, ok := client.WaitForRev("doc1", "1-1513b53e2738671e634d9dd111f48de0")
-	assert.True(t, ok)
-	assert.Contains(t, string(data), `"channels":["public"]`)
-	assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+	if isDefault {
+		data, ok := client.WaitForRev("doc1", "1-1513b53e2738671e634d9dd111f48de0")
+		assert.True(t, ok)
+		assert.Contains(t, string(data), `"channels":["public"]`)
+		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+	} else {
+		data, ok := btcCollection.WaitForRev("doc1", "1-1513b53e2738671e634d9dd111f48de0")
+		assert.True(t, ok)
+		assert.Contains(t, string(data), `"channels":["public"]`)
+		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+	}
 
 	// create doc1 rev 2-ff91e11bc1fd12bbb4815a06571859a9
-	resp = rt.SendAdminRequest(http.MethodPut, "/db/doc1?rev=1-1513b53e2738671e634d9dd111f48de0", `{"channels": ["private"], "greetings": [{"hello": "world!"}, {"hi": "bob"}]}`)
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1?rev=1-1513b53e2738671e634d9dd111f48de0", `{"channels": ["private"], "greetings": [{"hello": "world!"}, {"hi": "bob"}]}`)
 	assert.Equal(t, http.StatusCreated, resp.Code)
 
-	data, ok = client.WaitForRev("doc1", "2-ff91e11bc1fd12bbb4815a06571859a9")
-	assert.True(t, ok)
-	assert.Equal(t, `{"_removed":true}`, string(data))
+	if isDefault {
+		data, ok := client.WaitForRev("doc1", "2-ff91e11bc1fd12bbb4815a06571859a9")
+		assert.True(t, ok)
+		assert.Equal(t, `{"_removed":true}`, string(data))
+	} else {
+		data, ok := btcCollection.WaitForRev("doc1", "2-ff91e11bc1fd12bbb4815a06571859a9")
+		assert.True(t, ok)
+		assert.Equal(t, `{"_removed":true}`, string(data))
+	}
 
 	msg, ok := client.pullReplication.WaitForMessage(5)
 	assert.True(t, ok)
@@ -484,14 +573,17 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
-	rt := NewRestTesterDefaultCollection(t, // CBG-2619: make collection aware
+	rt := NewRestTester(t, // CBG-2619: make collection aware
 		&rtConfig)
 	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
 
 	var deltaCacheHitsStart int64
 	var deltaCacheMissesStart int64
 	var deltasRequestedStart int64
 	var deltasSentStart int64
+	var data []byte
+	var ok bool
 
 	if rt.GetDatabase().DbStats.DeltaSync() != nil {
 		deltaCacheHitsStart = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
@@ -500,33 +592,53 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 		deltasSentStart = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 	}
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+	client, isDefault, err := BlipClientInitialization(t, rt, collection, &BlipTesterClientOpts{
 		Username:     "alice",
 		Channels:     []string{"public"},
 		ClientDeltas: true,
 	})
 	require.NoError(t, err)
 	defer client.Close()
+	btcCollection, err := client.BlipClientCollectionSetup(collection)
+	require.NoError(t, err)
 
-	err = client.StartPull()
-	assert.NoError(t, err)
+	if isDefault {
+		err = client.StartPull()
+		assert.NoError(t, err)
+	} else {
+		err = btcCollection.StartPull()
+		assert.NoError(t, err)
+	}
 
 	// create doc1 rev 1-e89945d756a1d444fa212bffbbb31941
-	resp := rt.SendAdminRequest(http.MethodPut, "/db/doc1", `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
 	assert.Equal(t, http.StatusCreated, resp.Code)
 
-	data, ok := client.WaitForRev("doc1", "1-1513b53e2738671e634d9dd111f48de0")
-	assert.True(t, ok)
-	assert.Contains(t, string(data), `"channels":["public"]`)
-	assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+	if isDefault {
+		data, ok = client.WaitForRev("doc1", "1-1513b53e2738671e634d9dd111f48de0")
+		assert.True(t, ok)
+		assert.Contains(t, string(data), `"channels":["public"]`)
+		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+	} else {
+		data, ok = btcCollection.WaitForRev("doc1", "1-1513b53e2738671e634d9dd111f48de0")
+		assert.True(t, ok)
+		assert.Contains(t, string(data), `"channels":["public"]`)
+		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+	}
 
 	// tombstone doc1 at rev 2-2db70833630b396ef98a3ec75b3e90fc
-	resp = rt.SendAdminRequest(http.MethodDelete, "/db/doc1?rev=1-1513b53e2738671e634d9dd111f48de0", "")
+	resp = rt.SendAdminRequest(http.MethodDelete, "/{{.keyspace}}/doc1?rev=1-1513b53e2738671e634d9dd111f48de0", "")
 	assert.Equal(t, http.StatusOK, resp.Code)
 
-	data, ok = client.WaitForRev("doc1", "2-ed278cbc310c9abeea414da15d0b2cac")
-	assert.True(t, ok)
-	assert.Equal(t, `{}`, string(data))
+	if isDefault {
+		data, ok = client.WaitForRev("doc1", "2-ed278cbc310c9abeea414da15d0b2cac")
+		assert.True(t, ok)
+		assert.Equal(t, `{}`, string(data))
+	} else {
+		data, ok = btcCollection.WaitForRev("doc1", "2-ed278cbc310c9abeea414da15d0b2cac")
+		assert.True(t, ok)
+		assert.Equal(t, `{}`, string(data))
+	}
 
 	msg, ok := client.pullReplication.WaitForMessage(5)
 	assert.True(t, ok)
@@ -580,15 +692,18 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
-	rt := NewRestTesterDefaultCollection(t, // CBG-2619: make collection aware
+	rt := NewRestTester(t, // CBG-2619: make collection aware
 		&rtConfig)
-
 	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
 
 	var deltaCacheHitsStart int64
 	var deltaCacheMissesStart int64
 	var deltasRequestedStart int64
 	var deltasSentStart int64
+	var data []byte
+	var ok bool
+	var msg *blip.Message
 
 	if rt.GetDatabase().DbStats.DeltaSync() != nil {
 		deltaCacheHitsStart = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
@@ -596,53 +711,84 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 		deltasRequestedStart = rt.GetDatabase().DbStats.DeltaSync().DeltasRequested.Value()
 		deltasSentStart = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 	}
-
-	client1, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+	client1, isDefault, err := BlipClientInitialization(t, rt, collection, &BlipTesterClientOpts{
 		Username:     "client1",
 		Channels:     []string{"*"},
 		ClientDeltas: true,
 	})
 	require.NoError(t, err)
 	defer client1.Close()
+	btcCollection1, err := client1.BlipClientCollectionSetup(collection)
+	require.NoError(t, err)
 
-	client2, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+	client2, _, err := BlipClientInitialization(t, rt, collection, &BlipTesterClientOpts{
 		Username:     "client2",
 		Channels:     []string{"*"},
 		ClientDeltas: true,
 	})
 	require.NoError(t, err)
 	defer client2.Close()
-
-	err = client1.StartPull()
+	btcCollection2, err := client2.BlipClientCollectionSetup(collection)
 	require.NoError(t, err)
 
+	if isDefault {
+		err = client1.StartPull()
+		require.NoError(t, err)
+	} else {
+		err = btcCollection1.StartPull()
+		require.NoError(t, err)
+	}
+
 	// create doc1 rev 1-e89945d756a1d444fa212bffbbb31941
-	resp := rt.SendAdminRequest(http.MethodPut, "/db/doc1", `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
 	assert.Equal(t, http.StatusCreated, resp.Code)
 
-	data, ok := client1.WaitForRev("doc1", "1-1513b53e2738671e634d9dd111f48de0")
-	assert.True(t, ok)
-	assert.Contains(t, string(data), `"channels":["public"]`)
-	assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+	if isDefault {
+		data, ok = client1.WaitForRev("doc1", "1-1513b53e2738671e634d9dd111f48de0")
+		assert.True(t, ok)
+		assert.Contains(t, string(data), `"channels":["public"]`)
+		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+	} else {
+		data, ok = btcCollection1.WaitForRev("doc1", "1-1513b53e2738671e634d9dd111f48de0")
+		assert.True(t, ok)
+		assert.Contains(t, string(data), `"channels":["public"]`)
+		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+	}
 
 	// Have client2 get only rev-1 and then stop replicating
-	err = client2.StartOneshotPull()
-	assert.NoError(t, err)
-	data, ok = client2.WaitForRev("doc1", "1-1513b53e2738671e634d9dd111f48de0")
-	assert.True(t, ok)
-	assert.Contains(t, string(data), `"channels":["public"]`)
-	assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+	if isDefault {
+		err = client2.StartOneshotPull()
+		assert.NoError(t, err)
+		data, ok = client2.WaitForRev("doc1", "1-1513b53e2738671e634d9dd111f48de0")
+		assert.True(t, ok)
+		assert.Contains(t, string(data), `"channels":["public"]`)
+		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+	} else {
+		err = btcCollection2.StartOneshotPull()
+		assert.NoError(t, err)
+		data, ok = btcCollection2.WaitForRev("doc1", "1-1513b53e2738671e634d9dd111f48de0")
+		assert.True(t, ok)
+		assert.Contains(t, string(data), `"channels":["public"]`)
+		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+	}
 
 	// tombstone doc1 at rev 2-2db70833630b396ef98a3ec75b3e90fc
-	resp = rt.SendAdminRequest(http.MethodDelete, "/db/doc1?rev=1-1513b53e2738671e634d9dd111f48de0", `{"test": true"`)
+	resp = rt.SendAdminRequest(http.MethodDelete, "/{{.keyspace}}/doc1?rev=1-1513b53e2738671e634d9dd111f48de0", `{"test": true"`)
 	assert.Equal(t, http.StatusOK, resp.Code)
 
-	data, ok = client1.WaitForRev("doc1", "2-ed278cbc310c9abeea414da15d0b2cac")
-	assert.True(t, ok)
-	assert.Equal(t, `{}`, string(data))
-
-	msg, ok := client1.WaitForBlipRevMessage("doc1", "2-ed278cbc310c9abeea414da15d0b2cac") // docid, revid to get the message
-	assert.True(t, ok)
+	if isDefault {
+		data, ok = client1.WaitForRev("doc1", "2-ed278cbc310c9abeea414da15d0b2cac")
+		assert.True(t, ok)
+		assert.Equal(t, `{}`, string(data))
+		msg, ok = client1.WaitForBlipRevMessage("doc1", "2-ed278cbc310c9abeea414da15d0b2cac") // docid, revid to get the message
+		assert.True(t, ok)
+	} else {
+		data, ok = btcCollection1.WaitForRev("doc1", "2-ed278cbc310c9abeea414da15d0b2cac")
+		assert.True(t, ok)
+		assert.Equal(t, `{}`, string(data))
+		msg, ok = btcCollection1.WaitForBlipRevMessage("doc1", "2-ed278cbc310c9abeea414da15d0b2cac") // docid, revid to get the message
+		assert.True(t, ok)
+	}
 	if !assert.Equal(t, db.MessageRev, msg.Profile()) {
 		t.Logf("unexpected profile for message %v in %v",
 			msg.SerialNumber(), client1.pullReplication.GetMessages())
@@ -659,15 +805,24 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 	}
 
 	// Sync Gateway will have cached the tombstone delta, so client 2 should be able to retrieve it from the cache
-	err = client2.StartOneshotPull()
-	assert.NoError(t, err)
+	if isDefault {
+		err = client2.StartOneshotPull()
+		assert.NoError(t, err)
+		data, ok = client2.WaitForRev("doc1", "2-ed278cbc310c9abeea414da15d0b2cac")
+		assert.True(t, ok)
+		assert.Equal(t, `{}`, string(data))
+		msg, ok = client2.WaitForBlipRevMessage("doc1", "2-ed278cbc310c9abeea414da15d0b2cac")
+		assert.True(t, ok)
+	} else {
+		err = btcCollection2.StartOneshotPull()
+		assert.NoError(t, err)
+		data, ok = btcCollection2.WaitForRev("doc1", "2-ed278cbc310c9abeea414da15d0b2cac")
+		assert.True(t, ok)
+		assert.Equal(t, `{}`, string(data))
+		msg, ok = btcCollection2.WaitForBlipRevMessage("doc1", "2-ed278cbc310c9abeea414da15d0b2cac")
+		assert.True(t, ok)
+	}
 
-	data, ok = client2.WaitForRev("doc1", "2-ed278cbc310c9abeea414da15d0b2cac")
-	assert.True(t, ok)
-	assert.Equal(t, `{}`, string(data))
-
-	msg, ok = client2.WaitForBlipRevMessage("doc1", "2-ed278cbc310c9abeea414da15d0b2cac")
-	assert.True(t, ok)
 	if !assert.Equal(t, db.MessageRev, msg.Profile()) {
 		t.Logf("unexpected profile for message %v in %v",
 			msg.SerialNumber(), client2.pullReplication.GetMessages())
@@ -717,6 +872,9 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 	}
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	var data []byte
+	var ok bool
+	var msg, msg2 *blip.Message
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{
@@ -727,50 +885,80 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTesterDefaultCollection(t, // CBG-2619: make collection aware
+	rt := NewRestTester(t, // CBG-2619: make collection aware
 		&rtConfig)
 	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
+	client, isDefault, err := BlipClientInitialization(t, rt, collection, nil)
 	require.NoError(t, err)
 	defer client.Close()
+	btcCollection1, err := client.BlipClientCollectionSetup(collection)
+	require.NoError(t, err)
 
 	client.ClientDeltas = true
-	err = client.StartPull()
-	assert.NoError(t, err)
+	if isDefault {
+		err = client.StartPull()
+		assert.NoError(t, err)
+	} else {
+		err = btcCollection1.StartPull()
+		assert.NoError(t, err)
+	}
 
 	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 	assert.Equal(t, http.StatusCreated, resp.Code)
 
-	data, ok := client.WaitForRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4")
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+	if isDefault {
+		data, ok = client.WaitForRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4")
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+	} else {
+		data, ok = btcCollection1.WaitForRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4")
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+	}
 
 	// Perform a one-shot pull as client 2 to pull down the first revision
 
-	client2, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
+	client2, _, err := BlipClientInitialization(t, rt, collection, nil)
 	require.NoError(t, err)
 	defer client2.Close()
+	btcCollection2, err := client2.BlipClientCollectionSetup(collection)
+	require.NoError(t, err)
 
 	client2.ClientDeltas = true
-	err = client2.StartOneshotPull()
-	assert.NoError(t, err)
-
-	data, ok = client2.WaitForRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4")
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+	if isDefault {
+		err = client2.StartOneshotPull()
+		assert.NoError(t, err)
+		data, ok = client2.WaitForRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4")
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+	} else {
+		err = btcCollection2.StartOneshotPull()
+		assert.NoError(t, err)
+		data, ok = btcCollection2.WaitForRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4")
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+	}
 
 	// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
-	resp = rt.SendAdminRequest(http.MethodPut, "/db/doc1?rev=1-0335a345b6ffed05707ccc4cbc1b67f4", `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": "bob"}]}`)
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1?rev=1-0335a345b6ffed05707ccc4cbc1b67f4", `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": "bob"}]}`)
 	assert.Equal(t, http.StatusCreated, resp.Code)
 
-	data, ok = client.WaitForRev("doc1", "2-959f0e9ad32d84ff652fb91d8d0caa7e")
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(data))
-
-	msg, ok := client.WaitForBlipRevMessage("doc1", "2-959f0e9ad32d84ff652fb91d8d0caa7e")
-	assert.True(t, ok)
+	if isDefault {
+		data, ok = client.WaitForRev("doc1", "2-959f0e9ad32d84ff652fb91d8d0caa7e")
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(data))
+		msg, ok = client.WaitForBlipRevMessage("doc1", "2-959f0e9ad32d84ff652fb91d8d0caa7e")
+		assert.True(t, ok)
+	} else {
+		data, ok = btcCollection1.WaitForRev("doc1", "2-959f0e9ad32d84ff652fb91d8d0caa7e")
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(data))
+		msg, ok = btcCollection1.WaitForBlipRevMessage("doc1", "2-959f0e9ad32d84ff652fb91d8d0caa7e")
+		assert.True(t, ok)
+	}
 
 	// Check EE is delta
 	// Check the request was sent with the correct deltaSrc property
@@ -785,11 +973,17 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 
 	// Run another one shot pull to get the 2nd revision - validate it comes as delta, and uses cached version
 	client2.ClientDeltas = true
-	err = client2.StartOneshotPull()
-	assert.NoError(t, err)
-
-	msg2, ok := client2.WaitForBlipRevMessage("doc1", "2-959f0e9ad32d84ff652fb91d8d0caa7e")
-	assert.True(t, ok)
+	if isDefault {
+		err = client2.StartOneshotPull()
+		assert.NoError(t, err)
+		msg2, ok = client2.WaitForBlipRevMessage("doc1", "2-959f0e9ad32d84ff652fb91d8d0caa7e")
+		assert.True(t, ok)
+	} else {
+		err = btcCollection2.StartOneshotPull()
+		assert.NoError(t, err)
+		msg2, ok = btcCollection2.WaitForBlipRevMessage("doc1", "2-959f0e9ad32d84ff652fb91d8d0caa7e")
+		assert.True(t, ok)
+	}
 
 	// Check the request was sent with the correct deltaSrc property
 	assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg2.Properties[db.RevMessageDeltaSrc])
@@ -812,6 +1006,10 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	sgUseDeltas := base.IsEnterpriseEdition()
+	var newRev, revID string
+	var ok bool
+	var data []byte
+	var msg *blip.Message
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			DeltaSync: &DeltaSyncConfig{
@@ -820,34 +1018,56 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTesterDefaultCollection(t, // CBG-2619: make collection aware
+	rt := NewRestTester(t, // CBG-2619: make collection aware
 		&rtConfig)
 	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
+	client, isDefault, err := BlipClientInitialization(t, rt, collection, nil)
 	require.NoError(t, err)
 	defer client.Close()
-
 	client.ClientDeltas = true
-	err = client.StartPull()
-	assert.NoError(t, err)
+	btcCollection, err := client.BlipClientCollectionSetup(collection)
+	require.NoError(t, err)
+
+	if isDefault {
+		err = client.StartPull()
+		assert.NoError(t, err)
+	} else {
+		err = btcCollection.StartPull()
+		assert.NoError(t, err)
+	}
 
 	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 	assert.Equal(t, http.StatusCreated, resp.Code)
 
-	data, ok := client.WaitForRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4")
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
-
-	// create doc1 rev 2-abc on client
-	newRev, err := client.PushRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
-	assert.NoError(t, err)
-	assert.Equal(t, "2-abc", newRev)
+	if isDefault {
+		data, ok = client.WaitForRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4")
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+		// create doc1 rev 2-abc on client
+		newRev, err = client.PushRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
+		assert.NoError(t, err)
+		assert.Equal(t, "2-abc", newRev)
+	} else {
+		data, ok = btcCollection.WaitForRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4")
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+		// create doc1 rev 2-abc on client
+		newRev, err = btcCollection.PushRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
+		assert.NoError(t, err)
+		assert.Equal(t, "2-abc", newRev)
+	}
 
 	// Check EE is delta, and CE is full-body replication
-	msg, ok := client.pushReplication.WaitForMessage(2)
-	assert.True(t, ok)
+	if isDefault {
+		msg, ok = client.pushReplication.WaitForMessage(2)
+		assert.True(t, ok)
+	} else {
+		msg, ok = client.pushReplication.WaitForMessage(3)
+		assert.True(t, ok)
+	}
 
 	if base.IsEnterpriseEdition() {
 		// Check the request was sent with the correct deltaSrc property
@@ -871,7 +1091,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(msgBody))
 	}
 
-	resp = rt.SendAdminRequest(http.MethodGet, "/db/doc1?rev="+newRev, "")
+	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/doc1?rev="+newRev, "")
 	assert.Equal(t, http.StatusOK, resp.Code)
 	var respBody db.Body
 	assert.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &respBody))
@@ -884,19 +1104,29 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{"howdy": "bob"}, greetings[2])
 
 	// tombstone doc1 (gets rev 3-f3be6c85e0362153005dae6f08fc68bb)
-	resp = rt.SendAdminRequest(http.MethodDelete, "/db/doc1?rev="+newRev, "")
+	resp = rt.SendAdminRequest(http.MethodDelete, "/{{.keyspace}}/doc1?rev="+newRev, "")
 	assert.Equal(t, http.StatusOK, resp.Code)
 
-	data, ok = client.WaitForRev("doc1", "3-fcc2db8cdbf1831799b7a39bb57edd71")
-	assert.True(t, ok)
-	assert.Equal(t, `{}`, string(data))
+	if isDefault {
+		data, ok = client.WaitForRev("doc1", "3-fcc2db8cdbf1831799b7a39bb57edd71")
+		assert.True(t, ok)
+		assert.Equal(t, `{}`, string(data))
+	} else {
+		data, ok = btcCollection.WaitForRev("doc1", "3-fcc2db8cdbf1831799b7a39bb57edd71")
+		assert.True(t, ok)
+		assert.Equal(t, `{}`, string(data))
+	}
 
 	var deltaPushDocCountStart int64
 
 	if rt.GetDatabase().DbStats.DeltaSync() != nil {
 		deltaPushDocCountStart = rt.GetDatabase().DbStats.DeltaSync().DeltaPushDocCount.Value()
 	}
-	revID, err := client.PushRev("doc1", "3-fcc2db8cdbf1831799b7a39bb57edd71", []byte(`{"undelete":true}`))
+	if isDefault {
+		revID, err = client.PushRev("doc1", "3-fcc2db8cdbf1831799b7a39bb57edd71", []byte(`{"undelete":true}`))
+	} else {
+		revID, err = btcCollection.PushRev("doc1", "3-fcc2db8cdbf1831799b7a39bb57edd71", []byte(`{"undelete":true}`))
+	}
 
 	if base.IsEnterpriseEdition() {
 		// Now make the client push up a delta that has the parent of the tombstone.
@@ -932,34 +1162,58 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTesterDefaultCollection(t, // CBG-2619: make collection aware
+	rt := NewRestTester(t, // CBG-2619: make collection aware
 		&rtConfig)
 	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
+	var msg *blip.Message
+	var ok bool
+	var data []byte
+	var newRev string
+
+	client, isDefault, err := BlipClientInitialization(t, rt, collection, nil)
 	require.NoError(t, err)
 	defer client.Close()
+	btcCollection, err := client.BlipClientCollectionSetup(collection)
+	require.NoError(t, err)
 
 	client.ClientDeltas = false
-	err = client.StartPull()
-	assert.NoError(t, err)
+	if isDefault {
+		err = client.StartPull()
+		assert.NoError(t, err)
+	} else {
+		err = btcCollection.StartPull()
+		assert.NoError(t, err)
+	}
 
 	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 	assert.Equal(t, http.StatusCreated, resp.Code)
 
-	data, ok := client.WaitForRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4")
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
-
-	// create doc1 rev 2-abcxyz on client
-	newRev, err := client.PushRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
-	assert.NoError(t, err)
-	assert.Equal(t, "2-abc", newRev)
-
-	// Check EE is delta, and CE is full-body replication
-	msg, ok := client.pushReplication.WaitForMessage(2)
-	assert.True(t, ok)
+	if isDefault {
+		data, ok = client.WaitForRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4")
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+		// create doc1 rev 2-abcxyz on client
+		newRev, err = client.PushRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
+		assert.NoError(t, err)
+		assert.Equal(t, "2-abc", newRev)
+		// Check EE is delta, and CE is full-body replication
+		msg, ok = client.pushReplication.WaitForMessage(2)
+		assert.True(t, ok)
+	} else {
+		data, ok = btcCollection.WaitForRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4")
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+		// create doc1 rev 2-abcxyz on client
+		newRev, err = btcCollection.PushRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
+		assert.NoError(t, err)
+		assert.Equal(t, "2-abc", newRev)
+		// Check EE is delta, and CE is full-body replication
+		msg, ok = client.pushReplication.WaitForMessage(3)
+		assert.True(t, ok)
+	}
 
 	// Check the request was NOT sent with a deltaSrc property
 	assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
@@ -969,7 +1223,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 	assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
 	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(msgBody))
 
-	resp = rt.SendAdminRequest(http.MethodGet, "/db/doc1?rev="+newRev, "")
+	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/doc1?rev="+newRev, "")
 	assert.Equal(t, http.StatusOK, resp.Code)
 	assert.Contains(t, resp.Body.String(), `{"howdy":"bob"}`)
 }

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -48,7 +48,6 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
 	require.NoError(t, err)
 	defer btc.Close()
-	require.NoError(t, err)
 
 	// Push first rev
 	revID, err := btc.PushRev(docID, "", []byte(`{"key":"val"}`))
@@ -820,8 +819,6 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		&rtConfig)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
-	var msg *blip.Message
-	var ok bool
 
 	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
 	require.NoError(t, err)
@@ -935,8 +932,6 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 		&rtConfig)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
-	var msg *blip.Message
-	var ok bool
 
 	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
 	require.NoError(t, err)

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -844,6 +844,8 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		&rtConfig)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
+	var msg *blip.Message
+	var ok bool
 
 	client, err := BlipClientInitialization(t, rt, collection, nil)
 	require.NoError(t, err)
@@ -868,8 +870,13 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 	assert.Equal(t, "2-abc", newRev)
 
 	// Check EE is delta, and CE is full-body replication
-	msg, ok := client.pushReplication.WaitForMessage(3)
-	assert.True(t, ok)
+	if base.IsDefaultCollection(collection.ScopeName(), collection.Name()) {
+		msg, ok = client.pushReplication.WaitForMessage(2)
+		assert.True(t, ok)
+	} else {
+		msg, ok = client.pushReplication.WaitForMessage(3)
+		assert.True(t, ok)
+	}
 
 	if base.IsEnterpriseEdition() {
 		// Check the request was sent with the correct deltaSrc property
@@ -959,6 +966,8 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 		&rtConfig)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
+	var msg *blip.Message
+	var ok bool
 
 	client, err := BlipClientInitialization(t, rt, collection, nil)
 	require.NoError(t, err)
@@ -982,8 +991,13 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "2-abc", newRev)
 	// Check EE is delta, and CE is full-body replication
-	msg, ok := client.pushReplication.WaitForMessage(3)
-	assert.True(t, ok)
+	if base.IsDefaultCollection(collection.ScopeName(), collection.Name()) {
+		msg, ok = client.pushReplication.WaitForMessage(2)
+		assert.True(t, ok)
+	} else {
+		msg, ok = client.pushReplication.WaitForMessage(3)
+		assert.True(t, ok)
+	}
 
 	// Check the request was NOT sent with a deltaSrc property
 	assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -1121,6 +1121,7 @@ func (btc *BlipTesterCollectionClient) sendPushMsg(msg *blip.Message) error {
 	return btc.parent.pushReplication.sendMsg(msg)
 }
 
+/*
 func BlipClientInitialization(t *testing.T, rt *RestTester, options *BlipTesterClientOpts) (*BlipTesterClient, *BlipTesterCollectionClient, error) {
 	collection := rt.GetSingleTestDatabaseCollection()
 	scopeAndCollectionKey := strings.Join([]string{collection.ScopeName(), collection.Name()}, base.ScopeCollectionSeparator)
@@ -1133,7 +1134,7 @@ func BlipClientInitialization(t *testing.T, rt *RestTester, options *BlipTesterC
 		if err != nil {
 			return nil, nil, err
 		}
-		btcCollection = client.DefaultCollection()
+		btcCollection = client.SingleCollection()
 	} else {
 		if options == nil {
 			options = &BlipTesterClientOpts{}
@@ -1150,3 +1151,5 @@ func BlipClientInitialization(t *testing.T, rt *RestTester, options *BlipTesterC
 	}
 	return client, btcCollection, nil
 }
+
+*/

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -1149,32 +1149,31 @@ func (btc *BlipTesterClient) BlipClientCollectionSetup(collection *db.DatabaseCo
 		if !found {
 			return nil, fmt.Errorf("error waiting for getCollections serial number to be stored by the replicator")
 		}
+	} else {
+		btcCollection = btc.DefaultCollection()
 	}
 	return btcCollection, nil
 }
 
-func BlipClientInitialization(t *testing.T, rt *RestTester, collection *db.DatabaseCollection, options *BlipTesterClientOpts) (*BlipTesterClient, bool, error) {
+func BlipClientInitialization(t *testing.T, rt *RestTester, collection *db.DatabaseCollection, options *BlipTesterClientOpts) (*BlipTesterClient, error) {
 	scopeAndCollectionKey := strings.Join([]string{collection.ScopeName(), collection.Name()}, base.ScopeCollectionSeparator)
-	var isDefault bool
 	var client *BlipTesterClient
 	var err error
 
 	if base.IsDefaultCollection(collection.ScopeName(), collection.Name()) {
 		client, err = NewBlipTesterClientOptsWithRT(t, rt, options)
-		isDefault = true
 		if err != nil {
-			return nil, isDefault, err
+			return nil, err
 		}
 	} else {
 		if options == nil {
 			options = &BlipTesterClientOpts{}
 		}
 		options.Collections = []string{scopeAndCollectionKey}
-		isDefault = false
 		client, err = NewBlipTesterClientOptsWithRT(t, rt, options)
 		if err != nil {
-			return nil, isDefault, err
+			return nil, err
 		}
 	}
-	return client, isDefault, nil
+	return client, nil
 }

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -596,6 +596,17 @@ func (btc *BlipTesterClient) initCollectionReplication(collection string, collec
 	return nil
 }
 
+func (btc *BlipTesterClient) waitForReplicationMessage(collection *db.DatabaseCollection, serialNumber blip.MessageNumber) (*blip.Message, bool) {
+	var msg *blip.Message
+	var ok bool
+	if base.IsDefaultCollection(collection.ScopeName(), collection.Name()) {
+		msg, ok = btc.pushReplication.WaitForMessage(serialNumber)
+	} else {
+		msg, ok = btc.pushReplication.WaitForMessage(serialNumber + 1)
+	}
+	return msg, ok
+}
+
 // SingleCollection returns a single collection blip tester if the RestTester database is configured with only one collection. Otherwise, throw a fatal test error.
 func (btc *BlipTesterClient) SingleCollection() *BlipTesterCollectionClient {
 	if btc.nonCollectionAwareClient != nil {

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -1120,36 +1120,3 @@ func (btc *BlipTesterCollectionClient) sendPushMsg(msg *blip.Message) error {
 	btc.addCollectionProperty(msg)
 	return btc.parent.pushReplication.sendMsg(msg)
 }
-
-/*
-func BlipClientInitialization(t *testing.T, rt *RestTester, options *BlipTesterClientOpts) (*BlipTesterClient, *BlipTesterCollectionClient, error) {
-	collection := rt.GetSingleTestDatabaseCollection()
-	scopeAndCollectionKey := strings.Join([]string{collection.ScopeName(), collection.Name()}, base.ScopeCollectionSeparator)
-	var client *BlipTesterClient
-	var err error
-	var btcCollection *BlipTesterCollectionClient
-
-	if base.IsDefaultCollection(collection.ScopeName(), collection.Name()) {
-		client, err = NewBlipTesterClientOptsWithRT(t, rt, options)
-		if err != nil {
-			return nil, nil, err
-		}
-		btcCollection = client.SingleCollection()
-	} else {
-		if options == nil {
-			options = &BlipTesterClientOpts{}
-		}
-		options.Collections = []string{scopeAndCollectionKey}
-		client, err = NewBlipTesterClientOptsWithRT(t, rt, options)
-		if err != nil {
-			return nil, nil, err
-		}
-		btcCollection, err = client.Collection(scopeAndCollectionKey)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-	return client, btcCollection, nil
-}
-
-*/

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -2093,7 +2093,7 @@ func TestRevocationMessage(t *testing.T) {
 	require.NoError(t, rt.WaitForPendingChanges())
 
 	// Start pull
-	err = btc.StartOneshotPull()
+	err = btc.DefaultCollection().StartOneshotPull()
 	assert.NoError(t, err)
 
 	// Wait for doc revision to come over
@@ -2204,7 +2204,7 @@ func TestRevocationNoRev(t *testing.T) {
 	firstOneShotSinceSeq := rt.GetDocumentSequence("doc")
 
 	// OneShot pull to grab doc
-	err = btc.StartOneshotPull()
+	err = btc.DefaultCollection().StartOneshotPull()
 	assert.NoError(t, err)
 
 	_, ok := btc.WaitForRev("doc", "1-ad48b5c9d9c47b98532a3d8164ec0ae7")
@@ -2296,7 +2296,7 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 	firstOneShotSinceSeq := rt.GetDocumentSequence("doc")
 
 	// OneShot pull to grab doc
-	err = btc.StartOneshotPull()
+	err = btc.DefaultCollection().StartOneshotPull()
 	assert.NoError(t, err)
 	throw = true
 	_, ok := btc.WaitForRev("doc", "1-ad48b5c9d9c47b98532a3d8164ec0ae7")
@@ -2349,7 +2349,7 @@ func TestBlipRevokeNonExistentRole(t *testing.T) {
 	})
 	require.NoError(t, err)
 	defer bt.Close()
-	btcCollection, err := bt.BlipClientCollectionSetup(collection)
+	_, err = bt.pushReplication.bt.BlipCollectionSetup(rt)
 	require.NoError(t, err)
 
 	require.NoError(t, btcCollection.StartPull())

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -2320,7 +2320,7 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 
 // Regression test for CBG-2183.
 func TestBlipRevokeNonExistentRole(t *testing.T) {
-	rt := NewRestTester(t, // CBG-2619: make collection aware
+	rt := NewRestTester(t,
 		&RestTesterConfig{
 			GuestEnabled: false,
 		})
@@ -2352,11 +2352,8 @@ func TestBlipRevokeNonExistentRole(t *testing.T) {
 	btcCollection, err := bt.BlipClientCollectionSetup(collection)
 	require.NoError(t, err)
 
-	if isDefault {
-		require.NoError(t, bt.StartPull())
-	} else {
-		require.NoError(t, btcCollection.StartPull())
-	}
+	require.NoError(t, btcCollection.StartPull())
+
 	// in the failing case we'll panic before hitting this
 	base.WaitForStat(func() int64 {
 		return rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplCaughtUp.Value()

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -2093,7 +2093,7 @@ func TestRevocationMessage(t *testing.T) {
 	require.NoError(t, rt.WaitForPendingChanges())
 
 	// Start pull
-	err = btc.DefaultCollection().StartOneshotPull()
+	err = btc.StartOneshotPull()
 	assert.NoError(t, err)
 
 	// Wait for doc revision to come over
@@ -2204,7 +2204,7 @@ func TestRevocationNoRev(t *testing.T) {
 	firstOneShotSinceSeq := rt.GetDocumentSequence("doc")
 
 	// OneShot pull to grab doc
-	err = btc.DefaultCollection().StartOneshotPull()
+	err = btc.StartOneshotPull()
 	assert.NoError(t, err)
 
 	_, ok := btc.WaitForRev("doc", "1-ad48b5c9d9c47b98532a3d8164ec0ae7")
@@ -2296,7 +2296,7 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 	firstOneShotSinceSeq := rt.GetDocumentSequence("doc")
 
 	// OneShot pull to grab doc
-	err = btc.DefaultCollection().StartOneshotPull()
+	err = btc.StartOneshotPull()
 	assert.NoError(t, err)
 	throw = true
 	_, ok := btc.WaitForRev("doc", "1-ad48b5c9d9c47b98532a3d8164ec0ae7")
@@ -2349,10 +2349,8 @@ func TestBlipRevokeNonExistentRole(t *testing.T) {
 	})
 	require.NoError(t, err)
 	defer bt.Close()
-	_, err = bt.pushReplication.bt.BlipCollectionSetup(rt)
-	require.NoError(t, err)
 
-	require.NoError(t, btcCollection.StartPull())
+	require.NoError(t, bt.StartPull())
 
 	// in the failing case we'll panic before hitting this
 	base.WaitForStat(func() int64 {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1200,6 +1200,24 @@ func NewBlipTesterFromSpecWithRT(tb testing.TB, spec *BlipTesterSpec, rt *RestTe
 	return blipTester, err
 }
 
+// NewBlipTesterDefaultCollection creates a blip tester that has a RestTester only using a single database and `_default._default` collection.
+func NewBlipTesterDefaultCollection(tb testing.TB) *BlipTester {
+	return NewBlipTesterDefaultCollectionFromSpec(tb, BlipTesterSpec{GuestEnabled: true})
+}
+
+// NewBlipTesterDefaultCollectionFromSpec creates a blip tester that has a RestTester only using a single database and `_default._default` collection.
+func NewBlipTesterDefaultCollectionFromSpec(tb testing.TB, spec BlipTesterSpec) *BlipTester {
+	rtConfig := RestTesterConfig{
+		EnableNoConflictsMode: spec.noConflictsMode,
+		GuestEnabled:          spec.GuestEnabled,
+		DatabaseConfig:        &DatabaseConfig{},
+	}
+	rt := newRestTester(tb, &rtConfig, useSingleCollectionDefaultOnly, 1)
+	bt, err := createBlipTesterWithSpec(tb, spec, rt)
+	require.NoError(tb, err)
+	return bt
+}
+
 // Create a BlipTester using the default spec
 func NewBlipTester(tb testing.TB) (*BlipTester, error) {
 	return NewBlipTesterFromSpec(tb, getDefaultBlipTesterSpec())

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1517,16 +1517,6 @@ func addChannelsToPrincipal(config auth.PrincipalConfig, collection *db.Database
 	return payload, nil
 }
 
-func getBlipProperties(rt *RestTester) blip.Properties {
-	collection := rt.GetSingleTestDatabaseCollection()
-	properties := blip.Properties{}
-	if base.IsDefaultCollection(collection.ScopeName(), collection.Name()) {
-		return properties
-	}
-	properties[db.BlipCollection] = "0"
-	return properties
-}
-
 func getChangesHandler(changesFinishedWg, revsFinishedWg *sync.WaitGroup) func(request *blip.Message) {
 	return func(request *blip.Message) {
 		// Send a response telling the other side we want ALL revisions

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1868,6 +1868,7 @@ func (bt *BlipTester) PullDocs() (docs map[string]RestDocument) {
 			if bt.blipContext.ActiveSubprotocol() == db.BlipCBMobileReplicationV3 {
 				getAttachmentRequest.Properties[db.GetAttachmentID] = docId
 			}
+			bt.addCollectionProperty(getAttachmentRequest)
 			sent := bt.sender.Send(getAttachmentRequest)
 			if !sent {
 				panic("Unable to get attachment.")

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1200,24 +1200,6 @@ func NewBlipTesterFromSpecWithRT(tb testing.TB, spec *BlipTesterSpec, rt *RestTe
 	return blipTester, err
 }
 
-// NewBlipTesterDefaultCollection creates a blip tester that has a RestTester only using a single database and `_default._default` collection.
-func NewBlipTesterDefaultCollection(tb testing.TB) *BlipTester {
-	return NewBlipTesterDefaultCollectionFromSpec(tb, BlipTesterSpec{GuestEnabled: true})
-}
-
-// NewBlipTesterDefaultCollectionFromSpec creates a blip tester that has a RestTester only using a single database and `_default._default` collection.
-func NewBlipTesterDefaultCollectionFromSpec(tb testing.TB, spec BlipTesterSpec) *BlipTester {
-	rtConfig := RestTesterConfig{
-		EnableNoConflictsMode: spec.noConflictsMode,
-		GuestEnabled:          spec.GuestEnabled,
-		DatabaseConfig:        &DatabaseConfig{},
-	}
-	rt := newRestTester(tb, &rtConfig, useSingleCollectionDefaultOnly, 1)
-	bt, err := createBlipTesterWithSpec(tb, spec, rt)
-	require.NoError(tb, err)
-	return bt
-}
-
 // Create a BlipTester using the default spec
 func NewBlipTester(tb testing.TB) (*BlipTester, error) {
 	return NewBlipTesterFromSpec(tb, getDefaultBlipTesterSpec())

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1238,19 +1238,10 @@ func createBlipTesterWithSpec(tb testing.TB, spec BlipTesterSpec, rt *RestTester
 			adminChannels = append(adminChannels, spec.connectingUserChannelGrants...)
 		}
 
-		// serialize admin channels to json array
-		adminChannelsJson, err := base.JSONMarshal(adminChannels)
+		userDocBody, err := GetUserPayload(spec.connectingUsername, spec.connectingPassword, "", bt.restTester.GetSingleTestDatabaseCollection(), adminChannels, nil)
 		if err != nil {
 			return nil, err
 		}
-		adminChannelsStr := string(adminChannelsJson)
-		adminChannelsStr = `"admin_channels": ` + adminChannelsStr
-
-		userDocBody := fmt.Sprintf(`{"name":"%s", "password":"%s", %s}`,
-			spec.connectingUsername,
-			spec.connectingPassword,
-			AdminChannelGrant(bt.restTester.GetSingleTestDatabaseCollection(), adminChannelsStr),
-		)
 		log.Printf("Creating user: %v", userDocBody)
 
 		// Create a user.  NOTE: this must come *after* the bt.rt.TestPublicHandler() call, otherwise it will end up getting ignored

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -189,7 +189,7 @@ func (rt *RestTester) GetReplicationStatuses(queryString string) (statuses []db.
 func SetupSGRPeers(t *testing.T) (activeRT *RestTester, passiveRT *RestTester, remoteDBURLString string, teardown func()) {
 	// Set up passive RestTester (rt2)
 	passiveTestBucket := base.GetTestBucket(t)
-	passiveRT = NewRestTesterDefaultCollection(t, // CBG-2619: make collection aware
+	passiveRT = NewRestTesterDefaultCollection(t, // TODO: CBG-2491: make collection aware
 		&RestTesterConfig{
 			CustomTestBucket: passiveTestBucket.NoCloseClone(),
 			DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -213,7 +213,7 @@ func SetupSGRPeers(t *testing.T) (activeRT *RestTester, passiveRT *RestTester, r
 
 	// Set up active RestTester (rt1)
 	activeTestBucket := base.GetTestBucket(t)
-	activeRT = NewRestTesterDefaultCollection(t, // CBG-2619: make collection aware
+	activeRT = NewRestTesterDefaultCollection(t, // TODO: CBG-2491: make collection aware
 		&RestTesterConfig{
 			CustomTestBucket:   activeTestBucket.NoCloseClone(),
 			SgReplicateEnabled: true,

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -94,7 +94,7 @@ func (rt *RestTester) DeleteDoc(docID, revID string) {
 
 func (rt *RestTester) WaitForRev(docID string, revID string) error {
 	return rt.WaitForCondition(func() bool {
-		rawResponse := rt.SendAdminRequest("GET", "/db/"+docID, "")
+		rawResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/"+docID, "")
 		if rawResponse.Code != 200 && rawResponse.Code != 201 {
 			return false
 		}


### PR DESCRIPTION
CBG-2619

Changes to Blip tests to make them collection aware. Includes some helper functions to do this, one of which is in my collection channels PR so will conflict depending on which is merged first. All tests that were labelled as part fpo this ticket have changed. `SetupSGRPeers` was part of this ticket to make collection aware but there is still work to do on [CBG-2491](https://issues.couchbase.com/browse/CBG-2491) to make this possible. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1421/
- [x]  `GSI=true. xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1370/
- [x]  `GSI=false, xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1371/
- [x]  `GSI=false, xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1422/
