### PR TITLE
switch resync manager according to test

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -760,7 +760,7 @@ func TestResync(t *testing.T) {
 
 			_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManager)
 			if !ok {
-				t.Skip("This test only works when ResyncManager is used")
+				rt.GetDatabase().ResyncManager = db.NewResyncManager(rt.GetSingleDataStore())
 			}
 
 			for i := 0; i < testCase.docsCreated; i++ {
@@ -845,7 +845,7 @@ func TestResyncUsingDCPStream(t *testing.T) {
 
 			_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
 			if !ok {
-				t.Skip("This test only works when ResyncManagerDCP is used")
+				rt.GetDatabase().ResyncManager = db.NewResyncManagerDCP(rt.GetSingleDataStore())
 			}
 
 			for i := 0; i < testCase.docsCreated; i++ {
@@ -923,7 +923,7 @@ func TestResyncErrorScenarios(t *testing.T) {
 
 	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManager)
 	if !ok {
-		t.Skip("This test only works when ResyncManager is used")
+		rt.GetDatabase().ResyncManager = db.NewResyncManager(rt.GetSingleDataStore())
 	}
 
 	leakyDataStore, ok := base.AsLeakyDataStore(rt.TestBucket.GetSingleDataStore())
@@ -1026,7 +1026,7 @@ func TestResyncErrorScenariosUsingDCPStream(t *testing.T) {
 
 	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
 	if !ok {
-		t.Skip("This test only works when ResyncManagerDCP is used")
+		rt.GetDatabase().ResyncManager = db.NewResyncManagerDCP(rt.GetSingleDataStore())
 	}
 
 	numOfDocs := 1000
@@ -1113,7 +1113,7 @@ func TestResyncStop(t *testing.T) {
 
 	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManager)
 	if !ok {
-		t.Skip("This test only works when ResyncManager is used")
+		rt.GetDatabase().ResyncManager = db.NewResyncManager(rt.GetSingleDataStore())
 	}
 
 	leakyDataStore, ok := base.AsLeakyDataStore(rt.TestBucket.GetSingleDataStore())
@@ -1200,7 +1200,7 @@ func TestResyncStopUsingDCPStream(t *testing.T) {
 
 	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
 	if !ok {
-		t.Skip("This test only works when ResyncManagerDCP is used")
+		rt.GetDatabase().ResyncManager = db.NewResyncManagerDCP(rt.GetSingleDataStore())
 	}
 
 	numOfDocs := 1000
@@ -1276,7 +1276,7 @@ func TestResyncRegenerateSequences(t *testing.T) {
 
 	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManager)
 	if !ok {
-		t.Skip("This test only works when ResyncManager is used")
+		rt.GetDatabase().ResyncManager = db.NewResyncManager(rt.GetSingleDataStore())
 	}
 
 	var response *rest.TestResponse
@@ -1441,9 +1441,8 @@ func TestResyncRegenerateSequencesUsingDCPStream(t *testing.T) {
 	)
 	defer rt.Close()
 
-	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
-	if !ok {
-		t.Skip("This test only works when ResyncManagerDCP is used")
+	if _, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP); !ok {
+		rt.GetDatabase().ResyncManager = db.NewResyncManagerDCP(rt.GetSingleDataStore())
 	}
 
 	var response *rest.TestResponse


### PR DESCRIPTION
CBG-0000

Describe your PR here...
- Switch between `ResyncManager` and `ResyncMangerDCP` according to test requirement
  - this will allow us to always test both - Query and DCP based ResyncManager

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1372/ (only ^TestResync tests in `rest/adminapitest` pkg)
