### PR TITLE
CBG-2599 Enforce _blipsync read-only GUEST within blipSyncContext

### DIFF
--- a/rest/handler.go
+++ b/rest/handler.go
@@ -331,7 +331,10 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 			return err
 		}
 		if h.user != nil && h.user.Name() == "" && dbContext != nil && dbContext.IsGuestReadOnly() {
-			if requiresWritePermission(accessPermissions) {
+			// Prevent read-only guest access to any endpoint requiring write permissions except
+			// blipsync.  Read-only guest handling for websocket replication (blipsync) is evaluated
+			// at the blip message level to support read-only pull replications.
+			if requiresWritePermission(accessPermissions) && !h.pathTemplateContains("_blipsync") {
 				return base.HTTPErrorf(http.StatusForbidden, auth.GuestUserReadOnly)
 			}
 		}
@@ -1409,4 +1412,14 @@ func requiresWritePermission(accessPermissions []Permission) bool {
 		}
 	}
 	return false
+}
+
+// Checks whether the mux path template for the current route contains the specified pattern
+func (h *handler) pathTemplateContains(pattern string) bool {
+	route := mux.CurrentRoute(h.rq)
+	pathTemplate, err := route.GetPathTemplate()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(pathTemplate, pattern)
 }


### PR DESCRIPTION
CBG-2599

Handling already exists to reject writes within blipSyncContext, but _blipsync REST endpoint was also incorrectly being blocked.  This prevented read-only pull replications from successfully connecting.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1373/
