### PR TITLE
CBG-2682 GetPersistentTestBucket API to support testing with persistent walrus buckets

### DIFF
--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -225,7 +225,13 @@ func (tbp *TestBucketPool) GetWalrusTestBucket(t testing.TB, url string) (b Buck
 		atomic.AddInt32(&tbp.stats.NumBucketsClosed, 1)
 		atomic.AddInt64(&tbp.stats.TotalInuseBucketNano, time.Since(openedStart).Nanoseconds())
 		tbp.markBucketClosed(t, b)
-		b.Close()
+		if url == kTestWalrusURL {
+			b.Close()
+		} else {
+			// Persisted buckets should call close and delete
+			_ = walrusBucket.CloseAndDelete()
+		}
+
 	}
 }
 
@@ -253,14 +259,18 @@ func (tbp *TestBucketPool) GetExistingBucket(t testing.TB) (b Bucket, s BucketSp
 // GetTestBucketAndSpec returns a bucket to be used during a test.
 // The returned teardownFn MUST be called once the test is done,
 // which closes the bucket, readies it for a new test, and releases back into the pool.
-func (tbp *TestBucketPool) getTestBucketAndSpec(t testing.TB) (b Bucket, s BucketSpec, teardownFn func()) {
+func (tbp *TestBucketPool) getTestBucketAndSpec(t testing.TB, persistentBucket bool) (b Bucket, s BucketSpec, teardownFn func()) {
 
 	ctx := TestCtx(t)
 
 	// Return a new Walrus bucket when tbp has not been initialized
 	if !tbp.integrationMode {
 		tbp.Logf(ctx, "Getting walrus test bucket - tbp.integrationMode is not set")
-		return tbp.GetWalrusTestBucket(t, kTestWalrusURL)
+		walrusURL := kTestWalrusURL
+		if persistentBucket {
+			walrusURL = walrusURL + t.TempDir()
+		}
+		return tbp.GetWalrusTestBucket(t, walrusURL)
 	}
 
 	if tbp.useExistingBucket {

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -229,7 +229,10 @@ func (tbp *TestBucketPool) GetWalrusTestBucket(t testing.TB, url string) (b Buck
 			b.Close()
 		} else {
 			// Persisted buckets should call close and delete
-			_ = walrusBucket.CloseAndDelete()
+			closeErr := walrusBucket.CloseAndDelete()
+			if closeErr != nil {
+				tbp.Logf(ctx, "Unexpected error closing persistent walrus bucket: %v", closeErr)
+			}
 		}
 
 	}
@@ -259,6 +262,8 @@ func (tbp *TestBucketPool) GetExistingBucket(t testing.TB) (b Bucket, s BucketSp
 // GetTestBucketAndSpec returns a bucket to be used during a test.
 // The returned teardownFn MUST be called once the test is done,
 // which closes the bucket, readies it for a new test, and releases back into the pool.
+// persistentBucket flag determines behaviour for walrus buckets only; Couchbase bucket
+// behaviour is defined by the bucket pool readier/init.
 func (tbp *TestBucketPool) getTestBucketAndSpec(t testing.TB, persistentBucket bool) (b Bucket, s BucketSpec, teardownFn func()) {
 
 	ctx := TestCtx(t)

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -108,12 +108,14 @@ func GetTestBucket(t testing.TB) *TestBucket {
 	return getTestBucket(t, false)
 }
 
-// GetTestBucket returns a test bucket from a pool.
+// GetTestBucket returns a test bucket from a pool.  If running with walrus buckets, will persist bucket data
+// across bucket close.
 func GetPersistentTestBucket(t testing.TB) *TestBucket {
 	return getTestBucket(t, true)
 }
 
-// getTestBucket returns a bucket from the bucket pool
+// getTestBucket returns a bucket from the bucket pool.  Persistent flag determines behaviour for walrus
+// buckets only - Couchbase bucket behaviour is defined by the bucket pool readier/init.
 func getTestBucket(t testing.TB, persistent bool) *TestBucket {
 	bucket, spec, closeFn := GTestBucketPool.getTestBucketAndSpec(t, persistent)
 	return &TestBucket{

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -105,13 +105,17 @@ func (tb *TestBucket) NoCloseClone() *TestBucket {
 
 // GetTestBucket returns a test bucket from a pool.
 func GetTestBucket(t testing.TB) *TestBucket {
-	//debug.PrintStack()
-	return getTestBucket(t)
+	return getTestBucket(t, false)
+}
+
+// GetTestBucket returns a test bucket from a pool.
+func GetPersistentTestBucket(t testing.TB) *TestBucket {
+	return getTestBucket(t, true)
 }
 
 // getTestBucket returns a bucket from the bucket pool
-func getTestBucket(t testing.TB) *TestBucket {
-	bucket, spec, closeFn := GTestBucketPool.getTestBucketAndSpec(t)
+func getTestBucket(t testing.TB, persistent bool) *TestBucket {
+	bucket, spec, closeFn := GTestBucketPool.getTestBucketAndSpec(t, persistent)
 	return &TestBucket{
 		Bucket:     bucket,
 		BucketSpec: spec,
@@ -173,6 +177,7 @@ func (b *TestBucket) GetSingleDataStore() sgbucket.DataStore {
 // Returns both the test bucket which is persisted and a function which can be used to remove the created temporary
 // directory once the test has finished with it.
 func GetPersistentWalrusBucket(t testing.TB) (*TestBucket, func()) {
+
 	tempDir, err := os.MkdirTemp("", "walrustemp")
 	require.NoError(t, err)
 


### PR DESCRIPTION
CBG-2682

Validated the change with the pending test from https://github.com/couchbase/sync_gateway/pull/6020.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1412/
