### PR TITLE
CBG-2685: change context on database operations

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -48,6 +48,19 @@ const (
 	kMaxDeltaTtlDuration = 60 * 60 * 24 * 30 * time.Second
 )
 
+// NonCancellableContext is here to stroe a context that is not cancellable. Used to explicitly state when a change from
+// a cancellable context to a context withoutr contex is required
+type NonCancellableContext struct {
+	Ctx context.Context
+}
+
+func NewNonCancelCtx() NonCancellableContext {
+	ctxStruct := NonCancellableContext{
+		Ctx: context.Background(),
+	}
+	return ctxStruct
+}
+
 // RedactBasicAuthURLUserAndPassword returns the given string, with a redacted HTTP basic auth component.
 func RedactBasicAuthURLUserAndPassword(urlIn string) string {
 	redactedUrl, err := RedactBasicAuthURL(urlIn, false)

--- a/base/util.go
+++ b/base/util.go
@@ -54,6 +54,7 @@ type NonCancellableContext struct {
 	Ctx context.Context
 }
 
+// NewNonCancelCtx creates a new background context struct for operations that require a fresh context
 func NewNonCancelCtx() NonCancellableContext {
 	ctxStruct := NonCancellableContext{
 		Ctx: context.Background(),

--- a/db/database.go
+++ b/db/database.go
@@ -999,8 +999,8 @@ func (dc *DatabaseContext) TakeDbOffline(ctx context.Context, reason string) err
 	}
 }
 
-func (db *Database) TakeDbOffline(ctx context.Context, reason string) error {
-	return db.DatabaseContext.TakeDbOffline(ctx, reason)
+func (db *Database) TakeDbOffline(nonContextStruct base.NonCancellableContext, reason string) error {
+	return db.DatabaseContext.TakeDbOffline(nonContextStruct.Ctx, reason)
 }
 
 func (context *DatabaseContext) Authenticator(ctx context.Context) *auth.Authenticator {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2448,7 +2448,7 @@ func TestResyncUpdateAllDocChannels(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	err = db.TakeDbOffline(ctx, "")
+	err = db.TakeDbOffline(base.NewNonCancelCtx(), "")
 	assert.NoError(t, err)
 
 	waitAndAssertCondition(t, func() bool {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -10,6 +10,7 @@ package rest
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -37,8 +38,13 @@ const paramDeleted = "deleted"
 
 // ////// DATABASE MAINTENANCE:
 
+type nonCancellableContext struct {
+	ctx context.Context
+}
+
 // "Create" a database (actually just register an existing bucket)
 func (h *handler) handleCreateDB() error {
+	contextNoCancel := createNonCancelCtx()
 	h.assertAdminOnly()
 	dbName := h.PathVar("newdb")
 	config, err := h.readSanitizeDbConfigJSON()
@@ -59,7 +65,7 @@ func (h *handler) handleCreateDB() error {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
 
-		if err := config.validate(h.ctx(), validateOIDC); err != nil {
+		if err := config.validate(contextNoCancel.ctx, validateOIDC); err != nil {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
 
@@ -97,7 +103,7 @@ func (h *handler) handleCreateDB() error {
 				"Duplicate database name %q", dbName)
 		}
 
-		_, err = h.server._applyConfig(h.ctx(), loadedConfig, true, false)
+		_, err = h.server._applyConfig(contextNoCancel.ctx, loadedConfig, true, false)
 		if err != nil {
 			var httpErr *base.HTTPError
 			if errors.As(err, &httpErr) {
@@ -116,12 +122,12 @@ func (h *handler) handleCreateDB() error {
 		cas, err := h.server.BootstrapContext.Connection.InsertConfig(bucket, h.server.Config.Bootstrap.ConfigGroupID, persistedConfig)
 		if err != nil {
 			// unload the requested database config to prevent the cluster being in an inconsistent state
-			h.server._removeDatabase(h.ctx(), dbName)
+			h.server._removeDatabase(contextNoCancel.ctx, dbName)
 			if errors.Is(err, base.ErrAuthError) {
 				return base.HTTPErrorf(http.StatusForbidden, "auth failure accessing provided bucket using bootstrap credentials: %s", bucket)
 			} else if errors.Is(err, base.ErrAlreadyExists) {
 				// on-demand config load if someone else beat us to db creation
-				if _, err := h.server._fetchAndLoadDatabase(h.ctx(), dbName); err != nil {
+				if _, err := h.server._fetchAndLoadDatabase(contextNoCancel.ctx, dbName); err != nil {
 					base.WarnfCtx(h.ctx(), "Couldn't load database after conflicting create: %v", err)
 				}
 				return base.HTTPErrorf(http.StatusPreconditionFailed, // what CouchDB returns
@@ -138,7 +144,7 @@ func (h *handler) handleCreateDB() error {
 		}
 
 		// load database in-memory for non-persistent nodes
-		if _, err := h.server.AddDatabaseFromConfigFailFast(h.ctx(), DatabaseConfig{DbConfig: *config}); err != nil {
+		if _, err := h.server.AddDatabaseFromConfigFailFast(contextNoCancel.ctx, DatabaseConfig{DbConfig: *config}); err != nil {
 			if errors.Is(err, base.ErrAuthError) {
 				return base.HTTPErrorf(http.StatusForbidden, "auth failure using provided bucket credentials for database %s", base.MD(config.Name))
 			}
@@ -147,6 +153,13 @@ func (h *handler) handleCreateDB() error {
 	}
 
 	return base.HTTPErrorf(http.StatusCreated, "created")
+}
+
+func createNonCancelCtx() nonCancellableContext {
+	ctxStruct := nonCancellableContext{
+		ctx: context.Background(),
+	}
+	return ctxStruct
 }
 
 // getAuthScopeHandleCreateDB is used in the router to supply an auth scope for the admin api auth. Takes the JSON body
@@ -170,6 +183,7 @@ func getAuthScopeHandleCreateDB(bodyJSON []byte) (string, error) {
 // Take a DB online, first reload the DB config
 func (h *handler) handleDbOnline() error {
 	h.assertAdminOnly()
+	contextNoCancel := createNonCancelCtx()
 	dbState := atomic.LoadUint32(&h.db.State)
 	// If the DB is already transitioning to: online or is online silently return
 	if dbState == db.DBOnline || dbState == db.DBStarting {
@@ -197,7 +211,7 @@ func (h *handler) handleDbOnline() error {
 	base.InfofCtx(h.ctx(), base.KeyCRUD, "Taking Database : %v, online in %v seconds", base.MD(h.db.Name), input.Delay)
 	go func() {
 		time.Sleep(time.Duration(input.Delay) * time.Second)
-		h.server.TakeDbOnline(h.ctx(), h.db.DatabaseContext)
+		h.server.TakeDbOnline(contextNoCancel.ctx, h.db.DatabaseContext)
 	}()
 
 	return nil
@@ -206,8 +220,9 @@ func (h *handler) handleDbOnline() error {
 // Take a DB offline
 func (h *handler) handleDbOffline() error {
 	h.assertAdminOnly()
+	contextNoCancel := createNonCancelCtx()
 	var err error
-	if err = h.db.TakeDbOffline(h.ctx(), "ADMIN Request"); err != nil {
+	if err = h.db.TakeDbOffline(contextNoCancel.ctx, "ADMIN Request"); err != nil {
 		base.InfofCtx(h.ctx(), base.KeyCRUD, "Unable to take Database : %v, offline", base.MD(h.db.Name))
 	}
 
@@ -450,6 +465,7 @@ func (h *handler) handlePutConfig() error {
 // handlePutDbConfig Upserts a new database config
 func (h *handler) handlePutDbConfig() (err error) {
 	h.assertAdminOnly()
+	contextNoCancel := createNonCancelCtx()
 
 	var dbConfig *DbConfig
 
@@ -512,7 +528,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 
 	if !h.server.persistentConfig {
 		updatedDbConfig := &DatabaseConfig{DbConfig: *dbConfig}
-		err = updatedDbConfig.validate(h.ctx(), validateOIDC)
+		err = updatedDbConfig.validate(contextNoCancel.ctx, validateOIDC)
 		if err != nil {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
@@ -521,7 +537,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 		if err := updatedDbConfig.setup(dbName, h.server.Config.Bootstrap, dbCreds, nil, false); err != nil {
 			return err
 		}
-		if err := h.server.ReloadDatabaseWithConfig(h.ctx(), *updatedDbConfig); err != nil {
+		if err := h.server.ReloadDatabaseWithConfig(contextNoCancel.ctx, *updatedDbConfig); err != nil {
 			return err
 		}
 		return base.HTTPErrorf(http.StatusCreated, "updated")
@@ -557,7 +573,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 			if err := dbConfig.validatePersistentDbConfig(); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
-			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), oldBucketDbConfig, validateOIDC); err != nil {
+			if err := bucketDbConfig.validateConfigUpdate(contextNoCancel.ctx, oldBucketDbConfig, validateOIDC); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
 
@@ -583,7 +599,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 			}
 
 			// Load the new dbConfig before we persist the update.
-			err = h.server.ReloadDatabaseWithConfig(h.ctx(), tmpConfig)
+			err = h.server.ReloadDatabaseWithConfig(contextNoCancel.ctx, tmpConfig)
 			if err != nil {
 				return nil, err
 			}
@@ -593,7 +609,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 	if err != nil {
 		base.WarnfCtx(h.ctx(), "Couldn't update config for database - rolling back: %v", err)
 		// failed to start the new database config - rollback and return the original error for the user
-		if _, err := h.server.fetchAndLoadDatabase(h.ctx(), dbName); err != nil {
+		if _, err := h.server.fetchAndLoadDatabase(contextNoCancel.ctx, dbName); err != nil {
 			base.WarnfCtx(h.ctx(), "got error rolling back database %q after failed update: %v", base.UD(dbName), err)
 		}
 		return err

--- a/rest/config.go
+++ b/rest/config.go
@@ -1333,20 +1333,20 @@ func (sc *ServerContext) fetchAndLoadDatabaseSince(ctx context.Context, dbName s
 	return found, nil
 }
 
-func (sc *ServerContext) fetchAndLoadDatabase(ctx context.Context, dbName string) (found bool, err error) {
+func (sc *ServerContext) fetchAndLoadDatabase(nonContextStruct base.NonCancellableContext, dbName string) (found bool, err error) {
 	sc.lock.Lock()
 	defer sc.lock.Unlock()
-	return sc._fetchAndLoadDatabase(ctx, dbName)
+	return sc._fetchAndLoadDatabase(nonContextStruct, dbName)
 }
 
 // _fetchAndLoadDatabase will attempt to find the given database name first in a matching bucket name,
 // but then fall back to searching through configs in each bucket to try and find a config.
-func (sc *ServerContext) _fetchAndLoadDatabase(ctx context.Context, dbName string) (found bool, err error) {
-	found, dbConfig, err := sc.fetchDatabase(ctx, dbName)
+func (sc *ServerContext) _fetchAndLoadDatabase(nonContextStruct base.NonCancellableContext, dbName string) (found bool, err error) {
+	found, dbConfig, err := sc.fetchDatabase(nonContextStruct.Ctx, dbName)
 	if err != nil || !found {
 		return false, err
 	}
-	sc._applyConfigs(ctx, map[string]DatabaseConfig{dbName: *dbConfig}, false)
+	sc._applyConfigs(nonContextStruct.Ctx, map[string]DatabaseConfig{dbName: *dbConfig}, false)
 
 	return true, nil
 }
@@ -1558,7 +1558,7 @@ func (sc *ServerContext) FetchConfigs(ctx context.Context, isInitialStartup bool
 // _applyConfigs takes a map of dbName->DatabaseConfig and loads them into the ServerContext where necessary.
 func (sc *ServerContext) _applyConfigs(ctx context.Context, dbNameConfigs map[string]DatabaseConfig, isInitialStartup bool) (count int) {
 	for dbName, cnf := range dbNameConfigs {
-		applied, err := sc._applyConfig(ctx, cnf, false, isInitialStartup)
+		applied, err := sc._applyConfig(base.NewNonCancelCtx(), cnf, false, isInitialStartup)
 		if err != nil {
 			base.ErrorfCtx(ctx, "Couldn't apply config for database %q: %v", base.MD(dbName), err)
 			continue
@@ -1578,7 +1578,7 @@ func (sc *ServerContext) applyConfigs(ctx context.Context, dbNameConfigs map[str
 }
 
 // _applyConfig loads the given database, failFast=true will not attempt to retry connecting/loading
-func (sc *ServerContext) _applyConfig(ctx context.Context, cnf DatabaseConfig, failFast, isInitialStartup bool) (applied bool, err error) {
+func (sc *ServerContext) _applyConfig(nonContextStruct base.NonCancellableContext, cnf DatabaseConfig, failFast, isInitialStartup bool) (applied bool, err error) {
 	// 3.0.0 doesn't write a SGVersion, but everything else will
 	configSGVersionStr := "3.0.0"
 	if cnf.SGVersion != "" {
@@ -1594,7 +1594,7 @@ func (sc *ServerContext) _applyConfig(ctx context.Context, cnf DatabaseConfig, f
 		// Skip applying if the config is from a newer SG version than this node and we're not just starting up
 		nodeSGVersion := base.ProductVersion
 		if nodeSGVersion.Less(configSGVersion) {
-			base.WarnfCtx(ctx, "Cannot apply config update from server for db %q, this SG version is older than config's SG version (%s < %s)", cnf.Name, nodeSGVersion.String(), configSGVersion.String())
+			base.WarnfCtx(nonContextStruct.Ctx, "Cannot apply config update from server for db %q, this SG version is older than config's SG version (%s < %s)", cnf.Name, nodeSGVersion.String(), configSGVersion.String())
 			return false, nil
 		}
 	}
@@ -1609,13 +1609,13 @@ func (sc *ServerContext) _applyConfig(ctx context.Context, cnf DatabaseConfig, f
 
 		if cnf.cfgCas == 0 {
 			// force an update when the new config's cas was set to zero prior to load
-			base.InfofCtx(ctx, base.KeyConfig, "Forcing update of config for database %q bucket %q", cnf.Name, *cnf.Bucket)
+			base.InfofCtx(nonContextStruct.Ctx, base.KeyConfig, "Forcing update of config for database %q bucket %q", cnf.Name, *cnf.Bucket)
 		} else {
 			if sc.dbConfigs[foundDbName].cfgCas >= cnf.cfgCas {
-				base.DebugfCtx(ctx, base.KeyConfig, "Database %q bucket %q config has not changed since last update", cnf.Name, *cnf.Bucket)
+				base.DebugfCtx(nonContextStruct.Ctx, base.KeyConfig, "Database %q bucket %q config has not changed since last update", cnf.Name, *cnf.Bucket)
 				return false, nil
 			}
-			base.InfofCtx(ctx, base.KeyConfig, "Updating database %q for bucket %q with new config from bucket", cnf.Name, *cnf.Bucket)
+			base.InfofCtx(nonContextStruct.Ctx, base.KeyConfig, "Updating database %q for bucket %q with new config from bucket", cnf.Name, *cnf.Bucket)
 		}
 	}
 
@@ -1637,7 +1637,7 @@ func (sc *ServerContext) _applyConfig(ctx context.Context, cnf DatabaseConfig, f
 	}
 
 	// TODO: Dynamic update instead of reload
-	if err := sc._reloadDatabaseWithConfig(ctx, cnf, failFast); err != nil {
+	if err := sc._reloadDatabaseWithConfig(nonContextStruct.Ctx, cnf, failFast); err != nil {
 		// remove these entries we just created above if the database hasn't loaded properly
 		return false, fmt.Errorf("couldn't reload database: %w", err)
 	}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -237,7 +237,7 @@ func (sc *ServerContext) GetInactiveDatabase(ctx context.Context, name string) (
 			found, err = sc.fetchAndLoadDatabaseSince(ctx, name, sc.Config.Unsupported.Serverless.MinConfigFetchInterval)
 
 		} else {
-			found, err = sc.fetchAndLoadDatabase(ctx, name)
+			found, err = sc.fetchAndLoadDatabase(base.NewNonCancelCtx(), name)
 		}
 		if found {
 			sc.lock.RLock()
@@ -342,10 +342,10 @@ func (sc *ServerContext) ReloadDatabase(ctx context.Context, reloadDbName string
 	return dbContext, err
 }
 
-func (sc *ServerContext) ReloadDatabaseWithConfig(ctx context.Context, config DatabaseConfig) error {
+func (sc *ServerContext) ReloadDatabaseWithConfig(nonContextStruct base.NonCancellableContext, config DatabaseConfig) error {
 	sc.lock.Lock()
 	defer sc.lock.Unlock()
-	return sc._reloadDatabaseWithConfig(ctx, config, true)
+	return sc._reloadDatabaseWithConfig(nonContextStruct.Ctx, config, true)
 }
 
 func (sc *ServerContext) _reloadDatabaseWithConfig(ctx context.Context, config DatabaseConfig, failFast bool) error {
@@ -790,7 +790,7 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 	// Create a callback function that will be invoked if the database goes offline and comes
 	// back online again
 	dbOnlineCallback := func(dbContext *db.DatabaseContext) {
-		sc.TakeDbOnline(ctx, dbContext)
+		sc.TakeDbOnline(base.NewNonCancelCtx(), dbContext)
 	}
 
 	oldRevExpirySeconds := base.DefaultOldRevExpirySeconds
@@ -975,7 +975,7 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 	return contextOptions, nil
 }
 
-func (sc *ServerContext) TakeDbOnline(ctx context.Context, database *db.DatabaseContext) {
+func (sc *ServerContext) TakeDbOnline(nonContextStruct base.NonCancellableContext, database *db.DatabaseContext) {
 
 	// Take a write lock on the Database context, so that we can cycle the underlying Database
 	// without any other call running concurrently
@@ -984,9 +984,9 @@ func (sc *ServerContext) TakeDbOnline(ctx context.Context, database *db.Database
 
 	// We can only transition to Online from Offline state
 	if atomic.CompareAndSwapUint32(&database.State, db.DBOffline, db.DBStarting) {
-		reloadedDb, err := sc.ReloadDatabase(ctx, database.Name)
+		reloadedDb, err := sc.ReloadDatabase(nonContextStruct.Ctx, database.Name)
 		if err != nil {
-			base.ErrorfCtx(ctx, "Error reloading database from config: %v", err)
+			base.ErrorfCtx(nonContextStruct.Ctx, "Error reloading database from config: %v", err)
 			return
 		}
 
@@ -995,7 +995,7 @@ func (sc *ServerContext) TakeDbOnline(ctx context.Context, database *db.Database
 		atomic.StoreUint32(&reloadedDb.State, db.DBOnline)
 
 	} else {
-		base.InfofCtx(ctx, base.KeyCRUD, "Unable to take Database : %v online , database must be in Offline state", base.UD(database.Name))
+		base.InfofCtx(nonContextStruct.Ctx, base.KeyCRUD, "Unable to take Database : %v online , database must be in Offline state", base.UD(database.Name))
 	}
 
 }
@@ -1096,8 +1096,8 @@ func (sc *ServerContext) AddDatabaseFromConfig(ctx context.Context, config Datab
 
 // AddDatabaseFromConfigFailFast adds a database to the ServerContext given its configuration and fails fast.
 // If an existing config is found for the name, returns an error.
-func (sc *ServerContext) AddDatabaseFromConfigFailFast(ctx context.Context, config DatabaseConfig) (*db.DatabaseContext, error) {
-	return sc.getOrAddDatabaseFromConfig(ctx, config, false, db.GetConnectToBucketFn(true))
+func (sc *ServerContext) AddDatabaseFromConfigFailFast(nonContextStruct base.NonCancellableContext, config DatabaseConfig) (*db.DatabaseContext, error) {
+	return sc.getOrAddDatabaseFromConfig(nonContextStruct.Ctx, config, false, db.GetConnectToBucketFn(true))
 }
 
 func (sc *ServerContext) processEventHandlersForEvent(ctx context.Context, events []*EventConfig, eventType db.EventType, dbcontext *db.DatabaseContext) error {


### PR DESCRIPTION
CBG-2685

Simple change to pass a background context into functions that start carrying out actions to create/update a database.
This will prevent the request scoped context cancellation cancelling any operations further on down the stack that use the context off the database. 
I have done this through creating a struct and a helper function to initialize the struct. This is to make it explicit what is required for these functions so future enhancements in the area can be sure to use the same context for functions on the database. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1414/
