### PR TITLE
Namespace sequence metadata keys

### DIFF
--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -145,7 +145,7 @@ func formatMetadataKey(metadataPrefix string, metaKey metadataKey) string {
 	return SyncDocMetadataPrefix + metadataPrefix + ":" + metaKey.String()
 }
 
-// formatMetadataKey formats key into the form _sync:[metaKey]
+// formatDefaultMetadataKey formats key into the form _sync:[metaKey]
 func formatDefaultMetadataKey(metaKey metadataKey) string {
 	return SyncDocPrefix + metaKey.String()
 }

--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -13,15 +13,33 @@ package base
 import (
 	"errors"
 	"fmt"
+	"strconv"
 )
 
-const SyncDocPrefix = "_sync:" // SyncDocPrefix is a common prefix for all Sync Gateway metadata documents
+const SyncDocPrefix = "_sync:"                                 // Prefix for all legacy (non-namespaced) Sync Gateway metadata documents
+const MetadataIdPrefix = "m_"                                  // Prefix for metadataId, to prevent collisions between namespaced and non-namespaced metadata documents
+const SyncDocMetadataPrefix = SyncDocPrefix + MetadataIdPrefix // Prefix for all namespaced Sync Gateway metadata documents
 
-// Sync Gateway Metadata documents
+// Sync Gateway Metadata document types
+type metadataKey int
+
 const (
-	SyncSeqKey                       = SyncDocPrefix + "seq"                           // SyncSeqKey is a counter document storing the SG sequence number of a collection
-	UnusedSeqPrefix                  = SyncDocPrefix + "unusedSeq:"                    // UnusedSeqPrefix stores a sequence that was reserved by SG but was unused
-	UnusedSeqRangePrefix             = SyncDocPrefix + "unusedSeqs:"                   // UnusedSeqRangePrefix stores a sequence range that was reserved by SG but was unused
+	MetaKeySeq            metadataKey = iota // "seq"
+	MetaKeyUnusedSeq                         // "unusedSeq:"
+	MetaKeyUnusedSeqRange                    // "unusedSeqs:"
+)
+
+var metadataKeyNames = []string{
+	"seq",         // counter document storing the sequence number for a database
+	"unusedSeq:",  // stores a sequence that was reserved by SG but was unused
+	"unusedSeqs:", // stores a sequence range that was reserved by SG but was unused
+}
+
+func (m metadataKey) String() string {
+	return metadataKeyNames[m]
+}
+
+const (
 	RevBodyPrefix                    = SyncDocPrefix + "rb:"                           // RevBodyPrefix stores a conflicting revision's body
 	RevPrefix                        = SyncDocPrefix + "rev:"                          // RevPrefix stores an old revision's body for temporary lookup (in-flight requests or delta sync)
 	BackgroundProcessHeartbeatPrefix = SyncDocPrefix + "background_process:heartbeat:" // BackgroundProcessHeartbeatPrefix stores a background process heartbeat
@@ -47,6 +65,90 @@ const (
 	SyncFunctionKeyWithoutGroupID           = SyncDocPrefix + "syncdata"            // SyncFunctionKeyWithoutGroupID stores a copy of the Sync Function
 	CollectionSyncFunctionKeyWithoutGroupID = SyncDocPrefix + "syncdata_collection" // CollectionSyncFunctionKeyWithoutGroupID stores a copy of the Sync Function
 )
+
+// MetadataKeys defines metadata keys and prefixes for a database, for a given metadataID.  Each Sync Gateway database
+// uses a unique metadataID, but may share the same MetadataStore.  MetadataKeys implements key namespacing for that
+// MetadataStore.
+type MetadataKeys struct {
+	metadataID           string
+	syncSeq              string
+	unusedSeqPrefix      string
+	unusedSeqRangePrefix string
+}
+
+// DefaultMetadataKeys defines the legacy metadata keys and prefixes.  These are used when the metadata collection is the only
+// defined collection, including upgrade scenarios.
+var DefaultMetadataKeys = &MetadataKeys{
+	metadataID:           "",
+	syncSeq:              formatDefaultMetadataKey(MetaKeySeq),
+	unusedSeqPrefix:      formatDefaultMetadataKey(MetaKeyUnusedSeq),
+	unusedSeqRangePrefix: formatDefaultMetadataKey(MetaKeyUnusedSeqRange),
+}
+
+// NewMetadataKeys returns MetadataKeys for the specified MetadataID  If metadataID is empty string, returns the default (legacy) metadata keys.
+// Key and prefix formatting is done in this constructor to minimize the work done per retrieval.
+func NewMetadataKeys(metadataID string) *MetadataKeys {
+	if metadataID == "" {
+		return DefaultMetadataKeys
+	} else {
+		return &MetadataKeys{
+			metadataID:           metadataID,
+			syncSeq:              formatMetadataKey(metadataID, MetaKeySeq),
+			unusedSeqPrefix:      formatMetadataKey(metadataID, MetaKeyUnusedSeq),
+			unusedSeqRangePrefix: formatMetadataKey(metadataID, MetaKeyUnusedSeqRange),
+		}
+	}
+}
+
+// SyncSeqKey returns the key for the sequence counter document for a database
+//
+//	format: _sync:{m_$}:seq
+func (mp *MetadataKeys) SyncSeqKey() string {
+	return mp.syncSeq
+}
+
+// UnusedSeqKey returns the key used to store a unused sequence document for sequence seq.
+// These documents are used to release sequences that are allocated but not used, so that they may be
+// accounted for by all SG nodes in the cluster.
+//
+//	format: _sync:{m_$}:unusedSeq:[seq]
+func (mp *MetadataKeys) UnusedSeqKey(seq uint64) string {
+	return mp.unusedSeqPrefix + strconv.FormatUint(seq, 10)
+}
+
+// UnusedSeqPrefix returns just the prefix used for UnusedSeqKey documents (used for DCP filtering)
+//
+//	format: _sync:{m_$}:unusedSeq:
+func (mp *MetadataKeys) UnusedSeqPrefix() string {
+	return mp.unusedSeqPrefix
+}
+
+// UnusedSeqRangeKey returns the key used to store a unused sequence document for sequence seq.
+// These documents are used to release sequences that are allocated but not used, so that they may be
+// accounted for by all SG nodes in the cluster.
+//
+//	format: _sync:{m_$}:unusedSeqs:[fromSeq]:[toSeq]
+func (mp *MetadataKeys) UnusedSeqRangeKey(fromSeq, toSeq uint64) string {
+
+	return mp.unusedSeqRangePrefix + strconv.FormatUint(fromSeq, 10) + ":" + strconv.FormatUint(toSeq, 10)
+}
+
+// UnusedSeqRangePrefix returns just the prefix used for UnusedSeqRangeKey documents (used for DCP filtering)
+//
+//	format: _sync:{m_$}:unusedSeqs:
+func (mp *MetadataKeys) UnusedSeqRangePrefix() string {
+	return mp.unusedSeqRangePrefix
+}
+
+// formatMetadataKey formats key into the form _sync:m_[metadataID]:[metaKey]
+func formatMetadataKey(metadataPrefix string, metaKey metadataKey) string {
+	return SyncDocMetadataPrefix + metadataPrefix + ":" + metaKey.String()
+}
+
+// formatMetadataKey formats key into the form _sync:[metaKey]
+func formatDefaultMetadataKey(metaKey metadataKey) string {
+	return SyncDocPrefix + metaKey.String()
+}
 
 // SyncFunctionKeyWithGroupID returns a doc ID to use when storing the sync function
 func SyncFunctionKeyWithGroupID(groupID string) string {

--- a/base/constants_syncdocs_test.go
+++ b/base/constants_syncdocs_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2023-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package base
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetaKeyNames(t *testing.T) {
+
+	// Validates that metadata keys aren't prefixed with MetadataIdPrefix
+	for _, metaKeyName := range metadataKeyNames {
+		assert.False(t, strings.HasPrefix(metaKeyName, MetadataIdPrefix))
+	}
+
+}

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -65,6 +65,7 @@ func TestDCPKeyFilter(t *testing.T) {
 		metaKeys *MetadataKeys
 	}{
 		{"default meta keys", DefaultMetadataKeys},
+		{"default meta keys from empty metaID", NewMetadataKeys("")},
 		{"db specific meta keys", NewMetadataKeys("dbname")},
 	}
 	for _, tc := range testCases {

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -169,6 +169,10 @@ func (b *TestBucket) GetSingleDataStore() sgbucket.DataStore {
 	return b.Bucket.DefaultDataStore()
 }
 
+func (b *TestBucket) GetMetadataStore() sgbucket.DataStore {
+	return b.Bucket.DefaultDataStore()
+}
+
 // GetDefaultDataStore returns the default DataStore. This is likely never actually wanted over GetSingleDataStore, so is left commented until absolutely required.
 // func (b *TestBucket) GetDefaultDataStore() sgbucket.DataStore {
 // 	b.t.Logf("Using default collection - Are you sure you want this instead of GetSingleDataStore() ?")

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -69,6 +69,7 @@ type changeCache struct {
 	internalStats      changeCacheStats        // Running stats for the change cache.  Only applied to expvars on a call to changeCache.updateStats
 	cfgEventCallback   base.CfgEventNotifyFunc // Callback for Cfg updates recieved over the caching feed
 	sgCfgPrefix        string                  // Prefix for SG Cfg doc keys
+	metaKeys           *base.MetadataKeys      // Metadata key formatter
 }
 
 type changeCacheStats struct {
@@ -157,7 +158,7 @@ func DefaultCacheOptions() CacheOptions {
 // notifyChange is an optional function that will be called to notify of channel changes.
 // After calling Init(), you must call .Start() to start useing the cache, otherwise it will be in a locked state
 // and callers will block on trying to obtain the lock.
-func (c *changeCache) Init(logCtx context.Context, collection *DatabaseCollection, channelCache ChannelCache, notifyChange func(channels.Set), options *CacheOptions) error {
+func (c *changeCache) Init(logCtx context.Context, collection *DatabaseCollection, channelCache ChannelCache, notifyChange func(channels.Set), options *CacheOptions, metaKeys *base.MetadataKeys) error {
 	c.collection = collection
 	c.logCtx = logCtx
 
@@ -168,6 +169,7 @@ func (c *changeCache) Init(logCtx context.Context, collection *DatabaseCollectio
 	c.skippedSeqs = NewSkippedSequenceList()
 	c.lastAddPendingTime = time.Now().UnixNano()
 	c.sgCfgPrefix = base.SGCfgPrefixWithGroupID(collection.groupID())
+	c.metaKeys = metaKeys
 
 	// init cache options
 	if options != nil {
@@ -410,11 +412,11 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	}
 
 	// Is this an unused sequence notification?
-	if strings.HasPrefix(docID, base.UnusedSeqPrefix) {
+	if strings.HasPrefix(docID, c.metaKeys.UnusedSeqPrefix()) {
 		c.processUnusedSequence(docID, event.TimeReceived)
 		return
 	}
-	if strings.HasPrefix(docID, base.UnusedSeqRangePrefix) {
+	if strings.HasPrefix(docID, c.metaKeys.UnusedSeqRangePrefix()) {
 		c.processUnusedSequenceRange(docID)
 		return
 	}
@@ -593,7 +595,7 @@ func (c *changeCache) unmarshalCachePrincipal(docJSON []byte) (cachePrincipal, e
 
 // Process unused sequence notification.  Extracts sequence from docID and sends to cache for buffering
 func (c *changeCache) processUnusedSequence(docID string, timeReceived time.Time) {
-	sequenceStr := strings.TrimPrefix(docID, base.UnusedSeqPrefix)
+	sequenceStr := strings.TrimPrefix(docID, c.metaKeys.UnusedSeqPrefix())
 	sequence, err := strconv.ParseUint(sequenceStr, 10, 64)
 	if err != nil {
 		base.WarnfCtx(c.logCtx, "Unable to identify sequence number for unused sequence notification with key: %s, error: %v", base.UD(docID), err)

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -961,7 +961,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	assert.Len(t, changes, 3)
 	assert.True(t, verifyChangesFullSequences(changes, []string{"1", "2", "2::6"}))
 
-	_, incrErr := db.singleCollection.dataStore.Incr(base.SyncSeqKey, 7, 7, 0)
+	_, incrErr := db.singleCollection.dataStore.Incr(db.MetadataKeys.SyncSeqKey(), 7, 7, 0)
 	require.NoError(t, incrErr)
 
 	// Modify user to have access to both channels (sequence 2):
@@ -2084,7 +2084,7 @@ func BenchmarkProcessEntry(b *testing.B) {
 
 			ctx = context.AddDatabaseLogContext(ctx)
 			changeCache := &changeCache{}
-			if err := changeCache.Init(ctx, collection, context.channelCache, nil, nil); err != nil {
+			if err := changeCache.Init(ctx, collection, context.channelCache, nil, nil, context.MetadataKeys); err != nil {
 				log.Printf("Init failed for changeCache: %v", err)
 				b.Fail()
 			}
@@ -2316,7 +2316,7 @@ func BenchmarkDocChanged(b *testing.B) {
 
 			ctx = context.AddDatabaseLogContext(ctx)
 			changeCache := &changeCache{}
-			if err := changeCache.Init(ctx, collection, context.channelCache, nil, nil); err != nil {
+			if err := changeCache.Init(ctx, collection, context.channelCache, nil, nil, context.MetadataKeys); err != nil {
 				log.Printf("Init failed for changeCache: %v", err)
 				b.Fail()
 			}

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1008,7 +1008,7 @@ func TestMalformedRevisionStorageRecovery(t *testing.T) {
 	assert.NoError(t, addErr, "Error writing raw document")
 
 	// Increment _sync:seq to match sequences allocated by raw doc
-	_, incrErr := collection.dataStore.Incr(base.SyncSeqKey, 5, 0, 0)
+	_, incrErr := collection.dataStore.Incr(db.MetadataKeys.SyncSeqKey(), 5, 0, 0)
 	assert.NoError(t, incrErr, "Error incrementing sync:seq")
 
 	// Add child to non-winning revision w/ malformed inline body.

--- a/db/database.go
+++ b/db/database.go
@@ -128,7 +128,6 @@ type DatabaseContext struct {
 	singleCollection             *DatabaseCollection            // Temporary collection
 	CollectionByID               map[uint32]*DatabaseCollection // A map keyed by collection ID to Collection
 	CollectionNames              map[string]map[string]struct{} // Map of scope, collection names
-	MetadataID                   string                         // Unique ID used when storing documents in MetadataStore
 	MetadataKeys                 *base.MetadataKeys             // Factory to generate metadata document keys
 }
 
@@ -396,13 +395,12 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	}
 
 	// Initialize metadata ID and keys
+	// TODO: apply length limit to MetadataPrefix
+	metadataID := dbName
 	if options.Scopes.onlyDefaultCollection() {
-		dbContext.MetadataID = ""
-	} else {
-		// TODO: apply length limit to MetadataPrefix
-		dbContext.MetadataID = dbName
+		metadataID = ""
 	}
-	metaKeys := base.NewMetadataKeys(dbContext.MetadataID)
+	metaKeys := base.NewMetadataKeys(metadataID)
 	dbContext.MetadataKeys = metaKeys
 
 	cleanupFunctions = append(cleanupFunctions, func() {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -93,11 +93,11 @@ func setupTestDBWithCustomSyncSeq(t testing.TB, customSeq uint64) (*Database, co
 	tBucket := base.GetTestBucket(t)
 
 	// This may need to change when we move to a non-default metadata collection...
-	metadataStore := tBucket.DefaultDataStore()
+	metadataStore := tBucket.GetMetadataStore()
 
-	log.Printf("Initializing test %s to %d", base.SyncSeqKey, customSeq)
-	_, incrErr := metadataStore.Incr(base.SyncSeqKey, customSeq, customSeq, 0)
-	assert.NoError(t, incrErr, fmt.Sprintf("Couldn't increment %s by %d", base.SyncSeqKey, customSeq))
+	log.Printf("Initializing test %s to %d", base.DefaultMetadataKeys.SyncSeqKey(), customSeq)
+	_, incrErr := metadataStore.Incr(base.DefaultMetadataKeys.SyncSeqKey(), customSeq, customSeq, 0)
+	assert.NoError(t, incrErr, fmt.Sprintf("Couldn't increment %s by %d", base.DefaultMetadataKeys.SyncSeqKey(), customSeq))
 
 	dbCtx, err := NewDatabaseContext(ctx, "db", tBucket, false, dbcOptions)
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
@@ -2667,7 +2667,7 @@ func Test_invalidateAllPrincipalsCache(t *testing.T) {
 	defer db.Close(ctx)
 	db.Options.QueryPaginationLimit = 100
 
-	sequenceAllocator, err := newSequenceAllocator(db.MetadataStore, db.DbStats.DatabaseStats)
+	sequenceAllocator, err := newSequenceAllocator(db.MetadataStore, db.DbStats.DatabaseStats, db.MetadataKeys)
 	assert.NoError(t, err)
 
 	db.sequences = sequenceAllocator

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -29,9 +29,10 @@ type importListener struct {
 	collections      map[uint32]DatabaseCollectionWithUser // Admin databases used for import, keyed by collection ID (CB-server-side)
 	dbStats          *base.DatabaseStats                   // Database stats group
 	importStats      *base.SharedBucketImportStats         // import stats group
-	cbgtContext      *base.CbgtContext                     // Handle to cbgt manager,cfg
-	checkpointPrefix string                                // DCP checkpoint key prefix
-	loggingCtx       context.Context                       // ctx for logging on event callbacks
+	metadataKeys     *base.MetadataKeys
+	cbgtContext      *base.CbgtContext // Handle to cbgt manager,cfg
+	checkpointPrefix string            // DCP checkpoint key prefix
+	loggingCtx       context.Context   // ctx for logging on event callbacks
 }
 
 func NewImportListener(groupID string) *importListener {
@@ -52,6 +53,7 @@ func (il *importListener) StartImportFeed(ctx context.Context, bucket base.Bucke
 	il.collections = make(map[uint32]DatabaseCollectionWithUser)
 	il.dbStats = dbStats.Database()
 	il.importStats = dbStats.SharedBucketImport()
+	il.metadataKeys = dbContext.MetadataKeys
 
 	collectionNamesByScope := make(map[string][]string)
 	var scopeName string

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -97,7 +97,7 @@ func (il *importListener) NewImportDest() (cbgt.Dest, error) {
 	importFeedStatsMap := il.dbStats.ImportFeedMapStats
 	importPartitionStat := il.importStats.ImportPartitions
 
-	importDest, _, err := base.NewDCPDest(il.loggingCtx, callback, il.bucket, maxVbNo, true, importFeedStatsMap.Map, base.DCPImportFeedID, importPartitionStat, il.checkpointPrefix)
+	importDest, _, err := base.NewDCPDest(il.loggingCtx, callback, il.bucket, maxVbNo, true, importFeedStatsMap.Map, base.DCPImportFeedID, importPartitionStat, il.checkpointPrefix, il.metadataKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -38,6 +38,7 @@ func TestSequenceAllocator(t *testing.T) {
 		dbStats:           testStats,
 		sequenceBatchSize: idleBatchSize,
 		reserveNotify:     make(chan struct{}, 50), // Buffered to allow multiple allocations without releaseSequenceMonitor
+		metaKeys:          base.DefaultMetadataKeys,
 	}
 
 	// Set high incr frequency to force batch size increase
@@ -103,7 +104,7 @@ func TestReleaseSequencesOnStop(t *testing.T) {
 	defer func() { MaxSequenceIncrFrequency = oldFrequency }()
 	MaxSequenceIncrFrequency = 1000 * time.Millisecond
 
-	a, err := newSequenceAllocator(bucket.GetSingleDataStore(), testStats)
+	a, err := newSequenceAllocator(bucket.GetSingleDataStore(), testStats, base.DefaultMetadataKeys)
 	// Reduce sequence wait for Stop testing
 	a.releaseSequenceWait = 10 * time.Millisecond
 	assert.NoError(t, err, "error creating allocator")
@@ -180,7 +181,7 @@ func TestSequenceAllocatorDeadlock(t *testing.T) {
 	defer func() { MaxSequenceIncrFrequency = oldFrequency }()
 	MaxSequenceIncrFrequency = 1000 * time.Millisecond
 
-	a, err = newSequenceAllocator(bucket.DefaultDataStore(), testStats)
+	a, err = newSequenceAllocator(bucket.DefaultDataStore(), testStats, base.DefaultMetadataKeys)
 	// Reduce sequence wait for Stop testing
 	a.releaseSequenceWait = 10 * time.Millisecond
 	assert.NoError(t, err, "error creating allocator")
@@ -208,7 +209,7 @@ func TestReleaseSequenceWait(t *testing.T) {
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 
-	a, err := newSequenceAllocator(bucket.GetSingleDataStore(), testStats)
+	a, err := newSequenceAllocator(bucket.GetSingleDataStore(), testStats, base.DefaultMetadataKeys)
 	require.NoError(t, err)
 	defer a.Stop()
 

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -3619,11 +3619,15 @@ func TestChangesIncludeConflicts(t *testing.T) {
 func TestChangesLargeSequences(t *testing.T) {
 
 	if base.UnitTestUrlIsWalrus() {
-		t.Skip("TestChangesLargeSequences doesn't support walrus - needs to customize " + base.SyncSeqKey + " prior to db creation")
+		t.Skip("TestChangesLargeSequences doesn't support walrus - needs to customize " + base.DefaultMetadataKeys.SyncSeqKey() + " prior to db creation")
 	}
 	if !base.TestsDisableGSI() {
 		t.Skip("Requires N1QL due to CBG-361")
 
+	}
+
+	if base.TestsUseNamedCollections() {
+		t.Skip("Requires default collection to set " + base.DefaultMetadataKeys.SyncSeqKey())
 	}
 	initialSeq := uint64(9223372036854775807)
 	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc,oldDoc) {

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1969,7 +1969,7 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	// allocate a fake sequence to trigger skipped sequence handling - this never arrives at rt1 - we could think about creating the doc afterwards to let the replicator recover, but not necessary for the test.
-	_, err = rt2.MetadataStore().Incr(base.SyncSeqKey, 1, 1, 0)
+	_, err = rt2.MetadataStore().Incr(rt2.GetDatabase().MetadataKeys.SyncSeqKey(), 1, 1, 0)
 	require.NoError(t, err)
 
 	docID3 := docIDPrefix + "3"

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -159,11 +159,15 @@ func (rt *RestTester) Bucket() base.Bucket {
 	rt.TestBucket = testBucket
 
 	if rt.InitSyncSeq > 0 {
-		log.Printf("Initializing %s to %d", base.SyncSeqKey, rt.InitSyncSeq)
-		tbDatastore := testBucket.GetSingleDataStore()
-		_, incrErr := tbDatastore.Incr(base.SyncSeqKey, rt.InitSyncSeq, rt.InitSyncSeq, 0)
+		if base.TestsUseNamedCollections() {
+			rt.TB.Fatalf("RestTester InitSyncSeq doesn't support non-default collections")
+		}
+
+		log.Printf("Initializing %s to %d", base.DefaultMetadataKeys.SyncSeqKey(), rt.InitSyncSeq)
+		tbDatastore := testBucket.GetMetadataStore()
+		_, incrErr := tbDatastore.Incr(base.DefaultMetadataKeys.SyncSeqKey(), rt.InitSyncSeq, rt.InitSyncSeq, 0)
 		if incrErr != nil {
-			rt.TB.Fatalf("Error initializing %s in test bucket: %v", base.SyncSeqKey, incrErr)
+			rt.TB.Fatalf("Error initializing %s in test bucket: %v", base.DefaultMetadataKeys.SyncSeqKey(), incrErr)
 		}
 	}
 


### PR DESCRIPTION
Adds infrastructure for namespacing metadata keys, and implements for _sync:seq and unusedSeq documents.  Defines a factory type for generating metadata keys (MetadataKeys) that is initialized when a databaseContext is created, and passed to consumers associated with that database.

CBG-0000

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1417/
