### PR TITLE
CBG-2489: Collection stats

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -414,8 +414,19 @@ type CollectionStats struct {
 	SyncFunctionRejectAccessCount *SgwIntStat `json:"sync_function_reject_access_count"`
 	// The total number of times the sync function encountered an exception for this collection.
 	SyncFunctionExceptionCount *SgwIntStat `json:"sync_function_exception_count"`
+
 	// The total number of documents imported to this collection since Sync Gateway node startup.
 	ImportCount *SgwIntStat `json:"import_count"`
+
+	// The total number of documents read from this collection since Sync Gateway node startup (i.e. sending to a client)
+	NumDocReads *SgwIntStat `json:"num_doc_reads"`
+	// The total number of bytes read from this collection as part of document writes since Sync Gateway node startup.
+	DocReadsBytes *SgwIntStat `json:"doc_reads_bytes"`
+
+	// The total number of documents written to this collection since Sync Gateway node startup (i.e. receiving from a client)
+	NumDocWrites *SgwIntStat `json:"num_doc_writes"`
+	// The total number of bytes written to this collection as part of document writes since Sync Gateway node startup.
+	DocWritesBytes *SgwIntStat `json:"doc_writes_bytes"`
 }
 
 type DatabaseStats struct {
@@ -1569,6 +1580,12 @@ func (d *DbStats) unregisterCollectionStats(scopeAndCollectionName string) {
 	prometheus.Unregister(d.CollectionStats[scopeAndCollectionName].SyncFunctionExceptionCount)
 
 	prometheus.Unregister(d.CollectionStats[scopeAndCollectionName].ImportCount)
+
+	prometheus.Unregister(d.CollectionStats[scopeAndCollectionName].NumDocReads)
+	prometheus.Unregister(d.CollectionStats[scopeAndCollectionName].DocReadsBytes)
+
+	prometheus.Unregister(d.CollectionStats[scopeAndCollectionName].NumDocWrites)
+	prometheus.Unregister(d.CollectionStats[scopeAndCollectionName].DocWritesBytes)
 }
 
 func (d *DbStats) unregisterSecurityStats() {
@@ -1607,6 +1624,24 @@ func NewCollectionStats(dbName, scopeAndCollectionName string) (stats *Collectio
 	}
 
 	stats.ImportCount, err = NewIntStat(SubsystemCollection, "import_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	stats.NumDocReads, err = NewIntStat(SubsystemCollection, "num_doc_reads", labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return nil, err
+	}
+	stats.DocReadsBytes, err = NewIntStat(SubsystemCollection, "doc_reads_bytes", labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	stats.NumDocWrites, err = NewIntStat(SubsystemCollection, "num_doc_writes", labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return nil, err
+	}
+	stats.DocWritesBytes, err = NewIntStat(SubsystemCollection, "doc_writes_bytes", labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/base/stats.go
+++ b/base/stats.go
@@ -13,6 +13,7 @@ package base
 import (
 	"context"
 	"expvar"
+	"fmt"
 	"log"
 	"math"
 	"strconv"
@@ -1431,17 +1432,13 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.SyncFunctionTime)
 }
 
-func (d *DbStats) CollectionStat(scopeName, collectionName string) *CollectionStats {
+func (d *DbStats) CollectionStat(scopeName, collectionName string) (*CollectionStats, error) {
 	scopeAndCollectionName := scopeName + "." + collectionName
 	if _, ok := d.CollectionStats[scopeAndCollectionName]; !ok {
-		// DbStats was not initialised with this collection upfront in NewDBStats for some reason (_default._default for example, since we pass named collections only ...)
-		stats, err := NewCollectionStats(d.dbName, scopeAndCollectionName)
-		if err != nil {
-			panic(err)
-		}
-		d.CollectionStats[scopeAndCollectionName] = stats
+		// DbStats was not initialised with this collection upfront in NewDBStats for some reason - not something we'd expect to happen
+		return nil, fmt.Errorf("stats for collection %q not found", scopeAndCollectionName)
 	}
-	return d.CollectionStats[scopeAndCollectionName]
+	return d.CollectionStats[scopeAndCollectionName], nil
 }
 
 func (d *DbStats) Database() *DatabaseStats {

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -824,6 +824,10 @@ func (bsc *BlipSyncContext) sendRevAsDelta(sender *blip.Sender, docID, revID str
 		return err
 	}
 
+	// We'll consider this one doc read for collection stats purposes, since GetDelta doesn't go through the normal getRev codepath.
+	handleChangesResponseCollection.collectionStats.NumDocReads.Add(1)
+	handleChangesResponseCollection.collectionStats.DocReadsBytes.Add(int64(len(revDelta.DeltaBytes)))
+
 	bsc.replicationStats.SendRevDeltaSentCount.Add(1)
 	return nil
 }

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -123,7 +123,7 @@ func TestLateSequenceHandling(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	cache := newSingleChannelCache(collection, channels.NewID("Test1", collectionID), 0, dbstats.CacheStats)
@@ -199,7 +199,7 @@ func TestLateSequenceHandlingWithMultipleListeners(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	cache := newSingleChannelCache(collection, channels.NewID("Test1", collectionID), 0, dbstats.CacheStats)

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -38,7 +38,7 @@ func TestDuplicateDocID(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, dbstats.Cache())
@@ -93,7 +93,7 @@ func TestLateArrivingSequence(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
@@ -136,7 +136,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
@@ -179,7 +179,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
@@ -264,7 +264,7 @@ func TestPrependChanges(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collectionID := dbCtx.GetSingleDatabaseCollection().GetCollectionID()
@@ -289,7 +289,7 @@ func TestPrependChanges(t *testing.T) {
 	// 2. Test prepend to populated cache, with overlap and duplicates
 	stats, err = base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err = stats.NewDBStats("", false, false, false)
+	dbstats, err = stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 	cache = newSingleChannelCache(dbCtx.GetSingleDatabaseCollection(), channels.NewID("PrependPopulatedCache", collectionID), 0, dbstats.Cache())
 	cache.validFrom = 13
@@ -347,7 +347,7 @@ func TestPrependChanges(t *testing.T) {
 	// 3. Test prepend that exceeds cache capacity
 	stats, err = base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err = stats.NewDBStats("", false, false, false)
+	dbstats, err = stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 	cache = newSingleChannelCache(dbCtx.GetSingleDatabaseCollection(), channels.NewID("PrependToFillCache", collectionID), 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
@@ -388,7 +388,7 @@ func TestPrependChanges(t *testing.T) {
 	// 4. Test prepend where all docids are already present in cache.  Cache entries shouldn't change, but validFrom is updated
 	stats, err = base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err = stats.NewDBStats("", false, false, false)
+	dbstats, err = stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 	cache = newSingleChannelCache(dbCtx.GetSingleDatabaseCollection(), channels.NewID("PrependDuplicatesOnly", collectionID), 0, dbstats.Cache())
 	cache.validFrom = 13
@@ -422,7 +422,7 @@ func TestPrependChanges(t *testing.T) {
 	// 5. Test prepend for an already full cache
 	stats, err = base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err = stats.NewDBStats("", false, false, false)
+	dbstats, err = stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 	cache = newSingleChannelCache(dbCtx.GetSingleDatabaseCollection(), channels.NewID("PrependFullCache", collectionID), 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
@@ -474,7 +474,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
@@ -523,7 +523,7 @@ func TestChannelCacheStats(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
@@ -603,7 +603,7 @@ func TestChannelCacheStatsOnPrune(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
@@ -643,7 +643,7 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
@@ -742,7 +742,7 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
@@ -771,7 +771,7 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
@@ -797,7 +797,7 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
@@ -823,7 +823,7 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
@@ -849,7 +849,7 @@ func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
@@ -875,7 +875,7 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
@@ -901,7 +901,7 @@ func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -84,7 +84,7 @@ func TestChannelCacheSimpleCompact(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	activeChannelStat := &base.SgwIntStat{}
@@ -125,7 +125,7 @@ func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	testStats := dbstats.Cache()
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
@@ -182,7 +182,7 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	activeChannelStat := &base.SgwIntStat{}
@@ -278,7 +278,7 @@ func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	queryHandler := &testQueryHandler{}
@@ -352,7 +352,7 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	queryHandler := &testQueryHandler{}
@@ -421,7 +421,7 @@ func TestChannelCacheBypass(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	queryHandler := &testQueryHandler{}
@@ -526,7 +526,7 @@ func TestChannelCacheBackgroundTaskWithIllegalTimeInterval(t *testing.T) {
 	options.ChannelCacheAge = 0
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false)
+	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -279,6 +279,9 @@ func (db *DatabaseCollectionWithUser) getRev(ctx context.Context, docid, revid s
 		return DocumentRevision{}, ErrMissing
 	}
 
+	db.collectionStats.NumDocReads.Add(1)
+	db.collectionStats.DocReadsBytes.Add(int64(len(revision.BodyBytes)))
+
 	// RequestedHistory is the _revisions returned in the body.  Avoids mutating revision.History, in case it's needed
 	// during attachment processing below
 	requestedHistory := revision.History
@@ -1914,6 +1917,8 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 		return nil, "", err
 	}
 
+	db.collectionStats.NumDocWrites.Add(1)
+	db.collectionStats.DocWritesBytes.Add(int64(docBytes))
 	db.dbStats().Database().NumDocWrites.Add(1)
 	db.dbStats().Database().DocWritesBytes.Add(int64(docBytes))
 	db.dbStats().Database().DocWritesXattrBytes.Add(int64(xattrBytes))

--- a/db/crud.go
+++ b/db/crud.go
@@ -2220,14 +2220,18 @@ func (db *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context, 
 
 	if db.channelMapper() != nil {
 		// Call the ChannelMapper:
-		startTime := time.Now()
 		db.dbStats().Database().SyncFunctionCount.Add(1)
+		db.dbStats().CollectionStat(db.ScopeName(), db.Name()).SyncFunctionCount.Add(1)
 
 		var output *channels.ChannelMapperOutput
+
+		startTime := time.Now()
 		output, err = db.channelMapper().MapToChannelsAndAccess(body, oldJson, metaMap,
 			MakeUserCtx(db.user, db.ScopeName(), db.Name()))
+		syncFunctionTimeNano := time.Since(startTime).Nanoseconds()
 
-		db.dbStats().Database().SyncFunctionTime.Add(time.Since(startTime).Nanoseconds())
+		db.dbStats().Database().SyncFunctionTime.Add(syncFunctionTimeNano)
+		db.dbStats().CollectionStat(db.ScopeName(), db.Name()).SyncFunctionTime.Add(syncFunctionTimeNano)
 
 		if err == nil {
 			result = output.Channels
@@ -2239,8 +2243,10 @@ func (db *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context, 
 				base.InfofCtx(ctx, base.KeyAll, "Sync fn rejected doc %q / %q --> %s", base.UD(doc.ID), base.UD(doc.NewestRev), err)
 				base.DebugfCtx(ctx, base.KeyAll, "    rejected doc %q / %q : new=%+v  old=%s", base.UD(doc.ID), base.UD(doc.NewestRev), base.UD(body), base.UD(oldJson))
 				db.dbStats().Security().NumDocsRejected.Add(1)
+				db.dbStats().CollectionStat(db.ScopeName(), db.Name()).SyncFunctionRejectCount.Add(1)
 				if isAccessError(err) {
 					db.dbStats().Security().NumAccessErrors.Add(1)
+					db.dbStats().CollectionStat(db.ScopeName(), db.Name()).SyncFunctionRejectAccessCount.Add(1)
 				}
 			} else if !validateAccessMap(access) || !validateRoleAccessMap(roles) {
 				err = base.HTTPErrorf(500, "Error in JS sync function")
@@ -2252,6 +2258,7 @@ func (db *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context, 
 				err = base.HTTPErrorf(500, "JS sync function timed out")
 			} else {
 				err = base.HTTPErrorf(500, "Exception in JS sync function")
+				db.dbStats().CollectionStat(db.ScopeName(), db.Name()).SyncFunctionExceptionCount.Add(1)
 			}
 		}
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -2221,7 +2221,7 @@ func (db *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context, 
 	if db.channelMapper() != nil {
 		// Call the ChannelMapper:
 		db.dbStats().Database().SyncFunctionCount.Add(1)
-		db.dbStats().CollectionStat(db.ScopeName(), db.Name()).SyncFunctionCount.Add(1)
+		db.collectionStats.SyncFunctionCount.Add(1)
 
 		var output *channels.ChannelMapperOutput
 
@@ -2231,7 +2231,7 @@ func (db *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context, 
 		syncFunctionTimeNano := time.Since(startTime).Nanoseconds()
 
 		db.dbStats().Database().SyncFunctionTime.Add(syncFunctionTimeNano)
-		db.dbStats().CollectionStat(db.ScopeName(), db.Name()).SyncFunctionTime.Add(syncFunctionTimeNano)
+		db.collectionStats.SyncFunctionTime.Add(syncFunctionTimeNano)
 
 		if err == nil {
 			result = output.Channels
@@ -2243,10 +2243,10 @@ func (db *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context, 
 				base.InfofCtx(ctx, base.KeyAll, "Sync fn rejected doc %q / %q --> %s", base.UD(doc.ID), base.UD(doc.NewestRev), err)
 				base.DebugfCtx(ctx, base.KeyAll, "    rejected doc %q / %q : new=%+v  old=%s", base.UD(doc.ID), base.UD(doc.NewestRev), base.UD(body), base.UD(oldJson))
 				db.dbStats().Security().NumDocsRejected.Add(1)
-				db.dbStats().CollectionStat(db.ScopeName(), db.Name()).SyncFunctionRejectCount.Add(1)
+				db.collectionStats.SyncFunctionRejectCount.Add(1)
 				if isAccessError(err) {
 					db.dbStats().Security().NumAccessErrors.Add(1)
-					db.dbStats().CollectionStat(db.ScopeName(), db.Name()).SyncFunctionRejectAccessCount.Add(1)
+					db.collectionStats.SyncFunctionRejectAccessCount.Add(1)
 				}
 			} else if !validateAccessMap(access) || !validateRoleAccessMap(roles) {
 				err = base.HTTPErrorf(500, "Error in JS sync function")
@@ -2258,7 +2258,7 @@ func (db *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context, 
 				err = base.HTTPErrorf(500, "JS sync function timed out")
 			} else {
 				err = base.HTTPErrorf(500, "Exception in JS sync function")
-				db.dbStats().CollectionStat(db.ScopeName(), db.Name()).SyncFunctionExceptionCount.Add(1)
+				db.collectionStats.SyncFunctionExceptionCount.Add(1)
 			}
 		}
 

--- a/db/database.go
+++ b/db/database.go
@@ -2156,7 +2156,14 @@ func initDatabaseStats(dbName string, autoImport bool, options DatabaseContextOp
 		queryNames = append(queryNames, options.GraphQL.N1QLQueryNames()...)
 	}
 
-	return base.SyncGatewayStats.NewDBStats(dbName, enabledDeltaSync, enabledImport, enabledViews, queryNames...)
+	var collections []string
+	for scopeName, scope := range options.Scopes {
+		for collectionName := range scope.Collections {
+			collections = append(collections, scopeName+"."+collectionName)
+		}
+	}
+
+	return base.SyncGatewayStats.NewDBStats(dbName, enabledDeltaSync, enabledImport, enabledViews, queryNames, collections)
 }
 
 func (context *DatabaseContext) AllowConflicts() bool {

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -22,6 +22,7 @@ import (
 type DatabaseCollection struct {
 	dataStore            base.DataStore          // Storage
 	revisionCache        RevisionCache           // Cache of recently-accessed doc revisions
+	collectionStats      *base.CollectionStats   // pointer to the collection stats (to avoid map lookups when used)
 	changeCache          *changeCache            // Cache of recently-access channels
 	dbCtx                *DatabaseContext        // pointer to database context to allow passthrough of functions
 	ChannelMapper        *channels.ChannelMapper // Collection's sync function

--- a/db/import.go
+++ b/db/import.go
@@ -328,6 +328,7 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 		docOut = alreadyImportedDoc
 	case nil:
 		db.dbStats().SharedBucketImport().ImportCount.Add(1)
+		db.dbStats().CollectionStat(db.ScopeName(), db.Name()).ImportCount.Add(1)
 		db.dbStats().SharedBucketImport().ImportHighSeq.Set(int64(docOut.SyncData.Sequence))
 		db.dbStats().SharedBucketImport().ImportProcessingTime.Add(time.Since(importStartTime).Nanoseconds())
 		base.DebugfCtx(ctx, base.KeyImport, "Imported %s (delete=%v) as rev %s", base.UD(newDoc.ID), isDelete, newRev)

--- a/db/import.go
+++ b/db/import.go
@@ -328,7 +328,7 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 		docOut = alreadyImportedDoc
 	case nil:
 		db.dbStats().SharedBucketImport().ImportCount.Add(1)
-		db.dbStats().CollectionStat(db.ScopeName(), db.Name()).ImportCount.Add(1)
+		db.collectionStats.ImportCount.Add(1)
 		db.dbStats().SharedBucketImport().ImportHighSeq.Set(int64(docOut.SyncData.Sequence))
 		db.dbStats().SharedBucketImport().ImportProcessingTime.Add(time.Since(importStartTime).Nanoseconds())
 		base.DebugfCtx(ctx, base.KeyImport, "Imported %s (delete=%v) as rev %s", base.UD(newDoc.ID), isDelete, newRev)

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -27,7 +27,7 @@ func TestSequenceAllocator(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false)
+	dbstats, err := sgw.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 
@@ -95,7 +95,7 @@ func TestReleaseSequencesOnStop(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false)
+	dbstats, err := sgw.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 
@@ -172,7 +172,7 @@ func TestSequenceAllocatorDeadlock(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false)
+	dbstats, err := sgw.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 
@@ -204,7 +204,7 @@ func TestReleaseSequenceWait(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false)
+	dbstats, err := sgw.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -139,6 +139,7 @@ ExpVars:
             This array contains stats for all databases declared in the config file -- see the [Sync Gateway Statistics Schema](./../stats-monitoring.html) for more details on the metrics collected and reported by Sync Gateway.
             The statistics for each {$db_name} database are grouped into:
             - cache related statistics
+            - collections statistics
             - cbl_replication_push
             - cbl_replication_pull
             - database_related_statistics
@@ -156,7 +157,9 @@ ExpVars:
               database:
                 type: object
               per_replication:
-                type: array
+                type: object
+              collections:
+                type: object
               security:
                 type: object
         per_replication:

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -566,3 +566,136 @@ func TestCollectionsChangeConfigScope(t *testing.T) {
 		assert.Contains(t, res.Body, "cannot change scopes after database creation"),
 	)
 }
+
+// TestCollecitonStats ensures that stats are specific to each collection.
+func TestCollectionStats(t *testing.T) {
+	base.TestRequiresCollections(t)
+
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+
+	scopesConfig := GetCollectionsConfig(t, tb, 2)
+	dataStoreNames := GetDataStoreNamesFromScopesConfig(scopesConfig)
+	syncFn := `
+		function(doc) {
+			if (doc.throwException) {
+				channel(undefinedvariable);
+			}
+			if (doc.require) {
+				requireAdmin();
+			}
+		}`
+
+	scope1Name, collection1Name := dataStoreNames[0].ScopeName(), dataStoreNames[0].CollectionName()
+	scope2Name, collection2Name := dataStoreNames[1].ScopeName(), dataStoreNames[1].CollectionName()
+	scopesConfig[scope1Name].Collections[collection1Name] = CollectionConfig{SyncFn: &syncFn}
+	scopesConfig[scope2Name].Collections[collection2Name] = CollectionConfig{SyncFn: &syncFn}
+
+	rtConfig := &RestTesterConfig{
+		CustomTestBucket: tb,
+		GuestEnabled:     true,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				Scopes:           scopesConfig,
+				NumIndexReplicas: base.UintPtr(0),
+				AutoImport:       base.TestUseXattrs(),
+				EnableXattrs:     base.BoolPtr(base.TestUseXattrs()),
+			},
+		},
+	}
+
+	rt := NewRestTesterMultipleCollections(t, rtConfig, 2)
+	defer rt.Close()
+
+	// Wait for the DB to be ready before attempting to get initial error count
+	require.NoError(t, rt.WaitForDBOnline())
+
+	collection1Stats, err := rt.GetDatabase().DbStats.CollectionStat(scope1Name, collection1Name)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), collection1Stats.SyncFunctionCount.Value())
+	assert.Equal(t, int64(0), collection1Stats.SyncFunctionTime.Value())
+	assert.Equal(t, int64(0), collection1Stats.SyncFunctionRejectCount.Value())
+	assert.Equal(t, int64(0), collection1Stats.SyncFunctionRejectAccessCount.Value())
+	assert.Equal(t, int64(0), collection1Stats.SyncFunctionExceptionCount.Value())
+	assert.Equal(t, int64(0), collection1Stats.ImportCount.Value())
+	assert.Equal(t, int64(0), collection1Stats.NumDocReads.Value())
+	assert.Equal(t, int64(0), collection1Stats.DocReadsBytes.Value())
+	assert.Equal(t, int64(0), collection1Stats.NumDocWrites.Value())
+	assert.Equal(t, int64(0), collection1Stats.DocWritesBytes.Value())
+
+	collection2Stats, err := rt.GetDatabase().DbStats.CollectionStat(scope2Name, collection2Name)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), collection2Stats.SyncFunctionCount.Value())
+	assert.Equal(t, int64(0), collection2Stats.SyncFunctionTime.Value())
+	assert.Equal(t, int64(0), collection2Stats.SyncFunctionRejectCount.Value())
+	assert.Equal(t, int64(0), collection2Stats.SyncFunctionRejectAccessCount.Value())
+	assert.Equal(t, int64(0), collection2Stats.SyncFunctionExceptionCount.Value())
+	assert.Equal(t, int64(0), collection2Stats.ImportCount.Value())
+	assert.Equal(t, int64(0), collection2Stats.NumDocReads.Value())
+	assert.Equal(t, int64(0), collection2Stats.DocReadsBytes.Value())
+	assert.Equal(t, int64(0), collection2Stats.NumDocWrites.Value())
+	assert.Equal(t, int64(0), collection2Stats.DocWritesBytes.Value())
+
+	doc1Contents := `{"foobar":true}`
+	response := rt.SendAdminRequest("PUT", "/{{.keyspace1}}/doc1", doc1Contents)
+	assert.Equal(t, http.StatusCreated, response.Code)
+	assert.Equal(t, int64(1), collection1Stats.NumDocWrites.Value())
+	if base.TestUseXattrs() {
+		assert.Equal(t, int64(len(doc1Contents)), collection1Stats.DocWritesBytes.Value()) // xattr writes size should exactly match doc contents
+	} else {
+		assert.Greater(t, collection1Stats.DocWritesBytes.Value(), int64(len(doc1Contents))) // non-xattr writes have sync data size included
+	}
+	assert.Equal(t, int64(1), collection1Stats.SyncFunctionCount.Value())
+	assert.GreaterOrEqual(t, collection1Stats.SyncFunctionTime.Value(), int64(0))
+	assert.Equal(t, int64(0), collection1Stats.NumDocReads.Value())
+	assert.Equal(t, int64(0), collection1Stats.DocReadsBytes.Value())
+
+	response = rt.SendAdminRequest("GET", "/{{.keyspace1}}/doc1", ``)
+	assert.Equal(t, http.StatusOK, response.Code)
+	assert.Equal(t, int64(1), collection1Stats.NumDocReads.Value())
+	assert.Equal(t, int64(len(doc1Contents)), collection1Stats.DocReadsBytes.Value())
+	assert.Equal(t, int64(1), collection1Stats.SyncFunctionCount.Value())
+
+	// runtime error
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace1}}/doc2", `{"throwException":true}`)
+	assert.Equal(t, http.StatusInternalServerError, response.Code)
+	assert.Contains(t, response.Body.String(), "Exception in JS sync function")
+	assert.Equal(t, int64(2), collection1Stats.SyncFunctionCount.Value())
+	assert.Equal(t, int64(1), collection1Stats.SyncFunctionExceptionCount.Value())
+
+	// require methods shouldn't cause a true exception
+	response = rt.SendRequest("PUT", "/{{.keyspace1}}/doc3", `{"require":true}`)
+	assert.Equal(t, http.StatusForbidden, response.Code)
+	assert.Contains(t, response.Body.String(), "sg admin required")
+	assert.Equal(t, int64(3), collection1Stats.SyncFunctionCount.Value())
+	assert.Equal(t, int64(1), collection1Stats.SyncFunctionExceptionCount.Value())
+	assert.Equal(t, int64(1), collection1Stats.SyncFunctionRejectCount.Value())
+
+	// we've not done anything to collection 2 yet, so still expect zero everything
+	assert.Equal(t, int64(0), collection2Stats.SyncFunctionCount.Value())
+	assert.Equal(t, int64(0), collection2Stats.SyncFunctionTime.Value())
+	assert.Equal(t, int64(0), collection2Stats.SyncFunctionRejectCount.Value())
+	assert.Equal(t, int64(0), collection2Stats.SyncFunctionRejectAccessCount.Value())
+	assert.Equal(t, int64(0), collection2Stats.SyncFunctionExceptionCount.Value())
+	assert.Equal(t, int64(0), collection2Stats.ImportCount.Value())
+	assert.Equal(t, int64(0), collection2Stats.NumDocReads.Value())
+	assert.Equal(t, int64(0), collection2Stats.DocReadsBytes.Value())
+	assert.Equal(t, int64(0), collection2Stats.NumDocWrites.Value())
+	assert.Equal(t, int64(0), collection2Stats.DocWritesBytes.Value())
+
+	// but make sure the 2nd collection stats are indeed wired up correctly... we don't need to be too comprehensive here given above coverage.
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace2}}/doc1", doc1Contents)
+	assert.Equal(t, http.StatusCreated, response.Code)
+	assert.Equal(t, int64(1), collection2Stats.NumDocWrites.Value())
+
+	// write a doc to the bucket and have it imported and check stat
+	if base.TestUseXattrs() {
+		dbc, err := rt.GetDatabase().GetDatabaseCollection(scope2Name, collection2Name)
+		require.NoError(t, err)
+		ok, err := dbc.GetCollectionDatastore().AddRaw("importeddoc", 0, []byte(`{"imported":true}`))
+		require.NoError(t, err)
+		assert.True(t, ok)
+		base.WaitForStat(collection2Stats.ImportCount.Value, 1)
+		assert.Equal(t, int64(2), collection2Stats.NumDocWrites.Value())
+	}
+}

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2418,7 +2418,7 @@ func TestProcessRevIncrementsStat(t *testing.T) {
 
 	remoteURL, _ := url.Parse(remoteURLString)
 
-	stats, err := base.SyncGatewayStats.NewDBStats("test", false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats("test", false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -51,7 +51,7 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
-	stats, err := base.SyncGatewayStats.NewDBStats("test", false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats("test", false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1718,7 +1718,7 @@ func TestActiveReplicatorHeartbeats(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -1813,7 +1813,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -1920,7 +1920,7 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2073,7 +2073,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2402,7 +2402,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2580,7 +2580,7 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 	require.NoError(t, err)
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2740,7 +2740,7 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2840,7 +2840,7 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2933,7 +2933,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3071,7 +3071,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	}
 
 	// Create the first active replicator to pull from seq:0
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3127,7 +3127,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	}
 
 	// Create a new replicator using the same config, which should use the checkpoint set from the first.
-	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false)
+	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err = stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3244,7 +3244,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	arConfig.SetCheckpointPrefix(t, "cluster1:")
 
 	// Create the first active replicator to pull from seq:0
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3306,7 +3306,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	ctx2 := edge2.Context()
 
 	// Create a new replicator using the same ID, which should NOT use the checkpoint set by the first edge.
-	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"edge2", false, false, false)
+	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"edge2", false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err = stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3335,7 +3335,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	require.NoError(t, rt1.WaitForPendingChanges())
 
 	// run a replicator on edge1 again to make sure that edge2 didn't blow away its checkpoint
-	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", false, false, false)
+	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err = stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3417,7 +3417,7 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3517,7 +3517,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3627,7 +3627,7 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3824,7 +3824,7 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 
 			customConflictResolver, err := db.NewCustomConflictResolver(test.conflictResolver, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err)
-			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 			replicationStats, err := stats.DBReplicatorStats(t.Name())
 			require.NoError(t, err)
 
@@ -4068,7 +4068,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			customConflictResolver, err := db.NewCustomConflictResolver(test.conflictResolver, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err)
 
-			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 			require.NoError(t, err)
 			dbstats, err := stats.DBReplicatorStats(t.Name())
 			require.NoError(t, err)
@@ -4225,7 +4225,7 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -4308,7 +4308,7 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -4380,7 +4380,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 			CustomTestBucket: base.GetTestBucket(t),
 		})
 	ctx1 := rt1.Context()
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -4557,7 +4557,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	}
 
 	// Create the first active replicator to pull from seq:0
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -4630,7 +4630,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	require.NoError(t, err)
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 	arConfig.RemoteDBURL = passiveDBURL
-	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false)
+	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err = stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -4730,7 +4730,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	assert.NoError(t, rt1.WaitForPendingChanges())
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -4885,7 +4885,7 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -5001,7 +5001,7 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -5120,7 +5120,7 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -5332,7 +5332,7 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 					defer rt1.Close()
 					ctx1 := rt1.Context()
 
-					sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+					sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 					require.NoError(t, err)
 					dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 					require.NoError(t, err)
@@ -5429,7 +5429,7 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 
 	id, err := base.GenerateRandomID()
 	require.NoError(t, err)
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -5521,7 +5521,7 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -5843,7 +5843,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 
 			customConflictResolver, err := db.NewCustomConflictResolver(test.conflictResolver, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err)
-			dbstats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+			dbstats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 			require.NoError(t, err)
 			replicationStats, err := dbstats.DBReplicatorStats(t.Name())
 			require.NoError(t, err)
@@ -6322,7 +6322,7 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 			defaultConflictResolver, err := db.NewCustomConflictResolver(
 				`function(conflict) { return defaultPolicy(conflict); }`, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err, "Error creating custom conflict resolver")
-			sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+			sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 			require.NoError(t, err)
 			dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 			require.NoError(t, err)
@@ -6483,7 +6483,7 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 			defaultConflictResolver, err := db.NewCustomConflictResolver(
 				`function(conflict) { return defaultPolicy(conflict); }`, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err, "Error creating custom conflict resolver")
-			sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+			sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 			require.NoError(t, err)
 			dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 			require.NoError(t, err)
@@ -6821,7 +6821,7 @@ func TestSendChangesToNoConflictPreHydrogenTarget(t *testing.T) {
 
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -6991,7 +6991,7 @@ func TestConflictResolveMergeWithMutatedRev(t *testing.T) {
 		}`, rt1.GetDatabase().Options.JavascriptTimeout)
 	require.NoError(t, err)
 
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -7086,7 +7086,7 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 	// Set-up replicator //
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), true, false, false)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), true, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -7194,7 +7194,7 @@ func TestUnprocessableDeltas(t *testing.T) {
 	// Set-up replicator //
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), true, false, false)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), true, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -7302,7 +7302,7 @@ func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
 
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -7355,7 +7355,7 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 	// Set-up replicator
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1502,7 +1502,7 @@ func TestReplicatorRevocations(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "test")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -1561,7 +1561,7 @@ func TestReplicatorRevocationsNoRev(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "test")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -1628,7 +1628,7 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "test")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -1688,7 +1688,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "test")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -1802,7 +1802,7 @@ func TestReplicatorRevocationsWithTombstoneResurrection(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "letmein")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -1894,7 +1894,7 @@ func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "test")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -1988,7 +1988,7 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "letmein")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2389,7 +2389,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "letmein")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2448,7 +2448,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 
 	require.NoError(t, ar.Stop())
 	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
-	sgwStats, err = base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false)
+	sgwStats, err = base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err = sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)


### PR DESCRIPTION
CBG-2489

- Refactor NewDBStats to take slices of query and collections to initialise
- Add collection stats for sync and import
- NumDocsRead/NumDocsWrite and associated Bytes stats
- Unit/integration test coverage 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1434/