### PR TITLE
CBG-2689: Add SyncFunctionExceptionCount stat

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -491,6 +491,8 @@ type DatabaseStats struct {
 	SyncFunctionCount *SgwIntStat `json:"sync_function_count"`
 	// The total time spent evaluating a sync function (across all collections).
 	SyncFunctionTime *SgwIntStat `json:"sync_function_time"`
+	// The total number of times that a sync function encountered an exception (across all collections).
+	SyncFunctionExceptionCount *SgwIntStat `json:"sync_function_exception_count"`
 
 	// These can be cleaned up in future versions of SGW, implemented as maps to reduce amount of potential risk
 	// prior to Hydrogen release. These are not exported as part of prometheus and only exposed through expvars
@@ -1401,6 +1403,10 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.SyncFunctionExceptionCount, err = NewIntStat(SubsystemDatabaseKey, "sync_function_exception_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.ImportFeedMapStats = &ExpVarMapWrapper{new(expvar.Map).Init()}
 
 	resUtil.CacheFeedMapStats = &ExpVarMapWrapper{new(expvar.Map).Init()}
@@ -1441,6 +1447,7 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.WarnXattrSizeCount)
 	prometheus.Unregister(d.DatabaseStats.SyncFunctionCount)
 	prometheus.Unregister(d.DatabaseStats.SyncFunctionTime)
+	prometheus.Unregister(d.DatabaseStats.SyncFunctionExceptionCount)
 }
 
 func (d *DbStats) CollectionStat(scopeName, collectionName string) (*CollectionStats, error) {

--- a/db/crud.go
+++ b/db/crud.go
@@ -2264,6 +2264,7 @@ func (db *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context, 
 			} else {
 				err = base.HTTPErrorf(500, "Exception in JS sync function")
 				db.collectionStats.SyncFunctionExceptionCount.Add(1)
+				db.dbStats().Database().SyncFunctionExceptionCount.Add(1)
 			}
 		}
 

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -327,6 +327,60 @@ func TestSyncFunctionErrorLogging(t *testing.T) {
 	assert.Equal(t, numErrors+1, numErrorsAfter)
 }
 
+func TestSyncFunctionException(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyJavascript)
+
+	rtConfig := RestTesterConfig{
+		SyncFn: `
+		function(doc) {
+			if (doc.throwException) {
+				channel(undefinedvariable);
+			}
+			if (doc.throwExplicit) {
+				throw("Explicit exception");
+			}
+			if (doc.require) {
+				requireAdmin();
+			}
+		}`,
+		GuestEnabled: true,
+	}
+
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+
+	// Wait for the DB to be ready before attempting to get initial error count
+	assert.NoError(t, rt.WaitForDBOnline())
+
+	numDBSyncExceptionsStart := rt.GetDatabase().DbStats.Database().SyncFunctionExceptionCount.Value()
+
+	// runtime error
+	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"throwException":true}`)
+	assert.Equal(t, http.StatusInternalServerError, response.Code)
+	assert.Contains(t, response.Body.String(), "Exception in JS sync function")
+
+	numDBSyncExceptions := rt.GetDatabase().DbStats.Database().SyncFunctionExceptionCount.Value()
+	assert.Equal(t, numDBSyncExceptionsStart+1, numDBSyncExceptions)
+	numDBSyncExceptionsStart = numDBSyncExceptions
+
+	// explicit throws should cause an exception
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc2", `{"throwExplicit":true}`)
+	assert.Equal(t, http.StatusInternalServerError, response.Code)
+	assert.Contains(t, response.Body.String(), "Exception in JS sync function")
+
+	numDBSyncExceptions = rt.GetDatabase().DbStats.Database().SyncFunctionExceptionCount.Value()
+	assert.Equal(t, numDBSyncExceptionsStart+1, numDBSyncExceptions)
+	numDBSyncExceptionsStart = numDBSyncExceptions
+
+	// require methods shouldn't cause a true exception
+	response = rt.SendRequest("PUT", "/{{.keyspace}}/doc3", `{"require":true}`)
+	assert.Equal(t, http.StatusForbidden, response.Code)
+	assert.Contains(t, response.Body.String(), "sg admin required")
+	numDBSyncExceptions = rt.GetDatabase().DbStats.Database().SyncFunctionExceptionCount.Value()
+	assert.Equal(t, numDBSyncExceptionsStart, numDBSyncExceptions)
+}
+
 func TestSyncFnTimeout(t *testing.T) {
 	syncFn := `function(doc) { while(true) {} }`
 

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -375,6 +375,8 @@ func TestSyncFunctionException(t *testing.T) {
 	numDBSyncExceptions = rt.GetDatabase().DbStats.Database().SyncFunctionExceptionCount.Value()
 	assert.Equal(t, numDBSyncExceptionsStart+1, numDBSyncExceptions)
 	numDBSyncExceptionsStart = numDBSyncExceptions
+	numDBSyncRejected := rt.GetDatabase().DbStats.Security().NumDocsRejected.Value()
+	assert.Equal(t, int64(0), numDBSyncRejected)
 
 	// throw with a forbidden property shouldn't cause a true exception
 	response = rt.SendRequest("PUT", "/{{.keyspace}}/doc3", `{"throwForbidden":true}`)
@@ -382,6 +384,8 @@ func TestSyncFunctionException(t *testing.T) {
 	assert.Contains(t, response.Body.String(), "read only!")
 	numDBSyncExceptions = rt.GetDatabase().DbStats.Database().SyncFunctionExceptionCount.Value()
 	assert.Equal(t, numDBSyncExceptionsStart, numDBSyncExceptions)
+	numDBSyncRejected = rt.GetDatabase().DbStats.Security().NumDocsRejected.Value()
+	assert.Equal(t, int64(1), numDBSyncRejected)
 
 	// require methods shouldn't cause a true exception
 	response = rt.SendRequest("PUT", "/{{.keyspace}}/doc4", `{"require":true}`)
@@ -389,6 +393,8 @@ func TestSyncFunctionException(t *testing.T) {
 	assert.Contains(t, response.Body.String(), "sg admin required")
 	numDBSyncExceptions = rt.GetDatabase().DbStats.Database().SyncFunctionExceptionCount.Value()
 	assert.Equal(t, numDBSyncExceptionsStart, numDBSyncExceptions)
+	numDBSyncRejected = rt.GetDatabase().DbStats.Security().NumDocsRejected.Value()
+	assert.Equal(t, int64(2), numDBSyncRejected)
 }
 
 func TestSyncFnTimeout(t *testing.T) {


### PR DESCRIPTION
CBG-2689

Adds a stat that is incremented when a sync function encounters an exception.
Does not increment when a built-in like `requireRole`/`requireAdmin` is used.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1423/
