### PR TITLE
[2.8.4] CBG-2611: Upgrade Blip, compress and websocket dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
         EE_BUILD_TAG = "cb_sg_enterprise"
         SGW_REPO = "github.com/couchbase/sync_gateway"
         GH_ACCESS_TOKEN_CREDENTIAL = "github_cb-robot-sg_access_token"
+        GO111MODULE = "off"
     }
 
     tools {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -307,6 +307,7 @@ pipeline {
                             }
                         }
                         stage('against EE') {
+                            when { expression { return false } }
                             steps {
 
                                 githubNotify(credentialsId: "${GH_ACCESS_TOKEN_CREDENTIAL}", context: 'sgw-pipeline-litecore-ee', description: 'Running LiteCore Tests', status: 'PENDING')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
     }
 
     tools {
-        go '1.13.4'
+        go '1.19'
     }
 
     stages {
@@ -62,7 +62,7 @@ pipeline {
                             steps {
                                 withEnv(["GOPATH=${GOTOOLS}"]) {
                                     // unhandled error checker
-                                    sh 'go get -v -u github.com/kisielk/errcheck@v1.6.2'
+                                    sh 'go get -v -u github.com/kisielk/errcheck'
                                     // goveralls is used to send coverprofiles to coveralls.io
                                     sh 'go get -v -u github.com/mattn/goveralls'
                                     // Jenkins coverage reporting tools

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
     }
 
     tools {
-        go '1.19'
+        go '1.16'
     }
 
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
                             steps {
                                 withEnv(["GOPATH=${GOTOOLS}"]) {
                                     // unhandled error checker
-                                    sh 'go get -v -u github.com/kisielk/errcheck'
+                                    sh 'go get -v -u github.com/kisielk/errcheck@v1.6.2'
                                     // goveralls is used to send coverprofiles to coveralls.io
                                     sh 'go get -v -u github.com/mattn/goveralls'
                                     // Jenkins coverage reporting tools

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -186,7 +186,10 @@ func (ar *ActiveReplicator) GetStatus() *ReplicationStatus {
 func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sender, bsc *BlipSyncContext, err error) {
 	arc.replicationStats.NumConnectAttempts.Add(1)
 
-	blipContext := NewSGBlipContext(arc.ctx, arc.config.ID+idSuffix)
+	blipContext, err := NewSGBlipContext(arc.ctx, arc.config.ID+idSuffix)
+	if err != nil {
+		return nil, nil, err
+	}
 	blipContext.WebsocketPingInterval = arc.config.WebsocketPingInterval
 	blipContext.OnExitCallback = func() {
 		// fall into a reconnect loop only if the connection is unexpectedly closed.

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -12,7 +11,6 @@ import (
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
-	"golang.org/x/net/websocket"
 )
 
 // ActiveReplicator is a wrapper to encapsulate separate push and pull active replicators.
@@ -254,23 +252,18 @@ func blipSync(target url.URL, blipContext *blip.Context, insecureSkipVerify bool
 		target.User = nil
 	}
 
-	config, err := websocket.NewConfig(target.String()+"/_blipsync?"+BLIPSyncClientTypeQueryParam+"="+string(BLIPClientTypeSGR2), "http://localhost")
-	if err != nil {
-		return nil, err
-	}
-
-	if insecureSkipVerify {
-		if config.TlsConfig == nil {
-			config.TlsConfig = new(tls.Config)
-		}
-		config.TlsConfig.InsecureSkipVerify = true
+	config := blip.DialOptions{
+		URL:        target.String() + "/_blipsync?" + BLIPSyncClientTypeQueryParam + "=" + string(BLIPClientTypeSGR2),
+		HTTPClient: client,
 	}
 
 	if basicAuthCreds != nil {
-		config.Header.Add("Authorization", "Basic "+base64UserInfo(basicAuthCreds))
+		config.HTTPHeader = http.Header{
+			"Authorization": []string{"Basic " + base64UserInfo(basicAuthCreds)},
+		}
 	}
 
-	return blipContext.DialConfig(config)
+	return blipContext.DialConfig(&config)
 }
 
 // base64UserInfo returns the base64 encoded version of the given UserInfo.

--- a/db/active_replicator_test.go
+++ b/db/active_replicator_test.go
@@ -55,7 +55,9 @@ func TestBlipSyncErrorUserinfo(t *testing.T) {
 			srvURL.Path = "/db1"
 			t.Logf("srvURL: %v", srvURL.String())
 
-			_, err = blipSync(*srvURL, NewSGBlipContext(context.Background(), t.Name()), false)
+			blipCtx, err := NewSGBlipContext(context.Background(), t.Name())
+			require.NoError(t, err)
+			_, err = blipSync(*srvURL, blipCtx, false)
 			require.Error(t, err)
 			t.Logf("error: %v", err)
 			if targetPassword, hasPassword := srvURL.User.Password(); hasPassword {

--- a/db/blip.go
+++ b/db/blip.go
@@ -15,18 +15,24 @@ const (
 )
 
 // NewSGBlipContext returns a go-blip context with the given ID, initialized for use in Sync Gateway.
-func NewSGBlipContext(ctx context.Context, id string) (bc *blip.Context) {
+func NewSGBlipContext(ctx context.Context, id string) (bc *blip.Context, err error) {
 	if id == "" {
-		bc = blip.NewContext(blipCBMobileReplication)
+		bc, err = blip.NewContext(blipCBMobileReplication)
+		if err != nil {
+			return nil, err
+		}
 	} else {
-		bc = blip.NewContextCustomID(id, blipCBMobileReplication)
+		bc, err = blip.NewContextCustomID(id, blipCBMobileReplication)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	bc.LogMessages = base.LogDebugEnabled(base.KeyWebSocket)
 	bc.LogFrames = base.LogDebugEnabled(base.KeyWebSocketFrame)
 	bc.Logger = defaultBlipLogger(ctx)
 
-	return bc
+	return bc, nil
 }
 
 // defaultBlipLogger returns a function that can be set as the blip.Context.Logger for Sync Gateway integrated go-blip logging.

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -94,7 +94,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="73600c7628b2f93657bfa60083289a6b403615b3"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="215cbac22bd7d160b16eebc1fd0d3fbe13e92051"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 
@@ -145,5 +145,8 @@
   <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="d7df74196a9e781ede915320c11c378c1b2f3a1f"/>
   <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="b5d812f8a3706043e23a9cd5babf2e5423744d30"/>
   <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="1ecb1f411c1f2ce65a2db6ea4a8ae927182d342e"/>
+
+  <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
+  <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="9559b037e79ad673c71f6ef7c732c00949014cd2"/>
 
 </manifest>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -147,6 +147,6 @@
   <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="1ecb1f411c1f2ce65a2db6ea4a8ae927182d342e"/>
 
   <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
-  <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="9559b037e79ad673c71f6ef7c732c00949014cd2"/>
+  <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="a1a9cfc821f00faf2f5231beaa96244344d50391"/>
 
 </manifest>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -149,4 +149,7 @@
   <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
   <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="a1a9cfc821f00faf2f5231beaa96244344d50391"/>
 
+  <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
+  <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="a1a9cfc821f00faf2f5231beaa96244344d50391"/>
+
 </manifest>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -149,7 +149,4 @@
   <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
   <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="a1a9cfc821f00faf2f5231beaa96244344d50391"/>
 
-  <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
-  <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="a1a9cfc821f00faf2f5231beaa96244344d50391"/>
-
 </manifest>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -118,9 +118,9 @@
   <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
   <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
 
-  <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="819acad769e54806c920726ac93537ba4e2c22ad"/>
+  <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="024077e996b048517130b21ea6bf12aa23055d3d"/>
   <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
-  <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="94122c33edd36123c84d5368cfb2b69df93a0ec8"/>
+  <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="2b33151c9bbc5231aea69b8861c540102b087070"/>
 
   <!-- gozip tools -->
   <project name="ns_server" path="godeps/src/github.com/couchbase/ns_server" remote="couchbase" revision="6d835931f574f25e3781192c09e45a3ee30deb51"/>

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -367,7 +367,7 @@ function(doc, oldDoc) {
 
 	numExpectedChanges := 201
 
-	go func(t *testing.T) {
+	go func() {
 		defer wg.Done()
 
 		since := ""
@@ -404,12 +404,13 @@ function(doc, oldDoc) {
 
 			numTries++
 			if numTries > maxTries {
-				t.Fatalf("Giving up trying to receive %d changes.  Only received %d", numExpectedChanges, len(changesAccumulated))
+				t.Errorf("Giving up trying to receive %d changes.  Only received %d", numExpectedChanges, len(changesAccumulated))
+				return
 			}
 
 		}
 
-	}(t)
+	}()
 
 	// Make bulk docs calls, 100 docs each, all triggering access grants to the list docs.
 	for j := 0; j < 1; j++ {

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -367,7 +367,7 @@ function(doc, oldDoc) {
 
 	numExpectedChanges := 201
 
-	go func() {
+	go func(t *testing.T) {
 		defer wg.Done()
 
 		since := ""
@@ -409,7 +409,7 @@ function(doc, oldDoc) {
 
 		}
 
-	}()
+	}(t)
 
 	// Make bulk docs calls, 100 docs each, all triggering access grants to the list docs.
 	for j := 0; j < 1; j++ {
@@ -745,7 +745,7 @@ func TestGuestUser(t *testing.T) {
 	assertStatus(t, response, http.StatusMethodNotAllowed)
 }
 
-//Test that TTL values greater than the default max offset TTL 2592000 seconds are processed correctly
+// Test that TTL values greater than the default max offset TTL 2592000 seconds are processed correctly
 // fixes #974
 func TestSessionTtlGreaterThan30Days(t *testing.T) {
 
@@ -952,7 +952,7 @@ func TestFlush(t *testing.T) {
 	assertStatus(t, rt.SendRequest("GET", "/db/doc2", ""), 404)
 }
 
-//Test a single call to take DB offline
+// Test a single call to take DB offline
 func TestDBOfflineSingle(t *testing.T) {
 
 	rt := NewRestTester(t, nil)
@@ -972,7 +972,7 @@ func TestDBOfflineSingle(t *testing.T) {
 	goassert.True(t, body["state"].(string) == "Offline")
 }
 
-//Make two concurrent calls to take DB offline
+// Make two concurrent calls to take DB offline
 // Ensure both calls succeed and that DB is offline
 // when both calls return
 func TestDBOfflineConcurrent(t *testing.T) {
@@ -1016,7 +1016,7 @@ func TestDBOfflineConcurrent(t *testing.T) {
 
 }
 
-//Test that a DB can be created offline
+// Test that a DB can be created offline
 func TestStartDBOffline(t *testing.T) {
 
 	rt := NewRestTester(t, nil)
@@ -1036,8 +1036,8 @@ func TestStartDBOffline(t *testing.T) {
 	goassert.True(t, body["state"].(string) == "Offline")
 }
 
-//Take DB offline and ensure that normal REST calls
-//fail with status 503
+// Take DB offline and ensure that normal REST calls
+// fail with status 503
 func TestDBOffline503Response(t *testing.T) {
 
 	rt := NewRestTester(t, nil)
@@ -1060,7 +1060,7 @@ func TestDBOffline503Response(t *testing.T) {
 	assertStatus(t, rt.SendRequest("GET", "/db/doc1", ""), 503)
 }
 
-//Take DB offline and ensure can put db config
+// Take DB offline and ensure can put db config
 func TestDBOfflinePutDbConfig(t *testing.T) {
 
 	rt := NewRestTester(t, nil)
@@ -1111,7 +1111,7 @@ func TestDBGetConfigNames(t *testing.T) {
 
 }
 
-//Take DB offline and ensure can post _resync
+// Take DB offline and ensure can post _resync
 func TestDBOfflinePostResync(t *testing.T) {
 
 	if testing.Short() {
@@ -1138,7 +1138,7 @@ func TestDBOfflinePostResync(t *testing.T) {
 	assertStatus(t, rt.SendAdminRequest("POST", "/db/_resync", ""), 200)
 }
 
-//Take DB offline and ensure only one _resync can be in progress
+// Take DB offline and ensure only one _resync can be in progress
 func TestDBOfflineSingleResync(t *testing.T) {
 
 	if testing.Short() {
@@ -1226,9 +1226,9 @@ func TestDBOnlineSingle(t *testing.T) {
 	goassert.True(t, body["state"].(string) == "Online")
 }
 
-//Take DB online concurrently using two goroutines
-//Both should return success and DB should be online
-//once both goroutines return
+// Take DB online concurrently using two goroutines
+// Both should return success and DB should be online
+// once both goroutines return
 func TestDBOnlineConcurrent(t *testing.T) {
 
 	rt := NewRestTester(t, nil)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -116,7 +116,7 @@ func TestDocLifecycle(t *testing.T) {
 	assertStatus(t, response, 200)
 }
 
-//Validate that Etag header value is surrounded with double quotes, see issue #808
+// Validate that Etag header value is surrounded with double quotes, see issue #808
 func TestDocEtag(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -2527,12 +2527,13 @@ func TestSyncFnOldDocBodyPropertiesTombstoneResurrect(t *testing.T) {
 
 // TestSyncFnDocBodyPropertiesSwitchActiveTombstone creates a branched revtree, where the first tombstone created becomes active again after the shorter b branch is tombstoned.
 // The test makes sure that in this scenario, the "doc" body of the sync function when switching from (T) 3-b to (T) 4-a contains a _deleted property (stamped by getAvailable1xRev)
-//     1-a
-//     ├── 2-a
-//     │   └── 3-a
-//     │       └──────── (T) 4-a
-//     └──────────── 2-b
-//                   └────────────── (T) 3-b
+//
+//	1-a
+//	├── 2-a
+//	│   └── 3-a
+//	│       └──────── (T) 4-a
+//	└──────────── 2-b
+//	              └────────────── (T) 3-b
 func TestSyncFnDocBodyPropertiesSwitchActiveTombstone(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyJavascript)()
@@ -2601,7 +2602,7 @@ func TestSyncFnDocBodyPropertiesSwitchActiveTombstone(t *testing.T) {
 	assert.Equal(t, 1, numErrorsAfter-numErrorsBefore, "expecting to see only only 1 error logged")
 }
 
-//Test for wrong _changes entries for user joining a populated channel
+// Test for wrong _changes entries for user joining a populated channel
 func TestUserJoiningPopulatedChannel(t *testing.T) {
 
 	if testing.Short() {
@@ -2990,7 +2991,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 	goassert.Equals(t, allDocsResult.Rows[0].Value.Channels[0], "ch2")
 }
 
-//Test for regression of issue #447
+// Test for regression of issue #447
 func TestAttachmentsNoCrossTalk(t *testing.T) {
 
 	rt := NewRestTester(t, nil)
@@ -5159,15 +5160,17 @@ func TestHandlePprofs(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.inputProfile, func(t *testing.T) {
-			expectedContentDisposition := fmt.Sprintf(`attachment; filename="%v"`, tc.inputProfile)
+			expectedContentDispositionPrefix := fmt.Sprintf(`attachment; filename="%v`, tc.inputProfile)
 			response := rt.SendAdminRequest(http.MethodGet, tc.inputResource, "")
-			assert.Equal(t, expectedContentDisposition, response.Header().Get("Content-Disposition"))
+			cdHeader := response.Header().Get("Content-Disposition")
+			assert.Truef(t, strings.HasPrefix(cdHeader, expectedContentDispositionPrefix), "Expected header prefix: %q but got %q", expectedContentDispositionPrefix, cdHeader)
 			assert.Equal(t, "application/octet-stream", response.Header().Get("Content-Type"))
 			assert.Equal(t, "nosniff", response.Header().Get("X-Content-Type-Options"))
 			assertStatus(t, response, http.StatusOK)
 
 			response = rt.SendAdminRequest(http.MethodPost, tc.inputResource, "")
-			assert.Equal(t, expectedContentDisposition, response.Header().Get("Content-Disposition"))
+			cdHeader = response.Header().Get("Content-Disposition")
+			assert.Truef(t, strings.HasPrefix(cdHeader, expectedContentDispositionPrefix), "Expected header prefix: %q but got %q", expectedContentDispositionPrefix, cdHeader)
 			assert.Equal(t, "application/octet-stream", response.Header().Get("Content-Type"))
 			assert.Equal(t, "nosniff", response.Header().Get("X-Content-Type-Options"))
 			assertStatus(t, response, http.StatusOK)

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
-	"golang.org/x/net/websocket"
 )
 
 // HTTP handler for incoming BLIP sync WebSocket request (/db/_blipsync)
@@ -51,16 +50,17 @@ func (h *handler) handleBLIPSync() error {
 
 	// Create a BLIP WebSocket handler and have it handle the request:
 	server := blipContext.WebSocketServer()
-	defaultHandler := server.Handler
-	server.Handler = func(conn *websocket.Conn) {
-		h.logStatus(http.StatusSwitchingProtocols, fmt.Sprintf("[%s] Upgraded to BLIP+WebSocket protocol%s", blipContext.ID, h.formattedEffectiveUserName()))
-		defer func() {
-			_ = conn.Close() // in case it wasn't closed already
-			base.InfofCtx(h.db.Ctx, base.KeyHTTP, "%s:    --> BLIP+WebSocket connection closed", h.formatSerialNumber())
-		}()
-		defaultHandler(conn)
+
+	middleware := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				h.logStatus(http.StatusSwitchingProtocols, fmt.Sprintf("[%s] Upgraded to WebSocket protocol %s+%s%s", blipContext.ID, blip.WebSocketSubProtocolPrefix, blipContext.ActiveSubprotocol(), h.formattedEffectiveUserName()))
+				defer base.InfofCtx(h.db.Ctx, base.KeyHTTP, "%s:    --> BLIP+WebSocket connection closed", h.formatSerialNumber())
+				next.ServeHTTP(w, r)
+			})
 	}
 
-	server.ServeHTTP(h.response, h.rq)
+	middleware(server).ServeHTTP(h.response, h.rq)
+
 	return nil
 }

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -29,7 +29,10 @@ func (h *handler) handleBLIPSync() error {
 	}
 
 	// Create a BLIP context:
-	blipContext := db.NewSGBlipContext(h.db.Ctx, "")
+	blipContext, err := db.NewSGBlipContext(h.db.Ctx, "")
+	if err != nil {
+		return err
+	}
 
 	// Overwrite the existing logging context with the blip context ID
 	h.db.Ctx = context.WithValue(h.db.Ctx, base.LogContextKey{},

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -806,7 +806,10 @@ func NewBlipTesterFromSpec(tb testing.TB, spec BlipTesterSpec) (*BlipTester, err
 	u.Scheme = "ws"
 
 	// Make BLIP/Websocket connection
-	bt.blipContext = db.NewSGBlipContext(context.Background(), "")
+	bt.blipContext, err = db.NewSGBlipContext(context.Background(), "")
+	if err != nil {
+		return nil, err
+	}
 
 	origin := "http://localhost" // TODO: what should be used here?
 
@@ -902,12 +905,12 @@ func (bt *BlipTester) SendRev(docId, docRev string, body []byte, properties blip
 //
 // - Call subChanges (continuous=false) endpoint to get all changes from Sync Gateway
 // - Respond to each "change" request telling the other side to send the revision
-//		- NOTE: this could be made more efficient by only requesting the revision for the docid/revid pair
-//              passed in the parameter.
+//   - NOTE: this could be made more efficient by only requesting the revision for the docid/revid pair
+//     passed in the parameter.
+//
 // - If the rev handler is called back with the desired docid/revid pair, save that into a variable that will be returned
 // - Block until all pending operations are complete
 // - Return the resultDoc or an empty resultDoc
-//
 func (bt *BlipTester) GetDocAtRev(requestedDocID, requestedDocRev string) (resultDoc RestDocument, err error) {
 
 	docs := map[string]RestDocument{}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -24,7 +24,7 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/websocket"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // Testing utilities that have been included in the rest package so that they
@@ -811,20 +811,17 @@ func NewBlipTesterFromSpec(tb testing.TB, spec BlipTesterSpec) (*BlipTester, err
 		return nil, err
 	}
 
-	origin := "http://localhost" // TODO: what should be used here?
-
-	config, err := websocket.NewConfig(u.String(), origin)
-	if err != nil {
-		return nil, err
+	config := blip.DialOptions{
+		URL: u.String(),
 	}
 
 	if len(spec.connectingUsername) > 0 {
-		config.Header = http.Header{
+		config.HTTPHeader = http.Header{
 			"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte(spec.connectingUsername+":"+spec.connectingPassword))},
 		}
 	}
 
-	bt.sender, err = bt.blipContext.DialConfig(config)
+	bt.sender, err = bt.blipContext.DialConfig(&config)
 	if err != nil {
 		return nil, err
 	}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -24,7 +24,6 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/bcrypt"
 )
 
 // Testing utilities that have been included in the rest package so that they


### PR DESCRIPTION
CBG-2611
First I upgraded Go-Blip to the most recent commit needed for upgrade go-blip for 2.8.4 tickets. -> [CBG-2609](https://issues.couchbase.com/browse/CBG-2609)
Next added the compress and web socket dependencies that were needed for this back-port ticket. Also added the cherry pick code for the associated back-port ticket. -> [CBG-2607](https://issues.couchbase.com/browse/CBG-2607)

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
