### PR TITLE
CBG-2679 use 3.0 metadata version information for cbgt

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -334,7 +334,7 @@ func initCBGTManager(ctx context.Context, bucket Bucket, spec BucketSpec, cfgSG 
 
 	// Creates a new cbgt manager.
 	mgr := cbgt.NewManagerEx(
-		cbgt.VERSION, // cbgt metadata version
+		SGCbgtMetadataVersion, // cbgt metadata version, matching 3.0 clients
 		cfgSG,
 		uuid,
 		tags,

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -337,7 +337,7 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 	options[cbgt.FeedAllotmentOption] = cbgt.FeedAllotmentOnePerPIndex
 	options["managerLoadDataDir"] = "false"
 	testManager := cbgt.NewManagerEx(
-		cbgt.VERSION,
+		SGCbgtMetadataVersion,
 		cbgt.NewCfgMem(),
 		testUUID,
 		nil,

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -20,6 +20,8 @@ import (
 	sgbucket "github.com/couchbase/sg-bucket"
 )
 
+const SGCbgtMetadataVersion = "5.5.0" // cbgt metadata version, matching 3.0 clients
+
 // CfgSG is used to manage shared information between Sync Gateway nodes.
 // It implements cbgt.Cfg for use with cbgt, but can be used for to manage
 // any shared data.  It uses Sync Gateway's existing
@@ -53,6 +55,7 @@ func NewCfgSG(datastore sgbucket.DataStore, groupID string) (*CfgSG, error) {
 		subscriptions: make(map[string][]chan<- cbgt.CfgEvent),
 		keyPrefix:     SGCfgPrefixWithGroupID(groupID),
 	}
+
 	return c, nil
 }
 
@@ -62,6 +65,10 @@ func (c *CfgSG) sgCfgBucketKey(cfgKey string) string {
 
 func (c *CfgSG) Get(cfgKey string, cas uint64) (
 	[]byte, uint64, error) {
+
+	if cfgKey == cbgt.VERSION_KEY {
+		return []byte(SGCbgtMetadataVersion), cas, nil
+	}
 
 	DebugfCtx(c.loggingCtx, KeyCluster, "cfg_sg: Get, key: %s, cas: %d", cfgKey, cas)
 	bucketKey := c.sgCfgBucketKey(cfgKey)


### PR DESCRIPTION
We can use 5.5.0 as metadata storage to match and not cause downgrade problems from helium -> 3.0. 

The version changes to the current version of cbgt metadata latest version are compressed metadata, and information for hibernation/suspend, neither of which are needed. The version of cbgt can read/write 5.5.0 fine.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1432/
