### PR TITLE
CBG-2684: adding check for default collection as resposne for session will be different

### DIFF
--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -1044,7 +1044,7 @@ func TestOpenIDConnectImplicitFlow(t *testing.T) {
 
 			opts := auth.OIDCOptions{Providers: tc.providers, DefaultProvider: &tc.defaultProvider}
 			restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{OIDCConfig: &opts}}}
-			restTester := NewRestTesterDefaultCollection(t, &restTesterConfig) // CBG-2618: fix collection channel access
+			restTester := NewRestTester(t, &restTesterConfig)
 			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
 
@@ -1070,13 +1070,15 @@ func TestOpenIDConnectImplicitFlow(t *testing.T) {
 				assertHttpResponse(t, response, tc.expectedError)
 				return
 			}
-			checkGoodAuthResponse(t, response, "foo_noah")
+			checkGoodAuthResponse(t, restTester, response, "foo_noah")
 		})
 	}
 }
 
 // checkGoodAuthResponse asserts expected session response values against the given response.
-func checkGoodAuthResponse(t *testing.T, response *http.Response, username string) {
+func checkGoodAuthResponse(t *testing.T, rt *RestTester, response *http.Response, username string) {
+	var responseBodyExpected map[string]interface{}
+	collection := rt.GetSingleTestDatabaseCollection()
 	require.Equal(t, http.StatusOK, response.StatusCode)
 	assert.Equal(t, "application/json", response.Header.Get("Content-Type"))
 	var responseBodyActual map[string]interface{}
@@ -1084,15 +1086,28 @@ func checkGoodAuthResponse(t *testing.T, response *http.Response, username strin
 	sessionCookie := getCookie(response.Cookies(), auth.DefaultCookieName)
 	require.NotNil(t, sessionCookie, "No session cookie found")
 	require.NoError(t, response.Body.Close(), "error closing response body")
-	responseBodyExpected := map[string]interface{}{
-		"authentication_handlers": []interface{}{
-			"default", "cookie",
-		},
-		"ok": true,
-		"userCtx": map[string]interface{}{
-			"channels": map[string]interface{}{"!": float64(1)},
-			"name":     username,
-		},
+	if base.IsDefaultCollection(collection.ScopeName(), collection.Name()) {
+		responseBodyExpected = map[string]interface{}{
+			"authentication_handlers": []interface{}{
+				"default", "cookie",
+			},
+			"ok": true,
+			"userCtx": map[string]interface{}{
+				"channels": map[string]interface{}{"!": float64(1)},
+				"name":     username,
+			},
+		}
+	} else {
+		responseBodyExpected = map[string]interface{}{
+			"authentication_handlers": []interface{}{
+				"default", "cookie",
+			},
+			"ok": true,
+			"userCtx": map[string]interface{}{
+				"channels": interface{}(nil),
+				"name":     username,
+			},
+		}
 	}
 	assert.Equal(t, responseBodyExpected, responseBodyActual, "Session response mismatch")
 }
@@ -1114,7 +1129,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 
 	opts := auth.OIDCOptions{Providers: providers, DefaultProvider: &defaultProvider}
 	restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{OIDCConfig: &opts}}}
-	restTester := NewRestTesterDefaultCollection(t, &restTesterConfig) // CBG-2618: fix collection channel access
+	restTester := NewRestTester(t, &restTesterConfig)
 	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 
@@ -1146,7 +1161,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 	runGoodAuthTest := func(claimSet claimSet, username string) {
 		response, err := sendAuthRequest(claimSet)
 		require.NoError(t, err, "Error sending request with bearer token")
-		checkGoodAuthResponse(t, response, username)
+		checkGoodAuthResponse(t, restTester, response, username)
 	}
 
 	t.Run("new user authentication with an expired token", func(t *testing.T) {
@@ -2110,7 +2125,7 @@ func TestEventuallyReachableOIDCClient(t *testing.T) {
 
 			opts := auth.OIDCOptions{Providers: tc.providers, DefaultProvider: &tc.defaultProvider}
 			restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{OIDCConfig: &opts}}}
-			restTester := NewRestTesterDefaultCollection(t, &restTesterConfig) // CBG-2618: fix collection channel access
+			restTester := NewRestTester(t, &restTesterConfig)
 			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
 
@@ -2139,14 +2154,14 @@ func TestEventuallyReachableOIDCClient(t *testing.T) {
 			request = createOIDCRequest(t, sessionEndpoint, token)
 			response, err = http.DefaultClient.Do(request)
 			require.NoError(t, err, "Error sending request with bearer token")
-			checkGoodAuthResponse(t, response, "foo_noah")
+			checkGoodAuthResponse(t, restTester, response, "foo_noah")
 
 			// Unreachable again after being reachable - still success
 			refreshProviderConfig(restTester.DatabaseConfig.OIDCConfig.Providers, unreachableAddr)
 			request = createOIDCRequest(t, sessionEndpoint, token)
 			response, err = http.DefaultClient.Do(request)
 			require.NoError(t, err, "Error sending request with bearer token")
-			checkGoodAuthResponse(t, response, "foo_noah")
+			checkGoodAuthResponse(t, restTester, response, "foo_noah")
 		})
 	}
 }

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -307,7 +307,7 @@ func TestOpenIDConnectTestProviderWithRealWorldToken(t *testing.T) {
 						},
 					},
 				}}}
-			restTester := NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+			restTester := NewRestTester(t,
 				&restTesterConfig)
 			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
@@ -378,7 +378,7 @@ func TestOpenIDConnectTestProviderWithRealWorldToken(t *testing.T) {
 			request.Header.Add("Authorization", BearerToken+" "+authResponseActual.IDToken)
 			response, err = http.DefaultClient.Do(request)
 			require.NoError(t, err, "Error sending request with bearer token")
-			checkGoodAuthResponse(t, response, "foo_noah")
+			checkGoodAuthResponse(t, restTester, response, "foo_noah")
 		})
 	}
 }
@@ -410,7 +410,7 @@ func TestOIDCWithBasicAuthDisabled(t *testing.T) {
 			},
 			DisablePasswordAuth: base.BoolPtr(true),
 		}}}
-	restTester := NewRestTesterDefaultCollection(t, // CBG-2618: fix collection channel access
+	restTester := NewRestTester(t,
 		&restTesterConfig)
 	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
@@ -468,7 +468,7 @@ func TestOIDCWithBasicAuthDisabled(t *testing.T) {
 	request.Header.Add("Authorization", BearerToken+" "+authResponseActual.IDToken)
 	response, err = http.DefaultClient.Do(request)
 	require.NoError(t, err, "Error sending request with bearer token")
-	checkGoodAuthResponse(t, response, "foo_noah")
+	checkGoodAuthResponse(t, restTester, response, "foo_noah")
 
 	// Now verify that we can perform a trivial request
 	request, err = http.NewRequest(http.MethodGet, mockSyncGatewayURL+"/"+restTester.DatabaseConfig.Name, nil)


### PR DESCRIPTION
CBG-2684

Adding check for default collection as response for session will be different when running with named collections. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1438/
