### PR TITLE
CBG-2654 don't leak potential information about other collections

### DIFF
--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -51,13 +51,6 @@ func TestCollectionsPutDocInKeyspace(t *testing.T) {
 		keyspace       string
 		expectedStatus int
 	}{
-		// if a single scope and collection is defined, use that implicitly
-		/*{
-			name:           "implicit scope and collection",
-			keyspace:       "db",
-			expectedStatus: http.StatusNotFound,
-		},
-		*/
 		{
 			name:           "fully qualified",
 			keyspace:       rt.GetSingleKeyspace(),

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -432,6 +432,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 
 	// Collection keyspace handling
 	if ks != "" {
+		ksNotFound := base.HTTPErrorf(http.StatusNotFound, "keyspace %s not found", ks)
 		if dbContext.Scopes != nil {
 			// If scopes are defined on the database but not in th an empty scope to refer to the one SG is running with, rather than falling back to _default
 			if keyspaceScope == nil {
@@ -446,7 +447,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 			}
 			scope, foundScope := dbContext.Scopes[*keyspaceScope]
 			if !foundScope {
-				return base.HTTPErrorf(http.StatusNotFound, "keyspace %q not found", ks)
+				return ksNotFound
 			}
 
 			if keyspaceCollection == nil {
@@ -457,12 +458,12 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 			}
 			_, foundCollection := scope.Collections[*keyspaceCollection]
 			if !foundCollection {
-				return base.HTTPErrorf(http.StatusNotFound, "keyspace %q not found", ks)
+				return ksNotFound
 			}
 		} else {
 			if keyspaceScope != nil && *keyspaceScope != base.DefaultScope || keyspaceCollection != nil && *keyspaceCollection != base.DefaultCollection {
 				// request tried specifying a named collection on a non-named collections database
-				return base.HTTPErrorf(http.StatusNotFound, "keyspace %q not found", ks)
+				return ksNotFound
 			}
 			// Set these for handlers that expect a scope/collection to be set, even if not using named collections.
 			keyspaceScope = base.StringPtr(base.DefaultScope)

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -452,7 +452,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 
 			if keyspaceCollection == nil {
 				if len(scope.Collections) > 1 {
-					return base.HTTPErrorf(http.StatusNotFound, "keyspace %q not found", ks)
+					return ksNotFound
 				}
 				keyspaceCollection = base.StringPtr(base.DefaultCollection)
 			}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -441,29 +441,28 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 					}
 
 				} else {
-					return base.HTTPErrorf(http.StatusBadRequest, "Ambiguous keyspace: %s.%s", base.MD(keyspaceDb), base.MD(base.StringDefault(keyspaceScope, "")))
+					keyspaceScope = base.StringPtr(base.DefaultScope)
 				}
 			}
 			scope, foundScope := dbContext.Scopes[*keyspaceScope]
 			if !foundScope {
-				return base.HTTPErrorf(http.StatusNotFound, "keyspace %s.%s.%s not found", base.MD(keyspaceDb), base.MD(base.StringDefault(keyspaceScope, "")), base.MD(base.StringDefault(keyspaceCollection, "")))
+				return base.HTTPErrorf(http.StatusNotFound, "keyspace %q not found", ks)
 			}
 
 			if keyspaceCollection == nil {
 				if len(scope.Collections) > 1 {
-					// _default doesn't exist for a non-default scope - so make it a required element if it's ambiguous
-					return base.HTTPErrorf(http.StatusBadRequest, "Ambiguous keyspace: %s.%s", base.MD(keyspaceDb), base.MD(base.StringDefault(keyspaceScope, "")))
+					return base.HTTPErrorf(http.StatusNotFound, "keyspace %q not found", ks)
 				}
 				keyspaceCollection = base.StringPtr(base.DefaultCollection)
 			}
 			_, foundCollection := scope.Collections[*keyspaceCollection]
 			if !foundCollection {
-				return base.HTTPErrorf(http.StatusNotFound, "keyspace %s.%s.%s not found", base.MD(keyspaceDb), base.MD(base.StringDefault(keyspaceScope, "")), base.MD(base.StringDefault(keyspaceCollection, "")))
+				return base.HTTPErrorf(http.StatusNotFound, "keyspace %q not found", ks)
 			}
 		} else {
 			if keyspaceScope != nil && *keyspaceScope != base.DefaultScope || keyspaceCollection != nil && *keyspaceCollection != base.DefaultCollection {
 				// request tried specifying a named collection on a non-named collections database
-				return base.HTTPErrorf(http.StatusNotFound, "keyspace %s.%s.%s not found", base.MD(keyspaceDb), base.MD(base.StringDefault(keyspaceScope, "")), base.MD(base.StringDefault(keyspaceCollection, "")))
+				return base.HTTPErrorf(http.StatusNotFound, "keyspace %q not found", ks)
 			}
 			// Set these for handlers that expect a scope/collection to be set, even if not using named collections.
 			keyspaceScope = base.StringPtr(base.DefaultScope)


### PR DESCRIPTION
Always return the fact that the keyspace exists, and not information about how many scopes or collections might be configured.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1440/ (one test failed but tested it manually and it passed)
