### PR TITLE
Recognize a leaky bucket and pass to server

### DIFF
--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -310,7 +310,8 @@ func (rt *RestTester) Bucket() base.Bucket {
 			rt.DatabaseConfig.ImportPartitions = base.Uint16Ptr(1)
 		}
 
-		if rt.leakyBucketConfig != nil {
+		_, isLeaky := base.AsLeakyBucket(rt.TestBucket)
+		if rt.leakyBucketConfig != nil || isLeaky {
 			_, err = rt.RestTesterServerContext.AddDatabaseFromConfigWithBucket(ctx, rt.TB, *rt.DatabaseConfig, testBucket.Bucket)
 		} else {
 			_, err = rt.RestTesterServerContext.AddDatabaseFromConfig(ctx, *rt.DatabaseConfig)


### PR DESCRIPTION
I think this got brushed over in a refactor somewhere and helps @mohammed-madi run a test successfully, so if you pass a `NoCloneClose()` bucket, calling `Database.Close()` won't close the bucket that is passed in.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1443/
