### PR TITLE
Mark this test as requiring xattrs

### DIFF
--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -206,6 +206,9 @@ func TestPostUpgradeMultipleCollections(t *testing.T) {
 	if base.TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
+	if !base.TestUseXattrs() {
+		t.Skip("For simplicity of the test, run with xattrs=true as the likely upgrade case of multiple collections")
+	}
 
 	tb := base.GetTestBucket(t)
 	defer tb.Close()


### PR DESCRIPTION
We could make it work with or without xattrs as in `TestPostUpgradeIndexesSimple`, but that tests covers this case while this covers this case anyway.