### PR TITLE
CBG-2066: updated master 2.8 dependencies in manifest 

### DIFF
--- a/manifest/2.8.xml
+++ b/manifest/2.8.xml
@@ -75,7 +75,7 @@ licenses/APL2.txt.
 
     <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
 
-    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.3.7"/>
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.6.0"/>
 
     <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
 

--- a/manifest/2.8.xml
+++ b/manifest/2.8.xml
@@ -75,7 +75,7 @@ licenses/APL2.txt.
 
     <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
 
-    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.3.7"/>
 
     <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
@@ -158,6 +158,6 @@ licenses/APL2.txt.
     <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="1ecb1f411c1f2ce65a2db6ea4a8ae927182d342e"/>
 
     <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
-    <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="a1a9cfc821f00faf2f5231beaa96244344d50391"/>
+    <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="b8a3c6140400c11b62877a800d0aa3ee755e89ea"/>
 
 </manifest>

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -317,7 +317,7 @@
             "release_name": "Couchbase Sync Gateway 2.8.4",
             "production": true,
             "interval": 120,
-            "go_version": "1.13.4",
+            "go_version": "1.19.5",
             "trigger_blackduck": true,
             "start_build": 1
         },


### PR DESCRIPTION
CBG-2066

Update master 2.8 manifest for dependencies:
- upgrading text -> CBG-2066
- upgrading compress -> [CBG-1712](https://issues.couchbase.com/browse/CBG-1712)
- upgrading go version 

This needs merging before [CBG-2698](https://github.com/couchbase/sync_gateway/pull/6050)

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
