### PR TITLE
CBG-2671: upgrade go version for 3.0.5 build

### DIFF
--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -385,7 +385,7 @@
             "release_name": "Couchbase Sync Gateway 3.0.5",
             "production": true,
             "interval": 120,
-            "go_version": "1.16.6",
+            "go_version": "1.19.5",
             "trigger_blackduck": true,
             "start_build": 1
         },


### PR DESCRIPTION
CBG-2671

Small change to update the go version used for 3.0.5 build.

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
