### PR TITLE
CBG-2498 Remove TimedSetByCollection to remove complexity/restore channel redaction

### DIFF
--- a/auth/collection_access.go
+++ b/auth/collection_access.go
@@ -88,7 +88,7 @@ type UserCollectionChannelAPI interface {
 	// to for the collection, annotated with the sequence number at which access was granted.
 	// Returns a string array containing any channels filtered out due to the user not having access
 	// to them.
-	FilterToAvailableCollectionChannels(scope, collection string, channels ch.Set) (filtered ch.TimedSet, removed []string)
+	FilterToAvailableCollectionChannels(scope, collection string, channels base.Set) (filtered ch.TimedSet, removed []string)
 
 	// If the input set contains the wildcard "*" channel, returns the user's inheritedChannels for the collection;
 	// else returns the input channel list unaltered.

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -135,7 +135,7 @@ type User interface {
 	// to, annotated with the sequence number at which access was granted.
 	// Returns a string array containing any channels filtered out due to the user not having access
 	// to them.
-	filterToAvailableChannels(channels ch.Set) (filtered ch.TimedSet, removed []string)
+	filterToAvailableChannels(channels base.Set) (filtered ch.TimedSet, removed []string)
 
 	setRolesSince(ch.TimedSet)
 

--- a/auth/user.go
+++ b/auth/user.go
@@ -630,19 +630,19 @@ func (user *userImpl) expandCollectionWildCardChannel(scope, collection string, 
 	return channels
 }
 
-func (user *userImpl) filterToAvailableChannels(channels ch.Set) (filtered ch.TimedSet, removed []string) {
-	return user.FilterToAvailableCollectionChannels(base.DefaultScope, base.DefaultCollection, channels)
+func (user *userImpl) filterToAvailableChannels(channelNames base.Set) (filtered ch.TimedSet, removed []string) {
+	return user.FilterToAvailableCollectionChannels(base.DefaultScope, base.DefaultCollection, channelNames)
 }
 
-func (user *userImpl) FilterToAvailableCollectionChannels(scope, collection string, channels ch.Set) (filtered ch.TimedSet, removed []string) {
+func (user *userImpl) FilterToAvailableCollectionChannels(scope, collection string, channelNames base.Set) (filtered ch.TimedSet, removed []string) {
 	filtered = ch.TimedSet{}
-	for channel := range channels {
-		if channel.Name == ch.AllChannelWildcard {
+	for channelName, _ := range channelNames {
+		if channelName == ch.AllChannelWildcard {
 			return user.InheritedCollectionChannels(scope, collection).Copy(), nil
 		}
-		added := filtered.AddChannel(channel.Name, user.canSeeCollectionChannelSince(scope, collection, channel.Name))
+		added := filtered.AddChannel(channelName, user.canSeeCollectionChannelSince(scope, collection, channelName))
 		if !added {
-			removed = append(removed, channel.Name)
+			removed = append(removed, channelName)
 		}
 	}
 	return filtered, removed

--- a/channels/active_channels.go
+++ b/channels/active_channels.go
@@ -42,13 +42,13 @@ func NewActiveChannels(activeChannelCountStat *base.SgwIntStat) *ActiveChannels 
 
 // Update changed increments/decrements active channel counts based on a set of changed channels.  Triggered
 // when the set of channels being replicated by a given replication changes.
-func (ac *ActiveChannels) UpdateChanged(changedChannels ChangedChannels) {
+func (ac *ActiveChannels) UpdateChanged(collectionID uint32, changedChannels ChangedKeys) {
 	ac.lock.Lock()
-	for channel, isIncrement := range changedChannels {
+	for channelName, isIncrement := range changedChannels {
 		if isIncrement {
-			ac._incr(channel)
+			ac._incr(NewID(channelName, collectionID))
 		} else {
-			ac._decr(channel)
+			ac._decr(NewID(channelName, collectionID))
 		}
 	}
 
@@ -56,23 +56,19 @@ func (ac *ActiveChannels) UpdateChanged(changedChannels ChangedChannels) {
 }
 
 // Active channel counts track channels being replicated by an active changes request.
-func (ac *ActiveChannels) IncrChannels(timedSetByCollection TimedSetByCollectionID) {
+func (ac *ActiveChannels) IncrChannels(collectionID uint32, timedSet TimedSet) {
 	ac.lock.Lock()
 	defer ac.lock.Unlock()
-	for collectionID, timedSetByChannel := range timedSetByCollection {
-		for channelName, _ := range timedSetByChannel {
-			ac._incr(NewID(channelName, collectionID))
-		}
+	for channelName, _ := range timedSet {
+		ac._incr(NewID(channelName, collectionID))
 	}
 }
 
-func (ac *ActiveChannels) DecrChannels(timedSetByCollection TimedSetByCollectionID) {
+func (ac *ActiveChannels) DecrChannels(collectionID uint32, timedSet TimedSet) {
 	ac.lock.Lock()
 	defer ac.lock.Unlock()
-	for collectionID, timedSetByChannel := range timedSetByCollection {
-		for channelName, _ := range timedSetByChannel {
-			ac._decr(NewID(channelName, collectionID))
-		}
+	for channelName, _ := range timedSet {
+		ac._decr(NewID(channelName, collectionID))
 	}
 }
 

--- a/channels/active_channels_test.go
+++ b/channels/active_channels_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestActiveChannelsConcurrency(t *testing.T) {
@@ -35,15 +34,13 @@ func TestActiveChannelsConcurrency(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			const seqNo uint64 = 0
-			activeChans, err := SetOf(ABCChan, DEFChan, GHIChan, JKLChan, MNOChan)
-			require.NoError(t, err)
-			activeChansTimedSet := AtSequenceByCollection(activeChans, seqNo)
-			ac.IncrChannels(activeChansTimedSet)
-			inactiveChans, err := SetOf(ABCChan, DEFChan)
-			require.NoError(t, err)
-			inactiveChansTimedSet := AtSequenceByCollection(inactiveChans, seqNo)
+			activeChans := base.SetOf(ABCChan.Name, DEFChan.Name, GHIChan.Name, JKLChan.Name, MNOChan.Name)
+			activeChansTimedSet := AtSequence(activeChans, seqNo)
+			ac.IncrChannels(base.DefaultCollectionID, activeChansTimedSet)
+			inactiveChans := base.SetOf(ABCChan.Name, DEFChan.Name)
+			inactiveChansTimedSet := AtSequence(inactiveChans, seqNo)
 
-			ac.DecrChannels(inactiveChansTimedSet)
+			ac.DecrChannels(base.DefaultCollectionID, inactiveChansTimedSet)
 		}()
 	}
 	wg.Wait()
@@ -59,10 +56,10 @@ func TestActiveChannelsConcurrency(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			changedKeys := ChangedChannels{ABCChan: true, DEFChan: true, GHIChan: false, MNOChan: true}
-			ac.UpdateChanged(changedKeys)
-			changedKeys = ChangedChannels{DEFChan: false}
-			ac.UpdateChanged(changedKeys)
+			changedKeys := ChangedKeys{"ABC": true, "DEF": true, "GHI": false, "MNO": true}
+			ac.UpdateChanged(base.DefaultCollectionID, changedKeys)
+			changedKeys = ChangedKeys{"DEF": false}
+			ac.UpdateChanged(base.DefaultCollectionID, changedKeys)
 		}()
 	}
 	wg.Wait()

--- a/channels/set.go
+++ b/channels/set.go
@@ -120,15 +120,6 @@ func SetOfNoValidate(chans ...ID) Set {
 	return SetFromArrayNoValidate(chans)
 }
 
-// SetOfFromSingleCollection creates a new Set from series of strings
-func SetOfFromSingleCollection(chans []string, collectionID uint32) Set {
-	result := make(Set, len(chans))
-	for _, chanName := range chans {
-		result[NewID(chanName, collectionID)] = present{}
-	}
-	return result
-}
-
 // Update adds all elements from other set and returns the union of the sets.
 func (s Set) Update(other Set) Set {
 	if len(s) == 0 {

--- a/channels/set_test.go
+++ b/channels/set_test.go
@@ -110,65 +110,6 @@ func TestSetFromArrayNoValidate(t *testing.T) {
 	}
 }
 
-func TestSetFromSingleCollection(t *testing.T) {
-	testCases := []struct {
-		name         string
-		input        []string
-		collectionID uint32
-		output       Set
-	}{
-		{
-			name:         "singleChannel0",
-			input:        []string{"A"},
-			collectionID: 0,
-			output: Set{
-				NewID("A", 0): present{},
-			},
-		},
-
-		{
-			name:         "singleChannel1",
-			input:        []string{"A"},
-			collectionID: 1,
-			output: Set{
-				NewID("A", 1): present{},
-			},
-		},
-		{
-			name:         "multiChannel0",
-			input:        []string{"A", "B"},
-			collectionID: 0,
-			output: Set{
-				NewID("A", 0): present{},
-				NewID("B", 0): present{},
-			},
-		},
-
-		{
-			name:         "multiChannel1",
-			input:        []string{"A", "B"},
-			collectionID: 1,
-			output: Set{
-				NewID("A", 1): present{},
-				NewID("B", 1): present{},
-			},
-		},
-		{
-			name:         "illegalChannel",
-			input:        []string{","},
-			collectionID: 1,
-			output: Set{
-				NewID(",", 1): present{},
-			},
-		},
-	}
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			require.Equal(t, test.output, SetOfFromSingleCollection(test.input, test.collectionID))
-		})
-	}
-}
-
 func TestSetUpdate(t *testing.T) {
 	testCases := []struct {
 		name        string

--- a/channels/timed_set.go
+++ b/channels/timed_set.go
@@ -390,21 +390,3 @@ func TimedSetFromString(encoded string) TimedSet {
 	}
 	return set
 }
-
-// TimedSetByCollectionID is a map of kv collectionIDs to TimedSets
-type TimedSetByCollectionID map[uint32]TimedSet
-
-// AtSequenceByCollection creates a map of collectionID to a map of channel IDs to sequences.
-func AtSequenceByCollection(chans Set, sequence uint64) TimedSetByCollectionID {
-	collectionByTimedSet := TimedSetByCollectionID{}
-	for ch := range chans {
-		val, exists := collectionByTimedSet[ch.CollectionID]
-		if !exists {
-			val = make(TimedSet)
-		}
-		val[ch.Name] = NewVbSimpleSequence(sequence)
-		collectionByTimedSet[ch.CollectionID] = val
-
-	}
-	return collectionByTimedSet
-}

--- a/channels/timed_set_test.go
+++ b/channels/timed_set_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestTimedSetMarshal(t *testing.T) {
@@ -168,19 +167,4 @@ func TestTimedSetCompareKeys(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestTimedSetByCollectionID(t *testing.T) {
-	chans, err := SetOf(
-		NewID("A", 2),
-		NewID("B", 2),
-		NewID("B", 1),
-		NewID("C", 1),
-	)
-	require.NoError(t, err)
-	collectionByTimedSet := AtSequenceByCollection(chans, 42)
-	require.Equal(t, TimedSetByCollectionID{
-		1: TimedSetFromString("B:42,C:42"),
-		2: TimedSetFromString("A:42,B:42"),
-	}, collectionByTimedSet)
 }

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -404,14 +404,12 @@ func (waiter *ChangeWaiter) RefreshUserCount() bool {
 }
 
 // Updates the set of channel keys in the ChangeWaiter (maintains the existing set of user keys)
-func (waiter *ChangeWaiter) UpdateChannels(timedSetByCollectionID channels.TimedSetByCollectionID) {
+func (waiter *ChangeWaiter) UpdateChannels(collectionID uint32, timedSet channels.TimedSet) {
 	// This capacity is not right can not accomodate channels without iteration.
 	initialCapacity := len(waiter.userKeys)
 	updatedKeys := make([]string, 0, initialCapacity)
-	for collectionID, timedSetByChannel := range timedSetByCollectionID {
-		for channelName, _ := range timedSetByChannel {
-			updatedKeys = append(updatedKeys, channels.NewID(channelName, collectionID).String())
-		}
+	for channelName, _ := range timedSet {
+		updatedKeys = append(updatedKeys, channels.NewID(channelName, collectionID).String())
 	}
 	if len(waiter.userKeys) > 0 {
 		updatedKeys = append(updatedKeys, waiter.userKeys...)

--- a/db/changes.go
+++ b/db/changes.go
@@ -543,7 +543,7 @@ func (db *DatabaseCollectionWithUser) MultiChangesFeed(ctx context.Context, chan
 
 	base.DebugfCtx(ctx, base.KeyChanges, "Int sequence multi changes feed...")
 
-	return db.SimpleMultiChangesFeed(ctx, channels.SetOfFromSingleCollection(chans.ToArray(), db.GetCollectionID()), options)
+	return db.SimpleMultiChangesFeed(ctx, chans, options)
 
 }
 
@@ -572,38 +572,32 @@ func (db *DatabaseCollectionWithUser) appendUserFeed(feeds []<-chan *ChangeEntry
 	return feeds
 }
 
-func (db *DatabaseCollectionWithUser) checkForUserUpdates(ctx context.Context, userChangeCount uint64, changeWaiter *ChangeWaiter, isContinuous bool) (isChanged bool, newCount uint64, changedChannels channels.ChangedChannels, err error) {
+func (col *DatabaseCollectionWithUser) checkForUserUpdates(ctx context.Context, userChangeCount uint64, changeWaiter *ChangeWaiter, isContinuous bool) (isChanged bool, newCount uint64, changedChannels channels.ChangedKeys, err error) {
 
 	newCount = changeWaiter.CurrentUserCount()
 	// If not continuous, we force user reload as a workaround for https://github.com/couchbase/sync_gateway/issues/2068.  For continuous, #2068 is handled by changedChannels check, and
 	// we can reload only when there's been a user change notification
 	if newCount > userChangeCount || !isContinuous {
-		changedChannels := channels.ChangedChannels{}
 		var previousChannels channels.TimedSet
-		base.DebugfCtx(ctx, base.KeyChanges, "MultiChangesFeed reloading user %+v", base.UD(db.user))
+		base.DebugfCtx(ctx, base.KeyChanges, "MultiChangesFeed reloading user %+v", base.UD(col.user))
 		userChangeCount = newCount
 
-		if db.user != nil {
-			previousChannels = db.user.InheritedCollectionChannels(db.ScopeName(), db.Name())
-			previousRoles := db.user.RoleNames()
-			if err := db.ReloadUser(ctx); err != nil {
-				base.WarnfCtx(ctx, "Error reloading user %q: %v", base.UD(db.user.Name()), err)
+		if col.user != nil {
+			previousChannels = col.user.InheritedCollectionChannels(col.ScopeName(), col.Name())
+			previousRoles := col.user.RoleNames()
+			if err := col.ReloadUser(ctx); err != nil {
+				base.WarnfCtx(ctx, "Error reloading user %q: %v", base.UD(col.user.Name()), err)
 				return false, 0, nil, err
 			}
 			// check whether channel set has changed
-			singleCollectionChannels := db.user.InheritedCollectionChannels(db.ScopeName(), db.Name()).CompareKeys(previousChannels)
-			collectionID := db.GetCollectionID()
-
-			for channelName, changed := range singleCollectionChannels {
-				changedChannels[channels.NewID(channelName, collectionID)] = changed
-			}
+			changedChannels = col.user.InheritedCollectionChannels(col.ScopeName(), col.Name()).CompareKeys(previousChannels)
 			if len(changedChannels) > 0 {
 				base.DebugfCtx(ctx, base.KeyChanges, "Modified channel set after user reload: %v", base.UD(changedChannels))
 			}
 
-			changedRoles := db.user.RoleNames().CompareKeys(previousRoles)
+			changedRoles := col.user.RoleNames().CompareKeys(previousRoles)
 			if len(changedRoles) > 0 {
-				changeWaiter.RefreshUserKeys(db.User())
+				changeWaiter.RefreshUserKeys(col.User())
 			}
 		}
 		return true, newCount, changedChannels, nil
@@ -612,17 +606,17 @@ func (db *DatabaseCollectionWithUser) checkForUserUpdates(ctx context.Context, u
 }
 
 // Returns the (ordered) union of all of the changes made to multiple channels.
-func (db *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Context, chans channels.Set, options ChangesOptions) (<-chan *ChangeEntry, error) {
+func (col *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Context, chans base.Set, options ChangesOptions) (<-chan *ChangeEntry, error) {
 
 	to := ""
-	if db.user != nil && db.user.Name() != "" {
-		to = fmt.Sprintf("  (to %s)", db.user.Name())
+	if col.user != nil && col.user.Name() != "" {
+		to = fmt.Sprintf("  (to %s)", col.user.Name())
 	}
 
 	base.InfofCtx(ctx, base.KeyChanges, "MultiChangesFeed(channels: %s, options: %s) ... %s", base.UD(chans), options, base.UD(to))
 	output := make(chan *ChangeEntry, 50)
 
-	singleCollectionID := db.GetCollectionID()
+	collectionID := col.GetCollectionID()
 	go func() {
 
 		defer func() {
@@ -638,24 +632,24 @@ func (db *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Context
 		var lowSequence uint64
 		var currentCachedSequence uint64
 		var lateSequenceFeeds map[channels.ID]*lateSequenceFeed
-		var userCounter uint64                       // Wait counter used to identify changes to the user document
-		var changedChannels channels.ChangedChannels // Tracks channels added/removed to the user during changes processing.
-		var userChanged bool                         // Whether the user document has changed in a given iteration loop
-		var deferredBackfill bool                    // Whether there's a backfill identified in the user doc that's deferred while the SG cache catches up
+		var userCounter uint64                   // Wait counter used to identify changes to the user document
+		var changedChannels channels.ChangedKeys // Tracks channels added/removed to the user during changes processing.
+		var userChanged bool                     // Whether the user document has changed in a given iteration loop
+		var deferredBackfill bool                // Whether there's a backfill identified in the user doc that's deferred while the SG cache catches up
 
 		// Retrieve the current max cached sequence - ensures there isn't a race between the subsequent channel cache queries
-		currentCachedSequence = db.changeCache().getChannelCache().GetHighCacheSequence()
+		currentCachedSequence = col.changeCache().getChannelCache().GetHighCacheSequence()
 		if options.Wait {
 			options.Wait = false
 
-			changeWaiter = db.startChangeWaiter() // Waiter is updated with the actual channel set (post-user reload) at the start of the outer changes loop
+			changeWaiter = col.startChangeWaiter() // Waiter is updated with the actual channel set (post-user reload) at the start of the outer changes loop
 			userCounter = changeWaiter.CurrentUserCount()
 			// Reload user to pick up user changes that happened between auth and the change waiter
 			// initialization.  Without this, notification for user doc changes in that window (a) won't be
 			// included in the initial changes loop iteration, and (b) won't wake up the ChangeWaiter.
-			if db.user != nil {
-				if err := db.ReloadUser(ctx); err != nil {
-					base.WarnfCtx(ctx, "Error reloading user during changes initialization %q: %v", base.UD(db.user.Name()), err)
+			if col.user != nil {
+				if err := col.ReloadUser(ctx); err != nil {
+					base.WarnfCtx(ctx, "Error reloading user during changes initialization %q: %v", base.UD(col.user.Name()), err)
 					change := makeErrorEntry("User not found during reload - terminating changes feed")
 					output <- &change
 					return
@@ -666,26 +660,26 @@ func (db *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Context
 
 		// Restrict to available channels, expand wild-card, and find since when these channels
 		// have been available to the user:
-		channelsSince := channels.TimedSetByCollectionID{}
-		if db.user != nil {
-			chansSince, channelsRemoved := db.user.FilterToAvailableCollectionChannels(db.ScopeName(), db.Name(), chans)
+		channelsSince := channels.TimedSet{}
+		if col.user != nil {
+			var channelsRemoved []string
+			channelsSince, channelsRemoved = col.user.FilterToAvailableCollectionChannels(col.ScopeName(), col.Name(), chans)
 			if len(channelsRemoved) > 0 {
-				base.InfofCtx(ctx, base.KeyChanges, "Channels %s request without access by user %s", base.UD(channelsRemoved), base.UD(db.user.Name()))
+				base.InfofCtx(ctx, base.KeyChanges, "Channels %s request without access by user %s", base.UD(channelsRemoved), base.UD(col.user.Name()))
 			}
-			channelsSince[singleCollectionID] = chansSince
 		} else {
-			channelsSince = channels.AtSequenceByCollection(chans, 0)
+			channelsSince = channels.AtSequence(chans, 0)
 		}
 
 		// Mark channel set as active, schedule defer
-		db.activeChannels().IncrChannels(channelsSince)
-		defer db.activeChannels().DecrChannels(channelsSince)
+		col.activeChannels().IncrChannels(collectionID, channelsSince)
+		defer col.activeChannels().DecrChannels(collectionID, channelsSince)
 
 		// For a continuous feed, initialise the lateSequenceFeeds that track late-arriving sequences
 		// to the channel caches.
 		if options.Continuous {
 			lateSequenceFeeds = make(map[channels.ID]*lateSequenceFeed)
-			defer db.closeLateFeeds(lateSequenceFeeds)
+			defer col.closeLateFeeds(lateSequenceFeeds)
 		}
 
 		// Store incoming low sequence, for potential use by longpoll iterations
@@ -699,13 +693,13 @@ func (db *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Context
 		for {
 			// Updates the ChangeWaiter to the current set of available channels
 			if changeWaiter != nil {
-				changeWaiter.UpdateChannels(channelsSince)
+				changeWaiter.UpdateChannels(col.GetCollectionID(), channelsSince)
 			}
 			base.DebugfCtx(ctx, base.KeyChanges, "MultiChangesFeed: channels expand to %#v ... %s", base.UD(channelsSince), base.UD(to))
 
 			// lowSequence is used to send composite keys to clients, so that they can obtain any currently
 			// skipped sequences in a future iteration or request.
-			oldestSkipped := db.changeCache().getOldestSkippedSequence()
+			oldestSkipped := col.changeCache().getOldestSkippedSequence()
 			if oldestSkipped > 0 {
 				lowSequence = oldestSkipped - 1
 				base.InfofCtx(ctx, base.KeyChanges, "%d is the oldest skipped sequence, using stable sequence number of %d for this feed %s", oldestSkipped, lowSequence, base.UD(to))
@@ -730,125 +724,123 @@ func (db *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Context
 			// with access to both channels would see two versions on the feed.
 
 			deferredBackfill = false
-			for collectionID, chanSeq := range channelsSince {
-				for chanName, vbSeqAddedAt := range chanSeq {
-					chanOpts := options
+			for chanName, vbSeqAddedAt := range channelsSince {
+				chanOpts := options
 
-					chanID := channels.NewID(chanName, collectionID)
-					// Obtain a SingleChannelCache instance to use for both normal and late feeds.  Required to ensure consistency
-					// if cache is evicted during processing
-					singleChannelCache, err := db.changeCache().getChannelCache().getSingleChannelCache(chanID)
-					if err != nil {
-						base.WarnfCtx(ctx, "Unable to obtain channel cache for %v, terminating feed", chanID)
-						change := makeErrorEntry("Channel cache unavailable, terminating feed")
-						output <- &change
-						return
-					}
+				chanID := channels.NewID(chanName, collectionID)
+				// Obtain a SingleChannelCache instance to use for both normal and late feeds.  Required to ensure consistency
+				// if cache is evicted during processing
+				singleChannelCache, err := col.changeCache().getChannelCache().getSingleChannelCache(chanID)
+				if err != nil {
+					base.WarnfCtx(ctx, "Unable to obtain channel cache for %v, terminating feed", chanID)
+					change := makeErrorEntry("Channel cache unavailable, terminating feed")
+					output <- &change
+					return
+				}
 
-					// Set up late sequence handling first, as we need to roll back the regular feed on error
-					// Handles previously skipped sequences prior to options.Since that
-					// have arrived in the channel cache since this changes request started.  Only needed for
-					// continuous feeds - one-off changes requests only require the standard channel cache.
-					if options.Continuous {
-						lateSequenceFeedHandler := lateSequenceFeeds[chanID]
-						if lateSequenceFeedHandler != nil {
-							latefeed, err := db.getLateFeed(lateSequenceFeedHandler, singleChannelCache)
-							if err != nil {
-								base.WarnfCtx(ctx, "MultiChangesFeed got error reading late sequence feed %q, rolling back channel changes feed to last sent low sequence #%d.", base.UD(chanID.String()), lastSentLowSeq)
-								chanOpts.Since.LowSeq = lastSentLowSeq
-								if lateFeed := db.newLateSequenceFeed(singleChannelCache); lateFeed != nil {
-									lateSequenceFeeds[chanID] = lateFeed
-								}
-							} else {
-								// Mark feed as actively used in this iteration.  Used to remove lateSequenceFeeds
-								// when the user loses channel access
-								lateSequenceFeedHandler.active = true
-								feeds = append(feeds, latefeed)
-							}
-						} else {
-							// Initialize lateSequenceFeeds[name] for next iteration
-							if lateFeed := db.newLateSequenceFeed(singleChannelCache); lateFeed != nil {
+				// Set up late sequence handling first, as we need to roll back the regular feed on error
+				// Handles previously skipped sequences prior to options.Since that
+				// have arrived in the channel cache since this changes request started.  Only needed for
+				// continuous feeds - one-off changes requests only require the standard channel cache.
+				if options.Continuous {
+					lateSequenceFeedHandler := lateSequenceFeeds[chanID]
+					if lateSequenceFeedHandler != nil {
+						latefeed, err := col.getLateFeed(lateSequenceFeedHandler, singleChannelCache)
+						if err != nil {
+							base.WarnfCtx(ctx, "MultiChangesFeed got error reading late sequence feed %q, rolling back channel changes feed to last sent low sequence #%d.", base.UD(chanID.String()), lastSentLowSeq)
+							chanOpts.Since.LowSeq = lastSentLowSeq
+							if lateFeed := col.newLateSequenceFeed(singleChannelCache); lateFeed != nil {
 								lateSequenceFeeds[chanID] = lateFeed
 							}
+						} else {
+							// Mark feed as actively used in this iteration.  Used to remove lateSequenceFeeds
+							// when the user loses channel access
+							lateSequenceFeedHandler.active = true
+							feeds = append(feeds, latefeed)
+						}
+					} else {
+						// Initialize lateSequenceFeeds[name] for next iteration
+						if lateFeed := col.newLateSequenceFeed(singleChannelCache); lateFeed != nil {
+							lateSequenceFeeds[chanID] = lateFeed
+						}
+					}
+				}
+
+				seqAddedAt := vbSeqAddedAt.Sequence
+
+				// Check whether requires backfill based on changedChannels in this _changes feed
+				isNewChannel := false
+				if changedChannels != nil {
+					isNewChannel, _ = changedChannels[chanID.Name]
+				}
+
+				// Check whether requires backfill based on current sequence, seqAddedAt
+				// Triggered by handling:
+				//   1. options.Since.TriggeredBy == seqAddedAt : We're in the middle of backfill for this channel, based
+				//    on the access grant in sequence options.Since.TriggeredBy.  Normally the entire backfill would be done in one
+				//    changes feed iteration, but this can be split over multiple iterations when 'limit' is used.
+				//   2. options.Since.TriggeredBy == 0 : Not currently doing a backfill
+				//   3. options.Since.TriggeredBy != 0 and <= seqAddedAt: We're in the middle of a backfill for another channel, but the backfill for
+				//     this channel is still pending.  Initiate the backfill for this channel - will be ordered below in the usual way (iterating over all channels)
+				//   4. options.Since.TriggeredBy !=0 and options.Since.TriggeredBy > seqAddedAt: We're in the
+				//  middle of a backfill for another channel.  This should issue normal (non-backfill) changes
+				//  request with  since= options.Since.TriggeredBy for the non-backfill channel.
+
+				// Backfill required when seqAddedAt is before current sequence
+				backfillRequired := seqAddedAt > 1 && options.Since.Before(SequenceID{Seq: seqAddedAt}) && seqAddedAt <= currentCachedSequence
+				if seqAddedAt > currentCachedSequence {
+					base.DebugfCtx(ctx, base.KeyChanges, "Grant for channel [%s] is after the current sequence - skipped for this iteration.  Grant:[%d] Current:[%d] %s", base.UD(chanID.String()), seqAddedAt, currentCachedSequence, base.UD(to))
+					deferredBackfill = true
+					continue
+				}
+
+				// Ensure backfill isn't already in progress for this seqAddedAt
+				backfillPending := options.Since.TriggeredBy == 0 || options.Since.TriggeredBy < seqAddedAt
+
+				backfillInOtherChannel := options.Since.TriggeredBy != 0 && options.Since.TriggeredBy > seqAddedAt
+
+				if isNewChannel || (backfillRequired && backfillPending) {
+					// Newly added channel so initiate backfill:
+					chanOpts.Since = SequenceID{Seq: 0, TriggeredBy: seqAddedAt}
+				} else if backfillInOtherChannel {
+					chanOpts.Since = SequenceID{Seq: options.Since.TriggeredBy - 1}
+				}
+
+				feed := col.changesFeed(ctx, singleChannelCache, chanOpts, to)
+				feeds = append(feeds, feed)
+
+			}
+			// If the user object has changed, create a special pseudo-feed for it:
+			if col.user != nil {
+				feeds = col.appendUserFeed(feeds, options)
+			}
+
+			if options.Revocations && col.user != nil && !options.ActiveOnly {
+				channelsToRevoke := col.user.RevokedCollectionChannels(col.ScopeName(), col.Name(), options.Since.Seq, options.Since.LowSeq, options.Since.TriggeredBy)
+				for channel, revokedSeq := range channelsToRevoke {
+					revocationSinceSeq := options.Since.SafeSequence()
+					revokeFrom := uint64(0)
+
+					// If we have a triggeredBy sequence:
+					// If channel access was lost at the triggeredBy sequence then replication may have been interrupted
+					// so we need to roll back one sequence to re-send the values with that previous triggeredBy as we
+					// cannot be sure that they were all sent. However, we can get changes from triggeredBy rather than
+					// 0 when finding docs to revoke.
+					// If channel access was after the triggeredBy then we can just use the triggeredBy and need to
+					// check for docs to revoke since 0.
+					if options.Since.TriggeredBy != 0 {
+						if revokedSeq == options.Since.TriggeredBy {
+							revocationSinceSeq = options.Since.TriggeredBy - 1
+							revokeFrom = options.Since.Seq
+						}
+						if revokedSeq > options.Since.TriggeredBy {
+							revocationSinceSeq = options.Since.TriggeredBy
+							revokeFrom = 0
 						}
 					}
 
-					seqAddedAt := vbSeqAddedAt.Sequence
-
-					// Check whether requires backfill based on changedChannels in this _changes feed
-					isNewChannel := false
-					if changedChannels != nil {
-						isNewChannel, _ = changedChannels[chanID]
-					}
-
-					// Check whether requires backfill based on current sequence, seqAddedAt
-					// Triggered by handling:
-					//   1. options.Since.TriggeredBy == seqAddedAt : We're in the middle of backfill for this channel, based
-					//    on the access grant in sequence options.Since.TriggeredBy.  Normally the entire backfill would be done in one
-					//    changes feed iteration, but this can be split over multiple iterations when 'limit' is used.
-					//   2. options.Since.TriggeredBy == 0 : Not currently doing a backfill
-					//   3. options.Since.TriggeredBy != 0 and <= seqAddedAt: We're in the middle of a backfill for another channel, but the backfill for
-					//     this channel is still pending.  Initiate the backfill for this channel - will be ordered below in the usual way (iterating over all channels)
-					//   4. options.Since.TriggeredBy !=0 and options.Since.TriggeredBy > seqAddedAt: We're in the
-					//  middle of a backfill for another channel.  This should issue normal (non-backfill) changes
-					//  request with  since= options.Since.TriggeredBy for the non-backfill channel.
-
-					// Backfill required when seqAddedAt is before current sequence
-					backfillRequired := seqAddedAt > 1 && options.Since.Before(SequenceID{Seq: seqAddedAt}) && seqAddedAt <= currentCachedSequence
-					if seqAddedAt > currentCachedSequence {
-						base.DebugfCtx(ctx, base.KeyChanges, "Grant for channel [%s] is after the current sequence - skipped for this iteration.  Grant:[%d] Current:[%d] %s", base.UD(chanID.String()), seqAddedAt, currentCachedSequence, base.UD(to))
-						deferredBackfill = true
-						continue
-					}
-
-					// Ensure backfill isn't already in progress for this seqAddedAt
-					backfillPending := options.Since.TriggeredBy == 0 || options.Since.TriggeredBy < seqAddedAt
-
-					backfillInOtherChannel := options.Since.TriggeredBy != 0 && options.Since.TriggeredBy > seqAddedAt
-
-					if isNewChannel || (backfillRequired && backfillPending) {
-						// Newly added channel so initiate backfill:
-						chanOpts.Since = SequenceID{Seq: 0, TriggeredBy: seqAddedAt}
-					} else if backfillInOtherChannel {
-						chanOpts.Since = SequenceID{Seq: options.Since.TriggeredBy - 1}
-					}
-
-					feed := db.changesFeed(ctx, singleChannelCache, chanOpts, to)
+					feed := col.buildRevokedFeed(ctx, channels.NewID(channel, collectionID), options, revokedSeq, revocationSinceSeq, revokeFrom, to)
 					feeds = append(feeds, feed)
-
-				}
-				// If the user object has changed, create a special pseudo-feed for it:
-				if db.user != nil {
-					feeds = db.appendUserFeed(feeds, options)
-				}
-
-				if options.Revocations && db.user != nil && !options.ActiveOnly {
-					channelsToRevoke := db.user.RevokedCollectionChannels(db.ScopeName(), db.Name(), options.Since.Seq, options.Since.LowSeq, options.Since.TriggeredBy)
-					for channel, revokedSeq := range channelsToRevoke {
-						revocationSinceSeq := options.Since.SafeSequence()
-						revokeFrom := uint64(0)
-
-						// If we have a triggeredBy sequence:
-						// If channel access was lost at the triggeredBy sequence then replication may have been interrupted
-						// so we need to roll back one sequence to re-send the values with that previous triggeredBy as we
-						// cannot be sure that they were all sent. However, we can get changes from triggeredBy rather than
-						// 0 when finding docs to revoke.
-						// If channel access was after the triggeredBy then we can just use the triggeredBy and need to
-						// check for docs to revoke since 0.
-						if options.Since.TriggeredBy != 0 {
-							if revokedSeq == options.Since.TriggeredBy {
-								revocationSinceSeq = options.Since.TriggeredBy - 1
-								revokeFrom = options.Since.Seq
-							}
-							if revokedSeq > options.Since.TriggeredBy {
-								revocationSinceSeq = options.Since.TriggeredBy
-								revokeFrom = 0
-							}
-						}
-
-						feed := db.buildRevokedFeed(ctx, channels.NewID(channel, collectionID), options, revokedSeq, revocationSinceSeq, revokeFrom, to)
-						feeds = append(feeds, feed)
-					}
 				}
 			}
 
@@ -940,7 +932,7 @@ func (db *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Context
 
 				// Add the doc body or the conflicting rev IDs, if those options are set:
 				if options.IncludeDocs || options.Conflicts {
-					db.addDocToChangeEntry(ctx, minEntry, options)
+					col.addDocToChangeEntry(ctx, minEntry, options)
 				}
 
 				// Update the low sequence on the entry we're going to send
@@ -994,17 +986,17 @@ func (db *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Context
 				// visible to the user), and so ChangeWaiter.Wait() would block until the next user-visible doc arrives.  Use a hardcoded wait instead
 				// Similar handling for when we see sequences later than the stable sequence.
 				if deferredBackfill || postStableSeqsFound {
-					cancelled := db.waitForCacheUpdate(options.ChangesCtx, currentCachedSequence)
+					cancelled := col.waitForCacheUpdate(options.ChangesCtx, currentCachedSequence)
 					if cancelled {
 						return
 					}
 					break waitForChanges
 				}
 
-				db.dbStats().CBLReplicationPull().NumPullReplTotalCaughtUp.Add(1)
-				db.dbStats().CBLReplicationPull().NumPullReplCaughtUp.Add(1)
+				col.dbStats().CBLReplicationPull().NumPullReplTotalCaughtUp.Add(1)
+				col.dbStats().CBLReplicationPull().NumPullReplCaughtUp.Add(1)
 				waitResponse := changeWaiter.Wait()
-				db.dbStats().CBLReplicationPull().NumPullReplCaughtUp.Add(-1)
+				col.dbStats().CBLReplicationPull().NumPullReplCaughtUp.Add(-1)
 
 				if waitResponse == WaiterClosed {
 					break outer
@@ -1025,37 +1017,32 @@ func (db *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Context
 				}
 			}
 			// Update the current max cached sequence for the next changes iteration
-			currentCachedSequence = db.changeCache().getChannelCache().GetHighCacheSequence()
+			currentCachedSequence = col.changeCache().getChannelCache().GetHighCacheSequence()
 
 			// Check whether user channel access has changed while waiting:
 			var err error
-			userChanged, userCounter, changedChannels, err = db.checkForUserUpdates(ctx, userCounter, changeWaiter, options.Continuous)
+			userChanged, userCounter, changedChannels, err = col.checkForUserUpdates(ctx, userCounter, changeWaiter, options.Continuous)
 			if err != nil {
 				change := makeErrorEntry("User not found during reload - terminating changes feed")
 				base.DebugfCtx(ctx, base.KeyChanges, "User not found during reload - terminating changes feed with entry %+v", base.UD(change))
 				output <- &change
 				return
 			}
-			if userChanged && db.user != nil {
-				newChannelsSince, _ := db.user.FilterToAvailableCollectionChannels(db.ScopeName(), db.Name(), chans)
-				// change when we support multiple collections
-				singleCollectionChannels := newChannelsSince.CompareKeys(channelsSince[singleCollectionID])
+			if userChanged && col.user != nil {
+				newChannelsSince, _ := col.user.FilterToAvailableCollectionChannels(col.ScopeName(), col.Name(), chans)
 
-				for channelName, changed := range singleCollectionChannels {
-					changedChannels[channels.NewID(channelName, singleCollectionID)] = changed
-				}
+				changedChannels = newChannelsSince.CompareKeys(channelsSince)
 
 				if len(changedChannels) > 0 {
-					db.activeChannels().UpdateChanged(changedChannels)
+					col.activeChannels().UpdateChanged(collectionID, changedChannels)
 				}
-				channelsSince = channels.TimedSetByCollectionID{}
-				channelsSince[singleCollectionID] = newChannelsSince
+				channelsSince = newChannelsSince
 			}
 
 			// Clean up inactive lateSequenceFeeds (because user has lost access to the channel)
 			for channel, lateFeed := range lateSequenceFeeds {
 				if !lateFeed.active {
-					db.closeLateFeed(lateFeed)
+					col.closeLateFeed(lateFeed)
 					delete(lateSequenceFeeds, channel)
 				} else {
 					lateFeed.active = false
@@ -1068,7 +1055,7 @@ func (db *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Context
 	return output, nil
 }
 
-func (db *DatabaseCollectionWithUser) waitForCacheUpdate(ctx context.Context, currentCachedSequence uint64) (cancelled bool) {
+func (col *DatabaseCollectionWithUser) waitForCacheUpdate(ctx context.Context, currentCachedSequence uint64) (cancelled bool) {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	for retry := 0; retry <= 50; retry++ {
@@ -1077,7 +1064,7 @@ func (db *DatabaseCollectionWithUser) waitForCacheUpdate(ctx context.Context, cu
 		case <-ctx.Done():
 			return true
 		case <-ticker.C:
-			if db.changeCache().getChannelCache().GetHighCacheSequence() != currentCachedSequence {
+			if col.changeCache().getChannelCache().GetHighCacheSequence() != currentCachedSequence {
 				return false
 			}
 		}


### PR DESCRIPTION
- Removes datastructure that would cause N^2 on logging, which was once everytime you run a change feed and update channels.
- changed some receiver methods from `db` -> `col`

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true,USE_DEFAULT_COLLECTION=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1451/ (test failures unrelated to this PR)
- [x] `GSI=true,xattrs=true,USE_DEFAULT_COLLECTION=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1450/
