### PR TITLE
CBG-2602: [3.0.5] Anon read only access support pull replications 

### DIFF
--- a/rest/doc_api_test.go
+++ b/rest/doc_api_test.go
@@ -161,4 +161,15 @@ func TestGuestReadOnly(t *testing.T) {
 	response = rt.SendRequest("PUT", "/db/doc?rev=1-ca9ad22802b66f662ff171f226211d5c", `{"val": "newval"}`)
 	assertStatus(t, response, http.StatusForbidden)
 
+	// Attempt to access _blipsync as guest - blip sync handling for read-only GUEST is applied at replication level (to allow pull-only replications).
+	// Should succeed permission check, and only fail on websocket upgrade
+	response = rt.SendRequest("GET", "/{{.db}}/_blipsync", "")
+	RequireStatus(t, response, http.StatusUpgradeRequired)
+
+	// Verify matching on _blipsync path doesn't incorrectly match docs, attachments
+	response = rt.SendRequest("PUT", "/{{.keyspace}}/doc_named_blipsync", "")
+	RequireStatus(t, response, http.StatusForbidden)
+	response = rt.SendRequest("PUT", "/{{.keyspace}}/doc/_blipsync", "")
+	RequireStatus(t, response, http.StatusForbidden)
+
 }

--- a/rest/doc_api_test.go
+++ b/rest/doc_api_test.go
@@ -163,13 +163,13 @@ func TestGuestReadOnly(t *testing.T) {
 
 	// Attempt to access _blipsync as guest - blip sync handling for read-only GUEST is applied at replication level (to allow pull-only replications).
 	// Should succeed permission check, and only fail on websocket upgrade
-	response = rt.SendRequest("GET", "/{{.db}}/_blipsync", "")
-	RequireStatus(t, response, http.StatusUpgradeRequired)
+	response = rt.SendRequest("GET", "/db/_blipsync", "")
+	assertStatus(t, response, http.StatusUpgradeRequired)
 
 	// Verify matching on _blipsync path doesn't incorrectly match docs, attachments
-	response = rt.SendRequest("PUT", "/{{.keyspace}}/doc_named_blipsync", "")
-	RequireStatus(t, response, http.StatusForbidden)
-	response = rt.SendRequest("PUT", "/{{.keyspace}}/doc/_blipsync", "")
-	RequireStatus(t, response, http.StatusForbidden)
+	response = rt.SendRequest("PUT", "/db/doc_named_blipsync", "")
+	assertStatus(t, response, http.StatusForbidden)
+	response = rt.SendRequest("PUT", "/db/doc/_blipsync", "")
+	assertStatus(t, response, http.StatusForbidden)
 
 }


### PR DESCRIPTION
CBG-2602

Back port to 3.0.5 for anonymous read only support for pull replications. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] [CBG-2674](https://github.com/couchbase/sync_gateway/pull/6055) [CBG-2671](https://github.com/couchbase/sync_gateway/pull/6056) also https://github.com/couchbase/sync_gateway/pull/6062


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
