### PR TITLE
CBG-2601: [3.0.5] ISGR processedSeqs/expectedSeq mismatch based on JSON string

### DIFF
--- a/db/active_replicator_checkpointer_test.go
+++ b/db/active_replicator_checkpointer_test.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,87 +21,98 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 	tests := []struct {
 		name                    string
 		c                       *Checkpointer
-		expectedSafeSeq         string
+		expectedSafeSeq         *SequenceID
 		expectedExpectedSeqsIdx int
-		expectedExpectedSeqs    []string
-		expectedProcessedSeqs   map[string]struct{}
+		expectedExpectedSeqs    []SequenceID
+		expectedProcessedSeqs   map[SequenceID]struct{}
 	}{
 		{
 			name: "empty",
 			c: &Checkpointer{
-				expectedSeqs:  []string{},
-				processedSeqs: map[string]struct{}{},
+				expectedSeqs:  []SequenceID{},
+				processedSeqs: map[SequenceID]struct{}{},
 			},
-			expectedSafeSeq:         "",
+			expectedSafeSeq:         nil,
 			expectedExpectedSeqsIdx: -1,
-			expectedExpectedSeqs:    []string{},
-			expectedProcessedSeqs:   map[string]struct{}{},
+			expectedExpectedSeqs:    []SequenceID{},
+			expectedProcessedSeqs:   map[SequenceID]struct{}{},
 		},
 		{
 			name: "none processed",
 			c: &Checkpointer{
-				expectedSeqs:  []string{"1", "2", "3"},
-				processedSeqs: map[string]struct{}{},
+				expectedSeqs:  []SequenceID{{Seq: 1}, {Seq: 2}, {Seq: 3}},
+				processedSeqs: map[SequenceID]struct{}{},
 			},
-			expectedSafeSeq:         "",
+			expectedSafeSeq:         nil,
 			expectedExpectedSeqsIdx: -1,
-			expectedExpectedSeqs:    []string{"1", "2", "3"},
-			expectedProcessedSeqs:   map[string]struct{}{},
+			expectedExpectedSeqs:    []SequenceID{{Seq: 1}, {Seq: 2}, {Seq: 3}},
+			expectedProcessedSeqs:   map[SequenceID]struct{}{},
 		},
 		{
 			name: "partial processed",
 			c: &Checkpointer{
-				expectedSeqs:  []string{"1", "2", "3"},
-				processedSeqs: map[string]struct{}{"1": {}},
+				expectedSeqs:  []SequenceID{{Seq: 1}, {Seq: 2}, {Seq: 3}},
+				processedSeqs: map[SequenceID]struct{}{{Seq: 1}: {}},
 			},
-			expectedSafeSeq:         "1",
+			expectedSafeSeq:         &SequenceID{Seq: 1},
 			expectedExpectedSeqsIdx: 0,
-			expectedExpectedSeqs:    []string{"2", "3"},
-			expectedProcessedSeqs:   map[string]struct{}{},
+			expectedExpectedSeqs:    []SequenceID{{Seq: 2}, {Seq: 3}},
+			expectedProcessedSeqs:   map[SequenceID]struct{}{},
 		},
 		{
 			name: "partial processed with gap",
 			c: &Checkpointer{
-				expectedSeqs:  []string{"1", "2", "3"},
-				processedSeqs: map[string]struct{}{"1": {}, "3": {}},
+				expectedSeqs:  []SequenceID{{Seq: 1}, {Seq: 2}, {Seq: 3}},
+				processedSeqs: map[SequenceID]struct{}{{Seq: 1}: {}, {Seq: 3}: {}},
 			},
-			expectedSafeSeq:         "1",
+			expectedSafeSeq:         &SequenceID{Seq: 1},
 			expectedExpectedSeqsIdx: 0,
-			expectedExpectedSeqs:    []string{"2", "3"},
-			expectedProcessedSeqs:   map[string]struct{}{"3": {}},
+			expectedExpectedSeqs:    []SequenceID{{Seq: 2}, {Seq: 3}},
+			expectedProcessedSeqs:   map[SequenceID]struct{}{{Seq: 3}: {}},
 		},
 		{
 			name: "fully processed",
 			c: &Checkpointer{
-				expectedSeqs:  []string{"1", "2", "3"},
-				processedSeqs: map[string]struct{}{"1": {}, "2": {}, "3": {}},
+				expectedSeqs:  []SequenceID{{Seq: 1}, {Seq: 2}, {Seq: 3}},
+				processedSeqs: map[SequenceID]struct{}{{Seq: 1}: {}, {Seq: 2}: {}, {Seq: 3}: {}},
 			},
-			expectedSafeSeq:         "3",
+			expectedSafeSeq:         &SequenceID{Seq: 3},
 			expectedExpectedSeqsIdx: 2,
-			expectedExpectedSeqs:    []string{},
-			expectedProcessedSeqs:   map[string]struct{}{},
+			expectedExpectedSeqs:    []SequenceID{},
+			expectedProcessedSeqs:   map[SequenceID]struct{}{},
 		},
 		{
 			name: "extra processed",
 			c: &Checkpointer{
-				expectedSeqs:  []string{"1", "2", "3"},
-				processedSeqs: map[string]struct{}{"1": {}, "2": {}, "3": {}, "4": {}, "5": {}},
+				expectedSeqs:  []SequenceID{{Seq: 1}, {Seq: 2}, {Seq: 3}},
+				processedSeqs: map[SequenceID]struct{}{{Seq: 1}: {}, {Seq: 2}: {}, {Seq: 3}: {}, {Seq: 4}: {}, {Seq: 5}: {}},
 			},
-			expectedSafeSeq:         "3",
+			expectedSafeSeq:         &SequenceID{Seq: 3},
 			expectedExpectedSeqsIdx: 2,
-			expectedExpectedSeqs:    []string{},
-			expectedProcessedSeqs:   map[string]struct{}{"4": {}, "5": {}},
+			expectedExpectedSeqs:    []SequenceID{},
+			expectedProcessedSeqs:   map[SequenceID]struct{}{{Seq: 4}: {}, {Seq: 5}: {}},
 		},
 		{
 			name: "out of order expected seqs",
 			c: &Checkpointer{
-				expectedSeqs:  []string{"3", "2", "1"},
-				processedSeqs: map[string]struct{}{"1": {}, "2": {}, "3": {}},
+				expectedSeqs:  []SequenceID{{Seq: 3}, {Seq: 2}, {Seq: 1}},
+				processedSeqs: map[SequenceID]struct{}{{Seq: 1}: {}, {Seq: 2}: {}, {Seq: 3}: {}},
 			},
-			expectedSafeSeq:         "3",
+			expectedSafeSeq:         &SequenceID{Seq: 3},
 			expectedExpectedSeqsIdx: 2,
-			expectedExpectedSeqs:    []string{},
-			expectedProcessedSeqs:   map[string]struct{}{},
+			expectedExpectedSeqs:    []SequenceID{},
+			expectedProcessedSeqs:   map[SequenceID]struct{}{},
+		},
+		{
+			name: "compound sequence",
+			c: &Checkpointer{
+				expectedSeqs:  []SequenceID{{Seq: 1}, {Seq: 3, LowSeq: 1}},
+				processedSeqs: map[SequenceID]struct{}{{Seq: 1}: {}, {Seq: 3, LowSeq: 1}: {}},
+			},
+			expectedSafeSeq:         &SequenceID{Seq: 3, LowSeq: 1},
+			expectedExpectedSeqsIdx: 1,
+			expectedExpectedSeqs:    []SequenceID{},
+			expectedProcessedSeqs:   map[SequenceID]struct{}{},
 		},
 	}
 	for _, tt := range tests {
@@ -112,17 +124,54 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 
 			t.Run("_updateCheckpointLists", func(t *testing.T) {
 				actualSafeSeq := tt.c._updateCheckpointLists()
-				assert.Equal(t, tt.expectedSafeSeq, actualSafeSeq)
+				if tt.expectedSafeSeq == nil {
+					assert.Nil(t, actualSafeSeq)
+				} else {
+					assert.Equal(t, *tt.expectedSafeSeq, *actualSafeSeq)
+				}
 				assert.Equal(t, tt.expectedExpectedSeqs, tt.c.expectedSeqs)
 				assert.Equal(t, tt.expectedProcessedSeqs, tt.c.processedSeqs)
 
 				// _updateCheckpointLists should be idempotent
 				// we'd expect no safe seq, and no further changes to either list, as long as c.processedSeqs hasn't been added to
 				actualSafeSeq2 := tt.c._updateCheckpointLists()
-				assert.Equal(t, "", actualSafeSeq2)
+				assert.Nil(t, actualSafeSeq2)
 				assert.Equal(t, tt.expectedExpectedSeqs, tt.c.expectedSeqs)
 				assert.Equal(t, tt.expectedProcessedSeqs, tt.c.processedSeqs)
 			})
+		})
+	}
+}
+
+func BenchmarkCheckpointerUpdateCheckpointLists(b *testing.B) {
+	tests := []struct {
+		expectedSeqsLen  int
+		processedSeqsLen int
+	}{
+		{expectedSeqsLen: 1, processedSeqsLen: 1},
+		{expectedSeqsLen: 100, processedSeqsLen: 100},
+		{expectedSeqsLen: 500, processedSeqsLen: 500},
+		{expectedSeqsLen: 1000, processedSeqsLen: 1000},
+		{expectedSeqsLen: 10000, processedSeqsLen: 10000},
+		{expectedSeqsLen: 50000, processedSeqsLen: 50000},
+		{expectedSeqsLen: 100000, processedSeqsLen: 100000},
+	}
+	for _, test := range tests {
+		b.Run(fmt.Sprintf("expectedSeqsLen=%d,processedSeqsLen=%d", test.expectedSeqsLen, test.processedSeqsLen), func(b *testing.B) {
+			expectedSeqs := make([]SequenceID, 0, test.expectedSeqsLen)
+			for i := 0; i < test.expectedSeqsLen; i++ {
+				expectedSeqs = append(expectedSeqs, SequenceID{Seq: uint64(i)})
+			}
+			processedSeqs := make(map[SequenceID]struct{}, test.processedSeqsLen)
+			for i := 0; i < test.processedSeqsLen; i++ {
+				processedSeqs[SequenceID{Seq: uint64(i)}] = struct{}{}
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				c := &Checkpointer{expectedSeqs: expectedSeqs, processedSeqs: processedSeqs}
+				_ = c._updateCheckpointLists()
+			}
 		})
 	}
 }

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -83,7 +83,7 @@ func (apr *ActivePullReplicator) _connect() error {
 	subChangesRequest := SubChangesRequest{
 		Continuous:     apr.config.Continuous,
 		Batch:          apr.config.ChangesBatchSize,
-		Since:          apr.Checkpointer.lastCheckpointSeq,
+		Since:          apr.Checkpointer.lastCheckpointSeq.String(),
 		Filter:         apr.config.Filter,
 		FilterChannels: apr.config.FilterChannels,
 		DocIDs:         apr.config.DocIDs,
@@ -172,7 +172,7 @@ func (apr *ActivePullReplicator) GetStatus() *ReplicationStatus {
 	var lastSeqPulled string
 	apr.lock.RLock()
 	if apr.Checkpointer != nil {
-		lastSeqPulled = apr.Checkpointer.calculateSafeProcessedSeq()
+		lastSeqPulled = apr.Checkpointer.calculateSafeProcessedSeq().String()
 	}
 	apr.lock.RUnlock()
 	status := apr.getPullStatus(lastSeqPulled)

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -180,7 +180,9 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 	bh.gotSubChanges = true
 
 	logCtx := bh.loggingCtx
-	subChangesParams, err := NewSubChangesParams(logCtx, rq, bh.db.CreateZeroSinceValue(), bh.db.ParseSequenceID)
+
+	defaultSince := CreateZeroSinceValue()
+	subChangesParams, err := NewSubChangesParams(bh.loggingCtx, rq, defaultSince, latestSeq, ParseJSONSequenceID)
 	if err != nil {
 		return base.HTTPErrorf(http.StatusBadRequest, "Invalid subChanges parameters")
 	}
@@ -527,8 +529,8 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 	}()
 
 	// DocID+RevID -> SeqNo
-	expectedSeqs := make(map[IDAndRev]string, 0)
-	alreadyKnownSeqs := make([]string, 0)
+	expectedSeqs := make(map[IDAndRev]SequenceID, 0)
+	alreadyKnownSeqs := make([]SequenceID, 0)
 
 	for _, change := range changeList {
 		docID := change[1].(string)
@@ -572,7 +574,13 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 			// already have this rev, tell the peer to skip sending it
 			output.Write([]byte("0"))
 			if bh.sgr2PullAlreadyKnownSeqsCallback != nil {
-				alreadyKnownSeqs = append(alreadyKnownSeqs, seqStr(change[0]))
+				seq, err := ParseJSONSequenceID(seqStr(change[0]))
+				if err != nil {
+					base.WarnfCtx(bh.loggingCtx, "Unable to parse known sequence %q for %q/%q: %v", change[0], base.UD(docID), revID, err)
+				} else {
+					// we're not able to checkpoint a sequence we can't parse and aren't expecting so just skip the callback if we errored
+					alreadyKnownSeqs = append(alreadyKnownSeqs, seq)
+				}
 			}
 		} else {
 			// we want this rev, send possible ancestors to the peer
@@ -588,7 +596,13 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 
 			// skip parsing seqno if we're not going to use it (no callback defined)
 			if bh.sgr2PullAddExpectedSeqsCallback != nil {
-				expectedSeqs[IDAndRev{DocID: docID, RevID: revID}] = seqStr(change[0])
+				seq, err := ParseJSONSequenceID(seqStr(change[0]))
+				if err != nil {
+					// We've already asked for the doc/rev for the sequence so assume we're going to receive it... Just log this and carry on
+					base.WarnfCtx(bh.loggingCtx, "Unable to parse expected sequence %q for %q/%q: %v", change[0], base.UD(docID), revID, err)
+				} else {
+					expectedSeqs[IDAndRev{DocID: docID, RevID: revID}] = seq
+				}
 			}
 		}
 		nWritten++
@@ -611,17 +625,6 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 	}
 
 	return nil
-}
-
-func seqStr(seq interface{}) string {
-	switch seq := seq.(type) {
-	case string:
-		return seq
-	case json.Number:
-		return seq.String()
-	}
-	base.Warnf("unknown seq type: %T", seq)
-	return ""
 }
 
 // Handles a "proposeChanges" request, similar to "changes" but in no-conflicts mode
@@ -740,14 +743,22 @@ func (bsc *BlipSyncContext) sendRevAsDelta(sender *blip.Sender, docID, revID, de
 }
 
 func (bh *blipHandler) handleNoRev(rq *blip.Message) error {
+	docID, revID := rq.Properties[NorevMessageId], rq.Properties[NorevMessageRev]
 	base.InfofCtx(bh.loggingCtx, base.KeySyncMsg, "%s: norev for doc %q / %q - error: %q - reason: %q",
-		rq.String(), base.UD(rq.Properties[NorevMessageId]), rq.Properties[NorevMessageRev], rq.Properties[NorevMessageError], rq.Properties[NorevMessageReason])
+		rq.String(), base.UD(docID), revID, rq.Properties[NorevMessageError], rq.Properties[NorevMessageReason])
 
 	if bh.sgr2PullProcessedSeqCallback != nil {
+		var seqStr string
 		if bh.blipContext.ActiveSubprotocol() == BlipCBMobileReplicationV2 && bh.clientType == BLIPClientTypeSGR2 {
-			bh.sgr2PullProcessedSeqCallback(rq.Properties[NorevMessageSeq], IDAndRev{DocID: rq.Properties[NorevMessageId], RevID: rq.Properties[NorevMessageRev]})
+			seqStr = rq.Properties[NorevMessageSeq]
 		} else {
-			bh.sgr2PullProcessedSeqCallback(rq.Properties[NorevMessageSequence], IDAndRev{DocID: rq.Properties[NorevMessageId], RevID: rq.Properties[NorevMessageRev]})
+			seqStr = rq.Properties[NorevMessageSequence]
+		}
+		seq, err := ParseJSONSequenceID(seqStr)
+		if err != nil {
+			base.WarnfCtx(bh.loggingCtx, "Unable to parse sequence %q from norev message: %w - not tracking for checkpointing", seqStr, err)
+		} else {
+			bh.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: revID})
 		}
 	}
 
@@ -814,7 +825,13 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 			}
 			bh.replicationStats.HandleRevDocsPurgedCount.Add(1)
 			if bh.sgr2PullProcessedSeqCallback != nil {
-				bh.sgr2PullProcessedSeqCallback(rq.Properties[RevMessageSequence], IDAndRev{DocID: docID, RevID: revID})
+				seqStr := rq.Properties[RevMessageSequence]
+				seq, err := ParseJSONSequenceID(seqStr)
+				if err != nil {
+					base.WarnfCtx(bh.loggingCtx, "Unable to parse sequence %q from rev message: %w - not tracking for checkpointing", seqStr, err)
+				} else {
+					bh.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: revID})
+				}
 			}
 			return nil
 		}
@@ -1024,7 +1041,13 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 	}
 
 	if bh.sgr2PullProcessedSeqCallback != nil {
-		bh.sgr2PullProcessedSeqCallback(rq.Properties[RevMessageSequence], IDAndRev{DocID: docID, RevID: revID})
+		seqProperty := rq.Properties[RevMessageSequence]
+		seq, err := ParseJSONSequenceID(seqProperty)
+		if err != nil {
+			base.WarnfCtx(bh.loggingCtx, "Unable to parse sequence %q from rev message: %w - not tracking for checkpointing", seqProperty, err)
+		} else {
+			bh.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: revID})
+		}
 	}
 
 	return nil

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -181,8 +181,8 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 
 	logCtx := bh.loggingCtx
 
-	defaultSince := CreateZeroSinceValue()
-	subChangesParams, err := NewSubChangesParams(bh.loggingCtx, rq, defaultSince, latestSeq, ParseJSONSequenceID)
+	defaultSince := bh.db.CreateZeroSinceValue()
+	subChangesParams, err := NewSubChangesParams(logCtx, rq, defaultSince, ParseJSONSequenceID)
 	if err != nil {
 		return base.HTTPErrorf(http.StatusBadRequest, "Invalid subChanges parameters")
 	}

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -97,25 +97,25 @@ type BlipSyncContext struct {
 	continuous                       bool
 	lock                             sync.Mutex
 	allowedAttachments               map[string]AllowedAttachment
-	handlerSerialNumber              uint64                                    // Each handler within a context gets a unique serial number for logging
-	terminatorOnce                   sync.Once                                 // Used to ensure the terminator channel below is only ever closed once.
-	terminator                       chan bool                                 // Closed during BlipSyncContext.close(). Ensures termination of async goroutines.
-	activeSubChanges                 base.AtomicBool                           // Flag for whether there is a subChanges subscription currently active.  Atomic access
-	useDeltas                        bool                                      // Whether deltas can be used for this connection - This should be set via setUseDeltas()
-	sgCanUseDeltas                   bool                                      // Whether deltas can be used by Sync Gateway for this connection
-	userChangeWaiter                 *ChangeWaiter                             // Tracks whether the users/roles associated with the replication have changed
-	userName                         string                                    // Avoid contention on db.user during userChangeWaiter user lookup
-	sgr2PullAddExpectedSeqsCallback  func(expectedSeqs map[IDAndRev]string)    // sgr2PullAddExpectedSeqsCallback is called after successfully handling an incoming changes message
-	sgr2PullProcessedSeqCallback     func(remoteSeq string, idAndRev IDAndRev) // sgr2PullProcessedSeqCallback is called after successfully handling an incoming rev message
-	sgr2PullAlreadyKnownSeqsCallback func(alreadyKnownSeqs ...string)          // sgr2PullAlreadyKnownSeqsCallback is called to mark the sequences as being immediately processed
-	sgr2PushAddExpectedSeqsCallback  func(expectedSeqs ...string)              // sgr2PushAddExpectedSeqsCallback is called after sync gateway has sent a revision, but is still awaiting an acknowledgement
-	sgr2PushProcessedSeqCallback     func(remoteSeq string)                    // sgr2PushProcessedSeqCallback is called after receiving acknowledgement of a sent revision
-	sgr2PushAlreadyKnownSeqsCallback func(alreadyKnownSeqs ...string)          // sgr2PushAlreadyKnownSeqsCallback is called to mark the sequence as being immediately processed
-	emptyChangesMessageCallback      func()                                    // emptyChangesMessageCallback is called when an empty changes message is received
-	replicationStats                 *BlipSyncStats                            // Replication stats
-	purgeOnRemoval                   bool                                      // Purges the document when we pull a _removed:true revision.
-	conflictResolver                 *ConflictResolver                         // Conflict resolver for active replications
-	changesPendingResponseCount      int64                                     // Number of changes messages pending changesResponse
+	handlerSerialNumber              uint64                                         // Each handler within a context gets a unique serial number for logging
+	terminatorOnce                   sync.Once                                      // Used to ensure the terminator channel below is only ever closed once.
+	terminator                       chan bool                                      // Closed during BlipSyncContext.close(). Ensures termination of async goroutines.
+	activeSubChanges                 base.AtomicBool                                // Flag for whether there is a subChanges subscription currently active.  Atomic access
+	useDeltas                        bool                                           // Whether deltas can be used for this connection - This should be set via setUseDeltas()
+	sgCanUseDeltas                   bool                                           // Whether deltas can be used by Sync Gateway for this connection
+	userChangeWaiter                 *ChangeWaiter                                  // Tracks whether the users/roles associated with the replication have changed
+	userName                         string                                         // Avoid contention on db.user during userChangeWaiter user lookup
+	sgr2PullAddExpectedSeqsCallback  func(expectedSeqs map[IDAndRev]SequenceID)     // sgr2PullAddExpectedSeqsCallback is called after successfully handling an incoming changes message
+	sgr2PullProcessedSeqCallback     func(remoteSeq *SequenceID, idAndRev IDAndRev) // sgr2PullProcessedSeqCallback is called after successfully handling an incoming rev message
+	sgr2PullAlreadyKnownSeqsCallback func(alreadyKnownSeqs ...SequenceID)           // sgr2PullAlreadyKnownSeqsCallback is called to mark the sequences as being immediately processed
+	sgr2PushAddExpectedSeqsCallback  func(expectedSeqs ...SequenceID)               // sgr2PushAddExpectedSeqsCallback is called after sync gateway has sent a revision, but is still awaiting an acknowledgement
+	sgr2PushProcessedSeqCallback     func(remoteSeq SequenceID)                     // sgr2PushProcessedSeqCallback is called after receiving acknowledgement of a sent revision
+	sgr2PushAlreadyKnownSeqsCallback func(alreadyKnownSeqs ...SequenceID)           // sgr2PushAlreadyKnownSeqsCallback is called to mark the sequence as being immediately processed
+	emptyChangesMessageCallback      func()                                         // emptyChangesMessageCallback is called when an empty changes message is received
+	replicationStats                 *BlipSyncStats                                 // Replication stats
+	purgeOnRemoval                   bool                                           // Purges the document when we pull a _removed:true revision.
+	conflictResolver                 *ConflictResolver                              // Conflict resolver for active replications
+	changesPendingResponseCount      int64                                          // Number of changes messages pending changesResponse
 	// TODO: For review, whether sendRevAllConflicts needs to be per sendChanges invocation
 	sendRevNoConflicts bool                      // Whether to set noconflicts=true when sending revisions
 	clientType         BLIPSyncContextClientType // Can perform client-specific replication behaviour based on this field
@@ -290,8 +290,8 @@ func (bsc *BlipSyncContext) handleChangesResponse(sender *blip.Sender, response 
 	// placeholder (probably 0). The item numbers match those of changeArray.
 	var revSendTimeLatency int64
 	var revSendCount int64
-	sentSeqs := make([]string, 0)
-	alreadyKnownSeqs := make([]string, 0)
+	sentSeqs := make([]SequenceID, 0)
+	alreadyKnownSeqs := make([]SequenceID, 0)
 
 	for i, knownRevsArrayInterface := range answer {
 		seq := changeArray[i][0].(SequenceID)
@@ -337,12 +337,12 @@ func (bsc *BlipSyncContext) handleChangesResponse(sender *blip.Sender, response 
 			revSendCount++
 
 			if bsc.sgr2PushAddExpectedSeqsCallback != nil {
-				sentSeqs = append(sentSeqs, seq.String())
+				sentSeqs = append(sentSeqs, seq)
 			}
 		} else {
 			base.DebugfCtx(bsc.loggingCtx, base.KeySync, "Peer didn't want revision %s / %s (seq:%v)", base.UD(docID), revID, seq)
 			if bsc.sgr2PushAlreadyKnownSeqsCallback != nil {
-				alreadyKnownSeqs = append(alreadyKnownSeqs, seq.String())
+				alreadyKnownSeqs = append(alreadyKnownSeqs, seq)
 			}
 		}
 	}
@@ -457,7 +457,7 @@ func (bsc *BlipSyncContext) sendRevisionWithProperties(sender *blip.Sender, docI
 			bsc.removeAllowedAttachments(docID, attMeta, activeSubprotocol)
 
 			if bsc.sgr2PushProcessedSeqCallback != nil {
-				bsc.sgr2PushProcessedSeqCallback(seq.String())
+				bsc.sgr2PushProcessedSeqCallback(seq)
 			}
 		}(activeSubprotocol)
 	}
@@ -552,7 +552,7 @@ func (bsc *BlipSyncContext) sendNoRev(sender *blip.Sender, docID, revID string, 
 	}
 
 	if bsc.sgr2PushProcessedSeqCallback != nil {
-		bsc.sgr2PushProcessedSeqCallback(seq.String())
+		bsc.sgr2PushProcessedSeqCallback(seq)
 	}
 
 	return nil

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -130,9 +130,9 @@ func NewSubChangesParams(logCtx context.Context, rq *blip.Message, zeroSeq Seque
 
 	// Determine incoming since and docIDs once, since there is some overhead associated with their calculation
 	sinceSequenceId := zeroSeq
+	var err error
 	if sinceStr, found := rq.Properties[SubChangesSince]; found {
-		var err error
-		if sinceSequenceId, err = sequenceIDParser(base.ConvertJSONString(sinceStr)); err != nil {
+		if sinceSequenceId, err = sequenceIDParser(sinceStr); err != nil {
 			base.InfofCtx(logCtx, base.KeySync, "%s: Invalid sequence ID in 'since': %s", rq, sinceStr)
 			return params, err
 		}

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -146,7 +146,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	assert.True(t, changes[2].principalDoc)
 
 	lastSeq := getLastSeq(changes)
-	lastSeq, _ = db.ParseSequenceID(lastSeq.String())
+	lastSeq, _ = ParsePlainSequenceID(lastSeq.String())
 
 	// Add a new doc (sequence 3):
 	revid, _, err = db.Put("doc2", Body{"channels": []string{"PBS"}})
@@ -226,7 +226,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 		ID:      "alpha",
 		Changes: []ChangeRev{{"rev": revid}}})
 	lastSeq := getLastSeq(changes)
-	lastSeq, _ = db.ParseSequenceID(lastSeq.String())
+	lastSeq, _ = ParsePlainSequenceID(lastSeq.String())
 
 	// Get raw document from the bucket
 	rv, _, _ := db.Bucket.GetRaw("alpha") // cas, err
@@ -311,7 +311,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 		ID:      "alpha",
 		Changes: []ChangeRev{{"rev": revid}}})
 	lastSeq := getLastSeq(changes)
-	lastSeq, _ = db.ParseSequenceID(lastSeq.String())
+	lastSeq, _ = ParsePlainSequenceID(lastSeq.String())
 
 	// Get raw document from the bucket
 	rv, _, _ := db.Bucket.GetRaw("alpha") // cas, err

--- a/db/sequence_id.go
+++ b/db/sequence_id.go
@@ -11,6 +11,8 @@ licenses/APL2.txt.
 package db
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
@@ -66,9 +68,26 @@ func (s SequenceID) intSeqToString() string {
 	}
 }
 
-// Currently accepts a plain string, but in the future might accept generic JSON objects.
-// Calling this with a JSON string will result in an error.
-func (dbc *DatabaseContext) ParseSequenceID(str string) (s SequenceID, err error) {
+func seqStr(seq interface{}) string {
+	switch seq := seq.(type) {
+	case string:
+		return seq
+	case json.Number:
+		return seq.String()
+	}
+	base.WarnfCtx(context.Background(), "unknown seq type: %T", seq)
+	return ""
+}
+
+// ParseJSONSequenceID will parse a JSON string sequence ID. (e.g. accepts: `"1::3"`, `2`, and also a plain sequence like `1::3`)
+func ParseJSONSequenceID(str string) (SequenceID, error) {
+	plainStr := base.ConvertJSONString(str)
+	return ParsePlainSequenceID(plainStr)
+}
+
+// ParsePlainSequenceID will parse a plain sequence string - but not a JSON sequence string (e.g. accepts: `1::3` but not `"1::3"`)
+// Calling this with a JSON string will result in an error. Use ParseJSONSequenceID instead.
+func ParsePlainSequenceID(str string) (s SequenceID, err error) {
 	return parseIntegerSequenceID(str)
 }
 
@@ -166,6 +185,10 @@ func (s SequenceID) Equals(s2 SequenceID) bool {
 func (s SequenceID) Before(s2 SequenceID) bool {
 	// using SafeSequence for comparison, which takes the lower of LowSeq and Seq
 	if s.TriggeredBy == s2.TriggeredBy {
+		if s.SafeSequence() == s2.SafeSequence() {
+			// If both are equal, one sequence must be a non-zero LowSeq - sort those after the actual sequence.
+			return s.Seq < s2.Seq
+		}
 		return s.SafeSequence() < s2.SafeSequence() // the simple case: untriggered, or triggered by same sequence
 	} else if s.TriggeredBy == 0 {
 		return s.SafeSequence() < s2.TriggeredBy // s2 triggered but not s

--- a/db/sequence_id_test.go
+++ b/db/sequence_id_test.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -132,6 +133,24 @@ func TestCompareSequenceIDs(t *testing.T) {
 	for i := 0; i < len(orderedSeqs); i++ {
 		for j := 0; j < len(orderedSeqs); j++ {
 			goassert.Equals(t, orderedSeqs[i].Before(orderedSeqs[j]), i < j)
+		}
+	}
+}
+
+func TestCompareSequenceIDsLowSeq(t *testing.T) {
+	orderedSeqs := []SequenceID{
+		{LowSeq: 1200, Seq: 1233},
+		{LowSeq: 1205, Seq: 1234},
+		{Seq: 1234},
+		{LowSeq: 1234, Seq: 5677},
+		{LowSeq: 1234, Seq: 5678},
+	}
+
+	for i := 0; i < len(orderedSeqs); i++ {
+		for j := 0; j < len(orderedSeqs); j++ {
+			t.Run(fmt.Sprintf("%v<%v==%v", orderedSeqs[i], orderedSeqs[j], i < j), func(t *testing.T) {
+				assert.Equalf(t, i < j, orderedSeqs[i].Before(orderedSeqs[j]), "expected %v < %v", orderedSeqs[i], orderedSeqs[j])
+			})
 		}
 	}
 }

--- a/rest/blip_sync_messages_test.go
+++ b/rest/blip_sync_messages_test.go
@@ -77,7 +77,7 @@ func TestSubChangesSince(t *testing.T) {
 	rq := blip.NewRequest()
 	rq.Properties["since"] = `"1"`
 
-	subChangesParams, err := db.NewSubChangesParams(context.TODO(), rq, db.SequenceID{}, nil, db.ParseJSONSequenceID())
+	subChangesParams, err := db.NewSubChangesParams(context.TODO(), rq, db.SequenceID{}, db.ParseJSONSequenceID)
 	require.NoError(t, err)
 
 	seqID := subChangesParams.Since()

--- a/rest/blip_sync_messages_test.go
+++ b/rest/blip_sync_messages_test.go
@@ -74,15 +74,10 @@ func TestAddRevision(t *testing.T) {
 // Reproduces SG #3283
 func TestSubChangesSince(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
-	defer rt.Close()
-
-	testDb := rt.GetDatabase()
-
 	rq := blip.NewRequest()
 	rq.Properties["since"] = `"1"`
 
-	subChangesParams, err := db.NewSubChangesParams(context.TODO(), rq, db.SequenceID{}, testDb.ParseSequenceID)
+	subChangesParams, err := db.NewSubChangesParams(context.TODO(), rq, db.SequenceID{}, nil, db.ParseJSONSequenceID())
 	require.NoError(t, err)
 
 	seqID := subChangesParams.Since()

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -83,7 +83,7 @@ func (h *handler) updateChangesOptionsFromQuery(feed *string, options *db.Change
 	}
 
 	if _, ok := values["since"]; ok {
-		if options.Since, err = h.db.ParseSequenceID(h.getJSONStringQuery("since")); err != nil {
+		if options.Since, err = db.ParsePlainSequenceID(h.getJSONStringQuery("since")); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -125,8 +125,8 @@ func (h *handler) updateChangesOptionsFromQuery(feed *string, options *db.Change
 					docIdsArray = querydocidKeys
 				}
 			} else {
-				//This is not a JSON array so treat as a simple
-				//comma separated list of doc id's
+				// This is not a JSON array so treat as a simple
+				// comma separated list of doc id's
 				docIdsArray = strings.Split(docidsParam, ",")
 			}
 		}
@@ -171,7 +171,7 @@ func (h *handler) handleChanges() error {
 		// GET request has parameters in URL:
 		feed = h.getQuery("feed")
 		var err error
-		if options.Since, err = h.db.ParseSequenceID(h.getJSONStringQuery("since")); err != nil {
+		if options.Since, err = db.ParsePlainSequenceID(h.getJSONStringQuery("since")); err != nil {
 			return err
 		}
 		options.Limit = int(h.getIntQuery("limit", 0))
@@ -194,8 +194,8 @@ func (h *handler) handleChanges() error {
 					docIdsArray = docidKeys
 				}
 			} else {
-				//This is not a JSON array so treat as a simple
-				//comma separated list of doc id's
+				// This is not a JSON array so treat as a simple
+				// comma separated list of doc id's
 				docIdsArray = strings.Split(docidsParam, ",")
 			}
 		}
@@ -506,9 +506,9 @@ func (h *handler) sendContinuousChangesByWebSocket(inChannels base.Set, options 
 			}
 		}
 
-		//Copy options.Terminator to new WebSocket options
-		//options.Terminator will be closed automatically when
-		//changes feed completes
+		// Copy options.Terminator to new WebSocket options
+		// options.Terminator will be closed automatically when
+		// changes feed completes
 		wsoptions.Terminator = options.Terminator
 
 		// Set up GZip compression


### PR DESCRIPTION
CBG-2601

Back-port for the processed/expectedSeq mismatch fix based on JSON string. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
