### PR TITLE
CBG-2701: [2.8.4] Use MaxInt64 for high sequence queries

### DIFF
--- a/db/query.go
+++ b/db/query.go
@@ -3,7 +3,6 @@ package db
 import (
 	"errors"
 	"fmt"
-	"math"
 	"strings"
 	"time"
 
@@ -17,6 +16,10 @@ import (
 type QueryIdRow struct {
 	Id string
 }
+
+const (
+	N1QLMaxInt64 = 9223372036854775000 // Use this for compatibly with all server versions, see MB-54930 for discussion
+)
 
 const (
 	QueryTypeAccess       = "access"
@@ -399,8 +402,8 @@ func (context *DatabaseContext) buildChannelsQuery(channelName string, startSeq 
 	params[QueryParamStartSeq] = N1QLSafeUint64(startSeq)
 	// If endSeq isn't defined, set to max int64.
 	if endSeq == 0 {
-		endSeq = math.MaxInt64
-	} else if endSeq < math.MaxInt64 {
+		endSeq = N1QLMaxInt64
+	} else if endSeq < N1QLMaxInt64 {
 		// channels query isn't based on inclusive end - add one to ensure complete result set
 		endSeq++
 	}
@@ -411,8 +414,8 @@ func (context *DatabaseContext) buildChannelsQuery(channelName string, startSeq 
 
 // N1QL only supports int64 values (https://issues.couchbase.com/browse/MB-24464), so restrict parameter values to this range
 func N1QLSafeUint64(value uint64) uint64 {
-	if value > math.MaxInt64 {
-		return math.MaxInt64
+	if value > N1QLMaxInt64 {
+		return N1QLMaxInt64
 	}
 	return value
 }

--- a/db/query.go
+++ b/db/query.go
@@ -396,17 +396,25 @@ func (context *DatabaseContext) buildChannelsQuery(channelName string, startSeq 
 	// Channel queries use a prepared query
 	params = make(map[string]interface{}, 3)
 	params[QueryParamChannelName] = channelName
-	params[QueryParamStartSeq] = startSeq
+	params[QueryParamStartSeq] = N1QLSafeUint64(startSeq)
+	// If endSeq isn't defined, set to max int64.
 	if endSeq == 0 {
-		// If endSeq isn't defined, set to max uint64
-		endSeq = math.MaxUint64
-	} else if endSeq < math.MaxUint64 {
+		endSeq = math.MaxInt64
+	} else if endSeq < math.MaxInt64 {
 		// channels query isn't based on inclusive end - add one to ensure complete result set
 		endSeq++
 	}
-	params[QueryParamEndSeq] = endSeq
+	params[QueryParamEndSeq] = N1QLSafeUint64(endSeq)
 
 	return channelQueryStatement, params
+}
+
+// N1QL only supports int64 values (https://issues.couchbase.com/browse/MB-24464), so restrict parameter values to this range
+func N1QLSafeUint64(value uint64) uint64 {
+	if value > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return value
 }
 
 func (context *DatabaseContext) QueryResync() (sgbucket.QueryResultIterator, error) {

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"expvar"
 	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -44,7 +43,7 @@ func isIndexEmpty(bucket *base.CouchbaseBucketGoCB, useXattrs bool) (bool, error
 	starChannelQueryStatement = replaceIndexTokensQuery(starChannelQueryStatement, sgIndexes[IndexAllDocs], useXattrs)
 	params := map[string]interface{}{}
 	params[QueryParamStartSeq] = 0
-	params[QueryParamEndSeq] = math.MaxInt64
+	params[QueryParamEndSeq] = N1QLMaxInt64
 
 	// Execute the query
 	results, err := bucket.Query(starChannelQueryStatement, params, gocb.RequestPlus, true)


### PR DESCRIPTION
CBG-2701

Backport to 2.8.4 use maxint64 for high sequence queries, also included cherry pick for CBG-2666

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
