### PR TITLE
CBG-2700: [3.0.5] Use MaxInt64 for high sequence queries

### DIFF
--- a/db/query.go
+++ b/db/query.go
@@ -13,7 +13,6 @@ package db
 import (
 	"errors"
 	"fmt"
-	"math"
 	"strings"
 	"time"
 
@@ -26,6 +25,10 @@ import (
 type QueryIdRow struct {
 	Id string
 }
+
+const (
+	N1QLMaxInt64 = 9223372036854775000 // Use this for compatibly with all server versions, see MB-54930 for discussion
+)
 
 const (
 	QueryTypeAccess       = "access"
@@ -443,8 +446,8 @@ func (context *DatabaseContext) buildChannelsQuery(channelName string, startSeq 
 	params[QueryParamStartSeq] = N1QLSafeUint64(startSeq)
 	// If endSeq isn't defined, set to max int64.
 	if endSeq == 0 {
-		endSeq = math.MaxInt64
-	} else if endSeq < math.MaxInt64 {
+		endSeq = N1QLMaxInt64
+	} else if endSeq < N1QLMaxInt64 {
 		// channels query isn't based on inclusive end - add one to ensure complete result set
 		endSeq++
 	}
@@ -455,8 +458,8 @@ func (context *DatabaseContext) buildChannelsQuery(channelName string, startSeq 
 
 // N1QL only supports int64 values (https://issues.couchbase.com/browse/MB-24464), so restrict parameter values to this range
 func N1QLSafeUint64(value uint64) uint64 {
-	if value > math.MaxInt64 {
-		return math.MaxInt64
+	if value > N1QLMaxInt64 {
+		return N1QLMaxInt64
 	}
 	return value
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -52,7 +51,7 @@ func isIndexEmpty(store base.N1QLStore, useXattrs bool) (bool, error) {
 	starChannelQueryStatement = replaceIndexTokensQuery(starChannelQueryStatement, sgIndexes[IndexAllDocs], useXattrs)
 	params := map[string]interface{}{}
 	params[QueryParamStartSeq] = 0
-	params[QueryParamEndSeq] = math.MaxInt64
+	params[QueryParamEndSeq] = N1QLMaxInt64
 
 	// Execute the query
 	results, err := store.Query(starChannelQueryStatement, params, base.RequestPlus, true)


### PR DESCRIPTION
CBG-2700

Backport to 3.0.5 use maxint64 for high sequence queries, also included cherry pick for [CBG-2666](https://issues.couchbase.com/browse/CBG-2666)

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
