### PR TITLE
CBG-2708 always use counter for blip attachments

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1259,10 +1259,8 @@ func (bsc *BlipSyncContext) addAllowedAttachments(docID string, attMeta []Attach
 		key := allowedAttachmentKey(docID, attachment.digest, activeSubprotocol)
 		att, found := bsc.allowedAttachments[key]
 		if found {
-			if activeSubprotocol == BlipCBMobileReplicationV2 {
-				att.counter = att.counter + 1
-				bsc.allowedAttachments[key] = att
-			}
+			att.counter++
+			bsc.allowedAttachments[key] = att
 		} else {
 			bsc.allowedAttachments[key] = AllowedAttachment{
 				version: attachment.version,
@@ -1286,15 +1284,13 @@ func (bsc *BlipSyncContext) removeAllowedAttachments(docID string, attMeta []Att
 	for _, attachment := range attMeta {
 		key := allowedAttachmentKey(docID, attachment.digest, activeSubprotocol)
 		att, found := bsc.allowedAttachments[key]
-		if found && activeSubprotocol == BlipCBMobileReplicationV2 {
+		if found {
 			if n := att.counter; n > 1 {
 				att.counter = n - 1
 				bsc.allowedAttachments[key] = att
 			} else {
 				delete(bsc.allowedAttachments, key)
 			}
-		} else if found && activeSubprotocol == BlipCBMobileReplicationV3 {
-			delete(bsc.allowedAttachments, key)
 		}
 	}
 


### PR DESCRIPTION
In BlipCBMobileReplicationV3, it is possible for multiple messages to happen at once, with the same doc id + attachment digest, but a different rev ID in the state of conflict resolution. Therefore, we continue to use a counted map for BlipCBMobileReplicationV3 and BlipCBMobileReplicationV2.


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1455/
