### PR TITLE
CBG-2576 cache scope/collection name on DatabaseCollection

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -168,7 +168,7 @@ func collectionBlipHandler(next blipHandlerFunc) blipHandlerFunc {
 		if collection == nil {
 			return base.HTTPErrorf(http.StatusBadRequest, "Collection index %d does not match a valid collection from GetCollections", collectionIndex)
 		}
-		bh.loggingCtx = base.CollectionCtx(bh.BlipSyncContext.loggingCtx, collection.Name())
+		bh.loggingCtx = base.CollectionCtx(bh.BlipSyncContext.loggingCtx, collection.Name)
 		bh.collection = &DatabaseCollectionWithUser{
 			DatabaseCollection: bh.collectionMapping[collectionIndex],
 			user:               bh.db.user,

--- a/db/blip_handler_collections.go
+++ b/db/blip_handler_collections.go
@@ -103,7 +103,7 @@ func (bsc *BlipSyncContext) getCollectionIndexForDB(collection *DatabaseCollecti
 		return 0, false
 	}
 	for i, iCollection := range bsc.collectionMapping {
-		if iCollection.ScopeName() == collection.ScopeName() && iCollection.Name() == collection.Name() {
+		if iCollection.ScopeName == collection.ScopeName && iCollection.Name == collection.Name {
 			return i, true
 		}
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -433,10 +433,10 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 	return nil, nil, nil
 }
 
-func (db *DatabaseCollectionWithUser) authorizeUserForChannels(docID, revID string, channels base.Set, isDeleted bool, history Revisions) (isAuthorized bool, redactedRev DocumentRevision) {
+func (col *DatabaseCollectionWithUser) authorizeUserForChannels(docID, revID string, channels base.Set, isDeleted bool, history Revisions) (isAuthorized bool, redactedRev DocumentRevision) {
 
-	if db.user != nil {
-		if err := db.user.AuthorizeAnyCollectionChannel(db.ScopeName(), db.Name(), channels); err != nil {
+	if col.user != nil {
+		if err := col.user.AuthorizeAnyCollectionChannel(col.ScopeName, col.Name, channels); err != nil {
 			// On access failure, return (only) the doc history and deletion/removal
 			// status instead of returning an error. For justification see the comment in
 			// the getRevFromDoc method, below
@@ -485,8 +485,8 @@ func (db *DatabaseCollectionWithUser) Get1xRevAndChannels(ctx context.Context, d
 }
 
 // Returns an HTTP 403 error if the User is not allowed to access any of this revision's channels.
-func (db *DatabaseCollectionWithUser) authorizeDoc(doc *Document, revid string) error {
-	user := db.user
+func (col *DatabaseCollectionWithUser) authorizeDoc(doc *Document, revid string) error {
+	user := col.user
 	if doc == nil || user == nil {
 		return nil // A nil User means access control is disabled
 	}
@@ -495,7 +495,7 @@ func (db *DatabaseCollectionWithUser) authorizeDoc(doc *Document, revid string) 
 	}
 	if rev := doc.History[revid]; rev != nil {
 		// Authenticate against specific revision:
-		return db.user.AuthorizeAnyCollectionChannel(db.ScopeName(), db.Name(), rev.Channels)
+		return col.user.AuthorizeAnyCollectionChannel(col.ScopeName, col.Name, rev.Channels)
 	} else {
 		// No such revision; let the caller proceed and return a 404
 		return nil
@@ -2207,7 +2207,7 @@ func (db *DatabaseCollectionWithUser) Purge(ctx context.Context, key string) err
 
 // Calls the JS sync function to assign the doc to channels, grant users
 // access to channels, and reject invalid documents.
-func (db *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context, doc *Document, body Body, metaMap map[string]interface{}, revID string) (
+func (col *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context, doc *Document, body Body, metaMap map[string]interface{}, revID string) (
 	result base.Set,
 	access channels.AccessMap,
 	roles channels.AccessMap,
@@ -2217,31 +2217,31 @@ func (db *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context, 
 	base.DebugfCtx(ctx, base.KeyCRUD, "Invoking sync on doc %q rev %s", base.UD(doc.ID), body[BodyRev])
 
 	// Low-level protection against writes for read-only guest.  Handles write pathways that don't fail-fast
-	if db.user != nil && db.user.Name() == "" && db.isGuestReadOnly() {
+	if col.user != nil && col.user.Name() == "" && col.isGuestReadOnly() {
 		return result, access, roles, expiry, oldJson, base.HTTPErrorf(403, auth.GuestUserReadOnly)
 	}
 
 	// Get the parent revision, to pass to the sync function:
 	var oldJsonBytes []byte
-	if oldJsonBytes, err = db.getAncestorJSON(ctx, doc, revID); err != nil {
+	if oldJsonBytes, err = col.getAncestorJSON(ctx, doc, revID); err != nil {
 		return
 	}
 	oldJson = string(oldJsonBytes)
 
-	if db.channelMapper() != nil {
+	if col.channelMapper() != nil {
 		// Call the ChannelMapper:
-		db.dbStats().Database().SyncFunctionCount.Add(1)
-		db.collectionStats.SyncFunctionCount.Add(1)
+		col.dbStats().Database().SyncFunctionCount.Add(1)
+		col.collectionStats.SyncFunctionCount.Add(1)
 
 		var output *channels.ChannelMapperOutput
 
 		startTime := time.Now()
-		output, err = db.channelMapper().MapToChannelsAndAccess(body, oldJson, metaMap,
-			MakeUserCtx(db.user, db.ScopeName(), db.Name()))
+		output, err = col.channelMapper().MapToChannelsAndAccess(body, oldJson, metaMap,
+			MakeUserCtx(col.user, col.ScopeName, col.Name))
 		syncFunctionTimeNano := time.Since(startTime).Nanoseconds()
 
-		db.dbStats().Database().SyncFunctionTime.Add(syncFunctionTimeNano)
-		db.collectionStats.SyncFunctionTime.Add(syncFunctionTimeNano)
+		col.dbStats().Database().SyncFunctionTime.Add(syncFunctionTimeNano)
+		col.collectionStats.SyncFunctionTime.Add(syncFunctionTimeNano)
 
 		if err == nil {
 			result = output.Channels
@@ -2252,11 +2252,11 @@ func (db *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context, 
 			if err != nil {
 				base.InfofCtx(ctx, base.KeyAll, "Sync fn rejected doc %q / %q --> %s", base.UD(doc.ID), base.UD(doc.NewestRev), err)
 				base.DebugfCtx(ctx, base.KeyAll, "    rejected doc %q / %q : new=%+v  old=%s", base.UD(doc.ID), base.UD(doc.NewestRev), base.UD(body), base.UD(oldJson))
-				db.dbStats().Security().NumDocsRejected.Add(1)
-				db.collectionStats.SyncFunctionRejectCount.Add(1)
+				col.dbStats().Security().NumDocsRejected.Add(1)
+				col.collectionStats.SyncFunctionRejectCount.Add(1)
 				if isAccessError(err) {
-					db.dbStats().Security().NumAccessErrors.Add(1)
-					db.collectionStats.SyncFunctionRejectAccessCount.Add(1)
+					col.dbStats().Security().NumAccessErrors.Add(1)
+					col.collectionStats.SyncFunctionRejectAccessCount.Add(1)
 				}
 			} else if !validateAccessMap(access) || !validateRoleAccessMap(roles) {
 				err = base.HTTPErrorf(500, "Error in JS sync function")
@@ -2268,8 +2268,8 @@ func (db *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context, 
 				err = base.HTTPErrorf(500, "JS sync function timed out")
 			} else {
 				err = base.HTTPErrorf(500, "Exception in JS sync function")
-				db.collectionStats.SyncFunctionExceptionCount.Add(1)
-				db.dbStats().Database().SyncFunctionExceptionCount.Add(1)
+				col.collectionStats.SyncFunctionExceptionCount.Add(1)
+				col.dbStats().Database().SyncFunctionExceptionCount.Add(1)
 			}
 		}
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1475,10 +1475,10 @@ func TestAccessFunctionDb(t *testing.T) {
 	user, err = authenticator.GetUser("naomi")
 	assert.NoError(t, err, "GetUser")
 	expected := channels.AtSequence(channels.BaseSetOf(t, "Hulu", "Netflix", "!"), 1)
-	assert.Equal(t, expected, user.CollectionChannels(collection.ScopeName(), collection.Name()))
+	assert.Equal(t, expected, user.CollectionChannels(collection.ScopeName, collection.Name))
 
 	expected.AddChannel("CrunchyRoll", 2)
-	assert.Equal(t, expected, user.InheritedCollectionChannels(collection.ScopeName(), collection.Name()))
+	assert.Equal(t, expected, user.InheritedCollectionChannels(collection.ScopeName, collection.Name))
 }
 
 func TestDocIDs(t *testing.T) {
@@ -3075,8 +3075,8 @@ func TestGetDatabaseCollectionWithUserDefaultCollection(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, col)
-				require.Equal(t, col.ScopeName(), testCase.scope)
-				require.Equal(t, col.Name(), testCase.collection)
+				require.Equal(t, col.ScopeName, testCase.scope)
+				require.Equal(t, col.Name, testCase.collection)
 			}
 
 		})

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -36,8 +36,8 @@ func TestPublicChanGuestAccess(t *testing.T) {
 		})
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
-	c := collection.Name()
-	s := collection.ScopeName()
+	c := collection.Name
+	s := collection.ScopeName
 
 	// Create a document on the public channel
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc", `{"channels": ["!"], "foo": "bar"}`)
@@ -394,8 +394,8 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 				})
 			defer rt.Close()
 			collection := rt.GetSingleTestDatabaseCollection()
-			c := collection.Name()
-			s := collection.ScopeName()
+			c := collection.Name
+			s := collection.ScopeName
 
 			resp := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/Perms", GetUserPayload(t, "Perms", "password", "", collection, []string{"chan"}, nil))
 			RequireStatus(t, resp, http.StatusOK)
@@ -798,8 +798,8 @@ func TestChannelAccessChanges(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
-	c := collection.Name()
-	s := collection.ScopeName()
+	c := collection.Name
+	s := collection.ScopeName
 
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
@@ -1121,8 +1121,8 @@ func TestRoleChannelGrantInheritance(t *testing.T) {
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
 
 	collection := rt.GetDatabase().GetSingleDatabaseCollection()
-	scopeName := collection.ScopeName()
-	collectionName := collection.Name()
+	scopeName := collection.ScopeName
+	collectionName := collection.Name
 
 	user, err := a.GetUser("")
 	assert.NoError(t, err)

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -631,9 +631,9 @@ func (h *handler) handleGetCollectionConfigSync() error {
 		etagVersion = dbConfig.Version
 
 		if dbConfig.Scopes != nil {
-			scope, ok := dbConfig.Scopes[h.collection.ScopeName()]
+			scope, ok := dbConfig.Scopes[h.collection.ScopeName]
 			if ok {
-				collectionConfig, ok := scope.Collections[h.collection.Name()]
+				collectionConfig, ok := scope.Collections[h.collection.Name]
 				if ok && collectionConfig.SyncFn != nil {
 					syncFunction = *collectionConfig.SyncFn
 
@@ -672,10 +672,10 @@ func (h *handler) handleDeleteCollectionConfigSync() error {
 				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 			}
 			if bucketDbConfig.Scopes != nil {
-				config := bucketDbConfig.Scopes[h.collection.ScopeName()].Collections[h.collection.Name()]
+				config := bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name]
 				config.SyncFn = nil
-				bucketDbConfig.Scopes[h.collection.ScopeName()].Collections[h.collection.Name()] = config
-			} else if base.IsDefaultCollection(h.collection.ScopeName(), h.collection.Name()) {
+				bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name] = config
+			} else if base.IsDefaultCollection(h.collection.ScopeName, h.collection.Name) {
 				bucketDbConfig.Sync = nil
 			}
 
@@ -740,10 +740,10 @@ func (h *handler) handlePutCollectionConfigSync() error {
 			}
 
 			if bucketDbConfig.Scopes != nil {
-				config := bucketDbConfig.Scopes[h.collection.ScopeName()].Collections[h.collection.Name()]
+				config := bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name]
 				config.SyncFn = &js
-				bucketDbConfig.Scopes[h.collection.ScopeName()].Collections[h.collection.Name()] = config
-			} else if base.IsDefaultCollection(h.collection.ScopeName(), h.collection.Name()) {
+				bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name] = config
+			} else if base.IsDefaultCollection(h.collection.ScopeName, h.collection.Name) {
 				bucketDbConfig.Sync = &js
 			}
 
@@ -802,9 +802,9 @@ func (h *handler) handleGetCollectionConfigImportFilter() error {
 		}
 		etagVersion = dbConfig.Version
 		if dbConfig.Scopes != nil {
-			scope, ok := dbConfig.Scopes[h.collection.ScopeName()]
+			scope, ok := dbConfig.Scopes[h.collection.ScopeName]
 			if ok {
-				collectionConfig, ok := scope.Collections[h.collection.Name()]
+				collectionConfig, ok := scope.Collections[h.collection.Name]
 				if ok && collectionConfig.ImportFilter != nil {
 					importFilterFunction = *collectionConfig.ImportFilter
 
@@ -846,10 +846,10 @@ func (h *handler) handleDeleteCollectionConfigImportFilter() error {
 			}
 
 			if bucketDbConfig.Scopes != nil {
-				config := bucketDbConfig.Scopes[h.collection.ScopeName()].Collections[h.collection.Name()]
+				config := bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name]
 				config.ImportFilter = nil
-				bucketDbConfig.Scopes[h.collection.ScopeName()].Collections[h.collection.Name()] = config
-			} else if base.IsDefaultCollection(h.collection.ScopeName(), h.collection.Name()) {
+				bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name] = config
+			} else if base.IsDefaultCollection(h.collection.ScopeName, h.collection.Name) {
 				bucketDbConfig.ImportFilter = nil
 			}
 
@@ -914,10 +914,10 @@ func (h *handler) handlePutCollectionConfigImportFilter() error {
 			}
 
 			if bucketDbConfig.Scopes != nil {
-				config := bucketDbConfig.Scopes[h.collection.ScopeName()].Collections[h.collection.Name()]
+				config := bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name]
 				config.ImportFilter = &js
-				bucketDbConfig.Scopes[h.collection.ScopeName()].Collections[h.collection.Name()] = config
-			} else if base.IsDefaultCollection(h.collection.ScopeName(), h.collection.Name()) {
+				bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name] = config
+			} else if base.IsDefaultCollection(h.collection.ScopeName, h.collection.Name) {
 				bucketDbConfig.ImportFilter = &js
 			}
 

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -515,8 +515,8 @@ func TestCollectionsBasicIndexQuery(t *testing.T) {
 
 	// if the index was created on a collection, the keyspace_id becomes the collection, along with additional fields for bucket and scope.
 	assert.Equal(t, rt.Bucket().GetName(), *indexMetaResult.BucketID)
-	assert.Equal(t, collection.ScopeName(), *indexMetaResult.ScopeID)
-	assert.Equal(t, collection.Name(), *indexMetaResult.KeyspaceID)
+	assert.Equal(t, collection.ScopeName, *indexMetaResult.ScopeID)
+	assert.Equal(t, collection.Name, *indexMetaResult.KeyspaceID)
 
 	// try and query the document that we wrote via SG
 	res, err = n1qlStore.Query("SELECT test FROM "+base.KeyspaceQueryToken+" WHERE test = true", nil, base.RequestPlus, true)

--- a/rest/blip_api_collections_test.go
+++ b/rest/blip_api_collections_test.go
@@ -41,7 +41,7 @@ func TestBlipGetCollections(t *testing.T) {
 	checkpointID1 := "checkpoint1"
 	checkpoint1Body := db.Body{"seq": "123"}
 	collection := rt.GetSingleTestDatabaseCollection()
-	scopeAndCollection := fmt.Sprintf("%s.%s", collection.ScopeName(), collection.Name())
+	scopeAndCollection := fmt.Sprintf("%s.%s", collection.ScopeName, collection.Name)
 	revID, err := collection.PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
 	require.NoError(t, err)
 	checkpoint1RevID := "0-1"
@@ -192,7 +192,7 @@ func TestBlipGetCollectionsAndSetCheckpoint(t *testing.T) {
 	require.Equal(t, checkpoint1RevID, revID)
 	getCollectionsRequest, err := db.NewGetCollectionsMessage(db.GetCollectionsRequestBody{
 		CheckpointIDs: []string{checkpointID1},
-		Collections:   []string{fmt.Sprintf("%s.%s", collection.ScopeName(), collection.Name())},
+		Collections:   []string{fmt.Sprintf("%s.%s", collection.ScopeName, collection.Name)},
 	})
 
 	require.NoError(t, err)

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -502,11 +502,11 @@ func getCollectionsForBLIP(_ testing.TB, rt *RestTester) []string {
 	db := rt.GetDatabase()
 	var collections []string
 	for _, collection := range db.CollectionByID {
-		if base.IsDefaultCollection(collection.ScopeName(), collection.Name()) {
+		if base.IsDefaultCollection(collection.ScopeName, collection.Name) {
 			continue
 		}
 		collections = append(collections,
-			strings.Join([]string{collection.ScopeName(), collection.Name()}, base.ScopeCollectionSeparator))
+			strings.Join([]string{collection.ScopeName, collection.Name}, base.ScopeCollectionSeparator))
 	}
 	return collections
 }
@@ -599,7 +599,7 @@ func (btc *BlipTesterClient) initCollectionReplication(collection string, collec
 func (btc *BlipTesterClient) waitForReplicationMessage(collection *db.DatabaseCollection, serialNumber blip.MessageNumber) (*blip.Message, bool) {
 	var msg *blip.Message
 	var ok bool
-	if base.IsDefaultCollection(collection.ScopeName(), collection.Name()) {
+	if base.IsDefaultCollection(collection.ScopeName, collection.Name) {
 		msg, ok = btc.pushReplication.WaitForMessage(serialNumber)
 	} else {
 		msg, ok = btc.pushReplication.WaitForMessage(serialNumber + 1)

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -56,7 +56,7 @@ func (h *handler) handleAllDocs() error {
 	// Get the set of channels the user has access to; nil if user is admin or has access to user "*"
 	var availableChannels ch.TimedSet
 	if h.user != nil {
-		availableChannels = h.user.InheritedCollectionChannels(h.collection.ScopeName(), h.collection.Name())
+		availableChannels = h.user.InheritedCollectionChannels(h.collection.ScopeName, h.collection.Name)
 		if availableChannels == nil {
 			// TODO: CBG-1948
 			panic("no channels for user?")

--- a/rest/jwt_auth_test.go
+++ b/rest/jwt_auth_test.go
@@ -454,8 +454,8 @@ func TestLocalJWTRolesChannels(t *testing.T) {
 	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 	collection := restTester.GetSingleTestDatabaseCollection()
-	c := collection.Name()
-	s := collection.ScopeName()
+	c := collection.Name
+	s := collection.ScopeName
 
 	token := auth.CreateTestJWT(t, jose.RS256, testRSAKeypair, auth.JWTHeaders{
 		"alg": jose.RS256,

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -1086,7 +1086,7 @@ func checkGoodAuthResponse(t *testing.T, rt *RestTester, response *http.Response
 	sessionCookie := getCookie(response.Cookies(), auth.DefaultCookieName)
 	require.NotNil(t, sessionCookie, "No session cookie found")
 	require.NoError(t, response.Body.Close(), "error closing response body")
-	if base.IsDefaultCollection(collection.ScopeName(), collection.Name()) {
+	if base.IsDefaultCollection(collection.ScopeName, collection.Name) {
 		responseBodyExpected = map[string]interface{}{
 			"authentication_handlers": []interface{}{
 				"default", "cookie",

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1314,8 +1314,8 @@ func TestChannelHistoryPruning(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
-	c := collection.Name()
-	s := collection.ScopeName()
+	c := collection.Name
+	s := collection.ScopeName
 
 	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "a")

--- a/rest/role_api_test.go
+++ b/rest/role_api_test.go
@@ -237,8 +237,8 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 		&rtConfig)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
-	c := collection.Name()
-	s := collection.ScopeName()
+	c := collection.Name
+	s := collection.ScopeName
 
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
@@ -289,8 +289,8 @@ func TestRoleAccessChanges(t *testing.T) {
 		&rtConfig)
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
-	c := collection.Name()
-	s := collection.ScopeName()
+	c := collection.Name
+	s := collection.ScopeName
 
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -269,8 +269,8 @@ func TestUserAPI(t *testing.T) {
 	defer rt.Close()
 	ctx := rt.Context()
 	collection := rt.GetSingleTestDatabaseCollection()
-	c := collection.Name()
-	s := collection.ScopeName()
+	c := collection.Name
+	s := collection.ScopeName
 
 	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/snej", ""), 404)
 
@@ -641,8 +641,8 @@ func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
 				})
 			defer rt.Close()
 			collection := rt.GetSingleTestDatabaseCollection()
-			c := collection.Name()
-			s := collection.ScopeName()
+			c := collection.Name
+			s := collection.ScopeName
 
 			// Create role
 			resp := rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", "", collection, []string{"channel"}))

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -463,8 +463,8 @@ func (rt *RestTester) GetSingleTestDatabaseCollectionWithUser() *db.DatabaseColl
 func (rt *RestTester) GetSingleDataStore() base.DataStore {
 	collection := rt.GetSingleTestDatabaseCollection()
 	ds, err := rt.GetDatabase().Bucket.NamedDataStore(base.ScopeAndCollectionName{
-		Scope:      collection.ScopeName(),
-		Collection: collection.Name(),
+		Scope:      collection.ScopeName,
+		Collection: collection.Name,
 	})
 	require.NoError(rt.TB, err)
 	return ds
@@ -1502,14 +1502,14 @@ func GetRolePayload(t *testing.T, roleName, password string, collection *db.Data
 
 // add channels to principal depending if running with collections or not. then marshal the principal config
 func addChannelsToPrincipal(config auth.PrincipalConfig, collection *db.DatabaseCollection, chans []string) ([]byte, error) {
-	if base.IsDefaultCollection(collection.ScopeName(), collection.Name()) {
+	if base.IsDefaultCollection(collection.ScopeName, collection.Name) {
 		if len(chans) == 0 {
 			config.ExplicitChannels = base.SetOf("[]")
 		} else {
 			config.ExplicitChannels = base.SetFromArray(chans)
 		}
 	} else {
-		config.SetExplicitChannels(collection.ScopeName(), collection.Name(), chans...)
+		config.SetExplicitChannels(collection.ScopeName, collection.Name, chans...)
 	}
 	payload, err := json.Marshal(config)
 	if err != nil {
@@ -2242,13 +2242,13 @@ func (sc *ServerContext) suspendDatabase(t *testing.T, ctx context.Context, dbNa
 
 // getRESTkeyspace returns a keyspace for REST URIs
 func getRESTKeyspace(_ testing.TB, dbName string, collection *db.DatabaseCollection) string {
-	if base.IsDefaultCollection(collection.ScopeName(), collection.Name()) {
+	if base.IsDefaultCollection(collection.ScopeName, collection.Name) {
 		// for backwards compatibility (and user-friendliness),
 		// we can optionally just use `/db/` instead of `/db._default._default/`
 		// Return this format to get coverage of both formats.
 		return dbName
 	}
-	return strings.Join([]string{dbName, collection.ScopeName(), collection.Name()}, base.ScopeCollectionSeparator)
+	return strings.Join([]string{dbName, collection.ScopeName, collection.Name}, base.ScopeCollectionSeparator)
 }
 
 // GetKeyspaces returns the names of all the keyspaces on the rest tester. Currently assumes a single database.
@@ -2282,7 +2282,7 @@ func (rt *RestTester) getCollectionsForBLIP() []string {
 	}
 	for _, collection := range db.CollectionByID {
 		collections = append(collections,
-			strings.Join([]string{collection.ScopeName(), collection.Name()}, base.ScopeCollectionSeparator))
+			strings.Join([]string{collection.ScopeName, collection.Name}, base.ScopeCollectionSeparator))
 	}
 	return collections
 }


### PR DESCRIPTION
Use attr instead of function to make it clear this is a cheap operation.

Change the name of some receiver methods from `db` -> `col`.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1458/
