### PR TITLE
CBG-2691 use max value given for highseqnos from each node

### DIFF
--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -161,7 +161,9 @@ func (dc *DCPClient) getCollectionHighSeqNos(collectionID uint32) ([]uint64, err
 		highSeqNoCallback := func(entries []gocbcore.VbSeqNoEntry, err error) {
 			if err == nil {
 				for _, entry := range entries {
-					highSeqNos[entry.VbID] = uint64(entry.SeqNo)
+					if highSeqNos[entry.VbID] < uint64(entry.SeqNo) {
+						highSeqNos[entry.VbID] = uint64(entry.SeqNo)
+					}
 				}
 			}
 			highSeqNoError <- err


### PR DESCRIPTION
## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

(Tested manually, don't have code in jenkins to do multi node clusters yet.)