### PR TITLE
CBG-2633: TestMultiCollectionChangesMultipleChannels

### DIFF
--- a/rest/changestest/changes_collection_test.go
+++ b/rest/changestest/changes_collection_test.go
@@ -292,9 +292,9 @@ func TestMultiCollectionChangesMultiChannelOneShot(t *testing.T) {
 	changesResponse = rt.GetChangesOneShot(t, "keyspace2", 0, "BRNchr", 3) // 2 docs in BRN, 1 doc in CHR in collection 2
 	logChangesResponse(t, changesResponse.Body.Bytes())
 
-	rt.AssertChangesFeedMultiCollection(t, "bernard", "continuous", 2, []int{4, 2}, 500)
-	rt.AssertChangesFeedMultiCollection(t, "charlie", "continuous", 2, []int{3, 1}, 500)
-	rt.AssertChangesFeedMultiCollection(t, "BRNchr", "continuous", 2, []int{7, 3}, 1000)
+	rt.RequireContinuousFeedChangesCount(t, "bernard", "continuous", 2, []int{4, 2}, 500)
+	rt.RequireContinuousFeedChangesCount(t, "charlie", "continuous", 2, []int{3, 1}, 500)
+	rt.RequireContinuousFeedChangesCount(t, "BRNchr", "continuous", 2, []int{7, 3}, 1000)
 }
 
 // TestMultiCollectionChangesUserDynamicGrant tests a dynamic channel grant when that channel is not already resident

--- a/rest/changestest/changes_collection_test.go
+++ b/rest/changestest/changes_collection_test.go
@@ -283,7 +283,7 @@ func TestMultiCollectionChangesMultipleChannels(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		changesResponse = rt.SendUserRequest("GET", "/{{.keyspace1}}/_changes?feed=continuous&timeout=5000", "", "bernard")
+		changesResponse = rt.SendUserRequest("GET", "/{{.keyspace1}}/_changes?feed=continuous&timeout=2000", "", "bernard")
 		rest.RequireStatus(t, changesResponse, 200)
 		contChanges, err := rt.ReadContinuousChanges(changesResponse)
 		assert.NoError(t, err)
@@ -301,6 +301,8 @@ func TestMultiCollectionChangesMultipleChannels(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace1}}/chr4_c1", `{"value":1, "channels":["CHR"]}`)
 	rest.RequireStatus(t, response, 201)
+	_ = rt.WaitForPendingChanges()
+
 	wg.Wait()
 }
 

--- a/rest/changestest/changes_collection_test.go
+++ b/rest/changestest/changes_collection_test.go
@@ -282,7 +282,7 @@ func TestMultiCollectionChangesMultiChannelOneShot(t *testing.T) {
 	// Changes that shouldn't be caught by the continuous changes feed
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace2}}/brn4_c1", `{"value":1, "channels":["BRN"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/{{.keyspace1}}/chr4_c1", `{"value":1, "channels":["CHR"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace1}}/chr3_c1", `{"value":1, "channels":["CHR"]}`)
 	rest.RequireStatus(t, response, 201)
 	_ = rt.WaitForPendingChanges()
 
@@ -292,6 +292,9 @@ func TestMultiCollectionChangesMultiChannelOneShot(t *testing.T) {
 	changesResponse = rt.GetChangesOneShot(t, "keyspace2", 0, "BRNchr", 3) // 2 docs in BRN, 1 doc in CHR in collection 2
 	logChangesResponse(t, changesResponse.Body.Bytes())
 
+	rt.AssertChangesFeedMultiCollection(t, "bernard", "continuous", 2, []int{4, 2}, 500) // 2 docs in BRN, 1 doc in CHR in collection 2
+	rt.AssertChangesFeedMultiCollection(t, "charlie", "continuous", 2, []int{3, 1}, 500) // 2 docs in BRN, 1 doc in CHR in collection 2
+	rt.AssertChangesFeedMultiCollection(t, "BRNchr", "continuous", 2, []int{7, 3}, 1000) // 2 docs in BRN, 1 doc in CHR in collection 2
 }
 
 // TestMultiCollectionChangesUserDynamicGrant tests a dynamic channel grant when that channel is not already resident

--- a/rest/changestest/changes_collection_test.go
+++ b/rest/changestest/changes_collection_test.go
@@ -264,6 +264,8 @@ func TestMultiCollectionChangesMultipleChannels(t *testing.T) {
 
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace1}}/brn3_c1", `{"value":1, "channels":["BRN"]}`)
 	rest.RequireStatus(t, response, 201)
+	_ = rt.WaitForPendingChanges()
+
 	changesResponse = rt.SendUserRequest("GET", fmt.Sprintf("/{{.keyspace1}}/_changes?since=%s", lastSeqBRN), "", "bernard")
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
@@ -281,7 +283,7 @@ func TestMultiCollectionChangesMultipleChannels(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		changesResponse = rt.SendUserRequest("GET", "/{{.keyspace1}}/_changes?feed=continuous&timeout=2000", "", "bernard")
+		changesResponse = rt.SendUserRequest("GET", "/{{.keyspace1}}/_changes?feed=continuous&timeout=5000", "", "bernard")
 		rest.RequireStatus(t, changesResponse, 200)
 		contChanges, err := rt.ReadContinuousChanges(changesResponse)
 		assert.NoError(t, err)

--- a/rest/changestest/changes_collection_test.go
+++ b/rest/changestest/changes_collection_test.go
@@ -292,9 +292,9 @@ func TestMultiCollectionChangesMultiChannelOneShot(t *testing.T) {
 	changesResponse = rt.GetChangesOneShot(t, "keyspace2", 0, "BRNchr", 3) // 2 docs in BRN, 1 doc in CHR in collection 2
 	logChangesResponse(t, changesResponse.Body.Bytes())
 
-	rt.AssertChangesFeedMultiCollection(t, "bernard", "continuous", 2, []int{4, 2}, 500) // 2 docs in BRN, 1 doc in CHR in collection 2
-	rt.AssertChangesFeedMultiCollection(t, "charlie", "continuous", 2, []int{3, 1}, 500) // 2 docs in BRN, 1 doc in CHR in collection 2
-	rt.AssertChangesFeedMultiCollection(t, "BRNchr", "continuous", 2, []int{7, 3}, 1000) // 2 docs in BRN, 1 doc in CHR in collection 2
+	rt.AssertChangesFeedMultiCollection(t, "bernard", "continuous", 2, []int{4, 2}, 500)
+	rt.AssertChangesFeedMultiCollection(t, "charlie", "continuous", 2, []int{3, 1}, 500)
+	rt.AssertChangesFeedMultiCollection(t, "BRNchr", "continuous", 2, []int{7, 3}, 1000)
 }
 
 // TestMultiCollectionChangesUserDynamicGrant tests a dynamic channel grant when that channel is not already resident

--- a/rest/changestest/changes_collection_test.go
+++ b/rest/changestest/changes_collection_test.go
@@ -283,7 +283,7 @@ func TestMultiCollectionChangesMultipleChannels(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		changesResponse = rt.SendUserRequest("GET", "/{{.keyspace1}}/_changes?feed=continuous&timeout=2000", "", "bernard")
+		changesResponse = rt.SendUserRequest("GET", "/{{.keyspace1}}/_changes?feed=continuous&timeout=5000", "", "bernard")
 		rest.RequireStatus(t, changesResponse, 200)
 		contChanges, err := rt.ReadContinuousChanges(changesResponse)
 		assert.NoError(t, err)

--- a/rest/changestest/changes_collection_test.go
+++ b/rest/changestest/changes_collection_test.go
@@ -270,9 +270,13 @@ func TestMultiCollectionChangesMultiChannelOneShot(t *testing.T) {
 	changesResponse = rt.GetChangesOneShot(t, "keyspace2", 0, "BRNchr", 3) // 2 docs in BRN, 1 doc in CHR in collection 2
 	logChangesResponse(t, changesResponse.Body.Bytes())
 
-	rt.RequireContinuousFeedChangesCount(t, "bernard", 2, []int{4, 2}, 500)
-	rt.RequireContinuousFeedChangesCount(t, "charlie", 2, []int{3, 1}, 500)
-	rt.RequireContinuousFeedChangesCount(t, "BRNchr", 2, []int{7, 3}, 1000)
+	rt.RequireContinuousFeedChangesCount(t, "bernard", 1, 4, 500)
+	rt.RequireContinuousFeedChangesCount(t, "bernard", 2, 2, 500)
+
+	rt.RequireContinuousFeedChangesCount(t, "charlie", 1, 3, 500)
+	rt.RequireContinuousFeedChangesCount(t, "charlie", 2, 1, 500)
+	rt.RequireContinuousFeedChangesCount(t, "BRNchr", 1, 7, 1000)
+	rt.RequireContinuousFeedChangesCount(t, "BRNchr", 2, 3, 1000)
 }
 
 // TestMultiCollectionChangesUserDynamicGrant tests a dynamic channel grant when that channel is not already resident

--- a/rest/changestest/changes_collection_test.go
+++ b/rest/changestest/changes_collection_test.go
@@ -292,9 +292,9 @@ func TestMultiCollectionChangesMultiChannelOneShot(t *testing.T) {
 	changesResponse = rt.GetChangesOneShot(t, "keyspace2", 0, "BRNchr", 3) // 2 docs in BRN, 1 doc in CHR in collection 2
 	logChangesResponse(t, changesResponse.Body.Bytes())
 
-	rt.RequireContinuousFeedChangesCount(t, "bernard", "continuous", 2, []int{4, 2}, 500)
-	rt.RequireContinuousFeedChangesCount(t, "charlie", "continuous", 2, []int{3, 1}, 500)
-	rt.RequireContinuousFeedChangesCount(t, "BRNchr", "continuous", 2, []int{7, 3}, 1000)
+	rt.RequireContinuousFeedChangesCount(t, "bernard", 2, []int{4, 2}, 500)
+	rt.RequireContinuousFeedChangesCount(t, "charlie", 2, []int{3, 1}, 500)
+	rt.RequireContinuousFeedChangesCount(t, "BRNchr", 2, []int{7, 3}, 1000)
 }
 
 // TestMultiCollectionChangesUserDynamicGrant tests a dynamic channel grant when that channel is not already resident

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -9,11 +9,8 @@
 package rest
 
 import (
-	"bufio"
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"sort"
@@ -914,7 +911,7 @@ function(doc, oldDoc) {
 			log.Printf("Invoking _changes?feed=continuous&since=%s&timeout=2000", since)
 			changesResponse := rt.SendUserRequest("GET", fmt.Sprintf("/{{.keyspace}}/_changes?feed=continuous&since=%s&timeout=2000", since), "", "bernard")
 
-			changes, err := readContinuousChanges(changesResponse)
+			changes, err := rt.ReadContinuousChanges(changesResponse)
 			assert.NoError(t, err)
 
 			changesAccumulated = append(changesAccumulated, changes...)
@@ -997,7 +994,7 @@ func TestUserDeleteDuringChangesWithAccess(t *testing.T) {
 		} else {
 			// case 2 - ensure no error processing the changes response.  The number of entries may vary, depending
 			// on whether the changes loop performed an additional iteration before catching the deleted user.
-			_, err := readContinuousChanges(changesResponse)
+			_, err := rt.ReadContinuousChanges(changesResponse)
 			assert.NoError(t, err)
 		}
 	}()
@@ -1074,34 +1071,6 @@ func validateUsersNameOnlyFalse(t *testing.T, rt *RestTester) {
 	}
 }
 
-// Reads continuous changes feed response into slice of ChangeEntry
-func readContinuousChanges(response *TestResponse) ([]db.ChangeEntry, error) {
-	var change db.ChangeEntry
-	changes := make([]db.ChangeEntry, 0)
-	reader := bufio.NewReader(response.Body)
-	for {
-		entry, readError := reader.ReadBytes('\n')
-		if readError == io.EOF {
-			// done
-			break
-		}
-		if readError != nil {
-			// unexpected read error
-			return changes, readError
-		}
-		entry = bytes.TrimSpace(entry)
-		if len(entry) > 0 {
-			err := base.JSONUnmarshal(entry, &change)
-			if err != nil {
-				return changes, err
-			}
-			changes = append(changes, change)
-			log.Printf("Got change ==> %v", change)
-		}
-
-	}
-	return changes, nil
-}
 func TestFunkyUsernames(t *testing.T) {
 	cases := []struct {
 		Name     string

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2317,26 +2317,6 @@ func (rt *RestTester) ReadContinuousChanges(response *TestResponse) ([]db.Change
 	return changes, nil
 }
 
-// GetNextContinousChange reads the next changes entry from the feed.
-func GetNextContinuousChange(reader *bufio.Reader) (*db.ChangeEntry, error) {
-	var change *db.ChangeEntry
-	for {
-		entry, readError := reader.ReadBytes('\n')
-		if readError != nil {
-			return nil, readError
-		}
-		entry = bytes.TrimSpace(entry)
-		if len(entry) > 0 {
-			err := base.JSONUnmarshal(entry, &change)
-			if err != nil {
-				return nil, err
-			}
-			log.Printf("Got change ==> %v", change)
-			return change, nil
-		}
-	}
-}
-
 // RequireContinuousFeedChangesCount Calls a changes feed on every collection and asserts that the nth expected change is
 // the number of changes for the nth collection.
 func (rt *RestTester) RequireContinuousFeedChangesCount(t testing.TB, username string, numKeyspaces int, expectedChanges []int, timeout int) {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2304,6 +2304,7 @@ func (rt *RestTester) ReadContinuousChanges(response *TestResponse) ([]db.Change
 			return changes, readError
 		}
 		entry = bytes.TrimSpace(entry)
+		fmt.Println("HONK", entry)
 		if len(entry) > 0 {
 			err := base.JSONUnmarshal(entry, &change)
 			if err != nil {
@@ -2315,4 +2316,25 @@ func (rt *RestTester) ReadContinuousChanges(response *TestResponse) ([]db.Change
 
 	}
 	return changes, nil
+}
+
+// GetNextContinousChange reads the next changes entry from the feed.
+func GetNextContinuousChange(reader *bufio.Reader) (*db.ChangeEntry, error) {
+	var change *db.ChangeEntry
+	for {
+		entry, readError := reader.ReadBytes('\n')
+		if readError != nil {
+			return nil, readError
+		}
+		entry = bytes.TrimSpace(entry)
+		if len(entry) > 0 {
+			err := base.JSONUnmarshal(entry, &change)
+			if err != nil {
+				return nil, err
+			}
+			log.Printf("Got change ==> %v", change)
+			return change, nil
+		}
+	}
+	return nil, fmt.Errorf("Did not find body")
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2304,7 +2304,6 @@ func (rt *RestTester) ReadContinuousChanges(response *TestResponse) ([]db.Change
 			return changes, readError
 		}
 		entry = bytes.TrimSpace(entry)
-		fmt.Println("HONK", entry)
 		if len(entry) > 0 {
 			err := base.JSONUnmarshal(entry, &change)
 			if err != nil {
@@ -2336,4 +2335,16 @@ func GetNextContinuousChange(reader *bufio.Reader) (*db.ChangeEntry, error) {
 			return change, nil
 		}
 	}
+}
+
+func (rt *RestTester) GetChangesOneShot(t testing.TB, keyspace string, since int, username string, changesCount int) *TestResponse {
+	var changes struct {
+		Results []db.ChangeEntry
+		LastSeq db.SequenceID
+	}
+	changesResponse := rt.SendUserRequest("GET", fmt.Sprintf("/{{.%s}}/_changes?since=%s", keyspace, since), "", username)
+	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Len(t, changes.Results, changesCount)
+	return changesResponse
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1018,6 +1018,13 @@ func (r TestResponse) GetRestDocument() RestDocument {
 	return *restDoc
 }
 
+//func (r TestResponse) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+//	h, ok := r.Req.Response.(http.Hijacker)
+//	if !ok {
+//		return nil, nil, errors.New("hijack not supported")
+//	}
+//	return h.Hijack()
+//}
 func Request(method, resource, body string) *http.Request {
 	request, err := http.NewRequest(method, "http://localhost"+resource, bytes.NewBufferString(body))
 	request.RequestURI = resource // This doesn't get filled in by NewRequest

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1018,13 +1018,6 @@ func (r TestResponse) GetRestDocument() RestDocument {
 	return *restDoc
 }
 
-//func (r TestResponse) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-//	h, ok := r.Req.Response.(http.Hijacker)
-//	if !ok {
-//		return nil, nil, errors.New("hijack not supported")
-//	}
-//	return h.Hijack()
-//}
 func Request(method, resource, body string) *http.Request {
 	request, err := http.NewRequest(method, "http://localhost"+resource, bytes.NewBufferString(body))
 	request.RequestURI = resource // This doesn't get filled in by NewRequest

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2337,16 +2337,11 @@ func GetNextContinuousChange(reader *bufio.Reader) (*db.ChangeEntry, error) {
 	}
 }
 
-var changes struct {
-	Results []db.ChangeEntry
-	LastSeq db.SequenceID
-}
-
-// AssertChangesFeedMultiCollection Calls a changes feed on every collection and asserts that the nth expected change is
+// RequireContinuousFeedChangesCount Calls a changes feed on every collection and asserts that the nth expected change is
 // the number of changes for the nth collection.
-func (rt *RestTester) AssertChangesFeedMultiCollection(t testing.TB, username string, feedMode string, numKeyspaces int, expectedChanges []int, timeout int) {
+func (rt *RestTester) RequireContinuousFeedChangesCount(t testing.TB, username string, numKeyspaces int, expectedChanges []int, timeout int) {
 	for i := 1; i <= numKeyspaces; i++ {
-		resp := rt.SendUserRequest("GET", fmt.Sprintf("/{{.keyspace%d}}/_changes?feed=%s&timeout=%d", i, feedMode, timeout), "", username)
+		resp := rt.SendUserRequest("GET", fmt.Sprintf("/{{.keyspace%d}}/_changes?feed=continuous&timeout=%d", i, timeout), "", username)
 		changes, err := rt.ReadContinuousChanges(resp)
 		assert.NoError(t, err)
 		require.Len(t, changes, expectedChanges[i-1])
@@ -2355,6 +2350,7 @@ func (rt *RestTester) AssertChangesFeedMultiCollection(t testing.TB, username st
 
 func (rt *RestTester) GetChangesOneShot(t testing.TB, keyspace string, since int, username string, changesCount int) *TestResponse {
 	changesResponse := rt.SendUserRequest("GET", fmt.Sprintf("/{{.%s}}/_changes?since=%d", keyspace, since), "", username)
+	var changes ChangesResults
 	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, changesCount)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2336,5 +2336,4 @@ func GetNextContinuousChange(reader *bufio.Reader) (*db.ChangeEntry, error) {
 			return change, nil
 		}
 	}
-	return nil, fmt.Errorf("Did not find body")
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2342,7 +2342,7 @@ func (rt *RestTester) GetChangesOneShot(t testing.TB, keyspace string, since int
 		Results []db.ChangeEntry
 		LastSeq db.SequenceID
 	}
-	changesResponse := rt.SendUserRequest("GET", fmt.Sprintf("/{{.%s}}/_changes?since=%s", keyspace, since), "", username)
+	changesResponse := rt.SendUserRequest("GET", fmt.Sprintf("/{{.%s}}/_changes?since=%d", keyspace, since), "", username)
 	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, changesCount)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2319,13 +2319,11 @@ func (rt *RestTester) ReadContinuousChanges(response *TestResponse) ([]db.Change
 
 // RequireContinuousFeedChangesCount Calls a changes feed on every collection and asserts that the nth expected change is
 // the number of changes for the nth collection.
-func (rt *RestTester) RequireContinuousFeedChangesCount(t testing.TB, username string, numKeyspaces int, expectedChanges []int, timeout int) {
-	for i := 1; i <= numKeyspaces; i++ {
-		resp := rt.SendUserRequest("GET", fmt.Sprintf("/{{.keyspace%d}}/_changes?feed=continuous&timeout=%d", i, timeout), "", username)
-		changes, err := rt.ReadContinuousChanges(resp)
-		assert.NoError(t, err)
-		require.Len(t, changes, expectedChanges[i-1])
-	}
+func (rt *RestTester) RequireContinuousFeedChangesCount(t testing.TB, username string, keyspace int, expectedChanges int, timeout int) {
+	resp := rt.SendUserRequest("GET", fmt.Sprintf("/{{.keyspace%d}}/_changes?feed=continuous&timeout=%d", keyspace, timeout), "", username)
+	changes, err := rt.ReadContinuousChanges(resp)
+	assert.NoError(t, err)
+	require.Len(t, changes, expectedChanges)
 }
 
 func (rt *RestTester) GetChangesOneShot(t testing.TB, keyspace string, since int, username string, changesCount int) *TestResponse {


### PR DESCRIPTION
CBG-2633

Describe your PR here...
- TestMultiCollectionChangesMultipleChannels adds coverage for changes feeds (one shot, continuous) with multiple collections

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1496/

I ran the test 10 times on jenkins with -race to see if its potentially flakey due to the continuous feed goroutine.