### PR TITLE
CBG-2683 Validate metadatastore name

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3084,13 +3084,6 @@ func TestGetDatabaseCollectionWithUserDefaultCollection(t *testing.T) {
 
 }
 
-func TestValidateMetadataStore(t *testing.T) {
-	ctx := base.TestCtx(t)
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
-	require.NoError(t, validateMetadataStore(ctx, bucket.DefaultDataStore()))
-}
-
 func waitAndAssertConditionWithOptions(t *testing.T, fn func() bool, retryCount, msSleepTime int, failureMsgAndArgs ...interface{}) {
 	for i := 0; i <= retryCount; i++ {
 		if i == retryCount {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3084,6 +3084,13 @@ func TestGetDatabaseCollectionWithUserDefaultCollection(t *testing.T) {
 
 }
 
+func TestValidateMetadataStore(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+	require.NoError(t, validateMetadataStore(ctx, bucket.DefaultDataStore()))
+}
+
 func waitAndAssertConditionWithOptions(t *testing.T, fn func() bool, retryCount, msSleepTime int, failureMsgAndArgs ...interface{}) {
 	for i := 0; i <= retryCount; i++ {
 		if i == retryCount {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -615,6 +615,10 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	// Once system scope/collection is well-supported, and we have a migration path, we can consider using those.
 	// contextOptions.MetadataStore = bucket.NamedDataStore(base.ScopeAndCollectionName{base.MobileMetadataScope, base.MobileMetadataCollection})
 	contextOptions.MetadataStore = bucket.DefaultDataStore()
+	err = validateMetadataStore(ctx, contextOptions.MetadataStore)
+	if err != nil {
+		return nil, err
+	}
 
 	// Create the DB Context
 	dbcontext, err := db.NewDatabaseContext(ctx, dbName, bucket, autoImport, contextOptions)
@@ -1001,6 +1005,24 @@ func (sc *ServerContext) TakeDbOnline(nonContextStruct base.NonCancellableContex
 		base.InfofCtx(nonContextStruct.Ctx, base.KeyCRUD, "Unable to take Database : %v online , database must be in Offline state", base.UD(database.Name))
 	}
 
+}
+
+// validateMetadataStore will
+func validateMetadataStore(ctx context.Context, metadataStore base.DataStore) error {
+	// Check if scope/collection specified exists. Will enter retry loop if connection unsuccessful
+	err := base.WaitUntilDataStoreExists(metadataStore)
+	if err == nil {
+		return nil
+	}
+	metadataStoreName, ok := base.AsDataStoreName(metadataStore)
+	if ok {
+		keyspace := strings.Join([]string{metadataStore.GetName(), metadataStoreName.ScopeName(), metadataStoreName.CollectionName()}, base.ScopeCollectionSeparator)
+		if base.IsDefaultCollection(metadataStoreName.ScopeName(), metadataStoreName.CollectionName()) {
+			base.WarnfCtx(ctx, "_default._default has been deleted from the server for bucket %s, to recover recreate the bucket", metadataStore.GetName())
+		}
+		return fmt.Errorf("metadata store %s does not exist on couchbase server: %w", base.MD(keyspace), err)
+	}
+	return fmt.Errorf("metadata store %s does not exist on couchbase server: %w", base.MD(metadataStore.GetName()), err)
 }
 
 // validateEventConfigOptions returns errors for all invalid event type options.

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -751,3 +751,10 @@ func TestLogFlush(t *testing.T) {
 	}
 
 }
+
+func TestValidateMetadataStore(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+	require.NoError(t, validateMetadataStore(ctx, bucket.DefaultDataStore()))
+}


### PR DESCRIPTION
- I'm not sure what the redaction should be here, we would use base.MD(dbName), but this only occurs on an update of the database where they presumably already have access to this information.
- Should we retry a KV op, or should I explicitly check reason as KV_COLLECTION_OUTDATED? I'm not sure if that's always going to show up.
- There's not an obvious way for me to test the negative version of this.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1473/
