### PR TITLE
change go version and compress version for 3.0.5 build

### DIFF
--- a/manifest/3.0.xml
+++ b/manifest/3.0.xml
@@ -157,6 +157,6 @@ licenses/APL2.txt.
   <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
 
   <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
-  <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="b8a3c6140400c11b62877a800d0aa3ee755e89ea"/>
+  <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="4b4f3c94fdf8c3a6c725e2ff110d9b44f88823ed"/>
 
 </manifest>

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -385,7 +385,7 @@
             "release_name": "Couchbase Sync Gateway 3.0.5",
             "production": true,
             "interval": 120,
-            "go_version": "1.16.6",
+            "go_version": "1.16.15",
             "trigger_blackduck": true,
             "start_build": 1
         },

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -385,7 +385,7 @@
             "release_name": "Couchbase Sync Gateway 3.0.5",
             "production": true,
             "interval": 120,
-            "go_version": "1.19.5",
+            "go_version": "1.16.6",
             "trigger_blackduck": true,
             "start_build": 1
         },


### PR DESCRIPTION
CBG-0000

Change go version to 1.16.15 and change compress library version to 1.15.9 to be compatible with 1.16 version go. Compress version here is now 1.15.9

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
