### PR TITLE
change go versions and compress version for 2.8.4 build

### DIFF
--- a/manifest/2.8.xml
+++ b/manifest/2.8.xml
@@ -158,6 +158,6 @@ licenses/APL2.txt.
     <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="1ecb1f411c1f2ce65a2db6ea4a8ae927182d342e"/>
 
     <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
-    <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="b8a3c6140400c11b62877a800d0aa3ee755e89ea"/>
+    <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="4b4f3c94fdf8c3a6c725e2ff110d9b44f88823ed"/>
 
 </manifest>

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -317,7 +317,7 @@
             "release_name": "Couchbase Sync Gateway 2.8.4",
             "production": true,
             "interval": 120,
-            "go_version": "1.19.5",
+            "go_version": "1.16.15",
             "trigger_blackduck": true,
             "start_build": 1
         },


### PR DESCRIPTION
CBG-0000

Roll back compress verison to a version compatible with go 1.26. Also change go version for the build to 1.16.15 
Compress version here is now 1.15.9

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
