### PR TITLE
Allow renaming databases in rest tester

### DIFF
--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2633,7 +2633,7 @@ func TestUpdateExistingAttachment(t *testing.T) {
 	defer rt.Close()
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer btc.Close()
 
 	var doc1Body db.Body

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -32,8 +32,10 @@ import (
 func TestActiveReplicatorBlipsync(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyHTTPResp)
 
+	passiveDBName := "passivedb"
 	rt := NewRestTesterDefaultCollection(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			Name: passiveDBName,
 			Users: map[string]*auth.PrincipalConfig{
 				"alice": {Password: base.StringPtr("pass")},
 			},
@@ -46,7 +48,7 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 	srv := httptest.NewServer(rt.TestPublicHandler())
 	defer srv.Close()
 
-	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	passiveDBURL, err := url.Parse(srv.URL + "/" + passiveDBName)
 	require.NoError(t, err)
 
 	// Add basic auth creds to target db URL


### PR DESCRIPTION
Allow customization of db name, which is great for replication tests, so log lines are can be prefaced with `activedb` or `passivedb` and you can spot the differences.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1475/
