### PR TITLE
Avoid logging error on startup of test harness

### DIFF
--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -245,7 +245,7 @@ func (c *Collection) IsErrNoResults(err error) bool {
 	return err == gocb.ErrNoResult
 }
 
-func (c *Collection) getIndexes() (indexes []string, err error) {
+func (c *Collection) GetIndexes() (indexes []string, err error) {
 
 	indexes = []string{}
 	var opts *gocb.GetAllQueryIndexesOptions

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -57,7 +57,7 @@ type N1QLStore interface {
 	executeStatement(statement string) error
 
 	// getIndexes retrieves all index names, used by test harness
-	getIndexes() (indexes []string, err error)
+	GetIndexes() (indexes []string, err error)
 
 	// waitUntilQueryServiceReady waits until the query service is ready to accept requests
 	waitUntilQueryServiceReady(timeout time.Duration) error

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -318,7 +318,7 @@ func (t TestAuthenticator) GetCredentials() (username, password, bucketname stri
 func DropAllIndexes(ctx context.Context, n1QLStore N1QLStore) error {
 
 	// Retrieve all indexes on the bucket/collection
-	indexes, err := n1QLStore.getIndexes()
+	indexes, err := n1QLStore.GetIndexes()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Use query index manager to check if index exists before we run query.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1476/
