### PR TITLE
CBG-2687 allow docsProcessed to account for server tombstoned docs that come over DCP

### DIFF
--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -107,8 +107,9 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 		docID := string(event.Key)
 		key := realDocID(docID)
 		base.TracefCtx(ctx, base.KeyAll, "[%s] Received DCP event %d for doc %v", resyncLoggingID, event.Opcode, base.UD(docID))
-		// Ignore deletion events
-		if event.Opcode == sgbucket.FeedOpDeletion {
+
+		// Ignore documents without Xattrs
+		if event.DataType&base.MemcachedDataTypeXattr == 0 {
 			return true
 		}
 		// Don't want to process raw binary docs

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -74,12 +74,11 @@ func (r *ResyncManagerDCP) Init(ctx context.Context, options map[string]interfac
 		// process from scratch with a new resync ID. Otherwise, we should resume with the resync ID, stats specified in the doc.
 		if statusDoc.State == BackgroundProcessStateCompleted || err != nil || (reset && ok) {
 			return newRunInit()
-		} else {
-			r.ResyncID = statusDoc.ResyncID
-			r.SetStatus(statusDoc.DocsChanged, statusDoc.DocsProcessed)
-
-			base.InfofCtx(ctx, base.KeyAll, "Resync: Attempting to resume resync with resync ID: %s", r.ResyncID)
 		}
+		r.ResyncID = statusDoc.ResyncID
+		r.SetStatus(statusDoc.DocsChanged, statusDoc.DocsProcessed)
+
+		base.InfofCtx(ctx, base.KeyAll, "Resync: Attempting to resume resync with resync ID: %s", r.ResyncID)
 
 		return nil
 	}
@@ -105,10 +104,13 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 	defer atomic.CompareAndSwapUint32(&db.State, DBResyncing, DBOffline)
 
 	callback := func(event sgbucket.FeedEvent) bool {
-		var err error
 		docID := string(event.Key)
 		key := realDocID(docID)
 		base.TracefCtx(ctx, base.KeyAll, "[%s] Received DCP event %d for doc %v", resyncLoggingID, event.Opcode, base.UD(docID))
+		// Ignore deletion events
+		if event.Opcode == sgbucket.FeedOpDeletion {
+			return true
+		}
 		// Don't want to process raw binary docs
 		// The binary check should suffice but for additional safety also check for empty bodies
 		if event.DataType == base.MemcachedDataTypeRaw || len(event.Value) == 0 {
@@ -121,7 +123,6 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 		}
 
 		r.DocsProcessed.Add(1)
-
 		databaseCollection := db.CollectionByID[event.CollectionID]
 		_, unusedSequences, err := (&DatabaseCollectionWithUser{
 			DatabaseCollection: databaseCollection,
@@ -153,10 +154,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 		base.InfofCtx(ctx, base.KeyAll, "[%s] running resync against specified collections", resyncLoggingID)
 	}
 
-	clientOptions, err := getReSyncDCPClientOptions(collectionIDs, db.Options.GroupID)
-	if err != nil {
-		return err
-	}
+	clientOptions := getReSyncDCPClientOptions(collectionIDs, db.Options.GroupID)
 
 	dcpFeedKey := generateResyncDCPStreamName(r.ResyncID)
 	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, *clientOptions, bucket)
@@ -312,16 +310,14 @@ type ResyncManagerStatusDocDCP struct {
 }
 
 // getReSyncDCPClientOptions returns the default set of DCPClientOptions suitable for resync
-func getReSyncDCPClientOptions(collectionIDs []uint32, groupID string) (*base.DCPClientOptions, error) {
-	clientOptions := &base.DCPClientOptions{
+func getReSyncDCPClientOptions(collectionIDs []uint32, groupID string) *base.DCPClientOptions {
+	return &base.DCPClientOptions{
 		OneShot:           true,
 		FailOnRollback:    true,
 		MetadataStoreType: base.DCPMetadataStoreCS,
 		GroupID:           groupID,
 		CollectionIDs:     collectionIDs,
 	}
-
-	return clientOptions, nil
 }
 
 func generateResyncDCPStreamName(resyncID string) string {


### PR DESCRIPTION
We are processing all docs that come over DCP, but when running tests outside of isolation, and reusing the same bucket, we can see documents over DCP in a different test. (Diagnosed this by printing the docsProcessed/docsChanged).

Looking at these extra docs, they come from a previous tests and we'll see a mutation event (and the doc body is not found in bucket, so they are not processed), followed by a deletion event. I added code to skip the deletion event processing.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1481/
