### PR TITLE
Make RestTester URI templating error for invalid template variables

### DIFF
--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -392,8 +392,12 @@ func TestMultiCollectionChannelAccess(t *testing.T) {
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// Ensure users can't access docs in a removed collection
-	resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/{{.keyspace3}}/testDocBazA", "", nil, "userB", "letmein")
-	RequireStatus(t, resp, http.StatusBadRequest)
+	//
+	// we can't use the {{.keyspace3}} URI template variable here as the collection no longer exists on the RestTester,
+	// but we still want to try issuing the request to the old keyspace name.
+	keyspace3 := "db." + scope + "." + collection3
+	resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/"+keyspace3+"/testDocBazA", "", nil, "userB", "letmein")
+	RequireStatus(t, resp, http.StatusNotFound)
 }
 
 func TestMultiCollectionDynamicChannelAccess(t *testing.T) {

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -99,3 +99,25 @@ func TestAttachmentRoundTrip(t *testing.T) {
 	assert.Equal(t, []byte{}, attachments["baz"].Data) // data field is explicitly ignored
 
 }
+
+// TestRestTesterInvalidPathVariable ensures that invalid path variables return an error instead of silently returning "<no value>" or empty string.
+func TestRestTesterInvalidPathVariable(t *testing.T) {
+	const dbName = "dbname"
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				Name: dbName,
+			},
+		},
+	})
+	defer rt.Close()
+
+	uri, err := rt.templateResource("/foo/{{.invalid}}/bar")
+	assert.Errorf(t, err, "Expected error for invalid path variable")
+	assert.Equalf(t, "", uri, "Expected empty URI for invalid path variable")
+	assert.NotContainsf(t, uri, "<no value>", "Expected URI to not contain \"<no value>\" for invalid path variable")
+
+	uri, err = rt.templateResource("/foo/{{.db}}/bar")
+	assert.NoError(t, err)
+	assert.Equalf(t, "/foo/"+dbName+"/bar", uri, "Expected valid URI for valid path variable")
+}


### PR DESCRIPTION
- Avoids obscure downstream errors resulting from an invalid template variable being set to `"<no value>"`
  - i.e. using `{{.keyspace}}` in the case of >1 collection, or `{{.keyspace3}}` in the case of <=2 collections
- Sets `missingkey=error` option on the RestTester URI template
- Split into fatal and non-fatal template parse methods for testing
- Correct invalid use of template variable in `TestMultiCollectionChannelAccess`
  - This also resulted in a status code change, as `"<no value>"` was triggering "invalid db name" handling rather than "not found" handling

## Unit test before change
```go
    utilities_testing_test.go:116:
        	Error Trace:	/Users/benbrooks/dev/cb/sync_gateway-workspace/sync_gateway/rest/utilities_testing_test.go:116
        	Error:      	An error is expected but got nil.
        	Test:       	TestRestTesterInvalidPathVariable
        	Messages:   	Expected error for invalid path variable
    utilities_testing_test.go:117:
        	Error Trace:	/Users/benbrooks/dev/cb/sync_gateway-workspace/sync_gateway/rest/utilities_testing_test.go:117
        	Error:      	Not equal:
        	            	expected: ""
        	            	actual  : "/foo/<no value>/bar"

        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-
        	            	+/foo/<no value>/bar
        	Test:       	TestRestTesterInvalidPathVariable
        	Messages:   	Expected empty URI for invalid path variable
    utilities_testing_test.go:118:
        	Error Trace:	/Users/benbrooks/dev/cb/sync_gateway-workspace/sync_gateway/rest/utilities_testing_test.go:118
        	Error:      	"/foo/<no value>/bar" should not contain "<no value>"
        	Test:       	TestRestTesterInvalidPathVariable
        	Messages:   	Expected URI to not contain "<no value>" for invalid path variable
--- FAIL: TestRestTesterInvalidPathVariable (0.01s)
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1484/