### PR TITLE
CBG-2636: Add EE checks to admin api auth tests that use mobile sgw role

### DIFF
--- a/base/main_test_bucket_pool_config.go
+++ b/base/main_test_bucket_pool_config.go
@@ -71,6 +71,12 @@ func TestsUseNamedCollections() bool {
 	return err == nil && ok
 }
 
+// TestsUseNamedCollections returns true if the tests use named collections.
+func TestsUseServerCE() bool {
+	ok, err := GTestBucketPool.cluster.isServerEnterprise()
+	return err == nil && ok
+}
+
 // canUseNamedCollections returns true if the cluster supports named collections, and they are also requested
 func (tbp *TestBucketPool) canUseNamedCollections() (bool, error) {
 	// walrus supports collections, but we need to query the server's version for capability check

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -181,7 +181,7 @@ func TestCheckRoles(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 	SGWorBFArole := RouteRole{MobileSyncGatewayRole.RoleName, true}
-	if !base.IsEnterpriseEdition() {
+	if !rt.IsServerEnterprise(t) {
 		SGWorBFArole = RouteRole{BucketFullAccessRole.RoleName, true}
 	}
 
@@ -845,10 +845,9 @@ func TestAdminAPIAuth(t *testing.T) {
 	}
 
 	SGWorBFArole := MobileSyncGatewayRole.RoleName
-	if !base.IsEnterpriseEdition() {
+	if !rt.IsServerEnterprise(t) {
 		SGWorBFArole = BucketFullAccessRole.RoleName
 	}
-	fmt.Println("IFFFFF", SGWorBFArole)
 	eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
 	require.NoError(t, err)
 
@@ -914,10 +913,12 @@ func TestDisablePermissionCheck(t *testing.T) {
 	viewsAdminRole := RouteRole{RoleName: "views_admin", DatabaseScoped: true}
 	statsReadPermission := Permission{".stats!read", true}
 
+	rt := NewRestTester(t, nil)
 	SGWorBFArole := RouteRole{MobileSyncGatewayRole.RoleName, true}
-	if !base.IsEnterpriseEdition() {
+	if !rt.IsServerEnterprise(t) {
 		SGWorBFArole = RouteRole{BucketFullAccessRole.RoleName, true}
 	}
+	rt.Close()
 
 	testCases := []struct {
 		Name               string
@@ -1453,10 +1454,6 @@ func TestCreateDBSpecificBucketPerm(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}
-	SGWorBFArole := RouteRole{MobileSyncGatewayRole.RoleName, true}
-	if !base.IsEnterpriseEdition() {
-		SGWorBFArole = RouteRole{BucketFullAccessRole.RoleName, true}
-	}
 
 	base.RequireNumTestBuckets(t, 2)
 
@@ -1467,6 +1464,11 @@ func TestCreateDBSpecificBucketPerm(t *testing.T) {
 		AdminInterfaceAuthentication: true,
 	})
 	defer rt.Close()
+
+	SGWorBFArole := RouteRole{MobileSyncGatewayRole.RoleName, true}
+	if !rt.IsServerEnterprise(t) {
+		SGWorBFArole = RouteRole{BucketFullAccessRole.RoleName, true}
+	}
 
 	eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
 	require.NoError(t, err)

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -181,7 +181,7 @@ func TestCheckRoles(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 	SGWorBFArole := RouteRole{MobileSyncGatewayRole.RoleName, true}
-	if !rt.IsServerEnterprise(t) {
+	if base.TestsUseServerCE() {
 		SGWorBFArole = RouteRole{BucketFullAccessRole.RoleName, true}
 	}
 
@@ -845,7 +845,7 @@ func TestAdminAPIAuth(t *testing.T) {
 	}
 
 	SGWorBFArole := MobileSyncGatewayRole.RoleName
-	if !rt.IsServerEnterprise(t) {
+	if base.TestsUseServerCE() {
 		SGWorBFArole = BucketFullAccessRole.RoleName
 	}
 	eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
@@ -860,7 +860,7 @@ func TestAdminAPIAuth(t *testing.T) {
 	MakeUser(t, httpClient, eps[0], "ROAdminUser", "password", []string{ReadOnlyAdminRole.RoleName})
 	defer DeleteUser(t, httpClient, eps[0], "ROAdminUser")
 
-	if rt.IsServerEnterprise(t) {
+	if base.TestsUseServerCE() {
 		MakeUser(t, httpClient, eps[0], "ClusterAdminUser", "password", []string{ClusterAdminRole.RoleName})
 		defer DeleteUser(t, httpClient, eps[0], "ClusterAdminUser")
 	}
@@ -894,7 +894,7 @@ func TestAdminAPIAuth(t *testing.T) {
 						RequireStatus(t, resp, http.StatusForbidden)
 					}
 
-					if rt.IsServerEnterprise(t) {
+					if base.TestsUseServerCE() {
 						resp = rt.SendAdminRequestWithAuth(endPoint.Method, endPoint.Endpoint, body, "ClusterAdminUser", "password")
 						assert.True(t, resp.Code != http.StatusUnauthorized && resp.Code != http.StatusForbidden)
 					}
@@ -918,7 +918,7 @@ func TestDisablePermissionCheck(t *testing.T) {
 
 	rt := NewRestTester(t, nil)
 	SGWorBFArole := RouteRole{MobileSyncGatewayRole.RoleName, true}
-	if !rt.IsServerEnterprise(t) {
+	if base.TestsUseServerCE() {
 		SGWorBFArole = RouteRole{BucketFullAccessRole.RoleName, true}
 	}
 	rt.Close()
@@ -1469,7 +1469,7 @@ func TestCreateDBSpecificBucketPerm(t *testing.T) {
 	defer rt.Close()
 
 	SGWorBFArole := RouteRole{MobileSyncGatewayRole.RoleName, true}
-	if !rt.IsServerEnterprise(t) {
+	if base.TestsUseServerCE() {
 		SGWorBFArole = RouteRole{BucketFullAccessRole.RoleName, true}
 	}
 

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -180,6 +180,10 @@ func TestCheckRoles(t *testing.T) {
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
+	SGWorBFArole := RouteRole{MobileSyncGatewayRole.RoleName, true}
+	if !base.IsEnterpriseEdition() {
+		SGWorBFArole = RouteRole{BucketFullAccessRole.RoleName, true}
+	}
 
 	testCases := []struct {
 		Name               string
@@ -227,22 +231,22 @@ func TestCheckRoles(t *testing.T) {
 			Username:           "CreatedBucketAdmin",
 			Password:           "password",
 			BucketName:         rt.Bucket().GetName(),
-			RequestRoles:       []RouteRole{MobileSyncGatewayRole},
+			RequestRoles:       []RouteRole{SGWorBFArole},
 			ExpectedStatusCode: http.StatusOK,
 			CreateUser:         "CreatedBucketAdmin",
 			CreatePassword:     "password",
-			CreateRoles:        []string{fmt.Sprintf("mobile_sync_gateway[%s]", rt.Bucket().GetName())},
+			CreateRoles:        []string{fmt.Sprintf("%s[%s]", SGWorBFArole.RoleName, rt.Bucket().GetName())},
 		},
 		{
 			Name:               "CreatedBucketAdminWildcard",
 			Username:           "CreatedBucketAdminWildcard",
 			Password:           "password",
 			BucketName:         rt.Bucket().GetName(),
-			RequestRoles:       []RouteRole{MobileSyncGatewayRole},
+			RequestRoles:       []RouteRole{SGWorBFArole},
 			ExpectedStatusCode: http.StatusOK,
 			CreateUser:         "CreatedBucketAdminWildcard",
 			CreatePassword:     "password",
-			CreateRoles:        []string{"mobile_sync_gateway[*]"},
+			CreateRoles:        []string{fmt.Sprintf("%s[*]", SGWorBFArole.RoleName)},
 		},
 		{
 			Name:               "CreateUserNoRole",
@@ -260,7 +264,7 @@ func TestCheckRoles(t *testing.T) {
 			Username:           "CreateUserInsufficientRole",
 			Password:           "password",
 			BucketName:         "",
-			RequestRoles:       []RouteRole{MobileSyncGatewayRole},
+			RequestRoles:       []RouteRole{SGWorBFArole},
 			ExpectedStatusCode: http.StatusForbidden,
 			CreateUser:         "CreateUserInsufficientRole",
 			CreatePassword:     "password",
@@ -840,13 +844,18 @@ func TestAdminAPIAuth(t *testing.T) {
 		},
 	}
 
+	SGWorBFArole := MobileSyncGatewayRole.RoleName
+	if !base.IsEnterpriseEdition() {
+		SGWorBFArole = BucketFullAccessRole.RoleName
+	}
+	fmt.Println("IFFFFF", SGWorBFArole)
 	eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
 	require.NoError(t, err)
 
 	MakeUser(t, httpClient, eps[0], "noaccess", "password", []string{})
 	defer DeleteUser(t, httpClient, eps[0], "noaccess")
 
-	MakeUser(t, httpClient, eps[0], "MobileSyncGatewayUser", "password", []string{fmt.Sprintf("%s[%s]", MobileSyncGatewayRole.RoleName, rt.Bucket().GetName())})
+	MakeUser(t, httpClient, eps[0], "MobileSyncGatewayUser", "password", []string{fmt.Sprintf("%s[%s]", SGWorBFArole, rt.Bucket().GetName())})
 	defer DeleteUser(t, httpClient, eps[0], "MobileSyncGatewayUser")
 
 	MakeUser(t, httpClient, eps[0], "ROAdminUser", "password", []string{ReadOnlyAdminRole.RoleName})
@@ -905,6 +914,11 @@ func TestDisablePermissionCheck(t *testing.T) {
 	viewsAdminRole := RouteRole{RoleName: "views_admin", DatabaseScoped: true}
 	statsReadPermission := Permission{".stats!read", true}
 
+	SGWorBFArole := RouteRole{MobileSyncGatewayRole.RoleName, true}
+	if !base.IsEnterpriseEdition() {
+		SGWorBFArole = RouteRole{BucketFullAccessRole.RoleName, true}
+	}
+
 	testCases := []struct {
 		Name               string
 		CreateUser         string
@@ -916,7 +930,7 @@ func TestDisablePermissionCheck(t *testing.T) {
 		{
 			Name:               "AccessViaRole",
 			CreateUser:         "SGWUser",
-			CreateUserRole:     &MobileSyncGatewayRole,
+			CreateUserRole:     &SGWorBFArole,
 			RequirePerms:       []Permission{clusterAdminPermission},
 			DoPermissionCheck:  false,
 			ExpectedStatusCode: http.StatusOK,
@@ -1439,6 +1453,10 @@ func TestCreateDBSpecificBucketPerm(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}
+	SGWorBFArole := RouteRole{MobileSyncGatewayRole.RoleName, true}
+	if !base.IsEnterpriseEdition() {
+		SGWorBFArole = RouteRole{BucketFullAccessRole.RoleName, true}
+	}
 
 	base.RequireNumTestBuckets(t, 2)
 
@@ -1453,10 +1471,9 @@ func TestCreateDBSpecificBucketPerm(t *testing.T) {
 	eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
 	require.NoError(t, err)
 
-	mobileSyncGateway := "mobile_sync_gateway"
-	MakeUser(t, httpClient, eps[0], mobileSyncGateway, "password", []string{fmt.Sprintf("%s[%s]", mobileSyncGateway, tb.GetName())})
-	defer DeleteUser(t, httpClient, eps[0], mobileSyncGateway)
+	MakeUser(t, httpClient, eps[0], SGWorBFArole.RoleName, "password", []string{fmt.Sprintf("%s[%s]", SGWorBFArole.RoleName, tb.GetName())})
+	defer DeleteUser(t, httpClient, eps[0], SGWorBFArole.RoleName)
 
-	resp := rt.SendAdminRequestWithAuth("PUT", "/db2/", `{"bucket": "`+tb.GetName()+`", "username": "`+base.TestClusterUsername()+`", "password": "`+base.TestClusterPassword()+`", "num_index_replicas": 0, "use_views": `+strconv.FormatBool(base.TestsDisableGSI())+`}`, mobileSyncGateway, "password")
+	resp := rt.SendAdminRequestWithAuth("PUT", "/db2/", `{"bucket": "`+tb.GetName()+`", "username": "`+base.TestClusterUsername()+`", "password": "`+base.TestClusterPassword()+`", "num_index_replicas": 0, "use_views": `+strconv.FormatBool(base.TestsDisableGSI())+`}`, SGWorBFArole.RoleName, "password")
 	RequireStatus(t, resp, http.StatusCreated)
 }

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -860,8 +860,10 @@ func TestAdminAPIAuth(t *testing.T) {
 	MakeUser(t, httpClient, eps[0], "ROAdminUser", "password", []string{ReadOnlyAdminRole.RoleName})
 	defer DeleteUser(t, httpClient, eps[0], "ROAdminUser")
 
-	MakeUser(t, httpClient, eps[0], "ClusterAdminUser", "password", []string{ClusterAdminRole.RoleName})
-	defer DeleteUser(t, httpClient, eps[0], "ClusterAdminUser")
+	if rt.IsServerEnterprise(t) {
+		MakeUser(t, httpClient, eps[0], "ClusterAdminUser", "password", []string{ClusterAdminRole.RoleName})
+		defer DeleteUser(t, httpClient, eps[0], "ClusterAdminUser")
+	}
 
 	for _, endPoint := range endPoints {
 		body := `{}`
@@ -892,9 +894,10 @@ func TestAdminAPIAuth(t *testing.T) {
 						RequireStatus(t, resp, http.StatusForbidden)
 					}
 
-					resp = rt.SendAdminRequestWithAuth(endPoint.Method, endPoint.Endpoint, body, "ClusterAdminUser", "password")
-					assert.True(t, resp.Code != http.StatusUnauthorized && resp.Code != http.StatusForbidden)
-
+					if rt.IsServerEnterprise(t) {
+						resp = rt.SendAdminRequestWithAuth(endPoint.Method, endPoint.Endpoint, body, "ClusterAdminUser", "password")
+						assert.True(t, resp.Code != http.StatusUnauthorized && resp.Code != http.StatusForbidden)
+					}
 				}
 			}
 		})

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -29,8 +29,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/couchbase/gocb/v2"
-
 	"github.com/couchbase/go-blip"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
@@ -2289,19 +2287,4 @@ func (rt *RestTester) getCollectionsForBLIP() []string {
 			strings.Join([]string{collection.ScopeName, collection.Name}, base.ScopeCollectionSeparator))
 	}
 	return collections
-}
-
-// IsServerEnterprise returns true if the connected couchbase server instance is Enterprise edition
-// And false for Community edition
-func (rt *RestTester) IsServerEnterprise(t testing.TB) bool {
-	gocbBucket, err := base.AsGocbV2Bucket(rt.Bucket())
-	require.NoError(t, err)
-
-	metadata, err := gocbBucket.GetCluster().Internal().GetNodesMetadata(&gocb.GetNodesMetadataOptions{})
-	require.NoError(t, err)
-
-	if strings.Contains("enterprise", metadata[0].Version) {
-		return true
-	}
-	return false
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -16,7 +16,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/couchbase/gocb/v2"
 	"log"
 	"net"
 	"net/http"
@@ -29,6 +28,8 @@ import (
 	"testing"
 	"text/template"
 	"time"
+
+	"github.com/couchbase/gocb/v2"
 
 	"github.com/couchbase/go-blip"
 	sgbucket "github.com/couchbase/sg-bucket"

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -16,6 +16,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/couchbase/gocb/v2"
 	"log"
 	"net"
 	"net/http"
@@ -2287,4 +2288,19 @@ func (rt *RestTester) getCollectionsForBLIP() []string {
 			strings.Join([]string{collection.ScopeName, collection.Name}, base.ScopeCollectionSeparator))
 	}
 	return collections
+}
+
+// IsServerEnterprise returns true if the connected couchbase server instance is Enterprise edition
+// And false for Community edition
+func (rt *RestTester) IsServerEnterprise(t testing.TB) bool {
+	gocbBucket, err := base.AsGocbV2Bucket(rt.Bucket())
+	require.NoError(t, err)
+
+	metadata, err := gocbBucket.GetCluster().Internal().GetNodesMetadata(&gocb.GetNodesMetadataOptions{})
+	require.NoError(t, err)
+	
+	if strings.Contains("enterprise", metadata[0].Version) {
+		return true
+	}
+	return false
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2298,7 +2298,7 @@ func (rt *RestTester) IsServerEnterprise(t testing.TB) bool {
 
 	metadata, err := gocbBucket.GetCluster().Internal().GetNodesMetadata(&gocb.GetNodesMetadataOptions{})
 	require.NoError(t, err)
-	
+
 	if strings.Contains("enterprise", metadata[0].Version) {
 		return true
 	}

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -122,5 +122,5 @@ func TestCECheck(t *testing.T) {
 	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/settings/rbac/users/local/%s", eps[0], "username"), strings.NewReader(form.Encode()))
 	require.Error(t, err)
 	require.Equal(t, req, http.StatusBadRequest)
-	
+
 }

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -105,6 +105,9 @@ func TestAttachmentRoundTrip(t *testing.T) {
 }
 
 func TestCECheck(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Only works with CBS")
+	}
 	if base.TestsUseServerCE() {
 		rt := NewRestTester(t, nil)
 		defer rt.Close()

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -109,16 +109,18 @@ func TestCECheck(t *testing.T) {
 		t.Skip("Only works with CBS")
 	}
 	if base.TestsUseServerCE() {
-		rt := NewRestTester(t, nil)
-		defer rt.Close()
-		form := url.Values{}
-		form.Add("password", "password")
-		form.Add("roles", "[mobile_sync_Gateway]")
-		eps, _, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
-		require.NoError(t, err)
-
-		req, err := http.NewRequest("PUT", fmt.Sprintf("%s/settings/rbac/users/local/%s", eps[0], "username"), strings.NewReader(form.Encode()))
-		require.Error(t, err)
-		require.Equal(t, req, http.StatusBadRequest)
+		t.Skip("test only runs with CE server")
 	}
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+	form := url.Values{}
+	form.Add("password", "password")
+	form.Add("roles", "[mobile_sync_Gateway]")
+	eps, _, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/settings/rbac/users/local/%s", eps[0], "username"), strings.NewReader(form.Encode()))
+	require.Error(t, err)
+	require.Equal(t, req, http.StatusBadRequest)
+	
 }


### PR DESCRIPTION
CBG-2636
Add rt.IsServerEnterprise to check if the connected CBS instance is EE or CE

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1489/
