### PR TITLE
CBG-2687 docsProcessed accounts for server tombstoned docs

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1142,7 +1142,7 @@ func TestResyncUsingDCPStreamForNamedCollection(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, int(resyncManagerStatus.DocsChanged))
-	assert.Equal(t, 10, int(resyncManagerStatus.DocsProcessed))
+	assert.LessOrEqual(t, 10, int(resyncManagerStatus.DocsProcessed))
 
 	// Run resync for all collections
 	resp = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
@@ -1163,7 +1163,7 @@ func TestResyncUsingDCPStreamForNamedCollection(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, int(resyncManagerStatus.DocsChanged))
-	assert.Equal(t, 20, int(resyncManagerStatus.DocsProcessed))
+	assert.LessOrEqual(t, 20, int(resyncManagerStatus.DocsProcessed))
 }
 
 func TestResyncErrorScenarios(t *testing.T) {


### PR DESCRIPTION
Due to the way the test harness works, there can be tombstoned docs hanging around from previous test bucket pool


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1488/
