### PR TITLE
CBG-2699 add clusterUUID to sync metadata

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -59,7 +59,6 @@ type CouchbaseBucketStore interface {
 	GetName() string
 	MgmtEps() ([]string, error)
 	MetadataPurgeInterval() (time.Duration, error)
-	ServerUUID() (uuid string, err error)
 	MaxTTL() (int, error)
 	HttpClient() *http.Client
 	GetSpec() BucketSpec
@@ -473,7 +472,7 @@ func getMaxTTL(store CouchbaseBucketStore) (int, error) {
 }
 
 // Get the Server UUID of the bucket, this is also known as the Cluster UUID
-func getServerUUID(store CouchbaseBucketStore) (uuid string, err error) {
+func GetServerUUID(store CouchbaseBucketStore) (uuid string, err error) {
 	resp, err := store.mgmtRequest(http.MethodGet, "/pools", "application/json", nil)
 	if err != nil {
 		return "", err

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -2479,15 +2479,3 @@ func TestUpsertOptionPreserveExpiry(t *testing.T) {
 		})
 	}
 }
-
-func TestClusterUUID(t *testing.T) {
-	if !TestUseCouchbaseServer() {
-		t.Skip("Test can only be ran against CBS requiring a gocb connection")
-	}
-	bucket := GetTestBucket(t)
-	defer bucket.Close()
-
-	gocbV2Bucket, err := AsGocbV2Bucket(bucket)
-	require.NoError(t, err)
-	require.Len(t, gocbV2Bucket.ClusterUUID, 32) // no dashes in UUID
-}

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -2489,5 +2489,5 @@ func TestClusterUUID(t *testing.T) {
 
 	gocbV2Bucket, err := AsGocbV2Bucket(bucket)
 	require.NoError(t, err)
-	require.Equal(t, 32, len(gocbV2Bucket.ClusterUUID)) // no dashes in UUID
+	require.Len(t, gocbV2Bucket.ClusterUUID, 32) // no dashes in UUID
 }

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -2479,3 +2479,15 @@ func TestUpsertOptionPreserveExpiry(t *testing.T) {
 		})
 	}
 }
+
+func TestClusterUUID(t *testing.T) {
+	if !TestUseCouchbaseServer() {
+		t.Skip("Test can only be ran against CBS requiring a gocb connection")
+	}
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
+
+	gocbV2Bucket, err := AsGocbV2Bucket(bucket)
+	require.NoError(t, err)
+	require.Equal(t, 32, len(gocbV2Bucket.ClusterUUID)) // no dashes in UUID
+}

--- a/base/collection.go
+++ b/base/collection.go
@@ -140,13 +140,7 @@ func GetGocbV2BucketFromCluster(cluster *gocb.Cluster, spec BucketSpec, waitUnti
 		clusterCompatMajorVersion: uint64(clusterCompatMajor),
 		clusterCompatMinorVersion: uint64(clusterCompatMinor),
 	}
-	uuid, err := getServerUUID(gocbv2Bucket)
-	if err != nil {
-		_ = cluster.Close(&gocb.ClusterCloseOptions{})
-		return nil, err
-	}
 
-	gocbv2Bucket.ClusterUUID = uuid
 	// Set limits for concurrent query and kv ops
 	maxConcurrentQueryOps := MaxConcurrentQueryOps
 	if spec.MaxConcurrentQueryOps != nil {
@@ -189,7 +183,6 @@ type GocbV2Bucket struct {
 	queryOps                                             chan struct{} // Manages max concurrent query ops
 	kvOps                                                chan struct{} // Manages max concurrent kv ops
 	clusterCompatMajorVersion, clusterCompatMinorVersion uint64        // E.g: 6 and 0 for 6.0.3
-	ClusterUUID                                          string        // uuid of cluster
 }
 
 var (
@@ -450,10 +443,6 @@ func (b *GocbV2Bucket) QueryEpsCount() (int, error) {
 // found, retrieves the cluster-wide value.
 func (b *GocbV2Bucket) MetadataPurgeInterval() (time.Duration, error) {
 	return getMetadataPurgeInterval(b)
-}
-
-func (b *GocbV2Bucket) ServerUUID() (uuid string, err error) {
-	return getServerUUID(b)
 }
 
 func (b *GocbV2Bucket) MaxTTL() (int, error) {

--- a/base/collection.go
+++ b/base/collection.go
@@ -130,7 +130,7 @@ func GetGocbV2BucketFromCluster(cluster *gocb.Cluster, spec BucketSpec, waitUnti
 	clusterCompatMajor, clusterCompatMinor, err := getClusterVersion(cluster)
 	if err != nil {
 		_ = cluster.Close(&gocb.ClusterCloseOptions{})
-		return nil, fmt.Errorf("%s", err)
+		return nil, err
 	}
 
 	gocbv2Bucket := &GocbV2Bucket{
@@ -143,7 +143,7 @@ func GetGocbV2BucketFromCluster(cluster *gocb.Cluster, spec BucketSpec, waitUnti
 	uuid, err := getServerUUID(gocbv2Bucket)
 	if err != nil {
 		_ = cluster.Close(&gocb.ClusterCloseOptions{})
-		return nil, fmt.Errorf("%s", err)
+		return nil, err
 	}
 
 	gocbv2Bucket.ClusterUUID = uuid

--- a/base/collection.go
+++ b/base/collection.go
@@ -140,7 +140,13 @@ func GetGocbV2BucketFromCluster(cluster *gocb.Cluster, spec BucketSpec, waitUnti
 		clusterCompatMajorVersion: uint64(clusterCompatMajor),
 		clusterCompatMinorVersion: uint64(clusterCompatMinor),
 	}
+	uuid, err := getServerUUID(gocbv2Bucket)
+	if err != nil {
+		_ = cluster.Close(&gocb.ClusterCloseOptions{})
+		return nil, fmt.Errorf("%s", err)
+	}
 
+	gocbv2Bucket.ClusterUUID = uuid
 	// Set limits for concurrent query and kv ops
 	maxConcurrentQueryOps := MaxConcurrentQueryOps
 	if spec.MaxConcurrentQueryOps != nil {
@@ -183,6 +189,7 @@ type GocbV2Bucket struct {
 	queryOps                                             chan struct{} // Manages max concurrent query ops
 	kvOps                                                chan struct{} // Manages max concurrent kv ops
 	clusterCompatMajorVersion, clusterCompatMinorVersion uint64        // E.g: 6 and 0 for 6.0.3
+	ClusterUUID                                          string        // uuid of cluster
 }
 
 var (

--- a/db/crud.go
+++ b/db/crud.go
@@ -1753,7 +1753,7 @@ func (col *DatabaseCollectionWithUser) documentUpdateFunc(ctx context.Context, d
 		return
 	}
 
-	doc.ClusterUUID = col.clusterUUID()
+	doc.ClusterUUID = col.serverUUID()
 	doc.TimeSaved = time.Now()
 	return updatedExpiry, newRevID, newDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, createNewRevIDSkipped, err
 }

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1553,3 +1553,30 @@ func TestMergeAttachments(t *testing.T) {
 		})
 	}
 }
+
+func TestPutStampClusterUUID(t *testing.T) {
+	if !base.TestUseXattrs() {
+		t.Skip("This test only works with XATTRS enabled")
+	}
+
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	collection := GetSingleDatabaseCollectionWithUser(t, db)
+
+	key := "doc1"
+
+	body := Body{}
+	err := body.Unmarshal([]byte(`{"field": "value"}`))
+	require.NoError(t, err)
+
+	_, doc, err := collection.Put(ctx, key, body)
+
+	require.NoError(t, err)
+	require.Equal(t, 32, len(doc.ClusterUUID))
+
+	var xattr map[string]string
+	_, err = collection.dataStore.GetWithXattr(key, base.SyncXattrName, "", &body, &xattr, nil)
+	require.NoError(t, err)
+	require.Equal(t, 32, len(xattr["cluster_uuid"]))
+}

--- a/db/database.go
+++ b/db/database.go
@@ -129,7 +129,7 @@ type DatabaseContext struct {
 	singleCollection             *DatabaseCollection            // Temporary collection
 	CollectionByID               map[uint32]*DatabaseCollection // A map keyed by collection ID to Collection
 	CollectionNames              map[string]map[string]struct{} // Map of scope, collection names
-	clusterUUID                  string                         // uuid of cluster
+	ClusterUUID                  string                         // uuid of cluster
 }
 
 type Scope struct {
@@ -258,6 +258,14 @@ func ValidateDatabaseName(dbName string) error {
 	return nil
 }
 
+// getNewDatabaseSleeperFunc returns a sleeper function during database connection
+func getNewDatabaseSleeperFunc() base.RetrySleeper {
+	return base.CreateDoublingSleeperFunc(
+		13, // MaxNumRetries approx 40 seconds total retry duration
+		5,  // InitialRetrySleepTimeMS
+	)
+}
+
 // connectToBucketErrorHandling takes the given spec and error and returns a formatted error, along with whether it was a fatal error.
 func connectToBucketErrorHandling(ctx context.Context, spec base.BucketSpec, gotErr error) (fatalError bool, err error) {
 	if gotErr != nil {
@@ -305,13 +313,8 @@ func connectToBucket(ctx context.Context, spec base.BucketSpec) (base.Bucket, er
 		return shouldRetry, newErr, bucket
 	}
 
-	sleeper := base.CreateDoublingSleeperFunc(
-		13, // MaxNumRetries approx 40 seconds total retry duration
-		5,  // InitialRetrySleepTimeMS
-	)
-
 	description := fmt.Sprintf("Attempt to connect to bucket : %v", spec.BucketName)
-	err, ibucket := base.RetryLoop(description, worker, sleeper)
+	err, ibucket := base.RetryLoop(description, worker, getNewDatabaseSleeperFunc())
 	if err != nil {
 		return nil, err
 	}
@@ -325,6 +328,22 @@ func GetConnectToBucketFn(failFast bool) OpenBucketFn {
 		return connectToBucketFailFast
 	}
 	return connectToBucket
+}
+
+// Returns cluster UUID. If running against walrus, do return an empty string.
+func getClusterUUID(ctx context.Context, bucket base.Bucket) (string, error) {
+	gocbV2Bucket, err := base.AsGocbV2Bucket(bucket)
+	if err != nil {
+		return "", nil
+	}
+	// start a retry loop to get server ID
+	worker := func() (bool, error, interface{}) {
+		uuid, err := base.GetServerUUID(gocbV2Bucket)
+		return err != nil, err, uuid
+	}
+
+	err, uuid := base.RetryLoopCtx("Getting ClusterUUID", worker, getNewDatabaseSleeperFunc(), ctx)
+	return uuid.(string), err
 }
 
 // Function type for something that calls NewDatabaseContext and wants a callback when the DB is detected
@@ -367,6 +386,10 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		return nil, statsError
 	}
 
+	clusterUUID, err := getClusterUUID(ctx, bucket)
+	if err != nil {
+		return nil, err
+	}
 	dbContext := &DatabaseContext{
 		Name:           dbName,
 		UUID:           cbgt.NewUUID(),
@@ -377,12 +400,9 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		Options:        options,
 		DbStats:        dbStats,
 		CollectionByID: make(map[uint32]*DatabaseCollection),
+		ClusterUUID:    clusterUUID,
 	}
 
-	gocbV2Bucket, err := base.AsGocbV2Bucket(bucket)
-	if err == nil {
-		dbContext.clusterUUID = gocbV2Bucket.ClusterUUID
-	}
 	cleanupFunctions = append(cleanupFunctions, func() {
 		base.SyncGatewayStats.ClearDBStats(dbName)
 	})
@@ -748,32 +768,6 @@ func (context *DatabaseContext) GetOIDCProvider(providerName string) (*auth.OIDC
 	} else {
 		return nil, base.RedactErrorf("No provider found for provider name %q", base.MD(providerName))
 	}
-}
-
-func (dbCtx *DatabaseContext) GetServerUUID(ctx context.Context) string {
-
-	dbCtx.BucketLock.RLock()
-	defer dbCtx.BucketLock.RUnlock()
-
-	// Lazy load the server UUID, if we can get it.
-	if dbCtx.serverUUID == "" {
-		cbs, ok := base.AsCouchbaseBucketStore(dbCtx.Bucket)
-		if !ok {
-			base.WarnfCtx(ctx, "Database %v: Unable to get server UUID. Underlying bucket type was not GoCBBucket.", base.MD(dbCtx.Name))
-			return ""
-		}
-
-		uuid, err := cbs.ServerUUID()
-		if err != nil {
-			base.WarnfCtx(ctx, "Database %v: Unable to get server UUID: %v", base.MD(dbCtx.Name), err)
-			return ""
-		}
-
-		base.DebugfCtx(ctx, base.KeyAll, "Database %v: Got server UUID %v", base.MD(dbCtx.Name), base.MD(uuid))
-		dbCtx.serverUUID = uuid
-	}
-
-	return dbCtx.serverUUID
 }
 
 func (context *DatabaseContext) Close(ctx context.Context) {

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -121,7 +121,7 @@ func (c *DatabaseCollection) channelQueryLimit() int {
 
 // clusterUUID returns a couchbase server UUID. If running with walrus, return an empty string.
 func (c *DatabaseCollection) clusterUUID() string {
-	return c.dbCtx.clusterUUID
+	return c.dbCtx.ClusterUUID
 }
 
 // DbStats are stats that correspond to database level collections.

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -119,6 +119,11 @@ func (c *DatabaseCollection) channelQueryLimit() int {
 	return c.dbCtx.Options.CacheOptions.ChannelQueryLimit
 }
 
+// clusterUUID returns a couchbase server UUID. If running with walrus, return an empty string.
+func (c *DatabaseCollection) clusterUUID() string {
+	return c.dbCtx.clusterUUID
+}
+
 // DbStats are stats that correspond to database level collections.
 func (c *DatabaseCollection) dbStats() *base.DbStats {
 	return c.dbCtx.DbStats

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -120,8 +120,8 @@ func (c *DatabaseCollection) channelQueryLimit() int {
 }
 
 // clusterUUID returns a couchbase server UUID. If running with walrus, return an empty string.
-func (c *DatabaseCollection) clusterUUID() string {
-	return c.dbCtx.ClusterUUID
+func (c *DatabaseCollection) serverUUID() string {
+	return c.dbCtx.ServerUUID
 }
 
 // DbStats are stats that correspond to database level collections.

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3084,6 +3084,20 @@ func TestGetDatabaseCollectionWithUserDefaultCollection(t *testing.T) {
 
 }
 
+func TestClusterUUID(t *testing.T) {
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+
+	db, err := NewDatabaseContext(base.TestCtx(t), "db", bucket, false, DatabaseContextOptions{})
+	require.NoError(t, err)
+
+	if base.TestUseCouchbaseServer() {
+		require.Equal(t, 32, len(db.clusterUUID)) // no dashes in UUID
+	} else {
+		require.Equal(t, "", db.clusterUUID) // no dashes in UUID
+	}
+}
+
 func waitAndAssertConditionWithOptions(t *testing.T, fn func() bool, retryCount, msSleepTime int, failureMsgAndArgs ...interface{}) {
 	for i := 0; i <= retryCount; i++ {
 		if i == retryCount {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3092,9 +3092,9 @@ func TestClusterUUID(t *testing.T) {
 	require.NoError(t, err)
 
 	if base.TestUseCouchbaseServer() {
-		require.Equal(t, 32, len(db.clusterUUID)) // no dashes in UUID
+		require.Len(t, db.clusterUUID, 32) // no dashes in UUID
 	} else {
-		require.Equal(t, "", db.clusterUUID) // no dashes in UUID
+		require.Len(t, db.clusterUUID, 0) // no dashes in UUID
 	}
 }
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3092,9 +3092,9 @@ func TestClusterUUID(t *testing.T) {
 	require.NoError(t, err)
 
 	if base.TestUseCouchbaseServer() {
-		require.Len(t, db.clusterUUID, 32) // no dashes in UUID
+		require.Len(t, db.ClusterUUID, 32) // no dashes in UUID
 	} else {
-		require.Len(t, db.clusterUUID, 0) // no dashes in UUID
+		require.Len(t, db.ClusterUUID, 0) // no dashes in UUID
 	}
 }
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3084,7 +3084,7 @@ func TestGetDatabaseCollectionWithUserDefaultCollection(t *testing.T) {
 
 }
 
-func TestClusterUUID(t *testing.T) {
+func TestServerUUID(t *testing.T) {
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
 
@@ -3092,9 +3092,9 @@ func TestClusterUUID(t *testing.T) {
 	require.NoError(t, err)
 
 	if base.TestUseCouchbaseServer() {
-		require.Len(t, db.ClusterUUID, 32) // no dashes in UUID
+		require.Len(t, db.ServerUUID, 32) // no dashes in UUID
 	} else {
-		require.Len(t, db.ClusterUUID, 0) // no dashes in UUID
+		require.Len(t, db.ServerUUID, 0) // no dashes in UUID
 	}
 }
 

--- a/db/document.go
+++ b/db/document.go
@@ -84,6 +84,8 @@ type SyncData struct {
 	// Only used for performance metrics:
 	TimeSaved time.Time `json:"time_saved,omitempty"` // Timestamp of save.
 
+	ClusterUUID string `json:"cluster_uuid,omitempty"` // Couchbase Server UUID when the document is updated
+
 	// Backward compatibility (the "deleted" field was, um, deleted in commit 4194f81, 2/17/14)
 	Deleted_OLD bool `json:"deleted,omitempty"`
 	// History should be marshalled last to optimize indexing (CBG-2559)
@@ -91,7 +93,6 @@ type SyncData struct {
 
 	addedRevisionBodies     []string          // revIDs of non-winning revision bodies that have been added (and so require persistence)
 	removedRevisionBodyKeys map[string]string // keys of non-winning revisions that have been removed (and so may require deletion), indexed by revID
-	ClusterUUID             string            `json:"cluster_uuid,omitempty"`
 }
 
 func (sd *SyncData) HashRedact(salt string) SyncData {

--- a/db/document.go
+++ b/db/document.go
@@ -91,6 +91,7 @@ type SyncData struct {
 
 	addedRevisionBodies     []string          // revIDs of non-winning revision bodies that have been added (and so require persistence)
 	removedRevisionBodyKeys map[string]string // keys of non-winning revisions that have been removed (and so may require deletion), indexed by revID
+	ClusterUUID             string            `json:"cluster_uuid,omitempty"`
 }
 
 func (sd *SyncData) HashRedact(salt string) SyncData {

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -487,3 +487,34 @@ func TestEvaluateFunction(t *testing.T) {
 	assert.Error(t, err, `strconv.ParseBool: parsing "TruE": invalid syntax`)
 	assert.False(t, result, "Import filter function should return true")
 }
+
+func TestImportStampClusterUUID(t *testing.T) {
+	if !base.TestUseXattrs() {
+		t.Skip("This test only works with XATTRS enabled")
+	}
+
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	collection := GetSingleDatabaseCollectionWithUser(t, db)
+
+	key := "doc1"
+	bodyBytes := rawDocNoMeta()
+
+	_, err := collection.dataStore.Add(key, 0, bodyBytes)
+	require.NoError(t, err)
+
+	body := Body{}
+	err = body.Unmarshal(rawDocNoMeta())
+	require.NoError(t, err)
+	existingDoc := &sgbucket.BucketDocument{Body: bodyBytes}
+
+	importedDoc, err := collection.importDoc(ctx, key, body, nil, false, existingDoc, ImportOnDemand)
+	require.NoError(t, err)
+	require.Equal(t, 32, len(importedDoc.ClusterUUID))
+
+	var xattr map[string]string
+	_, err = collection.dataStore.GetWithXattr(key, base.SyncXattrName, "", &body, &xattr, nil)
+	require.NoError(t, err)
+	require.Equal(t, 32, len(xattr["cluster_uuid"]))
+}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1122,7 +1122,7 @@ func (h *handler) handleGetStatus() error {
 		status.Databases[database.Name] = DatabaseStatus{
 			SequenceNumber:    lastSeq,
 			State:             runState,
-			ServerUUID:        database.GetServerUUID(h.ctx()),
+			ServerUUID:        database.ClusterUUID,
 			ReplicationStatus: replicationsStatus,
 			SGRCluster:        cluster,
 		}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1122,7 +1122,7 @@ func (h *handler) handleGetStatus() error {
 		status.Databases[database.Name] = DatabaseStatus{
 			SequenceNumber:    lastSeq,
 			State:             runState,
-			ServerUUID:        database.ClusterUUID,
+			ServerUUID:        database.ServerUUID,
 			ReplicationStatus: replicationsStatus,
 			SGRCluster:        cluster,
 		}

--- a/rest/api.go
+++ b/rest/api.go
@@ -427,7 +427,7 @@ func (h *handler) handleGetDB() error {
 		PurgeSequenceNumber:           0, // TODO: Should track this value
 		DiskFormatVersion:             0, // Probably meaningless, but add for compatibility
 		State:                         runState,
-		ServerUUID:                    h.db.DatabaseContext.ClusterUUID,
+		ServerUUID:                    h.db.DatabaseContext.ServerUUID,
 		// TODO: If running with multiple scope/collections
 		// Scopes: map[string]databaseRootScope{
 		// 	"scope1": {

--- a/rest/api.go
+++ b/rest/api.go
@@ -427,7 +427,7 @@ func (h *handler) handleGetDB() error {
 		PurgeSequenceNumber:           0, // TODO: Should track this value
 		DiskFormatVersion:             0, // Probably meaningless, but add for compatibility
 		State:                         runState,
-		ServerUUID:                    h.db.DatabaseContext.GetServerUUID(h.ctx()),
+		ServerUUID:                    h.db.DatabaseContext.ClusterUUID,
 		// TODO: If running with multiple scope/collections
 		// Scopes: map[string]databaseRootScope{
 		// 	"scope1": {


### PR DESCRIPTION
-renamed receiver methods from `db` -> `col` for clarity
- intentionally left UUID blank for walrus, but don't know if this is a good plan or not

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1486/
