### PR TITLE
CBG-2688 Modify sync function for collections

### DIFF
--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -56,9 +56,9 @@ func SyncFunctionKeyWithGroupID(groupID string) string {
 	return SyncFunctionKeyWithoutGroupID
 }
 
-// SyncFunctionKeyWithGroupID returns a doc ID to use when storing the sync function
+// CollectionsSyncFunctionKeyWithGroupID returns a doc ID to use when storing the sync function.
 func CollectionSyncFunctionKeyWithGroupID(groupID string, scopeName, collectionName string) string {
-	// use legacy format for _default._default
+	// use legacy format for _default._default for backward compatibility
 	if IsDefaultCollection(scopeName, collectionName) {
 		return SyncFunctionKeyWithGroupID(groupID)
 	}

--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -57,11 +57,15 @@ func SyncFunctionKeyWithGroupID(groupID string) string {
 }
 
 // SyncFunctionKeyWithGroupID returns a doc ID to use when storing the sync function
-func CollectionSyncFunctionKeyWithGroupID(groupID string, collectionID uint32) string {
-	if groupID != "" {
-		return fmt.Sprintf("%s:%d:%s", CollectionSyncFunctionKeyWithoutGroupID, collectionID, groupID)
+func CollectionSyncFunctionKeyWithGroupID(groupID string, scopeName, collectionName string) string {
+	// use legacy format for _default._default
+	if IsDefaultCollection(scopeName, collectionName) {
+		return SyncFunctionKeyWithGroupID(groupID)
 	}
-	return fmt.Sprintf("%s:%d", CollectionSyncFunctionKeyWithoutGroupID, collectionID)
+	if groupID != "" {
+		return fmt.Sprintf("%s:%s.%s:%s", CollectionSyncFunctionKeyWithoutGroupID, scopeName, collectionName, groupID)
+	}
+	return fmt.Sprintf("%s:%s.%s", CollectionSyncFunctionKeyWithoutGroupID, scopeName, collectionName)
 }
 
 // DCPCheckpointPrefixWithGroupID returns a doc ID prefix to use for DCP checkpoints

--- a/base/constants_syncdocs_test.go
+++ b/base/constants_syncdocs_test.go
@@ -1,0 +1,54 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package base
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectionSyncFunctionKeyWithGroupID(t *testing.T) {
+	testCases := []struct {
+		scopeName      string
+		collectionName string
+		groupID        string
+		key            string
+	}{
+		{
+			scopeName:      DefaultScope,
+			collectionName: DefaultCollection,
+			key:            "_sync:syncdata",
+		},
+		{
+			scopeName:      DefaultScope,
+			collectionName: DefaultCollection,
+			groupID:        "1",
+			key:            "_sync:syncdata:1",
+		},
+		{
+			scopeName:      "fooscope",
+			collectionName: "barcollection",
+			key:            "_sync:syncdata_collection:fooscope.barcollection",
+		},
+		{
+			scopeName:      "fooscope",
+			collectionName: "barcollection",
+			groupID:        "1",
+			key:            "_sync:syncdata_collection:fooscope.barcollection:1",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(fmt.Sprintf("%s.%s_GroupID:%s", test.scopeName, test.collectionName, test.groupID), func(t *testing.T) {
+			require.Equal(t, test.key, CollectionSyncFunctionKeyWithGroupID(test.groupID, test.scopeName, test.collectionName))
+		})
+	}
+}

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -61,7 +61,7 @@ func StartShardedDCPFeed(ctx context.Context, dbName string, configGroup string,
 		return nil, fmt.Errorf("failed to get minimum node version in cluster: %w", err)
 	}
 	if minVersion.Less(firstVersionToSupportCollections) {
-		if scope != "" || len(collections) > 0 {
+		if scope != DefaultScope || len(collections) > 0 {
 			return nil, fmt.Errorf("cannot start DCP feed on non-default collection with legacy nodes present in the cluster")
 		}
 	}

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -62,7 +62,7 @@ func StartShardedDCPFeed(ctx context.Context, dbName string, configGroup string,
 	}
 	if minVersion.Less(firstVersionToSupportCollections) {
 		// DefaultScope is allowed by older versions of CBGT as long as no collections are specified.
-		if scope != DefaultScope || len(collections) > 0 {
+		if len(collections) > 0 {
 			return nil, fmt.Errorf("cannot start DCP feed on non-default collection with legacy nodes present in the cluster")
 		}
 	}

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -61,6 +61,7 @@ func StartShardedDCPFeed(ctx context.Context, dbName string, configGroup string,
 		return nil, fmt.Errorf("failed to get minimum node version in cluster: %w", err)
 	}
 	if minVersion.Less(firstVersionToSupportCollections) {
+		// DefaultScope is allowed by older versions of CBGT as long as no collections are specified.
 		if scope != DefaultScope || len(collections) > 0 {
 			return nil, fmt.Errorf("cannot start DCP feed on non-default collection with legacy nodes present in the cluster")
 		}

--- a/channels/channelmapper_test.go
+++ b/channels/channelmapper_test.go
@@ -9,6 +9,7 @@
 package channels
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -594,6 +595,31 @@ func TestCollectionSyncFunction(t *testing.T) {
 			res, err := mapper.MapToChannelsAndAccess(parse(test.docBody), `{}`, emptyMetaMap(), noUser)
 			require.NoError(t, err)
 			require.Equal(t, BaseSetOf(t, collectionName), res.Channels)
+		})
+	}
+}
+
+func TestGetDefaultSyncFunction(t *testing.T) {
+	testCases := []struct {
+		scopeName      string
+		collectionName string
+		syncFn         string
+	}{
+		{
+			scopeName:      base.DefaultScope,
+			collectionName: base.DefaultCollection,
+			syncFn:         DocChannelsSyncFunction,
+		},
+		{
+			scopeName:      "fooscope",
+			collectionName: "barcollection",
+			syncFn:         `function(doc){channel("barcollection");}`,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(fmt.Sprintf("%s.%s", test.scopeName, test.collectionName), func(t *testing.T) {
+			require.Equal(t, test.syncFn, GetDefaultSyncFunction(test.scopeName, test.collectionName))
 		})
 	}
 }

--- a/db/access_test.go
+++ b/db/access_test.go
@@ -25,7 +25,7 @@ func TestDynamicChannelGrant(t *testing.T) {
 	defer db.Close(ctx)
 	dbCollection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	db.ChannelMapper = channels.NewChannelMapper(`
+	dbCollection.ChannelMapper = channels.NewChannelMapper(`
 	function(doc) {
 		if(doc.type == "setaccess") {
 			channel(doc.channel);

--- a/db/access_test.go
+++ b/db/access_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +25,7 @@ func TestDynamicChannelGrant(t *testing.T) {
 	defer db.Close(ctx)
 	dbCollection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	_, err := dbCollection.UpdateSyncFun(ctx, `
+	syncFn := `
 	function(doc) {
 		if(doc.type == "setaccess") {
 			channel(doc.channel);
@@ -32,8 +33,8 @@ func TestDynamicChannelGrant(t *testing.T) {
 		} else {
 			channel(doc.channel)
 		}
-	}`)
-	require.NoError(t, err)
+	}`
+	dbCollection.ChannelMapper = channels.NewChannelMapper(syncFn, db.Options.JavascriptTimeout)
 
 	a := dbCollection.Authenticator(ctx)
 	user, err := a.NewUser("user1", "letmein", nil)

--- a/db/access_test.go
+++ b/db/access_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/channels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,15 +24,16 @@ func TestDynamicChannelGrant(t *testing.T) {
 	defer db.Close(ctx)
 	dbCollection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	dbCollection.ChannelMapper = channels.NewChannelMapper(`
+	_, err := dbCollection.UpdateSyncFun(ctx, `
 	function(doc) {
 		if(doc.type == "setaccess") {
 			channel(doc.channel);
 			access(doc.owner, doc.channel);
-		} else { 
+		} else {
 			channel(doc.channel)
 		}
-	}`, 0)
+	}`)
+	require.NoError(t, err)
 
 	a := dbCollection.Authenticator(ctx)
 	user, err := a.NewUser("user1", "letmein", nil)

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -55,6 +55,13 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 			Enabled:          deltasEnabled,
 			RevMaxAgeSeconds: DefaultDeltaSyncRevMaxAge,
 		},
+		Scopes: map[string]ScopeOptions{
+			base.DefaultScope: ScopeOptions{
+				Collections: map[string]CollectionOptions{
+					base.DefaultCollection: {},
+				},
+			},
+		},
 	})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
 	defer dbCtx.Close(ctx)
@@ -109,13 +116,8 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 
 func TestAttachments(t *testing.T) {
 
-	ctx := base.TestCtx(t)
-	bucket := base.GetTestBucket(t)
-	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
-	assert.NoError(t, err, "Couldn't create context for database 'db'")
-	defer context.Close(ctx)
-	db, err := CreateDatabase(context)
-	assert.NoError(t, err, "Couldn't create database 'db'")
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 
 	// Test creating & updating a document:
 	log.Printf("Create rev 1...")
@@ -224,24 +226,18 @@ func TestAttachments(t *testing.T) {
 }
 
 func TestAttachmentForRejectedDocument(t *testing.T) {
-
-	ctx := base.TestCtx(t)
-	bucket := base.GetTestBucket(t)
-	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
-	assert.NoError(t, err, "Couldn't create context for database 'db'")
-	defer context.Close(ctx)
-	db, err := CreateDatabase(context)
-	assert.NoError(t, err, "Couldn't create database 'db'")
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {
+	collection.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {
 		throw({forbidden: "None shall pass!"});
 	}`, 0)
 
 	docBody := `{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
 	var body Body
 	require.NoError(t, base.JSONUnmarshal([]byte(docBody), &body))
-	_, _, err = collection.Put(ctx, "doc1", unjson(docBody))
+	_, _, err := collection.Put(ctx, "doc1", unjson(docBody))
 	require.Error(t, err)
 
 	// Attempt to retrieve the attachment doc
@@ -250,20 +246,15 @@ func TestAttachmentForRejectedDocument(t *testing.T) {
 }
 
 func TestAttachmentRetrievalUsingRevCache(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 
-	ctx := base.TestCtx(t)
-	bucket := base.GetTestBucket(t)
-	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
-	assert.NoError(t, err, "Couldn't create context for database 'db'")
-	defer context.Close(ctx)
-	db, err := CreateDatabase(context)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	assert.NoError(t, err, "Couldn't create database 'db'")
 
 	// Test creating & updating a document:
 	rev1input := `{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="},
                                     "bye.txt": {"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA=="}}}`
-	_, _, err = collection.Put(ctx, "doc1", unjson(rev1input))
+	_, _, err := collection.Put(ctx, "doc1", unjson(rev1input))
 	assert.NoError(t, err, "Couldn't create document")
 
 	initCount, countErr := base.GetExpvarAsInt("syncGateway_db", "document_gets")
@@ -437,13 +428,8 @@ func TestAttachmentCASRetryDuringNewAttachment(t *testing.T) {
 }
 
 func TestForEachStubAttachmentErrors(t *testing.T) {
-	ctx := base.TestCtx(t)
-	bucket := base.GetTestBucket(t)
-	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
-	assert.NoError(t, err, "Couldn't create context for database 'db'")
-	defer context.Close(ctx)
-	db, err := CreateDatabase(context)
-	assert.NoError(t, err, "Couldn't create database 'db'")
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
 	var body Body
@@ -458,7 +444,7 @@ func TestForEachStubAttachmentErrors(t *testing.T) {
 	docID := "foo"
 	existingDigests := make(map[string]string)
 	assert.NoError(t, base.JSONUnmarshal([]byte(doc), &body))
-	err = collection.ForEachStubAttachment(body, 1, docID, existingDigests, callback)
+	err := collection.ForEachStubAttachment(body, 1, docID, existingDigests, callback)
 	assert.Error(t, err, "It should throw 400 Invalid _attachments")
 	assert.Contains(t, err.Error(), strconv.Itoa(http.StatusBadRequest))
 
@@ -586,19 +572,14 @@ func TestDecodeAttachmentError(t *testing.T) {
 }
 
 func TestSetAttachment(t *testing.T) {
-	ctx := base.TestCtx(t)
-	bucket := base.GetTestBucket(t)
-	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
-	assert.NoError(t, err, "The database context should be created for database 'db'")
-	defer context.Close(ctx)
-	db, err := CreateDatabase(context)
-	assert.NoError(t, err, "The database 'db' should be created")
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
 	// Set attachment with a valid attachment
 	att := `{"att1.txt": {"data": "YXR0MS50eHQ="}}}`
 	key := Sha1DigestKey([]byte(att))
-	err = collection.setAttachment(ctx, key, []byte(att))
+	err := collection.setAttachment(ctx, key, []byte(att))
 	assert.NoError(t, err, "Attachment should be saved in db and key should be returned")
 	attBytes, err := collection.GetAttachment(key)
 	assert.NoError(t, err, "Attachment should be retrieved from the database")
@@ -606,13 +587,8 @@ func TestSetAttachment(t *testing.T) {
 }
 
 func TestRetrieveAncestorAttachments(t *testing.T) {
-	ctx := base.TestCtx(t)
-	bucket := base.GetTestBucket(t)
-	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
-	assert.NoError(t, err, "The database context should be created for database 'db'")
-	defer context.Close(ctx)
-	db, err := CreateDatabase(context)
-	require.NoError(t, err, "The database 'db' should be created")
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
 	var body Body
@@ -677,16 +653,11 @@ func TestRetrieveAncestorAttachments(t *testing.T) {
 }
 
 func TestStoreAttachments(t *testing.T) {
-	ctx := base.TestCtx(t)
-	bucket := base.GetTestBucket(t)
-	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
-	assert.NoError(t, err, "The database context should be created for database 'db'")
-	defer context.Close(ctx)
-	db, err := CreateDatabase(context)
-	require.NoError(t, err, "The database 'db' should be created")
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	var revBody Body
 
+	var revBody Body
 	// Simulate Invalid _attachments scenario; try to put a document with bad
 	// attachment metadata. It should throw "Invalid _attachments" error.
 	revText := `{"key1": "value1", "_attachments": {"att1.txt": "YXR0MS50eHQ="}}`
@@ -798,6 +769,7 @@ func TestMigrateBodyAttachments(t *testing.T) {
 		bucket := base.GetTestBucket(t)
 		dbCtx, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{
 			EnableXattr: base.TestUseXattrs(),
+			Scopes:      GetScopesConfigForDefaultCollection(),
 		})
 
 		assert.NoError(t, err, "The database context should be created for database 'db'")
@@ -1081,23 +1053,15 @@ func TestMigrateBodyAttachmentsMerge(t *testing.T) {
 
 	const docKey = "TestAttachmentMigrate"
 
-	ctx := base.TestCtx(t)
-	bucket := base.GetTestBucket(t)
-	dbCtx, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{
-		EnableXattr: base.TestUseXattrs(),
-	})
-	require.NoError(t, err, "The database context should be created for database 'db'")
-	defer dbCtx.Close(ctx)
-
-	db, err := CreateDatabase(dbCtx)
-	require.NoError(t, err, "The database 'db' should be created")
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
 	// Put a document 2 attachments, to write attachment to the bucket
 	rev1input := `{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="},"bye.txt": {"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA=="}}}`
 	var body Body
 	assert.NoError(t, base.JSONUnmarshal([]byte(rev1input), &body))
-	_, _, err = collection.Put(ctx, "doc1", body)
+	_, _, err := collection.Put(ctx, "doc1", body)
 	assert.NoError(t, err, "Couldn't create document")
 
 	gotbody, err := collection.Get1xRevBody(ctx, "doc1", "", false, []string{})
@@ -1246,23 +1210,15 @@ func TestMigrateBodyAttachmentsMergeConflicting(t *testing.T) {
 
 	const docKey = "TestAttachmentMigrate"
 
-	ctx := base.TestCtx(t)
-	bucket := base.GetTestBucket(t)
-	context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{
-		EnableXattr: base.TestUseXattrs(),
-	})
-	require.NoError(t, err, "The database context should be created for database 'db'")
-	defer context.Close(ctx)
-
-	db, err := CreateDatabase(context)
-	require.NoError(t, err, "The database 'db' should be created")
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
 	// Put a document with 3 attachments, to write attachments to the bucket
 	rev1input := `{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="},"bye.txt": {"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA=="},"new.txt": {"data":"bmV3IGRhdGE="}}}`
 	var body Body
 	assert.NoError(t, base.JSONUnmarshal([]byte(rev1input), &body))
-	_, _, err = collection.Put(ctx, "doc1", body)
+	_, _, err := collection.Put(ctx, "doc1", body)
 	assert.NoError(t, err, "Couldn't create document")
 
 	gotbody, err := collection.Get1xRevBody(ctx, "doc1", "", false, []string{})
@@ -1602,12 +1558,8 @@ func TestGetAttVersion(t *testing.T) {
 }
 
 func TestLargeAttachments(t *testing.T) {
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
-	assert.NoError(t, err, "Couldn't create context for database 'db'")
-	defer context.Close(ctx)
-	db, err := CreateDatabase(context)
-	require.NoError(t, err, "Couldn't create database 'db'")
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
 	normalAttachment := make([]byte, 15*1024*1024)   // permissible size
@@ -1617,7 +1569,7 @@ func TestLargeAttachments(t *testing.T) {
 	_, _ = rand.Read(oversizeAttachment)
 	_, _ = rand.Read(hugeAttachment)
 
-	_, _, err = collection.Put(ctx, "testdoc", Body{
+	_, _, err := collection.Put(ctx, "testdoc", Body{
 		"_attachments": AttachmentsMeta{
 			"foo.bin": map[string]interface{}{
 				"data": base64.StdEncoding.EncodeToString(normalAttachment),

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -401,10 +401,10 @@ function sync(doc, oldDoc){
 	channel("channel.ABC");
 }
 `
-	_, err := db.UpdateSyncFun(ctx, syncFn)
-	require.NoError(t, err)
-
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
+
+	_, err := collection.UpdateSyncFun(ctx, syncFn)
+	require.NoError(t, err)
 
 	// Create the docs that will be marked and not swept
 	body := map[string]interface{}{"foo": "bar"}
@@ -423,8 +423,7 @@ function sync(doc, oldDoc){
 	channel("channel.ABC123");
 }
 `
-
-		_, err = db.UpdateSyncFun(ctx, syncFn)
+		_, err = collection.UpdateSyncFun(ctx, syncFn)
 		require.NoError(t, err)
 	}
 	return db, ctx

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -141,7 +141,7 @@ func collectionBlipHandler(next blipHandlerFunc) blipHandlerFunc {
 	return func(bh *blipHandler, bm *blip.Message) error {
 		collectionIndexStr, ok := bm.Properties[BlipCollection]
 		if !ok {
-			if !bh.db.hasDefaultCollection() {
+			if !bh.db.HasDefaultCollection() {
 				return base.HTTPErrorf(http.StatusBadRequest, "Method requires passing a collection property and a prior GetCollections message")
 			}
 			// temp use private method

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -187,14 +187,10 @@ func TestLateSequenceHandling(t *testing.T) {
 }
 
 func TestLateSequenceHandlingWithMultipleListeners(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 
-	ctx := base.TestCtx(t)
-	b := base.GetTestBucket(t)
-	context, err := NewDatabaseContext(ctx, "db", b, false, DatabaseContextOptions{})
-	require.NoError(t, err)
-	defer context.Close(ctx)
-
-	collection := context.GetSingleDatabaseCollection()
+	collection := db.GetSingleDatabaseCollection()
 	collectionID := collection.GetCollectionID()
 
 	stats, err := base.NewSyncGatewayStats()

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1027,11 +1027,10 @@ func TestChannelQueryCancellation(t *testing.T) {
 	db, ctx := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
-	require.NoError(t, err)
+	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Write a handful of docs/sequences to the bucket
-	_, _, err = collection.Put(ctx, "key1", Body{"channels": "ABC"})
+	_, _, err := collection.Put(ctx, "key1", Body{"channels": "ABC"})
 	assert.NoError(t, err, "Put failed with error: %v", err)
 	_, _, err = collection.Put(ctx, "key2", Body{"channels": "ABC"})
 	assert.NoError(t, err, "Put failed with error: %v", err)
@@ -1668,8 +1667,7 @@ func TestInitializeEmptyCache(t *testing.T) {
 	db, ctx := setupTestDBWithCacheOptions(t, cacheOptions)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
-	require.NoError(t, err)
+	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
 	docCount := 0
@@ -1721,8 +1719,7 @@ func TestInitializeCacheUnderLoad(t *testing.T) {
 	db, ctx := setupTestDBWithCacheOptions(t, cacheOptions)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
-	require.NoError(t, err)
+	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Writes [docCount] documents.  Use wait group (writesDone)to identify when all docs have been written.
 	// Use another waitGroup (writesInProgress) to trigger getChanges midway through writes
@@ -1778,8 +1775,7 @@ func TestNotifyForInactiveChannel(t *testing.T) {
 	defer db.Close(ctx)
 
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
-	require.NoError(t, err)
+	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 	collectionID := collection.GetCollectionID()
 
 	// -------- Setup notifyChange callback ----------------
@@ -1794,7 +1790,7 @@ func TestNotifyForInactiveChannel(t *testing.T) {
 
 	// Write a document to channel zero
 	body := Body{"channels": []string{"zero"}}
-	_, _, err = collection.Put(ctx, "inactiveCacheNotify", body)
+	_, _, err := collection.Put(ctx, "inactiveCacheNotify", body)
 	assert.NoError(t, err)
 
 	// Wait for notify to arrive

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1026,10 +1026,12 @@ func TestChannelQueryCancellation(t *testing.T) {
 
 	db, ctx := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
 	defer db.Close(ctx)
-
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
+	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
+	require.NoError(t, err)
+
 	// Write a handful of docs/sequences to the bucket
-	_, _, err := collection.Put(ctx, "key1", Body{"channels": "ABC"})
+	_, _, err = collection.Put(ctx, "key1", Body{"channels": "ABC"})
 	assert.NoError(t, err, "Put failed with error: %v", err)
 	_, _, err = collection.Put(ctx, "key2", Body{"channels": "ABC"})
 	assert.NoError(t, err, "Put failed with error: %v", err)

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -56,8 +56,7 @@ func TestFilterToAvailableChannels(t *testing.T) {
 			db, ctx := setupTestDB(t)
 			defer db.Close(ctx)
 			collection := GetSingleDatabaseCollectionWithUser(t, db)
-			_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
-			require.NoError(t, err)
+			collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 			auth := db.Authenticator(base.TestCtx(t))
 			user, err := auth.NewUser("test", "pass", testCase.userChans)
@@ -103,8 +102,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 
-	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
-	require.NoError(t, err)
+	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Create a user with access to channel ABC
 	authenticator := db.Authenticator(base.TestCtx(t))
@@ -114,7 +112,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
 
 	// Create a doc on two channels (sequence 1):
-	_, _, err = collection.Put(ctx, "doc1", Body{"channels": []string{"ABC", "PBS"}})
+	_, _, err := collection.Put(ctx, "doc1", Body{"channels": []string{"ABC", "PBS"}})
 	require.NoError(t, err)
 	cacheWaiter.AddAndWait(1)
 
@@ -214,12 +212,12 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
-	require.NoError(t, err)
+	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Create a user with access to channel A
 	authenticator := db.Authenticator(base.TestCtx(t))
-	user, _ := authenticator.NewUser("alice", "letmein", channels.BaseSetOf(t, "A"))
+	user, err := authenticator.NewUser("alice", "letmein", channels.BaseSetOf(t, "A"))
+	require.NoError(t, err)
 	require.NoError(t, authenticator.Save(user))
 
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
@@ -300,12 +298,12 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
-	require.NoError(t, err)
+	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Create a user with access to channel A
 	authenticator := db.Authenticator(base.TestCtx(t))
-	user, _ := authenticator.NewUser("alice", "letmein", channels.BaseSetOf(t, "A"))
+	user, err := authenticator.NewUser("alice", "letmein", channels.BaseSetOf(t, "A"))
+	require.NoError(t, err)
 	require.NoError(t, authenticator.Save(user))
 
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -56,6 +56,8 @@ func TestFilterToAvailableChannels(t *testing.T) {
 			db, ctx := setupTestDB(t)
 			defer db.Close(ctx)
 			collection := GetSingleDatabaseCollectionWithUser(t, db)
+			_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
+			require.NoError(t, err)
 
 			auth := db.Authenticator(base.TestCtx(t))
 			user, err := auth.NewUser("test", "pass", testCase.userChans)
@@ -101,7 +103,8 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 
-	db.ChannelMapper = channels.NewDefaultChannelMapper()
+	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
+	require.NoError(t, err)
 
 	// Create a user with access to channel ABC
 	authenticator := db.Authenticator(base.TestCtx(t))
@@ -111,7 +114,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
 
 	// Create a doc on two channels (sequence 1):
-	_, _, err := collection.Put(ctx, "doc1", Body{"channels": []string{"ABC", "PBS"}})
+	_, _, err = collection.Put(ctx, "doc1", Body{"channels": []string{"ABC", "PBS"}})
 	require.NoError(t, err)
 	cacheWaiter.AddAndWait(1)
 
@@ -211,7 +214,8 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	db.ChannelMapper = channels.NewDefaultChannelMapper()
+	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
+	require.NoError(t, err)
 
 	// Create a user with access to channel A
 	authenticator := db.Authenticator(base.TestCtx(t))
@@ -227,7 +231,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 
 	collection.user, _ = authenticator.GetUser("alice")
 	changes, err := collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq())
-	assert.NoError(t, err, "Couldn't GetChanges")
+	require.NoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)
 	assert.Equal(t, 1, len(changes))
 	collectionID := collection.GetCollectionID()
@@ -296,7 +300,8 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	db.ChannelMapper = channels.NewDefaultChannelMapper()
+	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
+	require.NoError(t, err)
 
 	// Create a user with access to channel A
 	authenticator := db.Authenticator(base.TestCtx(t))

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -28,12 +28,10 @@ func TestDuplicateDocID(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
-	require.NoError(t, err)
-	defer context.Close(ctx)
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 
-	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
+	collectionID := db.GetSingleDatabaseCollection().GetCollectionID()
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
@@ -41,7 +39,7 @@ func TestDuplicateDocID(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
-	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	// Add some entries to cache
@@ -85,10 +83,8 @@ func TestLateArrivingSequence(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
-	require.NoError(t, err)
-	defer context.Close(ctx)
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
@@ -96,9 +92,9 @@ func TestLateArrivingSequence(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
-	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
+	collectionID := db.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	// Add some entries to cache
@@ -128,10 +124,8 @@ func TestLateSequenceAsFirst(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
-	require.NoError(t, err)
-	defer context.Close(ctx)
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
@@ -139,9 +133,9 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
-	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
+	collectionID := db.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	// Add some entries to cache
@@ -171,10 +165,8 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
-	require.NoError(t, err)
-	defer context.Close(ctx)
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
@@ -182,9 +174,9 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
-	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
+	collectionID := db.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	// Add some entries to cache
@@ -255,10 +247,8 @@ func TestPrependChanges(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	ctx := base.TestCtx(t)
-	dbCtx, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
-	require.NoError(t, err)
-	defer dbCtx.Close(ctx)
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 
 	// 1. Test prepend to empty cache
 	stats, err := base.NewSyncGatewayStats()
@@ -267,9 +257,9 @@ func TestPrependChanges(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
-	collectionID := dbCtx.GetSingleDatabaseCollection().GetCollectionID()
+	collectionID := db.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(dbCtx.GetSingleDatabaseCollection(), channels.NewID("PrependEmptyCache", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("PrependEmptyCache", collectionID), 0, dbstats.Cache())
 	assert.NotNil(t, cache)
 
 	changesToPrepend := LogEntries{
@@ -291,7 +281,7 @@ func TestPrependChanges(t *testing.T) {
 	require.NoError(t, err)
 	dbstats, err = stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
-	cache = newSingleChannelCache(dbCtx.GetSingleDatabaseCollection(), channels.NewID("PrependPopulatedCache", collectionID), 0, dbstats.Cache())
+	cache = newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("PrependPopulatedCache", collectionID), 0, dbstats.Cache())
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
 	cache.addToCache(testLogEntry(20, "doc2", "3-a"), false)
@@ -349,7 +339,7 @@ func TestPrependChanges(t *testing.T) {
 	require.NoError(t, err)
 	dbstats, err = stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
-	cache = newSingleChannelCache(dbCtx.GetSingleDatabaseCollection(), channels.NewID("PrependToFillCache", collectionID), 0, dbstats.Cache())
+	cache = newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("PrependToFillCache", collectionID), 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
@@ -390,7 +380,7 @@ func TestPrependChanges(t *testing.T) {
 	require.NoError(t, err)
 	dbstats, err = stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
-	cache = newSingleChannelCache(dbCtx.GetSingleDatabaseCollection(), channels.NewID("PrependDuplicatesOnly", collectionID), 0, dbstats.Cache())
+	cache = newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("PrependDuplicatesOnly", collectionID), 0, dbstats.Cache())
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
 	cache.addToCache(testLogEntry(20, "doc2", "3-a"), false)
@@ -424,7 +414,7 @@ func TestPrependChanges(t *testing.T) {
 	require.NoError(t, err)
 	dbstats, err = stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
-	cache = newSingleChannelCache(dbCtx.GetSingleDatabaseCollection(), channels.NewID("PrependFullCache", collectionID), 0, dbstats.Cache())
+	cache = newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("PrependFullCache", collectionID), 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
@@ -466,10 +456,8 @@ func TestChannelCacheRemove(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
-	require.NoError(t, err)
-	defer context.Close(ctx)
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
@@ -477,9 +465,9 @@ func TestChannelCacheRemove(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
-	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
+	collectionID := db.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, dbstats.Cache())
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
@@ -515,10 +503,8 @@ func TestChannelCacheStats(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
-	require.NoError(t, err)
-	defer context.Close(ctx)
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
@@ -526,10 +512,10 @@ func TestChannelCacheStats(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
-	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
+	collectionID := db.GetSingleDatabaseCollection().GetCollectionID()
 
 	testStats := dbstats.Cache()
-	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, testStats)
+	cache := newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, testStats)
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
@@ -595,10 +581,8 @@ func TestChannelCacheStatsOnPrune(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
-	require.NoError(t, err)
-	defer context.Close(ctx)
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
@@ -606,10 +590,10 @@ func TestChannelCacheStatsOnPrune(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
-	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
+	collectionID := db.GetSingleDatabaseCollection().GetCollectionID()
 
 	testStats := dbstats.Cache()
-	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, testStats)
+	cache := newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 0, testStats)
 	cache.options.ChannelCacheMaxLength = 5
 
 	// Add more than ChannelCacheMaxLength entries to cache
@@ -635,10 +619,8 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
-	require.NoError(t, err)
-	defer context.Close(ctx)
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
@@ -646,10 +628,10 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(t, err)
 
-	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
+	collectionID := db.GetSingleDatabaseCollection().GetCollectionID()
 
 	testStats := dbstats.Cache()
-	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 99, testStats)
+	cache := newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("Test1", collectionID), 99, testStats)
 	cache.options.ChannelCacheMaxLength = 15
 
 	// Add 9 entries to cache, 3 of each type
@@ -734,10 +716,8 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 
 	base.DisableTestLogging(b)
 
-	ctx := base.TestCtx(b)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
-	require.NoError(b, err)
-	defer context.Close(ctx)
+	db, ctx := setupTestDB(b)
+	defer db.Close(ctx)
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
@@ -745,9 +725,9 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(b, err)
 
-	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
+	collectionID := db.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
 	docIDs := make([]string, b.N)
 	for i := 0; i < b.N; i++ {
@@ -763,10 +743,8 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 
 	base.DisableTestLogging(b)
 
-	ctx := base.TestCtx(b)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
-	require.NoError(b, err)
-	defer context.Close(ctx)
+	db, ctx := setupTestDB(b)
+	defer db.Close(ctx)
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
@@ -774,9 +752,9 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(b, err)
 
-	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
+	collectionID := db.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(5.0, b.N)
@@ -790,19 +768,17 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 
 	base.DisableTestLogging(b)
 
-	ctx := base.TestCtx(b)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
-	require.NoError(b, err)
-	defer context.Close(ctx)
+	db, ctx := setupTestDB(b)
+	defer db.Close(ctx)
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
 	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(b, err)
 
-	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
+	collectionID := db.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(20.0, b.N)
@@ -816,19 +792,17 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 
 	base.DisableTestLogging(b)
 
-	ctx := base.TestCtx(b)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
-	require.NoError(b, err)
-	defer context.Close(ctx)
+	db, ctx := setupTestDB(b)
+	defer db.Close(ctx)
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
 	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(b, err)
 
-	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
+	collectionID := db.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(50.0, b.N)
@@ -842,19 +816,17 @@ func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 
 	base.DisableTestLogging(b)
 
-	ctx := base.TestCtx(b)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
-	require.NoError(b, err)
-	defer context.Close(ctx)
+	db, ctx := setupTestDB(b)
+	defer db.Close(ctx)
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
 	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(b, err)
 
-	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
+	collectionID := db.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(80.0, b.N)
@@ -868,19 +840,17 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 
 	base.SetUpBenchmarkLogging(b, base.LevelInfo, base.KeyHTTP)
 
-	ctx := base.TestCtx(b)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
-	require.NoError(b, err)
-	defer context.Close(ctx)
+	db, ctx := setupTestDB(b)
+	defer db.Close(ctx)
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
 	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(b, err)
 
-	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
+	collectionID := db.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(95.0, b.N)
@@ -894,19 +864,17 @@ func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 
 	base.DisableTestLogging(b)
 
-	ctx := base.TestCtx(b)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
-	require.NoError(b, err)
-	defer context.Close(ctx)
+	db, ctx := setupTestDB(b)
+	defer db.Close(ctx)
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
 	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
 	require.NoError(b, err)
 
-	collectionID := context.GetSingleDatabaseCollection().GetCollectionID()
+	collectionID := db.GetSingleDatabaseCollection().GetCollectionID()
 
-	cache := newSingleChannelCache(context.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
+	cache := newSingleChannelCache(db.GetSingleDatabaseCollection(), channels.NewID("Benchmark", collectionID), 0, dbstats.Cache())
 	// generate docs
 	docs := make([]*LogEntry, b.N)
 	r := rand.New(rand.NewSource(99))

--- a/db/crud.go
+++ b/db/crud.go
@@ -2228,7 +2228,7 @@ func (col *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context,
 	}
 	oldJson = string(oldJsonBytes)
 
-	if col.channelMapper() != nil {
+	if col.ChannelMapper != nil {
 		// Call the ChannelMapper:
 		col.dbStats().Database().SyncFunctionCount.Add(1)
 		col.collectionStats.SyncFunctionCount.Add(1)
@@ -2236,7 +2236,7 @@ func (col *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context,
 		var output *channels.ChannelMapperOutput
 
 		startTime := time.Now()
-		output, err = col.channelMapper().MapToChannelsAndAccess(body, oldJson, metaMap,
+		output, err = col.ChannelMapper.MapToChannelsAndAccess(body, oldJson, metaMap,
 			MakeUserCtx(col.user, col.ScopeName, col.Name))
 		syncFunctionTimeNano := time.Since(startTime).Nanoseconds()
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -2274,14 +2274,18 @@ func (col *DatabaseCollectionWithUser) getChannelsAndAccess(ctx context.Context,
 		}
 
 	} else {
-		// No ChannelMapper so by default use the "channels" property:
-		value := body["channels"]
-		if value != nil {
-			array, nonStrings := base.ValueToStringArray(value)
-			if nonStrings != nil {
-				base.WarnfCtx(ctx, "Channel names must be string values only. Ignoring non-string channels: %s", base.UD(nonStrings))
+		if base.IsDefaultCollection(col.ScopeName, col.Name) {
+			// No ChannelMapper so by default use the "channels" property:
+			value := body["channels"]
+			if value != nil {
+				array, nonStrings := base.ValueToStringArray(value)
+				if nonStrings != nil {
+					base.WarnfCtx(ctx, "Channel names must be string values only. Ignoring non-string channels: %s", base.UD(nonStrings))
+				}
+				result, err = channels.SetFromArray(array, channels.KeepStar)
 			}
-			result, err = channels.SetFromArray(array, channels.KeepStar)
+		} else {
+			result = base.SetOf(col.Name)
 		}
 	}
 	return result, access, roles, expiry, oldJson, err

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -946,8 +946,6 @@ func TestLargeSequence(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	db.ChannelMapper = channels.NewDefaultChannelMapper()
-
 	// Write a doc via SG
 	body := Body{"key1": "largeSeqTest"}
 	_, _, err := collection.PutExistingRevWithBody(ctx, "largeSeqDoc", body, []string{"1-a"}, false)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -17,7 +17,6 @@ import (
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/channels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -815,8 +814,6 @@ func TestOldRevisionStorageError(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {channel(doc.channels);}`, 0)
-
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "v": "1a"}
@@ -984,7 +981,6 @@ func TestMalformedRevisionStorageRecovery(t *testing.T) {
 	defer db.Close(ctx)
 
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {channel(doc.channels);}`, 0)
 
 	// Create a document with a malformed revision body (due to https://github.com/couchbase/sync_gateway/issues/3692) in the bucket
 	// Document has the following rev tree, with a malformed body of revision 2-b remaining in the revision tree (same set of operations as

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1194,12 +1194,8 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 }
 
 func TestGetAvailableRevAttachments(t *testing.T) {
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
-	assert.NoError(t, err, "Couldn't create context for database 'db'")
-	defer context.Close(ctx)
-	db, err := CreateDatabase(context)
-	require.NoError(t, err, "Couldn't create database 'db'")
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
 	// Create the very first revision of the document with attachment; let's call this as rev 1-a
@@ -1236,12 +1232,8 @@ func TestGetAvailableRevAttachments(t *testing.T) {
 }
 
 func TestGet1xRevAndChannels(t *testing.T) {
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
-	assert.NoError(t, err, "Couldn't create context for database 'db'")
-	defer context.Close(ctx)
-	db, err := CreateDatabase(context)
-	require.NoError(t, err, "Couldn't create database 'db'")
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
 	docId := "dd6d2dcc679d12b9430a9787bab45b33"
@@ -1301,12 +1293,8 @@ func TestGet1xRevAndChannels(t *testing.T) {
 }
 
 func TestGet1xRevFromDoc(t *testing.T) {
-	ctx := base.TestCtx(t)
-	context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, DatabaseContextOptions{})
-	assert.NoError(t, err, "Couldn't create context for database 'db'")
-	defer context.Close(ctx)
-	db, err := CreateDatabase(context)
-	require.NoError(t, err, "Couldn't create database 'db'")
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
 	// Create the first revision of the document

--- a/db/database.go
+++ b/db/database.go
@@ -441,6 +441,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	}
 	dbContext.Scopes = make(map[string]Scope, len(options.Scopes))
 	dbContext.CollectionNames = make(map[string]map[string]struct{}, len(options.Scopes))
+	// if any sync functions for any collection, we recommend running a resync
 	syncFunctionsChanged := false
 	for scopeName, scope := range options.Scopes {
 		dbContext.Scopes[scopeName] = Scope{
@@ -466,7 +467,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 				if err != nil {
 					return nil, err
 				}
-				if !fnChanged {
+				if fnChanged {
 					syncFunctionsChanged = true
 				}
 

--- a/db/database.go
+++ b/db/database.go
@@ -460,7 +460,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 				if err != nil {
 					return nil, err
 				}
-				syncFn := ""
+				syncFn := channels.GetDefaultSyncFunction(scopeName, collName)
 				if collOpts.Sync != nil {
 					syncFn = *collOpts.Sync
 				}

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -104,13 +104,8 @@ func (c *DatabaseCollection) changeCache() *changeCache {
 	return &c.dbCtx.changeCache
 }
 
-// channelMapper runs the javascript sync function. This is currently at the database level.
+// channelMapper runs the javascript sync function.
 func (c *DatabaseCollection) channelMapper() *channels.ChannelMapper {
-	// FIXME: this supports RestTesterConfig.SyncFn being applied to named bucket for single bucket testing.  That should
-	//  be done by test code, not here
-	if c.ChannelMapper == nil {
-		return c.dbCtx.ChannelMapper
-	}
 	return c.ChannelMapper
 }
 
@@ -282,9 +277,7 @@ func (c *DatabaseCollection) useViews() bool {
 	return c.dbCtx.Options.UseViews
 }
 
-// ////// SYNC FUNCTION:
-
-// Sets the database context's sync function based on the JS code from config.
+// Sets the collection's sync function based on the JS code from config.
 // Returns a boolean indicating whether the function is different from the saved one.
 // If multiple gateway instances try to update the function at the same time (to the same new
 // value) only one of them will get a changed=true result.
@@ -305,7 +298,7 @@ func (dc *DatabaseCollection) UpdateSyncFun(ctx context.Context, syncFun string)
 		Sync string
 	}
 
-	syncFunctionDocID := base.CollectionSyncFunctionKeyWithGroupID(dc.dbCtx.Options.GroupID, dc.GetCollectionID())
+	syncFunctionDocID := base.CollectionSyncFunctionKeyWithGroupID(dc.dbCtx.Options.GroupID, dc.ScopeName, dc.Name)
 	_, err = dc.dbCtx.MetadataStore.Update(syncFunctionDocID, 0, func(currentValue []byte) ([]byte, *uint32, bool, error) {
 		// The first time opening a new db, currentValue will be nil. Don't treat this as a change.
 		if currentValue != nil {

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -186,6 +186,11 @@ func (c *DatabaseCollection) IsClosed() bool {
 	return c.dataStore == nil
 }
 
+// IsDefaultCollection returns true if collection is _default._default.
+func (c *DatabaseCollection) IsDefaultCollection() bool {
+	return c.GetCollectionID() == base.DefaultCollectionID
+}
+
 // isGuestReadOnly returns true if the guest user can only perform read operations. This is controlled at the database level.
 func (c *DatabaseCollection) isGuestReadOnly() bool {
 	return c.dbCtx.Options.UnsupportedOptions != nil && c.dbCtx.Options.UnsupportedOptions.GuestReadOnly

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -104,11 +104,6 @@ func (c *DatabaseCollection) changeCache() *changeCache {
 	return &c.dbCtx.changeCache
 }
 
-// channelMapper runs the javascript sync function.
-func (c *DatabaseCollection) channelMapper() *channels.ChannelMapper {
-	return c.ChannelMapper
-}
-
 // channelQueryLimit returns the pagination for the number of channels returned in a query. This is a database level property.
 func (c *DatabaseCollection) channelQueryLimit() int {
 	return c.dbCtx.Options.CacheOptions.ChannelQueryLimit

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -188,7 +188,7 @@ func (c *DatabaseCollection) IsClosed() bool {
 
 // IsDefaultCollection returns true if collection is _default._default.
 func (c *DatabaseCollection) IsDefaultCollection() bool {
-	return c.GetCollectionID() == base.DefaultCollectionID
+	return base.IsDefaultCollection(c.ScopeName, c.Name)
 }
 
 // isGuestReadOnly returns true if the guest user can only perform read operations. This is controlled at the database level.

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -21,10 +21,6 @@ package db
 
 // Update database-specific stats that are more efficiently calculated at stats collection time
 func (db *DatabaseContext) UpdateCalculatedStats() {
-	if !db.hasDefaultCollection() {
-		return
-	}
-
 	db.changeCache.updateStats()
 	channelCache := db.changeCache.getChannelCache()
 	db.DbStats.Cache().ChannelCacheMaxEntries.Set(int64(channelCache.MaxCacheSize()))

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -305,8 +305,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
-	require.NoError(t, err)
+	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	rev1body := Body{
 		"key1":     1234,
@@ -415,8 +414,7 @@ func TestGetRemovalMultiChannel(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
-	require.NoError(t, err)
+	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	auth := db.Authenticator(base.TestCtx(t))
 
@@ -587,8 +585,7 @@ func TestDeltaSyncWhenToRevIsChannelRemoval(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
-	require.NoError(t, err)
+	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Create the first revision of doc1.
 	rev1Body := Body{
@@ -819,13 +816,12 @@ func TestAllDocsOnly(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
-	require.NoError(t, err)
+	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	collectionID := collection.GetCollectionID()
 
 	// Trigger creation of the channel cache for channel "all"
-	_, err = db.changeCache.getChannelCache().getSingleChannelCache(channels.NewID("all", collectionID))
+	_, err := db.changeCache.getChannelCache().getSingleChannelCache(channels.NewID("all", collectionID))
 	require.NoError(t, err)
 
 	ids := make([]AllDocsEntry, 100)
@@ -1003,14 +999,13 @@ func TestConflicts(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
-	require.NoError(t, err)
+	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Instantiate channel cache for channel 'all'
 	collectionID := collection.GetCollectionID()
 
 	allChannel := channels.NewID("all", collectionID)
-	_, err = db.changeCache.getChannelCache().getSingleChannelCache(allChannel)
+	_, err := db.changeCache.getChannelCache().getSingleChannelCache(allChannel)
 	require.NoError(t, err)
 
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
@@ -1417,11 +1412,10 @@ func TestInvalidChannel(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
-	require.NoError(t, err)
+	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	body := Body{"channels": []string{"bad,name"}}
-	_, _, err = collection.Put(ctx, "doc", body)
+	_, _, err := collection.Put(ctx, "doc", body)
 	assertHTTPError(t, err, 500)
 }
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3066,11 +3066,8 @@ func TestGetDatabaseCollectionWithUserDefaultCollection(t *testing.T) {
 }
 
 func TestServerUUID(t *testing.T) {
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
-
-	db, err := NewDatabaseContext(base.TestCtx(t), "db", bucket, false, DatabaseContextOptions{})
-	require.NoError(t, err)
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 
 	if base.TestUseCouchbaseServer() {
 		require.Len(t, db.ServerUUID, 32) // no dashes in UUID

--- a/db/dcp_sharded_upgrade_test.go
+++ b/db/dcp_sharded_upgrade_test.go
@@ -224,6 +224,7 @@ func TestShardedDCPUpgrade(t *testing.T) {
 		ImportOptions: ImportOptions{
 			ImportPartitions: numPartitions,
 		},
+		// Use default collection namespace since this will make sure we are upgrading from 3.0 -> post 3.0
 		Scopes: GetScopesOptionsDefaultCollectionOnly(t),
 	})
 	require.NoError(t, err, "NewDatabaseContext")

--- a/db/dcp_sharded_upgrade_test.go
+++ b/db/dcp_sharded_upgrade_test.go
@@ -224,6 +224,7 @@ func TestShardedDCPUpgrade(t *testing.T) {
 		ImportOptions: ImportOptions{
 			ImportPartitions: numPartitions,
 		},
+		Scopes: GetScopesOptionsDefaultCollectionOnly(t),
 	})
 	require.NoError(t, err, "NewDatabaseContext")
 	defer db.Close(ctx)

--- a/db/functions/function_test.go
+++ b/db/functions/function_test.go
@@ -646,7 +646,7 @@ func setupTestDBWithFunctions(t *testing.T, fnConfig *FunctionsConfig, gqConfig 
 	cacheOptions := db.DefaultCacheOptions()
 	options := db.DatabaseContextOptions{
 		CacheOptions: &cacheOptions,
-		Scopes:       db.GetScopesConfigForDefaultCollection(),
+		Scopes:       db.GetScopesOptionsDefaultCollectionOnly(t),
 	}
 	var err error
 	if fnConfig != nil {

--- a/db/functions/function_test.go
+++ b/db/functions/function_test.go
@@ -646,6 +646,7 @@ func setupTestDBWithFunctions(t *testing.T, fnConfig *FunctionsConfig, gqConfig 
 	cacheOptions := db.DefaultCacheOptions()
 	options := db.DatabaseContextOptions{
 		CacheOptions: &cacheOptions,
+		Scopes:       db.GetScopesConfigForDefaultCollection(),
 	}
 	var err error
 	if fnConfig != nil {

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -217,7 +217,7 @@ func TestPostUpgradeMultipleCollections(t *testing.T) {
 	if base.TestsUseNamedCollections() {
 		numCollections := 2
 		base.RequireNumTestDataStores(t, numCollections)
-		dbOptions.Scopes = getScopesOptions(t, tb, numCollections)
+		dbOptions.Scopes = GetScopesOptions(t, tb, numCollections)
 	}
 
 	db, ctx := SetupTestDBForDataStoreWithOptions(t, tb, dbOptions)

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -308,7 +308,6 @@ func TestAllPrincipalIDs(t *testing.T) {
 			base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 
 			database.Options.QueryPaginationLimit = 100
-			database.ChannelMapper = channels.NewDefaultChannelMapper()
 			authenticator := database.Authenticator(ctx)
 
 			rolename1 := uuid.NewString()
@@ -394,7 +393,6 @@ func TestGetRoleIDs(t *testing.T) {
 			base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 
 			database.Options.QueryPaginationLimit = 100
-			database.ChannelMapper = channels.NewDefaultChannelMapper()
 			authenticator := database.Authenticator(ctx)
 
 			rolename1 := uuid.NewString()

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -33,8 +33,9 @@ func TestQueryChannelsStatsView(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
-	require.NoError(t, err)
+
+	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+
 	// docID -> Sequence
 	docSeqMap := make(map[string]uint64, 3)
 
@@ -89,8 +90,8 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
-	require.NoError(t, err)
+
+	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// docID -> Sequence
 	docSeqMap := make(map[string]uint64, 3)
@@ -271,10 +272,11 @@ func TestAccessQuery(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	_, err := collection.UpdateSyncFun(ctx, `function(doc, oldDoc) {
+	collection.ChannelMapper = channels.NewChannelMapper(
+		`function(doc, oldDoc) {
 	access(doc.accessUser, doc.accessChannel)
-}`)
-	require.NoError(t, err)
+}`,
+		db.Options.JavascriptTimeout)
 	// Add docs with access grants assignment
 	for i := 1; i <= 5; i++ {
 		_, _, err := collection.Put(ctx, fmt.Sprintf("accessTest%d", i), Body{"accessUser": "user1", "accessChannel": fmt.Sprintf("channel%d", i)})
@@ -319,10 +321,10 @@ func TestRoleAccessQuery(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	_, err := collection.UpdateSyncFun(ctx, `function(doc, oldDoc) {
-	role(doc.accessUser, "role:" + doc.accessChannel)
-}`)
-	require.NoError(t, err)
+	collection.ChannelMapper = channels.NewChannelMapper(
+		`function(doc, oldDoc) {
+	ole(doc.accessUser, "role:" + doc.accessChannel)
+}`, db.Options.JavascriptTimeout)
 	// Add docs with access grants assignment
 	for i := 1; i <= 5; i++ {
 		_, _, err := collection.Put(ctx, fmt.Sprintf("accessTest%d", i), Body{"accessUser": "user1", "accessChannel": fmt.Sprintf("channel%d", i)})
@@ -375,8 +377,7 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
-	require.NoError(t, err)
+	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 	docIdFlagMap := make(map[string]uint8)
 	var startSeq, endSeq uint64
 	body := Body{"channels": []string{"ABC"}}

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -33,7 +33,7 @@ func TestQueryChannelsStatsView(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-
+	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
 	// docID -> Sequence
 	docSeqMap := make(map[string]uint64, 3)
 
@@ -88,6 +88,8 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
+	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
+	require.NoError(t, err)
 
 	// docID -> Sequence
 	docSeqMap := make(map[string]uint64, 3)
@@ -268,9 +270,10 @@ func TestAccessQuery(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {
+	_, err := collection.UpdateSyncFun(ctx, `function(doc, oldDoc) {
 	access(doc.accessUser, doc.accessChannel)
-}`, 0)
+}`)
+	require.NoError(t, err)
 	// Add docs with access grants assignment
 	for i := 1; i <= 5; i++ {
 		_, _, err := collection.Put(ctx, fmt.Sprintf("accessTest%d", i), Body{"accessUser": "user1", "accessChannel": fmt.Sprintf("channel%d", i)})
@@ -315,9 +318,10 @@ func TestRoleAccessQuery(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {
+	_, err := collection.UpdateSyncFun(ctx, `function(doc, oldDoc) {
 	role(doc.accessUser, "role:" + doc.accessChannel)
-}`, 0)
+}`)
+	require.NoError(t, err)
 	// Add docs with access grants assignment
 	for i := 1; i <= 5; i++ {
 		_, _, err := collection.Put(ctx, fmt.Sprintf("accessTest%d", i), Body{"accessUser": "user1", "accessChannel": fmt.Sprintf("channel%d", i)})
@@ -370,7 +374,8 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-
+	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
+	require.NoError(t, err)
 	docIdFlagMap := make(map[string]uint8)
 	var startSeq, endSeq uint64
 	body := Body{"channels": []string{"ABC"}}

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -34,6 +34,7 @@ func TestQueryChannelsStatsView(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 	_, err := collection.UpdateSyncFun(ctx, channels.DocChannelsSyncFunction)
+	require.NoError(t, err)
 	// docID -> Sequence
 	docSeqMap := make(map[string]uint64, 3)
 

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -649,16 +649,17 @@ func TestReplicateGroupIDAssignedNodes(t *testing.T) {
 	defer tb.Close()
 	ctx := base.TestCtx(t)
 
+	const numCollections = 1
 	// Set up databases
-	dbDefault, err := NewDatabaseContext(ctx, "default", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "", Scopes: GetScopesConfigForDefaultCollection()})
+	dbDefault, err := NewDatabaseContext(ctx, "default", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "", Scopes: GetScopesOptions(t, tb, 1)})
 	require.NoError(t, err)
 	defer dbDefault.Close(ctx)
 
-	dbGroupA, err := NewDatabaseContext(ctx, "groupa", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupA", Scopes: GetScopesConfigForDefaultCollection()})
+	dbGroupA, err := NewDatabaseContext(ctx, "groupa", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupA", Scopes: GetScopesOptions(t, tb, 1)})
 	require.NoError(t, err)
 	defer dbGroupA.Close(ctx)
 
-	dbGroupB, err := NewDatabaseContext(ctx, "groupb", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupB", Scopes: GetScopesConfigForDefaultCollection()})
+	dbGroupB, err := NewDatabaseContext(ctx, "groupb", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupB", Scopes: GetScopesOptions(t, tb, 1)})
 	require.NoError(t, err)
 	defer dbGroupB.Close(ctx)
 

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -649,17 +649,18 @@ func TestReplicateGroupIDAssignedNodes(t *testing.T) {
 	defer tb.Close()
 	ctx := base.TestCtx(t)
 
-	const numCollections = 1
+	// scopes config will set up from test environment whether backed by default or non default collection
+	scopesConfig := GetScopesOptions(t, tb, 1)
 	// Set up databases
-	dbDefault, err := NewDatabaseContext(ctx, "default", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "", Scopes: GetScopesOptions(t, tb, 1)})
+	dbDefault, err := NewDatabaseContext(ctx, "default", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "", Scopes: scopesConfig})
 	require.NoError(t, err)
 	defer dbDefault.Close(ctx)
 
-	dbGroupA, err := NewDatabaseContext(ctx, "groupa", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupA", Scopes: GetScopesOptions(t, tb, 1)})
+	dbGroupA, err := NewDatabaseContext(ctx, "groupa", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupA", Scopes: scopesConfig})
 	require.NoError(t, err)
 	defer dbGroupA.Close(ctx)
 
-	dbGroupB, err := NewDatabaseContext(ctx, "groupb", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupB", Scopes: GetScopesOptions(t, tb, 1)})
+	dbGroupB, err := NewDatabaseContext(ctx, "groupb", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupB", Scopes: scopesConfig})
 	require.NoError(t, err)
 	defer dbGroupB.Close(ctx)
 

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -650,15 +650,15 @@ func TestReplicateGroupIDAssignedNodes(t *testing.T) {
 	ctx := base.TestCtx(t)
 
 	// Set up databases
-	dbDefault, err := NewDatabaseContext(ctx, "default", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: ""})
+	dbDefault, err := NewDatabaseContext(ctx, "default", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "", Scopes: GetScopesConfigForDefaultCollection()})
 	require.NoError(t, err)
 	defer dbDefault.Close(ctx)
 
-	dbGroupA, err := NewDatabaseContext(ctx, "groupa", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupA"})
+	dbGroupA, err := NewDatabaseContext(ctx, "groupa", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupA", Scopes: GetScopesConfigForDefaultCollection()})
 	require.NoError(t, err)
 	defer dbGroupA.Close(ctx)
 
-	dbGroupB, err := NewDatabaseContext(ctx, "groupb", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupB"})
+	dbGroupB, err := NewDatabaseContext(ctx, "groupb", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupB", Scopes: GetScopesConfigForDefaultCollection()})
 	require.NoError(t, err)
 	defer dbGroupB.Close(ctx)
 

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -515,6 +515,8 @@ func SetupTestDBForDataStoreWithOptions(t testing.TB, tBucket *base.TestBucket, 
 				},
 			}
 		}
+	} else if dbcOptions.Scopes == nil {
+		dbcOptions.Scopes = GetScopesConfigForDefaultCollection()
 	}
 
 	dbCtx, err := NewDatabaseContext(ctx, "db", tBucket, false, dbcOptions)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -532,7 +532,7 @@ func SetupTestDBForDataStoreWithOptions(t testing.TB, tBucket *base.TestBucket, 
 	return db, ctx
 }
 
-// GetScopesOptions sets up a ScopesOptions from a TestBucket for use with non default collections to pass in DatabaseContextOptions.
+// GetScopesOptions sets up a ScopesOptions from a TestBucket. This will set up default or non default collections depending on the test harness use of SG_TEST_USE_NAMED_COLLECTIONS and whether the backing store supports collections.
 func GetScopesOptions(t testing.TB, testBucket *base.TestBucket, numCollections int) ScopesOptions {
 	if !base.TestsUseNamedCollections() {
 		if numCollections != 1 {

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -28,6 +28,7 @@ import (
 func TestPublicChanGuestAccess(t *testing.T) {
 	rt := NewRestTester(t,
 		&RestTesterConfig{
+			SyncFn: channels.DocChannelsSyncFunction,
 			DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 				Guest: &auth.PrincipalConfig{
 					Disabled: base.BoolPtr(false),
@@ -88,7 +89,7 @@ func TestStarAccess(t *testing.T) {
 	}
 
 	// Create some docs:
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 
 	a := auth.NewAuthenticator(rt.MetadataStore(), nil, auth.DefaultAuthenticatorOptions())
@@ -579,7 +580,7 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 
 // Test _all_docs API call under different security scenarios
 func TestAllDocsAccessControl(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 
 	type allDocsRow struct {
@@ -793,7 +794,6 @@ func TestAllDocsAccessControl(t *testing.T) {
 func TestChannelAccessChanges(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyCRUD)
-
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {access(doc.owner, doc._id);channel(doc.channel)}`}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -954,7 +954,7 @@ func TestChannelAccessChanges(t *testing.T) {
 
 	collectionWithUser := db.GetSingleDatabaseCollectionWithUser(t, database)
 
-	changed, err := database.UpdateSyncFun(ctx, `function(doc) {access("alice", "beta");channel("beta");}`)
+	changed, err := collection.UpdateSyncFun(ctx, `function(doc) {access("alice", "beta");channel("beta");}`)
 	assert.NoError(t, err)
 	assert.True(t, changed)
 	changeCount, err := collectionWithUser.UpdateAllDocChannels(ctx, false, func(docsProcessed, docsChanged *int) {}, base.NewSafeTerminator())

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1825,7 +1825,7 @@ func TestPurgeWithMultipleValidDocs(t *testing.T) {
 // TestPurgeWithChannelCache will make sure thant upon calling _purge, the channel caches are also cleaned
 // This was fixed in #3765, previously channel caches were not cleaned up
 func TestPurgeWithChannelCache(t *testing.T) {
-	rt := rest.NewRestTester(t, nil)
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 
 	rest.RequireStatus(t, rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"foo":"bar", "channels": ["abc", "def"]}`), http.StatusCreated)
@@ -1872,7 +1872,7 @@ func TestPurgeWithSomeInvalidDocs(t *testing.T) {
 }
 
 func TestRawRedaction(t *testing.T) {
-	rt := rest.NewRestTester(t, nil)
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 
 	res := rt.SendAdminRequest("PUT", "/{{.keyspace}}/testdoc", `{"foo":"bar", "channels": ["achannel"]}`)
@@ -3314,7 +3314,7 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Validate a few default values to ensure they are set
-	assert.Equal(t, channels.DefaultSyncFunction, *dbConfig.Sync)
+	assert.Equal(t, channels.DocChannelsSyncFunction, *dbConfig.Sync)
 	assert.Equal(t, db.DefaultChannelCacheMaxNumber, *dbConfig.CacheConfig.ChannelCacheConfig.MaxNumber)
 	assert.Equal(t, base.DefaultOldRevExpirySeconds, *dbConfig.OldRevExpirySeconds)
 	assert.Equal(t, false, *dbConfig.StartOffline)
@@ -3328,7 +3328,7 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 
 	require.Contains(t, runtimeServerConfigResponse.Databases, "db")
 	runtimeServerConfigDatabase := runtimeServerConfigResponse.Databases["db"]
-	assert.Equal(t, channels.DefaultSyncFunction, *runtimeServerConfigDatabase.Sync)
+	assert.Equal(t, channels.DocChannelsSyncFunction, *runtimeServerConfigDatabase.Sync)
 	assert.Equal(t, db.DefaultChannelCacheMaxNumber, *runtimeServerConfigDatabase.CacheConfig.ChannelCacheConfig.MaxNumber)
 	assert.Equal(t, base.DefaultOldRevExpirySeconds, *runtimeServerConfigDatabase.OldRevExpirySeconds)
 	assert.Equal(t, false, *runtimeServerConfigDatabase.StartOffline)

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/couchbase/gocb/v2"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -103,6 +104,7 @@ func TestCollectionsPublicChannel(t *testing.T) {
 	)
 
 	rt := NewRestTester(t, &RestTesterConfig{
+		SyncFn: channels.DocChannelsSyncFunction,
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
 				Users: map[string]*auth.PrincipalConfig{

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1672,7 +1672,7 @@ func TestUnsupportedConfig(t *testing.T) {
 }
 
 func TestDocIDFilterResurrection(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 
 	// Create User
@@ -2389,7 +2389,7 @@ func TestUptimeStat(t *testing.T) {
 func TestDocumentChannelHistory(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 
 	var body db.Body
@@ -2439,7 +2439,7 @@ func TestDocumentChannelHistory(t *testing.T) {
 func TestChannelHistoryLegacyDoc(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 
 	docData := `
@@ -2591,7 +2591,7 @@ func TestMetricsHandler(t *testing.T) {
 
 func TestDocChannelSetPruning(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 
 	revID := rt.CreateDocReturnRev(t, "doc", "", map[string]interface{}{"channels": []string{"a"}})

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2541,7 +2541,8 @@ func TestMetricsHandler(t *testing.T) {
 	// Create and remove a database
 	// This ensures that creation and removal of a DB is possible without a re-registration issue ( the below rest tester will re-register "db")
 	ctx := base.TestCtx(t)
-	context, err := db.NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, db.DatabaseContextOptions{Scopes: db.GetScopesConfigForDefaultCollection()})
+	tBucket := base.GetTestBucket(t)
+	context, err := db.NewDatabaseContext(ctx, "db", tBucket, false, db.DatabaseContextOptions{Scopes: db.GetScopesOptions(t, tBucket, 1)})
 	require.NoError(t, err)
 	context.Close(context.AddDatabaseLogContext(ctx))
 
@@ -2566,7 +2567,8 @@ func TestMetricsHandler(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Initialize another database to ensure both are registered successfully
-	context, err = db.NewDatabaseContext(ctx, "db2", base.GetTestBucket(t), false, db.DatabaseContextOptions{Scopes: db.GetScopesConfigForDefaultCollection()})
+	tBucket2 := base.GetTestBucket(t)
+	context, err = db.NewDatabaseContext(ctx, "db2", tBucket2, false, db.DatabaseContextOptions{Scopes: db.GetScopesOptions(t, tBucket2, 1)})
 	require.NoError(t, err)
 	defer context.Close(context.AddDatabaseLogContext(ctx))
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2541,7 +2541,7 @@ func TestMetricsHandler(t *testing.T) {
 	// Create and remove a database
 	// This ensures that creation and removal of a DB is possible without a re-registration issue ( the below rest tester will re-register "db")
 	ctx := base.TestCtx(t)
-	context, err := db.NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, db.DatabaseContextOptions{})
+	context, err := db.NewDatabaseContext(ctx, "db", base.GetTestBucket(t), false, db.DatabaseContextOptions{Scopes: db.GetScopesConfigForDefaultCollection()})
 	require.NoError(t, err)
 	context.Close(context.AddDatabaseLogContext(ctx))
 
@@ -2566,7 +2566,7 @@ func TestMetricsHandler(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Initialize another database to ensure both are registered successfully
-	context, err = db.NewDatabaseContext(ctx, "db2", base.GetTestBucket(t), false, db.DatabaseContextOptions{})
+	context, err = db.NewDatabaseContext(ctx, "db2", base.GetTestBucket(t), false, db.DatabaseContextOptions{Scopes: db.GetScopesConfigForDefaultCollection()})
 	require.NoError(t, err)
 	defer context.Close(context.AddDatabaseLogContext(ctx))
 

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/gocb/v2"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -760,6 +761,7 @@ func TestPublicPortAuthentication(t *testing.T) {
 		BlipTesterSpec{
 			connectingUsername: "user1",
 			connectingPassword: "1234",
+			syncFn:             channels.DocChannelsSyncFunction,
 		})
 	require.NoError(t, err)
 	defer btUser1.Close()
@@ -1423,9 +1425,10 @@ func TestAccessGrantViaAdminApi(t *testing.T) {
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
+		syncFn:             channels.DocChannelsSyncFunction,
 	})
-	defer bt.Close()
 	require.NoError(t, err)
+	defer bt.Close()
 	collection := bt.restTester.GetSingleTestDatabaseCollection()
 
 	// Add a doc in the PBS channel
@@ -1681,7 +1684,7 @@ func TestGetRemovedDoc(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 	btSpec := BlipTesterSpec{
 		connectingUsername: "user1",
@@ -1954,7 +1957,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 
@@ -2058,7 +2061,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 	defer db.SuspendSequenceBatching()()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -76,7 +77,7 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 	newBody, err := base.InjectJSONPropertiesFromBytes(body, base.KVPairBytes{Key: "update", Val: []byte(`true`)})
 	require.NoError(t, err)
 
-	revID, err = btc.PushRev(docID, revID, newBody)
+	_, err = btc.PushRev(docID, revID, newBody)
 	require.NoError(t, err)
 
 	syncData, err = rt.GetDatabase().GetSingleDatabaseCollection().GetDocSyncData(base.TestCtx(t), docID)
@@ -428,7 +429,16 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
+	rtConfig := RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				DeltaSync: &DeltaSyncConfig{
+					Enabled: &sgUseDeltas,
+				},
+			},
+		},
+		SyncFn: channels.DocChannelsSyncFunction,
+	}
 	rt := NewRestTester(t,
 		&rtConfig)
 	defer rt.Close()
@@ -484,7 +494,16 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
+	rtConfig := RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				DeltaSync: &DeltaSyncConfig{
+					Enabled: &sgUseDeltas,
+				},
+			},
+		},
+		SyncFn: channels.DocChannelsSyncFunction,
+	}
 	rt := NewRestTester(t,
 		&rtConfig)
 	defer rt.Close()

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -37,7 +37,7 @@ func TestReproduce2383(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
-	rt := rest.NewRestTester(t, nil)
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 
 	ctx := rt.Context()
@@ -3728,7 +3728,7 @@ func TestChangesAdminChannelGrantLongpollNotify(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
-	rt := rest.NewRestTester(t, nil)
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 

--- a/rest/changestest/changes_collection_test.go
+++ b/rest/changestest/changes_collection_test.go
@@ -198,7 +198,7 @@ func TestMultiCollectionChangesMultiChannelOneShot(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyChanges, base.KeyCache, base.KeyCRUD)
 	numCollections := 2
 	base.RequireNumTestDataStores(t, numCollections)
-	rt := rest.NewRestTesterMultipleCollections(t, nil, numCollections)
+	rt := rest.NewRestTesterMultipleCollections(t, &rest.RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction}, numCollections)
 	defer rt.Close()
 
 	// Create user with access to channel PBS in both collections

--- a/rest/changestest/changes_collection_test.go
+++ b/rest/changestest/changes_collection_test.go
@@ -136,7 +136,8 @@ func TestMultiCollectionChangesUser(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyChanges, base.KeyCache, base.KeyCRUD)
 	numCollections := 2
 	base.RequireNumTestDataStores(t, numCollections)
-	rt := rest.NewRestTesterMultipleCollections(t, nil, numCollections)
+	rtConfig := &rest.RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction}
+	rt := rest.NewRestTesterMultipleCollections(t, rtConfig, numCollections)
 	defer rt.Close()
 
 	// Create user with access to channel PBS in both collections
@@ -198,7 +199,8 @@ func TestMultiCollectionChangesUserDynamicGrant(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyChanges, base.KeyCache, base.KeyCRUD)
 	numCollections := 2
 	base.RequireNumTestDataStores(t, numCollections)
-	rt := rest.NewRestTesterMultipleCollections(t, nil, numCollections)
+	rtConfig := &rest.RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction}
+	rt := rest.NewRestTesterMultipleCollections(t, rtConfig, numCollections)
 	defer rt.Close()
 
 	// Create user with access to channel PBS in both collections
@@ -264,7 +266,8 @@ func TestMultiCollectionChangesUserDynamicGrantDCP(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyChanges, base.KeyCache, base.KeyCRUD)
 	numCollections := 2
 	base.RequireNumTestDataStores(t, numCollections)
-	rt := rest.NewRestTesterMultipleCollections(t, nil, numCollections)
+	rtConfig := &rest.RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction}
+	rt := rest.NewRestTesterMultipleCollections(t, rtConfig, numCollections)
 	defer rt.Close()
 
 	// Create user with access to channel PBS in both collections

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -90,7 +90,7 @@ func DefaultDbConfig(sc *StartupConfig) *DbConfig {
 	dbConfig := DbConfig{
 		BucketConfig:       BucketConfig{},
 		Name:               "",
-		Sync:               base.StringPtr(channels.DefaultSyncFunction),
+		Sync:               base.StringPtr(channels.DocChannelsSyncFunction),
 		Users:              nil,
 		Roles:              nil,
 		RevsLimit:          nil, // Set this below struct

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -309,7 +309,7 @@ func TestGroupIDReplications(t *testing.T) {
 		resp := BootstrapAdminRequestCustomHost(t, http.MethodPut, adminHosts[i], "/db/",
 			fmt.Sprintf(
 				`{"bucket": "%s", "num_index_replicas": 0, "use_views": %t, "import_docs": true, "sync":"%s"}`,
-				activeBucket.GetName(), base.TestsDisableGSI(), channels.DefaultSyncFunction,
+				activeBucket.GetName(), base.TestsDisableGSI(), channels.DocChannelsSyncFunction,
 			),
 		)
 		resp.RequireStatus(http.StatusCreated)

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -890,7 +891,7 @@ func TestEnsureRevocationUsingDocHistory(t *testing.T) {
 func TestRevocationWithAdminChannels(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 
@@ -921,7 +922,7 @@ func TestRevocationWithAdminChannels(t *testing.T) {
 func TestRevocationWithAdminRoles(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -666,10 +666,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	dbcontext.AllowEmptyPassword = base.BoolDefault(config.AllowEmptyPassword, false)
 	dbcontext.ServeInsecureAttachmentTypes = base.BoolDefault(config.ServeInsecureAttachmentTypes, false)
 
-	if dbcontext.ChannelMapper == nil {
-		base.InfofCtx(ctx, base.KeyAll, "Using default sync function 'channel(doc.channels)' for database %q", base.MD(dbName))
-	}
-
 	// Create default users & roles:
 	if err := sc.installPrincipals(ctx, dbcontext, config.Roles, "role"); err != nil {
 		return nil, err

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -144,7 +144,7 @@ func TestInvalidSession(t *testing.T) {
 // Test for issue 758 - basic auth with stale session cookie
 func TestBasicAuthWithSessionCookie(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1127,7 +1127,7 @@ func TestFunkyUsernames(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			require.Truef(t, auth.IsValidPrincipalName(tc.UserName), "expected '%s' to be accepted", tc.UserName)
-			rt := NewRestTester(t, nil)
+			rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 			defer rt.Close()
 
 			ctx := rt.Context()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -282,9 +282,9 @@ func (rt *RestTester) Bucket() base.Bucket {
 			// If scopes is already set, assume the caller has a plan
 			if rt.DatabaseConfig.Scopes == nil {
 				// Configure non default collections by default
-				syncFn := base.StringPtr(rt.SyncFn)
-				if rt.SyncFn == "" {
-					syncFn = nil
+				var syncFn *string
+				if rt.SyncFn != "" {
+					syncFn = base.StringPtr(rt.SyncFn)
 				}
 				rt.DatabaseConfig.Scopes = getCollectionsConfigWithSyncFn(rt.TB, testBucket, syncFn, rt.numCollections)
 			}

--- a/rest/view_api.go
+++ b/rest/view_api.go
@@ -30,9 +30,13 @@ func (h *handler) handleGetDesignDoc() error {
 		// we serve this content here so that CouchDB 1.2 has something to
 		// hash into the replication-id, to correspond to our filter.
 		filter := "ok"
-		if h.db.DatabaseContext.ChannelMapper != nil {
+		defaultCollection, err := h.db.GetDefaultDatabaseCollection()
+		if err != nil {
+			return err
+		}
+		if defaultCollection.ChannelMapper != nil {
 			hash := sha1.New()
-			_, _ = io.WriteString(hash, h.db.DatabaseContext.ChannelMapper.Function())
+			_, _ = io.WriteString(hash, defaultCollection.ChannelMapper.Function())
 			filter = fmt.Sprint(hash.Sum(nil))
 		}
 		result = db.Body{"filters": db.Body{"bychannel": filter}}


### PR DESCRIPTION
- rename `DefaultSyncFunction` to `DocChannelsSyncFunction` which isn't a great name
- remove NewDefaultChannelMapper since it is not collection aware
- updated tests to use `UpdateSyncFn or pass SyncFn via rest tester.
- Removed ChannelMapper from `DatabaseContext` to always be collection scoped. This also means constructing `NewDatabaseContext` that `Scopes` is now a required field - this actually simplifies the code a good bit. It does move _some_ validation into `NewDatabaseContext` when we set the import filter which was formerly done in `ServerContext` but I think it makes it more possible to test sync and import in the `db` package.
- Changed the name of the sync function key to not store kv collection id, since in a DR unidirectional XDCR this value will be wrong, and we shouldn't write any docs with the kv collection id in them. Use the same synchronization field for `_default._default` for backward compatibility.
- Preserve no js passthrough behavior in `crud.go` if `DatabaseCollection.ChannelMapper = nil`

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2884/
