### PR TITLE
Maintain multiple activeSubChanges, one per collection

### DIFF
--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -215,6 +215,7 @@ func (a *activeReplicatorCommon) stopSubChanges() {
 	t := time.NewTicker(retryInterval)
 	defer t.Stop()
 
+	collectionCtxs := a.blipSyncContext.collections.getAll()
 retry:
 	for {
 		select {
@@ -222,15 +223,11 @@ retry:
 			break retry
 		case <-t.C:
 			// wait until all activeSubChanges have stopped
-			for _, collectionCtx := range a.blipSyncContext.collectionContexts {
+			for _, collectionCtx := range collectionCtxs {
 				if collectionCtx.activeSubChanges.IsTrue() {
 					continue retry
 				}
 			}
-			if a.blipSyncContext.nonCollectionAwareContext.activeSubChanges.IsTrue() {
-				continue retry
-			}
-			break retry
 		}
 	}
 }

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -210,7 +210,7 @@ func (a *activeReplicatorCommon) stopSubChanges() {
 		maxWaitTime   = 10 * time.Second
 		retryInterval = 10 * time.Millisecond
 	)
-	ctx, cancel := context.WithDeadline(a.ctx, time.Now().Add(maxWaitTime))
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(maxWaitTime))
 	defer cancel()
 	t := time.NewTicker(retryInterval)
 	defer t.Stop()

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -194,42 +194,12 @@ func (a *activeReplicatorCommon) _disconnect() error {
 	}
 
 	if a.blipSyncContext != nil {
-		a.stopSubChanges()
 		base.TracefCtx(a.ctx, base.KeyReplicate, "closing blip sync context")
 		a.blipSyncContext.Close()
 		a.blipSyncContext = nil
 	}
 
 	return nil
-}
-
-// stopSubChanges stops any active subChanges requests
-func (a *activeReplicatorCommon) stopSubChanges() {
-	base.TracefCtx(a.ctx, base.KeyReplicate, "closing active subChanges")
-	const (
-		maxWaitTime   = 10 * time.Second
-		retryInterval = 10 * time.Millisecond
-	)
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(maxWaitTime))
-	defer cancel()
-	t := time.NewTicker(retryInterval)
-	defer t.Stop()
-
-	collectionCtxs := a.blipSyncContext.collections.getAll()
-retry:
-	for {
-		select {
-		case <-ctx.Done():
-			break retry
-		case <-t.C:
-			// wait until all activeSubChanges have stopped
-			for _, collectionCtx := range collectionCtxs {
-				if collectionCtx.activeSubChanges.IsTrue() {
-					continue retry
-				}
-			}
-		}
-	}
 }
 
 // _stop aborts any replicator processes that run outside of a running replication (e.g: async reconnect handling)

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -239,5 +239,8 @@ func (apr *ActivePullReplicator) registerCheckpointerCallbacks() {
 // Stop stops the pull replication and waits for the sub changes goroutine to finish.
 func (apr *ActivePullReplicator) Stop() error {
 	base.TracefCtx(apr.ctx, base.KeyReplicate, "Calling stop and disconnect from Stop()")
-	return apr.stopAndDisconnect()
+	if err := apr.stopAndDisconnect(); err != nil {
+		return err
+	}
+	return nil
 }

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -13,7 +13,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 )
@@ -240,13 +239,5 @@ func (apr *ActivePullReplicator) registerCheckpointerCallbacks() {
 // Stop stops the pull replication and waits for the sub changes goroutine to finish.
 func (apr *ActivePullReplicator) Stop() error {
 	base.TracefCtx(apr.ctx, base.KeyReplicate, "Calling stop and disconnect from Stop()")
-	if err := apr.stopAndDisconnect(); err != nil {
-		return err
-	}
-	teardownStart := time.Now()
-	for (apr.blipSyncContext != nil && apr.blipSyncContext.activeSubChanges.IsTrue()) &&
-		(time.Since(teardownStart) < time.Second*10) {
-		time.Sleep(10 * time.Millisecond)
-	}
-	return nil
+	return apr.stopAndDisconnect()
 }

--- a/db/blip_collection_context.go
+++ b/db/blip_collection_context.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package db
 
 import (

--- a/db/blip_collection_context.go
+++ b/db/blip_collection_context.go
@@ -1,0 +1,90 @@
+package db
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/couchbase/sync_gateway/base"
+)
+
+// blipSyncCollectionContext stores information about a single collection for a BlipSyncContext
+type blipSyncCollectionContext struct {
+	dbCollection     *DatabaseCollection
+	activeSubChanges base.AtomicBool // Flag for whether there is a subChanges subscription currently active.  Atomic access
+}
+
+// blipCollections is a container for all collections blip is aware of.
+type blipCollections struct {
+	nonCollectionAwareContext *blipSyncCollectionContext   // A collection represented by no Collection property message or prior GetCollections message.
+	collectionContexts        []*blipSyncCollectionContext // Indexed by replication collectionIdx to store per-collection information on a replication
+	sync.RWMutex
+}
+
+// setNonCollectionAware adds a single collection matching _default._default collection, to be refered to if no Collection property is set on a blip message.
+func (b *blipCollections) setNonCollectionAware(collectionCtx *blipSyncCollectionContext) {
+	b.Lock()
+	defer b.Unlock()
+	if b.nonCollectionAwareContext == nil {
+		b.nonCollectionAwareContext = collectionCtx
+	}
+}
+
+// set adds a set of collections to this contexts struct.
+func (b *blipCollections) set(collectionCtxs []*blipSyncCollectionContext) {
+	b.Lock()
+	defer b.Unlock()
+	b.collectionContexts = collectionCtxs
+}
+
+// getCollectionContext returns a collection matching the blip collection idx set by the initial GetCollections handshake. If collectionIdx is nil, assume that the messages are not collection aware.
+func (b *blipCollections) get(collectionIdx *int) (*blipSyncCollectionContext, error) {
+	b.RLock()
+	defer b.RUnlock()
+	if collectionIdx == nil {
+		if b.nonCollectionAwareContext == nil {
+			return nil, fmt.Errorf("No default collection has been specified")
+		}
+		return b.nonCollectionAwareContext, nil
+	}
+	if len(b.collectionContexts) <= *collectionIdx {
+		return nil, fmt.Errorf("Collection index %d is outside range indexes set by GetCollections", *collectionIdx)
+	}
+	if b.collectionContexts[*collectionIdx] == nil {
+		return nil, fmt.Errorf("Collection index %d was not a valid collection set by GetCollections", *collectionIdx)
+	}
+	return b.collectionContexts[*collectionIdx], nil
+}
+
+// getAll returns all collection contexts.
+func (b *blipCollections) getAll() []*blipSyncCollectionContext {
+	b.RLock()
+	defer b.RUnlock()
+	var collections []*blipSyncCollectionContext
+	if b.nonCollectionAwareContext != nil {
+		collections = append(collections, b.nonCollectionAwareContext)
+	}
+	collections = append(collections, b.collectionContexts...)
+	return collections
+}
+
+// hasNamedCollections returns true if named collections have been set.
+func (b *blipCollections) hasNamedCollections() bool {
+	b.RLock()
+	defer b.RUnlock()
+	return len(b.collectionContexts) != 0
+}
+
+// getIndexForDB returns the index of a given named collection by the array specified in initial GetCollections handshake.
+func (b *blipCollections) getIndexForDB(collection *DatabaseCollectionWithUser) (int, bool) {
+	b.RLock()
+	defer b.RUnlock()
+	if b.collectionContexts == nil {
+		return 0, false
+	}
+	for i, collectionCtx := range b.collectionContexts {
+		if collectionCtx.dbCollection.ScopeName == collection.ScopeName && collectionCtx.dbCollection.Name == collection.Name {
+			return i, true
+		}
+	}
+	return 0, false
+}

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -305,10 +305,6 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 
 		defer func() {
 			bh.changesCtxCancel()
-			collectionCtx, err := bh.collections.get(bh.collectionIdx)
-			if err != nil {
-				base.WarnfCtx(bh.loggingCtx, "Error getting collectionContext on stopping subChanges request: %w", err)
-			}
 			collectionCtx.activeSubChanges.Set(false)
 		}()
 		// sendChanges runs until blip context closes, or fails due to error

--- a/db/blip_handler_collections.go
+++ b/db/blip_handler_collections.go
@@ -55,6 +55,7 @@ func (bh *blipHandler) handleGetCollections(rq *blip.Message) error {
 	}
 
 	checkpoints := make([]Body, len(requestBody.Collections))
+	collectionContexts := make([]*blipSyncCollectionContext, len(requestBody.Collections))
 	for i, scopeAndCollection := range requestBody.Collections {
 		scope, collectionName, err := parseScopeAndCollection(scopeAndCollection)
 		if err != nil {
@@ -64,13 +65,13 @@ func (bh *blipHandler) handleGetCollections(rq *blip.Message) error {
 		scopeOnDb, ok := bh.db.Scopes[*scope]
 		if !ok {
 			checkpoints[i] = nil
-			bh.collectionContexts = append(bh.collectionContexts, nil)
+			collectionContexts[i] = nil
 			continue
 		}
 		collection, ok := scopeOnDb.Collections[*collectionName]
 		if !ok {
 			checkpoints[i] = nil
-			bh.collectionContexts = append(bh.collectionContexts, nil)
+			collectionContexts[i] = nil
 			continue
 		}
 		key := CheckpointDocIDPrefix + requestBody.CheckpointIDs[i]
@@ -79,7 +80,7 @@ func (bh *blipHandler) handleGetCollections(rq *blip.Message) error {
 			status, _ := base.ErrorAsHTTPStatus(err)
 			if status == http.StatusNotFound {
 				checkpoints[i] = Body{}
-				bh.collectionContexts = append(bh.collectionContexts, &BlipSyncCollectionContext{dbCollection: collection})
+				collectionContexts[i] = &blipSyncCollectionContext{dbCollection: collection}
 			} else {
 				errMsg := fmt.Sprintf("Unable to fetch client checkpoint %q for collection %s: %s", key, scopeAndCollection, err)
 				base.WarnfCtx(bh.loggingCtx, errMsg)
@@ -89,23 +90,12 @@ func (bh *blipHandler) handleGetCollections(rq *blip.Message) error {
 		}
 		delete(value, BodyId)
 		checkpoints[i] = value
-		bh.collectionContexts = append(bh.collectionContexts, &BlipSyncCollectionContext{dbCollection: collection})
+		collectionContexts[i] = &blipSyncCollectionContext{dbCollection: collection}
 	}
+	bh.collections.set(collectionContexts)
 	response := rq.Response()
 	if response == nil {
 		return fmt.Errorf("Internal go-blip error generating request response")
 	}
 	return response.SetJSONBody(checkpoints)
-}
-
-func (bsc *BlipSyncContext) getCollectionIndexForDB(collection *DatabaseCollectionWithUser) (int, bool) {
-	if bsc.collectionContexts == nil {
-		return 0, false
-	}
-	for i, collectionCtx := range bsc.collectionContexts {
-		if collectionCtx.dbCollection.ScopeName == collection.ScopeName && collectionCtx.dbCollection.Name == collection.Name {
-			return i, true
-		}
-	}
-	return 0, false
 }

--- a/db/blip_handler_test.go
+++ b/db/blip_handler_test.go
@@ -30,11 +30,11 @@ func TestCollectionBlipHandler(t *testing.T) {
 	realCollectionDB0 := &DatabaseCollection{dbCtx: &DatabaseContext{}}
 	realCollectionDB1 := &DatabaseCollection{dbCtx: &DatabaseContext{}}
 	testCases := []struct {
-		name              string
-		blipMessage       *blip.Message
-		err               *base.HTTPError
-		collection        *DatabaseCollectionWithUser
-		collectionMapping []*DatabaseCollection
+		name               string
+		blipMessage        *blip.Message
+		err                *base.HTTPError
+		collection         *DatabaseCollectionWithUser
+		collectionContexts []*BlipSyncCollectionContext
 	}{
 		{
 			name:        "NoCollections",
@@ -93,7 +93,7 @@ func TestCollectionBlipHandler(t *testing.T) {
 			collection: &DatabaseCollectionWithUser{
 				DatabaseCollection: realCollectionDB0,
 			},
-			collectionMapping: []*DatabaseCollection{realCollectionDB0},
+			collectionContexts: []*BlipSyncCollectionContext{{dbCollection: realCollectionDB0}},
 		},
 		{
 			name: "twoPresentCollections",
@@ -106,7 +106,7 @@ func TestCollectionBlipHandler(t *testing.T) {
 			collection: &DatabaseCollectionWithUser{
 				DatabaseCollection: realCollectionDB1,
 			},
-			collectionMapping: []*DatabaseCollection{realCollectionDB0, realCollectionDB1},
+			collectionContexts: []*BlipSyncCollectionContext{{dbCollection: realCollectionDB0}, {dbCollection: realCollectionDB1}},
 		},
 		{
 			name: "collectionPassedInGetCollectionsButHitErrorInGetCollections",
@@ -115,9 +115,9 @@ func TestCollectionBlipHandler(t *testing.T) {
 					BlipCollection: "1",
 				},
 			},
-			err:               &base.HTTPError{Status: http.StatusBadRequest},
-			collection:        nil,
-			collectionMapping: []*DatabaseCollection{realCollectionDB0, nil},
+			err:                &base.HTTPError{Status: http.StatusBadRequest},
+			collection:         nil,
+			collectionContexts: []*BlipSyncCollectionContext{{dbCollection: realCollectionDB0}, nil},
 		},
 		{
 			name: "outOfRangeCollections",
@@ -126,9 +126,9 @@ func TestCollectionBlipHandler(t *testing.T) {
 					BlipCollection: "2",
 				},
 			},
-			err:               &base.HTTPError{Status: http.StatusBadRequest},
-			collection:        nil,
-			collectionMapping: []*DatabaseCollection{realCollectionDB0, realCollectionDB1},
+			err:                &base.HTTPError{Status: http.StatusBadRequest},
+			collection:         nil,
+			collectionContexts: []*BlipSyncCollectionContext{{dbCollection: realCollectionDB0}, {dbCollection: realCollectionDB1}},
 		},
 	}
 	for _, testCase := range testCases {
@@ -137,9 +137,8 @@ func TestCollectionBlipHandler(t *testing.T) {
 			bh := blipHandler{
 				db: allDB,
 				BlipSyncContext: &BlipSyncContext{
-					loggingCtx:        ctx,
-					collectionMapping: testCase.collectionMapping,
-				},
+					loggingCtx:         ctx,
+					collectionContexts: testCase.collectionContexts},
 			}
 
 			passedMiddleware := false

--- a/db/blip_handler_test.go
+++ b/db/blip_handler_test.go
@@ -34,7 +34,7 @@ func TestCollectionBlipHandler(t *testing.T) {
 		blipMessage        *blip.Message
 		err                *base.HTTPError
 		collection         *DatabaseCollectionWithUser
-		collectionContexts []*BlipSyncCollectionContext
+		collectionContexts []*blipSyncCollectionContext
 	}{
 		{
 			name:        "NoCollections",
@@ -93,7 +93,7 @@ func TestCollectionBlipHandler(t *testing.T) {
 			collection: &DatabaseCollectionWithUser{
 				DatabaseCollection: realCollectionDB0,
 			},
-			collectionContexts: []*BlipSyncCollectionContext{{dbCollection: realCollectionDB0}},
+			collectionContexts: []*blipSyncCollectionContext{{dbCollection: realCollectionDB0}},
 		},
 		{
 			name: "twoPresentCollections",
@@ -106,7 +106,7 @@ func TestCollectionBlipHandler(t *testing.T) {
 			collection: &DatabaseCollectionWithUser{
 				DatabaseCollection: realCollectionDB1,
 			},
-			collectionContexts: []*BlipSyncCollectionContext{{dbCollection: realCollectionDB0}, {dbCollection: realCollectionDB1}},
+			collectionContexts: []*blipSyncCollectionContext{{dbCollection: realCollectionDB0}, {dbCollection: realCollectionDB1}},
 		},
 		{
 			name: "collectionPassedInGetCollectionsButHitErrorInGetCollections",
@@ -117,7 +117,7 @@ func TestCollectionBlipHandler(t *testing.T) {
 			},
 			err:                &base.HTTPError{Status: http.StatusBadRequest},
 			collection:         nil,
-			collectionContexts: []*BlipSyncCollectionContext{{dbCollection: realCollectionDB0}, nil},
+			collectionContexts: []*blipSyncCollectionContext{{dbCollection: realCollectionDB0}, nil},
 		},
 		{
 			name: "outOfRangeCollections",
@@ -128,7 +128,7 @@ func TestCollectionBlipHandler(t *testing.T) {
 			},
 			err:                &base.HTTPError{Status: http.StatusBadRequest},
 			collection:         nil,
-			collectionContexts: []*BlipSyncCollectionContext{{dbCollection: realCollectionDB0}, {dbCollection: realCollectionDB1}},
+			collectionContexts: []*blipSyncCollectionContext{{dbCollection: realCollectionDB0}, {dbCollection: realCollectionDB1}},
 		},
 	}
 	for _, testCase := range testCases {
@@ -137,8 +137,13 @@ func TestCollectionBlipHandler(t *testing.T) {
 			bh := blipHandler{
 				db: allDB,
 				BlipSyncContext: &BlipSyncContext{
-					loggingCtx:         ctx,
-					collectionContexts: testCase.collectionContexts},
+					loggingCtx:  ctx,
+					collections: &blipCollections{},
+				},
+			}
+			bh.collections.set(testCase.collectionContexts)
+			if testCase.collection != nil {
+				bh.collections.setNonCollectionAware(&blipSyncCollectionContext{dbCollection: testCase.collection.DatabaseCollection})
 			}
 
 			passedMiddleware := false


### PR DESCRIPTION
- maintain a mapping of CollectionContexts rather than collections
- move shutdown of subChanges go routines to `stopAndDisconnect` to avoid data race, since we have the potential to call `apr.blipSyncContext = nil` before we are actually done waiting.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1501/
