### PR TITLE
Skip test when not using CE

### DIFF
--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -130,7 +130,7 @@ func TestCECheck(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Only works with CBS")
 	}
-	if base.TestsUseServerCE() {
+	if !base.TestsUseServerCE() {
 		t.Skip("test only runs with CE server")
 	}
 	rt := NewRestTester(t, nil)


### PR DESCRIPTION
follow up on CBG-2633 after  TestCECheck failed in master integration testing