### PR TITLE
CBG-760 hash user to invalidate sessions

### DIFF
--- a/auth/principal.go
+++ b/auth/principal.go
@@ -88,7 +88,7 @@ type User interface {
 	// GetSessionUUID returns the UUID that a session to match to be a valid session.
 	GetSessionUUID() string
 
-	// UpdateSessionUUID creates a new session UUID
+	// UpdateSessionUUID will invalidate all earlier sessions associated with this user.
 	UpdateSessionUUID()
 
 	// Changes the user's password.

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -86,7 +86,7 @@ type User interface {
 	Authenticate(password string) bool
 
 	// GetSessionUUID returns the UUID that a session to match to be a valid session.
-	GetSessionUUID() []byte
+	GetSessionUUID() string
 
 	// UpdateSessionUUID creates a new session UUID
 	UpdateSessionUUID()

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -88,7 +88,7 @@ type User interface {
 	// GetSessionUUID returns the UUID that a session to match to be a valid session.
 	GetSessionUUID() string
 
-	// UpdateSessionUUID will invalidate all earlier sessions associated with this user.
+	// UpdateSessionUUID creates a new session UUID
 	UpdateSessionUUID()
 
 	// Changes the user's password.

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -85,6 +85,9 @@ type User interface {
 	// Authenticates the user's password.
 	Authenticate(password string) bool
 
+	// GetPasswordHash returns the hashed password.
+	GetPasswordHash() []byte
+
 	// Changes the user's password.
 	SetPassword(password string) error
 

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -85,8 +85,11 @@ type User interface {
 	// Authenticates the user's password.
 	Authenticate(password string) bool
 
-	// GetPasswordHash returns the hashed password.
-	GetPasswordHash() []byte
+	// GetSessionUUID returns the UUID that a session to match to be a valid session.
+	GetSessionUUID() []byte
+
+	// UpdateSessionUUID creates a new session UUID
+	UpdateSessionUUID()
 
 	// Changes the user's password.
 	SetPassword(password string) error

--- a/auth/session.go
+++ b/auth/session.go
@@ -93,17 +93,13 @@ func (auth *Authenticator) CreateSession(username string, ttl time.Duration) (*L
 	} else if err != nil {
 		return nil, err
 	}
-	sessionUUID := ""
-	if user != nil {
-		sessionUUID = user.GetSessionUUID()
-	}
 
 	session := &LoginSession{
 		ID:          secret,
 		Username:    username,
 		Expiration:  time.Now().Add(ttl),
 		Ttl:         ttl,
-		SessionUUID: sessionUUID,
+		SessionUUID: user.GetSessionUUID(),
 	}
 	if err := auth.datastore.Set(DocIDForSession(session.ID), base.DurationToCbsExpiry(ttl), nil, session); err != nil {
 		return nil, err

--- a/auth/session.go
+++ b/auth/session.go
@@ -76,7 +76,7 @@ func (auth *Authenticator) AuthenticateCookie(rq *http.Request, response http.Re
 	return user, err
 }
 
-func (auth *Authenticator) CreateSession(username string, ttl time.Duration) (*LoginSession, error) {
+func (auth *Authenticator) CreateSession(user User, ttl time.Duration) (*LoginSession, error) {
 	ttlSec := int(ttl.Seconds())
 	if ttlSec <= 0 {
 		return nil, base.HTTPErrorf(400, "Invalid session time-to-live")
@@ -87,7 +87,6 @@ func (auth *Authenticator) CreateSession(username string, ttl time.Duration) (*L
 		return nil, err
 	}
 
-	user, err := auth.GetUser(username)
 	if user != nil && user.Disabled() {
 		return nil, base.HTTPErrorf(400, "User is disabled")
 	} else if err != nil {
@@ -96,7 +95,7 @@ func (auth *Authenticator) CreateSession(username string, ttl time.Duration) (*L
 
 	session := &LoginSession{
 		ID:          secret,
-		Username:    username,
+		Username:    user.Name(),
 		Expiration:  time.Now().Add(ttl),
 		Ttl:         ttl,
 		SessionUUID: user.GetSessionUUID(),

--- a/auth/session.go
+++ b/auth/session.go
@@ -93,13 +93,17 @@ func (auth *Authenticator) CreateSession(username string, ttl time.Duration) (*L
 	} else if err != nil {
 		return nil, err
 	}
+	sessionUUID := ""
+	if user != nil {
+		sessionUUID = user.GetSessionUUID()
+	}
 
 	session := &LoginSession{
 		ID:          secret,
 		Username:    username,
 		Expiration:  time.Now().Add(ttl),
 		Ttl:         ttl,
-		SessionUUID: user.GetSessionUUID(),
+		SessionUUID: sessionUUID,
 	}
 	if err := auth.datastore.Set(DocIDForSession(session.ID), base.DurationToCbsExpiry(ttl), nil, session); err != nil {
 		return nil, err

--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -301,32 +301,3 @@ func TestUserWithoutSessionUUID(t *testing.T) {
 	require.NoError(t, err)
 
 }
-
-func TestGetSessionThenCreateUser(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
-	dataStore := testBucket.GetSingleDataStore()
-	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions())
-	const username = "Alice"
-
-	// Create session with a username and valid TTL of 2 hours.
-	session, err := auth.CreateSession(username, 2*time.Hour)
-	require.NoError(t, err)
-
-	session, err = auth.GetSession(session.ID)
-	require.NoError(t, err)
-
-	user, err := auth.NewUser(username, "password", base.Set{})
-	require.NoError(t, err)
-	require.NotNil(t, user)
-	require.NoError(t, auth.Save(user))
-
-	request, err := http.NewRequest(http.MethodGet, "", nil)
-	require.NoError(t, err)
-	request.AddCookie(auth.MakeSessionCookie(session, true, true))
-
-	recorder := httptest.NewRecorder()
-	_, err = auth.AuthenticateCookie(request, recorder)
-	require.NoError(t, err)
-
-}

--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -37,7 +37,7 @@ func TestCreateSession(t *testing.T) {
 	require.NoError(t, auth.Save(user))
 
 	// Create session with a username and valid TTL of 2 hours.
-	session, err := auth.CreateSession(username, 2*time.Hour)
+	session, err := auth.CreateSession(user, 2*time.Hour)
 	require.NoError(t, err)
 
 	assert.Equal(t, username, session.Username)
@@ -56,13 +56,13 @@ func TestCreateSession(t *testing.T) {
 	assert.NotEmpty(t, session.Expiration)
 
 	// Session must not be created with zero TTL; it's illegal.
-	session, err = auth.CreateSession(username, time.Duration(0))
+	session, err = auth.CreateSession(user, time.Duration(0))
 	assert.Nil(t, session)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), invalidSessionTTLError)
 
 	// Session must not be created with negative TTL; it's illegal.
-	session, err = auth.CreateSession(username, time.Duration(-1))
+	session, err = auth.CreateSession(user, time.Duration(-1))
 	assert.Nil(t, session)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), invalidSessionTTLError)
@@ -235,7 +235,7 @@ func TestCreateSessionChangePassword(t *testing.T) {
 			require.NoError(t, auth.Save(user))
 
 			// Create session with a username and valid TTL of 2 hours.
-			session, err := auth.CreateSession(test.username, 2*time.Hour)
+			session, err := auth.CreateSession(user, 2*time.Hour)
 			require.NoError(t, err)
 
 			session, err = auth.GetSession(session.ID)
@@ -285,8 +285,12 @@ func TestUserWithoutSessionUUID(t *testing.T) {
 	err = auth.datastore.Set(user.DocID(), 0, nil, rawUser)
 	require.NoError(t, err)
 
+	user, err = auth.GetUser(username)
+	require.NoError(t, err)
+	require.NotNil(t, user)
+
 	// Create session with a username and valid TTL of 2 hours.
-	session, err := auth.CreateSession(username, 2*time.Hour)
+	session, err := auth.CreateSession(user, 2*time.Hour)
 	require.NoError(t, err)
 
 	session, err = auth.GetSession(session.ID)

--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -301,3 +301,32 @@ func TestUserWithoutSessionUUID(t *testing.T) {
 	require.NoError(t, err)
 
 }
+
+func TestGetSessionThenCreateUser(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close()
+	dataStore := testBucket.GetSingleDataStore()
+	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions())
+	const username = "Alice"
+
+	// Create session with a username and valid TTL of 2 hours.
+	session, err := auth.CreateSession(username, 2*time.Hour)
+	require.NoError(t, err)
+
+	session, err = auth.GetSession(session.ID)
+	require.NoError(t, err)
+
+	user, err := auth.NewUser(username, "password", base.Set{})
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	require.NoError(t, auth.Save(user))
+
+	request, err := http.NewRequest(http.MethodGet, "", nil)
+	require.NoError(t, err)
+	request.AddCookie(auth.MakeSessionCookie(session, true, true))
+
+	recorder := httptest.NewRecorder()
+	_, err = auth.AuthenticateCookie(request, recorder)
+	require.NoError(t, err)
+
+}

--- a/auth/user.go
+++ b/auth/user.go
@@ -531,6 +531,11 @@ func (user *userImpl) Authenticate(password string) bool {
 	return true
 }
 
+// GetPasswordHash returns the hash of the user's password.
+func (user *userImpl) GetPasswordHash() []byte {
+	return user.PasswordHash_
+}
+
 // Changes a user's password to the given string.
 func (user *userImpl) SetPassword(password string) error {
 	if password == "" {

--- a/auth/user.go
+++ b/auth/user.go
@@ -51,7 +51,7 @@ type userImplBody struct {
 	RolesSince_      ch.TimedSet     `json:"rolesSince"`
 	RoleInvalSeq     uint64          `json:"role_inval_seq,omitempty"` // Sequence at which the roles were invalidated. Data remains in RolesSince_ for history calculation.
 	RoleHistory_     TimedSetHistory `json:"role_history,omitempty"`   // Added to when a previously granted role is revoked. Calculated inside of rebuildRoles.
-	SessionUUID_     []byte          `json:"session_uuid"`             // marker of when the user object changes, to match with session docs to determine if they are valid
+	SessionUUID_     string          `json:"session_uuid"`             // marker of when the user object changes, to match with session docs to determine if they are valid
 
 	OldExplicitRoles_ []string `json:"admin_roles,omitempty"` // obsolete; declared for migration
 }
@@ -534,13 +534,13 @@ func (user *userImpl) Authenticate(password string) bool {
 }
 
 // GetSessionUUID returns the UUID that a session to match to be a valid session.
-func (user *userImpl) GetSessionUUID() []byte {
+func (user *userImpl) GetSessionUUID() string {
 	return user.SessionUUID_
 }
 
 // UpdateSessionUUID creates a new UUID for a session.
 func (user *userImpl) UpdateSessionUUID() {
-	user.SessionUUID_ = []byte(uuid.NewString())
+	user.SessionUUID_ = uuid.NewString()
 }
 
 // Changes a user's password to the given string.

--- a/auth/user.go
+++ b/auth/user.go
@@ -100,7 +100,7 @@ func (auth *Authenticator) NewUser(username string, password string, channels ba
 		return nil, err
 	}
 
-	err := user.setPassword(password)
+	err := user.SetPassword(password)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func (auth *Authenticator) NewUserNoChannels(username string, password string) (
 		return nil, err
 	}
 
-	err := user.setPassword(password)
+	err := user.SetPassword(password)
 	if err != nil {
 		return nil, err
 	}
@@ -543,14 +543,9 @@ func (user *userImpl) UpdateSessionUUID() {
 	user.SessionUUID_ = uuid.NewString()
 }
 
-// SetPassword changes a user's password to the given string. This needs to be called from external functions, so we invalidate sessions.
+// Changes a user's password to the given string.
 func (user *userImpl) SetPassword(password string) error {
 	user.UpdateSessionUUID()
-	return user.setPassword(password)
-}
-
-// setPassword to the given string. It should only be called from constructors, since it will avoid invalidating existing sessions.
-func (user *userImpl) setPassword(password string) error {
 	if password == "" {
 		user.PasswordHash_ = nil
 	} else {

--- a/auth/user.go
+++ b/auth/user.go
@@ -100,7 +100,7 @@ func (auth *Authenticator) NewUser(username string, password string, channels ba
 		return nil, err
 	}
 
-	err := user.SetPassword(password)
+	err := user.setPassword(password)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func (auth *Authenticator) NewUserNoChannels(username string, password string) (
 		return nil, err
 	}
 
-	err := user.SetPassword(password)
+	err := user.setPassword(password)
 	if err != nil {
 		return nil, err
 	}
@@ -543,9 +543,14 @@ func (user *userImpl) UpdateSessionUUID() {
 	user.SessionUUID_ = uuid.NewString()
 }
 
-// Changes a user's password to the given string.
+// SetPassword changes a user's password to the given string. This needs to be called from external functions, so we invalidate sessions.
 func (user *userImpl) SetPassword(password string) error {
 	user.UpdateSessionUUID()
+	return user.setPassword(password)
+}
+
+// setPassword to the given string. It should only be called from constructors, since it will avoid invalidating existing sessions.
+func (user *userImpl) setPassword(password string) error {
 	if password == "" {
 		user.PasswordHash_ = nil
 	} else {

--- a/db/database.go
+++ b/db/database.go
@@ -1541,26 +1541,6 @@ func (db *DatabaseContext) GetRoleIDs(ctx context.Context, useViews, includeDele
 	return roles, nil
 }
 
-// ////// HOUSEKEEPING:
-
-// Deletes all session documents for a user
-func (db *DatabaseContext) DeleteUserSessions(ctx context.Context, userName string) error {
-
-	results, err := db.QuerySessions(ctx, userName)
-	if err != nil {
-		return err
-	}
-
-	var sessionsRow QueryIdRow
-	for results.Next(&sessionsRow) {
-		base.InfofCtx(ctx, base.KeyCRUD, "\tDeleting %q", sessionsRow.Id)
-		if err := db.MetadataStore.Delete(sessionsRow.Id); err != nil {
-			base.WarnfCtx(ctx, "Error deleting %q: %v", sessionsRow.Id, err)
-		}
-	}
-	return results.Close()
-}
-
 // Trigger tombstone compaction from view and/or GSI indexes.  Several Sync Gateway indexes server tombstones (deleted documents with an xattr).
 // There currently isn't a mechanism for server to remove these docs from the index when the tombstone is purged by the server during
 // metadata purge, because metadata purge doesn't trigger a DCP event.

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -53,7 +53,6 @@ const (
 	IndexTombstones
 	IndexSyncDocs
 	IndexUser
-	IndexSession
 	IndexRole
 	indexTypeCount // Used for iteration
 )
@@ -83,7 +82,6 @@ var (
 		IndexTombstones: "tombstones",
 		IndexSyncDocs:   "syncDocs",
 		IndexUser:       "users",
-		IndexSession:    "sessions",
 		IndexRole:       "roles",
 	}
 
@@ -96,7 +94,6 @@ var (
 		IndexTombstones: 1,
 		IndexSyncDocs:   1,
 		IndexUser:       1,
-		IndexSession:    1,
 		IndexRole:       1,
 	}
 
@@ -109,7 +106,6 @@ var (
 		IndexTombstones: {},
 		IndexSyncDocs:   {},
 		IndexUser:       {},
-		IndexSession:    {},
 		IndexRole:       {},
 	}
 
@@ -124,7 +120,6 @@ var (
 		IndexTombstones: "$sync.tombstoned_at",
 		IndexSyncDocs:   "META().id",
 		IndexUser:       "META().id, name, email, disabled",
-		IndexSession:    "META().id, username",
 		IndexRole:       "META().id, name, deleted",
 	}
 
@@ -132,7 +127,6 @@ var (
 		IndexAllDocs:  fmt.Sprintf("META().id NOT LIKE '%s'", SyncDocWildcard),
 		IndexSyncDocs: fmt.Sprintf("META().id LIKE '%s'", SyncDocWildcard),
 		IndexUser:     fmt.Sprintf("META().id LIKE '%s'", SyncUserWildcard),
-		IndexSession:  fmt.Sprintf("META().id LIKE '%s'", SyncSessionWildcard),
 		IndexRole:     fmt.Sprintf("META().id LIKE '%s'", SyncRoleWildcard),
 	}
 
@@ -154,7 +148,6 @@ var (
 		IndexTombstones: Always,
 		IndexSyncDocs:   Dedicated,
 		IndexUser:       Serverless,
-		IndexSession:    Serverless,
 		IndexRole:       Serverless,
 	}
 

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -130,48 +130,6 @@ func TestBuildRolesQuery(t *testing.T) {
 	}
 }
 
-func TestBuildSessionsQuery(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
-		t.Skip("This test is Couchbase Server and UseViews=false only")
-	}
-
-	testCases := []struct {
-		isServerless bool
-	}{
-		{
-			isServerless: false,
-		},
-		{
-			isServerless: true,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(fmt.Sprintf("BuildSessionsQuery in Serverless=%t", testCase.isServerless), func(t *testing.T) {
-			dbContextConfig := getDatabaseContextOptions(testCase.isServerless)
-			database, ctx := db.SetupTestDBWithOptions(t, dbContextConfig)
-			defer database.Close(ctx)
-
-			n1QLStores, reset, err := setupN1QLStore(database.Bucket, testCase.isServerless)
-			require.NoError(t, err, "Unable to get n1QLStore for testBucket")
-			defer func(n1QLStore []base.N1QLStore, isServerless bool) {
-				err := reset(n1QLStores, isServerless)
-				require.NoError(t, err, "Reset fn shouldn't return error")
-			}(n1QLStores, testCase.isServerless)
-
-			// Sessions
-			roleStatement, _ := database.BuildSessionsQuery("user1")
-			plan, explainErr := n1QLStores[0].ExplainQuery(roleStatement, nil)
-			require.NoError(t, explainErr, "Error generating explain for roleAccess query")
-
-			covered := db.IsCovered(plan)
-			planJSON, err := base.JSONMarshal(plan)
-			require.NoError(t, err)
-			require.Equal(t, testCase.isServerless, covered, "Session query covered by index; expectedToBeCovered: %t, Plan: %s", testCase.isServerless, planJSON)
-		})
-	}
-}
-
 func TestBuildUsersQuery(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
 		t.Skip("This test is Couchbase Server and UseViews=false only")

--- a/db/query.go
+++ b/db/query.go
@@ -302,36 +302,6 @@ var QueryUsersUsingSyncDocsIdx = SGQuery{
 	adhoc: false,
 }
 
-var QuerySessions = SGQuery{
-	name: QueryTypeSessions,
-	statement: fmt.Sprintf(
-		"SELECT META(%s).id "+
-			"FROM %s AS %s "+
-			"USE INDEX($idx) "+
-			"WHERE META(%s).id LIKE '%s' "+
-			"AND META(%s).id LIKE '%s' "+
-			"AND username = $userName",
-		base.KeyspaceQueryAlias,
-		base.KeyspaceQueryToken, base.KeyspaceQueryAlias,
-		base.KeyspaceQueryAlias, SyncDocWildcard,
-		base.KeyspaceQueryAlias, SyncSessionWildcard),
-	adhoc: false,
-}
-
-var QuerySessionsUsingSessionIdx = SGQuery{
-	name: QueryTypeSessions,
-	statement: fmt.Sprintf(
-		"SELECT META(%s).id "+
-			"FROM %s AS %s "+
-			"USE INDEX($idx) "+
-			"WHERE META(%s).id LIKE '%s' "+
-			"AND username = $userName",
-		base.KeyspaceQueryAlias,
-		base.KeyspaceQueryToken, base.KeyspaceQueryAlias,
-		base.KeyspaceQueryAlias, SyncSessionWildcard),
-	adhoc: false,
-}
-
 var QueryTombstones = SGQuery{
 	name: QueryTypeTombstones,
 	statement: fmt.Sprintf(

--- a/db/users.go
+++ b/db/users.go
@@ -78,11 +78,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 					err = base.HTTPErrorf(http.StatusBadRequest, "Error creating user: %s", reason)
 					return replaced, err
 				}
-				password := ""
-				if updates.Password != nil {
-					password = *updates.Password
-				}
-				user, err = authenticator.NewUserNoChannels(*updates.Name, password)
+				user, err = authenticator.NewUserNoChannels(*updates.Name, "")
 				princ = user
 			} else {
 				princ, err = authenticator.NewRoleNoChannels(*updates.Name)
@@ -135,9 +131,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 				}
 				changed = true
 			}
-
-			// If a newly created user, don't set password explicitly, in order to not invalidate a session that may have been created before the user was created.
-			if updates.Password != nil && replaced {
+			if updates.Password != nil {
 				err = user.SetPassword(*updates.Password)
 				if err != nil {
 					return false, err

--- a/db/users.go
+++ b/db/users.go
@@ -78,7 +78,11 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 					err = base.HTTPErrorf(http.StatusBadRequest, "Error creating user: %s", reason)
 					return replaced, err
 				}
-				user, err = authenticator.NewUserNoChannels(*updates.Name, "")
+				password := ""
+				if updates.Password != nil {
+					password = *updates.Password
+				}
+				user, err = authenticator.NewUserNoChannels(*updates.Name, password)
 				princ = user
 			} else {
 				princ, err = authenticator.NewRoleNoChannels(*updates.Name)
@@ -131,7 +135,9 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 				}
 				changed = true
 			}
-			if updates.Password != nil {
+
+			// If a newly created user, don't set password explicitly, in order to not invalidate a session that may have been created before the user was created.
+			if updates.Password != nil && replaced {
 				err = user.SetPassword(*updates.Password)
 				if err != nil {
 					return false, err

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1354,13 +1354,6 @@ func (h *handler) updatePrincipal(name string, isUser bool) error {
 	if err != nil {
 		return err
 	} else if replaced {
-		// on update with a new password, remove previous user sessions
-		if newInfo.Password != nil {
-			err = h.db.DeleteUserSessions(h.ctx(), *newInfo.Name)
-			if err != nil {
-				return err
-			}
-		}
 		h.writeStatus(http.StatusOK, "OK")
 	} else {
 		h.writeStatus(http.StatusCreated, "Created")

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -259,7 +259,16 @@ func (h *handler) deleteUserSession() error {
 func (h *handler) deleteUserSessions() error {
 	h.assertAdminOnly()
 	userName := h.PathVar("name")
-	return h.db.DeleteUserSessions(h.ctx(), userName)
+	auth := h.db.Authenticator(h.ctx())
+	user, err := auth.GetUser(userName)
+	if err != nil {
+		return err
+	}
+	if user == nil {
+		return nil
+	}
+	user.UpdateSessionUUID()
+	return auth.Save(user)
 }
 
 // Delete a session if associated with the user provided

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -128,7 +128,7 @@ func (h *handler) makeSessionWithTTL(user auth.User, expiry time.Duration) (sess
 	}
 	h.user = user
 	auth := h.db.Authenticator(h.ctx())
-	session, err := auth.CreateSession(user.Name(), expiry)
+	session, err := auth.CreateSession(h.user, expiry)
 	if err != nil {
 		return "", err
 	}
@@ -199,7 +199,10 @@ func (h *handler) createUserSession() error {
 		return err
 	} else if params.Name == "" || params.Name == base.GuestUsername || !auth.IsValidPrincipalName(params.Name) {
 		return base.HTTPErrorf(http.StatusBadRequest, "Invalid or missing user name")
-	} else if user, err := h.db.Authenticator(h.ctx()).GetUser(params.Name); user == nil {
+	}
+	authenticator := h.db.Authenticator(h.ctx())
+	user, err := authenticator.GetUser(params.Name)
+	if user == nil {
 		if err == nil {
 			err = base.HTTPErrorf(http.StatusNotFound, "No such user %q", params.Name)
 		}
@@ -211,8 +214,7 @@ func (h *handler) createUserSession() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Invalid or missing ttl")
 	}
 
-	authenticator := h.db.Authenticator(h.ctx())
-	session, err := authenticator.CreateSession(params.Name, ttl)
+	session, err := authenticator.CreateSession(user, ttl)
 	if err != nil {
 		return err
 	}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -93,6 +93,9 @@ type RestTester struct {
 	closed                  bool
 }
 
+// restTesterDefaultUserPassword is usable as a default password for SendUserRequest
+const restTesterDefaultUserPassword = "letmein"
+
 // NewRestTester returns a rest tester and corresponding keyspace backed by a single database and a single collection. This collection may be named or default collection based on global test configuration.
 func NewRestTester(tb testing.TB, restConfig *RestTesterConfig) *RestTester {
 	return newRestTester(tb, restConfig, useSingleCollection, 1)
@@ -1048,7 +1051,7 @@ func Request(method, resource, body string) *http.Request {
 
 func RequestByUser(method, resource, body, username string) *http.Request {
 	r := Request(method, resource, body)
-	r.SetBasicAuth(username, "letmein")
+	r.SetBasicAuth(username, restTesterDefaultUserPassword)
 	return r
 }
 


### PR DESCRIPTION
- Hash password in order to invalidate sessions.
- Kept `QuerySessions` for `DELETE /db/_user/username/session` 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1504/
