### PR TITLE
Update changecache stats  always

### DIFF
--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -21,10 +21,6 @@ package db
 
 // Update database-specific stats that are more efficiently calculated at stats collection time
 func (db *DatabaseContext) UpdateCalculatedStats() {
-	if !db.hasDefaultCollection() {
-		return
-	}
-
 	db.changeCache.updateStats()
 	channelCache := db.changeCache.getChannelCache()
 	db.DbStats.Cache().ChannelCacheMaxEntries.Set(int64(channelCache.MaxCacheSize()))


### PR DESCRIPTION
An intermediate version of the collections work had a collection specific changesFeed and channelCache, but now this is database wide. Modify code to make sure stats are always up to date.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
