### PR TITLE
CBG-2676: Expose internal ISGR checkpointer list length stats

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -1578,6 +1578,10 @@ func (d *DbStats) unregisterReplicationStats(replicationID string) {
 	prometheus.Unregister(d.DbReplicatorStats[replicationID].NumConnectAttemptsPull)
 	prometheus.Unregister(d.DbReplicatorStats[replicationID].NumReconnectsAbortedPull)
 	prometheus.Unregister(d.DbReplicatorStats[replicationID].NumHandlersPanicked)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].ExpectedSequenceLen)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].ExpectedSequenceLenPostCleanup)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].ProcessedSequenceLen)
+	prometheus.Unregister(d.DbReplicatorStats[replicationID].ProcessedSequenceLenPostCleanup)
 }
 
 func (d *DbStats) unregisterCollectionStats(scopeAndCollectionName string) {
@@ -1786,6 +1790,22 @@ func (d *DbStats) DBReplicatorStats(replicationID string) (*DbReplicatorStats, e
 		if err != nil {
 			return nil, err
 		}
+		resUtil.ExpectedSequenceLen, err = NewIntStat(SubsystemReplication, "expected_sequence_len", labelKeys, labelVals, prometheus.CounterValue, 0)
+		if err != nil {
+			return nil, err
+		}
+		resUtil.ExpectedSequenceLenPostCleanup, err = NewIntStat(SubsystemReplication, "expected_sequence_len_post_cleanup", labelKeys, labelVals, prometheus.CounterValue, 0)
+		if err != nil {
+			return nil, err
+		}
+		resUtil.ProcessedSequenceLen, err = NewIntStat(SubsystemReplication, "processed_sequence_len", labelKeys, labelVals, prometheus.CounterValue, 0)
+		if err != nil {
+			return nil, err
+		}
+		resUtil.ProcessedSequenceLenPostCleanup, err = NewIntStat(SubsystemReplication, "processed_sequence_len_post_cleanup", labelKeys, labelVals, prometheus.CounterValue, 0)
+		if err != nil {
+			return nil, err
+		}
 
 		d.DbReplicatorStats[replicationID] = resUtil
 
@@ -1815,6 +1835,11 @@ func (dbr *DbReplicatorStats) Reset() {
 	dbr.ConflictResolvedLocalCount.Set(0)
 	dbr.ConflictResolvedRemoteCount.Set(0)
 	dbr.ConflictResolvedMergedCount.Set(0)
+	dbr.ExpectedSequenceLen.Set(0)
+	dbr.ExpectedSequenceLenPostCleanup.Set(0)
+	dbr.ProcessedSequenceLen.Set(0)
+	dbr.ProcessedSequenceLenPostCleanup.Set(0)
+
 }
 
 func (d *DbStats) Security() *SecurityStats {

--- a/base/stats.go
+++ b/base/stats.go
@@ -647,6 +647,11 @@ type DbReplicatorStats struct {
 
 	// The number of times a handler panicked and didn't know how to recover from it.
 	NumHandlersPanicked *SgwIntStat `json:"-"`
+	// Internal stats for the lengths of expectedSeqs/processedSeqs lists in the ISGR checkpointer.
+	ExpectedSequenceLen             *SgwIntStat `json:"expected_seq_len,omitempty"`
+	ExpectedSequenceLenPostCleanup  *SgwIntStat `json:"expected_seq_len_post_cleanup,omitempty"`
+	ProcessedSequenceLen            *SgwIntStat `json:"processed_seq_len,omitempty"`
+	ProcessedSequenceLenPostCleanup *SgwIntStat `json:"processed_seq_len_post_cleanup,omitempty"`
 }
 
 type SecurityStats struct {

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -300,11 +300,12 @@ func (c *Checkpointer) _updateCheckpointLists() (safeSeq *SequenceID) {
 	c.stats.ExpectedSequenceLenPostCleanup = int64(len(c.expectedSeqs))
 	c.stats.ProcessedSequenceLenPostCleanup = int64(len(c.processedSeqs))
 
-	c.dbStats.ProcessedSequenceLen.Set(c.stats.ProcessedSequenceLen)
-	c.dbStats.ProcessedSequenceLenPostCleanup.Set(c.stats.ProcessedSequenceLenPostCleanup)
-	c.dbStats.ExpectedSequenceLen.Set(c.stats.ExpectedSequenceLen)
-	c.dbStats.ExpectedSequenceLenPostCleanup.Set(c.stats.ExpectedSequenceLenPostCleanup)
-
+	if c.dbStats != nil {
+		c.dbStats.ProcessedSequenceLen.Set(c.stats.ProcessedSequenceLen)
+		c.dbStats.ProcessedSequenceLenPostCleanup.Set(c.stats.ProcessedSequenceLenPostCleanup)
+		c.dbStats.ExpectedSequenceLen.Set(c.stats.ExpectedSequenceLen)
+		c.dbStats.ExpectedSequenceLenPostCleanup.Set(c.stats.ExpectedSequenceLenPostCleanup)
+	}
 	return safeSeq
 }
 

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -301,7 +301,7 @@ func (c *Checkpointer) _updateCheckpointLists() (safeSeq *SequenceID) {
 	c.stats.ProcessedSequenceLenPostCleanup = int64(len(c.processedSeqs))
 
 	c.dbStats.ProcessedSequenceLen.Set(c.stats.ProcessedSequenceLen)
-	c.dbStats.ProcessedSequenceLen.Set(c.stats.ProcessedSequenceLenPostCleanup)
+	c.dbStats.ProcessedSequenceLenPostCleanup.Set(c.stats.ProcessedSequenceLenPostCleanup)
 	c.dbStats.ExpectedSequenceLen.Set(c.stats.ExpectedSequenceLen)
 	c.dbStats.ExpectedSequenceLenPostCleanup.Set(c.stats.ExpectedSequenceLenPostCleanup)
 

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -299,7 +299,7 @@ func (c *Checkpointer) _updateCheckpointLists() (safeSeq *SequenceID) {
 		}
 	}
 
-	c.stats.ExpectedSequenceLenPostCleanup.Set(int64(len(c.processedSeqs)))
+	c.stats.ProcessedSequenceLenPostCleanup.Set(int64(len(c.processedSeqs)))
 	c.stats.ExpectedSequenceLenPostCleanup.Set(int64(len(c.expectedSeqs)))
 	return safeSeq
 }

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -67,11 +67,11 @@ type statusFunc func(lastSeq string) *ReplicationStatus
 
 type CheckpointerStats struct {
 	ExpectedSequenceCount           int64
-	ExpectedSequenceLen             base.SgwIntStat
-	ExpectedSequenceLenPostCleanup  base.SgwIntStat
+	ExpectedSequenceLen             *base.SgwIntStat
+	ExpectedSequenceLenPostCleanup  *base.SgwIntStat
 	ProcessedSequenceCount          int64
-	ProcessedSequenceLen            base.SgwIntStat
-	ProcessedSequenceLenPostCleanup base.SgwIntStat
+	ProcessedSequenceLen            *base.SgwIntStat
+	ProcessedSequenceLenPostCleanup *base.SgwIntStat
 	AlreadyKnownSequenceCount       int64
 	SetCheckpointCount              int64
 	GetCheckpointHitCount           int64
@@ -90,10 +90,10 @@ func NewCheckpointer(ctx context.Context, clientID string, configHash string, bl
 		checkpointInterval: replicatorConfig.CheckpointInterval,
 		ctx:                ctx,
 		stats: CheckpointerStats{
-			ProcessedSequenceLen:            *replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
-			ProcessedSequenceLenPostCleanup: *replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
-			ExpectedSequenceLen:             *replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
-			ExpectedSequenceLenPostCleanup:  *replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
+			ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
+			ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
+			ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
+			ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
 		},
 		dbStats:                        replicatorConfig.ReplicationStatsMap,
 		statusCallback:                 statusCallback,

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -67,11 +67,11 @@ type statusFunc func(lastSeq string) *ReplicationStatus
 
 type CheckpointerStats struct {
 	ExpectedSequenceCount           int64
-	ExpectedSequenceLen             int64
-	ExpectedSequenceLenPostCleanup  int64
+	ExpectedSequenceLen             base.SgwIntStat
+	ExpectedSequenceLenPostCleanup  base.SgwIntStat
 	ProcessedSequenceCount          int64
-	ProcessedSequenceLen            int64
-	ProcessedSequenceLenPostCleanup int64
+	ProcessedSequenceLen            base.SgwIntStat
+	ProcessedSequenceLenPostCleanup base.SgwIntStat
 	AlreadyKnownSequenceCount       int64
 	SetCheckpointCount              int64
 	GetCheckpointHitCount           int64
@@ -80,16 +80,21 @@ type CheckpointerStats struct {
 
 func NewCheckpointer(ctx context.Context, clientID string, configHash string, blipSender *blip.Sender, replicatorConfig *ActiveReplicatorConfig, statusCallback statusFunc) *Checkpointer {
 	return &Checkpointer{
-		clientID:                       clientID,
-		configHash:                     configHash,
-		blipSender:                     blipSender,
-		activeDB:                       replicatorConfig.ActiveDB,
-		expectedSeqs:                   make([]SequenceID, 0),
-		processedSeqs:                  make(map[SequenceID]struct{}),
-		idAndRevLookup:                 make(map[IDAndRev]SequenceID),
-		checkpointInterval:             replicatorConfig.CheckpointInterval,
-		ctx:                            ctx,
-		stats:                          CheckpointerStats{},
+		clientID:           clientID,
+		configHash:         configHash,
+		blipSender:         blipSender,
+		activeDB:           replicatorConfig.ActiveDB,
+		expectedSeqs:       make([]SequenceID, 0),
+		processedSeqs:      make(map[SequenceID]struct{}),
+		idAndRevLookup:     make(map[IDAndRev]SequenceID),
+		checkpointInterval: replicatorConfig.CheckpointInterval,
+		ctx:                ctx,
+		stats: CheckpointerStats{
+			ProcessedSequenceLen:            *replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
+			ProcessedSequenceLenPostCleanup: *replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
+			ExpectedSequenceLen:             *replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
+			ExpectedSequenceLenPostCleanup:  *replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
+		},
 		dbStats:                        replicatorConfig.ReplicationStatsMap,
 		statusCallback:                 statusCallback,
 		expectedSeqCompactionThreshold: defaultExpectedSeqCompactionThreshold,
@@ -261,8 +266,10 @@ func (c *Checkpointer) _updateCheckpointLists() (safeSeq *SequenceID) {
 	base.TracefCtx(c.ctx, base.KeyReplicate, "checkpointer: _updateCheckpointLists(expectedSeqs: %v, processedSeqs: %v)", c.expectedSeqs, c.processedSeqs)
 	base.TracefCtx(c.ctx, base.KeyReplicate, "Inside update checkpoint lists")
 
-	c.stats.ExpectedSequenceLen = int64(len(c.expectedSeqs))
-	c.stats.ProcessedSequenceLen = int64(len(c.processedSeqs))
+	if c.dbStats != nil {
+		c.dbStats.ProcessedSequenceLen.Set(int64(len(c.processedSeqs)))
+		c.dbStats.ExpectedSequenceLen.Set(int64(len(c.expectedSeqs)))
+	}
 	maxI := c._calculateSafeExpectedSeqsIdx()
 
 	if maxI > -1 {
@@ -297,14 +304,9 @@ func (c *Checkpointer) _updateCheckpointLists() (safeSeq *SequenceID) {
 		}
 	}
 
-	c.stats.ExpectedSequenceLenPostCleanup = int64(len(c.expectedSeqs))
-	c.stats.ProcessedSequenceLenPostCleanup = int64(len(c.processedSeqs))
-
 	if c.dbStats != nil {
-		c.dbStats.ProcessedSequenceLen.Set(c.stats.ProcessedSequenceLen)
-		c.dbStats.ProcessedSequenceLenPostCleanup.Set(c.stats.ProcessedSequenceLenPostCleanup)
-		c.dbStats.ExpectedSequenceLen.Set(c.stats.ExpectedSequenceLen)
-		c.dbStats.ExpectedSequenceLenPostCleanup.Set(c.stats.ExpectedSequenceLenPostCleanup)
+		c.dbStats.ExpectedSequenceLenPostCleanup.Set(int64(len(c.processedSeqs)))
+		c.dbStats.ExpectedSequenceLenPostCleanup.Set(int64(len(c.expectedSeqs)))
 	}
 	return safeSeq
 }

--- a/db/active_replicator_checkpointer_test.go
+++ b/db/active_replicator_checkpointer_test.go
@@ -12,9 +12,10 @@ package db
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/require"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/db/active_replicator_checkpointer_test.go
+++ b/db/active_replicator_checkpointer_test.go
@@ -12,6 +12,8 @@ package db
 
 import (
 	"fmt"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,6 +45,12 @@ func genProcessedForTest(t testing.TB, seqs ...string) map[SequenceID]struct{} {
 
 func TestCheckpointerSafeSeq(t *testing.T) {
 
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	replicationStats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+	replicatorConfig := &ActiveReplicatorConfig{}
+	replicatorConfig.ReplicationStatsMap = replicationStats
+
 	tests := []struct {
 		name                    string
 		c                       *Checkpointer
@@ -56,6 +64,12 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			c: &Checkpointer{
 				expectedSeqs:  genExpectedForTest(t),
 				processedSeqs: genProcessedForTest(t),
+				stats: CheckpointerStats{
+					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
+					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
+					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
+					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
+				},
 			},
 			expectedSafeSeq:         nil,
 			expectedExpectedSeqsIdx: -1,
@@ -67,6 +81,12 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			c: &Checkpointer{
 				expectedSeqs:  genExpectedForTest(t, "1", "2", "3"),
 				processedSeqs: genProcessedForTest(t),
+				stats: CheckpointerStats{
+					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
+					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
+					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
+					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
+				},
 			},
 			expectedSafeSeq:         nil,
 			expectedExpectedSeqsIdx: -1,
@@ -78,6 +98,12 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			c: &Checkpointer{
 				expectedSeqs:  genExpectedForTest(t, "1", "2", "3"),
 				processedSeqs: genProcessedForTest(t, "1"),
+				stats: CheckpointerStats{
+					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
+					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
+					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
+					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
+				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 1},
 			expectedExpectedSeqsIdx: 0,
@@ -89,6 +115,12 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			c: &Checkpointer{
 				expectedSeqs:  genExpectedForTest(t, "1", "2", "3"),
 				processedSeqs: genProcessedForTest(t, "1", "3"),
+				stats: CheckpointerStats{
+					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
+					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
+					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
+					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
+				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 1},
 			expectedExpectedSeqsIdx: 0,
@@ -100,6 +132,12 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			c: &Checkpointer{
 				expectedSeqs:  genExpectedForTest(t, "1", "2", "3"),
 				processedSeqs: genProcessedForTest(t, "1", "2", "3"),
+				stats: CheckpointerStats{
+					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
+					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
+					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
+					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
+				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 3},
 			expectedExpectedSeqsIdx: 2,
@@ -111,6 +149,12 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			c: &Checkpointer{
 				expectedSeqs:  genExpectedForTest(t, "1", "2", "3"),
 				processedSeqs: genProcessedForTest(t, "1", "2", "3", "4", "5"),
+				stats: CheckpointerStats{
+					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
+					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
+					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
+					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
+				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 3},
 			expectedExpectedSeqsIdx: 2,
@@ -122,6 +166,12 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			c: &Checkpointer{
 				expectedSeqs:  genExpectedForTest(t, "3", "2", "1"),
 				processedSeqs: genProcessedForTest(t, "1", "2", "3"),
+				stats: CheckpointerStats{
+					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
+					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
+					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
+					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
+				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 3},
 			expectedExpectedSeqsIdx: 2,
@@ -133,6 +183,12 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			c: &Checkpointer{
 				expectedSeqs:  genExpectedForTest(t, "1", "1::3"),
 				processedSeqs: genProcessedForTest(t, "1", "1::3"),
+				stats: CheckpointerStats{
+					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
+					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
+					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
+					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
+				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 3, LowSeq: 1},
 			expectedExpectedSeqsIdx: 1,
@@ -144,6 +200,12 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			c: &Checkpointer{
 				expectedSeqs:  genExpectedForTest(t, "1", "1::3", "4:2"),
 				processedSeqs: genProcessedForTest(t, "1", "1::3", "4:2"),
+				stats: CheckpointerStats{
+					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
+					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
+					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
+					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
+				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 2, TriggeredBy: 4},
 			expectedExpectedSeqsIdx: 2,
@@ -164,6 +226,12 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 				expectedSeqs:                   genExpectedForTest(t, "1", "2", "3", "4", "5", "6"),
 				processedSeqs:                  genProcessedForTest(t, "1", "3", "4", "5"),
 				expectedSeqCompactionThreshold: 3, // this many expected seqs to trigger compaction
+				stats: CheckpointerStats{
+					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
+					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
+					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
+					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
+				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 1},
 			expectedExpectedSeqsIdx: 0,
@@ -184,6 +252,12 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 				expectedSeqs:                   genExpectedForTest(t, "2", "1", "6", "8", "4", "9"),
 				processedSeqs:                  genProcessedForTest(t, "4", "1", "6", "8"),
 				expectedSeqCompactionThreshold: 3, // this many expected seqs to trigger compaction
+				stats: CheckpointerStats{
+					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
+					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
+					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
+					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
+				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 1},
 			expectedExpectedSeqsIdx: 0,
@@ -196,6 +270,12 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 				expectedSeqs:                   genExpectedForTest(t, "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20"),
 				processedSeqs:                  genProcessedForTest(t, "1", "2", "4", "5", "7", "8", "9", "11", "12", "13", "15", "16", "17", "19"),
 				expectedSeqCompactionThreshold: 5, // this many expected seqs to trigger compaction
+				stats: CheckpointerStats{
+					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
+					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
+					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
+					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
+				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 2},
 			expectedExpectedSeqsIdx: 1,
@@ -230,6 +310,12 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 					"47358513", "47358514", "47358515", "47358516", "47358517", "47358518", "47358519", "47358520", "47358521", "47358522", "47358523", "47358524", "47358525", "47358526",
 					"47358527", "47358528", "47358529", "47358530", "47358531", "47358532"),
 				expectedSeqCompactionThreshold: 5, // this many expected seqs to trigger compaction
+				stats: CheckpointerStats{
+					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
+					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
+					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
+					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
+				},
 			},
 			expectedSafeSeq:         nil,
 			expectedExpectedSeqsIdx: -1,

--- a/db/active_replicator_checkpointer_test.go
+++ b/db/active_replicator_checkpointer_test.go
@@ -46,12 +46,6 @@ func genProcessedForTest(t testing.TB, seqs ...string) map[SequenceID]struct{} {
 
 func TestCheckpointerSafeSeq(t *testing.T) {
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-	replicationStats, err := stats.DBReplicatorStats(t.Name())
-	require.NoError(t, err)
-	replicatorConfig := &ActiveReplicatorConfig{}
-	replicatorConfig.ReplicationStatsMap = replicationStats
-
 	tests := []struct {
 		name                    string
 		c                       *Checkpointer
@@ -65,12 +59,6 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			c: &Checkpointer{
 				expectedSeqs:  genExpectedForTest(t),
 				processedSeqs: genProcessedForTest(t),
-				stats: CheckpointerStats{
-					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
-					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
-					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
-					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
-				},
 			},
 			expectedSafeSeq:         nil,
 			expectedExpectedSeqsIdx: -1,
@@ -82,12 +70,6 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			c: &Checkpointer{
 				expectedSeqs:  genExpectedForTest(t, "1", "2", "3"),
 				processedSeqs: genProcessedForTest(t),
-				stats: CheckpointerStats{
-					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
-					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
-					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
-					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
-				},
 			},
 			expectedSafeSeq:         nil,
 			expectedExpectedSeqsIdx: -1,
@@ -99,12 +81,6 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			c: &Checkpointer{
 				expectedSeqs:  genExpectedForTest(t, "1", "2", "3"),
 				processedSeqs: genProcessedForTest(t, "1"),
-				stats: CheckpointerStats{
-					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
-					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
-					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
-					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
-				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 1},
 			expectedExpectedSeqsIdx: 0,
@@ -116,12 +92,6 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			c: &Checkpointer{
 				expectedSeqs:  genExpectedForTest(t, "1", "2", "3"),
 				processedSeqs: genProcessedForTest(t, "1", "3"),
-				stats: CheckpointerStats{
-					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
-					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
-					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
-					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
-				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 1},
 			expectedExpectedSeqsIdx: 0,
@@ -133,12 +103,6 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			c: &Checkpointer{
 				expectedSeqs:  genExpectedForTest(t, "1", "2", "3"),
 				processedSeqs: genProcessedForTest(t, "1", "2", "3"),
-				stats: CheckpointerStats{
-					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
-					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
-					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
-					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
-				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 3},
 			expectedExpectedSeqsIdx: 2,
@@ -150,12 +114,6 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			c: &Checkpointer{
 				expectedSeqs:  genExpectedForTest(t, "1", "2", "3"),
 				processedSeqs: genProcessedForTest(t, "1", "2", "3", "4", "5"),
-				stats: CheckpointerStats{
-					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
-					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
-					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
-					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
-				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 3},
 			expectedExpectedSeqsIdx: 2,
@@ -167,12 +125,6 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			c: &Checkpointer{
 				expectedSeqs:  genExpectedForTest(t, "3", "2", "1"),
 				processedSeqs: genProcessedForTest(t, "1", "2", "3"),
-				stats: CheckpointerStats{
-					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
-					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
-					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
-					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
-				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 3},
 			expectedExpectedSeqsIdx: 2,
@@ -184,12 +136,6 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			c: &Checkpointer{
 				expectedSeqs:  genExpectedForTest(t, "1", "1::3"),
 				processedSeqs: genProcessedForTest(t, "1", "1::3"),
-				stats: CheckpointerStats{
-					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
-					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
-					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
-					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
-				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 3, LowSeq: 1},
 			expectedExpectedSeqsIdx: 1,
@@ -201,12 +147,6 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			c: &Checkpointer{
 				expectedSeqs:  genExpectedForTest(t, "1", "1::3", "4:2"),
 				processedSeqs: genProcessedForTest(t, "1", "1::3", "4:2"),
-				stats: CheckpointerStats{
-					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
-					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
-					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
-					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
-				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 2, TriggeredBy: 4},
 			expectedExpectedSeqsIdx: 2,
@@ -227,12 +167,6 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 				expectedSeqs:                   genExpectedForTest(t, "1", "2", "3", "4", "5", "6"),
 				processedSeqs:                  genProcessedForTest(t, "1", "3", "4", "5"),
 				expectedSeqCompactionThreshold: 3, // this many expected seqs to trigger compaction
-				stats: CheckpointerStats{
-					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
-					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
-					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
-					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
-				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 1},
 			expectedExpectedSeqsIdx: 0,
@@ -253,12 +187,6 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 				expectedSeqs:                   genExpectedForTest(t, "2", "1", "6", "8", "4", "9"),
 				processedSeqs:                  genProcessedForTest(t, "4", "1", "6", "8"),
 				expectedSeqCompactionThreshold: 3, // this many expected seqs to trigger compaction
-				stats: CheckpointerStats{
-					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
-					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
-					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
-					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
-				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 1},
 			expectedExpectedSeqsIdx: 0,
@@ -271,12 +199,6 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 				expectedSeqs:                   genExpectedForTest(t, "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20"),
 				processedSeqs:                  genProcessedForTest(t, "1", "2", "4", "5", "7", "8", "9", "11", "12", "13", "15", "16", "17", "19"),
 				expectedSeqCompactionThreshold: 5, // this many expected seqs to trigger compaction
-				stats: CheckpointerStats{
-					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
-					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
-					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
-					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
-				},
 			},
 			expectedSafeSeq:         &SequenceID{Seq: 2},
 			expectedExpectedSeqsIdx: 1,
@@ -311,12 +233,6 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 					"47358513", "47358514", "47358515", "47358516", "47358517", "47358518", "47358519", "47358520", "47358521", "47358522", "47358523", "47358524", "47358525", "47358526",
 					"47358527", "47358528", "47358529", "47358530", "47358531", "47358532"),
 				expectedSeqCompactionThreshold: 5, // this many expected seqs to trigger compaction
-				stats: CheckpointerStats{
-					ProcessedSequenceLen:            replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen,
-					ProcessedSequenceLenPostCleanup: replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup,
-					ExpectedSequenceLen:             replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen,
-					ExpectedSequenceLenPostCleanup:  replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup,
-				},
 			},
 			expectedSafeSeq:         nil,
 			expectedExpectedSeqsIdx: -1,
@@ -336,6 +252,15 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+			replicationStats, err := stats.DBReplicatorStats(t.Name())
+			require.NoError(t, err)
+			replicatorConfig := &ActiveReplicatorConfig{}
+			replicatorConfig.ReplicationStatsMap = replicationStats
+			tt.c.stats.ProcessedSequenceLen = replicatorConfig.ReplicationStatsMap.ProcessedSequenceLen
+			tt.c.stats.ProcessedSequenceLenPostCleanup = replicatorConfig.ReplicationStatsMap.ProcessedSequenceLenPostCleanup
+			tt.c.stats.ExpectedSequenceLen = replicatorConfig.ReplicationStatsMap.ExpectedSequenceLen
+			tt.c.stats.ExpectedSequenceLenPostCleanup = replicatorConfig.ReplicationStatsMap.ExpectedSequenceLenPostCleanup
 			t.Run("_calculateSafeExpectedSeqsIdx", func(t *testing.T) {
 				actualIdx := tt.c._calculateSafeExpectedSeqsIdx()
 				assert.Equal(t, tt.expectedExpectedSeqsIdx, actualIdx)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1959,10 +1959,10 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().AlreadyKnownSequenceCount)
 	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ProcessedSequenceCount)
 
-	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ExpectedSequenceLen)
-	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ProcessedSequenceLen)
-	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().ExpectedSequenceLenPostCleanup)
-	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().ProcessedSequenceLenPostCleanup)
+	assert.Equal(t, int64(1), dbstats.ExpectedSequenceLen.Value())
+	assert.Equal(t, int64(1), dbstats.ProcessedSequenceLen.Value())
+	assert.Equal(t, int64(0), dbstats.ExpectedSequenceLenPostCleanup.Value())
+	assert.Equal(t, int64(0), dbstats.ProcessedSequenceLenPostCleanup.Value())
 
 	docID2 := docIDPrefix + "2"
 	resp = rt2.SendAdminRequest(http.MethodPut, "/db/"+docID2, `{"source":"rt2","channels":["`+username+`"]}`)
@@ -1990,10 +1990,10 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().AlreadyKnownSequenceCount)
 	assert.Equal(t, int64(2), ar.Pull.Checkpointer.Stats().ProcessedSequenceCount)
 
-	assert.Equal(t, int64(2), ar.Pull.Checkpointer.Stats().ExpectedSequenceLen)
-	assert.Equal(t, int64(2), ar.Pull.Checkpointer.Stats().ProcessedSequenceLen)
-	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().ExpectedSequenceLenPostCleanup)
-	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().ProcessedSequenceLenPostCleanup)
+	assert.Equal(t, int64(2), dbstats.ExpectedSequenceLen.Value())
+	assert.Equal(t, int64(2), dbstats.ProcessedSequenceLen.Value())
+	assert.Equal(t, int64(0), dbstats.ExpectedSequenceLenPostCleanup.Value())
+	assert.Equal(t, int64(0), dbstats.ProcessedSequenceLenPostCleanup.Value())
 
 	docID4 := docIDPrefix + "4"
 	resp = rt2.SendAdminRequest(http.MethodPut, "/db/"+docID4, `{"source":"rt2","channels":["`+username+`"]}`)
@@ -2011,10 +2011,10 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().AlreadyKnownSequenceCount)
 	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ProcessedSequenceCount)
 
-	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ExpectedSequenceLen)
-	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ProcessedSequenceLen)
-	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().ExpectedSequenceLenPostCleanup)
-	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().ProcessedSequenceLenPostCleanup)
+	assert.Equal(t, int64(1), dbstats.ExpectedSequenceLen.Value())
+	assert.Equal(t, int64(1), dbstats.ExpectedSequenceLen.Value())
+	assert.Equal(t, int64(0), dbstats.ExpectedSequenceLenPostCleanup.Value())
+	assert.Equal(t, int64(0), dbstats.ProcessedSequenceLenPostCleanup.Value())
 }
 
 // TestActiveReplicatorPullAttachments:

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1959,10 +1959,10 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().AlreadyKnownSequenceCount)
 	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ProcessedSequenceCount)
 
-	assert.Equal(t, 1, ar.Pull.Checkpointer.Stats().ExpectedSequenceLen)
-	assert.Equal(t, 1, ar.Pull.Checkpointer.Stats().ProcessedSequenceLen)
-	assert.Equal(t, 0, ar.Pull.Checkpointer.Stats().ExpectedSequenceLenPostCleanup)
-	assert.Equal(t, 0, ar.Pull.Checkpointer.Stats().ProcessedSequenceLenPostCleanup)
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ExpectedSequenceLen)
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ProcessedSequenceLen)
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().ExpectedSequenceLenPostCleanup)
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().ProcessedSequenceLenPostCleanup)
 
 	docID2 := docIDPrefix + "2"
 	resp = rt2.SendAdminRequest(http.MethodPut, "/db/"+docID2, `{"source":"rt2","channels":["`+username+`"]}`)
@@ -1990,10 +1990,10 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().AlreadyKnownSequenceCount)
 	assert.Equal(t, int64(2), ar.Pull.Checkpointer.Stats().ProcessedSequenceCount)
 
-	assert.Equal(t, 2, ar.Pull.Checkpointer.Stats().ExpectedSequenceLen)
-	assert.Equal(t, 2, ar.Pull.Checkpointer.Stats().ProcessedSequenceLen)
-	assert.Equal(t, 0, ar.Pull.Checkpointer.Stats().ExpectedSequenceLenPostCleanup)
-	assert.Equal(t, 0, ar.Pull.Checkpointer.Stats().ProcessedSequenceLenPostCleanup)
+	assert.Equal(t, int64(2), ar.Pull.Checkpointer.Stats().ExpectedSequenceLen)
+	assert.Equal(t, int64(2), ar.Pull.Checkpointer.Stats().ProcessedSequenceLen)
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().ExpectedSequenceLenPostCleanup)
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().ProcessedSequenceLenPostCleanup)
 
 	docID4 := docIDPrefix + "4"
 	resp = rt2.SendAdminRequest(http.MethodPut, "/db/"+docID4, `{"source":"rt2","channels":["`+username+`"]}`)
@@ -2011,10 +2011,10 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().AlreadyKnownSequenceCount)
 	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ProcessedSequenceCount)
 
-	assert.Equal(t, 1, ar.Pull.Checkpointer.Stats().ExpectedSequenceLen)
-	assert.Equal(t, 1, ar.Pull.Checkpointer.Stats().ProcessedSequenceLen)
-	assert.Equal(t, 0, ar.Pull.Checkpointer.Stats().ExpectedSequenceLenPostCleanup)
-	assert.Equal(t, 0, ar.Pull.Checkpointer.Stats().ProcessedSequenceLenPostCleanup)
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ExpectedSequenceLen)
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ProcessedSequenceLen)
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().ExpectedSequenceLenPostCleanup)
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().ProcessedSequenceLenPostCleanup)
 }
 
 // TestActiveReplicatorPullAttachments:


### PR DESCRIPTION
CBG-2676

Describe your PR here...
- dbStats can now be passed when creating a checkpointer, and it will store expected/processed sequence lists lengths, pre and post cleanup.
- Tests that assert on those stats in the checkpointer stats were changes to assert on them in the dbstats

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1506/
