### PR TITLE
Add HashStringKVMap util for generating a hash based on the contents of a map

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -1785,13 +1785,13 @@ func WaitForNoError(callback func() error) error {
 	return err
 }
 
-// MapKVHash returns a deterministic hash for the keys and values of a map
+// HashStringKVMap returns a deterministic hash for the keys and values of a map.
 // Performance warning: ~3 map iterations required to get a hash from a sorted set of kv pairs.
-func MapKVHash[M ~map[K]V, K, V comparable](m M) []byte {
+func HashStringKVMap(m map[string]string) []byte {
 	mapStrings := make([]struct{ k, v string }, 0, len(m))
 
 	for k, v := range m {
-		mapStrings = append(mapStrings, struct{ k, v string }{fmt.Sprintf("%v", k), fmt.Sprintf("%v", v)})
+		mapStrings = append(mapStrings, struct{ k, v string }{k, v})
 	}
 
 	// sort by map key - don't worry about stable sort as map keys must be unique anyway

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -1665,7 +1665,7 @@ func TestReplaceLast(t *testing.T) {
 	}
 }
 
-func TestMapKVHashString(t *testing.T) {
+func TestHashStringKVMap(t *testing.T) {
 	tests := []struct {
 		name  string
 		input map[string]string
@@ -1705,48 +1705,17 @@ func TestMapKVHashString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hash := MapKVHash(tt.input)
+			hash := HashStringKVMap(tt.input)
 			hashString := fmt.Sprintf("%x", hash)
 			assert.Equalf(t, tt.want, hashString, "MapKVHash(%v) -> %s", tt.input, hashString)
 		})
 	}
 }
 
-func TestMapKVHashInt(t *testing.T) {
-	tests := []struct {
-		name  string
-		input map[int]string
-		want  string
-	}{
-		{
-			name:  "single-element map",
-			input: map[int]string{3: "bar"},
-			want:  "ac829bb16903bef21be0f516010a469b72c08733",
-		},
-		{
-			name:  "in order map",
-			input: map[int]string{4: "buzz", 7: "bar"},
-			want:  "113604ae70d118d8c17d784ebe9b9bf5982ad630", // same hash as below (same KVs)
-		},
-		{
-			name:  "out of order map",
-			input: map[int]string{7: "bar", 4: "buzz"},
-			want:  "113604ae70d118d8c17d784ebe9b9bf5982ad630", // same hash as above (same KVs)
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			hash := MapKVHash(tt.input)
-			hashString := fmt.Sprintf("%x", hash)
-			assert.Equalf(t, tt.want, hashString, "MapKVHash(%v) -> %s", tt.input, hashString)
-		})
-	}
-}
-
-func BenchmarkMapKVHashString(b *testing.B) {
+func BenchmarkHashStringKVMap(b *testing.B) {
 	b.ReportAllocs()
 	input := map[string]string{"foo": "buzz", "zoo": "bar"}
 	for i := 0; i < b.N; i++ {
-		_ = MapKVHash(input)
+		_ = HashStringKVMap(input)
 	}
 }


### PR DESCRIPTION
Required for upcoming ISGR collections work, which requires identifying when the set of collections (or their mappings) change.
We use this generated hash in the replication config hash inside the checkpoint to detect changes and reset the replicator since value.
 
Tried to figure out if I could reduce number of map iterations and I'm not sure I can. If anybody has any brighter ideas I'm open to it.

```go
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkHashStringKVMap
BenchmarkHashStringKVMap-12    	 1496924	       797.8 ns/op	     192 B/op	       5 allocs/op
PASS
```