### PR TITLE
CBG-2343 Add database registry and associated API

### DIFF
--- a/base/collection_common.go
+++ b/base/collection_common.go
@@ -48,3 +48,7 @@ func (s ScopeAndCollectionNames) ScopeAndCollectionNames() []string {
 	}
 	return scopes
 }
+
+func FullyQualifiedCollectionName(bucketName, scopeName, collectionName string) string {
+	return bucketName + "." + scopeName + "." + collectionName
+}

--- a/base/collection_gocb.go
+++ b/base/collection_gocb.go
@@ -73,7 +73,7 @@ func (c *Collection) GetName() string {
 		return c.Collection.Bucket().Name()
 	}
 	// An unescaped variant of c.EscapedKeyspace()
-	return fmt.Sprintf("%s.%s.%s", c.BucketName(), c.ScopeName(), c.CollectionName())
+	return FullyQualifiedCollectionName(c.BucketName(), c.ScopeName(), c.CollectionName())
 }
 
 // KV store

--- a/base/config_persistence_test.go
+++ b/base/config_persistence_test.go
@@ -78,11 +78,11 @@ func TestConfigPersistence(t *testing.T) {
 			require.NoError(t, marshalErr)
 
 			// update with incorrect cas
-			_, _, updateErr := cp.replaceRawConfig(c, configKey, updatedRawBody, 1234)
+			_, updateErr := cp.replaceRawConfig(c, configKey, updatedRawBody, 1234)
 			require.Error(t, updateErr)
 
 			// update with correct cas
-			updateCas, _, updateErr := cp.replaceRawConfig(c, configKey, updatedRawBody, gocb.Cas(insertCas))
+			updateCas, updateErr := cp.replaceRawConfig(c, configKey, updatedRawBody, gocb.Cas(insertCas))
 			require.NoError(t, updateErr)
 
 			// retrieve config, validate updated value

--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -11,7 +11,6 @@ licenses/APL2.txt.
 package base
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -36,6 +35,7 @@ const (
 	RepairBackupPrefix               = SyncDocPrefix + "repair:backup:"                // RepairBackupPrefix is the doc prefix used to store a backup of a repaired document
 	RepairDryRunPrefix               = SyncDocPrefix + "repair:dryrun:"                // RepairDryRunPrefix is the doc prefix used to store a repaired document in dry-run mode
 	SGRStatusPrefix                  = SyncDocPrefix + "sgrStatus:"                    // SGRStatusPrefix is the doc prefix used to store ISGR status documents
+	SGRegistryKey                    = SyncDocPrefix + "registry"                      // Registry of all SG databases defined for the bucket (for all group IDs)
 )
 
 // Sync Gateway Metadata documents that should be GroupID scoped and accessed via the "WithGroupID" helper methods below
@@ -90,12 +90,4 @@ func HeartbeaterPrefixWithGroupID(groupID string) string {
 		return HeartbeaterPrefixWithoutGroupID + groupID + ":"
 	}
 	return HeartbeaterPrefixWithoutGroupID
-}
-
-// PersistentConfigKey returns a document key to use to store database configs
-func PersistentConfigKey(groupID string) (string, error) {
-	if groupID == "" {
-		return "", errors.New("PersistentConfigKey requires a group ID, even if it's just `default`.")
-	}
-	return PersistentConfigPrefixWithoutGroupID + groupID, nil
 }

--- a/base/error.go
+++ b/base/error.go
@@ -58,6 +58,15 @@ var (
 	// ErrDeltaSourceIsTombstone is returned to indicate delta sync should do a full body replication due to the
 	// delta source being a tombstone (therefore having an empty body)
 	ErrDeltaSourceIsTombstone = &sgError{"From rev is a tombstone"}
+
+	// ErrConfigVersionMismatch is returned when the db config document doesn't match the requested version
+	ErrConfigVersionMismatch = &sgError{"Config version mismatch"}
+
+	// ErrConfigRegistryRollback is returned when a db config fetch triggered a registry rollback based on version mismatch (config is older)
+	ErrConfigRegistryRollback = &sgError{"Config registry rollback"}
+
+	// ErrConfigRegistryReloadRequired is returned when a db config fetch requires a registry reload based on version mismatch (config is newer)
+	ErrConfigRegistryReloadRequired = &sgError{"Config registry reload required"}
 )
 
 func (e *sgError) Error() string {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -114,11 +114,15 @@ func (h *handler) handleCreateDB() error {
 		}
 
 		// now we've started the db successfully, we can persist it to the cluster
-		cas, err := h.server.BootstrapContext.Connection.InsertConfig(bucket, h.server.Config.Bootstrap.ConfigGroupID, persistedConfig)
+		cas, err := h.server.BootstrapContext.InsertConfig(contextNoCancel.Ctx, bucket, h.server.Config.Bootstrap.ConfigGroupID, &persistedConfig)
 		if err != nil {
 			// unload the requested database config to prevent the cluster being in an inconsistent state
 			h.server._removeDatabase(contextNoCancel.Ctx, dbName)
-			if errors.Is(err, base.ErrAuthError) {
+			var httpError *base.HTTPError
+			if errors.As(err, &httpError) {
+				// Collection conflict returned as http error with conflict details
+				return err
+			} else if errors.Is(err, base.ErrAuthError) {
 				return base.HTTPErrorf(http.StatusForbidden, "auth failure accessing provided bucket using bootstrap credentials: %s", bucket)
 			} else if errors.Is(err, base.ErrAlreadyExists) {
 				// on-demand config load if someone else beat us to db creation
@@ -530,68 +534,56 @@ func (h *handler) handlePutDbConfig() (err error) {
 	}
 
 	var updatedDbConfig *DatabaseConfig
-	cas, err := h.server.BootstrapContext.Connection.UpdateConfig(
-		bucket, h.server.Config.Bootstrap.ConfigGroupID,
-		func(rawBucketConfig []byte, rawBucketConfigCas uint64) (newConfig []byte, err error) {
-			var bucketDbConfig DatabaseConfig
-			if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {
+	cas, err := h.server.BootstrapContext.UpdateConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, dbConfig.Name, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+		if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
+			return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
+		}
+		oldBucketDbConfig := bucketDbConfig.DbConfig
+
+		if h.rq.Method == http.MethodPost {
+			base.TracefCtx(h.ctx(), base.KeyConfig, "merging upserted config into bucket config")
+			if err := base.ConfigMerge(&bucketDbConfig.DbConfig, dbConfig); err != nil {
 				return nil, err
 			}
+		} else {
+			base.TracefCtx(h.ctx(), base.KeyConfig, "using config as-is without merge")
+			bucketDbConfig.DbConfig = *dbConfig
+		}
 
-			if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
-				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
-			}
+		if err := dbConfig.validatePersistentDbConfig(); err != nil {
+			return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
+		}
+		if err := bucketDbConfig.validateConfigUpdate(h.ctx(), oldBucketDbConfig, validateOIDC); err != nil {
+			return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
+		}
 
-			bucketDbConfig.cfgCas = rawBucketConfigCas
+		bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
+		if err != nil {
+			return nil, err
+		}
 
-			oldBucketDbConfig := bucketDbConfig.DbConfig
+		bucketDbConfig.SGVersion = base.ProductVersion.String()
+		updatedDbConfig = bucketDbConfig
 
-			if h.rq.Method == http.MethodPost {
-				base.TracefCtx(h.ctx(), base.KeyConfig, "merging upserted config into bucket config")
-				if err := base.ConfigMerge(&bucketDbConfig.DbConfig, dbConfig); err != nil {
-					return nil, err
-				}
-			} else {
-				base.TracefCtx(h.ctx(), base.KeyConfig, "using config as-is without merge")
-				bucketDbConfig.DbConfig = *dbConfig
-			}
+		// take a copy to stamp credentials and load before we persist
+		var tmpConfig DatabaseConfig
+		if err = base.DeepCopyInefficient(&tmpConfig, bucketDbConfig); err != nil {
+			return nil, err
+		}
+		tmpConfig.cfgCas = bucketDbConfig.cfgCas
+		dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
+		bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
+		if err := tmpConfig.setup(dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
+			return nil, err
+		}
 
-			if err := dbConfig.validatePersistentDbConfig(); err != nil {
-				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
-			}
-			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), oldBucketDbConfig, validateOIDC); err != nil {
-				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
-			}
-
-			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
-			if err != nil {
-				return nil, err
-			}
-
-			bucketDbConfig.SGVersion = base.ProductVersion.String()
-
-			updatedDbConfig = &bucketDbConfig
-
-			// take a copy to stamp credentials and load before we persist
-			var tmpConfig DatabaseConfig
-			if err = base.DeepCopyInefficient(&tmpConfig, bucketDbConfig); err != nil {
-				return nil, err
-			}
-			tmpConfig.cfgCas = rawBucketConfigCas
-			dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
-			bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
-			if err := tmpConfig.setup(dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
-				return nil, err
-			}
-
-			// Load the new dbConfig before we persist the update.
-			err = h.server.ReloadDatabaseWithConfig(contextNoCancel, tmpConfig)
-			if err != nil {
-				return nil, err
-			}
-
-			return base.JSONMarshal(bucketDbConfig)
-		})
+		// Load the new dbConfig before we persist the update.
+		err = h.server.ReloadDatabaseWithConfig(contextNoCancel, tmpConfig)
+		if err != nil {
+			return nil, err
+		}
+		return bucketDbConfig, nil
+	})
 	if err != nil {
 		base.WarnfCtx(h.ctx(), "Couldn't update config for database - rolling back: %v", err)
 		// failed to start the new database config - rollback and return the original error for the user
@@ -658,37 +650,29 @@ func (h *handler) handleDeleteCollectionConfigSync() error {
 	}
 
 	bucket := h.db.Bucket.GetName()
-
 	var updatedDbConfig *DatabaseConfig
-	cas, err := h.server.BootstrapContext.Connection.UpdateConfig(
-		bucket, h.server.Config.Bootstrap.ConfigGroupID,
-		func(rawBucketConfig []byte, rawBucketConfigCas uint64) (newConfig []byte, err error) {
-			var bucketDbConfig DatabaseConfig
-			if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {
-				return nil, err
-			}
+	cas, err := h.server.BootstrapContext.UpdateConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, h.db.Name, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+		if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
+			return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
+		}
+		if bucketDbConfig.Scopes != nil {
+			config := bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name]
+			config.SyncFn = nil
+			bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name] = config
+		} else if base.IsDefaultCollection(h.collection.ScopeName, h.collection.Name) {
+			bucketDbConfig.Sync = nil
+		}
 
-			if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
-				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
-			}
-			if bucketDbConfig.Scopes != nil {
-				config := bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name]
-				config.SyncFn = nil
-				bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name] = config
-			} else if base.IsDefaultCollection(h.collection.ScopeName, h.collection.Name) {
-				bucketDbConfig.Sync = nil
-			}
+		bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
+		if err != nil {
+			return nil, err
+		}
 
-			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
-			if err != nil {
-				return nil, err
-			}
+		bucketDbConfig.SGVersion = base.ProductVersion.String()
+		updatedDbConfig = bucketDbConfig
 
-			bucketDbConfig.SGVersion = base.ProductVersion.String()
-
-			updatedDbConfig = &bucketDbConfig
-			return base.JSONMarshal(bucketDbConfig)
-		})
+		return bucketDbConfig, nil
+	})
 	if err != nil {
 		return err
 	}
@@ -725,48 +709,40 @@ func (h *handler) handlePutCollectionConfigSync() error {
 	}
 
 	bucket := h.db.Bucket.GetName()
+	dbName := h.db.Name
 
 	var updatedDbConfig *DatabaseConfig
-	cas, err := h.server.BootstrapContext.Connection.UpdateConfig(
-		bucket, h.server.Config.Bootstrap.ConfigGroupID,
-		func(rawBucketConfig []byte, rawBucketConfigCas uint64) (newConfig []byte, err error) {
-			var bucketDbConfig DatabaseConfig
-			if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {
-				return nil, err
-			}
+	cas, err := h.server.BootstrapContext.UpdateConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+		if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
+			return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
+		}
 
-			if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
-				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
-			}
+		if bucketDbConfig.Scopes != nil {
+			config := bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name]
+			config.SyncFn = &js
+			bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name] = config
+		} else if base.IsDefaultCollection(h.collection.ScopeName, h.collection.Name) {
+			bucketDbConfig.Sync = &js
+		}
 
-			if bucketDbConfig.Scopes != nil {
-				config := bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name]
-				config.SyncFn = &js
-				bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name] = config
-			} else if base.IsDefaultCollection(h.collection.ScopeName, h.collection.Name) {
-				bucketDbConfig.Sync = &js
-			}
+		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
+			return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
+		}
 
-			if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
-				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
-			}
+		bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
+		if err != nil {
+			return nil, err
+		}
 
-			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
-			if err != nil {
-				return nil, err
-			}
-
-			bucketDbConfig.SGVersion = base.ProductVersion.String()
-
-			updatedDbConfig = &bucketDbConfig
-			return base.JSONMarshal(bucketDbConfig)
-		})
+		bucketDbConfig.SGVersion = base.ProductVersion.String()
+		updatedDbConfig = bucketDbConfig
+		return bucketDbConfig, nil
+	})
 	if err != nil {
 		return err
 	}
 	updatedDbConfig.cfgCas = cas
 
-	dbName := h.db.Name
 	dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
 	bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
 	if err := updatedDbConfig.setup(dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
@@ -831,44 +807,37 @@ func (h *handler) handleDeleteCollectionConfigImportFilter() error {
 	}
 
 	bucket := h.db.Bucket.GetName()
+	dbName := h.db.Name
 
 	var updatedDbConfig *DatabaseConfig
-	cas, err := h.server.BootstrapContext.Connection.UpdateConfig(
-		bucket, h.server.Config.Bootstrap.ConfigGroupID,
-		func(rawBucketConfig []byte, rawBucketConfigCas uint64) (newConfig []byte, err error) {
-			var bucketDbConfig DatabaseConfig
-			if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {
-				return nil, err
-			}
+	cas, err := h.server.BootstrapContext.UpdateConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
 
-			if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
-				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
-			}
+		if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
+			return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
+		}
 
-			if bucketDbConfig.Scopes != nil {
-				config := bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name]
-				config.ImportFilter = nil
-				bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name] = config
-			} else if base.IsDefaultCollection(h.collection.ScopeName, h.collection.Name) {
-				bucketDbConfig.ImportFilter = nil
-			}
+		if bucketDbConfig.Scopes != nil {
+			config := bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name]
+			config.ImportFilter = nil
+			bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name] = config
+		} else if base.IsDefaultCollection(h.collection.ScopeName, h.collection.Name) {
+			bucketDbConfig.ImportFilter = nil
+		}
 
-			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
-			if err != nil {
-				return nil, err
-			}
+		bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
+		if err != nil {
+			return nil, err
+		}
 
-			bucketDbConfig.SGVersion = base.ProductVersion.String()
-
-			updatedDbConfig = &bucketDbConfig
-			return base.JSONMarshal(bucketDbConfig)
-		})
+		bucketDbConfig.SGVersion = base.ProductVersion.String()
+		updatedDbConfig = bucketDbConfig
+		return bucketDbConfig, nil
+	})
 	if err != nil {
 		return err
 	}
 	updatedDbConfig.cfgCas = cas
 
-	dbName := h.db.Name
 	dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
 	bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
 	if err := updatedDbConfig.setup(dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
@@ -899,48 +868,41 @@ func (h *handler) handlePutCollectionConfigImportFilter() error {
 		return err
 	}
 	bucket := h.db.Bucket.GetName()
+	dbName := h.db.Name
 
 	var updatedDbConfig *DatabaseConfig
-	cas, err := h.server.BootstrapContext.Connection.UpdateConfig(
-		bucket, h.server.Config.Bootstrap.ConfigGroupID,
-		func(rawBucketConfig []byte, rawBucketConfigCas uint64) (newConfig []byte, err error) {
-			var bucketDbConfig DatabaseConfig
-			if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {
-				return nil, err
-			}
+	cas, err := h.server.BootstrapContext.UpdateConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
 
-			if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
-				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
-			}
+		if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
+			return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
+		}
 
-			if bucketDbConfig.Scopes != nil {
-				config := bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name]
-				config.ImportFilter = &js
-				bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name] = config
-			} else if base.IsDefaultCollection(h.collection.ScopeName, h.collection.Name) {
-				bucketDbConfig.ImportFilter = &js
-			}
+		if bucketDbConfig.Scopes != nil {
+			config := bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name]
+			config.ImportFilter = &js
+			bucketDbConfig.Scopes[h.collection.ScopeName].Collections[h.collection.Name] = config
+		} else if base.IsDefaultCollection(h.collection.ScopeName, h.collection.Name) {
+			bucketDbConfig.ImportFilter = &js
+		}
 
-			if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
-				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
-			}
+		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
+			return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
+		}
 
-			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
-			if err != nil {
-				return nil, err
-			}
+		bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
+		if err != nil {
+			return nil, err
+		}
 
-			bucketDbConfig.SGVersion = base.ProductVersion.String()
-
-			updatedDbConfig = &bucketDbConfig
-			return base.JSONMarshal(bucketDbConfig)
-		})
+		bucketDbConfig.SGVersion = base.ProductVersion.String()
+		updatedDbConfig = bucketDbConfig
+		return bucketDbConfig, nil
+	})
 	if err != nil {
 		return err
 	}
 	updatedDbConfig.cfgCas = cas
 
-	dbName := h.db.Name
 	dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
 	bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
 	if err := updatedDbConfig.setup(dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
@@ -968,9 +930,7 @@ func (h *handler) handleDeleteDB() error {
 
 	if h.server.persistentConfig {
 		bucket, _ = h.server.bucketNameFromDbName(dbName)
-		_, err := h.server.BootstrapContext.Connection.UpdateConfig(bucket, h.server.Config.Bootstrap.ConfigGroupID, func(rawBucketConfig []byte, rawBucketConfigCas uint64) (updatedConfig []byte, err error) {
-			return nil, nil
-		})
+		err := h.server.BootstrapContext.DeleteConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName)
 		if err != nil {
 			return base.HTTPErrorf(http.StatusInternalServerError, "couldn't remove database %q from bucket %q: %s", base.MD(dbName), base.MD(bucket), err.Error())
 		}

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -3546,13 +3546,14 @@ func TestDbConfigPersistentSGVersions(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer func() { tb.Close() }()
 
+	dbName := "db"
 	dbConfig := rest.DatabaseConfig{
 		SGVersion: "", // leave empty to emulate what 3.0.0 would've written to the bucket
 		DbConfig: rest.DbConfig{
 			BucketConfig: rest.BucketConfig{
 				Bucket: base.StringPtr(tb.GetName()),
 			},
-			Name:             "db",
+			Name:             dbName,
 			EnableXattrs:     base.BoolPtr(base.TestUseXattrs()),
 			UseViews:         base.BoolPtr(base.TestsDisableGSI()),
 			NumIndexReplicas: base.UintPtr(0),
@@ -3568,7 +3569,7 @@ func TestDbConfigPersistentSGVersions(t *testing.T) {
 
 	assertRevsLimit := func(sc *rest.ServerContext, revsLimit uint32) {
 		rest.WaitAndAssertCondition(t, func() bool {
-			dbc, err := sc.GetDatabase(ctx, "db")
+			dbc, err := sc.GetDatabase(ctx, dbName)
 			if err != nil {
 				t.Logf("expected database with RevsLimit=%v but got err=%v", revsLimit, err)
 				return false
@@ -3584,7 +3585,7 @@ func TestDbConfigPersistentSGVersions(t *testing.T) {
 	assertRevsLimit(sc, 123)
 
 	writeRevsLimitConfigWithVersion := func(sc *rest.ServerContext, version string, revsLimit uint32) error {
-		_, err = sc.BootstrapContext.UpdateConfig(base.TestCtx(t), tb.GetName(), t.Name(), "db", func(db *rest.DatabaseConfig) (updatedConfig *rest.DatabaseConfig, err error) {
+		_, err = sc.BootstrapContext.UpdateConfig(base.TestCtx(t), tb.GetName(), t.Name(), dbName, func(db *rest.DatabaseConfig) (updatedConfig *rest.DatabaseConfig, err error) {
 
 			db.SGVersion = version
 			db.DbConfig.RevsLimit = base.Uint32Ptr(revsLimit)

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -3584,7 +3584,7 @@ func TestDbConfigPersistentSGVersions(t *testing.T) {
 	assertRevsLimit(sc, 123)
 
 	writeRevsLimitConfigWithVersion := func(sc *rest.ServerContext, version string, revsLimit uint32) error {
-		_, err = sc.BootstrapContext.UpdateConfig(base.TestCtx(t), tb.GetName(), "db", t.Name(), func(db *rest.DatabaseConfig) (updatedConfig *rest.DatabaseConfig, err error) {
+		_, err = sc.BootstrapContext.UpdateConfig(base.TestCtx(t), tb.GetName(), t.Name(), "db", func(db *rest.DatabaseConfig) (updatedConfig *rest.DatabaseConfig, err error) {
 
 			db.SGVersion = version
 			db.DbConfig.RevsLimit = base.Uint32Ptr(revsLimit)

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -138,8 +138,8 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	resp.RequireResponse(http.StatusOK, `{"_id":"doc1","_rev":"1-cd809becc169215072fd567eebd8b8de","foo":"bar"}`)
 }
 
-// TestBootstrapDuplicateBucket will attempt to create two databases sharing the same bucket and ensure this isn't allowed.
-func TestBootstrapDuplicateBucket(t *testing.T) {
+// TestBootstrapDuplicateBucket will attempt to create two databases sharing the same collections and ensure this isn't allowed.
+func TestBootstrapDuplicateCollections(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Bootstrap works with Couchbase Server only")
 	}
@@ -175,7 +175,7 @@ func TestBootstrapDuplicateBucket(t *testing.T) {
 	)
 	resp.RequireStatus(http.StatusCreated)
 
-	// Create db2 using the same bucket and expect it to fail
+	// Create db2 using the same collection (on the same bucket) and expect it to fail
 	resp = BootstrapAdminRequest(t, http.MethodPut, "/db2/",
 		fmt.Sprintf(
 			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,
@@ -183,10 +183,6 @@ func TestBootstrapDuplicateBucket(t *testing.T) {
 		),
 	)
 	resp.RequireStatus(http.StatusConflict)
-
-	// CBG-1785 - Check the error has been changed from the original misleading error to a more informative one.
-	assert.NotContains(t, resp.Body, fmt.Sprintf(`Database \"%s\" already exists`, "db2"))
-	assert.Contains(t, resp.Body, fmt.Sprintf(`Bucket \"%s\" already in use by database \"%s\"`, tb.GetName(), "db1"))
 }
 
 // TestBootstrapDuplicateDatabase will attempt to create a second database and ensure this isn't allowed.

--- a/rest/config.go
+++ b/rest/config.go
@@ -1318,10 +1318,6 @@ func (sc *ServerContext) fetchAndLoadConfigs(ctx context.Context, isInitialStart
 		}
 	}
 
-	base.InfofCtx(ctx, base.KeyAll, "calling applyConfigs")
-	defer func() {
-		base.InfofCtx(ctx, base.KeyAll, "finished calling applyConfigs")
-	}()
 	return sc._applyConfigs(ctx, fetchedConfigs, isInitialStartup), nil
 }
 
@@ -1372,6 +1368,7 @@ func (sc *ServerContext) migrateV30Configs(ctx context.Context) error {
 			return fmt.Errorf("Error retrieving 3.0 config for bucket: %s, groupID: %s: %w", bucketName, groupID, err)
 		}
 
+		base.InfofCtx(ctx, base.KeyConfig, "Found legacy persisted config for database %s - migrating to db registry.", base.MD(dbConfig.Name))
 		_, insertErr := sc.BootstrapContext.InsertConfig(ctx, bucketName, groupID, &dbConfig)
 		if insertErr != nil {
 			if insertErr == base.ErrAlreadyExists {

--- a/rest/config.go
+++ b/rest/config.go
@@ -1626,14 +1626,6 @@ func (sc *ServerContext) _applyConfig(nonContextStruct base.NonCancellableContex
 		}
 	}
 
-	// ensure we're not loading a database from multiple buckets
-	if dbc := sc.databases_[cnf.Name]; dbc != nil {
-		runningBucket := dbc.Bucket.GetName()
-		if runningBucket != *cnf.Bucket {
-			return false, fmt.Errorf("database %q bucket %q cannot be added - already running %q using bucket %q", cnf.Name, *cnf.Bucket, cnf.Name, runningBucket)
-		}
-	}
-
 	// Strip out version as we have no use for this locally and we want to prevent it being stored and being returned
 	// by any output
 	cnf.Version = ""

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -333,8 +333,11 @@ func TestLegacyGuestUserMigration(t *testing.T) {
 	cluster, err := CreateCouchbaseClusterFromStartupConfig(sc, base.PerUseClusterConnections)
 	require.NoError(t, err)
 
-	var dbConfig DbConfig
-	_, err = cluster.GetMetadataDocument(tb.GetName(), PersistentConfigDefaultGroupID, &dbConfig)
+	bootstrap := bootstrapContext{
+		Connection: cluster,
+	}
+	var dbConfig DatabaseConfig
+	_, err = bootstrap.GetConfig(tb.GetName(), PersistentConfigDefaultGroupID, "db", &dbConfig)
 	require.NoError(t, err)
 
 	assert.Equal(t, &expected, dbConfig.Guest)

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -334,7 +334,7 @@ func TestLegacyGuestUserMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	var dbConfig DbConfig
-	_, err = cluster.GetConfig(tb.GetName(), PersistentConfigDefaultGroupID, &dbConfig)
+	_, err = cluster.GetMetadataDocument(tb.GetName(), PersistentConfigDefaultGroupID, &dbConfig)
 	require.NoError(t, err)
 
 	assert.Equal(t, &expected, dbConfig.Guest)

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -1,0 +1,609 @@
+package rest
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+)
+
+// ConfigManager should be used for any read/write of persisted database configuration files
+type ConfigManager interface {
+	// GetConfig fetches a database config for a given bucket and config group ID, along with the CAS of the config document. Does not enforce version match with registry.
+	GetConfig(bucket, groupID, dbName string, config *DatabaseConfig) (cas uint64, err error)
+	// GetDatabaseConfigs returns all configs for the bucket and config group.  Enforces version match with registry.
+	GetDatabaseConfigs(ctx context.Context, bucketName, groupID string) ([]*DatabaseConfig, error)
+	// InsertConfig saves a new database config for a given bucket and config group ID.
+	InsertConfig(ctx context.Context, bucket, groupID string, config *DatabaseConfig) (newCAS uint64, err error)
+	// UpdateConfig updates an existing database config for a given bucket and config group ID. updateCallback can return nil to remove the config.
+	UpdateConfig(ctx context.Context, bucket, groupID, dbName string, updateCallback func(bucketConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error)) (newCAS uint64, err error)
+	// DeleteConfig removes a database config for a given bucket, config group ID and database name.
+	DeleteConfig(ctx context.Context, bucket, dbName, groupID string) (err error)
+}
+
+type dbConfigNameOnly struct {
+	Name string `json:"name"`
+}
+
+var _ ConfigManager = &bootstrapContext{}
+
+const configUpdateMaxRetryAttempts = 5 // Maximum number of retries due to conflicting updates or rollback
+const configFetchMaxRetryAttempts = 5  // Maximum number of retries due to registry rollback
+
+// GetConfig fetches a database name for a given bucket and config group ID.
+func (b *bootstrapContext) GetConfigName(bucketName, groupID, dbName string, configName *dbConfigNameOnly) (cas uint64, err error) {
+	return b.Connection.GetMetadataDocument(bucketName, PersistentConfigKey(groupID, dbName), configName)
+}
+
+// GetConfig fetches a database config for a given bucket and config group ID, along with the CAS of the config document.
+// GetConfig does *not* validate that config version matches registry version - operations requiring synchronization
+// with registry should use getRegistryAndDatabase, or getConfig with the required version
+func (b *bootstrapContext) GetConfig(bucketName, groupID, dbName string, config *DatabaseConfig) (cas uint64, err error) {
+	return b.Connection.GetMetadataDocument(bucketName, PersistentConfigKey(groupID, dbName), config)
+}
+
+// InsertConfig saves a new database config for a given bucket and config group ID. This is a three-step process:
+//  1. getRegistryAndDatabase to enforce synchronization pre-update
+//  2. Update the registry to add the config
+//  3. Write the config
+func (b *bootstrapContext) InsertConfig(ctx context.Context, bucketName, groupID string, config *DatabaseConfig) (newCAS uint64, err error) {
+	dbName := config.Name
+	attempts := 0
+	for attempts < configUpdateMaxRetryAttempts {
+		attempts++
+
+		// Step 1. Fetch registry and databases - enforces registry/config synchronization
+		registry, existingConfig, err := b.getRegistryAndDatabase(ctx, bucketName, groupID, dbName)
+		if err != nil {
+			return 0, err
+		}
+		if existingConfig != nil {
+			return 0, base.ErrAlreadyExists
+		}
+
+		// Step 1. Update the registry to add the config
+		// Add database to registry
+		previousVersionConflicts, upsertErr := registry.upsertDatabaseConfig(ctx, groupID, config)
+		if upsertErr != nil {
+			return 0, upsertErr
+		}
+
+		// If there are conflicts with previous versions of in-progress database updates, wait for those to complete
+		if len(previousVersionConflicts) > 0 {
+			err := b.WaitForConflictingUpdates(ctx, bucketName, previousVersionConflicts)
+			if err != nil {
+				return 0, err
+			}
+			continue
+		}
+
+		// Persist registry
+		writeErr := b.setGatewayRegistry(bucketName, registry)
+		if writeErr == nil {
+			break
+		}
+		// retry on cas mismatch, otherwise return error
+		if !base.IsCasMismatch(writeErr) {
+			return 0, writeErr
+		}
+
+		// Check for context cancel before retrying
+		select {
+		case <-ctx.Done():
+			return 0, fmt.Errorf("Exiting InsertConfig - context cancelled")
+		default:
+		}
+	}
+	// Step 3. Write the database config
+	return b.Connection.InsertMetadataDocument(bucketName, PersistentConfigKey(groupID, dbName), config)
+}
+
+// UpdateConfig updates an existing database config for a given bucket and config group ID. This is a four-step process:
+//  1. getRegistryAndDatabase to enforce synchronization pre-update
+//  2. Update the registry to update the database definition including previous version (to support recovery in case step 2 fails)
+//  3. Update the config
+//  4. Update the registry to remove the previous version
+func (b *bootstrapContext) UpdateConfig(ctx context.Context, bucketName, groupID, dbName string, updateCallback func(bucketConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error)) (newCAS uint64, err error) {
+	var updatedConfig *DatabaseConfig
+	var registry *GatewayRegistry
+	var previousVersion string
+	attempts := 0
+	for attempts < configUpdateMaxRetryAttempts {
+		attempts++
+		// Step 1. Fetch registry and databases - enforces registry/config synchronization
+		var existingConfig *DatabaseConfig
+		registry, existingConfig, err = b.getRegistryAndDatabase(ctx, bucketName, groupID, dbName)
+		if err != nil {
+			return 0, err
+		}
+		if existingConfig == nil {
+			return 0, base.ErrNotFound
+		}
+
+		// Step 2. Update registry to update registry entry, and move previous registry entry to PreviousVersion
+		previousVersion = existingConfig.Version
+		var callbackErr error
+		updatedConfig, callbackErr = updateCallback(existingConfig)
+		if callbackErr != nil {
+			return 0, callbackErr
+		}
+
+		// Update database in registry
+		previousVersionConflicts, err := registry.upsertDatabaseConfig(ctx, groupID, updatedConfig)
+		if err != nil {
+			return 0, err
+		}
+
+		// If there are conflicts with previous versions of in-progress database updates, wait for those to complete
+		if len(previousVersionConflicts) > 0 {
+			err := b.WaitForConflictingUpdates(ctx, bucketName, previousVersionConflicts)
+			if err != nil {
+				return 0, err
+			}
+			continue
+		}
+
+		// Persist registry
+		writeErr := b.setGatewayRegistry(bucketName, registry)
+		if writeErr == nil {
+			break
+		}
+		// retry on cas mismatch, otherwise return error
+		if !base.IsCasMismatch(writeErr) {
+			return 0, writeErr
+		}
+
+		// Check for context cancel before retrying
+		select {
+		case <-ctx.Done():
+			break
+		default:
+		}
+	}
+
+	// Step 2. Update the config document
+	casOut, err := b.Connection.WriteMetadataDocument(bucketName, PersistentConfigKey(groupID, dbName), updatedConfig.cfgCas, updatedConfig)
+	if err != nil {
+		return 0, err
+	}
+
+	// Step 3. After config is successfully updated, finalize the update by removing the previous version from the registry
+	err = registry.removePreviousVersion(groupID, dbName, previousVersion)
+	if err != nil {
+		return 0, fmt.Errorf("Error removing previous version of config group: %s, database: %s from registry after successful update: %w", base.MD(groupID), base.MD(dbName), err)
+	}
+	writeErr := b.setGatewayRegistry(bucketName, registry)
+	if writeErr != nil {
+		return 0, fmt.Errorf("Error persisting removal of previous version of config group: %s, database: %s from registry after successful update: %w", base.MD(groupID), base.MD(dbName), writeErr)
+	}
+
+	return casOut, nil
+}
+
+// DeleteConfig deletes a database config
+//  1. getRegistryAndDatabase to enforce synchronization pre-update
+//  2. Update the registry to delete the database definition and store the previous version (to support recovery in case step 2 fails)
+//  3. Delete the config document
+//  4. Update the registry to remove the database definition altogether
+func (b *bootstrapContext) DeleteConfig(ctx context.Context, bucketName, groupID, dbName string) (err error) {
+	var existingCas uint64
+	var registry *GatewayRegistry
+	attempts := 0
+	for attempts < configUpdateMaxRetryAttempts {
+		attempts++
+		var existingConfig *DatabaseConfig
+		// Step 1. Fetch registry and databases - enforces registry/config synchronization
+		registry, existingConfig, err = b.getRegistryAndDatabase(ctx, bucketName, groupID, dbName)
+		if err != nil {
+			return err
+		}
+		if existingConfig == nil {
+			return base.ErrNotFound
+		}
+		existingCas = existingConfig.cfgCas
+
+		// Step 2. Update registry, mark database deleted in registry
+		err = registry.deleteDatabase(groupID, dbName)
+		if err != nil {
+			return err
+		}
+
+		// Persist registry
+		writeErr := b.setGatewayRegistry(bucketName, registry)
+		if writeErr == nil {
+			break
+		}
+		// retry on cas mismatch, otherwise return error
+		if !base.IsCasMismatch(writeErr) {
+			return writeErr
+		}
+
+		// Check for context cancel before retrying
+		select {
+		case <-ctx.Done():
+			break
+		default:
+		}
+	}
+
+	err = b.Connection.DeleteMetadataDocument(bucketName, PersistentConfigKey(groupID, dbName), existingCas)
+	if err != nil {
+		return err
+	}
+	// Step 3. After config is successfully deleted, finalize the delete by removing the previous version from the registry
+	found := registry.removeDatabase(groupID, dbName)
+	if !found {
+		base.InfofCtx(ctx, base.KeyConfig, "Database not found in registry during finalization for config group:%s, database: %s", base.MD(groupID), base.MD(dbName))
+	} else {
+		writeErr := b.setGatewayRegistry(bucketName, registry)
+		if writeErr != nil {
+			return fmt.Errorf("Error persisting removal of previous version of config group: %s, database: %s from registry after successful delete: %w", base.MD(groupID), base.MD(dbName), writeErr)
+		}
+	}
+
+	return nil
+
+}
+
+// WaitForConflictingUpdates is called when an upsert is in conflict with previous versions found in the registry.  Previous
+// versions indicate an in-progress update - WaitForConflictingUpdates uses getRegistryAndDatabase to wait for these
+// updates to either successfully complete or be rolled back.
+func (b *bootstrapContext) WaitForConflictingUpdates(ctx context.Context, bucketName string, databases []configGroupAndDatabase) error {
+	for _, db := range databases {
+		_, _, err := b.getRegistryAndDatabase(ctx, bucketName, db.configGroup, db.databaseName)
+		if err != nil {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("Exiting WaitForConflictingUpdates - context cancelled")
+		default:
+		}
+	}
+	return nil
+}
+
+// GetConfigsForConfigGroup returns all configs for the bucket and config group.
+func (b *bootstrapContext) GetDatabaseConfigs(ctx context.Context, bucketName, groupID string) ([]*DatabaseConfig, error) {
+
+	attempts := 0
+	for attempts < configFetchMaxRetryAttempts {
+		attempts++
+
+		registry, err := b.getGatewayRegistry(ctx, bucketName)
+		if err != nil {
+			return nil, err
+		}
+		configGroup, ok := registry.ConfigGroups[groupID]
+		if !ok {
+			// no configs defined for this config group
+			return nil, nil
+		}
+
+		dbConfigs := make([]*DatabaseConfig, 0)
+		for dbName, registryDb := range configGroup.Databases {
+			// Ignore databases with empty version - represents an in-progress delete
+			if registryDb.Version == "" {
+				continue
+			}
+			dbConfig, err := b.getDatabaseConfig(ctx, bucketName, groupID, dbName, registryDb.Version, registry)
+			if err == base.ErrConfigRegistryReloadRequired {
+				break
+			} else if err != nil {
+				return nil, err
+			}
+			dbConfigs = append(dbConfigs, dbConfig)
+		}
+		// Retry on ErrConfigRegistryReloadRequired until reaching attempts limit
+		if err == base.ErrConfigRegistryReloadRequired {
+			continue
+		}
+		return dbConfigs, err
+	}
+	base.WarnfCtx(ctx, "Unable to successfully retrieve GetDatabaseConfigs for groupID: %s after %d attempts", base.MD(groupID), attempts)
+	return nil, base.ErrConfigRegistryReloadRequired
+}
+
+// getConfigVersionWithRetry attempts to retrieve the specified config file.
+// On file not found, will perform backoff retry up to specified timeout.  On timeout, returns the nil and rollback error.
+// On mismatched version when registry version is newer, will perform backoff retry up to timeout.  On timeout, returns the config and rollback error.
+// On mismatched version when config version is newer, returns the config and ErrConfigVersionMismatch.
+func (b *bootstrapContext) getConfigVersionWithRetry(ctx context.Context, bucketName, groupID, dbName, version string) (*DatabaseConfig, error) {
+
+	timeout := defaultConfigRetryTimeout
+	if b.configRetryTimeout != 0 {
+		timeout = b.configRetryTimeout
+	}
+
+	retryWorker := func() (shouldRetry bool, err error, value interface{}) {
+		config := &DatabaseConfig{}
+		cas, err := b.Connection.GetMetadataDocument(bucketName, PersistentConfigKey(groupID, dbName), config)
+		if err == base.ErrNotFound {
+			return true, base.ErrConfigRegistryRollback, nil
+		}
+		if err != nil {
+			return false, err, nil
+		}
+
+		config.cfgCas = cas
+		// If version matches, success!
+		if config.Version == version {
+			return false, nil, config
+		}
+
+		// For version mismatch, handling depends on whether config has newer or older version than requested
+		requestedGen, _ := db.ParseRevID(version)
+		currentGen, _ := db.ParseRevID(config.Version)
+		if currentGen > requestedGen {
+			// If the config has a newer version than requested, return the config but alert caller that they have
+			// requested a stale version.
+			return false, base.ErrConfigVersionMismatch, config
+		} else {
+			return true, base.ErrConfigRegistryRollback, config
+		}
+	}
+
+	// Kick off the retry loop
+	err, retryResult := base.RetryLoop(
+		"Wait for config version match",
+		retryWorker,
+		base.CreateDoublingSleeperDurationFunc(50, timeout),
+	)
+
+	// Return the config with rollback error, to support rollback by the caller if appropriate
+	if err != nil && err != base.ErrConfigRegistryRollback {
+		return nil, err
+	}
+
+	if retryResult != nil {
+		config, ok := retryResult.(*DatabaseConfig)
+		if !ok {
+			return nil, fmt.Errorf("Unable to convert returned config of type %T to *DatabaseConfig", retryResult)
+		}
+		return config, err
+	}
+
+	return nil, err
+}
+
+// getDatabaseConfig retrieves the database config, and enforces version match.  On config not found or mismatched
+// version, will retry with backoff (to wait for in-flight updates to complete).  After retry timeout,
+// triggers registry rollback and returns rollback error
+func (b *bootstrapContext) getDatabaseConfig(ctx context.Context, bucketName, groupID, dbName string, version string, registry *GatewayRegistry) (*DatabaseConfig, error) {
+	config, err := b.getConfigVersionWithRetry(ctx, bucketName, groupID, dbName, version)
+	if err != nil {
+		if err == base.ErrConfigRegistryRollback {
+			rollbackErr := b.rollbackRegistry(ctx, bucketName, groupID, dbName, config, registry)
+			// On successful registry rollback, caller needs reload registry
+			if rollbackErr == nil {
+				return nil, base.ErrConfigRegistryReloadRequired
+			}
+			// On unsuccessful rollback due to CAS failure, caller also needs to reload registry
+			if base.IsCasMismatch(rollbackErr) {
+				return nil, base.ErrConfigRegistryReloadRequired
+			}
+			return nil, rollbackErr
+		}
+		return nil, err
+	}
+	return config, nil
+}
+
+// waitForConfigDelete waits for a config file to be deleted.  After retry timeout, returns latest cas
+// and version, will backoff retry (to wait for in-flight updates to complete).  After retry timeout,
+// triggers registry cleanup and returns returns rollback error.
+// If version is not empty, waitForConfigDelete will attempt to remove the previousVersion from the registry
+// on rollback.
+func (b *bootstrapContext) waitForConfigDelete(ctx context.Context, bucketName, groupID, dbName string, version string, registry *GatewayRegistry) error {
+	timeout := defaultConfigRetryTimeout
+	if b.configRetryTimeout != 0 {
+		timeout = b.configRetryTimeout
+	}
+
+	retryWorker := func() (shouldRetry bool, err error, value interface{}) {
+		config := &DatabaseConfig{}
+		cas, getErr := b.Connection.GetMetadataDocument(bucketName, PersistentConfigKey(groupID, dbName), config)
+		// Success case - delete has been completed
+		if getErr == base.ErrNotFound {
+			return false, nil, nil
+		}
+		// For non-recoverable errors, return the error
+		if getErr != nil {
+			return false, getErr, nil
+		}
+		// On version mismatch, abandon attempts to delete
+		if version != "" && version != config.Version {
+			return false, base.ErrConfigRegistryReloadRequired, nil
+		}
+
+		return true, base.ErrAlreadyExists, cas
+	}
+
+	// Kick off the retry loop
+	err, retryResult := base.RetryLoop(
+		"Wait for config version match",
+		retryWorker,
+		base.CreateDoublingSleeperDurationFunc(50, timeout),
+	)
+
+	// If still exists after retry, re-attempt the delete
+	if err == base.ErrAlreadyExists {
+		existingCas, ok := retryResult.(uint64)
+		if !ok {
+			return fmt.Errorf("Unable to convert returned cas of type %T to uint64", retryResult)
+		}
+
+		err = b.Connection.DeleteMetadataDocument(bucketName, PersistentConfigKey(groupID, dbName), existingCas)
+		if err != nil {
+			return err
+		}
+		// delete successful, call rollback to remove entry from registry
+		if version != "" {
+			rollbackErr := b.rollbackRegistry(ctx, bucketName, groupID, dbName, nil, registry)
+			if rollbackErr != nil {
+				return rollbackErr
+			}
+		}
+
+		return base.ErrConfigRegistryRollback
+	}
+	return err
+}
+
+// rollbackRegistry updates the registry entry to match the provided config
+func (b *bootstrapContext) rollbackRegistry(ctx context.Context, bucketName, groupID, dbName string, config *DatabaseConfig, registry *GatewayRegistry) error {
+
+	if config == nil {
+		// nil config indicates dbName should be removed from registry
+		base.InfofCtx(ctx, base.KeyConfig, "Rolling back config registry to remove db %s - config does not exist. bucketName:%s groupID:%s - config has been deleted", base.MD(dbName), base.MD(bucketName), base.MD(groupID))
+		found := registry.removeDatabase(groupID, dbName)
+		if !found {
+			// The registry hasn't been reloaded since we tried to find this config, failing to find it now is unexpected
+			return fmt.Errorf("Attempted to remove database %s (%s) from registry, was not found", base.MD(dbName), base.MD(groupID))
+		}
+	} else {
+		// Mark the database config being rolled back first to update CAS, to ensure a slow writer doesn't succeed while we're rolling back.
+		// Use the database name property for the update, as this is otherwise immutable.
+		casOut, err := b.Connection.TouchMetadataDocument(bucketName, PersistentConfigKey(groupID, dbName), "name", dbName, config.cfgCas)
+		if err != nil {
+			return fmt.Errorf("Rollback cancelled - document has been updated")
+		}
+		config.cfgCas = casOut
+
+		// non-nil config indicates database version in registry should be updated to match config
+		base.InfofCtx(ctx, base.KeyConfig, "Rolling back config registry to align with db config version %s for db: %s, bucket:%s configGroup:%s", config.Version, base.MD(dbName), base.MD(bucketName), base.MD(groupID))
+		registryErr := registry.rollbackDatabaseConfig(ctx, groupID, dbName)
+		if registryErr != nil {
+			// There shouldn't be a case where rollback introduces a collection conflict - it
+			// shouldn't be possible to add a conflicting collection to the registry while a previous
+			// config persistence is in-flight
+			return fmt.Errorf("Unable to roll back registry to match existing config for database %s(%s): %w", base.MD(dbName), base.MD(groupID), registryErr)
+		}
+	}
+
+	// Attempt to persist the registry
+	casOut, err := b.Connection.WriteMetadataDocument(bucketName, base.SGRegistryKey, registry.cas, registry)
+	if err == nil {
+		registry.cas = casOut
+		base.InfofCtx(ctx, base.KeyConfig, "Successful config registry rollback for bucket: %s, configGroup: %s, db: %s", base.MD(bucketName), base.MD(groupID), base.MD(dbName))
+	}
+	return err
+}
+
+// getGatewayRegistry returns the database registry document for the bucket
+func (b *bootstrapContext) getGatewayRegistry(ctx context.Context, bucketName string) (result *GatewayRegistry, err error) {
+
+	registry := &GatewayRegistry{}
+	cas, getErr := b.Connection.GetMetadataDocument(bucketName, base.SGRegistryKey, registry)
+	if getErr != nil {
+		if getErr == base.ErrNotFound {
+			return NewGatewayRegistry(), nil
+		}
+		return nil, getErr
+	}
+	registry.cas = cas
+
+	return registry, nil
+}
+
+// getGatewayRegistry returns the database registry document for the bucket
+func (b *bootstrapContext) setGatewayRegistry(bucketName string, registry *GatewayRegistry) (err error) {
+
+	cas := uint64(0)
+	if registry != nil {
+		cas = registry.cas
+	}
+
+	var casOut uint64
+	var writeErr error
+	if cas == 0 {
+		casOut, writeErr = b.Connection.InsertMetadataDocument(bucketName, base.SGRegistryKey, registry)
+	} else {
+		casOut, writeErr = b.Connection.WriteMetadataDocument(bucketName, base.SGRegistryKey, cas, registry)
+	}
+
+	if writeErr != nil {
+		return writeErr
+	}
+	registry.cas = casOut
+	return nil
+}
+
+// getRegistryAndDatabase retrieves both the gateway registry and database config for the specified dbName and groupID.
+// If registry is not found, returns ErrNotFound
+// If registry exists but database is not found, returns err=nil and config=nil
+//
+// This function manages synchronization between the registry and config by only returning successfully when the database
+// versions align.  If the versions do not match, it will retry up to the maxRegistryRetryInterval.  If the maxInterval is
+// reached, it triggers rollback of the registry to the config version - this covers cases where another node has failed
+// between persisting registry and config.
+// If the dbName does not exist in the registry but a config file does, similar retry is performed to wait for in-flight
+// database deletion.
+// If config rollback is triggered, the process is restarted up to the maximum registry reload count
+func (b *bootstrapContext) getRegistryAndDatabase(ctx context.Context, bucketName, groupID, dbName string) (registry *GatewayRegistry, config *DatabaseConfig, err error) {
+
+	registryLoadCount := 0
+	// Registry reloads should only happen in the event of node failure, or due to concurrent registry operations from multiple requests.
+	// Given this, we can abandon the current operation and return error after a small number of retry attempts
+	maxRegistryLoadCount := 5
+
+	// Outer loop performs a full retry (restarting from registry retrieval
+	for registryLoadCount < maxRegistryLoadCount {
+		registryLoadCount++
+		if registryLoadCount > 1 {
+			base.InfofCtx(ctx, base.KeyConfig, "Reloading registry, config retrieval attempt (%d/%d)", registryLoadCount, maxRegistryLoadCount)
+		}
+
+		registry, err = b.getGatewayRegistry(ctx, bucketName)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		var registryDb *RegistryDatabase
+		configGroup, exists := registry.ConfigGroups[groupID]
+		if exists {
+			registryDb, exists = configGroup.Databases[dbName]
+		}
+
+		if !exists {
+			// Use waitForConfigDelete to confirm/clean up any unexpected config files.  Recovers from slow updates
+			// racing with rollback.
+			err := b.waitForConfigDelete(ctx, bucketName, groupID, dbName, "", registry)
+			if err == base.ErrConfigRegistryReloadRequired {
+				continue
+			}
+			// On rollback (delete) of config for non-existent registry entry, log a warning but continue.
+			if err == base.ErrConfigRegistryRollback {
+				base.WarnfCtx(ctx, "Removed existing config for groupID: %v, dbName: %v that was not found in the registry", base.MD(groupID), base.MD(dbName))
+				return registry, nil, nil
+			}
+			return registry, nil, err
+		} else {
+			if registryDb.Version != "" {
+				// Database exists in registry, go fetch the config
+				config, err = b.getDatabaseConfig(ctx, bucketName, groupID, dbName, registryDb.Version, registry)
+				if err == base.ErrConfigRegistryReloadRequired {
+					// ReloadRegistry is returned by getDatabaseConfig immediately if the config version is greater than version found in the registry.
+					// We want to restart to pick up the latest registry
+					continue
+				}
+			} else if registryDb.PreviousVersion != nil {
+				// Previous Version without current version represents in-progress delete.  Wait for delete to complete
+				err := b.waitForConfigDelete(ctx, bucketName, groupID, dbName, registryDb.PreviousVersion.Version, registry)
+				if err == base.ErrConfigRegistryReloadRequired {
+					// ReloadRegistry is returned by waitForConfigDelete immediately if the config exists but the
+					// version does not match the previous version. Indicates a concurrent author has recreated the
+					// database - continue to reload the registry.
+					continue
+				}
+			}
+
+			// Otherwise we're done (either success, or return unrecoverable error)
+			return registry, config, err
+		}
+	}
+
+	return nil, nil, fmt.Errorf("Unable to retrieve config - registry reload limit reached(%v)", maxRegistryLoadCount)
+
+}

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -287,11 +287,11 @@ func (b *bootstrapContext) GetDatabaseConfigs(ctx context.Context, bucketName, g
 		// Check for legacy config file
 		var legacyConfig DatabaseConfig
 		var legacyDbName string
-		cas, err := b.Connection.GetMetadataDocument(bucketName, PersistentConfigKey(groupID, ""), &legacyConfig)
-		if err != nil && err != base.ErrNotFound {
-			return nil, fmt.Errorf("Error checking for legacy config for %s, %s: %w", base.MD(bucketName), base.MD(groupID), err)
+		cas, legacyErr := b.Connection.GetMetadataDocument(bucketName, PersistentConfigKey(groupID, ""), &legacyConfig)
+		if legacyErr != nil && legacyErr != base.ErrNotFound {
+			return nil, fmt.Errorf("Error checking for legacy config for %s, %s: %w", base.MD(bucketName), base.MD(groupID), legacyErr)
 		}
-		if err == nil {
+		if legacyErr == nil {
 			legacyConfig.cfgCas = cas
 			legacyDbName = legacyConfig.Name
 		}

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -591,7 +591,7 @@ func (b *bootstrapContext) getRegistryAndDatabase(ctx context.Context, bucketNam
 			}
 			return registry, nil, err
 		} else {
-			if registryDb.Version != "" {
+			if registryDb.Version != "" && registryDb.Version != deletedDatabaseVersion {
 				// Database exists in registry, go fetch the config
 				config, err = b.getDatabaseConfig(ctx, bucketName, groupID, dbName, registryDb.Version, registry)
 				if err == base.ErrConfigRegistryReloadRequired {

--- a/rest/config_manager_test.go
+++ b/rest/config_manager_test.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/config_manager_test.go
+++ b/rest/config_manager_test.go
@@ -1,0 +1,45 @@
+package rest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBootstrapConfig(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	base.TestRequiresCollections(t)
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyDCP)
+
+	// Start SG with no databases
+	config := BootstrapStartupConfigForTest(t)
+	ctx := base.TestCtx(t)
+	sc, err := SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+	}()
+
+	bootstrapContext := sc.BootstrapContext
+
+	// Get a test bucket for bootstrap testing
+	tb := base.GetTestBucket(t)
+	defer func() {
+		fmt.Println("closing test bucket")
+		tb.Close()
+	}()
+	bucketName := tb.GetName()
+	db1Name := "db"
+	configGroup1 := "cg1"
+
+	var dbConfig1 *DatabaseConfig
+
+	_, err = bootstrapContext.GetConfig(bucketName, configGroup1, db1Name, dbConfig1)
+	require.Error(t, err)
+}

--- a/rest/config_registry.go
+++ b/rest/config_registry.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/config_registry.go
+++ b/rest/config_registry.go
@@ -159,13 +159,13 @@ func (r *GatewayRegistry) upsertDatabaseConfig(ctx context.Context, configGroupI
 	}
 	collectionConflicts := r.getCollectionConflicts(ctx, config.Name, config.Scopes)
 	if len(collectionConflicts) > 0 {
-		return nil, base.HTTPErrorf(http.StatusConflict, fmt.Sprintf("Cannot update config for database %s - collections are in use by another database: %v", base.UD(config.Name), collectionConflicts))
+		return nil, base.HTTPErrorf(http.StatusConflict, "Cannot update config for database %s - collections are in use by another database: %v", base.UD(config.Name), collectionConflicts)
 	}
 
 	// For conflicts with in-flight updates, call getRegistryAndDatabase to block until those updates complete or rollback
 	previousVersionConflicts = r.getPreviousConflicts(ctx, config.Name, config.Scopes)
 	if len(previousVersionConflicts) > 0 {
-		return previousVersionConflicts, base.HTTPErrorf(http.StatusConflict, fmt.Sprintf("Cannot update config, collections are in use by another database with an update in progress"))
+		return previousVersionConflicts, base.HTTPErrorf(http.StatusConflict, "Cannot update config, collections are in use by another database with an update in progress")
 	}
 
 	configGroup, ok := r.ConfigGroups[configGroupID]

--- a/rest/config_registry.go
+++ b/rest/config_registry.go
@@ -94,7 +94,7 @@ func (r *GatewayRegistry) getCollectionsByDatabase(ctx context.Context) map[base
 		for dbName, database := range configGroup.Databases {
 			for scopeName, scope := range database.Scopes {
 				for _, collectionName := range scope.Collections {
-					scName := base.ScopeAndCollectionName{scopeName, collectionName}
+					scName := base.ScopeAndCollectionName{Scope: scopeName, Collection: collectionName}
 					// If duplicate found with different db name, log info
 					if existingName, ok := collectionsByDatabase[scName]; ok && existingName != dbName {
 						base.InfofCtx(ctx, base.KeyAll, "Collection %s associated with multiple databases in registry: [%s, %s]", scName, existingName, dbName)
@@ -230,7 +230,7 @@ func (r *GatewayRegistry) getRegistryDatabase(configGroupID, dbName string) (*Re
 // getDbForCollection returns the database associated with the specified scope and collection
 func (r *GatewayRegistry) getDbForCollection(ctx context.Context, scopeName string, collectionName string) (string, bool) {
 	collectionsByDatabase := r.getCollectionsByDatabase(ctx)
-	dbName, ok := collectionsByDatabase[base.ScopeAndCollectionName{scopeName, collectionName}]
+	dbName, ok := collectionsByDatabase[base.ScopeAndCollectionName{Scope: scopeName, Collection: collectionName}]
 	return dbName, ok
 }
 
@@ -308,7 +308,7 @@ func findCollectionConflicts(scopes ScopesConfig, registryScopes map[string]Regi
 			for collectionName, _ := range scope.Collections {
 				for _, registryCollectionName := range registryScope.Collections {
 					if collectionName == registryCollectionName {
-						conflicts = append(conflicts, base.ScopeAndCollectionName{scopeName, collectionName})
+						conflicts = append(conflicts, base.ScopeAndCollectionName{Scope: scopeName, Collection: collectionName})
 					}
 				}
 			}

--- a/rest/config_registry.go
+++ b/rest/config_registry.go
@@ -154,6 +154,9 @@ func (r *GatewayRegistry) removeDatabase(configGroupID, dbName string) bool {
 // can wait and retry.
 func (r *GatewayRegistry) upsertDatabaseConfig(ctx context.Context, configGroupID string, config *DatabaseConfig) (previousVersionConflicts []configGroupAndDatabase, err error) {
 
+	if config == nil {
+		return nil, fmt.Errorf("attempted to upsertDatabaseConfig with nil config")
+	}
 	collectionConflicts := r.getCollectionConflicts(ctx, config.Name, config.Scopes)
 	if len(collectionConflicts) > 0 {
 		return nil, base.HTTPErrorf(http.StatusConflict, fmt.Sprintf("Cannot update config for database %s - collections are in use by another database: %v", base.UD(config.Name), collectionConflicts))

--- a/rest/config_registry.go
+++ b/rest/config_registry.go
@@ -1,0 +1,339 @@
+package rest
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/couchbase/sync_gateway/base"
+)
+
+// GatewayRegistry lists all databases defined for the bucket, across config groups.  Used to fetch the full set of databases for a config group (for config polling),
+// and to prevent assignment of a collection to multiple databases.  Note that the same database may exist in different config groups,
+// and matching database names in different config groups are allowed to target the same collection.
+// Storage format:
+//
+//		configGroups: {
+//		   	default: {
+//		   		databases: {
+//		       		db1: {
+//		           		version: 2-abc,
+//		           		scopes: {
+//		               		_default:
+//								collections: [_default, c1, c2]
+//							}
+//						},
+//	                 previous_version: {
+//		           			version: 1-abc,
+//		           			scopes: {
+//		               			_default:
+//									collections: [_default, c2]
+//								}
+//						},
+//					}
+//				}
+//			}
+//		}
+type GatewayRegistry struct {
+	cas          uint64
+	Version      string                          `json:"version"`       // Registry version
+	ConfigGroups map[string]*RegistryConfigGroup `json:"config_groups"` // Map of config groups, keyed by config group ID
+}
+
+const GatewayRegistryVersion = "1.0"
+
+// RegistryConfigGroup stores the set of databases for a given config group
+type RegistryConfigGroup struct {
+	Databases map[string]*RegistryDatabase `json:"databases"`
+}
+
+// RegistryDatabase stores the version and set of RegistryScopes for a database
+type RegistryDatabase struct {
+	RegistryDatabaseVersion        // current version
+	UUID                    string `json:"uuid,omitempty"` // Database UUID
+	// PreviousVersion stores the previous database version while an update is in progress, in case update of the config
+	// fails and rollback is required.  Required to avoid cross-database collection conflicts during rollback.
+	PreviousVersion *RegistryDatabaseVersion `json:"previous_version,omitempty"`
+}
+
+// DatabaseVersion stores the version and collection set for a database.  Used for storing current or previous version.
+type RegistryDatabaseVersion struct {
+	Version string         `json:"version,omitempty"` // Database Version
+	Scopes  RegistryScopes `json:"scopes,omitempty"`  // Scopes and collections for this version
+}
+
+type RegistryScopes map[string]RegistryScope
+
+// RegistryScope stores the list of collections for the scope as a slice
+type RegistryScope struct {
+	Collections []string `json:"collections,omitempty"`
+}
+
+var defaultOnlyRegistryScopes = map[string]RegistryScope{base.DefaultScope: {Collections: []string{base.DefaultCollection}}}
+var defaultOnlyScopesConfig = ScopesConfig{base.DefaultScope: {Collections: map[string]CollectionConfig{base.DefaultCollection: {}}}}
+
+func NewGatewayRegistry() *GatewayRegistry {
+	return &GatewayRegistry{
+		ConfigGroups: make(map[string]*RegistryConfigGroup),
+		Version:      GatewayRegistryVersion,
+	}
+}
+
+// getCollectionsByDatabase returns all in-use collections as a map from collection name to the associated dbname
+func (r *GatewayRegistry) getCollectionsByDatabase(ctx context.Context) map[base.ScopeAndCollectionName]string {
+	collectionsByDatabase := make(map[base.ScopeAndCollectionName]string, 0)
+	for _, configGroup := range r.ConfigGroups {
+		for dbName, database := range configGroup.Databases {
+			for scopeName, scope := range database.Scopes {
+				for _, collectionName := range scope.Collections {
+					scName := base.ScopeAndCollectionName{scopeName, collectionName}
+					// If duplicate found with different db name, log info
+					if existingName, ok := collectionsByDatabase[scName]; ok && existingName != dbName {
+						base.InfofCtx(ctx, base.KeyAll, "Collection %s associated with multiple databases in registry: [%s, %s]", scName, existingName, dbName)
+					}
+					collectionsByDatabase[scName] = dbName
+				}
+			}
+		}
+	}
+	return collectionsByDatabase
+}
+
+// deleteDatabase deletes the current version of the db from the registry, updating previous version
+func (r *GatewayRegistry) deleteDatabase(configGroupID, dbName string) error {
+	configGroup, ok := r.ConfigGroups[configGroupID]
+	if !ok {
+		return base.ErrNotFound
+	}
+	database, ok := configGroup.Databases[dbName]
+	if !ok {
+		return base.ErrNotFound
+	}
+	database.PreviousVersion = &RegistryDatabaseVersion{
+		Version: database.Version,
+	}
+	// Scopes are not copied to PreviousVersion, as previous collections for in-flight deletes are not considered conflicts, since
+	// an interrupted delete is still processed as a delete (since we have enough information to identify intent)
+	database.Version = ""
+	database.Scopes = nil
+	return nil
+}
+
+// removeDatabase removes the specified db from the registry entirely
+func (r *GatewayRegistry) removeDatabase(configGroupID, dbName string) bool {
+	configGroup, ok := r.ConfigGroups[configGroupID]
+	if !ok {
+		return false
+	}
+	_, ok = configGroup.Databases[dbName]
+	if !ok {
+		return false
+	}
+	delete(configGroup.Databases, dbName)
+	if len(configGroup.Databases) == 0 {
+		delete(r.ConfigGroups, configGroupID)
+	}
+	return true
+}
+
+// upsertDatabaseConfig upserts the registry entry for the specified db to match the config.  If there is
+// an existing entry for the database, it will be replaced - otherwise a new entry for the database is added.
+// Returns error if database config is in conflict with the active version of another database.
+// If in-conflict with an in-flight update to other database(s), returns that set as previousVersionConflicts so that callers
+// can wait and retry.
+func (r *GatewayRegistry) upsertDatabaseConfig(ctx context.Context, configGroupID string, config *DatabaseConfig) (previousVersionConflicts []configGroupAndDatabase, err error) {
+
+	collectionConflicts := r.getCollectionConflicts(ctx, config.Name, config.Scopes)
+	if len(collectionConflicts) > 0 {
+		return nil, base.HTTPErrorf(http.StatusConflict, fmt.Sprintf("Cannot update config for database %s - collections are in use by another database: %v", base.UD(config.Name), collectionConflicts))
+	}
+
+	// For conflicts with in-flight updates, call getRegistryAndDatabase to block until those updates complete or rollback
+	previousVersionConflicts = r.getPreviousConflicts(ctx, config.Name, config.Scopes)
+	if len(previousVersionConflicts) > 0 {
+		return previousVersionConflicts, base.HTTPErrorf(http.StatusConflict, fmt.Sprintf("Cannot update config, collections are in use by another database with an update in progress"))
+	}
+
+	configGroup, ok := r.ConfigGroups[configGroupID]
+	if !ok {
+		configGroup = NewRegistryConfigGroup()
+		r.ConfigGroups[configGroupID] = configGroup
+	}
+
+	newRegistryDatabase := registryDatabaseFromConfig(config)
+	previousRegistryDatabase, ok := configGroup.Databases[config.Name]
+	// TODO: set previous version on insert as well, to indicate an in-flight operation?  An 'status:inprogress' flag might be cleanest
+	if ok {
+		if previousRegistryDatabase.PreviousVersion != nil {
+			base.WarnfCtx(ctx, "Previous version for config group:%s database:%s - will be ignored", config.Name, configGroupID)
+		}
+		newRegistryDatabase.PreviousVersion = &RegistryDatabaseVersion{
+			Version: previousRegistryDatabase.Version,
+			Scopes:  previousRegistryDatabase.Scopes,
+		}
+	}
+	configGroup.Databases[config.Name] = newRegistryDatabase
+	return nil, nil
+}
+
+// rollbackDatabaseConfig reverts the registry entry to the previous version, and removes the previous version
+func (r *GatewayRegistry) rollbackDatabaseConfig(ctx context.Context, configGroupID string, dbName string) (err error) {
+
+	configGroup, ok := r.ConfigGroups[configGroupID]
+	if !ok {
+		return base.ErrNotFound
+	}
+	registryDatabase, ok := configGroup.Databases[dbName]
+	if !ok {
+		return base.ErrNotFound
+	}
+
+	if registryDatabase.PreviousVersion == nil {
+		return fmt.Errorf("Rollback requested but registry did not include previous version for db %s", base.MD(dbName))
+	}
+
+	registryDatabase.Version = registryDatabase.PreviousVersion.Version
+	registryDatabase.Scopes = registryDatabase.PreviousVersion.Scopes
+	registryDatabase.PreviousVersion = nil
+	return nil
+}
+
+func (r *GatewayRegistry) removePreviousVersion(configGroupID string, dbName string, version string) error {
+	registryDatabase, ok := r.getRegistryDatabase(configGroupID, dbName)
+	if !ok {
+		return base.ErrNotFound
+	}
+	if registryDatabase.PreviousVersion == nil || registryDatabase.PreviousVersion.Version != version {
+		return base.ErrConfigVersionMismatch
+	}
+	registryDatabase.PreviousVersion = nil
+	return nil
+}
+
+func (r *GatewayRegistry) getRegistryDatabase(configGroupID, dbName string) (*RegistryDatabase, bool) {
+	cg, ok := r.ConfigGroups[configGroupID]
+	if !ok {
+		return nil, false
+	}
+	db, found := cg.Databases[dbName]
+	return db, found
+}
+
+// getDbForCollection returns the database associated with the specified scope and collection
+func (r *GatewayRegistry) getDbForCollection(ctx context.Context, scopeName string, collectionName string) (string, bool) {
+	collectionsByDatabase := r.getCollectionsByDatabase(ctx)
+	dbName, ok := collectionsByDatabase[base.ScopeAndCollectionName{scopeName, collectionName}]
+	return dbName, ok
+}
+
+// configGroupAndDatabase stores the [configGroup, databaseName] tuple.
+type configGroupAndDatabase struct {
+	configGroup  string
+	databaseName string
+}
+
+// getCollectionConflicts returns a map of registry collections that are in conflict with the provided scopesConfig.  Map values
+// are the dbName for the conflicting collection.  Matching collections for the same dbname is not a conflicts (even across config groups).
+func (r *GatewayRegistry) getCollectionConflicts(ctx context.Context, dbName string, scopes ScopesConfig) (activeConflicts map[base.ScopeAndCollectionName]string) {
+
+	if len(scopes) == 0 {
+		return r.getCollectionConflicts(ctx, dbName, defaultOnlyScopesConfig)
+	}
+	// activeConflicts is a map from conflicting collection names to db name
+	activeConflicts = make(map[base.ScopeAndCollectionName]string, 0)
+
+	for _, configGroup := range r.ConfigGroups {
+		for registryDbName, database := range configGroup.Databases {
+			if registryDbName != dbName {
+				registryScopes := database.Scopes
+				if len(registryScopes) == 0 {
+					registryScopes = defaultOnlyRegistryScopes
+				}
+				for _, scName := range findCollectionConflicts(scopes, registryScopes) {
+					activeConflicts[scName] = registryDbName
+				}
+			}
+		}
+	}
+	return activeConflicts
+}
+
+// getPreviousConflicts returns the set of unique [configGroupAndDatabase] where the previousVersion for that database has a conflicting collection
+// with the provided ScopesConfig.  previousVersion indicates an in-flight update of the registry for that database.
+// Matching collections for the same dbname is not a conflicts (even across config groups).
+func (r *GatewayRegistry) getPreviousConflicts(ctx context.Context, dbName string, scopes ScopesConfig) (previousConflicts []configGroupAndDatabase) {
+
+	if len(scopes) == 0 {
+		return r.getPreviousConflicts(ctx, dbName, defaultOnlyScopesConfig)
+	}
+	conflictingDbs := make(map[configGroupAndDatabase]struct{}, 0)
+	for cgName, configGroup := range r.ConfigGroups {
+		for registryDbName, database := range configGroup.Databases {
+			if registryDbName != dbName && database.PreviousVersion != nil {
+				previousScopes := database.PreviousVersion.Scopes
+				if len(previousScopes) == 0 {
+					previousScopes = defaultOnlyRegistryScopes
+				}
+				previousConflicts := findCollectionConflicts(scopes, previousScopes)
+				if len(previousConflicts) > 0 {
+					conflictingDb := configGroupAndDatabase{cgName, registryDbName}
+					conflictingDbs[conflictingDb] = struct{}{}
+				}
+			}
+		}
+	}
+
+	previousConflicts = make([]configGroupAndDatabase, 0, len(conflictingDbs))
+	for key, _ := range conflictingDbs {
+		previousConflicts = append(previousConflicts, key)
+	}
+	return previousConflicts
+}
+
+// findCollectionConflicts is a utility method to find the set of conflicting collections between a database config (stored in ScopesConfig)
+// and a database version in the registry (stored in a map of scopeName to RegistryScope).
+func findCollectionConflicts(scopes ScopesConfig, registryScopes map[string]RegistryScope) []base.ScopeAndCollectionName {
+	conflicts := make([]base.ScopeAndCollectionName, 0)
+	for scopeName, scope := range scopes {
+		registryScope, ok := registryScopes[scopeName]
+		if ok {
+			for collectionName, _ := range scope.Collections {
+				for _, registryCollectionName := range registryScope.Collections {
+					if collectionName == registryCollectionName {
+						conflicts = append(conflicts, base.ScopeAndCollectionName{scopeName, collectionName})
+					}
+				}
+			}
+		}
+	}
+	return conflicts
+}
+
+// registryDatabaseFromConfig creates a RegistryDatabase based on the specified config
+func registryDatabaseFromConfig(config *DatabaseConfig) *RegistryDatabase {
+	rdb := &RegistryDatabase{}
+	rdb.Version = config.Version
+	if len(config.Scopes) == 0 {
+		rdb.Scopes = defaultOnlyRegistryScopes
+		return rdb
+	}
+
+	rdb.Scopes = make(map[string]RegistryScope)
+	for scopeName, scope := range config.Scopes {
+		registryScope := RegistryScope{
+			Collections: make([]string, 0),
+		}
+		for collectionName, _ := range scope.Collections {
+			registryScope.Collections = append(registryScope.Collections, collectionName)
+		}
+		rdb.Scopes[scopeName] = registryScope
+	}
+	return rdb
+}
+
+// NewRegistryConfigGroup initializes an empty RegistryConfigGroup
+func NewRegistryConfigGroup() *RegistryConfigGroup {
+	return &RegistryConfigGroup{
+		Databases: make(map[string]*RegistryDatabase),
+	}
+}

--- a/rest/config_registry_test.go
+++ b/rest/config_registry_test.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/config_registry_test.go
+++ b/rest/config_registry_test.go
@@ -223,17 +223,17 @@ func TestRegistryConflicts(t *testing.T) {
 		{
 			name:              "Same scope, one conflicting collection",
 			dbConfig:          makeDatabaseConfig("newDb", "scope1", []string{"c1", "c7"}),
-			expectedConflicts: []base.ScopeAndCollectionName{{"scope1", "c1"}},
+			expectedConflicts: []base.ScopeAndCollectionName{{Scope: "scope1", Collection: "c1"}},
 		},
 		{
 			name:              "Same scope, two conflicting collections",
 			dbConfig:          makeDatabaseConfig("newDb", "scope1", []string{"c7", "c1", "c2"}),
-			expectedConflicts: []base.ScopeAndCollectionName{{"scope1", "c1"}, {"scope1", "c2"}},
+			expectedConflicts: []base.ScopeAndCollectionName{{Scope: "scope1", Collection: "c1"}, {Scope: "scope1", Collection: "c2"}},
 		},
 		{
 			name:              "Same scope, two conflicting collections",
 			dbConfig:          makeDatabaseConfig("newDb", "scope1", []string{"c7", "c1", "c2"}),
-			expectedConflicts: []base.ScopeAndCollectionName{{"scope1", "c1"}, {"scope1", "c2"}},
+			expectedConflicts: []base.ScopeAndCollectionName{{Scope: "scope1", Collection: "c1"}, {Scope: "scope1", Collection: "c2"}},
 		},
 		{
 			name:              "Non-conflict with default collection, same dbName",
@@ -248,17 +248,17 @@ func TestRegistryConflicts(t *testing.T) {
 		{
 			name:              "Conflict with legacy default collection",
 			dbConfig:          &DatabaseConfig{DbConfig: DbConfig{Name: "newDb"}},
-			expectedConflicts: []base.ScopeAndCollectionName{{base.DefaultScope, base.DefaultCollection}},
+			expectedConflicts: []base.ScopeAndCollectionName{{Scope: base.DefaultScope, Collection: base.DefaultCollection}},
 		},
 		{
 			name:              "Conflict with explicit default collection",
 			dbConfig:          makeDatabaseConfig("newDb", base.DefaultScope, []string{base.DefaultCollection}),
-			expectedConflicts: []base.ScopeAndCollectionName{{base.DefaultScope, base.DefaultCollection}},
+			expectedConflicts: []base.ScopeAndCollectionName{{Scope: base.DefaultScope, Collection: base.DefaultCollection}},
 		},
 		{
 			name:              "Conflict with explicit default collection among others",
 			dbConfig:          makeDatabaseConfig("newDb", base.DefaultScope, []string{base.DefaultCollection, "c1"}),
-			expectedConflicts: []base.ScopeAndCollectionName{{base.DefaultScope, base.DefaultCollection}},
+			expectedConflicts: []base.ScopeAndCollectionName{{Scope: base.DefaultScope, Collection: base.DefaultCollection}},
 		},
 	}
 

--- a/rest/config_registry_test.go
+++ b/rest/config_registry_test.go
@@ -1,0 +1,293 @@
+package rest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegistryHelpers unmarshals a registry and performs upserts and removals
+func TestRegistryHelpers(t *testing.T) {
+
+	registryJSON :=
+		`{
+		"config_groups": {
+			"default": {
+				"databases": {
+	       			"db1": {
+						"version": "1-abc",
+						"scopes": {
+	               			"_default": {
+								"collections": ["c1", "c2"]
+							}
+						}
+					},
+	       			"db2": {
+						"version": "1-abc",
+						"scopes": {
+	               			"_default": {
+								"collections": ["c3", "c4"]
+							}
+						}
+					}
+				}
+			},
+			"cg1": {
+				"databases": {
+	       			"db1": {
+						"version": "1-abc",
+						"scopes": {
+	               			"_default": {
+								"collections": ["c2"]
+							}
+						}
+					},
+					"db3": {
+						"version": "1-def",
+						"scopes": {
+	               			"s1": {
+								"collections": ["c1", "c2"]
+							}
+						}
+					}
+				}
+			}
+		}
+	}`
+	ctx := base.TestCtx(t)
+
+	var registry *GatewayRegistry
+	err := base.JSONUnmarshal([]byte(registryJSON), &registry)
+	require.NoError(t, err)
+	configGroup, ok := registry.ConfigGroups["default"]
+	require.True(t, ok)
+	registryDb, ok := configGroup.Databases["db1"]
+	require.True(t, ok)
+	assert.Equal(t, "1-abc", registryDb.Version)
+
+	// Request db for collection that only exists in one config group
+	dbName, ok := registry.getDbForCollection(ctx, "_default", "c1")
+	require.True(t, ok)
+	assert.Equal(t, "db1", dbName)
+
+	// Request db for collection that exists in multiple config groups (same db)
+	dbName, ok = registry.getDbForCollection(ctx, "_default", "c2")
+	require.True(t, ok)
+	assert.Equal(t, "db1", dbName)
+
+	// Request db for unused collection
+	_, ok = registry.getDbForCollection(ctx, "_default", "c5")
+	require.False(t, ok)
+
+	dbName, ok = registry.getDbForCollection(ctx, "s1", "c1")
+	require.True(t, ok)
+	assert.Equal(t, "db3", dbName)
+
+	require.True(t, registry.removeDatabase("cg1", "db3"))
+	require.False(t, registry.removeDatabase("cg1", "db3"))
+
+	// verify removal from collection map
+	_, ok = registry.getDbForCollection(ctx, "s1", "c1")
+	assert.False(t, ok)
+
+	dbConfig := &DatabaseConfig{
+		Version: "1-ghi",
+		DbConfig: DbConfig{
+			Name: "defaultDb",
+		},
+	}
+	registry.upsertDatabaseConfig(ctx, "cg1", dbConfig)
+	addedDefaultDb, ok := registry.getDbForCollection(ctx, "_default", "_default")
+	require.True(t, ok)
+	assert.Equal(t, "defaultDb", addedDefaultDb)
+}
+
+// TestUpsertDatabaseConfig tests registry.upsertDatabaseConfig
+func TestUpsertDatabaseConfig(t *testing.T) {
+
+	ctx := base.TestCtx(t)
+	registry := NewGatewayRegistry()
+	dbConfig := makeDatabaseConfig("db1", "scope1", []string{"c1", "c2", "c3"}) // in cg1
+	dbConfig.Version = "1"
+	_, err := registry.upsertDatabaseConfig(ctx, "cg1", dbConfig)
+	require.NoError(t, err)
+	registryDatabase, ok := registry.ConfigGroups["cg1"].Databases["db1"]
+	require.True(t, ok)
+	require.Equal(t, "1", registryDatabase.Version)
+	require.Nil(t, registryDatabase.PreviousVersion)
+	registryScope, ok := registryDatabase.Scopes["scope1"]
+	require.True(t, ok)
+	registryCollections := registryScope.Collections
+	require.True(t, base.StringSliceContains(registryCollections, "c1"))
+	require.True(t, base.StringSliceContains(registryCollections, "c2"))
+	require.True(t, base.StringSliceContains(registryCollections, "c3"))
+
+	dbConfigUpdate := makeDatabaseConfig("db1", "scope1", []string{"c3", "c4", "c5"})
+	dbConfigUpdate.Version = "2"
+	_, err = registry.upsertDatabaseConfig(ctx, "cg1", dbConfigUpdate)
+	require.NoError(t, err)
+	registryDatabase, ok = registry.ConfigGroups["cg1"].Databases["db1"]
+	require.True(t, ok)
+	require.Equal(t, "2", registryDatabase.Version)
+	registryScope, ok = registryDatabase.Scopes["scope1"]
+	require.True(t, ok)
+	registryCollections = registryScope.Collections
+	require.True(t, base.StringSliceContains(registryCollections, "c3"))
+	require.True(t, base.StringSliceContains(registryCollections, "c4"))
+	require.True(t, base.StringSliceContains(registryCollections, "c5"))
+
+	require.NotNil(t, registryDatabase.PreviousVersion)
+	require.Equal(t, "1", registryDatabase.PreviousVersion.Version)
+	previousScope, ok := registryDatabase.PreviousVersion.Scopes["scope1"]
+	require.True(t, ok)
+	previousCollections := previousScope.Collections
+	require.True(t, base.StringSliceContains(previousCollections, "c1"))
+	require.True(t, base.StringSliceContains(previousCollections, "c2"))
+	require.True(t, base.StringSliceContains(previousCollections, "c3"))
+
+	// Test previous version removal
+	err = registry.removePreviousVersion("cg2", "db1", "1") // config group mismatch
+	require.Equal(t, base.ErrNotFound, err)
+	err = registry.removePreviousVersion("cg1", "db2", "1") // db name mismatch
+	require.Equal(t, base.ErrNotFound, err)
+	err = registry.removePreviousVersion("cg1", "db1", "2") // config version mismatch
+	require.Equal(t, base.ErrConfigVersionMismatch, err)
+	err = registry.removePreviousVersion("cg1", "db1", "1") // config version mismatch
+	require.NoError(t, err)
+	registryDatabase, ok = registry.ConfigGroups["cg1"].Databases["db1"]
+	require.True(t, ok)
+	require.Nil(t, registryDatabase.PreviousVersion)
+
+}
+
+// TestRegistryConflicts tests registry.findCollectionConflicts
+func TestRegistryConflicts(t *testing.T) {
+
+	// Initialize registry with databases
+	dbConfig1 := makeDatabaseConfig("db1", "scope1", []string{"c1", "c2", "c3"}) // in cg1
+	dbConfig2 := makeDatabaseConfig("db1", "scope1", []string{"c1", "c3"})       // in cg2
+	dbConfig3 := makeDatabaseConfig("db2", "scope1", []string{"c4", "c5", "c6"}) // in cg1
+	dbConfig4 := makeDatabaseConfig("db3", "scope2", []string{"c1", "c2", "c3"}) // in cg1
+	defaultConfig := &DatabaseConfig{DbConfig: DbConfig{Name: "defaultDb"}}
+
+	ctx := base.TestCtx(t)
+	registry := NewGatewayRegistry()
+	_, err := registry.upsertDatabaseConfig(ctx, "cg1", dbConfig1)
+	require.NoError(t, err)
+	_, err = registry.upsertDatabaseConfig(ctx, "cg2", dbConfig2)
+	require.NoError(t, err)
+	_, err = registry.upsertDatabaseConfig(ctx, "cg1", dbConfig3)
+	require.NoError(t, err)
+	_, err = registry.upsertDatabaseConfig(ctx, "cg1", dbConfig4)
+	require.NoError(t, err)
+	_, err = registry.upsertDatabaseConfig(ctx, "cg1", defaultConfig)
+	require.NoError(t, err)
+	testCases := []struct {
+		name              string
+		dbConfig          *DatabaseConfig
+		expectedConflicts []base.ScopeAndCollectionName
+	}{
+		{
+			name:              "Different scope, different collections",
+			dbConfig:          makeDatabaseConfig("newDb", "scope3", []string{"c5", "c6"}),
+			expectedConflicts: []base.ScopeAndCollectionName{},
+		},
+		{
+			name:              "Same scope, different collections",
+			dbConfig:          makeDatabaseConfig("newDb", "scope1", []string{"c7", "c8"}),
+			expectedConflicts: []base.ScopeAndCollectionName{},
+		},
+		{
+			name:              "Different scope, Same collections",
+			dbConfig:          makeDatabaseConfig("newDb", "scope3", []string{"c1", "c2"}),
+			expectedConflicts: []base.ScopeAndCollectionName{},
+		},
+		{
+			name:              "Same scope, same collections, same dbName",
+			dbConfig:          makeDatabaseConfig("db1", "scope1", []string{"c2", "c3"}),
+			expectedConflicts: []base.ScopeAndCollectionName{},
+		},
+		{
+			name:              "Same scope, one conflicting collection",
+			dbConfig:          makeDatabaseConfig("newDb", "scope1", []string{"c1", "c7"}),
+			expectedConflicts: []base.ScopeAndCollectionName{{"scope1", "c1"}},
+		},
+		{
+			name:              "Same scope, two conflicting collections",
+			dbConfig:          makeDatabaseConfig("newDb", "scope1", []string{"c7", "c1", "c2"}),
+			expectedConflicts: []base.ScopeAndCollectionName{{"scope1", "c1"}, {"scope1", "c2"}},
+		},
+		{
+			name:              "Same scope, two conflicting collections",
+			dbConfig:          makeDatabaseConfig("newDb", "scope1", []string{"c7", "c1", "c2"}),
+			expectedConflicts: []base.ScopeAndCollectionName{{"scope1", "c1"}, {"scope1", "c2"}},
+		},
+		{
+			name:              "Non-conflict with default collection, same dbName",
+			dbConfig:          &DatabaseConfig{DbConfig: DbConfig{Name: "defaultDb"}},
+			expectedConflicts: []base.ScopeAndCollectionName{},
+		},
+		{
+			name:              "Non-conflict with default scope, different collection",
+			dbConfig:          makeDatabaseConfig("newDb", base.DefaultScope, []string{"c1"}),
+			expectedConflicts: []base.ScopeAndCollectionName{},
+		},
+		{
+			name:              "Conflict with legacy default collection",
+			dbConfig:          &DatabaseConfig{DbConfig: DbConfig{Name: "newDb"}},
+			expectedConflicts: []base.ScopeAndCollectionName{{base.DefaultScope, base.DefaultCollection}},
+		},
+		{
+			name:              "Conflict with explicit default collection",
+			dbConfig:          makeDatabaseConfig("newDb", base.DefaultScope, []string{base.DefaultCollection}),
+			expectedConflicts: []base.ScopeAndCollectionName{{base.DefaultScope, base.DefaultCollection}},
+		},
+		{
+			name:              "Conflict with explicit default collection among others",
+			dbConfig:          makeDatabaseConfig("newDb", base.DefaultScope, []string{base.DefaultCollection, "c1"}),
+			expectedConflicts: []base.ScopeAndCollectionName{{base.DefaultScope, base.DefaultCollection}},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			conflicts := registry.getCollectionConflicts(ctx, testCase.dbConfig.Name, testCase.dbConfig.Scopes)
+			assert.Equal(t, len(testCase.expectedConflicts), len(conflicts))
+			// no ordering guarantee on returned conflicts, need to compare slices
+			for _, expectedConflict := range testCase.expectedConflicts {
+				found := false
+				for conflict, _ := range conflicts {
+					if conflict == expectedConflict {
+						found = true
+					}
+				}
+				assert.True(t, found, fmt.Sprintf("Not found: %v", expectedConflict))
+			}
+		})
+	}
+
+}
+
+func makeDatabaseConfig(dbName string, scopeName string, collectionNames []string) *DatabaseConfig {
+
+	var scopesConfig ScopesConfig
+	scopesConfig = ScopesConfig{
+		scopeName: ScopeConfig{
+			map[string]CollectionConfig{},
+		},
+	}
+	for _, collectionName := range collectionNames {
+		scopesConfig[scopeName].Collections[collectionName] = CollectionConfig{}
+	}
+
+	return &DatabaseConfig{
+		DbConfig: DbConfig{
+			Name:   dbName,
+			Scopes: scopesConfig,
+		},
+	}
+}

--- a/rest/config_registry_test.go
+++ b/rest/config_registry_test.go
@@ -108,7 +108,8 @@ func TestRegistryHelpers(t *testing.T) {
 			Name: "defaultDb",
 		},
 	}
-	registry.upsertDatabaseConfig(ctx, "cg1", dbConfig)
+	_, err = registry.upsertDatabaseConfig(ctx, "cg1", dbConfig)
+	require.NoError(t, err)
 	addedDefaultDb, ok := registry.getDbForCollection(ctx, "_default", "_default")
 	require.True(t, ok)
 	assert.Equal(t, "defaultDb", addedDefaultDb)

--- a/rest/handler_config_database.go
+++ b/rest/handler_config_database.go
@@ -66,6 +66,7 @@ func (h *handler) mutateDbConfig(mutator func(*DbConfig) error) error {
 			if err != nil {
 				return nil, err
 			}
+			updatedDbConfig = bucketDbConfig
 			return bucketDbConfig, nil
 		})
 		if err != nil {

--- a/rest/handler_config_database.go
+++ b/rest/handler_config_database.go
@@ -47,35 +47,27 @@ func (h *handler) mutateDbConfig(mutator func(*DbConfig) error) error {
 		// Update persistently-stored config:
 		bucket := h.db.Bucket.GetName()
 		var updatedDbConfig *DatabaseConfig
-		cas, err := h.server.BootstrapContext.Connection.UpdateConfig(
-			bucket, h.server.Config.Bootstrap.ConfigGroupID,
-			func(rawBucketConfig []byte, rawBucketConfigCas uint64) (newConfig []byte, err error) {
-				var bucketDbConfig DatabaseConfig
-				if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {
-					return nil, err
-				}
+		cas, err := h.server.BootstrapContext.UpdateConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
 
-				if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
-					return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
-				}
+			if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
+				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
+			}
 
-				// Now call the mutator function:
-				if err := mutator(&bucketDbConfig.DbConfig); err != nil {
-					return nil, err
-				}
+			// Now call the mutator function:
+			if err := mutator(&bucketDbConfig.DbConfig); err != nil {
+				return nil, err
+			}
 
-				if err := bucketDbConfig.validate(h.ctx(), validateOIDC); err != nil {
-					return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
-				}
+			if err := bucketDbConfig.validate(h.ctx(), validateOIDC); err != nil {
+				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
+			}
 
-				bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
-				if err != nil {
-					return nil, err
-				}
-
-				updatedDbConfig = &bucketDbConfig
-				return base.JSONMarshal(bucketDbConfig)
-			})
+			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
+			if err != nil {
+				return nil, err
+			}
+			return bucketDbConfig, nil
+		})
 		if err != nil {
 			return err
 		}

--- a/rest/main.go
+++ b/rest/main.go
@@ -210,6 +210,9 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 		return nil, false, nil, nil, err
 	}
 
+	bootstrap := bootstrapContext{
+		Connection: cluster,
+	}
 	// Write database configs to CBS with groupID "default"
 	for _, dbConfig := range dbConfigs {
 		dbc := dbConfig.ToDatabaseConfig()
@@ -234,7 +237,7 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 			configGroupID = startupConfig.Bootstrap.ConfigGroupID
 		}
 
-		_, err = cluster.InsertMetadataDocument(*dbc.Bucket, configGroupID, dbc)
+		_, err = bootstrap.InsertConfig(context.Background(), *dbc.Bucket, configGroupID, dbc)
 		if err != nil {
 			// If key already exists just continue
 			if errors.Is(err, base.ErrAlreadyExists) {

--- a/rest/main.go
+++ b/rest/main.go
@@ -234,7 +234,7 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 			configGroupID = startupConfig.Bootstrap.ConfigGroupID
 		}
 
-		_, err = cluster.InsertConfig(*dbc.Bucket, configGroupID, dbc)
+		_, err = cluster.InsertMetadataDocument(*dbc.Bucket, configGroupID, dbc)
 		if err != nil {
 			// If key already exists just continue
 			if errors.Is(err, base.ErrAlreadyExists) {

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -204,7 +204,6 @@ func TestPersistentDbConfigWithInvalidUpsert(t *testing.T) {
 
 	// remove the db config directly from the bucket
 	docID := PersistentConfigKey(*rtc.config.groupID, db)
-	require.NoError(t, err)
 	// metadata store
 	_, err = rtc.testBucket.DefaultDataStore().Remove(docID, 0)
 	require.NoError(t, err)

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -203,7 +203,7 @@ func TestPersistentDbConfigWithInvalidUpsert(t *testing.T) {
 	assert.NotContains(t, string(resp.BodyBytes()), `"revs_limit":`)
 
 	// remove the db config directly from the bucket
-	docID, err := base.PersistentConfigKey(*rtc.config.groupID)
+	docID := PersistentConfigKey(*rtc.config.groupID, db)
 	require.NoError(t, err)
 	// metadata store
 	_, err = rtc.testBucket.DefaultDataStore().Remove(docID, 0)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1267,8 +1267,7 @@ func (sc *ServerContext) _unsuspendDatabase(ctx context.Context, dbName string) 
 			bucket = *dbConfig.Bucket
 		}
 
-		var config DatabaseConfig
-		cas, err := sc.BootstrapContext.GetConfig(bucket, sc.Config.Bootstrap.ConfigGroupID, dbName, &config)
+		cas, err := sc.BootstrapContext.GetConfig(bucket, sc.Config.Bootstrap.ConfigGroupID, dbName, &dbConfig.DatabaseConfig)
 		if err == base.ErrNotFound {
 			// Database no longer exists, so clean up dbConfigs
 			base.InfofCtx(ctx, base.KeyConfig, "Database %q has been removed while suspended from bucket %q", base.MD(dbName), base.MD(bucket))
@@ -1277,7 +1276,6 @@ func (sc *ServerContext) _unsuspendDatabase(ctx context.Context, dbName string) 
 		} else if err != nil {
 			return nil, fmt.Errorf("unsuspending db %q failed due to an error while trying to retrieve latest config from bucket %q: %w", base.MD(dbName).Redact(), base.MD(bucket).Redact(), err)
 		}
-		dbConfig.DatabaseConfig = config
 		dbConfig.cfgCas = cas
 		dbCtx, err = sc._getOrAddDatabaseFromConfig(ctx, dbConfig.DatabaseConfig, false, db.GetConnectToBucketFn(false))
 		if err != nil {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -53,7 +53,8 @@ type ServerContext struct {
 	Config                 *StartupConfig // The current runtime configuration of the node
 	initialStartupConfig   *StartupConfig // The configuration at startup of the node. Built from config file + flags
 	persistentConfig       bool
-	bucketDbName           map[string]string                 // bucketDbName is a map of bucket to database name
+	dbRegistry             map[string]struct{}               // registry of dbNames, used to ensure uniqueness even when db isn't active
+	collectionRegistry     map[string]string                 // map of fully qualified collection name to db name, used for local uniqueness checks
 	dbConfigs              map[string]*RuntimeDatabaseConfig // dbConfigs is a map of db name to the RuntimeDatabaseConfig
 	databases_             map[string]*db.DatabaseContext    // databases_ is a map of dbname to db.DatabaseContext
 	lock                   sync.RWMutex
@@ -70,10 +71,15 @@ type ServerContext struct {
 	fetchConfigsLastUpdate time.Time       // The last time fetchConfigsWithTTL() updated dbConfigs
 }
 
+// defaultConfigRetryTimeout is the total retry time when waiting for in-flight config updates.  Set as a multiple of kv op timeout,
+// based on the maximum of 3 kv ops for a successful config update
+const defaultConfigRetryTimeout = 3 * base.DefaultGocbV2OperationTimeout
+
 type bootstrapContext struct {
-	Connection base.BootstrapConnection
-	terminator chan struct{} // Used to stop the goroutine handling the stats logging
-	doneChan   chan struct{} // doneChan is closed when the stats logger goroutine finishes.
+	Connection         base.BootstrapConnection
+	configRetryTimeout time.Duration // configRetryTimeout defines the total amount of time to retry on a registry/config mismatch
+	terminator         chan struct{} // Used to stop the goroutine handling the stats logging
+	doneChan           chan struct{} // doneChan is closed when the stats logger goroutine finishes.
 }
 
 func (sc *ServerContext) CreateLocalDatabase(ctx context.Context, dbs DbConfigMap) error {
@@ -104,15 +110,16 @@ func (sc *ServerContext) CloseCpuPprofFile(ctx context.Context) {
 
 func NewServerContext(ctx context.Context, config *StartupConfig, persistentConfig bool) *ServerContext {
 	sc := &ServerContext{
-		Config:           config,
-		persistentConfig: persistentConfig,
-		bucketDbName:     map[string]string{},
-		dbConfigs:        map[string]*RuntimeDatabaseConfig{},
-		databases_:       map[string]*db.DatabaseContext{},
-		HTTPClient:       http.DefaultClient,
-		statsContext:     &statsContext{},
-		BootstrapContext: &bootstrapContext{},
-		hasStarted:       make(chan struct{}),
+		Config:             config,
+		persistentConfig:   persistentConfig,
+		dbRegistry:         map[string]struct{}{},
+		collectionRegistry: map[string]string{},
+		dbConfigs:          map[string]*RuntimeDatabaseConfig{},
+		databases_:         map[string]*db.DatabaseContext{},
+		HTTPClient:         http.DefaultClient,
+		statsContext:       &statsContext{},
+		BootstrapContext:   &bootstrapContext{},
+		hasStarted:         make(chan struct{}),
 	}
 
 	if base.ServerIsWalrus(sc.Config.Bootstrap.Server) {
@@ -605,6 +612,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 
 	javascriptTimeout := getJavascriptTimeout(&config.DbConfig)
 
+	fqCollections := make([]string, 0)
 	if len(config.Scopes) > 0 {
 		contextOptions.Scopes = make(db.ScopesOptions, len(config.Scopes))
 		for scopeName, scopeCfg := range config.Scopes {
@@ -621,7 +629,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 					Sync:         collCfg.SyncFn,
 					ImportFilter: importFilter,
 				}
-
+				fqCollections = append(fqCollections, base.FullyQualifiedCollectionName(spec.BucketName, scopeName, collName))
 			}
 		}
 	} else {
@@ -713,7 +721,10 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	// Register it so HTTP handlers can find it:
 	sc.databases_[dbcontext.Name] = dbcontext
 	sc.dbConfigs[dbcontext.Name] = &RuntimeDatabaseConfig{DatabaseConfig: config}
-	sc.bucketDbName[spec.BucketName] = dbName
+	sc.dbRegistry[dbName] = struct{}{}
+	for _, name := range fqCollections {
+		sc.collectionRegistry[name] = dbName
+	}
 
 	if base.BoolDefault(config.StartOffline, false) {
 		atomic.StoreUint32(&dbcontext.State, db.DBOffline)
@@ -1187,12 +1198,16 @@ func (sc *ServerContext) _removeDatabase(ctx context.Context, dbName string) boo
 	if dbCtx == nil {
 		return false
 	}
-	bucket := dbCtx.Bucket.GetName()
 	if ok := sc._unloadDatabase(ctx, dbName); !ok {
 		return ok
 	}
 	delete(sc.dbConfigs, dbName)
-	delete(sc.bucketDbName, bucket)
+	delete(sc.dbRegistry, dbName)
+	for fqCollection, registryDbName := range sc.collectionRegistry {
+		if dbName == registryDbName {
+			delete(sc.collectionRegistry, fqCollection)
+		}
+	}
 	return true
 }
 
@@ -1251,7 +1266,9 @@ func (sc *ServerContext) _unsuspendDatabase(ctx context.Context, dbName string) 
 		if dbConfig.Bucket != nil {
 			bucket = *dbConfig.Bucket
 		}
-		cas, err := sc.BootstrapContext.Connection.GetConfig(bucket, sc.Config.Bootstrap.ConfigGroupID, dbConfig)
+
+		var config DatabaseConfig
+		cas, err := sc.BootstrapContext.GetConfig(bucket, sc.Config.Bootstrap.ConfigGroupID, dbName, &config)
 		if err == base.ErrNotFound {
 			// Database no longer exists, so clean up dbConfigs
 			base.InfofCtx(ctx, base.KeyConfig, "Database %q has been removed while suspended from bucket %q", base.MD(dbName), base.MD(bucket))
@@ -1260,6 +1277,7 @@ func (sc *ServerContext) _unsuspendDatabase(ctx context.Context, dbName string) 
 		} else if err != nil {
 			return nil, fmt.Errorf("unsuspending db %q failed due to an error while trying to retrieve latest config from bucket %q: %w", base.MD(dbName).Redact(), base.MD(bucket).Redact(), err)
 		}
+		dbConfig.DatabaseConfig = config
 		dbConfig.cfgCas = cas
 		dbCtx, err = sc._getOrAddDatabaseFromConfig(ctx, dbConfig.DatabaseConfig, false, db.GetConnectToBucketFn(false))
 		if err != nil {
@@ -1749,6 +1767,10 @@ func (sc *ServerContext) Database(ctx context.Context, name string) *db.Database
 }
 
 func (sc *ServerContext) initializeCouchbaseServerConnections(ctx context.Context) error {
+	base.InfofCtx(ctx, base.KeyAll, "initializing server connections")
+	defer func() {
+		base.InfofCtx(ctx, base.KeyAll, "finished initializing server connections")
+	}()
 	goCBAgent, err := sc.initializeGoCBAgent(ctx)
 	if err != nil {
 		return err

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1796,6 +1796,12 @@ func (sc *ServerContext) initializeCouchbaseServerConnections(ctx context.Contex
 
 		sc.BootstrapContext.Connection = couchbaseCluster
 
+		// Check for v3.0 persisted configs, migrate to registry format if found
+		err = sc.migrateV30Configs(ctx)
+		if err != nil {
+			base.InfofCtx(ctx, base.KeyConfig, "Unable to migrate v3.0 config to registry - will not be migrated: %w", err)
+		}
+
 		count, err := sc.fetchAndLoadConfigs(ctx, true)
 		if err != nil {
 			return err

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -567,7 +567,8 @@ func TestSuspendingFlags(t *testing.T) {
 			tb := base.GetTestBucket(t)
 			defer tb.Close()
 
-			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, serverless: test.serverlessMode})
+			rt := NewRestTester(t,
+				&RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, serverless: test.serverlessMode})
 			defer rt.Close()
 
 			sc := rt.ServerContext()

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -30,7 +30,7 @@ func TestServerlessPollBuckets(t *testing.T) {
 	defer tb1.Close()
 
 	rt := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: tb1,
+		CustomTestBucket: tb1.NoCloseClone(),
 		serverless:       true,
 		PersistentConfig: true,
 		MutateStartupConfig: func(config *StartupConfig) {
@@ -51,7 +51,7 @@ func TestServerlessPollBuckets(t *testing.T) {
 	assert.Empty(t, configs)
 
 	// Create a database
-	rt2 := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1, PersistentConfig: true, groupID: &sc.Config.Bootstrap.ConfigGroupID})
+	rt2 := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1.NoCloseClone(), PersistentConfig: true, groupID: &sc.Config.Bootstrap.ConfigGroupID})
 	defer rt2.Close()
 	// Create a new db on the RT to confirm fetch won't retrieve it (due to bucket not being in BucketCredentials)
 	resp := rt2.SendAdminRequest(http.MethodPut, "/db/", fmt.Sprintf(`{
@@ -123,7 +123,7 @@ func TestServerlessDBSetupForceCreds(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1, serverless: true, PersistentConfig: true})
+			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1.NoCloseClone(), serverless: true, PersistentConfig: true})
 			defer rt.Close()
 
 			if test.perBucketCreds != nil {
@@ -149,7 +149,7 @@ func TestServerlessBucketCredentialsFetchDatabases(t *testing.T) {
 
 	tb1 := base.GetTestBucket(t)
 	defer tb1.Close()
-	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1, PersistentConfig: true, serverless: true,
+	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1.NoCloseClone(), PersistentConfig: true, serverless: true,
 		MutateStartupConfig: func(config *StartupConfig) {
 			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0)
 		},
@@ -211,7 +211,7 @@ func TestServerlessGoCBConnectionString(t *testing.T) {
 				tb.BucketSpec.KvPoolSize = 3
 			}
 
-			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, PersistentConfig: true, serverless: true})
+			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, serverless: true})
 			defer rt.Close()
 			sc := rt.ServerContext()
 			require.True(t, sc.Config.IsServerless())
@@ -255,7 +255,7 @@ func TestServerlessUnsupportedOptions(t *testing.T) {
 			bucketServer := tb.BucketSpec.Server
 			test.expectedConnStr = bucketServer + test.expectedConnStr
 
-			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, PersistentConfig: true, serverless: true})
+			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, serverless: true})
 			defer rt.Close()
 			sc := rt.ServerContext()
 			require.True(t, sc.Config.IsServerless())
@@ -285,7 +285,7 @@ func TestServerlessSuspendDatabase(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
 
-	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, PersistentConfig: true, serverless: true})
+	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, serverless: true})
 	defer rt.Close()
 
 	sc := rt.ServerContext()
@@ -356,7 +356,7 @@ func TestServerlessUnsuspendFetchFallback(t *testing.T) {
 	defer tb.Close()
 
 	rt := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: tb,
+		CustomTestBucket: tb.NoCloseClone(),
 		serverless:       true,
 		PersistentConfig: true,
 		MutateStartupConfig: func(config *StartupConfig) {
@@ -567,7 +567,7 @@ func TestSuspendingFlags(t *testing.T) {
 			tb := base.GetTestBucket(t)
 			defer tb.Close()
 
-			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, PersistentConfig: true, serverless: test.serverlessMode})
+			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, serverless: test.serverlessMode})
 			defer rt.Close()
 
 			sc := rt.ServerContext()
@@ -610,7 +610,7 @@ func TestServerlessUnsuspendAPI(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
 
-	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, PersistentConfig: true, serverless: true})
+	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, serverless: true})
 	defer rt.Close()
 
 	sc := rt.ServerContext()
@@ -647,7 +647,7 @@ func TestServerlessUnsuspendAdminAuth(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
 
-	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, PersistentConfig: true, serverless: true, AdminInterfaceAuthentication: true})
+	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, serverless: true, AdminInterfaceAuthentication: true})
 	defer rt.Close()
 
 	sc := rt.ServerContext()
@@ -721,7 +721,7 @@ func TestImportPartitionsServerless(t *testing.T) {
 
 			tb := base.GetTestBucket(t)
 			defer tb.Close()
-			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, PersistentConfig: true, serverless: test.serverless})
+			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, serverless: test.serverless})
 			defer rt.Close()
 			sc := rt.ServerContext()
 


### PR DESCRIPTION
Adds a new database registry document to the bucket that lists the set of databases defined for the bucket (across all config groups), and their associated collections.  The registry is used by persistent config polling to find all configs for a given bucket.

The registry is also used for cross-database config validation.  Currently the only validation is to ensure collections aren’t assigned to multiple databases (in separate config groups).

To synchronize access to the registry and ensure values are kept in step with the associated config files, changes were required to how the bootstrap manager interacts with config files.

The low-level config file operations in BootstrapConnection were made more generic so that they could be used for modifying both config and registry files. A new API (ConfigManager), implemented by bootstrapContext in REST, should be used for all mutations to config files.  It includes handling for failure cases (including but not limited to node failure between registry and database config updates).

CBG-2343

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1539/
