### PR TITLE
CBG-2679 use 3.0 metadata for in memory implementations as well

### DIFF
--- a/base/cbgt.go
+++ b/base/cbgt.go
@@ -1,0 +1,21 @@
+package base
+
+import (
+	"fmt"
+
+	"github.com/couchbase/cbgt"
+)
+
+// NewCbgtCfgMem runs cbgt.NewCfgMem and sets the matching version number we expect for Sync Gateway.
+func NewCbgtCfgMem() (*cbgt.CfgMem, error) {
+	cfg := cbgt.NewCfgMem()
+	cas, err := cfg.Set(cbgt.VERSION_KEY, []byte(SGCbgtMetadataVersion), 0)
+	if err != nil {
+		return nil, err
+	}
+	expectedCas := uint64(1)
+	if cas != uint64(1) {
+		return nil, fmt.Errorf("Expected cas value %d, got: %d", expectedCas, cas)
+	}
+	return cfg, nil
+}

--- a/base/cbgt.go
+++ b/base/cbgt.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/cbgt.go
+++ b/base/cbgt.go
@@ -9,21 +9,15 @@
 package base
 
 import (
-	"fmt"
-
 	"github.com/couchbase/cbgt"
 )
 
 // NewCbgtCfgMem runs cbgt.NewCfgMem and sets the matching version number we expect for Sync Gateway.
 func NewCbgtCfgMem() (*cbgt.CfgMem, error) {
 	cfg := cbgt.NewCfgMem()
-	cas, err := cfg.Set(cbgt.VERSION_KEY, []byte(SGCbgtMetadataVersion), 0)
+	_, err := cfg.Set(cbgt.VERSION_KEY, []byte(SGCbgtMetadataVersion), 0)
 	if err != nil {
 		return nil, err
-	}
-	expectedCas := uint64(1)
-	if cas != uint64(1) {
-		return nil, fmt.Errorf("Expected cas value %d, got: %d", expectedCas, cas)
 	}
 	return cfg, nil
 }

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -151,7 +151,8 @@ func TestCBGTIndexCreation(t *testing.T) {
 
 			// Use an in-memory cfg, set up cbgt manager
 			ctx := LogContextWith(TestCtx(t), &DatabaseLogContext{DatabaseName: tc.dbName})
-			cfg := cbgt.NewCfgMem()
+			cfg, err := NewCbgtCfgMem()
+			require.NoError(t, err)
 			context, err := initCBGTManager(ctx, bucket, spec, cfg, "testIndexCreation", tc.dbName)
 			assert.NoError(t, err)
 			defer context.RemoveFeedCredentials(tc.dbName)
@@ -255,7 +256,8 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 
 	// Use an in-memory cfg, set up cbgt manager
 	ctx := TestCtx(t)
-	cfg := cbgt.NewCfgMem()
+	cfg, err := NewCbgtCfgMem()
+	require.NoError(t, err)
 	context, err := initCBGTManager(ctx, bucket, spec, cfg, "testIndexCreation", testDbName)
 	assert.NoError(t, err)
 	defer context.RemoveFeedCredentials(testDbName)
@@ -332,7 +334,8 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 
 	// Use an in-memory cfg, set up cbgt manager
 	ctx := TestCtx(t)
-	cfg := cbgt.NewCfgMem()
+	cfg, err := NewCbgtCfgMem()
+	require.NoError(t, err)
 	context, err := initCBGTManager(ctx, bucket, spec, cfg, "testIndexCreation", unsafeTestDBName)
 	assert.NoError(t, err)
 	defer context.RemoveFeedCredentials(unsafeTestDBName)

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -336,9 +336,12 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 	options := make(map[string]string)
 	options[cbgt.FeedAllotmentOption] = cbgt.FeedAllotmentOnePerPIndex
 	options["managerLoadDataDir"] = "false"
+	cfg, err := NewCbgtCfgMem()
+	require.NoError(t, err)
+
 	testManager := cbgt.NewManagerEx(
 		SGCbgtMetadataVersion,
-		cbgt.NewCfgMem(),
+		cfg,
 		testUUID,
 		nil,
 		"",

--- a/db/database.go
+++ b/db/database.go
@@ -453,7 +453,11 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		}
 		dbContext.CfgSG = sgCfg
 	} else {
-		dbContext.CfgSG = cbgt.NewCfgMem()
+		sgCfg, err := base.NewCbgtCfgMem()
+		if err != nil {
+			return nil, err
+		}
+		dbContext.CfgSG = sgCfg
 	}
 
 	// Initialize the tap Listener for notify handling


### PR DESCRIPTION
Fixes https://jenkins.sgwdev.com/job/MasterIntegration/387/testReport/junit/github/com_couchbase_sync_gateway_base/TestCBGTIndexCreationSafeLegacyName/

I could reproduce with `-count 100`

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1528/
