### PR TITLE
Always drop indexes on a non metadata collection

### DIFF
--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -104,10 +104,6 @@ type LeakyBucketConfig struct {
 	DDocDeleteErrorCount int
 	DDocGetErrorCount    int
 
-	// Allows us to force a specific index to be deleted. We will always error when attempting to delete an index if its
-	// name is specified in this slice
-	DropIndexErrorNames []string
-
 	// Emulate TAP/DCP feed de-dupliation behavior, such that within a
 	// window of # of mutations or a timeout, mutations for a given document
 	// will be filtered such that only the _latest_ mutation will make it through.

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -359,12 +359,7 @@ func TestRemoveObsoleteIndexOnError(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
-	leakyBucket := base.NewLeakyBucket(db.Bucket, base.LeakyBucketConfig{DropIndexErrorNames: []string{"sg_access_1", "sg_access_x1"}})
-
-	// TODO: CBG-2533 Multi-collection removal (iterate over each collection here?)
-	dataStore := db.Bucket.DefaultDataStore()
-
-	leakyDataStore := base.NewLeakyDataStore(leakyBucket, dataStore, &base.LeakyBucketConfig{DropIndexErrorNames: []string{"sg_access_1", "sg_access_x1"}})
+	dataStore := GetSingleDatabaseCollection(t, db.DatabaseContext).dataStore
 
 	defer func() {
 		// Restore indexes after test
@@ -398,7 +393,7 @@ func TestRemoveObsoleteIndexOnError(t *testing.T) {
 	channelIndex.previousVersions = []int{1}
 	testIndexes[IndexChannels] = channelIndex
 
-	n1qlStore, ok := base.AsN1QLStore(leakyDataStore)
+	n1qlStore, ok := base.AsN1QLStore(dataStore)
 	require.True(t, ok)
 
 	removedIndex, removeErr := removeObsoleteIndexes(n1qlStore, false, db.UseXattrs(), db.UseViews(), testIndexes)


### PR DESCRIPTION
This was broken by https://github.com/couchbase/sync_gateway/pull/6103. I removed some code that was already dead too.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1532/
