### PR TITLE
CBG-2321 Namespace sequence metadata keys

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -2787,7 +2787,7 @@ func TestInvalidateRoles(t *testing.T) {
 
 	// Ensure the inval seq was set to 5 (raw get to avoid rebuild)
 	var userOut userImpl
-	_, err = leakyDataStore.Get(docIDForUser("user"), &userOut)
+	_, err = leakyDataStore.Get(auth.DocIDForUser("user"), &userOut)
 	assert.NoError(t, err)
 
 	var expectedValue uint64
@@ -2803,7 +2803,7 @@ func TestInvalidateRoles(t *testing.T) {
 	err = auth.InvalidateRoles("user", 20)
 	assert.NoError(t, err)
 
-	_, err = leakyDataStore.Get(docIDForUser("user"), &userOut)
+	_, err = leakyDataStore.Get(auth.DocIDForUser("user"), &userOut)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedValue, userOut.GetRoleInvalSeq())
 }
@@ -2876,11 +2876,18 @@ func TestInvalidateChannels(t *testing.T) {
 			var princCheck Principal
 			var docID string
 			if testCase.isUser {
-				princCheck = &userImpl{}
-				docID = docIDForUser(testCase.name)
+				docID = auth.DocIDForUser(testCase.name)
+				princCheck = &userImpl{
+					roleImpl: roleImpl{
+						docID: docID,
+					},
+				}
+
 			} else {
-				princCheck = &roleImpl{}
-				docID = docIDForRole(testCase.name)
+				docID = auth.DocIDForRole(testCase.name)
+				princCheck = &roleImpl{
+					docID: docID,
+				}
 			}
 			_, err = leakyDataStore.Get(docID, &princCheck)
 			assert.NoError(t, err)

--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -86,7 +86,7 @@ func TestDeleteSession(t *testing.T) {
 		Ttl:        24 * time.Hour,
 	}
 	const noSessionExpiry = 0
-	assert.NoError(t, dataStore.Set(DocIDForSession(mockSession.ID), noSessionExpiry, nil, mockSession))
+	assert.NoError(t, dataStore.Set(auth.DocIDForSession(mockSession.ID), noSessionExpiry, nil, mockSession))
 	assert.NoError(t, auth.DeleteSession(mockSession.ID))
 
 	// Just to verify the session has been deleted gracefully.

--- a/auth/user.go
+++ b/auth/user.go
@@ -69,6 +69,7 @@ func IsValidEmail(email string) bool {
 func (auth *Authenticator) defaultGuestUser() User {
 	user := &userImpl{
 		roleImpl: roleImpl{
+			docID:             auth.DocIDForUser(""),
 			ExplicitChannels_: ch.AtSequence(make(base.Set, 0), 1),
 		},
 		userImplBody: userImplBody{
@@ -87,6 +88,9 @@ func (auth *Authenticator) NewUser(username string, password string, channels ba
 	user := &userImpl{
 		auth:         auth,
 		userImplBody: userImplBody{RolesSince_: ch.TimedSet{}},
+		roleImpl: roleImpl{
+			docID: auth.DocIDForUser(username),
+		},
 	}
 	if err := user.initRole(username, channels, auth.Collections); err != nil {
 		return nil, err
@@ -114,6 +118,9 @@ func (auth *Authenticator) NewUserNoChannels(username string, password string) (
 	user := &userImpl{
 		auth:         auth,
 		userImplBody: userImplBody{RolesSince_: ch.TimedSet{}},
+		roleImpl: roleImpl{
+			docID: auth.DocIDForUser(username),
+		},
 	}
 	if err := user.initRole(username, nil, nil); err != nil {
 		return nil, err
@@ -149,14 +156,6 @@ func (user *userImpl) validate() error {
 		}
 	}
 	return nil
-}
-
-func docIDForUser(username string) string {
-	return base.UserPrefix + username
-}
-
-func (user *userImpl) DocID() string {
-	return docIDForUser(user.Name_)
 }
 
 // Key used in 'access' view (not same meaning as doc ID)

--- a/base/constants.go
+++ b/base/constants.go
@@ -191,7 +191,7 @@ var (
 	ErrUnknownField = errors.New("unrecognized JSON field")
 
 	// MaxPrincipalNameLen is the maximum length for user and role names, accounting for internal prefixes, and is used to validate CRUD
-	MaxPrincipalNameLen = 250 - Max(len(UserPrefix), len(RolePrefix))
+	MaxPrincipalNameLen = 250 - Max(len(UserPrefixRoot), len(RolePrefixRoot))
 )
 
 // UnitTestUrl returns the configured test URL.

--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -11,42 +11,328 @@ licenses/APL2.txt.
 package base
 
 import (
+	"errors"
 	"fmt"
+	"strconv"
 )
 
-const SyncDocPrefix = "_sync:" // SyncDocPrefix is a common prefix for all Sync Gateway metadata documents
+const SyncDocPrefix = "_sync:"                                 // Prefix for all legacy (non-namespaced) Sync Gateway metadata documents
+const MetadataIdPrefix = "m_"                                  // Prefix for metadataId, to prevent collisions between namespaced and non-namespaced metadata documents
+const SyncDocMetadataPrefix = SyncDocPrefix + MetadataIdPrefix // Prefix for all namespaced Sync Gateway metadata documents
+const DCPCheckpointPrefix = "dcp_ck:"
 
-// Sync Gateway Metadata documents
+// Sync Gateway Metadata document types
+type metadataKey int
+
 const (
-	SyncSeqKey                       = SyncDocPrefix + "seq"                           // SyncSeqKey is a counter document storing the SG sequence number of a collection
-	UnusedSeqPrefix                  = SyncDocPrefix + "unusedSeq:"                    // UnusedSeqPrefix stores a sequence that was reserved by SG but was unused
-	UnusedSeqRangePrefix             = SyncDocPrefix + "unusedSeqs:"                   // UnusedSeqRangePrefix stores a sequence range that was reserved by SG but was unused
-	RevBodyPrefix                    = SyncDocPrefix + "rb:"                           // RevBodyPrefix stores a conflicting revision's body
-	RevPrefix                        = SyncDocPrefix + "rev:"                          // RevPrefix stores an old revision's body for temporary lookup (in-flight requests or delta sync)
-	BackgroundProcessHeartbeatPrefix = SyncDocPrefix + "background_process:heartbeat:" // BackgroundProcessHeartbeatPrefix stores a background process heartbeat
-	BackgroundProcessStatusPrefix    = SyncDocPrefix + "background_process:status:"    // BackgroundProcessStatusPrefix stores a background process status
-	UserPrefix                       = SyncDocPrefix + "user:"                         // UserPrefix stores user documents keyed by user name
-	RolePrefix                       = SyncDocPrefix + "role:"                         // RolePrefix stores role documents keyed by role name
-	UserEmailPrefix                  = SyncDocPrefix + "useremail:"                    // UserEmailPrefix maps a user's email to a user name for UserPrefix lookups
-	SessionPrefix                    = SyncDocPrefix + "session:"                      // SessionPrefix stores user sessions keyed by session ID
-	AttPrefix                        = SyncDocPrefix + "att:"                          // AttPrefix SG (v1) attachment data
-	Att2Prefix                       = SyncDocPrefix + "att2:"                         // Att2Prefix SG v2 attachment data
-	DCPBackfillSeqKey                = SyncDocPrefix + "dcp_backfill"                  // DCPBackfillSeqKey stores a BackfillSequences for a DCP feed
-	RepairBackupPrefix               = SyncDocPrefix + "repair:backup:"                // RepairBackupPrefix is the doc prefix used to store a backup of a repaired document
-	RepairDryRunPrefix               = SyncDocPrefix + "repair:dryrun:"                // RepairDryRunPrefix is the doc prefix used to store a repaired document in dry-run mode
-	SGRStatusPrefix                  = SyncDocPrefix + "sgrStatus:"                    // SGRStatusPrefix is the doc prefix used to store ISGR status documents
-	SGRegistryKey                    = SyncDocPrefix + "registry"                      // Registry of all SG databases defined for the bucket (for all group IDs)
+	MetaKeySeq                              metadataKey = iota // "seq"
+	MetaKeyUnusedSeq                                           // "unusedSeq:"
+	MetaKeyUnusedSeqRange                                      // "unusedSeqs:"
+	MetaKeySGRStatus                                           // "sgrStatus:"
+	MetaKeySGCfg                                               // "cfg"
+	MetaKeyHeartbeaterPrefix                                   // "hb:"
+	MetaKeyDCPBackfill                                         // "dcp_backfill"
+	MetaKeyDCPCheckpoint                                       // "dcp_ck:"
+	MetaKeyBackgroundProcessHeartbeatPrefix                    // "background_process:heartbeat:"
+	MetaKeyBackgroundProcessStatusPrefix                       // "background_process:status:"
+	MetaKeyUserPrefix                                          // "user:"
+	MetaKeyRolePrefix                                          // "role:"
+	MetaKeyUserEmailPrefix                                     // "useremail:"
+	MetaKeySessionPrefix                                       // "session:"
 )
 
-// Sync Gateway Metadata documents that should be GroupID scoped and accessed via the "WithGroupID" helper methods below
+var metadataKeyNames = []string{
+	"seq",                           // counter document storing the sequence number for a database
+	"unusedSeq:",                    // stores a sequence that was reserved by SG but was unused
+	"unusedSeqs:",                   // stores a sequence range that was reserved by SG but was unused
+	"sgrStatus:",                    // document prefix used to store ISGR status documents
+	"cfg",                           // document prefix used to store CfgSG/cbgt data
+	"hb:",                           // document prefix used to store SG node heartbeat documents
+	"dcp_backfill",                  // stores BackfillSequences for a DCP feed,\
+	DCPCheckpointPrefix,             // stores a DCP checkpoint
+	"background_process:heartbeat:", // stores a background process heartbeat
+	"background_process:status:",    // stores a background process status
+	"user:",                         // stores a user
+	"role:",                         // stores a role
+	"useremail:",                    // stores a role
+	"session:",                      // stores a session
+
+}
+
+func (m metadataKey) String() string {
+	return metadataKeyNames[m]
+}
+
 const (
-	DCPCheckpointPrefixWithoutGroupID       = SyncDocPrefix + "dcp_ck:"             // DCPCheckpointPrefixWithoutGroupID stores a DCP checkpoint
-	SGCfgPrefixWithoutGroupID               = SyncDocPrefix + "cfg"                 // SGCfgPrefixWithoutGroupID stores CfgSG/cbgt data
-	HeartbeaterPrefixWithoutGroupID         = SyncDocPrefix                         // HeartbeaterPrefixWithoutGroupID stores a SG node heartbeat document
-	PersistentConfigPrefixWithoutGroupID    = SyncDocPrefix + "dbconfig:"           // PersistentConfigPrefixWithoutGroupID stores a database config
+	UserPrefixRoot    = SyncDocPrefix + "user:"    // UserPrefix stores user documents keyed by username
+	RolePrefixRoot    = SyncDocPrefix + "role:"    // RolePrefix stores role documents keyed by role name
+	SessionPrefixRoot = SyncDocPrefix + "session:" // SessionPrefix stores user sessions keyed by session ID
+)
+
+// The following collection-scoped metadata documents are stored with the collection, don't require MetadataKeys handling
+const (
+	RevBodyPrefix = SyncDocPrefix + "rb:"   // RevBodyPrefix stores a conflicting revision's body
+	RevPrefix     = SyncDocPrefix + "rev:"  // RevPrefix stores an old revision's body for temporary lookup (in-flight requests or delta sync)
+	AttPrefix     = SyncDocPrefix + "att:"  // AttPrefix SG (v1) attachment data
+	Att2Prefix    = SyncDocPrefix + "att2:" // Att2Prefix SG v2 attachment data
+)
+
+// The following keys and prefixes don't require MetadataKeys handling as they are cross-database or have
+// custom handling for database namespacing
+const (
+	DCPCheckpointRootPrefix              = SyncDocPrefix + DCPCheckpointPrefix // used to filter checkpoints across groupIDs, databases
+	SGRegistryKey                        = SyncDocPrefix + "registry"          // Registry of all SG databases defined for the bucket (for all group IDs)
+	PersistentConfigPrefixWithoutGroupID = SyncDocPrefix + "dbconfig:"         // PersistentConfigPrefixWithoutGroupID stores a database config
+
+	// Sync function naming is collection-scoped, and collections cannot be associated with multiple databases
 	SyncFunctionKeyWithoutGroupID           = SyncDocPrefix + "syncdata"            // SyncFunctionKeyWithoutGroupID stores a copy of the Sync Function
 	CollectionSyncFunctionKeyWithoutGroupID = SyncDocPrefix + "syncdata_collection" // CollectionSyncFunctionKeyWithoutGroupID stores a copy of the Sync Function
 )
+
+// MetadataKeys defines metadata keys and prefixes for a database, for a given metadataID.  Each Sync Gateway database
+// uses a unique metadataID, but may share the same MetadataStore.  MetadataKeys implements key namespacing for that
+// MetadataStore.
+type MetadataKeys struct {
+	metadataID                string
+	syncSeq                   string
+	unusedSeqPrefix           string
+	unusedSeqRangePrefix      string
+	sgrStatusPrefix           string
+	heartbeaterPrefix         string
+	persistentConfigPrefix    string
+	sgCfgPrefix               string
+	dcpBackfill               string
+	dcpCheckpoint             string
+	backgroundHeartbeatPrefix string
+	backgroundStatusPrefix    string
+	userPrefix                string
+	rolePrefix                string
+	userEmailPrefix           string
+	sessionPrefix             string
+}
+
+// DefaultMetadataKeys defines the legacy metadata keys and prefixes.  These are used when the metadata collection is the only
+// defined collection, including upgrade scenarios.
+var DefaultMetadataKeys = &MetadataKeys{
+	metadataID:                "",
+	syncSeq:                   formatDefaultMetadataKey(MetaKeySeq),
+	unusedSeqPrefix:           formatDefaultMetadataKey(MetaKeyUnusedSeq),
+	unusedSeqRangePrefix:      formatDefaultMetadataKey(MetaKeyUnusedSeqRange),
+	sgrStatusPrefix:           formatDefaultMetadataKey(MetaKeySGRStatus),
+	sgCfgPrefix:               formatDefaultMetadataKey(MetaKeySGCfg),
+	heartbeaterPrefix:         SyncDocPrefix, // Default heartbeater prefix does not use MetaKeyHeartbeaterPrefix for backward compatibility with 3.0 and earlier
+	dcpBackfill:               formatDefaultMetadataKey(MetaKeyDCPBackfill),
+	dcpCheckpoint:             formatDefaultMetadataKey(MetaKeyDCPCheckpoint),
+	backgroundHeartbeatPrefix: formatDefaultMetadataKey(MetaKeyBackgroundProcessHeartbeatPrefix),
+	backgroundStatusPrefix:    formatDefaultMetadataKey(MetaKeyBackgroundProcessStatusPrefix),
+	userPrefix:                formatDefaultMetadataKey(MetaKeyUserPrefix),
+	rolePrefix:                formatDefaultMetadataKey(MetaKeyRolePrefix),
+	userEmailPrefix:           formatDefaultMetadataKey(MetaKeyUserEmailPrefix),
+	sessionPrefix:             formatDefaultMetadataKey(MetaKeySessionPrefix),
+}
+
+// NewMetadataKeys returns MetadataKeys for the specified MetadataID  If metadataID is empty string, returns the default (legacy) metadata keys.
+// Key and prefix formatting is done in this constructor to minimize the work done per retrieval.
+func NewMetadataKeys(metadataID string) *MetadataKeys {
+	if metadataID == "" {
+		return DefaultMetadataKeys
+	} else {
+		return &MetadataKeys{
+			metadataID:                metadataID,
+			syncSeq:                   formatMetadataKey(metadataID, MetaKeySeq),
+			unusedSeqPrefix:           formatMetadataKey(metadataID, MetaKeyUnusedSeq),
+			unusedSeqRangePrefix:      formatMetadataKey(metadataID, MetaKeyUnusedSeqRange),
+			sgrStatusPrefix:           formatMetadataKey(metadataID, MetaKeySGRStatus),
+			heartbeaterPrefix:         formatMetadataKey(metadataID, MetaKeyHeartbeaterPrefix),
+			sgCfgPrefix:               formatMetadataKey(metadataID, MetaKeySGCfg),
+			dcpBackfill:               formatMetadataKey(metadataID, MetaKeyDCPBackfill),
+			dcpCheckpoint:             formatInvertedMetadataKey(metadataID, MetaKeyDCPCheckpoint),
+			backgroundHeartbeatPrefix: formatMetadataKey(metadataID, MetaKeyBackgroundProcessHeartbeatPrefix),
+			backgroundStatusPrefix:    formatMetadataKey(metadataID, MetaKeyBackgroundProcessStatusPrefix),
+			userPrefix:                formatInvertedMetadataKey(metadataID, MetaKeyUserPrefix),
+			rolePrefix:                formatInvertedMetadataKey(metadataID, MetaKeyRolePrefix),
+			userEmailPrefix:           formatInvertedMetadataKey(metadataID, MetaKeyUserEmailPrefix),
+			sessionPrefix:             formatInvertedMetadataKey(metadataID, MetaKeySessionPrefix),
+		}
+	}
+}
+
+// SyncSeqKey returns the key for the sequence counter document for a database
+//
+//	format: _sync:{m_$}:seq
+func (m *MetadataKeys) SyncSeqKey() string {
+	return m.syncSeq
+}
+
+// UnusedSeqKey returns the key used to store an unused sequence document for sequence seq.
+// These documents are used to release sequences that are allocated but not used, so that they may be
+// accounted for by all SG nodes in the cluster.
+//
+//	format: _sync:{m_$}:unusedSeq:[seq]
+func (m *MetadataKeys) UnusedSeqKey(seq uint64) string {
+	return m.unusedSeqPrefix + strconv.FormatUint(seq, 10)
+}
+
+// UnusedSeqPrefix returns just the prefix used for UnusedSeqKey documents (used for DCP filtering)
+//
+//	format: _sync:{m_$}:unusedSeq:
+func (m *MetadataKeys) UnusedSeqPrefix() string {
+	return m.unusedSeqPrefix
+}
+
+// ReplicationStatusKey generates the key used to store status information for an ISGR replication.  If replicationID
+// is 40 characters or longer, an SHA-1 hash of the replicationID is used in the status key.
+// If the replicationID is less than 40 characters, the ID can be used directly without worrying about final key length
+// or collision with other sha-1 hashes.
+//
+//	format: _sync:{m_$}:sgrStatus:[replicationID]
+func (m *MetadataKeys) ReplicationStatusKey(replicationID string) string {
+	statusKeyID := replicationID
+	if len(statusKeyID) >= 40 {
+		statusKeyID = Sha1HashString(replicationID, "")
+	}
+	return m.sgrStatusPrefix + statusKeyID
+}
+
+// HeartbeaterPrefix returns a document prefix to use for heartbeat documents
+//
+//	format: _sync:{m_$}:hb:[groupID]:   (collections)
+//	format: _sync:[groupID]:   (default)
+func (m *MetadataKeys) HeartbeaterPrefix(groupID string) string {
+	if groupID != "" {
+		return m.heartbeaterPrefix + groupID + ":"
+	}
+	return m.heartbeaterPrefix
+}
+
+// SGCfgPrefix returns a document prefix to use for cfg documents (cbgt)
+//
+//	format: _sync:{m_$}:hb:[groupID]:   (collections)
+//	format: _sync:[groupID]:   (default)
+func (m *MetadataKeys) SGCfgPrefix(groupID string) string {
+	if groupID != "" {
+		return m.sgCfgPrefix + groupID + ":"
+	}
+	return m.sgCfgPrefix
+}
+
+// PersistentConfigKey returns a document key to use for persisted database configurations
+//
+//	format: _sync:{m_$}:db_config:[groupID]
+func (m *MetadataKeys) PersistentConfigKey(groupID string) (string, error) {
+
+	if groupID == "" {
+		return "", errors.New("PersistentConfigKey requires a group ID, even if it's just `default`")
+	}
+	return m.persistentConfigPrefix + groupID, nil
+}
+
+// UnusedSeqRangeKey returns the key used to store an unused sequence document for sequence seq.
+// These documents are used to release sequences that are allocated but not used, so that they may be
+// accounted for by all SG nodes in the cluster.
+//
+//	format: _sync:{m_$}:unusedSeqs:[fromSeq]:[toSeq]
+func (m *MetadataKeys) UnusedSeqRangeKey(fromSeq, toSeq uint64) string {
+
+	return m.unusedSeqRangePrefix + strconv.FormatUint(fromSeq, 10) + ":" + strconv.FormatUint(toSeq, 10)
+}
+
+// UnusedSeqRangePrefix returns just the prefix used for UnusedSeqRangeKey documents (used for DCP filtering)
+//
+//	format: _sync:{m_$}:unusedSeqs:
+func (m *MetadataKeys) UnusedSeqRangePrefix() string {
+	return m.unusedSeqRangePrefix
+}
+
+// DCPCheckpointPrefix returns the prefix used to store DCP checkpoints.
+//
+//	format: _sync:dcp_ck:{m_$}:groupID:
+func (m *MetadataKeys) DCPCheckpointPrefix(groupID string) string {
+	if groupID != "" {
+		return m.dcpCheckpoint + groupID + ":"
+	}
+	return m.dcpCheckpoint
+}
+
+// DCPBackfillKey returns the key used to store DCP backfill statistics.
+//
+//	format: _sync:{m_$}:dcp_backfill
+func (m *MetadataKeys) DCPBackfillKey() string {
+	return m.dcpBackfill
+}
+
+// UserKey returns the key used to store a user document
+//
+//	format: _sync:user:{m_$}:{username}
+func (m *MetadataKeys) UserKey(username string) string {
+	return m.userPrefix + username
+}
+
+// UserKeyPrefix returns the prefix used to store a user document
+//
+//	format: _sync:user:{m_$}:
+func (m *MetadataKeys) UserKeyPrefix() string {
+	return m.userPrefix
+}
+
+// RoleKey returns the key used to store a role document
+//
+//	format: _sync:role:{m_$}:{rolename}
+func (m *MetadataKeys) RoleKey(name string) string {
+	return m.rolePrefix + name
+}
+
+// RoleKeyPrefix returns the prefix used to store a role document
+//
+//	format: _sync:role:{m_$}:
+func (m *MetadataKeys) RoleKeyPrefix() string {
+	return m.rolePrefix
+}
+
+// UserEmailKey returns the key used to store a user email document
+//
+//	format: _sync:useremail:{m_$}:{username}
+func (m *MetadataKeys) UserEmailKey(username string) string {
+	return m.userEmailPrefix + username
+}
+
+// SessionKey returns the key used to store a session document
+//
+//	format: _sync:session:{m_$}:{sessionID}
+func (m *MetadataKeys) SessionKey(sessionID string) string {
+	return m.sessionPrefix + sessionID
+}
+
+// BackgroundProcessHeartbeatPrefix returns the prefix used to store background process heartbeats.
+//
+//	format: _sync:{m_$}:background_process:heartbeat:[processSuffix]
+func (m *MetadataKeys) BackgroundProcessHeartbeatPrefix(processSuffix string) string {
+	return m.backgroundHeartbeatPrefix + processSuffix
+}
+
+// BackgroundProcessStatusPrefix returns the prefix used to store background process status documents.
+//
+//	format: _sync:{m_$}:background_process:status:[processSuffix]
+func (m *MetadataKeys) BackgroundProcessStatusPrefix(processSuffix string) string {
+	return m.backgroundStatusPrefix + processSuffix
+}
+
+// formatMetadataKey formats key into the form _sync:m_[metadataID]:[metaKey]
+func formatMetadataKey(metadataPrefix string, metaKey metadataKey) string {
+	return SyncDocMetadataPrefix + metadataPrefix + ":" + metaKey.String()
+}
+
+// formatInvertedMetadataKey formats key into the form _sync:[metaKey][m_metadataID]:
+// Used for documents that require consistent prefixing across databases, typically
+// for indexing or key filtering
+func formatInvertedMetadataKey(metadataPrefix string, metaKey metadataKey) string {
+	return SyncDocPrefix + metaKey.String() + metadataPrefix + ":"
+}
+
+// formatDefaultMetadataKey formats key into the form _sync:[metaKey]
+func formatDefaultMetadataKey(metaKey metadataKey) string {
+	return SyncDocPrefix + metaKey.String()
+}
 
 // SyncFunctionKeyWithGroupID returns a doc ID to use when storing the sync function
 func SyncFunctionKeyWithGroupID(groupID string) string {
@@ -56,7 +342,7 @@ func SyncFunctionKeyWithGroupID(groupID string) string {
 	return SyncFunctionKeyWithoutGroupID
 }
 
-// CollectionsSyncFunctionKeyWithGroupID returns a doc ID to use when storing the sync function.
+// CollectionSyncFunctionKeyWithGroupID returns a doc ID to use when storing the sync function.
 func CollectionSyncFunctionKeyWithGroupID(groupID string, scopeName, collectionName string) string {
 	// use legacy format for _default._default for backward compatibility
 	if IsDefaultCollection(scopeName, collectionName) {
@@ -66,28 +352,4 @@ func CollectionSyncFunctionKeyWithGroupID(groupID string, scopeName, collectionN
 		return fmt.Sprintf("%s:%s.%s:%s", CollectionSyncFunctionKeyWithoutGroupID, scopeName, collectionName, groupID)
 	}
 	return fmt.Sprintf("%s:%s.%s", CollectionSyncFunctionKeyWithoutGroupID, scopeName, collectionName)
-}
-
-// DCPCheckpointPrefixWithGroupID returns a doc ID prefix to use for DCP checkpoints
-func DCPCheckpointPrefixWithGroupID(groupID string) string {
-	if groupID != "" {
-		return DCPCheckpointPrefixWithoutGroupID + groupID + ":"
-	}
-	return DCPCheckpointPrefixWithoutGroupID
-}
-
-// SGCfgPrefixWithGroupID returns a doc ID prefix to use for CfgSG/cbgt documents
-func SGCfgPrefixWithGroupID(groupID string) string {
-	if groupID != "" {
-		return SGCfgPrefixWithoutGroupID + ":" + groupID + ":"
-	}
-	return SGCfgPrefixWithoutGroupID
-}
-
-// HeartbeaterPrefixWithGroupID returns a document prefix to use for heartbeat documents
-func HeartbeaterPrefixWithGroupID(groupID string) string {
-	if groupID != "" {
-		return HeartbeaterPrefixWithoutGroupID + groupID + ":"
-	}
-	return HeartbeaterPrefixWithoutGroupID
 }

--- a/base/constants_syncdocs_test.go
+++ b/base/constants_syncdocs_test.go
@@ -10,8 +10,10 @@ package base
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,5 +52,13 @@ func TestCollectionSyncFunctionKeyWithGroupID(t *testing.T) {
 		t.Run(fmt.Sprintf("%s.%s_GroupID:%s", test.scopeName, test.collectionName, test.groupID), func(t *testing.T) {
 			require.Equal(t, test.key, CollectionSyncFunctionKeyWithGroupID(test.groupID, test.scopeName, test.collectionName))
 		})
+	}
+}
+
+func TestMetaKeyNames(t *testing.T) {
+
+	// Validates that metadata keys aren't prefixed with MetadataIdPrefix
+	for _, metaKeyName := range metadataKeyNames {
+		assert.False(t, strings.HasPrefix(metaKeyName, MetadataIdPrefix))
 	}
 }

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -69,6 +69,7 @@ type DCPCommon struct {
 	m                      sync.Mutex
 	couchbaseStore         CouchbaseBucketStore
 	metaStore              DataStore                      // For metadata persistence/retrieval
+	metaKeys               *MetadataKeys                  // Metadata key generator for filtering and checkpoints
 	maxVbNo                uint16                         // Number of vbuckets being used for this feed
 	persistCheckpoints     bool                           // Whether this DCPReceiver should persist metadata to the bucket
 	seqs                   []uint64                       // To track max seq #'s we received per vbucketId.
@@ -83,8 +84,11 @@ type DCPCommon struct {
 	checkpointPrefix       string                         // DCP checkpoint key prefix
 }
 
-func NewDCPCommon(ctx context.Context, callback sgbucket.FeedEventCallbackFunc, bucket Bucket, metaStore DataStore, maxVbNo uint16, persistCheckpoints bool, dbStats *expvar.Map, feedID, checkpointPrefix string) (*DCPCommon, error) {
-	newBackfillStatus := backfillStatus{}
+func NewDCPCommon(ctx context.Context, callback sgbucket.FeedEventCallbackFunc, bucket Bucket, metaStore DataStore,
+	maxVbNo uint16, persistCheckpoints bool, dbStats *expvar.Map, feedID, checkpointPrefix string, metaKeys *MetadataKeys) (*DCPCommon, error) {
+	newBackfillStatus := backfillStatus{
+		metaKeys: metaKeys,
+	}
 
 	couchbaseStore, ok := AsCouchbaseBucketStore(bucket)
 	if !ok {
@@ -95,6 +99,7 @@ func NewDCPCommon(ctx context.Context, callback sgbucket.FeedEventCallbackFunc, 
 		dbStatsExpvars:         dbStats,
 		couchbaseStore:         couchbaseStore,
 		metaStore:              metaStore,
+		metaKeys:               metaKeys,
 		maxVbNo:                maxVbNo,
 		persistCheckpoints:     persistCheckpoints,
 		seqs:                   make([]uint64, maxVbNo),
@@ -379,15 +384,16 @@ func (c *DCPCommon) seedSeqnos(uuids map[uint16]uint64, seqs map[uint16]uint64) 
 
 // BackfillStatus manages tracking of DCP backfill progress, to provide diagnostics and mid-snapshot restart capability
 type backfillStatus struct {
-	active            bool        // Whether this DCP feed is in backfill
-	vbActive          []bool      // Whether a vbucket is in backfill
-	receivedSequences uint64      // Number of backfill sequences received
-	expectedSequences uint64      // Expected number of sequences in backfill
-	endSeqs           []uint64    // Backfill complete sequences, indexed by vbno
-	snapStart         []uint64    // Start sequence of current backfill snapshot
-	snapEnd           []uint64    // End sequence of current backfill snapshot
-	lastPersistTime   time.Time   // The last time backfill stats were emitted (log, expvar)
-	statsMap          *expvar.Map // Stats map for backfill
+	active            bool          // Whether this DCP feed is in backfill
+	vbActive          []bool        // Whether a vbucket is in backfill
+	receivedSequences uint64        // Number of backfill sequences received
+	expectedSequences uint64        // Expected number of sequences in backfill
+	endSeqs           []uint64      // Backfill complete sequences, indexed by vbno
+	snapStart         []uint64      // Start sequence of current backfill snapshot
+	snapEnd           []uint64      // End sequence of current backfill snapshot
+	lastPersistTime   time.Time     // The last time backfill stats were emitted (log, expvar)
+	statsMap          *expvar.Map   // Stats map for backfill
+	metaKeys          *MetadataKeys // MetadataKeys for backfill
 }
 
 func (b *backfillStatus) init(start []uint64, end map[uint16]uint64, maxVbNo uint16, statsMap *expvar.Map) {
@@ -498,12 +504,12 @@ func (b *backfillStatus) persistBackfillSequences(datastore DataStore, currentSe
 		SnapStart: b.snapStart,
 		SnapEnd:   b.snapEnd,
 	}
-	return datastore.Set(DCPBackfillSeqKey, 0, nil, backfillSeqs)
+	return datastore.Set(b.metaKeys.DCPBackfillKey(), 0, nil, backfillSeqs)
 }
 
 func (b *backfillStatus) loadBackfillSequences(datastore DataStore) (*BackfillSequences, error) {
 	var backfillSeqs BackfillSequences
-	_, err := datastore.Get(DCPBackfillSeqKey, &backfillSeqs)
+	_, err := datastore.Get(b.metaKeys.DCPBackfillKey(), &backfillSeqs)
 	if err != nil {
 		return nil, err
 	}
@@ -512,7 +518,7 @@ func (b *backfillStatus) loadBackfillSequences(datastore DataStore) (*BackfillSe
 }
 
 func (b *backfillStatus) purgeBackfillSequences(datastore DataStore) error {
-	return datastore.Delete(DCPBackfillSeqKey)
+	return datastore.Delete(b.metaKeys.DCPBackfillKey())
 }
 
 // DCP-related utilities
@@ -521,7 +527,7 @@ func (b *backfillStatus) purgeBackfillSequences(datastore DataStore) error {
 // unused sequence documents.  Any other documents with the leading '_sync' prefix can be ignored.
 // dcpKeyFilter returns true for documents that should be processed, false for those that do not need processing.
 // c is used to get the SG Cfg prefix
-func dcpKeyFilter(key []byte) bool {
+func dcpKeyFilter(key []byte, metaKeys *MetadataKeys) bool {
 
 	// If it's a _txn doc, don't process
 	if bytes.HasPrefix(key, []byte(TxnPrefix)) {
@@ -534,11 +540,11 @@ func dcpKeyFilter(key []byte) bool {
 	}
 
 	// User, role, unused sequence markers and cbgt cfg (regardless of group ID) docs should be processed
-	if bytes.HasPrefix(key, []byte(UnusedSeqPrefix)) ||
-		bytes.HasPrefix(key, []byte(UnusedSeqRangePrefix)) ||
-		bytes.HasPrefix(key, []byte(UserPrefix)) ||
-		bytes.HasPrefix(key, []byte(RolePrefix)) ||
-		bytes.HasPrefix(key, []byte(SGCfgPrefixWithoutGroupID)) {
+	if bytes.HasPrefix(key, []byte(metaKeys.unusedSeqPrefix)) ||
+		bytes.HasPrefix(key, []byte(metaKeys.unusedSeqRangePrefix)) ||
+		bytes.HasPrefix(key, []byte(UserPrefixRoot)) ||
+		bytes.HasPrefix(key, []byte(RolePrefixRoot)) ||
+		bytes.HasPrefix(key, []byte(metaKeys.sgCfgPrefix)) {
 		return true
 	}
 

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -59,19 +59,34 @@ func TestTransformBucketCredentials(t *testing.T) {
 }
 
 func TestDCPKeyFilter(t *testing.T) {
-	assert.True(t, dcpKeyFilter([]byte("doc123")))
-	assert.True(t, dcpKeyFilter([]byte(UserPrefix+"user1")))
-	assert.True(t, dcpKeyFilter([]byte(RolePrefix+"role2")))
-	assert.True(t, dcpKeyFilter([]byte(UnusedSeqPrefix+"1234")))
-	assert.True(t, dcpKeyFilter([]byte(SGCfgPrefixWithGroupID("")+"123")))
-	assert.True(t, dcpKeyFilter([]byte(SGCfgPrefixWithGroupID("group")+"123")))
 
-	assert.False(t, dcpKeyFilter([]byte(SyncSeqKey)))
-	assert.False(t, dcpKeyFilter([]byte(SyncDocPrefix+"unusualSeq")))
-	assert.False(t, dcpKeyFilter([]byte(SyncFunctionKeyWithoutGroupID)))
-	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefixWithoutGroupID+"12")))
-	assert.False(t, dcpKeyFilter([]byte(TxnPrefix+"atrData")))
-	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefixWithGroupID("group")+"12")))
+	testCases := []struct {
+		name     string
+		metaKeys *MetadataKeys
+	}{
+		{"default meta keys", DefaultMetadataKeys},
+		{"default meta keys from empty metaID", NewMetadataKeys("")},
+		{"db specific meta keys", NewMetadataKeys("dbname")},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s", tc.name), func(t *testing.T) {
+
+			assert.True(t, dcpKeyFilter([]byte("doc123"), tc.metaKeys))
+			assert.True(t, dcpKeyFilter([]byte(tc.metaKeys.UnusedSeqKey(1234)), tc.metaKeys))
+			assert.True(t, dcpKeyFilter([]byte(tc.metaKeys.UserKey("user1")), tc.metaKeys))
+			assert.True(t, dcpKeyFilter([]byte(tc.metaKeys.UserKey("role2")), tc.metaKeys))
+			assert.True(t, dcpKeyFilter([]byte(tc.metaKeys.SGCfgPrefix("")+"123"), tc.metaKeys))
+			assert.True(t, dcpKeyFilter([]byte(tc.metaKeys.SGCfgPrefix("group")+"123"), tc.metaKeys))
+
+			assert.False(t, dcpKeyFilter([]byte(SyncDocPrefix+"unusualSeq"), tc.metaKeys))
+			assert.False(t, dcpKeyFilter([]byte(SyncFunctionKeyWithoutGroupID), tc.metaKeys))
+			assert.False(t, dcpKeyFilter([]byte(DCPCheckpointRootPrefix+"12"), tc.metaKeys))
+			assert.False(t, dcpKeyFilter([]byte(TxnPrefix+"atrData"), tc.metaKeys))
+			assert.False(t, dcpKeyFilter([]byte(tc.metaKeys.DCPCheckpointPrefix("")+"12"), tc.metaKeys))
+			assert.False(t, dcpKeyFilter([]byte(tc.metaKeys.DCPCheckpointPrefix("group")+"12"), tc.metaKeys))
+			assert.False(t, dcpKeyFilter([]byte(tc.metaKeys.SyncSeqKey()), tc.metaKeys))
+		})
+	}
 
 }
 

--- a/base/gocb_dcp_feed.go
+++ b/base/gocb_dcp_feed.go
@@ -95,6 +95,7 @@ func StartGocbDCPFeed(bucket *GocbV2Bucket, bucketName string, args sgbucket.Fee
 			DbStats:           dbStats,
 			CollectionIDs:     collectionIDs,
 			AgentPriority:     gocbcore.DcpAgentPriorityMed,
+			CheckpointPrefix:  args.CheckpointPrefix,
 		},
 		bucket)
 	if err != nil {

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -44,7 +44,7 @@ var ErrCfgCasError = &cbgt.CfgCASError{}
 //
 // urlStr: single URL or multiple URLs delimited by ';'
 // bucket: couchbase bucket name
-func NewCfgSG(datastore sgbucket.DataStore, groupID string) (*CfgSG, error) {
+func NewCfgSG(datastore sgbucket.DataStore, keyPrefix string) (*CfgSG, error) {
 
 	cfgContextID := MD(datastore.GetName()).Redact() + "-cfgSG"
 	loggingCtx := LogContextWith(context.Background(), &LogContext{CorrelationID: cfgContextID})
@@ -53,7 +53,7 @@ func NewCfgSG(datastore sgbucket.DataStore, groupID string) (*CfgSG, error) {
 		datastore:     datastore,
 		loggingCtx:    loggingCtx,
 		subscriptions: make(map[string][]chan<- cbgt.CfgEvent),
-		keyPrefix:     SGCfgPrefixWithGroupID(groupID),
+		keyPrefix:     keyPrefix,
 	}
 
 	return c, nil

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -172,6 +172,10 @@ func (b *TestBucket) GetSingleDataStore() sgbucket.DataStore {
 	return b.Bucket.DefaultDataStore()
 }
 
+func (b *TestBucket) GetMetadataStore() sgbucket.DataStore {
+	return b.Bucket.DefaultDataStore()
+}
+
 // GetDefaultDataStore returns the default DataStore. This is likely never actually wanted over GetSingleDataStore, so is left commented until absolutely required.
 // func (b *TestBucket) GetDefaultDataStore() sgbucket.DataStore {
 // 	b.t.Logf("Using default collection - Are you sure you want this instead of GetSingleDataStore() ?")

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -129,7 +129,7 @@ func attachmentCompactMarkPhase(ctx context.Context, dataStore base.DataStore, c
 		return true
 	}
 
-	clientOptions, err := getCompactionDCPClientOptions(collectionID, db.Options.GroupID)
+	clientOptions, err := getCompactionDCPClientOptions(collectionID, db.Options.GroupID, db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID))
 	if err != nil {
 		return 0, nil, err
 	}
@@ -357,7 +357,7 @@ func attachmentCompactSweepPhase(ctx context.Context, dataStore base.DataStore, 
 		return true
 	}
 
-	clientOptions, err := getCompactionDCPClientOptions(collectionID, db.Options.GroupID)
+	clientOptions, err := getCompactionDCPClientOptions(collectionID, db.Options.GroupID, db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID))
 	if err != nil {
 		return 0, err
 	}
@@ -493,7 +493,7 @@ func attachmentCompactCleanupPhase(ctx context.Context, dataStore base.DataStore
 		return true
 	}
 
-	clientOptions, err := getCompactionDCPClientOptions(collectionID, db.Options.GroupID)
+	clientOptions, err := getCompactionDCPClientOptions(collectionID, db.Options.GroupID, db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID))
 	if err != nil {
 		return err
 	}
@@ -553,13 +553,14 @@ func getCompactionIDSubDocPath(compactionID string) string {
 }
 
 // getCompactionDCPClientOptions returns the default set of DCPClientOptions suitable for attachment compaction
-func getCompactionDCPClientOptions(collectionID uint32, groupID string) (*base.DCPClientOptions, error) {
+func getCompactionDCPClientOptions(collectionID uint32, groupID string, prefix string) (*base.DCPClientOptions, error) {
 	clientOptions := &base.DCPClientOptions{
 		OneShot:           true,
 		FailOnRollback:    true,
 		MetadataStoreType: base.DCPMetadataStoreCS,
 		GroupID:           groupID,
 		CollectionIDs:     []uint32{collectionID},
+		CheckpointPrefix:  prefix,
 	}
 	return clientOptions, nil
 

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -64,17 +64,18 @@ const (
 
 type ClusterAwareBackgroundManagerOptions struct {
 	metadataStore base.DataStore
+	metaKeys      *base.MetadataKeys
 	processSuffix string
 
 	lastSuccessfulHeartbeatUnix base.AtomicInt
 }
 
 func (b *ClusterAwareBackgroundManagerOptions) HeartbeatDocID() string {
-	return base.BackgroundProcessHeartbeatPrefix + b.processSuffix
+	return b.metaKeys.BackgroundProcessHeartbeatPrefix(b.processSuffix)
 }
 
 func (b *ClusterAwareBackgroundManagerOptions) StatusDocID() string {
-	return base.BackgroundProcessStatusPrefix + b.processSuffix
+	return b.metaKeys.BackgroundProcessStatusPrefix(b.processSuffix)
 }
 
 // BackgroundManagerStatus simply stores data used in BackgroundManager. This data can also be exposed to users over

--- a/db/background_mgr_attachment_compaction.go
+++ b/db/background_mgr_attachment_compaction.go
@@ -33,12 +33,13 @@ type AttachmentCompactionManager struct {
 
 var _ BackgroundManagerProcessI = &AttachmentCompactionManager{}
 
-func NewAttachmentCompactionManager(metadataStore base.DataStore) *BackgroundManager {
+func NewAttachmentCompactionManager(metadataStore base.DataStore, metaKeys *base.MetadataKeys) *BackgroundManager {
 	return &BackgroundManager{
 		name:    "attachment_compaction",
 		Process: &AttachmentCompactionManager{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
 			metadataStore: metadataStore,
+			metaKeys:      metaKeys,
 			processSuffix: "compact",
 		},
 		terminator: base.NewSafeTerminator(),

--- a/db/background_mgr_resync.go
+++ b/db/background_mgr_resync.go
@@ -28,12 +28,13 @@ type ResyncManager struct {
 
 var _ BackgroundManagerProcessI = &ResyncManager{}
 
-func NewResyncManager(metadataStore base.DataStore) *BackgroundManager {
+func NewResyncManager(metadataStore base.DataStore, metaKeys *base.MetadataKeys) *BackgroundManager {
 	return &BackgroundManager{
 		name:    "resync",
 		Process: &ResyncManager{},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
 			metadataStore: metadataStore,
+			metaKeys:      metaKeys,
 			processSuffix: "resync",
 		},
 		terminator: base.NewSafeTerminator(),

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -38,12 +38,13 @@ type ResyncCollections map[string][]string
 
 var _ BackgroundManagerProcessI = &ResyncManagerDCP{}
 
-func NewResyncManagerDCP(metadataStore base.DataStore, useXattrs bool) *BackgroundManager {
+func NewResyncManagerDCP(metadataStore base.DataStore, useXattrs bool, metaKeys *base.MetadataKeys) *BackgroundManager {
 	return &BackgroundManager{
 		name:    "resync",
 		Process: &ResyncManagerDCP{useXattrs: useXattrs},
 		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
 			metadataStore: metadataStore,
+			metaKeys:      metaKeys,
 			processSuffix: "resync",
 		},
 		terminator: base.NewSafeTerminator(),

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -157,7 +157,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 		base.InfofCtx(ctx, base.KeyAll, "[%s] running resync against specified collections", resyncLoggingID)
 	}
 
-	clientOptions := getReSyncDCPClientOptions(collectionIDs, db.Options.GroupID)
+	clientOptions := getReSyncDCPClientOptions(collectionIDs, db.Options.GroupID, db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID))
 
 	dcpFeedKey := generateResyncDCPStreamName(r.ResyncID)
 	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, *clientOptions, bucket)
@@ -313,13 +313,14 @@ type ResyncManagerStatusDocDCP struct {
 }
 
 // getReSyncDCPClientOptions returns the default set of DCPClientOptions suitable for resync
-func getReSyncDCPClientOptions(collectionIDs []uint32, groupID string) *base.DCPClientOptions {
+func getReSyncDCPClientOptions(collectionIDs []uint32, groupID string, prefix string) *base.DCPClientOptions {
 	return &base.DCPClientOptions{
 		OneShot:           true,
 		FailOnRollback:    true,
 		MetadataStoreType: base.DCPMetadataStoreCS,
 		GroupID:           groupID,
 		CollectionIDs:     collectionIDs,
+		CheckpointPrefix:  prefix,
 	}
 }
 

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -97,7 +97,7 @@ func TestResyncDCPInit(t *testing.T) {
 			db, ctx := setupTestDB(t)
 			defer db.Close(ctx)
 
-			resycMgr := NewResyncManagerDCP(db.MetadataStore, base.TestUseXattrs())
+			resycMgr := NewResyncManagerDCP(db.MetadataStore, base.TestUseXattrs(), db.MetadataKeys)
 			require.NotNil(t, resycMgr)
 			db.ResyncManager = resycMgr
 
@@ -153,7 +153,8 @@ func TestResyncManagerDCPStopInMidWay(t *testing.T) {
 	db, ctx := setupTestDBForResyncWithDocs(t, docsToCreate, true)
 	defer db.Close(ctx)
 
-	resycMgr := NewResyncManagerDCP(db.MetadataStore, base.TestUseXattrs())
+	resycMgr := NewResyncManagerDCP(db.MetadataStore, base.TestUseXattrs(), db.MetadataKeys)
+
 	require.NotNil(t, resycMgr)
 	db.ResyncManager = resycMgr
 
@@ -210,7 +211,8 @@ func TestResyncManagerDCPStart(t *testing.T) {
 		db, ctx := setupTestDBForResyncWithDocs(t, docsToCreate, false)
 		defer db.Close(ctx)
 
-		resyncMgr := NewResyncManagerDCP(db.MetadataStore, base.TestUseXattrs())
+		resyncMgr := NewResyncManagerDCP(db.MetadataStore, base.TestUseXattrs(), db.MetadataKeys)
+
 		require.NotNil(t, resyncMgr)
 		db.ResyncManager = resyncMgr
 
@@ -242,7 +244,7 @@ func TestResyncManagerDCPStart(t *testing.T) {
 		db, ctx := setupTestDBForResyncWithDocs(t, docsToCreate, true)
 		defer db.Close(ctx)
 
-		resyncMgr := NewResyncManagerDCP(db.MetadataStore, base.TestUseXattrs())
+		resyncMgr := NewResyncManagerDCP(db.MetadataStore, base.TestUseXattrs(), db.MetadataKeys)
 		require.NotNil(t, resyncMgr)
 
 		initialStats := getResyncStats(resyncMgr.Process)
@@ -286,7 +288,7 @@ func TestResyncManagerDCPRunTwice(t *testing.T) {
 	db, ctx := setupTestDBForResyncWithDocs(t, docsToCreate, false)
 	defer db.Close(ctx)
 
-	resycMgr := NewResyncManagerDCP(db.MetadataStore, base.TestUseXattrs())
+	resycMgr := NewResyncManagerDCP(db.MetadataStore, base.TestUseXattrs(), db.MetadataKeys)
 	require.NotNil(t, resycMgr)
 	db.ResyncManager = resycMgr
 
@@ -344,7 +346,7 @@ func TestResycnManagerDCPResumeStoppedProcess(t *testing.T) {
 	db, ctx := setupTestDBForResyncWithDocs(t, docsToCreate, true)
 	defer db.Close(ctx)
 
-	resycMgr := NewResyncManagerDCP(db.MetadataStore, base.TestUseXattrs())
+	resycMgr := NewResyncManagerDCP(db.MetadataStore, base.TestUseXattrs(), db.MetadataKeys)
 	require.NotNil(t, resycMgr)
 	db.ResyncManager = resycMgr
 

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -121,7 +121,7 @@ func (bh *blipHandler) refreshUser() error {
 				return err
 			}
 			newUser.InitializeRoles()
-			bc.userChangeWaiter.RefreshUserKeys(newUser)
+			bc.userChangeWaiter.RefreshUserKeys(newUser, bc.blipContextDb.MetadataKeys)
 			bc.blipContextDb.SetUser(newUser)
 			// refresh the handler's database with the new BlipSyncContext database
 			bh.db = bh._copyContextDatabase()

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -67,6 +67,7 @@ type changeCache struct {
 	internalStats      changeCacheStats        // Running stats for the change cache.  Only applied to expvars on a call to changeCache.updateStats
 	cfgEventCallback   base.CfgEventNotifyFunc // Callback for Cfg updates recieved over the caching feed
 	sgCfgPrefix        string                  // Prefix for SG Cfg doc keys
+	metaKeys           *base.MetadataKeys      // Metadata key formatter
 }
 
 type changeCacheStats struct {
@@ -155,7 +156,8 @@ func DefaultCacheOptions() CacheOptions {
 // notifyChange is an optional function that will be called to notify of channel changes.
 // After calling Init(), you must call .Start() to start useing the cache, otherwise it will be in a locked state
 // and callers will block on trying to obtain the lock.
-func (c *changeCache) Init(logCtx context.Context, dbContext *DatabaseContext, channelCache ChannelCache, notifyChange func(channels.Set), options *CacheOptions) error {
+
+func (c *changeCache) Init(logCtx context.Context, dbContext *DatabaseContext, channelCache ChannelCache, notifyChange func(channels.Set), options *CacheOptions, metaKeys *base.MetadataKeys) error {
 	c.db = dbContext
 	c.logCtx = logCtx
 
@@ -165,7 +167,8 @@ func (c *changeCache) Init(logCtx context.Context, dbContext *DatabaseContext, c
 	c.initTime = time.Now()
 	c.skippedSeqs = NewSkippedSequenceList()
 	c.lastAddPendingTime = time.Now().UnixNano()
-	c.sgCfgPrefix = base.SGCfgPrefixWithGroupID(c.db.Options.GroupID)
+	c.sgCfgPrefix = dbContext.MetadataKeys.SGCfgPrefix(c.db.Options.GroupID)
+	c.metaKeys = metaKeys
 
 	// init cache options
 	if options != nil {
@@ -331,21 +334,21 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	changedChannelsCombined := channels.Set{}
 
 	// ** This method does not directly access any state of c, so it doesn't lock.
-	// Is this a user/role doc?
-	if strings.HasPrefix(docID, base.UserPrefix) {
+	// Is this a user/role doc for this database?
+	if strings.HasPrefix(docID, c.metaKeys.UserKeyPrefix()) {
 		c.processPrincipalDoc(docID, docJSON, true, event.TimeReceived)
 		return
-	} else if strings.HasPrefix(docID, base.RolePrefix) {
+	} else if strings.HasPrefix(docID, c.metaKeys.RoleKeyPrefix()) {
 		c.processPrincipalDoc(docID, docJSON, false, event.TimeReceived)
 		return
 	}
 
 	// Is this an unused sequence notification?
-	if strings.HasPrefix(docID, base.UnusedSeqPrefix) {
+	if strings.HasPrefix(docID, c.metaKeys.UnusedSeqPrefix()) {
 		c.processUnusedSequence(docID, event.TimeReceived)
 		return
 	}
-	if strings.HasPrefix(docID, base.UnusedSeqRangePrefix) {
+	if strings.HasPrefix(docID, c.metaKeys.UnusedSeqRangePrefix()) {
 		c.processUnusedSequenceRange(docID)
 		return
 	}
@@ -529,7 +532,7 @@ func (c *changeCache) unmarshalCachePrincipal(docJSON []byte) (cachePrincipal, e
 
 // Process unused sequence notification.  Extracts sequence from docID and sends to cache for buffering
 func (c *changeCache) processUnusedSequence(docID string, timeReceived time.Time) {
-	sequenceStr := strings.TrimPrefix(docID, base.UnusedSeqPrefix)
+	sequenceStr := strings.TrimPrefix(docID, c.metaKeys.UnusedSeqPrefix())
 	sequence, err := strconv.ParseUint(sequenceStr, 10, 64)
 	if err != nil {
 		base.WarnfCtx(c.logCtx, "Unable to identify sequence number for unused sequence notification with key: %s, error: %v", base.UD(docID), err)

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -495,7 +495,7 @@ func WriteDirect(db *Database, channelArray []string, sequence uint64) {
 }
 
 func WriteUserDirect(db *Database, username string, sequence uint64) {
-	docId := base.UserPrefix + username
+	docId := db.MetadataKeys.UserKey(username)
 	_, _ = db.singleCollection.dataStore.Add(docId, 0, Body{"sequence": sequence, "name": username})
 }
 
@@ -942,7 +942,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	assert.Len(t, changes, 3)
 	assert.True(t, verifyChangesFullSequences(changes, []string{"1", "2", "2::6"}))
 
-	_, incrErr := db.singleCollection.dataStore.Incr(base.SyncSeqKey, 7, 7, 0)
+	_, incrErr := db.singleCollection.dataStore.Incr(db.MetadataKeys.SyncSeqKey(), 7, 7, 0)
 	require.NoError(t, incrErr)
 
 	// Modify user to have access to both channels (sequence 2):
@@ -1976,7 +1976,7 @@ func BenchmarkProcessEntry(b *testing.B) {
 
 			ctx = context.AddDatabaseLogContext(ctx)
 			changeCache := &changeCache{}
-			if err := changeCache.Init(ctx, context, context.channelCache, nil, nil); err != nil {
+			if err := changeCache.Init(ctx, context, context.channelCache, nil, nil, context.MetadataKeys); err != nil {
 				log.Printf("Init failed for changeCache: %v", err)
 				b.Fail()
 			}
@@ -2208,7 +2208,7 @@ func BenchmarkDocChanged(b *testing.B) {
 
 			ctx = context.AddDatabaseLogContext(ctx)
 			changeCache := &changeCache{}
-			if err := changeCache.Init(ctx, context, context.channelCache, nil, nil); err != nil {
+			if err := changeCache.Init(ctx, context, context.channelCache, nil, nil, context.MetadataKeys); err != nil {
 				log.Printf("Init failed for changeCache: %v", err)
 				b.Fail()
 			}

--- a/db/change_listener_test.go
+++ b/db/change_listener_test.go
@@ -120,7 +120,7 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 	require.True(t, WaitForUserWaiterChange(userWaiter))
 
 	// Update the waiter with the current user (adds role to waiter.UserKeys)
-	userWaiter.RefreshUserKeys(userRefresh)
+	userWaiter.RefreshUserKeys(userRefresh, db.MetadataKeys)
 
 	// Update the role to grant a new channel
 	updatedRole := auth.PrincipalConfig{

--- a/db/changes.go
+++ b/db/changes.go
@@ -597,7 +597,7 @@ func (col *DatabaseCollectionWithUser) checkForUserUpdates(ctx context.Context, 
 
 			changedRoles := col.user.RoleNames().CompareKeys(previousRoles)
 			if len(changedRoles) > 0 {
-				changeWaiter.RefreshUserKeys(col.User())
+				changeWaiter.RefreshUserKeys(col.User(), col.dbCtx.MetadataKeys)
 			}
 		}
 		return true, newCount, changedChannels, nil

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -937,6 +937,8 @@ func TestOldRevisionStorageError(t *testing.T) {
 // Validate JSON number handling for large sequence values
 func TestLargeSequence(t *testing.T) {
 
+	// Test depends on setting _sync:seq in the default collection location
+	base.DisableTestWithCollections(t)
 	base.LongRunningTest(t)
 
 	db, ctx := setupTestDBWithCustomSyncSeq(t, 9223372036854775807)
@@ -1002,7 +1004,7 @@ func TestMalformedRevisionStorageRecovery(t *testing.T) {
 	assert.NoError(t, addErr, "Error writing raw document")
 
 	// Increment _sync:seq to match sequences allocated by raw doc
-	_, incrErr := collection.dataStore.Incr(base.SyncSeqKey, 5, 0, 0)
+	_, incrErr := collection.dataStore.Incr(db.MetadataKeys.SyncSeqKey(), 5, 0, 0)
 	assert.NoError(t, incrErr, "Error incrementing sync:seq")
 
 	// Add child to non-winning revision w/ malformed inline body.

--- a/db/database.go
+++ b/db/database.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -128,6 +129,7 @@ type DatabaseContext struct {
 	singleCollection             *DatabaseCollection            // Temporary collection
 	CollectionByID               map[uint32]*DatabaseCollection // A map keyed by collection ID to Collection
 	CollectionNames              map[string]map[string]struct{} // Map of scope, collection names
+	MetadataKeys                 *base.MetadataKeys             // Factory to generate metadata document keys
 }
 
 type Scope struct {
@@ -180,6 +182,22 @@ type ScopeOptions struct {
 type CollectionOptions struct {
 	Sync         *string               // Collection sync function
 	ImportFilter *ImportFilterFunction // Opt-in filter for document import
+}
+
+// Check whether the specified ScopesOptions only defines the default collection
+func (so ScopesOptions) onlyDefaultCollection() bool {
+	if so == nil || len(so) == 0 {
+		return true
+	}
+	if len(so) > 1 {
+		return false
+	}
+	defaultScope, ok := so[base.DefaultScope]
+	if !ok || len(defaultScope.Collections) > 1 {
+		return false
+	}
+	_, ok = defaultScope.Collections[base.DefaultCollection]
+	return ok
 }
 
 type SGReplicateOptions struct {
@@ -400,6 +418,15 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		ServerUUID:     serverUUID,
 	}
 
+	// Initialize metadata ID and keys
+	// TODO: apply length limit to MetadataPrefix
+	metadataID := dbName
+	if options.Scopes.onlyDefaultCollection() {
+		metadataID = ""
+	}
+	metaKeys := base.NewMetadataKeys(metadataID)
+	dbContext.MetadataKeys = metaKeys
+
 	cleanupFunctions = append(cleanupFunctions, func() {
 		base.SyncGatewayStats.ClearDBStats(dbName)
 	})
@@ -414,7 +441,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 
 	dbContext.EventMgr = NewEventManager(dbContext.terminator)
 
-	dbContext.sequences, err = newSequenceAllocator(metadataStore, dbContext.DbStats.Database())
+	dbContext.sequences, err = newSequenceAllocator(metadataStore, dbContext.DbStats.Database(), metaKeys)
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +474,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	// Initialize sg cluster config.  Required even if import and sgreplicate are disabled
 	// on this node, to support replication REST API calls
 	if base.IsEnterpriseEdition() {
-		sgCfg, err := base.NewCfgSG(metadataStore, dbContext.Options.GroupID)
+		sgCfg, err := base.NewCfgSG(metadataStore, metaKeys.SGCfgPrefix(dbContext.Options.GroupID))
 		if err != nil {
 			return nil, err
 		}
@@ -461,7 +488,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	}
 
 	// Initialize the tap Listener for notify handling
-	dbContext.mutationListener.Init(bucket.GetName(), options.GroupID)
+	dbContext.mutationListener.Init(bucket.GetName(), options.GroupID, dbContext.MetadataKeys)
 
 	if len(options.Scopes) == 0 {
 		return nil, fmt.Errorf("Setting scopes to be zero is invalid")
@@ -533,6 +560,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		dbContext.channelCache,
 		notifyChange,
 		dbContext.Options.CacheOptions,
+		metaKeys,
 	)
 	if err != nil {
 		base.DebugfCtx(ctx, base.KeyDCP, "Error initializing the change cache", err)
@@ -561,7 +589,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	// sending heartbeats before registering itself to the cfg, to avoid triggering immediate removal by other active nodes.
 	if base.IsEnterpriseEdition() && (importEnabled || sgReplicateEnabled) {
 		// Create heartbeater
-		heartbeaterPrefix := base.HeartbeaterPrefixWithGroupID(dbContext.Options.GroupID)
+		heartbeaterPrefix := metaKeys.HeartbeaterPrefix(dbContext.Options.GroupID)
 		heartbeater, err := base.NewCouchbaseHeartbeater(dbContext.MetadataStore, heartbeaterPrefix, dbContext.UUID)
 		if err != nil {
 			return nil, pkgerrors.Wrapf(err, "Error starting heartbeater for bucket %s", base.MD(bucket.GetName()).Redact())
@@ -621,7 +649,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	// If this is an xattr import node, start import feed.  Must be started after the caching DCP feed, as import cfg
 	// subscription relies on the caching feed.
 	if importEnabled {
-		dbContext.ImportListener = NewImportListener(dbContext.Options.GroupID)
+		dbContext.ImportListener = NewImportListener(metaKeys.DCPCheckpointPrefix(dbContext.Options.GroupID))
 		if importFeedErr := dbContext.ImportListener.StartImportFeed(ctx, bucket, dbContext.DbStats, dbContext); importFeedErr != nil {
 			return nil, importFeedErr
 		}
@@ -738,12 +766,12 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	}
 
 	if dbContext.UseQueryBasedResyncManager() {
-		dbContext.ResyncManager = NewResyncManager(metadataStore)
+		dbContext.ResyncManager = NewResyncManager(metadataStore, metaKeys)
 	} else {
-		dbContext.ResyncManager = NewResyncManagerDCP(metadataStore, dbContext.UseXattrs())
+		dbContext.ResyncManager = NewResyncManagerDCP(metadataStore, dbContext.UseXattrs(), metaKeys)
 	}
 	dbContext.TombstoneCompactionManager = NewTombstoneCompactionManager()
-	dbContext.AttachmentCompactionManager = NewAttachmentCompactionManager(metadataStore)
+	dbContext.AttachmentCompactionManager = NewAttachmentCompactionManager(metadataStore, metaKeys)
 
 	return dbContext, nil
 }
@@ -904,7 +932,7 @@ func (context *DatabaseContext) RestartListener() error {
 	context.mutationListener.Stop()
 	// Delay needed to properly stop
 	time.Sleep(2 * time.Second)
-	context.mutationListener.Init(context.Bucket.GetName(), context.Options.GroupID)
+	context.mutationListener.Init(context.Bucket.GetName(), context.Options.GroupID, context.MetadataKeys)
 	cacheFeedStatsMap := context.DbStats.Database().CacheFeedMapStats
 	if err := context.mutationListener.Start(context.Bucket, cacheFeedStatsMap.Map, context.Scopes, context.MetadataStore); err != nil {
 		return err
@@ -982,7 +1010,7 @@ func (dbCtx *DatabaseContext) RemoveObsoleteIndexes(ctx context.Context, preview
 //
 //	to remove
 func (context *DatabaseContext) NotifyTerminatedChanges(username string) {
-	context.mutationListener.NotifyCheckForTermination(base.SetOf(base.UserPrefix + username))
+	context.mutationListener.NotifyCheckForTermination(base.SetOf(base.UserPrefixRoot + username))
 }
 
 func (dc *DatabaseContext) TakeDbOffline(ctx context.Context, reason string) error {
@@ -1048,6 +1076,7 @@ func (context *DatabaseContext) Authenticator(ctx context.Context) *auth.Authent
 		BcryptCost:               context.Options.BcryptCost,
 		LogCtx:                   ctx,
 		Collections:              context.CollectionNames,
+		MetaKeys:                 context.MetadataKeys,
 	})
 
 	return authenticator
@@ -1246,7 +1275,8 @@ func (db *DatabaseContext) getRoleIDsInBackground(ctx context.Context) <-chan da
 
 // Returns the Names of all users
 func (db *DatabaseContext) GetUserNames(ctx context.Context) (users []string, err error) {
-	startKey := base.UserPrefix
+	dbUserPrefix := db.MetadataKeys.UserKeyPrefix()
+	startKey := dbUserPrefix
 	limit := db.Options.QueryPaginationLimit
 
 	users = []string{}
@@ -1265,7 +1295,7 @@ outerLoop:
 		for {
 			// startKey is inclusive for views, so need to skip first result if using non-empty startKey, as this results in an overlapping result
 			var skipAddition bool
-			if resultCount == 0 && startKey != base.UserPrefix {
+			if resultCount == 0 && startKey != dbUserPrefix {
 				skipAddition = true
 			}
 
@@ -1274,8 +1304,13 @@ outerLoop:
 			if !found {
 				break
 			}
+
+			if !strings.HasPrefix(queryRow.ID, dbUserPrefix) {
+				break
+			}
+
 			principalName = queryRow.Name
-			startKey = base.UserPrefix + queryRow.Name
+			startKey = queryRow.ID
 
 			resultCount++
 
@@ -1304,6 +1339,11 @@ func (db *DatabaseContext) getAllPrincipalIDsSyncDocs(ctx context.Context) (user
 	startKey := ""
 	limit := db.Options.QueryPaginationLimit
 
+	dbUserPrefix := db.MetadataKeys.UserKeyPrefix()
+	dbRolePrefix := db.MetadataKeys.RoleKeyPrefix()
+	lenDbUserPrefix := len(dbUserPrefix)
+	lenDbRolePrefix := len(dbRolePrefix)
+
 	users = []string{}
 	roles = []string{}
 
@@ -1314,9 +1354,8 @@ outerLoop:
 			return nil, nil, err
 		}
 
-		var isUser bool
+		var isDbUser, isDbRole bool
 		var principalName string
-		lenUserKeyPrefix := len(base.UserPrefix)
 
 		resultCount := 0
 
@@ -1327,32 +1366,44 @@ outerLoop:
 				skipAddition = true
 			}
 
+			var rowID string
 			if db.Options.UseViews {
 				var viewRow principalsViewRow
 				found := results.Next(&viewRow)
 				if !found {
 					break
 				}
-				isUser = viewRow.Value
-				principalName = viewRow.Key
-				startKey = principalName
+				rowID = viewRow.ID
+				//isUser = viewRow.Value
+				//principalName = viewRow.Key
+				startKey = viewRow.Key
 			} else {
 				var queryRow QueryIdRow
 				found := results.Next(&queryRow)
 				if !found {
 					break
 				}
-				if len(queryRow.Id) < lenUserKeyPrefix {
-					continue
-				}
-				isUser = queryRow.Id[0:lenUserKeyPrefix] == base.UserPrefix
-				principalName = queryRow.Id[lenUserKeyPrefix:]
+				rowID = queryRow.Id
 				startKey = queryRow.Id
+			}
+			if len(rowID) < lenDbUserPrefix && len(rowID) < lenDbRolePrefix {
+				continue
+			}
+
+			isDbUser = strings.HasPrefix(rowID, dbUserPrefix)
+			isDbRole = strings.HasPrefix(rowID, dbRolePrefix)
+			if !isDbUser && !isDbRole {
+				continue
+			}
+			if isDbUser {
+				principalName = rowID[lenDbUserPrefix:]
+			} else {
+				principalName = rowID[lenDbRolePrefix:]
 			}
 			resultCount++
 
 			if principalName != "" && !skipAddition {
-				if isUser {
+				if isDbUser {
 					users = append(users, principalName)
 				} else {
 					roles = append(roles, principalName)
@@ -1385,7 +1436,8 @@ func (db *DatabaseContext) GetUsers(ctx context.Context, limit int) (users []aut
 	// limit handling and startKey (non-user _sync: prefixed documents being included in the query limit evaluation).
 	// This doesn't happen for AllPrincipalIDs, I believe because the role check forces query to not assume
 	// a contiguous set of results
-	startKey := base.UserPrefix
+	dbUserKeyPrefix := db.MetadataKeys.UserKeyPrefix()
+	startKey := dbUserKeyPrefix
 	paginationLimit := db.Options.QueryPaginationLimit
 	if paginationLimit == 0 {
 		paginationLimit = DefaultQueryPaginationLimit
@@ -1411,7 +1463,7 @@ outerLoop:
 		for {
 			// startKey is inclusive, so need to skip first result if using non-empty startKey, as this results in an overlapping result
 			var skipAddition bool
-			if resultCount == 0 && startKey != base.UserPrefix {
+			if resultCount == 0 && startKey != dbUserKeyPrefix {
 				skipAddition = true
 			}
 
@@ -1420,7 +1472,11 @@ outerLoop:
 			if !found {
 				break
 			}
-			startKey = base.UserPrefix + queryRow.Name
+			if !strings.HasPrefix(queryRow.ID, dbUserKeyPrefix) {
+				break
+			}
+
+			startKey = queryRow.ID
 			resultCount++
 			if queryRow.Name != "" && !skipAddition {
 				principal := auth.PrincipalConfig{
@@ -1456,7 +1512,8 @@ outerLoop:
 
 func (db *DatabaseContext) getRoleIDsUsingIndex(ctx context.Context, includeDeleted bool) (roles []string, err error) {
 
-	startKey := ""
+	dbRoleIDPrefix := db.MetadataKeys.RoleKeyPrefix()
+	startKey := dbRoleIDPrefix
 	limit := db.Options.QueryPaginationLimit
 
 	roles = []string{}
@@ -1475,14 +1532,14 @@ outerLoop:
 		}
 
 		var roleName string
-		lenRoleKeyPrefix := len(base.RolePrefix)
+		lenRoleKeyPrefix := len(dbRoleIDPrefix)
 
 		resultCount := 0
 
 		for {
 			// startKey is inclusive for views, so need to skip first result if using non-empty startKey, as this results in an overlapping result
 			var skipAddition bool
-			if resultCount == 0 && startKey != "" {
+			if resultCount == 0 && startKey != dbRoleIDPrefix {
 				skipAddition = true
 			}
 
@@ -1493,6 +1550,9 @@ outerLoop:
 			}
 			if len(queryRow.Id) < lenRoleKeyPrefix {
 				continue
+			}
+			if !strings.HasPrefix(queryRow.Id, dbRoleIDPrefix) {
+				break
 			}
 			roleName = queryRow.Id[lenRoleKeyPrefix:]
 			startKey = queryRow.Id
@@ -2252,4 +2312,10 @@ func (dbc *Database) GetDefaultDatabaseCollectionWithUser() (*DatabaseCollection
 // GetSingleDatabaseCollection is a temporary function to return a single collection. This should be a temporary function while collection work is ongoing.
 func (dbc *DatabaseContext) GetSingleDatabaseCollection() *DatabaseCollection {
 	return dbc.singleCollection
+}
+
+func (dbc *DatabaseContext) AuthenticatorOptions() auth.AuthenticatorOptions {
+	defaultOptions := auth.DefaultAuthenticatorOptions()
+	defaultOptions.MetaKeys = dbc.MetadataKeys
+	return defaultOptions
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -100,11 +100,11 @@ func setupTestDBWithCustomSyncSeq(t testing.TB, customSeq uint64) (*Database, co
 	AddOptionsFromEnvironmentVariables(&dbcOptions)
 
 	// This may need to change when we move to a non-default metadata collection...
-	metadataStore := tBucket.DefaultDataStore()
+	metadataStore := tBucket.GetMetadataStore()
 
-	log.Printf("Initializing test %s to %d", base.SyncSeqKey, customSeq)
-	_, incrErr := metadataStore.Incr(base.SyncSeqKey, customSeq, customSeq, 0)
-	assert.NoError(t, incrErr, fmt.Sprintf("Couldn't increment %s by %d", base.SyncSeqKey, customSeq))
+	log.Printf("Initializing test %s to %d", base.DefaultMetadataKeys.SyncSeqKey(), customSeq)
+	_, incrErr := metadataStore.Incr(base.DefaultMetadataKeys.SyncSeqKey(), customSeq, customSeq, 0)
+	assert.NoError(t, incrErr, fmt.Sprintf("Couldn't increment %s by %d", base.DefaultMetadataKeys.SyncSeqKey(), customSeq))
 
 	dbCtx, err := NewDatabaseContext(ctx, "db", tBucket, false, dbcOptions)
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
@@ -289,7 +289,7 @@ func TestGetDeleted(t *testing.T) {
 	assert.Equal(t, rev2id, doc.SyncData.CurrentRev)
 
 	// Try again but with a user who doesn't have access to this revision (see #179)
-	authenticator := auth.NewAuthenticator(db.MetadataStore, db, auth.DefaultAuthenticatorOptions())
+	authenticator := auth.NewAuthenticator(db.MetadataStore, db, db.AuthenticatorOptions())
 	collection.user, err = authenticator.GetUser("")
 	assert.NoError(t, err, "GetUser")
 	collection.user.SetExplicitChannels(nil, 1)
@@ -356,7 +356,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 	assert.NoError(t, err, "Purge old revision JSON")
 
 	// Try again with a user who doesn't have access to this revision
-	authenticator := auth.NewAuthenticator(db.MetadataStore, db, auth.DefaultAuthenticatorOptions())
+	authenticator := auth.NewAuthenticator(db.MetadataStore, db, db.AuthenticatorOptions())
 	collection.user, err = authenticator.GetUser("")
 	assert.NoError(t, err, "GetUser")
 
@@ -1555,7 +1555,7 @@ func TestUpdateDesignDoc(t *testing.T) {
 	assert.True(t, strings.Contains(retrievedView.Map, "emit()"))
 	assert.NotEqual(t, mapFunction, retrievedView.Map) // SG should wrap the map function, so they shouldn't be equal
 
-	authenticator := auth.NewAuthenticator(db.MetadataStore, db, auth.DefaultAuthenticatorOptions())
+	authenticator := auth.NewAuthenticator(db.MetadataStore, db, db.AuthenticatorOptions())
 	db.user, _ = authenticator.NewUser("naomi", "letmein", channels.BaseSetOf(t, "Netflix"))
 	err = db.PutDesignDoc("_design/pwn3d", sgbucket.DesignDoc{})
 	assertHTTPError(t, err, 403)
@@ -2677,7 +2677,7 @@ func Test_invalidateAllPrincipalsCache(t *testing.T) {
 	defer db.Close(ctx)
 	db.Options.QueryPaginationLimit = 100
 
-	sequenceAllocator, err := newSequenceAllocator(db.MetadataStore, db.DbStats.DatabaseStats)
+	sequenceAllocator, err := newSequenceAllocator(db.MetadataStore, db.DbStats.DatabaseStats, db.MetadataKeys)
 	assert.NoError(t, err)
 
 	db.sequences = sequenceAllocator
@@ -2733,14 +2733,14 @@ func Test_invalidateAllPrincipalsCache(t *testing.T) {
 
 		var invalPrinc invalPric
 		for i := 0; i < 1; i++ {
-			raw, _, err := db.MetadataStore.GetRaw(fmt.Sprintf("_sync:role:role%d", i))
+			raw, _, err := db.MetadataStore.GetRaw(db.MetadataKeys.RoleKey(fmt.Sprintf("role%d", i)))
 			assert.NoError(t, err)
 			err = json.Unmarshal(raw, &invalPrinc)
 			assert.NoError(t, err)
 			assert.Equal(t, endSeq, invalPrinc.CollectionAccess[scopeName][collectionName].ChannelInvalSeq)
 			assert.Equal(t, fmt.Sprintf("role%d", i), invalPrinc.Name)
 
-			raw, _, err = db.MetadataStore.GetRaw(fmt.Sprintf("_sync:user:user%d", i))
+			raw, _, err = db.MetadataStore.GetRaw(db.MetadataKeys.UserKey(fmt.Sprintf("user%d", i)))
 			assert.NoError(t, err)
 			err = json.Unmarshal(raw, &invalPrinc)
 			assert.NoError(t, err)
@@ -2757,14 +2757,14 @@ func Test_invalidateAllPrincipalsCache(t *testing.T) {
 
 		var invalPrinc invalPric
 		for i := 0; i < 1; i++ {
-			raw, _, err := db.MetadataStore.GetRaw(fmt.Sprintf("_sync:role:role%d", i))
+			raw, _, err := db.MetadataStore.GetRaw(db.MetadataKeys.RoleKey(fmt.Sprintf("role%d", i)))
 			assert.NoError(t, err)
 			err = json.Unmarshal(raw, &invalPrinc)
 			assert.NoError(t, err)
 			assert.Equal(t, endSeq, invalPrinc.ChannelInvalSeq)
 			assert.Equal(t, fmt.Sprintf("role%d", i), invalPrinc.Name)
 
-			raw, _, err = db.MetadataStore.GetRaw(fmt.Sprintf("_sync:user:user%d", i))
+			raw, _, err = db.MetadataStore.GetRaw(db.MetadataKeys.UserKey(fmt.Sprintf("user%d", i)))
 			assert.NoError(t, err)
 			err = json.Unmarshal(raw, &invalPrinc)
 			assert.NoError(t, err)
@@ -3150,6 +3150,7 @@ func Test_stopBackgroundManagers(t *testing.T) {
 }
 
 func Test_waitForBackgroundManagersToStop(t *testing.T) {
+	base.LongRunningTest(t)
 	t.Run("single unstoppable process", func(t *testing.T) {
 		bgMngr := &BackgroundManager{
 			name:    "test_unstoppable_runner",

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -58,6 +58,7 @@ const (
 
 // Principals view result row
 type principalsViewRow struct {
+	ID    string
 	Key   string // principal name
 	Value bool   // 'isUser' flag
 }
@@ -429,7 +430,7 @@ func installViews(ctx context.Context, viewStore sgbucket.ViewStore) error {
                      	var prefix = meta.id.substring(0,%d);
                      	if (prefix == %q)
                      		emit(doc.username, meta.id);}`
-	sessions_map = fmt.Sprintf(sessions_map, len(base.SessionPrefix), base.SessionPrefix)
+	sessions_map = fmt.Sprintf(sessions_map, len(base.SessionPrefixRoot), base.SessionPrefixRoot)
 
 	// Tombstones view - used for view tombstone compaction
 	// Key is purge time; value is docid
@@ -446,8 +447,8 @@ func installViews(ctx context.Context, viewStore sgbucket.ViewStore) error {
 							 var isUser = (prefix == %q);
 							 if (isUser || prefix == %q)
 			                     emit(meta.id.substring(%d), isUser); }`
-	principals_map = fmt.Sprintf(principals_map, base.UserPrefix, base.RolePrefix,
-		len(base.UserPrefix))
+	principals_map = fmt.Sprintf(principals_map, base.UserPrefixRoot, base.RolePrefixRoot,
+		len(base.UserPrefixRoot))
 
 	// All-roles view, excluding deleted
 	// Key is role name; value is not used
@@ -457,8 +458,8 @@ func installViews(ctx context.Context, viewStore sgbucket.ViewStore) error {
 			if (prefix == %q && doc.deleted !== true)
 				emit(meta.id.substring(%d), null); 
 		}`
-	rolePrefixLen := len(base.UserPrefix)
-	roles_excludeDeleted_map = fmt.Sprintf(roles_excludeDeleted_map, rolePrefixLen, base.RolePrefix, rolePrefixLen)
+	rolePrefixLen := len(base.RolePrefixRoot)
+	roles_excludeDeleted_map = fmt.Sprintf(roles_excludeDeleted_map, rolePrefixLen, base.RolePrefixRoot, rolePrefixLen)
 
 	// By-channels view.
 	// Key is [channelname, sequence]; value is [docid, revid, flag?]

--- a/db/functions/function_test.go
+++ b/db/functions/function_test.go
@@ -485,7 +485,7 @@ func TestUserFunctionAllow(t *testing.T) {
 	db, ctx := setupTestDBWithFunctions(t, &kUserFunctionConfig, nil)
 	defer db.Close(ctx)
 
-	authenticator := auth.NewAuthenticator(db.MetadataStore, db, auth.DefaultAuthenticatorOptions())
+	authenticator := auth.NewAuthenticator(db.MetadataStore, db, db.AuthenticatorOptions())
 	user, err := authenticator.NewUser("maurice", "pass", base.SetOf("city-Paris"))
 	assert.NoError(t, err)
 

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -97,7 +97,7 @@ func (il *importListener) NewImportDest() (cbgt.Dest, error) {
 	importFeedStatsMap := il.dbStats.ImportFeedMapStats
 	importPartitionStat := il.importStats.ImportPartitions
 
-	importDest, _, err := base.NewDCPDest(il.loggingCtx, callback, il.bucket, maxVbNo, true, importFeedStatsMap.Map, base.DCPImportFeedID, importPartitionStat, il.checkpointPrefix)
+	importDest, _, err := base.NewDCPDest(il.loggingCtx, callback, il.bucket, maxVbNo, true, importFeedStatsMap.Map, base.DCPImportFeedID, importPartitionStat, il.checkpointPrefix, il.metadataKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/db/query.go
+++ b/db/query.go
@@ -253,6 +253,7 @@ var QueryRolesExcludeDeletedUsingRoleIdx = SGQuery{
 }
 
 type QueryUsersRow struct {
+	ID       string `json:"id"`
 	Name     string `json:"name"`
 	Email    string `json:"email,omitempty"`
 	Disabled bool   `json:"disabled,omitempty"`
@@ -261,7 +262,8 @@ type QueryUsersRow struct {
 var QueryUsers = SGQuery{
 	name: QueryTypeUsers,
 	statement: fmt.Sprintf(
-		"SELECT %s.name, "+
+		"SELECT META(%s).id, "+
+			"%s.name, "+
 			"%s.email, "+
 			"%s.disabled "+
 			"FROM %s as %s "+
@@ -269,6 +271,7 @@ var QueryUsers = SGQuery{
 			"WHERE META(%s).id LIKE '%s' "+
 			"AND META(%s).id >= $%s "+ // Using >= to match QueryPrincipals startKey handling
 			"ORDER BY META(%s).id",
+		base.KeyspaceQueryAlias,
 		base.KeyspaceQueryAlias,
 		base.KeyspaceQueryAlias,
 		base.KeyspaceQueryAlias,
@@ -282,7 +285,8 @@ var QueryUsers = SGQuery{
 var QueryUsersUsingSyncDocsIdx = SGQuery{
 	name: QueryTypeUsers,
 	statement: fmt.Sprintf(
-		"SELECT %s.name, "+
+		"SELECT META(%s).id, "+
+			"%s.name, "+
 			"%s.email, "+
 			"%s.disabled "+
 			"FROM %s as %s "+
@@ -291,6 +295,7 @@ var QueryUsersUsingSyncDocsIdx = SGQuery{
 			"AND META(%s).id LIKE '%s' "+
 			"AND META(%s).id >= $%s "+ // Using >= to match QueryPrincipals startKey handling
 			"ORDER BY META(%s).id",
+		base.KeyspaceQueryAlias,
 		base.KeyspaceQueryAlias,
 		base.KeyspaceQueryAlias,
 		base.KeyspaceQueryAlias,

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -38,6 +38,7 @@ func TestSequenceAllocator(t *testing.T) {
 		dbStats:           testStats,
 		sequenceBatchSize: idleBatchSize,
 		reserveNotify:     make(chan struct{}, 50), // Buffered to allow multiple allocations without releaseSequenceMonitor
+		metaKeys:          base.DefaultMetadataKeys,
 	}
 
 	// Set high incr frequency to force batch size increase
@@ -103,7 +104,7 @@ func TestReleaseSequencesOnStop(t *testing.T) {
 	defer func() { MaxSequenceIncrFrequency = oldFrequency }()
 	MaxSequenceIncrFrequency = 1000 * time.Millisecond
 
-	a, err := newSequenceAllocator(bucket.GetSingleDataStore(), testStats)
+	a, err := newSequenceAllocator(bucket.GetSingleDataStore(), testStats, base.DefaultMetadataKeys)
 	// Reduce sequence wait for Stop testing
 	a.releaseSequenceWait = 10 * time.Millisecond
 	assert.NoError(t, err, "error creating allocator")
@@ -180,7 +181,7 @@ func TestSequenceAllocatorDeadlock(t *testing.T) {
 	defer func() { MaxSequenceIncrFrequency = oldFrequency }()
 	MaxSequenceIncrFrequency = 1000 * time.Millisecond
 
-	a, err = newSequenceAllocator(bucket.DefaultDataStore(), testStats)
+	a, err = newSequenceAllocator(bucket.DefaultDataStore(), testStats, base.DefaultMetadataKeys)
 	// Reduce sequence wait for Stop testing
 	a.releaseSequenceWait = 10 * time.Millisecond
 	assert.NoError(t, err, "error creating allocator")
@@ -208,7 +209,7 @@ func TestReleaseSequenceWait(t *testing.T) {
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 
-	a, err := newSequenceAllocator(bucket.GetSingleDataStore(), testStats)
+	a, err := newSequenceAllocator(bucket.GetSingleDataStore(), testStats, base.DefaultMetadataKeys)
 	require.NoError(t, err)
 	defer a.Stop()
 

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -92,7 +92,7 @@ func TestStarAccess(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 
-	a := auth.NewAuthenticator(rt.MetadataStore(), nil, auth.DefaultAuthenticatorOptions())
+	a := auth.NewAuthenticator(rt.MetadataStore(), nil, rt.GetDatabase().AuthenticatorOptions())
 	a.Collections = rt.GetDatabase().CollectionNames
 	var changes struct {
 		Results []db.ChangeEntry
@@ -601,7 +601,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	}
 
 	// Create some docs:
-	a := auth.NewAuthenticator(rt.MetadataStore(), nil, auth.DefaultAuthenticatorOptions())
+	a := auth.NewAuthenticator(rt.MetadataStore(), nil, rt.GetDatabase().AuthenticatorOptions())
 	a.Collections = rt.GetDatabase().CollectionNames
 	guest, err := a.GetUser("")
 	assert.NoError(t, err)

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -760,7 +760,7 @@ func TestResync(t *testing.T) {
 
 			_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManager)
 			if !ok {
-				rt.GetDatabase().ResyncManager = db.NewResyncManager(rt.GetSingleDataStore())
+				rt.GetDatabase().ResyncManager = db.NewResyncManager(rt.GetSingleDataStore(), rt.GetDatabase().MetadataKeys)
 			}
 
 			for i := 0; i < testCase.docsCreated; i++ {
@@ -845,7 +845,7 @@ func TestResyncUsingDCPStream(t *testing.T) {
 
 			_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
 			if !ok {
-				rt.GetDatabase().ResyncManager = db.NewResyncManagerDCP(rt.GetSingleDataStore(), base.TestUseXattrs())
+				rt.GetDatabase().ResyncManager = db.NewResyncManagerDCP(rt.GetSingleDataStore(), base.TestUseXattrs(), rt.GetDatabase().MetadataKeys)
 			}
 
 			for i := 0; i < testCase.docsCreated; i++ {
@@ -1190,7 +1190,7 @@ func TestResyncErrorScenarios(t *testing.T) {
 
 	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManager)
 	if !ok {
-		rt.GetDatabase().ResyncManager = db.NewResyncManager(rt.GetSingleDataStore())
+		rt.GetDatabase().ResyncManager = db.NewResyncManager(rt.GetSingleDataStore(), rt.GetDatabase().MetadataKeys)
 	}
 
 	leakyDataStore, ok := base.AsLeakyDataStore(rt.TestBucket.GetSingleDataStore())
@@ -1293,7 +1293,7 @@ func TestResyncErrorScenariosUsingDCPStream(t *testing.T) {
 
 	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
 	if !ok {
-		rt.GetDatabase().ResyncManager = db.NewResyncManagerDCP(rt.GetSingleDataStore(), base.TestUseXattrs())
+		rt.GetDatabase().ResyncManager = db.NewResyncManagerDCP(rt.GetSingleDataStore(), base.TestUseXattrs(), rt.GetDatabase().MetadataKeys)
 	}
 
 	numOfDocs := 1000
@@ -1380,7 +1380,7 @@ func TestResyncStop(t *testing.T) {
 
 	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManager)
 	if !ok {
-		rt.GetDatabase().ResyncManager = db.NewResyncManager(rt.GetSingleDataStore())
+		rt.GetDatabase().ResyncManager = db.NewResyncManager(rt.GetSingleDataStore(), rt.GetDatabase().MetadataKeys)
 	}
 
 	leakyDataStore, ok := base.AsLeakyDataStore(rt.TestBucket.GetSingleDataStore())
@@ -1467,7 +1467,7 @@ func TestResyncStopUsingDCPStream(t *testing.T) {
 
 	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
 	if !ok {
-		rt.GetDatabase().ResyncManager = db.NewResyncManagerDCP(rt.GetSingleDataStore(), base.TestUseXattrs())
+		rt.GetDatabase().ResyncManager = db.NewResyncManagerDCP(rt.GetSingleDataStore(), base.TestUseXattrs(), rt.GetDatabase().MetadataKeys)
 	}
 
 	numOfDocs := 1000

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -3619,11 +3619,15 @@ func TestChangesIncludeConflicts(t *testing.T) {
 func TestChangesLargeSequences(t *testing.T) {
 
 	if base.UnitTestUrlIsWalrus() {
-		t.Skip("TestChangesLargeSequences doesn't support walrus - needs to customize " + base.SyncSeqKey + " prior to db creation")
+		t.Skip("TestChangesLargeSequences doesn't support walrus - needs to customize " + base.DefaultMetadataKeys.SyncSeqKey() + " prior to db creation")
 	}
 	if !base.TestsDisableGSI() {
 		t.Skip("Requires N1QL due to CBG-361")
 
+	}
+
+	if base.TestsUseNamedCollections() {
+		t.Skip("Requires default collection to set " + base.DefaultMetadataKeys.SyncSeqKey())
 	}
 	initialSeq := uint64(9223372036854775807)
 	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc,oldDoc) {

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -436,7 +436,7 @@ func TestLegacyConfigPrinciplesMigration(t *testing.T) {
 	rt.ServerContext().addLegacyPrincipals(ctx, users, roles)
 
 	// Check that principles all exist on bucket
-	authenticator := auth.NewAuthenticator(bucket.DefaultDataStore(), nil, auth.DefaultAuthenticatorOptions())
+	authenticator := auth.NewAuthenticator(bucket.DefaultDataStore(), nil, rt.GetDatabase().AuthenticatorOptions())
 	for _, name := range expectedUsers {
 		user, err := authenticator.GetUser(name)
 		assert.NoError(t, err)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1971,7 +1971,7 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	// allocate a fake sequence to trigger skipped sequence handling - this never arrives at rt1 - we could think about creating the doc afterwards to let the replicator recover, but not necessary for the test.
-	_, err = rt2.MetadataStore().Incr(base.SyncSeqKey, 1, 1, 0)
+	_, err = rt2.MetadataStore().Incr(rt2.GetDatabase().MetadataKeys.SyncSeqKey(), 1, 1, 0)
 	require.NoError(t, err)
 
 	docID3 := docIDPrefix + "3"

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -221,7 +221,7 @@ func TestLogin(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	a := auth.NewAuthenticator(rt.MetadataStore(), nil, auth.DefaultAuthenticatorOptions())
+	a := auth.NewAuthenticator(rt.MetadataStore(), nil, rt.GetDatabase().AuthenticatorOptions())
 	user, err := a.GetUser("")
 	assert.NoError(t, err)
 	user.SetDisabled(true)
@@ -263,7 +263,7 @@ func TestCustomCookieName(t *testing.T) {
 	defer rt.Close()
 
 	// Disable guest user
-	a := auth.NewAuthenticator(rt.MetadataStore(), nil, auth.DefaultAuthenticatorOptions())
+	a := auth.NewAuthenticator(rt.MetadataStore(), nil, rt.GetDatabase().AuthenticatorOptions())
 	user, err := a.GetUser("")
 	assert.NoError(t, err)
 	user.SetDisabled(true)
@@ -305,7 +305,7 @@ func TestSessionTtlGreaterThan30Days(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	a := auth.NewAuthenticator(rt.MetadataStore(), nil, auth.DefaultAuthenticatorOptions())
+	a := auth.NewAuthenticator(rt.MetadataStore(), nil, rt.GetDatabase().AuthenticatorOptions())
 	user, err := a.GetUser("")
 	assert.NoError(t, err)
 	user.SetDisabled(true)
@@ -378,7 +378,7 @@ func TestSessionExtension(t *testing.T) {
 		SessionUUID: user.GetSessionUUID(),
 	}
 
-	assert.NoError(t, rt.MetadataStore().Set(auth.DocIDForSession(fakeSession.ID), 0, nil, fakeSession))
+	assert.NoError(t, rt.MetadataStore().Set(authenticator.DocIDForSession(fakeSession.ID), 0, nil, fakeSession))
 	reqHeaders := map[string]string{
 		"Cookie": auth.DefaultCookieName + "=" + fakeSession.ID,
 	}
@@ -397,7 +397,7 @@ func TestSessionExtension(t *testing.T) {
 	// scenario for expired session. In reality, Sync Gateway rely on Couchbase
 	// Server to nuke the expired document based on TTL. Couchbase Server periodically
 	// removes all items with expiration times that have passed.
-	assert.NoError(t, rt.MetadataStore().Delete(auth.DocIDForSession(fakeSession.ID)))
+	assert.NoError(t, rt.MetadataStore().Delete(authenticator.DocIDForSession(fakeSession.ID)))
 
 	response = rt.SendRequestWithHeaders("GET", "/{{.keyspace}}/doc1", "", reqHeaders)
 	log.Printf("GET Request: Set-Cookie: %v", response.Header().Get("Set-Cookie"))
@@ -624,7 +624,7 @@ func TestUserWithoutSessionUUID(t *testing.T) {
 	require.NoError(t, authenticator.Save(user))
 
 	var rawUser map[string]interface{}
-	_, err = rt.MetadataStore().Get(user.DocID(), &rawUser)
+	_, err = rt.MetadataStore().Get(authenticator.DocIDForUser(user.Name()), &rawUser)
 	require.NoError(t, err)
 
 	sessionUUIDKey := "session_uuid"
@@ -632,7 +632,7 @@ func TestUserWithoutSessionUUID(t *testing.T) {
 	require.True(t, exists)
 	delete(rawUser, sessionUUIDKey)
 
-	err = rt.MetadataStore().Set(user.DocID(), 0, nil, rawUser)
+	err = rt.MetadataStore().Set(authenticator.DocIDForUser(user.Name()), 0, nil, rawUser)
 	require.NoError(t, err)
 
 	response := rt.SendUserRequest(http.MethodPost, "/{{.db}}/_session", "", username)
@@ -676,7 +676,7 @@ func TestSessionExpirationDateTimeFormat(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	authenticator := auth.NewAuthenticator(rt.MetadataStore(), nil, auth.DefaultAuthenticatorOptions())
+	authenticator := auth.NewAuthenticator(rt.MetadataStore(), nil, rt.GetDatabase().AuthenticatorOptions())
 	user, err := authenticator.NewUser("alice", "letMe!n", channels.BaseSetOf(t, "*"))
 	assert.NoError(t, err, "Couldn't create new user")
 	assert.NoError(t, authenticator.Save(user), "Couldn't save new user")

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -1009,11 +1009,11 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/{{.db}}/_user/user1", GetUserPayload(t, "user1", "letmein", "", collection, []string{"channel_1"}, []string{"role1"}))
 	RequireStatus(t, response, http.StatusCreated)
 
-	_, err := rt.MetadataStore().Get(base.RolePrefix+"role1", &body)
+	_, err := rt.MetadataStore().Get(rt.GetDatabase().MetadataKeys.RoleKey("role1"), &body)
 	assert.NoError(t, err)
 	role1SeqBefore := body["sequence"].(float64)
 
-	_, err = rt.MetadataStore().Get(base.UserPrefix+"user1", &body)
+	_, err = rt.MetadataStore().Get(rt.GetDatabase().MetadataKeys.UserKey("user1"), &body)
 	assert.NoError(t, err)
 	user1SeqBefore := body["sequence"].(float64)
 
@@ -1067,11 +1067,11 @@ func TestResyncRegenerateSequences(t *testing.T) {
 		})
 	WaitAndAssertBackgroundManagerExpiredHeartbeat(t, rt.GetDatabase().ResyncManager)
 
-	_, err = rt.MetadataStore().Get(base.RolePrefix+"role1", &body)
+	_, err = rt.MetadataStore().Get(rt.GetDatabase().MetadataKeys.RoleKey("role1"), &body)
 	assert.NoError(t, err)
 	role1SeqAfter := body["sequence"].(float64)
 
-	_, err = rt.MetadataStore().Get(base.UserPrefix+"user1", &body)
+	_, err = rt.MetadataStore().Get(rt.GetDatabase().MetadataKeys.UserKey("user1"), &body)
 	assert.NoError(t, err)
 	user1SeqAfter := body["sequence"].(float64)
 

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -487,7 +487,7 @@ func TestUserAndRoleResponseContentType(t *testing.T) {
 	assert.Equal(t, "application/json", response.Header().Get("Content-Type"))
 
 	// Create a new user and save to database to create user session.
-	authenticator := auth.NewAuthenticator(rt.MetadataStore(), nil, auth.DefaultAuthenticatorOptions())
+	authenticator := auth.NewAuthenticator(rt.MetadataStore(), nil, rt.GetDatabase().AuthenticatorOptions())
 	user, err := authenticator.NewUser("eve", "cGFzc3dvcmQ=", channels.BaseSetOf(t, "*"))
 	assert.NoError(t, err, "Couldn't create new user")
 	assert.NoError(t, authenticator.Save(user), "Couldn't save new user")

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -164,11 +164,15 @@ func (rt *RestTester) Bucket() base.Bucket {
 	rt.TestBucket = testBucket
 
 	if rt.InitSyncSeq > 0 {
-		log.Printf("Initializing %s to %d", base.SyncSeqKey, rt.InitSyncSeq)
-		tbDatastore := testBucket.GetSingleDataStore()
-		_, incrErr := tbDatastore.Incr(base.SyncSeqKey, rt.InitSyncSeq, rt.InitSyncSeq, 0)
+		if base.TestsUseNamedCollections() {
+			rt.TB.Fatalf("RestTester InitSyncSeq doesn't support non-default collections")
+		}
+
+		log.Printf("Initializing %s to %d", base.DefaultMetadataKeys.SyncSeqKey(), rt.InitSyncSeq)
+		tbDatastore := testBucket.GetMetadataStore()
+		_, incrErr := tbDatastore.Incr(base.DefaultMetadataKeys.SyncSeqKey(), rt.InitSyncSeq, rt.InitSyncSeq, 0)
 		if incrErr != nil {
-			rt.TB.Fatalf("Error initializing %s in test bucket: %v", base.SyncSeqKey, incrErr)
+			rt.TB.Fatalf("Error initializing %s in test bucket: %v", base.DefaultMetadataKeys.SyncSeqKey(), incrErr)
 		}
 	}
 


### PR DESCRIPTION
Adds infrastructure for namespacing metadata keys, and implements for database-scoped metadata documents. Defines a factory type for generating metadata keys (MetadataKeys) that is initialized when a databaseContext is created, and passed to consumers associated with that database.

CBG-2321

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1548/
- [ ] `GSI=true,xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1549/
