### PR TITLE
CBG-2663 change index definitions

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -467,8 +467,16 @@ func (c *CbgtContext) RemoveFeedCredentials(dbName string) {
 func ImportDestKey(dbName string, scope string, collections []string) string {
 	sort.Strings(collections)
 	collectionString := ""
+	onlyDefault := true
 	for _, collection := range collections {
+		if collection != DefaultCollection {
+			onlyDefault = false
+		}
 		collectionString += fmt.Sprintf("%s.%s:", scope, collection)
+	}
+	// format for _default._default
+	if collectionString == "" || (scope == DefaultScope && onlyDefault) {
+		return fmt.Sprintf("%s_import", dbName)
 	}
 	return fmt.Sprintf("%s_import_%x", dbName, sha256.Sum256([]byte(collectionString)))
 }

--- a/base/dcp_sharded_test.go
+++ b/base/dcp_sharded_test.go
@@ -35,3 +35,73 @@ func TestIndexName(t *testing.T) {
 		})
 	}
 }
+
+func TestImportDestKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		dbName      string
+		scopeName   string
+		collections []string
+		key         string
+	}{
+		{
+			name:   "no scope or collections",
+			dbName: "foo",
+			key:    "foo_import",
+		},
+		{
+			name:      "scope but only not collection",
+			dbName:    "foo",
+			scopeName: DefaultScope,
+			key:       "foo_import",
+		},
+		{
+			name:        "custom collection, default scope",
+			dbName:      "foo",
+			scopeName:   DefaultScope,
+			collections: []string{"bar"},
+			key:         "foo_import_02e3c10f452b5d9d5051ae25270ae5714471774097ca7e00424b52bf63de1f6d",
+		},
+		{
+			name:        "custom collection, custom scope",
+			dbName:      "foo",
+			scopeName:   "baz",
+			collections: []string{"bar"},
+			key:         "foo_import_3a4b66f3c8aa40608000c82c417f201de305a1994f3048b7734a33205be5e410",
+		},
+		{
+			name:        "custom collections, custom scope",
+			dbName:      "foo",
+			scopeName:   "bar",
+			collections: []string{"baz", "bat"},
+			key:         "foo_import_cc2777dc506c83ef70c0630be2f21cbe9380d83d2d50c8aeb428e67691503cfb",
+		},
+		{
+			name:        "custom collection, multiple scopes",
+			dbName:      "foo",
+			scopeName:   "bar",
+			collections: []string{"baz", "bat"},
+			key:         "foo_import_cc2777dc506c83ef70c0630be2f21cbe9380d83d2d50c8aeb428e67691503cfb",
+		},
+		{
+			name:        "default collection, multiple scopes",
+			dbName:      "foo",
+			scopeName:   DefaultScope,
+			collections: []string{"baz", "bat"},
+			key:         "foo_import_98ea225323328e1d6ae54575908419f85dcad91b2ee3acb56b3a6491145d87cf",
+		},
+
+		{
+			name:        "scope but only not collection",
+			dbName:      "foo",
+			scopeName:   DefaultScope,
+			collections: []string{DefaultCollection},
+			key:         "foo_import",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.key, ImportDestKey(test.dbName, test.scopeName, test.collections))
+		})
+	}
+}

--- a/base/main_test_bucket_pool_util.go
+++ b/base/main_test_bucket_pool_util.go
@@ -57,7 +57,7 @@ func RequireNumTestDataStores(t testing.TB, numRequired int) {
 	TestRequiresCollections(t)
 	available := tbpNumCollectionsPerBucket()
 	if available < numRequired {
-		t.Skipf("Only had %d usable test buckets available (test requires %d)", available, numRequired)
+		t.Skipf("Only had %d usable test data stores available (test requires %d)", available, numRequired)
 	}
 }
 

--- a/db/database.go
+++ b/db/database.go
@@ -649,8 +649,8 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	// If this is an xattr import node, start import feed.  Must be started after the caching DCP feed, as import cfg
 	// subscription relies on the caching feed.
 	if importEnabled {
-		dbContext.ImportListener = NewImportListener(metaKeys.DCPCheckpointPrefix(dbContext.Options.GroupID))
-		if importFeedErr := dbContext.ImportListener.StartImportFeed(ctx, bucket, dbContext.DbStats, dbContext); importFeedErr != nil {
+		dbContext.ImportListener = NewImportListener(ctx, metaKeys.DCPCheckpointPrefix(dbContext.Options.GroupID), dbContext)
+		if importFeedErr := dbContext.ImportListener.StartImportFeed(dbContext); importFeedErr != nil {
 			return nil, importFeedErr
 		}
 

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -79,8 +79,11 @@ func (il *importListener) StartImportFeed(dbContext *DatabaseContext) (err error
 		}
 	}
 	sort.Strings(collectionNamesByScope[scopeName])
-	il.importDestKey = base.ImportDestKey(il.dbName, scopeName, collectionNamesByScope[scopeName])
-
+	if dbContext.OnlyDefaultCollection() {
+		il.importDestKey = base.ImportDestKey(il.dbName, "", []string{})
+	} else {
+		il.importDestKey = base.ImportDestKey(il.dbName, scopeName, collectionNamesByScope[scopeName])
+	}
 	feedArgs := sgbucket.FeedArguments{
 		ID:               base.DCPImportFeedID,
 		Backfill:         sgbucket.FeedResume,

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -157,10 +157,7 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) (shouldPers
 	// Ignore internal documents
 	if strings.HasPrefix(key, base.SyncDocPrefix) {
 		// Ignore all DCP checkpoints no matter config group ID
-		if strings.HasPrefix(key, base.DCPCheckpointRootPrefix) {
-			return false
-		}
-		return true
+		return !strings.HasPrefix(key, base.DCPCheckpointRootPrefix)
 	}
 
 	// If this is a delete and there are no xattrs (no existing SG revision), we shouldn't import

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -3929,10 +3929,12 @@ func TestDeleteDatabasePointingAtSameBucketPersistent(t *testing.T) {
 	resp = rest.BootstrapAdminRequest(t, http.MethodPut, "/db2/", fmt.Sprintf(dbConfig, "db2"))
 	resp.RequireStatus(http.StatusCreated)
 
+	scopeName := ""
+	collectionNames := []string{}
 	// Validate that deleted database is no longer in dest factory set
-	_, fetchDb1DestErr := base.FetchDestFactory(base.ImportDestKey("db1"))
+	_, fetchDb1DestErr := base.FetchDestFactory(base.ImportDestKey("db1", scopeName, collectionNames))
 	assert.Equal(t, base.ErrNotFound, fetchDb1DestErr)
-	_, fetchDb2DestErr := base.FetchDestFactory(base.ImportDestKey("db2"))
+	_, fetchDb2DestErr := base.FetchDestFactory(base.ImportDestKey("db2", scopeName, collectionNames))
 	assert.NoError(t, fetchDb2DestErr)
 }
 

--- a/rest/importtest/collections_import_test.go
+++ b/rest/importtest/collections_import_test.go
@@ -331,7 +331,7 @@ func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, uint64(docCount), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
+	require.Equal(t, int64(docCount), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
 }
 
 func requireSyncData(rt *rest.RestTester, dataStore base.DataStore, docName string, hasSyncData bool) {

--- a/rest/importtest/collections_import_test.go
+++ b/rest/importtest/collections_import_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/rest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -336,6 +337,8 @@ func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
 }
 
 func TestMultiCollectionImportRemoveCollection(t *testing.T) {
+
+	defer db.SuspendSequenceBatching()()
 	base.SkipImportTestsIfNotEnabled(t)
 	numCollections := 2
 	base.RequireNumTestDataStores(t, numCollections)
@@ -399,8 +402,7 @@ func TestMultiCollectionImportRemoveCollection(t *testing.T) {
 		}
 	}
 
-	// _, err = rt.WaitForChanges(docCount*2, "/{{.keyspace}}/_changes", "", true) // this is correct
-	_, err = rt.WaitForChanges(docCount, "/{{.keyspace}}/_changes", "", true)
+	_, err = rt.WaitForChanges(docCount*2, "/{{.keyspace}}/_changes", "", true)
 	require.NoError(t, err)
 	// there should be 10 documents datastore1_{10..19}
 	require.Equal(t, int64(docCount), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())


### PR DESCRIPTION
I wonder if I should add collection names to the index config or if that's possible.

I did a refactor of import listener and it might be easier to look at this commit by commit.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true,default_collection=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1553/ five minute timeout on waiting for GSI indexes to be ready, not reproducible
- [x] `GSI=true,xattrs=false,default_collection=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1554/ failure https://issues.couchbase.com/browse/CBG-2733
- [x] `GSI=true,xattrs=true,default_collection=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1555/ failure https://issues.couchbase.com/browse/CBG-2738 known 
