### PR TITLE
CBG-2724 change error message to not panic

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -254,7 +254,11 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 		return base.HTTPErrorf(http.StatusBadRequest, fmt.Sprintf("%s", err))
 	}
 	if !collectionCtx.activeSubChanges.CASRetry(false, true) {
-		return fmt.Errorf("blipHandler for collection %d already has an outstanding subChanges. Cannot open another one", *bh.collectionIdx)
+		collectionStr := "default collection"
+		if bh.collectionIdx != nil {
+			collectionStr = fmt.Sprintf("collection %d", *bh.collectionIdx)
+		}
+		return fmt.Errorf("blipHandler for %s already has an outstanding subChanges. Cannot open another one", collectionStr)
 	}
 
 	// Create ctx if it has been cancelled


### PR DESCRIPTION
Reproducible with walrus, so didn't run jenkins.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

