### PR TITLE
CBG-2728 improve error message for /db/ when _default._default does not exist

### DIFF
--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -26,7 +26,6 @@ import (
 // TestCollectionsPutDocInKeyspace creates a collection and starts up a RestTester instance on it.
 // Ensures that various keyspaces can or can't be used to insert a doc in the collection.
 func TestCollectionsPutDocInKeyspace(t *testing.T) {
-	base.TestRequiresCollections(t)
 	const (
 		username = "alice"
 		password = "pass"
@@ -48,9 +47,10 @@ func TestCollectionsPutDocInKeyspace(t *testing.T) {
 	dataStoreName, ok := base.AsDataStoreName(ds)
 	require.True(t, ok)
 	tests := []struct {
-		name           string
-		keyspace       string
-		expectedStatus int
+		name               string
+		keyspace           string
+		expectedStatus     int
+		requireCollections bool
 	}{
 		{
 			name:           "fully qualified",
@@ -72,16 +72,30 @@ func TestCollectionsPutDocInKeyspace(t *testing.T) {
 			keyspace:       strings.Join([]string{dbName, "buzz", dataStoreName.CollectionName()}, base.ScopeCollectionSeparator),
 			expectedStatus: http.StatusNotFound,
 		},
+		{
+			name:               "no default db",
+			keyspace:           dbName,
+			expectedStatus:     http.StatusNotFound,
+			requireCollections: true,
+		},
 	}
 
 	for i, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
+			if test.requireCollections {
+				base.TestRequiresCollections(t)
+			}
 			docID := fmt.Sprintf("doc%d", i)
 			path := fmt.Sprintf("/%s/%s", test.keyspace, docID)
 			resp := rt.SendUserRequestWithHeaders(http.MethodPut, path, `{"test":true}`, nil, username, password)
 			RequireStatus(t, resp, test.expectedStatus)
-
+			if test.expectedStatus == http.StatusNotFound {
+				require.Contains(t, resp.Body.String(), test.keyspace)
+				// assert special case where /db/docID returns db._default._default
+				if test.keyspace == dbName {
+					require.Contains(t, resp.Body.String(), strings.Join([]string{dbName, base.DefaultScope, base.DefaultCollection}, base.ScopeCollectionSeparator))
+				}
+			}
 			if test.expectedStatus == http.StatusCreated {
 				// go and check that the doc didn't just end up in the default collection of the test bucket
 				docBody, _, err := ds.GetRaw(docID)
@@ -90,7 +104,11 @@ func TestCollectionsPutDocInKeyspace(t *testing.T) {
 
 				defaultDataStore := rt.Bucket().DefaultDataStore()
 				_, err = defaultDataStore.Get(docID, &gocb.GetOptions{})
-				assert.Error(t, err)
+				if rt.GetDatabase().OnlyDefaultCollection() {
+					assert.NoError(t, err)
+				} else {
+					assert.Error(t, err)
+				}
 			}
 		})
 	}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -435,6 +435,9 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 		ksNotFound := base.HTTPErrorf(http.StatusNotFound, "keyspace %s not found", ks)
 		if dbContext.Scopes != nil {
 			// If scopes are defined on the database but not in th an empty scope to refer to the one SG is running with, rather than falling back to _default
+			if keyspaceScope == nil && keyspaceCollection == nil {
+				ksNotFound = base.HTTPErrorf(http.StatusNotFound, "keyspace %s.%s.%s not found", ks, base.DefaultScope, base.DefaultCollection)
+			}
 			if keyspaceScope == nil {
 				if len(dbContext.Scopes) == 1 {
 					for scopeName, _ := range dbContext.Scopes {


### PR DESCRIPTION

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1558/
