### PR TITLE
CBG-2729: Add logging for absence of filter in webhook config

### DIFF
--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1105,9 +1105,6 @@ func (sc *ServerContext) initEventHandlers(ctx context.Context, dbcontext *db.Da
 			if err := validateEventConfigOptions(eventType, conf); err != nil {
 				return err
 			}
-			if conf.Filter == "" {
-				base.WarnfCtx(ctx, "No filter specified in webhook configuration or filter has failed to be retrieved")
-			}
 
 			// Load external webhook filter function
 			insecureSkipVerify := false
@@ -1123,6 +1120,9 @@ func (sc *ServerContext) initEventHandlers(ctx context.Context, dbcontext *db.Da
 				}
 			}
 			conf.Filter = filter
+			if conf.Filter == "" {
+				base.WarnfCtx(ctx, "No filter specified in webhook configuration or filter has failed to be retrieved")
+			}
 		}
 
 		// Register event handlers

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1105,6 +1105,9 @@ func (sc *ServerContext) initEventHandlers(ctx context.Context, dbcontext *db.Da
 			if err := validateEventConfigOptions(eventType, conf); err != nil {
 				return err
 			}
+			if conf.Filter == "" {
+				base.WarnfCtx(ctx, "No filter specified in webhook configuration or filter has failed to be retrieved")
+			}
 
 			// Load external webhook filter function
 			insecureSkipVerify := false

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1121,7 +1121,7 @@ func (sc *ServerContext) initEventHandlers(ctx context.Context, dbcontext *db.Da
 			}
 			conf.Filter = filter
 			if conf.Filter == "" {
-				base.WarnfCtx(ctx, "No filter specified in webhook configuration or filter has failed to be retrieved")
+				base.InfofCtx(ctx, base.KeyEvents, "No filter function defined for event handler %s - everything will be processed", eventType.String())
 			}
 		}
 


### PR DESCRIPTION
CBG-2729

Simple PR to just add a warning log line when a filter is not specified or not fetched in webhook config.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
