### PR TITLE
CBG-2733 make tests pass without xattrs

### DIFF
--- a/db/indexes.go
+++ b/db/indexes.go
@@ -472,7 +472,6 @@ func removeObsoleteIndexes(bucket base.N1QLStore, previewOnly bool, useXattrs bo
 
 // Removes an obsolete index from the database.  In preview mode, checks for existence of the index only.
 func removeObsoleteIndex(bucket base.N1QLStore, indexName string, previewOnly bool) (removed bool, err error) {
-
 	if previewOnly {
 		// Check for index existence
 		exists, _, getMetaErr := bucket.GetIndexMeta(indexName)

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -21,8 +21,39 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func requireRoleCount(ctx context.Context, t *testing.T, database *db.Database, expectedRoles int) {
+	// Standard query
+	results, queryErr := database.QueryRoles(ctx, "", 0)
+	require.NoError(t, queryErr, "Query error")
+	defer func() {
+		assert.NoError(t, results.Close())
+	}()
+	var row map[string]interface{}
+	rowCount := 0
+	for results.Next(&row) {
+		rowCount++
+	}
+
+	require.Equal(t, expectedRoles, rowCount)
+
+	// Standard query
+	results, queryErr = database.QueryAllRoles(ctx, "", 0)
+	require.NoError(t, queryErr)
+	defer func() {
+		assert.NoError(t, results.Close())
+	}()
+
+	rowCount = 0
+	for results.Next(&row) {
+		rowCount++
+	}
+	require.Equal(t, expectedRoles, rowCount)
+
+}
 
 func TestRoleQuery(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
@@ -49,8 +80,8 @@ func TestRoleQuery(t *testing.T) {
 
 			n1QLStores, reset, err := setupN1QLStore(ctx, database.Bucket, testCase.isServerless)
 			require.NoError(t, err, "Unable to get n1QLStore for testBucket")
-			defer func(n1QLStore []base.N1QLStore, isServerless bool) {
-				err := reset(n1QLStores, isServerless)
+			defer func(dataStores []base.N1QLStore, isServerless bool) {
+				err := reset(dataStores, isServerless)
 				require.NoError(t, err, "Reset fn shouldn't return error")
 			}(n1QLStores, testCase.isServerless)
 
@@ -64,25 +95,15 @@ func TestRoleQuery(t *testing.T) {
 				require.NoError(t, authenticator.Save(role))
 			}
 
+			requireRoleCount(ctx, t, database, 5)
+
 			// Delete 1 role
 			role1, err := authenticator.NewRole("role1", base.SetOf("ABC"))
 			require.NoError(t, err)
 			err = authenticator.DeleteRole(role1, false, 0)
 			require.NoError(t, err)
 
-			// Standard query
-			results, queryErr := database.QueryRoles(ctx, "", 0)
-			require.NoError(t, queryErr, "Query error")
-			defer func() {
-				require.NoError(t, results.Close())
-			}()
-			var row map[string]interface{}
-			rowCount := 0
-			for results.Next(&row) {
-				rowCount++
-			}
-
-			require.Equal(t, 4, rowCount)
+			requireRoleCount(ctx, t, database, 4)
 		})
 	}
 
@@ -113,8 +134,8 @@ func TestBuildRolesQuery(t *testing.T) {
 
 			n1QLStores, reset, err := setupN1QLStore(ctx, database.Bucket, testCase.isServerless)
 			require.NoError(t, err, "Unable to get n1QLStore for testBucket")
-			defer func(n1QLStore []base.N1QLStore, isServerless bool) {
-				err := reset(n1QLStores, isServerless)
+			defer func(dataStores []base.N1QLStore, isServerless bool) {
+				err := reset(dataStores, isServerless)
 				require.NoError(t, err, "Reset fn shouldn't return error")
 			}(n1QLStores, testCase.isServerless)
 
@@ -158,10 +179,9 @@ func TestBuildUsersQuery(t *testing.T) {
 
 			n1QLStores, reset, err := setupN1QLStore(ctx, database.Bucket, testCase.isServerless)
 			require.NoError(t, err, "Unable to get n1QLStore for testBucket")
-			defer func(n1QLStore []base.N1QLStore, isServerless bool) {
-				err := reset(n1QLStores, isServerless)
-				require.NoError(t, err, "Reset fn shouldn't return error")
-			}(n1QLStores, testCase.isServerless)
+			defer func() {
+				assert.NoError(t, reset(n1QLStores, testCase.isServerless))
+			}()
 
 			// Sessions
 			n1QLStore, ok := base.AsN1QLStore(database.MetadataStore)
@@ -174,68 +194,6 @@ func TestBuildUsersQuery(t *testing.T) {
 			planJSON, err := base.JSONMarshal(plan)
 			require.NoError(t, err)
 			require.Equal(t, testCase.isServerless, covered, "Users query covered by index; expectedToBeCovered: %t, Plan: %s", testCase.isServerless, planJSON)
-		})
-	}
-}
-
-func TestQueryAllRoles(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
-		t.Skip("This test is Couchbase Server and UseViews=false only")
-	}
-
-	testCases := []struct {
-		isServerless bool
-	}{
-		{
-			isServerless: false,
-		},
-		{
-			isServerless: true,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(fmt.Sprintf("TestQueryAllRoles in Serverless=%t", testCase.isServerless), func(t *testing.T) {
-			dbContextConfig := getDatabaseContextOptions(testCase.isServerless)
-			database, ctx := db.SetupTestDBWithOptions(t, dbContextConfig)
-			defer database.Close(ctx)
-
-			n1QLStores, reset, err := setupN1QLStore(ctx, database.Bucket, testCase.isServerless)
-			require.NoError(t, err, "Unable to get n1QLStore for testBucket")
-			defer func(n1QLStore []base.N1QLStore, isServerless bool) {
-				err := reset(n1QLStores, isServerless)
-				require.NoError(t, err, "Reset fn shouldn't return error")
-			}(n1QLStores, testCase.isServerless)
-
-			authenticator := database.Authenticator(ctx)
-			require.NotNil(t, authenticator, "db.Authenticator(ctx) returned nil")
-
-			// Add roles
-			for i := 1; i <= 5; i++ {
-				role, err := authenticator.NewRole(fmt.Sprintf("role%d", i), base.SetOf("ABC"))
-				require.NoError(t, err, "Error creating new role")
-				require.NoError(t, authenticator.Save(role))
-			}
-
-			// Delete 1 role
-			role1, err := authenticator.NewRole("role1", base.SetOf("ABC"))
-			require.NoError(t, err)
-			err = authenticator.DeleteRole(role1, false, 0)
-			require.NoError(t, err)
-
-			// Standard query
-			results, queryErr := database.QueryAllRoles(ctx, "", 0)
-			require.NoError(t, queryErr, "Query error")
-			defer func() {
-				require.NoError(t, results.Close())
-			}()
-
-			var row map[string]interface{}
-			rowCount := 0
-			for results.Next(&row) {
-				rowCount++
-			}
-			require.Equal(t, 5, rowCount)
 		})
 	}
 }
@@ -264,10 +222,9 @@ func TestAllPrincipalIDs(t *testing.T) {
 
 			n1QLStores, reset, err := setupN1QLStore(ctx, database.Bucket, testCase.isServerless)
 			require.NoError(t, err, "Unable to get n1QLStore for testBucket")
-			defer func(n1QLStore []base.N1QLStore, isServerless bool) {
-				err := reset(n1QLStores, isServerless)
-				require.NoError(t, err, "Reset fn shouldn't return error")
-			}(n1QLStores, testCase.isServerless)
+			defer func() {
+				assert.NoError(t, reset(n1QLStores, testCase.isServerless))
+			}()
 
 			base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 
@@ -349,10 +306,9 @@ func TestGetRoleIDs(t *testing.T) {
 
 			n1QLStores, reset, err := setupN1QLStore(ctx, database.Bucket, testCase.isServerless)
 			require.NoError(t, err, "Unable to get n1QLStore for testBucket")
-			defer func(n1QLStore []base.N1QLStore, isServerless bool) {
-				err := reset(n1QLStores, isServerless)
-				require.NoError(t, err, "Reset fn shouldn't return error")
-			}(n1QLStores, testCase.isServerless)
+			defer func() {
+				assert.NoError(t, reset(n1QLStores, testCase.isServerless))
+			}()
 
 			base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -367,7 +367,7 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 			return err
 		}
 		if base.IsDefaultCollection(dsName.ScopeName(), dsName.CollectionName()) {
-			options.MetadataIndexes = IndexesMetadataOnly
+			options.MetadataIndexes = IndexesAll
 		}
 		if err := InitializeIndexes(ctx, n1qlStore, options); err != nil {
 			return err

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -358,7 +358,7 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 			NumReplicas:     0,
 			FailFast:        false,
 			Serverless:      false,
-			MetadataIndexes: IndexesAll,
+			MetadataIndexes: IndexesWithoutMetadata,
 		}
 		dsName, ok := base.AsDataStoreName(dataStore)
 		if !ok {
@@ -393,7 +393,7 @@ func viewBucketReadier(ctx context.Context, dataStore base.DataStore, tbp *base.
 		return err
 	}
 
-	for ddocName, _ := range ddocs {
+	for ddocName := range ddocs {
 		tbp.Logf(ctx, "removing existing view: %s", ddocName)
 		if err := viewStore.DeleteDDoc(ddocName); err != nil {
 			return err

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -56,6 +56,9 @@ func TestSyncGatewayStartupIndexes(t *testing.T) {
 		if base.TestUseXattrs() {
 			indexSyncDocs += "_x1"
 			indexAccess += "_x1"
+		} else {
+			indexSyncDocs += "_1"
+			indexAccess += "_1"
 		}
 		metadataCollection, err := base.AsCollection(bucket.DefaultDataStore())
 		require.NoError(t, err)


### PR DESCRIPTION
- Some changes to rest/indextest for account of different test names
- Changed the db/indexes_test.go to use defer to clean up failed tests, and actually drop all indexes if they actually create indexes that aren't accounted for by the db setup. I'd like to move these tests to /db/indexestest because they are costly to run and also have propensity to kill the indexing service, and at least they'd be isolated from other db tests.
- change test bucket pool to create indexes on `_default._default` as metadata only if using default collection. This holds true for `db` package, but if someone creates `NewRestTesterDefaultCollection`, then `server_context.go` will create all indexes on the default bucket anyway in test.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true,default_collection=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1562/
- [x] `GSI=true,xattrs=false,default_collection=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1563/
- [x] `GSI=true,xattrs=true,default_collection=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1564/
- [x] `GSI=true,xattrs=false,default_collection=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1565/