### PR TITLE
Rename replicator dbs to be unique

### DIFF
--- a/rest/api_test_helpers.go
+++ b/rest/api_test_helpers.go
@@ -25,7 +25,7 @@ func (rt *RestTester) RequireDocNotFound(docID string) {
 }
 
 func (rt *RestTester) TombstoneDoc(docID string, revID string) {
-	rawResponse := rt.SendAdminRequest("DELETE", "/db/"+docID+"?rev="+revID, "")
+	rawResponse := rt.SendAdminRequest("DELETE", "/{{.keyspace}}/"+docID+"?rev="+revID, "")
 	RequireStatus(rt.TB, rawResponse, 200)
 }
 

--- a/rest/replicatortest/replicator_collection_test.go
+++ b/rest/replicatortest/replicator_collection_test.go
@@ -82,6 +82,7 @@ func TestActiveReplicatorMultiCollection(t *testing.T) {
 
 	var resp *rest.TestResponse
 	// create docs in all collections
+
 	for keyspaceNum := 1; keyspaceNum <= numCollections; keyspaceNum++ {
 		for j := 1; j <= numDocsPerCollection; j++ {
 			resp = rt1.SendAdminRequest(http.MethodPut,

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1589,6 +1589,7 @@ func TestDBReplicationStatsTeardown(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}
+
 	base.RequireNumTestBuckets(t, 2)
 	// Test tests Prometheus stat registration
 	base.SkipPrometheusStatsRegistration = false
@@ -1626,8 +1627,8 @@ func TestDBReplicationStatsTeardown(t *testing.T) {
 	}`, tb2.GetName(), base.TestsDisableGSI()))
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
-	rt.CreateReplication("repl1", db2Url.String(), db.ActiveReplicatorTypePush, nil, true, db.ConflictResolverDefault)
-	rt.WaitForReplicationStatus("repl1", db.ReplicationStateRunning)
+	rt.CreateReplicationForDB("{{.db1}}", "repl1", db2Url.String(), db.ActiveReplicatorTypePush, nil, true, db.ConflictResolverDefault)
+	rt.WaitForReplicationStatusForDB("{{.db1}}", "repl1", db.ReplicationStateRunning)
 
 	// Wait for document to replicate from db to db2 to confirm replication start
 	rt.CreateDoc(t, "marker1")

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -619,10 +619,11 @@ func (rt *RestTester) templateResource(resource string) (string, error) {
 			dbNames = append(dbNames, dbName)
 		}
 		sort.Strings(dbNames)
+		multipleDatabases := len(dbNames) > 1
 		for i, dbName := range dbNames {
 			database := databases[dbName]
 			dbPrefix := ""
-			if len(dbNames) == 1 {
+			if !multipleDatabases {
 				data["db"] = database.Name
 			} else {
 				dbPrefix = fmt.Sprintf("db%d", i+1)
@@ -631,18 +632,16 @@ func (rt *RestTester) templateResource(resource string) (string, error) {
 			if len(database.CollectionByID) == 1 {
 				data["keyspace"] = rt.GetSingleKeyspace()
 			} else {
-				multipleKeyspaces := len(getKeyspaces(rt.TB, database)) > 1
 				for j, keyspace := range getKeyspaces(rt.TB, database) {
-					if multipleKeyspaces {
-						data[fmt.Sprintf("db%dkeyspace%d", i+1, j+1)] = keyspace
+					if !multipleDatabases {
+						data[fmt.Sprintf("keyspace%d", j+1)] = keyspace
 					} else {
-						data[fmt.Sprintf("keyspace%d", i+1)] = keyspace
+						data[fmt.Sprintf("db%dkeyspace%d", i+1, j+1)] = keyspace
 					}
 				}
 			}
 		}
 	}
-
 	var uri bytes.Buffer
 	if err := tmpl.Execute(&uri, data); err != nil {
 		return "", err

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -607,16 +607,29 @@ func (rt *RestTester) templateResource(resource string) (string, error) {
 	}
 
 	data := make(map[string]string)
-	if rt.ServerContext() != nil && len(rt.ServerContext().AllDatabases()) == 1 {
-		data["db"] = rt.GetDatabase().Name
-	}
-	database := rt.GetDatabase()
-	if database != nil {
-		if len(database.CollectionByID) == 1 {
-			data["keyspace"] = rt.GetSingleKeyspace()
-		} else {
-			for i, keyspace := range rt.GetKeyspaces() {
-				data[fmt.Sprintf("keyspace%d", i+1)] = keyspace
+	require.NotNil(rt.TB, rt.ServerContext())
+	if rt.ServerContext() != nil {
+		databases := rt.ServerContext().AllDatabases()
+		var dbNames []string
+		for dbName := range databases {
+			dbNames = append(dbNames, dbName)
+		}
+		sort.Strings(dbNames)
+		for i, dbName := range dbNames {
+			database := databases[dbName]
+			dbPrefix := ""
+			if len(dbNames) == 1 {
+				data["db"] = database.Name
+			} else {
+				dbPrefix = fmt.Sprintf("db%d", i+1)
+				data[dbPrefix] = database.Name
+			}
+			if len(database.CollectionByID) == 1 {
+				data["keyspace"] = rt.GetSingleKeyspace()
+			} else {
+				for i, keyspace := range getKeyspaces(rt.TB, database) {
+					data[fmt.Sprintf("keyspace%d", i+1)] = keyspace
+				}
 			}
 		}
 	}
@@ -2302,6 +2315,16 @@ func getRESTKeyspace(_ testing.TB, dbName string, collection *db.DatabaseCollect
 		return dbName
 	}
 	return strings.Join([]string{dbName, collection.ScopeName, collection.Name}, base.ScopeCollectionSeparator)
+}
+
+// getKeyspaces returns the names of all the keyspaces on the rest tester. Currently assumes a single database.
+func getKeyspaces(t testing.TB, database *db.DatabaseContext) []string {
+	var keyspaces []string
+	for _, collection := range database.CollectionByID {
+		keyspaces = append(keyspaces, getRESTKeyspace(t, database.Name, collection))
+	}
+	sort.Strings(keyspaces)
+	return keyspaces
 }
 
 // GetKeyspaces returns the names of all the keyspaces on the rest tester. Currently assumes a single database.

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -146,3 +146,184 @@ func TestCECheck(t *testing.T) {
 	require.Equal(t, req, http.StatusBadRequest)
 
 }
+
+func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+	testCases := []struct {
+		input     string
+		output    string
+		errString string
+	}{
+		{
+			input:     "/{{.db}}/",
+			output:    "",
+			errString: `map has no entry for key "db"`,
+		},
+		{
+			input:     "/{{.db1}}/",
+			output:    "",
+			errString: `map has no entry for key "db1"`,
+		},
+		{
+			input:     "/{{.keyspace}}/",
+			output:    "",
+			errString: `map has no entry for key "keyspace"`,
+		},
+		{
+			input:     "/{{.keyspace1}}/",
+			output:    "",
+			errString: `map has no entry for key "keyspace1"`,
+		},
+		{
+			input:  "/passthrough/",
+			output: "/passthrough/",
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.input, func(t *testing.T) {
+			output, err := rt.templateResource(test.input)
+			if test.errString == "" {
+				require.NoError(t, err)
+			} else {
+				require.Contains(t, fmt.Sprintf("%s", err), test.errString)
+			}
+			require.Equal(t, test.output, output)
+		})
+	}
+	numCollections := 2
+	base.RequireNumTestDataStores(t, numCollections)
+	dbConfig := DbConfig{
+		Scopes: getCollectionsConfigWithSyncFn(rt.TB, rt.TestBucket, nil, numCollections),
+	}
+	dbOne := "dbone"
+	bucket1Datastore1, err := rt.TestBucket.GetNamedDataStore(0)
+	require.NoError(t, err)
+	bucket1Datastore1Name, ok := base.AsDataStoreName(bucket1Datastore1)
+	require.True(t, ok)
+	bucket1Datastore2, err := rt.TestBucket.GetNamedDataStore(1)
+	require.NoError(t, err)
+	bucket1Datastore2Name, ok := base.AsDataStoreName(bucket1Datastore2)
+	require.True(t, ok)
+	resp, err := rt.CreateDatabase(dbOne, dbConfig)
+	require.NoError(t, err)
+	RequireStatus(t, resp, http.StatusCreated)
+	testCases = []struct {
+		input     string
+		output    string
+		errString string
+	}{
+		{
+			input:  "/{{.db}}/",
+			output: fmt.Sprintf("/%s/", dbOne),
+		},
+		{
+			input:     "/{{.db1}}/",
+			output:    "",
+			errString: `map has no entry for key "db1"`,
+		},
+		{
+			input:     "/{{.keyspace}}/",
+			output:    "",
+			errString: `map has no entry for key "keyspace"`,
+		},
+		{
+			input:  "/{{.keyspace1}}/",
+			output: fmt.Sprintf("/%s.%s.%s/", dbOne, bucket1Datastore1Name.ScopeName(), bucket1Datastore1Name.CollectionName()),
+		},
+		{
+			input:  "/{{.keyspace2}}/",
+			output: fmt.Sprintf("/%s.%s.%s/", dbOne, bucket1Datastore2Name.ScopeName(), bucket1Datastore2Name.CollectionName()),
+		},
+	}
+	for _, test := range testCases {
+		t.Run("dbone_"+test.input, func(t *testing.T) {
+			output, err := rt.templateResource(test.input)
+			if test.errString == "" {
+				require.NoError(t, err)
+			} else {
+				require.Contains(t, fmt.Sprintf("%s", err), test.errString)
+			}
+			require.Equal(t, test.output, output)
+		})
+	}
+	base.RequireNumTestBuckets(t, 2)
+	bucket2 := base.GetPersistentTestBucket(t)
+	defer bucket2.Close()
+	dbConfig = DbConfig{
+		Scopes: getCollectionsConfigWithSyncFn(rt.TB, bucket2, nil, numCollections),
+	}
+	dbTwo := "dbtwo"
+	bucket2Datastore1, err := rt.TestBucket.GetNamedDataStore(0)
+	require.NoError(t, err)
+	bucket2Datastore1Name, ok := base.AsDataStoreName(bucket2Datastore1)
+	require.True(t, ok)
+	bucket2Datastore2, err := rt.TestBucket.GetNamedDataStore(1)
+	require.NoError(t, err)
+	bucket2Datastore2Name, ok := base.AsDataStoreName(bucket2Datastore2)
+	require.True(t, ok)
+	resp, err = rt.CreateDatabase(dbTwo, dbConfig)
+	require.NoError(t, err)
+	RequireStatus(t, resp, http.StatusCreated)
+	testCases = []struct {
+		input     string
+		output    string
+		errString string
+	}{
+		{
+			input:     "/{{.db}}/",
+			errString: `map has no entry for key "db"`,
+		},
+		{
+			input:  "/{{.db1}}/",
+			output: fmt.Sprintf("/%s/", dbOne),
+		},
+		{
+			input:  "/{{.db2}}/",
+			output: fmt.Sprintf("/%s/", dbTwo),
+		},
+		{
+			input:     "/{{.keyspace}}/",
+			errString: `map has no entry for key "keyspace"`,
+		},
+		{
+			input:     "/{{.keyspace1}}/",
+			errString: `map has no entry for key "keyspace1"`,
+		},
+		{
+			input:     "/{{.keyspace2}}/",
+			errString: `map has no entry for key "keyspace2"`,
+		},
+		{
+			input:  "/{{.db1keyspace1}}/",
+			output: fmt.Sprintf("/%s.%s.%s/", dbOne, bucket1Datastore1Name.ScopeName(), bucket2Datastore1Name.CollectionName()),
+		},
+		{
+			input:  "/{{.db1keyspace2}}/",
+			output: fmt.Sprintf("/%s.%s.%s/", dbOne, bucket1Datastore2Name.ScopeName(), bucket2Datastore2Name.CollectionName()),
+		},
+
+		{
+			input:  "/{{.db2keyspace1}}/",
+			output: fmt.Sprintf("/%s.%s.%s/", dbTwo, bucket2Datastore1Name.ScopeName(), bucket2Datastore1Name.CollectionName()),
+		},
+		{
+			input:  "/{{.db2keyspace2}}/",
+			output: fmt.Sprintf("/%s.%s.%s/", dbTwo, bucket2Datastore2Name.ScopeName(), bucket2Datastore2Name.CollectionName()),
+		},
+	}
+	for _, test := range testCases {
+		t.Run("twodb_"+test.input, func(t *testing.T) {
+			output, err := rt.templateResource(test.input)
+			if test.errString == "" {
+				require.NoError(t, err)
+			} else {
+				require.Contains(t, fmt.Sprintf("%s", err), test.errString)
+			}
+			require.Equal(t, test.output, output)
+		})
+	}
+
+}


### PR DESCRIPTION
- Using standard `SetupSGRPeers` name the dbs separately so you can tell them apart in the logs
- Enhance the templating scheme to account for multiple databases, `{{.db1}}` to match `{{.keyspace1}}`. More controversially I choose `{{.db1keyspace1}}` in place of `{{.keyspace1}}`

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1570/
