### PR TITLE
CBG-2731: Fix AccessLock blocking _offline calls

### DIFF
--- a/rest/handler.go
+++ b/rest/handler.go
@@ -309,8 +309,12 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 			// any other call
 			dbContext.AccessLock.RLock()
 
-			// defer releasing the dbContext until after the handler method returns
-			defer dbContext.AccessLock.RUnlock()
+			// defer releasing the dbContext until after the handler method returns, unless it's a blipsync request
+			if h.pathTemplateContains("_blipsync") {
+				dbContext.AccessLock.RUnlock()
+			} else {
+				defer dbContext.AccessLock.RUnlock()
+			}
 
 			dbState := atomic.LoadUint32(&dbContext.State)
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -307,12 +307,10 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 			// get a read lock on the dbContext
 			// When the lock is returned we know that the db state will not be changed by
 			// any other call
-			dbContext.AccessLock.RLock()
 
 			// defer releasing the dbContext until after the handler method returns, unless it's a blipsync request
-			if h.pathTemplateContains("_blipsync") {
-				dbContext.AccessLock.RUnlock()
-			} else {
+			if !h.pathTemplateContains("_blipsync") {
+				dbContext.AccessLock.RLock()
 				defer dbContext.AccessLock.RUnlock()
 			}
 

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1658,7 +1658,7 @@ func TestDBReplicationStatsTeardown(t *testing.T) {
 }
 
 func TestTakeDbOfflineOngoingPushReplication(t *testing.T) {
-	t.Skip("Skip until CBG-2731 is fixed")
+	//t.Skip("Skip until CBG-2731 is fixed")
 	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1658,7 +1658,6 @@ func TestDBReplicationStatsTeardown(t *testing.T) {
 }
 
 func TestTakeDbOfflineOngoingPushReplication(t *testing.T) {
-	//t.Skip("Skip until CBG-2731 is fixed")
 	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)


### PR DESCRIPTION
CBG-2731


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1573/
