### PR TITLE
CBG-2736: Set replicator's initialStatus to allow coherent stats across rebalances

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -45,14 +45,14 @@ func NewActiveReplicator(ctx context.Context, config *ActiveReplicatorConfig) *A
 	ar.statusKey = metakeys.ReplicationStatusKey(config.ID)
 
 	if pushReplication := config.Direction == ActiveReplicatorTypePush || config.Direction == ActiveReplicatorTypePushAndPull; pushReplication {
-		ar.Push = NewPushReplicator(config)
+		ar.Push = NewPushReplicator(ctx, config)
 		if ar.config.onComplete != nil {
 			ar.Push.onReplicatorComplete = ar._onReplicationComplete
 		}
 	}
 
 	if pullReplication := config.Direction == ActiveReplicatorTypePull || config.Direction == ActiveReplicatorTypePushAndPull; pullReplication {
-		ar.Pull = NewPullReplicator(config)
+		ar.Pull = NewPullReplicator(ctx, config)
 		if ar.config.onComplete != nil {
 			ar.Pull.onReplicatorComplete = ar._onReplicationComplete
 		}

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -87,7 +87,7 @@ func newActiveReplicatorCommon(ctx context.Context, config *ActiveReplicatorConf
 	initialStatus, err := LoadReplicationStatus(config.ActiveDB.DatabaseContext, config.ID)
 	if err != nil {
 		// Not finding an initialStatus isn't fatal, but we should at least log that we'll reset stats when we do...
-		base.InfofCtx(ctx, base.KeyReplicate, "Couldn't load initial replication status for %q: %v - stats will be reset", config.ID, err)
+		base.InfofCtx(ctx, base.KeyReplicate, "Couldn't load initial replication status for %q: %w - stats will be reset", config.ID, err)
 	}
 
 	apr := activeReplicatorCommon{

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -72,7 +72,7 @@ type activeReplicatorCollection struct {
 	Checkpointer  *Checkpointer  // Checkpointer for this collection
 }
 
-func newActiveReplicatorCommon(config *ActiveReplicatorConfig, direction ActiveReplicatorDirection) *activeReplicatorCommon {
+func newActiveReplicatorCommon(ctx context.Context, config *ActiveReplicatorConfig, direction ActiveReplicatorDirection) *activeReplicatorCommon {
 
 	var replicationStats *BlipSyncStats
 	var checkpointID string
@@ -87,7 +87,7 @@ func newActiveReplicatorCommon(config *ActiveReplicatorConfig, direction ActiveR
 	initialStatus, err := LoadReplicationStatus(config.ActiveDB.DatabaseContext, config.ID)
 	if err != nil {
 		// Not finding an initialStatus isn't fatal, but we should at least log that we'll reset stats when we do...
-		base.InfofCtx(context.TODO(), base.KeyReplicate, "Couldn't load initial replication status: %v - stats will reset", err)
+		base.InfofCtx(ctx, base.KeyReplicate, "Couldn't load initial replication status for %q: %v - stats will be reset", config.ID, err)
 	}
 
 	apr := activeReplicatorCommon{

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -84,11 +84,18 @@ func newActiveReplicatorCommon(config *ActiveReplicatorConfig, direction ActiveR
 		checkpointID = PullCheckpointID(config.ID)
 	}
 
+	initialStatus, err := LoadReplicationStatus(config.ActiveDB.DatabaseContext, config.ID)
+	if err != nil {
+		// Not finding an initialStatus isn't fatal, but we should at least log that we'll reset stats when we do...
+		base.InfofCtx(context.TODO(), base.KeyReplicate, "Couldn't load initial replication status: %v - stats will reset", err)
+	}
+
 	apr := activeReplicatorCommon{
 		config:           config,
 		state:            ReplicationStateStopped,
 		replicationStats: replicationStats,
 		CheckpointID:     config.checkpointPrefix + checkpointID,
+		initialStatus:    initialStatus,
 	}
 
 	if config.CollectionsEnabled {

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -22,9 +22,9 @@ type ActivePullReplicator struct {
 	*activeReplicatorCommon
 }
 
-func NewPullReplicator(config *ActiveReplicatorConfig) *ActivePullReplicator {
+func NewPullReplicator(ctx context.Context, config *ActiveReplicatorConfig) *ActivePullReplicator {
 	apr := ActivePullReplicator{
-		activeReplicatorCommon: newActiveReplicatorCommon(config, ActiveReplicatorTypePull),
+		activeReplicatorCommon: newActiveReplicatorCommon(ctx, config, ActiveReplicatorTypePull),
 	}
 	apr.replicatorConnectFn = apr._connect
 	return &apr

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -27,9 +27,9 @@ type ActivePushReplicator struct {
 	*activeReplicatorCommon
 }
 
-func NewPushReplicator(config *ActiveReplicatorConfig) *ActivePushReplicator {
+func NewPushReplicator(ctx context.Context, config *ActiveReplicatorConfig) *ActivePushReplicator {
 	apr := ActivePushReplicator{
-		activeReplicatorCommon: newActiveReplicatorCommon(config, ActiveReplicatorTypePush),
+		activeReplicatorCommon: newActiveReplicatorCommon(ctx, config, ActiveReplicatorTypePush),
 	}
 	apr.replicatorConnectFn = apr._connect
 	return &apr

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -639,9 +639,6 @@ func TestReplicationStatusActions(t *testing.T) {
 //   - Creates more documents, validates they are replicated
 func TestReplicationRebalancePull(t *testing.T) {
 
-	// TODO: CBG-2736 - Fix replication stats persistence and re-enable test.
-	t.Skipf("CBG-2736 - Fix replication stats persistence and re-enable test.")
-
 	if !base.IsEnterpriseEdition() {
 		t.Skipf("test is EE only (replication rebalance)")
 	}
@@ -746,9 +743,6 @@ func TestReplicationRebalancePull(t *testing.T) {
 //   - adds another active node
 //   - Creates more documents, validates they are replicated
 func TestReplicationRebalancePush(t *testing.T) {
-
-	// TODO: CBG-2736 - Fix replication stats persistence and re-enable test.
-	t.Skipf("CBG-2736 - Fix replication stats persistence and re-enable test.")
 
 	if !base.IsEnterpriseEdition() {
 		t.Skipf("test is EE only (replication rebalance)")


### PR DESCRIPTION
CBG-2736

A regression in #6113 prevented the `initialStatus` field of a replicator from being set. This prevented stats from persisting across replication rebalances and resetting to zero on a rebalance. Initialise the field with the status from a persisted checkpoint.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1575/
  - Unrelated `TestInitializeIndexes`