### PR TITLE
Replace invalid %w with %v in logging

### DIFF
--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -87,7 +87,7 @@ func newActiveReplicatorCommon(ctx context.Context, config *ActiveReplicatorConf
 	initialStatus, err := LoadReplicationStatus(config.ActiveDB.DatabaseContext, config.ID)
 	if err != nil {
 		// Not finding an initialStatus isn't fatal, but we should at least log that we'll reset stats when we do...
-		base.InfofCtx(ctx, base.KeyReplicate, "Couldn't load initial replication status for %q: %w - stats will be reset", config.ID, err)
+		base.InfofCtx(ctx, base.KeyReplicate, "Couldn't load initial replication status for %q: %v - stats will be reset", config.ID, err)
 	}
 
 	apr := activeReplicatorCommon{

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -417,7 +417,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 	// and BlipSyncContext user access.
 	changesDb, err := bh.copyDatabaseCollectionWithUser(bh.collectionIdx)
 	if err != nil {
-		base.WarnfCtx(bh.loggingCtx, "[%s] error sending changes: %w", bh.blipContext.ID, err)
+		base.WarnfCtx(bh.loggingCtx, "[%s] error sending changes: %v", bh.blipContext.ID, err)
 		return false
 
 	}
@@ -868,7 +868,7 @@ func (bh *blipHandler) handleNoRev(rq *blip.Message) error {
 	if collectionCtx.sgr2PullProcessedSeqCallback != nil {
 		seq, err := ParseJSONSequenceID(seqStr)
 		if err != nil {
-			base.WarnfCtx(bh.loggingCtx, "Unable to parse sequence %q from norev message: %w - not tracking for checkpointing", seqStr, err)
+			base.WarnfCtx(bh.loggingCtx, "Unable to parse sequence %q from norev message: %v - not tracking for checkpointing", seqStr, err)
 		} else {
 			collectionCtx.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: revID})
 		}
@@ -952,7 +952,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 				seqStr := rq.Properties[RevMessageSequence]
 				seq, err := ParseJSONSequenceID(seqStr)
 				if err != nil {
-					base.WarnfCtx(bh.loggingCtx, "Unable to parse sequence %q from rev message: %w - not tracking for checkpointing", seqStr, err)
+					base.WarnfCtx(bh.loggingCtx, "Unable to parse sequence %q from rev message: %v - not tracking for checkpointing", seqStr, err)
 				} else {
 					collectionCtx.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: revID})
 				}
@@ -1173,7 +1173,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		seqProperty := rq.Properties[RevMessageSequence]
 		seq, err := ParseJSONSequenceID(seqProperty)
 		if err != nil {
-			base.WarnfCtx(bh.loggingCtx, "Unable to parse sequence %q from rev message: %w - not tracking for checkpointing", seqProperty, err)
+			base.WarnfCtx(bh.loggingCtx, "Unable to parse sequence %q from rev message: %v - not tracking for checkpointing", seqProperty, err)
 		} else {
 			collectionCtx.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: revID})
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1802,7 +1802,7 @@ func (sc *ServerContext) initializeCouchbaseServerConnections(ctx context.Contex
 		// Check for v3.0 persisted configs, migrate to registry format if found
 		err = sc.migrateV30Configs(ctx)
 		if err != nil {
-			base.InfofCtx(ctx, base.KeyConfig, "Unable to migrate v3.0 config to registry - will not be migrated: %w", err)
+			base.InfofCtx(ctx, base.KeyConfig, "Unable to migrate v3.0 config to registry - will not be migrated: %v", err)
 		}
 
 		count, err := sc.fetchAndLoadConfigs(ctx, true)


### PR DESCRIPTION
Replaced all invalid instances of `%w` inside log statements with `%v`

https://go.dev/play/p/cz2vR6Vq2Ic

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a
