### PR TITLE
CBG-2320: ISGR collection explicit mapping (remap collections) (#6131

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -213,7 +213,7 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 	blipContext.WebsocketPingInterval = arc.config.WebsocketPingInterval
 	blipContext.OnExitCallback = func() {
 		// fall into a reconnect loop only if the connection is unexpectedly closed.
-		if arc.ctx.Err() == nil {
+		if arc.ctx.Err() == nil && arc.config.TotalReconnectTimeout != 0 {
 			go arc.reconnectLoop()
 		}
 	}

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -134,9 +134,7 @@ func (a *activeReplicatorCommon) reconnectLoop() {
 
 	// if a reconnect timeout is set, we'll wrap the existing so both can stop the retry loop
 	var deadlineCancel context.CancelFunc
-	if a.config.TotalReconnectTimeout != 0 {
-		ctx, deadlineCancel = context.WithDeadline(ctx, time.Now().Add(a.config.TotalReconnectTimeout))
-	}
+	ctx, deadlineCancel = context.WithDeadline(ctx, time.Now().Add(a.config.TotalReconnectTimeout))
 
 	sleeperFunc := base.SleeperFuncCtx(
 		base.CreateIndefiniteMaxDoublingSleeperFunc(

--- a/db/active_replicator_common_collections.go
+++ b/db/active_replicator_common_collections.go
@@ -99,7 +99,7 @@ func (arc *activeReplicatorCommon) _initCollections() ([]replicationCheckpoint, 
 	}
 	err = base.JSONUnmarshal(rBody, &resp)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("couldn't unmarshal response body: %q: %w", rBody, err)
 	}
 
 	blipSyncCollectionContexts := make([]*blipSyncCollectionContext, len(resp))
@@ -109,7 +109,7 @@ func (arc *activeReplicatorCommon) _initCollections() ([]replicationCheckpoint, 
 		var checkpoint *replicationCheckpoint
 		err = base.JSONUnmarshal(checkpointBody, &checkpoint)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("couldn't unmarshal checkpoint body: %q: %w", checkpointBody, err)
 		}
 
 		if checkpoint == nil {

--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -80,7 +80,7 @@ type ActiveReplicatorConfig struct {
 	InitialReconnectInterval time.Duration
 	// MaxReconnectInterval is the maximum amount of time to wait between exponential backoff reconnect attempts.
 	MaxReconnectInterval time.Duration
-	// TotalReconnectTimeout, if non-zero, is the amount of time to wait before giving up trying to reconnect.
+	// TotalReconnectTimeout, if non-zero, is the amount of time to wait before giving up trying to reconnect. Zero disables reconnect entirely.
 	TotalReconnectTimeout time.Duration
 
 	// CollectionsEnabled can be set to replicate one or more named collections, rather than just the default collection.

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -50,9 +50,12 @@ func (apr *ActivePullReplicator) Start(ctx context.Context) error {
 	err := apr._connect()
 	if err != nil {
 		_ = apr.setError(err)
-		base.WarnfCtx(apr.ctx, "Couldn't connect. Attempting to reconnect in background: %v", err)
-		apr.reconnectActive.Set(true)
-		go apr.reconnectLoop()
+		base.WarnfCtx(apr.ctx, "Couldn't connect: %v", err)
+		if apr.config.TotalReconnectTimeout != 0 {
+			base.InfofCtx(apr.ctx, base.KeyReplicate, "Attempting to reconnect in background: %v", err)
+			apr.reconnectActive.Set(true)
+			go apr.reconnectLoop()
+		}
 	}
 	apr._publishStatus()
 	return err

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -55,9 +55,12 @@ func (apr *ActivePushReplicator) Start(ctx context.Context) error {
 	err := apr._connect()
 	if err != nil {
 		_ = apr.setError(err)
-		base.WarnfCtx(apr.ctx, "Couldn't connect. Attempting to reconnect in background: %v", err)
-		apr.reconnectActive.Set(true)
-		go apr.reconnectLoop()
+		base.WarnfCtx(apr.ctx, "Couldn't connect: %v", err)
+		if apr.config.TotalReconnectTimeout != 0 {
+			base.InfofCtx(apr.ctx, base.KeyReplicate, "Attempting to reconnect in background: %v", err)
+			apr.reconnectActive.Set(true)
+			go apr.reconnectLoop()
+		}
 	}
 	apr._publishStatus()
 	return err

--- a/db/database.go
+++ b/db/database.go
@@ -2276,15 +2276,15 @@ func (dbc *DatabaseContext) GetDatabaseCollection(scopeName, collectionName stri
 		return dbc.GetDefaultDatabaseCollection()
 	}
 	if dbc.Scopes == nil {
-		return nil, fmt.Errorf("scope %s does not exist on this database", base.UD(scopeName))
+		return nil, fmt.Errorf("scope %q does not exist on this database", base.UD(scopeName))
 	}
 	collections, exists := dbc.Scopes[scopeName]
 	if !exists {
-		return nil, fmt.Errorf("scope %s does not exist on this database", base.UD(scopeName))
+		return nil, fmt.Errorf("scope %q does not exist on this database", base.UD(scopeName))
 	}
 	collection, exists := collections.Collections[collectionName]
 	if !exists {
-		return nil, fmt.Errorf("collection %s.%s is not configured on this database", base.UD(scopeName), base.UD(collectionName))
+		return nil, fmt.Errorf("collection \"%s.%s\" does not exist on this database", base.UD(scopeName), base.UD(collectionName))
 	}
 	return collection, nil
 }

--- a/rest/replicatortest/replicator_collection_test.go
+++ b/rest/replicatortest/replicator_collection_test.go
@@ -315,7 +315,7 @@ func TestActiveReplicatorMultiCollectionMismatchedLocalRemote(t *testing.T) {
 
 	err = ar.Start(ctx1)
 	assert.ErrorContains(t, err, "local and remote collections must be the same length")
-	defer func() { assert.NoError(t, ar.Stop()) }()
+	assert.NoError(t, ar.Stop())
 }
 
 // TestActiveReplicatorMultiCollectionMissingRemote attempts to map to a missing remote collection.
@@ -354,7 +354,7 @@ func TestActiveReplicatorMultiCollectionMissingRemote(t *testing.T) {
 
 	err = ar.Start(ctx1)
 	assert.ErrorContains(t, err, "peer does not have collection")
-	defer func() { assert.NoError(t, ar.Stop()) }()
+	assert.NoError(t, ar.Stop())
 }
 
 // TestActiveReplicatorMultiCollectionMissingLocal attempts to use a missing local collection.
@@ -394,5 +394,5 @@ func TestActiveReplicatorMultiCollectionMissingLocal(t *testing.T) {
 
 	err = ar.Start(ctx1)
 	assert.ErrorContains(t, err, "does not exist on this database")
-	defer func() { assert.NoError(t, ar.Stop()) }()
+	assert.NoError(t, ar.Stop())
 }

--- a/rest/replicatortest/replicator_collection_test.go
+++ b/rest/replicatortest/replicator_collection_test.go
@@ -288,7 +288,7 @@ func TestActiveReplicatorMultiCollectionMismatchedLocalRemote(t *testing.T) {
 	localCollections := []string{"ks1", "ks3"}
 	remoteCollections := []string{"ks2"}
 
-	activeRT, _, remoteDbURLString, teardown := rest.SetupSGRPeers(t)
+	activeRT, _, remoteDbURLString, teardown := rest.SetupSGRPeers(t, true)
 	defer teardown()
 
 	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
@@ -314,7 +314,8 @@ func TestActiveReplicatorMultiCollectionMismatchedLocalRemote(t *testing.T) {
 	})
 
 	err = ar.Start(ctx1)
-	require.ErrorContains(t, err, "local and remote collections must be the same length")
+	assert.ErrorContains(t, err, "local and remote collections must be the same length")
+	defer func() { assert.NoError(t, ar.Stop()) }()
 }
 
 // TestActiveReplicatorMultiCollectionMissingRemote attempts to map to a missing remote collection.
@@ -322,7 +323,7 @@ func TestActiveReplicatorMultiCollectionMissingRemote(t *testing.T) {
 
 	base.TestRequiresCollections(t)
 
-	activeRT, _, remoteDbURLString, teardown := rest.SetupSGRPeers(t)
+	activeRT, _, remoteDbURLString, teardown := rest.SetupSGRPeers(t, true)
 	defer teardown()
 
 	localCollection := activeRT.GetSingleTestDatabaseCollection().ScopeName + "." + activeRT.GetSingleTestDatabaseCollection().Name
@@ -352,7 +353,8 @@ func TestActiveReplicatorMultiCollectionMissingRemote(t *testing.T) {
 	})
 
 	err = ar.Start(ctx1)
-	require.ErrorContains(t, err, "peer does not have collection")
+	assert.ErrorContains(t, err, "peer does not have collection")
+	defer func() { assert.NoError(t, ar.Stop()) }()
 }
 
 // TestActiveReplicatorMultiCollectionMissingLocal attempts to use a missing local collection.
@@ -360,7 +362,7 @@ func TestActiveReplicatorMultiCollectionMissingLocal(t *testing.T) {
 
 	base.TestRequiresCollections(t)
 
-	activeRT, passiveRT, remoteDbURLString, teardown := rest.SetupSGRPeers(t)
+	activeRT, passiveRT, remoteDbURLString, teardown := rest.SetupSGRPeers(t, true)
 	defer teardown()
 
 	localCollection := activeRT.GetSingleTestDatabaseCollection().ScopeName + ".invalid"
@@ -391,5 +393,6 @@ func TestActiveReplicatorMultiCollectionMissingLocal(t *testing.T) {
 	})
 
 	err = ar.Start(ctx1)
-	require.ErrorContains(t, err, "does not exist on this database")
+	assert.ErrorContains(t, err, "does not exist on this database")
+	defer func() { assert.NoError(t, ar.Stop()) }()
 }

--- a/rest/replicatortest/replicator_collection_test.go
+++ b/rest/replicatortest/replicator_collection_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/couchbase/sync_gateway/rest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 )
 
 // TestActiveReplicatorMultiCollection is a test to get as much coverage of collections in ISGR as possible.
@@ -29,14 +30,13 @@ import (
 //   - Creates documents on both sides in all collections with identifying information in the document bodies.
 //   - Uses an ActiveReplicator configured for push and pull to ensure that all documents are replicated both ways as expected.
 //   - The replicator only replicates two of three collections, so we also check that we're filtering as expected.
-//   - A future enhancement to the test can be made to ensure that the replication collections are remapped using collections_remote.
+//   - The replicator also remaps local collections to different ones on the remote.
 func TestActiveReplicatorMultiCollection(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 	base.TestRequiresCollections(t)
 
-	// TODO (bbrks): Remove logging
-	base.SetUpTestLogging(t, base.LevelTrace, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
+	base.SetUpTestLogging(t, base.LevelTrace, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg, base.KeyReplicate)
 
 	const (
 		rt1DbName            = "rt1_active"
@@ -77,14 +77,9 @@ func TestActiveReplicatorMultiCollection(t *testing.T) {
 	activeKeyspace2 := rt1Collections[1].ScopeName + "." + rt1Collections[1].Name
 	activeKeyspace3 := rt1Collections[2].ScopeName + "." + rt1Collections[2].Name
 
-	// TODO CBG-2320: Force both sets of keyspaces to match (at least until mapping is implemented so we can support different ones)
-	require.Equal(t, activeKeyspace1, passiveKeyspace1)
-	require.Equal(t, activeKeyspace2, passiveKeyspace2)
-	require.Equal(t, activeKeyspace3, passiveKeyspace3)
-
 	var resp *rest.TestResponse
-	// create docs in all collections
 
+	// create docs in all collections
 	for keyspaceNum := 1; keyspaceNum <= numCollections; keyspaceNum++ {
 		for j := 1; j <= numDocsPerCollection; j++ {
 			resp = rt1.SendAdminRequest(http.MethodPut,
@@ -116,10 +111,17 @@ func TestActiveReplicatorMultiCollection(t *testing.T) {
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
 
+	t.Logf("remapping active %q to passive %q", activeKeyspace1, passiveKeyspace2)
+	t.Logf("not remapping active %q", activeKeyspace3)
 	localCollections := []string{activeKeyspace1, activeKeyspace3}
-	nonReplicatedLocalCollections := []string{activeKeyspace2}
 	remoteCollections := []string{passiveKeyspace2, ""}
-	nonReplicatedRemoteCollections := []string{passiveKeyspace2} // TODO: Change to keyspace one when remapping is implemented
+	t.Logf("not replicating active %q", activeKeyspace2)
+	nonReplicatedLocalCollections := []string{activeKeyspace2}
+	t.Logf("not replicating passive %q", passiveKeyspace1)
+	nonReplicatedRemoteCollections := []string{passiveKeyspace1}
+
+	// The mapping of `""` for activeKeyspace3 requires that these two collections are the same name.
+	assert.Equal(t, activeKeyspace3, passiveKeyspace3)
 
 	ctx1 := rt1.Context()
 	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
@@ -143,13 +145,19 @@ func TestActiveReplicatorMultiCollection(t *testing.T) {
 	require.NoError(t, ar.Start(ctx1))
 
 	// check all expected docs were pushed and pulled
-	for _, localCollection := range localCollections {
-		// TODO: CBG-2320 remap local to remote
-		// remoteCollection := remoteCollections[i]
-		remoteCollection := localCollection
+	for i, localCollection := range localCollections {
+		remoteCollection := remoteCollections[i]
+		if remoteCollection == "" {
+			remoteCollection = localCollection
+		}
 
-		// since we replicated a full collection of docs into another, expect double the amount in each now
+		// we replicated a full collection of docs into another, expect double numDocsPerCollection
 		expectedNumDocs := numDocsPerCollection * 2
+		if slices.Contains(nonReplicatedLocalCollections, localCollection) ||
+			slices.Contains(nonReplicatedRemoteCollections, remoteCollection) {
+			// only one set of docs for non-replicated collections
+			expectedNumDocs = numDocsPerCollection
+		}
 
 		localKeyspace := rt1DbName + "." + localCollection
 		changes, err := rt1.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", localKeyspace), "", true)
@@ -211,10 +219,11 @@ func TestActiveReplicatorMultiCollection(t *testing.T) {
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
 	// check all expected docs were pushed and pulled
-	for _, localCollection := range localCollections {
-		// TODO: CBG-2320 remap local to remote
-		// remoteCollection := remoteCollections[i]
-		remoteCollection := localCollection
+	for i, localCollection := range localCollections {
+		remoteCollection := remoteCollections[i]
+		if remoteCollection == "" {
+			remoteCollection = localCollection
+		}
 
 		// since we replicated a full collection of docs into another, expect double the amount in each now
 		expectedNumDocs := (numDocsPerCollection + 1) * 2


### PR DESCRIPTION
CBG-2320

Support `collections_remote` config to remap local collection names to different ones on the remote when using ISGR.
  - Mapping is encapsulated in `_initCollections` as everything on both sides use only indexes. There's no need to make this mapping leak any further into the code.
  - Extended `TestActiveReplicatorMultiCollection` to now also apply/assert on the mappings defined by `collections_local`/`collections_remote`.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1603/
