### PR TITLE
Add bucket name explicitly

### DIFF
--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -197,6 +197,9 @@ func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
 	base.RequireNumTestDataStores(t, numCollections)
 	dbConfig := DbConfig{
 		Scopes: getCollectionsConfigWithSyncFn(rt.TB, rt.TestBucket, nil, numCollections),
+		BucketConfig: BucketConfig{
+			Bucket: base.StringPtr(rt.TestBucket.GetName()),
+		},
 	}
 	dbOne := "dbone"
 	bucket1Datastore1, err := rt.TestBucket.GetNamedDataStore(0)
@@ -254,6 +257,9 @@ func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
 	defer bucket2.Close()
 	dbConfig = DbConfig{
 		Scopes: getCollectionsConfigWithSyncFn(rt.TB, bucket2, nil, numCollections),
+		BucketConfig: BucketConfig{
+			Bucket: base.StringPtr(bucket2.GetName()),
+		},
 	}
 	dbTwo := "dbtwo"
 	bucket2Datastore1, err := rt.TestBucket.GetNamedDataStore(0)


### PR DESCRIPTION
I broke this on master with https://github.com/couchbase/sync_gateway/commit/96577531331276fe6721704b89f17aad5a2f35fe

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1581/
