### PR TITLE
CBG-2749 create helper functions to be changed as we pass through a request

### DIFF
--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -113,8 +113,7 @@ func NewDCPCommon(ctx context.Context, callback sgbucket.FeedEventCallbackFunc, 
 		checkpointPrefix:       checkpointPrefix,
 	}
 
-	dcpContextID := fmt.Sprintf("%s-%s", MD(couchbaseStore.GetName()).Redact(), feedID)
-	c.loggingCtx = LogContextWith(ctx, &LogContext{CorrelationID: dcpContextID})
+	c.loggingCtx = CorrelationIDLogCtx(ctx, feedID)
 
 	return c, nil
 }

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -75,7 +75,7 @@ func StartShardedDCPFeed(ctx context.Context, dbName string, configGroup string,
 	}
 
 	// Add logging info before passing ctx down
-	ctx = cbgtContext.AddLogContext(ctx, spec.BucketName)
+	ctx = CorrelationIDLogCtx(ctx, DCPImportFeedID)
 
 	// Start Manager.  Registers this node in the cfg
 	err = cbgtContext.StartManager(ctx, dbName, configGroup, bucket, spec, scope, collections, numPartitions)
@@ -377,13 +377,6 @@ func initCBGTManager(ctx context.Context, bucket Bucket, spec BucketSpec, cfgSG 
 	}
 
 	return cbgtContext, nil
-}
-
-func (c *CbgtContext) AddLogContext(parent context.Context, bucketName string) context.Context {
-	if c != nil && bucketName != "" {
-		return LogContextWith(parent, &LogContext{CorrelationID: MD(bucketName).Redact() + "-" + DCPImportFeedID})
-	}
-	return parent
 }
 
 // StartManager registers this node with cbgt, and the janitor will start feeds on this node.

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -165,7 +165,7 @@ func TestCBGTIndexCreation(t *testing.T) {
 			spec := bucket.BucketSpec
 
 			// Use an in-memory cfg, set up cbgt manager
-			ctx := LogContextWith(TestCtx(t), &LogContext{Database: tc.dbName})
+			ctx := DatabaseLogCtx(TestCtx(t), tc.dbName)
 			cfg, err := NewCbgtCfgMem()
 			require.NoError(t, err)
 			context, err := initCBGTManager(ctx, bucket, spec, cfg, "testIndexCreation", tc.dbName)

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -165,7 +165,7 @@ func TestCBGTIndexCreation(t *testing.T) {
 			spec := bucket.BucketSpec
 
 			// Use an in-memory cfg, set up cbgt manager
-			ctx := LogContextWith(TestCtx(t), &DatabaseLogContext{DatabaseName: tc.dbName})
+			ctx := LogContextWith(TestCtx(t), &LogContext{Database: tc.dbName})
 			cfg, err := NewCbgtCfgMem()
 			require.NoError(t, err)
 			context, err := initCBGTManager(ctx, bucket, spec, cfg, "testIndexCreation", tc.dbName)

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -26,17 +26,20 @@ type LogContext struct {
 	// E.g: Either blip context ID or HTTP Serial number.
 	CorrelationID string
 
+	// Database is the name of the sync gateway database
+	Database string
+
+	// Bucket is the name of the backing bucket
+	Bucket string
+
+	// Scope is the name of a scope
+	Scope string
+
+	// Collection is the name of the collection
+	Collection string
+
 	// TestName can be a unit test name (from t.Name())
 	TestName string
-
-	// TestBucketName is the name of a bucket used during a test
-	TestBucketName string
-
-	// TestScopeName is the name of a scope on used during a test
-	TestScopeName string
-
-	// TestCollectionName is the name of the collection used during a test
-	TestCollectionName string
 }
 
 // addContext returns a string format with additional log context if present.
@@ -49,13 +52,19 @@ func (lc *LogContext) addContext(format string) string {
 		format = "c:" + lc.CorrelationID + " " + format
 	}
 
-	if lc.TestBucketName != "" {
-		keyspace := "b:" + lc.TestBucketName
-		if lc.TestScopeName != "" {
-			keyspace += "." + lc.TestScopeName
+	if lc.Database != "" {
+		if lc.Collection != "" {
+			format = "col:" + lc.Collection + " " + format
 		}
-		if lc.TestCollectionName != "" {
-			keyspace += "." + lc.TestCollectionName
+		format = "db:" + lc.Database + " " + format
+
+	} else if lc.Bucket != "" {
+		keyspace := "b:" + lc.Bucket
+		if lc.Scope != "" {
+			keyspace += "." + lc.Scope
+		}
+		if lc.Collection != "" {
+			keyspace += "." + lc.Collection
 		}
 
 		format = keyspace + " " + format
@@ -70,6 +79,17 @@ func (lc *LogContext) addContext(format string) string {
 
 func (lc *LogContext) getContextKey() LogContextKey {
 	return requestContextKey
+}
+
+func (lc *LogContext) getCopy() LogContext {
+	return LogContext{
+		CorrelationID: lc.CorrelationID,
+		Database:      lc.Database,
+		Bucket:        lc.Bucket,
+		Scope:         lc.Scope,
+		Collection:    lc.Collection,
+		TestName:      lc.TestName,
+	}
 }
 
 func FormatBlipContextID(contextID string) string {
@@ -92,33 +112,42 @@ func bucketCtx(parent context.Context, b Bucket) context.Context {
 	return bucketNameCtx(parent, b.GetName())
 }
 
+// getLogContext returns a log context possibly extending from previous context.
+func getLogCtx(ctx context.Context) LogContext {
+	parentLogCtx, ok := ctx.Value(requestContextKey).(*LogContext)
+	if !ok {
+		return LogContext{}
+	}
+	return parentLogCtx.getCopy()
+}
+
 // bucketNameCtx extends the parent context with a bucket name.
 func bucketNameCtx(parent context.Context, bucketName string) context.Context {
-	parentLogCtx, _ := parent.Value(requestContextKey).(LogContext)
-	newCtx := LogContext{
-		TestName:       parentLogCtx.TestName,
-		TestBucketName: bucketName,
-	}
+	newCtx := getLogCtx(parent)
+	newCtx.Bucket = bucketName
 	return LogContextWith(parent, &newCtx)
 }
 
 // CollectionCtx extends the parent context with a collection name.
-func CollectionCtx(parent context.Context, collectionName string) context.Context {
-	newCtx := CollectionLogContext{
-		Collection: collectionName,
-	}
+func CollectionLogCtx(parent context.Context, collectionName string) context.Context {
+	newCtx := getLogCtx(parent)
+	newCtx.Collection = collectionName
 	return LogContextWith(parent, &newCtx)
 }
 
-// testKeyspaceNameCtx extends the parent context with a bucket name.
-func testKeyspaceNameCtx(parent context.Context, bucketName, scopeName, collectionName string) context.Context {
-	parentLogCtx, _ := parent.Value(requestContextKey).(LogContext)
-	newCtx := LogContext{
-		TestName:           parentLogCtx.TestName,
-		TestBucketName:     bucketName,
-		TestScopeName:      scopeName,
-		TestCollectionName: collectionName,
-	}
+// DatabaseLogCtx extends the parent context with a database.
+func DatabaseLogCtx(parent context.Context, databaseName string) context.Context {
+	newCtx := getLogCtx(parent)
+	newCtx.Database = databaseName
+	return LogContextWith(parent, &newCtx)
+}
+
+// KeyspaceLogCtx extends the parent context with a bucket name.
+func KeyspaceLogCtx(parent context.Context, bucketName, scopeName, collectionName string) context.Context {
+	newCtx := getLogCtx(parent)
+	newCtx.Bucket = bucketName
+	newCtx.Collection = collectionName
+	newCtx.Scope = scopeName
 	return LogContextWith(parent, &newCtx)
 }
 
@@ -128,8 +157,6 @@ type LogContextKey int
 const (
 	requestContextKey LogContextKey = iota
 	serverLogContextKey
-	databaseLogContextKey
-	keyspaceLogContextKey
 )
 
 // ContextAdder interface should be implemented by all custom contexts.
@@ -142,7 +169,7 @@ type ContextAdder interface {
 
 // allLogContextKeys contains the keys of all custom contexts,
 // and is used when writing log prefixes (addPrefixes)
-var allLogContextKeys = [...]LogContextKey{requestContextKey, serverLogContextKey, databaseLogContextKey, keyspaceLogContextKey}
+var allLogContextKeys = [...]LogContextKey{requestContextKey, serverLogContextKey}
 
 // LogContextWith is called to add custom context to the go context.
 // All custom contexts should implement ContextAdder interface
@@ -162,39 +189,6 @@ func (c *ServerLogContext) getContextKey() LogContextKey {
 func (c *ServerLogContext) addContext(format string) string {
 	if c != nil && c.LogContextID != "" {
 		format = "sc:" + c.LogContextID + " " + format
-	}
-	return format
-}
-
-// DatabaseLogContext provides database context data for logging
-type DatabaseLogContext struct {
-	DatabaseName string
-}
-
-func (c *DatabaseLogContext) getContextKey() LogContextKey {
-	return databaseLogContextKey
-}
-
-func (c *DatabaseLogContext) addContext(format string) string {
-	if c != nil && c.DatabaseName != "" {
-		format = "db:" + c.DatabaseName + " " + format
-	}
-	return format
-}
-
-// CollectionLogContext provides collection context data for logging
-type CollectionLogContext struct {
-	Collection string
-}
-
-func (c *CollectionLogContext) getContextKey() LogContextKey {
-	return keyspaceLogContextKey
-}
-
-func (c *CollectionLogContext) addContext(format string) string {
-	if c.Collection != "" {
-		format = "col:" + c.Collection + " " + format
-
 	}
 	return format
 }

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -48,16 +48,8 @@ func (lc *LogContext) addContext(format string) string {
 		return ""
 	}
 
-	if lc.CorrelationID != "" {
-		format = "c:" + lc.CorrelationID + " " + format
-	}
-
-	if lc.Database != "" {
-		if lc.Collection != "" {
-			format = "col:" + lc.Collection + " " + format
-		}
-		format = "db:" + lc.Database + " " + format
-
+	if lc.Collection != "" && (lc.Database != "" || lc.Bucket == "") {
+		format = "col:" + lc.Collection + " " + format
 	} else if lc.Bucket != "" {
 		keyspace := "b:" + lc.Bucket
 		if lc.Scope != "" {
@@ -68,6 +60,12 @@ func (lc *LogContext) addContext(format string) string {
 		}
 
 		format = keyspace + " " + format
+	}
+	if lc.Database != "" {
+		format = "db:" + lc.Database + " " + format
+	}
+	if lc.CorrelationID != "" {
+		format = "c:" + lc.CorrelationID + " " + format
 	}
 
 	if lc.TestName != "" {

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -48,19 +48,26 @@ func (lc *LogContext) addContext(format string) string {
 		return ""
 	}
 
-	if lc.Collection != "" && (lc.Database != "" || lc.Bucket == "") {
-		format = "col:" + lc.Collection + " " + format
-	} else if lc.Bucket != "" {
-		keyspace := "b:" + lc.Bucket
-		if lc.Scope != "" {
-			keyspace += "." + lc.Scope
-		}
-		if lc.Collection != "" {
-			keyspace += "." + lc.Collection
-		}
+	if lc.Bucket != "" {
+		if lc.Database != "" {
+			if lc.Collection != "" {
+				format = "col:" + lc.Collection + " " + format
+			}
 
-		format = keyspace + " " + format
+		} else {
+			keyspace := "b:" + lc.Bucket
+			if lc.Scope != "" {
+				keyspace += "." + lc.Scope
+			}
+			if lc.Collection != "" {
+				keyspace += "." + lc.Collection
+			}
+			format = keyspace + " " + format
+		}
+	} else if lc.Collection != "" {
+		format = "col:" + lc.Collection + " " + format
 	}
+
 	if lc.Database != "" {
 		format = "db:" + lc.Database + " " + format
 	}

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -135,6 +135,13 @@ func CollectionLogCtx(parent context.Context, collectionName string) context.Con
 	return LogContextWith(parent, &newCtx)
 }
 
+// CorrelationIDCtx extends the parent context with a collection name.
+func CorrelationIDLogCtx(parent context.Context, correlationID string) context.Context {
+	newCtx := getLogCtx(parent)
+	newCtx.CorrelationID = correlationID
+	return LogContextWith(parent, &newCtx)
+}
+
 // DatabaseLogCtx extends the parent context with a database.
 func DatabaseLogCtx(parent context.Context, databaseName string) context.Context {
 	newCtx := getLogCtx(parent)

--- a/base/logging_context_test.go
+++ b/base/logging_context_test.go
@@ -1,0 +1,148 @@
+package base
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const standardMessage = "foobar"
+
+// RequireLogIs asserts that the logs produced by function f contain string s.
+func requireLogIs(t testing.TB, s string, f func()) {
+	b := bytes.Buffer{}
+
+	const timestampLength = 30
+
+	// Temporarily override logger output for the given function call
+	consoleLogger.logger.SetOutput(&b)
+	f()
+	var log string
+	// Allow time for logs to be printed
+	retry := func() (shouldRetry bool, err error, value interface{}) {
+		log = b.String()
+		if len(log) < timestampLength {
+			return false, nil, nil
+		}
+		log = b.String()[timestampLength:]
+		if log == s {
+			return false, nil, nil
+		}
+		return true, nil, nil
+	}
+	err, _ := RetryLoop("wait for logs", retry, CreateSleeperFunc(10, 100))
+	consoleLogger.logger.SetOutput(os.Stderr)
+
+	require.NoError(t, err, "Console logs did not contain %q, got %q", s, log)
+}
+
+func RequireLogMessage(t testing.TB, ctx context.Context, expectedMessage string, logString string) {
+	requireLogIs(t, expectedMessage, func() { InfofCtx(ctx, KeyAll, standardMessage) })
+}
+
+func TestLogFormat(t *testing.T) {
+	testCases := []struct {
+		name   string
+		ctx    context.Context
+		output string
+	}{
+		{
+			name:   "background context",
+			ctx:    context.Background(),
+			output: "[INF] foobar\n",
+		},
+		{
+			name:   "empty LogContext context",
+			ctx:    LogContextWith(context.Background(), &LogContext{}),
+			output: "[INF] foobar\n",
+		},
+		{
+			name:   "test context",
+			ctx:    TestCtx(t),
+			output: "[INF] t:TestLogFormat foobar\n",
+		},
+		{
+			name: "bucket only no database",
+			ctx: LogContextWith(context.Background(), &LogContext{
+				Bucket: "testBucket",
+			}),
+			output: "[INF] b:testBucket foobar\n",
+		},
+		{
+			name:   "test and bucket only no database",
+			ctx:    bucketNameCtx(TestCtx(t), "testBucket"),
+			output: "[INF] t:TestLogFormat b:testBucket foobar\n",
+		},
+
+		{
+			name: "full keyspace, no database",
+			ctx: LogContextWith(context.Background(), &LogContext{
+				Bucket:     "testBucket",
+				Collection: "testCollection",
+				Scope:      "testScope",
+			}),
+			output: "[INF] b:testBucket.testScope.testCollection foobar\n",
+		},
+		{
+			name: "partial keyspace, no database",
+			ctx: LogContextWith(context.Background(), &LogContext{
+				Bucket:     "testBucket",
+				Collection: "testCollection",
+			}),
+			output: "[INF] b:testBucket.testCollection foobar\n",
+		},
+		{
+			name: "database only",
+			ctx: LogContextWith(context.Background(), &LogContext{
+				Database: "dbName",
+			}),
+			output: "[INF] db:dbName foobar\n",
+		},
+		{
+			name: "database and bucket",
+			ctx: LogContextWith(context.Background(), &LogContext{
+				Bucket:   "testBucket",
+				Database: "dbName",
+			}),
+			output: "[INF] db:dbName foobar\n",
+		},
+		{
+			name: "database and collection",
+			ctx: LogContextWith(context.Background(), &LogContext{
+				Database:   "dbName",
+				Collection: "testCollection",
+			}),
+			output: "[INF] db:dbName col:testCollection foobar\n",
+		},
+		{
+			name: "database, scope, and collection",
+			ctx: LogContextWith(context.Background(), &LogContext{
+				Database:   "dbName",
+				Scope:      "scopeName",
+				Collection: "testCollection",
+			}),
+			output: "[INF] db:dbName col:testCollection foobar\n",
+		},
+
+		{
+			name: "database, scope, collection, and bucket",
+			ctx: LogContextWith(context.Background(), &LogContext{
+				Bucket:     "testBucket",
+				Collection: "testCollection",
+				Database:   "dbName",
+				Scope:      "ScopeName",
+			}),
+			output: "[INF] db:dbName col:testCollection foobar\n",
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+
+			RequireLogMessage(t, test.ctx, test.output, standardMessage)
+		})
+	}
+	RequireLogMessage(t, context.Background(), "[INF] foobar\n", standardMessage)
+}

--- a/base/logging_context_test.go
+++ b/base/logging_context_test.go
@@ -33,7 +33,7 @@ func requireLogIs(t testing.TB, s string, f func()) {
 		}
 		return true, nil, nil
 	}
-	err, _ := RetryLoop("wait for logs", retry, CreateSleeperFunc(10, 100))
+	err, _ := RetryLoop("wait for logs", retry, CreateSleeperFunc(10, 1000))
 	consoleLogger.logger.SetOutput(os.Stderr)
 
 	require.NoError(t, err, "Console logs did not contain %q, got %q", s, log)

--- a/base/logging_context_test.go
+++ b/base/logging_context_test.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -441,7 +441,7 @@ func (tbp *TestBucketPool) createCollections(ctx context.Context, bucket Bucket)
 	for i := 0; i < tbpNumCollectionsPerBucket(); i++ {
 		scopeName := tbp.testScopeName()
 		collectionName := fmt.Sprintf("%s%d", tbpCollectionPrefix, i)
-		ctx := testKeyspaceNameCtx(ctx, bucket.GetName(), scopeName, collectionName)
+		ctx := KeyspaceLogCtx(ctx, bucket.GetName(), scopeName, collectionName)
 
 		tbp.Logf(ctx, "Creating new collection: %s.%s", scopeName, collectionName)
 		dataStoreName := ScopeAndCollectionName{Scope: scopeName, Collection: collectionName}
@@ -514,7 +514,7 @@ func (tbp *TestBucketPool) createTestBuckets(numBuckets, bucketQuotaMB int, buck
 		itemName := "bucket"
 		if err, _ := RetryLoop(b.GetName()+"bucketInitRetry", func() (bool, error, interface{}) {
 			tbp.Logf(ctx, "Running %s through init function", itemName)
-			ctx = testKeyspaceNameCtx(ctx, b.GetName(), "", "")
+			ctx = KeyspaceLogCtx(ctx, b.GetName(), "", "")
 			err := bucketInitFunc(ctx, b, tbp)
 			if err != nil {
 				tbp.Logf(ctx, "Couldn't init %s, got error: %v - Retrying", itemName, err)
@@ -557,7 +557,7 @@ loop:
 
 				start := time.Now()
 				b, err := tbp.cluster.openTestBucket(testBucketName, waitForReadyBucketTimeout)
-				ctx = testKeyspaceNameCtx(ctx, b.GetName(), "", "")
+				ctx = KeyspaceLogCtx(ctx, b.GetName(), "", "")
 				if err != nil {
 					tbp.Logf(ctx, "Couldn't open bucket to get ready, got error: %v", err)
 					return

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -47,6 +47,7 @@ var ErrCfgCasError = &cbgt.CfgCASError{}
 func NewCfgSG(datastore sgbucket.DataStore, keyPrefix string) (*CfgSG, error) {
 
 	cfgContextID := MD(datastore.GetName()).Redact() + "-cfgSG"
+	// should this inherit DB context?
 	loggingCtx := LogContextWith(context.Background(), &LogContext{CorrelationID: cfgContextID})
 
 	c := &CfgSG{

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -219,7 +219,7 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 	}
 
 	bsc = NewBlipSyncContext(arc.ctx, blipContext, arc.config.ActiveDB, blipContext.ID, arc.replicationStats)
-	bsc.loggingCtx = base.LogContextWith(context.Background(), &base.LogContext{CorrelationID: arc.config.ID + idSuffix})
+	bsc.loggingCtx = base.CorrelationIDLogCtx(context.Background(), arc.config.ID+idSuffix)
 
 	// NewBlipSyncContext has already set deltas as disabled/enabled based on config.ActiveDB.
 	// If deltas have been disabled in the replication config, override this value

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -44,6 +44,7 @@ func (apr *ActivePullReplicator) Start(ctx context.Context) error {
 	}
 
 	apr.setState(ReplicationStateStarting)
+	// intentionally reset the context from having db information on it?
 	logCtx := base.LogContextWith(ctx, &base.LogContext{CorrelationID: apr.config.ID + "-" + string(ActiveReplicatorTypePull)})
 	apr.ctx, apr.ctxCancel = context.WithCancel(logCtx)
 

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -49,6 +49,7 @@ func (apr *ActivePushReplicator) Start(ctx context.Context) error {
 	}
 
 	apr.setState(ReplicationStateStarting)
+	// intentionally reset the context from having db information on it?
 	logCtx := base.LogContextWith(ctx, &base.LogContext{CorrelationID: apr.config.ID + "-" + string(ActiveReplicatorTypePush)})
 	apr.ctx, apr.ctxCancel = context.WithCancel(logCtx)
 

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -173,7 +173,7 @@ func collectionBlipHandler(next blipHandlerFunc) blipHandlerFunc {
 			DatabaseCollection: collectionCtx.dbCollection,
 			user:               bh.db.user,
 		}
-		bh.loggingCtx = base.CollectionCtx(bh.BlipSyncContext.loggingCtx, bh.collection.Name)
+		bh.loggingCtx = base.CollectionLogCtx(bh.BlipSyncContext.loggingCtx, bh.collection.Name)
 		// Call down to the underlying handler and return it's value
 		return next(bh, bm)
 	}

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -184,13 +184,13 @@ func (c *changeCache) Init(logCtx context.Context, dbContext *DatabaseContext, c
 	heap.Init(&c.pendingLogs)
 
 	// background tasks that perform housekeeping duties on the cache
-	bgt, err := NewBackgroundTask("InsertPendingEntries", c.db.Name, c.InsertPendingEntries, c.options.CachePendingSeqMaxWait/2, c.terminator)
+	bgt, err := NewBackgroundTask(c.logCtx, "InsertPendingEntries", c.InsertPendingEntries, c.options.CachePendingSeqMaxWait/2, c.terminator)
 	if err != nil {
 		return err
 	}
 	c.backgroundTasks = append(c.backgroundTasks, bgt)
 
-	bgt, err = NewBackgroundTask("CleanSkippedSequenceQueue", c.db.Name, c.CleanSkippedSequenceQueue, c.options.CacheSkippedSeqMaxWait/2, c.terminator)
+	bgt, err = NewBackgroundTask(c.logCtx, "CleanSkippedSequenceQueue", c.CleanSkippedSequenceQueue, c.options.CacheSkippedSeqMaxWait/2, c.terminator)
 	if err != nil {
 		return err
 	}

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -410,7 +410,7 @@ func TestLateSequenceHandlingDuringCompact(t *testing.T) {
 			perRequestDb, err := CreateDatabase(db.DatabaseContext)
 			dbCollection := GetSingleDatabaseCollectionWithUser(t, perRequestDb)
 			assert.NoError(t, err)
-			perRequestCtx := base.LogContextWith(ctx, &base.LogContext{CorrelationID: fmt.Sprintf("context_%s", channelName)})
+			perRequestCtx := base.CorrelationIDLogCtx(ctx, fmt.Sprintf("context_%s", channelName))
 			feed, err := dbCollection.MultiChangesFeed(perRequestCtx, base.SetOf(channelName), options)
 			require.NoError(t, err, "Feed initialization error")
 

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -102,11 +102,11 @@ type channelCacheImpl struct {
 	validFromLock        sync.RWMutex                  // Mutex used to avoid race between AddToCache and addChannelCache.  See CBG-520 for more details
 }
 
-func NewChannelCacheForContext(options ChannelCacheOptions, context *DatabaseContext) (*channelCacheImpl, error) {
-	return newChannelCache(context.Name, options, context.getQueryHandlerForCollection, context.activeChannels, context.DbStats.Cache())
+func NewChannelCacheForContext(ctx context.Context, options ChannelCacheOptions, context *DatabaseContext) (*channelCacheImpl, error) {
+	return newChannelCache(ctx, context.Name, options, context.getQueryHandlerForCollection, context.activeChannels, context.DbStats.Cache())
 }
 
-func newChannelCache(dbName string, options ChannelCacheOptions, queryHandlerFactory ChannelQueryHandlerFactory,
+func newChannelCache(ctx context.Context, dbName string, options ChannelCacheOptions, queryHandlerFactory ChannelQueryHandlerFactory,
 	activeChannels *channels.ActiveChannels, cacheStats *base.CacheStats) (*channelCacheImpl, error) {
 
 	channelCache := &channelCacheImpl{
@@ -121,7 +121,7 @@ func newChannelCache(dbName string, options ChannelCacheOptions, queryHandlerFac
 		activeChannels:       activeChannels,
 		cacheStats:           cacheStats,
 	}
-	bgt, err := NewBackgroundTask("CleanAgedItems", dbName, channelCache.cleanAgedItems, options.ChannelCacheAge, channelCache.terminator)
+	bgt, err := NewBackgroundTask(ctx, "CleanAgedItems", channelCache.cleanAgedItems, options.ChannelCacheAge, channelCache.terminator)
 	if err != nil {
 		return nil, err
 	}

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -84,7 +84,7 @@ func TestChannelCacheSimpleCompact(t *testing.T) {
 	testStats := dbstats.Cache()
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", options, testQueryHandlerFactory, activeChannels, testStats)
+	cache, err := newChannelCache(base.TestCtx(t), "testDb", options, testQueryHandlerFactory, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 	defer cache.Stop()
 
@@ -124,7 +124,7 @@ func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 	testStats := dbstats.Cache()
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", options, testQueryHandlerFactory, activeChannels, testStats)
+	cache, err := newChannelCache(base.TestCtx(t), "testDb", options, testQueryHandlerFactory, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 	defer cache.Stop()
 
@@ -182,7 +182,7 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 	testStats := dbstats.Cache()
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", options, testQueryHandlerFactory, activeChannels, testStats)
+	cache, err := newChannelCache(base.TestCtx(t), "testDb", options, testQueryHandlerFactory, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 	defer cache.Stop()
 
@@ -279,7 +279,7 @@ func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", options, queryHandler.asFactory, activeChannels, testStats)
+	cache, err := newChannelCache(base.TestCtx(t), "testDb", options, queryHandler.asFactory, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 	defer cache.Stop()
 
@@ -353,7 +353,7 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", options, queryHandler.asFactory, activeChannels, testStats)
+	cache, err := newChannelCache(base.TestCtx(t), "testDb", options, queryHandler.asFactory, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 	defer cache.Stop()
 
@@ -422,7 +422,7 @@ func TestChannelCacheBypass(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", options, queryHandler.asFactory, activeChannels, testStats)
+	cache, err := newChannelCache(base.TestCtx(t), "testDb", options, queryHandler.asFactory, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 	defer cache.Stop()
 
@@ -529,7 +529,7 @@ func TestChannelCacheBackgroundTaskWithIllegalTimeInterval(t *testing.T) {
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
 
-	cache, err := newChannelCache("testDb", options, queryHandler.asFactory, activeChannels, testStats)
+	cache, err := newChannelCache(base.TestCtx(t), "testDb", options, queryHandler.asFactory, activeChannels, testStats)
 	assert.Error(t, err, "Background task error whilst creating channel cache")
 	assert.Nil(t, cache)
 

--- a/db/database.go
+++ b/db/database.go
@@ -385,7 +385,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 
 	// add db info to ctx before having a DatabaseContext (cannot call AddDatabaseLogContext),
 	// in order to pass it to RegisterImportPindexImpl
-	ctx = base.LogContextWith(ctx, &base.DatabaseLogContext{DatabaseName: dbName})
+	ctx = base.DatabaseLogCtx(ctx, dbName)
 
 	// options.MetadataStore is always passed via rest._getOrAddDatabase...
 	// but in db package tests this is unlikely to be set. In this case we'll use the existing bucket connection to store metadata.
@@ -505,7 +505,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		}
 		collectionNameMap := make(map[string]struct{}, len(scope.Collections))
 		for collName, collOpts := range scope.Collections {
-			ctx := base.CollectionCtx(ctx, collName)
+			ctx := base.CollectionLogCtx(ctx, collName)
 			dataStore, err := bucket.NamedDataStore(base.ScopeAndCollectionName{Scope: scopeName, Collection: collName})
 			if err != nil {
 				return nil, err
@@ -1649,7 +1649,7 @@ func (db *Database) Compact(ctx context.Context, skipRunningStateCheck bool, cal
 	purgeBody := Body{"_purged": true}
 	for _, c := range db.CollectionByID {
 		// shadow ctx, sot that we can't misuse the parent's inside the loop
-		ctx := base.CollectionCtx(ctx, c.Name)
+		ctx := base.CollectionLogCtx(ctx, c.Name)
 
 		// create admin collection interface
 		collection, err := db.GetDatabaseCollectionWithUser(c.ScopeName, c.Name)
@@ -2240,7 +2240,7 @@ func CheckTimeout(ctx context.Context) error {
 // AddDatabaseLogContext adds database name to the parent context for logging
 func (dbCtx *DatabaseContext) AddDatabaseLogContext(ctx context.Context) context.Context {
 	if dbCtx != nil && dbCtx.Name != "" {
-		return base.LogContextWith(ctx, &base.DatabaseLogContext{DatabaseName: dbCtx.Name})
+		return base.DatabaseLogCtx(ctx, dbCtx.Name)
 	}
 	return ctx
 }

--- a/db/database.go
+++ b/db/database.go
@@ -467,7 +467,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		defaultOpts := DefaultCacheOptions()
 		cacheOptions = &defaultOpts
 	}
-	channelCache, err := NewChannelCacheForContext(cacheOptions.ChannelCacheOptions, dbContext)
+	channelCache, err := NewChannelCacheForContext(ctx, cacheOptions.ChannelCacheOptions, dbContext)
 	if err != nil {
 		return nil, err
 	}
@@ -725,7 +725,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 					<-dbContext.terminator
 					bgtTerminator.Close()
 				}()
-				bgt, err := NewBackgroundTask("Compact", dbContext.Name, func(ctx context.Context) error {
+				bgt, err := NewBackgroundTask(ctx, "Compact", func(ctx context.Context) error {
 					_, err := db.Compact(ctx, false, func(purgedDocCount *int) {}, bgtTerminator)
 					if err != nil {
 						base.WarnfCtx(ctx, "Error trying to compact tombstoned documents for %q with error: %v", dbContext.Name, err)

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -412,7 +412,7 @@ func setupN1QLStore(ctx context.Context, bucket base.Bucket, isServerless bool) 
 
 	outN1QLStores := make([]base.N1QLStore, 0)
 	for _, dataStoreName := range dataStoreNames {
-		ctx = base.CollectionCtx(ctx, dataStoreName.CollectionName())
+		ctx = base.CollectionLogCtx(ctx, dataStoreName.CollectionName())
 		dataStore, err := bucket.NamedDataStore(dataStoreName)
 		if err != nil {
 			return nil, nil, err

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -478,7 +478,7 @@ func NewSGReplicateManager(ctx context.Context, dbContext *DatabaseContext, cfg 
 
 	return &sgReplicateManager{
 		cfg:                        cfg,
-		loggingCtx:                 base.LogContextWith(ctx, &base.LogContext{CorrelationID: sgrClusterMgrContextID + dbContext.Name}),
+		loggingCtx:                 base.CorrelationIDLogCtx(ctx, sgrClusterMgrContextID),
 		clusterUpdateTerminator:    make(chan struct{}),
 		clusterSubscribeTerminator: make(chan struct{}),
 		dbContext:                  dbContext,

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -399,7 +399,7 @@ func TestRebalanceReplications(t *testing.T) {
 		t.Run(fmt.Sprintf("%s", testCase.name), func(t *testing.T) {
 
 			cluster := NewSGRCluster()
-			cluster.loggingCtx = base.LogContextWith(base.TestCtx(t), &base.LogContext{CorrelationID: sgrClusterMgrContextID + "test"})
+			cluster.loggingCtx = base.CorrelationIDLogCtx(base.TestCtx(t), sgrClusterMgrContextID+"test")
 			cluster.Nodes = testCase.nodes
 			cluster.Replications = testCase.replications
 			cluster.RebalanceReplications()

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -686,7 +686,7 @@ func (b *bootstrapContext) getRegistryAndDatabase(ctx context.Context, bucketNam
 }
 
 func (b *bootstrapContext) addDatabaseLogContext(ctx context.Context, dbName string) context.Context {
-	return base.LogContextWith(ctx, &base.DatabaseLogContext{DatabaseName: dbName})
+	return base.DatabaseLogCtx(ctx, dbName)
 }
 
 func (b *bootstrapContext) ComputeMetadataIDForDbConfig(ctx context.Context, config *DbConfig) (string, error) {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -172,7 +172,7 @@ func newHandler(server *ServerContext, privs handlerPrivs, r http.ResponseWriter
 // ctx returns the request-scoped context for logging/cancellation.
 func (h *handler) ctx() context.Context {
 	if h.rqCtx == nil {
-		h.rqCtx = base.LogContextWith(h.rq.Context(), &base.LogContext{CorrelationID: h.formatSerialNumber()})
+		h.rqCtx = base.CorrelationIDLogCtx(h.rq.Context(), h.formatSerialNumber())
 	}
 	return h.rqCtx
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -179,13 +179,13 @@ func (h *handler) ctx() context.Context {
 
 func (h *handler) addDatabaseLogContext(dbName string) {
 	if dbName != "" {
-		h.rqCtx = base.LogContextWith(h.ctx(), &base.DatabaseLogContext{DatabaseName: dbName})
+		h.rqCtx = base.DatabaseLogCtx(h.ctx(), dbName)
 	}
 }
 
 func (h *handler) addCollectionLogContext(collectionName string) {
 	if collectionName != "" {
-		h.rqCtx = base.LogContextWith(h.ctx(), &base.CollectionLogContext{Collection: collectionName})
+		h.rqCtx = base.CollectionLogCtx(h.ctx(), collectionName)
 	}
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -514,7 +514,11 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 			MetadataIndexes: metadataIndexes,
 			UseXattrs:       config.UseXattrs(),
 		}
-		ctx := base.CollectionCtx(ctx, ds.GetName())
+		dsName, ok := base.AsDataStoreName(ds)
+		if !ok {
+			return fmt.Errorf("Could not get datastore name from %s", base.MD(ds.GetName()))
+		}
+		ctx := base.KeyspaceLogCtx(ctx, bucket.GetName(), dsName.ScopeName(), ds.GetName())
 		indexErr := db.InitializeIndexes(ctx, n1qlStore, options)
 		if indexErr != nil {
 			return false, indexErr

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -518,7 +518,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		if !ok {
 			return false, fmt.Errorf("Could not get datastore name from %s", base.MD(ds.GetName()))
 		}
-		ctx := base.KeyspaceLogCtx(ctx, bucket.GetName(), dsName.ScopeName(), ds.GetName())
+		ctx := base.KeyspaceLogCtx(ctx, bucket.GetName(), dsName.ScopeName(), ds.CollectionName())
 		indexErr := db.InitializeIndexes(ctx, n1qlStore, options)
 		if indexErr != nil {
 			return false, indexErr

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1888,6 +1888,7 @@ func (sc *ServerContext) initializeCouchbaseServerConnections(ctx context.Contex
 }
 
 func (sc *ServerContext) AddServerLogContext(parent context.Context) context.Context {
+	// ServerLogContext is separate from standard LogContext, so this does not reset the log context
 	if sc != nil && sc.LogContextID != "" {
 		return base.LogContextWith(parent, &base.ServerLogContext{LogContextID: sc.LogContextID})
 	}
@@ -1897,6 +1898,7 @@ func (sc *ServerContext) AddServerLogContext(parent context.Context) context.Con
 func (sc *ServerContext) SetContextLogID(parent context.Context, id string) context.Context {
 	if sc != nil {
 		sc.LogContextID = id
+		// ServerLogContext is separate from standard LogContext, so this does not reset the log context
 		return base.LogContextWith(parent, &base.ServerLogContext{LogContextID: sc.LogContextID})
 	}
 	return parent

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -516,7 +516,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		}
 		dsName, ok := base.AsDataStoreName(ds)
 		if !ok {
-			return fmt.Errorf("Could not get datastore name from %s", base.MD(ds.GetName()))
+			return false, fmt.Errorf("Could not get datastore name from %s", base.MD(ds.GetName()))
 		}
 		ctx := base.KeyspaceLogCtx(ctx, bucket.GetName(), dsName.ScopeName(), ds.GetName())
 		indexErr := db.InitializeIndexes(ctx, n1qlStore, options)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -518,7 +518,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		if !ok {
 			return false, fmt.Errorf("Could not get datastore name from %s", base.MD(ds.GetName()))
 		}
-		ctx := base.KeyspaceLogCtx(ctx, bucket.GetName(), dsName.ScopeName(), ds.CollectionName())
+		ctx := base.KeyspaceLogCtx(ctx, bucket.GetName(), dsName.ScopeName(), dsName.CollectionName())
 		indexErr := db.InitializeIndexes(ctx, n1qlStore, options)
 		if indexErr != nil {
 			return false, indexErr

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -94,7 +94,7 @@ func (sg *sgCollect) Start(logFilePath string, ctxSerialNumber uint64, zipFilena
 	args = append(args, "--sync-gateway-executable", sgPath)
 	args = append(args, zipPath)
 
-	ctx := base.LogContextWith(context.Background(), &base.LogContext{CorrelationID: fmt.Sprintf("SGCollect-%03d", ctxSerialNumber)})
+	ctx := base.CorrelationIDLogCtx(context.Background(), fmt.Sprintf("SGCollect-%03d", ctxSerialNumber))
 
 	sg.context, sg.cancel = context.WithCancel(ctx)
 	cmd := exec.CommandContext(sg.context, sgCollectPath, args...)


### PR DESCRIPTION
Created everything on `LogContext` to represent the state of logging, and helper functions to allow updating it. Calling `LogContextWith` with a `LogContext{}` as a second argument will reset it. I wonder if we should have an explicit function for that.

For consideration:

- Order the log information is outputted (see logging_context_test.go)
- Whether there are circumstances where we want to elide information in a logger.
- Places we might want to reset db/collection information, so log lines aren't that long.
 
## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1598/
