### PR TITLE
CBG-2739 make more ISGR tests pass with collections

### DIFF
--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1499,7 +1499,7 @@ func TestPutUserCollectionAccess(t *testing.T) {
 	assert.Contains(t, getResponse.ResponseRecorder.Body.String(), `"all_channels":["!"]`)
 
 	dbConfig := DbConfig{
-		Scopes: getCollectionsConfigWithSyncFn(rt.TB, rt.TestBucket, nil, 1),
+		Scopes: GetCollectionsConfigWithSyncFn(rt.TB, rt.TestBucket, nil, 1),
 		BucketConfig: BucketConfig{
 			Bucket: base.StringPtr(rt.TestBucket.GetName()),
 		},

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -297,7 +297,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 				if rt.SyncFn != "" {
 					syncFn = base.StringPtr(rt.SyncFn)
 				}
-				rt.DatabaseConfig.Scopes = getCollectionsConfigWithSyncFn(rt.TB, testBucket, syncFn, rt.numCollections)
+				rt.DatabaseConfig.Scopes = GetCollectionsConfigWithSyncFn(rt.TB, testBucket, syncFn, rt.numCollections)
 			}
 		}
 
@@ -365,11 +365,11 @@ func (rt *RestTester) MetadataStore() base.DataStore {
 
 // GetCollectionsConfig sets up a ScopesConfig from a TestBucket for use with non default collections.
 func GetCollectionsConfig(t testing.TB, testBucket *base.TestBucket, numCollections int) ScopesConfig {
-	return getCollectionsConfigWithSyncFn(t, testBucket, nil, numCollections)
+	return GetCollectionsConfigWithSyncFn(t, testBucket, nil, numCollections)
 }
 
-// getCollectionsConfigWithSyncFn sets up a ScopesConfig from a TestBucket for use with non default collections. The sync function will be passed for all collections.
-func getCollectionsConfigWithSyncFn(t testing.TB, testBucket *base.TestBucket, syncFn *string, numCollections int) ScopesConfig {
+// GetCollectionsConfigWithSyncFn sets up a ScopesConfig from a TestBucket for use with non default collections. The sync function will be passed for all collections.
+func GetCollectionsConfigWithSyncFn(t testing.TB, testBucket *base.TestBucket, syncFn *string, numCollections int) ScopesConfig {
 	// Get a datastore as provided by the test
 	stores := testBucket.GetNonDefaultDatastoreNames()
 	require.True(t, len(stores) >= numCollections, "Requested more collections %d than found on testBucket %d", numCollections, len(stores))

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -196,7 +196,7 @@ func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
 	numCollections := 2
 	base.RequireNumTestDataStores(t, numCollections)
 	dbConfig := DbConfig{
-		Scopes: getCollectionsConfigWithSyncFn(rt.TB, rt.TestBucket, nil, numCollections),
+		Scopes: GetCollectionsConfigWithSyncFn(rt.TB, rt.TestBucket, nil, numCollections),
 		BucketConfig: BucketConfig{
 			Bucket: base.StringPtr(rt.TestBucket.GetName()),
 		},
@@ -256,7 +256,7 @@ func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
 	bucket2 := base.GetPersistentTestBucket(t)
 	defer bucket2.Close()
 	dbConfig = DbConfig{
-		Scopes: getCollectionsConfigWithSyncFn(rt.TB, bucket2, nil, numCollections),
+		Scopes: GetCollectionsConfigWithSyncFn(rt.TB, bucket2, nil, numCollections),
 		BucketConfig: BucketConfig{
 			Bucket: base.StringPtr(bucket2.GetName()),
 		},


### PR DESCRIPTION
- Fixed TestSGR2TombstoneConflictHandling,TestGroupIDReplications to work with named collections
- Filed special tickets for two tests I could not puzzle out https://issues.couchbase.com/browse/CBG-2772 and https://issues.couchbase.com/browse/CBG-2770

This will close CBG-2739 as all remaining tests are specifically marked with separate tickets.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1585/
