### PR TITLE
CBG-2735 Compute metadataID when database is created, persist in registry

### DIFF
--- a/auth/main_test.go
+++ b/auth/main_test.go
@@ -17,6 +17,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	memWatermarkThresholdMB := uint64(2048)
-	base.TestBucketPoolNoIndexes(m, memWatermarkThresholdMB)
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
+	base.TestBucketPoolNoIndexes(m, tbpOptions)
 }

--- a/base/collection.go
+++ b/base/collection.go
@@ -595,11 +595,13 @@ func (b *GocbV2Bucket) DropDataStore(name sgbucket.DataStoreName) error {
 
 func (b *GocbV2Bucket) CreateDataStore(name sgbucket.DataStoreName) error {
 	// create scope first (if it doesn't already exist)
-	err := b.bucket.Collections().CreateScope(name.ScopeName(), nil)
-	if err != nil && !errors.Is(err, gocb.ErrScopeExists) {
-		return err
+	if name.ScopeName() != DefaultScope {
+		err := b.bucket.Collections().CreateScope(name.ScopeName(), nil)
+		if err != nil && !errors.Is(err, gocb.ErrScopeExists) {
+			return err
+		}
 	}
-	err = b.bucket.Collections().CreateCollection(gocb.CollectionSpec{Name: name.CollectionName(), ScopeName: name.ScopeName()}, nil)
+	err := b.bucket.Collections().CreateCollection(gocb.CollectionSpec{Name: name.CollectionName(), ScopeName: name.ScopeName()}, nil)
 	if err != nil {
 		return err
 	}

--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -82,6 +82,7 @@ const (
 const (
 	DCPCheckpointRootPrefix              = SyncDocPrefix + DCPCheckpointPrefix // used to filter checkpoints across groupIDs, databases
 	SGRegistryKey                        = SyncDocPrefix + "registry"          // Registry of all SG databases defined for the bucket (for all group IDs)
+	SGSyncInfo                           = SyncDocPrefix + "syncInfo"          // SG info for a collection, stored with the collection
 	PersistentConfigPrefixWithoutGroupID = SyncDocPrefix + "dbconfig:"         // PersistentConfigPrefixWithoutGroupID stores a database config
 
 	// Sync function naming is collection-scoped, and collections cannot be associated with multiple databases

--- a/base/main_test.go
+++ b/base/main_test.go
@@ -15,6 +15,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	memWatermarkThresholdMB := uint64(2048)
-	TestBucketPoolNoIndexes(m, memWatermarkThresholdMB)
+	tbpOptions := TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
+	TestBucketPoolNoIndexes(m, tbpOptions)
 }

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -61,10 +61,22 @@ type TestBucketPool struct {
 	// skipCollections may be true for older Couchbase Server versions that do not support collections.
 	skipCollections   bool
 	useExistingBucket bool
+
+	// when useDefaultScope is set, named collections are created in the default scope
+	useDefaultScope bool
+}
+
+type TestBucketPoolOptions struct {
+	MemWatermarkThresholdMB uint64
+	UseDefaultScope         bool
+}
+
+func NewTestBucketPool(bucketReadierFunc TBPBucketReadierFunc, bucketInitFunc TBPBucketInitFunc) *TestBucketPool {
+	return NewTestBucketPoolWithOptions(bucketReadierFunc, bucketInitFunc, TestBucketPoolOptions{})
 }
 
 // NewTestBucketPool initializes a new TestBucketPool. To be called from TestMain for packages requiring test buckets.
-func NewTestBucketPool(bucketReadierFunc TBPBucketReadierFunc, bucketInitFunc TBPBucketInitFunc) *TestBucketPool {
+func NewTestBucketPoolWithOptions(bucketReadierFunc TBPBucketReadierFunc, bucketInitFunc TBPBucketInitFunc, options TestBucketPoolOptions) *TestBucketPool {
 	// We can safely skip setup when we want Walrus buckets to be used.
 	// They'll be created on-demand via GetTestBucketAndSpec,
 	// which is fast enough for Walrus that we don't need to prepare buckets ahead of time.
@@ -74,6 +86,7 @@ func NewTestBucketPool(bucketReadierFunc TBPBucketReadierFunc, bucketInitFunc TB
 			unclosedBuckets:   make(map[string]map[string]struct{}),
 			integrationMode:   TestUseCouchbaseServer(),
 			useExistingBucket: TestUseExistingBucket(),
+			useDefaultScope:   options.UseDefaultScope,
 		}
 		tbp.verbose.Set(tbpVerbose())
 		return &tbp
@@ -101,6 +114,7 @@ func NewTestBucketPool(bucketReadierFunc TBPBucketReadierFunc, bucketInitFunc TB
 		bucketInitFunc:         bucketInitFunc,
 		unclosedBuckets:        make(map[string]map[string]struct{}),
 		useExistingBucket:      TestUseExistingBucket(),
+		useDefaultScope:        options.UseDefaultScope,
 	}
 
 	tbp.cluster = newTestCluster(UnitTestUrl(), tbp.Logf)
@@ -425,7 +439,7 @@ func (tbp *TestBucketPool) createCollections(ctx context.Context, bucket Bucket)
 	}
 
 	for i := 0; i < tbpNumCollectionsPerBucket(); i++ {
-		scopeName := fmt.Sprintf("%s%d", tbpScopePrefix, 0)
+		scopeName := tbp.testScopeName()
 		collectionName := fmt.Sprintf("%s%d", tbpCollectionPrefix, i)
 		ctx := testKeyspaceNameCtx(ctx, bucket.GetName(), scopeName, collectionName)
 
@@ -574,6 +588,14 @@ loop:
 	tbp.Logf(context.Background(), "Stopped bucketReadier")
 }
 
+func (tbp *TestBucketPool) testScopeName() string {
+	if tbp.useDefaultScope {
+		return DefaultScope
+	} else {
+		return fmt.Sprintf("%s%d", tbpScopePrefix, 0)
+	}
+}
+
 // TBPBucketInitFunc is a function that is run once (synchronously) when creating/opening a bucket.
 type TBPBucketInitFunc func(ctx context.Context, b Bucket, tbp *TestBucketPool) error
 
@@ -642,16 +664,16 @@ type tbpBucketName string
 
 // TestBucketPoolMain is used as TestMain in main_test.go packages
 func TestBucketPoolMain(m *testing.M, bucketReadierFunc TBPBucketReadierFunc, bucketInitFunc TBPBucketInitFunc,
-	memWatermarkThresholdMB uint64) {
+	options TestBucketPoolOptions) {
 	// can't use defer because of os.Exit
 	teardownFuncs := make([]func(), 0)
 	teardownFuncs = append(teardownFuncs, SetUpGlobalTestLogging(m))
 	teardownFuncs = append(teardownFuncs, SetUpGlobalTestProfiling(m))
-	teardownFuncs = append(teardownFuncs, SetUpGlobalTestMemoryWatermark(m, memWatermarkThresholdMB))
+	teardownFuncs = append(teardownFuncs, SetUpGlobalTestMemoryWatermark(m, options.MemWatermarkThresholdMB))
 
 	SkipPrometheusStatsRegistration = true
 
-	GTestBucketPool = NewTestBucketPool(bucketReadierFunc, bucketInitFunc)
+	GTestBucketPool = NewTestBucketPoolWithOptions(bucketReadierFunc, bucketInitFunc, options)
 	teardownFuncs = append(teardownFuncs, GTestBucketPool.Close)
 
 	// must be the last teardown function added to the list to correctly detect leaked goroutines
@@ -668,6 +690,6 @@ func TestBucketPoolMain(m *testing.M, bucketReadierFunc TBPBucketReadierFunc, bu
 }
 
 // TestBucketPoolNoIndexes runs a TestMain for packages that do not require creation of indexes
-func TestBucketPoolNoIndexes(m *testing.M, memWatermarkThresholdMB uint64) {
-	TestBucketPoolMain(m, FlushBucketEmptierFunc, NoopInitFunc, memWatermarkThresholdMB)
+func TestBucketPoolNoIndexes(m *testing.M, options TestBucketPoolOptions) {
+	TestBucketPoolMain(m, FlushBucketEmptierFunc, NoopInitFunc, options)
 }

--- a/db/database.go
+++ b/db/database.go
@@ -171,6 +171,7 @@ type DatabaseContextOptions struct {
 	Scopes                        ScopesOptions
 	skipRegisterImportPIndex      bool           // if set, skips the global gocb PIndex registration
 	MetadataStore                 base.DataStore // If set, use this location/connection for SG metadata storage - if not set, metadata is stored using the same location/connection as the bucket used for data storage.
+	MetadataID                    string         // MetadataID used for metadata storage
 }
 
 type ScopesOptions map[string]ScopeOptions
@@ -419,10 +420,10 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	}
 
 	// Initialize metadata ID and keys
-	// TODO: apply length limit to MetadataPrefix
+	// TODO: apply length limit to metadataID
 	metadataID := dbName
-	if options.Scopes.onlyDefaultCollection() {
-		metadataID = ""
+	if options.MetadataID != "" {
+		metadataID = options.MetadataID
 	}
 	metaKeys := base.NewMetadataKeys(metadataID)
 	dbContext.MetadataKeys = metaKeys

--- a/db/functions/main_test.go
+++ b/db/functions/main_test.go
@@ -13,10 +13,12 @@ package functions
 import (
 	"testing"
 
+	"github.com/couchbase/sync_gateway/base"
+
 	"github.com/couchbase/sync_gateway/db"
 )
 
 func TestMain(m *testing.M) {
-	memWatermarkThresholdMB := uint64(2048)
-	db.TestBucketPoolWithIndexes(m, memWatermarkThresholdMB)
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
+	db.TestBucketPoolWithIndexes(m, tbpOptions)
 }

--- a/db/functions/main_test.go
+++ b/db/functions/main_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-
 	"github.com/couchbase/sync_gateway/db"
 )
 

--- a/db/indextest/main_test.go
+++ b/db/indextest/main_test.go
@@ -17,6 +17,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	memWatermarkThresholdMB := uint64(2048)
-	base.TestBucketPoolNoIndexes(m, memWatermarkThresholdMB)
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
+	base.TestBucketPoolNoIndexes(m, tbpOptions)
 }

--- a/db/main_test.go
+++ b/db/main_test.go
@@ -12,9 +12,11 @@ package db
 
 import (
 	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
 )
 
 func TestMain(m *testing.M) {
-	memWatermarkThresholdMB := uint64(2048)
-	TestBucketPoolWithIndexes(m, memWatermarkThresholdMB)
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
+	TestBucketPoolWithIndexes(m, tbpOptions)
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -472,8 +472,8 @@ func (dbc *DatabaseContext) GetPrincipalForTest(tb testing.TB, name string, isUs
 }
 
 // TestBucketPoolWithIndexes runs a TestMain for packages that require creation of indexes
-func TestBucketPoolWithIndexes(m *testing.M, memWatermarkThresholdMB uint64) {
-	base.TestBucketPoolMain(m, viewsAndGSIBucketReadier, viewsAndGSIBucketInit, memWatermarkThresholdMB)
+func TestBucketPoolWithIndexes(m *testing.M, tbpOptions base.TestBucketPoolOptions) {
+	base.TestBucketPoolMain(m, viewsAndGSIBucketReadier, viewsAndGSIBucketInit, tbpOptions)
 }
 
 // Parse the plan looking for use of the fetch operation (appears as the key/value pair "#operator":"Fetch")

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -74,6 +74,11 @@ func (h *handler) handleCreateDB() error {
 			bucket = *config.Bucket
 		}
 
+		metadataID, metadataIDError := h.server.BootstrapContext.ComputeMetadataIDForDbConfig(h.ctx(), config)
+		if metadataIDError != nil {
+			return metadataIDError
+		}
+
 		// copy config before setup to persist the raw config the user supplied
 		var persistedDbConfig DbConfig
 		if err := base.DeepCopyInefficient(&persistedDbConfig, config); err != nil {
@@ -86,9 +91,17 @@ func (h *handler) handleCreateDB() error {
 			return err
 		}
 
-		loadedConfig := DatabaseConfig{Version: version, DbConfig: *config}
+		loadedConfig := DatabaseConfig{
+			Version:    version,
+			MetadataID: metadataID,
+			DbConfig:   *config}
 
-		persistedConfig := DatabaseConfig{Version: version, DbConfig: persistedDbConfig, SGVersion: base.ProductVersion.String()}
+		persistedConfig := DatabaseConfig{
+			Version:    version,
+			MetadataID: metadataID,
+			DbConfig:   persistedDbConfig,
+			SGVersion:  base.ProductVersion.String(),
+		}
 
 		h.server.lock.Lock()
 		defer h.server.lock.Unlock()

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -76,7 +76,8 @@ func (h *handler) handleCreateDB() error {
 
 		metadataID, metadataIDError := h.server.BootstrapContext.ComputeMetadataIDForDbConfig(h.ctx(), config)
 		if metadataIDError != nil {
-			return metadataIDError
+			base.WarnfCtx(h.ctx(), "Unable to compute metadata ID - using standard metadataID.  Error: %v", metadataIDError)
+			metadataID = h.server.BootstrapContext.standardMetadataID(config.Name)
 		}
 
 		// copy config before setup to persist the raw config the user supplied

--- a/rest/adminapitest/main_test.go
+++ b/rest/adminapitest/main_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-
 	"github.com/couchbase/sync_gateway/db"
 )
 

--- a/rest/adminapitest/main_test.go
+++ b/rest/adminapitest/main_test.go
@@ -13,10 +13,12 @@ package adminapitest
 import (
 	"testing"
 
+	"github.com/couchbase/sync_gateway/base"
+
 	"github.com/couchbase/sync_gateway/db"
 )
 
 func TestMain(m *testing.M) {
-	memWatermarkThresholdMB := uint64(8192)
-	db.TestBucketPoolWithIndexes(m, memWatermarkThresholdMB)
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192}
+	db.TestBucketPoolWithIndexes(m, tbpOptions)
 }

--- a/rest/attachmentcompactiontest/main_test.go
+++ b/rest/attachmentcompactiontest/main_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-
 	"github.com/couchbase/sync_gateway/db"
 )
 

--- a/rest/attachmentcompactiontest/main_test.go
+++ b/rest/attachmentcompactiontest/main_test.go
@@ -13,10 +13,12 @@ package attachmentcompactiontest
 import (
 	"testing"
 
+	"github.com/couchbase/sync_gateway/base"
+
 	"github.com/couchbase/sync_gateway/db"
 )
 
 func TestMain(m *testing.M) {
-	memWatermarkThresholdMB := uint64(2048)
-	db.TestBucketPoolWithIndexes(m, memWatermarkThresholdMB)
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
+	db.TestBucketPoolWithIndexes(m, tbpOptions)
 }

--- a/rest/changestest/main_test.go
+++ b/rest/changestest/main_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-
 	"github.com/couchbase/sync_gateway/db"
 )
 

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -33,6 +33,9 @@ type DatabaseConfig struct {
 	// SGVersion is a base.ComparableVersion of the Sync Gateway node that wrote the config.
 	SGVersion string `json:"sg_version,omitempty"`
 
+	// MetadataID is the prefix used to store database metadata
+	MetadataID string `json:"metadata_id"`
+
 	// DbConfig embeds database config properties
 	DbConfig
 }

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -39,6 +39,8 @@ var _ ConfigManager = &bootstrapContext{}
 const configUpdateMaxRetryAttempts = 5 // Maximum number of retries due to conflicting updates or rollback
 const configFetchMaxRetryAttempts = 5  // Maximum number of retries due to registry rollback
 
+const defaultMetadataID = "_default"
+
 // GetConfig fetches a database name for a given bucket and config group ID.
 func (b *bootstrapContext) GetConfigName(bucketName, groupID, dbName string, configName *dbConfigNameOnly) (cas uint64, err error) {
 	return b.Connection.GetMetadataDocument(bucketName, PersistentConfigKey(groupID, dbName), configName)
@@ -71,6 +73,11 @@ func (b *bootstrapContext) InsertConfig(ctx context.Context, bucketName, groupID
 		}
 		if existingConfig != nil {
 			return 0, base.ErrAlreadyExists
+		}
+
+		// If metadataID is not set on the config, compute
+		if config.MetadataID == "" {
+			config.MetadataID = b.computeMetadataID(ctx, registry, &config.DbConfig)
 		}
 
 		// Step 2. Update the registry to add the config
@@ -678,4 +685,72 @@ func (b *bootstrapContext) getRegistryAndDatabase(ctx context.Context, bucketNam
 
 func (b *bootstrapContext) addDatabaseLogContext(ctx context.Context, dbName string) context.Context {
 	return base.LogContextWith(ctx, &base.DatabaseLogContext{DatabaseName: dbName})
+}
+
+func (b *bootstrapContext) ComputeMetadataIDForDbConfig(ctx context.Context, config *DbConfig) (string, error) {
+	bucketName := config.Bucket
+	if bucketName == nil {
+		return "", fmt.Errorf("No bucket defined in dbConfig, cannot compute metadataID")
+	}
+	registry, err := b.getGatewayRegistry(ctx, *bucketName)
+	if err != nil {
+		return "", err
+	}
+	metadataID := b.computeMetadataID(ctx, registry, config)
+	return metadataID, nil
+}
+
+// computeMetadataID determines whether the database should use the default metadata storage location (to support configurations upgrading with
+// existing sync metadata in the default collection).  The default metadataID is only used when all of the following
+// conditions are met:
+//  1. The default metadataID isn't already in use by another database
+//  2. The database includes _default._default
+//  3. The _default._default collection isn't already associated with a different metadata ID (_sync:syncInfo is not present)
+//  4. The _default._default collection has legacy data (_sync:seq is present)
+func (b *bootstrapContext) computeMetadataID(ctx context.Context, registry *GatewayRegistry, config *DbConfig) string {
+
+	standardMetadataID := config.Name
+
+	// If the default metadata ID is already in use in the registry, use standard ID
+	for _, cg := range registry.ConfigGroups {
+		for _, db := range cg.Databases {
+			if db.MetadataID == defaultMetadataID {
+				return standardMetadataID
+			}
+		}
+	}
+
+	// If the database config doesn't include _default._default, use standard ID
+	if config.Scopes != nil {
+		defaultFound := false
+		for scopeName, scope := range config.Scopes {
+			for collectionName, _ := range scope.Collections {
+				if base.IsDefaultCollection(scopeName, collectionName) {
+					defaultFound = true
+				}
+			}
+		}
+		if !defaultFound {
+			return standardMetadataID
+		}
+	}
+
+	// If _default._default is already associated with a metadataID, return standard metadata ID
+	bucketName := *config.Bucket
+	exists, err := b.Connection.KeyExists(bucketName, base.SGSyncInfo)
+	if err != nil {
+		base.WarnfCtx(ctx, "Error checking whether metadataID is already defined for default collection - using standard metadataID.  Error: %w", err)
+		return standardMetadataID
+	}
+	if exists {
+		return standardMetadataID
+	}
+
+	// If legacy _sync:seq doesn't exist, use the standard ID
+	legacySyncSeqExists, err := b.Connection.KeyExists(bucketName, base.DefaultMetadataKeys.SyncSeqKey())
+	if !legacySyncSeqExists {
+		return standardMetadataID
+	}
+	return defaultMetadataID
+
 }

--- a/rest/config_manager_test.go
+++ b/rest/config_manager_test.go
@@ -136,3 +136,23 @@ func TestComputeMetadataID(t *testing.T) {
 	assert.Equal(t, standardMetadataID, metadataID)
 
 }
+
+func TestLongMetadataID(t *testing.T) {
+
+	bootstrapContext := bootstrapContext{}
+
+	shortMetadataID := bootstrapContext.standardMetadataID("dbName")
+	assert.Equal(t, "dbName", shortMetadataID)
+
+	maxLengthNonHashedDbName := "longDbName012345678901234567890123456789012"
+	nonHashedMetadataID := bootstrapContext.standardMetadataID(maxLengthNonHashedDbName)
+	assert.Equal(t, maxLengthNonHashedDbName, nonHashedMetadataID)
+
+	longMetadataID := bootstrapContext.standardMetadataID("longDbName0123456789012345678901234567890123")
+	assert.Equal(t, "6g2n4W2aWmQLvZIH7JXbv4V0klGFAEvZJ68gTVrgW7A=", longMetadataID)
+
+	// Ensure no collision on hashed IDs (i.e. attempting to set a db name to a base64 hash will trigger rehashing)
+	rehashMetadataID := bootstrapContext.standardMetadataID(longMetadataID)
+	assert.NotEqual(t, rehashMetadataID, longMetadataID)
+
+}

--- a/rest/config_manager_test.go
+++ b/rest/config_manager_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,4 +51,88 @@ func TestBootstrapConfig(t *testing.T) {
 
 	_, err = bootstrapContext.GetConfig(bucketName, configGroup1, db1Name, dbConfig1)
 	require.Error(t, err)
+}
+
+func TestComputeMetadataID(t *testing.T) {
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server - requires bootstrap support")
+	}
+
+	base.TestRequiresCollections(t)
+	// Start SG with no databases
+	config := BootstrapStartupConfigForTest(t)
+	ctx := base.TestCtx(t)
+	sc, err := SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+	}()
+
+	bootstrapContext := sc.BootstrapContext
+
+	// Get a test bucket for bootstrap testing
+	tb := base.GetTestBucket(t)
+	defer func() {
+		fmt.Println("closing test bucket")
+		tb.Close()
+	}()
+	bucketName := tb.GetName()
+
+	registry, err := bootstrapContext.getGatewayRegistry(ctx, bucketName)
+
+	dbName := "dbName"
+	standardMetadataID := dbName
+
+	defaultVersion := "1-abc"
+	defaultDbConfig := makeDbConfig(tb.GetName(), dbName, nil)
+
+	// No sync data in default collection, so should use standard ID
+	metadataID := bootstrapContext.computeMetadataID(ctx, registry, &defaultDbConfig)
+	assert.Equal(t, standardMetadataID, metadataID)
+
+	// Set _sync:seq in default collection, verify computeMetadataID returns default ID
+	defaultStore := tb.Bucket.DefaultDataStore()
+	syncSeqKey := base.DefaultMetadataKeys.SyncSeqKey()
+	_, err = defaultStore.Incr(syncSeqKey, 1, 0, 0)
+	require.NoError(t, err)
+
+	metadataID = bootstrapContext.computeMetadataID(ctx, registry, &defaultDbConfig)
+	assert.Equal(t, defaultMetadataID, metadataID)
+
+	// Add another database to the registry already using defaultMetadataID
+	existingDbName := "existingDb"
+	existingDbConfig := makeDbConfig(tb.GetName(), existingDbName, nil)
+	existingDatabaseConfig := &DatabaseConfig{
+		DbConfig:   existingDbConfig,
+		Version:    defaultVersion,
+		MetadataID: defaultMetadataID,
+	}
+	_, err = registry.upsertDatabaseConfig(ctx, t.Name(), existingDatabaseConfig)
+	require.NoError(t, err)
+	metadataID = bootstrapContext.computeMetadataID(ctx, registry, &defaultDbConfig)
+	assert.Equal(t, standardMetadataID, metadataID)
+
+	// remove duplicate from registry for remaining cases
+	require.True(t, registry.removeDatabase(t.Name(), existingDbName))
+
+	// Database that includes the default collection (where _sync:seq exists) should use default metadata ID
+	defaultAndNamedScopesConfig := ScopesConfig{base.DefaultScope: ScopeConfig{map[string]CollectionConfig{base.DefaultCollection: {}, "collection1": {}}}}
+	defaultDbConfig.Scopes = defaultAndNamedScopesConfig
+	metadataID = bootstrapContext.computeMetadataID(ctx, registry, &defaultDbConfig)
+	assert.Equal(t, defaultMetadataID, metadataID)
+
+	// Single, non-default collection should use standard metadata ID
+	namedOnlyScopesConfig := ScopesConfig{base.DefaultScope: ScopeConfig{map[string]CollectionConfig{"collection1": {}}}}
+	defaultDbConfig.Scopes = namedOnlyScopesConfig
+	metadataID = bootstrapContext.computeMetadataID(ctx, registry, &defaultDbConfig)
+	assert.Equal(t, standardMetadataID, metadataID)
+
+	// Write syncInfo to default collection, indicating that default collection is already associated with a different database
+	docBody := []byte(`{"foo":"bar"}`)
+	err = defaultStore.Set(base.SGSyncInfo, 0, nil, docBody)
+	defaultDbConfig.Scopes = nil
+	metadataID = bootstrapContext.computeMetadataID(ctx, registry, &defaultDbConfig)
+	assert.Equal(t, standardMetadataID, metadataID)
+
 }

--- a/rest/config_registry.go
+++ b/rest/config_registry.go
@@ -326,10 +326,8 @@ func findCollectionConflicts(scopes ScopesConfig, registryScopes map[string]Regi
 	return conflicts
 }
 
-// getCollectionConflicts returns a map of registry collections that are in conflict with the provided scopesConfig.  Map values
-// are the dbName for the conflicting collection.  Matching collections for the same dbname is not a conflicts (even across config groups).
+// hasMetadataIDConflict checks whether the specified metadataID is already in use by a different db in the registry
 func (r *GatewayRegistry) hasMetadataIDConflict(dbName string, metadataID string) bool {
-
 	for _, configGroup := range r.ConfigGroups {
 		for registryDbName, database := range configGroup.Databases {
 			if registryDbName != dbName && database.MetadataID == metadataID {

--- a/rest/config_registry.go
+++ b/rest/config_registry.go
@@ -60,6 +60,7 @@ type RegistryConfigGroup struct {
 // RegistryDatabase stores the version and set of RegistryScopes for a database
 type RegistryDatabase struct {
 	RegistryDatabaseVersion        // current version
+	MetadataID              string `json:"metadata_id"`    // Metadata ID
 	UUID                    string `json:"uuid,omitempty"` // Database UUID
 	// PreviousVersion stores the previous database version while an update is in progress, in case update of the config
 	// fails and rollback is required.  Required to avoid cross-database collection conflicts during rollback.
@@ -80,7 +81,7 @@ type RegistryScope struct {
 }
 
 var defaultOnlyRegistryScopes = map[string]RegistryScope{base.DefaultScope: {Collections: []string{base.DefaultCollection}}}
-var defaultOnlyScopesConfig = ScopesConfig{base.DefaultScope: {Collections: map[string]CollectionConfig{base.DefaultCollection: {}}}}
+var DefaultOnlyScopesConfig = ScopesConfig{base.DefaultScope: {Collections: map[string]CollectionConfig{base.DefaultCollection: {}}}}
 
 func NewGatewayRegistry() *GatewayRegistry {
 	return &GatewayRegistry{
@@ -160,6 +161,12 @@ func (r *GatewayRegistry) upsertDatabaseConfig(ctx context.Context, configGroupI
 	collectionConflicts := r.getCollectionConflicts(ctx, config.Name, config.Scopes)
 	if len(collectionConflicts) > 0 {
 		return nil, base.HTTPErrorf(http.StatusConflict, "Cannot update config for database %s - collections are in use by another database: %v", base.UD(config.Name), collectionConflicts)
+	}
+
+	// This is just a defensive check - any potential races should have already collided on collections first
+	if r.hasMetadataIDConflict(config.Name, config.MetadataID) {
+		base.WarnfCtx(ctx, "Unexpected conflict on metadataID while upserting databaseConfig in registry for metadataID %s", base.UD(config.MetadataID))
+		return nil, base.HTTPErrorf(http.StatusConflict, "Cannot update config for database %s - metadataID is in use by another database: %v", base.UD(config.Name), collectionConflicts)
 	}
 
 	// For conflicts with in-flight updates, call getRegistryAndDatabase to block until those updates complete or rollback
@@ -247,7 +254,7 @@ type configGroupAndDatabase struct {
 func (r *GatewayRegistry) getCollectionConflicts(ctx context.Context, dbName string, scopes ScopesConfig) (activeConflicts map[base.ScopeAndCollectionName]string) {
 
 	if len(scopes) == 0 {
-		return r.getCollectionConflicts(ctx, dbName, defaultOnlyScopesConfig)
+		return r.getCollectionConflicts(ctx, dbName, DefaultOnlyScopesConfig)
 	}
 	// activeConflicts is a map from conflicting collection names to db name
 	activeConflicts = make(map[base.ScopeAndCollectionName]string, 0)
@@ -274,7 +281,7 @@ func (r *GatewayRegistry) getCollectionConflicts(ctx context.Context, dbName str
 func (r *GatewayRegistry) getPreviousConflicts(ctx context.Context, dbName string, scopes ScopesConfig) (previousConflicts []configGroupAndDatabase) {
 
 	if len(scopes) == 0 {
-		return r.getPreviousConflicts(ctx, dbName, defaultOnlyScopesConfig)
+		return r.getPreviousConflicts(ctx, dbName, DefaultOnlyScopesConfig)
 	}
 	conflictingDbs := make(map[configGroupAndDatabase]struct{}, 0)
 	for cgName, configGroup := range r.ConfigGroups {
@@ -319,10 +326,25 @@ func findCollectionConflicts(scopes ScopesConfig, registryScopes map[string]Regi
 	return conflicts
 }
 
+// getCollectionConflicts returns a map of registry collections that are in conflict with the provided scopesConfig.  Map values
+// are the dbName for the conflicting collection.  Matching collections for the same dbname is not a conflicts (even across config groups).
+func (r *GatewayRegistry) hasMetadataIDConflict(dbName string, metadataID string) bool {
+
+	for _, configGroup := range r.ConfigGroups {
+		for registryDbName, database := range configGroup.Databases {
+			if registryDbName != dbName && database.MetadataID == metadataID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // registryDatabaseFromConfig creates a RegistryDatabase based on the specified config
 func registryDatabaseFromConfig(config *DatabaseConfig) *RegistryDatabase {
 	rdb := &RegistryDatabase{}
 	rdb.Version = config.Version
+	rdb.MetadataID = config.MetadataID
 	if len(config.Scopes) == 0 {
 		rdb.Scopes = defaultOnlyRegistryScopes
 		return rdb

--- a/rest/config_registry_test.go
+++ b/rest/config_registry_test.go
@@ -32,7 +32,8 @@ func TestRegistryHelpers(t *testing.T) {
 	               			"_default": {
 								"collections": ["c1", "c2"]
 							}
-						}
+						},
+						"metadataID": "db1"
 					},
 	       			"db2": {
 						"version": "1-abc",
@@ -40,7 +41,8 @@ func TestRegistryHelpers(t *testing.T) {
 	               			"_default": {
 								"collections": ["c3", "c4"]
 							}
-						}
+						},
+						"metadataID": "db2"
 					}
 				}
 			},
@@ -52,7 +54,8 @@ func TestRegistryHelpers(t *testing.T) {
 	               			"_default": {
 								"collections": ["c2"]
 							}
-						}
+						},
+						"metadataID": "db1"
 					},
 					"db3": {
 						"version": "1-def",
@@ -60,7 +63,8 @@ func TestRegistryHelpers(t *testing.T) {
 	               			"s1": {
 								"collections": ["c1", "c2"]
 							}
-						}
+						},
+						"metadataID": "db3"
 					}
 				}
 			}
@@ -107,6 +111,7 @@ func TestRegistryHelpers(t *testing.T) {
 		DbConfig: DbConfig{
 			Name: "defaultDb",
 		},
+		MetadataID: "defaultDb",
 	}
 	_, err = registry.upsertDatabaseConfig(ctx, "cg1", dbConfig)
 	require.NoError(t, err)
@@ -298,5 +303,6 @@ func makeDatabaseConfig(dbName string, scopeName string, collectionNames []strin
 			Name:   dbName,
 			Scopes: scopesConfig,
 		},
+		MetadataID: dbName,
 	}
 }

--- a/rest/functionsapitest/main_test.go
+++ b/rest/functionsapitest/main_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-
 	"github.com/couchbase/sync_gateway/db"
 )
 

--- a/rest/functionsapitest/main_test.go
+++ b/rest/functionsapitest/main_test.go
@@ -13,10 +13,12 @@ package functionsapitest
 import (
 	"testing"
 
+	"github.com/couchbase/sync_gateway/base"
+
 	"github.com/couchbase/sync_gateway/db"
 )
 
 func TestMain(m *testing.M) {
-	memWatermarkThresholdMB := uint64(18192)
-	db.TestBucketPoolWithIndexes(m, memWatermarkThresholdMB)
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 18192}
+	db.TestBucketPoolWithIndexes(m, tbpOptions)
 }

--- a/rest/importtest/main_test.go
+++ b/rest/importtest/main_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-
 	"github.com/couchbase/sync_gateway/db"
 )
 

--- a/rest/importtest/main_test.go
+++ b/rest/importtest/main_test.go
@@ -13,10 +13,12 @@ package importtest
 import (
 	"testing"
 
+	"github.com/couchbase/sync_gateway/base"
+
 	"github.com/couchbase/sync_gateway/db"
 )
 
 func TestMain(m *testing.M) {
-	memWatermarkThresholdMB := uint64(2048)
-	db.TestBucketPoolWithIndexes(m, memWatermarkThresholdMB)
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
+	db.TestBucketPoolWithIndexes(m, tbpOptions)
 }

--- a/rest/indextest/main_test.go
+++ b/rest/indextest/main_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	memWatermarkThresholdMB := uint64(2048)
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
 	// Do not create indexes for this test, so they are built by server_context.go
-	base.TestBucketPoolNoIndexes(m, memWatermarkThresholdMB)
+	base.TestBucketPoolNoIndexes(m, tbpOptions)
 }

--- a/rest/main_test.go
+++ b/rest/main_test.go
@@ -20,8 +20,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	memWatermarkThresholdMB := uint64(8192)
-	db.TestBucketPoolWithIndexes(m, memWatermarkThresholdMB)
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192}
+	db.TestBucketPoolWithIndexes(m, tbpOptions)
 }
 
 func TestConfigOverwritesLegacyFlags(t *testing.T) {

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -1175,7 +1175,7 @@ func TestMigratev30PersistentConfigCollision(t *testing.T) {
 
 	// Set up a new database targeting the default collection
 	newDefaultDbName := "newDefaultDb"
-	newDefaultDbConfig := getTestDatabaseConfig(bucketName, newDefaultDbName, defaultOnlyScopesConfig, "1-a")
+	newDefaultDbConfig := getTestDatabaseConfig(bucketName, newDefaultDbName, DefaultOnlyScopesConfig, "1-a")
 	_, err = sc.BootstrapContext.InsertConfig(ctx, bucketName, groupID, newDefaultDbConfig)
 	require.NoError(t, err)
 

--- a/rest/replicatortest/main_test.go
+++ b/rest/replicatortest/main_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-
 	"github.com/couchbase/sync_gateway/db"
 )
 

--- a/rest/replicatortest/main_test.go
+++ b/rest/replicatortest/main_test.go
@@ -13,10 +13,12 @@ package replicatortest
 import (
 	"testing"
 
+	"github.com/couchbase/sync_gateway/base"
+
 	"github.com/couchbase/sync_gateway/db"
 )
 
 func TestMain(m *testing.M) {
-	memWatermarkThresholdMB := uint64(8192)
-	db.TestBucketPoolWithIndexes(m, memWatermarkThresholdMB)
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192}
+	db.TestBucketPoolWithIndexes(m, tbpOptions)
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -663,6 +663,8 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		return nil, err
 	}
 
+	contextOptions.MetadataID = config.MetadataID
+
 	// Create the DB Context
 	dbcontext, err := db.NewDatabaseContext(ctx, dbName, bucket, autoImport, contextOptions)
 	if err != nil {

--- a/rest/upgradetest/main_test.go
+++ b/rest/upgradetest/main_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-
 	"github.com/couchbase/sync_gateway/db"
 )
 

--- a/rest/upgradetest/main_test.go
+++ b/rest/upgradetest/main_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-Present Couchbase, Inc.
+Copyright 2023-Present Couchbase, Inc.
 
 Use of this software is governed by the Business Source License included in
 the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
@@ -8,7 +8,7 @@ be governed by the Apache License, Version 2.0, included in the file
 licenses/APL2.txt.
 */
 
-package changestest
+package upgradetest
 
 import (
 	"testing"
@@ -19,6 +19,9 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
+	tbpOptions := base.TestBucketPoolOptions{
+		MemWatermarkThresholdMB: 8192,
+		UseDefaultScope:         true,
+	}
 	db.TestBucketPoolWithIndexes(m, tbpOptions)
 }

--- a/rest/upgradetest/upgrade_registry_test.go
+++ b/rest/upgradetest/upgrade_registry_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2023-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package upgradetest
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/rest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDefaultMetadataID creates an database using the named collections on the default scope, then modifies that database to use
+// only the default collection. Verifies that metadata documents are still accessible.
+func TestDefaultMetadataIDNamedToDefault(t *testing.T) {
+	base.RequireNumTestDataStores(t, 2)
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+	rtConfig := &rest.RestTesterConfig{
+		CustomTestBucket: base.GetPersistentTestBucket(t),
+		PersistentConfig: true,
+	}
+
+	rt := rest.NewRestTesterMultipleCollections(t, rtConfig, 2)
+	defer rt.Close()
+
+	_ = rt.Bucket()
+
+	dbName := "db"
+
+	// Create a database with named collections
+	// Update config to remove named collections
+	scopesConfig := rest.GetCollectionsConfig(t, rt.TestBucket, 2)
+	dbConfig := rest.DbConfig{
+		Scopes: scopesConfig,
+		BucketConfig: rest.BucketConfig{
+			Bucket: base.StringPtr(rt.TestBucket.GetName()),
+		},
+		EnableXattrs:     base.BoolPtr(base.TestUseXattrs()),
+		NumIndexReplicas: base.UintPtr(0),
+	}
+
+	resp, err := rt.CreateDatabase(dbName, dbConfig)
+	require.NoError(t, err)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	userPayload := `{"password":"letmein",
+		"admin_channels":["foo", "bar"]}`
+
+	putResponse := rt.SendAdminRequest("PUT", "/"+dbName+"/_user/bob", userPayload)
+	rest.RequireStatus(t, putResponse, 201)
+
+	// Update database to only target default collection
+	dbConfig.Scopes = rest.DefaultOnlyScopesConfig
+	resp, err = rt.ReplaceDbConfig(dbName, dbConfig)
+	require.NoError(t, err)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	//  Validate that the user can still be retrieved
+	userResponse := rt.SendAdminRequest("GET", "/"+dbName+"/_user/bob", "")
+	rest.RequireStatus(t, userResponse, http.StatusOK)
+}
+
+// TestDefaultMetadataID creates an upgraded database using the defaultMetadataID, then modifies that database to use
+// named collections in the default scope. Verifies that metadata documents are still accessible.
+func TestDefaultMetadataIDDefaultToNamed(t *testing.T) {
+	base.RequireNumTestDataStores(t, 2)
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+	rtConfig := &rest.RestTesterConfig{
+		CustomTestBucket: base.GetPersistentTestBucket(t),
+		PersistentConfig: true,
+	}
+
+	rt := rest.NewRestTesterMultipleCollections(t, rtConfig, 2)
+	defer rt.Close()
+
+	_ = rt.Bucket()
+
+	dbName := "db"
+	// Create a database with named collections
+	// Update config to remove named collections
+
+	scopesConfig := rest.GetCollectionsConfig(t, rt.TestBucket, 2)
+	dbConfig := rest.DbConfig{
+		Scopes: rest.DefaultOnlyScopesConfig,
+		BucketConfig: rest.BucketConfig{
+			Bucket: base.StringPtr(rt.TestBucket.GetName()),
+		},
+		EnableXattrs:     base.BoolPtr(base.TestUseXattrs()),
+		NumIndexReplicas: base.UintPtr(0),
+	}
+
+	resp, err := rt.CreateDatabase(dbName, dbConfig)
+	require.NoError(t, err)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	userPayload := `{"password":"letmein",
+		"admin_channels":["foo", "bar"]}`
+
+	putResponse := rt.SendAdminRequest("PUT", "/"+dbName+"/_user/bob", userPayload)
+	rest.RequireStatus(t, putResponse, 201)
+
+	// Update database to only target default collection
+	dbConfig.Scopes = scopesConfig
+	resp, err = rt.ReplaceDbConfig(dbName, dbConfig)
+	require.NoError(t, err)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	//  Validate that the user can still be retrieved
+	userResponse := rt.SendAdminRequest("GET", "/"+dbName+"/_user/bob", "")
+	rest.RequireStatus(t, userResponse, http.StatusOK)
+}

--- a/rest/upgradetest/upgrade_registry_test.go
+++ b/rest/upgradetest/upgrade_registry_test.go
@@ -39,14 +39,9 @@ func TestDefaultMetadataIDNamedToDefault(t *testing.T) {
 	// Create a database with named collections
 	// Update config to remove named collections
 	scopesConfig := rest.GetCollectionsConfig(t, rt.TestBucket, 2)
-	dbConfig := rest.DbConfig{
-		Scopes: scopesConfig,
-		BucketConfig: rest.BucketConfig{
-			Bucket: base.StringPtr(rt.TestBucket.GetName()),
-		},
-		EnableXattrs:     base.BoolPtr(base.TestUseXattrs()),
-		NumIndexReplicas: base.UintPtr(0),
-	}
+
+	dbConfig := rest.GetBasicDbCfg(rt.TestBucket)
+	dbConfig.Scopes = scopesConfig
 
 	resp, err := rt.CreateDatabase(dbName, dbConfig)
 	require.NoError(t, err)
@@ -89,14 +84,8 @@ func TestDefaultMetadataIDDefaultToNamed(t *testing.T) {
 	// Update config to remove named collections
 
 	scopesConfig := rest.GetCollectionsConfig(t, rt.TestBucket, 2)
-	dbConfig := rest.DbConfig{
-		Scopes: rest.DefaultOnlyScopesConfig,
-		BucketConfig: rest.BucketConfig{
-			Bucket: base.StringPtr(rt.TestBucket.GetName()),
-		},
-		EnableXattrs:     base.BoolPtr(base.TestUseXattrs()),
-		NumIndexReplicas: base.UintPtr(0),
-	}
+	dbConfig := rest.GetBasicDbCfg(rt.TestBucket)
+	dbConfig.Scopes = rest.DefaultOnlyScopesConfig
 
 	resp, err := rt.CreateDatabase(dbName, dbConfig)
 	require.NoError(t, err)

--- a/rest/upgradetest/upgrade_registry_test.go
+++ b/rest/upgradetest/upgrade_registry_test.go
@@ -22,6 +22,10 @@ import (
 // TestDefaultMetadataID creates an database using the named collections on the default scope, then modifies that database to use
 // only the default collection. Verifies that metadata documents are still accessible.
 func TestDefaultMetadataIDNamedToDefault(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server, until creating a db through the REST API allows the views/walrus/collections combination")
+	}
+	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 2)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := &rest.RestTesterConfig{
@@ -67,6 +71,10 @@ func TestDefaultMetadataIDNamedToDefault(t *testing.T) {
 // TestDefaultMetadataID creates an upgraded database using the defaultMetadataID, then modifies that database to use
 // named collections in the default scope. Verifies that metadata documents are still accessible.
 func TestDefaultMetadataIDDefaultToNamed(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server, until creating a db through the REST API allows the views/walrus/collections combination")
+	}
+	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 2)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := &rest.RestTesterConfig{

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1445,7 +1445,6 @@ func TestPutUserCollectionAccess(t *testing.T) {
 	base.RequireNumTestDataStores(t, 2)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	testBucket := base.GetPersistentTestBucket(t)
-	defer testBucket.Close()
 
 	scopesConfig := GetCollectionsConfig(t, testBucket, 2)
 	rtConfig := &RestTesterConfig{
@@ -1499,7 +1498,7 @@ func TestPutUserCollectionAccess(t *testing.T) {
 	assert.Contains(t, getResponse.ResponseRecorder.Body.String(), `"all_channels":["!"]`)
 
 	dbConfig := DbConfig{
-		Scopes: getCollectionsConfigWithSyncFn(rt.TB, rt.TestBucket, nil, 1),
+		Scopes: GetCollectionsConfigWithSyncFn(rt.TB, rt.TestBucket, nil, 1),
 		BucketConfig: BucketConfig{
 			Bucket: base.StringPtr(rt.TestBucket.GetName()),
 		},

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -297,7 +297,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 				if rt.SyncFn != "" {
 					syncFn = base.StringPtr(rt.SyncFn)
 				}
-				rt.DatabaseConfig.Scopes = getCollectionsConfigWithSyncFn(rt.TB, testBucket, syncFn, rt.numCollections)
+				rt.DatabaseConfig.Scopes = GetCollectionsConfigWithSyncFn(rt.TB, testBucket, syncFn, rt.numCollections)
 			}
 		}
 
@@ -365,11 +365,11 @@ func (rt *RestTester) MetadataStore() base.DataStore {
 
 // GetCollectionsConfig sets up a ScopesConfig from a TestBucket for use with non default collections.
 func GetCollectionsConfig(t testing.TB, testBucket *base.TestBucket, numCollections int) ScopesConfig {
-	return getCollectionsConfigWithSyncFn(t, testBucket, nil, numCollections)
+	return GetCollectionsConfigWithSyncFn(t, testBucket, nil, numCollections)
 }
 
-// getCollectionsConfigWithSyncFn sets up a ScopesConfig from a TestBucket for use with non default collections. The sync function will be passed for all collections.
-func getCollectionsConfigWithSyncFn(t testing.TB, testBucket *base.TestBucket, syncFn *string, numCollections int) ScopesConfig {
+// GetCollectionsConfigWithSyncFn sets up a ScopesConfig from a TestBucket for use with non default collections. The sync function will be passed for all collections.
+func GetCollectionsConfigWithSyncFn(t testing.TB, testBucket *base.TestBucket, syncFn *string, numCollections int) ScopesConfig {
 	// Get a datastore as provided by the test
 	stores := testBucket.GetNonDefaultDatastoreNames()
 	require.True(t, len(stores) >= numCollections, "Requested more collections %d than found on testBucket %d", numCollections, len(stores))

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -196,7 +196,7 @@ func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
 	numCollections := 2
 	base.RequireNumTestDataStores(t, numCollections)
 	dbConfig := DbConfig{
-		Scopes: getCollectionsConfigWithSyncFn(rt.TB, rt.TestBucket, nil, numCollections),
+		Scopes: GetCollectionsConfigWithSyncFn(rt.TB, rt.TestBucket, nil, numCollections),
 		BucketConfig: BucketConfig{
 			Bucket: base.StringPtr(rt.TestBucket.GetName()),
 		},
@@ -256,7 +256,7 @@ func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
 	bucket2 := base.GetPersistentTestBucket(t)
 	defer bucket2.Close()
 	dbConfig = DbConfig{
-		Scopes: getCollectionsConfigWithSyncFn(rt.TB, bucket2, nil, numCollections),
+		Scopes: GetCollectionsConfigWithSyncFn(rt.TB, bucket2, nil, numCollections),
 		BucketConfig: BucketConfig{
 			Bucket: base.StringPtr(bucket2.GetName()),
 		},


### PR DESCRIPTION
Previously metadataID was based on usage of default collection - this led to failures when collections were added and removed from databases that previously used the default metadata ID (legacy metadata location).  

ComputeMetadataID added to bootstrap to determine whether a newly added database should use the default metadata location.  Assigns the default metadataID only when:
- Database includes _default._default
- Default metadata ID isn't already in use
- The _default._default collection has metadata in the default format (_sync:seq exists)
- _default._default isn't already associated with a different metadataID (i.e. had previously been associated with a non-default metadataID)

Adds KeyExists to BootstrapConnection interface to support checking existence of _sync:seq when determining whether to use the legacy metadata location.

References to _sync:syncInfo anticipate changes being made for CBG-2662 - decided to handle that work as a separate PR.

Required the ability to run TestBucketPool using the default scope to test the fix.  Setting this via a new TestBucketPoolOptions struct, and it seemed to make sense to move MemWatermarkThresholdMB to the same struct.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1587/
