### PR TITLE
CBG-2662 Require resync when a collection moves between databases

### DIFF
--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -511,3 +511,14 @@ func TestBucketSpecIsWalrusBucket(t *testing.T) {
 	}
 
 }
+
+func TestKeyNotFound(t *testing.T) {
+	bucket := GetTestBucket(t)
+	ds := bucket.GetSingleDataStore()
+	var body []byte
+	_, getErr := ds.Get("nonexistentKey", &body)
+	require.True(t, IsKeyNotFoundError(ds, getErr))
+
+	_, _, getRawErr := ds.GetRaw("nonexistentKey")
+	require.True(t, IsKeyNotFoundError(ds, getRawErr))
+}

--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -514,6 +514,7 @@ func TestBucketSpecIsWalrusBucket(t *testing.T) {
 
 func TestKeyNotFound(t *testing.T) {
 	bucket := GetTestBucket(t)
+	defer bucket.Close()
 	ds := bucket.GetSingleDataStore()
 	var body []byte
 	_, getErr := ds.Get("nonexistentKey", &body)

--- a/db/background_mgr_resync.go
+++ b/db/background_mgr_resync.go
@@ -75,11 +75,15 @@ func (r *ResyncManager) Run(ctx context.Context, options map[string]interface{},
 	}
 
 	for _, collectionID := range collectionIDs {
-		_, err := (&DatabaseCollectionWithUser{
+		dbc := &DatabaseCollectionWithUser{
 			DatabaseCollection: database.CollectionByID[collectionID],
-		}).UpdateAllDocChannels(ctx, regenerateSequences, callback, terminator)
+		}
+		_, err := dbc.UpdateAllDocChannels(ctx, regenerateSequences, callback, terminator)
 		if err != nil {
 			return err
+		}
+		if regenerateSequences {
+			base.SetSyncInfo(dbc.dataStore, dbc.dbCtx.Options.MetadataID)
 		}
 	}
 

--- a/db/background_mgr_resync.go
+++ b/db/background_mgr_resync.go
@@ -83,7 +83,10 @@ func (r *ResyncManager) Run(ctx context.Context, options map[string]interface{},
 			return err
 		}
 		if regenerateSequences {
-			base.SetSyncInfo(dbc.dataStore, dbc.dbCtx.Options.MetadataID)
+			err := base.SetSyncInfo(dbc.dataStore, dbc.dbCtx.Options.MetadataID)
+			if err != nil {
+				base.InfofCtx(ctx, base.KeyAll, "Failed to updateSyncInfo after resync: %v", err)
+			}
 		}
 	}
 

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -209,6 +209,17 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 			}
 
 		}
+
+		// If we regenerated sequences, update syncInfo for all collections affected
+		if regenerateSequences {
+			for _, collectionID := range collectionIDs {
+				dbc, ok := db.CollectionByID[collectionID]
+				if !ok {
+					base.WarnfCtx(ctx, "[%s] Completed resync, but unable to update syncInfo for collection %v (not found)", resyncLoggingID, collectionID)
+				}
+				base.SetSyncInfo(dbc.dataStore, db.DatabaseContext.Options.MetadataID)
+			}
+		}
 	case <-terminator.Done():
 		base.DebugfCtx(ctx, base.KeyAll, "[%s] Terminator closed. Ending Resync process.", resyncLoggingID)
 		err = dcpClient.Close()

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -217,7 +217,10 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 				if !ok {
 					base.WarnfCtx(ctx, "[%s] Completed resync, but unable to update syncInfo for collection %v (not found)", resyncLoggingID, collectionID)
 				}
-				base.SetSyncInfo(dbc.dataStore, db.DatabaseContext.Options.MetadataID)
+				if err := base.SetSyncInfo(dbc.dataStore, db.DatabaseContext.Options.MetadataID); err != nil {
+					base.WarnfCtx(ctx, "[%s] Completed resync, but unable to update syncInfo for collection %v: %v", resyncLoggingID, collectionID, err)
+				}
+
 			}
 		}
 	case <-terminator.Done():

--- a/db/database.go
+++ b/db/database.go
@@ -130,6 +130,7 @@ type DatabaseContext struct {
 	CollectionByID               map[uint32]*DatabaseCollection // A map keyed by collection ID to Collection
 	CollectionNames              map[string]map[string]struct{} // Map of scope, collection names
 	MetadataKeys                 *base.MetadataKeys             // Factory to generate metadata document keys
+	RequireResync                base.ScopeAndCollectionNames   // Collections requiring resync before database can go online
 }
 
 type Scope struct {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1049,6 +1049,7 @@ type DatabaseStatus struct {
 	SequenceNumber    uint64                  `json:"seq"`
 	ServerUUID        string                  `json:"server_uuid"`
 	State             string                  `json:"state"`
+	RequireResync     []string                `json:"require_resync"`
 	ReplicationStatus []*db.ReplicationStatus `json:"replication_status"`
 	SGRCluster        *db.SGRCluster          `json:"cluster"`
 }
@@ -1099,6 +1100,7 @@ func (h *handler) handleGetStatus() error {
 			ServerUUID:        database.ServerUUID,
 			ReplicationStatus: replicationsStatus,
 			SGRCluster:        cluster,
+			RequireResync:     database.RequireResync.ScopeAndCollectionNames(),
 		}
 	}
 

--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -248,7 +248,7 @@ func TestRequireResync(t *testing.T) {
 	// The online call is async, but subsequent get to status should remain offline
 	onlineResponse := rt.SendAdminRequest("POST", "/"+db2Name+"/_online", "")
 	rest.RequireStatus(t, onlineResponse, http.StatusOK)
-	require.NoError(t, rt.WaitForDatabaseState(db2Name, db.DBOnline))
+	require.NoError(t, rt.WaitForDatabaseState(db2Name, db.DBOffline))
 
 	resp = rt.SendAdminRequest("GET", "/"+db2Name+"/", "")
 	rest.RequireStatus(t, resp, http.StatusOK)

--- a/rest/api.go
+++ b/rest/api.go
@@ -392,6 +392,7 @@ type DatabaseRoot struct {
 	DiskFormatVersion             uint64                       `json:"disk_format_version"`
 	State                         string                       `json:"state"`
 	ServerUUID                    string                       `json:"server_uuid,omitempty"`
+	RequireResync                 []string                     `json:"require_resync,omitempty"`
 	Scopes                        map[string]databaseRootScope `json:"scopes,omitempty"` // stats for each scope/collection
 }
 
@@ -428,6 +429,8 @@ func (h *handler) handleGetDB() error {
 		DiskFormatVersion:             0, // Probably meaningless, but add for compatibility
 		State:                         runState,
 		ServerUUID:                    h.db.DatabaseContext.ServerUUID,
+		RequireResync:                 h.db.RequireResync.ScopeAndCollectionNames(),
+
 		// TODO: If running with multiple scope/collections
 		// Scopes: map[string]databaseRootScope{
 		// 	"scope1": {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -475,14 +475,27 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	}
 
 	// initDataStore is a function to initialize Views or GSI indexes for a datastore
-	initDataStore := func(ds base.DataStore, metadataIndexes db.CollectionIndexesType) error {
+	initDataStore := func(ds base.DataStore, metadataIndexes db.CollectionIndexesType, verifySyncInfo bool) (resyncRequired bool, err error) {
+
+		// If this collection uses syncInfo, verify the collection isn't associated with a different database's metadataID
+		if verifySyncInfo {
+			resyncRequired, err = base.InitSyncInfo(ds, config.MetadataID)
+			if err != nil {
+				return true, err
+			}
+		}
+
 		if useViews {
-			return db.InitializeViews(ctx, ds)
+			viewErr := db.InitializeViews(ctx, ds)
+			if viewErr != nil {
+				return false, viewErr
+			}
+			return resyncRequired, nil
 		}
 
 		gsiSupported := bucket.IsSupported(sgbucket.BucketStoreFeatureN1ql)
 		if !gsiSupported {
-			return errors.New("Sync Gateway was unable to connect to a query node on the provided Couchbase Server cluster.  Ensure a query node is accessible, or set 'use_views':true in Sync Gateway's database config.")
+			return false, errors.New("Sync Gateway was unable to connect to a query node on the provided Couchbase Server cluster.  Ensure a query node is accessible, or set 'use_views':true in Sync Gateway's database config.")
 		}
 
 		numReplicas := DefaultNumIndexReplicas
@@ -491,7 +504,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		}
 		n1qlStore, ok := base.AsN1QLStore(ds)
 		if !ok {
-			return errors.New("Cannot create indexes on non-Couchbase data store.")
+			return false, errors.New("Cannot create indexes on non-Couchbase data store.")
 
 		}
 		options := db.InitializeIndexOptions{
@@ -504,12 +517,13 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		ctx := base.CollectionCtx(ctx, ds.GetName())
 		indexErr := db.InitializeIndexes(ctx, n1qlStore, options)
 		if indexErr != nil {
-			return indexErr
+			return false, indexErr
 		}
 
-		return nil
+		return resyncRequired, nil
 	}
 
+	collectionsRequiringResync := make([]base.ScopeAndCollectionName, 0)
 	if len(config.Scopes) > 0 {
 		if !bucket.IsSupported(sgbucket.BucketStoreFeatureCollections) {
 			return nil, errCollectionsUnsupported
@@ -535,20 +549,28 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 					hasDefaultCollection = true
 					metadataIndexOption = db.IndexesAll
 				}
-				if err := initDataStore(dataStore, metadataIndexOption); err != nil {
+				requiresResync, err := initDataStore(dataStore, metadataIndexOption, true)
+				if err != nil {
 					return nil, err
+				}
+				if requiresResync {
+					collectionsRequiringResync = append(collectionsRequiringResync, base.ScopeAndCollectionName{Scope: scopeName, Collection: collectionName})
 				}
 			}
 		}
 		if !hasDefaultCollection {
-			if err := initDataStore(bucket.DefaultDataStore(), db.IndexesMetadataOnly); err != nil {
+			if _, err := initDataStore(bucket.DefaultDataStore(), db.IndexesMetadataOnly, false); err != nil {
 				return nil, err
 			}
 		}
 	} else {
 		// no scopes configured - init the default data store
-		if err := initDataStore(bucket.DefaultDataStore(), db.IndexesAll); err != nil {
+		requiresResync, err := initDataStore(bucket.DefaultDataStore(), db.IndexesAll, true)
+		if err != nil {
 			return nil, err
+		}
+		if requiresResync {
+			collectionsRequiringResync = append(collectionsRequiringResync, base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: base.DefaultCollection})
 		}
 	}
 
@@ -673,6 +695,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	dbcontext.BucketSpec = spec
 	dbcontext.ServerContextHasStarted = sc.hasStarted
 	dbcontext.NoX509HTTPClient = sc.NoX509HTTPClient
+	dbcontext.RequireResync = collectionsRequiringResync
 
 	if config.RevsLimit != nil {
 		dbcontext.RevsLimit = *config.RevsLimit
@@ -731,6 +754,9 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	if base.BoolDefault(config.StartOffline, false) {
 		atomic.StoreUint32(&dbcontext.State, db.DBOffline)
 		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "offline", "DB loaded from config", &sc.Config.API.AdminInterface)
+	} else if len(dbcontext.RequireResync) > 0 {
+		atomic.StoreUint32(&dbcontext.State, db.DBOffline)
+		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "offline", "Resync required for collections", &sc.Config.API.AdminInterface)
 	} else {
 		atomic.StoreUint32(&dbcontext.State, db.DBOnline)
 		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "online", "DB loaded from config", &sc.Config.API.AdminInterface)
@@ -1028,6 +1054,10 @@ func (sc *ServerContext) TakeDbOnline(nonContextStruct base.NonCancellableContex
 			return
 		}
 
+		if len(reloadedDb.RequireResync) > 0 {
+			base.ErrorfCtx(nonContextStruct.Ctx, "Database has collections that require resync before it can go online: %v", reloadedDb.RequireResync)
+			return
+		}
 		// Reloaded DB should already be online in most cases, but force state to online to handle cases
 		// where config specifies offline startup
 		atomic.StoreUint32(&reloadedDb.State, db.DBOnline)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -960,7 +960,7 @@ func (rt *RestTester) WaitForDatabaseState(dbName string, targetState uint32) er
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	return fmt.Errorf("given up waiting for DB state, want: %s, current: %s, attempts: %d", targetState, stateCurr, maxTries)
+	return fmt.Errorf("given up waiting for DB state, want: %s, current: %s, attempts: %d", db.RunStateString[targetState], stateCurr, maxTries)
 }
 
 func (rt *RestTester) SendAdminRequestWithHeaders(method, resource string, body string, headers map[string]string) *TestResponse {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -947,6 +947,22 @@ func (rt *RestTester) waitForDBState(stateWant string) (err error) {
 	return fmt.Errorf("given up waiting for DB state, want: %s, current: %s, attempts: %d", stateWant, stateCurr, maxTries)
 }
 
+func (rt *RestTester) WaitForDatabaseState(dbName string, targetState uint32) error {
+	var stateCurr string
+	maxTries := 50
+	for i := 0; i < maxTries; i++ {
+		dbRootResponse := DatabaseRoot{}
+		resp := rt.SendAdminRequest("GET", "/"+dbName+"/", "")
+		RequireStatus(rt.TB, resp, 200)
+		require.NoError(rt.TB, base.JSONUnmarshal(resp.Body.Bytes(), &dbRootResponse))
+		if dbRootResponse.State == db.RunStateString[targetState] {
+			return nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("given up waiting for DB state, want: %s, current: %s, attempts: %d", targetState, stateCurr, maxTries)
+}
+
 func (rt *RestTester) SendAdminRequestWithHeaders(method, resource string, body string, headers map[string]string) *TestResponse {
 	input := bytes.NewBufferString(body)
 	request, _ := http.NewRequest(method, "http://localhost"+rt.mustTemplateResource(resource), input)


### PR DESCRIPTION
CBG-2662 
If a collection moves between databases, resync must be run with regenerateSequences=true in order to preserve sequence consistency.

When a collection is associated with a database, a syncInfo document (_sync:syncInfo) is written to the collection that stores the metadataID for the collection.

On database start, checks syncInfo for all collections.  On mismatch, starts the database in offline mode.

When in this state, a 'require_resync' property is included in the root db response and the root /_status endpoint with a slice of collections that require resync.

When resync w/ regenerate sequences is successfully run for a collection, syncInfo is updated for the collection.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1592/
