### PR TITLE
CBG-2769 perform validation on config changes of non persistent config

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -532,7 +532,13 @@ func (h *handler) handlePutDbConfig() (err error) {
 
 	if !h.server.persistentConfig {
 		updatedDbConfig := &DatabaseConfig{DbConfig: *dbConfig}
-		err = updatedDbConfig.validate(h.ctx(), validateOIDC)
+		err := updatedDbConfig.validate(h.ctx(), validateOIDC)
+		if err != nil {
+			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
+		}
+		oldDBConfig := h.server.GetDatabaseConfig(h.db.Name).DatabaseConfig.DbConfig
+		err = updatedDbConfig.validateConfigUpdate(h.ctx(), oldDBConfig,
+			validateOIDC)
 		if err != nil {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}

--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -203,11 +203,10 @@ func TestRequireResync(t *testing.T) {
 	delete(scopesConfigC2Only[scope].Collections, collection1)
 
 	// Create a db1 with two collections
-	dbConfig := rest.GetBasicDbCfg(rt.TestBucket)
+	dbConfig := rt.NewDbConfig()
 	dbConfig.Scopes = scopesConfig
 
-	resp, err := rt.CreateDatabase(db1Name, dbConfig)
-	require.NoError(t, err)
+	resp := rt.CreateDatabase(db1Name, dbConfig)
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	// Write documents to collection 1 and 2
@@ -220,8 +219,7 @@ func TestRequireResync(t *testing.T) {
 
 	// Update db1 to remove collection1
 	dbConfig.Scopes = scopesConfigC2Only
-	resp, err = rt.ReplaceDbConfig(db1Name, dbConfig)
-	require.NoError(t, err)
+	resp = rt.ReplaceDbConfig(db1Name, dbConfig)
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	// Validate that doc can still be retrieved from collection 2
@@ -229,11 +227,10 @@ func TestRequireResync(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 
 	// Create db2 targeting collection 1
-	db2Config := rest.GetBasicDbCfg(rt.TestBucket)
+	db2Config := rt.NewDbConfig()
 	db2Config.Scopes = scopesConfigC1Only
 
-	resp, err = rt.CreateDatabase(db2Name, db2Config)
-	require.NoError(t, err)
+	resp = rt.CreateDatabase(db2Name, db2Config)
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	// Get status, verify offline
@@ -265,7 +262,7 @@ func TestRequireResync(t *testing.T) {
 	resp = rt.SendAdminRequest("POST", "/"+db2Name+"/_resync?action=start&regenerate_sequences=true", string(resyncPayload))
 	rest.RequireStatus(t, resp, http.StatusOK)
 
-	err = rt.WaitForConditionWithOptions(func() bool {
+	err := rt.WaitForConditionWithOptions(func() bool {
 		resyncStatus := db.BackgroundManagerStatus{}
 		response := rt.SendAdminRequest("GET", "/"+db2Name+"/_resync", "")
 		err := base.JSONUnmarshal(response.BodyBytes(), &resyncStatus)

--- a/rest/blip_api_no_race_test.go
+++ b/rest/blip_api_no_race_test.go
@@ -81,8 +81,7 @@ func TestBlipPusherUpdateDatabase(t *testing.T) {
 	// just change the sync function to cause the database to reload
 	dbConfig := *rt.ServerContext().GetDbConfig("db")
 	dbConfig.Sync = base.StringPtr(`function(doc){console.log("update");}`)
-	resp, err := rt.ReplaceDbConfig("db", dbConfig)
-	require.NoError(t, err)
+	resp := rt.ReplaceDbConfig("db", dbConfig)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// Did we tell the client to close the connection (via HTTP/503)?

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2617,3 +2617,17 @@ func requireErrorWithX509UnknownAuthority(t testing.TB, actual, expected error) 
 
 	require.ErrorContains(t, actual, expectedErrorString)
 }
+
+func TestDatabaseConfigDropScopes(t *testing.T) {
+	base.RequireNumTestDataStores(t, 2)
+
+	rt := NewRestTesterMultipleCollections(t, nil, 2)
+	defer rt.Close()
+
+	resp := rt.SendAdminRequest("PUT", "/db/_config", fmt.Sprintf(
+		`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "scopes":{}}`,
+		rt.Bucket().GetName(), base.TestUseXattrs()))
+	RequireStatus(t, resp, http.StatusBadRequest)
+	require.Contains(t, resp.Body.String(), "cannot change scope")
+
+}

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1754,8 +1754,7 @@ func TestPushReplicationAPIUpdateDatabase(t *testing.T) {
 	// just change the sync function to cause the database to reload
 	dbConfig := *rt2.ServerContext().GetDbConfig("db")
 	dbConfig.Sync = base.StringPtr(`function(doc){channel(doc.channels);}`)
-	resp, err := rt2.ReplaceDbConfig("db", dbConfig)
-	require.NoError(t, err)
+	resp := rt2.ReplaceDbConfig("db", dbConfig)
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	shouldCreateDocs.Set(false)

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -161,14 +161,12 @@ func TestPersistentDbConfigWithInvalidUpsert(t *testing.T) {
 	dbConfig := dbConfigForTestBucket(rtc.testBucket)
 
 	// Create database on a random node.
-	resp, err := rtc.RoundRobin().CreateDatabase(db, dbConfig)
-	require.NoError(t, err)
+	resp := rtc.RoundRobin().CreateDatabase(db, dbConfig)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// A duplicate create shouldn't work, even if this were a node that doesn't have the database loaded yet.
 	// But this _will_ trigger an on-demand load on this node. So now we have 2 nodes running the database.
-	resp, err = rtc.RoundRobin().CreateDatabase(db, dbConfig)
-	require.NoError(t, err)
+	resp = rtc.RoundRobin().CreateDatabase(db, dbConfig)
 	// CouchDB returns this status and body in this scenario
 	RequireStatus(t, resp, http.StatusPreconditionFailed)
 	assert.Contains(t, string(resp.BodyBytes()), "Duplicate database name")
@@ -189,8 +187,7 @@ func TestPersistentDbConfigWithInvalidUpsert(t *testing.T) {
 	rtNode := rtc.RoundRobin()
 
 	// upsert with an invalid config option
-	resp, err = rtNode.UpsertDbConfig(db, DbConfig{RevsLimit: base.Uint32Ptr(0)})
-	require.NoError(t, err)
+	resp = rtNode.UpsertDbConfig(db, DbConfig{RevsLimit: base.Uint32Ptr(0)})
 	RequireStatus(t, resp, http.StatusBadRequest)
 
 	// On the same node, make sure the database is still running.

--- a/rest/upgradetest/upgrade_registry_test.go
+++ b/rest/upgradetest/upgrade_registry_test.go
@@ -21,14 +21,9 @@ import (
 // TestDefaultMetadataID creates an database using the named collections on the default scope, then modifies that database to use
 // only the default collection. Verifies that metadata documents are still accessible.
 func TestDefaultMetadataIDNamedToDefault(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server, until creating a db through the REST API allows the views/walrus/collections combination")
-	}
 	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 2)
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := &rest.RestTesterConfig{
-		CustomTestBucket: base.GetPersistentTestBucket(t),
 		PersistentConfig: true,
 	}
 
@@ -68,14 +63,9 @@ func TestDefaultMetadataIDNamedToDefault(t *testing.T) {
 // TestDefaultMetadataID creates an upgraded database using the defaultMetadataID, then modifies that database to use
 // named collections in the default scope. Verifies that metadata documents are still accessible.
 func TestDefaultMetadataIDDefaultToNamed(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server, until creating a db through the REST API allows the views/walrus/collections combination")
-	}
 	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 2)
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := &rest.RestTesterConfig{
-		CustomTestBucket: base.GetPersistentTestBucket(t),
 		PersistentConfig: true,
 	}
 

--- a/rest/upgradetest/upgrade_registry_test.go
+++ b/rest/upgradetest/upgrade_registry_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/rest"
-	"github.com/stretchr/testify/require"
 )
 
 // TestDefaultMetadataID creates an database using the named collections on the default scope, then modifies that database to use
@@ -44,11 +43,10 @@ func TestDefaultMetadataIDNamedToDefault(t *testing.T) {
 	// Update config to remove named collections
 	scopesConfig := rest.GetCollectionsConfig(t, rt.TestBucket, 2)
 
-	dbConfig := rest.GetBasicDbCfg(rt.TestBucket)
+	dbConfig := rt.NewDbConfig()
 	dbConfig.Scopes = scopesConfig
 
-	resp, err := rt.CreateDatabase(dbName, dbConfig)
-	require.NoError(t, err)
+	resp := rt.CreateDatabase(dbName, dbConfig)
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	userPayload := `{"password":"letmein",
@@ -59,8 +57,7 @@ func TestDefaultMetadataIDNamedToDefault(t *testing.T) {
 
 	// Update database to only target default collection
 	dbConfig.Scopes = rest.DefaultOnlyScopesConfig
-	resp, err = rt.ReplaceDbConfig(dbName, dbConfig)
-	require.NoError(t, err)
+	resp = rt.ReplaceDbConfig(dbName, dbConfig)
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	//  Validate that the user can still be retrieved
@@ -92,11 +89,10 @@ func TestDefaultMetadataIDDefaultToNamed(t *testing.T) {
 	// Update config to remove named collections
 
 	scopesConfig := rest.GetCollectionsConfig(t, rt.TestBucket, 2)
-	dbConfig := rest.GetBasicDbCfg(rt.TestBucket)
+	dbConfig := rt.NewDbConfig()
 	dbConfig.Scopes = rest.DefaultOnlyScopesConfig
 
-	resp, err := rt.CreateDatabase(dbName, dbConfig)
-	require.NoError(t, err)
+	resp := rt.CreateDatabase(dbName, dbConfig)
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	userPayload := `{"password":"letmein",
@@ -107,8 +103,7 @@ func TestDefaultMetadataIDDefaultToNamed(t *testing.T) {
 
 	// Update database to only target default collection
 	dbConfig.Scopes = scopesConfig
-	resp, err = rt.ReplaceDbConfig(dbName, dbConfig)
-	require.NoError(t, err)
+	resp = rt.ReplaceDbConfig(dbName, dbConfig)
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	//  Validate that the user can still be retrieved

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1502,8 +1502,7 @@ func TestPutUserCollectionAccess(t *testing.T) {
 			Bucket: base.StringPtr(rt.TestBucket.GetName()),
 		},
 	}
-	resp, err := rt.ReplaceDbConfig(rt.GetDatabase().Name, dbConfig)
-	require.NoError(t, err)
+	resp := rt.ReplaceDbConfig(rt.GetDatabase().Name, dbConfig)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	//  Hide entries for collections that are no longer part of the database for GET /_user and /_role

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -436,33 +436,27 @@ func (rt *RestTester) ServerContext() *ServerContext {
 }
 
 // CreateDatabase is a utility function to create a database through the REST API
-func (rt *RestTester) CreateDatabase(dbName string, config DbConfig) (*TestResponse, error) {
+func (rt *RestTester) CreateDatabase(dbName string, config DbConfig) *TestResponse {
 	dbcJSON, err := base.JSONMarshal(config)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(rt.TB, err)
 	resp := rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/", dbName), string(dbcJSON))
-	return resp, nil
+	return resp
 }
 
 // ReplaceDbConfig is a utility function to replace a database config through the REST API
-func (rt *RestTester) ReplaceDbConfig(dbName string, config DbConfig) (*TestResponse, error) {
+func (rt *RestTester) ReplaceDbConfig(dbName string, config DbConfig) *TestResponse {
 	dbcJSON, err := base.JSONMarshal(config)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(rt.TB, err)
 	resp := rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/_config", dbName), string(dbcJSON))
-	return resp, nil
+	return resp
 }
 
 // UpsertDbConfig is a utility function to upsert a database through the REST API
-func (rt *RestTester) UpsertDbConfig(dbName string, config DbConfig) (*TestResponse, error) {
+func (rt *RestTester) UpsertDbConfig(dbName string, config DbConfig) *TestResponse {
 	dbcJSON, err := base.JSONMarshal(config)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(rt.TB, err)
 	resp := rt.SendAdminRequest(http.MethodPost, fmt.Sprintf("/%s/_config", dbName), string(dbcJSON))
-	return resp, nil
+	return resp
 }
 
 // GetDatabase Returns first database found for server context.
@@ -2437,4 +2431,28 @@ func (rt *RestTester) GetChangesOneShot(t testing.TB, keyspace string, since int
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, changesCount)
 	return changesResponse
+}
+
+func (rt *RestTester) NewDbConfig() DbConfig {
+	config := DbConfig{
+		BucketConfig: BucketConfig{
+			Bucket: base.StringPtr(rt.Bucket().GetName()),
+		},
+		NumIndexReplicas: base.UintPtr(0),
+		EnableXattrs:     base.BoolPtr(base.TestUseXattrs()),
+	}
+	// Walrus is peculiar in that it needs to run with views, but can run most GSI tests, including collections
+	if !base.UnitTestUrlIsWalrus() {
+		config.UseViews = base.BoolPtr(base.TestsDisableGSI())
+	}
+	// Setup scopes.
+	if base.TestsUseNamedCollections() && rt.collectionConfig != useSingleCollectionDefaultOnly && (base.UnitTestUrlIsWalrus() || (config.UseViews != nil && !*config.UseViews)) {
+		var syncFn *string
+		if rt.SyncFn != "" {
+			syncFn = base.StringPtr(rt.SyncFn)
+		}
+		config.Scopes = GetCollectionsConfigWithSyncFn(rt.TB, rt.TestBucket, syncFn, rt.numCollections)
+	}
+
+	return config
 }

--- a/rest/utilities_testing_functions_api.go
+++ b/rest/utilities_testing_functions_api.go
@@ -12,42 +12,27 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/stretchr/testify/assert"
 )
 
-func GetBasicDbCfg(tb *base.TestBucket) DbConfig {
-	return DbConfig{
-		BucketConfig: BucketConfig{
-			Bucket: base.StringPtr(tb.GetName()),
-		},
-		NumIndexReplicas: base.UintPtr(0),
-		UseViews:         base.BoolPtr(base.TestsDisableGSI()),
-		EnableXattrs:     base.BoolPtr(base.TestUseXattrs()),
-	}
-}
-
-// Creates a new RestTester using persistent config, and a database "db".
+// NewRestTesterForUserQueries creates a new RestTester using persistent config, and a database "db".
 // Only the user-query-related fields are copied from `queryConfig`; the rest are ignored.
 func NewRestTesterForUserQueries(t *testing.T, queryConfig DbConfig) *RestTester {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test requires persistent configs")
-		return nil
+	if base.TestsDisableGSI() {
+		t.Skip("graphql implies GSI")
 	}
-
 	rt := NewRestTester(t, &RestTesterConfig{
 		groupID:           base.StringPtr(t.Name()), // Avoids race conditions between tests
 		EnableUserQueries: true,
 		PersistentConfig:  true,
 	})
 
-	_ = rt.Bucket() // initializes the bucket as a side effect
-	dbConfig := GetBasicDbCfg(rt.TestBucket)
+	dbConfig := rt.NewDbConfig()
 
 	dbConfig.UserFunctions = queryConfig.UserFunctions
 	dbConfig.GraphQL = queryConfig.GraphQL
 
-	resp, err := rt.CreateDatabase("db", dbConfig)
-	if !assert.NoError(t, err) || !AssertStatus(t, resp, 201) {
+	resp := rt.CreateDatabase("db", dbConfig)
+	if !AssertStatus(t, resp, 201) {
 		rt.Close()
 		t.FailNow()
 		return nil // (never reached)

--- a/rest/utilities_testing_functions_api.go
+++ b/rest/utilities_testing_functions_api.go
@@ -20,8 +20,7 @@ func NewRestTesterForUserQueries(t *testing.T, queryConfig DbConfig) *RestTester
 	if base.TestsDisableGSI() {
 		t.Skip("graphql implies GSI")
 	}
-	rt := NewRestTester(t, &RestTesterConfig{
-		groupID:           base.StringPtr(t.Name()), // Avoids race conditions between tests
+	rt := NewRestTesterDefaultCollection(t, &RestTesterConfig{
 		EnableUserQueries: true,
 		PersistentConfig:  true,
 	})

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -210,8 +210,7 @@ func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
 	require.NoError(t, err)
 	bucket1Datastore2Name, ok := base.AsDataStoreName(bucket1Datastore2)
 	require.True(t, ok)
-	resp, err := rt.CreateDatabase(dbOne, dbConfig)
-	require.NoError(t, err)
+	resp := rt.CreateDatabase(dbOne, dbConfig)
 	RequireStatus(t, resp, http.StatusCreated)
 	testCases = []struct {
 		input     string
@@ -270,8 +269,7 @@ func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
 	require.NoError(t, err)
 	bucket2Datastore2Name, ok := base.AsDataStoreName(bucket2Datastore2)
 	require.True(t, ok)
-	resp, err = rt.CreateDatabase(dbTwo, dbConfig)
-	require.NoError(t, err)
+	resp = rt.CreateDatabase(dbTwo, dbConfig)
 	RequireStatus(t, resp, http.StatusCreated)
 	testCases = []struct {
 		input     string


### PR DESCRIPTION
This may not solve the entirety of the problem that I observed during test but this fixes the problem if you create a database *without* persistent config and then `POST` `/db/_config` it will allow you to change (or drop) the scopes. This only showed up in a test environment.

The only non-test change is in `admin_api.go`. There were test changes since we would do this accidentally in our test code, so I've moved some helper code about creating `DbConfig` to `rt.NewDbConfig` and switched some usages to use `rt.UpsertDbConfig` and `rt.ReplaceDbConfig`.

The other way I could have done this to create a function that returns `rt.ServerContext().GetDatabaseConfig(rt.GetDatabase().Name).DatabaseContext.DbConfig` that returns the runtime config so that you can modify for a re-post.

This brings up another question which is should we allow persistent config to even modify scopes? My understanding is that this only takes affect with the running instances, so other SGs in the cluster would not pick this up.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1595/
