### PR TITLE
CBG-2762: return error when collection_access has inexistent collections on /_user and _role endpoints

### DIFF
--- a/db/users.go
+++ b/db/users.go
@@ -120,7 +120,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		if collectionAccessChanged {
 			changed = true
 		}
-		//if updates.CollectionAccess
+
 		for scopeName, collections := range updates.CollectionAccess {
 			for collectionName, _ := range collections {
 				_, err = dbc.GetDatabaseCollection(scopeName, collectionName)

--- a/db/users.go
+++ b/db/users.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
@@ -122,7 +123,8 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		}
 		for scopeName, collections := range updates.CollectionAccess {
 			for collectionName, _ := range collections {
-				_, err = dbc.GetDatabaseCollection(scopeName, collectionName)
+				collectionNameSplit := strings.Split(collectionName, ".")
+				_, err = dbc.GetDatabaseCollection(scopeName, collectionNameSplit[1])
 				if err != nil {
 					return false, base.HTTPErrorf(http.StatusNotFound, "keyspace specified in collection_access (%s) not found", fmt.Sprintf("%s.%s.%s", dbc.Name, scopeName, collectionName))
 				}

--- a/db/users.go
+++ b/db/users.go
@@ -13,10 +13,11 @@ package db
 import (
 	"context"
 	"fmt"
+	"net/http"
+
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
-	"net/http"
 )
 
 func (db *DatabaseContext) DeleteRole(ctx context.Context, name string, purge bool) error {

--- a/db/users.go
+++ b/db/users.go
@@ -13,12 +13,10 @@ package db
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"strings"
-
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
+	"net/http"
 )
 
 func (db *DatabaseContext) DeleteRole(ctx context.Context, name string, purge bool) error {
@@ -121,10 +119,10 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		if collectionAccessChanged {
 			changed = true
 		}
+		//if updates.CollectionAccess
 		for scopeName, collections := range updates.CollectionAccess {
 			for collectionName, _ := range collections {
-				collectionNameSplit := strings.Split(collectionName, ".")
-				_, err = dbc.GetDatabaseCollection(scopeName, collectionNameSplit[1])
+				_, err = dbc.GetDatabaseCollection(scopeName, collectionName)
 				if err != nil {
 					return false, base.HTTPErrorf(http.StatusNotFound, "keyspace specified in collection_access (%s) not found", fmt.Sprintf("%s.%s.%s", dbc.Name, scopeName, collectionName))
 				}

--- a/db/users.go
+++ b/db/users.go
@@ -13,11 +13,10 @@ package db
 import (
 	"context"
 	"fmt"
-	"net/http"
-
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
+	"net/http"
 )
 
 func (db *DatabaseContext) DeleteRole(ctx context.Context, name string, purge bool) error {
@@ -118,15 +117,15 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 
 		collectionAccessChanged := dbc.RequiresCollectionAccessUpdate(ctx, princ, updates.CollectionAccess)
 		if collectionAccessChanged {
-			for scopeName, collections := range updates.CollectionAccess {
-				for collectionName, _ := range collections {
-					_, err = dbc.GetDatabaseCollection(scopeName, collectionName)
-					if err != nil {
-						return false, err
-					}
+			changed = true
+		}
+		for scopeName, collections := range updates.CollectionAccess {
+			for collectionName, _ := range collections {
+				_, err = dbc.GetDatabaseCollection(scopeName, collectionName)
+				if err != nil {
+					return false, base.HTTPErrorf(http.StatusNotFound, "keyspace specified in collection_access (%s) not found", fmt.Sprintf("%s.%s.%s", dbc.Name, scopeName, collectionName))
 				}
 			}
-			changed = true
 		}
 
 		var updatedExplicitRoles, updatedJWTRoles, updatedJWTChannels ch.TimedSet

--- a/db/users.go
+++ b/db/users.go
@@ -118,6 +118,14 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 
 		collectionAccessChanged := dbc.RequiresCollectionAccessUpdate(ctx, princ, updates.CollectionAccess)
 		if collectionAccessChanged {
+			for scopeName, collections := range updates.CollectionAccess {
+				for collectionName, _ := range collections {
+					_, err = dbc.GetDatabaseCollection(scopeName, collectionName)
+					if err != nil {
+						return false, err
+					}
+				}
+			}
 			changed = true
 		}
 

--- a/db/users.go
+++ b/db/users.go
@@ -260,27 +260,27 @@ func (dbc *DatabaseContext) UpdateCollectionExplicitChannels(ctx context.Context
 }
 
 // RequiresCollectionAccessUpdate returns true if the provided map of CollectionAccessConfig requires an update to the principal
-func (dbc *DatabaseContext) RequiresCollectionAccessUpdate(ctx context.Context, princ auth.Principal, updates map[string]map[string]*auth.CollectionAccessConfig) (requiresUpdate bool, err error) {
-
+func (dbc *DatabaseContext) RequiresCollectionAccessUpdate(ctx context.Context, princ auth.Principal, updates map[string]map[string]*auth.CollectionAccessConfig) (bool, error) {
+	requiresUpdate := false
 	for scopeName, scope := range updates {
 		if scope != nil {
 			for collectionName, updatedCollectionAccess := range scope {
-				_, err = dbc.GetDatabaseCollection(scopeName, collectionName)
+				_, err := dbc.GetDatabaseCollection(scopeName, collectionName)
 				if err != nil {
 					return false, base.HTTPErrorf(http.StatusNotFound, "keyspace specified in collection_access (%s) not found", fmt.Sprintf("%s.%s.%s", dbc.Name, scopeName, collectionName))
 				}
 				if updatedCollectionAccess == nil {
 					if princ.CollectionExplicitChannels(scopeName, collectionName) != nil {
-						return true, nil
+						requiresUpdate = true
 					}
 				} else {
 					if !princ.CollectionExplicitChannels(scopeName, collectionName).Equals(updatedCollectionAccess.ExplicitChannels_) {
-						return true, nil
+						requiresUpdate = true
 					}
 				}
 			}
 		}
 	}
 
-	return false, nil
+	return requiresUpdate, nil
 }

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -458,11 +458,11 @@ func TestMultiCollectionDynamicChannelAccess(t *testing.T) {
       }
    }`
 	// Create a few users without any channel access
-	resp := rt.SendAdminRequest("PUT", "/db/_user/alice", fmt.Sprintf(userPayload, dataStoreNames[0].ScopeName(), dataStoreNames[0], `[]`))
+	resp := rt.SendAdminRequest("PUT", "/db/_user/alice", fmt.Sprintf(userPayload, dataStoreNames[0].ScopeName(), dataStoreNames[0].CollectionName(), `[]`))
 	RequireStatus(t, resp, http.StatusCreated)
-	resp = rt.SendAdminRequest("PUT", "/db/_user/bob", fmt.Sprintf(userPayload, dataStoreNames[0].ScopeName(), dataStoreNames[0], `[]`))
+	resp = rt.SendAdminRequest("PUT", "/db/_user/bob", fmt.Sprintf(userPayload, dataStoreNames[0].ScopeName(), dataStoreNames[0].CollectionName(), `[]`))
 	RequireStatus(t, resp, http.StatusCreated)
-	resp = rt.SendAdminRequest("PUT", "/db/_user/abby", fmt.Sprintf(userPayload, dataStoreNames[0].ScopeName(), dataStoreNames[0], `[]`))
+	resp = rt.SendAdminRequest("PUT", "/db/_user/abby", fmt.Sprintf(userPayload, dataStoreNames[0].ScopeName(), dataStoreNames[0].CollectionName(), `[]`))
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// Write docs in each collection that runs the per-collection sync functions that grant users access to various channels

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1431,13 +1431,13 @@ func TestGetUserCollectionAccess(t *testing.T) {
 	RequireStatus(t, userResponse, 200)
 	assert.NotContains(t, userResponse.Body.Bytes(), collection2Name)
 
-	// Attempt to write collections that aren't defined for the database for PUT /_user and /_role, disabled until CBG-2762 is fixed
+	// Attempt to write collections that aren't defined for the database for PUT /_user and /_role
 	putResponse = rt.SendAdminRequest("PUT", "/db/_user/alice2", fmt.Sprintf(userRolePayload, `"email":"alice@couchbase.com","password":"@232dfdg",`, scope1Name, collection1Name, `,"rgergeggrenhnnh": {
 					"admin_channels":["foo", "bar1"]
 				}`))
-	RequireStatus(t, putResponse, 400)
+	RequireStatus(t, putResponse, 404)
 	putResponse = rt.SendAdminRequest("PUT", "/db/_role/role1", fmt.Sprintf(userRolePayload, ``, scope1Name, collection1Name, collectionPayload))
-	RequireStatus(t, putResponse, 400)
+	RequireStatus(t, putResponse, 404)
 }
 
 func TestPutUserCollectionAccess(t *testing.T) {

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1432,12 +1432,12 @@ func TestGetUserCollectionAccess(t *testing.T) {
 	assert.NotContains(t, userResponse.Body.Bytes(), collection2Name)
 
 	// Attempt to write collections that aren't defined for the database for PUT /_user and /_role, disabled until CBG-2762 is fixed
-	//putResponse = rt.SendAdminRequest("PUT", "/db/_user/alice2", fmt.Sprintf(userRolePayload, `"email":"alice@couchbase.com","password":"@232dfdg",`, scope1Name, collection1Name, `,"rgergeggrenhnnh": {
-	//				"admin_channels":["foo", "bar1"]
-	//			}`))
-	//RequireStatus(t, putResponse, 400)
-	//putResponse = rt.SendAdminRequest("PUT", "/db/_role/role1", fmt.Sprintf(userRolePayload, ``, scope1Name, collection1Name, collectionPayload))
-	//RequireStatus(t, putResponse, 400)
+	putResponse = rt.SendAdminRequest("PUT", "/db/_user/alice2", fmt.Sprintf(userRolePayload, `"email":"alice@couchbase.com","password":"@232dfdg",`, scope1Name, collection1Name, `,"rgergeggrenhnnh": {
+					"admin_channels":["foo", "bar1"]
+				}`))
+	RequireStatus(t, putResponse, 400)
+	putResponse = rt.SendAdminRequest("PUT", "/db/_role/role1", fmt.Sprintf(userRolePayload, ``, scope1Name, collection1Name, collectionPayload))
+	RequireStatus(t, putResponse, 400)
 }
 
 func TestPutUserCollectionAccess(t *testing.T) {


### PR DESCRIPTION
CBG-2762

Describe your PR here...
- /_user and /_role endpoints now check if all collections in the passed collection_access map exist. if an inexistent collection is found, a 404 is returned

I'm unsure if the api docs need changing, both _user and _role specify 404 as a response but for Resource not found errors and not collection/scope not found

## [Integration Tests]
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1600/
