### PR TITLE
CBG-2761: return bad request when writing read_only collection_access properties

### DIFF
--- a/db/users.go
+++ b/db/users.go
@@ -269,7 +269,7 @@ func (dbc *DatabaseContext) RequiresCollectionAccessUpdate(ctx context.Context, 
 				if err != nil {
 					return false, base.HTTPErrorf(http.StatusNotFound, "keyspace specified in collection_access (%s) not found", fmt.Sprintf("%s.%s.%s", dbc.Name, scopeName, collectionName))
 				}
-				if len(updatedCollectionAccess.Channels_) > 0 {
+				if updatedCollectionAccess.Channels_ != nil {
 					return false, base.HTTPErrorf(http.StatusBadRequest, "collection_access.all_channels is read-only")
 				}
 				if updatedCollectionAccess.JWTChannels_ != nil {

--- a/db/users.go
+++ b/db/users.go
@@ -269,6 +269,15 @@ func (dbc *DatabaseContext) RequiresCollectionAccessUpdate(ctx context.Context, 
 				if err != nil {
 					return false, base.HTTPErrorf(http.StatusNotFound, "keyspace specified in collection_access (%s) not found", fmt.Sprintf("%s.%s.%s", dbc.Name, scopeName, collectionName))
 				}
+				if len(updatedCollectionAccess.Channels_) > 0 {
+					return false, base.HTTPErrorf(http.StatusBadRequest, "collection_access.all_channels is read-only")
+				}
+				if updatedCollectionAccess.JWTChannels_ != nil {
+					return false, base.HTTPErrorf(http.StatusBadRequest, "collection_access.jwt_channels is read-only")
+				}
+				if updatedCollectionAccess.JWTLastUpdated != nil {
+					return false, base.HTTPErrorf(http.StatusBadRequest, "collection_access.jwt_last_updated is read-only")
+				}
 				if updatedCollectionAccess == nil {
 					if princ.CollectionExplicitChannels(scopeName, collectionName) != nil {
 						requiresUpdate = true

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1369,9 +1369,6 @@ func TestGetUserCollectionAccess(t *testing.T) {
 	collectionPayload := fmt.Sprintf(`,"%s": {
 					"admin_channels":["foo", "bar1"]
 				}`, collection2Name)
-	rdOnlycollectionPayload := fmt.Sprintf(`,"%s": {
-					"jwt_channels":["foo", "bar1"]
-				}`, collection2Name)
 
 	// Create a user with collection metadata
 	userRolePayload := `{
@@ -1407,12 +1404,6 @@ func TestGetUserCollectionAccess(t *testing.T) {
 	assert.Equal(t, channels.BaseSetOf(t, "foo", "bar1", "!"), collectionAccess.Channels_)
 	assert.Nil(t, collectionAccess.JWTChannels_)
 	assert.Nil(t, collectionAccess.JWTLastUpdated)
-
-	// Attempt to write read-only properties for PUT /_user and /_role
-	putResponse = rt.SendAdminRequest("PUT", "/db/_user/bob2", fmt.Sprintf(userRolePayload, `"email":"bob@couchbase.com","password":"letmein",`, scope1Name, collection2Name, rdOnlycollectionPayload))
-	RequireStatus(t, putResponse, 400)
-	putResponse = rt.SendAdminRequest("PUT", "/db/_role/role12", fmt.Sprintf(userRolePayload, ``, scope1Name, collection2Name, rdOnlycollectionPayload))
-	RequireStatus(t, putResponse, 400)
 
 	scopesConfig = GetCollectionsConfig(t, testBucket, 1)
 	scopesConfigString, err := json.Marshal(scopesConfig)
@@ -1510,4 +1501,21 @@ func TestPutUserCollectionAccess(t *testing.T) {
 	userResponse := rt.SendAdminRequest("GET", "/db/_user/bob", "")
 	RequireStatus(t, userResponse, http.StatusOK)
 	assert.NotContains(t, userResponse.ResponseRecorder.Body.String(), collection2Name)
+
+	// Attempt to write collections that aren't defined for the database for PUT /_user and /_role
+	readOnlyProperties := []string{"all_channels", "jwt_channels", "jwt_last_updated"}
+	for _, property := range readOnlyProperties {
+		rdOnlyValue := `["ABC"]`
+		if property == "jwt_last_updated" {
+			rdOnlyValue = "22:55:44"
+		}
+		readOnlyCollectionPayload := fmt.Sprintf(`,"%s": {
+					"%s":%s
+				}`, collection2Name, property, rdOnlyValue)
+		// Attempt to write read-only properties for PUT /_user and /_role
+		putResponse = rt.SendAdminRequest("PUT", "/db/_user/bob2", fmt.Sprintf(userPayload, `"email":"bob@couchbase.com","password":"letmein",`, scopeName, collection2Name, `["ABC"]`, readOnlyCollectionPayload))
+		RequireStatus(t, putResponse, 400)
+		putResponse = rt.SendAdminRequest("PUT", "/db/_role/role12", fmt.Sprintf(userPayload, ``, scopeName, collection2Name, `["ABC"]`, readOnlyCollectionPayload))
+		RequireStatus(t, putResponse, 400)
+	}
 }

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1369,9 +1369,10 @@ func TestGetUserCollectionAccess(t *testing.T) {
 	collectionPayload := fmt.Sprintf(`,"%s": {
 					"admin_channels":["foo", "bar1"]
 				}`, collection2Name)
-	//rdOnlycollectionPayload := fmt.Sprintf(`,"%s": {
-	//				"jwt_channels":["foo", "bar1"]
-	//			}`, collection2Name)
+	rdOnlycollectionPayload := fmt.Sprintf(`,"%s": {
+					"jwt_channels":["foo", "bar1"]
+				}`, collection2Name)
+
 	// Create a user with collection metadata
 	userRolePayload := `{
 		%s
@@ -1407,11 +1408,11 @@ func TestGetUserCollectionAccess(t *testing.T) {
 	assert.Nil(t, collectionAccess.JWTChannels_)
 	assert.Nil(t, collectionAccess.JWTLastUpdated)
 
-	// Attempt to write read-only properties for PUT /_user and /_role, disabled until CBG-2761 is fixed
-	//putResponse = rt.SendAdminRequest("PUT", "/db/_user/bob2", fmt.Sprintf(userRolePayload, `"email":"bob@couchbase.com","password":"letmein",`, scope1Name, collection2Name, rdOnlycollectionPayload))
-	//RequireStatus(t, putResponse, 400)
-	//putResponse = rt.SendAdminRequest("PUT", "/db/_role/role12", fmt.Sprintf(userRolePayload, ``, scope1Name, collection2Name, rdOnlycollectionPayload))
-	//RequireStatus(t, putResponse, 400)
+	// Attempt to write read-only properties for PUT /_user and /_role
+	putResponse = rt.SendAdminRequest("PUT", "/db/_user/bob2", fmt.Sprintf(userRolePayload, `"email":"bob@couchbase.com","password":"letmein",`, scope1Name, collection2Name, rdOnlycollectionPayload))
+	RequireStatus(t, putResponse, 400)
+	putResponse = rt.SendAdminRequest("PUT", "/db/_role/role12", fmt.Sprintf(userRolePayload, ``, scope1Name, collection2Name, rdOnlycollectionPayload))
+	RequireStatus(t, putResponse, 400)
 
 	scopesConfig = GetCollectionsConfig(t, testBucket, 1)
 	scopesConfigString, err := json.Marshal(scopesConfig)

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1502,7 +1502,7 @@ func TestPutUserCollectionAccess(t *testing.T) {
 	RequireStatus(t, userResponse, http.StatusOK)
 	assert.NotContains(t, userResponse.ResponseRecorder.Body.String(), collection2Name)
 
-	// Attempt to write collections that aren't defined for the database for PUT /_user and /_role
+	// Attempt to write read-only properties for PUT /_user and /_role
 	readOnlyProperties := []string{"all_channels", "jwt_channels", "jwt_last_updated"}
 	for _, property := range readOnlyProperties {
 		rdOnlyValue := `["ABC"]`
@@ -1512,7 +1512,6 @@ func TestPutUserCollectionAccess(t *testing.T) {
 		readOnlyCollectionPayload := fmt.Sprintf(`,"%s": {
 					"%s":%s
 				}`, collection2Name, property, rdOnlyValue)
-		// Attempt to write read-only properties for PUT /_user and /_role
 		putResponse = rt.SendAdminRequest("PUT", "/db/_user/bob2", fmt.Sprintf(userPayload, `"email":"bob@couchbase.com","password":"letmein",`, scopeName, collection2Name, `["ABC"]`, readOnlyCollectionPayload))
 		RequireStatus(t, putResponse, 400)
 		putResponse = rt.SendAdminRequest("PUT", "/db/_role/role12", fmt.Sprintf(userPayload, ``, scopeName, collection2Name, `["ABC"]`, readOnlyCollectionPayload))

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1007,16 +1007,17 @@ func (rt *RestTester) SetAdminChannels(username string, keyspace string, channel
 
 	currentConfig.SetExplicitChannels(*scopeName, *collectionName, channels...)
 	// Remove read only properties returned from the user api
-	writableConfig := auth.PrincipalConfig{
-		Name:              currentConfig.Name,
-		ExplicitChannels:  currentConfig.ExplicitChannels,
-		CollectionAccess:  currentConfig.CollectionAccess,
-		Email:             currentConfig.Email,
-		Disabled:          currentConfig.Disabled,
-		Password:          currentConfig.Password,
-		ExplicitRoleNames: currentConfig.ExplicitRoleNames,
+	for _, scope := range currentConfig.CollectionAccess {
+		if scope != nil {
+			for _, collectionAccess := range scope {
+				collectionAccess.Channels_ = nil
+				collectionAccess.JWTChannels_ = nil
+				collectionAccess.JWTLastUpdated = nil
+			}
+		}
 	}
-	newConfigBytes, _ := base.JSONMarshal(writableConfig)
+
+	newConfigBytes, _ := base.JSONMarshal(currentConfig)
 
 	userResponse = rt.SendAdminRequest("PUT", "/"+dbName+"/_user/"+username, string(newConfigBytes))
 	if userResponse.Code != 200 {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1007,6 +1007,10 @@ func (rt *RestTester) SetAdminChannels(username string, keyspace string, channel
 	}
 
 	currentConfig.SetExplicitChannels(*scopeName, *collectionName, channels...)
+	currentConfig.JWTChannels = nil
+	currentConfig.JWTLastUpdated = nil
+	currentConfig.Channels = nil
+
 	newConfigBytes, _ := base.JSONMarshal(currentConfig)
 
 	userResponse = rt.SendAdminRequest("PUT", "/"+dbName+"/_user/"+username, string(newConfigBytes))


### PR DESCRIPTION
CBG-2761

Describe your PR here...
- Return 400 bad request when writing read_only collection_access properties for /_user and /_role endpoints


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1609/
