### PR TITLE
Disable ANSII color codes when running requireLogIs

### DIFF
--- a/base/logging_context_test.go
+++ b/base/logging_context_test.go
@@ -30,7 +30,13 @@ func requireLogIs(t testing.TB, s string, f func()) {
 	originalColor := consoleLogger.ColorEnabled
 	consoleLogger.ColorEnabled = false
 	consoleLogger.logger.SetOutput(&b)
+	defer func() {
+		consoleLogger.ColorEnabled = originalColor
+		consoleLogger.logger.SetOutput(os.Stderr)
+	}()
+
 	f()
+
 	var log string
 	var originalLog string
 	// Allow time for logs to be printed
@@ -46,8 +52,6 @@ func requireLogIs(t testing.TB, s string, f func()) {
 		return true, nil, nil
 	}
 	err, _ := RetryLoop("wait for logs", retry, CreateSleeperFunc(10, 100))
-	consoleLogger.ColorEnabled = originalColor
-	consoleLogger.logger.SetOutput(os.Stderr)
 
 	require.NoError(t, err, "Console logs did not contain %q, got %q", s, originalLog)
 }

--- a/base/logging_context_test.go
+++ b/base/logging_context_test.go
@@ -27,6 +27,8 @@ func requireLogIs(t testing.TB, s string, f func()) {
 	timestampLength := len(time.Now().Format(ISO8601Format) + " ")
 
 	// Temporarily override logger output for the given function call
+	originalColor := consoleLogger.ColorEnabled
+	consoleLogger.ColorEnabled = false
 	consoleLogger.logger.SetOutput(&b)
 	f()
 	var log string
@@ -44,6 +46,7 @@ func requireLogIs(t testing.TB, s string, f func()) {
 		return true, nil, nil
 	}
 	err, _ := RetryLoop("wait for logs", retry, CreateSleeperFunc(10, 100))
+	consoleLogger.ColorEnabled = originalColor
 	consoleLogger.logger.SetOutput(os.Stderr)
 
 	require.NoError(t, err, "Console logs did not contain %q, got %q", s, originalLog)


### PR DESCRIPTION
Tests using `requireLogIs` fail when `SG_COLOR=true` is set, because the ANSII color codes interrupt the regular string comparison.
- When we override the console logger for the function, disable color as well.

## Example failure
```go
=== RUN   TestBucketNameCtx
    logging_context_test.go:49:
        	Error Trace:	/Users/benbrooks/dev/cb/sync_gateway-workspace/sync_gateway/base/logging_context_test.go:49
        	            				/Users/benbrooks/dev/cb/sync_gateway-workspace/sync_gateway/base/logging_context_test.go:53
        	            				/Users/benbrooks/dev/cb/sync_gateway-workspace/sync_gateway/base/logging_context_test.go:202
        	Error:      	Received unexpected error:
        	            	RetryLoop for wait for logs giving up after 11 attempts
        	Test:       	TestBucketNameCtx
        	Messages:   	Console logs did not contain "[INF] t:TestBucketNameCtx b:fooBucket foobar\n", got "\x1b[1;34m2023-03-17T11:58:41.967Z [INF] t:TestBucketNameCtx b:fooBucket foobar\x1b[0m\n"
--- FAIL: TestBucketNameCtx (1.00s)
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a