### PR TITLE
CBG-2493: Rollback bug causing oneshot behaviour on continuous clients

### DIFF
--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -237,17 +237,6 @@ func (dc *DCPClient) configureOneShot() error {
 	return nil
 }
 
-func (dc *DCPClient) configureContinuous() {
-	var i uint16
-	maxSeqno := gocbcore.SeqNo(0xffffffffffffffff)
-	endSeqNos := make(map[uint16]uint64, dc.numVbuckets)
-
-	for i = 0; i < dc.numVbuckets; i++ {
-		endSeqNos[i] = uint64(maxSeqno)
-	}
-	dc.metadata.SetEndSeqNos(endSeqNos)
-}
-
 // Start returns an error and a channel to indicate when the DCPClient is done. If Start returns an error, DCPClient.Close() needs to be called.
 func (dc *DCPClient) Start() (doneChan chan error, err error) {
 	err = dc.initAgent(dc.spec)
@@ -259,8 +248,6 @@ func (dc *DCPClient) Start() (doneChan chan error, err error) {
 		if err != nil {
 			return dc.doneChannel, err
 		}
-	} else {
-		dc.configureContinuous()
 	}
 	dc.startWorkers()
 

--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -473,11 +473,11 @@ func (dc *DCPClient) openStream(vbID uint16, maxRetries uint32) (err error) {
 	return fmt.Errorf("openStream failed to complete after %d attempts, last error: %w", openRetryCount, openStreamErr)
 }
 
-func (dc *DCPClient) rollback(logCtx context.Context, vbID uint16) (err error) {
+func (dc *DCPClient) rollback(ctx context.Context, vbID uint16) (err error) {
 	if dc.dbStats != nil {
 		dc.dbStats.Add("dcp_rollback_count", 1)
 	}
-	dc.metadata.Rollback(logCtx, vbID)
+	dc.metadata.Rollback(ctx, vbID)
 	return nil
 }
 

--- a/base/dcp_client_metadata.go
+++ b/base/dcp_client_metadata.go
@@ -35,7 +35,7 @@ type DCPMetadata struct {
 }
 
 type DCPMetadataStore interface {
-	// Rollback resets vBucket metadata, preserving endSeqno and startSeqno
+	// Rollback resets vBucket metadata, preserving endSeqno
 	Rollback(ctx context.Context, vbID uint16)
 
 	// SetMeta updates the DCPMetadata for a vbucket
@@ -83,7 +83,7 @@ func NewDCPMetadataMem(numVbuckets uint16) *DCPMetadataMem {
 	return m
 }
 
-// Rollback resets the metadata, preserving EndSeqNo and startSeqno
+// Rollback resets the metadata, preserving EndSeqNo
 func (m *DCPMetadataMem) Rollback(logCtx context.Context, vbID uint16) {
 	m.metadata[vbID] = DCPMetadata{
 		VbUUID:          0,

--- a/base/dcp_client_metadata.go
+++ b/base/dcp_client_metadata.go
@@ -35,11 +35,8 @@ type DCPMetadata struct {
 }
 
 type DCPMetadataStore interface {
-	// Rollback resets vbucket metadata, but preserves endSeqNo
-	OneshotRollback(vbID uint16)
-
-	// Rollback resets vBucket metadata, but in this case sets endSeqno to maxSeqno for it to run continuous
-	ContinuousRollback(vbID uint16)
+	// Rollback resets vBucket metadata, preserving endSeqno and startSeqno
+	Rollback(ctx context.Context, vbID uint16)
 
 	// SetMeta updates the DCPMetadata for a vbucket
 	SetMeta(vbID uint16, meta DCPMetadata)
@@ -86,35 +83,17 @@ func NewDCPMetadataMem(numVbuckets uint16) *DCPMetadataMem {
 	return m
 }
 
-// OneshotRollback resets the metadata, preserving EndSeqNo if set, should be used if you want stream to end
-// after rollback is complete
-func (m *DCPMetadataMem) OneshotRollback(vbID uint16) {
-	rollbackStartSeqno := findRollbackStartSeqno(m.metadata[vbID].FailoverEntries)
+// Rollback resets the metadata, preserving EndSeqNo and startSeqno
+func (m *DCPMetadataMem) Rollback(logCtx context.Context, vbID uint16) {
 	m.metadata[vbID] = DCPMetadata{
 		VbUUID:          0,
-		StartSeqNo:      rollbackStartSeqno,
+		StartSeqNo:      0,
 		EndSeqNo:        m.endSeqNos[vbID],
 		SnapStartSeqNo:  0,
 		SnapEndSeqNo:    0,
 		FailoverEntries: make([]gocbcore.FailoverEntry, 0),
 	}
-	TracefCtx(context.TODO(), KeyDCP, "rolling back vb:%d with metadata set to %v", vbID, m.metadata[vbID])
-}
-
-// ContinuousRollback should be used when you want rollback to occur but the stream to remain open after its finished
-func (m *DCPMetadataMem) ContinuousRollback(vbID uint16) {
-	// use max seqno for end seqno in continuous clients
-	var maxEndSeqno = gocbcore.SeqNo(0xffffffffffffffff)
-	rollbackStartSeqno := findRollbackStartSeqno(m.metadata[vbID].FailoverEntries)
-	m.metadata[vbID] = DCPMetadata{
-		VbUUID:          0,
-		StartSeqNo:      rollbackStartSeqno,
-		EndSeqNo:        maxEndSeqno,
-		SnapStartSeqNo:  0,
-		SnapEndSeqNo:    0,
-		FailoverEntries: make([]gocbcore.FailoverEntry, 0),
-	}
-	TracefCtx(context.TODO(), KeyDCP, "rolling back vb:%d with metadata set to %v", vbID, m.metadata[vbID])
+	TracefCtx(logCtx, KeyDCP, "rolling back vb:%d with metadata set to %v", vbID, m.metadata[vbID])
 }
 
 func (m *DCPMetadataMem) SetMeta(vbID uint16, meta DCPMetadata) {
@@ -218,37 +197,17 @@ func NewDCPMetadataCS(store DataStore, numVbuckets uint16, numWorkers int, keyPr
 	return m
 }
 
-// OneshotRollback resets the metadata, preserving EndSeqNo if set, should be used if you want stream to end
-// after rollback is complete
-func (m *DCPMetadataCS) OneshotRollback(vbID uint16) {
-	// Preserve endSeqNo on rollback
+func (m *DCPMetadataCS) Rollback(logCtx context.Context, vbID uint16) {
 	endSeqNo := m.metadata[vbID].EndSeqNo
-	rollbackStartSeqno := findRollbackStartSeqno(m.metadata[vbID].FailoverEntries)
 	m.metadata[vbID] = DCPMetadata{
 		VbUUID:          0,
-		StartSeqNo:      rollbackStartSeqno,
+		StartSeqNo:      0,
 		EndSeqNo:        endSeqNo,
 		SnapStartSeqNo:  0,
 		SnapEndSeqNo:    0,
 		FailoverEntries: make([]gocbcore.FailoverEntry, 0),
 	}
-	TracefCtx(context.TODO(), KeyDCP, "rolling back vb:%d with metadata set to %v", vbID, m.metadata[vbID])
-}
-
-// ContinuousRollback should be used when you want rollback to occur but the stream to remain open after its finished
-func (m *DCPMetadataCS) ContinuousRollback(vbID uint16) {
-	// use max seqno for end seqno in continuous clients
-	var maxEndSeqno = gocbcore.SeqNo(0xffffffffffffffff)
-	rollbackStartSeqno := findRollbackStartSeqno(m.metadata[vbID].FailoverEntries)
-	m.metadata[vbID] = DCPMetadata{
-		VbUUID:          0,
-		StartSeqNo:      rollbackStartSeqno,
-		EndSeqNo:        maxEndSeqno,
-		SnapStartSeqNo:  0,
-		SnapEndSeqNo:    0,
-		FailoverEntries: make([]gocbcore.FailoverEntry, 0),
-	}
-	TracefCtx(context.TODO(), KeyDCP, "rolling back vb:%d with metadata set to %v", vbID, m.metadata[vbID])
+	TracefCtx(logCtx, KeyDCP, "rolling back vb:%d with metadata set to %v", vbID, m.metadata[vbID])
 }
 
 func (m *DCPMetadataCS) SetMeta(vbNo uint16, metadata DCPMetadata) {
@@ -335,18 +294,4 @@ func (m *DCPMetadataCS) getMetadataKey(workerID int) string {
 
 type WorkerMetadata struct {
 	DCPMeta map[uint16]DCPMetadata
-}
-
-// findRollbackStartSeqno finds the highest seqno available in the failover log and will use that as start seqno for the rollback.
-// This reduces the work needed on a rollback.
-func findRollbackStartSeqno(failoverLog []gocbcore.FailoverEntry) gocbcore.SeqNo {
-	var rollBackSeqno gocbcore.SeqNo = 0
-	if len(failoverLog) > 0 {
-		for i := 0; i < len(failoverLog); i++ {
-			if rollBackSeqno < failoverLog[i].SeqNo {
-				rollBackSeqno = failoverLog[i].SeqNo
-			}
-		}
-	}
-	return rollBackSeqno
 }

--- a/base/dcp_client_metadata.go
+++ b/base/dcp_client_metadata.go
@@ -65,14 +65,12 @@ type DCPMetadataStore interface {
 }
 
 type DCPMetadataMem struct {
-	metadata  []DCPMetadata
-	endSeqNos []gocbcore.SeqNo
+	metadata []DCPMetadata
 }
 
 func NewDCPMetadataMem(numVbuckets uint16) *DCPMetadataMem {
 	m := &DCPMetadataMem{
-		metadata:  make([]DCPMetadata, numVbuckets),
-		endSeqNos: make([]gocbcore.SeqNo, numVbuckets),
+		metadata: make([]DCPMetadata, numVbuckets),
 	}
 	for vbNo := uint16(0); vbNo < numVbuckets; vbNo++ {
 		m.metadata[vbNo] = DCPMetadata{
@@ -84,16 +82,17 @@ func NewDCPMetadataMem(numVbuckets uint16) *DCPMetadataMem {
 }
 
 // Rollback resets the metadata, preserving EndSeqNo
-func (m *DCPMetadataMem) Rollback(logCtx context.Context, vbID uint16) {
+func (m *DCPMetadataMem) Rollback(ctx context.Context, vbID uint16) {
+	endSeqNo := m.metadata[vbID].EndSeqNo
 	m.metadata[vbID] = DCPMetadata{
 		VbUUID:          0,
 		StartSeqNo:      0,
-		EndSeqNo:        m.endSeqNos[vbID],
+		EndSeqNo:        endSeqNo,
 		SnapStartSeqNo:  0,
 		SnapEndSeqNo:    0,
 		FailoverEntries: make([]gocbcore.FailoverEntry, 0),
 	}
-	TracefCtx(logCtx, KeyDCP, "rolling back vb:%d with metadata set to %v", vbID, m.metadata[vbID])
+	TracefCtx(ctx, KeyDCP, "rolling back vb:%d with metadata set to %v", vbID, m.metadata[vbID])
 }
 
 func (m *DCPMetadataMem) SetMeta(vbID uint16, meta DCPMetadata) {
@@ -124,7 +123,6 @@ func (m *DCPMetadataMem) SetEndSeqNos(endSeqNos map[uint16]uint64) {
 	for i := 0; i < len(m.metadata); i++ {
 		endSeqNo, _ := endSeqNos[uint16(i)]
 		m.metadata[i].EndSeqNo = gocbcore.SeqNo(endSeqNo)
-		m.endSeqNos[i] = gocbcore.SeqNo(endSeqNo)
 	}
 }
 
@@ -171,7 +169,6 @@ type DCPMetadataCS struct {
 	dataStore DataStore
 	keyPrefix string
 	metadata  []DCPMetadata
-	endSeqNos []gocbcore.SeqNo
 }
 
 func NewDCPMetadataCS(store DataStore, numVbuckets uint16, numWorkers int, keyPrefix string) *DCPMetadataCS {
@@ -180,7 +177,6 @@ func NewDCPMetadataCS(store DataStore, numVbuckets uint16, numWorkers int, keyPr
 		dataStore: store,
 		keyPrefix: keyPrefix,
 		metadata:  make([]DCPMetadata, numVbuckets),
-		endSeqNos: make([]gocbcore.SeqNo, numVbuckets),
 	}
 	for vbNo := uint16(0); vbNo < numVbuckets; vbNo++ {
 		m.metadata[vbNo] = DCPMetadata{
@@ -197,7 +193,7 @@ func NewDCPMetadataCS(store DataStore, numVbuckets uint16, numWorkers int, keyPr
 	return m
 }
 
-func (m *DCPMetadataCS) Rollback(logCtx context.Context, vbID uint16) {
+func (m *DCPMetadataCS) Rollback(ctx context.Context, vbID uint16) {
 	endSeqNo := m.metadata[vbID].EndSeqNo
 	m.metadata[vbID] = DCPMetadata{
 		VbUUID:          0,
@@ -207,7 +203,7 @@ func (m *DCPMetadataCS) Rollback(logCtx context.Context, vbID uint16) {
 		SnapEndSeqNo:    0,
 		FailoverEntries: make([]gocbcore.FailoverEntry, 0),
 	}
-	TracefCtx(logCtx, KeyDCP, "rolling back vb:%d with metadata set to %v", vbID, m.metadata[vbID])
+	TracefCtx(ctx, KeyDCP, "rolling back vb:%d with metadata set to %v", vbID, m.metadata[vbID])
 }
 
 func (m *DCPMetadataCS) SetMeta(vbNo uint16, metadata DCPMetadata) {

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -393,7 +393,7 @@ func TestContinuousDCPRollback(t *testing.T) {
 		mutationCount := atomic.LoadUint64(&mutationCount)
 		require.Equal(t, uint64(1000), mutationCount)
 	case <-timeout:
-		t.Fatalf("continuous client closed early")
+		t.Fatalf("timeout on client reached")
 	}
 
 	// Assert that the number of vBuckets active are the same as the total number of vBuckets on the client.

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -322,6 +322,7 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 }
 
 func TestContinuousDCPRollback(t *testing.T) {
+	SetUpTestLogging(t, LevelDebug, KeyDCP)
 
 	if UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
@@ -359,10 +360,11 @@ func TestContinuousDCPRollback(t *testing.T) {
 	}
 
 	dcpClientOpts := DCPClientOptions{
-		FailOnRollback:   false,
-		OneShot:          false,
-		CollectionIDs:    collectionIDs,
-		CheckpointPrefix: DefaultMetadataKeys.DCPCheckpointPrefix(t.Name()),
+		FailOnRollback:    false,
+		OneShot:           false,
+		CollectionIDs:     collectionIDs,
+		CheckpointPrefix:  DefaultMetadataKeys.DCPCheckpointPrefix(t.Name()),
+		MetadataStoreType: DCPMetadataStoreInMemory,
 	}
 
 	// timeout for feed to complete
@@ -412,7 +414,7 @@ func (dc *DCPClient) forceRollbackvBucket(uuid gocbcore.VbUUID) {
 		if i%2 == 0 {
 			metadata[i] = dc.metadata.GetMeta(i)
 			metadata[i].VbUUID = uuid
-			metadata[i].StartSeqNo = 6
+			metadata[i].StartSeqNo = 4
 		} else {
 			metadata[i] = dc.metadata.GetMeta(i)
 		}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -129,66 +129,6 @@ func TestDisablePublicBasicAuth(t *testing.T) {
 	RequireStatus(t, response, http.StatusOK)
 }
 
-func TestLol(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyDCP, base.KeyCRUD, base.KeyChanges, base.KeyQuery, base.KeyHTTP)
-	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction,
-		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{AutoImport: true}}})
-	defer rt.Close()
-
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq db.SequenceID
-	}
-
-	sync := channels.DocChannelsSyncFunction
-	var resp *TestResponse
-	testBucket := base.GetPersistentTestBucket(t)
-	defer testBucket.Close()
-	fmt.Println(rt.GetSingleTestDatabaseCollection().Name)
-
-	resp = rt.SendAdminRequest(http.MethodPut, "/db/_config", fmt.Sprintf(`{"bucket": "%s", "num_index_replicas": 0, "scopes": {"%s": { "collections": {"%s": {"sync":"%s"}}}}}`,
-		testBucket.GetName(), rt.GetSingleTestDatabaseCollection().ScopeName, rt.GetSingleTestDatabaseCollection().Name, sync))
-	RequireStatus(t, resp, http.StatusCreated)
-
-	fmt.Println("failover + rebalance out now now")
-	time.Sleep(50 * time.Second)
-
-	err := rt.GetDatabase().RestartListener()
-	require.NoError(t, err)
-
-	for i := 0; i < 10; i++ {
-		resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+fmt.Sprint(i), `{"greg": "lol"}`)
-		if resp.Code != http.StatusCreated {
-			i--
-		}
-		time.Sleep(4 * time.Second)
-	}
-
-	changesResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/_changes?since=0", "")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Len(t, changes.Results, 10)
-
-	fmt.Println("add server back")
-	time.Sleep(10 * time.Second)
-	fmt.Println("rebalance it in")
-	time.Sleep(50 * time.Second)
-
-	for i := 10; i < 110; i++ {
-		resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+fmt.Sprint(i), `{"greg": "lol"}`)
-		if resp.Code != http.StatusCreated {
-			i--
-		}
-	}
-
-	time.Sleep(10 * time.Second)
-	changesResponse = rt.SendAdminRequest("GET", "/{{.keyspace}}/_changes?since=0", "")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Len(t, changes.Results, 110)
-
-}
-
 func TestDocLifecycle(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()


### PR DESCRIPTION
CBG-2493

High level below is to fix bug where if a rollback was needfed the feed would close after the rollback was done even if the client was not a oneshot client. This caused an issue in QE test where documents weren't getting streamed back to sync gateway mutation feed after docs were put into server through sync gateway. Essentially due to these docs hitting these particular vBuckets that ended rollback and there was no open stream to stream these to the mutation feed on sync gateway. 

This PR adds a function for creating initialising the endSeqNo map on the metadata on the DCP client for continuous clients. This was only being done for one shot clients before. This led to the map being initialised with 0's for all vbID's and the rollback setting the vBucket metadata end seqno to the end senqo in the map for the vBucket. Causing feeds to shutdown immediately as they end up with end seqno of 0. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1625/
