### PR TITLE
Write test for channels.set printing

### DIFF
--- a/channels/set.go
+++ b/channels/set.go
@@ -160,7 +160,7 @@ func (s Set) Contains(ch ID) bool {
 
 // Convert to String(), necessary for logging.
 func (s Set) String() string {
-	keys := make([]string, len(s))
+	keys := make([]string, 0, len(s))
 	for ch := range s {
 		keys = append(keys, ch.String())
 	}

--- a/channels/set_test.go
+++ b/channels/set_test.go
@@ -325,3 +325,47 @@ func TestSetContains(t *testing.T) {
 		})
 	}
 }
+
+func TestSetString(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  Set
+		output string
+	}{
+		{
+			name:   "empty,emptyID",
+			input:  Set{},
+			output: "{}",
+		},
+		{
+			name: "two collections",
+			input: Set{
+				NewID("A", 1): present{},
+				NewID("B", 2): present{},
+				NewID("C", 1): present{},
+			},
+			output: "{1.A, 1.C, 2.B}",
+		},
+		{
+			name: "two collections, collection2",
+			input: Set{
+				NewID("A", 2): present{},
+				NewID("B", 2): present{},
+				NewID("C", 1): present{},
+			},
+			output: "{1.C, 2.A, 2.B}",
+		},
+		{
+			name: "one collection",
+			input: Set{
+				NewID("A", 1): present{},
+			},
+			output: "{1.A}",
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.output, test.input.String())
+		})
+	}
+}


### PR DESCRIPTION
The way this PR is written, calling `%s` on `channels.Set` produces "{1.A, 1.C, 2.B}". This often gets redacted as a group as in:

```Changes+: Notifying that "sg_int_walrus_a2aea84bbcfd39a411ffe32de2b5e2f8" changed (keys="<ud>{, , 1.*, 1.b}</ud>") count=6```

I've eliminated the obvious dead wide space here but you might actually want for this to be something that stores KV ids together:

```keys="<ud>{KVID 1: {*, b}}</ud>"```

or more optimally:

```keys="{KVID 1: {<ud>*</ud>, <ud>b</ud>}}</ud>"```

Doing either of those iterations will be paying a major cost to iteration for a really high throughput point. https://github.com/couchbase/sync_gateway/blob/6534e9de57841a322dac110ada33a92ae0becd3e/db/change_listener.go#L238 However, storing the data in a different format potentially makes the channel cache bigger in terms of RAM.

Filed https://issues.couchbase.com/browse/CBG-2789 for a larger explanation of this issue, with a more comprehensive fix.