### PR TITLE
CBG-2734 hash principal names when storing keys

### DIFF
--- a/base/constants_syncdocs_test.go
+++ b/base/constants_syncdocs_test.go
@@ -62,3 +62,29 @@ func TestMetaKeyNames(t *testing.T) {
 		assert.False(t, strings.HasPrefix(metaKeyName, MetadataIdPrefix))
 	}
 }
+
+func TestMetadataKeyHash(t *testing.T) {
+	defaultMetadataKeys := NewMetadataKeys("")
+	customMetadataKeys := NewMetadataKeys("foo")
+
+	// normal user name
+	bob := "bob"
+	require.Equal(t, "_sync:user:bob", defaultMetadataKeys.UserKey(bob))
+	require.Equal(t, "_sync:user:foo:bob", customMetadataKeys.UserKey(bob))
+
+	// username one less than hash length
+	user39 := strings.Repeat("b", 39)
+	require.Equal(t, "_sync:user:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", defaultMetadataKeys.UserKey(user39))
+	require.Equal(t, "_sync:user:foo:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", customMetadataKeys.UserKey(user39))
+
+	// username equal to hash length
+	user40 := strings.Repeat("b", 40)
+	require.Equal(t, "_sync:user:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", defaultMetadataKeys.UserKey(user40))
+	require.Equal(t, "_sync:user:foo:56e892b750b146f39a486af8c31d555e9c771b3e", customMetadataKeys.UserKey(user40))
+
+	// make sure hashed user won't get rehashed
+	hashedUser := "56e892b750b146f39a486af8c31d555e9c771b3e"
+	require.Equal(t, "_sync:user:56e892b750b146f39a486af8c31d555e9c771b3e", defaultMetadataKeys.UserKey(hashedUser))
+	require.Equal(t, "_sync:user:foo:afbf3a596bfe3e6687240e011bfccafd51611052", customMetadataKeys.UserKey(hashedUser))
+
+}

--- a/db/database.go
+++ b/db/database.go
@@ -1389,7 +1389,14 @@ outerLoop:
 			if !isDbUser && !isDbRole {
 				continue
 			}
-			principalName = startKey
+			if !db.Options.UseViews {
+				principalName = startKey
+			} else if isDbUser {
+				principalName = rowID[lenDbUserPrefix:]
+			} else {
+				principalName = rowID[lenDbRolePrefix:]
+
+			}
 			resultCount++
 
 			if principalName != "" && !skipAddition {
@@ -1544,7 +1551,12 @@ outerLoop:
 			if !strings.HasPrefix(queryRow.Id, dbRoleIDPrefix) {
 				break
 			}
-			roleName = queryRow.Name
+			if !db.UseViews() {
+				roleName = queryRow.Name
+			} else {
+				roleName = queryRow.Id[lenRoleKeyPrefix:]
+
+			}
 			startKey = queryRow.Id
 
 			resultCount++

--- a/db/database.go
+++ b/db/database.go
@@ -1324,7 +1324,6 @@ outerLoop:
 		}
 
 	}
-
 	return users, nil
 }
 
@@ -1373,13 +1372,13 @@ outerLoop:
 				//principalName = viewRow.Key
 				startKey = viewRow.Key
 			} else {
-				var queryRow QueryIdRow
+				var queryRow principalRow
 				found := results.Next(&queryRow)
 				if !found {
 					break
 				}
 				rowID = queryRow.Id
-				startKey = queryRow.Id
+				startKey = queryRow.Name
 			}
 			if len(rowID) < lenDbUserPrefix && len(rowID) < lenDbRolePrefix {
 				continue
@@ -1390,11 +1389,7 @@ outerLoop:
 			if !isDbUser && !isDbRole {
 				continue
 			}
-			if isDbUser {
-				principalName = rowID[lenDbUserPrefix:]
-			} else {
-				principalName = rowID[lenDbRolePrefix:]
-			}
+			principalName = startKey
 			resultCount++
 
 			if principalName != "" && !skipAddition {
@@ -1538,7 +1533,7 @@ outerLoop:
 				skipAddition = true
 			}
 
-			var queryRow QueryIdRow
+			var queryRow principalRow
 			found := results.Next(&queryRow)
 			if !found {
 				break
@@ -1549,7 +1544,7 @@ outerLoop:
 			if !strings.HasPrefix(queryRow.Id, dbRoleIDPrefix) {
 				break
 			}
-			roleName = queryRow.Id[lenRoleKeyPrefix:]
+			roleName = queryRow.Name
 			startKey = queryRow.Id
 
 			resultCount++

--- a/db/query.go
+++ b/db/query.go
@@ -27,6 +27,12 @@ type QueryIdRow struct {
 	Id string
 }
 
+// Used for queries that only return doc id
+type principalRow struct {
+	Id   string
+	Name string
+}
+
 const (
 	N1QLMaxInt64 = 9223372036854775000 // Use this for compatibly with all server versions, see MB-54930 for discussion
 )
@@ -158,7 +164,7 @@ type QueryChannelsRow struct {
 var QueryPrincipals = SGQuery{
 	name: QueryTypePrincipals,
 	statement: fmt.Sprintf(
-		"SELECT META(%s).id "+
+		"SELECT name, META(%s).id "+
 			"FROM %s AS %s "+
 			"USE INDEX($idx) "+
 			"WHERE META(%s).id LIKE '%s' "+
@@ -179,7 +185,7 @@ var QueryPrincipals = SGQuery{
 var QueryAllRolesUsingRoleIdx = SGQuery{
 	name: QueryTypeRoles,
 	statement: fmt.Sprintf(
-		"SELECT META(%s).id "+
+		"SELECT name, META(%s).id "+
 			"FROM %s AS %s "+
 			"USE INDEX($idx) "+
 			"WHERE META(%s).id LIKE '%s' "+
@@ -196,7 +202,7 @@ var QueryAllRolesUsingRoleIdx = SGQuery{
 var QueryAllRolesUsingSyncDocsIdx = SGQuery{
 	name: QueryTypeRoles,
 	statement: fmt.Sprintf(
-		"SELECT META(%s).id "+
+		"SELECT name, META(%s).id "+
 			"FROM %s AS %s "+
 			"USE INDEX($idx) "+
 			"WHERE META(%s).id LIKE '%s' "+
@@ -215,7 +221,7 @@ var QueryAllRolesUsingSyncDocsIdx = SGQuery{
 var QueryRolesExcludeDeleted = SGQuery{
 	name: QueryTypeRolesExcludeDeleted,
 	statement: fmt.Sprintf(
-		"SELECT META(%s).id "+
+		"SELECT name, META(%s).id "+
 			"FROM %s AS %s "+
 			"USE INDEX($idx) "+
 			"WHERE META(%s).id LIKE '%s' "+
@@ -236,7 +242,7 @@ var QueryRolesExcludeDeleted = SGQuery{
 var QueryRolesExcludeDeletedUsingRoleIdx = SGQuery{
 	name: QueryTypeRolesExcludeDeleted,
 	statement: fmt.Sprintf(
-		"SELECT META(%s).id "+
+		"SELECT name, META(%s).id "+
 			"FROM %s AS %s "+
 			"USE INDEX($idx) "+
 			"WHERE META(%s).id LIKE '%s' "+

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -10,8 +10,6 @@ package rest
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -761,11 +759,5 @@ func (b *bootstrapContext) computeMetadataID(ctx context.Context, registry *Gate
 
 // standardMetadataID returns either the dbName or a base64 encoded SHA256 hash of the dbName, whichever is shorter.
 func (b *bootstrapContext) standardMetadataID(dbName string) string {
-	if len(dbName) >= 44 {
-		digester := sha256.New()
-		digester.Write([]byte(dbName))
-		return base64.StdEncoding.EncodeToString(digester.Sum(nil))
-	} else {
-		return dbName
-	}
+	return base.SerializeIfLonger(dbName, 40)
 }

--- a/rest/config_manager_test.go
+++ b/rest/config_manager_test.go
@@ -144,12 +144,12 @@ func TestLongMetadataID(t *testing.T) {
 	shortMetadataID := bootstrapContext.standardMetadataID("dbName")
 	assert.Equal(t, "dbName", shortMetadataID)
 
-	maxLengthNonHashedDbName := "longDbName012345678901234567890123456789012"
+	maxLengthNonHashedDbName := "longDbName01234567890123456789012345678"
 	nonHashedMetadataID := bootstrapContext.standardMetadataID(maxLengthNonHashedDbName)
 	assert.Equal(t, maxLengthNonHashedDbName, nonHashedMetadataID)
 
-	longMetadataID := bootstrapContext.standardMetadataID("longDbName0123456789012345678901234567890123")
-	assert.Equal(t, "6g2n4W2aWmQLvZIH7JXbv4V0klGFAEvZJ68gTVrgW7A=", longMetadataID)
+	longMetadataID := bootstrapContext.standardMetadataID("longDbName012345678901234567890123456789")
+	assert.Equal(t, "da551b63fcdb3c725007b0909d48c2255ad1f934", longMetadataID)
 
 	// Ensure no collision on hashed IDs (i.e. attempting to set a db name to a base64 hash will trigger rehashing)
 	rehashMetadataID := bootstrapContext.standardMetadataID(longMetadataID)


### PR DESCRIPTION
Use a sha1 hash for keys stored in the database that now have metadata dbname stored in them:

- user
- user email
- role
- replication ID

Also:

- Switched metadata registry to use sha1 for consistency.
- Do _not_ shorten and redact if the metadata is the default.

I tested this code by creating the redaction length from 40 (length of sha1) to 1 character - and it shook out the query bugs.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1617/
