### PR TITLE
CBG-2759: Collection aware ISGR channel fitering

### DIFF
--- a/db/active_replicator_common_collections.go
+++ b/db/active_replicator_common_collections.go
@@ -198,10 +198,14 @@ func (arc *activeReplicatorCommon) forEachCollection(callback func(*activeReplic
 // getFilteredChannels returns the filtered channels.
 // collectionIdx can be nil if replicating without collections enabled.
 func (config ActiveReplicatorConfig) getFilteredChannels(collectionIdx *int) []string {
-	if collectionIdx != nil {
-		if len(config.CollectionsChannelFilter)-1 >= *collectionIdx {
-			return config.CollectionsChannelFilter[*collectionIdx]
-		}
+	if collectionIdx == nil {
+		return config.FilterChannels
 	}
-	return config.FilterChannels
+
+	if len(config.CollectionsChannelFilter)-1 >= *collectionIdx {
+		return config.CollectionsChannelFilter[*collectionIdx]
+	}
+
+	// filter not present for collections, show all channels
+	return nil
 }

--- a/db/active_replicator_common_collections.go
+++ b/db/active_replicator_common_collections.go
@@ -198,14 +198,10 @@ func (arc *activeReplicatorCommon) forEachCollection(callback func(*activeReplic
 // getFilteredChannels returns the filtered channels.
 // collectionIdx can be nil if replicating without collections enabled.
 func (config ActiveReplicatorConfig) getFilteredChannels(collectionIdx *int) []string {
-	if collectionIdx == nil {
-		return config.FilterChannels
+	if collectionIdx != nil {
+		if len(config.CollectionsChannelFilter)-1 >= *collectionIdx {
+			return config.CollectionsChannelFilter[*collectionIdx]
+		}
 	}
-
-	if len(config.CollectionsChannelFilter)-1 >= *collectionIdx {
-		return config.CollectionsChannelFilter[*collectionIdx]
-	}
-
-	// filter not present for collections, show all channels
-	return nil
+	return config.FilterChannels
 }

--- a/db/active_replicator_common_collections.go
+++ b/db/active_replicator_common_collections.go
@@ -34,9 +34,17 @@ func (arc *activeReplicatorCommon) _initCollections() ([]replicationCheckpoint, 
 		getCollectionsCheckpointIDs []string
 	)
 
+	// ensure remote collection set is the same length as local collection set
 	if remoteLen := len(arc.config.CollectionsRemote); remoteLen > 0 {
 		if localLen := len(arc.config.CollectionsLocal); localLen != remoteLen {
 			return nil, fmt.Errorf("local and remote collections must be the same length... had %d and %d", localLen, remoteLen)
+		}
+	}
+
+	// ensure channel filter set is the same length as local collection set
+	if channelFilterLen := len(arc.config.CollectionsChannelFilter); channelFilterLen > 0 {
+		if localLen := len(arc.config.CollectionsLocal); localLen != channelFilterLen {
+			return nil, fmt.Errorf("local collections and channel filter set must be the same length... had %d and %d", localLen, channelFilterLen)
 		}
 	}
 
@@ -156,6 +164,21 @@ func (arc *activeReplicatorCommon) forEachCollection(callback func(*activeReplic
 	} else {
 		if err := callback(arc.defaultCollection); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// getFilteredChannels returns the filtered channels.
+// collectionIdx can be nil if replicating without collections enabled.
+func (config ActiveReplicatorConfig) getFilteredChannels(collectionIdx *int) []string {
+	if collectionIdx != nil {
+		if len(config.CollectionsChannelFilter) > 0 {
+			return config.CollectionsChannelFilter[*collectionIdx]
+		}
+	} else {
+		if config.FilterChannels != nil {
+			return config.FilterChannels
 		}
 	}
 	return nil

--- a/db/active_replicator_common_collections.go
+++ b/db/active_replicator_common_collections.go
@@ -42,9 +42,12 @@ func (arc *activeReplicatorCommon) _initCollections() ([]replicationCheckpoint, 
 	}
 
 	// ensure channel filter set is the same length as local collection set
-	if channelFilterLen := len(arc.config.CollectionsChannelFilter); channelFilterLen > 0 {
-		if localLen := len(arc.config.CollectionsLocal); localLen != channelFilterLen {
-			return nil, fmt.Errorf("local collections and channel filter set must be the same length... had %d and %d", localLen, channelFilterLen)
+	if collectionsChannelFilterLen := len(arc.config.CollectionsChannelFilter); collectionsChannelFilterLen > 0 {
+		if localLen := len(arc.config.CollectionsLocal); localLen != collectionsChannelFilterLen {
+			return nil, fmt.Errorf("local collections and channel filter set must be the same length... had %d and %d", localLen, collectionsChannelFilterLen)
+		}
+		if channelFilterLen := len(arc.config.FilterChannels); channelFilterLen > 0 {
+			return nil, fmt.Errorf("channel filter and collection channel filter set cannot both be set")
 		}
 	}
 

--- a/db/active_replicator_common_collections.go
+++ b/db/active_replicator_common_collections.go
@@ -57,9 +57,9 @@ func (arc *activeReplicatorCommon) _initCollections() ([]replicationCheckpoint, 
 			localCollectionsKeyspaces = append(localCollectionsKeyspaces, localScopeAndCollectionName)
 
 			// remap collection name to remote if set
-			if remoteScopeAndCollection := arc.config.CollectionsRemote[i]; remoteScopeAndCollection != "" {
-				base.DebugfCtx(arc.ctx, base.KeyReplicate, "Mapping local %q to remote %q", localScopeAndCollection, remoteScopeAndCollection)
-				remoteScopeAndCollectionName, err := getScopeAndCollectionName(remoteScopeAndCollection)
+			if len(arc.config.CollectionsRemote) > 0 && arc.config.CollectionsRemote[i] != "" {
+				base.DebugfCtx(arc.ctx, base.KeyReplicate, "Mapping local %q to remote %q", localScopeAndCollection, arc.config.CollectionsRemote[i])
+				remoteScopeAndCollectionName, err := getScopeAndCollectionName(arc.config.CollectionsRemote[i])
 				if err != nil {
 					return nil, err
 				}
@@ -173,13 +173,9 @@ func (arc *activeReplicatorCommon) forEachCollection(callback func(*activeReplic
 // collectionIdx can be nil if replicating without collections enabled.
 func (config ActiveReplicatorConfig) getFilteredChannels(collectionIdx *int) []string {
 	if collectionIdx != nil {
-		if len(config.CollectionsChannelFilter) > 0 {
+		if len(config.CollectionsChannelFilter)-1 >= *collectionIdx {
 			return config.CollectionsChannelFilter[*collectionIdx]
 		}
-	} else {
-		if config.FilterChannels != nil {
-			return config.FilterChannels
-		}
 	}
-	return nil
+	return config.FilterChannels
 }

--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -167,6 +167,7 @@ func (arc ActiveReplicatorConfig) CheckpointHash() (string, error) {
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
 }
 
+// Equals returns true if the given config is equal to the receiver. Used to detect when a replication config has changed via isCfgChanged
 func (arc *ActiveReplicatorConfig) Equals(other *ActiveReplicatorConfig) bool {
 
 	if arc.ID != other.ID {
@@ -238,6 +239,18 @@ func (arc *ActiveReplicatorConfig) Equals(other *ActiveReplicatorConfig) bool {
 	}
 
 	if arc.DeltasEnabled != other.DeltasEnabled {
+		return false
+	}
+
+	if arc.CollectionsEnabled != other.CollectionsEnabled {
+		return false
+	}
+
+	if !reflect.DeepEqual(arc.CollectionsLocal, other.CollectionsLocal) {
+		return false
+	}
+
+	if !reflect.DeepEqual(arc.CollectionsRemote, other.CollectionsRemote) {
 		return false
 	}
 

--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -46,7 +46,7 @@ type ActiveReplicatorConfig struct {
 	ID string
 	// Filter is a predetermined filter name (e.g. sync_gateway/bychannel)
 	Filter string
-	// FilterChannels are a set of channels to be used by the sync_gateway/bychannel filter.
+	// FilterChannels are a set of channels to be used by the sync_gateway/bychannel filter. Access via getFilteredChannels.
 	FilterChannels []string
 	// DocIDs limits the changes to only those doc IDs specified.
 	DocIDs []string
@@ -91,6 +91,8 @@ type ActiveReplicatorConfig struct {
 	// CollectionsRemote represents an equivalent list of dot-separated scope/collections that the local collections will be remapped to on the remote/passive side.
 	// This slice can be empty to replicate all scopes/collections for the database when CollectionsEnabled is set to true.
 	CollectionsRemote []string // list of remote/passive "scope.collection"
+	// CollectionsChannelFilter represents a list of channels to be replicated for each collection. Access via getFilteredChannels.
+	CollectionsChannelFilter [][]string // list of channels to replicate for each collection.
 
 	// Delta sync enabled
 	DeltasEnabled bool
@@ -123,7 +125,7 @@ type OnCompleteFunc func(replicationID string)
 
 // CheckpointHash returns a deterministic hash of the given config to be used as part of a checkpoint's validity.
 // TODO: Might be a way of caching this value? But need to be sure no config values will change without clearing the cached hash.
-func (arc ActiveReplicatorConfig) CheckpointHash() (string, error) {
+func (arc ActiveReplicatorConfig) CheckpointHash(collectionIdx *int) (string, error) {
 	hash := sha1.New()
 
 	// For each field in the config that affects replication result, append its value to the hasher.
@@ -138,9 +140,11 @@ func (arc ActiveReplicatorConfig) CheckpointHash() (string, error) {
 	if _, err := hash.Write([]byte(arc.Filter)); err != nil {
 		return "", err
 	}
-	if _, err := hash.Write([]byte(strings.Join(arc.FilterChannels, ","))); err != nil {
+
+	if _, err := hash.Write([]byte(strings.Join(arc.getFilteredChannels(collectionIdx), ","))); err != nil {
 		return "", err
 	}
+
 	if _, err := hash.Write([]byte(strings.Join(arc.DocIDs, ","))); err != nil {
 		return "", err
 	}
@@ -251,6 +255,10 @@ func (arc *ActiveReplicatorConfig) Equals(other *ActiveReplicatorConfig) bool {
 	}
 
 	if !reflect.DeepEqual(arc.CollectionsRemote, other.CollectionsRemote) {
+		return false
+	}
+
+	if !reflect.DeepEqual(arc.CollectionsChannelFilter, other.CollectionsChannelFilter) {
 		return false
 	}
 

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -295,7 +295,7 @@ func (apr *ActivePushReplicator) _startPushNonCollection() error {
 	if filteredChannels := apr.config.getFilteredChannels(nil); len(filteredChannels) > 0 {
 		channels = base.SetFromArray(filteredChannels)
 	}
-	
+
 	apr.blipSyncContext.fatalErrorCallback = func(err error) {
 		if strings.Contains(err.Error(), ErrUseProposeChanges.Message) {
 			err = ErrUseProposeChanges

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -141,12 +141,12 @@ func (apr *ActivePushReplicator) _initCheckpointer() error {
 	// wrap the replicator context with a cancelFunc that can be called to abort the checkpointer from _disconnect
 	apr.checkpointerCtx, apr.checkpointerCtxCancel = context.WithCancel(apr.ctx)
 
-	checkpointHash, hashErr := apr.config.CheckpointHash()
-	if hashErr != nil {
-		return hashErr
-	}
-
 	err := apr.forEachCollection(func(c *activeReplicatorCollection) error {
+		checkpointHash, hashErr := apr.config.CheckpointHash(c.collectionIdx)
+		if hashErr != nil {
+			return hashErr
+		}
+
 		c.Checkpointer = NewCheckpointer(apr.checkpointerCtx, c.dataStore, apr.CheckpointID, checkpointHash, apr.blipSender, apr.config, apr.getPushStatus, c.collectionIdx)
 
 		if !apr.config.CollectionsEnabled {
@@ -292,10 +292,10 @@ func (apr *ActivePushReplicator) _startPushNonCollection() error {
 	}
 
 	var channels base.Set
-	if apr.config.FilterChannels != nil {
-		channels = base.SetFromArray(apr.config.FilterChannels)
+	if filteredChannels := apr.config.getFilteredChannels(nil); len(filteredChannels) > 0 {
+		channels = base.SetFromArray(filteredChannels)
 	}
-
+	
 	apr.blipSyncContext.fatalErrorCallback = func(err error) {
 		if strings.Contains(err.Error(), ErrUseProposeChanges.Message) {
 			err = ErrUseProposeChanges

--- a/db/active_replicator_push_collections.go
+++ b/db/active_replicator_push_collections.go
@@ -60,8 +60,8 @@ func (apr *ActivePushReplicator) _startPushWithCollections() error {
 		}
 
 		var channels base.Set
-		if apr.config.FilterChannels != nil {
-			channels = base.SetFromArray(apr.config.FilterChannels)
+		if filteredChannels := apr.config.getFilteredChannels(collectionIdx); len(filteredChannels) > 0 {
+			channels = base.SetFromArray(filteredChannels)
 		}
 
 		apr.blipSyncContext.fatalErrorCallback = func(err error) {

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -596,8 +596,7 @@ func (m *sgReplicateManager) NewActiveReplicatorConfig(config *ReplicationCfg) (
 	// Channel filter processing
 	if config.Filter == base.ByChannelFilter {
 		rc.Filter = base.ByChannelFilter
-		err = rc.setFilterChannels(config)
-		if err != nil {
+		if err := rc.setFilterChannels(config); err != nil {
 			return nil, err
 		}
 	}

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -250,12 +250,7 @@ func (rc *ReplicationConfig) ValidateReplication(fromConfig bool) (err error) {
 }
 
 func (rc *ReplicationConfig) validateFilteredChannels() error {
-	if rc.CollectionsEnabled {
-		_, err := CollectionChannelsFromQueryParams(rc.CollectionsLocal, rc.QueryParams)
-		return err
-	}
-
-	_, err := ChannelsFromQueryParams(rc.QueryParams)
+	_, _, err := CollectionChannelsFromQueryParams(rc.CollectionsLocal, rc.QueryParams)
 	return err
 }
 
@@ -655,12 +650,7 @@ func (m *sgReplicateManager) NewActiveReplicatorConfig(config *ReplicationCfg) (
 }
 
 func (rc *ActiveReplicatorConfig) setFilterChannels(config *ReplicationCfg) (err error) {
-	if rc.CollectionsEnabled {
-		rc.CollectionsChannelFilter, err = CollectionChannelsFromQueryParams(config.CollectionsLocal, config.QueryParams)
-		return err
-	}
-
-	rc.FilterChannels, err = ChannelsFromQueryParams(config.QueryParams)
+	rc.CollectionsChannelFilter, rc.FilterChannels, err = CollectionChannelsFromQueryParams(config.CollectionsLocal, config.QueryParams)
 	return err
 }
 

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -561,6 +561,7 @@ func TestIsCfgChanged(t *testing.T) {
 				QueryParams:            []interface{}{"ABC"},
 				Username:               "alice",
 				Password:               "password",
+				CollectionsLocal:       []string{"foo.bar"},
 			},
 		}
 	}
@@ -607,10 +608,32 @@ func TestIsCfgChanged(t *testing.T) {
 			expectedChanged: true,
 		},
 		{
+			name: "collections enabled",
+			updatedConfig: &ReplicationUpsertConfig{
+				CollectionsEnabled: base.BoolPtr(true),
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "collections local",
+			updatedConfig: &ReplicationUpsertConfig{
+				CollectionsLocal: []string{"foo.bar", "bar.buzz"},
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "collections local",
+			updatedConfig: &ReplicationUpsertConfig{
+				CollectionsLocal: []string{"foo.bar", "bar.buzz"},
+			},
+			expectedChanged: true,
+		},
+		{
 			name: "unchanged",
 			updatedConfig: &ReplicationUpsertConfig{
 				Remote:               base.StringPtr("a"),
 				ConflictResolutionFn: base.StringPtr("a"),
+				CollectionsLocal:     []string{"foo.bar"},
 			},
 			expectedChanged: false,
 		},

--- a/db/sg_replicate_util.go
+++ b/db/sg_replicate_util.go
@@ -12,22 +12,21 @@ package db
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/couchbase/sync_gateway/base"
 )
 
 // CollectionChannelsFromQueryParams returns the channels associated with the byChannel replication filter from the generic queryParams.
-// The channels may be passed in one of two ways:
+// The channels may be passed in one of three ways:
 //
-//  1. As a JSON array of strings directly:
+//  1. As a JSON array of strings directly. These channel names apply to all collections.
 //     ["channel1", "channel2"]
 //
-//  2. As a JSON array of strings embedded in a JSON object with the "channels" property:
+//  2. As a JSON array of strings embedded in a JSON object with the "channels" property. These channel names apply to all collections.
 //     {"channels": ["channel1", "channel2"] }
 //
-// 3. As a JSON object with a property for each collection, with the value being an array of channels:
+// 3. As a JSON object with a property for each collection, with the value being an array of channels. Each set of channels is specific to each collection.
 //
 //	{
 //	  "collections_channels": {
@@ -38,24 +37,38 @@ import (
 func CollectionChannelsFromQueryParams(namedCollections []string, queryParams interface{}) (perCollectionChannels [][]string, allCollectionsChannels []string, err error) {
 	switch val := queryParams.(type) {
 	case map[string]interface{}:
-		if chanarray, ok := val["channels"].([]interface{}); ok {
-			allCollectionsChannels, err = interfaceValsToStringVals(chanarray)
-			return nil, allCollectionsChannels, err
+		_, hasChannels := val["channels"]
+		_, hasCollectionsChannels := val["collections_channels"]
+		if hasChannels && hasCollectionsChannels {
+			return nil, nil, errors.New("query_params cannot contain both 'channels' and 'collections_channels'")
 		}
 
-		if collectionChannels, ok := val["collections_channels"].(map[string]interface{}); ok {
-			perCollectionChannels = make([][]string, len(namedCollections))
-			for i, collection := range namedCollections {
-				collectionQueryParams := collectionChannels[collection]
-				collectionQueryParamsArray, ok := collectionQueryParams.([]interface{})
-				if !ok {
-					return nil, nil, errors.New("query_params must be a map of collection name to array of channels")
+		if hasChannels {
+			if chanarray, ok := val["channels"].([]interface{}); ok {
+				allCollectionsChannels, err = interfaceValsToStringVals(chanarray)
+				return nil, allCollectionsChannels, err
+			} else {
+				return nil, nil, errors.New("query_params value for 'channels' must be an array of channels")
+			}
+		}
+
+		if hasCollectionsChannels {
+			if collectionChannels, ok := val["collections_channels"].(map[string]interface{}); ok {
+				perCollectionChannels = make([][]string, len(namedCollections))
+				for i, collection := range namedCollections {
+					collectionQueryParams := collectionChannels[collection]
+					collectionQueryParamsArray, ok := collectionQueryParams.([]interface{})
+					if !ok {
+						return nil, nil, errors.New("query_params must be a map of collection name to array of channels")
+					}
+					channels, err := interfaceValsToStringVals(collectionQueryParamsArray)
+					if err != nil {
+						return nil, nil, err
+					}
+					perCollectionChannels[i] = channels
 				}
-				channels, err := interfaceValsToStringVals(collectionQueryParamsArray)
-				if err != nil {
-					return nil, nil, err
-				}
-				perCollectionChannels[i] = channels
+			} else {
+				return nil, nil, errors.New("query_params value for 'collections_channels' must be a map of collection name to array of channels")
 			}
 		}
 		return perCollectionChannels, nil, nil
@@ -73,7 +86,7 @@ func interfaceValsToStringVals(interfaceVals []interface{}) ([]string, error) {
 	for i := range interfaceVals {
 		str, ok := interfaceVals[i].(string)
 		if !ok {
-			return nil, fmt.Errorf("Bad channel name %v (%T) in query_params for sync_gateway/bychannel filter - expecting strings", interfaceVals[i], interfaceVals[i])
+			return nil, base.RedactErrorf("Expecting string channel but got %v (%T) in query_params for sync_gateway/bychannel filter", base.UD(interfaceVals[i]), interfaceVals[i])
 		}
 		stringVals[i] = str
 	}

--- a/db/sg_replicate_util.go
+++ b/db/sg_replicate_util.go
@@ -30,7 +30,7 @@ import (
 // 3. As a JSON object with a property for each collection, with the value being an array of channels:
 //
 //	{
-//	  "collection_channels": {
+//	  "collections_channels": {
 //	    "collection1": ["scope1.channel1"],
 //	    "collection2": ["scope1.channel1", "scope1.channel2"]
 //	  }
@@ -43,7 +43,7 @@ func CollectionChannelsFromQueryParams(namedCollections []string, queryParams in
 			return nil, allCollectionsChannels, err
 		}
 
-		if collectionChannels, ok := val["collection_channels"].(map[string]interface{}); ok {
+		if collectionChannels, ok := val["collections_channels"].(map[string]interface{}); ok {
 			perCollectionChannels = make([][]string, len(namedCollections))
 			for i, collection := range namedCollections {
 				collectionQueryParams := collectionChannels[collection]

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1405,6 +1405,90 @@ func TestRequireReplicatorStoppedBeforeUpsert(t *testing.T) {
 
 }
 
+func TestReplicationMultiCollectionChannelFilter(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+
+	rt1, rt2, remoteURLString, teardown := rest.SetupSGRPeers(t, true)
+	defer teardown()
+
+	// Add docs to two channels
+	bulkDocs := `
+	{
+	"docs":
+		[
+			{"channels": ["ChannelOne"], "_id": "doc_1"},
+			{"channels": ["ChannelOne"], "_id": "doc_2"},
+			{"channels": ["ChannelOne"], "_id": "doc_3"},
+			{"channels": ["ChannelOne"], "_id": "doc_4"},
+			{"channels": ["ChannelTwo"], "_id": "doc_5"},
+			{"channels": ["ChannelTwo"], "_id": "doc_6"},
+			{"channels": ["ChannelTwo"], "_id": "doc_7"},
+			{"channels": ["ChannelTwo"], "_id": "doc_8"}
+		]
+	}
+	`
+	resp := rt1.SendAdminRequest("POST", "/{{.keyspace}}/_bulk_docs", bulkDocs)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	rt1Keyspace := rt1.GetSingleTestDatabaseCollection().ScopeName + "." + rt1.GetSingleTestDatabaseCollection().Name
+
+	replicationID := "testRepl"
+
+	replConf := `
+	{
+		"replication_id": "` + replicationID + `",
+		"remote": "` + remoteURLString + `",
+		"direction": "push",
+		"continuous": true,
+		"filter":"sync_gateway/bychannel",
+		"query_params": {
+			"collection_channels": {
+				"` + rt1Keyspace + `": ["ChannelOne"]
+			}
+		},
+		"collections_enabled": ` + strconv.FormatBool(!rt1.GetDatabase().OnlyDefaultCollection()) + `,
+		"collections_local": ["` + rt1Keyspace + `"]
+	}`
+
+	// Create replication for first channel
+	resp = rt1.SendAdminRequest("PUT", "/{{.db}}/_replication/"+replicationID, replConf)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
+
+	changesResults, err := rt2.WaitForChanges(4, "/{{.keyspace}}/_changes?since=0", "", true)
+	require.NoError(t, err)
+	require.Len(t, changesResults.Results, 4)
+
+	resp = rt1.SendAdminRequest("PUT", "/{{.db}}/_replicationStatus/"+replicationID+"?action=stop", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateStopped)
+
+	// Upsert replication to use second channel
+	replConfUpdate := `
+	{
+		"replication_id": "` + replicationID + `",
+		"query_params": {
+			"collection_channels": {
+				"` + rt1Keyspace + `": ["ChannelTwo"]
+			}
+		}
+	}`
+
+	resp = rt1.SendAdminRequest("PUT", "/{{.db}}/_replication/"+replicationID, replConfUpdate)
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	resp = rt1.SendAdminRequest("PUT", "/{{.db}}/_replicationStatus/"+replicationID+"?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
+
+	changesResults, err = rt2.WaitForChanges(8, "/{{.keyspace}}/_changes?since=0", "", true)
+	require.NoError(t, err)
+	require.Len(t, changesResults.Results, 8)
+}
+
 func TestReplicationConfigChange(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1444,7 +1444,7 @@ func TestReplicationMultiCollectionChannelFilter(t *testing.T) {
 		"continuous": true,
 		"filter":"sync_gateway/bychannel",
 		"query_params": {
-			"collection_channels": {
+			"collections_channels": {
 				"` + rt1Keyspace + `": ["ChannelOne"]
 			}
 		},
@@ -1471,7 +1471,7 @@ func TestReplicationMultiCollectionChannelFilter(t *testing.T) {
 	{
 		"replication_id": "` + replicationID + `",
 		"query_params": {
-			"collection_channels": {
+			"collections_channels": {
 				"` + rt1Keyspace + `": ["ChannelTwo"]
 			}
 		}

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1448,7 +1448,7 @@ func TestReplicationMultiCollectionChannelFilter(t *testing.T) {
 				"` + rt1Keyspace + `": ["ChannelOne"]
 			}
 		},
-		"collections_enabled": ` + strconv.FormatBool(!rt1.GetDatabase().OnlyDefaultCollection()) + `,
+		"collections_enabled": true,
 		"collections_local": ["` + rt1Keyspace + `"]
 	}`
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -741,7 +741,8 @@ func (rt *RestTester) CreateWaitForChangesRetryWorker(numChangesExpected int, ch
 		}
 		if len(changes.Results) < numChangesExpected {
 			// not enough results, retry
-			return true, nil, nil
+			rt.TB.Logf("Waiting for changes, expected %d, got %d: %v", numChangesExpected, len(changes.Results), changes)
+			return true, fmt.Errorf("expecting %d changes, got %d", numChangesExpected, len(changes.Results)), nil
 		}
 		// If it made it this far, there is no errors and it got enough changes
 		return false, nil, changes

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -145,7 +145,15 @@ func (rt *RestTester) CreateReplicationForDB(dbName string, replicationID string
 
 	if len(channels) > 0 {
 		replicationConfig.Filter = base.ByChannelFilter
-		replicationConfig.QueryParams = map[string]interface{}{"channels": channels}
+		if replicationConfig.CollectionsEnabled {
+			collectionChannels := make(map[string][]string)
+			for _, collectionName := range rt.getCollectionsForBLIP() {
+				collectionChannels[collectionName] = channels
+			}
+			replicationConfig.QueryParams = collectionChannels
+		} else {
+			replicationConfig.QueryParams = map[string]interface{}{"channels": channels}
+		}
 	}
 	payload, err := json.Marshal(replicationConfig)
 	require.NoError(rt.TB, err)


### PR DESCRIPTION
CBG-2759

- Replications can now optionally define a set of per-collection channels in the filter query params when using the `syncgateway/bychannel` filter.
  - Example:
    ```json
	{
      "direction": "pushAndPull",
      "remote": "http://remotesg:4985/remoteDb",
      "collections_enabled": true,
      "collections_local": ["scope1.collection1", "scope1.collection2"],
      "filter": "syncgateway/bychannel",
      "query_params": {
        "collections_channels": {
          "scope1.collection1": ["chanA", "chanB"],
          "scope1.collection2": ["chanc"]
        }
      }
    }
    ```
- The existing channel filter query parameter to can be used to apply to all collections.
  - This is useful in situations where you aren't specifying an explicit list of collections to replicate, but only want to replicate a subset of documents by channel in all collections.
  - Example:
    ```json
	{
      "direction": "pushAndPull",
      "remote": "http://remotesg:4985/remoteDb",
      "collections_enabled": true,
      "collections_local": ["scope1.collection1", "scope1.collection2"],
      "filter": "syncgateway/bychannel",
      "query_params": {
        "channels": ["chanA", "chanB"]
      }
    }
    ```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1620/
