### PR TITLE
WaitForPendingChanges in TestMultiCollectionChangesUserDynamicGrant

### DIFF
--- a/rest/changestest/changes_collection_test.go
+++ b/rest/changestest/changes_collection_test.go
@@ -307,7 +307,7 @@ func TestMultiCollectionChangesUserDynamicGrant(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace2}}/abc1_c2", `{"value":1, "channels":["ABC"]}`)
 	rest.RequireStatus(t, response, 201)
-	_ = rt.WaitForPendingChanges()
+	assert.NoError(t, rt.WaitForPendingChanges())
 
 	var changes struct {
 		Results  []db.ChangeEntry
@@ -331,6 +331,7 @@ func TestMultiCollectionChangesUserDynamicGrant(t *testing.T) {
 	// Grant user access to channel ABC in collection 1
 	err = rt.SetAdminChannels("bernard", rt.GetKeyspaces()[0], "ABC", "PBS")
 	require.NoError(t, err)
+	assert.NoError(t, rt.WaitForPendingChanges())
 
 	// confirm that change from c1 is sent, along with user doc
 	changesResponse = rt.SendUserRequest("GET", "/{{.keyspace1}}/_changes?since="+lastSeq.String(), "", "bernard")

--- a/rest/changestest/changes_collection_test.go
+++ b/rest/changestest/changes_collection_test.go
@@ -307,7 +307,7 @@ func TestMultiCollectionChangesUserDynamicGrant(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace2}}/abc1_c2", `{"value":1, "channels":["ABC"]}`)
 	rest.RequireStatus(t, response, 201)
-	assert.NoError(t, rt.WaitForPendingChanges())
+	require.NoError(t, rt.WaitForPendingChanges())
 
 	var changes struct {
 		Results  []db.ChangeEntry
@@ -331,7 +331,7 @@ func TestMultiCollectionChangesUserDynamicGrant(t *testing.T) {
 	// Grant user access to channel ABC in collection 1
 	err = rt.SetAdminChannels("bernard", rt.GetKeyspaces()[0], "ABC", "PBS")
 	require.NoError(t, err)
-	assert.NoError(t, rt.WaitForPendingChanges())
+	require.NoError(t, rt.WaitForPendingChanges())
 
 	// confirm that change from c1 is sent, along with user doc
 	changesResponse = rt.SendUserRequest("GET", "/{{.keyspace1}}/_changes?since="+lastSeq.String(), "", "bernard")


### PR DESCRIPTION
Tries to avoid race where changes feed runs before principal update has been seen over DCP

https://github.com/couchbase/sync_gateway/actions/runs/4484519886/jobs/7885105548?pr=6157

```
2023-03-21T22:53:33.8787707Z 2023-03-21T22:51:55.377Z [INF] HTTP: c:#1541 db:db GET http://localhost/db/_user/<ud>bernard</ud> (as ADMIN)
2023-03-21T22:53:33.8788038Z 2023-03-21T22:51:55.379Z [INF] HTTP: c:#1542 db:db PUT http://localhost/db/_user/<ud>bernard</ud> (as ADMIN)
2023-03-21T22:53:33.8788443Z 2023-03-21T22:51:55.382Z [INF] HTTP: c:#1543 db:db col:sg_test_0 GET http://localhost/db.sg_test_0.sg_test_0/_changes?since=3 (as <ud>bernard</ud>)
2023-03-21T22:53:33.8788811Z 2023-03-21T22:51:55.382Z [DBG] Changes+: c:#1543 db:db col:sg_test_0 Int sequence multi changes feed...
2023-03-21T22:53:33.8789500Z 2023-03-21T22:51:55.382Z [INF] Changes: c:#1543 db:db col:sg_test_0 MultiChangesFeed(channels: {<ud>*</ud>}, options: {Since: 3, Limit: 0, Conflicts: false, IncludeDocs: false, Wait: false, Continuous: false, HeartbeatMs: 0, TimeoutMs: 300000, ActiveOnly: false}) ... <ud>  (to bernard)</ud>
2023-03-21T22:53:33.8790008Z 2023-03-21T22:51:55.382Z [INF] Changes: c:#1543 db:db col:sg_test_0 simple changes cannot get Close Notifier from ResponseWriter
2023-03-21T22:53:33.8790440Z 2023-03-21T22:51:55.382Z [DBG] Changes+: c:#1543 db:db col:sg_test_0 MultiChangesFeed: channels expand to "<ud>!:1,ABC:5,PBS:1</ud>" ... <ud>  (to bernard)</ud>
2023-03-21T22:53:33.8790818Z 2023-03-21T22:51:55.382Z [DBG] Cache+: Initialized cache for channel "<ud>1.ABC</ud>" with min:50 max:500 age:1m0s, validFrom: 5
2023-03-21T22:53:33.8791358Z 2023-03-21T22:51:55.382Z [DBG] Changes+: c:#1543 db:db col:sg_test_0 Grant for channel [<ud>1.ABC</ud>] is after the current sequence - skipped for this iteration.  Grant:[5] Current:[4] <ud>  (to bernard)</ud>
2023-03-21T22:53:33.8791657Z 2023-03-21T22:51:55.382Z [DBG] Cache+: GetCachedChanges("<ud>1.PBS</ud>", 3) --> nothing cached
2023-03-21T22:53:33.8792027Z 2023-03-21T22:51:55.382Z [DBG] Changes+: c:#1543 db:db col:sg_test_0 [changesFeed] Found 0 changes for channel "<ud>1.PBS</ud>"
2023-03-21T22:53:33.8792323Z 2023-03-21T22:51:55.382Z [DBG] Cache+: GetCachedChanges("<ud>1.!</ud>", 3) --> nothing cached
2023-03-21T22:53:33.8792680Z 2023-03-21T22:51:55.382Z [DBG] Changes+: c:#1543 db:db col:sg_test_0 [changesFeed] Found 0 changes for channel "<ud>1.!</ud>"
2023-03-21T22:53:33.8793106Z 2023-03-21T22:51:55.382Z [DBG] Changes+: c:#1543 db:db col:sg_test_0 Found sequence later than stable sequence: stable:[4] entry:[5] (<ud>_user/bernard</ud>)
2023-03-21T22:53:33.8793447Z 2023-03-21T22:51:55.382Z [INF] Changes: c:#1543 db:db col:sg_test_0 MultiChangesFeed done <ud>  (to bernard)</ud>
2023-03-21T22:53:33.8793632Z     changes_collection_test.go:339: 
2023-03-21T22:53:33.8794143Z         	Error Trace:	/home/runner/work/sync_gateway/sync_gateway/rest/changestest/changes_collection_test.go:339
2023-03-21T22:53:33.8794421Z         	Error:      	"[]" should have 2 item(s), but has 0
2023-03-21T22:53:33.8794748Z         	Test:       	TestMultiCollectionChangesUserDynamicGrant
```