### PR TITLE
Pass error instead of panic when creating a Replicator

### DIFF
--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -72,7 +72,7 @@ type activeReplicatorCollection struct {
 	Checkpointer  *Checkpointer  // Checkpointer for this collection
 }
 
-func newActiveReplicatorCommon(ctx context.Context, config *ActiveReplicatorConfig, direction ActiveReplicatorDirection) *activeReplicatorCommon {
+func newActiveReplicatorCommon(ctx context.Context, config *ActiveReplicatorConfig, direction ActiveReplicatorDirection) (*activeReplicatorCommon, error) {
 
 	var replicationStats *BlipSyncStats
 	var checkpointID string
@@ -103,14 +103,14 @@ func newActiveReplicatorCommon(ctx context.Context, config *ActiveReplicatorConf
 	} else {
 		defaultDatabaseCollection, err := config.ActiveDB.GetDefaultDatabaseCollection()
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 		apr.defaultCollection = &activeReplicatorCollection{
 			dataStore: defaultDatabaseCollection.dataStore,
 		}
 	}
 
-	return &apr
+	return &apr, nil
 }
 
 // reconnectLoop synchronously calls replicatorConnectFn until successful, or times out trying. Retry loop can be stopped by cancelling ctx

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -22,12 +22,16 @@ type ActivePullReplicator struct {
 	*activeReplicatorCommon
 }
 
-func NewPullReplicator(ctx context.Context, config *ActiveReplicatorConfig) *ActivePullReplicator {
+func NewPullReplicator(ctx context.Context, config *ActiveReplicatorConfig) (*ActivePullReplicator, error) {
+	replicator, err := newActiveReplicatorCommon(ctx, config, ActiveReplicatorTypePull)
+	if err != nil {
+		return nil, err
+	}
 	apr := ActivePullReplicator{
-		activeReplicatorCommon: newActiveReplicatorCommon(ctx, config, ActiveReplicatorTypePull),
+		activeReplicatorCommon: replicator,
 	}
 	apr.replicatorConnectFn = apr._connect
-	return &apr
+	return &apr, nil
 }
 
 func (apr *ActivePullReplicator) Start(ctx context.Context) error {

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -27,12 +27,16 @@ type ActivePushReplicator struct {
 	*activeReplicatorCommon
 }
 
-func NewPushReplicator(ctx context.Context, config *ActiveReplicatorConfig) *ActivePushReplicator {
+func NewPushReplicator(ctx context.Context, config *ActiveReplicatorConfig) (*ActivePushReplicator, error) {
+	replicator, err := newActiveReplicatorCommon(ctx, config, ActiveReplicatorTypePush)
+	if err != nil {
+		return nil, err
+	}
 	apr := ActivePushReplicator{
-		activeReplicatorCommon: newActiveReplicatorCommon(ctx, config, ActiveReplicatorTypePush),
+		activeReplicatorCommon: replicator,
 	}
 	apr.replicatorConnectFn = apr._connect
-	return &apr
+	return &apr, nil
 }
 
 func (apr *ActivePushReplicator) Start(ctx context.Context) error {

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -689,9 +689,7 @@ func (m *sgReplicateManager) InitializeReplication(config *ReplicationCfg) (repl
 	// disable recovered panic reporting (test only)
 	rc.reportHandlerPanicsOnStop = base.BoolPtr(false)
 
-	replicator = NewActiveReplicator(m.loggingCtx, rc)
-
-	return replicator, nil
+	return NewActiveReplicator(m.loggingCtx, rc)
 }
 
 // replicationComplete updates the replication status.

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2420,7 +2420,7 @@ func TestProcessRevIncrementsStat(t *testing.T) {
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
 
-	ar := db.NewActiveReplicator(activeCtx, &db.ActiveReplicatorConfig{
+	ar, err := db.NewActiveReplicator(activeCtx, &db.ActiveReplicatorConfig{
 		ID:                  t.Name(),
 		Direction:           db.ActiveReplicatorTypePull,
 		ActiveDB:            &db.Database{DatabaseContext: activeRT.GetDatabase()},
@@ -2429,6 +2429,8 @@ func TestProcessRevIncrementsStat(t *testing.T) {
 		ReplicationStatsMap: dbstats,
 		CollectionsEnabled:  !activeRT.GetDatabase().OnlyDefaultCollection(),
 	})
+	require.NoError(t, err)
+
 	// Confirm all stats starting on 0
 	require.NotNil(t, ar.Pull)
 	pullStats := ar.Pull.GetStats()

--- a/rest/replicatortest/replicator_collection_test.go
+++ b/rest/replicatortest/replicator_collection_test.go
@@ -124,7 +124,7 @@ func TestActiveReplicatorMultiCollection(t *testing.T) {
 	assert.Equal(t, activeKeyspace3, passiveKeyspace3)
 
 	ctx1 := rt1.Context()
-	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePushAndPull,
 		RemoteDBURL: passiveDBURL,
@@ -138,6 +138,7 @@ func TestActiveReplicatorMultiCollection(t *testing.T) {
 		CollectionsLocal:    localCollections,
 		CollectionsRemote:   remoteCollections,
 	})
+	require.NoError(t, err)
 
 	assert.Equal(t, "", ar.GetStatus().LastSeqPull)
 
@@ -300,7 +301,7 @@ func TestActiveReplicatorMultiCollectionMismatchedLocalRemote(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx1 := activeRT.Context()
-	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePushAndPull,
 		RemoteDBURL: passiveDBURL,
@@ -312,6 +313,7 @@ func TestActiveReplicatorMultiCollectionMismatchedLocalRemote(t *testing.T) {
 		CollectionsLocal:    localCollections,
 		CollectionsRemote:   remoteCollections,
 	})
+	require.NoError(t, err)
 
 	err = ar.Start(ctx1)
 	assert.ErrorContains(t, err, "local and remote collections must be the same length")
@@ -339,7 +341,7 @@ func TestActiveReplicatorMultiCollectionMissingRemote(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx1 := activeRT.Context()
-	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePushAndPull,
 		RemoteDBURL: passiveDBURL,
@@ -351,6 +353,7 @@ func TestActiveReplicatorMultiCollectionMissingRemote(t *testing.T) {
 		CollectionsLocal:    localCollections,
 		CollectionsRemote:   remoteCollections,
 	})
+	require.NoError(t, err)
 
 	err = ar.Start(ctx1)
 	assert.ErrorContains(t, err, "peer does not have collection")
@@ -379,7 +382,7 @@ func TestActiveReplicatorMultiCollectionMissingLocal(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx1 := activeRT.Context()
-	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePushAndPull,
 		RemoteDBURL: passiveDBURL,
@@ -391,6 +394,7 @@ func TestActiveReplicatorMultiCollectionMissingLocal(t *testing.T) {
 		CollectionsLocal:    localCollections,
 		CollectionsRemote:   remoteCollections,
 	})
+	require.NoError(t, err)
 
 	err = ar.Start(ctx1)
 	assert.ErrorContains(t, err, "does not exist on this database")

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1508,7 +1508,7 @@ func TestReplicatorRevocations(t *testing.T) {
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
 
-	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePull,
 		RemoteDBURL: passiveDBURL,
@@ -1519,6 +1519,7 @@ func TestReplicatorRevocations(t *testing.T) {
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: dbstats,
 	})
+	require.NoError(t, err)
 
 	require.NoError(t, ar.Start(ctx1))
 	rt1.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
@@ -1567,7 +1568,7 @@ func TestReplicatorRevocationsNoRev(t *testing.T) {
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
 
-	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePull,
 		RemoteDBURL: passiveDBURL,
@@ -1578,6 +1579,7 @@ func TestReplicatorRevocationsNoRev(t *testing.T) {
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: dbstats,
 	})
+	require.NoError(t, err)
 
 	require.NoError(t, ar.Start(ctx1))
 	rt1.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
@@ -1634,7 +1636,7 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
 
-	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePull,
 		RemoteDBURL: passiveDBURL,
@@ -1645,6 +1647,7 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: dbstats,
 	})
+	require.NoError(t, err)
 
 	require.NoError(t, ar.Start(ctx1))
 	rt1.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
@@ -1694,7 +1697,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
 
-	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePull,
 		RemoteDBURL: passiveDBURL,
@@ -1705,6 +1708,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: dbstats,
 	})
+	require.NoError(t, err)
 	require.NoError(t, ar.Start(ctx1))
 
 	defer func() {
@@ -1808,7 +1812,7 @@ func TestReplicatorRevocationsWithTombstoneResurrection(t *testing.T) {
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
 
-	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePull,
 		RemoteDBURL: passiveDBURL,
@@ -1819,6 +1823,7 @@ func TestReplicatorRevocationsWithTombstoneResurrection(t *testing.T) {
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: dbstats,
 	})
+	require.NoError(t, err)
 
 	docARev := rt2.CreateDocReturnRev(t, "docA", "", map[string][]string{"channels": []string{"A"}})
 	docA1Rev := rt2.CreateDocReturnRev(t, "docA1", "", map[string][]string{"channels": []string{"A"}})
@@ -1902,7 +1907,7 @@ func TestReplicatorRevocationsWithChannelFilter(t *testing.T) {
 	_ = rt2.CreateDocReturnRev(t, "docA", "", map[string][]string{"channels": []string{"ABC"}})
 	require.NoError(t, rt2.WaitForPendingChanges())
 
-	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePull,
 		RemoteDBURL: passiveDBURL,
@@ -1914,6 +1919,7 @@ func TestReplicatorRevocationsWithChannelFilter(t *testing.T) {
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: dbstats,
 	})
+	require.NoError(t, err)
 
 	resp := rt2.SendAdminRequest("PUT", "/{{.db}}/_user/user", GetUserPayload(t, username, password, "", rt2Collection, []string{"ABC"}, nil))
 	RequireStatus(t, resp, http.StatusOK)
@@ -1982,7 +1988,7 @@ func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
 	_ = rt2.CreateDocReturnRev(t, "docC", "", map[string][]string{"channels": []string{"C"}})
 	require.NoError(t, rt2.WaitForPendingChanges())
 
-	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePull,
 		RemoteDBURL: passiveDBURL,
@@ -1993,6 +1999,7 @@ func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: dbstats,
 	})
+	require.NoError(t, err)
 
 	resp := rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "test", "", rt2_collection, []string{"*"}, nil))
 	RequireStatus(t, resp, http.StatusOK)
@@ -2081,7 +2088,8 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 		ReplicationStatsMap: dbstats,
 	}
 
-	ar := db.NewActiveReplicator(ctx1, activeReplCfg)
+	ar, err := db.NewActiveReplicator(ctx1, activeReplCfg)
+	require.NoError(t, err)
 
 	_ = rt2.CreateDocReturnRev(t, "docA", "", map[string][]string{"channels": []string{"A"}})
 	_ = rt2.CreateDocReturnRev(t, "docA1", "", map[string][]string{"channels": []string{"A"}})
@@ -2470,7 +2478,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
 
-	ar := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePull,
 		RemoteDBURL: passiveDBURL,
@@ -2480,6 +2488,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 		Continuous:          true,
 		ReplicationStatsMap: dbstats,
 	})
+	require.NoError(t, err)
 
 	for i := 0; i < 10; i++ {
 		_ = rt2.CreateDocReturnRev(t, fmt.Sprintf("docA%d", i), "", map[string][]string{"channels": []string{"A"}})
@@ -2529,7 +2538,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 	dbstats, err = sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
 
-	ar = db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+	ar, err = db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
 		Direction:   db.ActiveReplicatorTypePull,
 		RemoteDBURL: passiveDBURL,
@@ -2540,6 +2549,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: dbstats,
 	})
+	require.NoError(t, err)
 
 	// Send a doc to act as a 'marker' so we know when replication has completed
 	_ = rt2.CreateDocReturnRev(t, "docMarker", "", map[string][]string{"channels": []string{"B"}})


### PR DESCRIPTION

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1624/
