### PR TITLE
Disable fieldalignment for test files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,3 +67,7 @@ issues:
     - path: (_test\.go|utilities_testing\.go)
       linters:
         - goconst
+    - path: (_test\.go|utilities_testing\.go)
+      linters:
+        - govet
+      text: fieldalignment


### PR DESCRIPTION
We don't care about tightly packed structs for test files, this helps me use the linter better to eliminate false positives.