### PR TITLE
CBG-2760 add error type for fatal connection error

### DIFF
--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"expvar"
 	"sync"
 	"testing"
@@ -25,6 +26,8 @@ const (
 	defaultInitialReconnectInterval = time.Second
 	defaultMaxReconnectInterval     = time.Minute * 5
 )
+
+var fatalReplicatorConnectError = errors.New("Fatal replication connection")
 
 // replicatorCommon defines the struct contents shared by ActivePushReplicator
 // and ActivePullReplicator

--- a/db/active_replicator_common_collections.go
+++ b/db/active_replicator_common_collections.go
@@ -141,7 +141,6 @@ func (arc *activeReplicatorCommon) _initCollections() ([]replicationCheckpoint, 
 	}
 
 	arc.blipSyncContext.collections.set(blipSyncCollectionContexts)
-
 	return collectionCheckpoints, nil
 }
 

--- a/db/active_replicator_pull_collections.go
+++ b/db/active_replicator_pull_collections.go
@@ -11,6 +11,8 @@ licenses/APL2.txt.
 package db
 
 import (
+	"fmt"
+
 	"github.com/couchbase/sync_gateway/base"
 )
 
@@ -20,7 +22,7 @@ import (
 func (apr *ActivePullReplicator) _startPullWithCollections() error {
 	collectionCheckpoints, err := apr._initCollections()
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %s", fatalReplicatorConnectError, err)
 	}
 
 	if err := apr._initCheckpointer(); err != nil {

--- a/db/active_replicator_push_collections.go
+++ b/db/active_replicator_push_collections.go
@@ -9,6 +9,7 @@
 package db
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/couchbase/go-blip"
@@ -21,7 +22,8 @@ import (
 func (apr *ActivePushReplicator) _startPushWithCollections() error {
 	collectionCheckpoints, err := apr._initCollections()
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %s", fatalReplicatorConnectError, err)
+
 	}
 
 	if err := apr._initCheckpointer(); err != nil {

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -204,6 +204,10 @@ func (bsc *BlipSyncContext) register(profile string, handlerFn func(*blipHandler
 func (bsc *BlipSyncContext) Close() {
 	bsc.terminatorOnce.Do(func() {
 		for _, collection := range bsc.collections.getAll() {
+			// if initial GetCollections returned an invalid collections, this will be nil
+			if collection == nil {
+				continue
+			}
 			// Lock so that we don't close the changesCtx at the same time as handleSubChanges is creating it
 			collection.changesCtxLock.Lock()
 			defer collection.changesCtxLock.Unlock()

--- a/rest/replicatortest/replicator_collection_test.go
+++ b/rest/replicatortest/replicator_collection_test.go
@@ -13,6 +13,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -399,4 +401,79 @@ func TestActiveReplicatorMultiCollectionMissingLocal(t *testing.T) {
 	err = ar.Start(ctx1)
 	assert.ErrorContains(t, err, "does not exist on this database")
 	assert.NoError(t, ar.Stop())
+}
+
+func TestReplicatorMissingCollections(t *testing.T) {
+	const numCollections = 2
+	base.RequireNumTestDataStores(t, numCollections)
+	base.RequireNumTestBuckets(t, 2)
+	testCases := []struct {
+		name       string
+		direction  db.ActiveReplicatorDirection
+		maxBackoff int
+	}{
+		{
+			name:       "push replication,maxbackoff 0",
+			direction:  db.ActiveReplicatorTypePush,
+			maxBackoff: 0,
+		},
+		{
+			name:       "pull replication, max backoff 0",
+			direction:  db.ActiveReplicatorTypePull,
+			maxBackoff: 0,
+		},
+		{
+			name:       "push replication,maxbackoff 100",
+			direction:  db.ActiveReplicatorTypePush,
+			maxBackoff: 100,
+		},
+		{
+			name:       "pull replication, max backoff 100",
+			direction:  db.ActiveReplicatorTypePull,
+			maxBackoff: 100,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			const username = "alice"
+			passiveRT := rest.NewRestTester(t, &rest.RestTesterConfig{SgReplicateEnabled: true})
+			defer passiveRT.Close()
+			passiveRT.CreateUser(username, []string{"sg_test_0.sg_test_0", "sg_test_0.sg_test_1"})
+
+			// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
+			srv := httptest.NewServer(passiveRT.TestPublicHandler())
+
+			// Build passiveDBURL with basic auth creds
+			passiveDBURL, _ := url.Parse(srv.URL + "/" + passiveRT.GetDatabase().Name)
+			passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
+
+			activeRT := rest.NewRestTesterMultipleCollections(t, &rest.RestTesterConfig{SgReplicateEnabled: true}, numCollections)
+			defer activeRT.Close()
+
+			const numDocs = 1
+			for i := 1; i <= numDocs; i++ {
+				for _, keyspace := range []string{"{{.keyspace1}}", "{{.keyspace2}}"} {
+					resp := activeRT.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/active_doc_%d", keyspace, i), `{"foo": "bar"}`)
+					rest.RequireStatus(t, resp, http.StatusCreated)
+				}
+				resp := passiveRT.SendAdminRequest(http.MethodPut, fmt.Sprintf("/{{.keyspace}}/passive_doc_%d", i), `{"foo": "bar"}`)
+				rest.RequireStatus(t, resp, http.StatusCreated)
+
+			}
+			require.NoError(t, activeRT.WaitForPendingChanges())
+			// use string since omitempty will occur for max_backoff_time, rendering test useless
+			replicationID := strings.ReplaceAll(t.Name(), "/", "_")
+			replicationConfig := `{
+				"replication_id": "` + replicationID + `",
+				"remote": "` + passiveDBURL.String() + `",
+				"direction": "` + string(test.direction) + `",
+				"collections_enabled": true,
+				"max_backoff_time": ` + strconv.Itoa(test.maxBackoff) + `
+			}`
+			resp := activeRT.SendAdminRequest(http.MethodPost, "/{{.db}}/_replication/", replicationConfig)
+			rest.RequireStatus(t, resp, http.StatusCreated)
+
+			activeRT.WaitForReplicationStatus(replicationID, db.ReplicationStateError)
+		})
+	}
 }

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -162,11 +162,12 @@ func (rt *RestTester) WaitForAssignedReplications(count int) {
 }
 
 func (rt *RestTester) WaitForReplicationStatusForDB(dbName string, replicationID string, targetStatus string) {
+	var status db.ReplicationStatus
 	successFunc := func() bool {
-		status := rt.GetReplicationStatusForDB(dbName, replicationID)
+		status = rt.GetReplicationStatusForDB(dbName, replicationID)
 		return status.Status == targetStatus
 	}
-	require.NoError(rt.TB, rt.WaitForCondition(successFunc))
+	require.NoError(rt.TB, rt.WaitForCondition(successFunc), "Expected status: %s, actual status: %s", targetStatus, status.Status)
 }
 
 func (rt *RestTester) WaitForReplicationStatus(replicationID string, targetStatus string) {


### PR DESCRIPTION
On this error, don't enter a retry loop. We only enter a retry loop if max_backoff_time != 0.

I waffled on the implementation of a custom error type or doing `error.Is`, I can swap this out if you like one better than the other. I can't remember what is idiomatic in 2023. I didn't like that doing `fmt.Errorf("%w: %w")` would  result in annoying printing when doing `err.String()` eventually, so I settled on this because it looked not unreasonable in the logs.

Fixed a panic on teardown of blip contexts if `GetCollections` makes a call to a collection that isn't found.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1628/
