### PR TITLE
CBG-2789 implement channels.Set redaction

### DIFF
--- a/base/redactor.go
+++ b/base/redactor.go
@@ -27,6 +27,11 @@ type Redactor interface {
 	String() string
 }
 
+// RedactorBuilder provides a struct a way to implement its own redaction.
+type RedactorBuilder interface {
+	BuildRedactor(redactor func(interface{}) RedactorFunc) Redactor
+}
+
 // This allows for lazy evaluation for a Redactor. Means that we don't have to process redaction unless we are
 // definitely performing a redaction
 type RedactorFunc func() Redactor
@@ -74,13 +79,6 @@ func (redactorSlice RedactorSlice) String() string {
 		tmp = append(tmp, ' ')
 	}
 	return "[ " + string(tmp) + "]"
-}
-
-func (set Set) buildRedactorSet(function func(interface{}) RedactorFunc) RedactorSet {
-	return RedactorSet{
-		set:          set,
-		redactorFunc: function,
-	}
 }
 
 type RedactorSet struct {

--- a/base/redactor_metadata.go
+++ b/base/redactor_metadata.go
@@ -58,9 +58,9 @@ func MD(i interface{}) RedactorFunc {
 		return func() Redactor {
 			return Metadata(v)
 		}
-	case Set:
+	case RedactorBuilder:
 		return func() Redactor {
-			return v.buildRedactorSet(MD)
+			return v.BuildRedactor(MD)
 		}
 	case fmt.Stringer:
 		return func() Redactor {

--- a/base/redactor_systemdata.go
+++ b/base/redactor_systemdata.go
@@ -55,9 +55,9 @@ func SD(i interface{}) RedactorFunc {
 		return func() Redactor {
 			return SystemData(v)
 		}
-	case Set:
+	case RedactorBuilder:
 		return func() Redactor {
-			return v.buildRedactorSet(SD)
+			return v.BuildRedactor(SD)
 		}
 	case fmt.Stringer:
 		return func() Redactor {

--- a/base/redactor_test.go
+++ b/base/redactor_test.go
@@ -116,7 +116,7 @@ func TestMixedTypeSliceRedaction(t *testing.T) {
 	}()
 
 	slice := RedactorSlice{MD("cluster name"), SD("server ip"), UD("username")}
-	assert.Equal(t, `[ `+metaDataPrefix+"cluster name"+metaDataSuffix+` `+systemDataPrefix+"server ip"+systemDataSuffix+" "+userDataPrefix+"username"+userDataSuffix+" ]", slice.Redact())
+	assert.Equal(t, `[ `+metaDataPrefix+"cluster name"+metaDataSuffix+` `+systemDataPrefix+"server ip"+systemDataSuffix+" "+UserDataPrefix+"username"+UserDataSuffix+" ]", slice.Redact())
 }
 
 func BenchmarkRedactHelper(b *testing.B) {

--- a/base/redactor_userdata.go
+++ b/base/redactor_userdata.go
@@ -56,9 +56,9 @@ func UD(i interface{}) RedactorFunc {
 		return func() Redactor {
 			return UserData(v)
 		}
-	case Set:
+	case RedactorBuilder:
 		return func() Redactor {
-			return v.buildRedactorSet(UD)
+			return v.BuildRedactor(UD)
 		}
 	case fmt.Stringer:
 		return func() Redactor {

--- a/base/redactor_userdata.go
+++ b/base/redactor_userdata.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	userDataPrefix = "<ud>"
-	userDataSuffix = "</ud>"
+	UserDataPrefix = "<ud>"
+	UserDataSuffix = "</ud>"
 )
 
 // RedactUserData is a global toggle for user data redaction.
@@ -43,7 +43,7 @@ func (ud UserData) Redact() string {
 	if !RedactUserData {
 		return string(ud)
 	}
-	return userDataPrefix + string(ud) + userDataSuffix
+	return UserDataPrefix + string(ud) + UserDataSuffix
 }
 
 // Compile-time interface check.

--- a/base/redactor_userdata_test.go
+++ b/base/redactor_userdata_test.go
@@ -23,7 +23,7 @@ func TestUserDataRedact(t *testing.T) {
 	userdata := UserData(username)
 
 	RedactUserData = true
-	assert.Equal(t, userDataPrefix+username+userDataSuffix, userdata.Redact())
+	assert.Equal(t, UserDataPrefix+username+UserDataSuffix, userdata.Redact())
 
 	RedactUserData = false
 	assert.Equal(t, username, userdata.Redact())
@@ -35,25 +35,25 @@ func TestUD(t *testing.T) {
 
 	// Straight-forward string test.
 	ud := UD("hello world")
-	assert.Equal(t, userDataPrefix+"hello world"+userDataSuffix, ud.Redact())
+	assert.Equal(t, UserDataPrefix+"hello world"+UserDataSuffix, ud.Redact())
 
 	// big.Int fulfils the Stringer interface, so we should get sensible values.
 	ud = UD(big.NewInt(1234))
-	assert.Equal(t, userDataPrefix+"1234"+userDataSuffix, ud.Redact())
+	assert.Equal(t, UserDataPrefix+"1234"+UserDataSuffix, ud.Redact())
 
 	// Even plain structs could be redactable.
 	ud = UD(struct{}{})
-	assert.Equal(t, userDataPrefix+"{}"+userDataSuffix, ud.Redact())
+	assert.Equal(t, UserDataPrefix+"{}"+UserDataSuffix, ud.Redact())
 
 	// String slice test.
 	ud = UD([]string{"hello", "world", "o/"})
-	assert.Equal(t, "[ "+userDataPrefix+"hello"+userDataSuffix+" "+userDataPrefix+"world"+userDataSuffix+" "+userDataPrefix+"o/"+userDataSuffix+" ]", ud.Redact())
+	assert.Equal(t, "[ "+UserDataPrefix+"hello"+UserDataSuffix+" "+UserDataPrefix+"world"+UserDataSuffix+" "+UserDataPrefix+"o/"+UserDataSuffix+" ]", ud.Redact())
 
 	// Set
 	ud = UD(SetOf("hello", "world"))
 	// As a set comes from a map we can't be sure which order it'll end up with so should check both permutations
-	redactedPerm1 := "{" + userDataPrefix + "hello" + userDataSuffix + ", " + userDataPrefix + "world" + userDataSuffix + "}"
-	redactedPerm2 := "{" + userDataPrefix + "world" + userDataSuffix + ", " + userDataPrefix + "hello" + userDataSuffix + "}"
+	redactedPerm1 := "{" + UserDataPrefix + "hello" + UserDataSuffix + ", " + UserDataPrefix + "world" + UserDataSuffix + "}"
+	redactedPerm2 := "{" + UserDataPrefix + "world" + UserDataSuffix + ", " + UserDataPrefix + "hello" + UserDataSuffix + "}"
 	redactedSet := ud.Redact()
 	redactedCorrectly := redactedPerm1 == redactedSet || redactedPerm2 == redactedSet
 	assert.True(t, redactedCorrectly, "Unexpected redact got %v", redactedSet)

--- a/base/set.go
+++ b/base/set.go
@@ -155,3 +155,10 @@ func (setPtr *Set) UnmarshalJSON(data []byte) error {
 	*setPtr = set
 	return nil
 }
+
+func (set Set) BuildRedactor(function func(interface{}) RedactorFunc) Redactor {
+	return RedactorSet{
+		set:          set,
+		redactorFunc: function,
+	}
+}

--- a/channels/set.go
+++ b/channels/set.go
@@ -46,7 +46,7 @@ func NewID(channelName string, collectionID uint32) ID {
 	return ID{
 		Name:          channelName,
 		CollectionID:  collectionID,
-		serialization: strconv.FormatUint(uint64(collectionID), 10) + "." + channelName,
+		serialization: strconv.FormatUint(uint64(collectionID), 10) + "." + base.UserDataPrefix + channelName + base.UserDataSuffix,
 	}
 }
 
@@ -189,13 +189,15 @@ func (redactorSet RedactorSet) String() string {
 }
 
 func (redactorSet RedactorSet) GetRedactionString(shouldRedact bool) string {
-	if !shouldRedact {
-		return redactorSet.set.String()
+	tmp := []byte("{")
+	iterationCount := 0
+	for setItem, _ := range redactorSet.set {
+		tmp = append(tmp, redactorSet.redactorFunc(setItem).String()...)
+		iterationCount++
+		if iterationCount != len(redactorSet.set) {
+			tmp = append(tmp, ", "...)
+		}
 	}
-	keys := make([]string, 0, len(redactorSet.set))
-	for channelID := range redactorSet.set {
-		keys = append(keys, fmt.Sprintf("%d.%s", channelID.CollectionID, redactorSet.redactorFunc(channelID.Name).Redact()))
-	}
-	sort.Strings(keys)
-	return fmt.Sprintf("{%s}", strings.Join(keys, ", "))
+
+	return string(append(tmp, "}"...))
 }

--- a/channels/set_test.go
+++ b/channels/set_test.go
@@ -332,13 +332,13 @@ func TestSetString(t *testing.T) {
 		name           string
 		input          Set
 		output         string
-		redactedOutput string
+		redactedOutput []string
 	}{
 		{
 			name:           "empty,emptyID",
 			input:          Set{},
 			output:         "{}",
-			redactedOutput: "{}",
+			redactedOutput: []string{"{}"},
 		},
 		{
 			name: "two collections",
@@ -347,8 +347,15 @@ func TestSetString(t *testing.T) {
 				NewID("B", 2): present{},
 				NewID("C", 1): present{},
 			},
-			output:         "{1.A, 1.C, 2.B}",
-			redactedOutput: "{1.<ud>A</ud>, 1.<ud>C</ud>, 2.<ud>B</ud>}",
+			output: "{1.<ud>A</ud>, 1.<ud>C</ud>, 2.<ud>B</ud>}",
+			redactedOutput: []string{
+				"{1.<ud>A</ud>, 1.<ud>C</ud>, 2.<ud>B</ud>}",
+				"{1.<ud>A</ud>, 2.<ud>B</ud>, 1.<ud>C</ud>}",
+				"{1.<ud>C</ud>, 1.<ud>A</ud>, 2.<ud>B</ud>}",
+				"{1.<ud>C</ud>, 2.<ud>B</ud>, 1.<ud>A</ud>}",
+				"{2.<ud>B</ud>, 1.<ud>A</ud>, 1.<ud>C</ud>}",
+				"{2.<ud>B</ud>, 1.<ud>C</ud>, 1.<ud>A</ud>}",
+			},
 		},
 		{
 			name: "two collections, collection2",
@@ -357,22 +364,29 @@ func TestSetString(t *testing.T) {
 				NewID("B", 2): present{},
 				NewID("C", 1): present{},
 			},
-			output:         "{1.C, 2.A, 2.B}",
-			redactedOutput: "{1.<ud>C</ud>, 2.<ud>A</ud>, 2.<ud>B</ud>}",
+			output: "{1.<ud>C</ud>, 2.<ud>A</ud>, 2.<ud>B</ud>}",
+			redactedOutput: []string{
+				"{2.<ud>A</ud>, 1.<ud>C</ud>, 2.<ud>B</ud>}",
+				"{2.<ud>A</ud>, 2.<ud>B</ud>, 1.<ud>C</ud>}",
+				"{1.<ud>C</ud>, 2.<ud>A</ud>, 2.<ud>B</ud>}",
+				"{1.<ud>C</ud>, 2.<ud>B</ud>, 2.<ud>A</ud>}",
+				"{2.<ud>B</ud>, 2.<ud>A</ud>, 1.<ud>C</ud>}",
+				"{2.<ud>B</ud>, 1.<ud>C</ud>, 2.<ud>A</ud>}",
+			},
 		},
 		{
 			name: "one collection",
 			input: Set{
 				NewID("A", 1): present{},
 			},
-			output:         "{1.A}",
-			redactedOutput: "{1.<ud>A</ud>}",
+			output:         "{1.<ud>A</ud>}",
+			redactedOutput: []string{"{1.<ud>A</ud>}"},
 		},
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			require.Equal(t, test.output, test.input.String())
-			require.Equal(t, test.redactedOutput, base.UD(test.input).Redact())
+			require.Contains(t, test.redactedOutput, base.UD(test.input).Redact())
 		})
 	}
 }

--- a/channels/set_test.go
+++ b/channels/set_test.go
@@ -11,6 +11,7 @@ package channels
 import (
 	"testing"
 
+	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -328,14 +329,16 @@ func TestSetContains(t *testing.T) {
 
 func TestSetString(t *testing.T) {
 	testCases := []struct {
-		name   string
-		input  Set
-		output string
+		name           string
+		input          Set
+		output         string
+		redactedOutput string
 	}{
 		{
-			name:   "empty,emptyID",
-			input:  Set{},
-			output: "{}",
+			name:           "empty,emptyID",
+			input:          Set{},
+			output:         "{}",
+			redactedOutput: "{}",
 		},
 		{
 			name: "two collections",
@@ -344,7 +347,8 @@ func TestSetString(t *testing.T) {
 				NewID("B", 2): present{},
 				NewID("C", 1): present{},
 			},
-			output: "{1.A, 1.C, 2.B}",
+			output:         "{1.A, 1.C, 2.B}",
+			redactedOutput: "{1.<ud>A</ud>, 1.<ud>C</ud>, 2.<ud>B</ud>}",
 		},
 		{
 			name: "two collections, collection2",
@@ -353,19 +357,22 @@ func TestSetString(t *testing.T) {
 				NewID("B", 2): present{},
 				NewID("C", 1): present{},
 			},
-			output: "{1.C, 2.A, 2.B}",
+			output:         "{1.C, 2.A, 2.B}",
+			redactedOutput: "{1.<ud>C</ud>, 2.<ud>A</ud>, 2.<ud>B</ud>}",
 		},
 		{
 			name: "one collection",
 			input: Set{
 				NewID("A", 1): present{},
 			},
-			output: "{1.A}",
+			output:         "{1.A}",
+			redactedOutput: "{1.<ud>A</ud>}",
 		},
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			require.Equal(t, test.output, test.input.String())
+			require.Equal(t, test.redactedOutput, base.UD(test.input).Redact())
 		})
 	}
 }


### PR DESCRIPTION
This mostly does the right thing at the same cost as `base.Set` redaction. However, it looks like `base.Set` doesn't do sorting of elements? It's very hard to read without sorting but if we've gotten this long without sorting for `base.Set` then maybe it doesn't matter?

One way that we could optimize this is by storing the `channels.ID.serializationString` with `1.<ud>A</ud>` so we pay the cost at construction of disassembling the string. This would mean channelID.String() would always include the redaction tags but that's almost a benefit?

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
