### PR TITLE
CBG-2766: Further split status/stats from checkpoints

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -345,33 +345,29 @@ func (ar *ActiveReplicator) purgeCheckpoints() {
 }
 
 // LoadReplicationStatus attempts to load both push and pull replication checkpoints, and constructs the combined status
-func LoadReplicationStatus(dbContext *DatabaseContext, replicationID string) (status *ReplicationStatus, err error) {
+func LoadReplicationStatus(ctx context.Context, dbContext *DatabaseContext, replicationID string) (status *ReplicationStatus, err error) {
 
 	status = &ReplicationStatus{
 		ID: replicationID,
 	}
 
-	pullCheckpoint, _ := getLocalCheckpoint(dbContext.MetadataStore, PullCheckpointID(replicationID), int(dbContext.Options.LocalDocExpirySecs))
+	pullCheckpoint, _ := getLocalStatus(ctx, dbContext.MetadataStore, PullCheckpointID(replicationID), int(dbContext.Options.LocalDocExpirySecs))
 	if pullCheckpoint != nil {
 		if pullCheckpoint.Status != nil {
 			status.PullReplicationStatus = pullCheckpoint.Status.PullReplicationStatus
 			status.Status = pullCheckpoint.Status.Status
 			status.ErrorMessage = pullCheckpoint.Status.ErrorMessage
 			status.LastSeqPull = pullCheckpoint.Status.LastSeqPull
-		} else {
-			status.LastSeqPull = pullCheckpoint.LastSeq
 		}
 	}
 
-	pushCheckpoint, _ := getLocalCheckpoint(dbContext.MetadataStore, PushCheckpointID(replicationID), int(dbContext.Options.LocalDocExpirySecs))
+	pushCheckpoint, _ := getLocalStatus(ctx, dbContext.MetadataStore, PushCheckpointID(replicationID), int(dbContext.Options.LocalDocExpirySecs))
 	if pushCheckpoint != nil {
 		if pushCheckpoint.Status != nil {
 			status.PushReplicationStatus = pushCheckpoint.Status.PushReplicationStatus
 			status.Status = pushCheckpoint.Status.Status
 			status.ErrorMessage = pushCheckpoint.Status.ErrorMessage
 			status.LastSeqPush = pushCheckpoint.Status.LastSeqPush
-		} else {
-			status.LastSeqPush = pushCheckpoint.LastSeq
 		}
 	}
 

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -517,7 +517,7 @@ func (c *Checkpointer) _setCheckpoints(seq *SequenceID) (err error) {
 	return nil
 }
 
-// getLocalStatus returns the sequence and rev for the local checkpoint.
+// getLocalCheckpoint returns the sequence and rev for the local checkpoint.
 // if the checkpoint does not exist, returns empty sequence and rev.
 func (c *Checkpointer) getLocalCheckpoint() (checkpoint *replicationCheckpoint, err error) {
 	base.TracefCtx(c.ctx, base.KeyReplicate, "getLocalCheckpoint")
@@ -695,7 +695,7 @@ func (c *Checkpointer) setRetry(checkpoint *replicationCheckpoint, setFn setChec
 // setLocalStatus updates status in a replication checkpoint without a checkpointer.
 // Increments existing rev, preserves stats fields if none set.
 func (c *Checkpointer) setLocalStatus(status, errorMessage string, pushStats *PushReplicationStatus, pullStats *PullReplicationStatus) {
-	base.TracefCtx(c.ctx, base.KeyReplicate, "setLocalStatus(%v, %v)", status)
+	base.TracefCtx(c.ctx, base.KeyReplicate, "setLocalStatus(%v)", status)
 
 	newRev, err := setLocalStatus(c.ctx, c.metadataStore, c.clientID, status, errorMessage, pushStats, pullStats, c.localDocExpirySecs)
 	if err != nil {

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"errors"
 	"expvar"
-	"fmt"
 	"sync"
 	"testing"
 	"time"

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"errors"
 	"expvar"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -70,9 +71,10 @@ func (apr *activeReplicatorCommon) GetSingleCollection(tb testing.TB) *activeRep
 
 // activeReplicatorCollection stores data about a single collection for the replication.
 type activeReplicatorCollection struct {
-	dataStore     base.DataStore // DataStore for this collection
-	collectionIdx *int           // collectionIdx for this collection for this BLIP replication, passed into Get/SetCheckpoint messages
-	Checkpointer  *Checkpointer  // Checkpointer for this collection
+	metadataStore       base.DataStore // DataStore for metadata outside the collection.
+	collectionDataStore base.DataStore // DataStore for this collection
+	collectionIdx       *int           // collectionIdx for this collection for this BLIP replication, passed into Get/SetCheckpoint messages
+	Checkpointer        *Checkpointer  // Checkpointer for this collection
 }
 
 func newActiveReplicatorCommon(ctx context.Context, config *ActiveReplicatorConfig, direction ActiveReplicatorDirection) (*activeReplicatorCommon, error) {
@@ -87,7 +89,7 @@ func newActiveReplicatorCommon(ctx context.Context, config *ActiveReplicatorConf
 		checkpointID = PullCheckpointID(config.ID)
 	}
 
-	initialStatus, err := LoadReplicationStatus(config.ActiveDB.DatabaseContext, config.ID)
+	initialStatus, err := LoadReplicationStatus(ctx, config.ActiveDB.DatabaseContext, config.ID)
 	if err != nil {
 		// Not finding an initialStatus isn't fatal, but we should at least log that we'll reset stats when we do...
 		base.InfofCtx(ctx, base.KeyReplicate, "Couldn't load initial replication status for %q: %v - stats will be reset", config.ID, err)
@@ -109,7 +111,8 @@ func newActiveReplicatorCommon(ctx context.Context, config *ActiveReplicatorConf
 			return nil, err
 		}
 		apr.defaultCollection = &activeReplicatorCollection{
-			dataStore: defaultDatabaseCollection.dataStore,
+			metadataStore:       config.ActiveDB.MetadataStore,
+			collectionDataStore: defaultDatabaseCollection.dataStore,
 		}
 	}
 
@@ -339,5 +342,8 @@ func (a *activeReplicatorCommon) getCheckpointHighSeq() string {
 
 func (a *activeReplicatorCommon) _publishStatus() {
 	status, errorMessage := a.getStateWithErrorMessage()
-	setLocalCheckpointStatus(a.ctx, a.config.ActiveDB.MetadataStore, a.CheckpointID, status, errorMessage, int(a.config.ActiveDB.Options.LocalDocExpirySecs))
+	_, err := setLocalStatus(a.ctx, a.config.ActiveDB.MetadataStore, a.CheckpointID, status, errorMessage, nil, nil, int(a.config.ActiveDB.Options.LocalDocExpirySecs))
+	if err != nil {
+		base.WarnfCtx(a.ctx, "Error setting local status: %v", err)
+	}
 }

--- a/db/active_replicator_common_collections.go
+++ b/db/active_replicator_common_collections.go
@@ -171,7 +171,11 @@ func (arc *activeReplicatorCommon) _initCollections() ([]replicationCheckpoint, 
 		blipSyncCollectionContexts[i] = collectionContext
 		collectionCheckpoints[i] = *checkpoint
 
-		arc.namedCollections[localCollectionsKeyspaces[i]] = &activeReplicatorCollection{collectionIdx: base.IntPtr(i), dataStore: dbCollection.dataStore}
+		arc.namedCollections[localCollectionsKeyspaces[i]] = &activeReplicatorCollection{
+			collectionIdx:       base.IntPtr(i),
+			metadataStore:       arc.config.ActiveDB.MetadataStore,
+			collectionDataStore: dbCollection.dataStore,
+		}
 	}
 
 	arc.blipSyncContext.collections.set(blipSyncCollectionContexts)

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -132,6 +132,7 @@ const (
 )
 
 const CheckpointDocIDPrefix = "checkpoint/"
+const ReplicationStatusDocIDPrefix = "replicationStatus/"
 
 const falseProperty = "false"
 const trueProperty = "true"

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -1309,6 +1309,25 @@ type PushReplicationStatus struct {
 	DeltasSent       int64  `json:"deltas_sent,omitempty"`
 }
 
+// ReplicationStatusDoc is used to store the replication status in a local document
+type ReplicationStatusDoc struct {
+	Rev    string             `json:"_rev"`
+	Status *ReplicationStatus `json:"status,omitempty"`
+}
+
+const (
+	replicationStatusBodyRev    = "_rev"
+	replicationStatusBodyStatus = "status"
+)
+
+// AsBody returns a Body representation of ReplicationStatusDoc for use with putSpecial
+func (r *ReplicationStatusDoc) AsBody() Body {
+	return Body{
+		replicationStatusBodyRev:    r.Rev,
+		replicationStatusBodyStatus: r.Status,
+	}
+}
+
 // Add adds the value of all counter stats in other to ReplicationStatus
 func (rs *PullReplicationStatus) Add(other PullReplicationStatus) {
 	if rs == nil {
@@ -1369,7 +1388,7 @@ func (m *sgReplicateManager) GetReplicationStatus(replicationID string, options 
 	} else {
 		// Attempt to retrieve persisted status
 		var loadErr error
-		status, loadErr = LoadReplicationStatus(m.dbContext, replicationID)
+		status, loadErr = LoadReplicationStatus(m.loggingCtx, m.dbContext, replicationID)
 		if loadErr != nil {
 			// Unable to load persisted status.  Create status stub based on config
 			var err error

--- a/db/sg_replicate_util.go
+++ b/db/sg_replicate_util.go
@@ -34,7 +34,7 @@ import (
 //	    "collection2": ["scope1.channel1", "scope1.channel2"]
 //	  }
 //	}
-func CollectionChannelsFromQueryParams(namedCollections []string, queryParams interface{}) (perCollectionChannels [][]string, allCollectionsChannels []string, err error) {
+func CollectionChannelsFromQueryParams(localCollections []string, queryParams interface{}) (perCollectionChannels [][]string, allCollectionsChannels []string, err error) {
 	switch val := queryParams.(type) {
 	case map[string]interface{}:
 		_, hasChannels := val["channels"]
@@ -53,9 +53,12 @@ func CollectionChannelsFromQueryParams(namedCollections []string, queryParams in
 		}
 
 		if hasCollectionsChannels {
+			if localCollections == nil {
+				return nil, nil, errors.New("channel filters using 'collections_channels' also requires 'collections_local' to be specified")
+			}
 			if collectionChannels, ok := val["collections_channels"].(map[string]interface{}); ok {
-				perCollectionChannels = make([][]string, len(namedCollections))
-				for i, collection := range namedCollections {
+				perCollectionChannels = make([][]string, len(localCollections))
+				for i, collection := range localCollections {
 					collectionQueryParams := collectionChannels[collection]
 					collectionQueryParamsArray, ok := collectionQueryParams.([]interface{})
 					if !ok {

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2409,7 +2409,7 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 func TestProcessRevIncrementsStat(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
-	activeRT, remoteRT, remoteURLString, teardown := SetupSGRPeers(t, true)
+	activeRT, remoteRT, remoteURLString, teardown := SetupSGRPeers(t)
 	defer teardown()
 	activeCtx := activeRT.Context()
 

--- a/rest/replicatortest/replicator_collection_test.go
+++ b/rest/replicatortest/replicator_collection_test.go
@@ -318,7 +318,7 @@ func TestActiveReplicatorMultiCollectionMismatchedLocalRemote(t *testing.T) {
 	localCollections := []string{"ks1", "ks3"}
 	remoteCollections := []string{"ks2"}
 
-	activeRT, _, remoteDbURLString, teardown := rest.SetupSGRPeers(t, true)
+	activeRT, _, remoteDbURLString, teardown := rest.SetupSGRPeers(t)
 	defer teardown()
 
 	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
@@ -354,7 +354,7 @@ func TestActiveReplicatorMultiCollectionMissingRemote(t *testing.T) {
 
 	base.TestRequiresCollections(t)
 
-	activeRT, _, remoteDbURLString, teardown := rest.SetupSGRPeers(t, true)
+	activeRT, _, remoteDbURLString, teardown := rest.SetupSGRPeers(t)
 	defer teardown()
 
 	localCollection := activeRT.GetSingleTestDatabaseCollection().ScopeName + "." + activeRT.GetSingleTestDatabaseCollection().Name
@@ -394,7 +394,7 @@ func TestActiveReplicatorMultiCollectionMissingLocal(t *testing.T) {
 
 	base.TestRequiresCollections(t)
 
-	activeRT, passiveRT, remoteDbURLString, teardown := rest.SetupSGRPeers(t, true)
+	activeRT, passiveRT, remoteDbURLString, teardown := rest.SetupSGRPeers(t)
 	defer teardown()
 
 	localCollection := activeRT.GetSingleTestDatabaseCollection().ScopeName + ".invalid"

--- a/rest/replicatortest/replicator_test_helper.go
+++ b/rest/replicatortest/replicator_test_helper.go
@@ -36,9 +36,8 @@ func reduceTestCheckpointInterval(interval time.Duration) func() {
 // AddActiveRT returns a new RestTester backed by a no-close clone of TestBucket
 func addActiveRT(t *testing.T, dbName string, testBucket *base.TestBucket) (activeRT *rest.RestTester) {
 
-	// CBG-2766 adding a new RestTester on the same database will cause stats to be broken, when fixing change to `NewRestTester`
 	// Create a new rest tester, using a NoCloseClone of testBucket, which disables the TestBucketPool teardown
-	activeRT = rest.NewRestTesterDefaultCollection(t,
+	activeRT = rest.NewRestTester(t,
 		&rest.RestTesterConfig{
 			CustomTestBucket:   testBucket.NoCloseClone(),
 			SgReplicateEnabled: true,

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -187,7 +187,7 @@ func InitScenario(t *testing.T, rtConfig *RestTesterConfig) (ChannelRevocationTe
 		rtConfig.SyncFn = defaultSyncFn
 	}
 
-	rt := NewRestTester(t, rtConfig) //  CBG-2319: replicator currently requires default collection
+	rt := NewRestTester(t, rtConfig)
 
 	revocationTester := ChannelRevocationTester{
 		test:       t,

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -183,13 +183,11 @@ func InitScenario(t *testing.T, rtConfig *RestTesterConfig) (ChannelRevocationTe
 		rtConfig = &RestTesterConfig{
 			SyncFn: defaultSyncFn,
 		}
-	} else {
-		if rtConfig.SyncFn == "" {
-			rtConfig.SyncFn = defaultSyncFn
-		}
+	} else if rtConfig.SyncFn == "" {
+		rtConfig.SyncFn = defaultSyncFn
 	}
 
-	rt := NewRestTesterDefaultCollection(t, rtConfig) //  CBG-2319: replicator currently requires default collection
+	rt := NewRestTester(t, rtConfig) //  CBG-2319: replicator currently requires default collection
 
 	revocationTester := ChannelRevocationTester{
 		test:       t,
@@ -1483,9 +1481,10 @@ func TestReplicatorRevocations(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
-	rt1 := NewRestTesterDefaultCollection(t, //  CBG-2319: replicator currently requires default collection
+	rt1 := NewRestTester(t,
 		&RestTesterConfig{
 			CustomTestBucket: base.GetTestBucket(t),
+			SyncFn:           channels.DocChannelsSyncFunction,
 		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -1518,6 +1517,7 @@ func TestReplicatorRevocations(t *testing.T) {
 		Continuous:          false,
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: dbstats,
+		CollectionsEnabled:  base.TestsUseNamedCollections(),
 	})
 	require.NoError(t, err)
 
@@ -1544,9 +1544,10 @@ func TestReplicatorRevocationsNoRev(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
-	rt1 := NewRestTesterDefaultCollection(t, //  CBG-2319: replicator currently requires default collection
+	rt1 := NewRestTester(t,
 		&RestTesterConfig{
 			CustomTestBucket: base.GetTestBucket(t),
+			SyncFn:           channels.DocChannelsSyncFunction,
 		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -1578,13 +1579,14 @@ func TestReplicatorRevocationsNoRev(t *testing.T) {
 		Continuous:          false,
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: dbstats,
+		CollectionsEnabled:  base.TestsUseNamedCollections(),
 	})
 	require.NoError(t, err)
 
 	require.NoError(t, ar.Start(ctx1))
 	rt1.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
 
-	resp := rt1.SendAdminRequest("GET", "/db/doc1", "")
+	resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
 	RequireStatus(t, resp, http.StatusOK)
 
 	revocationTester.removeRole("user", "foo")
@@ -1594,7 +1596,7 @@ func TestReplicatorRevocationsNoRev(t *testing.T) {
 	require.NoError(t, ar.Start(ctx1))
 	rt1.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
 
-	resp = rt1.SendAdminRequest("GET", "/db/doc1", "")
+	resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
 	RequireStatus(t, resp, http.StatusNotFound)
 }
 
@@ -1606,9 +1608,10 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
-	rt1 := NewRestTesterDefaultCollection(t, //  CBG-2319: replicator currently requires default collection
+	rt1 := NewRestTester(t,
 		&RestTesterConfig{
 			CustomTestBucket: base.GetTestBucket(t),
+			SyncFn:           channels.DocChannelsSyncFunction,
 		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -1646,13 +1649,14 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 		Continuous:          false,
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: dbstats,
+		CollectionsEnabled:  base.TestsUseNamedCollections(),
 	})
 	require.NoError(t, err)
 
 	require.NoError(t, ar.Start(ctx1))
 	rt1.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
 
-	resp = rt1.SendAdminRequest("GET", "/db/doc1", "")
+	resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
 	RequireStatus(t, resp, http.StatusOK)
 
 	revocationTester.removeRole("user", "foo")
@@ -1662,7 +1666,7 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 	require.NoError(t, ar.Start(ctx1))
 	rt1.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
 
-	resp = rt1.SendAdminRequest("GET", "/db/doc1", "")
+	resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
 	RequireStatus(t, resp, http.StatusOK)
 }
 
@@ -1677,9 +1681,10 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	rt2_collection := rt2.GetSingleTestDatabaseCollection()
 
 	// Active
-	rt1 := NewRestTesterDefaultCollection(t, //  CBG-2319: replicator currently requires default collection
+	rt1 := NewRestTester(t,
 		&RestTesterConfig{
 			CustomTestBucket: base.GetTestBucket(t),
+			SyncFn:           channels.DocChannelsSyncFunction,
 		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -1707,6 +1712,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 		Continuous:          true,
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: dbstats,
+		CollectionsEnabled:  base.TestsUseNamedCollections(),
 	})
 	require.NoError(t, err)
 	require.NoError(t, ar.Start(ctx1))
@@ -1789,9 +1795,10 @@ func TestReplicatorRevocationsWithTombstoneResurrection(t *testing.T) {
 	rt2_collection := rt2.GetSingleTestDatabaseCollection()
 
 	// Active
-	rt1 := NewRestTesterDefaultCollection(t, //  CBG-2319: replicator currently requires default collection
+	rt1 := NewRestTester(t,
 		&RestTesterConfig{
 			CustomTestBucket: base.GetTestBucket(t),
+			SyncFn:           channels.DocChannelsSyncFunction,
 		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -1822,6 +1829,7 @@ func TestReplicatorRevocationsWithTombstoneResurrection(t *testing.T) {
 		Continuous:          true,
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: dbstats,
+		CollectionsEnabled:  base.TestsUseNamedCollections(),
 	})
 	require.NoError(t, err)
 
@@ -1883,7 +1891,9 @@ func TestReplicatorRevocationsWithChannelFilter(t *testing.T) {
 	rt2Collection := rt2.GetSingleTestDatabaseCollection()
 
 	// Active
-	rt1 := NewRestTesterDefaultCollection(t, nil)
+	rt1 := NewRestTester(t, &RestTesterConfig{
+		SyncFn: channels.DocChannelsSyncFunction,
+	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
@@ -1918,6 +1928,7 @@ func TestReplicatorRevocationsWithChannelFilter(t *testing.T) {
 		FilterChannels:      []string{"ABC"},
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: dbstats,
+		CollectionsEnabled:  base.TestsUseNamedCollections(),
 	})
 	require.NoError(t, err)
 
@@ -1961,9 +1972,10 @@ func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
 	rt2_collection := rt2.GetSingleTestDatabaseCollection()
 
 	// Active
-	rt1 := NewRestTesterDefaultCollection(t, //  CBG-2319: replicator currently requires default collection
+	rt1 := NewRestTester(t,
 		&RestTesterConfig{
 			CustomTestBucket: base.GetTestBucket(t),
+			SyncFn:           channels.DocChannelsSyncFunction,
 		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -1998,6 +2010,7 @@ func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
 		Continuous:          false,
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: dbstats,
+		CollectionsEnabled:  base.TestsUseNamedCollections(),
 	})
 	require.NoError(t, err)
 
@@ -2053,9 +2066,10 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 	rt2_collection := rt2.GetSingleTestDatabaseCollection()
 
 	// Active
-	rt1 := NewRestTesterDefaultCollection(t, //  CBG-2319: replicator currently requires default collection
+	rt1 := NewRestTester(t,
 		&RestTesterConfig{
 			CustomTestBucket: base.GetTestBucket(t),
+			SyncFn:           channels.DocChannelsSyncFunction,
 		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -2086,6 +2100,7 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 		Continuous:          false,
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: dbstats,
+		CollectionsEnabled:  base.TestsUseNamedCollections(),
 	}
 
 	ar, err := db.NewActiveReplicator(ctx1, activeReplCfg)
@@ -2455,9 +2470,10 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 	rt2_collection := rt2.GetSingleTestDatabaseCollection()
 
 	// Active
-	rt1 := NewRestTesterDefaultCollection(t, //  CBG-2319: replicator currently requires default collection
+	rt1 := NewRestTester(t,
 		&RestTesterConfig{
 			CustomTestBucket: base.GetTestBucket(t),
+			SyncFn:           channels.DocChannelsSyncFunction,
 		})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -2487,6 +2503,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 		},
 		Continuous:          true,
 		ReplicationStatsMap: dbstats,
+		CollectionsEnabled:  base.TestsUseNamedCollections(),
 	})
 	require.NoError(t, err)
 
@@ -2548,6 +2565,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 		Continuous:          true,
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: dbstats,
+		CollectionsEnabled:  base.TestsUseNamedCollections(),
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
CBG-2766: Further split status/stats from checkpoints

- Enable all ISGR tests with collections.
- Split replication status/stats from checkpoints further by using different structs and doc IDs.
  - Store _only_ status/stats in metadata store
  - Store _only_ sequence/config hash in checkpoints (in associated collections)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1636/
