### PR TITLE
CBG-2766 follow up: Replication stats/status writer separate from checkpointer

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -32,7 +32,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -1808,66 +1807,4 @@ func WaitForNoError(callback func() error) error {
 		return callbackErr != nil, callbackErr, nil
 	}, CreateMaxDoublingSleeperFunc(30, 10, 1000))
 	return err
-}
-
-// LoggingMutex is a normal sync.Mutex that logs before and after each operation.
-type LoggingMutex struct {
-	ctx  context.Context
-	name string
-	sync.Mutex
-}
-
-var _ sync.Locker = &LoggingMutex{}
-
-func NewLoggingMutex(ctx context.Context, name string) LoggingMutex {
-	return LoggingMutex{ctx: ctx, name: name}
-}
-
-func (m *LoggingMutex) Lock() {
-	TracefCtx(m.ctx, KeyAll, "Before %s.Lock() %s", m.name, GetCallersName(1, true))
-	m.Mutex.Lock()
-	TracefCtx(m.ctx, KeyAll, "After %s.Lock() %s", m.name, GetCallersName(1, true))
-}
-
-func (m *LoggingMutex) Unlock() {
-	TracefCtx(m.ctx, KeyAll, "Before %s.Unlock() %s", m.name, GetCallersName(1, true))
-	m.Mutex.Unlock()
-	TracefCtx(m.ctx, KeyAll, "After %s.Unlock() %s", m.name, GetCallersName(1, true))
-}
-
-// LoggingMutex is a normal sync.RWMutex that logs before and after each operation.
-type LoggingRWMutex struct {
-	ctx  context.Context
-	name string
-	sync.RWMutex
-}
-
-var _ sync.Locker = &LoggingRWMutex{}
-
-func NewLoggingRWMutex(ctx context.Context, name string) LoggingRWMutex {
-	return LoggingRWMutex{ctx: ctx, name: name}
-}
-
-func (m *LoggingRWMutex) Lock() {
-	TracefCtx(m.ctx, KeyAll, "Before %s.Lock() %s", m.name, GetCallersName(1, true))
-	m.RWMutex.Lock()
-	TracefCtx(m.ctx, KeyAll, "After %s.Lock() %s", m.name, GetCallersName(1, true))
-}
-
-func (m *LoggingRWMutex) Unlock() {
-	TracefCtx(m.ctx, KeyAll, "Before %s.Unlock() %s", m.name, GetCallersName(1, true))
-	m.RWMutex.Unlock()
-	TracefCtx(m.ctx, KeyAll, "After %s.Unlock() %s", m.name, GetCallersName(1, true))
-}
-
-func (m *LoggingRWMutex) RLock() {
-	TracefCtx(m.ctx, KeyAll, "Before %s.RLock() %s", m.name, GetCallersName(1, true))
-	m.RWMutex.RLock()
-	TracefCtx(m.ctx, KeyAll, "After %s.RLock() %s", m.name, GetCallersName(1, true))
-}
-
-func (m *LoggingRWMutex) RUnlock() {
-	TracefCtx(m.ctx, KeyAll, "Before %s.RUnlock() %s", m.name, GetCallersName(1, true))
-	m.RWMutex.RUnlock()
-	TracefCtx(m.ctx, KeyAll, "After %s.RUnlock() %s", m.name, GetCallersName(1, true))
 }

--- a/base/util.go
+++ b/base/util.go
@@ -32,6 +32,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -1807,4 +1808,66 @@ func WaitForNoError(callback func() error) error {
 		return callbackErr != nil, callbackErr, nil
 	}, CreateMaxDoublingSleeperFunc(30, 10, 1000))
 	return err
+}
+
+// LoggingMutex is a normal sync.Mutex that logs before and after each operation.
+type LoggingMutex struct {
+	ctx  context.Context
+	name string
+	sync.Mutex
+}
+
+var _ sync.Locker = &LoggingMutex{}
+
+func NewLoggingMutex(ctx context.Context, name string) LoggingMutex {
+	return LoggingMutex{ctx: ctx, name: name}
+}
+
+func (m *LoggingMutex) Lock() {
+	TracefCtx(m.ctx, KeyAll, "Before %s.Lock() %s", m.name, GetCallersName(1, true))
+	m.Mutex.Lock()
+	TracefCtx(m.ctx, KeyAll, "After %s.Lock() %s", m.name, GetCallersName(1, true))
+}
+
+func (m *LoggingMutex) Unlock() {
+	TracefCtx(m.ctx, KeyAll, "Before %s.Unlock() %s", m.name, GetCallersName(1, true))
+	m.Mutex.Unlock()
+	TracefCtx(m.ctx, KeyAll, "After %s.Unlock() %s", m.name, GetCallersName(1, true))
+}
+
+// LoggingMutex is a normal sync.RWMutex that logs before and after each operation.
+type LoggingRWMutex struct {
+	ctx  context.Context
+	name string
+	sync.RWMutex
+}
+
+var _ sync.Locker = &LoggingRWMutex{}
+
+func NewLoggingRWMutex(ctx context.Context, name string) LoggingRWMutex {
+	return LoggingRWMutex{ctx: ctx, name: name}
+}
+
+func (m *LoggingRWMutex) Lock() {
+	TracefCtx(m.ctx, KeyAll, "Before %s.Lock() %s", m.name, GetCallersName(1, true))
+	m.RWMutex.Lock()
+	TracefCtx(m.ctx, KeyAll, "After %s.Lock() %s", m.name, GetCallersName(1, true))
+}
+
+func (m *LoggingRWMutex) Unlock() {
+	TracefCtx(m.ctx, KeyAll, "Before %s.Unlock() %s", m.name, GetCallersName(1, true))
+	m.RWMutex.Unlock()
+	TracefCtx(m.ctx, KeyAll, "After %s.Unlock() %s", m.name, GetCallersName(1, true))
+}
+
+func (m *LoggingRWMutex) RLock() {
+	TracefCtx(m.ctx, KeyAll, "Before %s.RLock() %s", m.name, GetCallersName(1, true))
+	m.RWMutex.RLock()
+	TracefCtx(m.ctx, KeyAll, "After %s.RLock() %s", m.name, GetCallersName(1, true))
+}
+
+func (m *LoggingRWMutex) RUnlock() {
+	TracefCtx(m.ctx, KeyAll, "Before %s.RUnlock() %s", m.name, GetCallersName(1, true))
+	m.RWMutex.RUnlock()
+	TracefCtx(m.ctx, KeyAll, "After %s.RUnlock() %s", m.name, GetCallersName(1, true))
 }

--- a/base/util_logging_mutex.go
+++ b/base/util_logging_mutex.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/util_logging_mutex.go
+++ b/base/util_logging_mutex.go
@@ -1,0 +1,162 @@
+package base
+
+import (
+	"context"
+	"sync"
+)
+
+// LoggingMutex is a normal sync.Mutex that logs before and after each operation. Recommended for dev-time debugging only.
+type LoggingMutex struct {
+	ctx  context.Context
+	name string
+	sync.Mutex
+}
+
+var _ sync.Locker = &LoggingMutex{}
+
+// NewLoggingMutex returns a new LoggingMutex with the given context/name.
+func NewLoggingMutex(ctx context.Context, name string) LoggingMutex {
+	return LoggingMutex{ctx: ctx, name: name}
+}
+
+// Lock locks m.
+// If the lock is already in use, the calling goroutine
+// blocks until the mutex is available.
+func (m *LoggingMutex) Lock() {
+	TracefCtx(m.ctx, KeyAll, "Before %s.Lock() %s", m.getName(), GetCallersName(1, true))
+	m.Mutex.Lock()
+	TracefCtx(m.ctx, KeyAll, "After %s.Lock() %s", m.getName(), GetCallersName(1, true))
+}
+
+// Unlock unlocks m.
+// It is a run-time error if m is not locked on entry to Unlock.
+//
+// A locked Mutex is not associated with a particular goroutine.
+// It is allowed for one goroutine to lock a Mutex and then
+// arrange for another goroutine to unlock it.
+func (m *LoggingMutex) Unlock() {
+	TracefCtx(m.ctx, KeyAll, "Before %s.Unlock() %s", m.getName(), GetCallersName(1, true))
+	m.Mutex.Unlock()
+	TracefCtx(m.ctx, KeyAll, "After %s.Unlock() %s", m.getName(), GetCallersName(1, true))
+}
+
+// TryLock tries to lock m and reports whether it succeeded.
+//
+// Note that while correct uses of TryLock do exist, they are rare,
+// and use of TryLock is often a sign of a deeper problem
+// in a particular use of mutexes.
+func (m *LoggingMutex) TryLock() bool {
+	TracefCtx(m.ctx, KeyAll, "Before %s.TryLock() %s", m.getName(), GetCallersName(1, true))
+	result := m.Mutex.TryLock()
+	TracefCtx(m.ctx, KeyAll, "After %s.TryLock() %s", m.getName(), GetCallersName(1, true))
+	return result
+}
+
+// getName returns the name of the mutex for logging.
+func (m *LoggingMutex) getName() string {
+	if m.name != "" {
+		return m.name
+	}
+	return "LoggingMutex"
+}
+
+// LoggingRWMutex is a normal sync.RWMutex that logs before and after each operation. Recommended for dev-time debugging only.
+type LoggingRWMutex struct {
+	ctx  context.Context
+	name string
+	sync.RWMutex
+}
+
+var _ sync.Locker = &LoggingRWMutex{}
+
+// NewLoggingRWMutex returns a new LoggingRWMutex with the given context/name.
+func NewLoggingRWMutex(ctx context.Context, name string) LoggingRWMutex {
+	return LoggingRWMutex{ctx: ctx, name: name}
+}
+
+// Lock locks rw for writing.
+// If the lock is already locked for reading or writing,
+// Lock blocks until the lock is available.
+func (m *LoggingRWMutex) Lock() {
+	TracefCtx(m.ctx, KeyAll, "Before %s.Lock() %s", m.getName(), GetCallersName(1, true))
+	m.RWMutex.Lock()
+	TracefCtx(m.ctx, KeyAll, "After %s.Lock() %s", m.getName(), GetCallersName(1, true))
+}
+
+// Unlock unlocks rw for writing. It is a run-time error if rw is
+// not locked for writing on entry to Unlock.
+//
+// As with Mutexes, a locked RWMutex is not associated with a particular
+// goroutine. One goroutine may RLock (Lock) a RWMutex and then
+// arrange for another goroutine to RUnlock (Unlock) it.
+func (m *LoggingRWMutex) Unlock() {
+	TracefCtx(m.ctx, KeyAll, "Before %s.Unlock() %s", m.getName(), GetCallersName(1, true))
+	m.RWMutex.Unlock()
+	TracefCtx(m.ctx, KeyAll, "After %s.Unlock() %s", m.getName(), GetCallersName(1, true))
+}
+
+// Happens-before relationships are indicated to the race detector via:
+// - Unlock  -> Lock:  readerSem
+// - Unlock  -> RLock: readerSem
+// - RUnlock -> Lock:  writerSem
+//
+// The methods below temporarily disable handling of race synchronization
+// events in order to provide the more precise model above to the race
+// detector.
+//
+// For example, atomic.AddInt32 in RLock should not appear to provide
+// acquire-release semantics, which would incorrectly synchronize racing
+// readers, thus potentially missing races.
+
+// RLock locks rw for reading.
+//
+// It should not be used for recursive read locking; a blocked Lock
+// call excludes new readers from acquiring the lock. See the
+// documentation on the RWMutex type.
+func (m *LoggingRWMutex) RLock() {
+	TracefCtx(m.ctx, KeyAll, "Before %s.RLock() %s", m.getName(), GetCallersName(1, true))
+	m.RWMutex.RLock()
+	TracefCtx(m.ctx, KeyAll, "After %s.RLock() %s", m.getName(), GetCallersName(1, true))
+}
+
+// RUnlock undoes a single RLock call;
+// it does not affect other simultaneous readers.
+// It is a run-time error if rw is not locked for reading
+// on entry to RUnlock.
+func (m *LoggingRWMutex) RUnlock() {
+	TracefCtx(m.ctx, KeyAll, "Before %s.RUnlock() %s", m.getName(), GetCallersName(1, true))
+	m.RWMutex.RUnlock()
+	TracefCtx(m.ctx, KeyAll, "After %s.RUnlock() %s", m.getName(), GetCallersName(1, true))
+}
+
+// TryLock tries to lock rw for writing and reports whether it succeeded.
+//
+// Note that while correct uses of TryLock do exist, they are rare,
+// and use of TryLock is often a sign of a deeper problem
+// in a particular use of mutexes.
+func (m *LoggingRWMutex) TryLock() bool {
+	TracefCtx(m.ctx, KeyAll, "Before %s.TryLock() %s", m.getName(), GetCallersName(1, true))
+	result := m.RWMutex.TryLock()
+	TracefCtx(m.ctx, KeyAll, "After %s.TryLock() %s", m.getName(), GetCallersName(1, true))
+	return result
+}
+
+// TryRLock tries to lock rw for reading and reports whether it succeeded.
+//
+// Note that while correct uses of TryRLock do exist, they are rare,
+// and use of TryRLock is often a sign of a deeper problem
+// in a particular use of mutexes.
+func (m *LoggingRWMutex) TryRLock() bool {
+	TracefCtx(m.ctx, KeyAll, "Before %s.TryRLock() %s", m.getName(), GetCallersName(1, true))
+	result := m.RWMutex.TryRLock()
+	TracefCtx(m.ctx, KeyAll, "After %s.TryRLock() %s", m.getName(), GetCallersName(1, true))
+	return result
+}
+
+// getName returns the name of the mutex for logging.
+func (m *LoggingRWMutex) getName() string {
+	if m.name != "" {
+		return m.name
+	}
+	return "LoggingRWMutex"
+}

--- a/base/util_logging_mutex_test.go
+++ b/base/util_logging_mutex_test.go
@@ -1,0 +1,87 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoggingMutex(t *testing.T) {
+	SetUpTestLogging(t, LevelTrace, KeyAll)
+
+	tests := []struct {
+		name     string
+		getMutex func() *LoggingMutex
+	}{
+		{
+			name: "initialized",
+			getMutex: func() *LoggingMutex {
+				m := NewLoggingMutex(TestCtx(t), "test")
+				return &m
+			},
+		},
+		{
+			name: "zero value",
+			getMutex: func() *LoggingMutex {
+				return &LoggingMutex{}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := test.getMutex()
+
+			m.Lock()
+			assert.False(t, m.TryLock())
+			m.Unlock()
+			assert.True(t, m.TryLock())
+		})
+	}
+
+}
+
+func TestLoggingRWMutex(t *testing.T) {
+	SetUpTestLogging(t, LevelTrace, KeyAll)
+
+	tests := []struct {
+		name     string
+		getMutex func() *LoggingRWMutex
+	}{
+		{
+			name: "initialized",
+			getMutex: func() *LoggingRWMutex {
+				m := NewLoggingRWMutex(TestCtx(t), "test")
+				return &m
+			},
+		},
+		{
+			name: "zero value",
+			getMutex: func() *LoggingRWMutex {
+				return &LoggingRWMutex{}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := test.getMutex()
+
+			m.Lock()
+			assert.False(t, m.TryLock())
+			assert.False(t, m.TryRLock())
+			m.Unlock()
+
+			m.RLock()
+			assert.False(t, m.TryLock())
+			assert.True(t, m.TryRLock())
+			m.RUnlock() // TryRLock()
+			m.RUnlock() // RLock()
+
+			assert.True(t, m.TryLock())
+			m.Unlock() // TryLock()
+
+			assert.True(t, m.TryRLock())
+		})
+	}
+}

--- a/base/util_logging_mutex_test.go
+++ b/base/util_logging_mutex_test.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -351,27 +351,27 @@ func LoadReplicationStatus(ctx context.Context, dbContext *DatabaseContext, repl
 		ID: replicationID,
 	}
 
-	pullCheckpoint, _ := getLocalStatus(ctx, dbContext.MetadataStore, PullCheckpointID(replicationID), int(dbContext.Options.LocalDocExpirySecs))
-	if pullCheckpoint != nil {
-		if pullCheckpoint.Status != nil {
-			status.PullReplicationStatus = pullCheckpoint.Status.PullReplicationStatus
-			status.Status = pullCheckpoint.Status.Status
-			status.ErrorMessage = pullCheckpoint.Status.ErrorMessage
-			status.LastSeqPull = pullCheckpoint.Status.LastSeqPull
+	pullStatusDoc, _ := getLocalStatus(ctx, dbContext.MetadataStore, PullCheckpointID(replicationID))
+	if pullStatusDoc != nil {
+		if pullStatusDoc.Status != nil {
+			status.PullReplicationStatus = pullStatusDoc.Status.PullReplicationStatus
+			status.Status = pullStatusDoc.Status.Status
+			status.ErrorMessage = pullStatusDoc.Status.ErrorMessage
+			status.LastSeqPull = pullStatusDoc.Status.LastSeqPull
 		}
 	}
 
-	pushCheckpoint, _ := getLocalStatus(ctx, dbContext.MetadataStore, PushCheckpointID(replicationID), int(dbContext.Options.LocalDocExpirySecs))
-	if pushCheckpoint != nil {
-		if pushCheckpoint.Status != nil {
-			status.PushReplicationStatus = pushCheckpoint.Status.PushReplicationStatus
-			status.Status = pushCheckpoint.Status.Status
-			status.ErrorMessage = pushCheckpoint.Status.ErrorMessage
-			status.LastSeqPush = pushCheckpoint.Status.LastSeqPush
+	pushStatusDoc, _ := getLocalStatus(ctx, dbContext.MetadataStore, PushCheckpointID(replicationID))
+	if pushStatusDoc != nil {
+		if pushStatusDoc.Status != nil {
+			status.PushReplicationStatus = pushStatusDoc.Status.PushReplicationStatus
+			status.Status = pushStatusDoc.Status.Status
+			status.ErrorMessage = pushStatusDoc.Status.ErrorMessage
+			status.LastSeqPush = pushStatusDoc.Status.LastSeqPush
 		}
 	}
 
-	if (pullCheckpoint == nil || pullCheckpoint.Status == nil) && (pushCheckpoint == nil || pushCheckpoint.Status == nil) {
+	if (pullStatusDoc == nil || pullStatusDoc.Status == nil) && (pushStatusDoc == nil || pushStatusDoc.Status == nil) {
 		return nil, errors.New("Replication status not found")
 	}
 

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -351,27 +351,23 @@ func LoadReplicationStatus(ctx context.Context, dbContext *DatabaseContext, repl
 		ID: replicationID,
 	}
 
-	pullStatusDoc, _ := getLocalStatus(ctx, dbContext.MetadataStore, PullCheckpointID(replicationID))
-	if pullStatusDoc != nil {
-		if pullStatusDoc.Status != nil {
-			status.PullReplicationStatus = pullStatusDoc.Status.PullReplicationStatus
-			status.Status = pullStatusDoc.Status.Status
-			status.ErrorMessage = pullStatusDoc.Status.ErrorMessage
-			status.LastSeqPull = pullStatusDoc.Status.LastSeqPull
-		}
+	pullStatus, _ := getLocalStatus(ctx, dbContext.MetadataStore, PullCheckpointID(replicationID))
+	if pullStatus != nil {
+		status.PullReplicationStatus = pullStatus.PullReplicationStatus
+		status.Status = pullStatus.Status
+		status.ErrorMessage = pullStatus.ErrorMessage
+		status.LastSeqPull = pullStatus.LastSeqPull
 	}
 
-	pushStatusDoc, _ := getLocalStatus(ctx, dbContext.MetadataStore, PushCheckpointID(replicationID))
-	if pushStatusDoc != nil {
-		if pushStatusDoc.Status != nil {
-			status.PushReplicationStatus = pushStatusDoc.Status.PushReplicationStatus
-			status.Status = pushStatusDoc.Status.Status
-			status.ErrorMessage = pushStatusDoc.Status.ErrorMessage
-			status.LastSeqPush = pushStatusDoc.Status.LastSeqPush
-		}
+	pushStatus, _ := getLocalStatus(ctx, dbContext.MetadataStore, PushCheckpointID(replicationID))
+	if pushStatus != nil {
+		status.PushReplicationStatus = pushStatus.PushReplicationStatus
+		status.Status = pushStatus.Status
+		status.ErrorMessage = pushStatus.ErrorMessage
+		status.LastSeqPush = pushStatus.LastSeqPush
 	}
 
-	if (pullStatusDoc == nil || pullStatusDoc.Status == nil) && (pushStatusDoc == nil || pushStatusDoc.Status == nil) {
+	if pullStatus == nil && pushStatus == nil {
 		return nil, errors.New("Replication status not found")
 	}
 

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -316,6 +316,7 @@ func (a *activeReplicatorCommon) getLastError() error {
 	return a.lastError
 }
 
+// requires a.stateErrorLock
 func (a *activeReplicatorCommon) _getStateWithErrorMessage() (state string, lastErrorMessage string) {
 	if a.lastError == nil {
 		return a.state, ""

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -100,8 +100,6 @@ func newActiveReplicatorCommon(ctx context.Context, config *ActiveReplicatorConf
 		replicationStats: replicationStats,
 		CheckpointID:     config.checkpointPrefix + checkpointID,
 		initialStatus:    initialStatus,
-		lock:             base.NewLoggingRWMutex(ctx, "lock"),
-		stateErrorLock:   base.NewLoggingRWMutex(ctx, "stateErrorLock"),
 	}
 
 	if config.CollectionsEnabled {

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -390,7 +390,7 @@ func (arc *activeReplicatorCommon) startStatusReporter() error {
 
 // getLocalStatusDoc retrieves replication status document for a given client ID from the given metadataStore
 func getLocalStatusDoc(ctx context.Context, metadataStore base.DataStore, statusKey string) (*ReplicationStatusDoc, error) {
-	statusDocBytes, err := getSpecialBytes(metadataStore, DocTypeLocal, ReplicationStatusDocIDPrefix+statusKey, 0)
+	statusDocBytes, err := getWithTouch(metadataStore, statusKey, 0)
 	if err != nil {
 		if !base.IsKeyNotFoundError(metadataStore, err) {
 			return nil, err
@@ -435,7 +435,7 @@ func setLocalStatus(ctx context.Context, metadataStore base.DataStore, statusKey
 		Status: status,
 	}
 
-	_, err = putSpecial(metadataStore, DocTypeLocal, ReplicationStatusDocIDPrefix+statusKey, revID, newStatus.AsBody(), localDocExpirySecs)
+	_, err = putDocWithRevision(metadataStore, statusKey, revID, newStatus.AsBody(), localDocExpirySecs)
 	return err
 }
 
@@ -454,6 +454,6 @@ func removeLocalStatus(ctx context.Context, metadataStore base.DataStore, status
 		return nil
 	}
 
-	_, err = putSpecial(metadataStore, DocTypeLocal, ReplicationStatusDocIDPrefix+statusKey, currentStatus.Rev, nil, 0)
+	_, err = putDocWithRevision(metadataStore, statusKey, currentStatus.Rev, nil, 0)
 	return err
 }

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -277,7 +277,7 @@ func (apr *ActivePullReplicator) reset() error {
 		return err
 	}
 
-	return removeLocalStatus(apr.ctx, apr.config.ActiveDB.MetadataStore, apr.CheckpointID)
+	return removeLocalStatus(apr.ctx, apr.config.ActiveDB.MetadataStore, apr.statusKey)
 }
 
 // registerCheckpointerCallbacks registers appropriate callback functions for checkpointing.

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -230,6 +230,7 @@ func (apr *ActivePullReplicator) _initCheckpointer(remoteCheckpoints []replicati
 	return nil
 }
 
+// requires apr.lock
 func (apr *ActivePullReplicator) _getStatus() *ReplicationStatus {
 	status := &ReplicationStatus{
 		ID: apr.CheckpointID,

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -186,6 +186,7 @@ func (apr *ActivePushReplicator) _initCheckpointer(remoteCheckpoints []replicati
 	return nil
 }
 
+// requires apr.lock
 func (apr *ActivePushReplicator) _getStatus() *ReplicationStatus {
 	status := &ReplicationStatus{}
 	status.Status, status.ErrorMessage = apr._getStateWithErrorMessage()

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -231,7 +231,7 @@ func (apr *ActivePushReplicator) reset() error {
 		return err
 	}
 
-	return removeLocalStatus(apr.ctx, apr.config.ActiveDB.MetadataStore, apr.CheckpointID)
+	return removeLocalStatus(apr.ctx, apr.config.ActiveDB.MetadataStore, apr.statusKey)
 }
 
 // registerCheckpointerCallbacks registers appropriate callback functions for checkpointing.

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -35,6 +35,7 @@ func NewPushReplicator(ctx context.Context, config *ActiveReplicatorConfig) (*Ac
 	apr := ActivePushReplicator{
 		activeReplicatorCommon: replicator,
 	}
+	replicator._getStatusCallback = apr._getStatus
 	apr.replicatorConnectFn = apr._connect
 	return &apr, nil
 }
@@ -97,6 +98,10 @@ func (apr *ActivePushReplicator) _connect() error {
 		}
 	}
 
+	if err := apr.startStatusReporter(); err != nil {
+		return err
+	}
+
 	apr.setState(ReplicationStateRunning)
 	return nil
 }
@@ -104,6 +109,7 @@ func (apr *ActivePushReplicator) _connect() error {
 // Complete gracefully shuts down a replication, waiting for all in-flight revisions to be processed
 // before stopping the replication
 func (apr *ActivePushReplicator) Complete() {
+	base.TracefCtx(apr.ctx, base.KeyReplicate, "ActivePushReplicator.Complete()")
 	apr.lock.Lock()
 	if apr == nil {
 		apr.lock.Unlock()
@@ -152,7 +158,7 @@ func (apr *ActivePushReplicator) _initCheckpointer(remoteCheckpoints []replicati
 			return hashErr
 		}
 
-		c.Checkpointer = NewCheckpointer(apr.checkpointerCtx, c.metadataStore, c.collectionDataStore, apr.CheckpointID, checkpointHash, apr.blipSender, apr.config, apr.getPushStatus, c.collectionIdx)
+		c.Checkpointer = NewCheckpointer(apr.checkpointerCtx, c.metadataStore, c.collectionDataStore, apr.CheckpointID, checkpointHash, apr.blipSender, apr.config, c.collectionIdx)
 
 		if apr.config.CollectionsEnabled {
 			err := c.Checkpointer.setLastCheckpointSeq(&remoteCheckpoints[*c.collectionIdx])
@@ -180,16 +186,9 @@ func (apr *ActivePushReplicator) _initCheckpointer(remoteCheckpoints []replicati
 	return nil
 }
 
-// GetStatus is used externally to retrieve pull replication status.  Combines current running stats with
-// initialStatus.
-func (apr *ActivePushReplicator) GetStatus() *ReplicationStatus {
-	return apr.getPushStatus(apr.getCheckpointHighSeq())
-}
-
-// getPullStatus is used internally, and passed as statusCallback to checkpointer
-func (apr *ActivePushReplicator) getPushStatus(lastSeqPushed string) *ReplicationStatus {
+func (apr *ActivePushReplicator) _getStatus() *ReplicationStatus {
 	status := &ReplicationStatus{}
-	status.Status, status.ErrorMessage = apr.getStateWithErrorMessage()
+	status.Status, status.ErrorMessage = apr._getStateWithErrorMessage()
 
 	pushStats := apr.replicationStats
 	status.DocsWritten = pushStats.SendRevCount.Value()
@@ -198,11 +197,19 @@ func (apr *ActivePushReplicator) getPushStatus(lastSeqPushed string) *Replicatio
 	status.DocWriteConflict = pushStats.SendRevErrorConflictCount.Value()
 	status.RejectedRemote = pushStats.SendRevErrorRejectedCount.Value()
 	status.DeltasSent = pushStats.SendRevDeltaSentCount.Value()
-	status.LastSeqPush = lastSeqPushed
+	status.LastSeqPush = apr.getCheckpointHighSeq()
 	if apr.initialStatus != nil {
 		status.PushReplicationStatus.Add(apr.initialStatus.PushReplicationStatus)
 	}
 	return status
+}
+
+// GetStatus is used externally to retrieve pull replication status.  Combines current running stats with
+// initialStatus.
+func (apr *ActivePushReplicator) GetStatus() *ReplicationStatus {
+	apr.lock.RLock()
+	defer apr.lock.RUnlock()
+	return apr._getStatus()
 }
 
 // reset performs a reset on the replication by removing the local checkpoint document.

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -132,7 +132,6 @@ const (
 )
 
 const CheckpointDocIDPrefix = "checkpoint/"
-const ReplicationStatusDocIDPrefix = "replicationStatus/"
 
 const falseProperty = "false"
 const trueProperty = "true"


### PR DESCRIPTION
CBG-2766 follow up

- Introduces LoggingMutex types. I'm OK with removing this from the PR if it's contentious. It was just used for debugging a deadlock.
- Introduces another background process in the replicator that is used to periodically update replication stats, outside of the regular state change updates.
- Prior to collections, this was done when the checkpointer ran, but now we have N checkpointers, we do not want to be writing N status updates each time.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1645/
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1647/