### PR TITLE
CBG-2755 Revert to using db pathVar for deleteDB

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -944,7 +944,7 @@ func (h *handler) handlePutCollectionConfigImportFilter() error {
 // In non-persistent mode, the endpoint just removes the database from the node.
 func (h *handler) handleDeleteDB() error {
 	h.assertAdminOnly()
-	dbName := h.PathVar("olddb")
+	dbName := h.PathVar("db")
 
 	var bucket string
 

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -323,7 +323,7 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	// so the handlers are moved to the admin port.
 	r.Handle("/{newdb:"+dbRegex+"}/",
 		makeHandlerSpecificAuthScope(sc, adminPrivs, []Permission{PermCreateDb}, nil, (*handler).handleCreateDB, getAuthScopeHandleCreateDB)).Methods("PUT")
-	r.Handle("/{olddb:"+dbRegex+"}/",
+	r.Handle("/{db:"+dbRegex+"}/",
 		makeOfflineHandler(sc, adminPrivs, []Permission{PermDeleteDb}, nil, (*handler).handleDeleteDB)).Methods("DELETE")
 
 	r.Handle("/_all_dbs",


### PR DESCRIPTION
CBG-2755

Revert to using db pathVar for deleteDB, to properly evaluate admin auth.  Change was previously made for CBG-2420, which has already been reopened due to incompatibility of previous approach with db registry.

Was able to repro the issue locally prior to the fix, and verified the fix locally as well (admin auth with custom RBAC not straightforward for unit testing).

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1639/
