### PR TITLE
CBG-2750 Add endpoint for registry retrieval, invoke from sgcollect

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -1518,9 +1518,8 @@ func (sc *ServerContext) fetchConfigsSince(ctx context.Context, refreshInterval 
 	return sc.dbConfigs, nil
 }
 
-// FetchConfigs retrieves all database configs from the ServerContext's bootstrapConnection.
-func (sc *ServerContext) FetchConfigs(ctx context.Context, isInitialStartup bool) (dbNameConfigs map[string]DatabaseConfig, err error) {
-	var buckets []string
+// GetBucketNames returns a slice of the bucket names associated with the server context
+func (sc *ServerContext) GetBucketNames() (buckets []string, err error) {
 	if sc.Config.IsServerless() {
 		buckets = make([]string, len(sc.Config.BucketCredentials))
 		for bucket, _ := range sc.Config.BucketCredentials {
@@ -1541,6 +1540,16 @@ func (sc *ServerContext) FetchConfigs(ctx context.Context, isInitialStartup bool
 		if err != nil {
 			return nil, fmt.Errorf("couldn't get buckets from cluster: %w", err)
 		}
+	}
+	return buckets, nil
+}
+
+// FetchConfigs retrieves all database configs from the ServerContext's bootstrapConnection.
+func (sc *ServerContext) FetchConfigs(ctx context.Context, isInitialStartup bool) (dbNameConfigs map[string]DatabaseConfig, err error) {
+
+	buckets, err := sc.GetBucketNames()
+	if err != nil {
+		return nil, err
 	}
 
 	fetchedConfigs := make(map[string]DatabaseConfig, len(buckets))

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -257,6 +257,9 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	r.Handle("/_config",
 		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handlePutConfig)).Methods("PUT")
 
+	r.Handle("/_cluster_info",
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleGetClusterInfo)).Methods("GET")
+
 	r.Handle("/_status",
 		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleGetStatus)).Methods("GET")
 

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -490,7 +490,18 @@ def make_config_tasks(zip_dir, sg_config_path, sg_url, sg_username, sg_password,
                                  log_file="sync_gateway.log",
                                  content_postprocessors=db_config_postprocessors)
         collect_config_tasks.append(db_config_task)
-    
+
+    # Get cluster information
+    cluster_info_url = "{0}/_cluster_info".format(sg_url)
+    cluster_info_task = make_curl_task(name="Collect SG cluster info",
+                                 user=sg_username,
+                                 password=sg_password,
+                                 url=cluster_info_url,
+                                 log_file="sync_gateway.log",
+                                 content_postprocessors=server_config_postprocessors)
+    collect_config_tasks.append(cluster_info_task)
+
+
     return collect_config_tasks
 
 


### PR DESCRIPTION
CBG-2750

Adds /_cluster_info endpoint to the admin API, secured the same way as other root endpoints (PermDevOps).  Returns the registry for all buckets associated with the node.

This endpoint is added to the set retrieved by sgcollectinfo and included in sync_gateway.log.

sgcollect invocation includes content_postprocessors for JSON formatting, even though there's no redaction needed (without this, json was being written as a single unformatted line to sync_gateway.log).

Sample sgcollect output attached [sync_gateway.log](https://github.com/couchbase/sync_gateway/files/11127945/sync_gateway.log)

Screenshot of new content:
<img width="678" alt="Screen Shot 2023-03-31 at 5 00 02 PM" src="https://user-images.githubusercontent.com/8866453/229252610-4f081cf9-640c-4612-be8a-5025ee7cdd57.png">




## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1640/


