### PR TITLE
CBG-1971: TestReplicationConcurrentPush flaky test fix

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -1194,6 +1194,10 @@ func (c *SGRCluster) GetReplicationIDsForNode(nodeUUID string) (replicationIDs [
 	return replicationIDs
 }
 
+func (m *sgReplicateManager) GetActiveReplicators() map[string]*ActiveReplicator {
+	return m.activeReplicators
+}
+
 // RebalanceReplications distributes the set of defined replications across the set of available nodes
 func (c *SGRCluster) RebalanceReplications() {
 

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -802,6 +802,7 @@ func (m *sgReplicateManager) RefreshReplicationCfg(ctx context.Context) error {
 
 	// Check for replications newly assigned to this node
 	for replicationID, replicationCfg := range configReplications {
+		fmt.Println("newly assigned code", replicationID)
 		if replicationCfg.AssignedNode == m.localNodeUUID {
 			replicator, exists := m.activeReplicators[replicationID]
 			if !exists {

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -1194,8 +1194,10 @@ func (c *SGRCluster) GetReplicationIDsForNode(nodeUUID string) (replicationIDs [
 	return replicationIDs
 }
 
-func (m *sgReplicateManager) GetActiveReplicators() map[string]*ActiveReplicator {
-	return m.activeReplicators
+func (m *sgReplicateManager) GetNumberActiveReplicators() int {
+	m.activeReplicatorsLock.Lock()
+	defer m.activeReplicatorsLock.Unlock()
+	return len(m.activeReplicators)
 }
 
 // RebalanceReplications distributes the set of defined replications across the set of available nodes

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -802,7 +802,6 @@ func (m *sgReplicateManager) RefreshReplicationCfg(ctx context.Context) error {
 
 	// Check for replications newly assigned to this node
 	for replicationID, replicationCfg := range configReplications {
-		fmt.Println("newly assigned code", replicationID)
 		if replicationCfg.AssignedNode == m.localNodeUUID {
 			replicator, exists := m.activeReplicators[replicationID]
 			if !exists {

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -833,6 +833,10 @@ func (m *sgReplicateManager) SubscribeCfgChanges(ctx context.Context) error {
 		base.DebugfCtx(m.loggingCtx, base.KeyCluster, "Error subscribing to %s key changes: %v", cfgKeySGRCluster, err)
 		return err
 	}
+	err = m.RefreshReplicationCfg(ctx)
+	if err != nil {
+		base.WarnfCtx(m.loggingCtx, "Error while updating refreshing replications before subscribing to cfg: %v", err)
+	}
 	m.closeWg.Add(1)
 	go func() {
 		defer base.FatalPanicHandler()

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -956,11 +956,12 @@ func TestReplicationConcurrentPush(t *testing.T) {
 
 	activeRT, remoteRT, remoteURLString, teardown := rest.SetupSGRPeers(t)
 	defer teardown()
-	// Create push replications, verify running
+	// Create push replications, wait for active replicator to be initialized on sgReplicateManager, verify running
 	activeRT.CreateReplication("rep_ABC", remoteURLString, db.ActiveReplicatorTypePush, []string{"ABC"}, true, db.ConflictResolverDefault)
-	activeRT.CreateReplication("rep_DEF", remoteURLString, db.ActiveReplicatorTypePush, []string{"DEF"}, true, db.ConflictResolverDefault)
-	activeRT.WaitForAssignedReplications(2)
+	activeRT.WaitForActiveReplicatorInitialization(1)
 	activeRT.WaitForReplicationStatus("rep_ABC", db.ReplicationStateRunning)
+	activeRT.CreateReplication("rep_DEF", remoteURLString, db.ActiveReplicatorTypePush, []string{"DEF"}, true, db.ConflictResolverDefault)
+	activeRT.WaitForActiveReplicatorInitialization(2)
 	activeRT.WaitForReplicationStatus("rep_DEF", db.ReplicationStateRunning)
 
 	// Create docs on active

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -956,13 +956,14 @@ func TestReplicationConcurrentPush(t *testing.T) {
 
 	activeRT, remoteRT, remoteURLString, teardown := rest.SetupSGRPeers(t)
 	defer teardown()
-	// Create push replications, wait for active replicator to be initialized on sgReplicateManager, verify running
+	// Create push replication, wait for assigned replication (this gives time for the first replication to be created and start initializing),
+	// verify running, then create second replication, verify running and verify both replicators are initialized on sgReplicateManager
 	activeRT.CreateReplication("rep_ABC", remoteURLString, db.ActiveReplicatorTypePush, []string{"ABC"}, true, db.ConflictResolverDefault)
-	activeRT.WaitForActiveReplicatorInitialization(1)
 	activeRT.WaitForReplicationStatus("rep_ABC", db.ReplicationStateRunning)
+	activeRT.WaitForAssignedReplications(1)
 	activeRT.CreateReplication("rep_DEF", remoteURLString, db.ActiveReplicatorTypePush, []string{"DEF"}, true, db.ConflictResolverDefault)
-	activeRT.WaitForActiveReplicatorInitialization(2)
 	activeRT.WaitForReplicationStatus("rep_DEF", db.ReplicationStateRunning)
+	activeRT.WaitForActiveReplicatorInitialization(2)
 
 	// Create docs on active
 	docAllChannels1 := t.Name() + "All1"

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -946,7 +946,7 @@ func TestReplicationConcurrentPush(t *testing.T) {
 	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	// Disable sequence batching for multi-RT tests (pending CBG-1000)
 	defer db.SuspendSequenceBatching()()
@@ -956,8 +956,7 @@ func TestReplicationConcurrentPush(t *testing.T) {
 
 	activeRT, remoteRT, remoteURLString, teardown := rest.SetupSGRPeers(t)
 	defer teardown()
-	// Create push replication, wait for assigned replication (this gives time for the first replication to be created and start initializing),
-	// verify running, then create second replication, verify running and verify both replicators are initialized on sgReplicateManager
+	// Create push replications, verify running, also verify active replicators are created
 	activeRT.CreateReplication("rep_ABC", remoteURLString, db.ActiveReplicatorTypePush, []string{"ABC"}, true, db.ConflictResolverDefault)
 	activeRT.CreateReplication("rep_DEF", remoteURLString, db.ActiveReplicatorTypePush, []string{"DEF"}, true, db.ConflictResolverDefault)
 	activeRT.WaitForReplicationStatus("rep_ABC", db.ReplicationStateRunning)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -946,7 +946,7 @@ func TestReplicationConcurrentPush(t *testing.T) {
 	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	// Disable sequence batching for multi-RT tests (pending CBG-1000)
 	defer db.SuspendSequenceBatching()()
@@ -959,9 +959,8 @@ func TestReplicationConcurrentPush(t *testing.T) {
 	// Create push replication, wait for assigned replication (this gives time for the first replication to be created and start initializing),
 	// verify running, then create second replication, verify running and verify both replicators are initialized on sgReplicateManager
 	activeRT.CreateReplication("rep_ABC", remoteURLString, db.ActiveReplicatorTypePush, []string{"ABC"}, true, db.ConflictResolverDefault)
-	activeRT.WaitForReplicationStatus("rep_ABC", db.ReplicationStateRunning)
-	activeRT.WaitForAssignedReplications(1)
 	activeRT.CreateReplication("rep_DEF", remoteURLString, db.ActiveReplicatorTypePush, []string{"DEF"}, true, db.ConflictResolverDefault)
+	activeRT.WaitForReplicationStatus("rep_ABC", db.ReplicationStateRunning)
 	activeRT.WaitForReplicationStatus("rep_DEF", db.ReplicationStateRunning)
 	activeRT.WaitForActiveReplicatorInitialization(2)
 

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -127,8 +127,9 @@ func (rt *RestTester) WaitForCheckpointLastSequence(expectedName string) (string
 }
 
 func (rt *RestTester) WaitForActiveReplicatorInitialization(count int) {
-	ar := rt.GetDatabase().SGReplicateMgr.GetActiveReplicators()
 	successFunc := func() bool {
+		ar := rt.GetDatabase().SGReplicateMgr.GetActiveReplicators()
+		fmt.Println(len(ar))
 		return len(ar) == count
 	}
 	require.NoError(rt.TB, rt.WaitForCondition(successFunc), "mismatch on number of active replicators")

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -129,7 +129,6 @@ func (rt *RestTester) WaitForCheckpointLastSequence(expectedName string) (string
 func (rt *RestTester) WaitForActiveReplicatorInitialization(count int) {
 	successFunc := func() bool {
 		ar := rt.GetDatabase().SGReplicateMgr.GetActiveReplicators()
-		fmt.Println(len(ar))
 		return len(ar) == count
 	}
 	require.NoError(rt.TB, rt.WaitForCondition(successFunc), "mismatch on number of active replicators")

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -128,8 +128,8 @@ func (rt *RestTester) WaitForCheckpointLastSequence(expectedName string) (string
 
 func (rt *RestTester) WaitForActiveReplicatorInitialization(count int) {
 	successFunc := func() bool {
-		ar := rt.GetDatabase().SGReplicateMgr.GetActiveReplicators()
-		return len(ar) == count
+		ar := rt.GetDatabase().SGReplicateMgr.GetNumberActiveReplicators()
+		return ar == count
 	}
 	require.NoError(rt.TB, rt.WaitForCondition(successFunc), "mismatch on number of active replicators")
 }

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -126,6 +126,14 @@ func (rt *RestTester) WaitForCheckpointLastSequence(expectedName string) (string
 	return lastSeq, rt.WaitForCondition(successFunc)
 }
 
+func (rt *RestTester) WaitForActiveReplicatorInitialization(count int) {
+	ar := rt.GetDatabase().SGReplicateMgr.GetActiveReplicators()
+	successFunc := func() bool {
+		return len(ar) == count
+	}
+	require.NoError(rt.TB, rt.WaitForCondition(successFunc), "mismatch on number of active replicators")
+}
+
 // createReplication creates a replication via the REST API with the specified ID, remoteURL, direction and channel filter
 func (rt *RestTester) CreateReplication(replicationID string, remoteURLString string, direction db.ActiveReplicatorDirection, channels []string, continuous bool, conflictResolver db.ConflictResolverType) {
 	rt.CreateReplicationForDB("{{.db}}", replicationID, remoteURLString, direction, channels, continuous, conflictResolver)


### PR DESCRIPTION
CBG-1971


Test was flaking on waiting for nodes to be assigned. But also did a few runs where that wasn't included and notcied that it also failed on asserting for the number of docs pushed on the second replicator (rep_DEF). After digging into the losg I noticed that in all cases where it failed for this reaon I saw a log line:
`[INF] Replicate: t:TestReplicationConcurrentPush c:sgr-mgr- db:activedb Initializing replication <ud>rep_ABC</ud>`
But no corresponding log line for the second created replications (rep_DEF). When looking into the code I noticed this is called when refreshing the sgreplicate config. After adding new print lines everywhere I noticed on failure scenarios the reason the test wasn't actually initialising the second replication was due to `StartReplications` being called after the first replication was created and inserted into sgreplicate. This function created a new suscription and in this time the second replication config is inserted into sgreplicate. There is a race where this second replication is missed as a new addition as a new channel is created in subscribe replicate. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1648/ (for running particular tests 200 times) 
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1650/   (full inegration test run)
