### PR TITLE
Add 3.1 release manifest

### DIFF
--- a/base/version.go
+++ b/base/version.go
@@ -20,7 +20,7 @@ const (
 	ProductName = "Couchbase Sync Gateway"
 
 	ProductAPIVersionMajor = "3"
-	ProductAPIVersionMinor = "1"
+	ProductAPIVersionMinor = "2"
 	ProductAPIVersion      = ProductAPIVersionMajor + "." + ProductAPIVersionMinor
 )
 

--- a/manifest/3.1.xml
+++ b/manifest/3.1.xml
@@ -12,7 +12,7 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+  <remote fetch="https://github.com/couchbase/" name="couchbase" revision="release/3.1.0"/>
   <default remote="couchbase" revision="master"/>
 
   <!-- Build Scripts (required on CI servers) -->

--- a/manifest/3.1.xml
+++ b/manifest/3.1.xml
@@ -12,7 +12,7 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase" revision="release/3.1.0"/>
+  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
   <default remote="couchbase" revision="master"/>
 
   <!-- Build Scripts (required on CI servers) -->
@@ -25,6 +25,6 @@ licenses/APL2.txt.
 
 
   <!-- Sync Gateway -->
-   <project name="sync_gateway" path="sync_gateway" remote="couchbase" />
+   <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/3.1.0"/>
 
 </manifest>

--- a/manifest/3.1.xml
+++ b/manifest/3.1.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Copyright 2016-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+-->
+
+<manifest>
+
+  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+  <default remote="couchbase" revision="master"/>
+
+  <!-- Build Scripts (required on CI servers) -->
+  <project name="product-texts" path="product-texts" remote="couchbase"/>
+  <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
+    <annotation name="VERSION" value="3.1.0"     keep="true"/>
+    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+  </project>
+
+
+  <!-- Sync Gateway -->
+   <project name="sync_gateway" path="sync_gateway" remote="couchbase" />
+
+</manifest>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -18,7 +18,7 @@ licenses/APL2.txt.
   <!-- Build Scripts (required on CI servers) -->
   <project name="product-texts" path="product-texts" remote="couchbase"/>
   <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
-    <annotation name="VERSION" value="3.1.0"     keep="true"/>
+    <annotation name="VERSION" value="3.2.0"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
   </project>

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -389,6 +389,15 @@
             "trigger_blackduck": true,
             "start_build": 1
         },
+        "manifest/3.1.xml": {
+            "release": "3.1.0",
+            "release_name": "Couchbase Sync Gateway 3.1.0",
+            "production": true,
+            "interval": 120,
+            "go_version": "1.19.5",
+            "trigger_blackduck": true,
+            "start_build": 1
+        },
         "manifest/dev.xml": {
             "release": "dev",
             "release_name": "Couchbase Sync Gateway Dev",

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -2,7 +2,7 @@
     "product": "sync_gateway",
     "manifests": {
         "manifest/default.xml": {
-            "release": "3.1.0",
+            "release": "3.2.0",
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,
@@ -396,7 +396,7 @@
             "interval": 120,
             "go_version": "1.19.5",
             "trigger_blackduck": true,
-            "start_build": 1
+            "start_build": 586
         },
         "manifest/dev.xml": {
             "release": "dev",


### PR DESCRIPTION
Should I also add a file for 

manifest/3.1/3.1.0.xml with duplicate contents of 3.1.xml or leave that to the inevitable 3.1.1 point release?

I was going to merge this change into the release branch AND master.