### PR TITLE
Take a copy of UserData without pointer-hacks that get optimised away

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -269,7 +269,11 @@ func blipSync(target url.URL, blipContext *blip.Context, insecureSkipVerify bool
 	var basicAuthCreds *url.Userinfo
 	if target.User != nil {
 		// take a copy
-		basicAuthCreds = &*target.User
+		if password, hasPassword := target.User.Password(); hasPassword {
+			basicAuthCreds = url.UserPassword(target.User.Username(), password)
+		} else {
+			basicAuthCreds = url.User(target.User.Username())
+		}
 		target.User = nil
 	}
 


### PR DESCRIPTION
According to a linter `&*` gets compiled away as an optimisation, so take a copy of UserInfo in a more explicit way.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
