### PR TITLE
CBG-2686: fix for dcp resync flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
-        run: go test -timeout=30m -count=100 -v ./rest/adminapitest -run TestResync | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+        run: go test -timeout=30m -count=101 -v ./rest/adminapitest -run TestResync | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
       - name: Annotate Failures
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
-        run: go test -timeout=30m -count=100 -v ./rest/adminapitest -run TestResync
+        run: go test -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
       - name: Annotate Failures
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
-        run: go test -timeout=30m -count=101 -v ./rest/adminapitest -run TestResync | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+        run: go test -timeout=30m -count=100 -v ./rest/adminapitest -run TestResync | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
       - name: Annotate Failures
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
-        run: go test -timeout=30m -count=100 -v ./rest/adminapitest -run TestResync | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+        run: go test -timeout=30m -count=100 -v ./rest/adminapitest -run TestResync
         shell: bash
       - name: Annotate Failures
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
-        run: go test -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+        run: go test -timeout=30m -count=100 -v ./rest/adminapitest -run TestResync | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
       - name: Annotate Failures
         if: always()

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -307,7 +307,7 @@ func (b *BackgroundManager) getStatusFromCluster() ([]byte, error) {
 		_, _, err = b.clusterAwareOptions.metadataStore.GetRaw(b.clusterAwareOptions.HeartbeatDocID())
 		if err != nil {
 			if base.IsDocNotFoundError(err) {
-				if clusterStatus["status"] != BackgroundProcessStateCompleted {
+				if clusterState != string(BackgroundProcessStateCompleted) {
 					clusterStatus["status"] = BackgroundProcessStateStopped
 					status, err = base.JSONMarshal(clusterStatus)
 					if err != nil {

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -307,7 +307,12 @@ func (b *BackgroundManager) getStatusFromCluster() ([]byte, error) {
 		_, _, err = b.clusterAwareOptions.metadataStore.GetRaw(b.clusterAwareOptions.HeartbeatDocID())
 		if err != nil {
 			if base.IsDocNotFoundError(err) {
-				if clusterState != string(BackgroundProcessStateCompleted) {
+				if clusterState == string(BackgroundProcessStateRunning) {
+					status, _, err = b.getStatusLocal()
+					if err != nil {
+						return nil, err
+					}
+				} else {
 					clusterStatus["status"] = BackgroundProcessStateStopped
 					status, err = base.JSONMarshal(clusterStatus)
 					if err != nil {

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -307,10 +307,12 @@ func (b *BackgroundManager) getStatusFromCluster() ([]byte, error) {
 		_, _, err = b.clusterAwareOptions.metadataStore.GetRaw(b.clusterAwareOptions.HeartbeatDocID())
 		if err != nil {
 			if base.IsDocNotFoundError(err) {
-				clusterStatus["status"] = BackgroundProcessStateStopped
-				status, err = base.JSONMarshal(clusterStatus)
-				if err != nil {
-					return nil, err
+				if clusterStatus["status"] != BackgroundProcessStateCompleted {
+					clusterStatus["status"] = BackgroundProcessStateStopped
+					status, err = base.JSONMarshal(clusterStatus)
+					if err != nil {
+						return nil, err
+					}
 				}
 
 				// In the event there is a crash and need to update the status we should attempt to update the doc to

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -614,8 +614,8 @@ func TestResync(t *testing.T) {
 				assert.Equal(t, testCase.expectedQueryCount, int(rt.GetDatabase().DbStats.Query(queryName).QueryCount.Value()))
 				assert.Equal(t, testCase.docsCreated, resyncManagerStatus.DocsProcessed)
 			} else {
-				assert.GreaterOrEqual(t, testCase.expectedSyncFnRuns, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
-				assert.GreaterOrEqual(t, testCase.docsCreated, resyncManagerStatus.DocsProcessed)
+				assert.GreaterOrEqual(t, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()), testCase.expectedSyncFnRuns)
+				assert.GreaterOrEqual(t, resyncManagerStatus.DocsProcessed, testCase.docsCreated)
 			}
 
 			assert.Equal(t, 0, resyncManagerStatus.DocsChanged)

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -603,19 +603,21 @@ func TestResync(t *testing.T) {
 			})
 			assert.NoError(t, err)
 
-			assert.Equal(t, testCase.expectedSyncFnRuns, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
-
 			if !isDCPResync {
 				var queryName string
+				assert.Equal(t, testCase.expectedSyncFnRuns, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
 				if base.TestsDisableGSI() {
 					queryName = fmt.Sprintf(base.StatViewFormat, db.DesignDocSyncGateway(), db.ViewChannels)
 				} else {
 					queryName = db.QueryTypeChannels
 				}
 				assert.Equal(t, testCase.expectedQueryCount, int(rt.GetDatabase().DbStats.Query(queryName).QueryCount.Value()))
+				assert.Equal(t, testCase.docsCreated, resyncManagerStatus.DocsProcessed)
+			} else {
+				assert.GreaterOrEqual(t, testCase.expectedSyncFnRuns, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
+				assert.GreaterOrEqual(t, testCase.docsCreated, resyncManagerStatus.DocsProcessed)
 			}
 
-			assert.Equal(t, testCase.docsCreated, resyncManagerStatus.DocsProcessed)
 			assert.Equal(t, 0, resyncManagerStatus.DocsChanged)
 		})
 	}

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -514,7 +514,7 @@ func TestDBOfflineSingleResync(t *testing.T) {
 
 func TestResyncOverDCP(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test doesn't works with walrus")
+		t.Skip("DCP requires gocb and CBS")
 	}
 	base.LongRunningTest(t)
 
@@ -599,7 +599,7 @@ func TestResyncOverDCP(t *testing.T) {
 					return false
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.GreaterOrEqual(t, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()), testCase.expectedSyncFnRuns)
 			assert.GreaterOrEqual(t, resyncManagerStatus.DocsProcessed, testCase.docsCreated)


### PR DESCRIPTION
CBG-2686


We were asseerting on docs prcessed on dcp resync. I think this was causing some flaking results. Due to nature of dcp it's hard to assert on what you see over dcp so I have changed the assertions to be at least the number of docs added in the test case and thus have to change assertion on sync function runs stats too. This will behind the `isDCPResync` flag and the original, assertion will remain there for non dcp runs. 
I have then added a check in the code to get status doc from the cluster. We were originally just setting sttaus to stopped if heartbeat isnt found. It is entirely possible that the status is completed and thus the heartbeat doc won't be there. So if the status is completed we cant it to remain this way indicating the background process has been successful. 

* Took a slightly different apprioach as it still flaked on git hub actions once. I think this now fixes the issue, I have re run jenkins github actions a few times now with no flake for this test. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1689/ (Run dcp resync 200 times)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1690/ (Run non dcp resync 200 times against server) 

