### PR TITLE
Make tests work with XATTRS=false

### DIFF
--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -780,6 +780,8 @@ func TestDisableScopesInLegacyConfig(t *testing.T) {
 						Username: base.TestClusterUsername(),
 						Password: base.TestClusterPassword(),
 					},
+					EnableXattrs: base.BoolPtr(base.TestUseXattrs()),
+					UseViews:     base.BoolPtr(base.TestsDisableGSI()),
 				}
 				if scopes {
 					if !base.TestsUseNamedCollections() {

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1493,6 +1493,8 @@ func TestPutUserCollectionAccess(t *testing.T) {
 		BucketConfig: BucketConfig{
 			Bucket: base.StringPtr(rt.TestBucket.GetName()),
 		},
+		EnableXattrs: base.BoolPtr(base.TestUseXattrs()),
+		UseViews:     base.BoolPtr(base.TestsDisableGSI()),
 	}
 	resp := rt.ReplaceDbConfig(rt.GetDatabase().Name, dbConfig)
 	RequireStatus(t, resp, http.StatusCreated)

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1488,14 +1488,8 @@ func TestPutUserCollectionAccess(t *testing.T) {
 	RequireStatus(t, getResponse, 200)
 	assert.Contains(t, getResponse.ResponseRecorder.Body.String(), `"all_channels":["!"]`)
 
-	dbConfig := DbConfig{
-		Scopes: GetCollectionsConfigWithSyncFn(rt.TB, rt.TestBucket, nil, 1),
-		BucketConfig: BucketConfig{
-			Bucket: base.StringPtr(rt.TestBucket.GetName()),
-		},
-		EnableXattrs: base.BoolPtr(base.TestUseXattrs()),
-		UseViews:     base.BoolPtr(base.TestsDisableGSI()),
-	}
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Scopes = GetCollectionsConfigWithSyncFn(rt.TB, rt.TestBucket, nil, 1)
 	resp := rt.ReplaceDbConfig(rt.GetDatabase().Name, dbConfig)
 	RequireStatus(t, resp, http.StatusCreated)
 

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -200,6 +200,8 @@ func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
 		BucketConfig: BucketConfig{
 			Bucket: base.StringPtr(rt.TestBucket.GetName()),
 		},
+		EnableXattrs: base.BoolPtr(base.TestUseXattrs()),
+		UseViews:     base.BoolPtr(base.TestsDisableGSI()),
 	}
 	dbOne := "dbone"
 	bucket1Datastore1, err := rt.TestBucket.GetNamedDataStore(0)
@@ -259,6 +261,8 @@ func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
 		BucketConfig: BucketConfig{
 			Bucket: base.StringPtr(bucket2.GetName()),
 		},
+		EnableXattrs: base.BoolPtr(base.TestUseXattrs()),
+		UseViews:     base.BoolPtr(base.TestsDisableGSI()),
 	}
 	dbTwo := "dbtwo"
 	bucket2Datastore1, err := rt.TestBucket.GetNamedDataStore(0)


### PR DESCRIPTION
I'm planning to backport this to 3.1

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1687/
