### PR TITLE
CBG-2412: Leaking rest/replicator_test.go goroutines

### DIFF
--- a/rest/replicatortest/replicator_collection_test.go
+++ b/rest/replicatortest/replicator_collection_test.go
@@ -469,6 +469,7 @@ func TestReplicatorMissingCollections(t *testing.T) {
 
 			// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
 			srv := httptest.NewServer(passiveRT.TestPublicHandler())
+			defer srv.Close()
 
 			// Build passiveDBURL with basic auth creds
 			passiveDBURL, _ := url.Parse(srv.URL + "/" + passiveRT.GetDatabase().Name)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -5409,8 +5409,6 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 	}
 }
 
-// HERE ONWARDS
-
 // TestActiveReplicatorReconnectOnStartEventualSuccess ensures an active replicator with invalid creds retries,
 // but succeeds once the user is created on the remote.
 func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
@@ -6922,7 +6920,6 @@ func TestReplicatorConflictAttachment(t *testing.T) {
 	}
 }
 
-// maybe
 func TestConflictResolveMergeWithMutatedRev(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -5409,6 +5409,8 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 	}
 }
 
+// HERE ONWARDS
+
 // TestActiveReplicatorReconnectOnStartEventualSuccess ensures an active replicator with invalid creds retries,
 // but succeeds once the user is created on the remote.
 func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
@@ -6919,6 +6921,8 @@ func TestReplicatorConflictAttachment(t *testing.T) {
 		})
 	}
 }
+
+// maybe
 func TestConflictResolveMergeWithMutatedRev(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
@@ -7594,7 +7598,7 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 	"replication_id": "` + t.Name() + `",
 	"remote": "` + adminSrv.URL + `/db",
 	"direction": "push",
-	"continuous": true,
+	"continuous": false,
 	"collections_enabled": ` + strconv.FormatBool(!activeRT.GetDatabase().OnlyDefaultCollection()) + `
 }
 `
@@ -7606,8 +7610,8 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 	err = passiveRT.WaitForRev("test", rev)
 	require.NoError(t, err)
 
-	_, err = activeRT.GetDatabase().SGReplicateMgr.PutReplicationStatus(t.Name(), "stop")
-	require.NoError(t, err)
+	resp = activeRT.SendAdminRequest("PUT", "/{{.db}}/_replicationStatus/"+t.Name()+"?action=stop", "")
+	rest.RequireStatus(t, resp, 200)
 	activeRT.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
 
 	// Check checkpoint document was wrote to bucket with correct status

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -7588,6 +7588,11 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 	err = passiveRT.WaitForRev("test", rev)
 	require.NoError(t, err)
 
+	// stop active replicator explicitly
+	ar, ok := activeRT.GetDatabase().SGReplicateMgr.GetLocalActiveReplicatorForTest(t, t.Name())
+	assert.True(t, ok)
+	require.NoError(t, ar.Stop())
+
 	// Check checkpoint document was wrote to bucket with correct status
 	// _sync:local:checkpoint/sgr2cp:push:TestReplicatorCheckpointOnStop
 	expectedCheckpointName := base.SyncDocPrefix + "local:checkpoint/" + db.PushCheckpointID(t.Name())

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -7571,45 +7571,22 @@ func TestReplicatorDeprecatedCredentials(t *testing.T) {
 func TestReplicatorCheckpointOnStop(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
-	passiveRT := rest.NewRestTester(t, nil)
-	defer passiveRT.Close()
-
-	adminSrv := httptest.NewServer(passiveRT.TestAdminHandler())
-	defer adminSrv.Close()
-
-	activeRT := rest.NewRestTester(t, nil)
-	defer activeRT.Close()
+	activeRT, passiveRT, remoteURL, teardown := rest.SetupSGRPeers(t)
+	defer teardown()
 	activeCtx := activeRT.Context()
 
 	// Disable checkpointing at an interval
 	activeRT.GetDatabase().SGReplicateMgr.CheckpointInterval = 0
-	err := activeRT.GetDatabase().SGReplicateMgr.StartReplications(activeCtx)
-	require.NoError(t, err)
 
 	rev, doc, err := activeRT.GetSingleTestDatabaseCollectionWithUser().Put(activeCtx, "test", db.Body{})
 	require.NoError(t, err)
 	seq := strconv.FormatUint(doc.Sequence, 10)
 
-	replConfig := `
-{
-	"replication_id": "` + t.Name() + `",
-	"remote": "` + adminSrv.URL + `/db",
-	"direction": "push",
-	"continuous": false,
-	"collections_enabled": ` + strconv.FormatBool(!activeRT.GetDatabase().OnlyDefaultCollection()) + `
-}
-`
-	resp := activeRT.SendAdminRequest("POST", "/{{.db}}/_replication/", replConfig)
-	rest.RequireStatus(t, resp, 201)
-
+	activeRT.CreateReplication(t.Name(), remoteURL, db.ActiveReplicatorTypePush, nil, true, db.ConflictResolverDefault)
 	activeRT.WaitForReplicationStatus(t.Name(), db.ReplicationStateRunning)
 
 	err = passiveRT.WaitForRev("test", rev)
 	require.NoError(t, err)
-
-	resp = activeRT.SendAdminRequest("PUT", "/{{.db}}/_replicationStatus/"+t.Name()+"?action=stop", "")
-	rest.RequireStatus(t, resp, 200)
-	activeRT.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
 
 	// Check checkpoint document was wrote to bucket with correct status
 	// _sync:local:checkpoint/sgr2cp:push:TestReplicatorCheckpointOnStop


### PR DESCRIPTION
CBG-2412


A small PR that fixes leaking goroutines in blip sender/receiver and a http server leak. Attached is the pprof output for the replicator test package now.
- http server leak came friom the collectiosn test, missing a close afrter the creation of the object 
- There was a test in the main replicator_test file that wasn't stopping a replication properly. I've changed the test to use sgr peers helper function to make use of the teardown function. Also made use of the create replication helper function as it just makes the test more readable. 

![Screenshot 2023-04-12 at 15 30 24](https://user-images.githubusercontent.com/109068393/231490145-f9a28edf-88c5-4b98-9c76-829a9d8da787.png)


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1691/
