### PR TITLE
Don't log if pruneCacheAge didn't prune anything

### DIFF
--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -306,7 +306,9 @@ func (c *singleChannelCacheImpl) pruneCacheAge(ctx context.Context) {
 		c.logs = c.logs[1:]
 		pruned++
 	}
-	base.DebugfCtx(ctx, base.KeyCache, "Pruned %d old entries from channel %q", pruned, base.UD(c.channelID))
+	if pruned > 0 {
+		base.DebugfCtx(ctx, base.KeyCache, "Pruned %d old entries from channel %q", pruned, base.UD(c.channelID))
+	}
 
 }
 


### PR DESCRIPTION
We don't log when we don't prune based on length, so don't do it based on age either:

```
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
[DBG] Cache+: c:db-CleanAgedItems-1234 Pruned 0 old entries from channel "..."
```