### PR TITLE
(3.0.6 backport) CBG-2842 Always return unauthorized for non authorized public API (#6183)

### DIFF
--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -963,7 +963,6 @@ func TestAdminAPIAuth(t *testing.T) {
 			assertStatus(t, resp, http.StatusUnauthorized)
 
 			resp = rt.SendAdminRequestWithAuth(endPoint.Method, formattedEndpoint, body, "noaccess", "password")
-			require.Contains(t, resp.Body.String(), ErrLoginRequired.Message)
 			assertStatus(t, resp, http.StatusForbidden)
 
 			if !endPoint.SkipSuccessTest {
@@ -1573,7 +1572,7 @@ func TestLoginRequiredForAdmin(t *testing.T) {
 	username := "nonexistent"
 	password := "nope"
 
-	response := rt.SendAdminRequestWithAuth(http.MethodGet, "/{{.db}}/", "", username, password)
+	response := rt.SendAdminRequestWithAuth(http.MethodGet, "/db/", "", username, password)
 
 	assertStatus(t, response, http.StatusUnauthorized)
 	require.Contains(t, response.Body.String(), ErrInvalidLogin.Message)

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -961,7 +961,7 @@ func TestAdminAPIAuth(t *testing.T) {
 		t.Run(endPoint.Method+formattedEndpoint, func(t *testing.T) {
 			resp := rt.SendAdminRequest(endPoint.Method, formattedEndpoint, body)
 			assertStatus(t, resp, http.StatusUnauthorized)
-
+			require.Contains(t, resp.Body.String(), ErrLoginRequired.Message)
 			resp = rt.SendAdminRequestWithAuth(endPoint.Method, formattedEndpoint, body, "noaccess", "password")
 			assertStatus(t, resp, http.StatusForbidden)
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3635,8 +3635,7 @@ func TestNotExistentDBRequest(t *testing.T) {
 
 	// Request to non-existent db with valid credentials
 	resp := rt.SendAdminRequestWithAuth("PUT", "/dbx/_config", "", "random", "password")
-	assertStatus(t, resp, http.StatusUnauthorized)
-	require.Contains(t, resp.Body.String(), ErrInvalidLogin.Message)
+	assertStatus(t, resp, http.StatusForbidden)
 
 	// Request to non-existent db with invalid credentials
 	resp = rt.SendAdminRequestWithAuth("PUT", "/dbx/_config", "", "random", "passwordx")

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -820,7 +820,7 @@ func TestSessionExtension(t *testing.T) {
 	response = rt.SendRequestWithHeaders("GET", "/db/doc1", "", reqHeaders)
 	log.Printf("GET Request: Set-Cookie: %v", response.Header().Get("Set-Cookie"))
 	assertStatus(t, response, http.StatusUnauthorized)
-	require.Contains(t, response.Body.String(), "Session invalid")
+	require.Contains(t, response.Body.String(), "Session Invalid")
 
 }
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3635,11 +3635,13 @@ func TestNotExistentDBRequest(t *testing.T) {
 
 	// Request to non-existent db with valid credentials
 	resp := rt.SendAdminRequestWithAuth("PUT", "/dbx/_config", "", "random", "password")
-	assertStatus(t, resp, http.StatusForbidden)
+	assertStatus(t, resp, http.StatusUnauthorized)
+	require.Contains(t, resp.Body.String(), ErrInvalidLogin.Message)
 
 	// Request to non-existent db with invalid credentials
 	resp = rt.SendAdminRequestWithAuth("PUT", "/dbx/_config", "", "random", "passwordx")
 	assertStatus(t, resp, http.StatusUnauthorized)
+	require.Contains(t, resp.Body.String(), ErrInvalidLogin.Message)
 }
 
 func TestConfigsIncludeDefaults(t *testing.T) {

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -820,6 +820,7 @@ func TestSessionExtension(t *testing.T) {
 	response = rt.SendRequestWithHeaders("GET", "/db/doc1", "", reqHeaders)
 	log.Printf("GET Request: Set-Cookie: %v", response.Header().Get("Set-Cookie"))
 	assertStatus(t, response, http.StatusUnauthorized)
+	require.Contains(t, response.Body.String(), "Session invalid")
 
 }
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -678,7 +678,6 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 }
 
 func TestCORSOrigin(t *testing.T) {
-	// FIXME ADD ASSERTS FROM UPSTREAM
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -107,6 +107,12 @@ func TestDisablePublicBasicAuth(t *testing.T) {
 
 	response := rt.SendRequest(http.MethodGet, "/db/", "")
 	assertStatus(t, response, http.StatusUnauthorized)
+	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+	assert.NotContains(t, response.Header(), "WWW-Authenticate", "expected to not receive a WWW-Auth header when password auth is disabled")
+
+	response = rt.SendRequest(http.MethodGet, "/notadb/", "")
+	assertStatus(t, response, http.StatusUnauthorized)
+	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
 	assert.NotContains(t, response.Header(), "WWW-Authenticate", "expected to not receive a WWW-Auth header when password auth is disabled")
 
 	// Double-check that even if we provide valid credentials we still won't be let in
@@ -118,10 +124,15 @@ func TestDisablePublicBasicAuth(t *testing.T) {
 	response = rt.Send(requestByUser(http.MethodGet, "/db/", "", "user1"))
 	assertStatus(t, response, http.StatusUnauthorized)
 	assert.NotContains(t, response.Header(), "WWW-Authenticate", "expected to not receive a WWW-Auth header when password auth is disabled")
-
+	require.Contains(t, response.Body.String(), ErrInvalidLogin.Message)
 	// Also check that we can't create a session through POST /db/_session
 	response = rt.SendRequest(http.MethodPost, "/db/_session", `{"name":"user1","password":"letmein"}`)
 	assertStatus(t, response, http.StatusUnauthorized)
+	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+
+	response = rt.SendRequest(http.MethodPost, "/notadb/_session", `{"name":"user1","password":"letmein"}`)
+	assertStatus(t, response, http.StatusUnauthorized)
+	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
 
 	// As a sanity check, ensure it does work when the setting is disabled
 	rt.ServerContext().Database("db").Options.DisablePasswordAuthentication = false
@@ -667,6 +678,7 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 }
 
 func TestCORSOrigin(t *testing.T) {
+	// FIXME ADD ASSERTS FROM UPSTREAM
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -125,6 +125,12 @@ func TestDisablePublicBasicAuth(t *testing.T) {
 	assertStatus(t, response, http.StatusUnauthorized)
 	assert.NotContains(t, response.Header(), "WWW-Authenticate", "expected to not receive a WWW-Auth header when password auth is disabled")
 	require.Contains(t, response.Body.String(), ErrInvalidLogin.Message)
+
+	response = rt.Send(requestByUser(http.MethodGet, "/notadb/", "", "user1"))
+	assertStatus(t, response, http.StatusUnauthorized)
+	assert.NotContains(t, response.Header(), "WWW-Authenticate", "expected to not receive a WWW-Auth header when password auth is disabled")
+	require.Contains(t, response.Body.String(), ErrInvalidLogin.Message)
+
 	// Also check that we can't create a session through POST /db/_session
 	response = rt.SendRequest(http.MethodPost, "/db/_session", `{"name":"user1","password":"letmein"}`)
 	assertStatus(t, response, http.StatusUnauthorized)

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -220,7 +220,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 						return err
 					}
 
-					if !authorized || h.providedAuthCredentials() {
+					if !authorized {
 						return ErrInvalidLogin
 					}
 				} else {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -223,6 +223,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 					if !authorized {
 						return ErrInvalidLogin
 					}
+					return base.HTTPErrorf(http.StatusForbidden, "")
 				} else {
 					if h.privs == regularPrivs || h.privs == publicPrivs {
 						if !h.providedAuthCredentials() {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -220,11 +220,10 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 						return err
 					}
 
-					if !authorized {
+					if !authorized || h.providedAuthCredentials() {
 						return ErrInvalidLogin
 					}
 				} else {
-
 					if h.privs == regularPrivs || h.privs == publicPrivs {
 						if !h.providedAuthCredentials() {
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -41,6 +41,10 @@ const (
 	minCompressibleJSONSize = 1000
 )
 
+var ErrInvalidLogin = base.HTTPErrorf(http.StatusUnauthorized, "Invalid login")
+var ErrLoginRequired = base.HTTPErrorf(http.StatusUnauthorized, "Login required")
+var errPasswordAuthenticationDisabled = base.HTTPErrorf(http.StatusUnauthorized, "Password authentication is disabled")
+
 // If set to true, JSON output will be pretty-printed.
 var PrettyPrint bool = false
 
@@ -209,17 +213,25 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 		if dbContext, err = h.server.GetDatabase(dbname); err != nil {
 			base.Infof(base.KeyHTTP, "Error trying to get db %s: %v", base.MD(dbname), err)
 
-			if shouldCheckAdminAuth {
-				if httpError, ok := err.(*base.HTTPError); ok && httpError.Status == http.StatusNotFound {
+			if httpError, ok := err.(*base.HTTPError); ok && httpError.Status == http.StatusNotFound {
+				if shouldCheckAdminAuth {
 					authorized, err := h.checkAdminAuthenticationOnly()
 					if err != nil {
 						return err
 					}
 
-					if authorized {
-						return base.HTTPErrorf(http.StatusForbidden, "")
+					if !authorized {
+						return ErrInvalidLogin
 					}
-					return base.HTTPErrorf(http.StatusUnauthorized, "")
+				} else {
+
+					if h.privs == regularPrivs || h.privs == publicPrivs {
+						if !h.providedAuthCredentials() {
+
+							return ErrLoginRequired
+						}
+						return ErrInvalidLogin
+					}
 				}
 			}
 
@@ -280,7 +292,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 			if dbContext == nil || dbContext.Options.SendWWWAuthenticateHeader == nil || *dbContext.Options.SendWWWAuthenticateHeader {
 				h.response.Header().Set("WWW-Authenticate", wwwAuthenticateHeader)
 			}
-			return base.HTTPErrorf(http.StatusUnauthorized, "Login required")
+			return ErrLoginRequired
 		}
 
 		var managementEndpoints []string
@@ -326,6 +338,9 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 
 		if statusCode != http.StatusOK {
 			base.Infof(base.KeyAuth, "%s: User %s failed to auth as an admin statusCode: %d", h.formatSerialNumber(), base.UD(username), statusCode)
+			if statusCode == http.StatusUnauthorized {
+				return ErrInvalidLogin
+			}
 			return base.HTTPErrorf(statusCode, "")
 		}
 
@@ -439,7 +454,7 @@ func (h *handler) checkAuth(context *db.DatabaseContext) (err error) {
 			var authJwtErr error
 			h.user, authJwtErr = context.Authenticator().AuthenticateUntrustedJWT(token, context.OIDCProviders, h.getOIDCCallbackURL)
 			if h.user == nil || authJwtErr != nil {
-				return base.HTTPErrorf(http.StatusUnauthorized, "Invalid login")
+				return ErrInvalidLogin
 			}
 			return nil
 		}
@@ -472,7 +487,7 @@ func (h *handler) checkAuth(context *db.DatabaseContext) (err error) {
 				if context.Options.SendWWWAuthenticateHeader == nil || *context.Options.SendWWWAuthenticateHeader {
 					h.response.Header().Set("WWW-Authenticate", wwwAuthenticateHeader)
 				}
-				return base.HTTPErrorf(http.StatusUnauthorized, "Invalid login")
+				return ErrInvalidLogin
 			}
 			return nil
 		}
@@ -494,7 +509,10 @@ func (h *handler) checkAuth(context *db.DatabaseContext) (err error) {
 		if context.Options.SendWWWAuthenticateHeader == nil || *context.Options.SendWWWAuthenticateHeader {
 			h.response.Header().Set("WWW-Authenticate", wwwAuthenticateHeader)
 		}
-		return base.HTTPErrorf(http.StatusUnauthorized, "Login required")
+		if h.providedAuthCredentials() {
+			return ErrInvalidLogin
+		}
+		return ErrLoginRequired
 	}
 
 	return nil
@@ -511,8 +529,7 @@ func (h *handler) checkAdminAuthenticationOnly() (bool, error) {
 	username, password := h.getBasicAuth()
 	if username == "" {
 		h.response.Header().Set("WWW-Authenticate", wwwAuthenticateHeader)
-
-		return false, base.HTTPErrorf(http.StatusUnauthorized, "Login required")
+		return false, ErrLoginRequired
 	}
 
 	statusCode, _, err := doHTTPAuthRequest(httpClient, username, password, "POST", "/pools/default/checkPermissions", managementEndpoints, nil)
@@ -825,6 +842,25 @@ func (h *handler) getBearerToken() string {
 		return token
 	}
 	return ""
+}
+
+// providedAuthCredentials returns true if basic auth or session auth is enabled
+func (h *handler) providedAuthCredentials() bool {
+	username, _ := h.getBasicAuth()
+	if username != "" {
+		return true
+	}
+	token := h.getBearerToken()
+	if token != "" {
+		return true
+	}
+	cookieName := auth.DefaultCookieName
+	if h.db != nil {
+		authenticator := h.db.Authenticator()
+		cookieName = authenticator.SessionCookieName
+	}
+	cookie, _ := h.rq.Cookie(cookieName)
+	return cookie != nil
 }
 
 // taggedEffectiveUserName returns the tagged effective name of the user for the request.

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -84,7 +84,7 @@ func (h *handler) handleOIDCChallenge() error {
 
 	authHeader := fmt.Sprintf("OIDC login=%q", redirectURL)
 	h.setHeader("WWW-Authenticate", authHeader)
-	return base.HTTPErrorf(http.StatusUnauthorized, "Login Required")
+	return ErrLoginRequired
 }
 
 func (h *handler) handleOIDCCommon() (redirectURLString string, err error) {
@@ -266,7 +266,7 @@ func (h *handler) createSessionForTrustedIdToken(rawIDToken string, provider *au
 		return "", "", err
 	}
 	if user == nil {
-		return "", "", base.HTTPErrorf(http.StatusUnauthorized, "Invalid login")
+		return "", "", ErrInvalidLogin
 	}
 
 	if !provider.DisableSession {

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -615,7 +615,7 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 			forceAuthError: forceError{
 				errorType:            noAutoRegistrationErr,
 				expectedErrorCode:    http.StatusUnauthorized,
-				expectedErrorMessage: "Invalid login",
+				expectedErrorMessage: ErrInvalidLogin.Message,
 			},
 		}, {
 			// Successful new user authentication against single provider with auto
@@ -649,7 +649,7 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 			forceAuthError: forceError{
 				errorType:            noAutoRegistrationErr,
 				expectedErrorCode:    http.StatusUnauthorized,
-				expectedErrorMessage: "Invalid login",
+				expectedErrorMessage: ErrInvalidLogin.Message,
 			},
 		}, {
 			// Successful new user authentication against multiple providers with auto
@@ -1069,7 +1069,7 @@ func TestOpenIDConnectImplicitFlow(t *testing.T) {
 			defaultProvider: "foo",
 			expectedError: forceError{
 				expectedErrorCode:    http.StatusUnauthorized,
-				expectedErrorMessage: "Invalid login",
+				expectedErrorMessage: ErrInvalidLogin.Message,
 			},
 		}, {
 			name: "successful registered user authentication against single provider",
@@ -1184,7 +1184,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		require.NoError(t, err, "Error sending request with bearer token")
 		expectedAuthError := forceError{
 			expectedErrorCode:    http.StatusUnauthorized,
-			expectedErrorMessage: "Invalid login",
+			expectedErrorMessage: ErrInvalidLogin.Message,
 		}
 		assertHttpResponse(t, response, expectedAuthError)
 	}
@@ -1981,7 +1981,7 @@ func TestOpenIDConnectAuthCodeFlowWithUsernameClaim(t *testing.T) {
 			registeredUsername:    "foo_noah",
 			authErrorExpected: forceError{
 				expectedErrorCode:    http.StatusUnauthorized,
-				expectedErrorMessage: "Invalid login",
+				expectedErrorMessage: ErrInvalidLogin.Message,
 			},
 		}, {
 			name: "unsuccessful new user auth when username_claim is set but claim is of illegal type in token",

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -51,7 +51,7 @@ func (h *handler) handleSessionPOST() error {
 	// NOTE: handleSessionPOST doesn't handle creating users from OIDC - checkAuth calls out into AuthenticateUntrustedJWT.
 	// Therefore, if by this point `h.user` is guest, this isn't creating a session from OIDC.
 	if h.db.Options.DisablePasswordAuthentication && (h.user == nil || h.user.Name() == "") {
-		return base.HTTPErrorf(http.StatusUnauthorized, "Password authentication is disabled")
+		return ErrLoginRequired
 	}
 	user, err := h.getUserFromSessionRequestBody()
 
@@ -124,7 +124,7 @@ func (h *handler) makeSession(user auth.User) error {
 // Creates a session with TTL and adds to the response.  Does NOT return the session info response.
 func (h *handler) makeSessionWithTTL(user auth.User, expiry time.Duration) (sessionID string, err error) {
 	if user == nil {
-		return "", base.HTTPErrorf(http.StatusUnauthorized, "Invalid login")
+		return "", ErrInvalidLogin
 	}
 	h.user = user
 	auth := h.db.Authenticator()


### PR DESCRIPTION
CBG-2850

Backport of https://github.com/couchbase/sync_gateway/commit/e0520bcbe86c5d12a35dba8a77bc73f15e09fa6b

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-go1.16.15/42/
