### PR TITLE
Sync optimizations for changes and proposeChanges

### DIFF
--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -208,8 +208,6 @@ func WriteUpdateWithXattr(store SubdocXattrStore, k string, xattrKey string, use
 				xattrValue = previous.Xattr
 				cas = previous.Cas
 				userXattrValue = previous.UserXattr
-			} else if previous.Body != nil || previous.Xattr != nil {
-				panic("WriteUpdateWithXattr: previous doc has zero Cas but is not empty")
 			}
 			previous = nil // a retry will get value from bucket, as below
 		} else {

--- a/db/blip_collection_context.go
+++ b/db/blip_collection_context.go
@@ -51,7 +51,8 @@ const kMaxPendingInsertions = 1000
 // newBlipSyncCollection constructs a context to hold all blip data for a given collection.
 func newBlipSyncCollectionContext(dbCollection *DatabaseCollection) *blipSyncCollectionContext {
 	c := &blipSyncCollectionContext{
-		dbCollection: dbCollection,
+		dbCollection:      dbCollection,
+		pendingInsertions: base.Set{},
 	}
 	c.changesCtx, c.changesCtxCancel = context.WithCancel(context.Background())
 	return c
@@ -61,9 +62,6 @@ func newBlipSyncCollectionContext(dbCollection *DatabaseCollection) *blipSyncCol
 func (bsc *blipSyncCollectionContext) notePendingInsertion(docID string) {
 	bsc.pendingInsertionsLock.Lock()
 	defer bsc.pendingInsertionsLock.Unlock()
-	if bsc.pendingInsertions == nil {
-		bsc.pendingInsertions = base.Set{}
-	}
 	if len(bsc.pendingInsertions) < kMaxPendingInsertions {
 		bsc.pendingInsertions.Add(docID)
 	} else {

--- a/db/blip_collection_context.go
+++ b/db/blip_collection_context.go
@@ -18,11 +18,13 @@ import (
 
 // blipSyncCollectionContext stores information about a single collection for a BlipSyncContext
 type blipSyncCollectionContext struct {
-	dbCollection     *DatabaseCollection
-	activeSubChanges base.AtomicBool // Flag for whether there is a subChanges subscription currently active.  Atomic access
-	changesCtxLock   sync.Mutex
-	changesCtx       context.Context    // Used for the unsub changes Blip message to check if the subChanges feed should stop
-	changesCtxCancel context.CancelFunc // Cancel function for changesCtx to cancel subChanges being sent
+	dbCollection          *DatabaseCollection
+	activeSubChanges      base.AtomicBool // Flag for whether there is a subChanges subscription currently active.  Atomic access
+	changesCtxLock        sync.Mutex
+	changesCtx            context.Context    // Used for the unsub changes Blip message to check if the subChanges feed should stop
+	changesCtxCancel      context.CancelFunc // Cancel function for changesCtx to cancel subChanges being sent
+	pendingInsertionsLock sync.Mutex
+	pendingInsertions     base.Set // DocIDs from handleProposeChanges that aren't in the db
 
 	sgr2PullAddExpectedSeqsCallback  func(expectedSeqs map[IDAndRev]SequenceID)     // sgr2PullAddExpectedSeqsCallback is called after successfully handling an incoming changes message
 	sgr2PullProcessedSeqCallback     func(remoteSeq *SequenceID, idAndRev IDAndRev) // sgr2PullProcessedSeqCallback is called after successfully handling an incoming rev message
@@ -48,6 +50,27 @@ func newBlipSyncCollectionContext(dbCollection *DatabaseCollection) *blipSyncCol
 	}
 	c.changesCtx, c.changesCtxCancel = context.WithCancel(context.Background())
 	return c
+}
+
+// Remembers a docID that doesn't exist in the collection at the time handleProposeChanges ran.
+func (bsc *blipSyncCollectionContext) notePendingInsertion(docID string) {
+	bsc.pendingInsertionsLock.Lock() // TODO: Rename this lock?
+	defer bsc.pendingInsertionsLock.Unlock()
+	if bsc.pendingInsertions == nil {
+		bsc.pendingInsertions = base.Set{}
+	}
+	bsc.pendingInsertions.Add(docID)
+}
+
+// True if this docID was known not to exist in the collection when handleProposeChanges ran.
+// (If so, this fn also forgets the docID, so any subsequent call will return false.)
+func (bsc *blipSyncCollectionContext) checkPendingInsertion(docID string) (found bool) {
+	bsc.pendingInsertionsLock.Lock()
+	defer bsc.pendingInsertionsLock.Unlock()
+	if found = bsc.pendingInsertions.Contains(docID); found {
+		delete(bsc.pendingInsertions, docID)
+	}
+	return
 }
 
 // setNonCollectionAware adds a single collection matching _default._default collection, to be refered to if no Collection property is set on a blip message.

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -58,6 +58,7 @@ type blipHandler struct {
 	*BlipSyncContext
 	db            *Database                   // Handler-specific copy of the BlipSyncContext's blipContextDb
 	collection    *DatabaseCollectionWithUser // Handler-specific copy of the BlipSyncContext's collection specific DB
+	collectionCtx *blipSyncCollectionContext  // Sync-specific data for this collection
 	collectionIdx *int                        // index into BlipSyncContext.collectionMapping for the collection
 	loggingCtx    context.Context             // inherited from BlipSyncContext.loggingCtx with additional handler-only information (like keyspace)
 	serialNumber  uint64                      // This blip handler's serial number to differentiate logs w/ other handlers
@@ -152,7 +153,11 @@ func collectionBlipHandler(next blipHandlerFunc) blipHandlerFunc {
 			if err != nil {
 				return err
 			}
-			bh.collections.setNonCollectionAware(newBlipSyncCollectionContext(bh.collection.DatabaseCollection))
+			bh.collectionCtx, err = bh.collections.get(nil)
+			if err != nil {
+				bh.collections.setNonCollectionAware(newBlipSyncCollectionContext(bh.collection.DatabaseCollection))
+				bh.collectionCtx, _ = bh.collections.get(nil)
+			}
 			return next(bh, bm)
 		}
 		if !bh.collections.hasNamedCollections() {
@@ -165,12 +170,12 @@ func collectionBlipHandler(next blipHandlerFunc) blipHandlerFunc {
 		}
 
 		bh.collectionIdx = &collectionIndex
-		collectionCtx, err := bh.collections.get(&collectionIndex)
+		bh.collectionCtx, err = bh.collections.get(&collectionIndex)
 		if err != nil {
 			return base.HTTPErrorf(http.StatusBadRequest, fmt.Sprintf("%s", err))
 		}
 		bh.collection = &DatabaseCollectionWithUser{
-			DatabaseCollection: collectionCtx.dbCollection,
+			DatabaseCollection: bh.collectionCtx.dbCollection,
 			user:               bh.db.user,
 		}
 		bh.loggingCtx = base.CollectionLogCtx(bh.BlipSyncContext.loggingCtx, bh.collection.Name)
@@ -246,10 +251,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 	}
 
 	// Ensure that only _one_ subChanges subscription can be open on this blip connection at any given time.  SG #3222.
-	collectionCtx, err := bh.collections.get(bh.collectionIdx)
-	if err != nil {
-		return base.HTTPErrorf(http.StatusBadRequest, fmt.Sprintf("%s", err))
-	}
+	collectionCtx := bh.collectionCtx
 	collectionCtx.changesCtxLock.Lock()
 	defer collectionCtx.changesCtxLock.Unlock()
 	if !collectionCtx.activeSubChanges.CASRetry(false, true) {
@@ -331,10 +333,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 }
 
 func (bh *blipHandler) handleUnsubChanges(rq *blip.Message) error {
-	collectionCtx, err := bh.collections.get(bh.collectionIdx)
-	if err != nil {
-		return err
-	}
+	collectionCtx := bh.collectionCtx
 	collectionCtx.changesCtxLock.Lock()
 	defer collectionCtx.changesCtxLock.Unlock()
 	collectionCtx.changesCtxCancel()
@@ -603,11 +602,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 		return err
 	}
 
-	collectionCtx, err := bh.collections.get(bh.collectionIdx)
-	if err != nil {
-		return err
-	}
-
+	collectionCtx := bh.collectionCtx
 	bh.logEndpointEntry(rq.Profile(), fmt.Sprintf("#Changes:%d", len(changeList)))
 	if len(changeList) == 0 {
 		// An empty changeList is sent when a one-shot replication sends its final changes
@@ -768,7 +763,7 @@ func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 		status, currentRev := bh.collection.CheckProposedRev(bh.loggingCtx, docID, revID, parentRevID)
 		if status == ProposedRev_OK_IsNew {
 			// Remember that the doc doesn't exist locally, in order to optimize the upcoming Put:
-			bh.notePendingInsertion(docID)
+			bh.collectionCtx.notePendingInsertion(docID)
 		} else if status != ProposedRev_OK {
 			// Reject the proposed change.
 			// Skip writing trailing zeroes; but if we write a number afterwards we have to catch up
@@ -864,17 +859,12 @@ func (bh *blipHandler) handleNoRev(rq *blip.Message) error {
 	base.InfofCtx(bh.loggingCtx, base.KeySyncMsg, "%s: norev for doc %q / %q seq:%q - error: %q - reason: %q",
 		rq.String(), base.UD(docID), revID, seqStr, rq.Properties[NorevMessageError], rq.Properties[NorevMessageReason])
 
-	collectionCtx, err := bh.collections.get(bh.collectionIdx)
-	if err != nil {
-		return err
-	}
-
-	if collectionCtx.sgr2PullProcessedSeqCallback != nil {
+	if bh.collectionCtx.sgr2PullProcessedSeqCallback != nil {
 		seq, err := ParseJSONSequenceID(seqStr)
 		if err != nil {
 			base.WarnfCtx(bh.loggingCtx, "Unable to parse sequence %q from norev message: %v - not tracking for checkpointing", seqStr, err)
 		} else {
-			collectionCtx.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: revID})
+			bh.collectionCtx.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: revID})
 		}
 	}
 
@@ -946,19 +936,14 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 				return err
 			}
 
-			collectionCtx, err := bh.collections.get(bh.collectionIdx)
-			if err != nil {
-				return err
-			}
-
 			stats.docsPurgedCount.Add(1)
-			if collectionCtx.sgr2PullProcessedSeqCallback != nil {
+			if bh.collectionCtx.sgr2PullProcessedSeqCallback != nil {
 				seqStr := rq.Properties[RevMessageSequence]
 				seq, err := ParseJSONSequenceID(seqStr)
 				if err != nil {
 					base.WarnfCtx(bh.loggingCtx, "Unable to parse sequence %q from rev message: %v - not tracking for checkpointing", seqStr, err)
 				} else {
-					collectionCtx.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: revID})
+					bh.collectionCtx.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: revID})
 				}
 			}
 			return nil
@@ -1153,7 +1138,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		newDoc.UpdateBody(body)
 	}
 
-	if rawBucketDoc == nil && bh.checkPendingInsertion(docID) {
+	if rawBucketDoc == nil && bh.collectionCtx.checkPendingInsertion(docID) {
 		// At the time we handled the `propseChanges` request, there was no doc with this docID
 		// in the bucket. As an optimization, tell PutExistingRev to assume the doc still doesn't
 		// exist and bypass getting it from the bucket during the save. If we're wrong, the save
@@ -1176,18 +1161,13 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		return err
 	}
 
-	collectionCtx, err := bh.collections.get(bh.collectionIdx)
-	if err != nil {
-		return err
-	}
-
-	if collectionCtx.sgr2PullProcessedSeqCallback != nil {
+	if bh.collectionCtx.sgr2PullProcessedSeqCallback != nil {
 		seqProperty := rq.Properties[RevMessageSequence]
 		seq, err := ParseJSONSequenceID(seqProperty)
 		if err != nil {
 			base.WarnfCtx(bh.loggingCtx, "Unable to parse sequence %q from rev message: %v - not tracking for checkpointing", seqProperty, err)
 		} else {
-			collectionCtx.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: revID})
+			bh.collectionCtx.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: revID})
 		}
 	}
 

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -115,6 +115,8 @@ type BlipSyncContext struct {
 	readOnly bool
 
 	collections *blipCollections // all collections handled by blipSyncContext, implicit or via GetCollections
+
+	pendingInsertions map[string]struct{} // DocIDs from handleProposeChanges that aren't in the db
 }
 
 // AllowedAttachment contains the metadata for handling allowed attachments
@@ -654,4 +656,25 @@ func toHistory(revisions Revisions, knownRevs map[string]bool, maxHistory int) [
 		}
 	}
 	return history
+}
+
+// Remembers a docID that doesn't exist in the bucket at the time handleProposeChanges ran.
+func (bsc *BlipSyncContext) notePendingInsertion(docID string) {
+	bsc.allowedAttachmentsLock.Lock() // TODO: Rename this lock?
+	defer bsc.allowedAttachmentsLock.Unlock()
+	if bsc.pendingInsertions == nil {
+		bsc.pendingInsertions = map[string]struct{}{}
+	}
+	bsc.pendingInsertions[docID] = struct{}{}
+}
+
+// Returns true if this docID was known not to exist in the bucket when handleProposeChanges ran.
+// (If so, this fn also forgets the docID, so any subsequent call will return false.)
+func (bsc *BlipSyncContext) checkPendingInsertion(docID string) (found bool) {
+	bsc.allowedAttachmentsLock.Lock()
+	defer bsc.allowedAttachmentsLock.Unlock()
+	if _, found = bsc.pendingInsertions[docID]; found {
+		delete(bsc.pendingInsertions, docID)
+	}
+	return
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -242,6 +242,35 @@ func TestDatabase(t *testing.T) {
 
 	assert.True(t, possible == nil)
 
+	// Test CheckProposedRev:
+	log.Printf("Check CheckProposedRev...")
+	proposedStatus, current := collection.CheckProposedRev(ctx, "doc1", "3-foo",
+		"2-488724414d0ed6b398d6d2aeb228d797")
+	assert.Equal(t, ProposedRev_OK, proposedStatus)
+	assert.Equal(t, "", current)
+
+	proposedStatus, current = collection.CheckProposedRev(ctx, "doc1",
+		"2-488724414d0ed6b398d6d2aeb228d797",
+		"1-xxx")
+	assert.Equal(t, ProposedRev_Exists, proposedStatus)
+	assert.Equal(t, "", current)
+
+	proposedStatus, current = collection.CheckProposedRev(ctx, "doc1",
+		"3-foo",
+		"2-bogus")
+	assert.Equal(t, ProposedRev_Conflict, proposedStatus)
+	assert.Equal(t, "2-488724414d0ed6b398d6d2aeb228d797", current)
+
+	proposedStatus, current = collection.CheckProposedRev(ctx, "doc1",
+		"3-foo",
+		"")
+	assert.Equal(t, ProposedRev_Conflict, proposedStatus)
+	assert.Equal(t, "2-488724414d0ed6b398d6d2aeb228d797", current)
+
+	proposedStatus, current = collection.CheckProposedRev(ctx, "nosuchdoc", "3-foo", "")
+	assert.Equal(t, ProposedRev_OK_IsNew, proposedStatus)
+	assert.Equal(t, "", current)
+
 	// Test PutExistingRev:
 	log.Printf("Check PutExistingRev...")
 	body[BodyRev] = "4-four"

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -504,14 +504,21 @@ func TestImportStampClusterUUID(t *testing.T) {
 	_, err := collection.dataStore.Add(key, 0, bodyBytes)
 	require.NoError(t, err)
 
+	_, cas, err := collection.dataStore.GetRaw(key)
+	require.NoError(t, err)
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeyMigrate, base.KeyImport)
+
 	body := Body{}
 	err = body.Unmarshal(rawDocNoMeta())
 	require.NoError(t, err)
-	existingDoc := &sgbucket.BucketDocument{Body: bodyBytes}
+	existingDoc := &sgbucket.BucketDocument{Body: bodyBytes, Cas: cas}
 
 	importedDoc, err := collection.importDoc(ctx, key, body, nil, false, existingDoc, ImportOnDemand)
 	require.NoError(t, err)
-	require.Equal(t, 32, len(importedDoc.ClusterUUID))
+	if assert.NotNil(t, importedDoc) {
+		require.Equal(t, 32, len(importedDoc.ClusterUUID))
+	}
 
 	var xattr map[string]string
 	_, err = collection.dataStore.GetWithXattr(key, base.SyncXattrName, "", &body, &xattr, nil)


### PR DESCRIPTION
CBG-2851

Describe your PR here...
* **Skip bucket Get when a new doc is pushed via BLIP.** When a client pushes a doc and `proposeChanges` sees that the docID doesn't exist in the bucket, the `rev` handler will write the doc to the bucket as new without trying to get an existing copy first. This will usually succeed, saving time. If it fails, it's handled like any other CAS mismatch, by retrying and getting the existing doc.
  - Added a field BlipSyncContext.pendingInsertions, a set of docIDs.
  - RevDiff returns a new status `ProposedRev_OK_IsNew`.
  - When the `proposeChanges` handler gets ProposedRev_OK_IsNew, it treats it
  like ProposedRev_OK and adds the docID to pendingInsertions.
  - The `rev` handler then checks if the docID is in pendingInsertions; if so,
  it passes an empty BucketDoc with cas=0 to PutExistingRev as the
  `existingDoc`.
  - WriteUpdateWithXattr now allows a `previous` doc with cas=0, interpreting it
  as the document not previously existing.
* **Make RevDiff & CheckProposedRev read and unmarshal less.**
  - Added a new DocUnmarshalLevel constant, DocUnmarshalHistory, which unmarshals
  just the history, current rev and CAS.
  - Added GetDocSyncDataNoImport, which is like GetDocSyncData but does not
  check whether on-demand import is needed (this lets it avoid reading the doc
  body) and takes a DocumentUnmarshalLevel parameter.
  - RevDiff and CheckProposedRev call this instead. RevDiff uses the level
  DocUnmarshalHistory, and CheckProposedRev uses DocUnmarshalRev unless it
  might need the history.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [x] Link upstream PRs
- [x] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
