### PR TITLE
Rename gh actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,14 @@ jobs:
         include:
           - os: ubuntu-20.04
             set-gopath: echo "GOPATH=$GITHUB_WORKSPACE/godeps" >> $GITHUB_ENV
+            name: ubuntu
           - os: macos-latest
             set-gopath: echo "GOPATH=$GITHUB_WORKSPACE/godeps" >> $GITHUB_ENV
+            name: macos
           - os: windows-latest
             set-gopath: echo "GOPATH=$Env:GITHUB_WORKSPACE\godeps" >> $Env:GITHUB_ENV
-    name: test (${{ matrix.os }})
+            name: macos
+    name: test (${{ matrix.name }})
     steps:
       - uses: actions/cache@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     needs: run-bootstrap
     env:
       GO111MODULE: off
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/cache@v1
         with:
@@ -69,7 +69,7 @@ jobs:
             name: macos
           - os: windows-latest
             set-gopath: echo "GOPATH=$Env:GITHUB_WORKSPACE\godeps" >> $Env:GITHUB_ENV
-            name: macos
+            name: windows
     name: test (${{ matrix.name }})
     steps:
       - uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             set-gopath: echo "GOPATH=$GITHUB_WORKSPACE/godeps" >> $GITHUB_ENV
           - os: macos-latest
             set-gopath: echo "GOPATH=$GITHUB_WORKSPACE/godeps" >> $GITHUB_ENV
@@ -85,7 +85,7 @@ jobs:
     needs: run-bootstrap
     env:
       GO111MODULE: off
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/cache@v1
         with:


### PR DESCRIPTION
Rename builds to have consistent names to be able to be used across branches.

I'd push a corresponding PR to master and release/3.1.0 and then we change merge requirements.

(If you have a better idea, that's cool.)