### PR TITLE
CBG-2807: Allow databases to override CORS config (#6179)

### DIFF
--- a/auth/cors.go
+++ b/auth/cors.go
@@ -1,0 +1,49 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package auth
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Configuration for Cross-Origin Resource Sharing
+// <https://en.wikipedia.org/wiki/Cross-origin_resource_sharing>
+type CORSConfig struct {
+	Origin      []string `json:"origin,omitempty"       help:"List of allowed origins, use ['*'] to allow access from everywhere"`
+	LoginOrigin []string `json:"login_origin,omitempty" help:"List of allowed login origins"`
+	Headers     []string `json:"headers,omitempty"      help:"List of allowed headers"`
+	MaxAge      int      `json:"max_age,omitempty"      help:"Maximum age of the CORS Options request"`
+}
+
+// Adds Access-Control-Allow-Origin, Access-Control-Allow-Credentials, Access-Control-Allow-Headers headers to an HTTP response.
+func (cors *CORSConfig) AddResponseHeaders(request *http.Request, response http.ResponseWriter) {
+	if originHeader := request.Header["Origin"]; len(originHeader) > 0 {
+		origin := MatchedOrigin(cors.Origin, originHeader)
+		response.Header().Add("Access-Control-Allow-Origin", origin)
+		response.Header().Add("Access-Control-Allow-Credentials", "true")
+		response.Header().Add("Access-Control-Allow-Headers", strings.Join(cors.Headers, ", "))
+	}
+}
+
+func MatchedOrigin(allowOrigins []string, rqOrigins []string) string {
+	for _, rv := range rqOrigins {
+		for _, av := range allowOrigins {
+			if rv == av {
+				return av
+			}
+		}
+	}
+	for _, av := range allowOrigins {
+		if av == "*" {
+			return "*"
+		}
+	}
+	return ""
+}

--- a/db/database.go
+++ b/db/database.go
@@ -120,6 +120,7 @@ type DatabaseContext struct {
 	ServeInsecureAttachmentTypes bool                     // Attachment content type will bypass the content-disposition handling, default false
 	NoX509HTTPClient             *http.Client             // A HTTP Client from gocb to use the management endpoints
 	ServerContextHasStarted      chan struct{}            // Closed via PostStartup once the server has fully started
+	CORS                         *auth.CORSConfig         // CORS configuration
 }
 
 type DatabaseContextOptions struct {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -45,7 +45,6 @@ func (h *handler) handleCreateDB() error {
 		return err
 	}
 	config.Name = dbName
-
 	if h.server.persistentConfig {
 		if err := config.validatePersistentDbConfig(); err != nil {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -734,7 +734,7 @@ func TestCORSOrigin(t *testing.T) {
 
 			sc.config.API.CORS.Origin = []string{"http://example.com", "http://staging.example.com"}
 			if !base.StringSliceContains(sc.config.API.CORS.Origin, tc.origin) {
-				response = rt.SendRequestWithHeaders("GET", "/{{.keyspace}}/", "", reqHeaders)
+				response = rt.SendRequestWithHeaders("GET", "/db/", "", reqHeaders)
 				assert.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
 			}
 		})

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -686,45 +686,59 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 func TestCORSOrigin(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
+	tests := []struct {
+		origin       string
+		headerOutput string
+	}{
+		{
+			origin:       "http://example.com",
+			headerOutput: "http://example.com",
+		},
+		{
+			origin:       "http://staging.example.com",
+			headerOutput: "http://staging.example.com",
+		},
 
-	reqHeaders := map[string]string{
-		"Origin": "http://example.com",
+		{
+			origin:       "http://hack0r.com",
+			headerOutput: "*",
+		},
 	}
-	response := rt.SendRequestWithHeaders("GET", "/db/", "", reqHeaders)
-	goassert.Equals(t, response.Header().Get("Access-Control-Allow-Origin"), "http://example.com")
+	for _, tc := range tests {
+		t.Run(tc.origin, func(t *testing.T) {
 
-	// now test a non-listed origin
-	// b/c * is in config we get *
-	reqHeaders = map[string]string{
-		"Origin": "http://hack0r.com",
-	}
-	response = rt.SendRequestWithHeaders("GET", "/db/", "", reqHeaders)
-	goassert.Equals(t, response.Header().Get("Access-Control-Allow-Origin"), "*")
+			reqHeaders := map[string]string{
+				"Origin": tc.origin,
+			}
 
-	// now test another origin in config
-	reqHeaders = map[string]string{
-		"Origin": "http://staging.example.com",
-	}
-	response = rt.SendRequestWithHeaders("GET", "/db/", "", reqHeaders)
-	goassert.Equals(t, response.Header().Get("Access-Control-Allow-Origin"), "http://staging.example.com")
+			response := rt.SendRequestWithHeaders("GET", "/db/", "", reqHeaders)
+			assert.Equal(t, tc.headerOutput, response.Header().Get("Access-Control-Allow-Origin"))
+			assertStatus(t, response, http.StatusUnauthorized)
+			require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
 
-	// test no header on _admin apis
-	reqHeaders = map[string]string{
-		"Origin": "http://example.com",
-	}
-	response = rt.SendAdminRequestWithHeaders("GET", "/db/_all_docs", "", reqHeaders)
-	goassert.Equals(t, response.Header().Get("Access-Control-Allow-Origin"), "")
+			response = rt.SendRequestWithHeaders("GET", "/notadb/", "", reqHeaders)
+			assert.Equal(t, tc.headerOutput, response.Header().Get("Access-Control-Allow-Origin"))
+			assertStatus(t, response, http.StatusUnauthorized)
+			require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
 
-	// test with a config without * should reject non-matches
-	sc := rt.ServerContext()
-	sc.config.API.CORS.Origin = []string{"http://example.com", "http://staging.example.com"}
-	// now test a non-listed origin
-	// b/c * is in config we get *
-	reqHeaders = map[string]string{
-		"Origin": "http://hack0r.com",
+			// admin port doesn't have CORS
+			response = rt.SendAdminRequestWithHeaders("GET", "/db/_all_docs", "", reqHeaders)
+			assert.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+			assertStatus(t, response, http.StatusOK)
+
+			// test with a config without * should reject non-matches
+			sc := rt.ServerContext()
+			defer func() {
+				sc.config.API.CORS.Origin = defaultTestingCORSOrigin
+			}()
+
+			sc.config.API.CORS.Origin = []string{"http://example.com", "http://staging.example.com"}
+			if !base.StringSliceContains(sc.config.API.CORS.Origin, tc.origin) {
+				response = rt.SendRequestWithHeaders("GET", "/{{.keyspace}}/", "", reqHeaders)
+				assert.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+			}
+		})
 	}
-	response = rt.SendRequestWithHeaders("GET", "/db/", "", reqHeaders)
-	goassert.Equals(t, response.Header().Get("Access-Control-Allow-Origin"), "")
 }
 
 // assertGatewayStatus is like assertStatus but with StatusGatewayTimeout error checking for temporary network failures.

--- a/rest/config.go
+++ b/rest/config.go
@@ -154,6 +154,7 @@ type DbConfig struct {
 	UserXattrKey                     string                           `json:"user_xattr_key,omitempty"`                       // Key of user xattr that will be accessible from the Sync Function. If empty the feature will be disabled.
 	ClientPartitionWindowSecs        *int                             `json:"client_partition_window_secs,omitempty"`         // How long clients can remain offline for without losing replication metadata. Default 30 days (in seconds)
 	Guest                            *db.PrincipalConfig              `json:"guest,omitempty"`                                // Guest user settings
+	CORS                             *auth.CORSConfig                 `json:"cors,omitempty"`
 }
 
 type DeltaSyncConfig struct {
@@ -626,6 +627,10 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition, validateOIDCConfi
 		}
 	}
 
+	if dbConfig.CORS != nil && dbConfig.CORS.MaxAge != 0 {
+		multiError = multiError.Append(fmt.Errorf("cors.max_age can not be set on a database level"))
+
+	}
 	if dbConfig.DeprecatedPool != nil {
 		base.Warnf(`"pool" config option is not supported. The pool will be set to "default". The option should be removed from config file.`)
 	}

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/couchbase/gocbcore/v10/connstr"
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	pkgerrors "github.com/pkg/errors"
@@ -209,7 +210,7 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 	}
 
 	if lc.CORS != nil {
-		sc.API.CORS = &CORSConfig{
+		sc.API.CORS = &auth.CORSConfig{
 			Origin:      lc.CORS.Origin,
 			LoginOrigin: lc.CORS.LoginOrigin,
 			Headers:     lc.CORS.Headers,

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -107,21 +107,14 @@ type APIConfig struct {
 	CompressResponses  *bool `json:"compress_responses,omitempty"   help:"If false, disables compression of HTTP responses"`
 	HideProductVersion *bool `json:"hide_product_version,omitempty" help:"Whether product versions removed from Server headers and REST API responses"`
 
-	HTTPS HTTPSConfig `json:"https,omitempty"`
-	CORS  *CORSConfig `json:"cors,omitempty"`
+	HTTPS HTTPSConfig      `json:"https,omitempty"`
+	CORS  *auth.CORSConfig `json:"cors,omitempty"`
 }
 
 type HTTPSConfig struct {
 	TLSMinimumVersion string `json:"tls_minimum_version,omitempty" help:"The minimum allowable TLS version for the REST APIs"`
 	TLSCertPath       string `json:"tls_cert_path,omitempty"       help:"The TLS cert file to use for the REST APIs"`
 	TLSKeyPath        string `json:"tls_key_path,omitempty"        help:"The TLS key file to use for the REST APIs"`
-}
-
-type CORSConfig struct {
-	Origin      []string `json:"origin,omitempty"       help:"List of allowed origins, use ['*'] to allow access from everywhere"`
-	LoginOrigin []string `json:"login_origin,omitempty" help:"List of allowed login origins"`
-	Headers     []string `json:"headers,omitempty"      help:"List of allowed headers"`
-	MaxAge      int      `json:"max_age,omitempty"      help:"Maximum age of the CORS Options request"`
 }
 
 type AuthConfig struct {
@@ -197,7 +190,7 @@ func LoadStartupConfigFromPath(path string) (*StartupConfig, error) {
 func NewEmptyStartupConfig() StartupConfig {
 	return StartupConfig{
 		API: APIConfig{
-			CORS: &CORSConfig{},
+			CORS: &auth.CORSConfig{},
 		},
 		Logging: base.LoggingConfig{
 			Console: &base.ConsoleLoggerConfig{},

--- a/rest/config_startup_test.go
+++ b/rest/config_startup_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -84,15 +85,15 @@ func TestStartupConfigMerge(t *testing.T) {
 		},
 		{
 			name:     "Keep original *CORSconfig",
-			config:   StartupConfig{API: APIConfig{CORS: &CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
-			override: StartupConfig{API: APIConfig{CORS: &CORSConfig{}}},
-			expected: StartupConfig{API: APIConfig{CORS: &CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
+			config:   StartupConfig{API: APIConfig{CORS: &auth.CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
+			override: StartupConfig{API: APIConfig{CORS: &auth.CORSConfig{}}},
+			expected: StartupConfig{API: APIConfig{CORS: &auth.CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
 		},
 		{
-			name:     "Keep original *CORSConfig from override nil value",
-			config:   StartupConfig{API: APIConfig{CORS: &CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
+			name:     "Keep original *auth.CORSConfig from override nil value",
+			config:   StartupConfig{API: APIConfig{CORS: &auth.CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
 			override: StartupConfig{},
-			expected: StartupConfig{API: APIConfig{CORS: &CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
+			expected: StartupConfig{API: APIConfig{CORS: &auth.CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
 		},
 		{
 			name:     "Override unset ConfigDuration",

--- a/rest/cors_test.go
+++ b/rest/cors_test.go
@@ -1,0 +1,315 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/auth"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCORSDynamicSet(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("persistent config tests not support on walrus in 3.0")
+	}
+	rt := NewRestTester(t, &RestTesterConfig{
+		persistentConfig: true,
+	})
+	defer rt.Close()
+
+	// CORS is set to http://example.com by RestTester ServerContext
+	dbName := "db"
+	dbConfig := rt.NewDbConfig()
+
+	resp, err := rt.CreateDatabase(dbName, dbConfig)
+	require.NoError(t, err)
+	assertStatus(t, resp, http.StatusCreated)
+
+	const username = "alice"
+	rt.CreateUser(username, nil)
+
+	reqHeaders := map[string]string{
+		"Origin": "http://example.com",
+	}
+	response := rt.SendRequestWithHeaders("GET", "/db/", "", reqHeaders)
+	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+	assertStatus(t, response, http.StatusUnauthorized)
+	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+
+	// successful request
+	response = rt.SendUserRequestWithHeaders("GET", "/db/_all_docs", "", reqHeaders, username, RestTesterDefaultUserPassword)
+	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+	assertStatus(t, response, http.StatusOK)
+
+	response = rt.SendRequestWithHeaders("GET", "/db/", "", reqHeaders)
+	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+	assertStatus(t, response, http.StatusUnauthorized)
+	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+
+	response = rt.SendUserRequestWithHeaders("GET", "/db/", "", reqHeaders, username, RestTesterDefaultUserPassword)
+	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+	assertStatus(t, response, http.StatusOK)
+
+	dbConfig = rt.NewDbConfig()
+	dbConfig.CORS = &auth.CORSConfig{
+		Origin: []string{"http://example.org"},
+	}
+
+	resp, err = rt.ReplaceDbConfig(dbName, dbConfig)
+	require.NoError(t, err)
+	assertStatus(t, resp, http.StatusCreated)
+
+	// this falls back to the server config CORS without the user being authenticated
+	response = rt.SendRequestWithHeaders("GET", "/db/", "", reqHeaders)
+	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+	assertStatus(t, response, http.StatusUnauthorized)
+	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+
+	// successful request - mismatched headers
+	response = rt.SendUserRequestWithHeaders("GET", "/db/_all_docs", "", reqHeaders, username, RestTesterDefaultUserPassword)
+	assertStatus(t, response, http.StatusOK)
+	require.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+
+	response = rt.SendRequestWithHeaders("GET", "/db/", "", reqHeaders)
+	assertStatus(t, response, http.StatusUnauthorized)
+	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+
+	response = rt.SendRequestWithHeaders("GET", "/notadb/", "", reqHeaders)
+	assertStatus(t, response, http.StatusUnauthorized)
+	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+
+	response = rt.SendUserRequestWithHeaders("GET", "/db/", "", reqHeaders, username, RestTesterDefaultUserPassword)
+	require.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+	assertStatus(t, response, http.StatusOK)
+
+	// successful request - matched headers
+	reqHeaders = map[string]string{
+		"Origin": "http://example.org",
+	}
+	response = rt.SendUserRequestWithHeaders("GET", "/db/_all_docs", "", reqHeaders, username, RestTesterDefaultUserPassword)
+	require.Equal(t, "http://example.org", response.Header().Get("Access-Control-Allow-Origin"))
+	assertStatus(t, response, http.StatusOK)
+
+	response = rt.SendRequestWithHeaders("GET", "/db/", "", reqHeaders)
+	require.Equal(t, "*", response.Header().Get("Access-Control-Allow-Origin"))
+	assertStatus(t, response, http.StatusUnauthorized)
+	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+
+	response = rt.SendRequestWithHeaders("GET", "/notadb/", "", reqHeaders)
+	require.Equal(t, "*", response.Header().Get("Access-Control-Allow-Origin"))
+	assertStatus(t, response, http.StatusUnauthorized)
+	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+
+	response = rt.SendUserRequestWithHeaders("GET", "/db/", "", reqHeaders, username, RestTesterDefaultUserPassword)
+	require.Equal(t, "http://example.org", response.Header().Get("Access-Control-Allow-Origin"))
+	assertStatus(t, response, http.StatusOK)
+
+}
+
+func TestCORSNoMux(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	reqHeaders := map[string]string{
+		"Origin": "http://example.com",
+	}
+	// this method doesn't exist
+	response := rt.SendRequestWithHeaders("GET", "/_notanendpoint/", "", reqHeaders)
+	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+	assertStatus(t, response, http.StatusNotFound)
+	require.Contains(t, response.Body.String(), "unknown URL")
+
+	// admin port shouldn't populate CORS
+	response = rt.SendAdminRequestWithHeaders("GET", "/_notanendpoint/", "", reqHeaders)
+	require.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+	assertStatus(t, response, http.StatusNotFound)
+	require.Contains(t, response.Body.String(), "unknown URL")
+
+	// this method doesn't exist
+	response = rt.SendRequestWithHeaders(http.MethodDelete, "/notadb/", "", reqHeaders)
+	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+	assertStatus(t, response, http.StatusMethodNotAllowed)
+	require.Equal(t, strconv.Itoa(rt.ServerContext().config.API.CORS.MaxAge), response.Header().Get("Access-Control-Max-Age"))
+	require.Equal(t, "GET, HEAD, POST, PUT", response.Header().Get("Access-Control-Allow-Methods"))
+
+	response = rt.SendAdminRequestWithHeaders(http.MethodDelete, "/_stats/", "", reqHeaders)
+	assertStatus(t, response, http.StatusMethodNotAllowed)
+	require.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+	require.Equal(t, "", response.Header().Get("Access-Control-Max-Age"))
+	require.Equal(t, "", response.Header().Get("Access-Control-Allow-Methods"))
+
+}
+
+func TestCORSUserNoAccess(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				CORS: &auth.CORSConfig{
+					Origin: []string{"http://couchbase.com"},
+				},
+			},
+		},
+	})
+	defer rt.Close()
+
+	const alice = "alice"
+	response := rt.SendAdminRequest(http.MethodPut,
+		"/"+rt.GetDatabase().Name+"/_user/"+alice,
+		`{"name": "`+alice+`", "password": "`+RestTesterDefaultUserPassword+`"}`)
+
+	for _, endpoint := range []string{"/db/", "/notadb/"} {
+		t.Run(endpoint, func(t *testing.T) {
+			reqHeaders := map[string]string{
+				"Origin": "http://couchbase.com",
+			}
+			response = rt.SendRequestWithHeaders(http.MethodGet, endpoint, "", reqHeaders)
+			assertStatus(t, response, http.StatusUnauthorized)
+			require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+			assert.Equal(t, "*", response.Header().Get("Access-Control-Allow-Origin"))
+		})
+	}
+}
+
+func TestCORSOriginPerDatabase(t *testing.T) {
+	// Override the default (example.com) CORS configuration in the DbConfig for /db:
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				CORS: &auth.CORSConfig{
+					Origin:      []string{"http://couchbase.com", "http://staging.couchbase.com"},
+					LoginOrigin: []string{"http://couchbase.com"},
+					Headers:     []string{},
+					MaxAge:      1728000,
+				},
+			},
+		},
+		guestEnabled: true,
+	})
+	defer rt.Close()
+
+	testCases := []struct {
+		name           string
+		endpoint       string
+		origin         string
+		headerResponse string
+		responseCode   int
+	}{
+		{
+			name:           "CORS origin allowed couchbase",
+			endpoint:       "/db/",
+			origin:         "http://couchbase.com",
+			headerResponse: "http://couchbase.com",
+			responseCode:   http.StatusOK,
+		},
+		{
+			name:           "CORS origin allowed example.com",
+			endpoint:       "/db/",
+			origin:         "http://example.com",
+			headerResponse: "",
+			responseCode:   http.StatusOK,
+		},
+		{
+			name:           "not allowed domain",
+			endpoint:       "/db/",
+			origin:         "http://hack0r.com",
+			headerResponse: "",
+			responseCode:   http.StatusOK,
+		},
+		{
+			name:           "root url allow hack0r",
+			endpoint:       "/",
+			origin:         "http://hack0r.com",
+			headerResponse: "*",
+			responseCode:   http.StatusOK,
+		},
+		{
+			name:           "root url allow couchbase",
+			endpoint:       "/",
+			origin:         "http://couchbase.com",
+			headerResponse: "*",
+			responseCode:   http.StatusOK,
+		},
+		{
+			name:           "root url allow example.com",
+			endpoint:       "/",
+			origin:         "http://example.com",
+			headerResponse: "http://example.com",
+			responseCode:   http.StatusOK,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			reqHeaders := map[string]string{
+				"Origin": test.origin,
+			}
+			response := rt.SendRequestWithHeaders(http.MethodGet, test.endpoint, "", reqHeaders)
+			require.Equal(t, test.responseCode, response.Code)
+			require.Equal(t, test.headerResponse, response.Header().Get("Access-Control-Allow-Origin"))
+
+		})
+	}
+}
+
+func TestCORSValidation(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		persistentConfig: true,
+	})
+	defer rt.Close()
+
+	// CORS is set to http://example.com by RestTester ServerContext
+	dbName := "corsdb"
+	dbConfig := rt.NewDbConfig()
+	dbConfig.CORS = &auth.CORSConfig{
+		MaxAge: 1000,
+	}
+	resp, err := rt.CreateDatabase(dbName, dbConfig)
+	require.NoError(t, err)
+	// walrus doesn't set ServerContext.persistentConfig so we miss some validation
+	if base.UnitTestUrlIsWalrus() {
+		assertStatus(t, resp, http.StatusCreated)
+	} else {
+		assertStatus(t, resp, http.StatusBadRequest)
+		require.Contains(t, resp.Body.String(), "max_age")
+		nonCORSDbConfig := rt.NewDbConfig()
+		resp, err := rt.CreateDatabase(dbName, nonCORSDbConfig)
+		require.NoError(t, err)
+		assertStatus(t, resp, http.StatusCreated)
+	}
+	resp, err = rt.UpsertDbConfig(dbName, dbConfig)
+	require.NoError(t, err)
+	assertStatus(t, resp, http.StatusBadRequest)
+	require.Contains(t, resp.Body.String(), "max_age")
+
+	resp, err = rt.ReplaceDbConfig(dbName, dbConfig)
+	require.NoError(t, err)
+	assertStatus(t, resp, http.StatusBadRequest)
+	require.Contains(t, resp.Body.String(), "max_age")
+
+	// make sure you are allowed to set CORS values that aren't max_age
+	originCORSDbConfig := rt.NewDbConfig()
+	originCORSDbConfig.CORS = &auth.CORSConfig{
+		Origin: []string{"http://example.com"},
+	}
+
+	resp, err = rt.UpsertDbConfig(dbName, originCORSDbConfig)
+	require.NoError(t, err)
+	assertStatus(t, resp, http.StatusCreated)
+
+	resp, err = rt.ReplaceDbConfig(dbName, originCORSDbConfig)
+	require.NoError(t, err)
+	assertStatus(t, resp, http.StatusCreated)
+
+}

--- a/rest/facebook.go
+++ b/rest/facebook.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 )
 
@@ -28,7 +29,8 @@ func (h *handler) handleFacebookPOST() error {
 	// CORS not allowed for login #115 #762
 	originHeader := h.rq.Header["Origin"]
 	if len(originHeader) > 0 {
-		matched := matchedOrigin(h.server.config.API.CORS.LoginOrigin, originHeader)
+		matched := auth.MatchedOrigin(h.server.config.API.CORS.LoginOrigin, originHeader)
+
 		if matched == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
 		}

--- a/rest/google.go
+++ b/rest/google.go
@@ -13,6 +13,7 @@ package rest
 import (
 	"net/http"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 )
 
@@ -30,7 +31,7 @@ func (h *handler) handleGooglePOST() error {
 	// CORS not allowed for login #115 #762
 	originHeader := h.rq.Header["Origin"]
 	if len(originHeader) > 0 {
-		matched := matchedOrigin(h.server.config.API.CORS.LoginOrigin, originHeader)
+		matched := auth.MatchedOrigin(h.server.config.API.CORS.LoginOrigin, originHeader)
 		if matched == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -515,6 +515,12 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config DatabaseConfig, useE
 		return nil, err
 	}
 
+	if config.CORS != nil {
+		dbcontext.CORS = config.DbConfig.CORS
+	} else {
+		dbcontext.CORS = sc.config.API.CORS
+	}
+
 	if config.RevsLimit != nil {
 		dbcontext.RevsLimit = *config.RevsLimit
 		if dbcontext.AllowConflicts() {

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -21,8 +21,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/couchbase/gocbcore/v10/connstr"
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
+
+	"github.com/couchbase/gocbcore/v10/connstr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -112,7 +114,7 @@ func TestAllDatabaseNames(t *testing.T) {
 
 	serverConfig := &StartupConfig{
 		Bootstrap: BootstrapConfig{UseTLSServer: base.BoolPtr(base.ServerIsTLS(base.UnitTestUrl())), ServerTLSSkipVerify: base.BoolPtr(base.TestTLSSkipVerify())},
-		API:       APIConfig{CORS: &CORSConfig{}, AdminInterface: DefaultAdminInterface}}
+		API:       APIConfig{CORS: &auth.CORSConfig{}, AdminInterface: DefaultAdminInterface}}
 	serverContext := NewServerContext(serverConfig, false)
 	defer serverContext.Close()
 
@@ -153,7 +155,7 @@ func TestAllDatabaseNames(t *testing.T) {
 }
 
 func TestGetOrAddDatabaseFromConfig(t *testing.T) {
-	serverConfig := &StartupConfig{API: APIConfig{CORS: &CORSConfig{}, AdminInterface: DefaultAdminInterface}}
+	serverConfig := &StartupConfig{API: APIConfig{CORS: &auth.CORSConfig{}, AdminInterface: DefaultAdminInterface}}
 	serverContext := NewServerContext(serverConfig, false)
 	defer serverContext.Close()
 

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -41,7 +41,7 @@ func (h *handler) handleSessionPOST() error {
 	if len(originHeader) > 0 {
 		matched := ""
 		if h.server.config.API.CORS != nil {
-			matched = matchedOrigin(h.server.config.API.CORS.LoginOrigin, originHeader)
+			matched = auth.MatchedOrigin(h.server.config.API.CORS.LoginOrigin, originHeader)
 		}
 		if matched == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
@@ -97,7 +97,7 @@ func (h *handler) handleSessionDELETE() error {
 	if len(originHeader) > 0 {
 		matched := ""
 		if h.server.config.API.CORS != nil {
-			matched = matchedOrigin(h.server.config.API.CORS.LoginOrigin, originHeader)
+			matched = auth.MatchedOrigin(h.server.config.API.CORS.LoginOrigin, originHeader)
 		}
 		if matched == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")


### PR DESCRIPTION
* Don't set db headers unless we auth to DB
* Disallow setting max_age on database

backport of https://github.com/couchbase/sync_gateway/commit/a5cd3b0728fe80a3f533f738dee3178a4ee87828

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-go1.16.15/44/ (passes except for design doc tests unrelated)
