### PR TITLE
Feature/v8 build tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ on:
     branches:
       - 'master'
       - 'release/*'
+      - 'feature*'
 
 jobs:
   build:
@@ -87,6 +88,38 @@ jobs:
         uses: guyarb/golang-test-annotations@v0.6.0
         with:
           test-results: test.json
+  test-v8:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            name: macos
+          - os: windows-latest
+            name: windows
+          - os: ubuntu-latest
+            name: ubuntu
+    env:
+      GOPRIVATE: github.com/couchbaselabs
+      MallocNanoZone: 0
+    name: test v8 (${{ matrix.name }})
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.20.3
+      - uses: actions/checkout@v3
+      - name: Build
+        run: go build -tags cb_sg_v8 -v "./..."
+      - name: Run Tests
+        run: go test -tags cb_sg_v8 -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+        shell: bash
+      - name: Annotate Failures
+        if: always()
+        uses: guyarb/golang-test-annotations@v0.6.0
+        with:
+          test-results: test.json
+
 
   test-race:
     runs-on: ubuntu-latest

--- a/db/database.go
+++ b/db/database.go
@@ -81,9 +81,6 @@ const (
 // completion of all background tasks and background managers before the server is stopped.
 const BGTCompletionMaxWait = 30 * time.Second
 
-// The default JavaScript engine if not otherwise specified in the DatabaseContextOptions.
-const DefaultJavaScriptEngine = "V8" // Can be "Otto" or "V8"
-
 // Max number of JavaScript interpreter instances to create (per database)
 const MaxJavaScriptVMs = 8
 

--- a/db/database_no_v8.go
+++ b/db/database_no_v8.go
@@ -6,7 +6,7 @@
 // software will be governed by the Apache License, Version 2.0, included in
 // the file licenses/APL2.txt.
 
-// -build cb_sg_v8
+//go:build !cb_sg_v8
 
 package db
 

--- a/db/database_no_v8.go
+++ b/db/database_no_v8.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 // -build cb_sg_v8
 
 package db

--- a/db/database_no_v8.go
+++ b/db/database_no_v8.go
@@ -1,0 +1,6 @@
+// -build cb_sg_v8
+
+package db
+
+// The default JavaScript engine if not otherwise specified in the DatabaseContextOptions.
+const DefaultJavaScriptEngine = "Otto" // Can be "Otto" or "V8"

--- a/db/database_v8.go
+++ b/db/database_v8.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 //go:build cb_sg_v8
 // +build cb_sg_v8
 

--- a/db/database_v8.go
+++ b/db/database_v8.go
@@ -7,7 +7,6 @@
 // the file licenses/APL2.txt.
 
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 package db
 

--- a/db/database_v8.go
+++ b/db/database_v8.go
@@ -1,0 +1,7 @@
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
+package db
+
+// The default JavaScript engine if not otherwise specified in the DatabaseContextOptions.
+const DefaultJavaScriptEngine = "V8" // Can be "Otto" or "V8"

--- a/db/functions/concurrent_test.go
+++ b/db/functions/concurrent_test.go
@@ -1,3 +1,6 @@
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
 /*
 Copyright 2022-Present Couchbase, Inc.
 

--- a/db/functions/concurrent_test.go
+++ b/db/functions/concurrent_test.go
@@ -1,5 +1,4 @@
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 /*
 Copyright 2022-Present Couchbase, Inc.

--- a/db/functions/evaluator.go
+++ b/db/functions/evaluator.go
@@ -1,3 +1,6 @@
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
 /*
 Copyright 2022-Present Couchbase, Inc.
 
@@ -115,13 +118,6 @@ type evaluatorDelegate interface {
 	save(doc map[string]any, docID string, collection string, asAdmin bool) (saved bool, err error)
 	// Delete a document.
 	delete(docID string, revID string, collection string, asAdmin bool) (ok bool, err error)
-}
-
-// Name and capabilities of the current user. (Admin is represented by a nil `*userCredentials`.)
-type userCredentials struct {
-	Name     string
-	Roles    []string
-	Channels []string
 }
 
 // Returns an evaluator for use with a Service.

--- a/db/functions/evaluator.go
+++ b/db/functions/evaluator.go
@@ -1,5 +1,4 @@
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 /*
 Copyright 2022-Present Couchbase, Inc.

--- a/db/functions/evaluator_test.go
+++ b/db/functions/evaluator_test.go
@@ -1,3 +1,6 @@
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
 /*
 Copyright 2022-Present Couchbase, Inc.
 

--- a/db/functions/evaluator_test.go
+++ b/db/functions/evaluator_test.go
@@ -1,5 +1,4 @@
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 /*
 Copyright 2022-Present Couchbase, Inc.

--- a/db/functions/function.go
+++ b/db/functions/function.go
@@ -1,5 +1,4 @@
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 /*
 Copyright 2022-Present Couchbase, Inc.

--- a/db/functions/function.go
+++ b/db/functions/function.go
@@ -1,3 +1,6 @@
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
 /*
 Copyright 2022-Present Couchbase, Inc.
 
@@ -21,59 +24,6 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/js"
 )
-
-//////// CONFIGURATION TYPES:
-
-// Combines functions & GraphQL configuration. Implements db.IFunctionsAndGraphQLConfig.
-type Config struct {
-	Functions *FunctionsConfig
-	GraphQL   *GraphQLConfig
-}
-
-// Top level user-function config object: the map of names to queries.
-type FunctionsConfig struct {
-	Definitions      FunctionsDefs `json:"definitions"`                  // The function definitions
-	MaxFunctionCount *int          `json:"max_function_count,omitempty"` // Maximum number of functions
-	MaxCodeSize      *int          `json:"max_code_size,omitempty"`      // Maximum length (in bytes) of a function's code
-	MaxRequestSize   *int          `json:"max_request_size,omitempty"`   // Maximum size of the JSON-encoded function arguments
-}
-
-type FunctionsDefs = map[string]*FunctionConfig
-
-// Defines a JavaScript or N1QL function that a client can invoke by name.
-// (Its name is the key in the FunctionsDefs.)
-type FunctionConfig struct {
-	Type     string   `json:"type"`
-	Code     string   `json:"code"`               // Javascript function or N1QL 'SELECT'
-	Args     []string `json:"args,omitempty"`     // Names of parameters/arguments
-	Mutating bool     `json:"mutating,omitempty"` // Allowed to modify database?
-	Allow    *Allow   `json:"allow,omitempty"`    // Permissions (admin-only if nil)
-}
-
-// Permissions for a function
-type Allow struct {
-	Channels []string `json:"channels,omitempty"` // Names of channel(s) that grant access
-	Roles    []string `json:"roles,omitempty"`    // Names of role(s) that have access
-	Users    base.Set `json:"users,omitempty"`    // Names of user(s) that have access
-}
-
-// Configuration for GraphQL.
-type GraphQLConfig struct {
-	Schema           *string         `json:"schema,omitempty"`             // Schema in SDL syntax
-	SchemaFile       *string         `json:"schemaFile,omitempty"`         // Path of schema file
-	Resolvers        GraphQLTypesMap `json:"resolvers"`                    // Defines query/mutation code
-	Subgraph         bool            `json:"subgraph,omitempty"`           // Enable Apollo Subgraph support
-	MaxSchemaSize    *int            `json:"max_schema_size,omitempty"`    // Maximum length (in bytes) of GraphQL schema
-	MaxResolverCount *int            `json:"max_resolver_count,omitempty"` // Maximum number of GraphQL resolvers
-	MaxCodeSize      *int            `json:"max_code_size,omitempty"`      // Maximum length (in bytes) of a function's code
-	MaxRequestSize   *int            `json:"max_request_size,omitempty"`   // Maximum size of the encoded query & arguments
-}
-
-// Maps GraphQL type names (incl. "Query") to their resolvers.
-type GraphQLTypesMap map[string]GraphQLResolverConfig
-
-// Maps GraphQL field names to the resolvers that implement them.
-type GraphQLResolverConfig map[string]FunctionConfig
 
 //////// INITIALIZATION:
 

--- a/db/functions/function_base.go
+++ b/db/functions/function_base.go
@@ -1,0 +1,56 @@
+package functions
+
+import "github.com/couchbase/sync_gateway/base"
+
+// Combines functions & GraphQL configuration. Implements db.IFunctionsAndGraphQLConfig.
+type Config struct {
+	Functions *FunctionsConfig
+	GraphQL   *GraphQLConfig
+}
+
+// Top level user-function config object: the map of names to queries.
+type FunctionsConfig struct {
+	Definitions      FunctionsDefs `json:"definitions"`                  // The function definitions
+	MaxFunctionCount *int          `json:"max_function_count,omitempty"` // Maximum number of functions
+	MaxCodeSize      *int          `json:"max_code_size,omitempty"`      // Maximum length (in bytes) of a function's code
+	MaxRequestSize   *int          `json:"max_request_size,omitempty"`   // Maximum size of the JSON-encoded function arguments
+}
+
+type FunctionsDefs = map[string]*FunctionConfig
+
+// Defines a JavaScript or N1QL function that a client can invoke by name.
+// (Its name is the key in the FunctionsDefs.)
+type FunctionConfig struct {
+	Type     string   `json:"type"`
+	Code     string   `json:"code"`               // Javascript function or N1QL 'SELECT'
+	Args     []string `json:"args,omitempty"`     // Names of parameters/arguments
+	Mutating bool     `json:"mutating,omitempty"` // Allowed to modify database?
+	Allow    *Allow   `json:"allow,omitempty"`    // Permissions (admin-only if nil)
+}
+
+// Permissions for a function
+type Allow struct {
+	Channels []string `json:"channels,omitempty"` // Names of channel(s) that grant access
+	Roles    []string `json:"roles,omitempty"`    // Names of role(s) that have access
+	Users    base.Set `json:"users,omitempty"`    // Names of user(s) that have access
+}
+
+// Configuration for GraphQL.
+type GraphQLConfig struct {
+	Schema           *string         `json:"schema,omitempty"`             // Schema in SDL syntax
+	SchemaFile       *string         `json:"schemaFile,omitempty"`         // Path of schema file
+	Resolvers        GraphQLTypesMap `json:"resolvers"`                    // Defines query/mutation code
+	Subgraph         bool            `json:"subgraph,omitempty"`           // Enable Apollo Subgraph support
+	MaxSchemaSize    *int            `json:"max_schema_size,omitempty"`    // Maximum length (in bytes) of GraphQL schema
+	MaxResolverCount *int            `json:"max_resolver_count,omitempty"` // Maximum number of GraphQL resolvers
+	MaxCodeSize      *int            `json:"max_code_size,omitempty"`      // Maximum length (in bytes) of a function's code
+	MaxRequestSize   *int            `json:"max_request_size,omitempty"`   // Maximum size of the encoded query & arguments
+}
+
+//////// CONFIGURATION TYPES:
+
+// Maps GraphQL type names (incl. "Query") to their resolvers.
+type GraphQLTypesMap map[string]GraphQLResolverConfig
+
+// Maps GraphQL field names to the resolvers that implement them.
+type GraphQLResolverConfig map[string]FunctionConfig

--- a/db/functions/function_base.go
+++ b/db/functions/function_base.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package functions
 
 import "github.com/couchbase/sync_gateway/base"

--- a/db/functions/function_no_v8.go
+++ b/db/functions/function_no_v8.go
@@ -1,0 +1,27 @@
+package functions
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/js"
+)
+
+// -build cb_sg_v8
+
+// Validates a FunctionsConfig & GraphQLConfig.
+func ValidateFunctions(ctx context.Context, vm js.ServiceHost, fnConfig *FunctionsConfig, gqConfig *GraphQLConfig) error {
+	if fnConfig != nil || gqConfig != nil {
+		return fmt.Errorf("ValidateFunctions is not supported in non v8 build")
+	}
+	return nil
+}
+
+func (fnc *Config) Compile(vms *js.VMPool) (*db.UserFunctions, db.GraphQL, error) {
+	return nil, nil, fmt.Errorf("functions.Config.Compile is not supported in non v8 build")
+}
+
+func (fnc *Config) N1QLQueryNames() []string {
+	return nil
+}

--- a/db/functions/function_no_v8.go
+++ b/db/functions/function_no_v8.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package functions
 
 import (

--- a/db/functions/function_no_v8.go
+++ b/db/functions/function_no_v8.go
@@ -6,6 +6,8 @@
 // software will be governed by the Apache License, Version 2.0, included in
 // the file licenses/APL2.txt.
 
+//go:build !cb_sg_v8
+
 package functions
 
 import (
@@ -15,8 +17,6 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/js"
 )
-
-// -build cb_sg_v8
 
 // Validates a FunctionsConfig & GraphQLConfig.
 func ValidateFunctions(ctx context.Context, vm js.ServiceHost, fnConfig *FunctionsConfig, gqConfig *GraphQLConfig) error {

--- a/db/functions/function_test.go
+++ b/db/functions/function_test.go
@@ -1,3 +1,6 @@
+//go:build cb_sg_enterprise
+// +build cb_sg_enterprise
+
 /*
 Copyright 2022-Present Couchbase, Inc.
 

--- a/db/functions/function_test.go
+++ b/db/functions/function_test.go
@@ -1,5 +1,4 @@
-//go:build cb_sg_enterprise
-// +build cb_sg_enterprise
+//go:build cb_sg_v8
 
 /*
 Copyright 2022-Present Couchbase, Inc.

--- a/db/functions/graphql_subgraph_test.go
+++ b/db/functions/graphql_subgraph_test.go
@@ -1,3 +1,6 @@
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
 /*
 Copyright 2022-Present Couchbase, Inc.
 

--- a/db/functions/graphql_subgraph_test.go
+++ b/db/functions/graphql_subgraph_test.go
@@ -1,5 +1,4 @@
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 /*
 Copyright 2022-Present Couchbase, Inc.

--- a/db/functions/graphql_test.go
+++ b/db/functions/graphql_test.go
@@ -1,3 +1,6 @@
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
 /*
 Copyright 2020-Present Couchbase, Inc.
 

--- a/db/functions/graphql_test.go
+++ b/db/functions/graphql_test.go
@@ -1,5 +1,4 @@
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 /*
 Copyright 2020-Present Couchbase, Inc.

--- a/db/functions/n1ql_function_test.go
+++ b/db/functions/n1ql_function_test.go
@@ -1,3 +1,6 @@
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
 /*
 Copyright 2020-Present Couchbase, Inc.
 

--- a/db/functions/n1ql_function_test.go
+++ b/db/functions/n1ql_function_test.go
@@ -1,5 +1,4 @@
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 /*
 Copyright 2020-Present Couchbase, Inc.

--- a/db/functions/user.go
+++ b/db/functions/user.go
@@ -1,0 +1,8 @@
+package functions
+
+// Name and capabilities of the current user. (Admin is represented by a nil `*userCredentials`.)
+type userCredentials struct {
+	Name     string
+	Roles    []string
+	Channels []string
+}

--- a/db/functions/user.go
+++ b/db/functions/user.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package functions
 
 // Name and capabilities of the current user. (Admin is represented by a nil `*userCredentials`.)

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -1,3 +1,6 @@
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
 /*
 Copyright 2022-Present Couchbase, Inc.
 

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -1,5 +1,4 @@
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 /*
 Copyright 2022-Present Couchbase, Inc.

--- a/js/service.go
+++ b/js/service.go
@@ -37,6 +37,15 @@ type ServiceHost interface {
 	withRunner(*Service, func(Runner) (any, error)) (any, error)
 }
 
+// A factory/initialization function for Services that need to add JS globals or callbacks or
+// otherwise extend their runtime environment. They do this by operating on its Template.
+//
+// The function's parameter is a BasicTemplate that doesn't have a script yet.
+// The function MUST call its SetScript method.
+// The function may return the Template it was given, or it may instantiate its own struct that
+// implements Template (which presumably includes a pointer to the BasicTemplate) and return that.
+type TemplateFactory func(base *V8BasicTemplate) (V8Template, error)
+
 // Creates a new Service in a ServiceHost (a VM or VMPool.)
 // The name is primarily for logging; it does not need to be unique.
 // The source code should be of the form `function(arg1,arg2…) {…body…; return result;}`.
@@ -60,15 +69,6 @@ func NewCustomService(host ServiceHost, name string, factory TemplateFactory) *S
 	service.v8Init = factory
 	return service
 }
-
-// A factory/initialization function for Services that need to add JS globals or callbacks or
-// otherwise extend their runtime environment. They do this by operating on its Template.
-//
-// The function's parameter is a BasicTemplate that doesn't have a script yet.
-// The function MUST call its SetScript method.
-// The function may return the Template it was given, or it may instantiate its own struct that
-// implements Template (which presumably includes a pointer to the BasicTemplate) and return that.
-type TemplateFactory func(base *V8BasicTemplate) (V8Template, error)
 
 // The Service's name, given when it was created.
 func (service *Service) Name() string { return service.name }

--- a/js/service_no_v8.go
+++ b/js/service_no_v8.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 // -build cb_sg_v8
 
 package js

--- a/js/service_no_v8.go
+++ b/js/service_no_v8.go
@@ -1,0 +1,9 @@
+// -build cb_sg_v8
+
+package js
+
+type V8BasicTemplate struct {
+}
+
+type V8Template struct {
+}

--- a/js/service_no_v8.go
+++ b/js/service_no_v8.go
@@ -6,7 +6,7 @@
 // software will be governed by the Apache License, Version 2.0, included in
 // the file licenses/APL2.txt.
 
-// -build cb_sg_v8
+//go:build !cb_sg_v8
 
 package js
 

--- a/js/string.go
+++ b/js/string.go
@@ -1,0 +1,5 @@
+package js
+
+// A string type that v8Runner.NewValue will treat specially, by parsing it as JSON and converting
+// it to a JavaScript object.
+type JSONString string

--- a/js/string.go
+++ b/js/string.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package js
 
 // A string type that v8Runner.NewValue will treat specially, by parsing it as JSON and converting

--- a/js/test_utils.go
+++ b/js/test_utils.go
@@ -14,8 +14,7 @@ import "testing"
 
 // Unit-test utility. Calls the function with each supported type of VM (Otto and V8).
 func TestWithVMs(t *testing.T, fn func(t *testing.T, vm VM)) {
-	engines := []*Engine{V8, Otto}
-	for _, engine := range engines {
+	for _, engine := range testEngines {
 		t.Run(engine.String(), func(t *testing.T) {
 			vm := engine.NewVM()
 			defer vm.Close()
@@ -27,8 +26,7 @@ func TestWithVMs(t *testing.T, fn func(t *testing.T, vm VM)) {
 // Unit-test utility. Calls the function with a VMPool of each supported type (Otto and V8).
 // The behavior will be basically identical to TestWithVMs unless your test is multi-threaded.
 func TestWithVMPools(t *testing.T, maxVMs int, fn func(t *testing.T, pool *VMPool)) {
-	engines := []*Engine{V8, Otto}
-	for _, engine := range engines {
+	for _, engine := range testEngines {
 		t.Run(engine.String(), func(t *testing.T) {
 			pool := NewVMPool(engine, maxVMs)
 			defer pool.Close()

--- a/js/test_utils_no_v8.go
+++ b/js/test_utils_no_v8.go
@@ -1,0 +1,4 @@
+package js
+
+// -build cb_sg_v8
+var testEngines = []*Engine{Otto}

--- a/js/test_utils_no_v8.go
+++ b/js/test_utils_no_v8.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package js
 
 // -build cb_sg_v8

--- a/js/test_utils_no_v8.go
+++ b/js/test_utils_no_v8.go
@@ -6,7 +6,8 @@
 // software will be governed by the Apache License, Version 2.0, included in
 // the file licenses/APL2.txt.
 
+//go:build !cb_sg_v8
+
 package js
 
-// -build cb_sg_v8
 var testEngines = []*Engine{Otto}

--- a/js/test_utils_v8.go
+++ b/js/test_utils_v8.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 //go:build cb_sg_v8
 // +build cb_sg_v8
 

--- a/js/test_utils_v8.go
+++ b/js/test_utils_v8.go
@@ -1,0 +1,6 @@
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
+package js
+
+var testEngines = []*Engine{V8, Otto}

--- a/js/test_utils_v8.go
+++ b/js/test_utils_v8.go
@@ -7,7 +7,6 @@
 // the file licenses/APL2.txt.
 
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 package js
 

--- a/js/underscore-umd-min.js
+++ b/js/underscore-umd-min.js
@@ -1,3 +1,13 @@
+/**
+ * Copyright 2023-Present Couchbase, Inc.
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+ * in that file, in accordance with the Business Source License, use of this
+ * software will be governed by the Apache License, Version 2.0, included in
+ * the file licenses/APL2.txt.
+ */
+
 !function(n,r){"object"==typeof exports&&"undefined"!=typeof module?module.exports=r():"function"==typeof define&&define.amd?define("underscore",r):(n="undefined"!=typeof globalThis?globalThis:n||self,function(){var t=n._,e=n._=r();e.noConflict=function(){return n._=t,e}}())}(this,(function(){
 //     Underscore.js 1.13.6
 //     https://underscorejs.org

--- a/js/underscore-umd-min.js
+++ b/js/underscore-umd-min.js
@@ -1,13 +1,3 @@
-/**
- * Copyright 2023-Present Couchbase, Inc.
- *
- * Use of this software is governed by the Business Source License included
- * in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
- * in that file, in accordance with the Business Source License, use of this
- * software will be governed by the Apache License, Version 2.0, included in
- * the file licenses/APL2.txt.
- */
-
 !function(n,r){"object"==typeof exports&&"undefined"!=typeof module?module.exports=r():"function"==typeof define&&define.amd?define("underscore",r):(n="undefined"!=typeof globalThis?globalThis:n||self,function(){var t=n._,e=n._=r();e.noConflict=function(){return n._=t,e}}())}(this,(function(){
 //     Underscore.js 1.13.6
 //     https://underscorejs.org

--- a/js/underscore-umd.js
+++ b/js/underscore-umd.js
@@ -1,3 +1,13 @@
+/**
+ * Copyright 2023-Present Couchbase, Inc.
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+ * in that file, in accordance with the Business Source License, use of this
+ * software will be governed by the Apache License, Version 2.0, included in
+ * the file licenses/APL2.txt.
+ */
+
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
   typeof define === 'function' && define.amd ? define('underscore', factory) :

--- a/js/underscore-umd.js
+++ b/js/underscore-umd.js
@@ -1,13 +1,3 @@
-/**
- * Copyright 2023-Present Couchbase, Inc.
- *
- * Use of this software is governed by the Business Source License included
- * in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
- * in that file, in accordance with the Business Source License, use of this
- * software will be governed by the Apache License, Version 2.0, included in
- * the file licenses/APL2.txt.
- */
-
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
   typeof define === 'function' && define.amd ? define('underscore', factory) :

--- a/js/v8_runner.go
+++ b/js/v8_runner.go
@@ -1,3 +1,6 @@
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
 /*
 Copyright 2022-Present Couchbase, Inc.
 
@@ -231,10 +234,6 @@ func (r *V8Runner) NewValue(val any) (v8Val *v8.Value, err error) {
 	}
 	return v8Val, err
 }
-
-// A string type that v8Runner.NewValue will treat specially, by parsing it as JSON and converting
-// it to a JavaScript object.
-type JSONString string
 
 // Creates a JavaScript number value.
 func (r *V8Runner) NewInt(i int) *v8.Value { return mustSucceed(r.ctx.NewValue(i)) }

--- a/js/v8_runner.go
+++ b/js/v8_runner.go
@@ -1,5 +1,4 @@
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 /*
 Copyright 2022-Present Couchbase, Inc.

--- a/js/v8_template.go
+++ b/js/v8_template.go
@@ -1,3 +1,6 @@
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
 /*
 Copyright 2022-Present Couchbase, Inc.
 

--- a/js/v8_template.go
+++ b/js/v8_template.go
@@ -1,5 +1,4 @@
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 /*
 Copyright 2022-Present Couchbase, Inc.

--- a/js/v8_utils.go
+++ b/js/v8_utils.go
@@ -1,3 +1,6 @@
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
 /*
 Copyright 2022-Present Couchbase, Inc.
 

--- a/js/v8_utils.go
+++ b/js/v8_utils.go
@@ -1,5 +1,4 @@
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 /*
 Copyright 2022-Present Couchbase, Inc.

--- a/js/v8_vm.go
+++ b/js/v8_vm.go
@@ -1,3 +1,6 @@
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
 /*
 Copyright 2022-Present Couchbase, Inc.
 
@@ -47,6 +50,19 @@ var V8MaxHeap uint64 = 32 * 1024 * 1024
 var V8StackSizeLimit = 400 * 1024
 
 const v8VMName = "V8"
+
+// Returns the Engine with the given name, else nil.
+// Valid names are "V8" and "Otto", which map to the instances `V8` and `Otto`.
+func EngineNamed(name string) *Engine {
+	switch name {
+	case v8VMName:
+		return V8
+	case ottoVMName:
+		return Otto
+	default:
+		return nil
+	}
+}
 
 // A VMType for instantiating V8-based VMs and VMPools.
 var V8 = &Engine{

--- a/js/v8_vm.go
+++ b/js/v8_vm.go
@@ -1,5 +1,4 @@
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 /*
 Copyright 2022-Present Couchbase, Inc.

--- a/js/vm.go
+++ b/js/vm.go
@@ -15,8 +15,6 @@ import (
 	"time"
 )
 
-const v8VMName = "V8"
-
 //////// ENGINE
 
 // An opaque object identifying a JavaScript engine (V8 or Otto)

--- a/js/vm.go
+++ b/js/vm.go
@@ -15,6 +15,8 @@ import (
 	"time"
 )
 
+const v8VMName = "V8"
+
 //////// ENGINE
 
 // An opaque object identifying a JavaScript engine (V8 or Otto)
@@ -22,19 +24,6 @@ type Engine struct {
 	name            string
 	languageVersion int
 	factory         func(*Engine, *servicesConfiguration) VM
-}
-
-// Returns the Engine with the given name, else nil.
-// Valid names are "V8" and "Otto", which map to the instances `V8` and `Otto`.
-func EngineNamed(name string) *Engine {
-	switch name {
-	case v8VMName:
-		return V8
-	case ottoVMName:
-		return Otto
-	default:
-		return nil
-	}
 }
 
 // The name identifying this engine ("V8" or "Otto")

--- a/js/vm_otto_only.go
+++ b/js/vm_otto_only.go
@@ -1,0 +1,12 @@
+package js
+
+// Returns the Engine with the given name, else nil.
+// Valid names are "V8" and "Otto", which map to the instances `V8` and `Otto`.
+func EngineNamed(name string) *Engine {
+	switch name {
+	case ottoVMName:
+		return Otto
+	default:
+		return nil
+	}
+}

--- a/js/vm_otto_only.go
+++ b/js/vm_otto_only.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package js
 
 // Returns the Engine with the given name, else nil.

--- a/js/vm_otto_only.go
+++ b/js/vm_otto_only.go
@@ -6,6 +6,8 @@
 // software will be governed by the Apache License, Version 2.0, included in
 // the file licenses/APL2.txt.
 
+//go:build !cb_sg_v8
+
 package js
 
 // Returns the Engine with the given name, else nil.

--- a/js/vmpool_test.go
+++ b/js/vmpool_test.go
@@ -1,3 +1,6 @@
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
 /*
 Copyright 2022-Present Couchbase, Inc.
 

--- a/js/vmpool_test.go
+++ b/js/vmpool_test.go
@@ -1,5 +1,4 @@
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 /*
 Copyright 2022-Present Couchbase, Inc.

--- a/rest/functionsapitest/graphql_admin_test.go
+++ b/rest/functionsapitest/graphql_admin_test.go
@@ -7,7 +7,6 @@
 // the file licenses/APL2.txt.
 
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 package functionsapitest
 

--- a/rest/functionsapitest/graphql_admin_test.go
+++ b/rest/functionsapitest/graphql_admin_test.go
@@ -6,6 +6,9 @@
 // software will be governed by the Apache License, Version 2.0, included in
 // the file licenses/APL2.txt.
 
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
 package functionsapitest
 
 import (

--- a/rest/functionsapitest/graphql_queries_test.go
+++ b/rest/functionsapitest/graphql_queries_test.go
@@ -7,7 +7,6 @@
 //  the file licenses/APL2.txt.
 
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 package functionsapitest
 

--- a/rest/functionsapitest/graphql_queries_test.go
+++ b/rest/functionsapitest/graphql_queries_test.go
@@ -6,6 +6,9 @@
 //  software will be governed by the Apache License, Version 2.0, included in
 //  the file licenses/APL2.txt.
 
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
 package functionsapitest
 
 import (

--- a/rest/functionsapitest/main_test.go
+++ b/rest/functionsapitest/main_test.go
@@ -7,7 +7,7 @@ file, in accordance with the Business Source License, use of this software will
 be governed by the Apache License, Version 2.0, included in the file
 licenses/APL2.txt.
 */
-// -build cb_sg_v8
+// go:build cb_sg_v8
 
 package functionsapitest
 

--- a/rest/functionsapitest/main_test.go
+++ b/rest/functionsapitest/main_test.go
@@ -7,6 +7,7 @@ file, in accordance with the Business Source License, use of this software will
 be governed by the Apache License, Version 2.0, included in the file
 licenses/APL2.txt.
 */
+// -build cb_sg_v8
 
 package functionsapitest
 

--- a/rest/functionsapitest/user_functions_admin_test.go
+++ b/rest/functionsapitest/user_functions_admin_test.go
@@ -7,7 +7,6 @@
 //  the file licenses/APL2.txt.
 
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 package functionsapitest
 

--- a/rest/functionsapitest/user_functions_admin_test.go
+++ b/rest/functionsapitest/user_functions_admin_test.go
@@ -6,6 +6,9 @@
 //  software will be governed by the Apache License, Version 2.0, included in
 //  the file licenses/APL2.txt.
 
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
 package functionsapitest
 
 import (

--- a/rest/functionsapitest/user_functions_queries_test.go
+++ b/rest/functionsapitest/user_functions_queries_test.go
@@ -7,7 +7,6 @@
 //  the file licenses/APL2.txt.
 
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 package functionsapitest
 

--- a/rest/functionsapitest/user_functions_queries_test.go
+++ b/rest/functionsapitest/user_functions_queries_test.go
@@ -6,6 +6,9 @@
 //  software will be governed by the Apache License, Version 2.0, included in
 //  the file licenses/APL2.txt.
 
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
 package functionsapitest
 
 import (

--- a/rest/utilities_testing_functions_api_test.go
+++ b/rest/utilities_testing_functions_api_test.go
@@ -7,7 +7,6 @@
 // the file licenses/APL2.txt.
 
 //go:build cb_sg_v8
-// +build cb_sg_v8
 
 package rest
 

--- a/rest/utilities_testing_functions_api_test.go
+++ b/rest/utilities_testing_functions_api_test.go
@@ -6,6 +6,9 @@
 // software will be governed by the Apache License, Version 2.0, included in
 // the file licenses/APL2.txt.
 
+//go:build cb_sg_v8
+// +build cb_sg_v8
+
 package rest
 
 import (

--- a/test.sh
+++ b/test.sh
@@ -32,8 +32,12 @@ doTest () {
     buildTags=""
     if [ "$1" = "EE" ]; then
         buildTags="-tags cb_sg_enterprise"
+	if [ -n "${SG_V8:-}" ]; then
+		buildTags="${buildTags},cb_sg_v8"
+        fi
+    elif [ -n "${SG_V8:-}" ]; then
+	buildTags="-tags cb_sg_v8"
     fi
-
     EXTRA_FLAGS=""
     if [ "$SG_TEST_BACKING_STORE" == "Couchbase" ] || [ "$SG_TEST_BACKING_STORE" == "couchbase" ]; then
         ./test-integration-init.sh
@@ -64,6 +68,16 @@ doTest () {
 }
 
 for edition in "${build_editions[@]}"; do
-    echo "  Testing edition: ${edition}"
-    doTest $edition "$@"
+    if [[ -z "${SG_V8:-}" ]]; then
+        echo "  Testing edition: ${edition} without V8"
+    else
+        echo "  Testing edition: ${edition} with V8"
+    fi
+    (doTest $edition "$@")
+    if [[ -z "${SG_V8:-}" ]]; then
+        echo "  Testing edition: ${edition} with V8"
+        SG_V8=1
+        (doTest $edition "$@")
+        unset SG_V8
+    fi
 done


### PR DESCRIPTION
Add a build tag to enable v8 or otto only.

I'm trying to add this to jenkins automation, but when I run `go test -tags cb_sg_enterprise -tags
## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1722/
