### PR TITLE
remove spurious warnings

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -58,14 +58,12 @@ var _ Bucket = &TestBucket{}
 // DefaultDataStore is intentionally not implemented for TestBucket
 // DEPRECATED: Should use GetSingleDataStore
 func (b *TestBucket) DefaultDataStore() sgbucket.DataStore {
-	b.t.Logf("Tests directly using TestBucket should use GetSingleDataStore accessor!")
 	return b.Bucket.DefaultDataStore()
 }
 
 // NamedDataStore is intentionally not implemented for TestBucket
 // DEPRECATED: Should use GetNamedDataStore
 func (b *TestBucket) NamedDataStore(name sgbucket.DataStoreName) (sgbucket.DataStore, error) {
-	b.t.Logf("Tests directly using TestBucket should use GetNamedDataStore accessor!")
 	return b.Bucket.NamedDataStore(name)
 }
 


### PR DESCRIPTION
Because Bucket that is passed to newDatabaseContext is often a TestBucket in a test, every time you instianiate a Database you see this  error but you are not doing any unapproved activity.