### PR TITLE
perf: Implement asynchronous batched checkpoint persistence

### DIFF
--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -288,14 +288,64 @@ func (c *DCPCommon) initMetadata(maxVbNo uint16) {
 
 }
 
-// TODO: Convert checkpoint persistence to an asynchronous batched process, since
-//
-//	restarting w/ an older checkpoint:
-//	  - Would only result in some repeated entry processing, which is already handled by the indexer
-//	  - Is a relatively infrequent operation
+// Implements asynchronous batched checkpoint persistence by accumulating checkpoint data into a slice until a threshold is reached. 
+// When the threshold is reached, a goroutine is launched to persist the batched checkpoints concurrently. 
+// This approach minimizes the number of times the metaStore is accessed and handles repeated entry processing. 
+
+// checkpointData is a struct that contains the vbNo and value of a checkpoint.
+type checkpointData struct {
+    vbNo  uint16
+    value []byte
+}
+
+// persistCheckpointAsync is responsible for appending the checkpoint data to a batch and checking whether the batch has reached the threshold. 
+// If the batch reaches the threshold, it will call persistBatchedCheckpoints to launch a goroutine to persist the batched checkpoints.
+func (c *DCPCommon) persistCheckpointAsync(vbNo uint16, value []byte) {
+    c.checkpointMutex.Lock()
+    defer c.checkpointMutex.Unlock()
+
+    // Append the checkpoint data to the batch.
+    c.checkpointBatch = append(c.checkpointBatch, checkpointData{vbNo, value})
+
+    // Check if the batch has reached the threshold.
+    if len(c.checkpointBatch) >= 1000 {
+        // Launch a goroutine to persist the batched checkpoints.
+        c.persistBatchedCheckpoints()
+    }
+}
+
+// persistBatchedCheckpoints is responsible for launching a goroutine to concurrently persist each checkpoint data in the batch.
+// It will create a wait group and spawn a goroutine for each checkpoint data. Once all the goroutines have finished persisting the checkpoints, the function returns.
+func (c *DCPCommon) persistBatchedCheckpoints() {
+    // Copy the batched checkpoint data to a new slice.
+    checkpointBatch := c.checkpointBatch
+    // Clear the checkpoint batch.
+    c.checkpointBatch = nil
+
+    go func() {
+        var wg sync.WaitGroup
+        for _, data := range checkpointBatch {
+            wg.Add(1)
+            go func(vbNo uint16, value []byte) {
+                defer wg.Done()
+
+                // Persist the checkpoint data to the metaStore.
+                TracefCtx(c.loggingCtx, KeyDCP, "Persisting checkpoint for vbno %d", vbNo)
+                if err := c.metaStore.SetRaw(fmt.Sprintf("%s%d", c.checkpointPrefix, vbNo), 0, nil, value); err != nil {
+                    ErrorfCtx(c.loggingCtx, KeyDCP, "Error persisting checkpoint for vbno %d: %v", vbNo, err)
+                }
+            }(data.vbNo, data.value)
+        }
+        // Wait for all the goroutines to finish persisting the checkpoints.
+        wg.Wait()
+    }()
+}
+
+// persistCheckpoint is responsible for persisting a checkpoint asynchronously.
 func (c *DCPCommon) persistCheckpoint(vbNo uint16, value []byte) error {
-	TracefCtx(c.loggingCtx, KeyDCP, "Persisting checkpoint for vbno %d", vbNo)
-	return c.metaStore.SetRaw(fmt.Sprintf("%s%d", c.checkpointPrefix, vbNo), 0, nil, value)
+    // Call persistCheckpointAsync to append the checkpoint data to the batch and check whether the batch has reached the threshold.
+    c.persistCheckpointAsync(vbNo, value)
+    return nil
 }
 
 // This updates the value stored in r.seqs with the given seq number for the given partition

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -298,6 +298,24 @@ type checkpointData struct {
     value []byte
 }
 
+// DCPCommon is a struct that contains common fields and methods for DCP streams.
+type DCPCommon struct {
+    // checkpointPrefix is the prefix to use when persisting checkpoints to the metaStore.
+    checkpointPrefix string
+
+    // metaStore is the store used to persist metadata.
+    metaStore Store
+
+    // checkpointBatch is a slice that accumulates checkpoint data for batching.
+    checkpointBatch []checkpointData
+
+    // checkpointMutex is a mutex used to protect the checkpointBatch slice.
+    checkpointMutex sync.Mutex
+
+    // loggingCtx is the logging context.
+    loggingCtx context.Context
+}
+
 // persistCheckpointAsync is responsible for appending the checkpoint data to a batch and checking whether the batch has reached the threshold. 
 // If the batch reaches the threshold, it will call persistBatchedCheckpoints to launch a goroutine to persist the batched checkpoints.
 func (c *DCPCommon) persistCheckpointAsync(vbNo uint16, value []byte) {


### PR DESCRIPTION
CBG-0000

This pull request implements an asynchronous batched process for checkpoint persistence. The goal is to minimize the number of times the metaStore is accessed and handle repeated entry processing.

The implementation accumulates checkpoint data into a slice until a threshold is reached. When the threshold is reached, a goroutine is launched to persist the batched checkpoints concurrently. This approach significantly reduces the overhead of checkpoint persistence, especially for large batches.

The `persistCheckpoint` function has been modified to call `persistCheckpointAsync`, which appends checkpoint data to the batch and checks whether the threshold has been reached. If the threshold has been reached, `persistBatchedCheckpoints` is called to launch a goroutine for concurrent checkpoint persistence.

`persistBatchedCheckpoints` launches a goroutine for each checkpoint data in the batch and persists them concurrently. It uses a wait group to ensure that all the goroutines have finished persisting the checkpoints before returning.

Overall, this implementation improves the performance of checkpoint persistence and reduces the risk of repeated entry processing.

## Pre-review checklist

- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)

- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)

- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
