### PR TITLE
CBG-2873 retry on all stream end error types

### DIFF
--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -446,7 +446,7 @@ func (dc *DCPClient) openStream(vbID uint16, maxRetries uint32) error {
 			WarnfCtx(logCtx, "%s", err)
 			return err
 		case errors.Is(openStreamErr, errVbUUIDMismatch):
-			WarnfCtx(logCtx, "%s", openStreamErr)
+			WarnfCtx(logCtx, "Closing Stream for vbID: %d, %s", vbID, openStreamErr)
 			return openStreamErr
 		case errors.Is(openStreamErr, gocbcore.ErrShutdown):
 			WarnfCtx(logCtx, "Closing stream for vbID %d, agent has been shut down", vbID)
@@ -575,9 +575,9 @@ func (dc *DCPClient) onStreamEnd(e endStreamEvent) {
 	}
 
 	if errors.Is(e.err, gocbcore.ErrDCPStreamStateChanged) || errors.Is(e.err, gocbcore.ErrDCPStreamTooSlow) || errors.Is(e.err, gocbcore.ErrDCPStreamDisconnected) {
-		DebugfCtx(logCtx, KeyDCP, "Stream (vb:%d) ended with a known error: %w", e.vbID, e.err)
+		DebugfCtx(logCtx, KeyDCP, "Stream (vb:%d) ended with a known error, will reconnect. Reason: %s", e.vbID, e.err)
 	} else {
-		InfofCtx(logCtx, KeyDCP, "Stream (vb:%d) ended with an unknown error: %w", e.vbID, e.err)
+		InfofCtx(logCtx, KeyDCP, "Stream (vb:%d) ended with an unknown error, will reconnect. Reason: %s", e.vbID, e.err)
 	}
 	retries := infiniteOpenStreamRetries
 	if dc.oneShot {

--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -565,12 +565,10 @@ func (dc *DCPClient) onStreamEnd(e endStreamEvent) {
 
 	if errors.Is(e.err, gocbcore.ErrDCPStreamClosed) {
 		DebugfCtx(logCtx, KeyDCP, "Stream (vb:%d) closed by DCPClient", e.vbID)
+		dc.fatalError(fmt.Errorf("Stream (vb:%d) closed by DCPClient", e.vbID))
 		return
 	}
 
-	if errors.Is(e.err, gocbcore.ErrDCPStreamClosed) {
-		DebugfCtx(logCtx, KeyDCP, "Stream (vb:%d) closed by DCPClient", e.vbID)
-	}
 	if errors.Is(e.err, gocbcore.ErrDCPStreamStateChanged) || errors.Is(e.err, gocbcore.ErrDCPStreamTooSlow) || errors.Is(e.err, gocbcore.ErrDCPStreamDisconnected) {
 		DebugfCtx(logCtx, KeyDCP, "Stream (vb:%d) ended with a known error: %w", e.vbID, e.err)
 	} else {

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -627,7 +627,7 @@ func TestAttachmentDifferentVBUUIDsBetweenPhases(t *testing.T) {
 	vbUUIDs[0] = 1
 
 	_, err = attachmentCompactSweepPhase(ctx, dataStore, collectionID, testDB, t.Name(), vbUUIDs, false, terminator, &base.AtomicInt{})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "error opening stream for vb 0: VbUUID mismatch when failOnRollback set")
 }
 


### PR DESCRIPTION
## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1726/
