### PR TITLE
[3.0.7] CBG-2903: Cherry pick: CBG-2282: timeout/retry for gocbv2 bootstrap

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -77,7 +77,8 @@ func NewCouchbaseCluster(server, username, password,
 	clusterOptions := gocb.ClusterOptions{
 		Authenticator:  authenticatorConfig,
 		SecurityConfig: securityConfig,
-		RetryStrategy:  &goCBv2FailFastRetryStrategy{},
+		TimeoutsConfig: GoCBv2TimeoutsConfig(nil, nil),
+		RetryStrategy:  gocb.NewBestEffortRetryStrategy(nil),
 	}
 
 	var configPersistence ConfigPersistence

--- a/base/collection.go
+++ b/base/collection.go
@@ -87,16 +87,23 @@ func GetCouchbaseCollection(spec BucketSpec) (*Collection, error) {
 		return nil, err
 	}
 
-	return GetCollectionFromCluster(cluster, spec, 30)
+	return GetCollectionFromCluster(cluster, spec, time.Second*30, true)
 
 }
 
-func GetCollectionFromCluster(cluster *gocb.Cluster, spec BucketSpec, waitUntilReadySeconds int) (*Collection, error) {
+func GetCollectionFromCluster(cluster *gocb.Cluster, spec BucketSpec, waitUntilReady time.Duration, failFast bool) (*Collection, error) {
 
 	// Connect to bucket
 	bucket := cluster.Bucket(spec.BucketName)
-	err := bucket.WaitUntilReady(time.Duration(waitUntilReadySeconds)*time.Second, &gocb.WaitUntilReadyOptions{
-		RetryStrategy: &goCBv2FailFastRetryStrategy{},
+
+	var retryStrategy gocb.RetryStrategy
+	if failFast {
+		retryStrategy = &goCBv2FailFastRetryStrategy{}
+	} else {
+		retryStrategy = gocb.NewBestEffortRetryStrategy(nil)
+	}
+	err := bucket.WaitUntilReady(waitUntilReady, &gocb.WaitUntilReadyOptions{
+		RetryStrategy: retryStrategy,
 	})
 	if err != nil {
 		_ = cluster.Close(&gocb.ClusterCloseOptions{})

--- a/base/collection.go
+++ b/base/collection.go
@@ -60,7 +60,7 @@ func GetCouchbaseCollection(spec BucketSpec) (*Collection, error) {
 		Authenticator:  authenticator,
 		SecurityConfig: securityConfig,
 		TimeoutsConfig: timeoutsConfig,
-		RetryStrategy:  &goCBv2FailFastRetryStrategy{},
+		RetryStrategy:  gocb.NewBestEffortRetryStrategy(nil),
 	}
 
 	if spec.KvPoolSize > 0 {
@@ -95,7 +95,9 @@ func GetCollectionFromCluster(cluster *gocb.Cluster, spec BucketSpec, waitUntilR
 
 	// Connect to bucket
 	bucket := cluster.Bucket(spec.BucketName)
-	err := bucket.WaitUntilReady(time.Duration(waitUntilReadySeconds)*time.Second, nil)
+	err := bucket.WaitUntilReady(time.Duration(waitUntilReadySeconds)*time.Second, &gocb.WaitUntilReadyOptions{
+		RetryStrategy: &goCBv2FailFastRetryStrategy{},
+	})
 	if err != nil {
 		_ = cluster.Close(&gocb.ClusterCloseOptions{})
 		if errors.Is(err, gocb.ErrAuthenticationFailure) {

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -464,7 +464,7 @@ func (tbp *TestBucketPool) createTestBuckets(numBuckets int, bucketQuotaMB int, 
 				FatalfCtx(ctx, "Couldn't create test bucket: %v", err)
 			}
 
-			b, err := tbp.cluster.openTestBucket(tbpBucketName(bucketName), 10*numBuckets)
+			b, err := tbp.cluster.openTestBucket(tbpBucketName(bucketName), waitForReadyBucketTimeout)
 			if err != nil {
 				FatalfCtx(ctx, "Timed out trying to open new bucket: %v", err)
 			}
@@ -544,7 +544,7 @@ loop:
 				defer tbp.bucketReadierWaitGroup.Done()
 
 				start := time.Now()
-				b, err := tbp.cluster.openTestBucket(testBucketName, 5)
+				b, err := tbp.cluster.openTestBucket(testBucketName, waitForReadyBucketTimeout)
 				if err != nil {
 					tbp.Logf(ctx, "Couldn't open bucket to get ready, got error: %v", err)
 					return

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -15,7 +15,7 @@ type tbpCluster interface {
 	getBucketNames() ([]string, error)
 	insertBucket(name string, quotaMB int) error
 	removeBucket(name string) error
-	openTestBucket(name tbpBucketName, waitUntilReadySeconds int) (Bucket, error)
+	openTestBucket(name tbpBucketName, waitUntilReady time.Duration) (Bucket, error)
 	close() error
 }
 
@@ -110,9 +110,9 @@ func (c *tbpClusterV1) removeBucket(name string) error {
 }
 
 // openTestBucket opens the bucket of the given name for the gocb cluster in the given TestBucketPool.
-func (c *tbpClusterV1) openTestBucket(testBucketName tbpBucketName, waitUntilReadySeconds int) (Bucket, error) {
+func (c *tbpClusterV1) openTestBucket(testBucketName tbpBucketName, waitUntilReady time.Duration) (Bucket, error) {
 
-	sleeper := CreateSleeperFunc(waitUntilReadySeconds, 1000)
+	sleeper := CreateSleeperFunc(int(waitUntilReady.Seconds()), 1000)
 	ctx := bucketNameCtx(context.Background(), string(testBucketName))
 
 	bucketSpec := getBucketSpec(testBucketName)
@@ -253,12 +253,12 @@ func (c *tbpClusterV2) removeBucket(name string) error {
 }
 
 // openTestBucket opens the bucket of the given name for the gocb cluster in the given TestBucketPool.
-func (c *tbpClusterV2) openTestBucket(testBucketName tbpBucketName, waitUntilReadySeconds int) (Bucket, error) {
+func (c *tbpClusterV2) openTestBucket(testBucketName tbpBucketName, waitUntilReady time.Duration) (Bucket, error) {
 
 	cluster := getCluster(c.server)
 	bucketSpec := getBucketSpec(testBucketName)
 
-	return GetCollectionFromCluster(cluster, bucketSpec, waitUntilReadySeconds)
+	return GetCollectionFromCluster(cluster, bucketSpec, waitUntilReady, false)
 }
 
 func (c *tbpClusterV2) close() error {


### PR DESCRIPTION
Backports #5807 to 3.0.7 

- Applies best effort retry and increased timeouts for KV ops for bootstrap connections.
- Backports small parts of https://github.com/couchbase/sync_gateway/pull/5832 to set increased test bucket pool timeouts/`failFast` in `GetCollectionFromCluster`

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-go1.16.15/49/