### PR TITLE
CBG-2901 Port 3.1.0 DCP failover enhancements to main

### DIFF
--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -627,7 +627,7 @@ func TestAttachmentDifferentVBUUIDsBetweenPhases(t *testing.T) {
 	vbUUIDs[0] = 1
 
 	_, err = attachmentCompactSweepPhase(ctx, dataStore, collectionID, testDB, t.Name(), vbUUIDs, false, terminator, &base.AtomicInt{})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "error opening stream for vb 0: VbUUID mismatch when failOnRollback set")
 }
 


### PR DESCRIPTION
CBG-2873 retry on all stream end error types
CBG-2873 Avoid deadlock when attempting to reopen a closed stream
CBG-2880 Cancel timed out gocbcore dcp operations
CBG-2899 Implement cbgt mgrEventHandlers

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1738/
