### PR TITLE
CBG-2894: Reject user auth when channel threshold is over 500 

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -197,7 +197,7 @@ func (auth *Authenticator) InheritedChannels(user User, princ Principal) error {
 		}
 	})
 
-	// Error at >=500 channels if ServerlessChannelThreshold is set
+	// Error if ServerlessChannelThreshold is set and is >= than the threshold
 	if serverlessChanThreshold := auth.ServerlessChannelThreshold; serverlessChanThreshold != 0 {
 		if uint32(channelCount) >= serverlessChanThreshold {
 			base.ErrorfCtx(auth.LogCtx, "User ID: %v channel count: %d exceeds %d for channels per user threshold. Auth will be rejected until rectified",

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -284,7 +284,8 @@ func (auth *Authenticator) rebuildChannels(princ Principal) (changed bool, err e
 		}
 	}
 
-	if auth.ServerlessChannelThreshold != 0 {
+	// only warn/limit if the threshold is set and if we are in this function as a "user" not a role
+	if auth.ServerlessChannelThreshold != 0 && princUser != nil {
 		// Warning at 50 channels
 		princUser.GetWarnChanSync().Do(func() {
 			if channelsPerUserThreshold := auth.ChannelsWarningThreshold; channelsPerUserThreshold != nil {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -29,8 +28,7 @@ type Authenticator struct {
 	datastore       base.DataStore
 	channelComputer ChannelComputer
 	AuthenticatorOptions
-	bcryptCostChanged     bool
-	warnChanThresholdOnce sync.Once
+	bcryptCostChanged bool
 }
 
 type AuthenticatorOptions struct {
@@ -182,7 +180,7 @@ func (auth *Authenticator) InheritedChannels(princ Principal) error {
 	channelCount := len(cumulativeChannels)
 
 	// Warning at 50 channels
-	auth.warnChanThresholdOnce.Do(func() {
+	user.GetWarnChanSync().Do(func() {
 		if channelsPerUserThreshold := auth.ChannelsWarningThreshold; channelsPerUserThreshold != nil {
 			if uint32(channelCount) >= *channelsPerUserThreshold {
 				base.WarnfCtx(auth.LogCtx, "User ID: %v channel count: %d exceeds %d for channels per user warning threshold",

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -166,6 +166,7 @@ func (auth *Authenticator) GetRoleIncDeleted(name string) (Role, error) {
 func (auth *Authenticator) InheritedChannels(princ Principal) error {
 	cumulativeChannels := ch.TimedSet{}
 	user := princ.(User)
+	user.SetAuthenticator(auth)
 
 	for scope, collections := range auth.Collections {
 		for collection, _ := range collections {
@@ -227,9 +228,11 @@ func (auth *Authenticator) getPrincipal(docID string, factory func() Principal) 
 			}
 			if channelsChanged {
 				changed = true
-				err = auth.InheritedChannels(princ)
-				if err != nil {
-					return nil, nil, false, err
+				if _, ok := princ.(User); ok {
+					err = auth.InheritedChannels(princ)
+					if err != nil {
+						return nil, nil, false, err
+					}
 				}
 			}
 		}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -161,9 +161,8 @@ func (auth *Authenticator) GetRoleIncDeleted(name string) (Role, error) {
 	return role, err
 }
 
-func (auth *Authenticator) InheritedChannels(princ Principal) error {
+func (auth *Authenticator) InheritedChannels(user User, princ Principal) error {
 	cumulativeChannels := ch.TimedSet{}
-	user := princ.(User)
 	roles := make([]Role, 0, len(user.RoleNames()))
 
 	for scope, collections := range auth.Collections {
@@ -235,8 +234,8 @@ func (auth *Authenticator) getPrincipal(docID string, factory func() Principal) 
 			}
 			if channelsChanged {
 				changed = true
-				if _, ok := princ.(User); ok {
-					err = auth.InheritedChannels(princ)
+				if user, ok := princ.(User); ok {
+					err = auth.InheritedChannels(user, princ)
 					if err != nil {
 						return nil, nil, false, err
 					}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -2796,6 +2796,7 @@ func TestServerlessChannelLimitsRoles(t *testing.T) {
 				require.NoError(t, auth.Save(role1))
 			} else {
 				role2, err = auth.NewRole("role2", nil)
+				require.NoError(t, err)
 				user1.SetExplicitRoles(ch.TimedSet{"role1": ch.NewVbSimpleSequence(1), "role2": ch.NewVbSimpleSequence(1)}, 1)
 				require.NoError(t, auth.Save(user1))
 				role1.SetCollectionExplicitChannels("scope1", "collection1", ch.AtSequence(ch.BaseSetOf(t, "ABC", "DEF", "GHI", "JKL"), 1), 1)

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -2784,19 +2784,19 @@ func TestServerlessChannelLimits(t *testing.T) {
 			user1, err := auth.NewUser("user1", "pass", ch.BaseSetOf(t, "ABC"))
 			require.NoError(t, err)
 			err = auth.Save(user1)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = auth.AuthenticateUser("user1", "pass")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			if !testCase.Collection {
 				user1.SetCollectionExplicitChannels("_default", "_default", ch.AtSequence(ch.BaseSetOf(t, "ABC", "DEF", "GHI", "JKL", "MNO", "PQR"), 1), 1)
 				err = auth.Save(user1)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
 				user1.SetCollectionExplicitChannels("scope1", "collection1", ch.AtSequence(ch.BaseSetOf(t, "ABC", "DEF", "GHI", "JKL"), 1), 1)
 				user1.SetCollectionExplicitChannels("scope1", "collection2", ch.AtSequence(ch.BaseSetOf(t, "MNO", "PQR"), 1), 1)
 				err = auth.Save(user1)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			_, err = auth.AuthenticateUser("user1", "pass")
 			require.Error(t, err)

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -99,9 +99,6 @@ type User interface {
 	// Returns nil if invalidated
 	RoleNames() ch.TimedSet
 
-	// Returns list of roles associated with the user
-	GetRoles() []Role
-
 	// The roles the user was explicitly granted access to thru the admin API.
 	ExplicitRoles() ch.TimedSet
 
@@ -128,9 +125,6 @@ type User interface {
 	RoleHistory() TimedSetHistory
 
 	InitializeRoles()
-
-	// Adds authenticator to user
-	SetAuthenticator(auth *Authenticator)
 
 	GetWarnChanSync() *sync.Once
 

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -128,6 +128,9 @@ type User interface {
 
 	InitializeRoles()
 
+	// Adds authenticator to user
+	SetAuthenticator(auth *Authenticator)
+
 	revokedChannels(since uint64, lowSeq uint64, triggeredBy uint64) RevokedChannels
 
 	// Obtains the period over which the user had access to the given channel. Either directly or via a role.

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -9,6 +9,7 @@
 package auth
 
 import (
+	"sync"
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -130,6 +131,8 @@ type User interface {
 
 	// Adds authenticator to user
 	SetAuthenticator(auth *Authenticator)
+
+	GetWarnChanSync() *sync.Once
 
 	revokedChannels(since uint64, lowSeq uint64, triggeredBy uint64) RevokedChannels
 

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -98,6 +98,9 @@ type User interface {
 	// Returns nil if invalidated
 	RoleNames() ch.TimedSet
 
+	// Returns list of roles associated with the user
+	GetRoles() []Role
+
 	// The roles the user was explicitly granted access to thru the admin API.
 	ExplicitRoles() ch.TimedSet
 

--- a/auth/user.go
+++ b/auth/user.go
@@ -183,6 +183,10 @@ func (user *userImpl) SetEmail(email string) error {
 	return nil
 }
 
+func (user *userImpl) SetAuthenticator(auth *Authenticator) {
+	user.auth = auth
+}
+
 func (user *userImpl) RoleNames() ch.TimedSet {
 	if user.RoleInvalSeq != 0 {
 		return nil

--- a/auth/user.go
+++ b/auth/user.go
@@ -14,7 +14,6 @@ import (
 	"math"
 	"net/http"
 	"regexp"
-	"sync"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
@@ -30,10 +29,6 @@ type userImpl struct {
 	userImplBody
 	auth  *Authenticator
 	roles []Role
-
-	// warnChanThresholdOnce ensures that the check for channels
-	// per user threshold is only performed exactly once.
-	warnChanThresholdOnce sync.Once
 }
 
 // Marshallable data is stored in separate struct from userImpl,
@@ -621,7 +616,7 @@ func (user *userImpl) inheritedChannels() ch.TimedSet {
 		channels.AddAtSequence(role.Channels(), roleSince.Sequence)
 	}
 
-	user.warnChanThresholdOnce.Do(func() {
+	user.auth.warnChanThresholdOnce.Do(func() {
 		if channelsPerUserThreshold := user.auth.ChannelsWarningThreshold; channelsPerUserThreshold != nil {
 			channelCount := len(channels)
 			if uint32(channelCount) >= *channelsPerUserThreshold {

--- a/auth/user.go
+++ b/auth/user.go
@@ -183,10 +183,6 @@ func (user *userImpl) SetEmail(email string) error {
 	return nil
 }
 
-func (user *userImpl) SetAuthenticator(auth *Authenticator) {
-	user.auth = auth
-}
-
 func (user *userImpl) GetWarnChanSync() *sync.Once {
 	return &user.warnChanThresholdOnce
 }

--- a/auth/user_collection_access.go
+++ b/auth/user_collection_access.go
@@ -58,7 +58,7 @@ func (user *userImpl) InheritedCollectionChannels(scope, collection string) ch.T
 	}
 
 	// Warning threshold is per-collection, as we lazily load per-collection channel information
-	user.warnChanThresholdOnce.Do(func() {
+	user.auth.warnChanThresholdOnce.Do(func() {
 		if channelsPerUserThreshold := user.auth.ChannelsWarningThreshold; channelsPerUserThreshold != nil {
 			channelCount := len(channels)
 			if uint32(channelCount) >= *channelsPerUserThreshold {

--- a/auth/user_collection_access.go
+++ b/auth/user_collection_access.go
@@ -58,7 +58,7 @@ func (user *userImpl) InheritedCollectionChannels(scope, collection string) ch.T
 	}
 
 	// Warning threshold is per-collection, as we lazily load per-collection channel information
-	user.auth.warnChanThresholdOnce.Do(func() {
+	user.warnChanThresholdOnce.Do(func() {
 		if channelsPerUserThreshold := user.auth.ChannelsWarningThreshold; channelsPerUserThreshold != nil {
 			channelCount := len(channels)
 			if uint32(channelCount) >= *channelsPerUserThreshold {

--- a/base/constants.go
+++ b/base/constants.go
@@ -151,6 +151,9 @@ const (
 	// DefaultJavascriptTimeoutSecs is number of seconds before Javascript functions (i.e. the sync function or import filter) timeout
 	// If set to zero, timeout is disabled.
 	DefaultJavascriptTimeoutSecs = uint32(0)
+
+	// ServerlessChannelLimit is hard limit on channels allowed per user when running in serverless mode
+	ServerlessChannelLimit = 500
 )
 
 const (

--- a/base/error.go
+++ b/base/error.go
@@ -67,6 +67,9 @@ var (
 
 	// ErrConfigRegistryReloadRequired is returned when a db config fetch requires a registry reload based on version mismatch (config is newer)
 	ErrConfigRegistryReloadRequired = &sgError{"Config registry reload required"}
+
+	// ErrMaximumChannelsForUserExceeded is returned when running in serverless mode and the user has more than 500 channels granted to them
+	ErrMaximumChannelsForUserExceeded = &sgError{"User has exceeded maximum of 500 channels"}
 )
 
 func (e *sgError) Error() string {

--- a/base/error.go
+++ b/base/error.go
@@ -118,6 +118,8 @@ func ErrorAsHTTPStatus(err error) (int, string) {
 		return http.StatusRequestEntityTooLarge, "Document too large!"
 	case ErrViewTimeoutError:
 		return http.StatusServiceUnavailable, unwrappedErr.Error()
+	case ErrMaximumChannelsForUserExceeded:
+		return http.StatusInternalServerError, "Maximum number of channels exceeded for this user"
 	}
 
 	// gocb V2 errors

--- a/base/error.go
+++ b/base/error.go
@@ -69,7 +69,7 @@ var (
 	ErrConfigRegistryReloadRequired = &sgError{"Config registry reload required"}
 
 	// ErrMaximumChannelsForUserExceeded is returned when running in serverless mode and the user has more than 500 channels granted to them
-	ErrMaximumChannelsForUserExceeded = &sgError{"User has exceeded maximum of 500 channels"}
+	ErrMaximumChannelsForUserExceeded = &sgError{fmt.Sprintf("User has exceeded maximum of %d channels", ServerlessChannelLimit)}
 )
 
 func (e *sgError) Error() string {

--- a/db/database.go
+++ b/db/database.go
@@ -48,6 +48,8 @@ const (
 	DBCompactRunning
 )
 
+const ServerlessChannelLimit = 500
+
 const (
 	DefaultRevsLimitNoConflicts = 50
 	DefaultRevsLimitConflicts   = 100
@@ -1063,16 +1065,21 @@ func (context *DatabaseContext) Authenticator(ctx context.Context) *auth.Authent
 	if context.Options.UnsupportedOptions != nil && context.Options.UnsupportedOptions.WarningThresholds != nil {
 		channelsWarningThreshold = context.Options.UnsupportedOptions.WarningThresholds.ChannelsPerUser
 	}
+	var channelServerlessThreshold uint32
+	if context.IsServerless() {
+		channelServerlessThreshold = ServerlessChannelLimit
+	}
 
 	// Authenticators are lightweight & stateless, so it's OK to return a new one every time
 	authenticator := auth.NewAuthenticator(context.MetadataStore, context, auth.AuthenticatorOptions{
-		ClientPartitionWindow:    context.Options.ClientPartitionWindow,
-		ChannelsWarningThreshold: channelsWarningThreshold,
-		SessionCookieName:        sessionCookieName,
-		BcryptCost:               context.Options.BcryptCost,
-		LogCtx:                   ctx,
-		Collections:              context.CollectionNames,
-		MetaKeys:                 context.MetadataKeys,
+		ClientPartitionWindow:      context.Options.ClientPartitionWindow,
+		ChannelsWarningThreshold:   channelsWarningThreshold,
+		ServerlessChannelThreshold: channelServerlessThreshold,
+		SessionCookieName:          sessionCookieName,
+		BcryptCost:                 context.Options.BcryptCost,
+		LogCtx:                     ctx,
+		Collections:                context.CollectionNames,
+		MetaKeys:                   context.MetadataKeys,
 	})
 
 	return authenticator

--- a/db/database.go
+++ b/db/database.go
@@ -48,8 +48,6 @@ const (
 	DBCompactRunning
 )
 
-const ServerlessChannelLimit = 500
-
 const (
 	DefaultRevsLimitNoConflicts = 50
 	DefaultRevsLimitConflicts   = 100
@@ -1067,7 +1065,7 @@ func (context *DatabaseContext) Authenticator(ctx context.Context) *auth.Authent
 	}
 	var channelServerlessThreshold uint32
 	if context.IsServerless() {
-		channelServerlessThreshold = ServerlessChannelLimit
+		channelServerlessThreshold = base.ServerlessChannelLimit
 	}
 
 	// Authenticators are lightweight & stateless, so it's OK to return a new one every time


### PR DESCRIPTION
CBG-2894

When channels set on a user have changed we need to be able to see how many channels this user has to warn if over warning threshold and to reject any future authorization requests for the user if they have exceeded the channel limit on the user. This code will only be called if a change in channel set has been detected removing the need for this check to be performed each time a user authenticates. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1765/
