### PR TITLE
Always close bootstrap connections from ServerContext.Close()

### DIFF
--- a/integration-test/start_server.sh
+++ b/integration-test/start_server.sh
@@ -55,10 +55,11 @@ docker stop ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} || true
 docker rm ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} || true
 # --volume: Makes and mounts a CBS folder for storing a CBCollect if needed
 
-if [[ -z "${MULTI_NODE:-}" ]]; then
-    docker run -d --name ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} --volume "${DOCKER_CBS_ROOT_DIR}/cbs:/root" --volume "${WORKSPACE_ROOT}:/workspace" -p 8091-8096:8091-8096 -p 11207:11207 -p 11210:11210 -p 11211:11211 -p 18091-18094:18091-18094 "couchbase/server:${COUCHBASE_DOCKER_IMAGE_NAME}"
-else
+if [ "${MULTI_NODE}" == "true" ]; then
     ${DOCKER_COMPOSE} up -d --force-recreate --renew-anon-volumes --remove-orphans
+else
+    # single node
+    docker run -d --name ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} --volume "${DOCKER_CBS_ROOT_DIR}/cbs:/root" --volume "${WORKSPACE_ROOT}:/workspace" -p 8091-8096:8091-8096 -p 11207:11207 -p 11210:11210 -p 11211:11211 -p 18091-18094:18091-18094 "couchbase/server:${COUCHBASE_DOCKER_IMAGE_NAME}"
 fi
 
 # Test to see if Couchbase Server is up
@@ -72,7 +73,8 @@ docker exec couchbase couchbase-cli setting-index --cluster couchbase://localhos
 
 curl -u Administrator:password -v -X POST http://127.0.0.1:8091/node/controller/rename -d 'hostname=127.0.0.1'
 
-if [[ -n "${MULTI_NODE:-}" ]]; then
+
+if [ "${MULTI_NODE}" == "true" ]; then
     REPLICA1_NAME=couchbase-replica1
     REPLICA2_NAME=couchbase-replica2
     CLI_ARGS=(-c couchbase://couchbase -u Administrator -p password)

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -120,12 +120,13 @@ if [ "${RUN_WALRUS}" == "true" ]; then
 fi
 
 # Run CBS
-if [[ -z ${MULTI_NODE:-} ]]; then
-    # Run CBS
-    ./integration-test/start_server.sh "${COUCHBASE_SERVER_VERSION}"
-else
+if [ "${MULTI_NODE}" == "true" ]; then
+    # multi node
     ./integration-test/start_server.sh -m "${COUCHBASE_SERVER_VERSION}"
     export SG_TEST_BUCKET_NUM_REPLICAS=1
+else
+    # single node
+    ./integration-test/start_server.sh "${COUCHBASE_SERVER_VERSION}"
 fi
 
 # Set up test environment variables for CBS runs

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -181,13 +181,13 @@ func (sc *ServerContext) Close(ctx context.Context) {
 		base.InfofCtx(ctx, base.KeyAll, "Couldn't stop background config update worker: %v", err)
 	}
 
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
+
 	// close cached bootstrap bucket connections
 	if sc.BootstrapContext != nil && sc.BootstrapContext.Connection != nil {
 		sc.BootstrapContext.Connection.Close()
 	}
-
-	sc.lock.Lock()
-	defer sc.lock.Unlock()
 
 	for _, db := range sc.databases_ {
 		db.Close(ctx)


### PR DESCRIPTION
Always close cached bootstrap bucket connections when the ServerContext closes - even if we weren't polling for config updates (like when started from a RestTester)

This reduces memory usage, lingering goroutines and connections for tests that start RestTester in persistent config mode (which intentionally does not poll for config updates).

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1737/
