### PR TITLE
Set default for MULTI_NODE to avoid unbound variable error

### DIFF
--- a/integration-test/start_server.sh
+++ b/integration-test/start_server.sh
@@ -55,7 +55,7 @@ docker stop ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} || true
 docker rm ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} || true
 # --volume: Makes and mounts a CBS folder for storing a CBCollect if needed
 
-if [ "${MULTI_NODE}" == "true" ]; then
+if [ "${MULTI_NODE:-}" == "true" ]; then
     ${DOCKER_COMPOSE} up -d --force-recreate --renew-anon-volumes --remove-orphans
 else
     # single node
@@ -74,7 +74,7 @@ docker exec couchbase couchbase-cli setting-index --cluster couchbase://localhos
 curl -u Administrator:password -v -X POST http://127.0.0.1:8091/node/controller/rename -d 'hostname=127.0.0.1'
 
 
-if [ "${MULTI_NODE}" == "true" ]; then
+if [ "${MULTI_NODE:-}" == "true" ]; then
     REPLICA1_NAME=couchbase-replica1
     REPLICA2_NAME=couchbase-replica2
     CLI_ARGS=(-c couchbase://couchbase -u Administrator -p password)

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -120,7 +120,7 @@ if [ "${RUN_WALRUS}" == "true" ]; then
 fi
 
 # Run CBS
-if [ "${MULTI_NODE}" == "true" ]; then
+if [ "${MULTI_NODE:-}" == "true" ]; then
     # multi node
     ./integration-test/start_server.sh -m "${COUCHBASE_SERVER_VERSION}"
     export SG_TEST_BUCKET_NUM_REPLICAS=1


### PR DESCRIPTION
If the script was invoked without an explicit `MULTI_NODE` variable or `-m` these lines would error. Caused by change in #6215 

https://jenkins.sgwdev.com/job/MasterIntegration/456/

```
./jenkins-integration-build.sh: line 123: MULTI_NODE: unbound variable
```

```
./integration-test/start_server.sh: line 58: MULTI_NODE: unbound variable 
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a (this job always sets var even if false)