### PR TITLE
Tweak wording of doc_ids filter for /_changes API

### DIFF
--- a/docs/api/paths/admin/keyspace-_changes.yaml
+++ b/docs/api/paths/admin/keyspace-_changes.yaml
@@ -65,7 +65,7 @@ get:
         type: string
     - name: doc_ids
       in: query
-      description: 'A valid JSON array of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`. Also accepts a comma separated list of document IDs instead.'
+      description: 'A comma-separated list of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`.'
       schema:
         type: array
         items:
@@ -145,7 +145,7 @@ post:
               description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannels`.'
               type: string
             doc_ids:
-              description: 'A valid JSON array of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`.'
+              description: 'A comma-separated list of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`.'
               type: string
             heartbeat:
               description: The interval (in milliseconds) to send an empty line (CRLF) in the response. This is to help prevent gateways from deciding the socket is idle and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`. This will override any timeouts to keep the feed alive indefinitely. Setting to 0 results in no heartbeat. The maximum heartbeat can be set in the server replication configuration.

--- a/docs/api/paths/public/keyspace-_changes.yaml
+++ b/docs/api/paths/public/keyspace-_changes.yaml
@@ -60,7 +60,7 @@ get:
         type: string
     - name: doc_ids
       in: query
-      description: 'A valid JSON array of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`. Also accepts a comma separated list of document IDs instead.'
+      description: 'A comma-separated list of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`.'
       schema:
         type: array
         items:
@@ -135,7 +135,7 @@ post:
               description: 'A comma-separated list of channel names to filter the response to only the channels specified. To use this option, the `filter` query option must be set to `sync_gateway/bychannels`.'
               type: string
             doc_ids:
-              description: 'A valid JSON array of document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`.'
+              description: 'A comma-separated list document IDs to filter the documents in the response to only the documents specified. To use this option, the `filter` query option must be set to `_doc_ids` and the `feed` parameter must be `normal`.'
               type: string
             heartbeat:
               description: The interval (in milliseconds) to send an empty line (CRLF) in the response. This is to help prevent gateways from deciding the socket is idle and therefore closing it. This is only applicable to `feed=longpoll` or `feed=continuous`. This will override any timeouts to keep the feed alive indefinitely. Setting to 0 results in no heartbeat. The maximum heartbeat can be set in the server replication configuration.


### PR DESCRIPTION
- `doc_ids=[id1]` != `doc_ids=id1`
- The endpoint will try to match a literal `[id1]` document ID