### PR TITLE
Correct default value of EnableStarChannel

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1294,7 +1294,7 @@ Database:
             enable_star_channel:
               description: Used to control whether Sync Gateway should use the all documents (*) channel.
               type: boolean
-              default: false
+              default: true
             max_length:
               description: The maximum number of entries to maintain in the cache per channel.
               type: integer

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -116,7 +116,7 @@ func DefaultDbConfig(sc *StartupConfig) *DbConfig {
 				MaxWaitPending:       base.Uint32Ptr(uint32(db.DefaultCachePendingSeqMaxWait.Milliseconds())),
 				MaxNumPending:        base.IntPtr(db.DefaultCachePendingSeqMaxNum),
 				MaxWaitSkipped:       base.Uint32Ptr(uint32(db.DefaultSkippedSeqMaxWait.Milliseconds())),
-				EnableStarChannel:    base.BoolPtr(false),
+				EnableStarChannel:    base.BoolPtr(true),
 				MaxLength:            base.IntPtr(db.DefaultChannelCacheMaxLength),
 				MinLength:            base.IntPtr(db.DefaultChannelCacheMinLength),
 				ExpirySeconds:        base.IntPtr(int(db.DefaultChannelCacheAge.Seconds())),


### PR DESCRIPTION
Actual default value is `true` (`var EnableStarChannelLog = true`), but we report it as `false` in db config `include_runtime` response.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1742/
