### PR TITLE
CBG-2911 allow /db/ if default collection is configured with other named collections

### DIFF
--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -94,7 +94,7 @@ func TestCollectionsPutDocInKeyspace(t *testing.T) {
 				require.Contains(t, resp.Body.String(), test.keyspace)
 				// assert special case where /db/docID returns db._default._default
 				if test.keyspace == dbName {
-					require.Contains(t, resp.Body.String(), strings.Join([]string{dbName, base.DefaultScope, base.DefaultCollection}, base.ScopeCollectionSeparator))
+					require.Contains(t, resp.Body.String(), "keyspace db not found")
 				}
 			}
 			if test.expectedStatus == http.StatusCreated {
@@ -400,7 +400,6 @@ func TestMultiCollectionChannelAccess(t *testing.T) {
 	// Remove collection and update the db config
 	scopesConfig = GetCollectionsConfig(t, tb, 2)
 
-	//collection3 := dataStoreNames[2].CollectionName()
 	scopesConfig[scope].Collections[collection1] = CollectionConfig{SyncFn: &c1SyncFunction}
 	scopesConfig[scope].Collections[collection2] = CollectionConfig{SyncFn: &c1SyncFunction}
 	scopesConfigString, err = json.Marshal(scopesConfig)
@@ -639,9 +638,6 @@ func TestCollectionsPutDBInexistentCollection(t *testing.T) {
 }
 
 func TestCollectionsPutDocInDefaultCollectionWithNamedCollections(t *testing.T) {
-	// FIXME: CBG-2911 - PUT /db/doc1 should route to the default collection
-	t.Skip("CBG-2911 - This test reproduces CBG-2911 - PUT /db/doc1 should route to the default collection")
-
 	base.TestRequiresCollections(t)
 
 	if base.UnitTestUrlIsWalrus() {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -483,6 +483,7 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 		ksNotFound := base.HTTPErrorf(http.StatusNotFound, "keyspace %s not found", ks)
 		if dbContext.Scopes != nil {
 			// endpoint like /db/doc where this matches /db._default._default/
+			// the check whether the _default._default actually exists on this database is performed below
 			if keyspaceScope == nil && keyspaceCollection == nil {
 				keyspaceScope = base.StringPtr(base.DefaultScope)
 				keyspaceCollection = base.StringPtr(base.DefaultCollection)

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -482,9 +482,9 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 	if ks != "" {
 		ksNotFound := base.HTTPErrorf(http.StatusNotFound, "keyspace %s not found", ks)
 		if dbContext.Scopes != nil {
-			// If scopes are defined on the database but not in th an empty scope to refer to the one SG is running with, rather than falling back to _default
 			if keyspaceScope == nil && keyspaceCollection == nil {
-				ksNotFound = base.HTTPErrorf(http.StatusNotFound, "keyspace %s.%s.%s not found", ks, base.DefaultScope, base.DefaultCollection)
+				keyspaceScope = base.StringPtr(base.DefaultScope)
+				keyspaceCollection = base.StringPtr(base.DefaultCollection)
 			}
 			if keyspaceScope == nil {
 				if len(dbContext.Scopes) == 1 {


### PR DESCRIPTION
## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1574/
