### PR TITLE
Allow v8 build

### DIFF
--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -22,6 +22,7 @@ if [ "${1:-}" == "-m" ]; then
     DETECT_RACES="false"
     SG_EDITION="EE"
     XATTRS="true"
+    SG_V8="false"
     RUN_COUNT="1"
     # CBS server settings
     COUCHBASE_SERVER_PROTOCOL="couchbase"
@@ -112,9 +113,15 @@ if [ "${SG_TEST_PROFILE_FREQUENCY:-}" == "true" ]; then
     export SG_TEST_PROFILE_FREQUENCY=${SG_TEST_PROFILE_FREQUENCY}
 fi
 
+if [ "${SG_V8:-}" == "true" ]; then
+    BUILD_TAGS="-tags cb_sg_v8"
+else
+    BUILD_TAGS="-tags"
+fi
+
 if [ "${RUN_WALRUS}" == "true" ]; then
     # EE
-    go test -coverprofile=coverage_walrus_ee.out -coverpkg=github.com/couchbase/sync_gateway/... -tags cb_sg_enterprise $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} > verbose_unit_ee.out.raw 2>&1 | true
+    go test -coverprofile=coverage_walrus_ee.out -coverpkg=github.com/couchbase/sync_gateway/... ${BUILD_TAGS},cb_sg_enterprise $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} > verbose_unit_ee.out.raw 2>&1 | true
     # CE
     go test -coverprofile=coverage_walrus_ce.out -coverpkg=github.com/couchbase/sync_gateway/... $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} > verbose_unit_ce.out.raw 2>&1 | true
 fi
@@ -138,7 +145,7 @@ export SG_TEST_BUCKET_POOL_DEBUG=${SG_TEST_BUCKET_POOL_DEBUG}
 export SG_TEST_TLS_SKIP_VERIFY=${TLS_SKIP_VERIFY}
 
 if [ "${SG_EDITION}" == "EE" ]; then
-    GO_TEST_FLAGS="${GO_TEST_FLAGS} -tags cb_sg_enterprise"
+    GO_TEST_FLAGS="${GO_TEST_FLAGS} ${BUILD_TAGS},cb_sg_enterprise"
 fi
 
 go test ${GO_TEST_FLAGS} -coverprofile=coverage_int.out -coverpkg=github.com/couchbase/sync_gateway/... github.com/couchbase/sync_gateway/${TARGET_PACKAGE} 2>&1 | stdbuf -oL tee "${INT_LOG_FILE_NAME}.out.raw" | stdbuf -oL grep -a -E '(--- (FAIL|PASS|SKIP):|github.com/couchbase/sync_gateway(/.+)?\t|TEST: |panic: )'


### PR DESCRIPTION
Allow v8 builds in jenkins with a flag. It mostly passes except for

https://jenkins.sgwdev.com/job/SyncGateway-Integration/1753/testReport/junit/github/com_couchbase_sync_gateway_rest_functionsapitest/TestFunctionTimeout/

I think the other failures are unrelated and part of things that fail on server 7.1.4 intermittently.

[Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
[x] GSI=true,xattrs=true https://jenkins.sgwdev.com/job/SyncGateway-Integration/1753/