### PR TITLE
allow rbac tests to run

### DIFF
--- a/base/main_test_bucket_pool_config.go
+++ b/base/main_test_bucket_pool_config.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"os"
 	"strconv"
+	"testing"
 	"time"
 )
 
@@ -80,10 +81,12 @@ func TestsUseServerCE() bool {
 	return err == nil && ok
 }
 
-// TestsSupportCreatingRBAC returns true if the server can create RBAC users.
-func TestsSupportCreatingRBAC() bool {
-	ok, err := GTestBucketPool.cluster.supportsSettingRBAC()
-	return err == nil && ok
+// TestsRequireMobileRBAC returns true if the server has Sync Gateway RBAC roles.
+func TestsRequireMobileRBAC(t *testing.T) {
+	ok, err := GTestBucketPool.cluster.supportsMobileRBAC()
+	if err != nil || ok {
+		t.Skip("Mobile RBAC roles for Sync Gateway are only fully supported in CBS 7.1 or greater")
+	}
 }
 
 // canUseNamedCollections returns true if the cluster supports named collections, and they are also requested

--- a/base/main_test_bucket_pool_config.go
+++ b/base/main_test_bucket_pool_config.go
@@ -80,6 +80,12 @@ func TestsUseServerCE() bool {
 	return err == nil && ok
 }
 
+// TestsSupportCreatingRBAC returns true if the server can create RBAC users.
+func TestsSupportCreatingRBAC() bool {
+	ok, err := GTestBucketPool.cluster.supportsSettingRBAC()
+	return err == nil && ok
+}
+
 // canUseNamedCollections returns true if the cluster supports named collections, and they are also requested
 func (tbp *TestBucketPool) canUseNamedCollections() (bool, error) {
 	// walrus supports collections, but we need to query the server's version for capability check

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -24,6 +24,7 @@ type tbpCluster interface {
 	removeBucket(name string) error
 	openTestBucket(name tbpBucketName, waitUntilReady time.Duration) (Bucket, error)
 	supportsCollections() (bool, error)
+	supportsSettingRBAC() (bool, error)
 	isServerEnterprise() (bool, error)
 	close() error
 }
@@ -195,6 +196,14 @@ func (c *tbpClusterV2) supportsCollections() (bool, error) {
 		return false, err
 	}
 	return major >= 7, nil
+}
+
+func (c *tbpClusterV2) supportsSettingRBAC() (bool, error) {
+	major, minor, err := getClusterVersion(c.cluster)
+	if err != nil {
+		return false, err
+	}
+	return major >= 7 && minor >= 1, nil
 }
 
 // dropAllScopesAndCollections attempts to drop *all* non-_default scopes and collections from the bucket associated with the collection, except those used by the test bucket pool. Intended for test usage only.

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -24,7 +24,7 @@ type tbpCluster interface {
 	removeBucket(name string) error
 	openTestBucket(name tbpBucketName, waitUntilReady time.Duration) (Bucket, error)
 	supportsCollections() (bool, error)
-	supportsSettingRBAC() (bool, error)
+	supportsMobileRBAC() (bool, error)
 	isServerEnterprise() (bool, error)
 	close() error
 }
@@ -198,7 +198,8 @@ func (c *tbpClusterV2) supportsCollections() (bool, error) {
 	return major >= 7, nil
 }
 
-func (c *tbpClusterV2) supportsSettingRBAC() (bool, error) {
+// supportsMobileRBAC is true if running couchbase server with all Sync Gateway roles
+func (c *tbpClusterV2) supportsMobileRBAC() (bool, error) {
 	major, minor, err := getClusterVersion(c.cluster)
 	if err != nil {
 		return false, err

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -988,9 +988,7 @@ func TestNewlyCreateSGWPermissions(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}
-	if !base.TestsSupportCreatingRBAC() {
-		t.Skip("This test needs >= server 7.1 to work")
-	}
+	base.TestsRequireMobileRBAC(t)
 	mobileSyncGateway := "mobile_sync_gateway"
 	syncGatewayDevOps := "sync_gateway_dev_ops"
 	syncGatewayApp := "sync_gateway_app"


### PR DESCRIPTION
I'm not actually sure what feature is only supported in 7.1 in this test - I think it's user creation, but if it's not, let me know how to change this test.

There were a few changes to make to this test with database and keyspace which are expected.

Unexpected was that `/_stats` and `/_expvar/` are granted to `syncGatewayConfigurator`

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1760/
