### PR TITLE
CBG-2895: Add static replication connection limit

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -70,6 +70,9 @@ var (
 
 	// ErrMaximumChannelsForUserExceeded is returned when running in serverless mode and the user has more than 500 channels granted to them
 	ErrMaximumChannelsForUserExceeded = &sgError{fmt.Sprintf("User has exceeded maximum of %d channels", ServerlessChannelLimit)}
+
+	// ErrReplicationLimitExceeded is returned when then replication connection threshold is exceeded
+	ErrReplicationLimitExceeded = &sgError{"Replication limit exceeded. Try agin later."}
 )
 
 func (e *sgError) Error() string {
@@ -120,6 +123,8 @@ func ErrorAsHTTPStatus(err error) (int, string) {
 		return http.StatusServiceUnavailable, unwrappedErr.Error()
 	case ErrMaximumChannelsForUserExceeded:
 		return http.StatusInternalServerError, "Maximum number of channels exceeded for this user"
+	case ErrReplicationLimitExceeded:
+		return http.StatusServiceUnavailable, unwrappedErr.Error()
 	}
 
 	// gocb V2 errors

--- a/base/stats.go
+++ b/base/stats.go
@@ -494,7 +494,7 @@ type DatabaseStats struct {
 	// The total number of times that a sync function encountered an exception (across all collections).
 	SyncFunctionExceptionCount *SgwIntStat `json:"sync_function_exception_count"`
 	// The total number of times a replication connection is rejected due ot it being over the threshold
-	NumReplicationsRejected *SgwIntStat `json:"num_replications_rejected"`
+	NumReplicationsRejectedLimit *SgwIntStat `json:"num_replications_rejected_limit"`
 
 	// These can be cleaned up in future versions of SGW, implemented as maps to reduce amount of potential risk
 	// prior to Hydrogen release. These are not exported as part of prometheus and only exposed through expvars
@@ -1414,7 +1414,7 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.NumReplicationsRejected, err = NewIntStat(SubsystemDatabaseKey, "num_replications_rejected", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.NumReplicationsRejectedLimit, err = NewIntStat(SubsystemDatabaseKey, "num_replications_rejected_limit", labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
@@ -1459,7 +1459,7 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.SyncFunctionCount)
 	prometheus.Unregister(d.DatabaseStats.SyncFunctionTime)
 	prometheus.Unregister(d.DatabaseStats.SyncFunctionExceptionCount)
-	prometheus.Unregister(d.DatabaseStats.NumReplicationsRejected)
+	prometheus.Unregister(d.DatabaseStats.NumReplicationsRejectedLimit)
 }
 
 func (d *DbStats) CollectionStat(scopeName, collectionName string) (*CollectionStats, error) {

--- a/base/stats.go
+++ b/base/stats.go
@@ -493,6 +493,8 @@ type DatabaseStats struct {
 	SyncFunctionTime *SgwIntStat `json:"sync_function_time"`
 	// The total number of times that a sync function encountered an exception (across all collections).
 	SyncFunctionExceptionCount *SgwIntStat `json:"sync_function_exception_count"`
+	// The total number of times a replication connection is rejected due ot it being over the threshold
+	NumReplicationsRejected *SgwIntStat `json:"num_replications_rejected"`
 
 	// These can be cleaned up in future versions of SGW, implemented as maps to reduce amount of potential risk
 	// prior to Hydrogen release. These are not exported as part of prometheus and only exposed through expvars
@@ -1409,6 +1411,10 @@ func (d *DbStats) initDatabaseStats() error {
 		return err
 	}
 	resUtil.SyncFunctionExceptionCount, err = NewIntStat(SubsystemDatabaseKey, "sync_function_exception_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.NumReplicationsRejected, err = NewIntStat(SubsystemDatabaseKey, "num_replications_rejected", labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}

--- a/base/stats.go
+++ b/base/stats.go
@@ -1459,6 +1459,7 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.SyncFunctionCount)
 	prometheus.Unregister(d.DatabaseStats.SyncFunctionTime)
 	prometheus.Unregister(d.DatabaseStats.SyncFunctionExceptionCount)
+	prometheus.Unregister(d.DatabaseStats.NumReplicationsRejected)
 }
 
 func (d *DbStats) CollectionStat(scopeName, collectionName string) (*CollectionStats, error) {

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2112,7 +2112,7 @@ Startup-config:
           type: integer
           maximum: 9
           minimum: 0
-        max_concurrent_connections:
+        max_concurrent_replications:
           description: Maximum number of concurrent replication connections allowed. If set to 0 this limit will be ignored.
           type: integer
       readOnly: true
@@ -2200,7 +2200,7 @@ Runtime-config:
           $ref: '#/File-logging-config'
         stats:
           $ref: '#/File-logging-config'
-    max_concurrent_connections:
+    max_concurrent_replications:
       description: Maximum number of concurrent replication connections allowed. If set to 0 this limit will be ignored.
       type: integer
       default: 0

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2112,6 +2112,9 @@ Startup-config:
           type: integer
           maximum: 9
           minimum: 0
+        max_concurrent_connections:
+          description: Maximum number of concurrent replication connections allowed. If set to 0 this limit will be ignored.
+          type: integer
       readOnly: true
     unsupported:
       description: Settings that are not officially supported. It is highly recommended these are **not** used.
@@ -2162,6 +2165,46 @@ Startup-config:
       type: integer
       readOnly: true
   title: Startup-config
+Runtime-config:
+  type: object
+  properties:
+    logging:
+      description: The configuration settings for modifying Sync Gateway logging.
+      type: object
+      properties:
+        log_file_path:
+          description: Absolute or relative path on the filesystem to the log file directory. A relative path is from the directory that contains the Sync Gateway executable file.
+          type: string
+          readOnly: true
+        redaction_level:
+          description: Redaction level to apply to log output.
+          type: string
+          default: partial
+          enum:
+            - none
+            - partial
+            - full
+            - unset
+          readOnly: true
+        console:
+          $ref: '#/Console-logging-config'
+        error:
+          $ref: '#/File-logging-config'
+        warn:
+          $ref: '#/File-logging-config'
+        info:
+          $ref: '#/File-logging-config'
+        debug:
+          $ref: '#/File-logging-config'
+        trace:
+          $ref: '#/File-logging-config'
+        stats:
+          $ref: '#/File-logging-config'
+    max_concurrent_connections:
+      description: Maximum number of concurrent replication connections allowed. If set to 0 this limit will be ignored.
+      type: integer
+      default: 0
+  title: Runtime-config
 File-logging-config:
   type: object
   properties:

--- a/docs/api/paths/admin/_config.yaml
+++ b/docs/api/paths/admin/_config.yaml
@@ -49,7 +49,7 @@ put:
     content:
       application/json:
         schema:
-          $ref: ../../components/schemas.yaml#/Startup-config
+          $ref: ../../components/schemas.yaml#/Runtime-config
   responses:
     '200':
       description: Successfully set runtime options

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -411,6 +411,7 @@ func (h *handler) handlePutConfig() error {
 			Trace   FileLoggerPutConfig     `json:"trace,omitempty"`
 			Stats   FileLoggerPutConfig     `json:"stats,omitempty"`
 		} `json:"logging"`
+		ReplicationLimit *int `json:"max_concurrent_connections,omitempty"`
 	}
 
 	var config ServerPutConfig
@@ -460,6 +461,10 @@ func (h *handler) handlePutConfig() error {
 
 	if config.Logging.Stats.Enabled != nil {
 		base.EnableStatsLogger(*config.Logging.Stats.Enabled)
+	}
+
+	if config.ReplicationLimit != nil {
+		h.server.Config.Replicator.MaxConcurrentConnections = *config.ReplicationLimit
 	}
 
 	return base.HTTPErrorf(http.StatusOK, "Updated")

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -465,7 +465,7 @@ func (h *handler) handlePutConfig() error {
 
 	if config.ReplicationLimit != nil {
 		h.server.Config.Replicator.MaxConcurrentReplications = *config.ReplicationLimit
-		h.server.activeReplicatorLimit = *config.ReplicationLimit
+		h.server.ActiveReplicationsCounter.activeReplicatorLimit = *config.ReplicationLimit
 	}
 
 	return base.HTTPErrorf(http.StatusOK, "Updated")

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -465,6 +465,7 @@ func (h *handler) handlePutConfig() error {
 
 	if config.ReplicationLimit != nil {
 		h.server.Config.Replicator.MaxConcurrentReplications = *config.ReplicationLimit
+		h.server.activeReplicatorLimit = *config.ReplicationLimit
 	}
 
 	return base.HTTPErrorf(http.StatusOK, "Updated")

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -411,7 +411,7 @@ func (h *handler) handlePutConfig() error {
 			Trace   FileLoggerPutConfig     `json:"trace,omitempty"`
 			Stats   FileLoggerPutConfig     `json:"stats,omitempty"`
 		} `json:"logging"`
-		ReplicationLimit *int `json:"max_concurrent_connections,omitempty"`
+		ReplicationLimit *int `json:"max_concurrent_replications,omitempty"`
 	}
 
 	var config ServerPutConfig
@@ -464,7 +464,7 @@ func (h *handler) handlePutConfig() error {
 	}
 
 	if config.ReplicationLimit != nil {
-		h.server.Config.Replicator.MaxConcurrentConnections = *config.ReplicationLimit
+		h.server.Config.Replicator.MaxConcurrentReplications = *config.ReplicationLimit
 	}
 
 	return base.HTTPErrorf(http.StatusOK, "Updated")

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -411,7 +411,7 @@ func (h *handler) handlePutConfig() error {
 			Trace   FileLoggerPutConfig     `json:"trace,omitempty"`
 			Stats   FileLoggerPutConfig     `json:"stats,omitempty"`
 		} `json:"logging"`
-		ReplicationLimit *int `json:"max_concurrent_replications,omitempty"`
+		ReplicationLimit *uint `json:"max_concurrent_replications,omitempty"`
 	}
 
 	var config ServerPutConfig
@@ -465,7 +465,9 @@ func (h *handler) handlePutConfig() error {
 
 	if config.ReplicationLimit != nil {
 		h.server.Config.Replicator.MaxConcurrentReplications = *config.ReplicationLimit
+		h.server.ActiveReplicationsCounter.lock.Lock()
 		h.server.ActiveReplicationsCounter.activeReplicatorLimit = *config.ReplicationLimit
+		h.server.ActiveReplicationsCounter.lock.Unlock()
 	}
 
 	return base.HTTPErrorf(http.StatusOK, "Updated")

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -411,7 +411,7 @@ func (h *handler) handlePutConfig() error {
 			Trace   FileLoggerPutConfig     `json:"trace,omitempty"`
 			Stats   FileLoggerPutConfig     `json:"stats,omitempty"`
 		} `json:"logging"`
-		ReplicationLimit *uint `json:"max_concurrent_replications,omitempty"`
+		ReplicationLimit *int `json:"max_concurrent_replications,omitempty"`
 	}
 
 	var config ServerPutConfig
@@ -464,6 +464,9 @@ func (h *handler) handlePutConfig() error {
 	}
 
 	if config.ReplicationLimit != nil {
+		if *config.ReplicationLimit < 0 {
+			return base.HTTPErrorf(http.StatusBadRequest, "replication limit cannot be less than 0")
+		}
 		h.server.Config.Replicator.MaxConcurrentReplications = *config.ReplicationLimit
 		h.server.ActiveReplicationsCounter.lock.Lock()
 		h.server.ActiveReplicationsCounter.activeReplicatorLimit = *config.ReplicationLimit

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -243,25 +243,45 @@ func TestLoggingKeys(t *testing.T) {
 
 func TestServerlessChangesEndpointLimit(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
-	rt := rest.NewRestTester(t, nil)
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg, base.KeyChanges)
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		SyncFn: `function(doc) {channel(doc.channel);}`,
+	})
 	defer rt.Close()
 
-	resp := rt.SendAdminRequest(http.MethodPut, "/_config", `{"max_concurrent_connections" : 2}`)
+	resp := rt.SendAdminRequest(http.MethodPut, "/_config", `{"max_concurrent_replications" : 2}`)
 	rest.RequireStatus(t, resp, http.StatusOK)
+	resp = rt.SendAdminRequest("PUT", "/db/_user/alice", rest.GetUserPayload(t, "alice", "letmein", "", rt.GetSingleTestDatabaseCollection(), []string{"ABC"}, nil))
+	rest.RequireStatus(t, resp, 201)
 
-	for i := 0; i < 200; i++ {
-		_ = rt.PutDoc(fmt.Sprint(i), `{"source":"rt","channels":["alice"]}`)
-	}
+	// Put several documents in channel PBS
+	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs1", `{"value":1, "channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs2", `{"value":2, "channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs3", `{"value":3, "channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+
+	changesJSON := `{"style":"all_docs", 
+					 "heartbeat":300000, 
+					 "feed":"longpoll", 
+					 "limit":50, 
+					 "since":"1",
+					 "filter":"` + base.ByChannelFilter + `",
+					 "channels":"ABC,PBS"}`
+	var wg sync.WaitGroup
+	wg.Add(2)
 
 	// send some changes requests in go routines to run concurrently along with test
 	go func() {
-		resp1 := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_changes?feed=longpoll&since=999999&timeout=100000", "")
+		defer wg.Done()
+		resp1 := rt.SendUserRequest(http.MethodPost, "/{{.keyspace}}/_changes", changesJSON, "alice")
 		rest.RequireStatus(t, resp1, http.StatusOK)
 	}()
 
 	go func() {
-		resp2 := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_changes?feed=longpoll&since=999999&timeout=100000", "")
+		defer wg.Done()
+		resp2 := rt.SendUserRequest(http.MethodPost, "/{{.keyspace}}/_changes", changesJSON, "alice")
 		rest.RequireStatus(t, resp2, http.StatusOK)
 	}()
 
@@ -271,7 +291,10 @@ func TestServerlessChangesEndpointLimit(t *testing.T) {
 	// assert this request is rejected due to this request taking us over the limit
 	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_changes?feed=longpoll&since=999999&timeout=100000", "")
 	rest.RequireStatus(t, resp, http.StatusServiceUnavailable)
-
+	// put doc to end changes feeds
+	resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/abc1", `{"value":3, "channel":["ABC"]}`)
+	rest.RequireStatus(t, resp, 201)
+	wg.Wait()
 }
 
 func TestLoggingLevels(t *testing.T) {

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -256,13 +256,13 @@ func TestServerlessChangesEndpointLimit(t *testing.T) {
 
 	// send some changes requests in go routines to run concurrently along with test
 	go func() {
-		resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_changes?feed=longpoll&since=999999&timeout=100000", "")
-		rest.RequireStatus(t, resp, http.StatusOK)
+		resp1 := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_changes?feed=longpoll&since=999999&timeout=100000", "")
+		rest.RequireStatus(t, resp1, http.StatusOK)
 	}()
 
 	go func() {
-		resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_changes?feed=longpoll&since=999999&timeout=100000", "")
-		rest.RequireStatus(t, resp, http.StatusOK)
+		resp2 := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_changes?feed=longpoll&since=999999&timeout=100000", "")
+		rest.RequireStatus(t, resp2, http.StatusOK)
 	}()
 
 	// assert count for replicators is correct according to changes request made above

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2598,7 +2598,6 @@ func (rt *RestTester) CreateDocReturnRev(t *testing.T, docID string, revID strin
 
 func TestMetricsHandler(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	base.SkipPrometheusStatsRegistration = false
 	defer func() {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2598,6 +2598,7 @@ func (rt *RestTester) CreateDocReturnRev(t *testing.T, docID string, revID strin
 
 func TestMetricsHandler(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	base.SkipPrometheusStatsRegistration = false
 	defer func() {

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -89,7 +89,6 @@ func (sc *ServerContext) limitConcurrentReplications(ctx context.Context) (func(
 
 	capacity := sc.Config.Replicator.MaxConcurrentConnections
 	count := sc.activeReplicatorCount
-	//base.InfofCtx(ctx, base.KeyHTTP, "count %v + capacity %v", count, capacity)
 
 	release := func(sc *ServerContext) {
 		sc.lock.Lock()

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -90,19 +90,19 @@ func (sc *ServerContext) incrementConcurrentReplications(ctx context.Context) (b
 	sc.ActiveReplicationsCounter.lock.Lock()
 	defer sc.ActiveReplicationsCounter.lock.Unlock()
 	// if max concurrent replications is 0 then we don't need to keep track of concurrent replications
-	if sc.activeReplicatorLimit == 0 {
+	if sc.ActiveReplicationsCounter.activeReplicatorLimit == 0 {
 		return false, nil
 	}
 
-	capacity := sc.activeReplicatorLimit
-	count := sc.activeReplicatorCount
+	capacity := sc.ActiveReplicationsCounter.activeReplicatorLimit
+	count := sc.ActiveReplicationsCounter.activeReplicatorCount
 
 	if count >= capacity {
 		base.InfofCtx(ctx, base.KeyHTTP, "Replication limit exceeded (active: %d limit: %d)", count, capacity)
 		return false, base.ErrReplicationLimitExceeded
 	}
-	sc.activeReplicatorCount++
-	base.TracefCtx(ctx, base.KeyHTTP, "Acquired replication slot (active: %d/%d)", sc.activeReplicatorCount, capacity)
+	sc.ActiveReplicationsCounter.activeReplicatorCount++
+	base.TracefCtx(ctx, base.KeyHTTP, "Acquired replication slot (active: %d/%d)", sc.ActiveReplicationsCounter.activeReplicatorCount, capacity)
 
 	return true, nil
 }
@@ -112,7 +112,7 @@ func (sc *ServerContext) decrementConcurrentReplications(ctx context.Context) {
 	// lock replications config limit + the active replications counter
 	sc.ActiveReplicationsCounter.lock.Lock()
 	defer sc.ActiveReplicationsCounter.lock.Unlock()
-	connections := sc.activeReplicatorLimit
-	sc.activeReplicatorCount--
+	connections := sc.ActiveReplicationsCounter.activeReplicatorLimit
+	sc.ActiveReplicationsCounter.activeReplicatorCount--
 	base.TracefCtx(ctx, base.KeyHTTP, "Released replication slot (active: %d/%d)", sc.activeReplicatorCount, connections)
 }

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -89,14 +89,12 @@ func (sc *ServerContext) incrementConcurrentReplications(ctx context.Context) (b
 	// lock replications config limit + the active replications counter
 	sc.ActiveReplicationsCounter.lock.Lock()
 	defer sc.ActiveReplicationsCounter.lock.Unlock()
-	sc.Config.Replicator.lock.Lock()
-	defer sc.Config.Replicator.lock.Unlock()
 	// if max concurrent replications is 0 then we don't need to keep track of concurrent replications
-	if sc.Config.Replicator.MaxConcurrentReplications == 0 {
+	if sc.activeReplicatorLimit == 0 {
 		return false, nil
 	}
 
-	capacity := sc.Config.Replicator.MaxConcurrentReplications
+	capacity := sc.activeReplicatorLimit
 	count := sc.activeReplicatorCount
 
 	if count >= capacity {
@@ -114,9 +112,7 @@ func (sc *ServerContext) decrementConcurrentReplications(ctx context.Context) {
 	// lock replications config limit + the active replications counter
 	sc.ActiveReplicationsCounter.lock.Lock()
 	defer sc.ActiveReplicationsCounter.lock.Unlock()
-	sc.Config.Replicator.lock.Lock()
-	defer sc.Config.Replicator.lock.Unlock()
-	connections := sc.Config.Replicator.MaxConcurrentReplications
+	connections := sc.activeReplicatorLimit
 	sc.activeReplicatorCount--
 	base.TracefCtx(ctx, base.KeyHTTP, "Released replication slot (active: %d/%d)", sc.activeReplicatorCount, connections)
 }

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -248,6 +248,15 @@ func (h *handler) handleChanges() error {
 		feed = "normal"
 	}
 
+	if feed != "normal" {
+		release, err := h.server.limitConcurrentReplications(h.rqCtx)
+		if err != nil {
+			return err
+		} else if release != nil {
+			defer release(h.server)
+		}
+	}
+
 	// Get the channels as parameters to an imaginary "bychannel" filter.
 	// The default is all channels the user can access.
 	userChannels := base.SetOf(ch.AllChannelWildcard)

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -248,13 +248,13 @@ func (h *handler) handleChanges() error {
 		feed = "normal"
 	}
 
-	if feed != "normal" {
-		release, err := h.server.limitConcurrentReplications(h.rqCtx)
-		if err != nil {
-			return err
-		} else if release != nil {
-			defer release(h.server)
-		}
+	needRelease, concurrentReplicationsErr := h.server.incrementConcurrentReplications(h.rqCtx)
+	if concurrentReplicationsErr != nil {
+		return concurrentReplicationsErr
+	}
+	// if we haven't incremented the active replicator due to MaxConcurrentReplications being 0, we don't need to decrement it
+	if needRelease {
+		defer h.server.decrementConcurrentReplications(h.rqCtx)
 	}
 
 	// Get the channels as parameters to an imaginary "bychannel" filter.

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -122,9 +122,9 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 
 		"auth.bcrypt_cost": {&config.Auth.BcryptCost, fs.Int("auth.bcrypt_cost", 0, "Cost to use for bcrypt password hashes")},
 
-		"replicator.max_heartbeat":              {&config.Replicator.MaxHeartbeat, fs.String("replicator.max_heartbeat", "", "Max heartbeat value for _changes request")},
-		"replicator.blip_compression":           {&config.Replicator.BLIPCompression, fs.Int("replicator.blip_compression", 0, "BLIP data compression level (0-9)")},
-		"replicator.max_concurrent_connections": {&config.Replicator.MaxConcurrentConnections, fs.Int("replicator.max_concurrent_connections", 0, "Maximum number of replication connections to the node")},
+		"replicator.max_heartbeat":               {&config.Replicator.MaxHeartbeat, fs.String("replicator.max_heartbeat", "", "Max heartbeat value for _changes request")},
+		"replicator.blip_compression":            {&config.Replicator.BLIPCompression, fs.Int("replicator.blip_compression", 0, "BLIP data compression level (0-9)")},
+		"replicator.max_concurrent_replications": {&config.Replicator.MaxConcurrentReplications, fs.Int("replicator.max_concurrent_replications", 0, "Maximum number of replication connections to the node")},
 
 		"unsupported.stats_log_frequency":                  {&config.Unsupported.StatsLogFrequency, fs.String("unsupported.stats_log_frequency", "", "How often should stats be written to stats logs")},
 		"unsupported.use_stdlib_json":                      {&config.Unsupported.UseStdlibJSON, fs.Bool("unsupported.use_stdlib_json", false, "Bypass the jsoniter package and use Go's stdlib instead")},

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -122,8 +122,9 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 
 		"auth.bcrypt_cost": {&config.Auth.BcryptCost, fs.Int("auth.bcrypt_cost", 0, "Cost to use for bcrypt password hashes")},
 
-		"replicator.max_heartbeat":    {&config.Replicator.MaxHeartbeat, fs.String("replicator.max_heartbeat", "", "Max heartbeat value for _changes request")},
-		"replicator.blip_compression": {&config.Replicator.BLIPCompression, fs.Int("replicator.blip_compression", 0, "BLIP data compression level (0-9)")},
+		"replicator.max_heartbeat":              {&config.Replicator.MaxHeartbeat, fs.String("replicator.max_heartbeat", "", "Max heartbeat value for _changes request")},
+		"replicator.blip_compression":           {&config.Replicator.BLIPCompression, fs.Int("replicator.blip_compression", 0, "BLIP data compression level (0-9)")},
+		"replicator.max_concurrent_connections": {&config.Replicator.MaxConcurrentConnections, fs.Int("replicator.max_concurrent_connections", 0, "Maximum number of replication connections to the node")},
 
 		"unsupported.stats_log_frequency":                  {&config.Unsupported.StatsLogFrequency, fs.String("unsupported.stats_log_frequency", "", "How often should stats be written to stats logs")},
 		"unsupported.use_stdlib_json":                      {&config.Unsupported.UseStdlibJSON, fs.Bool("unsupported.use_stdlib_json", false, "Bypass the jsoniter package and use Go's stdlib instead")},

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -138,7 +138,7 @@ type AuthConfig struct {
 type ReplicatorConfig struct {
 	MaxHeartbeat              *base.ConfigDuration `json:"max_heartbeat,omitempty"    help:"Max heartbeat value for _changes request"`
 	BLIPCompression           *int                 `json:"blip_compression,omitempty" help:"BLIP data compression level (0-9)"`
-	MaxConcurrentReplications int                  `json:"max_concurrent_replications,omitempty" help:"Maximum number of replication connections to the node"`
+	MaxConcurrentReplications uint                 `json:"max_concurrent_replications,omitempty" help:"Maximum number of replication connections to the node"`
 }
 
 type UnsupportedConfig struct {

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -136,8 +136,9 @@ type AuthConfig struct {
 }
 
 type ReplicatorConfig struct {
-	MaxHeartbeat    *base.ConfigDuration `json:"max_heartbeat,omitempty"    help:"Max heartbeat value for _changes request"`
-	BLIPCompression *int                 `json:"blip_compression,omitempty" help:"BLIP data compression level (0-9)"`
+	MaxHeartbeat             *base.ConfigDuration `json:"max_heartbeat,omitempty"    help:"Max heartbeat value for _changes request"`
+	BLIPCompression          *int                 `json:"blip_compression,omitempty" help:"BLIP data compression level (0-9)"`
+	MaxConcurrentConnections int                  `json:"max_concurrent_connections,omitempty" help:"Maximum number of replication connections to the node"`
 }
 
 type UnsupportedConfig struct {

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"os"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/couchbase/go-couchbase"
@@ -136,9 +137,10 @@ type AuthConfig struct {
 }
 
 type ReplicatorConfig struct {
-	MaxHeartbeat             *base.ConfigDuration `json:"max_heartbeat,omitempty"    help:"Max heartbeat value for _changes request"`
-	BLIPCompression          *int                 `json:"blip_compression,omitempty" help:"BLIP data compression level (0-9)"`
-	MaxConcurrentConnections int                  `json:"max_concurrent_connections,omitempty" help:"Maximum number of replication connections to the node"`
+	MaxHeartbeat              *base.ConfigDuration `json:"max_heartbeat,omitempty"    help:"Max heartbeat value for _changes request"`
+	BLIPCompression           *int                 `json:"blip_compression,omitempty" help:"BLIP data compression level (0-9)"`
+	MaxConcurrentReplications int                  `json:"max_concurrent_replications,omitempty" help:"Maximum number of replication connections to the node"`
+	lock                      sync.Mutex           // Lock for evaluating maximum concurrent replications
 }
 
 type UnsupportedConfig struct {

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -138,7 +138,7 @@ type AuthConfig struct {
 type ReplicatorConfig struct {
 	MaxHeartbeat              *base.ConfigDuration `json:"max_heartbeat,omitempty"    help:"Max heartbeat value for _changes request"`
 	BLIPCompression           *int                 `json:"blip_compression,omitempty" help:"BLIP data compression level (0-9)"`
-	MaxConcurrentReplications uint                 `json:"max_concurrent_replications,omitempty" help:"Maximum number of replication connections to the node"`
+	MaxConcurrentReplications int                  `json:"max_concurrent_replications,omitempty" help:"Maximum number of replication connections to the node"`
 }
 
 type UnsupportedConfig struct {

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"os"
 	"runtime"
-	"sync"
 	"time"
 
 	"github.com/couchbase/go-couchbase"
@@ -140,7 +139,6 @@ type ReplicatorConfig struct {
 	MaxHeartbeat              *base.ConfigDuration `json:"max_heartbeat,omitempty"    help:"Max heartbeat value for _changes request"`
 	BLIPCompression           *int                 `json:"blip_compression,omitempty" help:"BLIP data compression level (0-9)"`
 	MaxConcurrentReplications int                  `json:"max_concurrent_replications,omitempty" help:"Maximum number of replication connections to the node"`
-	lock                      sync.Mutex           // Lock for evaluating maximum concurrent replications
 }
 
 type UnsupportedConfig struct {

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -569,14 +569,16 @@ func TestServerlessConnectionLimitingOneshotFeed(t *testing.T) {
 
 	rt1.WaitForActiveReplicatorInitialization(2)
 	// assert the active replicator count has increased by 2
-	assert.Equal(t, 2, rt2.GetActiveReplicatorCount())
+	//assert.Equal(t, 2, rt2.GetActiveReplicatorCount())
+	rt2.WaitForActiveReplicatorCount(2)
 	replicationID = t.Name()
 	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateStopped)
 	replicationID = t.Name() + "1"
 	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateStopped)
 
 	// assert that the count for active replicators has decreased by 2 as both replications have finished
-	assert.Equal(t, 0, rt2.GetActiveReplicatorCount())
+	//assert.Equal(t, 0, rt2.GetActiveReplicatorCount())
+	rt2.WaitForActiveReplicatorCount(0)
 
 	// assert we can create a new replication as count has decreased below threshold
 	replicationID = t.Name() + "2"
@@ -624,7 +626,8 @@ func TestServerlessConnectionLimitingContinuous(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 
 	// assert the replications aren't killed as result of change in limit
-	assert.Equal(t, 2, rt2.GetActiveReplicatorCount())
+	//assert.Equal(t, 2, rt2.GetActiveReplicatorCount())
+	rt2.WaitForActiveReplicatorCount(2)
 	// assert we still can't create a new replication
 	replicationID = t.Name() + "3"
 	rt1.CreateReplication(replicationID, remoteURLString, db.ActiveReplicatorTypePull, nil, true, db.ConflictResolverDefault)
@@ -635,7 +638,8 @@ func TestServerlessConnectionLimitingContinuous(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 	rt1.WaitForReplicationStatus(t.Name()+"1", db.ReplicationStateStopped)
 	// assert the count has been decremented
-	assert.Equal(t, 1, rt2.GetActiveReplicatorCount())
+	//assert.Equal(t, 1, rt2.GetActiveReplicatorCount())
+	rt2.WaitForActiveReplicatorCount(1)
 
 	// assert we still can't create new replication (new limit is 1)
 	replicationID = t.Name() + "4"

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -569,7 +569,6 @@ func TestServerlessConnectionLimitingOneshotFeed(t *testing.T) {
 
 	rt1.WaitForActiveReplicatorInitialization(2)
 	// assert the active replicator count has increased by 2
-	//assert.Equal(t, 2, rt2.GetActiveReplicatorCount())
 	rt2.WaitForActiveReplicatorCount(2)
 	replicationID = t.Name()
 	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateStopped)
@@ -577,7 +576,6 @@ func TestServerlessConnectionLimitingOneshotFeed(t *testing.T) {
 	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateStopped)
 
 	// assert that the count for active replicators has decreased by 2 as both replications have finished
-	//assert.Equal(t, 0, rt2.GetActiveReplicatorCount())
 	rt2.WaitForActiveReplicatorCount(0)
 
 	// assert we can create a new replication as count has decreased below threshold
@@ -626,7 +624,6 @@ func TestServerlessConnectionLimitingContinuous(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 
 	// assert the replications aren't killed as result of change in limit
-	//assert.Equal(t, 2, rt2.GetActiveReplicatorCount())
 	rt2.WaitForActiveReplicatorCount(2)
 	// assert we still can't create a new replication
 	replicationID = t.Name() + "3"
@@ -638,7 +635,6 @@ func TestServerlessConnectionLimitingContinuous(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 	rt1.WaitForReplicationStatus(t.Name()+"1", db.ReplicationStateStopped)
 	// assert the count has been decremented
-	//assert.Equal(t, 1, rt2.GetActiveReplicatorCount())
 	rt2.WaitForActiveReplicatorCount(1)
 
 	// assert we still can't create new replication (new limit is 1)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -75,6 +75,7 @@ type ServerContext struct {
 
 type ActiveReplicationsCounter struct {
 	activeReplicatorCount int        // The count of concurrent active replicators
+	activeReplicatorLimit int        // The limit on number of active replicators allowed
 	lock                  sync.Mutex // Lock for managing access to shared memory location
 }
 
@@ -138,6 +139,9 @@ func NewServerContext(ctx context.Context, config *StartupConfig, persistentConf
 			sc.Config.API.AdminInterfaceAuthentication = base.BoolPtr(false)
 			sc.Config.API.MetricsInterfaceAuthentication = base.BoolPtr(false)
 		}
+	}
+	if config.Replicator.MaxConcurrentReplications != 0 {
+		sc.activeReplicatorLimit = config.Replicator.MaxConcurrentReplications
 	}
 
 	sc.startStatsLogger(ctx)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -70,7 +70,12 @@ type ServerContext struct {
 	LogContextID                  string          // ID to differentiate log messages from different server context
 	fetchConfigsLastUpdate        time.Time       // The last time fetchConfigsWithTTL() updated dbConfigs
 	allowScopesInPersistentConfig bool            // Test only backdoor to allow scopes in persistent config, not supported for multiple databases with different collections targeting the same bucket
-	activeReplicatorCount         int             // The count of concurrent active replicators
+	ActiveReplicationsCounter
+}
+
+type ActiveReplicationsCounter struct {
+	activeReplicatorCount int        // The count of concurrent active replicators
+	lock                  sync.Mutex // Lock for managing access to shared memory location
 }
 
 // defaultConfigRetryTimeout is the total retry time when waiting for in-flight config updates.  Set as a multiple of kv op timeout,

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -74,8 +74,8 @@ type ServerContext struct {
 }
 
 type ActiveReplicationsCounter struct {
-	activeReplicatorCount uint         // The count of concurrent active replicators
-	activeReplicatorLimit uint         // The limit on number of active replicators allowed
+	activeReplicatorCount int          // The count of concurrent active replicators
+	activeReplicatorLimit int          // The limit on number of active replicators allowed
 	lock                  sync.RWMutex // Lock for managing access to shared memory location
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -74,8 +74,8 @@ type ServerContext struct {
 }
 
 type ActiveReplicationsCounter struct {
-	activeReplicatorCount int          // The count of concurrent active replicators
-	activeReplicatorLimit int          // The limit on number of active replicators allowed
+	activeReplicatorCount uint         // The count of concurrent active replicators
+	activeReplicatorLimit uint         // The limit on number of active replicators allowed
 	lock                  sync.RWMutex // Lock for managing access to shared memory location
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -74,9 +74,9 @@ type ServerContext struct {
 }
 
 type ActiveReplicationsCounter struct {
-	activeReplicatorCount int        // The count of concurrent active replicators
-	activeReplicatorLimit int        // The limit on number of active replicators allowed
-	lock                  sync.Mutex // Lock for managing access to shared memory location
+	activeReplicatorCount int          // The count of concurrent active replicators
+	activeReplicatorLimit int          // The limit on number of active replicators allowed
+	lock                  sync.RWMutex // Lock for managing access to shared memory location
 }
 
 // defaultConfigRetryTimeout is the total retry time when waiting for in-flight config updates.  Set as a multiple of kv op timeout,
@@ -141,7 +141,7 @@ func NewServerContext(ctx context.Context, config *StartupConfig, persistentConf
 		}
 	}
 	if config.Replicator.MaxConcurrentReplications != 0 {
-		sc.activeReplicatorLimit = config.Replicator.MaxConcurrentReplications
+		sc.ActiveReplicationsCounter.activeReplicatorLimit = config.Replicator.MaxConcurrentReplications
 	}
 
 	sc.startStatsLogger(ctx)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -70,6 +70,7 @@ type ServerContext struct {
 	LogContextID                  string          // ID to differentiate log messages from different server context
 	fetchConfigsLastUpdate        time.Time       // The last time fetchConfigsWithTTL() updated dbConfigs
 	allowScopesInPersistentConfig bool            // Test only backdoor to allow scopes in persistent config, not supported for multiple databases with different collections targeting the same bucket
+	activeReplicatorCount         int             // The count of concurrent active replicators
 }
 
 // defaultConfigRetryTimeout is the total retry time when waiting for in-flight config updates.  Set as a multiple of kv op timeout,

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -167,6 +167,19 @@ func (rt *RestTester) WaitForAssignedReplications(count int) {
 	require.NoError(rt.TB, rt.WaitForCondition(successFunc))
 }
 
+func (rt *RestTester) GetActiveReplicatorCount() int {
+	return rt.ServerContext().activeReplicatorCount
+}
+
+func (rt *RestTester) WaitForActiveReplicatorCount(expCount int) {
+	var count int
+	successFunc := func() bool {
+		count = rt.GetActiveReplicatorCount()
+		return count == expCount
+	}
+	require.NoError(rt.TB, rt.WaitForCondition(successFunc), "Mismatch in active replicator count, expected count %d actual %d", expCount, count)
+}
+
 func (rt *RestTester) WaitForReplicationStatusForDB(dbName string, replicationID string, targetStatus string) {
 	var status db.ReplicationStatus
 	successFunc := func() bool {

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -167,17 +167,17 @@ func (rt *RestTester) WaitForAssignedReplications(count int) {
 	require.NoError(rt.TB, rt.WaitForCondition(successFunc))
 }
 
-func (rt *RestTester) GetActiveReplicatorCount() uint {
+func (rt *RestTester) GetActiveReplicatorCount() int {
 	rt.ServerContext().ActiveReplicationsCounter.lock.Lock()
 	defer rt.ServerContext().ActiveReplicationsCounter.lock.Unlock()
 	return rt.ServerContext().ActiveReplicationsCounter.activeReplicatorCount
 }
 
 func (rt *RestTester) WaitForActiveReplicatorCount(expCount int) {
-	var count uint
+	var count int
 	successFunc := func() bool {
 		count = rt.GetActiveReplicatorCount()
-		return count == uint(expCount)
+		return count == expCount
 	}
 	require.NoError(rt.TB, rt.WaitForCondition(successFunc), "Mismatch in active replicator count, expected count %d actual %d", expCount, count)
 }

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -168,6 +168,8 @@ func (rt *RestTester) WaitForAssignedReplications(count int) {
 }
 
 func (rt *RestTester) GetActiveReplicatorCount() int {
+	rt.ServerContext().lock.Lock()
+	defer rt.ServerContext().lock.Unlock()
 	return rt.ServerContext().activeReplicatorCount
 }
 

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -167,17 +167,17 @@ func (rt *RestTester) WaitForAssignedReplications(count int) {
 	require.NoError(rt.TB, rt.WaitForCondition(successFunc))
 }
 
-func (rt *RestTester) GetActiveReplicatorCount() int {
+func (rt *RestTester) GetActiveReplicatorCount() uint {
 	rt.ServerContext().ActiveReplicationsCounter.lock.Lock()
 	defer rt.ServerContext().ActiveReplicationsCounter.lock.Unlock()
 	return rt.ServerContext().ActiveReplicationsCounter.activeReplicatorCount
 }
 
 func (rt *RestTester) WaitForActiveReplicatorCount(expCount int) {
-	var count int
+	var count uint
 	successFunc := func() bool {
 		count = rt.GetActiveReplicatorCount()
-		return count == expCount
+		return count == uint(expCount)
 	}
 	require.NoError(rt.TB, rt.WaitForCondition(successFunc), "Mismatch in active replicator count, expected count %d actual %d", expCount, count)
 }

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -168,9 +168,9 @@ func (rt *RestTester) WaitForAssignedReplications(count int) {
 }
 
 func (rt *RestTester) GetActiveReplicatorCount() int {
-	rt.ServerContext().lock.Lock()
-	defer rt.ServerContext().lock.Unlock()
-	return rt.ServerContext().activeReplicatorCount
+	rt.ServerContext().ActiveReplicationsCounter.lock.Lock()
+	defer rt.ServerContext().ActiveReplicationsCounter.lock.Unlock()
+	return rt.ServerContext().ActiveReplicationsCounter.activeReplicatorCount
 }
 
 func (rt *RestTester) WaitForActiveReplicatorCount(expCount int) {


### PR DESCRIPTION
CBG-2895

Adding a configurable limit option for concurerent replication connections, this works for one shot and continuous feeds. Adding unit test for both scenarios and also have it limiting the changes endpoint requests for non normal feed requests. Unit test for this functionality is also included. I have also added a stat to track number of rejected connections. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1777/
