### PR TITLE
3.1.1 backport of allow /db/ if default collection is configured with other named collections (#6222)

### DIFF
--- a/rest/handler.go
+++ b/rest/handler.go
@@ -452,10 +452,13 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 	if ks != "" {
 		ksNotFound := base.HTTPErrorf(http.StatusNotFound, "keyspace %s not found", ks)
 		if dbContext.Scopes != nil {
-			// If scopes are defined on the database but not in th an empty scope to refer to the one SG is running with, rather than falling back to _default
+			// endpoint like /db/doc where this matches /db._default._default/
+			// the check whether the _default._default actually exists on this database is performed below
 			if keyspaceScope == nil && keyspaceCollection == nil {
-				ksNotFound = base.HTTPErrorf(http.StatusNotFound, "keyspace %s.%s.%s not found", ks, base.DefaultScope, base.DefaultCollection)
+				keyspaceScope = base.StringPtr(base.DefaultScope)
+				keyspaceCollection = base.StringPtr(base.DefaultCollection)
 			}
+			// endpoint like /db.collectionName/doc where this matches /db.scopeName.collectionName/doc because there's a single scope defined
 			if keyspaceScope == nil {
 				if len(dbContext.Scopes) == 1 {
 					for scopeName, _ := range dbContext.Scopes {
@@ -463,7 +466,8 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 					}
 
 				} else {
-					keyspaceScope = base.StringPtr(base.DefaultScope)
+					// There are multiple scopes on a DatabaseContext. This isn't allowed in Sync Gateway but if the feature becomes available, it will be ambiguous which scope to match.
+					return ksNotFound
 				}
 			}
 			scope, foundScope := dbContext.Scopes[*keyspaceScope]
@@ -471,12 +475,6 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 				return ksNotFound
 			}
 
-			if keyspaceCollection == nil {
-				if len(scope.Collections) > 1 {
-					return ksNotFound
-				}
-				keyspaceCollection = base.StringPtr(base.DefaultCollection)
-			}
 			_, foundCollection := scope.Collections[*keyspaceCollection]
 			if !foundCollection {
 				return ksNotFound


### PR DESCRIPTION
[07d12c3](https://github.com/couchbase/sync_gateway/commit/07d12c3f91b16a16a3ba96287aa94608ed61cdbc)

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1775/
