### PR TITLE
API Spec cleanup (scopes/collections)

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -529,15 +529,14 @@ Design-doc:
       type: string
     views:
       type: object
-      properties:
-        additionalProperties:
-          description: The name of the view.
-          type: object
-          properties:
-            map:
-              type: string
-            reduce:
-              type: string
+      additionalProperties:
+        description: The name of the view.
+        type: object
+        properties:
+          map:
+            type: string
+          reduce:
+            type: string
     options:
       type: object
       properties:
@@ -1078,13 +1077,17 @@ Replication-status:
     - replication_id
   title: Replication-status
 Scopes:
-  description: A map of all the collections with their corresponding configs for this scope
+  description: Scope-specific configuration.
   type: object
-  additionalProperties:
-    $ref: '#/CollectionConfig'
+  properties:
+    collections:
+      description: An object keyed by collection name containing config for the specific collection.
+      type: object
+      additionalProperties:
+        $ref: '#/CollectionConfig'
   title: Scopes
 CollectionConfig:
-  description: The configuration for the individual collection
+  description: Collection-specific configuration.
   type: object
   properties:
     sync:
@@ -1156,11 +1159,10 @@ Database:
       type: integer
       default: 1000
     scopes:
-      description: Scope and collection specific config.
+      description: An object keyed by scope name containing config for the specific collection.
       type: object
-      properties:
-        additionalProperties:
-          $ref: '#/Scopes'
+      additionalProperties:
+        $ref: '#/Scopes'
     name:
       description: The name of the database.
       type: string
@@ -1788,8 +1790,7 @@ Event-config:
     options:
       description: The options for the event.
       type: object
-      properties:
-        additionalProperties:
+      additionalProperties:
           description: The option key and value.
   title: Event-config
 Resync-status:


### PR DESCRIPTION
- Correctly represent the scopes/collections config structure in the OpenAPI specs.
- Cleanup invalid/redundant nesting of `additionalProperties` under `properties`

## Before:

![Screenshot 2023-05-11 at 12 45 16](https://github.com/couchbase/sync_gateway/assets/1525809/bf83a421-9f22-4ebb-beab-79bc4c8c3182)
![Screenshot 2023-05-11 at 12 45 11](https://github.com/couchbase/sync_gateway/assets/1525809/2ac7a008-cc68-4cc9-a30f-8979b650a920)

## After:

![Screenshot 2023-05-11 at 12 44 35](https://github.com/couchbase/sync_gateway/assets/1525809/0e2c2077-15df-419c-95dd-fd8a6934a775)
![Screenshot 2023-05-11 at 12 44 46](https://github.com/couchbase/sync_gateway/assets/1525809/ac3d2253-0424-43ac-9532-4ad36ba26d43)
