### PR TITLE
CBG-2944: Ensure proveAttachments works for v2 attachments with a v2 replication protocol

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -376,7 +376,8 @@ type CBLReplicationPullStats struct {
 	// The total amount of time processing rev messages (revisions) during pull revision.
 	RevProcessingTime *SgwIntStat `json:"rev_processing_time"`
 	// The total number of rev messages processed during replication.
-	RevSendCount *SgwIntStat `json:"rev_send_count"`
+	RevSendCount  *SgwIntStat `json:"rev_send_count"`
+	RevErrorCount *SgwIntStat `json:"rev_error_count"`
 	// The total amount of time between Sync Gateway receiving a request for a revision and that revision being sent.
 	//
 	// In a pull replication, Sync Gateway sends a /_changes request to the client and the client responds with the list of revisions it wants to receive.
@@ -1202,6 +1203,10 @@ func (d *DbStats) initCBLReplicationPullStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.RevErrorCount, err = NewIntStat(SubsystemReplicationPull, "rev_error_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.RevSendLatency, err = NewIntStat(SubsystemReplicationPull, "rev_send_latency", labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
@@ -1227,6 +1232,7 @@ func (d *DbStats) unregisterCBLReplicationPullStats() {
 	prometheus.Unregister(d.CBLReplicationPullStats.RequestChangesTime)
 	prometheus.Unregister(d.CBLReplicationPullStats.RevProcessingTime)
 	prometheus.Unregister(d.CBLReplicationPullStats.RevSendCount)
+	prometheus.Unregister(d.CBLReplicationPullStats.RevErrorCount)
 	prometheus.Unregister(d.CBLReplicationPullStats.RevSendLatency)
 }
 

--- a/base/stats.go
+++ b/base/stats.go
@@ -393,6 +393,8 @@ type CBLReplicationPushStats struct {
 	AttachmentPushCount *SgwIntStat `json:"attachment_push_count"`
 	// The total number of documents pushed.
 	DocPushCount *SgwIntStat `json:"doc_push_count"`
+	// The total number of documents that failed to push.
+	DocPushErrorCount *SgwIntStat `json:"doc_push_error_count"`
 	// The total number of changes and-or proposeChanges messages processed since node start-up.
 	ProposeChangeCount *SgwIntStat `json:"propose_change_count"`
 	// The total time spent processing changes and/or proposeChanges messages.
@@ -1258,6 +1260,10 @@ func (d *DbStats) initCBLReplicationPushStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.DocPushErrorCount, err = NewIntStat(SubsystemReplicationPush, "doc_push_error_count", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.ProposeChangeCount, err = NewIntStat(SubsystemReplicationPush, "propose_change_count", labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
@@ -1279,6 +1285,7 @@ func (d *DbStats) unregisterCBLReplicationPushStats() {
 	prometheus.Unregister(d.CBLReplicationPushStats.AttachmentPushBytes)
 	prometheus.Unregister(d.CBLReplicationPushStats.AttachmentPushCount)
 	prometheus.Unregister(d.CBLReplicationPushStats.DocPushCount)
+	prometheus.Unregister(d.CBLReplicationPushStats.DocPushErrorCount)
 	prometheus.Unregister(d.CBLReplicationPushStats.ProposeChangeCount)
 	prometheus.Unregister(d.CBLReplicationPushStats.ProposeChangeTime)
 	prometheus.Unregister(d.CBLReplicationPushStats.WriteProcessingTime)

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1204,7 +1204,9 @@ func (bh *blipHandler) handleProveAttachment(rq *blip.Message) error {
 		return base.HTTPErrorf(http.StatusBadRequest, "no digest sent with proveAttachment")
 	}
 
-	attData, err := bh.collection.GetAttachment(base.AttPrefix + digest)
+	allowedAttachment := bh.allowedAttachment(digest)
+	attachmentKey := MakeAttachmentKey(allowedAttachment.version, allowedAttachment.docID, digest)
+	attData, err := bh.collection.GetAttachment(attachmentKey)
 	if err != nil {
 		if bh.clientType == BLIPClientTypeSGR2 {
 			return ErrAttachmentNotFound

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -141,6 +141,7 @@ func BlipSyncStatsForCBL(dbStats *base.DbStats) *BlipSyncStats {
 	blipStats.HandleChangesResponseCount = dbStats.CBLReplicationPull().RequestChangesCount
 	blipStats.HandleChangesResponseTime = dbStats.CBLReplicationPull().RequestChangesTime
 	blipStats.HandleChangesSendRevCount = dbStats.CBLReplicationPull().RevSendCount
+	blipStats.SendRevErrorTotal = dbStats.CBLReplicationPull().RevErrorCount
 	blipStats.HandleChangesSendRevLatency = dbStats.CBLReplicationPull().RevSendLatency
 	blipStats.HandleChangesSendRevTime = dbStats.CBLReplicationPull().RevProcessingTime
 

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -135,6 +135,7 @@ func BlipSyncStatsForCBL(dbStats *base.DbStats) *BlipSyncStats {
 	blipStats.HandleRevProcessingTime = dbStats.CBLReplicationPush().WriteProcessingTime
 
 	blipStats.HandleRevCount = dbStats.CBLReplicationPush().DocPushCount
+	blipStats.HandleRevErrorCount = dbStats.CBLReplicationPush().DocPushErrorCount
 
 	blipStats.HandleGetAttachment = dbStats.CBLReplicationPull().AttachmentPullCount
 	blipStats.HandleGetAttachmentBytes = dbStats.CBLReplicationPull().AttachmentPullBytes

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -129,6 +129,7 @@ func BlipSyncStatsForCBL(dbStats *base.DbStats) *BlipSyncStats {
 
 	blipStats.SendRevBytes = dbStats.Database().DocReadsBytesBlip
 	blipStats.SendRevCount = dbStats.Database().NumDocReadsBlip
+	blipStats.SendRevErrorTotal = dbStats.CBLReplicationPull().RevErrorCount
 
 	blipStats.HandleRevBytes = dbStats.Database().DocWritesBytesBlip
 	blipStats.HandleRevProcessingTime = dbStats.CBLReplicationPush().WriteProcessingTime
@@ -141,7 +142,6 @@ func BlipSyncStatsForCBL(dbStats *base.DbStats) *BlipSyncStats {
 	blipStats.HandleChangesResponseCount = dbStats.CBLReplicationPull().RequestChangesCount
 	blipStats.HandleChangesResponseTime = dbStats.CBLReplicationPull().RequestChangesTime
 	blipStats.HandleChangesSendRevCount = dbStats.CBLReplicationPull().RevSendCount
-	blipStats.SendRevErrorTotal = dbStats.CBLReplicationPull().RevErrorCount
 	blipStats.HandleChangesSendRevLatency = dbStats.CBLReplicationPull().RevSendLatency
 	blipStats.HandleChangesSendRevTime = dbStats.CBLReplicationPull().RevProcessingTime
 

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -212,7 +212,7 @@ func TestBlipProveAttachmentV2(t *testing.T) {
 		attachmentDigest  = "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="
 	)
 
-	// Create two docs with the same attachment data on SG - v2 attachments result in two copies,
+	// Create two docs with the same attachment data on SG - v2 attachments intentionally result in two copies,
 	// CBL will still de-dupe attachments based on digest, so will still try proveAttachmnet for the 2nd.
 	doc1Body := fmt.Sprintf(`{"greetings":[{"hi": "alice"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
 	response := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+doc1ID, doc1Body)
@@ -239,6 +239,58 @@ func TestBlipProveAttachmentV2(t *testing.T) {
 	assert.Equal(t, int64(0), rt.GetDatabase().DbStats.CBLReplicationPull().RevErrorCount.Value())
 	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.CBLReplicationPull().AttachmentPullCount.Value())
 	assert.Equal(t, int64(len(attachmentData)), rt.GetDatabase().DbStats.CBLReplicationPull().AttachmentPullBytes.Value())
+}
+
+// TestBlipProveAttachmentV2Push ensures that CBL's attachment deduplication is ignored for push replications - resulting in new server-side digests and duplicated attachment data (v2 attachment format).
+func TestBlipProveAttachmentV2Push(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
+	rtConfig := RestTesterConfig{
+		GuestEnabled: true,
+	}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+
+	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+		SupportedBLIPProtocols: []string{db.BlipCBMobileReplicationV2},
+	})
+	require.NoError(t, err)
+	defer btc.Close()
+
+	const (
+		doc1ID = "doc1"
+		doc2ID = "doc2"
+	)
+
+	const (
+		attachmentName = "hello.txt"
+		attachmentData = "hello world"
+	)
+
+	var (
+		attachmentDataB64 = base64.StdEncoding.EncodeToString([]byte(attachmentData))
+		// attachmentDigest  = "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="
+	)
+
+	// Create two docs with the same attachment data on the client - v2 attachments intentionally result in two copies stored on the server, despite the client being able to share the data for both.
+	doc1Body := fmt.Sprintf(`{"greetings":[{"hi": "alice"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
+	doc1revID, err := btc.PushRev(doc1ID, "", []byte(doc1Body))
+	require.NoError(t, err)
+
+	err = rt.WaitForRev(doc1ID, doc1revID)
+	require.NoError(t, err)
+
+	// create doc2 now that we know the server has the attachment - SG should still request the attachment data from the client.
+	doc2Body := fmt.Sprintf(`{"greetings":[{"howdy": "bob"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
+	doc2RevID, err := btc.PushRev(doc2ID, "", []byte(doc2Body))
+	require.NoError(t, err)
+
+	err = rt.WaitForRev(doc2ID, doc2RevID)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPush().DocPushCount.Value())
+	assert.Equal(t, int64(0), rt.GetDatabase().DbStats.CBLReplicationPush().DocPushErrorCount.Value())
+	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value())
+	assert.Equal(t, int64(2*len(attachmentData)), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushBytes.Value())
 }
 
 func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -178,6 +178,69 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value())
 	assert.Equal(t, int64(11), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushBytes.Value())
 }
+
+// TestBlipProveAttachmentV2 ensures that CBL's proveAttachment for deduplication is working correctly even for v2 attachments which aren't de-duped on the server side.
+func TestBlipProveAttachmentV2(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
+	rtConfig := RestTesterConfig{
+		GuestEnabled: true,
+	}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+
+	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+		SupportedBLIPProtocols: []string{db.BlipCBMobileReplicationV2},
+	})
+	require.NoError(t, err)
+	defer btc.Close()
+
+	err = btc.StartPull()
+	assert.NoError(t, err)
+
+	const (
+		doc1ID = "doc1"
+		doc2ID = "doc2"
+	)
+
+	const (
+		attachmentName = "hello.txt"
+		attachmentData = "hello world"
+	)
+
+	var (
+		attachmentDataB64 = base64.StdEncoding.EncodeToString([]byte(attachmentData))
+		attachmentDigest  = "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="
+	)
+
+	// Create two docs with the same attachment data on SG - v2 attachments result in two copies,
+	// CBL will still de-dupe attachments based on digest, so will still try proveAttachmnet for the 2nd.
+	doc1Body := fmt.Sprintf(`{"greetings":[{"hi": "alice"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
+	response := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+doc1ID, doc1Body)
+	RequireStatus(t, response, http.StatusCreated)
+	doc1RevID := RespRevID(t, response)
+
+	data, ok := btc.WaitForRev(doc1ID, doc1RevID)
+	require.True(t, ok)
+	bodyTextExpected := fmt.Sprintf(`{"greetings":[{"hi":"alice"}],"_attachments":{"%s":{"revpos":1,"length":%d,"stub":true,"digest":"%s"}}}`, attachmentName, len(attachmentData), attachmentDigest)
+	require.JSONEq(t, bodyTextExpected, string(data))
+
+	// create doc2 now that we know the client has the attachment
+	doc2Body := fmt.Sprintf(`{"greetings":[{"howdy": "bob"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
+	response = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+doc2ID, doc2Body)
+	RequireStatus(t, response, http.StatusCreated)
+	doc2RevID := RespRevID(t, response)
+
+	data, ok = btc.WaitForRev(doc2ID, doc2RevID)
+	require.True(t, ok)
+	bodyTextExpected = fmt.Sprintf(`{"greetings":[{"howdy":"bob"}],"_attachments":{"%s":{"revpos":1,"length":%d,"stub":true,"digest":"%s"}}}`, attachmentName, len(attachmentData), attachmentDigest)
+	require.JSONEq(t, bodyTextExpected, string(data))
+
+	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPull().RevSendCount.Value())
+	assert.Equal(t, int64(0), rt.GetDatabase().DbStats.CBLReplicationPull().RevErrorCount.Value())
+	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.CBLReplicationPull().AttachmentPullCount.Value())
+	assert.Equal(t, int64(len(attachmentData)), rt.GetDatabase().DbStats.CBLReplicationPull().AttachmentPullBytes.Value())
+}
+
 func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -322,7 +322,10 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 					if _, found := btcr.attachments[digest]; !found {
 						missingDigests = append(missingDigests, digest)
 					} else {
-						knownDigests = append(knownDigests, digest)
+						if btr.bt.blipContext.ActiveSubprotocol() == db.BlipCBMobileReplicationV2 {
+							// only v2 clients care about proveAttachments
+							knownDigests = append(knownDigests, digest)
+						}
 					}
 				}
 				btcr.attachmentsLock.RUnlock()

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -310,6 +310,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 				}
 
 				var missingDigests []string
+				var knownDigests []string
 				btcr.attachmentsLock.RLock()
 				for _, attachment := range attsMap {
 					attMap, ok := attachment.(map[string]interface{})
@@ -320,9 +321,59 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 
 					if _, found := btcr.attachments[digest]; !found {
 						missingDigests = append(missingDigests, digest)
+					} else {
+						knownDigests = append(knownDigests, digest)
 					}
 				}
 				btcr.attachmentsLock.RUnlock()
+
+				for _, digest := range knownDigests {
+					attData, err := btcr.getAttachment(digest)
+					if err != nil {
+						panic(err)
+					}
+					nonce, proof, err := db.GenerateProofOfAttachment(attData)
+					if err != nil {
+						panic(err)
+					}
+
+					// if we already have this attachment, _we_ should ask the peer whether _they_ have the attachment
+					outrq := blip.NewRequest()
+					outrq.SetProfile(db.MessageProveAttachment)
+					outrq.Properties[db.ProveAttachmentDigest] = digest
+					outrq.SetBody(nonce)
+
+					err = btcr.sendPullMsg(outrq)
+					if err != nil {
+						panic(err)
+					}
+
+					resp := outrq.Response()
+					btc.pullReplication.storeMessage(resp)
+					respBody, err := resp.Body()
+					if err != nil {
+						panic(err)
+					}
+
+					if resp.Type() == blip.ErrorType {
+						// forward error from proveAttachment response into rev response
+						if !msg.NoReply() {
+							response := msg.Response()
+							errorCode, _ := strconv.Atoi(resp.Properties["Error-Code"])
+							response.SetError(resp.Properties["Error-Code"], errorCode, string(respBody))
+						}
+						return
+					}
+
+					if string(respBody) != proof {
+						// forward error from proveAttachment response into rev response
+						if !msg.NoReply() {
+							response := msg.Response()
+							response.SetError(resp.Properties["Error-Code"], http.StatusForbidden, fmt.Sprintf("Incorrect proof for attachment %s", digest))
+						}
+						return
+					}
+				}
 
 				for _, digest := range missingDigests {
 					outrq := blip.NewRequest()

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -484,10 +484,11 @@ func (btc *BlipTesterCollectionClient) saveAttachment(_, base64data string) (dat
 
 	digest = db.Sha1DigestKey(data)
 	if _, found := btc.attachments[digest]; found {
-		return 0, "", fmt.Errorf("attachment with digest already exists")
+		base.InfofCtx(context.TODO(), base.KeySync, "attachment with digest %s already exists", digest)
+	} else {
+		btc.attachments[digest] = data
 	}
 
-	btc.attachments[digest] = data
 	return len(data), digest, nil
 }
 


### PR DESCRIPTION
CBG-2944

- Ensures that v2 attachments are found for `proveAttachments` by getting doc ID
- Not handling case for v3 replication protocol as `proveAttachments` isn't used (attachments are document scoped)
- Adds BlipTesterClient enhancements to run `proveAttachments` under v2 replication for known attachments

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1778/
