### PR TITLE
Rename TestStatusAfterReplicationRebalanceFail to avoid 'Fail:' search term

### DIFF
--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -781,7 +781,8 @@ func TestReplicationStatusActions(t *testing.T) {
 
 }
 
-func TestStatusAfterReplicationRebalanceFail(t *testing.T) {
+// TestReplicationRebalanceToZeroNodes checks that the replication goes into an unassigned state when there are no nodes available to run replications.
+func TestReplicationRebalanceToZeroNodes(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	activeRT, remoteRT, _, teardown := rest.SetupSGRPeers(t)
 	defer teardown()


### PR DESCRIPTION
Fixes minor annoyance where this test name appears when searching test output for `Fail:`