### PR TITLE
Redeclare TestOneShotGrantRequestPlusDbConfig changes variable in goroutines to avoid race

### DIFF
--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -4190,6 +4190,10 @@ func TestOneShotGrantRequestPlusDbConfig(t *testing.T) {
 	// Issue a GET one-shot changes request in a separate goroutine.  Should run as request plus based on config
 	oneShotComplete.Add(1)
 	go func() {
+		var changes struct {
+			Results  []db.ChangeEntry
+			Last_Seq interface{}
+		}
 		defer oneShotComplete.Done()
 		changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
 		rest.RequireStatus(t, changesResponse, 200)
@@ -4204,6 +4208,10 @@ func TestOneShotGrantRequestPlusDbConfig(t *testing.T) {
 	// Issue a POST one-shot changes request in a separate goroutine. Should run as request plus based on config
 	oneShotComplete.Add(1)
 	go func() {
+		var changes struct {
+			Results  []db.ChangeEntry
+			Last_Seq interface{}
+		}
 		defer oneShotComplete.Done()
 		changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", `{}`, "bernard")
 		rest.RequireStatus(t, changesResponse, 200)


### PR DESCRIPTION
These goroutines are using `changes` in a way that was racy - redeclare variable inside the scope for each to avoid race:

https://jenkins.sgwdev.com/job/Sync%20Gateway%20Pipeline/job/master/628 

```
==================
WARNING: DATA RACE
Write at 0x00c000e0d8d8 by goroutine 17823:
  reflect.Value.SetString()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/reflect/value.go:2439 +0x90
  encoding/json.(*decodeState).literalStore()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/encoding/json/decode.go:967 +0xf2f
  encoding/json.(*decodeState).value()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/encoding/json/decode.go:388 +0x24e
  encoding/json.(*decodeState).object()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/encoding/json/decode.go:775 +0x12c9
  encoding/json.(*decodeState).value()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/encoding/json/decode.go:374 +0xb9
  encoding/json.(*decodeState).array()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/encoding/json/decode.go:562 +0xb70
  encoding/json.(*decodeState).value()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/encoding/json/decode.go:364 +0x128
  encoding/json.(*decodeState).object()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/encoding/json/decode.go:775 +0x12c9
  encoding/json.(*decodeState).value()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/encoding/json/decode.go:374 +0xb9
  encoding/json.(*decodeState).unmarshal()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/encoding/json/decode.go:181 +0x3e4
  encoding/json.Unmarshal()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/encoding/json/decode.go:108 +0x239
  github.com/couchbase/sync_gateway/base.JSONUnmarshal()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master@2/base/util_ce.go:37 +0x24b
  github.com/couchbase/sync_gateway/rest/changestest.TestOneShotGrantRequestPlusDbConfig.func1()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master@2/rest/changestest/changes_api_test.go:4196 +0x115

Previous read at 0x00c000e0d8d8 by goroutine 17824:
  github.com/couchbase/sync_gateway/rest/changestest.TestOneShotGrantRequestPlusDbConfig.func2()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master@2/rest/changestest/changes_api_test.go:4212 +0x37d

Goroutine 17823 (running) created at:
  github.com/couchbase/sync_gateway/rest/changestest.TestOneShotGrantRequestPlusDbConfig()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master@2/rest/changestest/changes_api_test.go:4192 +0x13d5
  testing.tRunner()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/testing/testing.go:1629 +0x47

Goroutine 17824 (running) created at:
  github.com/couchbase/sync_gateway/rest/changestest.TestOneShotGrantRequestPlusDbConfig()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master@2/rest/changestest/changes_api_test.go:4206 +0x15ab
  testing.tRunner()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/testing/testing.go:1629 +0x47
==================
```