### PR TITLE
Use less or equal as a speculative fix

### DIFF
--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -672,7 +672,7 @@ func toHistory(revisions Revisions, knownRevs map[string]bool, maxHistory int) [
 
 // timeElapsedForStatsReporting will return true if enough time has passed since the previous report.
 func (bsc *BlipSyncContext) timeElapsedForStatsReporting(currentTime int64) bool {
-	return (currentTime - bsc.stats.lastReportTime.Load()) > bsc.blipContextDb.Options.BlipStatsReportingInterval
+	return (currentTime - bsc.stats.lastReportTime.Load()) >= bsc.blipContextDb.Options.BlipStatsReportingInterval
 }
 
 // reportStats will update the stats on a database immediately if updateImmediately is true, otherwise update on BlipStatsReportinInterval


### PR DESCRIPTION
It seems like the failure in https://jenkins.sgwdev.com/job/MasterIntegration/474/testReport/junit/github/com_couchbase_sync_gateway_rest/TestBlipStatsFastReport/ could be caused by this if the millisecond resolution happens very fast. But it seems like the machines are slower than my test machines.

I don't think this fix will cause any problems but it's a speculative fix.