### PR TITLE
Fix race in TestOneShotGrant tests

### DIFF
--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -4051,11 +4051,6 @@ func TestOneShotGrantRequestPlus(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-4", `{"channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
 
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
-
 	// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
 	slowSequence, seqErr := db.AllocateTestSequence(database)
 	require.NoError(t, seqErr)
@@ -4071,9 +4066,10 @@ func TestOneShotGrantRequestPlus(t *testing.T) {
 	oneShotComplete.Add(1)
 	go func() {
 		defer oneShotComplete.Done()
+		var changes rest.ChangesResults
 		changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?request_plus=true", "", "bernard")
 		rest.RequireStatus(t, changesResponse, 200)
-		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+		err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 		assert.NoError(t, err, "Error unmarshalling changes response")
 		for _, entry := range changes.Results {
 			log.Printf("Entry:%+v", entry)
@@ -4085,6 +4081,7 @@ func TestOneShotGrantRequestPlus(t *testing.T) {
 	oneShotComplete.Add(1)
 	go func() {
 		defer oneShotComplete.Done()
+		var changes rest.ChangesResults
 		changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", `{"request_plus":true}`, "bernard")
 		rest.RequireStatus(t, changesResponse, 200)
 		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
@@ -4148,11 +4145,6 @@ func TestOneShotGrantRequestPlusDbConfig(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-4", `{"channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
 
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
-
 	// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
 	slowSequence, seqErr := db.AllocateTestSequence(database)
 	require.NoError(t, seqErr)
@@ -4166,6 +4158,7 @@ func TestOneShotGrantRequestPlusDbConfig(t *testing.T) {
 	// Expect no results as granting document hasn't been buffered (blocked by slowSequence)
 	changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?request_plus=false", "", "bernard")
 	rest.RequireStatus(t, changesResponse, 200)
+	var changes rest.ChangesResults
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	for _, entry := range changes.Results {
@@ -4191,9 +4184,10 @@ func TestOneShotGrantRequestPlusDbConfig(t *testing.T) {
 	oneShotComplete.Add(1)
 	go func() {
 		defer oneShotComplete.Done()
+		var changes rest.ChangesResults
 		changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
 		rest.RequireStatus(t, changesResponse, 200)
-		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+		err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 		assert.NoError(t, err, "Error unmarshalling changes response")
 		for _, entry := range changes.Results {
 			log.Printf("Entry:%+v", entry)
@@ -4205,9 +4199,10 @@ func TestOneShotGrantRequestPlusDbConfig(t *testing.T) {
 	oneShotComplete.Add(1)
 	go func() {
 		defer oneShotComplete.Done()
+		var changes rest.ChangesResults
 		changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", `{}`, "bernard")
 		rest.RequireStatus(t, changesResponse, 200)
-		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+		err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 		assert.NoError(t, err, "Error unmarshalling changes response")
 		for _, entry := range changes.Results {
 			log.Printf("Entry:%+v", entry)


### PR DESCRIPTION
CBG-2853

Fix for data race in new tests.

