### PR TITLE
Backport rest API tweaks for docs (#6182) to release/3.1.0

### DIFF
--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -22,7 +22,6 @@ lint:
   rules:
     # disable unnecessary/invalid warnings
     operation-2xx-response: off # _blipsync 101 Upgrade ...
-    operation-operationId: off  # Optional (mostly used for generating code)
     operation-summary: off      # Optional field
     no-ambiguous-paths: off     # /{db}/{doc} != /_debug/expvar
     no-identical-paths: off     # /{db} != /{targetdb}

--- a/docs/api/paths/admin/-.yaml
+++ b/docs/api/paths/admin/-.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get server information
   description: Returns information about the Sync Gateway node.
@@ -18,6 +17,7 @@ get:
             $ref: ../../components/schemas.yaml#/NodeInfo
   tags:
     - Server
+  operationId: get_-
 head:
   responses:
     '200':
@@ -26,3 +26,4 @@ head:
     - Server
   summary: Check if server online
   description: Check if the server is online by checking the status code of response.
+  operationId: head_-

--- a/docs/api/paths/admin/_all_dbs.yaml
+++ b/docs/api/paths/admin/_all_dbs.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get a list of all the databases
   description: |-
@@ -25,6 +24,7 @@ get:
               type: string
   tags:
     - Database Management
+  operationId: get__all_dbs
 head:
   summary: /_all_dbs
   description: |-
@@ -36,3 +36,4 @@ head:
       description: OK
   tags:
     - Database Management
+  operationId: head__all_dbs

--- a/docs/api/paths/admin/_config.yaml
+++ b/docs/api/paths/admin/_config.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get server configuration
   description: |-
@@ -33,6 +32,7 @@ get:
       $ref: ../../components/responses.yaml#/request-problem
   tags:
     - Server
+  operationId: get__config
 put:
   summary: Set runtime configuration
   description: |-
@@ -57,3 +57,4 @@ put:
       $ref: ../../components/responses.yaml#/request-problem
   tags:
     - Server
+  operationId: put__config

--- a/docs/api/paths/admin/_debug-fgprof.yaml
+++ b/docs/api/paths/admin/_debug-fgprof.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get fgprof profile
   description: |-
@@ -25,6 +24,7 @@ get:
             type: string
   tags:
     - Profiling
+  operationId: get__debug-fgprof
 post:
   summary: Get fgprof profile
   description: |-
@@ -44,3 +44,4 @@ post:
             type: string
   tags:
     - Profiling
+  operationId: post__debug-fgprof

--- a/docs/api/paths/admin/_debug-pprof-block.yaml
+++ b/docs/api/paths/admin/_debug-pprof-block.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get block profile
   description: |-
@@ -30,6 +29,7 @@ get:
             reason: Can only run one mutex profile at a time
   tags:
     - Profiling
+  operationId: get__debug-pprof-block
 post:
   summary: Get block profile
   description: |-
@@ -54,3 +54,4 @@ post:
             reason: Can only run one mutex profile at a time
   tags:
     - Profiling
+  operationId: post__debug-pprof-block

--- a/docs/api/paths/admin/_debug-pprof-cmdline.yaml
+++ b/docs/api/paths/admin/_debug-pprof-cmdline.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get passed in command line parameters
   description: |-
@@ -23,6 +22,7 @@ get:
             type: string
   tags:
     - Profiling
+  operationId: get__debug-pprof-cmdline
 post:
   summary: Get passed in command line parameters
   description: |-
@@ -40,3 +40,4 @@ post:
             type: string
   tags:
     - Profiling
+  operationId: post__debug-pprof-cmdline

--- a/docs/api/paths/admin/_debug-pprof-goroutine.yaml
+++ b/docs/api/paths/admin/_debug-pprof-goroutine.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get goroutine profile
   description: |-
@@ -21,6 +20,7 @@ get:
       $ref: ../../components/responses.yaml#/pprof-binary
   tags:
     - Profiling
+  operationId: get__debug-pprof-goroutine
 post:
   summary: Get goroutine profile
   description: |-
@@ -36,3 +36,4 @@ post:
       $ref: ../../components/responses.yaml#/pprof-binary
   tags:
     - Profiling
+  operationId: post__debug-pprof-goroutine

--- a/docs/api/paths/admin/_debug-pprof-heap.yaml
+++ b/docs/api/paths/admin/_debug-pprof-heap.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get the heap pprof debug file
   description: |-
@@ -19,6 +18,7 @@ get:
       $ref: ../../components/responses.yaml#/pprof-binary
   tags:
     - Profiling
+  operationId: get__debug-pprof-heap
 post:
   summary: Get the heap pprof debug file
   description: |-
@@ -32,3 +32,4 @@ post:
       $ref: ../../components/responses.yaml#/pprof-binary
   tags:
     - Profiling
+  operationId: post__debug-pprof-heap

--- a/docs/api/paths/admin/_debug-pprof-mutex.yaml
+++ b/docs/api/paths/admin/_debug-pprof-mutex.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get mutex profile
   description: |-
@@ -30,6 +29,7 @@ get:
             reason: Can only run one mutex profile at a time
   tags:
     - Profiling
+  operationId: get__debug-pprof-mutex
 post:
   summary: Get mutex profile
   description: |-
@@ -54,3 +54,4 @@ post:
             reason: Can only run one mutex profile at a time
   tags:
     - Profiling
+  operationId: post__debug-pprof-mutex

--- a/docs/api/paths/admin/_debug-pprof-profile.yaml
+++ b/docs/api/paths/admin/_debug-pprof-profile.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get the profile pprof debug file
   description: |-
@@ -19,6 +18,7 @@ get:
       $ref: ../../components/responses.yaml#/pprof-binary
   tags:
     - Profiling
+  operationId: get__debug-pprof-profile
 post:
   summary: Get the profile pprof debug file
   description: |-
@@ -32,3 +32,4 @@ post:
       $ref: ../../components/responses.yaml#/pprof-binary
   tags:
     - Profiling
+  operationId: post__debug-pprof-profile

--- a/docs/api/paths/admin/_debug-pprof-symbol.yaml
+++ b/docs/api/paths/admin/_debug-pprof-symbol.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get symbol pprof debug information
   description: |-
@@ -21,6 +20,7 @@ get:
             type: string
   tags:
     - Profiling
+  operationId: get__debug-pprof-symbol
 post:
   summary: Get symbol pprof debug information
   description: |-
@@ -36,3 +36,4 @@ post:
             type: string
   tags:
     - Profiling
+  operationId: post__debug-pprof-symbol

--- a/docs/api/paths/admin/_debug-pprof-threadcreate.yaml
+++ b/docs/api/paths/admin/_debug-pprof-threadcreate.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get the threadcreate pprof debug file
   description: |-
@@ -17,6 +16,7 @@ get:
       $ref: ../../components/responses.yaml#/pprof-binary
   tags:
     - Profiling
+  operationId: get__debug-pprof-threadcreate
 post:
   summary: Get the threadcreate pprof debug file
   description: |-
@@ -28,3 +28,4 @@ post:
       $ref: ../../components/responses.yaml#/pprof-binary
   tags:
     - Profiling
+  operationId: post__debug-pprof-threadcreate

--- a/docs/api/paths/admin/_debug-pprof-trace.yaml
+++ b/docs/api/paths/admin/_debug-pprof-trace.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get trace profile
   description: |-
@@ -25,6 +24,7 @@ get:
       $ref: ../../components/responses.yaml#/pprof-binary
   tags:
     - Profiling
+  operationId: get__debug-pprof-trace
 post:
   summary: Get trace profile
   description: |-
@@ -44,3 +44,4 @@ post:
       $ref: ../../components/responses.yaml#/pprof-binary
   tags:
     - Profiling
+  operationId: post__debug-pprof-trace

--- a/docs/api/paths/admin/_expvar.yaml
+++ b/docs/api/paths/admin/_expvar.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get all Sync Gateway statistics
   description: |-
@@ -27,3 +26,4 @@ get:
             $ref: ../../components/schemas.yaml#/ExpVars
   tags:
     - Metrics
+  operationId: get__expvar

--- a/docs/api/paths/admin/_heap.yaml
+++ b/docs/api/paths/admin/_heap.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 post:
   summary: Dump heap profile
   description: |-
@@ -23,3 +22,4 @@ post:
       $ref: ../../components/responses.yaml#/request-problem
   tags:
     - Profiling
+  operationId: post__heap

--- a/docs/api/paths/admin/_logging.yaml
+++ b/docs/api/paths/admin/_logging.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get console logging settings
   description: |-
@@ -25,6 +24,7 @@ get:
   deprecated: true
   tags:
     - Server
+  operationId: get__logging
 put:
   summary: Set console logging settings
   description: |-
@@ -51,6 +51,7 @@ put:
   deprecated: true
   tags:
     - Server
+  operationId: put__logging
 post:
   summary: Update console logging settings
   description: |-
@@ -77,3 +78,4 @@ post:
   deprecated: true
   tags:
     - Server
+  operationId: post__logging

--- a/docs/api/paths/admin/_post_upgrade.yaml
+++ b/docs/api/paths/admin/_post_upgrade.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 post:
   summary: Run the post upgrade process on all databases
   description: |-
@@ -57,3 +56,4 @@ post:
               - post_upgrade_results
   tags:
     - Server
+  operationId: post__post_upgrade

--- a/docs/api/paths/admin/_profile-profilename.yaml
+++ b/docs/api/paths/admin/_profile-profilename.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - name: profilename
     in: path
@@ -38,3 +37,4 @@ post:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Profiling
+  operationId: post__profile-profilename

--- a/docs/api/paths/admin/_profile.yaml
+++ b/docs/api/paths/admin/_profile.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 post:
   summary: Start or Stop continuous CPU profiling
   description: |-
@@ -27,3 +26,4 @@ post:
       $ref: ../../components/responses.yaml#/request-problem
   tags:
     - Profiling
+  operationId: post__profile

--- a/docs/api/paths/admin/_sgcollect_info.yaml
+++ b/docs/api/paths/admin/_sgcollect_info.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get the status of the Sync Gateway Collect Info
   description: |-
@@ -32,6 +31,7 @@ get:
               - status
   tags:
     - Server
+  operationId: get__sgcollect_info
 post:
   summary: Start Sync Gateway Collect Info
   description: |-
@@ -107,6 +107,7 @@ post:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
     - Server
+  operationId: post__sgcollect_info
 delete:
   summary: Cancel the Sync Gateway Collect Info job
   description: |-
@@ -131,3 +132,4 @@ delete:
       $ref: ../../components/responses.yaml#/request-problem
   tags:
     - Server
+  operationId: delete__sgcollect_info

--- a/docs/api/paths/admin/_stats.yaml
+++ b/docs/api/paths/admin/_stats.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get memory statistics
   description: |-
@@ -29,3 +28,4 @@ get:
                 additionalProperties: true
   tags:
     - Metrics
+  operationId: get__stats

--- a/docs/api/paths/admin/_status.yaml
+++ b/docs/api/paths/admin/_status.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get the server status
   description: |-
@@ -25,3 +24,4 @@ get:
       $ref: ../../components/responses.yaml#/request-problem
   tags:
     - Server
+  operationId: get__status

--- a/docs/api/paths/admin/db-.yaml
+++ b/docs/api/paths/admin/db-.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -95,6 +94,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Management
+  operationId: get_db-
 delete:
   summary: Remove a database
   description: |-
@@ -123,6 +123,7 @@ delete:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
     - Database Management
+  operationId: delete_db-
 head:
   summary: Check if database exists
   description: |-
@@ -138,6 +139,7 @@ head:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Management
+  operationId: head_db-
 put:
   summary: Create a new Sync Gateway database
   description: |-
@@ -191,3 +193,4 @@ put:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
     - Database Management
+  operationId: put_db-

--- a/docs/api/paths/admin/db-_blipsync.yaml
+++ b/docs/api/paths/admin/db-_blipsync.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -42,3 +41,4 @@ get:
             reason: Can't upgrade this request to websocket connection
   tags:
     - Replication
+  operationId: get_db-_blipsync

--- a/docs/api/paths/admin/db-_compact.yaml
+++ b/docs/api/paths/admin/db-_compact.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:
@@ -64,6 +63,7 @@ post:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
     - Database Management
+  operationId: post_db-_compact
 get:
   summary: Get the status of the most recent compact operation
   description: |-
@@ -87,3 +87,4 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Management
+  operationId: get_db-_compact

--- a/docs/api/paths/admin/db-_config.yaml
+++ b/docs/api/paths/admin/db-_config.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get database configuration
   description: |-
@@ -45,6 +44,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Configuration
+  operationId: get_db-_config
 put:
   summary: Replace database configuration
   description: |-
@@ -76,6 +76,7 @@ put:
       $ref: ../../components/responses.yaml#/DB-config-precondition-failed
   tags:
     - Database Configuration
+  operationId: put_db-_config
 post:
   summary: Update database configuration
   description: |-
@@ -106,5 +107,6 @@ post:
       $ref: ../../components/responses.yaml#/DB-config-precondition-failed
   tags:
     - Database Configuration
+  operationId: post_db-_config
 parameters:
   - $ref: ../../components/parameters.yaml#/db

--- a/docs/api/paths/admin/db-_design-ddoc-_view-view.yaml
+++ b/docs/api/paths/admin/db-_design-ddoc-_view-view.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/ddoc
@@ -78,3 +77,4 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Unsupported
+  operationId: get_db-_design-ddoc-_view-view

--- a/docs/api/paths/admin/db-_design-ddoc.yaml
+++ b/docs/api/paths/admin/db-_design-ddoc.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/ddoc
@@ -33,6 +32,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Unsupported
+  operationId: get_db-_design-ddoc
 put:
   summary: Update views of a design document | Unsupported
   description: |-
@@ -57,6 +57,7 @@ put:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Unsupported
+  operationId: put_db-_design-ddoc
 delete:
   summary: Delete a design document | Unsupported
   description: |-
@@ -76,6 +77,7 @@ delete:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Unsupported
+  operationId: delete_db-_design-ddoc
 head:
   responses:
     '200':
@@ -96,3 +98,4 @@ head:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   summary: Check if view of design document exists | Unsupported
+  operationId: head_db-_design-ddoc

--- a/docs/api/paths/admin/db-_dump-view.yaml
+++ b/docs/api/paths/admin/db-_dump-view.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/view
@@ -37,3 +36,4 @@ get:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
     - Unsupported
+  operationId: get_db-_dump-view

--- a/docs/api/paths/admin/db-_ensure_full_commit.yaml
+++ b/docs/api/paths/admin/db-_ensure_full_commit.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:
@@ -35,3 +34,4 @@ post:
                 default: true
   tags:
     - Database Management
+  operationId: post_db-_ensure_full_commit

--- a/docs/api/paths/admin/db-_facebook.yaml
+++ b/docs/api/paths/admin/db-_facebook.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:
@@ -68,3 +67,4 @@ post:
   deprecated: true
   tags:
     - Authentication
+  operationId: post_db-_facebook

--- a/docs/api/paths/admin/db-_flush.yaml
+++ b/docs/api/paths/admin/db-_flush.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:
@@ -33,3 +32,4 @@ post:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
     - Unsupported
+  operationId: post_db-_flush

--- a/docs/api/paths/admin/db-_google.yaml
+++ b/docs/api/paths/admin/db-_google.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:
@@ -59,3 +58,4 @@ post:
   deprecated: true
   tags:
     - Authentication
+  operationId: post_db-_google

--- a/docs/api/paths/admin/db-_offline.yaml
+++ b/docs/api/paths/admin/db-_offline.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:
@@ -39,3 +38,4 @@ post:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
     - Database Management
+  operationId: post_db-_offline

--- a/docs/api/paths/admin/db-_oidc.yaml
+++ b/docs/api/paths/admin/db-_oidc.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -30,3 +29,4 @@ get:
       $ref: ../../components/responses.yaml#/OIDC-connection
   tags:
     - Authentication
+  operationId: get_db-_oidc

--- a/docs/api/paths/admin/db-_oidc_callback.yaml
+++ b/docs/api/paths/admin/db-_oidc_callback.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -42,3 +41,4 @@ get:
                 type: string
   tags:
     - Authentication
+  operationId: get_db-_oidc_callback

--- a/docs/api/paths/admin/db-_oidc_challenge.yaml
+++ b/docs/api/paths/admin/db-_oidc_challenge.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -30,3 +29,4 @@ get:
       description: Unable to connect and validate with the OpenID Connect provider requested
   tags:
     - Authentication
+  operationId: get_db-_oidc_challenge

--- a/docs/api/paths/admin/db-_oidc_refresh.yaml
+++ b/docs/api/paths/admin/db-_oidc_refresh.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -30,3 +29,4 @@ get:
       $ref: ../../components/responses.yaml#/OIDC-connection
   tags:
     - Authentication
+  operationId: get_db-_oidc_refresh

--- a/docs/api/paths/admin/db-_oidc_testing-.well-known-openid-configuration.yaml
+++ b/docs/api/paths/admin/db-_oidc_testing-.well-known-openid-configuration.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -52,3 +51,4 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Authentication
+  operationId: get_db-_oidc_testing-.well-known-openid-configuration

--- a/docs/api/paths/admin/db-_oidc_testing-authenticate.yaml
+++ b/docs/api/paths/admin/db-_oidc_testing-authenticate.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -43,6 +42,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Authentication
+  operationId: get_db-_oidc_testing-authenticate
 post:
   summary: OpenID Connect mock login page handler
   description: 'Used to handle the login page displayed for the `GET /{db}/_oidc_testing/authorize` endpoint.'
@@ -60,3 +60,4 @@ post:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Authentication
+  operationId: post_db-_oidc_testing-authenticate

--- a/docs/api/paths/admin/db-_oidc_testing-authorize.yaml
+++ b/docs/api/paths/admin/db-_oidc_testing-authorize.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -26,6 +25,7 @@ get:
       $ref: ../../components/responses.yaml#/OIDC-testing-internal-error
   tags:
     - Authentication
+  operationId: get_db-_oidc_testing-authorize
 post:
   summary: OpenID Connect mock login page
   description: Show a mock OpenID Connect login page for the client to log in to.
@@ -44,3 +44,4 @@ post:
       $ref: ../../components/responses.yaml#/OIDC-testing-internal-error
   tags:
     - Authentication
+  operationId: post_db-_oidc_testing-authorize

--- a/docs/api/paths/admin/db-_oidc_testing-certs.yaml
+++ b/docs/api/paths/admin/db-_oidc_testing-certs.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -59,3 +58,4 @@ get:
                 type: string
   tags:
     - Authentication
+  operationId: get_db-_oidc_testing-certs

--- a/docs/api/paths/admin/db-_oidc_testing-token.yaml
+++ b/docs/api/paths/admin/db-_oidc_testing-token.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:
@@ -39,3 +38,4 @@ post:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Authentication
+  operationId: post_db-_oidc_testing-token

--- a/docs/api/paths/admin/db-_online.yaml
+++ b/docs/api/paths/admin/db-_online.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:
@@ -49,3 +48,4 @@ post:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
     - Database Management
+  operationId: post_db-_online

--- a/docs/api/paths/admin/db-_repair.yaml
+++ b/docs/api/paths/admin/db-_repair.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:
@@ -21,4 +20,4 @@ post:
       description: This endpoint is disabled
   tags:
     - Unsupported
-
+  operationId: post_db-_repair

--- a/docs/api/paths/admin/db-_replication-.yaml
+++ b/docs/api/paths/admin/db-_replication-.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -29,6 +28,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Replication
+  operationId: get_db-_replication-
 post:
   summary: Upsert a replication
   description: |-
@@ -52,6 +52,7 @@ post:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Replication
+  operationId: post_db-_replication-
 head:
   summary: /{db}/_replication/
   responses:
@@ -65,3 +66,4 @@ head:
     Required Sync Gateway RBAC roles:
 
     * Sync Gateway Replicator
+  operationId: head_db-_replication-

--- a/docs/api/paths/admin/db-_replication-replicationid.yaml
+++ b/docs/api/paths/admin/db-_replication-replicationid.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/replicationid
@@ -28,6 +27,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Replication
+  operationId: get_db-_replication-replicationid
 put:
   summary: Upsert a replication
   description: |-
@@ -53,6 +53,7 @@ put:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Replication
+  operationId: put_db-_replication-replicationid
 delete:
   summary: Stop and delete a replication
   description: |-
@@ -70,6 +71,7 @@ delete:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Replication
+  operationId: delete_db-_replication-replicationid
 head:
   responses:
     '200':
@@ -85,3 +87,4 @@ head:
     Required Sync Gateway RBAC roles:
 
     * Sync Gateway Replicator
+  operationId: head_db-_replication-replicationid

--- a/docs/api/paths/admin/db-_replicationStatus-.yaml
+++ b/docs/api/paths/admin/db-_replicationStatus-.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -34,6 +33,7 @@ get:
       $ref: ../../components/responses.yaml#/request-problem
   tags:
     - Replication
+  operationId: get_db-_replicationStatus-
 head:
   summary: /{db}/_replicationStatus/
   responses:
@@ -47,3 +47,4 @@ head:
     Required Sync Gateway RBAC roles:
 
     * Sync Gateway Replicator
+  operationId: head_db-_replicationStatus-

--- a/docs/api/paths/admin/db-_replicationStatus-replicationid.yaml
+++ b/docs/api/paths/admin/db-_replicationStatus-replicationid.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/replicationid
@@ -39,6 +38,7 @@ get:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
     - Replication
+  operationId: get_db-_replicationStatus-replicationid
 put:
   summary: Control a replication state
   description: |-
@@ -76,6 +76,7 @@ put:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Replication
+  operationId: put_db-_replicationStatus-replicationid
 head:
   responses:
     '200':
@@ -98,3 +99,4 @@ head:
     Required Sync Gateway RBAC roles:
 
     * Sync Gateway Replicator
+  operationId: head_db-_replicationStatus-replicationid

--- a/docs/api/paths/admin/db-_resync.yaml
+++ b/docs/api/paths/admin/db-_resync.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -27,6 +26,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Management
+  operationId: get_db-_resync
 post:
   summary: Start or stop Resync
   description: |
@@ -90,3 +90,4 @@ post:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
     - Database Management
+  operationId: post_db-_resync

--- a/docs/api/paths/admin/db-_role-.yaml
+++ b/docs/api/paths/admin/db-_role-.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -47,6 +46,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Security
+  operationId: get_db-_role-
 post:
   summary: Create a new role
   description: |-
@@ -67,6 +67,7 @@ post:
       $ref: ../../components/responses.yaml#/Conflict
   tags:
     - Database Security
+  operationId: post_db-_role-
 head:
   summary: /{db}/_role/
   responses:
@@ -82,3 +83,4 @@ head:
     * Sync Gateway Architect
     * Sync Gateway Application
     * Sync Gateway Application Read Only
+  operationId: head_db-_role-

--- a/docs/api/paths/admin/db-_role-name.yaml
+++ b/docs/api/paths/admin/db-_role-name.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/role-name
@@ -26,6 +25,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Security
+  operationId: get_db-_role-name
 put:
   summary: Upsert a role
   description: |-
@@ -46,6 +46,7 @@ put:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Security
+  operationId: put_db-_role-name
 delete:
   summary: Delete a role
   description: |-
@@ -62,6 +63,7 @@ delete:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Security
+  operationId: delete_db-_role-name
 head:
   responses:
     '200':
@@ -79,3 +81,4 @@ head:
     * Sync Gateway Application
     * Sync Gateway Application Read Only
   summary: Check if role exists
+  operationId: head_db-_role-name

--- a/docs/api/paths/admin/db-_session-sessionid.yaml
+++ b/docs/api/paths/admin/db-_session-sessionid.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/sessionid
@@ -26,6 +25,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Session
+  operationId: get_db-_session-sessionid
 delete:
   summary: Remove session
   description: |-
@@ -42,3 +42,4 @@ delete:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Session
+  operationId: delete_db-_session-sessionid

--- a/docs/api/paths/admin/db-_session.yaml
+++ b/docs/api/paths/admin/db-_session.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -18,6 +17,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Session
+  operationId: get_db-_session
 post:
   summary: Create a new user session
   description: |-
@@ -71,6 +71,7 @@ post:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Session
+  operationId: post_db-_session
 head:
   summary: /{db}/_session
   responses:
@@ -80,3 +81,4 @@ head:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Session
+  operationId: head_db-_session

--- a/docs/api/paths/admin/db-_user-.yaml
+++ b/docs/api/paths/admin/db-_user-.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -38,6 +37,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Security
+  operationId: get_db-_user-
 post:
   summary: Create a new user
   description: |-
@@ -58,6 +58,7 @@ post:
       $ref: ../../components/responses.yaml#/Conflict
   tags:
     - Database Security
+  operationId: post_db-_user-
 head:
   summary: /{db}/_user/
   responses:
@@ -73,3 +74,4 @@ head:
     * Sync Gateway Architect
     * Sync Gateway Application
     * Sync Gateway Application Read Only
+  operationId: head_db-_user-

--- a/docs/api/paths/admin/db-_user-name-_session-sessionid.yaml
+++ b/docs/api/paths/admin/db-_user-name-_session-sessionid.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/user-name
@@ -26,3 +25,4 @@ delete:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Session
+  operationId: delete_db-_user-name-_session-sessionid

--- a/docs/api/paths/admin/db-_user-name-_session.yaml
+++ b/docs/api/paths/admin/db-_user-name-_session.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/user-name
@@ -27,3 +26,4 @@ delete:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Session
+  operationId: delete_db-_user-name-_session

--- a/docs/api/paths/admin/db-_user-name.yaml
+++ b/docs/api/paths/admin/db-_user-name.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/user-name
@@ -26,6 +25,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Security
+  operationId: get_db-_user-name
 put:
   summary: Upsert a user
   description: |-
@@ -46,6 +46,7 @@ put:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Security
+  operationId: put_db-_user-name
 delete:
   summary: Delete a user
   description: |-
@@ -62,6 +63,7 @@ delete:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Security
+  operationId: delete_db-_user-name
 head:
   responses:
     '200':
@@ -79,3 +81,4 @@ head:
     * Sync Gateway Architect
     * Sync Gateway Application
     * Sync Gateway Application Read Only
+  operationId: head_db-_user-name

--- a/docs/api/paths/admin/db-_view-view.yaml
+++ b/docs/api/paths/admin/db-_view-view.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/view
@@ -77,3 +76,4 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Unsupported
+  operationId: get_db-_view-view

--- a/docs/api/paths/admin/keyspace-.yaml
+++ b/docs/api/paths/admin/keyspace-.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:
@@ -49,3 +48,4 @@ post:
       $ref: ../../components/responses.yaml#/Invalid-content-type
   tags:
     - Document
+  operationId: post_keyspace-

--- a/docs/api/paths/admin/keyspace-_all_docs.yaml
+++ b/docs/api/paths/admin/keyspace-_all_docs.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 get:
@@ -36,6 +35,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Document
+  operationId: get_keyspace-_all_docs
 post:
   summary: Get all the documents in the database using a built-in view
   description: |-
@@ -76,6 +76,7 @@ post:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Document
+  operationId: post_keyspace-_all_docs
 head:
   summary: /{db}/_all_docs
   responses:
@@ -102,3 +103,4 @@ head:
 
     * Sync Gateway Application
     * Sync Gateway Application Read Only
+  operationId: head_keyspace-_all_docs

--- a/docs/api/paths/admin/keyspace-_bulk_docs.yaml
+++ b/docs/api/paths/admin/keyspace-_bulk_docs.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:
@@ -107,3 +106,4 @@ post:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Document
+  operationId: post_keyspace-_bulk_docs

--- a/docs/api/paths/admin/keyspace-_bulk_get.yaml
+++ b/docs/api/paths/admin/keyspace-_bulk_get.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:
@@ -78,3 +77,4 @@ post:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Document
+  operationId: post_keyspace-_bulk_get

--- a/docs/api/paths/admin/keyspace-_changes.yaml
+++ b/docs/api/paths/admin/keyspace-_changes.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 get:
@@ -106,6 +105,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Management
+  operationId: get_keyspace-_changes
 post:
   summary: Get changes list
   description: |-
@@ -165,6 +165,7 @@ post:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Management
+  operationId: post_keyspace-_changes
 head:
   summary: /{db}/_changes
   responses:
@@ -181,3 +182,4 @@ head:
 
     * Sync Gateway Application
     * Sync Gateway Application Read Only
+  operationId: head_keyspace-_changes

--- a/docs/api/paths/admin/keyspace-_config-import_filter.yaml
+++ b/docs/api/paths/admin/keyspace-_config-import_filter.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 get:
@@ -34,6 +33,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Configuration
+  operationId: get_keyspace-_config-import_filter
 put:
   summary: Set database import filter
   description: |-
@@ -62,6 +62,7 @@ put:
       $ref: ../../components/responses.yaml#/DB-config-precondition-failed
   tags:
     - Database Configuration
+  operationId: put_keyspace-_config-import_filter
 delete:
   summary: Delete import filter
   description: |-
@@ -81,3 +82,4 @@ delete:
       $ref: ../../components/responses.yaml#/DB-config-precondition-failed
   tags:
     - Database Configuration
+  operationId: delete_keyspace-_config-import_filter

--- a/docs/api/paths/admin/keyspace-_config-sync.yaml
+++ b/docs/api/paths/admin/keyspace-_config-sync.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 get:
@@ -38,6 +37,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Configuration
+  operationId: get_keyspace-_config-sync
 put:
   summary: Set database sync function
   description: |-
@@ -70,6 +70,7 @@ put:
       $ref: ../../components/responses.yaml#/DB-config-precondition-failed
   tags:
     - Database Configuration
+  operationId: put_keyspace-_config-sync
 delete:
   summary: Remove custom sync function
   description: |-
@@ -96,3 +97,4 @@ delete:
       $ref: ../../components/responses.yaml#/DB-config-precondition-failed
   tags:
     - Database Configuration
+  operationId: delete_keyspace-_config-sync

--- a/docs/api/paths/admin/keyspace-_dumpchannel-channel.yaml
+++ b/docs/api/paths/admin/keyspace-_dumpchannel-channel.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
   - name: channel
@@ -42,3 +41,4 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Unsupported
+  operationId: get_keyspace-_dumpchannel-channel

--- a/docs/api/paths/admin/keyspace-_local-docid.yaml
+++ b/docs/api/paths/admin/keyspace-_local-docid.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
   - name: docid
@@ -34,6 +33,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Document
+  operationId: get_keyspace-_local-docid
 put:
   summary: Upsert a local document
   description: |-
@@ -70,6 +70,7 @@ put:
       description: A revision ID conflict would result from updating this document revision.
   tags:
     - Document
+  operationId: put_keyspace-_local-docid
 delete:
   summary: Delete a local document
   description: |-
@@ -98,6 +99,7 @@ delete:
       description: A revision ID conflict would result from deleting this document revision.
   tags:
     - Document
+  operationId: delete_keyspace-_local-docid
 head:
   responses:
     '200':
@@ -118,3 +120,4 @@ head:
 
     * Sync Gateway Application
     * Sync Gateway Application Read Only
+  operationId: head_keyspace-_local-docid

--- a/docs/api/paths/admin/keyspace-_purge.yaml
+++ b/docs/api/paths/admin/keyspace-_purge.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:
@@ -93,3 +92,4 @@ post:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Document
+  operationId: post_keyspace-_purge

--- a/docs/api/paths/admin/keyspace-_raw-docid.yaml
+++ b/docs/api/paths/admin/keyspace-_raw-docid.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
   - $ref: ../../components/parameters.yaml#/docid
@@ -112,6 +111,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Document
+  operationId: get_keyspace-_raw-docid
 head:
   summary: /{keyspace}/_raw/{docid}
   responses:
@@ -128,3 +128,4 @@ head:
 
     * Sync Gateway Application
     * Sync Gateway Application Read Only
+  operationId: head_keyspace-_raw-docid

--- a/docs/api/paths/admin/keyspace-_revs_diff.yaml
+++ b/docs/api/paths/admin/keyspace-_revs_diff.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:
@@ -53,3 +52,4 @@ post:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Management
+  operationId: post_keyspace-_revs_diff

--- a/docs/api/paths/admin/keyspace-_revtree-docid.yaml
+++ b/docs/api/paths/admin/keyspace-_revtree-docid.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
   - $ref: ../../components/parameters.yaml#/docid
@@ -37,3 +36,4 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Unsupported
+  operationId: get_keyspace-_revtree-docid

--- a/docs/api/paths/admin/keyspace-docid-attach.yaml
+++ b/docs/api/paths/admin/keyspace-docid-attach.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
   - $ref: ../../components/parameters.yaml#/docid
@@ -68,6 +67,7 @@ get:
       description: Requested range exceeds content length
   tags:
     - Document
+  operationId: get_keyspace-docid-attach
 put:
   summary: Create or update an attachment on a document
   description: |-
@@ -122,6 +122,7 @@ put:
       $ref: ../../components/responses.yaml#/Conflict
   tags:
     - Document
+  operationId: put_keyspace-docid-attach
 head:
   responses:
     '200':
@@ -149,6 +150,7 @@ head:
     * Sync Gateway Application Read Only
   parameters:
     - $ref: ../../components/parameters.yaml#/rev
+  operationId: head_keyspace-docid-attach
 delete:
   summary: Delete an attachment on a document
   description: |-
@@ -184,3 +186,4 @@ delete:
       $ref: ../../components/responses.yaml#/Conflict
   tags:
     - Document
+  operationId: delete_keyspace-docid-attach

--- a/docs/api/paths/admin/keyspace-docid.yaml
+++ b/docs/api/paths/admin/keyspace-docid.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
   - $ref: ../../components/parameters.yaml#/docid
@@ -65,6 +64,7 @@ get:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
     - Document
+  operationId: get_keyspace-docid
 put:
   summary: Upsert a document
   description: |-
@@ -112,6 +112,7 @@ put:
       $ref: ../../components/responses.yaml#/Invalid-content-type
   tags:
     - Document
+  operationId: put_keyspace-docid
 delete:
   summary: Delete a document
   description: |-
@@ -134,6 +135,7 @@ delete:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Document
+  operationId: delete_keyspace-docid
 head:
   responses:
     '200':
@@ -161,3 +163,4 @@ head:
 
     * Sync Gateway Application
     * Sync Gateway Application Read Only
+  operationId: head_keyspace-docid

--- a/docs/api/paths/metric/_expvar.yaml
+++ b/docs/api/paths/metric/_expvar.yaml
@@ -6,7 +6,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get all Sync Gateway statistics
   description: |-
@@ -26,3 +25,4 @@ get:
         application/javascript:
           schema:
             $ref: ../../components/schemas.yaml#/ExpVars
+  operationId: get__expvar

--- a/docs/api/paths/metric/_metrics.yaml
+++ b/docs/api/paths/metric/_metrics.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Debugging/monitoring runtime stats in Prometheus Exposition format
   description: |-
@@ -25,3 +24,4 @@ get:
             type: string
   tags:
     - Prometheus
+  operationId: get__metrics

--- a/docs/api/paths/public/-.yaml
+++ b/docs/api/paths/public/-.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 get:
   summary: Get server information
   description: Returns information about the Sync Gateway node.
@@ -18,6 +17,7 @@ get:
             $ref: ../../components/schemas.yaml#/NodeInfo
   tags:
     - Server
+  operationId: get_-
 head:
   responses:
     '200':
@@ -26,3 +26,4 @@ head:
     - Server
   summary: Check if server online
   description: Check if the server is online by checking the status code of response.
+  operationId: head_-

--- a/docs/api/paths/public/db-.yaml
+++ b/docs/api/paths/public/db-.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -66,6 +65,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Management
+  operationId: get_db-
 head:
   summary: Check if database exists
   description: Check if a database exists by using the response status code.
@@ -76,3 +76,4 @@ head:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Management
+  operationId: head_db-

--- a/docs/api/paths/public/db-_blipsync.yaml
+++ b/docs/api/paths/public/db-_blipsync.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -37,3 +36,4 @@ get:
             reason: Can't upgrade this request to websocket connection
   tags:
     - Replication
+  operationId: get_db-_blipsync

--- a/docs/api/paths/public/db-_design-ddoc-_view-view.yaml
+++ b/docs/api/paths/public/db-_design-ddoc-_view-view.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/ddoc
@@ -73,3 +72,4 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Unsupported
+  operationId: get_db-_design-ddoc-_view-view

--- a/docs/api/paths/public/db-_design-ddoc.yaml
+++ b/docs/api/paths/public/db-_design-ddoc.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
   - $ref: ../../components/parameters.yaml#/ddoc
@@ -28,6 +27,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Unsupported
+  operationId: get_db-_design-ddoc
 put:
   summary: Update views of a design document | Unsupported
   description: |-
@@ -48,6 +48,7 @@ put:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Unsupported
+  operationId: put_db-_design-ddoc
 delete:
   summary: Delete a design document | Unsupported
   description: |-
@@ -63,6 +64,7 @@ delete:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Unsupported
+  operationId: delete_db-_design-ddoc
 head:
   responses:
     '200':
@@ -78,3 +80,4 @@ head:
 
     Check if a design document can be queried.
   summary: Check if view of design document exists | Unsupported
+  operationId: head_db-_design-ddoc

--- a/docs/api/paths/public/db-_ensure_full_commit.yaml
+++ b/docs/api/paths/public/db-_ensure_full_commit.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:
@@ -29,3 +28,4 @@ post:
                 default: true
   tags:
     - Database Management
+  operationId: post_db-_ensure_full_commit

--- a/docs/api/paths/public/db-_facebook.yaml
+++ b/docs/api/paths/public/db-_facebook.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:
@@ -68,3 +67,4 @@ post:
   deprecated: true
   tags:
     - Authentication
+  operationId: post_db-_facebook

--- a/docs/api/paths/public/db-_google.yaml
+++ b/docs/api/paths/public/db-_google.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:
@@ -59,3 +58,4 @@ post:
   deprecated: true
   tags:
     - Authentication
+  operationId: post_db-_google

--- a/docs/api/paths/public/db-_oidc.yaml
+++ b/docs/api/paths/public/db-_oidc.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -30,3 +29,4 @@ get:
       $ref: ../../components/responses.yaml#/OIDC-connection
   tags:
     - Authentication
+  operationId: get_db-_oidc

--- a/docs/api/paths/public/db-_oidc_callback.yaml
+++ b/docs/api/paths/public/db-_oidc_callback.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -42,3 +41,4 @@ get:
                 type: string
   tags:
     - Authentication
+  operationId: get_db-_oidc_callback

--- a/docs/api/paths/public/db-_oidc_challenge.yaml
+++ b/docs/api/paths/public/db-_oidc_challenge.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -30,3 +29,4 @@ get:
       description: Unable to connect and validate with the OpenID Connect provider requested
   tags:
     - Authentication
+  operationId: get_db-_oidc_challenge

--- a/docs/api/paths/public/db-_oidc_refresh.yaml
+++ b/docs/api/paths/public/db-_oidc_refresh.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -30,3 +29,4 @@ get:
       $ref: ../../components/responses.yaml#/OIDC-connection
   tags:
     - Authentication
+  operationId: get_db-_oidc_refresh

--- a/docs/api/paths/public/db-_oidc_testing-.well-known-openid-configuration.yaml
+++ b/docs/api/paths/public/db-_oidc_testing-.well-known-openid-configuration.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -52,3 +51,4 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Authentication
+  operationId: get_db-_oidc_testing-.well-known-openid-configuration

--- a/docs/api/paths/public/db-_oidc_testing-authenticate.yaml
+++ b/docs/api/paths/public/db-_oidc_testing-authenticate.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -43,6 +42,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Authentication
+  operationId: get_db-_oidc_testing-authenticate
 post:
   summary: OpenID Connect mock login page handler
   description: 'Used to handle the login page displayed for the `GET /{db}/_oidc_testing/authorize` endpoint.'
@@ -60,3 +60,4 @@ post:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Authentication
+  operationId: post_db-_oidc_testing-authenticate

--- a/docs/api/paths/public/db-_oidc_testing-authorize.yaml
+++ b/docs/api/paths/public/db-_oidc_testing-authorize.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -26,6 +25,7 @@ get:
       $ref: ../../components/responses.yaml#/OIDC-testing-internal-error
   tags:
     - Authentication
+  operationId: get_db-_oidc_testing-authorize
 post:
   summary: OpenID Connect mock login page
   description: Show a mock OpenID Connect login page for the client to log in to.
@@ -44,3 +44,4 @@ post:
       $ref: ../../components/responses.yaml#/OIDC-testing-internal-error
   tags:
     - Authentication
+  operationId: post_db-_oidc_testing-authorize

--- a/docs/api/paths/public/db-_oidc_testing-certs.yaml
+++ b/docs/api/paths/public/db-_oidc_testing-certs.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -59,3 +58,4 @@ get:
                 type: string
   tags:
     - Authentication
+  operationId: get_db-_oidc_testing-certs

--- a/docs/api/paths/public/db-_oidc_testing-token.yaml
+++ b/docs/api/paths/public/db-_oidc_testing-token.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 post:
@@ -39,3 +38,4 @@ post:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Authentication
+  operationId: post_db-_oidc_testing-token

--- a/docs/api/paths/public/db-_session.yaml
+++ b/docs/api/paths/public/db-_session.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/db
 get:
@@ -18,6 +17,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Session
+  operationId: get_db-_session
 post:
   summary: Create a new user session
   description: |-
@@ -97,6 +97,7 @@ post:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Session
+  operationId: post_db-_session
 delete:
   summary: Log out
   description: |-
@@ -111,8 +112,8 @@ delete:
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-    - Public only endpoints
     - Session
+  operationId: delete_db-_session
 head:
   summary: /{db}/_session
   responses:
@@ -122,3 +123,4 @@ head:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Session
+  operationId: head_db-_session

--- a/docs/api/paths/public/keyspace-.yaml
+++ b/docs/api/paths/public/keyspace-.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:
@@ -49,3 +48,4 @@ post:
       $ref: ../../components/responses.yaml#/Invalid-content-type
   tags:
     - Document
+  operationId: post_keyspace-

--- a/docs/api/paths/public/keyspace-_all_docs.yaml
+++ b/docs/api/paths/public/keyspace-_all_docs.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 get:
@@ -30,6 +29,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Document
+  operationId: get_keyspace-_all_docs
 post:
   summary: Get all the documents in the database using a built-in view
   description: Get a built-in view of all the documents in the database.
@@ -64,6 +64,7 @@ post:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Document
+  operationId: post_keyspace-_all_docs
 head:
   summary: /{db}/_all_docs
   responses:
@@ -86,3 +87,4 @@ head:
     - $ref: ../../components/parameters.yaml#/endkey
     - $ref: ../../components/parameters.yaml#/limit-result-rows
   description: ''
+  operationId: head_keyspace-_all_docs

--- a/docs/api/paths/public/keyspace-_bulk_docs.yaml
+++ b/docs/api/paths/public/keyspace-_bulk_docs.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:
@@ -103,3 +102,4 @@ post:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Document
+  operationId: post_keyspace-_bulk_docs

--- a/docs/api/paths/public/keyspace-_bulk_get.yaml
+++ b/docs/api/paths/public/keyspace-_bulk_get.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:
@@ -73,3 +72,4 @@ post:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Document
+  operationId: post_keyspace-_bulk_get

--- a/docs/api/paths/public/keyspace-_changes.yaml
+++ b/docs/api/paths/public/keyspace-_changes.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 get:
@@ -101,6 +100,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Management
+  operationId: get_keyspace-_changes
 post:
   summary: Get changes list
   description: |-
@@ -155,6 +155,7 @@ post:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Management
+  operationId: post_keyspace-_changes
 head:
   summary: /{db}/_changes
   responses:
@@ -167,3 +168,4 @@ head:
   tags:
     - Database Management
   description: ''
+  operationId: head_keyspace-_changes

--- a/docs/api/paths/public/keyspace-_local-docid.yaml
+++ b/docs/api/paths/public/keyspace-_local-docid.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
   - name: docid
@@ -29,6 +28,7 @@ get:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Document
+  operationId: get_keyspace-_local-docid
 put:
   summary: Upsert a local document
   description: |-
@@ -60,6 +60,7 @@ put:
       description: A revision ID conflict would result from updating this document revision.
   tags:
     - Document
+  operationId: put_keyspace-_local-docid
 delete:
   summary: Delete a local document
   description: |-
@@ -84,6 +85,7 @@ delete:
       description: A revision ID conflict would result from deleting this document revision.
   tags:
     - Document
+  operationId: delete_keyspace-_local-docid
 head:
   responses:
     '200':
@@ -99,3 +101,4 @@ head:
     This request checks if a local document exists.
 
     Local document IDs begin with `_local/`. Local documents are not replicated or indexed, don't support attachments, and don't save revision histories. In practice they are almost only used by Couchbase Lite's replicator, as a place to store replication checkpoint data.
+  operationId: head_keyspace-_local-docid

--- a/docs/api/paths/public/keyspace-_revs_diff.yaml
+++ b/docs/api/paths/public/keyspace-_revs_diff.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:
@@ -48,3 +47,4 @@ post:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Database Management
+  operationId: post_keyspace-_revs_diff

--- a/docs/api/paths/public/keyspace-docid-attach.yaml
+++ b/docs/api/paths/public/keyspace-docid-attach.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
   - $ref: ../../components/parameters.yaml#/docid
@@ -63,6 +62,7 @@ get:
       description: Requested range exceeds content length
   tags:
     - Document Attachment
+  operationId: get_keyspace-docid-attach
 put:
   summary: Create or update an attachment on a document
   description: |-
@@ -113,6 +113,7 @@ put:
       $ref: ../../components/responses.yaml#/Conflict
   tags:
     - Document Attachment
+  operationId: put_keyspace-docid-attach
 head:
   responses:
     '200':
@@ -134,6 +135,7 @@ head:
   description: This request check if the attachment exists on the specified document.
   parameters:
     - $ref: ../../components/parameters.yaml#/rev
+  operationId: head_keyspace-docid-attach
 delete:
   summary: Delete an attachment on a document
   description: |-
@@ -169,3 +171,4 @@ delete:
       $ref: ../../components/responses.yaml#/Conflict
   tags:
     - Document Attachment
+  operationId: delete_keyspace-docid-attach

--- a/docs/api/paths/public/keyspace-docid.yaml
+++ b/docs/api/paths/public/keyspace-docid.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
   - $ref: ../../components/parameters.yaml#/docid
@@ -59,6 +58,7 @@ get:
             $ref: ../../components/schemas.yaml#/HTTP-Error
   tags:
     - Document
+  operationId: get_keyspace-docid
 put:
   summary: Upsert a document
   description: |-
@@ -102,6 +102,7 @@ put:
       $ref: ../../components/responses.yaml#/Invalid-content-type
   tags:
     - Document
+  operationId: put_keyspace-docid
 delete:
   summary: Delete a document
   description: |-
@@ -120,6 +121,7 @@ delete:
       $ref: ../../components/responses.yaml#/Not-found
   tags:
     - Document
+  operationId: delete_keyspace-docid
 head:
   responses:
     '200':
@@ -141,3 +143,4 @@ head:
     - $ref: ../../components/parameters.yaml#/includeAttachments
     - $ref: ../../components/parameters.yaml#/replicator2
   description: Return a status code based on if the document exists or not.
+  operationId: head_keyspace-docid

--- a/docs/api/paths/public/targetdb-.yaml
+++ b/docs/api/paths/public/targetdb-.yaml
@@ -5,7 +5,6 @@
 # in that file, in accordance with the Business Source License, use of this
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
-
 parameters:
   - name: targetdb
     in: path
@@ -22,5 +21,5 @@ put:
     '412':
       description: Database exists
   tags:
-    - Public only endpoints
     - Database Management
+  operationId: put_targetdb-

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -85,8 +85,6 @@ paths:
   '/{db}/_blipsync':
     $ref: './paths/public/db-_blipsync.yaml'
 tags:
-  - name: Public only endpoints
-    description: Endpoints that are unique to the Public API (port 4984)
   - name: Server
     description: Manage server activities
   - name: Database Management


### PR DESCRIPTION
* Remove "Public Only Endpoints" tag.

OpenAPI-Generator doesn't give nice output with multiple tags. (e.g. it generates multiple copies of the same link in the generated navigation)

As discussed with Ben & Isaac, the multiple tags aren't hugely important so we've already removed in most places, but looks like I missed Public Only Endpoints in my previous commit.

* Add operationId to all operations.

This is recommended by OpenAPI Spec, and makes openapi-generator and some of the Docs tooling happy.

I've generated these based on the METHOD + FILENAME and updated in batch with a bash + yq script.

* Update .redocly.yaml

As advised by @bbrks as this will verify that all endpoints have an operationID.