### PR TITLE
Make turnOffNoDelay log more info in error case

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -1652,7 +1652,7 @@ func GetHttpClientForWebSocket(insecureSkipVerify bool) *http.Client {
 // (There's really no reason for a caller to take note of the return value.)
 func turnOffNoDelay(ctx context.Context, conn net.Conn) bool {
 	if tcpConn, ok := conn.(*net.TCPConn); !ok {
-		WarnfCtx(ctx, "Couldn't turn off NODELAY for %v: it's not a TCPConn", conn)
+		WarnfCtx(ctx, "Couldn't turn off NODELAY for %v: %T is not type *net.TCPConn", conn, conn)
 	} else if err := tcpConn.SetNoDelay(false); err != nil {
 		WarnfCtx(ctx, "Couldn't turn off NODELAY for %v: %v", conn, err)
 	} else {


### PR DESCRIPTION
Observed unexpected logging which suggests `conn` is not always a `*net.TCPConn`, which is confusing... What _is_ it?! Suspected `tls.Conn` wrapping a `*net.TCPConn` which fails the type assertion.

```
2023-05-16T09:10:42.421-07:00 [WRN] Couldn't turn off NODELAY for &{...}: it's not a TCPConn -- base.turnOffNoDelay() at util.go:1655
```