### PR TITLE
CBG-2905 remove cached connections when bucket disappear

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -110,12 +110,12 @@ func (c *cachedBucketConnections) closeAll() {
 func (c *cachedBucketConnections) teardown(bucketName string) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
+	c.buckets[bucketName].refcount--
 	c._teardown(bucketName)
 }
 
-// _teardown closes expects the lock to be acquired before calling this function
+// _teardown closes expects the lock to be acquired before calling this function and the reference count to be up to date.
 func (c *cachedBucketConnections) _teardown(bucketName string) {
-	c.buckets[bucketName].refcount--
 	if !c.buckets[bucketName].shouldClose || c.buckets[bucketName].refcount > 0 {
 		return
 	}

--- a/base/bootstrap_test.go
+++ b/base/bootstrap_test.go
@@ -36,6 +36,9 @@ func TestMergeStructPointer(t *testing.T) {
 }
 
 func TestBootstrapRefCounting(t *testing.T) {
+	if UnitTestUrlIsWalrus() {
+		t.Skip("Test requires making a connection to CBS")
+	}
 	// Integration tests are configured to run in these parameters, they are used in main_test_bucket_pool.go
 	// Future enhancement would be to allow all integration tests to run with TLS
 	x509CertPath := ""

--- a/base/bootstrap_test.go
+++ b/base/bootstrap_test.go
@@ -73,15 +73,15 @@ func TestBootstrapRefCounting(t *testing.T) {
 	}
 
 	primeBucketConnectionCache(buckets)
-	// GetConfigBuckets doesn't cache connections
 	require.Len(t, cluster.cachedBucketConnections.buckets, tbpNumBuckets())
 
-	cluster.cachedBucketConnections.removeOutdatedBuckets(Set{})
-	require.Len(t, cluster.cachedBucketConnections.buckets, 0)
+	// call removeOutdatedBuckets to remove all cached buckets, call multiple times to make sure
+	for i := 0; i < 3; i++ {
+		cluster.cachedBucketConnections.removeOutdatedBuckets(Set{})
+		require.Len(t, cluster.cachedBucketConnections.buckets, 0)
+	}
 
-	// re-cache connections
 	primeBucketConnectionCache(buckets)
-	// GetConfigBuckets doesn't cache connections
 	require.Len(t, cluster.cachedBucketConnections.buckets, tbpNumBuckets())
 
 	// make sure that you can still use an active connection while the bucket has been removed
@@ -106,4 +106,8 @@ func TestBootstrapRefCounting(t *testing.T) {
 	makeConnection <- struct{}{}
 
 	wg.Wait()
+
+	// make sure you can "remove" a non existent bucket in the case that bucket removal is called multiple times
+	cluster.cachedBucketConnections.removeOutdatedBuckets(SetOf("not-a-bucket"))
+
 }

--- a/base/bootstrap_test.go
+++ b/base/bootstrap_test.go
@@ -9,6 +9,7 @@
 package base
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/imdario/mergo"
@@ -32,4 +33,74 @@ func TestMergeStructPointer(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, "changed", source.Ptr.S)
 	assert.Equal(t, IntPtr(5), source.Ptr.I)
+}
+
+func TestBootstrapRefCounting(t *testing.T) {
+	// Integration tests are configured to run in these parameters, they are used in main_test_bucket_pool.go
+	// Future enhancement would be to allow all integration tests to run with TLS
+	x509CertPath := ""
+	x509KeyPath := ""
+	caCertPath := ""
+	forcePerBucketAuth := false
+	tlsSkipVerify := BoolPtr(false)
+	var perBucketCredentialsConfig map[string]*CredentialsConfig
+
+	cluster, err := NewCouchbaseCluster(UnitTestUrl(), TestClusterUsername(), TestClusterPassword(), x509CertPath, x509KeyPath, caCertPath, forcePerBucketAuth, perBucketCredentialsConfig, tlsSkipVerify, BoolPtr(TestUseXattrs()), CachedClusterConnections)
+	require.NoError(t, err)
+	defer cluster.Close()
+	require.NotNil(t, cluster)
+
+	clusterConnection, err := cluster.getClusterConnection()
+	require.NoError(t, err)
+	require.NotNil(t, clusterConnection)
+
+	buckets, err := cluster.GetConfigBuckets()
+	require.NoError(t, err)
+	require.Len(t, buckets, tbpNumBuckets())
+	// GetConfigBuckets doesn't cache connections, it uses cluster connection to determine number of buckets
+	require.Len(t, cluster.cachedBucketConnections.buckets, 0)
+
+	primeBucketConnectionCache := func(bucketNames []string) {
+		// Bucket CRUD ops do cache connections
+		for _, bucketName := range bucketNames {
+			exists, err := cluster.KeyExists(bucketName, "keyThatDoesNotExist")
+			require.NoError(t, err)
+			require.False(t, exists)
+		}
+	}
+
+	primeBucketConnectionCache(buckets)
+	// GetConfigBuckets doesn't cache connections
+	require.Len(t, cluster.cachedBucketConnections.buckets, tbpNumBuckets())
+
+	cluster.cachedBucketConnections.removeOutdatedBuckets(Set{})
+	require.Len(t, cluster.cachedBucketConnections.buckets, 0)
+
+	// re-cache connections
+	primeBucketConnectionCache(buckets)
+	// GetConfigBuckets doesn't cache connections
+	require.Len(t, cluster.cachedBucketConnections.buckets, tbpNumBuckets())
+
+	// make sure that you can still use an active connection while the bucket has been removed
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	makeConnection := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		b, teardown, err := cluster.getBucket(buckets[0])
+		defer teardown()
+		require.NoError(t, err)
+		require.NotNil(t, b)
+		<-makeConnection
+		// make sure that we can still use bucket after it is no longer cached
+		exists, err := cluster.configPersistence.keyExists(b.DefaultCollection(), "keyThatDoesNotExist")
+		require.NoError(t, err)
+		require.False(t, exists)
+	}()
+
+	cluster.cachedBucketConnections.removeOutdatedBuckets(Set{})
+	require.Len(t, cluster.cachedBucketConnections.buckets, 0)
+	makeConnection <- struct{}{}
+
+	wg.Wait()
 }

--- a/base/bootstrap_test.go
+++ b/base/bootstrap_test.go
@@ -75,7 +75,11 @@ func TestBootstrapRefCounting(t *testing.T) {
 	primeBucketConnectionCache(buckets)
 	require.Len(t, cluster.cachedBucketConnections.buckets, tbpNumBuckets())
 
-	// call removeOutdatedBuckets to remove all cached buckets, call multiple times to make sure
+	// call removeOutdatedBuckets as no-op
+	cluster.cachedBucketConnections.removeOutdatedBuckets(SetOf(buckets...))
+	require.Len(t, cluster.cachedBucketConnections.buckets, tbpNumBuckets())
+
+	// call removeOutdatedBuckets to remove all cached buckets, call multiple times to make sure idempotent
 	for i := 0; i < 3; i++ {
 		cluster.cachedBucketConnections.removeOutdatedBuckets(Set{})
 		require.Len(t, cluster.cachedBucketConnections.buckets, 0)


### PR DESCRIPTION
CBG-2905 

If a bucket disappears, then remove the cached connections. Within a ServerContext, `CouchbaseCluster.GetConfigBuckets` gets called 1/sec from https://github.com/couchbase/sync_gateway/blob/4fe200cf387419034ec250ee614f9e760900710a/rest/config.go#L1519

So with `import_docs=false`, to avoid CBG-2983, you'll now see this logged once and it will fail.

Because of the nature of `CouchbaseCluster`, it seemed necessary to write this in a thread safe manner, but I am not sure that it is ever called concurrently right now. The other consumers might be the metadata registry.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1787/
