### PR TITLE
CBG-2973: Fix panic for assigning to nil map inside Mutable1xBody

### DIFF
--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -13,6 +13,7 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -161,6 +162,9 @@ func (rev *DocumentRevision) Mutable1xBody(db *DatabaseCollectionWithUser, reque
 	b, err = rev.Body()
 	if err != nil {
 		return nil, err
+	}
+	if b == nil {
+		return nil, fmt.Errorf("null doc body for doc: %s", rev.DocID)
 	}
 
 	b[BodyId] = rev.DocID

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -13,7 +13,6 @@ package db
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -164,7 +163,7 @@ func (rev *DocumentRevision) Mutable1xBody(db *DatabaseCollectionWithUser, reque
 		return nil, err
 	}
 	if b == nil {
-		return nil, fmt.Errorf("null doc body for doc: %s", rev.DocID)
+		return nil, base.RedactErrorf("null doc body for docID: %s revID: %s", base.UD(rev.DocID), base.UD(rev.RevID))
 	}
 
 	b[BodyId] = rev.DocID

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2678,6 +2678,19 @@ func TestDocChannelSetPruning(t *testing.T) {
 	assert.Equal(t, uint64(12), syncData.ChannelSetHistory[0].End)
 }
 
+func TestNullDocHandlingForMutable1xBody(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollectionWithUser()
+
+	documentRev := db.DocumentRevision{DocID: "doc1", BodyBytes: []byte("null")}
+
+	body, err := documentRev.Mutable1xBody(collection, nil, nil, false)
+	require.Error(t, err)
+	require.Nil(t, body)
+	assert.Contains(t, err.Error(), "null doc body for doc")
+}
+
 func TestTombstoneCompactionAPI(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	rt.GetDatabase().PurgeInterval = 0


### PR DESCRIPTION
CBG-2973

Small PR to fix a panic hit by a customer where they have null doc bodies and we try assign to a nil map as a result. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1784/
