### PR TITLE
Fix RedactableError not satisfying the Redactor interface

### DIFF
--- a/base/redactable_error.go
+++ b/base/redactable_error.go
@@ -12,13 +12,17 @@ package base
 
 import "fmt"
 
-// A redactable error can be used as a drop-in replacement for a base error (as would have been created via
-// fmt.Errorf), which has the ability to redact any sensitive user data by calling redact() on all if it's
-// stored args.
+// RedactableError is an error that can be used as a drop-in replacement for an error,
+// which has the ability to redact any sensitive data by calling redact() on all of its args.
 type RedactableError struct {
 	fmt  string
 	args []interface{}
 }
+
+var (
+	_ error    = &RedactableError{}
+	_ Redactor = &RedactableError{}
+)
 
 // Create a new redactable error.  Same signature as fmt.Errorf() for easy drop-in replacement.
 func RedactErrorf(fmt string, args ...interface{}) *RedactableError {
@@ -28,12 +32,17 @@ func RedactErrorf(fmt string, args ...interface{}) *RedactableError {
 	}
 }
 
-// Satisfy error interface
+// Error satisfies the error interface
 func (re *RedactableError) Error() string {
+	return re.String()
+}
+
+// String returns a non-redacted version of the error - satisfies the Redactor interface.
+func (re *RedactableError) String() string {
 	return fmt.Sprintf(re.fmt, re.args...)
 }
 
-// Satisfy redact interface
+// Redact returns a redacted version of the error - satisfies the Redactor interface.
 func (re *RedactableError) Redact() string {
 	redactedArgs := redact(re.args)
 	return fmt.Sprintf(re.fmt, redactedArgs...)


### PR DESCRIPTION
- Add `String()` method to `RedactableError` to allow it to satisfy `Redactor` again.
- Add compile-time interface checks to type to catch future regressions.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1785/
