### PR TITLE
CBG-2998 always set no TLS bootstrap parameter to false for cbgt

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -325,7 +325,8 @@ func initCBGTManager(ctx context.Context, bucket Bucket, spec BucketSpec, cfgSG 
 	options := make(map[string]string)
 	options[cbgt.FeedAllotmentOption] = cbgt.FeedAllotmentOnePerPIndex
 	options["managerLoadDataDir"] = "false"
-	// Let gocbcore decide whether to use TLS or not from TLS handlers. This flag only applies to the initial bootstrap connection to the seed node, and we can always use TLS or not, depending on connection parameters.
+	// TLS is controlled by the connection string.
+	// cbgt uses this parameter to run in mixed mode - non-TLS for CCCP but TLS for memcached. Sync Gateway does not need to set this parameter.
 	options["feedInitialBootstrapNonTLS"] = "false"
 
 	// Disable collections if unsupported

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -16,7 +16,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -326,8 +325,8 @@ func initCBGTManager(ctx context.Context, bucket Bucket, spec BucketSpec, cfgSG 
 	options := make(map[string]string)
 	options[cbgt.FeedAllotmentOption] = cbgt.FeedAllotmentOnePerPIndex
 	options["managerLoadDataDir"] = "false"
-	// Ensure we always use TLS if configured - cbgt defaults to non-TLS on initial connection
-	options["feedInitialBootstrapNonTLS"] = strconv.FormatBool(!spec.IsTLS())
+	// Let gocbcore decide whether to use TLS or not from TLS handlers. This flag only applies to the initial bootstrap connection to the seed node, and we can always use TLS or not, depending on connection parameters.
+	options["feedInitialBootstrapNonTLS"] = "false"
 
 	// Disable collections if unsupported
 	if !bucket.IsSupported(sgbucket.BucketStoreFeatureCollections) {


### PR DESCRIPTION
cbgt will use TLS if we ask, and not if we don't.

Tested in two ways (failed before and passes now):

- set cbgt connection string to include `?bootstrap_on=cccp`
- created a DNS SRV record on my local DNS server and set that in my bootstrap config.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1786/
