### PR TITLE
Log around config.FromConnStr to diagnose slow DNS SRV resolution

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -154,6 +154,9 @@ const (
 
 	// ServerlessChannelLimit is hard limit on channels allowed per user when running in serverless mode
 	ServerlessChannelLimit = 500
+
+	// FromConnStrWarningThreshold determines the amount of time it should take before we warn about parsing a connstr (mostly for DNS resolution)
+	FromConnStrWarningThreshold = 10 * time.Second
 )
 
 const (

--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -320,9 +320,16 @@ func (dc *DCPClient) initAgent(spec BucketSpec) error {
 	}
 
 	agentConfig := gocbcore.DCPAgentConfig{}
+	DebugfCtx(context.TODO(), KeyAll, "Parsing cluster connection string %q", UD(connStr))
+	beforeFromConnStr := time.Now()
 	connStrError := agentConfig.FromConnStr(connStr)
 	if connStrError != nil {
 		return fmt.Errorf("Unable to start DCP Client - error building conn str: %v", connStrError)
+	}
+	if d := time.Since(beforeFromConnStr); d > FromConnStrWarningThreshold {
+		WarnfCtx(context.TODO(), "Parsed cluster connection string %q in: %v", UD(connStr), d)
+	} else {
+		DebugfCtx(context.TODO(), KeyAll, "Parsed cluster connection string %q in: %v", UD(connStr), d)
 	}
 
 	auth, authErr := spec.GocbcoreAuthProvider()

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -41,9 +41,6 @@ const kStatsReportInterval = time.Hour
 const kDefaultSlowQueryWarningThreshold = 500 // ms
 const KDefaultNumShards = 16
 
-// fromConnStrWarningThreshold determines the amount of time it should take before we warn about parsing a connstr (mostly for DNS SRV resolution)
-const fromConnStrWarningThreshold = 10 * time.Second
-
 // defaultBlipStatsReportingInterval is the default interval when to report blip stats, at the end of a message handler.
 const defaultBlipStatsReportingInterval = 30 * time.Second
 
@@ -1532,7 +1529,7 @@ func initClusterAgent(ctx context.Context, clusterAddress, clusterUser, clusterP
 	if err != nil {
 		return nil, err
 	}
-	if d := time.Since(beforeFromConnStr); d > fromConnStrWarningThreshold {
+	if d := time.Since(beforeFromConnStr); d > base.FromConnStrWarningThreshold {
 		base.WarnfCtx(ctx, "Parsed cluster connection string %q in: %v", base.UD(clusterAddress), d)
 	} else {
 		base.DebugfCtx(ctx, base.KeyAll, "Parsed cluster connection string %q in: %v", base.UD(clusterAddress), d)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1523,10 +1523,12 @@ func initClusterAgent(ctx context.Context, clusterAddress, clusterUser, clusterP
 		},
 	}
 
+	base.DebugfCtx(ctx, base.KeyAll, "Parsing cluster connection string: %s", base.UD(clusterAddress))
 	err = config.FromConnStr(clusterAddress)
 	if err != nil {
 		return nil, err
 	}
+	base.DebugfCtx(ctx, base.KeyAll, "Done parsing cluster connection string")
 
 	agent, err := gocbcore.CreateAgent(&config)
 	if err != nil {


### PR DESCRIPTION
`config.FromConnStr` performs SRV DNS lookups, which under some circumstances can cause slow startup times for Sync Gateway.

Log around this function to diganose and log at warning when it takes longer than 10 seconds.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a