### PR TITLE
CBG-2983 Close cbgt indexes on feed close

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -789,7 +789,10 @@ func (meh *sgMgrEventHandlers) OnFeedError(srcType string, r cbgt.Feed, feedErr 
 			srcType, bucketName, bucketUUID)
 
 		if meh.manager != nil {
-			meh.manager.DeleteAllIndexFromSource(srcType, bucketName, bucketUUID)
+			deleteIndexErr := meh.manager.DeleteAllIndexFromSource(srcType, bucketName, bucketUUID)
+			if deleteIndexErr != nil {
+				InfofCtx(meh.ctx, KeyDCP, "Error closing cbgt connections after OnFeedError. err: %v", deleteIndexErr)
+			}
 		}
 	}
 


### PR DESCRIPTION
Required to trigger close of cbgt memcached connections.

CBG-2983

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1789/
