### PR TITLE
CBG-2977 allow DELETE on a broken DB config

### DIFF
--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -11,6 +11,7 @@ package base
 
 import (
 	"expvar"
+	"fmt"
 	"math"
 	"time"
 
@@ -27,6 +28,7 @@ type LeakyBucket struct {
 }
 
 var _ sgbucket.BucketStore = &LeakyBucket{}
+var _ sgbucket.DynamicDataStoreBucket = &LeakyBucket{}
 
 func NewLeakyBucket(bucket Bucket, config LeakyBucketConfig) *LeakyBucket {
 	return &LeakyBucket{
@@ -92,6 +94,22 @@ func (b *LeakyBucket) NamedDataStore(name sgbucket.DataStoreName) (sgbucket.Data
 
 func (b *LeakyBucket) GetUnderlyingBucket() Bucket {
 	return b.bucket
+}
+
+func (b *LeakyBucket) CreateDataStore(name sgbucket.DataStoreName) error {
+	dynamicDataStore, ok := b.GetUnderlyingBucket().(sgbucket.DynamicDataStoreBucket)
+	if !ok {
+		return fmt.Errorf("Bucket %T doesn't support dynamic collection creation", b.GetUnderlyingBucket())
+	}
+	return dynamicDataStore.CreateDataStore(name)
+}
+
+func (b *LeakyBucket) DropDataStore(name sgbucket.DataStoreName) error {
+	dynamicDataStore, ok := b.GetUnderlyingBucket().(sgbucket.DynamicDataStoreBucket)
+	if !ok {
+		return fmt.Errorf("Bucket %T doesn't support dynamic collection creation", b.GetUnderlyingBucket())
+	}
+	return dynamicDataStore.DropDataStore(name)
 }
 
 // The config object that controls the LeakyBucket behavior

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -174,6 +174,22 @@ func (b *TestBucket) GetMetadataStore() sgbucket.DataStore {
 	return b.Bucket.DefaultDataStore()
 }
 
+func (b *TestBucket) CreateDataStore(name sgbucket.DataStoreName) error {
+	dynamicDataStore, ok := b.Bucket.(sgbucket.DynamicDataStoreBucket)
+	if !ok {
+		return fmt.Errorf("Bucket %T doesn't support dynamic collection creation", b.Bucket)
+	}
+	return dynamicDataStore.CreateDataStore(name)
+}
+
+func (b *TestBucket) DropDataStore(name sgbucket.DataStoreName) error {
+	dynamicDataStore, ok := b.GetUnderlyingBucket().(sgbucket.DynamicDataStoreBucket)
+	if !ok {
+		return fmt.Errorf("Bucket %T doesn't support dynamic collection creation", b.GetUnderlyingBucket())
+	}
+	return dynamicDataStore.DropDataStore(name)
+}
+
 // GetDefaultDataStore returns the default DataStore. This is likely never actually wanted over GetSingleDataStore, so is left commented until absolutely required.
 // func (b *TestBucket) GetDefaultDataStore() sgbucket.DataStore {
 // 	b.t.Logf("Using default collection - Are you sure you want this instead of GetSingleDataStore() ?")

--- a/db/database.go
+++ b/db/database.go
@@ -310,17 +310,15 @@ func connectToBucketErrorHandling(ctx context.Context, spec base.BucketSpec, got
 	return false, nil
 }
 
-type OpenBucketFn func(ctx context.Context, spec base.BucketSpec) (base.Bucket, error)
+type OpenBucketFn func(context.Context, base.BucketSpec, bool) (base.Bucket, error)
 
-// connectToBucketFailFast opens a Couchbase connect and return a specific bucket without retrying on failure.
-func connectToBucketFailFast(ctx context.Context, spec base.BucketSpec) (bucket base.Bucket, err error) {
-	bucket, err = base.GetBucket(spec)
-	_, err = connectToBucketErrorHandling(ctx, spec, err)
-	return bucket, err
-}
-
-// connectToBucket opens a Couchbase connection and return a specific bucket.
-func connectToBucket(ctx context.Context, spec base.BucketSpec) (base.Bucket, error) {
+// ConnectToBucket opens a Couchbase connection and return a specific bucket. If failFast is set, fail immediately if the bucket doesn't exist, otherwise retry waiting for bucket to exist.
+func ConnectToBucket(ctx context.Context, spec base.BucketSpec, failFast bool) (base.Bucket, error) {
+	if failFast {
+		bucket, err := base.GetBucket(spec)
+		_, err = connectToBucketErrorHandling(ctx, spec, err)
+		return bucket, err
+	}
 
 	// start a retry loop to connect to the bucket backing off double the delay each time
 	worker := func() (bool, error, interface{}) {
@@ -340,14 +338,6 @@ func connectToBucket(ctx context.Context, spec base.BucketSpec) (base.Bucket, er
 	}
 
 	return ibucket.(base.Bucket), nil
-}
-
-// GetConnectToBucketFn returns a different OpenBucketFn to connect to the bucket depending on the value of failFast
-func GetConnectToBucketFn(failFast bool) OpenBucketFn {
-	if failFast {
-		return connectToBucketFailFast
-	}
-	return connectToBucket
 }
 
 // Returns Couchbase Server Cluster UUID on a timeout. If running against walrus, do return an empty string.

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1849,9 +1849,10 @@ func BenchmarkDatabase(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		ctx := base.TestCtx(b)
-		bucket, _ := connectToBucket(ctx, base.BucketSpec{
+		bucket, _ := ConnectToBucket(ctx, base.BucketSpec{
 			Server:     base.UnitTestUrl(),
-			BucketName: fmt.Sprintf("b-%d", i)})
+			BucketName: fmt.Sprintf("b-%d", i)},
+			true)
 		dbCtx, _ := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 		db, _ := CreateDatabase(dbCtx)
 		collection := GetSingleDatabaseCollectionWithUser(b, db)
@@ -1867,9 +1868,10 @@ func BenchmarkPut(b *testing.B) {
 	base.DisableTestLogging(b)
 
 	ctx := base.TestCtx(b)
-	bucket, _ := connectToBucket(ctx, base.BucketSpec{
+	bucket, _ := ConnectToBucket(ctx, base.BucketSpec{
 		Server:     base.UnitTestUrl(),
-		BucketName: "Bucket"})
+		BucketName: "Bucket"},
+		true)
 	context, _ := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	db, _ := CreateDatabase(context)
 	collection := GetSingleDatabaseCollectionWithUser(b, db)

--- a/rest/api.go
+++ b/rest/api.go
@@ -218,7 +218,7 @@ func (h *handler) handleFlush() error {
 		}
 
 		// Manually re-open a temporary bucket connection just for flushing purposes
-		tempBucketForFlush, err := db.GetConnectToBucketFn(false)(h.ctx(), spec)
+		tempBucketForFlush, err := db.ConnectToBucket(h.ctx(), spec, false)
 		if err != nil {
 			return err
 		}

--- a/rest/config.go
+++ b/rest/config.go
@@ -1481,7 +1481,7 @@ func (sc *ServerContext) bucketNameFromDbName(dbName string) (bucketName string,
 		return dbc.Bucket.GetName(), true
 	}
 
-	if base.ServerIsWalrus(sc.Config.Bootstrap.Server) {
+	if sc.BootstrapContext.Connection == nil {
 		return "", false
 	}
 	// To search for database with the specified name, need to iterate over all buckets:

--- a/rest/config.go
+++ b/rest/config.go
@@ -1481,6 +1481,9 @@ func (sc *ServerContext) bucketNameFromDbName(dbName string) (bucketName string,
 		return dbc.Bucket.GetName(), true
 	}
 
+	if base.ServerIsWalrus(sc.Config.Bootstrap.Server) {
+		return "", false
+	}
 	// To search for database with the specified name, need to iterate over all buckets:
 	//   - look for dbName-scoped config file
 	//   - fetch default config file (backward compatibility, check internal DB name)

--- a/rest/config.go
+++ b/rest/config.go
@@ -1267,7 +1267,8 @@ func SetupServerContext(ctx context.Context, config *StartupConfig, persistentCo
 
 	sc := NewServerContext(ctx, config, persistentConfig)
 	if !base.ServerIsWalrus(config.Bootstrap.Server) {
-		if err := sc.initializeCouchbaseServerConnections(ctx); err != nil {
+		failFast := false
+		if err := sc.initializeCouchbaseServerConnections(ctx, failFast); err != nil {
 			return nil, err
 		}
 	}
@@ -1614,7 +1615,7 @@ func (sc *ServerContext) FetchConfigs(ctx context.Context, isInitialStartup bool
 // _applyConfigs takes a map of dbName->DatabaseConfig and loads them into the ServerContext where necessary.
 func (sc *ServerContext) _applyConfigs(ctx context.Context, dbNameConfigs map[string]DatabaseConfig, isInitialStartup bool) (count int) {
 	for dbName, cnf := range dbNameConfigs {
-		applied, err := sc._applyConfig(base.NewNonCancelCtx(), cnf, false, isInitialStartup)
+		applied, err := sc._applyConfig(base.NewNonCancelCtx(), cnf, true, isInitialStartup)
 		if err != nil {
 			base.ErrorfCtx(ctx, "Couldn't apply config for database %q: %v", base.MD(dbName), err)
 			continue

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -330,8 +330,12 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 							return ErrInvalidLogin
 						}
 					}
-					base.InfofCtx(h.ctx(), base.KeyHTTP, "Error trying to get db %s: %v", base.MD(keyspaceDb), err)
-					return err
+					// look for db in config registry
+					_, ok := h.server.bucketNameFromDbName(keyspaceDb)
+					if !ok {
+						base.InfofCtx(h.ctx(), base.KeyHTTP, "Error trying to get db %s: %v", base.MD(keyspaceDb), err)
+						return err
+					}
 				}
 			} else {
 				return err

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -100,9 +100,9 @@ func NewRestTesterCluster(t *testing.T, config *RestTesterClusterConfig) *RestTe
 
 	// Set group ID for each RestTester from cluster
 	if config.rtConfig == nil {
-		config.rtConfig = &RestTesterConfig{groupID: config.groupID}
+		config.rtConfig = &RestTesterConfig{GroupID: config.groupID}
 	} else {
-		config.rtConfig.groupID = config.groupID
+		config.rtConfig.GroupID = config.groupID
 	}
 	// only persistent mode is supported for a RestTesterCluster
 	config.rtConfig.PersistentConfig = true

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -327,7 +327,7 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	r.Handle("/{newdb:"+dbRegex+"}/",
 		makeHandlerSpecificAuthScope(sc, adminPrivs, []Permission{PermCreateDb}, nil, (*handler).handleCreateDB, getAuthScopeHandleCreateDB)).Methods("PUT")
 	r.Handle("/{db:"+dbRegex+"}/",
-		makeOfflineHandler(sc, adminPrivs, []Permission{PermDeleteDb}, nil, (*handler).handleDeleteDB)).Methods("DELETE")
+		makeMetadataDBOfflineHandler(sc, adminPrivs, []Permission{PermDeleteDb}, nil, (*handler).handleDeleteDB)).Methods("DELETE")
 
 	r.Handle("/_all_dbs",
 		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleAllDbs)).Methods("GET", "HEAD")
@@ -364,7 +364,7 @@ func wrapRouter(sc *ServerContext, privs handlerPrivs, router *mux.Router) http.
 			router.ServeHTTP(response, rq)
 		} else {
 			// Log the request
-			h := newHandler(sc, privs, response, rq, false)
+			h := newHandler(sc, privs, response, rq, handlerOptions{})
 			h.logRequestLine()
 
 			// Inject CORS if enabled and requested and not admin port

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -94,9 +94,10 @@ type bootstrapContext struct {
 }
 
 func (sc *ServerContext) CreateLocalDatabase(ctx context.Context, dbs DbConfigMap) error {
+	failFast := false
 	for _, dbConfig := range dbs {
 		dbc := dbConfig.ToDatabaseConfig()
-		_, err := sc._getOrAddDatabaseFromConfig(ctx, *dbc, false, db.GetConnectToBucketFn(false))
+		_, err := sc._getOrAddDatabaseFromConfig(ctx, *dbc, false, db.GetConnectToBucketFn(failFast), failFast)
 		if err != nil {
 			return err
 		}
@@ -356,7 +357,7 @@ func (sc *ServerContext) PostUpgrade(ctx context.Context, preview bool) (postUpg
 func (sc *ServerContext) _reloadDatabase(ctx context.Context, reloadDbName string, failFast bool) (*db.DatabaseContext, error) {
 	sc._unloadDatabase(ctx, reloadDbName)
 	config := sc.dbConfigs[reloadDbName]
-	return sc._getOrAddDatabaseFromConfig(ctx, config.DatabaseConfig, true, db.GetConnectToBucketFn(failFast))
+	return sc._getOrAddDatabaseFromConfig(ctx, config.DatabaseConfig, true, db.GetConnectToBucketFn(failFast), failFast)
 }
 
 // Removes and re-adds a database to the ServerContext.
@@ -377,18 +378,18 @@ func (sc *ServerContext) ReloadDatabaseWithConfig(nonContextStruct base.NonCance
 
 func (sc *ServerContext) _reloadDatabaseWithConfig(ctx context.Context, config DatabaseConfig, failFast bool) error {
 	sc._removeDatabase(ctx, config.Name)
-	_, err := sc._getOrAddDatabaseFromConfig(ctx, config, false, db.GetConnectToBucketFn(failFast))
+	_, err := sc._getOrAddDatabaseFromConfig(ctx, config, false, db.GetConnectToBucketFn(failFast), failFast)
 	return err
 }
 
 // Adds a database to the ServerContext.  Attempts a read after it gets the write
 // lock to see if it's already been added by another process. If so, returns either the
 // existing DatabaseContext or an error based on the useExisting flag.
-func (sc *ServerContext) getOrAddDatabaseFromConfig(ctx context.Context, config DatabaseConfig, useExisting bool, openBucketFn db.OpenBucketFn) (*db.DatabaseContext, error) {
+func (sc *ServerContext) getOrAddDatabaseFromConfig(ctx context.Context, config DatabaseConfig, useExisting bool, openBucketFn db.OpenBucketFn, failFast bool) (*db.DatabaseContext, error) {
 	// Obtain write lock during add database, to avoid race condition when creating based on ConfigServer
 	sc.lock.Lock()
 	defer sc.lock.Unlock()
-	return sc._getOrAddDatabaseFromConfig(ctx, config, useExisting, openBucketFn)
+	return sc._getOrAddDatabaseFromConfig(ctx, config, useExisting, openBucketFn, failFast)
 }
 
 func GetBucketSpec(ctx context.Context, config *DatabaseConfig, serverConfig *StartupConfig) (spec base.BucketSpec, err error) {
@@ -432,8 +433,7 @@ func GetBucketSpec(ctx context.Context, config *DatabaseConfig, serverConfig *St
 // lock to see if it's already been added by another process. If so, returns either the
 // existing DatabaseContext or an error based on the useExisting flag.
 // Pass in a bucketFromBucketSpecFn to replace the default ConnectToBucket function. This will cause the failFast argument to be ignored
-func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config DatabaseConfig, useExisting bool, openBucketFn db.OpenBucketFn) (*db.DatabaseContext, error) {
-
+func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config DatabaseConfig, useExisting bool, openBucketFn db.OpenBucketFn, failFast bool) (*db.DatabaseContext, error) {
 	// Generate bucket spec and validate whether db already exists
 	spec, err := GetBucketSpec(ctx, &config, sc.Config)
 	if err != nil {
@@ -558,15 +558,20 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 			for collectionName, _ := range scopeConfig.Collections {
 				var dataStore sgbucket.DataStore
 
-				waitForCollection := func() (bool, error, interface{}) {
+				var err error
+				if failFast {
 					dataStore, err = bucket.NamedDataStore(base.ScopeAndCollectionName{Scope: scopeName, Collection: collectionName})
-					return err != nil, err, nil
-				}
+				} else {
+					waitForCollection := func() (bool, error, interface{}) {
+						dataStore, err = bucket.NamedDataStore(base.ScopeAndCollectionName{Scope: scopeName, Collection: collectionName})
+						return err != nil, err, nil
+					}
 
-				err, _ := base.RetryLoop(
-					fmt.Sprintf("waiting for %s.%s.%s to exist", base.MD(bucket.GetName()), base.MD(scopeName), base.MD(collectionName)),
-					waitForCollection,
-					base.CreateMaxDoublingSleeperFunc(30, 10, 1000))
+					err, _ = base.RetryLoop(
+						fmt.Sprintf("waiting for %s.%s.%s to exist", base.MD(bucket.GetName()), base.MD(scopeName), base.MD(collectionName)),
+						waitForCollection,
+						base.CreateMaxDoublingSleeperFunc(30, 10, 1000))
+				}
 				if err != nil {
 					return nil, fmt.Errorf("error attempting to create/update database: %w", err)
 				}
@@ -1224,13 +1229,15 @@ func (sc *ServerContext) initEventHandlers(ctx context.Context, dbcontext *db.Da
 // Adds a database to the ServerContext given its configuration.  If an existing config is found
 // for the name, returns an error.
 func (sc *ServerContext) AddDatabaseFromConfig(ctx context.Context, config DatabaseConfig) (*db.DatabaseContext, error) {
-	return sc.getOrAddDatabaseFromConfig(ctx, config, false, db.GetConnectToBucketFn(false))
+	failFast := false
+	return sc.getOrAddDatabaseFromConfig(ctx, config, false, db.GetConnectToBucketFn(failFast), failFast)
 }
 
 // AddDatabaseFromConfigFailFast adds a database to the ServerContext given its configuration and fails fast.
 // If an existing config is found for the name, returns an error.
 func (sc *ServerContext) AddDatabaseFromConfigFailFast(nonContextStruct base.NonCancellableContext, config DatabaseConfig) (*db.DatabaseContext, error) {
-	return sc.getOrAddDatabaseFromConfig(nonContextStruct.Ctx, config, false, db.GetConnectToBucketFn(true))
+	failFast := true
+	return sc.getOrAddDatabaseFromConfig(nonContextStruct.Ctx, config, false, db.GetConnectToBucketFn(failFast), failFast)
 }
 
 func (sc *ServerContext) processEventHandlersForEvent(ctx context.Context, events []*EventConfig, eventType db.EventType, dbcontext *db.DatabaseContext) error {
@@ -1356,7 +1363,8 @@ func (sc *ServerContext) _unsuspendDatabase(ctx context.Context, dbName string) 
 			return nil, fmt.Errorf("unsuspending db %q failed due to an error while trying to retrieve latest config from bucket %q: %w", base.MD(dbName).Redact(), base.MD(bucket).Redact(), err)
 		}
 		dbConfig.cfgCas = cas
-		dbCtx, err = sc._getOrAddDatabaseFromConfig(ctx, dbConfig.DatabaseConfig, false, db.GetConnectToBucketFn(false))
+		failFast := false
+		dbCtx, err = sc._getOrAddDatabaseFromConfig(ctx, dbConfig.DatabaseConfig, false, db.GetConnectToBucketFn(failFast), failFast)
 		if err != nil {
 			return nil, err
 		}
@@ -1850,7 +1858,7 @@ func (sc *ServerContext) Database(ctx context.Context, name string) *db.Database
 	return db
 }
 
-func (sc *ServerContext) initializeCouchbaseServerConnections(ctx context.Context) error {
+func (sc *ServerContext) initializeCouchbaseServerConnections(ctx context.Context, failFast bool) error {
 	base.InfofCtx(ctx, base.KeyAll, "Initializing server connections")
 	defer func() {
 		base.InfofCtx(ctx, base.KeyAll, "Finished initializing server connections")

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -498,10 +498,13 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		base.MD(dbName), base.MD(spec.BucketName), base.SD(base.DefaultPool), base.SD(spec.Server))
 
 	// the connectToBucketFn is used for testing seam
-	if options.connectToBucketFn == nil {
-		options.connectToBucketFn = db.ConnectToBucket
+	var bucket base.Bucket
+	if options.connectToBucketFn != nil {
+		// the connectToBucketFn is used for testing seam
+		bucket, err = options.connectToBucketFn(ctx, spec, options.failFast)
+	} else {
+		bucket, err = db.ConnectToBucket(ctx, spec, options.failFast)
 	}
-	bucket, err := options.connectToBucketFn(ctx, spec, options.failFast)
 	if err != nil {
 		return nil, err
 	}

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -168,7 +168,7 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 
 	// Get or add database name from config without valid database name; throws 400 Illegal database name error
 	dbConfig := DbConfig{OldRevExpirySeconds: &oldRevExpirySeconds, LocalDocExpirySecs: &localDocExpirySecs}
-	dbContext, err := serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(false))
+	dbContext, err := serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(false), false)
 	assert.Nil(t, dbContext, "Can't create database context without a valid database name")
 	assert.Error(t, err, "It should throw 400 Illegal database name")
 	assert.Contains(t, err.Error(), strconv.Itoa(http.StatusBadRequest))
@@ -187,7 +187,7 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 		BucketConfig:        BucketConfig{Server: &server, Bucket: &bucketName},
 	}
 
-	dbContext, err = serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(false))
+	dbContext, err = serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(false), false)
 	assert.Nil(t, dbContext, "Can't create database context from config with unrecognized value for import_docs")
 	assert.Error(t, err, "It should throw Unrecognized value for import_docs")
 
@@ -214,14 +214,14 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 		AutoImport:          false,
 	}
 
-	dbContext, err = serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(false))
+	dbContext, err = serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(false), false)
 	assert.Nil(t, dbContext, "Can't create database context with duplicate database name")
 	assert.Error(t, err, "It should throw 412 Duplicate database names")
 	assert.Contains(t, err.Error(), strconv.Itoa(http.StatusPreconditionFailed))
 
 	// Get or add database from config with duplicate database name and useExisting as true
 	// Existing database context should be returned
-	dbContext, err = serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, true, db.GetConnectToBucketFn(false))
+	dbContext, err = serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, true, db.GetConnectToBucketFn(false), false)
 	assert.NoError(t, err, "No error while trying to get the existing database name")
 	assert.Equal(t, server, dbContext.BucketSpec.Server)
 	assert.Equal(t, bucketName, dbContext.BucketSpec.BucketName)
@@ -615,7 +615,7 @@ func TestServerContextSetupCollectionsSupport(t *testing.T) {
 			},
 		},
 	}
-	_, err := serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(true))
+	_, err := serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(true), true)
 	require.ErrorIs(t, err, errCollectionsUnsupported)
 }
 
@@ -790,7 +790,7 @@ func TestDisableScopesInLegacyConfig(t *testing.T) {
 					}
 					dbConfig.Scopes = GetCollectionsConfigWithSyncFn(t, bucket, nil, 1)
 				}
-				dbContext, err := serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(false))
+				dbContext, err := serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(false), false)
 				if persistentConfig || scopes == false {
 					require.NoError(t, err)
 					require.NotNil(t, dbContext)

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -51,7 +51,7 @@ func TestServerlessPollBuckets(t *testing.T) {
 	assert.Empty(t, configs)
 
 	// Create a database
-	rt2 := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1.NoCloseClone(), PersistentConfig: true, groupID: &sc.Config.Bootstrap.ConfigGroupID})
+	rt2 := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1.NoCloseClone(), PersistentConfig: true, GroupID: &sc.Config.Bootstrap.ConfigGroupID})
 	defer rt2.Close()
 	// Create a new db on the RT to confirm fetch won't retrieve it (due to bucket not being in BucketCredentials)
 	resp := rt2.SendAdminRequest(http.MethodPut, "/db/", fmt.Sprintf(`{

--- a/rest/upgradetest/remove_collection_test.go
+++ b/rest/upgradetest/remove_collection_test.go
@@ -21,7 +21,7 @@ import (
 // TestRemoveCollection tests when a collection has been removed from CBS, and the server is restarted. We should be able to modify or delete the database.
 func TestRemoveCollection(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
-		t.Skip("test relies on boostrap connection and needs CBS")
+		t.Skip("test relies on bootstrap connection and needs CBS")
 	}
 	base.TestRequiresCollections(t)
 	numCollections := 2

--- a/rest/upgradetest/remove_collection_test.go
+++ b/rest/upgradetest/remove_collection_test.go
@@ -1,0 +1,80 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package upgradetest
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/rest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveCollection(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("test relies on boostrap connection and needs CBS")
+	}
+	base.TestRequiresCollections(t)
+	numCollections := 2
+	bucket := base.GetPersistentTestBucket(t)
+	defer bucket.Close()
+	base.RequireNumTestDataStores(t, numCollections)
+	rtConfig := &rest.RestTesterConfig{
+		CustomTestBucket: bucket.NoCloseClone(),
+		PersistentConfig: true,
+		GroupID:          base.StringPtr(t.Name()),
+	}
+
+	rt := rest.NewRestTesterMultipleCollections(t, rtConfig, 2)
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Scopes = rest.GetCollectionsConfig(t, rt.TestBucket, numCollections)
+
+	dbName := "removecollectiondb"
+	resp := rt.CreateDatabase(dbName, dbConfig)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	dataStores := rt.TestBucket.GetNonDefaultDatastoreNames()
+	deletedDataStore := dataStores[1]
+
+	defer func() {
+		assert.NoError(t, bucket.CreateDataStore(deletedDataStore))
+
+	}()
+	// drop a data store
+	require.NoError(t, rt.TestBucket.DropDataStore(deletedDataStore))
+	require.Len(t, rt.TestBucket.GetNonDefaultDatastoreNames(), len(dataStores)-1)
+
+	/*resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_offline", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_online", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	delete(dbConfig.Scopes[deletedDataStore.ScopeName()].Collections, deletedDataStore.CollectionName())
+	resp = rt.UpsertDbConfig(dbName, dbConfig)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+	*/
+
+	rt.Close()
+	rtConfig = &rest.RestTesterConfig{
+		CustomTestBucket: bucket.NoCloseClone(),
+		PersistentConfig: true,
+		GroupID:          base.StringPtr(t.Name()),
+	}
+
+	rt = rest.NewRestTesterMultipleCollections(t, rtConfig, 2)
+	defer rt.Close()
+
+	resp = rt.SendAdminRequest(http.MethodDelete, "/"+dbName+"/", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+}

--- a/rest/upgradetest/remove_collection_test.go
+++ b/rest/upgradetest/remove_collection_test.go
@@ -23,74 +23,51 @@ func TestRemoveCollection(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("test relies on boostrap connection and needs CBS")
 	}
-	base.RequireNumTestBuckets(t, 2) // test parameterize uses 2 buckets since bucket collection is on parent test
-	testCases := []struct {
-		name string
-	}{
-		{
-			name: "delete",
-		},
-		{
-			name: "upsert",
-		},
+	base.TestRequiresCollections(t)
+	numCollections := 2
+	bucket := base.GetPersistentTestBucket(t)
+	defer bucket.Close()
+	base.RequireNumTestDataStores(t, numCollections)
+	rtConfig := &rest.RestTesterConfig{
+		CustomTestBucket: bucket.NoCloseClone(),
+		PersistentConfig: true,
+		GroupID:          base.StringPtr(t.Name()),
 	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			base.TestRequiresCollections(t)
-			numCollections := 2
-			bucket := base.GetPersistentTestBucket(t)
-			defer bucket.Close()
-			base.RequireNumTestDataStores(t, numCollections)
-			rtConfig := &rest.RestTesterConfig{
-				CustomTestBucket: bucket.NoCloseClone(),
-				PersistentConfig: true,
-				GroupID:          base.StringPtr(t.Name()),
-			}
-			rt := rest.NewRestTesterMultipleCollections(t, rtConfig, 2)
+	rt := rest.NewRestTesterMultipleCollections(t, rtConfig, 2)
 
-			dbConfig := rt.NewDbConfig()
-			dbConfig.Scopes = rest.GetCollectionsConfig(t, rt.TestBucket, numCollections)
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Scopes = rest.GetCollectionsConfig(t, rt.TestBucket, numCollections)
 
-			dbName := "removecollectiondb"
-			resp := rt.CreateDatabase(dbName, dbConfig)
-			rest.RequireStatus(t, resp, http.StatusCreated)
+	dbName := "removecollectiondb"
+	resp := rt.CreateDatabase(dbName, dbConfig)
+	rest.RequireStatus(t, resp, http.StatusCreated)
 
-			dataStores := rt.TestBucket.GetNonDefaultDatastoreNames()
-			deletedDataStore := dataStores[1]
+	dataStores := rt.TestBucket.GetNonDefaultDatastoreNames()
+	deletedDataStore := dataStores[1]
 
-			defer func() {
-				assert.NoError(t, bucket.CreateDataStore(deletedDataStore))
+	defer func() {
+		assert.NoError(t, bucket.CreateDataStore(deletedDataStore))
 
-			}()
-			// drop a data store
-			require.NoError(t, rt.TestBucket.DropDataStore(deletedDataStore))
-			require.Len(t, rt.TestBucket.GetNonDefaultDatastoreNames(), len(dataStores)-1)
+	}()
+	// drop a data store
+	require.NoError(t, rt.TestBucket.DropDataStore(deletedDataStore))
+	require.Len(t, rt.TestBucket.GetNonDefaultDatastoreNames(), len(dataStores)-1)
 
-			delete(dbConfig.Scopes[deletedDataStore.ScopeName()].Collections, deletedDataStore.CollectionName())
-			resp = rt.UpsertDbConfig(dbName, dbConfig)
-			rest.RequireStatus(t, resp, http.StatusCreated)
-
-			rt.Close()
-			rtConfig = &rest.RestTesterConfig{
-				CustomTestBucket: bucket.NoCloseClone(),
-				PersistentConfig: true,
-				GroupID:          base.StringPtr(t.Name()),
-			}
-
-			rt = rest.NewRestTesterMultipleCollections(t, rtConfig, 2)
-			defer rt.Close()
-
-			switch testCase.name {
-			case "upsert":
-				delete(dbConfig.Scopes[deletedDataStore.ScopeName()].Collections, deletedDataStore.CollectionName())
-				resp = rt.UpsertDbConfig(dbName, dbConfig)
-				rest.RequireStatus(t, resp, http.StatusCreated)
-			case "delete":
-
-				resp = rt.SendAdminRequest(http.MethodDelete, "/"+dbName+"/", "")
-				rest.RequireStatus(t, resp, http.StatusOK)
-			}
-		})
+	rt.Close()
+	rtConfig = &rest.RestTesterConfig{
+		CustomTestBucket: bucket.NoCloseClone(),
+		PersistentConfig: true,
+		GroupID:          base.StringPtr(t.Name()),
 	}
+
+	rt = rest.NewRestTesterMultipleCollections(t, rtConfig, 2)
+	defer rt.Close()
+
+	delete(dbConfig.Scopes[deletedDataStore.ScopeName()].Collections, deletedDataStore.CollectionName())
+	resp = rt.UpsertDbConfig(dbName, dbConfig)
+	rest.RequireStatus(t, resp, http.StatusNotFound) // the database can't be loaded so it is not found
+
+	resp = rt.SendAdminRequest(http.MethodDelete, "/"+dbName+"/", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
 
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1181,10 +1181,14 @@ func (s *SlowResponseRecorder) Write(buf []byte) (int, error) {
 // AddDatabaseFromConfigWithBucket adds a database to the ServerContext and sets a specific bucket on the database context.
 // If an existing config is found for the name, returns an error.
 func (sc *ServerContext) AddDatabaseFromConfigWithBucket(ctx context.Context, tb testing.TB, config DatabaseConfig, bucket base.Bucket) (*db.DatabaseContext, error) {
-	failFast := true
-	return sc.getOrAddDatabaseFromConfig(ctx, config, false, func(ctx context.Context, spec base.BucketSpec) (base.Bucket, error) {
-		return bucket, nil
-	}, failFast)
+	options := getOrAddDatabaseConfigOptions{
+		useExisting: false,
+		failFast:    false,
+		connectToBucketFn: func(_ context.Context, spec base.BucketSpec, _ bool) (base.Bucket, error) {
+			return bucket, nil
+		},
+	}
+	return sc.getOrAddDatabaseFromConfig(ctx, config, options)
 }
 
 // The parameters used to create a BlipTester

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2458,7 +2458,6 @@ func (rt *RestTester) GetChangesOneShot(t testing.TB, keyspace string, since int
 
 func (rt *RestTester) NewDbConfig() DbConfig {
 	// make sure bucket has been initialized
-	_ = rt.Bucket()
 	config := DbConfig{
 		BucketConfig: BucketConfig{
 			Bucket: base.StringPtr(rt.Bucket().GetName()),

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -66,7 +66,7 @@ type RestTesterConfig struct {
 	enableAdminAuthPermissionsCheck bool
 	useTLSServer                    bool // If true, TLS will be required for communications with CBS. Default: false
 	PersistentConfig                bool
-	groupID                         *string
+	GroupID                         *string
 	serverless                      bool // Runs SG in serverless mode. Must be used in conjunction with persistent config
 	collectionConfig                collectionConfiguration
 	numCollections                  int
@@ -227,8 +227,8 @@ func (rt *RestTester) Bucket() base.Bucket {
 		}
 	}
 
-	if rt.RestTesterConfig.groupID != nil {
-		sc.Bootstrap.ConfigGroupID = *rt.RestTesterConfig.groupID
+	if rt.RestTesterConfig.GroupID != nil {
+		sc.Bootstrap.ConfigGroupID = *rt.RestTesterConfig.GroupID
 	} else if rt.RestTesterConfig.PersistentConfig {
 		// If running in persistent config mode, the database has to be manually created. If the db name is the same as a
 		// past tests db name, a db already exists error could happen if the past tests bucket is still flushing. Prevent this
@@ -2457,6 +2457,8 @@ func (rt *RestTester) GetChangesOneShot(t testing.TB, keyspace string, since int
 }
 
 func (rt *RestTester) NewDbConfig() DbConfig {
+	// make sure bucket has been initialized
+	_ = rt.Bucket()
 	config := DbConfig{
 		BucketConfig: BucketConfig{
 			Bucket: base.StringPtr(rt.Bucket().GetName()),

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -270,7 +270,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 		rt.TestBucket.BucketSpec.TLSSkipVerify = base.TestTLSSkipVerify()
 
-		if err := rt.RestTesterServerContext.initializeCouchbaseServerConnections(ctx); err != nil {
+		if err := rt.RestTesterServerContext.initializeCouchbaseServerConnections(ctx, true); err != nil {
 			panic("Couldn't initialize Couchbase Server connection: " + err.Error())
 		}
 	}
@@ -1181,9 +1181,10 @@ func (s *SlowResponseRecorder) Write(buf []byte) (int, error) {
 // AddDatabaseFromConfigWithBucket adds a database to the ServerContext and sets a specific bucket on the database context.
 // If an existing config is found for the name, returns an error.
 func (sc *ServerContext) AddDatabaseFromConfigWithBucket(ctx context.Context, tb testing.TB, config DatabaseConfig, bucket base.Bucket) (*db.DatabaseContext, error) {
+	failFast := true
 	return sc.getOrAddDatabaseFromConfig(ctx, config, false, func(ctx context.Context, spec base.BucketSpec) (base.Bucket, error) {
 		return bucket, nil
-	})
+	}, failFast)
 }
 
 // The parameters used to create a BlipTester


### PR DESCRIPTION
CBG-2977

- This only works with a bootstrap connection, because otherwise you'd just modify the file on disk. This means that this _only_ has test coverage where we use persistent config enabled. Also, persistent config isn't enabled for walrus.
- Added some boilerplate to allow `LeakyBucket` and `TestBucket` to support `DropDataStore` and `CreateDataStore` on the assumption this test would work with walrus. It does not though, because it relies on the bootstrap connection.
- Trying to delete a config without a bootstrap connection will result in a 404 since you wouldn't be able start up sync gateway with a bad config.
- the only non test changes are in `rest/config.go` and `rest/handler.go`. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1814/
