### PR TITLE
Tweak TestIncrCounter to cover non-equal def and amt values

### DIFF
--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -362,22 +362,22 @@ func TestIncrCounter(t *testing.T) {
 		}
 	}()
 
-	// New Counter - incr 1, default 1
-	value, err := dataStore.Incr(key, 1, 1, 0)
-	assert.NoError(t, err, "Error incrementing non-existent counter")
+	// New Counter - incr 1, default 5
+	value, err := dataStore.Incr(key, 1, 5, 0)
+	require.NoError(t, err, "Error incrementing non-existent counter")
 
-	// key did not exist - so expect the "initial" value of 1
-	assert.Equal(t, uint64(1), value)
+	// key did not exist - so expect the "initial" value of 5
+	require.Equal(t, uint64(5), value)
 
 	// Retrieve existing counter value using GetCounter
 	retrieval, err := GetCounter(dataStore, key)
-	assert.NoError(t, err, "Error retrieving value for existing counter")
-	assert.Equal(t, uint64(1), retrieval)
+	require.NoError(t, err, "Error retrieving value for existing counter")
+	require.Equal(t, uint64(5), retrieval)
 
 	// Increment existing counter
-	retrieval, err = dataStore.Incr(key, 1, 1, 0)
-	assert.NoError(t, err, "Error incrementing value for existing counter")
-	assert.Equal(t, uint64(2), retrieval)
+	retrieval, err = dataStore.Incr(key, 1, 5, 0)
+	require.NoError(t, err, "Error incrementing value for existing counter")
+	require.Equal(t, uint64(6), retrieval)
 }
 
 func TestGetAndTouchRaw(t *testing.T) {

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -362,15 +362,28 @@ func TestIncrCounter(t *testing.T) {
 		}
 	}()
 
+	// New Counter - incr 0, default 0 - expect zero-value counter doc to be created
+	value, err := dataStore.Incr(key, 0, 0, 0)
+	require.NoError(t, err, "Error incrementing non-existent counter")
+	require.Equal(t, uint64(0), value)
+
+	// Retrieve existing counter value using GetCounter
+	retrieval, err := GetCounter(dataStore, key)
+	require.NoError(t, err, "Error retrieving value for existing counter")
+	require.Equal(t, uint64(0), retrieval)
+
+	// remove zero value so we're able to test default below
+	require.NoError(t, dataStore.Delete(key))
+
 	// New Counter - incr 1, default 5
-	value, err := dataStore.Incr(key, 1, 5, 0)
+	value, err = dataStore.Incr(key, 1, 5, 0)
 	require.NoError(t, err, "Error incrementing non-existent counter")
 
 	// key did not exist - so expect the "initial" value of 5
 	require.Equal(t, uint64(5), value)
 
 	// Retrieve existing counter value using GetCounter
-	retrieval, err := GetCounter(dataStore, key)
+	retrieval, err = GetCounter(dataStore, key)
 	require.NoError(t, err, "Error retrieving value for existing counter")
 	require.Equal(t, uint64(5), retrieval)
 

--- a/base/collection_gocb.go
+++ b/base/collection_gocb.go
@@ -356,9 +356,6 @@ func (c *Collection) Update(k string, exp uint32, callback sgbucket.UpdateFunc) 
 func (c *Collection) Incr(k string, amt, def uint64, exp uint32) (uint64, error) {
 	c.Bucket.waitForAvailKvOp()
 	defer c.Bucket.releaseKvOp()
-	if amt == 0 {
-		return 0, errors.New("amt passed to Incr must be non-zero")
-	}
 	incrOptions := gocb.IncrementOptions{
 		Initial: int64(def),
 		Delta:   amt,


### PR DESCRIPTION
Prereq for CBG-3027

Allows the Collection API `Incr()` op to take a zero value delta/amt to pass through to Gocb, which initializes the counter with the given `def` value.

## Dependencies (if applicable)
- [x] Link upstream PRs
- [x] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1803/
