### PR TITLE
CBG-2909-v2: Move processes into db online function

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -586,3 +586,23 @@ func WaitUntilDataStoreExists(ds DataStore) error {
 		return err
 	})
 }
+
+// RequireNoBucketTTL ensures there is no MaxTTL set on the bucket (SG #3314)
+func RequireNoBucketTTL(b Bucket) error {
+	cbs, ok := AsCouchbaseBucketStore(b)
+	if !ok {
+		// Not a Couchbase bucket - no TTL check to do
+		return nil
+	}
+
+	maxTTL, err := cbs.MaxTTL()
+	if err != nil {
+		return err
+	}
+
+	if maxTTL != 0 {
+		return fmt.Errorf("Backing Couchbase Server bucket has a non-zero MaxTTL value: %d.  Please set MaxTTL to 0 in Couchbase Server Admin UI and try again.", maxTTL)
+	}
+
+	return nil
+}

--- a/base/util.go
+++ b/base/util.go
@@ -1258,6 +1258,10 @@ func (ab *AtomicBool) IsTrue() bool {
 }
 
 func (ab *AtomicBool) CompareAndSwap(old bool, new bool) bool {
+	if ab == nil {
+		// ab was never initialized, so we can't do anything to it
+		return false
+	}
 	var oldint32 int32
 	var newint32 int32
 	if old {

--- a/base/util.go
+++ b/base/util.go
@@ -1258,10 +1258,6 @@ func (ab *AtomicBool) IsTrue() bool {
 }
 
 func (ab *AtomicBool) CompareAndSwap(old bool, new bool) bool {
-	if ab == nil {
-		// ab was never initialized, so we can't do anything to it
-		return false
-	}
 	var oldint32 int32
 	var newint32 int32
 	if old {

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -223,6 +223,10 @@ func (c *changeCache) Start(initialSequence uint64) error {
 // Stops the cache. Clears its state and tells the housekeeping task to stop.
 func (c *changeCache) Stop() {
 
+	if c.stopped == nil {
+		// changeCache never initialized - nothing to stop
+		return
+	}
 	if !c.stopped.CompareAndSwap(false, true) {
 		return
 	}

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1976,6 +1976,9 @@ func BenchmarkProcessEntry(b *testing.B) {
 			require.NoError(b, err)
 			defer context.Close(ctx)
 
+			err = context.StartOnlineProcesses(ctx)
+			require.NoError(b, err)
+
 			collection := GetSingleDatabaseCollection(b, context)
 			collectionID := collection.GetCollectionID()
 
@@ -2207,6 +2210,9 @@ func BenchmarkDocChanged(b *testing.B) {
 			context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 			require.NoError(b, err)
 			defer context.Close(ctx)
+
+			err = context.StartOnlineProcesses(ctx)
+			require.NoError(b, err)
 
 			collection := GetSingleDatabaseCollection(b, context)
 			collectionID := collection.GetCollectionID()

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -192,6 +192,11 @@ func (listener *changeListener) Stop() {
 	logCtx := context.TODO()
 	base.DebugfCtx(logCtx, base.KeyChanges, "changeListener.Stop() called")
 
+	if !listener.started.IsTrue() {
+		// already stopped
+		return
+	}
+
 	if listener.terminator != nil {
 		close(listener.terminator)
 	}

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -193,7 +193,7 @@ func (listener *changeListener) Stop() {
 	base.DebugfCtx(logCtx, base.KeyChanges, "changeListener.Stop() called")
 
 	if !listener.started.IsTrue() {
-		// already stopped
+		// not started, nothing to do
 		return
 	}
 

--- a/db/database.go
+++ b/db/database.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	pkgerrors "github.com/pkg/errors"
 	"net/http"
 	"regexp"
 	"strings"
@@ -25,6 +24,7 @@ import (
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
+	pkgerrors "github.com/pkg/errors"
 )
 
 const (

--- a/db/database.go
+++ b/db/database.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	pkgerrors "github.com/pkg/errors"
 	"net/http"
 	"regexp"
 	"strings"
@@ -24,7 +25,6 @@ import (
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
-	pkgerrors "github.com/pkg/errors"
 )
 
 const (
@@ -441,13 +441,6 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		dbContext.sequences.Stop()
 	})
 
-	// Get current value of _sync:seq
-	initialSequence, seqErr := dbContext.sequences.lastSequence()
-	if seqErr != nil {
-		return nil, seqErr
-	}
-	initialSequenceTime := time.Now()
-
 	// Initialize the active channel counter
 	dbContext.activeChannels = channels.NewActiveChannels(dbContext.DbStats.Cache().NumActiveChannels)
 
@@ -537,231 +530,6 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	if syncFunctionsChanged {
 		base.InfofCtx(ctx, base.KeyAll, "**NOTE:** %q's sync function has changed. The new function may assign different channels to documents, or permissions to users. You may want to re-sync the database to update these.", base.MD(dbContext.Name))
 	}
-
-	// Callback that is invoked whenever a set of channels is changed in the ChangeCache
-	notifyChange := func(changedChannels channels.Set) {
-		dbContext.mutationListener.Notify(changedChannels)
-	}
-
-	// Initialize the ChangeCache.  Will be locked and unusable until .Start() is called (SG #3558)
-	err = dbContext.changeCache.Init(
-		ctx,
-		dbContext,
-		dbContext.channelCache,
-		notifyChange,
-		dbContext.Options.CacheOptions,
-		metaKeys,
-	)
-	if err != nil {
-		base.DebugfCtx(ctx, base.KeyDCP, "Error initializing the change cache", err)
-		return nil, err
-	}
-	dbContext.mutationListener.OnChangeCallback = dbContext.changeCache.DocChanged
-
-	if base.IsEnterpriseEdition() {
-		cfgSG, ok := dbContext.CfgSG.(*base.CfgSG)
-		if !ok {
-			return nil, fmt.Errorf("Could not cast %V to CfgSG", dbContext.CfgSG)
-		}
-		dbContext.changeCache.cfgEventCallback = cfgSG.FireEvent
-	}
-
-	// Initialize sg-replicate manager
-	dbContext.SGReplicateMgr, err = NewSGReplicateManager(ctx, dbContext, dbContext.CfgSG)
-	if err != nil {
-		return nil, err
-	}
-
-	importEnabled := dbContext.UseXattrs() && dbContext.autoImport
-	sgReplicateEnabled := dbContext.Options.SGReplicateOptions.Enabled
-
-	// Initialize node heartbeater in EE mode if sg-replicate or import enabled on the node.  This node must start
-	// sending heartbeats before registering itself to the cfg, to avoid triggering immediate removal by other active nodes.
-	if base.IsEnterpriseEdition() && (importEnabled || sgReplicateEnabled) {
-		// Create heartbeater
-		heartbeaterPrefix := metaKeys.HeartbeaterPrefix(dbContext.Options.GroupID)
-		heartbeater, err := base.NewCouchbaseHeartbeater(dbContext.MetadataStore, heartbeaterPrefix, dbContext.UUID)
-		if err != nil {
-			return nil, pkgerrors.Wrapf(err, "Error starting heartbeater for bucket %s", base.MD(bucket.GetName()).Redact())
-		}
-		err = heartbeater.StartSendingHeartbeats()
-		if err != nil {
-			return nil, err
-		}
-		dbContext.Heartbeater = heartbeater
-
-		cleanupFunctions = append(cleanupFunctions, func() {
-			dbContext.Heartbeater.Stop()
-		})
-	}
-
-	// If sgreplicate is enabled on this node, register this node to accept notifications
-	if sgReplicateEnabled {
-		registerNodeErr := dbContext.SGReplicateMgr.StartLocalNode(dbContext.UUID, dbContext.Heartbeater)
-		if registerNodeErr != nil {
-			return nil, registerNodeErr
-		}
-
-		cleanupFunctions = append(cleanupFunctions, func() {
-			dbContext.SGReplicateMgr.Stop()
-		})
-	}
-
-	// Start DCP feed
-	base.InfofCtx(ctx, base.KeyDCP, "Starting mutation feed on bucket %v due to either channel cache mode or doc tracking (auto-import)", base.MD(bucket.GetName()))
-	cacheFeedStatsMap := dbContext.DbStats.Database().CacheFeedMapStats
-	err = dbContext.mutationListener.Start(bucket, cacheFeedStatsMap.Map, dbContext.Scopes, dbContext.MetadataStore)
-
-	// Check if there is an error starting the DCP feed
-	if err != nil {
-		dbContext.channelCache = nil
-		return nil, err
-	}
-
-	cleanupFunctions = append(cleanupFunctions, func() {
-		dbContext.mutationListener.Stop()
-	})
-
-	// Unlock change cache.  Validate that any allocated sequences on other nodes have either been assigned or released
-	// before starting
-	if initialSequence > 0 {
-		_ = dbContext.sequences.waitForReleasedSequences(initialSequenceTime)
-	}
-
-	err = dbContext.changeCache.Start(initialSequence)
-	if err != nil {
-		return nil, err
-	}
-	cleanupFunctions = append(cleanupFunctions, func() {
-		dbContext.changeCache.Stop()
-	})
-
-	// If this is an xattr import node, start import feed.  Must be started after the caching DCP feed, as import cfg
-	// subscription relies on the caching feed.
-	if importEnabled {
-		dbContext.ImportListener = NewImportListener(ctx, metaKeys.DCPCheckpointPrefix(dbContext.Options.GroupID), dbContext)
-		if importFeedErr := dbContext.ImportListener.StartImportFeed(dbContext); importFeedErr != nil {
-			return nil, importFeedErr
-		}
-
-		cleanupFunctions = append(cleanupFunctions, func() {
-			dbContext.ImportListener.Stop()
-		})
-	}
-
-	// Load providers into provider map.  Does basic validation on the provider definition, and identifies the default provider.
-	if options.OIDCOptions != nil {
-		dbContext.OIDCProviders = make(auth.OIDCProviderMap)
-
-		for name, provider := range options.OIDCOptions.Providers {
-			if provider.Issuer == "" || base.StringDefault(provider.ClientID, "") == "" {
-				// TODO: this duplicates a check in DbConfig.validate to avoid a backwards compatibility issue
-				base.WarnfCtx(ctx, "Issuer and Client ID not defined for provider %q - skipping", base.UD(name))
-				continue
-			}
-			provider.Name = name
-
-			// If this is the default provider, or there's only one provider defined, set IsDefault
-			if (options.OIDCOptions.DefaultProvider != nil && name == *options.OIDCOptions.DefaultProvider) || len(options.OIDCOptions.Providers) == 1 {
-				provider.IsDefault = true
-			}
-
-			insecureSkipVerify := false
-			if options.UnsupportedOptions != nil {
-				insecureSkipVerify = options.UnsupportedOptions.OidcTlsSkipVerify
-			}
-			provider.InsecureSkipVerify = insecureSkipVerify
-
-			// If this isn't the default provider, add the provider to the callback URL (needed to identify provider to _oidc_callback)
-			if !provider.IsDefault && provider.CallbackURL != nil {
-				updatedCallback, err := auth.SetURLQueryParam(*provider.CallbackURL, auth.OIDCAuthProvider, name)
-				if err != nil {
-					return nil, base.RedactErrorf("Failed to add provider %q to OIDC callback URL: %v", base.UD(name), err)
-				}
-				provider.CallbackURL = &updatedCallback
-			}
-
-			dbContext.OIDCProviders[name] = provider
-		}
-	}
-
-	dbContext.LocalJWTProviders = make(auth.LocalJWTProviderMap, len(options.LocalJWTConfig))
-	for name, cfg := range options.LocalJWTConfig {
-		dbContext.LocalJWTProviders[name] = cfg.BuildProvider(name)
-	}
-
-	if dbContext.UseXattrs() {
-		// Set the purge interval for tombstone compaction
-		dbContext.PurgeInterval = DefaultPurgeInterval
-		cbStore, ok := base.AsCouchbaseBucketStore(bucket)
-		if ok {
-			serverPurgeInterval, err := cbStore.MetadataPurgeInterval()
-			if err != nil {
-				base.WarnfCtx(ctx, "Unable to retrieve server's metadata purge interval - will use default value. %s", err)
-			} else if serverPurgeInterval > 0 {
-				dbContext.PurgeInterval = serverPurgeInterval
-			}
-		}
-		base.InfofCtx(ctx, base.KeyAll, "Using metadata purge interval of %.2f days for tombstone compaction.", dbContext.PurgeInterval.Hours()/24)
-
-		if dbContext.Options.CompactInterval != 0 {
-			if autoImport {
-				db := Database{DatabaseContext: dbContext}
-				// Wrap the dbContext's terminator in a SafeTerminator for the compaction task
-				bgtTerminator := base.NewSafeTerminator()
-				go func() {
-					<-dbContext.terminator
-					bgtTerminator.Close()
-				}()
-				bgt, err := NewBackgroundTask(ctx, "Compact", func(ctx context.Context) error {
-					_, err := db.Compact(ctx, false, func(purgedDocCount *int) {}, bgtTerminator)
-					if err != nil {
-						base.WarnfCtx(ctx, "Error trying to compact tombstoned documents for %q with error: %v", dbContext.Name, err)
-					}
-					return nil
-				}, time.Duration(dbContext.Options.CompactInterval)*time.Second, dbContext.terminator)
-				if err != nil {
-					return nil, err
-				}
-				db.backgroundTasks = append(db.backgroundTasks, bgt)
-			} else {
-				base.WarnfCtx(ctx, "Automatic compaction can only be enabled on nodes running an Import process")
-			}
-		}
-
-	}
-
-	// Make sure there is no MaxTTL set on the bucket (SG #3314)
-	cbs, ok := base.AsCouchbaseBucketStore(bucket)
-	if ok {
-		maxTTL, err := cbs.MaxTTL()
-		if err != nil {
-			return nil, err
-		}
-		if maxTTL != 0 {
-			return nil, fmt.Errorf("Backing Couchbase Server bucket has a non-zero MaxTTL value: %d.  Please set MaxTTL to 0 in Couchbase Server Admin UI and try again.", maxTTL)
-		}
-	}
-
-	dbContext.ExitChanges = make(chan struct{})
-
-	// Start checking heartbeats for other nodes.  Must be done after caching feed starts, to ensure any removals
-	// are detected and processed by this node.
-	if dbContext.Heartbeater != nil {
-		err = dbContext.Heartbeater.StartCheckingHeartbeats()
-		if err != nil {
-			return nil, err
-		}
-		// No cleanup necessary, stop heartbeater above will take care of it
-	}
-
-	if dbContext.UseQueryBasedResyncManager() {
-		dbContext.ResyncManager = NewResyncManager(metadataStore, metaKeys)
-	} else {
-		dbContext.ResyncManager = NewResyncManagerDCP(metadataStore, dbContext.UseXattrs(), metaKeys)
-	}
-	dbContext.TombstoneCompactionManager = NewTombstoneCompactionManager()
-	dbContext.AttachmentCompactionManager = NewAttachmentCompactionManager(metadataStore, metaKeys)
 
 	return dbContext, nil
 }
@@ -2322,4 +2090,219 @@ func (dbc *DatabaseContext) AuthenticatorOptions() auth.AuthenticatorOptions {
 // across all nodes, while lastSequence is just the latest allocation from this node
 func (dbc *DatabaseContext) GetRequestPlusSequence() (uint64, error) {
 	return dbc.sequences.getSequence()
+}
+
+func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) error {
+
+	// Callback that is invoked whenever a set of channels is changed in the ChangeCache
+	notifyChange := func(changedChannels channels.Set) {
+		db.mutationListener.Notify(changedChannels)
+	}
+
+	// Initialize the ChangeCache.  Will be locked and unusable until .Start() is called (SG #3558)
+	if err := db.changeCache.Init(
+		ctx,
+		db,
+		db.channelCache,
+		notifyChange,
+		db.Options.CacheOptions,
+		db.MetadataKeys,
+	); err != nil {
+		base.DebugfCtx(ctx, base.KeyDCP, "Error initializing the change cache", err)
+		return err
+	}
+	db.mutationListener.OnChangeCallback = db.changeCache.DocChanged
+
+	if base.IsEnterpriseEdition() {
+		cfgSG, ok := db.CfgSG.(*base.CfgSG)
+		if !ok {
+			return fmt.Errorf("Could not cast %V to CfgSG", db.CfgSG)
+		}
+		db.changeCache.cfgEventCallback = cfgSG.FireEvent
+	}
+
+	// Initialize sg-replicate manager
+	sgrMgr, err := NewSGReplicateManager(ctx, db, db.CfgSG)
+	if err != nil {
+		return err
+	}
+	db.SGReplicateMgr = sgrMgr
+
+	importEnabled := db.UseXattrs() && db.autoImport
+	sgReplicateEnabled := db.Options.SGReplicateOptions.Enabled
+
+	// Initialize node heartbeater in EE mode if sg-replicate or import enabled on the node.  This node must start
+	// sending heartbeats before registering itself to the cfg, to avoid triggering immediate removal by other active nodes.
+	if base.IsEnterpriseEdition() && (importEnabled || sgReplicateEnabled) {
+		// Create heartbeater
+		heartbeaterPrefix := db.MetadataKeys.HeartbeaterPrefix(db.Options.GroupID)
+		heartbeater, err := base.NewCouchbaseHeartbeater(db.MetadataStore, heartbeaterPrefix, db.UUID)
+		if err != nil {
+			return pkgerrors.Wrapf(err, "Error starting heartbeater for bucket %s", base.MD(db.Bucket.GetName()).Redact())
+		}
+		err = heartbeater.StartSendingHeartbeats()
+		if err != nil {
+			return err
+		}
+		db.Heartbeater = heartbeater
+	}
+
+	// If sgreplicate is enabled on this node, register this node to accept notifications
+	if sgReplicateEnabled {
+		registerNodeErr := db.SGReplicateMgr.StartLocalNode(db.UUID, db.Heartbeater)
+		if registerNodeErr != nil {
+			return registerNodeErr
+		}
+	}
+
+	// Start DCP feed
+	base.InfofCtx(ctx, base.KeyDCP, "Starting mutation feed on bucket %v due to either channel cache mode or doc tracking (auto-import)", base.MD(db.Bucket.GetName()))
+	cacheFeedStatsMap := db.DbStats.Database().CacheFeedMapStats
+	if err := db.mutationListener.Start(db.Bucket, cacheFeedStatsMap.Map, db.Scopes, db.MetadataStore); err != nil {
+		db.channelCache = nil
+		return err
+	}
+
+	// Get current value of _sync:seq
+	initialSequence, seqErr := db.sequences.lastSequence()
+	if seqErr != nil {
+		return seqErr
+	}
+	initialSequenceTime := time.Now()
+
+	// Unlock change cache.  Validate that any allocated sequences on other nodes have either been assigned or released
+	// before starting
+	if initialSequence > 0 {
+		_ = db.sequences.waitForReleasedSequences(initialSequenceTime)
+	}
+
+	if err := db.changeCache.Start(initialSequence); err != nil {
+		return err
+	}
+
+	// If this is an xattr import node, start import feed.  Must be started after the caching DCP feed, as import cfg
+	// subscription relies on the caching feed.
+	if db.autoImport {
+		db.ImportListener = NewImportListener(ctx, db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID), db)
+		if importFeedErr := db.ImportListener.StartImportFeed(db); importFeedErr != nil {
+			return importFeedErr
+		}
+	}
+
+	// Load providers into provider map.  Does basic validation on the provider definition, and identifies the default provider.
+	if db.Options.OIDCOptions != nil {
+		db.OIDCProviders = make(auth.OIDCProviderMap)
+
+		for name, provider := range db.Options.OIDCOptions.Providers {
+			if provider.Issuer == "" || base.StringDefault(provider.ClientID, "") == "" {
+				// TODO: this duplicates a check in DbConfig.validate to avoid a backwards compatibility issue
+				base.WarnfCtx(ctx, "Issuer and Client ID not defined for provider %q - skipping", base.UD(name))
+				continue
+			}
+			provider.Name = name
+
+			// If this is the default provider, or there's only one provider defined, set IsDefault
+			if (db.Options.OIDCOptions.DefaultProvider != nil && name == *db.Options.OIDCOptions.DefaultProvider) || len(db.Options.OIDCOptions.Providers) == 1 {
+				provider.IsDefault = true
+			}
+
+			insecureSkipVerify := false
+			if db.Options.UnsupportedOptions != nil {
+				insecureSkipVerify = db.Options.UnsupportedOptions.OidcTlsSkipVerify
+			}
+			provider.InsecureSkipVerify = insecureSkipVerify
+
+			// If this isn't the default provider, add the provider to the callback URL (needed to identify provider to _oidc_callback)
+			if !provider.IsDefault && provider.CallbackURL != nil {
+				updatedCallback, err := auth.SetURLQueryParam(*provider.CallbackURL, auth.OIDCAuthProvider, name)
+				if err != nil {
+					return base.RedactErrorf("Failed to add provider %q to OIDC callback URL: %v", base.UD(name), err)
+				}
+				provider.CallbackURL = &updatedCallback
+			}
+
+			db.OIDCProviders[name] = provider
+		}
+	}
+
+	db.LocalJWTProviders = make(auth.LocalJWTProviderMap, len(db.Options.LocalJWTConfig))
+	for name, cfg := range db.Options.LocalJWTConfig {
+		db.LocalJWTProviders[name] = cfg.BuildProvider(name)
+	}
+
+	if db.UseXattrs() {
+		// Set the purge interval for tombstone compaction
+		db.PurgeInterval = DefaultPurgeInterval
+		cbStore, ok := base.AsCouchbaseBucketStore(db.Bucket)
+		if ok {
+			serverPurgeInterval, err := cbStore.MetadataPurgeInterval()
+			if err != nil {
+				base.WarnfCtx(ctx, "Unable to retrieve server's metadata purge interval - will use default value. %s", err)
+			} else if serverPurgeInterval > 0 {
+				db.PurgeInterval = serverPurgeInterval
+			}
+		}
+		base.InfofCtx(ctx, base.KeyAll, "Using metadata purge interval of %.2f days for tombstone compaction.", db.PurgeInterval.Hours()/24)
+
+		if db.Options.CompactInterval != 0 {
+			if db.autoImport {
+				db := Database{DatabaseContext: db}
+				// Wrap the dbContext's terminator in a SafeTerminator for the compaction task
+				bgtTerminator := base.NewSafeTerminator()
+				go func() {
+					<-db.terminator
+					bgtTerminator.Close()
+				}()
+				bgt, err := NewBackgroundTask(ctx, "Compact", func(ctx context.Context) error {
+					_, err := db.Compact(ctx, false, func(purgedDocCount *int) {}, bgtTerminator)
+					if err != nil {
+						base.WarnfCtx(ctx, "Error trying to compact tombstoned documents for %q with error: %v", db.Name, err)
+					}
+					return nil
+				}, time.Duration(db.Options.CompactInterval)*time.Second, db.terminator)
+				if err != nil {
+					return err
+				}
+				db.backgroundTasks = append(db.backgroundTasks, bgt)
+			} else {
+				base.WarnfCtx(ctx, "Automatic compaction can only be enabled on nodes running an Import process")
+			}
+		}
+
+	}
+
+	// Make sure there is no MaxTTL set on the bucket (SG #3314)
+	cbs, ok := base.AsCouchbaseBucketStore(db.Bucket)
+	if ok {
+		maxTTL, err := cbs.MaxTTL()
+		if err != nil {
+			return err
+		}
+		if maxTTL != 0 {
+			return fmt.Errorf("Backing Couchbase Server bucket has a non-zero MaxTTL value: %d.  Please set MaxTTL to 0 in Couchbase Server Admin UI and try again.", maxTTL)
+		}
+	}
+
+	db.ExitChanges = make(chan struct{})
+
+	// Start checking heartbeats for other nodes.  Must be done after caching feed starts, to ensure any removals
+	// are detected and processed by this node.
+	if db.Heartbeater != nil {
+		if err := db.Heartbeater.StartCheckingHeartbeats(); err != nil {
+			return err
+		}
+		// No cleanup necessary, stop heartbeater above will take care of it
+	}
+
+	if db.UseQueryBasedResyncManager() {
+		db.ResyncManager = NewResyncManager(db.MetadataStore, db.MetadataKeys)
+	} else {
+		db.ResyncManager = NewResyncManagerDCP(db.MetadataStore, db.UseXattrs(), db.MetadataKeys)
+	}
+	db.TombstoneCompactionManager = NewTombstoneCompactionManager()
+	db.AttachmentCompactionManager = NewAttachmentCompactionManager(db.MetadataStore, db.MetadataKeys)
+
+	db.startReplications(ctx)
+
+	return nil
 }

--- a/db/database.go
+++ b/db/database.go
@@ -537,6 +537,12 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		return nil, err
 	}
 
+	if dbContext.UseQueryBasedResyncManager() {
+		dbContext.ResyncManager = NewResyncManager(metadataStore, metaKeys)
+	} else {
+		dbContext.ResyncManager = NewResyncManagerDCP(metadataStore, dbContext.UseXattrs(), metaKeys)
+	}
+
 	return dbContext, nil
 }
 
@@ -2293,11 +2299,6 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) error {
 		// No cleanup necessary, stop heartbeater above will take care of it
 	}
 
-	if db.UseQueryBasedResyncManager() {
-		db.ResyncManager = NewResyncManager(db.MetadataStore, db.MetadataKeys)
-	} else {
-		db.ResyncManager = NewResyncManagerDCP(db.MetadataStore, db.UseXattrs(), db.MetadataKeys)
-	}
 	db.TombstoneCompactionManager = NewTombstoneCompactionManager()
 	db.AttachmentCompactionManager = NewAttachmentCompactionManager(db.MetadataStore, db.MetadataKeys)
 

--- a/db/database.go
+++ b/db/database.go
@@ -531,6 +531,12 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		base.InfofCtx(ctx, base.KeyAll, "**NOTE:** %q's sync function has changed. The new function may assign different channels to documents, or permissions to users. You may want to re-sync the database to update these.", base.MD(dbContext.Name))
 	}
 
+	// Initialize sg-replicate manager
+	dbContext.SGReplicateMgr, err = NewSGReplicateManager(ctx, dbContext, dbContext.CfgSG)
+	if err != nil {
+		return nil, err
+	}
+
 	return dbContext, nil
 }
 
@@ -2120,13 +2126,6 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) error {
 		}
 		db.changeCache.cfgEventCallback = cfgSG.FireEvent
 	}
-
-	// Initialize sg-replicate manager
-	sgrMgr, err := NewSGReplicateManager(ctx, db, db.CfgSG)
-	if err != nil {
-		return err
-	}
-	db.SGReplicateMgr = sgrMgr
 
 	importEnabled := db.UseXattrs() && db.autoImport
 	sgReplicateEnabled := db.Options.SGReplicateOptions.Enabled

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -134,6 +134,11 @@ func setupTestLeakyDBWithCacheOptions(t *testing.T, options CacheOptions, leakyO
 		testBucket.Close()
 		t.Fatalf("Unable to create database context: %v", err)
 	}
+	err = dbCtx.StartOnlineProcesses(ctx)
+	if err != nil {
+		dbCtx.Close(ctx)
+		t.Fatalf("Unable to start online processes: %v", err)
+	}
 	db, err := CreateDatabase(dbCtx)
 	if err != nil {
 		dbCtx.Close(ctx)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -63,6 +63,10 @@ func setupTestDBWithOptionsAndImport(t testing.TB, tBucket *base.TestBucket, dbc
 	}
 	dbCtx, err := NewDatabaseContext(ctx, "db", tBucket, true, dbcOptions)
 	require.NoError(t, err, "Couldn't create context for database 'db'")
+
+	err = dbCtx.StartOnlineProcesses(ctx)
+	require.NoError(t, err)
+
 	db, err := CreateDatabase(dbCtx)
 	require.NoError(t, err, "Couldn't create database 'db'")
 	ctx = db.AddDatabaseLogContext(ctx)
@@ -111,6 +115,10 @@ func setupTestDBWithCustomSyncSeq(t testing.TB, customSeq uint64) (*Database, co
 
 	dbCtx, err := NewDatabaseContext(ctx, "db", tBucket, false, dbcOptions)
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
+
+	err = dbCtx.StartOnlineProcesses(ctx)
+	require.NoError(t, err)
+
 	db, err := CreateDatabase(dbCtx)
 	assert.NoError(t, err, "Couldn't create database 'db'")
 

--- a/db/dcp_sharded_upgrade_test.go
+++ b/db/dcp_sharded_upgrade_test.go
@@ -229,6 +229,10 @@ func TestShardedDCPUpgrade(t *testing.T) {
 	})
 	require.NoError(t, err, "NewDatabaseContext")
 	defer db.Close(ctx)
+
+	err = db.StartOnlineProcesses(ctx)
+	require.NoError(t, err)
+
 	ctx = db.AddDatabaseLogContext(ctx)
 	collection := GetSingleDatabaseCollection(t, db)
 

--- a/db/functions/function_test.go
+++ b/db/functions/function_test.go
@@ -670,9 +670,14 @@ func setupTestDBForBucketWithOptions(t testing.TB, tBucket base.Bucket, dbcOptio
 	ctx := base.TestCtx(t)
 	AddOptionsFromEnvironmentVariables(&dbcOptions)
 	dbCtx, err := db.NewDatabaseContext(ctx, "db", tBucket, false, dbcOptions)
-	assert.NoError(t, err, "Couldn't create context for database 'db'")
+	require.NoError(t, err, "Couldn't create context for database 'db'")
+
+	err = dbCtx.StartOnlineProcesses(ctx)
+	require.NoError(t, err)
+
 	db, err := db.CreateDatabase(dbCtx)
-	assert.NoError(t, err, "Couldn't create database 'db'")
+	require.NoError(t, err, "Couldn't create database 'db'")
+
 	ctx = db.AddDatabaseLogContext(ctx)
 	return db, ctx
 }

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -447,7 +447,7 @@ func (ar *ActiveReplicator) alignState(ctx context.Context, targetState string) 
 
 }
 
-func (dbc *DatabaseContext) StartReplications(ctx context.Context) {
+func (dbc *DatabaseContext) startReplications(ctx context.Context) {
 	if dbc.Options.SGReplicateOptions.Enabled {
 		base.DebugfCtx(dbc.SGReplicateMgr.loggingCtx, base.KeyReplicate, "Will start Inter-Sync Gateway Replications for database %q", dbc.Name)
 		dbc.SGReplicateMgr.closeWg.Add(1)

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -679,14 +679,20 @@ func TestReplicateGroupIDAssignedNodes(t *testing.T) {
 	dbDefault, err := NewDatabaseContext(ctx, "default", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "", Scopes: scopesConfig})
 	require.NoError(t, err)
 	defer dbDefault.Close(ctx)
+	err = dbDefault.StartOnlineProcesses(ctx)
+	require.NoError(t, err)
 
 	dbGroupA, err := NewDatabaseContext(ctx, "groupa", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupA", Scopes: scopesConfig})
 	require.NoError(t, err)
 	defer dbGroupA.Close(ctx)
+	err = dbGroupA.StartOnlineProcesses(ctx)
+	require.NoError(t, err)
 
 	dbGroupB, err := NewDatabaseContext(ctx, "groupb", tb.NoCloseClone(), false, DatabaseContextOptions{GroupID: "GroupB", Scopes: scopesConfig})
 	require.NoError(t, err)
 	defer dbGroupB.Close(ctx)
+	err = dbGroupB.StartOnlineProcesses(ctx)
+	require.NoError(t, err)
 
 	// Set up replicators
 	err = dbDefault.SGReplicateMgr.RegisterNode("nodeDefault")

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -545,8 +545,13 @@ func SetupTestDBForDataStoreWithOptions(t testing.TB, tBucket *base.TestBucket, 
 
 	dbCtx, err := NewDatabaseContext(ctx, "db", tBucket, false, dbcOptions)
 	require.NoError(t, err, "Couldn't create context for database 'db'")
+
+	err = dbCtx.StartOnlineProcesses(ctx)
+	require.NoError(t, err)
+
 	db, err := CreateDatabase(dbCtx)
 	require.NoError(t, err, "Couldn't create database 'db'")
+
 	ctx = db.AddDatabaseLogContext(ctx)
 	return db, ctx
 }

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -10,6 +10,7 @@ package adminapitest
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -4024,6 +4025,19 @@ func TestDeleteDatabasePointingAtSameBucketPersistent(t *testing.T) {
 	resp = rest.BootstrapAdminRequest(t, http.MethodPut, "/db2/", fmt.Sprintf(dbConfig, "db2"))
 	resp.RequireStatus(http.StatusCreated)
 
+	// because we moved database - resync is required for the default collection before we're able to bring db2 online
+	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/db2/_resync?regenerate_sequences=true", "")
+	resp.RequireStatus(http.StatusOK)
+
+	// after resync is done, state will flip back to offline
+	BootstrapWaitForDatabaseState(t, "db2", db.DBOffline)
+
+	// now bring the db online so we're able to check dest factory
+	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/db2/_online", "")
+	resp.RequireStatus(http.StatusOK)
+
+	BootstrapWaitForDatabaseState(t, "db2", db.DBOnline)
+
 	scopeName := ""
 	collectionNames := []string{}
 	// Validate that deleted database is no longer in dest factory set
@@ -4031,6 +4045,22 @@ func TestDeleteDatabasePointingAtSameBucketPersistent(t *testing.T) {
 	assert.Equal(t, base.ErrNotFound, fetchDb1DestErr)
 	_, fetchDb2DestErr := base.FetchDestFactory(base.ImportDestKey("db2", scopeName, collectionNames))
 	assert.NoError(t, fetchDb2DestErr)
+}
+
+func BootstrapWaitForDatabaseState(t *testing.T, dbName string, state uint32) {
+	err := base.WaitForNoError(func() error {
+		resp := rest.BootstrapAdminRequest(t, http.MethodGet, "/"+dbName+"/", "")
+		if resp.StatusCode != http.StatusOK {
+			return errors.New("expected 200 status")
+		}
+		var rootResp rest.DatabaseRoot
+		require.NoError(t, json.Unmarshal([]byte(resp.Body), &rootResp))
+		if rootResp.State != db.RunStateString[state] {
+			return errors.New("expected db to be offline")
+		}
+		return nil
+	})
+	require.NoError(t, err)
 }
 
 func TestApiInternalPropertiesHandling(t *testing.T) {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -825,8 +825,11 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 
 	stateChangeMsg := "DB loaded from config"
 
-	if offline := base.BoolDefault(config.StartOffline, false) || len(dbcontext.RequireResync) > 0; !options.forceOnline && offline {
-		if len(dbcontext.RequireResync) > 0 {
+	startOffline := base.BoolDefault(config.StartOffline, false)
+	needsResync := len(dbcontext.RequireResync) > 0
+
+	if needsResync || (startOffline && !options.forceOnline) {
+		if needsResync {
 			stateChangeMsg = "Resync required for collections"
 		}
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -97,6 +97,7 @@ type getOrAddDatabaseConfigOptions struct {
 	failFast          bool            // if set, a failure to connect to a bucket of collection will immediately fail
 	useExisting       bool            //  if true, return an existing DatabaseContext vs return an error
 	connectToBucketFn db.OpenBucketFn // supply a custom function for buckets, used for testing only
+	forceOnline bool // force the database to come online, even if startOffline is set
 }
 
 func (sc *ServerContext) CreateLocalDatabase(ctx context.Context, dbs DbConfigMap) error {
@@ -363,19 +364,21 @@ func (sc *ServerContext) PostUpgrade(ctx context.Context, preview bool) (postUpg
 }
 
 // Removes and re-adds a database to the ServerContext.
-func (sc *ServerContext) _reloadDatabase(ctx context.Context, reloadDbName string, failFast bool) (*db.DatabaseContext, error) {
+func (sc *ServerContext) _reloadDatabase(ctx context.Context, reloadDbName string, failFast bool, forceOnline bool) (*db.DatabaseContext, error) {
 	sc._unloadDatabase(ctx, reloadDbName)
 	config := sc.dbConfigs[reloadDbName]
 	return sc._getOrAddDatabaseFromConfig(ctx, config.DatabaseConfig, getOrAddDatabaseConfigOptions{
 		useExisting: true,
-		failFast:    failFast})
+		failFast:    failFast,
+		forceOnline: forceOnline,
+	})
 }
 
 // Removes and re-adds a database to the ServerContext.
-func (sc *ServerContext) ReloadDatabase(ctx context.Context, reloadDbName string) (*db.DatabaseContext, error) {
+func (sc *ServerContext) ReloadDatabase(ctx context.Context, reloadDbName string, forceOnline bool) (*db.DatabaseContext, error) {
 	// Obtain write lock during add database, to avoid race condition when creating based on ConfigServer
 	sc.lock.Lock()
-	dbContext, err := sc._reloadDatabase(ctx, reloadDbName, false)
+	dbContext, err := sc._reloadDatabase(ctx, reloadDbName, false, forceOnline)
 	sc.lock.Unlock()
 
 	return dbContext, err
@@ -806,12 +809,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		return nil, err
 	}
 
-	// Upsert replications
-	replicationErr := dbcontext.SGReplicateMgr.PutReplications(config.Replications)
-	if replicationErr != nil {
-		return nil, replicationErr
-	}
-
 	// Register it so HTTP handlers can find it:
 	sc.databases_[dbcontext.Name] = dbcontext
 	sc.dbConfigs[dbcontext.Name] = &RuntimeDatabaseConfig{DatabaseConfig: config}
@@ -820,18 +817,25 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		sc.collectionRegistry[name] = dbName
 	}
 
-	if base.BoolDefault(config.StartOffline, false) {
+	stateChangeMsg := "DB loaded from config"
+
+	if offline := base.BoolDefault(config.StartOffline, false) || len(dbcontext.RequireResync) > 0; !forceOnline && offline {
+		if len(dbcontext.RequireResync) > 0 {
+			stateChangeMsg = "Resync required for collections"
+		}
+
 		atomic.StoreUint32(&dbcontext.State, db.DBOffline)
-		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "offline", "DB loaded from config", &sc.Config.API.AdminInterface)
-	} else if len(dbcontext.RequireResync) > 0 {
-		atomic.StoreUint32(&dbcontext.State, db.DBOffline)
-		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "offline", "Resync required for collections", &sc.Config.API.AdminInterface)
-	} else {
-		atomic.StoreUint32(&dbcontext.State, db.DBOnline)
-		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "online", "DB loaded from config", &sc.Config.API.AdminInterface)
+		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "offline", stateChangeMsg, &sc.Config.API.AdminInterface)
+
+		return dbcontext, nil
 	}
 
-	dbcontext.StartReplications(ctx)
+	atomic.StoreUint32(&dbcontext.State, db.DBOnline)
+	_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "online", stateChangeMsg, &sc.Config.API.AdminInterface)
+
+	if err := dbcontext.StartOnlineProcesses(ctx); err != nil {
+		return nil, err
+	}
 
 	return dbcontext, nil
 }
@@ -1118,7 +1122,7 @@ func (sc *ServerContext) TakeDbOnline(nonContextStruct base.NonCancellableContex
 
 	// We can only transition to Online from Offline state
 	if atomic.CompareAndSwapUint32(&database.State, db.DBOffline, db.DBStarting) {
-		reloadedDb, err := sc.ReloadDatabase(nonContextStruct.Ctx, database.Name)
+		reloadedDb, err := sc.ReloadDatabase(nonContextStruct.Ctx, database.Name, true)
 		if err != nil {
 			base.ErrorfCtx(nonContextStruct.Ctx, "Error reloading database from config: %v", err)
 			return
@@ -1387,7 +1391,8 @@ func (sc *ServerContext) _unsuspendDatabase(ctx context.Context, dbName string) 
 		failFast := false
 		dbCtx, err = sc._getOrAddDatabaseFromConfig(ctx, dbConfig.DatabaseConfig, getOrAddDatabaseConfigOptions{
 			useExisting: false,
-			failFast:    failFast})
+			failFast:    failFast,
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -809,6 +809,12 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		return nil, err
 	}
 
+	// Upsert replications
+	replicationErr := dbcontext.SGReplicateMgr.PutReplications(config.Replications)
+	if replicationErr != nil {
+		return nil, replicationErr
+	}
+
 	// Register it so HTTP handlers can find it:
 	sc.databases_[dbcontext.Name] = dbcontext
 	sc.dbConfigs[dbcontext.Name] = &RuntimeDatabaseConfig{DatabaseConfig: config}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -97,7 +97,7 @@ type getOrAddDatabaseConfigOptions struct {
 	failFast          bool            // if set, a failure to connect to a bucket of collection will immediately fail
 	useExisting       bool            //  if true, return an existing DatabaseContext vs return an error
 	connectToBucketFn db.OpenBucketFn // supply a custom function for buckets, used for testing only
-	forceOnline bool // force the database to come online, even if startOffline is set
+	forceOnline       bool            // force the database to come online, even if startOffline is set
 }
 
 func (sc *ServerContext) CreateLocalDatabase(ctx context.Context, dbs DbConfigMap) error {
@@ -819,7 +819,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 
 	stateChangeMsg := "DB loaded from config"
 
-	if offline := base.BoolDefault(config.StartOffline, false) || len(dbcontext.RequireResync) > 0; !forceOnline && offline {
+	if offline := base.BoolDefault(config.StartOffline, false) || len(dbcontext.RequireResync) > 0; !options.forceOnline && offline {
 		if len(dbcontext.RequireResync) > 0 {
 			stateChangeMsg = "Resync required for collections"
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1138,7 +1138,7 @@ func (sc *ServerContext) TakeDbOnline(nonContextStruct base.NonCancellableContex
 		}
 
 		if len(reloadedDb.RequireResync) > 0 {
-			base.ErrorfCtx(nonContextStruct.Ctx, "Database has collections that require resync before it can go online: %v", reloadedDb.RequireResync)
+			base.ErrorfCtx(nonContextStruct.Ctx, "Database has collections that require regenerate_sequences resync before it can go online: %v", reloadedDb.RequireResync)
 			return
 		}
 		// Reloaded DB should already be online in most cases, but force state to online to handle cases

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -11,6 +11,7 @@ package rest
 import (
 	"bytes"
 	"fmt"
+	"github.com/couchbase/sync_gateway/db"
 	"io"
 	"net/http"
 	"os"

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -11,7 +11,6 @@ package rest
 import (
 	"bytes"
 	"fmt"
-	"github.com/couchbase/sync_gateway/db"
 	"io"
 	"net/http"
 	"os"
@@ -22,11 +21,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/couchbase/sync_gateway/auth"
-
 	"github.com/couchbase/gocbcore/v10/connstr"
 	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -823,3 +823,51 @@ func TestDisableScopesInLegacyConfig(t *testing.T) {
 		}
 	}
 }
+
+// TestOfflineDatabaseStartup ensures that background processes are not actually running when starting up a database in offline mode.
+func TestOfflineDatabaseStartup(t *testing.T) {
+	if !base.TestUseXattrs() {
+		t.Skip("TestOfflineDatabaseStartup requires xattrs for document import")
+	}
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				StartOffline: base.BoolPtr(true),
+				AutoImport:   true,
+				EnableXattrs: base.BoolPtr(true),
+			},
+		},
+	})
+	defer rt.Close()
+
+	ds := rt.GetSingleDataStore()
+	_, err := ds.AddRaw("doc1", 0, []byte(`{"type":"doc1"}`))
+	require.NoError(t, err)
+
+	// make sure we actually started offline (try to put a doc through the REST API)
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc2", `{"type":"doc2"}`)
+	RequireStatus(t, resp, http.StatusServiceUnavailable)
+
+	// put doc2 bypassing offline checks (this step will begin to fail with Elixir - since we're making offline more comprehensive)
+	_, _, err = rt.GetSingleTestDatabaseCollectionWithUser().Put(base.TestCtx(t), "doc2", db.Body{"type": "doc2"})
+	require.NoError(t, err)
+
+	// wait long enough to be confident that import isn't running...
+	time.Sleep(time.Second * 5)
+
+	// ensure doc1 is not imported - since we started the database offline
+	assert.Equal(t, int64(0), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
+
+	rt.ServerContext().TakeDbOnline(base.NewNonCancelCtx(), rt.GetDatabase())
+
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc3", `{"type":"doc3"}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	// ensure doc1 is imported now we're online
+	_, err = rt.WaitForChanges(3, "/{{.keyspace}}/_changes", "", true)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
+}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -946,7 +946,8 @@ func (rt *RestTester) WaitForDatabaseState(dbName string, targetState uint32) er
 		resp := rt.SendAdminRequest("GET", "/"+dbName+"/", "")
 		RequireStatus(rt.TB, resp, 200)
 		require.NoError(rt.TB, base.JSONUnmarshal(resp.Body.Bytes(), &dbRootResponse))
-		if dbRootResponse.State == db.RunStateString[targetState] {
+		stateCurr = dbRootResponse.State
+		if stateCurr == db.RunStateString[targetState] {
 			return nil
 		}
 		time.Sleep(50 * time.Millisecond)


### PR DESCRIPTION
CBG-2909

Moves the following processes into a `StartOnlineProcesses` method that is run only when a database is brought online (either at startup, or through a REST API request)
- `changeCache` (Init and Start)
- `Heartbeater` (Import and ISGR sharding)
- `ImportListener`
- `OIDCProviders`
- `Compact` background process
- `TombstoneCompactionManager`
- `AttachmentCompactionManager`
- ISGR replications

An offline database still has these processes (`NewDatabaseContext`):
- Stats (an offline database can report stats)
- `EventManager` (it has to send offline/online events)
- `ResyncManager` (Resync requires the database be offline)
- `sequenceAllocator` (resync with regenerate sequences)
- `activeChannels` ???
- `channelCache` ???
- `NewCfgSG` ???
- `mutationListener` ???
- `SGReplicateMgr` ???

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1865/
