### PR TITLE
[3.0.8 Backport] CBG-2944 Ensure proveAttachments works for v2 attachments with a v2 replication protocol

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -236,6 +236,7 @@ type CBLReplicationPullStats struct {
 	RequestChangesTime          *SgwIntStat `json:"request_changes_time"`
 	RevProcessingTime           *SgwIntStat `json:"rev_processing_time"`
 	RevSendCount                *SgwIntStat `json:"rev_send_count"`
+	RevErrorCount               *SgwIntStat `json:"rev_error_count"`
 	RevSendLatency              *SgwIntStat `json:"rev_send_latency"`
 }
 
@@ -243,6 +244,7 @@ type CBLReplicationPushStats struct {
 	AttachmentPushBytes *SgwIntStat `json:"attachment_push_bytes"`
 	AttachmentPushCount *SgwIntStat `json:"attachment_push_count"`
 	DocPushCount        *SgwIntStat `json:"doc_push_count"`
+	DocPushErrorCount   *SgwIntStat `json:"doc_push_error_count"`
 	ProposeChangeCount  *SgwIntStat `json:"propose_change_count"`
 	ProposeChangeTime   *SgwIntStat `json:"propose_change_time"`
 	WriteProcessingTime *SgwIntStat `json:"write_processing_time"`
@@ -763,6 +765,7 @@ func (d *DbStats) initCBLReplicationPullStats() {
 		RequestChangesTime:          NewIntStat(SubsystemReplicationPull, "request_changes_time", labelKeys, labelVals, prometheus.CounterValue, 0),
 		RevProcessingTime:           NewIntStat(SubsystemReplicationPull, "rev_processing_time", labelKeys, labelVals, prometheus.GaugeValue, 0),
 		RevSendCount:                NewIntStat(SubsystemReplicationPull, "rev_send_count", labelKeys, labelVals, prometheus.CounterValue, 0),
+		RevErrorCount:               NewIntStat(SubsystemReplicationPull, "rev_error_count", labelKeys, labelVals, prometheus.CounterValue, 0),
 		RevSendLatency:              NewIntStat(SubsystemReplicationPull, "rev_send_latency", labelKeys, labelVals, prometheus.CounterValue, 0),
 	}
 }
@@ -783,6 +786,7 @@ func (d *DbStats) unregisterCBLReplicationPullStats() {
 	prometheus.Unregister(d.CBLReplicationPullStats.RequestChangesTime)
 	prometheus.Unregister(d.CBLReplicationPullStats.RevProcessingTime)
 	prometheus.Unregister(d.CBLReplicationPullStats.RevSendCount)
+	prometheus.Unregister(d.CBLReplicationPullStats.RevErrorCount)
 	prometheus.Unregister(d.CBLReplicationPullStats.RevSendLatency)
 }
 
@@ -797,6 +801,7 @@ func (d *DbStats) initCBLReplicationPushStats() {
 		AttachmentPushBytes: NewIntStat(SubsystemReplicationPush, "attachment_push_bytes", labelKeys, labelVals, prometheus.CounterValue, 0),
 		AttachmentPushCount: NewIntStat(SubsystemReplicationPush, "attachment_push_count", labelKeys, labelVals, prometheus.CounterValue, 0),
 		DocPushCount:        NewIntStat(SubsystemReplicationPush, "doc_push_count", labelKeys, labelVals, prometheus.GaugeValue, 0),
+		DocPushErrorCount:   NewIntStat(SubsystemReplicationPush, "doc_push_error_count", labelKeys, labelVals, prometheus.GaugeValue, 0),
 		ProposeChangeCount:  NewIntStat(SubsystemReplicationPush, "propose_change_count", labelKeys, labelVals, prometheus.CounterValue, 0),
 		ProposeChangeTime:   NewIntStat(SubsystemReplicationPush, "propose_change_time", labelKeys, labelVals, prometheus.CounterValue, 0),
 		WriteProcessingTime: NewIntStat(SubsystemReplicationPush, "write_processing_time", labelKeys, labelVals, prometheus.GaugeValue, 0),
@@ -807,6 +812,7 @@ func (d *DbStats) unregisterCBLReplicationPushStats() {
 	prometheus.Unregister(d.CBLReplicationPushStats.AttachmentPushBytes)
 	prometheus.Unregister(d.CBLReplicationPushStats.AttachmentPushCount)
 	prometheus.Unregister(d.CBLReplicationPushStats.DocPushCount)
+	prometheus.Unregister(d.CBLReplicationPushStats.DocPushErrorCount)
 	prometheus.Unregister(d.CBLReplicationPushStats.ProposeChangeCount)
 	prometheus.Unregister(d.CBLReplicationPushStats.ProposeChangeTime)
 	prometheus.Unregister(d.CBLReplicationPushStats.WriteProcessingTime)

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1070,7 +1070,9 @@ func (bh *blipHandler) handleProveAttachment(rq *blip.Message) error {
 		return base.HTTPErrorf(http.StatusBadRequest, "no digest sent with proveAttachment")
 	}
 
-	attData, err := bh.db.GetAttachment(base.AttPrefix + digest)
+	allowedAttachment := bh.allowedAttachment(digest)
+	attachmentKey := MakeAttachmentKey(allowedAttachment.version, allowedAttachment.docID, digest)
+	attData, err := bh.db.GetAttachment(attachmentKey)
 	if err != nil {
 		if bh.clientType == BLIPClientTypeSGR2 {
 			return ErrAttachmentNotFound

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -113,11 +113,13 @@ func BlipSyncStatsForCBL(dbStats *base.DbStats) *BlipSyncStats {
 
 	blipStats.SendRevBytes = dbStats.Database().DocReadsBytesBlip
 	blipStats.SendRevCount = dbStats.Database().NumDocReadsBlip
+	blipStats.SendRevErrorTotal = dbStats.CBLReplicationPull().RevErrorCount
 
 	blipStats.HandleRevBytes = dbStats.Database().DocWritesBytesBlip
 	blipStats.HandleRevProcessingTime = dbStats.CBLReplicationPush().WriteProcessingTime
 
 	blipStats.HandleRevCount = dbStats.CBLReplicationPush().DocPushCount
+	blipStats.HandleRevErrorCount = dbStats.CBLReplicationPush().DocPushErrorCount
 
 	blipStats.HandleGetAttachment = dbStats.CBLReplicationPull().AttachmentPullCount
 	blipStats.HandleGetAttachmentBytes = dbStats.CBLReplicationPull().AttachmentPullBytes

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2022-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package rest
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBlipProveAttachmentV2 ensures that CBL's proveAttachment for deduplication is working correctly even for v2 attachments which aren't de-duped on the server side.
+func TestBlipProveAttachmentV2(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	rtConfig := RestTesterConfig{
+		guestEnabled: true,
+	}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+
+	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+		SupportedBLIPProtocols: []string{db.BlipCBMobileReplicationV2},
+	})
+	require.NoError(t, err)
+	defer btc.Close()
+
+	err = btc.StartPull()
+	assert.NoError(t, err)
+
+	const (
+		doc1ID = "doc1"
+		doc2ID = "doc2"
+	)
+
+	const (
+		attachmentName = "hello.txt"
+		attachmentData = "hello world"
+	)
+
+	var (
+		attachmentDataB64 = base64.StdEncoding.EncodeToString([]byte(attachmentData))
+		attachmentDigest  = "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="
+	)
+
+	// Create two docs with the same attachment data on SG - v2 attachments intentionally result in two copies,
+	// CBL will still de-dupe attachments based on digest, so will still try proveAttachmnet for the 2nd.
+	doc1Body := fmt.Sprintf(`{"greetings":[{"hi": "alice"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
+	response := rt.SendAdminRequest(http.MethodPut, "/db/"+doc1ID, doc1Body)
+	RequireStatus(t, response, http.StatusCreated)
+	doc1RevID := RespRevID(t, response)
+
+	data, ok := btc.WaitForRev(doc1ID, doc1RevID)
+	require.True(t, ok)
+	bodyTextExpected := fmt.Sprintf(`{"greetings":[{"hi":"alice"}],"_attachments":{"%s":{"revpos":1,"length":%d,"stub":true,"digest":"%s"}}}`, attachmentName, len(attachmentData), attachmentDigest)
+	require.JSONEq(t, bodyTextExpected, string(data))
+
+	// create doc2 now that we know the client has the attachment
+	doc2Body := fmt.Sprintf(`{"greetings":[{"howdy": "bob"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
+	response = rt.SendAdminRequest(http.MethodPut, "/db/"+doc2ID, doc2Body)
+	RequireStatus(t, response, http.StatusCreated)
+	doc2RevID := RespRevID(t, response)
+
+	data, ok = btc.WaitForRev(doc2ID, doc2RevID)
+	require.True(t, ok)
+	bodyTextExpected = fmt.Sprintf(`{"greetings":[{"howdy":"bob"}],"_attachments":{"%s":{"revpos":1,"length":%d,"stub":true,"digest":"%s"}}}`, attachmentName, len(attachmentData), attachmentDigest)
+	require.JSONEq(t, bodyTextExpected, string(data))
+
+	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPull().RevSendCount.Value())
+	assert.Equal(t, int64(0), rt.GetDatabase().DbStats.CBLReplicationPull().RevErrorCount.Value())
+	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.CBLReplicationPull().AttachmentPullCount.Value())
+	assert.Equal(t, int64(len(attachmentData)), rt.GetDatabase().DbStats.CBLReplicationPull().AttachmentPullBytes.Value())
+}
+
+// TestBlipProveAttachmentV2Push ensures that CBL's attachment deduplication is ignored for push replications - resulting in new server-side digests and duplicated attachment data (v2 attachment format).
+func TestBlipProveAttachmentV2Push(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	rtConfig := RestTesterConfig{
+		guestEnabled: true,
+	}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+
+	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+		SupportedBLIPProtocols: []string{db.BlipCBMobileReplicationV2},
+	})
+	require.NoError(t, err)
+	defer btc.Close()
+
+	const (
+		doc1ID = "doc1"
+		doc2ID = "doc2"
+	)
+
+	const (
+		attachmentName = "hello.txt"
+		attachmentData = "hello world"
+	)
+
+	var (
+		attachmentDataB64 = base64.StdEncoding.EncodeToString([]byte(attachmentData))
+		// attachmentDigest  = "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="
+	)
+
+	// Create two docs with the same attachment data on the client - v2 attachments intentionally result in two copies stored on the server, despite the client being able to share the data for both.
+	doc1Body := fmt.Sprintf(`{"greetings":[{"hi": "alice"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
+	doc1revID, err := btc.PushRev(doc1ID, "", []byte(doc1Body))
+	require.NoError(t, err)
+
+	err = rt.WaitForRev(doc1ID, doc1revID)
+	require.NoError(t, err)
+
+	// create doc2 now that we know the server has the attachment - SG should still request the attachment data from the client.
+	doc2Body := fmt.Sprintf(`{"greetings":[{"howdy": "bob"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
+	doc2RevID, err := btc.PushRev(doc2ID, "", []byte(doc2Body))
+	require.NoError(t, err)
+
+	err = rt.WaitForRev(doc2ID, doc2RevID)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPush().DocPushCount.Value())
+	assert.Equal(t, int64(0), rt.GetDatabase().DbStats.CBLReplicationPush().DocPushErrorCount.Value())
+	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value())
+	assert.Equal(t, int64(2*len(attachmentData)), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushBytes.Value())
+}

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -12,6 +12,7 @@ package rest
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -291,6 +292,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 				}
 
 				var missingDigests []string
+				var knownDigests []string
 				btc.attachmentsLock.RLock()
 				for _, attachment := range attsMap {
 					attMap, ok := attachment.(map[string]interface{})
@@ -301,9 +303,59 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 
 					if _, found := btc.attachments[digest]; !found {
 						missingDigests = append(missingDigests, digest)
+					} else {
+						if btr.bt.blipContext.ActiveSubprotocol() == db.BlipCBMobileReplicationV2 {
+							// only v2 clients care about proveAttachments
+							knownDigests = append(knownDigests, digest)
+						}
 					}
 				}
 				btc.attachmentsLock.RUnlock()
+
+				for _, digest := range knownDigests {
+					attData, err := btc.getAttachment(digest)
+					if err != nil {
+						panic(err)
+					}
+					nonce, proof := db.GenerateProofOfAttachment(attData)
+
+					// if we already have this attachment, _we_ should ask the peer whether _they_ have the attachment
+					outrq := blip.NewRequest()
+					outrq.SetProfile(db.MessageProveAttachment)
+					outrq.Properties[db.ProveAttachmentDigest] = digest
+					outrq.SetBody(nonce)
+
+					err = btc.pullReplication.sendMsg(outrq)
+					if err != nil {
+						panic(err)
+					}
+
+					resp := outrq.Response()
+					btc.pullReplication.storeMessage(resp)
+					respBody, err := resp.Body()
+					if err != nil {
+						panic(err)
+					}
+
+					if resp.Type() == blip.ErrorType {
+						// forward error from proveAttachment response into rev response
+						if !msg.NoReply() {
+							response := msg.Response()
+							errorCode, _ := strconv.Atoi(resp.Properties["Error-Code"])
+							response.SetError(resp.Properties["Error-Code"], errorCode, string(respBody))
+						}
+						return
+					}
+
+					if string(respBody) != proof {
+						// forward error from proveAttachment response into rev response
+						if !msg.NoReply() {
+							response := msg.Response()
+							response.SetError(resp.Properties["Error-Code"], http.StatusForbidden, fmt.Sprintf("Incorrect proof for attachment %s", digest))
+						}
+						return
+					}
+				}
 
 				for _, digest := range missingDigests {
 					outrq := blip.NewRequest()
@@ -409,10 +461,11 @@ func (btc *BlipTesterClient) saveAttachment(contentType, base64data string) (dat
 
 	digest = db.Sha1DigestKey(data)
 	if _, found := btc.attachments[digest]; found {
-		return 0, "", fmt.Errorf("attachment with digest already exists")
+		base.InfofCtx(context.TODO(), base.KeySync, "attachment with digest %s already exists", digest)
+	} else {
+		btc.attachments[digest] = data
 	}
 
-	btc.attachments[digest] = data
 	return len(data), digest, nil
 }
 


### PR DESCRIPTION
CBG-2968, backports CBG-2944

- Ensures that v2 attachments are found for proveAttachments by getting doc ID
- Not handling case for v3 replication protocol as proveAttachments isn't used (attachments are document scoped)
- Adds BlipTesterClient enhancements to run proveAttachments under v2 replication for known attachments


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-go1.16.15/52/
