### PR TITLE
CBG-3023 backport of cbgt cluster connection fails with HTTP polling enabled and TLS disabled

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -16,7 +16,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -322,8 +321,9 @@ func initCBGTManager(ctx context.Context, bucket Bucket, spec BucketSpec, cfgSG 
 	options := make(map[string]string)
 	options[cbgt.FeedAllotmentOption] = cbgt.FeedAllotmentOnePerPIndex
 	options["managerLoadDataDir"] = "false"
-	// Ensure we always use TLS if configured - cbgt defaults to non-TLS on initial connection
-	options["feedInitialBootstrapNonTLS"] = strconv.FormatBool(!spec.IsTLS())
+	// TLS is controlled by the connection string.
+	// cbgt uses this parameter to run in mixed mode - non-TLS for CCCP but TLS for memcached. Sync Gateway does not need to set this parameter.
+	options["feedInitialBootstrapNonTLS"] = "false"
 
 	// Disable collections if unsupported
 	if !bucket.IsSupported(sgbucket.BucketStoreFeatureCollections) {


### PR DESCRIPTION
Cherry-pick backport of https://github.com/couchbase/sync_gateway/commit/1f98662c351d4817ae73b6551b21bc816cb4c0a9)

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1816/
