### PR TITLE
CBG-3019 CBG-3038 CBG-3040 3.1.1 cbgt backports

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -740,48 +740,38 @@ func (meh *sgMgrEventHandlers) OnUnregisterPIndex(pindex *cbgt.PIndex) {
 	// No-op for SG
 }
 
-// OnFeedError is required to trigger reconnection to a feed on an closed connection (EOF).
-// Handling below based on cbft implementation - checks whether the underlying source (bucket)
-// still exists with VerifySourceNotExists, and if it exists, calls NotifyMgrOnClose.
-// This will trigger cbgt closing and then attempting to reconnect to the feed.
+// OnFeedError is required to trigger reconnection to a feed on a closed connection (EOF).
+// NotifyMgrOnClose will trigger cbgt closing and then attempt to reconnect to the feed, if the manager hasn't
+// been stopped.
 func (meh *sgMgrEventHandlers) OnFeedError(srcType string, r cbgt.Feed, feedErr error) {
 
 	// cbgt always passes srcType = SOURCE_GOCBCORE, but we have a wrapped type associated with our indexes - use that instead
 	// for our logging
 	srcType = SOURCE_DCP_SG
-
-	DebugfCtx(meh.ctx, KeyDCP, "cbgt Mgr OnFeedError, srcType: %s, feed name: %s, err: %v",
-		srcType, r.Name(), feedErr)
-
+	var bucketName, bucketUUID string
 	dcpFeed, ok := r.(cbgt.FeedEx)
-	if !ok {
-		return
+	if ok {
+		bucketName, bucketUUID = dcpFeed.GetBucketDetails()
 	}
+	DebugfCtx(meh.ctx, KeyDCP, "cbgt Mgr OnFeedError, srcType: %s, feed name: %s, bucket name: %s, err: %v",
+		srcType, r.Name(), MD(bucketName), feedErr)
 
-	gone, indexUUID, err := dcpFeed.VerifySourceNotExists()
-	DebugfCtx(meh.ctx, KeyDCP, "cbgt Mgr OnFeedError, VerifySourceNotExists,"+
-		" srcType: %s, gone: %t, indexUUID: %s, err: %v",
-		srcType, gone, indexUUID, err)
-	if !gone {
-		// If we get an EOF error from the feeds and the bucket is still alive,
-		// then there could at the least two potential error scenarios.
-		//
-		// 1. Faulty kv node is failed over.
-		// 2. Ephemeral network connection issues with the host.
-		//
-		// In either case, the current feed instance turns dangling.
-		// Hence we can close the feeds so that they get refreshed to fix
-		// the connectivity problems either during the next rebalance
-		// (new kv node after failover-recovery rebalance) or
-		// on the next janitor work cycle(ephemeral network issue to the same node).
-		if strings.Contains(feedErr.Error(), "EOF") {
-			// If this wasn't an intentional close, log about the EOF
-			if meh.ctx.Err() != context.Canceled {
-				InfofCtx(meh.ctx, KeyDCP, "Handling EOF on cbgt feed - notifying manager to trigger reconnection to feed.  indexUUID: %v, err: %v", indexUUID, feedErr)
-			}
-			dcpFeed.NotifyMgrOnClose()
+	// If we get an EOF error from the feeds and the import listener hasn't been closed,
+	// then there could at the least two potential error scenarios.
+	//
+	// 1. Faulty kv node is failed over.
+	// 2. Ephemeral network connection issues with the host.
+	//
+	// In either case, the current feed instance turns dangling.
+	// Hence we can close the feeds so that they get refreshed to fix
+	// the connectivity problems either during the next rebalance
+	// (new kv node after failover-recovery rebalance) or
+	// on the next janitor work cycle(ephemeral network issue to the same node).
+	if strings.Contains(feedErr.Error(), "EOF") {
+		// If this wasn't an intentional close, log about the EOF
+		if meh.ctx.Err() != context.Canceled {
+			InfofCtx(meh.ctx, KeyDCP, "Handling EOF on cbgt feed - notifying manager to trigger reconnection to feed for bucketName:%v, bucketUUID:%v, err: %v", MD(bucketName), bucketUUID, feedErr)
 		}
-		return
+		dcpFeed.NotifyMgrOnClose()
 	}
-
 }

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -214,19 +214,7 @@ func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
 func (il *importListener) Stop() {
 	if il != nil {
 		if il.cbgtContext != nil {
-			il.cbgtContext.StopHeartbeatListener()
-
-			// Close open PIndexes before stopping the manager.
-			_, pindexes := il.cbgtContext.Manager.CurrentMaps()
-			for _, pIndex := range pindexes {
-				err := il.cbgtContext.Manager.ClosePIndex(pIndex)
-				if err != nil {
-					base.DebugfCtx(il.loggingCtx, base.KeyImport, "Error closing pindex: %v", err)
-				}
-			}
-			// ClosePIndex calls are synchronous, so can stop manager once they've completed
-			il.cbgtContext.Manager.Stop()
-			il.cbgtContext.RemoveFeedCredentials(il.dbName)
+			il.cbgtContext.Stop()
 
 			// Remove entry from global listener directory
 			base.RemoveDestFactory(il.importDestKey)

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4309,3 +4309,30 @@ func TestPerDBCredsOverride(t *testing.T) {
 	assert.Equal(t, "invalidUsername", configs["db"].BucketConfig.Username)
 	assert.Equal(t, "invalidPassword", configs["db"].BucketConfig.Password)
 }
+
+// Can be used to reproduce connections left open after database close.  Manually deleting the bucket used by the test
+// once the test reaches the sleep loop will log connection errors for unclosed connections.
+func TestDeleteDatabaseCBGTTeardown(t *testing.T) {
+	t.Skip("Dev-time test used to repro agent connections being left open after database close")
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+	base.SetUpTestLogging(t, base.LevelTrace, base.KeyHTTP, base.KeyImport)
+
+	rtConfig := rest.RestTesterConfig{DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{AutoImport: true}}}
+	rt := rest.NewRestTester(t, &rtConfig)
+	defer rt.Close()
+	// Initialize database
+	_ = rt.GetDatabase()
+
+	for i := 0; i < 1; i++ {
+		time.Sleep(1 * time.Second) // some time for polling
+	}
+
+	resp := rt.SendAdminRequest(http.MethodDelete, "/db/", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	for i := 0; i < 1000; i++ {
+		time.Sleep(1 * time.Second) // some time for polling
+	}
+}


### PR DESCRIPTION
Clean cherry-picks of

- CBG-2938 Ignore Cbgt EOF feed errors when intentionally stopped #6235 (Cherry-pick ticket CBG-3040)
- CBG-2983 Close cbgt agents on database close #6265 (Cherry-pick ticket CBG-3038)
- CBG-3001 Avoid bucket retrieval error during OnFeedClose #6269 (Cherry-pick ticket CBG-3019)


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1822/
