### PR TITLE
CBG-3030: [3.1.1] Fix panic for assigning to nil map inside Mutable1xBody

### DIFF
--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -162,6 +162,9 @@ func (rev *DocumentRevision) Mutable1xBody(db *DatabaseCollectionWithUser, reque
 	if err != nil {
 		return nil, err
 	}
+	if b == nil {
+		return nil, base.RedactErrorf("null doc body for docID: %s revID: %s", base.UD(rev.DocID), base.UD(rev.RevID))
+	}
 
 	b[BodyId] = rev.DocID
 	b[BodyRev] = rev.RevID

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2629,6 +2629,19 @@ func TestDocChannelSetPruning(t *testing.T) {
 	assert.Equal(t, uint64(12), syncData.ChannelSetHistory[0].End)
 }
 
+func TestNullDocHandlingForMutable1xBody(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollectionWithUser()
+
+	documentRev := db.DocumentRevision{DocID: "doc1", BodyBytes: []byte("null")}
+
+	body, err := documentRev.Mutable1xBody(collection, nil, nil, false)
+	require.Error(t, err)
+	require.Nil(t, body)
+	assert.Contains(t, err.Error(), "null doc body for doc")
+}
+
 func TestTombstoneCompactionAPI(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	rt.GetDatabase().PurgeInterval = 0


### PR DESCRIPTION
CBG-3030

Backport of the fix for incorrect handling casuing a panic for null docs inside Mutable1xBody. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1827/
