### PR TITLE
CBG-2864 (3.1.1 backport) of ability to override CORS config on a per DB basis

### DIFF
--- a/auth/cors.go
+++ b/auth/cors.go
@@ -1,0 +1,49 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package auth
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Configuration for Cross-Origin Resource Sharing
+// <https://en.wikipedia.org/wiki/Cross-origin_resource_sharing>
+type CORSConfig struct {
+	Origin      []string `json:"origin,omitempty"       help:"List of allowed origins, use ['*'] to allow access from everywhere"`
+	LoginOrigin []string `json:"login_origin,omitempty" help:"List of allowed login origins"`
+	Headers     []string `json:"headers,omitempty"      help:"List of allowed headers"`
+	MaxAge      int      `json:"max_age,omitempty"      help:"Maximum age of the CORS Options request"`
+}
+
+// Adds Access-Control-Allow-Origin, Access-Control-Allow-Credentials, Access-Control-Allow-Headers headers to an HTTP response.
+func (cors *CORSConfig) AddResponseHeaders(request *http.Request, response http.ResponseWriter) {
+	if originHeader := request.Header["Origin"]; len(originHeader) > 0 {
+		origin := MatchedOrigin(cors.Origin, originHeader)
+		response.Header().Add("Access-Control-Allow-Origin", origin)
+		response.Header().Add("Access-Control-Allow-Credentials", "true")
+		response.Header().Add("Access-Control-Allow-Headers", strings.Join(cors.Headers, ", "))
+	}
+}
+
+func MatchedOrigin(allowOrigins []string, rqOrigins []string) string {
+	for _, rv := range rqOrigins {
+		for _, av := range allowOrigins {
+			if rv == av {
+				return av
+			}
+		}
+	}
+	for _, av := range allowOrigins {
+		if av == "*" {
+			return "*"
+		}
+	}
+	return ""
+}

--- a/db/database.go
+++ b/db/database.go
@@ -130,6 +130,7 @@ type DatabaseContext struct {
 	CollectionNames              map[string]map[string]struct{} // Map of scope, collection names
 	MetadataKeys                 *base.MetadataKeys             // Factory to generate metadata document keys
 	RequireResync                base.ScopeAndCollectionNames   // Collections requiring resync before database can go online
+	CORS                         *auth.CORSConfig               // CORS configuration
 }
 
 type Scope struct {

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1762,6 +1762,25 @@ Database:
         Defaults to true when running in serverless mode otherwise defaults to false.
       type: boolean
       default: false
+    cors:
+      description: CORS configuration for this database; if present, overrides server's config.
+      type: object
+      properties:
+        origin:
+          description: 'List of allowed origins, use [''*''] to allow access from everywhere'
+          type: array
+          items:
+            type: string
+        login_origin:
+          description: List of allowed login origins
+          type: array
+          items:
+            type: string
+        headers:
+          description: List of allowed headers
+          type: array
+          items:
+            type: string
   title: Database-config
 Event-config:
   type: object

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -54,7 +54,6 @@ func (h *handler) handleCreateDB() error {
 	}
 
 	config.Name = dbName
-
 	if h.server.persistentConfig {
 		if err := config.validatePersistentDbConfig(); err != nil {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -229,45 +229,65 @@ func TestFunkyDocIDs(t *testing.T) {
 func TestCORSOrigin(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
+	tests := []struct {
+		origin       string
+		headerOutput string
+	}{
+		{
+			origin:       "http://example.com",
+			headerOutput: "http://example.com",
+		},
+		{
+			origin:       "http://staging.example.com",
+			headerOutput: "http://staging.example.com",
+		},
 
-	reqHeaders := map[string]string{
-		"Origin": "http://example.com",
+		{
+			origin:       "http://hack0r.com",
+			headerOutput: "*",
+		},
 	}
-	response := rt.SendRequestWithHeaders("GET", "/{{.keyspace}}/", "", reqHeaders)
-	assert.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
 
-	// now test a non-listed origin
-	// b/c * is in config we get *
-	reqHeaders = map[string]string{
-		"Origin": "http://hack0r.com",
-	}
-	response = rt.SendRequestWithHeaders("GET", "/{{.keyspace}}/", "", reqHeaders)
-	assert.Equal(t, "*", response.Header().Get("Access-Control-Allow-Origin"))
+	for _, tc := range tests {
+		t.Run(tc.origin, func(t *testing.T) {
 
-	// now test another origin in config
-	reqHeaders = map[string]string{
-		"Origin": "http://staging.example.com",
-	}
-	response = rt.SendRequestWithHeaders("GET", "/{{.keyspace}}/", "", reqHeaders)
-	assert.Equal(t, "http://staging.example.com", response.Header().Get("Access-Control-Allow-Origin"))
+			invalidDatabaseName := "invalid database name"
+			reqHeaders := map[string]string{
+				"Origin": tc.origin,
+			}
+			response := rt.SendRequestWithHeaders("GET", "/{{.keyspace}}/", "", reqHeaders)
+			assert.Equal(t, tc.headerOutput, response.Header().Get("Access-Control-Allow-Origin"))
+			RequireStatus(t, response, http.StatusBadRequest)
+			require.Contains(t, response.Body.String(), invalidDatabaseName)
 
-	// test no header on _admin apis
-	reqHeaders = map[string]string{
-		"Origin": "http://example.com",
-	}
-	response = rt.SendAdminRequestWithHeaders("GET", "/{{.keyspace}}/_all_docs", "", reqHeaders)
-	assert.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+			response = rt.SendRequestWithHeaders("GET", "/{{.db}}/", "", reqHeaders)
+			assert.Equal(t, tc.headerOutput, response.Header().Get("Access-Control-Allow-Origin"))
+			RequireStatus(t, response, http.StatusUnauthorized)
+			require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
 
-	// test with a config without * should reject non-matches
-	sc := rt.ServerContext()
-	sc.Config.API.CORS.Origin = []string{"http://example.com", "http://staging.example.com"}
-	// now test a non-listed origin
-	// b/c * is in config we get *
-	reqHeaders = map[string]string{
-		"Origin": "http://hack0r.com",
+			response = rt.SendRequestWithHeaders("GET", "/notadb/", "", reqHeaders)
+			assert.Equal(t, tc.headerOutput, response.Header().Get("Access-Control-Allow-Origin"))
+			RequireStatus(t, response, http.StatusUnauthorized)
+			require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+
+			// admin port doesn't have CORS
+			response = rt.SendAdminRequestWithHeaders("GET", "/{{.keyspace}}/_all_docs", "", reqHeaders)
+			assert.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+			RequireStatus(t, response, http.StatusOK)
+
+			// test with a config without * should reject non-matches
+			sc := rt.ServerContext()
+			defer func() {
+				sc.Config.API.CORS.Origin = defaultTestingCORSOrigin
+			}()
+
+			sc.Config.API.CORS.Origin = []string{"http://example.com", "http://staging.example.com"}
+			if !base.StringSliceContains(sc.Config.API.CORS.Origin, tc.origin) {
+				response = rt.SendRequestWithHeaders("GET", "/{{.keyspace}}/", "", reqHeaders)
+				assert.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+			}
+		})
 	}
-	response = rt.SendRequestWithHeaders("GET", "/{{.keyspace}}/", "", reqHeaders)
-	assert.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
 }
 
 // assertGatewayStatus is like requireStatus but with StatusGatewayTimeout error checking for temporary network failures.

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -255,26 +255,50 @@ func TestCORSOrigin(t *testing.T) {
 			reqHeaders := map[string]string{
 				"Origin": tc.origin,
 			}
-			response := rt.SendRequestWithHeaders("GET", "/{{.keyspace}}/", "", reqHeaders)
-			assert.Equal(t, tc.headerOutput, response.Header().Get("Access-Control-Allow-Origin"))
-			RequireStatus(t, response, http.StatusBadRequest)
-			require.Contains(t, response.Body.String(), invalidDatabaseName)
+			for _, method := range []string{http.MethodGet, http.MethodOptions} {
+				response := rt.SendRequestWithHeaders(method, "/{{.keyspace}}/", "", reqHeaders)
+				assert.Equal(t, tc.headerOutput, response.Header().Get("Access-Control-Allow-Origin"))
+				if method == http.MethodGet {
+					RequireStatus(t, response, http.StatusBadRequest)
+					require.Contains(t, response.Body.String(), invalidDatabaseName)
+				} else {
+					RequireStatus(t, response, http.StatusNoContent)
 
-			response = rt.SendRequestWithHeaders("GET", "/{{.db}}/", "", reqHeaders)
-			assert.Equal(t, tc.headerOutput, response.Header().Get("Access-Control-Allow-Origin"))
-			RequireStatus(t, response, http.StatusUnauthorized)
-			require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+				}
+			}
+			for _, method := range []string{http.MethodGet, http.MethodOptions} {
+				response := rt.SendRequestWithHeaders(method, "/{{.db}}/", "", reqHeaders)
+				assert.Equal(t, tc.headerOutput, response.Header().Get("Access-Control-Allow-Origin"))
+				if method == http.MethodGet {
+					RequireStatus(t, response, http.StatusUnauthorized)
+					require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+				} else {
+					RequireStatus(t, response, http.StatusNoContent)
 
-			response = rt.SendRequestWithHeaders("GET", "/notadb/", "", reqHeaders)
-			assert.Equal(t, tc.headerOutput, response.Header().Get("Access-Control-Allow-Origin"))
-			RequireStatus(t, response, http.StatusUnauthorized)
-			require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+				}
+			}
+			for _, method := range []string{http.MethodGet, http.MethodOptions} {
+				response := rt.SendRequestWithHeaders(method, "/notadb/", "", reqHeaders)
+				assert.Equal(t, tc.headerOutput, response.Header().Get("Access-Control-Allow-Origin"))
+				if method == http.MethodGet {
+					RequireStatus(t, response, http.StatusUnauthorized)
+					require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+				} else {
+					RequireStatus(t, response, http.StatusNoContent)
 
-			// admin port doesn't have CORS
-			response = rt.SendAdminRequestWithHeaders("GET", "/{{.keyspace}}/_all_docs", "", reqHeaders)
-			assert.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
-			RequireStatus(t, response, http.StatusOK)
+				}
+			}
 
+			for _, method := range []string{http.MethodGet, http.MethodOptions} {
+				// admin port doesn't have CORS
+				response := rt.SendAdminRequestWithHeaders(method, "/{{.keyspace}}/_all_docs", "", reqHeaders)
+				assert.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+				if method == http.MethodGet {
+					RequireStatus(t, response, http.StatusOK)
+				} else {
+					RequireStatus(t, response, http.StatusNoContent)
+				}
+			}
 			// test with a config without * should reject non-matches
 			sc := rt.ServerContext()
 			defer func() {
@@ -283,8 +307,10 @@ func TestCORSOrigin(t *testing.T) {
 
 			sc.Config.API.CORS.Origin = []string{"http://example.com", "http://staging.example.com"}
 			if !base.StringSliceContains(sc.Config.API.CORS.Origin, tc.origin) {
-				response = rt.SendRequestWithHeaders("GET", "/{{.keyspace}}/", "", reqHeaders)
-				assert.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+				for _, method := range []string{http.MethodGet, http.MethodOptions} {
+					response := rt.SendRequestWithHeaders(method, "/{{.keyspace}}/", "", reqHeaders)
+					assert.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+				}
 			}
 		})
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -165,6 +165,7 @@ type DbConfig struct {
 	GraphQL                          *functions.GraphQLConfig         `json:"graphql,omitempty"`                              // GraphQL configuration & resolver fns
 	UserFunctions                    *functions.FunctionsConfig       `json:"functions,omitempty"`                            // Named JS fns for clients to call
 	Suspendable                      *bool                            `json:"suspendable,omitempty"`                          // Allow the database to be suspended
+	CORS                             *auth.CORSConfig                 `json:"cors,omitempty"`
 }
 
 type ScopesConfig map[string]ScopeConfig
@@ -680,6 +681,10 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 		}
 	}
 
+	if dbConfig.CORS != nil && dbConfig.CORS.MaxAge != 0 {
+		multiError = multiError.Append(fmt.Errorf("cors.max_age can not be set on a database level"))
+
+	}
 	if dbConfig.DeprecatedPool != nil {
 		base.WarnfCtx(ctx, `"pool" config option is not supported. The pool will be set to "default". The option should be removed from config file.`)
 	}

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -230,7 +230,7 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 	}
 
 	if lc.CORS != nil {
-		sc.API.CORS = &CORSConfig{
+		sc.API.CORS = &auth.CORSConfig{
 			Origin:      lc.CORS.Origin,
 			LoginOrigin: lc.CORS.LoginOrigin,
 			Headers:     lc.CORS.Headers,

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -121,21 +121,14 @@ type APIConfig struct {
 	CompressResponses  *bool `json:"compress_responses,omitempty"   help:"If false, disables compression of HTTP responses"`
 	HideProductVersion *bool `json:"hide_product_version,omitempty" help:"Whether product versions removed from Server headers and REST API responses"`
 
-	HTTPS HTTPSConfig `json:"https,omitempty"`
-	CORS  *CORSConfig `json:"cors,omitempty"`
+	HTTPS HTTPSConfig      `json:"https,omitempty"`
+	CORS  *auth.CORSConfig `json:"cors,omitempty"`
 }
 
 type HTTPSConfig struct {
 	TLSMinimumVersion string `json:"tls_minimum_version,omitempty" help:"The minimum allowable TLS version for the REST APIs"`
 	TLSCertPath       string `json:"tls_cert_path,omitempty"       help:"The TLS cert file to use for the REST APIs"`
 	TLSKeyPath        string `json:"tls_key_path,omitempty"        help:"The TLS key file to use for the REST APIs"`
-}
-
-type CORSConfig struct {
-	Origin      []string `json:"origin,omitempty"       help:"List of allowed origins, use ['*'] to allow access from everywhere"`
-	LoginOrigin []string `json:"login_origin,omitempty" help:"List of allowed login origins"`
-	Headers     []string `json:"headers,omitempty"      help:"List of allowed headers"`
-	MaxAge      int      `json:"max_age,omitempty"      help:"Maximum age of the CORS Options request"`
 }
 
 type AuthConfig struct {
@@ -220,7 +213,7 @@ func LoadStartupConfigFromPath(path string) (*StartupConfig, error) {
 func NewEmptyStartupConfig() StartupConfig {
 	return StartupConfig{
 		API: APIConfig{
-			CORS: &CORSConfig{},
+			CORS: &auth.CORSConfig{},
 		},
 		Logging: base.LoggingConfig{
 			Console: &base.ConsoleLoggerConfig{},

--- a/rest/config_startup_test.go
+++ b/rest/config_startup_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -92,15 +93,15 @@ func TestStartupConfigMerge(t *testing.T) {
 		},
 		{
 			name:     "Keep original *CORSconfig",
-			config:   StartupConfig{API: APIConfig{CORS: &CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
-			override: StartupConfig{API: APIConfig{CORS: &CORSConfig{}}},
-			expected: StartupConfig{API: APIConfig{CORS: &CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
+			config:   StartupConfig{API: APIConfig{CORS: &auth.CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
+			override: StartupConfig{API: APIConfig{CORS: &auth.CORSConfig{}}},
+			expected: StartupConfig{API: APIConfig{CORS: &auth.CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
 		},
 		{
-			name:     "Keep original *CORSConfig from override nil value",
-			config:   StartupConfig{API: APIConfig{CORS: &CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
+			name:     "Keep original *auth.CORSConfig from override nil value",
+			config:   StartupConfig{API: APIConfig{CORS: &auth.CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
 			override: StartupConfig{},
-			expected: StartupConfig{API: APIConfig{CORS: &CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
+			expected: StartupConfig{API: APIConfig{CORS: &auth.CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
 		},
 		{
 			name:     "Override unset ConfigDuration",

--- a/rest/cors_test.go
+++ b/rest/cors_test.go
@@ -1,0 +1,305 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/auth"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCORSDynamicSet(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	// CORS is set to http://example.com by RestTester ServerContext
+	dbName := "corsdb"
+	dbConfig := rt.NewDbConfig()
+
+	resp := rt.CreateDatabase(dbName, dbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	const username = "alice"
+	rt.CreateUser(username, nil)
+
+	invalidDatabaseName := "invalid database name"
+	reqHeaders := map[string]string{
+		"Origin": "http://example.com",
+	}
+	response := rt.SendRequestWithHeaders("GET", "/{{.keyspace}}/", "", reqHeaders)
+	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+	RequireStatus(t, response, http.StatusBadRequest)
+	require.Contains(t, response.Body.String(), invalidDatabaseName)
+
+	// successful request
+	response = rt.SendUserRequestWithHeaders("GET", "/{{.keyspace}}/_all_docs", "", reqHeaders, username, RestTesterDefaultUserPassword)
+	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+	RequireStatus(t, response, http.StatusOK)
+
+	response = rt.SendRequestWithHeaders("GET", "/{{.db}}/", "", reqHeaders)
+	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+	RequireStatus(t, response, http.StatusUnauthorized)
+	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+
+	response = rt.SendUserRequestWithHeaders("GET", "/{{.db}}/", "", reqHeaders, username, RestTesterDefaultUserPassword)
+	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+	RequireStatus(t, response, http.StatusOK)
+
+	dbConfig = rt.NewDbConfig()
+	dbConfig.CORS = &auth.CORSConfig{
+		Origin: []string{"http://example.org"},
+	}
+
+	resp = rt.ReplaceDbConfig(dbName, dbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	// this falls back to the server config CORS without the user being authenticated
+	response = rt.SendRequestWithHeaders("GET", "/{{.keyspace}}/", "", reqHeaders)
+	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+	RequireStatus(t, response, http.StatusBadRequest)
+	require.Contains(t, response.Body.String(), invalidDatabaseName)
+
+	// successful request - mismatched headers
+	response = rt.SendUserRequestWithHeaders("GET", "/{{.keyspace}}/_all_docs", "", reqHeaders, username, RestTesterDefaultUserPassword)
+	require.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+	RequireStatus(t, response, http.StatusOK)
+
+	response = rt.SendRequestWithHeaders("GET", "/{{.db}}/", "", reqHeaders)
+	RequireStatus(t, response, http.StatusUnauthorized)
+	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+
+	response = rt.SendRequestWithHeaders("GET", "/notadb/", "", reqHeaders)
+	RequireStatus(t, response, http.StatusUnauthorized)
+	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+
+	response = rt.SendUserRequestWithHeaders("GET", "/{{.db}}/", "", reqHeaders, username, RestTesterDefaultUserPassword)
+	require.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+	RequireStatus(t, response, http.StatusOK)
+
+	// successful request - matched headers
+	reqHeaders = map[string]string{
+		"Origin": "http://example.org",
+	}
+	response = rt.SendUserRequestWithHeaders("GET", "/{{.keyspace}}/_all_docs", "", reqHeaders, username, RestTesterDefaultUserPassword)
+	require.Equal(t, "http://example.org", response.Header().Get("Access-Control-Allow-Origin"))
+	RequireStatus(t, response, http.StatusOK)
+
+	response = rt.SendRequestWithHeaders("GET", "/{{.db}}/", "", reqHeaders)
+	require.Equal(t, "*", response.Header().Get("Access-Control-Allow-Origin"))
+	RequireStatus(t, response, http.StatusUnauthorized)
+	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+
+	response = rt.SendRequestWithHeaders("GET", "/notadb/", "", reqHeaders)
+	require.Equal(t, "*", response.Header().Get("Access-Control-Allow-Origin"))
+	RequireStatus(t, response, http.StatusUnauthorized)
+	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+
+	response = rt.SendUserRequestWithHeaders("GET", "/{{.db}}/", "", reqHeaders, username, RestTesterDefaultUserPassword)
+	require.Equal(t, "http://example.org", response.Header().Get("Access-Control-Allow-Origin"))
+	RequireStatus(t, response, http.StatusOK)
+
+}
+
+func TestCORSNoMux(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	reqHeaders := map[string]string{
+		"Origin": "http://example.com",
+	}
+	// this method doesn't exist
+	response := rt.SendRequestWithHeaders("GET", "/_notanendpoint/", "", reqHeaders)
+	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+	RequireStatus(t, response, http.StatusNotFound)
+	require.Contains(t, response.Body.String(), "unknown URL")
+
+	// admin port shouldn't populate CORS
+	response = rt.SendAdminRequestWithHeaders("GET", "/_notanendpoint/", "", reqHeaders)
+	require.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+	RequireStatus(t, response, http.StatusNotFound)
+	require.Contains(t, response.Body.String(), "unknown URL")
+
+	// this method doesn't exist
+	response = rt.SendRequestWithHeaders(http.MethodDelete, "/notadb/", "", reqHeaders)
+	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+	RequireStatus(t, response, http.StatusMethodNotAllowed)
+	require.Equal(t, strconv.Itoa(rt.ServerContext().Config.API.CORS.MaxAge), response.Header().Get("Access-Control-Max-Age"))
+	require.Equal(t, "GET, HEAD, POST, PUT", response.Header().Get("Access-Control-Allow-Methods"))
+
+	response = rt.SendAdminRequestWithHeaders(http.MethodDelete, "/_stats/", "", reqHeaders)
+	RequireStatus(t, response, http.StatusMethodNotAllowed)
+	require.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+	require.Equal(t, "", response.Header().Get("Access-Control-Max-Age"))
+	require.Equal(t, "", response.Header().Get("Access-Control-Allow-Methods"))
+
+}
+
+func TestCORSUserNoAccess(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				CORS: &auth.CORSConfig{
+					Origin: []string{"http://couchbase.com"},
+				},
+			},
+		},
+	})
+	defer rt.Close()
+
+	const alice = "alice"
+	response := rt.SendAdminRequest(http.MethodPut,
+		"/"+rt.GetDatabase().Name+"/_user/"+alice,
+		`{"name": "`+alice+`", "password": "`+RestTesterDefaultUserPassword+`"}`)
+
+	for _, endpoint := range []string{"/{{.db}}/", "/notadb/"} {
+		t.Run(endpoint, func(t *testing.T) {
+			reqHeaders := map[string]string{
+				"Origin": "http://couchbase.com",
+			}
+			response = rt.SendRequestWithHeaders(http.MethodGet, endpoint, "", reqHeaders)
+			RequireStatus(t, response, http.StatusUnauthorized)
+			require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+			assert.Equal(t, "*", response.Header().Get("Access-Control-Allow-Origin"))
+		})
+	}
+}
+
+func TestCORSOriginPerDatabase(t *testing.T) {
+	// Override the default (example.com) CORS configuration in the DbConfig for /db:
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				CORS: &auth.CORSConfig{
+					Origin:      []string{"http://couchbase.com", "http://staging.couchbase.com"},
+					LoginOrigin: []string{"http://couchbase.com"},
+					Headers:     []string{},
+					MaxAge:      1728000,
+				},
+			},
+		},
+		GuestEnabled: true,
+	})
+	defer rt.Close()
+
+	testCases := []struct {
+		name           string
+		endpoint       string
+		origin         string
+		headerResponse string
+		responseCode   int
+	}{
+		{
+			name:           "CORS origin allowed couchbase",
+			endpoint:       "/{{.db}}/",
+			origin:         "http://couchbase.com",
+			headerResponse: "http://couchbase.com",
+			responseCode:   http.StatusOK,
+		},
+		{
+			name:           "CORS origin allowed example.com",
+			endpoint:       "/{{.db}}/",
+			origin:         "http://example.com",
+			headerResponse: "",
+			responseCode:   http.StatusOK,
+		},
+		{
+			name:           "not allowed domain",
+			endpoint:       "/{{.db}}/",
+			origin:         "http://hack0r.com",
+			headerResponse: "",
+			responseCode:   http.StatusOK,
+		},
+		{
+			name:           "root url allow hack0r",
+			endpoint:       "/",
+			origin:         "http://hack0r.com",
+			headerResponse: "*",
+			responseCode:   http.StatusOK,
+		},
+		{
+			name:           "root url allow couchbase",
+			endpoint:       "/",
+			origin:         "http://couchbase.com",
+			headerResponse: "*",
+			responseCode:   http.StatusOK,
+		},
+		{
+			name:           "root url allow example.com",
+			endpoint:       "/",
+			origin:         "http://example.com",
+			headerResponse: "http://example.com",
+			responseCode:   http.StatusOK,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			reqHeaders := map[string]string{
+				"Origin": test.origin,
+			}
+			response := rt.SendRequestWithHeaders(http.MethodGet, test.endpoint, "", reqHeaders)
+			require.Equal(t, test.responseCode, response.Code)
+			require.Equal(t, test.headerResponse, response.Header().Get("Access-Control-Allow-Origin"))
+
+		})
+	}
+}
+
+func TestCORSValidation(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	// CORS is set to http://example.com by RestTester ServerContext
+	dbName := "corsdb"
+	dbConfig := rt.NewDbConfig()
+	dbConfig.CORS = &auth.CORSConfig{
+		MaxAge: 1000,
+	}
+	resp := rt.CreateDatabase(dbName, dbConfig)
+	// walrus doesn't set ServerContext.persistentConfig so we miss some validation
+	if base.UnitTestUrlIsWalrus() {
+		RequireStatus(t, resp, http.StatusCreated)
+	} else {
+		RequireStatus(t, resp, http.StatusBadRequest)
+		require.Contains(t, resp.Body.String(), "max_age")
+		nonCORSDbConfig := rt.NewDbConfig()
+		resp := rt.CreateDatabase(dbName, nonCORSDbConfig)
+		RequireStatus(t, resp, http.StatusCreated)
+	}
+	resp = rt.UpsertDbConfig(dbName, dbConfig)
+	RequireStatus(t, resp, http.StatusBadRequest)
+	require.Contains(t, resp.Body.String(), "max_age")
+
+	resp = rt.ReplaceDbConfig(dbName, dbConfig)
+	RequireStatus(t, resp, http.StatusBadRequest)
+	require.Contains(t, resp.Body.String(), "max_age")
+
+	// make sure you are allowed to set CORS values that aren't max_age
+	originCORSDbConfig := rt.NewDbConfig()
+	originCORSDbConfig.CORS = &auth.CORSConfig{
+		Origin: []string{"http://example.com"},
+	}
+
+	resp = rt.UpsertDbConfig(dbName, originCORSDbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	resp = rt.ReplaceDbConfig(dbName, originCORSDbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
+
+}

--- a/rest/cors_test.go
+++ b/rest/cors_test.go
@@ -39,25 +39,46 @@ func TestCORSDynamicSet(t *testing.T) {
 	reqHeaders := map[string]string{
 		"Origin": "http://example.com",
 	}
-	response := rt.SendRequestWithHeaders("GET", "/{{.keyspace}}/", "", reqHeaders)
-	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
-	RequireStatus(t, response, http.StatusBadRequest)
-	require.Contains(t, response.Body.String(), invalidDatabaseName)
 
+	for _, method := range []string{http.MethodGet, http.MethodOptions} {
+		response := rt.SendRequestWithHeaders(method, "/{{.keyspace}}/", "", reqHeaders)
+		require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+		if method == http.MethodGet {
+			RequireStatus(t, response, http.StatusBadRequest)
+			require.Contains(t, response.Body.String(), invalidDatabaseName)
+		} else {
+			RequireStatus(t, response, http.StatusNoContent)
+		}
+	}
 	// successful request
-	response = rt.SendUserRequestWithHeaders("GET", "/{{.keyspace}}/_all_docs", "", reqHeaders, username, RestTesterDefaultUserPassword)
-	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
-	RequireStatus(t, response, http.StatusOK)
-
-	response = rt.SendRequestWithHeaders("GET", "/{{.db}}/", "", reqHeaders)
-	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
-	RequireStatus(t, response, http.StatusUnauthorized)
-	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
-
-	response = rt.SendUserRequestWithHeaders("GET", "/{{.db}}/", "", reqHeaders, username, RestTesterDefaultUserPassword)
-	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
-	RequireStatus(t, response, http.StatusOK)
-
+	for _, method := range []string{http.MethodGet, http.MethodOptions} {
+		response := rt.SendUserRequestWithHeaders(method, "/{{.keyspace}}/_all_docs", "", reqHeaders, username, RestTesterDefaultUserPassword)
+		require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+		if method == http.MethodGet {
+			RequireStatus(t, response, http.StatusOK)
+		} else {
+			RequireStatus(t, response, http.StatusNoContent)
+		}
+	}
+	for _, method := range []string{http.MethodGet, http.MethodOptions} {
+		response := rt.SendRequestWithHeaders(method, "/{{.db}}/", "", reqHeaders)
+		require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+		if method == http.MethodGet {
+			RequireStatus(t, response, http.StatusUnauthorized)
+			require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+		} else {
+			RequireStatus(t, response, http.StatusNoContent)
+		}
+	}
+	for _, method := range []string{http.MethodGet, http.MethodOptions} {
+		response := rt.SendUserRequestWithHeaders(method, "/{{.db}}/", "", reqHeaders, username, RestTesterDefaultUserPassword)
+		require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+		if method == http.MethodGet {
+			RequireStatus(t, response, http.StatusOK)
+		} else {
+			RequireStatus(t, response, http.StatusNoContent)
+		}
+	}
 	dbConfig = rt.NewDbConfig()
 	dbConfig.CORS = &auth.CORSConfig{
 		Origin: []string{"http://example.org"},
@@ -67,52 +88,109 @@ func TestCORSDynamicSet(t *testing.T) {
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// this falls back to the server config CORS without the user being authenticated
-	response = rt.SendRequestWithHeaders("GET", "/{{.keyspace}}/", "", reqHeaders)
-	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
-	RequireStatus(t, response, http.StatusBadRequest)
-	require.Contains(t, response.Body.String(), invalidDatabaseName)
+	for _, method := range []string{http.MethodGet, http.MethodOptions} {
+		response := rt.SendRequestWithHeaders(method, "/{{.keyspace}}/", "", reqHeaders)
+		if method == http.MethodGet {
+			require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+			RequireStatus(t, response, http.StatusBadRequest)
+			require.Contains(t, response.Body.String(), invalidDatabaseName)
+		} else {
+			// information leak: the options request knows about the database and knows it doesn't match
+			require.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+			RequireStatus(t, response, http.StatusNoContent)
+		}
+	}
 
 	// successful request - mismatched headers
-	response = rt.SendUserRequestWithHeaders("GET", "/{{.keyspace}}/_all_docs", "", reqHeaders, username, RestTesterDefaultUserPassword)
-	require.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
-	RequireStatus(t, response, http.StatusOK)
+	for _, method := range []string{http.MethodGet, http.MethodOptions} {
+		response := rt.SendUserRequestWithHeaders(method, "/{{.keyspace}}/_all_docs", "", reqHeaders, username, RestTesterDefaultUserPassword)
+		require.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+		if method == http.MethodGet {
+			RequireStatus(t, response, http.StatusOK)
+		} else {
+			RequireStatus(t, response, http.StatusNoContent)
+		}
+	}
 
-	response = rt.SendRequestWithHeaders("GET", "/{{.db}}/", "", reqHeaders)
-	RequireStatus(t, response, http.StatusUnauthorized)
-	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
-	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
-
-	response = rt.SendRequestWithHeaders("GET", "/notadb/", "", reqHeaders)
-	RequireStatus(t, response, http.StatusUnauthorized)
-	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
-	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
-
-	response = rt.SendUserRequestWithHeaders("GET", "/{{.db}}/", "", reqHeaders, username, RestTesterDefaultUserPassword)
-	require.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
-	RequireStatus(t, response, http.StatusOK)
+	for _, method := range []string{http.MethodGet, http.MethodOptions} {
+		response := rt.SendRequestWithHeaders(method, "/{{.db}}/", "", reqHeaders)
+		if method == http.MethodGet {
+			RequireStatus(t, response, http.StatusUnauthorized)
+			require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+			require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+		} else {
+			RequireStatus(t, response, http.StatusNoContent)
+			// information leak: the options request knows about the database and knows it doesn't match
+			require.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+		}
+	}
+	for _, method := range []string{http.MethodGet, http.MethodOptions} {
+		response := rt.SendRequestWithHeaders(method, "/notadb/", "", reqHeaders)
+		require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+		if method == http.MethodGet {
+			RequireStatus(t, response, http.StatusUnauthorized)
+			require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+		} else {
+			RequireStatus(t, response, http.StatusNoContent)
+		}
+	}
+	for _, method := range []string{http.MethodGet, http.MethodOptions} {
+		response := rt.SendUserRequestWithHeaders(method, "/{{.db}}/", "", reqHeaders, username, RestTesterDefaultUserPassword)
+		require.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+		if method == http.MethodGet {
+			RequireStatus(t, response, http.StatusOK)
+		} else {
+			RequireStatus(t, response, http.StatusNoContent)
+		}
+	}
 
 	// successful request - matched headers
 	reqHeaders = map[string]string{
 		"Origin": "http://example.org",
 	}
-	response = rt.SendUserRequestWithHeaders("GET", "/{{.keyspace}}/_all_docs", "", reqHeaders, username, RestTesterDefaultUserPassword)
-	require.Equal(t, "http://example.org", response.Header().Get("Access-Control-Allow-Origin"))
-	RequireStatus(t, response, http.StatusOK)
 
-	response = rt.SendRequestWithHeaders("GET", "/{{.db}}/", "", reqHeaders)
-	require.Equal(t, "*", response.Header().Get("Access-Control-Allow-Origin"))
-	RequireStatus(t, response, http.StatusUnauthorized)
-	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+	for _, method := range []string{http.MethodGet, http.MethodOptions} {
+		response := rt.SendUserRequestWithHeaders(method, "/{{.keyspace}}/_all_docs", "", reqHeaders, username, RestTesterDefaultUserPassword)
+		require.Equal(t, "http://example.org", response.Header().Get("Access-Control-Allow-Origin"))
+		if method == http.MethodGet {
+			RequireStatus(t, response, http.StatusOK)
+		} else {
+			RequireStatus(t, response, http.StatusNoContent)
+		}
+	}
 
-	response = rt.SendRequestWithHeaders("GET", "/notadb/", "", reqHeaders)
-	require.Equal(t, "*", response.Header().Get("Access-Control-Allow-Origin"))
-	RequireStatus(t, response, http.StatusUnauthorized)
-	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+	for _, method := range []string{http.MethodGet, http.MethodOptions} {
+		response := rt.SendRequestWithHeaders(method, "/{{.db}}/", "", reqHeaders)
+		if method == http.MethodGet {
+			require.Equal(t, "*", response.Header().Get("Access-Control-Allow-Origin"))
+			RequireStatus(t, response, http.StatusUnauthorized)
+			require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+		} else {
+			// information leak: the options request knows about the database and knows it doesn't match
+			require.Equal(t, "http://example.org", response.Header().Get("Access-Control-Allow-Origin"))
+			RequireStatus(t, response, http.StatusNoContent)
+		}
+	}
+	for _, method := range []string{http.MethodGet, http.MethodOptions} {
+		response := rt.SendRequestWithHeaders(method, "/notadb/", "", reqHeaders)
+		require.Equal(t, "*", response.Header().Get("Access-Control-Allow-Origin"))
+		if method == http.MethodGet {
+			RequireStatus(t, response, http.StatusUnauthorized)
+			require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+		} else {
+			RequireStatus(t, response, http.StatusNoContent)
 
-	response = rt.SendUserRequestWithHeaders("GET", "/{{.db}}/", "", reqHeaders, username, RestTesterDefaultUserPassword)
-	require.Equal(t, "http://example.org", response.Header().Get("Access-Control-Allow-Origin"))
-	RequireStatus(t, response, http.StatusOK)
-
+		}
+	}
+	for _, method := range []string{http.MethodGet, http.MethodOptions} {
+		response := rt.SendUserRequestWithHeaders(method, "/{{.db}}/", "", reqHeaders, username, RestTesterDefaultUserPassword)
+		require.Equal(t, "http://example.org", response.Header().Get("Access-Control-Allow-Origin"))
+		if method == http.MethodGet {
+			RequireStatus(t, response, http.StatusOK)
+		} else {
+			RequireStatus(t, response, http.StatusNoContent)
+		}
+	}
 }
 
 func TestCORSNoMux(t *testing.T) {
@@ -123,30 +201,43 @@ func TestCORSNoMux(t *testing.T) {
 		"Origin": "http://example.com",
 	}
 	// this method doesn't exist
-	response := rt.SendRequestWithHeaders("GET", "/_notanendpoint/", "", reqHeaders)
-	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
-	RequireStatus(t, response, http.StatusNotFound)
-	require.Contains(t, response.Body.String(), "unknown URL")
+	for _, method := range []string{http.MethodGet, http.MethodOptions} {
+		response := rt.SendRequestWithHeaders(method, "/_notanendpoint/", "", reqHeaders)
+		require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+		RequireStatus(t, response, http.StatusNotFound)
+		require.Contains(t, response.Body.String(), "unknown URL")
+	}
 
 	// admin port shouldn't populate CORS
-	response = rt.SendAdminRequestWithHeaders("GET", "/_notanendpoint/", "", reqHeaders)
-	require.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
-	RequireStatus(t, response, http.StatusNotFound)
-	require.Contains(t, response.Body.String(), "unknown URL")
-
+	for _, method := range []string{http.MethodGet, http.MethodOptions} {
+		response := rt.SendAdminRequestWithHeaders(method, "/_notanendpoint/", "", reqHeaders)
+		require.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+		RequireStatus(t, response, http.StatusNotFound)
+		require.Contains(t, response.Body.String(), "unknown URL")
+	}
 	// this method doesn't exist
-	response = rt.SendRequestWithHeaders(http.MethodDelete, "/notadb/", "", reqHeaders)
-	require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
-	RequireStatus(t, response, http.StatusMethodNotAllowed)
-	require.Equal(t, strconv.Itoa(rt.ServerContext().Config.API.CORS.MaxAge), response.Header().Get("Access-Control-Max-Age"))
-	require.Equal(t, "GET, HEAD, POST, PUT", response.Header().Get("Access-Control-Allow-Methods"))
+	for _, method := range []string{http.MethodDelete, http.MethodOptions} {
+		response := rt.SendRequestWithHeaders(method, "/notadb/", "", reqHeaders)
+		require.Equal(t, "http://example.com", response.Header().Get("Access-Control-Allow-Origin"))
+		if method == http.MethodDelete {
+			RequireStatus(t, response, http.StatusMethodNotAllowed)
+		} else {
+			RequireStatus(t, response, http.StatusNoContent)
+		}
+		require.Equal(t, strconv.Itoa(rt.ServerContext().Config.API.CORS.MaxAge), response.Header().Get("Access-Control-Max-Age"))
+		require.Equal(t, "GET, HEAD, POST, PUT", response.Header().Get("Access-Control-Allow-Methods"))
+	}
 
-	response = rt.SendAdminRequestWithHeaders(http.MethodDelete, "/_stats/", "", reqHeaders)
-	RequireStatus(t, response, http.StatusMethodNotAllowed)
-	require.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
-	require.Equal(t, "", response.Header().Get("Access-Control-Max-Age"))
-	require.Equal(t, "", response.Header().Get("Access-Control-Allow-Methods"))
+	for _, method := range []string{http.MethodDelete, http.MethodOptions} {
+		response := rt.SendAdminRequestWithHeaders(method, "/_stats/", "", reqHeaders)
+		if method == http.MethodGet {
+			RequireStatus(t, response, http.StatusMethodNotAllowed)
+		}
 
+		require.Equal(t, "", response.Header().Get("Access-Control-Allow-Origin"))
+		require.Equal(t, "", response.Header().Get("Access-Control-Max-Age"))
+		require.Equal(t, "", response.Header().Get("Access-Control-Allow-Methods"))
+	}
 }
 
 func TestCORSUserNoAccess(t *testing.T) {
@@ -165,16 +256,30 @@ func TestCORSUserNoAccess(t *testing.T) {
 	response := rt.SendAdminRequest(http.MethodPut,
 		"/"+rt.GetDatabase().Name+"/_user/"+alice,
 		`{"name": "`+alice+`", "password": "`+RestTesterDefaultUserPassword+`"}`)
+	RequireStatus(t, response, http.StatusCreated)
 
 	for _, endpoint := range []string{"/{{.db}}/", "/notadb/"} {
 		t.Run(endpoint, func(t *testing.T) {
 			reqHeaders := map[string]string{
 				"Origin": "http://couchbase.com",
 			}
-			response = rt.SendRequestWithHeaders(http.MethodGet, endpoint, "", reqHeaders)
-			RequireStatus(t, response, http.StatusUnauthorized)
-			require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
-			assert.Equal(t, "*", response.Header().Get("Access-Control-Allow-Origin"))
+			for _, method := range []string{http.MethodGet, http.MethodOptions} {
+				response := rt.SendRequestWithHeaders(method, endpoint, "", reqHeaders)
+				if method == http.MethodOptions && endpoint == "/{{.db}}/" {
+					// information leak: the options request knows about the database and knows it doesn't match
+					assert.Equal(t, "http://couchbase.com", response.Header().Get("Access-Control-Allow-Origin"))
+				} else {
+					assert.Equal(t, "*", response.Header().Get("Access-Control-Allow-Origin"))
+				}
+
+				if method == http.MethodGet {
+					RequireStatus(t, response, http.StatusUnauthorized)
+					require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+
+				} else {
+					RequireStatus(t, response, http.StatusNoContent)
+				}
+			}
 		})
 	}
 }
@@ -197,18 +302,20 @@ func TestCORSOriginPerDatabase(t *testing.T) {
 	defer rt.Close()
 
 	testCases := []struct {
-		name           string
-		endpoint       string
-		origin         string
-		headerResponse string
-		responseCode   int
+		name                  string
+		endpoint              string
+		origin                string
+		headerResponse        string
+		headerResponseOptions string
+		responseCode          int
 	}{
 		{
-			name:           "CORS origin allowed couchbase",
-			endpoint:       "/{{.db}}/",
-			origin:         "http://couchbase.com",
-			headerResponse: "http://couchbase.com",
-			responseCode:   http.StatusOK,
+			name:                  "CORS origin allowed couchbase",
+			endpoint:              "/{{.db}}/",
+			origin:                "http://couchbase.com",
+			headerResponse:        "http://couchbase.com",
+			headerResponseOptions: "http://couchbase.com",
+			responseCode:          http.StatusOK,
 		},
 		{
 			name:           "CORS origin allowed example.com",
@@ -232,18 +339,20 @@ func TestCORSOriginPerDatabase(t *testing.T) {
 			responseCode:   http.StatusOK,
 		},
 		{
-			name:           "root url allow couchbase",
-			endpoint:       "/",
-			origin:         "http://couchbase.com",
-			headerResponse: "*",
-			responseCode:   http.StatusOK,
+			name:                  "root url allow couchbase",
+			endpoint:              "/",
+			origin:                "http://couchbase.com",
+			headerResponse:        "*",
+			headerResponseOptions: "*",
+			responseCode:          http.StatusOK,
 		},
 		{
-			name:           "root url allow example.com",
-			endpoint:       "/",
-			origin:         "http://example.com",
-			headerResponse: "http://example.com",
-			responseCode:   http.StatusOK,
+			name:                  "root url allow example.com",
+			endpoint:              "/",
+			origin:                "http://example.com",
+			headerResponse:        "http://example.com",
+			headerResponseOptions: "http://example.com",
+			responseCode:          http.StatusOK,
 		},
 	}
 	for _, test := range testCases {
@@ -251,9 +360,15 @@ func TestCORSOriginPerDatabase(t *testing.T) {
 			reqHeaders := map[string]string{
 				"Origin": test.origin,
 			}
-			response := rt.SendRequestWithHeaders(http.MethodGet, test.endpoint, "", reqHeaders)
-			require.Equal(t, test.responseCode, response.Code)
-			require.Equal(t, test.headerResponse, response.Header().Get("Access-Control-Allow-Origin"))
+			for _, method := range []string{http.MethodGet, http.MethodOptions} {
+				response := rt.SendRequestWithHeaders(method, test.endpoint, "", reqHeaders)
+				if method == http.MethodGet {
+					require.Equal(t, test.responseCode, response.Code)
+				} else {
+					require.Equal(t, http.StatusNoContent, response.Code)
+				}
+				require.Equal(t, test.headerResponse, response.Header().Get("Access-Control-Allow-Origin"))
+			}
 
 		})
 	}

--- a/rest/facebook.go
+++ b/rest/facebook.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 )
 
@@ -28,7 +29,7 @@ func (h *handler) handleFacebookPOST() error {
 	// CORS not allowed for login #115 #762
 	originHeader := h.rq.Header["Origin"]
 	if len(originHeader) > 0 {
-		matched := matchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
+		matched := auth.MatchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
 		if matched == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
 		}

--- a/rest/google.go
+++ b/rest/google.go
@@ -13,6 +13,7 @@ package rest
 import (
 	"net/http"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 )
 
@@ -30,7 +31,7 @@ func (h *handler) handleGooglePOST() error {
 	// CORS not allowed for login #115 #762
 	originHeader := h.rq.Header["Origin"]
 	if len(originHeader) > 0 {
-		matched := matchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
+		matched := auth.MatchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
 		if matched == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
 		}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -223,7 +223,6 @@ func ParseKeyspace(ks string) (db string, scope, collection *string, err error) 
 
 // Top-level handler call. It's passed a pointer to the specific method to run.
 func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, responsePermissions []Permission) error {
-	var err error
 	if h.server.Config.API.CompressResponses == nil || *h.server.Config.API.CompressResponses {
 		if encoded := NewEncodedResponseWriter(h.response, h.rq); encoded != nil {
 			h.response = encoded
@@ -231,6 +230,15 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 		}
 	}
 
+	err := h.validateAndWriteHeaders(method, accessPermissions, responsePermissions)
+	if err != nil {
+		return err
+	}
+	return method(h) // Call the actual handler code
+}
+
+// validateAndWriteHeaders sets up handler.db and validates the permission of the user and returns an error if there is not permission.
+func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermissions []Permission, responsePermissions []Permission) error {
 	var isRequestLogged bool
 	defer func() {
 		if !isRequestLogged {
@@ -238,10 +246,24 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 		}
 	}()
 
+	defer func() {
+		// Now that we know the DB, add CORS headers to the response:
+		if h.privs != adminPrivs && h.privs != metricsPrivs {
+			cors := h.server.Config.API.CORS
+			if h.db != nil {
+				cors = h.db.CORS
+			}
+			if cors != nil {
+				cors.AddResponseHeaders(h.rq, h.response)
+			}
+		}
+	}()
+
 	switch h.rq.Header.Get("Content-Encoding") {
 	case "":
 		h.requestBody = h.rq.Body
 	case "gzip":
+		var err error
 		if h.requestBody, err = gzip.NewReader(h.rq.Body); err != nil {
 			return err
 		}
@@ -266,6 +288,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 	// If there is a "keyspace" path variable in the route, parse the keyspace:
 	ks := h.PathVar("keyspace")
 	if ks != "" {
+		var err error
 		keyspaceDb, keyspaceScope, keyspaceCollection, err = ParseKeyspace(ks)
 		if err != nil {
 			return err
@@ -275,10 +298,12 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 		}
 	}
 
-	// look up the database context:
 	var dbContext *db.DatabaseContext
+
+	// look up the database context:
 	if keyspaceDb != "" {
 		h.addDatabaseLogContext(keyspaceDb)
+		var err error
 		if dbContext, err = h.server.GetActiveDatabase(keyspaceDb); err != nil {
 			if err == base.ErrNotFound {
 
@@ -342,6 +367,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 
 	// Authenticate, if not on admin port:
 	if h.privs != adminPrivs {
+		var err error
 		if err = h.checkAuth(dbContext); err != nil {
 			return err
 		}
@@ -390,6 +416,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 		var httpClient *http.Client
 		var authScope string
 
+		var err error
 		if dbContext != nil {
 			managementEndpoints, httpClient, err = dbContext.ObtainManagementEndpointsAndHTTPClient(h.ctx())
 			authScope = dbContext.Bucket.GetName()
@@ -495,19 +522,21 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 
 	// Now set the request's Database (i.e. context + user)
 	if dbContext != nil {
+		var err error
 		h.db, err = db.GetDatabase(dbContext, h.user)
+
 		if err != nil {
 			return err
 		}
 		if ks != "" {
+			var err error
 			h.collection, err = h.db.GetDatabaseCollectionWithUser(*keyspaceScope, *keyspaceCollection)
 			if err != nil {
 				return err
 			}
 		}
 	}
-
-	return method(h) // Call the actual handler code
+	return nil
 }
 
 func (h *handler) logRequestLine() {

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -360,22 +360,18 @@ func wrapRouter(sc *ServerContext, privs handlerPrivs, router *mux.Router) http.
 	return http.HandlerFunc(func(response http.ResponseWriter, rq *http.Request) {
 		FixQuotedSlashes(rq)
 		var match mux.RouteMatch
-
-		// Inject CORS if enabled and requested and not admin port
-		originHeader := rq.Header["Origin"]
-		if privs != adminPrivs && sc.Config.API.CORS != nil && len(originHeader) > 0 {
-			origin := matchedOrigin(sc.Config.API.CORS.Origin, originHeader)
-			response.Header().Add("Access-Control-Allow-Origin", origin)
-			response.Header().Add("Access-Control-Allow-Credentials", "true")
-			response.Header().Add("Access-Control-Allow-Headers", strings.Join(sc.Config.API.CORS.Headers, ", "))
-		}
-
 		if router.Match(rq, &match) {
 			router.ServeHTTP(response, rq)
 		} else {
 			// Log the request
 			h := newHandler(sc, privs, response, rq, false)
 			h.logRequestLine()
+
+			// Inject CORS if enabled and requested and not admin port
+			cors := sc.Config.API.CORS
+			if privs != adminPrivs && cors != nil {
+				cors.AddResponseHeaders(rq, response)
+			}
 
 			// What methods would have matched?
 			var options []string
@@ -387,9 +383,10 @@ func wrapRouter(sc *ServerContext, privs handlerPrivs, router *mux.Router) http.
 			if len(options) == 0 {
 				h.writeStatus(http.StatusNotFound, "unknown URL")
 			} else {
+				// Add CORS headers for OPTIONS request, since these are never registered by muxer.
 				response.Header().Add("Allow", strings.Join(options, ", "))
-				if privs != adminPrivs && sc.Config.API.CORS != nil && len(originHeader) > 0 {
-					response.Header().Add("Access-Control-Max-Age", strconv.Itoa(sc.Config.API.CORS.MaxAge))
+				if privs != adminPrivs && cors != nil && len(rq.Header["Origin"]) > 0 {
+					response.Header().Add("Access-Control-Max-Age", strconv.Itoa(cors.MaxAge))
 					response.Header().Add("Access-Control-Allow-Methods", strings.Join(options, ", "))
 				}
 				if rq.Method != "OPTIONS" {
@@ -401,22 +398,6 @@ func wrapRouter(sc *ServerContext, privs handlerPrivs, router *mux.Router) http.
 			h.logDuration(true)
 		}
 	})
-}
-
-func matchedOrigin(allowOrigins []string, rqOrigins []string) string {
-	for _, rv := range rqOrigins {
-		for _, av := range allowOrigins {
-			if rv == av {
-				return av
-			}
-		}
-	}
-	for _, av := range allowOrigins {
-		if av == "*" {
-			return "*"
-		}
-	}
-	return ""
 }
 
 func FixQuotedSlashes(rq *http.Request) {

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -368,17 +368,29 @@ func wrapRouter(sc *ServerContext, privs handlerPrivs, router *mux.Router) http.
 			h.logRequestLine()
 
 			// Inject CORS if enabled and requested and not admin port
-			cors := sc.Config.API.CORS
-			if privs != adminPrivs && cors != nil {
-				cors.AddResponseHeaders(rq, response)
-			}
-
 			// What methods would have matched?
 			var options []string
+			var keyspace string
 			for _, method := range []string{"GET", "HEAD", "POST", "PUT", "DELETE"} {
-				if wouldMatch(router, rq, method) {
+				found, matchedKeyspace := wouldMatch(router, rq, method)
+				if found {
 					options = append(options, method)
+					if keyspace == "" && matchedKeyspace != "" {
+						keyspace = matchedKeyspace
+					}
 				}
+			}
+
+			cors := sc.Config.API.CORS
+			dbName, _, _, _ := ParseKeyspace(keyspace)
+			if dbName != "" {
+				db, err := h.server.GetActiveDatabase(dbName)
+				if err == nil {
+					cors = db.CORS
+				}
+			}
+			if cors != nil && privs != adminPrivs && privs != metricsPrivs {
+				cors.AddResponseHeaders(rq, response)
 			}
 			if len(options) == 0 {
 				h.writeStatus(http.StatusNotFound, "unknown URL")
@@ -410,10 +422,25 @@ func FixQuotedSlashes(rq *http.Request) {
 	}
 }
 
-func wouldMatch(router *mux.Router, rq *http.Request, method string) bool {
+func wouldMatch(router *mux.Router, rq *http.Request, method string) (found bool, keyspace string) {
 	savedMethod := rq.Method
 	rq.Method = method
 	defer func() { rq.Method = savedMethod }()
 	var matchInfo mux.RouteMatch
-	return router.Match(rq, &matchInfo)
+	found = router.Match(rq, &matchInfo)
+	// If a match is found, check for any db/keyspace path variable in the resolved match.  Some paths may
+	// match routes with different path variables depending on the method.
+	if found {
+		matchVars := matchInfo.Vars
+		if dbName, ok := matchVars["db"]; ok {
+			keyspace = dbName
+		} else if keyspaceName, ok := matchVars["keyspace"]; ok {
+			keyspace = keyspaceName
+		} else if targetDbName, ok := matchVars["targetdb"]; ok {
+			keyspace = targetDbName
+		} else if newDbName, ok := matchVars["newdb"]; ok {
+			keyspace = newDbName
+		}
+	}
+	return found, keyspace
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -708,6 +708,12 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	dbcontext.NoX509HTTPClient = sc.NoX509HTTPClient
 	dbcontext.RequireResync = collectionsRequiringResync
 
+	if config.CORS != nil {
+		dbcontext.CORS = config.DbConfig.CORS
+	} else {
+		dbcontext.CORS = sc.Config.API.CORS
+	}
+
 	if config.RevsLimit != nil {
 		dbcontext.RevsLimit = *config.RevsLimit
 		if dbcontext.AllowConflicts() {

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/db"
 
 	"github.com/couchbase/gocbcore/v10/connstr"
@@ -116,7 +117,7 @@ func TestAllDatabaseNames(t *testing.T) {
 	ctx := base.TestCtx(t)
 	serverConfig := &StartupConfig{
 		Bootstrap: BootstrapConfig{UseTLSServer: base.BoolPtr(base.ServerIsTLS(base.UnitTestUrl())), ServerTLSSkipVerify: base.BoolPtr(base.TestTLSSkipVerify())},
-		API:       APIConfig{CORS: &CORSConfig{}, AdminInterface: DefaultAdminInterface}}
+		API:       APIConfig{CORS: &auth.CORSConfig{}, AdminInterface: DefaultAdminInterface}}
 	serverContext := NewServerContext(ctx, serverConfig, false)
 	defer serverContext.Close(ctx)
 
@@ -158,7 +159,7 @@ func TestAllDatabaseNames(t *testing.T) {
 
 func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 	ctx := base.TestCtx(t)
-	serverConfig := &StartupConfig{API: APIConfig{CORS: &CORSConfig{}, AdminInterface: DefaultAdminInterface}}
+	serverConfig := &StartupConfig{API: APIConfig{CORS: &auth.CORSConfig{}, AdminInterface: DefaultAdminInterface}}
 	serverContext := NewServerContext(ctx, serverConfig, false)
 	defer serverContext.Close(ctx)
 
@@ -591,7 +592,7 @@ func TestServerContextSetupCollectionsSupport(t *testing.T) {
 			UseTLSServer:        base.BoolPtr(base.ServerIsTLS(base.UnitTestUrl())),
 			ServerTLSSkipVerify: base.BoolPtr(base.TestTLSSkipVerify()),
 		},
-		API: APIConfig{CORS: &CORSConfig{}, AdminInterface: DefaultAdminInterface},
+		API: APIConfig{CORS: &auth.CORSConfig{}, AdminInterface: DefaultAdminInterface},
 	}
 	serverContext := NewServerContext(ctx, serverConfig, false)
 	defer serverContext.Close(ctx)

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -41,7 +41,7 @@ func (h *handler) handleSessionPOST() error {
 	if len(originHeader) > 0 {
 		matched := ""
 		if h.server.Config.API.CORS != nil {
-			matched = matchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
+			matched = auth.MatchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
 		}
 		if matched == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
@@ -97,7 +97,7 @@ func (h *handler) handleSessionDELETE() error {
 	if len(originHeader) > 0 {
 		matched := ""
 		if h.server.Config.API.CORS != nil {
-			matched = matchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
+			matched = auth.MatchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
 		}
 		if matched == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -80,6 +80,8 @@ const (
 	useMultipleCollection
 )
 
+var defaultTestingCORSOrigin = []string{"http://example.com", "*", "http://staging.example.com"}
+
 // RestTester provides a fake server for testing endpoints
 type RestTester struct {
 	*RestTesterConfig
@@ -180,8 +182,8 @@ func (rt *RestTester) Bucket() base.Bucket {
 		}
 	}
 
-	corsConfig := &CORSConfig{
-		Origin:      []string{"http://example.com", "*", "http://staging.example.com"},
+	corsConfig := &auth.CORSConfig{
+		Origin:      defaultTestingCORSOrigin,
 		LoginOrigin: []string{"http://example.com"},
 		Headers:     []string{},
 		MaxAge:      1728000,


### PR DESCRIPTION
Clean cherry-pick of:

- CBG-2807: Allow databases to override CORS config #61799
- CBG-2877: allow options to contain db-scoped CORS #6205

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1832/
