### PR TITLE
CBG-3034 (3.1.1 backport) allow DELETE on a broken DB config

### DIFF
--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -11,6 +11,7 @@ package base
 
 import (
 	"expvar"
+	"fmt"
 	"math"
 	"time"
 
@@ -27,6 +28,7 @@ type LeakyBucket struct {
 }
 
 var _ sgbucket.BucketStore = &LeakyBucket{}
+var _ sgbucket.DynamicDataStoreBucket = &LeakyBucket{}
 
 func NewLeakyBucket(bucket Bucket, config LeakyBucketConfig) *LeakyBucket {
 	return &LeakyBucket{
@@ -92,6 +94,22 @@ func (b *LeakyBucket) NamedDataStore(name sgbucket.DataStoreName) (sgbucket.Data
 
 func (b *LeakyBucket) GetUnderlyingBucket() Bucket {
 	return b.bucket
+}
+
+func (b *LeakyBucket) CreateDataStore(name sgbucket.DataStoreName) error {
+	dynamicDataStore, ok := b.GetUnderlyingBucket().(sgbucket.DynamicDataStoreBucket)
+	if !ok {
+		return fmt.Errorf("Bucket %T doesn't support dynamic collection creation", b.GetUnderlyingBucket())
+	}
+	return dynamicDataStore.CreateDataStore(name)
+}
+
+func (b *LeakyBucket) DropDataStore(name sgbucket.DataStoreName) error {
+	dynamicDataStore, ok := b.GetUnderlyingBucket().(sgbucket.DynamicDataStoreBucket)
+	if !ok {
+		return fmt.Errorf("Bucket %T doesn't support dynamic collection creation", b.GetUnderlyingBucket())
+	}
+	return dynamicDataStore.DropDataStore(name)
 }
 
 // The config object that controls the LeakyBucket behavior

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -176,6 +176,22 @@ func (b *TestBucket) GetMetadataStore() sgbucket.DataStore {
 	return b.Bucket.DefaultDataStore()
 }
 
+func (b *TestBucket) CreateDataStore(name sgbucket.DataStoreName) error {
+	dynamicDataStore, ok := b.Bucket.(sgbucket.DynamicDataStoreBucket)
+	if !ok {
+		return fmt.Errorf("Bucket %T doesn't support dynamic collection creation", b.Bucket)
+	}
+	return dynamicDataStore.CreateDataStore(name)
+}
+
+func (b *TestBucket) DropDataStore(name sgbucket.DataStoreName) error {
+	dynamicDataStore, ok := b.GetUnderlyingBucket().(sgbucket.DynamicDataStoreBucket)
+	if !ok {
+		return fmt.Errorf("Bucket %T doesn't support dynamic collection creation", b.GetUnderlyingBucket())
+	}
+	return dynamicDataStore.DropDataStore(name)
+}
+
 // GetDefaultDataStore returns the default DataStore. This is likely never actually wanted over GetSingleDataStore, so is left commented until absolutely required.
 // func (b *TestBucket) GetDefaultDataStore() sgbucket.DataStore {
 // 	b.t.Logf("Using default collection - Are you sure you want this instead of GetSingleDataStore() ?")

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1802,9 +1802,10 @@ func BenchmarkDatabase(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		ctx := base.TestCtx(b)
-		bucket, _ := connectToBucket(ctx, base.BucketSpec{
+		bucket, _ := ConnectToBucket(ctx, base.BucketSpec{
 			Server:     base.UnitTestUrl(),
-			BucketName: fmt.Sprintf("b-%d", i)})
+			BucketName: fmt.Sprintf("b-%d", i)},
+			true)
 		dbCtx, _ := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 		db, _ := CreateDatabase(dbCtx)
 		collection := GetSingleDatabaseCollectionWithUser(b, db)
@@ -1820,9 +1821,10 @@ func BenchmarkPut(b *testing.B) {
 	base.DisableTestLogging(b)
 
 	ctx := base.TestCtx(b)
-	bucket, _ := connectToBucket(ctx, base.BucketSpec{
+	bucket, _ := ConnectToBucket(ctx, base.BucketSpec{
 		Server:     base.UnitTestUrl(),
-		BucketName: "Bucket"})
+		BucketName: "Bucket"},
+		true)
 	context, _ := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{})
 	db, _ := CreateDatabase(context)
 	collection := GetSingleDatabaseCollectionWithUser(b, db)

--- a/rest/api.go
+++ b/rest/api.go
@@ -218,7 +218,7 @@ func (h *handler) handleFlush() error {
 		}
 
 		// Manually re-open a temporary bucket connection just for flushing purposes
-		tempBucketForFlush, err := db.GetConnectToBucketFn(false)(h.ctx(), spec)
+		tempBucketForFlush, err := db.ConnectToBucket(h.ctx(), spec, false)
 		if err != nil {
 			return err
 		}

--- a/rest/config.go
+++ b/rest/config.go
@@ -1480,6 +1480,9 @@ func (sc *ServerContext) bucketNameFromDbName(dbName string) (bucketName string,
 		return dbc.Bucket.GetName(), true
 	}
 
+	if sc.BootstrapContext.Connection == nil {
+		return "", false
+	}
 	// To search for database with the specified name, need to iterate over all buckets:
 	//   - look for dbName-scoped config file
 	//   - fetch default config file (backward compatibility, check internal DB name)
@@ -1610,7 +1613,7 @@ func (sc *ServerContext) FetchConfigs(ctx context.Context, isInitialStartup bool
 // _applyConfigs takes a map of dbName->DatabaseConfig and loads them into the ServerContext where necessary.
 func (sc *ServerContext) _applyConfigs(ctx context.Context, dbNameConfigs map[string]DatabaseConfig, isInitialStartup bool) (count int) {
 	for dbName, cnf := range dbNameConfigs {
-		applied, err := sc._applyConfig(base.NewNonCancelCtx(), cnf, false, isInitialStartup)
+		applied, err := sc._applyConfig(base.NewNonCancelCtx(), cnf, true, isInitialStartup)
 		if err != nil {
 			base.ErrorfCtx(ctx, "Couldn't apply config for database %q: %v", base.MD(dbName), err)
 			continue

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -1,4 +1,4 @@
-//  Copyright 2012-Present Couchbase, Inc.
+///  Copyright 2012-Present Couchbase, Inc.
 //
 //  Use of this software is governed by the Business Source License included
 //  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
@@ -100,7 +100,8 @@ type handler struct {
 	serialNumber          uint64
 	formattedSerialNumber string
 	loggedDuration        bool
-	runOffline            bool
+	runOffline            bool       // allows running on an offline database
+	allowNilDBContext     bool       // allow acceess to a database based only on name, looking up in metadata registry
 	queryValues           url.Values // Copy of results of rq.URL.Query()
 	permissionsResults    map[string]bool
 	authScopeFunc         authScopeFunc
@@ -123,8 +124,7 @@ type handlerMethod func(*handler) error
 // Creates an http.Handler that will run a handler with the given method
 func makeHandler(server *ServerContext, privs handlerPrivs, accessPermissions []Permission, responsePermissions []Permission, method handlerMethod) http.Handler {
 	return http.HandlerFunc(func(r http.ResponseWriter, rq *http.Request) {
-		runOffline := false
-		h := newHandler(server, privs, r, rq, runOffline)
+		h := newHandler(server, privs, r, rq, handlerOptions{})
 		err := h.invoke(method, accessPermissions, responsePermissions)
 		h.writeError(err)
 		h.logDuration(true)
@@ -134,8 +134,24 @@ func makeHandler(server *ServerContext, privs handlerPrivs, accessPermissions []
 // Creates an http.Handler that will run a handler with the given method even if the target DB is offline
 func makeOfflineHandler(server *ServerContext, privs handlerPrivs, accessPermissions []Permission, responsePermissions []Permission, method handlerMethod) http.Handler {
 	return http.HandlerFunc(func(r http.ResponseWriter, rq *http.Request) {
-		runOffline := true
-		h := newHandler(server, privs, r, rq, runOffline)
+		options := handlerOptions{
+			runOffline: true,
+		}
+		h := newHandler(server, privs, r, rq, options)
+		err := h.invoke(method, accessPermissions, responsePermissions)
+		h.writeError(err)
+		h.logDuration(true)
+	})
+}
+
+// makeMetadataDBOfflineHandler creates an http.Handler that will run a handler with the given method even if the target DB is not able to be instantiated
+func makeMetadataDBOfflineHandler(server *ServerContext, privs handlerPrivs, accessPermissions []Permission, responsePermissions []Permission, method handlerMethod) http.Handler {
+	return http.HandlerFunc(func(r http.ResponseWriter, rq *http.Request) {
+		options := handlerOptions{
+			runOffline:        true,
+			allowNilDBContext: true,
+		}
+		h := newHandler(server, privs, r, rq, options)
 		err := h.invoke(method, accessPermissions, responsePermissions)
 		h.writeError(err)
 		h.logDuration(true)
@@ -146,8 +162,7 @@ func makeOfflineHandler(server *ServerContext, privs handlerPrivs, accessPermiss
 // given the endpoint payload returns an auth scope.
 func makeHandlerSpecificAuthScope(server *ServerContext, privs handlerPrivs, accessPermissions []Permission, responsePermissions []Permission, method handlerMethod, dbAuthStringFunc func([]byte) (string, error)) http.Handler {
 	return http.HandlerFunc(func(r http.ResponseWriter, rq *http.Request) {
-		runOffline := false
-		h := newHandler(server, privs, r, rq, runOffline)
+		h := newHandler(server, privs, r, rq, handlerOptions{})
 		h.authScopeFunc = dbAuthStringFunc
 		err := h.invoke(method, accessPermissions, responsePermissions)
 		h.writeError(err)
@@ -155,16 +170,22 @@ func makeHandlerSpecificAuthScope(server *ServerContext, privs handlerPrivs, acc
 	})
 }
 
-func newHandler(server *ServerContext, privs handlerPrivs, r http.ResponseWriter, rq *http.Request, runOffline bool) *handler {
+type handlerOptions struct {
+	runOffline        bool // if true, allow handler to run when a database is offline
+	allowNilDBContext bool // if true, allow a db-scoped handler to be invoked with a nil dbContext in cases where the database config exists but has an error preventing dbContext initialization"
+}
+
+func newHandler(server *ServerContext, privs handlerPrivs, r http.ResponseWriter, rq *http.Request, options handlerOptions) *handler {
 	h := &handler{
-		server:       server,
-		privs:        privs,
-		rq:           rq,
-		response:     r,
-		status:       http.StatusOK,
-		serialNumber: atomic.AddUint64(&lastSerialNum, 1),
-		startTime:    time.Now(),
-		runOffline:   runOffline,
+		server:            server,
+		privs:             privs,
+		rq:                rq,
+		response:          r,
+		status:            http.StatusOK,
+		serialNumber:      atomic.AddUint64(&lastSerialNum, 1),
+		startTime:         time.Now(),
+		runOffline:        options.runOffline,
+		allowNilDBContext: options.allowNilDBContext,
 	}
 
 	// initialize h.rqCtx
@@ -300,13 +321,14 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 
 	var dbContext *db.DatabaseContext
 
+	var bucketName string
+
 	// look up the database context:
 	if keyspaceDb != "" {
 		h.addDatabaseLogContext(keyspaceDb)
 		var err error
 		if dbContext, err = h.server.GetActiveDatabase(keyspaceDb); err != nil {
 			if err == base.ErrNotFound {
-
 				if shouldCheckAdminAuth {
 					// Check if authenticated before attempting to get inactive database
 					authorized, err := h.checkAdminAuthenticationOnly()
@@ -317,10 +339,11 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 						return ErrInvalidLogin
 					}
 				}
-				dbContext, err = h.server.GetInactiveDatabase(h.ctx(), keyspaceDb)
+				var dbConfigFound bool
+				dbContext, dbConfigFound, err = h.server.GetInactiveDatabase(h.ctx(), keyspaceDb)
 				if err != nil {
 					if httpError, ok := err.(*base.HTTPError); ok && httpError.Status == http.StatusNotFound {
-						if shouldCheckAdminAuth {
+						if shouldCheckAdminAuth && (!h.allowNilDBContext || !dbConfigFound) {
 							return base.HTTPErrorf(http.StatusForbidden, "")
 						} else if h.privs == regularPrivs || h.privs == publicPrivs {
 							if !h.providedAuthCredentials() {
@@ -330,8 +353,11 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 							return ErrInvalidLogin
 						}
 					}
-					base.InfofCtx(h.ctx(), base.KeyHTTP, "Error trying to get db %s: %v", base.MD(keyspaceDb), err)
-					return err
+					if !h.allowNilDBContext || !dbConfigFound {
+						base.InfofCtx(h.ctx(), base.KeyHTTP, "Error trying to get db %s: %v", base.MD(keyspaceDb), err)
+						return err
+					}
+					bucketName, _ = h.server.bucketNameFromDbName(keyspaceDb)
 				}
 			} else {
 				return err
@@ -395,7 +421,6 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 			h.user, err = dbContext.Authenticator(h.ctx()).GetUser(*updates.Name)
 		}
 	}
-
 	if shouldCheckAdminAuth {
 		// If server is walrus but auth is enabled we should just kick the user out as invalid as we have nothing to
 		// validate credentials against
@@ -422,13 +447,12 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 			authScope = dbContext.Bucket.GetName()
 		} else {
 			managementEndpoints, httpClient, err = h.server.ObtainManagementEndpointsAndHTTPClient()
-			authScope = ""
+			authScope = bucketName
 		}
 		if err != nil {
 			base.WarnfCtx(h.ctx(), "An error occurred whilst obtaining management endpoints: %v", err)
 			return base.HTTPErrorf(http.StatusInternalServerError, "")
 		}
-
 		if h.authScopeFunc != nil {
 			body, err := h.readBody()
 			if err != nil {

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -100,9 +100,9 @@ func NewRestTesterCluster(t *testing.T, config *RestTesterClusterConfig) *RestTe
 
 	// Set group ID for each RestTester from cluster
 	if config.rtConfig == nil {
-		config.rtConfig = &RestTesterConfig{groupID: config.groupID}
+		config.rtConfig = &RestTesterConfig{GroupID: config.groupID}
 	} else {
-		config.rtConfig.groupID = config.groupID
+		config.rtConfig.GroupID = config.groupID
 	}
 	// only persistent mode is supported for a RestTesterCluster
 	config.rtConfig.PersistentConfig = true

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -327,7 +327,7 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	r.Handle("/{newdb:"+dbRegex+"}/",
 		makeHandlerSpecificAuthScope(sc, adminPrivs, []Permission{PermCreateDb}, nil, (*handler).handleCreateDB, getAuthScopeHandleCreateDB)).Methods("PUT")
 	r.Handle("/{db:"+dbRegex+"}/",
-		makeOfflineHandler(sc, adminPrivs, []Permission{PermDeleteDb}, nil, (*handler).handleDeleteDB)).Methods("DELETE")
+		makeMetadataDBOfflineHandler(sc, adminPrivs, []Permission{PermDeleteDb}, nil, (*handler).handleDeleteDB)).Methods("DELETE")
 
 	r.Handle("/_all_dbs",
 		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleAllDbs)).Methods("GET", "HEAD")
@@ -364,7 +364,7 @@ func wrapRouter(sc *ServerContext, privs handlerPrivs, router *mux.Router) http.
 			router.ServeHTTP(response, rq)
 		} else {
 			// Log the request
-			h := newHandler(sc, privs, response, rq, false)
+			h := newHandler(sc, privs, response, rq, handlerOptions{})
 			h.logRequestLine()
 
 			// Inject CORS if enabled and requested and not admin port

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -83,10 +83,19 @@ type bootstrapContext struct {
 	doneChan           chan struct{} // doneChan is closed when the stats logger goroutine finishes.
 }
 
+type getOrAddDatabaseConfigOptions struct {
+	failFast          bool            // if set, a failure to connect to a bucket of collection will immediately fail
+	useExisting       bool            //  if true, return an existing DatabaseContext vs return an error
+	connectToBucketFn db.OpenBucketFn // supply a custom function for buckets, used for testing only
+}
+
 func (sc *ServerContext) CreateLocalDatabase(ctx context.Context, dbs DbConfigMap) error {
 	for _, dbConfig := range dbs {
 		dbc := dbConfig.ToDatabaseConfig()
-		_, err := sc._getOrAddDatabaseFromConfig(ctx, *dbc, false, db.GetConnectToBucketFn(false))
+		_, err := sc._getOrAddDatabaseFromConfig(ctx, *dbc, getOrAddDatabaseConfigOptions{
+			useExisting: false,
+			failFast:    false,
+		})
 		if err != nil {
 			return err
 		}
@@ -208,7 +217,8 @@ func (sc *ServerContext) Close(ctx context.Context) {
 func (sc *ServerContext) GetDatabase(ctx context.Context, name string) (*db.DatabaseContext, error) {
 	dbc, err := sc.GetActiveDatabase(name)
 	if err == base.ErrNotFound {
-		return sc.GetInactiveDatabase(ctx, name)
+		dbc, _, err := sc.GetInactiveDatabase(ctx, name)
+		return dbc, err
 	}
 	return dbc, err
 }
@@ -229,35 +239,35 @@ func (sc *ServerContext) GetActiveDatabase(name string) (*db.DatabaseContext, er
 
 // GetInactiveDatabase attempts to load the database and return it's DatabaseContext. It will first attempt to unsuspend the
 // database, and if that fails, try to load the database from the buckets.
-// This should be used if GetActiveDatabase fails.
-func (sc *ServerContext) GetInactiveDatabase(ctx context.Context, name string) (*db.DatabaseContext, error) {
+// This should be used if GetActiveDatabase fails. Turns the database context, a variable to say if the config exists, and an error.
+func (sc *ServerContext) GetInactiveDatabase(ctx context.Context, name string) (*db.DatabaseContext, bool, error) {
 	dbc, err := sc.unsuspendDatabase(ctx, name)
 	if err != nil && err != base.ErrNotFound && err != ErrSuspendingDisallowed {
-		return nil, err
+		return nil, false, err
 	} else if err == nil {
-		return dbc, nil
+		return dbc, true, nil
 	}
 
+	var dbConfigFound bool
 	// database not loaded, fallback to fetching it from cluster
 	if sc.BootstrapContext.Connection != nil {
-		var found bool
 		if sc.Config.IsServerless() {
-			found, err = sc.fetchAndLoadDatabaseSince(ctx, name, sc.Config.Unsupported.Serverless.MinConfigFetchInterval)
+			dbConfigFound, _ = sc.fetchAndLoadDatabaseSince(ctx, name, sc.Config.Unsupported.Serverless.MinConfigFetchInterval)
 
 		} else {
-			found, err = sc.fetchAndLoadDatabase(base.NewNonCancelCtx(), name)
+			dbConfigFound, _ = sc.fetchAndLoadDatabase(base.NewNonCancelCtx(), name)
 		}
-		if found {
+		if dbConfigFound {
 			sc.lock.RLock()
 			defer sc.lock.RUnlock()
 			dbc := sc.databases_[name]
 			if dbc != nil {
-				return dbc, nil
+				return dbc, dbConfigFound, nil
 			}
 		}
 	}
 
-	return nil, base.HTTPErrorf(http.StatusNotFound, "no such database %q", name)
+	return nil, dbConfigFound, base.HTTPErrorf(http.StatusNotFound, "no such database %q", name)
 }
 
 func (sc *ServerContext) GetDbConfig(name string) *DbConfig {
@@ -337,7 +347,9 @@ func (sc *ServerContext) PostUpgrade(ctx context.Context, preview bool) (postUpg
 func (sc *ServerContext) _reloadDatabase(ctx context.Context, reloadDbName string, failFast bool) (*db.DatabaseContext, error) {
 	sc._unloadDatabase(ctx, reloadDbName)
 	config := sc.dbConfigs[reloadDbName]
-	return sc._getOrAddDatabaseFromConfig(ctx, config.DatabaseConfig, true, db.GetConnectToBucketFn(failFast))
+	return sc._getOrAddDatabaseFromConfig(ctx, config.DatabaseConfig, getOrAddDatabaseConfigOptions{
+		useExisting: true,
+		failFast:    failFast})
 }
 
 // Removes and re-adds a database to the ServerContext.
@@ -358,18 +370,21 @@ func (sc *ServerContext) ReloadDatabaseWithConfig(nonContextStruct base.NonCance
 
 func (sc *ServerContext) _reloadDatabaseWithConfig(ctx context.Context, config DatabaseConfig, failFast bool) error {
 	sc._removeDatabase(ctx, config.Name)
-	_, err := sc._getOrAddDatabaseFromConfig(ctx, config, false, db.GetConnectToBucketFn(failFast))
+	_, err := sc._getOrAddDatabaseFromConfig(ctx, config, getOrAddDatabaseConfigOptions{
+		useExisting: false,
+		failFast:    failFast,
+	})
 	return err
 }
 
 // Adds a database to the ServerContext.  Attempts a read after it gets the write
 // lock to see if it's already been added by another process. If so, returns either the
 // existing DatabaseContext or an error based on the useExisting flag.
-func (sc *ServerContext) getOrAddDatabaseFromConfig(ctx context.Context, config DatabaseConfig, useExisting bool, openBucketFn db.OpenBucketFn) (*db.DatabaseContext, error) {
+func (sc *ServerContext) getOrAddDatabaseFromConfig(ctx context.Context, config DatabaseConfig, options getOrAddDatabaseConfigOptions) (*db.DatabaseContext, error) {
 	// Obtain write lock during add database, to avoid race condition when creating based on ConfigServer
 	sc.lock.Lock()
 	defer sc.lock.Unlock()
-	return sc._getOrAddDatabaseFromConfig(ctx, config, useExisting, openBucketFn)
+	return sc._getOrAddDatabaseFromConfig(ctx, config, options)
 }
 
 func GetBucketSpec(ctx context.Context, config *DatabaseConfig, serverConfig *StartupConfig) (spec base.BucketSpec, err error) {
@@ -413,8 +428,7 @@ func GetBucketSpec(ctx context.Context, config *DatabaseConfig, serverConfig *St
 // lock to see if it's already been added by another process. If so, returns either the
 // existing DatabaseContext or an error based on the useExisting flag.
 // Pass in a bucketFromBucketSpecFn to replace the default ConnectToBucket function. This will cause the failFast argument to be ignored
-func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config DatabaseConfig, useExisting bool, openBucketFn db.OpenBucketFn) (*db.DatabaseContext, error) {
-
+func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config DatabaseConfig, options getOrAddDatabaseConfigOptions) (*db.DatabaseContext, error) {
 	// Generate bucket spec and validate whether db already exists
 	spec, err := GetBucketSpec(ctx, &config, sc.Config)
 	if err != nil {
@@ -448,7 +462,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	}
 
 	if sc.databases_[dbName] != nil {
-		if useExisting {
+		if options.useExisting {
 			return sc.databases_[dbName], nil
 		} else {
 			return nil, base.HTTPErrorf(http.StatusPreconditionFailed, // what CouchDB returns
@@ -463,11 +477,18 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	// Connect to bucket
 	base.InfofCtx(ctx, base.KeyAll, "Opening db /%s as bucket %q, pool %q, server <%s>",
 		base.MD(dbName), base.MD(spec.BucketName), base.SD(base.DefaultPool), base.SD(spec.Server))
-	bucket, err := openBucketFn(ctx, spec)
+
+	// the connectToBucketFn is used for testing seam
+	var bucket base.Bucket
+	if options.connectToBucketFn != nil {
+		// the connectToBucketFn is used for testing seam
+		bucket, err = options.connectToBucketFn(ctx, spec, options.failFast)
+	} else {
+		bucket, err = db.ConnectToBucket(ctx, spec, options.failFast)
+	}
 	if err != nil {
 		return nil, err
 	}
-
 	// If using a walrus bucket, force use of views
 	useViews := base.BoolDefault(config.UseViews, false)
 	if !useViews && spec.IsWalrusBucket() {
@@ -538,10 +559,21 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		for scopeName, scopeConfig := range config.Scopes {
 			for collectionName, _ := range scopeConfig.Collections {
 				var dataStore sgbucket.DataStore
-				err := base.WaitForNoError(func() error {
+
+				var err error
+				if options.failFast {
 					dataStore, err = bucket.NamedDataStore(base.ScopeAndCollectionName{Scope: scopeName, Collection: collectionName})
-					return err
-				})
+				} else {
+					waitForCollection := func() (bool, error, interface{}) {
+						dataStore, err = bucket.NamedDataStore(base.ScopeAndCollectionName{Scope: scopeName, Collection: collectionName})
+						return err != nil, err, nil
+					}
+
+					err, _ = base.RetryLoop(
+						fmt.Sprintf("waiting for %s.%s.%s to exist", base.MD(bucket.GetName()), base.MD(scopeName), base.MD(collectionName)),
+						waitForCollection,
+						base.CreateMaxDoublingSleeperFunc(30, 10, 1000))
+				}
 				if err != nil {
 					return nil, fmt.Errorf("error attempting to create/update database: %w", err)
 				}
@@ -1197,13 +1229,15 @@ func (sc *ServerContext) initEventHandlers(ctx context.Context, dbcontext *db.Da
 // Adds a database to the ServerContext given its configuration.  If an existing config is found
 // for the name, returns an error.
 func (sc *ServerContext) AddDatabaseFromConfig(ctx context.Context, config DatabaseConfig) (*db.DatabaseContext, error) {
-	return sc.getOrAddDatabaseFromConfig(ctx, config, false, db.GetConnectToBucketFn(false))
+	failFast := false
+	return sc.getOrAddDatabaseFromConfig(ctx, config, getOrAddDatabaseConfigOptions{useExisting: false, failFast: failFast})
 }
 
 // AddDatabaseFromConfigFailFast adds a database to the ServerContext given its configuration and fails fast.
 // If an existing config is found for the name, returns an error.
 func (sc *ServerContext) AddDatabaseFromConfigFailFast(nonContextStruct base.NonCancellableContext, config DatabaseConfig) (*db.DatabaseContext, error) {
-	return sc.getOrAddDatabaseFromConfig(nonContextStruct.Ctx, config, false, db.GetConnectToBucketFn(true))
+	failFast := true
+	return sc.getOrAddDatabaseFromConfig(nonContextStruct.Ctx, config, getOrAddDatabaseConfigOptions{useExisting: false, failFast: failFast})
 }
 
 func (sc *ServerContext) processEventHandlersForEvent(ctx context.Context, events []*EventConfig, eventType db.EventType, dbcontext *db.DatabaseContext) error {
@@ -1329,7 +1363,10 @@ func (sc *ServerContext) _unsuspendDatabase(ctx context.Context, dbName string) 
 			return nil, fmt.Errorf("unsuspending db %q failed due to an error while trying to retrieve latest config from bucket %q: %w", base.MD(dbName).Redact(), base.MD(bucket).Redact(), err)
 		}
 		dbConfig.cfgCas = cas
-		dbCtx, err = sc._getOrAddDatabaseFromConfig(ctx, dbConfig.DatabaseConfig, false, db.GetConnectToBucketFn(false))
+		failFast := false
+		dbCtx, err = sc._getOrAddDatabaseFromConfig(ctx, dbConfig.DatabaseConfig, getOrAddDatabaseConfigOptions{
+			useExisting: false,
+			failFast:    failFast})
 		if err != nil {
 			return nil, err
 		}

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/couchbase/sync_gateway/auth"
-	"github.com/couchbase/sync_gateway/db"
 
 	"github.com/couchbase/gocbcore/v10/connstr"
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -168,7 +167,7 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 
 	// Get or add database name from config without valid database name; throws 400 Illegal database name error
 	dbConfig := DbConfig{OldRevExpirySeconds: &oldRevExpirySeconds, LocalDocExpirySecs: &localDocExpirySecs}
-	dbContext, err := serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(false))
+	dbContext, err := serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, getOrAddDatabaseConfigOptions{useExisting: false, failFast: false})
 	assert.Nil(t, dbContext, "Can't create database context without a valid database name")
 	assert.Error(t, err, "It should throw 400 Illegal database name")
 	assert.Contains(t, err.Error(), strconv.Itoa(http.StatusBadRequest))
@@ -187,7 +186,10 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 		BucketConfig:        BucketConfig{Server: &server, Bucket: &bucketName},
 	}
 
-	dbContext, err = serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(false))
+	dbContext, err = serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, getOrAddDatabaseConfigOptions{
+		failFast:    false,
+		useExisting: false,
+	})
 	assert.Nil(t, dbContext, "Can't create database context from config with unrecognized value for import_docs")
 	assert.Error(t, err, "It should throw Unrecognized value for import_docs")
 
@@ -214,14 +216,22 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 		AutoImport:          false,
 	}
 
-	dbContext, err = serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(false))
+	dbContext, err = serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, getOrAddDatabaseConfigOptions{
+		failFast:    false,
+		useExisting: false,
+	})
 	assert.Nil(t, dbContext, "Can't create database context with duplicate database name")
 	assert.Error(t, err, "It should throw 412 Duplicate database names")
 	assert.Contains(t, err.Error(), strconv.Itoa(http.StatusPreconditionFailed))
 
 	// Get or add database from config with duplicate database name and useExisting as true
 	// Existing database context should be returned
-	dbContext, err = serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, true, db.GetConnectToBucketFn(false))
+	dbContext, err = serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig},
+		getOrAddDatabaseConfigOptions{
+			failFast:    false,
+			useExisting: true,
+		})
+
 	assert.NoError(t, err, "No error while trying to get the existing database name")
 	assert.Equal(t, server, dbContext.BucketSpec.Server)
 	assert.Equal(t, bucketName, dbContext.BucketSpec.BucketName)
@@ -615,7 +625,12 @@ func TestServerContextSetupCollectionsSupport(t *testing.T) {
 			},
 		},
 	}
-	_, err := serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(true))
+	_, err := serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig},
+		getOrAddDatabaseConfigOptions{
+			failFast:    false,
+			useExisting: false,
+		})
+
 	require.ErrorIs(t, err, errCollectionsUnsupported)
 }
 
@@ -788,7 +803,11 @@ func TestDisableScopesInLegacyConfig(t *testing.T) {
 					}
 					dbConfig.Scopes = GetCollectionsConfigWithSyncFn(t, bucket, nil, 1)
 				}
-				dbContext, err := serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, false, db.GetConnectToBucketFn(false))
+				dbContext, err := serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig},
+					getOrAddDatabaseConfigOptions{
+						failFast:    false,
+						useExisting: false,
+					})
 				if persistentConfig || scopes == false {
 					require.NoError(t, err)
 					require.NotNil(t, dbContext)

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -51,7 +51,7 @@ func TestServerlessPollBuckets(t *testing.T) {
 	assert.Empty(t, configs)
 
 	// Create a database
-	rt2 := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1.NoCloseClone(), PersistentConfig: true, groupID: &sc.Config.Bootstrap.ConfigGroupID})
+	rt2 := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1.NoCloseClone(), PersistentConfig: true, GroupID: &sc.Config.Bootstrap.ConfigGroupID})
 	defer rt2.Close()
 	// Create a new db on the RT to confirm fetch won't retrieve it (due to bucket not being in BucketCredentials)
 	resp := rt2.SendAdminRequest(http.MethodPut, "/db/", fmt.Sprintf(`{

--- a/rest/upgradetest/remove_collection_test.go
+++ b/rest/upgradetest/remove_collection_test.go
@@ -1,0 +1,112 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package upgradetest
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/rest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoveCollection tests when a collection has been removed from CBS, and the server is restarted. We should be able to modify or delete the database.
+func TestRemoveCollection(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("test relies on bootstrap connection and needs CBS")
+	}
+	base.TestRequiresCollections(t)
+	base.RequireNumTestBuckets(t, 2)
+	numCollections := 2
+	bucket := base.GetPersistentTestBucket(t)
+	defer bucket.Close()
+	base.RequireNumTestDataStores(t, numCollections)
+	rtConfig := &rest.RestTesterConfig{
+		CustomTestBucket:             bucket.NoCloseClone(),
+		PersistentConfig:             true,
+		GroupID:                      base.StringPtr(t.Name()),
+		AdminInterfaceAuthentication: true,
+	}
+	rt := rest.NewRestTesterMultipleCollections(t, rtConfig, 2)
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Scopes = rest.GetCollectionsConfig(t, rt.TestBucket, numCollections)
+
+	dbName := "removecollectiondb"
+
+	dbcJSON, err := base.JSONMarshal(dbConfig)
+	require.NoError(t, err)
+	resp := rt.SendAdminRequestWithAuth(http.MethodPut, "/"+dbName+"/", string(dbcJSON), base.TestClusterUsername(), base.TestClusterPassword())
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	dataStores := rt.TestBucket.GetNonDefaultDatastoreNames()
+	deletedDataStore := dataStores[1]
+
+	defer func() {
+		assert.NoError(t, bucket.CreateDataStore(deletedDataStore))
+
+	}()
+	// drop a data store
+	require.NoError(t, rt.TestBucket.DropDataStore(deletedDataStore))
+	require.Len(t, rt.TestBucket.GetNonDefaultDatastoreNames(), len(dataStores)-1)
+
+	rt.Close()
+	rtConfig = &rest.RestTesterConfig{
+		CustomTestBucket:             bucket.NoCloseClone(),
+		PersistentConfig:             true,
+		GroupID:                      base.StringPtr(t.Name()),
+		AdminInterfaceAuthentication: true,
+	}
+
+	rt = rest.NewRestTesterMultipleCollections(t, rtConfig, 2)
+	defer rt.Close()
+
+	bucket2Role := rest.RouteRole{
+		RoleName:       rest.MobileSyncGatewayRole.RoleName,
+		DatabaseScoped: true,
+	}
+	if base.TestsUseServerCE() {
+		bucket2Role = rest.RouteRole{
+			RoleName:       rest.BucketFullAccessRole.RoleName,
+			DatabaseScoped: true,
+		}
+	}
+
+	eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
+	require.NoError(t, err)
+
+	altBucket := base.GetTestBucket(t)
+	defer altBucket.Close()
+	const password = "password2"
+	rest.MakeUser(t, httpClient, eps[0], bucket2Role.RoleName, password, []string{fmt.Sprintf("%s[%s]", bucket2Role.RoleName, altBucket.GetName())})
+	defer rest.DeleteUser(t, httpClient, eps[0], bucket2Role.RoleName)
+
+	delete(dbConfig.Scopes[deletedDataStore.ScopeName()].Collections, deletedDataStore.CollectionName())
+
+	dbcJSON, err = base.JSONMarshal(dbConfig)
+	require.NoError(t, err)
+
+	resp = rt.SendAdminRequestWithAuth(http.MethodPost, "/"+dbName+"/", string(dbcJSON), base.TestClusterUsername(), base.TestClusterPassword())
+	rest.RequireStatus(t, resp, http.StatusForbidden)
+
+	// wrong RBAC user
+	resp = rt.SendAdminRequestWithAuth(http.MethodDelete, "/"+dbName+"/", "", bucket2Role.RoleName, password)
+	rest.RequireStatus(t, resp, http.StatusForbidden)
+
+	// bad credentials
+	resp = rt.SendAdminRequestWithAuth(http.MethodDelete, "/"+dbName+"/", "", "baduser", "badpassword")
+	rest.RequireStatus(t, resp, http.StatusUnauthorized)
+
+	resp = rt.SendAdminRequestWithAuth(http.MethodDelete, "/"+dbName+"/", "", base.TestClusterUsername(), base.TestClusterPassword())
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -66,7 +66,7 @@ type RestTesterConfig struct {
 	enableAdminAuthPermissionsCheck bool
 	useTLSServer                    bool // If true, TLS will be required for communications with CBS. Default: false
 	PersistentConfig                bool
-	groupID                         *string
+	GroupID                         *string
 	serverless                      bool // Runs SG in serverless mode. Must be used in conjunction with persistent config
 	collectionConfig                collectionConfiguration
 	numCollections                  int
@@ -227,8 +227,8 @@ func (rt *RestTester) Bucket() base.Bucket {
 		}
 	}
 
-	if rt.RestTesterConfig.groupID != nil {
-		sc.Bootstrap.ConfigGroupID = *rt.RestTesterConfig.groupID
+	if rt.RestTesterConfig.GroupID != nil {
+		sc.Bootstrap.ConfigGroupID = *rt.RestTesterConfig.GroupID
 	} else if rt.RestTesterConfig.PersistentConfig {
 		// If running in persistent config mode, the database has to be manually created. If the db name is the same as a
 		// past tests db name, a db already exists error could happen if the past tests bucket is still flushing. Prevent this
@@ -1181,9 +1181,14 @@ func (s *SlowResponseRecorder) Write(buf []byte) (int, error) {
 // AddDatabaseFromConfigWithBucket adds a database to the ServerContext and sets a specific bucket on the database context.
 // If an existing config is found for the name, returns an error.
 func (sc *ServerContext) AddDatabaseFromConfigWithBucket(ctx context.Context, tb testing.TB, config DatabaseConfig, bucket base.Bucket) (*db.DatabaseContext, error) {
-	return sc.getOrAddDatabaseFromConfig(ctx, config, false, func(ctx context.Context, spec base.BucketSpec) (base.Bucket, error) {
-		return bucket, nil
-	})
+	options := getOrAddDatabaseConfigOptions{
+		useExisting: false,
+		failFast:    false,
+		connectToBucketFn: func(_ context.Context, spec base.BucketSpec, _ bool) (base.Bucket, error) {
+			return bucket, nil
+		},
+	}
+	return sc.getOrAddDatabaseFromConfig(ctx, config, options)
 }
 
 // The parameters used to create a BlipTester
@@ -2457,6 +2462,7 @@ func (rt *RestTester) GetChangesOneShot(t testing.TB, keyspace string, since int
 }
 
 func (rt *RestTester) NewDbConfig() DbConfig {
+	// make sure bucket has been initialized
 	config := DbConfig{
 		BucketConfig: BucketConfig{
 			Bucket: base.StringPtr(rt.Bucket().GetName()),


### PR DESCRIPTION
cherry-pick of CBG-2977 allow DELETE on a broken DB config (#6260)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1836/
