### PR TITLE
CBG-3028: fixes for failing CE tests

### DIFF
--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -93,8 +93,6 @@ func DefaultDbConfig(sc *StartupConfig) *DbConfig {
 	var partitions *uint16
 	if base.IsEnterpriseEdition() {
 		partitions = base.Uint16Ptr(base.GetDefaultImportPartitions(sc.IsServerless()))
-	} else {
-		partitions = nil
 	}
 	dbConfig := DbConfig{
 		BucketConfig:       BucketConfig{},

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -90,6 +90,12 @@ func MergeDatabaseConfigWithDefaults(sc *StartupConfig, dbConfig *DbConfig) (*Db
 // to provide defaults to  include_runtime config endpoints.
 // Note that this does not include unsupported options
 func DefaultDbConfig(sc *StartupConfig) *DbConfig {
+	var partitions *uint16
+	if base.IsEnterpriseEdition() {
+		partitions = base.Uint16Ptr(base.GetDefaultImportPartitions(sc.IsServerless()))
+	} else {
+		partitions = nil
+	}
 	dbConfig := DbConfig{
 		BucketConfig:       BucketConfig{},
 		Name:               "",
@@ -98,7 +104,7 @@ func DefaultDbConfig(sc *StartupConfig) *DbConfig {
 		Roles:              nil,
 		RevsLimit:          nil, // Set this below struct
 		AutoImport:         base.BoolPtr(base.DefaultAutoImport),
-		ImportPartitions:   base.Uint16Ptr(base.GetDefaultImportPartitions(sc.IsServerless())),
+		ImportPartitions:   partitions,
 		ImportFilter:       nil,
 		ImportBackupOldRev: base.BoolPtr(false),
 		EventHandlers:      nil,

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1025,6 +1025,7 @@ func TestReplicationRebalancePush(t *testing.T) {
 func TestPullOneshotReplicationAPI(t *testing.T) {
 
 	base.LongRunningTest(t)
+	fmt.Println("enterpirse?", base.IsEnterpriseEdition())
 
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
@@ -1901,8 +1902,8 @@ func TestDBReplicationStatsTeardown(t *testing.T) {
 
 	// If CE, recreate the replication
 	if !base.IsEnterpriseEdition() {
-		rt.CreateReplication("repl1", db2Url.String(), db.ActiveReplicatorTypePush, nil, true, db.ConflictResolverDefault)
-		rt.WaitForReplicationStatus("repl1", db.ReplicationStateRunning)
+		rt.CreateReplicationForDB("{{.db1}}", "repl1", db2Url.String(), db.ActiveReplicatorTypePush, nil, true, db.ConflictResolverDefault)
+		rt.WaitForReplicationStatusForDB("{{.db1}}", "repl1", db.ReplicationStateRunning)
 	}
 
 	// Wait for second document to replicate to confirm replication restart

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1025,7 +1025,6 @@ func TestReplicationRebalancePush(t *testing.T) {
 func TestPullOneshotReplicationAPI(t *testing.T) {
 
 	base.LongRunningTest(t)
-	fmt.Println("enterpirse?", base.IsEnterpriseEdition())
 
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)


### PR DESCRIPTION
CBG-3028

Small PR to fix bug in helper function to get a default db config for `TestImportPartitionsServerless` where import partitions were being configured for a database when running in CE mode. Also an issue where creating a replication was using the wriong {{db}} template. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1837/ (CE edition)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1838/ (EE edition)
