### PR TITLE
CBG-3031: [3.1.1] Allow one-shot replications to wait for DCP to catch up on changes feed

### DIFF
--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -68,6 +68,8 @@ const (
 	SubChangesContinuous  = "continuous"
 	SubChangesBatch       = "batch"
 	SubChangesRevocations = "revocations"
+	SubChangesRequestPlus = "requestPlus"
+	SubChangesFuture      = "future"
 
 	// rev message properties
 	RevMessageID          = "id"
@@ -163,7 +165,7 @@ func NewSubChangesParams(logCtx context.Context, rq *blip.Message, zeroSeq Seque
 	// Determine incoming since and docIDs once, since there is some overhead associated with their calculation
 	sinceSequenceId := zeroSeq
 	var err error
-	if rq.Properties["future"] == trueProperty {
+	if rq.Properties[SubChangesFuture] == trueProperty {
 		sinceSequenceId, err = latestSeq()
 	} else if sinceStr, found := rq.Properties[SubChangesSince]; found {
 		if sinceSequenceId, err = sequenceIDParser(sinceStr); err != nil {
@@ -232,6 +234,14 @@ func (s *SubChangesParams) revocations() bool {
 
 func (s *SubChangesParams) activeOnly() bool {
 	return (s.rq.Properties[SubChangesActiveOnly] == trueProperty)
+}
+
+func (s *SubChangesParams) requestPlus(defaultValue bool) (value bool) {
+	propertyValue, isDefined := s.rq.Properties[SubChangesRequestPlus]
+	if !isDefined {
+		return defaultValue
+	}
+	return propertyValue == trueProperty
 }
 
 func (s *SubChangesParams) filter() string {

--- a/db/database.go
+++ b/db/database.go
@@ -173,6 +173,8 @@ type DatabaseContextOptions struct {
 	skipRegisterImportPIndex      bool           // if set, skips the global gocb PIndex registration
 	MetadataStore                 base.DataStore // If set, use this location/connection for SG metadata storage - if not set, metadata is stored using the same location/connection as the bucket used for data storage.
 	MetadataID                    string         // MetadataID used for metadata storage
+	BlipStatsReportingInterval    int64          // interval to report blip stats in milliseconds
+	ChangesRequestPlus            bool           // Sets the default value for request_plus, for non-continuous changes feeds
 }
 
 type ScopesOptions map[string]ScopeOptions
@@ -2306,4 +2308,11 @@ func (dbc *DatabaseContext) AuthenticatorOptions() auth.AuthenticatorOptions {
 	defaultOptions := auth.DefaultAuthenticatorOptions()
 	defaultOptions.MetaKeys = dbc.MetadataKeys
 	return defaultOptions
+}
+
+// GetRequestPlusSequence fetches the current value of the sequence counter for the database.
+// Uses getSequence (instead of lastSequence) as it's intended to be up to date with allocations
+// across all nodes, while lastSequence is just the latest allocation from this node
+func (dbc *DatabaseContext) GetRequestPlusSequence() (uint64, error) {
+	return dbc.sequences.getSequence()
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -95,6 +95,17 @@ func (db *DatabaseContext) WaitForCaughtUp(targetCount int64) error {
 	return errors.New("WaitForCaughtUp didn't catch up")
 }
 
+func (db *DatabaseContext) WaitForTotalCaughtUp(targetCount int64) error {
+	for i := 0; i < 100; i++ {
+		caughtUpCount := db.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
+		if caughtUpCount >= targetCount {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return errors.New("WaitForCaughtUp didn't catch up")
+}
+
 type StatWaiter struct {
 	initCount   int64            // Document cached count when NewStatWaiter is called
 	targetCount int64            // Target count used when Wait is called
@@ -597,4 +608,14 @@ func GetSingleDatabaseCollection(tb testing.TB, database *DatabaseContext) *Data
 	}
 	tb.Fatalf("Could not find a collection")
 	return nil
+}
+
+// AllocateTestSequence allocates a sequence via the sequenceAllocator.  For use by non-db tests
+func AllocateTestSequence(database *DatabaseContext) (uint64, error) {
+	return database.sequences.incrementSequence(1)
+}
+
+// ReleaseTestSequence releases a sequence via the sequenceAllocator.  For use by non-db tests
+func ReleaseTestSequence(database *DatabaseContext, sequence uint64) error {
+	return database.sequences.releaseSequence(sequence)
 }

--- a/docs/api/paths/admin/keyspace-_changes.yaml
+++ b/docs/api/paths/admin/keyspace-_changes.yaml
@@ -96,6 +96,13 @@ get:
           - longpoll
           - continuous
           - websocket
+
+    - name: request_plus
+      in: query
+      description: When true, ensures all valid documents written prior to the request being issued are included in the response.  This is only applicable for non-continuous feeds.
+      schema:
+        type: boolean
+        default: 'false'
   responses:
     '200':
       $ref: ../../components/responses.yaml#/changes-feed
@@ -155,6 +162,9 @@ post:
               type: string
             feed:
               description: 'The type of changes feed to use. '
+              type: string
+            request_plus:
+              description: 'When true, ensures all valid documents written prior to the request being issued are included in the response.  This is only applicable for non-continuous feeds.'
               type: string
   responses:
     '200':

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2642,3 +2642,122 @@ func TestUnsubChanges(t *testing.T) {
 	_, found = btc.WaitForRev("doc2", resp.Rev)
 	assert.True(t, found)
 }
+
+// TestRequestPlusPull tests that a one-shot pull replication waits for pending changes when request plus is set on the replication.
+func TestRequestPlusPull(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyDCP, base.KeyChanges, base.KeyHTTP)
+	defer db.SuspendSequenceBatching()() // Required for slow sequence simulation
+
+	rtConfig := RestTesterConfig{
+		SyncFn: `function(doc) {
+				channel(doc.channel);
+				if (doc.accessUser != "") {
+					access(doc.accessUser, doc.accessChannel)
+				}
+			}`,
+	}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+	database := rt.GetDatabase()
+
+	// Initialize blip tester client (will create user)
+	client, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+		Username: "bernard",
+	})
+	require.NoError(t, err)
+	defer client.Close()
+
+	// Put a doc in channel PBS
+	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-1", `{"channel":["PBS"]}`)
+	RequireStatus(t, response, 201)
+
+	// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
+	slowSequence, seqErr := db.AllocateTestSequence(database)
+	require.NoError(t, seqErr)
+
+	// Write a document granting user 'bernard' access to PBS
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/grantDoc", `{"accessUser":"bernard", "accessChannel":"PBS"}`)
+	RequireStatus(t, response, 201)
+
+	caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
+
+	// Start a regular one-shot pull
+	err = client.StartOneshotPullRequestPlus()
+	assert.NoError(t, err)
+
+	// Wait for the one-shot changes feed to go into wait mode before releasing the slow sequence
+	require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+1))
+
+	// Release the slow sequence
+	releaseErr := db.ReleaseTestSequence(database, slowSequence)
+	require.NoError(t, releaseErr)
+
+	// The one-shot pull should unblock and replicate the document in the granted channel
+	data, ok := client.WaitForDoc("pbs-1")
+	assert.True(t, ok)
+	assert.Equal(t, `{"channel":["PBS"]}`, string(data))
+
+}
+
+// TestRequestPlusPull tests that a one-shot pull replication waits for pending changes when request plus is set on the db config.
+func TestRequestPlusPullDbConfig(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyDCP, base.KeyChanges, base.KeyHTTP)
+	defer db.SuspendSequenceBatching()() // Required for slow sequence simulation
+
+	rtConfig := RestTesterConfig{
+		SyncFn: `function(doc) {
+				channel(doc.channel);
+				if (doc.accessUser != "") {
+					access(doc.accessUser, doc.accessChannel)
+				}
+			}`,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				ChangesRequestPlus: base.BoolPtr(true),
+			},
+		},
+	}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+	database := rt.GetDatabase()
+
+	// Initialize blip tester client (will create user)
+	client, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+		Username: "bernard",
+	})
+	require.NoError(t, err)
+	defer client.Close()
+
+	// Put a doc in channel PBS
+	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-1", `{"channel":["PBS"]}`)
+	RequireStatus(t, response, 201)
+
+	// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
+	slowSequence, seqErr := db.AllocateTestSequence(database)
+	require.NoError(t, seqErr)
+
+	// Write a document granting user 'bernard' access to PBS
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/grantDoc", `{"accessUser":"bernard", "accessChannel":"PBS"}`)
+	RequireStatus(t, response, 201)
+
+	caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
+
+	// Start a regular one-shot pull
+	err = client.StartOneshotPull()
+	assert.NoError(t, err)
+
+	// Wait for the one-shot changes feed to go into wait mode before releasing the slow sequence
+	require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+1))
+
+	// Release the slow sequence
+	releaseErr := db.ReleaseTestSequence(database, slowSequence)
+	require.NoError(t, releaseErr)
+
+	// The one-shot pull should unblock and replicate the document in the granted channel
+	data, ok := client.WaitForDoc("pbs-1")
+	assert.True(t, ok)
+	assert.Equal(t, `{"channel":["PBS"]}`, string(data))
+
+}

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -37,6 +37,12 @@ const kDefaultTimeoutMS = 5 * 60 * 1000
 // Maximum value of _changes?timeout property
 const kMaxTimeoutMS = 15 * 60 * 1000
 
+// Values for feed parameter on changes request
+const feedTypeContinuous = "continuous"
+const feedTypeLongpoll = "longpoll"
+const feedTypeNormal = "normal"
+const feedTypeWebsocket = "websocket"
+
 func (h *handler) handleRevsDiff() error {
 	var input map[string][]string
 	err := h.readJSONInto(&input)
@@ -180,6 +186,16 @@ func (h *handler) handleChanges() error {
 		options.ActiveOnly = h.getBoolQuery("active_only")
 		options.IncludeDocs = h.getBoolQuery("include_docs")
 		options.Revocations = h.getBoolQuery("revocations")
+
+		useRequestPlus, _ := h.getOptBoolQuery("request_plus", h.db.Options.ChangesRequestPlus)
+		if useRequestPlus && feed != feedTypeContinuous {
+			var seqErr error
+			options.RequestPlusSeq, seqErr = h.db.GetRequestPlusSequence()
+			if seqErr != nil {
+				return base.HTTPErrorf(http.StatusServiceUnavailable, "Unable to retrieve requestPlus sequence")
+			}
+
+		}
 		filter = h.getQuery("filter")
 		channelsParam := h.getQuery("channels")
 		if channelsParam != "" {
@@ -303,18 +319,18 @@ func (h *handler) handleChanges() error {
 	var err error
 
 	switch feed {
-	case "normal":
+	case feedTypeNormal:
 		if filter == "_doc_ids" {
 			err, forceClose = h.sendSimpleChanges(userChannels, options, docIdsArray)
 		} else {
 			err, forceClose = h.sendSimpleChanges(userChannels, options, nil)
 		}
-	case "longpoll":
+	case feedTypeLongpoll:
 		options.Wait = true
 		err, forceClose = h.sendSimpleChanges(userChannels, options, nil)
-	case "continuous":
+	case feedTypeContinuous:
 		err, forceClose = h.sendContinuousChangesByHTTP(userChannels, options)
-	case "websocket":
+	case feedTypeWebsocket:
 		err, forceClose = h.sendContinuousChangesByWebSocket(userChannels, options)
 	default:
 		err = base.HTTPErrorf(http.StatusBadRequest, "Unknown feed type")
@@ -445,7 +461,7 @@ func (h *handler) generateContinuousChanges(inChannels base.Set, options db.Chan
 	options.Continuous = true
 	err, forceClose := db.GenerateChanges(h.ctx(), h.rq.Context(), h.collection, inChannels, options, nil, send)
 	if sendErr, ok := err.(*db.ChangesSendErr); ok {
-		h.logStatus(http.StatusOK, fmt.Sprintf("0Write error: %v", sendErr))
+		h.logStatus(http.StatusOK, fmt.Sprintf("Write error: %v", sendErr))
 		return nil, forceClose // error is probably because the client closed the connection
 	} else {
 		h.logStatus(http.StatusOK, "OK (continuous feed closed)")
@@ -571,7 +587,8 @@ func (h *handler) readChangesOptionsFromJSON(jsonData []byte) (feed string, opti
 		HeartbeatMs    *uint64       `json:"heartbeat"`
 		TimeoutMs      *uint64       `json:"timeout"`
 		AcceptEncoding string        `json:"accept_encoding"`
-		ActiveOnly     bool          `json:"active_only"` // Return active revisions only
+		ActiveOnly     bool          `json:"active_only"`  // Return active revisions only
+		RequestPlus    *bool         `json:"request_plus"` // Wait for sequence buffering to catch up to database seq value at time request was issued
 	}
 
 	// Initialize since clock and hasher ahead of unmarshalling sequence
@@ -615,6 +632,20 @@ func (h *handler) readChangesOptionsFromJSON(jsonData []byte) (feed string, opti
 
 	compress = (input.AcceptEncoding == "gzip")
 
+	if h.db != nil && feed != feedTypeContinuous {
+		useRequestPlus := h.db.Options.ChangesRequestPlus
+		if input.RequestPlus != nil {
+			useRequestPlus = *input.RequestPlus
+		}
+		if useRequestPlus {
+			var seqErr error
+			options.RequestPlusSeq, seqErr = h.db.GetRequestPlusSequence()
+			if seqErr != nil {
+				err = base.HTTPErrorf(http.StatusServiceUnavailable, "Unable to retrieve requestPlus sequence: %v", seqErr)
+				return
+			}
+		}
+	}
 	return
 }
 

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -4050,11 +4050,6 @@ func TestOneShotGrantRequestPlus(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-4", `{"channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
 
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
-
 	// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
 	slowSequence, seqErr := db.AllocateTestSequence(database)
 	require.NoError(t, seqErr)
@@ -4070,9 +4065,10 @@ func TestOneShotGrantRequestPlus(t *testing.T) {
 	oneShotComplete.Add(1)
 	go func() {
 		defer oneShotComplete.Done()
+		var changes rest.ChangesResults
 		changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?request_plus=true", "", "bernard")
 		rest.RequireStatus(t, changesResponse, 200)
-		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+		err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 		assert.NoError(t, err, "Error unmarshalling changes response")
 		for _, entry := range changes.Results {
 			log.Printf("Entry:%+v", entry)
@@ -4084,6 +4080,7 @@ func TestOneShotGrantRequestPlus(t *testing.T) {
 	oneShotComplete.Add(1)
 	go func() {
 		defer oneShotComplete.Done()
+		var changes rest.ChangesResults
 		changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", `{"request_plus":true}`, "bernard")
 		rest.RequireStatus(t, changesResponse, 200)
 		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
@@ -4147,11 +4144,6 @@ func TestOneShotGrantRequestPlusDbConfig(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-4", `{"channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
 
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
-
 	// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
 	slowSequence, seqErr := db.AllocateTestSequence(database)
 	require.NoError(t, seqErr)
@@ -4165,6 +4157,7 @@ func TestOneShotGrantRequestPlusDbConfig(t *testing.T) {
 	// Expect no results as granting document hasn't been buffered (blocked by slowSequence)
 	changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?request_plus=false", "", "bernard")
 	rest.RequireStatus(t, changesResponse, 200)
+	var changes rest.ChangesResults
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	for _, entry := range changes.Results {
@@ -4190,9 +4183,10 @@ func TestOneShotGrantRequestPlusDbConfig(t *testing.T) {
 	oneShotComplete.Add(1)
 	go func() {
 		defer oneShotComplete.Done()
+		var changes rest.ChangesResults
 		changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
 		rest.RequireStatus(t, changesResponse, 200)
-		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+		err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 		assert.NoError(t, err, "Error unmarshalling changes response")
 		for _, entry := range changes.Results {
 			log.Printf("Entry:%+v", entry)
@@ -4204,9 +4198,10 @@ func TestOneShotGrantRequestPlusDbConfig(t *testing.T) {
 	oneShotComplete.Add(1)
 	go func() {
 		defer oneShotComplete.Done()
+		var changes rest.ChangesResults
 		changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", `{}`, "bernard")
 		rest.RequireStatus(t, changesResponse, 200)
-		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+		err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 		assert.NoError(t, err, "Error unmarshalling changes response")
 		for _, entry := range changes.Results {
 			log.Printf("Entry:%+v", entry)

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -3934,6 +3934,297 @@ func TestTombstoneCompaction(t *testing.T) {
 	TestCompact(db.QueryTombstoneBatch + 20)
 }
 
+// TestOneShotGrantTiming simulates a one-shot changes feed returning before a previously issued grant has been
+// buffered over DCP.
+func TestOneShotGrantTiming(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges, base.KeyHTTP)
+
+	defer db.SuspendSequenceBatching()()
+
+	rt := rest.NewRestTester(t,
+		&rest.RestTesterConfig{
+			SyncFn: `function(doc) {
+				channel(doc.channel);
+				if (doc.accessUser != "") {
+					access(doc.accessUser, doc.accessChannel)
+				}
+			}`,
+		})
+	defer rt.Close()
+
+	// Create user with access to no channels
+	ctx := rt.Context()
+	database := rt.GetDatabase()
+	a := database.Authenticator(ctx)
+	bernard, err := a.NewUser("bernard", "letmein", nil)
+	assert.NoError(t, err)
+	assert.NoError(t, a.Save(bernard))
+
+	// Put several documents in channel PBS
+	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-1", `{"channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-2", `{"channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-3", `{"channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-4", `{"channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+
+	var changes struct {
+		Results  []db.ChangeEntry
+		Last_Seq interface{}
+	}
+
+	// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
+	slowSequence, seqErr := db.AllocateTestSequence(database)
+	require.NoError(t, seqErr)
+	log.Printf("Allocated slowSequence: %v", slowSequence)
+
+	// Write a document granting user access to PBS
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/grantDoc", `{"accessUser":"bernard", "accessChannel":"PBS"}`)
+	rest.RequireStatus(t, response, 201)
+
+	// Issue normal one-shot changes request.  Expect no results as granting document hasn't been buffered (blocked by
+	// slowSequence)
+	changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
+	rest.RequireStatus(t, changesResponse, 200)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	for _, entry := range changes.Results {
+		log.Printf("Entry:%+v", entry)
+	}
+	require.Len(t, changes.Results, 0)
+
+	// Release the slow sequence and wait for it to be processed over DCP
+	releaseErr := db.ReleaseTestSequence(database, slowSequence)
+	require.NoError(t, releaseErr)
+	require.NoError(t, rt.WaitForPendingChanges())
+
+	// Issue normal one-shot changes request.  Expect results as granting document buffering is unblocked
+	changesResponse = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
+	rest.RequireStatus(t, changesResponse, 200)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	for _, entry := range changes.Results {
+		log.Printf("Entry:%+v", entry)
+	}
+	require.Len(t, changes.Results, 4)
+
+}
+
+// TestOneShotGrantRequestPlus simulates a one-shot changes feed being made before a previously issued grant has been
+// buffered over DCP.  When requestPlus is set, changes feed should block until grant is processed.
+func TestOneShotGrantRequestPlus(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges, base.KeyHTTP)
+
+	defer db.SuspendSequenceBatching()() // Required for slow sequence simulation
+
+	rt := rest.NewRestTester(t,
+		&rest.RestTesterConfig{
+			SyncFn: `function(doc) {
+				channel(doc.channel);
+				if (doc.accessUser != "") {
+					access(doc.accessUser, doc.accessChannel)
+				}
+			}`,
+		})
+	defer rt.Close()
+
+	// Create user with access to no channels
+	ctx := rt.Context()
+	database := rt.GetDatabase()
+	a := database.Authenticator(ctx)
+	bernard, err := a.NewUser("bernard", "letmein", nil)
+	assert.NoError(t, err)
+	assert.NoError(t, a.Save(bernard))
+
+	// Put several documents in channel PBS
+	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-1", `{"channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-2", `{"channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-3", `{"channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-4", `{"channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+
+	var changes struct {
+		Results  []db.ChangeEntry
+		Last_Seq interface{}
+	}
+
+	// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
+	slowSequence, seqErr := db.AllocateTestSequence(database)
+	require.NoError(t, seqErr)
+
+	// Write a document granting user access to PBS
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/grantDoc", `{"accessUser":"bernard", "accessChannel":"PBS"}`)
+	rest.RequireStatus(t, response, 201)
+
+	caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
+
+	var oneShotComplete sync.WaitGroup
+	// Issue a GET requestPlus one-shot changes request in a separate goroutine.
+	oneShotComplete.Add(1)
+	go func() {
+		defer oneShotComplete.Done()
+		changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?request_plus=true", "", "bernard")
+		rest.RequireStatus(t, changesResponse, 200)
+		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+		assert.NoError(t, err, "Error unmarshalling changes response")
+		for _, entry := range changes.Results {
+			log.Printf("Entry:%+v", entry)
+		}
+		require.Len(t, changes.Results, 4)
+	}()
+
+	// Issue a POST requestPlus one-shot changes request in a separate goroutine.
+	oneShotComplete.Add(1)
+	go func() {
+		defer oneShotComplete.Done()
+		changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", `{"request_plus":true}`, "bernard")
+		rest.RequireStatus(t, changesResponse, 200)
+		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+		assert.NoError(t, err, "Error unmarshalling changes response")
+		for _, entry := range changes.Results {
+			log.Printf("Entry:%+v", entry)
+		}
+		require.Len(t, changes.Results, 4)
+	}()
+
+	// Wait for the one-shot changes feed to go into wait mode before releasing the slow sequence
+	require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+2))
+
+	// Release the slow sequence and wait for it to be processed over DCP
+	releaseErr := db.ReleaseTestSequence(database, slowSequence)
+	require.NoError(t, releaseErr)
+	require.NoError(t, rt.WaitForPendingChanges())
+
+	oneShotComplete.Wait()
+}
+
+// TestOneShotGrantRequestPlusDbConfig simulates a one-shot changes feed being made before a previously issued grant has been
+// buffered over DCP.  When requestPlus is set via config, changes feed should block until grant is processed.
+func TestOneShotGrantRequestPlusDbConfig(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges, base.KeyHTTP)
+
+	defer db.SuspendSequenceBatching()()
+
+	rt := rest.NewRestTester(t,
+		&rest.RestTesterConfig{
+			SyncFn: `function(doc) {
+				channel(doc.channel);
+				if (doc.accessUser != "") {
+					access(doc.accessUser, doc.accessChannel)
+				}
+			}`,
+			DatabaseConfig: &rest.DatabaseConfig{
+				DbConfig: rest.DbConfig{
+					ChangesRequestPlus: base.BoolPtr(true),
+				},
+			},
+		})
+	defer rt.Close()
+
+	// Create user with access to no channels
+	ctx := rt.Context()
+	database := rt.GetDatabase()
+	a := database.Authenticator(ctx)
+	bernard, err := a.NewUser("bernard", "letmein", nil)
+	assert.NoError(t, err)
+	assert.NoError(t, a.Save(bernard))
+
+	// Put several documents in channel PBS
+	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-1", `{"channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-2", `{"channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-3", `{"channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-4", `{"channel":["PBS"]}`)
+	rest.RequireStatus(t, response, 201)
+
+	var changes struct {
+		Results  []db.ChangeEntry
+		Last_Seq interface{}
+	}
+
+	// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
+	slowSequence, seqErr := db.AllocateTestSequence(database)
+	require.NoError(t, seqErr)
+	log.Printf("Allocated slowSequence: %v", slowSequence)
+
+	// Write a document granting user access to PBS
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/grantDoc", `{"accessUser":"bernard", "accessChannel":"PBS"}`)
+	rest.RequireStatus(t, response, 201)
+
+	// Issue one-shot GET changes request explicitly setting request_plus=false (should override config value).
+	// Expect no results as granting document hasn't been buffered (blocked by slowSequence)
+	changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?request_plus=false", "", "bernard")
+	rest.RequireStatus(t, changesResponse, 200)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	for _, entry := range changes.Results {
+		log.Printf("Entry:%+v", entry)
+	}
+	require.Len(t, changes.Results, 0)
+
+	// Issue one-shot POST changes request explicitly setting request_plus=false (should override config value).
+	// Expect no results as granting document hasn't been buffered (blocked by slowSequence)
+	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", `{"request_plus":false}`, "bernard")
+	rest.RequireStatus(t, changesResponse, 200)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	for _, entry := range changes.Results {
+		log.Printf("Entry:%+v", entry)
+	}
+	require.Len(t, changes.Results, 0)
+
+	caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
+
+	var oneShotComplete sync.WaitGroup
+	// Issue a GET one-shot changes request in a separate goroutine.  Should run as request plus based on config
+	oneShotComplete.Add(1)
+	go func() {
+		defer oneShotComplete.Done()
+		changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
+		rest.RequireStatus(t, changesResponse, 200)
+		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+		assert.NoError(t, err, "Error unmarshalling changes response")
+		for _, entry := range changes.Results {
+			log.Printf("Entry:%+v", entry)
+		}
+		require.Len(t, changes.Results, 4)
+	}()
+
+	// Issue a POST one-shot changes request in a separate goroutine. Should run as request plus based on config
+	oneShotComplete.Add(1)
+	go func() {
+		defer oneShotComplete.Done()
+		changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", `{}`, "bernard")
+		rest.RequireStatus(t, changesResponse, 200)
+		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+		assert.NoError(t, err, "Error unmarshalling changes response")
+		for _, entry := range changes.Results {
+			log.Printf("Entry:%+v", entry)
+		}
+		require.Len(t, changes.Results, 4)
+	}()
+
+	// Wait for the one-shot changes feed to go into wait mode before releasing the slow sequence
+	require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+2))
+
+	// Release the slow sequence and wait for it to be processed over DCP
+	releaseErr := db.ReleaseTestSequence(database, slowSequence)
+	require.NoError(t, releaseErr)
+	require.NoError(t, rt.WaitForPendingChanges())
+
+	oneShotComplete.Wait()
+}
+
 func waitForCompactStopped(dbc *db.DatabaseContext) error {
 	for i := 0; i < 100; i++ {
 		compactRunning := dbc.CacheCompactActive()

--- a/rest/config.go
+++ b/rest/config.go
@@ -165,6 +165,7 @@ type DbConfig struct {
 	GraphQL                          *functions.GraphQLConfig         `json:"graphql,omitempty"`                              // GraphQL configuration & resolver fns
 	UserFunctions                    *functions.FunctionsConfig       `json:"functions,omitempty"`                            // Named JS fns for clients to call
 	Suspendable                      *bool                            `json:"suspendable,omitempty"`                          // Allow the database to be suspended
+	ChangesRequestPlus               *bool                            `json:"changes_request_plus,omitempty"`                 // If set, is used as the default value of request_plus for non-continuous replications
 	CORS                             *auth.CORSConfig                 `json:"cors,omitempty"`
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1062,6 +1062,7 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		GroupID:                   groupID,
 		JavascriptTimeout:         javascriptTimeout,
 		Serverless:                sc.Config.IsServerless(),
+		ChangesRequestPlus:        base.BoolDefault(config.ChangesRequestPlus, false),
 		// UserQueries:               config.UserQueries,   // behind feature flag (see below)
 		// UserFunctions:             config.UserFunctions, // behind feature flag (see below)
 		// GraphQL:                   config.GraphQL,       // behind feature flag (see below)


### PR DESCRIPTION
CBG-3031

Backport of the new feature to allow chnages feed to wait for DCP mutations to arrive before continuing with one shot replication. Cherry pick of both the main feature PR and the follow up fix for a race condition in the test. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1843/
