### PR TITLE
CBG-3042: [3.1.1] attachment compaction code erroneously sets failOnRollback

### DIFF
--- a/base/dcp_client_metadata.go
+++ b/base/dcp_client_metadata.go
@@ -62,6 +62,9 @@ type DCPMetadataStore interface {
 	// Purge removes all metadata associated with the metadata store from the bucket.  It does not remove the
 	// in-memory metadata.
 	Purge(numWorkers int)
+
+	// GetKeyPrefix will retrieve the key prefix used for metadata persistence
+	GetKeyPrefix() string
 }
 
 type dcpMetadataBase struct {
@@ -153,6 +156,10 @@ func (md *DCPMetadataMem) Persist(workerID int, vbIDs []uint16) {
 // Purge is no-op for in-memory metadata store
 func (md *DCPMetadataMem) Purge(numWorkers int) {
 	return
+}
+
+func (md *DCPMetadataMem) GetKeyPrefix() string {
+	return ""
 }
 
 // Reset sets metadata sequences to zero, but maintains vbucket UUID and failover entries.  Used for scenarios
@@ -259,6 +266,10 @@ func (m *DCPMetadataCS) Purge(numWorkers int) {
 			InfofCtx(context.TODO(), KeyDCP, "Unable to remove DCP checkpoint for key %s: %v", m.getMetadataKey(i), err)
 		}
 	}
+}
+
+func (m *DCPMetadataCS) GetKeyPrefix() string {
+	return m.keyPrefix
 }
 
 func (m *DCPMetadataCS) getMetadataKey(workerID int) string {

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -341,7 +341,7 @@ func TestContinuousDCPRollback(t *testing.T) {
 	counterCallback := func(event sgbucket.FeedEvent) bool {
 		if bytes.HasPrefix(event.Key, []byte(t.Name())) {
 			atomic.AddUint64(&mutationCount, 1)
-			if atomic.LoadUint64(&mutationCount) == uint64(1000) {
+			if atomic.LoadUint64(&mutationCount) == uint64(10000) {
 				c <- true
 			}
 		}
@@ -374,14 +374,11 @@ func TestContinuousDCPRollback(t *testing.T) {
 	dcpClient, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, gocbv2Bucket)
 	require.NoError(t, err)
 
-	// function to force the rollback of some vBuckets
-	dcpClient.forceRollbackvBucket(vbUUID)
-
 	_, startErr := dcpClient.Start()
 	require.NoError(t, startErr)
 
 	// Add documents
-	const numDocs = 1000
+	const numDocs = 10000
 	updatedBody := map[string]interface{}{"foo": "bar"}
 	for i := 0; i < numDocs; i++ {
 		key := fmt.Sprintf("%s_%d", t.Name(), i)
@@ -393,17 +390,38 @@ func TestContinuousDCPRollback(t *testing.T) {
 	select {
 	case <-c:
 		mutationCount := atomic.LoadUint64(&mutationCount)
-		require.Equal(t, uint64(1000), mutationCount)
+		require.Equal(t, uint64(10000), mutationCount)
 	case <-timeout:
 		t.Fatalf("timeout on client reached")
 	}
 
+	// new dcp client to simulate a rollback
+	dcpClientOpts = DCPClientOptions{
+		InitialMetadata:   dcpClient.GetMetadata(),
+		FailOnRollback:    false,
+		OneShot:           false,
+		CollectionIDs:     collectionIDs,
+		CheckpointPrefix:  DefaultMetadataKeys.DCPCheckpointPrefix(t.Name()),
+		MetadataStoreType: DCPMetadataStoreInMemory,
+	}
+	require.NoError(t, dcpClient.Close())
+
+	dcpClient1, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, gocbv2Bucket)
+	require.NoError(t, err)
+	// function to force the rollback of some vBuckets
+	dcpClient1.forceRollbackvBucket(vbUUID)
+
+	_, startErr = dcpClient1.Start()
+	require.NoError(t, startErr)
+
 	// Assert that the number of vBuckets active are the same as the total number of vBuckets on the client.
 	// In continuous rollback the streams should not close after they're finished.
-	numVBuckets := len(dcpClient.activeVbuckets)
-	require.Equal(t, dcpClient.numVbuckets, uint16(numVBuckets))
+	numVBuckets := len(dcpClient1.activeVbuckets)
+	require.Equal(t, dcpClient1.numVbuckets, uint16(numVBuckets))
 
-	require.NoError(t, dcpClient.Close())
+	defer func() {
+		assert.NoError(t, dcpClient1.Close())
+	}()
 
 }
 
@@ -412,13 +430,12 @@ func TestContinuousDCPRollback(t *testing.T) {
 func (dc *DCPClient) forceRollbackvBucket(uuid gocbcore.VbUUID) {
 	metadata := make([]DCPMetadata, dc.numVbuckets)
 	for i := uint16(0); i < dc.numVbuckets; i++ {
+		// rollback roughly half the vBuckets
 		if i%2 == 0 {
 			metadata[i] = dc.metadata.GetMeta(i)
 			metadata[i].VbUUID = uuid
-		} else {
-			metadata[i] = dc.metadata.GetMeta(i)
+			dc.metadata.SetMeta(i, metadata[i])
 		}
-		dc.metadata.SetMeta(i, metadata[i])
 	}
 }
 

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -29,7 +29,7 @@ const (
 	CleanupPhase    = "cleanup"
 )
 
-func attachmentCompactMarkPhase(ctx context.Context, dataStore base.DataStore, collectionID uint32, db *Database, compactionID string, terminator *base.SafeTerminator, markedAttachmentCount *base.AtomicInt) (count int64, vbUUIDs []uint64, err error) {
+func attachmentCompactMarkPhase(ctx context.Context, dataStore base.DataStore, collectionID uint32, db *Database, compactionID string, terminator *base.SafeTerminator, markedAttachmentCount *base.AtomicInt) (count int64, vbUUIDs []uint64, checkpointPrefix string, err error) {
 	base.InfofCtx(ctx, base.KeyAll, "Starting first phase of attachment compaction (mark phase) with compactionID: %q", compactionID)
 	compactionLoggingID := "Compaction Mark: " + compactionID
 
@@ -131,32 +131,30 @@ func attachmentCompactMarkPhase(ctx context.Context, dataStore base.DataStore, c
 
 	clientOptions, err := getCompactionDCPClientOptions(collectionID, db.Options.GroupID, db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID))
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, "", err
 	}
 
 	base.InfofCtx(ctx, base.KeyAll, "[%s] Starting DCP feed for mark phase of attachment compaction", compactionLoggingID)
 
-	dcpFeedKey := generateCompactionDCPStreamName(compactionID, MarkPhase)
-	if err != nil {
-		return 0, nil, err
-	}
+	dcpFeedKey := GenerateCompactionDCPStreamName(compactionID, MarkPhase)
 
 	bucket, err := base.AsGocbV2Bucket(db.Bucket)
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, "", err
 	}
 
 	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, *clientOptions, bucket)
 	if err != nil {
 		base.WarnfCtx(ctx, "[%s] Failed to create attachment compaction DCP client! %v", compactionLoggingID, err)
-		return 0, nil, err
+		return 0, nil, "", err
 	}
+	metadataKeyPrefix := dcpClient.GetMetadataKeyPrefix()
 
 	doneChan, err := dcpClient.Start()
 	if err != nil {
 		base.WarnfCtx(ctx, "[%s] Failed to start attachment compaction DCP feed! %v", compactionLoggingID, err)
 		_ = dcpClient.Close()
-		return 0, nil, err
+		return 0, nil, metadataKeyPrefix, err
 	}
 	base.DebugfCtx(ctx, base.KeyAll, "[%s] DCP feed started.", compactionLoggingID)
 
@@ -165,27 +163,27 @@ func attachmentCompactMarkPhase(ctx context.Context, dataStore base.DataStore, c
 		base.InfofCtx(ctx, base.KeyAll, "[%s] Mark phase of attachment compaction completed. Marked %d attachments", compactionLoggingID, markedAttachmentCount.Value())
 		err = dcpClient.Close()
 		if markProcessFailureErr != nil {
-			return markedAttachmentCount.Value(), nil, markProcessFailureErr
+			return markedAttachmentCount.Value(), nil, metadataKeyPrefix, markProcessFailureErr
 		}
 	case <-terminator.Done():
 		base.DebugfCtx(ctx, base.KeyAll, "[%s] Terminator closed. Stopping mark phase.", compactionLoggingID)
 		err = dcpClient.Close()
 		if markProcessFailureErr != nil {
-			return markedAttachmentCount.Value(), nil, markProcessFailureErr
+			return markedAttachmentCount.Value(), nil, metadataKeyPrefix, markProcessFailureErr
 		}
 		if err != nil {
-			return markedAttachmentCount.Value(), base.GetVBUUIDs(dcpClient.GetMetadata()), err
+			return markedAttachmentCount.Value(), base.GetVBUUIDs(dcpClient.GetMetadata()), metadataKeyPrefix, err
 		}
 
 		err = <-doneChan
 		if err != nil {
-			return markedAttachmentCount.Value(), base.GetVBUUIDs(dcpClient.GetMetadata()), err
+			return markedAttachmentCount.Value(), base.GetVBUUIDs(dcpClient.GetMetadata()), metadataKeyPrefix, err
 		}
 
 		base.InfofCtx(ctx, base.KeyAll, "[%s] Mark phase of attachment compaction was terminated. Marked %d attachments", compactionLoggingID, markedAttachmentCount.Value())
 	}
 
-	return markedAttachmentCount.Value(), base.GetVBUUIDs(dcpClient.GetMetadata()), err
+	return markedAttachmentCount.Value(), base.GetVBUUIDs(dcpClient.GetMetadata()), metadataKeyPrefix, err
 }
 
 // AttachmentsMetaMap struct is a very minimal struct to unmarshal into when getting attachments from bodies
@@ -363,7 +361,7 @@ func attachmentCompactSweepPhase(ctx context.Context, dataStore base.DataStore, 
 	}
 	clientOptions.InitialMetadata = base.BuildDCPMetadataSliceFromVBUUIDs(vbUUIDs)
 
-	dcpFeedKey := generateCompactionDCPStreamName(compactionID, SweepPhase)
+	dcpFeedKey := GenerateCompactionDCPStreamName(compactionID, SweepPhase)
 
 	bucket, err := base.AsGocbV2Bucket(db.Bucket)
 	if err != nil {
@@ -408,7 +406,7 @@ func attachmentCompactSweepPhase(ctx context.Context, dataStore base.DataStore, 
 	return purgedAttachmentCount.Value(), err
 }
 
-func attachmentCompactCleanupPhase(ctx context.Context, dataStore base.DataStore, collectionID uint32, db *Database, compactionID string, vbUUIDs []uint64, terminator *base.SafeTerminator) error {
+func attachmentCompactCleanupPhase(ctx context.Context, dataStore base.DataStore, collectionID uint32, db *Database, compactionID string, vbUUIDs []uint64, terminator *base.SafeTerminator) (string, error) {
 	base.InfofCtx(ctx, base.KeyAll, "Starting third phase of attachment compaction (cleanup phase) with compactionID: %q", compactionID)
 	compactionLoggingID := "Compaction Cleanup: " + compactionID
 
@@ -495,31 +493,32 @@ func attachmentCompactCleanupPhase(ctx context.Context, dataStore base.DataStore
 
 	clientOptions, err := getCompactionDCPClientOptions(collectionID, db.Options.GroupID, db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID))
 	if err != nil {
-		return err
+		return "", err
 	}
 	clientOptions.InitialMetadata = base.BuildDCPMetadataSliceFromVBUUIDs(vbUUIDs)
 
 	base.InfofCtx(ctx, base.KeyAll, "[%s] Starting DCP feed for cleanup phase of attachment compaction", compactionLoggingID)
 
-	dcpFeedKey := generateCompactionDCPStreamName(compactionID, CleanupPhase)
+	dcpFeedKey := GenerateCompactionDCPStreamName(compactionID, CleanupPhase)
 
 	bucket, err := base.AsGocbV2Bucket(db.Bucket)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, *clientOptions, bucket)
 	if err != nil {
 		base.WarnfCtx(ctx, "[%s] Failed to create attachment compaction DCP client! %v", compactionLoggingID, err)
-		return err
+		return "", err
 	}
+	metadataKeyPrefix := dcpClient.GetMetadataKeyPrefix()
 
 	doneChan, err := dcpClient.Start()
 	if err != nil {
 		base.WarnfCtx(ctx, "[%s] Failed to start attachment compaction DCP feed! %v", compactionLoggingID, err)
 		// simplify close in CBG-2234
 		_ = dcpClient.Close()
-		return err
+		return metadataKeyPrefix, err
 	}
 
 	select {
@@ -532,18 +531,18 @@ func attachmentCompactCleanupPhase(ctx context.Context, dataStore base.DataStore
 		err = dcpClient.Close()
 		if err != nil {
 			base.WarnfCtx(ctx, "[%s] Failed to close attachment compaction DCP client! %v", compactionLoggingID, err)
-			return err
+			return metadataKeyPrefix, err
 		}
 
 		err = <-doneChan
 		if err != nil {
-			return err
+			return metadataKeyPrefix, err
 		}
 
 		base.InfofCtx(ctx, base.KeyAll, "[%s] Cleanup phase of attachment compaction was terminated", compactionLoggingID)
 	}
 
-	return err
+	return metadataKeyPrefix, err
 }
 
 // getCompactionIDSubDocPath is just a tiny helper func that just concatenates the subdoc path we're using to store
@@ -566,7 +565,7 @@ func getCompactionDCPClientOptions(collectionID uint32, groupID string, prefix s
 
 }
 
-func generateCompactionDCPStreamName(compactionID, compactionAction string) string {
+func GenerateCompactionDCPStreamName(compactionID, compactionAction string) string {
 	return fmt.Sprintf(
 		"sg-%v:att_compaction:%v_%v",
 		base.ProductAPIVersion,

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/gocbcore/v10"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -60,7 +61,7 @@ func TestAttachmentMark(t *testing.T) {
 	attKeys = append(attKeys, createDocWithInBodyAttachment(t, ctx, "inBodyDoc", []byte(`{}`), "attForInBodyRef", []byte(`{"val": "inBodyAtt"}`), databaseCollection))
 
 	terminator := base.NewSafeTerminator()
-	attachmentsMarked, _, err := attachmentCompactMarkPhase(ctx, dataStore, collectionID, testDb, t.Name(), terminator, &base.AtomicInt{})
+	attachmentsMarked, _, _, err := attachmentCompactMarkPhase(ctx, dataStore, collectionID, testDb, t.Name(), terminator, &base.AtomicInt{})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(13), attachmentsMarked)
 
@@ -196,7 +197,7 @@ func TestAttachmentCleanup(t *testing.T) {
 	}
 
 	terminator := base.NewSafeTerminator()
-	err := attachmentCompactCleanupPhase(ctx, dataStore, collectionID, testDb, t.Name(), nil, terminator)
+	_, err := attachmentCompactCleanupPhase(ctx, dataStore, collectionID, testDb, t.Name(), nil, terminator)
 	assert.NoError(t, err)
 
 	for _, docID := range singleMarkedAttIDs {
@@ -230,6 +231,90 @@ func TestAttachmentCleanup(t *testing.T) {
 		assert.NotContains(t, xattr, t.Name())
 		assert.NotContains(t, xattr, "old")
 		assert.Contains(t, xattr, "recent")
+	}
+
+}
+
+func TestAttachmentCleanupRollback(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server since it requires DCP")
+	}
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+	dbcOptions := DatabaseContextOptions{
+		Scopes: GetScopesOptionsDefaultCollectionOnly(t),
+	}
+	testDb, ctx := SetupTestDBWithOptions(t, dbcOptions)
+	defer testDb.Close(ctx)
+
+	var garbageVBUUID gocbcore.VbUUID = 1234
+	collection := GetSingleDatabaseCollection(t, testDb.DatabaseContext)
+	dataStore := collection.dataStore
+	collectionID := collection.GetCollectionID()
+
+	makeMarkedDoc := func(docid string, compactID string) {
+		err := dataStore.SetRaw(docid, 0, nil, []byte("{}"))
+		assert.NoError(t, err)
+		_, err = dataStore.SetXattr(docid, getCompactionIDSubDocPath(compactID), []byte(strconv.Itoa(int(time.Now().Unix()))))
+		assert.NoError(t, err)
+	}
+
+	// create some marked attachments
+	singleMarkedAttIDs := make([]string, 0, 100)
+	for i := 0; i < 100; i++ {
+		docID := fmt.Sprintf("%s%s%d", base.AttPrefix, "marked", i)
+		makeMarkedDoc(docID, t.Name())
+		singleMarkedAttIDs = append(singleMarkedAttIDs, docID)
+	}
+
+	// assert there are marked attachments to clean up
+	for _, docID := range singleMarkedAttIDs {
+		var xattr map[string]interface{}
+		_, err := dataStore.GetXattr(docID, base.AttachmentCompactionXattrName, &xattr)
+		assert.NoError(t, err)
+	}
+
+	bucket, err := base.AsGocbV2Bucket(testDb.Bucket)
+	require.NoError(t, err)
+	dcpFeedKey := GenerateCompactionDCPStreamName(t.Name(), CleanupPhase)
+	clientOptions, err := getCompactionDCPClientOptions(collectionID, testDb.Options.GroupID, testDb.MetadataKeys.DCPCheckpointPrefix(testDb.Options.GroupID))
+	require.NoError(t, err)
+	dcpClient, err := base.NewDCPClient(dcpFeedKey, nil, *clientOptions, bucket)
+	require.NoError(t, err)
+
+	// alter dcp metadata to feed into the compaction manager
+	vbUUID := base.GetVBUUIDs(dcpClient.GetMetadata())
+	vbUUID[0] = uint64(garbageVBUUID)
+
+	metadataKeys := base.NewMetadataKeys(testDb.Options.MetadataID)
+	testDb.AttachmentCompactionManager = NewAttachmentCompactionManager(dataStore, metadataKeys)
+	manager := AttachmentCompactionManager{CompactID: t.Name(), Phase: CleanupPhase, VBUUIDs: vbUUID}
+	testDb.AttachmentCompactionManager.Process = &manager
+
+	terminator := base.NewSafeTerminator()
+	err = testDb.AttachmentCompactionManager.Process.Run(ctx, map[string]interface{}{"database": testDb}, testDb.AttachmentCompactionManager.UpdateStatusClusterAware, terminator)
+	require.NoError(t, err)
+
+	err = WaitForConditionWithOptions(func() bool {
+		var status AttachmentManagerResponse
+		rawStatus, err := testDb.AttachmentCompactionManager.GetStatus()
+		assert.NoError(t, err)
+		err = base.JSONUnmarshal(rawStatus, &status)
+		require.NoError(t, err)
+
+		if status.State == BackgroundProcessStateCompleted {
+			return true
+		}
+
+		return false
+	}, 100, 1000)
+	require.NoError(t, err)
+
+	// assert that the marked attachments have been "cleaned up"
+	for _, docID := range singleMarkedAttIDs {
+		var xattr map[string]interface{}
+		_, err := dataStore.GetXattr(docID, base.AttachmentCompactionXattrName, &xattr)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, base.ErrXattrNotFound))
 	}
 
 }
@@ -271,7 +356,7 @@ func TestAttachmentMarkAndSweepAndCleanup(t *testing.T) {
 	}
 
 	terminator := base.NewSafeTerminator()
-	attachmentsMarked, vbUUIDS, err := attachmentCompactMarkPhase(ctx, dataStore, collectionID, testDb, t.Name(), terminator, &base.AtomicInt{})
+	attachmentsMarked, vbUUIDS, _, err := attachmentCompactMarkPhase(ctx, dataStore, collectionID, testDb, t.Name(), terminator, &base.AtomicInt{})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(10), attachmentsMarked)
 
@@ -293,7 +378,7 @@ func TestAttachmentMarkAndSweepAndCleanup(t *testing.T) {
 		}
 	}
 
-	err = attachmentCompactCleanupPhase(ctx, dataStore, collectionID, testDb, t.Name(), vbUUIDS, terminator)
+	_, err = attachmentCompactCleanupPhase(ctx, dataStore, collectionID, testDb, t.Name(), vbUUIDS, terminator)
 	assert.NoError(t, err)
 
 	for _, attDocKey := range attKeys {
@@ -620,7 +705,7 @@ func TestAttachmentDifferentVBUUIDsBetweenPhases(t *testing.T) {
 
 	// Run mark phase as usual
 	terminator := base.NewSafeTerminator()
-	_, vbUUIDs, err := attachmentCompactMarkPhase(ctx, dataStore, collectionID, testDB, t.Name(), terminator, &base.AtomicInt{})
+	_, vbUUIDs, _, err := attachmentCompactMarkPhase(ctx, dataStore, collectionID, testDB, t.Name(), terminator, &base.AtomicInt{})
 	assert.NoError(t, err)
 
 	// Manually modify a vbUUID and ensure the Sweep phase errors
@@ -891,7 +976,7 @@ func TestAttachmentCompactIncorrectStat(t *testing.T) {
 	stat := &base.AtomicInt{}
 	count := int64(0)
 	go func() {
-		attachmentCount, _, err := attachmentCompactMarkPhase(ctx, dataStore, collectionID, testDb, "mark", terminator, stat)
+		attachmentCount, _, _, err := attachmentCompactMarkPhase(ctx, dataStore, collectionID, testDb, "mark", terminator, stat)
 		atomic.StoreInt64(&count, attachmentCount)
 		require.NoError(t, err)
 	}()

--- a/db/background_mgr_attachment_compaction.go
+++ b/db/background_mgr_attachment_compaction.go
@@ -10,9 +10,11 @@ package db
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
+	"github.com/couchbase/gocbcore/v10"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/google/uuid"
 )
@@ -100,6 +102,23 @@ func (a *AttachmentCompactionManager) Init(ctx context.Context, options map[stri
 	return newRunInit()
 }
 
+func (a *AttachmentCompactionManager) PurgeDCPMetadata(ctx context.Context, datastore base.DataStore, database *Database, metadataKeyPrefix string) error {
+
+	bucket, err := base.AsGocbV2Bucket(database.Bucket)
+	if err != nil {
+		return err
+	}
+	numVbuckets, err := bucket.GetMaxVbno()
+	if err != nil {
+		return err
+	}
+
+	metadata := base.NewDCPMetadataCS(datastore, numVbuckets, base.DefaultNumWorkers, metadataKeyPrefix)
+	base.InfofCtx(ctx, base.KeyDCP, "purging persisted dcp metadata for attachment compaction run %s", a.CompactID)
+	metadata.Purge(base.DefaultNumWorkers)
+	return nil
+}
+
 func (a *AttachmentCompactionManager) Run(ctx context.Context, options map[string]interface{}, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
 	database := options["database"].(*Database)
 
@@ -110,6 +129,7 @@ func (a *AttachmentCompactionManager) Run(ctx context.Context, options map[strin
 	// but we'll consider that a follow-up enhancement to point this compaction operation at arbitrary collections.
 	dataStore := database.Bucket.DefaultDataStore()
 	collectionID := base.DefaultCollectionID
+	var metadataKeyPrefix string
 
 	persistClusterStatus := func() {
 		err := persistClusterStatusCallback()
@@ -120,15 +140,29 @@ func (a *AttachmentCompactionManager) Run(ctx context.Context, options map[strin
 
 	defer persistClusterStatus()
 
+	var rollbackErr gocbcore.DCPRollbackError
+
 	// Need to check the current phase in the event we are resuming - No need to run mark again if we got as far as
 	// cleanup last time...
 	var err error
 	switch a.Phase {
 	case "mark", "":
 		a.SetPhase("mark")
-		persistClusterStatus()
-		_, a.VBUUIDs, err = attachmentCompactMarkPhase(ctx, dataStore, collectionID, database, a.CompactID, terminator, &a.MarkedAttachments)
+		worker := func() (shouldRetry bool, err error, value interface{}) {
+			persistClusterStatus()
+			_, a.VBUUIDs, metadataKeyPrefix, err = attachmentCompactMarkPhase(ctx, dataStore, collectionID, database, a.CompactID, terminator, &a.MarkedAttachments)
+			if err != nil {
+				shouldRetry, err = a.handleAttachmentCompactionRollbackError(ctx, options, dataStore, database, err, MarkPhase, metadataKeyPrefix)
+			}
+			return shouldRetry, err, nil
+		}
+		// retry loop for handling a rollback during mark phase of compaction process
+		err, _ = base.RetryLoop("attachmentCompactMarkPhase", worker, base.CreateMaxDoublingSleeperFunc(25, 100, 10000))
 		if err != nil || terminator.IsClosed() {
+			if errors.As(err, &rollbackErr) || errors.Is(err, base.ErrVbUUIDMismatch) {
+				// log warning to show we hit max number of retries
+				base.WarnfCtx(ctx, "maximum retry attempts reached on mark phase: %v", err)
+			}
 			return err
 		}
 		fallthrough
@@ -142,15 +176,57 @@ func (a *AttachmentCompactionManager) Run(ctx context.Context, options map[strin
 		fallthrough
 	case "cleanup":
 		a.SetPhase("cleanup")
-		persistClusterStatus()
-		err := attachmentCompactCleanupPhase(ctx, dataStore, collectionID, database, a.CompactID, a.VBUUIDs, terminator)
+		worker := func() (shouldRetry bool, err error, value interface{}) {
+			persistClusterStatus()
+			metadataKeyPrefix, err = attachmentCompactCleanupPhase(ctx, dataStore, collectionID, database, a.CompactID, a.VBUUIDs, terminator)
+			if err != nil {
+				shouldRetry, err = a.handleAttachmentCompactionRollbackError(ctx, options, dataStore, database, err, CleanupPhase, metadataKeyPrefix)
+			}
+			return shouldRetry, err, nil
+		}
+		// retry loop for handling a rollback during mark phase of compaction process
+		err, _ = base.RetryLoop("attachmentCompactCleanupPhase", worker, base.CreateMaxDoublingSleeperFunc(25, 100, 10000))
 		if err != nil || terminator.IsClosed() {
+			if errors.As(err, &rollbackErr) || errors.Is(err, base.ErrVbUUIDMismatch) {
+				// log warning to show we hit max number of retries
+				base.WarnfCtx(ctx, "maximum retry attempts reached on cleanup phase: %v", err)
+			}
 			return err
 		}
 	}
 
 	a.SetPhase("")
 	return nil
+}
+
+func (a *AttachmentCompactionManager) handleAttachmentCompactionRollbackError(ctx context.Context, options map[string]interface{}, dataStore base.DataStore, database *Database, err error, phase, keyPrefix string) (bool, error) {
+	var rollbackErr gocbcore.DCPRollbackError
+	if errors.As(err, &rollbackErr) || errors.Is(err, base.ErrVbUUIDMismatch) {
+		base.InfofCtx(ctx, base.KeyDCP, "rollback indicated on %s phase of attachment compaction, resetting the task", phase)
+		// to rollback any phase for attachment compaction we need to purge all persisted dcp metadata
+		err = a.PurgeDCPMetadata(ctx, dataStore, database, keyPrefix)
+		if err != nil {
+			base.WarnfCtx(ctx, "error occurred during purging of dcp metadata: %w", err)
+			return false, err
+		}
+		if phase == MarkPhase {
+			// initialise new compaction run as we want to start the phase mark again in event of rollback
+			err = a.Init(ctx, options, nil)
+			if err != nil {
+				base.WarnfCtx(ctx, "error on initialization of new run after rollback has been indicated, %w", err)
+				return false, err
+			}
+		} else {
+			// we only handle rollback for mark and cleanup so if we call here it will be for cleanup phase
+			// we need to clear the vbUUID's on the manager for cleanup phase otherwise we will end up in loop of constant rollback
+			// as these are used for the initial metadata on the client
+			a.VBUUIDs = nil
+		}
+		// we should try again if it is rollback error
+		return true, nil
+	}
+	// if error isn't rollback then assume it's not recoverable
+	return false, err
 }
 
 func (a *AttachmentCompactionManager) SetPhase(phase string) {


### PR DESCRIPTION
CBG-3042

Backport of recent work to allow handling of a rollback error on attachment compaction Mark and Cleanup phases.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1844/

^^ Known flakey test 