### PR TITLE
(3.0.8 backport) CBG-2855 Allow one-shot replications to wait for DCP to catch up on changes feed

### DIFF
--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -60,6 +60,7 @@ const (
 	SubChangesContinuous  = "continuous"
 	SubChangesBatch       = "batch"
 	SubChangesRevocations = "revocations"
+	SubChangesRequestPlus = "requestPlus"
 
 	// rev message properties
 	RevMessageId          = "id"
@@ -197,6 +198,14 @@ func (s *SubChangesParams) revocations() bool {
 
 func (s *SubChangesParams) activeOnly() bool {
 	return (s.rq.Properties[SubChangesActiveOnly] == "true")
+}
+
+func (s *SubChangesParams) requestPlus(defaultValue bool) (value bool) {
+	propertyValue, isDefined := s.rq.Properties[SubChangesRequestPlus]
+	if !isDefined {
+		return defaultValue
+	}
+	return propertyValue == "true"
 }
 
 func (s *SubChangesParams) filter() string {

--- a/db/changes.go
+++ b/db/changes.go
@@ -627,8 +627,6 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 		var userChanged bool                // Whether the user document has changed in a given iteration loop
 		var deferredBackfill bool           // Whether there's a backfill identified in the user doc that's deferred while the SG cache catches up
 
-		// Retrieve the current max cached sequence - ensures there isn't a race between the subsequent channel cache queries
-		currentCachedSequence = db.changeCache.getChannelCache().GetHighCacheSequence()
 		var useLateSequenceFeeds bool // LateSequence feeds are only used for continuous, or one-shot where options.RequestPlusSeq > currentCachedSequence
 		// Retrieve the current max cached sequence - ensures there isn't a race between the subsequent channel cache queries
 		currentCachedSequence = db.changeCache.getChannelCache().GetHighCacheSequence()
@@ -986,7 +984,6 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 					break waitForChanges
 				}
 
-				db.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Add(1)
 				db.DbStats.CBLReplicationPull().NumPullReplCaughtUp.Add(1)
 				waitResponse := changeWaiter.Wait()
 				db.DbStats.CBLReplicationPull().NumPullReplCaughtUp.Add(-1)

--- a/db/changes.go
+++ b/db/changes.go
@@ -26,19 +26,20 @@ import (
 // Options for changes-feeds.  ChangesOptions must not contain any mutable pointer references, as
 // changes processing currently assumes a deep copy when doing chanOpts := changesOptions.
 type ChangesOptions struct {
-	Since       SequenceID      // sequence # to start _after_
-	Limit       int             // Max number of changes to return, if nonzero
-	Conflicts   bool            // Show all conflicting revision IDs, not just winning one?
-	IncludeDocs bool            // Include doc body of each change?
-	Wait        bool            // Wait for results, instead of immediately returning empty result?
-	Continuous  bool            // Run continuously until terminated?
-	Terminator  chan bool       // Caller can close this channel to terminate the feed
-	HeartbeatMs uint64          // How often to send a heartbeat to the client
-	TimeoutMs   uint64          // After this amount of time, close the longpoll connection
-	ActiveOnly  bool            // If true, only return information on non-deleted, non-removed revisions
-	Revocations bool            // Specifies whether revocation messages should be sent on the changes feed
-	clientType  clientType      // Can be used to determine if the replication is being started from a CBL 2.x or SGR2 client
-	Ctx         context.Context // Used for adding context to logs
+	Since          SequenceID      // sequence # to start _after_
+	Limit          int             // Max number of changes to return, if nonzero
+	Conflicts      bool            // Show all conflicting revision IDs, not just winning one?
+	IncludeDocs    bool            // Include doc body of each change?
+	Wait           bool            // Wait for results, instead of immediately returning empty result?
+	Continuous     bool            // Run continuously until terminated?
+	Terminator     chan bool       // Caller can close this channel to terminate the feed
+	HeartbeatMs    uint64          // How often to send a heartbeat to the client
+	TimeoutMs      uint64          // After this amount of time, close the longpoll connection
+	ActiveOnly     bool            // If true, only return information on non-deleted, non-removed revisions
+	Revocations    bool            // Specifies whether revocation messages should be sent on the changes feed
+	clientType     clientType      // Can be used to determine if the replication is being started from a CBL 2.x or SGR2 client
+	Ctx            context.Context // Used for adding context to logs
+	RequestPlusSeq uint64          // Do not stop changes before cached sequence catches up with requestPlusSeq
 }
 
 // A changes entry; Database.GetChanges returns an array of these.
@@ -628,9 +629,13 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 
 		// Retrieve the current max cached sequence - ensures there isn't a race between the subsequent channel cache queries
 		currentCachedSequence = db.changeCache.getChannelCache().GetHighCacheSequence()
-		if options.Wait {
-			options.Wait = false
-			changeWaiter = db.startChangeWaiter(base.Set{}) // Waiter is updated with the actual channel set (post-user reload) at the start of the outer changes loop
+		var useLateSequenceFeeds bool // LateSequence feeds are only used for continuous, or one-shot where options.RequestPlusSeq > currentCachedSequence
+		// Retrieve the current max cached sequence - ensures there isn't a race between the subsequent channel cache queries
+		currentCachedSequence = db.changeCache.getChannelCache().GetHighCacheSequence()
+
+		// If changes feed requires more than one ChangesLoop iteration, initialize changeWaiter
+		if options.Wait || options.RequestPlusSeq > currentCachedSequence {
+			changeWaiter = db.startChangeWaiter(nil) // Waiter is updated with the actual channel set (post-user reload) at the start of the outer changes loop
 			userCounter = changeWaiter.CurrentUserCount()
 			// Reload user to pick up user changes that happened between auth and the change waiter
 			// initialization.  Without this, notification for user doc changes in that window (a) won't be
@@ -665,7 +670,8 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 
 		// For a continuous feed, initialise the lateSequenceFeeds that track late-arriving sequences
 		// to the channel caches.
-		if options.Continuous {
+		if options.Continuous || options.RequestPlusSeq > currentCachedSequence {
+			useLateSequenceFeeds = true
 			lateSequenceFeeds = make(map[string]*lateSequenceFeed)
 			defer db.closeLateFeeds(lateSequenceFeeds)
 		}
@@ -723,7 +729,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 				// Handles previously skipped sequences prior to options.Since that
 				// have arrived in the channel cache since this changes request started.  Only needed for
 				// continuous feeds - one-off changes requests only require the standard channel cache.
-				if options.Continuous {
+				if useLateSequenceFeeds {
 					lateSequenceFeedHandler := lateSequenceFeeds[name]
 					if lateSequenceFeedHandler != nil {
 						latefeed, err := db.getLateFeed(lateSequenceFeedHandler, singleChannelCache)
@@ -940,14 +946,18 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 				}
 			}
 
-			if !options.Continuous && (sentSomething || changeWaiter == nil) {
-				break
+			// Check whether non-continuous changes feeds that aren't waiting to reach requestPlus sequence can exit
+			if !options.Continuous && currentCachedSequence >= options.RequestPlusSeq {
+				// If non-longpoll, or longpoll has sent something, can exit
+				if !options.Wait || sentSomething {
+					break
+				}
 			}
 
 			// For longpoll requests that didn't send any results, reset low sequence to the original since value,
 			// as the system low sequence may change before the longpoll request wakes up, and longpoll feeds don't
 			// use lateSequenceFeeds.
-			if !options.Continuous {
+			if !useLateSequenceFeeds {
 				options.Since.LowSeq = requestLowSeq
 			}
 
@@ -964,6 +974,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 
 		waitForChanges:
 			for {
+				db.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Add(1)
 				// If we're in a deferred Backfill, the user may not get notification when the cache catches up to the backfill (e.g. when the granting doc isn't
 				// visible to the user), and so ChangeWaiter.Wait() would block until the next user-visible doc arrives.  Use a hardcoded wait instead
 				// Similar handling for when we see sequences later than the stable sequence.
@@ -1288,7 +1299,7 @@ func createChangesEntry(docid string, db *Database, options ChangesOptions) *Cha
 
 func (options ChangesOptions) String() string {
 	return fmt.Sprintf(
-		`{Since: %s, Limit: %d, Conflicts: %t, IncludeDocs: %t, Wait: %t, Continuous: %t, HeartbeatMs: %d, TimeoutMs: %d, ActiveOnly: %t}`,
+		`{Since: %s, Limit: %d, Conflicts: %t, IncludeDocs: %t, Wait: %t, Continuous: %t, HeartbeatMs: %d, TimeoutMs: %d, ActiveOnly: %t, RequestPlusSeq: %d}`,
 		options.Since,
 		options.Limit,
 		options.Conflicts,
@@ -1298,6 +1309,7 @@ func (options ChangesOptions) String() string {
 		options.HeartbeatMs,
 		options.TimeoutMs,
 		options.ActiveOnly,
+		options.RequestPlusSeq,
 	)
 }
 

--- a/db/database.go
+++ b/db/database.go
@@ -150,6 +150,7 @@ type DatabaseContextOptions struct {
 	ClientPartitionWindow         time.Duration
 	BcryptCost                    int
 	GroupID                       string
+	ChangesRequestPlus            bool // Sets the default value for request_plus, for non-continuous changes feeds
 }
 
 type SGReplicateOptions struct {
@@ -1710,4 +1711,11 @@ func (context *DatabaseContext) LastSequence() (uint64, error) {
 func (context *DatabaseContext) IsGuestReadOnly() bool {
 	return context.Options.UnsupportedOptions != nil && context.Options.UnsupportedOptions.GuestReadOnly
 
+}
+
+// GetRequestPlusSequence fetches the current value of the sequence counter for the database.
+// Uses getSequence (instead of lastSequence) as it's intended to be up to date with allocations
+// across all nodes, while lastSequence is just the latest allocation from this node
+func (dbc *DatabaseContext) GetRequestPlusSequence() (uint64, error) {
+	return dbc.sequences.getSequence()
 }

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2018-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package rest
+
+import (
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRequestPlusPull tests that a one-shot pull replication waits for pending changes when request plus is set on the replication.
+func TestRequestPlusPull(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyDCP, base.KeyChanges, base.KeyHTTP)()
+	defer db.SuspendSequenceBatching()() // Required for slow sequence simulation
+
+	rtConfig := RestTesterConfig{
+		SyncFn: `function(doc) {
+				channel(doc.channel);
+				if (doc.accessUser != "") {
+					access(doc.accessUser, doc.accessChannel)
+				}
+			}`,
+	}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+	database := rt.GetDatabase()
+
+	// Initialize blip tester client (will create user)
+	client, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+		Username: "bernard",
+	})
+	require.NoError(t, err)
+	defer client.Close()
+
+	// Put a doc in channel PBS
+	response := rt.SendAdminRequest("PUT", "/db/pbs-1", `{"channel":["PBS"]}`)
+	RequireStatus(t, response, 201)
+
+	// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
+	slowSequence, seqErr := db.AllocateTestSequence(database)
+	require.NoError(t, seqErr)
+
+	// Write a document granting user 'bernard' access to PBS
+	response = rt.SendAdminRequest("PUT", "/db/grantDoc", `{"accessUser":"bernard", "accessChannel":"PBS"}`)
+	RequireStatus(t, response, 201)
+
+	caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
+
+	// Start a regular one-shot pull
+	err = client.StartOneshotPullRequestPlus()
+	assert.NoError(t, err)
+
+	// Wait for the one-shot changes feed to go into wait mode before releasing the slow sequence
+	require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+1))
+
+	// Release the slow sequence
+	releaseErr := db.ReleaseTestSequence(database, slowSequence)
+	require.NoError(t, releaseErr)
+
+	// The one-shot pull should unblock and replicate the document in the granted channel
+	data, ok := client.WaitForDoc("pbs-1")
+	assert.True(t, ok)
+	assert.Equal(t, `{"channel":["PBS"]}`, string(data))
+
+}
+
+// TestRequestPlusPull tests that a one-shot pull replication waits for pending changes when request plus is set on the db config.
+func TestRequestPlusPullDbConfig(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyDCP, base.KeyChanges, base.KeyHTTP)()
+	defer db.SuspendSequenceBatching()() // Required for slow sequence simulation
+
+	rtConfig := RestTesterConfig{
+		SyncFn: `function(doc) {
+				channel(doc.channel);
+				if (doc.accessUser != "") {
+					access(doc.accessUser, doc.accessChannel)
+				}
+			}`,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				ChangesRequestPlus: base.BoolPtr(true),
+			},
+		},
+	}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+	database := rt.GetDatabase()
+
+	// Initialize blip tester client (will create user)
+	client, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+		Username: "bernard",
+	})
+	require.NoError(t, err)
+	defer client.Close()
+
+	// Put a doc in channel PBS
+	response := rt.SendAdminRequest("PUT", "/db/pbs-1", `{"channel":["PBS"]}`)
+	RequireStatus(t, response, 201)
+
+	// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
+	slowSequence, seqErr := db.AllocateTestSequence(database)
+	require.NoError(t, seqErr)
+
+	// Write a document granting user 'bernard' access to PBS
+	response = rt.SendAdminRequest("PUT", "/db/grantDoc", `{"accessUser":"bernard", "accessChannel":"PBS"}`)
+	RequireStatus(t, response, 201)
+
+	caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
+
+	// Start a regular one-shot pull
+	err = client.StartOneshotPull()
+	assert.NoError(t, err)
+
+	// Wait for the one-shot changes feed to go into wait mode before releasing the slow sequence
+	require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+1))
+
+	// Release the slow sequence
+	releaseErr := db.ReleaseTestSequence(database, slowSequence)
+	require.NoError(t, releaseErr)
+
+	// The one-shot pull should unblock and replicate the document in the granted channel
+	data, ok := client.WaitForDoc("pbs-1")
+	assert.True(t, ok)
+	assert.Equal(t, `{"channel":["PBS"]}`, string(data))
+
+}

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -2862,7 +2862,7 @@ func TestActiveOnlyContinuous(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &docResp))
 
 	// start an initial pull
-	require.NoError(t, btc.StartPullSince("true", "0", "true", ""))
+	require.NoError(t, btc.StartPullSince("true", "0", "true", "", ""))
 
 	rev, found := btc.WaitForRev("doc1", docResp.Rev)
 	assert.True(t, found)
@@ -3475,7 +3475,7 @@ func TestRevocationMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a pull since 5 to receive revocation and removal
-	err = btc.StartPullSince("false", "5", "false", "")
+	err = btc.StartPullSince("false", "5", "false", "", "")
 	assert.NoError(t, err)
 
 	// Wait for doc1 rev2 - This is the last rev we expect so we can be sure replication is complete here
@@ -3585,7 +3585,7 @@ func TestRevocationNoRev(t *testing.T) {
 	_, err = rt.WaitForChanges(3, "/db/_changes?since="+lastSeq, "user", true)
 	require.NoError(t, err)
 
-	err = btc.StartPullSince("false", lastSeq, "false", "")
+	err = btc.StartPullSince("false", lastSeq, "false", "", "")
 	assert.NoError(t, err)
 
 	_, ok = btc.WaitForRev("docmarker", waitRevID)

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -4169,6 +4169,7 @@ func TestOneShotGrantRequestPlusDbConfig(t *testing.T) {
 		defer oneShotComplete.Done()
 		changesResponse := rt.SendUserRequest("GET", "/db/_changes", "", "bernard")
 		RequireStatus(t, changesResponse, 200)
+		var changes changesResults
 		err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 		assert.NoError(t, err, "Error unmarshalling changes response")
 		for _, entry := range changes.Results {

--- a/rest/config.go
+++ b/rest/config.go
@@ -154,6 +154,7 @@ type DbConfig struct {
 	UserXattrKey                     string                           `json:"user_xattr_key,omitempty"`                       // Key of user xattr that will be accessible from the Sync Function. If empty the feature will be disabled.
 	ClientPartitionWindowSecs        *int                             `json:"client_partition_window_secs,omitempty"`         // How long clients can remain offline for without losing replication metadata. Default 30 days (in seconds)
 	Guest                            *db.PrincipalConfig              `json:"guest,omitempty"`                                // Guest user settings
+	ChangesRequestPlus               *bool                            `json:"changes_request_plus,omitempty"`                 // If set, is used as the default value of request_plus for non-continuous replications
 	CORS                             *auth.CORSConfig                 `json:"cors,omitempty"`
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -823,6 +823,7 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		ClientPartitionWindow:     clientPartitionWindow,
 		BcryptCost:                bcryptCost,
 		GroupID:                   groupID,
+		ChangesRequestPlus:        base.BoolDefault(config.ChangesRequestPlus, false),
 	}
 
 	return contextOptions, nil

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -376,6 +376,10 @@ func (rt *RestTester) SendRequest(method, resource string, body string) *TestRes
 	return rt.Send(request(method, resource, body))
 }
 
+func (rt *RestTester) SendUserRequest(method, resource string, body string, username string) *TestResponse {
+	return rt.Send(requestByUser(method, resource, body, username))
+}
+
 func (rt *RestTester) SendRequestWithHeaders(method, resource string, body string, headers map[string]string) *TestResponse {
 	req := request(method, resource, body)
 	for k, v := range headers {


### PR DESCRIPTION
This was a bit of a messy cherry-pick - the biggest changes were in `db/changes.go` and in test files, since the code in 3.0.8 is not collections aware.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=false,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-go1.16.15/62/ 
