### PR TITLE
CBG-3022: Replicator will not reconnect when max_back_off != 0

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -214,7 +214,7 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 	blipContext.WebsocketPingInterval = arc.config.WebsocketPingInterval
 	blipContext.OnExitCallback = func() {
 		// fall into a reconnect loop only if the connection is unexpectedly closed.
-		if arc.ctx.Err() == nil && arc.config.TotalReconnectTimeout != 0 {
+		if arc.ctx.Err() == nil {
 			go arc.reconnectLoop()
 		}
 	}

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -153,7 +153,9 @@ func (a *activeReplicatorCommon) reconnectLoop() {
 
 	// if a reconnect timeout is set, we'll wrap the existing so both can stop the retry loop
 	var deadlineCancel context.CancelFunc
-	ctx, deadlineCancel = context.WithDeadline(ctx, time.Now().Add(a.config.TotalReconnectTimeout))
+	if a.config.TotalReconnectTimeout != 0 {
+		ctx, deadlineCancel = context.WithDeadline(ctx, time.Now().Add(a.config.TotalReconnectTimeout))
+	}
 
 	sleeperFunc := base.SleeperFuncCtx(
 		base.CreateIndefiniteMaxDoublingSleeperFunc(

--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -80,7 +80,7 @@ type ActiveReplicatorConfig struct {
 	InitialReconnectInterval time.Duration
 	// MaxReconnectInterval is the maximum amount of time to wait between exponential backoff reconnect attempts.
 	MaxReconnectInterval time.Duration
-	// TotalReconnectTimeout, if non-zero, is the amount of time to wait before giving up trying to reconnect. Zero disables reconnect entirely.
+	// TotalReconnectTimeout, if non-zero, is the amount of time to wait before giving up trying to reconnect. Zero value will retry indefinitely.
 	TotalReconnectTimeout time.Duration
 
 	// CollectionsEnabled can be set to replicate one or more named collections, rather than just the default collection.

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -59,7 +59,7 @@ func (apr *ActivePullReplicator) Start(ctx context.Context) error {
 		base.WarnfCtx(apr.ctx, "Couldn't connect: %v", err)
 		if errors.Is(err, fatalReplicatorConnectError) {
 			base.WarnfCtx(apr.ctx, "Stopping replication connection attempt")
-		} else if apr.config.TotalReconnectTimeout != 0 {
+		} else {
 			base.InfofCtx(apr.ctx, base.KeyReplicate, "Attempting to reconnect in background: %v", err)
 			apr.reconnectActive.Set(true)
 			go apr.reconnectLoop()

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -63,7 +63,7 @@ func (apr *ActivePushReplicator) Start(ctx context.Context) error {
 		base.WarnfCtx(apr.ctx, "Couldn't connect: %s", err)
 		if errors.Is(err, fatalReplicatorConnectError) {
 			base.WarnfCtx(apr.ctx, "Stopping replication connection attempt")
-		} else if apr.config.TotalReconnectTimeout != 0 {
+		} else {
 			base.InfofCtx(apr.ctx, base.KeyReplicate, "Attempting to reconnect in background: %v", err)
 			apr.reconnectActive.Set(true)
 			go apr.reconnectLoop()

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -1204,6 +1204,12 @@ func (m *sgReplicateManager) GetNumberActiveReplicators() int {
 	return len(m.activeReplicators)
 }
 
+func (m *sgReplicateManager) GetActiveReplicator(name string) *ActiveReplicator {
+	m.activeReplicatorsLock.Lock()
+	defer m.activeReplicatorsLock.Unlock()
+	return m.activeReplicators[name]
+}
+
 // RebalanceReplications distributes the set of defined replications across the set of available nodes
 func (c *SGRCluster) RebalanceReplications() {
 

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/go-blip"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
@@ -618,4 +619,12 @@ func AllocateTestSequence(database *DatabaseContext) (uint64, error) {
 // ReleaseTestSequence releases a sequence via the sequenceAllocator.  For use by non-db tests
 func ReleaseTestSequence(database *DatabaseContext, sequence uint64) error {
 	return database.sequences.releaseSequence(sequence)
+}
+
+func (a *ActiveReplicator) GetActiveReplicatorConfig() *ActiveReplicatorConfig {
+	return a.config
+}
+
+func (apr *ActivePullReplicator) GetBlipSender() *blip.Sender {
+	return apr.blipSender
 }

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -572,7 +572,7 @@ func TestStopServerlessConnectionLimitingDuringReplications(t *testing.T) {
 	// assert it enter error state
 	replicationID = t.Name() + "2"
 	rt1.CreateReplication(replicationID, remoteURLString, db.ActiveReplicatorTypePull, nil, true, db.ConflictResolverDefault)
-	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateError)
+	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateReconnecting)
 
 	// change limit to 0 (turning limiting off) and assert that the replications currently running continue as normal and reject any new ones being added
 	resp = rt2.SendAdminRequest(http.MethodPut, "/_config", `{"max_concurrent_replications" : 0}`)
@@ -670,7 +670,7 @@ func TestServerlessConnectionLimitingContinuous(t *testing.T) {
 	// assert we still can't create a new replication
 	replicationID = t.Name() + "3"
 	rt1.CreateReplication(replicationID, remoteURLString, db.ActiveReplicatorTypePull, nil, true, db.ConflictResolverDefault)
-	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateError)
+	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateReconnecting)
 
 	// stop one of the replicators currently running
 	resp = rt1.SendAdminRequest(http.MethodPut, "/{{.db}}/_replicationStatus/"+t.Name()+"1?action=stop", "")
@@ -682,7 +682,7 @@ func TestServerlessConnectionLimitingContinuous(t *testing.T) {
 	// assert we still can't create new replication (new limit is 1)
 	replicationID = t.Name() + "4"
 	rt1.CreateReplication(replicationID, remoteURLString, db.ActiveReplicatorTypePull, nil, true, db.ConflictResolverDefault)
-	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateError)
+	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateReconnecting)
 
 }
 
@@ -2333,6 +2333,135 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	assert.Equal(t, int64(1), dbstats.ExpectedSequenceLen.Value())
 	assert.Equal(t, int64(0), dbstats.ExpectedSequenceLenPostCleanup.Value())
 	assert.Equal(t, int64(0), dbstats.ProcessedSequenceLenPostCleanup.Value())
+}
+
+// TestReplicatorReconnectBehaviour tests the interactive values that configure replicator reconnection behaviour
+func TestReplicatorReconnectBehaviour(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+
+	testCases := []struct {
+		name                 string
+		maxBackoff           int
+		specified            bool
+		reconnectTimeout     time.Duration
+		maxReconnectInterval time.Duration
+	}{
+		{
+			name:                 "maxbackoff 0",
+			specified:            true,
+			maxBackoff:           0,
+			reconnectTimeout:     10 * time.Minute,
+			maxReconnectInterval: 5 * time.Minute,
+		},
+		{
+			name:                 "max backoff not specified",
+			specified:            false,
+			reconnectTimeout:     0 * time.Minute,
+			maxReconnectInterval: 5 * time.Minute,
+		},
+		{
+			name:                 "maxbackoff 1",
+			specified:            true,
+			maxBackoff:           1,
+			reconnectTimeout:     0 * time.Minute,
+			maxReconnectInterval: 1 * time.Minute,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			activeRT, _, remoteURL, teardown := rest.SetupSGRPeers(t)
+			defer teardown()
+			var resp *rest.TestResponse
+
+			if test.specified {
+				resp = activeRT.SendAdminRequest(http.MethodPut, "/{{.db}}/_replication/replication1", fmt.Sprintf(`{
+    					"replication_id": "replication1", "remote": "%s", "direction": "pushAndPull",
+						"collections_enabled": %t, "continuous": true, "max_backoff_time": %d}`, remoteURL, base.TestsUseNamedCollections(), test.maxBackoff))
+				rest.RequireStatus(t, resp, http.StatusCreated)
+			} else {
+				resp = activeRT.SendAdminRequest(http.MethodPut, "/{{.db}}/_replication/replication1", fmt.Sprintf(`{
+    					"replication_id": "replication1", "remote": "%s", "direction": "pushAndPull",
+						"collections_enabled": %t, "continuous": true}`, remoteURL, base.TestsUseNamedCollections()))
+				rest.RequireStatus(t, resp, http.StatusCreated)
+			}
+			activeRT.WaitForReplicationStatus("replication1", db.ReplicationStateRunning)
+
+			activeReplicator := activeRT.GetDatabase().SGReplicateMgr.GetActiveReplicator("replication1")
+			config := activeReplicator.GetActiveReplicatorConfig()
+
+			assert.Equal(t, test.reconnectTimeout, config.TotalReconnectTimeout)
+			assert.Equal(t, test.maxReconnectInterval, config.MaxReconnectInterval)
+		})
+	}
+
+}
+
+// TestReconnectReplicator:
+//   - Starts 2 RestTesters, one active, and one remote.
+//   - creates a pull replication from remote to active rest tester
+//   - kills the blip sender to simulate a disconnect that was not initiated by the user
+//   - asserts the replicator enters a reconnecting state and eventually enters a running state again
+//   - puts some docs on the remote rest tester and assert the replicator pulls these docs to prove reconnect was successful
+func TestReconnectReplicator(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+
+	testCases := []struct {
+		name       string
+		maxBackoff int
+		specified  bool
+	}{
+		{
+			name:       "maxbackoff 0",
+			specified:  true,
+			maxBackoff: 0,
+		},
+		{
+			name:      "max backoff not specified",
+			specified: false,
+		},
+		{
+			name:       "maxbackoff 1",
+			specified:  true,
+			maxBackoff: 1,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			activeRT, remoteRT, remoteURL, teardown := rest.SetupSGRPeers(t)
+			defer teardown()
+			var resp *rest.TestResponse
+			const replicationName = "replication1"
+
+			if test.specified {
+				resp = activeRT.SendAdminRequest(http.MethodPut, "/{{.db}}/_replication/replication1", fmt.Sprintf(`{
+    					"replication_id": "%s", "remote": "%s", "direction": "pull",
+						"collections_enabled": %t, "continuous": true, "max_backoff_time": %d}`, replicationName, remoteURL, base.TestsUseNamedCollections(), test.maxBackoff))
+				rest.RequireStatus(t, resp, http.StatusCreated)
+			} else {
+				resp = activeRT.SendAdminRequest(http.MethodPut, "/{{.db}}/_replication/replication1", fmt.Sprintf(`{
+    					"replication_id": "%s", "remote": "%s", "direction": "pull",
+						"collections_enabled": %t, "continuous": true}`, replicationName, remoteURL, base.TestsUseNamedCollections()))
+				rest.RequireStatus(t, resp, http.StatusCreated)
+			}
+			activeRT.WaitForReplicationStatus("replication1", db.ReplicationStateRunning)
+
+			ar := activeRT.GetDatabase().SGReplicateMgr.GetActiveReplicator("replication1")
+			ar.Pull.GetBlipSender().Stop()
+
+			activeRT.WaitForReplicationStatus(replicationName, db.ReplicationStateReconnecting)
+
+			activeRT.WaitForReplicationStatus(replicationName, db.ReplicationStateRunning)
+
+			for i := 0; i < 10; i++ {
+				response := remoteRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+fmt.Sprint(i), `{"source": "remote"}`)
+				rest.RequireStatus(t, response, http.StatusCreated)
+			}
+			_, err := activeRT.WaitForChanges(10, "/{{.keyspace}}/_changes", "", true)
+			require.NoError(t, err)
+		})
+	}
+
 }
 
 // TestActiveReplicatorPullAttachments:

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -134,6 +134,14 @@ func (rt *RestTester) WaitForActiveReplicatorInitialization(count int) {
 	require.NoError(rt.TB, rt.WaitForCondition(successFunc), "mismatch on number of active replicators")
 }
 
+func (rt *RestTester) WaitForPullBlipSenderInitialisation(name string) {
+	successFunc := func() bool {
+		bs := rt.GetDatabase().SGReplicateMgr.GetActiveReplicator(name).Pull.GetBlipSender()
+		return bs != nil
+	}
+	require.NoError(rt.TB, rt.WaitForCondition(successFunc), "blip sender on active replicator not initialized")
+}
+
 // createReplication creates a replication via the REST API with the specified ID, remoteURL, direction and channel filter
 func (rt *RestTester) CreateReplication(replicationID string, remoteURLString string, direction db.ActiveReplicatorDirection, channels []string, continuous bool, conflictResolver db.ConflictResolverType) {
 	rt.CreateReplicationForDB("{{.db}}", replicationID, remoteURLString, direction, channels, continuous, conflictResolver)


### PR DESCRIPTION
CBG-3022

MaxBackOff Behaviour:

MaxBackOff = 0: 
* Current behaviour: Reconnects with exponential back off up till 5 mins and will stop trying to reconnect after 10 mins 
* Behaviour we want: same as above
* TotalReconnectTimeout = 10 mins 
* MaxReconnectInterval = 5 mins 

MaxBackOff = default value:
* Current Behaviour: Doesn’t reconnect 
* Behaviour we want: to rear exponential back off till 5 mins, but retry indefinitely
* TotalReconnectTimeout = 0
* MaxReconnectInterval = 5 mins 

MaxBackOff = something other than 0 or default:
* Current Behaviour: Doesn’t reconnect 
* Behaviour we want: to have exponential back off time till the value specified (in minutes) and then retry indefinitely
* TotalReconnectTimeout = 0 
* MaxReconnectInterval = <specified MaxBackOff value> mins

What the problem is currently that TotalReconnectTimeout = 0 will disable reconnect all together. I think we want when TotalReconnectTimeout = 0 to retry indefinitely. Changes I am making locally seem to work for this without effecting tests that are testing for missing collections. 

This change also broke CBG-2895 (replication limit handling) tests. The tests were asserting on the replicator going into an error state once being rejected by the limit. We should’ve been entering a reconnect loop (like we’d expect CBL to be doing, hence the 503 code returned), so I have also update those tests to assert on replication going into reconnect loop. Also took out assertion on stats, due to the nature these stats get incremented each time on the reconnect loop and there is no way we can assert on how many times this will happen in the test. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1851/
