### PR TITLE
make jenkins tests compatible with amazon linux 2023

### DIFF
--- a/integration-test/start_server.sh
+++ b/integration-test/start_server.sh
@@ -42,7 +42,10 @@ if [ "${CBS_ROOT_DIR:-}" != "" ]; then
     DOCKER_CBS_ROOT_DIR="${CBS_ROOT_DIR}"
 fi
 
-if [[ -n "${JENKINS_URL:-}" ]]; then
+set +e
+AMAZON_LINUX_2=$(grep 'Amazon Linux 2"' /etc/os-release)
+set -e
+if [[ -n "${AMAZON_LINUX_2}" ]]; then
     DOCKER_COMPOSE="docker-compose" # use docker-compose v1 for Jenkins AWS Linux 2
 else
     DOCKER_COMPOSE="docker compose"
@@ -72,7 +75,6 @@ docker exec couchbase couchbase-cli cluster-init --cluster-username Administrato
 docker exec couchbase couchbase-cli setting-index --cluster couchbase://localhost --username Administrator --password password --index-threads 4 --index-log-level verbose --index-max-rollback-points 10 --index-storage-setting default --index-memory-snapshot-interval 150 --index-stable-snapshot-interval 40000
 
 curl -u Administrator:password -v -X POST http://127.0.0.1:8091/node/controller/rename -d 'hostname=127.0.0.1'
-
 
 if [ "${MULTI_NODE:-}" == "true" ]; then
     REPLICA1_NAME=couchbase-replica1

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -62,13 +62,6 @@ else
     go install -v github.com/AlekSi/gocov-xml@latest
 fi
 
-if [[ -n "${JENKINS_URL:-}" ]]; then
-    # last 1.x version, when updating aws linux 2 docker, docker-compose becomes docker compose
-    sudo yum install -y jq
-    sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-    sudo chmod +x /usr/local/bin/docker-compose
-fi
-
 if [ "${SG_TEST_X509:-}" == "true" -a "${COUCHBASE_SERVER_PROTOCOL}" != "couchbases" ]; then
     echo "Setting SG_TEST_X509 requires using couchbases:// protocol, aborting integration tests"
     exit 1


### PR DESCRIPTION
- docker-compose was moved to jenkins init script
- detect docker-compose (v1) by looking for amazon linux 2 specifically

I plan to move the Integration Test / Master Integration / Pipeline Agent to 2023, but leave the old Integration Test runs to use aws linux 2 AMIs