### PR TITLE
CBG-3036: [3.1.1] Replicator will not reconnect when max_back_off != 0 

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -214,7 +214,7 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 	blipContext.WebsocketPingInterval = arc.config.WebsocketPingInterval
 	blipContext.OnExitCallback = func() {
 		// fall into a reconnect loop only if the connection is unexpectedly closed.
-		if arc.ctx.Err() == nil && arc.config.TotalReconnectTimeout != 0 {
+		if arc.ctx.Err() == nil {
 			go arc.reconnectLoop()
 		}
 	}

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -153,7 +153,9 @@ func (a *activeReplicatorCommon) reconnectLoop() {
 
 	// if a reconnect timeout is set, we'll wrap the existing so both can stop the retry loop
 	var deadlineCancel context.CancelFunc
-	ctx, deadlineCancel = context.WithDeadline(ctx, time.Now().Add(a.config.TotalReconnectTimeout))
+	if a.config.TotalReconnectTimeout != 0 {
+		ctx, deadlineCancel = context.WithDeadline(ctx, time.Now().Add(a.config.TotalReconnectTimeout))
+	}
 
 	sleeperFunc := base.SleeperFuncCtx(
 		base.CreateIndefiniteMaxDoublingSleeperFunc(

--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -80,7 +80,7 @@ type ActiveReplicatorConfig struct {
 	InitialReconnectInterval time.Duration
 	// MaxReconnectInterval is the maximum amount of time to wait between exponential backoff reconnect attempts.
 	MaxReconnectInterval time.Duration
-	// TotalReconnectTimeout, if non-zero, is the amount of time to wait before giving up trying to reconnect. Zero disables reconnect entirely.
+	// TotalReconnectTimeout, if non-zero, is the amount of time to wait before giving up trying to reconnect. Zero value will retry indefinitely.
 	TotalReconnectTimeout time.Duration
 
 	// CollectionsEnabled can be set to replicate one or more named collections, rather than just the default collection.

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -59,7 +59,7 @@ func (apr *ActivePullReplicator) Start(ctx context.Context) error {
 		base.WarnfCtx(apr.ctx, "Couldn't connect: %v", err)
 		if errors.Is(err, fatalReplicatorConnectError) {
 			base.WarnfCtx(apr.ctx, "Stopping replication connection attempt")
-		} else if apr.config.TotalReconnectTimeout != 0 {
+		} else {
 			base.InfofCtx(apr.ctx, base.KeyReplicate, "Attempting to reconnect in background: %v", err)
 			apr.reconnectActive.Set(true)
 			go apr.reconnectLoop()

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -63,7 +63,7 @@ func (apr *ActivePushReplicator) Start(ctx context.Context) error {
 		base.WarnfCtx(apr.ctx, "Couldn't connect: %s", err)
 		if errors.Is(err, fatalReplicatorConnectError) {
 			base.WarnfCtx(apr.ctx, "Stopping replication connection attempt")
-		} else if apr.config.TotalReconnectTimeout != 0 {
+		} else {
 			base.InfofCtx(apr.ctx, base.KeyReplicate, "Attempting to reconnect in background: %v", err)
 			apr.reconnectActive.Set(true)
 			go apr.reconnectLoop()

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -1194,6 +1194,18 @@ func (c *SGRCluster) GetReplicationIDsForNode(nodeUUID string) (replicationIDs [
 	return replicationIDs
 }
 
+func (m *sgReplicateManager) GetNumberActiveReplicators() int {
+	m.activeReplicatorsLock.Lock()
+	defer m.activeReplicatorsLock.Unlock()
+	return len(m.activeReplicators)
+}
+
+func (m *sgReplicateManager) GetActiveReplicator(name string) *ActiveReplicator {
+	m.activeReplicatorsLock.Lock()
+	defer m.activeReplicatorsLock.Unlock()
+	return m.activeReplicators[name]
+}
+
 // RebalanceReplications distributes the set of defined replications across the set of available nodes
 func (c *SGRCluster) RebalanceReplications() {
 

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/go-blip"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
@@ -618,4 +619,12 @@ func AllocateTestSequence(database *DatabaseContext) (uint64, error) {
 // ReleaseTestSequence releases a sequence via the sequenceAllocator.  For use by non-db tests
 func ReleaseTestSequence(database *DatabaseContext, sequence uint64) error {
 	return database.sequences.releaseSequence(sequence)
+}
+
+func (a *ActiveReplicator) GetActiveReplicatorConfig() *ActiveReplicatorConfig {
+	return a.config
+}
+
+func (apr *ActivePullReplicator) GetBlipSender() *blip.Sender {
+	return apr.blipSender
 }

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -126,6 +126,22 @@ func (rt *RestTester) WaitForCheckpointLastSequence(expectedName string) (string
 	return lastSeq, rt.WaitForCondition(successFunc)
 }
 
+func (rt *RestTester) WaitForActiveReplicatorInitialization(count int) {
+	successFunc := func() bool {
+		ar := rt.GetDatabase().SGReplicateMgr.GetNumberActiveReplicators()
+		return ar == count
+	}
+	require.NoError(rt.TB, rt.WaitForCondition(successFunc), "mismatch on number of active replicators")
+}
+
+func (rt *RestTester) WaitForPullBlipSenderInitialisation(name string) {
+	successFunc := func() bool {
+		bs := rt.GetDatabase().SGReplicateMgr.GetActiveReplicator(name).Pull.GetBlipSender()
+		return bs != nil
+	}
+	require.NoError(rt.TB, rt.WaitForCondition(successFunc), "blip sender on active replicator not initialized")
+}
+
 // createReplication creates a replication via the REST API with the specified ID, remoteURL, direction and channel filter
 func (rt *RestTester) CreateReplication(replicationID string, remoteURLString string, direction db.ActiveReplicatorDirection, channels []string, continuous bool, conflictResolver db.ConflictResolverType) {
 	rt.CreateReplicationForDB("{{.db}}", replicationID, remoteURLString, direction, channels, continuous, conflictResolver)


### PR DESCRIPTION
CBG-3036

Backport of the MaxBackOff fix for replicators failing to reconnect after disconnection. Backport includes number of test helper methods that are needed for the tests. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1859/
