### PR TITLE
CBG-2932: Request Count stat for REST

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -469,6 +469,8 @@ type DatabaseStats struct {
 	NumDocReadsRest *SgwIntStat `json:"num_doc_reads_rest"`
 	// The total number of documents written by any means (replication, rest API interaction or imports) since Sync Gateway node startup.
 	NumDocWrites *SgwIntStat `json:"num_doc_writes"`
+	// The total number of requests sent over the public REST api
+	NumPublicRestRequests *SgwIntStat `json:"num_public_rest_requests"`
 	// The total number of active replications.
 	NumReplicationsActive *SgwIntStat `json:"num_replications_active"`
 	// The total number of replications created since Sync Gateway node startup.
@@ -1441,6 +1443,10 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.NumPublicRestRequests, err = NewIntStat(SubsystemDatabaseKey, "num_public_rest_requests", labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.ImportFeedMapStats = &ExpVarMapWrapper{new(expvar.Map).Init()}
 
 	resUtil.CacheFeedMapStats = &ExpVarMapWrapper{new(expvar.Map).Init()}
@@ -1485,6 +1491,7 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.SyncFunctionTime)
 	prometheus.Unregister(d.DatabaseStats.SyncFunctionExceptionCount)
 	prometheus.Unregister(d.DatabaseStats.NumReplicationsRejectedLimit)
+	prometheus.Unregister(d.DatabaseStats.NumPublicRestRequests)
 }
 
 func (d *DbStats) CollectionStat(scopeName, collectionName string) (*CollectionStats, error) {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -75,30 +75,34 @@ func TestPublicRESTStatCount(t *testing.T) {
 	// create a user to authenticate as for public api calls and assert the stat hasn't incremented as a result
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/greg", GetUserPayload(t, "greg", "letmein", "", rt.GetSingleTestDatabaseCollection(), []string{"ABC"}, nil))
 	RequireStatus(t, resp, http.StatusCreated)
-	base.WaitForStat(func() int64 {
+	_, ok := base.WaitForStat(func() int64 {
 		return rt.GetDatabase().DbStats.DatabaseStats.NumPublicRestRequests.Value()
 	}, 0)
+	require.True(t, ok)
 
 	// use public api to put a doc through SGW then assert the stat has increased by 1
 	resp = rt.SendUserRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"foo":"bar", "channels":["ABC"]}`, "greg")
 	RequireStatus(t, resp, http.StatusCreated)
-	base.WaitForStat(func() int64 {
+	_, ok = base.WaitForStat(func() int64 {
 		return rt.GetDatabase().DbStats.DatabaseStats.NumPublicRestRequests.Value()
 	}, 1)
+	require.True(t, ok)
 
 	// send admin request assert that the public rest count doesn't increase
 	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/doc1", "")
 	RequireStatus(t, resp, http.StatusOK)
-	base.WaitForStat(func() int64 {
+	_, ok = base.WaitForStat(func() int64 {
 		return rt.GetDatabase().DbStats.DatabaseStats.NumPublicRestRequests.Value()
 	}, 1)
+	require.True(t, ok)
 
 	// send another public request to assert the stat increases by 1
 	resp = rt.SendUserRequest(http.MethodGet, "/{{.keyspace}}/doc1", "", "greg")
 	RequireStatus(t, resp, http.StatusOK)
-	base.WaitForStat(func() int64 {
+	_, ok = base.WaitForStat(func() int64 {
 		return rt.GetDatabase().DbStats.DatabaseStats.NumPublicRestRequests.Value()
 	}, 2)
+	require.True(t, ok)
 
 }
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -104,7 +104,7 @@ func TestPublicRESTStatCount(t *testing.T) {
 	require.True(t, ok)
 
 	resp = rt.SendUserRequest(http.MethodGet, "/{{.db}}/_blipsync", "", "greg")
-	fmt.Println(resp.Code)
+	RequireStatus(t, resp, http.StatusUpgradeRequired)
 
 	_, ok = base.WaitForStat(func() int64 {
 		return rt.GetDatabase().DbStats.DatabaseStats.NumPublicRestRequests.Value()

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -606,7 +606,7 @@ func (h *handler) logDuration(realTime bool) {
 	)
 }
 
-// logRESTCount will increment the number of public REST requests stat for public REST requests excluding blipsync requests
+// logRESTCount will increment the number of public REST requests stat for public REST requests excluding _blipsync requests if they are attached to a database.
 func (h *handler) logRESTCount() {
 	if h.db == nil {
 		return

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -128,7 +128,6 @@ func makeHandler(server *ServerContext, privs handlerPrivs, accessPermissions []
 		err := h.invoke(method, accessPermissions, responsePermissions)
 		h.writeError(err)
 		h.logDuration(true)
-		h.logRESTCount()
 	})
 }
 
@@ -142,7 +141,6 @@ func makeOfflineHandler(server *ServerContext, privs handlerPrivs, accessPermiss
 		err := h.invoke(method, accessPermissions, responsePermissions)
 		h.writeError(err)
 		h.logDuration(true)
-		h.logRESTCount()
 	})
 }
 
@@ -267,6 +265,7 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 		if !isRequestLogged {
 			h.logRequestLine()
 		}
+		h.logRESTCount()
 	}()
 
 	defer func() {
@@ -607,6 +606,7 @@ func (h *handler) logDuration(realTime bool) {
 	)
 }
 
+// logRESTCount will increment the number of public REST requests stat for public REST requests excluding blipsync requests
 func (h *handler) logRESTCount() {
 	if h.db == nil {
 		return


### PR DESCRIPTION
CBG-2932

SImple implementation where we count the number of public rest requests throiughh sybnc gateway. Does this through adding a function on the handler to call each time a new handler is crerated and if the handlerPrivs is public realted we increment the stat. Also has a check to exit the function before we increment the stats for blipsync requests. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1866/
