### PR TITLE
CBG-2930: Import compute stat implementation

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -177,6 +177,8 @@ const (
 	EmptyDocument = `{}`
 )
 
+const MiB = 1 * 1024 * 1024
+
 var (
 	SyncFnAccessErrors = []string{
 		HTTPErrorf(403, SyncFnErrorMissingRole).Error(),

--- a/base/constants.go
+++ b/base/constants.go
@@ -177,8 +177,6 @@ const (
 	EmptyDocument = `{}`
 )
 
-const MiB = 1 * 1024 * 1024
-
 var (
 	SyncFnAccessErrors = []string{
 		HTTPErrorf(403, SyncFnErrorMissingRole).Error(),

--- a/base/stats.go
+++ b/base/stats.go
@@ -692,6 +692,8 @@ type SharedBucketImportStats struct {
 	ImportHighSeq *SgwIntStat `json:"import_high_seq"`
 	// The total number of import partitions.
 	ImportPartitions *SgwIntStat `json:"import_partitions"`
+	// Represents the compute unit
+	ImportProcessCompute *SgwFloatStat `json:"import_process_compute"`
 }
 
 type SgwStat struct {
@@ -1921,6 +1923,10 @@ func (d *DbStats) InitSharedBucketImportStats() error {
 			return err
 		}
 		resUtil.ImportPartitions, err = NewIntStat(SubsystemSharedBucketImport, "import_partitions", labelKeys, labelVals, prometheus.GaugeValue, 0)
+		if err != nil {
+			return err
+		}
+		resUtil.ImportProcessCompute, err = NewFloatStat(SubsystemSharedBucketImport, "import_process_compute", labelKeys, labelVals, prometheus.GaugeValue, 0)
 		if err != nil {
 			return err
 		}

--- a/base/stats.go
+++ b/base/stats.go
@@ -505,6 +505,8 @@ type DatabaseStats struct {
 	SyncFunctionExceptionCount *SgwIntStat `json:"sync_function_exception_count"`
 	// The total number of times a replication connection is rejected due ot it being over the threshold
 	NumReplicationsRejectedLimit *SgwIntStat `json:"num_replications_rejected_limit"`
+	// Represents the compute unit for import processes on the database
+	ImportProcessCompute *SgwIntStat `json:"import_process_compute"`
 
 	// These can be cleaned up in future versions of SGW, implemented as maps to reduce amount of potential risk
 	// prior to Hydrogen release. These are not exported as part of prometheus and only exposed through expvars
@@ -692,8 +694,6 @@ type SharedBucketImportStats struct {
 	ImportHighSeq *SgwIntStat `json:"import_high_seq"`
 	// The total number of import partitions.
 	ImportPartitions *SgwIntStat `json:"import_partitions"`
-	// Represents the compute unit
-	ImportProcessCompute *SgwIntStat `json:"import_process_compute"`
 }
 
 type SgwStat struct {
@@ -1456,6 +1456,11 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.ImportProcessCompute, err = NewIntStat(SubsystemSharedBucketImport, "import_process_compute", labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+
 	resUtil.ImportFeedMapStats = &ExpVarMapWrapper{new(expvar.Map).Init()}
 
 	resUtil.CacheFeedMapStats = &ExpVarMapWrapper{new(expvar.Map).Init()}
@@ -1502,6 +1507,7 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.NumReplicationsRejectedLimit)
 	prometheus.Unregister(d.DatabaseStats.NumPublicRestRequests)
 	prometheus.Unregister(d.DatabaseStats.TotalSyncTime)
+	prometheus.Unregister(d.DatabaseStats.ImportProcessCompute)
 }
 
 func (d *DbStats) CollectionStat(scopeName, collectionName string) (*CollectionStats, error) {
@@ -1926,10 +1932,6 @@ func (d *DbStats) InitSharedBucketImportStats() error {
 		if err != nil {
 			return err
 		}
-		resUtil.ImportProcessCompute, err = NewIntStat(SubsystemSharedBucketImport, "import_process_compute", labelKeys, labelVals, prometheus.CounterValue, 0)
-		if err != nil {
-			return err
-		}
 
 		d.SharedBucketImportStats = resUtil
 	}
@@ -1943,7 +1945,6 @@ func (d *DbStats) unregisterSharedBucketImportStats() {
 	prometheus.Unregister(d.SharedBucketImportStats.ImportProcessingTime)
 	prometheus.Unregister(d.SharedBucketImportStats.ImportHighSeq)
 	prometheus.Unregister(d.SharedBucketImportStats.ImportPartitions)
-	prometheus.Unregister(d.SharedBucketImportStats.ImportProcessCompute)
 }
 
 func (d *DbStats) SharedBucketImport() *SharedBucketImportStats {

--- a/base/stats.go
+++ b/base/stats.go
@@ -693,7 +693,7 @@ type SharedBucketImportStats struct {
 	// The total number of import partitions.
 	ImportPartitions *SgwIntStat `json:"import_partitions"`
 	// Represents the compute unit
-	ImportProcessCompute *SgwFloatStat `json:"import_process_compute"`
+	ImportProcessCompute *SgwIntStat `json:"import_process_compute"`
 }
 
 type SgwStat struct {
@@ -1926,7 +1926,7 @@ func (d *DbStats) InitSharedBucketImportStats() error {
 		if err != nil {
 			return err
 		}
-		resUtil.ImportProcessCompute, err = NewFloatStat(SubsystemSharedBucketImport, "import_process_compute", labelKeys, labelVals, prometheus.GaugeValue, 0)
+		resUtil.ImportProcessCompute, err = NewIntStat(SubsystemSharedBucketImport, "import_process_compute", labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return err
 		}

--- a/base/stats.go
+++ b/base/stats.go
@@ -1943,6 +1943,7 @@ func (d *DbStats) unregisterSharedBucketImportStats() {
 	prometheus.Unregister(d.SharedBucketImportStats.ImportProcessingTime)
 	prometheus.Unregister(d.SharedBucketImportStats.ImportHighSeq)
 	prometheus.Unregister(d.SharedBucketImportStats.ImportPartitions)
+	prometheus.Unregister(d.SharedBucketImportStats.ImportProcessCompute)
 }
 
 func (d *DbStats) SharedBucketImport() *SharedBucketImportStats {

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -338,9 +338,9 @@ func TestResyncManagerDCPRunTwice(t *testing.T) {
 
 func TestResyncImportComputeStat(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
-		t.Skip("Test requires Couchbase Server")
+		t.Skip("Test requires Couchbase Server for DCP")
 	}
-	const docsToCreate = 1000
+	const docsToCreate = 100
 	db, ctx := setupTestDBForResyncWithDocs(t, docsToCreate, false)
 	defer db.Close(ctx)
 

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -336,6 +336,43 @@ func TestResyncManagerDCPRunTwice(t *testing.T) {
 	wg.Wait()
 }
 
+func TestResyncImportComputeStat(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Test requires Couchbase Server")
+	}
+	const docsToCreate = 1000
+	db, ctx := setupTestDBForResyncWithDocs(t, docsToCreate, false)
+	defer db.Close(ctx)
+
+	resycMgr := NewResyncManagerDCP(db.MetadataStore, base.TestUseXattrs(), db.MetadataKeys)
+	require.NotNil(t, resycMgr)
+	db.ResyncManager = resycMgr
+
+	options := map[string]interface{}{
+		"database":            db,
+		"regenerateSequences": false,
+		"collections":         ResyncCollections{},
+	}
+
+	computeStat := db.DbStats.DatabaseStats.ImportProcessCompute.Value()
+	require.Equal(t, int64(0), computeStat)
+
+	err := resycMgr.Start(ctx, options)
+	require.NoError(t, err)
+
+	err = WaitForConditionWithOptions(func() bool {
+		var status BackgroundManagerStatus
+		rawStatus, _ := resycMgr.GetStatus()
+		_ = json.Unmarshal(rawStatus, &status)
+		return status.State == BackgroundProcessStateCompleted
+	}, 200, 200)
+	require.NoError(t, err)
+
+	computeStat1 := db.DbStats.DatabaseStats.ImportProcessCompute.Value()
+	require.Greater(t, computeStat1, computeStat)
+
+}
+
 func TestResycnManagerDCPResumeStoppedProcess(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server")

--- a/db/crud.go
+++ b/db/crud.go
@@ -233,10 +233,6 @@ func (db *DatabaseCollection) GetDocSyncDataNoImport(ctx context.Context, docid 
 func (c *DatabaseCollection) OnDemandImportForGet(ctx context.Context, docid string, rawDoc []byte, rawXattr []byte, rawUserXattr []byte, cas uint64) (docOut *Document, err error) {
 	startTime := time.Now()
 	defer func() {
-		// if auto import is enabled the doc will be processed as import event. We don't want to calculate import compute again in this case
-		if c.dbCtx.autoImport {
-			return
-		}
 		// we must grab the time in seconds here and convert to ms as the .Milliseconds() function returns integer millisecond count
 		functionTime := time.Since(startTime).Seconds()
 		var bytes float64
@@ -838,10 +834,6 @@ func (db *DatabaseCollectionWithUser) backupAncestorRevs(ctx context.Context, do
 func (db *DatabaseCollectionWithUser) OnDemandImportForWrite(ctx context.Context, docid string, doc *Document, deleted bool) error {
 	startTime := time.Now()
 	defer func() {
-		// if auto import is enabled the doc will be processed as import event. We don't want to calculate import compute again in this case
-		if db.dbCtx.autoImport {
-			return
-		}
 		// we must grab the time in seconds here and convert to ms as the .Milliseconds() function returns integer millisecond count
 		functionTime := time.Since(startTime).Seconds()
 		var bytes float64

--- a/db/crud.go
+++ b/db/crud.go
@@ -233,7 +233,6 @@ func (db *DatabaseCollection) GetDocSyncDataNoImport(ctx context.Context, docid 
 func (c *DatabaseCollection) OnDemandImportForGet(ctx context.Context, docid string, rawDoc []byte, rawXattr []byte, rawUserXattr []byte, cas uint64) (docOut *Document, err error) {
 	startTime := time.Now()
 	defer func() {
-		// we must grab the time in seconds here and convert to ms as the .Milliseconds() function returns integer millisecond count
 		functionTime := time.Since(startTime).Milliseconds()
 		var bytes int
 		if docOut != nil {
@@ -834,7 +833,6 @@ func (db *DatabaseCollectionWithUser) backupAncestorRevs(ctx context.Context, do
 func (db *DatabaseCollectionWithUser) OnDemandImportForWrite(ctx context.Context, docid string, doc *Document, deleted bool) error {
 	startTime := time.Now()
 	defer func() {
-		// we must grab the time in seconds here and convert to ms as the .Milliseconds() function returns integer millisecond count
 		functionTime := time.Since(startTime).Milliseconds()
 		var bytes int
 		if doc != nil {

--- a/db/crud.go
+++ b/db/crud.go
@@ -236,8 +236,7 @@ func (c *DatabaseCollection) OnDemandImportForGet(ctx context.Context, docid str
 		// we must grab the time in seconds here and convert to ms as the .Milliseconds() function returns integer millisecond count
 		functionTime := time.Since(startTime).Seconds()
 		bytes := float64(len(docOut._rawBody))
-		ms := functionTime * float64(1000)
-		stat := calculateImportCompute(ms, bytes)
+		stat := calculateImportCompute(bytes, functionTime)
 		c.dbCtx.DbStats.SharedBucketImportStats.ImportProcessCompute.Add(stat)
 	}()
 	isDelete := rawDoc == nil
@@ -833,8 +832,7 @@ func (db *DatabaseCollectionWithUser) OnDemandImportForWrite(ctx context.Context
 		// we must grab the time in seconds here and convert to ms as the .Milliseconds() function returns integer millisecond count
 		functionTime := time.Since(startTime).Seconds()
 		bytes := float64(len(doc._rawBody))
-		ms := functionTime * float64(1000)
-		stat := calculateImportCompute(ms, bytes)
+		stat := calculateImportCompute(bytes, functionTime)
 		db.dbCtx.DbStats.SharedBucketImportStats.ImportProcessCompute.Add(stat)
 	}()
 	// Check whether the doc requiring import is an SDK delete

--- a/db/crud.go
+++ b/db/crud.go
@@ -240,7 +240,7 @@ func (c *DatabaseCollection) OnDemandImportForGet(ctx context.Context, docid str
 		} else {
 			return
 		}
-		stat := calculateImportCompute(int64(bytes), functionTime)
+		stat := CalculateComputeStat(int64(bytes), functionTime)
 		c.dbCtx.DbStats.DatabaseStats.ImportProcessCompute.Add(stat)
 	}()
 	isDelete := rawDoc == nil
@@ -840,7 +840,7 @@ func (db *DatabaseCollectionWithUser) OnDemandImportForWrite(ctx context.Context
 		} else {
 			return
 		}
-		stat := calculateImportCompute(int64(bytes), functionTime)
+		stat := CalculateComputeStat(int64(bytes), functionTime)
 		db.dbCtx.DbStats.DatabaseStats.ImportProcessCompute.Add(stat)
 	}()
 	// Check whether the doc requiring import is an SDK delete

--- a/db/crud.go
+++ b/db/crud.go
@@ -235,7 +235,12 @@ func (c *DatabaseCollection) OnDemandImportForGet(ctx context.Context, docid str
 	defer func() {
 		// we must grab the time in seconds here and convert to ms as the .Milliseconds() function returns integer millisecond count
 		functionTime := time.Since(startTime).Seconds()
-		bytes := float64(len(docOut._rawBody))
+		var bytes float64
+		if docOut != nil {
+			bytes = float64(len(docOut._rawBody))
+		} else {
+			return
+		}
 		stat := calculateImportCompute(bytes, functionTime)
 		c.dbCtx.DbStats.SharedBucketImportStats.ImportProcessCompute.Add(stat)
 	}()
@@ -831,7 +836,12 @@ func (db *DatabaseCollectionWithUser) OnDemandImportForWrite(ctx context.Context
 	defer func() {
 		// we must grab the time in seconds here and convert to ms as the .Milliseconds() function returns integer millisecond count
 		functionTime := time.Since(startTime).Seconds()
-		bytes := float64(len(doc._rawBody))
+		var bytes float64
+		if doc != nil {
+			bytes = float64(len(doc._rawBody))
+		} else {
+			return
+		}
 		stat := calculateImportCompute(bytes, functionTime)
 		db.dbCtx.DbStats.SharedBucketImportStats.ImportProcessCompute.Add(stat)
 	}()

--- a/db/crud.go
+++ b/db/crud.go
@@ -233,6 +233,10 @@ func (db *DatabaseCollection) GetDocSyncDataNoImport(ctx context.Context, docid 
 func (c *DatabaseCollection) OnDemandImportForGet(ctx context.Context, docid string, rawDoc []byte, rawXattr []byte, rawUserXattr []byte, cas uint64) (docOut *Document, err error) {
 	startTime := time.Now()
 	defer func() {
+		// if auto import is enabled the doc will be processed as import event. We don't want to calculate import compute again in this case
+		if c.dbCtx.autoImport {
+			return
+		}
 		// we must grab the time in seconds here and convert to ms as the .Milliseconds() function returns integer millisecond count
 		functionTime := time.Since(startTime).Seconds()
 		var bytes float64
@@ -834,6 +838,10 @@ func (db *DatabaseCollectionWithUser) backupAncestorRevs(ctx context.Context, do
 func (db *DatabaseCollectionWithUser) OnDemandImportForWrite(ctx context.Context, docid string, doc *Document, deleted bool) error {
 	startTime := time.Now()
 	defer func() {
+		// if auto import is enabled the doc will be processed as import event. We don't want to calculate import compute again in this case
+		if db.dbCtx.autoImport {
+			return
+		}
 		// we must grab the time in seconds here and convert to ms as the .Milliseconds() function returns integer millisecond count
 		functionTime := time.Since(startTime).Seconds()
 		var bytes float64

--- a/db/crud.go
+++ b/db/crud.go
@@ -234,14 +234,14 @@ func (c *DatabaseCollection) OnDemandImportForGet(ctx context.Context, docid str
 	startTime := time.Now()
 	defer func() {
 		// we must grab the time in seconds here and convert to ms as the .Milliseconds() function returns integer millisecond count
-		functionTime := time.Since(startTime).Seconds()
-		var bytes float64
+		functionTime := time.Since(startTime).Milliseconds()
+		var bytes int
 		if docOut != nil {
-			bytes = float64(len(docOut._rawBody))
+			bytes = len(docOut._rawBody)
 		} else {
 			return
 		}
-		stat := calculateImportCompute(bytes, functionTime)
+		stat := calculateImportCompute(int64(bytes), functionTime)
 		c.dbCtx.DbStats.SharedBucketImportStats.ImportProcessCompute.Add(stat)
 	}()
 	isDelete := rawDoc == nil
@@ -835,14 +835,14 @@ func (db *DatabaseCollectionWithUser) OnDemandImportForWrite(ctx context.Context
 	startTime := time.Now()
 	defer func() {
 		// we must grab the time in seconds here and convert to ms as the .Milliseconds() function returns integer millisecond count
-		functionTime := time.Since(startTime).Seconds()
-		var bytes float64
+		functionTime := time.Since(startTime).Milliseconds()
+		var bytes int
 		if doc != nil {
-			bytes = float64(len(doc._rawBody))
+			bytes = len(doc._rawBody)
 		} else {
 			return
 		}
-		stat := calculateImportCompute(bytes, functionTime)
+		stat := calculateImportCompute(int64(bytes), functionTime)
 		db.dbCtx.DbStats.SharedBucketImportStats.ImportProcessCompute.Add(stat)
 	}()
 	// Check whether the doc requiring import is an SDK delete

--- a/db/crud.go
+++ b/db/crud.go
@@ -241,7 +241,7 @@ func (c *DatabaseCollection) OnDemandImportForGet(ctx context.Context, docid str
 			return
 		}
 		stat := calculateImportCompute(int64(bytes), functionTime)
-		c.dbCtx.DbStats.SharedBucketImportStats.ImportProcessCompute.Add(stat)
+		c.dbCtx.DbStats.DatabaseStats.ImportProcessCompute.Add(stat)
 	}()
 	isDelete := rawDoc == nil
 	importDb := DatabaseCollectionWithUser{DatabaseCollection: c, user: nil}
@@ -841,7 +841,7 @@ func (db *DatabaseCollectionWithUser) OnDemandImportForWrite(ctx context.Context
 			return
 		}
 		stat := calculateImportCompute(int64(bytes), functionTime)
-		db.dbCtx.DbStats.SharedBucketImportStats.ImportProcessCompute.Add(stat)
+		db.dbCtx.DbStats.DatabaseStats.ImportProcessCompute.Add(stat)
 	}()
 	// Check whether the doc requiring import is an SDK delete
 	isDelete := false

--- a/db/database.go
+++ b/db/database.go
@@ -1746,7 +1746,7 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 		} else {
 			return
 		}
-		stat := calculateImportCompute(int64(bytes), functionTime)
+		stat := CalculateComputeStat(int64(bytes), functionTime)
 		db.dbStats().DatabaseStats.ImportProcessCompute.Add(stat)
 	}()
 	if db.UseXattrs() {

--- a/db/database.go
+++ b/db/database.go
@@ -1734,9 +1734,21 @@ func (db *DatabaseCollectionWithUser) getResyncedDocument(ctx context.Context, d
 }
 
 func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid, key string, regenerateSequences bool, unusedSequences []uint64) (updatedHighSeq uint64, updatedUnusedSequences []uint64, err error) {
+	startTime := time.Now()
 	var updatedDoc *Document
 	var shouldUpdate bool
 	var updatedExpiry *uint32
+	defer func() {
+		functionTime := time.Since(startTime).Milliseconds()
+		var bytes int
+		if updatedDoc != nil {
+			bytes = len(updatedDoc._rawBody)
+		} else {
+			return
+		}
+		stat := calculateImportCompute(int64(bytes), functionTime)
+		db.dbStats().DatabaseStats.ImportProcessCompute.Add(stat)
+	}()
 	if db.UseXattrs() {
 		writeUpdateFunc := func(currentValue []byte, currentXattr []byte, currentUserXattr []byte, cas uint64) (
 			raw []byte, rawXattr []byte, deleteDoc bool, expiry *uint32, err error) {

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -167,8 +167,13 @@ func calculateImportCompute(bytes, functionTime float64) float64 {
 }
 
 func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
+	var importAttempt bool
 	startTime := time.Now()
 	defer func() {
+		// if we aren't attempting to import doc we don't want a calculation to happen
+		if !importAttempt {
+			return
+		}
 		// we must grab the time in seconds here and convert to ms as the .Milliseconds() function returns integer millisecond count
 		functionTime := time.Since(startTime).Seconds()
 		bytes := float64(len(event.Value))
@@ -202,6 +207,7 @@ func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
 
 	// If syncData is nil, or if this was not an SG write, attempt to import
 	if syncData == nil || !isSGWrite {
+		importAttempt = true
 		isDelete := event.Opcode == sgbucket.FeedOpDeletion
 		if isDelete {
 			rawBody = nil

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -180,7 +180,7 @@ func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
 		functionTime := time.Since(startTime).Milliseconds()
 		bytes := len(event.Value)
 		stat := calculateImportCompute(int64(bytes), functionTime)
-		il.importStats.ImportProcessCompute.Add(stat)
+		il.dbStats.ImportProcessCompute.Add(stat)
 	}()
 	// Unmarshal the doc metadata (if present) to determine if this mutation requires import.
 	collectionCtx, ok := il.collections[event.CollectionID]

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -21,8 +21,6 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
-const MiB = 1048576
-
 // ImportListener manages the import DCP feed.  ProcessFeedEvent is triggered for each feed events,
 // and invokes ImportFeedEvent for any event that's eligible for import handling.
 type importListener struct {
@@ -163,8 +161,8 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) (shouldPers
 // to use MB (Si) unit we must change the 'MiB' constant used here to 1000000
 func calculateImportCompute(bytes, functionTime float64) float64 {
 	timeMS := functionTime * float64(1000)
-	eventMb := bytes / MiB
-	stat := timeMS * (eventMb / 32 * MiB)
+	eventMb := bytes / base.MiB
+	stat := timeMS * (eventMb / 32 * base.MiB)
 	return stat
 }
 

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -162,7 +162,7 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) (shouldPers
 func calculateImportCompute(bytes, functionTime float64) float64 {
 	timeMS := functionTime * float64(1000)
 	eventMb := bytes / base.MiB
-	stat := timeMS * (eventMb / 32 * base.MiB)
+	stat := timeMS * eventMb
 	return stat
 }
 

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -157,18 +157,6 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) (shouldPers
 	return true
 }
 
-// calculateImportCompute calculates the import Process compute stat. NOTE: this current uses MiB as the MB unit to compute the stat
-// to use MB (Si) unit we must change the 'MiB' constant used here to 1000000
-func calculateImportCompute(bytes, functionTime int64) int64 {
-	// possible to get a less than 1 millisecond time on the function execution time. If we get this we need to have 1 as function time
-	// or the stat will be 0 even when import work is taking place
-	if functionTime == 0 {
-		functionTime = 1
-	}
-	stat := functionTime * bytes
-	return stat
-}
-
 func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
 	var importAttempt bool
 	startTime := time.Now()
@@ -179,7 +167,7 @@ func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
 		}
 		functionTime := time.Since(startTime).Milliseconds()
 		bytes := len(event.Value)
-		stat := calculateImportCompute(int64(bytes), functionTime)
+		stat := CalculateComputeStat(int64(bytes), functionTime)
 		il.dbStats.ImportProcessCompute.Add(stat)
 	}()
 	// Unmarshal the doc metadata (if present) to determine if this mutation requires import.

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -161,7 +161,8 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) (shouldPers
 
 // calculateImportCompute calculates the import Process compute stat. NOTE: this current uses MiB as the MB unit to compute the stat
 // to use MB (Si) unit we must change the 'MiB' constant used here to 1000000
-func calculateImportCompute(timeMS, bytes float64) float64 {
+func calculateImportCompute(bytes, functionTime float64) float64 {
+	timeMS := functionTime * float64(1000)
 	eventMb := bytes / MiB
 	stat := timeMS * (eventMb / 32 * MiB)
 	return stat
@@ -173,8 +174,7 @@ func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
 		// we must grab the time in seconds here and convert to ms as the .Milliseconds() function returns integer millisecond count
 		functionTime := time.Since(startTime).Seconds()
 		bytes := float64(len(event.Value))
-		ms := functionTime * float64(1000)
-		stat := calculateImportCompute(ms, bytes)
+		stat := calculateImportCompute(bytes, functionTime)
 		il.importStats.ImportProcessCompute.Add(stat)
 	}()
 	// Unmarshal the doc metadata (if present) to determine if this mutation requires import.

--- a/db/utils.go
+++ b/db/utils.go
@@ -70,3 +70,12 @@ type BackgroundTask struct {
 	taskName string        // Name of the background task.
 	doneChan chan struct{} // doneChan is closed when background task is terminated.
 }
+
+// CalculateComputeStat calculates the compute stat for import/sync
+func CalculateComputeStat(bytes, functionTime int64) int64 {
+	if functionTime == 0 {
+		functionTime = 1
+	}
+	stat := functionTime * bytes
+	return stat
+}

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -1918,6 +1918,8 @@ func TestImportRevisionCopyUnavailable(t *testing.T) {
 }
 
 func TestImportComputeStatOnDemandGet(t *testing.T) {
+	base.SkipImportTestsIfNotEnabled(t)
+
 	rtConfig := rest.RestTesterConfig{
 		SyncFn: channels.DocChannelsSyncFunction,
 		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
@@ -1971,6 +1973,8 @@ func TestImportComputeStatOnDemandGet(t *testing.T) {
 }
 
 func TestImportComputeStatOnDemandWrite(t *testing.T) {
+	base.SkipImportTestsIfNotEnabled(t)
+	
 	importFilter := `function (doc) { return doc.type == "mobile"}`
 	rtConfig := rest.RestTesterConfig{
 		SyncFn: channels.DocChannelsSyncFunction,
@@ -1989,6 +1993,8 @@ func TestImportComputeStatOnDemandWrite(t *testing.T) {
 	docBody["channels"] = "ABC"
 
 	// assert the stat starts at 0 for a new database
+	//fmt.Println(rt.GetDatabase().DbStats.SharedBucketImportStats.ImportProcessCompute)
+	time.Sleep(5 * time.Second)
 	computeStat := rt.GetDatabase().DbStats.SharedBucketImportStats.ImportProcessCompute.Value()
 	require.Equal(t, float64(0), computeStat)
 

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -2081,7 +2081,7 @@ func TestQueryResyncImportComputeStat(t *testing.T) {
 
 	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_offline", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	rt.WaitForDatabaseState(rt.GetDatabase().Name, db.DBOffline)
+	require.NoError(t, rt.WaitForDatabaseState(rt.GetDatabase().Name, db.DBOffline))
 
 	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_resync?action=start", "")
 	rest.RequireStatus(t, resp, http.StatusOK)

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -1937,7 +1937,7 @@ func TestImportComputeStatOnDemandGet(t *testing.T) {
 
 	// assert the stat starts at 0 for a new database
 	computeStat := rt.GetDatabase().DbStats.SharedBucketImportStats.ImportProcessCompute.Value()
-	require.Equal(t, float64(0), computeStat)
+	require.Equal(t, int64(0), computeStat)
 
 	// add doc to bucket
 	_, err := dataStore.Add(key, 0, docBody)
@@ -1952,7 +1952,7 @@ func TestImportComputeStatOnDemandGet(t *testing.T) {
 
 	// assert the process compute stat has incremented
 	computeStat1 := rt.GetDatabase().DbStats.SharedBucketImportStats.ImportProcessCompute.Value()
-	require.Greater(t, computeStat1, float64(0))
+	require.Greater(t, computeStat1, int64(0))
 
 	// update doc in bucket
 	updatedBody := make(map[string]interface{})
@@ -1994,7 +1994,7 @@ func TestImportComputeStatOnDemandWrite(t *testing.T) {
 
 	// assert the stat starts at 0 for a new database
 	computeStat := rt.GetDatabase().DbStats.SharedBucketImportStats.ImportProcessCompute.Value()
-	require.Equal(t, float64(0), computeStat)
+	require.Equal(t, int64(0), computeStat)
 
 	// add doc to bucket
 	_, err := dataStore.Add(key, 0, docBody)
@@ -2007,7 +2007,7 @@ func TestImportComputeStatOnDemandWrite(t *testing.T) {
 
 	// assert stat still no incremented as import filter rejects the doc
 	computeStat1 := rt.GetDatabase().DbStats.SharedBucketImportStats.ImportProcessCompute.Value()
-	require.Equal(t, float64(0), computeStat1)
+	require.Equal(t, int64(0), computeStat1)
 
 	// rewrite through SG - should treat as new insert
 	docBodyString := `{"type":"SG client rewrite",
@@ -2040,7 +2040,7 @@ func TestAutoImportComputeStat(t *testing.T) {
 
 	// assert the stat starts at 0 for a new database
 	computeStat := rt.GetDatabase().DbStats.SharedBucketImportStats.ImportProcessCompute.Value()
-	require.Equal(t, float64(0), computeStat)
+	require.Equal(t, int64(0), computeStat)
 
 	// add doc to bucket
 	_, err := dataStore.Add(key, 0, docBody)
@@ -2054,7 +2054,7 @@ func TestAutoImportComputeStat(t *testing.T) {
 
 	// assert the stat increments for the auto import of the above doc
 	computeStat1 := rt.GetDatabase().DbStats.SharedBucketImportStats.ImportProcessCompute.Value()
-	require.Greater(t, computeStat1, float64(0))
+	require.Greater(t, computeStat1, int64(0))
 }
 
 // Verify config flag for import creation of backup revision on import

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -1946,9 +1946,6 @@ func TestImportComputeStatOnDemandGet(t *testing.T) {
 	// trigger import via SG retrieval
 	response := rt.SendAdminRequest("GET", "/{{.keyspace}}/_raw/"+key, "")
 	rest.RequireStatus(t, response, http.StatusOK)
-	var rawInsertResponse rest.RawResponse
-	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
-	require.NoError(t, err, "Unable to unmarshal raw response")
 
 	// assert the process compute stat has incremented
 	computeStat1 := rt.GetDatabase().DbStats.SharedBucketImportStats.ImportProcessCompute.Value()
@@ -1964,8 +1961,6 @@ func TestImportComputeStatOnDemandGet(t *testing.T) {
 	// trigger import via SG retrieval
 	response = rt.SendAdminRequest("GET", "/{{.keyspace}}/_raw/"+key, "")
 	rest.RequireStatus(t, response, http.StatusOK)
-	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
-	require.NoError(t, err, "Unable to unmarshal raw response")
 	// assert the process compute stat has incremented again after another import
 	computeStat2 := rt.GetDatabase().DbStats.SharedBucketImportStats.ImportProcessCompute.Value()
 	require.Greater(t, computeStat2, computeStat1)

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -1974,7 +1974,7 @@ func TestImportComputeStatOnDemandGet(t *testing.T) {
 
 func TestImportComputeStatOnDemandWrite(t *testing.T) {
 	base.SkipImportTestsIfNotEnabled(t)
-	
+
 	importFilter := `function (doc) { return doc.type == "mobile"}`
 	rtConfig := rest.RestTesterConfig{
 		SyncFn: channels.DocChannelsSyncFunction,
@@ -1993,8 +1993,6 @@ func TestImportComputeStatOnDemandWrite(t *testing.T) {
 	docBody["channels"] = "ABC"
 
 	// assert the stat starts at 0 for a new database
-	//fmt.Println(rt.GetDatabase().DbStats.SharedBucketImportStats.ImportProcessCompute)
-	time.Sleep(5 * time.Second)
 	computeStat := rt.GetDatabase().DbStats.SharedBucketImportStats.ImportProcessCompute.Value()
 	require.Equal(t, float64(0), computeStat)
 

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -562,26 +562,6 @@ func TestResyncOverDCP(t *testing.T) {
 			RequireStatus(t, response, http.StatusOK)
 
 			resyncManagerStatus := rt.WaitForResyncStatus(db.BackgroundProcessStateCompleted)
-			/*
-				var resyncManagerStatus db.ResyncManagerResponse
-				err := rt.WaitForCondition(func() bool {
-					response := rt.SendAdminRequest("GET", "/{{.db}}/_resync", "")
-					err := json.Unmarshal(response.BodyBytes(), &resyncManagerStatus)
-					assert.NoError(t, err)
-
-					var val interface{}
-					_, err = rt.MetadataStore().Get(rt.GetDatabase().ResyncManager.GetHeartbeatDocID(t), &val)
-
-					if resyncManagerStatus.State == db.BackgroundProcessStateCompleted && base.IsDocNotFoundError(err) {
-						return true
-					} else {
-						t.Logf("resyncManagerStatus.State != %v: %v - err:%v", db.BackgroundProcessStateCompleted, resyncManagerStatus.State, err)
-						return false
-					}
-				})
-				require.NoError(t, err)
-
-			*/
 
 			assert.GreaterOrEqual(t, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()), testCase.expectedSyncFnRuns)
 			assert.GreaterOrEqual(t, resyncManagerStatus.DocsProcessed, testCase.docsCreated)

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -1101,9 +1101,12 @@ func TestResyncPersistence(t *testing.T) {
 	// Wait for resync to complete
 	_ = rt1.WaitForResyncStatus(db.BackgroundProcessStateCompleted)
 
+	resp = rt1.SendAdminRequest("GET", "/{{.db}}/_resync", "")
+	RequireStatus(t, resp, http.StatusOK)
+
 	// Check statuses match
 	resp2 := rt2.SendAdminRequest("GET", "/{{.db}}/_resync", "")
-	RequireStatus(t, resp, http.StatusOK)
+	RequireStatus(t, resp2, http.StatusOK)
 	fmt.Printf("RT1 Resync Status: %s\n", resp.BodyBytes())
 	fmt.Printf("RT2 Resync Status: %s\n", resp2.BodyBytes())
 	assert.Equal(t, resp.BodyBytes(), resp2.BodyBytes())

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -228,6 +228,46 @@ func (rt *RestTester) GetReplicationStatuses(queryString string) (statuses []db.
 	return statuses
 }
 
+func (rt *RestTester) WaitForResyncStatus(status db.BackgroundProcessState) db.ResyncManagerResponse {
+	var resyncStatus db.ResyncManagerResponse
+	successFunc := func() bool {
+		response := rt.SendAdminRequest("GET", "/{{.db}}/_resync", "")
+		err := json.Unmarshal(response.BodyBytes(), &resyncStatus)
+		require.NoError(rt.TB, err)
+
+		var val interface{}
+		_, err = rt.Bucket().DefaultDataStore().Get(rt.GetDatabase().ResyncManager.GetHeartbeatDocID(rt.TB), &val)
+
+		if status == db.BackgroundProcessStateCompleted {
+			return resyncStatus.State == status && base.IsDocNotFoundError(err)
+		} else {
+			return resyncStatus.State == status
+		}
+	}
+	require.NoError(rt.TB, rt.WaitForCondition(successFunc), "Expected status: %s, actual status: %s", status, resyncStatus.State)
+	return resyncStatus
+}
+
+func (rt *RestTester) WaitForResyncDCPStatus(status db.BackgroundProcessState) db.ResyncManagerResponseDCP {
+	var resyncStatus db.ResyncManagerResponseDCP
+	successFunc := func() bool {
+		response := rt.SendAdminRequest("GET", "/{{.db}}/_resync", "")
+		err := json.Unmarshal(response.BodyBytes(), &resyncStatus)
+		require.NoError(rt.TB, err)
+
+		var val interface{}
+		_, err = rt.Bucket().DefaultDataStore().Get(rt.GetDatabase().ResyncManager.GetHeartbeatDocID(rt.TB), &val)
+
+		if status == db.BackgroundProcessStateCompleted {
+			return resyncStatus.State == status && base.IsDocNotFoundError(err)
+		} else {
+			return resyncStatus.State == status
+		}
+	}
+	require.NoError(rt.TB, rt.WaitForCondition(successFunc), "Expected status: %s, actual status: %s", status, resyncStatus.State)
+	return resyncStatus
+}
+
 // setupSGRPeers sets up two rest testers to be used for sg-replicate testing with the following configuration:
 //
 //	activeRT:


### PR DESCRIPTION
CBG-2930

Import feed compute stat implementation. 

- total time of the function (ms) * memory of Event.Value in bytes 
- We have to record time in seconds and convert to milliseconds as .Millisecond() returns ineger value. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1917/
- [x] `GSI=true,xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1916/
