### PR TITLE
Prerequisite work for CBG-2837

### DIFF
--- a/base/cluster_n1ql.go
+++ b/base/cluster_n1ql.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2023-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package base
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/couchbase/gocb/v2"
+	sgbucket "github.com/couchbase/sg-bucket"
+	pkgerrors "github.com/pkg/errors"
+	"strings"
+	"time"
+)
+
+var _ N1QLStore = &ClusterOnlyN1QLStore{}
+
+// ClusterOnlyN1qlStore implements the N1QLStore using only a cluster connection.
+// Currently still intended for use for operations against a single collection, but maintains that
+// information via metadata, and so supports sharing of the underlying gocb.Cluster with other
+// ClusterOnlyN1QLStore instances.  Anticipates future refactoring of N1QLStore to differentiate between
+// collection-scoped and non-collection-scoped operations.
+type ClusterOnlyN1QLStore struct {
+	cluster             *gocb.Cluster
+	bucketName          string
+	scopeName           string
+	collectionName      string
+	supportsCollections bool
+}
+
+func NewClusterOnlyN1QLStore(cluster *gocb.Cluster, bucketName, scopeName, collectionName string) (*ClusterOnlyN1QLStore, error) {
+
+	clusterOnlyn1qlStore := &ClusterOnlyN1QLStore{
+		cluster:        cluster,
+		bucketName:     bucketName,
+		scopeName:      scopeName,
+		collectionName: collectionName,
+	}
+
+	major, minor, err := getClusterVersion(cluster)
+	if err != nil {
+		return nil, err
+	}
+	clusterOnlyn1qlStore.supportsCollections = isMinimumVersion(uint64(major), uint64(minor), 7, 0)
+
+	return clusterOnlyn1qlStore, nil
+
+}
+
+func (cl *ClusterOnlyN1QLStore) GetName() string {
+	return cl.bucketName
+}
+
+func (cl *ClusterOnlyN1QLStore) BuildDeferredIndexes(indexSet []string) error {
+	return BuildDeferredIndexes(cl, indexSet)
+}
+
+func (cl *ClusterOnlyN1QLStore) CreateIndex(indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
+	return CreateIndex(cl, indexName, expression, filterExpression, options)
+}
+
+func (cl *ClusterOnlyN1QLStore) CreatePrimaryIndex(indexName string, options *N1qlIndexOptions) error {
+	return CreatePrimaryIndex(cl, indexName, options)
+}
+
+func (cl *ClusterOnlyN1QLStore) ExplainQuery(statement string, params map[string]interface{}) (plan map[string]interface{}, err error) {
+	return ExplainQuery(cl, statement, params)
+}
+
+func (cl *ClusterOnlyN1QLStore) DropIndex(indexName string) error {
+	return DropIndex(cl, indexName)
+}
+
+// IndexMetaKeyspaceID returns the value of keyspace_id for the system:indexes table for the collection.
+func (cl *ClusterOnlyN1QLStore) IndexMetaKeyspaceID() string {
+	return IndexMetaKeyspaceID(cl.bucketName, cl.scopeName, cl.collectionName)
+}
+
+// IndexMetaBucketID returns the value of bucket_id for the system:indexes table for the collection.
+func (cl *ClusterOnlyN1QLStore) IndexMetaBucketID() string {
+	if IsDefaultCollection(cl.scopeName, cl.collectionName) {
+		return ""
+	}
+	return cl.bucketName
+}
+
+// IndexMetaScopeID returns the value of scope_id for the system:indexes table for the collection.
+func (cl *ClusterOnlyN1QLStore) IndexMetaScopeID() string {
+	if IsDefaultCollection(cl.scopeName, cl.collectionName) {
+		return ""
+	}
+	return cl.scopeName
+}
+
+func (cl *ClusterOnlyN1QLStore) Query(statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (resultsIterator sgbucket.QueryResultIterator, err error) {
+	logCtx := context.TODO()
+
+	keyspaceStatement := strings.Replace(statement, KeyspaceQueryToken, cl.EscapedKeyspace(), -1)
+
+	n1qlOptions := &gocb.QueryOptions{
+		ScanConsistency: gocb.QueryScanConsistency(consistency),
+		Adhoc:           adhoc,
+		NamedParameters: params,
+	}
+
+	waitTime := 10 * time.Millisecond
+	for i := 1; i <= MaxQueryRetries; i++ {
+		TracefCtx(logCtx, KeyQuery, "Executing N1QL query: %v - %+v", UD(keyspaceStatement), UD(params))
+		queryResults, queryErr := cl.runQuery(keyspaceStatement, n1qlOptions)
+		if queryErr == nil {
+			resultsIterator := &gocbRawIterator{
+				rawResult:                  queryResults.Raw(),
+				concurrentQueryOpLimitChan: nil,
+			}
+			return resultsIterator, queryErr
+		}
+
+		// Timeout error - return named error
+		if errors.Is(queryErr, gocb.ErrTimeout) {
+			return resultsIterator, ErrViewTimeoutError
+		}
+
+		// Non-retry error - return
+		if !isTransientIndexerError(queryErr) {
+			WarnfCtx(logCtx, "Error when querying index using statement: [%s] parameters: [%+v] error:%v", UD(keyspaceStatement), UD(params), queryErr)
+			return resultsIterator, pkgerrors.WithStack(queryErr)
+		}
+
+		// Indexer error - wait then retry
+		err = queryErr
+		WarnfCtx(logCtx, "Indexer error during query - retry %d/%d after %v.  Error: %v", i, MaxQueryRetries, waitTime, queryErr)
+		time.Sleep(waitTime)
+
+		waitTime = waitTime * 2
+	}
+
+	WarnfCtx(logCtx, "Exceeded max retries for query when querying index using statement: [%s] parameters: [%+v], err:%v", UD(keyspaceStatement), UD(params), err)
+	return nil, err
+}
+
+// executeQuery runs a N1QL query against the cluster.  Does not throttle query ops.
+func (cl *ClusterOnlyN1QLStore) executeQuery(statement string) (sgbucket.QueryResultIterator, error) {
+	queryResults, queryErr := cl.runQuery(statement, nil)
+	if queryErr != nil {
+		return nil, queryErr
+	}
+
+	resultsIterator := &gocbRawIterator{
+		rawResult:                  queryResults.Raw(),
+		concurrentQueryOpLimitChan: nil,
+	}
+	return resultsIterator, nil
+}
+
+func (cl *ClusterOnlyN1QLStore) executeStatement(statement string) error {
+	queryResults, queryErr := cl.runQuery(statement, nil)
+	if queryErr != nil {
+		return queryErr
+	}
+
+	// Drain results to return any non-query errors
+	for queryResults.Next() {
+	}
+	closeErr := queryResults.Close()
+	if closeErr != nil {
+		return closeErr
+	}
+	return queryResults.Err()
+}
+
+func (cl *ClusterOnlyN1QLStore) runQuery(statement string, n1qlOptions *gocb.QueryOptions) (*gocb.QueryResult, error) {
+	if n1qlOptions == nil {
+		n1qlOptions = &gocb.QueryOptions{}
+	}
+	queryResults, err := cl.cluster.Query(statement, n1qlOptions)
+
+	return queryResults, err
+}
+
+func (cl *ClusterOnlyN1QLStore) WaitForIndexesOnline(indexNames []string, failfast bool) error {
+	return WaitForIndexesOnline(cl.cluster, cl.bucketName, cl.scopeName, cl.collectionName, indexNames, failfast)
+}
+
+func (cl *ClusterOnlyN1QLStore) GetIndexMeta(indexName string) (exists bool, meta *IndexMeta, err error) {
+	return GetIndexMeta(cl, indexName)
+}
+
+func (cl *ClusterOnlyN1QLStore) IsErrNoResults(err error) bool {
+	return err == gocb.ErrNoResult
+}
+
+// EscapedKeyspace returns the escaped fully-qualified identifier for the keyspace (e.g. `bucket`.`scope`.`collection`)
+func (cl *ClusterOnlyN1QLStore) EscapedKeyspace() string {
+	if !cl.supportsCollections {
+		return fmt.Sprintf("`%s`", cl.bucketName)
+	}
+	return fmt.Sprintf("`%s`.`%s`.`%s`", cl.bucketName, cl.scopeName, cl.collectionName)
+}
+
+func (cl *ClusterOnlyN1QLStore) GetIndexes() (indexes []string, err error) {
+	if cl.supportsCollections {
+		return GetAllIndexes(cl.cluster, cl.bucketName, cl.scopeName, cl.collectionName)
+	} else {
+		return GetAllIndexes(cl.cluster, cl.bucketName, "", "")
+	}
+}
+
+// waitUntilQueryServiceReady will wait for the specified duration until the query service is available.
+func (cl *ClusterOnlyN1QLStore) waitUntilQueryServiceReady(timeout time.Duration) error {
+	return cl.cluster.WaitUntilReady(timeout,
+		&gocb.WaitUntilReadyOptions{ServiceTypes: []gocb.ServiceType{gocb.ServiceTypeQuery}},
+	)
+}

--- a/base/cluster_n1ql.go
+++ b/base/cluster_n1ql.go
@@ -14,11 +14,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/couchbase/gocb/v2"
 	sgbucket "github.com/couchbase/sg-bucket"
 	pkgerrors "github.com/pkg/errors"
-	"strings"
-	"time"
 )
 
 var _ N1QLStore = &ClusterOnlyN1QLStore{}

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -506,3 +506,81 @@ func (i *gocbRawIterator) Close() error {
 	resultErr := i.rawResult.Err()
 	return resultErr
 }
+
+func IndexMetaKeyspaceID(bucketName, scopeName, collectionName string) string {
+	if IsDefaultCollection(scopeName, collectionName) {
+		return bucketName
+	}
+	return collectionName
+}
+
+// WaitForIndexesOnline takes set of indexes and watches them till they're online.
+func WaitForIndexesOnline(cluster *gocb.Cluster, bucketName, scopeName, collectionName string, indexNames []string, failfast bool) error {
+	logCtx := context.TODO()
+	mgr := cluster.QueryIndexes()
+	maxNumAttempts := 180
+	if failfast {
+		maxNumAttempts = 1
+	}
+	retrySleeper := CreateMaxDoublingSleeperFunc(maxNumAttempts, 100, 5000)
+	retryCount := 0
+
+	onlineIndexes := make(map[string]bool)
+
+	indexOption := gocb.GetAllQueryIndexesOptions{
+		ScopeName:      scopeName,
+		CollectionName: collectionName,
+		RetryStrategy:  &goCBv2FailFastRetryStrategy{},
+	}
+
+	for {
+		watchedOnlineIndexCount := 0
+		currIndexes, err := mgr.GetAllIndexes(bucketName, &indexOption)
+		if err != nil {
+			return err
+		}
+		// check each of the current indexes state, add to map once finished to make sure each index online is only being logged once
+		for i := 0; i < len(currIndexes); i++ {
+			if currIndexes[i].State == IndexStateOnline {
+				if !onlineIndexes[currIndexes[i].Name] {
+					InfofCtx(logCtx, KeyAll, "Index %s is online", MD(currIndexes[i].Name))
+					onlineIndexes[currIndexes[i].Name] = true
+				}
+			}
+		}
+		// check online index against indexes we watch to have online, increase counter as each comes online
+		for _, listVal := range indexNames {
+			if onlineIndexes[listVal] {
+				watchedOnlineIndexCount++
+			}
+		}
+
+		if watchedOnlineIndexCount == len(indexNames) {
+			return nil
+		}
+		retryCount++
+		shouldContinue, sleepMs := retrySleeper(retryCount)
+		if !shouldContinue {
+			return fmt.Errorf("error waiting for indexes for bucket %s....", MD(bucketName))
+		}
+		InfofCtx(logCtx, KeyAll, "Indexes for bucket %s not ready - retrying...", MD(bucketName))
+		time.Sleep(time.Millisecond * time.Duration(sleepMs))
+	}
+}
+
+func GetAllIndexes(cluster *gocb.Cluster, bucketName, scopeName, collectionName string) (indexes []string, err error) {
+	indexes = []string{}
+	opts := &gocb.GetAllQueryIndexesOptions{
+		ScopeName:      scopeName,
+		CollectionName: collectionName,
+	}
+	indexInfo, err := cluster.QueryIndexes().GetAllIndexes(bucketName, opts)
+	if err != nil {
+		return indexes, err
+	}
+
+	for _, indexInfo := range indexInfo {
+		indexes = append(indexes, indexInfo.Name)
+	}
+	return indexes, nil
+}


### PR DESCRIPTION
CBG-2837

Have split this work out of CBG-2837 to reduce PR complexity.  This PR includes two main bits of functionality:

**Cluster-only implementation of N1QLStore**
Supports performing index initialization without establishing a bucket connection.  To support the current N1QLStore interface, a keyspace (bucket/scope/collection) is still specified, but is only used for building keyspace inside query statements.  A future enhancement is anticipated to remove built-in keyspace from the IndexMeta API operations, but not included in this PR.
To support this implementation, some functionality common to the collection-based N1QLStore and the cluster N1QLStore was moved to collection_n1ql_common.

**Refactoring _getOrAddDatabaseFromConfig to better isolate index creation functionality**
There shouldn't be any functional change to _getOrAddDatabaseFromConfig in this PR, but moves the syncInfo checks out of initDataStore.  This should simplify review of future changes to initDataStore behaviour. 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1871/
- [ ] `defaultCollection=true,GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1873/
  - [ ] [`TestResyncManagerDCPStopInMidWay`](https://jenkins.sgwdev.com/job/SyncGateway-Integration/1873/testReport/junit/github/com_couchbase_sync_gateway_db/TestResyncManagerDCPStopInMidWay/)
  - [ ] [`TestAllDocsQuery`](https://jenkins.sgwdev.com/job/SyncGateway-Integration/1873/testReport/junit/github/com_couchbase_sync_gateway_db/TestAllDocsQuery/)
- [x] rerun `defaultCollection=true,GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1876/