### PR TITLE
CBG-3091: [3.1.1] backport the small fix for flake on TestReconnectReplicator in jenkins 

### DIFF
--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -2308,14 +2308,18 @@ func TestReconnectReplicator(t *testing.T) {
 
 			activeRT.WaitForActiveReplicatorInitialization(1)
 			ar := activeRT.GetDatabase().SGReplicateMgr.GetActiveReplicator("replication1")
+			numConnectionAttempts := ar.Pull.GetStats().NumConnectAttempts.Value()
 			// race between stopping the blip sender here and the initialization of it on the replicator so need this assertion in here to avoid panic
 			activeRT.WaitForPullBlipSenderInitialisation(replicationName)
 			ar.Pull.GetBlipSender().Stop()
 
-			activeRT.WaitForReplicationStatus(replicationName, db.ReplicationStateReconnecting)
-
+			// assert on replicator reconnecting and getting back to running state once reconnected
+			// due to race in jenkins we assert on connection stat increasing instead of asserting on replication state hitting reconnecting state
+			ar = activeRT.GetDatabase().SGReplicateMgr.GetActiveReplicator("replication1")
+			assert.Greater(t, ar.Pull.GetStats().NumConnectAttempts.Value(), numConnectionAttempts)
 			activeRT.WaitForReplicationStatus(replicationName, db.ReplicationStateRunning)
 
+			// assert the replicator works and we replicate docs still after replicator reconnects
 			for i := 0; i < 10; i++ {
 				response := remoteRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+fmt.Sprint(i), `{"source": "remote"}`)
 				rest.RequireStatus(t, response, http.StatusCreated)


### PR DESCRIPTION
CBG-3091

Backport the small fix for this test. It seems to flake fairly regular in Jenkins builds so this will reduce noise whilst 3.1.1 is still in progress. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1878/
