### PR TITLE
Fix error checking inside Request utility func

### DIFF
--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1104,11 +1104,11 @@ func (r TestResponse) GetRestDocument() RestDocument {
 
 func Request(method, resource, body string) *http.Request {
 	request, err := http.NewRequest(method, "http://localhost"+resource, bytes.NewBufferString(body))
-	request.RequestURI = resource // This doesn't get filled in by NewRequest
-	FixQuotedSlashes(request)
 	if err != nil {
 		panic(fmt.Sprintf("http.NewRequest failed: %v", err))
 	}
+	request.RequestURI = resource // This doesn't get filled in by NewRequest
+	FixQuotedSlashes(request)
 	return request
 }
 

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -335,3 +335,10 @@ func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
 	}
 
 }
+
+func TestRequest(t *testing.T) {
+	assert.PanicsWithValue(t, `http.NewRequest failed: parse "http://localhost%": invalid URL escape "%"`, func() {
+		// invalid URL escape - should panic (with a prefix in message)
+		_ = Request(http.MethodGet, "%", "")
+	})
+}


### PR DESCRIPTION
If `http.NewRequest` returns `nil, err` we don't know and panic when trying to do `request.RequestURI`