### PR TITLE
Cover keyspace request in TestOpenIDConnectImplicitFlow

### DIFF
--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -1071,6 +1071,11 @@ func TestOpenIDConnectImplicitFlow(t *testing.T) {
 				return
 			}
 			checkGoodAuthResponse(t, restTester, response, "foo_noah")
+
+			c := getCookie(response.Cookies(), auth.DefaultCookieName)
+
+			resp := restTester.SendRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc1", `{"foo":"bar"}`, map[string]string{"Cookie": c.String()})
+			RequireStatus(t, resp, http.StatusCreated)
 		})
 	}
 }


### PR DESCRIPTION
Adds a (working) step to issue a keyspace-scoped cookie authenticated request for more coverage.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1880/
