### PR TITLE
Fix CE integration tests

### DIFF
--- a/base/main_test_bucket_pool_config.go
+++ b/base/main_test_bucket_pool_config.go
@@ -75,10 +75,10 @@ func TestsUseNamedCollections() bool {
 	return err == nil && ok
 }
 
-// TestsUseNamedCollections returns true if the tests use named collections.
+// TestsUseServerCE returns true if the tests are targeting a CE server.
 func TestsUseServerCE() bool {
-	ok, err := GTestBucketPool.cluster.isServerEnterprise()
-	return err == nil && ok
+	isEE, err := GTestBucketPool.cluster.isServerEnterprise()
+	return err == nil && !isEE
 }
 
 // TestsRequireMobileRBAC returns true if the server has Sync Gateway RBAC roles.

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -200,6 +200,15 @@ func (c *tbpClusterV2) supportsCollections() (bool, error) {
 
 // supportsMobileRBAC is true if running couchbase server with all Sync Gateway roles
 func (c *tbpClusterV2) supportsMobileRBAC() (bool, error) {
+	isEE, err := c.isServerEnterprise()
+	if err != nil {
+		return false, err
+	}
+	// mobile RBAC is only supported on EE
+	if !isEE {
+		return false, nil
+	}
+	// mobile RBAC is only supported on 7.1+
 	major, minor, err := getClusterVersion(c.cluster)
 	if err != nil {
 		return false, err

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -109,7 +109,7 @@ func (c *tbpClusterV2) isServerEnterprise() (bool, error) {
 		return false, err
 	}
 
-	if strings.Contains("enterprise", metadata[0].Version) {
+	if strings.Contains(metadata[0].Version, "enterprise") {
 		return true, nil
 	}
 	return false, nil

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -845,8 +845,10 @@ func TestAdminAPIAuth(t *testing.T) {
 		},
 	}
 
+	serverIsCE := base.TestsUseServerCE()
+
 	SGWorBFArole := MobileSyncGatewayRole.RoleName
-	if base.TestsUseServerCE() {
+	if serverIsCE {
 		SGWorBFArole = BucketFullAccessRole.RoleName
 	}
 	eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
@@ -861,7 +863,8 @@ func TestAdminAPIAuth(t *testing.T) {
 	MakeUser(t, httpClient, eps[0], "ROAdminUser", "password", []string{ReadOnlyAdminRole.RoleName})
 	defer DeleteUser(t, httpClient, eps[0], "ROAdminUser")
 
-	if base.TestsUseServerCE() {
+	// EE only role
+	if !serverIsCE {
 		MakeUser(t, httpClient, eps[0], "ClusterAdminUser", "password", []string{ClusterAdminRole.RoleName})
 		defer DeleteUser(t, httpClient, eps[0], "ClusterAdminUser")
 	}
@@ -896,7 +899,7 @@ func TestAdminAPIAuth(t *testing.T) {
 						RequireStatus(t, resp, http.StatusForbidden)
 					}
 
-					if base.TestsUseServerCE() {
+					if !serverIsCE {
 						resp = rt.SendAdminRequestWithAuth(endPoint.Method, endPoint.Endpoint, body, "ClusterAdminUser", "password")
 						assert.True(t, resp.Code != http.StatusUnauthorized && resp.Code != http.StatusForbidden)
 					}

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -135,16 +135,22 @@ func TestCECheck(t *testing.T) {
 	}
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
-	form := url.Values{}
-	form.Add("password", "password")
-	form.Add("roles", "[mobile_sync_Gateway]")
 	eps, _, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
 	require.NoError(t, err)
 
-	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/settings/rbac/users/local/%s", eps[0], "username"), strings.NewReader(form.Encode()))
-	require.Error(t, err)
-	require.Equal(t, req, http.StatusBadRequest)
+	form := url.Values{}
+	form.Add("password", "password")
+	form.Add("roles", "[mobile_sync_Gateway]")
 
+	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/settings/rbac/users/local/%s", eps[0], "username"), strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(base.TestClusterUsername(), base.TestClusterPassword())
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, resp.StatusCode, http.StatusBadRequest)
 }
 
 func TestRestTesterTemplateMultipleDatabases(t *testing.T) {


### PR DESCRIPTION
Follow up for #6086 #6094 

The function `isServerEnterprise` was doing `strings.Contains` incorrectly, resulting in both CE and EE _always_ returning `false` for `isServerEnterprise`.

Corrected and flipped bool returned by `TestsUseServerCE` to accommodate fix.
This resulted in uncovering failing CE tests.

Subsequent fixes:
- `TestDisablePermissionCheck`
  - Was trying to use RBAC permissions in CE (which don't exist)
- `TestAdminAPIAuth`
  - Was trying to use a role that doesn't exist in CE
- `TestCECheck`
  - Was creating a HTTP request, expecting it not to work (when it did), and not sending it! The test was _never_ being executed...
  - Fixed test to actually send the request to CB Server

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `EE` `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1881/
- [ ] `CE` `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1882/
  - FAIL: [`TestNewlyCreateSGWPermissions`](https://jenkins.sgwdev.com/job/SyncGateway-Integration/1882/testReport/junit/github/com_couchbase_sync_gateway_rest/TestNewlyCreateSGWPermissions/)
- [x] `CE` `TestNewlyCreateSGWPermissions` fix https://jenkins.sgwdev.com/job/SyncGateway-Integration/1883/