### PR TITLE
CBG-2993: allow tcp_nodelay to be set to false for tls connections

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -1650,25 +1650,27 @@ func GetHttpClientForWebSocket(insecureSkipVerify bool) *http.Client {
 // Turns off TCP NODELAY on a TCP connection.
 // On success returns true; on failure logs a warning and returns false.
 // (There's really no reason for a caller to take note of the return value.)
-func turnOffNoDelay(ctx context.Context, conn net.Conn) bool {
+func turnOffNoDelay(ctx context.Context, conn net.Conn) {
+	var underlyingTCPConn *net.TCPConn
 	if tlsConn, ok := conn.(*tls.Conn); ok {
-		underlyingTCPConn := tlsConn.NetConn()
-		if tcp, ok := underlyingTCPConn.(*net.TCPConn); !ok {
-			WarnfCtx(ctx, "Couldn't turn off NODELAY for tls conn %v: underlying connection is not type *net.TCPConn", conn)
-		} else if err := tcp.SetNoDelay(false); err != nil {
-			WarnfCtx(ctx, "Couldn't turn off NODELAY for %v: %v", conn, err)
+		netConnection := tlsConn.NetConn()
+		if tcp, isTCPConn := netConnection.(*net.TCPConn); isTCPConn {
+			underlyingTCPConn = tcp
 		} else {
-			return true
+			WarnfCtx(ctx, "Couldn't turn off NODELAY for conn %v: underlying connection is not type *net.TCPConn", conn)
+		}
+	} else if tcpConn, isTCPConn := conn.(*net.TCPConn); isTCPConn {
+		underlyingTCPConn = tcpConn
+	} else {
+		WarnfCtx(ctx, "Couldn't turn off NODELAY for conn %v: underlying connection is not type *net.TCPConn", conn)
+	}
+
+	if underlyingTCPConn != nil {
+		if err := underlyingTCPConn.SetNoDelay(false); err != nil {
+			WarnfCtx(ctx, "Couldn't turn off NODELAY for %v: %v", conn, err)
 		}
 	}
-	if tcpConn, ok := conn.(*net.TCPConn); !ok {
-		WarnfCtx(ctx, "Couldn't turn off NODELAY for %v: %T is not type *net.TCPConn", conn, conn)
-	} else if err := tcpConn.SetNoDelay(false); err != nil {
-		WarnfCtx(ctx, "Couldn't turn off NODELAY for %v: %v", conn, err)
-	} else {
-		return true
-	}
-	return false
+	return
 }
 
 // IsConnectionRefusedError returns true if the given error is due to a connection being actively refused.

--- a/base/util.go
+++ b/base/util.go
@@ -1651,6 +1651,16 @@ func GetHttpClientForWebSocket(insecureSkipVerify bool) *http.Client {
 // On success returns true; on failure logs a warning and returns false.
 // (There's really no reason for a caller to take note of the return value.)
 func turnOffNoDelay(ctx context.Context, conn net.Conn) bool {
+	if tlsConn, ok := conn.(*tls.Conn); ok {
+		underlyingTCPConn := tlsConn.NetConn()
+		if tcp, ok := underlyingTCPConn.(*net.TCPConn); !ok {
+			WarnfCtx(ctx, "Couldn't turn off NODELAY for tls conn %v: underlying connection is not type *net.TCPConn", conn)
+		} else if err := tcp.SetNoDelay(false); err != nil {
+			WarnfCtx(ctx, "Couldn't turn off NODELAY for %v: %v", conn, err)
+		} else {
+			return true
+		}
+	}
 	if tcpConn, ok := conn.(*net.TCPConn); !ok {
 		WarnfCtx(ctx, "Couldn't turn off NODELAY for %v: %T is not type *net.TCPConn", conn, conn)
 	} else if err := tcpConn.SetNoDelay(false); err != nil {


### PR DESCRIPTION
CBG-2993


Small change to allow tcp_nodelay to be set for tls connections. The PR essentialy checks for tls connection and then gets the underlying tcp connection to perform the SetNoDelay operation on. 
Tested manually through the debugger and seems to work fine with tls connections and TCP connections. 
This change includes a refactor of the code. I have made the function return type void and the callers don't use the returned type. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1890/
