### PR TITLE
Add `context.Context` to `Consolef` logging function for consistency

### DIFF
--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -49,7 +50,7 @@ type ConsoleLoggerConfig struct {
 }
 
 // NewConsoleLogger returns a new ConsoleLogger from a config.
-func NewConsoleLogger(shouldLogLocation bool, config *ConsoleLoggerConfig) (*ConsoleLogger, error) {
+func NewConsoleLogger(ctx context.Context, shouldLogLocation bool, config *ConsoleLoggerConfig) (*ConsoleLogger, error) {
 	if config == nil {
 		config = &ConsoleLoggerConfig{}
 	}
@@ -92,9 +93,9 @@ func NewConsoleLogger(shouldLogLocation bool, config *ConsoleLoggerConfig) (*Con
 			if config.FileOutput != "" {
 				consoleOutput = config.FileOutput
 			}
-			Consolef(LevelInfo, KeyNone, "Logging: Console to %v", consoleOutput)
+			ConsolefCtx(ctx, LevelInfo, KeyNone, "Logging: Console to %v", consoleOutput)
 		} else {
-			Consolef(LevelInfo, KeyNone, "Logging: Console disabled")
+			ConsolefCtx(ctx, LevelInfo, KeyNone, "Logging: Console disabled")
 		}
 	}
 
@@ -216,8 +217,8 @@ func (lcc *ConsoleLoggerConfig) init() error {
 	return nil
 }
 
-func mustInitConsoleLogger(config *ConsoleLoggerConfig) *ConsoleLogger {
-	logger, err := NewConsoleLogger(false, config)
+func mustInitConsoleLogger(ctx context.Context, config *ConsoleLoggerConfig) *ConsoleLogger {
+	logger, err := NewConsoleLogger(ctx, false, config)
 	if err != nil {
 		// TODO: CBG-1948
 		panic(err)

--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -97,7 +97,7 @@ func TestConsoleShouldLog(t *testing.T) {
 			test.loggerLevel.StringShort(), test.loggerKeys,
 			test.logToLevel.StringShort(), test.logToKey)
 
-		l := mustInitConsoleLogger(&ConsoleLoggerConfig{
+		l := mustInitConsoleLogger(TestCtx(t), &ConsoleLoggerConfig{
 			LogLevel: &test.loggerLevel,
 			LogKeys:  test.loggerKeys,
 			FileLoggerConfig: FileLoggerConfig{
@@ -118,7 +118,7 @@ func BenchmarkConsoleShouldLog(b *testing.B) {
 			test.loggerLevel.StringShort(), test.loggerKeys,
 			test.logToLevel.StringShort(), test.logToKey)
 
-		l := mustInitConsoleLogger(&ConsoleLoggerConfig{
+		l := mustInitConsoleLogger(TestCtx(b), &ConsoleLoggerConfig{
 			LogLevel: &test.loggerLevel,
 			LogKeys:  test.loggerKeys,
 			FileLoggerConfig: FileLoggerConfig{
@@ -184,7 +184,7 @@ func TestConsoleLogDefaults(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			logger, err := NewConsoleLogger(false, &test.config)
+			logger, err := NewConsoleLogger(TestCtx(t), false, &test.config)
 			assert.NoError(tt, err)
 			assert.Equal(tt, test.expected.Enabled, logger.Enabled)
 			assert.Equal(tt, *test.expected.LogLevel, *logger.LogLevel)

--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -184,7 +184,7 @@ func TestConsoleLogDefaults(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			logger, err := NewConsoleLogger(TestCtx(t), false, &test.config)
+			logger, err := NewConsoleLogger(TestCtx(tt), false, &test.config)
 			assert.NoError(tt, err)
 			assert.Equal(tt, test.expected.Enabled, logger.Enabled)
 			assert.Equal(tt, *test.expected.LogLevel, *logger.LogLevel)

--- a/base/logging.go
+++ b/base/logging.go
@@ -122,7 +122,7 @@ func init() {
 	// initializing a logging config, and when running under a test scenario.
 	initialCollationBufferSize := 0
 
-	consoleLogger = mustInitConsoleLogger(&ConsoleLoggerConfig{FileLoggerConfig: FileLoggerConfig{Enabled: BoolPtr(true), CollationBufferSize: &initialCollationBufferSize}})
+	consoleLogger = mustInitConsoleLogger(context.Background(), &ConsoleLoggerConfig{FileLoggerConfig: FileLoggerConfig{Enabled: BoolPtr(true), CollationBufferSize: &initialCollationBufferSize}})
 	initExternalLoggers()
 }
 
@@ -240,24 +240,24 @@ func logTo(ctx context.Context, logLevel LogLevel, logKey LogKey, format string,
 
 var consoleFOutput io.Writer = os.Stderr
 
-// Consolef logs the given formatted string and args to the given log level and log key,
+// ConsolefCtx logs the given formatted string and args to the given log level and log key,
 // as well as making sure the message is *always* logged to stdout.
-func Consolef(logLevel LogLevel, logKey LogKey, format string, args ...interface{}) {
-	logTo(context.Background(), logLevel, logKey, format, args...)
+func ConsolefCtx(ctx context.Context, logLevel LogLevel, logKey LogKey, format string, args ...interface{}) {
+	logTo(ctx, logLevel, logKey, format, args...)
 
 	// If the above logTo didn't already log to stderr, do it directly here
 	if !consoleLogger.isStderr || !consoleLogger.shouldLog(logLevel, logKey) {
-		format = color(addPrefixes(format, context.Background(), logLevel, logKey), logLevel)
+		format = color(addPrefixes(format, ctx, logLevel, logKey), logLevel)
 		_, _ = fmt.Fprintf(consoleFOutput, format+"\n", args...)
 	}
 }
 
 // LogSyncGatewayVersion will print the '==== name/version ====' startup indicator to ALL log outputs.
-func LogSyncGatewayVersion() {
+func LogSyncGatewayVersion(ctx context.Context) {
 	msg := fmt.Sprintf("==== %s ====", LongVersionString)
 
 	// Log the startup indicator to the stderr.
-	Consolef(LevelNone, KeyNone, msg)
+	ConsolefCtx(ctx, LevelNone, KeyNone, msg)
 
 	// Log the startup indicator to ALL log files too.
 	msg = addPrefixes(msg, context.Background(), LevelNone, KeyNone)

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -55,20 +56,20 @@ type LegacyLoggingConfig struct {
 	Stats          FileLoggerConfig    `json:"stats,omitempty"`           // Stats log file output
 }
 
-func InitLogging(logFilePath string,
+func InitLogging(ctx context.Context, logFilePath string,
 	console *ConsoleLoggerConfig,
 	error, warn, info, debug, trace, stats *FileLoggerConfig) (err error) {
 
-	consoleLogger, err = NewConsoleLogger(true, console)
+	consoleLogger, err = NewConsoleLogger(ctx, true, console)
 	if err != nil {
 		return err
 	}
 
 	// If there's nowhere to specified put log files, we'll log an error, but continue anyway.
 	if logFilePath == "" {
-		Consolef(LevelInfo, KeyNone, "Logging: Files disabled")
+		ConsolefCtx(ctx, LevelInfo, KeyNone, "Logging: Files disabled")
 		// Explicitly log this error to console
-		Consolef(LevelError, KeyNone, ErrUnsetLogFilePath.Error())
+		ConsolefCtx(ctx, LevelError, KeyNone, ErrUnsetLogFilePath.Error())
 
 		// nil out other loggers
 		errorLogger = nil
@@ -85,7 +86,7 @@ func InitLogging(logFilePath string,
 	if err != nil {
 		return err
 	} else {
-		Consolef(LevelInfo, KeyNone, "Logging: Files to %v", logFilePath)
+		ConsolefCtx(ctx, LevelInfo, KeyNone, "Logging: Files to %v", logFilePath)
 	}
 
 	errorLogger, err = NewFileLogger(error, LevelError, LevelError.String(), logFilePath, errorMinAge, &errorLogger.buffer)

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -198,7 +198,7 @@ func TestLogSyncGatewayVersion(t *testing.T) {
 	for i := LevelNone; i < levelCount; i++ {
 		t.Run(i.String(), func(t *testing.T) {
 			consoleLogger.LogLevel.Set(i)
-			out := CaptureConsolefLogOutput(LogSyncGatewayVersion)
+			out := CaptureConsolefLogOutput(func() { LogSyncGatewayVersion(TestCtx(t)) })
 			assert.Contains(t, out, LongVersionString)
 		})
 	}

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -2676,7 +2676,7 @@ func TestConfigEndpoint(t *testing.T) {
 			base.InitializeMemoryLoggers()
 			tempDir := os.TempDir()
 			test := rest.DefaultStartupConfig(tempDir)
-			err := test.SetupAndValidateLogging()
+			err := test.SetupAndValidateLogging(base.TestCtx(t))
 			assert.NoError(t, err)
 
 			rt := rest.NewRestTester(t, nil)
@@ -2777,7 +2777,7 @@ func TestIncludeRuntimeStartupConfig(t *testing.T) {
 	base.InitializeMemoryLoggers()
 	tempDir := os.TempDir()
 	test := rest.DefaultStartupConfig(tempDir)
-	err := test.SetupAndValidateLogging()
+	err := test.SetupAndValidateLogging(base.TestCtx(t))
 	assert.NoError(t, err)
 
 	rt := rest.NewRestTester(t, nil)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -678,7 +678,7 @@ func TestSetupAndValidateLogging(t *testing.T) {
 	t.Skip("Skipping TestSetupAndValidateLogging")
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	sc := &StartupConfig{}
-	err := sc.SetupAndValidateLogging()
+	err := sc.SetupAndValidateLogging(base.TestCtx(t))
 	assert.NoError(t, err, "Setup and validate logging should be successful")
 	assert.NotEmpty(t, sc.Logging)
 }
@@ -688,7 +688,7 @@ func TestSetupAndValidateLoggingWithLoggingConfig(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	logFilePath := "/var/log/sync_gateway"
 	sc := &StartupConfig{Logging: base.LoggingConfig{LogFilePath: logFilePath, RedactionLevel: base.RedactFull}}
-	err := sc.SetupAndValidateLogging()
+	err := sc.SetupAndValidateLogging(base.TestCtx(t))
 	assert.NoError(t, err, "Setup and validate logging should be successful")
 	assert.Equal(t, base.RedactFull, sc.Logging.RedactionLevel)
 }
@@ -1328,13 +1328,13 @@ func TestDefaultLogging(t *testing.T) {
 	assert.Equal(t, base.RedactPartial, config.Logging.RedactionLevel)
 	assert.Equal(t, true, base.RedactUserData)
 
-	require.NoError(t, config.SetupAndValidateLogging())
+	require.NoError(t, config.SetupAndValidateLogging(base.TestCtx(t)))
 	assert.Equal(t, base.LevelNone, *base.ConsoleLogLevel())
 	assert.Equal(t, []string{"HTTP"}, base.ConsoleLogKey().EnabledLogKeys())
 
 	// setting just a log key should enable logging
 	config.Logging.Console = &base.ConsoleLoggerConfig{LogKeys: []string{"CRUD"}}
-	require.NoError(t, config.SetupAndValidateLogging())
+	require.NoError(t, config.SetupAndValidateLogging(base.TestCtx(t)))
 	assert.Equal(t, base.LevelInfo, *base.ConsoleLogLevel())
 	assert.Equal(t, []string{"CRUD", "HTTP"}, base.ConsoleLogKey().EnabledLogKeys())
 }

--- a/rest/main.go
+++ b/rest/main.go
@@ -40,7 +40,7 @@ func serverMain(ctx context.Context, osArgs []string) error {
 	defer base.FatalPanicHandler()
 
 	base.InitializeMemoryLoggers()
-	base.LogSyncGatewayVersion()
+	base.LogSyncGatewayVersion(ctx)
 
 	flagStartupConfig, fs, disablePersistentConfig, err := parseFlags(osArgs)
 	if err != nil {

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -709,7 +709,7 @@ func TestLogFlush(t *testing.T) {
 			config = testCase.EnableFunc(config)
 
 			// Setup logging
-			err := config.SetupAndValidateLogging()
+			err := config.SetupAndValidateLogging(base.TestCtx(t))
 			assert.NoError(t, err)
 
 			// Flush memory loggers


### PR DESCRIPTION
Split from upcoming PR.

- No functional change, all existing callers of this function have no log context fields set
- Renames `Consolef` to `ConsolefCtx` for consistency with other logging functions
- Adds `ctx context.Context` parameter and pass through