### PR TITLE
CBG-3102: Allow keyspace requests to initialize OIDC provider with correct callback URL

### DIFF
--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -297,7 +297,14 @@ func (h *handler) getOIDCProvider(providerName string) (*auth.OIDCProvider, erro
 // Builds the OIDC callback based on the current request. Used during OIDC Client lazy initialization.
 // Need to pass providerName and isDefault for the requested provider to determine whether we need to append it to the callback URL or not.
 func (h *handler) getOIDCCallbackURL(providerName string, isDefault bool) string {
+	// h.db not initialized at this point (checkAuth) from validateAndWriteHeaders
+	// we'll have to pull it out of the router path rather than using h.db.Name
 	dbName := h.PathVar("db")
+	if dbName == "" {
+		// could be a keyspace-scoped request instead
+		dbName, _, _, _ = ParseKeyspace(h.PathVar("keyspace"))
+	}
+
 	if dbName == "" {
 		base.WarnfCtx(h.ctx(), "Can't calculate OIDC callback URL without DB in path.")
 		return ""

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -933,6 +933,15 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 			require.NoError(t, json.NewDecoder(response.Body).Decode(&responseBody))
 			require.NoError(t, response.Body.Close(), "Error closing response body")
 			assert.Equal(t, restTester.DatabaseConfig.Name, responseBody["db_name"])
+
+			// Make a keyspace-scoped request
+			request, err = http.NewRequest(http.MethodPut, mockSyncGatewayURL+"/"+restTester.GetSingleKeyspace()+"/doc1", bytes.NewBufferString(`{"foo":"bar"}`))
+			require.NoError(t, err, "Error creating new request")
+			request.Header.Add("Authorization", BearerToken+" "+refreshResponseActual.IDToken)
+			response, err = client.Do(request)
+			require.NoError(t, err, "Error sending request with bearer token")
+			require.Equal(t, http.StatusCreated, response.StatusCode)
+			require.NoError(t, response.Body.Close(), "Error closing response body")
 		})
 	}
 }

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -1080,6 +1080,11 @@ func TestOpenIDConnectImplicitFlow(t *testing.T) {
 				return
 			}
 			checkGoodAuthResponse(t, restTester, response, "foo_noah")
+
+			c := getCookie(response.Cookies(), auth.DefaultCookieName)
+
+			resp := restTester.SendRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc1", `{"foo":"bar"}`, map[string]string{"Cookie": c.String()})
+			RequireStatus(t, resp, http.StatusCreated)
 		})
 	}
 }


### PR DESCRIPTION
CBG-3102

- Extra test coverage for keyspace requests on an already initialized provider (didn't trigger failure condition). Previously:
  - #6301
  - #6303
- Adds test `TestOpenIDConnectImplicitFlowInitWithKeyspace` to hit condition where a keyspace-scoped request fails to initialize the OIDC provider

- Add fix for keyspace path var in `h.getOIDCCallbackURL`

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1891/
