### PR TITLE
Don't use flush on GSI indexcreation tests

### DIFF
--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,10 +50,9 @@ func TestRoleQuery(t *testing.T) {
 
 			n1QLStores, reset, err := setupN1QLStore(ctx, database.Bucket, testCase.isServerless)
 			require.NoError(t, err, "Unable to get n1QLStore for testBucket")
-			defer func(n1QLStore []base.N1QLStore, isServerless bool) {
-				err := reset(n1QLStores, isServerless)
-				require.NoError(t, err, "Reset fn shouldn't return error")
-			}(n1QLStores, testCase.isServerless)
+			defer func() {
+				assert.NoError(t, reset(n1QLStores, testCase.isServerless))
+			}()
 
 			authenticator := database.Authenticator(ctx)
 			require.NotNil(t, authenticator, "database.Authenticator(ctx) returned nil")
@@ -113,10 +113,9 @@ func TestBuildRolesQuery(t *testing.T) {
 
 			n1QLStores, reset, err := setupN1QLStore(ctx, database.Bucket, testCase.isServerless)
 			require.NoError(t, err, "Unable to get n1QLStore for testBucket")
-			defer func(n1QLStore []base.N1QLStore, isServerless bool) {
-				err := reset(n1QLStores, isServerless)
-				require.NoError(t, err, "Reset fn shouldn't return error")
-			}(n1QLStores, testCase.isServerless)
+			defer func() {
+				assert.NoError(t, reset(n1QLStores, testCase.isServerless))
+			}()
 
 			// roles
 			n1QLStore, ok := base.AsN1QLStore(database.MetadataStore)
@@ -158,10 +157,9 @@ func TestBuildUsersQuery(t *testing.T) {
 
 			n1QLStores, reset, err := setupN1QLStore(ctx, database.Bucket, testCase.isServerless)
 			require.NoError(t, err, "Unable to get n1QLStore for testBucket")
-			defer func(n1QLStore []base.N1QLStore, isServerless bool) {
-				err := reset(n1QLStores, isServerless)
-				require.NoError(t, err, "Reset fn shouldn't return error")
-			}(n1QLStores, testCase.isServerless)
+			defer func() {
+				assert.NoError(t, reset(n1QLStores, testCase.isServerless))
+			}()
 
 			// Sessions
 			n1QLStore, ok := base.AsN1QLStore(database.MetadataStore)
@@ -202,10 +200,9 @@ func TestQueryAllRoles(t *testing.T) {
 
 			n1QLStores, reset, err := setupN1QLStore(ctx, database.Bucket, testCase.isServerless)
 			require.NoError(t, err, "Unable to get n1QLStore for testBucket")
-			defer func(n1QLStore []base.N1QLStore, isServerless bool) {
-				err := reset(n1QLStores, isServerless)
-				require.NoError(t, err, "Reset fn shouldn't return error")
-			}(n1QLStores, testCase.isServerless)
+			defer func() {
+				assert.NoError(t, reset(n1QLStores, testCase.isServerless))
+			}()
 
 			authenticator := database.Authenticator(ctx)
 			require.NotNil(t, authenticator, "db.Authenticator(ctx) returned nil")
@@ -264,10 +261,9 @@ func TestAllPrincipalIDs(t *testing.T) {
 
 			n1QLStores, reset, err := setupN1QLStore(ctx, database.Bucket, testCase.isServerless)
 			require.NoError(t, err, "Unable to get n1QLStore for testBucket")
-			defer func(n1QLStore []base.N1QLStore, isServerless bool) {
-				err := reset(n1QLStores, isServerless)
-				require.NoError(t, err, "Reset fn shouldn't return error")
-			}(n1QLStores, testCase.isServerless)
+			defer func() {
+				assert.NoError(t, reset(n1QLStores, testCase.isServerless))
+			}()
 
 			base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 
@@ -349,10 +345,9 @@ func TestGetRoleIDs(t *testing.T) {
 
 			n1QLStores, reset, err := setupN1QLStore(ctx, database.Bucket, testCase.isServerless)
 			require.NoError(t, err, "Unable to get n1QLStore for testBucket")
-			defer func(n1QLStore []base.N1QLStore, isServerless bool) {
-				err := reset(n1QLStores, isServerless)
-				require.NoError(t, err, "Reset fn shouldn't return error")
-			}(n1QLStores, testCase.isServerless)
+			defer func() {
+				assert.NoError(t, reset(n1QLStores, testCase.isServerless))
+			}()
 
 			base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 

--- a/db/indextest/main_test.go
+++ b/db/indextest/main_test.go
@@ -11,12 +11,105 @@ licenses/APL2.txt.
 package indextest
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
 )
 
 func TestMain(m *testing.M) {
+	// these tests are only meant to be be run against Couchbase Server with GSI
+	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
+		return
+	}
 	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
-	base.TestBucketPoolNoIndexes(m, tbpOptions)
+	base.TestBucketPoolMain(m, primaryIndexReadier, primaryIndexInit, tbpOptions)
+}
+
+// primaryIndexInit is run synchronously only once per-bucket to create a primary index.
+var primaryIndexInit base.TBPBucketInitFunc = func(ctx context.Context, b base.Bucket, tbp *base.TestBucketPool) error {
+	tbp.Logf(ctx, "Starting bucket init function")
+
+	dataStores, err := b.ListDataStores()
+	if err != nil {
+		return err
+	}
+
+	for _, dataStoreName := range dataStores {
+		dataStore, err := b.NamedDataStore(dataStoreName)
+		if err != nil {
+			return err
+		}
+
+		n1qlStore, ok := base.AsN1QLStore(dataStore)
+		if !ok {
+			return fmt.Errorf("bucket %T was not a N1QL store", b)
+		}
+
+		tbp.Logf(ctx, "dropping existing bucket indexes")
+		if err := base.DropAllIndexes(ctx, n1qlStore); err != nil {
+			tbp.Logf(ctx, "Failed to drop bucket indexes: %v", err)
+			return err
+		}
+
+		err = n1qlStore.CreatePrimaryIndex(base.PrimaryIndexName, nil)
+		if err != nil {
+			return err
+		}
+		tbp.Logf(ctx, "finished creating SG bucket indexes")
+	}
+	return nil
+}
+
+// primaryIndexReadier empties the bucket using the primary index. It is run asynchronously as soon as a test is finished with a bucket.
+var primaryIndexReadier base.TBPBucketReadierFunc = func(ctx context.Context, b base.Bucket, tbp *base.TestBucketPool) error {
+	tbp.Logf(ctx, "emptying bucket via N1QL primary index")
+	if err := base.N1QLBucketEmptierFunc(ctx, b, tbp); err != nil {
+		return err
+	}
+
+	dataStores, err := b.ListDataStores()
+	if err != nil {
+		return err
+	}
+	for _, dataStoreName := range dataStores {
+		dataStore, err := b.NamedDataStore(dataStoreName)
+		if err != nil {
+			return err
+		}
+		dsName, ok := base.AsDataStoreName(dataStore)
+		if !ok {
+			err := fmt.Errorf("Could not determine datastore name from datastore: %+v", dataStore)
+			tbp.Logf(ctx, "%s", err)
+			return err
+		}
+		tbp.Logf(ctx, "dropping existing bucket indexes")
+
+		if err := db.EmptyPrimaryIndex(dataStore); err != nil {
+			return err
+		}
+		n1qlStore, ok := base.AsN1QLStore(dataStore)
+		if !ok {
+			return errors.New("attempting to empty indexes with non-N1QL store")
+		}
+		// assert no lost indexes
+		indexes, err := n1qlStore.GetIndexes()
+		if err != nil {
+			return err
+		}
+		if len(indexes) != 1 && indexes[0] != base.PrimaryIndexName {
+			return fmt.Errorf("expected only primary index to be present, found: %v", indexes)
+		}
+		tbp.Logf(ctx, "waiting for empty bucket indexes %s.%s.%s", b.GetName(), dsName.ScopeName(), dsName.CollectionName())
+		// wait for primary index to be empty
+		if err := db.WaitForPrimaryIndexEmpty(n1qlStore); err != nil {
+			tbp.Logf(ctx, "waitForPrimaryIndexEmpty returned an error: %v", err)
+			return err
+		}
+		tbp.Logf(ctx, "bucket primary index empty")
+	}
+	return nil
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -27,7 +27,7 @@ import (
 
 // Workaround SG #3570 by doing a polling loop until the star channel query returns 0 results.
 // Uses the star channel index as a proxy to indicate that _all_ indexes are empty (which might not be true)
-func waitForPrimaryIndexEmpty(store base.N1QLStore) error {
+func WaitForPrimaryIndexEmpty(store base.N1QLStore) error {
 
 	retryWorker := func() (shouldRetry bool, err error, value interface{}) {
 		empty, err := isPrimaryIndexEmpty(store)
@@ -184,8 +184,8 @@ func WaitForUserWaiterChange(userWaiter *ChangeWaiter) bool {
 	return isChanged
 }
 
-// emptyPrimaryIndex deletes all docs from primary index
-func emptyPrimaryIndex(dataStore sgbucket.DataStore) error {
+// EmptyPrimaryIndex deletes all docs from primary index
+func EmptyPrimaryIndex(dataStore sgbucket.DataStore) error {
 	n1qlStore, ok := base.AsN1QLStore(dataStore)
 	if !ok {
 		return fmt.Errorf("bucket was not a n1ql store")
@@ -288,7 +288,7 @@ var viewsAndGSIBucketReadier base.TBPBucketReadierFunc = func(ctx context.Contex
 		if _, err := emptyAllDocsIndex(ctx, dataStore, tbp); err != nil {
 			return err
 		}
-		if err := emptyPrimaryIndex(dataStore); err != nil {
+		if err := EmptyPrimaryIndex(dataStore); err != nil {
 			return err
 		}
 		n1qlStore, ok := base.AsN1QLStore(dataStore)
@@ -297,7 +297,7 @@ var viewsAndGSIBucketReadier base.TBPBucketReadierFunc = func(ctx context.Contex
 		}
 		tbp.Logf(ctx, "waiting for empty bucket indexes %s.%s.%s", b.GetName(), dsName.ScopeName(), dsName.CollectionName())
 		// we can't init indexes concurrently, so we'll just wait for them to be empty after emptying instead of recreating.
-		if err := waitForPrimaryIndexEmpty(n1qlStore); err != nil {
+		if err := WaitForPrimaryIndexEmpty(n1qlStore); err != nil {
 			tbp.Logf(ctx, "waitForPrimaryIndexEmpty returned an error: %v", err)
 			return err
 		}


### PR DESCRIPTION
- create a bucket readier function that uses primary index to empty documents
- make sure there's only one index at the end of each test
- simplify defer functions that weren't actually using the variables passed in, use assert instead of require in a defer

In local tests, this improves by 5 minutes, but jenkins doesn't see a comparable improvement (but it does hit bucket flush timeouts in weekly-runs)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1894
