### PR TITLE
[3.1.1 Backport] CBG-3103: Allow keyspace requests to initialize OIDC provider with correct callback URL (#6310)

### DIFF
--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -297,7 +297,14 @@ func (h *handler) getOIDCProvider(providerName string) (*auth.OIDCProvider, erro
 // Builds the OIDC callback based on the current request. Used during OIDC Client lazy initialization.
 // Need to pass providerName and isDefault for the requested provider to determine whether we need to append it to the callback URL or not.
 func (h *handler) getOIDCCallbackURL(providerName string, isDefault bool) string {
+	// h.db not initialized at this point (checkAuth) from validateAndWriteHeaders
+	// we'll have to pull it out of the router path rather than using h.db.Name
 	dbName := h.PathVar("db")
+	if dbName == "" {
+		// could be a keyspace-scoped request instead
+		dbName, _, _, _ = ParseKeyspace(h.PathVar("keyspace"))
+	}
+
 	if dbName == "" {
 		base.WarnfCtx(h.ctx(), "Can't calculate OIDC callback URL without DB in path.")
 		return ""

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -933,6 +933,15 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 			require.NoError(t, json.NewDecoder(response.Body).Decode(&responseBody))
 			require.NoError(t, response.Body.Close(), "Error closing response body")
 			assert.Equal(t, restTester.DatabaseConfig.Name, responseBody["db_name"])
+
+			// Make a keyspace-scoped request
+			request, err = http.NewRequest(http.MethodPut, mockSyncGatewayURL+"/"+restTester.GetSingleKeyspace()+"/doc1", bytes.NewBufferString(`{"foo":"bar"}`))
+			require.NoError(t, err, "Error creating new request")
+			request.Header.Add("Authorization", BearerToken+" "+refreshResponseActual.IDToken)
+			response, err = client.Do(request)
+			require.NoError(t, err, "Error sending request with bearer token")
+			require.Equal(t, http.StatusCreated, response.StatusCode)
+			require.NoError(t, response.Body.Close(), "Error closing response body")
 		})
 	}
 }
@@ -1071,8 +1080,48 @@ func TestOpenIDConnectImplicitFlow(t *testing.T) {
 				return
 			}
 			checkGoodAuthResponse(t, restTester, response, "foo_noah")
+
+			// try using cookie in a subsequent keyspace request
+			c := getCookie(response.Cookies(), auth.DefaultCookieName)
+			resp := restTester.SendRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc1", `{"foo":"bar"}`, map[string]string{"Cookie": c.String()})
+			RequireStatus(t, resp, http.StatusCreated)
+
+			// try directly using bearer token in a keyspace request
+			resp = restTester.SendRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc2", `{"foo":"bar"}`, map[string]string{"Authorization": BearerToken + " " + token})
+			RequireStatus(t, resp, http.StatusCreated)
 		})
 	}
+}
+
+// TestOpenIDConnectImplicitFlowInitWithKeyspace ensures that a keyspace request that initializes an OIDC provider works correctly and isn't reliant on a database endpoint to initialize the provider first.
+func TestOpenIDConnectImplicitFlowInitWithKeyspace(t *testing.T) {
+	testProviders := auth.OIDCProviderMap{
+		"foo": mockProviderWith("foo", mockProviderUserPrefix{"foo"}),
+	}
+	defaultProvider := "foo"
+
+	mockAuthServer, err := newMockAuthServer()
+	require.NoError(t, err, "Error creating mock oauth2 server")
+	mockAuthServer.Start()
+	defer mockAuthServer.Shutdown()
+	mockAuthServer.options.issuer = mockAuthServer.URL + "/" + defaultProvider
+	refreshProviderConfig(testProviders, mockAuthServer.URL)
+
+	opts := auth.OIDCOptions{Providers: testProviders, DefaultProvider: &defaultProvider}
+	restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{OIDCConfig: &opts}}}
+	restTester := NewRestTester(t, &restTesterConfig)
+	require.NoError(t, restTester.SetAdminParty(false))
+	defer restTester.Close()
+
+	createUser(t, restTester, "foo_noah")
+
+	token, err := mockAuthServer.makeToken(claimsAuthentic())
+	require.NoError(t, err, "Error obtaining signed token from OpenID Connect provider")
+	require.NotEmpty(t, token, "Empty token retrieved from OpenID Connect provider")
+
+	// try directly using bearer token in a keyspace request
+	resp := restTester.SendRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc1", `{"foo":"bar"}`, map[string]string{"Authorization": BearerToken + " " + token})
+	RequireStatus(t, resp, http.StatusCreated)
 }
 
 // checkGoodAuthResponse asserts expected session response values against the given response.


### PR DESCRIPTION
CBG-3103

Clean cherry pick - backports #6310 to 3.1.1

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-1.19.5/6/
