### PR TITLE
CBG-2927: Total Sync Time stat

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -2310,6 +2310,16 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 
 	}
 
+	// create a background task to keep track of the number of active replication connections the database has each second
+	bgtSyncTime, err := NewBackgroundTask(ctx, "TotalSyncTimeStat", func(ctx context.Context) error {
+		db.UpdateTotalSyncTimeStat()
+		return nil
+	}, 1*time.Second, db.terminator)
+	if err != nil {
+		return err
+	}
+	db.backgroundTasks = append(db.backgroundTasks, bgtSyncTime)
+
 	if err := base.RequireNoBucketTTL(db.Bucket); err != nil {
 		return err
 	}

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -27,3 +27,9 @@ func (db *DatabaseContext) UpdateCalculatedStats() {
 	db.DbStats.Cache().HighSeqCached.Set(int64(channelCache.GetHighCacheSequence()))
 
 }
+
+// UpdateTotalSyncTimeStat updates the TotalSyncTime to the current value + NumReplicationsActive each time this is called
+func (db *DatabaseContext) UpdateTotalSyncTimeStat() {
+	currentActiveReplications := db.DbStats.DatabaseStats.NumReplicationsActive.Value()
+	db.DbStats.DatabaseStats.TotalSyncTime.Add(currentActiveReplications)
+}

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -2494,7 +2494,7 @@ func TestTotalSyncTimeStat(t *testing.T) {
 	}, 1)
 	require.True(t, ok)
 
-	// wait some time to wait for the stat to increment. this should wait for
+	// wait some time to wait for the stat to increment
 	_, ok = base.WaitForStat(func() int64 {
 		return passiveRT.GetDatabase().DbStats.DatabaseStats.TotalSyncTime.Value()
 	}, 2)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -2494,11 +2494,14 @@ func TestTotalSyncTimeStat(t *testing.T) {
 	}, 1)
 	require.True(t, ok)
 
-	// wait some time to wait for the stat to increment more
-	time.Sleep(3 * time.Second)
+	// wait some time to wait for the stat to increment. this should wait for
+	_, ok = base.WaitForStat(func() int64 {
+		return passiveRT.GetDatabase().DbStats.DatabaseStats.TotalSyncTime.Value()
+	}, 2)
+	require.True(t, ok)
 
 	syncTimeStat := passiveRT.GetDatabase().DbStats.DatabaseStats.TotalSyncTime.Value()
-	// we can't be certain only 3 seconds have passed since grabbing the stat so to avoid flake here just assert the stat has incremented
+	// we can't be certain how long has passed since grabbing the stat so to avoid flake here just assert the stat has incremented
 	require.Greater(t, syncTimeStat, startValue)
 }
 


### PR DESCRIPTION
CBG-2927

Small change to add a new stat called TotalSyncTime. This is implemneted through a background task that runs each seocnd and incremnets the stat by the NumReplicationsActive stat each time. 
NOTE: due to timing issues the unit test cannot assert on the exact value of the stat so rather just asserts that the stat increases after a wait for a few seconds. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1898/
