### PR TITLE
CBG-2837 Support async database initialization

### DIFF
--- a/base/cluster_n1ql.go
+++ b/base/cluster_n1ql.go
@@ -60,6 +60,10 @@ func (cl *ClusterOnlyN1QLStore) GetName() string {
 	return cl.bucketName
 }
 
+func (cl *ClusterOnlyN1QLStore) BucketName() string {
+	return cl.bucketName
+}
+
 func (cl *ClusterOnlyN1QLStore) BuildDeferredIndexes(ctx context.Context, indexSet []string) error {
 	return BuildDeferredIndexes(ctx, cl, indexSet)
 }

--- a/base/cluster_n1ql.go
+++ b/base/cluster_n1ql.go
@@ -31,9 +31,9 @@ var _ N1QLStore = &ClusterOnlyN1QLStore{}
 // collection-scoped and non-collection-scoped operations.
 type ClusterOnlyN1QLStore struct {
 	cluster             *gocb.Cluster
-	bucketName          string
-	scopeName           string
-	collectionName      string
+	bucketName          string // User to build keyspace for query when not otherwise set
+	scopeName           string // Used to build keyspace for query when not otherwise set
+	collectionName      string // Used to build keyspace for query when not otherwise set
 	supportsCollections bool
 }
 
@@ -228,4 +228,10 @@ func (cl *ClusterOnlyN1QLStore) waitUntilQueryServiceReady(timeout time.Duration
 	return cl.cluster.WaitUntilReady(timeout,
 		&gocb.WaitUntilReadyOptions{ServiceTypes: []gocb.ServiceType{gocb.ServiceTypeQuery}},
 	)
+}
+
+// ClusterOnlyN1QLStore allows callers to set the scope and collection per operation
+func (cl *ClusterOnlyN1QLStore) SetScopeAndCollection(scName ScopeAndCollectionName) {
+	cl.scopeName = scName.Scope
+	cl.collectionName = scName.Collection
 }

--- a/base/collection.go
+++ b/base/collection.go
@@ -32,60 +32,8 @@ import (
 // GetGoCBv2Bucket opens a connection to the Couchbase cluster and returns a *GocbV2Bucket for the specified BucketSpec.
 func GetGoCBv2Bucket(spec BucketSpec) (*GocbV2Bucket, error) {
 
-	logCtx := context.TODO()
-	connString, err := spec.GetGoCBConnString(nil)
+	cluster, err := GetGocbCluster(spec)
 	if err != nil {
-		WarnfCtx(logCtx, "Unable to parse server value: %s error: %v", SD(spec.Server), err)
-		return nil, err
-	}
-
-	securityConfig, err := GoCBv2SecurityConfig(&spec.TLSSkipVerify, spec.CACertPath)
-	if err != nil {
-		return nil, err
-	}
-
-	authenticator, err := spec.GocbAuthenticator()
-	if err != nil {
-		return nil, err
-	}
-
-	if _, ok := authenticator.(gocb.CertificateAuthenticator); ok {
-		InfofCtx(logCtx, KeyAuth, "Using cert authentication for bucket %s on %s", MD(spec.BucketName), MD(spec.Server))
-	} else {
-		InfofCtx(logCtx, KeyAuth, "Using credential authentication for bucket %s on %s", MD(spec.BucketName), MD(spec.Server))
-	}
-
-	timeoutsConfig := GoCBv2TimeoutsConfig(spec.BucketOpTimeout, StdlibDurationPtr(spec.GetViewQueryTimeout()))
-	InfofCtx(logCtx, KeyAll, "Setting query timeouts for bucket %s to %v", spec.BucketName, timeoutsConfig.QueryTimeout)
-
-	clusterOptions := gocb.ClusterOptions{
-		Authenticator:  authenticator,
-		SecurityConfig: securityConfig,
-		TimeoutsConfig: timeoutsConfig,
-		RetryStrategy:  gocb.NewBestEffortRetryStrategy(nil),
-	}
-
-	if spec.KvPoolSize > 0 {
-		// TODO: Equivalent of kvPoolSize in gocb v2?
-	}
-
-	cluster, err := gocb.Connect(connString, clusterOptions)
-	if err != nil {
-		InfofCtx(logCtx, KeyAuth, "Unable to connect to cluster: %v", err)
-		return nil, err
-	}
-
-	err = cluster.WaitUntilReady(time.Second*5, &gocb.WaitUntilReadyOptions{
-		DesiredState:  gocb.ClusterStateOnline,
-		ServiceTypes:  []gocb.ServiceType{gocb.ServiceTypeManagement},
-		RetryStrategy: &goCBv2FailFastRetryStrategy{},
-	})
-	if err != nil {
-		_ = cluster.Close(nil)
-		if errors.Is(err, gocb.ErrAuthenticationFailure) {
-			return nil, ErrAuthError
-		}
-		WarnfCtx(context.TODO(), "Error waiting for cluster to be ready: %v", err)
 		return nil, err
 	}
 
@@ -174,6 +122,68 @@ func GetGocbV2BucketFromCluster(cluster *gocb.Cluster, spec BucketSpec, waitUnti
 	gocbv2Bucket.kvOps = make(chan struct{}, MaxConcurrentSingleOps*nodeCount*numPools)
 
 	return gocbv2Bucket, nil
+}
+
+// GetGocbCluster opens a connection to the Couchbase cluster and returns a *gocb.Cluster for the specified BucketSpec.
+func GetGocbCluster(spec BucketSpec) (*gocb.Cluster, error) {
+
+	logCtx := context.TODO()
+	connString, err := spec.GetGoCBConnString(nil)
+	if err != nil {
+		WarnfCtx(logCtx, "Unable to parse server value: %s error: %v", SD(spec.Server), err)
+		return nil, err
+	}
+
+	securityConfig, err := GoCBv2SecurityConfig(&spec.TLSSkipVerify, spec.CACertPath)
+	if err != nil {
+		return nil, err
+	}
+
+	authenticator, err := spec.GocbAuthenticator()
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := authenticator.(gocb.CertificateAuthenticator); ok {
+		InfofCtx(logCtx, KeyAuth, "Using cert authentication for bucket %s on %s", MD(spec.BucketName), MD(spec.Server))
+	} else {
+		InfofCtx(logCtx, KeyAuth, "Using credential authentication for bucket %s on %s", MD(spec.BucketName), MD(spec.Server))
+	}
+
+	timeoutsConfig := GoCBv2TimeoutsConfig(spec.BucketOpTimeout, StdlibDurationPtr(spec.GetViewQueryTimeout()))
+	InfofCtx(logCtx, KeyAll, "Setting query timeouts for bucket %s to %v", spec.BucketName, timeoutsConfig.QueryTimeout)
+
+	clusterOptions := gocb.ClusterOptions{
+		Authenticator:  authenticator,
+		SecurityConfig: securityConfig,
+		TimeoutsConfig: timeoutsConfig,
+		RetryStrategy:  gocb.NewBestEffortRetryStrategy(nil),
+	}
+
+	if spec.KvPoolSize > 0 {
+		// TODO: Equivalent of kvPoolSize in gocb v2?
+	}
+
+	cluster, err := gocb.Connect(connString, clusterOptions)
+	if err != nil {
+		InfofCtx(logCtx, KeyAuth, "Unable to connect to cluster: %v", err)
+		return nil, err
+	}
+
+	err = cluster.WaitUntilReady(time.Second*5, &gocb.WaitUntilReadyOptions{
+		DesiredState:  gocb.ClusterStateOnline,
+		ServiceTypes:  []gocb.ServiceType{gocb.ServiceTypeManagement},
+		RetryStrategy: &goCBv2FailFastRetryStrategy{},
+	})
+	if err != nil {
+		_ = cluster.Close(nil)
+		if errors.Is(err, gocb.ErrAuthenticationFailure) {
+			return nil, ErrAuthError
+		}
+		WarnfCtx(context.TODO(), "Error waiting for cluster to be ready: %v", err)
+		return nil, err
+	}
+	return cluster, nil
 }
 
 type GocbV2Bucket struct {

--- a/base/collection.go
+++ b/base/collection.go
@@ -80,9 +80,6 @@ func GetGoCBv2Bucket(spec BucketSpec) (*GocbV2Bucket, error) {
 		ServiceTypes:  []gocb.ServiceType{gocb.ServiceTypeManagement},
 		RetryStrategy: &goCBv2FailFastRetryStrategy{},
 	})
-	if err != nil {
-		return nil, err
-	}
 
 	if err != nil {
 		_ = cluster.Close(nil)

--- a/base/collection_common.go
+++ b/base/collection_common.go
@@ -38,6 +38,10 @@ func (s ScopeAndCollectionName) String() string {
 	return s.Scope + ScopeCollectionSeparator + s.Collection
 }
 
+func DefaultScopeAndCollectionName() ScopeAndCollectionName {
+	return ScopeAndCollectionName{Scope: DefaultScope, Collection: DefaultCollection}
+}
+
 type ScopeAndCollectionNames []ScopeAndCollectionName
 
 // ScopeAndCollectionNames returns a dot-separated formatted slice of scope and collection names.

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -50,6 +50,7 @@ type N1QLStore interface {
 	IndexMetaBucketID() string
 	IndexMetaScopeID() string
 	IndexMetaKeyspaceID() string
+	BucketName() string
 	WaitForIndexesOnline(ctx context.Context, indexNames []string, failfast bool) error
 
 	// executeQuery performs the specified query without any built-in retry handling and returns the resultset

--- a/base/util.go
+++ b/base/util.go
@@ -63,6 +63,15 @@ func NewNonCancelCtx() NonCancellableContext {
 	return ctxStruct
 }
 
+// NewNonCancelCtx creates a new background context struct for operations that require a fresh context, with database logging context added
+func NewNonCancelCtxForDatabase(dbName string) NonCancellableContext {
+	dbLogContext := DatabaseLogCtx(context.Background(), dbName)
+	ctxStruct := NonCancellableContext{
+		Ctx: dbLogContext,
+	}
+	return ctxStruct
+}
+
 // RedactBasicAuthURLUserAndPassword returns the given string, with a redacted HTTP basic auth component.
 func RedactBasicAuthURLUserAndPassword(urlIn string) string {
 	redactedUrl, err := RedactBasicAuthURL(urlIn, false)

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -80,13 +80,15 @@ type changeCacheStats struct {
 func (c *changeCache) updateStats() {
 
 	c.lock.Lock()
-
+	defer c.lock.Unlock()
+	if c.db == nil {
+		return
+	}
 	c.db.DbStats.Database().HighSeqFeed.SetIfMax(int64(c.internalStats.highSeqFeed))
 	c.db.DbStats.Cache().PendingSeqLen.Set(int64(c.internalStats.pendingSeqLen))
 	c.db.DbStats.CBLReplicationPull().MaxPending.SetIfMax(int64(c.internalStats.maxPending))
 	c.db.DbStats.Cache().HighSeqStable.Set(int64(c._getMaxStableCached()))
 
-	c.lock.Unlock()
 }
 
 type LogEntry channels.LogEntry

--- a/db/database.go
+++ b/db/database.go
@@ -2341,3 +2341,55 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 
 	return nil
 }
+
+func (dbc *DatabaseContext) InstallPrincipals(ctx context.Context, spec map[string]*auth.PrincipalConfig, what string) error {
+	for name, princ := range spec {
+		isGuest := name == base.GuestUsername
+		if isGuest {
+			internalName := ""
+			princ.Name = &internalName
+		} else {
+			n := name
+			princ.Name = &n
+		}
+
+		createdPrincipal := true
+		worker := func() (shouldRetry bool, err error, value interface{}) {
+			_, err = dbc.UpdatePrincipal(ctx, princ, (what == "user"), isGuest)
+			if err != nil {
+				if status, _ := base.ErrorAsHTTPStatus(err); status == http.StatusConflict {
+					// Ignore and absorb this error if it's a conflict error, which just means that updatePrincipal didn't overwrite an existing user.
+					// Since if there's an existing user it's "mission accomplished", this can be treated as a success case.
+					createdPrincipal = false
+					return false, nil, nil
+				}
+
+				if err == base.ErrViewTimeoutError {
+					// Timeout error, possibly due to view re-indexing, so retry
+					base.InfofCtx(ctx, base.KeyAuth, "Error calling UpdatePrincipal(): %v.  Will retry in case this is a temporary error", err)
+					return true, err, nil
+				}
+
+				// Unexpected error, return error don't retry
+				return false, err, nil
+			}
+
+			// No errors, assume it worked
+			return false, nil, nil
+
+		}
+
+		err, _ := base.RetryLoop("installPrincipals", worker, base.CreateDoublingSleeperFunc(16, 10))
+		if err != nil {
+			return err
+		}
+
+		if isGuest {
+			base.InfofCtx(ctx, base.KeyAll, "Reset guest user to config")
+		} else if createdPrincipal {
+			base.InfofCtx(ctx, base.KeyAll, "Created %s %q", what, base.UD(name))
+		}
+
+	}
+	return nil
+}

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -21,6 +21,7 @@ package db
 
 // Update database-specific stats that are more efficiently calculated at stats collection time
 func (db *DatabaseContext) UpdateCalculatedStats() {
+
 	db.changeCache.updateStats()
 	channelCache := db.changeCache.getChannelCache()
 	db.DbStats.Cache().ChannelCacheMaxEntries.Set(int64(channelCache.MaxCacheSize()))

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -557,7 +557,7 @@ func SetupTestDBForDataStoreWithOptions(t testing.TB, tBucket *base.TestBucket, 
 	return db, ctx
 }
 
-// GetScopesOptions sets up a ScopesOptions from a TestBucket. This will set up default or non default collections depending on the test harness use of SG_TEST_USE_NAMED_COLLECTIONS and whether the backing store supports collections.
+// GetScopesOptions sets up a ScopesOptions from a TestBucket. This will set up default or non default collections depending on the test harness use of SG_TEST_USE_DEFAULT_COLLECTION and whether the backing store supports collections.
 func GetScopesOptions(t testing.TB, testBucket *base.TestBucket, numCollections int) ScopesOptions {
 	if !base.TestsUseNamedCollections() {
 		if numCollections != 1 {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -557,7 +557,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 		if err := updatedDbConfig.setup(dbName, h.server.Config.Bootstrap, dbCreds, nil, false); err != nil {
 			return err
 		}
-		if err := h.server.ReloadDatabaseWithConfig(contextNoCancel, *updatedDbConfig); err != nil {
+		if err := h.server.ReloadDatabaseWithConfig(contextNoCancel, *updatedDbConfig, false); err != nil {
 			return err
 		}
 		return base.HTTPErrorf(http.StatusCreated, "updated")
@@ -608,7 +608,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 		}
 
 		// Load the new dbConfig before we persist the update.
-		err = h.server.ReloadDatabaseWithConfig(contextNoCancel, tmpConfig)
+		err = h.server.ReloadDatabaseWithConfig(contextNoCancel, tmpConfig, true)
 		if err != nil {
 			return nil, err
 		}
@@ -719,7 +719,7 @@ func (h *handler) handleDeleteCollectionConfigSync() error {
 	defer h.server.lock.Unlock()
 
 	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 		return err
 	}
 
@@ -783,7 +783,7 @@ func (h *handler) handlePutCollectionConfigSync() error {
 	defer h.server.lock.Unlock()
 
 	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 		return err
 	}
 
@@ -878,7 +878,7 @@ func (h *handler) handleDeleteCollectionConfigImportFilter() error {
 	defer h.server.lock.Unlock()
 
 	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 		return err
 	}
 
@@ -943,7 +943,7 @@ func (h *handler) handlePutCollectionConfigImportFilter() error {
 	defer h.server.lock.Unlock()
 
 	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 		return err
 	}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -1708,7 +1708,7 @@ func (sc *ServerContext) addLegacyPrincipals(ctx context.Context, legacyDbUsers,
 			base.ErrorfCtx(ctx, "Couldn't get database context to install user principles: %v", err)
 			continue
 		}
-		err = sc.installPrincipals(ctx, dbCtx, dbUser, "user")
+		err = dbCtx.InstallPrincipals(ctx, dbUser, "user")
 		if err != nil {
 			base.ErrorfCtx(ctx, "Couldn't install user principles: %v", err)
 		}
@@ -1720,7 +1720,7 @@ func (sc *ServerContext) addLegacyPrincipals(ctx context.Context, legacyDbUsers,
 			base.ErrorfCtx(ctx, "Couldn't get database context to install role principles: %v", err)
 			continue
 		}
-		err = sc.installPrincipals(ctx, dbCtx, dbRole, "role")
+		err = dbCtx.InstallPrincipals(ctx, dbRole, "role")
 		if err != nil {
 			base.ErrorfCtx(ctx, "Couldn't install role principles: %v", err)
 		}

--- a/rest/config.go
+++ b/rest/config.go
@@ -1690,7 +1690,7 @@ func (sc *ServerContext) _applyConfig(nonContextStruct base.NonCancellableContex
 	}
 
 	// TODO: Dynamic update instead of reload
-	if err := sc._reloadDatabaseWithConfig(nonContextStruct.Ctx, cnf, failFast); err != nil {
+	if err := sc._reloadDatabaseWithConfig(nonContextStruct.Ctx, cnf, failFast, false); err != nil {
 		// remove these entries we just created above if the database hasn't loaded properly
 		return false, fmt.Errorf("couldn't reload database: %w", err)
 	}

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -60,6 +60,16 @@ func (dbc *DatabaseConfig) Redacted() (*DatabaseConfig, error) {
 	return &config, nil
 }
 
+func (dbc *DatabaseConfig) GetCollectionNames() base.ScopeAndCollectionNames {
+	collections := make(base.ScopeAndCollectionNames, 0)
+	for scopeName, scopeConfig := range dbc.Scopes {
+		for collectionName, _ := range scopeConfig.Collections {
+			collections = append(collections, base.ScopeAndCollectionName{Scope: scopeName, Collection: collectionName})
+		}
+	}
+	return collections
+}
+
 func GenerateDatabaseConfigVersionID(previousRevID string, dbConfig *DbConfig) (string, error) {
 	encodedBody, err := base.JSONMarshalCanonical(dbConfig)
 	if err != nil {

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -378,7 +378,7 @@ func TestLegacyConfigPrinciplesMigration(t *testing.T) {
 			ExplicitChannels: base.SetOf("*"),
 		},
 	}
-	err := rt.ServerContext().installPrincipals(ctx, rt.GetDatabase(), existingUsers, "user")
+	err := rt.GetDatabase().InstallPrincipals(ctx, existingUsers, "user")
 	require.NoError(t, err)
 
 	existingRoles := map[string]*auth.PrincipalConfig{
@@ -391,7 +391,7 @@ func TestLegacyConfigPrinciplesMigration(t *testing.T) {
 			ExplicitChannels: base.SetOf("*"),
 		},
 	}
-	err = rt.ServerContext().installPrincipals(ctx, rt.GetDatabase(), existingRoles, "role")
+	err = rt.GetDatabase().InstallPrincipals(ctx, existingRoles, "role")
 	require.NoError(t, err)
 
 	// Config to migrate to persistent config on bucket

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -1,0 +1,312 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+)
+
+// DatabaseInitManager coordinates InitializeDatabase requests across multiple callers and
+// databases.  At most one worker per database may be active at a time.  If the required initialization
+// (based on the databaseConfig) changes for a database while a worker is already active, that worker is
+// cancelled and a new one created.  Currently this is based solely on the set of collections in the config, and
+// their computed index sets.
+// DatabaseInitManager is only responsible for asynchronous execution of the initialization processing - it
+// is not intended maintain initialization status, or the success/failure of historic executions. The expectation
+// is that evaluation of whether a database has been initialized is relatively inexpensive and is the responsibility
+// of the code in databaseInitWork.Run.
+type DatabaseInitManager struct {
+
+	// Set of active DatabaseInitWorkers.  Workers are removed from the set on completion.
+	workers     map[string]*DatabaseInitWorker
+	workersLock sync.Mutex
+
+	// collectionCompleteCallback is defined for testability only.
+	// Invoked after collection initialization is complete for each collection
+	collectionCompleteCallback collectionCallbackFunc
+
+	// databaseCompleteCallback is defined for testability only.
+	// Invoked after worker completes, but before worker is removed from workers set
+	databaseCompleteCallback func(databaseName string) // Callback for testability only
+}
+
+type collectionCallbackFunc func(dbName, collectionName string)
+
+// CollectionInitData defines the set of collections being created (by ScopeAneCollectionName), and the set of
+// indexes required for each collection.
+type CollectionInitData map[base.ScopeAndCollectionName]db.CollectionIndexesType
+
+// Initializes the database.  Will establish a new cluster connection using the provided server config.  Establishes a new
+// cluster-only N1QLStore based on the startup config to perform initialization.
+func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupConfig *StartupConfig, dbConfig *DatabaseConfig) (doneChan chan error, err error) {
+	m.workersLock.Lock()
+	defer m.workersLock.Unlock()
+	if m.workers == nil {
+		m.workers = make(map[string]*DatabaseInitWorker)
+	}
+	base.InfofCtx(ctx, base.KeyAll, "Initializing database %s ...",
+		base.MD(dbConfig.Name))
+	dbInitWorker, ok := m.workers[dbConfig.Name]
+	collectionSet := m.buildCollectionIndexData(dbConfig)
+	if ok {
+		// If worker exists for the database and the collection sets match,
+		if dbInitWorker.collectionsEqual(collectionSet) {
+			base.InfofCtx(ctx, base.KeyAll, "Found existing database initialization for database %s ...",
+				base.MD(dbConfig.Name))
+			doneChan, err := dbInitWorker.addWatcher()
+			return doneChan, err
+		}
+		// For a mismatch in collections, stop and remove the existing worker, then continue through to creation of new worker
+		dbInitWorker.Stop()
+		delete(m.workers, dbConfig.Name)
+	}
+
+	base.InfofCtx(ctx, base.KeyAll, "Starting new async initialization for database %s ...",
+		base.MD(dbConfig.Name))
+	couchbaseCluster, err := CreateCouchbaseClusterFromStartupConfig(startupConfig, base.PerUseClusterConnections)
+	if err != nil {
+		return nil, err
+	}
+
+	bucketName := dbConfig.Name
+	if dbConfig.Bucket != nil {
+		bucketName = *dbConfig.Bucket
+	}
+
+	// Initialize ClusterN1QLStore for the bucket.  Scope and collection name are set
+	// per-operation
+	n1qlStore, err := couchbaseCluster.GetClusterN1QLStore(bucketName, "", "")
+	if err != nil {
+		return nil, err
+	}
+
+	indexOptions := m.BuildIndexOptions(startupConfig, dbConfig)
+
+	// Create new worker and add this caller as a watcher
+	worker := NewDatabaseInitWorker(ctx, dbConfig.Name, n1qlStore, collectionSet, indexOptions, m.collectionCompleteCallback)
+	m.workers[dbConfig.Name] = worker
+	doneChan, err = worker.addWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	// Start a goroutine to perform the initialization
+	go func() {
+		defer couchbaseCluster.Close()
+		// worker.Run blocks until completion, and returns any error on doneChan.
+		worker.Run()
+		if m.databaseCompleteCallback != nil {
+			m.databaseCompleteCallback(dbConfig.Name)
+		}
+		// On success, remove worker
+		m.workersLock.Lock()
+		delete(m.workers, dbConfig.Name)
+		m.workersLock.Unlock()
+	}()
+	return doneChan, nil
+}
+
+func (m *DatabaseInitManager) HasActiveInitialization(dbName string) bool {
+	m.workersLock.Lock()
+	defer m.workersLock.Unlock()
+	_, ok := m.workers[dbName]
+	return ok
+}
+
+func (m *DatabaseInitManager) BuildIndexOptions(startupConfig *StartupConfig, dbConfig *DatabaseConfig) db.InitializeIndexOptions {
+	numReplicas := DefaultNumIndexReplicas
+	if dbConfig.NumIndexReplicas != nil {
+		numReplicas = *dbConfig.NumIndexReplicas
+	}
+	return db.InitializeIndexOptions{
+		FailFast:    false,
+		NumReplicas: numReplicas,
+		Serverless:  startupConfig.IsServerless(),
+		UseXattrs:   dbConfig.UseXattrs(),
+	}
+}
+
+// Intended for test usage.  Updates to callback function aren't synchronized
+func (m *DatabaseInitManager) SetCallbacks(collectionComplete collectionCallbackFunc, databaseComplete func(dbName string)) {
+	m.collectionCompleteCallback = collectionComplete
+	m.databaseCompleteCallback = databaseComplete
+}
+
+func (m *DatabaseInitManager) Cancel(dbName string) {
+	m.workersLock.Lock()
+	defer m.workersLock.Unlock()
+	worker, ok := m.workers[dbName]
+	if !ok {
+		return
+	}
+	worker.Stop()
+}
+
+// buildCollectionIndexData determines the set of indexes required for each collection in the config, including
+// the metadata collection
+func (m *DatabaseInitManager) buildCollectionIndexData(config *DatabaseConfig) CollectionInitData {
+	collectionInitData := make(CollectionInitData, 0)
+	if len(config.Scopes) > 0 {
+		hasDefaultCollection := false
+		for scopeName, scopeConfig := range config.Scopes {
+			for collectionName, _ := range scopeConfig.Collections {
+				metadataIndexOption := db.IndexesWithoutMetadata
+				if base.IsDefaultCollection(scopeName, collectionName) {
+					hasDefaultCollection = true
+					metadataIndexOption = db.IndexesAll
+				}
+				scName := base.ScopeAndCollectionName{Scope: scopeName, Collection: collectionName}
+				collectionInitData[scName] = metadataIndexOption
+			}
+		}
+		if !hasDefaultCollection {
+			collectionInitData[base.DefaultScopeAndCollectionName()] = db.IndexesMetadataOnly
+		}
+	} else {
+		collectionInitData[base.DefaultScopeAndCollectionName()] = db.IndexesAll
+	}
+	return collectionInitData
+}
+
+// DatabaseInitWorker performs async database initialization tasks that should be performed in the background,
+// independent of the database being reloaded for config changes
+type DatabaseInitWorker struct {
+	dbName                     string
+	n1qlStore                  *base.ClusterOnlyN1QLStore
+	options                    DatabaseInitOptions
+	ctx                        context.Context        // On close, terminates any goroutines associated with the worker
+	cancelFunc                 context.CancelFunc     // Cancel function for context, invoked if Cancel is called
+	collections                CollectionInitData     // The set of collections associated with the worker, mapped by name to their index set
+	collectionCompleteCallback collectionCallbackFunc // Callback for testability
+
+	// Multiple goroutines (watchers) may be waiting for database initialization.  To support sending error information to
+	// every goroutine, we maintain a channel for each of these watching goroutines.  On success, all channels are
+	// closed.  On error, the error is sent to each channel before closing the channel
+	watchers    []chan error
+	watcherLock sync.Mutex // Mutex for synchronized watchers access
+	completed   bool       // Set to true when processing completes, to handle watcher registration during completion.  Synchronized with watcherLock.
+	lastError   error      // Set for when processing does not complete successfully.  Synchronized with watcherLock
+}
+
+// TODO: remove unless we find another option that's needed
+type DatabaseInitOptions struct {
+	indexOptions db.InitializeIndexOptions
+}
+
+func NewDatabaseInitWorker(ctx context.Context, dbName string, n1qlStore *base.ClusterOnlyN1QLStore, collections CollectionInitData, indexOptions db.InitializeIndexOptions, callback collectionCallbackFunc) *DatabaseInitWorker {
+	cancelCtx, cancelFunc := context.WithCancel(ctx)
+	return &DatabaseInitWorker{
+		dbName:                     dbName,
+		options:                    DatabaseInitOptions{indexOptions: indexOptions},
+		ctx:                        cancelCtx,
+		cancelFunc:                 cancelFunc,
+		collections:                collections,
+		n1qlStore:                  n1qlStore,
+		collectionCompleteCallback: callback,
+	}
+}
+
+func (w *DatabaseInitWorker) Run() {
+
+	// Ensure cancelFunc resources are released on normal completion
+	defer func() {
+		if w.cancelFunc != nil {
+			w.cancelFunc()
+		}
+	}()
+
+	// TODO: future refactoring of initialize indexes to reduce number of system:indexes calls
+	var indexErr error
+	for scName, indexSet := range w.collections {
+		// Add the index set to the common indexOptions
+		collectionIndexOptions := w.options.indexOptions
+		collectionIndexOptions.MetadataIndexes = indexSet
+
+		// TODO: Future refactor of InitializeIndexes API to move scope, collection to parameters on system:indexes calls
+		// Set the scope and collection name on the cluster n1ql store for use by initializeIndexes
+		w.n1qlStore.SetScopeAndCollection(scName)
+		indexErr = db.InitializeIndexes(w.ctx, w.n1qlStore, collectionIndexOptions)
+		if indexErr != nil {
+			break
+		}
+
+		// Check for context cancellation after each collection is processed - if cancelled, return cancellation error
+		// to all watchers end exit
+		select {
+		case <-w.ctx.Done():
+			indexErr = errors.New("Database initialization cancelled")
+		default:
+		}
+		if indexErr != nil {
+			break
+		}
+
+		if w.collectionCompleteCallback != nil {
+			w.collectionCompleteCallback(w.dbName, scName.CollectionName())
+		}
+	}
+
+	// On completion (success or error), notify watchers
+	w.watcherLock.Lock()
+	w.lastError = indexErr
+	for _, doneChan := range w.watchers {
+		if indexErr != nil {
+			doneChan <- indexErr
+		}
+		close(doneChan)
+	}
+	w.completed = true
+	w.watcherLock.Unlock()
+}
+
+// Adds a watcher for the current worker.  Creates a new notification channel for completion and adds
+// to watcher set.
+func (w *DatabaseInitWorker) addWatcher() (doneChan chan error, err error) {
+	w.watcherLock.Lock()
+	defer w.watcherLock.Unlock()
+	if w.completed {
+		// If the worker has completed while we acquired the lock, return any error and close channel
+		doneChan = make(chan error, 1)
+		if w.lastError != nil {
+			doneChan <- w.lastError
+		}
+		close(doneChan)
+		return doneChan, nil
+	}
+	doneChan = make(chan error, 1)
+	w.watchers = append(w.watchers, doneChan)
+	return doneChan, nil
+}
+
+// Compare collections checks whether the provided CollectionInitData matches the set being
+// initialized by the worker.
+func (w *DatabaseInitWorker) collectionsEqual(newCollectionSet CollectionInitData) bool {
+
+	if len(newCollectionSet) != len(w.collections) {
+		return false
+	}
+
+	for name, indexType := range newCollectionSet {
+		currentType, ok := w.collections[name]
+		if !ok || currentType != indexType {
+			return false
+		}
+	}
+	return true
+}
+
+// Stop cancels the context, which will terminate initialization after the current collection being processed
+func (w *DatabaseInitWorker) Stop() {
+	w.cancelFunc()
+}

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -1,0 +1,615 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"fmt"
+	"log"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatabaseInitManager(t *testing.T) {
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server - requires bootstrap support")
+	}
+
+	// Start SG with no databases
+	config := BootstrapStartupConfigForTest(t)
+	ctx := base.TestCtx(t)
+	sc, err := SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+	}()
+
+	initMgr := sc.DatabaseInitManager
+
+	// Get a test bucket for bootstrap testing, and create dbconfig targeting that bucket
+	tb := base.GetTestBucket(t)
+	defer func() {
+		tb.Close()
+	}()
+	dbName := "dbName"
+	var scopesConfig ScopesConfig
+	if base.TestsUseNamedCollections() {
+		scopesConfig = GetCollectionsConfig(t, tb, 1)
+	}
+	dbConfig := makeDbConfig(tb.GetName(), dbName, scopesConfig)
+
+	// Drop indexes
+	dropAllNonPrimaryIndexes(t, tb.GetSingleDataStore())
+
+	// Async index creation
+	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	select {
+	case <-doneChan:
+		log.Printf("done channel was closed")
+		// continue
+	case <-time.After(10 * time.Second):
+		require.Fail(t, "InitializeDatabase didn't complete in 10s")
+	}
+
+}
+
+// TestDatabaseInitConfigChangeSameCollections tests modifications made to the database config while init is running.
+// Uses initManager callbacks to simulate slow index creation and build.  Tests the following two scenarios:
+//  1. InitalizeDatabase called concurrently for the same collection set, verifies that active init worker is identified and reused
+//  2. InitalizeDatabase called after previous InitalizeDatabase completes - verifies that new init worker is started
+func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
+
+	base.TestRequiresCollections(t)
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server - requires bootstrap support")
+	}
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
+
+	// Start SG with no databases
+	config := BootstrapStartupConfigForTest(t)
+	ctx := base.TestCtx(t)
+	sc, err := SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+	}()
+
+	// Get a test bucket for bootstrap testing, and drop indexes created by bucket pool readier
+	tb := base.GetTestBucket(t)
+	defer func() {
+		tb.Close()
+	}()
+	// Drop all test indexes so we can test InitializeDatabase
+	dropAllTestIndexes(t, tb)
+
+	// Set up collection names and ScopesConfig for testing
+	scopesConfig := GetCollectionsConfig(t, tb, 3)
+	dataStoreNames := GetDataStoreNamesFromScopesConfig(scopesConfig)
+	scopeName := dataStoreNames[0].ScopeName()
+	collection1Name := dataStoreNames[0].CollectionName()
+	collection2Name := dataStoreNames[1].CollectionName()
+	collection1and2ScopesConfig := makeScopesConfig(scopeName, []string{collection1Name, collection2Name})
+
+	initMgr := sc.DatabaseInitManager
+
+	// Use waitChannel to have collectionCallback block, to simulate long-running creation
+	testSignalChannel := make(chan error)
+	singleCollectionInitChannel := make(chan error)
+	expectedCollectionCount := int64(3) // default, collection1, collection2
+	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
+	collectionCount := int64(0)
+	initMgr.collectionCompleteCallback = func(dbName, collectionName string) {
+		log.Printf("Collection complete callback invoked for %s %s", dbName, collectionName)
+		currentCount := atomic.LoadInt64(&collectionCount)
+		if currentCount == 0 {
+			notifyChannel(t, singleCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", collectionName)) // notify the test that indexes have been created for this collection
+			waitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))             // wait for the test to unblock before proceeding to the next collection
+		}
+		atomic.AddInt64(&collectionCount, 1)
+	}
+
+	dbName := "dbName"
+	dbConfig := makeDbConfig(tb.GetName(), dbName, collection1and2ScopesConfig)
+
+	// Start first async index creation, blocks after first collection
+	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	// Wait for first collection to be initialized
+	waitForChannel(t, singleCollectionInitChannel, "first collection init")
+
+	// Make a duplicate call to initialize database, should reuse the existing agent
+	duplicateDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	// Unblock collection callback to process all remaining collections
+	close(testSignalChannel)
+
+	// Wait for notification on both done channels
+	waitForChannel(t, doneChan, "first init done chan")
+	waitForChannel(t, duplicateDoneChan, "duplicate init done chan")
+
+	// Verify initialization was only run for two collections
+	totalCount := atomic.LoadInt64(&collectionCount)
+	require.Equal(t, expectedCollectionCount, totalCount)
+
+	waitForWorkerDone(t, initMgr, "dbName")
+
+	// Rerun init, should start a new worker for the database and re-verify init for each collection
+	rerunDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
+	require.NoError(t, err)
+	waitForChannel(t, rerunDoneChan, "repeated init done chan")
+	totalCount = atomic.LoadInt64(&collectionCount)
+	require.Equal(t, expectedCollectionCount*2, totalCount)
+}
+
+// TestDatabaseInitConfigChangeDifferentCollections tests modifications made to the database config while init is running.
+// Uses initManager callbacks to simulate slow index creation and concurrent init requests.  Tests the following scenario:
+//  1. InitalizeDatabase called concurrently with a different collection set, verifies that active init worker is
+//     stopped and a new one is started
+func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
+
+	base.TestRequiresCollections(t)
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server - requires bootstrap support")
+	}
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
+
+	// Start SG with no databases
+	config := BootstrapStartupConfigForTest(t)
+	ctx := base.TestCtx(t)
+	sc, err := SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+	}()
+
+	// Get a test bucket for bootstrap testing, and drop indexes created by bucket pool readier
+	tb := base.GetTestBucket(t)
+	defer func() {
+		tb.Close()
+	}()
+
+	// Drop all test indexes so we can test InitializeDatabase
+	dropAllTestIndexes(t, tb)
+
+	// Set up collection names and ScopesConfig for testing
+	scopesConfig := GetCollectionsConfig(t, tb, 3)
+	dataStoreNames := GetDataStoreNamesFromScopesConfig(scopesConfig)
+	scopeName := dataStoreNames[0].ScopeName()
+	collection1Name := dataStoreNames[0].CollectionName()
+	collection2Name := dataStoreNames[1].CollectionName()
+	collection3Name := dataStoreNames[2].CollectionName()
+	collection1and2ScopesConfig := makeScopesConfig(scopeName, []string{collection1Name, collection2Name})
+	collection1and3ScopesConfig := makeScopesConfig(scopeName, []string{collection1Name, collection3Name})
+
+	initMgr := sc.DatabaseInitManager
+
+	// Use waitChannel to have collectionCallback block, to simulate long-running creation
+	testSignalChannel := make(chan error)
+	firstCollectionInitChannel := make(chan error)
+
+	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
+	collectionCount := int64(0)
+	initMgr.collectionCompleteCallback = func(dbName, collectionName string) {
+		log.Printf("Collection complete callback invoked for %s %s", dbName, collectionName)
+		currentCount := atomic.LoadInt64(&collectionCount)
+		if currentCount == 0 {
+			notifyChannel(t, firstCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", collectionName)) // notify the test that indexes have been created for this collection
+			waitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))            // wait for the test to unblock before proceeding to the next collection
+		}
+		atomic.AddInt64(&collectionCount, 1)
+	}
+
+	dbName := "dbName"
+	dbConfig := makeDbConfig(tb.GetName(), dbName, collection1and2ScopesConfig)
+
+	// Start first async index creation, should block after first collection
+	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	// Wait for first collection to be initialized
+	waitForChannel(t, firstCollectionInitChannel, "first collection init")
+
+	// Make a call to initialize database for the same db name, different collections
+	modifiedDbConfig := makeDbConfig(tb.GetName(), dbName, collection1and3ScopesConfig)
+	modifiedDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, modifiedDbConfig.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	// Unblock the first InitializeDatabase, should cancel
+	close(testSignalChannel)
+
+	// Unblock second collection for original invocation
+	cancelErr := waitForError(t, doneChan, "first init cancellation")
+	require.Error(t, cancelErr)
+
+	// Wait for notification on new done channel
+	waitForChannel(t, modifiedDoneChan, "modified init done chan")
+
+	// Verify initialization was run for four collections (one prior to cancellation, three for subsequent init)
+	totalCount := atomic.LoadInt64(&collectionCount)
+	require.Equal(t, int64(4), totalCount)
+
+}
+
+// TestDatabaseInitConcurrentDatabasesSameBucket tests InitializeDatabase running for multiple databases concurrently.
+// Uses initManager callbacks to simulate slow index creation and concurrent init requests.
+func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
+
+	base.TestRequiresCollections(t)
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server - requires bootstrap support")
+	}
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
+
+	// Start SG with no databases
+	config := BootstrapStartupConfigForTest(t)
+	ctx := base.TestCtx(t)
+	sc, err := SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+	}()
+
+	// Get a test bucket for bootstrap testing, and drop indexes created by bucket pool readier
+	tb := base.GetTestBucket(t)
+	defer func() {
+		tb.Close()
+	}()
+
+	// Drop all test indexes so we can test InitializeDatabase
+	dropAllTestIndexes(t, tb)
+
+	// Set up collection names and ScopesConfig for testing
+	scopesConfig := GetCollectionsConfig(t, tb, 3)
+	dataStoreNames := GetDataStoreNamesFromScopesConfig(scopesConfig)
+	scopeName := dataStoreNames[0].ScopeName()
+	collection1Name := dataStoreNames[0].CollectionName()
+	collection2Name := dataStoreNames[1].CollectionName()
+	collection3Name := dataStoreNames[2].CollectionName()
+	collection1and2ScopesConfig := makeScopesConfig(scopeName, []string{collection1Name, collection2Name})
+	collection3ScopesConfig := makeScopesConfig(scopeName, []string{collection3Name})
+
+	initMgr := sc.DatabaseInitManager
+
+	// Use waitChannel to have collectionCallback block, to simulate long-running creation
+	testSignalChannel := make(chan error)
+	firstCollectionInitChannel := make(chan error)
+
+	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
+	collectionCount := int64(0)
+	initMgr.collectionCompleteCallback = func(dbName, collectionName string) {
+		log.Printf("Collection complete callback invoked for %s %s", dbName, collectionName)
+		currentCount := atomic.LoadInt64(&collectionCount)
+		if currentCount == 0 {
+			notifyChannel(t, firstCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", collectionName)) // notify the test that indexes have been created for this collection
+			waitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))            // wait for the test to unblock before proceeding to the next collection
+		}
+		atomic.AddInt64(&collectionCount, 1)
+	}
+
+	db1Name := "db1Name"
+	db1Config := makeDbConfig(tb.GetName(), db1Name, collection1and2ScopesConfig)
+
+	db2Name := "db2Name"
+	db2Config := makeDbConfig(tb.GetName(), db2Name, collection3ScopesConfig)
+
+	// Start first async index creation, should block after first collection
+	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, db1Config.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	// Wait for first collection to be initialized
+	waitForChannel(t, firstCollectionInitChannel, "first collection init")
+
+	// Start second async index creation for db2 while first is still running
+	doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, db2Config.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	// Unblock the first InitializeDatabase, should cancel
+	close(testSignalChannel)
+
+	// Wait for notification on both done channels
+	waitForChannel(t, doneChan1, "modified init done chan")
+	waitForChannel(t, doneChan2, "modified init done chan")
+
+	// Verify initialization was run for 5 collections (three for db1, two for db2)
+	totalCount := atomic.LoadInt64(&collectionCount)
+	require.Equal(t, int64(5), totalCount)
+
+}
+
+// TestDatabaseInitConcurrentDatabasesDifferentBuckets tests InitializeDatabase running for multiple databases concurrently.
+// Uses initManager callbacks to simulate slow index creation and concurrent init requests.
+func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
+
+	base.RequireNumTestBuckets(t, 2)
+	base.TestRequiresCollections(t)
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server - requires bootstrap support")
+	}
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
+
+	// Start SG with no databases
+	config := BootstrapStartupConfigForTest(t)
+	ctx := base.TestCtx(t)
+	sc, err := SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+	}()
+
+	// Get two test buckets for bootstrap testing, and drop indexes created by bucket pool readier
+	tb1 := base.GetTestBucket(t)
+	defer func() {
+		tb1.Close()
+	}()
+
+	// Drop all test indexes so we can test InitializeDatabase
+	dropAllTestIndexes(t, tb1)
+
+	// Get two test buckets for bootstrap testing, and drop indexes created by bucket pool readier
+	tb2 := base.GetTestBucket(t)
+	defer func() {
+		tb2.Close()
+	}()
+
+	// Drop all test indexes so we can test InitializeDatabase
+	dropAllTestIndexes(t, tb2)
+
+	// Set up collection names and ScopesConfig for testing - use same collections for both buckets
+	scopesConfig := GetCollectionsConfig(t, tb1, 3)
+	dataStoreNames := GetDataStoreNamesFromScopesConfig(scopesConfig)
+	scopeName := dataStoreNames[0].ScopeName()
+	collection1Name := dataStoreNames[0].CollectionName()
+	collection2Name := dataStoreNames[1].CollectionName()
+	collection1and2ScopesConfig := makeScopesConfig(scopeName, []string{collection1Name, collection2Name})
+
+	initMgr := sc.DatabaseInitManager
+
+	// Use waitChannel to have collectionCallback block, to simulate long-running creation
+	testSignalChannel := make(chan error)
+	firstCollectionInitChannel := make(chan error)
+	databaseCompleteChannel := make(chan error)
+
+	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
+	collectionCount := int64(0)
+	initMgr.collectionCompleteCallback = func(dbName, collectionName string) {
+		log.Printf("Collection complete callback invoked for %s %s", dbName, collectionName)
+		currentCount := atomic.LoadInt64(&collectionCount)
+		if currentCount == 0 {
+			notifyChannel(t, firstCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", collectionName)) // notify the test that indexes have been created for this collection
+			waitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))            // wait for the test to unblock before proceeding to the next collection
+		}
+		atomic.AddInt64(&collectionCount, 1)
+	}
+	initMgr.databaseCompleteCallback = func(dbName string) {
+		notifyChannel(t, databaseCompleteChannel, "database complete")
+	}
+
+	db1Name := "db1Name"
+	db1Config := makeDbConfig(tb1.GetName(), db1Name, collection1and2ScopesConfig)
+
+	db2Name := "db2Name"
+	db2Config := makeDbConfig(tb2.GetName(), db2Name, collection1and2ScopesConfig)
+
+	// Start first async index creation, should block after first collection
+	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, db1Config.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	// Wait for first collection to be initialized
+	waitForChannel(t, firstCollectionInitChannel, "first collection init")
+
+	// Start second async index creation for db2 while first is still running
+	doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, db2Config.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	// Unblock the first InitializeDatabase, should cancel
+	close(testSignalChannel)
+
+	// Wait for notification on both done channels
+	waitForChannel(t, doneChan1, "modified init done chan")
+	waitForChannel(t, doneChan2, "modified init done chan")
+
+	// Wait for db completion notifications for both databases
+	waitForChannel(t, databaseCompleteChannel, "database 1 init complete")
+	waitForChannel(t, databaseCompleteChannel, "database 2 init complete")
+
+	// Verify initialization was run for 6 collections (three for db1, three for db2)
+	totalCount := atomic.LoadInt64(&collectionCount)
+	require.Equal(t, int64(6), totalCount)
+
+}
+
+// TestDatabaseInitTeardownTiming tests scenarios where InitializeDatabase is called during
+// the completion phase of a previous async initialization.  Ensures there are no cases where a
+// watcher is added but never receives a done notification.
+func TestDatabaseInitTeardownTiming(t *testing.T) {
+
+	base.TestRequiresCollections(t)
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server - requires bootstrap support")
+	}
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
+
+	// Start SG with no databases
+	config := BootstrapStartupConfigForTest(t)
+	ctx := base.TestCtx(t)
+	sc, err := SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+	}()
+
+	// Get a test bucket for bootstrap testing, and drop indexes created by bucket pool readier
+	tb := base.GetTestBucket(t)
+	defer func() {
+		tb.Close()
+	}()
+
+	// Drop all test indexes so we can test InitializeDatabase
+	dropAllTestIndexes(t, tb)
+
+	// Set up collection names and ScopesConfig for testing
+	scopesConfig := GetCollectionsConfig(t, tb, 3)
+	dataStoreNames := GetDataStoreNamesFromScopesConfig(scopesConfig)
+	scopeName := dataStoreNames[0].ScopeName()
+	collection1Name := dataStoreNames[0].CollectionName()
+	collection2Name := dataStoreNames[1].CollectionName()
+	collection1and2ScopesConfig := makeScopesConfig(scopeName, []string{collection1Name, collection2Name})
+
+	initMgr := sc.DatabaseInitManager
+
+	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
+	collectionCount := int64(0)
+	initMgr.collectionCompleteCallback = func(dbName, collectionName string) {
+		atomic.AddInt64(&collectionCount, 1)
+	}
+	dbName := "dbName"
+	dbConfig := makeDbConfig(tb.GetName(), dbName, collection1and2ScopesConfig)
+
+	var doneChan2 chan error
+	databaseCompleteCount := int64(0)
+	initMgr.databaseCompleteCallback = func(dbName string) {
+		// On first completion, invoke InitializeDatabase with the same collection set post-completion
+		currentCount := atomic.LoadInt64(&databaseCompleteCount)
+		if currentCount == 0 {
+			log.Printf("invoking InitializeDatabase again during teardown")
+			var err error
+			doneChan2, err = initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
+			require.NoError(t, err)
+		}
+		atomic.AddInt64(&databaseCompleteCount, 1)
+
+	}
+
+	// Start first async index creation, should block after first collection
+	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	waitForChannel(t, doneChan1, "done chan 1")
+	waitForChannel(t, doneChan2, "done chan 2")
+
+	// Verify initialization was run for 3 collections only
+	totalCollectionInitCount := atomic.LoadInt64(&collectionCount)
+	require.Equal(t, int64(3), totalCollectionInitCount)
+
+	// Expect only a single database complete callback, since init should only have been run once.
+	totalDbCompleteCount := atomic.LoadInt64(&databaseCompleteCount)
+	require.Equal(t, int64(1), totalDbCompleteCount)
+
+}
+
+// testChannelTimeout can be increased to support step-through debugging
+const testChannelTimeout = 10 * time.Second
+
+func waitForChannel(t *testing.T, ch <-chan error, message string) {
+	if message != "" {
+		log.Printf("[%s] starting wait", message)
+		defer func() {
+			log.Printf("[%s] completed wait", message)
+		}()
+	}
+	select {
+	case err := <-ch:
+		if err != nil {
+			require.Fail(t, fmt.Sprintf("[%s] channel returned error: %v", message, err))
+		}
+		return
+	case <-time.After(testChannelTimeout):
+		require.Fail(t, fmt.Sprintf("[%s] expected channel message did not arrive in 10s", message))
+	}
+}
+
+func waitForError(t *testing.T, ch <-chan error, message string) error {
+	if message != "" {
+		log.Printf("[%s] starting wait for error", message)
+		defer func() {
+			log.Printf("[%s] completed wait for error", message)
+		}()
+	}
+	select {
+	case err := <-ch:
+		if err == nil {
+			require.Fail(t, "[%s] Received non-error message on channel", message)
+		}
+		return err
+	case <-time.After(testChannelTimeout):
+		require.Fail(t, fmt.Sprintf("[%s] expected error message did not arrive in 10s", message))
+		return nil
+	}
+}
+
+func notifyChannel(t *testing.T, ch chan<- error, message string) {
+	if message != "" {
+		log.Printf("[%s] starting notify", message)
+		defer func() {
+			log.Printf("[%s] completed notify", message)
+		}()
+	}
+	select {
+	case ch <- nil:
+		return
+	case <-time.After(testChannelTimeout):
+		require.Fail(t, fmt.Sprintf("[%s] unable to send channel notification within 10s", message))
+	}
+}
+
+func dropAllTestIndexes(t *testing.T, tb *base.TestBucket) {
+	dropAllNonPrimaryIndexes(t, tb.GetMetadataStore())
+
+	dsNames := tb.GetNonDefaultDatastoreNames()
+	for i := 0; i < len(dsNames); i++ {
+		ds, err := tb.GetNamedDataStore(i)
+		require.NoError(t, err)
+		dropAllNonPrimaryIndexes(t, ds)
+	}
+}
+
+// Calls DropAllIndexes to remove all indexes, then restores the primary index for TestBucketPool readier requirements
+func dropAllNonPrimaryIndexes(t *testing.T, dataStore base.DataStore) {
+
+	n1qlStore, ok := base.AsN1QLStore(dataStore)
+	require.True(t, ok)
+	ctx := base.TestCtx(t)
+	dropErr := base.DropAllIndexes(ctx, n1qlStore)
+	require.NoError(t, dropErr)
+	err := n1qlStore.CreatePrimaryIndex(base.PrimaryIndexName, nil)
+	require.NoError(t, err, "Unable to recreate primary index")
+}
+
+func makeScopesConfig(scopeName string, collectionNames []string) ScopesConfig {
+
+	collectionsConfig := make(CollectionsConfig)
+	for _, collectionName := range collectionNames {
+		collectionsConfig[collectionName] = CollectionConfig{}
+	}
+	return ScopesConfig{
+		scopeName: ScopeConfig{
+			Collections: collectionsConfig,
+		},
+	}
+}
+
+// waitForWorkerDone avoids races when testing db initializations performed serially
+func waitForWorkerDone(t *testing.T, manager *DatabaseInitManager, dbName string) {
+	for i := 0; i < 1000; i++ {
+		if !manager.HasActiveInitialization(dbName) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("Worker did not complete in expected time interval for db %s", dbName)
+}

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -93,7 +93,7 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 		tb.Close()
 	}()
 	// Drop all test indexes so we can test InitializeDatabase
-	dropAllTestIndexes(t, tb)
+	DropAllTestIndexes(t, tb)
 
 	// Set up collection names and ScopesConfig for testing
 	scopesConfig := GetCollectionsConfig(t, tb, 3)
@@ -184,7 +184,7 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 	}()
 
 	// Drop all test indexes so we can test InitializeDatabase
-	dropAllTestIndexes(t, tb)
+	DropAllTestIndexes(t, tb)
 
 	// Set up collection names and ScopesConfig for testing
 	scopesConfig := GetCollectionsConfig(t, tb, 3)
@@ -271,7 +271,7 @@ func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
 	}()
 
 	// Drop all test indexes so we can test InitializeDatabase
-	dropAllTestIndexes(t, tb)
+	DropAllTestIndexes(t, tb)
 
 	// Set up collection names and ScopesConfig for testing
 	scopesConfig := GetCollectionsConfig(t, tb, 3)
@@ -358,7 +358,7 @@ func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
 	}()
 
 	// Drop all test indexes so we can test InitializeDatabase
-	dropAllTestIndexes(t, tb1)
+	DropAllTestIndexes(t, tb1)
 
 	// Get two test buckets for bootstrap testing, and drop indexes created by bucket pool readier
 	tb2 := base.GetTestBucket(t)
@@ -367,7 +367,7 @@ func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
 	}()
 
 	// Drop all test indexes so we can test InitializeDatabase
-	dropAllTestIndexes(t, tb2)
+	DropAllTestIndexes(t, tb2)
 
 	// Set up collection names and ScopesConfig for testing - use same collections for both buckets
 	scopesConfig := GetCollectionsConfig(t, tb1, 3)
@@ -460,7 +460,7 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 	}()
 
 	// Drop all test indexes so we can test InitializeDatabase
-	dropAllTestIndexes(t, tb)
+	DropAllTestIndexes(t, tb)
 
 	// Set up collection names and ScopesConfig for testing
 	scopesConfig := GetCollectionsConfig(t, tb, 3)
@@ -510,29 +510,6 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 	totalDbCompleteCount := atomic.LoadInt64(&databaseCompleteCount)
 	require.Equal(t, int64(1), totalDbCompleteCount)
 
-}
-
-func dropAllTestIndexes(t *testing.T, tb *base.TestBucket) {
-	dropAllNonPrimaryIndexes(t, tb.GetMetadataStore())
-
-	dsNames := tb.GetNonDefaultDatastoreNames()
-	for i := 0; i < len(dsNames); i++ {
-		ds, err := tb.GetNamedDataStore(i)
-		require.NoError(t, err)
-		dropAllNonPrimaryIndexes(t, ds)
-	}
-}
-
-// Calls DropAllIndexes to remove all indexes, then restores the primary index for TestBucketPool readier requirements
-func dropAllNonPrimaryIndexes(t *testing.T, dataStore base.DataStore) {
-
-	n1qlStore, ok := base.AsN1QLStore(dataStore)
-	require.True(t, ok)
-	ctx := base.TestCtx(t)
-	dropErr := base.DropAllIndexes(ctx, n1qlStore)
-	require.NoError(t, dropErr)
-	err := n1qlStore.CreatePrimaryIndex(base.PrimaryIndexName, nil)
-	require.NoError(t, err, "Unable to recreate primary index")
 }
 
 func makeScopesConfig(scopeName string, collectionNames []string) ScopesConfig {

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -116,7 +116,7 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 		currentCount := atomic.LoadInt64(&collectionCount)
 		if currentCount == 0 {
 			notifyChannel(t, singleCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", collectionName)) // notify the test that indexes have been created for this collection
-			waitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))             // wait for the test to unblock before proceeding to the next collection
+			WaitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))             // wait for the test to unblock before proceeding to the next collection
 		}
 		atomic.AddInt64(&collectionCount, 1)
 	}
@@ -129,7 +129,7 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for first collection to be initialized
-	waitForChannel(t, singleCollectionInitChannel, "first collection init")
+	WaitForChannel(t, singleCollectionInitChannel, "first collection init")
 
 	// Make a duplicate call to initialize database, should reuse the existing agent
 	duplicateDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
@@ -139,8 +139,8 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 	close(testSignalChannel)
 
 	// Wait for notification on both done channels
-	waitForChannel(t, doneChan, "first init done chan")
-	waitForChannel(t, duplicateDoneChan, "duplicate init done chan")
+	WaitForChannel(t, doneChan, "first init done chan")
+	WaitForChannel(t, duplicateDoneChan, "duplicate init done chan")
 
 	// Verify initialization was only run for two collections
 	totalCount := atomic.LoadInt64(&collectionCount)
@@ -151,7 +151,7 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 	// Rerun init, should start a new worker for the database and re-verify init for each collection
 	rerunDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
 	require.NoError(t, err)
-	waitForChannel(t, rerunDoneChan, "repeated init done chan")
+	WaitForChannel(t, rerunDoneChan, "repeated init done chan")
 	totalCount = atomic.LoadInt64(&collectionCount)
 	require.Equal(t, expectedCollectionCount*2, totalCount)
 }
@@ -209,7 +209,7 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 		currentCount := atomic.LoadInt64(&collectionCount)
 		if currentCount == 0 {
 			notifyChannel(t, firstCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", collectionName)) // notify the test that indexes have been created for this collection
-			waitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))            // wait for the test to unblock before proceeding to the next collection
+			WaitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))            // wait for the test to unblock before proceeding to the next collection
 		}
 		atomic.AddInt64(&collectionCount, 1)
 	}
@@ -222,7 +222,7 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for first collection to be initialized
-	waitForChannel(t, firstCollectionInitChannel, "first collection init")
+	WaitForChannel(t, firstCollectionInitChannel, "first collection init")
 
 	// Make a call to initialize database for the same db name, different collections
 	modifiedDbConfig := makeDbConfig(tb.GetName(), dbName, collection1and3ScopesConfig)
@@ -237,7 +237,7 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 	require.Error(t, cancelErr)
 
 	// Wait for notification on new done channel
-	waitForChannel(t, modifiedDoneChan, "modified init done chan")
+	WaitForChannel(t, modifiedDoneChan, "modified init done chan")
 
 	// Verify initialization was run for four collections (one prior to cancellation, three for subsequent init)
 	totalCount := atomic.LoadInt64(&collectionCount)
@@ -296,7 +296,7 @@ func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
 		currentCount := atomic.LoadInt64(&collectionCount)
 		if currentCount == 0 {
 			notifyChannel(t, firstCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", collectionName)) // notify the test that indexes have been created for this collection
-			waitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))            // wait for the test to unblock before proceeding to the next collection
+			WaitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))            // wait for the test to unblock before proceeding to the next collection
 		}
 		atomic.AddInt64(&collectionCount, 1)
 	}
@@ -312,7 +312,7 @@ func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for first collection to be initialized
-	waitForChannel(t, firstCollectionInitChannel, "first collection init")
+	WaitForChannel(t, firstCollectionInitChannel, "first collection init")
 
 	// Start second async index creation for db2 while first is still running
 	doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, db2Config.ToDatabaseConfig())
@@ -322,8 +322,8 @@ func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
 	close(testSignalChannel)
 
 	// Wait for notification on both done channels
-	waitForChannel(t, doneChan1, "modified init done chan")
-	waitForChannel(t, doneChan2, "modified init done chan")
+	WaitForChannel(t, doneChan1, "modified init done chan")
+	WaitForChannel(t, doneChan2, "modified init done chan")
 
 	// Verify initialization was run for 5 collections (three for db1, two for db2)
 	totalCount := atomic.LoadInt64(&collectionCount)
@@ -391,7 +391,7 @@ func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
 		currentCount := atomic.LoadInt64(&collectionCount)
 		if currentCount == 0 {
 			notifyChannel(t, firstCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", collectionName)) // notify the test that indexes have been created for this collection
-			waitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))            // wait for the test to unblock before proceeding to the next collection
+			WaitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))            // wait for the test to unblock before proceeding to the next collection
 		}
 		atomic.AddInt64(&collectionCount, 1)
 	}
@@ -410,7 +410,7 @@ func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for first collection to be initialized
-	waitForChannel(t, firstCollectionInitChannel, "first collection init")
+	WaitForChannel(t, firstCollectionInitChannel, "first collection init")
 
 	// Start second async index creation for db2 while first is still running
 	doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, db2Config.ToDatabaseConfig())
@@ -420,12 +420,12 @@ func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
 	close(testSignalChannel)
 
 	// Wait for notification on both done channels
-	waitForChannel(t, doneChan1, "modified init done chan")
-	waitForChannel(t, doneChan2, "modified init done chan")
+	WaitForChannel(t, doneChan1, "modified init done chan")
+	WaitForChannel(t, doneChan2, "modified init done chan")
 
 	// Wait for db completion notifications for both databases
-	waitForChannel(t, databaseCompleteChannel, "database 1 init complete")
-	waitForChannel(t, databaseCompleteChannel, "database 2 init complete")
+	WaitForChannel(t, databaseCompleteChannel, "database 1 init complete")
+	WaitForChannel(t, databaseCompleteChannel, "database 2 init complete")
 
 	// Verify initialization was run for 6 collections (three for db1, three for db2)
 	totalCount := atomic.LoadInt64(&collectionCount)
@@ -499,8 +499,8 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
 	require.NoError(t, err)
 
-	waitForChannel(t, doneChan1, "done chan 1")
-	waitForChannel(t, doneChan2, "done chan 2")
+	WaitForChannel(t, doneChan1, "done chan 1")
+	WaitForChannel(t, doneChan2, "done chan 2")
 
 	// Verify initialization was run for 3 collections only
 	totalCollectionInitCount := atomic.LoadInt64(&collectionCount)
@@ -510,61 +510,6 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 	totalDbCompleteCount := atomic.LoadInt64(&databaseCompleteCount)
 	require.Equal(t, int64(1), totalDbCompleteCount)
 
-}
-
-// testChannelTimeout can be increased to support step-through debugging
-const testChannelTimeout = 10 * time.Second
-
-func waitForChannel(t *testing.T, ch <-chan error, message string) {
-	if message != "" {
-		log.Printf("[%s] starting wait", message)
-		defer func() {
-			log.Printf("[%s] completed wait", message)
-		}()
-	}
-	select {
-	case err := <-ch:
-		if err != nil {
-			require.Fail(t, fmt.Sprintf("[%s] channel returned error: %v", message, err))
-		}
-		return
-	case <-time.After(testChannelTimeout):
-		require.Fail(t, fmt.Sprintf("[%s] expected channel message did not arrive in 10s", message))
-	}
-}
-
-func waitForError(t *testing.T, ch <-chan error, message string) error {
-	if message != "" {
-		log.Printf("[%s] starting wait for error", message)
-		defer func() {
-			log.Printf("[%s] completed wait for error", message)
-		}()
-	}
-	select {
-	case err := <-ch:
-		if err == nil {
-			require.Fail(t, "[%s] Received non-error message on channel", message)
-		}
-		return err
-	case <-time.After(testChannelTimeout):
-		require.Fail(t, fmt.Sprintf("[%s] expected error message did not arrive in 10s", message))
-		return nil
-	}
-}
-
-func notifyChannel(t *testing.T, ch chan<- error, message string) {
-	if message != "" {
-		log.Printf("[%s] starting notify", message)
-		defer func() {
-			log.Printf("[%s] completed notify", message)
-		}()
-	}
-	select {
-	case ch <- nil:
-		return
-	case <-time.After(testChannelTimeout):
-		require.Fail(t, fmt.Sprintf("[%s] unable to send channel notification within 10s", message))
-	}
 }
 
 func dropAllTestIndexes(t *testing.T, tb *base.TestBucket) {

--- a/rest/handler_config_database.go
+++ b/rest/handler_config_database.go
@@ -84,7 +84,7 @@ func (h *handler) mutateDbConfig(mutator func(*DbConfig) error) error {
 		defer h.server.lock.Unlock()
 
 		// TODO: Dynamic update instead of reload
-		if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+		if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 			return err
 		}
 		h.setEtag(updatedDbConfig.Version)

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -10,6 +10,7 @@ package indextest
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"strings"
@@ -113,12 +114,14 @@ func TestSyncGatewayStartupIndexes(t *testing.T) {
 
 }
 
+// TestAsyncInitializeIndexes creates a database and simulates slow index creation (using collectionCompleteCallback).
+// Verifies that offline operations can be performed successfully.
 func TestAsyncInitializeIndexes(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}
-
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
+	base.TestRequiresCollections(t)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP)
 
 	serverErr := make(chan error, 0)
 
@@ -138,7 +141,6 @@ func TestAsyncInitializeIndexes(t *testing.T) {
 	require.NoError(t, sc.WaitForRESTAPIs())
 
 	// Set testing callbacks for async initialization
-
 	collectionCount := int64(0)
 	initStarted := make(chan error)
 	unblockInit := make(chan error)
@@ -186,6 +188,7 @@ func TestAsyncInitializeIndexes(t *testing.T) {
 	resp.RequireStatus(http.StatusOK)
 	dbConfigBeforeOffline := resp.Body
 
+	// Modify import filter and sync function while index init is pending/blocked
 	resp = rest.BootstrapAdminRequest(t, http.MethodGet, "/"+keyspace+"/_config/import_filter", "")
 	resp.RequireResponse(http.StatusOK, importFilter)
 
@@ -202,6 +205,7 @@ func TestAsyncInitializeIndexes(t *testing.T) {
 	resp = rest.BootstrapAdminRequest(t, http.MethodGet, "/"+keyspace+"/_config/sync", "")
 	resp.RequireResponse(http.StatusOK, syncFunc)
 
+	// unblock initialization
 	log.Printf("closing unblockInit")
 	close(unblockInit)
 
@@ -213,29 +217,334 @@ func TestAsyncInitializeIndexes(t *testing.T) {
 	resp.RequireStatus(http.StatusCreated)
 
 	// wait for db to come online
-	var stateCurr string
-	for i := 0; i < 100; i++ {
-		var dbRootResponse rest.DatabaseRoot
-		resp = rest.BootstrapAdminRequest(t, http.MethodGet, "/"+dbName+"/", "")
-		resp.Unmarshal(&dbRootResponse)
-		stateCurr = dbRootResponse.State
-		log.Printf("db state: %v", stateCurr)
-		if stateCurr == db.RunStateString[db.DBOnline] {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	require.Equal(t, db.RunStateString[db.DBOnline], stateCurr)
+	waitAndRequireDBState(t, dbName, db.DBOnline)
 
 }
 
-//TODO:
-//   - remove indexes, add callbacks to verify functionality works while database is offline
-//   - similar test that has data populated in the bucket, validate resync
-//    - create db, write a bunch of docs
-//    - delete db
-//    - manually drop indexes  (simulates something like XDCR of populated data into a collection with no data)
-//    - create new db, init indexes, run resync without indexes
+// TestAsyncInitWithResync verifies that resync can run successfully while async index initialization is in progress.
+// Handles the case where data has been migrated between buckets but index doesn't yet exist in new bucket.
+//  1. Creates a database, writes documents via SG to generate metadata
+//  2. Deletes the database
+//  3. Manually drops indexes
+//  4. Recreates the database with blocking callback for index initialization
+//  5. Runs resync while init is blocked/in progress
+func TestAsyncInitWithResync(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	base.TestRequiresCollections(t)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP)
+
+	serverErr := make(chan error, 0)
+
+	// Start SG with no databases
+	ctx := base.TestCtx(t)
+	config := rest.BootstrapStartupConfigForTest(t)
+	sc, err := rest.SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+		require.NoError(t, <-serverErr)
+	}()
+
+	go func() {
+		serverErr <- rest.StartServer(ctx, &config, sc)
+	}()
+	require.NoError(t, sc.WaitForRESTAPIs())
+
+	// Seed the bucket with some documents
+	tb := base.GetTestBucket(t)
+	defer func() { tb.Close() }()
+
+	syncFunc := "function(doc){ channel(doc.channel1); }"
+	dbConfig := makeDbConfig(t, tb, syncFunc, "")
+	dbConfig.StartOffline = base.BoolPtr(false)
+	dbConfigPayload, err := json.Marshal(dbConfig)
+	require.NoError(t, err)
+	dbName := "db"
+
+	docCollection, err := base.AsCollection(tb.GetSingleDataStore())
+	require.NoError(t, err)
+	keyspace := dbName + "." + docCollection.ScopeName() + "." + docCollection.CollectionName()
+
+	// Persist config
+	resp := rest.BootstrapAdminRequest(t, http.MethodPut, "/"+dbName+"/", string(dbConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+	waitAndRequireDBState(t, dbName, db.DBOnline)
+
+	for i := 0; i < 5; i++ {
+		docID := fmt.Sprintf("doc%d", i)
+		docBody := `{"channel1":["ABC"], "channel2":["DEF"]}`
+		resp := rest.BootstrapAdminRequest(t, http.MethodPut, "/"+keyspace+"/"+docID, docBody)
+		resp.RequireStatus(http.StatusCreated)
+	}
+
+	// Delete the database
+	resp = rest.BootstrapAdminRequest(t, http.MethodDelete, "/"+dbName+"/", "")
+	resp.RequireStatus(http.StatusOK)
+
+	rest.DropAllTestIndexes(t, tb)
+
+	// Set testing callbacks for async initialization
+
+	collectionCount := int64(0)
+	initStarted := make(chan error)
+	unblockInit := make(chan error)
+	collectionCompleteCallback := func(dbName, collectionName string) {
+		count := atomic.AddInt64(&collectionCount, 1)
+		// On first collection, close initStarted channel
+		log.Printf("collection callback count: %v", count)
+		if count == 1 {
+			log.Printf("closing initStarted")
+			close(initStarted)
+		}
+		rest.WaitForChannel(t, unblockInit, "waiting for test to unblock initialization")
+	}
+	sc.DatabaseInitManager.SetCallbacks(collectionCompleteCallback, nil)
+	// Recreate the database with offline=true and a modified sync function
+	syncFunc = "function(doc){ channel(doc.channel2);}"
+	dbConfig = makeDbConfig(t, tb, syncFunc, "")
+	dbConfig.StartOffline = base.BoolPtr(true)
+	dbConfigPayload, err = json.Marshal(dbConfig)
+	require.NoError(t, err)
+
+	// Recreate database
+	resp = rest.BootstrapAdminRequest(t, http.MethodPut, "/"+dbName+"/", string(dbConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+
+	// Wait for init to start before calling resync
+	rest.WaitForChannel(t, initStarted, "waiting for initialization to start")
+	log.Printf("initialization started")
+
+	// Start resync
+	resyncPayload := rest.ResyncPostReqBody{}
+	resyncPayload.Scope = db.ResyncCollections{
+		docCollection.ScopeName(): []string{docCollection.CollectionName()},
+	}
+	payloadBytes, err := json.Marshal(resyncPayload)
+	require.NoError(t, err)
+
+	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/"+dbName+"/_resync", string(payloadBytes))
+	resp.RequireStatus(http.StatusOK)
+
+	// Wait for resync to complete
+	waitAndRequireDBState(t, dbName, db.DBOffline)
+
+	// verify raw documents in the bucket to validate that resync ran before db came online
+	for i := 0; i < 5; i++ {
+		docID := fmt.Sprintf("doc%d", i)
+		requireActiveChannel(t, docCollection, docID, "DEF")
+	}
+
+	// unblock initialization
+	log.Printf("closing unblockInit")
+	close(unblockInit)
+
+	// Bring the database online
+	dbConfig.StartOffline = base.BoolPtr(false)
+	dbOnlineConfigPayload, err := json.Marshal(dbConfig)
+	require.NoError(t, err)
+	resp = rest.BootstrapAdminRequest(t, http.MethodPut, "/"+dbName+"/_config", string(dbOnlineConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+
+	// wait for db to come online
+	waitAndRequireDBState(t, dbName, db.DBOnline)
+
+}
+
+// TestAsyncOnlineOffline verifies that a database that has been brought online can be taken offline
+// while async index initialization is still in progress
+func TestAsyncOnlineOffline(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	base.TestRequiresCollections(t)
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP)
+
+	serverErr := make(chan error, 0)
+
+	// Start SG with no databases
+	ctx := base.TestCtx(t)
+	config := rest.BootstrapStartupConfigForTest(t)
+	sc, err := rest.SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+		require.NoError(t, <-serverErr)
+	}()
+
+	go func() {
+		serverErr <- rest.StartServer(ctx, &config, sc)
+	}()
+	require.NoError(t, sc.WaitForRESTAPIs())
+
+	// Set testing callbacks for async initialization
+	collectionCount := int64(0)
+	initStarted := make(chan error)
+	unblockInit := make(chan error)
+	collectionCompleteCallback := func(dbName, collectionName string) {
+		count := atomic.AddInt64(&collectionCount, 1)
+		// On first collection, close initStarted channel
+		log.Printf("collection callback count: %v", count)
+		if count == 1 {
+			log.Printf("closing initStarted")
+			close(initStarted)
+		}
+		rest.WaitForChannel(t, unblockInit, "waiting for test to unblock initialization")
+	}
+	sc.DatabaseInitManager.SetCallbacks(collectionCompleteCallback, nil)
+
+	// Get a test bucket, and use it to create the database.
+	tb := base.GetTestBucket(t)
+	defer func() { tb.Close() }()
+
+	importFilter := "function(doc) { return true }"
+	syncFunc := "function(doc){ channel(doc.channels); }"
+
+	dbConfig := makeDbConfig(t, tb, syncFunc, importFilter)
+	dbConfig.StartOffline = base.BoolPtr(true)
+	dbConfigPayload, err := json.Marshal(dbConfig)
+	dbName := "db"
+
+	keyspace := dbName
+	expectedCollectionCount := 1 // metadata store
+	if len(dbConfig.Scopes) > 0 {
+		keyspaces := getRESTKeyspaces(dbName, dbConfig.Scopes)
+		keyspace = keyspaces[0]
+		expectedCollectionCount += len(keyspaces)
+	}
+	require.NoError(t, err)
+
+	// Create database with offline=true
+	resp := rest.BootstrapAdminRequest(t, http.MethodPut, "/"+dbName+"/", string(dbConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+
+	// Wait for init to start before interacting with the db, validate db state is offline
+	rest.WaitForChannel(t, initStarted, "waiting for initialization to start")
+	log.Printf("initialization started")
+	waitAndRequireDBState(t, dbName, db.DBOffline)
+
+	// Set up payloads for upserting db state
+	onlineConfigUpsert := rest.DbConfig{
+		StartOffline: base.BoolPtr(false),
+	}
+	dbOnlineConfigPayload, err := json.Marshal(onlineConfigUpsert)
+	require.NoError(t, err)
+
+	offlineConfigUpsert := rest.DbConfig{
+		StartOffline: base.BoolPtr(true),
+	}
+	dbOfflineConfigPayload, err := json.Marshal(offlineConfigUpsert)
+	require.NoError(t, err)
+
+	// Take the database online while async init is still in progress, verify state goes to Starting
+	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/"+dbName+"/_config", string(dbOnlineConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+	waitAndRequireDBState(t, dbName, db.DBStarting)
+
+	// Take the database offline while async init is still in progress
+	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/"+dbName+"/_config", string(dbOfflineConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+	waitAndRequireDBState(t, dbName, db.DBOffline)
+
+	// Verify offline changes can still be made
+	resp = rest.BootstrapAdminRequest(t, http.MethodGet, "/"+keyspace+"/_config/sync", "")
+	resp.RequireResponse(http.StatusOK, syncFunc)
+
+	// Take the database back online while async init is still in progress, verify state goes to Starting
+	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/"+dbName+"/_config", string(dbOnlineConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+	waitAndRequireDBState(t, dbName, db.DBStarting)
+
+	// Unblock initialization, verify status goes to Online
+	log.Printf("closing unblockInit")
+	close(unblockInit)
+	waitAndRequireDBState(t, dbName, db.DBOnline)
+
+	// Verify only four collections were initialized (offline/online didn't trigger duplicate initialization)
+	totalCount := atomic.LoadInt64(&collectionCount)
+	require.Equal(t, int64(expectedCollectionCount), totalCount)
+
+	// Take database back offline after init complete
+	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/"+dbName+"/_config", string(dbOfflineConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+	waitAndRequireDBState(t, dbName, db.DBOffline)
+
+	// Take database back online after init complete, verify successful
+	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/"+dbName+"/_config", string(dbOnlineConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+	waitAndRequireDBState(t, dbName, db.DBOnline)
+
+}
+
+// TestSyncOnline verifies that a database that is created with startOffline=false doesn't trigger async initialization
+func TestSyncOnline(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	base.TestRequiresCollections(t)
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP)
+
+	serverErr := make(chan error, 0)
+
+	// Start SG with no databases
+	ctx := base.TestCtx(t)
+	config := rest.BootstrapStartupConfigForTest(t)
+	sc, err := rest.SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+		require.NoError(t, <-serverErr)
+	}()
+
+	go func() {
+		serverErr <- rest.StartServer(ctx, &config, sc)
+	}()
+	require.NoError(t, sc.WaitForRESTAPIs())
+
+	// Set testing callbacks for async initialization
+	collectionCount := int64(0)
+	collectionCompleteCallback := func(dbName, collectionName string) {
+		_ = atomic.AddInt64(&collectionCount, 1)
+	}
+	sc.DatabaseInitManager.SetCallbacks(collectionCompleteCallback, nil)
+
+	// Get a test bucket, and use it to create the database.
+	tb := base.GetTestBucket(t)
+	defer func() { tb.Close() }()
+
+	importFilter := "function(doc) { return true }"
+	syncFunc := "function(doc){ channel(doc.channels); }"
+
+	dbConfig := makeDbConfig(t, tb, syncFunc, importFilter)
+	dbConfig.StartOffline = base.BoolPtr(false)
+	dbConfigPayload, err := json.Marshal(dbConfig)
+	dbName := "db"
+
+	expectedCollectionCount := 1 // metadata store
+	if len(dbConfig.Scopes) > 0 {
+		keyspaces := getRESTKeyspaces(dbName, dbConfig.Scopes)
+		expectedCollectionCount += len(keyspaces)
+	}
+	require.NoError(t, err)
+
+	// Create database with offline=false
+	resp := rest.BootstrapAdminRequest(t, http.MethodPut, "/"+dbName+"/", string(dbConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+
+	// Verify online
+	waitAndRequireDBState(t, dbName, db.DBOnline)
+
+	// Verify no collections were initialized asynchronously
+	totalCount := atomic.LoadInt64(&collectionCount)
+	require.Equal(t, int64(0), totalCount)
+
+}
 
 func makeDbConfig(t *testing.T, tb *base.TestBucket, syncFunction string, importFilter string) rest.DbConfig {
 
@@ -275,4 +584,30 @@ func getRESTKeyspaces(dbName string, scopesConfig rest.ScopesConfig) []string {
 		}
 	}
 	return keyspaces
+}
+
+// waitAndRequireDBState issues BootstrapAdminRequests to monitor db state
+func waitAndRequireDBState(t *testing.T, dbName string, targetState uint32) {
+	// wait for db to come online
+	var stateCurr string
+	for i := 0; i < 100; i++ {
+		var dbRootResponse rest.DatabaseRoot
+		resp := rest.BootstrapAdminRequest(t, http.MethodGet, "/"+dbName+"/", "")
+		resp.Unmarshal(&dbRootResponse)
+		stateCurr = dbRootResponse.State
+		if stateCurr == db.RunStateString[targetState] {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	require.Equal(t, db.RunStateString[targetState], stateCurr)
+}
+
+func requireActiveChannel(t *testing.T, dataStore base.DataStore, key string, channelName string) {
+	xattr := db.SyncData{}
+	_, err := dataStore.GetWithXattr(key, base.SyncXattrName, "", nil, &xattr, nil)
+	require.NoError(t, err, "Error Getting Xattr as sync data")
+	channel, ok := xattr.Channels[channelName]
+	require.True(t, ok)
+	require.True(t, channel == nil)
 }

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -709,6 +709,7 @@ func waitAndRequireDBState(t *testing.T, dbName string, targetState uint32) {
 		if stateCurr == db.RunStateString[targetState] {
 			break
 		}
+		log.Printf("Waiting for state %s, current state %s", db.RunStateString[targetState], stateCurr)
 		time.Sleep(500 * time.Millisecond)
 	}
 	require.Equal(t, db.RunStateString[targetState], stateCurr)

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -208,6 +208,7 @@ func TestAsyncInitializeIndexes(t *testing.T) {
 	// Bring the database online
 	dbConfig.StartOffline = base.BoolPtr(false)
 	dbOnlineConfigPayload, err := json.Marshal(dbConfig)
+	require.NoError(t, err)
 	resp = rest.BootstrapAdminRequest(t, http.MethodPut, "/"+dbName+"/_config", string(dbOnlineConfigPayload))
 	resp.RequireStatus(http.StatusCreated)
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -826,19 +826,10 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	dbcontext.AllowEmptyPassword = base.BoolDefault(config.AllowEmptyPassword, false)
 	dbcontext.ServeInsecureAttachmentTypes = base.BoolDefault(config.ServeInsecureAttachmentTypes, false)
 
-	// Create default users & roles:
-	if err := dbcontext.InstallPrincipals(ctx, config.Roles, "role"); err != nil {
-		return nil, err
-	}
-	if err := dbcontext.InstallPrincipals(ctx, config.Users, "user"); err != nil {
-		return nil, err
-	}
-
-	if config.Guest != nil {
-		guest := map[string]*auth.PrincipalConfig{base.GuestUsername: config.Guest}
-		if err := dbcontext.InstallPrincipals(ctx, guest, "user"); err != nil {
-			return nil, err
-		}
+	dbcontext.Options.ConfigPrincipals = &db.ConfigPrincipals{
+		Users: config.Users,
+		Roles: config.Roles,
+		Guest: config.Guest,
 	}
 
 	// Initialize event handlers

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -633,6 +633,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		}
 
 		// If database has been requested to start offline, or there's an active async initialization, use async initialization
+		// DatabaseInitManager will be nil if persistent config is not being used.
 		if sc.DatabaseInitManager != nil && (startOffline || sc.DatabaseInitManager.HasActiveInitialization(dbName)) {
 			// Initialize indexes asynchronously using DatabaseInitManager.
 			dbInitDoneChan, err = sc.DatabaseInitManager.InitializeDatabase(ctx, sc.Config, &config)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -870,7 +870,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	}
 
 	// If asyncOnline wasn't specified, block until db init is completed, then start online processes
-	if !options.asyncOnline {
+	if !options.asyncOnline || dbInitDoneChan == nil {
 		base.DebugfCtx(ctx, base.KeyConfig, "Waiting for database init to complete...")
 		if dbInitDoneChan != nil {
 			initError := <-dbInitDoneChan

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2486,3 +2486,26 @@ func (rt *RestTester) NewDbConfig() DbConfig {
 
 	return config
 }
+
+func DropAllTestIndexes(t *testing.T, tb *base.TestBucket) {
+	dropAllNonPrimaryIndexes(t, tb.GetMetadataStore())
+
+	dsNames := tb.GetNonDefaultDatastoreNames()
+	for i := 0; i < len(dsNames); i++ {
+		ds, err := tb.GetNamedDataStore(i)
+		require.NoError(t, err)
+		dropAllNonPrimaryIndexes(t, ds)
+	}
+}
+
+// Calls DropAllIndexes to remove all indexes, then restores the primary index for TestBucketPool readier requirements
+func dropAllNonPrimaryIndexes(t *testing.T, dataStore base.DataStore) {
+
+	n1qlStore, ok := base.AsN1QLStore(dataStore)
+	require.True(t, ok)
+	ctx := base.TestCtx(t)
+	dropErr := base.DropAllIndexes(ctx, n1qlStore)
+	require.NoError(t, dropErr)
+	err := n1qlStore.CreatePrimaryIndex(base.PrimaryIndexName, nil)
+	require.NoError(t, err, "Unable to recreate primary index")
+}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2506,6 +2506,6 @@ func dropAllNonPrimaryIndexes(t *testing.T, dataStore base.DataStore) {
 	ctx := base.TestCtx(t)
 	dropErr := base.DropAllIndexes(ctx, n1qlStore)
 	require.NoError(t, dropErr)
-	err := n1qlStore.CreatePrimaryIndex(base.PrimaryIndexName, nil)
+	err := n1qlStore.CreatePrimaryIndex(ctx, base.PrimaryIndexName, nil)
 	require.NoError(t, err, "Unable to recreate primary index")
 }

--- a/rest/utilities_testing_async.go
+++ b/rest/utilities_testing_async.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package rest
 
 import (

--- a/rest/utilities_testing_async.go
+++ b/rest/utilities_testing_async.go
@@ -1,0 +1,65 @@
+package rest
+
+import (
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestChannelTimeout can be increased to support step-through debugging
+const TestChannelTimeout = 10 * time.Second
+
+func WaitForChannel(t *testing.T, ch <-chan error, message string) {
+	if message != "" {
+		log.Printf("[%s] starting wait", message)
+		defer func() {
+			log.Printf("[%s] completed wait", message)
+		}()
+	}
+	select {
+	case err := <-ch:
+		if err != nil {
+			require.Fail(t, fmt.Sprintf("[%s] channel returned error: %v", message, err))
+		}
+		return
+	case <-time.After(TestChannelTimeout):
+		require.Fail(t, fmt.Sprintf("[%s] expected channel message did not arrive in 10s", message))
+	}
+}
+
+func waitForError(t *testing.T, ch <-chan error, message string) error {
+	if message != "" {
+		log.Printf("[%s] starting wait for error", message)
+		defer func() {
+			log.Printf("[%s] completed wait for error", message)
+		}()
+	}
+	select {
+	case err := <-ch:
+		if err == nil {
+			require.Fail(t, "[%s] Received non-error message on channel", message)
+		}
+		return err
+	case <-time.After(TestChannelTimeout):
+		require.Fail(t, fmt.Sprintf("[%s] expected error message did not arrive in 10s", message))
+		return nil
+	}
+}
+
+func notifyChannel(t *testing.T, ch chan<- error, message string) {
+	if message != "" {
+		log.Printf("[%s] starting notify", message)
+		defer func() {
+			log.Printf("[%s] completed notify", message)
+		}()
+	}
+	select {
+	case ch <- nil:
+		return
+	case <-time.After(TestChannelTimeout):
+		require.Fail(t, fmt.Sprintf("[%s] unable to send channel notification within 10s", message))
+	}
+}

--- a/rest/utilities_testing_async.go
+++ b/rest/utilities_testing_async.go
@@ -10,7 +10,7 @@ import (
 )
 
 // TestChannelTimeout can be increased to support step-through debugging
-const TestChannelTimeout = 10 * time.Second
+const TestChannelTimeout = 30 * time.Second
 
 func WaitForChannel(t *testing.T, ch <-chan error, message string) {
 	if message != "" {
@@ -26,7 +26,7 @@ func WaitForChannel(t *testing.T, ch <-chan error, message string) {
 		}
 		return
 	case <-time.After(TestChannelTimeout):
-		require.Fail(t, fmt.Sprintf("[%s] expected channel message did not arrive in 10s", message))
+		require.Fail(t, fmt.Sprintf("[%s] expected channel message did not arrive in %v", message, TestChannelTimeout))
 	}
 }
 
@@ -44,7 +44,7 @@ func waitForError(t *testing.T, ch <-chan error, message string) error {
 		}
 		return err
 	case <-time.After(TestChannelTimeout):
-		require.Fail(t, fmt.Sprintf("[%s] expected error message did not arrive in 10s", message))
+		require.Fail(t, fmt.Sprintf("[%s] expected error message did not arrive in %v", message, TestChannelTimeout))
 		return nil
 	}
 }

--- a/rest/utilities_testing_bootstrap.go
+++ b/rest/utilities_testing_bootstrap.go
@@ -79,6 +79,11 @@ func (r *bootstrapAdminResponse) RequireResponse(status int, body string) {
 	require.Equal(r.t, body, r.Body, "unexpected body")
 }
 
+func (r *bootstrapAdminResponse) Unmarshal(v interface{}) {
+	err := base.JSONUnmarshal([]byte(r.Body), &v)
+	require.NoError(r.t, err, "Error unmarshalling bootstrap response body")
+}
+
 func BootstrapAdminRequest(t *testing.T, method, path, body string) bootstrapAdminResponse {
 	return doBootstrapAdminRequest(t, method, "", path, body, nil)
 }

--- a/test.sh
+++ b/test.sh
@@ -67,3 +67,4 @@ for edition in "${build_editions[@]}"; do
     echo "  Testing edition: ${edition}"
     doTest $edition "$@"
 done
+golangci-lint run --config=.golangci-strict.yml


### PR DESCRIPTION
When a database is started in offline mode, allows all offline REST endpoints to be used while index initialization occurs asynchronously.

When the database is taken online via config when async initialization is in progress, sets db state to 'Starting' and does not block.  When initialization completes, database state is moved to 'Online'.

Changes to the collection set while offline will cancel and restart the async initialization with the updated set.

Initialization creation status is not persisted (as we do with background processes), because we want to re-validate index existence on every database startup.  If async processing completes, any subsequent database start/reload will check for index existence in the usual way (checking system:indexes).

CBG-2837

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1927/
