### PR TITLE
CBG-3105 ensure autoImport is false without xattrs enabled

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -2217,7 +2217,7 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 
 	// If this is an xattr import node, start import feed.  Must be started after the caching DCP feed, as import cfg
 	// subscription relies on the caching feed.
-	if db.autoImport {
+	if importEnabled {
 		db.ImportListener = NewImportListener(ctx, db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID), db)
 		if importFeedErr := db.ImportListener.StartImportFeed(db); importFeedErr != nil {
 			return importFeedErr

--- a/rest/config.go
+++ b/rest/config.go
@@ -478,6 +478,9 @@ func readFromPath(path string, insecureSkipVerify bool) (rc io.ReadCloser, err e
 
 func (dbConfig *DbConfig) AutoImportEnabled() (bool, error) {
 	if dbConfig.AutoImport == nil {
+		if !dbConfig.UseXattrs() {
+			return false, nil
+		}
 		return base.DefaultAutoImport, nil
 	}
 


### PR DESCRIPTION
I'm not sure how this regressed in https://github.com/couchbase/sync_gateway/commit/22ffb9012391f5c70840570f264d562955f4836

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1905/
