### PR TITLE
(3.1.1 backport) CBG-3109 allow autoImport unspecified and xattrs=false to work

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -2210,7 +2210,7 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 
 	// If this is an xattr import node, start import feed.  Must be started after the caching DCP feed, as import cfg
 	// subscription relies on the caching feed.
-	if db.autoImport {
+	if importEnabled {
 		db.ImportListener = NewImportListener(ctx, db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID), db)
 		if importFeedErr := db.ImportListener.StartImportFeed(db); importFeedErr != nil {
 			return importFeedErr


### PR DESCRIPTION
## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration-1.19.5/9 (tests failed but are unrelated)
