### PR TITLE
CBG-3108 only log relevant SG indexes

### DIFF
--- a/base/cluster_n1ql.go
+++ b/base/cluster_n1ql.go
@@ -60,24 +60,24 @@ func (cl *ClusterOnlyN1QLStore) GetName() string {
 	return cl.bucketName
 }
 
-func (cl *ClusterOnlyN1QLStore) BuildDeferredIndexes(indexSet []string) error {
-	return BuildDeferredIndexes(cl, indexSet)
+func (cl *ClusterOnlyN1QLStore) BuildDeferredIndexes(ctx context.Context, indexSet []string) error {
+	return BuildDeferredIndexes(ctx, cl, indexSet)
 }
 
-func (cl *ClusterOnlyN1QLStore) CreateIndex(indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
-	return CreateIndex(cl, indexName, expression, filterExpression, options)
+func (cl *ClusterOnlyN1QLStore) CreateIndex(ctx context.Context, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
+	return CreateIndex(ctx, cl, indexName, expression, filterExpression, options)
 }
 
-func (cl *ClusterOnlyN1QLStore) CreatePrimaryIndex(indexName string, options *N1qlIndexOptions) error {
-	return CreatePrimaryIndex(cl, indexName, options)
+func (cl *ClusterOnlyN1QLStore) CreatePrimaryIndex(ctx context.Context, indexName string, options *N1qlIndexOptions) error {
+	return CreatePrimaryIndex(ctx, cl, indexName, options)
 }
 
 func (cl *ClusterOnlyN1QLStore) ExplainQuery(statement string, params map[string]interface{}) (plan map[string]interface{}, err error) {
 	return ExplainQuery(cl, statement, params)
 }
 
-func (cl *ClusterOnlyN1QLStore) DropIndex(indexName string) error {
-	return DropIndex(cl, indexName)
+func (cl *ClusterOnlyN1QLStore) DropIndex(ctx context.Context, indexName string) error {
+	return DropIndex(ctx, cl, indexName)
 }
 
 // IndexMetaKeyspaceID returns the value of keyspace_id for the system:indexes table for the collection.
@@ -195,12 +195,12 @@ func (cl *ClusterOnlyN1QLStore) indexManager(scopeName, collectionName string) *
 	}
 }
 
-func (cl *ClusterOnlyN1QLStore) WaitForIndexesOnline(indexNames []string, failfast bool) error {
-	return WaitForIndexesOnline(cl.indexManager(cl.scopeName, cl.collectionName), indexNames, failfast)
+func (cl *ClusterOnlyN1QLStore) WaitForIndexesOnline(ctx context.Context, indexNames []string, failfast bool) error {
+	return WaitForIndexesOnline(ctx, cl.indexManager(cl.scopeName, cl.collectionName), indexNames, failfast)
 }
 
-func (cl *ClusterOnlyN1QLStore) GetIndexMeta(indexName string) (exists bool, meta *IndexMeta, err error) {
-	return GetIndexMeta(cl, indexName)
+func (cl *ClusterOnlyN1QLStore) GetIndexMeta(ctx context.Context, indexName string) (exists bool, meta *IndexMeta, err error) {
+	return GetIndexMeta(ctx, cl, indexName)
 }
 
 func (cl *ClusterOnlyN1QLStore) IsErrNoResults(err error) bool {

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -131,31 +131,31 @@ func (c *Collection) ExplainQuery(statement string, params map[string]interface{
 	return ExplainQuery(c, statement, params)
 }
 
-func (c *Collection) CreateIndex(indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
-	return CreateIndex(c, indexName, expression, filterExpression, options)
+func (c *Collection) CreateIndex(ctx context.Context, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
+	return CreateIndex(ctx, c, indexName, expression, filterExpression, options)
 }
 
-func (c *Collection) CreatePrimaryIndex(indexName string, options *N1qlIndexOptions) error {
-	return CreatePrimaryIndex(c, indexName, options)
+func (c *Collection) CreatePrimaryIndex(ctx context.Context, indexName string, options *N1qlIndexOptions) error {
+	return CreatePrimaryIndex(ctx, c, indexName, options)
 }
 
 // WaitForIndexesOnline takes set of indexes and watches them till they're online.
-func (c *Collection) WaitForIndexesOnline(indexNames []string, failfast bool) error {
-	return WaitForIndexesOnline(c.indexManager(), indexNames, failfast)
+func (c *Collection) WaitForIndexesOnline(ctx context.Context, indexNames []string, failfast bool) error {
+	return WaitForIndexesOnline(ctx, c.indexManager(), indexNames, failfast)
 }
 
-func (c *Collection) GetIndexMeta(indexName string) (exists bool, meta *IndexMeta, err error) {
-	return GetIndexMeta(c, indexName)
+func (c *Collection) GetIndexMeta(ctx context.Context, indexName string) (exists bool, meta *IndexMeta, err error) {
+	return GetIndexMeta(ctx, c, indexName)
 }
 
 // DropIndex drops the specified index from the current bucket.
-func (c *Collection) DropIndex(indexName string) error {
-	return DropIndex(c, indexName)
+func (c *Collection) DropIndex(ctx context.Context, indexName string) error {
+	return DropIndex(ctx, c, indexName)
 }
 
 // Issues a build command for any deferred sync gateway indexes associated with the bucket.
-func (c *Collection) BuildDeferredIndexes(indexSet []string) error {
-	return BuildDeferredIndexes(c, indexSet)
+func (c *Collection) BuildDeferredIndexes(ctx context.Context, indexSet []string) error {
+	return BuildDeferredIndexes(ctx, c, indexSet)
 }
 
 func (b *GocbV2Bucket) runQuery(scopeName string, statement string, n1qlOptions *gocb.QueryOptions) (*gocb.QueryResult, error) {

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/couchbase/gocb/v2"
 	sgbucket "github.com/couchbase/sg-bucket"
 	pkgerrors "github.com/pkg/errors"
@@ -36,19 +38,19 @@ const (
 // N1QLStore defines the set of operations Sync Gateway uses to manage and interact with N1QL
 type N1QLStore interface {
 	GetName() string
-	BuildDeferredIndexes(indexSet []string) error
-	CreateIndex(indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error
-	CreatePrimaryIndex(indexName string, options *N1qlIndexOptions) error
-	DropIndex(indexName string) error
+	BuildDeferredIndexes(ctx context.Context, indexSet []string) error
+	CreateIndex(ctx context.Context, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error
+	CreatePrimaryIndex(ctx context.Context, indexName string, options *N1qlIndexOptions) error
+	DropIndex(ctx context.Context, indexName string) error
 	ExplainQuery(statement string, params map[string]interface{}) (plan map[string]interface{}, err error)
-	GetIndexMeta(indexName string) (exists bool, meta *IndexMeta, err error)
+	GetIndexMeta(ctx context.Context, indexName string) (exists bool, meta *IndexMeta, err error)
 	Query(statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (results sgbucket.QueryResultIterator, err error)
 	IsErrNoResults(error) bool
 	EscapedKeyspace() string
 	IndexMetaBucketID() string
 	IndexMetaScopeID() string
 	IndexMetaKeyspaceID() string
-	WaitForIndexesOnline(indexNames []string, failfast bool) error
+	WaitForIndexesOnline(ctx context.Context, indexNames []string, failfast bool) error
 
 	// executeQuery performs the specified query without any built-in retry handling and returns the resultset
 	executeQuery(statement string) (sgbucket.QueryResultIterator, error)
@@ -110,7 +112,7 @@ func (im *indexManager) GetAllIndexes() ([]gocb.QueryIndex, error) {
 //
 //	  CreateIndex("myIndex", "field1, field2, nested.field", "field1 > 0", N1qlIndexOptions{numReplica:1})
 //	CREATE INDEX myIndex on myBucket(field1, field2, nested.field) WHERE field1 > 0 WITH {"numReplica":1}
-func CreateIndex(store N1QLStore, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
+func CreateIndex(ctx context.Context, store N1QLStore, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
 	createStatement := fmt.Sprintf("CREATE INDEX `%s` ON %s(%s)", indexName, store.EscapedKeyspace(), expression)
 
 	// Add filter expression, when present
@@ -121,7 +123,7 @@ func CreateIndex(store N1QLStore, indexName string, expression string, filterExp
 	// Replace any KeyspaceQueryToken references in the index expression
 	createStatement = strings.Replace(createStatement, KeyspaceQueryToken, store.EscapedKeyspace(), -1)
 
-	createErr := createIndex(store, indexName, createStatement, options)
+	createErr := createIndex(ctx, store, indexName, createStatement, options)
 	if createErr != nil {
 		if strings.Contains(createErr.Error(), "already exists") || strings.Contains(createErr.Error(), "duplicate index name") {
 			return ErrAlreadyExists
@@ -130,12 +132,12 @@ func CreateIndex(store N1QLStore, indexName string, expression string, filterExp
 	return createErr
 }
 
-func CreatePrimaryIndex(store N1QLStore, indexName string, options *N1qlIndexOptions) error {
+func CreatePrimaryIndex(ctx context.Context, store N1QLStore, indexName string, options *N1qlIndexOptions) error {
 	createStatement := fmt.Sprintf("CREATE PRIMARY INDEX `%s` ON %s", indexName, store.EscapedKeyspace())
-	return createIndex(store, indexName, createStatement, options)
+	return createIndex(ctx, store, indexName, createStatement, options)
 }
 
-func createIndex(store N1QLStore, indexName string, createStatement string, options *N1qlIndexOptions) error {
+func createIndex(ctx context.Context, store N1QLStore, indexName string, createStatement string, options *N1qlIndexOptions) error {
 
 	if options != nil {
 		withClause, marshalErr := JSONMarshal(options)
@@ -145,7 +147,7 @@ func createIndex(store N1QLStore, indexName string, createStatement string, opti
 		createStatement = fmt.Sprintf(`%s with %s`, createStatement, withClause)
 	}
 
-	DebugfCtx(context.TODO(), KeyQuery, "Attempting to create index using statement: [%s]", UD(createStatement))
+	DebugfCtx(ctx, KeyQuery, "Attempting to create index using statement: [%s]", UD(createStatement))
 
 	err := store.executeStatement(createStatement)
 	if err == nil {
@@ -153,27 +155,27 @@ func createIndex(store N1QLStore, indexName string, createStatement string, opti
 	}
 
 	if IsIndexerRetryIndexError(err) {
-		InfofCtx(context.TODO(), KeyQuery, "Indexer error creating index - waiting for server background retry.  Error:%v", err)
+		InfofCtx(ctx, KeyQuery, "Indexer error creating index - waiting for server background retry.  Error:%v", err)
 		// Wait for bucket to be created in background before returning
-		return waitForIndexExistence(store, indexName, true)
+		return waitForIndexExistence(ctx, store, indexName, true)
 	}
 
 	if IsCreateDuplicateIndexError(err) {
-		InfofCtx(context.TODO(), KeyQuery, "Duplicate index creation in progress - waiting for index readiness.  Error:%v", err)
+		InfofCtx(ctx, KeyQuery, "Duplicate index creation in progress - waiting for index readiness.  Error:%v", err)
 		// Wait for bucket to be created in background before returning
-		return waitForIndexExistence(store, indexName, true)
+		return waitForIndexExistence(ctx, store, indexName, true)
 	}
 
 	return pkgerrors.WithStack(RedactErrorf("Error creating index with statement: %s.  Error: %v", UD(createStatement), err))
 }
 
 // Waits for index to exist/not exist.  Used in response to background create/drop processing by server.
-func waitForIndexExistence(store N1QLStore, indexName string, shouldExist bool) error {
+func waitForIndexExistence(ctx context.Context, store N1QLStore, indexName string, shouldExist bool) error {
 
 	worker := func() (shouldRetry bool, err error, value interface{}) {
 		// GetIndexMeta has its own error retry handling,
 		// but keep the retry logic up here for checking if the index exists.
-		exists, _, err := store.GetIndexMeta(indexName)
+		exists, _, err := store.GetIndexMeta(ctx, indexName)
 		if err != nil {
 			return false, err, nil
 		}
@@ -195,7 +197,7 @@ func waitForIndexExistence(store N1QLStore, indexName string, shouldExist bool) 
 }
 
 // BuildDeferredIndexes issues a build command for any deferred sync gateway indexes associated with the bucket.
-func BuildDeferredIndexes(s N1QLStore, indexSet []string) error {
+func BuildDeferredIndexes(ctx context.Context, s N1QLStore, indexSet []string) error {
 
 	if len(indexSet) == 0 {
 		return nil
@@ -238,15 +240,15 @@ func BuildDeferredIndexes(s N1QLStore, indexSet []string) error {
 		return nil
 	}
 
-	InfofCtx(context.TODO(), KeyQuery, "Building deferred indexes: %v", deferredIndexes)
-	buildErr := buildIndexes(s, deferredIndexes)
+	InfofCtx(ctx, KeyQuery, "Building deferred indexes: %v", deferredIndexes)
+	buildErr := buildIndexes(ctx, s, deferredIndexes)
 	return buildErr
 }
 
 // BuildIndexes executes a BUILD INDEX statement in the current bucket, using the form:
 //
 //	BUILD INDEX ON `bucket.Name`(`index1`, `index2`, ...)
-func buildIndexes(s N1QLStore, indexNames []string) error {
+func buildIndexes(ctx context.Context, s N1QLStore, indexNames []string) error {
 	if len(indexNames) == 0 {
 		return nil
 	}
@@ -261,7 +263,7 @@ func buildIndexes(s N1QLStore, indexNames []string) error {
 	if IsIndexerRetryBuildError(err) {
 		InfofCtx(context.TODO(), KeyQuery, "Indexer error creating index - waiting for background build.  Error:%v", err)
 		// Wait for bucket to be created in background before returning
-		return s.WaitForIndexesOnline(indexNames, false)
+		return s.WaitForIndexesOnline(ctx, indexNames, false)
 	}
 
 	return err
@@ -283,13 +285,13 @@ type getIndexMetaRetryValues struct {
 	meta   *IndexMeta
 }
 
-func GetIndexMeta(store N1QLStore, indexName string) (exists bool, meta *IndexMeta, err error) {
+func GetIndexMeta(ctx context.Context, store N1QLStore, indexName string) (exists bool, meta *IndexMeta, err error) {
 
 	worker := func() (shouldRetry bool, err error, value interface{}) {
 		exists, meta, err := getIndexMetaWithoutRetry(store, indexName)
 		if err != nil {
 			// retry
-			WarnfCtx(context.TODO(), "Error from GetIndexMeta for index %s: %v will retry", indexName, err)
+			WarnfCtx(ctx, "Error from GetIndexMeta for index %s: %v will retry", indexName, err)
 			return true, err, nil
 		}
 		return false, nil, getIndexMetaRetryValues{
@@ -338,7 +340,7 @@ func getIndexMetaWithoutRetry(store N1QLStore, indexName string) (exists bool, m
 }
 
 // DropIndex drops the specified index from the current bucket.
-func DropIndex(store N1QLStore, indexName string) error {
+func DropIndex(ctx context.Context, store N1QLStore, indexName string) error {
 	statement := fmt.Sprintf("DROP INDEX default:%s.`%s`", store.EscapedKeyspace(), indexName)
 
 	err := store.executeStatement(statement)
@@ -347,9 +349,9 @@ func DropIndex(store N1QLStore, indexName string) error {
 	}
 
 	if IsIndexerRetryIndexError(err) {
-		InfofCtx(context.TODO(), KeyQuery, "Indexer error dropping index - waiting for server background retry.  Error:%v", err)
+		InfofCtx(ctx, KeyQuery, "Indexer error dropping index - waiting for server background retry.  Error:%v", err)
 		// Wait for bucket to be dropped in background before returning
-		return waitForIndexExistence(store, indexName, false)
+		return waitForIndexExistence(ctx, store, indexName, false)
 	}
 
 	return err
@@ -536,8 +538,7 @@ func IndexMetaKeyspaceID(bucketName, scopeName, collectionName string) string {
 }
 
 // WaitForIndexesOnline takes set of indexes and watches them till they're online.
-func WaitForIndexesOnline(mgr *indexManager, indexNames []string, failfast bool) error {
-	logCtx := context.TODO()
+func WaitForIndexesOnline(ctx context.Context, mgr *indexManager, indexNames []string, failfast bool) error {
 	maxNumAttempts := 180
 	if failfast {
 		maxNumAttempts = 1
@@ -555,17 +556,22 @@ func WaitForIndexesOnline(mgr *indexManager, indexNames []string, failfast bool)
 		}
 		// check each of the current indexes state, add to map once finished to make sure each index online is only being logged once
 		for i := 0; i < len(currIndexes); i++ {
-			if currIndexes[i].State == IndexStateOnline {
-				if !onlineIndexes[currIndexes[i].Name] {
-					InfofCtx(logCtx, KeyAll, "Index %s is online", MD(currIndexes[i].Name))
-					onlineIndexes[currIndexes[i].Name] = true
+			name := currIndexes[i].Name
+			// use slices.Contains since the number of indexes is expected to be small
+			if currIndexes[i].State == IndexStateOnline && slices.Contains(indexNames, name) {
+				if !onlineIndexes[name] {
+					InfofCtx(ctx, KeyAll, "Index %s is online", MD(name))
+					onlineIndexes[name] = true
 				}
 			}
 		}
 		// check online index against indexes we watch to have online, increase counter as each comes online
+		var offlineIndexes []string
 		for _, listVal := range indexNames {
 			if onlineIndexes[listVal] {
 				watchedOnlineIndexCount++
+			} else {
+				offlineIndexes = append(offlineIndexes, listVal)
 			}
 		}
 
@@ -575,9 +581,9 @@ func WaitForIndexesOnline(mgr *indexManager, indexNames []string, failfast bool)
 		retryCount++
 		shouldContinue, sleepMs := retrySleeper(retryCount)
 		if !shouldContinue {
-			return fmt.Errorf("error waiting for indexes for bucket %s....", MD(mgr.bucketName))
+			return fmt.Errorf("error waiting for indexes %s ...", strings.Join(offlineIndexes, ", "))
 		}
-		InfofCtx(logCtx, KeyAll, "Indexes for bucket %s not ready - retrying...", MD(mgr.bucketName))
+		InfofCtx(ctx, KeyAll, "Indexes %s not ready - retrying...", strings.Join(offlineIndexes, ", "))
 		time.Sleep(time.Millisecond * time.Duration(sleepMs))
 	}
 }

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -357,10 +357,10 @@ func DropAllIndexes(ctx context.Context, n1QLStore N1QLStore) error {
 			defer wg.Done()
 
 			InfofCtx(ctx, KeySGTest, "Dropping index %s on bucket %s...", indexToDrop, n1QLStore.GetName())
-			dropErr := n1QLStore.DropIndex(indexToDrop)
+			dropErr := n1QLStore.DropIndex(ctx, indexToDrop)
 			if dropErr != nil {
 				// Retry dropping index if first try fails before returning error
-				dropRetry := n1QLStore.DropIndex(indexToDrop)
+				dropRetry := n1QLStore.DropIndex(ctx, indexToDrop)
 				if dropRetry != nil {
 					asyncErrors <- dropErr
 					ErrorfCtx(ctx, "...failed to drop index %s on bucket %s: %s", indexToDrop, n1QLStore.GetName(), dropErr)

--- a/db/database.go
+++ b/db/database.go
@@ -762,7 +762,7 @@ func (dbCtx *DatabaseContext) RemoveObsoleteIndexes(ctx context.Context, preview
 			errs = errs.Append(errors.New(err))
 			continue
 		}
-		collectionRemovedIndexes, err := removeObsoleteIndexes(n1qlStore, previewOnly, dbCtx.UseXattrs(), dbCtx.UseViews(), sgIndexes)
+		collectionRemovedIndexes, err := removeObsoleteIndexes(ctx, n1qlStore, previewOnly, dbCtx.UseXattrs(), dbCtx.UseViews(), sgIndexes)
 		if err != nil {
 			errs = errs.Append(err)
 			continue

--- a/db/functions/function_test.go
+++ b/db/functions/function_test.go
@@ -684,12 +684,13 @@ func setupTestDBForBucketWithOptions(t testing.TB, tBucket base.Bucket, dbcOptio
 
 // createPrimaryIndex returns true if there was no index created before
 func createPrimaryIndex(t *testing.T, n1qlStore base.N1QLStore) bool {
-	hasPrimary, _, err := base.GetIndexMeta(n1qlStore, base.PrimaryIndexName)
+	ctx := base.TestCtx(t)
+	hasPrimary, _, err := base.GetIndexMeta(ctx, n1qlStore, base.PrimaryIndexName)
 	assert.NoError(t, err)
 	if hasPrimary {
 		return false
 	}
-	err = n1qlStore.CreatePrimaryIndex(base.PrimaryIndexName, nil)
+	err = n1qlStore.CreatePrimaryIndex(ctx, base.PrimaryIndexName, nil)
 	assert.NoError(t, err)
 	return true
 }

--- a/db/functions/graphql_test.go
+++ b/db/functions/graphql_test.go
@@ -439,7 +439,7 @@ func TestUserGraphQLWithN1QL(t *testing.T) {
 
 	if createdPrimaryIdx {
 		defer func() {
-			err := n1qlStore.DropIndex(base.PrimaryIndexName)
+			err := n1qlStore.DropIndex(base.TestCtx(t), base.PrimaryIndexName)
 			require.NoError(t, err)
 		}()
 

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -153,19 +153,19 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	require.NoError(t, err)
 
 	// Running w/ opposite xattrs flag should preview removal of the indexes associated with this db context
-	removedIndexes, removeErr := removeObsoleteIndexes(n1qlStore, true, !db.UseXattrs(), db.UseViews(), sgIndexes)
+	removedIndexes, removeErr := removeObsoleteIndexes(ctx, n1qlStore, true, !db.UseXattrs(), db.UseViews(), sgIndexes)
 	sort.Strings(removedIndexes)
 	require.EqualValues(t, expectedRemovedIndexes, removedIndexes)
 	require.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in preview mode")
 
 	// Running again w/ preview=false to perform cleanup
-	removedIndexes, removeErr = removeObsoleteIndexes(n1qlStore, false, !db.UseXattrs(), db.UseViews(), sgIndexes)
+	removedIndexes, removeErr = removeObsoleteIndexes(ctx, n1qlStore, false, !db.UseXattrs(), db.UseViews(), sgIndexes)
 	sort.Strings(removedIndexes)
 	require.Equal(t, expectedRemovedIndexes, removedIndexes)
 	require.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in non-preview mode")
 
 	// One more time to make sure they are actually gone
-	removedIndexes, removeErr = removeObsoleteIndexes(n1qlStore, false, !db.UseXattrs(), db.UseViews(), sgIndexes)
+	removedIndexes, removeErr = removeObsoleteIndexes(ctx, n1qlStore, false, !db.UseXattrs(), db.UseViews(), sgIndexes)
 	require.Len(t, removedIndexes, 0)
 	require.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in post-cleanup no-op")
 
@@ -199,7 +199,7 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	copiedIndexes := copySGIndexes(sgIndexes)
 
 	// Validate that removeObsoleteIndexes is a no-op for the default case
-	removedIndexes, removeErr := removeObsoleteIndexes(n1qlStore, true, db.UseXattrs(), db.UseViews(), copiedIndexes)
+	removedIndexes, removeErr := removeObsoleteIndexes(ctx, n1qlStore, true, db.UseXattrs(), db.UseViews(), copiedIndexes)
 	log.Printf("removedIndexes: %+v", removedIndexes)
 	assert.Equal(t, 0, len(removedIndexes))
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in no-op case")
@@ -216,7 +216,7 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	copiedIndexes[IndexAccess] = accessIndex
 
 	// Validate that removeObsoleteIndexes now triggers removal of one index
-	removedIndexes, removeErr = removeObsoleteIndexes(n1qlStore, true, db.UseXattrs(), db.UseViews(), copiedIndexes)
+	removedIndexes, removeErr = removeObsoleteIndexes(ctx, n1qlStore, true, db.UseXattrs(), db.UseViews(), copiedIndexes)
 	log.Printf("removedIndexes: %+v", removedIndexes)
 	assert.Equal(t, 1, len(removedIndexes))
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes with hacked sgIndexes")
@@ -352,11 +352,11 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 		}
 	}
 
-	removedIndexes, removeErr := removeObsoleteIndexes(n1QLStore, false, db.UseXattrs(), true, copiedIndexes)
+	removedIndexes, removeErr := removeObsoleteIndexes(ctx, n1QLStore, false, db.UseXattrs(), true, copiedIndexes)
 	require.NoError(t, removeErr)
 	require.Len(t, removedIndexes, expectedIndexes)
 
-	removedIndexes, removeErr = removeObsoleteIndexes(n1QLStore, false, db.UseXattrs(), false, copiedIndexes)
+	removedIndexes, removeErr = removeObsoleteIndexes(ctx, n1QLStore, false, db.UseXattrs(), false, copiedIndexes)
 	require.NoError(t, removeErr)
 	require.Len(t, removedIndexes, 0)
 
@@ -407,7 +407,7 @@ func TestRemoveObsoleteIndexOnError(t *testing.T) {
 	n1qlStore, ok := base.AsN1QLStore(dataStore)
 	require.True(t, ok)
 
-	removedIndex, removeErr := removeObsoleteIndexes(n1qlStore, false, db.UseXattrs(), db.UseViews(), testIndexes)
+	removedIndex, removeErr := removeObsoleteIndexes(ctx, n1qlStore, false, db.UseXattrs(), db.UseViews(), testIndexes)
 	assert.NoError(t, removeErr)
 
 	if base.TestUseXattrs() {
@@ -440,7 +440,7 @@ func dropAndInitializeIndexes(ctx context.Context, n1qlStore base.N1QLStore, opt
 	}
 
 	// Recreate the primary index required by the test bucket pooling framework
-	err := n1qlStore.CreatePrimaryIndex(base.PrimaryIndexName, nil)
+	err := n1qlStore.CreatePrimaryIndex(ctx, base.PrimaryIndexName, nil)
 	if err != nil {
 		return err
 	}

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -51,7 +51,7 @@ func TestRoleQuery(t *testing.T) {
 			n1QLStores, reset, err := setupN1QLStore(ctx, database.Bucket, testCase.isServerless)
 			require.NoError(t, err, "Unable to get n1QLStore for testBucket")
 			defer func() {
-				assert.NoError(t, reset(n1QLStores, testCase.isServerless))
+				assert.NoError(t, reset(ctx, n1QLStores, testCase.isServerless))
 			}()
 
 			authenticator := database.Authenticator(ctx)
@@ -114,7 +114,7 @@ func TestBuildRolesQuery(t *testing.T) {
 			n1QLStores, reset, err := setupN1QLStore(ctx, database.Bucket, testCase.isServerless)
 			require.NoError(t, err, "Unable to get n1QLStore for testBucket")
 			defer func() {
-				assert.NoError(t, reset(n1QLStores, testCase.isServerless))
+				assert.NoError(t, reset(ctx, n1QLStores, testCase.isServerless))
 			}()
 
 			// roles
@@ -158,7 +158,7 @@ func TestBuildUsersQuery(t *testing.T) {
 			n1QLStores, reset, err := setupN1QLStore(ctx, database.Bucket, testCase.isServerless)
 			require.NoError(t, err, "Unable to get n1QLStore for testBucket")
 			defer func() {
-				assert.NoError(t, reset(n1QLStores, testCase.isServerless))
+				assert.NoError(t, reset(ctx, n1QLStores, testCase.isServerless))
 			}()
 
 			// Sessions
@@ -201,7 +201,7 @@ func TestQueryAllRoles(t *testing.T) {
 			n1QLStores, reset, err := setupN1QLStore(ctx, database.Bucket, testCase.isServerless)
 			require.NoError(t, err, "Unable to get n1QLStore for testBucket")
 			defer func() {
-				assert.NoError(t, reset(n1QLStores, testCase.isServerless))
+				assert.NoError(t, reset(ctx, n1QLStores, testCase.isServerless))
 			}()
 
 			authenticator := database.Authenticator(ctx)
@@ -262,7 +262,7 @@ func TestAllPrincipalIDs(t *testing.T) {
 			n1QLStores, reset, err := setupN1QLStore(ctx, database.Bucket, testCase.isServerless)
 			require.NoError(t, err, "Unable to get n1QLStore for testBucket")
 			defer func() {
-				assert.NoError(t, reset(n1QLStores, testCase.isServerless))
+				assert.NoError(t, reset(ctx, n1QLStores, testCase.isServerless))
 			}()
 
 			base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
@@ -346,7 +346,7 @@ func TestGetRoleIDs(t *testing.T) {
 			n1QLStores, reset, err := setupN1QLStore(ctx, database.Bucket, testCase.isServerless)
 			require.NoError(t, err, "Unable to get n1QLStore for testBucket")
 			defer func() {
-				assert.NoError(t, reset(n1QLStores, testCase.isServerless))
+				assert.NoError(t, reset(ctx, n1QLStores, testCase.isServerless))
 			}()
 
 			base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
@@ -396,7 +396,7 @@ func getDatabaseContextOptions(isServerless bool) db.DatabaseContextOptions {
 	}
 }
 
-type resetN1QLStoreFn func(n1QLStores []base.N1QLStore, isServerless bool) error
+type resetN1QLStoreFn func(ctx context.Context, n1QLStores []base.N1QLStore, isServerless bool) error
 
 func setupN1QLStore(ctx context.Context, bucket base.Bucket, isServerless bool) ([]base.N1QLStore, resetN1QLStoreFn, error) {
 
@@ -436,7 +436,7 @@ func setupN1QLStore(ctx context.Context, bucket base.Bucket, isServerless bool) 
 }
 
 // resetN1QLStores restores the set of indexes to the starting state
-var clearIndexes resetN1QLStoreFn = func(n1QLStores []base.N1QLStore, isServerless bool) error {
+var clearIndexes resetN1QLStoreFn = func(ctx context.Context, n1QLStores []base.N1QLStore, isServerless bool) error {
 	options := db.InitializeIndexOptions{
 		UseXattrs:       base.TestUseXattrs(),
 		NumReplicas:     0,
@@ -449,7 +449,7 @@ var clearIndexes resetN1QLStoreFn = func(n1QLStores []base.N1QLStore, isServerle
 	var err error
 	for _, n1QLStore := range n1QLStores {
 		for _, index := range indexes {
-			newErr := n1QLStore.DropIndex(index)
+			newErr := n1QLStore.DropIndex(ctx, index)
 			if newErr != nil && strings.Contains(newErr.Error(), "Index not exist") {
 				err = errors.Wrap(err, newErr.Error())
 			}

--- a/db/indextest/main_test.go
+++ b/db/indextest/main_test.go
@@ -55,7 +55,7 @@ var primaryIndexInit base.TBPBucketInitFunc = func(ctx context.Context, b base.B
 			return err
 		}
 
-		err = n1qlStore.CreatePrimaryIndex(base.PrimaryIndexName, nil)
+		err = n1qlStore.CreatePrimaryIndex(ctx, base.PrimaryIndexName, nil)
 		if err != nil {
 			return err
 		}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -384,7 +384,7 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 			return err
 		}
 
-		err = n1qlStore.CreatePrimaryIndex(base.PrimaryIndexName, nil)
+		err = n1qlStore.CreatePrimaryIndex(ctx, base.PrimaryIndexName, nil)
 		if err != nil {
 			return err
 		}

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -515,8 +515,9 @@ func TestCollectionsBasicIndexQuery(t *testing.T) {
 	require.True(t, ok)
 
 	idxName := t.Name() + "_primary"
-	require.NoError(t, n1qlStore.CreatePrimaryIndex(idxName, nil))
-	require.NoError(t, n1qlStore.WaitForIndexesOnline([]string{idxName}, false))
+	ctx := base.TestCtx(t)
+	require.NoError(t, n1qlStore.CreatePrimaryIndex(ctx, idxName, nil))
+	require.NoError(t, n1qlStore.WaitForIndexesOnline(ctx, []string{idxName}, false))
 
 	res, err := n1qlStore.Query("SELECT keyspace_id, bucket_id, scope_id from system:indexes WHERE name = $idxName",
 		map[string]interface{}{"idxName": idxName}, base.RequestPlus, true)


### PR DESCRIPTION
In the first commit, just log SG only indexes. I also add which indexes _aren't_ ready yet so we know which indexes are slow to create.

I think the second commit is more comprehensive about logging but might be too much for 3.1.1

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
