### PR TITLE
CBG-2933: sync compute stat 

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -508,6 +508,16 @@ type DatabaseStats struct {
 	// Represents the compute unit for import processes on the database
 	ImportProcessCompute *SgwIntStat `json:"import_process_compute"`
 
+	ReadAttachmentComputeUnit *SgwIntStat `json:"read_attachment_compute_unit"`
+
+	WriteAttachmentComputeUnit *SgwIntStat `json:"write_attachment_compute_unit"`
+
+	DocReadComputeUnit *SgwIntStat `json:"doc_read_compute_unit"`
+
+	DocWriteComputeUnit *SgwIntStat `json:"doc_write_compute_unit"`
+
+	DocCheckComputeUnit *SgwIntStat `json:"doc_check_compute_unit"`
+
 	// These can be cleaned up in future versions of SGW, implemented as maps to reduce amount of potential risk
 	// prior to Hydrogen release. These are not exported as part of prometheus and only exposed through expvars
 	CacheFeedMapStats  *ExpVarMapWrapper `json:"cache_feed"`
@@ -1456,11 +1466,30 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.ReadAttachmentComputeUnit, err = NewIntStat(SubsystemDatabaseKey, "read_attachment_compute_unit", labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.WriteAttachmentComputeUnit, err = NewIntStat(SubsystemDatabaseKey, "write_attachment_compute_unit", labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.DocReadComputeUnit, err = NewIntStat(SubsystemDatabaseKey, "doc_read_compute_unit", labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.DocWriteComputeUnit, err = NewIntStat(SubsystemDatabaseKey, "doc_write_compute_unit", labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.DocCheckComputeUnit, err = NewIntStat(SubsystemDatabaseKey, "doc_check_compute_unit", labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.ImportProcessCompute, err = NewIntStat(SubsystemSharedBucketImport, "import_process_compute", labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-
 	resUtil.ImportFeedMapStats = &ExpVarMapWrapper{new(expvar.Map).Init()}
 
 	resUtil.CacheFeedMapStats = &ExpVarMapWrapper{new(expvar.Map).Init()}
@@ -1507,6 +1536,11 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.NumReplicationsRejectedLimit)
 	prometheus.Unregister(d.DatabaseStats.NumPublicRestRequests)
 	prometheus.Unregister(d.DatabaseStats.TotalSyncTime)
+	prometheus.Unregister(d.DatabaseStats.ReadAttachmentComputeUnit)
+	prometheus.Unregister(d.DatabaseStats.WriteAttachmentComputeUnit)
+	prometheus.Unregister(d.DatabaseStats.DocReadComputeUnit)
+	prometheus.Unregister(d.DatabaseStats.DocWriteComputeUnit)
+	prometheus.Unregister(d.DatabaseStats.DocCheckComputeUnit)
 	prometheus.Unregister(d.DatabaseStats.ImportProcessCompute)
 }
 

--- a/base/stats.go
+++ b/base/stats.go
@@ -505,18 +505,10 @@ type DatabaseStats struct {
 	SyncFunctionExceptionCount *SgwIntStat `json:"sync_function_exception_count"`
 	// The total number of times a replication connection is rejected due ot it being over the threshold
 	NumReplicationsRejectedLimit *SgwIntStat `json:"num_replications_rejected_limit"`
-	// The compute unit used relating to reading attachments over blip
-	ReadAttachmentComputeUnit *SgwIntStat `json:"read_attachment_compute_unit"`
-	// The compute unit used relating to writing attachments over blip
-	WriteAttachmentComputeUnit *SgwIntStat `json:"write_attachment_compute_unit"`
-	// The compute unit used relating to reading docs over blip
-	DocReadComputeUnit *SgwIntStat `json:"doc_read_compute_unit"`
-	// The compute unit used relating to writing docs over blip
-	DocWriteComputeUnit *SgwIntStat `json:"doc_write_compute_unit"`
-	// The compute unit used relating to changes, proposeChanges over blip
-	DocCheckComputeUnit *SgwIntStat `json:"doc_check_compute_unit"`
 	// Represents the compute unit for import processes on the database
 	ImportProcessCompute *SgwIntStat `json:"import_process_compute"`
+	// SyncProcessCompute the comopute unit for syncing with clients
+	SyncProcessCompute *SgwIntStat `json:"sync_process_compute"`
 
 	// These can be cleaned up in future versions of SGW, implemented as maps to reduce amount of potential risk
 	// prior to Hydrogen release. These are not exported as part of prometheus and only exposed through expvars
@@ -1466,27 +1458,11 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.ReadAttachmentComputeUnit, err = NewIntStat(SubsystemDatabaseKey, "read_attachment_compute_unit", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.ImportProcessCompute, err = NewIntStat(SubsystemDatabaseKey, "import_process_compute", labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.WriteAttachmentComputeUnit, err = NewIntStat(SubsystemDatabaseKey, "write_attachment_compute_unit", labelKeys, labelVals, prometheus.CounterValue, 0)
-	if err != nil {
-		return err
-	}
-	resUtil.DocReadComputeUnit, err = NewIntStat(SubsystemDatabaseKey, "doc_read_compute_unit", labelKeys, labelVals, prometheus.CounterValue, 0)
-	if err != nil {
-		return err
-	}
-	resUtil.DocWriteComputeUnit, err = NewIntStat(SubsystemDatabaseKey, "doc_write_compute_unit", labelKeys, labelVals, prometheus.CounterValue, 0)
-	if err != nil {
-		return err
-	}
-	resUtil.DocCheckComputeUnit, err = NewIntStat(SubsystemDatabaseKey, "doc_check_compute_unit", labelKeys, labelVals, prometheus.CounterValue, 0)
-	if err != nil {
-		return err
-	}
-	resUtil.ImportProcessCompute, err = NewIntStat(SubsystemSharedBucketImport, "import_process_compute", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.SyncProcessCompute, err = NewIntStat(SubsystemDatabaseKey, "sync_process_compute", labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
@@ -1536,12 +1512,8 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.NumReplicationsRejectedLimit)
 	prometheus.Unregister(d.DatabaseStats.NumPublicRestRequests)
 	prometheus.Unregister(d.DatabaseStats.TotalSyncTime)
-	prometheus.Unregister(d.DatabaseStats.ReadAttachmentComputeUnit)
-	prometheus.Unregister(d.DatabaseStats.WriteAttachmentComputeUnit)
-	prometheus.Unregister(d.DatabaseStats.DocReadComputeUnit)
-	prometheus.Unregister(d.DatabaseStats.DocWriteComputeUnit)
-	prometheus.Unregister(d.DatabaseStats.DocCheckComputeUnit)
 	prometheus.Unregister(d.DatabaseStats.ImportProcessCompute)
+	prometheus.Unregister(d.DatabaseStats.SyncProcessCompute)
 }
 
 func (d *DbStats) CollectionStat(scopeName, collectionName string) (*CollectionStats, error) {

--- a/base/stats.go
+++ b/base/stats.go
@@ -505,18 +505,18 @@ type DatabaseStats struct {
 	SyncFunctionExceptionCount *SgwIntStat `json:"sync_function_exception_count"`
 	// The total number of times a replication connection is rejected due ot it being over the threshold
 	NumReplicationsRejectedLimit *SgwIntStat `json:"num_replications_rejected_limit"`
+	// The compute unit used relating to reading attachments over blip
+	ReadAttachmentComputeUnit *SgwIntStat `json:"read_attachment_compute_unit"`
+	// The compute unit used relating to writing attachments over blip
+	WriteAttachmentComputeUnit *SgwIntStat `json:"write_attachment_compute_unit"`
+	// The compute unit used relating to reading docs over blip
+	DocReadComputeUnit *SgwIntStat `json:"doc_read_compute_unit"`
+	// The compute unit used relating to writing docs over blip
+	DocWriteComputeUnit *SgwIntStat `json:"doc_write_compute_unit"`
+	// The compute unit used relating to changes, proposeChanges over blip
+	DocCheckComputeUnit *SgwIntStat `json:"doc_check_compute_unit"`
 	// Represents the compute unit for import processes on the database
 	ImportProcessCompute *SgwIntStat `json:"import_process_compute"`
-
-	ReadAttachmentComputeUnit *SgwIntStat `json:"read_attachment_compute_unit"`
-
-	WriteAttachmentComputeUnit *SgwIntStat `json:"write_attachment_compute_unit"`
-
-	DocReadComputeUnit *SgwIntStat `json:"doc_read_compute_unit"`
-
-	DocWriteComputeUnit *SgwIntStat `json:"doc_write_compute_unit"`
-
-	DocCheckComputeUnit *SgwIntStat `json:"doc_check_compute_unit"`
 
 	// These can be cleaned up in future versions of SGW, implemented as maps to reduce amount of potential risk
 	// prior to Hydrogen release. These are not exported as part of prometheus and only exposed through expvars

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -560,7 +560,10 @@ func (bh *blipHandler) sendBatchOfChanges(sender *blip.Sender, changeArray [][]i
 			return
 		}
 		stat := CalculateComputeStat(int64(bytes), functionTime)
+		// increment associated blip stat
 		bh.replicationStats.DocWriteComputeUnit.Add(stat)
+		// increment stat on the database stats
+		bh.blipContextDb.DbStats.DatabaseStats.DocWriteComputeUnit.Add(stat)
 	}()
 
 	if len(changeArray) > 0 {
@@ -666,7 +669,10 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 			return
 		}
 		stat := CalculateComputeStat(int64(bytes), functionTime)
+		// increment associated blip stat
 		bh.replicationStats.DocCheckComputeUnit.Add(stat)
+		// increment stat on the database stats
+		bh.blipContextDb.DbStats.DatabaseStats.DocCheckComputeUnit.Add(stat)
 	}()
 	bh.replicationStats.HandleChangesCount.Add(int64(len(changeList)))
 	defer func() {
@@ -806,7 +812,10 @@ func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 			return
 		}
 		stat := CalculateComputeStat(int64(bytes), functionTime)
+		// increment associated blip stat
 		bh.replicationStats.DocCheckComputeUnit.Add(stat)
+		// increment stat on the database stats
+		bh.blipContextDb.DbStats.DatabaseStats.DocCheckComputeUnit.Add(stat)
 	}()
 	bh.replicationStats.HandleChangesCount.Add(int64(len(changeList)))
 	defer func() {
@@ -969,7 +978,10 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		}
 		functionTime := time.Since(startTime).Milliseconds()
 		stat := CalculateComputeStat(int64(bytes), functionTime)
+		// increment associated blip stat
 		bh.replicationStats.DocReadComputeUnit.Add(stat)
+		// increment stat on the database stats
+		bh.blipContextDb.DbStats.DatabaseStats.DocReadComputeUnit.Add(stat)
 	}()
 
 	// addRevisionParams := newAddRevisionParams(rq)
@@ -1312,7 +1324,10 @@ func (bh *blipHandler) handleGetAttachment(rq *blip.Message) error {
 		}
 		functionTime := time.Since(startTime).Milliseconds()
 		stat := CalculateComputeStat(int64(attachmentBytes), functionTime)
+		// increment associated blip stat
 		bh.replicationStats.WriteAttachmentComputeUnit.Add(stat)
+		// increment stat on the database stats
+		bh.blipContextDb.DbStats.DatabaseStats.WriteAttachmentComputeUnit.Add(stat)
 	}()
 
 	getAttachmentParams := newGetAttachmentParams(rq)
@@ -1388,7 +1403,10 @@ func (bh *blipHandler) sendGetAttachment(sender *blip.Sender, docID string, name
 		}
 		functionTime := time.Since(startTime).Milliseconds()
 		stat := CalculateComputeStat(int64(lenAttachment), functionTime)
+		// increment associated blip stat
 		bh.replicationStats.ReadAttachmentComputeUnit.Add(stat)
+		// increment stat on the database stats
+		bh.blipContextDb.DbStats.DatabaseStats.ReadAttachmentComputeUnit.Add(stat)
 	}()
 
 	if !bh.sendBLIPMessage(sender, outrq) {

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -963,6 +963,10 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 			return
 		}
 		bytes := len(messageBody)
+		// if message body is 0 bytes don't calculate stat
+		if bytes == 0 {
+			return
+		}
 		functionTime := time.Since(startTime).Milliseconds()
 		stat := CalculateComputeStat(int64(bytes), functionTime)
 		bh.replicationStats.DocReadComputeUnit.Add(stat)

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -743,10 +743,10 @@ func (bsc *BlipSyncContext) reportTotalSyncTimeStats() {
 	if dbStats == nil {
 		return
 	}
+	blipInterval := time.Duration(bsc.blipContextDb.Options.BlipStatsReportingInterval)
 	bsc.loadStats()
 	go func() {
-		interval := time.Duration(bsc.blipContextDb.Options.BlipStatsReportingInterval)
-		ticker := time.NewTicker(interval)
+		ticker := time.NewTicker(blipInterval)
 		defer ticker.Stop()
 		for {
 			select {

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -120,7 +120,7 @@ type BlipSyncContext struct {
 
 	stats blipSyncStats // internal structure to store stats
 
-	persistedComputeStats syncComputeStats
+	persistedComputeStats syncComputeStats // representation of the persisted database compute stats on the blipSyncStats
 }
 
 // blipSyncStats has support structures to support reporting stats at regular interval
@@ -131,13 +131,13 @@ type blipSyncStats struct {
 	lock           sync.Mutex
 }
 
+// syncComputeStats will represent the persisted value of compute stats off the database stats at each interval
 type syncComputeStats struct {
 	docCheckComputeUnit        atomic.Int64
 	docReadComputeUnit         atomic.Int64
 	docWriteComputeUnit        atomic.Int64
 	readAttachmentComputeUnit  atomic.Int64
 	writeAttachmentComputeUnit atomic.Int64
-	lock                       sync.Mutex
 }
 
 // AllowedAttachment contains the metadata for handling allowed attachments

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -713,11 +713,15 @@ func (bsc *BlipSyncContext) reportStats(updateImmediately bool) {
 
 }
 
+// reportComputeStat will report the amount of data transferred for a blip Message. This message can be a request or a response.
 func (bsc *BlipSyncContext) reportComputeStat(rq *blip.Message, startTime time.Time) {
 	messageCPUtime := time.Since(startTime).Milliseconds()
 	messBody, err := rq.Body()
 	if err == nil && bsc.blipContextDb != nil {
 		bytes := len(messBody)
+		if bytes == 0 {
+			return
+		}
 		stat := CalculateComputeStat(int64(bytes), messageCPUtime)
 		bsc.blipContextDb.DbStats.DatabaseStats.SyncProcessCompute.Add(stat)
 	}

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -141,12 +141,6 @@ func BlipSyncStatsForCBL(dbStats *base.DbStats) *BlipSyncStats {
 	blipStats.SendRevCount = dbStats.Database().NumDocReadsBlip
 	blipStats.SendRevErrorTotal = dbStats.CBLReplicationPull().RevErrorCount
 
-	blipStats.DocCheckComputeUnit = dbStats.Database().DocCheckComputeUnit
-	blipStats.DocReadComputeUnit = dbStats.Database().DocReadComputeUnit
-	blipStats.DocWriteComputeUnit = dbStats.Database().DocWriteComputeUnit
-	blipStats.ReadAttachmentComputeUnit = dbStats.Database().ReadAttachmentComputeUnit
-	blipStats.WriteAttachmentComputeUnit = dbStats.Database().WriteAttachmentComputeUnit
-
 	blipStats.HandleRevBytes = dbStats.Database().DocWritesBytesBlip
 	blipStats.HandleRevProcessingTime = dbStats.CBLReplicationPush().WriteProcessingTime
 

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -141,6 +141,12 @@ func BlipSyncStatsForCBL(dbStats *base.DbStats) *BlipSyncStats {
 	blipStats.SendRevCount = dbStats.Database().NumDocReadsBlip
 	blipStats.SendRevErrorTotal = dbStats.CBLReplicationPull().RevErrorCount
 
+	blipStats.DocCheckComputeUnit = dbStats.Database().DocCheckComputeUnit
+	blipStats.DocReadComputeUnit = dbStats.Database().DocReadComputeUnit
+	blipStats.DocWriteComputeUnit = dbStats.Database().DocWriteComputeUnit
+	blipStats.ReadAttachmentComputeUnit = dbStats.Database().ReadAttachmentComputeUnit
+	blipStats.WriteAttachmentComputeUnit = dbStats.Database().WriteAttachmentComputeUnit
+
 	blipStats.HandleRevBytes = dbStats.Database().DocWritesBytesBlip
 	blipStats.HandleRevProcessingTime = dbStats.CBLReplicationPush().WriteProcessingTime
 

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -61,6 +61,11 @@ type BlipSyncStats struct {
 	NumConnectAttempts               *base.SgwIntStat
 	NumReconnectsAborted             *base.SgwIntStat
 	NumHandlersPanicked              *base.SgwIntStat
+	ReadAttachmentComputeUnit        *base.SgwIntStat
+	WriteAttachmentComputeUnit       *base.SgwIntStat
+	DocReadComputeUnit               *base.SgwIntStat
+	DocWriteComputeUnit              *base.SgwIntStat
+	DocCheckComputeUnit              *base.SgwIntStat
 }
 
 func NewBlipSyncStats() *BlipSyncStats {
@@ -109,6 +114,11 @@ func NewBlipSyncStats() *BlipSyncStats {
 		NumConnectAttempts:               &base.SgwIntStat{},
 		NumReconnectsAborted:             &base.SgwIntStat{},
 		NumHandlersPanicked:              &base.SgwIntStat{},
+		ReadAttachmentComputeUnit:        &base.SgwIntStat{},
+		WriteAttachmentComputeUnit:       &base.SgwIntStat{},
+		DocReadComputeUnit:               &base.SgwIntStat{},
+		DocWriteComputeUnit:              &base.SgwIntStat{},
+		DocCheckComputeUnit:              &base.SgwIntStat{},
 	}
 }
 

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -61,11 +61,6 @@ type BlipSyncStats struct {
 	NumConnectAttempts               *base.SgwIntStat
 	NumReconnectsAborted             *base.SgwIntStat
 	NumHandlersPanicked              *base.SgwIntStat
-	ReadAttachmentComputeUnit        *base.SgwIntStat
-	WriteAttachmentComputeUnit       *base.SgwIntStat
-	DocReadComputeUnit               *base.SgwIntStat
-	DocWriteComputeUnit              *base.SgwIntStat
-	DocCheckComputeUnit              *base.SgwIntStat
 }
 
 func NewBlipSyncStats() *BlipSyncStats {
@@ -114,11 +109,6 @@ func NewBlipSyncStats() *BlipSyncStats {
 		NumConnectAttempts:               &base.SgwIntStat{},
 		NumReconnectsAborted:             &base.SgwIntStat{},
 		NumHandlersPanicked:              &base.SgwIntStat{},
-		ReadAttachmentComputeUnit:        &base.SgwIntStat{},
-		WriteAttachmentComputeUnit:       &base.SgwIntStat{},
-		DocReadComputeUnit:               &base.SgwIntStat{},
-		DocWriteComputeUnit:              &base.SgwIntStat{},
-		DocCheckComputeUnit:              &base.SgwIntStat{},
 	}
 }
 

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -708,7 +708,7 @@ func TestAttachmentComputeStat(t *testing.T) {
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, opts)
 	require.NoError(t, err)
 	defer btc.Close()
-	attachmentWriteCompute := btc.rt.GetDatabase().DbStats.DatabaseStats.WriteAttachmentComputeUnit.Value()
+	syncProcessCompute := btc.rt.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
 
 	err = btc.StartPull()
 	assert.NoError(t, err)
@@ -727,6 +727,6 @@ func TestAttachmentComputeStat(t *testing.T) {
 	require.JSONEq(t, bodyTextExpected, string(data))
 
 	// assert the attachment read compute stat is incremented
-	require.Greater(t, btc.rt.GetDatabase().DbStats.DatabaseStats.WriteAttachmentComputeUnit.Value(), attachmentWriteCompute)
+	require.Greater(t, btc.rt.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), syncProcessCompute)
 
 }

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -702,7 +702,6 @@ func TestAttachmentComputeStat(t *testing.T) {
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	rt.GetDatabase().Options.BlipStatsReportingInterval = 1
 
 	opts := &BlipTesterClientOpts{}
 	opts.SupportedBLIPProtocols = []string{db.BlipCBMobileReplicationV2}

--- a/rest/blip_stats_test.go
+++ b/rest/blip_stats_test.go
@@ -125,13 +125,10 @@ func TestBlipStatsISGRComputePush(t *testing.T) {
 	_, err := passiveRT.WaitForChanges(100, "/{{.keyspace}}/_changes", "", true)
 	require.NoError(t, err)
 
-	fmt.Println("active", activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value())
 	activeSyncStat := activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
 	passiveSyncStat := passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
-	fmt.Println("passive", passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value())
 	require.Greater(t, activeSyncStat, activeSyncStartStat)
 	require.Greater(t, passiveSyncStat, passiveSyncStartStat)
-	require.Greater(t, passiveSyncStat, activeSyncStat)
 
 }
 
@@ -161,8 +158,6 @@ func TestBlipStatsISGRComputePull(t *testing.T) {
 
 	_, err := activeRT.WaitForChanges(50, "/{{.keyspace}}/_changes", "", true)
 	require.NoError(t, err)
-	fmt.Println("active", activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value())
-	fmt.Println("passive", passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value())
 
 	require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), activeSyncStat)
 	require.Greater(t, passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), passiveSyncStat)
@@ -217,8 +212,6 @@ func TestBlipStatAttachmentComputeISGR(t *testing.T) {
 				// assert the stats increment/do not increment as expected
 				require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), syncComputeStartActive)
 				require.Greater(t, passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), syncComputeStartPassive)
-				fmt.Println(activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value())
-				fmt.Println(passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value())
 			} else {
 				bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
 				resp = passiveRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", bodyText)
@@ -238,8 +231,6 @@ func TestBlipStatAttachmentComputeISGR(t *testing.T) {
 				// assert the stats increment/do not increment as expected
 				require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), syncComputeStartActive)
 				require.Greater(t, passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), syncComputeStartPassive)
-				fmt.Println(activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value())
-				fmt.Println(passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value())
 			}
 
 		})

--- a/rest/blip_stats_test.go
+++ b/rest/blip_stats_test.go
@@ -111,8 +111,6 @@ func TestBlipStatsISGRComputePush(t *testing.T) {
 	activeRT, passiveRT, remoteURL, teardown := SetupSGRPeers(t)
 	defer teardown()
 	const repName = "replication1"
-	activeRT.GetDatabase().Options.BlipStatsReportingInterval = 1
-	passiveRT.GetDatabase().Options.BlipStatsReportingInterval = 1
 	var resp *TestResponse
 
 	docWriteCompute := activeRT.GetDatabase().DbStats.DatabaseStats.DocWriteComputeUnit.Value()
@@ -155,8 +153,6 @@ func TestBlipStatsISGRComputePull(t *testing.T) {
 	activeRT, passiveRT, remoteURL, teardown := SetupSGRPeers(t)
 	defer teardown()
 	const repName = "replication1"
-	activeRT.GetDatabase().Options.BlipStatsReportingInterval = 1
-	passiveRT.GetDatabase().Options.BlipStatsReportingInterval = 1
 	var resp *TestResponse
 
 	docWriteCompute := passiveRT.GetDatabase().DbStats.DatabaseStats.DocWriteComputeUnit.Value()
@@ -214,8 +210,6 @@ func TestBlipStatAttachmentComputeISGR(t *testing.T) {
 			activeRT, passiveRT, remoteURL, teardown := SetupSGRPeers(t)
 			defer teardown()
 			const repName = "replication1"
-			activeRT.GetDatabase().Options.BlipStatsReportingInterval = 1
-			passiveRT.GetDatabase().Options.BlipStatsReportingInterval = 1
 			var resp *TestResponse
 
 			if test.direction == "push" {
@@ -278,7 +272,6 @@ func TestBlipStatsChangesComputation(t *testing.T) {
 	bt, err := NewBlipTester(t)
 	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
-	bt.restTester.GetDatabase().Options.BlipStatsReportingInterval = 1
 
 	// test changes request increments the DocCheckComputeStat
 	changesRequest := bt.newRequest()
@@ -339,8 +332,6 @@ func TestComputeStatAfterContextTeardown(t *testing.T) {
 	activeRT, passiveRT, remoteURL, teardown := SetupSGRPeers(t)
 	defer teardown()
 	const repName = "replication1"
-	activeRT.GetDatabase().Options.BlipStatsReportingInterval = 1
-	passiveRT.GetDatabase().Options.BlipStatsReportingInterval = 1
 
 	resp := passiveRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"source": "activeRT"}`)
 	RequireStatus(t, resp, http.StatusCreated)

--- a/rest/blip_stats_test.go
+++ b/rest/blip_stats_test.go
@@ -13,10 +13,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -113,9 +111,8 @@ func TestBlipStatsISGRComputePush(t *testing.T) {
 	const repName = "replication1"
 	var resp *TestResponse
 
-	docWriteCompute := activeRT.GetDatabase().DbStats.DatabaseStats.DocWriteComputeUnit.Value()
-	docReadCompute := passiveRT.GetDatabase().DbStats.DatabaseStats.DocReadComputeUnit.Value()
-	docCheckPassive := passiveRT.GetDatabase().DbStats.DatabaseStats.DocCheckComputeUnit.Value()
+	activeSyncStartStat := activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
+	passiveSyncStartStat := passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
 
 	for i := 0; i < 100; i++ {
 		resp = activeRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+fmt.Sprint(i), `{"source": "activeRT"}`)
@@ -128,17 +125,13 @@ func TestBlipStatsISGRComputePush(t *testing.T) {
 	_, err := passiveRT.WaitForChanges(100, "/{{.keyspace}}/_changes", "", true)
 	require.NoError(t, err)
 
-	// assert active has written docs
-	require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.DocWriteComputeUnit.Value(), docWriteCompute)
-	// assert that active has niot read docs along replicatiuon
-	require.Equal(t, int64(0), activeRT.GetDatabase().DbStats.DatabaseStats.DocReadComputeUnit.Value())
-	// assert passtive has read docs along replication
-	require.Greater(t, passiveRT.GetDatabase().DbStats.DatabaseStats.DocReadComputeUnit.Value(), docReadCompute)
-	// assert passtive has not wrotten docs alongbg replication
-	require.Equal(t, int64(0), passiveRT.GetDatabase().DbStats.DatabaseStats.DocWriteComputeUnit.Value())
-
-	// for handling the set of changes sent by active
-	require.Greater(t, passiveRT.GetDatabase().DbStats.DatabaseStats.DocCheckComputeUnit.Value(), docCheckPassive)
+	fmt.Println("active", activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value())
+	activeSyncStat := activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
+	passiveSyncStat := passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
+	fmt.Println("passive", passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value())
+	require.Greater(t, activeSyncStat, activeSyncStartStat)
+	require.Greater(t, passiveSyncStat, passiveSyncStartStat)
+	require.Greater(t, passiveSyncStat, activeSyncStat)
 
 }
 
@@ -155,9 +148,8 @@ func TestBlipStatsISGRComputePull(t *testing.T) {
 	const repName = "replication1"
 	var resp *TestResponse
 
-	docWriteCompute := passiveRT.GetDatabase().DbStats.DatabaseStats.DocWriteComputeUnit.Value()
-	docReadCompute := activeRT.GetDatabase().DbStats.DatabaseStats.DocReadComputeUnit.Value()
-	docCheckActive := activeRT.GetDatabase().DbStats.DatabaseStats.DocCheckComputeUnit.Value()
+	activeSyncStat := activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
+	passiveSyncStat := passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
 
 	for i := 0; i < 50; i++ {
 		resp = passiveRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+fmt.Sprint(i), `{"source": "activeRT"}`)
@@ -169,17 +161,11 @@ func TestBlipStatsISGRComputePull(t *testing.T) {
 
 	_, err := activeRT.WaitForChanges(50, "/{{.keyspace}}/_changes", "", true)
 	require.NoError(t, err)
+	fmt.Println("active", activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value())
+	fmt.Println("passive", passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value())
 
-	// assert that passive peer wrote
-	require.Greater(t, passiveRT.GetDatabase().DbStats.DatabaseStats.DocWriteComputeUnit.Value(), docWriteCompute)
-	// assert passive peer doc read compute stat is still 0
-	require.Equal(t, int64(0), passiveRT.GetDatabase().DbStats.DatabaseStats.DocReadComputeUnit.Value())
-	// assert active peer doc read compute stat increased
-	require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.DocReadComputeUnit.Value(), docReadCompute)
-	// assert that active peer doc write compute stat is still 0
-	require.Equal(t, int64(0), activeRT.GetDatabase().DbStats.DatabaseStats.DocWriteComputeUnit.Value())
-	// assert active peer doc check compute stat incremented
-	require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.DocCheckComputeUnit.Value(), docCheckActive)
+	require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), activeSyncStat)
+	require.Greater(t, passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), passiveSyncStat)
 
 }
 
@@ -217,8 +203,8 @@ func TestBlipStatAttachmentComputeISGR(t *testing.T) {
 				resp = activeRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", bodyText)
 				RequireStatus(t, resp, http.StatusCreated)
 				// grab stats values before replication takes place
-				computeWriteAttachment := activeRT.GetDatabase().DbStats.DatabaseStats.WriteAttachmentComputeUnit.Value()
-				computeReadAttachment := activeRT.GetDatabase().DbStats.DatabaseStats.ReadAttachmentComputeUnit.Value()
+				syncComputeStartActive := activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
+				syncComputeStartPassive := passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
 
 				// create replication
 				activeRT.CreateReplication(repName, remoteURL, db.ActiveReplicatorTypePush, nil, true, db.ConflictResolverDefault)
@@ -229,17 +215,17 @@ func TestBlipStatAttachmentComputeISGR(t *testing.T) {
 				require.NoError(t, err)
 
 				// assert the stats increment/do not increment as expected
-				require.Equal(t, int64(0), activeRT.GetDatabase().DbStats.DatabaseStats.ReadAttachmentComputeUnit.Value())
-				require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.WriteAttachmentComputeUnit.Value(), computeWriteAttachment)
-				require.Greater(t, passiveRT.GetDatabase().DbStats.DatabaseStats.ReadAttachmentComputeUnit.Value(), computeReadAttachment)
-				require.Equal(t, int64(0), passiveRT.GetDatabase().DbStats.DatabaseStats.WriteAttachmentComputeUnit.Value())
+				require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), syncComputeStartActive)
+				require.Greater(t, passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), syncComputeStartPassive)
+				fmt.Println(activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value())
+				fmt.Println(passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value())
 			} else {
 				bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
 				resp = passiveRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", bodyText)
 				RequireStatus(t, resp, http.StatusCreated)
 				// grab stats values before replication takes place
-				computeWriteAttachment := activeRT.GetDatabase().DbStats.DatabaseStats.WriteAttachmentComputeUnit.Value()
-				computeReadAttachment := activeRT.GetDatabase().DbStats.DatabaseStats.ReadAttachmentComputeUnit.Value()
+				syncComputeStartActive := activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
+				syncComputeStartPassive := passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
 
 				// create replication
 				activeRT.CreateReplication(repName, remoteURL, db.ActiveReplicatorTypePull, nil, true, db.ConflictResolverDefault)
@@ -250,71 +236,14 @@ func TestBlipStatAttachmentComputeISGR(t *testing.T) {
 				require.NoError(t, err)
 
 				// assert the stats increment/do not increment as expected
-				require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.ReadAttachmentComputeUnit.Value(), computeReadAttachment)
-				require.Equal(t, int64(0), activeRT.GetDatabase().DbStats.DatabaseStats.WriteAttachmentComputeUnit.Value())
-				require.Equal(t, int64(0), passiveRT.GetDatabase().DbStats.DatabaseStats.ReadAttachmentComputeUnit.Value())
-				require.Greater(t, passiveRT.GetDatabase().DbStats.DatabaseStats.WriteAttachmentComputeUnit.Value(), computeWriteAttachment)
+				require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), syncComputeStartActive)
+				require.Greater(t, passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), syncComputeStartPassive)
+				fmt.Println(activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value())
+				fmt.Println(passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value())
 			}
 
 		})
 	}
-
-}
-
-// TestBlipStatsChangesComputation:
-//   - Create Blip tester
-//   - Send blip changes request
-//   - assert on DocCheckedCompute stat
-//   - send rev assert stat increased
-//   - send proposeChanges request and assert the DocCheckedCompute stat increased
-func TestBlipStatsChangesComputation(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync)
-	bt, err := NewBlipTester(t)
-	assert.NoError(t, err, "Error creating BlipTester")
-	defer bt.Close()
-
-	// test changes request increments the DocCheckComputeStat
-	changesRequest := bt.newRequest()
-	changesRequest.SetProfile("changes")
-	changesBody := `[["1", "foo", "1-abc", false]]`
-	changesRequest.SetBody([]byte(changesBody))
-	sent := bt.sender.Send(changesRequest)
-	assert.True(t, sent)
-	changesResponse := changesRequest.Response()
-	assert.Equal(t, changesRequest.SerialNumber(), changesResponse.SerialNumber())
-
-	require.Greater(t, bt.restTester.GetDatabase().DbStats.DatabaseStats.DocCheckComputeUnit.Value(), int64(0))
-	changesCompute := bt.restTester.GetDatabase().DbStats.DatabaseStats.DocCheckComputeUnit.Value()
-
-	// put a rev to increment the read compute stat
-	_, _, revResponse, err := bt.SendRev(
-		"foo",
-		"1-abc",
-		[]byte(`{"key": "val"}`),
-		blip.Properties{},
-	)
-	assert.NoError(t, err)
-
-	_, err = revResponse.Body()
-	assert.NoError(t, err, "Error unmarshalling response body")
-	require.Greater(t, bt.restTester.GetDatabase().DbStats.DatabaseStats.DocReadComputeUnit.Value(), int64(0))
-
-	// test proposeChanges increments the DocCheckCompute stat
-	proposeChangesRequest := bt.newRequest()
-	proposeChangesRequest.SetProfile("proposeChanges")
-	proposeChangesRequest.SetCompressed(true)
-
-	// define changes body
-	changesBody = `[["foo", "1-abc"],["foo2", "1-abc"]]`
-	proposeChangesRequest.SetBody([]byte(changesBody))
-	sent = bt.sender.Send(proposeChangesRequest)
-	assert.True(t, sent)
-	proposeChangesResponse := proposeChangesRequest.Response()
-	_, err = proposeChangesResponse.Body()
-	assert.NoError(t, err, "Error getting changes response body")
-
-	// assert the doc check compute stat has increased
-	require.Greater(t, bt.restTester.GetDatabase().DbStats.DatabaseStats.DocCheckComputeUnit.Value(), changesCompute)
 
 }
 
@@ -341,16 +270,15 @@ func TestComputeStatAfterContextTeardown(t *testing.T) {
 	_, err := activeRT.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
 	require.NoError(t, err)
 
+	// wait for replication teardown
 	activeRT.WaitForReplicationStatus(repName, db.ReplicationStateStopped)
 
-	docWriteCompute := passiveRT.GetDatabase().DbStats.DatabaseStats.DocWriteComputeUnit.Value()
-	docReadCompute := activeRT.GetDatabase().DbStats.DatabaseStats.DocReadComputeUnit.Value()
-	docCheckActive := activeRT.GetDatabase().DbStats.DatabaseStats.DocCheckComputeUnit.Value()
+	syncProcessComputeActive := activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
+	syncProcessComputePassive := passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
 
-	// assert that expected stats are greater than 0
-	require.Greater(t, docWriteCompute, int64(0))
-	require.Greater(t, docReadCompute, int64(0))
-	require.Greater(t, docCheckActive, int64(0))
+	// assert that sync compute stats are greater than 0
+	require.Greater(t, syncProcessComputeActive, int64(0))
+	require.Greater(t, syncProcessComputePassive, int64(0))
 
 	// add new doc and start replication again
 	resp = passiveRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc2", `{"source": "activeRT"}`)
@@ -360,51 +288,11 @@ func TestComputeStatAfterContextTeardown(t *testing.T) {
 
 	_, err = activeRT.WaitForChanges(2, "/{{.keyspace}}/_changes", "", true)
 	require.NoError(t, err)
+	// wait for replication teardown
 	activeRT.WaitForReplicationStatus(repName, db.ReplicationStateStopped)
 
-	// assert that the stats have increased from what they were before
-	require.Greater(t, passiveRT.GetDatabase().DbStats.DatabaseStats.DocWriteComputeUnit.Value(), docReadCompute)
-	require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.DocReadComputeUnit.Value(), docReadCompute)
-	require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.DocCheckComputeUnit.Value(), docCheckActive)
-
-}
-
-// TestPerReplicationComputationStats:
-//   - Add doc to remote node
-//   - Create continuous replication
-//   - Wait for work to be done over that replication
-//   - Create a new replication and scope it to a channel so doc won't get replicated
-//   - assert that the blip stats for that particular replication start from 0 again (shows isolation between blip contexts for compute units)
-func TestPerReplicationComputationStats(t *testing.T) {
-	base.RequireNumTestBuckets(t, 2)
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync)
-	activeRT, passiveRT, remoteURL, teardown := SetupSGRPeers(t)
-	defer teardown()
-	const repName = "replication1"
-	const repName2 = "replication2"
-
-	resp := passiveRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"source": "activeRT"}`)
-	RequireStatus(t, resp, http.StatusCreated)
-
-	activeRT.CreateReplication(repName, remoteURL, db.ActiveReplicatorTypePull, nil, true, db.ConflictResolverDefault)
-	activeRT.WaitForReplicationStatus(repName, db.ReplicationStateRunning)
-
-	// wait for replication to do some work so compute stats won't all be 0 for this particular replication
-	_, err := activeRT.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
-	require.NoError(t, err)
-
-	// Create new replication and assert that the stats for this replication are all 0 showing isolation between each replication in terms of compute stats
-	activeRT.CreateReplication(repName2, remoteURL, db.ActiveReplicatorTypePull, []string{"ABC"}, true, db.ConflictResolverDefault)
-	activeRT.WaitForReplicationStatus(repName, db.ReplicationStateRunning)
-	activeRT.WaitForActiveReplicatorInitialization(2)
-
-	// get the active replicator and assert blip stats are 0 for new replication
-	ar := activeRT.GetDatabase().SGReplicateMgr.GetActiveReplicator(repName2)
-	blipStats := ar.Pull.GetStats()
-	require.Equal(t, int64(0), blipStats.ReadAttachmentComputeUnit.Value())
-	require.Equal(t, int64(0), blipStats.WriteAttachmentComputeUnit.Value())
-	require.Equal(t, int64(0), blipStats.DocWriteComputeUnit.Value())
-	require.Equal(t, int64(0), blipStats.DocReadComputeUnit.Value())
-	require.Equal(t, int64(0), blipStats.DocCheckComputeUnit.Value())
+	// assert that the stats have increased from what they were before showing stats don't start from 0 again after replication teardown
+	require.Greater(t, passiveRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), syncProcessComputePassive)
+	require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), syncProcessComputeActive)
 
 }

--- a/rest/blip_stats_test.go
+++ b/rest/blip_stats_test.go
@@ -9,9 +9,14 @@
 package rest
 
 import (
+	"fmt"
+	"net/http"
 	"testing"
 
+	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -93,4 +98,285 @@ func TestBlipStatsFastReport(t *testing.T) {
 	sendRequest()
 	require.Less(t, int64(0), dbStats.ReplicationBytesReceived.Value())
 	require.Less(t, int64(0), dbStats.ReplicationBytesSent.Value())
+}
+
+// TestBlipStatsISGRComputePush:
+//   - Put docs on activeRT
+//   - Create push replication
+//   - Wait for docs to replicate
+//   - assert on stats after docs replicated
+func TestBlipStatsISGRComputePush(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeySync)
+	activeRT, passiveRT, remoteURL, teardown := SetupSGRPeers(t)
+	defer teardown()
+	const repName = "replication1"
+	activeRT.GetDatabase().Options.BlipStatsReportingInterval = 1
+	passiveRT.GetDatabase().Options.BlipStatsReportingInterval = 1
+	var resp *TestResponse
+
+	docWriteCompute := activeRT.GetDatabase().DbStats.DatabaseStats.DocWriteComputeUnit.Value()
+	docReadCompute := passiveRT.GetDatabase().DbStats.DatabaseStats.DocReadComputeUnit.Value()
+	docCheckPassive := passiveRT.GetDatabase().DbStats.DatabaseStats.DocCheckComputeUnit.Value()
+
+	for i := 0; i < 100; i++ {
+		resp = activeRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+fmt.Sprint(i), `{"source": "activeRT"}`)
+		RequireStatus(t, resp, http.StatusCreated)
+	}
+
+	activeRT.CreateReplication(repName, remoteURL, db.ActiveReplicatorTypePush, nil, true, db.ConflictResolverDefault)
+	activeRT.WaitForReplicationStatus(repName, db.ReplicationStateRunning)
+
+	_, err := passiveRT.WaitForChanges(100, "/{{.keyspace}}/_changes", "", true)
+	require.NoError(t, err)
+
+	// assert active has written docs
+	require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.DocWriteComputeUnit.Value(), docWriteCompute)
+	// assert that active has niot read docs along replicatiuon
+	require.Equal(t, int64(0), activeRT.GetDatabase().DbStats.DatabaseStats.DocReadComputeUnit.Value())
+	// assert passtive has read docs along replication
+	require.Greater(t, passiveRT.GetDatabase().DbStats.DatabaseStats.DocReadComputeUnit.Value(), docReadCompute)
+	// assert passtive has not wrotten docs alongbg replication
+	require.Equal(t, int64(0), passiveRT.GetDatabase().DbStats.DatabaseStats.DocWriteComputeUnit.Value())
+
+	// for handling the set of changes sent by active
+	require.Greater(t, passiveRT.GetDatabase().DbStats.DatabaseStats.DocCheckComputeUnit.Value(), docCheckPassive)
+
+}
+
+// TestBlipStatsISGRComputePull:
+//   - Put docs on passiveRT
+//   - Create pull replication
+//   - Wait for docs to replicate
+//   - assert on stats after docs replicated
+func TestBlipStatsISGRComputePull(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync)
+	activeRT, passiveRT, remoteURL, teardown := SetupSGRPeers(t)
+	defer teardown()
+	const repName = "replication1"
+	activeRT.GetDatabase().Options.BlipStatsReportingInterval = 1
+	passiveRT.GetDatabase().Options.BlipStatsReportingInterval = 1
+	var resp *TestResponse
+
+	docWriteCompute := passiveRT.GetDatabase().DbStats.DatabaseStats.DocWriteComputeUnit.Value()
+	docReadCompute := activeRT.GetDatabase().DbStats.DatabaseStats.DocReadComputeUnit.Value()
+	docCheckActive := activeRT.GetDatabase().DbStats.DatabaseStats.DocCheckComputeUnit.Value()
+
+	for i := 0; i < 50; i++ {
+		resp = passiveRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+fmt.Sprint(i), `{"source": "activeRT"}`)
+		RequireStatus(t, resp, http.StatusCreated)
+	}
+
+	activeRT.CreateReplication(repName, remoteURL, db.ActiveReplicatorTypePull, nil, true, db.ConflictResolverDefault)
+	activeRT.WaitForReplicationStatus(repName, db.ReplicationStateRunning)
+
+	_, err := activeRT.WaitForChanges(50, "/{{.keyspace}}/_changes", "", true)
+	require.NoError(t, err)
+
+	// assert that passive peer wrote
+	require.Greater(t, passiveRT.GetDatabase().DbStats.DatabaseStats.DocWriteComputeUnit.Value(), docWriteCompute)
+	// assert passive peer doc read compute stat is still 0
+	require.Equal(t, int64(0), passiveRT.GetDatabase().DbStats.DatabaseStats.DocReadComputeUnit.Value())
+	// assert active peer doc read compute stat increased
+	require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.DocReadComputeUnit.Value(), docReadCompute)
+	// assert that active peer doc write compute stat is still 0
+	require.Equal(t, int64(0), activeRT.GetDatabase().DbStats.DatabaseStats.DocWriteComputeUnit.Value())
+	// assert active peer doc check compute stat incremented
+	require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.DocCheckComputeUnit.Value(), docCheckActive)
+
+}
+
+// TestBlipStatAttachmentComputeISGR:
+//   - Two test cases (one with push replication and one with pull replication)
+//   - Creat doc with attachment
+//   - Create replication
+//   - Wait for doc to be replicated
+//   - Assert on expected value for stats
+func TestBlipStatAttachmentComputeISGR(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync)
+	testCases := []struct {
+		name      string
+		direction string
+	}{
+		{
+			name:      "pushISGR",
+			direction: "push",
+		},
+		{
+			name:      "pullISGR",
+			direction: "pull",
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			activeRT, passiveRT, remoteURL, teardown := SetupSGRPeers(t)
+			defer teardown()
+			const repName = "replication1"
+			activeRT.GetDatabase().Options.BlipStatsReportingInterval = 1
+			passiveRT.GetDatabase().Options.BlipStatsReportingInterval = 1
+			var resp *TestResponse
+
+			if test.direction == "push" {
+				bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
+				resp = activeRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", bodyText)
+				RequireStatus(t, resp, http.StatusCreated)
+				// grab stats values before replication takes place
+				computeWriteAttachment := activeRT.GetDatabase().DbStats.DatabaseStats.WriteAttachmentComputeUnit.Value()
+				computeReadAttachment := activeRT.GetDatabase().DbStats.DatabaseStats.ReadAttachmentComputeUnit.Value()
+
+				// create replication
+				activeRT.CreateReplication(repName, remoteURL, db.ActiveReplicatorTypePush, nil, true, db.ConflictResolverDefault)
+				activeRT.WaitForReplicationStatus(repName, db.ReplicationStateRunning)
+
+				// wait for changes
+				_, err := passiveRT.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+				require.NoError(t, err)
+
+				// assert the stats increment/do not increment as expected
+				require.Equal(t, int64(0), activeRT.GetDatabase().DbStats.DatabaseStats.ReadAttachmentComputeUnit.Value())
+				require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.WriteAttachmentComputeUnit.Value(), computeWriteAttachment)
+				require.Greater(t, passiveRT.GetDatabase().DbStats.DatabaseStats.ReadAttachmentComputeUnit.Value(), computeReadAttachment)
+				require.Equal(t, int64(0), passiveRT.GetDatabase().DbStats.DatabaseStats.WriteAttachmentComputeUnit.Value())
+			} else {
+				bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
+				resp = passiveRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", bodyText)
+				RequireStatus(t, resp, http.StatusCreated)
+				// grab stats values before replication takes place
+				computeWriteAttachment := activeRT.GetDatabase().DbStats.DatabaseStats.WriteAttachmentComputeUnit.Value()
+				computeReadAttachment := activeRT.GetDatabase().DbStats.DatabaseStats.ReadAttachmentComputeUnit.Value()
+
+				// create replication
+				activeRT.CreateReplication(repName, remoteURL, db.ActiveReplicatorTypePull, nil, true, db.ConflictResolverDefault)
+				activeRT.WaitForReplicationStatus(repName, db.ReplicationStateRunning)
+
+				// wait for changes
+				_, err := activeRT.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+				require.NoError(t, err)
+
+				// assert the stats increment/do not increment as expected
+				require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.ReadAttachmentComputeUnit.Value(), computeReadAttachment)
+				require.Equal(t, int64(0), activeRT.GetDatabase().DbStats.DatabaseStats.WriteAttachmentComputeUnit.Value())
+				require.Equal(t, int64(0), passiveRT.GetDatabase().DbStats.DatabaseStats.ReadAttachmentComputeUnit.Value())
+				require.Greater(t, passiveRT.GetDatabase().DbStats.DatabaseStats.WriteAttachmentComputeUnit.Value(), computeWriteAttachment)
+			}
+
+		})
+	}
+
+}
+
+// TestBlipStatsChangesComputation:
+//   - Create Blip tester
+//   - Send blip changes request
+//   - assert on DocCheckedCompute stat
+//   - send rev assert stat increased
+//   - send proposeChanges request and assert the DocCheckedCompute stat increased
+func TestBlipStatsChangesComputation(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync)
+	bt, err := NewBlipTester(t)
+	assert.NoError(t, err, "Error creating BlipTester")
+	defer bt.Close()
+	bt.restTester.GetDatabase().Options.BlipStatsReportingInterval = 1
+
+	// test changes request increments the DocCheckComputeStat
+	changesRequest := bt.newRequest()
+	changesRequest.SetProfile("changes")
+	changesBody := `[["1", "foo", "1-abc", false]]`
+	changesRequest.SetBody([]byte(changesBody))
+	sent := bt.sender.Send(changesRequest)
+	assert.True(t, sent)
+	changesResponse := changesRequest.Response()
+	assert.Equal(t, changesRequest.SerialNumber(), changesResponse.SerialNumber())
+
+	require.Greater(t, bt.restTester.GetDatabase().DbStats.DatabaseStats.DocCheckComputeUnit.Value(), int64(0))
+	changesCompute := bt.restTester.GetDatabase().DbStats.DatabaseStats.DocCheckComputeUnit.Value()
+
+	// put a rev to increment the read compute stat
+	_, _, revResponse, err := bt.SendRev(
+		"foo",
+		"1-abc",
+		[]byte(`{"key": "val"}`),
+		blip.Properties{},
+	)
+	assert.NoError(t, err)
+
+	_, err = revResponse.Body()
+	assert.NoError(t, err, "Error unmarshalling response body")
+	require.Greater(t, bt.restTester.GetDatabase().DbStats.DatabaseStats.DocReadComputeUnit.Value(), int64(0))
+
+	// test proposeChanges increments the DocCheckCompute stat
+	proposeChangesRequest := bt.newRequest()
+	proposeChangesRequest.SetProfile("proposeChanges")
+	proposeChangesRequest.SetCompressed(true)
+
+	// define changes body
+	changesBody = `[["foo", "1-abc"],["foo2", "1-abc"]]`
+	proposeChangesRequest.SetBody([]byte(changesBody))
+	sent = bt.sender.Send(proposeChangesRequest)
+	assert.True(t, sent)
+	proposeChangesResponse := proposeChangesRequest.Response()
+	_, err = proposeChangesResponse.Body()
+	assert.NoError(t, err, "Error getting changes response body")
+
+	// assert the doc check compute stat has increased
+	require.Greater(t, bt.restTester.GetDatabase().DbStats.DatabaseStats.DocCheckComputeUnit.Value(), changesCompute)
+
+}
+
+// TestComputeStatAfterContextTeardown:
+//   - Add doc to passiveRT
+//   - Create replication oneshot to pull this doc
+//   - Assert that the stats are incremented
+//   - Add another doc and start the replication again
+//   - Assert the starts are incremented from their last value
+//
+// Objective of test is to test stats resume from correct value after a blipContext cancellation
+func TestComputeStatAfterContextTeardown(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync)
+	activeRT, passiveRT, remoteURL, teardown := SetupSGRPeers(t)
+	defer teardown()
+	const repName = "replication1"
+	activeRT.GetDatabase().Options.BlipStatsReportingInterval = 1
+	passiveRT.GetDatabase().Options.BlipStatsReportingInterval = 1
+
+	resp := passiveRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"source": "activeRT"}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	activeRT.CreateReplication(repName, remoteURL, db.ActiveReplicatorTypePull, nil, false, db.ConflictResolverDefault)
+	activeRT.WaitForReplicationStatus(repName, db.ReplicationStateRunning)
+
+	_, err := activeRT.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+	require.NoError(t, err)
+
+	activeRT.WaitForReplicationStatus(repName, db.ReplicationStateStopped)
+
+	docWriteCompute := passiveRT.GetDatabase().DbStats.DatabaseStats.DocWriteComputeUnit.Value()
+	docReadCompute := activeRT.GetDatabase().DbStats.DatabaseStats.DocReadComputeUnit.Value()
+	docCheckActive := activeRT.GetDatabase().DbStats.DatabaseStats.DocCheckComputeUnit.Value()
+
+	// assert that expected stats are greater than 0
+	require.Greater(t, docWriteCompute, int64(0))
+	require.Greater(t, docReadCompute, int64(0))
+	require.Greater(t, docCheckActive, int64(0))
+
+	// add new doc and start replication again
+	resp = passiveRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc2", `{"source": "activeRT"}`)
+	RequireStatus(t, resp, http.StatusCreated)
+	resp = activeRT.SendAdminRequest(http.MethodPut, "/{{.db}}/_replicationStatus/"+repName+"?action=start", "")
+	RequireStatus(t, resp, http.StatusOK)
+
+	activeRT.WaitForReplicationStatus(repName, db.ReplicationStateRunning)
+
+	_, err = activeRT.WaitForChanges(2, "/{{.keyspace}}/_changes", "", true)
+	require.NoError(t, err)
+	activeRT.WaitForReplicationStatus(repName, db.ReplicationStateStopped)
+
+	// assert that the stats have increased from what they were before
+	require.Greater(t, passiveRT.GetDatabase().DbStats.DatabaseStats.DocWriteComputeUnit.Value(), docReadCompute)
+	require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.DocReadComputeUnit.Value(), docReadCompute)
+	require.Greater(t, activeRT.GetDatabase().DbStats.DatabaseStats.DocCheckComputeUnit.Value(), docCheckActive)
+
 }

--- a/rest/blip_stats_test.go
+++ b/rest/blip_stats_test.go
@@ -346,7 +346,6 @@ func TestComputeStatAfterContextTeardown(t *testing.T) {
 	RequireStatus(t, resp, http.StatusCreated)
 
 	activeRT.CreateReplication(repName, remoteURL, db.ActiveReplicatorTypePull, nil, false, db.ConflictResolverDefault)
-	activeRT.WaitForReplicationStatus(repName, db.ReplicationStateRunning)
 
 	_, err := activeRT.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
 	require.NoError(t, err)
@@ -367,8 +366,6 @@ func TestComputeStatAfterContextTeardown(t *testing.T) {
 	RequireStatus(t, resp, http.StatusCreated)
 	resp = activeRT.SendAdminRequest(http.MethodPut, "/{{.db}}/_replicationStatus/"+repName+"?action=start", "")
 	RequireStatus(t, resp, http.StatusOK)
-
-	activeRT.WaitForReplicationStatus(repName, db.ReplicationStateRunning)
 
 	_, err = activeRT.WaitForChanges(2, "/{{.keyspace}}/_changes", "", true)
 	require.NoError(t, err)


### PR DESCRIPTION
CBG-2933

Adds compute stat for sync compute. 
- Addded calculation to register function on the blip handler for all incoming blip messages. 
- Added calculation to where we cann sendmessage on blip to handle outgoing blip messages. 
- Test coverage of both ISGR and CBL replications 
- Noticed a mistake in import process compute stat, it had the shared bucket import key on it and it hsould be the databse key, so added that change.
- Calculation is done in helper method on the blipsynccontext object 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1934/
