### PR TITLE
Add const to allow dev-time disabling of gocb log level remapping

### DIFF
--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -57,8 +57,10 @@ func (GoCBLogger) Log(level gocb.LogLevel, offset int, format string, v ...inter
 		logTo(context.TODO(), LevelInfo, KeyGoCB, format, v...)
 	case gocb.LogDebug:
 		logTo(context.TODO(), LevelDebug, KeyGoCB, format, v...)
-	case gocb.LogTrace, gocb.LogSched:
+	case gocb.LogTrace:
 		logTo(context.TODO(), LevelTrace, KeyGoCB, format, v...)
+	case gocb.LogSched:
+		logTo(context.TODO(), LevelTrace, KeyGoCB, "<SCHED>: "+format, v...)
 	}
 	return nil
 }
@@ -85,6 +87,7 @@ var _ gocb.Logger = GoCBLoggerRemapped{}
 //	Info   -> SG Debug
 //	Debug  -> SG Trace
 //	Trace  -> SG Trace
+//	Sched  -> SG Trace
 //	Others -> no-op
 func (GoCBLoggerRemapped) Log(level gocb.LogLevel, offset int, format string, v ...interface{}) error {
 	switch level {


### PR DESCRIPTION
Allows easier dev-time evaluation of what GoCB logs look like if we don't remap the log levels.

Initial findings:
- Info level seems OK to keep as info, without dropping to debug, with the exception of dumping structs for "Creating new agent".
- Debug is very noisy with vbucket and cluster information every second per agent/CCCPOLL but that could possibly be moved to trace inside GoCB, allowing us more info at debug?
