### PR TITLE
CBG-3128: Prevent unnecessary user updates when using OIDC claims to grant channel/roles

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -916,14 +916,12 @@ func (auth *Authenticator) authenticateJWTIdentity(identity *Identity, provider 
 	}
 
 	if user != nil {
-		now := time.Now()
 		updates = PrincipalConfig{
-			Name:           base.StringPtr(user.Name()),
-			Email:          &identity.Email,
-			JWTIssuer:      &provider.Issuer,
-			JWTRoles:       jwtRoles,
-			JWTChannels:    jwtChannels,
-			JWTLastUpdated: &now,
+			Name:        base.StringPtr(user.Name()),
+			Email:       &identity.Email,
+			JWTIssuer:   &provider.Issuer,
+			JWTRoles:    jwtRoles,
+			JWTChannels: jwtChannels,
 		}
 	}
 

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -1241,7 +1241,7 @@ func TestJWTRolesChannels(t *testing.T) {
 				require.NotNil(t, user, "nil user")
 				user.SetJWTChannels(ch.AtSequence(updates.JWTChannels, user.Sequence()), user.Sequence())
 				user.SetJWTRoles(ch.AtSequence(updates.JWTRoles, user.Sequence()), user.Sequence())
-				user.SetJWTLastUpdated(*updates.JWTLastUpdated)
+				user.SetJWTLastUpdated(time.Now())
 
 				require.NoError(t, auth.rebuildRoles(user))
 				_, rebuildErr := auth.rebuildChannels(user)

--- a/base/util.go
+++ b/base/util.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"reflect"
 	"regexp"
 	"runtime"
 	"runtime/debug"
@@ -1802,9 +1803,13 @@ func safeCutAfter(s, sep string) (value, remainder string) {
 func AllOrNoneNil(vals ...interface{}) bool {
 	nonNil := 0
 	for _, val := range vals {
-		if val != nil {
-			nonNil++
+		// slow path reflect for typed nils
+		// see: https://codefibershq.com/blog/golang-why-nil-is-not-always-nil
+		if val == nil || reflect.ValueOf(val).IsNil() {
+			continue
 		}
+		nonNil++
+
 	}
 	return nonNil == 0 || nonNil == len(vals)
 }

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -1664,3 +1664,42 @@ func TestReplaceLast(t *testing.T) {
 		})
 	}
 }
+
+func TestAllOrNoneNil(t *testing.T) {
+	tests := []struct {
+		name string
+		args []interface{}
+		want bool
+	}{
+		{
+			name: "untyped nils",
+			args: []interface{}{nil, nil, nil},
+			want: true,
+		},
+		{
+			name: "typed nils",
+			args: []interface{}{(*int64)(nil), (*float64)(nil), (*string)(nil), (*time.Time)(nil)},
+			want: true,
+		},
+		{
+			name: "one non-nil",
+			args: []interface{}{nil, StringPtr("foo"), nil},
+			want: false,
+		},
+		{
+			name: "one typed nil",
+			args: []interface{}{Uint64Ptr(1234), StringPtr("foo"), (*time.Time)(nil)},
+			want: false,
+		},
+		{
+			name: "all non-nil",
+			args: []interface{}{Uint64Ptr(1234), StringPtr("foo"), StdlibDurationPtr(time.Second)},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, AllOrNoneNil(tt.args...), "AllOrNoneNil(%v)", tt.args...)
+		})
+	}
+}

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -871,3 +871,15 @@ func LongRunningTest(t *testing.T) {
 		}
 	})
 }
+
+func AssertTimeGreaterThan(t *testing.T, e1, e2 time.Time, msgAndArgs ...interface{}) bool {
+	return AssertTimestampGreaterThan(t, e1.UnixNano(), e2.UnixNano(), msgAndArgs...)
+}
+
+func AssertTimestampGreaterThan(t *testing.T, e1, e2 int64, msgAndArgs ...interface{}) bool {
+	// time.Nanoseconds has poor precision on Windows - equal is good enough there...
+	if runtime.GOOS == "windows" {
+		return assert.GreaterOrEqual(t, e1, e2, msgAndArgs...)
+	}
+	return assert.Greater(t, e1, e2, msgAndArgs...)
+}

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -12,7 +12,6 @@ package db
 
 import (
 	"fmt"
-	"runtime"
 	"strconv"
 	"testing"
 
@@ -70,12 +69,7 @@ func TestQueryChannelsStatsView(t *testing.T) {
 	channelQueryErrorCountAfter := db.DbStats.Query(queryExpvar).QueryErrorCount.Value()
 
 	assert.Equal(t, channelQueryCountBefore+1, channelQueryCountAfter)
-	// time.Nanoseconds has poor precision on Windows
-	if runtime.GOOS == "windows" {
-		assert.GreaterOrEqual(t, channelQueryTimeAfter, channelQueryTimeBefore, "Channel query time stat didn't change")
-	} else {
-		assert.Greater(t, channelQueryTimeAfter, channelQueryTimeBefore, "Channel query time stat didn't change")
-	}
+	base.AssertTimestampGreaterThan(t, channelQueryTimeAfter, channelQueryTimeBefore, "Channel query time stat didn't change")
 	assert.Equal(t, channelQueryErrorCountBefore, channelQueryErrorCountAfter)
 
 }
@@ -125,12 +119,7 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 	channelQueryErrorCountAfter := db.DbStats.Query(QueryTypeChannels).QueryErrorCount.Value()
 
 	assert.Equal(t, channelQueryCountBefore+1, channelQueryCountAfter)
-	// time.Nanoseconds has poor precision on Windows
-	if runtime.GOOS == "windows" {
-		assert.GreaterOrEqual(t, channelQueryTimeAfter, channelQueryTimeBefore, "Channel query time stat didn't change")
-	} else {
-		assert.Greater(t, channelQueryTimeAfter, channelQueryTimeBefore, "Channel query time stat didn't change")
-	}
+	base.AssertTimestampGreaterThan(t, channelQueryTimeAfter, channelQueryTimeBefore, "Channel query time stat didn't change")
 	assert.Equal(t, channelQueryErrorCountBefore, channelQueryErrorCountAfter)
 
 }

--- a/db/users.go
+++ b/db/users.go
@@ -44,7 +44,7 @@ func (db *DatabaseContext) DeleteRole(ctx context.Context, name string, purge bo
 // UpdatePrincipal updates or creates a principal from a PrincipalConfig structure.
 func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.PrincipalConfig, isUser bool, allowReplace bool) (replaced bool, err error) {
 	// Sanity checking
-	if !base.AllOrNoneNil(updates.JWTIssuer, updates.JWTRoles, updates.JWTChannels, updates.JWTLastUpdated) {
+	if !base.AllOrNoneNil(updates.JWTIssuer, updates.JWTRoles, updates.JWTChannels) {
 		return false, fmt.Errorf("must either specify all OIDC properties or none")
 	}
 

--- a/db/users.go
+++ b/db/users.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
@@ -172,10 +173,6 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 			if updates.JWTChannels != nil && !updatedJWTChannels.Equals(updates.JWTChannels) {
 				changed = true
 			}
-
-			if updates.JWTLastUpdated != nil && !user.JWTLastUpdated().Equal(*updates.JWTLastUpdated) {
-				changed = true
-			}
 		}
 
 		// And finally save the Principal if anything has changed:
@@ -211,9 +208,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 			if updates.JWTChannels != nil && updatedJWTChannels.UpdateAtSequence(updates.JWTChannels, nextSeq) {
 				user.SetJWTChannels(updatedJWTChannels, nextSeq)
 			}
-			if updates.JWTLastUpdated != nil {
-				user.SetJWTLastUpdated(*updates.JWTLastUpdated)
-			}
+			user.SetJWTLastUpdated(time.Now())
 		}
 		err = authenticator.Save(princ)
 		// On cas error, retry.  Otherwise break out of loop

--- a/db/users.go
+++ b/db/users.go
@@ -202,13 +202,18 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 			if updates.ExplicitRoleNames != nil && updatedExplicitRoles.UpdateAtSequence(updates.ExplicitRoleNames, nextSeq) {
 				user.SetExplicitRoles(updatedExplicitRoles, nextSeq)
 			}
+			var hasJWTUpdates bool
 			if updates.JWTRoles != nil && updatedJWTRoles.UpdateAtSequence(updates.JWTRoles, nextSeq) {
 				user.SetJWTRoles(updatedJWTRoles, nextSeq)
+				hasJWTUpdates = true
 			}
 			if updates.JWTChannels != nil && updatedJWTChannels.UpdateAtSequence(updates.JWTChannels, nextSeq) {
 				user.SetJWTChannels(updatedJWTChannels, nextSeq)
+				hasJWTUpdates = true
 			}
-			user.SetJWTLastUpdated(time.Now())
+			if hasJWTUpdates {
+				user.SetJWTLastUpdated(time.Now())
+			}
 		}
 		err = authenticator.Save(princ)
 		// On cas error, retry.  Otherwise break out of loop

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
@@ -1122,6 +1123,96 @@ func TestOpenIDConnectImplicitFlowInitWithKeyspace(t *testing.T) {
 	// try directly using bearer token in a keyspace request
 	resp := restTester.SendRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc1", `{"foo":"bar"}`, map[string]string{"Authorization": BearerToken + " " + token})
 	RequireStatus(t, resp, http.StatusCreated)
+}
+
+// TestOpenIDConnectImplicitFlowReuseToken ensures that requests that use the same token containing channel grants don't end up recomputing or updating the user for each use.
+func TestOpenIDConnectImplicitFlowReuseToken(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
+
+	testProviders := auth.OIDCProviderMap{
+		"foo": mockProviderWith("foo", mockProviderUserPrefix{"foo"}, mockProviderChannelsClaim{"channels"}),
+	}
+	defaultProvider := "foo"
+
+	mockAuthServer, err := newMockAuthServer()
+	require.NoError(t, err, "Error creating mock oauth2 server")
+	mockAuthServer.Start()
+	defer mockAuthServer.Shutdown()
+	mockAuthServer.options.issuer = mockAuthServer.URL + "/" + defaultProvider
+	refreshProviderConfig(testProviders, mockAuthServer.URL)
+
+	opts := auth.OIDCOptions{Providers: testProviders, DefaultProvider: &defaultProvider}
+	restTesterConfig := RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction, DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{OIDCConfig: &opts}}}
+
+	// JWT claim based grants do not support named collections
+	restTester := NewRestTesterDefaultCollection(t, &restTesterConfig)
+	require.NoError(t, restTester.SetAdminParty(false))
+	defer restTester.Close()
+
+	createUser(t, restTester, "foo_noah")
+
+	token, err := mockAuthServer.makeToken(claimsAuthenticWithExtraClaims(map[string]interface{}{"channels": []string{"foo"}}))
+	require.NoError(t, err, "Error obtaining signed token from OpenID Connect provider")
+	require.NotEmpty(t, token, "Empty token retrieved from OpenID Connect provider")
+
+	// try directly using bearer token in a keyspace request
+	resp := restTester.SendRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc1", `{"channels":"foo"}`, map[string]string{"Authorization": BearerToken + " " + token})
+	RequireStatus(t, resp, http.StatusCreated)
+	docSeq := restTester.GetDocumentSequence("doc1")
+
+	require.NoError(t, restTester.WaitForPendingChanges())
+
+	u, err := restTester.GetDatabase().Authenticator(base.TestCtx(t)).GetUser("foo_noah")
+	require.NoError(t, err)
+	firstJWTLastUpdated := u.JWTLastUpdated()
+
+	lastSeq, err := restTester.GetDatabase().LastSequence()
+	assert.NoError(t, err)
+
+	// Observing an updated user inside the changes request isn't deterministic, as it depends on the timing of the DCP feed for the principal update made during the changes request...
+	// If we send some of these, we can at least compare JWTLastUpdated timestamps to ensure it hasn't changed.
+	const numChanges = 10
+	var observedUserUpdateCount int64
+	for i := 0; i < numChanges; i++ {
+		resp = restTester.SendRequestWithHeaders(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", docSeq), ``, map[string]string{"Authorization": BearerToken + " " + token})
+		RequireStatus(t, resp, http.StatusOK)
+		var changesResp ChangesResults
+		require.NoError(t, json.Unmarshal(resp.BodyBytes(), &changesResp))
+		if !assert.Lenf(t, changesResp.Results, 0, "Expected no changes, got %d: %v", len(changesResp.Results), changesResp) {
+			observedUserUpdateCount++
+		}
+	}
+	assert.Equalf(t, int64(0), observedUserUpdateCount, "%d of %d changes observed user update (expected 0)", observedUserUpdateCount, numChanges)
+
+	// since we made no changes to channels, we shouldn't expect the user to actually be updated with a new JWT timestamp.
+	u, err = restTester.GetDatabase().Authenticator(base.TestCtx(t)).GetUser("foo_noah")
+	require.NoError(t, err)
+	finalJWTLastUpdated := u.JWTLastUpdated()
+	assert.Equal(t, firstJWTLastUpdated, finalJWTLastUpdated)
+
+	finalLastSeq, err := restTester.GetDatabase().LastSequence()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(lastSeq), int64(finalLastSeq))
+
+	// add new channel - expect user to be updated after using this new token
+	token, err = mockAuthServer.makeToken(claimsAuthenticWithExtraClaims(map[string]interface{}{"channels": []string{"foo", "bar"}}))
+	require.NoError(t, err, "Error obtaining signed token from OpenID Connect provider")
+	require.NotEmpty(t, token, "Empty token retrieved from OpenID Connect provider")
+
+	resp = restTester.SendRequestWithHeaders(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", docSeq), ``, map[string]string{"Authorization": BearerToken + " " + token})
+	RequireStatus(t, resp, http.StatusOK)
+	var changesResp ChangesResults
+	require.NoError(t, json.Unmarshal(resp.BodyBytes(), &changesResp))
+	assert.Lenf(t, changesResp.Results, 1, "Expected user update on changes feed")
+
+	u, err = restTester.GetDatabase().Authenticator(base.TestCtx(t)).GetUser("foo_noah")
+	require.NoError(t, err)
+	postUpdateJWTLastUpdated := u.JWTLastUpdated()
+	base.AssertTimeGreaterThan(t, postUpdateJWTLastUpdated, finalJWTLastUpdated)
+
+	postUpdateLastSeq, err := restTester.GetDatabase().LastSequence()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(finalLastSeq+1), int64(postUpdateLastSeq))
 }
 
 // checkGoodAuthResponse asserts expected session response values against the given response.


### PR DESCRIPTION
CBG-3128

- Add `TestOpenIDConnectImplicitFlowReuseToken` to reproduce identical OIDC claims causing user updates due to JWTLastUpdated changing prematurely.
- Only set `JWTLastUpdated` when actually updating a user as the result of access changes.
- Test util: Add `AssertTimestampGreaterThan` / `AssertTimeGreaterThan` to centralise Windows time resolution hack.
- Fix `AllOrNoneNil` handling for typed nils (and cover with unit test)

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1912/
