### PR TITLE
CBG-3127 call unsub changes in the unit test

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -155,19 +155,24 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 	assert.NoError(t, timeoutErr, "Timed out waiting")
 }
 
-// Start subChanges w/ continuous=true, batchsize=20
+// Start subChanges w/ continuous=true, batchsize=10
 // Make several updates
 // Wait until we get the expected updates
 func TestContinuousChangesSubscription(t *testing.T) {
 
-	base.LongRunningTest(t)
-
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)
 
 	bt, err := NewBlipTester(t)
-	assert.NoError(t, err, "Error creating BlipTester")
-	defer bt.Close()
-
+	require.NoError(t, err, "Error creating BlipTester")
+	defer func() {
+		unsubChangesRequest := bt.newRequest()
+		blip.NewRequest()
+		unsubChangesRequest.SetProfile(db.MessageUnsubChanges)
+		assert.True(t, bt.sender.Send(unsubChangesRequest))
+		unsubChangesResponse := unsubChangesRequest.Response()
+		assert.Equal(t, "", unsubChangesResponse.Properties[db.BlipErrorCode])
+		bt.Close()
+	}()
 	// Counter/Waitgroup to help ensure that all callbacks on continuous changes handler are received
 	receivedChangesWg := sync.WaitGroup{}
 
@@ -180,7 +185,6 @@ func TestContinuousChangesSubscription(t *testing.T) {
 
 		body, err := request.Body()
 		require.NoError(t, err)
-		log.Printf("got change with body %s, count %d", body, changeCount)
 		if string(body) != "null" {
 
 			atomic.AddInt32(&numbatchesReceived, 1)
@@ -218,9 +222,6 @@ func TestContinuousChangesSubscription(t *testing.T) {
 
 		if !request.NoReply() {
 			// Send an empty response to avoid the Sync: Invalid response to 'changes' message
-			// TODO: Sleeping here to avoid race in CBG-462, which appears to be occurring when there's very low latency
-			// between the sendBatchOfChanges request and the response
-			time.Sleep(10 * time.Millisecond)
 			response := request.Response()
 			emptyResponseVal := []interface{}{}
 			emptyResponseValBytes, err := base.JSONMarshal(emptyResponseVal)
@@ -258,16 +259,13 @@ func TestContinuousChangesSubscription(t *testing.T) {
 	}
 
 	// Wait until all expected changes are received by change handler
-	// receivedChangesWg.Wait()
-	timeoutErr := WaitWithTimeout(&receivedChangesWg, time.Second*30)
-	assert.NoError(t, timeoutErr, "Timed out waiting for all changes.")
+	require.NoError(t, WaitWithTimeout(&receivedChangesWg, time.Second*30))
 
 	// Since batch size was set to 10, and 15 docs were added, expect at _least_ 2 batches
 	numBatchesReceivedSnapshot := atomic.LoadInt32(&numbatchesReceived)
 	assert.True(t, numBatchesReceivedSnapshot >= 2)
 
 	assert.False(t, nonIntegerSequenceReceived, "Unexpected non-integer sequence seen.")
-
 }
 
 // Make several updates


### PR DESCRIPTION
The test panics in walrus because the continuous changes feed is still running when the database is closed. In practice, it'd call `ReloadUser` and then the datastore would be closed and SG would log a warning and be done. However, walrus panics if you try to write to a closed bucket.

- Removed some verbose debugging to try to reduce our test log bloat.
- Remove sleep after running 100k with/without -race.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1914/
