### PR TITLE
Remove close notifier, deprecated since go 1.7 

### DIFF
--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -402,14 +402,6 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 			}
 		}
 
-		var closeNotify <-chan bool
-		cn, ok := h.response.(http.CloseNotifier)
-		if ok {
-			closeNotify = cn.CloseNotify()
-		} else {
-			base.InfofCtx(h.ctx(), base.KeyChanges, "simple changes cannot get Close Notifier from ResponseWriter")
-		}
-
 		encoder := base.JSONEncoderCanonical(h.response)
 	loop:
 		for {
@@ -439,7 +431,7 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 				message = "OK (timeout)"
 				forceClose = true
 				break loop
-			case <-closeNotify:
+			case <-h.rq.Context().Done():
 				base.InfofCtx(h.ctx(), base.KeyChanges, "Connection lost from client")
 				forceClose = true
 				break loop

--- a/rest/encoded_response_writer.go
+++ b/rest/encoded_response_writer.go
@@ -121,15 +121,6 @@ func (w *EncodedResponseWriter) Close() {
 	}
 }
 
-func (w *EncodedResponseWriter) CloseNotify() <-chan bool {
-	var closeNotify <-chan bool
-	cn, ok := w.ResponseWriter.(http.CloseNotifier)
-	if ok {
-		closeNotify = cn.CloseNotify()
-	}
-	return closeNotify
-}
-
 //////// GZIP WRITER CACHE:
 
 var zipperCache sync.Pool


### PR DESCRIPTION
Since context package was introduced in go, this hasn't been necessary. Removing this means that we can implement new ResponseWriter without implementing this legacy code, see CBG-2929.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`