### PR TITLE
Make test pass with views

### DIFF
--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8042,6 +8042,8 @@ func TestGroupIDReplications(t *testing.T) {
 			BucketConfig: rest.BucketConfig{
 				Bucket: base.StringPtr(activeBucket.GetName()),
 			},
+			EnableXattrs: base.BoolPtr(base.TestUseXattrs()),
+			UseViews:     base.BoolPtr(base.TestsDisableGSI()),
 		}
 		if rt.GetDatabase().OnlyDefaultCollection() {
 			dbConfig.Sync = base.StringPtr(channels.DocChannelsSyncFunction)


### PR DESCRIPTION
This test would fail without GSI, now fixed.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1920/
