### PR TITLE
CBG-3110: Handle ErrImportCancelled case for OnDemandImportForGet

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -77,6 +77,7 @@ func (c *DatabaseCollection) GetDocumentWithRaw(ctx context.Context, docid strin
 			if importErr != nil {
 				return nil, nil, importErr
 			}
+			// nil, nil returned when ErrImportCancelled is swallowed by importDoc switch
 			if doc == nil {
 				return nil, nil, base.ErrNotFound
 			}

--- a/db/crud.go
+++ b/db/crud.go
@@ -77,6 +77,9 @@ func (c *DatabaseCollection) GetDocumentWithRaw(ctx context.Context, docid strin
 			if importErr != nil {
 				return nil, nil, importErr
 			}
+			if doc == nil {
+				return nil, nil, base.ErrNotFound
+			}
 		}
 		if !doc.HasValidSyncData() {
 			return nil, nil, base.HTTPErrorf(404, "Not imported")

--- a/db/import.go
+++ b/db/import.go
@@ -334,8 +334,9 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 		base.DebugfCtx(ctx, base.KeyImport, "Imported %s (delete=%v) as rev %s", base.UD(newDoc.ID), isDelete, newRev)
 	case base.ErrImportCancelled:
 		// Import was cancelled (SG purge) - don't return error.
+		base.DebugfCtx(ctx, base.KeyImport, "Import cancelled for purged doc %s\n", base.UD(newDoc.ID))
 	case base.ErrImportCancelledFilter:
-		// Import was cancelled based on import filter.  Return error (required for on-demand write import logic), but don't log as error/warning.
+		// Import was cancelled based on import filter.  Return error (required for on-demand write import logic), but don't log as error/warning. Already logged above.
 		return nil, err
 	case base.ErrImportCasFailure:
 		// Import was cancelled due to CAS failure.


### PR DESCRIPTION
CBG-3110

- Prevents panic when `ErrImportCancelled` ends up causing `nil, nil` to be returned from `ImportDoc`.
- Adds test to reproduce - where import is called for a `nil` binary document.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1924/
