### PR TITLE
CBG-3130 notify on request plus unused sequence docs

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -33,8 +33,8 @@ const (
 	DefaultCachePendingSeqMaxWait = 5 * time.Second  // Max time we'll wait for a pending sequence before sending to missed queue
 	DefaultSkippedSeqMaxWait      = 60 * time.Minute // Max time we'll wait for an entry in the missing before purging
 	QueryTombstoneBatch           = 250              // Max number of tombstones checked per query during Compact
-	unusedSeqKey                  = "_unusedSeqKey"
-	unusedSeqCollectionID         = 0
+	unusedSeqKey                  = "_unusedSeqKey"  // Key used by ChangeWaiter to mark unused sequences
+	unusedSeqCollectionID         = 0                // Collection ID used by ChangeWaiter to mark unused sequences
 )
 
 // Enable keeping a channel-log for the "*" channel (channel.UserStarChannel). The only time this channel is needed is if
@@ -557,6 +557,7 @@ func (c *changeCache) releaseUnusedSequence(sequence uint64, timeReceived time.T
 	if c.notifyChange != nil && len(changedChannels) > 0 {
 		c.notifyChange(changedChannels)
 	}
+	c.channelCache.AddSkippedSequence(change)
 }
 
 // Process unused sequence notification.  Extracts sequence from docID and sends to cache for buffering

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -33,6 +33,8 @@ const (
 	DefaultCachePendingSeqMaxWait = 5 * time.Second  // Max time we'll wait for a pending sequence before sending to missed queue
 	DefaultSkippedSeqMaxWait      = 60 * time.Minute // Max time we'll wait for an entry in the missing before purging
 	QueryTombstoneBatch           = 250              // Max number of tombstones checked per query during Compact
+	unusedSeqKey                  = "_unusedSeqKey"
+	unusedSeqCollectionID         = 0
 )
 
 // Enable keeping a channel-log for the "*" channel (channel.UserStarChannel). The only time this channel is needed is if
@@ -546,6 +548,12 @@ func (c *changeCache) releaseUnusedSequence(sequence uint64, timeReceived time.T
 	// Since processEntry may unblock pending sequences, if there were any changed channels we need
 	// to notify any change listeners that are working changes feeds for these channels
 	changedChannels := c.processEntry(change)
+	unusedSeq := channels.NewID(unusedSeqKey, unusedSeqCollectionID)
+	if changedChannels == nil {
+		changedChannels = channels.SetOfNoValidate(unusedSeq)
+	} else {
+		changedChannels.Add(unusedSeq)
+	}
 	if c.notifyChange != nil && len(changedChannels) > 0 {
 		c.notifyChange(changedChannels)
 	}

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -554,10 +554,10 @@ func (c *changeCache) releaseUnusedSequence(sequence uint64, timeReceived time.T
 	} else {
 		changedChannels.Add(unusedSeq)
 	}
+	c.channelCache.AddSkippedSequence(change)
 	if c.notifyChange != nil && len(changedChannels) > 0 {
 		c.notifyChange(changedChannels)
 	}
-	c.channelCache.AddSkippedSequence(change)
 }
 
 // Process unused sequence notification.  Extracts sequence from docID and sends to cache for buffering

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -576,7 +576,7 @@ func TestChannelCacheBufferingWithUserDoc(t *testing.T) {
 	// Start wait for doc in ABC
 	chans := channels.SetOfNoValidate(
 		channels.NewID("ABC", collectionID))
-	waiter := db.mutationListener.NewWaiterWithChannels(chans, nil)
+	waiter := db.mutationListener.NewWaiterWithChannels(chans, nil, false)
 
 	successChan := make(chan bool)
 	go func() {

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -416,7 +416,13 @@ func (waiter *ChangeWaiter) UpdateChannels(collectionID uint32, timedSet channel
 	initialCapacity := len(waiter.userKeys)
 	updatedKeys := make([]string, 0, initialCapacity)
 	for channelName, _ := range timedSet {
-		updatedKeys = append(updatedKeys, channels.NewID(channelName, collectionID).String())
+		var channelKey string
+		if channelName == unusedSeqKey {
+			channelKey = channels.NewID(unusedSeqKey, unusedSeqCollectionID).String()
+		} else {
+			channelKey = channels.NewID(channelName, collectionID).String()
+		}
+		updatedKeys = append(updatedKeys, channelKey)
 	}
 	if len(waiter.userKeys) > 0 {
 		updatedKeys = append(updatedKeys, waiter.userKeys...)

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -341,19 +341,22 @@ type ChangeWaiter struct {
 	lastCounter               uint64
 	lastTerminateCheckCounter uint64
 	lastUserCount             uint64
+	trackUnusedSequences      bool // track unused sequences in Wait functions
 }
 
-// Creates a new ChangeWaiter that will wait for changes for the given document keys.
-func (listener *changeListener) NewWaiter(keys []string) *ChangeWaiter {
+// NewWaiter a new ChangeWaiter that will wait for changes for the given document keys, and will optionally track unused sequences.
+func (listener *changeListener) NewWaiter(keys []string, trackUnusedSequences bool) *ChangeWaiter {
 	return &ChangeWaiter{
 		listener:                  listener,
 		keys:                      keys,
 		lastCounter:               listener.CurrentCount(keys),
 		lastTerminateCheckCounter: listener.terminateCheckCounter,
+		trackUnusedSequences:      trackUnusedSequences,
 	}
 }
 
-func (listener *changeListener) NewWaiterWithChannels(chans channels.Set, user auth.User) *ChangeWaiter {
+// NewWaiterWithChannels creates ChangeWaiter for a given channel and user, and will optionally track unused sequences.
+func (listener *changeListener) NewWaiterWithChannels(chans channels.Set, user auth.User, trackUnusedSequences bool) *ChangeWaiter {
 	waitKeys := make([]string, 0, 5)
 	for channel := range chans {
 		waitKeys = append(waitKeys, channel.String())
@@ -366,7 +369,8 @@ func (listener *changeListener) NewWaiterWithChannels(chans channels.Set, user a
 		}
 		waitKeys = append(waitKeys, userKeys...)
 	}
-	waiter := listener.NewWaiter(waitKeys)
+	waiter := listener.NewWaiter(waitKeys, trackUnusedSequences)
+
 	waiter.userKeys = userKeys
 	if userKeys != nil {
 		waiter.lastUserCount = listener.CurrentCount(userKeys)
@@ -416,13 +420,10 @@ func (waiter *ChangeWaiter) UpdateChannels(collectionID uint32, timedSet channel
 	initialCapacity := len(waiter.userKeys)
 	updatedKeys := make([]string, 0, initialCapacity)
 	for channelName, _ := range timedSet {
-		var channelKey string
-		if channelName == unusedSeqKey {
-			channelKey = channels.NewID(unusedSeqKey, unusedSeqCollectionID).String()
-		} else {
-			channelKey = channels.NewID(channelName, collectionID).String()
-		}
-		updatedKeys = append(updatedKeys, channelKey)
+		updatedKeys = append(updatedKeys, channels.NewID(channelName, collectionID).String())
+	}
+	if waiter.trackUnusedSequences {
+		updatedKeys = append(updatedKeys, channels.NewID(unusedSeqKey, unusedSeqCollectionID).String())
 	}
 	if len(waiter.userKeys) > 0 {
 		updatedKeys = append(updatedKeys, waiter.userKeys...)
@@ -451,6 +452,8 @@ func (waiter *ChangeWaiter) RefreshUserKeys(user auth.User, metaKeys *base.Metad
 	}
 }
 
+// NewUserWaiter creates a change waiter with all keys for the matching user.
 func (db *Database) NewUserWaiter() *ChangeWaiter {
-	return db.mutationListener.NewWaiterWithChannels(channels.Set{}, db.User())
+	trackUnusedSequences := false
+	return db.mutationListener.NewWaiterWithChannels(channels.Set{}, db.User(), trackUnusedSequences)
 }

--- a/db/changes.go
+++ b/db/changes.go
@@ -672,6 +672,11 @@ func (col *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Contex
 			channelsSince = channels.AtSequence(chans, 0)
 		}
 
+		if options.RequestPlusSeq > 0 {
+			// QUESTION: why can't I use 0 for AtSequence here?
+			channelsSince.Add(channels.AtSequence(base.SetOf(unusedSeqKey), currentCachedSequence))
+		}
+
 		// Mark channel set as active, schedule defer
 		col.activeChannels().IncrChannels(collectionID, channelsSince)
 		defer col.activeChannels().DecrChannels(collectionID, channelsSince)
@@ -1037,7 +1042,7 @@ func (col *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Contex
 			}
 			if userChanged && col.user != nil {
 				newChannelsSince, _ := col.user.FilterToAvailableCollectionChannels(col.ScopeName, col.Name, chans)
-
+				// QUESTION: updating channels here again will cause test to hang
 				changedChannels = newChannelsSince.CompareKeys(channelsSince)
 
 				if len(changedChannels) > 0 {

--- a/db/changes.go
+++ b/db/changes.go
@@ -548,8 +548,8 @@ func (db *DatabaseCollectionWithUser) MultiChangesFeed(ctx context.Context, chan
 
 }
 
-func (db *DatabaseCollectionWithUser) startChangeWaiter() *ChangeWaiter {
-	return db.mutationListener().NewWaiterWithChannels(channels.Set{}, db.user)
+func (db *DatabaseCollectionWithUser) startChangeWaiter(trackUnusedSequences bool) *ChangeWaiter {
+	return db.mutationListener().NewWaiterWithChannels(channels.Set{}, db.user, trackUnusedSequences)
 }
 
 func (db *DatabaseCollectionWithUser) appendUserFeed(feeds []<-chan *ChangeEntry, options ChangesOptions) []<-chan *ChangeEntry {
@@ -643,7 +643,8 @@ func (col *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Contex
 
 		// If changes feed requires more than one ChangesLoop iteration, initialize changeWaiter
 		if options.Wait || options.RequestPlusSeq > currentCachedSequence {
-			changeWaiter = col.startChangeWaiter() // Waiter is updated with the actual channel set (post-user reload) at the start of the outer changes loop
+			trackUnusedSequences := options.RequestPlusSeq > 0
+			changeWaiter = col.startChangeWaiter(trackUnusedSequences) // Waiter is updated with the actual channel set (post-user reload) at the start of the outer changes loop
 			userCounter = changeWaiter.CurrentUserCount()
 			// Reload user to pick up user changes that happened between auth and the change waiter
 			// initialization.  Without this, notification for user doc changes in that window (a) won't be
@@ -670,11 +671,6 @@ func (col *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Contex
 			}
 		} else {
 			channelsSince = channels.AtSequence(chans, 0)
-		}
-
-		if options.RequestPlusSeq > 0 {
-			// QUESTION: why can't I use 0 for AtSequence here?
-			channelsSince.Add(channels.AtSequence(base.SetOf(unusedSeqKey), currentCachedSequence))
 		}
 
 		// Mark channel set as active, schedule defer
@@ -1042,7 +1038,6 @@ func (col *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Contex
 			}
 			if userChanged && col.user != nil {
 				newChannelsSince, _ := col.user.FilterToAvailableCollectionChannels(col.ScopeName, col.Name, chans)
-				// QUESTION: updating channels here again will cause test to hang
 				changedChannels = newChannelsSince.CompareKeys(channelsSince)
 
 				if len(changedChannels) > 0 {
@@ -1063,7 +1058,6 @@ func (col *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Contex
 
 		}
 	}()
-
 	return output, nil
 }
 

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -44,6 +44,9 @@ type ChannelCache interface {
 	// Notifies the cache of a principal update.  Updates the cache's high sequence
 	AddPrincipal(change *LogEntry)
 
+	// Notifies the cache of a skipped sequence update. Updates the cache's high sequence
+	AddSkippedSequence(change *LogEntry)
+
 	// Remove purges the given doc IDs from all channel caches and returns the number of items removed.
 	Remove(collectionID uint32, docIDs []string, startTime time.Time) (count int)
 
@@ -183,6 +186,11 @@ func (c *channelCacheImpl) getSingleChannelCache(ch channels.ID) (SingleChannelC
 }
 
 func (c *channelCacheImpl) AddPrincipal(change *LogEntry) {
+	c.updateHighCacheSequence(change.Sequence)
+}
+
+// AddSkipedSequence notifies the cache of a skipped sequence update. Updates the cache's high sequence
+func (c *channelCacheImpl) AddSkippedSequence(change *LogEntry) {
 	c.updateHighCacheSequence(change.Sequence)
 }
 

--- a/rest/changes_request_plus_test.go
+++ b/rest/changes_request_plus_test.go
@@ -45,5 +45,5 @@ func TestRequestPlusSkippedSequence(t *testing.T) {
 	var changesResp ChangesResults
 	require.NoError(t, json.Unmarshal(resp.BodyBytes(), &changesResp))
 	// QUESTION: this returns alice doc, which makes sense because we did a channel grant?, but why didn't it catch up with `WaitForPendingChanges`
-	require.Len(t, changesResp, 1)
+	require.Len(t, changesResp.Results, 0)
 }

--- a/rest/changes_request_plus_test.go
+++ b/rest/changes_request_plus_test.go
@@ -1,0 +1,49 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/channels"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRequirePlusSkippedSequence
+func TestRequestPlusSkippedSequence(t *testing.T) {
+
+	restTesterConfig := RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction}
+
+	// JWT claim based grants do not support named collections
+	rt := NewRestTester(t, &restTesterConfig)
+	defer rt.Close()
+
+	const (
+		username = "alice"
+		channel  = "foo"
+	)
+	rt.CreateUser(username, []string{channel})
+
+	// try directly using bearer token in a keyspace request
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", fmt.Sprintf(`{"channels":"%s"}`, channel))
+	RequireStatus(t, resp, http.StatusCreated)
+	docSeq := rt.GetDocumentSequence("doc1")
+
+	require.NoError(t, rt.WaitForPendingChanges())
+
+	resp = rt.SendUserRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d&request_plus=true", docSeq), "", username)
+	RequireStatus(t, resp, http.StatusOK)
+	var changesResp ChangesResults
+	require.NoError(t, json.Unmarshal(resp.BodyBytes(), &changesResp))
+	// QUESTION: this returns alice doc, which makes sense because we did a channel grant?, but why didn't it catch up with `WaitForPendingChanges`
+	require.Len(t, changesResp, 1)
+}

--- a/rest/changes_request_plus_test.go
+++ b/rest/changes_request_plus_test.go
@@ -42,7 +42,6 @@ func TestRequestPlusSkippedSequence(t *testing.T) {
 
 	require.NoError(t, rt.WaitForPendingChanges())
 
-	caughtUpStart := rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
 	// add an unused sequence
 	unusedSeq, err := db.AllocateTestSequence(rt.GetDatabase())
 	require.NoError(t, err)
@@ -58,8 +57,6 @@ func TestRequestPlusSkippedSequence(t *testing.T) {
 	err = db.ReleaseTestSequence(rt.GetDatabase(), unusedSeq)
 	require.NoError(t, err)
 	<-requestFinished
-	// the changes feed should catch up this value
-	require.NoError(t, rt.GetDatabase().WaitForTotalCaughtUp(caughtUpStart+1))
 	var changesResp ChangesResults
 	require.NoError(t, json.Unmarshal(resp.BodyBytes(), &changesResp))
 	require.Len(t, changesResp.Results, 0)

--- a/rest/changes_request_plus_test.go
+++ b/rest/changes_request_plus_test.go
@@ -41,6 +41,7 @@ func TestRequestPlusSkippedSequence(t *testing.T) {
 
 	require.NoError(t, rt.WaitForPendingChanges())
 
+	caughtUpStart := rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
 	unusedSeq, err := db.AllocateTestSequence(rt.GetDatabase())
 	require.NoError(t, err)
 
@@ -50,6 +51,7 @@ func TestRequestPlusSkippedSequence(t *testing.T) {
 		RequireStatus(t, resp, http.StatusOK)
 		close(requestFinished)
 	}()
+	require.NoError(t, rt.GetDatabase().WaitForTotalCaughtUp(caughtUpStart+1))
 	err = db.ReleaseTestSequence(rt.GetDatabase(), unusedSeq)
 	require.NoError(t, err)
 	<-requestFinished


### PR DESCRIPTION
Creates a fake key for unused sequences, and if request_plus is enabled, the changeWaiter will listen for this key.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1925/
