### PR TITLE
[3.1.1 Backport] CBG-3131: Handle ErrImportCancelled case for OnDemandImportForGet (#6325)

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -77,6 +77,10 @@ func (c *DatabaseCollection) GetDocumentWithRaw(ctx context.Context, docid strin
 			if importErr != nil {
 				return nil, nil, importErr
 			}
+			// nil, nil returned when ErrImportCancelled is swallowed by importDoc switch
+			if doc == nil {
+				return nil, nil, base.ErrNotFound
+			}
 		}
 		if !doc.HasValidSyncData() {
 			return nil, nil, base.HTTPErrorf(404, "Not imported")

--- a/db/import.go
+++ b/db/import.go
@@ -334,8 +334,9 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 		base.DebugfCtx(ctx, base.KeyImport, "Imported %s (delete=%v) as rev %s", base.UD(newDoc.ID), isDelete, newRev)
 	case base.ErrImportCancelled:
 		// Import was cancelled (SG purge) - don't return error.
+		base.DebugfCtx(ctx, base.KeyImport, "Import cancelled for purged doc %s\n", base.UD(newDoc.ID))
 	case base.ErrImportCancelledFilter:
-		// Import was cancelled based on import filter.  Return error (required for on-demand write import logic), but don't log as error/warning.
+		// Import was cancelled based on import filter.  Return error (required for on-demand write import logic), but don't log as error/warning. Already logged above.
 		return nil, err
 	case base.ErrImportCasFailure:
 		// Import was cancelled due to CAS failure.

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -1394,8 +1394,7 @@ func TestFeedBasedMigrateWithExpiry(t *testing.T) {
 
 }
 
-// Verify that an on-demand import of a null document during write doesn't block
-// the incoming write
+// Verify that an on-demand import of a null document during write doesn't block the incoming write
 func TestOnDemandWriteImportReplacingNullDoc(t *testing.T) {
 
 	base.SkipImportTestsIfNotEnabled(t)
@@ -1412,12 +1411,55 @@ func TestOnDemandWriteImportReplacingNullDoc(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
-	key := "TestXattrOnDemandImportNullBody"
+	key := t.Name()
 
-	// Write directly to bucket with an null body
+	// Write json doc directly to bucket with a null body
 	nullBody := []byte("null")
 	_, err := dataStore.AddRaw(key, 0, nullBody)
 	require.NoError(t, err, "Error writing SDK doc")
+
+	// Attempt to get the doc via Sync Gateway, triggering a cancelled on-demand import of the null document
+	response := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+key, "")
+	rest.RequireStatus(t, response, http.StatusBadRequest) // import attempted with empty body
+
+	// Attempt to update the doc via Sync Gateway, triggering on-demand import of the null document - should ignore empty body error and proceed with write
+	mobileBody := make(map[string]interface{})
+	mobileBody["type"] = "mobile"
+	mobileBody["channels"] = "ABC"
+	mobileBody["foo"] = "bar"
+	mobileBodyMarshalled, err := base.JSONMarshal(mobileBody)
+	assert.NoError(t, err, "Error marshalling body")
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+key, string(mobileBodyMarshalled))
+	rest.RequireStatus(t, response, 201)
+}
+
+// Verify that an on-demand import of a nil document during write doesn't block the incoming write
+func TestOnDemandWriteImportReplacingNilDoc(t *testing.T) {
+
+	base.SkipImportTestsIfNotEnabled(t)
+
+	rtConfig := rest.RestTesterConfig{
+		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+			AutoImport: false,
+		}},
+	}
+	rt := rest.NewRestTester(t, &rtConfig)
+	defer rt.Close()
+	dataStore := rt.GetSingleDataStore()
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
+
+	key := t.Name()
+
+	// Write binary doc directly to bucket with a nil body
+	var nilBody []byte
+	_, err := dataStore.AddRaw(key, 0, nilBody)
+	require.NoError(t, err, "Error writing SDK doc")
+
+	// Attempt to get the doc via Sync Gateway, triggering a cancelled on-demand import of the null document
+	response := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+key, "")
+	rest.RequireStatus(t, response, 404)
 
 	// Attempt to update the doc via Sync Gateway, triggering on-demand import of the null document
 	mobileBody := make(map[string]interface{})
@@ -1426,9 +1468,8 @@ func TestOnDemandWriteImportReplacingNullDoc(t *testing.T) {
 	mobileBody["foo"] = "bar"
 	mobileBodyMarshalled, err := base.JSONMarshal(mobileBody)
 	assert.NoError(t, err, "Error marshalling body")
-	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+key, string(mobileBodyMarshalled))
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+key, string(mobileBodyMarshalled))
 	rest.RequireStatus(t, response, 201)
-
 }
 
 // Write a doc via SDK with an expiry value.  Verify that expiry is preserved when doc is imported via on-demand


### PR DESCRIPTION
CBG-3131

Clean cherry-pick to backport #6325 to 3.1.1

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-1.19.5/11/