### PR TITLE
CBG-3041 [3.1.1 Backport] Support async database initialization 

### DIFF
--- a/base/cluster_n1ql.go
+++ b/base/cluster_n1ql.go
@@ -31,9 +31,9 @@ var _ N1QLStore = &ClusterOnlyN1QLStore{}
 // collection-scoped and non-collection-scoped operations.
 type ClusterOnlyN1QLStore struct {
 	cluster             *gocb.Cluster
-	bucketName          string
-	scopeName           string
-	collectionName      string
+	bucketName          string // User to build keyspace for query when not otherwise set
+	scopeName           string // Used to build keyspace for query when not otherwise set
+	collectionName      string // Used to build keyspace for query when not otherwise set
 	supportsCollections bool
 }
 
@@ -57,6 +57,10 @@ func NewClusterOnlyN1QLStore(cluster *gocb.Cluster, bucketName, scopeName, colle
 }
 
 func (cl *ClusterOnlyN1QLStore) GetName() string {
+	return cl.bucketName
+}
+
+func (cl *ClusterOnlyN1QLStore) BucketName() string {
 	return cl.bucketName
 }
 
@@ -219,4 +223,10 @@ func (cl *ClusterOnlyN1QLStore) waitUntilQueryServiceReady(timeout time.Duration
 	return cl.cluster.WaitUntilReady(timeout,
 		&gocb.WaitUntilReadyOptions{ServiceTypes: []gocb.ServiceType{gocb.ServiceTypeQuery}},
 	)
+}
+
+// ClusterOnlyN1QLStore allows callers to set the scope and collection per operation
+func (cl *ClusterOnlyN1QLStore) SetScopeAndCollection(scName ScopeAndCollectionName) {
+	cl.scopeName = scName.Scope
+	cl.collectionName = scName.Collection
 }

--- a/base/cluster_n1ql.go
+++ b/base/cluster_n1ql.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2023-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package base
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/couchbase/gocb/v2"
+	sgbucket "github.com/couchbase/sg-bucket"
+	pkgerrors "github.com/pkg/errors"
+)
+
+var _ N1QLStore = &ClusterOnlyN1QLStore{}
+
+// ClusterOnlyN1qlStore implements the N1QLStore using only a cluster connection.
+// Currently still intended for use for operations against a single collection, but maintains that
+// information via metadata, and so supports sharing of the underlying gocb.Cluster with other
+// ClusterOnlyN1QLStore instances.  Anticipates future refactoring of N1QLStore to differentiate between
+// collection-scoped and non-collection-scoped operations.
+type ClusterOnlyN1QLStore struct {
+	cluster             *gocb.Cluster
+	bucketName          string
+	scopeName           string
+	collectionName      string
+	supportsCollections bool
+}
+
+func NewClusterOnlyN1QLStore(cluster *gocb.Cluster, bucketName, scopeName, collectionName string) (*ClusterOnlyN1QLStore, error) {
+
+	clusterOnlyn1qlStore := &ClusterOnlyN1QLStore{
+		cluster:        cluster,
+		bucketName:     bucketName,
+		scopeName:      scopeName,
+		collectionName: collectionName,
+	}
+
+	major, minor, err := getClusterVersion(cluster)
+	if err != nil {
+		return nil, err
+	}
+	clusterOnlyn1qlStore.supportsCollections = isMinimumVersion(uint64(major), uint64(minor), 7, 0)
+
+	return clusterOnlyn1qlStore, nil
+
+}
+
+func (cl *ClusterOnlyN1QLStore) GetName() string {
+	return cl.bucketName
+}
+
+func (cl *ClusterOnlyN1QLStore) BuildDeferredIndexes(indexSet []string) error {
+	return BuildDeferredIndexes(cl, indexSet)
+}
+
+func (cl *ClusterOnlyN1QLStore) CreateIndex(indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
+	return CreateIndex(cl, indexName, expression, filterExpression, options)
+}
+
+func (cl *ClusterOnlyN1QLStore) CreatePrimaryIndex(indexName string, options *N1qlIndexOptions) error {
+	return CreatePrimaryIndex(cl, indexName, options)
+}
+
+func (cl *ClusterOnlyN1QLStore) ExplainQuery(statement string, params map[string]interface{}) (plan map[string]interface{}, err error) {
+	return ExplainQuery(cl, statement, params)
+}
+
+func (cl *ClusterOnlyN1QLStore) DropIndex(indexName string) error {
+	return DropIndex(cl, indexName)
+}
+
+// IndexMetaKeyspaceID returns the value of keyspace_id for the system:indexes table for the collection.
+func (cl *ClusterOnlyN1QLStore) IndexMetaKeyspaceID() string {
+	return IndexMetaKeyspaceID(cl.bucketName, cl.scopeName, cl.collectionName)
+}
+
+// IndexMetaBucketID returns the value of bucket_id for the system:indexes table for the collection.
+func (cl *ClusterOnlyN1QLStore) IndexMetaBucketID() string {
+	if IsDefaultCollection(cl.scopeName, cl.collectionName) {
+		return ""
+	}
+	return cl.bucketName
+}
+
+// IndexMetaScopeID returns the value of scope_id for the system:indexes table for the collection.
+func (cl *ClusterOnlyN1QLStore) IndexMetaScopeID() string {
+	if IsDefaultCollection(cl.scopeName, cl.collectionName) {
+		return ""
+	}
+	return cl.scopeName
+}
+
+func (cl *ClusterOnlyN1QLStore) Query(statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (resultsIterator sgbucket.QueryResultIterator, err error) {
+	logCtx := context.TODO()
+
+	keyspaceStatement := strings.Replace(statement, KeyspaceQueryToken, cl.EscapedKeyspace(), -1)
+
+	n1qlOptions := &gocb.QueryOptions{
+		ScanConsistency: gocb.QueryScanConsistency(consistency),
+		Adhoc:           adhoc,
+		NamedParameters: params,
+	}
+
+	waitTime := 10 * time.Millisecond
+	for i := 1; i <= MaxQueryRetries; i++ {
+		TracefCtx(logCtx, KeyQuery, "Executing N1QL query: %v - %+v", UD(keyspaceStatement), UD(params))
+		queryResults, queryErr := cl.runQuery(keyspaceStatement, n1qlOptions)
+		if queryErr == nil {
+			resultsIterator := &gocbRawIterator{
+				rawResult:                  queryResults.Raw(),
+				concurrentQueryOpLimitChan: nil,
+			}
+			return resultsIterator, queryErr
+		}
+
+		// Timeout error - return named error
+		if errors.Is(queryErr, gocb.ErrTimeout) {
+			return resultsIterator, ErrViewTimeoutError
+		}
+
+		// Non-retry error - return
+		if !isTransientIndexerError(queryErr) {
+			WarnfCtx(logCtx, "Error when querying index using statement: [%s] parameters: [%+v] error:%v", UD(keyspaceStatement), UD(params), queryErr)
+			return resultsIterator, pkgerrors.WithStack(queryErr)
+		}
+
+		// Indexer error - wait then retry
+		err = queryErr
+		WarnfCtx(logCtx, "Indexer error during query - retry %d/%d after %v.  Error: %v", i, MaxQueryRetries, waitTime, queryErr)
+		time.Sleep(waitTime)
+
+		waitTime = waitTime * 2
+	}
+
+	WarnfCtx(logCtx, "Exceeded max retries for query when querying index using statement: [%s] parameters: [%+v], err:%v", UD(keyspaceStatement), UD(params), err)
+	return nil, err
+}
+
+// executeQuery runs a N1QL query against the cluster.  Does not throttle query ops.
+func (cl *ClusterOnlyN1QLStore) executeQuery(statement string) (sgbucket.QueryResultIterator, error) {
+	queryResults, queryErr := cl.runQuery(statement, nil)
+	if queryErr != nil {
+		return nil, queryErr
+	}
+
+	resultsIterator := &gocbRawIterator{
+		rawResult:                  queryResults.Raw(),
+		concurrentQueryOpLimitChan: nil,
+	}
+	return resultsIterator, nil
+}
+
+func (cl *ClusterOnlyN1QLStore) executeStatement(statement string) error {
+	queryResults, queryErr := cl.runQuery(statement, nil)
+	if queryErr != nil {
+		return queryErr
+	}
+
+	// Drain results to return any non-query errors
+	for queryResults.Next() {
+	}
+	closeErr := queryResults.Close()
+	if closeErr != nil {
+		return closeErr
+	}
+	return queryResults.Err()
+}
+
+func (cl *ClusterOnlyN1QLStore) runQuery(statement string, n1qlOptions *gocb.QueryOptions) (*gocb.QueryResult, error) {
+	if n1qlOptions == nil {
+		n1qlOptions = &gocb.QueryOptions{}
+	}
+	queryResults, err := cl.cluster.Query(statement, n1qlOptions)
+
+	return queryResults, err
+}
+
+func (cl *ClusterOnlyN1QLStore) WaitForIndexesOnline(indexNames []string, failfast bool) error {
+	return WaitForIndexesOnline(cl.cluster, cl.bucketName, cl.scopeName, cl.collectionName, indexNames, failfast)
+}
+
+func (cl *ClusterOnlyN1QLStore) GetIndexMeta(indexName string) (exists bool, meta *IndexMeta, err error) {
+	return GetIndexMeta(cl, indexName)
+}
+
+func (cl *ClusterOnlyN1QLStore) IsErrNoResults(err error) bool {
+	return err == gocb.ErrNoResult
+}
+
+// EscapedKeyspace returns the escaped fully-qualified identifier for the keyspace (e.g. `bucket`.`scope`.`collection`)
+func (cl *ClusterOnlyN1QLStore) EscapedKeyspace() string {
+	if !cl.supportsCollections {
+		return fmt.Sprintf("`%s`", cl.bucketName)
+	}
+	return fmt.Sprintf("`%s`.`%s`.`%s`", cl.bucketName, cl.scopeName, cl.collectionName)
+}
+
+func (cl *ClusterOnlyN1QLStore) GetIndexes() (indexes []string, err error) {
+	if cl.supportsCollections {
+		return GetAllIndexes(cl.cluster, cl.bucketName, cl.scopeName, cl.collectionName)
+	} else {
+		return GetAllIndexes(cl.cluster, cl.bucketName, "", "")
+	}
+}
+
+// waitUntilQueryServiceReady will wait for the specified duration until the query service is available.
+func (cl *ClusterOnlyN1QLStore) waitUntilQueryServiceReady(timeout time.Duration) error {
+	return cl.cluster.WaitUntilReady(timeout,
+		&gocb.WaitUntilReadyOptions{ServiceTypes: []gocb.ServiceType{gocb.ServiceTypeQuery}},
+	)
+}

--- a/base/collection.go
+++ b/base/collection.go
@@ -80,6 +80,7 @@ func GetGoCBv2Bucket(spec BucketSpec) (*GocbV2Bucket, error) {
 		ServiceTypes:  []gocb.ServiceType{gocb.ServiceTypeManagement},
 		RetryStrategy: &goCBv2FailFastRetryStrategy{},
 	})
+
 	if err != nil {
 		_ = cluster.Close(nil)
 		if errors.Is(err, gocb.ErrAuthenticationFailure) {

--- a/base/collection_common.go
+++ b/base/collection_common.go
@@ -38,6 +38,10 @@ func (s ScopeAndCollectionName) String() string {
 	return s.Scope + ScopeCollectionSeparator + s.Collection
 }
 
+func DefaultScopeAndCollectionName() ScopeAndCollectionName {
+	return ScopeAndCollectionName{Scope: DefaultScope, Collection: DefaultCollection}
+}
+
 type ScopeAndCollectionNames []ScopeAndCollectionName
 
 // ScopeAndCollectionNames returns a dot-separated formatted slice of scope and collection names.

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -48,6 +48,7 @@ type N1QLStore interface {
 	IndexMetaBucketID() string
 	IndexMetaScopeID() string
 	IndexMetaKeyspaceID() string
+	BucketName() string
 	WaitForIndexesOnline(indexNames []string, failfast bool) error
 
 	// executeQuery performs the specified query without any built-in retry handling and returns the resultset

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -506,3 +506,81 @@ func (i *gocbRawIterator) Close() error {
 	resultErr := i.rawResult.Err()
 	return resultErr
 }
+
+func IndexMetaKeyspaceID(bucketName, scopeName, collectionName string) string {
+	if IsDefaultCollection(scopeName, collectionName) {
+		return bucketName
+	}
+	return collectionName
+}
+
+// WaitForIndexesOnline takes set of indexes and watches them till they're online.
+func WaitForIndexesOnline(cluster *gocb.Cluster, bucketName, scopeName, collectionName string, indexNames []string, failfast bool) error {
+	logCtx := context.TODO()
+	mgr := cluster.QueryIndexes()
+	maxNumAttempts := 180
+	if failfast {
+		maxNumAttempts = 1
+	}
+	retrySleeper := CreateMaxDoublingSleeperFunc(maxNumAttempts, 100, 5000)
+	retryCount := 0
+
+	onlineIndexes := make(map[string]bool)
+
+	indexOption := gocb.GetAllQueryIndexesOptions{
+		ScopeName:      scopeName,
+		CollectionName: collectionName,
+		RetryStrategy:  &goCBv2FailFastRetryStrategy{},
+	}
+
+	for {
+		watchedOnlineIndexCount := 0
+		currIndexes, err := mgr.GetAllIndexes(bucketName, &indexOption)
+		if err != nil {
+			return err
+		}
+		// check each of the current indexes state, add to map once finished to make sure each index online is only being logged once
+		for i := 0; i < len(currIndexes); i++ {
+			if currIndexes[i].State == IndexStateOnline {
+				if !onlineIndexes[currIndexes[i].Name] {
+					InfofCtx(logCtx, KeyAll, "Index %s is online", MD(currIndexes[i].Name))
+					onlineIndexes[currIndexes[i].Name] = true
+				}
+			}
+		}
+		// check online index against indexes we watch to have online, increase counter as each comes online
+		for _, listVal := range indexNames {
+			if onlineIndexes[listVal] {
+				watchedOnlineIndexCount++
+			}
+		}
+
+		if watchedOnlineIndexCount == len(indexNames) {
+			return nil
+		}
+		retryCount++
+		shouldContinue, sleepMs := retrySleeper(retryCount)
+		if !shouldContinue {
+			return fmt.Errorf("error waiting for indexes for bucket %s....", MD(bucketName))
+		}
+		InfofCtx(logCtx, KeyAll, "Indexes for bucket %s not ready - retrying...", MD(bucketName))
+		time.Sleep(time.Millisecond * time.Duration(sleepMs))
+	}
+}
+
+func GetAllIndexes(cluster *gocb.Cluster, bucketName, scopeName, collectionName string) (indexes []string, err error) {
+	indexes = []string{}
+	opts := &gocb.GetAllQueryIndexesOptions{
+		ScopeName:      scopeName,
+		CollectionName: collectionName,
+	}
+	indexInfo, err := cluster.QueryIndexes().GetAllIndexes(bucketName, opts)
+	if err != nil {
+		return indexes, err
+	}
+
+	for _, indexInfo := range indexInfo {
+		indexes = append(indexes, indexInfo.Name)
+	}
+	return indexes, nil
+}

--- a/base/util.go
+++ b/base/util.go
@@ -63,6 +63,15 @@ func NewNonCancelCtx() NonCancellableContext {
 	return ctxStruct
 }
 
+// NewNonCancelCtx creates a new background context struct for operations that require a fresh context, with database logging context added
+func NewNonCancelCtxForDatabase(dbName string) NonCancellableContext {
+	dbLogContext := DatabaseLogCtx(context.Background(), dbName)
+	ctxStruct := NonCancellableContext{
+		Ctx: dbLogContext,
+	}
+	return ctxStruct
+}
+
 // RedactBasicAuthURLUserAndPassword returns the given string, with a redacted HTTP basic auth component.
 func RedactBasicAuthURLUserAndPassword(urlIn string) string {
 	redactedUrl, err := RedactBasicAuthURL(urlIn, false)

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -80,13 +80,15 @@ type changeCacheStats struct {
 func (c *changeCache) updateStats() {
 
 	c.lock.Lock()
-
+	defer c.lock.Unlock()
+	if c.db == nil {
+		return
+	}
 	c.db.DbStats.Database().HighSeqFeed.SetIfMax(int64(c.internalStats.highSeqFeed))
 	c.db.DbStats.Cache().PendingSeqLen.Set(int64(c.internalStats.pendingSeqLen))
 	c.db.DbStats.CBLReplicationPull().MaxPending.SetIfMax(int64(c.internalStats.maxPending))
 	c.db.DbStats.Cache().HighSeqStable.Set(int64(c._getMaxStableCached()))
 
-	c.lock.Unlock()
 }
 
 type LogEntry channels.LogEntry

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -21,6 +21,7 @@ package db
 
 // Update database-specific stats that are more efficiently calculated at stats collection time
 func (db *DatabaseContext) UpdateCalculatedStats() {
+
 	db.changeCache.updateStats()
 	channelCache := db.changeCache.getChannelCache()
 	db.DbStats.Cache().ChannelCacheMaxEntries.Set(int64(channelCache.MaxCacheSize()))

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -557,7 +557,7 @@ func SetupTestDBForDataStoreWithOptions(t testing.TB, tBucket *base.TestBucket, 
 	return db, ctx
 }
 
-// GetScopesOptions sets up a ScopesOptions from a TestBucket. This will set up default or non default collections depending on the test harness use of SG_TEST_USE_NAMED_COLLECTIONS and whether the backing store supports collections.
+// GetScopesOptions sets up a ScopesOptions from a TestBucket. This will set up default or non default collections depending on the test harness use of SG_TEST_USE_DEFAULT_COLLECTION and whether the backing store supports collections.
 func GetScopesOptions(t testing.TB, testBucket *base.TestBucket, numCollections int) ScopesOptions {
 	if !base.TestsUseNamedCollections() {
 		if numCollections != 1 {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -546,7 +546,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 		if err := updatedDbConfig.setup(dbName, h.server.Config.Bootstrap, dbCreds, nil, false); err != nil {
 			return err
 		}
-		if err := h.server.ReloadDatabaseWithConfig(contextNoCancel, *updatedDbConfig); err != nil {
+		if err := h.server.ReloadDatabaseWithConfig(contextNoCancel, *updatedDbConfig, false); err != nil {
 			return err
 		}
 		return base.HTTPErrorf(http.StatusCreated, "updated")
@@ -597,7 +597,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 		}
 
 		// Load the new dbConfig before we persist the update.
-		err = h.server.ReloadDatabaseWithConfig(contextNoCancel, tmpConfig)
+		err = h.server.ReloadDatabaseWithConfig(contextNoCancel, tmpConfig, true)
 		if err != nil {
 			return nil, err
 		}
@@ -708,7 +708,7 @@ func (h *handler) handleDeleteCollectionConfigSync() error {
 	defer h.server.lock.Unlock()
 
 	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 		return err
 	}
 
@@ -772,7 +772,7 @@ func (h *handler) handlePutCollectionConfigSync() error {
 	defer h.server.lock.Unlock()
 
 	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 		return err
 	}
 
@@ -867,7 +867,7 @@ func (h *handler) handleDeleteCollectionConfigImportFilter() error {
 	defer h.server.lock.Unlock()
 
 	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 		return err
 	}
 
@@ -932,7 +932,7 @@ func (h *handler) handlePutCollectionConfigImportFilter() error {
 	defer h.server.lock.Unlock()
 
 	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 		return err
 	}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -1686,7 +1686,7 @@ func (sc *ServerContext) _applyConfig(nonContextStruct base.NonCancellableContex
 	}
 
 	// TODO: Dynamic update instead of reload
-	if err := sc._reloadDatabaseWithConfig(nonContextStruct.Ctx, cnf, failFast); err != nil {
+	if err := sc._reloadDatabaseWithConfig(nonContextStruct.Ctx, cnf, failFast, false); err != nil {
 		// remove these entries we just created above if the database hasn't loaded properly
 		return false, fmt.Errorf("couldn't reload database: %w", err)
 	}
@@ -1704,7 +1704,7 @@ func (sc *ServerContext) addLegacyPrincipals(ctx context.Context, legacyDbUsers,
 			base.ErrorfCtx(ctx, "Couldn't get database context to install user principles: %v", err)
 			continue
 		}
-		err = sc.installPrincipals(ctx, dbCtx, dbUser, "user")
+		err = dbCtx.InstallPrincipals(ctx, dbUser, "user")
 		if err != nil {
 			base.ErrorfCtx(ctx, "Couldn't install user principles: %v", err)
 		}
@@ -1716,7 +1716,7 @@ func (sc *ServerContext) addLegacyPrincipals(ctx context.Context, legacyDbUsers,
 			base.ErrorfCtx(ctx, "Couldn't get database context to install role principles: %v", err)
 			continue
 		}
-		err = sc.installPrincipals(ctx, dbCtx, dbRole, "role")
+		err = dbCtx.InstallPrincipals(ctx, dbRole, "role")
 		if err != nil {
 			base.ErrorfCtx(ctx, "Couldn't install role principles: %v", err)
 		}

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -60,6 +60,16 @@ func (dbc *DatabaseConfig) Redacted() (*DatabaseConfig, error) {
 	return &config, nil
 }
 
+func (dbc *DatabaseConfig) GetCollectionNames() base.ScopeAndCollectionNames {
+	collections := make(base.ScopeAndCollectionNames, 0)
+	for scopeName, scopeConfig := range dbc.Scopes {
+		for collectionName, _ := range scopeConfig.Collections {
+			collections = append(collections, base.ScopeAndCollectionName{Scope: scopeName, Collection: collectionName})
+		}
+	}
+	return collections
+}
+
 func GenerateDatabaseConfigVersionID(previousRevID string, dbConfig *DbConfig) (string, error) {
 	encodedBody, err := base.JSONMarshalCanonical(dbConfig)
 	if err != nil {

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -377,7 +377,7 @@ func TestLegacyConfigPrinciplesMigration(t *testing.T) {
 			ExplicitChannels: base.SetOf("*"),
 		},
 	}
-	err := rt.ServerContext().installPrincipals(ctx, rt.GetDatabase(), existingUsers, "user")
+	err := rt.GetDatabase().InstallPrincipals(ctx, existingUsers, "user")
 	require.NoError(t, err)
 
 	existingRoles := map[string]*auth.PrincipalConfig{
@@ -390,7 +390,7 @@ func TestLegacyConfigPrinciplesMigration(t *testing.T) {
 			ExplicitChannels: base.SetOf("*"),
 		},
 	}
-	err = rt.ServerContext().installPrincipals(ctx, rt.GetDatabase(), existingRoles, "role")
+	err = rt.GetDatabase().InstallPrincipals(ctx, existingRoles, "role")
 	require.NoError(t, err)
 
 	// Config to migrate to persistent config on bucket

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -1,0 +1,310 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+)
+
+// DatabaseInitManager coordinates InitializeDatabase requests across multiple callers and
+// databases.  At most one worker per database may be active at a time.  If the required initialization
+// (based on the databaseConfig) changes for a database while a worker is already active, that worker is
+// cancelled and a new one created.  Currently this is based solely on the set of collections in the config, and
+// their computed index sets.
+// DatabaseInitManager is only responsible for asynchronous execution of the initialization processing - it
+// is not intended maintain initialization status, or the success/failure of historic executions. The expectation
+// is that evaluation of whether a database has been initialized is relatively inexpensive and is the responsibility
+// of the code in databaseInitWork.Run.
+type DatabaseInitManager struct {
+
+	// Set of active DatabaseInitWorkers.  Workers are removed from the set on completion.
+	workers     map[string]*DatabaseInitWorker
+	workersLock sync.Mutex
+
+	// collectionCompleteCallback is defined for testability only.
+	// Invoked after collection initialization is complete for each collection
+	collectionCompleteCallback collectionCallbackFunc
+
+	// databaseCompleteCallback is defined for testability only.
+	// Invoked after worker completes, but before worker is removed from workers set
+	databaseCompleteCallback func(databaseName string) // Callback for testability only
+}
+
+type collectionCallbackFunc func(dbName, collectionName string)
+
+// CollectionInitData defines the set of collections being created (by ScopeAneCollectionName), and the set of
+// indexes required for each collection.
+type CollectionInitData map[base.ScopeAndCollectionName]db.CollectionIndexesType
+
+// Initializes the database.  Will establish a new cluster connection using the provided server config.  Establishes a new
+// cluster-only N1QLStore based on the startup config to perform initialization.
+func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupConfig *StartupConfig, dbConfig *DatabaseConfig) (doneChan chan error, err error) {
+	m.workersLock.Lock()
+	defer m.workersLock.Unlock()
+	if m.workers == nil {
+		m.workers = make(map[string]*DatabaseInitWorker)
+	}
+	base.InfofCtx(ctx, base.KeyAll, "Initializing database %s ...",
+		base.MD(dbConfig.Name))
+	dbInitWorker, ok := m.workers[dbConfig.Name]
+	collectionSet := m.buildCollectionIndexData(dbConfig)
+	if ok {
+		// If worker exists for the database and the collection sets match, add watcher to the existing worker
+		if dbInitWorker.collectionsEqual(collectionSet) {
+			base.InfofCtx(ctx, base.KeyAll, "Found existing database initialization for database %s ...",
+				base.MD(dbConfig.Name))
+			doneChan := dbInitWorker.addWatcher()
+			return doneChan, nil
+		}
+		// For a mismatch in collections, stop and remove the existing worker, then continue through to creation of new worker
+		dbInitWorker.Stop()
+		delete(m.workers, dbConfig.Name)
+	}
+
+	base.InfofCtx(ctx, base.KeyAll, "Starting new async initialization for database %s ...",
+		base.MD(dbConfig.Name))
+	couchbaseCluster, err := CreateCouchbaseClusterFromStartupConfig(startupConfig, base.PerUseClusterConnections)
+	if err != nil {
+		return nil, err
+	}
+
+	bucketName := dbConfig.Name
+	if dbConfig.Bucket != nil {
+		bucketName = *dbConfig.Bucket
+	}
+
+	// Initialize ClusterN1QLStore for the bucket.  Scope and collection name are set
+	// per-operation
+	n1qlStore, err := couchbaseCluster.GetClusterN1QLStore(bucketName, "", "")
+	if err != nil {
+		return nil, err
+	}
+
+	indexOptions := m.BuildIndexOptions(startupConfig, dbConfig)
+
+	// Create new worker and add this caller as a watcher
+	worker := NewDatabaseInitWorker(ctx, dbConfig.Name, n1qlStore, collectionSet, indexOptions, m.collectionCompleteCallback)
+	m.workers[dbConfig.Name] = worker
+	doneChan = worker.addWatcher()
+
+	// Start a goroutine to perform the initialization
+	go func() {
+		defer couchbaseCluster.Close()
+		// worker.Run blocks until completion, and returns any error on doneChan.
+		worker.Run()
+		if m.databaseCompleteCallback != nil {
+			m.databaseCompleteCallback(dbConfig.Name)
+		}
+		// On success, remove worker
+		m.workersLock.Lock()
+		delete(m.workers, dbConfig.Name)
+		m.workersLock.Unlock()
+	}()
+	return doneChan, nil
+}
+
+func (m *DatabaseInitManager) HasActiveInitialization(dbName string) bool {
+	m.workersLock.Lock()
+	defer m.workersLock.Unlock()
+	_, ok := m.workers[dbName]
+	return ok
+}
+
+func (m *DatabaseInitManager) BuildIndexOptions(startupConfig *StartupConfig, dbConfig *DatabaseConfig) db.InitializeIndexOptions {
+	numReplicas := DefaultNumIndexReplicas
+	if dbConfig.NumIndexReplicas != nil {
+		numReplicas = *dbConfig.NumIndexReplicas
+	}
+	return db.InitializeIndexOptions{
+		FailFast:    false,
+		NumReplicas: numReplicas,
+		Serverless:  startupConfig.IsServerless(),
+		UseXattrs:   dbConfig.UseXattrs(),
+	}
+}
+
+// Intended for test usage.  Updates to callback function aren't synchronized
+func (m *DatabaseInitManager) SetCallbacks(collectionComplete collectionCallbackFunc, databaseComplete func(dbName string)) {
+	m.collectionCompleteCallback = collectionComplete
+	m.databaseCompleteCallback = databaseComplete
+}
+
+func (m *DatabaseInitManager) Cancel(dbName string) {
+	m.workersLock.Lock()
+	defer m.workersLock.Unlock()
+	worker, ok := m.workers[dbName]
+	if !ok {
+		return
+	}
+	worker.Stop()
+}
+
+// buildCollectionIndexData determines the set of indexes required for each collection in the config, including
+// the metadata collection
+func (m *DatabaseInitManager) buildCollectionIndexData(config *DatabaseConfig) CollectionInitData {
+	collectionInitData := make(CollectionInitData, 0)
+	if len(config.Scopes) > 0 {
+		hasDefaultCollection := false
+		for scopeName, scopeConfig := range config.Scopes {
+			for collectionName, _ := range scopeConfig.Collections {
+				metadataIndexOption := db.IndexesWithoutMetadata
+				if base.IsDefaultCollection(scopeName, collectionName) {
+					hasDefaultCollection = true
+					metadataIndexOption = db.IndexesAll
+				}
+				scName := base.ScopeAndCollectionName{Scope: scopeName, Collection: collectionName}
+				collectionInitData[scName] = metadataIndexOption
+			}
+		}
+		if !hasDefaultCollection {
+			collectionInitData[base.DefaultScopeAndCollectionName()] = db.IndexesMetadataOnly
+		}
+	} else {
+		collectionInitData[base.DefaultScopeAndCollectionName()] = db.IndexesAll
+	}
+	return collectionInitData
+}
+
+// DatabaseInitWorker performs async database initialization tasks that should be performed in the background,
+// independent of the database being reloaded for config changes
+type DatabaseInitWorker struct {
+	dbName                     string
+	n1qlStore                  *base.ClusterOnlyN1QLStore
+	options                    DatabaseInitOptions
+	ctx                        context.Context        // On close, terminates any goroutines associated with the worker
+	cancelFunc                 context.CancelFunc     // Cancel function for context, invoked if Cancel is called
+	collections                CollectionInitData     // The set of collections associated with the worker, mapped by name to their index set
+	collectionCompleteCallback collectionCallbackFunc // Callback for testability
+
+	// Multiple goroutines (watchers) may be waiting for database initialization.  To support sending error information to
+	// every goroutine, we maintain a channel for each of these watching goroutines.  On success, all channels are
+	// closed.  On error, the error is sent to each channel before closing the channel
+	watchers    []chan error
+	watcherLock sync.Mutex // Mutex for synchronized watchers access
+	completed   bool       // Set to true when processing completes, to handle watcher registration during completion.  Synchronized with watcherLock.
+	lastError   error      // Set for when processing does not complete successfully.  Synchronized with watcherLock
+}
+
+// DatabaseInitOptions specifies the options used for database initialization
+type DatabaseInitOptions struct {
+	indexOptions db.InitializeIndexOptions // Options used for index initialization
+}
+
+func NewDatabaseInitWorker(ctx context.Context, dbName string, n1qlStore *base.ClusterOnlyN1QLStore, collections CollectionInitData, indexOptions db.InitializeIndexOptions, callback collectionCallbackFunc) *DatabaseInitWorker {
+	cancelCtx, cancelFunc := context.WithCancel(ctx)
+	return &DatabaseInitWorker{
+		dbName:                     dbName,
+		options:                    DatabaseInitOptions{indexOptions: indexOptions},
+		ctx:                        cancelCtx,
+		cancelFunc:                 cancelFunc,
+		collections:                collections,
+		n1qlStore:                  n1qlStore,
+		collectionCompleteCallback: callback,
+	}
+}
+
+func (w *DatabaseInitWorker) Run() {
+
+	// Ensure cancelFunc resources are released on normal completion
+	defer func() {
+		if w.cancelFunc != nil {
+			w.cancelFunc()
+		}
+	}()
+
+	// TODO: CBG-2838 refactor initialize indexes to reduce number of system:indexes calls
+	var indexErr error
+	for scName, indexSet := range w.collections {
+		// Add the index set to the common indexOptions
+		collectionIndexOptions := w.options.indexOptions
+		collectionIndexOptions.MetadataIndexes = indexSet
+
+		// TODO: CBG-2838 Refactor InitializeIndexes API to move scope, collection to parameters on system:indexes calls
+		// Set the scope and collection name on the cluster n1ql store for use by initializeIndexes
+		w.n1qlStore.SetScopeAndCollection(scName)
+		keyspaceCtx := base.KeyspaceLogCtx(w.ctx, w.n1qlStore.BucketName(), scName.ScopeName(), scName.CollectionName())
+		indexErr = db.InitializeIndexes(keyspaceCtx, w.n1qlStore, collectionIndexOptions)
+		if indexErr != nil {
+			break
+		}
+
+		// Check for context cancellation after each collection is processed - if cancelled, return cancellation error
+		// to all watchers end exit
+		select {
+		case <-w.ctx.Done():
+			indexErr = errors.New("Database initialization cancelled")
+		default:
+		}
+		if indexErr != nil {
+			break
+		}
+
+		if w.collectionCompleteCallback != nil {
+			w.collectionCompleteCallback(w.dbName, scName.CollectionName())
+		}
+	}
+
+	// On completion (success or error), notify watchers
+	w.watcherLock.Lock()
+	defer w.watcherLock.Unlock()
+	w.lastError = indexErr
+	for _, doneChan := range w.watchers {
+		if indexErr != nil {
+			doneChan <- indexErr
+		}
+		close(doneChan)
+	}
+	w.completed = true
+}
+
+// Adds a watcher for the current worker.  Creates a new notification channel for completion and adds
+// to watcher set.
+func (w *DatabaseInitWorker) addWatcher() (doneChan chan error) {
+	w.watcherLock.Lock()
+	defer w.watcherLock.Unlock()
+	if w.completed {
+		// If the worker has completed while we acquired the lock, return any error and close channel
+		doneChan = make(chan error, 1)
+		if w.lastError != nil {
+			doneChan <- w.lastError
+		}
+		close(doneChan)
+		return doneChan
+	}
+	doneChan = make(chan error, 1)
+	w.watchers = append(w.watchers, doneChan)
+	return doneChan
+}
+
+// Compare collections checks whether the provided CollectionInitData matches the set being
+// initialized by the worker.
+func (w *DatabaseInitWorker) collectionsEqual(newCollectionSet CollectionInitData) bool {
+
+	if len(newCollectionSet) != len(w.collections) {
+		return false
+	}
+
+	for name, indexType := range newCollectionSet {
+		currentType, ok := w.collections[name]
+		if !ok || currentType != indexType {
+			return false
+		}
+	}
+	return true
+}
+
+// Stop cancels the context, which will terminate initialization after the current collection being processed
+func (w *DatabaseInitWorker) Stop() {
+	w.cancelFunc()
+}

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -1,0 +1,537 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"fmt"
+	"log"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatabaseInitManager(t *testing.T) {
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server - requires bootstrap support")
+	}
+
+	// Start SG with no databases
+	config := BootstrapStartupConfigForTest(t)
+	ctx := base.TestCtx(t)
+	sc, err := SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+	}()
+
+	initMgr := sc.DatabaseInitManager
+
+	// Get a test bucket for bootstrap testing, and create dbconfig targeting that bucket
+	tb := base.GetTestBucket(t)
+	defer func() {
+		tb.Close()
+	}()
+	dbName := "dbName"
+	var scopesConfig ScopesConfig
+	if base.TestsUseNamedCollections() {
+		scopesConfig = GetCollectionsConfig(t, tb, 1)
+	}
+	dbConfig := makeDbConfig(tb.GetName(), dbName, scopesConfig)
+
+	// Drop indexes
+	dropAllNonPrimaryIndexes(t, tb.GetSingleDataStore())
+
+	// Async index creation
+	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	select {
+	case <-doneChan:
+		log.Printf("done channel was closed")
+		// continue
+	case <-time.After(10 * time.Second):
+		require.Fail(t, "InitializeDatabase didn't complete in 10s")
+	}
+
+}
+
+// TestDatabaseInitConfigChangeSameCollections tests modifications made to the database config while init is running.
+// Uses initManager callbacks to simulate slow index creation and build.  Tests the following two scenarios:
+//  1. InitalizeDatabase called concurrently for the same collection set, verifies that active init worker is identified and reused
+//  2. InitalizeDatabase called after previous InitalizeDatabase completes - verifies that new init worker is started
+func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
+
+	base.TestRequiresCollections(t)
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server - requires bootstrap support")
+	}
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
+
+	// Start SG with no databases
+	config := BootstrapStartupConfigForTest(t)
+	ctx := base.TestCtx(t)
+	sc, err := SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+	}()
+
+	// Get a test bucket for bootstrap testing, and drop indexes created by bucket pool readier
+	tb := base.GetTestBucket(t)
+	defer func() {
+		tb.Close()
+	}()
+	// Drop all test indexes so we can test InitializeDatabase
+	DropAllTestIndexes(t, tb)
+
+	// Set up collection names and ScopesConfig for testing
+	scopesConfig := GetCollectionsConfig(t, tb, 3)
+	dataStoreNames := GetDataStoreNamesFromScopesConfig(scopesConfig)
+	scopeName := dataStoreNames[0].ScopeName()
+	collection1Name := dataStoreNames[0].CollectionName()
+	collection2Name := dataStoreNames[1].CollectionName()
+	collection1and2ScopesConfig := makeScopesConfig(scopeName, []string{collection1Name, collection2Name})
+
+	initMgr := sc.DatabaseInitManager
+
+	// Use waitChannel to have collectionCallback block, to simulate long-running creation
+	testSignalChannel := make(chan error)
+	singleCollectionInitChannel := make(chan error)
+	expectedCollectionCount := int64(3) // default, collection1, collection2
+	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
+	collectionCount := int64(0)
+	initMgr.collectionCompleteCallback = func(dbName, collectionName string) {
+		log.Printf("Collection complete callback invoked for %s %s", dbName, collectionName)
+		currentCount := atomic.LoadInt64(&collectionCount)
+		if currentCount == 0 {
+			notifyChannel(t, singleCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", collectionName)) // notify the test that indexes have been created for this collection
+			WaitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))             // wait for the test to unblock before proceeding to the next collection
+		}
+		atomic.AddInt64(&collectionCount, 1)
+	}
+
+	dbName := "dbName"
+	dbConfig := makeDbConfig(tb.GetName(), dbName, collection1and2ScopesConfig)
+
+	// Start first async index creation, blocks after first collection
+	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	// Wait for first collection to be initialized
+	WaitForChannel(t, singleCollectionInitChannel, "first collection init")
+
+	// Make a duplicate call to initialize database, should reuse the existing agent
+	duplicateDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	// Unblock collection callback to process all remaining collections
+	close(testSignalChannel)
+
+	// Wait for notification on both done channels
+	WaitForChannel(t, doneChan, "first init done chan")
+	WaitForChannel(t, duplicateDoneChan, "duplicate init done chan")
+
+	// Verify initialization was only run for two collections
+	totalCount := atomic.LoadInt64(&collectionCount)
+	require.Equal(t, expectedCollectionCount, totalCount)
+
+	waitForWorkerDone(t, initMgr, "dbName")
+
+	// Rerun init, should start a new worker for the database and re-verify init for each collection
+	rerunDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
+	require.NoError(t, err)
+	WaitForChannel(t, rerunDoneChan, "repeated init done chan")
+	totalCount = atomic.LoadInt64(&collectionCount)
+	require.Equal(t, expectedCollectionCount*2, totalCount)
+}
+
+// TestDatabaseInitConfigChangeDifferentCollections tests modifications made to the database config while init is running.
+// Uses initManager callbacks to simulate slow index creation and concurrent init requests.  Tests the following scenario:
+//  1. InitalizeDatabase called concurrently with a different collection set, verifies that active init worker is
+//     stopped and a new one is started
+func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
+
+	base.TestRequiresCollections(t)
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server - requires bootstrap support")
+	}
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
+
+	// Start SG with no databases
+	config := BootstrapStartupConfigForTest(t)
+	ctx := base.TestCtx(t)
+	sc, err := SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+	}()
+
+	// Get a test bucket for bootstrap testing, and drop indexes created by bucket pool readier
+	tb := base.GetTestBucket(t)
+	defer func() {
+		tb.Close()
+	}()
+
+	// Drop all test indexes so we can test InitializeDatabase
+	DropAllTestIndexes(t, tb)
+
+	// Set up collection names and ScopesConfig for testing
+	scopesConfig := GetCollectionsConfig(t, tb, 3)
+	dataStoreNames := GetDataStoreNamesFromScopesConfig(scopesConfig)
+	scopeName := dataStoreNames[0].ScopeName()
+	collection1Name := dataStoreNames[0].CollectionName()
+	collection2Name := dataStoreNames[1].CollectionName()
+	collection3Name := dataStoreNames[2].CollectionName()
+	collection1and2ScopesConfig := makeScopesConfig(scopeName, []string{collection1Name, collection2Name})
+	collection1and3ScopesConfig := makeScopesConfig(scopeName, []string{collection1Name, collection3Name})
+
+	initMgr := sc.DatabaseInitManager
+
+	// Use waitChannel to have collectionCallback block, to simulate long-running creation
+	testSignalChannel := make(chan error)
+	firstCollectionInitChannel := make(chan error)
+
+	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
+	collectionCount := int64(0)
+	initMgr.collectionCompleteCallback = func(dbName, collectionName string) {
+		log.Printf("Collection complete callback invoked for %s %s", dbName, collectionName)
+		currentCount := atomic.LoadInt64(&collectionCount)
+		if currentCount == 0 {
+			notifyChannel(t, firstCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", collectionName)) // notify the test that indexes have been created for this collection
+			WaitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))            // wait for the test to unblock before proceeding to the next collection
+		}
+		atomic.AddInt64(&collectionCount, 1)
+	}
+
+	dbName := "dbName"
+	dbConfig := makeDbConfig(tb.GetName(), dbName, collection1and2ScopesConfig)
+
+	// Start first async index creation, should block after first collection
+	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	// Wait for first collection to be initialized
+	WaitForChannel(t, firstCollectionInitChannel, "first collection init")
+
+	// Make a call to initialize database for the same db name, different collections
+	modifiedDbConfig := makeDbConfig(tb.GetName(), dbName, collection1and3ScopesConfig)
+	modifiedDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, modifiedDbConfig.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	// Unblock the first InitializeDatabase, should cancel
+	close(testSignalChannel)
+
+	// Unblock second collection for original invocation
+	cancelErr := waitForError(t, doneChan, "first init cancellation")
+	require.Error(t, cancelErr)
+
+	// Wait for notification on new done channel
+	WaitForChannel(t, modifiedDoneChan, "modified init done chan")
+
+	// Verify initialization was run for four collections (one prior to cancellation, three for subsequent init)
+	totalCount := atomic.LoadInt64(&collectionCount)
+	require.Equal(t, int64(4), totalCount)
+
+}
+
+// TestDatabaseInitConcurrentDatabasesSameBucket tests InitializeDatabase running for multiple databases concurrently.
+// Uses initManager callbacks to simulate slow index creation and concurrent init requests.
+func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
+
+	base.TestRequiresCollections(t)
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server - requires bootstrap support")
+	}
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
+
+	// Start SG with no databases
+	config := BootstrapStartupConfigForTest(t)
+	ctx := base.TestCtx(t)
+	sc, err := SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+	}()
+
+	// Get a test bucket for bootstrap testing, and drop indexes created by bucket pool readier
+	tb := base.GetTestBucket(t)
+	defer func() {
+		tb.Close()
+	}()
+
+	// Drop all test indexes so we can test InitializeDatabase
+	DropAllTestIndexes(t, tb)
+
+	// Set up collection names and ScopesConfig for testing
+	scopesConfig := GetCollectionsConfig(t, tb, 3)
+	dataStoreNames := GetDataStoreNamesFromScopesConfig(scopesConfig)
+	scopeName := dataStoreNames[0].ScopeName()
+	collection1Name := dataStoreNames[0].CollectionName()
+	collection2Name := dataStoreNames[1].CollectionName()
+	collection3Name := dataStoreNames[2].CollectionName()
+	collection1and2ScopesConfig := makeScopesConfig(scopeName, []string{collection1Name, collection2Name})
+	collection3ScopesConfig := makeScopesConfig(scopeName, []string{collection3Name})
+
+	initMgr := sc.DatabaseInitManager
+
+	// Use waitChannel to have collectionCallback block, to simulate long-running creation
+	testSignalChannel := make(chan error)
+	firstCollectionInitChannel := make(chan error)
+
+	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
+	collectionCount := int64(0)
+	initMgr.collectionCompleteCallback = func(dbName, collectionName string) {
+		log.Printf("Collection complete callback invoked for %s %s", dbName, collectionName)
+		currentCount := atomic.LoadInt64(&collectionCount)
+		if currentCount == 0 {
+			notifyChannel(t, firstCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", collectionName)) // notify the test that indexes have been created for this collection
+			WaitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))            // wait for the test to unblock before proceeding to the next collection
+		}
+		atomic.AddInt64(&collectionCount, 1)
+	}
+
+	db1Name := "db1Name"
+	db1Config := makeDbConfig(tb.GetName(), db1Name, collection1and2ScopesConfig)
+
+	db2Name := "db2Name"
+	db2Config := makeDbConfig(tb.GetName(), db2Name, collection3ScopesConfig)
+
+	// Start first async index creation, should block after first collection
+	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, db1Config.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	// Wait for first collection to be initialized
+	WaitForChannel(t, firstCollectionInitChannel, "first collection init")
+
+	// Start second async index creation for db2 while first is still running
+	doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, db2Config.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	// Unblock the first InitializeDatabase, should cancel
+	close(testSignalChannel)
+
+	// Wait for notification on both done channels
+	WaitForChannel(t, doneChan1, "modified init done chan")
+	WaitForChannel(t, doneChan2, "modified init done chan")
+
+	// Verify initialization was run for 5 collections (three for db1, two for db2)
+	totalCount := atomic.LoadInt64(&collectionCount)
+	require.Equal(t, int64(5), totalCount)
+
+}
+
+// TestDatabaseInitConcurrentDatabasesDifferentBuckets tests InitializeDatabase running for multiple databases concurrently.
+// Uses initManager callbacks to simulate slow index creation and concurrent init requests.
+func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
+
+	base.RequireNumTestBuckets(t, 2)
+	base.TestRequiresCollections(t)
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server - requires bootstrap support")
+	}
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
+
+	// Start SG with no databases
+	config := BootstrapStartupConfigForTest(t)
+	ctx := base.TestCtx(t)
+	sc, err := SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+	}()
+
+	// Get two test buckets for bootstrap testing, and drop indexes created by bucket pool readier
+	tb1 := base.GetTestBucket(t)
+	defer func() {
+		tb1.Close()
+	}()
+
+	// Drop all test indexes so we can test InitializeDatabase
+	DropAllTestIndexes(t, tb1)
+
+	// Get two test buckets for bootstrap testing, and drop indexes created by bucket pool readier
+	tb2 := base.GetTestBucket(t)
+	defer func() {
+		tb2.Close()
+	}()
+
+	// Drop all test indexes so we can test InitializeDatabase
+	DropAllTestIndexes(t, tb2)
+
+	// Set up collection names and ScopesConfig for testing - use same collections for both buckets
+	scopesConfig := GetCollectionsConfig(t, tb1, 3)
+	dataStoreNames := GetDataStoreNamesFromScopesConfig(scopesConfig)
+	scopeName := dataStoreNames[0].ScopeName()
+	collection1Name := dataStoreNames[0].CollectionName()
+	collection2Name := dataStoreNames[1].CollectionName()
+	collection1and2ScopesConfig := makeScopesConfig(scopeName, []string{collection1Name, collection2Name})
+
+	initMgr := sc.DatabaseInitManager
+
+	// Use waitChannel to have collectionCallback block, to simulate long-running creation
+	testSignalChannel := make(chan error)
+	firstCollectionInitChannel := make(chan error)
+	databaseCompleteChannel := make(chan error)
+
+	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
+	collectionCount := int64(0)
+	initMgr.collectionCompleteCallback = func(dbName, collectionName string) {
+		log.Printf("Collection complete callback invoked for %s %s", dbName, collectionName)
+		currentCount := atomic.LoadInt64(&collectionCount)
+		if currentCount == 0 {
+			notifyChannel(t, firstCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", collectionName)) // notify the test that indexes have been created for this collection
+			WaitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))            // wait for the test to unblock before proceeding to the next collection
+		}
+		atomic.AddInt64(&collectionCount, 1)
+	}
+	initMgr.databaseCompleteCallback = func(dbName string) {
+		notifyChannel(t, databaseCompleteChannel, "database complete")
+	}
+
+	db1Name := "db1Name"
+	db1Config := makeDbConfig(tb1.GetName(), db1Name, collection1and2ScopesConfig)
+
+	db2Name := "db2Name"
+	db2Config := makeDbConfig(tb2.GetName(), db2Name, collection1and2ScopesConfig)
+
+	// Start first async index creation, should block after first collection
+	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, db1Config.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	// Wait for first collection to be initialized
+	WaitForChannel(t, firstCollectionInitChannel, "first collection init")
+
+	// Start second async index creation for db2 while first is still running
+	doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, db2Config.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	// Unblock the first InitializeDatabase, should cancel
+	close(testSignalChannel)
+
+	// Wait for notification on both done channels
+	WaitForChannel(t, doneChan1, "modified init done chan")
+	WaitForChannel(t, doneChan2, "modified init done chan")
+
+	// Wait for db completion notifications for both databases
+	WaitForChannel(t, databaseCompleteChannel, "database 1 init complete")
+	WaitForChannel(t, databaseCompleteChannel, "database 2 init complete")
+
+	// Verify initialization was run for 6 collections (three for db1, three for db2)
+	totalCount := atomic.LoadInt64(&collectionCount)
+	require.Equal(t, int64(6), totalCount)
+
+}
+
+// TestDatabaseInitTeardownTiming tests scenarios where InitializeDatabase is called during
+// the completion phase of a previous async initialization.  Ensures there are no cases where a
+// watcher is added but never receives a done notification.
+func TestDatabaseInitTeardownTiming(t *testing.T) {
+
+	base.TestRequiresCollections(t)
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server - requires bootstrap support")
+	}
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
+
+	// Start SG with no databases
+	config := BootstrapStartupConfigForTest(t)
+	ctx := base.TestCtx(t)
+	sc, err := SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+	}()
+
+	// Get a test bucket for bootstrap testing, and drop indexes created by bucket pool readier
+	tb := base.GetTestBucket(t)
+	defer func() {
+		tb.Close()
+	}()
+
+	// Drop all test indexes so we can test InitializeDatabase
+	DropAllTestIndexes(t, tb)
+
+	// Set up collection names and ScopesConfig for testing
+	scopesConfig := GetCollectionsConfig(t, tb, 3)
+	dataStoreNames := GetDataStoreNamesFromScopesConfig(scopesConfig)
+	scopeName := dataStoreNames[0].ScopeName()
+	collection1Name := dataStoreNames[0].CollectionName()
+	collection2Name := dataStoreNames[1].CollectionName()
+	collection1and2ScopesConfig := makeScopesConfig(scopeName, []string{collection1Name, collection2Name})
+
+	initMgr := sc.DatabaseInitManager
+
+	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
+	collectionCount := int64(0)
+	initMgr.collectionCompleteCallback = func(dbName, collectionName string) {
+		atomic.AddInt64(&collectionCount, 1)
+	}
+	dbName := "dbName"
+	dbConfig := makeDbConfig(tb.GetName(), dbName, collection1and2ScopesConfig)
+
+	var doneChan2 chan error
+	databaseCompleteCount := int64(0)
+	initMgr.databaseCompleteCallback = func(dbName string) {
+		// On first completion, invoke InitializeDatabase with the same collection set post-completion
+		currentCount := atomic.LoadInt64(&databaseCompleteCount)
+		if currentCount == 0 {
+			log.Printf("invoking InitializeDatabase again during teardown")
+			var err error
+			doneChan2, err = initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
+			require.NoError(t, err)
+		}
+		atomic.AddInt64(&databaseCompleteCount, 1)
+
+	}
+
+	// Start first async index creation, should block after first collection
+	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
+	require.NoError(t, err)
+
+	WaitForChannel(t, doneChan1, "done chan 1")
+	WaitForChannel(t, doneChan2, "done chan 2")
+
+	// Verify initialization was run for 3 collections only
+	totalCollectionInitCount := atomic.LoadInt64(&collectionCount)
+	require.Equal(t, int64(3), totalCollectionInitCount)
+
+	// Expect only a single database complete callback, since init should only have been run once.
+	totalDbCompleteCount := atomic.LoadInt64(&databaseCompleteCount)
+	require.Equal(t, int64(1), totalDbCompleteCount)
+
+}
+
+func makeScopesConfig(scopeName string, collectionNames []string) ScopesConfig {
+
+	collectionsConfig := make(CollectionsConfig)
+	for _, collectionName := range collectionNames {
+		collectionsConfig[collectionName] = CollectionConfig{}
+	}
+	return ScopesConfig{
+		scopeName: ScopeConfig{
+			Collections: collectionsConfig,
+		},
+	}
+}
+
+// waitForWorkerDone avoids races when testing db initializations performed serially
+func waitForWorkerDone(t *testing.T, manager *DatabaseInitManager, dbName string) {
+	for i := 0; i < 1000; i++ {
+		if !manager.HasActiveInitialization(dbName) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("Worker did not complete in expected time interval for db %s", dbName)
+}

--- a/rest/handler_config_database.go
+++ b/rest/handler_config_database.go
@@ -84,7 +84,7 @@ func (h *handler) mutateDbConfig(mutator func(*DbConfig) error) error {
 		defer h.server.lock.Unlock()
 
 		// TODO: Dynamic update instead of reload
-		if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+		if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 			return err
 		}
 		h.setEtag(updatedDbConfig.Version)

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -10,10 +10,16 @@ package indextest
 
 import (
 	"encoding/json"
+	"fmt"
+	"log"
 	"net/http"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/rest"
 	"github.com/stretchr/testify/require"
 )
@@ -106,4 +112,614 @@ func TestSyncGatewayStartupIndexes(t *testing.T) {
 		require.Equal(t, roles, responseRoles)
 	})
 
+}
+
+// TestAsyncInitializeIndexes creates a database and simulates slow index creation (using collectionCompleteCallback).
+// Verifies that offline operations can be performed successfully.
+func TestAsyncInitializeIndexes(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+	base.TestRequiresCollections(t)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP)
+
+	serverErr := make(chan error, 0)
+
+	// Start SG with no databases
+	ctx := base.TestCtx(t)
+	config := rest.BootstrapStartupConfigForTest(t)
+	sc, err := rest.SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+		require.NoError(t, <-serverErr)
+	}()
+
+	go func() {
+		serverErr <- rest.StartServer(ctx, &config, sc)
+	}()
+	require.NoError(t, sc.WaitForRESTAPIs())
+
+	// Set testing callbacks for async initialization
+	collectionCount := int64(0)
+	initStarted := make(chan error)
+	unblockInit := make(chan error)
+	collectionCompleteCallback := func(dbName, collectionName string) {
+		count := atomic.AddInt64(&collectionCount, 1)
+		// On first collection, close initStarted channel
+		log.Printf("collection callback count: %v", count)
+		if count == 1 {
+			log.Printf("closing initStarted")
+			close(initStarted)
+		}
+		rest.WaitForChannel(t, unblockInit, "waiting for test to unblock initialization")
+	}
+	sc.DatabaseInitManager.SetCallbacks(collectionCompleteCallback, nil)
+
+	// Get a test bucket, and use it to create the database.
+	tb := base.GetTestBucket(t)
+	defer func() { tb.Close() }()
+
+	importFilter := "function(doc) { return true }"
+	syncFunc := "function(doc){ channel(doc.channels); }"
+
+	dbConfig := makeDbConfig(t, tb, syncFunc, importFilter)
+	dbConfig.StartOffline = base.BoolPtr(true)
+	dbConfigPayload, err := json.Marshal(dbConfig)
+	require.NoError(t, err)
+	dbName := "db"
+
+	keyspace := dbName
+	if len(dbConfig.Scopes) > 0 {
+		keyspaces := getRESTKeyspaces(dbName, dbConfig.Scopes)
+		keyspace = keyspaces[0]
+	}
+
+	// Persist config
+	resp := rest.BootstrapAdminRequest(t, http.MethodPut, "/"+dbName+"/", string(dbConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+
+	// Wait for init to start before interacting with the db
+	rest.WaitForChannel(t, initStarted, "waiting for initialization to start")
+	log.Printf("initialization started")
+
+	// Get config values before taking db offline
+	resp = rest.BootstrapAdminRequest(t, http.MethodGet, "/"+dbName+"/_config", "")
+	resp.RequireStatus(http.StatusOK)
+	dbConfigBeforeOffline := resp.Body
+
+	// Modify import filter and sync function while index init is pending/blocked
+	resp = rest.BootstrapAdminRequest(t, http.MethodGet, "/"+keyspace+"/_config/import_filter", "")
+	resp.RequireResponse(http.StatusOK, importFilter)
+
+	resp = rest.BootstrapAdminRequest(t, http.MethodGet, "/"+keyspace+"/_config/sync", "")
+	resp.RequireResponse(http.StatusOK, syncFunc)
+
+	// Check values are updated
+	resp = rest.BootstrapAdminRequest(t, http.MethodGet, "/"+dbName+"/_config", "")
+	resp.RequireResponse(http.StatusOK, dbConfigBeforeOffline)
+
+	resp = rest.BootstrapAdminRequest(t, http.MethodGet, "/"+keyspace+"/_config/import_filter", "")
+	resp.RequireResponse(http.StatusOK, importFilter)
+
+	resp = rest.BootstrapAdminRequest(t, http.MethodGet, "/"+keyspace+"/_config/sync", "")
+	resp.RequireResponse(http.StatusOK, syncFunc)
+
+	// unblock initialization
+	log.Printf("closing unblockInit")
+	close(unblockInit)
+
+	// Bring the database online
+	dbConfig.StartOffline = base.BoolPtr(false)
+	dbOnlineConfigPayload, err := json.Marshal(dbConfig)
+	require.NoError(t, err)
+	resp = rest.BootstrapAdminRequest(t, http.MethodPut, "/"+dbName+"/_config", string(dbOnlineConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+
+	// wait for db to come online
+	waitAndRequireDBState(t, dbName, db.DBOnline)
+
+}
+
+// TestAsyncInitWithResync verifies that resync can run successfully while async index initialization is in progress.
+// Handles the case where data has been migrated between buckets but index doesn't yet exist in new bucket.
+//  1. Creates a database, writes documents via SG to generate metadata
+//  2. Deletes the database
+//  3. Manually drops indexes
+//  4. Recreates the database with blocking callback for index initialization
+//  5. Runs resync while init is blocked/in progress
+func TestAsyncInitWithResync(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	base.TestRequiresCollections(t)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP)
+
+	serverErr := make(chan error, 0)
+
+	// Start SG with no databases
+	ctx := base.TestCtx(t)
+	config := rest.BootstrapStartupConfigForTest(t)
+	sc, err := rest.SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+		require.NoError(t, <-serverErr)
+	}()
+
+	go func() {
+		serverErr <- rest.StartServer(ctx, &config, sc)
+	}()
+	require.NoError(t, sc.WaitForRESTAPIs())
+
+	// Seed the bucket with some documents
+	tb := base.GetTestBucket(t)
+	defer func() { tb.Close() }()
+
+	syncFunc := "function(doc){ channel(doc.channel1); }"
+	dbConfig := makeDbConfig(t, tb, syncFunc, "")
+	dbConfig.StartOffline = base.BoolPtr(false)
+	dbConfigPayload, err := json.Marshal(dbConfig)
+	require.NoError(t, err)
+	dbName := "db"
+
+	docCollection, err := base.AsCollection(tb.GetSingleDataStore())
+	require.NoError(t, err)
+	keyspace := dbName + "." + docCollection.ScopeName() + "." + docCollection.CollectionName()
+
+	// Persist config
+	resp := rest.BootstrapAdminRequest(t, http.MethodPut, "/"+dbName+"/", string(dbConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+	waitAndRequireDBState(t, dbName, db.DBOnline)
+
+	for i := 0; i < 5; i++ {
+		docID := fmt.Sprintf("doc%d", i)
+		docBody := `{"channel1":["ABC"], "channel2":["DEF"]}`
+		resp := rest.BootstrapAdminRequest(t, http.MethodPut, "/"+keyspace+"/"+docID, docBody)
+		resp.RequireStatus(http.StatusCreated)
+	}
+
+	// Delete the database
+	resp = rest.BootstrapAdminRequest(t, http.MethodDelete, "/"+dbName+"/", "")
+	resp.RequireStatus(http.StatusOK)
+
+	rest.DropAllTestIndexes(t, tb)
+
+	// Set testing callbacks for async initialization
+
+	collectionCount := int64(0)
+	initStarted := make(chan error)
+	unblockInit := make(chan error)
+	collectionCompleteCallback := func(dbName, collectionName string) {
+		count := atomic.AddInt64(&collectionCount, 1)
+		// On first collection, close initStarted channel
+		log.Printf("collection callback count: %v", count)
+		if count == 1 {
+			log.Printf("closing initStarted")
+			close(initStarted)
+		}
+		rest.WaitForChannel(t, unblockInit, "waiting for test to unblock initialization")
+	}
+	sc.DatabaseInitManager.SetCallbacks(collectionCompleteCallback, nil)
+	// Recreate the database with offline=true and a modified sync function
+	syncFunc = "function(doc){ channel(doc.channel2);}"
+	dbConfig = makeDbConfig(t, tb, syncFunc, "")
+	dbConfig.StartOffline = base.BoolPtr(true)
+	dbConfigPayload, err = json.Marshal(dbConfig)
+	require.NoError(t, err)
+
+	// Recreate database
+	resp = rest.BootstrapAdminRequest(t, http.MethodPut, "/"+dbName+"/", string(dbConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+
+	// Wait for init to start before calling resync
+	rest.WaitForChannel(t, initStarted, "waiting for initialization to start")
+	log.Printf("initialization started")
+
+	// Start resync
+	resyncPayload := rest.ResyncPostReqBody{}
+	resyncPayload.Scope = db.ResyncCollections{
+		docCollection.ScopeName(): []string{docCollection.CollectionName()},
+	}
+	payloadBytes, err := json.Marshal(resyncPayload)
+	require.NoError(t, err)
+
+	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/"+dbName+"/_resync", string(payloadBytes))
+	resp.RequireStatus(http.StatusOK)
+
+	// Wait for resync to complete
+	waitAndRequireDBState(t, dbName, db.DBOffline)
+
+	// verify raw documents in the bucket to validate that resync ran before db came online
+	for i := 0; i < 5; i++ {
+		docID := fmt.Sprintf("doc%d", i)
+		requireActiveChannel(t, docCollection, docID, "DEF")
+	}
+
+	// unblock initialization
+	log.Printf("closing unblockInit")
+	close(unblockInit)
+
+	// Bring the database online
+	dbConfig.StartOffline = base.BoolPtr(false)
+	dbOnlineConfigPayload, err := json.Marshal(dbConfig)
+	require.NoError(t, err)
+	resp = rest.BootstrapAdminRequest(t, http.MethodPut, "/"+dbName+"/_config", string(dbOnlineConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+
+	// wait for db to come online
+	waitAndRequireDBState(t, dbName, db.DBOnline)
+
+}
+
+// TestAsyncOnlineOffline verifies that a database that has been brought online can be taken offline
+// while async index initialization is still in progress
+func TestAsyncOnlineOffline(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	base.TestRequiresCollections(t)
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP)
+
+	serverErr := make(chan error, 0)
+
+	// Start SG with no databases
+	ctx := base.TestCtx(t)
+	config := rest.BootstrapStartupConfigForTest(t)
+	sc, err := rest.SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+		require.NoError(t, <-serverErr)
+	}()
+
+	go func() {
+		serverErr <- rest.StartServer(ctx, &config, sc)
+	}()
+	require.NoError(t, sc.WaitForRESTAPIs())
+
+	// Set testing callbacks for async initialization
+	collectionCount := int64(0)
+	initStarted := make(chan error)
+	unblockInit := make(chan error)
+	collectionCompleteCallback := func(dbName, collectionName string) {
+		count := atomic.AddInt64(&collectionCount, 1)
+		// On first collection, close initStarted channel
+		log.Printf("collection callback count: %v", count)
+		if count == 1 {
+			log.Printf("closing initStarted")
+			close(initStarted)
+		}
+		rest.WaitForChannel(t, unblockInit, "waiting for test to unblock initialization")
+	}
+	sc.DatabaseInitManager.SetCallbacks(collectionCompleteCallback, nil)
+
+	// Get a test bucket, and use it to create the database.
+	tb := base.GetTestBucket(t)
+	defer func() { tb.Close() }()
+
+	importFilter := "function(doc) { return true }"
+	syncFunc := "function(doc){ channel(doc.channels); }"
+
+	dbConfig := makeDbConfig(t, tb, syncFunc, importFilter)
+	dbConfig.StartOffline = base.BoolPtr(true)
+	dbConfigPayload, err := json.Marshal(dbConfig)
+	require.NoError(t, err)
+	dbName := "db"
+
+	keyspace := dbName
+	expectedCollectionCount := 1 // metadata store
+	if len(dbConfig.Scopes) > 0 {
+		keyspaces := getRESTKeyspaces(dbName, dbConfig.Scopes)
+		keyspace = keyspaces[0]
+		expectedCollectionCount += len(keyspaces)
+	}
+
+	// Create database with offline=true
+	resp := rest.BootstrapAdminRequest(t, http.MethodPut, "/"+dbName+"/", string(dbConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+
+	// Wait for init to start before interacting with the db, validate db state is offline
+	rest.WaitForChannel(t, initStarted, "waiting for initialization to start")
+	log.Printf("initialization started")
+	waitAndRequireDBState(t, dbName, db.DBOffline)
+
+	// Set up payloads for upserting db state
+	onlineConfigUpsert := rest.DbConfig{
+		StartOffline: base.BoolPtr(false),
+	}
+	dbOnlineConfigPayload, err := json.Marshal(onlineConfigUpsert)
+	require.NoError(t, err)
+
+	offlineConfigUpsert := rest.DbConfig{
+		StartOffline: base.BoolPtr(true),
+	}
+	dbOfflineConfigPayload, err := json.Marshal(offlineConfigUpsert)
+	require.NoError(t, err)
+
+	// Take the database online while async init is still in progress, verify state goes to Starting
+	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/"+dbName+"/_config", string(dbOnlineConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+	waitAndRequireDBState(t, dbName, db.DBStarting)
+
+	// Take the database offline while async init is still in progress
+	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/"+dbName+"/_config", string(dbOfflineConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+	waitAndRequireDBState(t, dbName, db.DBOffline)
+
+	// Verify offline changes can still be made
+	resp = rest.BootstrapAdminRequest(t, http.MethodGet, "/"+keyspace+"/_config/sync", "")
+	resp.RequireResponse(http.StatusOK, syncFunc)
+
+	// Take the database back online while async init is still in progress, verify state goes to Starting
+	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/"+dbName+"/_config", string(dbOnlineConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+	waitAndRequireDBState(t, dbName, db.DBStarting)
+
+	// Unblock initialization, verify status goes to Online
+	close(unblockInit)
+	waitAndRequireDBState(t, dbName, db.DBOnline)
+
+	// Verify only four collections were initialized (offline/online didn't trigger duplicate initialization)
+	totalCount := atomic.LoadInt64(&collectionCount)
+	require.Equal(t, int64(expectedCollectionCount), totalCount)
+
+	// Take database back offline after init complete
+	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/"+dbName+"/_config", string(dbOfflineConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+	waitAndRequireDBState(t, dbName, db.DBOffline)
+
+	// Take database back online after init complete, verify successful
+	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/"+dbName+"/_config", string(dbOnlineConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+	waitAndRequireDBState(t, dbName, db.DBOnline)
+
+}
+
+// TestAsyncCreateThenDelete verifies that async initialization of a database will be terminated
+// if the database is deleted.  Also verifies that recreating the database succeeds as expected.
+func TestAsyncCreateThenDelete(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+	base.TestRequiresCollections(t)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP)
+	serverErr := make(chan error, 0)
+
+	// Start SG with no databases
+	ctx := base.TestCtx(t)
+	config := rest.BootstrapStartupConfigForTest(t)
+	sc, err := rest.SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+		require.NoError(t, <-serverErr)
+	}()
+
+	go func() {
+		serverErr <- rest.StartServer(ctx, &config, sc)
+	}()
+	require.NoError(t, sc.WaitForRESTAPIs())
+
+	// Set testing callbacks for async initialization
+	collectionCount := int64(0)
+	initStarted := make(chan error)
+	unblockInit := make(chan error)
+	collectionCompleteCallback := func(dbName, collectionName string) {
+		count := atomic.AddInt64(&collectionCount, 1)
+		// On first collection, close initStarted channel
+		log.Printf("collection callback count: %v", count)
+		if count == 1 {
+			log.Printf("closing initStarted")
+			close(initStarted)
+		}
+		rest.WaitForChannel(t, unblockInit, "waiting for test to unblock initialization")
+	}
+	firstDatabaseComplete := make(chan error)
+	databaseCompleteCount := int64(0)
+	databaseCompleteCallback := func(dbName string) {
+		count := atomic.AddInt64(&databaseCompleteCount, 1)
+		// on first complete, close test channel
+		if count == 1 {
+			close(firstDatabaseComplete)
+		}
+	}
+	sc.DatabaseInitManager.SetCallbacks(collectionCompleteCallback, databaseCompleteCallback)
+
+	// Get a test bucket, and use it to create the database.
+	tb := base.GetTestBucket(t)
+	defer func() { tb.Close() }()
+
+	importFilter := "function(doc) { return true }"
+	syncFunc := "function(doc){ channel(doc.channels); }"
+
+	dbConfig := makeDbConfig(t, tb, syncFunc, importFilter)
+	dbConfig.StartOffline = base.BoolPtr(true)
+	dbConfigPayload, err := json.Marshal(dbConfig)
+	require.NoError(t, err)
+	dbName := "db"
+	expectedCollectionCount := 1 // metadata store
+	if len(dbConfig.Scopes) > 0 {
+		keyspaces := getRESTKeyspaces(dbName, dbConfig.Scopes)
+		expectedCollectionCount += len(keyspaces)
+	}
+
+	// Set up payloads for upserting db state
+	onlineConfigUpsert := rest.DbConfig{
+		StartOffline: base.BoolPtr(false),
+	}
+	dbOnlineConfigPayload, err := json.Marshal(onlineConfigUpsert)
+	require.NoError(t, err)
+
+	// Create database with offline=true
+	resp := rest.BootstrapAdminRequest(t, http.MethodPut, "/"+dbName+"/", string(dbConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+
+	// Wait for init to start before interacting with the db, validate db state is offline
+	rest.WaitForChannel(t, initStarted, "waiting for initialization to start")
+	waitAndRequireDBState(t, dbName, db.DBOffline)
+
+	// Take the database online while async init is still in progress, verify state goes to Starting
+	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/"+dbName+"/_config", string(dbOnlineConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+	waitAndRequireDBState(t, dbName, db.DBStarting)
+
+	// Delete the database before unblocking init
+	resp = rest.BootstrapAdminRequest(t, http.MethodDelete, "/"+dbName+"/", "")
+	resp.RequireStatus(http.StatusOK)
+
+	// verify not found
+	resp = rest.BootstrapAdminRequest(t, http.MethodGet, "/"+dbName+"/", "")
+	resp.RequireStatus(http.StatusNotFound)
+
+	close(unblockInit)
+
+	rest.WaitForChannel(t, firstDatabaseComplete, "waiting for database complete callback")
+
+	// Verify only one collection was initialized asynchronously (in-progress when database was deleted)
+	totalCount := atomic.LoadInt64(&collectionCount)
+	require.Equal(t, int64(1), totalCount)
+
+	// Recreate the database, then bring online
+	resp = rest.BootstrapAdminRequest(t, http.MethodPut, "/"+dbName+"/", string(dbConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+	waitAndRequireDBState(t, dbName, db.DBOffline)
+
+	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/"+dbName+"/_config", string(dbOnlineConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+	waitAndRequireDBState(t, dbName, db.DBOnline)
+
+	// Verify all collections are initialized (1 from deleted run, plus full expected set)
+	totalCount = atomic.LoadInt64(&collectionCount)
+	require.Equal(t, int64(expectedCollectionCount+1), totalCount)
+}
+
+// TestSyncOnline verifies that a database that is created with startOffline=false doesn't trigger async initialization
+func TestSyncOnline(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	base.TestRequiresCollections(t)
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP)
+
+	serverErr := make(chan error, 0)
+
+	// Start SG with no databases
+	ctx := base.TestCtx(t)
+	config := rest.BootstrapStartupConfigForTest(t)
+	sc, err := rest.SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+		require.NoError(t, <-serverErr)
+	}()
+
+	go func() {
+		serverErr <- rest.StartServer(ctx, &config, sc)
+	}()
+	require.NoError(t, sc.WaitForRESTAPIs())
+
+	// Set testing callbacks for async initialization
+	collectionCount := int64(0)
+	collectionCompleteCallback := func(dbName, collectionName string) {
+		_ = atomic.AddInt64(&collectionCount, 1)
+	}
+	sc.DatabaseInitManager.SetCallbacks(collectionCompleteCallback, nil)
+
+	// Get a test bucket, and use it to create the database.
+	tb := base.GetTestBucket(t)
+	defer func() { tb.Close() }()
+
+	importFilter := "function(doc) { return true }"
+	syncFunc := "function(doc){ channel(doc.channels); }"
+
+	dbConfig := makeDbConfig(t, tb, syncFunc, importFilter)
+	dbConfig.StartOffline = base.BoolPtr(false)
+	dbConfigPayload, err := json.Marshal(dbConfig)
+	require.NoError(t, err)
+	dbName := "db"
+
+	// Create database with offline=false
+	resp := rest.BootstrapAdminRequest(t, http.MethodPut, "/"+dbName+"/", string(dbConfigPayload))
+	resp.RequireStatus(http.StatusCreated)
+
+	// Verify online
+	waitAndRequireDBState(t, dbName, db.DBOnline)
+
+	// Verify no collections were initialized asynchronously
+	totalCount := atomic.LoadInt64(&collectionCount)
+	require.Equal(t, int64(0), totalCount)
+
+}
+
+func makeDbConfig(t *testing.T, tb *base.TestBucket, syncFunction string, importFilter string) rest.DbConfig {
+
+	scopesConfig := rest.GetCollectionsConfig(t, tb, 3)
+	for scopeName, scope := range scopesConfig {
+		for collectionName, _ := range scope.Collections {
+			collectionConfig := rest.CollectionConfig{}
+			if syncFunction != "" {
+				collectionConfig.SyncFn = &syncFunction
+			}
+			if importFilter != "" {
+				collectionConfig.ImportFilter = &importFilter
+			}
+			scopesConfig[scopeName].Collections[collectionName] = collectionConfig
+		}
+	}
+	bucketName := tb.GetName()
+	numIndexReplicas := uint(0)
+	enableXattrs := base.TestUseXattrs()
+
+	dbConfig := rest.DbConfig{
+		BucketConfig: rest.BucketConfig{
+			Bucket: &bucketName,
+		},
+		NumIndexReplicas: &numIndexReplicas,
+		EnableXattrs:     &enableXattrs,
+		Scopes:           scopesConfig,
+	}
+	return dbConfig
+}
+
+func getRESTKeyspaces(dbName string, scopesConfig rest.ScopesConfig) []string {
+	keyspaces := make([]string, 0)
+	for scopeName, scope := range scopesConfig {
+		for collectionName, _ := range scope.Collections {
+			keyspaces = append(keyspaces, strings.Join([]string{dbName, scopeName, collectionName}, base.ScopeCollectionSeparator))
+		}
+	}
+	return keyspaces
+}
+
+// waitAndRequireDBState issues BootstrapAdminRequests to monitor db state
+func waitAndRequireDBState(t *testing.T, dbName string, targetState uint32) {
+	// wait for db to come online
+	var stateCurr string
+	for i := 0; i < 100; i++ {
+		var dbRootResponse rest.DatabaseRoot
+		resp := rest.BootstrapAdminRequest(t, http.MethodGet, "/"+dbName+"/", "")
+		resp.Unmarshal(&dbRootResponse)
+		stateCurr = dbRootResponse.State
+		if stateCurr == db.RunStateString[targetState] {
+			break
+		}
+		log.Printf("Waiting for state %s, current state %s", db.RunStateString[targetState], stateCurr)
+		time.Sleep(500 * time.Millisecond)
+	}
+	require.Equal(t, db.RunStateString[targetState], stateCurr)
+}
+
+func requireActiveChannel(t *testing.T, dataStore base.DataStore, key string, channelName string) {
+	xattr := db.SyncData{}
+	_, err := dataStore.GetWithXattr(key, base.SyncXattrName, "", nil, &xattr, nil)
+	require.NoError(t, err, "Error Getting Xattr as sync data")
+	channel, ok := xattr.Channels[channelName]
+	require.True(t, ok)
+	require.True(t, channel == nil)
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -500,27 +500,18 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	}
 
 	// initDataStore is a function to initialize Views or GSI indexes for a datastore
-	initDataStore := func(ds base.DataStore, metadataIndexes db.CollectionIndexesType, verifySyncInfo bool) (resyncRequired bool, err error) {
-
-		// If this collection uses syncInfo, verify the collection isn't associated with a different database's metadataID
-		if verifySyncInfo {
-			resyncRequired, err = base.InitSyncInfo(ds, config.MetadataID)
-			if err != nil {
-				return true, err
-			}
-		}
-
+	initDataStore := func(ds base.DataStore, metadataIndexes db.CollectionIndexesType) (err error) {
 		if useViews {
 			viewErr := db.InitializeViews(ctx, ds)
 			if viewErr != nil {
-				return false, viewErr
+				return viewErr
 			}
-			return resyncRequired, nil
+			return nil
 		}
 
 		gsiSupported := bucket.IsSupported(sgbucket.BucketStoreFeatureN1ql)
 		if !gsiSupported {
-			return false, errors.New("Sync Gateway was unable to connect to a query node on the provided Couchbase Server cluster.  Ensure a query node is accessible, or set 'use_views':true in Sync Gateway's database config.")
+			return errors.New("Sync Gateway was unable to connect to a query node on the provided Couchbase Server cluster.  Ensure a query node is accessible, or set 'use_views':true in Sync Gateway's database config.")
 		}
 
 		numReplicas := DefaultNumIndexReplicas
@@ -529,7 +520,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		}
 		n1qlStore, ok := base.AsN1QLStore(ds)
 		if !ok {
-			return false, errors.New("Cannot create indexes on non-Couchbase data store.")
+			return errors.New("Cannot create indexes on non-Couchbase data store.")
 
 		}
 		options := db.InitializeIndexOptions{
@@ -541,15 +532,15 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		}
 		dsName, ok := base.AsDataStoreName(ds)
 		if !ok {
-			return false, fmt.Errorf("Could not get datastore name from %s", base.MD(ds.GetName()))
+			return fmt.Errorf("Could not get datastore name from %s", base.MD(ds.GetName()))
 		}
 		ctx := base.KeyspaceLogCtx(ctx, bucket.GetName(), dsName.ScopeName(), dsName.CollectionName())
 		indexErr := db.InitializeIndexes(ctx, n1qlStore, options)
 		if indexErr != nil {
-			return false, indexErr
+			return indexErr
 		}
 
-		return resyncRequired, nil
+		return nil
 	}
 
 	collectionsRequiringResync := make([]base.ScopeAndCollectionName, 0)
@@ -589,28 +580,37 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 					hasDefaultCollection = true
 					metadataIndexOption = db.IndexesAll
 				}
-				requiresResync, err := initDataStore(dataStore, metadataIndexOption, true)
+
+				// Verify whether the collection is associated with a different database's metadataID - if so, add to set requiring resync
+				resyncRequired, err := base.InitSyncInfo(dataStore, config.MetadataID)
 				if err != nil {
 					return nil, err
 				}
-				if requiresResync {
+				if resyncRequired {
 					collectionsRequiringResync = append(collectionsRequiringResync, base.ScopeAndCollectionName{Scope: scopeName, Collection: collectionName})
+				}
+
+				if err := initDataStore(dataStore, metadataIndexOption); err != nil {
+					return nil, err
 				}
 			}
 		}
 		if !hasDefaultCollection {
-			if _, err := initDataStore(bucket.DefaultDataStore(), db.IndexesMetadataOnly, false); err != nil {
+			if err := initDataStore(bucket.DefaultDataStore(), db.IndexesMetadataOnly); err != nil {
 				return nil, err
 			}
 		}
 	} else {
 		// no scopes configured - init the default data store
-		requiresResync, err := initDataStore(bucket.DefaultDataStore(), db.IndexesAll, true)
+		resyncRequired, err := base.InitSyncInfo(bucket.DefaultDataStore(), config.MetadataID)
 		if err != nil {
 			return nil, err
 		}
-		if requiresResync {
+		if resyncRequired {
 			collectionsRequiringResync = append(collectionsRequiringResync, base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: base.DefaultCollection})
+		}
+		if err := initDataStore(bucket.DefaultDataStore(), db.IndexesAll); err != nil {
+			return nil, err
 		}
 	}
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -61,15 +61,16 @@ type ServerContext struct {
 	statsContext                  *statsContext
 	BootstrapContext              *bootstrapContext
 	HTTPClient                    *http.Client
-	cpuPprofFileMutex             sync.Mutex      // Protect cpuPprofFile from concurrent Start and Stop CPU profiling requests
-	cpuPprofFile                  *os.File        // An open file descriptor holds the reference during CPU profiling
-	_httpServers                  []*http.Server  // A list of HTTP servers running under the ServerContext
-	GoCBAgent                     *gocbcore.Agent // GoCB Agent to use when obtaining management endpoints
-	NoX509HTTPClient              *http.Client    // httpClient for the cluster that doesn't include x509 credentials, even if they are configured for the cluster
-	hasStarted                    chan struct{}   // A channel that is closed via PostStartup once the ServerContext has fully started
-	LogContextID                  string          // ID to differentiate log messages from different server context
-	fetchConfigsLastUpdate        time.Time       // The last time fetchConfigsWithTTL() updated dbConfigs
-	allowScopesInPersistentConfig bool            // Test only backdoor to allow scopes in persistent config, not supported for multiple databases with different collections targeting the same bucket
+	cpuPprofFileMutex             sync.Mutex           // Protect cpuPprofFile from concurrent Start and Stop CPU profiling requests
+	cpuPprofFile                  *os.File             // An open file descriptor holds the reference during CPU profiling
+	_httpServers                  []*http.Server       // A list of HTTP servers running under the ServerContext
+	GoCBAgent                     *gocbcore.Agent      // GoCB Agent to use when obtaining management endpoints
+	NoX509HTTPClient              *http.Client         // httpClient for the cluster that doesn't include x509 credentials, even if they are configured for the cluster
+	hasStarted                    chan struct{}        // A channel that is closed via PostStartup once the ServerContext has fully started
+	LogContextID                  string               // ID to differentiate log messages from different server context
+	fetchConfigsLastUpdate        time.Time            // The last time fetchConfigsWithTTL() updated dbConfigs
+	allowScopesInPersistentConfig bool                 // Test only backdoor to allow scopes in persistent config, not supported for multiple databases with different collections targeting the same bucket
+	DatabaseInitManager           *DatabaseInitManager // Manages database initialization (index creation and readiness) independent of database stop/start/reload, when using persistent config
 }
 
 // defaultConfigRetryTimeout is the total retry time when waiting for in-flight config updates.  Set as a multiple of kv op timeout,
@@ -88,6 +89,7 @@ type getOrAddDatabaseConfigOptions struct {
 	useExisting       bool            //  if true, return an existing DatabaseContext vs return an error
 	connectToBucketFn db.OpenBucketFn // supply a custom function for buckets, used for testing only
 	forceOnline       bool            // force the database to come online, even if startOffline is set
+	asyncOnline       bool            // Whether getOrAddDatabaseConfig should block until database is ready, when startOffline=false
 }
 
 func (sc *ServerContext) CreateLocalDatabase(ctx context.Context, dbs DbConfigMap) error {
@@ -142,6 +144,10 @@ func NewServerContext(ctx context.Context, config *StartupConfig, persistentConf
 			sc.Config.API.AdminInterfaceAuthentication = base.BoolPtr(false)
 			sc.Config.API.MetricsInterfaceAuthentication = base.BoolPtr(false)
 		}
+	}
+
+	if sc.persistentConfig {
+		sc.DatabaseInitManager = &DatabaseInitManager{}
 	}
 
 	sc.startStatsLogger(ctx)
@@ -365,17 +371,18 @@ func (sc *ServerContext) ReloadDatabase(ctx context.Context, reloadDbName string
 	return dbContext, err
 }
 
-func (sc *ServerContext) ReloadDatabaseWithConfig(nonContextStruct base.NonCancellableContext, config DatabaseConfig) error {
+func (sc *ServerContext) ReloadDatabaseWithConfig(nonContextStruct base.NonCancellableContext, config DatabaseConfig, asyncOnline bool) error {
 	sc.lock.Lock()
 	defer sc.lock.Unlock()
-	return sc._reloadDatabaseWithConfig(nonContextStruct.Ctx, config, true)
+	return sc._reloadDatabaseWithConfig(nonContextStruct.Ctx, config, true, asyncOnline)
 }
 
-func (sc *ServerContext) _reloadDatabaseWithConfig(ctx context.Context, config DatabaseConfig, failFast bool) error {
+func (sc *ServerContext) _reloadDatabaseWithConfig(ctx context.Context, config DatabaseConfig, failFast bool, asyncOnline bool) error {
 	sc._removeDatabase(ctx, config.Name)
 	_, err := sc._getOrAddDatabaseFromConfig(ctx, config, getOrAddDatabaseConfigOptions{
 		useExisting: false,
 		failFast:    failFast,
+		asyncOnline: asyncOnline,
 	})
 	return err
 }
@@ -499,8 +506,16 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		useViews = true
 	}
 
+	type indexInitData struct {
+		scopeAndCollection base.ScopeAndCollectionName
+		indexSet           db.CollectionIndexesType
+		datastore          base.DataStore
+	}
+
+	collectionsRequiringIndexes := make([]indexInitData, 0)
+
 	// initDataStore is a function to initialize Views or GSI indexes for a datastore
-	initDataStore := func(ds base.DataStore, metadataIndexes db.CollectionIndexesType) (err error) {
+	initDataStore := func(ds base.DataStore, metadataIndexes db.CollectionIndexesType, name base.ScopeAndCollectionName) (err error) {
 		if useViews {
 			viewErr := db.InitializeViews(ctx, ds)
 			if viewErr != nil {
@@ -509,37 +524,12 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 			return nil
 		}
 
-		gsiSupported := bucket.IsSupported(sgbucket.BucketStoreFeatureN1ql)
-		if !gsiSupported {
-			return errors.New("Sync Gateway was unable to connect to a query node on the provided Couchbase Server cluster.  Ensure a query node is accessible, or set 'use_views':true in Sync Gateway's database config.")
+		indexInit := indexInitData{
+			scopeAndCollection: name,
+			indexSet:           metadataIndexes,
+			datastore:          ds,
 		}
-
-		numReplicas := DefaultNumIndexReplicas
-		if config.NumIndexReplicas != nil {
-			numReplicas = *config.NumIndexReplicas
-		}
-		n1qlStore, ok := base.AsN1QLStore(ds)
-		if !ok {
-			return errors.New("Cannot create indexes on non-Couchbase data store.")
-
-		}
-		options := db.InitializeIndexOptions{
-			FailFast:        false,
-			NumReplicas:     numReplicas,
-			Serverless:      sc.Config.IsServerless(),
-			MetadataIndexes: metadataIndexes,
-			UseXattrs:       config.UseXattrs(),
-		}
-		dsName, ok := base.AsDataStoreName(ds)
-		if !ok {
-			return fmt.Errorf("Could not get datastore name from %s", base.MD(ds.GetName()))
-		}
-		ctx := base.KeyspaceLogCtx(ctx, bucket.GetName(), dsName.ScopeName(), dsName.CollectionName())
-		indexErr := db.InitializeIndexes(ctx, n1qlStore, options)
-		if indexErr != nil {
-			return indexErr
-		}
-
+		collectionsRequiringIndexes = append(collectionsRequiringIndexes, indexInit)
 		return nil
 	}
 
@@ -586,17 +576,17 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 				if err != nil {
 					return nil, err
 				}
+				scName := base.ScopeAndCollectionName{Scope: scopeName, Collection: collectionName}
 				if resyncRequired {
-					collectionsRequiringResync = append(collectionsRequiringResync, base.ScopeAndCollectionName{Scope: scopeName, Collection: collectionName})
+					collectionsRequiringResync = append(collectionsRequiringResync, scName)
 				}
-
-				if err := initDataStore(dataStore, metadataIndexOption); err != nil {
+				if err := initDataStore(dataStore, metadataIndexOption, scName); err != nil {
 					return nil, err
 				}
 			}
 		}
 		if !hasDefaultCollection {
-			if err := initDataStore(bucket.DefaultDataStore(), db.IndexesMetadataOnly); err != nil {
+			if err := initDataStore(bucket.DefaultDataStore(), db.IndexesMetadataOnly, base.DefaultScopeAndCollectionName()); err != nil {
 				return nil, err
 			}
 		}
@@ -609,8 +599,58 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		if resyncRequired {
 			collectionsRequiringResync = append(collectionsRequiringResync, base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: base.DefaultCollection})
 		}
-		if err := initDataStore(bucket.DefaultDataStore(), db.IndexesAll); err != nil {
+		if err := initDataStore(bucket.DefaultDataStore(), db.IndexesAll, base.DefaultScopeAndCollectionName()); err != nil {
 			return nil, err
+		}
+	}
+
+	startOffline := base.BoolDefault(config.StartOffline, false)
+	var dbInitDoneChan chan error
+	// Initialize any required indexes
+	if len(collectionsRequiringIndexes) > 0 {
+		gsiSupported := bucket.IsSupported(sgbucket.BucketStoreFeatureN1ql)
+		if !gsiSupported {
+			return nil, errors.New("Sync Gateway was unable to connect to a query node on the provided Couchbase Server cluster.  Ensure a query node is accessible, or set 'use_views':true in Sync Gateway's database config.")
+		}
+
+		// If database has been requested to start offline, or there's an active async initialization, use async initialization
+		// DatabaseInitManager will be nil if persistent config is not being used.
+		if sc.DatabaseInitManager != nil && (startOffline || sc.DatabaseInitManager.HasActiveInitialization(dbName)) {
+			// Initialize indexes asynchronously using DatabaseInitManager.
+			dbInitDoneChan, err = sc.DatabaseInitManager.InitializeDatabase(ctx, sc.Config, &config)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			// Initialize indexes as a blocking, synchronous operation using per-collection N1QL store
+			numReplicas := DefaultNumIndexReplicas
+			if config.NumIndexReplicas != nil {
+				numReplicas = *config.NumIndexReplicas
+			}
+
+			for _, indexInfo := range collectionsRequiringIndexes {
+				ds := indexInfo.datastore
+				n1qlStore, ok := base.AsN1QLStore(ds)
+				if !ok {
+					return nil, errors.New("Cannot create indexes on non-Couchbase data store.")
+				}
+				options := db.InitializeIndexOptions{
+					FailFast:        false,
+					NumReplicas:     numReplicas,
+					Serverless:      sc.Config.IsServerless(),
+					MetadataIndexes: indexInfo.indexSet,
+					UseXattrs:       config.UseXattrs(),
+				}
+				dsName, ok := base.AsDataStoreName(ds)
+				if !ok {
+					return nil, fmt.Errorf("Could not get datastore name from %s", base.MD(ds.GetName()))
+				}
+				ctx := base.KeyspaceLogCtx(ctx, bucket.GetName(), dsName.ScopeName(), dsName.CollectionName())
+				indexErr := db.InitializeIndexes(ctx, n1qlStore, options)
+				if indexErr != nil {
+					return nil, indexErr
+				}
+			}
 		}
 	}
 
@@ -769,19 +809,10 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	dbcontext.AllowEmptyPassword = base.BoolDefault(config.AllowEmptyPassword, false)
 	dbcontext.ServeInsecureAttachmentTypes = base.BoolDefault(config.ServeInsecureAttachmentTypes, false)
 
-	// Create default users & roles:
-	if err := sc.installPrincipals(ctx, dbcontext, config.Roles, "role"); err != nil {
-		return nil, err
-	}
-	if err := sc.installPrincipals(ctx, dbcontext, config.Users, "user"); err != nil {
-		return nil, err
-	}
-
-	if config.Guest != nil {
-		guest := map[string]*auth.PrincipalConfig{base.GuestUsername: config.Guest}
-		if err := sc.installPrincipals(ctx, dbcontext, guest, "user"); err != nil {
-			return nil, err
-		}
+	dbcontext.Options.ConfigPrincipals = &db.ConfigPrincipals{
+		Users: config.Users,
+		Roles: config.Roles,
+		Guest: config.Guest,
 	}
 
 	// Initialize event handlers
@@ -805,7 +836,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 
 	stateChangeMsg := "DB loaded from config"
 
-	startOffline := base.BoolDefault(config.StartOffline, false)
 	needsResync := len(dbcontext.RequireResync) > 0
 
 	if needsResync || (startOffline && !options.forceOnline) {
@@ -819,14 +849,77 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		return dbcontext, nil
 	}
 
-	atomic.StoreUint32(&dbcontext.State, db.DBOnline)
-	_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "online", stateChangeMsg, &sc.Config.API.AdminInterface)
+	// If asyncOnline wasn't specified, block until db init is completed, then start online processes
+	if !options.asyncOnline || dbInitDoneChan == nil {
+		base.DebugfCtx(ctx, base.KeyConfig, "Waiting for database init to complete...")
+		if dbInitDoneChan != nil {
+			initError := <-dbInitDoneChan
+			if initError != nil {
+				return nil, initError
+			}
+		}
+		base.DebugfCtx(ctx, base.KeyConfig, "Database init completed, starting online processes")
+		if err := dbcontext.StartOnlineProcesses(ctx); err != nil {
+			return nil, err
+		}
+		atomic.StoreUint32(&dbcontext.State, db.DBOnline)
+		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "online", stateChangeMsg, &sc.Config.API.AdminInterface)
+		return dbcontext, nil
+	} else {
+		// If asyncOnline is requested, set state to Starting and spawn a separate goroutine to wait for init completion
+		// before going online
+		base.DebugfCtx(ctx, base.KeyConfig, "Waiting for database init to complete asynchonously...")
+		atomic.StoreUint32(&dbcontext.State, db.DBStarting)
+		nonCancelCtx := base.NewNonCancelCtxForDatabase(dbName)
+		go sc.asyncDatabaseOnline(nonCancelCtx, dbcontext, dbInitDoneChan, config.Version)
+		return dbcontext, nil
+	}
+}
 
-	if err := dbcontext.StartOnlineProcesses(ctx); err != nil {
-		return nil, err
+// asyncDatabaseOnline waits for async initialization to complete (based on doneChan).  On successful completion, brings the database online.
+// Checks to ensure the database config hasn't been updated while waiting for init to complete - if that happens, doesn't attempt to bring
+// db online (it may have been set to offline=true)
+func (sc *ServerContext) asyncDatabaseOnline(nonCancelCtx base.NonCancellableContext, dbc *db.DatabaseContext, doneChan chan error, version string) {
+
+	ctx := nonCancelCtx.Ctx
+	if doneChan != nil {
+		initError := <-doneChan
+		if initError != nil {
+			base.WarnfCtx(ctx, "Async database init returned error: %v", initError)
+			atomic.CompareAndSwapUint32(&dbc.State, db.DBStarting, db.DBOffline)
+			return
+		}
 	}
 
-	return dbcontext, nil
+	// Before bringing the database online, ensure that the database hasn't been modified while we waited for initialization to complete
+	currentDbVersion := sc.GetDbVersion(dbc.Name)
+	if currentDbVersion != version {
+		base.InfofCtx(ctx, base.KeyConfig, "Database version changed while waiting for async init - cancelling obsolete online request. Old version: %s New version: %s", version, currentDbVersion)
+		atomic.CompareAndSwapUint32(&dbc.State, db.DBStarting, db.DBOffline)
+		return
+	}
+
+	base.DebugfCtx(ctx, base.KeyConfig, "Async database initialization complete, starting online processes...")
+	err := dbc.StartOnlineProcesses(ctx)
+	if err != nil {
+		base.InfofCtx(ctx, base.KeyAll, "Error starting online processes after async initialization: %v", err)
+		atomic.CompareAndSwapUint32(&dbc.State, db.DBStarting, db.DBOffline)
+	}
+
+	stateChangeMsg := "DB loaded from config"
+	atomic.StoreUint32(&dbc.State, db.DBOnline)
+	_ = dbc.EventMgr.RaiseDBStateChangeEvent(dbc.Name, "online", stateChangeMsg, &sc.Config.API.AdminInterface)
+
+}
+
+func (sc *ServerContext) GetDbVersion(dbName string) string {
+	sc.lock.RLock()
+	defer sc.lock.RUnlock()
+	currentDbConfig, ok := sc.dbConfigs[dbName]
+	if !ok {
+		return ""
+	}
+	return currentDbConfig.Version
 }
 
 // getJavascriptTimeout returns the duration javascript functions can run.
@@ -1273,9 +1366,16 @@ func (sc *ServerContext) processEventHandlersForEvent(ctx context.Context, event
 	return nil
 }
 
+// RemoveDatabase is called when an external request is made to delete the database
 func (sc *ServerContext) RemoveDatabase(ctx context.Context, dbName string) bool {
 	sc.lock.Lock()
 	defer sc.lock.Unlock()
+
+	// If async init is running for the database, cancel it for an external remove.  (cannot be
+	// done in _removeDatabase, as this is called during reload)
+	if sc.DatabaseInitManager != nil && sc.DatabaseInitManager.HasActiveInitialization(dbName) {
+		sc.DatabaseInitManager.Cancel(dbName)
+	}
 
 	return sc._removeDatabase(ctx, dbName)
 }
@@ -1298,6 +1398,7 @@ func (sc *ServerContext) _removeDatabase(ctx context.Context, dbName string) boo
 	if dbCtx == nil {
 		return false
 	}
+
 	if ok := sc._unloadDatabase(ctx, dbName); !ok {
 		return ok
 	}
@@ -1391,58 +1492,6 @@ func (sc *ServerContext) _unsuspendDatabase(ctx context.Context, dbName string) 
 	return nil, base.ErrNotFound
 }
 
-func (sc *ServerContext) installPrincipals(ctx context.Context, dbc *db.DatabaseContext, spec map[string]*auth.PrincipalConfig, what string) error {
-	for name, princ := range spec {
-		isGuest := name == base.GuestUsername
-		if isGuest {
-			internalName := ""
-			princ.Name = &internalName
-		} else {
-			n := name
-			princ.Name = &n
-		}
-
-		createdPrincipal := true
-		worker := func() (shouldRetry bool, err error, value interface{}) {
-			_, err = dbc.UpdatePrincipal(ctx, princ, (what == "user"), isGuest)
-			if err != nil {
-				if status, _ := base.ErrorAsHTTPStatus(err); status == http.StatusConflict {
-					// Ignore and absorb this error if it's a conflict error, which just means that updatePrincipal didn't overwrite an existing user.
-					// Since if there's an existing user it's "mission accomplished", this can be treated as a success case.
-					createdPrincipal = false
-					return false, nil, nil
-				}
-
-				if err == base.ErrViewTimeoutError {
-					// Timeout error, possibly due to view re-indexing, so retry
-					base.InfofCtx(ctx, base.KeyAuth, "Error calling UpdatePrincipal(): %v.  Will retry in case this is a temporary error", err)
-					return true, err, nil
-				}
-
-				// Unexpected error, return error don't retry
-				return false, err, nil
-			}
-
-			// No errors, assume it worked
-			return false, nil, nil
-
-		}
-
-		err, _ := base.RetryLoop("installPrincipals", worker, base.CreateDoublingSleeperFunc(16, 10))
-		if err != nil {
-			return err
-		}
-
-		if isGuest {
-			base.InfofCtx(ctx, base.KeyAll, "Reset guest user to config")
-		} else if createdPrincipal {
-			base.InfofCtx(ctx, base.KeyAll, "Created %s %q", what, base.UD(name))
-		}
-
-	}
-	return nil
-}
-
 // ////// STATS LOGGING
 
 type statsWrapper struct {
@@ -1531,7 +1580,10 @@ func (sc *ServerContext) updateCalculatedStats() {
 	sc.lock.RLock()
 	defer sc.lock.RUnlock()
 	for _, dbContext := range sc.databases_ {
-		dbContext.UpdateCalculatedStats()
+		dbState := atomic.LoadUint32(&dbContext.State)
+		if dbState == db.DBOnline {
+			dbContext.UpdateCalculatedStats()
+		}
 	}
 
 }
@@ -1878,6 +1930,7 @@ func (sc *ServerContext) initializeCouchbaseServerConnections(ctx context.Contex
 		return err
 	}
 	sc.GoCBAgent = goCBAgent
+	//sc.DatabaseInitManager.cluster = goCBAgent.
 
 	sc.NoX509HTTPClient, err = sc.initializeNoX509HttpClient()
 	if err != nil {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2486,3 +2486,26 @@ func (rt *RestTester) NewDbConfig() DbConfig {
 
 	return config
 }
+
+func DropAllTestIndexes(t *testing.T, tb *base.TestBucket) {
+	dropAllNonPrimaryIndexes(t, tb.GetMetadataStore())
+
+	dsNames := tb.GetNonDefaultDatastoreNames()
+	for i := 0; i < len(dsNames); i++ {
+		ds, err := tb.GetNamedDataStore(i)
+		require.NoError(t, err)
+		dropAllNonPrimaryIndexes(t, ds)
+	}
+}
+
+// Calls DropAllIndexes to remove all indexes, then restores the primary index for TestBucketPool readier requirements
+func dropAllNonPrimaryIndexes(t *testing.T, dataStore base.DataStore) {
+
+	n1qlStore, ok := base.AsN1QLStore(dataStore)
+	require.True(t, ok)
+	ctx := base.TestCtx(t)
+	dropErr := base.DropAllIndexes(ctx, n1qlStore)
+	require.NoError(t, dropErr)
+	err := n1qlStore.CreatePrimaryIndex(base.PrimaryIndexName, nil)
+	require.NoError(t, err, "Unable to recreate primary index")
+}

--- a/rest/utilities_testing_async.go
+++ b/rest/utilities_testing_async.go
@@ -1,0 +1,73 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestChannelTimeout can be increased to support step-through debugging
+const TestChannelTimeout = 30 * time.Second
+
+func WaitForChannel(t *testing.T, ch <-chan error, message string) {
+	if message != "" {
+		log.Printf("[%s] starting wait", message)
+		defer func() {
+			log.Printf("[%s] completed wait", message)
+		}()
+	}
+	select {
+	case err := <-ch:
+		if err != nil {
+			require.Fail(t, fmt.Sprintf("[%s] channel returned error: %v", message, err))
+		}
+		return
+	case <-time.After(TestChannelTimeout):
+		require.Fail(t, fmt.Sprintf("[%s] expected channel message did not arrive in %v", message, TestChannelTimeout))
+	}
+}
+
+func waitForError(t *testing.T, ch <-chan error, message string) error {
+	if message != "" {
+		log.Printf("[%s] starting wait for error", message)
+		defer func() {
+			log.Printf("[%s] completed wait for error", message)
+		}()
+	}
+	select {
+	case err := <-ch:
+		if err == nil {
+			require.Fail(t, "[%s] Received non-error message on channel", message)
+		}
+		return err
+	case <-time.After(TestChannelTimeout):
+		require.Fail(t, fmt.Sprintf("[%s] expected error message did not arrive in %v", message, TestChannelTimeout))
+		return nil
+	}
+}
+
+func notifyChannel(t *testing.T, ch chan<- error, message string) {
+	if message != "" {
+		log.Printf("[%s] starting notify", message)
+		defer func() {
+			log.Printf("[%s] completed notify", message)
+		}()
+	}
+	select {
+	case ch <- nil:
+		return
+	case <-time.After(TestChannelTimeout):
+		require.Fail(t, fmt.Sprintf("[%s] unable to send channel notification within 10s", message))
+	}
+}

--- a/rest/utilities_testing_bootstrap.go
+++ b/rest/utilities_testing_bootstrap.go
@@ -79,6 +79,11 @@ func (r *bootstrapAdminResponse) RequireResponse(status int, body string) {
 	require.Equal(r.t, body, r.Body, "unexpected body")
 }
 
+func (r *bootstrapAdminResponse) Unmarshal(v interface{}) {
+	err := base.JSONUnmarshal([]byte(r.Body), &v)
+	require.NoError(r.t, err, "Error unmarshalling bootstrap response body")
+}
+
 func BootstrapAdminRequest(t *testing.T, method, path, body string) bootstrapAdminResponse {
 	return doBootstrapAdminRequest(t, method, "", path, body, nil)
 }


### PR DESCRIPTION
CBG-3041
(Backports CBG-2837)

When a database is started in offline mode, allows offline REST endpoints to be used while index initialization occurs asynchronously.

When the database is taken online, blocks until initialization is complete.

Changes to the collection set while offline will cancel and restart the async initialization with the updated set.

Initialization creation status is not persisted, as we want to validate index existence on every database startup.  If async processing completes, any subsequent database start/reload will check for index existence in the usual way (checking system:indexes).

When modifying a database config to bring the cluster online (via startOffline=false) via a config update, the PUT/POST config request shouldn't block if async initialization is running.

First-time creation of a database with startOffline=false will continue to run synchronously, to preserve existing behaviour.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-1.19.5/14/
