### PR TITLE
(backport 3.1.1) CBG-3130 notify on request plus unused sequence docs (#6326)

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -33,6 +33,8 @@ const (
 	DefaultCachePendingSeqMaxWait = 5 * time.Second  // Max time we'll wait for a pending sequence before sending to missed queue
 	DefaultSkippedSeqMaxWait      = 60 * time.Minute // Max time we'll wait for an entry in the missing before purging
 	QueryTombstoneBatch           = 250              // Max number of tombstones checked per query during Compact
+	unusedSeqKey                  = "_unusedSeqKey"  // Key used by ChangeWaiter to mark unused sequences
+	unusedSeqCollectionID         = 0                // Collection ID used by ChangeWaiter to mark unused sequences
 )
 
 // Enable keeping a channel-log for the "*" channel (channel.UserStarChannel). The only time this channel is needed is if
@@ -547,6 +549,13 @@ func (c *changeCache) releaseUnusedSequence(sequence uint64, timeReceived time.T
 	// Since processEntry may unblock pending sequences, if there were any changed channels we need
 	// to notify any change listeners that are working changes feeds for these channels
 	changedChannels := c.processEntry(change)
+	unusedSeq := channels.NewID(unusedSeqKey, unusedSeqCollectionID)
+	if changedChannels == nil {
+		changedChannels = channels.SetOfNoValidate(unusedSeq)
+	} else {
+		changedChannels.Add(unusedSeq)
+	}
+	c.channelCache.AddSkippedSequence(change)
 	if c.notifyChange != nil && len(changedChannels) > 0 {
 		c.notifyChange(changedChannels)
 	}

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -574,7 +574,7 @@ func TestChannelCacheBufferingWithUserDoc(t *testing.T) {
 	// Start wait for doc in ABC
 	chans := channels.SetOfNoValidate(
 		channels.NewID("ABC", collectionID))
-	waiter := db.mutationListener.NewWaiterWithChannels(chans, nil)
+	waiter := db.mutationListener.NewWaiterWithChannels(chans, nil, false)
 
 	successChan := make(chan bool)
 	go func() {

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -44,6 +44,9 @@ type ChannelCache interface {
 	// Notifies the cache of a principal update.  Updates the cache's high sequence
 	AddPrincipal(change *LogEntry)
 
+	// Notifies the cache of a skipped sequence update. Updates the cache's high sequence
+	AddSkippedSequence(change *LogEntry)
+
 	// Remove purges the given doc IDs from all channel caches and returns the number of items removed.
 	Remove(collectionID uint32, docIDs []string, startTime time.Time) (count int)
 
@@ -183,6 +186,11 @@ func (c *channelCacheImpl) getSingleChannelCache(ch channels.ID) (SingleChannelC
 }
 
 func (c *channelCacheImpl) AddPrincipal(change *LogEntry) {
+	c.updateHighCacheSequence(change.Sequence)
+}
+
+// AddSkipedSequence notifies the cache of a skipped sequence update. Updates the cache's high sequence
+func (c *channelCacheImpl) AddSkippedSequence(change *LogEntry) {
 	c.updateHighCacheSequence(change.Sequence)
 }
 

--- a/rest/changes_request_plus_test.go
+++ b/rest/changes_request_plus_test.go
@@ -1,0 +1,66 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/channels"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRequirePlusSkippedSequence makes sure that a final skipped sequence in a request_plus request will not hang the request
+func TestRequestPlusSkippedSequence(t *testing.T) {
+
+	defer db.SuspendSequenceBatching()()
+	restTesterConfig := RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction}
+
+	// JWT claim based grants do not support named collections
+	rt := NewRestTester(t, &restTesterConfig)
+	defer rt.Close()
+
+	const (
+		username = "alice"
+		channel  = "foo"
+	)
+	rt.CreateUser(username, []string{channel})
+
+	// add a single document for the user
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", fmt.Sprintf(`{"channels":"%s"}`, channel))
+	RequireStatus(t, resp, http.StatusCreated)
+	docSeq := rt.GetDocumentSequence("doc1")
+
+	require.NoError(t, rt.WaitForPendingChanges())
+
+	// add an unused sequence
+	unusedSeq, err := db.AllocateTestSequence(rt.GetDatabase())
+	require.NoError(t, err)
+
+	caughtUpCount := rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplCaughtUp.Value()
+
+	requestFinished := make(chan struct{})
+	// make sure this request doesn't hang
+	go func() {
+		resp = rt.SendUserRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d&request_plus=true", docSeq), "", username)
+		RequireStatus(t, resp, http.StatusOK)
+		close(requestFinished)
+	}()
+	require.NoError(t, rt.GetDatabase().WaitForCaughtUp(caughtUpCount+1))
+	// the request should finish once the sequence is released
+	err = db.ReleaseTestSequence(rt.GetDatabase(), unusedSeq)
+	require.NoError(t, err)
+	<-requestFinished
+	var changesResp ChangesResults
+	require.NoError(t, json.Unmarshal(resp.BodyBytes(), &changesResp))
+	require.Len(t, changesResp.Results, 0)
+}


### PR DESCRIPTION
Clean cherry-pick of 2c804dc43

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-1.19.5/13/
