### PR TITLE
(3.1.1 backport) CBG-3108 don't log non SG indexes (#6317)

### DIFF
--- a/base/cluster_n1ql.go
+++ b/base/cluster_n1ql.go
@@ -64,24 +64,24 @@ func (cl *ClusterOnlyN1QLStore) BucketName() string {
 	return cl.bucketName
 }
 
-func (cl *ClusterOnlyN1QLStore) BuildDeferredIndexes(indexSet []string) error {
-	return BuildDeferredIndexes(cl, indexSet)
+func (cl *ClusterOnlyN1QLStore) BuildDeferredIndexes(ctx context.Context, indexSet []string) error {
+	return BuildDeferredIndexes(ctx, cl, indexSet)
 }
 
-func (cl *ClusterOnlyN1QLStore) CreateIndex(indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
-	return CreateIndex(cl, indexName, expression, filterExpression, options)
+func (cl *ClusterOnlyN1QLStore) CreateIndex(ctx context.Context, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
+	return CreateIndex(ctx, cl, indexName, expression, filterExpression, options)
 }
 
-func (cl *ClusterOnlyN1QLStore) CreatePrimaryIndex(indexName string, options *N1qlIndexOptions) error {
-	return CreatePrimaryIndex(cl, indexName, options)
+func (cl *ClusterOnlyN1QLStore) CreatePrimaryIndex(ctx context.Context, indexName string, options *N1qlIndexOptions) error {
+	return CreatePrimaryIndex(ctx, cl, indexName, options)
 }
 
 func (cl *ClusterOnlyN1QLStore) ExplainQuery(statement string, params map[string]interface{}) (plan map[string]interface{}, err error) {
 	return ExplainQuery(cl, statement, params)
 }
 
-func (cl *ClusterOnlyN1QLStore) DropIndex(indexName string) error {
-	return DropIndex(cl, indexName)
+func (cl *ClusterOnlyN1QLStore) DropIndex(ctx context.Context, indexName string) error {
+	return DropIndex(ctx, cl, indexName)
 }
 
 // IndexMetaKeyspaceID returns the value of keyspace_id for the system:indexes table for the collection.
@@ -190,12 +190,12 @@ func (cl *ClusterOnlyN1QLStore) runQuery(statement string, n1qlOptions *gocb.Que
 	return queryResults, err
 }
 
-func (cl *ClusterOnlyN1QLStore) WaitForIndexesOnline(indexNames []string, failfast bool) error {
-	return WaitForIndexesOnline(cl.cluster, cl.bucketName, cl.scopeName, cl.collectionName, indexNames, failfast)
+func (cl *ClusterOnlyN1QLStore) WaitForIndexesOnline(ctx context.Context, indexNames []string, failfast bool) error {
+	return WaitForIndexesOnline(ctx, cl.cluster, cl.bucketName, cl.scopeName, cl.collectionName, indexNames, failfast)
 }
 
-func (cl *ClusterOnlyN1QLStore) GetIndexMeta(indexName string) (exists bool, meta *IndexMeta, err error) {
-	return GetIndexMeta(cl, indexName)
+func (cl *ClusterOnlyN1QLStore) GetIndexMeta(ctx context.Context, indexName string) (exists bool, meta *IndexMeta, err error) {
+	return GetIndexMeta(ctx, cl, indexName)
 }
 
 func (cl *ClusterOnlyN1QLStore) IsErrNoResults(err error) bool {

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -117,31 +117,30 @@ func (c *Collection) ExplainQuery(statement string, params map[string]interface{
 	return ExplainQuery(c, statement, params)
 }
 
-func (c *Collection) CreateIndex(indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
-	return CreateIndex(c, indexName, expression, filterExpression, options)
+func (c *Collection) CreateIndex(ctx context.Context, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
+	return CreateIndex(ctx, c, indexName, expression, filterExpression, options)
 }
 
-func (c *Collection) CreatePrimaryIndex(indexName string, options *N1qlIndexOptions) error {
-	return CreatePrimaryIndex(c, indexName, options)
+func (c *Collection) CreatePrimaryIndex(ctx context.Context, indexName string, options *N1qlIndexOptions) error {
+	return CreatePrimaryIndex(ctx, c, indexName, options)
 }
 
-// WaitForIndexesOnline takes set of indexes and watches them till they're online.
-func (c *Collection) WaitForIndexesOnline(indexNames []string, failfast bool) error {
-	return WaitForIndexesOnline(c.Bucket.cluster, c.BucketName(), c.ScopeName(), c.CollectionName(), indexNames, failfast)
+func (c *Collection) WaitForIndexesOnline(ctx context.Context, indexNames []string, failfast bool) error {
+	return WaitForIndexesOnline(ctx, c.Bucket.cluster, c.BucketName(), c.ScopeName(), c.CollectionName(), indexNames, failfast)
 }
 
-func (c *Collection) GetIndexMeta(indexName string) (exists bool, meta *IndexMeta, err error) {
-	return GetIndexMeta(c, indexName)
+func (c *Collection) GetIndexMeta(ctx context.Context, indexName string) (exists bool, meta *IndexMeta, err error) {
+	return GetIndexMeta(ctx, c, indexName)
 }
 
 // DropIndex drops the specified index from the current bucket.
-func (c *Collection) DropIndex(indexName string) error {
-	return DropIndex(c, indexName)
+func (c *Collection) DropIndex(ctx context.Context, indexName string) error {
+	return DropIndex(ctx, c, indexName)
 }
 
 // Issues a build command for any deferred sync gateway indexes associated with the bucket.
-func (c *Collection) BuildDeferredIndexes(indexSet []string) error {
-	return BuildDeferredIndexes(c, indexSet)
+func (c *Collection) BuildDeferredIndexes(ctx context.Context, indexSet []string) error {
+	return BuildDeferredIndexes(ctx, c, indexSet)
 }
 
 func (b *GocbV2Bucket) runQuery(statement string, n1qlOptions *gocb.QueryOptions) (*gocb.QueryResult, error) {

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -359,10 +359,10 @@ func DropAllIndexes(ctx context.Context, n1QLStore N1QLStore) error {
 			defer wg.Done()
 
 			InfofCtx(ctx, KeySGTest, "Dropping index %s on bucket %s...", indexToDrop, n1QLStore.GetName())
-			dropErr := n1QLStore.DropIndex(indexToDrop)
+			dropErr := n1QLStore.DropIndex(ctx, indexToDrop)
 			if dropErr != nil {
 				// Retry dropping index if first try fails before returning error
-				dropRetry := n1QLStore.DropIndex(indexToDrop)
+				dropRetry := n1QLStore.DropIndex(ctx, indexToDrop)
 				if dropRetry != nil {
 					asyncErrors <- dropErr
 					ErrorfCtx(ctx, "...failed to drop index %s on bucket %s: %s", indexToDrop, n1QLStore.GetName(), dropErr)

--- a/db/database.go
+++ b/db/database.go
@@ -767,7 +767,7 @@ func (dbCtx *DatabaseContext) RemoveObsoleteIndexes(ctx context.Context, preview
 			errs = errs.Append(errors.New(err))
 			continue
 		}
-		collectionRemovedIndexes, err := removeObsoleteIndexes(n1qlStore, previewOnly, dbCtx.UseXattrs(), dbCtx.UseViews(), sgIndexes)
+		collectionRemovedIndexes, err := removeObsoleteIndexes(ctx, n1qlStore, previewOnly, dbCtx.UseXattrs(), dbCtx.UseViews(), sgIndexes)
 		if err != nil {
 			errs = errs.Append(err)
 			continue

--- a/db/functions/function_test.go
+++ b/db/functions/function_test.go
@@ -684,12 +684,13 @@ func setupTestDBForBucketWithOptions(t testing.TB, tBucket base.Bucket, dbcOptio
 
 // createPrimaryIndex returns true if there was no index created before
 func createPrimaryIndex(t *testing.T, n1qlStore base.N1QLStore) bool {
-	hasPrimary, _, err := base.GetIndexMeta(n1qlStore, base.PrimaryIndexName)
+	ctx := base.TestCtx(t)
+	hasPrimary, _, err := base.GetIndexMeta(ctx, n1qlStore, base.PrimaryIndexName)
 	assert.NoError(t, err)
 	if hasPrimary {
 		return false
 	}
-	err = n1qlStore.CreatePrimaryIndex(base.PrimaryIndexName, nil)
+	err = n1qlStore.CreatePrimaryIndex(ctx, base.PrimaryIndexName, nil)
 	assert.NoError(t, err)
 	return true
 }

--- a/db/functions/graphql_test.go
+++ b/db/functions/graphql_test.go
@@ -439,7 +439,7 @@ func TestUserGraphQLWithN1QL(t *testing.T) {
 
 	if createdPrimaryIdx {
 		defer func() {
-			err := n1qlStore.DropIndex(base.PrimaryIndexName)
+			err := n1qlStore.DropIndex(base.TestCtx(t), base.PrimaryIndexName)
 			require.NoError(t, err)
 		}()
 

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -153,19 +153,19 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	require.NoError(t, err)
 
 	// Running w/ opposite xattrs flag should preview removal of the indexes associated with this db context
-	removedIndexes, removeErr := removeObsoleteIndexes(n1qlStore, true, !db.UseXattrs(), db.UseViews(), sgIndexes)
+	removedIndexes, removeErr := removeObsoleteIndexes(ctx, n1qlStore, true, !db.UseXattrs(), db.UseViews(), sgIndexes)
 	sort.Strings(removedIndexes)
 	require.EqualValues(t, expectedRemovedIndexes, removedIndexes)
 	require.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in preview mode")
 
 	// Running again w/ preview=false to perform cleanup
-	removedIndexes, removeErr = removeObsoleteIndexes(n1qlStore, false, !db.UseXattrs(), db.UseViews(), sgIndexes)
+	removedIndexes, removeErr = removeObsoleteIndexes(ctx, n1qlStore, false, !db.UseXattrs(), db.UseViews(), sgIndexes)
 	sort.Strings(removedIndexes)
 	require.Equal(t, expectedRemovedIndexes, removedIndexes)
 	require.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in non-preview mode")
 
 	// One more time to make sure they are actually gone
-	removedIndexes, removeErr = removeObsoleteIndexes(n1qlStore, false, !db.UseXattrs(), db.UseViews(), sgIndexes)
+	removedIndexes, removeErr = removeObsoleteIndexes(ctx, n1qlStore, false, !db.UseXattrs(), db.UseViews(), sgIndexes)
 	require.Len(t, removedIndexes, 0)
 	require.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in post-cleanup no-op")
 
@@ -199,7 +199,7 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	copiedIndexes := copySGIndexes(sgIndexes)
 
 	// Validate that removeObsoleteIndexes is a no-op for the default case
-	removedIndexes, removeErr := removeObsoleteIndexes(n1qlStore, true, db.UseXattrs(), db.UseViews(), copiedIndexes)
+	removedIndexes, removeErr := removeObsoleteIndexes(ctx, n1qlStore, true, db.UseXattrs(), db.UseViews(), copiedIndexes)
 	log.Printf("removedIndexes: %+v", removedIndexes)
 	assert.Equal(t, 0, len(removedIndexes))
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in no-op case")
@@ -216,7 +216,7 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	copiedIndexes[IndexAccess] = accessIndex
 
 	// Validate that removeObsoleteIndexes now triggers removal of one index
-	removedIndexes, removeErr = removeObsoleteIndexes(n1qlStore, true, db.UseXattrs(), db.UseViews(), copiedIndexes)
+	removedIndexes, removeErr = removeObsoleteIndexes(ctx, n1qlStore, true, db.UseXattrs(), db.UseViews(), copiedIndexes)
 	log.Printf("removedIndexes: %+v", removedIndexes)
 	assert.Equal(t, 1, len(removedIndexes))
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes with hacked sgIndexes")
@@ -352,11 +352,11 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 		}
 	}
 
-	removedIndexes, removeErr := removeObsoleteIndexes(n1QLStore, false, db.UseXattrs(), true, copiedIndexes)
+	removedIndexes, removeErr := removeObsoleteIndexes(ctx, n1QLStore, false, db.UseXattrs(), true, copiedIndexes)
 	require.NoError(t, removeErr)
 	require.Len(t, removedIndexes, expectedIndexes)
 
-	removedIndexes, removeErr = removeObsoleteIndexes(n1QLStore, false, db.UseXattrs(), false, copiedIndexes)
+	removedIndexes, removeErr = removeObsoleteIndexes(ctx, n1QLStore, false, db.UseXattrs(), false, copiedIndexes)
 	require.NoError(t, removeErr)
 	require.Len(t, removedIndexes, 0)
 
@@ -407,7 +407,7 @@ func TestRemoveObsoleteIndexOnError(t *testing.T) {
 	n1qlStore, ok := base.AsN1QLStore(dataStore)
 	require.True(t, ok)
 
-	removedIndex, removeErr := removeObsoleteIndexes(n1qlStore, false, db.UseXattrs(), db.UseViews(), testIndexes)
+	removedIndex, removeErr := removeObsoleteIndexes(ctx, n1qlStore, false, db.UseXattrs(), db.UseViews(), testIndexes)
 	assert.NoError(t, removeErr)
 
 	if base.TestUseXattrs() {
@@ -440,7 +440,7 @@ func dropAndInitializeIndexes(ctx context.Context, n1qlStore base.N1QLStore, opt
 	}
 
 	// Recreate the primary index required by the test bucket pooling framework
-	err := n1qlStore.CreatePrimaryIndex(base.PrimaryIndexName, nil)
+	err := n1qlStore.CreatePrimaryIndex(ctx, base.PrimaryIndexName, nil)
 	if err != nil {
 		return err
 	}

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -454,7 +454,7 @@ var clearIndexes resetN1QLStoreFn = func(n1QLStores []base.N1QLStore, isServerle
 	var err error
 	for _, n1QLStore := range n1QLStores {
 		for _, index := range indexes {
-			newErr := n1QLStore.DropIndex(index)
+			newErr := n1QLStore.DropIndex(context.TODO(), index)
 			if newErr != nil && strings.Contains(newErr.Error(), "Index not exist") {
 				err = errors.Wrap(err, newErr.Error())
 			}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -384,7 +384,7 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 			return err
 		}
 
-		err = n1qlStore.CreatePrimaryIndex(base.PrimaryIndexName, nil)
+		err = n1qlStore.CreatePrimaryIndex(ctx, base.PrimaryIndexName, nil)
 		if err != nil {
 			return err
 		}

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -516,8 +516,9 @@ func TestCollectionsBasicIndexQuery(t *testing.T) {
 	require.True(t, ok)
 
 	idxName := t.Name() + "_primary"
-	require.NoError(t, n1qlStore.CreatePrimaryIndex(idxName, nil))
-	require.NoError(t, n1qlStore.WaitForIndexesOnline([]string{idxName}, false))
+	ctx := base.TestCtx(t)
+	require.NoError(t, n1qlStore.CreatePrimaryIndex(ctx, idxName, nil))
+	require.NoError(t, n1qlStore.WaitForIndexesOnline(ctx, []string{idxName}, false))
 
 	res, err := n1qlStore.Query("SELECT keyspace_id, bucket_id, scope_id from system:indexes WHERE name = $idxName",
 		map[string]interface{}{"idxName": idxName}, base.RequestPlus, true)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2506,6 +2506,6 @@ func dropAllNonPrimaryIndexes(t *testing.T, dataStore base.DataStore) {
 	ctx := base.TestCtx(t)
 	dropErr := base.DropAllIndexes(ctx, n1qlStore)
 	require.NoError(t, dropErr)
-	err := n1qlStore.CreatePrimaryIndex(base.PrimaryIndexName, nil)
+	err := n1qlStore.CreatePrimaryIndex(ctx, base.PrimaryIndexName, nil)
 	require.NoError(t, err, "Unable to recreate primary index")
 }


### PR DESCRIPTION
- add context based logging to include bucket and collection information

Minimal modification on cherry-pick to remove `indexManager`.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-1.19.5/15/
