### PR TITLE
CBG-3182: document prometheus stats

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -94,7 +94,7 @@ func NewSyncGatewayStats() (*SgwStats, error) {
 
 	// This provides a stat for sgw_up where the value will be fixed to one. This is to allow backwards compatibility
 	// where the standalone exporter would export a value of 1 if it has contact with SGW.
-	_, err = NewIntStat("", "up", "", nil, nil, prometheus.GaugeValue, 1)
+	_, err = NewIntStat("", "up", SGWUpDesc, nil, nil, prometheus.GaugeValue, 1)
 	if err != nil {
 		return nil, err
 	}

--- a/base/stats.go
+++ b/base/stats.go
@@ -744,6 +744,9 @@ func newSGWStat(subsystem string, key string, description string, labelKeys []st
 }
 
 func NewIntStat(subsystem string, key string, description string, labelKeys []string, labelVals []string, statValueType prometheus.ValueType, initialValue int64) (*SgwIntStat, error) {
+	if description == "" {
+		return nil, fmt.Errorf("attempting to register stat with no description")
+	}
 	stat := &SgwIntStat{
 		SgwStat: *newSGWStat(subsystem, key, description, labelKeys, labelVals, statValueType),
 	}
@@ -777,6 +780,9 @@ func (s *SgwIntStat) String() string {
 }
 
 func NewFloatStat(subsystem string, key string, description string, labelKeys []string, labelVals []string, statValueType prometheus.ValueType, initialValue float64) (*SgwFloatStat, error) {
+	if description == "" {
+		return nil, fmt.Errorf("attempting to register stat with no description")
+	}
 	stat := &SgwFloatStat{
 		SgwStat: *newSGWStat(subsystem, key, description, labelKeys, labelVals, statValueType),
 		Val:     math.Float64bits(initialValue),
@@ -854,6 +860,9 @@ type SgwDurStat struct {
 // Prometheus's DefaultRegisterer and returns the collector. It panics if any error
 // occurs while registering the collector on Prometheus registry.
 func NewDurStat(subsystem string, key string, description string, labelKeys []string, labelVals []string, statValueType prometheus.ValueType, initialValue time.Time) (*SgwDurStat, error) {
+	if description == "" {
+		return nil, fmt.Errorf("attempting to register stat with no description")
+	}
 	stat := &SgwDurStat{
 		SgwStat:   *newSGWStat(subsystem, key, description, labelKeys, labelVals, statValueType),
 		StartTime: initialValue,

--- a/base/stats.go
+++ b/base/stats.go
@@ -511,7 +511,7 @@ type DatabaseStats struct {
 	NumReplicationsRejectedLimit *SgwIntStat `json:"num_replications_rejected_limit"`
 	// Represents the compute unit for import processes on the database
 	ImportProcessCompute *SgwIntStat `json:"import_process_compute"`
-	// SyncProcessCompute the comopute unit for syncing with clients
+	// SyncProcessCompute the compute unit for syncing with clients
 	SyncProcessCompute *SgwIntStat `json:"sync_process_compute"`
 
 	// These can be cleaned up in future versions of SGW, implemented as maps to reduce amount of potential risk
@@ -1378,11 +1378,10 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.PublicRestBytesWritten, err = NewIntStat(SubsystemDatabaseKey, "http_bytes_written", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.PublicRestBytesWritten, err = NewIntStat(SubsystemDatabaseKey, "http_bytes_written", PublicRestBytesWrittenDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-
 	resUtil.NumAttachmentsCompacted, err = NewIntStat(SubsystemDatabaseKey, "num_attachments_compacted", NumAttachmentsCompactedDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
@@ -1415,7 +1414,7 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.PublicRestBytesRead, err = NewIntStat(SubsystemDatabaseKey, "public_rest_bytes_read", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.PublicRestBytesRead, err = NewIntStat(SubsystemDatabaseKey, "public_rest_bytes_read", PublicRestBytesReadDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
@@ -1483,7 +1482,7 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.SyncProcessCompute, err = NewIntStat(SubsystemDatabaseKey, "sync_process_compute", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.SyncProcessCompute, err = NewIntStat(SubsystemDatabaseKey, "sync_process_compute", SyncProcessComputeDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}

--- a/base/stats.go
+++ b/base/stats.go
@@ -94,7 +94,7 @@ func NewSyncGatewayStats() (*SgwStats, error) {
 
 	// This provides a stat for sgw_up where the value will be fixed to one. This is to allow backwards compatibility
 	// where the standalone exporter would export a value of 1 if it has contact with SGW.
-	_, err = NewIntStat("", "up", nil, nil, prometheus.GaugeValue, 1)
+	_, err = NewIntStat("", "up", "", nil, nil, prometheus.GaugeValue, 1)
 	if err != nil {
 		return nil, err
 	}
@@ -137,83 +137,83 @@ func (g *GlobalStat) initResourceUtilizationStats() error {
 	var err error
 	resUtil := &ResourceUtilization{}
 
-	resUtil.AdminNetworkInterfaceBytesReceived, err = NewIntStat(ResourceUtilizationSubsystem, "admin_net_bytes_recv", nil, nil, prometheus.CounterValue, 0)
+	resUtil.AdminNetworkInterfaceBytesReceived, err = NewIntStat(ResourceUtilizationSubsystem, "admin_net_bytes_recv", AdminNetBytesRecDesc, nil, nil, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.AdminNetworkInterfaceBytesSent, err = NewIntStat(ResourceUtilizationSubsystem, "admin_net_bytes_sent", nil, nil, prometheus.CounterValue, 0)
+	resUtil.AdminNetworkInterfaceBytesSent, err = NewIntStat(ResourceUtilizationSubsystem, "admin_net_bytes_sent", AdminNetBytesSentDesc, nil, nil, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ErrorCount, err = NewIntStat(ResourceUtilizationSubsystem, "error_count", nil, nil, prometheus.CounterValue, 0)
+	resUtil.ErrorCount, err = NewIntStat(ResourceUtilizationSubsystem, "error_count", ErrorCountDesc, nil, nil, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.GoMemstatsHeapAlloc, err = NewIntStat(ResourceUtilizationSubsystem, "go_memstats_heapalloc", nil, nil, prometheus.GaugeValue, 0)
+	resUtil.GoMemstatsHeapAlloc, err = NewIntStat(ResourceUtilizationSubsystem, "go_memstats_heapalloc", GoMemHeapAllocDesc, nil, nil, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.GoMemstatsHeapIdle, err = NewIntStat(ResourceUtilizationSubsystem, "go_memstats_heapidle", nil, nil, prometheus.GaugeValue, 0)
+	resUtil.GoMemstatsHeapIdle, err = NewIntStat(ResourceUtilizationSubsystem, "go_memstats_heapidle", GoMemHeapIdleDesc, nil, nil, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.GoMemstatsHeapInUse, err = NewIntStat(ResourceUtilizationSubsystem, "go_memstats_heapinuse", nil, nil, prometheus.GaugeValue, 0)
+	resUtil.GoMemstatsHeapInUse, err = NewIntStat(ResourceUtilizationSubsystem, "go_memstats_heapinuse", GoMemHeapInUseDesc, nil, nil, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.GoMemstatsHeapReleased, err = NewIntStat(ResourceUtilizationSubsystem, "go_memstats_heapreleased", nil, nil, prometheus.GaugeValue, 0)
+	resUtil.GoMemstatsHeapReleased, err = NewIntStat(ResourceUtilizationSubsystem, "go_memstats_heapreleased", GoMemHeapReleasedDesc, nil, nil, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.GoMemstatsPauseTotalNS, err = NewIntStat(ResourceUtilizationSubsystem, "go_memstats_pausetotalns", nil, nil, prometheus.GaugeValue, 0)
+	resUtil.GoMemstatsPauseTotalNS, err = NewIntStat(ResourceUtilizationSubsystem, "go_memstats_pausetotalns", GoMemPauseTotalNSDesc, nil, nil, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.GoMemstatsStackInUse, err = NewIntStat(ResourceUtilizationSubsystem, "go_memstats_stackinuse", nil, nil, prometheus.GaugeValue, 0)
+	resUtil.GoMemstatsStackInUse, err = NewIntStat(ResourceUtilizationSubsystem, "go_memstats_stackinuse", GoMemStackInUseDesc, nil, nil, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.GoMemstatsStackSys, err = NewIntStat(ResourceUtilizationSubsystem, "go_memstats_stacksys", nil, nil, prometheus.GaugeValue, 0)
+	resUtil.GoMemstatsStackSys, err = NewIntStat(ResourceUtilizationSubsystem, "go_memstats_stacksys", GoMemStackSysDesc, nil, nil, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.GoMemstatsSys, err = NewIntStat(ResourceUtilizationSubsystem, "go_memstats_sys", nil, nil, prometheus.GaugeValue, 0)
+	resUtil.GoMemstatsSys, err = NewIntStat(ResourceUtilizationSubsystem, "go_memstats_sys", GoMemSysDesc, nil, nil, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.GoroutinesHighWatermark, err = NewIntStat(ResourceUtilizationSubsystem, "goroutines_high_watermark", nil, nil, prometheus.GaugeValue, 0)
+	resUtil.GoroutinesHighWatermark, err = NewIntStat(ResourceUtilizationSubsystem, "goroutines_high_watermark", GoroutinesHighWatermarkDesc, nil, nil, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumGoroutines, err = NewIntStat(ResourceUtilizationSubsystem, "num_goroutines", nil, nil, prometheus.GaugeValue, 0)
+	resUtil.NumGoroutines, err = NewIntStat(ResourceUtilizationSubsystem, "num_goroutines", NumGoroutinesDesc, nil, nil, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ProcessMemoryResident, err = NewIntStat(ResourceUtilizationSubsystem, "process_memory_resident", nil, nil, prometheus.GaugeValue, 0)
+	resUtil.ProcessMemoryResident, err = NewIntStat(ResourceUtilizationSubsystem, "process_memory_resident", ProcessMemoryResidentDesc, nil, nil, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.PublicNetworkInterfaceBytesReceived, err = NewIntStat(ResourceUtilizationSubsystem, "pub_net_bytes_recv", nil, nil, prometheus.CounterValue, 0)
+	resUtil.PublicNetworkInterfaceBytesReceived, err = NewIntStat(ResourceUtilizationSubsystem, "pub_net_bytes_recv", PublicNetBytesRecvDesc, nil, nil, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.PublicNetworkInterfaceBytesSent, err = NewIntStat(ResourceUtilizationSubsystem, "pub_net_bytes_sent", nil, nil, prometheus.CounterValue, 0)
+	resUtil.PublicNetworkInterfaceBytesSent, err = NewIntStat(ResourceUtilizationSubsystem, "pub_net_bytes_sent", PublicNetBytesSentDesc, nil, nil, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.SystemMemoryTotal, err = NewIntStat(ResourceUtilizationSubsystem, "system_memory_total", nil, nil, prometheus.GaugeValue, 0)
+	resUtil.SystemMemoryTotal, err = NewIntStat(ResourceUtilizationSubsystem, "system_memory_total", SystemMemoryTotalDesc, nil, nil, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.WarnCount, err = NewIntStat(ResourceUtilizationSubsystem, "warn_count", nil, nil, prometheus.CounterValue, 0)
+	resUtil.WarnCount, err = NewIntStat(ResourceUtilizationSubsystem, "warn_count", WarnCountDesc, nil, nil, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.CpuPercentUtil, err = NewFloatStat(ResourceUtilizationSubsystem, "process_cpu_percent_utilization", nil, nil, prometheus.GaugeValue, 0)
+	resUtil.CpuPercentUtil, err = NewFloatStat(ResourceUtilizationSubsystem, "process_cpu_percent_utilization", ProcessCPUPercentUtilDesc, nil, nil, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.Uptime, err = NewDurStat(ResourceUtilizationSubsystem, "uptime", nil, nil, prometheus.CounterValue, time.Now())
+	resUtil.Uptime, err = NewDurStat(ResourceUtilizationSubsystem, "uptime", UptimeDesc, nil, nil, prometheus.CounterValue, time.Now())
 	if err != nil {
 		return err
 	}
@@ -503,7 +503,7 @@ type DatabaseStats struct {
 	// The total time spent evaluating a sync function (across all collections).
 	SyncFunctionTime *SgwIntStat `json:"sync_function_time"`
 	// The total total sync time is a proxy for websocket connections. Tracking long lived and potentially idle connections.
-	// This stat represents teh continually growing number of connections per sec.
+	// This stat represents the continually growing number of connections per sec.
 	TotalSyncTime *SgwIntStat `json:"total_sync_time"`
 	// The total number of times that a sync function encountered an exception (across all collections).
 	SyncFunctionExceptionCount *SgwIntStat `json:"sync_function_exception_count"`
@@ -725,7 +725,7 @@ type SgwBoolStat struct {
 	Val bool
 }
 
-func newSGWStat(subsystem string, key string, labelKeys []string, labelVals []string, statValueType prometheus.ValueType) *SgwStat {
+func newSGWStat(subsystem string, key string, description string, labelKeys []string, labelVals []string, statValueType prometheus.ValueType) *SgwStat {
 	name := prometheus.BuildFQName(NamespaceKey, subsystem, key)
 
 	constLabels := make(prometheus.Labels)
@@ -733,7 +733,7 @@ func newSGWStat(subsystem string, key string, labelKeys []string, labelVals []st
 		constLabels[labelKey] = labelVals[i]
 	}
 
-	desc := prometheus.NewDesc(name, key, nil, constLabels)
+	desc := prometheus.NewDesc(name, description, nil, constLabels)
 
 	return &SgwStat{
 		statFQN:       name,
@@ -743,9 +743,9 @@ func newSGWStat(subsystem string, key string, labelKeys []string, labelVals []st
 	}
 }
 
-func NewIntStat(subsystem string, key string, labelKeys []string, labelVals []string, statValueType prometheus.ValueType, initialValue int64) (*SgwIntStat, error) {
+func NewIntStat(subsystem string, key string, description string, labelKeys []string, labelVals []string, statValueType prometheus.ValueType, initialValue int64) (*SgwIntStat, error) {
 	stat := &SgwIntStat{
-		SgwStat: *newSGWStat(subsystem, key, labelKeys, labelVals, statValueType),
+		SgwStat: *newSGWStat(subsystem, key, description, labelKeys, labelVals, statValueType),
 	}
 
 	stat.Set(initialValue)
@@ -776,9 +776,9 @@ func (s *SgwIntStat) String() string {
 	return strconv.FormatInt(s.Value(), 10)
 }
 
-func NewFloatStat(subsystem string, key string, labelKeys []string, labelVals []string, statValueType prometheus.ValueType, initialValue float64) (*SgwFloatStat, error) {
+func NewFloatStat(subsystem string, key string, description string, labelKeys []string, labelVals []string, statValueType prometheus.ValueType, initialValue float64) (*SgwFloatStat, error) {
 	stat := &SgwFloatStat{
-		SgwStat: *newSGWStat(subsystem, key, labelKeys, labelVals, statValueType),
+		SgwStat: *newSGWStat(subsystem, key, description, labelKeys, labelVals, statValueType),
 		Val:     math.Float64bits(initialValue),
 	}
 
@@ -853,10 +853,9 @@ type SgwDurStat struct {
 // NewDurStat creates a new collector for time duration metric, registers it with the
 // Prometheus's DefaultRegisterer and returns the collector. It panics if any error
 // occurs while registering the collector on Prometheus registry.
-func NewDurStat(subsystem string, key string, labelKeys []string, labelVals []string,
-	statValueType prometheus.ValueType, initialValue time.Time) (*SgwDurStat, error) {
+func NewDurStat(subsystem string, key string, description string, labelKeys []string, labelVals []string, statValueType prometheus.ValueType, initialValue time.Time) (*SgwDurStat, error) {
 	stat := &SgwDurStat{
-		SgwStat:   *newSGWStat(subsystem, key, labelKeys, labelVals, statValueType),
+		SgwStat:   *newSGWStat(subsystem, key, description, labelKeys, labelVals, statValueType),
 		StartTime: initialValue,
 	}
 
@@ -1010,107 +1009,107 @@ func (d *DbStats) initCacheStats() error {
 	labelKeys := []string{DatabaseLabelKey}
 	labelVals := []string{d.dbName}
 
-	resUtil.AbandonedSeqs, err = NewIntStat(SubsystemCacheKey, "abandoned_seqs", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.AbandonedSeqs, err = NewIntStat(SubsystemCacheKey, "abandoned_seqs", AbandonedSeqsDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ChannelCacheRevsActive, err = NewIntStat(SubsystemCacheKey, "chan_cache_active_revs", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.ChannelCacheRevsActive, err = NewIntStat(SubsystemCacheKey, "chan_cache_active_revs", ChanCacheActiveRevsDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ChannelCacheBypassCount, err = NewIntStat(SubsystemCacheKey, "chan_cache_bypass_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.ChannelCacheBypassCount, err = NewIntStat(SubsystemCacheKey, "chan_cache_bypass_count", ChanCacheBypassCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ChannelCacheChannelsAdded, err = NewIntStat(SubsystemCacheKey, "chan_cache_channels_added", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.ChannelCacheChannelsAdded, err = NewIntStat(SubsystemCacheKey, "chan_cache_channels_added", ChanCacheChannelsAddedDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ChannelCacheChannelsEvictedInactive, err = NewIntStat(SubsystemCacheKey, "chan_cache_channels_evicted_inactive", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.ChannelCacheChannelsEvictedInactive, err = NewIntStat(SubsystemCacheKey, "chan_cache_channels_evicted_inactive", ChanCacheChannelsEvictedInactiveDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ChannelCacheChannelsEvictedNRU, err = NewIntStat(SubsystemCacheKey, "chan_cache_channels_evicted_nru", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.ChannelCacheChannelsEvictedNRU, err = NewIntStat(SubsystemCacheKey, "chan_cache_channels_evicted_nru", ChanCacheChannelsEvictedNRUDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ChannelCacheCompactCount, err = NewIntStat(SubsystemCacheKey, "chan_cache_compact_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.ChannelCacheCompactCount, err = NewIntStat(SubsystemCacheKey, "chan_cache_compact_count", ChanCacheCompactCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ChannelCacheCompactTime, err = NewIntStat(SubsystemCacheKey, "chan_cache_compact_time", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.ChannelCacheCompactTime, err = NewIntStat(SubsystemCacheKey, "chan_cache_compact_time", ChanCacheCompactTimeDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ChannelCacheHits, err = NewIntStat(SubsystemCacheKey, "chan_cache_hits", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.ChannelCacheHits, err = NewIntStat(SubsystemCacheKey, "chan_cache_hits", ChanCacheHitsDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ChannelCacheMaxEntries, err = NewIntStat(SubsystemCacheKey, "chan_cache_max_entries", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.ChannelCacheMaxEntries, err = NewIntStat(SubsystemCacheKey, "chan_cache_max_entries", ChanCacheMaxEntriesDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ChannelCacheMisses, err = NewIntStat(SubsystemCacheKey, "chan_cache_misses", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.ChannelCacheMisses, err = NewIntStat(SubsystemCacheKey, "chan_cache_misses", ChanCacheMissesDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ChannelCacheNumChannels, err = NewIntStat(SubsystemCacheKey, "chan_cache_num_channels", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.ChannelCacheNumChannels, err = NewIntStat(SubsystemCacheKey, "chan_cache_num_channels", ChanCacheNumChannelsDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ChannelCachePendingQueries, err = NewIntStat(SubsystemCacheKey, "chan_cache_pending_queries", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.ChannelCachePendingQueries, err = NewIntStat(SubsystemCacheKey, "chan_cache_pending_queries", ChanCachePendingQueriesDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ChannelCacheRevsRemoval, err = NewIntStat(SubsystemCacheKey, "chan_cache_removal_revs", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.ChannelCacheRevsRemoval, err = NewIntStat(SubsystemCacheKey, "chan_cache_removal_revs", ChanCacheRemovalRevsDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ChannelCacheRevsTombstone, err = NewIntStat(SubsystemCacheKey, "chan_cache_tombstone_revs", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.ChannelCacheRevsTombstone, err = NewIntStat(SubsystemCacheKey, "chan_cache_tombstone_revs", ChanCacheTombstoneRevsDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.HighSeqCached, err = NewIntStat(SubsystemCacheKey, "high_seq_cached", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.HighSeqCached, err = NewIntStat(SubsystemCacheKey, "high_seq_cached", HighSeqCachedDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.HighSeqStable, err = NewIntStat(SubsystemCacheKey, "high_seq_stable", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.HighSeqStable, err = NewIntStat(SubsystemCacheKey, "high_seq_stable", HighStableSeqCachedDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NonMobileIgnoredCount, err = NewIntStat(SubsystemCacheKey, "non_mobile_ignored_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.NonMobileIgnoredCount, err = NewIntStat(SubsystemCacheKey, "non_mobile_ignored_count", NonMobileIgnoredCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumActiveChannels, err = NewIntStat(SubsystemCacheKey, "num_active_channels", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.NumActiveChannels, err = NewIntStat(SubsystemCacheKey, "num_active_channels", NumActiveChannelsDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumSkippedSeqs, err = NewIntStat(SubsystemCacheKey, "num_skipped_seqs", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.NumSkippedSeqs, err = NewIntStat(SubsystemCacheKey, "num_skipped_seqs", NumSkippedSeqsDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.PendingSeqLen, err = NewIntStat(SubsystemCacheKey, "pending_seq_len", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.PendingSeqLen, err = NewIntStat(SubsystemCacheKey, "pending_seq_len", PendingSeqLengthDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.RevisionCacheBypass, err = NewIntStat(SubsystemCacheKey, "rev_cache_bypass", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.RevisionCacheBypass, err = NewIntStat(SubsystemCacheKey, "rev_cache_bypass", RevCacheBypassDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.RevisionCacheHits, err = NewIntStat(SubsystemCacheKey, "rev_cache_hits", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.RevisionCacheHits, err = NewIntStat(SubsystemCacheKey, "rev_cache_hits", RevCacheHitsDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.RevisionCacheMisses, err = NewIntStat(SubsystemCacheKey, "rev_cache_misses", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.RevisionCacheMisses, err = NewIntStat(SubsystemCacheKey, "rev_cache_misses", RevCacheMissesDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.SkippedSeqLen, err = NewIntStat(SubsystemCacheKey, "skipped_seq_len", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.SkippedSeqLen, err = NewIntStat(SubsystemCacheKey, "skipped_seq_len", SkippedSeqLengthDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ViewQueries, err = NewIntStat(SubsystemCacheKey, "view_queries", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.ViewQueries, err = NewIntStat(SubsystemCacheKey, "view_queries", ViewQueriesDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
@@ -1158,71 +1157,71 @@ func (d *DbStats) initCBLReplicationPullStats() error {
 	labelKeys := []string{DatabaseLabelKey}
 	labelVals := []string{d.dbName}
 
-	resUtil.AttachmentPullBytes, err = NewIntStat(SubsystemReplicationPull, "attachment_pull_bytes", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.AttachmentPullBytes, err = NewIntStat(SubsystemReplicationPull, "attachment_pull_bytes", AttachmentPullBytesDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.AttachmentPullCount, err = NewIntStat(SubsystemReplicationPull, "attachment_pull_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.AttachmentPullCount, err = NewIntStat(SubsystemReplicationPull, "attachment_pull_count", AttachmentPullCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.MaxPending, err = NewIntStat(SubsystemReplicationPull, "max_pending", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.MaxPending, err = NewIntStat(SubsystemReplicationPull, "max_pending", MaxPendingDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumReplicationsActive, err = NewIntStat(SubsystemReplicationPull, "num_replications_active", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.NumReplicationsActive, err = NewIntStat(SubsystemReplicationPull, "num_replications_active", NumReplicationsActiveDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumPullReplActiveContinuous, err = NewIntStat(SubsystemReplicationPull, "num_pull_repl_active_continuous", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.NumPullReplActiveContinuous, err = NewIntStat(SubsystemReplicationPull, "num_pull_repl_active_continuous", NumPullRepliActiveContinuousDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumPullReplActiveOneShot, err = NewIntStat(SubsystemReplicationPull, "num_pull_repl_active_one_shot", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.NumPullReplActiveOneShot, err = NewIntStat(SubsystemReplicationPull, "num_pull_repl_active_one_shot", NumPullRepliActiveOneShotDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumPullReplCaughtUp, err = NewIntStat(SubsystemReplicationPull, "num_pull_repl_caught_up", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.NumPullReplCaughtUp, err = NewIntStat(SubsystemReplicationPull, "num_pull_repl_caught_up", NumPullRepliCaughtUpDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumPullReplTotalCaughtUp, err = NewIntStat(SubsystemReplicationPull, "num_pull_repl_total_caught_up", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.NumPullReplTotalCaughtUp, err = NewIntStat(SubsystemReplicationPull, "num_pull_repl_total_caught_up", NumPullRepliTotalCaughtUpDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumPullReplSinceZero, err = NewIntStat(SubsystemReplicationPull, "num_pull_repl_since_zero", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.NumPullReplSinceZero, err = NewIntStat(SubsystemReplicationPull, "num_pull_repl_since_zero", NumPullRepliSinceZeroDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumPullReplTotalContinuous, err = NewIntStat(SubsystemReplicationPull, "num_pull_repl_total_continuous", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.NumPullReplTotalContinuous, err = NewIntStat(SubsystemReplicationPull, "num_pull_repl_total_continuous", NumPullRepliContinuousDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumPullReplTotalOneShot, err = NewIntStat(SubsystemReplicationPull, "num_pull_repl_total_one_shot", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.NumPullReplTotalOneShot, err = NewIntStat(SubsystemReplicationPull, "num_pull_repl_total_one_shot", NumPullRepliTotalOneshotDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.RequestChangesCount, err = NewIntStat(SubsystemReplicationPull, "request_changes_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.RequestChangesCount, err = NewIntStat(SubsystemReplicationPull, "request_changes_count", RequestChangesCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.RequestChangesTime, err = NewIntStat(SubsystemReplicationPull, "request_changes_time", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.RequestChangesTime, err = NewIntStat(SubsystemReplicationPull, "request_changes_time", RequestChangesTimeDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.RevProcessingTime, err = NewIntStat(SubsystemReplicationPull, "rev_processing_time", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.RevProcessingTime, err = NewIntStat(SubsystemReplicationPull, "rev_processing_time", RevProcessingTimeDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.RevSendCount, err = NewIntStat(SubsystemReplicationPull, "rev_send_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.RevSendCount, err = NewIntStat(SubsystemReplicationPull, "rev_send_count", RevSendCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.RevErrorCount, err = NewIntStat(SubsystemReplicationPull, "rev_error_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.RevErrorCount, err = NewIntStat(SubsystemReplicationPull, "rev_error_count", RevErrorCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.RevSendLatency, err = NewIntStat(SubsystemReplicationPull, "rev_send_latency", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.RevSendLatency, err = NewIntStat(SubsystemReplicationPull, "rev_send_latency", RevSendLatencyDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
@@ -1261,31 +1260,31 @@ func (d *DbStats) initCBLReplicationPushStats() error {
 	labelKeys := []string{DatabaseLabelKey}
 	labelVals := []string{d.dbName}
 
-	resUtil.AttachmentPushBytes, err = NewIntStat(SubsystemReplicationPush, "attachment_push_bytes", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.AttachmentPushBytes, err = NewIntStat(SubsystemReplicationPush, "attachment_push_bytes", AttachmentPushBytesDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.AttachmentPushCount, err = NewIntStat(SubsystemReplicationPush, "attachment_push_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.AttachmentPushCount, err = NewIntStat(SubsystemReplicationPush, "attachment_push_count", AttachmentPushCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.DocPushCount, err = NewIntStat(SubsystemReplicationPush, "doc_push_count", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.DocPushCount, err = NewIntStat(SubsystemReplicationPush, "doc_push_count", DocPushCountDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.DocPushErrorCount, err = NewIntStat(SubsystemReplicationPush, "doc_push_error_count", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.DocPushErrorCount, err = NewIntStat(SubsystemReplicationPush, "doc_push_error_count", DocPushErrorCountDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ProposeChangeCount, err = NewIntStat(SubsystemReplicationPush, "propose_change_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.ProposeChangeCount, err = NewIntStat(SubsystemReplicationPush, "propose_change_count", ProposeChangeCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ProposeChangeTime, err = NewIntStat(SubsystemReplicationPush, "propose_change_time", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.ProposeChangeTime, err = NewIntStat(SubsystemReplicationPush, "propose_change_time", ProposeChangeTimeDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.WriteProcessingTime, err = NewIntStat(SubsystemReplicationPush, "write_processing_time", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.WriteProcessingTime, err = NewIntStat(SubsystemReplicationPush, "write_processing_time", WriteProcessingTimeDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
@@ -1314,59 +1313,59 @@ func (d *DbStats) initDatabaseStats() error {
 	labelKeys := []string{DatabaseLabelKey}
 	labelVals := []string{d.dbName}
 
-	resUtil.ReplicationBytesReceived, err = NewIntStat(SubsystemDatabaseKey, "replication_bytes_received", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.ReplicationBytesReceived, err = NewIntStat(SubsystemDatabaseKey, "replication_bytes_received", ReplicationBytesReceivedDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ReplicationBytesSent, err = NewIntStat(SubsystemDatabaseKey, "replication_bytes_sent", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.ReplicationBytesSent, err = NewIntStat(SubsystemDatabaseKey, "replication_bytes_sent", ReplicationBytesSentDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.CompactionAttachmentStartTime, err = NewIntStat(SubsystemDatabaseKey, "compaction_attachment_start_time", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.CompactionAttachmentStartTime, err = NewIntStat(SubsystemDatabaseKey, "compaction_attachment_start_time", CompactionAttachmentStartTimeDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.CompactionTombstoneStartTime, err = NewIntStat(SubsystemDatabaseKey, "compaction_tombstone_start_time", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.CompactionTombstoneStartTime, err = NewIntStat(SubsystemDatabaseKey, "compaction_tombstone_start_time", CompactionTombstoneStartTimeDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ConflictWriteCount, err = NewIntStat(SubsystemDatabaseKey, "conflict_write_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.ConflictWriteCount, err = NewIntStat(SubsystemDatabaseKey, "conflict_write_count", ConflictWriteCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.Crc32MatchCount, err = NewIntStat(SubsystemDatabaseKey, "crc32c_match_count", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.Crc32MatchCount, err = NewIntStat(SubsystemDatabaseKey, "crc32c_match_count", Crc32MatchCountDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.DCPCachingCount, err = NewIntStat(SubsystemDatabaseKey, "dcp_caching_count", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.DCPCachingCount, err = NewIntStat(SubsystemDatabaseKey, "dcp_caching_count", DCPCachingCountDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.DCPCachingTime, err = NewIntStat(SubsystemDatabaseKey, "dcp_caching_time", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.DCPCachingTime, err = NewIntStat(SubsystemDatabaseKey, "dcp_caching_time", DCPCachingTimeDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.DCPReceivedCount, err = NewIntStat(SubsystemDatabaseKey, "dcp_received_count", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.DCPReceivedCount, err = NewIntStat(SubsystemDatabaseKey, "dcp_received_count", DCPReceivedCountDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.DCPReceivedTime, err = NewIntStat(SubsystemDatabaseKey, "dcp_received_time", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.DCPReceivedTime, err = NewIntStat(SubsystemDatabaseKey, "dcp_received_time", DCPReceivedTimeDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.DocReadsBytesBlip, err = NewIntStat(SubsystemDatabaseKey, "doc_reads_bytes_blip", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.DocReadsBytesBlip, err = NewIntStat(SubsystemDatabaseKey, "doc_reads_bytes_blip", DocReadsBytesBlipDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.DocWritesBytes, err = NewIntStat(SubsystemDatabaseKey, "doc_writes_bytes", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.DocWritesBytes, err = NewIntStat(SubsystemDatabaseKey, "doc_writes_bytes", DocWritesBytesDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.DocWritesXattrBytes, err = NewIntStat(SubsystemDatabaseKey, "doc_writes_xattr_bytes", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.DocWritesXattrBytes, err = NewIntStat(SubsystemDatabaseKey, "doc_writes_xattr_bytes", DocWritesXattrBytesDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.HighSeqFeed, err = NewIntStat(SubsystemDatabaseKey, "high_seq_feed", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.HighSeqFeed, err = NewIntStat(SubsystemDatabaseKey, "high_seq_feed", HighSeqFeedDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
@@ -1375,35 +1374,35 @@ func (d *DbStats) initDatabaseStats() error {
 		return err
 	}
 
-	resUtil.NumAttachmentsCompacted, err = NewIntStat(SubsystemDatabaseKey, "num_attachments_compacted", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.NumAttachmentsCompacted, err = NewIntStat(SubsystemDatabaseKey, "num_attachments_compacted", NumAttachmentsCompactedDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.DocWritesBytesBlip, err = NewIntStat(SubsystemDatabaseKey, "doc_writes_bytes_blip", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.DocWritesBytesBlip, err = NewIntStat(SubsystemDatabaseKey, "doc_writes_bytes_blip", DocWritesBytesBlipDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumDocReadsBlip, err = NewIntStat(SubsystemDatabaseKey, "num_doc_reads_blip", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.NumDocReadsBlip, err = NewIntStat(SubsystemDatabaseKey, "num_doc_reads_blip", NumDocsReadsBlipDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumDocReadsRest, err = NewIntStat(SubsystemDatabaseKey, "num_doc_reads_rest", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.NumDocReadsRest, err = NewIntStat(SubsystemDatabaseKey, "num_doc_reads_rest", NumDocReadsRestDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumDocWrites, err = NewIntStat(SubsystemDatabaseKey, "num_doc_writes", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.NumDocWrites, err = NewIntStat(SubsystemDatabaseKey, "num_doc_writes", NumDocWritesDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumReplicationsActive, err = NewIntStat(SubsystemDatabaseKey, "num_replications_active", labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.NumReplicationsActive, err = NewIntStat(SubsystemDatabaseKey, "num_replications_active", NumReplicationsActiveDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumReplicationsTotal, err = NewIntStat(SubsystemDatabaseKey, "num_replications_total", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.NumReplicationsTotal, err = NewIntStat(SubsystemDatabaseKey, "num_replications_total", NumReplicationsTotalDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumTombstonesCompacted, err = NewIntStat(SubsystemDatabaseKey, "num_tombstones_compacted", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.NumTombstonesCompacted, err = NewIntStat(SubsystemDatabaseKey, "num_tombstones_compacted", NumTombstonesCompactedDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
@@ -1411,67 +1410,67 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.SequenceAssignedCount, err = NewIntStat(SubsystemDatabaseKey, "sequence_assigned_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.SequenceAssignedCount, err = NewIntStat(SubsystemDatabaseKey, "sequence_assigned_count", SequenceAssignedCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.SequenceGetCount, err = NewIntStat(SubsystemDatabaseKey, "sequence_get_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.SequenceGetCount, err = NewIntStat(SubsystemDatabaseKey, "sequence_get_count", SequenceGetCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.SequenceIncrCount, err = NewIntStat(SubsystemDatabaseKey, "sequence_incr_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.SequenceIncrCount, err = NewIntStat(SubsystemDatabaseKey, "sequence_incr_count", SequenceIncrCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.SequenceReleasedCount, err = NewIntStat(SubsystemDatabaseKey, "sequence_released_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.SequenceReleasedCount, err = NewIntStat(SubsystemDatabaseKey, "sequence_released_count", SequenceReleasedCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.SequenceReservedCount, err = NewIntStat(SubsystemDatabaseKey, "sequence_reserved_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.SequenceReservedCount, err = NewIntStat(SubsystemDatabaseKey, "sequence_reserved_count", SequenceReservedCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.WarnChannelNameSizeCount, err = NewIntStat(SubsystemDatabaseKey, "warn_channel_name_size_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.WarnChannelNameSizeCount, err = NewIntStat(SubsystemDatabaseKey, "warn_channel_name_size_count", WarnChannelNameSizeCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.WarnChannelsPerDocCount, err = NewIntStat(SubsystemDatabaseKey, "warn_channels_per_doc_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.WarnChannelsPerDocCount, err = NewIntStat(SubsystemDatabaseKey, "warn_channels_per_doc_count", WarnChannelsPerDocCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.WarnGrantsPerDocCount, err = NewIntStat(SubsystemDatabaseKey, "warn_grants_per_doc_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.WarnGrantsPerDocCount, err = NewIntStat(SubsystemDatabaseKey, "warn_grants_per_doc_count", WarnGrantsPerDocCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.WarnXattrSizeCount, err = NewIntStat(SubsystemDatabaseKey, "warn_xattr_size_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.WarnXattrSizeCount, err = NewIntStat(SubsystemDatabaseKey, "warn_xattr_size_count", WarnsXattrSizeCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.SyncFunctionCount, err = NewIntStat(SubsystemDatabaseKey, "sync_function_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.SyncFunctionCount, err = NewIntStat(SubsystemDatabaseKey, "sync_function_count", SyncFunctionCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.SyncFunctionTime, err = NewIntStat(SubsystemDatabaseKey, "sync_function_time", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.SyncFunctionTime, err = NewIntStat(SubsystemDatabaseKey, "sync_function_time", SyncFunctionTimeDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.SyncFunctionExceptionCount, err = NewIntStat(SubsystemDatabaseKey, "sync_function_exception_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.SyncFunctionExceptionCount, err = NewIntStat(SubsystemDatabaseKey, "sync_function_exception_count", SyncFunctionExceptionCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumReplicationsRejectedLimit, err = NewIntStat(SubsystemDatabaseKey, "num_replications_rejected_limit", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.NumReplicationsRejectedLimit, err = NewIntStat(SubsystemDatabaseKey, "num_replications_rejected_limit", NumReplicationsRejectedLimitDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumPublicRestRequests, err = NewIntStat(SubsystemDatabaseKey, "num_public_rest_requests", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.NumPublicRestRequests, err = NewIntStat(SubsystemDatabaseKey, "num_public_rest_requests", NumPublicRestRequestsDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.TotalSyncTime, err = NewIntStat(SubsystemDatabaseKey, "total_sync_time", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.TotalSyncTime, err = NewIntStat(SubsystemDatabaseKey, "total_sync_time", TotalSyncTimeDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ImportProcessCompute, err = NewIntStat(SubsystemDatabaseKey, "import_process_compute", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.ImportProcessCompute, err = NewIntStat(SubsystemDatabaseKey, "import_process_compute", ImportProcessComputeDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
@@ -1550,27 +1549,27 @@ func (d *DbStats) InitDeltaSyncStats() error {
 	labelKeys := []string{DatabaseLabelKey}
 	labelVals := []string{d.dbName}
 
-	resUtil.DeltasRequested, err = NewIntStat(SubsystemDeltaSyncKey, "deltas_requested", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.DeltasRequested, err = NewIntStat(SubsystemDeltaSyncKey, "deltas_requested", DeltasRequestedDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.DeltasSent, err = NewIntStat(SubsystemDeltaSyncKey, "deltas_sent", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.DeltasSent, err = NewIntStat(SubsystemDeltaSyncKey, "deltas_sent", DeltasSentDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.DeltaPullReplicationCount, err = NewIntStat(SubsystemDeltaSyncKey, "delta_pull_replication_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.DeltaPullReplicationCount, err = NewIntStat(SubsystemDeltaSyncKey, "delta_pull_replication_count", DeltaPullReplicationCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.DeltaCacheHit, err = NewIntStat(SubsystemDeltaSyncKey, "delta_cache_hit", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.DeltaCacheHit, err = NewIntStat(SubsystemDeltaSyncKey, "delta_cache_hit", DeltaCacheHitDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.DeltaCacheMiss, err = NewIntStat(SubsystemDeltaSyncKey, "delta_sync_miss", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.DeltaCacheMiss, err = NewIntStat(SubsystemDeltaSyncKey, "delta_sync_miss", DeltaCacheMissDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.DeltaPushDocCount, err = NewIntStat(SubsystemDeltaSyncKey, "delta_push_doc_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.DeltaPushDocCount, err = NewIntStat(SubsystemDeltaSyncKey, "delta_push_doc_count", DeltaPushDocCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
@@ -1599,23 +1598,23 @@ func (d *DbStats) initSecurityStats() error {
 		labelKeys := []string{DatabaseLabelKey}
 		labelVals := []string{d.dbName}
 
-		resUtil.AuthFailedCount, err = NewIntStat(SubsystemSecurity, "auth_failed_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.AuthFailedCount, err = NewIntStat(SubsystemSecurity, "auth_failed_count", AuthFailedCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return err
 		}
-		resUtil.AuthSuccessCount, err = NewIntStat(SubsystemSecurity, "auth_success_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.AuthSuccessCount, err = NewIntStat(SubsystemSecurity, "auth_success_count", AuthSuccessCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return err
 		}
-		resUtil.NumAccessErrors, err = NewIntStat(SubsystemSecurity, "num_access_errors", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.NumAccessErrors, err = NewIntStat(SubsystemSecurity, "num_access_errors", NumAccessErrorsDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return err
 		}
-		resUtil.NumDocsRejected, err = NewIntStat(SubsystemSecurity, "num_docs_rejected", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.NumDocsRejected, err = NewIntStat(SubsystemSecurity, "num_docs_rejected", NumDocsRejectedDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return err
 		}
-		resUtil.TotalAuthTime, err = NewIntStat(SubsystemSecurity, "total_auth_time", labelKeys, labelVals, prometheus.GaugeValue, 0)
+		resUtil.TotalAuthTime, err = NewIntStat(SubsystemSecurity, "total_auth_time", TotalAuthTimeDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 		if err != nil {
 			return err
 		}
@@ -1694,46 +1693,46 @@ func NewCollectionStats(dbName, scopeAndCollectionName string) (stats *Collectio
 
 	stats = &CollectionStats{}
 
-	stats.SyncFunctionCount, err = NewIntStat(SubsystemCollection, "sync_function_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	stats.SyncFunctionCount, err = NewIntStat(SubsystemCollection, "sync_function_count", SyncFunctionCountCollDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return nil, err
 	}
-	stats.SyncFunctionTime, err = NewIntStat(SubsystemCollection, "sync_function_time", labelKeys, labelVals, prometheus.CounterValue, 0)
+	stats.SyncFunctionTime, err = NewIntStat(SubsystemCollection, "sync_function_time", SyncFunctionTimeCollDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return nil, err
 	}
-	stats.SyncFunctionRejectCount, err = NewIntStat(SubsystemCollection, "sync_function_reject_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	stats.SyncFunctionRejectCount, err = NewIntStat(SubsystemCollection, "sync_function_reject_count", SyncFunctionRejectCountCollDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return nil, err
 	}
-	stats.SyncFunctionRejectAccessCount, err = NewIntStat(SubsystemCollection, "sync_function_reject_access_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	stats.SyncFunctionRejectAccessCount, err = NewIntStat(SubsystemCollection, "sync_function_reject_access_count", SyncFunctionRejectAccessCountCollDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return nil, err
 	}
-	stats.SyncFunctionExceptionCount, err = NewIntStat(SubsystemCollection, "sync_function_exception_count", labelKeys, labelVals, prometheus.CounterValue, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	stats.ImportCount, err = NewIntStat(SubsystemCollection, "import_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+	stats.SyncFunctionExceptionCount, err = NewIntStat(SubsystemCollection, "sync_function_exception_count", SyncFunctionExceptionCountCollDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return nil, err
 	}
 
-	stats.NumDocReads, err = NewIntStat(SubsystemCollection, "num_doc_reads", labelKeys, labelVals, prometheus.CounterValue, 0)
-	if err != nil {
-		return nil, err
-	}
-	stats.DocReadsBytes, err = NewIntStat(SubsystemCollection, "doc_reads_bytes", labelKeys, labelVals, prometheus.CounterValue, 0)
+	stats.ImportCount, err = NewIntStat(SubsystemCollection, "import_count", ImportCountCollDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return nil, err
 	}
 
-	stats.NumDocWrites, err = NewIntStat(SubsystemCollection, "num_doc_writes", labelKeys, labelVals, prometheus.CounterValue, 0)
+	stats.NumDocReads, err = NewIntStat(SubsystemCollection, "num_doc_reads", NumDocReadsCollDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return nil, err
 	}
-	stats.DocWritesBytes, err = NewIntStat(SubsystemCollection, "doc_writes_bytes", labelKeys, labelVals, prometheus.CounterValue, 0)
+	stats.DocReadsBytes, err = NewIntStat(SubsystemCollection, "doc_reads_bytes", DocReadsBytesCollDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	stats.NumDocWrites, err = NewIntStat(SubsystemCollection, "num_doc_writes", NumDocWritesCollDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return nil, err
+	}
+	stats.DocWritesBytes, err = NewIntStat(SubsystemCollection, "doc_writes_bytes", DocWritesBytesCollDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -1770,115 +1769,115 @@ func (d *DbStats) DBReplicatorStats(replicationID string) (*DbReplicatorStats, e
 		labelKeys := []string{DatabaseLabelKey, ReplicationLabelKey}
 		labelVals := []string{d.dbName, replicationID}
 
-		resUtil.NumAttachmentBytesPushed, err = NewIntStat(SubsystemReplication, "sgr_num_attachment_bytes_pushed", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.NumAttachmentBytesPushed, err = NewIntStat(SubsystemReplication, "sgr_num_attachment_bytes_pushed", SGRNumAttachmentBytesPushedDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.NumAttachmentPushed, err = NewIntStat(SubsystemReplication, "sgr_num_attachments_pushed", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.NumAttachmentPushed, err = NewIntStat(SubsystemReplication, "sgr_num_attachments_pushed", SGRNumAttachmentsPushedDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.NumDocPushed, err = NewIntStat(SubsystemReplication, "sgr_num_docs_pushed", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.NumDocPushed, err = NewIntStat(SubsystemReplication, "sgr_num_docs_pushed", SGRNumDocsPushedDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.NumDocsFailedToPush, err = NewIntStat(SubsystemReplication, "sgr_num_docs_failed_to_push", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.NumDocsFailedToPush, err = NewIntStat(SubsystemReplication, "sgr_num_docs_failed_to_push", SGRNumDocsFailedToPushDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.PushConflictCount, err = NewIntStat(SubsystemReplication, "sgr_push_conflict_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.PushConflictCount, err = NewIntStat(SubsystemReplication, "sgr_push_conflict_count", SGRPushConflictCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.PushRejectedCount, err = NewIntStat(SubsystemReplication, "sgr_push_rejected_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.PushRejectedCount, err = NewIntStat(SubsystemReplication, "sgr_push_rejected_count", SGRPushRejectedCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.PushDeltaSentCount, err = NewIntStat(SubsystemReplication, "sgr_deltas_sent", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.PushDeltaSentCount, err = NewIntStat(SubsystemReplication, "sgr_deltas_sent", SGRDeltasSentDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.DocsCheckedSent, err = NewIntStat(SubsystemReplication, "sgr_docs_checked_sent", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.DocsCheckedSent, err = NewIntStat(SubsystemReplication, "sgr_docs_checked_sent", SGRDocsCheckedSentDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.NumConnectAttemptsPush, err = NewIntStat(SubsystemReplication, "sgr_num_connect_attempts_push", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.NumConnectAttemptsPush, err = NewIntStat(SubsystemReplication, "sgr_num_connect_attempts_push", SGRNumConnectAttemptsPushDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.NumReconnectsAbortedPush, err = NewIntStat(SubsystemReplication, "sgr_num_reconnects_aborted_push", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.NumReconnectsAbortedPush, err = NewIntStat(SubsystemReplication, "sgr_num_reconnects_aborted_push", SGRNumReconnectsAbortedPushDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.NumAttachmentBytesPulled, err = NewIntStat(SubsystemReplication, "sgr_num_attachment_bytes_pulled", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.NumAttachmentBytesPulled, err = NewIntStat(SubsystemReplication, "sgr_num_attachment_bytes_pulled", SGRNumAttachmentBytesPulledDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.NumAttachmentsPulled, err = NewIntStat(SubsystemReplication, "sgr_num_attachments_pulled", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.NumAttachmentsPulled, err = NewIntStat(SubsystemReplication, "sgr_num_attachments_pulled", SGRNumAttachmentsPulledDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.PulledCount, err = NewIntStat(SubsystemReplication, "sgr_num_docs_pulled", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.PulledCount, err = NewIntStat(SubsystemReplication, "sgr_num_docs_pulled", SGRNumDocsPulledDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.PurgedCount, err = NewIntStat(SubsystemReplication, "sgr_num_docs_purged", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.PurgedCount, err = NewIntStat(SubsystemReplication, "sgr_num_docs_purged", SGRNumDocsPurgedDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.FailedToPullCount, err = NewIntStat(SubsystemReplication, "sgr_num_docs_failed_to_pull", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.FailedToPullCount, err = NewIntStat(SubsystemReplication, "sgr_num_docs_failed_to_pull", SGRNumDocsFailedToPullDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.DeltaReceivedCount, err = NewIntStat(SubsystemReplication, "sgr_deltas_recv", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.DeltaReceivedCount, err = NewIntStat(SubsystemReplication, "sgr_deltas_recv", SGRDeltasRecvDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.DeltaRequestedCount, err = NewIntStat(SubsystemReplication, "sgr_deltas_requested", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.DeltaRequestedCount, err = NewIntStat(SubsystemReplication, "sgr_deltas_requested", SGRDeltasRequestedDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.DocsCheckedReceived, err = NewIntStat(SubsystemReplication, "sgr_docs_checked_recv", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.DocsCheckedReceived, err = NewIntStat(SubsystemReplication, "sgr_docs_checked_recv", SGRDocsCheckedRecvDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.ConflictResolvedLocalCount, err = NewIntStat(SubsystemReplication, "sgr_conflict_resolved_local_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.ConflictResolvedLocalCount, err = NewIntStat(SubsystemReplication, "sgr_conflict_resolved_local_count", SGRConflictResolvedLocalCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.ConflictResolvedRemoteCount, err = NewIntStat(SubsystemReplication, "sgr_conflict_resolved_remote_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.ConflictResolvedRemoteCount, err = NewIntStat(SubsystemReplication, "sgr_conflict_resolved_remote_count", SGRConflictResolvedRemoteCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.ConflictResolvedMergedCount, err = NewIntStat(SubsystemReplication, "sgr_conflict_resolved_merge_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.ConflictResolvedMergedCount, err = NewIntStat(SubsystemReplication, "sgr_conflict_resolved_merge_count", SGRConflictResolvedMergeCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.NumConnectAttemptsPull, err = NewIntStat(SubsystemReplication, "sgr_num_connect_attempts_pull", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.NumConnectAttemptsPull, err = NewIntStat(SubsystemReplication, "sgr_num_connect_attempts_pull", SGRNumConnectAttemptsPullDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.NumReconnectsAbortedPull, err = NewIntStat(SubsystemReplication, "sgr_num_reconnects_aborted_pull", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.NumReconnectsAbortedPull, err = NewIntStat(SubsystemReplication, "sgr_num_reconnects_aborted_pull", SGRNumReconnectsAbortedPullDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.NumHandlersPanicked, err = NewIntStat(SubsystemReplication, "sgr_num_handlers_panicked", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.NumHandlersPanicked, err = NewIntStat(SubsystemReplication, "sgr_num_handlers_panicked", SGRNumHandlersPanickedDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.ExpectedSequenceLen, err = NewIntStat(SubsystemReplication, "expected_sequence_len", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.ExpectedSequenceLen, err = NewIntStat(SubsystemReplication, "expected_sequence_len", SGRExpectedSequenceLengthDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.ExpectedSequenceLenPostCleanup, err = NewIntStat(SubsystemReplication, "expected_sequence_len_post_cleanup", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.ExpectedSequenceLenPostCleanup, err = NewIntStat(SubsystemReplication, "expected_sequence_len_post_cleanup", SGRExpectedSequenceLengthPostCleanupDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.ProcessedSequenceLen, err = NewIntStat(SubsystemReplication, "processed_sequence_len", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.ProcessedSequenceLen, err = NewIntStat(SubsystemReplication, "processed_sequence_len", SGRProcessedSequenceLength, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
-		resUtil.ProcessedSequenceLenPostCleanup, err = NewIntStat(SubsystemReplication, "processed_sequence_len_post_cleanup", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.ProcessedSequenceLenPostCleanup, err = NewIntStat(SubsystemReplication, "processed_sequence_len_post_cleanup", SGRProcessedSequenceLengthPostCleanupDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -1929,27 +1928,27 @@ func (d *DbStats) InitSharedBucketImportStats() error {
 		labelKeys := []string{DatabaseLabelKey}
 		labelVals := []string{d.dbName}
 
-		resUtil.ImportCount, err = NewIntStat(SubsystemSharedBucketImport, "import_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.ImportCount, err = NewIntStat(SubsystemSharedBucketImport, "import_count", ImportCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return err
 		}
-		resUtil.ImportCancelCAS, err = NewIntStat(SubsystemSharedBucketImport, "import_cancel_cas", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.ImportCancelCAS, err = NewIntStat(SubsystemSharedBucketImport, "import_cancel_cas", ImportCancelCASDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return err
 		}
-		resUtil.ImportErrorCount, err = NewIntStat(SubsystemSharedBucketImport, "import_error_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.ImportErrorCount, err = NewIntStat(SubsystemSharedBucketImport, "import_error_count", ImportErrorCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return err
 		}
-		resUtil.ImportProcessingTime, err = NewIntStat(SubsystemSharedBucketImport, "import_processing_time", labelKeys, labelVals, prometheus.GaugeValue, 0)
+		resUtil.ImportProcessingTime, err = NewIntStat(SubsystemSharedBucketImport, "import_processing_time", ImportProcessingTimeDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 		if err != nil {
 			return err
 		}
-		resUtil.ImportHighSeq, err = NewIntStat(SubsystemSharedBucketImport, "import_high_seq", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.ImportHighSeq, err = NewIntStat(SubsystemSharedBucketImport, "import_high_seq", ImportHighSeqDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return err
 		}
-		resUtil.ImportPartitions, err = NewIntStat(SubsystemSharedBucketImport, "import_partitions", labelKeys, labelVals, prometheus.GaugeValue, 0)
+		resUtil.ImportPartitions, err = NewIntStat(SubsystemSharedBucketImport, "import_partitions", ImportPartitionsDesc, labelKeys, labelVals, prometheus.GaugeValue, 0)
 		if err != nil {
 			return err
 		}
@@ -2001,15 +2000,15 @@ func (d *DbStats) _initQueryStat(useViews bool, queryName string) error {
 			splitName := strings.Split(queryName, ".")
 			prometheusKey = splitName[len(splitName)-1]
 		}
-		resUtil.QueryCount, err = NewIntStat(SubsystemGSIViews, prometheusKey+"_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.QueryCount, err = NewIntStat(SubsystemGSIViews, prometheusKey+"_count", QueryNameCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return err
 		}
-		resUtil.QueryErrorCount, err = NewIntStat(SubsystemGSIViews, prometheusKey+"_error_count", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.QueryErrorCount, err = NewIntStat(SubsystemGSIViews, prometheusKey+"_error_count", QueryNameErrorCountDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return err
 		}
-		resUtil.QueryTime, err = NewIntStat(SubsystemGSIViews, prometheusKey+"_time", labelKeys, labelVals, prometheus.CounterValue, 0)
+		resUtil.QueryTime, err = NewIntStat(SubsystemGSIViews, prometheusKey+"_time", QueryNameTimeDesc, labelKeys, labelVals, prometheus.CounterValue, 0)
 		if err != nil {
 			return err
 		}

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -1,0 +1,416 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package base
+
+// ResourceUtilization descriptions
+const (
+	AdminNetBytesRecDesc = "The total number of bytes received (since node start-up) on the network interface to which the Sync Gateway api.admin_interface is bound. " +
+		"By default, that is the number of bytes received on 127.0.0.1:4985 since node start-up."
+
+	AdminNetBytesSentDesc = "The total number of bytes sent (since node start-up) on the network interface to which the Sync Gateway api.admin_interface is bound." +
+		"By default, that is the number of bytes sent on 127.0.0.1:4985 since node start-up."
+
+	ErrorCountDesc = "The total number of errors logged."
+
+	GoMemHeapAllocDesc = "HeapAlloc is bytes of allocated heap objects. \"Allocated\" heap objects include all reachable objects, as well as unreachable objects that the garbage collector has " +
+		"not yet freed. Specifically, HeapAlloc increases as heap objects are allocated and decreases as the heap is swept and unreachable objects are freed. Sweeping occurs " +
+		"incrementally between GC cycles, so these two processes occur simultaneously, and as a result HeapAlloc tends to change smoothly (in contrast with the sawtooth that is" +
+		"typical of stop-the-world garbage collectors)."
+
+	GoMemHeapIdleDesc = "HeapIdle is bytes in idle (unused) spans. Idle spans have no objects in them. These spans could be (and may already have been) returned to the OS, or they can" +
+		" be reused for heap allocations, or they can be reused as stack memory. HeapIdle minus HeapReleased estimates the amount of memory that could be returned to the OS, but is being retained by " +
+		"the runtime so it can grow the heap without requesting more memory from the OS. If this difference is significantly larger than the heap size, it indicates there was a recent " +
+		"transient spike in live heap size."
+
+	GoMemHeapInUseDesc = "HeapInuse is bytes in in-use spans. In-use spans have at least one object in them. These spans an only be used for other objects of roughly the same size. " +
+		"HeapInuse minus HeapAlloc estimates the amount of memory that has been dedicated to particular size classes, but is not currently being used. This is an upper bound on " +
+		"fragmentation, but in general this memory can be reused efficiently."
+
+	GoMemHeapReleasedDesc = "HeapReleased is bytes of physical memory returned to the OS. This counts heap memory from idle spans that was returned to the OS and has not yet been reacquired for the heap."
+
+	GoMemPauseTotalNSDesc = "PauseTotalNs is the cumulative nanoseconds in GC stop-the-world pauses since the program started. During a stop-the-world pause, all goroutines are paused and only the garbage collector can run."
+
+	GoMemStackInUseDesc = "StackInuse is bytes in stack spans. In-use stack spans have at least one stack in them. These spans can only be used for other stacks of the same size. There is no StackIdle because unused stack spans are " +
+		"returned to the heap (and hence counted toward HeapIdle)."
+
+	GoMemStackSysDesc = "StackSys is bytes of stack memory obtained from the OS. StackSys is StackInuse, plus any memory obtained directly from the OS for OS thread stacks (which should be minimal)."
+
+	GoMemSysDesc = "Sys is the total bytes of memory obtained from the OS. Sys is the sum of the XSys fields below. Sys measures the virtual address space reserved by the Go runtime for the " +
+		"heap, stacks, and other internal data structures. It's likely that not all of the virtual address space is backed by physical memory at any given moment, though in general " +
+		"it all was at some point."
+
+	GoroutinesHighWatermarkDesc = "Peak number of go routines since process start."
+
+	NumGoroutinesDesc = "The total number of goroutines."
+
+	ProcessCPUPercentUtilDesc = "The CPU’s utilization as percentage value. The CPU usage calculation is performed based on user and system CPU time, but it does not include components such as iowait. The derivation means that the values of " +
+		"process_cpu_percent_utilization and %Cpu, returned when running the top command, will differ"
+
+	ProcessMemoryResidentDesc = "The memory utilization (Resident Set Size) for the process, in bytes."
+
+	PublicNetBytesRecvDesc = "The total number of bytes received (since node start-up) on the network interface to which the Sync Gateway api.public_interface is bound. By default, that is the number of bytes received on 127.0.0.1:4984 since node start-up"
+
+	PublicNetBytesSentDesc = "The total number of bytes sent (since node start-up) on the network interface to which Sync Gateway api.public_interface is bound. By default, that is the number of bytes sent on 127.0.0.1:4984 since node start-up."
+
+	SystemMemoryTotalDesc = "The total memory available on the system in bytes."
+
+	WarnCountDesc = "The total number of warnings logged."
+
+	UptimeDesc = "The total uptime."
+)
+
+// cache stats descriptions
+const (
+	AbandonedSequencesDesc = "The total number of skipped sequences that were not found after 60 minutes and were abandoned."
+
+	ChanCacheActiveRevsDesc = "The total number of active revisions in the channel cache."
+
+	ChanCacheBypassCountDesc = "The total number of transient bypass channel caches created to serve requests when the channel cache was at capacity."
+
+	ChanCacheChannelsAddedDesc = "The total number of channel caches added. The metric doesn’t decrease when a channel is removed. That is, it is similar to chan_cache_num_channels but doesn’t track removals."
+
+	ChanCacheChannelsEvictedInactiveDesc = "The total number of channel cache channels evicted due to inactivity."
+
+	ChanCacheChannelsEvictedNRUDesc = "The total number of active channel cache channels evicted, based on ‘not recently used’ criteria."
+
+	ChanCacheCompactCountDesc = "The total number of channel cache compaction runs."
+
+	ChanCacheCompactTimeDesc = "The total amount of time taken by channel cache compaction across all compaction runs."
+
+	ChanCacheHitsDesc = "The total number of channel cache requests fully served by the cache. This metric is useful in calculating the channel cache hit ratio: channel cache hit ratio = chan_cache_hits / (chan_cache_hits + chan_cache_misses)"
+
+	ChanCacheMaxEntriesDesc = "The total size of the largest channel cache. This metric helps with channel cache tuning, and provides a hint on cache size variation (when compared to average cache size)."
+
+	ChanCacheMissesDesc = "The total number of channel cache requests not fully served by the cache. This metric is useful when calculating the channel cache hit ratio: channel cache hit ratio = chan_cache_hits / (chan_cache_hits + chan_cache_misses)"
+
+	ChanCacheNumChannelsDesc = "The total number of channels being cached. The total number of channels being cached provides insight into potential max cache size requirements and also node usage (for example, chan_cache_num_channels * max_cache_size)."
+
+	ChanCachePendingQueriesDesc = "The total number of channel cache pending queries."
+
+	ChanCacheRemovalRevsDesc = "The total number of removal revisions in the channel cache. This metric acts as a reminder that removals must be considered when tuning the channel cache size and also helps users understand whether they should be tuning " +
+		"tombstone retention policy (metadata purge interval) and running compact."
+
+	ChanCacheTombstoneRevsDesc = "The total number of tombstone revisions in the channel cache. This metric acts as a reminder that tombstones and removals must be considered when tuning the channel cache size and also helps users understand whether they should " +
+		"be tuning tombstone retention policy (metadata purge interval), and running compact."
+
+	HighSeqCachedDesc = "The highest sequence number cached. Note: There may be skipped sequences lower than high_seq_cached."
+
+	HighStableSeqCachedDesc = "The highest contiguous sequence number that has been cached."
+
+	NumActiveChannelsDesc = "The total number of active channels."
+
+	NumSkippedSeqsDesc = "The total number of skipped sequences."
+
+	PendingSeqLengthDesc = "The total number of pending sequences. These are out-of-sequence entries waiting to be cached."
+
+	RevCacheBypassDesc = "The total number of revision cache bypass operations performed."
+
+	RevCacheHitsDesc = "The total number of revision cache hits. This metric can be used to calculate the ratio of revision cache hits: " +
+		"Rev Cache Hit Ratio = rev_cache_hits / (rev_cache_hits + rev_cache_misses)"
+
+	RevCacheMissesDesc = "The total number of revision cache misses. This metric can be used to calculate the ratio of revision cache misses: " +
+		"Rev Cache Miss Ratio = rev_cache_misses / (rev_cache_hits + rev_cache_misses)"
+
+	SkippedSeqLengthDesc = "The current length of the pending skipped sequence queue."
+
+	ViewQueriesDesc = "The total view_queries."
+
+	NonMobileIgnoredCountDesc = "Number of non mobile documents that were ignored off the cache feed."
+)
+
+// CBL Replication pull stats descriptions
+
+const (
+	AttachmentPullBytesDesc = "The total size of attachments pulled. This is the pre-compressed size."
+
+	AttachmentPullCountDesc = "The total number of attachments pulled."
+
+	MaxPendingDesc = "The high watermark for the number of documents buffered during feed processing, waiting on a missing earlier sequence."
+
+	NumPullRepliActiveContinuousDesc = "The total number of continuous pull replications in the active state."
+
+	NumPullRepliActiveOneShotDesc = "The total number of one-shot pull replications in the active state."
+
+	NumPullRepliCaughtUpDesc = "The total number of replications which have caught up to the latest changes."
+
+	NumPullRepliSinceZeroDesc = "The total number of new replications started (/_changes?since=0)."
+
+	NumPullRepliContinuousDesc = "The total number of continuous pull replications."
+
+	NumPullRepliTotalOneshotDesc = "The total number of one-shot pull replications."
+
+	RequestChangesCountDesc = "The total number of changes requested. This metric can be used to calculate the latency of requested changes: " +
+		"changes request latency = request_changes_time / request_changes_count"
+
+	RequestChangesTimeDesc = "Total time taken to handle changes request response. This metric can be used to calculate the latency of requested changes: " +
+		"changes request latency = request_changes_time / request_changes_count"
+
+	RevProcessingTimeDesc = "The total amount of time processing rev messages (revisions) during pull revision. This metric can be used with rev_send_count to calculate " +
+		"the average processing time per revision: average processing time per revision = rev_processing_time / rev_send_count"
+
+	RevSendCountDesc = "The total number of rev messages processed during replication. This metric can be used with rev_processing_time to calculate the average processing time per revision: " +
+		"average processing time per revision = rev_processing_time / rev_send_count"
+
+	RevSendLatencyDesc = "The total amount of time between Sync Gateway receiving a request for a revision and that revision being sent. In a pull replication, Sync Gateway sends a /_changes request to " +
+		"the client and the client responds with the list of revisions it wants to receive. So, rev_send_latency measures the time between the client asking for those revisions and Sync Gateway sending them to the client. " +
+		"Note: Measuring time from the /_changes response means that this stat will vary significantly depending on the changes batch size A larger batch size will result in a spike of this stat, even if the processing time per revision is unchanged. " +
+		"A more useful stat might be the average processing time per revision: average processing time per revision = rev_processing_time] / rev_send_count"
+
+	NumPullRepliTotalCaughtUpDesc = "The total number of pull replications which have caught up to the latest changes across all replications."
+
+	RevErrorCountDesc = "The total number of rev messages that were failed to be processed during replication."
+)
+
+// CBL replication push stats descriptions
+const (
+	AttachmentPushBytesDesc = "The total number of attachment bytes pushed."
+
+	CompactionAttachmentStartTimeDesc = "The compaction_attachment_start_time"
+
+	CompactionTombstoneStartTimeDesc = "The compaction_tombstone_start_time."
+
+	AttachmentPushCountDesc = "The total number of attachments pushed."
+
+	ConflictWriteCountDesc = "The total number of writes that left the document in a conflicted state. Includes new conflicts, and mutations that don’t resolve existing conflicts."
+
+	DocPushCountDesc = "The total number of documents pushed."
+
+	ProposeChangeCountDesc = "The total number of changes and-or proposeChanges messages processed since node start-up. The propose_change_count stat can be useful when: (a). Assessing the number of redundant requested changes being pushed by the client. " +
+		"Do this by comparing the propose_change_count value with the number of actual writes num_doc_writes, which could indicate that clients are pushing changes already known to Sync Gateway. " +
+		"(b). Identifying situations where push replications are unexpectedly being restarted from zero."
+
+	ProposeChangeTimeDesc = "The total time spent processing changes and/or proposeChanges messages. The propose_change_time stat can be useful in diagnosing push replication issues arising from potential bottlenecks changes and-or proposeChanges processing. " +
+		"Note: The propose_change_time is not included in the write_processing_time"
+
+	SyncFunctionCountDesc = "The total number of times that the sync_function is evaluated. The {sync_function_count_ stat is useful in assessing the usage of the sync_function, when used in conjunction with the sync_function_time."
+
+	SyncFunctionTimeDesc = "The total time spent evaluating the sync_function. The sync_function_time stat can be useful when: (a). Troubleshooting excessively long push times, where it can help identify potential sync_function bottlenecks (for example, those arising from complex, " +
+		"or inefficient, sync_function design. (b). Assessing the overall contribution of the sync_function processing to overall push replication write times."
+
+	WriteProcessingTimeDesc = "Total time spent processing writes. Measures complete request-to-response time for a write. The write_processing_time stat can be useful when: (a). Determining the average time per write: average time per write = write_processing_time / num_doc_writes stat value " +
+		"(b). Assessing the benefit of adding additional Sync Gateway nodes, as it can point to Sync Gateway being a bottleneck (c). Troubleshooting slow push replication, in which case it ought to be considered in conjunction with sync_function_time"
+
+	DocPushErrorCountDesc = "The total number of documents that failed to push."
+)
+
+// Database specific stats descriptions
+const (
+	AbandonedSeqsDesc = "The total number of skipped sequences abandoned, based on cache.channel_cache.max_wait_skipped."
+
+	CacheFeedDesc = "Contains low level dcp stats: (a). dcp_backfill_expected - the expected number of sequences in backfill (b). dcp_backfill_completed - the number of backfill items processed (c). dcp_rollback_count - the number of DCP rollbacks"
+
+	Crc32MatchCountDesc = "The total number of instances during import when the document cas had changed, but the document was not imported because the document body had not changed."
+
+	DCPCachingCountDesc = "The total number of DCP mutations added to Sync Gateway’s channel cache. Can be used with dcp_caching_time to monitor cache processing latency. That is, the time between seeing a change on the DCP feed and when it’s available in the channel cache: " +
+		"DCP cache latency = dcp_caching_time / dcp_caching_count"
+
+	DCPCachingTimeDesc = "The total time between a DCP mutation arriving at Sync Gateway and being added to channel cache. This metric can be used with dcp_caching_count to monitor cache processing latency. That is, the time between seeing a change on the DCP feed and when it’s available in the channel cache: " +
+		"dcp_cache_latency = dcp_caching_time / dcp_caching_count"
+
+	DCPReceivedCountDesc = "The total number of document mutations received by Sync Gateway over DCP."
+
+	DCPReceivedTimeDesc = "The time between a document write and that document being received by Sync Gateway over DCP. If the document was written prior to Sync Gateway starting the feed, it is recorded as the time since the feed was started. " +
+		"This metric can be used to monitor DCP feed processing latency"
+
+	DocReadsBytesBlipDesc = "The total number of bytes read via Couchbase Lite 2.x replication since Sync Gateway node startup."
+
+	DocWritesBytesDesc = "The total number of bytes written as part of document writes since Sync Gateway node startup."
+
+	DocWritesBytesBlipDesc = "The total number of bytes written as part of Couchbase Lite document writes since Sync Gateway node startup."
+
+	DocWritesXattrBytesDesc = "The total size of xattrs written (in bytes)."
+
+	HighSeqFeedDesc = "Highest sequence number seen on the caching DCP feed."
+
+	NumAttachmentsCompactedDesc = "The number of attachments compacted import_feed"
+
+	ImportFeedDesc = "Contains low level dcp stats: (a). dcp_backfill_expected - the expected number of sequences in backfill (b). dcp_backfill_completed - the number of backfill items processed (c). dcp_rollback_count - the number of DCP rollbacks"
+
+	NumDocsReadsBlipDesc = "The total number of documents read via Couchbase Lite 2.x replication since Sync Gateway node startup."
+
+	NumDocReadsRestDesc = "The total number of documents read via the REST API since Sync Gateway node startup. Includes Couchbase Lite 1.x replication."
+
+	NumDocWritesDesc = "The total number of documents written by any means (replication, rest API interaction or imports) since Sync Gateway node startup."
+
+	NumReplicationsActiveDesc = "The total number of active replications. This metric only counts continuous pull replications."
+
+	NumReplicationsTotalDesc = "The total number of replications created since Sync Gateway node startup."
+
+	SequenceAssignedCountDesc = "The total number of sequence numbers assigned."
+
+	SequenceGetCountDesc = "The total number of high sequence lookups."
+
+	SequenceIncrCountDesc = "The total number of times the sequence counter document has been incremented."
+
+	SequenceReleasedCountDesc = "The total number of unused, reserved sequences released by Sync Gateway."
+
+	SequenceReservedCountDesc = "The total number of sequences reserved by Sync Gateway."
+
+	WarnChannelNameSizeCountDesc = "The total number of warnings relating to the channel name size."
+
+	WarnChannelsPerDocCountDesc = "The total number of warnings relating to the channel count exceeding the channel count threshold."
+
+	WarnGrantsPerDocCountDesc = "The total number of warnings relating to the grant count exceeding the grant count threshold."
+
+	WarnsXattrSizeCountDesc = "The total number of warnings relating to the xattr sync data being larger than a configured threshold."
+
+	ReplicationBytesReceivedDesc = "Total bytes received over replications to the database."
+
+	ReplicationBytesSentDesc = "Total bytes sent over replications from the database."
+
+	NumTombstonesCompactedDesc = "Number of tombstones compacted through tombstone compaction task on the database."
+
+	SyncFunctionExceptionCountDesc = "The total number of times that a sync function encountered an exception (across all collections)."
+
+	NumReplicationsRejectedLimitDesc = "The total number of times a replication connection is rejected due ot it being over the threshold."
+
+	NumPublicRestRequestsDesc = "The total number of requests sent over the public REST api."
+
+	TotalSyncTimeDesc = "The total total sync time is a proxy for websocket connections. Tracking long lived and potentially idle connections. " +
+		"This stat represents the continually growing number of connections per sec."
+
+	ImportProcessComputeDesc = "Represents the compute unit for import processes on the database."
+)
+
+// Delta Sync stats descriptions
+const (
+	DeltaCacheHitDesc = "The total number of requested deltas that were available in the revision cache."
+
+	DeltaCacheMissDesc = "The total number of requested deltas that were not available in the revision cache."
+
+	DeltaPullReplicationCountDesc = "The number of delta replications that have been run."
+
+	DeltaPushDocCountDesc = "The total number of documents pushed as a delta from a previous revision."
+
+	DeltasRequestedDesc = "The total number of times a revision is sent as delta from a previous revision."
+
+	DeltasSentDesc = "The total number of revisions sent to clients as deltas."
+)
+
+// Query stats descriptions
+const (
+	QueryNameCountDesc = "The total number of gsi/view queries performed."
+
+	QueryNameErrorCountDesc = "The total number of errors that occurred when performing the gsi/view query"
+
+	QueryNameTimeDesc = "The total time taken to perform gsi/view queries."
+)
+
+// Security stats descriptions
+const (
+	AuthFailedCountDesc = "The total number of unsuccessful authentications. This metric is useful in monitoring the number of authentication errors."
+
+	AuthSuccessCountDesc = "The total number of successful authentications. This metric is useful in monitoring the number of authenticated requests."
+
+	NumAccessErrorsDesc = "The total number of documents rejected by write access functions (requireAccess, requireRole, requireUser)."
+
+	NumDocsRejectedDesc = "The total number of documents rejected by the sync_function."
+
+	TotalAuthTimeDesc = "The total time spent in authenticating all requests. This metric can be compared with auth_success_count and auth_failed_count " +
+		"to derive an average success and-or fail rate."
+)
+
+// Shared Bucket Import stats descriptions
+const (
+	ImportCancelCASDesc = "The total number of imports cancelled due to cas failure."
+
+	ImportCountDesc = "The total number of docs imported."
+
+	ImportErrorCountDesc = "The total number of errors arising as a result of a document import."
+
+	ImportHighSeqDesc = "The highest sequence number value imported."
+
+	ImportPartitionsDesc = "The total number of import partitions."
+
+	ImportProcessingTimeDesc = "The total time taken to process a document import."
+)
+
+// DB Replicators stats descriptions (ISGR Specific)
+const (
+	SGRDocsCheckedSentDesc = "The total number of documents checked for changes since replication started. This represents the number " +
+		"of potential change notifications pushed by Sync Gateway. This is not necessarily the number of documents pushed, as a given target might already have the change " +
+		"and this is used by Inter-Sync Gateway and SG Replicate. This metric can be useful when analyzing replication history, and to filter by active replications."
+
+	SGRNumDocsFailedToPushDesc = "The total number of documents that failed to be pushed since replication started. Used by Inter-Sync Gateway and SG Replicate."
+
+	SGRNumDocsPushedDesc = "The total number of documents that were pushed since replication started. Used by Inter-Sync Gateway and SG Replicate."
+
+	SGRNumAttachmentsPushedDesc = "The total number of attachments that were pushed since replication started."
+
+	SGRNumAttachmentBytesPushedDesc = "The total number of bytes in all the attachments that were pushed since replication started."
+
+	SGRNumAttachmentsPulledDesc = "The total number of attachments that were pulled since replication started."
+
+	SGRNumAttachmentBytesPulledDesc = "The total number of bytes in all the attachments that were pulled since replication started."
+
+	SGRNumDocsPulledDesc = "The total number of documents that were pulled since replication started."
+
+	SGRNumDocsPurgedDesc = "The total number of documents that were purged since replication started."
+
+	SGRNumDocsFailedToPullDesc = "The total number of document pulls that failed since replication started."
+
+	SGRPushConflictCountDesc = "The total number of pushed documents that conflicted since replication started."
+
+	SGRPushRejectedCountDesc = "The total number of pushed documents that were rejected since replication started."
+
+	SGRDocsCheckedRecvDesc = "The total number of document changes received over changes message."
+
+	SGRDeltasRecvDesc = "The total number of documents that were purged since replication started."
+
+	SGRDeltasRequestedDesc = "The total number of deltas requested."
+
+	SGRDeltasSentDesc = "The total number of deltas sent."
+
+	SGRConflictResolvedLocalCountDesc = "The total number of conflicting documents that were resolved successfully locally (by the active replicator)"
+
+	SGRConflictResolvedRemoteCountDesc = "The total number of conflicting documents that were resolved successfully remotely (by the active replicator)"
+
+	SGRConflictResolvedMergeCountDesc = "The total number of conflicting documents that were resolved successfully by a merge action (by the active replicator)"
+
+	SGRNumConnectAttemptsPushDesc = "Number of connection attempts made for push replication connection."
+
+	SGRNumReconnectsAbortedPushDesc = "Number of times push replication connection reconnect loops have failed."
+
+	SGRNumConnectAttemptsPullDesc = "Number of connection attempts made for pull replication connection."
+
+	SGRNumReconnectsAbortedPullDesc = "Number of times pull replication connection reconnect loops have failed."
+
+	SGRNumHandlersPanickedDesc = "The number of times a handler panicked and didn't know how to recover from it."
+
+	SGRExpectedSequenceLengthDesc = "The length of expectedSeqs list in the ISGR checkpointer."
+
+	SGRExpectedSequenceLengthPostCleanupDesc = "The length of expectedSeqs list in the ISGR checkpointer after the cleanup task has been run."
+
+	SGRProcessedSequenceLength = "The length of processedSeqs list in the ISGR checkpointer."
+
+	SGRProcessedSequenceLengthPostCleanupDesc = "The length of processedSeqs list in the ISGR checkpointer after the cleanup task has been run."
+)
+
+// Collection stats descriptions
+const (
+	SyncFunctionCountCollDesc = "The total number of times that the sync_function is evaluated for this collection."
+
+	SyncFunctionTimeCollDesc = "The total time spent evaluating the sync_function for this keyspace."
+
+	SyncFunctionRejectCountCollDesc = "The total number of documents rejected by the sync_function for this collection."
+
+	SyncFunctionRejectAccessCountCollDesc = "The total number of documents rejected by write access functions (requireAccess, requireRole, requireUser) for this collection."
+
+	SyncFunctionExceptionCountCollDesc = "The total number of times the sync function encountered an exception for this collection."
+
+	ImportCountCollDesc = "The total number of documents imported to this collection since Sync Gateway node startup."
+
+	NumDocReadsCollDesc = "The total number of documents read from this collection since Sync Gateway node startup (i.e. sending to a client)"
+
+	DocReadsBytesCollDesc = "The total number of bytes read from this collection as part of document writes since Sync Gateway node startup."
+
+	NumDocWritesCollDesc = "The total number of documents written to this collection since Sync Gateway node startup (i.e. receiving from a client)"
+
+	DocWritesBytesCollDesc = "The total number of bytes written to this collection as part of document writes since Sync Gateway node startup."
+)

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -8,6 +8,8 @@
 
 package base
 
+const SGWUpDesc = "This provides a stat for sgw_up where the value will be fixed to one."
+
 // ResourceUtilization descriptions
 const (
 	AdminNetBytesRecDesc = "The total number of bytes received (since node start-up) on the network interface to which the Sync Gateway api.admin_interface is bound. " +

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -278,6 +278,12 @@ const (
 		"This stat represents the continually growing number of connections per sec."
 
 	ImportProcessComputeDesc = "Represents the compute unit for import processes on the database."
+
+	PublicRestBytesWrittenDesc = "Number of bytes written over public interface for REST api"
+
+	PublicRestBytesReadDesc = "The total amount of bytes read over the public REST api"
+
+	SyncProcessComputeDesc = "The compute unit for syncing with clients measured through cpu time and memory used for sync"
 )
 
 // Delta Sync stats descriptions

--- a/rest/counted_response_writer_test.go
+++ b/rest/counted_response_writer_test.go
@@ -101,7 +101,7 @@ func TestCountableResponseWriterNoDelay(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			stat, err := base.NewIntStat(base.SubsystemDatabaseKey, "http_bytes_written", nil, nil, prometheus.CounterValue, 0)
+			stat, err := base.NewIntStat(base.SubsystemDatabaseKey, "http_bytes_written", base.PublicRestBytesWrittenDesc, nil, nil, prometheus.CounterValue, 0)
 			require.NoError(t, err)
 
 			responseWriter := getResponseWriter(t, stat, test.name, 0)
@@ -134,7 +134,7 @@ func TestCountableResponseWriterWithDelay(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 
-			stat, err := base.NewIntStat(base.SubsystemDatabaseKey, "http_bytes_written", nil, nil, prometheus.CounterValue, 0)
+			stat, err := base.NewIntStat(base.SubsystemDatabaseKey, "http_bytes_written", base.PublicRestBytesWrittenDesc, nil, nil, prometheus.CounterValue, 0)
 			require.NoError(t, err)
 			responseWriter := getResponseWriter(t, stat, test.name, 30*time.Second)
 			n, err := responseWriter.Write(oneByte)

--- a/rest/stats_context_test.go
+++ b/rest/stats_context_test.go
@@ -57,6 +57,7 @@ func TestDescriptionPopulation(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	bodyString, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
 	// assert on a HELP description
 	assert.Contains(t, string(bodyString), `HELP sgw_cache_high_seq_stable The highest contiguous sequence number that has been cached.`)
 }


### PR DESCRIPTION
CBG-3182

PR to add the description of a stats to the stats that already exist on the product. Added new file full of descriptions for stats and changed the existing methods to add a description parameter to pass into the `AddDesc` function on prometheus.


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1942/
