### PR TITLE
CBG-2837 skip test that doesn't work with xattrs

### DIFF
--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -232,7 +232,9 @@ func TestAsyncInitWithResync(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}
-
+	if !base.TestUseXattrs() {
+		t.Skip("this test uses xattrs for verification of sync metadata")
+	}
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP)
 


### PR DESCRIPTION
This test reads xattrs of the documents and doesn't work with xattrs disabled.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

