### PR TITLE
CBG-3192: Added exposed /metrics endpoint to API docs

### DIFF
--- a/docs/api/metric.yaml
+++ b/docs/api/metric.yaml
@@ -29,7 +29,9 @@ servers:
         default: localhost
 paths:
   /_metrics:
-    $ref: ./paths/metric/_metrics.yaml
+    $ref: ./paths/metric/metrics.yaml
+  /metrics:
+    $ref: ./paths/metric/metrics.yaml
   /_expvar:
     $ref: ./paths/metric/_expvar.yaml
 tags:

--- a/docs/api/paths/metric/metrics.yaml
+++ b/docs/api/paths/metric/metrics.yaml
@@ -24,4 +24,4 @@ get:
             type: string
   tags:
     - Prometheus
-  operationId: get__metrics
+  operationId: get_metrics


### PR DESCRIPTION
CBG-3192

Added `/metrics` to metrics API specs

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
N/A
