### PR TITLE
Add ctx to know db/collection for replication based messages

### DIFF
--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -174,6 +174,7 @@ func (bsc *BlipSyncContext) register(profile string, handlerFn func(*blipHandler
 			BlipSyncContext: bsc,
 			db:              bsc.copyContextDatabase(),
 			serialNumber:    bsc.incrementSerialNumber(),
+			ctx:             bsc.loggingCtx,
 		}
 
 		// Trace log the full message body and properties


### PR DESCRIPTION
Inspired from TestReplicationHeartbeatRemoval

This typically didn't have database name associated with it before so maybe it's a bit redundant because we have a blip ctx ID but we don't get to know database or collection without this log information easily.

There's a bit of tension over whether knowing the information when the document is being processed is useful.