### PR TITLE
CBG-3206: In-memory struct and API for HLV

### DIFF
--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -1,0 +1,97 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package db
+
+type HybridLogicalVector struct {
+	CurrentVersionCAS uint64            // current version cas (or cvCAS) stores the current CAS at the time of replication
+	SourceID          string            // source bucket uuid of where this entry originated from
+	Version           uint64            // current cas of the current version on the version vector
+	MergeVersions     map[string]uint64 // map of merge versions for fast efficient lookup
+	PreviousVersions  map[string]uint64 // map of previous versions for fast efficient lookup
+}
+
+// CurrentVersionVector is a structure used to add a new sourceID:CAS entry to a HLV
+type CurrentVersionVector struct {
+	VersionCAS uint64
+	SourceID   string
+}
+
+// GetCurrentVersion return the current version vector from the HLV in memory
+func (hlv *HybridLogicalVector) GetCurrentVersion() (string, uint64) {
+	return hlv.SourceID, hlv.Version
+}
+
+// IsInConflict tests to see if in memory HLV is conflicting with another HLV
+func (hlv *HybridLogicalVector) IsInConflict(otherVector HybridLogicalVector) bool {
+	// test if in memory version vector is dominating or if they are equal. If so no conflict is present
+	if hlv.isDominating(otherVector) || hlv.isEqual(otherVector) {
+		return false
+	}
+	// if the version vectors aren't dominating or equal then conflict is present
+	return true
+}
+
+// AddVersion adds a version vector to the in memory representation of a HLV and moves current version vector to
+// previous versions on the HLV
+func (hlv *HybridLogicalVector) AddVersion(version CurrentVersionVector) {
+	hlv.PreviousVersions[hlv.SourceID] = hlv.Version
+	hlv.Version = version.VersionCAS
+	hlv.SourceID = version.SourceID
+}
+
+// Remove removes a vector from previous versions section of in memory HLV
+func (hlv *HybridLogicalVector) Remove(source string) {
+	delete(hlv.PreviousVersions, source)
+}
+
+// isDominating tests if in memory HLV is dominating over another
+func (hlv *HybridLogicalVector) isDominating(otherVector HybridLogicalVector) bool {
+	// in memory hlv is dominating if source ID matches other sourceID but with in memory CAS greater than other vector
+	if hlv.SourceID == otherVector.SourceID && hlv.Version > otherVector.Version {
+		return true
+	}
+	// if im memory CAS is greater than other and other sourceID:CAS pair is inside previous versions or
+	// merge versions then in memory HLV is dominating
+	if hlv.Version > otherVector.Version {
+		if hlv.PreviousVersions[otherVector.SourceID] == otherVector.Version {
+			return true
+		}
+		if hlv.MergeVersions[otherVector.SourceID] == otherVector.Version {
+			return true
+		}
+	}
+	return false
+}
+
+// isEqual tests if in memory HLV is equal to another
+func (hlv *HybridLogicalVector) isEqual(otherVector HybridLogicalVector) bool {
+	// if in memory hlv sourceID the sae as other sourceID and in memory CAS is equal to other CAS then HLV's are equal
+	if hlv.SourceID == otherVector.SourceID && hlv.Version == otherVector.Version {
+		return true
+	}
+	// if the in memory HLV merge versions isn't empty and the other HLV merge versions isn't empty AND if
+	// merge versions between the two HLV's are the same, they are equal
+	if len(hlv.MergeVersions) != 0 && len(otherVector.MergeVersions) != 0 {
+		if hlv.equalMergeVectors(otherVector) {
+			return true
+		}
+	}
+	// they aren't equal
+	return false
+}
+
+// equalMergeVectors tests if two merge vectors between HLV's are equal or not
+func (hlv *HybridLogicalVector) equalMergeVectors(otherVector HybridLogicalVector) bool {
+	for k, v := range hlv.MergeVersions {
+		if v != otherVector.MergeVersions[k] {
+			return false
+		}
+	}
+	return true
+}

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -1,0 +1,187 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package db
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInternalHLVFunctions:
+//   - Tests internal api methods on the HLV work as expected
+//   - Tests methods GetCurrentVersion, AddVersion and Remove
+func TestInternalHLVFunctions(t *testing.T) {
+	mv := make(map[string]uint64)
+	pv := make(map[string]uint64)
+	currSourceId := "s_5pRi8Piv1yLcLJ1iVNJIsA"
+	const currVersion = 12345678
+
+	mv["s_NqiIe0LekFPLeX4JvTO6Iw"] = 345454
+	pv["s_YZvBpEaztom9z5V/hDoeIw"] = 64463204720
+
+	hlv := HybridLogicalVector{
+		CurrentVersionCAS: currVersion,
+		SourceID:          currSourceId,
+		Version:           currVersion,
+		MergeVersions:     mv,
+		PreviousVersions:  pv,
+	}
+
+	const newCAS = 123456789
+	const newSource = "s_testsource"
+	currVersionVector := CurrentVersionVector{
+		VersionCAS: 123456789,
+		SourceID:   newSource,
+	}
+
+	pv[currSourceId] = currVersion
+
+	// Get current version vector, sourceID and CAS pair
+	source, version := hlv.GetCurrentVersion()
+	assert.Equal(t, currSourceId, source)
+	assert.Equal(t, uint64(currVersion), version)
+
+	// Add a new version vector pair to the HLV structure and assert that it moves the current version vector pair to the previous versions section
+	hlv.AddVersion(currVersionVector)
+	assert.Equal(t, uint64(newCAS), hlv.Version)
+	assert.Equal(t, newSource, hlv.SourceID)
+	assert.True(t, reflect.DeepEqual(hlv.PreviousVersions, pv))
+
+	// Remove a sourceID CAS pair from previous versions section of the HLV structure (for compaction)
+	hlv.Remove(currSourceId)
+	delete(pv, currSourceId)
+	assert.True(t, reflect.DeepEqual(hlv.PreviousVersions, pv))
+}
+
+// TestConflictDetectionDominating:
+//   - Tests two cases where one HLV's is said to be 'dominating' over another and thus not in conflict
+//   - Test case 1: where sourceID is the same between HLV's but the in memory representation has higher version CAS
+//   - Test case 2: where sourceID is different and the in memory HLV has higher CAS than other HLV but the other HLV's
+//     sourceID:CAS pair is present in the in memory HLV's previous versions
+//   - Assert that both scenarios returns false from IsInConflict method, as we have a HLV that is dominating in each case
+func TestConflictDetectionDominating(t *testing.T) {
+	testCases := []struct {
+		name          string
+		sourceID      string
+		version       uint64
+		otherSourceID string
+		otherVersion  uint64
+	}{
+		{
+			name:          "dominating case 1",
+			sourceID:      "cluster1",
+			version:       2,
+			otherSourceID: "cluster1",
+			otherVersion:  1,
+		},
+		{
+			name:          "dominating case 2",
+			sourceID:      "cluster1",
+			version:       2,
+			otherSourceID: "cluster2",
+			otherVersion:  1,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.name == "dominating case 1" {
+				inMemoryHLV := HybridLogicalVector{
+					CurrentVersionCAS: testCase.version,
+					SourceID:          testCase.sourceID,
+					Version:           testCase.version,
+				}
+				otherHLV := HybridLogicalVector{
+					CurrentVersionCAS: testCase.otherVersion,
+					SourceID:          testCase.otherSourceID,
+					Version:           testCase.otherVersion,
+				}
+				require.False(t, inMemoryHLV.IsInConflict(otherHLV))
+			} else {
+				inMemoryPV := make(map[string]uint64)
+				inMemoryHLV := HybridLogicalVector{
+					CurrentVersionCAS: testCase.version,
+					SourceID:          testCase.sourceID,
+					Version:           testCase.version,
+				}
+				otherHLV := HybridLogicalVector{
+					CurrentVersionCAS: testCase.otherVersion,
+					SourceID:          testCase.otherSourceID,
+					Version:           testCase.otherVersion,
+				}
+				inMemoryPV["cluster2"] = 1
+				inMemoryHLV.PreviousVersions = inMemoryPV
+				require.False(t, inMemoryHLV.IsInConflict(otherHLV))
+			}
+		})
+	}
+}
+
+// TestConflictEqualHLV:
+//   - Creates two 'equal' HLV's and asserts that they are not in conflict
+//   - Then tests other code path in event source ID differs and current CAS differs but with identical merge versions
+//     that we identify they are not in conflict and are in fact 'equal'
+func TestConflictEqualHLV(t *testing.T) {
+	inMemoryMV := make(map[string]uint64)
+	inMemoryPV := make(map[string]uint64)
+
+	inMemoryHLV := HybridLogicalVector{
+		CurrentVersionCAS: 1,
+		SourceID:          "cluster1",
+		Version:           1,
+		MergeVersions:     inMemoryMV,
+		PreviousVersions:  inMemoryPV,
+	}
+
+	otherVectorMV := make(map[string]uint64)
+	otherVectorPV := make(map[string]uint64)
+	otherVector := HybridLogicalVector{
+		CurrentVersionCAS: 1,
+		SourceID:          "cluster1",
+		Version:           1,
+		MergeVersions:     otherVectorMV,
+		PreviousVersions:  otherVectorPV,
+	}
+	require.False(t, inMemoryHLV.IsInConflict(otherVector))
+
+	// test conflict detection with different version CAS but same merge versions (force that code path)
+	inMemoryHLV.Version = 12
+	inMemoryHLV.SourceID = "cluster2"
+	inMemoryHLV.MergeVersions["test1"] = 123
+	otherVector.MergeVersions["test1"] = 123
+	require.False(t, inMemoryHLV.IsInConflict(otherVector))
+}
+
+// TestConflictExample:
+//   - Takes example conflict scenario from PRD to see if we correctly identify conflict in that scenario
+//   - Creates two HLV's similar to ones in example and calls IsInConflict to assert it returns true
+func TestConflictExample(t *testing.T) {
+	inMemoryMV := make(map[string]uint64)
+	inMemoryPV := make(map[string]uint64)
+	inMemoryHLV := HybridLogicalVector{
+		CurrentVersionCAS: 1,
+		SourceID:          "cluster1",
+		Version:           3,
+		MergeVersions:     inMemoryMV,
+		PreviousVersions:  inMemoryPV,
+	}
+
+	otherVectorMV := make(map[string]uint64)
+	otherVectorPV := make(map[string]uint64)
+	otherVector := HybridLogicalVector{
+		CurrentVersionCAS: 1,
+		SourceID:          "cluster2",
+		Version:           2,
+		MergeVersions:     otherVectorMV,
+		PreviousVersions:  otherVectorPV,
+	}
+	require.True(t, inMemoryHLV.IsInConflict(otherVector))
+}

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -10,6 +10,8 @@ package db
 
 import (
 	"reflect"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,168 +22,173 @@ import (
 //   - Tests internal api methods on the HLV work as expected
 //   - Tests methods GetCurrentVersion, AddVersion and Remove
 func TestInternalHLVFunctions(t *testing.T) {
-	mv := make(map[string]uint64)
 	pv := make(map[string]uint64)
 	currSourceId := "s_5pRi8Piv1yLcLJ1iVNJIsA"
 	const currVersion = 12345678
-
-	mv["s_NqiIe0LekFPLeX4JvTO6Iw"] = 345454
 	pv["s_YZvBpEaztom9z5V/hDoeIw"] = 64463204720
 
-	hlv := HybridLogicalVector{
-		CurrentVersionCAS: currVersion,
-		SourceID:          currSourceId,
-		Version:           currVersion,
-		MergeVersions:     mv,
-		PreviousVersions:  pv,
-	}
+	inputHLV := []string{"s_5pRi8Piv1yLcLJ1iVNJIsA@12345678", "s_YZvBpEaztom9z5V/hDoeIw@64463204720", "m_s_NqiIe0LekFPLeX4JvTO6Iw@345454"}
+	hlv := createHLVForTest(t, inputHLV)
 
 	const newCAS = 123456789
 	const newSource = "s_testsource"
-	currVersionVector := CurrentVersionVector{
-		VersionCAS: 123456789,
-		SourceID:   newSource,
-	}
 
-	pv[currSourceId] = currVersion
+	// create a new version vector entry that will error method AddVersion
+	badNewVector := CurrentVersionVector{
+		VersionCAS: 123345,
+		SourceID:   currSourceId,
+	}
+	// create a new version vector entry that should be added to HLV successfully
+	newVersionVector := CurrentVersionVector{
+		VersionCAS: newCAS,
+		SourceID:   currSourceId,
+	}
 
 	// Get current version vector, sourceID and CAS pair
 	source, version := hlv.GetCurrentVersion()
 	assert.Equal(t, currSourceId, source)
 	assert.Equal(t, uint64(currVersion), version)
 
+	// add new version vector with same sourceID as current sourceID and assert it doesn't add to previous versions then restore HLV to previous state
+	require.NoError(t, hlv.AddVersion(newVersionVector))
+	assert.Equal(t, 1, len(hlv.PreviousVersions))
+	hlv.Version = currVersion
+
+	// attempt to add new version vector to HLV that has a CAS value less than the current CAS value
+	require.Error(t, hlv.AddVersion(badNewVector))
+
+	// add current version and sourceID of HLV to pv map for assertions
+	pv[currSourceId] = currVersion
 	// Add a new version vector pair to the HLV structure and assert that it moves the current version vector pair to the previous versions section
-	hlv.AddVersion(currVersionVector)
+	newVersionVector.SourceID = newSource
+	require.NoError(t, hlv.AddVersion(newVersionVector))
 	assert.Equal(t, uint64(newCAS), hlv.Version)
 	assert.Equal(t, newSource, hlv.SourceID)
 	assert.True(t, reflect.DeepEqual(hlv.PreviousVersions, pv))
 
+	// remove garbage sourceID from PV and assert we get error
+	require.Error(t, hlv.Remove("testing"))
 	// Remove a sourceID CAS pair from previous versions section of the HLV structure (for compaction)
-	hlv.Remove(currSourceId)
+	require.NoError(t, hlv.Remove(currSourceId))
 	delete(pv, currSourceId)
 	assert.True(t, reflect.DeepEqual(hlv.PreviousVersions, pv))
 }
 
 // TestConflictDetectionDominating:
 //   - Tests two cases where one HLV's is said to be 'dominating' over another and thus not in conflict
-//   - Test case 1: where sourceID is the same between HLV's but the in memory representation has higher version CAS
-//   - Test case 2: where sourceID is different and the in memory HLV has higher CAS than other HLV but the other HLV's
-//     sourceID:CAS pair is present in the in memory HLV's previous versions
-//   - Assert that both scenarios returns false from IsInConflict method, as we have a HLV that is dominating in each case
+//   - Test case 1: where sourceID is the same between HLV's but HLV(A) has higher version CAS than HLV(B) thus A dominates
+//   - Test case 2: where sourceID is different and HLV(A) sourceID is present in HLV(B) PV and HLV(A) has dominating version
+//   - Test case 3: where sourceID is different and HLV(A) sourceID is present in HLV(B) MV and HLV(A) has dominating version
+//   - Test case 4: where sourceID is test case 2 but flipped to show the code checks for dominating versions both sides
+//   - Assert that all scenarios returns false from IsInConflict method, as we have a HLV that is dominating in each case
 func TestConflictDetectionDominating(t *testing.T) {
 	testCases := []struct {
 		name          string
-		sourceID      string
-		version       uint64
-		otherSourceID string
-		otherVersion  uint64
+		inputListHLVA []string
+		inputListHLVB []string
 	}{
 		{
-			name:          "dominating case 1",
-			sourceID:      "cluster1",
-			version:       2,
-			otherSourceID: "cluster1",
-			otherVersion:  1,
+			name:          "Test case 1",
+			inputListHLVA: []string{"cluster1@20", "cluster2@2"},
+			inputListHLVB: []string{"cluster1@10", "cluster2@1"},
 		},
 		{
-			name:          "dominating case 2",
-			sourceID:      "cluster1",
-			version:       2,
-			otherSourceID: "cluster2",
-			otherVersion:  1,
+			name:          "Test case 2",
+			inputListHLVA: []string{"cluster1@20", "cluster3@3"},
+			inputListHLVB: []string{"cluster2@10", "cluster1@15"},
+		},
+		{
+			name:          "Test case 3",
+			inputListHLVA: []string{"cluster1@20", "cluster3@3"},
+			inputListHLVB: []string{"cluster2@10", "m_cluster1@12", "m_cluster2@11"},
+		},
+		{
+			name:          "Test case 4",
+			inputListHLVA: []string{"cluster2@10", "cluster1@15"},
+
+			inputListHLVB: []string{"cluster1@20", "cluster3@3"},
 		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			if testCase.name == "dominating case 1" {
-				inMemoryHLV := HybridLogicalVector{
-					CurrentVersionCAS: testCase.version,
-					SourceID:          testCase.sourceID,
-					Version:           testCase.version,
-				}
-				otherHLV := HybridLogicalVector{
-					CurrentVersionCAS: testCase.otherVersion,
-					SourceID:          testCase.otherSourceID,
-					Version:           testCase.otherVersion,
-				}
-				require.False(t, inMemoryHLV.IsInConflict(otherHLV))
-			} else {
-				inMemoryPV := make(map[string]uint64)
-				inMemoryHLV := HybridLogicalVector{
-					CurrentVersionCAS: testCase.version,
-					SourceID:          testCase.sourceID,
-					Version:           testCase.version,
-				}
-				otherHLV := HybridLogicalVector{
-					CurrentVersionCAS: testCase.otherVersion,
-					SourceID:          testCase.otherSourceID,
-					Version:           testCase.otherVersion,
-				}
-				inMemoryPV["cluster2"] = 1
-				inMemoryHLV.PreviousVersions = inMemoryPV
-				require.False(t, inMemoryHLV.IsInConflict(otherHLV))
-			}
+			hlvA := createHLVForTest(t, testCase.inputListHLVA)
+			hlvB := createHLVForTest(t, testCase.inputListHLVB)
+			require.False(t, hlvA.IsInConflict(hlvB))
 		})
 	}
 }
 
 // TestConflictEqualHLV:
-//   - Creates two 'equal' HLV's and asserts that they are not in conflict
+//   - Creates two 'equal' HLV's and asserts we identify them as equal
 //   - Then tests other code path in event source ID differs and current CAS differs but with identical merge versions
-//     that we identify they are not in conflict and are in fact 'equal'
+//     that we identify they are in fact 'equal'
+//   - Then test the same but for previous versions
 func TestConflictEqualHLV(t *testing.T) {
-	inMemoryMV := make(map[string]uint64)
-	inMemoryPV := make(map[string]uint64)
+	// two vectors with the same sourceID and version pair as the current vector
+	inputHLVA := []string{"cluster1@10", "cluster2@3"}
+	inputHLVB := []string{"cluster1@10", "cluster2@4"}
+	hlvA := createHLVForTest(t, inputHLVA)
+	hlvB := createHLVForTest(t, inputHLVB)
+	require.True(t, hlvA.isEqual(hlvB))
 
-	inMemoryHLV := HybridLogicalVector{
-		CurrentVersionCAS: 1,
-		SourceID:          "cluster1",
-		Version:           1,
-		MergeVersions:     inMemoryMV,
-		PreviousVersions:  inMemoryPV,
-	}
+	// test conflict detection with different version CAS but same merge versions
+	inputHLVA = []string{"cluster2@12", "cluster3@3", "cluster4@2"}
+	inputHLVB = []string{"cluster1@10", "cluster3@3", "cluster4@2"}
+	hlvA = createHLVForTest(t, inputHLVA)
+	hlvB = createHLVForTest(t, inputHLVB)
+	require.True(t, hlvA.isEqual(hlvB))
 
-	otherVectorMV := make(map[string]uint64)
-	otherVectorPV := make(map[string]uint64)
-	otherVector := HybridLogicalVector{
-		CurrentVersionCAS: 1,
-		SourceID:          "cluster1",
-		Version:           1,
-		MergeVersions:     otherVectorMV,
-		PreviousVersions:  otherVectorPV,
-	}
-	require.False(t, inMemoryHLV.IsInConflict(otherVector))
+	// test conflict detection with different version CAS but same previous version vectors
+	inputHLVA = []string{"cluster3@2", "cluster1@3", "cluster2@5"}
+	hlvA = createHLVForTest(t, inputHLVA)
+	inputHLVB = []string{"cluster4@7", "cluster1@3", "cluster2@5"}
+	hlvB = createHLVForTest(t, inputHLVB)
+	require.True(t, hlvA.isEqual(hlvB))
 
-	// test conflict detection with different version CAS but same merge versions (force that code path)
-	inMemoryHLV.Version = 12
-	inMemoryHLV.SourceID = "cluster2"
-	inMemoryHLV.MergeVersions["test1"] = 123
-	otherVector.MergeVersions["test1"] = 123
-	require.False(t, inMemoryHLV.IsInConflict(otherVector))
+	// remove an entry from one of the HLV PVs to assert we get false returned from isEqual
+	require.NoError(t, hlvA.Remove("cluster1"))
+	require.False(t, hlvA.isEqual(hlvB))
 }
 
 // TestConflictExample:
 //   - Takes example conflict scenario from PRD to see if we correctly identify conflict in that scenario
 //   - Creates two HLV's similar to ones in example and calls IsInConflict to assert it returns true
 func TestConflictExample(t *testing.T) {
-	inMemoryMV := make(map[string]uint64)
-	inMemoryPV := make(map[string]uint64)
-	inMemoryHLV := HybridLogicalVector{
-		CurrentVersionCAS: 1,
-		SourceID:          "cluster1",
-		Version:           3,
-		MergeVersions:     inMemoryMV,
-		PreviousVersions:  inMemoryPV,
-	}
+	input := []string{"cluster1@11", "cluster3@2", "cluster2@4"}
+	inMemoryHLV := createHLVForTest(t, input)
 
-	otherVectorMV := make(map[string]uint64)
-	otherVectorPV := make(map[string]uint64)
-	otherVector := HybridLogicalVector{
-		CurrentVersionCAS: 1,
-		SourceID:          "cluster2",
-		Version:           2,
-		MergeVersions:     otherVectorMV,
-		PreviousVersions:  otherVectorPV,
-	}
+	input = []string{"cluster2@2", "cluster3@3"}
+	otherVector := createHLVForTest(t, input)
 	require.True(t, inMemoryHLV.IsInConflict(otherVector))
+}
+
+// createHLVForTest is a helper function to create a HLV for use in a test. Takes a list of strings in the format of <sourceID@version> and assumes
+// first entry is current version. For merge version entries you must specify 'm_' as a prefix to sourceID NOTE: it also sets cvCAS to the current version
+func createHLVForTest(tb *testing.T, inputList []string) HybridLogicalVector {
+	hlvOutput := NewHybridLogicalVector()
+
+	// first element will be current version and source pair
+	currentVersionPair := strings.Split(inputList[0], "@")
+	hlvOutput.SourceID = currentVersionPair[0]
+	version, err := strconv.Atoi(currentVersionPair[1])
+	require.NoError(tb, err)
+	hlvOutput.Version = uint64(version)
+	hlvOutput.CurrentVersionCAS = uint64(version)
+
+	// remove current version entry in list now we have parsed it into the HLV
+	inputList = inputList[1:]
+
+	for _, value := range inputList {
+		currentVersionPair = strings.Split(value, "@")
+		version, err = strconv.Atoi(currentVersionPair[1])
+		require.NoError(tb, err)
+		if strings.HasPrefix(currentVersionPair[0], "m_") {
+			// add entry to merge version removing the leading prefix for sourceID
+			hlvOutput.MergeVersions[currentVersionPair[0][2:]] = uint64(version)
+		} else {
+			// if its not got the prefix we assume its a previous version entry
+			hlvOutput.PreviousVersions[currentVersionPair[0]] = uint64(version)
+		}
+	}
+	return hlvOutput
 }


### PR DESCRIPTION
CBG-3206

Basic in memory struct for HLV and the basic operations on that struct. 
Note to reviewer logic on detecting conflict between two HLV's is pulled from this section of this doc -> https://docs.google.com/document/d/1KTGXrRnxWMaRI6jwI0-0hoSmBHe3S6IEL3QvprhN_Lk/edit#heading=h.x50fvn11ltma 
Includes tests on operations defined on the HLV but also various conflict detection scenarios including false conflict scenarios. Essentially if a HLV is 'dominating' they are said not to be in conflict, so test coverage is included. 

Have included a helper method for tests to create a HLV for test.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1945/
