### PR TITLE
CBG-3235: Query based resync infinite loop when querylimit <= number of docs+tombstones

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -1761,10 +1761,11 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 			raw []byte, rawXattr []byte, deleteDoc bool, expiry *uint32, err error) {
 			// There's no scenario where a doc should from non-deleted to deleted during UpdateAllDocChannels processing,
 			// so deleteDoc is always returned as false.
+			doc, err := unmarshalDocumentWithXattr(docid, currentValue, currentXattr, currentUserXattr, cas, DocUnmarshalAll)
+			updatedHighSeq = doc.Sequence
 			if currentValue == nil || len(currentValue) == 0 {
 				return nil, nil, deleteDoc, nil, base.ErrUpdateCancel
 			}
-			doc, err := unmarshalDocumentWithXattr(docid, currentValue, currentXattr, currentUserXattr, cas, DocUnmarshalAll)
 			if err != nil {
 				return nil, nil, deleteDoc, nil, err
 			}

--- a/db/database.go
+++ b/db/database.go
@@ -1589,7 +1589,7 @@ func (db *DatabaseCollectionWithUser) UpdateAllDocChannels(ctx context.Context, 
 			key := realDocID(docid)
 			queryRowCount++
 			docsProcessed++
-			highSeq, unusedSequences, err = db.resyncDocument(ctx, docid, key, regenerateSequences, unusedSequences)
+			_, unusedSequences, err = db.resyncDocument(ctx, docid, key, regenerateSequences, unusedSequences)
 			if err == nil {
 				docsChanged++
 			} else if err != base.ErrUpdateCancel {

--- a/db/database.go
+++ b/db/database.go
@@ -1573,9 +1573,6 @@ func (db *DatabaseCollectionWithUser) UpdateAllDocChannels(ctx context.Context, 
 					break
 				}
 			}
-			if !found {
-				break
-			}
 			select {
 			case <-terminator.Done():
 				base.InfofCtx(ctx, base.KeyAll, "Resync was stopped before the operation could be completed. System "+

--- a/db/database.go
+++ b/db/database.go
@@ -1762,12 +1762,12 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 			// There's no scenario where a doc should from non-deleted to deleted during UpdateAllDocChannels processing,
 			// so deleteDoc is always returned as false.
 			doc, err := unmarshalDocumentWithXattr(docid, currentValue, currentXattr, currentUserXattr, cas, DocUnmarshalAll)
+			if err != nil {
+				return nil, nil, deleteDoc, nil, err
+			}
 			updatedHighSeq = doc.Sequence
 			if currentValue == nil || len(currentValue) == 0 {
 				return nil, nil, deleteDoc, nil, base.ErrUpdateCancel
-			}
-			if err != nil {
-				return nil, nil, deleteDoc, nil, err
 			}
 			updatedDoc, shouldUpdate, updatedExpiry, updatedHighSeq, unusedSequences, err = db.getResyncedDocument(ctx, doc, regenerateSequences, unusedSequences)
 			if err != nil {

--- a/db/query.go
+++ b/db/query.go
@@ -24,7 +24,8 @@ import (
 
 // Used for queries that only return doc id
 type QueryIdRow struct {
-	Id string
+	Id  string
+	Seq uint64
 }
 
 // Used for queries that only return doc id

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -3858,7 +3858,6 @@ func TestCacheCompactDuringChangesWait(t *testing.T) {
 
 func TestResyncAllTombstones(t *testing.T) {
 	base.LongRunningTest(t)
-	t.Skip() // skip until CBG-3235 is resolved
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Walrus does not support Xattrs")
 	}


### PR DESCRIPTION
CBG-3235

Describe your PR here...
- Assign highseq before checking if doc is empty on resyncDocument, which was defaulting to 0 before causing
- 		if queryRowCount < queryLimit || highSeq >= endSeq {
- to fail as highseq is 0, leading to an infinite loop


## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1946/
