### PR TITLE
CBG-3132 ensure TestLargeSequence doesn't leave large doc in primary index

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -755,13 +755,6 @@ func TestRequiresCollections(t testing.TB) {
 	}
 }
 
-// DisableTestWithCollections will skip the current test if using named collections.
-func DisableTestWithCollections(t *testing.T) {
-	if TestsUseNamedCollections() {
-		t.Skip("Skipping test because collections are enabled")
-	}
-}
-
 // SkipImportTestsIfNotEnabled skips test that exercise import features
 func SkipImportTestsIfNotEnabled(t *testing.T) {
 

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -939,7 +939,6 @@ func TestOldRevisionStorageError(t *testing.T) {
 func TestLargeSequence(t *testing.T) {
 
 	// Test depends on setting _sync:seq in the default collection location
-	base.DisableTestWithCollections(t)
 	base.LongRunningTest(t)
 
 	db, ctx := setupTestDBWithCustomSyncSeq(t, 9223372036854775807)

--- a/db/functions/graphql_test.go
+++ b/db/functions/graphql_test.go
@@ -416,8 +416,9 @@ type Body = db.Body
 
 // Unit test for GraphQL queries.
 func TestUserGraphQLWithN1QL(t *testing.T) {
-
-	base.DisableTestWithCollections(t)
+	if TestsUseNamedCollections() {
+		t.Skip("Skipping test because collections are enabled")
+	}
 
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test is Couchbase Server only (requires N1QL)")

--- a/db/functions/graphql_test.go
+++ b/db/functions/graphql_test.go
@@ -416,10 +416,9 @@ type Body = db.Body
 
 // Unit test for GraphQL queries.
 func TestUserGraphQLWithN1QL(t *testing.T) {
-	if TestsUseNamedCollections() {
+	if base.TestsUseNamedCollections() {
 		t.Skip("Skipping test because collections are enabled")
 	}
-
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test is Couchbase Server only (requires N1QL)")
 	}


### PR DESCRIPTION
- adding a doc with overlarge JSON will not be emptied by `emptyAllDocsIndex` which is clearing out tombstones.
- allow test to run with or without default collection (already did, but was skipped)
- change comments in code to be more clear about what is happening

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1950/
