### PR TITLE
CBG-3286 Per-db console log settings

### DIFF
--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -165,7 +165,7 @@ func TestCBGTIndexCreation(t *testing.T) {
 			spec := bucket.BucketSpec
 
 			// Use an in-memory cfg, set up cbgt manager
-			ctx := DatabaseLogCtx(TestCtx(t), tc.dbName)
+			ctx := DatabaseLogCtx(TestCtx(t), tc.dbName, nil)
 			cfg, err := NewCbgtCfgMem()
 			require.NoError(t, err)
 			context, err := initCBGTManager(ctx, bucket, spec, cfg, "testIndexCreation", tc.dbName)

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -111,24 +111,28 @@ func (l *ConsoleLogger) logf(format string, args ...interface{}) {
 	}
 }
 
+// shouldLog returns true if a log at the given logLineLevel/logLineKey should get logged for the given logger levels/keys.
+func shouldLog(loggerLevel *LogLevel, loggerKeys *LogKeyMask, logLineLevel LogLevel, logLineKey LogKey) bool {
+	// Log level disabled
+	if !loggerLevel.Enabled(logLineLevel) {
+		return false
+	}
+
+	// Log key All should always log at this point, unless KeyNone is set
+	if logLineKey == KeyAll && !loggerKeys.Enabled(KeyNone) {
+		return true
+	}
+
+	// Finally, check the specific log key is enabled
+	return loggerKeys.Enabled(logLineKey)
+}
+
 // shouldLog returns true if the given logLevel and logKey should get logged.
 func (l *ConsoleLogger) shouldLog(logLevel LogLevel, logKey LogKey) bool {
 	if l == nil || l.logger == nil {
 		return false
 	}
-
-	// Log level disabled
-	if !l.LogLevel.Enabled(logLevel) {
-		return false
-	}
-
-	// Log key All should always log at this point, unless KeyNone is set
-	if logKey == KeyAll && !l.LogKeyMask.Enabled(KeyNone) {
-		return true
-	}
-
-	// Finally, check the specific log key is enabled
-	return l.LogKeyMask.Enabled(logKey)
+	return shouldLog(l.LogLevel, l.LogKeyMask, logLevel, logKey)
 }
 
 func (l *ConsoleLogger) getConsoleLoggerConfig() *ConsoleLoggerConfig {

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -111,6 +111,14 @@ func (l *ConsoleLogger) logf(format string, args ...interface{}) {
 	}
 }
 
+// shouldLog returns true if the given logLevel and logKey should get logged.
+func (l *ConsoleLogger) shouldLog(logLevel LogLevel, logKey LogKey) bool {
+	if l == nil || l.logger == nil {
+		return false
+	}
+	return shouldLog(l.LogLevel, l.LogKeyMask, logLevel, logKey)
+}
+
 // shouldLog returns true if a log at the given logLineLevel/logLineKey should get logged for the given logger levels/keys.
 func shouldLog(loggerLevel *LogLevel, loggerKeys *LogKeyMask, logLineLevel LogLevel, logLineKey LogKey) bool {
 	// Log level disabled
@@ -125,14 +133,6 @@ func shouldLog(loggerLevel *LogLevel, loggerKeys *LogKeyMask, logLineLevel LogLe
 
 	// Finally, check the specific log key is enabled
 	return loggerKeys.Enabled(logLineKey)
-}
-
-// shouldLog returns true if the given logLevel and logKey should get logged.
-func (l *ConsoleLogger) shouldLog(logLevel LogLevel, logKey LogKey) bool {
-	if l == nil || l.logger == nil {
-		return false
-	}
-	return shouldLog(l.LogLevel, l.LogKeyMask, logLevel, logKey)
 }
 
 func (l *ConsoleLogger) getConsoleLoggerConfig() *ConsoleLoggerConfig {

--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -106,7 +106,7 @@ func TestConsoleShouldLog(t *testing.T) {
 			}})
 
 		t.Run(name, func(ts *testing.T) {
-			got := l.shouldLog(test.logToLevel, test.logToKey)
+			got := l.shouldLog(TestCtx(ts), test.logToLevel, test.logToKey)
 			assert.Equal(ts, test.expected, got)
 		})
 	}
@@ -128,7 +128,7 @@ func BenchmarkConsoleShouldLog(b *testing.B) {
 
 		b.Run(name, func(bb *testing.B) {
 			for i := 0; i < bb.N; i++ {
-				l.shouldLog(test.logToLevel, test.logToKey)
+				l.shouldLog(TestCtx(bb), test.logToLevel, test.logToKey)
 			}
 		})
 	}

--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -46,7 +46,7 @@ func initExternalLoggers() {
 }
 
 func updateExternalLoggers() {
-	if consoleLogger != nil && consoleLogger.shouldLog(LevelDebug, KeyWalrus) {
+	if consoleLogger != nil && consoleLogger.shouldLog(context.Background(), LevelDebug, KeyWalrus) {
 		rosmar.SetLogLevel(rosmar.LevelTrace)
 	} else {
 		rosmar.SetLogLevel(rosmar.LevelInfo)

--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -46,7 +46,7 @@ func initExternalLoggers() {
 }
 
 func updateExternalLoggers() {
-	if consoleLogger != nil && consoleLogger.shouldLog(context.Background(), LevelDebug, KeyWalrus) {
+	if consoleLogger != nil && consoleLogger.shouldLog(nil, LevelDebug, KeyWalrus) {
 		rosmar.SetLogLevel(rosmar.LevelTrace)
 	} else {
 		rosmar.SetLogLevel(rosmar.LevelInfo)

--- a/base/logging.go
+++ b/base/logging.go
@@ -365,19 +365,19 @@ func ConsoleLogKey() *LogKeyMask {
 // LogInfoEnabled returns true if either the console should log at info level,
 // or if the infoLogger is enabled.
 func LogInfoEnabled(logKey LogKey) bool {
-	return consoleLogger.shouldLog(context.Background(), LevelInfo, logKey) || infoLogger.shouldLog(LevelInfo)
+	return consoleLogger.shouldLog(nil, LevelInfo, logKey) || infoLogger.shouldLog(LevelInfo)
 }
 
 // LogDebugEnabled returns true if either the console should log at debug level,
 // or if the debugLogger is enabled.
 func LogDebugEnabled(logKey LogKey) bool {
-	return consoleLogger.shouldLog(context.Background(), LevelDebug, logKey) || debugLogger.shouldLog(LevelDebug)
+	return consoleLogger.shouldLog(nil, LevelDebug, logKey) || debugLogger.shouldLog(LevelDebug)
 }
 
 // LogTraceEnabled returns true if either the console should log at trace level,
 // or if the traceLogger is enabled.
 func LogTraceEnabled(logKey LogKey) bool {
-	return consoleLogger.shouldLog(context.Background(), LevelTrace, logKey) || traceLogger.shouldLog(LevelTrace)
+	return consoleLogger.shouldLog(nil, LevelTrace, logKey) || traceLogger.shouldLog(LevelTrace)
 }
 
 // AssertLogContains asserts that the logs produced by function f contain string s.

--- a/base/logging.go
+++ b/base/logging.go
@@ -292,6 +292,7 @@ type DbConsoleLogConfig struct {
 	LogKeys  *LogKeyMask
 }
 
+// shouldLogConsoleDatabase extracts the database's log settings from the context (if set) to determine whether to log
 func shouldLogConsoleDatabase(ctx context.Context, logLevel LogLevel, logKey LogKey) bool {
 	if ctx == nil {
 		return false

--- a/base/logging.go
+++ b/base/logging.go
@@ -253,7 +253,7 @@ func ConsolefCtx(ctx context.Context, logLevel LogLevel, logKey LogKey, format s
 	logTo(ctx, logLevel, logKey, format, args...)
 
 	// If the above logTo didn't already log to stderr, do it directly here
-	if !consoleLogger.isStderr || !consoleLogger.shouldLog(logLevel, logKey) {
+	if !consoleLogger.isStderr || !consoleLogger.shouldLog(ctx, logLevel, logKey) {
 		format = color(addPrefixes(format, ctx, logLevel, logKey), logLevel)
 		_, _ = fmt.Fprintf(consoleFOutput, format+"\n", args...)
 	}
@@ -365,19 +365,19 @@ func ConsoleLogKey() *LogKeyMask {
 // LogInfoEnabled returns true if either the console should log at info level,
 // or if the infoLogger is enabled.
 func LogInfoEnabled(logKey LogKey) bool {
-	return consoleLogger.shouldLog(LevelInfo, logKey) || infoLogger.shouldLog(LevelInfo)
+	return consoleLogger.shouldLog(context.Background(), LevelInfo, logKey) || infoLogger.shouldLog(LevelInfo)
 }
 
 // LogDebugEnabled returns true if either the console should log at debug level,
 // or if the debugLogger is enabled.
 func LogDebugEnabled(logKey LogKey) bool {
-	return consoleLogger.shouldLog(LevelDebug, logKey) || debugLogger.shouldLog(LevelDebug)
+	return consoleLogger.shouldLog(context.Background(), LevelDebug, logKey) || debugLogger.shouldLog(LevelDebug)
 }
 
 // LogTraceEnabled returns true if either the console should log at trace level,
 // or if the traceLogger is enabled.
 func LogTraceEnabled(logKey LogKey) bool {
-	return consoleLogger.shouldLog(LevelTrace, logKey) || traceLogger.shouldLog(LevelTrace)
+	return consoleLogger.shouldLog(context.Background(), LevelTrace, logKey) || traceLogger.shouldLog(LevelTrace)
 }
 
 // AssertLogContains asserts that the logs produced by function f contain string s.

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -29,6 +29,9 @@ type LogContext struct {
 	// Database is the name of the sync gateway database
 	Database string
 
+	// DbConsoleLogConfig is any database-specific log settings that should be applied
+	DbConsoleLogConfig *DbConsoleLogConfig
+
 	// Bucket is the name of the backing bucket
 	Bucket string
 
@@ -148,9 +151,10 @@ func CorrelationIDLogCtx(parent context.Context, correlationID string) context.C
 }
 
 // DatabaseLogCtx extends the parent context with a database.
-func DatabaseLogCtx(parent context.Context, databaseName string) context.Context {
+func DatabaseLogCtx(parent context.Context, databaseName string, config *DbConsoleLogConfig) context.Context {
 	newCtx := getLogCtx(parent)
 	newCtx.Database = databaseName
+	newCtx.DbConsoleLogConfig = config
 	return LogContextWith(parent, &newCtx)
 }
 

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -45,6 +45,12 @@ type LogContext struct {
 	TestName string
 }
 
+// DbConsoleLogConfig can be used to customise the console logging for logs associated with this database.
+type DbConsoleLogConfig struct {
+	LogLevel *LogLevel
+	LogKeys  *LogKeyMask
+}
+
 // addContext returns a string format with additional log context if present.
 func (lc *LogContext) addContext(format string) string {
 	if lc == nil {

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -23,25 +23,25 @@ import (
 // LogContext stores values which may be useful to include in logs
 type LogContext struct {
 	// CorrelationID is a pre-formatted identifier used to correlate logs.
-	// E.g: Either blip context ID or HTTP Serial number.
+	// E.g: Either blip context ID or HTTP Serial number. (see CorrelationIDLogCtx)
 	CorrelationID string
 
-	// Database is the name of the sync gateway database
+	// Database is the name of the sync gateway database (see DatabaseLogCtx)
 	Database string
 
-	// DbConsoleLogConfig is any database-specific log settings that should be applied
+	// DbConsoleLogConfig is database-specific log settings that should be applied (see DatabaseLogCtx)
 	DbConsoleLogConfig *DbConsoleLogConfig
 
-	// Bucket is the name of the backing bucket
+	// Bucket is the name of the backing bucket (see KeyspaceLogCtx)
 	Bucket string
 
-	// Scope is the name of a scope
+	// Scope is the name of a scope see (KeyspaceLogCtx)
 	Scope string
 
-	// Collection is the name of the collection
+	// Collection is the name of the collection (see KeyspaceLogCtx)
 	Collection string
 
-	// TestName can be a unit test name (from t.Name())
+	// TestName can be a unit test name (see TestCtx)
 	TestName string
 }
 

--- a/base/logging_context_test.go
+++ b/base/logging_context_test.go
@@ -235,7 +235,7 @@ func TestCtxWorkflow(t *testing.T) {
 	RequireLogMessage(t, correlationCtx, "[INF] t:TestCtxWorkflow c:correlationID foobar\n", standardMessage)
 	RequireLogMessage(t, ctx, "[INF] t:TestCtxWorkflow foobar\n", standardMessage)
 
-	databaseCtx := DatabaseLogCtx(keyspaceCtx, "fooDB")
+	databaseCtx := DatabaseLogCtx(keyspaceCtx, "fooDB", nil)
 	RequireLogMessage(t, databaseCtx, "[INF] t:TestCtxWorkflow c:correlationID db:fooDB col:fooCollection foobar\n", standardMessage)
 	RequireLogMessage(t, keyspaceCtx, "[INF] t:TestCtxWorkflow c:correlationID b:fooBucket.fooScope.fooCollection foobar\n", standardMessage)
 	RequireLogMessage(t, bucketCtx, "[INF] t:TestCtxWorkflow c:correlationID b:fooBucket foobar\n", standardMessage)

--- a/base/util.go
+++ b/base/util.go
@@ -64,8 +64,8 @@ func NewNonCancelCtx() NonCancellableContext {
 }
 
 // NewNonCancelCtx creates a new background context struct for operations that require a fresh context, with database logging context added
-func NewNonCancelCtxForDatabase(dbName string) NonCancellableContext {
-	dbLogContext := DatabaseLogCtx(context.Background(), dbName)
+func NewNonCancelCtxForDatabase(dbName string, dbConsoleLogConfig *DbConsoleLogConfig) NonCancellableContext {
+	dbLogContext := DatabaseLogCtx(context.Background(), dbName, dbConsoleLogConfig)
 	ctxStruct := NonCancellableContext{
 		Ctx: dbLogContext,
 	}

--- a/db/database.go
+++ b/db/database.go
@@ -177,6 +177,12 @@ type DatabaseContextOptions struct {
 	BlipStatsReportingInterval    int64          // interval to report blip stats in milliseconds
 	ChangesRequestPlus            bool           // Sets the default value for request_plus, for non-continuous changes feeds
 	ConfigPrincipals              *ConfigPrincipals
+	LoggingConfig                 DbLogConfig // Per-database log configuration
+}
+
+// DbLogConfig can be used to customise the logging for logs associated with this database.
+type DbLogConfig struct {
+	Console *base.DbConsoleLogConfig
 }
 
 type ConfigPrincipals struct {
@@ -385,7 +391,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 
 	// add db info to ctx before having a DatabaseContext (cannot call AddDatabaseLogContext),
 	// in order to pass it to RegisterImportPindexImpl
-	ctx = base.DatabaseLogCtx(ctx, dbName)
+	ctx = base.DatabaseLogCtx(ctx, dbName, options.LoggingConfig.Console)
 
 	if err := base.RequireNoBucketTTL(bucket); err != nil {
 		return nil, err
@@ -2061,7 +2067,8 @@ func CheckTimeout(ctx context.Context) error {
 // AddDatabaseLogContext adds database name to the parent context for logging
 func (dbCtx *DatabaseContext) AddDatabaseLogContext(ctx context.Context) context.Context {
 	if dbCtx != nil && dbCtx.Name != "" {
-		return base.DatabaseLogCtx(ctx, dbCtx.Name)
+		dbLogCtx := base.DatabaseLogCtx(ctx, dbCtx.Name, dbCtx.Options.LoggingConfig.Console)
+		return dbLogCtx
 	}
 	return ctx
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2748,7 +2748,7 @@ func Test_invalidateAllPrincipalsCache(t *testing.T) {
 	defer db.Close(ctx)
 	db.Options.QueryPaginationLimit = 100
 
-	sequenceAllocator, err := newSequenceAllocator(base.DatabaseLogCtx(base.TestCtx(t), db.Name), db.MetadataStore, db.DbStats.DatabaseStats, db.MetadataKeys)
+	sequenceAllocator, err := newSequenceAllocator(base.DatabaseLogCtx(base.TestCtx(t), db.Name, nil), db.MetadataStore, db.DbStats.DatabaseStats, db.MetadataKeys)
 	assert.NoError(t, err)
 
 	db.sequences = sequenceAllocator

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1781,6 +1781,31 @@ Database:
           type: array
           items:
             type: string
+    logging:
+      description: Per-database logging configuration.
+      type: object
+      properties:
+        console:
+          description: Console logging configuration.
+          type: object
+          properties:
+            log_level:
+              description: Log Level for the console output
+              type: string
+              enum:
+                - none
+                - error
+                - warn
+                - info
+                - debug
+                - trace
+              example: debug
+            log_keys:
+              description: Log Keys for the console output
+              type: array
+              items:
+                type: string
+              example: ["CRUD", "HTTP", "Query"]
   title: Database-config
 Event-config:
   type: object

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -4045,7 +4045,7 @@ func TestOneShotGrantTiming(t *testing.T) {
 	require.Len(t, changes.Results, 0)
 
 	// Release the slow sequence and wait for it to be processed over DCP
-	releaseErr := db.ReleaseTestSequence(base.DatabaseLogCtx(base.TestCtx(t), database.Name), database, slowSequence)
+	releaseErr := db.ReleaseTestSequence(base.DatabaseLogCtx(base.TestCtx(t), database.Name, nil), database, slowSequence)
 	require.NoError(t, releaseErr)
 	require.NoError(t, rt.WaitForPendingChanges())
 
@@ -4143,7 +4143,7 @@ func TestOneShotGrantRequestPlus(t *testing.T) {
 	require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+2))
 
 	// Release the slow sequence and wait for it to be processed over DCP
-	releaseErr := db.ReleaseTestSequence(base.DatabaseLogCtx(base.TestCtx(t), database.Name), database, slowSequence)
+	releaseErr := db.ReleaseTestSequence(base.DatabaseLogCtx(base.TestCtx(t), database.Name, nil), database, slowSequence)
 	require.NoError(t, releaseErr)
 	require.NoError(t, rt.WaitForPendingChanges())
 
@@ -4261,7 +4261,7 @@ func TestOneShotGrantRequestPlusDbConfig(t *testing.T) {
 	require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+2))
 
 	// Release the slow sequence and wait for it to be processed over DCP
-	releaseErr := db.ReleaseTestSequence(base.DatabaseLogCtx(base.TestCtx(t), database.Name), database, slowSequence)
+	releaseErr := db.ReleaseTestSequence(base.DatabaseLogCtx(base.TestCtx(t), database.Name, nil), database, slowSequence)
 	require.NoError(t, releaseErr)
 	require.NoError(t, rt.WaitForPendingChanges())
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -166,7 +166,8 @@ type DbConfig struct {
 	UserFunctions                    *functions.FunctionsConfig       `json:"functions,omitempty"`                            // Named JS fns for clients to call
 	Suspendable                      *bool                            `json:"suspendable,omitempty"`                          // Allow the database to be suspended
 	ChangesRequestPlus               *bool                            `json:"changes_request_plus,omitempty"`                 // If set, is used as the default value of request_plus for non-continuous replications
-	CORS                             *auth.CORSConfig                 `json:"cors,omitempty"`
+	CORS                             *auth.CORSConfig                 `json:"cors,omitempty"`                                 // Per-database CORS config
+	Logging                          *DbLoggingConfig                 `json:"logging,omitempty"`                              // Per-database Logging config
 }
 
 type ScopesConfig map[string]ScopeConfig
@@ -236,6 +237,17 @@ type ChannelCacheConfig struct {
 	MinLength            *int    `json:"min_length,omitempty"`                 // Minimum number of entries maintained in cache per channel
 	ExpirySeconds        *int    `json:"expiry_seconds,omitempty"`             // Time (seconds) to keep entries in cache beyond the minimum retained
 	DeprecatedQueryLimit *int    `json:"query_limit,omitempty"`                // Limit used for channel queries, if not specified by client DEPRECATED in favour of db.QueryPaginationLimit
+}
+
+// DbLoggingConfig allows per-database logging overrides
+type DbLoggingConfig struct {
+	Console *DbConsoleLoggingConfig `json:"console,omitempty"`
+}
+
+// DbConsoleLoggingConfig are per-db options configurable for console logging
+type DbConsoleLoggingConfig struct {
+	LogLevel *base.LogLevel `json:"log_level,omitempty"`
+	LogKeys  []string       `json:"log_keys,omitempty"`
 }
 
 func GetTLSVersionFromString(stringV *string) uint16 {

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -686,7 +686,7 @@ func (b *bootstrapContext) getRegistryAndDatabase(ctx context.Context, bucketNam
 }
 
 func (b *bootstrapContext) addDatabaseLogContext(ctx context.Context, dbName string) context.Context {
-	return base.DatabaseLogCtx(ctx, dbName)
+	return base.DatabaseLogCtx(ctx, dbName, nil)
 }
 
 func (b *bootstrapContext) ComputeMetadataIDForDbConfig(ctx context.Context, config *DbConfig) (string, error) {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -204,9 +204,9 @@ func (h *handler) ctx() context.Context {
 	return h.rqCtx
 }
 
-func (h *handler) addDatabaseLogContext(dbName string) {
+func (h *handler) addDatabaseLogContext(dbName string, logConfig *base.DbConsoleLogConfig) {
 	if dbName != "" {
-		h.rqCtx = base.DatabaseLogCtx(h.ctx(), dbName)
+		h.rqCtx = base.DatabaseLogCtx(h.ctx(), dbName, logConfig)
 	}
 }
 
@@ -337,9 +337,9 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 
 	// look up the database context:
 	if keyspaceDb != "" {
-		h.addDatabaseLogContext(keyspaceDb)
 		var err error
 		if dbContext, err = h.server.GetActiveDatabase(keyspaceDb); err != nil {
+			h.addDatabaseLogContext(keyspaceDb, nil)
 			if err == base.ErrNotFound {
 				if shouldCheckAdminAuth {
 					// Check if authenticated before attempting to get inactive database
@@ -379,6 +379,7 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 
 	// If this call is in the context of a DB make sure the DB is in a valid state
 	if dbContext != nil {
+		h.addDatabaseLogContext(keyspaceDb, dbContext.Options.LoggingConfig.Console)
 		if !h.runOffline {
 			// get a read lock on the dbContext
 			// When the lock is returned we know that the db state will not be changed by


### PR DESCRIPTION
CBG-0000

Stores a reference to the database log configuration inside the database-scoped log context, so that we're able to look it up when we log to determine whether to emit the console log or not.

This allows databases to define their own console log level and log keys. Neither of the two settings takes precedence. They're additive (either node OR db log level/key are checked when writing a log line, if either match, it will be logged).

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
