### PR TITLE
CBG-3247 turn channel send into blocking call

### DIFF
--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -504,13 +504,7 @@ func (dc *DCPClient) openStreamRequest(vbID uint16) error {
 		if err == nil {
 			err = dc.verifyFailoverLog(vbID, f)
 			if err == nil {
-				e := streamOpenEvent{
-					streamEventCommon: streamEventCommon{
-						vbID: vbID,
-					},
-					failoverLogs: f,
-				}
-				dc.workerForVbno(vbID).Send(e)
+				dc.metadata.SetFailoverEntries(vbID, f)
 			}
 		}
 		openStreamError <- err

--- a/base/dcp_client_stream_event.go
+++ b/base/dcp_client_stream_event.go
@@ -47,11 +47,6 @@ type mutationEvent struct {
 	value      []byte
 }
 
-type streamOpenEvent struct {
-	streamEventCommon
-	failoverLogs []gocbcore.FailoverEntry
-}
-
 func (e mutationEvent) asFeedEvent() sgbucket.FeedEvent {
 	return sgbucket.FeedEvent{
 		Opcode:       sgbucket.FeedOpMutation,

--- a/base/dcp_client_worker.go
+++ b/base/dcp_client_worker.go
@@ -110,8 +110,6 @@ func (w *DCPWorker) Start(wg *sync.WaitGroup) {
 			case event := <-w.eventFeed:
 				vbID := event.VbID()
 				switch e := event.(type) {
-				case streamOpenEvent:
-					w.metadata.SetFailoverEntries(e.vbID, e.failoverLogs)
 				case snapshotEvent:
 					// Set pending snapshot - don't persist to meta until we receive first sequence in the snapshot,
 					// to avoid attempting to restart with a new snapshot and old sequence value


### PR DESCRIPTION
This is a speculative fix, but definitely simplifies the code. Ran {{base}} DCP tests against race detector.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1951/
