### PR TITLE
Add .gitignore entry auto-added by Couchbase IntelliJ plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ verbose*.xml
 sync_gateway
 *.pb.gz
 __pycache__
+
+### Couchbase Plugin ###
+.cbcache/


### PR DESCRIPTION
The [Couchbase plugin](https://plugins.jetbrains.com/plugin/22131-couchbase) for IntelliJ IDEs automatically adds this entry to `.gitignore` on usage.

The plugin seems likely to be used at some point by somebody, so let's just pre-emptively commit this change.