### PR TITLE
Require persistence in test configuration

### DIFF
--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -832,7 +832,10 @@ func TestOfflineDatabaseStartup(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
+	bucket := base.GetPersistentTestBucket(t)
+	defer bucket.Close()
 	rt := NewRestTester(t, &RestTesterConfig{
+		CustomTestBucket: bucket.NoCloseClone(),
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
 				StartOffline: base.BoolPtr(true),


### PR DESCRIPTION
This is necessary if we use walrus with xattrs or rosmar.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

