### PR TITLE
CBG-3241: 3.0.8.1 Backport: CBG-3235: Query resync loop

### DIFF
--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -397,7 +397,7 @@ func (b *BackgroundManager) GetRunState(t *testing.T) BackgroundProcessState {
 
 // For test use only
 // Returns empty string if background process is not cluster aware
-func (b *BackgroundManager) GetHeartbeatDocID(t *testing.T) string {
+func (b *BackgroundManager) GetHeartbeatDocID(t testing.TB) string {
 	if b.isClusterAware() {
 		return b.clusterAwareOptions.HeartbeatDocID()
 	}

--- a/db/query.go
+++ b/db/query.go
@@ -23,7 +23,8 @@ import (
 
 // Used for queries that only return doc id
 type QueryIdRow struct {
-	Id string
+	Id  string
+	Seq uint64
 }
 
 const (

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -666,10 +666,10 @@ func (rt *RestTester) GetDBState() string {
 }
 
 func (rt *RestTester) WaitForDBOnline() (err error) {
-	return rt.waitForDBState("Online")
+	return rt.WaitForDBState("Online")
 }
 
-func (rt *RestTester) waitForDBState(stateWant string) (err error) {
+func (rt *RestTester) WaitForDBState(stateWant string) (err error) {
 	var stateCurr string
 	maxTries := 20
 


### PR DESCRIPTION
CBG-3241

Backports #6346 plus test-only changes to 3.0.8.1

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration-go1.16.15/build?delay=0sec)
- [x] `GSI=false,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-go1.16.15/66/
- [x] `^TestResyncAllTombstones$,GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-go1.16.15/67/