### PR TITLE
Add boundary test coverage for resync query pagination

### DIFF
--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -3881,7 +3881,7 @@ func TestResyncAllTombstones(t *testing.T) {
 			rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
 					QueryPaginationLimit: base.IntPtr(queryPaginationLimit),
-				}},
+					Unsupported:          &db.UnsupportedOptions{UseQueryBasedResyncManager: true}}},
 			})
 			rt.GetDatabase().PurgeInterval = 0
 			defer rt.Close()

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -3857,7 +3857,6 @@ func TestCacheCompactDuringChangesWait(t *testing.T) {
 }
 
 func TestResyncAllTombstones(t *testing.T) {
-	base.LongRunningTest(t)
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Walrus does not support Xattrs")
 	}
@@ -3866,41 +3865,46 @@ func TestResyncAllTombstones(t *testing.T) {
 		t.Skip("If running with no xattrs compact acts as a no-op")
 	}
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			QueryPaginationLimit: base.IntPtr(5),
-			Unsupported:          &db.UnsupportedOptions{UseQueryBasedResyncManager: true}}},
-	})
-	rt.GetDatabase().PurgeInterval = 0
-	defer rt.Close()
-
-	TestResyncTombstones := func(numDocs int) {
-
-		count := 0
-
-		for count < numDocs {
-			count++
-			for _, keyspace := range rt.GetKeyspaces() {
-				response := rt.SendAdminRequest("POST", fmt.Sprintf("/%s/", keyspace), `{"foo":"bar"}`)
-				assert.Equal(t, 200, response.Code)
-				var body db.Body
-				err := base.JSONUnmarshal(response.Body.Bytes(), &body)
-				assert.NoError(t, err)
-				revId := body["rev"].(string)
-				docId := body["id"].(string)
-				response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/%s/%s?rev=%s", keyspace, docId, revId), "")
-				assert.Equal(t, 200, response.Code)
-			}
-		}
-		resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_offline", "")
-		rest.RequireStatus(t, resp, http.StatusOK)
-		require.NoError(t, rt.WaitForDatabaseState(rt.GetDatabase().Name, db.DBOffline))
-
-		resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_resync?action=start", "")
-		rest.RequireStatus(t, resp, http.StatusOK)
-		rt.WaitForResyncStatus(db.BackgroundProcessStateCompleted)
+	const queryPaginationLimit = 5
+	tests := []int{
+		0,
+		queryPaginationLimit - 1,
+		queryPaginationLimit,
+		queryPaginationLimit + 1,
+		(queryPaginationLimit * 2) - 1,
+		(queryPaginationLimit * 2),
+		(queryPaginationLimit * 2) + 1,
 	}
-	TestResyncTombstones(5)
+
+	for _, numTombstones := range tests {
+		t.Run(fmt.Sprintf("limit:%d-numTombstones:%d", queryPaginationLimit, numTombstones), func(t *testing.T) {
+			rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+					QueryPaginationLimit: base.IntPtr(queryPaginationLimit),
+				}},
+			})
+			rt.GetDatabase().PurgeInterval = 0
+			defer rt.Close()
+
+			for i := 0; i < numTombstones; i++ {
+				docID := fmt.Sprintf("doc%d", i)
+				resp := rt.PutDoc(docID, `{"foo":"bar"}`)
+				require.True(t, resp.Ok)
+				rt.DeleteDoc(docID, resp.Rev)
+			}
+
+			resp := rt.SendAdminRequest(http.MethodPost, fmt.Sprintf("/%s/_offline", rt.GetDatabase().Name), "")
+			rest.RequireStatus(t, resp, http.StatusOK)
+			require.NoError(t, rt.WaitForDBState(db.RunStateString[db.DBOffline]))
+
+			resp = rt.SendAdminRequest(http.MethodPost, fmt.Sprintf("/%s/_resync?action=start", rt.GetDatabase().Name), "")
+			rest.RequireStatus(t, resp, http.StatusOK)
+
+			status := rt.WaitForResyncStatus(db.BackgroundProcessStateCompleted)
+			assert.Equal(t, numTombstones, status.DocsProcessed)
+			assert.Equal(t, 0, status.DocsChanged)
+		})
+	}
 }
 
 func TestTombstoneCompaction(t *testing.T) {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -922,10 +922,10 @@ func (rt *RestTester) GetDBState() string {
 }
 
 func (rt *RestTester) WaitForDBOnline() (err error) {
-	return rt.waitForDBState("Online")
+	return rt.WaitForDBState("Online")
 }
 
-func (rt *RestTester) waitForDBState(stateWant string) (err error) {
+func (rt *RestTester) WaitForDBState(stateWant string) (err error) {
 	var stateCurr string
 	maxTries := 20
 


### PR DESCRIPTION
Adds extra coverage for the boundary conditions around resync query pagination and assert on resync processed stat.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `DCP resync,^TestResyncAllTombstones$,GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1952/
- [x] `DCP resync,^TestResyncAllTombstones$,GSI=false,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1953/
- `^TestResyncAllTombstones$,GSI=false,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1954/
  - View engine `unknown_error` ... rerun:
  - [x] https://jenkins.sgwdev.com/job/SyncGateway-Integration/1956/
- [ ] `^TestResyncAllTombstones$,GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1955/