### PR TITLE
CBG-3207: Implementation of persisted form of HLV.

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -14,6 +14,7 @@ import (
 	"crypto/rand"
 	"crypto/sha1"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
@@ -1106,6 +1107,27 @@ func HexCasToUint64(cas string) uint64 {
 	}
 
 	return binary.LittleEndian.Uint64(casBytes[0:8])
+}
+
+func Uint64CASToLittleEndianHex(cas uint64) []byte {
+	littleEndian := make([]byte, 8)
+	binary.LittleEndian.PutUint64(littleEndian, cas)
+	encodedArray := make([]byte, hex.EncodedLen(8)+2)
+	_ = hex.Encode(encodedArray[2:], littleEndian)
+	encodedArray[0] = '0'
+	encodedArray[1] = 'x'
+	return encodedArray
+}
+
+func HexToBase64(hexStr string) ([]byte, error) {
+	decodedArray := make([]byte, hex.DecodedLen(len(hexStr)))
+	_, err := hex.Decode(decodedArray, []byte(hexStr))
+	if err != nil {
+		return nil, err
+	}
+	base64Encoded := make([]byte, base64.RawStdEncoding.EncodedLen(len(decodedArray)))
+	base64.RawStdEncoding.Encode(base64Encoded, decodedArray)
+	return base64Encoded, nil
 }
 
 func Crc32cHash(input []byte) uint32 {

--- a/base/util.go
+++ b/base/util.go
@@ -14,7 +14,6 @@ import (
 	"crypto/rand"
 	"crypto/sha1"
 	"crypto/tls"
-	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
@@ -1117,17 +1116,6 @@ func Uint64CASToLittleEndianHex(cas uint64) []byte {
 	encodedArray[0] = '0'
 	encodedArray[1] = 'x'
 	return encodedArray
-}
-
-func HexToBase64(hexStr string) ([]byte, error) {
-	decodedArray := make([]byte, hex.DecodedLen(len(hexStr)))
-	_, err := hex.Decode(decodedArray, []byte(hexStr))
-	if err != nil {
-		return nil, err
-	}
-	base64Encoded := make([]byte, base64.RawStdEncoding.EncodedLen(len(decodedArray)))
-	base64.RawStdEncoding.Encode(base64Encoded, decodedArray)
-	return base64Encoded, nil
 }
 
 func Crc32cHash(input []byte) uint32 {

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -1710,11 +1710,3 @@ func TestCASToLittleEndianHex(t *testing.T) {
 	littleEndianHex := Uint64CASToLittleEndianHex(casValue)
 	require.Equal(t, expHexValue, string(littleEndianHex))
 }
-
-func TestHexToBase64Encoding(t *testing.T) {
-	const inputValue = "cb06dc003846116d9b66d2ab23887a96"
-	const expectedValue = "ywbcADhGEW2bZtKrI4h6lg"
-	encodedValue, err := HexToBase64(inputValue)
-	require.NoError(t, err)
-	require.Equal(t, expectedValue, string(encodedValue))
-}

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -1703,3 +1703,18 @@ func TestAllOrNoneNil(t *testing.T) {
 		})
 	}
 }
+
+func TestCASToLittleEndianHex(t *testing.T) {
+	const casValue = 123456
+	const expHexValue = "0x40e2010000000000"
+	littleEndianHex := Uint64CASToLittleEndianHex(casValue)
+	require.Equal(t, expHexValue, string(littleEndianHex))
+}
+
+func TestHexToBase64Encoding(t *testing.T) {
+	const inputValue = "cb06dc003846116d9b66d2ab23887a96"
+	const expectedValue = "ywbcADhGEW2bZtKrI4h6lg"
+	encodedValue, err := HexToBase64(inputValue)
+	require.NoError(t, err)
+	require.Equal(t, expectedValue, string(encodedValue))
+}

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -9,7 +9,6 @@
 package db
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -30,11 +29,11 @@ type CurrentVersionVector struct {
 }
 
 type PersistedHybridLogicalVector struct {
-	CurrentVersionCAS string            `json:"cvCas"` // current version cas (or cvCAS) stores the current CAS at the time of replication
-	SourceID          string            `json:"src"`   // source bucket uuid of where this entry originated from
-	Version           string            `json:"vrs"`   // current cas of the current version on the version vector
-	MergeVersions     map[string]string `json:"mv"`    // map of merge versions for fast efficient lookup
-	PreviousVersions  map[string]string `json:"pv"`
+	CurrentVersionCAS string            `json:"cvCas,omitempty"` // current version cas (or cvCAS) stores the current CAS at the time of replication
+	SourceID          string            `json:"src,omitempty"`   // source bucket uuid of where this entry originated from
+	Version           string            `json:"vrs,omitempty"`   // current cas of the current version on the version vector
+	MergeVersions     map[string]string `json:"mv,omitempty"`    // map of merge versions for fast efficient lookup
+	PreviousVersions  map[string]string `json:"pv,omitempty"`
 }
 
 type PersistedVersionVector struct {
@@ -191,12 +190,12 @@ func (hlv *HybridLogicalVector) MarshalJSON() ([]byte, error) {
 	persistedHLV.PreviousVersions = pvPersistedFormat
 	persistedHLV.MergeVersions = mvPersistedFormat
 
-	return json.Marshal(persistedHLV)
+	return base.JSONMarshal(persistedHLV)
 }
 
 func (hlv *HybridLogicalVector) UnmarshalJSON(inputjson []byte) error {
 	persistedJSON := PersistedVersionVector{}
-	err := json.Unmarshal(inputjson, &persistedJSON)
+	err := base.JSONUnmarshal(inputjson, &persistedJSON)
 	if err != nil {
 		return err
 	}

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -193,7 +193,10 @@ func (hlv *HybridLogicalVector) UnmarshalJSON(inputjson []byte) error {
 
 func (hlv *HybridLogicalVector) convertHLVToPersistedFormat() (*PersistedVersionVector, error) {
 	persistedHLV := PersistedVersionVector{}
-	cvCasByteArray := base.Uint64CASToLittleEndianHex(hlv.CurrentVersionCAS)
+	var cvCasByteArray []byte
+	if hlv.CurrentVersionCAS != 0 {
+		cvCasByteArray = base.Uint64CASToLittleEndianHex(hlv.CurrentVersionCAS)
+	}
 	vrsCasByteArray := base.Uint64CASToLittleEndianHex(hlv.Version)
 
 	pvPersistedFormat, err := convertMapToPersistedFormat(hlv.PreviousVersions)

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -213,7 +213,7 @@ func TestHybridLogicalVectorPersistence(t *testing.T) {
 	assert.Contains(t, strHLV, `"cvCas":"0x40e2010000000000`)
 	assert.Contains(t, strHLV, `"src":"cb06dc003846116d9b66d2ab23887a96"`)
 	assert.Contains(t, strHLV, `"vrs":"0x40e2010000000000"`)
-	assert.Contains(t, strHLV, `"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16"}`)
+	assert.Contains(t, strHLV, `"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16"`)
 	assert.Contains(t, strHLV, `"s_NqiIe0LekFPLeX4JvTO6Iw":"1c008cd6ac059a16"`)
 	assert.Contains(t, strHLV, `"pv":{"s_YZvBpEaztom9z5V/hDoeIw":"f0ff44d6ac059a16"}`)
 

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -14,15 +14,10 @@ import (
 	"strings"
 	"testing"
 
-<<<<<<< HEAD
-=======
-	"github.com/couchbase/sync_gateway/base"
->>>>>>> 21874614 (CBG-3207: Implementation of persisted form of HLV.)
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-<<<<<<< HEAD
 // TestInternalHLVFunctions:
 //   - Tests internal api methods on the HLV work as expected
 //   - Tests methods GetCurrentVersion, AddVersion and Remove
@@ -169,48 +164,6 @@ func TestConflictExample(t *testing.T) {
 
 // createHLVForTest is a helper function to create a HLV for use in a test. Takes a list of strings in the format of <sourceID@version> and assumes
 // first entry is current version. For merge version entries you must specify 'm_' as a prefix to sourceID NOTE: it also sets cvCAS to the current version
-=======
-// TestHybridLogicalVectorPersistence:
-//   - Tests the process of constructing in memory HLV and marshaling it to persisted format
-//   - Asserts on teh format
-//   - Unmarshal the HLV and assert that the process works as expected
-func TestHybridLogicalVectorPersistence(t *testing.T) {
-	// create HLV
-	inputHLV := []string{"cb06dc003846116d9b66d2ab23887a96@123456", "s_YZvBpEaztom9z5V/hDoeIw@1628620455135215600", "m_s_NqiIe0LekFPLeX4JvTO6Iw@1628620455139868700",
-		"m_s_LhRPsa7CpjEvP5zeXTXEBA@1628620455147864000"}
-	inMemoryHLV := createHLVForTest(t, inputHLV)
-
-	// marshal in memory hlv into persisted form
-	byteArray, err := inMemoryHLV.MarshalJSON()
-	require.NoError(t, err)
-
-	// convert to string and assert the in memory struct is converted to persisted form correctly
-	strHLV := string(byteArray)
-	assert.Contains(t, strHLV, `"cvCas":"0x40e2010000000000`)
-	assert.Contains(t, strHLV, `"src":"m_ywbcADhGEW2bZtKrI4h6lg"`)
-	assert.Contains(t, strHLV, `"vrs":"0x40e2010000000000"`)
-	assert.Contains(t, strHLV, `"mv":{"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16","s_NqiIe0LekFPLeX4JvTO6Iw":"1c008cd6ac059a16"}`)
-	assert.Contains(t, strHLV, `"pv":{"s_YZvBpEaztom9z5V/hDoeIw":"f0ff44d6ac059a16"}`)
-
-	// Unmarshal the in memory constructed HLV above
-	hlvFromPersistance := HybridLogicalVector{}
-	err = hlvFromPersistance.UnmarshalJSON(byteArray)
-	require.NoError(t, err)
-	fmt.Println(strHLV, hlvFromPersistance)
-
-	// extract expected sourceID from the in memory HLV by converting the hex to Base64 for assertion below
-	expectedSourceID, err := base.HexToBase64(inMemoryHLV.SourceID)
-	require.NoError(t, err)
-
-	// assertions on values of unmarshaled HLV
-	assert.Equal(t, inMemoryHLV.CurrentVersionCAS, hlvFromPersistance.CurrentVersionCAS)
-	assert.Equal(t, "m_"+string(expectedSourceID), hlvFromPersistance.SourceID)
-	assert.Equal(t, inMemoryHLV.Version, hlvFromPersistance.Version)
-	assert.Equal(t, inMemoryHLV.PreviousVersions, hlvFromPersistance.PreviousVersions)
-	assert.Equal(t, inMemoryHLV.MergeVersions, hlvFromPersistance.MergeVersions)
-}
-
->>>>>>> 21874614 (CBG-3207: Implementation of persisted form of HLV.)
 func createHLVForTest(tb *testing.T, inputList []string) HybridLogicalVector {
 	hlvOutput := NewHybridLogicalVector()
 
@@ -242,7 +195,7 @@ func createHLVForTest(tb *testing.T, inputList []string) HybridLogicalVector {
 
 // TestHybridLogicalVectorPersistence:
 //   - Tests the process of constructing in memory HLV and marshaling it to persisted format
-//   - Asserts on teh format
+//   - Asserts on the format
 //   - Unmarshal the HLV and assert that the process works as expected
 func TestHybridLogicalVectorPersistence(t *testing.T) {
 	// create HLV
@@ -257,7 +210,7 @@ func TestHybridLogicalVectorPersistence(t *testing.T) {
 	// convert to string and assert the in memory struct is converted to persisted form correctly
 	strHLV := string(byteArray)
 	assert.Contains(t, strHLV, `"cvCas":"0x40e2010000000000`)
-	assert.Contains(t, strHLV, `"src":"m_ywbcADhGEW2bZtKrI4h6lg"`)
+	assert.Contains(t, strHLV, `"src":"cb06dc003846116d9b66d2ab23887a96"`)
 	assert.Contains(t, strHLV, `"vrs":"0x40e2010000000000"`)
 	assert.Contains(t, strHLV, `"mv":{"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16","s_NqiIe0LekFPLeX4JvTO6Iw":"1c008cd6ac059a16"}`)
 	assert.Contains(t, strHLV, `"pv":{"s_YZvBpEaztom9z5V/hDoeIw":"f0ff44d6ac059a16"}`)
@@ -266,47 +219,11 @@ func TestHybridLogicalVectorPersistence(t *testing.T) {
 	hlvFromPersistance := HybridLogicalVector{}
 	err = hlvFromPersistance.UnmarshalJSON(byteArray)
 	require.NoError(t, err)
-	fmt.Println(strHLV, hlvFromPersistance)
-
-	// extract expected sourceID from the in memory HLV by converting the hex to Base64 for assertion below
-	expectedSourceID, err := base.HexToBase64(inMemoryHLV.SourceID)
-	require.NoError(t, err)
 
 	// assertions on values of unmarshaled HLV
 	assert.Equal(t, inMemoryHLV.CurrentVersionCAS, hlvFromPersistance.CurrentVersionCAS)
-	assert.Equal(t, "m_"+string(expectedSourceID), hlvFromPersistance.SourceID)
+	assert.Equal(t, inMemoryHLV.SourceID, hlvFromPersistance.SourceID)
 	assert.Equal(t, inMemoryHLV.Version, hlvFromPersistance.Version)
 	assert.Equal(t, inMemoryHLV.PreviousVersions, hlvFromPersistance.PreviousVersions)
 	assert.Equal(t, inMemoryHLV.MergeVersions, hlvFromPersistance.MergeVersions)
 }
-
-func createHLVForTest(tb *testing.T, inputList []string) HybridLogicalVector {
-	hlvOutput := NewHybridLogicalVector()
-
-	// first element will be current version and source pair
-	currentVersionPair := strings.Split(inputList[0], "@")
-	hlvOutput.SourceID = currentVersionPair[0]
-	version, err := strconv.Atoi(currentVersionPair[1])
-	require.NoError(tb, err)
-	hlvOutput.Version = uint64(version)
-	hlvOutput.CurrentVersionCAS = uint64(version)
-
-	// remove current version entry in list now we have parsed it into the HLV
-	inputList = inputList[1:]
-
-	for _, value := range inputList {
-		currentVersionPair = strings.Split(value, "@")
-		version, err = strconv.Atoi(currentVersionPair[1])
-		require.NoError(tb, err)
-		if strings.HasPrefix(currentVersionPair[0], "m_") {
-			// add entry to merge version removing the leading prefix for sourceID
-			hlvOutput.MergeVersions[currentVersionPair[0][2:]] = uint64(version)
-		} else {
-			// if its not got the prefix we assume its a previous version entry
-			hlvOutput.PreviousVersions[currentVersionPair[0]] = uint64(version)
-		}
-
-	}
-	return hlvOutput
-}
-

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -14,10 +14,15 @@ import (
 	"strings"
 	"testing"
 
+<<<<<<< HEAD
+=======
+	"github.com/couchbase/sync_gateway/base"
+>>>>>>> 21874614 (CBG-3207: Implementation of persisted form of HLV.)
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+<<<<<<< HEAD
 // TestInternalHLVFunctions:
 //   - Tests internal api methods on the HLV work as expected
 //   - Tests methods GetCurrentVersion, AddVersion and Remove
@@ -164,6 +169,48 @@ func TestConflictExample(t *testing.T) {
 
 // createHLVForTest is a helper function to create a HLV for use in a test. Takes a list of strings in the format of <sourceID@version> and assumes
 // first entry is current version. For merge version entries you must specify 'm_' as a prefix to sourceID NOTE: it also sets cvCAS to the current version
+=======
+// TestHybridLogicalVectorPersistence:
+//   - Tests the process of constructing in memory HLV and marshaling it to persisted format
+//   - Asserts on teh format
+//   - Unmarshal the HLV and assert that the process works as expected
+func TestHybridLogicalVectorPersistence(t *testing.T) {
+	// create HLV
+	inputHLV := []string{"cb06dc003846116d9b66d2ab23887a96@123456", "s_YZvBpEaztom9z5V/hDoeIw@1628620455135215600", "m_s_NqiIe0LekFPLeX4JvTO6Iw@1628620455139868700",
+		"m_s_LhRPsa7CpjEvP5zeXTXEBA@1628620455147864000"}
+	inMemoryHLV := createHLVForTest(t, inputHLV)
+
+	// marshal in memory hlv into persisted form
+	byteArray, err := inMemoryHLV.MarshalJSON()
+	require.NoError(t, err)
+
+	// convert to string and assert the in memory struct is converted to persisted form correctly
+	strHLV := string(byteArray)
+	assert.Contains(t, strHLV, `"cvCas":"0x40e2010000000000`)
+	assert.Contains(t, strHLV, `"src":"m_ywbcADhGEW2bZtKrI4h6lg"`)
+	assert.Contains(t, strHLV, `"vrs":"0x40e2010000000000"`)
+	assert.Contains(t, strHLV, `"mv":{"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16","s_NqiIe0LekFPLeX4JvTO6Iw":"1c008cd6ac059a16"}`)
+	assert.Contains(t, strHLV, `"pv":{"s_YZvBpEaztom9z5V/hDoeIw":"f0ff44d6ac059a16"}`)
+
+	// Unmarshal the in memory constructed HLV above
+	hlvFromPersistance := HybridLogicalVector{}
+	err = hlvFromPersistance.UnmarshalJSON(byteArray)
+	require.NoError(t, err)
+	fmt.Println(strHLV, hlvFromPersistance)
+
+	// extract expected sourceID from the in memory HLV by converting the hex to Base64 for assertion below
+	expectedSourceID, err := base.HexToBase64(inMemoryHLV.SourceID)
+	require.NoError(t, err)
+
+	// assertions on values of unmarshaled HLV
+	assert.Equal(t, inMemoryHLV.CurrentVersionCAS, hlvFromPersistance.CurrentVersionCAS)
+	assert.Equal(t, "m_"+string(expectedSourceID), hlvFromPersistance.SourceID)
+	assert.Equal(t, inMemoryHLV.Version, hlvFromPersistance.Version)
+	assert.Equal(t, inMemoryHLV.PreviousVersions, hlvFromPersistance.PreviousVersions)
+	assert.Equal(t, inMemoryHLV.MergeVersions, hlvFromPersistance.MergeVersions)
+}
+
+>>>>>>> 21874614 (CBG-3207: Implementation of persisted form of HLV.)
 func createHLVForTest(tb *testing.T, inputList []string) HybridLogicalVector {
 	hlvOutput := NewHybridLogicalVector()
 
@@ -192,3 +239,74 @@ func createHLVForTest(tb *testing.T, inputList []string) HybridLogicalVector {
 	}
 	return hlvOutput
 }
+
+// TestHybridLogicalVectorPersistence:
+//   - Tests the process of constructing in memory HLV and marshaling it to persisted format
+//   - Asserts on teh format
+//   - Unmarshal the HLV and assert that the process works as expected
+func TestHybridLogicalVectorPersistence(t *testing.T) {
+	// create HLV
+	inputHLV := []string{"cb06dc003846116d9b66d2ab23887a96@123456", "s_YZvBpEaztom9z5V/hDoeIw@1628620455135215600", "m_s_NqiIe0LekFPLeX4JvTO6Iw@1628620455139868700",
+		"m_s_LhRPsa7CpjEvP5zeXTXEBA@1628620455147864000"}
+	inMemoryHLV := createHLVForTest(t, inputHLV)
+
+	// marshal in memory hlv into persisted form
+	byteArray, err := inMemoryHLV.MarshalJSON()
+	require.NoError(t, err)
+
+	// convert to string and assert the in memory struct is converted to persisted form correctly
+	strHLV := string(byteArray)
+	assert.Contains(t, strHLV, `"cvCas":"0x40e2010000000000`)
+	assert.Contains(t, strHLV, `"src":"m_ywbcADhGEW2bZtKrI4h6lg"`)
+	assert.Contains(t, strHLV, `"vrs":"0x40e2010000000000"`)
+	assert.Contains(t, strHLV, `"mv":{"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16","s_NqiIe0LekFPLeX4JvTO6Iw":"1c008cd6ac059a16"}`)
+	assert.Contains(t, strHLV, `"pv":{"s_YZvBpEaztom9z5V/hDoeIw":"f0ff44d6ac059a16"}`)
+
+	// Unmarshal the in memory constructed HLV above
+	hlvFromPersistance := HybridLogicalVector{}
+	err = hlvFromPersistance.UnmarshalJSON(byteArray)
+	require.NoError(t, err)
+	fmt.Println(strHLV, hlvFromPersistance)
+
+	// extract expected sourceID from the in memory HLV by converting the hex to Base64 for assertion below
+	expectedSourceID, err := base.HexToBase64(inMemoryHLV.SourceID)
+	require.NoError(t, err)
+
+	// assertions on values of unmarshaled HLV
+	assert.Equal(t, inMemoryHLV.CurrentVersionCAS, hlvFromPersistance.CurrentVersionCAS)
+	assert.Equal(t, "m_"+string(expectedSourceID), hlvFromPersistance.SourceID)
+	assert.Equal(t, inMemoryHLV.Version, hlvFromPersistance.Version)
+	assert.Equal(t, inMemoryHLV.PreviousVersions, hlvFromPersistance.PreviousVersions)
+	assert.Equal(t, inMemoryHLV.MergeVersions, hlvFromPersistance.MergeVersions)
+}
+
+func createHLVForTest(tb *testing.T, inputList []string) HybridLogicalVector {
+	hlvOutput := NewHybridLogicalVector()
+
+	// first element will be current version and source pair
+	currentVersionPair := strings.Split(inputList[0], "@")
+	hlvOutput.SourceID = currentVersionPair[0]
+	version, err := strconv.Atoi(currentVersionPair[1])
+	require.NoError(tb, err)
+	hlvOutput.Version = uint64(version)
+	hlvOutput.CurrentVersionCAS = uint64(version)
+
+	// remove current version entry in list now we have parsed it into the HLV
+	inputList = inputList[1:]
+
+	for _, value := range inputList {
+		currentVersionPair = strings.Split(value, "@")
+		version, err = strconv.Atoi(currentVersionPair[1])
+		require.NoError(tb, err)
+		if strings.HasPrefix(currentVersionPair[0], "m_") {
+			// add entry to merge version removing the leading prefix for sourceID
+			hlvOutput.MergeVersions[currentVersionPair[0][2:]] = uint64(version)
+		} else {
+			// if its not got the prefix we assume its a previous version entry
+			hlvOutput.PreviousVersions[currentVersionPair[0]] = uint64(version)
+		}
+
+	}
+	return hlvOutput
+}
+

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -208,11 +208,13 @@ func TestHybridLogicalVectorPersistence(t *testing.T) {
 	require.NoError(t, err)
 
 	// convert to string and assert the in memory struct is converted to persisted form correctly
+	// no guarantee the order of the marshaling of the mv part so just assert on the values
 	strHLV := string(byteArray)
 	assert.Contains(t, strHLV, `"cvCas":"0x40e2010000000000`)
 	assert.Contains(t, strHLV, `"src":"cb06dc003846116d9b66d2ab23887a96"`)
 	assert.Contains(t, strHLV, `"vrs":"0x40e2010000000000"`)
-	assert.Contains(t, strHLV, `"mv":{"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16","s_NqiIe0LekFPLeX4JvTO6Iw":"1c008cd6ac059a16"}`)
+	assert.Contains(t, strHLV, `"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16"}`)
+	assert.Contains(t, strHLV, `"s_NqiIe0LekFPLeX4JvTO6Iw":"1c008cd6ac059a16"`)
 	assert.Contains(t, strHLV, `"pv":{"s_YZvBpEaztom9z5V/hDoeIw":"f0ff44d6ac059a16"}`)
 
 	// Unmarshal the in memory constructed HLV above


### PR DESCRIPTION
CBG-3207

Converts the in memory representation of HLV in #6345 to correct format for persistence. 

Defined here -> https://docs.google.com/document/d/1S0WStgbqRGlmwbdNyHn_9qqEqvshPv9WyG8skauJDEc/edit#heading=h.x82j5i9fdonk


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [x] Link upstream PRs -> https://github.com/couchbase/sync_gateway/pull/6345
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1956/
