### PR TITLE
Improve test assertions

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -290,10 +290,10 @@ func TestSaveUsers(t *testing.T) {
 	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions())
 	user, _ := auth.NewUser("testUser", "password", ch.BaseSetOf(t, "test"))
 	err := auth.Save(user)
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 
 	user2, err := auth.GetUser("testUser")
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 	assert.Equal(t, user, user2)
 }
 

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -29,6 +29,18 @@ type PutDocResponse struct {
 	Rev string
 }
 
+// Run is equivalent to testing.T.Run() but updates the RestTester's TB to the new testing.T
+// so that checks are made against the right instance (otherwise the outer test complains
+// "subtest may have called FailNow on a parent test")
+func (rt *RestTester) Run(name string, test func(*testing.T)) {
+	mainT := rt.TB.(*testing.T)
+	mainT.Run(name, func(t *testing.T) {
+		rt.TB = t
+		defer func() { rt.TB = mainT }()
+		test(t)
+	})
+}
+
 func (rt *RestTester) GetDoc(docID string) (body db.Body) {
 	rawResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/"+docID, "")
 	RequireStatus(rt.TB, rawResponse, 200)

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -219,7 +219,7 @@ func TestViewQueryMultipleViewsInterfaceValues(t *testing.T) {
 	// Currently fails against walrus bucket as '_sync' property will exist in doc object if it is emitted in the map function
 	t.Skip("WARNING: TEST DISABLED")
 
-	rt := NewRestTester(t, nil)
+	rt := NewRestTesterDefaultCollection(t, nil)
 	defer rt.Close()
 
 	// Define three views
@@ -632,7 +632,7 @@ func TestPostInstallCleanup(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc) {channel(doc.channel)}`,
 	}
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTesterDefaultCollection(t, &rtConfig)
 	defer rt.Close()
 
 	// Cleanup existing design docs
@@ -749,7 +749,7 @@ func TestViewQueryWithXattrAndNonXattr(t *testing.T) {
 		}},
 	}
 
-	rt := NewRestTester(t, rtConfig)
+	rt := NewRestTesterDefaultCollection(t, rtConfig)
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/db/doc1", `{"value":"foo"}`)


### PR DESCRIPTION
This improves some test assertions and prevents in `TestAttachment` from calling t.Error on a parent test from a subtest. This isn't done everywhere, but it is a start of an idiom.

Ran integration tests by hand.

Make sure views tests are always using default collection.