### PR TITLE
CBG-3269: Update build revision commit hash to implement stat definition generation

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -17,7 +17,7 @@ licenses/APL2.txt.
 
   <!-- Build Scripts (required on CI servers) -->
   <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
+  <project name="build" path="cbbuild" remote="couchbase" revision="3f3d1e973566724a16060b4eb013ae5fa895308a">
     <annotation name="VERSION" value="3.2.0"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>


### PR DESCRIPTION
CBG-3269

Update the revision hash of the build script so the changes done in https://review.couchbase.org/c/build/+/195074 can be used.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

