### PR TITLE
CBG-3171: Fix rev cache multi node inconsistency

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -481,8 +481,9 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	}
 
 	// Now add the entry for the new doc revision:
-	// Invalidate revision cache
-	collection.revisionCache.Invalidate(c.logCtx, docID, syncData.CurrentRev)
+	if len(rawUserXattr) > 0 {
+		collection.revisionCache.Invalidate(c.logCtx, docID, syncData.CurrentRev)
+	}
 	change := &LogEntry{
 		Sequence:     syncData.Sequence,
 		DocID:        docID,

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -481,11 +481,8 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	}
 
 	// Now add the entry for the new doc revision:
-	if len(rawUserXattr) > 0 {
-		collection.revisionCache.Invalidate(c.logCtx, docID, syncData.CurrentRev)
-	} else if len(rawUserXattr) == 0 {
-		collection.revisionCache.Invalidate(c.logCtx, docID, syncData.CurrentRev)
-	}
+	// Invalidate revision cache
+	collection.revisionCache.Invalidate(c.logCtx, docID, syncData.CurrentRev)
 	change := &LogEntry{
 		Sequence:     syncData.Sequence,
 		DocID:        docID,

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -481,6 +481,11 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	}
 
 	// Now add the entry for the new doc revision:
+	if len(rawUserXattr) > 0 {
+		collection.revisionCache.Invalidate(c.logCtx, docID, syncData.CurrentRev)
+	} else if len(rawUserXattr) == 0 {
+		collection.revisionCache.Invalidate(c.logCtx, docID, syncData.CurrentRev)
+	}
 	change := &LogEntry{
 		Sequence:     syncData.Sequence,
 		DocID:        docID,

--- a/db/import.go
+++ b/db/import.go
@@ -269,7 +269,7 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 			}
 		}
 
-		shouldGenerateNewRev := bodyChanged
+		shouldGenerateNewRev := bodyChanged || len(existingDoc.UserXattr) == 0
 
 		// If the body has changed then the document has been updated and we should generate a new revision. Otherwise
 		// the import was triggered by a user xattr mutation and therefore should not generate a new revision.

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1090,6 +1090,7 @@ func TestRevocationResumeSameRoleAndLowSeqCheck(t *testing.T) {
 
 func TestRevocationsWithQueryLimit(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
+	base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
 
 	revocationTester, rt := InitScenario(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -1107,20 +1108,29 @@ func TestRevocationsWithQueryLimit(t *testing.T) {
 	defer rt.Close()
 
 	revocationTester.addRole("user", "foo")
+	revocationTester.addUserChannel("user", "ch2")
+
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	revocationTester.fillToSeq(9)
+	_ = rt.CreateDocReturnRev(t, "doc11", "", map[string]interface{}{"channels": []string{"ch2"}})
+	_ = rt.CreateDocReturnRev(t, "doc12", "", map[string]interface{}{"channels": []string{"ch2"}})
+	_ = rt.CreateDocReturnRev(t, "doc13", "", map[string]interface{}{"channels": []string{"ch2"}})
+
 	_ = rt.CreateDocReturnRev(t, "doc1", "", map[string]interface{}{"channels": []string{"ch1"}})
 	_ = rt.CreateDocReturnRev(t, "doc2", "", map[string]interface{}{"channels": []string{"ch1"}})
 	_ = rt.CreateDocReturnRev(t, "doc3", "", map[string]interface{}{"channels": []string{"ch1"}})
 
-	changes := revocationTester.getChanges("0", 4)
+	changes := revocationTester.getChanges("0", 7)
 
 	revocationTester.removeRole("user", "foo")
+	_ = rt.CreateDocReturnRev(t, "doc14", "", map[string]interface{}{"channels": []string{"ch2"}})
+	_ = rt.CreateDocReturnRev(t, "doc15", "", map[string]interface{}{"channels": []string{"ch2"}})
+	_ = rt.CreateDocReturnRev(t, "doc5", "", map[string]interface{}{"channels": []string{"ch1"}})
 
 	// Run changes once (which has its own wait)
 	sinceVal := changes.Last_Seq
-	changes = revocationTester.getChanges(sinceVal, 3)
+	changes = revocationTester.getChanges(sinceVal, 5)
 
 	var queryKey string
 	if base.TestsDisableGSI() {
@@ -1131,7 +1141,7 @@ func TestRevocationsWithQueryLimit(t *testing.T) {
 
 	// Once we know the changes will return to right count run again to validate queries ran
 	channelQueryCountBefore := rt.GetDatabase().DbStats.Query(queryKey).QueryCount.Value()
-	changes = revocationTester.getChanges(sinceVal, 3)
+	changes = revocationTester.getChanges(sinceVal, 5)
 	channelQueryCountAfter := rt.GetDatabase().DbStats.Query(queryKey).QueryCount.Value()
 
 	assert.Equal(t, int64(3), channelQueryCountAfter-channelQueryCountBefore)

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1321,6 +1321,7 @@ func TestUserXattrRevCache(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+	assert.NoError(t, err)
 
 	resp = rt2.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userDEF")
 	RequireStatus(t, resp, http.StatusOK)
@@ -1331,7 +1332,9 @@ func TestUserXattrRevCache(t *testing.T) {
 
 	// wait for import of the xattr change on both nodes
 	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+	assert.NoError(t, err)
 	_, err = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+	assert.NoError(t, err)
 
 	// GET the doc with userABC to ensure it is accessible on both nodes
 	resp = rt2.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userABC")
@@ -1410,6 +1413,7 @@ func TestUserXattrDeleteWithRevCache(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+	assert.NoError(t, err)
 
 	resp = rt2.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userDEF")
 	RequireStatus(t, resp, http.StatusOK)
@@ -1420,7 +1424,9 @@ func TestUserXattrDeleteWithRevCache(t *testing.T) {
 
 	// wait for import of the xattr change on both nodes
 	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+	assert.NoError(t, err)
 	_, err = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+	assert.NoError(t, err)
 
 	// GET the doc with userDEF on both nodes to ensure userDEF no longer has access
 	resp = rt2.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userDEF")

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1320,7 +1320,7 @@ func TestUserXattrRevCache(t *testing.T) {
 	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, "DEF")
 	assert.NoError(t, err)
 
-	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "userDEF", false)
 	assert.NoError(t, err)
 
 	resp = rt2.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userDEF")
@@ -1331,9 +1331,9 @@ func TestUserXattrRevCache(t *testing.T) {
 	assert.NoError(t, err)
 
 	// wait for import of the xattr change on both nodes
-	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "userABC", false)
 	assert.NoError(t, err)
-	_, err = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+	_, err = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes", "userABC", false)
 	assert.NoError(t, err)
 
 	// GET the doc with userABC to ensure it is accessible on both nodes
@@ -1412,7 +1412,7 @@ func TestUserXattrDeleteWithRevCache(t *testing.T) {
 	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, "DEF")
 	assert.NoError(t, err)
 
-	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "userDEF", false)
 	assert.NoError(t, err)
 
 	resp = rt2.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userDEF")
@@ -1423,9 +1423,9 @@ func TestUserXattrDeleteWithRevCache(t *testing.T) {
 	assert.NoError(t, err)
 
 	// wait for import of the xattr change on both nodes
-	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "userDEF", false)
 	assert.NoError(t, err)
-	_, err = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+	_, err = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes", "userDEF", false)
 	assert.NoError(t, err)
 
 	// GET the doc with userDEF on both nodes to ensure userDEF no longer has access

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1249,6 +1249,77 @@ func TestRemovingUserXattr(t *testing.T) {
 		})
 	}
 }
+
+func TestUserXattrRevCache(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	if !base.TestUseXattrs() {
+		t.Skip("This test only works with XATTRS enabled")
+	}
+
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("test is EE only - user xattrs")
+	}
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+
+	docKey := t.Name()
+	xattrKey := "channels"
+	channelName := []string{"ABC", "DEF"}
+	revCacheSize := uint32(0)
+
+	// Sync function to set channel access to whatever xattr is
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			AutoImport:   true,
+			UserXattrKey: xattrKey,
+			CacheConfig:  &CacheConfig{RevCacheConfig: &RevCacheConfig{Size: &revCacheSize}},
+		}},
+		SyncFn: `
+			function (doc, oldDoc, meta){
+				if (meta.xattrs.channels !== undefined){
+					channel(meta.xattrs.channels);
+					console.log(JSON.stringify(meta));
+				}
+			}`,
+	})
+
+	defer rt.Close()
+
+	dataStore := rt.GetSingleDataStore()
+	userXattrStore, ok := base.AsUserXattrStore(dataStore)
+	if !ok {
+		t.Skip("Test requires Couchbase Bucket")
+	}
+
+	//subdocXattrStore, ok := base.AsSubdocXattrStore(dataStore)
+	//require.True(t, ok)
+
+	// Initial PUT
+	resp := rt.SendAdminRequest("PUT", "/{{.db}}/_user/userABC", `{"email":"abc@couchbase.com","password":"letmein","admin_channels":["ABC"]}`)
+	RequireStatus(t, resp, http.StatusCreated)
+	resp = rt.SendAdminRequest("PUT", "/{{.db}}/_user/userDEF", `{"email":"def@couchbase.com","password":"letmein","admin_channels":["DEF"]}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+docKey, `{}`)
+	RequireStatus(t, resp, http.StatusCreated)
+	require.NoError(t, rt.WaitForPendingChanges())
+
+	_, err := userXattrStore.WriteUserXattr(docKey, xattrKey, "DEF")
+	assert.NoError(t, err)
+
+	resp = rt.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userDEF")
+	RequireStatus(t, resp, http.StatusOK)
+
+	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, channelName)
+	assert.NoError(t, err)
+	resp = rt.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userABC")
+	RequireStatus(t, resp, http.StatusOK)
+
+}
+
 func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1340,7 +1340,7 @@ func TestUserXattrRevCache(t *testing.T) {
 	assert.Equal(t, resp.Code, http.StatusOK)
 }
 
-func TestUserXattrDelete(t *testing.T) {
+func TestUserXattrDeleteWithRevCache(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
@@ -1424,9 +1424,9 @@ func TestUserXattrDelete(t *testing.T) {
 
 	// GET the doc with userDEF on both nodes to ensure userDEF no longer has access
 	resp = rt2.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userDEF")
-	assert.Equal(t, resp.Code, http.StatusOK)
+	assert.Equal(t, resp.Code, http.StatusForbidden)
 	resp = rt.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userDEF")
-	assert.Equal(t, resp.Code, http.StatusOK)
+	assert.Equal(t, resp.Code, http.StatusForbidden)
 }
 
 func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {


### PR DESCRIPTION
CBG-3171

Describe your PR here...
- Invalidate rev cache on DocChanged when userXattr is not empty, and generate a new rev when the userXattr gets deleted, fixing inconsistencies in channel assignments using userXattrKeys on multi node SGW deployments.
- Add TestUserXattrDeleteWithRevCache and TestUserXattrRevCache to ensure expected behaviour with channel assignments and userXattr writes/deletes in multi node SGW environments

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1967/
