### PR TITLE
CBG-3287: Increase console log buffer size when writing to file

### DIFF
--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -234,7 +234,12 @@ func (lcc *ConsoleLoggerConfig) init() error {
 	if lcc.CollationBufferSize == nil {
 		bufferSize := 0
 		if *lcc.LogLevel >= LevelInfo {
-			bufferSize = defaultConsoleLoggerCollateBufferSize
+			if lcc.FileOutput != "" {
+				// increase buffer size for file output
+				bufferSize = defaultFileLoggerCollateBufferSize
+			} else {
+				bufferSize = defaultConsoleLoggerCollateBufferSize
+			}
 		}
 		lcc.CollationBufferSize = &bufferSize
 	}


### PR DESCRIPTION
CBG-3287

When the console logger has a FileOutput set, increase the log collation buffer size to match file loggers.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1966/
