### PR TITLE
CBG-3315: Add /_ping healthcheck API

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -175,6 +175,11 @@ func TracefCtx(ctx context.Context, logKey LogKey, format string, args ...interf
 	logTo(ctx, LevelTrace, logKey, format, args...)
 }
 
+// LogLevelCtx allows logging where the level can be set via parameter.
+func LogLevelCtx(ctx context.Context, logLevel LogLevel, logKey LogKey, format string, args ...interface{}) {
+	logTo(ctx, logLevel, logKey, format, args...)
+}
+
 // RecordStats writes the given stats JSON content to a stats log file, if enabled.
 // The content passed in is expected to be a JSON dictionary.
 func RecordStats(statsJson string) {

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -130,6 +130,8 @@ paths:
     $ref: ./paths/admin/_expvar.yaml
   /:
     $ref: ./paths/admin/-.yaml
+  /_ping:
+    $ref: ./paths/common/_ping.yaml
   '/{keyspace}/_all_docs':
     $ref: './paths/admin/keyspace-_all_docs.yaml'
   '/{keyspace}/_bulk_docs':

--- a/docs/api/metric.yaml
+++ b/docs/api/metric.yaml
@@ -28,6 +28,8 @@ servers:
         description: The hostname to use
         default: localhost
 paths:
+  /_ping:
+    $ref: ./paths/common/_ping.yaml
   /_metrics:
     $ref: ./paths/metric/metrics.yaml
   /metrics:

--- a/docs/api/paths/common/_ping.yaml
+++ b/docs/api/paths/common/_ping.yaml
@@ -1,0 +1,30 @@
+# Copyright 2023-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+get:
+  summary: Check if API is available
+  description: Returns OK status if API is available.
+  responses:
+    '200':
+      description: Returned status
+      content:
+        text/plain:
+          schema:
+            type: string
+          example: "OK"
+  tags:
+    - Server
+  operationId: get__ping
+head:
+  responses:
+    '200':
+      description: Server is available
+  tags:
+    - Server
+  summary: Check if API is available
+  description: Returns OK status if API is available.
+  operationId: head__ping

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -36,6 +36,8 @@ paths:
     $ref: './paths/public/db-.yaml'
   /:
     $ref: ./paths/public/-.yaml
+  /_ping:
+    $ref: ./paths/common/_ping.yaml
   '/{keyspace}/':
     $ref: './paths/admin/keyspace-.yaml'
   '/{keyspace}/_all_docs':

--- a/rest/api.go
+++ b/rest/api.go
@@ -68,6 +68,12 @@ func (h *handler) handleRoot() error {
 	return nil
 }
 
+// HTTP handler for a simple ping healthcheck
+func (h *handler) handlePing() error {
+	h.writeTextStatus(http.StatusOK, []byte("OK"))
+	return nil
+}
+
 func (h *handler) handleAllDbs() error {
 	h.writeJSON(h.server.AllDatabaseNames())
 	return nil

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2822,3 +2822,50 @@ func assertHTTPErrorReason(t testing.TB, response *TestResponse, expectedStatus 
 
 	assert.Equal(t, expectedReason, httpError.Reason)
 }
+
+// TestPing ensures that /_ping is accessible on all APIs for GET and HEAD without authentication.
+func TestPing(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyHTTPResp)
+
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	tests := []struct {
+		method         string
+		expectedStatus int
+		expectedBody   string
+	}{
+		{method: http.MethodGet, expectedStatus: http.StatusOK, expectedBody: "OK"},
+		{method: http.MethodHead, expectedStatus: http.StatusOK, expectedBody: ""},
+		{method: http.MethodPost, expectedStatus: http.StatusMethodNotAllowed},
+		{method: http.MethodPut, expectedStatus: http.StatusMethodNotAllowed},
+		{method: http.MethodPatch, expectedStatus: http.StatusMethodNotAllowed},
+		{method: http.MethodDelete, expectedStatus: http.StatusMethodNotAllowed},
+		{method: http.MethodConnect, expectedStatus: http.StatusMethodNotAllowed},
+		{method: http.MethodOptions, expectedStatus: http.StatusNoContent},
+		{method: http.MethodTrace, expectedStatus: http.StatusMethodNotAllowed},
+	}
+
+	testAPIs := []struct {
+		apiName   string
+		requestFn func(string, string, string) *TestResponse
+	}{
+		{"Public", rt.SendRequest},
+		{"Admin", rt.SendAdminRequest},
+		{"Metrics", rt.SendMetricsRequest},
+	}
+
+	for _, test := range tests {
+		for _, api := range testAPIs {
+			t.Run(fmt.Sprintf("%s %s", test.method, api.apiName), func(t *testing.T) {
+				resp := api.requestFn(test.method, "/_ping", "")
+				AssertStatus(t, resp, test.expectedStatus)
+				if test.expectedStatus == http.StatusOK {
+					assert.Containsf(t, resp.Header().Get("Content-Type"), "text/plain", "Should have text/plain Content-Type")
+					assert.Equalf(t, "2", resp.Header().Get("Content-Length"), "Should have a Content-Length")
+					assert.Equalf(t, test.expectedBody, string(resp.BodyBytes()), "Unexpected response body")
+				}
+			})
+		}
+	}
+}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -651,14 +651,16 @@ func (h *handler) logDuration(realTime bool) {
 	// Log timings/status codes for errors under the HTTP log key
 	// and the HTTPResp log key for everything else.
 	logKey := base.KeyHTTPResp
+	logLevel := base.LevelInfo
+
+	// if error status, log at HTTP/Info
 	if h.status >= 300 {
 		logKey = base.KeyHTTP
-	}
-
-	logLevel := base.LevelInfo
-	if h.httpLogLevel != nil {
+	} else if h.httpLogLevel != nil {
+		// if the handler requested a different log level, and the request was successful, we'll honour that log level.
 		logLevel = *h.httpLogLevel
 	}
+
 	base.LogLevelCtx(h.ctx(), logLevel, logKey, "%s:     --> %d %s  (%.1f ms)",
 		h.formatSerialNumber(), h.status, h.statusMessage,
 		float64(duration)/float64(time.Millisecond),

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -1379,7 +1379,10 @@ func (h *handler) writeWithMimetypeStatus(status int, value []byte, mimetype str
 		h.response.WriteHeader(status)
 		h.setStatus(status, http.StatusText(status))
 	}
-	_, _ = h.response.Write(value)
+	// RFC-9110: "HEAD method .. the server MUST NOT send content in the response"
+	if h.rq.Method != http.MethodHead {
+		_, _ = h.response.Write(value)
+	}
 }
 
 func (h *handler) addJSON(value interface{}) error {

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -39,8 +39,10 @@ func init() {
 func createCommonRouter(sc *ServerContext, privs handlerPrivs) (root, db, keyspace *mux.Router) {
 	root = mux.NewRouter()
 	root.StrictSlash(true)
+
 	// Global operations:
 	root.Handle("/", makeHandler(sc, privs, nil, nil, (*handler).handleRoot)).Methods("GET", "HEAD")
+	root.Handle("/_ping", makeSilentHandler(sc, privs, nil, nil, (*handler).handlePing)).Methods("GET", "HEAD")
 
 	// Operations on databases:
 	root.Handle("/{db:"+dbRegex+"}/", makeOfflineHandler(sc, privs, []Permission{PermDevOps}, nil, (*handler).handleGetDB)).Methods("GET", "HEAD")

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -42,7 +42,7 @@ func createCommonRouter(sc *ServerContext, privs handlerPrivs) (root, db, keyspa
 
 	// Global operations:
 	root.Handle("/", makeHandler(sc, privs, nil, nil, (*handler).handleRoot)).Methods("GET", "HEAD")
-	root.Handle("/_ping", makeSilentHandler(sc, privs, nil, nil, (*handler).handlePing)).Methods("GET", "HEAD")
+	root.Handle("/_ping", makeSilentHandler(sc, publicPrivs, nil, nil, (*handler).handlePing)).Methods("GET", "HEAD")
 
 	// Operations on databases:
 	root.Handle("/{db:"+dbRegex+"}/", makeOfflineHandler(sc, privs, []Permission{PermDevOps}, nil, (*handler).handleGetDB)).Methods("GET", "HEAD")
@@ -348,6 +348,7 @@ func CreateMetricHandler(sc *ServerContext) http.Handler {
 func CreateMetricRouter(sc *ServerContext) *mux.Router {
 	r := mux.NewRouter()
 	r.StrictSlash(true)
+	r.Handle("/_ping", makeSilentHandler(sc, publicPrivs, nil, nil, (*handler).handlePing)).Methods("GET", "HEAD")
 
 	r.Handle("/metrics", makeHandler(sc, metricsPrivs, []Permission{PermStatsExport}, nil, (*handler).handleMetrics)).Methods("GET")
 	r.Handle("/_metrics", makeHandler(sc, metricsPrivs, []Permission{PermStatsExport}, nil, (*handler).handleMetrics)).Methods("GET")

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -680,6 +680,17 @@ func (rt *RestTester) Send(request *http.Request) *TestResponse {
 	return response
 }
 
+func (rt *RestTester) SendMetricsRequest(method, resource, body string) *TestResponse {
+	return rt.sendMetrics(Request(method, rt.mustTemplateResource(resource), body))
+}
+
+func (rt *RestTester) sendMetrics(request *http.Request) *TestResponse {
+	response := &TestResponse{ResponseRecorder: httptest.NewRecorder(), Req: request}
+	response.Code = 200 // doesn't seem to be initialized by default; filed Go bug #4188
+	rt.TestMetricsHandler().ServeHTTP(response, request)
+	return response
+}
+
 func (rt *RestTester) TestAdminHandlerNoConflictsMode() http.Handler {
 	rt.EnableNoConflictsMode = true
 	return rt.TestAdminHandler()
@@ -811,7 +822,7 @@ func (rt *RestTester) WaitForConditionShouldRetry(conditionFunc func() (shouldRe
 	return nil
 }
 
-func (rt *RestTester) SendAdminRequest(method, resource string, body string) *TestResponse {
+func (rt *RestTester) SendAdminRequest(method, resource, body string) *TestResponse {
 	input := bytes.NewBufferString(body)
 	request, err := http.NewRequest(method, "http://localhost"+rt.mustTemplateResource(resource), input)
 	require.NoError(rt.TB, err)
@@ -823,7 +834,7 @@ func (rt *RestTester) SendAdminRequest(method, resource string, body string) *Te
 	return response
 }
 
-func (rt *RestTester) SendUserRequest(method, resource string, body string, username string) *TestResponse {
+func (rt *RestTester) SendUserRequest(method, resource, body, username string) *TestResponse {
 	return rt.Send(RequestByUser(method, rt.mustTemplateResource(resource), body, username))
 }
 


### PR DESCRIPTION
CBG-3315

Adds a `/_ping` healthcheck endpoint to all APIs (Public, Admin, Metrics) that always returns Status `200`/`"OK"`
- Refactoring of `makeHandler` to make better use of `handlerOptions` and reduce duplication.
- Make `/_ping` only log at debug level (`makeSilentHandler`/`handlerOptions.httpLogLevel`)
- OpenAPI Docs
- Unit test
- Fix for disallowed response body when request was a `HEAD` (discovered via above unit test)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1969/
