### PR TITLE
CBG-3316: Silence metrics requests

### DIFF
--- a/rest/debug.go
+++ b/rest/debug.go
@@ -96,7 +96,7 @@ func recordCBClientStat(opname, k string, start time.Time, err error) {
 }
 
 func (h *handler) handleExpvar() error {
-	base.InfofCtx(h.ctx(), base.KeyHTTP, "Recording snapshot of current debug variables.")
+	base.DebugfCtx(h.ctx(), base.KeyHTTP, "Recording snapshot of current debug variables.")
 	h.rq.URL.Path = strings.Replace(h.rq.URL.Path, kDebugURLPathPrefix, "/debug/vars", 1)
 	http.DefaultServeMux.ServeHTTP(h.response, h.rq)
 	return nil

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -517,7 +517,7 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 		h.authorizedAdminUser = username
 		h.permissionsResults = permissions
 
-		base.InfofCtx(h.ctx(), base.KeyAuth, "%s: User %s was successfully authorized as an admin", h.formatSerialNumber(), base.UD(username))
+		base.DebugfCtx(h.ctx(), base.KeyAuth, "%s: User %s was successfully authorized as an admin", h.formatSerialNumber(), base.UD(username))
 	} else {
 		// If admin auth is not enabled we should set any responsePermissions to true so that any handlers checking for
 		// these still pass

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -276,7 +276,7 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	r.Handle("/_stats",
 		makeHandler(sc, adminPrivs, []Permission{PermStatsExport}, nil, (*handler).handleStats)).Methods("GET")
 	r.Handle(kDebugURLPathPrefix,
-		makeHandler(sc, adminPrivs, []Permission{PermStatsExport}, nil, (*handler).handleExpvar)).Methods("GET")
+		makeSilentHandler(sc, adminPrivs, []Permission{PermStatsExport}, nil, (*handler).handleExpvar)).Methods("GET")
 	r.Handle("/_profile/{profilename}",
 		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleProfiling)).Methods("POST")
 	r.Handle("/_profile",
@@ -350,9 +350,9 @@ func CreateMetricRouter(sc *ServerContext) *mux.Router {
 	r.StrictSlash(true)
 	r.Handle("/_ping", makeSilentHandler(sc, publicPrivs, nil, nil, (*handler).handlePing)).Methods("GET", "HEAD")
 
-	r.Handle("/metrics", makeHandler(sc, metricsPrivs, []Permission{PermStatsExport}, nil, (*handler).handleMetrics)).Methods("GET")
-	r.Handle("/_metrics", makeHandler(sc, metricsPrivs, []Permission{PermStatsExport}, nil, (*handler).handleMetrics)).Methods("GET")
-	r.Handle(kDebugURLPathPrefix, makeHandler(sc, metricsPrivs, []Permission{PermStatsExport}, nil, (*handler).handleExpvar)).Methods("GET")
+	r.Handle("/metrics", makeSilentHandler(sc, metricsPrivs, []Permission{PermStatsExport}, nil, (*handler).handleMetrics)).Methods("GET")
+	r.Handle("/_metrics", makeSilentHandler(sc, metricsPrivs, []Permission{PermStatsExport}, nil, (*handler).handleMetrics)).Methods("GET")
+	r.Handle(kDebugURLPathPrefix, makeSilentHandler(sc, metricsPrivs, []Permission{PermStatsExport}, nil, (*handler).handleExpvar)).Methods("GET")
 
 	return r
 }


### PR DESCRIPTION
CBG-3316

Metrics API requests silenced (logged at debug)
- Associated logging with metrics requests also lowered to debug:
  - `User <ud>Administrator</ud> was successfully authorized as an admin`
  - `Recording snapshot of current debug variables.`

## Dependencies
- [x] Depends on `makeSilentHandler` added in #6375 

## Testing

New log output of:
```
$ curl -i http://localhost:4986/_ping && \
curl -i http://Administrator:password@localhost:4986/_metrics && \
curl -i http://Administrator:password@localhost:4986/metrics && \
curl -i http://Administrator:password@localhost:4986/_expvar
```

```
2023-08-23T13:55:12.754+01:00 [DBG] HTTP+: c:#001 GET /_ping
2023-08-23T13:55:12.754+01:00 [DBG] HTTP++: c:#001 #001:     --> 200 OK  (0.2 ms)
2023-08-23T13:55:12.864+01:00 [DBG] Auth+: c:#002 #002: User <ud>Administrator</ud> was successfully authorized as an admin
2023-08-23T13:55:12.864+01:00 [DBG] HTTP+: c:#002 GET /_metrics (as <ud>Administrator</ud> as ADMIN)
2023-08-23T13:55:12.865+01:00 [DBG] HTTP++: c:#002 #002:     --> 200   (87.5 ms)
2023-08-23T13:55:12.908+01:00 [DBG] Auth+: c:#003 #003: User <ud>Administrator</ud> was successfully authorized as an admin
2023-08-23T13:55:12.908+01:00 [DBG] HTTP+: c:#003 GET /metrics (as <ud>Administrator</ud> as ADMIN)
2023-08-23T13:55:12.909+01:00 [DBG] HTTP++: c:#003 #003:     --> 200   (20.9 ms)
2023-08-23T13:55:12.938+01:00 [DBG] Auth+: c:#004 #004: User <ud>Administrator</ud> was successfully authorized as an admin
2023-08-23T13:55:12.938+01:00 [DBG] HTTP+: c:#004 GET /_expvar (as <ud>Administrator</ud> as ADMIN)
2023-08-23T13:55:12.938+01:00 [DBG] HTTP+: c:#004 Recording snapshot of current debug variables.
2023-08-23T13:55:12.938+01:00 [DBG] HTTP++: c:#004 #004:     --> 200   (13.3 ms)
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
