### PR TITLE
CBG-3292: Handling for corrupt db config 

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -230,6 +230,13 @@ func UnitTestUrlIsWalrus() bool {
 	return ServerIsWalrus(UnitTestUrl())
 }
 
+func TestsRequireBootstrapConnection() bool {
+	if !TestUseCouchbaseServer() && UnitTestUrlIsWalrus() {
+		return true
+	}
+	return false
+}
+
 // ServerIsTLS returns true if the server URL is using an accepted secure protocol as it's prefix
 // Prefix checked: couchbases:
 func ServerIsTLS(server string) bool {

--- a/base/constants.go
+++ b/base/constants.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/couchbaselabs/rosmar"
@@ -230,11 +231,10 @@ func UnitTestUrlIsWalrus() bool {
 	return ServerIsWalrus(UnitTestUrl())
 }
 
-func TestsRequireBootstrapConnection() bool {
-	if !TestUseCouchbaseServer() && UnitTestUrlIsWalrus() {
-		return true
+func TestsRequireBootstrapConnection(t *testing.T) {
+	if UnitTestUrlIsWalrus() {
+		t.Skipf("Tests requiring a bootstrap connection are not supporting using rosmar yet - CBG-3271")
 	}
-	return false
 }
 
 // ServerIsTLS returns true if the server URL is using an accepted secure protocol as it's prefix

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -128,7 +128,7 @@ func (h *handler) handleCreateDB() error {
 
 		// now we've started the db successfully, we can persist it to the cluster first checking if this db used to be a corrupt db
 		// if it used to be corrupt we need to remove it from the invalid database map on server context and remove the old corrupt config from the bucket
-		err = h.fixCorruptDatabaseConfig(contextNoCancel.Ctx, bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName)
+		err = h.removeCorruptConfigIfExists(contextNoCancel.Ctx, bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName)
 		if err != nil {
 			return err
 		}

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1449,6 +1449,7 @@ func TestCorruptDbConfigHandling(t *testing.T) {
 	if base.TestsRequireBootstrapConnection() {
 		t.Skip("Walrus/Rosmar does not support persistent config")
 	}
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyConfig)
 
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: base.GetPersistentTestBucket(t),

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1491,17 +1491,17 @@ func TestCorruptDbConfigHandling(t *testing.T) {
 	// assert that fetching config fails with the correct error message to the user
 	resp = rt.SendAdminRequest(http.MethodGet, "/db1/_config", "")
 	rest.RequireStatus(t, resp, http.StatusNotFound)
-	assert.Contains(t, resp.Body.String(), "Must update database config immediately")
+	assert.Contains(t, resp.Body.String(), "You must update database config immediately")
 
 	// assert trying to delete fails with the correct error message to the user
 	resp = rt.SendAdminRequest(http.MethodDelete, "/db1/", "")
 	rest.RequireStatus(t, resp, http.StatusNotFound)
-	assert.Contains(t, resp.Body.String(), "Must update database config immediately")
+	assert.Contains(t, resp.Body.String(), "You must update database config immediately")
 
 	// correct the name through update to config
 	resp = rt.ReplaceDbConfig("db1", dbConfig)
 	rest.RequireStatus(t, resp, http.StatusNotFound)
-	assert.Contains(t, resp.Body.String(), "Must update database config immediately")
+	assert.Contains(t, resp.Body.String(), "You must update database config immediately")
 
 	// create db of same name with correct db config to correct the corrupt db config
 	resp = rt.CreateDatabase("db1", dbConfig)

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1440,48 +1440,28 @@ func TestResyncStop(t *testing.T) {
 //     dbconfig becoming corrupt)
 //   - Update the persisted config to change the bucket name to a non-existent bucket
 //   - Assert that the db context and config are removed from server context and that operations on the database GET and
-//     DELETE fail with appropriate error message for user
-//   - Test we are able to update the config to correct the corrupted db config
-//   - asser the db returns to the server context and is removed from corrupt database tracking AND that the bucket name
+//     DELETE and operation to update the config fail with appropriate error message for user
+//   - Test we are able to update the config to correct the corrupted db config using the /db1/ endpoint
+//   - assert the db returns to the server context and is removed from corrupt database tracking AND that the bucket name
 //     on the config now matches the rest tester bucket name
 func TestCorruptDbConfigHandling(t *testing.T) {
 	base.LongRunningTest(t)
 	if base.TestsRequireBootstrapConnection() {
 		t.Skip("Walrus/Rosmar does not support persistent config")
 	}
-	numCollections := 1
-	base.RequireNumTestDataStores(t, numCollections)
 
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: base.GetPersistentTestBucket(t),
 		PersistentConfig: true,
 		MutateStartupConfig: func(config *rest.StartupConfig) {
-			// configure the interval time to pick up new configs from the bucket to every 2 seconds
-			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(2)
+			// configure the interval time to pick up new configs from the bucket to every 1 seconds
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(1000000000)
 		},
 	})
 	defer rt.Close()
 
-	ds := rt.CustomTestBucket.GetSingleDataStore()
-	name, ok := base.AsDataStoreName(ds)
-	require.True(t, ok)
-
-	scopesMap := make(map[string]rest.ScopeConfig)
-	collectionMap := make(map[string]rest.CollectionConfig)
-	collectionMap[name.CollectionName()] = rest.CollectionConfig{}
-	scopesMap[name.ScopeName()] = rest.ScopeConfig{
-		Collections: collectionMap,
-	}
-
 	// create db with correct config
-	dbConfig := rest.DbConfig{
-		BucketConfig: rest.BucketConfig{
-			Bucket: base.StringPtr(rt.CustomTestBucket.GetName()),
-		},
-		NumIndexReplicas: base.UintPtr(0),
-		EnableXattrs:     base.BoolPtr(base.TestUseXattrs()),
-		Scopes:           scopesMap,
-	}
+	dbConfig := rt.NewDbConfig()
 	resp := rt.CreateDatabase("db1", dbConfig)
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
@@ -1499,7 +1479,11 @@ func TestCorruptDbConfigHandling(t *testing.T) {
 	require.NoError(t, err)
 
 	// wait for some time for interval to remove the db
-	time.Sleep(2 * time.Second)
+	err = rt.WaitForConditionWithOptions(func() bool {
+		list := rt.ServerContext().AllDatabaseNames()
+		return len(list) == 0
+	}, 200, 1000)
+	require.NoError(t, err)
 
 	// assert that the in memory representation of the db config on the server context is gone now we have broken the config
 	responseConfig := rt.ServerContext().GetDbConfig("db1")
@@ -1525,7 +1509,11 @@ func TestCorruptDbConfigHandling(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	// wait some time for interval to pick up change
-	time.Sleep(2 * time.Second)
+	err = rt.WaitForConditionWithOptions(func() bool {
+		list := rt.ServerContext().AllDatabaseNames()
+		return len(list) == 1
+	}, 200, 1000)
+	require.NoError(t, err)
 
 	// assert that the config is back in memory even after another interval update pass and asser the persisted config
 	// bucket name matches rest tester bucket name
@@ -1533,8 +1521,302 @@ func TestCorruptDbConfigHandling(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, dbCtx)
 	assert.Equal(t, rt.CustomTestBucket.GetName(), dbCtx.Bucket.GetName())
-	corruptMap := rt.ServerContext().GetCorruptDatabaseMap()
-	assert.Equal(t, 0, len(corruptMap))
+	rt.ServerContext().RequireInvalidDatabaseConfigNames(t, []string{})
+}
+
+// TestBadConfigInsertionToBucket:
+//	 - start a rest tester
+//	 - insert an invalid db config to the bucket while rest tester is running
+//   - assert that the db config is picked up as an invalid db config
+//   - assert that a call to the db endpoint will fail with correct error message
+func TestBadConfigInsertionToBucket(t *testing.T) {
+	if base.TestsRequireBootstrapConnection() {
+		t.Skip("Walrus/Rosmar does not support persistent config")
+	}
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: base.GetPersistentTestBucket(t),
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// configure the interval time to pick up new configs from the bucket to every 1 seconds
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(1000000000)
+		},
+		DatabaseConfig: nil,
+	})
+	defer rt.Close()
+
+	// create a new invalid db config and persist to bucket
+	badName := "badBucketName"
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Name = "db1"
+
+	version, err := rest.GenerateDatabaseConfigVersionID("", &dbConfig)
+	require.NoError(t, err)
+
+	metadataID, metadataIDError := rt.ServerContext().BootstrapContext.ComputeMetadataIDForDbConfig(base.TestCtx(t), &dbConfig)
+	require.NoError(t, metadataIDError)
+
+	dbConfig.Bucket = &badName
+	persistedConfig := rest.DatabaseConfig{
+		Version:    version,
+		MetadataID: metadataID,
+		DbConfig:   dbConfig,
+		SGVersion:  base.ProductVersion.String(),
+	}
+	rt.InsertDbConfigToBucket(&persistedConfig, rt.CustomTestBucket.GetName())
+
+	// asser that the config is picked up as invalid config on server context
+	err = rt.WaitForConditionWithOptions(func() bool {
+		invalidDatabases := rt.ServerContext().AllInvalidDatabases()
+		return len(invalidDatabases) == 1
+	}, 200, 1000)
+	require.NoError(t, err)
+
+	// assert that a request to the database fails with correct error message
+	resp := rt.SendAdminRequest(http.MethodGet, "/db1/_config", "")
+	rest.RequireStatus(t, resp, http.StatusNotFound)
+	assert.Contains(t, resp.Body.String(), "Must update database config immediately")
+}
+
+// TestMismatchedBucketNameOnDbConfigUpdate:
+//   - Create a db on the rest tester
+//   - attempt to update the config to change the bucket name on the config to a mismatched bucket name
+//   - assert the request fails
+func TestMismatchedBucketNameOnDbConfigUpdate(t *testing.T) {
+	if base.TestsRequireBootstrapConnection() {
+		t.Skip("Walrus/Rosmar does not support persistent config")
+	}
+	base.RequireNumTestBuckets(t, 2)
+	tb1 := base.GetPersistentTestBucket(t)
+	defer tb1.Close()
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: base.GetPersistentTestBucket(t),
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// configure the interval time to pick up new configs from the bucket to every 1 seconds
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(1000000000)
+		},
+	})
+	defer rt.Close()
+
+	// create db with correct config
+	dbConfig := rt.NewDbConfig()
+	resp := rt.CreateDatabase("db1", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	// wait for db to come online
+	require.NoError(t, rt.WaitForDBOnline())
+	badName := tb1.GetName()
+	dbConfig.Bucket = &badName
+
+	// assert request fails
+	resp = rt.ReplaceDbConfig("db1", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusNotFound)
+}
+
+// TestMultipleBucketWithBadDbConfigScenario1:
+//   - in bucketA and bucketB, write two db configs with bucket name as bucketC
+//   - Start new rest tester and ensure they aren't picked up as valid configs
+func TestMultipleBucketWithBadDbConfigScenario1(t *testing.T) {
+	if base.TestsRequireBootstrapConnection() {
+		t.Skip("Walrus/Rosmar does not support persistent config")
+	}
+	base.RequireNumTestBuckets(t, 3)
+	tb1 := base.GetPersistentTestBucket(t)
+	defer tb1.Close()
+	tb2 := base.GetPersistentTestBucket(t)
+	defer tb2.Close()
+	tb3 := base.GetPersistentTestBucket(t)
+	defer tb3.Close()
+
+	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb1,
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// configure same config groupID
+			config.Bootstrap.ConfigGroupID = "60ce5544-c368-4b08-b0ed-4ca3b37973f9"
+		},
+	})
+	defer rt1.Close()
+
+	// create a db config that has bucket C in the config and persist to rt1 bucket
+	dbConfig := rt1.NewDbConfig()
+	dbConfig.Name = "db1"
+	rt1.PersistDbConfigToBucket(dbConfig, tb3.GetName())
+
+	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb2,
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// configure same config groupID
+			config.Bootstrap.ConfigGroupID = "60ce5544-c368-4b08-b0ed-4ca3b37973f9"
+		},
+	})
+	defer rt2.Close()
+
+	// create a db config that has bucket C in the config and persist to rt2 bucket
+	dbConfig = rt2.NewDbConfig()
+	dbConfig.Name = "db1"
+	rt2.PersistDbConfigToBucket(dbConfig, tb3.GetName())
+
+	rt3 := rest.NewRestTester(t, &rest.RestTesterConfig{
+		PersistentConfig: true,
+		CustomTestBucket: tb3,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// configure the interval time to pick up new configs from the bucket to every 1 seconds
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(1000000000)
+			// configure same config groupID
+			config.Bootstrap.ConfigGroupID = "60ce5544-c368-4b08-b0ed-4ca3b37973f9"
+		},
+	})
+	defer rt3.Close()
+
+	// assert the invalid database is picked up with new rest tester
+	err := rt3.WaitForConditionWithOptions(func() bool {
+		invalidDatabases := rt3.ServerContext().AllInvalidDatabases()
+		return len(invalidDatabases) == 1
+	}, 200, 1000)
+	require.NoError(t, err)
+
+	// assert that there are no valid db configs on the server context
+	err = rt3.WaitForConditionWithOptions(func() bool {
+		databaseNames := rt3.ServerContext().AllDatabaseNames()
+		return len(databaseNames) == 0
+	}, 200, 1000)
+	require.NoError(t, err)
+
+	// assert a request to the db fails with correct error message
+	resp := rt3.SendAdminRequest(http.MethodGet, "/db1/_config", "")
+	rest.RequireStatus(t, resp, http.StatusNotFound)
+	assert.Contains(t, resp.Body.String(), "Must update database config immediately")
+}
+
+// TestMultipleBucketWithBadDbConfigScenario2:
+//   - create bucketA and bucketB with db configs that that both list bucket name as bucketA
+//   - start a new rest tester and assert that invalid db config is picked up and the valid one is also picked up
+func TestMultipleBucketWithBadDbConfigScenario2(t *testing.T) {
+	if base.TestsRequireBootstrapConnection() {
+		t.Skip("Walrus/Rosmar does not support persistent config")
+	}
+
+	base.RequireNumTestBuckets(t, 3)
+	tb1 := base.GetPersistentTestBucket(t)
+	defer tb1.Close()
+	tb2 := base.GetPersistentTestBucket(t)
+	defer tb2.Close()
+
+	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb1,
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// configure same config groupID
+			config.Bootstrap.ConfigGroupID = "60ce5544-c368-4b08-b0ed-4ca3b37973f9"
+		},
+	})
+	// create a db config pointing to bucket C and persist to bucket A
+	dbConfig := rt1.NewDbConfig()
+	dbConfig.Name = "db1"
+	rt1.PersistDbConfigToBucket(dbConfig, rt1.CustomTestBucket.GetName())
+	defer rt1.Close()
+
+	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb2,
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// configure same config groupID
+			config.Bootstrap.ConfigGroupID = "60ce5544-c368-4b08-b0ed-4ca3b37973f9"
+		},
+	})
+	defer rt2.Close()
+
+	// create a db config pointing to bucket C and persist to bucket B
+	dbConfig = rt2.NewDbConfig()
+	dbConfig.Name = "db1"
+	rt2.PersistDbConfigToBucket(dbConfig, "badName")
+
+	rt3 := rest.NewRestTester(t, &rest.RestTesterConfig{
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// configure the interval time to pick up new configs from the bucket to every 1 seconds
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(1000000000)
+			// configure same config groupID
+			config.Bootstrap.ConfigGroupID = "60ce5544-c368-4b08-b0ed-4ca3b37973f9"
+		},
+	})
+	defer rt3.Close()
+
+	// assert that the invalid config is picked up by the new rest tester
+	err := rt3.WaitForConditionWithOptions(func() bool {
+		invalidDatabases := rt3.ServerContext().AllInvalidDatabases()
+		return len(invalidDatabases) == 1
+	}, 200, 1000)
+	require.NoError(t, err)
+
+	// assert that there is a valid database picked up as the invalid configs have this rest tester backing bucket
+	err = rt3.WaitForConditionWithOptions(func() bool {
+		validDatabase := rt3.ServerContext().AllDatabases()
+		return len(validDatabase) == 1
+	}, 200, 1000)
+	require.NoError(t, err)
+}
+
+// TestMultipleBucketWithBadDbConfigScenario3:
+//   - create a rest tester
+//   - create a db on the rest tester
+//   - persist that db config to another bucket
+//   - assert that is picked up as an invalid db config
+func TestMultipleBucketWithBadDbConfigScenario3(t *testing.T) {
+	if base.TestsRequireBootstrapConnection() {
+		t.Skip("Walrus/Rosmar does not support persistent config")
+	}
+
+	tb1 := base.GetPersistentTestBucket(t)
+	defer tb1.Close()
+	tb2 := base.GetPersistentTestBucket(t)
+	defer tb2.Close()
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb1,
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// configure the interval time to pick up new configs from the bucket to every 1 seconds
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(1000000000)
+		},
+	})
+	defer rt.Close()
+
+	// create a new db
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Name = "db1"
+	dbConfig.BucketConfig.Bucket = base.StringPtr(rt.CustomTestBucket.GetName())
+	resp := rt.CreateDatabase("db1", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	// persistence logic construction
+	version, err := rest.GenerateDatabaseConfigVersionID("", &dbConfig)
+	require.NoError(rt.TB, err)
+
+	metadataID, metadataIDError := rt.ServerContext().BootstrapContext.ComputeMetadataIDForDbConfig(base.TestCtx(rt.TB), &dbConfig)
+	require.NoError(rt.TB, metadataIDError)
+
+	badName := "badName"
+	dbConfig.Bucket = &badName
+	persistedConfig := rest.DatabaseConfig{
+		Version:    version,
+		MetadataID: metadataID,
+		DbConfig:   dbConfig,
+		SGVersion:  base.ProductVersion.String(),
+	}
+	// add the config to the other bucket
+	rt.InsertDbConfigToBucket(&persistedConfig, tb2.GetName())
+
+	// assert the config is picked as invalid db config
+	err = rt.WaitForConditionWithOptions(func() bool {
+		invalidDatabases := rt.ServerContext().AllInvalidDatabases()
+		return len(invalidDatabases) == 1
+	}, 200, 1000)
+	require.NoError(t, err)
 }
 
 func TestResyncStopUsingDCPStream(t *testing.T) {

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1525,8 +1525,8 @@ func TestCorruptDbConfigHandling(t *testing.T) {
 }
 
 // TestBadConfigInsertionToBucket:
-//	 - start a rest tester
-//	 - insert an invalid db config to the bucket while rest tester is running
+//   - start a rest tester
+//   - insert an invalid db config to the bucket while rest tester is running
 //   - assert that the db config is picked up as an invalid db config
 //   - assert that a call to the db endpoint will fail with correct error message
 func TestBadConfigInsertionToBucket(t *testing.T) {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -588,12 +588,9 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 	return nil
 }
 
-// fixCorruptDatabaseConfig will remove the config from the bucket and remove it from the map if it exists on the invalid database config map
-func (h *handler) fixCorruptDatabaseConfig(ctx context.Context, bucket, configGroupID, dbName string) error {
-	h.server.invalidDatabaseConfigTracking.m.Lock()
-	defer h.server.invalidDatabaseConfigTracking.m.Unlock()
-
-	_, ok := h.server.invalidDatabaseConfigTracking.dbNames[dbName]
+// removeCorruptConfigIfExists will remove the config from the bucket and remove it from the map if it exists on the invalid database config map
+func (h *handler) removeCorruptConfigIfExists(ctx context.Context, bucket, configGroupID, dbName string) error {
+	_, ok := h.server.invalidDatabaseConfigTracking.exists(dbName)
 	if ok {
 		// remove the bad config from the bucket
 		err := h.server.BootstrapContext.DeleteConfig(ctx, bucket, configGroupID, dbName)
@@ -601,7 +598,7 @@ func (h *handler) fixCorruptDatabaseConfig(ctx context.Context, bucket, configGr
 			return err
 		}
 		// delete the database name form the invalid database map on server context
-		delete(h.server.invalidDatabaseConfigTracking.dbNames, dbName)
+		h.server.invalidDatabaseConfigTracking.remove(dbName)
 	}
 	return nil
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -591,15 +591,18 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 // removeCorruptConfigIfExists will remove the config from the bucket and remove it from the map if it exists on the invalid database config map
 func (h *handler) removeCorruptConfigIfExists(ctx context.Context, bucket, configGroupID, dbName string) error {
 	_, ok := h.server.invalidDatabaseConfigTracking.exists(dbName)
-	if ok {
-		// remove the bad config from the bucket
-		err := h.server.BootstrapContext.DeleteConfig(ctx, bucket, configGroupID, dbName)
-		if err != nil {
-			return err
-		}
-		// delete the database name form the invalid database map on server context
-		h.server.invalidDatabaseConfigTracking.remove(dbName)
+	if !ok {
+		// exit early of it doesn't exist
+		return nil
 	}
+	// remove the bad config from the bucket
+	err := h.server.BootstrapContext.DeleteConfig(ctx, bucket, configGroupID, dbName)
+	if err != nil {
+		return err
+	}
+	// delete the database name form the invalid database map on server context
+	h.server.invalidDatabaseConfigTracking.remove(dbName)
+
 	return nil
 }
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -601,6 +601,7 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 	return nil
 }
 
+// checkDbCorruption checks if the db is present in the corrupt db context map and returns it if so
 func (h *handler) checkDbCorruption(name string) *db.DatabaseContext {
 	h.server.lock.RLock()
 	dbc := h.server.corruptDbContext[name]

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -146,8 +146,7 @@ func NewServerContext(ctx context.Context, config *StartupConfig, persistentConf
 		hasStarted:         make(chan struct{}),
 	}
 	sc.invalidDatabaseConfigTracking = invalidDatabaseConfigs{
-		loggingCtx: ctx,
-		dbNames:    map[string]*invalidConfigInfo{},
+		dbNames: map[string]*invalidConfigInfo{},
 	}
 
 	if base.ServerIsWalrus(sc.Config.Bootstrap.Server) {
@@ -302,7 +301,7 @@ func (sc *ServerContext) GetInactiveDatabase(ctx context.Context, name string) (
 	var httpErr *base.HTTPError
 	invalidConfig, ok := sc.invalidDatabaseConfigTracking.exists(name)
 	if !dbConfigFound && ok {
-		httpErr = base.HTTPErrorf(http.StatusNotFound, "Database %s config corrupt. Database config bucket name: %s not equal to bucket it is persisted in: %s. Must update database config immediately", name, invalidConfig.configBucketName, invalidConfig.persistedBucketName)
+		httpErr = base.HTTPErrorf(http.StatusNotFound, "Mismatch in database config for database %s bucket name: %s and backend bucket: %s groupID: %s You must update database config immediately", base.MD(name), base.MD(invalidConfig.configBucketName), base.MD(invalidConfig.persistedBucketName), base.MD(sc.Config.Bootstrap.ConfigGroupID))
 	} else {
 		httpErr = base.HTTPErrorf(http.StatusNotFound, "no such database %q", name)
 	}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2498,10 +2498,10 @@ func DropAllTestIndexes(t *testing.T, tb *base.TestBucket) {
 	}
 }
 
-func (sc *ServerContext) GetCorruptDatabaseMap() map[string]*db.DatabaseContext {
-	sc.lock.RLock()
-	defer sc.lock.RUnlock()
-	return sc.corruptDbContext
+func (sc *ServerContext) GetCorruptDatabaseMap() map[string]*invalidConfigInfo {
+	sc.invalidDatabaseConfigTracking.m.RLock()
+	defer sc.invalidDatabaseConfigTracking.m.RUnlock()
+	return sc.invalidDatabaseConfigTracking.dbNames
 }
 
 // Calls DropAllIndexes to remove all indexes, then restores the primary index for TestBucketPool readier requirements

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2498,10 +2498,13 @@ func DropAllTestIndexes(t *testing.T, tb *base.TestBucket) {
 	}
 }
 
-func (sc *ServerContext) GetCorruptDatabaseMap() map[string]*invalidConfigInfo {
+func (sc *ServerContext) RequireInvalidDatabaseConfigNames(t *testing.T, dbNames []string) {
 	sc.invalidDatabaseConfigTracking.m.RLock()
 	defer sc.invalidDatabaseConfigTracking.m.RUnlock()
-	return sc.invalidDatabaseConfigTracking.dbNames
+	require.Equal(t, len(dbNames), len(sc.invalidDatabaseConfigTracking.dbNames))
+	for _, v := range dbNames {
+		require.NotNil(t, sc.invalidDatabaseConfigTracking.dbNames[v])
+	}
 }
 
 // Calls DropAllIndexes to remove all indexes, then restores the primary index for TestBucketPool readier requirements

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2498,6 +2498,12 @@ func DropAllTestIndexes(t *testing.T, tb *base.TestBucket) {
 	}
 }
 
+func (sc *ServerContext) GetCorruptDatabaseMap() map[string]*db.DatabaseContext {
+	sc.lock.RLock()
+	defer sc.lock.RUnlock()
+	return sc.corruptDbContext
+}
+
 // Calls DropAllIndexes to remove all indexes, then restores the primary index for TestBucketPool readier requirements
 func dropAllNonPrimaryIndexes(t *testing.T, dataStore base.DataStore) {
 

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -280,6 +280,19 @@ func (rt *RestTester) WaitForResyncDCPStatus(status db.BackgroundProcessState) d
 	return resyncStatus
 }
 
+// UpdatePersistedBucketName will update the persisted config bucket name to name specified in parameters
+func (rt *RestTester) UpdatePersistedBucketName(dbConfig *DatabaseConfig, newBucketName *string) (*DatabaseConfig, error) {
+	updatedDbConfig := DatabaseConfig{}
+	_, err := rt.ServerContext().BootstrapContext.UpdateConfig(base.TestCtx(rt.TB), *dbConfig.Bucket, rt.ServerContext().Config.Bootstrap.ConfigGroupID, dbConfig.Name, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+
+		bucketDbConfig = dbConfig
+		bucketDbConfig.Bucket = newBucketName
+
+		return bucketDbConfig, nil
+	})
+	return &updatedDbConfig, err
+}
+
 // setupSGRPeers sets up two rest testers to be used for sg-replicate testing with the following configuration:
 //
 //	activeRT:


### PR DESCRIPTION
CBG-3292

First I have changed it so that when sync gateway on the config interval looks for database configs in the bucket, will also check that the config bucket name matches the bucket the config is found in. If it doesn't we add the db context to the server context corrupt database map to keep track of. Then the changes will remove the in memory representation of the db config and the db context off of the server context all together. 
This forces operation on the database to fail so I have added some handling for a suitable error message to be returned to the user in this eventuality informing them that they need to update config to correct the bucket name. 
Lastly we needed to be able to correct this corrupt config which is a challenge as at this stage all requests to the db would fail. But I added handling to handle a PUT/POST requests to the db to update the config to correct the corrupt bucket name. 
Test seems to panic against rosmar when trying to update bucket config so added walrus check to avoid it against rosmar. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1982/
