### PR TITLE
CBG-3273: Fix revocation feed loop

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -269,6 +269,7 @@ func (db *DatabaseCollectionWithUser) buildRevokedFeed(ctx context.Context, ch c
 						return
 					}
 
+					lastSeq = logEntry.Sequence
 					if !requiresRevocation {
 						base.TracefCtx(ctx, base.KeyChanges, "Channel feed processing revocation, seq: %v in channel %s does not require revocation", seqID, base.UD(singleChannelCache.ChannelID().Name))
 						continue
@@ -284,13 +285,13 @@ func (db *DatabaseCollectionWithUser) buildRevokedFeed(ctx context.Context, ch c
 					return
 				}
 
+				lastSeq = logEntry.Sequence
 				if userHasAccessToDoc {
 					paginationOptions.Since.Seq = lastSeq
 					continue
 				}
 
 				change := makeRevocationChangeEntry(logEntry, seqID, singleChannelCache.ChannelID())
-				lastSeq = logEntry.Sequence
 
 				base.DebugfCtx(ctx, base.KeyChanges, "Channel feed processing revocation seq: %v in channel %s ", seqID, base.UD(singleChannelCache.ChannelID().Name))
 

--- a/db/changes.go
+++ b/db/changes.go
@@ -252,6 +252,7 @@ func (db *DatabaseCollectionWithUser) buildRevokedFeed(ctx context.Context, ch c
 				// Otherwise: we need to determine whether a previous revision of the document was in the channel prior
 				// to the since value, and only send a revocation if that was the case
 
+				lastSeq = logEntry.Sequence
 				if logEntry.Sequence > sinceVal {
 					// Get doc sync data so we can verify the docs grant history
 					syncData, err := db.GetDocSyncData(ctx, logEntry.DocID)
@@ -269,7 +270,6 @@ func (db *DatabaseCollectionWithUser) buildRevokedFeed(ctx context.Context, ch c
 						return
 					}
 
-					lastSeq = logEntry.Sequence
 					if !requiresRevocation {
 						base.TracefCtx(ctx, base.KeyChanges, "Channel feed processing revocation, seq: %v in channel %s does not require revocation", seqID, base.UD(singleChannelCache.ChannelID().Name))
 						continue
@@ -285,7 +285,6 @@ func (db *DatabaseCollectionWithUser) buildRevokedFeed(ctx context.Context, ch c
 					return
 				}
 
-				lastSeq = logEntry.Sequence
 				if userHasAccessToDoc {
 					paginationOptions.Since.Seq = lastSeq
 					continue

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1137,6 +1137,46 @@ func TestRevocationsWithQueryLimit(t *testing.T) {
 	assert.Equal(t, int64(3), channelQueryCountAfter-channelQueryCountBefore)
 }
 
+func TestRevocationsWithQueryLimit2Channels(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	revocationTester, rt := InitScenario(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			AutoImport:           false,
+			QueryPaginationLimit: base.IntPtr(2),
+		}},
+	})
+	defer rt.Close()
+
+	revocationTester.addRole("user", "foo")
+	revocationTester.addRoleChannel("foo", "ch1")
+	revocationTester.addUserChannel("user", "ch2")
+
+	revocationTester.fillToSeq(9)
+	_ = rt.CreateDocReturnRev(t, "doc1", "", map[string]interface{}{"channels": []string{"ch1", "ch2"}})
+	_ = rt.CreateDocReturnRev(t, "doc2", "", map[string]interface{}{"channels": []string{"ch1", "ch2"}})
+	_ = rt.CreateDocReturnRev(t, "doc3", "", map[string]interface{}{"channels": []string{"ch1", "ch2"}})
+
+	changes := revocationTester.getChanges("0", 4)
+
+	revocationTester.removeRole("user", "foo")
+
+	_ = changes.Last_Seq
+	// This changes feed would loop if CBG-3273 was still an issue
+	changes = revocationTester.getChanges(0, 4)
+
+	// Get one of the 3 docs which the user should still have access to
+	resp := rt.SendUserRequestWithHeaders("GET", "/{{.keyspace}}/doc1", "", nil, "user", "test")
+	RequireStatus(t, resp, 200)
+
+	// Revoke access to ch2
+	revocationTester.removeUserChannel("user", "ch2")
+	changes = revocationTester.getChanges(0, 7)
+	// Get a doc to ensure no access
+	resp = rt.SendUserRequestWithHeaders("GET", "/{{.keyspace}}/doc1", "", nil, "user", "test")
+	RequireStatus(t, resp, 403)
+}
+
 func TestRevocationsWithQueryLimitChangesLimit(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 


### PR DESCRIPTION
CBG-3237

Describe your PR here...
- The revocation feed loop can run infinitely if an iteration is skipped before lastSeq is reset to the last entry's sequence.
- The solution is to assign lastSeq before iterations are skipped, in the inner for .. in changes loop and the outer loop
- Added TestRevocationsWithQueryLimit2Channels which reproduces the loop and checks access to docs works as expected.

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1972/
