### PR TITLE
CBG-3289 handle in memory walrus databases as rosmar databases

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -343,13 +343,13 @@ func GetStatsVbSeqno(stats map[string]map[string]string, maxVbno uint16, useAbsH
 
 }
 
-func GetBucket(spec BucketSpec) (bucket Bucket, err error) {
+func GetBucket(ctx context.Context, spec BucketSpec) (bucket Bucket, err error) {
 	if spec.IsWalrusBucket() {
-		InfofCtx(context.TODO(), KeyAll, "Opening Walrus database %s on <%s>", MD(spec.BucketName), SD(spec.Server))
+		InfofCtx(ctx, KeyAll, "Opening rosmar database %s on <%s>", MD(spec.BucketName), SD(spec.Server))
 		sgbucket.SetLogging(ConsoleLogKey().Enabled(KeyBucket))
 		bucket, err = rosmar.OpenBucketIn(spec.Server, spec.BucketName, rosmar.CreateOrOpen)
 		if err != nil {
-			ErrorfCtx(context.TODO(), "Failed to open Walrus database %s on <%s>: %s", MD(spec.BucketName), SD(spec.Server), err)
+			ErrorfCtx(ctx, "Failed to open rosmar database %s on <%s>: %s", MD(spec.BucketName), SD(spec.Server), err)
 			return nil, err
 		}
 
@@ -358,7 +358,7 @@ func GetBucket(spec BucketSpec) (bucket Bucket, err error) {
 		if spec.Auth != nil {
 			username, _, _ = spec.Auth.GetCredentials()
 		}
-		InfofCtx(context.TODO(), KeyAll, "Opening Couchbase database %s on <%s> as user %q", MD(spec.BucketName), SD(spec.Server), UD(username))
+		InfofCtx(ctx, KeyAll, "Opening Couchbase database %s on <%s> as user %q", MD(spec.BucketName), SD(spec.Server), UD(username))
 
 		bucket, err = GetGoCBv2Bucket(spec)
 		if err != nil {
@@ -369,7 +369,7 @@ func GetBucket(spec BucketSpec) (bucket Bucket, err error) {
 		// or later, otherwise refuse to connect to the bucket since pre 5.0 versions don't support XATTRs
 		if spec.UseXattrs {
 			if !bucket.IsSupported(sgbucket.BucketStoreFeatureXattrs) {
-				WarnfCtx(context.Background(), "If using XATTRS, Couchbase Server version must be >= 5.0.")
+				WarnfCtx(ctx, "If using XATTRS, Couchbase Server version must be >= 5.0.")
 				return nil, ErrFatalBucketConnection
 			}
 		}

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1976,7 +1976,7 @@ func TestCouchbaseServerIncorrectLogin(t *testing.T) {
 	}
 
 	// Attempt to open the bucket again using invalid creds. We should expect an error.
-	bucket, err := GetBucket(testBucket.BucketSpec)
+	bucket, err := GetBucket(TestCtx(t), testBucket.BucketSpec)
 	assert.Equal(t, ErrAuthError, err)
 	assert.Nil(t, bucket)
 }
@@ -2010,7 +2010,7 @@ func TestCouchbaseServerIncorrectX509Login(t *testing.T) {
 	testBucket.BucketSpec.Keypath = keyPath
 
 	// Attempt to open a test bucket with invalid certs
-	bucket, err := GetBucket(testBucket.BucketSpec)
+	bucket, err := GetBucket(TestCtx(t), testBucket.BucketSpec)
 
 	// We no longer need the cert files, so go ahead and clean those up now before any assertions stop the test.
 	x509CleanupFn()

--- a/db/database.go
+++ b/db/database.go
@@ -328,14 +328,14 @@ type OpenBucketFn func(context.Context, base.BucketSpec, bool) (base.Bucket, err
 // ConnectToBucket opens a Couchbase connection and return a specific bucket. If failFast is set, fail immediately if the bucket doesn't exist, otherwise retry waiting for bucket to exist.
 func ConnectToBucket(ctx context.Context, spec base.BucketSpec, failFast bool) (base.Bucket, error) {
 	if failFast {
-		bucket, err := base.GetBucket(spec)
+		bucket, err := base.GetBucket(ctx, spec)
 		_, err = connectToBucketErrorHandling(ctx, spec, err)
 		return bucket, err
 	}
 
 	// start a retry loop to connect to the bucket backing off double the delay each time
 	worker := func() (bool, error, interface{}) {
-		bucket, err := base.GetBucket(spec)
+		bucket, err := base.GetBucket(ctx, spec)
 
 		// Retry if there was a non-fatal error
 		fatalError, newErr := connectToBucketErrorHandling(ctx, spec, err)

--- a/rest/config.go
+++ b/rest/config.go
@@ -35,6 +35,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/db/functions"
+	"github.com/couchbaselabs/rosmar"
 )
 
 var (
@@ -88,7 +89,14 @@ func (dc *DbConfig) MakeBucketSpec() base.BucketSpec {
 	tlsPort := 11207
 
 	if bc.Server != nil {
-		server = *bc.Server
+		// walrus:data represents in memory data store, convert this to rosmar.InMemoryURL
+		// but do not match walrus:///path/to/db, which is incompatible with rosmar URLs
+		if strings.HasPrefix(*bc.Server, "walrus:") && !strings.HasPrefix(*bc.Server, "walrus:/") {
+			server = rosmar.InMemoryURL
+		} else {
+			server = *bc.Server
+
+		}
 	}
 	if bc.Bucket != nil {
 		bucketName = *bc.Bucket

--- a/rest/config.go
+++ b/rest/config.go
@@ -89,9 +89,8 @@ func (dc *DbConfig) MakeBucketSpec() base.BucketSpec {
 	tlsPort := 11207
 
 	if bc.Server != nil {
-		// walrus:data represents in memory data store, convert this to rosmar.InMemoryURL
-		// but do not match walrus:///path/to/db, which is incompatible with rosmar URLs
-		if strings.HasPrefix(*bc.Server, "walrus:") && !strings.HasPrefix(*bc.Server, "walrus:/") {
+		// treat all walrus: as in memory storage, any persistent storage would have to be converted to rosmar
+		if strings.HasPrefix(*bc.Server, "walrus:") {
 			server = rosmar.InMemoryURL
 		} else {
 			server = *bc.Server

--- a/rest/rosmar_test.go
+++ b/rest/rosmar_test.go
@@ -1,0 +1,74 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/auth"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbaselabs/rosmar"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWalrusServerValues(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", t.Name())
+	require.NoError(t, err)
+	serverConfig := &StartupConfig{API: APIConfig{CORS: &auth.CORSConfig{}, AdminInterface: DefaultAdminInterface}}
+	ctx := base.TestCtx(t)
+	serverContext := NewServerContext(ctx, serverConfig, false)
+	defer func() {
+		serverContext.Close(ctx)
+		assert.NoError(t, os.RemoveAll(tempDir))
+	}()
+
+	onDiskRosmarPath := tempDir
+	if runtime.GOOS == "windows" {
+		// windows uris look like rosmar:///c:/foo/bar
+		onDiskRosmarPath = "/" + strings.ReplaceAll(tempDir, "\\", "/")
+	}
+	testCases := []struct {
+		name   string
+		server string
+	}{
+		{
+			name:   "walrusInMemory",
+			server: "walrus:foo",
+		},
+		{
+			name:   "rosmarInMemory",
+			server: rosmar.InMemoryURL,
+		},
+		{
+			name:   "rosmarOnDisk",
+			server: "rosmar://" + onDiskRosmarPath,
+		},
+	}
+	for i, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			dbConfig := DbConfig{
+				Name:         fmt.Sprintf("db%d", i),
+				BucketConfig: BucketConfig{Server: &testCase.server},
+			}
+
+			dbContext, err := serverContext._getOrAddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig}, getOrAddDatabaseConfigOptions{
+				failFast:    false,
+				useExisting: false,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, dbContext)
+		})
+	}
+}

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbaselabs/rosmar"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -206,7 +207,7 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 	dbContext, err = serverContext.AddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig})
 
 	assert.NoError(t, err, "Unexpected error while adding database to server context")
-	assert.Equal(t, server, dbContext.BucketSpec.Server)
+	assert.Equal(t, rosmar.InMemoryURL, dbContext.BucketSpec.Server)
 	assert.Equal(t, bucketName, dbContext.BucketSpec.BucketName)
 
 	dbConfig = DbConfig{
@@ -233,7 +234,7 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 		})
 
 	assert.NoError(t, err, "No error while trying to get the existing database name")
-	assert.Equal(t, server, dbContext.BucketSpec.Server)
+	assert.Equal(t, rosmar.InMemoryURL, dbContext.BucketSpec.Server)
 	assert.Equal(t, bucketName, dbContext.BucketSpec.BucketName)
 }
 


### PR DESCRIPTION
Handle in memory walrus databases as rosmar databases. Tests to make sure that old-style in memory databases (`walrus:data`), rosmar in memory (rosmar:/?mode=memory), and rosmar on disk all will work without being part of a bucket pool.

Removed a context.TODO()/context.Background() because there was always a clear calling context.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

