### PR TITLE
CBG-2455 fix race detector issue with variable shadowing

### DIFF
--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -132,7 +132,7 @@ func (b *BackgroundManager) Start(ctx context.Context, options map[string]interf
 			for {
 				select {
 				case <-ticker.C:
-					err = b.UpdateStatusClusterAware()
+					err := b.UpdateStatusClusterAware()
 					if err != nil {
 						base.WarnfCtx(ctx, "Failed to update background manager status: %v", err)
 					}
@@ -164,7 +164,7 @@ func (b *BackgroundManager) Start(ctx context.Context, options map[string]interf
 		// Once our background process run has completed we should update the completed status and delete the heartbeat
 		// doc
 		if b.isClusterAware() {
-			err = b.UpdateStatusClusterAware()
+			err := b.UpdateStatusClusterAware()
 			if err != nil {
 				base.WarnfCtx(ctx, "Failed to update background manager status: %v", err)
 			}
@@ -176,7 +176,7 @@ func (b *BackgroundManager) Start(ctx context.Context, options map[string]interf
 	}()
 
 	if b.isClusterAware() {
-		err = b.UpdateStatusClusterAware()
+		err := b.UpdateStatusClusterAware()
 		if err != nil {
 			base.ErrorfCtx(ctx, "Failed to update background manager status: %v", err)
 		}


### PR DESCRIPTION
err was shadowed inside a goroutine, added scoping when available

Technically, only one of those places needs to be fixed (the first one), but I did it in all places for good measure.
```
==================
WARNING: DATA RACE
Write at 0x00c0014ba6c0 by goroutine 15848:
  github.com/couchbase/sync_gateway/db.(*BackgroundManager).Start()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/background_mgr.go:179 +0xb6e
  github.com/couchbase/sync_gateway/rest.(*handler).handlePostResync()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/api.go:318 +0x7c5
  github.com/couchbase/sync_gateway/rest.(*handler).invoke()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/handler.go:269 +0x539
  github.com/couchbase/sync_gateway/rest.makeHandlerWithOptions.func1()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/handler.go:128 +0x14a
  net/http.HandlerFunc.ServeHTTP()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/net/http/server.go:2122 +0x4d
  github.com/gorilla/mux.(*Router).ServeHTTP()
      /home/ec2-user/go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0x371
  github.com/couchbase/sync_gateway/rest.wrapRouter.func1()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/routing.go:368 +0x269
  net/http.HandlerFunc.ServeHTTP()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/net/http/server.go:2122 +0x4d
  github.com/couchbase/sync_gateway/rest.(*RestTester).SendAdminRequest()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/utilities_testing.go:833 +0x4af
  github.com/couchbase/sync_gateway/rest/adminapitest.TestResyncErrorScenarios()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/adminapitest/admin_api_test.go:1235 +0x1644
  testing.tRunner()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/testing/testing.go:1629 +0x47

Previous write at 0x00c0014ba6c0 by goroutine 19353:
  github.com/couchbase/sync_gateway/db.(*BackgroundManager).Start.func1()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/background_mgr.go:135 +0x24e
  github.com/couchbase/sync_gateway/db.(*BackgroundManager).Start.func3()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/background_mgr.go:144 +0x47

Goroutine 15848 (running) created at:
  testing.(*T).Run()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/testing/testing.go:1629 +0x805
  testing.runTests.func1()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/testing/testing.go:2036 +0x8d
  testing.tRunner()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/testing/testing.go:1576 +0x216
  testing.runTests()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/testing/testing.go:2034 +0x87c
  testing.(*M).Run()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/testing/testing.go:1906 +0xb44
  github.com/couchbase/sync_gateway/base.TestBucketPoolMain()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/base/main_test_bucket_pool.go:705 +0x444
  github.com/couchbase/sync_gateway/db.TestBucketPoolWithIndexes()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/util_testing.go:490 +0x3e7
  github.com/couchbase/sync_gateway/rest/adminapitest.TestMain()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/adminapitest/main_test.go:22 +0x340
  main.main()
      _testmain.go:254 +0x33f

Goroutine 19353 (running) created at:
  github.com/couchbase/sync_gateway/db.(*BackgroundManager).Start()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/db/background_mgr.go:129 +0x989
  github.com/couchbase/sync_gateway/rest.(*handler).handlePostResync()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/api.go:318 +0x7c5
  github.com/couchbase/sync_gateway/rest.(*handler).invoke()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/handler.go:269 +0x539
  github.com/couchbase/sync_gateway/rest.makeHandlerWithOptions.func1()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/handler.go:128 +0x14a
  net/http.HandlerFunc.ServeHTTP()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/net/http/server.go:2122 +0x4d
  github.com/gorilla/mux.(*Router).ServeHTTP()
      /home/ec2-user/go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0x371
  github.com/couchbase/sync_gateway/rest.wrapRouter.func1()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/routing.go:368 +0x269
  net/http.HandlerFunc.ServeHTTP()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/net/http/server.go:2122 +0x4d
  github.com/couchbase/sync_gateway/rest.(*RestTester).SendAdminRequest()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/utilities_testing.go:833 +0x4af
  github.com/couchbase/sync_gateway/rest/adminapitest.TestResyncErrorScenarios()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_master/rest/adminapitest/admin_api_test.go:1235 +0x1644
  testing.tRunner()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.20.3/src/testing/testing.go:1629 +0x47
==================
```