### PR TITLE
CBG-3324: Add startup cnf logging to DefaultDbConfig

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -571,8 +571,6 @@ func TestDBGetConfigNamesAndDefaultLogging(t *testing.T) {
 	}
 }
 
-// Tests that the users returned in the config endpoint have the correct names
-// Reproduces #2223
 func TestDBGetConfigCustomLogging(t *testing.T) {
 	logKeys := []string{base.KeyAccess.String(), base.KeyHTTP.String()}
 	rt := rest.NewRestTester(t,

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -3271,6 +3271,8 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 	ctx := base.TestCtx(t)
 	config := rest.BootstrapStartupConfigForTest(t)
 	sc, err := rest.SetupServerContext(ctx, &config, true)
+	config.Logging.Console.LogKeys = []string{base.KeyDCP.String()}
+	config.Logging.Console.LogLevel.Set(base.LevelDebug)
 	require.NoError(t, err)
 	defer func() {
 		sc.Close(ctx)
@@ -3302,6 +3304,9 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 	assert.Equal(t, base.DefaultOldRevExpirySeconds, *dbConfig.OldRevExpirySeconds)
 	assert.Equal(t, false, *dbConfig.StartOffline)
 	assert.Equal(t, db.DefaultCompactInterval, uint32(*dbConfig.CompactIntervalDays))
+
+	assert.Equal(t, dbConfig.Logging.Console.LogLevel.String(), base.LevelDebug.String())
+	assert.Equal(t, dbConfig.Logging.Console.LogKeys, []string{base.KeyDCP.String()})
 
 	var runtimeServerConfigResponse rest.RunTimeServerConfigResponse
 	resp = rest.BootstrapAdminRequest(t, http.MethodGet, "/_config?include_runtime=true", "")

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -83,6 +83,15 @@ func GenerateDatabaseConfigVersionID(previousRevID string, dbConfig *DbConfig) (
 	return hash, nil
 }
 
+func DefaultPerDBLogging(bootstrapCnf base.LoggingConfig) *DbLoggingConfig {
+	return &DbLoggingConfig{
+		Console: &DbConsoleLoggingConfig{
+			LogLevel: bootstrapCnf.Console.LogLevel,
+			LogKeys:  bootstrapCnf.Console.LogKeys,
+		},
+	}
+}
+
 // MergeDatabaseConfigWithDefaults merges the passed in config onto a DefaultDbConfig which results in returned value
 // being populated with defaults when not set
 func MergeDatabaseConfigWithDefaults(sc *StartupConfig, dbConfig *DbConfig) (*DbConfig, error) {
@@ -165,6 +174,7 @@ func DefaultDbConfig(sc *StartupConfig) *DbConfig {
 		ClientPartitionWindowSecs:        base.IntPtr(int(base.DefaultClientPartitionWindow.Seconds())),
 		JavascriptTimeoutSecs:            base.Uint32Ptr(base.DefaultJavascriptTimeoutSecs),
 		Suspendable:                      base.BoolPtr(sc.IsServerless()),
+		Logging:                          DefaultPerDBLogging(sc.Logging),
 	}
 
 	revsLimit := db.DefaultRevsLimitNoConflicts

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -85,11 +85,13 @@ func GenerateDatabaseConfigVersionID(previousRevID string, dbConfig *DbConfig) (
 
 func DefaultPerDBLogging(bootstrapLoggingCnf base.LoggingConfig) *DbLoggingConfig {
 	if bootstrapLoggingCnf.Console != nil {
-		return &DbLoggingConfig{
-			Console: &DbConsoleLoggingConfig{
-				LogLevel: bootstrapLoggingCnf.Console.LogLevel,
-				LogKeys:  bootstrapLoggingCnf.Console.LogKeys,
-			},
+		if *bootstrapLoggingCnf.Console.Enabled {
+			return &DbLoggingConfig{
+				Console: &DbConsoleLoggingConfig{
+					LogLevel: bootstrapLoggingCnf.Console.LogLevel,
+					LogKeys:  bootstrapLoggingCnf.Console.LogKeys,
+				},
+			}
 		}
 	}
 	return &DbLoggingConfig{}

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -83,13 +83,16 @@ func GenerateDatabaseConfigVersionID(previousRevID string, dbConfig *DbConfig) (
 	return hash, nil
 }
 
-func DefaultPerDBLogging(bootstrapCnf base.LoggingConfig) *DbLoggingConfig {
-	return &DbLoggingConfig{
-		Console: &DbConsoleLoggingConfig{
-			LogLevel: bootstrapCnf.Console.LogLevel,
-			LogKeys:  bootstrapCnf.Console.LogKeys,
-		},
+func DefaultPerDBLogging(bootstrapLoggingCnf base.LoggingConfig) *DbLoggingConfig {
+	if bootstrapLoggingCnf.Console != nil {
+		return &DbLoggingConfig{
+			Console: &DbConsoleLoggingConfig{
+				LogLevel: bootstrapLoggingCnf.Console.LogLevel,
+				LogKeys:  bootstrapLoggingCnf.Console.LogKeys,
+			},
+		}
 	}
+	return &DbLoggingConfig{}
 }
 
 // MergeDatabaseConfigWithDefaults merges the passed in config onto a DefaultDbConfig which results in returned value


### PR DESCRIPTION
CBG-3324

Describe your PR here...
- Copy startup config logging to default db config, to be returned on GET /db/_config?include_runtime=true calls
- Add check on TestConfigsIncludeDefaults 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1974/
