### PR TITLE
CBG-3288: Pass Context into NewSyncRunner for logging

### DIFF
--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -97,12 +97,13 @@ func (lc *LogContext) getContextKey() LogContextKey {
 
 func (lc *LogContext) getCopy() LogContext {
 	return LogContext{
-		CorrelationID: lc.CorrelationID,
-		Database:      lc.Database,
-		Bucket:        lc.Bucket,
-		Scope:         lc.Scope,
-		Collection:    lc.Collection,
-		TestName:      lc.TestName,
+		CorrelationID:      lc.CorrelationID,
+		Database:           lc.Database,
+		DbConsoleLogConfig: lc.DbConsoleLogConfig,
+		Bucket:             lc.Bucket,
+		Scope:              lc.Scope,
+		Collection:         lc.Collection,
+		TestName:           lc.TestName,
 	}
 }
 

--- a/channels/channelmapper.go
+++ b/channels/channelmapper.go
@@ -9,6 +9,7 @@
 package channels
 
 import (
+	"context"
 	"encoding/json"
 	"strconv"
 	"time"
@@ -42,11 +43,11 @@ const kTaskCacheSize = 16
 const DocChannelsSyncFunction = `function(doc){channel(doc.channels);}`
 
 // NewChannelMapper creates a new channel mapper with a specific javascript function and a timeout. A zero value timeout will never timeout.
-func NewChannelMapper(fnSource string, timeout time.Duration) *ChannelMapper {
+func NewChannelMapper(ctx context.Context, fnSource string, timeout time.Duration) *ChannelMapper {
 	return &ChannelMapper{
 		JSServer: sgbucket.NewJSServer(fnSource, timeout, kTaskCacheSize,
 			func(fnSource string, timeout time.Duration) (sgbucket.JSServerTask, error) {
-				return NewSyncRunner(fnSource, timeout)
+				return NewSyncRunner(ctx, fnSource, timeout)
 			}),
 	}
 }

--- a/channels/channelmapper_test.go
+++ b/channels/channelmapper_test.go
@@ -51,7 +51,7 @@ func TestOttoValueToStringArray(t *testing.T) {
 
 // verify that our version of Otto treats JSON parsed arrays like real arrays
 func TestJavaScriptWorks(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {channel(doc.x.concat(doc.y));}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {channel(doc.x.concat(doc.y));}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"x":["abc"],"y":["xyz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "abc", "xyz"), res.Channels)
@@ -59,7 +59,7 @@ func TestJavaScriptWorks(t *testing.T) {
 
 // Just verify that the calls to the channel() fn show up in the output channel list.
 func TestSyncFunction(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {channel("foo", "bar"); channel("baz")}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {channel("foo", "bar"); channel("baz")}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo", "bar", "baz"), res.Channels)
@@ -67,7 +67,7 @@ func TestSyncFunction(t *testing.T) {
 
 // Just verify that the calls to the access() fn show up in the output channel list.
 func TestAccessFunction(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access("foo", "bar"); access("foo", "baz")}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access("foo", "bar"); access("foo", "baz")}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"foo": BaseSetOf(t, "bar", "baz")}, res.Access)
@@ -75,7 +75,7 @@ func TestAccessFunction(t *testing.T) {
 
 // Just verify that the calls to the channel() fn show up in the output channel list.
 func TestSyncFunctionTakesArray(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {channel(["foo", "bar ok","baz"])}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {channel(["foo", "bar ok","baz"])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo", "bar ok", "baz"), res.Channels)
@@ -83,21 +83,21 @@ func TestSyncFunctionTakesArray(t *testing.T) {
 
 // Calling channel() with an invalid channel name should return an error.
 func TestSyncFunctionRejectsInvalidChannels(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {channel(["foo", "bad,name","baz"])}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {channel(["foo", "bad,name","baz"])}`, 0)
 	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser)
 	assert.True(t, err != nil)
 }
 
 // Calling access() with an invalid channel name should return an error.
 func TestAccessFunctionRejectsInvalidChannels(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access("foo", "bad,name");}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access("foo", "bad,name");}`, 0)
 	_, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.True(t, err != nil)
 }
 
 // Just verify that the calls to the access() fn show up in the output channel list.
 func TestAccessFunctionTakesArrayOfUsers(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access(["foo","bar","baz"], "ginger")}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access(["foo","bar","baz"], "ginger")}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"bar": BaseSetOf(t, "ginger"), "baz": BaseSetOf(t, "ginger"), "foo": BaseSetOf(t, "ginger")}, res.Access)
@@ -105,14 +105,14 @@ func TestAccessFunctionTakesArrayOfUsers(t *testing.T) {
 
 // Just verify that the calls to the access() fn show up in the output channel list.
 func TestAccessFunctionTakesArrayOfChannels(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access("lee", ["ginger", "earl_grey", "green"])}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access("lee", ["ginger", "earl_grey", "green"])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"lee": BaseSetOf(t, "ginger", "earl_grey", "green")}, res.Access)
 }
 
 func TestAccessFunctionTakesArrayOfChannelsAndUsers(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access(["lee", "nancy"], ["ginger", "earl_grey", "green"])}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access(["lee", "nancy"], ["ginger", "earl_grey", "green"])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "ginger", "earl_grey", "green"), res.Access["lee"])
@@ -120,42 +120,42 @@ func TestAccessFunctionTakesArrayOfChannelsAndUsers(t *testing.T) {
 }
 
 func TestAccessFunctionTakesEmptyArrayUser(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access([], ["ginger", "earl grey", "green"])}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access([], ["ginger", "earl grey", "green"])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
 }
 
 func TestAccessFunctionTakesEmptyArrayChannels(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access("lee", [])}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access("lee", [])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
 }
 
 func TestAccessFunctionTakesNullUser(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access(null, ["ginger", "earl grey", "green"])}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access(null, ["ginger", "earl grey", "green"])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
 }
 
 func TestAccessFunctionTakesNullChannels(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access("lee", null)}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access("lee", null)}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
 }
 
 func TestAccessFunctionTakesNonChannelsInArray(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access("lee", ["ginger", null, 5])}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access("lee", ["ginger", null, 5])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"lee": BaseSetOf(t, "ginger")}, res.Access)
 }
 
 func TestAccessFunctionTakesUndefinedUser(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {var x = {}; access(x.nothing, ["ginger", "earl grey", "green"])}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {var x = {}; access(x.nothing, ["ginger", "earl grey", "green"])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
@@ -164,7 +164,7 @@ func TestAccessFunctionTakesUndefinedUser(t *testing.T) {
 // Just verify that the calls to the role() fn show up in the output. (It shares a common
 // implementation with access(), so most of the above tests also apply to it.)
 func TestRoleFunction(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {role(["foo","bar","baz"], "role:froods")}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {role(["foo","bar","baz"], "role:froods")}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"bar": BaseSetOf(t, "froods"), "baz": BaseSetOf(t, "froods"), "foo": BaseSetOf(t, "froods")}, res.Roles)
@@ -172,7 +172,7 @@ func TestRoleFunction(t *testing.T) {
 
 // Now just make sure the input comes through intact
 func TestInputParse(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {channel(doc.channel);}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {channel(doc.channel);}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "foo"}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo"), res.Channels)
@@ -185,11 +185,11 @@ func TestDefaultChannelMapper(t *testing.T) {
 		name   string
 	}{
 		{
-			mapper: NewChannelMapper(DocChannelsSyncFunction, 0),
+			mapper: NewChannelMapper(base.TestCtx(t), DocChannelsSyncFunction, 0),
 			name:   "explicit_function",
 		},
 		{
-			mapper: NewChannelMapper(GetDefaultSyncFunction(base.DefaultScope, base.DefaultCollection), 0),
+			mapper: NewChannelMapper(base.TestCtx(t), GetDefaultSyncFunction(base.DefaultScope, base.DefaultCollection), 0),
 			name:   "explicit_function",
 		},
 	}
@@ -209,7 +209,7 @@ func TestDefaultChannelMapper(t *testing.T) {
 
 // Empty/no-op channel mapper fn
 func TestEmptyChannelMapper(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.Set{}, res.Channels)
@@ -219,7 +219,7 @@ func TestEmptyChannelMapper(t *testing.T) {
 func TestChannelMapperUnderscoreLib(t *testing.T) {
 	underscore.Enable() // It really slows down unit tests (by making otto.New take a lot longer)
 	defer underscore.Disable()
-	mapper := NewChannelMapper(`function(doc) {channel(_.first(doc.channels));}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {channel(_.first(doc.channels));}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo"), res.Channels)
@@ -227,7 +227,7 @@ func TestChannelMapperUnderscoreLib(t *testing.T) {
 
 // Validation by calling reject()
 func TestChannelMapperReject(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {reject(403, "bad");}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {reject(403, "bad");}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, "bad"), res.Rejection)
@@ -235,7 +235,7 @@ func TestChannelMapperReject(t *testing.T) {
 
 // Rejection by calling throw()
 func TestChannelMapperThrow(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {throw({forbidden:"bad"});}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {throw({forbidden:"bad"});}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, "bad"), res.Rejection)
@@ -243,14 +243,14 @@ func TestChannelMapperThrow(t *testing.T) {
 
 // Test other runtime exception
 func TestChannelMapperException(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {(nil)[5];}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {(nil)[5];}`, 0)
 	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.True(t, err != nil)
 }
 
 // Test the public API
 func TestPublicChannelMapper(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {channel(doc.channels);}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {channel(doc.channels);}`, 0)
 	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo", "bar", "baz"), output.Channels)
@@ -258,7 +258,7 @@ func TestPublicChannelMapper(t *testing.T) {
 
 // Test the userCtx name parameter
 func TestCheckUser(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc, oldDoc) {
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc, oldDoc) {
 			requireUser(doc.owner);
 		}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "channels": []string{}}
@@ -278,7 +278,7 @@ func TestCheckUser(t *testing.T) {
 
 // Test the userCtx name parameter with a list
 func TestCheckUserArray(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc, oldDoc) {
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc, oldDoc) {
 			requireUser(doc.owners);
 		}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "channels": []string{}}
@@ -298,7 +298,7 @@ func TestCheckUserArray(t *testing.T) {
 
 // Test the userCtx role parameter
 func TestCheckRole(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc, oldDoc) {
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc, oldDoc) {
 			requireRole(doc.role);
 		}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "roles": map[string]int{"girl": 1, "5yo": 1}}
@@ -318,7 +318,7 @@ func TestCheckRole(t *testing.T) {
 
 // Test the userCtx role parameter with a list
 func TestCheckRoleArray(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc, oldDoc) {
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc, oldDoc) {
 			requireRole(doc.roles);
 		}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "roles": map[string]int{"girl": 1, "5yo": 1}}
@@ -338,7 +338,7 @@ func TestCheckRoleArray(t *testing.T) {
 
 // Test the userCtx.channels parameter
 func TestCheckAccess(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc, oldDoc) {
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc, oldDoc) {
 		requireAccess(doc.channel)
 	}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "roles": []string{"girl", "5yo"}, "channels": []string{"party", "school"}}
@@ -358,7 +358,7 @@ func TestCheckAccess(t *testing.T) {
 
 // Test the userCtx.channels parameter with a list
 func TestCheckAccessArray(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc, oldDoc) {
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc, oldDoc) {
 		requireAccess(doc.channels)
 	}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "roles": []string{"girl", "5yo"}, "channels": []string{"party", "school"}}
@@ -378,7 +378,7 @@ func TestCheckAccessArray(t *testing.T) {
 
 // Test changing the function
 func TestSetFunction(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {channel(doc.channels);}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {channel(doc.channels);}`, 0)
 	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	require.Equal(t, BaseSetOf(t, "foo", "baz", "bar"), output.Channels)
@@ -392,7 +392,7 @@ func TestSetFunction(t *testing.T) {
 
 // Test that expiry function sets the expiry property
 func TestExpiryFunction(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {expiry(doc.expiry);}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {expiry(doc.expiry);}`, 0)
 	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(100), *res1.Expiry)
@@ -437,53 +437,53 @@ func TestExpiryFunction(t *testing.T) {
 }
 
 func TestExpiryFunctionConstantValue(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {expiry(100);}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {expiry(100);}`, 0)
 	res1, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(100), *res1.Expiry)
 
-	mapper = NewChannelMapper(`function(doc) {expiry("500");}`, 0)
+	mapper = NewChannelMapper(base.TestCtx(t), `function(doc) {expiry("500");}`, 0)
 	res2, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(500), *res2.Expiry)
 
-	mapper = NewChannelMapper(`function(doc) {expiry("2105-01-01T00:00:00.000+00:00");}`, 0)
+	mapper = NewChannelMapper(base.TestCtx(t), `function(doc) {expiry("2105-01-01T00:00:00.000+00:00");}`, 0)
 	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(4260211200), *res_stringDate.Expiry)
 
 	// Validate invalid expiry values log warning and don't set expiry
-	mapper = NewChannelMapper(`function(doc) {expiry("abc");}`, 0)
+	mapper = NewChannelMapper(base.TestCtx(t), `function(doc) {expiry("abc");}`, 0)
 	res3, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:abc")
 	assert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
-	mapper = NewChannelMapper(`function(doc) {expiry(["100", "200"]);}`, 0)
+	mapper = NewChannelMapper(base.TestCtx(t), `function(doc) {expiry(["100", "200"]);}`, 0)
 	res4, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as array")
 	assert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
-	mapper = NewChannelMapper(`function(doc) {expiry(-100);}`, 0)
+	mapper = NewChannelMapper(base.TestCtx(t), `function(doc) {expiry(-100);}`, 0)
 	res5, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as negative value")
 	assert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
-	mapper = NewChannelMapper(`function(doc) {expiry(123456789012345);}`, 0)
+	mapper = NewChannelMapper(base.TestCtx(t), `function(doc) {expiry(123456789012345);}`, 0)
 	res6, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as > unit32")
 	assert.True(t, res6.Expiry == nil)
 
 	// Invalid - non-unix date
-	mapper = NewChannelMapper(`function(doc) {expiry("1805-01-01T00:00:00.000+00:00");}`, 0)
+	mapper = NewChannelMapper(base.TestCtx(t), `function(doc) {expiry("1805-01-01T00:00:00.000+00:00");}`, 0)
 	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:1805-01-01T00:00:00.000+00:00")
 	assert.True(t, resInvalidDate.Expiry == nil)
 
 	// No expiry specified
-	mapper = NewChannelMapper(`function(doc) {expiry();}`, 0)
+	mapper = NewChannelMapper(base.TestCtx(t), `function(doc) {expiry();}`, 0)
 	res7, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry not specified")
 	assert.True(t, res7.Expiry == nil)
@@ -491,7 +491,7 @@ func TestExpiryFunctionConstantValue(t *testing.T) {
 
 // Test that expiry function when invoked more than once by sync function
 func TestExpiryFunctionMultipleInvocation(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {expiry(doc.expiry); expiry(doc.secondExpiry)}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {expiry(doc.expiry); expiry(doc.secondExpiry)}`, 0)
 	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, uint32(100), *res1.Expiry)
@@ -527,7 +527,7 @@ func TestExpiryFunctionMultipleInvocation(t *testing.T) {
 }
 
 func TestMetaMap(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc, oldDoc, meta) {channel(meta.xattrs.myxattr.channels);}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc, oldDoc, meta) {channel(meta.xattrs.myxattr.channels);}`, 0)
 
 	channels := []string{"chan1", "chan2"}
 
@@ -546,7 +546,7 @@ func TestMetaMap(t *testing.T) {
 
 func TestNilMetaMap(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-	mapper := NewChannelMapper(`function(doc, oldDoc, meta) {channel(meta.xattrs.myxattr.val);}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc, oldDoc, meta) {channel(meta.xattrs.myxattr.val);}`, 0)
 
 	metaMap := map[string]interface{}{
 		base.MetaMapXattrsKey: map[string]interface{}{
@@ -592,7 +592,7 @@ func TestCollectionSyncFunction(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			collectionName := "barcollection"
-			mapper := NewChannelMapper(GetDefaultSyncFunction("fooscope", collectionName), 0)
+			mapper := NewChannelMapper(base.TestCtx(t), GetDefaultSyncFunction("fooscope", collectionName), 0)
 			res, err := mapper.MapToChannelsAndAccess(parse(test.docBody), `{}`, emptyMetaMap(), noUser)
 			require.NoError(t, err)
 			require.Equal(t, BaseSetOf(t, collectionName), res.Channels)

--- a/channels/sync_runner.go
+++ b/channels/sync_runner.go
@@ -116,8 +116,7 @@ type SyncRunner struct {
 	expiry            *uint32             // document expiry (in seconds) specified via expiry() callback
 }
 
-func NewSyncRunner(funcSource string, timeout time.Duration) (*SyncRunner, error) {
-	ctx := context.Background()
+func NewSyncRunner(ctx context.Context, funcSource string, timeout time.Duration) (*SyncRunner, error) {
 	funcSource = wrappedFuncSource(funcSource)
 	runner := &SyncRunner{}
 	err := runner.InitWithLogging(funcSource, timeout,

--- a/channels/sync_runner_test.go
+++ b/channels/sync_runner_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestRequireUser(t *testing.T) {
 	const funcSource = `function(doc, oldDoc) { requireUser(oldDoc._names) }`
-	runner, err := NewSyncRunner(funcSource, 0)
+	runner, err := NewSyncRunner(base.TestCtx(t), funcSource, 0)
 	require.NoError(t, err)
 	var result interface{}
 	result, _ = runner.Call(parse(`{}`), parse(`{"_names": "alpha"}`), emptyMetaMap(), parse(`{"name": "alpha"}`))
@@ -34,7 +34,7 @@ func TestRequireUser(t *testing.T) {
 
 func TestRequireRole(t *testing.T) {
 	const funcSource = `function(doc, oldDoc) { requireRole(oldDoc._roles) }`
-	runner, err := NewSyncRunner(funcSource, 0)
+	runner, err := NewSyncRunner(base.TestCtx(t), funcSource, 0)
 	require.NoError(t, err)
 	var result interface{}
 	result, _ = runner.Call(parse(`{}`), parse(`{"_roles": ["alpha"]}`), emptyMetaMap(), parse(`{"name": "", "roles": {"alpha":""}}`))
@@ -47,7 +47,7 @@ func TestRequireRole(t *testing.T) {
 
 func TestRequireAccess(t *testing.T) {
 	const funcSource = `function(doc, oldDoc) { requireAccess(oldDoc._access) }`
-	runner, err := NewSyncRunner(funcSource, 0)
+	runner, err := NewSyncRunner(base.TestCtx(t), funcSource, 0)
 	require.NoError(t, err)
 	var result interface{}
 	result, _ = runner.Call(parse(`{}`), parse(`{"_access": ["alpha"]}`), emptyMetaMap(), parse(`{"name": "", "channels": ["alpha"]}`))
@@ -60,7 +60,7 @@ func TestRequireAccess(t *testing.T) {
 
 func TestRequireAdmin(t *testing.T) {
 	const funcSource = `function(doc, oldDoc) { requireAdmin() }`
-	runner, err := NewSyncRunner(funcSource, 0)
+	runner, err := NewSyncRunner(base.TestCtx(t), funcSource, 0)
 	require.NoError(t, err)
 	var result interface{}
 	result, _ = runner.Call(parse(`{}`), parse(`{}`), emptyMetaMap(), parse(`{}`))

--- a/db/access_test.go
+++ b/db/access_test.go
@@ -34,7 +34,7 @@ func TestDynamicChannelGrant(t *testing.T) {
 			channel(doc.channel)
 		}
 	}`
-	dbCollection.ChannelMapper = channels.NewChannelMapper(syncFn, db.Options.JavascriptTimeout)
+	dbCollection.ChannelMapper = channels.NewChannelMapper(ctx, syncFn, db.Options.JavascriptTimeout)
 
 	a := dbCollection.Authenticator(ctx)
 	user, err := a.NewUser("user1", "letmein", nil)

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -215,7 +215,7 @@ func TestAttachmentForRejectedDocument(t *testing.T) {
 	defer db.Close(ctx)
 
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	collection.ChannelMapper = channels.NewChannelMapper(
+	collection.ChannelMapper = channels.NewChannelMapper(ctx,
 		`function(doc, oldDoc) {
 		throw({forbidden: "None shall pass!"});
 	}`, db.Options.JavascriptTimeout)

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1032,7 +1032,7 @@ func TestChannelQueryCancellation(t *testing.T) {
 	db, ctx := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Write a handful of docs/sequences to the bucket
 	_, _, err := collection.Put(ctx, "key1", Body{"channels": "ABC"})
@@ -1672,7 +1672,7 @@ func TestInitializeEmptyCache(t *testing.T) {
 	db, ctx := setupTestDBWithCacheOptions(t, cacheOptions)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
 	docCount := 0
@@ -1724,7 +1724,7 @@ func TestInitializeCacheUnderLoad(t *testing.T) {
 	db, ctx := setupTestDBWithCacheOptions(t, cacheOptions)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Writes [docCount] documents.  Use wait group (writesDone)to identify when all docs have been written.
 	// Use another waitGroup (writesInProgress) to trigger getChanges midway through writes
@@ -1780,7 +1780,7 @@ func TestNotifyForInactiveChannel(t *testing.T) {
 	defer db.Close(ctx)
 
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 	collectionID := collection.GetCollectionID()
 
 	// -------- Setup notifyChange callback ----------------

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -56,7 +56,7 @@ func TestFilterToAvailableChannels(t *testing.T) {
 			db, ctx := setupTestDB(t)
 			defer db.Close(ctx)
 			collection := GetSingleDatabaseCollectionWithUser(t, db)
-			collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+			collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 			auth := db.Authenticator(base.TestCtx(t))
 			user, err := auth.NewUser("test", "pass", testCase.userChans)
@@ -102,7 +102,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Create a user with access to channel ABC
 	authenticator := db.Authenticator(base.TestCtx(t))
@@ -213,7 +213,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Create a user with access to channel A
 	authenticator := db.Authenticator(base.TestCtx(t))
@@ -299,7 +299,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Create a user with access to channel A
 	authenticator := db.Authenticator(base.TestCtx(t))

--- a/db/database.go
+++ b/db/database.go
@@ -505,7 +505,11 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		}
 		collectionNameMap := make(map[string]struct{}, len(scope.Collections))
 		for collName, collOpts := range scope.Collections {
-			ctx := base.CollectionLogCtx(ctx, collName)
+			// intentional shadow - we want each collection to have its own context inside this loop body
+			ctx := ctx
+			if !base.IsDefaultCollection(scopeName, collName) {
+				ctx = base.CollectionLogCtx(ctx, collName)
+			}
 			dataStore, err := bucket.NamedDataStore(base.ScopeAndCollectionName{Scope: scopeName, Collection: collName})
 			if err != nil {
 				return nil, err

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -292,7 +292,7 @@ func (c *DatabaseCollection) UpdateSyncFun(ctx context.Context, syncFun string) 
 	} else if c.ChannelMapper != nil {
 		_, err = c.ChannelMapper.SetFunction(syncFun)
 	} else {
-		c.ChannelMapper = channels.NewChannelMapper(syncFun, c.dbCtx.Options.JavascriptTimeout)
+		c.ChannelMapper = channels.NewChannelMapper(ctx, syncFun, c.dbCtx.Options.JavascriptTimeout)
 	}
 	if err != nil {
 		base.WarnfCtx(ctx, "Error setting sync function: %s", err)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -352,7 +352,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	rev1body := Body{
 		"key1":     1234,
@@ -461,7 +461,7 @@ func TestGetRemovalMultiChannel(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	auth := db.Authenticator(base.TestCtx(t))
 
@@ -633,7 +633,7 @@ func TestDeltaSyncWhenToRevIsChannelRemoval(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Create the first revision of doc1.
 	rev1Body := Body{
@@ -866,7 +866,7 @@ func TestAllDocsOnly(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	collectionID := collection.GetCollectionID()
 
@@ -1054,7 +1054,7 @@ func TestConflicts(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Instantiate channel cache for channel 'all'
 	collectionID := collection.GetCollectionID()
@@ -1472,7 +1472,7 @@ func TestInvalidChannel(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	body := Body{"channels": []string{"bad,name"}}
 	_, _, err := collection.Put(ctx, "doc", body)

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -33,7 +33,7 @@ func TestQueryChannelsStatsView(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// docID -> Sequence
 	docSeqMap := make(map[string]uint64, 3)
@@ -85,7 +85,7 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// docID -> Sequence
 	docSeqMap := make(map[string]uint64, 3)
@@ -263,7 +263,7 @@ func TestAccessQuery(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	collection.ChannelMapper = channels.NewChannelMapper(
+	collection.ChannelMapper = channels.NewChannelMapper(ctx,
 		`function(doc, oldDoc) {
 	access(doc.accessUser, doc.accessChannel)
 }`,
@@ -307,7 +307,7 @@ func TestRoleAccessQuery(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	collection.ChannelMapper = channels.NewChannelMapper(
+	collection.ChannelMapper = channels.NewChannelMapper(ctx,
 		`function(doc, oldDoc) {
 	role(doc.accessUser, "role:" + doc.accessChannel)
 }`, db.Options.JavascriptTimeout)
@@ -363,7 +363,7 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 	docIdFlagMap := make(map[string]uint8)
 	var startSeq, endSeq uint64
 	body := Body{"channels": []string{"ABC"}}


### PR DESCRIPTION
CBG-3288

Pass database/collection-scoped context into `NewSyncRunner` for the logging callbacks.
- **Note:** Context not request-scoped - does not include context/request ID (would require more significant JSRunner/sg-bucket refactoring - which would conflict with upcoming v8 work)
- Allows Javascript logging via `console.log`/`console.error` to be correctly tagged with database/collection
- Allows per-database log configuration to apply to sync function logs

## Example output:
```javascript
function(doc, oldDoc){ console.log(JSON.stringify(doc)) }
```

```
2023-08-24T15:03:22.856+01:00 [INF] Auth: c:#005 db:db1 #005: User <ud>Administrator</ud> was successfully authorized as an admin
2023-08-24T15:03:22.857+01:00 [DBG] CRUD+: c:#005 db:db1 Invoking sync on doc "<ud>1692885802</ud>" rev 1-e6d4b696bdb84036ce71d60ff7fced26
2023-08-24T15:03:22.857+01:00 [INF] Javascript: db:db1 Sync <ud>{"_id":"1692885802","_rev":"1-e6d4b696bdb84036ce71d60ff7fced26","created_at":"1692885802"}</ud>
2023-08-24T15:03:22.857+01:00 [DBG] CRUD+: c:#005 db:db1 Saving doc (seq: #1419, id: <ud>1692885802</ud> rev: 1-e6d4b696bdb84036ce71d60ff7fced26)
2023-08-24T15:03:22.858+01:00 [DBG] CRUD+: c:#005 db:db1 Stored doc "<ud>1692885802</ud>" / "1-e6d4b696bdb84036ce71d60ff7fced26" as #1419
2023-08-24T15:03:22.858+01:00 [INF] HTTP+: c:#005 db:db1 #005:     --> 201   (60.4 ms)
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1976/
