### PR TITLE
CBG-3288-import: Pass context to import filter function

### DIFF
--- a/db/import.go
+++ b/db/import.go
@@ -453,13 +453,11 @@ type jsImportFilterRunner struct {
 }
 
 // Compiles a JavaScript event function to a jsImportFilterRunner object.
-func newImportFilterRunner(funcSource string, timeout time.Duration) (sgbucket.JSServerTask, error) {
+func newImportFilterRunner(ctx context.Context, funcSource string, timeout time.Duration) (sgbucket.JSServerTask, error) {
 	importFilterRunner := &jsEventTask{}
 	err := importFilterRunner.InitWithLogging(funcSource, timeout,
-		func(s string) {
-			base.ErrorfCtx(context.Background(), base.KeyJavascript.String()+": Import %s", base.UD(s))
-		},
-		func(s string) { base.InfofCtx(context.Background(), base.KeyJavascript, "Import %s", base.UD(s)) })
+		func(s string) { base.ErrorfCtx(ctx, base.KeyJavascript.String()+": Import %s", base.UD(s)) },
+		func(s string) { base.InfofCtx(ctx, base.KeyJavascript, "Import %s", base.UD(s)) })
 	if err != nil {
 		return nil, err
 	}
@@ -476,13 +474,13 @@ type ImportFilterFunction struct {
 	*sgbucket.JSServer
 }
 
-func NewImportFilterFunction(fnSource string, timeout time.Duration) *ImportFilterFunction {
+func NewImportFilterFunction(ctx context.Context, fnSource string, timeout time.Duration) *ImportFilterFunction {
 
 	base.DebugfCtx(context.Background(), base.KeyImport, "Creating new ImportFilterFunction")
 	return &ImportFilterFunction{
 		JSServer: sgbucket.NewJSServer(fnSource, timeout, kTaskCacheSize,
 			func(fnSource string, timeout time.Duration) (sgbucket.JSServerTask, error) {
-				return newImportFilterRunner(fnSource, timeout)
+				return newImportFilterRunner(ctx, fnSource, timeout)
 			}),
 	}
 }

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -442,7 +442,7 @@ func TestEvaluateFunction(t *testing.T) {
 	// Simulate unexpected error invoking import filter for document
 	body := Body{"key": "value", "version": "1a"}
 	source := "illegal function(doc) {}"
-	importFilterFunc := NewImportFilterFunction(source, 0)
+	importFilterFunc := NewImportFilterFunction(base.TestCtx(t), source, 0)
 	result, err := importFilterFunc.EvaluateFunction(base.TestCtx(t), body)
 	assert.Error(t, err, "Unexpected token function error")
 	assert.False(t, result, "Function evaluation result should be false")
@@ -450,7 +450,7 @@ func TestEvaluateFunction(t *testing.T) {
 	// Simulate boolean return value from import filter function
 	body = Body{"key": "value", "version": "2a"}
 	source = `function(doc) { if (doc.version == "2a") { return true; } else { return false; }}`
-	importFilterFunc = NewImportFilterFunction(source, 0)
+	importFilterFunc = NewImportFilterFunction(base.TestCtx(t), source, 0)
 	result, err = importFilterFunc.EvaluateFunction(base.TestCtx(t), body)
 	assert.NoError(t, err, "Import filter function shouldn't throw any error")
 	assert.True(t, result, "Import filter function should return boolean value true")
@@ -458,7 +458,7 @@ func TestEvaluateFunction(t *testing.T) {
 	// Simulate non-boolean return value from import filter function; default switch case
 	body = Body{"key": "value", "version": "2b"}
 	source = `function(doc) { if (doc.version == "2b") { return 1.01; } else { return 0.01; }}`
-	importFilterFunc = NewImportFilterFunction(source, 0)
+	importFilterFunc = NewImportFilterFunction(base.TestCtx(t), source, 0)
 	result, err = importFilterFunc.EvaluateFunction(base.TestCtx(t), body)
 	assert.Error(t, err, "Import filter function returned non-boolean value")
 	assert.False(t, result, "Import filter function evaluation result should be false")
@@ -466,7 +466,7 @@ func TestEvaluateFunction(t *testing.T) {
 	// Simulate string return value true from import filter function
 	body = Body{"key": "value", "version": "1a"}
 	source = `function(doc) { if (doc.version == "1a") { return "true"; } else { return "false"; }}`
-	importFilterFunc = NewImportFilterFunction(source, 0)
+	importFilterFunc = NewImportFilterFunction(base.TestCtx(t), source, 0)
 	result, err = importFilterFunc.EvaluateFunction(base.TestCtx(t), body)
 	assert.NoError(t, err, "Import filter function shouldn't throw any error")
 	assert.True(t, result, "Import filter function should return true")
@@ -474,7 +474,7 @@ func TestEvaluateFunction(t *testing.T) {
 	// Simulate string return value false from import filter function
 	body = Body{"key": "value", "version": "2a"}
 	source = `function(doc) { if (doc.version == "1a") { return "true"; } else { return "false"; }}`
-	importFilterFunc = NewImportFilterFunction(source, 0)
+	importFilterFunc = NewImportFilterFunction(base.TestCtx(t), source, 0)
 	result, err = importFilterFunc.EvaluateFunction(base.TestCtx(t), body)
 	assert.NoError(t, err, "Import filter function shouldn't throw any error")
 	assert.False(t, result, "Import filter function should return false")
@@ -482,7 +482,7 @@ func TestEvaluateFunction(t *testing.T) {
 	// Simulate strconv.ParseBool: parsing "TruE": invalid syntax
 	body = Body{"key": "value", "version": "1a"}
 	source = `function(doc) { if (doc.version == "1a") { return "TruE"; } else { return "FaLsE"; }}`
-	importFilterFunc = NewImportFilterFunction(source, 0)
+	importFilterFunc = NewImportFilterFunction(base.TestCtx(t), source, 0)
 	result, err = importFilterFunc.EvaluateFunction(base.TestCtx(t), body)
 	assert.Error(t, err, `strconv.ParseBool: parsing "TruE": invalid syntax`)
 	assert.False(t, result, "Import filter function should return true")

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -747,6 +747,8 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 				Collections: make(map[string]db.CollectionOptions, len(scopeCfg.Collections)),
 			}
 			for collName, collCfg := range scopeCfg.Collections {
+				ctx := base.CollectionLogCtx(ctx, collName)
+
 				var importFilter *db.ImportFilterFunction
 				if collCfg.ImportFilter != nil {
 					importFilter = db.NewImportFilterFunction(ctx, *collCfg.ImportFilter, javascriptTimeout)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -729,6 +729,9 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	if err != nil {
 		return nil, err
 	}
+
+	ctx = base.DatabaseLogCtx(ctx, dbName, contextOptions.LoggingConfig.Console)
+
 	contextOptions.UseViews = useViews
 
 	javascriptTimeout := getJavascriptTimeout(&config.DbConfig)
@@ -746,7 +749,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 			for collName, collCfg := range scopeCfg.Collections {
 				var importFilter *db.ImportFilterFunction
 				if collCfg.ImportFilter != nil {
-					importFilter = db.NewImportFilterFunction(*collCfg.ImportFilter, javascriptTimeout)
+					importFilter = db.NewImportFilterFunction(ctx, *collCfg.ImportFilter, javascriptTimeout)
 				}
 
 				contextOptions.Scopes[scopeName].Collections[collName] = db.CollectionOptions{
@@ -760,7 +763,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		// Set up default import filter
 		var importFilter *db.ImportFilterFunction
 		if config.ImportFilter != nil {
-			importFilter = db.NewImportFilterFunction(*config.ImportFilter, javascriptTimeout)
+			importFilter = db.NewImportFilterFunction(ctx, *config.ImportFilter, javascriptTimeout)
 		}
 
 		contextOptions.Scopes = map[string]db.ScopeOptions{


### PR DESCRIPTION
CBG-3288

Extends CBG-3288 functionality to include import filter function logging

## Dependencies (if applicable)
- [x] #6382 

## Example Output
```javascript
function(doc){
  console.log(JSON.stringify(doc))
  return true
}
```

```
2023-08-24T16:06:42.119+01:00 [DBG] Import+: db:db1 Attempting to import doc "<ud>1692617217</ud>"...
2023-08-24T16:06:42.119+01:00 [DBG] CRUD+: db:db1 Doc <ud>1692617217</ud> is not an SG write, based on cas and body hash. cas:177e5a1fb20e0000 syncCas:"0x0000c72764627d17"
2023-08-24T16:06:42.135+01:00 [INF] Javascript: db:db1 Import <ud>{"foo":"bar","update":true}</ud>
2023-08-24T16:06:42.135+01:00 [DBG] Import+: db:db1 Created new rev ID for doc "<ud>1692617217</ud>" / "2-6e761063eb811c4a77d50b73bea57d77"
2023-08-24T16:06:42.135+01:00 [DBG] CRUD+: db:db1 Invoking sync on doc "<ud>1692617217</ud>" rev 2-6e761063eb811c4a77d50b73bea57d77
2023-08-24T16:06:42.143+01:00 [INF] Javascript: db:db1 Sync <ud>{"_id":"1692617217","_rev":"2-6e761063eb811c4a77d50b73bea57d77","foo":"bar","update":true}</ud>
2023-08-24T16:06:42.143+01:00 [DBG] CRUD+: db:db1 Saving doc (seq: #1427, id: <ud>1692617217</ud> rev: 2-6e761063eb811c4a77d50b73bea57d77)
2023-08-24T16:06:42.143+01:00 [DBG] CRUD+: db:db1 Stored doc "<ud>1692617217</ud>" / "2-6e761063eb811c4a77d50b73bea57d77" as #1427
2023-08-24T16:06:42.143+01:00 [DBG] Import+: db:db1 Imported <ud>1692617217</ud> (delete=false) as rev 2-6e761063eb811c4a77d50b73bea57d77
2023-08-24T16:06:42.143+01:00 [DBG] DCP+: db:db1 Received #1427 after   0ms ("<ud>1692617217</ud>" / "2-6e761063eb811c4a77d50b73bea57d77")
2023-08-24T16:06:42.144+01:00 [DBG] Changes+: db:db1 Notifying that "b1" changed (keys="{0.<ud>*</ud>}") count=2
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
