### PR TITLE
CBG-3274: Pass context into Query/channel cache/Changes

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -109,7 +109,7 @@ func putDDocForTombstones(name string, payload []byte, capiEps []string, client 
 // Requires a primary index on the bucket.
 func QueryBucketItemCount(n1qlStore N1QLStore) (itemCount int, err error) {
 	statement := fmt.Sprintf("SELECT COUNT(1) AS count FROM %s", KeyspaceQueryToken)
-	r, err := n1qlStore.Query(statement, nil, RequestPlus, true)
+	r, err := n1qlStore.Query(context.TODO(), statement, nil, RequestPlus, true)
 	if err != nil {
 		return -1, err
 	}

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -107,9 +107,9 @@ func putDDocForTombstones(name string, payload []byte, capiEps []string, client 
 
 // QueryBucketItemCount uses a request plus query to get the number of items in a bucket, as the REST API can be slow to update its value.
 // Requires a primary index on the bucket.
-func QueryBucketItemCount(n1qlStore N1QLStore) (itemCount int, err error) {
+func QueryBucketItemCount(ctx context.Context, n1qlStore N1QLStore) (itemCount int, err error) {
 	statement := fmt.Sprintf("SELECT COUNT(1) AS count FROM %s", KeyspaceQueryToken)
-	r, err := n1qlStore.Query(context.TODO(), statement, nil, RequestPlus, true)
+	r, err := n1qlStore.Query(ctx, statement, nil, RequestPlus, true)
 	if err != nil {
 		return -1, err
 	}

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -91,7 +91,7 @@ func TestN1qlQuery(t *testing.T) {
 	params := make(map[string]interface{})
 	params["minvalue"] = 2
 
-	queryResults, queryErr := n1qlStore.Query(queryExpression, params, RequestPlus, false)
+	queryResults, queryErr := n1qlStore.Query(ctx, queryExpression, params, RequestPlus, false)
 	require.NoError(t, queryErr, "Error executing n1ql query")
 
 	// Struct to receive the query response (META().id, val)
@@ -117,7 +117,7 @@ func TestN1qlQuery(t *testing.T) {
 	params = make(map[string]interface{})
 	params["minvalue"] = 10
 
-	queryResults, queryErr = n1qlStore.Query(queryExpression, params, RequestPlus, false)
+	queryResults, queryErr = n1qlStore.Query(ctx, queryExpression, params, RequestPlus, false)
 	assert.NoError(t, queryErr, "Error executing n1ql query")
 
 	count = 0
@@ -187,7 +187,7 @@ func TestN1qlFilterExpression(t *testing.T) {
 
 	// Query the index
 	queryExpression := fmt.Sprintf("SELECT META().id, val FROM %s WHERE %s AND META().id = 'doc1'", KeyspaceQueryToken, filterExpression)
-	queryResults, queryErr := n1qlStore.Query(queryExpression, nil, RequestPlus, false)
+	queryResults, queryErr := n1qlStore.Query(ctx, queryExpression, nil, RequestPlus, false)
 	require.NoError(t, queryErr, "Error executing n1ql query")
 
 	// Struct to receive the query response (META().id, val)
@@ -316,26 +316,26 @@ func TestMalformedN1qlQuery(t *testing.T) {
 	// Query with syntax error
 	queryExpression := "SELECT META().id, val WHERE val > $minvalue"
 	params := make(map[string]interface{})
-	_, queryErr := n1qlStore.Query(queryExpression, params, RequestPlus, false)
+	_, queryErr := n1qlStore.Query(ctx, queryExpression, params, RequestPlus, false)
 	assert.True(t, queryErr != nil, "Expected error for malformed n1ql query (syntax)")
 
 	// Query against non-existing bucket
 	queryExpression = fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > $minvalue", "badBucket")
 	params = map[string]interface{}{"minvalue": 2}
-	_, queryErr = n1qlStore.Query(queryExpression, params, RequestPlus, false)
+	_, queryErr = n1qlStore.Query(ctx, queryExpression, params, RequestPlus, false)
 	assert.True(t, queryErr != nil, "Expected error for malformed n1ql query (no bucket)")
 
 	// Specify params for non-parameterized query (no error expected, ensure doesn't break)
 	queryExpression = fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > 5", KeyspaceQueryToken)
 	params = map[string]interface{}{"minvalue": 2}
-	queryResults, queryErr := n1qlStore.Query(queryExpression, params, RequestPlus, false)
+	queryResults, queryErr := n1qlStore.Query(ctx, queryExpression, params, RequestPlus, false)
 	require.True(t, queryErr == nil, "Unexpected error for malformed n1ql query (extra params)")
 	assert.NoError(t, queryResults.Close())
 
 	// Omit params for parameterized query
 	queryExpression = fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > $minvalue", KeyspaceQueryToken)
 	params = map[string]interface{}{"othervalue": 2}
-	results, queryErr := n1qlStore.Query(queryExpression, params, RequestPlus, false)
+	results, queryErr := n1qlStore.Query(ctx, queryExpression, params, RequestPlus, false)
 	if queryErr == nil {
 		for results.NextBytes() != nil {
 		}

--- a/base/collection.go
+++ b/base/collection.go
@@ -346,7 +346,7 @@ func (b *GocbV2Bucket) GetSpec() BucketSpec {
 }
 
 // This flushes the *entire* bucket associated with the collection (not just the collection).  Intended for test usage only.
-func (b *GocbV2Bucket) Flush() error {
+func (b *GocbV2Bucket) Flush(ctx context.Context) error {
 
 	bucketManager := b.cluster.Buckets()
 
@@ -366,7 +366,7 @@ func (b *GocbV2Bucket) Flush() error {
 
 	// Wait until the bucket item count is 0, since flush is asynchronous
 	worker := func() (shouldRetry bool, err error, value interface{}) {
-		itemCount, err := b.BucketItemCount()
+		itemCount, err := b.BucketItemCount(ctx)
 		if err != nil {
 			return false, err, nil
 		}
@@ -393,7 +393,7 @@ func (b *GocbV2Bucket) Flush() error {
 
 // BucketItemCount first tries to retrieve an accurate bucket count via N1QL,
 // but falls back to the REST API if that cannot be done (when there's no index to count all items in a bucket)
-func (b *GocbV2Bucket) BucketItemCount() (itemCount int, err error) {
+func (b *GocbV2Bucket) BucketItemCount(ctx context.Context) (itemCount int, err error) {
 	dataStoreNames, err := b.ListDataStores()
 	if err != nil {
 		return 0, err
@@ -408,7 +408,7 @@ func (b *GocbV2Bucket) BucketItemCount() (itemCount int, err error) {
 		if !ok {
 			return 0, fmt.Errorf("DataStore %v %T is not a N1QLStore", ds.GetName(), ds)
 		}
-		itemCount, err = QueryBucketItemCount(ns)
+		itemCount, err = QueryBucketItemCount(ctx, ns)
 		if err == nil {
 			return itemCount, nil
 		}

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -81,9 +81,7 @@ func (c *Collection) IndexMetaKeyspaceID() string {
 	return IndexMetaKeyspaceID(c.BucketName(), c.ScopeName(), c.CollectionName())
 }
 
-func (c *Collection) Query(statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (resultsIterator sgbucket.QueryResultIterator, err error) {
-	logCtx := context.TODO()
-
+func (c *Collection) Query(ctx context.Context, statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (resultsIterator sgbucket.QueryResultIterator, err error) {
 	keyspaceStatement := strings.Replace(statement, KeyspaceQueryToken, c.EscapedKeyspace(), -1)
 
 	n1qlOptions := &gocb.QueryOptions{
@@ -94,7 +92,7 @@ func (c *Collection) Query(statement string, params map[string]interface{}, cons
 
 	waitTime := 10 * time.Millisecond
 	for i := 1; i <= MaxQueryRetries; i++ {
-		TracefCtx(logCtx, KeyQuery, "Executing N1QL query: %v - %+v", UD(keyspaceStatement), UD(params))
+		TracefCtx(ctx, KeyQuery, "Executing N1QL query: %v - %+v", UD(keyspaceStatement), UD(params))
 		queryResults, queryErr := c.Bucket.runQuery(c.ScopeName(), keyspaceStatement, n1qlOptions)
 		if queryErr == nil {
 			resultsIterator := &gocbRawIterator{
@@ -111,24 +109,24 @@ func (c *Collection) Query(statement string, params map[string]interface{}, cons
 
 		// Non-retry error - return
 		if !isTransientIndexerError(queryErr) {
-			WarnfCtx(logCtx, "Error when querying index using statement: [%s] parameters: [%+v] error:%v", UD(keyspaceStatement), UD(params), queryErr)
+			WarnfCtx(ctx, "Error when querying index using statement: [%s] parameters: [%+v] error:%v", UD(keyspaceStatement), UD(params), queryErr)
 			return resultsIterator, pkgerrors.WithStack(queryErr)
 		}
 
 		// Indexer error - wait then retry
 		err = queryErr
-		WarnfCtx(logCtx, "Indexer error during query - retry %d/%d after %v.  Error: %v", i, MaxQueryRetries, waitTime, queryErr)
+		WarnfCtx(ctx, "Indexer error during query - retry %d/%d after %v.  Error: %v", i, MaxQueryRetries, waitTime, queryErr)
 		time.Sleep(waitTime)
 
 		waitTime = waitTime * 2
 	}
 
-	WarnfCtx(logCtx, "Exceeded max retries for query when querying index using statement: [%s] parameters: [%+v], err:%v", UD(keyspaceStatement), UD(params), err)
+	WarnfCtx(ctx, "Exceeded max retries for query when querying index using statement: [%s] parameters: [%+v], err:%v", UD(keyspaceStatement), UD(params), err)
 	return nil, err
 }
 
-func (c *Collection) ExplainQuery(statement string, params map[string]interface{}) (plan map[string]interface{}, err error) {
-	return ExplainQuery(c, statement, params)
+func (c *Collection) ExplainQuery(ctx context.Context, statement string, params map[string]interface{}) (plan map[string]interface{}, err error) {
+	return ExplainQuery(ctx, c, statement, params)
 }
 
 func (c *Collection) CreateIndex(ctx context.Context, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -42,9 +42,9 @@ type N1QLStore interface {
 	CreateIndex(ctx context.Context, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error
 	CreatePrimaryIndex(ctx context.Context, indexName string, options *N1qlIndexOptions) error
 	DropIndex(ctx context.Context, indexName string) error
-	ExplainQuery(statement string, params map[string]interface{}) (plan map[string]interface{}, err error)
+	ExplainQuery(ctx context.Context, statement string, params map[string]interface{}) (plan map[string]interface{}, err error)
 	GetIndexMeta(ctx context.Context, indexName string) (exists bool, meta *IndexMeta, err error)
-	Query(statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (results sgbucket.QueryResultIterator, err error)
+	Query(ctx context.Context, statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (results sgbucket.QueryResultIterator, err error)
 	IsErrNoResults(error) bool
 	EscapedKeyspace() string
 	IndexMetaBucketID() string
@@ -66,9 +66,9 @@ type N1QLStore interface {
 	waitUntilQueryServiceReady(timeout time.Duration) error
 }
 
-func ExplainQuery(store N1QLStore, statement string, params map[string]interface{}) (plan map[string]interface{}, err error) {
+func ExplainQuery(ctx context.Context, store N1QLStore, statement string, params map[string]interface{}) (plan map[string]interface{}, err error) {
 	explainStatement := fmt.Sprintf("EXPLAIN %s", statement)
-	explainResults, explainErr := store.Query(explainStatement, params, RequestPlus, true)
+	explainResults, explainErr := store.Query(ctx, explainStatement, params, RequestPlus, true)
 
 	if explainErr != nil {
 		return nil, explainErr

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -661,7 +661,7 @@ var N1QLBucketEmptierFunc TBPBucketReadierFunc = func(ctx context.Context, b Buc
 			return fmt.Errorf("bucket does not have primary index, so can't empty bucket using N1QL")
 		}
 
-		if itemCount, err := QueryBucketItemCount(n1qlStore); err != nil {
+		if itemCount, err := QueryBucketItemCount(ctx, n1qlStore); err != nil {
 			return err
 		} else if itemCount == 0 {
 			tbp.Logf(ctx, "Bucket already empty - skipping")

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -437,7 +437,7 @@ func (tbp *TestBucketPool) emptyPreparedStatements(ctx context.Context, b Bucket
 		}
 
 		// search all statements for those containing a string matching the bucket name (which will also include all scope/collection-based prepared statements)
-		queryRes, err := n1qlStore.Query(`DELETE FROM system:prepareds WHERE statement LIKE "%`+b.GetName()+`%";`, nil, RequestPlus, true)
+		queryRes, err := n1qlStore.Query(ctx, `DELETE FROM system:prepareds WHERE statement LIKE "%`+b.GetName()+`%";`, nil, RequestPlus, true)
 		if err != nil {
 			tbp.Fatalf(ctx, "Couldn't remove old prepared statements: %v", err)
 		}
@@ -670,7 +670,7 @@ var N1QLBucketEmptierFunc TBPBucketReadierFunc = func(ctx context.Context, b Buc
 			// Use N1QL to empty bucket, with the hope that the query service is happier to deal with this than a bucket flush/rollback.
 			// Requires a primary index on the bucket.
 			// TODO: How can we delete xattr only docs from here too? It would avoid needing to call db.emptyAllDocsIndex in ViewsAndGSIBucketReadier
-			res, err := n1qlStore.Query(fmt.Sprintf(`DELETE FROM %s`, KeyspaceQueryToken), nil, RequestPlus, true)
+			res, err := n1qlStore.Query(ctx, fmt.Sprintf(`DELETE FROM %s`, KeyspaceQueryToken), nil, RequestPlus, true)
 			if err != nil {
 				return err
 			}

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -632,11 +632,11 @@ type TBPBucketReadierFunc func(ctx context.Context, b Bucket, tbp *TestBucketPoo
 // FlushBucketEmptierFunc ensures the bucket is empty by flushing. It is not recommended to use with GSI.
 var FlushBucketEmptierFunc TBPBucketReadierFunc = func(ctx context.Context, b Bucket, tbp *TestBucketPool) error {
 
-	flushableBucket, ok := b.(sgbucket.FlushableStore)
-	if !ok {
-		return errors.New("FlushBucketEmptierFunc used with non-flushable bucket")
+	bucket, err := AsGocbV2Bucket(b)
+	if err != nil {
+		return err
 	}
-	return flushableBucket.Flush()
+	return bucket.Flush(ctx)
 }
 
 // N1QLBucketEmptierFunc ensures the Bucket and all of its DataStore are empty by using N1QL deletes. This is the preferred approach when using GSI.

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -405,7 +405,6 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 		Continuous:     opts.continuous,
 		ActiveOnly:     opts.activeOnly,
 		Revocations:    opts.revocations,
-		LoggingCtx:     bh.loggingCtx,
 		clientType:     opts.clientType,
 		ChangesCtx:     opts.changesCtx,
 		RequestPlusSeq: opts.requestPlusSeq,

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -772,12 +772,12 @@ func (c *changeCache) getChannelCache() ChannelCache {
 
 // ////// CHANGE ACCESS:
 
-func (c *changeCache) GetChanges(channel channels.ID, options ChangesOptions) ([]*LogEntry, error) {
+func (c *changeCache) GetChanges(ctx context.Context, channel channels.ID, options ChangesOptions) ([]*LogEntry, error) {
 
 	if c.stopped.IsTrue() {
 		return nil, base.HTTPErrorf(503, "Database closed")
 	}
-	return c.channelCache.GetChanges(channel, options)
+	return c.channelCache.GetChanges(ctx, channel, options)
 }
 
 // Returns the sequence number the cache is up-to-date with.

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1999,7 +1999,7 @@ func BenchmarkProcessEntry(b *testing.B) {
 			if bm.warmCacheCount > 0 {
 				for i := 0; i < bm.warmCacheCount; i++ {
 					channel := channels.NewID(fmt.Sprintf("channel_%d", i), collectionID)
-					_, err := changeCache.GetChanges(channel, getChangesOptionsWithZeroSeq())
+					_, err := changeCache.GetChanges(ctx, channel, getChangesOptionsWithZeroSeq())
 					if err != nil {
 						log.Printf("GetChanges failed for changeCache: %v", err)
 						b.Fail()
@@ -2233,7 +2233,7 @@ func BenchmarkDocChanged(b *testing.B) {
 			if bm.warmCacheCount > 0 {
 				for i := 0; i < bm.warmCacheCount; i++ {
 					channel := channels.NewID(fmt.Sprintf("channel_%d", i), collectionID)
-					_, err := changeCache.GetChanges(channel, getChangesOptionsWithZeroSeq())
+					_, err := changeCache.GetChanges(ctx, channel, getChangesOptionsWithZeroSeq())
 					if err != nil {
 						log.Printf("GetChanges failed for changeCache: %v", err)
 						b.Fail()

--- a/db/changes.go
+++ b/db/changes.go
@@ -386,6 +386,8 @@ func (db *DatabaseCollectionWithUser) changesFeed(ctx context.Context, singleCha
 
 	feed := make(chan *ChangeEntry, 1)
 
+	options.LoggingCtx = ctx
+
 	queryLimit := db.channelQueryLimit()
 	requestLimit := options.Limit
 

--- a/db/changes.go
+++ b/db/changes.go
@@ -38,7 +38,6 @@ type ChangesOptions struct {
 	ActiveOnly     bool            // If true, only return information on non-deleted, non-removed revisions
 	Revocations    bool            // Specifies whether revocation messages should be sent on the changes feed
 	clientType     clientType      // Can be used to determine if the replication is being started from a CBL 2.x or SGR2 client
-	LoggingCtx     context.Context // Used for adding context to logs
 	ChangesCtx     context.Context // Used for cancelling checking the changes feed should stop
 }
 
@@ -229,7 +228,7 @@ func (db *DatabaseCollectionWithUser) buildRevokedFeed(ctx context.Context, ch c
 
 			// Get changes from 0 to latest seq
 			base.TracefCtx(ctx, base.KeyChanges, "Querying channel %q for revocation with options: %+v", base.UD(singleChannelCache.ChannelID().Name), paginationOptions)
-			changes, err := singleChannelCache.GetChanges(paginationOptions)
+			changes, err := singleChannelCache.GetChanges(ctx, paginationOptions)
 			if err != nil {
 				base.WarnfCtx(ctx, "Error retrieving changes for channel %q: %v", base.UD(singleChannelCache.ChannelID()), err)
 				change := ChangeEntry{
@@ -386,8 +385,6 @@ func (db *DatabaseCollectionWithUser) changesFeed(ctx context.Context, singleCha
 
 	feed := make(chan *ChangeEntry, 1)
 
-	options.LoggingCtx = ctx
-
 	queryLimit := db.channelQueryLimit()
 	requestLimit := options.Limit
 
@@ -416,9 +413,8 @@ func (db *DatabaseCollectionWithUser) changesFeed(ctx context.Context, singleCha
 				paginationOptions.Limit = base.Min(remainingLimit, queryLimit)
 			}
 
-			// TODO: pass db.Ctx down to changeCache?
 			base.TracefCtx(ctx, base.KeyChanges, "Querying channel %q with options: %+v", base.UD(singleChannelCache.ChannelID().Name), paginationOptions)
-			changes, err := singleChannelCache.GetChanges(paginationOptions)
+			changes, err := singleChannelCache.GetChanges(ctx, paginationOptions)
 			if err != nil {
 				base.WarnfCtx(ctx, "Error retrieving changes for channel %q: %v", base.UD(singleChannelCache.ChannelID().Name), err)
 				change := ChangeEntry{

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -51,7 +51,7 @@ type ChannelCache interface {
 	Remove(collectionID uint32, docIDs []string, startTime time.Time) (count int)
 
 	// Returns set of changes for a given channel, within the bounds specified in options
-	GetChanges(ch channels.ID, options ChangesOptions) ([]*LogEntry, error)
+	GetChanges(ctx context.Context, ch channels.ID, options ChangesOptions) ([]*LogEntry, error)
 
 	// Returns the set of all cached data for a given channel (intended for diagnostic usage)
 	GetCachedChanges(ch channels.ID) ([]*LogEntry, error)
@@ -278,13 +278,13 @@ func (c *channelCacheImpl) Remove(collectionID uint32, docIDs []string, startTim
 	return count
 }
 
-func (c *channelCacheImpl) GetChanges(ch channels.ID, options ChangesOptions) ([]*LogEntry, error) {
+func (c *channelCacheImpl) GetChanges(ctx context.Context, ch channels.ID, options ChangesOptions) ([]*LogEntry, error) {
 
 	cache, err := c.getChannelCache(ch)
 	if err != nil {
 		return nil, err
 	}
-	return cache.GetChanges(options)
+	return cache.GetChanges(ctx, options)
 }
 
 func (c *channelCacheImpl) GetCachedChanges(channel channels.ID) ([]*LogEntry, error) {

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -47,7 +47,7 @@ func TestDuplicateDocID(t *testing.T) {
 	cache.addToCache(testLogEntry(2, "doc3", "3-a"), false)
 	cache.addToCache(testLogEntry(3, "doc5", "5-a"), false)
 
-	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err := cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 2, 3}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc5"}))
@@ -55,7 +55,7 @@ func TestDuplicateDocID(t *testing.T) {
 
 	// Add a new revision matching mid-list
 	cache.addToCache(testLogEntry(4, "doc3", "3-b"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 3, 4}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc5", "doc3"}))
@@ -63,7 +63,7 @@ func TestDuplicateDocID(t *testing.T) {
 
 	// Add a new revision matching first
 	cache.addToCache(testLogEntry(5, "doc1", "1-b"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{3, 4, 5}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc5", "doc3", "doc1"}))
@@ -71,7 +71,7 @@ func TestDuplicateDocID(t *testing.T) {
 
 	// Add a new revision matching last
 	cache.addToCache(testLogEntry(6, "doc1", "1-c"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{3, 4, 6}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc5", "doc3", "doc1"}))
@@ -102,7 +102,7 @@ func TestLateArrivingSequence(t *testing.T) {
 	cache.addToCache(testLogEntry(3, "doc3", "3-a"), false)
 	cache.addToCache(testLogEntry(5, "doc5", "5-a"), false)
 
-	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err := cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 3, 5}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc5"}))
@@ -111,7 +111,7 @@ func TestLateArrivingSequence(t *testing.T) {
 	// Add a late-arriving sequence
 	cache.AddLateSequence(testLogEntry(2, "doc2", "2-a"))
 	cache.addToCache(testLogEntry(2, "doc2", "2-a"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 2, 3, 5}))
@@ -143,7 +143,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	cache.addToCache(testLogEntry(10, "doc2", "2-a"), false)
 	cache.addToCache(testLogEntry(15, "doc3", "3-a"), false)
 
-	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err := cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{5, 10, 15}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc2", "doc3"}))
@@ -152,7 +152,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	// Add a late-arriving sequence
 	cache.AddLateSequence(testLogEntry(3, "doc0", "0-a"))
 	cache.addToCache(testLogEntry(3, "doc0", "0-a"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{3, 5, 10, 15}))
@@ -185,7 +185,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	cache.addToCache(testLogEntry(30, "doc3", "3-a"), false)
 	cache.addToCache(testLogEntry(40, "doc4", "4-a"), false)
 
-	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err := cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	assert.True(t, verifyChannelSequences(entries, []uint64{10, 20, 30, 40}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc2", "doc3", "doc4"}))
@@ -194,7 +194,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	// Add a late-arriving sequence that should replace earlier sequence
 	cache.AddLateSequence(testLogEntry(25, "doc1", "1-c"))
 	cache.addToCache(testLogEntry(25, "doc1", "1-c"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{20, 25, 30, 40}))
@@ -204,7 +204,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	// Add a late-arriving sequence that should be ignored (later sequence exists for that docID)
 	cache.AddLateSequence(testLogEntry(15, "doc1", "1-b"))
 	cache.addToCache(testLogEntry(15, "doc1", "1-b"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{20, 25, 30, 40}))
@@ -214,7 +214,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	// Add a late-arriving sequence adjacent to same ID (cache inserts differently)
 	cache.AddLateSequence(testLogEntry(27, "doc1", "1-d"))
 	cache.addToCache(testLogEntry(27, "doc1", "1-d"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{20, 27, 30, 40}))
@@ -224,7 +224,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	// Add a late-arriving sequence adjacent to same ID (cache inserts differently)
 	cache.AddLateSequence(testLogEntry(41, "doc4", "4-b"))
 	cache.addToCache(testLogEntry(41, "doc4", "4-b"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{20, 27, 30, 41}))
@@ -234,7 +234,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	// Add late arriving that's duplicate of oldest in cache
 	cache.AddLateSequence(testLogEntry(45, "doc2", "2-b"))
 	cache.addToCache(testLogEntry(45, "doc2", "2-b"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{27, 30, 41, 45}))
@@ -475,7 +475,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	cache.addToCache(testLogEntry(2, "doc3", "3-a"), false)
 	cache.addToCache(testLogEntry(3, "doc5", "5-a"), false)
 
-	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err := cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 2, 3}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc5"}))
@@ -483,7 +483,7 @@ func TestChannelCacheRemove(t *testing.T) {
 
 	// Now remove doc1
 	cache.Remove(collectionID, []string{"doc1"}, time.Now())
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 2)
 	assert.True(t, verifyChannelSequences(entries, []uint64{2, 3}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc3", "doc5"}))
@@ -493,7 +493,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	// This will print a debug level log:
 	// [DBG] Cache+: Skipping removal of doc "doc5" from cache "Test1" - received after purge
 	cache.Remove(collectionID, []string{"doc5"}, time.Now().Add(-time.Second*5))
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 2)
 	assert.True(t, verifyChannelSequences(entries, []uint64{2, 3}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc3", "doc5"}))
@@ -707,7 +707,7 @@ func TestBypassSingleChannelCache(t *testing.T) {
 		queryHandler: queryHandler,
 	}
 
-	entries, err := bypassCache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err := bypassCache.GetChanges(base.TestCtx(t), getChangesOptionsWithZeroSeq())
 	assert.NoError(t, err)
 	require.Len(t, entries, 10)
 

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -32,13 +32,13 @@ func TestChannelCacheMaxSize(t *testing.T) {
 	collectionID := GetSingleDatabaseCollection(t, db.DatabaseContext).GetCollectionID()
 
 	// Make channels active
-	_, err := cache.GetChanges(channels.NewID("TestA", collectionID), getChangesOptionsWithCtxOnly())
+	_, err := cache.GetChanges(ctx, channels.NewID("TestA", collectionID), getChangesOptionsWithCtxOnly())
 	require.NoError(t, err)
-	_, err = cache.GetChanges(channels.NewID("TestB", collectionID), getChangesOptionsWithCtxOnly())
+	_, err = cache.GetChanges(ctx, channels.NewID("TestB", collectionID), getChangesOptionsWithCtxOnly())
 	require.NoError(t, err)
-	_, err = cache.GetChanges(channels.NewID("TestC", collectionID), getChangesOptionsWithCtxOnly())
+	_, err = cache.GetChanges(ctx, channels.NewID("TestC", collectionID), getChangesOptionsWithCtxOnly())
 	require.NoError(t, err)
-	_, err = cache.GetChanges(channels.NewID("TestD", collectionID), getChangesOptionsWithCtxOnly())
+	_, err = cache.GetChanges(ctx, channels.NewID("TestD", collectionID), getChangesOptionsWithCtxOnly())
 	require.NoError(t, err)
 
 	// Add some entries to caches, leaving some empty caches
@@ -313,7 +313,7 @@ func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 				channelNumber := rand.Intn(channelCount) + 1
 				channel := channels.NewID(fmt.Sprintf("chan_%d", channelNumber), base.DefaultCollectionID)
 				options := getChangesOptionsWithCtxOnly()
-				changes, err := cache.GetChanges(channel, options)
+				changes, err := cache.GetChanges(base.TestCtx(t), channel, options)
 				if len(changes) == 1 {
 					changesSuccessCount++
 				}
@@ -387,7 +387,7 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 				channelNumber := rand.Intn(channelCount) + 1
 				channel := channels.NewID(fmt.Sprintf("chan_%d", channelNumber), base.DefaultCollectionID)
 				options := getChangesOptionsWithCtxOnly()
-				changes, err := cache.GetChanges(channel, options)
+				changes, err := cache.GetChanges(base.TestCtx(t), channel, options)
 				if len(changes) == 1 {
 					changesSuccessCount++
 				}
@@ -447,7 +447,7 @@ func TestChannelCacheBypass(t *testing.T) {
 	for c := 1; c <= channelCount; c++ {
 		channel := channels.NewID(fmt.Sprintf("chan_%d", c), base.DefaultCollectionID)
 		options := getChangesOptionsWithCtxOnly()
-		changes, err := cache.GetChanges(channel, options)
+		changes, err := cache.GetChanges(base.TestCtx(t), channel, options)
 		assert.NoError(t, err, fmt.Sprintf("Error getting changes for channel %q", channel))
 		assert.True(t, len(changes) == 1, "Expected one change per channel")
 	}

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -122,7 +122,7 @@ func TestBuildRolesQuery(t *testing.T) {
 			require.True(t, ok)
 
 			roleStatement, _ := database.BuildRolesQuery("", 0)
-			plan, explainErr := n1QLStore.ExplainQuery(roleStatement, nil)
+			plan, explainErr := n1QLStore.ExplainQuery(ctx, roleStatement, nil)
 			require.NoError(t, explainErr, "Error generating explain for roleAccess query")
 
 			covered := db.IsCovered(plan)
@@ -165,7 +165,7 @@ func TestBuildUsersQuery(t *testing.T) {
 			n1QLStore, ok := base.AsN1QLStore(database.MetadataStore)
 			require.True(t, ok)
 			userStatement, _ := database.BuildUsersQuery("", 0)
-			plan, explainErr := n1QLStore.ExplainQuery(userStatement, nil)
+			plan, explainErr := n1QLStore.ExplainQuery(ctx, userStatement, nil)
 			require.NoError(t, explainErr)
 
 			covered := db.IsCovered(plan)

--- a/db/indextest/main_test.go
+++ b/db/indextest/main_test.go
@@ -88,7 +88,7 @@ var primaryIndexReadier base.TBPBucketReadierFunc = func(ctx context.Context, b 
 		}
 		tbp.Logf(ctx, "dropping existing bucket indexes")
 
-		if err := db.EmptyPrimaryIndex(dataStore); err != nil {
+		if err := db.EmptyPrimaryIndex(ctx, dataStore); err != nil {
 			return err
 		}
 		n1qlStore, ok := base.AsN1QLStore(dataStore)
@@ -105,7 +105,7 @@ var primaryIndexReadier base.TBPBucketReadierFunc = func(ctx context.Context, b 
 		}
 		tbp.Logf(ctx, "waiting for empty bucket indexes %s.%s.%s", b.GetName(), dsName.ScopeName(), dsName.CollectionName())
 		// wait for primary index to be empty
-		if err := db.WaitForPrimaryIndexEmpty(n1qlStore); err != nil {
+		if err := db.WaitForPrimaryIndexEmpty(ctx, n1qlStore); err != nil {
 			tbp.Logf(ctx, "waitForPrimaryIndexEmpty returned an error: %v", err)
 			return err
 		}

--- a/db/query.go
+++ b/db/query.go
@@ -382,7 +382,7 @@ func N1QLQueryWithStats(ctx context.Context, dataStore base.DataStore, queryName
 		return nil, errors.New("Cannot perform N1QL query on non-Couchbase bucket.")
 	}
 
-	results, err = n1QLStore.Query(statement, params, consistency, adhoc)
+	results, err = n1QLStore.Query(ctx, statement, params, consistency, adhoc)
 
 	if len(queryName) > 0 {
 		queryStat := dbStats.Query(queryName)

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -141,7 +141,7 @@ func TestCoveringQueries(t *testing.T) {
 
 	// channels
 	channelsStatement, params := collection.buildChannelsQuery("ABC", 0, 10, 100, false)
-	plan, explainErr := n1QLStore.ExplainQuery(channelsStatement, params)
+	plan, explainErr := n1QLStore.ExplainQuery(ctx, channelsStatement, params)
 	assert.NoError(t, explainErr, "Error generating explain for channels query")
 	covered := IsCovered(plan)
 	planJSON, err := base.JSONMarshal(plan)
@@ -150,7 +150,7 @@ func TestCoveringQueries(t *testing.T) {
 
 	// star channel
 	channelStarStatement, params := collection.buildChannelsQuery("*", 0, 10, 100, false)
-	plan, explainErr = n1QLStore.ExplainQuery(channelStarStatement, params)
+	plan, explainErr = n1QLStore.ExplainQuery(ctx, channelStarStatement, params)
 	assert.NoError(t, explainErr, "Error generating explain for star channel query")
 	covered = IsCovered(plan)
 	planJSON, err = base.JSONMarshal(plan)
@@ -161,7 +161,7 @@ func TestCoveringQueries(t *testing.T) {
 	// in the SELECT.
 	// Including here for ease-of-conversion when we get an indexing enhancement to support covered queries.
 	accessStatement := collection.buildAccessQuery("user1")
-	plan, explainErr = n1QLStore.ExplainQuery(accessStatement, nil)
+	plan, explainErr = n1QLStore.ExplainQuery(ctx, accessStatement, nil)
 	assert.NoError(t, explainErr, "Error generating explain for access query")
 	covered = IsCovered(plan)
 	planJSON, err = base.JSONMarshal(plan)
@@ -170,7 +170,7 @@ func TestCoveringQueries(t *testing.T) {
 
 	// roleAccess
 	roleAccessStatement := collection.buildRoleAccessQuery("user1")
-	plan, explainErr = n1QLStore.ExplainQuery(roleAccessStatement, nil)
+	plan, explainErr = n1QLStore.ExplainQuery(ctx, roleAccessStatement, nil)
 	assert.NoError(t, explainErr, "Error generating explain for roleAccess query")
 	covered = IsCovered(plan)
 	planJSON, err = base.JSONMarshal(plan)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -56,7 +56,7 @@ func isPrimaryIndexEmpty(store base.N1QLStore) (bool, error) {
 	params[QueryParamEndSeq] = N1QLMaxInt64
 
 	// Execute the query
-	results, err := store.Query(statement, params, base.RequestPlus, true)
+	results, err := store.Query(context.TODO(), statement, params, base.RequestPlus, true)
 
 	// If there was an error, then retry.  Assume it's an "index rollback" error which happens as
 	// the index processes the bucket flush operation
@@ -192,7 +192,7 @@ func EmptyPrimaryIndex(dataStore sgbucket.DataStore) error {
 	}
 
 	statement := `DELETE FROM ` + base.KeyspaceQueryToken
-	results, err := n1qlStore.Query(statement, nil, base.RequestPlus, true)
+	results, err := n1qlStore.Query(context.TODO(), statement, nil, base.RequestPlus, true)
 	if err != nil {
 		return err
 	}
@@ -214,7 +214,7 @@ func emptyAllDocsIndex(ctx context.Context, dataStore sgbucket.DataStore, tbp *b
 FROM ` + base.KeyspaceQueryToken + ` AS ks USE INDEX (sg_allDocs_x1)
 WHERE META(ks).xattrs._sync.sequence IS NOT MISSING
     AND META(ks).id NOT LIKE '\\_sync:%'`
-	results, err := n1qlStore.Query(statement, nil, base.RequestPlus, true)
+	results, err := n1qlStore.Query(ctx, statement, nil, base.RequestPlus, true)
 	if err != nil {
 		return 0, err
 	}

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -519,7 +519,7 @@ func TestCollectionsBasicIndexQuery(t *testing.T) {
 	require.NoError(t, n1qlStore.CreatePrimaryIndex(ctx, idxName, nil))
 	require.NoError(t, n1qlStore.WaitForIndexesOnline(ctx, []string{idxName}, false))
 
-	res, err := n1qlStore.Query("SELECT keyspace_id, bucket_id, scope_id from system:indexes WHERE name = $idxName",
+	res, err := n1qlStore.Query(ctx, "SELECT keyspace_id, bucket_id, scope_id from system:indexes WHERE name = $idxName",
 		map[string]interface{}{"idxName": idxName}, base.RequestPlus, true)
 	require.NoError(t, err)
 
@@ -543,7 +543,7 @@ func TestCollectionsBasicIndexQuery(t *testing.T) {
 	assert.Equal(t, collection.Name, *indexMetaResult.KeyspaceID)
 
 	// try and query the document that we wrote via SG
-	res, err = n1qlStore.Query("SELECT test FROM "+base.KeyspaceQueryToken+" WHERE test = true", nil, base.RequestPlus, true)
+	res, err = n1qlStore.Query(ctx, "SELECT test FROM "+base.KeyspaceQueryToken+" WHERE test = true", nil, base.RequestPlus, true)
 	require.NoError(t, err)
 
 	var primaryQueryResult struct {


### PR DESCRIPTION
CBG-3274

Pass context through into Query and channel cache/HTTP-based `GetChanges`

## Example Output

```
2023-08-24T17:11:20.111+01:00 [INF] Auth: c:#024 db:db1 #024: User <ud>Administrator</ud> was successfully authorized as an admin
2023-08-24T17:11:20.112+01:00 [DBG] Changes+: c:#024 db:db1 Int sequence multi changes feed...
2023-08-24T17:11:20.112+01:00 [INF] Changes: c:#024 db:db1 MultiChangesFeed(channels: {<ud>*</ud>}, options: {Since: 0, Limit: 0, Conflicts: false, IncludeDocs: false, Wait: false, Continuous: false, HeartbeatMs: 0, TimeoutMs: 300000, ActiveOnly: false, RequestPlusSeq: 0}) ... <ud></ud>
2023-08-24T17:11:20.112+01:00 [DBG] Changes+: c:#024 db:db1 MultiChangesFeed: channels expand to "<ud></ud>" ... <ud></ud>
2023-08-24T17:11:20.113+01:00 [TRC] Changes+: c:#024 db:db1 Querying channel "<ud>*</ud>" with options: {Since: 0, Limit: 5000, Conflicts: false, IncludeDocs: false, Wait: false, Continuous: false, HeartbeatMs: 0, TimeoutMs: 300000, ActiveOnly: false, RequestPlusSeq: 0} -- db.(*DatabaseCollectionWithUser).changesFeed.func1() at changes.go:420
2023-08-24T17:11:20.113+01:00 [INF] Cache: c:#024 db:db1 GetCachedChanges("<ud>0.<ud>*</ud></ud>", 0) --> 500 changes valid from #2639
2023-08-24T17:11:20.113+01:00 [INF] Cache: c:#024 db:db1   Querying 'channels' for "<ud>*</ud>" (start=#1, end=#2639, limit=5000)
2023-08-24T17:11:20.113+01:00 [TRC] Query+: c:#024 db:db1 Executing N1QL query: <ud>SELECT meta(sgQueryKeyspaceAlias).xattrs._sync.sequence AS seq, meta(sgQueryKeyspaceAlias).xattrs._sync.rev AS rev, meta(sgQueryKeyspaceAlias).xattrs._sync.flags AS flags, META(sgQueryKeyspaceAlias).id AS id FROM `b1`.`_default`.`_default` AS sgQueryKeyspaceAlias USE INDEX (sg_allDocs_x1) WHERE meta(sgQueryKeyspaceAlias).xattrs._sync.sequence >= $startSeq AND meta(sgQueryKeyspaceAlias).xattrs._sync.sequence < $endSeq AND META().id NOT LIKE '\\_sync:%' ORDER BY meta(sgQueryKeyspaceAlias).xattrs._sync.sequence LIMIT 5000</ud> - <ud>map[channelName:* endSeq:2640 startSeq:1]</ud> -- base.(*Collection).Query() at collection_n1ql.go:95
2023-08-24T17:11:20.126+01:00 [INF] Cache: c:#024 db:db1     Got 2633 rows from query for "<ud>*</ud>": #1 ... #2639
2023-08-24T17:11:20.126+01:00 [INF] Cache: c:#024 db:db1 GetChangesInChannel("<ud>0.<ud>*</ud></ud>") --> 3132 rows
2023-08-24T17:11:20.126+01:00 [DBG] Changes+: c:#024 db:db1 [changesFeed] Found 3132 changes for channel "<ud>*</ud>"
2023-08-24T17:11:20.126+01:00 [DBG] Changes+: c:#024 db:db1 Channel feed processing seq:1 in channel <ud>*</ud> <ud></ud>
2023-08-24T17:11:20.126+01:00 [DBG] Changes+: c:#024 db:db1 MultiChangesFeed sending <ud>{Seq:1, ID:doc1, Changes:[map[rev:1-cd809becc169215072fd567eebd8b8de]]}</ud> <ud></ud>

...

2023-08-24T17:11:20.208+01:00 [DBG] Changes+: c:#024 db:db1 Channel feed processing seq:3138 in channel <ud>*</ud> <ud></ud>
2023-08-24T17:11:20.208+01:00 [DBG] Changes+: c:#024 db:db1 MultiChangesFeed sending <ud>{Seq:3138, ID:1692893479, Changes:[map[rev:1-8454b87ef699c41114b51a4981ffb89e]]}</ud> <ud></ud>
2023-08-24T17:11:20.208+01:00 [INF] Changes: c:#024 db:db1 MultiChangesFeed done <ud></ud>
2023-08-24T17:11:20.208+01:00 [INF] HTTP+: c:#024 db:db1 #024:     --> 200 OK  (136.2 ms)
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1981/
