### PR TITLE
CBG-3352 lock value on read

### DIFF
--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -392,7 +392,8 @@ func (value *revCacheValue) updateBody(ctx context.Context) (err error) {
 // asDocumentRevision copies the rev cache value into a DocumentRevision.  Should only be called for non-empty
 // revCacheValues - copies all immutable revCacheValue properties, and adds the provided body/delta.
 func (value *revCacheValue) asDocumentRevision(body Body, delta *RevisionDelta) (DocumentRevision, error) {
-
+	value.lock.RLock()
+	defer value.lock.RUnlock()
 	docRev := DocumentRevision{
 		DocID:       value.key.DocID,
 		RevID:       value.key.RevID,


### PR DESCRIPTION

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1983/
