### PR TITLE
CBG-3352 remove invalid entries from revcache

### DIFF
--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -121,7 +121,6 @@ type DocumentRevision struct {
 	Delta       *RevisionDelta
 	Deleted     bool
 	Removed     bool // True if the revision is a removal.
-	Invalid     bool
 
 	_shallowCopyBody Body // an unmarshalled body that can produce shallow copies
 }

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -75,29 +75,29 @@ func (sc *ShardedLRURevisionCache) Invalidate(ctx context.Context, docID, revID 
 
 // An LRU cache of document revision bodies, together with their channel access.
 type LRURevisionCache struct {
-	cache        map[IDAndRev]*list.Element // Fast lookup of list element by doc/rev ID
-	lruList      *list.List                 // List ordered by most recent access (Front is newest)
-	capacity     uint32                     // Max number of revisions to cache
-	backingStore RevisionCacheBackingStore  // provides the methods used by the RevisionCacheLoaderFunc
-	lock         sync.Mutex                 // For thread-safety
+	backingStore RevisionCacheBackingStore
+	cache        map[IDAndRev]*list.Element
+	lruList      *list.List
 	cacheHits    *base.SgwIntStat
 	cacheMisses  *base.SgwIntStat
+	lock         sync.Mutex
+	capacity     uint32
 }
 
 // The cache payload data. Stored as the Value of a list Element.
 type revCacheValue struct {
-	key         IDAndRev        // doc/rev IDs
-	bodyBytes   []byte          // Revision body (with no special properties)
-	history     Revisions       // Rev history encoded like a "_revisions" property
-	channels    base.Set        // Set of channels that have access
-	expiry      *time.Time      // Document expiry
-	attachments AttachmentsMeta // Document _attachments property
-	delta       *RevisionDelta  // Available delta *from* this revision
-	deleted     bool            // True if revision is a tombstone
-	err         error           // Error from loaderFunc if it failed
-	lock        sync.RWMutex    // Synchronizes access to this struct
-	body        Body            // unmarshalled body (if available)
-	removed     bool            // True if revision is a removal
+	err         error
+	history     Revisions
+	channels    base.Set
+	expiry      *time.Time
+	attachments AttachmentsMeta
+	delta       *RevisionDelta
+	body        Body
+	key         IDAndRev
+	bodyBytes   []byte
+	lock        sync.RWMutex
+	deleted     bool
+	removed     bool
 }
 
 // Creates a revision cache with the given capacity and an optional loader function.

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -457,7 +457,6 @@ func TestInvalidate(t *testing.T) {
 	docRev, err := collection.revisionCache.Get(base.TestCtx(t), "doc", rev1id, true, true)
 	assert.NoError(t, err)
 	assert.Equal(t, rev1id, docRev.RevID)
-	assert.False(t, docRev.Invalid)
 	assert.Equal(t, int64(0), db.DbStats.Cache().RevisionCacheMisses.Value())
 
 	collection.revisionCache.Invalidate(base.TestCtx(t), "doc", rev1id)
@@ -465,26 +464,22 @@ func TestInvalidate(t *testing.T) {
 	docRev, err = collection.revisionCache.Get(base.TestCtx(t), "doc", rev1id, true, true)
 	assert.NoError(t, err)
 	assert.Equal(t, rev1id, docRev.RevID)
-	assert.True(t, docRev.Invalid)
 	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheMisses.Value())
 
 	docRev, err = collection.revisionCache.GetActive(base.TestCtx(t), "doc", true)
 	assert.NoError(t, err)
 	assert.Equal(t, rev1id, docRev.RevID)
-	assert.True(t, docRev.Invalid)
-	assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheMisses.Value())
+	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheMisses.Value())
 
 	docRev, err = collection.GetRev(ctx, "doc", docRev.RevID, true, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, rev1id, docRev.RevID)
-	assert.True(t, docRev.Invalid)
-	assert.Equal(t, int64(3), db.DbStats.Cache().RevisionCacheMisses.Value())
+	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheMisses.Value())
 
 	docRev, err = collection.GetRev(ctx, "doc", "", true, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, rev1id, docRev.RevID)
-	assert.True(t, docRev.Invalid)
-	assert.Equal(t, int64(4), db.DbStats.Cache().RevisionCacheMisses.Value())
+	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheMisses.Value())
 }
 
 func BenchmarkRevisionCacheRead(b *testing.B) {


### PR DESCRIPTION
Change `Invalidate` function from rev cache to remove the value from the cache. Ran `-race` 10 times without issues.

[x] https://jenkins.sgwdev.com/job/SyncGateway-Integration/1987/