### PR TITLE
CBG-3382: Catch invalid state transition in asyncDatabaseOnline

### DIFF
--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -934,7 +934,7 @@ func (sc *ServerContext) asyncDatabaseOnline(nonCancelCtx base.NonCancellableCon
 
 	if !atomic.CompareAndSwapUint32(&dbc.State, db.DBStarting, db.DBOnline) {
 		// 2nd atomic might end up being Starting here if there's a legitimate race, but it's the most we can do for CAS
-		panic(fmt.Sprintf("database state wasn't Starting during asyncDatabaseOnline Online transition... now %q", db.RunStateString[atomic.LoadUint32(&dbc.State)]))
+		base.PanicfCtx(ctx, "database state wasn't Starting during asyncDatabaseOnline Online transition... now %q", db.RunStateString[atomic.LoadUint32(&dbc.State)])
 	}
 
 	stateChangeMsg := "DB loaded from config"

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -929,12 +929,16 @@ func (sc *ServerContext) asyncDatabaseOnline(nonCancelCtx base.NonCancellableCon
 	if err != nil {
 		base.InfofCtx(ctx, base.KeyAll, "Error starting online processes after async initialization: %v", err)
 		atomic.CompareAndSwapUint32(&dbc.State, db.DBStarting, db.DBOffline)
+		return
+	}
+
+	if !atomic.CompareAndSwapUint32(&dbc.State, db.DBStarting, db.DBOnline) {
+		// 2nd atomic might end up being Starting here if there's a legitimate race, but it's the most we can do for CAS
+		panic(fmt.Sprintf("database state wasn't Starting during asyncDatabaseOnline Online transition... now %q", db.RunStateString[atomic.LoadUint32(&dbc.State)]))
 	}
 
 	stateChangeMsg := "DB loaded from config"
-	atomic.StoreUint32(&dbc.State, db.DBOnline)
 	_ = dbc.EventMgr.RaiseDBStateChangeEvent(dbc.Name, "online", stateChangeMsg, &sc.Config.API.AdminInterface)
-
 }
 
 func (sc *ServerContext) GetDbVersion(dbName string) string {


### PR DESCRIPTION
Spun out of #6388 

CBG-3382

- Test to force an error from `StartOnlineProcesses` from `asyncDatabaseOnline` that causes an invalid state transition via missed `return`
- Catch and panic with `atomic.CompareAndSwap`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/1989/
