### PR TITLE
[3.1.2 Backport] CBG-3270: Logging context changes

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -107,9 +107,9 @@ func putDDocForTombstones(name string, payload []byte, capiEps []string, client 
 
 // QueryBucketItemCount uses a request plus query to get the number of items in a bucket, as the REST API can be slow to update its value.
 // Requires a primary index on the bucket.
-func QueryBucketItemCount(n1qlStore N1QLStore) (itemCount int, err error) {
+func QueryBucketItemCount(ctx context.Context, n1qlStore N1QLStore) (itemCount int, err error) {
 	statement := fmt.Sprintf("SELECT COUNT(1) AS count FROM %s", KeyspaceQueryToken)
-	r, err := n1qlStore.Query(statement, nil, RequestPlus, true)
+	r, err := n1qlStore.Query(ctx, statement, nil, RequestPlus, true)
 	if err != nil {
 		return -1, err
 	}

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -91,7 +91,7 @@ func TestN1qlQuery(t *testing.T) {
 	params := make(map[string]interface{})
 	params["minvalue"] = 2
 
-	queryResults, queryErr := n1qlStore.Query(queryExpression, params, RequestPlus, false)
+	queryResults, queryErr := n1qlStore.Query(ctx, queryExpression, params, RequestPlus, false)
 	require.NoError(t, queryErr, "Error executing n1ql query")
 
 	// Struct to receive the query response (META().id, val)
@@ -117,7 +117,7 @@ func TestN1qlQuery(t *testing.T) {
 	params = make(map[string]interface{})
 	params["minvalue"] = 10
 
-	queryResults, queryErr = n1qlStore.Query(queryExpression, params, RequestPlus, false)
+	queryResults, queryErr = n1qlStore.Query(ctx, queryExpression, params, RequestPlus, false)
 	assert.NoError(t, queryErr, "Error executing n1ql query")
 
 	count = 0
@@ -187,7 +187,7 @@ func TestN1qlFilterExpression(t *testing.T) {
 
 	// Query the index
 	queryExpression := fmt.Sprintf("SELECT META().id, val FROM %s WHERE %s AND META().id = 'doc1'", KeyspaceQueryToken, filterExpression)
-	queryResults, queryErr := n1qlStore.Query(queryExpression, nil, RequestPlus, false)
+	queryResults, queryErr := n1qlStore.Query(ctx, queryExpression, nil, RequestPlus, false)
 	require.NoError(t, queryErr, "Error executing n1ql query")
 
 	// Struct to receive the query response (META().id, val)
@@ -316,26 +316,26 @@ func TestMalformedN1qlQuery(t *testing.T) {
 	// Query with syntax error
 	queryExpression := "SELECT META().id, val WHERE val > $minvalue"
 	params := make(map[string]interface{})
-	_, queryErr := n1qlStore.Query(queryExpression, params, RequestPlus, false)
+	_, queryErr := n1qlStore.Query(ctx, queryExpression, params, RequestPlus, false)
 	assert.True(t, queryErr != nil, "Expected error for malformed n1ql query (syntax)")
 
 	// Query against non-existing bucket
 	queryExpression = fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > $minvalue", "badBucket")
 	params = map[string]interface{}{"minvalue": 2}
-	_, queryErr = n1qlStore.Query(queryExpression, params, RequestPlus, false)
+	_, queryErr = n1qlStore.Query(ctx, queryExpression, params, RequestPlus, false)
 	assert.True(t, queryErr != nil, "Expected error for malformed n1ql query (no bucket)")
 
 	// Specify params for non-parameterized query (no error expected, ensure doesn't break)
 	queryExpression = fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > 5", KeyspaceQueryToken)
 	params = map[string]interface{}{"minvalue": 2}
-	queryResults, queryErr := n1qlStore.Query(queryExpression, params, RequestPlus, false)
+	queryResults, queryErr := n1qlStore.Query(ctx, queryExpression, params, RequestPlus, false)
 	require.True(t, queryErr == nil, "Unexpected error for malformed n1ql query (extra params)")
 	assert.NoError(t, queryResults.Close())
 
 	// Omit params for parameterized query
 	queryExpression = fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > $minvalue", KeyspaceQueryToken)
 	params = map[string]interface{}{"othervalue": 2}
-	results, queryErr := n1qlStore.Query(queryExpression, params, RequestPlus, false)
+	results, queryErr := n1qlStore.Query(ctx, queryExpression, params, RequestPlus, false)
 	if queryErr == nil {
 		for results.NextBytes() != nil {
 		}

--- a/base/collection.go
+++ b/base/collection.go
@@ -247,9 +247,9 @@ func (b *GocbV2Bucket) IsSupported(feature sgbucket.BucketStoreFeature) bool {
 	}
 }
 
-func (b *GocbV2Bucket) StartDCPFeed(args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
+func (b *GocbV2Bucket) StartDCPFeed(ctx context.Context, args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
 	groupID := ""
-	return StartGocbDCPFeed(b, b.Spec.BucketName, args, callback, dbStats, DCPMetadataStoreInMemory, groupID)
+	return StartGocbDCPFeed(ctx, b, b.Spec.BucketName, args, callback, dbStats, DCPMetadataStoreInMemory, groupID)
 }
 
 func (b *GocbV2Bucket) StartTapFeed(args sgbucket.FeedArguments, dbStats *expvar.Map) (sgbucket.MutationFeed, error) {

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -67,9 +67,7 @@ func (c *Collection) IndexMetaKeyspaceID() string {
 	return IndexMetaKeyspaceID(c.BucketName(), c.ScopeName(), c.CollectionName())
 }
 
-func (c *Collection) Query(statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (resultsIterator sgbucket.QueryResultIterator, err error) {
-	logCtx := context.TODO()
-
+func (c *Collection) Query(ctx context.Context, statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (resultsIterator sgbucket.QueryResultIterator, err error) {
 	keyspaceStatement := strings.Replace(statement, KeyspaceQueryToken, c.EscapedKeyspace(), -1)
 
 	n1qlOptions := &gocb.QueryOptions{
@@ -80,7 +78,7 @@ func (c *Collection) Query(statement string, params map[string]interface{}, cons
 
 	waitTime := 10 * time.Millisecond
 	for i := 1; i <= MaxQueryRetries; i++ {
-		TracefCtx(logCtx, KeyQuery, "Executing N1QL query: %v - %+v", UD(keyspaceStatement), UD(params))
+		TracefCtx(ctx, KeyQuery, "Executing N1QL query: %v - %+v", UD(keyspaceStatement), UD(params))
 		queryResults, queryErr := c.Bucket.runQuery(keyspaceStatement, n1qlOptions)
 		if queryErr == nil {
 			resultsIterator := &gocbRawIterator{
@@ -97,24 +95,24 @@ func (c *Collection) Query(statement string, params map[string]interface{}, cons
 
 		// Non-retry error - return
 		if !isTransientIndexerError(queryErr) {
-			WarnfCtx(logCtx, "Error when querying index using statement: [%s] parameters: [%+v] error:%v", UD(keyspaceStatement), UD(params), queryErr)
+			WarnfCtx(ctx, "Error when querying index using statement: [%s] parameters: [%+v] error:%v", UD(keyspaceStatement), UD(params), queryErr)
 			return resultsIterator, pkgerrors.WithStack(queryErr)
 		}
 
 		// Indexer error - wait then retry
 		err = queryErr
-		WarnfCtx(logCtx, "Indexer error during query - retry %d/%d after %v.  Error: %v", i, MaxQueryRetries, waitTime, queryErr)
+		WarnfCtx(ctx, "Indexer error during query - retry %d/%d after %v.  Error: %v", i, MaxQueryRetries, waitTime, queryErr)
 		time.Sleep(waitTime)
 
 		waitTime = waitTime * 2
 	}
 
-	WarnfCtx(logCtx, "Exceeded max retries for query when querying index using statement: [%s] parameters: [%+v], err:%v", UD(keyspaceStatement), UD(params), err)
+	WarnfCtx(ctx, "Exceeded max retries for query when querying index using statement: [%s] parameters: [%+v], err:%v", UD(keyspaceStatement), UD(params), err)
 	return nil, err
 }
 
-func (c *Collection) ExplainQuery(statement string, params map[string]interface{}) (plan map[string]interface{}, err error) {
-	return ExplainQuery(c, statement, params)
+func (c *Collection) ExplainQuery(ctx context.Context, statement string, params map[string]interface{}) (plan map[string]interface{}, err error) {
+	return ExplainQuery(ctx, c, statement, params)
 }
 
 func (c *Collection) CreateIndex(ctx context.Context, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -42,9 +42,9 @@ type N1QLStore interface {
 	CreateIndex(ctx context.Context, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error
 	CreatePrimaryIndex(ctx context.Context, indexName string, options *N1qlIndexOptions) error
 	DropIndex(ctx context.Context, indexName string) error
-	ExplainQuery(statement string, params map[string]interface{}) (plan map[string]interface{}, err error)
+	ExplainQuery(ctx context.Context, statement string, params map[string]interface{}) (plan map[string]interface{}, err error)
 	GetIndexMeta(ctx context.Context, indexName string) (exists bool, meta *IndexMeta, err error)
-	Query(statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (results sgbucket.QueryResultIterator, err error)
+	Query(ctx context.Context, statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (results sgbucket.QueryResultIterator, err error)
 	IsErrNoResults(error) bool
 	EscapedKeyspace() string
 	IndexMetaBucketID() string
@@ -66,9 +66,9 @@ type N1QLStore interface {
 	waitUntilQueryServiceReady(timeout time.Duration) error
 }
 
-func ExplainQuery(store N1QLStore, statement string, params map[string]interface{}) (plan map[string]interface{}, err error) {
+func ExplainQuery(ctx context.Context, store N1QLStore, statement string, params map[string]interface{}) (plan map[string]interface{}, err error) {
 	explainStatement := fmt.Sprintf("EXPLAIN %s", statement)
-	explainResults, explainErr := store.Query(explainStatement, params, RequestPlus, true)
+	explainResults, explainErr := store.Query(ctx, explainStatement, params, RequestPlus, true)
 
 	if explainErr != nil {
 		return nil, explainErr

--- a/base/gocb_dcp_feed.go
+++ b/base/gocb_dcp_feed.go
@@ -48,7 +48,7 @@ func getHighSeqMetadata(cbstore CouchbaseBucketStore) ([]DCPMetadata, error) {
 }
 
 // StartGocbDCPFeed starts a DCP Feed.
-func StartGocbDCPFeed(bucket *GocbV2Bucket, bucketName string, args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map, metadataStoreType DCPMetadataStoreType, groupID string) error {
+func StartGocbDCPFeed(ctx context.Context, bucket *GocbV2Bucket, bucketName string, args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map, metadataStoreType DCPMetadataStoreType, groupID string) error {
 
 	feedName, err := GenerateDcpStreamName(args.ID)
 	if err != nil {
@@ -107,43 +107,42 @@ func StartGocbDCPFeed(bucket *GocbV2Bucket, bucketName string, args sgbucket.Fee
 	}
 
 	doneChan, err := dcpClient.Start()
-	loggingCtx := context.TODO()
 	if err != nil {
-		ErrorfCtx(loggingCtx, "Failed to start DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), err)
+		ErrorfCtx(ctx, "Failed to start DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), err)
 		// simplify in CBG-2234
 		closeErr := dcpClient.Close()
-		ErrorfCtx(loggingCtx, "Finished called async close error from DCP Feed %q for bucket %q", feedName, MD(bucketName))
+		ErrorfCtx(ctx, "Finished called async close error from DCP Feed %q for bucket %q", feedName, MD(bucketName))
 		if closeErr != nil {
-			ErrorfCtx(loggingCtx, "Close error from DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), closeErr)
+			ErrorfCtx(ctx, "Close error from DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), closeErr)
 		}
 		asyncCloseErr := <-doneChan
-		ErrorfCtx(loggingCtx, "Finished calling async close error from DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), asyncCloseErr)
+		ErrorfCtx(ctx, "Finished calling async close error from DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), asyncCloseErr)
 		return err
 	}
-	InfofCtx(loggingCtx, KeyDCP, "Started DCP Feed %q for bucket %q", feedName, MD(bucketName))
+	InfofCtx(ctx, KeyDCP, "Started DCP Feed %q for bucket %q", feedName, MD(bucketName))
 	go func() {
 		select {
 		case dcpCloseError := <-doneChan:
 			// simplify close in CBG-2234
 			// This is a close because DCP client closed on its own, which should never happen since once
 			// DCP feed is started, there is nothing that will close it
-			InfofCtx(loggingCtx, KeyDCP, "Forced closed DCP Feed %q for %q", feedName, MD(bucketName))
+			InfofCtx(ctx, KeyDCP, "Forced closed DCP Feed %q for %q", feedName, MD(bucketName))
 			// wait for channel close
 			<-doneChan
 			if dcpCloseError != nil {
-				WarnfCtx(loggingCtx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseError)
+				WarnfCtx(ctx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseError)
 			}
 			// FIXME: close dbContext here
 			break
 		case <-args.Terminator:
-			InfofCtx(loggingCtx, KeyDCP, "Closing DCP Feed %q for bucket %q based on termination notification", feedName, MD(bucketName))
+			InfofCtx(ctx, KeyDCP, "Closing DCP Feed %q for bucket %q based on termination notification", feedName, MD(bucketName))
 			dcpCloseErr := dcpClient.Close()
 			if dcpCloseErr != nil {
-				WarnfCtx(loggingCtx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseErr)
+				WarnfCtx(ctx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseErr)
 			}
 			dcpCloseErr = <-doneChan
 			if dcpCloseErr != nil {
-				WarnfCtx(loggingCtx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseErr)
+				WarnfCtx(ctx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseErr)
 			}
 			break
 		}

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -10,6 +10,7 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"expvar"
 	"fmt"
 	"math"
@@ -203,8 +204,8 @@ func (b *LeakyBucket) StartTapFeed(args sgbucket.FeedArguments, dbStats *expvar.
 
 }
 
-func (b *LeakyBucket) StartDCPFeed(args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
-	return b.bucket.StartDCPFeed(args, callback, dbStats)
+func (b *LeakyBucket) StartDCPFeed(ctx context.Context, args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
+	return b.bucket.StartDCPFeed(ctx, args, callback, dbStats)
 }
 
 type EventUpdateFunc func(event *sgbucket.FeedEvent) bool

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -49,7 +50,7 @@ type ConsoleLoggerConfig struct {
 }
 
 // NewConsoleLogger returns a new ConsoleLogger from a config.
-func NewConsoleLogger(shouldLogLocation bool, config *ConsoleLoggerConfig) (*ConsoleLogger, error) {
+func NewConsoleLogger(ctx context.Context, shouldLogLocation bool, config *ConsoleLoggerConfig) (*ConsoleLogger, error) {
 	if config == nil {
 		config = &ConsoleLoggerConfig{}
 	}
@@ -92,9 +93,9 @@ func NewConsoleLogger(shouldLogLocation bool, config *ConsoleLoggerConfig) (*Con
 			if config.FileOutput != "" {
 				consoleOutput = config.FileOutput
 			}
-			Consolef(LevelInfo, KeyNone, "Logging: Console to %v", consoleOutput)
+			ConsolefCtx(ctx, LevelInfo, KeyNone, "Logging: Console to %v", consoleOutput)
 		} else {
-			Consolef(LevelInfo, KeyNone, "Logging: Console disabled")
+			ConsolefCtx(ctx, LevelInfo, KeyNone, "Logging: Console disabled")
 		}
 	}
 
@@ -216,8 +217,8 @@ func (lcc *ConsoleLoggerConfig) init() error {
 	return nil
 }
 
-func mustInitConsoleLogger(config *ConsoleLoggerConfig) *ConsoleLogger {
-	logger, err := NewConsoleLogger(false, config)
+func mustInitConsoleLogger(ctx context.Context, config *ConsoleLoggerConfig) *ConsoleLogger {
+	logger, err := NewConsoleLogger(ctx, false, config)
 	if err != nil {
 		// TODO: CBG-1948
 		panic(err)

--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -97,7 +97,7 @@ func TestConsoleShouldLog(t *testing.T) {
 			test.loggerLevel.StringShort(), test.loggerKeys,
 			test.logToLevel.StringShort(), test.logToKey)
 
-		l := mustInitConsoleLogger(&ConsoleLoggerConfig{
+		l := mustInitConsoleLogger(TestCtx(t), &ConsoleLoggerConfig{
 			LogLevel: &test.loggerLevel,
 			LogKeys:  test.loggerKeys,
 			FileLoggerConfig: FileLoggerConfig{
@@ -118,7 +118,7 @@ func BenchmarkConsoleShouldLog(b *testing.B) {
 			test.loggerLevel.StringShort(), test.loggerKeys,
 			test.logToLevel.StringShort(), test.logToKey)
 
-		l := mustInitConsoleLogger(&ConsoleLoggerConfig{
+		l := mustInitConsoleLogger(TestCtx(b), &ConsoleLoggerConfig{
 			LogLevel: &test.loggerLevel,
 			LogKeys:  test.loggerKeys,
 			FileLoggerConfig: FileLoggerConfig{
@@ -184,7 +184,7 @@ func TestConsoleLogDefaults(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			logger, err := NewConsoleLogger(false, &test.config)
+			logger, err := NewConsoleLogger(TestCtx(tt), false, &test.config)
 			assert.NoError(tt, err)
 			assert.Equal(tt, test.expected.Enabled, logger.Enabled)
 			assert.Equal(tt, *test.expected.LogLevel, *logger.LogLevel)

--- a/base/logging.go
+++ b/base/logging.go
@@ -132,7 +132,8 @@ func PanicfCtx(ctx context.Context, format string, args ...interface{}) {
 	if errorLogger == nil {
 		log.Panicf(format, args...)
 	}
-	logTo(ctx, LevelError, KeyAll, format, args...)
+	// ensure the log message always reaches console
+	ConsolefCtx(ctx, LevelError, KeyAll, format, args...)
 	FlushLogBuffers()
 	panic(fmt.Sprintf(format, args...))
 }
@@ -143,7 +144,8 @@ func FatalfCtx(ctx context.Context, format string, args ...interface{}) {
 	if errorLogger == nil {
 		log.Fatalf(format, args...)
 	}
-	logTo(ctx, LevelError, KeyAll, format, args...)
+	// ensure the log message always reaches console
+	ConsolefCtx(ctx, LevelError, KeyAll, format, args...)
 	FlushLogBuffers()
 	os.Exit(1)
 }

--- a/base/logging.go
+++ b/base/logging.go
@@ -122,7 +122,7 @@ func init() {
 	// initializing a logging config, and when running under a test scenario.
 	initialCollationBufferSize := 0
 
-	consoleLogger = mustInitConsoleLogger(&ConsoleLoggerConfig{FileLoggerConfig: FileLoggerConfig{Enabled: BoolPtr(true), CollationBufferSize: &initialCollationBufferSize}})
+	consoleLogger = mustInitConsoleLogger(context.Background(), &ConsoleLoggerConfig{FileLoggerConfig: FileLoggerConfig{Enabled: BoolPtr(true), CollationBufferSize: &initialCollationBufferSize}})
 	initExternalLoggers()
 }
 
@@ -240,24 +240,24 @@ func logTo(ctx context.Context, logLevel LogLevel, logKey LogKey, format string,
 
 var consoleFOutput io.Writer = os.Stderr
 
-// Consolef logs the given formatted string and args to the given log level and log key,
+// ConsolefCtx logs the given formatted string and args to the given log level and log key,
 // as well as making sure the message is *always* logged to stdout.
-func Consolef(logLevel LogLevel, logKey LogKey, format string, args ...interface{}) {
-	logTo(context.Background(), logLevel, logKey, format, args...)
+func ConsolefCtx(ctx context.Context, logLevel LogLevel, logKey LogKey, format string, args ...interface{}) {
+	logTo(ctx, logLevel, logKey, format, args...)
 
 	// If the above logTo didn't already log to stderr, do it directly here
 	if !consoleLogger.isStderr || !consoleLogger.shouldLog(logLevel, logKey) {
-		format = color(addPrefixes(format, context.Background(), logLevel, logKey), logLevel)
+		format = color(addPrefixes(format, ctx, logLevel, logKey), logLevel)
 		_, _ = fmt.Fprintf(consoleFOutput, format+"\n", args...)
 	}
 }
 
 // LogSyncGatewayVersion will print the '==== name/version ====' startup indicator to ALL log outputs.
-func LogSyncGatewayVersion() {
+func LogSyncGatewayVersion(ctx context.Context) {
 	msg := fmt.Sprintf("==== %s ====", LongVersionString)
 
 	// Log the startup indicator to the stderr.
-	Consolef(LevelNone, KeyNone, msg)
+	ConsolefCtx(ctx, LevelNone, KeyNone, msg)
 
 	// Log the startup indicator to ALL log files too.
 	msg = addPrefixes(msg, context.Background(), LevelNone, KeyNone)

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -55,20 +56,20 @@ type LegacyLoggingConfig struct {
 	Stats          FileLoggerConfig    `json:"stats,omitempty"`           // Stats log file output
 }
 
-func InitLogging(logFilePath string,
+func InitLogging(ctx context.Context, logFilePath string,
 	console *ConsoleLoggerConfig,
 	error, warn, info, debug, trace, stats *FileLoggerConfig) (err error) {
 
-	consoleLogger, err = NewConsoleLogger(true, console)
+	consoleLogger, err = NewConsoleLogger(ctx, true, console)
 	if err != nil {
 		return err
 	}
 
 	// If there's nowhere to specified put log files, we'll log an error, but continue anyway.
 	if logFilePath == "" {
-		Consolef(LevelInfo, KeyNone, "Logging: Files disabled")
+		ConsolefCtx(ctx, LevelInfo, KeyNone, "Logging: Files disabled")
 		// Explicitly log this error to console
-		Consolef(LevelError, KeyNone, ErrUnsetLogFilePath.Error())
+		ConsolefCtx(ctx, LevelError, KeyNone, ErrUnsetLogFilePath.Error())
 
 		// nil out other loggers
 		errorLogger = nil
@@ -85,7 +86,7 @@ func InitLogging(logFilePath string,
 	if err != nil {
 		return err
 	} else {
-		Consolef(LevelInfo, KeyNone, "Logging: Files to %v", logFilePath)
+		ConsolefCtx(ctx, LevelInfo, KeyNone, "Logging: Files to %v", logFilePath)
 	}
 
 	errorLogger, err = NewFileLogger(error, LevelError, LevelError.String(), logFilePath, errorMinAge, &errorLogger.buffer)

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -198,7 +198,7 @@ func TestLogSyncGatewayVersion(t *testing.T) {
 	for i := LevelNone; i < levelCount; i++ {
 		t.Run(i.String(), func(t *testing.T) {
 			consoleLogger.LogLevel.Set(i)
-			out := CaptureConsolefLogOutput(LogSyncGatewayVersion)
+			out := CaptureConsolefLogOutput(func() { LogSyncGatewayVersion(TestCtx(t)) })
 			assert.Contains(t, out, LongVersionString)
 		})
 	}

--- a/channels/channelmapper.go
+++ b/channels/channelmapper.go
@@ -9,6 +9,7 @@
 package channels
 
 import (
+	"context"
 	"encoding/json"
 	"strconv"
 	"time"
@@ -42,11 +43,11 @@ const kTaskCacheSize = 16
 const DocChannelsSyncFunction = `function(doc){channel(doc.channels);}`
 
 // NewChannelMapper creates a new channel mapper with a specific javascript function and a timeout. A zero value timeout will never timeout.
-func NewChannelMapper(fnSource string, timeout time.Duration) *ChannelMapper {
+func NewChannelMapper(ctx context.Context, fnSource string, timeout time.Duration) *ChannelMapper {
 	return &ChannelMapper{
 		JSServer: sgbucket.NewJSServer(fnSource, timeout, kTaskCacheSize,
 			func(fnSource string, timeout time.Duration) (sgbucket.JSServerTask, error) {
-				return NewSyncRunner(fnSource, timeout)
+				return NewSyncRunner(ctx, fnSource, timeout)
 			}),
 	}
 }

--- a/channels/channelmapper_test.go
+++ b/channels/channelmapper_test.go
@@ -51,7 +51,7 @@ func TestOttoValueToStringArray(t *testing.T) {
 
 // verify that our version of Otto treats JSON parsed arrays like real arrays
 func TestJavaScriptWorks(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {channel(doc.x.concat(doc.y));}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {channel(doc.x.concat(doc.y));}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"x":["abc"],"y":["xyz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "abc", "xyz"), res.Channels)
@@ -59,7 +59,7 @@ func TestJavaScriptWorks(t *testing.T) {
 
 // Just verify that the calls to the channel() fn show up in the output channel list.
 func TestSyncFunction(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {channel("foo", "bar"); channel("baz")}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {channel("foo", "bar"); channel("baz")}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo", "bar", "baz"), res.Channels)
@@ -67,7 +67,7 @@ func TestSyncFunction(t *testing.T) {
 
 // Just verify that the calls to the access() fn show up in the output channel list.
 func TestAccessFunction(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access("foo", "bar"); access("foo", "baz")}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access("foo", "bar"); access("foo", "baz")}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"foo": BaseSetOf(t, "bar", "baz")}, res.Access)
@@ -75,7 +75,7 @@ func TestAccessFunction(t *testing.T) {
 
 // Just verify that the calls to the channel() fn show up in the output channel list.
 func TestSyncFunctionTakesArray(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {channel(["foo", "bar ok","baz"])}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {channel(["foo", "bar ok","baz"])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo", "bar ok", "baz"), res.Channels)
@@ -83,21 +83,21 @@ func TestSyncFunctionTakesArray(t *testing.T) {
 
 // Calling channel() with an invalid channel name should return an error.
 func TestSyncFunctionRejectsInvalidChannels(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {channel(["foo", "bad,name","baz"])}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {channel(["foo", "bad,name","baz"])}`, 0)
 	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser)
 	assert.True(t, err != nil)
 }
 
 // Calling access() with an invalid channel name should return an error.
 func TestAccessFunctionRejectsInvalidChannels(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access("foo", "bad,name");}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access("foo", "bad,name");}`, 0)
 	_, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.True(t, err != nil)
 }
 
 // Just verify that the calls to the access() fn show up in the output channel list.
 func TestAccessFunctionTakesArrayOfUsers(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access(["foo","bar","baz"], "ginger")}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access(["foo","bar","baz"], "ginger")}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"bar": BaseSetOf(t, "ginger"), "baz": BaseSetOf(t, "ginger"), "foo": BaseSetOf(t, "ginger")}, res.Access)
@@ -105,14 +105,14 @@ func TestAccessFunctionTakesArrayOfUsers(t *testing.T) {
 
 // Just verify that the calls to the access() fn show up in the output channel list.
 func TestAccessFunctionTakesArrayOfChannels(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access("lee", ["ginger", "earl_grey", "green"])}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access("lee", ["ginger", "earl_grey", "green"])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"lee": BaseSetOf(t, "ginger", "earl_grey", "green")}, res.Access)
 }
 
 func TestAccessFunctionTakesArrayOfChannelsAndUsers(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access(["lee", "nancy"], ["ginger", "earl_grey", "green"])}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access(["lee", "nancy"], ["ginger", "earl_grey", "green"])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "ginger", "earl_grey", "green"), res.Access["lee"])
@@ -120,42 +120,42 @@ func TestAccessFunctionTakesArrayOfChannelsAndUsers(t *testing.T) {
 }
 
 func TestAccessFunctionTakesEmptyArrayUser(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access([], ["ginger", "earl grey", "green"])}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access([], ["ginger", "earl grey", "green"])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
 }
 
 func TestAccessFunctionTakesEmptyArrayChannels(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access("lee", [])}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access("lee", [])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
 }
 
 func TestAccessFunctionTakesNullUser(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access(null, ["ginger", "earl grey", "green"])}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access(null, ["ginger", "earl grey", "green"])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
 }
 
 func TestAccessFunctionTakesNullChannels(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access("lee", null)}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access("lee", null)}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
 }
 
 func TestAccessFunctionTakesNonChannelsInArray(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {access("lee", ["ginger", null, 5])}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {access("lee", ["ginger", null, 5])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"lee": BaseSetOf(t, "ginger")}, res.Access)
 }
 
 func TestAccessFunctionTakesUndefinedUser(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {var x = {}; access(x.nothing, ["ginger", "earl grey", "green"])}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {var x = {}; access(x.nothing, ["ginger", "earl grey", "green"])}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{}, res.Access)
@@ -164,7 +164,7 @@ func TestAccessFunctionTakesUndefinedUser(t *testing.T) {
 // Just verify that the calls to the role() fn show up in the output. (It shares a common
 // implementation with access(), so most of the above tests also apply to it.)
 func TestRoleFunction(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {role(["foo","bar","baz"], "role:froods")}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {role(["foo","bar","baz"], "role:froods")}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, AccessMap{"bar": BaseSetOf(t, "froods"), "baz": BaseSetOf(t, "froods"), "foo": BaseSetOf(t, "froods")}, res.Roles)
@@ -172,7 +172,7 @@ func TestRoleFunction(t *testing.T) {
 
 // Now just make sure the input comes through intact
 func TestInputParse(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {channel(doc.channel);}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {channel(doc.channel);}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "foo"}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo"), res.Channels)
@@ -185,11 +185,11 @@ func TestDefaultChannelMapper(t *testing.T) {
 		name   string
 	}{
 		{
-			mapper: NewChannelMapper(DocChannelsSyncFunction, 0),
+			mapper: NewChannelMapper(base.TestCtx(t), DocChannelsSyncFunction, 0),
 			name:   "explicit_function",
 		},
 		{
-			mapper: NewChannelMapper(GetDefaultSyncFunction(base.DefaultScope, base.DefaultCollection), 0),
+			mapper: NewChannelMapper(base.TestCtx(t), GetDefaultSyncFunction(base.DefaultScope, base.DefaultCollection), 0),
 			name:   "explicit_function",
 		},
 	}
@@ -209,7 +209,7 @@ func TestDefaultChannelMapper(t *testing.T) {
 
 // Empty/no-op channel mapper fn
 func TestEmptyChannelMapper(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.Set{}, res.Channels)
@@ -219,7 +219,7 @@ func TestEmptyChannelMapper(t *testing.T) {
 func TestChannelMapperUnderscoreLib(t *testing.T) {
 	underscore.Enable() // It really slows down unit tests (by making otto.New take a lot longer)
 	defer underscore.Disable()
-	mapper := NewChannelMapper(`function(doc) {channel(_.first(doc.channels));}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {channel(_.first(doc.channels));}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo"), res.Channels)
@@ -227,7 +227,7 @@ func TestChannelMapperUnderscoreLib(t *testing.T) {
 
 // Validation by calling reject()
 func TestChannelMapperReject(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {reject(403, "bad");}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {reject(403, "bad");}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, "bad"), res.Rejection)
@@ -235,7 +235,7 @@ func TestChannelMapperReject(t *testing.T) {
 
 // Rejection by calling throw()
 func TestChannelMapperThrow(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {throw({forbidden:"bad"});}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {throw({forbidden:"bad"});}`, 0)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, base.HTTPErrorf(403, "bad"), res.Rejection)
@@ -243,14 +243,14 @@ func TestChannelMapperThrow(t *testing.T) {
 
 // Test other runtime exception
 func TestChannelMapperException(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {(nil)[5];}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {(nil)[5];}`, 0)
 	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.True(t, err != nil)
 }
 
 // Test the public API
 func TestPublicChannelMapper(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {channel(doc.channels);}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {channel(doc.channels);}`, 0)
 	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, BaseSetOf(t, "foo", "bar", "baz"), output.Channels)
@@ -258,7 +258,7 @@ func TestPublicChannelMapper(t *testing.T) {
 
 // Test the userCtx name parameter
 func TestCheckUser(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc, oldDoc) {
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc, oldDoc) {
 			requireUser(doc.owner);
 		}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "channels": []string{}}
@@ -278,7 +278,7 @@ func TestCheckUser(t *testing.T) {
 
 // Test the userCtx name parameter with a list
 func TestCheckUserArray(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc, oldDoc) {
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc, oldDoc) {
 			requireUser(doc.owners);
 		}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "channels": []string{}}
@@ -298,7 +298,7 @@ func TestCheckUserArray(t *testing.T) {
 
 // Test the userCtx role parameter
 func TestCheckRole(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc, oldDoc) {
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc, oldDoc) {
 			requireRole(doc.role);
 		}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "roles": map[string]int{"girl": 1, "5yo": 1}}
@@ -318,7 +318,7 @@ func TestCheckRole(t *testing.T) {
 
 // Test the userCtx role parameter with a list
 func TestCheckRoleArray(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc, oldDoc) {
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc, oldDoc) {
 			requireRole(doc.roles);
 		}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "roles": map[string]int{"girl": 1, "5yo": 1}}
@@ -338,7 +338,7 @@ func TestCheckRoleArray(t *testing.T) {
 
 // Test the userCtx.channels parameter
 func TestCheckAccess(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc, oldDoc) {
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc, oldDoc) {
 		requireAccess(doc.channel)
 	}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "roles": []string{"girl", "5yo"}, "channels": []string{"party", "school"}}
@@ -358,7 +358,7 @@ func TestCheckAccess(t *testing.T) {
 
 // Test the userCtx.channels parameter with a list
 func TestCheckAccessArray(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc, oldDoc) {
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc, oldDoc) {
 		requireAccess(doc.channels)
 	}`, 0)
 	var sally = map[string]interface{}{"name": "sally", "roles": []string{"girl", "5yo"}, "channels": []string{"party", "school"}}
@@ -378,7 +378,7 @@ func TestCheckAccessArray(t *testing.T) {
 
 // Test changing the function
 func TestSetFunction(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {channel(doc.channels);}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {channel(doc.channels);}`, 0)
 	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	changed, err := mapper.SetFunction(`function(doc) {channel("all");}`)
@@ -391,7 +391,7 @@ func TestSetFunction(t *testing.T) {
 
 // Test that expiry function sets the expiry property
 func TestExpiryFunction(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {expiry(doc.expiry);}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {expiry(doc.expiry);}`, 0)
 	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(100), *res1.Expiry)
@@ -436,53 +436,53 @@ func TestExpiryFunction(t *testing.T) {
 }
 
 func TestExpiryFunctionConstantValue(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {expiry(100);}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {expiry(100);}`, 0)
 	res1, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(100), *res1.Expiry)
 
-	mapper = NewChannelMapper(`function(doc) {expiry("500");}`, 0)
+	mapper = NewChannelMapper(base.TestCtx(t), `function(doc) {expiry("500");}`, 0)
 	res2, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(500), *res2.Expiry)
 
-	mapper = NewChannelMapper(`function(doc) {expiry("2105-01-01T00:00:00.000+00:00");}`, 0)
+	mapper = NewChannelMapper(base.TestCtx(t), `function(doc) {expiry("2105-01-01T00:00:00.000+00:00");}`, 0)
 	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	assert.Equal(t, uint32(4260211200), *res_stringDate.Expiry)
 
 	// Validate invalid expiry values log warning and don't set expiry
-	mapper = NewChannelMapper(`function(doc) {expiry("abc");}`, 0)
+	mapper = NewChannelMapper(base.TestCtx(t), `function(doc) {expiry("abc");}`, 0)
 	res3, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:abc")
 	assert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
-	mapper = NewChannelMapper(`function(doc) {expiry(["100", "200"]);}`, 0)
+	mapper = NewChannelMapper(base.TestCtx(t), `function(doc) {expiry(["100", "200"]);}`, 0)
 	res4, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as array")
 	assert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
-	mapper = NewChannelMapper(`function(doc) {expiry(-100);}`, 0)
+	mapper = NewChannelMapper(base.TestCtx(t), `function(doc) {expiry(-100);}`, 0)
 	res5, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as negative value")
 	assert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
-	mapper = NewChannelMapper(`function(doc) {expiry(123456789012345);}`, 0)
+	mapper = NewChannelMapper(base.TestCtx(t), `function(doc) {expiry(123456789012345);}`, 0)
 	res6, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as > unit32")
 	assert.True(t, res6.Expiry == nil)
 
 	// Invalid - non-unix date
-	mapper = NewChannelMapper(`function(doc) {expiry("1805-01-01T00:00:00.000+00:00");}`, 0)
+	mapper = NewChannelMapper(base.TestCtx(t), `function(doc) {expiry("1805-01-01T00:00:00.000+00:00");}`, 0)
 	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:1805-01-01T00:00:00.000+00:00")
 	assert.True(t, resInvalidDate.Expiry == nil)
 
 	// No expiry specified
-	mapper = NewChannelMapper(`function(doc) {expiry();}`, 0)
+	mapper = NewChannelMapper(base.TestCtx(t), `function(doc) {expiry();}`, 0)
 	res7, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry not specified")
 	assert.True(t, res7.Expiry == nil)
@@ -490,7 +490,7 @@ func TestExpiryFunctionConstantValue(t *testing.T) {
 
 // Test that expiry function when invoked more than once by sync function
 func TestExpiryFunctionMultipleInvocation(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc) {expiry(doc.expiry); expiry(doc.secondExpiry)}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc) {expiry(doc.expiry); expiry(doc.secondExpiry)}`, 0)
 	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	assert.Equal(t, uint32(100), *res1.Expiry)
@@ -526,7 +526,7 @@ func TestExpiryFunctionMultipleInvocation(t *testing.T) {
 }
 
 func TestMetaMap(t *testing.T) {
-	mapper := NewChannelMapper(`function(doc, oldDoc, meta) {channel(meta.xattrs.myxattr.channels);}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc, oldDoc, meta) {channel(meta.xattrs.myxattr.channels);}`, 0)
 
 	channels := []string{"chan1", "chan2"}
 
@@ -545,7 +545,7 @@ func TestMetaMap(t *testing.T) {
 
 func TestNilMetaMap(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-	mapper := NewChannelMapper(`function(doc, oldDoc, meta) {channel(meta.xattrs.myxattr.val);}`, 0)
+	mapper := NewChannelMapper(base.TestCtx(t), `function(doc, oldDoc, meta) {channel(meta.xattrs.myxattr.val);}`, 0)
 
 	metaMap := map[string]interface{}{
 		base.MetaMapXattrsKey: map[string]interface{}{
@@ -591,7 +591,7 @@ func TestCollectionSyncFunction(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			collectionName := "barcollection"
-			mapper := NewChannelMapper(GetDefaultSyncFunction("fooscope", collectionName), 0)
+			mapper := NewChannelMapper(base.TestCtx(t), GetDefaultSyncFunction("fooscope", collectionName), 0)
 			res, err := mapper.MapToChannelsAndAccess(parse(test.docBody), `{}`, emptyMetaMap(), noUser)
 			require.NoError(t, err)
 			require.Equal(t, BaseSetOf(t, collectionName), res.Channels)

--- a/channels/sync_runner.go
+++ b/channels/sync_runner.go
@@ -116,8 +116,7 @@ type SyncRunner struct {
 	expiry            *uint32             // document expiry (in seconds) specified via expiry() callback
 }
 
-func NewSyncRunner(funcSource string, timeout time.Duration) (*SyncRunner, error) {
-	ctx := context.Background()
+func NewSyncRunner(ctx context.Context, funcSource string, timeout time.Duration) (*SyncRunner, error) {
 	funcSource = wrappedFuncSource(funcSource)
 	runner := &SyncRunner{}
 	err := runner.InitWithLogging(funcSource, timeout,

--- a/channels/sync_runner_test.go
+++ b/channels/sync_runner_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestRequireUser(t *testing.T) {
 	const funcSource = `function(doc, oldDoc) { requireUser(oldDoc._names) }`
-	runner, err := NewSyncRunner(funcSource, 0)
+	runner, err := NewSyncRunner(base.TestCtx(t), funcSource, 0)
 	require.NoError(t, err)
 	var result interface{}
 	result, _ = runner.Call(parse(`{}`), parse(`{"_names": "alpha"}`), emptyMetaMap(), parse(`{"name": "alpha"}`))
@@ -34,7 +34,7 @@ func TestRequireUser(t *testing.T) {
 
 func TestRequireRole(t *testing.T) {
 	const funcSource = `function(doc, oldDoc) { requireRole(oldDoc._roles) }`
-	runner, err := NewSyncRunner(funcSource, 0)
+	runner, err := NewSyncRunner(base.TestCtx(t), funcSource, 0)
 	require.NoError(t, err)
 	var result interface{}
 	result, _ = runner.Call(parse(`{}`), parse(`{"_roles": ["alpha"]}`), emptyMetaMap(), parse(`{"name": "", "roles": {"alpha":""}}`))
@@ -47,7 +47,7 @@ func TestRequireRole(t *testing.T) {
 
 func TestRequireAccess(t *testing.T) {
 	const funcSource = `function(doc, oldDoc) { requireAccess(oldDoc._access) }`
-	runner, err := NewSyncRunner(funcSource, 0)
+	runner, err := NewSyncRunner(base.TestCtx(t), funcSource, 0)
 	require.NoError(t, err)
 	var result interface{}
 	result, _ = runner.Call(parse(`{}`), parse(`{"_access": ["alpha"]}`), emptyMetaMap(), parse(`{"name": "", "channels": ["alpha"]}`))
@@ -60,7 +60,7 @@ func TestRequireAccess(t *testing.T) {
 
 func TestRequireAdmin(t *testing.T) {
 	const funcSource = `function(doc, oldDoc) { requireAdmin() }`
-	runner, err := NewSyncRunner(funcSource, 0)
+	runner, err := NewSyncRunner(base.TestCtx(t), funcSource, 0)
 	require.NoError(t, err)
 	var result interface{}
 	result, _ = runner.Call(parse(`{}`), parse(`{}`), emptyMetaMap(), parse(`{}`))

--- a/db/access_test.go
+++ b/db/access_test.go
@@ -34,7 +34,7 @@ func TestDynamicChannelGrant(t *testing.T) {
 			channel(doc.channel)
 		}
 	}`
-	dbCollection.ChannelMapper = channels.NewChannelMapper(syncFn, db.Options.JavascriptTimeout)
+	dbCollection.ChannelMapper = channels.NewChannelMapper(ctx, syncFn, db.Options.JavascriptTimeout)
 
 	a := dbCollection.Authenticator(ctx)
 	user, err := a.NewUser("user1", "letmein", nil)

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -215,7 +215,7 @@ func TestAttachmentForRejectedDocument(t *testing.T) {
 	defer db.Close(ctx)
 
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	collection.ChannelMapper = channels.NewChannelMapper(
+	collection.ChannelMapper = channels.NewChannelMapper(ctx,
 		`function(doc, oldDoc) {
 		throw({forbidden: "None shall pass!"});
 	}`, db.Options.JavascriptTimeout)

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -406,7 +406,6 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 		Continuous:     opts.continuous,
 		ActiveOnly:     opts.activeOnly,
 		Revocations:    opts.revocations,
-		LoggingCtx:     bh.loggingCtx,
 		clientType:     opts.clientType,
 		ChangesCtx:     opts.changesCtx,
 		RequestPlusSeq: opts.requestPlusSeq,

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -773,12 +773,12 @@ func (c *changeCache) getChannelCache() ChannelCache {
 
 // ////// CHANGE ACCESS:
 
-func (c *changeCache) GetChanges(channel channels.ID, options ChangesOptions) ([]*LogEntry, error) {
+func (c *changeCache) GetChanges(ctx context.Context, channel channels.ID, options ChangesOptions) ([]*LogEntry, error) {
 
 	if c.stopped.IsTrue() {
 		return nil, base.HTTPErrorf(503, "Database closed")
 	}
-	return c.channelCache.GetChanges(channel, options)
+	return c.channelCache.GetChanges(ctx, channel, options)
 }
 
 // Returns the sequence number the cache is up-to-date with.

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -51,26 +51,26 @@ var EnableStarChannelLog = true
 type changeCache struct {
 	db                 *DatabaseContext
 	logCtx             context.Context
-	logsDisabled       bool                    // If true, ignore incoming tap changes
-	nextSequence       uint64                  // Next consecutive sequence number to add.  State variable for sequence buffering tracking.  Should use getNextSequence() rather than accessing directly.
-	initialSequence    uint64                  // DB's current sequence at startup time. Should use getInitialSequence() rather than accessing directly.
-	receivedSeqs       map[uint64]struct{}     // Set of all sequences received
-	pendingLogs        LogPriorityQueue        // Out-of-sequence entries waiting to be cached
-	notifyChange       func(channels.Set)      // Client callback that notifies of channel changes
-	started            base.AtomicBool         // Set by the Start method
-	stopped            base.AtomicBool         // Set by the Stop method
-	skippedSeqs        *SkippedSequenceList    // Skipped sequences still pending on the TAP feed
-	lock               sync.RWMutex            // Coordinates access to struct fields
-	options            CacheOptions            // Cache config
-	terminator         chan bool               // Signal termination of background goroutines
-	backgroundTasks    []BackgroundTask        // List of background tasks.
-	initTime           time.Time               // Cache init time - used for latency calculations
-	channelCache       ChannelCache            // Underlying channel cache
-	lastAddPendingTime int64                   // The most recent time _addPendingLogs was run, as epoch time
-	internalStats      changeCacheStats        // Running stats for the change cache.  Only applied to expvars on a call to changeCache.updateStats
-	cfgEventCallback   base.CfgEventNotifyFunc // Callback for Cfg updates recieved over the caching feed
-	sgCfgPrefix        string                  // Prefix for SG Cfg doc keys
-	metaKeys           *base.MetadataKeys      // Metadata key formatter
+	logsDisabled       bool                                // If true, ignore incoming tap changes
+	nextSequence       uint64                              // Next consecutive sequence number to add.  State variable for sequence buffering tracking.  Should use getNextSequence() rather than accessing directly.
+	initialSequence    uint64                              // DB's current sequence at startup time. Should use getInitialSequence() rather than accessing directly.
+	receivedSeqs       map[uint64]struct{}                 // Set of all sequences received
+	pendingLogs        LogPriorityQueue                    // Out-of-sequence entries waiting to be cached
+	notifyChange       func(context.Context, channels.Set) // Client callback that notifies of channel changes
+	started            base.AtomicBool                     // Set by the Start method
+	stopped            base.AtomicBool                     // Set by the Stop method
+	skippedSeqs        *SkippedSequenceList                // Skipped sequences still pending on the TAP feed
+	lock               sync.RWMutex                        // Coordinates access to struct fields
+	options            CacheOptions                        // Cache config
+	terminator         chan bool                           // Signal termination of background goroutines
+	backgroundTasks    []BackgroundTask                    // List of background tasks.
+	initTime           time.Time                           // Cache init time - used for latency calculations
+	channelCache       ChannelCache                        // Underlying channel cache
+	lastAddPendingTime int64                               // The most recent time _addPendingLogs was run, as epoch time
+	internalStats      changeCacheStats                    // Running stats for the change cache.  Only applied to expvars on a call to changeCache.updateStats
+	cfgEventCallback   base.CfgEventNotifyFunc             // Callback for Cfg updates recieved over the caching feed
+	sgCfgPrefix        string                              // Prefix for SG Cfg doc keys
+	metaKeys           *base.MetadataKeys                  // Metadata key formatter
 }
 
 type changeCacheStats struct {
@@ -162,7 +162,7 @@ func DefaultCacheOptions() CacheOptions {
 // After calling Init(), you must call .Start() to start useing the cache, otherwise it will be in a locked state
 // and callers will block on trying to obtain the lock.
 
-func (c *changeCache) Init(logCtx context.Context, dbContext *DatabaseContext, channelCache ChannelCache, notifyChange func(channels.Set), options *CacheOptions, metaKeys *base.MetadataKeys) error {
+func (c *changeCache) Init(logCtx context.Context, dbContext *DatabaseContext, channelCache ChannelCache, notifyChange func(context.Context, channels.Set), options *CacheOptions, metaKeys *base.MetadataKeys) error {
 	c.db = dbContext
 	c.logCtx = logCtx
 
@@ -291,7 +291,7 @@ func (c *changeCache) InsertPendingEntries(ctx context.Context) error {
 	c.lock.Lock()
 	changedChannels := c._addPendingLogs()
 	if c.notifyChange != nil && len(changedChannels) > 0 {
-		c.notifyChange(changedChannels)
+		c.notifyChange(ctx, changedChannels)
 	}
 	c.lock.Unlock()
 
@@ -507,7 +507,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 	// Notify change listeners for all of the changed channels
 	if c.notifyChange != nil && len(changedChannelsCombined) > 0 {
-		c.notifyChange(changedChannelsCombined)
+		c.notifyChange(c.logCtx, changedChannelsCombined)
 	}
 
 }
@@ -559,7 +559,7 @@ func (c *changeCache) releaseUnusedSequence(sequence uint64, timeReceived time.T
 	}
 	c.channelCache.AddSkippedSequence(change)
 	if c.notifyChange != nil && len(changedChannels) > 0 {
-		c.notifyChange(changedChannels)
+		c.notifyChange(c.logCtx, changedChannels)
 	}
 }
 
@@ -621,7 +621,7 @@ func (c *changeCache) processPrincipalDoc(docID string, docJSON []byte, isUser b
 
 	changedChannels := c.processEntry(change)
 	if c.notifyChange != nil && len(changedChannels) > 0 {
-		c.notifyChange(changedChannels)
+		c.notifyChange(c.logCtx, changedChannels)
 	}
 }
 

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1996,7 +1996,7 @@ func BenchmarkProcessEntry(b *testing.B) {
 			if bm.warmCacheCount > 0 {
 				for i := 0; i < bm.warmCacheCount; i++ {
 					channel := channels.NewID(fmt.Sprintf("channel_%d", i), collectionID)
-					_, err := changeCache.GetChanges(channel, getChangesOptionsWithZeroSeq())
+					_, err := changeCache.GetChanges(ctx, channel, getChangesOptionsWithZeroSeq())
 					if err != nil {
 						log.Printf("GetChanges failed for changeCache: %v", err)
 						b.Fail()
@@ -2230,7 +2230,7 @@ func BenchmarkDocChanged(b *testing.B) {
 			if bm.warmCacheCount > 0 {
 				for i := 0; i < bm.warmCacheCount; i++ {
 					channel := channels.NewID(fmt.Sprintf("channel_%d", i), collectionID)
-					_, err := changeCache.GetChanges(channel, getChangesOptionsWithZeroSeq())
+					_, err := changeCache.GetChanges(ctx, channel, getChangesOptionsWithZeroSeq())
 					if err != nil {
 						log.Printf("GetChanges failed for changeCache: %v", err)
 						b.Fail()

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1588,7 +1588,7 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 	//  Detect whether the 2nd was ignored using an notifyChange listener callback and make sure it was not added to the ABC channel
 	waitForOnChangeCallback := sync.WaitGroup{}
 	waitForOnChangeCallback.Add(1)
-	db.changeCache.notifyChange = func(chans channels.Set) {
+	db.changeCache.notifyChange = func(_ context.Context, chans channels.Set) {
 		expectedChan := channels.NewID("ABC", collectionID)
 		for ch := range chans {
 			if ch == expectedChan {
@@ -1783,7 +1783,7 @@ func TestNotifyForInactiveChannel(t *testing.T) {
 	// -------- Setup notifyChange callback ----------------
 
 	notifyChannel := make(chan struct{})
-	db.changeCache.notifyChange = func(chans channels.Set) {
+	db.changeCache.notifyChange = func(_ context.Context, chans channels.Set) {
 		expectedChan := channels.NewID("zero", collectionID)
 		if chans.Contains(expectedChan) {
 			notifyChannel <- struct{}{}

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1029,7 +1029,7 @@ func TestChannelQueryCancellation(t *testing.T) {
 	db, ctx := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Write a handful of docs/sequences to the bucket
 	_, _, err := collection.Put(ctx, "key1", Body{"channels": "ABC"})
@@ -1669,7 +1669,7 @@ func TestInitializeEmptyCache(t *testing.T) {
 	db, ctx := setupTestDBWithCacheOptions(t, cacheOptions)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
 	docCount := 0
@@ -1721,7 +1721,7 @@ func TestInitializeCacheUnderLoad(t *testing.T) {
 	db, ctx := setupTestDBWithCacheOptions(t, cacheOptions)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Writes [docCount] documents.  Use wait group (writesDone)to identify when all docs have been written.
 	// Use another waitGroup (writesInProgress) to trigger getChanges midway through writes
@@ -1777,7 +1777,7 @@ func TestNotifyForInactiveChannel(t *testing.T) {
 	defer db.Close(ctx)
 
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 	collectionID := collection.GetCollectionID()
 
 	// -------- Setup notifyChange callback ----------------

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -28,6 +28,7 @@ import (
 // A wrapper around a Bucket's TapFeed that allows any number of client goroutines to wait for
 // changes.
 type changeListener struct {
+	ctx                   context.Context
 	bucket                base.Bucket
 	bucketName            string                 // Used for logging
 	tapFeed               base.TapFeed           // Observes changes to bucket
@@ -62,7 +63,7 @@ func (listener *changeListener) OnDocChanged(event sgbucket.FeedEvent) {
 }
 
 // Starts a changeListener on a given Bucket.
-func (listener *changeListener) Start(bucket base.Bucket, dbStats *expvar.Map, scopes map[string]Scope, metadataStore base.DataStore) error {
+func (listener *changeListener) Start(ctx context.Context, bucket base.Bucket, dbStats *expvar.Map, scopes map[string]Scope, metadataStore base.DataStore) error {
 
 	listener.terminator = make(chan bool)
 	listener.bucket = bucket
@@ -107,10 +108,10 @@ func (listener *changeListener) Start(bucket base.Bucket, dbStats *expvar.Map, s
 		listener.FeedArgs.Scopes = scopeArgs
 
 	}
-	return listener.StartMutationFeed(bucket, dbStats)
+	return listener.StartMutationFeed(ctx, bucket, dbStats)
 }
 
-func (listener *changeListener) StartMutationFeed(bucket base.Bucket, dbStats *expvar.Map) error {
+func (listener *changeListener) StartMutationFeed(ctx context.Context, bucket base.Bucket, dbStats *expvar.Map) error {
 
 	defer func() {
 		listener.started.Set(true)
@@ -145,8 +146,8 @@ func (listener *changeListener) StartMutationFeed(bucket base.Bucket, dbStats *e
 	default:
 		// DCP Feed
 		//    DCP receiver isn't go-channel based - DCPReceiver calls ProcessEvent directly.
-		base.InfofCtx(context.TODO(), base.KeyDCP, "Using DCP feed for bucket: %q (based on feed_type specified in config file)", base.MD(bucket.GetName()))
-		return bucket.StartDCPFeed(listener.FeedArgs, listener.ProcessFeedEvent, dbStats)
+		base.InfofCtx(ctx, base.KeyDCP, "Using DCP feed for bucket: %q (based on feed_type specified in config file)", base.MD(bucket.GetName()))
+		return bucket.StartDCPFeed(ctx, listener.FeedArgs, listener.ProcessFeedEvent, dbStats)
 	}
 }
 
@@ -164,7 +165,7 @@ func (listener *changeListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool 
 			if event.Opcode == sgbucket.FeedOpMutation {
 				listener.OnDocChanged(event)
 			}
-			listener.notifyKey(key)
+			listener.notifyKey(listener.ctx, key)
 		} else if strings.HasPrefix(key, listener.metaKeys.UnusedSeqPrefix()) || strings.HasPrefix(key, listener.metaKeys.UnusedSeqRangePrefix()) { // SG unused sequence marker docs
 			if event.Opcode == sgbucket.FeedOpMutation {
 				listener.OnDocChanged(event)
@@ -187,10 +188,9 @@ func (listener *changeListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool 
 const MutationFeedStopMaxWait = 30 * time.Second
 
 // Stops a changeListener. Any pending Wait() calls will immediately return false.
-func (listener *changeListener) Stop() {
+func (listener *changeListener) Stop(ctx context.Context) {
 
-	logCtx := context.TODO()
-	base.DebugfCtx(logCtx, base.KeyChanges, "changeListener.Stop() called")
+	base.DebugfCtx(ctx, base.KeyChanges, "changeListener.Stop() called")
 
 	if !listener.started.IsTrue() {
 		// not started, nothing to do
@@ -209,7 +209,7 @@ func (listener *changeListener) Stop() {
 	if listener.tapFeed != nil {
 		err := listener.tapFeed.Close()
 		if err != nil {
-			base.DebugfCtx(logCtx, base.KeyChanges, "Error closing listener tap feed: %v", err)
+			base.DebugfCtx(ctx, base.KeyChanges, "Error closing listener tap feed: %v", err)
 		}
 	}
 
@@ -219,7 +219,7 @@ func (listener *changeListener) Stop() {
 	case <-listener.FeedArgs.DoneChan:
 		// Mutation feed worker goroutine is terminated and doneChan is already closed.
 	case <-time.After(waitTime):
-		base.WarnfCtx(logCtx, "Timeout after %v of waiting for mutation feed worker to terminate", waitTime)
+		base.WarnfCtx(ctx, "Timeout after %v of waiting for mutation feed worker to terminate", waitTime)
 	}
 }
 
@@ -230,7 +230,7 @@ func (listener *changeListener) TapFeed() base.TapFeed {
 //////// NOTIFICATIONS:
 
 // Changes the counter, notifying waiting clients.
-func (listener *changeListener) Notify(keys channels.Set) {
+func (listener *changeListener) Notify(ctx context.Context, keys channels.Set) {
 
 	if len(keys) == 0 {
 		return
@@ -240,18 +240,18 @@ func (listener *changeListener) Notify(keys channels.Set) {
 	for key := range keys {
 		listener.keyCounts[key.String()] = listener.counter
 	}
-	base.DebugfCtx(context.TODO(), base.KeyChanges, "Notifying that %q changed (keys=%q) count=%d",
+	base.DebugfCtx(ctx, base.KeyChanges, "Notifying that %q changed (keys=%q) count=%d",
 		base.MD(listener.bucketName), base.UD(keys), listener.counter)
 	listener.tapNotifier.Broadcast()
 	listener.tapNotifier.L.Unlock()
 }
 
 // Changes the counter, notifying waiting clients. Only use for a key update.
-func (listener *changeListener) notifyKey(key string) {
+func (listener *changeListener) notifyKey(ctx context.Context, key string) {
 	listener.tapNotifier.L.Lock()
 	listener.counter++
 	listener.keyCounts[key] = listener.counter
-	base.DebugfCtx(context.TODO(), base.KeyChanges, "Notifying that %q changed (key=%q) count=%d",
+	base.DebugfCtx(ctx, base.KeyChanges, "Notifying that %q changed (key=%q) count=%d",
 		base.MD(listener.bucketName), base.UD(key), listener.counter)
 	listener.tapNotifier.Broadcast()
 	listener.tapNotifier.L.Unlock()

--- a/db/changes.go
+++ b/db/changes.go
@@ -38,7 +38,6 @@ type ChangesOptions struct {
 	ActiveOnly     bool            // If true, only return information on non-deleted, non-removed revisions
 	Revocations    bool            // Specifies whether revocation messages should be sent on the changes feed
 	clientType     clientType      // Can be used to determine if the replication is being started from a CBL 2.x or SGR2 client
-	LoggingCtx     context.Context // Used for adding context to logs
 	ChangesCtx     context.Context // Used for cancelling checking the changes feed should stop
 }
 
@@ -229,7 +228,7 @@ func (db *DatabaseCollectionWithUser) buildRevokedFeed(ctx context.Context, ch c
 
 			// Get changes from 0 to latest seq
 			base.TracefCtx(ctx, base.KeyChanges, "Querying channel %q for revocation with options: %+v", base.UD(singleChannelCache.ChannelID().Name), paginationOptions)
-			changes, err := singleChannelCache.GetChanges(paginationOptions)
+			changes, err := singleChannelCache.GetChanges(ctx, paginationOptions)
 			if err != nil {
 				base.WarnfCtx(ctx, "Error retrieving changes for channel %q: %v", base.UD(singleChannelCache.ChannelID()), err)
 				change := ChangeEntry{
@@ -414,9 +413,8 @@ func (db *DatabaseCollectionWithUser) changesFeed(ctx context.Context, singleCha
 				paginationOptions.Limit = base.Min(remainingLimit, queryLimit)
 			}
 
-			// TODO: pass db.Ctx down to changeCache?
 			base.TracefCtx(ctx, base.KeyChanges, "Querying channel %q with options: %+v", base.UD(singleChannelCache.ChannelID().Name), paginationOptions)
-			changes, err := singleChannelCache.GetChanges(paginationOptions)
+			changes, err := singleChannelCache.GetChanges(ctx, paginationOptions)
 			if err != nil {
 				base.WarnfCtx(ctx, "Error retrieving changes for channel %q: %v", base.UD(singleChannelCache.ChannelID().Name), err)
 				change := ChangeEntry{

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -56,7 +56,7 @@ func TestFilterToAvailableChannels(t *testing.T) {
 			db, ctx := setupTestDB(t)
 			defer db.Close(ctx)
 			collection := GetSingleDatabaseCollectionWithUser(t, db)
-			collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+			collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 			auth := db.Authenticator(base.TestCtx(t))
 			user, err := auth.NewUser("test", "pass", testCase.userChans)
@@ -102,7 +102,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Create a user with access to channel ABC
 	authenticator := db.Authenticator(base.TestCtx(t))
@@ -212,7 +212,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Create a user with access to channel A
 	authenticator := db.Authenticator(base.TestCtx(t))
@@ -298,7 +298,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Create a user with access to channel A
 	authenticator := db.Authenticator(base.TestCtx(t))

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -51,7 +51,7 @@ type ChannelCache interface {
 	Remove(collectionID uint32, docIDs []string, startTime time.Time) (count int)
 
 	// Returns set of changes for a given channel, within the bounds specified in options
-	GetChanges(ch channels.ID, options ChangesOptions) ([]*LogEntry, error)
+	GetChanges(ctx context.Context, ch channels.ID, options ChangesOptions) ([]*LogEntry, error)
 
 	// Returns the set of all cached data for a given channel (intended for diagnostic usage)
 	GetCachedChanges(ch channels.ID) ([]*LogEntry, error)
@@ -278,13 +278,13 @@ func (c *channelCacheImpl) Remove(collectionID uint32, docIDs []string, startTim
 	return count
 }
 
-func (c *channelCacheImpl) GetChanges(ch channels.ID, options ChangesOptions) ([]*LogEntry, error) {
+func (c *channelCacheImpl) GetChanges(ctx context.Context, ch channels.ID, options ChangesOptions) ([]*LogEntry, error) {
 
 	cache, err := c.getChannelCache(ch)
 	if err != nil {
 		return nil, err
 	}
-	return cache.GetChanges(options)
+	return cache.GetChanges(ctx, options)
 }
 
 func (c *channelCacheImpl) GetCachedChanges(channel channels.ID) ([]*LogEntry, error) {

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -47,7 +47,7 @@ func TestDuplicateDocID(t *testing.T) {
 	cache.addToCache(testLogEntry(2, "doc3", "3-a"), false)
 	cache.addToCache(testLogEntry(3, "doc5", "5-a"), false)
 
-	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err := cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 2, 3}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc5"}))
@@ -55,7 +55,7 @@ func TestDuplicateDocID(t *testing.T) {
 
 	// Add a new revision matching mid-list
 	cache.addToCache(testLogEntry(4, "doc3", "3-b"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 3, 4}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc5", "doc3"}))
@@ -63,7 +63,7 @@ func TestDuplicateDocID(t *testing.T) {
 
 	// Add a new revision matching first
 	cache.addToCache(testLogEntry(5, "doc1", "1-b"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{3, 4, 5}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc5", "doc3", "doc1"}))
@@ -71,7 +71,7 @@ func TestDuplicateDocID(t *testing.T) {
 
 	// Add a new revision matching last
 	cache.addToCache(testLogEntry(6, "doc1", "1-c"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{3, 4, 6}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc5", "doc3", "doc1"}))
@@ -102,7 +102,7 @@ func TestLateArrivingSequence(t *testing.T) {
 	cache.addToCache(testLogEntry(3, "doc3", "3-a"), false)
 	cache.addToCache(testLogEntry(5, "doc5", "5-a"), false)
 
-	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err := cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 3, 5}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc5"}))
@@ -111,7 +111,7 @@ func TestLateArrivingSequence(t *testing.T) {
 	// Add a late-arriving sequence
 	cache.AddLateSequence(testLogEntry(2, "doc2", "2-a"))
 	cache.addToCache(testLogEntry(2, "doc2", "2-a"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 2, 3, 5}))
@@ -143,7 +143,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	cache.addToCache(testLogEntry(10, "doc2", "2-a"), false)
 	cache.addToCache(testLogEntry(15, "doc3", "3-a"), false)
 
-	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err := cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{5, 10, 15}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc2", "doc3"}))
@@ -152,7 +152,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	// Add a late-arriving sequence
 	cache.AddLateSequence(testLogEntry(3, "doc0", "0-a"))
 	cache.addToCache(testLogEntry(3, "doc0", "0-a"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{3, 5, 10, 15}))
@@ -185,7 +185,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	cache.addToCache(testLogEntry(30, "doc3", "3-a"), false)
 	cache.addToCache(testLogEntry(40, "doc4", "4-a"), false)
 
-	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err := cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	assert.True(t, verifyChannelSequences(entries, []uint64{10, 20, 30, 40}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc2", "doc3", "doc4"}))
@@ -194,7 +194,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	// Add a late-arriving sequence that should replace earlier sequence
 	cache.AddLateSequence(testLogEntry(25, "doc1", "1-c"))
 	cache.addToCache(testLogEntry(25, "doc1", "1-c"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{20, 25, 30, 40}))
@@ -204,7 +204,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	// Add a late-arriving sequence that should be ignored (later sequence exists for that docID)
 	cache.AddLateSequence(testLogEntry(15, "doc1", "1-b"))
 	cache.addToCache(testLogEntry(15, "doc1", "1-b"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{20, 25, 30, 40}))
@@ -214,7 +214,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	// Add a late-arriving sequence adjacent to same ID (cache inserts differently)
 	cache.AddLateSequence(testLogEntry(27, "doc1", "1-d"))
 	cache.addToCache(testLogEntry(27, "doc1", "1-d"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{20, 27, 30, 40}))
@@ -224,7 +224,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	// Add a late-arriving sequence adjacent to same ID (cache inserts differently)
 	cache.AddLateSequence(testLogEntry(41, "doc4", "4-b"))
 	cache.addToCache(testLogEntry(41, "doc4", "4-b"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{20, 27, 30, 41}))
@@ -234,7 +234,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	// Add late arriving that's duplicate of oldest in cache
 	cache.AddLateSequence(testLogEntry(45, "doc2", "2-b"))
 	cache.addToCache(testLogEntry(45, "doc2", "2-b"), false)
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{27, 30, 41, 45}))
@@ -475,7 +475,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	cache.addToCache(testLogEntry(2, "doc3", "3-a"), false)
 	cache.addToCache(testLogEntry(3, "doc5", "5-a"), false)
 
-	entries, err := cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err := cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 2, 3}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc5"}))
@@ -483,7 +483,7 @@ func TestChannelCacheRemove(t *testing.T) {
 
 	// Now remove doc1
 	cache.Remove(collectionID, []string{"doc1"}, time.Now())
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 2)
 	assert.True(t, verifyChannelSequences(entries, []uint64{2, 3}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc3", "doc5"}))
@@ -493,7 +493,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	// This will print a debug level log:
 	// [DBG] Cache+: Skipping removal of doc "doc5" from cache "Test1" - received after purge
 	cache.Remove(collectionID, []string{"doc5"}, time.Now().Add(-time.Second*5))
-	entries, err = cache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err = cache.GetChanges(ctx, getChangesOptionsWithZeroSeq())
 	require.Len(t, entries, 2)
 	assert.True(t, verifyChannelSequences(entries, []uint64{2, 3}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc3", "doc5"}))
@@ -707,7 +707,7 @@ func TestBypassSingleChannelCache(t *testing.T) {
 		queryHandler: queryHandler,
 	}
 
-	entries, err := bypassCache.GetChanges(getChangesOptionsWithZeroSeq())
+	entries, err := bypassCache.GetChanges(base.TestCtx(t), getChangesOptionsWithZeroSeq())
 	assert.NoError(t, err)
 	require.Len(t, entries, 10)
 

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -32,13 +32,13 @@ func TestChannelCacheMaxSize(t *testing.T) {
 	collectionID := GetSingleDatabaseCollection(t, db.DatabaseContext).GetCollectionID()
 
 	// Make channels active
-	_, err := cache.GetChanges(channels.NewID("TestA", collectionID), getChangesOptionsWithCtxOnly())
+	_, err := cache.GetChanges(ctx, channels.NewID("TestA", collectionID), getChangesOptionsWithCtxOnly())
 	require.NoError(t, err)
-	_, err = cache.GetChanges(channels.NewID("TestB", collectionID), getChangesOptionsWithCtxOnly())
+	_, err = cache.GetChanges(ctx, channels.NewID("TestB", collectionID), getChangesOptionsWithCtxOnly())
 	require.NoError(t, err)
-	_, err = cache.GetChanges(channels.NewID("TestC", collectionID), getChangesOptionsWithCtxOnly())
+	_, err = cache.GetChanges(ctx, channels.NewID("TestC", collectionID), getChangesOptionsWithCtxOnly())
 	require.NoError(t, err)
-	_, err = cache.GetChanges(channels.NewID("TestD", collectionID), getChangesOptionsWithCtxOnly())
+	_, err = cache.GetChanges(ctx, channels.NewID("TestD", collectionID), getChangesOptionsWithCtxOnly())
 	require.NoError(t, err)
 
 	// Add some entries to caches, leaving some empty caches
@@ -312,7 +312,7 @@ func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 				channelNumber := rand.Intn(channelCount) + 1
 				channel := channels.NewID(fmt.Sprintf("chan_%d", channelNumber), base.DefaultCollectionID)
 				options := getChangesOptionsWithCtxOnly()
-				changes, err := cache.GetChanges(channel, options)
+				changes, err := cache.GetChanges(base.TestCtx(t), channel, options)
 				if len(changes) == 1 {
 					changesSuccessCount++
 				}
@@ -386,7 +386,7 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 				channelNumber := rand.Intn(channelCount) + 1
 				channel := channels.NewID(fmt.Sprintf("chan_%d", channelNumber), base.DefaultCollectionID)
 				options := getChangesOptionsWithCtxOnly()
-				changes, err := cache.GetChanges(channel, options)
+				changes, err := cache.GetChanges(base.TestCtx(t), channel, options)
 				if len(changes) == 1 {
 					changesSuccessCount++
 				}
@@ -446,7 +446,7 @@ func TestChannelCacheBypass(t *testing.T) {
 	for c := 1; c <= channelCount; c++ {
 		channel := channels.NewID(fmt.Sprintf("chan_%d", c), base.DefaultCollectionID)
 		options := getChangesOptionsWithCtxOnly()
-		changes, err := cache.GetChanges(channel, options)
+		changes, err := cache.GetChanges(base.TestCtx(t), channel, options)
 		assert.NoError(t, err, fmt.Sprintf("Error getting changes for channel %q", channel))
 		assert.True(t, len(changes) == 1, "Expected one change per channel")
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -1555,8 +1555,7 @@ func (db *DatabaseContext) assignSequence(ctx context.Context, docSequence uint6
 			if docSequence > doc.Sequence {
 				break
 			} else {
-				releaseErr := db.sequences.releaseSequence(docSequence)
-				if releaseErr != nil {
+				if err := db.sequences.releaseSequence(ctx, docSequence); err != nil {
 					base.WarnfCtx(ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", docSequence, err)
 				}
 			}
@@ -1905,13 +1904,13 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 	// If the WriteUpdate didn't succeed, check whether there are unused, allocated sequences that need to be accounted for
 	if err != nil {
 		if docSequence > 0 {
-			if seqErr := db.sequences().releaseSequence(docSequence); seqErr != nil {
+			if seqErr := db.sequences().releaseSequence(ctx, docSequence); seqErr != nil {
 				base.WarnfCtx(ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", docSequence, seqErr)
 			}
 
 		}
 		for _, sequence := range unusedSequences {
-			if seqErr := db.sequences().releaseSequence(sequence); seqErr != nil {
+			if seqErr := db.sequences().releaseSequence(ctx, sequence); seqErr != nil {
 				base.WarnfCtx(ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", sequence, seqErr)
 			}
 		}

--- a/db/database.go
+++ b/db/database.go
@@ -497,7 +497,11 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		}
 		collectionNameMap := make(map[string]struct{}, len(scope.Collections))
 		for collName, collOpts := range scope.Collections {
-			ctx := base.CollectionLogCtx(ctx, collName)
+			// intentional shadow - we want each collection to have its own context inside this loop body
+			ctx := ctx
+			if !base.IsDefaultCollection(scopeName, collName) {
+				ctx = base.CollectionLogCtx(ctx, collName)
+			}
 			dataStore, err := bucket.NamedDataStore(base.ScopeAndCollectionName{Scope: scopeName, Collection: collName})
 			if err != nil {
 				return nil, err

--- a/db/database.go
+++ b/db/database.go
@@ -442,13 +442,13 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 
 	dbContext.EventMgr = NewEventManager(dbContext.terminator)
 
-	dbContext.sequences, err = newSequenceAllocator(metadataStore, dbContext.DbStats.Database(), metaKeys)
+	dbContext.sequences, err = newSequenceAllocator(ctx, metadataStore, dbContext.DbStats.Database(), metaKeys)
 	if err != nil {
 		return nil, err
 	}
 
 	cleanupFunctions = append(cleanupFunctions, func() {
-		dbContext.sequences.Stop()
+		dbContext.sequences.Stop(ctx)
 	})
 
 	// Initialize the active channel counter
@@ -586,8 +586,8 @@ func (context *DatabaseContext) Close(ctx context.Context) {
 
 	// Wait for database background tasks to finish.
 	waitForBGTCompletion(ctx, BGTCompletionMaxWait, context.backgroundTasks, context.Name)
-	context.sequences.Stop()
-	context.mutationListener.Stop()
+	context.sequences.Stop(ctx)
+	context.mutationListener.Stop(ctx)
 	context.changeCache.Stop()
 	// Stop the channel cache and it's background tasks.
 	context.channelCache.Stop()
@@ -708,13 +708,13 @@ func (context *DatabaseContext) IsClosed() bool {
 }
 
 // For testing only!
-func (context *DatabaseContext) RestartListener() error {
-	context.mutationListener.Stop()
+func (context *DatabaseContext) RestartListener(ctx context.Context) error {
+	context.mutationListener.Stop(ctx)
 	// Delay needed to properly stop
 	time.Sleep(2 * time.Second)
 	context.mutationListener.Init(context.Bucket.GetName(), context.Options.GroupID, context.MetadataKeys)
 	cacheFeedStatsMap := context.DbStats.Database().CacheFeedMapStats
-	if err := context.mutationListener.Start(context.Bucket, cacheFeedStatsMap.Map, context.Scopes, context.MetadataStore); err != nil {
+	if err := context.mutationListener.Start(ctx, context.Bucket, cacheFeedStatsMap.Map, context.Scopes, context.MetadataStore); err != nil {
 		return err
 	}
 	return nil
@@ -1664,7 +1664,7 @@ func (c *DatabaseCollection) regeneratePrincipalSequences(authr *auth.Authentica
 
 func (c *DatabaseCollection) releaseSequences(ctx context.Context, sequences []uint64) {
 	for _, sequence := range sequences {
-		err := c.sequences().releaseSequence(sequence)
+		err := c.sequences().releaseSequence(ctx, sequence)
 		if err != nil {
 			base.WarnfCtx(ctx, "Error attempting to release sequence %d. Error %v", sequence, err)
 		}
@@ -2139,8 +2139,8 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 	}
 
 	// Callback that is invoked whenever a set of channels is changed in the ChangeCache
-	notifyChange := func(changedChannels channels.Set) {
-		db.mutationListener.Notify(changedChannels)
+	notifyChange := func(ctx context.Context, changedChannels channels.Set) {
+		db.mutationListener.Notify(ctx, changedChannels)
 	}
 
 	// Initialize the ChangeCache.  Will be locked and unusable until .Start() is called (SG #3558)
@@ -2204,13 +2204,13 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 	// Start DCP feed
 	base.InfofCtx(ctx, base.KeyDCP, "Starting mutation feed on bucket %v", base.MD(db.Bucket.GetName()))
 	cacheFeedStatsMap := db.DbStats.Database().CacheFeedMapStats
-	if err := db.mutationListener.Start(db.Bucket, cacheFeedStatsMap.Map, db.Scopes, db.MetadataStore); err != nil {
+	if err := db.mutationListener.Start(ctx, db.Bucket, cacheFeedStatsMap.Map, db.Scopes, db.MetadataStore); err != nil {
 		db.channelCache = nil
 		return err
 	}
 
 	cleanupFunctions = append(cleanupFunctions, func() {
-		db.mutationListener.Stop()
+		db.mutationListener.Stop(ctx)
 	})
 
 	// Get current value of _sync:seq

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -292,7 +292,7 @@ func (c *DatabaseCollection) UpdateSyncFun(ctx context.Context, syncFun string) 
 	} else if c.ChannelMapper != nil {
 		_, err = c.ChannelMapper.SetFunction(syncFun)
 	} else {
-		c.ChannelMapper = channels.NewChannelMapper(syncFun, c.dbCtx.Options.JavascriptTimeout)
+		c.ChannelMapper = channels.NewChannelMapper(ctx, syncFun, c.dbCtx.Options.JavascriptTimeout)
 	}
 	if err != nil {
 		base.WarnfCtx(ctx, "Error setting sync function: %s", err)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2695,7 +2695,7 @@ func Test_invalidateAllPrincipalsCache(t *testing.T) {
 	defer db.Close(ctx)
 	db.Options.QueryPaginationLimit = 100
 
-	sequenceAllocator, err := newSequenceAllocator(db.MetadataStore, db.DbStats.DatabaseStats, db.MetadataKeys)
+	sequenceAllocator, err := newSequenceAllocator(base.DatabaseLogCtx(base.TestCtx(t), db.Name), db.MetadataStore, db.DbStats.DatabaseStats, db.MetadataKeys)
 	assert.NoError(t, err)
 
 	db.sequences = sequenceAllocator

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -321,7 +321,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	rev1body := Body{
 		"key1":     1234,
@@ -430,7 +430,7 @@ func TestGetRemovalMultiChannel(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	auth := db.Authenticator(base.TestCtx(t))
 
@@ -601,7 +601,7 @@ func TestDeltaSyncWhenToRevIsChannelRemoval(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Create the first revision of doc1.
 	rev1Body := Body{
@@ -832,7 +832,7 @@ func TestAllDocsOnly(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	collectionID := collection.GetCollectionID()
 
@@ -1015,7 +1015,7 @@ func TestConflicts(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Instantiate channel cache for channel 'all'
 	collectionID := collection.GetCollectionID()
@@ -1428,7 +1428,7 @@ func TestInvalidChannel(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	body := Body{"channels": []string{"bad,name"}}
 	_, _, err := collection.Put(ctx, "doc", body)

--- a/db/import.go
+++ b/db/import.go
@@ -453,13 +453,11 @@ type jsImportFilterRunner struct {
 }
 
 // Compiles a JavaScript event function to a jsImportFilterRunner object.
-func newImportFilterRunner(funcSource string, timeout time.Duration) (sgbucket.JSServerTask, error) {
+func newImportFilterRunner(ctx context.Context, funcSource string, timeout time.Duration) (sgbucket.JSServerTask, error) {
 	importFilterRunner := &jsEventTask{}
 	err := importFilterRunner.InitWithLogging(funcSource, timeout,
-		func(s string) {
-			base.ErrorfCtx(context.Background(), base.KeyJavascript.String()+": Import %s", base.UD(s))
-		},
-		func(s string) { base.InfofCtx(context.Background(), base.KeyJavascript, "Import %s", base.UD(s)) })
+		func(s string) { base.ErrorfCtx(ctx, base.KeyJavascript.String()+": Import %s", base.UD(s)) },
+		func(s string) { base.InfofCtx(ctx, base.KeyJavascript, "Import %s", base.UD(s)) })
 	if err != nil {
 		return nil, err
 	}
@@ -476,13 +474,13 @@ type ImportFilterFunction struct {
 	*sgbucket.JSServer
 }
 
-func NewImportFilterFunction(fnSource string, timeout time.Duration) *ImportFilterFunction {
+func NewImportFilterFunction(ctx context.Context, fnSource string, timeout time.Duration) *ImportFilterFunction {
 
 	base.DebugfCtx(context.Background(), base.KeyImport, "Creating new ImportFilterFunction")
 	return &ImportFilterFunction{
 		JSServer: sgbucket.NewJSServer(fnSource, timeout, kTaskCacheSize,
 			func(fnSource string, timeout time.Duration) (sgbucket.JSServerTask, error) {
-				return newImportFilterRunner(fnSource, timeout)
+				return newImportFilterRunner(ctx, fnSource, timeout)
 			}),
 	}
 }

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -107,7 +107,7 @@ func (il *importListener) StartImportFeed(dbContext *DatabaseContext) (err error
 	cbStore, ok := base.AsCouchbaseBucketStore(il.bucket)
 	if !ok {
 		// walrus is not a couchbasestore
-		return il.bucket.StartDCPFeed(feedArgs, il.ProcessFeedEvent, importFeedStatsMap.Map)
+		return il.bucket.StartDCPFeed(il.loggingCtx, feedArgs, il.ProcessFeedEvent, importFeedStatsMap.Map)
 	}
 
 	if !base.IsEnterpriseEdition() {
@@ -116,7 +116,7 @@ func (il *importListener) StartImportFeed(dbContext *DatabaseContext) (err error
 		if err != nil {
 			return err
 		}
-		return base.StartGocbDCPFeed(gocbv2Bucket, il.bucket.GetName(), feedArgs, il.ProcessFeedEvent, importFeedStatsMap.Map, base.DCPMetadataStoreCS, groupID)
+		return base.StartGocbDCPFeed(il.loggingCtx, gocbv2Bucket, il.bucket.GetName(), feedArgs, il.ProcessFeedEvent, importFeedStatsMap.Map, base.DCPMetadataStoreCS, groupID)
 	}
 
 	il.cbgtContext, err = base.StartShardedDCPFeed(il.loggingCtx, dbContext.Name, dbContext.Options.GroupID, dbContext.UUID, dbContext.Heartbeater,

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -442,7 +442,7 @@ func TestEvaluateFunction(t *testing.T) {
 	// Simulate unexpected error invoking import filter for document
 	body := Body{"key": "value", "version": "1a"}
 	source := "illegal function(doc) {}"
-	importFilterFunc := NewImportFilterFunction(source, 0)
+	importFilterFunc := NewImportFilterFunction(base.TestCtx(t), source, 0)
 	result, err := importFilterFunc.EvaluateFunction(base.TestCtx(t), body)
 	assert.Error(t, err, "Unexpected token function error")
 	assert.False(t, result, "Function evaluation result should be false")
@@ -450,7 +450,7 @@ func TestEvaluateFunction(t *testing.T) {
 	// Simulate boolean return value from import filter function
 	body = Body{"key": "value", "version": "2a"}
 	source = `function(doc) { if (doc.version == "2a") { return true; } else { return false; }}`
-	importFilterFunc = NewImportFilterFunction(source, 0)
+	importFilterFunc = NewImportFilterFunction(base.TestCtx(t), source, 0)
 	result, err = importFilterFunc.EvaluateFunction(base.TestCtx(t), body)
 	assert.NoError(t, err, "Import filter function shouldn't throw any error")
 	assert.True(t, result, "Import filter function should return boolean value true")
@@ -458,7 +458,7 @@ func TestEvaluateFunction(t *testing.T) {
 	// Simulate non-boolean return value from import filter function; default switch case
 	body = Body{"key": "value", "version": "2b"}
 	source = `function(doc) { if (doc.version == "2b") { return 1.01; } else { return 0.01; }}`
-	importFilterFunc = NewImportFilterFunction(source, 0)
+	importFilterFunc = NewImportFilterFunction(base.TestCtx(t), source, 0)
 	result, err = importFilterFunc.EvaluateFunction(base.TestCtx(t), body)
 	assert.Error(t, err, "Import filter function returned non-boolean value")
 	assert.False(t, result, "Import filter function evaluation result should be false")
@@ -466,7 +466,7 @@ func TestEvaluateFunction(t *testing.T) {
 	// Simulate string return value true from import filter function
 	body = Body{"key": "value", "version": "1a"}
 	source = `function(doc) { if (doc.version == "1a") { return "true"; } else { return "false"; }}`
-	importFilterFunc = NewImportFilterFunction(source, 0)
+	importFilterFunc = NewImportFilterFunction(base.TestCtx(t), source, 0)
 	result, err = importFilterFunc.EvaluateFunction(base.TestCtx(t), body)
 	assert.NoError(t, err, "Import filter function shouldn't throw any error")
 	assert.True(t, result, "Import filter function should return true")
@@ -474,7 +474,7 @@ func TestEvaluateFunction(t *testing.T) {
 	// Simulate string return value false from import filter function
 	body = Body{"key": "value", "version": "2a"}
 	source = `function(doc) { if (doc.version == "1a") { return "true"; } else { return "false"; }}`
-	importFilterFunc = NewImportFilterFunction(source, 0)
+	importFilterFunc = NewImportFilterFunction(base.TestCtx(t), source, 0)
 	result, err = importFilterFunc.EvaluateFunction(base.TestCtx(t), body)
 	assert.NoError(t, err, "Import filter function shouldn't throw any error")
 	assert.False(t, result, "Import filter function should return false")
@@ -482,7 +482,7 @@ func TestEvaluateFunction(t *testing.T) {
 	// Simulate strconv.ParseBool: parsing "TruE": invalid syntax
 	body = Body{"key": "value", "version": "1a"}
 	source = `function(doc) { if (doc.version == "1a") { return "TruE"; } else { return "FaLsE"; }}`
-	importFilterFunc = NewImportFilterFunction(source, 0)
+	importFilterFunc = NewImportFilterFunction(base.TestCtx(t), source, 0)
 	result, err = importFilterFunc.EvaluateFunction(base.TestCtx(t), body)
 	assert.Error(t, err, `strconv.ParseBool: parsing "TruE": invalid syntax`)
 	assert.False(t, result, "Import filter function should return true")

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -123,7 +123,7 @@ func TestBuildRolesQuery(t *testing.T) {
 			require.True(t, ok)
 
 			roleStatement, _ := database.BuildRolesQuery("", 0)
-			plan, explainErr := n1QLStore.ExplainQuery(roleStatement, nil)
+			plan, explainErr := n1QLStore.ExplainQuery(ctx, roleStatement, nil)
 			require.NoError(t, explainErr, "Error generating explain for roleAccess query")
 
 			covered := db.IsCovered(plan)
@@ -167,7 +167,7 @@ func TestBuildUsersQuery(t *testing.T) {
 			n1QLStore, ok := base.AsN1QLStore(database.MetadataStore)
 			require.True(t, ok)
 			userStatement, _ := database.BuildUsersQuery("", 0)
-			plan, explainErr := n1QLStore.ExplainQuery(userStatement, nil)
+			plan, explainErr := n1QLStore.ExplainQuery(ctx, userStatement, nil)
 			require.NoError(t, explainErr)
 
 			covered := db.IsCovered(plan)

--- a/db/query.go
+++ b/db/query.go
@@ -381,7 +381,7 @@ func N1QLQueryWithStats(ctx context.Context, dataStore base.DataStore, queryName
 		return nil, errors.New("Cannot perform N1QL query on non-Couchbase bucket.")
 	}
 
-	results, err = n1QLStore.Query(statement, params, consistency, adhoc)
+	results, err = n1QLStore.Query(ctx, statement, params, consistency, adhoc)
 
 	if len(queryName) > 0 {
 		queryStat := dbStats.Query(queryName)

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -33,7 +33,7 @@ func TestQueryChannelsStatsView(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// docID -> Sequence
 	docSeqMap := make(map[string]uint64, 3)
@@ -85,7 +85,7 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// docID -> Sequence
 	docSeqMap := make(map[string]uint64, 3)
@@ -261,7 +261,7 @@ func TestAccessQuery(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	collection.ChannelMapper = channels.NewChannelMapper(
+	collection.ChannelMapper = channels.NewChannelMapper(ctx,
 		`function(doc, oldDoc) {
 	access(doc.accessUser, doc.accessChannel)
 }`,
@@ -310,7 +310,7 @@ func TestRoleAccessQuery(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	collection.ChannelMapper = channels.NewChannelMapper(
+	collection.ChannelMapper = channels.NewChannelMapper(ctx,
 		`function(doc, oldDoc) {
 	role(doc.accessUser, "role:" + doc.accessChannel)
 }`, db.Options.JavascriptTimeout)
@@ -366,7 +366,7 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	collection.ChannelMapper = channels.NewChannelMapper(channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 	docIdFlagMap := make(map[string]uint8)
 	var startSeq, endSeq uint64
 	body := Body{"channels": []string{"ABC"}}

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -141,7 +141,7 @@ func TestCoveringQueries(t *testing.T) {
 
 	// channels
 	channelsStatement, params := collection.buildChannelsQuery("ABC", 0, 10, 100, false)
-	plan, explainErr := n1QLStore.ExplainQuery(channelsStatement, params)
+	plan, explainErr := n1QLStore.ExplainQuery(ctx, channelsStatement, params)
 	assert.NoError(t, explainErr, "Error generating explain for channels query")
 	covered := IsCovered(plan)
 	planJSON, err := base.JSONMarshal(plan)
@@ -150,7 +150,7 @@ func TestCoveringQueries(t *testing.T) {
 
 	// star channel
 	channelStarStatement, params := collection.buildChannelsQuery("*", 0, 10, 100, false)
-	plan, explainErr = n1QLStore.ExplainQuery(channelStarStatement, params)
+	plan, explainErr = n1QLStore.ExplainQuery(ctx, channelStarStatement, params)
 	assert.NoError(t, explainErr, "Error generating explain for star channel query")
 	covered = IsCovered(plan)
 	planJSON, err = base.JSONMarshal(plan)
@@ -161,7 +161,7 @@ func TestCoveringQueries(t *testing.T) {
 	// in the SELECT.
 	// Including here for ease-of-conversion when we get an indexing enhancement to support covered queries.
 	accessStatement := collection.buildAccessQuery("user1")
-	plan, explainErr = n1QLStore.ExplainQuery(accessStatement, nil)
+	plan, explainErr = n1QLStore.ExplainQuery(ctx, accessStatement, nil)
 	assert.NoError(t, explainErr, "Error generating explain for access query")
 	covered = IsCovered(plan)
 	planJSON, err = base.JSONMarshal(plan)
@@ -170,7 +170,7 @@ func TestCoveringQueries(t *testing.T) {
 
 	// roleAccess
 	roleAccessStatement := collection.buildRoleAccessQuery("user1")
-	plan, explainErr = n1QLStore.ExplainQuery(roleAccessStatement, nil)
+	plan, explainErr = n1QLStore.ExplainQuery(ctx, roleAccessStatement, nil)
 	assert.NoError(t, explainErr, "Error generating explain for roleAccess query")
 	covered = IsCovered(plan)
 	planJSON, err = base.JSONMarshal(plan)

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -76,7 +76,7 @@ func TestSequenceAllocator(t *testing.T) {
 	assertNewAllocatorStats(t, testStats, 3, 7, 4, 0)
 
 	// Release unused sequences.  Should reduce batch size to 1 (based on 3 unused)
-	a.releaseUnusedSequences()
+	a.releaseUnusedSequences(base.TestCtx(t))
 	assertNewAllocatorStats(t, testStats, 3, 7, 4, 3)
 	assert.Equal(t, 1, int(a.sequenceBatchSize))
 
@@ -104,7 +104,7 @@ func TestReleaseSequencesOnStop(t *testing.T) {
 	defer func() { MaxSequenceIncrFrequency = oldFrequency }()
 	MaxSequenceIncrFrequency = 1000 * time.Millisecond
 
-	a, err := newSequenceAllocator(bucket.GetSingleDataStore(), testStats, base.DefaultMetadataKeys)
+	a, err := newSequenceAllocator(base.TestCtx(t), bucket.GetSingleDataStore(), testStats, base.DefaultMetadataKeys)
 	// Reduce sequence wait for Stop testing
 	a.releaseSequenceWait = 10 * time.Millisecond
 	assert.NoError(t, err, "error creating allocator")
@@ -122,7 +122,7 @@ func TestReleaseSequencesOnStop(t *testing.T) {
 	assertNewAllocatorStats(t, testStats, 2, 3, 2, 0)
 
 	// Stop the allocator
-	a.Stop()
+	a.Stop(base.TestCtx(t))
 
 	releasedCount := 0
 	// Ensure unused sequence is released on Stop
@@ -181,7 +181,7 @@ func TestSequenceAllocatorDeadlock(t *testing.T) {
 	defer func() { MaxSequenceIncrFrequency = oldFrequency }()
 	MaxSequenceIncrFrequency = 1000 * time.Millisecond
 
-	a, err = newSequenceAllocator(bucket.DefaultDataStore(), testStats, base.DefaultMetadataKeys)
+	a, err = newSequenceAllocator(base.TestCtx(t), bucket.DefaultDataStore(), testStats, base.DefaultMetadataKeys)
 	// Reduce sequence wait for Stop testing
 	a.releaseSequenceWait = 10 * time.Millisecond
 	assert.NoError(t, err, "error creating allocator")
@@ -196,7 +196,7 @@ func TestSequenceAllocatorDeadlock(t *testing.T) {
 
 	wg.Wait()
 
-	a.Stop()
+	a.Stop(base.TestCtx(t))
 }
 
 func TestReleaseSequenceWait(t *testing.T) {
@@ -209,9 +209,9 @@ func TestReleaseSequenceWait(t *testing.T) {
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 
-	a, err := newSequenceAllocator(bucket.GetSingleDataStore(), testStats, base.DefaultMetadataKeys)
+	a, err := newSequenceAllocator(base.TestCtx(t), bucket.GetSingleDataStore(), testStats, base.DefaultMetadataKeys)
 	require.NoError(t, err)
-	defer a.Stop()
+	defer a.Stop(base.TestCtx(t))
 
 	startTime := time.Now().Add(-1 * time.Second)
 	amountWaited := a.waitForReleasedSequences(startTime)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -622,8 +622,8 @@ func AllocateTestSequence(database *DatabaseContext) (uint64, error) {
 }
 
 // ReleaseTestSequence releases a sequence via the sequenceAllocator.  For use by non-db tests
-func ReleaseTestSequence(database *DatabaseContext, sequence uint64) error {
-	return database.sequences.releaseSequence(sequence)
+func ReleaseTestSequence(ctx context.Context, database *DatabaseContext, sequence uint64) error {
+	return database.sequences.releaseSequence(ctx, sequence)
 }
 
 func (a *ActiveReplicator) GetActiveReplicatorConfig() *ActiveReplicatorConfig {

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -25,12 +25,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// WaitForPrimaryIndexEmpty waits for #primary to be empty.
 // Workaround SG #3570 by doing a polling loop until the star channel query returns 0 results.
-// Uses the star channel index as a proxy to indicate that _all_ indexes are empty (which might not be true)
-func waitForPrimaryIndexEmpty(store base.N1QLStore) error {
+func WaitForPrimaryIndexEmpty(ctx context.Context, store base.N1QLStore) error {
 
 	retryWorker := func() (shouldRetry bool, err error, value interface{}) {
-		empty, err := isPrimaryIndexEmpty(store)
+		empty, err := isPrimaryIndexEmpty(ctx, store)
 		if err != nil {
 			return true, err, nil
 		}
@@ -48,7 +48,7 @@ func waitForPrimaryIndexEmpty(store base.N1QLStore) error {
 }
 
 // isPrimaryIndexEmpty returs true if there are no documents in the primary index
-func isPrimaryIndexEmpty(store base.N1QLStore) (bool, error) {
+func isPrimaryIndexEmpty(ctx context.Context, store base.N1QLStore) (bool, error) {
 	// Create the star channel query
 	statement := fmt.Sprintf("SELECT * FROM %s LIMIT 1", base.KeyspaceQueryToken)
 	params := map[string]interface{}{}
@@ -56,7 +56,7 @@ func isPrimaryIndexEmpty(store base.N1QLStore) (bool, error) {
 	params[QueryParamEndSeq] = N1QLMaxInt64
 
 	// Execute the query
-	results, err := store.Query(statement, params, base.RequestPlus, true)
+	results, err := store.Query(ctx, statement, params, base.RequestPlus, true)
 
 	// If there was an error, then retry.  Assume it's an "index rollback" error which happens as
 	// the index processes the bucket flush operation
@@ -184,15 +184,15 @@ func WaitForUserWaiterChange(userWaiter *ChangeWaiter) bool {
 	return isChanged
 }
 
-// emptyPrimaryIndex deletes all docs from primary index
-func emptyPrimaryIndex(dataStore sgbucket.DataStore) error {
+// EmptyPrimaryIndex deletes all docs from primary index
+func EmptyPrimaryIndex(ctx context.Context, dataStore sgbucket.DataStore) error {
 	n1qlStore, ok := base.AsN1QLStore(dataStore)
 	if !ok {
 		return fmt.Errorf("bucket was not a n1ql store")
 	}
 
 	statement := `DELETE FROM ` + base.KeyspaceQueryToken
-	results, err := n1qlStore.Query(statement, nil, base.RequestPlus, true)
+	results, err := n1qlStore.Query(ctx, statement, nil, base.RequestPlus, true)
 	if err != nil {
 		return err
 	}
@@ -215,7 +215,7 @@ FROM ` + base.KeyspaceQueryToken + ` AS ks USE INDEX (sg_allDocs_x1)
 WHERE META(ks).xattrs._sync.sequence >= 0
     AND META(ks).xattrs._sync.sequence < 9223372036854775807
     AND META(ks).id NOT LIKE '\\_sync:%'`
-	results, err := n1qlStore.Query(statement, nil, base.RequestPlus, true)
+	results, err := n1qlStore.Query(ctx, statement, nil, base.RequestPlus, true)
 	if err != nil {
 		return 0, err
 	}
@@ -288,7 +288,7 @@ var viewsAndGSIBucketReadier base.TBPBucketReadierFunc = func(ctx context.Contex
 		if _, err := emptyAllDocsIndex(ctx, dataStore, tbp); err != nil {
 			return err
 		}
-		if err := emptyPrimaryIndex(dataStore); err != nil {
+		if err := EmptyPrimaryIndex(ctx, dataStore); err != nil {
 			return err
 		}
 		n1qlStore, ok := base.AsN1QLStore(dataStore)
@@ -297,7 +297,7 @@ var viewsAndGSIBucketReadier base.TBPBucketReadierFunc = func(ctx context.Contex
 		}
 		tbp.Logf(ctx, "waiting for empty bucket indexes %s.%s.%s", b.GetName(), dsName.ScopeName(), dsName.CollectionName())
 		// we can't init indexes concurrently, so we'll just wait for them to be empty after emptying instead of recreating.
-		if err := waitForPrimaryIndexEmpty(n1qlStore); err != nil {
+		if err := WaitForPrimaryIndexEmpty(ctx, n1qlStore); err != nil {
 			tbp.Logf(ctx, "waitForPrimaryIndexEmpty returned an error: %v", err)
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,9 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.2.4-0.20230511103754-8dd1a95f5f33
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20230113211151-ac6a75f57046
+	github.com/couchbase/sg-bucket v0.0.0-20230719160953-b64208fd9341
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f
-	github.com/couchbaselabs/walrus v0.0.0-20230118190455-97ce18d0c47d
+	github.com/couchbaselabs/walrus v0.0.0-20230719161133-3ae76bc6e2d2
 	github.com/elastic/gosigar v0.14.2
 	github.com/felixge/fgprof v0.9.2
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,10 @@ github.com/couchbase/gomemcached v0.2.1 h1:lDONROGbklo8pOt4Sr4eV436PVEaKDr3o9gUl
 github.com/couchbase/gomemcached v0.2.1/go.mod h1:mxliKQxOv84gQ0bJWbI+w9Wxdpt9HjDvgW9MjCym5Vo=
 github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9BCs=
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
-github.com/couchbase/sg-bucket v0.0.0-20230113211151-ac6a75f57046 h1:fyGdhMTONSnC9Sqhc0f9KXhT5Pmpst7obe3Tg92xQsk=
-github.com/couchbase/sg-bucket v0.0.0-20230113211151-ac6a75f57046/go.mod h1:1LT+86k2vAk/puiscgWjGJYAaKxkHUjLg30eG6hzo+k=
+github.com/couchbase/sg-bucket v0.0.0-20230717201310-6e360028b2c1 h1:RNAkJa53wEjveqcZStgRNpK1DT4fE8ypTsOFIFrG5jU=
+github.com/couchbase/sg-bucket v0.0.0-20230717201310-6e360028b2c1/go.mod h1:1LT+86k2vAk/puiscgWjGJYAaKxkHUjLg30eG6hzo+k=
+github.com/couchbase/sg-bucket v0.0.0-20230719160953-b64208fd9341 h1:evkECvUxtezOtq5kSK3+LAoFaNvrx/NAa71gcJ/9+gU=
+github.com/couchbase/sg-bucket v0.0.0-20230719160953-b64208fd9341/go.mod h1:1LT+86k2vAk/puiscgWjGJYAaKxkHUjLg30eG6hzo+k=
 github.com/couchbase/tools-common v0.0.0-20220810163003-4c3c185822d4 h1:Ub0gZWccoNL+ag59v8S23tbHDknfN1l3CVl7Kb+hFO0=
 github.com/couchbase/tools-common v0.0.0-20220810163003-4c3c185822d4/go.mod h1:lW0Em1mo5xqQ0mRMzJlg013/6ruyISupTfW7nbLaa1E=
 github.com/couchbasedeps/graphql-go v0.8.1 h1:NpkpNePwszaRWK82vfCPDt86GT+vkhjZ9ot+X5rSAME=
@@ -92,8 +94,10 @@ github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f h1:al
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f/go.mod h1:daOs69VstinwoALl3wwWxjBf1nD4lIe3wwYhKHKDapY=
 github.com/couchbaselabs/gocaves/client v0.0.0-20230307083111-cc3960c624b1 h1:H7OK4q4WsDxqNIB/Ba8BQBXBHFilZnyItHrLr3qmsKA=
 github.com/couchbaselabs/gocaves/client v0.0.0-20230307083111-cc3960c624b1/go.mod h1:AVekAZwIY2stsJOMWLAS/0uA/+qdp7pjO8EHnl61QkY=
-github.com/couchbaselabs/walrus v0.0.0-20230118190455-97ce18d0c47d h1:xXu694Yreh2MsglrPtS4YP2vyCu5JEUAL2qGnf4ztlE=
-github.com/couchbaselabs/walrus v0.0.0-20230118190455-97ce18d0c47d/go.mod h1:gJu5EMZYtBqWR0SMdmR6sOHYjqXZEcZPd5uQFR+nt+c=
+github.com/couchbaselabs/walrus v0.0.0-20230717201422-d5d6dd81efea h1:FUT79W/Xb++QbcGunaFLRyyHLFsuUB27uy5rMK4St8s=
+github.com/couchbaselabs/walrus v0.0.0-20230717201422-d5d6dd81efea/go.mod h1:zkOKC/JM1SyRhq1Gu57uSM5vvGcF2cq1TZdp4rGjJ/4=
+github.com/couchbaselabs/walrus v0.0.0-20230719161133-3ae76bc6e2d2 h1:LCowNAhNbWwc8psqgjif85N0YSeVXWqeuTAeRPcOdsI=
+github.com/couchbaselabs/walrus v0.0.0-20230719161133-3ae76bc6e2d2/go.mod h1:zkOKC/JM1SyRhq1Gu57uSM5vvGcF2cq1TZdp4rGjJ/4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -2620,7 +2620,7 @@ func TestConfigEndpoint(t *testing.T) {
 			base.InitializeMemoryLoggers()
 			tempDir := os.TempDir()
 			test := rest.DefaultStartupConfig(tempDir)
-			err := test.SetupAndValidateLogging()
+			err := test.SetupAndValidateLogging(base.TestCtx(t))
 			assert.NoError(t, err)
 
 			rt := rest.NewRestTester(t, nil)
@@ -2721,7 +2721,7 @@ func TestIncludeRuntimeStartupConfig(t *testing.T) {
 	base.InitializeMemoryLoggers()
 	tempDir := os.TempDir()
 	test := rest.DefaultStartupConfig(tempDir)
-	err := test.SetupAndValidateLogging()
+	err := test.SetupAndValidateLogging(base.TestCtx(t))
 	assert.NoError(t, err)
 
 	rt := rest.NewRestTester(t, nil)

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -520,7 +520,7 @@ func TestCollectionsBasicIndexQuery(t *testing.T) {
 	require.NoError(t, n1qlStore.CreatePrimaryIndex(ctx, idxName, nil))
 	require.NoError(t, n1qlStore.WaitForIndexesOnline(ctx, []string{idxName}, false))
 
-	res, err := n1qlStore.Query("SELECT keyspace_id, bucket_id, scope_id from system:indexes WHERE name = $idxName",
+	res, err := n1qlStore.Query(ctx, "SELECT keyspace_id, bucket_id, scope_id from system:indexes WHERE name = $idxName",
 		map[string]interface{}{"idxName": idxName}, base.RequestPlus, true)
 	require.NoError(t, err)
 
@@ -544,7 +544,7 @@ func TestCollectionsBasicIndexQuery(t *testing.T) {
 	assert.Equal(t, collection.Name, *indexMetaResult.KeyspaceID)
 
 	// try and query the document that we wrote via SG
-	res, err = n1qlStore.Query("SELECT test FROM "+base.KeyspaceQueryToken+" WHERE test = true", nil, base.RequestPlus, true)
+	res, err = n1qlStore.Query(ctx, "SELECT test FROM "+base.KeyspaceQueryToken+" WHERE test = true", nil, base.RequestPlus, true)
 	require.NoError(t, err)
 
 	var primaryQueryResult struct {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1633,7 +1633,7 @@ func TestLongpollWithWildcard(t *testing.T) {
 	// triggers early termination of the changes loop.  This can only be reproduced if the feed is restarted after the user is created -
 	// otherwise the count for the user pseudo-channel will always be non-zero
 	db, _ := rt.ServerContext().GetDatabase(ctx, "db")
-	err = db.RestartListener()
+	err = db.RestartListener(base.TestCtx(t))
 	assert.True(t, err == nil)
 	// Put a document to increment the counter for the * channel
 	response := rt.Send(Request("PUT", "/{{.keyspace}}/lost", `{"channel":["ABC"]}`))

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2690,7 +2690,7 @@ func TestRequestPlusPull(t *testing.T) {
 	require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+1))
 
 	// Release the slow sequence
-	releaseErr := db.ReleaseTestSequence(database, slowSequence)
+	releaseErr := db.ReleaseTestSequence(base.TestCtx(t), database, slowSequence)
 	require.NoError(t, releaseErr)
 
 	// The one-shot pull should unblock and replicate the document in the granted channel
@@ -2752,7 +2752,7 @@ func TestRequestPlusPullDbConfig(t *testing.T) {
 	require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+1))
 
 	// Release the slow sequence
-	releaseErr := db.ReleaseTestSequence(database, slowSequence)
+	releaseErr := db.ReleaseTestSequence(base.TestCtx(t), database, slowSequence)
 	require.NoError(t, releaseErr)
 
 	// The one-shot pull should unblock and replicate the document in the granted channel

--- a/rest/changes_request_plus_test.go
+++ b/rest/changes_request_plus_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/require"
@@ -57,7 +58,7 @@ func TestRequestPlusSkippedSequence(t *testing.T) {
 	}()
 	require.NoError(t, rt.GetDatabase().WaitForCaughtUp(caughtUpCount+1))
 	// the request should finish once the sequence is released
-	err = db.ReleaseTestSequence(rt.GetDatabase(), unusedSeq)
+	err = db.ReleaseTestSequence(base.TestCtx(t), rt.GetDatabase(), unusedSeq)
 	require.NoError(t, err)
 	<-requestFinished
 	var changesResp ChangesResults

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -3997,7 +3997,7 @@ func TestOneShotGrantTiming(t *testing.T) {
 	require.Len(t, changes.Results, 0)
 
 	// Release the slow sequence and wait for it to be processed over DCP
-	releaseErr := db.ReleaseTestSequence(database, slowSequence)
+	releaseErr := db.ReleaseTestSequence(base.DatabaseLogCtx(base.TestCtx(t), database.Name), database, slowSequence)
 	require.NoError(t, releaseErr)
 	require.NoError(t, rt.WaitForPendingChanges())
 
@@ -4095,7 +4095,7 @@ func TestOneShotGrantRequestPlus(t *testing.T) {
 	require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+2))
 
 	// Release the slow sequence and wait for it to be processed over DCP
-	releaseErr := db.ReleaseTestSequence(database, slowSequence)
+	releaseErr := db.ReleaseTestSequence(base.DatabaseLogCtx(base.TestCtx(t), database.Name), database, slowSequence)
 	require.NoError(t, releaseErr)
 	require.NoError(t, rt.WaitForPendingChanges())
 
@@ -4213,7 +4213,7 @@ func TestOneShotGrantRequestPlusDbConfig(t *testing.T) {
 	require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+2))
 
 	// Release the slow sequence and wait for it to be processed over DCP
-	releaseErr := db.ReleaseTestSequence(database, slowSequence)
+	releaseErr := db.ReleaseTestSequence(base.DatabaseLogCtx(base.TestCtx(t), database.Name), database, slowSequence)
 	require.NoError(t, releaseErr)
 	require.NoError(t, rt.WaitForPendingChanges())
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -1101,7 +1101,7 @@ func envDefaultExpansion(key string, getEnvFn func(string) string) (value string
 }
 
 // SetupAndValidateLogging validates logging config and initializes all logging.
-func (sc *StartupConfig) SetupAndValidateLogging() (err error) {
+func (sc *StartupConfig) SetupAndValidateLogging(ctx context.Context) (err error) {
 
 	base.SetRedaction(sc.Logging.RedactionLevel)
 
@@ -1109,7 +1109,7 @@ func (sc *StartupConfig) SetupAndValidateLogging() (err error) {
 		sc.Logging.LogFilePath = defaultLogFilePath
 	}
 
-	return base.InitLogging(
+	return base.InitLogging(ctx,
 		sc.Logging.LogFilePath,
 		sc.Logging.Console,
 		sc.Logging.Error,
@@ -1244,7 +1244,7 @@ func SetupServerContext(ctx context.Context, config *StartupConfig, persistentCo
 	// Logging config will now have been loaded from command line
 	// or from a sync_gateway config file so we can validate the
 	// configuration and setup logging now
-	if err := config.SetupAndValidateLogging(); err != nil {
+	if err := config.SetupAndValidateLogging(ctx); err != nil {
 		// If we didn't set up logging correctly, we *probably* can't log via normal means...
 		// as a best-effort, last-ditch attempt, we'll log to stderr as well.
 		log.Printf("[ERR] Error setting up logging: %v", err)
@@ -1735,21 +1735,21 @@ func StartServer(ctx context.Context, config *StartupConfig, sc *ServerContext) 
 
 	go sc.PostStartup()
 
-	base.Consolef(base.LevelInfo, base.KeyAll, "Starting metrics server on %s", config.API.MetricsInterface)
+	base.ConsolefCtx(ctx, base.LevelInfo, base.KeyAll, "Starting metrics server on %s", config.API.MetricsInterface)
 	go func() {
 		if err := sc.Serve(config, config.API.MetricsInterface, CreateMetricHandler(sc)); err != nil {
 			base.ErrorfCtx(ctx, "Error serving the Metrics API: %v", err)
 		}
 	}()
 
-	base.Consolef(base.LevelInfo, base.KeyAll, "Starting admin server on %s", config.API.AdminInterface)
+	base.ConsolefCtx(ctx, base.LevelInfo, base.KeyAll, "Starting admin server on %s", config.API.AdminInterface)
 	go func() {
 		if err := sc.Serve(config, config.API.AdminInterface, CreateAdminHandler(sc)); err != nil {
 			base.ErrorfCtx(ctx, "Error serving the Admin API: %v", err)
 		}
 	}()
 
-	base.Consolef(base.LevelInfo, base.KeyAll, "Starting server on %s ...", config.API.PublicInterface)
+	base.ConsolefCtx(ctx, base.LevelInfo, base.KeyAll, "Starting server on %s ...", config.API.PublicInterface)
 	return sc.Serve(config, config.API.PublicInterface, CreatePublicHandler(sc))
 }
 

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -678,7 +678,7 @@ func TestSetupAndValidateLogging(t *testing.T) {
 	t.Skip("Skipping TestSetupAndValidateLogging")
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	sc := &StartupConfig{}
-	err := sc.SetupAndValidateLogging()
+	err := sc.SetupAndValidateLogging(base.TestCtx(t))
 	assert.NoError(t, err, "Setup and validate logging should be successful")
 	assert.NotEmpty(t, sc.Logging)
 }
@@ -688,7 +688,7 @@ func TestSetupAndValidateLoggingWithLoggingConfig(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	logFilePath := "/var/log/sync_gateway"
 	sc := &StartupConfig{Logging: base.LoggingConfig{LogFilePath: logFilePath, RedactionLevel: base.RedactFull}}
-	err := sc.SetupAndValidateLogging()
+	err := sc.SetupAndValidateLogging(base.TestCtx(t))
 	assert.NoError(t, err, "Setup and validate logging should be successful")
 	assert.Equal(t, base.RedactFull, sc.Logging.RedactionLevel)
 }
@@ -1328,13 +1328,13 @@ func TestDefaultLogging(t *testing.T) {
 	assert.Equal(t, base.RedactPartial, config.Logging.RedactionLevel)
 	assert.Equal(t, true, base.RedactUserData)
 
-	require.NoError(t, config.SetupAndValidateLogging())
+	require.NoError(t, config.SetupAndValidateLogging(base.TestCtx(t)))
 	assert.Equal(t, base.LevelNone, *base.ConsoleLogLevel())
 	assert.Equal(t, []string{"HTTP"}, base.ConsoleLogKey().EnabledLogKeys())
 
 	// setting just a log key should enable logging
 	config.Logging.Console = &base.ConsoleLoggerConfig{LogKeys: []string{"CRUD"}}
-	require.NoError(t, config.SetupAndValidateLogging())
+	require.NoError(t, config.SetupAndValidateLogging(base.TestCtx(t)))
 	assert.Equal(t, base.LevelInfo, *base.ConsoleLogLevel())
 	assert.Equal(t, []string{"CRUD", "HTTP"}, base.ConsoleLogKey().EnabledLogKeys())
 }

--- a/rest/main.go
+++ b/rest/main.go
@@ -40,7 +40,7 @@ func serverMain(ctx context.Context, osArgs []string) error {
 	defer base.FatalPanicHandler()
 
 	base.InitializeMemoryLoggers()
-	base.LogSyncGatewayVersion()
+	base.LogSyncGatewayVersion(ctx)
 
 	flagStartupConfig, fs, disablePersistentConfig, err := parseFlags(osArgs)
 	if err != nil {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -711,7 +711,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		return nil, err
 	}
 
-	ctx = base.DatabaseLogCtx(ctx, dbName, contextOptions.LoggingConfig.Console)
+	ctx = base.DatabaseLogCtx(ctx, dbName)
 
 	contextOptions.UseViews = useViews
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1661,13 +1661,16 @@ func (sc *ServerContext) initializeGoCBAgent(ctx context.Context) (*gocbcore.Age
 			sc.Config.Bootstrap.Server, sc.Config.Bootstrap.Username, sc.Config.Bootstrap.Password,
 			sc.Config.Bootstrap.X509CertPath, sc.Config.Bootstrap.X509KeyPath, sc.Config.Bootstrap.CACertPath, sc.Config.Bootstrap.ServerTLSSkipVerify)
 		if err != nil {
-			base.InfofCtx(ctx, base.KeyConfig, "Couldn't initialize cluster agent: %v - will retry...", err)
+			// since we're starting up - let's be verbose (on console) about these retries happening ... otherwise it looks like nothing is happening ...
+			base.ConsolefCtx(ctx, base.LevelInfo, base.KeyConfig, "Couldn't initialize cluster agent: %v - will retry...", err)
 			return true, err, nil
 		}
 
 		return false, nil, agent
 	}, base.CreateSleeperFunc(27, 1000)) // ~2 mins total - 5 second gocb WaitUntilReady timeout and 1 second interval
 	if err != nil {
+		// warn and bubble up error for further handling
+		base.ConsolefCtx(ctx, base.LevelWarn, base.KeyConfig, "Giving up initializing cluster agent after retry: %v", err)
 		return nil, err
 	}
 
@@ -1921,10 +1924,8 @@ func (sc *ServerContext) Database(ctx context.Context, name string) *db.Database
 }
 
 func (sc *ServerContext) initializeCouchbaseServerConnections(ctx context.Context) error {
-	base.InfofCtx(ctx, base.KeyAll, "initializing server connections")
-	defer func() {
-		base.InfofCtx(ctx, base.KeyAll, "finished initializing server connections")
-	}()
+	base.ConsolefCtx(ctx, base.LevelInfo, base.KeyAll, "Initializing server connections...")
+
 	goCBAgent, err := sc.initializeGoCBAgent(ctx)
 	if err != nil {
 		return err
@@ -2001,6 +2002,7 @@ func (sc *ServerContext) initializeCouchbaseServerConnections(ctx context.Contex
 		}
 	}
 
+	base.InfofCtx(ctx, base.KeyAll, "Finished initializing server connections")
 	return nil
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -710,6 +710,9 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	if err != nil {
 		return nil, err
 	}
+
+	ctx = base.DatabaseLogCtx(ctx, dbName, contextOptions.LoggingConfig.Console)
+
 	contextOptions.UseViews = useViews
 
 	javascriptTimeout := getJavascriptTimeout(&config.DbConfig)
@@ -725,9 +728,11 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 				Collections: make(map[string]db.CollectionOptions, len(scopeCfg.Collections)),
 			}
 			for collName, collCfg := range scopeCfg.Collections {
+				ctx := base.CollectionLogCtx(ctx, collName)
+
 				var importFilter *db.ImportFilterFunction
 				if collCfg.ImportFilter != nil {
-					importFilter = db.NewImportFilterFunction(*collCfg.ImportFilter, javascriptTimeout)
+					importFilter = db.NewImportFilterFunction(ctx, *collCfg.ImportFilter, javascriptTimeout)
 				}
 
 				contextOptions.Scopes[scopeName].Collections[collName] = db.CollectionOptions{
@@ -741,7 +746,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		// Set up default import filter
 		var importFilter *db.ImportFilterFunction
 		if config.ImportFilter != nil {
-			importFilter = db.NewImportFilterFunction(*config.ImportFilter, javascriptTimeout)
+			importFilter = db.NewImportFilterFunction(ctx, *config.ImportFilter, javascriptTimeout)
 		}
 
 		contextOptions.Scopes = map[string]db.ScopeOptions{

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -709,7 +709,7 @@ func TestLogFlush(t *testing.T) {
 			config = testCase.EnableFunc(config)
 
 			// Setup logging
-			err := config.SetupAndValidateLogging()
+			err := config.SetupAndValidateLogging(base.TestCtx(t))
 			assert.NoError(t, err)
 
 			// Flush memory loggers


### PR DESCRIPTION
CBG-3270

Cherry-picks:
- https://github.com/couchbase/sync_gateway/commit/5607fbb135d573c000c0366685cb3014518db5fb
- https://github.com/couchbase/sync_gateway/commit/ffab114c6bf899834874e58420eeef0705a77b21
- https://github.com/couchbase/sync_gateway/commit/ef2c538ff82073248c416dfd62b67a8dc0d0b587
- https://github.com/couchbase/sync_gateway/commit/db4b182cd02a57edafe74888daaace8486b5d114
- https://github.com/couchbase/sync_gateway/commit/3b3d1a7005e723b57974479f900d9862a810f984
- https://github.com/couchbase/sync_gateway/commit/c585e4807b2c2dc0a48d54b9da30a23e743560b