### PR TITLE
[3.1.2 Backport] CBG-3360: Increase console log buffer size when writing to file

### DIFF
--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -208,7 +208,12 @@ func (lcc *ConsoleLoggerConfig) init() error {
 	if lcc.CollationBufferSize == nil {
 		bufferSize := 0
 		if *lcc.LogLevel >= LevelInfo {
-			bufferSize = defaultConsoleLoggerCollateBufferSize
+			if lcc.FileOutput != "" {
+				// increase buffer size for file output
+				bufferSize = defaultFileLoggerCollateBufferSize
+			} else {
+				bufferSize = defaultConsoleLoggerCollateBufferSize
+			}
 		}
 		lcc.CollationBufferSize = &bufferSize
 	}


### PR DESCRIPTION
CBG-3360

Backports #6370 to 3.1.2

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a