### PR TITLE
CBG-3352 switch Invalidate to Remove

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -482,7 +482,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 	// Now add the entry for the new doc revision:
 	if len(rawUserXattr) > 0 {
-		collection.revisionCache.Invalidate(c.logCtx, docID, syncData.CurrentRev)
+		collection.revisionCache.Remove(docID, syncData.CurrentRev)
 	}
 	change := &LogEntry{
 		Sequence:     syncData.Sequence,

--- a/db/crud.go
+++ b/db/crud.go
@@ -1949,9 +1949,9 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 				}
 			}
 
-			// Prior to saving doc invalidate the revision in cache
+			// Prior to saving doc, remove the revision in cache
 			if createNewRevIDSkipped {
-				db.revisionCache.Invalidate(ctx, doc.ID, doc.CurrentRev)
+				db.revisionCache.Remove(doc.ID, doc.CurrentRev)
 			}
 
 			base.DebugfCtx(ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.CurrentRev)

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -96,7 +96,7 @@ func (rc *BypassRevisionCache) Upsert(ctx context.Context, docRev DocumentRevisi
 	// no-op
 }
 
-func (rc *BypassRevisionCache) Invalidate(ctx context.Context, docID, revID string) {
+func (rc *BypassRevisionCache) Remove(docID, revID string) {
 	// nop
 }
 

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -46,10 +46,8 @@ type RevisionCache interface {
 	// Update will remove existing value and re-create new one
 	Upsert(ctx context.Context, docRev DocumentRevision)
 
-	// Invalidate marks a revision in the cache as invalid. This is used to call into LoadInvalidRevFromBackingStore in LRU.
-	// Marked revision denotes that this value should not be used and should be replaced. Used in the event of an user
-	// xattr only update where there is no revision change.
-	Invalidate(ctx context.Context, docID, revID string)
+	// Remove eliminates a revision in the cache.
+	Remove(docID, revID string)
 
 	// UpdateDelta stores the given toDelta value in the given rev if cached
 	UpdateDelta(ctx context.Context, docID, revID string, toDelta RevisionDelta)

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -446,7 +446,7 @@ func TestConcurrentLoad(t *testing.T) {
 
 }
 
-func TestInvalidate(t *testing.T) {
+func TestRevisionCacheRemove(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
@@ -459,7 +459,7 @@ func TestInvalidate(t *testing.T) {
 	assert.Equal(t, rev1id, docRev.RevID)
 	assert.Equal(t, int64(0), db.DbStats.Cache().RevisionCacheMisses.Value())
 
-	collection.revisionCache.Invalidate(base.TestCtx(t), "doc", rev1id)
+	collection.revisionCache.Remove("doc", rev1id)
 
 	docRev, err = collection.revisionCache.Get(base.TestCtx(t), "doc", rev1id, true, true)
 	assert.NoError(t, err)


### PR DESCRIPTION
- drop a lock by not checking the value before we remove it from the cache.
- switched name from Invalidate to Remove for clarity

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
