### PR TITLE
CBG-3362: Silence metrics requests

### DIFF
--- a/rest/debug.go
+++ b/rest/debug.go
@@ -96,7 +96,7 @@ func recordCBClientStat(opname, k string, start time.Time, err error) {
 }
 
 func (h *handler) handleExpvar() error {
-	base.InfofCtx(h.ctx(), base.KeyHTTP, "Recording snapshot of current debug variables.")
+	base.DebugfCtx(h.ctx(), base.KeyHTTP, "Recording snapshot of current debug variables.")
 	h.rq.URL.Path = strings.Replace(h.rq.URL.Path, kDebugURLPathPrefix, "/debug/vars", 1)
 	http.DefaultServeMux.ServeHTTP(h.response, h.rq)
 	return nil

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -495,7 +495,7 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 		h.authorizedAdminUser = username
 		h.permissionsResults = permissions
 
-		base.InfofCtx(h.ctx(), base.KeyAuth, "%s: User %s was successfully authorized as an admin", h.formatSerialNumber(), base.UD(username))
+		base.DebugfCtx(h.ctx(), base.KeyAuth, "%s: User %s was successfully authorized as an admin", h.formatSerialNumber(), base.UD(username))
 	} else {
 		// If admin auth is not enabled we should set any responsePermissions to true so that any handlers checking for
 		// these still pass

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -276,7 +276,7 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	r.Handle("/_stats",
 		makeHandler(sc, adminPrivs, []Permission{PermStatsExport}, nil, (*handler).handleStats)).Methods("GET")
 	r.Handle(kDebugURLPathPrefix,
-		makeHandler(sc, adminPrivs, []Permission{PermStatsExport}, nil, (*handler).handleExpvar)).Methods("GET")
+		makeSilentHandler(sc, adminPrivs, []Permission{PermStatsExport}, nil, (*handler).handleExpvar)).Methods("GET")
 	r.Handle("/_profile/{profilename}",
 		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleProfiling)).Methods("POST")
 	r.Handle("/_profile",
@@ -350,8 +350,8 @@ func CreateMetricRouter(sc *ServerContext) *mux.Router {
 	r.StrictSlash(true)
 	r.Handle("/_ping", makeSilentHandler(sc, publicPrivs, nil, nil, (*handler).handlePing)).Methods("GET", "HEAD")
 
-	r.Handle("/_metrics", makeHandler(sc, metricsPrivs, []Permission{PermStatsExport}, nil, (*handler).handleMetrics)).Methods("GET")
-	r.Handle(kDebugURLPathPrefix, makeHandler(sc, metricsPrivs, []Permission{PermStatsExport}, nil, (*handler).handleExpvar)).Methods("GET")
+	r.Handle("/_metrics", makeSilentHandler(sc, metricsPrivs, []Permission{PermStatsExport}, nil, (*handler).handleMetrics)).Methods("GET")
+	r.Handle(kDebugURLPathPrefix, makeSilentHandler(sc, metricsPrivs, []Permission{PermStatsExport}, nil, (*handler).handleExpvar)).Methods("GET")
 
 	return r
 }


### PR DESCRIPTION
CBG-3362

Backport #6376 to 3.1.2

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
