### PR TITLE
[3.1.2 Backport] CBG-3388: Expose Prometheus stats on /metrics on 4986 (#6338)

### DIFF
--- a/docs/api/metric.yaml
+++ b/docs/api/metric.yaml
@@ -31,7 +31,9 @@ paths:
   /_ping:
     $ref: ./paths/common/_ping.yaml
   /_metrics:
-    $ref: ./paths/metric/_metrics.yaml
+    $ref: ./paths/metric/metrics.yaml
+  /metrics:
+    $ref: ./paths/metric/metrics.yaml
   /_expvar:
     $ref: ./paths/metric/_expvar.yaml
 tags:

--- a/docs/api/paths/metric/metrics.yaml
+++ b/docs/api/paths/metric/metrics.yaml
@@ -24,4 +24,4 @@ get:
             type: string
   tags:
     - Prometheus
-  operationId: get__metrics
+  operationId: get_metrics

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -350,6 +350,7 @@ func CreateMetricRouter(sc *ServerContext) *mux.Router {
 	r.StrictSlash(true)
 	r.Handle("/_ping", makeSilentHandler(sc, publicPrivs, nil, nil, (*handler).handlePing)).Methods("GET", "HEAD")
 
+	r.Handle("/metrics", makeSilentHandler(sc, metricsPrivs, []Permission{PermStatsExport}, nil, (*handler).handleMetrics)).Methods("GET")
 	r.Handle("/_metrics", makeHandler(sc, metricsPrivs, []Permission{PermStatsExport}, nil, (*handler).handleMetrics)).Methods("GET")
 	r.Handle(kDebugURLPathPrefix, makeHandler(sc, metricsPrivs, []Permission{PermStatsExport}, nil, (*handler).handleExpvar)).Methods("GET")
 


### PR DESCRIPTION
CBG-3388

Backports #6338 and #6339 to 3.1.2

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
