### PR TITLE
[3.1.2 Backport] CBG-3363: Change log levels for StartOnlineProcesses (#6388)

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -395,7 +395,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		return nil, err
 	}
 
-	dbStats, statsError := initDatabaseStats(dbName, autoImport, options)
+	dbStats, statsError := initDatabaseStats(ctx, dbName, autoImport, options)
 	if statsError != nil {
 		return nil, statsError
 	}
@@ -404,7 +404,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	// but in db package tests this is unlikely to be set. In this case we'll use the existing bucket connection to store metadata.
 	metadataStore := options.MetadataStore
 	if metadataStore == nil {
-		base.DebugfCtx(ctx, base.KeyConfig, "MetadataStore was nil - falling back to use existing bucket connection %q for database %q", bucket.GetName(), dbName)
+		base.DebugfCtx(ctx, base.KeyAll, "MetadataStore was nil - falling back to use existing bucket connection %q for database %q", bucket.GetName(), dbName)
 		metadataStore = bucket.DefaultDataStore()
 	}
 
@@ -1909,7 +1909,7 @@ func (context *DatabaseContext) SetUserViewsEnabled(value bool) {
 	context.Options.UnsupportedOptions.UserViews.Enabled = &value
 }
 
-func initDatabaseStats(dbName string, autoImport bool, options DatabaseContextOptions) (*base.DbStats, error) {
+func initDatabaseStats(ctx context.Context, dbName string, autoImport bool, options DatabaseContextOptions) (*base.DbStats, error) {
 
 	enabledDeltaSync := options.DeltaSyncOptions.Enabled
 	enabledImport := autoImport || options.EnableXattr
@@ -1961,7 +1961,7 @@ func initDatabaseStats(dbName string, autoImport bool, options DatabaseContextOp
 
 	var collections []string
 	if len(options.Scopes) == 0 {
-		base.DebugfCtx(context.TODO(), base.KeyConfig, "No named collections defined for database %q, using default collection for stats", base.MD(dbName))
+		base.DebugfCtx(ctx, base.KeyAll, "No named collections defined for database %q, using default collection for stats", base.MD(dbName))
 		collections = append(collections, base.DefaultScope+"."+base.DefaultCollection)
 	} else {
 		for scopeName, scope := range options.Scopes {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -856,14 +856,14 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 
 	// If asyncOnline wasn't specified, block until db init is completed, then start online processes
 	if !options.asyncOnline || dbInitDoneChan == nil {
-		base.DebugfCtx(ctx, base.KeyConfig, "Waiting for database init to complete...")
+		base.InfofCtx(ctx, base.KeyAll, "Waiting for database init to complete...")
 		if dbInitDoneChan != nil {
 			initError := <-dbInitDoneChan
 			if initError != nil {
 				return nil, initError
 			}
 		}
-		base.DebugfCtx(ctx, base.KeyConfig, "Database init completed, starting online processes")
+		base.InfofCtx(ctx, base.KeyAll, "Database init completed, starting online processes")
 		if err := dbcontext.StartOnlineProcesses(ctx); err != nil {
 			return nil, err
 		}
@@ -873,7 +873,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	} else {
 		// If asyncOnline is requested, set state to Starting and spawn a separate goroutine to wait for init completion
 		// before going online
-		base.DebugfCtx(ctx, base.KeyConfig, "Waiting for database init to complete asynchonously...")
+		base.InfofCtx(ctx, base.KeyAll, "Waiting for database init to complete asynchonously...")
 		atomic.StoreUint32(&dbcontext.State, db.DBStarting)
 		nonCancelCtx := base.NewNonCancelCtxForDatabase(dbName)
 		go sc.asyncDatabaseOnline(nonCancelCtx, dbcontext, dbInitDoneChan, config.Version)
@@ -904,10 +904,10 @@ func (sc *ServerContext) asyncDatabaseOnline(nonCancelCtx base.NonCancellableCon
 		return
 	}
 
-	base.DebugfCtx(ctx, base.KeyConfig, "Async database initialization complete, starting online processes...")
+	base.InfofCtx(ctx, base.KeyAll, "Async database initialization complete, starting online processes...")
 	err := dbc.StartOnlineProcesses(ctx)
 	if err != nil {
-		base.InfofCtx(ctx, base.KeyAll, "Error starting online processes after async initialization: %v", err)
+		base.ErrorfCtx(ctx, "Error starting online processes after async initialization: %v", err)
 		atomic.CompareAndSwapUint32(&dbc.State, db.DBStarting, db.DBOffline)
 	}
 


### PR DESCRIPTION
CBG-3363

Backports #6388 to 3.1.2

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
