### PR TITLE
[3.1.2 Backport] CBG-3359: Per-db console log settings (#6348)

### DIFF
--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -165,7 +165,7 @@ func TestCBGTIndexCreation(t *testing.T) {
 			spec := bucket.BucketSpec
 
 			// Use an in-memory cfg, set up cbgt manager
-			ctx := DatabaseLogCtx(TestCtx(t), tc.dbName)
+			ctx := DatabaseLogCtx(TestCtx(t), tc.dbName, nil)
 			cfg, err := NewCbgtCfgMem()
 			require.NoError(t, err)
 			context, err := initCBGTManager(ctx, bucket, spec, cfg, "testIndexCreation", tc.dbName)

--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -106,7 +106,7 @@ func TestConsoleShouldLog(t *testing.T) {
 			}})
 
 		t.Run(name, func(ts *testing.T) {
-			got := l.shouldLog(test.logToLevel, test.logToKey)
+			got := l.shouldLog(TestCtx(ts), test.logToLevel, test.logToKey)
 			assert.Equal(ts, test.expected, got)
 		})
 	}
@@ -128,7 +128,7 @@ func BenchmarkConsoleShouldLog(b *testing.B) {
 
 		b.Run(name, func(bb *testing.B) {
 			for i := 0; i < bb.N; i++ {
-				l.shouldLog(test.logToLevel, test.logToKey)
+				l.shouldLog(TestCtx(bb), test.logToLevel, test.logToKey)
 			}
 		})
 	}

--- a/base/logging.go
+++ b/base/logging.go
@@ -202,14 +202,14 @@ func logTo(ctx context.Context, logLevel LogLevel, logKey LogKey, format string,
 		SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Add(1)
 	}
 
-	shouldLogConsole := consoleLogger.shouldLog(logLevel, logKey)
+	shouldLogConsole := consoleLogger.shouldLog(ctx, logLevel, logKey)
 	shouldLogError := errorLogger.shouldLog(logLevel)
 	shouldLogWarn := warnLogger.shouldLog(logLevel)
 	shouldLogInfo := infoLogger.shouldLog(logLevel)
 	shouldLogDebug := debugLogger.shouldLog(logLevel)
 	shouldLogTrace := traceLogger.shouldLog(logLevel)
 
-	// exit early if we aren't going to log anything anywhere.
+	// exit before string formatting if no loggers need to log
 	if !(shouldLogConsole || shouldLogError || shouldLogWarn || shouldLogInfo || shouldLogDebug || shouldLogTrace) {
 		return
 	}
@@ -225,6 +225,7 @@ func logTo(ctx context.Context, logLevel LogLevel, logKey LogKey, format string,
 	// Perform log redaction, if necessary.
 	args = redact(args)
 
+	// If either global console or db console wants to log, allow it
 	if shouldLogConsole {
 		consoleLogger.logf(color(format, logLevel), args...)
 	}
@@ -253,7 +254,7 @@ func ConsolefCtx(ctx context.Context, logLevel LogLevel, logKey LogKey, format s
 	logTo(ctx, logLevel, logKey, format, args...)
 
 	// If the above logTo didn't already log to stderr, do it directly here
-	if !consoleLogger.isStderr || !consoleLogger.shouldLog(logLevel, logKey) {
+	if !consoleLogger.isStderr || !consoleLogger.shouldLog(ctx, logLevel, logKey) {
 		format = color(addPrefixes(format, ctx, logLevel, logKey), logLevel)
 		_, _ = fmt.Fprintf(consoleFOutput, format+"\n", args...)
 	}
@@ -365,19 +366,19 @@ func ConsoleLogKey() *LogKeyMask {
 // LogInfoEnabled returns true if either the console should log at info level,
 // or if the infoLogger is enabled.
 func LogInfoEnabled(logKey LogKey) bool {
-	return consoleLogger.shouldLog(LevelInfo, logKey) || infoLogger.shouldLog(LevelInfo)
+	return consoleLogger.shouldLog(nil, LevelInfo, logKey) || infoLogger.shouldLog(LevelInfo)
 }
 
 // LogDebugEnabled returns true if either the console should log at debug level,
 // or if the debugLogger is enabled.
 func LogDebugEnabled(logKey LogKey) bool {
-	return consoleLogger.shouldLog(LevelDebug, logKey) || debugLogger.shouldLog(LevelDebug)
+	return consoleLogger.shouldLog(nil, LevelDebug, logKey) || debugLogger.shouldLog(LevelDebug)
 }
 
 // LogTraceEnabled returns true if either the console should log at trace level,
 // or if the traceLogger is enabled.
 func LogTraceEnabled(logKey LogKey) bool {
-	return consoleLogger.shouldLog(LevelTrace, logKey) || traceLogger.shouldLog(LevelTrace)
+	return consoleLogger.shouldLog(nil, LevelTrace, logKey) || traceLogger.shouldLog(LevelTrace)
 }
 
 // AssertLogContains asserts that the logs produced by function f contain string s.

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -23,23 +23,32 @@ import (
 // LogContext stores values which may be useful to include in logs
 type LogContext struct {
 	// CorrelationID is a pre-formatted identifier used to correlate logs.
-	// E.g: Either blip context ID or HTTP Serial number.
+	// E.g: Either blip context ID or HTTP Serial number. (see CorrelationIDLogCtx)
 	CorrelationID string
 
-	// Database is the name of the sync gateway database
+	// Database is the name of the sync gateway database (see DatabaseLogCtx)
 	Database string
 
-	// Bucket is the name of the backing bucket
+	// DbConsoleLogConfig is database-specific log settings that should be applied (see DatabaseLogCtx)
+	DbConsoleLogConfig *DbConsoleLogConfig
+
+	// Bucket is the name of the backing bucket (see KeyspaceLogCtx)
 	Bucket string
 
-	// Scope is the name of a scope
+	// Scope is the name of a scope see (KeyspaceLogCtx)
 	Scope string
 
-	// Collection is the name of the collection
+	// Collection is the name of the collection (see KeyspaceLogCtx)
 	Collection string
 
-	// TestName can be a unit test name (from t.Name())
+	// TestName can be a unit test name (see TestCtx)
 	TestName string
+}
+
+// DbConsoleLogConfig can be used to customise the console logging for logs associated with this database.
+type DbConsoleLogConfig struct {
+	LogLevel *LogLevel
+	LogKeys  *LogKeyMask
 }
 
 // addContext returns a string format with additional log context if present.
@@ -148,9 +157,10 @@ func CorrelationIDLogCtx(parent context.Context, correlationID string) context.C
 }
 
 // DatabaseLogCtx extends the parent context with a database.
-func DatabaseLogCtx(parent context.Context, databaseName string) context.Context {
+func DatabaseLogCtx(parent context.Context, databaseName string, config *DbConsoleLogConfig) context.Context {
 	newCtx := getLogCtx(parent)
 	newCtx.Database = databaseName
+	newCtx.DbConsoleLogConfig = config
 	return LogContextWith(parent, &newCtx)
 }
 

--- a/base/logging_context_test.go
+++ b/base/logging_context_test.go
@@ -235,7 +235,7 @@ func TestCtxWorkflow(t *testing.T) {
 	RequireLogMessage(t, correlationCtx, "[INF] t:TestCtxWorkflow c:correlationID foobar\n", standardMessage)
 	RequireLogMessage(t, ctx, "[INF] t:TestCtxWorkflow foobar\n", standardMessage)
 
-	databaseCtx := DatabaseLogCtx(keyspaceCtx, "fooDB")
+	databaseCtx := DatabaseLogCtx(keyspaceCtx, "fooDB", nil)
 	RequireLogMessage(t, databaseCtx, "[INF] t:TestCtxWorkflow c:correlationID db:fooDB col:fooCollection foobar\n", standardMessage)
 	RequireLogMessage(t, keyspaceCtx, "[INF] t:TestCtxWorkflow c:correlationID b:fooBucket.fooScope.fooCollection foobar\n", standardMessage)
 	RequireLogMessage(t, bucketCtx, "[INF] t:TestCtxWorkflow c:correlationID b:fooBucket foobar\n", standardMessage)

--- a/base/util.go
+++ b/base/util.go
@@ -64,8 +64,8 @@ func NewNonCancelCtx() NonCancellableContext {
 }
 
 // NewNonCancelCtx creates a new background context struct for operations that require a fresh context, with database logging context added
-func NewNonCancelCtxForDatabase(dbName string) NonCancellableContext {
-	dbLogContext := DatabaseLogCtx(context.Background(), dbName)
+func NewNonCancelCtxForDatabase(dbName string, dbConsoleLogConfig *DbConsoleLogConfig) NonCancellableContext {
+	dbLogContext := DatabaseLogCtx(context.Background(), dbName, dbConsoleLogConfig)
 	ctxStruct := NonCancellableContext{
 		Ctx: dbLogContext,
 	}

--- a/db/database.go
+++ b/db/database.go
@@ -176,6 +176,12 @@ type DatabaseContextOptions struct {
 	BlipStatsReportingInterval    int64          // interval to report blip stats in milliseconds
 	ChangesRequestPlus            bool           // Sets the default value for request_plus, for non-continuous changes feeds
 	ConfigPrincipals              *ConfigPrincipals
+	LoggingConfig                 DbLogConfig // Per-database log configuration
+}
+
+// DbLogConfig can be used to customise the logging for logs associated with this database.
+type DbLogConfig struct {
+	Console *base.DbConsoleLogConfig
 }
 
 type ConfigPrincipals struct {
@@ -384,7 +390,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 
 	// add db info to ctx before having a DatabaseContext (cannot call AddDatabaseLogContext),
 	// in order to pass it to RegisterImportPindexImpl
-	ctx = base.DatabaseLogCtx(ctx, dbName)
+	ctx = base.DatabaseLogCtx(ctx, dbName, options.LoggingConfig.Console)
 
 	if err := base.RequireNoBucketTTL(bucket); err != nil {
 		return nil, err
@@ -2029,7 +2035,8 @@ func CheckTimeout(ctx context.Context) error {
 // AddDatabaseLogContext adds database name to the parent context for logging
 func (dbCtx *DatabaseContext) AddDatabaseLogContext(ctx context.Context) context.Context {
 	if dbCtx != nil && dbCtx.Name != "" {
-		return base.DatabaseLogCtx(ctx, dbCtx.Name)
+		dbLogCtx := base.DatabaseLogCtx(ctx, dbCtx.Name, dbCtx.Options.LoggingConfig.Console)
+		return dbLogCtx
 	}
 	return ctx
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2695,7 +2695,7 @@ func Test_invalidateAllPrincipalsCache(t *testing.T) {
 	defer db.Close(ctx)
 	db.Options.QueryPaginationLimit = 100
 
-	sequenceAllocator, err := newSequenceAllocator(base.DatabaseLogCtx(base.TestCtx(t), db.Name), db.MetadataStore, db.DbStats.DatabaseStats, db.MetadataKeys)
+	sequenceAllocator, err := newSequenceAllocator(base.DatabaseLogCtx(base.TestCtx(t), db.Name, nil), db.MetadataStore, db.DbStats.DatabaseStats, db.MetadataKeys)
 	assert.NoError(t, err)
 
 	db.sequences = sequenceAllocator

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1781,6 +1781,31 @@ Database:
           type: array
           items:
             type: string
+    logging:
+      description: Per-database logging configuration.
+      type: object
+      properties:
+        console:
+          description: Console logging configuration.
+          type: object
+          properties:
+            log_level:
+              description: Log Level for the console output
+              type: string
+              enum:
+                - none
+                - error
+                - warn
+                - info
+                - debug
+                - trace
+              example: debug
+            log_keys:
+              description: Log Keys for the console output
+              type: array
+              items:
+                type: string
+              example: ["CRUD", "HTTP", "Query"]
   title: Database-config
 Event-config:
   type: object

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -3997,7 +3997,7 @@ func TestOneShotGrantTiming(t *testing.T) {
 	require.Len(t, changes.Results, 0)
 
 	// Release the slow sequence and wait for it to be processed over DCP
-	releaseErr := db.ReleaseTestSequence(base.DatabaseLogCtx(base.TestCtx(t), database.Name), database, slowSequence)
+	releaseErr := db.ReleaseTestSequence(base.DatabaseLogCtx(base.TestCtx(t), database.Name, nil), database, slowSequence)
 	require.NoError(t, releaseErr)
 	require.NoError(t, rt.WaitForPendingChanges())
 
@@ -4095,7 +4095,7 @@ func TestOneShotGrantRequestPlus(t *testing.T) {
 	require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+2))
 
 	// Release the slow sequence and wait for it to be processed over DCP
-	releaseErr := db.ReleaseTestSequence(base.DatabaseLogCtx(base.TestCtx(t), database.Name), database, slowSequence)
+	releaseErr := db.ReleaseTestSequence(base.DatabaseLogCtx(base.TestCtx(t), database.Name, nil), database, slowSequence)
 	require.NoError(t, releaseErr)
 	require.NoError(t, rt.WaitForPendingChanges())
 
@@ -4213,7 +4213,7 @@ func TestOneShotGrantRequestPlusDbConfig(t *testing.T) {
 	require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+2))
 
 	// Release the slow sequence and wait for it to be processed over DCP
-	releaseErr := db.ReleaseTestSequence(base.DatabaseLogCtx(base.TestCtx(t), database.Name), database, slowSequence)
+	releaseErr := db.ReleaseTestSequence(base.DatabaseLogCtx(base.TestCtx(t), database.Name, nil), database, slowSequence)
 	require.NoError(t, releaseErr)
 	require.NoError(t, rt.WaitForPendingChanges())
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -166,7 +166,8 @@ type DbConfig struct {
 	UserFunctions                    *functions.FunctionsConfig       `json:"functions,omitempty"`                            // Named JS fns for clients to call
 	Suspendable                      *bool                            `json:"suspendable,omitempty"`                          // Allow the database to be suspended
 	ChangesRequestPlus               *bool                            `json:"changes_request_plus,omitempty"`                 // If set, is used as the default value of request_plus for non-continuous replications
-	CORS                             *auth.CORSConfig                 `json:"cors,omitempty"`
+	CORS                             *auth.CORSConfig                 `json:"cors,omitempty"`                                 // Per-database CORS config
+	Logging                          *DbLoggingConfig                 `json:"logging,omitempty"`                              // Per-database Logging config
 }
 
 type ScopesConfig map[string]ScopeConfig
@@ -236,6 +237,17 @@ type ChannelCacheConfig struct {
 	MinLength            *int    `json:"min_length,omitempty"`                 // Minimum number of entries maintained in cache per channel
 	ExpirySeconds        *int    `json:"expiry_seconds,omitempty"`             // Time (seconds) to keep entries in cache beyond the minimum retained
 	DeprecatedQueryLimit *int    `json:"query_limit,omitempty"`                // Limit used for channel queries, if not specified by client DEPRECATED in favour of db.QueryPaginationLimit
+}
+
+// DbLoggingConfig allows per-database logging overrides
+type DbLoggingConfig struct {
+	Console *DbConsoleLoggingConfig `json:"console,omitempty"`
+}
+
+// DbConsoleLoggingConfig are per-db options configurable for console logging
+type DbConsoleLoggingConfig struct {
+	LogLevel *base.LogLevel `json:"log_level,omitempty"`
+	LogKeys  []string       `json:"log_keys,omitempty"`
 }
 
 func GetTLSVersionFromString(stringV *string) uint16 {

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -686,7 +686,7 @@ func (b *bootstrapContext) getRegistryAndDatabase(ctx context.Context, bucketNam
 }
 
 func (b *bootstrapContext) addDatabaseLogContext(ctx context.Context, dbName string) context.Context {
-	return base.DatabaseLogCtx(ctx, dbName)
+	return base.DatabaseLogCtx(ctx, dbName, nil)
 }
 
 func (b *bootstrapContext) ComputeMetadataIDForDbConfig(ctx context.Context, config *DbConfig) (string, error) {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -208,9 +208,9 @@ func (h *handler) ctx() context.Context {
 	return h.rqCtx
 }
 
-func (h *handler) addDatabaseLogContext(dbName string) {
+func (h *handler) addDatabaseLogContext(dbName string, logConfig *base.DbConsoleLogConfig) {
 	if dbName != "" {
-		h.rqCtx = base.DatabaseLogCtx(h.ctx(), dbName)
+		h.rqCtx = base.DatabaseLogCtx(h.ctx(), dbName, logConfig)
 	}
 }
 
@@ -331,9 +331,9 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 
 	// look up the database context:
 	if keyspaceDb != "" {
-		h.addDatabaseLogContext(keyspaceDb)
 		var err error
 		if dbContext, err = h.server.GetActiveDatabase(keyspaceDb); err != nil {
+			h.addDatabaseLogContext(keyspaceDb, nil)
 			if err == base.ErrNotFound {
 				if shouldCheckAdminAuth {
 					// Check if authenticated before attempting to get inactive database
@@ -373,6 +373,7 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 
 	// If this call is in the context of a DB make sure the DB is in a valid state
 	if dbContext != nil {
+		h.addDatabaseLogContext(keyspaceDb, dbContext.Options.LoggingConfig.Console)
 		if !h.runOffline {
 			// get a read lock on the dbContext
 			// When the lock is returned we know that the db state will not be changed by

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -875,7 +875,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		// before going online
 		base.DebugfCtx(ctx, base.KeyConfig, "Waiting for database init to complete asynchonously...")
 		atomic.StoreUint32(&dbcontext.State, db.DBStarting)
-		nonCancelCtx := base.NewNonCancelCtxForDatabase(dbName)
+		nonCancelCtx := base.NewNonCancelCtxForDatabase(dbName, dbcontext.Options.LoggingConfig.Console)
 		go sc.asyncDatabaseOnline(nonCancelCtx, dbcontext, dbInitDoneChan, config.Version)
 		return dbcontext, nil
 	}
@@ -1177,6 +1177,15 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		// UserQueries:               config.UserQueries,   // behind feature flag (see below)
 		// UserFunctions:             config.UserFunctions, // behind feature flag (see below)
 		// GraphQL:                   config.GraphQL,       // behind feature flag (see below)
+	}
+
+	// Per-database console logging config overrides
+	if config.Logging != nil && config.Logging.Console != nil {
+		logKey := base.ToLogKey(config.Logging.Console.LogKeys)
+		contextOptions.LoggingConfig.Console = &base.DbConsoleLogConfig{
+			LogLevel: config.Logging.Console.LogLevel,
+			LogKeys:  &logKey,
+		}
 	}
 
 	if sc.Config.Unsupported.UserQueries != nil && *sc.Config.Unsupported.UserQueries {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -711,7 +711,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		return nil, err
 	}
 
-	ctx = base.DatabaseLogCtx(ctx, dbName)
+	ctx = base.DatabaseLogCtx(ctx, dbName, contextOptions.LoggingConfig.Console)
 
 	contextOptions.UseViews = useViews
 


### PR DESCRIPTION
CBG-3359

Backports #6348 to 3.1.2

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
