### PR TITLE
(3.0.8.2 backport) CBG-3332 increase log information for documents not imported (#6391)

### DIFF
--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -101,7 +101,7 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) (shouldPers
 
 	// If this is a binary document we can ignore, but update checkpoint to avoid reprocessing upon restart
 	if event.DataType == base.MemcachedDataTypeRaw {
-		base.InfofCtx(il.loggingCtx, base.KeyImport, "Ignoring binary mutation event for %s.", base.UD(event.Key))
+		base.Infof(base.KeyImport, "Ignoring binary mutation event for %s.", base.UD(event.Key))
 		return true
 	}
 
@@ -119,7 +119,7 @@ func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
 		} else {
 			base.Warnf("Found sync metadata, but unable to unmarshal for feed document %q.  Will not be imported.  Error: %v", base.UD(event.Key), err)
 		}
-		il.stats.SharedBucketImport().ImportErrorCount.Add(1)
+		il.database.DbStats.SharedBucketImport().ImportErrorCount.Add(1)
 		return
 	}
 

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -473,3 +473,31 @@ func TestEvaluateFunction(t *testing.T) {
 	assert.Error(t, err, `strconv.ParseBool: parsing "TruE": invalid syntax`)
 	assert.False(t, result, "Import filter function should return true")
 }
+
+// TestImportInvalidMetadata tests triggering an import error if the metadata is unmarshalable
+func TestImportInvalidMetadata(t *testing.T) {
+	if !base.TestUseXattrs() || base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works with XATTRS enabled and in integration mode")
+	}
+
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+
+	db, ctx := setupTestDBWithOptionsAndImport(t, bucket, DatabaseContextOptions{})
+	defer db.Close(ctx)
+
+	// make sure no documents are imported
+	require.Equal(t, int64(0), db.DbStats.SharedBucketImport().ImportCount.Value())
+	require.Equal(t, int64(0), db.DbStats.SharedBucketImport().ImportErrorCount.Value())
+
+	// write a document with inline sync metadata that is unmarshalable, triggering an import error
+	// can't write a document with invalid sync metadata as an xattr, so rely on legacy behavior
+	_, err := bucket.GetSingleDataStore().Add("doc1", 0, `{"foo" : "bar", "_sync" : 1 }`)
+	require.NoError(t, err)
+
+	_, ok := base.WaitForStat(func() int64 {
+		return db.DbStats.SharedBucketImport().ImportErrorCount.Value()
+	}, 1)
+	require.True(t, ok)
+	require.Equal(t, int64(0), db.DbStats.SharedBucketImport().ImportCount.Value())
+}

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -480,11 +480,8 @@ func TestImportInvalidMetadata(t *testing.T) {
 		t.Skip("This test only works with XATTRS enabled and in integration mode")
 	}
 
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close()
-
-	db, ctx := setupTestDBWithOptionsAndImport(t, bucket, DatabaseContextOptions{})
-	defer db.Close(ctx)
+	db := setupTestDBWithOptionsAndImport(t, DatabaseContextOptions{})
+	defer db.Close()
 
 	// make sure no documents are imported
 	require.Equal(t, int64(0), db.DbStats.SharedBucketImport().ImportCount.Value())
@@ -492,7 +489,7 @@ func TestImportInvalidMetadata(t *testing.T) {
 
 	// write a document with inline sync metadata that is unmarshalable, triggering an import error
 	// can't write a document with invalid sync metadata as an xattr, so rely on legacy behavior
-	_, err := bucket.GetSingleDataStore().Add("doc1", 0, `{"foo" : "bar", "_sync" : 1 }`)
+	_, err := db.Bucket.Add("doc1", 0, `{"foo" : "bar", "_sync" : 1 }`)
 	require.NoError(t, err)
 
 	_, ok := base.WaitForStat(func() int64 {


### PR DESCRIPTION
## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-go1.16.15/69/
