### PR TITLE
CBG-3285 fix DefaultDbConfig CompactIntervalDays

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -58,6 +58,7 @@ const (
 	DefaultPurgeInterval                    = 30 * 24 * time.Hour
 	DefaultSGReplicateEnabled               = true
 	DefaultSGReplicateWebsocketPingInterval = time.Minute * 5
+	DefaultCompactInterval                  = 24 * time.Hour
 )
 
 // Default values for delta sync
@@ -66,7 +67,6 @@ var (
 	DefaultDeltaSyncRevMaxAge = uint32(60 * 60 * 24) // 24 hours in seconds
 )
 
-var DefaultCompactInterval = uint32(60 * 60 * 24) // Default compact interval in seconds = 1 Day
 var (
 	DefaultQueryPaginationLimit = 5000
 )

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -169,7 +169,7 @@ func DefaultDbConfig(sc *StartupConfig) *DbConfig {
 			Enabled:          base.BoolPtr(db.DefaultDeltaSyncEnabled),
 			RevMaxAgeSeconds: base.Uint32Ptr(db.DefaultDeltaSyncRevMaxAge),
 		},
-		CompactIntervalDays:              base.Float32Ptr(float32(db.DefaultCompactInterval)),
+		CompactIntervalDays:              base.Float32Ptr(float32(db.DefaultCompactInterval.Hours() / 24)),
 		SGReplicateEnabled:               base.BoolPtr(db.DefaultSGReplicateEnabled),
 		SGReplicateWebsocketPingInterval: base.IntPtr(int(db.DefaultSGReplicateWebsocketPingInterval.Seconds())),
 		Replications:                     nil,

--- a/rest/config_database_test.go
+++ b/rest/config_database_test.go
@@ -1,0 +1,23 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultDbConfig(t *testing.T) {
+	sc := DefaultStartupConfig("")
+	compactIntervalDays := *(DefaultDbConfig(&sc).CompactIntervalDays)
+	require.Equal(t, db.DefaultCompactInterval, time.Duration(compactIntervalDays)*time.Hour*24)
+}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1069,7 +1069,7 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 	}
 	base.InfofCtx(ctx, base.KeyAll, "delta_sync enabled=%t with rev_max_age_seconds=%d for database %s", deltaSyncOptions.Enabled, deltaSyncOptions.RevMaxAgeSeconds, dbName)
 
-	compactIntervalSecs := db.DefaultCompactInterval
+	compactIntervalSecs := uint32(db.DefaultCompactInterval.Seconds())
 	if config.CompactIntervalDays != nil {
 		compactIntervalSecs = uint32(*config.CompactIntervalDays * 60 * 60 * 24)
 	}


### PR DESCRIPTION
This amounts to a change that only affects test code, I think. Moved `DefaultCompactInterval` to a typed constant and wrote tests to make sure we round trip data correctly.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`