### PR TITLE
(3.1.2 backport) CBG-3350 Restore 3.0.x read buffer size for cbgt

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -326,6 +326,10 @@ func initCBGTManager(ctx context.Context, bucket Bucket, spec BucketSpec, cfgSG 
 	// cbgt uses this parameter to run in mixed mode - non-TLS for CCCP but TLS for memcached. Sync Gateway does not need to set this parameter.
 	options["feedInitialBootstrapNonTLS"] = "false"
 
+	// Since cbgt initializes a buffer per CBS node per partition in most cases (vbuckets in partitions can't be grouped by CBS node),
+	// setting the small buffer size used in cbgt 1.3.2.  (see CBG-3341 for potential optimization of this value)
+	options["kvConnectionBufferSize"] = "16384"
+
 	// Disable collections if unsupported
 	if !bucket.IsSupported(sgbucket.BucketStoreFeatureCollections) {
 		options["disableCollectionsSupport"] = "true"


### PR DESCRIPTION
backport of CBG-3283 Restore 3.0.x read buffer size for cbgt (#6386)

Restores the 3.0.x read buffer size, to avoid memory growth in 3.1.1 associated with cbgt/import.
