### PR TITLE
CBG-1669: Warn -> Debug for 'gap in revision list' log

### DIFF
--- a/db/revtree.go
+++ b/db/revtree.go
@@ -796,7 +796,7 @@ func encodeRevisions(docID string, revs []string) Revisions {
 		if i == 0 {
 			start = gen
 		} else if gen != start-i {
-			base.WarnfCtx(context.TODO(), "Found gap in revision list for doc %q. Expecting gen %v but got %v in %v", base.UD(docID), start-i, gen, revs)
+			base.DebugfCtx(context.TODO(), base.KeyCRUD, "Found gap in revision list for doc %q. Expecting gen %v but got %v in %v", base.UD(docID), start-i, gen, revs)
 		}
 	}
 	return Revisions{RevisionsStart: start, RevisionsIds: ids}


### PR DESCRIPTION
CBG-1669

Change log level for the expected 'gap in revision list' log message.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a