### PR TITLE
[3.0.9 backport] CBG-3130 notify on request plus unused sequence docs (#6326)

### DIFF
--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -554,7 +554,7 @@ func TestChannelCacheBufferingWithUserDoc(t *testing.T) {
 	WriteDirect(db, []string{"ABC"}, 2)
 
 	// Start wait for doc in ABC
-	waiter := db.mutationListener.NewWaiterWithChannels(channels.SetOf(t, "ABC"), nil)
+	waiter := db.mutationListener.NewWaiterWithChannels(channels.SetOf(t, "ABC"), nil, false)
 
 	successChan := make(chan bool)
 	go func() {

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -44,6 +44,9 @@ type ChannelCache interface {
 	// Notifies the cache of a principal update.  Updates the cache's high sequence
 	AddPrincipal(change *LogEntry)
 
+	// Notifies the cache of a skipped sequence update. Updates the cache's high sequence
+	AddSkippedSequence(change *LogEntry)
+
 	// Remove purges the given doc IDs from all channel caches and returns the number of items removed.
 	Remove(docIDs []string, startTime time.Time) (count int)
 
@@ -180,6 +183,11 @@ func (c *channelCacheImpl) getSingleChannelCache(channelName string) SingleChann
 }
 
 func (c *channelCacheImpl) AddPrincipal(change *LogEntry) {
+	c.updateHighCacheSequence(change.Sequence)
+}
+
+// AddSkipedSequence notifies the cache of a skipped sequence update. Updates the cache's high sequence
+func (c *channelCacheImpl) AddSkippedSequence(change *LogEntry) {
 	c.updateHighCacheSequence(change.Sequence)
 }
 

--- a/rest/changes_request_plus_test.go
+++ b/rest/changes_request_plus_test.go
@@ -1,0 +1,63 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRequirePlusSkippedSequence makes sure that a final skipped sequence in a request_plus request will not hang the request
+func TestRequestPlusSkippedSequence(t *testing.T) {
+
+	defer db.SuspendSequenceBatching()()
+
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	const (
+		username = "alice"
+		channel  = "foo"
+	)
+	rt.CreateUser(username, []string{channel})
+
+	// add a single document for the user
+	resp := rt.SendAdminRequest(http.MethodPut, "/db/doc1", fmt.Sprintf(`{"channels":"%s"}`, channel))
+	RequireStatus(t, resp, http.StatusCreated)
+	docSeq := rt.GetDocumentSequence("doc1")
+
+	require.NoError(t, rt.WaitForPendingChanges())
+
+	// add an unused sequence
+	unusedSeq, err := db.AllocateTestSequence(rt.GetDatabase())
+	require.NoError(t, err)
+
+	caughtUpCount := rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplCaughtUp.Value()
+
+	requestFinished := make(chan struct{})
+	// make sure this request doesn't hang
+	go func() {
+		resp = rt.SendUserRequest(http.MethodGet, fmt.Sprintf("/db/_changes?since=%d&request_plus=true", docSeq), "", username)
+		RequireStatus(t, resp, http.StatusOK)
+		close(requestFinished)
+	}()
+	require.NoError(t, rt.GetDatabase().WaitForCaughtUp(caughtUpCount+1))
+	// the request should finish once the sequence is released
+	err = db.ReleaseTestSequence(rt.GetDatabase(), unusedSeq)
+	require.NoError(t, err)
+	<-requestFinished
+	var changesResp changesResults
+	require.NoError(t, json.Unmarshal(resp.BodyBytes(), &changesResp))
+	require.Len(t, changesResp.Results, 0)
+}


### PR DESCRIPTION
* backport ticket CBG-3242
* CBG-3130 notify on request plus skipped sequence docs

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-go1.16.15/70/ (known failures
