### PR TITLE
[3.1.2 backport] CBG-3273: Fix revocation feed loop (#6378)

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -251,6 +251,7 @@ func (db *DatabaseCollectionWithUser) buildRevokedFeed(ctx context.Context, ch c
 				// Otherwise: we need to determine whether a previous revision of the document was in the channel prior
 				// to the since value, and only send a revocation if that was the case
 
+				lastSeq = logEntry.Sequence
 				if logEntry.Sequence > sinceVal {
 					// Get doc sync data so we can verify the docs grant history
 					syncData, err := db.GetDocSyncData(ctx, logEntry.DocID)
@@ -289,7 +290,6 @@ func (db *DatabaseCollectionWithUser) buildRevokedFeed(ctx context.Context, ch c
 				}
 
 				change := makeRevocationChangeEntry(logEntry, seqID, singleChannelCache.ChannelID())
-				lastSeq = logEntry.Sequence
 
 				base.DebugfCtx(ctx, base.KeyChanges, "Channel feed processing revocation seq: %v in channel %s ", seqID, base.UD(singleChannelCache.ChannelID().Name))
 


### PR DESCRIPTION
* backport ticket CBG-3330
* Add TestRevocationsWithQueryLimit2Channels and fix loop
* Move lastSeq assignment before inner loop

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2012/
