### PR TITLE
CBG-3412: [3.0.9] Fix panic for assigning to nil map inside Mutable1xBody

### DIFF
--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1283,6 +1283,18 @@ func TestGet1xRevAndChannels(t *testing.T) {
 	assert.Equal(t, []interface{}{"a", "a"}, revisions[RevisionsIds])
 }
 
+func TestNullDocHandlingForMutable1xBody(t *testing.T) {
+
+	db := setupTestDB(t)
+
+	documentRev := DocumentRevision{DocID: "doc1", BodyBytes: []byte("null")}
+
+	body, err := documentRev.Mutable1xBody(db, nil, nil, false)
+	require.Error(t, err)
+	require.Nil(t, body)
+	assert.Contains(t, err.Error(), "null doc body for doc")
+}
+
 func TestGet1xRevFromDoc(t *testing.T) {
 	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -161,6 +161,9 @@ func (rev *DocumentRevision) Mutable1xBody(db *Database, requestedHistory Revisi
 	if err != nil {
 		return nil, err
 	}
+	if b == nil {
+		return nil, base.RedactErrorf("null doc body for docID: %s revID: %s", base.UD(rev.DocID), base.UD(rev.RevID))
+	}
 
 	b[BodyId] = rev.DocID
 	b[BodyRev] = rev.RevID

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -8138,6 +8138,19 @@ func TestDocChannelSetPruning(t *testing.T) {
 	assert.Equal(t, uint64(12), syncData.ChannelSetHistory[0].End)
 }
 
+func TestNullDocHandlingForMutable1xBody(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollectionWithUser()
+
+	documentRev := db.DocumentRevision{DocID: "doc1", BodyBytes: []byte("null")}
+
+	body, err := documentRev.Mutable1xBody(collection, nil, nil, false)
+	require.Error(t, err)
+	require.Nil(t, body)
+	assert.Contains(t, err.Error(), "null doc body for doc")
+}
+
 func TestBasicAttachmentRemoval(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -8138,19 +8138,6 @@ func TestDocChannelSetPruning(t *testing.T) {
 	assert.Equal(t, uint64(12), syncData.ChannelSetHistory[0].End)
 }
 
-func TestNullDocHandlingForMutable1xBody(t *testing.T) {
-	rt := NewRestTester(t, nil)
-	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollectionWithUser()
-
-	documentRev := db.DocumentRevision{DocID: "doc1", BodyBytes: []byte("null")}
-
-	body, err := documentRev.Mutable1xBody(collection, nil, nil, false)
-	require.Error(t, err)
-	require.Nil(t, body)
-	assert.Contains(t, err.Error(), "null doc body for doc")
-}
-
 func TestBasicAttachmentRemoval(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})


### PR DESCRIPTION
CBG-3412

Backport of the fix for panic found in Mutable1xBody. Had to move the test out of rest package into the db package as function parameters have changed since 3.1 and made more sense for it to be here as rest tester was no longer needed. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2013/
