### PR TITLE
CBG-3385: link up the reset resync code to the api for a user to use

### DIFF
--- a/docs/api/paths/admin/db-_resync.yaml
+++ b/docs/api/paths/admin/db-_resync.yaml
@@ -61,6 +61,12 @@ post:
       description: '**Use this only when requested to do so by the Couchbase support team** This request will regenerate the sequence numbers for each document processed.'
       schema:
         type: boolean
+    - name: reset
+      in: query
+      description: This forces a fresh resync run instead of trying to resume the previous resync operation
+      schema:
+        type : bool
+        default: false
   requestBody:
     content:
       application/json:

--- a/docs/api/paths/admin/db-_resync.yaml
+++ b/docs/api/paths/admin/db-_resync.yaml
@@ -65,7 +65,7 @@ post:
       in: query
       description: This forces a fresh resync run instead of trying to resume the previous resync operation
       schema:
-        type : bool
+        type: boolean
         default: false
   requestBody:
     content:

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -917,6 +917,71 @@ func TestResyncUsingDCPStream(t *testing.T) {
 	}
 }
 
+func TestResyncUsingDCPStreamReset(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't works with walrus")
+	}
+	base.LongRunningTest(t)
+
+	syncFn := `
+	function(doc) {
+		channel("x")
+	}`
+
+	rt := rest.NewRestTester(t,
+		&rest.RestTesterConfig{
+			SyncFn: syncFn,
+		},
+	)
+	defer rt.Close()
+
+	const numDocs = 1000
+
+	_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
+	if !ok {
+		rt.GetDatabase().ResyncManager = db.NewResyncManagerDCP(rt.GetSingleDataStore(), base.TestUseXattrs(), rt.GetDatabase().MetadataKeys)
+	}
+
+	// create some docs
+	for i := 0; i < numDocs; i++ {
+		rt.CreateDoc(t, fmt.Sprintf("doc%d", i))
+	}
+
+	// take db offline to run resync against it
+	response := rt.SendAdminRequest("POST", "/db/_offline", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+
+	// wait for db to be offline
+	err := rt.WaitForDBState(db.RunStateString[db.DBOffline])
+	require.NoError(t, err)
+
+	// start a resync run
+	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+
+	resyncManagerStatus := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
+	resyncID := resyncManagerStatus.ResyncID
+
+	// stop resync before it completes, assert it has been aborted
+	response = rt.SendAdminRequest("POST", "/db/_resync?action=stop", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+
+	_ = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateStopped)
+
+	// reset the resync process through the endpoint
+	response = rt.SendAdminRequest("POST", "/db/_resync?reset=true", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+
+	// grab new resync status from rest run, assert the resync if is not the same as the first
+	// run and that the docs processed is equal to number of docs we have created
+	resyncManagerStatus = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
+	assert.NotEqual(t, resyncID, resyncManagerStatus.ResyncID)
+
+	resyncManagerStatus = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+	assert.Equal(t, int64(numDocs), resyncManagerStatus.DocsProcessed)
+
+}
+
 func TestResyncForNamedCollection(t *testing.T) {
 	base.TestRequiresCollections(t)
 

--- a/rest/api.go
+++ b/rest/api.go
@@ -319,6 +319,7 @@ func (h *handler) handlePostResync() error {
 				"database":            h.db,
 				"regenerateSequences": regenerateSequences,
 				"collections":         resyncPostReqBody.Scope,
+				"reset":               h.getBoolQuery("reset"),
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
CBG-3385

Simple PR to connect reset code already there to something the user can trigger through a query parameter on the rest endpoint. including test that asserts the resync operation does actually reset once called. 
Also updated the api docs to reflect addition to the query parameter.  

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2015/
