### PR TITLE
Reenable TestMultiCollectionDCP and fix

### DIFF
--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -230,19 +230,12 @@ func TestSingleCollectionDCP(t *testing.T) {
 
 func TestMultiCollectionDCP(t *testing.T) {
 	base.TestRequiresCollections(t)
-
-	if !base.TestUseXattrs() {
-		t.Skip("Test relies on import - needs xattrs")
-	}
+	base.SkipImportTestsIfNotEnabled(t)
 
 	const numCollections = 2
 
-	tb := base.GetTestBucket(t)
-	defer tb.Close()
-
 	rt := NewRestTesterMultipleCollections(t, &RestTesterConfig{
-		CustomTestBucket: tb.NoCloseClone(),
-		DatabaseConfig:   &DatabaseConfig{DbConfig: DbConfig{AutoImport: true}},
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{AutoImport: true}},
 	}, numCollections)
 	defer rt.Close()
 


### PR DESCRIPTION
Test was skipped but the things it was skipped on were already done.

Needed some repairs to make work correctly but now works in both Rosmar and CB Server.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2016/
