### PR TITLE
CBG-3404: [3.1.2] link up the reset resync code to the api endpoint

### DIFF
--- a/docs/api/paths/admin/db-_resync.yaml
+++ b/docs/api/paths/admin/db-_resync.yaml
@@ -61,6 +61,12 @@ post:
       description: '**Use this only when requested to do so by the Couchbase support team** This request will regenerate the sequence numbers for each document processed.'
       schema:
         type: boolean
+    - name: reset
+      in: query
+      description: This forces a fresh resync run instead of trying to resume the previous resync operation
+      schema:
+        type: boolean
+        default: false
   requestBody:
     content:
       application/json:

--- a/rest/api.go
+++ b/rest/api.go
@@ -319,6 +319,7 @@ func (h *handler) handlePostResync() error {
 				"database":            h.db,
 				"regenerateSequences": regenerateSequences,
 				"collections":         resyncPostReqBody.Scope,
+				"reset":               h.getBoolQuery("reset"),
 			})
 			if err != nil {
 				return err

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -933,10 +933,10 @@ func (rt *RestTester) GetDBState() string {
 }
 
 func (rt *RestTester) WaitForDBOnline() (err error) {
-	return rt.waitForDBState("Online")
+	return rt.WaitForDBState("Online")
 }
 
-func (rt *RestTester) waitForDBState(stateWant string) (err error) {
+func (rt *RestTester) WaitForDBState(stateWant string) (err error) {
 	var stateCurr string
 	maxTries := 20
 

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -213,6 +213,26 @@ func (rt *RestTester) GetReplicationStatuses(queryString string) (statuses []db.
 	return statuses
 }
 
+func (rt *RestTester) WaitForResyncDCPStatus(status db.BackgroundProcessState) db.ResyncManagerResponseDCP {
+	var resyncStatus db.ResyncManagerResponseDCP
+	successFunc := func() bool {
+		response := rt.SendAdminRequest("GET", "/{{.db}}/_resync", "")
+		err := json.Unmarshal(response.BodyBytes(), &resyncStatus)
+		require.NoError(rt.TB, err)
+
+		var val interface{}
+		_, err = rt.Bucket().DefaultDataStore().Get(rt.GetDatabase().ResyncManager.GetHeartbeatDocID(rt.TB), &val)
+
+		if status == db.BackgroundProcessStateCompleted {
+			return resyncStatus.State == status && base.IsDocNotFoundError(err)
+		} else {
+			return resyncStatus.State == status
+		}
+	}
+	require.NoError(rt.TB, rt.WaitForCondition(successFunc), "Expected status: %s, actual status: %s", status, resyncStatus.State)
+	return resyncStatus
+}
+
 // setupSGRPeers sets up two rest testers to be used for sg-replicate testing with the following configuration:
 //
 //	activeRT:


### PR DESCRIPTION
CBG-3404

[Backport] 
Simple PR to connect reset code already there to something the user can trigger through a query parameter on the rest endpoint. including test that asserts the resync operation does actually reset once called.
Also updated the api docs to reflect addition to the query parameter.

- Had to add new test helper method `WaitForResyncDCPStatus` that we have on master but not on 3.1.x 
- Also refactored method `WaitForDBState` to be public method to be accessible for the test (like on master) 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2017/
- [ ] ^^ failed in flaky test issue - re-ran the test in isolation and it pased (see below)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2018/
