### PR TITLE
Log with keyspace for viewsAndGSIBucketInit

### DIFF
--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -143,21 +143,21 @@ func bucketNameCtx(parent context.Context, bucketName string) context.Context {
 	return LogContextWith(parent, &newCtx)
 }
 
-// CollectionCtx extends the parent context with a collection name.
+// CollectionCtx extends the parent context with a collection name. Used when bucket and scope are implicit (e.g. in the context of a SG database)
 func CollectionLogCtx(parent context.Context, collectionName string) context.Context {
 	newCtx := getLogCtx(parent)
 	newCtx.Collection = collectionName
 	return LogContextWith(parent, &newCtx)
 }
 
-// CorrelationIDCtx extends the parent context with a collection name.
+// CorrelationIDCtx extends the parent context with a correlation ID (HTTP request ID, BLIP context ID, etc.)
 func CorrelationIDLogCtx(parent context.Context, correlationID string) context.Context {
 	newCtx := getLogCtx(parent)
 	newCtx.CorrelationID = correlationID
 	return LogContextWith(parent, &newCtx)
 }
 
-// DatabaseLogCtx extends the parent context with a database.
+// DatabaseLogCtx extends the parent context with a database name.
 func DatabaseLogCtx(parent context.Context, databaseName string, config *DbConsoleLogConfig) context.Context {
 	newCtx := getLogCtx(parent)
 	newCtx.Database = databaseName
@@ -165,7 +165,7 @@ func DatabaseLogCtx(parent context.Context, databaseName string, config *DbConso
 	return LogContextWith(parent, &newCtx)
 }
 
-// KeyspaceLogCtx extends the parent context with a bucket name.
+// KeyspaceLogCtx extends the parent context with a fully qualified keyspace (bucket.scope.collection)
 func KeyspaceLogCtx(parent context.Context, bucketName, scopeName, collectionName string) context.Context {
 	newCtx := getLogCtx(parent)
 	newCtx.Bucket = bucketName

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -339,6 +339,7 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 	}
 
 	for _, dataStoreName := range dataStores {
+		ctx := base.KeyspaceLogCtx(ctx, b.GetName(), dataStoreName.ScopeName(), dataStoreName.CollectionName())
 		dataStore, err := b.NamedDataStore(dataStoreName)
 		if err != nil {
 			return err


### PR DESCRIPTION
### Before

```
2023-09-20T13:05:11.831+01:00 [INF] b:sg_int_0_1695211502556264000 Initializing indexes with numReplicas: 0...
2023/09/20 13:05:12 TEST: Memory high water mark increased to 215.57 MB (heap: 214.38 MB stack: 1.19 MB)
2023-09-20T13:05:14.720+01:00 [INF] b:sg_int_0_1695211502556264000 Verifying index availability...
2023-09-20T13:05:14.834+01:00 [INF] b:sg_int_0_1695211502556264000 Indexes sg_tombstones_x1, sg_access_x1, sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1 not ready - retrying...
2023-09-20T13:05:15.010+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_access_x1 is online
2023-09-20T13:05:15.010+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_allDocs_x1 is online
2023-09-20T13:05:15.010+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_channels_x1 is online
2023-09-20T13:05:15.010+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_roleAccess_x1 is online
2023-09-20T13:05:15.010+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_tombstones_x1 is online
2023-09-20T13:05:15.010+01:00 [INF] b:sg_int_0_1695211502556264000 Indexes ready
2023-09-20T13:05:16.406+01:00 [INF] b:sg_int_0_1695211502556264000 Initializing indexes with numReplicas: 0...
2023-09-20T13:05:16.970+01:00 [INF] b:sg_int_0_1695211502556264000 Verifying index availability...
2023-09-20T13:05:16.981+01:00 [INF] b:sg_int_0_1695211502556264000 Indexes sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1, sg_access_x1, sg_roleAccess_x1 not ready - retrying...
2023-09-20T13:05:17.087+01:00 [INF] b:sg_int_0_1695211502556264000 Indexes sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1, sg_access_x1, sg_roleAccess_x1 not ready - retrying...
2023-09-20T13:05:17.293+01:00 [INF] b:sg_int_0_1695211502556264000 Indexes sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1, sg_access_x1, sg_roleAccess_x1 not ready - retrying...
2023-09-20T13:05:17.718+01:00 [INF] b:sg_int_0_1695211502556264000 Indexes sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1, sg_access_x1, sg_roleAccess_x1 not ready - retrying...
2023/09/20 13:05:17 TEST: Memory high water mark increased to 215.98 MB (heap: 214.79 MB stack: 1.19 MB)
2023-09-20T13:05:18.549+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_access_x1 is online
2023-09-20T13:05:18.549+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_allDocs_x1 is online
2023-09-20T13:05:18.549+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_channels_x1 is online
2023-09-20T13:05:18.549+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_roleAccess_x1 is online
2023-09-20T13:05:18.549+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_tombstones_x1 is online
2023-09-20T13:05:18.549+01:00 [INF] b:sg_int_0_1695211502556264000 Indexes ready
2023-09-20T13:05:19.754+01:00 [INF] b:sg_int_0_1695211502556264000 Initializing indexes with numReplicas: 0...
2023-09-20T13:05:20.362+01:00 [INF] b:sg_int_0_1695211502556264000 Verifying index availability...
2023-09-20T13:05:20.380+01:00 [INF] b:sg_int_0_1695211502556264000 Indexes sg_access_x1, sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1 not ready - retrying...
2023-09-20T13:05:20.488+01:00 [INF] b:sg_int_0_1695211502556264000 Indexes sg_access_x1, sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1 not ready - retrying...
2023-09-20T13:05:20.713+01:00 [INF] b:sg_int_0_1695211502556264000 Indexes sg_access_x1, sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1 not ready - retrying...
2023-09-20T13:05:21.129+01:00 [INF] b:sg_int_0_1695211502556264000 Indexes sg_access_x1, sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1 not ready - retrying...
2023-09-20T13:05:21.971+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_access_x1 is online
2023-09-20T13:05:21.971+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_allDocs_x1 is online
2023-09-20T13:05:21.971+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_channels_x1 is online
2023-09-20T13:05:21.971+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_roleAccess_x1 is online
2023-09-20T13:05:21.971+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_tombstones_x1 is online
2023-09-20T13:05:21.971+01:00 [INF] b:sg_int_0_1695211502556264000 Indexes ready
2023/09/20 13:05:22 TEST: Memory high water mark increased to 216.60 MB (heap: 215.38 MB stack: 1.22 MB)
2023-09-20T13:05:23.343+01:00 [INF] b:sg_int_0_1695211502556264000 Initializing indexes with numReplicas: 0...
2023-09-20T13:05:24.339+01:00 [INF] b:sg_int_0_1695211502556264000 Verifying index availability...
2023-09-20T13:05:24.357+01:00 [INF] b:sg_int_0_1695211502556264000 Indexes sg_access_x1, sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1, sg_syncDocs_x1 not ready - retrying...
2023-09-20T13:05:24.465+01:00 [INF] b:sg_int_0_1695211502556264000 Indexes sg_access_x1, sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1, sg_syncDocs_x1 not ready - retrying...
2023-09-20T13:05:24.705+01:00 [INF] b:sg_int_0_1695211502556264000 Indexes sg_access_x1, sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1, sg_syncDocs_x1 not ready - retrying...
2023-09-20T13:05:25.144+01:00 [INF] b:sg_int_0_1695211502556264000 Indexes sg_access_x1, sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1, sg_syncDocs_x1 not ready - retrying...
2023-09-20T13:05:25.973+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_access_x1 is online
2023-09-20T13:05:25.973+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_allDocs_x1 is online
2023-09-20T13:05:25.973+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_channels_x1 is online
2023-09-20T13:05:25.973+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_roleAccess_x1 is online
2023-09-20T13:05:25.973+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_syncDocs_x1 is online
2023-09-20T13:05:25.973+01:00 [INF] b:sg_int_0_1695211502556264000 Index sg_tombstones_x1 is online
2023-09-20T13:05:25.973+01:00 [INF] b:sg_int_0_1695211502556264000 Indexes ready
```

### After

```
2023-09-20T13:04:01.601+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_2 Initializing indexes with numReplicas: 0...
2023-09-20T13:04:04.336+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_2 Verifying index availability...
2023-09-20T13:04:04.519+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_2 Indexes sg_access_x1, sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1 not ready - retrying...
2023-09-20T13:04:04.624+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_2 Indexes sg_access_x1, sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1 not ready - retrying...
2023-09-20T13:04:04.838+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_2 Index sg_access_x1 is online
2023-09-20T13:04:04.838+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_2 Index sg_allDocs_x1 is online
2023-09-20T13:04:04.838+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_2 Index sg_channels_x1 is online
2023-09-20T13:04:04.838+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_2 Index sg_roleAccess_x1 is online
2023-09-20T13:04:04.838+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_2 Index sg_tombstones_x1 is online
2023-09-20T13:04:04.838+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_2 Indexes ready
2023-09-20T13:04:05.905+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_1 Initializing indexes with numReplicas: 0...
2023/09/20 13:04:06 TEST: Memory high water mark increased to 196.26 MB (heap: 195.04 MB stack: 1.22 MB)
2023-09-20T13:04:06.475+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_1 Verifying index availability...
2023-09-20T13:04:06.490+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_1 Indexes sg_access_x1, sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1 not ready - retrying...
2023-09-20T13:04:06.595+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_1 Indexes sg_access_x1, sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1 not ready - retrying...
2023-09-20T13:04:06.815+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_1 Indexes sg_access_x1, sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1 not ready - retrying...
2023-09-20T13:04:07.250+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_1 Indexes sg_access_x1, sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1 not ready - retrying...
2023-09-20T13:04:08.088+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_1 Index sg_access_x1 is online
2023-09-20T13:04:08.088+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_1 Index sg_allDocs_x1 is online
2023-09-20T13:04:08.088+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_1 Index sg_channels_x1 is online
2023-09-20T13:04:08.088+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_1 Index sg_roleAccess_x1 is online
2023-09-20T13:04:08.088+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_1 Index sg_tombstones_x1 is online
2023-09-20T13:04:08.088+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_1 Indexes ready
2023-09-20T13:04:09.329+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_0 Initializing indexes with numReplicas: 0...
2023-09-20T13:04:10.045+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_0 Verifying index availability...
2023-09-20T13:04:10.063+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_0 Indexes sg_access_x1, sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1 not ready - retrying...
2023-09-20T13:04:10.173+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_0 Indexes sg_access_x1, sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1 not ready - retrying...
2023-09-20T13:04:10.398+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_0 Indexes sg_access_x1, sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1 not ready - retrying...
2023-09-20T13:04:10.819+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_0 Indexes sg_access_x1, sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1 not ready - retrying...
2023/09/20 13:04:11 TEST: Memory high water mark increased to 196.95 MB (heap: 195.73 MB stack: 1.22 MB)
2023-09-20T13:04:11.664+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_0 Index sg_access_x1 is online
2023-09-20T13:04:11.664+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_0 Index sg_allDocs_x1 is online
2023-09-20T13:04:11.664+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_0 Index sg_channels_x1 is online
2023-09-20T13:04:11.664+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_0 Index sg_roleAccess_x1 is online
2023-09-20T13:04:11.664+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_0 Index sg_tombstones_x1 is online
2023-09-20T13:04:11.664+01:00 [INF] b:sg_int_0_1695211431317915000.sg_test_0.sg_test_0 Indexes ready
2023-09-20T13:04:12.897+01:00 [INF] b:sg_int_0_1695211431317915000._default._default Initializing indexes with numReplicas: 0...
2023-09-20T13:04:13.816+01:00 [INF] b:sg_int_0_1695211431317915000._default._default Verifying index availability...
2023-09-20T13:04:13.837+01:00 [INF] b:sg_int_0_1695211431317915000._default._default Indexes sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1, sg_syncDocs_x1, sg_access_x1 not ready - retrying...
2023-09-20T13:04:13.943+01:00 [INF] b:sg_int_0_1695211431317915000._default._default Indexes sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1, sg_syncDocs_x1, sg_access_x1 not ready - retrying...
2023-09-20T13:04:14.163+01:00 [INF] b:sg_int_0_1695211431317915000._default._default Indexes sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1, sg_syncDocs_x1, sg_access_x1 not ready - retrying...
2023-09-20T13:04:14.584+01:00 [INF] b:sg_int_0_1695211431317915000._default._default Indexes sg_roleAccess_x1, sg_channels_x1, sg_allDocs_x1, sg_tombstones_x1, sg_syncDocs_x1, sg_access_x1 not ready - retrying...
2023-09-20T13:04:15.444+01:00 [INF] b:sg_int_0_1695211431317915000._default._default Index sg_access_x1 is online
2023-09-20T13:04:15.444+01:00 [INF] b:sg_int_0_1695211431317915000._default._default Index sg_allDocs_x1 is online
2023-09-20T13:04:15.444+01:00 [INF] b:sg_int_0_1695211431317915000._default._default Index sg_channels_x1 is online
2023-09-20T13:04:15.444+01:00 [INF] b:sg_int_0_1695211431317915000._default._default Index sg_roleAccess_x1 is online
2023-09-20T13:04:15.444+01:00 [INF] b:sg_int_0_1695211431317915000._default._default Index sg_syncDocs_x1 is online
2023-09-20T13:04:15.444+01:00 [INF] b:sg_int_0_1695211431317915000._default._default Index sg_tombstones_x1 is online
2023-09-20T13:04:15.444+01:00 [INF] b:sg_int_0_1695211431317915000._default._default Indexes ready
```