### PR TITLE
CBG-3196: Allow implicit to explicit _default scope config change

### DIFF
--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -781,6 +781,39 @@ func TestCollectionsAddNamedCollectionToImplicitDefaultScope(t *testing.T) {
 	assert.Equal(t, expectedKeyspaces, rt.GetKeyspaces())
 }
 
+func TestCollectionsChangeConfigScopeFromImplicitDefault(t *testing.T) {
+	base.TestRequiresCollections(t)
+
+	rt := NewRestTesterMultipleCollections(t, &RestTesterConfig{PersistentConfig: true}, 1)
+	defer rt.Close()
+
+	const dbName = "db"
+
+	// implicit default scope/collection
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Scopes = nil
+	resp := rt.CreateDatabase(dbName, dbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	expectedKeyspaces := []string{
+		dbName,
+	}
+	assert.Equal(t, expectedKeyspaces, rt.GetKeyspaces())
+
+	newCollection := base.ScopeAndCollectionName{Scope: t.Name(), Collection: t.Name()}
+	require.NoError(t, rt.TestBucket.CreateDataStore(base.TestCtx(t), newCollection))
+	defer func() {
+		require.NoError(t, rt.TestBucket.DropDataStore(newCollection))
+	}()
+
+	resp = rt.UpsertDbConfig(dbName, DbConfig{Scopes: ScopesConfig{
+		newCollection.ScopeName(): {Collections: CollectionsConfig{
+			newCollection.CollectionName(): {},
+		}},
+	}})
+	assertHTTPErrorReason(t, resp, http.StatusBadRequest, "1 errors:\ncannot change scopes after database creation")
+}
+
 // TestCollecitonStats ensures that stats are specific to each collection.
 func TestCollectionStats(t *testing.T) {
 	base.TestRequiresCollections(t)

--- a/rest/config.go
+++ b/rest/config.go
@@ -615,7 +615,7 @@ func (dbConfig *DbConfig) validateConfigUpdate(ctx context.Context, old DbConfig
 func (dbConfig *DbConfig) validateChanges(ctx context.Context, old DbConfig) error {
 	// allow switching from implicit `_default` to explicit `_default` scope
 	_, newIsDefaultScope := dbConfig.Scopes[base.DefaultScope]
-	if old.Scopes == nil && newIsDefaultScope {
+	if old.Scopes == nil && len(dbConfig.Scopes) == 1 && newIsDefaultScope {
 		return nil
 	}
 	// early exit

--- a/rest/config.go
+++ b/rest/config.go
@@ -613,6 +613,12 @@ func (dbConfig *DbConfig) validateConfigUpdate(ctx context.Context, old DbConfig
 // validateChanges compares the current DbConfig with the "old" config, and returns an error if any disallowed changes
 // are attempted.
 func (dbConfig *DbConfig) validateChanges(ctx context.Context, old DbConfig) error {
+	// allow switching from implicit `_default` to explicit `_default` scope
+	_, newIsDefaultScope := dbConfig.Scopes[base.DefaultScope]
+	if old.Scopes == nil && newIsDefaultScope {
+		return nil
+	}
+	// early exit
 	if len(dbConfig.Scopes) != len(old.Scopes) {
 		return fmt.Errorf("cannot change scopes after database creation")
 	}


### PR DESCRIPTION
CBG-3196

Relaxes the validation done by `dbConfig.validateChanges()` to allow changing from an implicit `_default` scope to an explicit `_default` scope.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2021/
