### PR TITLE
[3.0.9 backport] CBG-3273: Fix revocation feed loop

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -241,6 +241,8 @@ func (db *Database) buildRevokedFeed(channelName string, options ChangesOptions,
 				// If its less than we can send a standard revocation with Sequence ID as above.
 				// Otherwise: we need to determine whether a previous revision of the document was in the channel prior
 				// to the since value, and only send a revocation if that was the case
+
+				lastSeq = logEntry.Sequence
 				if logEntry.Sequence > sinceVal {
 					// Get doc sync data so we can verify the docs grant history
 					syncData, err := db.GetDocSyncData(logEntry.DocID)
@@ -279,7 +281,6 @@ func (db *Database) buildRevokedFeed(channelName string, options ChangesOptions,
 				}
 
 				change := makeRevocationChangeEntry(logEntry, seqID, singleChannelCache.ChannelName())
-				lastSeq = logEntry.Sequence
 
 				base.DebugfCtx(db.Ctx, base.KeyChanges, "Channel feed processing revocation seq: %v in channel %s ", seqID, base.UD(singleChannelCache.ChannelName()))
 

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1,0 +1,110 @@
+// Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+)
+
+const (
+	revocationTestRole     = "foo"
+	revocationTestUser     = "user"
+	revocationTestPassword = "test"
+)
+
+func InitScenario(t *testing.T, rtConfig *RestTesterConfig) (ChannelRevocationTester, *RestTester) {
+
+	defaultSyncFn := `
+			function (doc, oldDoc){
+				if (doc._id === 'userRoles'){
+					for (var key in doc.roles){
+						role(key, doc.roles[key]);
+					}
+				}
+				if (doc._id === 'roleChannels'){
+					for (var key in doc.channels){
+						access(key, doc.channels[key]);
+					}
+				}
+				if (doc._id === 'userChannels'){
+					for (var key in doc.channels){
+						access(key, doc.channels[key]);
+					}
+				}
+				if (doc._id.indexOf("doc") >= 0){
+					channel(doc.channels);
+				}
+			}`
+
+	if rtConfig == nil {
+		rtConfig = &RestTesterConfig{
+			SyncFn: defaultSyncFn,
+		}
+	} else if rtConfig.SyncFn == "" {
+		rtConfig.SyncFn = defaultSyncFn
+	}
+
+	rt := NewRestTester(t, rtConfig)
+
+	revocationTester := ChannelRevocationTester{
+		test:       t,
+		restTester: rt,
+	}
+
+	resp := rt.SendAdminRequest("PUT", "/db/_user/user", fmt.Sprintf(`{"name": "%s", "password": "%s"}`, revocationTestUser, revocationTestPassword))
+	RequireStatus(t, resp, http.StatusCreated)
+
+	resp = rt.SendAdminRequest("PUT", "/db/_role/foo", `{}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	return revocationTester, rt
+}
+
+func TestRevocationsWithQueryLimit2Channels(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+	revocationTester, rt := InitScenario(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			AutoImport:           false,
+			QueryPaginationLimit: base.IntPtr(2),
+		}},
+	})
+	defer rt.Close()
+
+	revocationTester.addRole("user", "foo")
+	revocationTester.addRoleChannel("foo", "ch1")
+	revocationTester.addUserChannel("user", "ch2")
+
+	revocationTester.fillToSeq(9)
+	_ = rt.createDocReturnRev(t, "doc1", "", map[string]interface{}{"channels": []string{"ch1", "ch2"}})
+	_ = rt.createDocReturnRev(t, "doc2", "", map[string]interface{}{"channels": []string{"ch1", "ch2"}})
+	_ = rt.createDocReturnRev(t, "doc3", "", map[string]interface{}{"channels": []string{"ch1", "ch2"}})
+
+	changes := revocationTester.getChanges("0", 4)
+
+	revocationTester.removeRole("user", "foo")
+
+	_ = changes.Last_Seq
+	// This changes feed would loop if CBG-3273 was still an issue
+	changes = revocationTester.getChanges(0, 4)
+
+	// Get one of the 3 docs which the user should still have access to
+	resp := rt.SendUserRequestWithHeaders("GET", "/db/doc1", "", nil, "user", "test")
+	RequireStatus(t, resp, 200)
+
+	// Revoke access to ch2
+	revocationTester.removeUserChannel("user", "ch2")
+	changes = revocationTester.getChanges(0, 7)
+	// Get a doc to ensure no access
+	resp = rt.SendUserRequestWithHeaders("GET", "/db/doc1", "", nil, "user", "test")
+	RequireStatus(t, resp, 403)
+}


### PR DESCRIPTION
* Add TestRevocationsWithQueryLimit2Channels and fix loop
* Move lastSeq assignment before inner loop

backport of https://github.com/couchbase/sync_gateway/pull/6378 / CBG-3273
backport ticket https://issues.couchbase.com/browse/CBG-3331
