### PR TITLE
CBG-3429: Move some log lines from KeyDCP to other keys

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -499,9 +499,9 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 	// If latency is larger than 1 minute or is negative there is likely an issue and this should be clear to the user
 	if millisecondLatency >= 60*1000 {
-		base.InfofCtx(ctx, base.KeyDCP, "Received #%d after %3dms (%q / %q)", change.Sequence, millisecondLatency, base.UD(change.DocID), change.RevID)
+		base.InfofCtx(ctx, base.KeyChanges, "Received #%d after %3dms (%q / %q)", change.Sequence, millisecondLatency, base.UD(change.DocID), change.RevID)
 	} else {
-		base.DebugfCtx(ctx, base.KeyDCP, "Received #%d after %3dms (%q / %q)", change.Sequence, millisecondLatency, base.UD(change.DocID), change.RevID)
+		base.DebugfCtx(ctx, base.KeyChanges, "Received #%d after %3dms (%q / %q)", change.Sequence, millisecondLatency, base.UD(change.DocID), change.RevID)
 	}
 
 	changedChannels := c.processEntry(ctx, change)
@@ -619,7 +619,7 @@ func (c *changeCache) processPrincipalDoc(ctx context.Context, docID string, doc
 		change.DocID = "_role/" + princ.Name
 	}
 
-	base.InfofCtx(ctx, base.KeyDCP, "Received #%d (%q)", change.Sequence, base.UD(change.DocID))
+	base.InfofCtx(ctx, base.KeyChanges, "Received #%d (%q)", change.Sequence, base.UD(change.DocID))
 
 	changedChannels := c.processEntry(ctx, change)
 	if c.notifyChange != nil && len(changedChannels) > 0 {
@@ -725,8 +725,8 @@ func (c *changeCache) _addToCache(ctx context.Context, change *LogEntry) []chann
 	// updatedChannels tracks the set of channels that should be notified of the change.  This includes
 	// the change's active channels, as well as any channel removals for the active revision.
 	updatedChannels := c.channelCache.AddToCache(ctx, change)
-	if base.LogDebugEnabled(base.KeyDCP) {
-		base.DebugfCtx(ctx, base.KeyDCP, " #%d ==> channels %v", change.Sequence, base.UD(updatedChannels))
+	if base.LogDebugEnabled(base.KeyChanges) {
+		base.DebugfCtx(ctx, base.KeyChanges, " #%d ==> channels %v", change.Sequence, base.UD(updatedChannels))
 	}
 
 	if !change.TimeReceived.IsZero() {

--- a/db/database.go
+++ b/db/database.go
@@ -2214,7 +2214,7 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 		db.Options.CacheOptions,
 		db.MetadataKeys,
 	); err != nil {
-		base.DebugfCtx(ctx, base.KeyDCP, "Error initializing the change cache", err)
+		base.DebugfCtx(ctx, base.KeyCache, "Error initializing the change cache", err)
 		return err
 	}
 

--- a/db/database.go
+++ b/db/database.go
@@ -2263,7 +2263,7 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 	}
 
 	// Start DCP feed
-	base.InfofCtx(ctx, base.KeyDCP, "Starting mutation feed on bucket %v", base.MD(db.Bucket.GetName()))
+	base.InfofCtx(ctx, base.KeyChanges, "Starting mutation feed on bucket %v", base.MD(db.Bucket.GetName()))
 	cacheFeedStatsMap := db.DbStats.Database().CacheFeedMapStats
 	if err := db.mutationListener.Start(ctx, db.Bucket, cacheFeedStatsMap.Map, db.Scopes, db.MetadataStore); err != nil {
 		db.channelCache = nil

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -102,7 +102,7 @@ func (il *importListener) StartImportFeed(dbContext *DatabaseContext) (err error
 	base.StoreDestFactory(il.loggingCtx, il.importDestKey, il.NewImportDest)
 
 	// Start DCP mutation feed
-	base.InfofCtx(il.loggingCtx, base.KeyDCP, "Starting DCP import feed for bucket: %q ", base.UD(il.bucket.GetName()))
+	base.InfofCtx(il.loggingCtx, base.KeyImport, "Starting DCP import feed for bucket: %q ", base.UD(il.bucket.GetName()))
 
 	// TODO: need to clean up StartDCPFeed to push bucket dependencies down
 	cbStore, ok := base.AsCouchbaseBucketStore(il.bucket)

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -102,7 +102,7 @@ func (il *importListener) StartImportFeed(dbContext *DatabaseContext) (err error
 	base.StoreDestFactory(il.loggingCtx, il.importDestKey, il.NewImportDest)
 
 	// Start DCP mutation feed
-	base.InfofCtx(il.loggingCtx, base.KeyImport, "Starting DCP import feed for bucket: %q ", base.UD(il.bucket.GetName()))
+	base.InfofCtx(il.loggingCtx, base.KeyDCP, "Starting DCP import feed for bucket: %q ", base.UD(il.bucket.GetName()))
 
 	// TODO: need to clean up StartDCPFeed to push bucket dependencies down
 	cbStore, ok := base.AsCouchbaseBucketStore(il.bucket)

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -56,7 +56,7 @@ func getListenerImportDest(ctx context.Context, indexParams string) (cbgt.Dest, 
 		return nil, fmt.Errorf("error unmarshalling dbname from cbgt index params: %w", err)
 	}
 
-	base.DebugfCtx(ctx, base.KeyDCP, "Fetching listener import dest for %v", base.MD(sgIndexParams.DestKey))
+	base.DebugfCtx(ctx, base.KeyImport, "Fetching listener import dest for %v", base.MD(sgIndexParams.DestKey))
 	destFactory, fetchErr := base.FetchDestFactory(sgIndexParams.DestKey)
 	if fetchErr != nil {
 		return nil, fmt.Errorf("error retrieving listener for indexParams %v: %v", indexParams, fetchErr)

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -56,7 +56,7 @@ func getListenerImportDest(ctx context.Context, indexParams string) (cbgt.Dest, 
 		return nil, fmt.Errorf("error unmarshalling dbname from cbgt index params: %w", err)
 	}
 
-	base.DebugfCtx(ctx, base.KeyImport, "Fetching listener import dest for %v", base.MD(sgIndexParams.DestKey))
+	base.DebugfCtx(ctx, base.KeyDCP, "Fetching listener import dest for %v", base.MD(sgIndexParams.DestKey))
 	destFactory, fetchErr := base.FetchDestFactory(sgIndexParams.DestKey)
 	if fetchErr != nil {
 		return nil, fmt.Errorf("error retrieving listener for indexParams %v: %v", indexParams, fetchErr)


### PR DESCRIPTION
CBG-3429

Describe your PR here...
- Move import and cache relevant log lines from KeyDCP to KeyCache or KeyChanges


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
