### PR TITLE
[3.1.2 Backport] CBG-3197: Allow implicit to explicit _default scope config change

### DIFF
--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -10,8 +10,10 @@ package rest
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -781,7 +783,12 @@ func TestCollectionsAddNamedCollectionToImplicitDefaultScope(t *testing.T) {
 	newCollection := base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: t.Name()}
 	require.NoError(t, rt.TestBucket.CreateDataStore(newCollection))
 	defer func() {
-		require.NoError(t, rt.TestBucket.DropDataStore(newCollection))
+		err := rt.TestBucket.DropDataStore(newCollection)
+		// Walrus doesn't write to disk if it has had no documents - ignore this error
+		// Not a problem in Rosmar or Couchbase Server...
+		if !errors.Is(err, os.ErrNotExist) {
+			assert.NoError(t, err)
+		}
 	}()
 
 	resp = rt.UpsertDbConfig(dbName, DbConfig{Scopes: ScopesConfig{
@@ -821,7 +828,12 @@ func TestCollectionsChangeConfigScopeFromImplicitDefault(t *testing.T) {
 	newCollection := base.ScopeAndCollectionName{Scope: t.Name(), Collection: t.Name()}
 	require.NoError(t, rt.TestBucket.CreateDataStore(newCollection))
 	defer func() {
-		require.NoError(t, rt.TestBucket.DropDataStore(newCollection))
+		err := rt.TestBucket.DropDataStore(newCollection)
+		// Walrus doesn't write to disk if it has had no documents - ignore this error
+		// Not a problem in Rosmar or Couchbase Server...
+		if !errors.Is(err, os.ErrNotExist) {
+			assert.NoError(t, err)
+		}
 	}()
 
 	resp = rt.UpsertDbConfig(dbName, DbConfig{Scopes: ScopesConfig{

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -759,6 +759,79 @@ func TestCollectionsChangeConfigScope(t *testing.T) {
 	)
 }
 
+func TestCollectionsAddNamedCollectionToImplicitDefaultScope(t *testing.T) {
+	base.TestRequiresCollections(t)
+
+	rt := NewRestTesterMultipleCollections(t, &RestTesterConfig{PersistentConfig: true}, 1)
+	defer rt.Close()
+
+	const dbName = "db"
+
+	// implicit default scope/collection
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Scopes = nil
+	resp := rt.CreateDatabase(dbName, dbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	expectedKeyspaces := []string{
+		dbName,
+	}
+	assert.Equal(t, expectedKeyspaces, rt.GetKeyspaces())
+
+	newCollection := base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: t.Name()}
+	require.NoError(t, rt.TestBucket.CreateDataStore(base.TestCtx(t), newCollection))
+	defer func() {
+		require.NoError(t, rt.TestBucket.DropDataStore(newCollection))
+	}()
+
+	resp = rt.UpsertDbConfig(dbName, DbConfig{Scopes: ScopesConfig{
+		base.DefaultScope: {Collections: CollectionsConfig{
+			base.DefaultCollection:         {},
+			newCollection.CollectionName(): {},
+		}},
+	}})
+	RequireStatus(t, resp, http.StatusCreated)
+
+	expectedKeyspaces = []string{
+		dbName,
+		fmt.Sprintf("%s.%s.%s", dbName, newCollection.ScopeName(), newCollection.CollectionName()),
+	}
+	assert.Equal(t, expectedKeyspaces, rt.GetKeyspaces())
+}
+
+func TestCollectionsChangeConfigScopeFromImplicitDefault(t *testing.T) {
+	base.TestRequiresCollections(t)
+
+	rt := NewRestTesterMultipleCollections(t, &RestTesterConfig{PersistentConfig: true}, 1)
+	defer rt.Close()
+
+	const dbName = "db"
+
+	// implicit default scope/collection
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Scopes = nil
+	resp := rt.CreateDatabase(dbName, dbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	expectedKeyspaces := []string{
+		dbName,
+	}
+	assert.Equal(t, expectedKeyspaces, rt.GetKeyspaces())
+
+	newCollection := base.ScopeAndCollectionName{Scope: t.Name(), Collection: t.Name()}
+	require.NoError(t, rt.TestBucket.CreateDataStore(base.TestCtx(t), newCollection))
+	defer func() {
+		require.NoError(t, rt.TestBucket.DropDataStore(newCollection))
+	}()
+
+	resp = rt.UpsertDbConfig(dbName, DbConfig{Scopes: ScopesConfig{
+		newCollection.ScopeName(): {Collections: CollectionsConfig{
+			newCollection.CollectionName(): {},
+		}},
+	}})
+	assertHTTPErrorReason(t, resp, http.StatusBadRequest, "1 errors:\ncannot change scopes after database creation")
+}
+
 // TestCollecitonStats ensures that stats are specific to each collection.
 func TestCollectionStats(t *testing.T) {
 	base.TestRequiresCollections(t)

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -779,7 +779,7 @@ func TestCollectionsAddNamedCollectionToImplicitDefaultScope(t *testing.T) {
 	assert.Equal(t, expectedKeyspaces, rt.GetKeyspaces())
 
 	newCollection := base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: t.Name()}
-	require.NoError(t, rt.TestBucket.CreateDataStore(base.TestCtx(t), newCollection))
+	require.NoError(t, rt.TestBucket.CreateDataStore(newCollection))
 	defer func() {
 		require.NoError(t, rt.TestBucket.DropDataStore(newCollection))
 	}()
@@ -819,7 +819,7 @@ func TestCollectionsChangeConfigScopeFromImplicitDefault(t *testing.T) {
 	assert.Equal(t, expectedKeyspaces, rt.GetKeyspaces())
 
 	newCollection := base.ScopeAndCollectionName{Scope: t.Name(), Collection: t.Name()}
-	require.NoError(t, rt.TestBucket.CreateDataStore(base.TestCtx(t), newCollection))
+	require.NoError(t, rt.TestBucket.CreateDataStore(newCollection))
 	defer func() {
 		require.NoError(t, rt.TestBucket.DropDataStore(newCollection))
 	}()

--- a/rest/config.go
+++ b/rest/config.go
@@ -552,6 +552,12 @@ func (dbConfig *DbConfig) validateConfigUpdate(ctx context.Context, old DbConfig
 // validateChanges compares the current DbConfig with the "old" config, and returns an error if any disallowed changes
 // are attempted.
 func (dbConfig *DbConfig) validateChanges(ctx context.Context, old DbConfig) error {
+	// allow switching from implicit `_default` to explicit `_default` scope
+	_, newIsDefaultScope := dbConfig.Scopes[base.DefaultScope]
+	if old.Scopes == nil && len(dbConfig.Scopes) == 1 && newIsDefaultScope {
+		return nil
+	}
+	// early exit
 	if len(dbConfig.Scopes) != len(old.Scopes) {
 		return fmt.Errorf("cannot change scopes after database creation")
 	}


### PR DESCRIPTION
CBG-3197

Backports #6436 to 3.1.2

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-1.19.5/26/
