### PR TITLE
Add dependabot module updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,11 @@
+# Copyright 2023-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included in
+# the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+# file, in accordance with the Business Source License, use of this software
+# will be governed by the Apache License, Version 2.0, included in the file
+# licenses/APL2.txt.
+
 version: 2
 updates:
   - package-ecosystem: "gomod"


### PR DESCRIPTION
I would like to use this as a mechanism to at least give us notifications for module updates, and ideally semi-automate the update.

Dependabot will open individual PRs for any upstream module updates.
We can just choose whether to merge them or close them.

More info here: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates 