### PR TITLE
CBG-3394 don't panic if user is deleted with active blip replication

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -86,6 +86,9 @@ const (
 type blipHandlerFunc func(*blipHandler, *blip.Message) error
 
 var (
+	// CBLReconnectErrorCode is the error code that CBL will use to trigger a reconnect
+	CBLReconnectErrorCode = http.StatusServiceUnavailable
+
 	ErrUseProposeChanges = base.HTTPErrorf(http.StatusConflict, "Use 'proposeChanges' instead")
 
 	// ErrDatabaseWentAway is returned when a replication tries to use a closed database.
@@ -128,7 +131,7 @@ func (bh *blipHandler) refreshUser() error {
 			// Refresh the BlipSyncContext database
 			err := bc.blipContextDb.ReloadUser(bh.loggingCtx)
 			if err != nil {
-				return err
+				return base.HTTPErrorf(CBLReconnectErrorCode, fmt.Sprintf("%s", err))
 			}
 			newUser := bc.blipContextDb.User()
 			newUser.InitializeRoles()

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -126,13 +126,13 @@ func (bh *blipHandler) refreshUser() error {
 		// If changed, refresh the user and db while holding the lock
 		if userChanged {
 			// Refresh the BlipSyncContext database
-			newUser, err := bc.blipContextDb.Authenticator(bh.loggingCtx).GetUser(bc.userName)
+			err := bc.blipContextDb.ReloadUser(bh.loggingCtx)
 			if err != nil {
 				return err
 			}
+			newUser := bc.blipContextDb.User()
 			newUser.InitializeRoles()
 			bc.userChangeWaiter.RefreshUserKeys(newUser, bc.blipContextDb.MetadataKeys)
-			bc.blipContextDb.SetUser(newUser)
 			// refresh the handler's database with the new BlipSyncContext database
 			bh.db = bh._copyContextDatabase()
 			if bh.collection != nil {

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2826,7 +2826,7 @@ func TestBlipRefreshUser(t *testing.T) {
 	require.NoError(t, err)
 
 	testResponse := unsubChangesRequest.Response()
-	require.Equal(t, strconv.Itoa(http.StatusInternalServerError), testResponse.Properties[db.BlipErrorCode])
+	require.Equal(t, strconv.Itoa(db.CBLReconnectErrorCode), testResponse.Properties[db.BlipErrorCode])
 	body, err := testResponse.Body()
 	require.NoError(t, err)
 	require.NotContains(t, string(body), "Panic:")

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -17,6 +17,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -2769,4 +2770,64 @@ func TestRequestPlusPullDbConfig(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, `{"channel":["PBS"]}`, string(data))
 
+}
+
+// TestBlipRefreshUser makes sure there is no panic if a user gets deleted during a replication
+func TestBlipRefreshUser(t *testing.T) {
+
+	rtConfig := RestTesterConfig{
+		SyncFn: channels.DocChannelsSyncFunction,
+	}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+
+	const username = "bernard"
+	// Initialize blip tester client (will create user)
+	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+		Username: "bernard",
+		Channels: []string{"chan1"},
+	})
+
+	require.NoError(t, err)
+	defer btc.Close()
+
+	// add chan1 explicitly
+	response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/"+username, GetUserPayload(rt.TB, "", RestTesterDefaultUserPassword, "", rt.GetSingleTestDatabaseCollection(), []string{"chan1"}, nil))
+
+	docID := "doc1"
+
+	RequireStatus(t, response, http.StatusOK)
+	response = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID, `{"channels":["chan1"]}`)
+	RequireStatus(t, response, http.StatusCreated)
+
+	response = rt.SendUserRequest(http.MethodGet, "/{{.keyspace}}/"+docID, "", username)
+	RequireStatus(t, response, http.StatusOK)
+
+	// Start a regular one-shot pull
+	err = btc.StartPullSince("true", "0", "false")
+	require.NoError(t, err)
+
+	_, ok := btc.WaitForDoc(docID)
+	require.True(t, ok)
+
+	_, ok = btc.GetRev(docID, "1-78211b5eedea356c9693e08bc68b93ce")
+	require.True(t, ok)
+
+	// delete user with an active blip connection
+	response = rt.SendAdminRequest(http.MethodDelete, "/{{.db}}/_user/"+username, "")
+	RequireStatus(t, response, http.StatusOK)
+
+	// further requests will 500, but shouldn't panic
+	unsubChangesRequest := blip.NewRequest()
+	unsubChangesRequest.SetProfile(db.MessageUnsubChanges)
+	btc.addCollectionProperty(unsubChangesRequest)
+
+	err = btc.pullReplication.sendMsg(unsubChangesRequest)
+	require.NoError(t, err)
+
+	testResponse := unsubChangesRequest.Response()
+	require.Equal(t, strconv.Itoa(http.StatusInternalServerError), testResponse.Properties[db.BlipErrorCode])
+	body, err := testResponse.Body()
+	require.NoError(t, err)
+	require.NotContains(t, string(body), "Panic:")
 }


### PR DESCRIPTION
Use common function that we use in changes feed to refresh user.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2026/
