### PR TITLE
CBG-3276 sort buckets deterministically

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -306,6 +307,7 @@ func (cc *CouchbaseCluster) GetConfigBuckets() ([]string, error) {
 		bucketList = append(bucketList, bucketName)
 	}
 
+	sort.Strings(bucketList)
 	cc.cachedBucketConnections.removeOutdatedBuckets(SetOf(bucketList...))
 
 	return bucketList, nil

--- a/base/bootstrap_test.go
+++ b/base/bootstrap_test.go
@@ -9,6 +9,7 @@
 package base
 
 import (
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -60,6 +61,12 @@ func TestBootstrapRefCounting(t *testing.T) {
 
 	buckets, err := cluster.GetConfigBuckets()
 	require.NoError(t, err)
+	// ensure these are sorted for determinstic bootstraping
+	sortedBuckets := make([]string, len(buckets))
+	copy(sortedBuckets, buckets)
+	sort.Strings(sortedBuckets)
+	require.Equal(t, sortedBuckets, buckets)
+
 	var testBuckets []string
 	for _, bucket := range buckets {
 		if strings.HasPrefix(bucket, tbpBucketNamePrefix) {


### PR DESCRIPTION
Every function that iterates over config uses `GetConfigBuckets`.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

