### PR TITLE
[3.1.2 backport] CBG-3329: Fix rev cache multi node inconsistency

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -482,6 +482,9 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	}
 
 	// Now add the entry for the new doc revision:
+	if len(rawUserXattr) > 0 {
+		collection.revisionCache.Invalidate(c.logCtx, docID, syncData.CurrentRev)
+	}
 	change := &LogEntry{
 		Sequence:     syncData.Sequence,
 		DocID:        docID,

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -483,7 +483,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 	// Now add the entry for the new doc revision:
 	if len(rawUserXattr) > 0 {
-		collection.revisionCache.Invalidate(c.logCtx, docID, syncData.CurrentRev)
+		collection.revisionCache.Remove(docID, syncData.CurrentRev)
 	}
 	change := &LogEntry{
 		Sequence:     syncData.Sequence,

--- a/db/crud.go
+++ b/db/crud.go
@@ -1882,9 +1882,9 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 				}
 			}
 
-			// Prior to saving doc invalidate the revision in cache
+			// Prior to saving doc, remove the revision in cache
 			if createNewRevIDSkipped {
-				db.revisionCache.Invalidate(ctx, doc.ID, doc.CurrentRev)
+				db.revisionCache.Remove(doc.ID, doc.CurrentRev)
 			}
 
 			base.DebugfCtx(ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.CurrentRev)

--- a/db/import.go
+++ b/db/import.go
@@ -269,7 +269,7 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 			}
 		}
 
-		shouldGenerateNewRev := bodyChanged
+		shouldGenerateNewRev := bodyChanged || len(existingDoc.UserXattr) == 0
 
 		// If the body has changed then the document has been updated and we should generate a new revision. Otherwise
 		// the import was triggered by a user xattr mutation and therefore should not generate a new revision.

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -96,7 +96,7 @@ func (rc *BypassRevisionCache) Upsert(ctx context.Context, docRev DocumentRevisi
 	// no-op
 }
 
-func (rc *BypassRevisionCache) Invalidate(ctx context.Context, docID, revID string) {
+func (rc *BypassRevisionCache) Remove(docID, revID string) {
 	// nop
 }
 

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -46,10 +46,8 @@ type RevisionCache interface {
 	// Update will remove existing value and re-create new one
 	Upsert(ctx context.Context, docRev DocumentRevision)
 
-	// Invalidate marks a revision in the cache as invalid. This is used to call into LoadInvalidRevFromBackingStore in LRU.
-	// Marked revision denotes that this value should not be used and should be replaced. Used in the event of an user
-	// xattr only update where there is no revision change.
-	Invalidate(ctx context.Context, docID, revID string)
+	// Remove eliminates a revision in the cache.
+	Remove(docID, revID string)
 
 	// UpdateDelta stores the given toDelta value in the given rev if cached
 	UpdateDelta(ctx context.Context, docID, revID string, toDelta RevisionDelta)
@@ -121,7 +119,6 @@ type DocumentRevision struct {
 	Delta       *RevisionDelta
 	Deleted     bool
 	Removed     bool // True if the revision is a removal.
-	Invalid     bool
 
 	_shallowCopyBody Body // an unmarshalled body that can produce shallow copies
 }

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1244,6 +1244,192 @@ func TestRemovingUserXattr(t *testing.T) {
 		})
 	}
 }
+
+func TestUserXattrRevCache(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	if !base.TestUseXattrs() {
+		t.Skip("This test only works with XATTRS enabled")
+	}
+
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("test is EE only - user xattrs")
+	}
+
+	docKey := t.Name()
+	xattrKey := "channels"
+	channelName := []string{"ABC", "DEF"}
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+	syncFn := `function (doc, oldDoc, meta){
+				if (meta.xattrs.channels !== undefined){
+					channel(meta.xattrs.channels);
+					console.log(JSON.stringify(meta));
+				}
+			}`
+
+	// Sync function to set channel access to a channels UserXattrKey
+	rt := NewRestTester(t, &RestTesterConfig{
+		CustomTestBucket: tb.NoCloseClone(),
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			AutoImport:   true,
+			UserXattrKey: xattrKey,
+		}},
+		SyncFn: syncFn,
+	})
+	defer rt.Close()
+
+	rt2 := NewRestTester(t, &RestTesterConfig{
+		CustomTestBucket: tb.NoCloseClone(),
+
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			AutoImport:   true,
+			UserXattrKey: xattrKey,
+		}},
+		SyncFn: syncFn,
+	})
+	defer rt2.Close()
+
+	dataStore := rt2.GetSingleDataStore()
+	userXattrStore, ok := base.AsUserXattrStore(dataStore)
+	if !ok {
+		t.Skip("Test requires Couchbase Bucket")
+	}
+
+	ctx := rt2.Context()
+	a := rt2.ServerContext().Database(ctx, "db").Authenticator(ctx)
+	userABC, err := a.NewUser("userABC", "letmein", channels.BaseSetOf(t, "ABC"))
+	require.NoError(t, err)
+	require.NoError(t, a.Save(userABC))
+
+	userDEF, err := a.NewUser("userDEF", "letmein", channels.BaseSetOf(t, "DEF"))
+	require.NoError(t, err)
+	require.NoError(t, a.Save(userDEF))
+
+	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+docKey, `{}`)
+	RequireStatus(t, resp, http.StatusCreated)
+	require.NoError(t, rt.WaitForPendingChanges())
+	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, "DEF")
+	assert.NoError(t, err)
+
+	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "userDEF", false)
+	assert.NoError(t, err)
+
+	resp = rt2.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userDEF")
+	RequireStatus(t, resp, http.StatusOK)
+
+	// Add channel ABC to the userXattr
+	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, channelName)
+	assert.NoError(t, err)
+
+	// wait for import of the xattr change on both nodes
+	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "userABC", false)
+	assert.NoError(t, err)
+	_, err = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes", "userABC", false)
+	assert.NoError(t, err)
+
+	// GET the doc with userABC to ensure it is accessible on both nodes
+	resp = rt2.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userABC")
+	assert.Equal(t, resp.Code, http.StatusOK)
+	resp = rt.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userABC")
+	assert.Equal(t, resp.Code, http.StatusOK)
+}
+
+func TestUserXattrDeleteWithRevCache(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	if !base.TestUseXattrs() {
+		t.Skip("This test only works with XATTRS enabled")
+	}
+
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("test is EE only - user xattrs")
+	}
+
+	// Sync function to set channel access to a channels UserXattrKey
+	syncFn := `
+			function (doc, oldDoc, meta){
+				if (meta.xattrs.channels !== undefined){
+					channel(meta.xattrs.channels);
+					console.log(JSON.stringify(meta));
+				}
+			}`
+
+	docKey := t.Name()
+	xattrKey := "channels"
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		CustomTestBucket: tb.NoCloseClone(),
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			AutoImport:   true,
+			UserXattrKey: xattrKey,
+		}},
+		SyncFn: syncFn,
+	})
+	defer rt.Close()
+
+	rt2 := NewRestTester(t, &RestTesterConfig{
+		CustomTestBucket: tb.NoCloseClone(),
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			AutoImport:   true,
+			UserXattrKey: xattrKey,
+		}},
+		SyncFn: syncFn,
+	})
+	defer rt2.Close()
+
+	dataStore := rt2.GetSingleDataStore()
+	userXattrStore, ok := base.AsUserXattrStore(dataStore)
+	if !ok {
+		t.Skip("Test requires Couchbase Bucket")
+	}
+
+	ctx := rt2.Context()
+	a := rt2.ServerContext().Database(ctx, "db").Authenticator(ctx)
+
+	userDEF, err := a.NewUser("userDEF", "letmein", channels.BaseSetOf(t, "DEF"))
+	require.NoError(t, err)
+	require.NoError(t, a.Save(userDEF))
+
+	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+docKey, `{}`)
+	RequireStatus(t, resp, http.StatusCreated)
+	require.NoError(t, rt.WaitForPendingChanges())
+
+	// Write DEF to the userXattrStore to give userDEF access
+	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, "DEF")
+	assert.NoError(t, err)
+
+	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "userDEF", false)
+	assert.NoError(t, err)
+
+	resp = rt2.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userDEF")
+	RequireStatus(t, resp, http.StatusOK)
+
+	// Delete DEF from the userXattr, removing the doc from channel DEF
+	_, err = userXattrStore.DeleteUserXattr(docKey, xattrKey)
+	assert.NoError(t, err)
+
+	// wait for import of the xattr change on both nodes
+	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "userDEF", false)
+	assert.NoError(t, err)
+	_, err = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes", "userDEF", false)
+	assert.NoError(t, err)
+
+	// GET the doc with userDEF on both nodes to ensure userDEF no longer has access
+	resp = rt2.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userDEF")
+	assert.Equal(t, resp.Code, http.StatusForbidden)
+	resp = rt.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userDEF")
+	assert.Equal(t, resp.Code, http.StatusForbidden)
+}
+
 func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1263,7 +1263,7 @@ func TestUserXattrRevCache(t *testing.T) {
 	xattrKey := "channels"
 	channelName := []string{"ABC", "DEF"}
 	tb := base.GetTestBucket(t)
-	defer tb.Close()
+	defer tb.Close(base.TestCtx(t))
 	syncFn := `function (doc, oldDoc, meta){
 				if (meta.xattrs.channels !== undefined){
 					channel(meta.xattrs.channels);
@@ -1364,7 +1364,7 @@ func TestUserXattrDeleteWithRevCache(t *testing.T) {
 	docKey := t.Name()
 	xattrKey := "channels"
 	tb := base.GetTestBucket(t)
-	defer tb.Close()
+	defer tb.Close(base.TestCtx(t))
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb.NoCloseClone(),


### PR DESCRIPTION
backports:

- CBG-3171 Fix rev cache multi node inconsistency https://github.com/couchbase/sync_gateway/pull/6369
- CBG-3352 switch Invalidate to Remove https://github.com/couchbase/sync_gateway/pull/6399

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-1.19.5/26/
