### PR TITLE
[3.0.9 backport] CBG-3328 invalidate rev cache across nodes

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -549,6 +549,9 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	}
 
 	// Now add the entry for the new doc revision:
+	if len(rawUserXattr) > 0 {
+		c.context.revisionCache.Invalidate(docID, syncData.CurrentRev)
+	}
 	change := &LogEntry{
 		Sequence:     syncData.Sequence,
 		DocID:        docID,

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -550,7 +550,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 	// Now add the entry for the new doc revision:
 	if len(rawUserXattr) > 0 {
-		c.context.revisionCache.Invalidate(docID, syncData.CurrentRev)
+		c.context.revisionCache.Remove(docID, syncData.CurrentRev)
 	}
 	change := &LogEntry{
 		Sequence:     syncData.Sequence,

--- a/db/crud.go
+++ b/db/crud.go
@@ -1818,9 +1818,9 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 				}
 			}
 
-			// Prior to saving doc invalidate the revision in cache
+			// Prior to saving doc, remove the revision in cache
 			if createNewRevIDSkipped {
-				db.revisionCache.Invalidate(doc.ID, doc.CurrentRev)
+				db.revisionCache.Remove(doc.ID, doc.CurrentRev)
 			}
 
 			base.DebugfCtx(db.Ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.CurrentRev)

--- a/db/import.go
+++ b/db/import.go
@@ -274,7 +274,7 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 			}
 		}
 
-		shouldGenerateNewRev := bodyChanged
+		shouldGenerateNewRev := bodyChanged || len(existingDoc.UserXattr) == 0
 
 		// If the body has changed then the document has been updated and we should generate a new revision. Otherwise
 		// the import was triggered by a user xattr mutation and therefore should not generate a new revision.

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -94,7 +94,7 @@ func (rc *BypassRevisionCache) Upsert(docRev DocumentRevision) {
 	// no-op
 }
 
-func (rc *BypassRevisionCache) Invalidate(docID, revID string) {
+func (rc *BypassRevisionCache) Remove(docID, revID string) {
 	// nop
 }
 

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -45,10 +45,8 @@ type RevisionCache interface {
 	// Update will remove existing value and re-create new one
 	Upsert(docRev DocumentRevision)
 
-	// Invalidate marks a revision in the cache as invalid. This is used to call into LoadInvalidRevFromBackingStore in LRU.
-	// Marked revision denotes that this value should not be used and should be replaced. Used in the event of an user
-	// xattr only update where there is no revision change.
-	Invalidate(docID, revID string)
+	// Remove eliminates a revision in the cache.
+	Remove(docID, revID string)
 
 	// UpdateDelta stores the given toDelta value in the given rev if cached
 	UpdateDelta(docID, revID string, toDelta RevisionDelta)
@@ -120,7 +118,6 @@ type DocumentRevision struct {
 	Delta       *RevisionDelta
 	Deleted     bool
 	Removed     bool // True if the revision is a removal.
-	Invalid     bool
 
 	_shallowCopyBody Body // an unmarshalled body that can produce shallow copies
 }

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -68,8 +68,8 @@ func (sc *ShardedLRURevisionCache) Upsert(docRev DocumentRevision) {
 	sc.getShard(docRev.DocID).Upsert(docRev)
 }
 
-func (sc *ShardedLRURevisionCache) Invalidate(docID, revID string) {
-	sc.getShard(docID).Invalidate(docID, revID)
+func (sc *ShardedLRURevisionCache) Remove(docID, revID string) {
+	sc.getShard(docID).Remove(docID, revID)
 }
 
 // An LRU cache of document revision bodies, together with their channel access.
@@ -269,13 +269,6 @@ func (rc *LRURevisionCache) Upsert(docRev DocumentRevision) {
 	value.store(docRev)
 }
 
-func (rc *LRURevisionCache) Invalidate(docID, revID string) {
-	value := rc.getValue(docID, revID, false)
-	if value != nil {
-		value.setInvalidFlag()
-	}
-}
-
 func (rc *LRURevisionCache) getValue(docID, revID string, create bool) (value *revCacheValue) {
 	if docID == "" || revID == "" {
 		panic("RevisionCache: invalid empty doc/rev id")
@@ -296,6 +289,20 @@ func (rc *LRURevisionCache) getValue(docID, revID string, create bool) (value *r
 	return
 }
 
+// Remove removes a value from the revision cache, if present.
+func (rc *LRURevisionCache) Remove(docID, revID string) {
+	key := IDAndRev{DocID: docID, RevID: revID}
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	element, ok := rc.cache[key]
+	if !ok {
+		return
+	}
+	rc.lruList.Remove(element)
+	delete(rc.cache, key)
+}
+
+// removeValue removes a value from the revision cache, if present and the value matches the the value. If there's an item in the revision cache with a matching docID and revID but the document is different, this item will not be removed from the rev cache.
 func (rc *LRURevisionCache) removeValue(value *revCacheValue) {
 	rc.lock.Lock()
 	if element := rc.cache[value.key]; element != nil && element.Value == value {
@@ -400,7 +407,6 @@ func (value *revCacheValue) asDocumentRevision(body Body, delta *RevisionDelta) 
 		Attachments: value.attachments.ShallowCopy(), // Avoid caller mutating the stored attachments
 		Deleted:     value.deleted,
 		Removed:     value.removed,
-		Invalid:     value.invalid,
 	}
 	if body != nil {
 		docRev._shallowCopyBody = body.ShallowCopy()


### PR DESCRIPTION
backports:

[CBG-3171](https://issues.couchbase.com/browse/CBG-3171) Fix rev cache multi node inconsistency https://github.com/couchbase/sync_gateway/pull/6369
[CBG-3352](https://issues.couchbase.com/browse/CBG-3352) switch Invalidate to Remove https://github.com/couchbase/sync_gateway/pull/6399

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-go1.16.15/77/
