### PR TITLE
[3.1.2 backport] CBG-3426 perform a length check on raw xattr bytes

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -48,6 +48,9 @@ var (
 	ErrTimeout               = &sgError{"Operation timed out"}
 	ErrPathNotFound          = &sgError{"Path not found"}
 
+	// ErrXattrInvalidLen is returned if the xattr is corrupt.
+	ErrXattrInvalidLen = &sgError{"Xattr stream length"}
+
 	// ErrPartialViewErrors is returned if the view call contains any partial errors.
 	// This is more of a warning, and inspecting ViewResult.Errors is required for detail.
 	ErrPartialViewErrors = &sgError{"Partial errors in view"}

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -211,7 +211,7 @@ func getAttachmentSyncData(dataType uint8, data []byte) (*AttachmentCompactionDa
 	if dataType&base.MemcachedDataTypeXattr != 0 {
 		body, xattr, _, err := parseXattrStreamData(base.SyncXattrName, "", data)
 		if err != nil {
-			if errors.Is(err, base.ErrXattrNotFound) {
+			if errors.Is(err, base.ErrXattrNotFound) || errors.Is(err, base.ErrXattrInvalidLen) {
 				return nil, nil
 			}
 			return nil, err

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -2253,3 +2253,12 @@ func BenchmarkDocChanged(b *testing.B) {
 		})
 	}
 }
+
+func TestInvalidXattrStream(t *testing.T) {
+
+	body, xattr, userXattr, err := parseXattrStreamData(base.SyncXattrName, "", []byte("abcde"))
+	require.Error(t, err)
+	require.Nil(t, body)
+	require.Nil(t, xattr)
+	require.Nil(t, userXattr)
+}

--- a/db/document.go
+++ b/db/document.go
@@ -509,6 +509,9 @@ func parseXattrStreamData(xattrName string, userXattrName string, data []byte) (
 	}
 
 	xattrsLen := binary.BigEndian.Uint32(data[0:4])
+	if int(xattrsLen+4) > len(data) {
+		return nil, nil, nil, fmt.Errorf("%w (%d) from bytes %+v", base.ErrXattrInvalidLen, xattrsLen, data[0:4])
+	}
 	body = data[xattrsLen+4:]
 	if xattrsLen == 0 {
 		return body, nil, nil, nil


### PR DESCRIPTION
backports: CBG-3238 perform a length check on raw bytes (#6438)
