### PR TITLE
[3.0.9 backport] CBG-3240 perform a length check on raw bytes (#6438)

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -48,6 +48,9 @@ var (
 	ErrXattrNotFound         = &sgError{"Xattr Not Found"}
 	ErrTimeout               = &sgError{"Operation timed out"}
 
+	// ErrXattrInvalidLen is returned if the xattr is corrupt.
+	ErrXattrInvalidLen = &sgError{"Xattr stream length"}
+
 	// ErrPartialViewErrors is returned if the view call contains any partial errors.
 	// This is more of a warning, and inspecting ViewResult.Errors is required for detail.
 	ErrPartialViewErrors = &sgError{"Partial errors in view"}

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -172,7 +172,7 @@ func getAttachmentSyncData(dataType uint8, data []byte) (*AttachmentCompactionDa
 	if dataType&base.MemcachedDataTypeXattr != 0 {
 		body, xattr, _, err := parseXattrStreamData(base.SyncXattrName, "", data)
 		if err != nil {
-			if errors.Is(err, base.ErrXattrNotFound) {
+			if errors.Is(err, base.ErrXattrNotFound) || errors.Is(err, base.ErrXattrInvalidLen) {
 				return nil, nil
 			}
 			return nil, err

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -2243,3 +2243,12 @@ func BenchmarkDocChanged(b *testing.B) {
 		})
 	}
 }
+
+func TestInvalidXattrStream(t *testing.T) {
+
+	body, xattr, userXattr, err := parseXattrStreamData(base.SyncXattrName, "", []byte("abcde"))
+	require.Error(t, err)
+	require.Nil(t, body)
+	require.Nil(t, xattr)
+	require.Nil(t, userXattr)
+}

--- a/db/document.go
+++ b/db/document.go
@@ -504,6 +504,9 @@ func parseXattrStreamData(xattrName string, userXattrName string, data []byte) (
 	}
 
 	xattrsLen := binary.BigEndian.Uint32(data[0:4])
+	if int(xattrsLen+4) > len(data) {
+		return nil, nil, nil, fmt.Errorf("%w (%d) from bytes %+v", base.ErrXattrInvalidLen, xattrsLen, data[0:4])
+	}
 	body = data[xattrsLen+4:]
 	if xattrsLen == 0 {
 		return body, nil, nil, nil

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -314,13 +314,11 @@ func TestInvalidXattrStreamDataLen(t *testing.T) {
 			// parseXattrStreamData is the underlying function
 			body, xattr, userXattr, err := parseXattrStreamData(base.SyncXattrName, "", test.body)
 			require.Error(t, err)
-			require.ErrorIs(t, err, test.expectedErr)
 			require.Nil(t, body)
 			require.Nil(t, xattr)
 			require.Nil(t, userXattr)
 			// UnmarshalDocumentSyncData wraps parseXattrStreamData
 			result, rawBody, rawXattr, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(test.body, base.MemcachedDataTypeXattr, "", false)
-			require.ErrorIs(t, err, base.ErrXattrInvalidLen)
 			require.Nil(t, result)
 			require.Nil(t, rawBody)
 			require.Nil(t, rawXattr)

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -13,6 +13,7 @@ package db
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"log"
 	"testing"
 
@@ -314,11 +315,13 @@ func TestInvalidXattrStreamDataLen(t *testing.T) {
 			// parseXattrStreamData is the underlying function
 			body, xattr, userXattr, err := parseXattrStreamData(base.SyncXattrName, "", test.body)
 			require.Error(t, err)
+			require.True(t, errors.Is(err, test.expectedErr))
 			require.Nil(t, body)
 			require.Nil(t, xattr)
 			require.Nil(t, userXattr)
 			// UnmarshalDocumentSyncData wraps parseXattrStreamData
 			result, rawBody, rawXattr, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(test.body, base.MemcachedDataTypeXattr, "", false)
+			require.True(t, errors.Is(err, base.ErrXattrInvalidLen))
 			require.Nil(t, result)
 			require.Nil(t, rawBody)
 			require.Nil(t, rawXattr)

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TODO: Could consider checking this in as a file and include it into the compiled test binary using something like https://github.com/jteeuwen/go-bindata
@@ -289,4 +290,62 @@ func TestGetDeepMutableBody(t *testing.T) {
 			assert.Equal(t, *test.expected, body)
 		})
 	}
+}
+
+func TestInvalidXattrStreamDataLen(t *testing.T) {
+	testCases := []struct {
+		name        string
+		body        []byte
+		expectedErr error
+	}{
+		{
+			name:        "bad value",
+			body:        []byte("abcde"),
+			expectedErr: base.ErrXattrInvalidLen,
+		},
+		{
+			name:        "xattr length 4, overflow",
+			body:        []byte{0x00, 0x00, 0x00, 0x04, 0x01},
+			expectedErr: base.ErrXattrInvalidLen,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			// parseXattrStreamData is the underlying function
+			body, xattr, userXattr, err := parseXattrStreamData(base.SyncXattrName, "", test.body)
+			require.Error(t, err)
+			require.ErrorIs(t, err, test.expectedErr)
+			require.Nil(t, body)
+			require.Nil(t, xattr)
+			require.Nil(t, userXattr)
+			// UnmarshalDocumentSyncData wraps parseXattrStreamData
+			result, rawBody, rawXattr, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(test.body, base.MemcachedDataTypeXattr, "", false)
+			require.ErrorIs(t, err, base.ErrXattrInvalidLen)
+			require.Nil(t, result)
+			require.Nil(t, rawBody)
+			require.Nil(t, rawXattr)
+			require.Nil(t, rawUserXattr)
+
+		})
+	}
+}
+
+func TestInvalidXattrStreamEmptyBody(t *testing.T) {
+	inputStream := []byte{0x00, 0x00, 0x00, 0x01, 0x01}
+	emptyBody := []byte{}
+	// parseXattrStreamData is the underlying function
+	body, xattr, userXattr, err := parseXattrStreamData(base.SyncXattrName, "", inputStream)
+	require.NoError(t, err)
+	require.Equal(t, emptyBody, body)
+	require.Nil(t, xattr)
+	require.Nil(t, userXattr)
+
+	// UnmarshalDocumentSyncData wraps parseXattrStreamData
+	result, rawBody, rawXattr, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(inputStream, base.MemcachedDataTypeXattr, "", false)
+	require.Error(t, err) // unexpected end of JSON input
+	require.Nil(t, result)
+	require.Equal(t, emptyBody, rawBody)
+	require.Nil(t, rawXattr)
+	require.Nil(t, rawUserXattr)
+
 }


### PR DESCRIPTION
backport of CBG-3238 perform a length check on raw bytes (#6438)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-go1.16.15/74/
