### PR TITLE
Move gocbconnstr module path to go mod

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -21,7 +21,7 @@ import (
 
 	"dario.cat/mergo"
 	"github.com/couchbase/gocb/v2"
-	"gopkg.in/couchbaselabs/gocbconnstr.v1"
+	"github.com/couchbaselabs/gocbconnstr"
 )
 
 // BootstrapConnection is the interface that can be used to bootstrap Sync Gateway against a Couchbase Server cluster.

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -26,9 +26,9 @@ import (
 	"github.com/couchbase/gocbcore/v10/memd"
 	"github.com/couchbase/gomemcached"
 	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbaselabs/gocbconnstr"
 	"github.com/couchbaselabs/rosmar"
 	pkgerrors "github.com/pkg/errors"
-	"gopkg.in/couchbaselabs/gocbconnstr.v1"
 )
 
 const (

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -25,9 +25,9 @@ import (
 	"github.com/couchbase/go-couchbase/cbdatasource"
 	memcached "github.com/couchbase/gomemcached/client"
 	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbaselabs/gocbconnstr"
 	"github.com/google/uuid"
 	pkgerrors "github.com/pkg/errors"
-	"gopkg.in/couchbaselabs/gocbconnstr.v1"
 )
 
 // Number of non-checkpoint updates per vbucket required to trigger metadata persistence.  Must be greater than zero to avoid

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -23,8 +23,8 @@ import (
 	"github.com/couchbase/go-couchbase"
 	"github.com/couchbase/go-couchbase/cbdatasource"
 	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbaselabs/gocbconnstr"
 	"github.com/pkg/errors"
-	"gopkg.in/couchbaselabs/gocbconnstr.v1"
 )
 
 const CBGTIndexTypeSyncGatewayImport = "syncGateway-import-"

--- a/base/util.go
+++ b/base/util.go
@@ -38,10 +38,10 @@ import (
 
 	"github.com/couchbase/go-couchbase"
 	"github.com/couchbase/gomemcached"
+	"github.com/couchbaselabs/gocbconnstr"
 	"github.com/gorilla/mux"
 	pkgerrors "github.com/pkg/errors"
 	"golang.org/x/exp/constraints"
-	"gopkg.in/couchbaselabs/gocbconnstr.v1"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/couchbase/goutils v0.1.2
 	github.com/couchbase/sg-bucket v0.0.0-20230921161645-dd0fa1dd0802
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20200408160354-2ed3f45fde8f
+	github.com/couchbaselabs/gocbconnstr v1.0.5
 	github.com/couchbaselabs/rosmar v0.0.0-20230921163813-6cdbac2ce2bc
 	github.com/elastic/gosigar v0.14.2
 	github.com/felixge/fgprof v0.9.2
@@ -35,7 +36,6 @@ require (
 	golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b
 	golang.org/x/net v0.13.0
 	golang.org/x/oauth2 v0.0.0-20220718184931-c8730f7fcb92
-	gopkg.in/couchbaselabs/gocbconnstr.v1 v1.0.4
 	gopkg.in/square/go-jose.v2 v2.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/couchbaselabs/rosmar v0.0.0-20230915041912-1ef8902279b3 h1:wT35/q1Yqb
 github.com/couchbaselabs/rosmar v0.0.0-20230915041912-1ef8902279b3/go.mod h1:jYNDVH7TiPYLipcOrYjeTbt3IwKrY7B7iKEBUvHiykU=
 github.com/couchbaselabs/rosmar v0.0.0-20230920002041-302a538289a8 h1:OeM2eKLmBZkywBInlb/xuNXswCeodcOfdpr0VuY0qzo=
 github.com/couchbaselabs/rosmar v0.0.0-20230920002041-302a538289a8/go.mod h1:WPnC0wScTiEbsMgUkmqRkVWr6WUc8JiA6RuOs7aujiw=
+github.com/couchbaselabs/gocbconnstr v1.0.5 h1:e0JokB5qbcz7rfnxEhNRTKz8q1svoRvDoZihsiwNigA=
+github.com/couchbaselabs/gocbconnstr v1.0.5/go.mod h1:KV3fnIKMi8/AzX0O9zOrO9rofEqrRF1d2rG7qqjxC7o=
 github.com/couchbaselabs/rosmar v0.0.0-20230921163813-6cdbac2ce2bc h1:NPunbWXvJ0WegP7CHvcKqYX5tGE7F3zIwPiITagZXTg=
 github.com/couchbaselabs/rosmar v0.0.0-20230921163813-6cdbac2ce2bc/go.mod h1:1r/4zwbprv8YLS32Jq7sEPi7XRpYNq0uoF94bOBQ260=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Drop `gopkg.in` version of `gocbconnstr` and update to version with actual module support

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2029/
