### PR TITLE
[3.1.2 backport] CBG-3430 sort buckets deterministically

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -306,6 +307,7 @@ func (cc *CouchbaseCluster) GetConfigBuckets() ([]string, error) {
 		bucketList = append(bucketList, bucketName)
 	}
 
+	sort.Strings(bucketList)
 	cc.cachedBucketConnections.removeOutdatedBuckets(SetOf(bucketList...))
 
 	return bucketList, nil

--- a/base/bootstrap_test.go
+++ b/base/bootstrap_test.go
@@ -9,6 +9,8 @@
 package base
 
 import (
+	"sort"
+	"strings"
 	"sync"
 	"testing"
 
@@ -60,6 +62,20 @@ func TestBootstrapRefCounting(t *testing.T) {
 	buckets, err := cluster.GetConfigBuckets()
 	require.NoError(t, err)
 	require.Len(t, buckets, tbpNumBuckets(ctx))
+	// ensure these are sorted for determinstic bootstraping
+	sortedBuckets := make([]string, len(buckets))
+	copy(sortedBuckets, buckets)
+	sort.Strings(sortedBuckets)
+	require.Equal(t, sortedBuckets, buckets)
+
+	var testBuckets []string
+	for _, bucket := range buckets {
+		if strings.HasPrefix(bucket, tbpBucketNamePrefix) {
+			testBuckets = append(testBuckets, bucket)
+		}
+
+	}
+	require.Len(t, testBuckets, tbpNumBuckets(ctx))
 	// GetConfigBuckets doesn't cache connections, it uses cluster connection to determine number of buckets
 	require.Len(t, cluster.cachedBucketConnections.buckets, 0)
 


### PR DESCRIPTION
backport of CBG-3276 sort buckets deterministically (#6446)
