### PR TITLE
CBG-3122 Additional defensive checks in UpdateCalculatedStats

### DIFF
--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -24,10 +24,15 @@ import "context"
 // Update database-specific stats that are more efficiently calculated at stats collection time
 func (db *DatabaseContext) UpdateCalculatedStats(ctx context.Context) {
 
+	if db == nil || db.DbStats == nil {
+		return
+	}
 	db.changeCache.updateStats(ctx)
 	channelCache := db.changeCache.getChannelCache()
-	db.DbStats.Cache().ChannelCacheMaxEntries.Set(int64(channelCache.MaxCacheSize(ctx)))
-	db.DbStats.Cache().HighSeqCached.Set(int64(channelCache.GetHighCacheSequence()))
+	if channelCache != nil {
+		db.DbStats.Cache().ChannelCacheMaxEntries.Set(int64(channelCache.MaxCacheSize(ctx)))
+		db.DbStats.Cache().HighSeqCached.Set(int64(channelCache.GetHighCacheSequence()))
+	}
 
 }
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -3220,6 +3221,32 @@ func Test_stopBackgroundManagers(t *testing.T) {
 			assert.Len(t, bgManagers, testCase.expected, "Unexpected Num of BackgroundManagers returned")
 		})
 	}
+}
+
+func TestUpdateCalculatedStatsPanic(t *testing.T) {
+
+	var dbc *DatabaseContext
+
+	defer func() {
+		r := recover()
+		if r != nil {
+			t.Errorf("UpdateCalculatedStats panic recovered, stack trace: %s", debug.Stack())
+		}
+	}()
+
+	// nil DatabaseContext check
+	ctx := base.TestCtx(t)
+	dbc.UpdateCalculatedStats(ctx)
+
+	// non-nil DatabaseContext, nil stats
+	dbc = &DatabaseContext{}
+	dbc.UpdateCalculatedStats(ctx)
+
+	// non-nil DatabaseContext and stats, nil channel cache
+	dbStats, statsError := initDatabaseStats(ctx, "db", false, DatabaseContextOptions{})
+	require.NoError(t, statsError)
+	dbc.DbStats = dbStats
+	dbc.UpdateCalculatedStats(ctx)
 }
 
 func Test_waitForBackgroundManagersToStop(t *testing.T) {


### PR DESCRIPTION
The previous changes to changeCache.updateStats() guard against an nil db inside that call, but don't cover nil channelCache.

We shouldn't hit the nil db and DbStats cases, but added these for additional protection in case of unexpected interactions with sc.logStats.

CBG-3122