### PR TITLE
CBG-3324: Add startup cnf logging to DefaultDbConfig (#6381)

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -485,7 +485,7 @@ func TestDBOfflinePutDbConfig(t *testing.T) {
 
 // Tests that the users returned in the config endpoint have the correct names
 // Reproduces #2223
-func TestDBGetConfigNames(t *testing.T) {
+func TestDBGetConfigNamesAndDefaultLogging(t *testing.T) {
 
 	p := "password"
 	rt := rest.NewRestTester(t,
@@ -507,11 +507,38 @@ func TestDBGetConfigNames(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 
 	assert.Equal(t, len(rt.DatabaseConfig.Users), len(body.Users))
+	emptyCnf := &rest.DbLoggingConfig{}
+	assert.Equal(t, body.Logging, emptyCnf)
 
 	for k, v := range body.Users {
 		assert.Equal(t, k, *v.Name)
 	}
+}
 
+func TestDBGetConfigCustomLogging(t *testing.T) {
+	logKeys := []string{base.KeyAccess.String(), base.KeyHTTP.String()}
+	rt := rest.NewRestTester(t,
+		&rest.RestTesterConfig{
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Logging: &rest.DbLoggingConfig{
+					Console: &rest.DbConsoleLoggingConfig{
+						LogLevel: base.LogLevelPtr(base.LevelError),
+						LogKeys:  logKeys,
+					},
+				},
+			},
+			},
+		},
+	)
+
+	defer rt.Close()
+
+	response := rt.SendAdminRequest("GET", "/db/_config?include_runtime=true", "")
+	var body rest.DbConfig
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
+
+	assert.Equal(t, body.Logging.Console.LogLevel, base.LogLevelPtr(base.LevelError))
+	assert.Equal(t, body.Logging.Console.LogKeys, logKeys)
 }
 
 // Take DB offline and ensure can post _resync
@@ -3349,6 +3376,8 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 	// Start SG with no databases
 	config := rest.BootstrapStartupConfigForTest(t)
 	sc, err := rest.SetupServerContext(ctx, &config, true)
+	config.Logging.Console.LogKeys = []string{base.KeyDCP.String()}
+	config.Logging.Console.LogLevel.Set(base.LevelDebug)
 	require.NoError(t, err)
 	defer func() {
 		sc.Close(ctx)
@@ -3380,6 +3409,9 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 	assert.Equal(t, base.DefaultOldRevExpirySeconds, *dbConfig.OldRevExpirySeconds)
 	assert.Equal(t, false, *dbConfig.StartOffline)
 	assert.Equal(t, db.DefaultCompactInterval, uint32(*dbConfig.CompactIntervalDays))
+
+	assert.Equal(t, dbConfig.Logging.Console.LogLevel.String(), base.LevelDebug.String())
+	assert.Equal(t, dbConfig.Logging.Console.LogKeys, []string{base.KeyDCP.String()})
 
 	var runtimeServerConfigResponse rest.RunTimeServerConfigResponse
 	resp = rest.BootstrapAdminRequest(t, http.MethodGet, "/_config?include_runtime=true", "")

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -85,6 +85,20 @@ func GenerateDatabaseConfigVersionID(ctx context.Context, previousRevID string, 
 	return hash, nil
 }
 
+func DefaultPerDBLogging(bootstrapLoggingCnf base.LoggingConfig) *DbLoggingConfig {
+	if bootstrapLoggingCnf.Console != nil {
+		if *bootstrapLoggingCnf.Console.Enabled {
+			return &DbLoggingConfig{
+				Console: &DbConsoleLoggingConfig{
+					LogLevel: bootstrapLoggingCnf.Console.LogLevel,
+					LogKeys:  bootstrapLoggingCnf.Console.LogKeys,
+				},
+			}
+		}
+	}
+	return &DbLoggingConfig{}
+}
+
 // MergeDatabaseConfigWithDefaults merges the passed in config onto a DefaultDbConfig which results in returned value
 // being populated with defaults when not set
 func MergeDatabaseConfigWithDefaults(sc *StartupConfig, dbConfig *DbConfig) (*DbConfig, error) {
@@ -163,6 +177,7 @@ func DefaultDbConfig(sc *StartupConfig) *DbConfig {
 		ClientPartitionWindowSecs:        base.IntPtr(int(base.DefaultClientPartitionWindow.Seconds())),
 		JavascriptTimeoutSecs:            base.Uint32Ptr(base.DefaultJavascriptTimeoutSecs),
 		Suspendable:                      base.BoolPtr(sc.IsServerless()),
+		Logging:                          DefaultPerDBLogging(sc.Logging),
 	}
 
 	revsLimit := db.DefaultRevsLimitNoConflicts


### PR DESCRIPTION
(cherry picked from commit 5288dbf17a705c668d588bb36dde7fb8fd22a2e9)

CBG-3440

- Copy startup config logging to default db config, to be returned on GET /db/_config?include_runtime=true calls
- Add check on TestConfigsIncludeDefaults

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
