### PR TITLE
CBG-2579: TestReplicatorCheckpointOnStop test fix 

### DIFF
--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -7949,8 +7949,8 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 	defer teardown()
 	activeCtx := activeRT.Context()
 
-	// reduce checkpointing interval temporarily to ensure there is a checkpoint to assert against later in test
-	defer reduceTestCheckpointInterval(50 * time.Millisecond)()
+	// increase checkpointing interval temporarily to ensure there is a checkpoint to assert against later
+	defer reduceTestCheckpointInterval(50 * time.Second)()
 
 	rev, doc, err := activeRT.GetSingleTestDatabaseCollectionWithUser().Put(activeCtx, "test", db.Body{})
 	require.NoError(t, err)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -7944,6 +7944,7 @@ func TestReplicatorDeprecatedCredentials(t *testing.T) {
 // CBG-1581: Ensure activeReplicatorCommon does final checkpoint on stop/disconnect
 func TestReplicatorCheckpointOnStop(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
+	base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
 
 	activeRT, passiveRT, remoteURL, teardown := rest.SetupSGRPeers(t)
 	defer teardown()

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -7944,14 +7944,15 @@ func TestReplicatorDeprecatedCredentials(t *testing.T) {
 // CBG-1581: Ensure activeReplicatorCommon does final checkpoint on stop/disconnect
 func TestReplicatorCheckpointOnStop(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
-	base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
+	base.SetUpTestLogging(t, base.LevelTrace, base.KeyReplicate)
 
 	activeRT, passiveRT, remoteURL, teardown := rest.SetupSGRPeers(t)
 	defer teardown()
 	activeCtx := activeRT.Context()
 
-	// increase checkpointing interval temporarily to ensure there is a checkpoint to assert against later
-	defer reduceTestCheckpointInterval(50 * time.Second)()
+	// increase checkpointing interval temporarily to ensure the checkpointer doesn't fiore on an
+	// interval during the running of the test
+	defer reduceTestCheckpointInterval(9999 * time.Hour)()
 
 	rev, doc, err := activeRT.GetSingleTestDatabaseCollectionWithUser().Put(activeCtx, "test", db.Body{})
 	require.NoError(t, err)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -7949,8 +7949,8 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 	defer teardown()
 	activeCtx := activeRT.Context()
 
-	// Disable checkpointing at an interval
-	activeRT.GetDatabase().SGReplicateMgr.CheckpointInterval = 0
+	// reduce checkpointing interval temporarily to ensure there is a checkpoint to assert against later in test
+	defer reduceTestCheckpointInterval(50 * time.Millisecond)()
 
 	rev, doc, err := activeRT.GetSingleTestDatabaseCollectionWithUser().Put(activeCtx, "test", db.Body{})
 	require.NoError(t, err)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -7950,7 +7950,7 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 	defer teardown()
 	activeCtx := activeRT.Context()
 
-	// increase checkpointing interval temporarily to ensure the checkpointer doesn't fiore on an
+	// increase checkpointing interval temporarily to ensure the checkpointer doesn't fire on an
 	// interval during the running of the test
 	defer reduceTestCheckpointInterval(9999 * time.Hour)()
 


### PR DESCRIPTION
CBG-2579

Not able to repro the failiure locally.

But the first thing that jumps out is that the test fails to fetch the persisted checkpoint, suggesting its simply not there. A comment in the test previously suggested setting the checkpoint interval to 0 is disabling the interval. This is incorrect, it will default to the default value in this context which is 5 seconds. See -> https://github.com/couchbase/sync_gateway/blob/ac740e85e06f965fff11a6f7972e8c8c56d6834b/db/active_replicator_common.go#L93C3-L93C3 I have now replaced this with `reduceTestCheckpointInterval` to increase the checkpoint frequency and 50 seconds. Hopefully will stop the test from flaking.  

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2036/
