### PR TITLE
[3.0.9 backport] CBG-3408 don't panic if user is deleted with active blip replication …

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -11,8 +11,11 @@ licenses/APL2.txt.
 package rest
 
 import (
+	"net/http"
+	"strconv"
 	"testing"
 
+	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
@@ -136,4 +139,63 @@ func TestRequestPlusPullDbConfig(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, `{"channel":["PBS"]}`, string(data))
 
+}
+
+// TestBlipRefreshUser makes sure there is no panic if a user gets deleted during a replication
+func TestBlipRefreshUser(t *testing.T) {
+
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	const username = "bernard"
+	// Initialize blip tester client (will create user)
+	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+		Username: "bernard",
+		Channels: []string{"chan1"},
+	})
+
+	require.NoError(t, err)
+	defer btc.Close()
+
+	// add chan1 explicitly
+	response := rt.SendAdminRequest(http.MethodPut, "/db/_user/"+username, `{"name": "bernard", "password" : "letmein", "admin_channels" : ["chan1"]}`)
+
+	docID := "doc1"
+
+	RequireStatus(t, response, http.StatusOK)
+	response = rt.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"channels":["chan1"]}`)
+	RequireStatus(t, response, http.StatusCreated)
+
+	response = rt.SendUserRequest(http.MethodGet, "/db/"+docID, "", username)
+	RequireStatus(t, response, http.StatusOK)
+
+	// Start a regular one-shot pull
+	err = btc.StartPullSince("true", "0", "false", "", "")
+	require.NoError(t, err)
+
+	_, ok := btc.WaitForDoc(docID)
+	require.True(t, ok)
+
+	_, ok = btc.GetRev(docID, "1-78211b5eedea356c9693e08bc68b93ce")
+	require.True(t, ok)
+
+	// delete user with an active blip connection
+	response = rt.SendAdminRequest(http.MethodDelete, "/db/_user/"+username, "")
+	RequireStatus(t, response, http.StatusOK)
+
+	rt.WaitForPendingChanges()
+	msg := blip.NewRequest()
+	msg.SetProfile(db.MessageRev)
+	msg.Properties[db.RevMessageId] = "doesnotexist"
+	msg.Properties[db.RevMessageRev] = "1-fakerev"
+	msg.SetBody([]byte(`{"foo": "bar"}`))
+
+	err = btc.pullReplication.sendMsg(msg)
+	require.NoError(t, err)
+
+	testResponse := msg.Response()
+	body, err := testResponse.Body()
+	require.NoError(t, err)
+	require.Equal(t, strconv.Itoa(db.CBLReconnectErrorCode), testResponse.Properties[db.BlipErrorCode])
+	require.NotContains(t, string(body), "Panic:")
 }

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -183,7 +183,8 @@ func TestBlipRefreshUser(t *testing.T) {
 	response = rt.SendAdminRequest(http.MethodDelete, "/db/_user/"+username, "")
 	RequireStatus(t, response, http.StatusOK)
 
-	rt.WaitForPendingChanges()
+	err = rt.WaitForPendingChanges()
+	require.NoError(t, err)
 	msg := blip.NewRequest()
 	msg.SetProfile(db.MessageRev)
 	msg.Properties[db.RevMessageId] = "doesnotexist"


### PR DESCRIPTION
backports: CBG-3394 don't panic if user is deleted with active blip replication (#6445)

Tests are changed a bit, because `unsubChanges` message doesn't exist on 3.0

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-go1.16.15/76/
