### PR TITLE
[3.0.9 Backport] CBG-3447: Lower 'Found gap in revision list' logging to debug

### DIFF
--- a/db/revtree.go
+++ b/db/revtree.go
@@ -791,7 +791,7 @@ func encodeRevisions(revs []string) Revisions {
 		if i == 0 {
 			start = gen
 		} else if gen != start-i {
-			base.Warnf("Found gap in revision list. Expecting gen %v but got %v in %v", start-i, gen, revs)
+			base.Debugf(base.KeyCRUD, "Found gap in revision list. Expecting gen %v but got %v in %v", start-i, gen, revs)
 		}
 	}
 	return Revisions{RevisionsStart: start, RevisionsIds: ids}


### PR DESCRIPTION
CBG-3447

Backports #6416 to 3.0.9

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a