### PR TITLE
CBG-3449 Ensure metadata persistence on rollback

### DIFF
--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -137,8 +137,10 @@ func (c *DCPCommon) snapshotStart(vbNo uint16, snapStart, snapEnd uint64) {
 }
 
 // setMetaData and getMetaData may used internally by dcp clients.  Expects send/receive of opaque
-// []byte data.  May be invoked from multiple goroutines, so need to manage synchronization
-func (c *DCPCommon) setMetaData(vbucketId uint16, value []byte) {
+// []byte data.  May be invoked from multiple goroutines, so need to manage synchronization.
+// Setting mustPersist=true bypasses checkpoint threshold checks and forces persistence as long as
+// persistCheckpoints=true
+func (c *DCPCommon) setMetaData(vbucketId uint16, value []byte, mustPersist bool) error {
 
 	c.m.Lock()
 	defer c.m.Unlock()
@@ -146,20 +148,22 @@ func (c *DCPCommon) setMetaData(vbucketId uint16, value []byte) {
 	c.meta[vbucketId] = value
 
 	// Check persistMeta to avoids persistence if the only feed events we've seen are the DCP echo of DCP checkpoint docs
-	if c.persistCheckpoints && c.updatesSinceCheckpoint[vbucketId] >= kCheckpointThreshold {
+	if c.persistCheckpoints && (mustPersist || c.updatesSinceCheckpoint[vbucketId] >= kCheckpointThreshold) {
 
 		// Don't checkpoint more frequently than kCheckpointTimeThreshold
-		if time.Since(c.lastCheckpointTime[vbucketId]) < kCheckpointTimeThreshold {
-			return
+		if !mustPersist && time.Since(c.lastCheckpointTime[vbucketId]) < kCheckpointTimeThreshold {
+			return nil
 		}
 
 		err := c.persistCheckpoint(vbucketId, value)
 		if err != nil {
 			WarnfCtx(c.loggingCtx, "Unable to persist DCP metadata - will retry next snapshot. Error: %v", err)
+			return fmt.Errorf("Unable to persist DCP metadata")
 		}
 		c.updatesSinceCheckpoint[vbucketId] = 0
 		c.lastCheckpointTime[vbucketId] = time.Now()
 	}
+	return nil
 }
 
 func (c *DCPCommon) getMetaData(vbucketId uint16) (
@@ -181,14 +185,14 @@ func (c *DCPCommon) getMetaData(vbucketId uint16) (
 }
 
 // RollbackEx should be called by cbdatasource - Rollback required to maintain the interface.  In the event
-// it's called, logs warning and does a hard reset on metadata for the vbucket
+// it's called, logs warning and does a hard reset on metadata for the vbucket.  Returns error if metadata
+// persistence fails
 func (c *DCPCommon) rollback(vbucketId uint16, rollbackSeq uint64) error {
 	WarnfCtx(c.loggingCtx, "DCP Rollback request.  Expected RollbackEx call - resetting vbucket %d to 0.", vbucketId)
 	c.dbStatsExpvars.Add("dcp_rollback_count", 1)
 	c.updateSeq(vbucketId, 0, false)
-	c.setMetaData(vbucketId, nil)
-
-	return nil
+	err := c.setMetaData(vbucketId, nil, false)
+	return err
 }
 
 // RollbackEx includes the vbucketUUID needed to reset the metadata correctly
@@ -196,8 +200,8 @@ func (c *DCPCommon) rollbackEx(vbucketId uint16, vbucketUUID uint64, rollbackSeq
 	WarnfCtx(c.loggingCtx, "DCP RollbackEx request - rolling back DCP feed for: vbucketId: %d, rollbackSeq: %x.", vbucketId, rollbackSeq)
 	c.dbStatsExpvars.Add("dcp_rollback_count", 1)
 	c.updateSeq(vbucketId, rollbackSeq, false)
-	c.setMetaData(vbucketId, rollbackMetaData)
-	return nil
+	err := c.setMetaData(vbucketId, rollbackMetaData, false)
+	return err
 }
 
 func (c *DCPCommon) incrementCheckpointCount(vbucketId uint16) {

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -191,7 +191,7 @@ func (c *DCPCommon) rollback(vbucketId uint16, rollbackSeq uint64) error {
 	WarnfCtx(c.loggingCtx, "DCP Rollback request.  Expected RollbackEx call - resetting vbucket %d to 0.", vbucketId)
 	c.dbStatsExpvars.Add("dcp_rollback_count", 1)
 	c.updateSeq(vbucketId, 0, false)
-	err := c.setMetaData(vbucketId, nil, false)
+	err := c.setMetaData(vbucketId, nil, true)
 	return err
 }
 
@@ -200,7 +200,7 @@ func (c *DCPCommon) rollbackEx(vbucketId uint16, vbucketUUID uint64, rollbackSeq
 	WarnfCtx(c.loggingCtx, "DCP RollbackEx request - rolling back DCP feed for: vbucketId: %d, rollbackSeq: %x.", vbucketId, rollbackSeq)
 	c.dbStatsExpvars.Add("dcp_rollback_count", 1)
 	c.updateSeq(vbucketId, rollbackSeq, false)
-	err := c.setMetaData(vbucketId, rollbackMetaData, false)
+	err := c.setMetaData(vbucketId, rollbackMetaData, true)
 	return err
 }
 

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -207,7 +207,7 @@ func (d *DCPDest) OpaqueSet(partition string, value []byte) error {
 		d.InitVbMeta(vbNo)
 		d.metaInitComplete[vbNo] = true
 	}
-	d.setMetaData(vbNo, value)
+	_ = d.setMetaData(vbNo, value, false)
 	return nil
 }
 

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -104,7 +104,7 @@ func (r *DCPReceiver) SnapshotStart(vbNo uint16,
 }
 
 func (r *DCPReceiver) SetMetaData(vbucketId uint16, value []byte) error {
-	r.setMetaData(vbucketId, value)
+	_ = r.setMetaData(vbucketId, value, false)
 	return nil
 }
 

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -891,3 +891,18 @@ func AssertTimestampGreaterThan(t *testing.T, e1, e2 int64, msgAndArgs ...interf
 	}
 	return assert.Greater(t, e1, e2, msgAndArgs...)
 }
+
+func GetVbucketForKey(bucket Bucket, key string) (vbNo uint32, err error) {
+
+	cbBucket, ok := AsCouchbaseBucketStore(bucket)
+	if !ok {
+		return 0, fmt.Errorf("GetVbucketForKey not supported for non-Couchbase bucket")
+	}
+
+	maxVbNo, err := cbBucket.GetMaxVbno()
+	if err != nil {
+		return 0, err
+	}
+
+	return sgbucket.VBHash(key, maxVbNo), nil
+}

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -3033,7 +3033,6 @@ func TestImportRollback(t *testing.T) {
 		// wait for doc to be imported
 		changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+lastSeq, "", true)
 		require.NoError(t, err)
-		log.Printf("got changes: %v", changes)
 		var ok bool
 		lastSeq, ok = changes.Last_Seq.(string)
 		require.True(t, ok)
@@ -3043,13 +3042,9 @@ func TestImportRollback(t *testing.T) {
 		checkpointPrefix = rt.GetDatabase().MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID)
 	}()
 
-	// fetch the checkpoint for the document's vbucket
+	// fetch the checkpoint for the document's vbucket, modify the checkpoint values to a higher sequence
 	vbNo, err := base.GetVbucketForKey(bucket, key)
 	require.NoError(t, err)
-	log.Printf("got vbno: %v", vbNo)
-
-	// modify the checkpoint to a seq
-
 	metaStore := bucket.GetMetadataStore()
 	checkpointKey := fmt.Sprintf("%s%d", checkpointPrefix, vbNo)
 	var checkpointData dcpMetaData

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -3000,3 +3000,106 @@ func TestImportFilterTimeout(t *testing.T) {
 	timeoutErr := rest.WaitWithTimeout(&syncFnFinishedWG, time.Second*15)
 	assert.NoError(t, timeoutErr)
 }
+
+func TestImportRollback(t *testing.T) {
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server - needs cbgt and import checkpointing")
+	}
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyDCP)
+
+	ctx := base.TestCtx(t)
+	bucket := base.GetPersistentTestBucket(t)
+	defer bucket.Close(ctx)
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: bucket.NoCloseClone(),
+		PersistentConfig: false,
+	})
+
+	key := "importRollbackTest"
+	lastSeq := "0"
+	var checkpointPrefix string
+	// do some setup work in an anonymous function so that we can be sure to close the rest tester on unexpected error
+	func() {
+		defer rt.Close()
+
+		// Create a document
+		added, err := rt.GetSingleDataStore().AddRaw(key, 0, []byte(fmt.Sprintf(`{"star": "6"}`)))
+		require.True(t, added)
+		require.NoError(t, err)
+
+		// wait for doc to be imported
+		changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+lastSeq, "", true)
+		require.NoError(t, err)
+		log.Printf("got changes: %v", changes)
+		var ok bool
+		lastSeq, ok = changes.Last_Seq.(string)
+		require.True(t, ok)
+
+		// Close db while we mess with checkpoints
+		db := rt.GetDatabase()
+		checkpointPrefix = rt.GetDatabase().MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID)
+	}()
+
+	// fetch the checkpoint for the document's vbucket
+	vbNo, err := base.GetVbucketForKey(bucket, key)
+	require.NoError(t, err)
+	log.Printf("got vbno: %v", vbNo)
+
+	// modify the checkpoint to a seq
+
+	metaStore := bucket.GetMetadataStore()
+	checkpointKey := fmt.Sprintf("%s%d", checkpointPrefix, vbNo)
+	var checkpointData dcpMetaData
+	checkpointBytes, _, err := metaStore.GetRaw(checkpointKey)
+	require.NoError(t, err)
+	base.JSONUnmarshal(checkpointBytes, &checkpointData)
+
+	checkpointData.SnapStart = 3000 + checkpointData.SnapStart
+	checkpointData.SnapEnd = 3000 + checkpointData.SnapEnd
+	checkpointData.SeqStart = 3000 + checkpointData.SeqStart
+	checkpointData.SeqEnd = 3000 + checkpointData.SeqEnd
+	updatedBytes, err := base.JSONMarshal(checkpointData)
+	err = metaStore.SetRaw(checkpointKey, 0, nil, updatedBytes)
+	require.NoError(t, err)
+
+	// Reopen the db, expect DCP rollback
+	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: bucket.NoCloseClone(),
+		PersistentConfig: false,
+	})
+	defer rt2.Close()
+
+	err = rt2.GetSingleDataStore().SetRaw(key, 0, nil, []byte(fmt.Sprintf(`{"star": "7 8 9"}`)))
+	require.NoError(t, err)
+
+	// on new RT, may be import latency until old RT heartbeat expires and partitions are assigned.  Wait for all import partitions
+	// to be assigned to the new db before waiting for changes
+	err = rt2.WaitForCondition(func() bool {
+		database := rt2.GetDatabase()
+		expectedPartitions := int64(database.Options.ImportOptions.ImportPartitions)
+		partitions := database.DbStats.SharedBucketImportStats.ImportPartitions.Value()
+		if partitions < expectedPartitions {
+			log.Printf("waiting for %d partitions to be assigned to RT (have %d)", expectedPartitions, partitions)
+		}
+		return partitions >= expectedPartitions
+	})
+	require.NoError(t, err)
+
+	// wait for doc update to be imported
+	changes, err := rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+lastSeq, "", true)
+	require.NoError(t, err)
+
+	time.Sleep(10 * time.Minute)
+	log.Printf("updated changes: %v", changes)
+}
+
+type dcpMetaData struct {
+	SeqStart    uint64     `json:"seqStart"`
+	SeqEnd      uint64     `json:"seqEnd"`
+	SnapStart   uint64     `json:"snapStart"`
+	SnapEnd     uint64     `json:"snapEnd"`
+	FailOverLog [][]uint64 `json:"failOverLog"`
+}


### PR DESCRIPTION
Adds a mustPersist option to setMeta to ensure persistence during rollback.

setMeta also returns error if checkpoint persistence fails (e.g. transient server error).  This error is ignored during normal checkpointing, but is returned by the Rollback/RollbackEx implementations.

CBG-3449

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` [https://jenkins.sgwdev.com/job/SyncGateway-Integration/2054/](https://jenkins.sgwdev.com/job/SyncGateway-Integration/2054/)
