### PR TITLE
CBG-3453: Per-db log settings should take precedence over bootstrap

### DIFF
--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -97,8 +97,9 @@ func TestConsoleShouldLog(t *testing.T) {
 			test.loggerLevel.StringShort(), test.loggerKeys,
 			test.logToLevel.StringShort(), test.logToKey)
 
+		level := test.loggerLevel
 		l := mustInitConsoleLogger(TestCtx(t), &ConsoleLoggerConfig{
-			LogLevel: &test.loggerLevel,
+			LogLevel: &level,
 			LogKeys:  test.loggerKeys,
 			FileLoggerConfig: FileLoggerConfig{
 				Enabled: BoolPtr(true),
@@ -118,8 +119,9 @@ func BenchmarkConsoleShouldLog(b *testing.B) {
 			test.loggerLevel.StringShort(), test.loggerKeys,
 			test.logToLevel.StringShort(), test.logToKey)
 
+		level := test.loggerLevel
 		l := mustInitConsoleLogger(TestCtx(b), &ConsoleLoggerConfig{
-			LogLevel: &test.loggerLevel,
+			LogLevel: &level,
 			LogKeys:  test.loggerKeys,
 			FileLoggerConfig: FileLoggerConfig{
 				Enabled: BoolPtr(true),
@@ -183,8 +185,9 @@ func TestConsoleLogDefaults(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		config := test.config
 		t.Run(test.name, func(tt *testing.T) {
-			logger, err := NewConsoleLogger(TestCtx(tt), false, &test.config)
+			logger, err := NewConsoleLogger(TestCtx(tt), false, &config)
 			assert.NoError(tt, err)
 			assert.Equal(tt, test.expected.Enabled, logger.Enabled)
 			assert.Equal(tt, *test.expected.LogLevel, *logger.LogLevel)

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1061,9 +1061,8 @@ func (h *handler) handleGetRevTree() error {
 }
 
 func (h *handler) handleGetLogging() error {
+	base.WarnfCtx(h.ctx(), "Using deprecated /_logging endpoint. Use /_config endpoints instead.")
 	h.writeJSON(base.GetLogKeys())
-	base.WarnfCtx(h.ctx(), "Deprecation notice: Current _logging endpoints are now deprecated. Using _config endpoints "+
-		"instead")
 	return nil
 }
 
@@ -1131,8 +1130,7 @@ func (h *handler) handleGetStatus() error {
 }
 
 func (h *handler) handleSetLogging() error {
-	base.WarnfCtx(h.ctx(), "Deprecation notice: Current _logging endpoints are now deprecated. Using _config endpoints "+
-		"instead")
+	base.WarnfCtx(h.ctx(), "Using deprecated /_logging endpoint. Use /_config endpoints instead.")
 
 	body, err := h.readBody()
 	if err != nil {


### PR DESCRIPTION
CBG-3453

If db console log config is set, this always takes precedence over whatever the global/boostrap console logger's settings are.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2050/