### PR TITLE
CBG-3448: alter WriteUpdateWithXattrFunc definitions in sync gateway

### DIFF
--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -894,7 +894,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 
 	// Dummy write update function that increments 'counter' in the doc and 'seq' in the xattr
 	writeUpdateFunc := func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (
-		updatedDoc []byte, updatedXattr []byte, isDelete bool, updatedExpiry *uint32, err error) {
+		updatedDoc []byte, updatedXattr []byte, isDelete bool, updatedExpiry *uint32, updatedSpec []sgbucket.MacroExpansionSpec, err error) {
 
 		var docMap map[string]interface{}
 		var xattrMap map[string]interface{}
@@ -902,7 +902,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 		if len(doc) > 0 {
 			err = JSONUnmarshal(doc, &docMap)
 			if err != nil {
-				return nil, nil, false, nil, pkgerrors.Wrapf(err, "Unable to unmarshal incoming doc")
+				return nil, nil, false, nil, nil, pkgerrors.Wrapf(err, "Unable to unmarshal incoming doc")
 			}
 		} else {
 			// No incoming doc, treat as insert.
@@ -913,7 +913,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 		if len(xattr) > 0 {
 			err = JSONUnmarshal(xattr, &xattrMap)
 			if err != nil {
-				return nil, nil, false, nil, pkgerrors.Wrapf(err, "Unable to unmarshal incoming xattr")
+				return nil, nil, false, nil, nil, pkgerrors.Wrapf(err, "Unable to unmarshal incoming xattr")
 			}
 		} else {
 			// No incoming xattr, treat as insert.
@@ -938,7 +938,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 
 		updatedDoc, _ = JSONMarshal(docMap)
 		updatedXattr, _ = JSONMarshal(xattrMap)
-		return updatedDoc, updatedXattr, false, nil, nil
+		return updatedDoc, updatedXattr, false, nil, updatedSpec, nil
 	}
 
 	// Insert
@@ -984,7 +984,7 @@ func TestWriteUpdateWithXattrUserXattr(t *testing.T) {
 	xattrKey := SyncXattrName
 	userXattrKey := "UserXattr"
 
-	writeUpdateFunc := func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, isDelete bool, updatedExpiry *uint32, err error) {
+	writeUpdateFunc := func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, isDelete bool, updatedExpiry *uint32, updatedSpec []sgbucket.MacroExpansionSpec, err error) {
 
 		var docMap map[string]interface{}
 		var xattrMap map[string]interface{}
@@ -992,7 +992,7 @@ func TestWriteUpdateWithXattrUserXattr(t *testing.T) {
 		if len(doc) > 0 {
 			err = JSONUnmarshal(xattr, &docMap)
 			if err != nil {
-				return nil, nil, false, nil, err
+				return nil, nil, false, nil, nil, err
 			}
 		} else {
 			docMap = make(map[string]interface{})
@@ -1001,7 +1001,7 @@ func TestWriteUpdateWithXattrUserXattr(t *testing.T) {
 		if len(xattr) > 0 {
 			err = JSONUnmarshal(xattr, &xattrMap)
 			if err != nil {
-				return nil, nil, false, nil, err
+				return nil, nil, false, nil, nil, err
 			}
 		} else {
 			xattrMap = make(map[string]interface{})
@@ -1011,7 +1011,7 @@ func TestWriteUpdateWithXattrUserXattr(t *testing.T) {
 		if len(userXattr) > 0 {
 			err = JSONUnmarshal(userXattr, &userXattrMap)
 			if err != nil {
-				return nil, nil, false, nil, err
+				return nil, nil, false, nil, nil, err
 			}
 		} else {
 			userXattrMap = nil
@@ -1022,7 +1022,7 @@ func TestWriteUpdateWithXattrUserXattr(t *testing.T) {
 		updatedDoc, _ = JSONMarshal(docMap)
 		updatedXattr, _ = JSONMarshal(xattrMap)
 
-		return updatedDoc, updatedXattr, false, nil, nil
+		return updatedDoc, updatedXattr, false, nil, updatedSpec, nil
 	}
 
 	_, err := dataStore.WriteUpdateWithXattr(ctx, key, xattrKey, userXattrKey, 0, nil, nil, writeUpdateFunc)

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -201,7 +201,7 @@ func WriteUpdateWithXattr(ctx context.Context, store *Collection, k string, xatt
 		}
 
 		// Invoke callback to get updated value
-		updatedValue, updatedXattrValue, isDelete, callbackExpiry, err := callback(value, xattrValue, userXattrValue, cas)
+		updatedValue, updatedXattrValue, isDelete, callbackExpiry, macroOpts, err := callback(value, xattrValue, userXattrValue, cas)
 
 		// If it's an ErrCasFailureShouldRetry, then retry by going back through the for loop
 		if err == ErrCasFailureShouldRetry {
@@ -214,6 +214,9 @@ func WriteUpdateWithXattr(ctx context.Context, store *Collection, k string, xatt
 		}
 		if callbackExpiry != nil {
 			exp = *callbackExpiry
+		}
+		if len(macroOpts) != 0 {
+			opts.MacroExpansion = append(opts.MacroExpansion, macroOpts...)
 		}
 
 		// Attempt to write the updated document to the bucket.  Mark body for deletion if previous body was non-empty

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -201,7 +201,7 @@ func WriteUpdateWithXattr(ctx context.Context, store *Collection, k string, xatt
 		}
 
 		// Invoke callback to get updated value
-		updatedValue, updatedXattrValue, isDelete, callbackExpiry, macroOpts, err := callback(value, xattrValue, userXattrValue, cas)
+		updatedValue, updatedXattrValue, isDelete, callbackExpiry, updatedOpts, err := callback(value, xattrValue, userXattrValue, opts, cas)
 
 		// If it's an ErrCasFailureShouldRetry, then retry by going back through the for loop
 		if err == ErrCasFailureShouldRetry {
@@ -215,8 +215,8 @@ func WriteUpdateWithXattr(ctx context.Context, store *Collection, k string, xatt
 		if callbackExpiry != nil {
 			exp = *callbackExpiry
 		}
-		if len(macroOpts) != 0 {
-			opts.MacroExpansion = append(opts.MacroExpansion, macroOpts...)
+		if updatedOpts != nil {
+			opts = updatedOpts
 		}
 
 		// Attempt to write the updated document to the bucket.  Mark body for deletion if previous body was non-empty

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -201,7 +201,7 @@ func WriteUpdateWithXattr(ctx context.Context, store *Collection, k string, xatt
 		}
 
 		// Invoke callback to get updated value
-		updatedValue, updatedXattrValue, isDelete, callbackExpiry, updatedOpts, err := callback(value, xattrValue, userXattrValue, opts, cas)
+		updatedValue, updatedXattrValue, isDelete, callbackExpiry, updatedSpec, err := callback(value, xattrValue, userXattrValue, cas)
 
 		// If it's an ErrCasFailureShouldRetry, then retry by going back through the for loop
 		if err == ErrCasFailureShouldRetry {
@@ -215,8 +215,8 @@ func WriteUpdateWithXattr(ctx context.Context, store *Collection, k string, xatt
 		if callbackExpiry != nil {
 			exp = *callbackExpiry
 		}
-		if updatedOpts != nil {
-			opts = updatedOpts
+		if updatedSpec != nil {
+			opts.MacroExpansion = append(opts.MacroExpansion, updatedSpec...)
 		}
 
 		// Attempt to write the updated document to the bucket.  Mark body for deletion if previous body was non-empty

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -257,10 +257,10 @@ func (lds *LeakyDataStore) WriteWithXattr(ctx context.Context, k string, xattrKe
 
 func (lds *LeakyDataStore) WriteUpdateWithXattr(ctx context.Context, k string, xattr string, userXattrKey string, exp uint32, previous *sgbucket.BucketDocument, opts *sgbucket.MutateInOptions, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	if lds.config.UpdateCallback != nil {
-		wrapperCallback := func(current []byte, xattr []byte, userXattr []byte, opts *sgbucket.MutateInOptions, cas uint64) (updated []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, updatedOpts *sgbucket.MutateInOptions, err error) {
-			updated, updatedXattr, deletedDoc, expiry, updatedOpts, err = callback(current, xattr, userXattr, opts, cas)
+		wrapperCallback := func(current []byte, xattr []byte, userXattr []byte, cas uint64) (updated []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, updatedSpec []sgbucket.MacroExpansionSpec, err error) {
+			updated, updatedXattr, deletedDoc, expiry, updatedSpec, err = callback(current, xattr, userXattr, cas)
 			lds.config.UpdateCallback(k)
-			return updated, updatedXattr, deletedDoc, expiry, updatedOpts, err
+			return updated, updatedXattr, deletedDoc, expiry, updatedSpec, err
 		}
 		return lds.dataStore.WriteUpdateWithXattr(ctx, k, xattr, userXattrKey, exp, previous, opts, wrapperCallback)
 	}

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -257,10 +257,10 @@ func (lds *LeakyDataStore) WriteWithXattr(ctx context.Context, k string, xattrKe
 
 func (lds *LeakyDataStore) WriteUpdateWithXattr(ctx context.Context, k string, xattr string, userXattrKey string, exp uint32, previous *sgbucket.BucketDocument, opts *sgbucket.MutateInOptions, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	if lds.config.UpdateCallback != nil {
-		wrapperCallback := func(current []byte, xattr []byte, userXattr []byte, cas uint64) (updated []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, err error) {
-			updated, updatedXattr, deletedDoc, expiry, err = callback(current, xattr, userXattr, cas)
+		wrapperCallback := func(current []byte, xattr []byte, userXattr []byte, cas uint64) (updated []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, macroOpts []sgbucket.MacroExpansionSpec, err error) {
+			updated, updatedXattr, deletedDoc, expiry, macroOpts, err = callback(current, xattr, userXattr, cas)
 			lds.config.UpdateCallback(k)
-			return updated, updatedXattr, deletedDoc, expiry, err
+			return updated, updatedXattr, deletedDoc, expiry, macroOpts, err
 		}
 		return lds.dataStore.WriteUpdateWithXattr(ctx, k, xattr, userXattrKey, exp, previous, opts, wrapperCallback)
 	}

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -257,10 +257,10 @@ func (lds *LeakyDataStore) WriteWithXattr(ctx context.Context, k string, xattrKe
 
 func (lds *LeakyDataStore) WriteUpdateWithXattr(ctx context.Context, k string, xattr string, userXattrKey string, exp uint32, previous *sgbucket.BucketDocument, opts *sgbucket.MutateInOptions, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	if lds.config.UpdateCallback != nil {
-		wrapperCallback := func(current []byte, xattr []byte, userXattr []byte, cas uint64) (updated []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, macroOpts []sgbucket.MacroExpansionSpec, err error) {
-			updated, updatedXattr, deletedDoc, expiry, macroOpts, err = callback(current, xattr, userXattr, cas)
+		wrapperCallback := func(current []byte, xattr []byte, userXattr []byte, opts *sgbucket.MutateInOptions, cas uint64) (updated []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, updatedOpts *sgbucket.MutateInOptions, err error) {
+			updated, updatedXattr, deletedDoc, expiry, updatedOpts, err = callback(current, xattr, userXattr, opts, cas)
 			lds.config.UpdateCallback(k)
-			return updated, updatedXattr, deletedDoc, expiry, macroOpts, err
+			return updated, updatedXattr, deletedDoc, expiry, updatedOpts, err
 		}
 		return lds.dataStore.WriteUpdateWithXattr(ctx, k, xattr, userXattrKey, exp, previous, opts, wrapperCallback)
 	}

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/couchbase/gocbcore/v10"
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -751,7 +752,7 @@ func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, db *DatabaseCo
 	_, _, err = db.Put(ctx, docID, unmarshalledBody)
 	require.NoError(t, err)
 
-	_, err = db.dataStore.WriteUpdateWithXattr(ctx, docID, base.SyncXattrName, "", 0, nil, nil, func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, err error) {
+	_, err = db.dataStore.WriteUpdateWithXattr(ctx, docID, base.SyncXattrName, "", 0, nil, nil, func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, updatedSpec []sgbucket.MacroExpansionSpec, err error) {
 		attachmentSyncData := map[string]interface{}{
 			attID: map[string]interface{}{
 				"content_type": "application/json",
@@ -771,7 +772,7 @@ func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, db *DatabaseCo
 		})
 		require.NoError(t, err)
 
-		return doc, xattr, false, nil, nil
+		return doc, xattr, false, nil, updatedSpec, nil
 	})
 	require.NoError(t, err)
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -1902,7 +1902,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			opts = &sgbucket.MutateInOptions{}
 		}
 		opts.MacroExpansion = macroExpandSpec(base.SyncXattrName)
-		casOut, err = db.dataStore.WriteUpdateWithXattr(ctx, key, base.SyncXattrName, db.userXattrKey(), expiry, existingDoc, opts, func(currentValue []byte, currentXattr []byte, currentUserXattr []byte, cas uint64) (raw []byte, rawXattr []byte, deleteDoc bool, syncFuncExpiry *uint32, macroOpts []sgbucket.MacroExpansionSpec, err error) {
+		casOut, err = db.dataStore.WriteUpdateWithXattr(ctx, key, base.SyncXattrName, db.userXattrKey(), expiry, existingDoc, opts, func(currentValue []byte, currentXattr []byte, currentUserXattr []byte, inputOpts *sgbucket.MutateInOptions, cas uint64) (raw []byte, rawXattr []byte, deleteDoc bool, syncFuncExpiry *uint32, opts *sgbucket.MutateInOptions, err error) {
 			// Be careful: this block can be invoked multiple times if there are races!
 			if doc, err = unmarshalDocumentWithXattr(ctx, docid, currentValue, currentXattr, currentUserXattr, cas, DocUnmarshalAll); err != nil {
 				return
@@ -1957,7 +1957,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			}
 
 			base.DebugfCtx(ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.CurrentRev)
-			return raw, rawXattr, deleteDoc, syncFuncExpiry, macroOpts, err
+			return raw, rawXattr, deleteDoc, syncFuncExpiry, opts, err
 		})
 		if err != nil {
 			if err == base.ErrDocumentMigrated {

--- a/db/crud.go
+++ b/db/crud.go
@@ -1902,7 +1902,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			opts = &sgbucket.MutateInOptions{}
 		}
 		opts.MacroExpansion = macroExpandSpec(base.SyncXattrName)
-		casOut, err = db.dataStore.WriteUpdateWithXattr(ctx, key, base.SyncXattrName, db.userXattrKey(), expiry, existingDoc, opts, func(currentValue []byte, currentXattr []byte, currentUserXattr []byte, inputOpts *sgbucket.MutateInOptions, cas uint64) (raw []byte, rawXattr []byte, deleteDoc bool, syncFuncExpiry *uint32, opts *sgbucket.MutateInOptions, err error) {
+		casOut, err = db.dataStore.WriteUpdateWithXattr(ctx, key, base.SyncXattrName, db.userXattrKey(), expiry, existingDoc, opts, func(currentValue []byte, currentXattr []byte, currentUserXattr []byte, cas uint64) (raw []byte, rawXattr []byte, deleteDoc bool, syncFuncExpiry *uint32, updatedSpec []sgbucket.MacroExpansionSpec, err error) {
 			// Be careful: this block can be invoked multiple times if there are races!
 			if doc, err = unmarshalDocumentWithXattr(ctx, docid, currentValue, currentXattr, currentUserXattr, cas, DocUnmarshalAll); err != nil {
 				return
@@ -1957,7 +1957,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			}
 
 			base.DebugfCtx(ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.CurrentRev)
-			return raw, rawXattr, deleteDoc, syncFuncExpiry, opts, err
+			return raw, rawXattr, deleteDoc, syncFuncExpiry, updatedSpec, err
 		})
 		if err != nil {
 			if err == base.ErrDocumentMigrated {

--- a/db/crud.go
+++ b/db/crud.go
@@ -1902,7 +1902,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			opts = &sgbucket.MutateInOptions{}
 		}
 		opts.MacroExpansion = macroExpandSpec(base.SyncXattrName)
-		casOut, err = db.dataStore.WriteUpdateWithXattr(ctx, key, base.SyncXattrName, db.userXattrKey(), expiry, existingDoc, opts, func(currentValue []byte, currentXattr []byte, currentUserXattr []byte, cas uint64) (raw []byte, rawXattr []byte, deleteDoc bool, syncFuncExpiry *uint32, err error) {
+		casOut, err = db.dataStore.WriteUpdateWithXattr(ctx, key, base.SyncXattrName, db.userXattrKey(), expiry, existingDoc, opts, func(currentValue []byte, currentXattr []byte, currentUserXattr []byte, cas uint64) (raw []byte, rawXattr []byte, deleteDoc bool, syncFuncExpiry *uint32, macroOpts []sgbucket.MacroExpansionSpec, err error) {
 			// Be careful: this block can be invoked multiple times if there are races!
 			if doc, err = unmarshalDocumentWithXattr(ctx, docid, currentValue, currentXattr, currentUserXattr, cas, DocUnmarshalAll); err != nil {
 				return
@@ -1957,7 +1957,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			}
 
 			base.DebugfCtx(ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.CurrentRev)
-			return raw, rawXattr, deleteDoc, syncFuncExpiry, err
+			return raw, rawXattr, deleteDoc, syncFuncExpiry, macroOpts, err
 		})
 		if err != nil {
 			if err == base.ErrDocumentMigrated {

--- a/db/database.go
+++ b/db/database.go
@@ -1799,8 +1799,8 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 		db.dbStats().DatabaseStats.ImportProcessCompute.Add(stat)
 	}()
 	if db.UseXattrs() {
-		writeUpdateFunc := func(currentValue []byte, currentXattr []byte, currentUserXattr []byte, inputOpts *sgbucket.MutateInOptions, cas uint64) (
-			raw []byte, rawXattr []byte, deleteDoc bool, expiry *uint32, opts *sgbucket.MutateInOptions, err error) {
+		writeUpdateFunc := func(currentValue []byte, currentXattr []byte, currentUserXattr []byte, cas uint64) (
+			raw []byte, rawXattr []byte, deleteDoc bool, expiry *uint32, updatedSpec []sgbucket.MacroExpansionSpec, err error) {
 			// There's no scenario where a doc should from non-deleted to deleted during UpdateAllDocChannels processing,
 			// so deleteDoc is always returned as false.
 			if currentValue == nil || len(currentValue) == 0 {
@@ -1821,7 +1821,7 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 				}
 				doc.SetCrc32cUserXattrHash()
 				raw, rawXattr, err = updatedDoc.MarshalWithXattr()
-				return raw, rawXattr, deleteDoc, updatedExpiry, inputOpts, err
+				return raw, rawXattr, deleteDoc, updatedExpiry, updatedSpec, err
 			} else {
 				return nil, nil, deleteDoc, nil, nil, base.ErrUpdateCancel
 			}

--- a/db/database.go
+++ b/db/database.go
@@ -1800,19 +1800,19 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 	}()
 	if db.UseXattrs() {
 		writeUpdateFunc := func(currentValue []byte, currentXattr []byte, currentUserXattr []byte, cas uint64) (
-			raw []byte, rawXattr []byte, deleteDoc bool, expiry *uint32, err error) {
+			raw []byte, rawXattr []byte, deleteDoc bool, expiry *uint32, macroOpts []sgbucket.MacroExpansionSpec, err error) {
 			// There's no scenario where a doc should from non-deleted to deleted during UpdateAllDocChannels processing,
 			// so deleteDoc is always returned as false.
 			if currentValue == nil || len(currentValue) == 0 {
-				return nil, nil, deleteDoc, nil, base.ErrUpdateCancel
+				return nil, nil, deleteDoc, nil, nil, base.ErrUpdateCancel
 			}
 			doc, err := unmarshalDocumentWithXattr(ctx, docid, currentValue, currentXattr, currentUserXattr, cas, DocUnmarshalAll)
 			if err != nil {
-				return nil, nil, deleteDoc, nil, err
+				return nil, nil, deleteDoc, nil, nil, err
 			}
 			updatedDoc, shouldUpdate, updatedExpiry, updatedHighSeq, unusedSequences, err = db.getResyncedDocument(ctx, doc, regenerateSequences, unusedSequences)
 			if err != nil {
-				return nil, nil, deleteDoc, nil, err
+				return nil, nil, deleteDoc, nil, nil, err
 			}
 			if shouldUpdate {
 				base.InfofCtx(ctx, base.KeyAccess, "Saving updated channels and access grants of %q", base.UD(docid))
@@ -1821,9 +1821,9 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 				}
 				doc.SetCrc32cUserXattrHash()
 				raw, rawXattr, err = updatedDoc.MarshalWithXattr()
-				return raw, rawXattr, deleteDoc, updatedExpiry, err
+				return raw, rawXattr, deleteDoc, updatedExpiry, macroOpts, err
 			} else {
-				return nil, nil, deleteDoc, nil, base.ErrUpdateCancel
+				return nil, nil, deleteDoc, nil, nil, base.ErrUpdateCancel
 			}
 		}
 		opts := &sgbucket.MutateInOptions{

--- a/db/database.go
+++ b/db/database.go
@@ -1799,8 +1799,8 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 		db.dbStats().DatabaseStats.ImportProcessCompute.Add(stat)
 	}()
 	if db.UseXattrs() {
-		writeUpdateFunc := func(currentValue []byte, currentXattr []byte, currentUserXattr []byte, cas uint64) (
-			raw []byte, rawXattr []byte, deleteDoc bool, expiry *uint32, macroOpts []sgbucket.MacroExpansionSpec, err error) {
+		writeUpdateFunc := func(currentValue []byte, currentXattr []byte, currentUserXattr []byte, inputOpts *sgbucket.MutateInOptions, cas uint64) (
+			raw []byte, rawXattr []byte, deleteDoc bool, expiry *uint32, opts *sgbucket.MutateInOptions, err error) {
 			// There's no scenario where a doc should from non-deleted to deleted during UpdateAllDocChannels processing,
 			// so deleteDoc is always returned as false.
 			if currentValue == nil || len(currentValue) == 0 {
@@ -1821,7 +1821,7 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 				}
 				doc.SetCrc32cUserXattrHash()
 				raw, rawXattr, err = updatedDoc.MarshalWithXattr()
-				return raw, rawXattr, deleteDoc, updatedExpiry, macroOpts, err
+				return raw, rawXattr, deleteDoc, updatedExpiry, inputOpts, err
 			} else {
 				return nil, nil, deleteDoc, nil, nil, base.ErrUpdateCancel
 			}

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/couchbase/sg-bucket v0.0.0-20230929163612-8f8844395aa5
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20230921163940-606a53cd621f
+	github.com/couchbaselabs/rosmar v0.0.0-20230928085442-758234b6bfd6
 	github.com/elastic/gosigar v0.14.2
 	github.com/felixge/fgprof v0.9.3
 	github.com/google/uuid v1.3.1

--- a/go.mod
+++ b/go.mod
@@ -13,10 +13,10 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.2.8
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20230929163612-8f8844395aa5
+	github.com/couchbase/sg-bucket v0.0.0-20231003103030-627c70e18148
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20230928085442-758234b6bfd6
+	github.com/couchbaselabs/rosmar v0.0.0-20231003104919-6d4a3e8a6db6
 	github.com/elastic/gosigar v0.14.2
 	github.com/felixge/fgprof v0.9.3
 	github.com/google/uuid v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/couchbase/gomemcached v0.2.1 h1:lDONROGbklo8pOt4Sr4eV436PVEaKDr3o9gUl
 github.com/couchbase/gomemcached v0.2.1/go.mod h1:mxliKQxOv84gQ0bJWbI+w9Wxdpt9HjDvgW9MjCym5Vo=
 github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9BCs=
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
-github.com/couchbase/sg-bucket v0.0.0-20230929163612-8f8844395aa5 h1:D+mNgxx9zlPfsR2dFdpb7fX6KyR0tlYfgBXBOVbtFD4=
-github.com/couchbase/sg-bucket v0.0.0-20230929163612-8f8844395aa5/go.mod h1:hy6J0RXx/Ry+5EiI8VVMetsVfBXQq5/djQLbvfRau0k=
+github.com/couchbase/sg-bucket v0.0.0-20231003103030-627c70e18148 h1:9E3u0yA+be219iLLOjuYgagOfM7UqtZ0YIhMXysJVKs=
+github.com/couchbase/sg-bucket v0.0.0-20231003103030-627c70e18148/go.mod h1:hy6J0RXx/Ry+5EiI8VVMetsVfBXQq5/djQLbvfRau0k=
 github.com/couchbase/tools-common v0.0.0-20220810163003-4c3c185822d4 h1:Ub0gZWccoNL+ag59v8S23tbHDknfN1l3CVl7Kb+hFO0=
 github.com/couchbase/tools-common v0.0.0-20220810163003-4c3c185822d4/go.mod h1:lW0Em1mo5xqQ0mRMzJlg013/6ruyISupTfW7nbLaa1E=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338 h1:xMeDnMiapTiq8n8J83Mo2tPjQNIU7GssSsbQsP1CLOY=
@@ -49,10 +49,8 @@ github.com/couchbaselabs/gocaves/client v0.0.0-20230404095311-05e3ba4f0259 h1:2T
 github.com/couchbaselabs/gocaves/client v0.0.0-20230404095311-05e3ba4f0259/go.mod h1:AVekAZwIY2stsJOMWLAS/0uA/+qdp7pjO8EHnl61QkY=
 github.com/couchbaselabs/gocbconnstr v1.0.5 h1:e0JokB5qbcz7rfnxEhNRTKz8q1svoRvDoZihsiwNigA=
 github.com/couchbaselabs/gocbconnstr v1.0.5/go.mod h1:KV3fnIKMi8/AzX0O9zOrO9rofEqrRF1d2rG7qqjxC7o=
-github.com/couchbaselabs/rosmar v0.0.0-20230921163940-606a53cd621f h1:dAMLUFIIwohh9xUT3n00D7ka8PRsmo7lUu0x3VXjOmk=
-github.com/couchbaselabs/rosmar v0.0.0-20230921163940-606a53cd621f/go.mod h1:1r/4zwbprv8YLS32Jq7sEPi7XRpYNq0uoF94bOBQ260=
-github.com/couchbaselabs/rosmar v0.0.0-20230928085442-758234b6bfd6 h1:c7ETH8whOEz6ct/V5qyDGiiL4o5W0HbL43GPKnn2Y5A=
-github.com/couchbaselabs/rosmar v0.0.0-20230928085442-758234b6bfd6/go.mod h1:LJGyaL8e0muPVIwxTZKvvaKI3lxEEaCV0XKS4KeqVis=
+github.com/couchbaselabs/rosmar v0.0.0-20231003104919-6d4a3e8a6db6 h1:TeqaJ0zV0omrnvQfw4DF6o+UQQbFdBNPJVod1Y7ovQo=
+github.com/couchbaselabs/rosmar v0.0.0-20231003104919-6d4a3e8a6db6/go.mod h1:+HMmQTjaINo51eSZFeCKreXYSIu6jbIp+EV9keoKl3E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/couchbaselabs/gocbconnstr v1.0.5 h1:e0JokB5qbcz7rfnxEhNRTKz8q1svoRvDo
 github.com/couchbaselabs/gocbconnstr v1.0.5/go.mod h1:KV3fnIKMi8/AzX0O9zOrO9rofEqrRF1d2rG7qqjxC7o=
 github.com/couchbaselabs/rosmar v0.0.0-20230921163940-606a53cd621f h1:dAMLUFIIwohh9xUT3n00D7ka8PRsmo7lUu0x3VXjOmk=
 github.com/couchbaselabs/rosmar v0.0.0-20230921163940-606a53cd621f/go.mod h1:1r/4zwbprv8YLS32Jq7sEPi7XRpYNq0uoF94bOBQ260=
+github.com/couchbaselabs/rosmar v0.0.0-20230928085442-758234b6bfd6 h1:c7ETH8whOEz6ct/V5qyDGiiL4o5W0HbL43GPKnn2Y5A=
+github.com/couchbaselabs/rosmar v0.0.0-20230928085442-758234b6bfd6/go.mod h1:LJGyaL8e0muPVIwxTZKvvaKI3lxEEaCV0XKS4KeqVis=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/rest/utilities_testing_attachment.go
+++ b/rest/utilities_testing_attachment.go
@@ -53,7 +53,7 @@ func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, collection *db
 	_, _, err = collection.Put(ctx, docID, unmarshalledBody)
 	require.NoError(t, err)
 
-	_, err = dataStore.WriteUpdateWithXattr(ctx, docID, base.SyncXattrName, "", 0, nil, nil, func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, macroOpts []sgbucket.MacroExpansionSpec, err error) {
+	_, err = dataStore.WriteUpdateWithXattr(ctx, docID, base.SyncXattrName, "", 0, nil, nil, func(doc []byte, xattr []byte, userXattr []byte, opts *sgbucket.MutateInOptions, cas uint64) (updatedDoc []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, updatedOpts *sgbucket.MutateInOptions, err error) {
 		attachmentSyncData := map[string]interface{}{
 			attID: map[string]interface{}{
 				"content_type": "application/json",
@@ -73,7 +73,7 @@ func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, collection *db
 		})
 		require.NoError(t, err)
 
-		return doc, xattr, false, nil, macroOpts, nil
+		return doc, xattr, false, nil, updatedOpts, nil
 	})
 	require.NoError(t, err)
 

--- a/rest/utilities_testing_attachment.go
+++ b/rest/utilities_testing_attachment.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"testing"
 
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
@@ -52,7 +53,7 @@ func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, collection *db
 	_, _, err = collection.Put(ctx, docID, unmarshalledBody)
 	require.NoError(t, err)
 
-	_, err = dataStore.WriteUpdateWithXattr(ctx, docID, base.SyncXattrName, "", 0, nil, nil, func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, err error) {
+	_, err = dataStore.WriteUpdateWithXattr(ctx, docID, base.SyncXattrName, "", 0, nil, nil, func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, macroOpts []sgbucket.MacroExpansionSpec, err error) {
 		attachmentSyncData := map[string]interface{}{
 			attID: map[string]interface{}{
 				"content_type": "application/json",
@@ -72,7 +73,7 @@ func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, collection *db
 		})
 		require.NoError(t, err)
 
-		return doc, xattr, false, nil, nil
+		return doc, xattr, false, nil, macroOpts, nil
 	})
 	require.NoError(t, err)
 

--- a/rest/utilities_testing_attachment.go
+++ b/rest/utilities_testing_attachment.go
@@ -53,7 +53,7 @@ func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, collection *db
 	_, _, err = collection.Put(ctx, docID, unmarshalledBody)
 	require.NoError(t, err)
 
-	_, err = dataStore.WriteUpdateWithXattr(ctx, docID, base.SyncXattrName, "", 0, nil, nil, func(doc []byte, xattr []byte, userXattr []byte, opts *sgbucket.MutateInOptions, cas uint64) (updatedDoc []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, updatedOpts *sgbucket.MutateInOptions, err error) {
+	_, err = dataStore.WriteUpdateWithXattr(ctx, docID, base.SyncXattrName, "", 0, nil, nil, func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, updatedSpec []sgbucket.MacroExpansionSpec, err error) {
 		attachmentSyncData := map[string]interface{}{
 			attID: map[string]interface{}{
 				"content_type": "application/json",
@@ -73,7 +73,7 @@ func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, collection *db
 		})
 		require.NoError(t, err)
 
-		return doc, xattr, false, nil, updatedOpts, nil
+		return doc, xattr, false, nil, updatedSpec, nil
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
CBG-3448

Small PR to make sync gateway compatible with update to WriteUpdateWithXattrFunc callback. Chnages are needed for the PR https://github.com/couchbase/sync_gateway/pull/6366 to work. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [x] https://github.com/couchbase/sg-bucket/pull/107
- [x] https://github.com/couchbaselabs/rosmar/pull/13
- [x] Update Go module dependencies when above two are merged merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2057/
