### PR TITLE
CBG-2579: TestReplicatorCheckpointOnStop flake

### DIFF
--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -7966,6 +7966,7 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 
 	// assert on the processed seq list being updated before stopping the active replicator
 	ar, ok := activeRT.GetDatabase().SGReplicateMgr.GetLocalActiveReplicatorForTest(t, t.Name())
+	assert.True(t, ok)
 	pullCheckpointer := ar.Push.GetSingleCollection(t).Checkpointer
 	_, ok = base.WaitForStat(t, func() int64 {
 		return pullCheckpointer.Stats().ProcessedSequenceCount
@@ -7973,7 +7974,6 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 	require.True(t, ok)
 
 	// stop active replicator explicitly
-	assert.True(t, ok)
 	require.NoError(t, ar.Stop())
 
 	// Check checkpoint document was wrote to bucket with correct status

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -7954,14 +7954,14 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 	// interval during the running of the test
 	defer reduceTestCheckpointInterval(9999 * time.Hour)()
 
-	rev, doc, err := activeRT.GetSingleTestDatabaseCollectionWithUser().Put(activeCtx, "test", db.Body{})
+	_, doc, err := activeRT.GetSingleTestDatabaseCollectionWithUser().Put(activeCtx, "test", db.Body{})
 	require.NoError(t, err)
 	seq := strconv.FormatUint(doc.Sequence, 10)
 
 	activeRT.CreateReplication(t.Name(), remoteURL, db.ActiveReplicatorTypePush, nil, true, db.ConflictResolverDefault)
 	activeRT.WaitForReplicationStatus(t.Name(), db.ReplicationStateRunning)
 
-	err = passiveRT.WaitForRev("test", rev)
+	_, err = passiveRT.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
 	require.NoError(t, err)
 
 	// stop active replicator explicitly


### PR DESCRIPTION
CBG-2579

What i've noticed from logs on the test failure: 

We seem to be exiting the checkpoint now function early. We see this log line in the failure case -> https://github.com/couchbase/sync_gateway/blob/f7b2ac82b93a040b8533bb2f3f69015eb421ad75/db/active_replicator_checkpointer.go#L238C2-L238C2 but not this log line -> https://github.com/couchbase/sync_gateway/blob/f7b2ac82b93a040b8533bb2f3f69015eb421ad75/db/active_replicator_checkpointer.go#L245

The only thing that can be forcing this to exit early is the checkpointer not finding a safe sequence. Then I notice in the logs we have expectedSeq list at [1] and processedSeq list empty at []. See below:
```
13:19:33 2023-09-26T05:18:34.875-07:00 [TRC] Replicate+: c:TestReplicatorCheckpointOnStop-push checkpointer: running -- db.(*Checkpointer).CheckpointNow() at active_replicator_checkpointer.go:238
13:19:33 2023-09-26T05:18:34.875-07:00 [TRC] Replicate+: c:TestReplicatorCheckpointOnStop-push checkpointer: _updateCheckpointLists(expectedSeqs: [1], processedSeqs: map[]) -- db.(*Checkpointer)._updateCheckpointLists() at active_replicator_checkpointer.go:263
13:19:33 2023-09-26T05:18:34.875-07:00 [TRC] Replicate+: c:TestReplicatorCheckpointOnStop-push Inside AddProcessedSeq and context has been cancelled -- db.(*Checkpointer).AddProcessedSeq() at active_replicator_checkpointer.go:125
13:19:33 2023-09-26T05:18:34.875-07:00 [TRC] Replicate+: c:TestReplicatorCheckpointOnStop-push Inside update checkpoint lists -- db.(*Checkpointer)._updateCheckpointLists() at active_replicator_checkpointer.go:264
13:19:33 2023-09-26T05:18:34.875-07:00 [DBG] Replicate+: c:TestReplicatorCheckpointOnStop-push stats reporter goroutine stopped
13:19:33 2023-09-26T05:18:34.876-07:00 [TRC] Replicate+: c:TestReplicatorCheckpointOnStop-push closing blip sender -- db.(*activeReplicatorCommon)._disconnect() at active_replicator_common.go:256
13:19:33 2023-09-26T05:18:34.927-07:00 [TRC] Replicate+: c:TestReplicatorCheckpointOnStop-push closing blip sync context -- db.(*activeReplicatorCommon)._disconnect() at active_replicator_common.go:262
```

Noticed that the log line `Inside AddProcessedSeq and context has been cancelled` is after the `_updateCheckpointLists` logging. I think the callback to update processed sequences isn't firing before the context is cancelled on the active replicator leaving the processed sequences list empty. Thus no checkpoint being created.

Added a wait for the processed sequence count to increase to 1 before test continues.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2052/
