### PR TITLE
CBG-3454: 3.1.2 Backport Per-db log settings should take precedence over bootstrap

### DIFF
--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -97,8 +97,9 @@ func TestConsoleShouldLog(t *testing.T) {
 			test.loggerLevel.StringShort(), test.loggerKeys,
 			test.logToLevel.StringShort(), test.logToKey)
 
+		level := test.loggerLevel
 		l := mustInitConsoleLogger(TestCtx(t), &ConsoleLoggerConfig{
-			LogLevel: &test.loggerLevel,
+			LogLevel: &level,
 			LogKeys:  test.loggerKeys,
 			FileLoggerConfig: FileLoggerConfig{
 				Enabled: BoolPtr(true),
@@ -118,8 +119,9 @@ func BenchmarkConsoleShouldLog(b *testing.B) {
 			test.loggerLevel.StringShort(), test.loggerKeys,
 			test.logToLevel.StringShort(), test.logToKey)
 
+		level := test.loggerLevel
 		l := mustInitConsoleLogger(TestCtx(b), &ConsoleLoggerConfig{
-			LogLevel: &test.loggerLevel,
+			LogLevel: &level,
 			LogKeys:  test.loggerKeys,
 			FileLoggerConfig: FileLoggerConfig{
 				Enabled: BoolPtr(true),
@@ -131,6 +133,80 @@ func BenchmarkConsoleShouldLog(b *testing.B) {
 				l.shouldLog(TestCtx(bb), test.logToLevel, test.logToKey)
 			}
 		})
+	}
+}
+
+// TestConsoleShouldLogWithDatabase ensures that if set, database log config takes precedence over console config.
+func TestConsoleShouldLogWithDatabase(t *testing.T) {
+	for _, test := range consoleShouldLogTests {
+		for _, dbConfig := range []struct {
+			config   *DbConsoleLogConfig
+			expected bool
+		}{
+			{
+				config:   nil,
+				expected: test.expected, // fully inherit from console logger when dbConfig nil
+			},
+			{
+				config: &DbConsoleLogConfig{
+					LogLevel: logLevelPtr(LevelNone),
+					LogKeys:  logKeyMask(KeyAll),
+				},
+				expected: false, // log nothing from db
+			},
+			{
+				config: &DbConsoleLogConfig{
+					LogLevel: logLevelPtr(LevelTrace),
+					LogKeys:  logKeyMask(KeyAll),
+				},
+				expected: true, // log everything from db
+			},
+			{
+				config: &DbConsoleLogConfig{
+					LogLevel: logLevelPtr(LevelInfo),
+					LogKeys:  logKeyMask(KeyDCP),
+				},
+				// log DCP only from db (overrides console key)
+				expected: test.logToKey == KeyDCP && test.logToLevel <= LevelInfo,
+			},
+			{
+				config: &DbConsoleLogConfig{
+					LogLevel: logLevelPtr(LevelInfo),
+					LogKeys:  logKeyMask(KeyHTTP),
+				},
+				// Still expect the HTTP warnings when Info is set on db
+				expected: test.logToKey == KeyHTTP && test.logToLevel <= LevelInfo,
+			},
+		} {
+			dbConfigLevel := "<nil>"
+			if dbConfig.config != nil && dbConfig.config.LogLevel != nil {
+				dbConfigLevel = dbConfig.config.LogLevel.StringShort()
+			}
+			dbConfigKeys := "<nil>"
+			if dbConfig.config != nil && dbConfig.config.LogKeys != nil {
+				dbConfigKeys = dbConfig.config.LogKeys.String()
+			}
+
+			name := fmt.Sprintf("logger{%s,%s}.shouldLog(dbConfig(%s,%s), %s,%s)",
+				test.loggerLevel.StringShort(), test.loggerKeys,
+				dbConfigLevel, dbConfigKeys,
+				test.logToLevel.StringShort(), test.logToKey)
+
+			level := test.loggerLevel
+			l := mustInitConsoleLogger(TestCtx(t), &ConsoleLoggerConfig{
+				LogLevel: &level,
+				LogKeys:  test.loggerKeys,
+				FileLoggerConfig: FileLoggerConfig{
+					Enabled: BoolPtr(true),
+					Output:  io.Discard,
+				}})
+
+			t.Run(name, func(ts *testing.T) {
+				ctx := DatabaseLogCtx(TestCtx(ts), "db", dbConfig.config)
+				got := l.shouldLog(ctx, test.logToLevel, test.logToKey)
+				assert.Equal(ts, dbConfig.expected, got)
+			})
+		}
 	}
 }
 
@@ -183,8 +259,9 @@ func TestConsoleLogDefaults(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		config := test.config
 		t.Run(test.name, func(tt *testing.T) {
-			logger, err := NewConsoleLogger(TestCtx(tt), false, &test.config)
+			logger, err := NewConsoleLogger(TestCtx(tt), false, &config)
 			assert.NoError(tt, err)
 			assert.Equal(tt, test.expected.Enabled, logger.Enabled)
 			assert.Equal(tt, *test.expected.LogLevel, *logger.LogLevel)

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1045,9 +1045,8 @@ func (h *handler) handleGetRevTree() error {
 }
 
 func (h *handler) handleGetLogging() error {
+	base.WarnfCtx(h.ctx(), "Using deprecated /_logging endpoint. Use /_config endpoints instead.")
 	h.writeJSON(base.GetLogKeys())
-	base.WarnfCtx(h.ctx(), "Deprecation notice: Current _logging endpoints are now deprecated. Using _config endpoints "+
-		"instead")
 	return nil
 }
 
@@ -1115,8 +1114,7 @@ func (h *handler) handleGetStatus() error {
 }
 
 func (h *handler) handleSetLogging() error {
-	base.WarnfCtx(h.ctx(), "Deprecation notice: Current _logging endpoints are now deprecated. Using _config endpoints "+
-		"instead")
+	base.WarnfCtx(h.ctx(), "Using deprecated /_logging endpoint. Use /_config endpoints instead.")
 
 	body, err := h.readBody()
 	if err != nil {


### PR DESCRIPTION
CBG-3454

Backports #6472 to 3.1.2

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
