### PR TITLE
CBG-3455 run tests without import feed

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4011,6 +4011,7 @@ func TestDbConfigPersistentSGVersions(t *testing.T) {
 			Name:             dbName,
 			EnableXattrs:     base.BoolPtr(base.TestUseXattrs()),
 			UseViews:         base.BoolPtr(base.TestsDisableGSI()),
+			AutoImport:       false, // starts faster without import feed, but will panic if turned on CBG-3455
 			NumIndexReplicas: base.UintPtr(0),
 			RevsLimit:        base.Uint32Ptr(123), // use RevsLimit to detect config changes
 		},


### PR DESCRIPTION
This prevents a panic and will make MasterIntegration test work faster. I think we should address the underlying panic but I think it's more important to continue momentum with other projects and this will speed up the tests anyway.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2058/
