### PR TITLE
CBG-3464 Delete legacy config when migrated config already exists

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -1472,9 +1472,9 @@ func (sc *ServerContext) migrateV30Configs(ctx context.Context) error {
 		if insertErr != nil {
 			if insertErr == base.ErrAlreadyExists {
 				base.DebugfCtx(ctx, base.KeyConfig, "Found legacy config for database %s, but already exists in registry.", base.MD(dbConfig.Name))
-				continue
+			} else {
+				return fmt.Errorf("Error migrating v3.0 config for bucket %s groupID %s: %w", base.MD(bucketName), base.MD(groupID), insertErr)
 			}
-			return fmt.Errorf("Error migrating v3.0 config for bucket %s groupID %s: %w", base.MD(bucketName), base.MD(groupID), insertErr)
 		}
 		removeErr := sc.BootstrapContext.Connection.DeleteMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), legacyCas)
 		if removeErr != nil {

--- a/rest/config.go
+++ b/rest/config.go
@@ -1464,7 +1464,8 @@ func (sc *ServerContext) migrateV30Configs(ctx context.Context) error {
 		if getErr == base.ErrNotFound {
 			continue
 		} else if getErr != nil {
-			return fmt.Errorf("Error retrieving 3.0 config for bucket: %s, groupID: %s: %w", bucketName, groupID, getErr)
+			base.InfofCtx(ctx, base.KeyConfig, "Unable to retrieve 3.0 config during config migration for bucket: %s, groupID: %s: %w", base.MD(bucketName), base.MD(groupID), getErr)
+			continue
 		}
 
 		base.InfofCtx(ctx, base.KeyConfig, "Found legacy persisted config for database %s - migrating to db registry.", base.MD(dbConfig.Name))
@@ -1473,7 +1474,8 @@ func (sc *ServerContext) migrateV30Configs(ctx context.Context) error {
 			if insertErr == base.ErrAlreadyExists {
 				base.DebugfCtx(ctx, base.KeyConfig, "Found legacy config for database %s, but already exists in registry.", base.MD(dbConfig.Name))
 			} else {
-				return fmt.Errorf("Error migrating v3.0 config for bucket %s groupID %s: %w", base.MD(bucketName), base.MD(groupID), insertErr)
+				base.InfofCtx(ctx, base.KeyConfig, "Unable to persist migrated v3.0 config for bucket %s groupID %s: %w", base.MD(bucketName), base.MD(groupID), insertErr)
+				continue
 			}
 		}
 		removeErr := sc.BootstrapContext.Connection.DeleteMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), legacyCas)

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -1138,6 +1138,95 @@ func TestMigratev30PersistentConfig(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, "2-abc", migratedDb.Version)
 
+	// Verify legacy config has been removed
+	_, getError = sc.BootstrapContext.Connection.GetMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), defaultDatabaseConfig)
+	require.Equal(t, base.ErrNotFound, getError)
+
+}
+
+func TestMigratev30PersistentConfigUseXattrStore(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	base.TestRequiresCollections(t)
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
+
+	serverErr := make(chan error, 0)
+
+	// Set up test for persistent config
+	config := BootstrapStartupConfigForTest(t)
+	config.Unsupported.UseXattrConfig = base.BoolPtr(true)
+	// "disable" config polling for this test, to avoid non-deterministic test output based on polling times
+	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(time.Minute * 10)
+	ctx := base.TestCtx(t)
+	sc, err := SetupServerContext(ctx, &config, true)
+	require.NoError(t, err)
+	defer func() {
+		sc.Close(ctx)
+		require.NoError(t, <-serverErr)
+	}()
+
+	go func() {
+		serverErr <- StartServer(ctx, &config, sc)
+	}()
+	require.NoError(t, sc.WaitForRESTAPIs(ctx))
+
+	// Get a test bucket, and use it to create the database.
+	tb := base.GetTestBucket(t)
+	defer func() {
+		fmt.Println("closing test bucket")
+		tb.Close(ctx)
+	}()
+
+	bucketName := tb.GetName()
+	groupID := sc.Config.Bootstrap.ConfigGroupID
+	defaultDbName := "defaultDb"
+	defaultVersion := "1-abc"
+	defaultDbConfig := makeDbConfig(tb.GetName(), defaultDbName, nil)
+	defaultDatabaseConfig := &DatabaseConfig{
+		DbConfig: defaultDbConfig,
+		Version:  defaultVersion,
+	}
+
+	_, insertError := sc.BootstrapContext.Connection.InsertMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), defaultDatabaseConfig)
+	require.NoError(t, insertError)
+
+	migrateErr := sc.migrateV30Configs(ctx)
+	require.NoError(t, migrateErr)
+
+	// Fetch the registry, verify database has been migrated
+	registry, registryErr := sc.BootstrapContext.getGatewayRegistry(ctx, bucketName)
+	require.NoError(t, registryErr)
+	require.NotNil(t, registry)
+	migratedDb, found := registry.getRegistryDatabase(groupID, defaultDbName)
+	require.True(t, found)
+	require.Equal(t, "1-abc", migratedDb.Version)
+	// Verify legacy config has been removed
+	_, getError := sc.BootstrapContext.Connection.GetMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), defaultDatabaseConfig)
+	require.Equal(t, base.ErrNotFound, getError)
+
+	// Update the db in the registry, and recreate legacy config.  Verify migration doesn't overwrite
+	_, insertError = sc.BootstrapContext.Connection.InsertMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), defaultDatabaseConfig)
+	require.NoError(t, insertError)
+	_, updateError := sc.BootstrapContext.UpdateConfig(ctx, bucketName, groupID, defaultDbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+		bucketDbConfig.Version = "2-abc"
+		return bucketDbConfig, nil
+	})
+	require.NoError(t, updateError)
+	migrateErr = sc.migrateV30Configs(ctx)
+	require.NoError(t, migrateErr)
+	registry, registryErr = sc.BootstrapContext.getGatewayRegistry(ctx, bucketName)
+	require.NoError(t, registryErr)
+	require.NotNil(t, registry)
+	migratedDb, found = registry.getRegistryDatabase(groupID, defaultDbName)
+	require.True(t, found)
+	require.Equal(t, "2-abc", migratedDb.Version)
+
+	// Verify legacy config has been removed
+	_, getError = sc.BootstrapContext.Connection.GetMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), defaultDatabaseConfig)
+	require.Equal(t, base.ErrNotFound, getError)
+
 }
 
 // TestMigratev30PersistentConfigCollision sets up a 3.1 database targeting the default collection, then attempts


### PR DESCRIPTION
CBG-3464

In the case where a 3.1 version of the config exists, delete duplicate 3.0 config if found with matching database and config group during migration.

Also adds a test for migrate handling with use_xattr_config=true.


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2072/
