### PR TITLE
CBG-3459: TestUserXattrRevCache flaky test

### DIFF
--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1274,8 +1274,9 @@ func TestUserXattrRevCache(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb.NoCloseClone(),
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			AutoImport:   true,
-			UserXattrKey: xattrKey,
+			AutoImport:       true,
+			UserXattrKey:     xattrKey,
+			ImportPartitions: base.Uint16Ptr(2), // temporarily config to 2 import partitions (default 1 for rest tester) pending CBG-3438 + CBG-3439
 		}},
 		SyncFn: syncFn,
 	})
@@ -1285,8 +1286,9 @@ func TestUserXattrRevCache(t *testing.T) {
 		CustomTestBucket: tb.NoCloseClone(),
 
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			AutoImport:   true,
-			UserXattrKey: xattrKey,
+			AutoImport:       true,
+			UserXattrKey:     xattrKey,
+			ImportPartitions: base.Uint16Ptr(2), // temporarily config to 2 import partitions (default 1 for rest tester) pending CBG-3438 + CBG-3439
 		}},
 		SyncFn: syncFn,
 	})


### PR DESCRIPTION
CBG-3459

Change import partitions on this test to stop the flake pending CBG-3438 + CBG-3439

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2060/
- [x]  `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2061/
