### PR TITLE
CBG-3353: Handle nil buckets in db config

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -906,3 +906,19 @@ func GetVbucketForKey(bucket Bucket, key string) (vbNo uint32, err error) {
 
 	return sgbucket.VBHash(key, maxVbNo), nil
 }
+
+// MoveDocument moves the document from src to dst
+// Note: does not handle xattr contents
+func MoveDocument(t testing.TB, docID string, dst, src DataStore) {
+	var data interface{}
+
+	srcCAS, err := src.Get(docID, &data)
+	require.NoError(t, err)
+
+	ok, err := dst.Add(docID, 0, data)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	_, err = src.Remove(docID, srcCAS)
+	require.NoError(t, err)
+}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -80,6 +80,11 @@ func (h *handler) handleCreateDB() error {
 			metadataID = h.server.BootstrapContext.standardMetadataID(config.Name)
 		}
 
+		// Before taking a copy of the "persistedDbConfig", stamp bucket if missing
+		if config.Bucket == nil {
+			config.Bucket = &dbName
+		}
+
 		// copy config before setup to persist the raw config the user supplied
 		var persistedDbConfig DbConfig
 		if err := base.DeepCopyInefficient(&persistedDbConfig, config); err != nil {
@@ -95,7 +100,8 @@ func (h *handler) handleCreateDB() error {
 		loadedConfig := DatabaseConfig{
 			Version:    version,
 			MetadataID: metadataID,
-			DbConfig:   *config}
+			DbConfig:   *config,
+		}
 
 		persistedConfig := DatabaseConfig{
 			Version:    version,

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -200,8 +200,12 @@ func getAuthScopeHandleCreateDB(ctx context.Context, h *handler) (bucketName str
 	}
 
 	if dbConfigBody.Bucket == "" {
+		dbName := h.PathVar("newdb")
+		if dbName == "" {
+			return "", base.HTTPErrorf(http.StatusBadRequest, "bucket or db name not specified in request")
+		}
 		// imply bucket name from db name in path if not in body
-		return h.PathVar("newdb"), nil
+		return dbName, nil
 	}
 
 	return dbConfigBody.Bucket, nil

--- a/rest/config.go
+++ b/rest/config.go
@@ -364,6 +364,8 @@ func (dbConfig *DbConfig) setDatabaseCredentials(credentials base.CredentialsCon
 // setup populates fields in the dbConfig
 func (dbConfig *DbConfig) setup(ctx context.Context, dbName string, bootstrapConfig BootstrapConfig, dbCredentials, bucketCredentials *base.CredentialsConfig, forcePerBucketAuth bool) error {
 	dbConfig.Name = dbName
+
+	// use db name as bucket if absent from config
 	if dbConfig.Bucket == nil {
 		dbConfig.Bucket = &dbConfig.Name
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -365,7 +365,7 @@ func (dbConfig *DbConfig) setDatabaseCredentials(credentials base.CredentialsCon
 func (dbConfig *DbConfig) setup(ctx context.Context, dbName string, bootstrapConfig BootstrapConfig, dbCredentials, bucketCredentials *base.CredentialsConfig, forcePerBucketAuth bool) error {
 	dbConfig.Name = dbName
 
-	// use db name as bucket if absent from config (handling for non-stamped configs)
+	// use db name as bucket if absent from config (handling for old non-stamped configs)
 	if dbConfig.Bucket == nil {
 		dbConfig.Bucket = &dbConfig.Name
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -365,7 +365,7 @@ func (dbConfig *DbConfig) setDatabaseCredentials(credentials base.CredentialsCon
 func (dbConfig *DbConfig) setup(ctx context.Context, dbName string, bootstrapConfig BootstrapConfig, dbCredentials, bucketCredentials *base.CredentialsConfig, forcePerBucketAuth bool) error {
 	dbConfig.Name = dbName
 
-	// use db name as bucket if absent from config
+	// use db name as bucket if absent from config (handling for non-stamped configs)
 	if dbConfig.Bucket == nil {
 		dbConfig.Bucket = &dbConfig.Name
 	}
@@ -546,6 +546,15 @@ func readFromPath(ctx context.Context, path string, insecureSkipVerify bool) (rc
 		return nil, ErrPathNotFound
 	}
 	return rc, nil
+}
+
+// GetBucketName returns the bucket name associated with the database config.
+func (dbConfig *DbConfig) GetBucketName() string {
+	if dbConfig.Bucket != nil {
+		return *dbConfig.Bucket
+	}
+	// db name as fallback in the case of a `nil` bucket.
+	return dbConfig.Name
 }
 
 func (dbConfig *DbConfig) AutoImportEnabled(ctx context.Context) (bool, error) {
@@ -1539,7 +1548,7 @@ func (sc *ServerContext) _fetchDatabase(ctx context.Context, dbName string) (fou
 		// We need to check for corruption in the database config (CC. CBG-3292). If the fetched config doesn't match the
 		// bucket name we got the config from we need to maker this db context as corrupt. Then remove the context and
 		// in memory representation on the server context.
-		if bucket != *cnf.Bucket {
+		if bucket != cnf.GetBucketName() {
 			sc._handleInvalidDatabaseConfig(ctx, bucket, cnf)
 			return true, fmt.Errorf("mismatch in persisted database bucket name %q vs the actual bucket name %q. Please correct db %q's config, groupID %q.", base.MD(cnf.Bucket), base.MD(bucket), base.MD(cnf.Name), base.MD(sc.Config.Bootstrap.ConfigGroupID))
 		}
@@ -1700,7 +1709,7 @@ func (sc *ServerContext) FetchConfigs(ctx context.Context, isInitialStartup bool
 			// We need to check for corruption in the database config (CC. CBG-3292). If the fetched config doesn't match the
 			// bucket name we got the config from we need to maker this db context as corrupt. Then remove the context and
 			// in memory representation on the server context.
-			if bucket != *cnf.Bucket {
+			if bucket != cnf.GetBucketName() {
 				sc.handleInvalidDatabaseConfig(ctx, bucket, *cnf)
 				continue
 			}

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -693,11 +693,7 @@ func (b *bootstrapContext) addDatabaseLogContext(ctx context.Context, config *Db
 }
 
 func (b *bootstrapContext) ComputeMetadataIDForDbConfig(ctx context.Context, config *DbConfig) (string, error) {
-	bucketName := config.Bucket
-	if bucketName == nil {
-		return "", fmt.Errorf("No bucket defined in dbConfig, cannot compute metadataID")
-	}
-	registry, err := b.getGatewayRegistry(ctx, *bucketName)
+	registry, err := b.getGatewayRegistry(ctx, config.GetBucketName())
 	if err != nil {
 		return "", err
 	}
@@ -740,8 +736,7 @@ func (b *bootstrapContext) computeMetadataID(ctx context.Context, registry *Gate
 		}
 	}
 
-	// If _default._default is already associated with a metadataID, return standard metadata ID
-	bucketName := *config.Bucket
+	bucketName := config.GetBucketName()
 	exists, err := b.Connection.KeyExists(ctx, bucketName, base.SGSyncInfo)
 	if err != nil {
 		base.WarnfCtx(ctx, "Error checking whether metadataID is already defined for default collection - using standard metadataID.  Error: %v", err)

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -271,8 +271,6 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 
 // validateAndWriteHeaders sets up handler.db and validates the permission of the user and returns an error if there is not permission.
 func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermissions []Permission, responsePermissions []Permission) error {
-	ctx := h.ctx()
-
 	var isRequestLogged bool
 	defer func() {
 		if !isRequestLogged {
@@ -358,7 +356,7 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 					}
 				}
 				var dbConfigFound bool
-				dbContext, dbConfigFound, err = h.server.GetInactiveDatabase(ctx, keyspaceDb)
+				dbContext, dbConfigFound, err = h.server.GetInactiveDatabase(h.ctx(), keyspaceDb)
 				if err != nil {
 					if httpError, ok := err.(*base.HTTPError); ok && httpError.Status == http.StatusNotFound {
 						if shouldCheckAdminAuth && (!h.allowNilDBContext || !dbConfigFound) {
@@ -372,10 +370,10 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 						}
 					}
 					if !h.allowNilDBContext || !dbConfigFound {
-						base.InfofCtx(ctx, base.KeyHTTP, "Error trying to get db %s: %v", base.MD(keyspaceDb), err)
+						base.InfofCtx(h.ctx(), base.KeyHTTP, "Error trying to get db %s: %v", base.MD(keyspaceDb), err)
 						return err
 					}
-					bucketName, _ = h.server.bucketNameFromDbName(ctx, keyspaceDb)
+					bucketName, _ = h.server.bucketNameFromDbName(h.ctx(), keyspaceDb)
 				}
 			} else {
 				return err
@@ -436,14 +434,14 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 	// Note: checkAuth already does this check if the user authenticates with a bearer token, but we still need to recheck
 	// for users using session tokens / basic auth. However, updatePrincipal will be idempotent.
 	if h.user != nil && h.user.JWTIssuer() != "" {
-		updates := checkJWTIssuerStillValid(ctx, dbContext, h.user)
+		updates := checkJWTIssuerStillValid(h.ctx(), dbContext, h.user)
 		if updates != nil {
-			_, err := dbContext.UpdatePrincipal(ctx, updates, true, true)
+			_, err := dbContext.UpdatePrincipal(h.ctx(), updates, true, true)
 			if err != nil {
 				return fmt.Errorf("failed to revoke stale OIDC roles/channels: %w", err)
 			}
 			// TODO: could avoid this extra fetch if UpdatePrincipal returned the new principal
-			h.user, err = dbContext.Authenticator(ctx).GetUser(*updates.Name)
+			h.user, err = dbContext.Authenticator(h.ctx()).GetUser(*updates.Name)
 			if err != nil {
 				return err
 			}
@@ -471,18 +469,18 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 
 		var err error
 		if dbContext != nil {
-			managementEndpoints, httpClient, err = dbContext.ObtainManagementEndpointsAndHTTPClient(ctx)
+			managementEndpoints, httpClient, err = dbContext.ObtainManagementEndpointsAndHTTPClient(h.ctx())
 			authScope = dbContext.Bucket.GetName()
 		} else {
 			managementEndpoints, httpClient, err = h.server.ObtainManagementEndpointsAndHTTPClient()
 			authScope = bucketName
 		}
 		if err != nil {
-			base.WarnfCtx(ctx, "An error occurred whilst obtaining management endpoints: %v", err)
+			base.WarnfCtx(h.ctx(), "An error occurred whilst obtaining management endpoints: %v", err)
 			return base.HTTPErrorf(http.StatusInternalServerError, "")
 		}
 		if h.authScopeFunc != nil {
-			authScope, err = h.authScopeFunc(ctx, h)
+			authScope, err = h.authScopeFunc(h.ctx(), h)
 			if err != nil {
 				return base.HTTPErrorf(http.StatusInternalServerError, "Unable to read body: %v", err)
 			}
@@ -491,16 +489,16 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 			}
 		}
 
-		permissions, statusCode, err := checkAdminAuth(ctx, authScope, username, password, h.rq.Method, httpClient,
+		permissions, statusCode, err := checkAdminAuth(h.ctx(), authScope, username, password, h.rq.Method, httpClient,
 			managementEndpoints, *h.server.Config.API.EnableAdminAuthenticationPermissionsCheck, accessPermissions,
 			responsePermissions)
 		if err != nil {
-			base.WarnfCtx(ctx, "An error occurred whilst checking whether a user was authorized: %v", err)
+			base.WarnfCtx(h.ctx(), "An error occurred whilst checking whether a user was authorized: %v", err)
 			return base.HTTPErrorf(http.StatusInternalServerError, "")
 		}
 
 		if statusCode != http.StatusOK {
-			base.InfofCtx(ctx, base.KeyAuth, "%s: User %s failed to auth as an admin statusCode: %d", h.formatSerialNumber(), base.UD(username), statusCode)
+			base.InfofCtx(h.ctx(), base.KeyAuth, "%s: User %s failed to auth as an admin statusCode: %d", h.formatSerialNumber(), base.UD(username), statusCode)
 			if statusCode == http.StatusUnauthorized {
 				return ErrInvalidLogin
 			}
@@ -510,7 +508,7 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 		h.authorizedAdminUser = username
 		h.permissionsResults = permissions
 
-		base.DebugfCtx(ctx, base.KeyAuth, "%s: User %s was successfully authorized as an admin", h.formatSerialNumber(), base.UD(username))
+		base.DebugfCtx(h.ctx(), base.KeyAuth, "%s: User %s was successfully authorized as an admin", h.formatSerialNumber(), base.UD(username))
 	} else {
 		// If admin auth is not enabled we should set any responsePermissions to true so that any handlers checking for
 		// these still pass

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -1307,7 +1307,6 @@ func TestPersistentConfigNoBucketField(t *testing.T) {
 
 	// Move config docs from original bucket to b2 and force a fetch/load (simulate backup/restore or XDCR to different bucket)
 	base.MoveDocument(t, base.SGRegistryKey, b2.GetMetadataStore(), b1.GetMetadataStore())
-	base.MoveDocument(t, base.SGSyncInfo, b2.GetMetadataStore(), b1.GetMetadataStore())
 	base.MoveDocument(t, configDocID, b2.GetMetadataStore(), b1.GetMetadataStore())
 
 	// put the bucket for the config back to b1 so we can use the admin API to repair the config (like a real user would have to do)

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -1340,6 +1340,5 @@ func TestPersistentConfigNoBucketField(t *testing.T) {
 	count, err = rt.ServerContext().fetchAndLoadConfigs(base.TestCtx(t), false)
 	require.NoError(t, err)
 	assert.Equal(t, 0, count)
-	dbBucketMismatch, _ = base.WaitForStat(t, base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Value, dbBucketMismatch+1)
-
+	_, _ = base.WaitForStat(t, base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Value, dbBucketMismatch+1)
 }

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -1287,5 +1287,5 @@ func TestPersistentConfigNoBucketField(t *testing.T) {
 
 	count, err = rt.ServerContext().fetchAndLoadConfigs(base.TestCtx(t), false)
 	require.NoError(t, err)
-	assert.Equal(t, 1, count, "should have loaded 1 config")
+	assert.Equal(t, 0, count)
 }

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -1240,22 +1240,19 @@ func makeDbConfig(bucketName string, dbName string, scopesConfig ScopesConfig) D
 }
 
 func TestPersistentConfigNoBucketField(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
+	base.TestsRequireBootstrapConnection(t)
+	base.RequireNumTestBuckets(t, 2)
 
 	base.SetUpTestLogging(t, base.LevelTrace, base.KeyConfig)
 
 	b1 := base.GetTestBucket(t)
 	defer b1.Close(base.TestCtx(t))
 	b1Name := b1.GetName()
-	t.Logf("b1: %s", b1Name)
 
 	// at the end of the test we'll move config from b1 into b2 to test backup/restore-type migration
 	b2 := base.GetTestBucket(t)
 	defer b2.Close(base.TestCtx(t))
 	b2Name := b2.GetName()
-	t.Logf("b2: %s", b2Name)
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		PersistentConfig: true,

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -1244,11 +1244,26 @@ func TestPersistentConfigNoBucketField(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
+	base.SetUpTestLogging(t, base.LevelTrace, base.KeyConfig)
+
+	b1 := base.GetTestBucket(t)
+	defer b1.Close(base.TestCtx(t))
+	b1Name := b1.GetName()
+	t.Logf("b1: %s", b1Name)
+
+	// at the end of the test we'll move config from b1 into b2 to test backup/restore-type migration
+	b2 := base.GetTestBucket(t)
+	defer b2.Close(base.TestCtx(t))
+	b2Name := b2.GetName()
+	t.Logf("b2: %s", b2Name)
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		PersistentConfig: true,
+		CustomTestBucket: b1.NoCloseClone(),
+	})
 	defer rt.Close()
 
-	bucketName := rt.Bucket().GetName()
-	dbName := bucketName
+	dbName := b1Name
 
 	dbConfig := rt.NewDbConfig()
 	// will infer from db name in handler and stamp into config (as of CBG-3353)
@@ -1256,16 +1271,16 @@ func TestPersistentConfigNoBucketField(t *testing.T) {
 	resp := rt.CreateDatabase(dbName, dbConfig)
 	RequireStatus(t, resp, http.StatusCreated)
 
-	// read back config in bucket to see if bucket exists in there
+	// read back config in bucket to see if bucket field was stamped into the config
 	var databaseConfig DatabaseConfig
 	groupID := rt.ServerContext().Config.Bootstrap.ConfigGroupID
-	configDocID := PersistentConfigKey(base.TestCtx(t), groupID, bucketName)
+	configDocID := PersistentConfigKey(base.TestCtx(t), groupID, b1Name)
 	_, err := rt.GetDatabase().MetadataStore.Get(configDocID, &databaseConfig)
 	require.NoError(t, err)
 	require.NotNil(t, databaseConfig.Bucket)
-	assert.Equal(t, bucketName, *databaseConfig.Bucket, "bucket field should be stamped into config")
+	assert.Equal(t, b1Name, *databaseConfig.Bucket, "bucket field should be stamped into config")
 
-	// strip out bucket to test backwards compatibility (older configs don't always have this field set)
+	// manually strip out bucket to test backwards compatibility (older configs don't always have this field set)
 	_, err = rt.GetDatabase().MetadataStore.Update(configDocID, 0, func(current []byte) (updated []byte, expiry *uint32, delete bool, err error) {
 		var d DatabaseConfig
 		require.NoError(t, base.JSONUnmarshal(current, &d))
@@ -1279,13 +1294,52 @@ func TestPersistentConfigNoBucketField(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, count, "should have loaded 1 config")
 
-	bucket2 := base.GetTestBucket(t)
-	defer bucket2.Close(base.TestCtx(t))
+	_, err = rt.UpdatePersistedBucketName(&databaseConfig, &b2Name)
+	require.NoError(t, err)
 
-	_, err = rt.UpdatePersistedBucketName(&databaseConfig, base.StringPtr(bucket2.GetName()))
+	dbBucketMismatch := base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Value()
+
+	// expect config to fail to load due to bucket mismatch
+	count, err = rt.ServerContext().fetchAndLoadConfigs(base.TestCtx(t), false)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+	dbBucketMismatch, _ = base.WaitForStat(t, base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Value, dbBucketMismatch+1)
+
+	// Move config docs from original bucket to b2 and force a fetch/load (simulate backup/restore or XDCR to different bucket)
+	base.MoveDocument(t, base.SGRegistryKey, b2.GetMetadataStore(), b1.GetMetadataStore())
+	base.MoveDocument(t, base.SGSyncInfo, b2.GetMetadataStore(), b1.GetMetadataStore())
+	base.MoveDocument(t, configDocID, b2.GetMetadataStore(), b1.GetMetadataStore())
+
+	// put the bucket for the config back to b1 so we can use the admin API to repair the config (like a real user would have to do)
+	_, err = b2.GetMetadataStore().Update(configDocID, 0, func(current []byte) (updated []byte, expiry *uint32, delete bool, err error) {
+		var d DatabaseConfig
+		require.NoError(t, base.JSONUnmarshal(current, &d))
+		d.Bucket = &b1Name
+		newConfig, err := base.JSONMarshal(d)
+		return newConfig, nil, false, err
+	})
 	require.NoError(t, err)
 
 	count, err = rt.ServerContext().fetchAndLoadConfigs(base.TestCtx(t), false)
 	require.NoError(t, err)
 	assert.Equal(t, 0, count)
+	dbBucketMismatch, _ = base.WaitForStat(t, base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Value, dbBucketMismatch+1)
+
+	// repair config
+	dbConfig.Bucket = &b2Name
+
+	// /db/_config won't work because db isn't actually loaded
+	resp = rt.UpsertDbConfig(dbName, dbConfig)
+	RequireStatus(t, resp, http.StatusNotFound)
+
+	// PUT /db/ will work to repair config
+	resp = rt.CreateDatabase(dbName, dbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	// do another fetch just to be sure that the config won't be unloaded again
+	count, err = rt.ServerContext().fetchAndLoadConfigs(base.TestCtx(t), false)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+	dbBucketMismatch, _ = base.WaitForStat(t, base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Value, dbBucketMismatch+1)
+
 }


### PR DESCRIPTION
CBG-3353

- Handles `nil` buckets in existing db configs (uses shared `dbConfig.GetBucketName()` function)
- Stamps buckets into new or updated db configs to avoid in future

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2069/
