### PR TITLE
CBG-3466 don't leak CBS server onto disk

### DIFF
--- a/integration-test/start_server.sh
+++ b/integration-test/start_server.sh
@@ -62,7 +62,7 @@ if [ "${MULTI_NODE:-}" == "true" ]; then
     ${DOCKER_COMPOSE} up -d --force-recreate --renew-anon-volumes --remove-orphans
 else
     # single node
-    docker run -d --name ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} --volume "${DOCKER_CBS_ROOT_DIR}/cbs:/root" --volume "${WORKSPACE_ROOT}:/workspace" -p 8091-8096:8091-8096 -p 11207:11207 -p 11210:11210 -p 11211:11211 -p 18091-18094:18091-18094 "couchbase/server:${COUCHBASE_DOCKER_IMAGE_NAME}"
+    docker run --rm -d --name ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} --volume "${WORKSPACE_ROOT}:/workspace" -p 8091-8096:8091-8096 -p 11207:11207 -p 11210:11210 -p 11211:11211 -p 18091-18094:18091-18094 "couchbase/server:${COUCHBASE_DOCKER_IMAGE_NAME}"
 fi
 
 # Test to see if Couchbase Server is up


### PR DESCRIPTION
Use anonymous volume to store CBS data so it cleans up automatically when the container stops. I think we were using this for cbcollect so I verified cbcollect still works fine.

https://jenkins.sgwdev.com/job/SyncGateway-Integration/2066 with cbcollect
https://jenkins.sgwdev.com/job/SyncGateway-Integration/2065 without cbcollect

