### PR TITLE
CBG-3122 [3.0.9 backport] Avoid panic in updateCalculatedStats for offline databases

### DIFF
--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -22,9 +22,12 @@ package db
 // Update database-specific stats that are more efficiently calculated at stats collection time
 func (db *DatabaseContext) UpdateCalculatedStats() {
 
-	if db.changeCache != nil {
-		db.changeCache.updateStats()
-		channelCache := db.changeCache.getChannelCache()
+	if db == nil || db.DbStats == nil || db.changeCache == nil {
+		return
+	}
+	db.changeCache.updateStats()
+	channelCache := db.changeCache.getChannelCache()
+	if channelCache != nil {
 		db.DbStats.Cache().ChannelCacheMaxEntries.Set(int64(channelCache.MaxCacheSize()))
 		db.DbStats.Cache().HighSeqCached.Set(int64(channelCache.GetHighCacheSequence()))
 	}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -2553,4 +2554,28 @@ func waitAndAssertConditionWithOptions(t *testing.T, fn func() bool, retryCount,
 
 func waitAndAssertCondition(t *testing.T, fn func() bool, failureMsgAndArgs ...interface{}) {
 	waitAndAssertConditionWithOptions(t, fn, 20, 100, failureMsgAndArgs...)
+}
+
+func TestUpdateCalculatedStatsPanic(t *testing.T) {
+
+	var dbc *DatabaseContext
+
+	defer func() {
+		r := recover()
+		if r != nil {
+			t.Errorf("UpdateCalculatedStats panic recovered, stack trace: %s", debug.Stack())
+		}
+	}()
+
+	// nil DatabaseContext check
+	dbc.UpdateCalculatedStats()
+
+	// non-nil DatabaseContext, nil stats
+	dbc = &DatabaseContext{}
+	dbc.UpdateCalculatedStats()
+
+	// non-nil DatabaseContext and stats, nil channel cache.
+	dbStats := initDatabaseStats("db", false, DatabaseContextOptions{})
+	dbc.DbStats = dbStats
+	dbc.UpdateCalculatedStats()
 }


### PR DESCRIPTION
CBG-3414

Provides additional defensive checks in updateCalculatedStats.  Backport of CBG-3122.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-go1.16.15/77/
