### PR TITLE
[3.1.2 Backport] CBG-3494: Handling for corrupt db config 

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"testing"
 	"time"
 )
 
@@ -212,6 +213,12 @@ func UnitTestUrl() string {
 // UnitTestUrlIsWalrus returns true if we're running with a Walrus test URL.
 func UnitTestUrlIsWalrus() bool {
 	return ServerIsWalrus(UnitTestUrl())
+}
+
+func TestsRequireBootstrapConnection(t *testing.T) {
+	if UnitTestUrlIsWalrus() {
+		t.Skipf("Tests requiring a bootstrap connection are not supporting using rosmar yet - CBG-3271")
+	}
 }
 
 // ServerIsTLS returns true if the server URL is using an accepted secure protocol as it's prefix

--- a/base/stats.go
+++ b/base/stats.go
@@ -62,33 +62,6 @@ const (
 
 const StatsGroupKeySyncGateway = "syncgateway"
 
-const (
-	PrometheusValueTypeGauge   = "gauge"
-	PrometheusValueTypeCounter = "counter"
-
-	StatUnitNoUnits       = ""
-	StatUnitPercent       = "percent"
-	StatUnitBytes         = "bytes"
-	StatUnitNanoseconds   = "nanoseconds"
-	StatUnitSeconds       = "seconds"
-	StatUnitUnixTimestamp = "unix timestamp"
-
-	StatFormatInt      = "int"
-	StatFormatFloat    = "float"
-	StatFormatDuration = "duration"
-	StatFormatBool     = "bool"
-
-	StatAddedVersion3dot0dot0 = "3.0.0"
-	StatAddedVersion3dot1dot0 = "3.1.0"
-	StatAddedVersion3dot2dot0 = "3.2.0"
-
-	StatDeprecatedVersionNotDeprecated = ""
-
-	StatStabilityCommitted = "committed"
-	StatStabilityVolatile  = "volatile"
-	StatStabilityInternal  = "internal"
-)
-
 type SgwStats struct {
 	GlobalStats     *GlobalStat         `json:"global"`
 	DbStats         map[string]*DbStats `json:"per_db"`

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -127,7 +127,12 @@ func (h *handler) handleCreateDB() error {
 			return base.HTTPErrorf(http.StatusInternalServerError, "couldn't load database: %v", err)
 		}
 
-		// now we've started the db successfully, we can persist it to the cluster
+		// now we've started the db successfully, we can persist it to the cluster first checking if this db used to be a corrupt db
+		// if it used to be corrupt we need to remove it from the invalid database map on server context and remove the old corrupt config from the bucket
+		err = h.removeCorruptConfigIfExists(contextNoCancel.Ctx, bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName)
+		if err != nil {
+			return err
+		}
 		cas, err := h.server.BootstrapContext.InsertConfig(contextNoCancel.Ctx, bucket, h.server.Config.Bootstrap.ConfigGroupID, &persistedConfig)
 		if err != nil {
 			// unload the requested database config to prevent the cluster being in an inconsistent state

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1676,7 +1676,7 @@ func TestBadConfigInsertionToBucket(t *testing.T) {
 	// assert that a request to the database fails with correct error message
 	resp := rt.SendAdminRequest(http.MethodGet, "/db1/_config", "")
 	rest.RequireStatus(t, resp, http.StatusNotFound)
-	assert.Contains(t, resp.Body.String(), "Must update database config immediately")
+	assert.Contains(t, resp.Body.String(), "You must update database config immediately")
 }
 
 // TestMismatchedBucketNameOnDbConfigUpdate:
@@ -1737,12 +1737,12 @@ func TestMultipleBucketWithBadDbConfigScenario1(t *testing.T) {
 			config.Bootstrap.ConfigGroupID = groupID
 		},
 	})
-	defer rt1.Close()
 
 	// create a db config that has bucket C in the config and persist to rt1 bucket
 	dbConfig := rt1.NewDbConfig()
 	dbConfig.Name = "db1"
 	rt1.PersistDbConfigToBucket(dbConfig, tb3.GetName())
+	defer rt1.Close()
 
 	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: tb2,
@@ -1788,7 +1788,7 @@ func TestMultipleBucketWithBadDbConfigScenario1(t *testing.T) {
 	// assert a request to the db fails with correct error message
 	resp := rt3.SendAdminRequest(http.MethodGet, "/db1/_config", "")
 	rest.RequireStatus(t, resp, http.StatusNotFound)
-	assert.Contains(t, resp.Body.String(), "Must update database config immediately")
+	assert.Contains(t, resp.Body.String(), "You must update database config immediately")
 }
 
 // TestMultipleBucketWithBadDbConfigScenario2:
@@ -1811,11 +1811,12 @@ func TestMultipleBucketWithBadDbConfigScenario2(t *testing.T) {
 			config.Bootstrap.ConfigGroupID = "60ce5544-c368-4b08-b0ed-4ca3b37973f9"
 		},
 	})
+	defer rt1.Close()
+
 	// create a db config pointing to bucket C and persist to bucket A
 	dbConfig := rt1.NewDbConfig()
 	dbConfig.Name = "db1"
 	rt1.PersistDbConfigToBucket(dbConfig, rt1.CustomTestBucket.GetName())
-	defer rt1.Close()
 
 	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: tb2,
@@ -1912,6 +1913,7 @@ func TestMultipleBucketWithBadDbConfigScenario3(t *testing.T) {
 		return len(invalidDatabases) == 1
 	}, 200, 1000)
 	require.NoError(t, err)
+
 }
 
 func TestResyncStopUsingDCPStream(t *testing.T) {

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1537,6 +1537,383 @@ func TestResyncStop(t *testing.T) {
 	assert.True(t, syncFnCount < 2000, "Expected syncFnCount < 2000 but syncFnCount=%d", syncFnCount)
 }
 
+// TestCorruptDbConfigHandling:
+//   - Create persistent config rest tester
+//   - Create a db with a non-corrupt config
+//   - Grab the persisted config from the bucket for purposes of changing the bucket name on it (this simulates a
+//     dbconfig becoming corrupt)
+//   - Update the persisted config to change the bucket name to a non-existent bucket
+//   - Assert that the db context and config are removed from server context and that operations on the database GET and
+//     DELETE and operation to update the config fail with appropriate error message for user
+//   - Test we are able to update the config to correct the corrupted db config using the /db1/ endpoint
+//   - assert the db returns to the server context and is removed from corrupt database tracking AND that the bucket name
+//     on the config now matches the rest tester bucket name
+func TestCorruptDbConfigHandling(t *testing.T) {
+	base.LongRunningTest(t)
+	base.TestsRequireBootstrapConnection(t)
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyConfig)
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: base.GetPersistentTestBucket(t),
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// configure the interval time to pick up new configs from the bucket to every 1 seconds
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(1 * time.Second)
+		},
+	})
+	defer rt.Close()
+
+	// create db with correct config
+	dbConfig := rt.NewDbConfig()
+	resp := rt.CreateDatabase("db1", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	// wait for db to come online
+	require.NoError(t, rt.WaitForDBOnline())
+
+	// grab the persisted db config from the bucket
+	databaseConfig := rest.DatabaseConfig{}
+	_, err := rt.ServerContext().BootstrapContext.GetConfig(rt.Context(), rt.CustomTestBucket.GetName(), rt.ServerContext().Config.Bootstrap.ConfigGroupID, "db1", &databaseConfig)
+	require.NoError(t, err)
+
+	// update the persisted config to a fake bucket name
+	newBucketName := "fakeBucket"
+	_, err = rt.UpdatePersistedBucketName(&databaseConfig, &newBucketName)
+	require.NoError(t, err)
+
+	// wait for some time for interval to remove the db
+	err = rt.WaitForConditionWithOptions(func() bool {
+		list := rt.ServerContext().AllDatabaseNames()
+		return len(list) == 0
+	}, 200, 1000)
+	require.NoError(t, err)
+
+	// assert that the in memory representation of the db config on the server context is gone now we have broken the config
+	responseConfig := rt.ServerContext().GetDbConfig("db1")
+	assert.Nil(t, responseConfig)
+
+	// assert that fetching config fails with the correct error message to the user
+	resp = rt.SendAdminRequest(http.MethodGet, "/db1/_config", "")
+	rest.RequireStatus(t, resp, http.StatusNotFound)
+	assert.Contains(t, resp.Body.String(), "You must update database config immediately")
+
+	// assert trying to delete fails with the correct error message to the user
+	resp = rt.SendAdminRequest(http.MethodDelete, "/db1/", "")
+	rest.RequireStatus(t, resp, http.StatusNotFound)
+	assert.Contains(t, resp.Body.String(), "You must update database config immediately")
+
+	// correct the name through update to config
+	resp = rt.ReplaceDbConfig("db1", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusNotFound)
+	assert.Contains(t, resp.Body.String(), "You must update database config immediately")
+
+	// create db of same name with correct db config to correct the corrupt db config
+	resp = rt.CreateDatabase("db1", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	// wait some time for interval to pick up change
+	err = rt.WaitForConditionWithOptions(func() bool {
+		list := rt.ServerContext().AllDatabaseNames()
+		return len(list) == 1
+	}, 200, 1000)
+	require.NoError(t, err)
+
+	// assert that the config is back in memory even after another interval update pass and asser the persisted config
+	// bucket name matches rest tester bucket name
+	dbCtx, err := rt.ServerContext().GetDatabase(base.TestCtx(t), "db1")
+	require.NoError(t, err)
+	assert.NotNil(t, dbCtx)
+	assert.Equal(t, rt.CustomTestBucket.GetName(), dbCtx.Bucket.GetName())
+	rt.ServerContext().RequireInvalidDatabaseConfigNames(t, []string{})
+}
+
+// TestBadConfigInsertionToBucket:
+//   - start a rest tester
+//   - insert an invalid db config to the bucket while rest tester is running
+//   - assert that the db config is picked up as an invalid db config
+//   - assert that a call to the db endpoint will fail with correct error message
+func TestBadConfigInsertionToBucket(t *testing.T) {
+	base.TestsRequireBootstrapConnection(t)
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: base.GetPersistentTestBucket(t),
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// configure the interval time to pick up new configs from the bucket to every 1 seconds
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(1 * time.Second)
+		},
+		DatabaseConfig: nil,
+	})
+	defer rt.Close()
+
+	// create a new invalid db config and persist to bucket
+	badName := "badBucketName"
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Name = "db1"
+
+	version, err := rest.GenerateDatabaseConfigVersionID(rt.Context(), "", &dbConfig)
+	require.NoError(t, err)
+
+	metadataID, metadataIDError := rt.ServerContext().BootstrapContext.ComputeMetadataIDForDbConfig(base.TestCtx(t), &dbConfig)
+	require.NoError(t, metadataIDError)
+
+	dbConfig.Bucket = &badName
+	persistedConfig := rest.DatabaseConfig{
+		Version:    version,
+		MetadataID: metadataID,
+		DbConfig:   dbConfig,
+		SGVersion:  base.ProductVersion.String(),
+	}
+	rt.InsertDbConfigToBucket(&persistedConfig, rt.CustomTestBucket.GetName())
+
+	// asser that the config is picked up as invalid config on server context
+	err = rt.WaitForConditionWithOptions(func() bool {
+		invalidDatabases := rt.ServerContext().AllInvalidDatabases()
+		return len(invalidDatabases) == 1
+	}, 200, 1000)
+	require.NoError(t, err)
+
+	// assert that a request to the database fails with correct error message
+	resp := rt.SendAdminRequest(http.MethodGet, "/db1/_config", "")
+	rest.RequireStatus(t, resp, http.StatusNotFound)
+	assert.Contains(t, resp.Body.String(), "Must update database config immediately")
+}
+
+// TestMismatchedBucketNameOnDbConfigUpdate:
+//   - Create a db on the rest tester
+//   - attempt to update the config to change the bucket name on the config to a mismatched bucket name
+//   - assert the request fails
+func TestMismatchedBucketNameOnDbConfigUpdate(t *testing.T) {
+	base.TestsRequireBootstrapConnection(t)
+	base.RequireNumTestBuckets(t, 2)
+	tb1 := base.GetPersistentTestBucket(t)
+	defer tb1.Close(base.TestCtx(t))
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: base.GetPersistentTestBucket(t),
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// configure the interval time to pick up new configs from the bucket to every 1 seconds
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(1 * time.Second)
+		},
+	})
+	defer rt.Close()
+
+	// create db with correct config
+	dbConfig := rt.NewDbConfig()
+	resp := rt.CreateDatabase("db1", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	// wait for db to come online
+	require.NoError(t, rt.WaitForDBOnline())
+	badName := tb1.GetName()
+	dbConfig.Bucket = &badName
+
+	// assert request fails
+	resp = rt.ReplaceDbConfig("db1", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusNotFound)
+}
+
+// TestMultipleBucketWithBadDbConfigScenario1:
+//   - in bucketA and bucketB, write two db configs with bucket name as bucketC
+//   - Start new rest tester and ensure they aren't picked up as valid configs
+func TestMultipleBucketWithBadDbConfigScenario1(t *testing.T) {
+	base.TestsRequireBootstrapConnection(t)
+	base.RequireNumTestBuckets(t, 3)
+	tb1 := base.GetPersistentTestBucket(t)
+	defer tb1.Close(base.TestCtx(t))
+	tb2 := base.GetPersistentTestBucket(t)
+	defer tb2.Close(base.TestCtx(t))
+	tb3 := base.GetPersistentTestBucket(t)
+	defer tb3.Close(base.TestCtx(t))
+
+	const groupID = "60ce5544-c368-4b08-b0ed-4ca3b37973f9"
+
+	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb1,
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// all RestTesters all this test must use the same config ID
+			config.Bootstrap.ConfigGroupID = groupID
+		},
+	})
+	defer rt1.Close()
+
+	// create a db config that has bucket C in the config and persist to rt1 bucket
+	dbConfig := rt1.NewDbConfig()
+	dbConfig.Name = "db1"
+	rt1.PersistDbConfigToBucket(dbConfig, tb3.GetName())
+
+	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb2,
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// configure same config groupID
+			config.Bootstrap.ConfigGroupID = groupID
+		},
+	})
+	defer rt2.Close()
+
+	// create a db config that has bucket C in the config and persist to rt2 bucket
+	dbConfig = rt2.NewDbConfig()
+	dbConfig.Name = "db1"
+	rt2.PersistDbConfigToBucket(dbConfig, tb3.GetName())
+
+	rt3 := rest.NewRestTester(t, &rest.RestTesterConfig{
+		PersistentConfig: true,
+		CustomTestBucket: tb3,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// configure the interval time to pick up new configs from the bucket to every 1 seconds
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(1 * time.Second)
+			// configure same config groupID
+			config.Bootstrap.ConfigGroupID = groupID
+		},
+	})
+	defer rt3.Close()
+
+	// assert the invalid database is picked up with new rest tester
+	err := rt3.WaitForConditionWithOptions(func() bool {
+		invalidDatabases := rt3.ServerContext().AllInvalidDatabases()
+		return len(invalidDatabases) == 1
+	}, 200, 1000)
+	require.NoError(t, err)
+
+	// assert that there are no valid db configs on the server context
+	err = rt3.WaitForConditionWithOptions(func() bool {
+		databaseNames := rt3.ServerContext().AllDatabaseNames()
+		return len(databaseNames) == 0
+	}, 200, 1000)
+	require.NoError(t, err)
+
+	// assert a request to the db fails with correct error message
+	resp := rt3.SendAdminRequest(http.MethodGet, "/db1/_config", "")
+	rest.RequireStatus(t, resp, http.StatusNotFound)
+	assert.Contains(t, resp.Body.String(), "Must update database config immediately")
+}
+
+// TestMultipleBucketWithBadDbConfigScenario2:
+//   - create bucketA and bucketB with db configs that that both list bucket name as bucketA
+//   - start a new rest tester and assert that invalid db config is picked up and the valid one is also picked up
+func TestMultipleBucketWithBadDbConfigScenario2(t *testing.T) {
+	base.TestsRequireBootstrapConnection(t)
+
+	base.RequireNumTestBuckets(t, 3)
+	tb1 := base.GetPersistentTestBucket(t)
+	defer tb1.Close(base.TestCtx(t))
+	tb2 := base.GetPersistentTestBucket(t)
+	defer tb2.Close(base.TestCtx(t))
+
+	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb1,
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// configure same config groupID
+			config.Bootstrap.ConfigGroupID = "60ce5544-c368-4b08-b0ed-4ca3b37973f9"
+		},
+	})
+	// create a db config pointing to bucket C and persist to bucket A
+	dbConfig := rt1.NewDbConfig()
+	dbConfig.Name = "db1"
+	rt1.PersistDbConfigToBucket(dbConfig, rt1.CustomTestBucket.GetName())
+	defer rt1.Close()
+
+	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb2,
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// configure same config groupID
+			config.Bootstrap.ConfigGroupID = "60ce5544-c368-4b08-b0ed-4ca3b37973f9"
+		},
+	})
+	defer rt2.Close()
+
+	// create a db config pointing to bucket C and persist to bucket B
+	dbConfig = rt2.NewDbConfig()
+	dbConfig.Name = "db1"
+	rt2.PersistDbConfigToBucket(dbConfig, "badName")
+
+	rt3 := rest.NewRestTester(t, &rest.RestTesterConfig{
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// configure the interval time to pick up new configs from the bucket to every 1 seconds
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(1 * time.Second)
+			// configure same config groupID
+			config.Bootstrap.ConfigGroupID = "60ce5544-c368-4b08-b0ed-4ca3b37973f9"
+		},
+	})
+	defer rt3.Close()
+
+	// assert that the invalid config is picked up by the new rest tester
+	err := rt3.WaitForConditionWithOptions(func() bool {
+		invalidDatabases := rt3.ServerContext().AllInvalidDatabases()
+		return len(invalidDatabases) == 1
+	}, 200, 1000)
+	require.NoError(t, err)
+
+	// assert that there is a valid database picked up as the invalid configs have this rest tester backing bucket
+	err = rt3.WaitForConditionWithOptions(func() bool {
+		validDatabase := rt3.ServerContext().AllDatabases()
+		return len(validDatabase) == 1
+	}, 200, 1000)
+	require.NoError(t, err)
+}
+
+// TestMultipleBucketWithBadDbConfigScenario3:
+//   - create a rest tester
+//   - create a db on the rest tester
+//   - persist that db config to another bucket
+//   - assert that is picked up as an invalid db config
+func TestMultipleBucketWithBadDbConfigScenario3(t *testing.T) {
+	base.TestsRequireBootstrapConnection(t)
+
+	tb1 := base.GetPersistentTestBucket(t)
+	defer tb1.Close(base.TestCtx(t))
+	tb2 := base.GetPersistentTestBucket(t)
+	defer tb2.Close(base.TestCtx(t))
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb1,
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			// configure the interval time to pick up new configs from the bucket to every 1 seconds
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(1 * time.Second)
+		},
+	})
+	defer rt.Close()
+
+	// create a new db
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Name = "db1"
+	dbConfig.BucketConfig.Bucket = base.StringPtr(rt.CustomTestBucket.GetName())
+	resp := rt.CreateDatabase("db1", dbConfig)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	// persistence logic construction
+	version, err := rest.GenerateDatabaseConfigVersionID(rt.Context(), "", &dbConfig)
+	require.NoError(rt.TB, err)
+
+	metadataID, metadataIDError := rt.ServerContext().BootstrapContext.ComputeMetadataIDForDbConfig(base.TestCtx(rt.TB), &dbConfig)
+	require.NoError(rt.TB, metadataIDError)
+
+	badName := "badName"
+	dbConfig.Bucket = &badName
+	persistedConfig := rest.DatabaseConfig{
+		Version:    version,
+		MetadataID: metadataID,
+		DbConfig:   dbConfig,
+		SGVersion:  base.ProductVersion.String(),
+	}
+	// add the config to the other bucket
+	rt.InsertDbConfigToBucket(&persistedConfig, tb2.GetName())
+
+	// assert the config is picked as invalid db config
+	err = rt.WaitForConditionWithOptions(func() bool {
+		invalidDatabases := rt.ServerContext().AllInvalidDatabases()
+		return len(invalidDatabases) == 1
+	}, 200, 1000)
+	require.NoError(t, err)
+}
+
 func TestResyncStopUsingDCPStream(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		// Walrus doesn't support Collections which is required to create DCP stream

--- a/rest/config.go
+++ b/rest/config.go
@@ -301,6 +301,7 @@ func (d *invalidDatabaseConfigs) addInvalidDatabase(ctx context.Context, dbname 
 		// already logged this entry at warning so need to log at info now
 		base.InfofCtx(ctx, base.KeyConfig, logMessage)
 	}
+	base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Add(1)
 }
 
 func (d *invalidDatabaseConfigs) exists(dbname string) (*invalidConfigInfo, bool) {
@@ -1364,6 +1365,7 @@ func (sc *ServerContext) fetchAndLoadConfigs(ctx context.Context, isInitialStart
 		}
 		for dbName, fetchedConfig := range fetchedConfigs {
 			if dbConfig, ok := sc.dbConfigs[dbName]; ok && dbConfig.cfgCas >= fetchedConfig.cfgCas {
+				sc.invalidDatabaseConfigTracking.remove(dbName)
 				base.DebugfCtx(ctx, base.KeyConfig, "Database %q bucket %q config has not changed since last update", fetchedConfig.Name, *fetchedConfig.Bucket)
 				delete(fetchedConfigs, dbName)
 			}
@@ -1383,7 +1385,7 @@ func (sc *ServerContext) fetchAndLoadConfigs(ctx context.Context, isInitialStart
 	for _, dbName := range deletedDatabases {
 		// It's possible that the "deleted" database was not written to the server until after sc.FetchConfigs had returned...
 		// we'll need to pay for the cost of getting the config again now that we've got the write lock to double-check this db is definitely ok to remove...
-		found, _, err := sc.fetchDatabase(ctx, dbName)
+		found, _, err := sc._fetchDatabase(ctx, dbName)
 		if err != nil {
 			base.InfofCtx(ctx, base.KeyConfig, "Error fetching config for database %q to check whether we need to remove it: %v", dbName, err)
 		}
@@ -1411,15 +1413,13 @@ func (sc *ServerContext) fetchAndLoadDatabaseSince(ctx context.Context, dbName s
 }
 
 func (sc *ServerContext) fetchAndLoadDatabase(nonContextStruct base.NonCancellableContext, dbName string) (found bool, err error) {
-	sc.lock.Lock()
-	defer sc.lock.Unlock()
 	return sc._fetchAndLoadDatabase(nonContextStruct, dbName)
 }
 
 // _fetchAndLoadDatabase will attempt to find the given database name first in a matching bucket name,
 // but then fall back to searching through configs in each bucket to try and find a config.
 func (sc *ServerContext) _fetchAndLoadDatabase(nonContextStruct base.NonCancellableContext, dbName string) (found bool, err error) {
-	found, dbConfig, err := sc.fetchDatabase(nonContextStruct.Ctx, dbName)
+	found, dbConfig, err := sc._fetchDatabase(nonContextStruct.Ctx, dbName)
 	if err != nil || !found {
 		return false, err
 	}
@@ -1487,6 +1487,13 @@ func (sc *ServerContext) findBucketWithCallback(callback func(bucket string) (ex
 }
 
 func (sc *ServerContext) fetchDatabase(ctx context.Context, dbName string) (found bool, dbConfig *DatabaseConfig, err error) {
+	// fetch will update the databses
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
+	return sc._fetchDatabase(ctx, dbName)
+}
+
+func (sc *ServerContext) _fetchDatabase(ctx context.Context, dbName string) (found bool, dbConfig *DatabaseConfig, err error) {
 	// loop code moved to foreachDbConfig
 	var cnf DatabaseConfig
 	callback := func(bucket string) (exit bool, err error) {
@@ -1520,7 +1527,7 @@ func (sc *ServerContext) fetchDatabase(ctx context.Context, dbName string) (foun
 		// bucket name we got the config from we need to maker this db context as corrupt. Then remove the context and
 		// in memory representation on the server context.
 		if bucket != *cnf.Bucket {
-			sc.handleInvalidDatabaseConfig(ctx, bucket, cnf)
+			sc._handleInvalidDatabaseConfig(ctx, bucket, cnf)
 			return true, fmt.Errorf("mismatch in persisted database bucket name %q vs the actual bucket name %q. Please correct db %q's config, groupID %q.", base.MD(cnf.Bucket), base.MD(bucket), base.MD(cnf.Name), base.MD(sc.Config.Bootstrap.ConfigGroupID))
 		}
 		bucketCopy := bucket
@@ -1548,6 +1555,12 @@ func (sc *ServerContext) fetchDatabase(ctx context.Context, dbName string) (foun
 }
 
 func (sc *ServerContext) handleInvalidDatabaseConfig(ctx context.Context, bucket string, cnf DatabaseConfig) {
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
+	sc._handleInvalidDatabaseConfig(ctx, bucket, cnf)
+}
+
+func (sc *ServerContext) _handleInvalidDatabaseConfig(ctx context.Context, bucket string, cnf DatabaseConfig) {
 	// track corrupt database context
 	sc.invalidDatabaseConfigTracking.addInvalidDatabase(ctx, cnf.Name, cnf, bucket)
 	// don't load config + remove from server context (apart from corrupt database map)

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -570,6 +570,24 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 	return nil
 }
 
+// removeCorruptConfigIfExists will remove the config from the bucket and remove it from the map if it exists on the invalid database config map
+func (h *handler) removeCorruptConfigIfExists(ctx context.Context, bucket, configGroupID, dbName string) error {
+	_, ok := h.server.invalidDatabaseConfigTracking.exists(dbName)
+	if !ok {
+		// exit early of it doesn't exist
+		return nil
+	}
+	// remove the bad config from the bucket
+	err := h.server.BootstrapContext.DeleteConfig(ctx, bucket, configGroupID, dbName)
+	if err != nil {
+		return err
+	}
+	// delete the database name form the invalid database map on server context
+	h.server.invalidDatabaseConfigTracking.remove(dbName)
+
+	return nil
+}
+
 func (h *handler) logRequestLine() {
 	// Check Log Level first, as SanitizeRequestURL is expensive to evaluate.
 	if !base.LogInfoEnabled(base.KeyHTTP) {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2511,6 +2511,15 @@ func DropAllTestIndexes(t *testing.T, tb *base.TestBucket) {
 	}
 }
 
+func (sc *ServerContext) RequireInvalidDatabaseConfigNames(t *testing.T, dbNames []string) {
+	sc.invalidDatabaseConfigTracking.m.RLock()
+	defer sc.invalidDatabaseConfigTracking.m.RUnlock()
+	require.Equal(t, len(dbNames), len(sc.invalidDatabaseConfigTracking.dbNames))
+	for _, v := range dbNames {
+		require.NotNil(t, sc.invalidDatabaseConfigTracking.dbNames[v])
+	}
+}
+
 // Calls DropAllIndexes to remove all indexes, then restores the primary index for TestBucketPool readier requirements
 func dropAllNonPrimaryIndexes(t *testing.T, dataStore base.DataStore) {
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2511,13 +2511,16 @@ func DropAllTestIndexes(t *testing.T, tb *base.TestBucket) {
 	}
 }
 
-func (sc *ServerContext) RequireInvalidDatabaseConfigNames(t *testing.T, dbNames []string) {
+func (sc *ServerContext) RequireInvalidDatabaseConfigNames(t *testing.T, expectedDbNames []string) {
 	sc.invalidDatabaseConfigTracking.m.RLock()
 	defer sc.invalidDatabaseConfigTracking.m.RUnlock()
-	require.Equal(t, len(dbNames), len(sc.invalidDatabaseConfigTracking.dbNames))
-	for _, v := range dbNames {
-		require.NotNil(t, sc.invalidDatabaseConfigTracking.dbNames[v])
+
+	dbNames := make([]string, 0, len(sc.invalidDatabaseConfigTracking.dbNames))
+
+	for name := range sc.invalidDatabaseConfigTracking.dbNames {
+		dbNames = append(dbNames, name)
 	}
+	require.EqualValues(t, expectedDbNames, dbNames)
 }
 
 // Calls DropAllIndexes to remove all indexes, then restores the primary index for TestBucketPool readier requirements

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -233,6 +233,41 @@ func (rt *RestTester) WaitForResyncDCPStatus(status db.BackgroundProcessState) d
 	return resyncStatus
 }
 
+// UpdatePersistedBucketName will update the persisted config bucket name to name specified in parameters
+func (rt *RestTester) UpdatePersistedBucketName(dbConfig *DatabaseConfig, newBucketName *string) (*DatabaseConfig, error) {
+	updatedDbConfig := DatabaseConfig{}
+	_, err := rt.ServerContext().BootstrapContext.UpdateConfig(base.TestCtx(rt.TB), *dbConfig.Bucket, rt.ServerContext().Config.Bootstrap.ConfigGroupID, dbConfig.Name, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+
+		bucketDbConfig = dbConfig
+		bucketDbConfig.Bucket = newBucketName
+
+		return bucketDbConfig, nil
+	})
+	return &updatedDbConfig, err
+}
+
+func (rt *RestTester) InsertDbConfigToBucket(config *DatabaseConfig, bucketName string) {
+	_, insertErr := rt.ServerContext().BootstrapContext.InsertConfig(base.TestCtx(rt.TB), bucketName, rt.ServerContext().Config.Bootstrap.ConfigGroupID, config)
+	require.NoError(rt.TB, insertErr)
+}
+
+func (rt *RestTester) PersistDbConfigToBucket(dbConfig DbConfig, bucketName string) {
+	version, err := GenerateDatabaseConfigVersionID(rt.Context(), "", &dbConfig)
+	require.NoError(rt.TB, err)
+
+	metadataID, metadataIDError := rt.ServerContext().BootstrapContext.ComputeMetadataIDForDbConfig(base.TestCtx(rt.TB), &dbConfig)
+	require.NoError(rt.TB, metadataIDError)
+
+	dbConfig.Bucket = &bucketName
+	persistedConfig := DatabaseConfig{
+		Version:    version,
+		MetadataID: metadataID,
+		DbConfig:   dbConfig,
+		SGVersion:  base.ProductVersion.String(),
+	}
+	rt.InsertDbConfigToBucket(&persistedConfig, rt.CustomTestBucket.GetName())
+}
+
 // setupSGRPeers sets up two rest testers to be used for sg-replicate testing with the following configuration:
 //
 //	activeRT:


### PR DESCRIPTION
CBG-3494 / CBG-3495

Backports #6377 and #6410 to 3.1.2

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-1.19.5/29/
