### PR TITLE
CBG-2997: Make `RedactableError` compatible with `%w`

### DIFF
--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -30,8 +30,7 @@ func TestRedactedLogFuncs(t *testing.T) {
 	username := UD("alice")
 	ctx := TestCtx(t)
 
-	originalRedactUserData := RedactUserData
-	defer func() { RedactUserData = originalRedactUserData }()
+	defer func() { RedactUserData = defaultRedactUserData }()
 
 	RedactUserData = false
 	AssertLogContains(t, "Username: alice", func() { InfofCtx(ctx, KeyAll, "Username: %s", username) })

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -30,7 +30,8 @@ func TestRedactedLogFuncs(t *testing.T) {
 	username := UD("alice")
 	ctx := TestCtx(t)
 
-	defer func() { RedactUserData = false }()
+	originalRedactUserData := RedactUserData
+	defer func() { RedactUserData = originalRedactUserData }()
 
 	RedactUserData = false
 	AssertLogContains(t, "Username: alice", func() { InfofCtx(ctx, KeyAll, "Username: %s", username) })

--- a/base/redactable_error.go
+++ b/base/redactable_error.go
@@ -24,7 +24,7 @@ var (
 	_ Redactor = &RedactableError{}
 )
 
-// Create a new redactable error.  Same signature as fmt.Errorf() for easy drop-in replacement.
+// RedactErrorf creates a new redactable error.  Same signature as fmt.Errorf() for easy drop-in replacement.
 func RedactErrorf(fmt string, args ...interface{}) *RedactableError {
 	return &RedactableError{
 		fmt:  fmt,
@@ -39,11 +39,13 @@ func (re *RedactableError) Error() string {
 
 // String returns a non-redacted version of the error - satisfies the Redactor interface.
 func (re *RedactableError) String() string {
-	return fmt.Sprintf(re.fmt, re.args...)
+	// can't use Sprintf as it doesn't support `%w`
+	return fmt.Errorf(re.fmt, re.args...).Error()
 }
 
 // Redact returns a redacted version of the error - satisfies the Redactor interface.
 func (re *RedactableError) Redact() string {
 	redactedArgs := redact(re.args)
-	return fmt.Sprintf(re.fmt, redactedArgs...)
+	// can't use Sprintf as it doesn't support `%w`
+	return fmt.Errorf(re.fmt, redactedArgs...).Error()
 }

--- a/base/redactable_error_test.go
+++ b/base/redactable_error_test.go
@@ -37,3 +37,23 @@ func TestRedactErrorf(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkRedactErrorf(b *testing.B) {
+	fmt := "Couldn't get user %q: "
+	fmtVerbs := []string{"%s", "%w"}
+	args := []interface{}{UD("Bob"), ErrNotFound}
+
+	for _, verb := range fmtVerbs {
+		err := RedactErrorf(fmt+verb, args...)
+		b.Run(verb+" String()", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = err.String()
+			}
+		})
+		b.Run(verb+" Redact()", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = err.Redact()
+			}
+		})
+	}
+}

--- a/base/redactable_error_test.go
+++ b/base/redactable_error_test.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/redactable_error_test.go
+++ b/base/redactable_error_test.go
@@ -1,0 +1,39 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedactErrorf(t *testing.T) {
+	tests := []struct {
+		name,
+		expectedString,
+		expectedRedact,
+		fmt string
+		args []interface{}
+	}{
+		{
+			name:           "%s",
+			expectedString: "Couldn't get user \"Bob\": Not Found",
+			expectedRedact: "Couldn't get user \"<ud>Bob</ud>\": Not Found",
+			fmt:            "Couldn't get user %q: %s",
+			args:           []interface{}{UD("Bob"), ErrNotFound},
+		},
+		{
+			name:           "%w",
+			expectedString: "Couldn't get user \"Bob\": Not Found",
+			expectedRedact: "Couldn't get user \"<ud>Bob</ud>\": Not Found",
+			fmt:            "Couldn't get user %q: %w",
+			args:           []interface{}{UD("Bob"), ErrNotFound},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := RedactErrorf(test.fmt, test.args...)
+			assert.Equal(t, test.expectedString, err.String())
+			assert.Equal(t, test.expectedRedact, err.Redact())
+		})
+	}
+}

--- a/base/redactor_metadata.go
+++ b/base/redactor_metadata.go
@@ -20,8 +20,10 @@ const (
 	metaDataSuffix = "</md>"
 )
 
+const defaultRedactMetadata = false
+
 // RedactMetadata is a global toggle for system data redaction.
-var RedactMetadata = false
+var RedactMetadata = defaultRedactMetadata
 
 // Metadata is a type which implements the Redactor interface for logging purposes of metadata.
 //

--- a/base/redactor_metadata_test.go
+++ b/base/redactor_metadata_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestMetadataRedact(t *testing.T) {
+	defer func() { RedactMetadata = defaultRedactMetadata }()
+
 	clusterName := "My Super Secret Cluster"
 	metadata := Metadata(clusterName)
 
@@ -29,8 +31,8 @@ func TestMetadataRedact(t *testing.T) {
 }
 
 func TestMD(t *testing.T) {
+	defer func() { RedactMetadata = defaultRedactMetadata }()
 	RedactMetadata = true
-	defer func() { RedactMetadata = false }()
 
 	// Base string test
 	md := MD("hello world")

--- a/base/redactor_systemdata.go
+++ b/base/redactor_systemdata.go
@@ -20,8 +20,10 @@ const (
 	systemDataSuffix = "</sd>"
 )
 
+const defaultRedactSystemData = false
+
 // RedactSystemData is a global toggle for system data redaction.
-var RedactSystemData = false
+var RedactSystemData = defaultRedactSystemData
 
 // SystemData is a type which implements the Redactor interface for logging purposes of system data.
 //

--- a/base/redactor_systemdata_test.go
+++ b/base/redactor_systemdata_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestSystemDataRedact(t *testing.T) {
+	defer func() { RedactSystemData = defaultRedactSystemData }()
+
 	clusterName := "My Super Secret IP"
 	systemdata := SystemData(clusterName)
 
@@ -30,7 +32,7 @@ func TestSystemDataRedact(t *testing.T) {
 
 func TestSD(t *testing.T) {
 	RedactSystemData = true
-	defer func() { RedactSystemData = false }()
+	defer func() { RedactSystemData = defaultRedactSystemData }()
 
 	// Base string test
 	sd := SD("hello world")

--- a/base/redactor_test.go
+++ b/base/redactor_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func TestRedactHelper(t *testing.T) {
-	originalRedactUserData := RedactUserData
-	defer func() { RedactUserData = originalRedactUserData }()
+	defer func() { RedactUserData = defaultRedactUserData }()
 
 	RedactUserData = true
 
@@ -112,9 +111,9 @@ func TestMixedTypeSliceRedaction(t *testing.T) {
 	RedactSystemData = true
 	RedactUserData = true
 	defer func() {
-		RedactMetadata = false
-		RedactSystemData = false
-		RedactUserData = false
+		RedactMetadata = defaultRedactMetadata
+		RedactSystemData = defaultRedactSystemData
+		RedactUserData = defaultRedactUserData
 	}()
 
 	slice := RedactorSlice{MD("cluster name"), SD("server ip"), UD("username")}
@@ -123,7 +122,7 @@ func TestMixedTypeSliceRedaction(t *testing.T) {
 
 func BenchmarkRedactHelper(b *testing.B) {
 	RedactUserData = true
-	defer func() { RedactUserData = false }()
+	defer func() { RedactUserData = defaultRedactUserData }()
 
 	var data = []interface{}{
 		UserData("alice"),

--- a/base/redactor_test.go
+++ b/base/redactor_test.go
@@ -18,8 +18,10 @@ import (
 )
 
 func TestRedactHelper(t *testing.T) {
+	originalRedactUserData := RedactUserData
+	defer func() { RedactUserData = originalRedactUserData }()
+
 	RedactUserData = true
-	defer func() { RedactUserData = false }()
 
 	ptr := UserData("hello")
 

--- a/base/redactor_userdata.go
+++ b/base/redactor_userdata.go
@@ -20,8 +20,10 @@ const (
 	UserDataSuffix = "</ud>"
 )
 
+const defaultRedactUserData = true
+
 // RedactUserData is a global toggle for user data redaction.
-var RedactUserData = true
+var RedactUserData = defaultRedactUserData
 
 // UserData is a type which implements the Redactor interface for logging purposes of user data.
 //

--- a/base/redactor_userdata_test.go
+++ b/base/redactor_userdata_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestUserDataRedact(t *testing.T) {
+	defer func() { RedactUserData = defaultRedactUserData }()
+
 	username := "alice"
 	userdata := UserData(username)
 
@@ -31,7 +33,7 @@ func TestUserDataRedact(t *testing.T) {
 
 func TestUD(t *testing.T) {
 	RedactUserData = true
-	defer func() { RedactUserData = false }()
+	defer func() { RedactUserData = defaultRedactUserData }()
 
 	// Straight-forward string test.
 	ud := UD("hello world")
@@ -60,6 +62,8 @@ func TestUD(t *testing.T) {
 }
 
 func BenchmarkUserDataRedact(b *testing.B) {
+	defer func() { RedactUserData = defaultRedactUserData }()
+
 	username := UserData("alice")
 	usernameSlice := UD([]string{"adam", "ben", "jacques"})
 
@@ -96,8 +100,9 @@ func (fakeLogger FakeLogger) String() string {
 }
 
 func BenchmarkRedactOnLog(b *testing.B) {
-
 	SetUpBenchmarkLogging(b, LevelWarn, KeyAll)
+
+	defer func() { RedactUserData = defaultRedactUserData }()
 
 	b.Run("WarnPlain", func(b *testing.B) {
 		ctx := TestCtx(b)


### PR DESCRIPTION
CBG-2997

Make `RedactableError` compatible with `%w`
- Uses `fmt.Errorf` instead of `fmt.Sprintf`
- Add basic test and benchmark for coverage of both `%s` and `%w` args

Both stdlib functions use same internal `fmt` pooled printer, so minimal difference in performance.
```
go test -run=- -bench='^BenchmarkRedactErrorf$' -v -count=3 ./base
goos: darwin
goarch: arm64
pkg: github.com/couchbase/sync_gateway/base
BenchmarkRedactErrorf
BenchmarkRedactErrorf/%s_String()
BenchmarkRedactErrorf/%s_String()-10         	 5896023	       193.4 ns/op
BenchmarkRedactErrorf/%s_String()-10         	 6308426	       190.8 ns/op
BenchmarkRedactErrorf/%s_String()-10         	 6311304	       191.1 ns/op
BenchmarkRedactErrorf/%s_Redact()
BenchmarkRedactErrorf/%s_Redact()-10         	 4706343	       255.7 ns/op
BenchmarkRedactErrorf/%s_Redact()-10         	 4702542	       255.4 ns/op
BenchmarkRedactErrorf/%s_Redact()-10         	 4660834	       255.1 ns/op
BenchmarkRedactErrorf/%w_String()
BenchmarkRedactErrorf/%w_String()-10         	 5515177	       220.9 ns/op
BenchmarkRedactErrorf/%w_String()-10         	 5507886	       218.3 ns/op
BenchmarkRedactErrorf/%w_String()-10         	 5509689	       218.3 ns/op
BenchmarkRedactErrorf/%w_Redact()
BenchmarkRedactErrorf/%w_Redact()-10         	 4466829	       269.0 ns/op
BenchmarkRedactErrorf/%w_Redact()-10         	 4475766	       270.3 ns/op
BenchmarkRedactErrorf/%w_Redact()-10         	 4482232	       269.3 ns/op
PASS
2023/10/03 14:36:46 TEST: Memory high water mark 6.10 MB
ok  	github.com/couchbase/sync_gateway/base	17.727s
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a