### PR TITLE
[3.0.9] CBG-3458 don't load config if db registry is present

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -208,7 +208,7 @@ func (cc *CouchbaseCluster) HasPost30Config(bucket string) (bool, error) {
 	defer teardown()
 
 	var valuePtr interface{}
-	_, err = cc.configPersistence.loadConfig(b.DefaultCollection(), "_sync:registry", valuePtr)
+	_, err = cc.configPersistence.loadConfig(b.DefaultCollection(), SGRegistryKey, valuePtr)
 	return !IsDocNotFoundError(err), nil
 }
 

--- a/base/constants.go
+++ b/base/constants.go
@@ -135,6 +135,7 @@ const (
 	UnusedSeqRangePrefix   = SyncPrefix + "unusedSeqs:"
 
 	DCPBackfillSeqKey = SyncPrefix + "dcp_backfill"
+	SGRegistryKey     = SyncPrefix + "registry" // Registry of all SG databases defined for the bucket (for all group IDs)
 	SyncDataKey       = SyncPrefix + "syncdata"
 	SyncSeqKey        = SyncPrefix + "seq"
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -1307,6 +1307,17 @@ func (sc *ServerContext) _applyConfig(cnf DatabaseConfig, failFast bool) (applie
 		}
 	}
 
+	if sc.bootstrapContext.connection != nil {
+		hasDBRegistry, err := sc.bootstrapContext.connection.HasPost30Config(*cnf.Bucket)
+		if err != nil {
+			return false, fmt.Errorf("Could not determine whether bucket %q has a newer config than 3.0. Error: %w", *cnf.Bucket, err)
+		}
+		if hasDBRegistry {
+			return false, fmt.Errorf("database %q from bucket %q cannot be added. Has a config newer than Sync Gateway version 3.0", cnf.Name, *cnf.Bucket)
+		}
+
+	}
+
 	// Strip out version as we have no use for this locally and we want to prevent it being stored and being returned
 	// by any output
 	cnf.Version = ""

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2236,3 +2236,55 @@ func requireErrorWithX509UnknownAuthority(t testing.TB, actual, expected error) 
 		t.FailNow()
 	}
 }
+
+func TestPost30Config(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("test requires bootstrap connection and doesn't work with walrus")
+	}
+
+	for _, persistentConfig := range []bool{true, false} {
+		t.Run(fmt.Sprintf("persistentConfig=%v", persistentConfig), func(t *testing.T) {
+			config := bootstrapStartupConfigForTest(t)
+			sc, err := setupServerContext(&config, persistentConfig)
+			require.NoError(t, err)
+
+			serverErr := make(chan error)
+			defer func() {
+				sc.Close()
+				require.NoError(t, <-serverErr)
+			}()
+
+			go func() {
+				serverErr <- startServer(&config, sc)
+			}()
+			require.NoError(t, sc.waitForRESTAPIs())
+
+			xattrs := base.TestUseXattrs()
+			useViews := base.TestsDisableGSI()
+			tb := base.GetTestBucket(t)
+			defer tb.Close()
+
+			dbConfig := DbConfig{
+				BucketConfig:       bucketConfigFromTestBucket(tb),
+				Name:               "db",
+				AllowEmptyPassword: base.BoolPtr(true),
+				NumIndexReplicas:   base.UintPtr(0),
+				EnableXattrs:       &xattrs,
+				UseViews:           &useViews,
+			}
+			err = tb.Set("_sync:registry", 0, `{"foo":"bar"}`)
+			require.NoError(t, err)
+			_, err = sc.applyConfig(DatabaseConfig{DbConfig: dbConfig})
+			if persistentConfig {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "newer than Sync Gateway version 3.0")
+				require.Len(t, sc.AllDatabaseNames(), 0)
+			} else {
+				require.NoError(t, err)
+				require.Len(t, sc.AllDatabaseNames(), 1)
+				require.Contains(t, sc.AllDatabaseNames(), "db")
+
+			}
+		})
+	}
+}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2272,7 +2272,7 @@ func TestPost30Config(t *testing.T) {
 				EnableXattrs:       &xattrs,
 				UseViews:           &useViews,
 			}
-			err = tb.Set("_sync:registry", 0, `{"foo":"bar"}`)
+			err = tb.Set(base.SGRegistryKey, 0, `{"foo":"bar"}`)
 			require.NoError(t, err)
 			_, err = sc.applyConfig(DatabaseConfig{DbConfig: dbConfig})
 			if persistentConfig {


### PR DESCRIPTION
A db registry will be present in > 3.0 Sync Gateway. Only added the check when persistent config is enabled, since this is primarily targeting capella and it simplifies how to get a temporary connection to a bucket before we load a database.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-go1.16.15/78/
