### PR TITLE
Restrict yamllint action to OpenAPI path

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -46,3 +46,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: karancode/yamllint-github-action@master
+        with:
+          yamllint_file_or_dir: 'docs/api'


### PR DESCRIPTION
This action only runs when something in `docs/api` changes, so it doesn't really make sense to be linting anything else, unless it's a completely separate action.

Doing it the way it is now allows yaml files outside of this path to deviate from the linting rules until a new PR comes along to touch an OpenAPI spec and trigger the action and subsequently fail for something that wasn't part of the PR.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a