### PR TITLE
CBG-3467 add verbose mode for _all_dbs

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2360,6 +2360,9 @@ Status:
             enum:
               - Online
               - Offline
+              - Starting
+              - Stopping
+              - Resyncing
           replication_status:
             type: array
             items:
@@ -2446,3 +2449,29 @@ CollectionNames:
   type: array
   items:
     type: string
+"All DBs":
+  description: "The names of all databases."
+  type: array
+  items:
+    type: string
+"All DBs Verbose":
+  description: "Description of all databases."
+  type: array
+  items:
+    type: object
+    properties:
+      db_name:
+        type: string
+        description: The name of the database.
+      bucket:
+        type: string
+        description: The Couchbase Server backing bucket for the database.
+      state:
+        description: Whether the database is online or offline.
+        type: string
+        enum:
+          - Online
+          - Offline
+          - Starting
+          - Stopping
+          - Resyncing

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2467,7 +2467,7 @@ CollectionNames:
         type: string
         description: The Couchbase Server backing bucket for the database.
       state:
-        description: Whether the database is online or offline.
+        description: The database state.
         type: string
         enum:
           - Online

--- a/docs/api/paths/admin/_all_dbs.yaml
+++ b/docs/api/paths/admin/_all_dbs.yaml
@@ -8,7 +8,7 @@
 get:
   summary: Get a list of all the databases
   description: |-
-    This retrieves all the databases that are in the current Sync Gateway node. If verbose, return bucket and status information about the databases, otherwise return the names.
+    This retrieves all the databases that are in the current Sync Gateway node. If verbose, returns bucket and state information for each database, otherwise returns names only.
 
     Required Sync Gateway RBAC roles:
 

--- a/docs/api/paths/admin/_all_dbs.yaml
+++ b/docs/api/paths/admin/_all_dbs.yaml
@@ -8,32 +8,25 @@
 get:
   summary: Get a list of all the databases
   description: |-
-    This retrieves all the database's names that are in the current Sync Gateway node.
+    This retrieves all the databases that are in the current Sync Gateway node. If verbose, return bucket and status information about the databases, otherwise return the names.
 
     Required Sync Gateway RBAC roles:
 
     * Sync Gateway Dev Ops
+  parameters:
+    - name: verbose
+      in: query
+      schema:
+        type: boolean
   responses:
     '200':
       description: Successfully retrieved all database names
       content:
         application/json:
           schema:
-            type: array
-            items:
-              type: string
+            oneOf:
+              - $ref: "../../components/schemas.yaml#/All DBs"
+              - $ref: "../../components/schemas.yaml#/All DBs Verbose"
   tags:
     - Database Management
   operationId: get__all_dbs
-head:
-  summary: /_all_dbs
-  description: |-
-    Required Sync Gateway RBAC roles:
-
-    * Sync Gateway Dev Ops
-  responses:
-    '200':
-      description: OK
-  tags:
-    - Database Management
-  operationId: head__all_dbs

--- a/rest/api.go
+++ b/rest/api.go
@@ -75,6 +75,10 @@ func (h *handler) handlePing() error {
 }
 
 func (h *handler) handleAllDbs() error {
+	if h.getBoolQuery("verbose") {
+		h.writeJSON(h.server.allDatabaseSummaries())
+		return nil
+	}
 	h.writeJSON(h.server.AllDatabaseNames())
 	return nil
 }
@@ -401,6 +405,12 @@ type DatabaseRoot struct {
 	ServerUUID                    string                       `json:"server_uuid,omitempty"`
 	RequireResync                 []string                     `json:"require_resync,omitempty"`
 	Scopes                        map[string]databaseRootScope `json:"scopes,omitempty"` // stats for each scope/collection
+}
+
+type dbSummary struct {
+	DBName string `json:"db_name"`
+	Bucket string `json:"bucket"`
+	State  string `json:"state"`
 }
 
 type databaseRootScope struct {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2861,3 +2861,16 @@ func TestPing(t *testing.T) {
 		}
 	}
 }
+
+func TestAllDbs(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	resp := rt.SendAdminRequest(http.MethodGet, "/_all_dbs", "")
+	RequireStatus(t, resp, http.StatusOK)
+	require.Equal(t, fmt.Sprintf(`["%s"]`, rt.GetDatabase().Name), resp.Body.String())
+
+	resp = rt.SendAdminRequest(http.MethodGet, "/_all_dbs?verbose=true", "")
+	RequireStatus(t, resp, http.StatusOK)
+	require.Equal(t, fmt.Sprintf(`[{"db_name":"%s","bucket":"%s","state":"Online"}]`, rt.GetDatabase().Name, rt.GetDatabase().Bucket.GetName()), resp.Body.String())
+}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -337,6 +337,21 @@ func (sc *ServerContext) AllDatabaseNames() []string {
 	return names
 }
 
+func (sc *ServerContext) allDatabaseSummaries() []dbSummary {
+	sc.lock.RLock()
+	defer sc.lock.RUnlock()
+
+	dbs := make([]dbSummary, 0, len(sc.databases_))
+	for name, dbctx := range sc.databases_ {
+		dbs = append(dbs, dbSummary{
+			DBName: name,
+			Bucket: dbctx.Bucket.GetName(),
+			State:  db.RunStateString[atomic.LoadUint32(&dbctx.State)],
+		})
+	}
+	return dbs
+}
+
 // AllDatabases returns a copy of the databases_ map.
 func (sc *ServerContext) AllDatabases() map[string]*db.DatabaseContext {
 	sc.lock.RLock()

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -343,21 +343,17 @@ func (sc *ServerContext) allDatabaseSummaries() []dbSummary {
 	sc.lock.RLock()
 	defer sc.lock.RUnlock()
 
-	names := make([]string, 0, len(sc.databases_))
-	for name := range sc.databases_ {
-		names = append(names, name)
-	}
-	slices.Sort(names)
-
 	dbs := make([]dbSummary, 0, len(sc.databases_))
-	for _, name := range names {
-		dbctx := sc.databases_[name]
+	for name, dbctx := range sc.databases_ {
 		dbs = append(dbs, dbSummary{
 			DBName: name,
 			Bucket: dbctx.Bucket.GetName(),
 			State:  db.RunStateString[atomic.LoadUint32(&dbctx.State)],
 		})
 	}
+	sort.Slice(dbs, func(i, j int) bool {
+		return dbs[i].DBName < dbs[j].DBName
+	})
 	return dbs
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/db/functions"
+	"golang.org/x/exp/slices"
 
 	"github.com/couchbase/gocbcore/v10"
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -334,6 +335,7 @@ func (sc *ServerContext) AllDatabaseNames() []string {
 	for name := range sc.databases_ {
 		names = append(names, name)
 	}
+	slices.Sort(names)
 	return names
 }
 
@@ -341,8 +343,15 @@ func (sc *ServerContext) allDatabaseSummaries() []dbSummary {
 	sc.lock.RLock()
 	defer sc.lock.RUnlock()
 
+	names := make([]string, 0, len(sc.databases_))
+	for name := range sc.databases_ {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
 	dbs := make([]dbSummary, 0, len(sc.databases_))
-	for name, dbctx := range sc.databases_ {
+	for _, name := range names {
+		dbctx := sc.databases_[name]
 		dbs = append(dbs, dbSummary{
 			DBName: name,
 			Bucket: dbctx.Bucket.GetName(),

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"


### PR DESCRIPTION
- Use a query parameter to show verbose view of databases.
- Used `oneOf` to specify this - this is how it renders in redocly: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/couchbase/sync_gateway/b62b000ed6cce3b069c8b3d1beafe1f0e40035c8/docs/api/admin.yaml#tag/Database-Management/operation/get__all_dbs
- removed HEAD from redocly since it is not that helpful and I updated the description and I decided to just drop it off.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
