### PR TITLE
Replace `%w` with `%s` inside log functions

### DIFF
--- a/db/background_mgr_attachment_compaction.go
+++ b/db/background_mgr_attachment_compaction.go
@@ -206,14 +206,14 @@ func (a *AttachmentCompactionManager) handleAttachmentCompactionRollbackError(ct
 		// to rollback any phase for attachment compaction we need to purge all persisted dcp metadata
 		err = a.PurgeDCPMetadata(ctx, dataStore, database, keyPrefix)
 		if err != nil {
-			base.WarnfCtx(ctx, "error occurred during purging of dcp metadata: %w", err)
+			base.WarnfCtx(ctx, "error occurred during purging of dcp metadata: %s", err)
 			return false, err
 		}
 		if phase == MarkPhase {
 			// initialise new compaction run as we want to start the phase mark again in event of rollback
 			err = a.Init(ctx, options, nil)
 			if err != nil {
-				base.WarnfCtx(ctx, "error on initialization of new run after rollback has been indicated, %w", err)
+				base.WarnfCtx(ctx, "error on initialization of new run after rollback has been indicated: %s", err)
 				return false, err
 			}
 		} else {

--- a/rest/config.go
+++ b/rest/config.go
@@ -1464,7 +1464,7 @@ func (sc *ServerContext) migrateV30Configs(ctx context.Context) error {
 		if getErr == base.ErrNotFound {
 			continue
 		} else if getErr != nil {
-			base.InfofCtx(ctx, base.KeyConfig, "Unable to retrieve 3.0 config during config migration for bucket: %s, groupID: %s: %w", base.MD(bucketName), base.MD(groupID), getErr)
+			base.InfofCtx(ctx, base.KeyConfig, "Unable to retrieve 3.0 config during config migration for bucket: %s, groupID: %s: %s", base.MD(bucketName), base.MD(groupID), getErr)
 			continue
 		}
 
@@ -1474,13 +1474,13 @@ func (sc *ServerContext) migrateV30Configs(ctx context.Context) error {
 			if insertErr == base.ErrAlreadyExists {
 				base.DebugfCtx(ctx, base.KeyConfig, "Found legacy config for database %s, but already exists in registry.", base.MD(dbConfig.Name))
 			} else {
-				base.InfofCtx(ctx, base.KeyConfig, "Unable to persist migrated v3.0 config for bucket %s groupID %s: %w", base.MD(bucketName), base.MD(groupID), insertErr)
+				base.InfofCtx(ctx, base.KeyConfig, "Unable to persist migrated v3.0 config for bucket %s groupID %s: %s", base.MD(bucketName), base.MD(groupID), insertErr)
 				continue
 			}
 		}
 		removeErr := sc.BootstrapContext.Connection.DeleteMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), legacyCas)
 		if removeErr != nil {
-			base.InfofCtx(ctx, base.KeyConfig, "Failed to remove legacy config for database %s.", base.MD(dbConfig.Name))
+			base.InfofCtx(ctx, base.KeyConfig, "Failed to remove legacy config for database %s: %s", base.MD(dbConfig.Name), removeErr)
 		}
 	}
 	return nil


### PR DESCRIPTION
Only `fmt.Errorf` supports `%w`

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a