### PR TITLE
[3.1.2 backport] CBG-3457 prevent N-1 downgrades by stamping db version into gateway registry

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -442,7 +442,7 @@ func getMinNodeVersion(cfg cbgt.Cfg) (*ComparableVersion, error) {
 			return nil, fmt.Errorf("failed to get version of node %v: %w", MD(node.HostPort).Redact(), err)
 		}
 		if nodeVersion == nil {
-			nodeVersion = zeroComparableVersion
+			nodeVersion = zeroComparableVersion()
 		}
 		if minVersion == nil || nodeVersion.Less(minVersion) {
 			minVersion = nodeVersion

--- a/base/version_comparable_test.go
+++ b/base/version_comparable_test.go
@@ -1,5 +1,4 @@
 // Copyright 2022-Present Couchbase, Inc.
-//
 // Use of this software is governed by the Business Source License included
 // in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
 // in that file, in accordance with the Business Source License, use of this
@@ -9,6 +8,7 @@
 package base
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -111,6 +111,125 @@ func TestInvalidComparableVersion(t *testing.T) {
 			ver, err := NewComparableVersionFromString(test.ver)
 			assert.Error(t, err)
 			assert.Nil(t, ver)
+		})
+	}
+}
+
+func TestComparableVersionJSONRoundTrip(t *testing.T) {
+	json, err := JSONMarshal(ProductVersion)
+	require.NoError(t, err)
+	var version ComparableVersion
+	err = JSONUnmarshal(json, &version)
+	require.NoError(t, err)
+	require.True(t, ProductVersion.Equal(&version))
+	require.Equal(t, ProductVersion.String(), version.String())
+}
+
+func TestComparableVersionEmptyStringJSON(t *testing.T) {
+	var version ComparableVersion
+	err := JSONUnmarshal([]byte(`""`), &version)
+	require.NoError(t, err)
+	require.True(t, zeroComparableVersion().Equal(&version))
+	require.Equal(t, "0.0.0", zeroComparableVersion().String())
+	require.Equal(t, "0.0.0", version.String())
+}
+
+func TestAtLeastMinorDowngradeVersion(t *testing.T) {
+	testCases := []struct {
+		versionA       string
+		versionB       string
+		minorDowngrade bool
+	}{
+		{
+			versionA:       "1.0.0",
+			versionB:       "1.0.0",
+			minorDowngrade: false,
+		},
+		{
+			versionA:       "1.0.0",
+			versionB:       "2.0.0",
+			minorDowngrade: false,
+		},
+		{
+			versionA:       "2.0.0",
+			versionB:       "1.0.0",
+			minorDowngrade: true,
+		},
+		{
+			versionA:       "1.0.0",
+			versionB:       "1.0.1",
+			minorDowngrade: false,
+		},
+		{
+			versionA:       "1.0.1",
+			versionB:       "1.0.0",
+			minorDowngrade: false,
+		},
+		{
+			versionA:       "1.1.0",
+			versionB:       "1.0.0",
+			minorDowngrade: true,
+		},
+		{
+			versionA:       "1.0.0",
+			versionB:       "1.1.0",
+			minorDowngrade: false,
+		},
+		{
+			versionA:       "1.0.0",
+			versionB:       "1.0.0.1",
+			minorDowngrade: false,
+		},
+		{
+			versionA:       "1.0.0.1",
+			versionB:       "1.0.0",
+			minorDowngrade: false,
+		},
+		{
+			versionA:       "1.0.0.1",
+			versionB:       "1.0.0.2",
+			minorDowngrade: false,
+		},
+		{
+			versionA:       "1.0.0.2",
+			versionB:       "1.0.0.1",
+			minorDowngrade: false,
+		},
+		{
+			versionA:       "1.0.0-EE",
+			versionB:       "1.1.0-CE",
+			minorDowngrade: false,
+		},
+		{
+			versionA:       "2.2.0",
+			versionB:       "1.1.0",
+			minorDowngrade: true,
+		},
+		{
+			versionA:       "1.1.0",
+			versionB:       "2.2.0",
+			minorDowngrade: false,
+		},
+		{
+			versionA:       "2.1.0",
+			versionB:       "1.2.0",
+			minorDowngrade: true,
+		},
+		{
+			versionA:       "1.2.0",
+			versionB:       "2.1.0",
+			minorDowngrade: false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(fmt.Sprintf("%s->%s", test.versionA, test.versionB), func(t *testing.T) {
+			versionA, err := NewComparableVersionFromString(test.versionA)
+			require.NoError(t, err)
+
+			versionB, err := NewComparableVersionFromString(test.versionB)
+			require.NoError(t, err)
+			require.Equal(t, test.minorDowngrade, versionA.AtLeastMinorDowngrade(versionB))
 		})
 	}
 }

--- a/rest/config.go
+++ b/rest/config.go
@@ -1751,6 +1751,13 @@ func (sc *ServerContext) applyConfigs(ctx context.Context, dbNameConfigs map[str
 
 // _applyConfig loads the given database, failFast=true will not attempt to retry connecting/loading
 func (sc *ServerContext) _applyConfig(nonContextStruct base.NonCancellableContext, cnf DatabaseConfig, failFast, isInitialStartup bool) (applied bool, err error) {
+	ctx := nonContextStruct.Ctx
+
+	nodeSGVersion := sc.BootstrapContext.sgVersion
+	err = sc.BootstrapContext.CheckMinorDowngrade(ctx, *cnf.Bucket, nodeSGVersion)
+	if err != nil {
+		return false, err
+	}
 	// 3.0.0 doesn't write a SGVersion, but everything else will
 	configSGVersionStr := "3.0.0"
 	if cnf.SGVersion != "" {
@@ -1764,9 +1771,8 @@ func (sc *ServerContext) _applyConfig(nonContextStruct base.NonCancellableContex
 
 	if !isInitialStartup {
 		// Skip applying if the config is from a newer SG version than this node and we're not just starting up
-		nodeSGVersion := base.ProductVersion
 		if nodeSGVersion.Less(configSGVersion) {
-			base.WarnfCtx(nonContextStruct.Ctx, "Cannot apply config update from server for db %q, this SG version is older than config's SG version (%s < %s)", cnf.Name, nodeSGVersion.String(), configSGVersion.String())
+			base.WarnfCtx(ctx, "Cannot apply config update from server for db %q, this SG version is older than config's SG version (%s < %s)", cnf.Name, nodeSGVersion.String(), configSGVersion.String())
 			return false, nil
 		}
 	}
@@ -1782,13 +1788,13 @@ func (sc *ServerContext) _applyConfig(nonContextStruct base.NonCancellableContex
 	if exists {
 		if cnf.cfgCas == 0 {
 			// force an update when the new config's cas was set to zero prior to load
-			base.InfofCtx(nonContextStruct.Ctx, base.KeyConfig, "Forcing update of config for database %q bucket %q", cnf.Name, *cnf.Bucket)
+			base.InfofCtx(ctx, base.KeyConfig, "Forcing update of config for database %q bucket %q", cnf.Name, *cnf.Bucket)
 		} else {
 			if sc.dbConfigs[cnf.Name].cfgCas >= cnf.cfgCas {
-				base.DebugfCtx(nonContextStruct.Ctx, base.KeyConfig, "Database %q bucket %q config has not changed since last update", cnf.Name, *cnf.Bucket)
+				base.DebugfCtx(ctx, base.KeyConfig, "Database %q bucket %q config has not changed since last update", cnf.Name, *cnf.Bucket)
 				return false, nil
 			}
-			base.InfofCtx(nonContextStruct.Ctx, base.KeyConfig, "Updating database %q for bucket %q with new config from bucket", cnf.Name, *cnf.Bucket)
+			base.InfofCtx(ctx, base.KeyConfig, "Updating database %q for bucket %q with new config from bucket", cnf.Name, *cnf.Bucket)
 		}
 	}
 
@@ -1796,13 +1802,18 @@ func (sc *ServerContext) _applyConfig(nonContextStruct base.NonCancellableContex
 	// by any output
 	cnf.Version = ""
 
+	err = sc.BootstrapContext.SetSGVersion(ctx, *cnf.Bucket, nodeSGVersion)
+	if err != nil {
+		return false, nil
+	}
+
 	// Prevent database from being unsuspended when it is suspended
 	if sc._isDatabaseSuspended(cnf.Name) {
 		return true, nil
 	}
 
 	// TODO: Dynamic update instead of reload
-	if err := sc._reloadDatabaseWithConfig(nonContextStruct.Ctx, cnf, failFast, false); err != nil {
+	if err := sc._reloadDatabaseWithConfig(ctx, cnf, failFast, false); err != nil {
 		// remove these entries we just created above if the database hasn't loaded properly
 		return false, fmt.Errorf("couldn't reload database: %w", err)
 	}

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -28,6 +28,12 @@ type ConfigManager interface {
 	UpdateConfig(ctx context.Context, bucket, groupID, dbName string, updateCallback func(bucketConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error)) (newCAS uint64, err error)
 	// DeleteConfig removes a database config for a given bucket, config group ID and database name.
 	DeleteConfig(ctx context.Context, bucket, dbName, groupID string) (err error)
+
+	// CheckMinorDowngrade returns an error the sgVersion represents at least minor version downgrade from the version in the bucket.
+	CheckMinorDowngrade(ctx context.Context, bucketName string, sgVersion base.ComparableVersion) error
+
+	// SetSGVersion updates the Sync Gateway version in the bucket registry
+	SetSGVersion(ctx context.Context, bucketName string, sgVersion base.ComparableVersion) error
 }
 
 type dbConfigNameOnly struct {
@@ -577,10 +583,21 @@ func (b *bootstrapContext) getGatewayRegistry(ctx context.Context, bucketName st
 	cas, getErr := b.Connection.GetMetadataDocument(ctx, bucketName, base.SGRegistryKey, registry)
 	if getErr != nil {
 		if getErr == base.ErrNotFound {
-			return NewGatewayRegistry(), nil
+			return NewGatewayRegistry(b.sgVersion), nil
 		}
 		return nil, getErr
 	}
+	if registry.SGVersion.String() == "" {
+		// 3.1.0 and 3.1.1 don't write a SGVersion, but everything else will
+		configSGVersionStr := "3.1.0"
+		v, err := base.NewComparableVersionFromString(configSGVersionStr)
+		if err != nil {
+			return nil, err
+		}
+		registry.SGVersion = *v
+
+	}
+
 	registry.cas = cas
 
 	return registry, nil
@@ -758,4 +775,39 @@ func (b *bootstrapContext) computeMetadataID(ctx context.Context, registry *Gate
 // standardMetadataID returns either the dbName or a base64 encoded SHA256 hash of the dbName, whichever is shorter.
 func (b *bootstrapContext) standardMetadataID(dbName string) string {
 	return base.SerializeIfLonger(dbName, 40)
+}
+
+// CheckMinorDowngrade returns an error the sgVersion represents at least minor version downgrade from the version in the bucket.
+func (b *bootstrapContext) CheckMinorDowngrade(ctx context.Context, bucketName string, sgVersion base.ComparableVersion) error {
+	registry, err := b.getGatewayRegistry(ctx, bucketName)
+	if err != nil {
+		return err
+	}
+
+	if registry.SGVersion.AtLeastMinorDowngrade(&sgVersion) {
+		err := base.RedactErrorf("Bucket %q has metadata from a newer Sync Gateway %s. Current version of Sync Gateway is %s.", base.MD(bucketName), registry.SGVersion, sgVersion)
+		return err
+	}
+
+	return nil
+}
+
+// SetSGVersion will update the registry in a bucket with a version of Sync Gateway. This will not perform a write if the version is already up to date.
+func (b *bootstrapContext) SetSGVersion(ctx context.Context, bucketName string, sgVersion base.ComparableVersion) error {
+	registry, err := b.getGatewayRegistry(ctx, bucketName)
+	if err != nil {
+		return err
+	}
+	if !registry.SGVersion.Less(&sgVersion) {
+		return nil
+	}
+	originalRegistryVersion := registry.SGVersion
+	registry.SGVersion = sgVersion
+	err = b.setGatewayRegistry(ctx, bucketName, registry)
+	if err != nil {
+		base.WarnfCtx(ctx, "Error setting gateway registry in bucket %q: %q", base.MD(bucketName), err)
+		return err
+	}
+	base.InfofCtx(ctx, base.KeyConfig, "Updated Sync Gateway version number in bucket %q from %s to %s", base.MD(bucketName), originalRegistryVersion, sgVersion)
+	return nil
 }

--- a/rest/config_manager_test.go
+++ b/rest/config_manager_test.go
@@ -10,6 +10,7 @@ package rest
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -155,4 +156,96 @@ func TestLongMetadataID(t *testing.T) {
 	rehashMetadataID := bootstrapContext.standardMetadataID(longMetadataID)
 	assert.NotEqual(t, rehashMetadataID, longMetadataID)
 
+}
+
+func TestVersionDowngrade(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	// rely on AtLeastMinorDowngrade unit test to cover all cases, starting up a db is slow
+	testCases := []struct {
+		syncGatewayVersion      string
+		metadataConfigVersion   string
+		expectedRegistryVersion string
+		name                    string
+		hasError                bool
+	}{
+		{
+			name:                    "equal versions",
+			syncGatewayVersion:      "10.0.0",
+			metadataConfigVersion:   "10.0.0",
+			expectedRegistryVersion: "10.0.0",
+			hasError:                false,
+		},
+		{
+			name:                    "minor upgrade",
+			syncGatewayVersion:      "10.1.0",
+			metadataConfigVersion:   "10.0.0",
+			expectedRegistryVersion: "10.1.0",
+			hasError:                false,
+		},
+		{
+			name:                    "patch upgrade",
+			syncGatewayVersion:      "10.0.1",
+			metadataConfigVersion:   "10.0.0",
+			expectedRegistryVersion: "10.0.1",
+			hasError:                false,
+		},
+		{
+			name:                    "patch downgrade",
+			syncGatewayVersion:      "10.0.1",
+			metadataConfigVersion:   "10.0.2",
+			expectedRegistryVersion: "10.0.2",
+			hasError:                false,
+		},
+		{
+			name:                    "minor downgrade",
+			syncGatewayVersion:      "10.0.0",
+			metadataConfigVersion:   "10.1.0",
+			expectedRegistryVersion: "10.1.0",
+			hasError:                true,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			syncGatewayVersion, err := base.NewComparableVersionFromString(test.syncGatewayVersion)
+			require.NoError(t, err)
+			rt := NewRestTester(t, &RestTesterConfig{
+				PersistentConfig:   true,
+				syncGatewayVersion: syncGatewayVersion,
+			})
+			defer rt.Close()
+
+			_ = rt.Bucket()
+			bootstrapContext := rt.RestTesterServerContext.BootstrapContext
+			registry, err := bootstrapContext.getGatewayRegistry(rt.Context(), rt.Bucket().GetName())
+			require.NoError(t, err)
+			require.True(t, syncGatewayVersion.Equal(&registry.SGVersion), "%+v != %+v", syncGatewayVersion, registry.SGVersion)
+
+			metadataConfigVersion, err := base.NewComparableVersionFromString(test.metadataConfigVersion)
+			registry.SGVersion = *metadataConfigVersion
+			require.NoError(t, err)
+			require.NoError(t, bootstrapContext.setGatewayRegistry(rt.Context(), rt.Bucket().GetName(), registry))
+
+			config := rt.NewDbConfig()
+			config.StartOffline = base.BoolPtr(true) // start offline to make test faster
+
+			resp := rt.CreateDatabase("db1", config)
+			if test.hasError {
+				RequireStatus(t, resp, http.StatusInternalServerError)
+				require.Contains(t, resp.Body.String(), "has metadata from")
+			} else {
+				RequireStatus(t, resp, http.StatusCreated)
+			}
+			registry, err = bootstrapContext.getGatewayRegistry(rt.Context(), rt.Bucket().GetName())
+			require.NoError(t, err)
+
+			expectedRegistryVersion, err := base.NewComparableVersionFromString(test.expectedRegistryVersion)
+			require.NoError(t, err)
+
+			require.True(t, expectedRegistryVersion.Equal(&registry.SGVersion), "%+v != %+v", expectedRegistryVersion, registry.SGVersion)
+
+		})
+	}
 }

--- a/rest/config_registry_test.go
+++ b/rest/config_registry_test.go
@@ -124,7 +124,7 @@ func TestRegistryHelpers(t *testing.T) {
 func TestUpsertDatabaseConfig(t *testing.T) {
 
 	ctx := base.TestCtx(t)
-	registry := NewGatewayRegistry()
+	registry := NewGatewayRegistry(*base.ProductVersion)
 	dbConfig := makeDatabaseConfig("db1", "scope1", []string{"c1", "c2", "c3"}) // in cg1
 	dbConfig.Version = "1"
 	_, err := registry.upsertDatabaseConfig(ctx, "cg1", dbConfig)
@@ -189,7 +189,7 @@ func TestRegistryConflicts(t *testing.T) {
 	defaultConfig := &DatabaseConfig{DbConfig: DbConfig{Name: "defaultDb"}}
 
 	ctx := base.TestCtx(t)
-	registry := NewGatewayRegistry()
+	registry := NewGatewayRegistry(*base.ProductVersion)
 	_, err := registry.upsertDatabaseConfig(ctx, "cg1", dbConfig1)
 	require.NoError(t, err)
 	_, err = registry.upsertDatabaseConfig(ctx, "cg2", dbConfig2)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -80,9 +80,10 @@ const defaultConfigRetryTimeout = 3 * base.DefaultGocbV2OperationTimeout
 
 type bootstrapContext struct {
 	Connection         base.BootstrapConnection
-	configRetryTimeout time.Duration // configRetryTimeout defines the total amount of time to retry on a registry/config mismatch
-	terminator         chan struct{} // Used to stop the goroutine handling the stats logging
-	doneChan           chan struct{} // doneChan is closed when the stats logger goroutine finishes.
+	configRetryTimeout time.Duration          // configRetryTimeout defines the total amount of time to retry on a registry/config mismatch
+	terminator         chan struct{}          // Used to stop the goroutine handling the stats logging
+	doneChan           chan struct{}          // doneChan is closed when the stats logger goroutine finishes.
+	sgVersion          base.ComparableVersion // version of Sync Gateway
 }
 
 type getOrAddDatabaseConfigOptions struct {
@@ -132,7 +133,7 @@ func NewServerContext(ctx context.Context, config *StartupConfig, persistentConf
 		databases_:         map[string]*db.DatabaseContext{},
 		HTTPClient:         http.DefaultClient,
 		statsContext:       &statsContext{},
-		BootstrapContext:   &bootstrapContext{},
+		BootstrapContext:   &bootstrapContext{sgVersion: *base.ProductVersion},
 		hasStarted:         make(chan struct{}),
 	}
 	sc.invalidDatabaseConfigTracking = invalidDatabaseConfigs{

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -70,6 +70,8 @@ type RestTesterConfig struct {
 	serverless                      bool // Runs SG in serverless mode. Must be used in conjunction with persistent config
 	collectionConfig                collectionConfiguration
 	numCollections                  int
+	syncGatewayVersion              *base.ComparableVersion // alternate version of Sync Gateway to use on startup
+	allowDbConfigEnvVars            *bool
 }
 
 type collectionConfiguration uint8
@@ -258,6 +260,9 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 	rt.RestTesterServerContext = NewServerContext(base.TestCtx(rt.TB), &sc, rt.RestTesterConfig.PersistentConfig)
 	rt.RestTesterServerContext.allowScopesInPersistentConfig = true
+	if rt.RestTesterConfig.syncGatewayVersion != nil {
+		rt.RestTesterServerContext.BootstrapContext.sgVersion = *rt.RestTesterConfig.syncGatewayVersion
+	}
 	ctx := rt.Context()
 
 	if !base.ServerIsWalrus(sc.Bootstrap.Server) {


### PR DESCRIPTION
backports CBG-3445 prevent N-1 downgrades by stamping db version into gateway registry (#6486)
