### PR TITLE
[3.1.2 Backport] CBG-3509: Add unsupported.allow_dbconfig_env_vars

### DIFF
--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -131,6 +131,7 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"unsupported.serverless.enabled":                   {&config.Unsupported.Serverless.Enabled, fs.Bool("unsupported.serverless.enabled", false, "Settings for running Sync Gateway in serverless mode.")},
 		"unsupported.serverless.min_config_fetch_interval": {&config.Unsupported.Serverless.MinConfigFetchInterval, fs.String("unsupported.serverless.min_config_fetch_interval", "", "How long to cache configs fetched from the buckets for. This cache is used for requested databases that SG does not know about.")},
 		"unsupported.use_xattr_config":                     {&config.Unsupported.UseXattrConfig, fs.Bool("unsupported.use_xattr_config", false, "Store database configurations in system xattrs")},
+		"unsupported.allow_dbconfig_env_vars":              {&config.Unsupported.AllowDbConfigEnvVars, fs.Bool("unsupported.allow_dbconfig_env_vars", true, "Can be set to false to skip environment variable expansion in database configs")},
 
 		"unsupported.user_queries": {&config.Unsupported.UserQueries, fs.Bool("unsupported.user_queries", false, "Whether user-query APIs are enabled")},
 

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -64,6 +64,7 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 				Enabled:                base.BoolPtr(false),
 				MinConfigFetchInterval: base.NewConfigDuration(DefaultMinConfigFetchInterval),
 			},
+			AllowDbConfigEnvVars: base.BoolPtr(true),
 		},
 		MaxFileDescriptors: DefaultMaxFileDescriptors,
 	}
@@ -141,12 +142,13 @@ type ReplicatorConfig struct {
 }
 
 type UnsupportedConfig struct {
-	StatsLogFrequency *base.ConfigDuration `json:"stats_log_frequency,omitempty"    help:"How often should stats be written to stats logs"`
-	UseStdlibJSON     *bool                `json:"use_stdlib_json,omitempty"        help:"Bypass the jsoniter package and use Go's stdlib instead"`
-	Serverless        ServerlessConfig     `json:"serverless,omitempty"`
-	HTTP2             *HTTP2Config         `json:"http2,omitempty"`
-	UserQueries       *bool                `json:"user_queries,omitempty" help:"Feature flag for user N1QL/JS/GraphQL queries"`
-	UseXattrConfig    *bool                `json:"use_xattr_config,omitempty"       help:"Store database configurations in system xattrs"`
+	StatsLogFrequency    *base.ConfigDuration `json:"stats_log_frequency,omitempty"    help:"How often should stats be written to stats logs"`
+	UseStdlibJSON        *bool                `json:"use_stdlib_json,omitempty"        help:"Bypass the jsoniter package and use Go's stdlib instead"`
+	Serverless           ServerlessConfig     `json:"serverless,omitempty"`
+	HTTP2                *HTTP2Config         `json:"http2,omitempty"`
+	UserQueries          *bool                `json:"user_queries,omitempty"            help:"Feature flag for user N1QL/JS/GraphQL queries"`
+	UseXattrConfig       *bool                `json:"use_xattr_config,omitempty"        help:"Store database configurations in system xattrs"`
+	AllowDbConfigEnvVars *bool                `json:"allow_dbconfig_env_vars,omitempty" help:"Can be set to false to skip environment variable expansion in database configs"`
 }
 
 type ServerlessConfig struct {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -1036,10 +1036,13 @@ func (h *handler) readSanitizeJSON(val interface{}) error {
 	}
 
 	// Expand environment variables.
-	content, err = expandEnv(h.ctx(), content)
-	if err != nil {
-		return err
+	if base.BoolDefault(h.server.Config.Unsupported.AllowDbConfigEnvVars, true) {
+		content, err = expandEnv(h.ctx(), content)
+		if err != nil {
+			return err
+		}
 	}
+
 	// Convert the back quotes into double-quotes, escapes literal
 	// backslashes, newlines or double-quotes with backslashes.
 	content = base.ConvertBackQuotedStrings(content)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -217,6 +217,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 	sc.Bootstrap.UseTLSServer = &rt.RestTesterConfig.useTLSServer
 	sc.Bootstrap.ServerTLSSkipVerify = base.BoolPtr(base.TestTLSSkipVerify())
 	sc.Unsupported.Serverless.Enabled = &rt.serverless
+	sc.Unsupported.AllowDbConfigEnvVars = rt.RestTesterConfig.allowDbConfigEnvVars
 	if rt.serverless {
 		if !rt.PersistentConfig {
 			rt.TB.Fatalf("Persistent config must be used when running in serverless mode")


### PR DESCRIPTION
CBG-3509

Backports #6496 to 3.1.2

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-1.19.5/33/
  - known flakes
