### PR TITLE
CBG-3384 Avoid triggering unnecessary resync when working with default collection

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -493,7 +493,7 @@ func (cc *CouchbaseCluster) GetDocument(ctx context.Context, bucketName, docID s
 		return false, err
 	}
 	err = getResult.Content(rv)
-	return true, nil
+	return true, err
 }
 
 // Close calls teardown for any cached buckets and removes from cachedBucketConnections

--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -400,6 +400,8 @@ func InitSyncInfo(ds DataStore, metadataID string) (requiresResync bool, err err
 
 // SetSyncInfo sets syncInfo in a DataStore to the specified metadataID
 func SetSyncInfo(ds DataStore, metadataID string) error {
+
+	// If the metadataID isn't defined, don't persist SyncInfo.  Defensive handling for legacy use cases.
 	if metadataID == "" {
 		return nil
 	}

--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -375,6 +375,9 @@ func InitSyncInfo(ds DataStore, metadataID string) (requiresResync bool, err err
 	var syncInfo SyncInfo
 	_, fetchErr := ds.Get(SGSyncInfo, &syncInfo)
 	if IsKeyNotFoundError(ds, fetchErr) {
+		if metadataID == "" {
+			return false, nil
+		}
 		newSyncInfo := &SyncInfo{MetadataID: metadataID}
 		_, addErr := ds.Add(SGSyncInfo, 0, newSyncInfo)
 		if IsCasMismatch(addErr) {
@@ -397,6 +400,9 @@ func InitSyncInfo(ds DataStore, metadataID string) (requiresResync bool, err err
 
 // SetSyncInfo sets syncInfo in a DataStore to the specified metadataID
 func SetSyncInfo(ds DataStore, metadataID string) error {
+	if metadataID == "" {
+		return nil
+	}
 	syncInfo := &SyncInfo{
 		MetadataID: metadataID,
 	}

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4434,19 +4434,6 @@ func TestDeleteDatabasePointingAtSameBucketPersistent(t *testing.T) {
 	resp = rest.BootstrapAdminRequest(t, http.MethodPut, "/db2/", fmt.Sprintf(dbConfig, "db2"))
 	resp.RequireStatus(http.StatusCreated)
 
-	// because we moved database - resync is required for the default collection before we're able to bring db2 online
-	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/db2/_resync?regenerate_sequences=true", "")
-	resp.RequireStatus(http.StatusOK)
-
-	// after resync is done, state will flip back to offline
-	BootstrapWaitForDatabaseState(t, "db2", db.DBOffline)
-
-	// now bring the db online so we're able to check dest factory
-	resp = rest.BootstrapAdminRequest(t, http.MethodPost, "/db2/_online", "")
-	resp.RequireStatus(http.StatusOK)
-
-	BootstrapWaitForDatabaseState(t, "db2", db.DBOnline)
-
 	scopeName := ""
 	collectionNames := []string{}
 	// Validate that deleted database is no longer in dest factory set

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -721,10 +721,9 @@ func (b *bootstrapContext) ComputeMetadataIDForDbConfig(ctx context.Context, con
 // computeMetadataID determines whether the database should use the default metadata storage location (to support configurations upgrading with
 // existing sync metadata in the default collection).  The default metadataID is only used when all of the following
 // conditions are met:
-//  1. The default metadataID isn't already in use by another database
+//  1. The default metadataID isn't already in use by another database in the registry
 //  2. The database includes _default._default
-//  3. The _default._default collection isn't already associated with a different metadata ID (_sync:syncInfo is not present)
-//  4. The _default._default collection has legacy data (_sync:seq is present)
+//  3. The _default._default collection isn't already associated with a different metadata ID (syncInfo document is not present, or has a value of defaultMetadataID)
 func (b *bootstrapContext) computeMetadataID(ctx context.Context, registry *GatewayRegistry, config *DbConfig) string {
 
 	standardMetadataID := b.standardMetadataID(config.Name)
@@ -753,21 +752,19 @@ func (b *bootstrapContext) computeMetadataID(ctx context.Context, registry *Gate
 		}
 	}
 
+	// If _default._default is already associated with a non-default metadataID, use the standard ID
 	bucketName := config.GetBucketName()
-	exists, err := b.Connection.KeyExists(ctx, bucketName, base.SGSyncInfo)
+	var syncInfo base.SyncInfo
+	exists, err := b.Connection.GetDocument(ctx, bucketName, base.SGSyncInfo, &syncInfo)
 	if err != nil {
-		base.WarnfCtx(ctx, "Error checking whether metadataID is already defined for default collection - using standard metadataID.  Error: %v", err)
-		return standardMetadataID
-	}
-	if exists {
+		base.WarnfCtx(ctx, "Error checking syncInfo metadataID in default collection - using standard metadataID.  Error: %v", err)
 		return standardMetadataID
 	}
 
-	// If legacy _sync:seq doesn't exist, use the standard ID
-	legacySyncSeqExists, _ := b.Connection.KeyExists(ctx, bucketName, base.DefaultMetadataKeys.SyncSeqKey())
-	if !legacySyncSeqExists {
+	if exists && syncInfo.MetadataID != defaultMetadataID {
 		return standardMetadataID
 	}
+
 	return defaultMetadataID
 
 }

--- a/rest/config_manager_test.go
+++ b/rest/config_manager_test.go
@@ -89,11 +89,11 @@ func TestComputeMetadataID(t *testing.T) {
 	defaultVersion := "1-abc"
 	defaultDbConfig := makeDbConfig(tb.GetName(), dbName, nil)
 
-	// No sync data in default collection, so should use standard ID
+	// Use defaultMetadataID if database targets the default collection
 	metadataID := bootstrapContext.computeMetadataID(ctx, registry, &defaultDbConfig)
-	assert.Equal(t, standardMetadataID, metadataID)
+	assert.Equal(t, defaultMetadataID, metadataID)
 
-	// Set _sync:seq in default collection, verify computeMetadataID returns default ID
+	// Set _sync:seq in default collection, verify computeMetadataID still returns default ID
 	defaultStore := tb.Bucket.DefaultDataStore()
 	syncSeqKey := base.DefaultMetadataKeys.SyncSeqKey()
 	_, err = defaultStore.Incr(syncSeqKey, 1, 0, 0)

--- a/rest/upgradetest/upgrade_registry_test.go
+++ b/rest/upgradetest/upgrade_registry_test.go
@@ -90,8 +90,8 @@ func TestDefaultMetadataIDDefaultToNamed(t *testing.T) {
 	_ = rt.Bucket()
 
 	dbName := "db"
-	// Create a database with named collections
-	// Update config to remove named collections
+	// Create a database with default collection,
+	// Update config to switch to named collections
 
 	scopesConfig := rest.GetCollectionsConfig(t, rt.TestBucket, 2)
 	dbConfig := rt.NewDbConfig()
@@ -105,10 +105,10 @@ func TestDefaultMetadataIDDefaultToNamed(t *testing.T) {
 
 	putResponse := rt.SendAdminRequest("PUT", "/"+dbName+"/_user/bob", userPayload)
 	rest.RequireStatus(t, putResponse, 201)
-	bobDocName := "_sync:user:db:bob"
+	bobDocName := "_sync:user:bob"
 	requireBobUserLocation(rt, bobDocName)
 
-	// Update database to only target default collection
+	// Update database to only target named collection
 	dbConfig.Scopes = scopesConfig
 	resp = rt.ReplaceDbConfig(dbName, dbConfig)
 	rest.RequireStatus(t, resp, http.StatusCreated)

--- a/rest/upgradetest/upgrade_registry_test.go
+++ b/rest/upgradetest/upgrade_registry_test.go
@@ -11,7 +11,6 @@ licenses/APL2.txt.
 package upgradetest
 
 import (
-	"log"
 	"net/http"
 	"testing"
 
@@ -185,14 +184,11 @@ func TestLegacyMetadataID(t *testing.T) {
 	// Get the legacy config for upgrade test below
 	resp = legacyRT.SendAdminRequest("GET", "/_config?include_runtime=true", "")
 	legacyConfigBytes := resp.BodyBytes()
-	log.Printf("Received legacy config: %s", legacyConfigBytes)
+
 	var legacyConfig rest.LegacyServerConfig
 	err := base.JSONUnmarshal(legacyConfigBytes, &legacyConfig)
-	require.NoError(t, err)
-
+	assert.NoError(t, err)
 	legacyRT.Close()
-
-	log.Printf("testing")
 
 	persistentRT := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: tb1,

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -104,6 +104,14 @@ func (rt *RestTester) DeleteDoc(docID, revID string) {
 		fmt.Sprintf("/%s/%s?rev=%s", rt.GetSingleKeyspace(), docID, revID), ""), http.StatusOK)
 }
 
+func (rt *RestTester) GetDatabaseRoot(dbname string) DatabaseRoot {
+	var dbroot DatabaseRoot
+	resp := rt.SendAdminRequest("GET", "/"+dbname+"/", "")
+	RequireStatus(rt.TB, resp, 200)
+	require.NoError(rt.TB, base.JSONUnmarshal(resp.BodyBytes(), &dbroot))
+	return dbroot
+}
+
 func (rt *RestTester) WaitForRev(docID string, revID string) error {
 	return rt.WaitForCondition(func() bool {
 		rawResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/"+docID, "")


### PR DESCRIPTION
CBG-3384

- Don’t persist syncInfo for empty metadataID (legacy config)
- Modify requirements for assignment of default metadata ID to a database:
  1. Remove requirement for presence of _sync:seq in default collection
  2. Allow assignment when default collection’s syncInfo is using defaultMetadataID

These avoid triggering resync for databases using only the default collection, in legacy and non-legacy mode.

Also ensures databases share metadataIDs across config groups (CBG-3527)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2111/
