### PR TITLE
Jenkinsfile: Avoid Groovy env var interpolation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -243,7 +243,7 @@ pipeline {
                                     // Replace covermode values with set just for coveralls to reduce the variability in reports.
                                     sh 'awk \'NR==1{print "mode: set";next} $NF>0{$NF=1} {print}\' cover_ce.out > cover_ce_coveralls.out'
                                     sh 'which goveralls' // check if goveralls is installed
-                                    sh "goveralls -coverprofile=cover_ce_coveralls.out -service=uberjenkins -repotoken=${COVERALLS_TOKEN} || true"
+                                    sh 'goveralls -coverprofile=cover_ce_coveralls.out -service=uberjenkins -repotoken=$COVERALLS_TOKEN || true'
                                 }
                             }
                         }


### PR DESCRIPTION
Fixes

```
11:09:07  [Pipeline] sh
11:09:07  Warning: A secret was passed to "sh" using Groovy String interpolation, which is insecure.
11:09:07  		 Affected argument(s) used the following variable(s): [COVERALLS_TOKEN]
11:09:07  		 See https://jenkins.io/redirect/groovy-string-interpolation for details.
11:09:07  + goveralls -coverprofile=cover_ce_coveralls.out -service=uberjenkins -repotoken=****
```

by passing the literal `$COVERALLS_TOKEN` into the shell, rather than Groovy's interpolation of the env var before the shell step.