### PR TITLE
Skip test under integration

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -383,6 +383,9 @@ func TestGetStatus(t *testing.T) {
 
 func TestFlush(t *testing.T) {
 
+	if !base.UnitTestUrlIsWalrus() {
+		t.Skip("sgbucket.DeleteableBucket inteface only supported by Walrus")
+	}
 	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
 


### PR DESCRIPTION
This was an accidental regression of https://github.com/couchbase/sync_gateway/commit/d183dbe21c1296138dd2f8ae898a4848b14ac135

Now that cbl doesn't use the flush interface, it might be worthwhile to remove this because it only works on rosmar.