### PR TITLE
CBG-3518: Conditional logging for DocChanged based on collection ID

### DIFF
--- a/base/collection_gocb.go
+++ b/base/collection_gocb.go
@@ -30,6 +30,10 @@ const (
 	SystemScope = "_system"
 	// SystemCollectionMobile is the place to store Sync Gateway metadata on a system-collections-enabled Couchbase Server (7.6+)
 	SystemCollectionMobile = "_mobile"
+
+	// MetadataCollectionID is the KV collection ID for the SG Metadata store.
+	// Subject to change when we move to system collections. Might not be possible to declare as const (need to retrieve from server?)
+	MetadataCollectionID = DefaultCollectionID
 )
 
 type Collection struct {

--- a/base/logging.go
+++ b/base/logging.go
@@ -391,6 +391,7 @@ func AssertLogContains(t *testing.T, s string, f func()) {
 	b := bytes.Buffer{}
 	mw := io.MultiWriter(&b, os.Stderr)
 	consoleLogger.logger.SetOutput(mw)
+	defer func() { consoleLogger.logger.SetOutput(os.Stderr) }()
 
 	// Call the given function
 	f()
@@ -403,7 +404,6 @@ func AssertLogContains(t *testing.T, s string, f func()) {
 		return true, nil, nil
 	}
 	err, _ := RetryLoop(TestCtx(t), "wait for logs", retry, CreateSleeperFunc(10, 100))
-	consoleLogger.logger.SetOutput(os.Stderr)
 
 	assert.NoError(t, err, "Console logs did not contain %q", s)
 }

--- a/base/logging.go
+++ b/base/logging.go
@@ -387,11 +387,14 @@ func LogTraceEnabled(logKey LogKey) bool {
 
 // AssertLogContains asserts that the logs produced by function f contain string s.
 func AssertLogContains(t *testing.T, s string, f func()) {
+	// Temporarily override logger output
 	b := bytes.Buffer{}
+	mw := io.MultiWriter(&b, os.Stderr)
+	consoleLogger.logger.SetOutput(mw)
 
-	// Temporarily override logger output for the given function call
-	consoleLogger.logger.SetOutput(&b)
+	// Call the given function
 	f()
+
 	// Allow time for logs to be printed
 	retry := func() (shouldRetry bool, err error, value interface{}) {
 		if strings.Contains(b.String(), s) {

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -370,7 +370,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 			base.WarnfCtx(ctx, "DocChanged(): Non-metadata mutation for doc %q in MetadataStore - kv ID: %d", base.UD(docID), cID)
 		} else {
 			// Unrecognised collection
-			// we shouldn't be receiving mutations for a collection we're not running a database for (barring the metadata store)
+			// we shouldn't be receiving mutations for a collection we're not running a database for (except the metadata store)
 			base.WarnfCtx(ctx, "DocChanged(): Could not find collection for doc %q - kv ID: %d", base.UD(docID), cID)
 		}
 		return


### PR DESCRIPTION
CBG-3518

Tweak logging from DocChanged for collections
- Include KV Collection ID in log lines where we don't recognise the collection (too expensive to lookup collection name from here)
- Add collection name context to all DocChanged logging when we're able to determine it
- Drop warning to debug and reword when it's an expected condition (DocChange events from another database's `_default` collection that we want to ignore)
- Allow `AssertLogContains` helper to "tee" logs with a `MultiWriter` to prevent logs going silent during assertions.

Examples:
```
2023-10-09T17:58:04.542+01:00 [DBG] Changes+: t:TestDocChangedLogging db:db col:sg_test_0 Received #1 after   0ms ("<ud>doc1</ud>" / "1-cd809becc169215072fd567eebd8b8de")
2023-10-09T17:58:04.542+01:00 [DBG] Changes+: t:TestDocChangedLogging db:db col:sg_test_1 Received #2 after   0ms ("<ud>doc1</ud>" / "1-cd809becc169215072fd567eebd8b8de")
2023-10-09T17:58:04.543+01:00 [DBG] Cache+: t:TestDocChangedLogging db:db DocChanged(): Ignoring non-metadata mutation for doc "<ud>doc1</ud>" in the default collection - kv ID: 0
```

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
