### PR TITLE
Skip tests that only work under rosmar

### DIFF
--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1001,6 +1001,9 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 //     - since it's been terminated, should return error before executing a second view query
 func TestChannelQueryCancellation(t *testing.T) {
 
+	if !base.UnitTestUrlIsWalrus() {
+		t.Skip("Skip test with LeakyBucket dependency test when running in integration")
+	}
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache)
 
 	// Set up PostQueryCallback on bucket - will be invoked when changes triggers the cache backfill view query

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -2755,6 +2755,9 @@ func TestConfigRedaction(t *testing.T) {
 }
 
 func TestSoftDeleteCasMismatch(t *testing.T) {
+	if !base.UnitTestUrlIsWalrus() {
+		t.Skip("Skip LeakyBucket test when running in integration")
+	}
 	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
 

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1231,6 +1231,9 @@ func TestRevocationsWithQueryLimitChangesLimit(t *testing.T) {
 }
 
 func TestRevocationUserHasDocAccessDocNotFound(t *testing.T) {
+	if !base.UnitTestUrlIsWalrus() {
+		t.Skip("Skip test with LeakyBucket dependency when running in integration")
+	}
 
 	revocationTester, rt := InitScenario(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{


### PR DESCRIPTION
accidentally removed in previous commit https://github.com/couchbase/sync_gateway/pull/6495
