### PR TITLE
CBG-3464 Update TestMigratev30PersistentConfigCollision based on changes to delete handling

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1579,6 +1579,8 @@ func TestCorruptDbConfigHandling(t *testing.T) {
 	responseConfig := rt.ServerContext().GetDbConfig("db1")
 	assert.Nil(t, responseConfig)
 
+	require.Equal(t, 1, len(rt.ServerContext().AllInvalidDatabases()))
+
 	// assert that fetching config fails with the correct error message to the user
 	resp = rt.SendAdminRequest(http.MethodGet, "/db1/_config", "")
 	rest.RequireStatus(t, resp, http.StatusNotFound)
@@ -1601,7 +1603,8 @@ func TestCorruptDbConfigHandling(t *testing.T) {
 	// wait some time for interval to pick up change
 	err = rt.WaitForConditionWithOptions(func() bool {
 		list := rt.ServerContext().AllDatabaseNames()
-		return len(list) == 1
+		numInvalid := len(rt.ServerContext().AllInvalidDatabases())
+		return len(list) == 1 && numInvalid == 0
 	}, 200, 1000)
 	require.NoError(t, err)
 


### PR DESCRIPTION
migrateV30Configs no longer terminates and returns error on migrate failure for a single bucket - it instead logs the error and continues through the rest of the buckets.

CBG-3464

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2092/
