### PR TITLE
CBG-3465 [3.1.2 backport] Delete legacy config when migrated config already exists

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1592,6 +1592,8 @@ func TestCorruptDbConfigHandling(t *testing.T) {
 	responseConfig := rt.ServerContext().GetDbConfig("db1")
 	assert.Nil(t, responseConfig)
 
+	require.Equal(t, 1, len(rt.ServerContext().AllInvalidDatabases()))
+
 	// assert that fetching config fails with the correct error message to the user
 	resp = rt.SendAdminRequest(http.MethodGet, "/db1/_config", "")
 	rest.RequireStatus(t, resp, http.StatusNotFound)
@@ -1614,7 +1616,8 @@ func TestCorruptDbConfigHandling(t *testing.T) {
 	// wait some time for interval to pick up change
 	err = rt.WaitForConditionWithOptions(func() bool {
 		list := rt.ServerContext().AllDatabaseNames()
-		return len(list) == 1
+		numInvalid := len(rt.ServerContext().AllInvalidDatabases())
+		return len(list) == 1 && numInvalid == 0
 	}, 200, 1000)
 	require.NoError(t, err)
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -1453,7 +1453,8 @@ func (sc *ServerContext) migrateV30Configs(ctx context.Context) error {
 		if getErr == base.ErrNotFound {
 			continue
 		} else if getErr != nil {
-			return fmt.Errorf("Error retrieving 3.0 config for bucket: %s, groupID: %s: %w", bucketName, groupID, err)
+			base.InfofCtx(ctx, base.KeyConfig, "Unable to retrieve 3.0 config during config migration for bucket: %s, groupID: %s: %w", base.MD(bucketName), base.MD(groupID), getErr)
+			continue
 		}
 
 		base.InfofCtx(ctx, base.KeyConfig, "Found legacy persisted config for database %s - migrating to db registry.", base.MD(dbConfig.Name))
@@ -1461,9 +1462,10 @@ func (sc *ServerContext) migrateV30Configs(ctx context.Context) error {
 		if insertErr != nil {
 			if insertErr == base.ErrAlreadyExists {
 				base.DebugfCtx(ctx, base.KeyConfig, "Found legacy config for database %s, but already exists in registry.", base.MD(dbConfig.Name))
+			} else {
+				base.InfofCtx(ctx, base.KeyConfig, "Unable to persist migrated v3.0 config for bucket %s groupID %s: %w", base.MD(bucketName), base.MD(groupID), insertErr)
 				continue
 			}
-			return fmt.Errorf("Error migrating v3.0 config for bucket %s groupID %s: %w", base.MD(bucketName), base.MD(groupID), insertErr)
 		}
 		removeErr := sc.BootstrapContext.Connection.DeleteMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), legacyCas)
 		if removeErr != nil {

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -1283,11 +1283,9 @@ func TestMigratev30PersistentConfigCollision(t *testing.T) {
 	_, insertError := sc.BootstrapContext.Connection.InsertMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), defaultDatabaseConfig)
 	require.NoError(t, insertError)
 
+	// migration should not return error, but legacy config will not be migrated due to collection conflict
 	migrateErr := sc.migrateV30Configs(ctx)
-	require.Error(t, migrateErr)
-	var httpErr *base.HTTPError
-	require.ErrorAs(t, migrateErr, &httpErr)
-	require.Equal(t, 409, httpErr.Status)
+	require.NoError(t, migrateErr)
 
 	// Fetch the registry, verify newDefaultDb still exists and defaultDb30 has not been migrated due to collection conflict
 	registry, registryErr := sc.BootstrapContext.getGatewayRegistry(ctx, bucketName)
@@ -1296,6 +1294,10 @@ func TestMigratev30PersistentConfigCollision(t *testing.T) {
 	migratedDb, found := registry.getRegistryDatabase(groupID, newDefaultDbName)
 	require.True(t, found)
 	require.Equal(t, "1-a", migratedDb.Version)
+
+	// Verify non-migrated legacy config has not been deleted (since it wasn't successfully migrated)
+	_, getErr := sc.BootstrapContext.Connection.GetMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), defaultDatabaseConfig)
+	require.NoError(t, getErr)
 }
 
 func getTestDatabaseConfig(bucketName string, dbName string, scopesConfig ScopesConfig, version string) *DatabaseConfig {


### PR DESCRIPTION
CBG-3465

Backports CBG-3464 and accompanying test fix.
