### PR TITLE
CBG-3211: Add PutExistingRev for HLV

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -2084,14 +2084,6 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			// update the mutate in options based on the above logic
 			updatedSpec = doc.SyncData.HLV.computeMacroExpansions()
 
-			// update the HLV values
-			doc, err = db.updateHLV(doc, docUpdateEvent)
-			if err != nil {
-				return
-			}
-			// update the mutate in options based on the above logic
-			updatedSpec = doc.SyncData.HLV.computeMacroExpansions()
-
 			deleteDoc = currentRevFromHistory.Deleted
 
 			// Return the new raw document value for the bucket to store.

--- a/db/crud.go
+++ b/db/crud.go
@@ -1144,7 +1144,6 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 		}
 
 		newDoc.RevID = newRev
-		newDoc.Deleted = newDoc.Deleted
 
 		return newDoc, newAttachments, false, nil, nil
 	})

--- a/db/crud.go
+++ b/db/crud.go
@@ -1062,7 +1062,7 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 	return newRevID, doc, err
 }
 
-func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Context, newDoc *Document, docHLV HybridLogicalVector, existingDoc *sgbucket.BucketDocument) (doc *Document, cv *CurrentVersionVector, newRevID string, err error) {
+func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Context, newDoc *Document, docHLV HybridLogicalVector, existingDoc *sgbucket.BucketDocument) (doc *Document, cv *SourceAndVersion, newRevID string, err error) {
 	var matchRev string
 	if existingDoc != nil {
 		doc, unmarshalErr := unmarshalDocumentWithXattr(ctx, newDoc.ID, existingDoc.Body, existingDoc.Xattr, existingDoc.UserXattr, existingDoc.Cas, DocUnmarshalRev)
@@ -1149,11 +1149,11 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 
 	if doc != nil && doc.HLV != nil {
 		if cv == nil {
-			cv = &CurrentVersionVector{}
+			cv = &SourceAndVersion{}
 		}
 		source, version := doc.HLV.GetCurrentVersion()
 		cv.SourceID = source
-		cv.VersionCAS = version
+		cv.Version = version
 	}
 
 	return doc, cv, newRevID, err

--- a/db/crud.go
+++ b/db/crud.go
@@ -1079,6 +1079,7 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx c
 		return nil, "", base.HTTPErrorf(http.StatusBadRequest, "Invalid revision ID")
 	}
 
+	docUpdateEvent := ExistingVersion
 	allowImport := db.UseXattrs()
 	doc, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, newDoc.DocExpiry, nil, docUpdateEvent, existingDoc, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)
@@ -1978,6 +1979,14 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 				err = base.RedactErrorf("WriteUpdateWithXattr() not able to find revision (%v) in history of doc: %+v.  Cannot update doc.", doc.CurrentRev, base.UD(doc))
 				return
 			}
+
+			// update the HLV values
+			doc, err = db.updateHLV(doc, docUpdateEvent)
+			if err != nil {
+				return
+			}
+			// update the mutate in options based on the above logic
+			updatedSpec = doc.SyncData.HLV.computeMacroExpansions()
 
 			// update the HLV values
 			doc, err = db.updateHLV(doc, docUpdateEvent)

--- a/db/crud.go
+++ b/db/crud.go
@@ -1079,7 +1079,6 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx c
 		return nil, "", base.HTTPErrorf(http.StatusBadRequest, "Invalid revision ID")
 	}
 
-	docUpdateEvent := ExistingVersion
 	allowImport := db.UseXattrs()
 	doc, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, newDoc.DocExpiry, nil, docUpdateEvent, existingDoc, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1743,7 +1743,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 	require.NoError(t, err)
 	// assert on returned CV
 	assert.Equal(t, "test", cv.SourceID)
-	assert.Equal(t, incomingVersion, cv.VersionCAS)
+	assert.Equal(t, incomingVersion, cv.Version)
 	assert.Equal(t, []byte(`{"key1":"value2"}`), doc._rawBody)
 
 	// assert on the sync data from the above update to the doc
@@ -1850,7 +1850,7 @@ func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 	assert.NotNil(t, doc)
 	// assert on returned CV value
 	assert.Equal(t, "test", cv.SourceID)
-	assert.Equal(t, incomingVersion, cv.VersionCAS)
+	assert.Equal(t, incomingVersion, cv.Version)
 	assert.Equal(t, []byte(`{"key1":"value2"}`), doc._rawBody)
 
 	// assert on the sync data from the above update to the doc

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1770,7 +1770,6 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 //   - Assert conflict between the local HLV for the doc and the incoming mutation is correctly identified
 //   - Assert that the doc's HLV in the bucket hasn't been updated
 func TestPutExistingCurrentVersionWithConflict(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCRUD)
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
@@ -1821,7 +1820,8 @@ func TestPutExistingCurrentVersionWithConflict(t *testing.T) {
 
 // TestPutExistingCurrentVersionWithNoExistingDoc:
 //   - Purpose of this test is to test PutExistingRevWithBody code pathway where an
-//     existing doc is not provided from the bucket into the function
+//     existing doc is not provided from the bucket into the function simulating a new, not seen
+//     before doc entering this code path
 func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1720,7 +1720,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 
 	// construct a mock doc update coming over a replicator
 	body = Body{"key1": "value2"}
-	newDoc := constructDocumentFromBody(key, body)
+	newDoc := createTestDocument(key, "", body, false, 0)
 
 	// construct a HLV that simulates a doc update happening on a client
 	// this means moving the current source version pair to PV and adding new sourceID and version pair to CV
@@ -1793,7 +1793,7 @@ func TestPutExistingCurrentVersionWithConflict(t *testing.T) {
 
 	// create a new doc update to simulate a doc update arriving over replicator from, client
 	body = Body{"key1": "value2"}
-	newDoc := constructDocumentFromBody(key, body)
+	newDoc := createTestDocument(key, "", body, false, 0)
 	incomingHLV := HybridLogicalVector{
 		SourceID: "test",
 		Version:  1234,
@@ -1831,7 +1831,7 @@ func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 
 	// construct a mock doc update coming over a replicator
 	body := Body{"key1": "value2"}
-	newDoc := constructDocumentFromBody("doc2", body)
+	newDoc := createTestDocument("doc2", "", body, false, 0)
 
 	// construct a HLV that simulates a doc update happening on a client
 	// this means moving the current source version pair to PV and adding new sourceID and version pair to CV

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1739,11 +1739,12 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 	_, rawDoc, err := collection.GetDocumentWithRaw(ctx, key, DocUnmarshalSync)
 	require.NoError(t, err)
 
-	_, cv, rev, err := collection.PutExistingCurrentVersion(ctx, newDoc, []string{"3-c", rev2, rev}, incomingHLV, rawDoc)
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, []string{"3-c", rev2, rev}, incomingHLV, rawDoc)
 	require.NoError(t, err)
 	// assert on returned CV
 	assert.Equal(t, "test", cv.SourceID)
 	assert.Equal(t, incomingVersion, cv.VersionCAS)
+	assert.Equal(t, []byte(`{"key1":"value2"}`), doc._rawBody)
 
 	// assert on the sync data from the above update to the doc
 	// CV should be equal to CV of update on client but the cvCAS should be updated with the new update and
@@ -1879,6 +1880,7 @@ func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 	// assert on returned CV value
 	assert.Equal(t, "test", cv.SourceID)
 	assert.Equal(t, incomingVersion, cv.VersionCAS)
+	assert.Equal(t, []byte(`{"key1":"value2"}`), doc._rawBody)
 
 	// assert on the sync data from the above update to the doc
 	// CV should be equal to CV of update on client but the cvCAS should be updated with the new update and

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -210,6 +210,7 @@ func (hlv *HybridLogicalVector) GetVersion(sourceID string) (uint64, bool) {
 }
 
 // AddNewerVersions will take a hlv and add any newer source/version pairs found across CV and PV found in the other HLV taken as parameter
+// when both HLV
 func (hlv *HybridLogicalVector) AddNewerVersions(otherVector HybridLogicalVector) error {
 
 	// create current version for incoming vector and attempt to add it to the local HLV, AddVersion will handle if attempting to add older
@@ -234,6 +235,15 @@ func (hlv *HybridLogicalVector) AddNewerVersions(otherVector HybridLogicalVector
 		delete(hlv.PreviousVersions, hlv.SourceID)
 	}
 	return nil
+}
+
+func (hlv *HybridLogicalVector) SetMergeVectors(otherVector HybridLogicalVector) {
+	if hlv.MergeVersions == nil {
+		hlv.MergeVersions = make(map[string]uint64)
+	}
+
+	hlv.setMergeVersion(otherVector.SourceID, otherVector.Version)
+	hlv.setMergeVersion(hlv.SourceID, hlv.Version)
 }
 
 func (hlv HybridLogicalVector) MarshalJSON() ([]byte, error) {
@@ -354,4 +364,12 @@ func (hlv *HybridLogicalVector) setPreviousVersion(source string, version uint64
 		hlv.PreviousVersions = make(map[string]uint64)
 	}
 	hlv.PreviousVersions[source] = version
+}
+
+// setMergeVersion will take a source/version pair and add it to the HLV merge versions map
+func (hlv *HybridLogicalVector) setMergeVersion(source string, version uint64) {
+	if hlv.MergeVersions == nil {
+		hlv.MergeVersions = make(map[string]uint64)
+	}
+	hlv.MergeVersions[source] = version
 }

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -215,7 +215,7 @@ func (hlv *HybridLogicalVector) AddNewerVersions(otherVector HybridLogicalVector
 
 	// create current version for incoming vector and attempt to add it to the local HLV, AddVersion will handle if attempting to add older
 	// version than local HLVs CV pair
-	otherVectorCV := CurrentVersionVector{SourceID: otherVector.SourceID, VersionCAS: otherVector.Version}
+	otherVectorCV := SourceAndVersion{SourceID: otherVector.SourceID, Version: otherVector.Version}
 	err := hlv.AddVersion(otherVectorCV)
 	if err != nil {
 		return err

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -237,15 +237,6 @@ func (hlv *HybridLogicalVector) AddNewerVersions(otherVector HybridLogicalVector
 	return nil
 }
 
-func (hlv *HybridLogicalVector) SetMergeVectors(otherVector HybridLogicalVector) {
-	if hlv.MergeVersions == nil {
-		hlv.MergeVersions = make(map[string]uint64)
-	}
-
-	hlv.setMergeVersion(otherVector.SourceID, otherVector.Version)
-	hlv.setMergeVersion(hlv.SourceID, hlv.Version)
-}
-
 func (hlv HybridLogicalVector) MarshalJSON() ([]byte, error) {
 
 	persistedHLV, err := hlv.convertHLVToPersistedFormat()

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -356,11 +356,3 @@ func (hlv *HybridLogicalVector) setPreviousVersion(source string, version uint64
 	}
 	hlv.PreviousVersions[source] = version
 }
-
-// setMergeVersion will take a source/version pair and add it to the HLV merge versions map
-func (hlv *HybridLogicalVector) setMergeVersion(source string, version uint64) {
-	if hlv.MergeVersions == nil {
-		hlv.MergeVersions = make(map[string]uint64)
-	}
-	hlv.MergeVersions[source] = version
-}

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -331,13 +331,7 @@ func (hlv *HybridLogicalVector) computeMacroExpansions() []sgbucket.MacroExpansi
 	return outputSpec
 }
 
-func (hlv *HybridLogicalVector) addMergeVersion(source string, version uint64) {
-	if hlv.MergeVersions == nil {
-		hlv.MergeVersions = make(map[string]uint64)
-	}
-	hlv.MergeVersions[source] = version
-}
-
+// addToPreviousVersions will take a source/version pair and add it to the HLV previous versions map
 func (hlv *HybridLogicalVector) addToPreviousVersions(source string, version uint64) {
 	if hlv.MergeVersions == nil {
 		hlv.MergeVersions = make(map[string]uint64)

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -85,19 +85,10 @@ func (hlv *HybridLogicalVector) AddVersion(newVersion SourceAndVersion) error {
 		hlv.SourceID = newVersion.SourceID
 		return nil
 	}
-	// check if this is the first time we're adding a source - version pair
-	if hlv.SourceID == "" {
-		hlv.Version = newVersion.VersionCAS
-		hlv.SourceID = newVersion.SourceID
-		return nil
-	}
 	// if new entry has the same source we simple just update the version
 	if newVersion.SourceID == hlv.SourceID {
 		hlv.Version = newVersion.Version
 		return nil
-	}
-	if hlv.PreviousVersions == nil {
-		hlv.PreviousVersions = make(map[string]uint64)
 	}
 	// if we get here this is a new version from a different sourceID thus need to move current sourceID to previous versions and update current version
 	if hlv.PreviousVersions == nil {

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -272,7 +272,7 @@ func TestAddNewerVersionsBetweenTwoVectors(t *testing.T) {
 			incomingHLV := createHLVForTest(t, test.incomingInput)
 			expectedHLV := createHLVForTest(t, test.expectedInput)
 
-			localHLV.AddNewerVersions(incomingHLV)
+			_ = localHLV.AddNewerVersions(incomingHLV)
 			// assert on expected values
 			assert.Equal(t, expectedHLV.SourceID, localHLV.SourceID)
 			assert.Equal(t, expectedHLV.Version, localHLV.Version)

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -252,12 +252,6 @@ func TestAddNewerVersionsBetweenTwoVectorsWhenNotInConflict(t *testing.T) {
 			incomingInput: []string{"def@35", "abc@15"},
 			expected:      []string{"def@35", "abc@15"},
 		},
-		{
-			name:          "testcase3",
-			localInput:    []string{"abc@17", "def@30"},
-			incomingInput: []string{"def@35", "abc@15"},
-			expected:      []string{"def@35", "abc@17"},
-		},
 	}
 
 	for _, test := range testCases {
@@ -273,27 +267,6 @@ func TestAddNewerVersionsBetweenTwoVectorsWhenNotInConflict(t *testing.T) {
 			assert.True(t, reflect.DeepEqual(expectedHLV.PreviousVersions, localHLV.PreviousVersions))
 		})
 	}
-}
-
-func TestAddToMergeVersionsWhenInConflict(t *testing.T) {
-
-	localInput := []string{"abc@20", "ghi@9"}
-	incomingInput := []string{"def@15", "ghi@17"}
-	expected := []string{"abc@20", "ghi@9", "m_def@15", "m_abc@20"}
-
-	localHLV := createHLVForTest(t, localInput)
-	incomingHLV := createHLVForTest(t, incomingInput)
-	expectedHLV := createHLVForTest(t, expected)
-
-	isInConflict := localHLV.IsInConflict(incomingHLV)
-	require.True(t, isInConflict)
-	localHLV.SetMergeVectors(incomingHLV)
-
-	// assert on expected values
-	assert.Equal(t, expectedHLV.SourceID, localHLV.SourceID)
-	assert.Equal(t, expectedHLV.Version, localHLV.Version)
-	assert.True(t, reflect.DeepEqual(expectedHLV.PreviousVersions, localHLV.PreviousVersions))
-	assert.True(t, reflect.DeepEqual(expectedHLV.MergeVersions, localHLV.MergeVersions))
 }
 
 // Tests import of server-side mutations made by HLV-aware and non-HLV-aware peers

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -644,3 +644,25 @@ func DefaultMutateInOpts() *sgbucket.MutateInOptions {
 		MacroExpansion: macroExpandSpec(base.SyncXattrName),
 	}
 }
+
+func constructDocumentFromBody(docID string, body Body) (newDoc *Document) {
+	expiry, _ := body.ExtractExpiry()
+	deleted := body.ExtractDeleted()
+	revid := body.ExtractRev()
+
+	newDoc = &Document{
+		ID:        docID,
+		Deleted:   deleted,
+		DocExpiry: expiry,
+		RevID:     revid,
+	}
+
+	delete(body, BodyId)
+	delete(body, BodyRevisions)
+
+	newDoc.DocAttachments = GetBodyAttachments(body)
+	delete(body, BodyAttachments)
+
+	newDoc.UpdateBody(body)
+	return newDoc
+}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -645,24 +645,13 @@ func DefaultMutateInOpts() *sgbucket.MutateInOptions {
 	}
 }
 
-func constructDocumentFromBody(docID string, body Body) (newDoc *Document) {
-	expiry, _ := body.ExtractExpiry()
-	deleted := body.ExtractDeleted()
-	revid := body.ExtractRev()
-
+func createTestDocument(docID string, revID string, body Body, deleted bool, expiry uint32) (newDoc *Document) {
 	newDoc = &Document{
 		ID:        docID,
 		Deleted:   deleted,
 		DocExpiry: expiry,
-		RevID:     revid,
+		RevID:     revID,
+		_body:     body,
 	}
-
-	delete(body, BodyId)
-	delete(body, BodyRevisions)
-
-	newDoc.DocAttachments = GetBodyAttachments(body)
-	delete(body, BodyAttachments)
-
-	newDoc.UpdateBody(body)
 	return newDoc
 }


### PR DESCRIPTION
CBG-3211

Adds a new function entitled PutExistingCurrentVersion which carries much the same functionality for PutExistingRev but carries out logic on the HLV.  
- Check for conflict between the two HLV's  
- If conflict is found we cancel the rest of the update to the doc. Here we need to add merge version and send the doc back to the client.  
- If not in conflict we need to add all newer source/version pairs from the incoming HLV to the local HLV for that doc. I have added a function called AddNewerVersions that does this, first by iterating through the Previous Versions and adding any newer version pair, then the incoming HLV's current version pair. 
- If not in conflict the revtree entry still needs to be computed and added to the doc update. 
- Added tests to ensure that the CV of the incoming HLV is preserved and that the cvCAS is updated still, then the PV of the HLV on the doc is updated correctly. 
- Also included a test where a conflict is found and assert we cancel the doc update, then fetch the persisted sync data to ensure it has remained unchanged. 


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2149/
