### PR TITLE
Fix data race in AssertLogContains and functional race in TestDocChangedLogging

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -388,22 +388,14 @@ func LogTraceEnabled(logKey LogKey) bool {
 // AssertLogContains asserts that the logs produced by function f contain string s.
 func AssertLogContains(t *testing.T, s string, f func()) {
 	// Temporarily override logger output
-	b := bytes.Buffer{}
-	mw := io.MultiWriter(&b, os.Stderr)
+	b := &bytes.Buffer{}
+	mw := io.MultiWriter(b, os.Stderr)
 	consoleLogger.logger.SetOutput(mw)
 	defer func() { consoleLogger.logger.SetOutput(os.Stderr) }()
 
 	// Call the given function
 	f()
 
-	// Allow time for logs to be printed
-	retry := func() (shouldRetry bool, err error, value interface{}) {
-		if strings.Contains(b.String(), s) {
-			return false, nil, nil
-		}
-		return true, nil, nil
-	}
-	err, _ := RetryLoop(TestCtx(t), "wait for logs", retry, CreateSleeperFunc(10, 100))
-
-	assert.NoError(t, err, "Console logs did not contain %q", s)
+	consoleLogger.FlushBufferToLog()
+	assert.True(t, strings.Contains(b.String(), s), "Console logs did not contain %q", s)
 }

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -4337,6 +4337,10 @@ func TestDocChangedLogging(t *testing.T) {
 	base.AssertLogContains(t, "Ignoring non-metadata mutation for doc", func() {
 		err := rt.GetDatabase().MetadataStore.Set("doc1", 0, nil, db.Body{"foo": "bar"})
 		require.NoError(t, err)
+		// write another doc to ensure the previous non-metadata doc has been seen...
+		// no other way of synchronising this no-op as no stats to wait on
+		response = rt.SendAdminRequest("PUT", "/{{.keyspace1}}/doc2", `{"foo":"bar"}`)
+		rest.RequireStatus(t, response, http.StatusCreated)
 		require.NoError(t, rt.WaitForPendingChanges())
 	})
 	assert.Equal(t, warnCountBefore, base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value())


### PR DESCRIPTION
- Ensures `TestDocChangedLogging` waits for a marker doc to be recieved, as we can't reliably wait for the no-op of non-metadata doc write to happen to assert on logs.
- Forces console log buffer flush before checking contents, instead of retry loop.
- Avoids multiple buffer reads during log writes
  - Prevents race if the log write causes buffer to grow during read inside retry loop
  - Prevents functional issues if buffer read was in the middle of the log line causing failed assertions (log lines split over multiple buffer reads)

Reliably tested before/after fix with:

```
$ go test -run='^TestDocChangedLogging$' -race -count=1000 -v ./rest/changestest
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a