### PR TITLE
[3.1.2 Backport] Conditional logging for DocChanged based on collection

### DIFF
--- a/base/collection_gocb.go
+++ b/base/collection_gocb.go
@@ -25,6 +25,12 @@ import (
 // DefaultCollectionID represents _default._default collection
 const DefaultCollectionID = uint32(0)
 
+const (
+	// MetadataCollectionID is the KV collection ID for the SG Metadata store.
+	// Subject to change when we move to system collections. Might not be possible to declare as const (need to retrieve from server?)
+	MetadataCollectionID = DefaultCollectionID
+)
+
 type Collection struct {
 	Bucket         *GocbV2Bucket
 	Collection     *gocb.Collection

--- a/base/logging.go
+++ b/base/logging.go
@@ -392,6 +392,7 @@ func AssertLogContains(t *testing.T, s string, f func()) {
 	// Call the given function
 	f()
 
+	FlushLogBuffers()
 	consoleLogger.FlushBufferToLog()
-	assert.True(t, strings.Contains(b.String(), s), "Console logs did not contain %q", s)
+	assert.Contains(t, b.String(), s)
 }

--- a/base/logging.go
+++ b/base/logging.go
@@ -383,11 +383,15 @@ func LogTraceEnabled(logKey LogKey) bool {
 
 // AssertLogContains asserts that the logs produced by function f contain string s.
 func AssertLogContains(t *testing.T, s string, f func()) {
+	// Temporarily override logger output
 	b := bytes.Buffer{}
+	mw := io.MultiWriter(&b, os.Stderr)
+	consoleLogger.logger.SetOutput(mw)
+	defer func() { consoleLogger.logger.SetOutput(os.Stderr) }()
 
-	// Temporarily override logger output for the given function call
-	consoleLogger.logger.SetOutput(&b)
+	// Call the given function
 	f()
+
 	// Allow time for logs to be printed
 	retry := func() (shouldRetry bool, err error, value interface{}) {
 		if strings.Contains(b.String(), s) {
@@ -396,7 +400,6 @@ func AssertLogContains(t *testing.T, s string, f func()) {
 		return true, nil, nil
 	}
 	err, _ := RetryLoop(TestCtx(t), "wait for logs", retry, CreateSleeperFunc(10, 100))
-	consoleLogger.logger.SetOutput(os.Stderr)
 
 	assert.NoError(t, err, "Console logs did not contain %q", s)
 }

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -359,17 +359,32 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 		return
 	}
 
+	collection, exists := c.db.CollectionByID[event.CollectionID]
+	if !exists {
+		cID := event.CollectionID
+		if cID == base.DefaultCollectionID {
+			// It's possible for the `_default` collection to be associated with other databases writing non-principal documents,
+			// but we still need this collection's feed for the MetadataStore docs. Conditionally drop log level to avoid spurious warnings.
+			base.DebugfCtx(ctx, base.KeyCache, "DocChanged(): Ignoring non-metadata mutation for doc %q in the default collection - kv ID: %d", base.UD(docID), cID)
+		} else if cID == base.MetadataCollectionID {
+			// When Metadata moves to a different collection, we should start to warn again - we don't expect non-metadata mutations here!
+			base.WarnfCtx(ctx, "DocChanged(): Non-metadata mutation for doc %q in MetadataStore - kv ID: %d", base.UD(docID), cID)
+		} else {
+			// Unrecognised collection
+			// we shouldn't be receiving mutations for a collection we're not running a database for (except the metadata store)
+			base.WarnfCtx(ctx, "DocChanged(): Could not find collection for doc %q - kv ID: %d", base.UD(docID), cID)
+		}
+		return
+	}
+
+	ctx = base.CollectionLogCtx(ctx, collection.Name)
+
 	// If this is a delete and there are no xattrs (no existing SG revision), we can ignore
 	if event.Opcode == sgbucket.FeedOpDeletion && len(docJSON) == 0 {
 		base.DebugfCtx(ctx, base.KeyImport, "Ignoring delete mutation for %s - no existing Sync Gateway metadata.", base.UD(docID))
 		return
 	}
 
-	collection, exists := c.db.CollectionByID[event.CollectionID]
-	if !exists {
-		base.WarnfCtx(ctx, "DocChanged: could not find collection with kv ID: %d", event.CollectionID)
-		return
-	}
 	// If this is a binary document (and not one of the above types), we can ignore.  Currently only performing this check when xattrs
 	// are enabled, because walrus doesn't support DataType on feed.
 	if collection.UseXattrs() && event.DataType == base.MemcachedDataTypeRaw {

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -4266,3 +4266,25 @@ func WriteDirectWithKey(t *testing.T, key string, channelArray []string, sequenc
 	require.NoError(t, err)
 
 }
+
+// TestDocChangedLogging exercises some of the logging in DocChanged
+func TestDocChangedLogging(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyCache, base.KeyChanges)
+
+	rt := rest.NewRestTesterMultipleCollections(t, nil, 2)
+	defer rt.Close()
+
+	response := rt.SendAdminRequest("PUT", "/{{.keyspace1}}/doc1", `{"foo":"bar"}`)
+	rest.RequireStatus(t, response, http.StatusCreated)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace2}}/doc1", `{"foo":"bar"}`)
+	rest.RequireStatus(t, response, http.StatusCreated)
+	require.NoError(t, rt.WaitForPendingChanges())
+
+	warnCountBefore := base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value()
+	base.AssertLogContains(t, "Ignoring non-metadata mutation for doc", func() {
+		err := rt.GetDatabase().MetadataStore.Set("doc1", 0, nil, db.Body{"foo": "bar"})
+		require.NoError(t, err)
+		require.NoError(t, rt.WaitForPendingChanges())
+	})
+	assert.Equal(t, warnCountBefore, base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value())
+}

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -4280,7 +4280,6 @@ func TestDocChangedLogging(t *testing.T) {
 	rest.RequireStatus(t, response, http.StatusCreated)
 	require.NoError(t, rt.WaitForPendingChanges())
 
-	warnCountBefore := base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value()
 	base.AssertLogContains(t, "Ignoring non-metadata mutation for doc", func() {
 		err := rt.GetDatabase().MetadataStore.Set("doc1", 0, nil, db.Body{"foo": "bar"})
 		require.NoError(t, err)
@@ -4290,5 +4289,4 @@ func TestDocChangedLogging(t *testing.T) {
 		rest.RequireStatus(t, response, http.StatusCreated)
 		require.NoError(t, rt.WaitForPendingChanges())
 	})
-	assert.Equal(t, warnCountBefore, base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value())
 }

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -4284,6 +4284,10 @@ func TestDocChangedLogging(t *testing.T) {
 	base.AssertLogContains(t, "Ignoring non-metadata mutation for doc", func() {
 		err := rt.GetDatabase().MetadataStore.Set("doc1", 0, nil, db.Body{"foo": "bar"})
 		require.NoError(t, err)
+		// write another doc to ensure the previous non-metadata doc has been seen...
+		// no other way of synchronising this no-op as no stats to wait on
+		response = rt.SendAdminRequest("PUT", "/{{.keyspace1}}/doc2", `{"foo":"bar"}`)
+		rest.RequireStatus(t, response, http.StatusCreated)
 		require.NoError(t, rt.WaitForPendingChanges())
 	})
 	assert.Equal(t, warnCountBefore, base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value())


### PR DESCRIPTION
Backports #6508 and #6517 to 3.1.2

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-1.19.5/35/