### PR TITLE
CBG-3518 flush the log buffers collateBuffer is enabled

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -396,6 +396,7 @@ func AssertLogContains(t *testing.T, s string, f func()) {
 	// Call the given function
 	f()
 
+	FlushLogBuffers()
 	consoleLogger.FlushBufferToLog()
 	assert.True(t, strings.Contains(b.String(), s), "Console logs did not contain %q", s)
 }

--- a/base/logging.go
+++ b/base/logging.go
@@ -398,5 +398,5 @@ func AssertLogContains(t *testing.T, s string, f func()) {
 
 	FlushLogBuffers()
 	consoleLogger.FlushBufferToLog()
-	assert.True(t, strings.Contains(b.String(), s), "Console logs did not contain %q", s)
+	assert.Contains(t, b.String(), s)
 }

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -4333,7 +4333,6 @@ func TestDocChangedLogging(t *testing.T) {
 	rest.RequireStatus(t, response, http.StatusCreated)
 	require.NoError(t, rt.WaitForPendingChanges())
 
-	warnCountBefore := base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value()
 	base.AssertLogContains(t, "Ignoring non-metadata mutation for doc", func() {
 		err := rt.GetDatabase().MetadataStore.Set("doc1", 0, nil, db.Body{"foo": "bar"})
 		require.NoError(t, err)
@@ -4343,5 +4342,4 @@ func TestDocChangedLogging(t *testing.T) {
 		rest.RequireStatus(t, response, http.StatusCreated)
 		require.NoError(t, rt.WaitForPendingChanges())
 	})
-	assert.Equal(t, warnCountBefore, base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value())
 }


### PR DESCRIPTION

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2108/
