### PR TITLE
CBG-3437 [3.1.2 backport] Additional defensive checks in UpdateCalculatedStats

### DIFF
--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -24,9 +24,14 @@ import "context"
 // Update database-specific stats that are more efficiently calculated at stats collection time
 func (db *DatabaseContext) UpdateCalculatedStats(ctx context.Context) {
 
+	if db == nil || db.DbStats == nil {
+		return
+	}
 	db.changeCache.updateStats(ctx)
 	channelCache := db.changeCache.getChannelCache()
-	db.DbStats.Cache().ChannelCacheMaxEntries.Set(int64(channelCache.MaxCacheSize(ctx)))
-	db.DbStats.Cache().HighSeqCached.Set(int64(channelCache.GetHighCacheSequence()))
+	if channelCache != nil {
+		db.DbStats.Cache().ChannelCacheMaxEntries.Set(int64(channelCache.MaxCacheSize(ctx)))
+		db.DbStats.Cache().HighSeqCached.Set(int64(channelCache.GetHighCacheSequence()))
+	}
 
 }


### PR DESCRIPTION
Backports CBG-3122.
