### PR TITLE
CBG-3533 remove implicit default of http console logging

### DIFF
--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -225,9 +225,6 @@ func (lcc *ConsoleLoggerConfig) init() error {
 		return fmt.Errorf("invalid log level: %v", *lcc.LogLevel)
 	}
 
-	// Always enable the HTTP log key
-	lcc.LogKeys = append(lcc.LogKeys, logKeyNames[KeyHTTP])
-
 	// If ColorEnabled is not explicitly set, use the value of $SG_COLOR
 	if lcc.ColorEnabled == nil {
 		// Ignore error parsing this value to treat it as false.

--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -222,7 +222,8 @@ func TestConsoleLogDefaults(t *testing.T) {
 			expected: ConsoleLogger{
 				FileLogger: FileLogger{Enabled: AtomicBool{0}},
 				LogLevel:   logLevelPtr(LevelNone),
-				LogKeyMask: logKeyMask(KeyHTTP),
+				LogKeyMask: logKeyMask(KeyNone),
+				config:     ConsoleLoggerConfig{LogKeys: []string{}},
 				isStderr:   false,
 			},
 		},
@@ -232,7 +233,8 @@ func TestConsoleLogDefaults(t *testing.T) {
 			expected: ConsoleLogger{
 				FileLogger: FileLogger{Enabled: AtomicBool{1}},
 				LogLevel:   logLevelPtr(LevelInfo),
-				LogKeyMask: logKeyMask(KeyHTTP, KeyCRUD),
+				LogKeyMask: logKeyMask(KeyCRUD),
+				config:     ConsoleLoggerConfig{LogKeys: []string{"CRUD"}},
 				isStderr:   true,
 			},
 		},
@@ -242,7 +244,8 @@ func TestConsoleLogDefaults(t *testing.T) {
 			expected: ConsoleLogger{
 				FileLogger: FileLogger{Enabled: AtomicBool{1}},
 				LogLevel:   logLevelPtr(LevelWarn),
-				LogKeyMask: logKeyMask(KeyHTTP),
+				LogKeyMask: logKeyMask(KeyNone),
+				config:     ConsoleLoggerConfig{LogKeys: nil},
 				isStderr:   true,
 			},
 		},
@@ -252,7 +255,19 @@ func TestConsoleLogDefaults(t *testing.T) {
 			expected: ConsoleLogger{
 				FileLogger: FileLogger{Enabled: AtomicBool{1}},
 				LogLevel:   logLevelPtr(LevelWarn),
-				LogKeyMask: logKeyMask(KeyHTTP, KeyCRUD),
+				LogKeyMask: logKeyMask(KeyCRUD),
+				config:     ConsoleLoggerConfig{LogKeys: []string{"CRUD"}},
+				isStderr:   true,
+			},
+		},
+		{
+			name:   "http default",
+			config: ConsoleLoggerConfig{LogKeys: []string{"HTTP"}},
+			expected: ConsoleLogger{
+				FileLogger: FileLogger{Enabled: AtomicBool{1}},
+				LogLevel:   logLevelPtr(LevelInfo),
+				LogKeyMask: logKeyMask(KeyHTTP),
+				config:     ConsoleLoggerConfig{LogKeys: []string{"HTTP"}},
 				isStderr:   true,
 			},
 		},
@@ -267,6 +282,7 @@ func TestConsoleLogDefaults(t *testing.T) {
 			assert.Equal(tt, *test.expected.LogLevel, *logger.LogLevel)
 			assert.Equal(tt, *test.expected.LogKeyMask, *logger.LogKeyMask)
 			assert.Equal(tt, test.expected.isStderr, logger.isStderr)
+			assert.Equal(tt, test.expected.config.LogKeys, logger.config.LogKeys)
 		})
 	}
 }

--- a/base/logging.go
+++ b/base/logging.go
@@ -122,7 +122,7 @@ func init() {
 	// initializing a logging config, and when running under a test scenario.
 	initialCollationBufferSize := 0
 
-	consoleLogger = mustInitConsoleLogger(context.Background(), &ConsoleLoggerConfig{FileLoggerConfig: FileLoggerConfig{Enabled: BoolPtr(true), CollationBufferSize: &initialCollationBufferSize}})
+	consoleLogger = mustInitConsoleLogger(context.Background(), &ConsoleLoggerConfig{LogKeys: []string{logKeyNames[KeyHTTP]}, FileLoggerConfig: FileLoggerConfig{Enabled: BoolPtr(true), CollationBufferSize: &initialCollationBufferSize}})
 	initExternalLoggers()
 }
 

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -595,7 +595,7 @@ func TestSetTestLogging(t *testing.T) {
 
 	// Check default state of logging is as expected.
 	require.Equal(t, LevelInfo, *consoleLogger.LogLevel)
-	require.Equal(t, *logKeyMask(KeyHTTP), *consoleLogger.LogKeyMask)
+	require.Equal(t, *logKeyMask(KeyNone), *consoleLogger.LogKeyMask)
 
 	cleanup := setTestLogging(LevelDebug, "", KeyDCP, KeySync)
 	assert.Equal(t, LevelDebug, *consoleLogger.LogLevel)
@@ -603,7 +603,7 @@ func TestSetTestLogging(t *testing.T) {
 
 	cleanup()
 	assert.Equal(t, LevelInfo, *consoleLogger.LogLevel)
-	assert.Equal(t, *logKeyMask(KeyHTTP), *consoleLogger.LogKeyMask)
+	assert.Equal(t, *logKeyMask(KeyNone), *consoleLogger.LogKeyMask)
 
 	cleanup = setTestLogging(LevelNone, "", KeyNone)
 	assert.Equal(t, LevelNone, *consoleLogger.LogLevel)
@@ -611,7 +611,7 @@ func TestSetTestLogging(t *testing.T) {
 
 	cleanup()
 	assert.Equal(t, LevelInfo, *consoleLogger.LogLevel)
-	assert.Equal(t, *logKeyMask(KeyHTTP), *consoleLogger.LogKeyMask)
+	assert.Equal(t, *logKeyMask(KeyNone), *consoleLogger.LogKeyMask)
 
 	cleanup = setTestLogging(LevelDebug, "", KeyDCP, KeySync)
 	assert.Equal(t, LevelDebug, *consoleLogger.LogLevel)

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -595,7 +595,7 @@ func TestSetTestLogging(t *testing.T) {
 
 	// Check default state of logging is as expected.
 	require.Equal(t, LevelInfo, *consoleLogger.LogLevel)
-	require.Equal(t, *logKeyMask(KeyNone), *consoleLogger.LogKeyMask)
+	require.Equal(t, *logKeyMask(KeyHTTP), *consoleLogger.LogKeyMask)
 
 	cleanup := setTestLogging(LevelDebug, "", KeyDCP, KeySync)
 	assert.Equal(t, LevelDebug, *consoleLogger.LogLevel)
@@ -603,7 +603,7 @@ func TestSetTestLogging(t *testing.T) {
 
 	cleanup()
 	assert.Equal(t, LevelInfo, *consoleLogger.LogLevel)
-	assert.Equal(t, *logKeyMask(KeyNone), *consoleLogger.LogKeyMask)
+	require.Equal(t, *logKeyMask(KeyHTTP), *consoleLogger.LogKeyMask)
 
 	cleanup = setTestLogging(LevelNone, "", KeyNone)
 	assert.Equal(t, LevelNone, *consoleLogger.LogLevel)
@@ -611,7 +611,7 @@ func TestSetTestLogging(t *testing.T) {
 
 	cleanup()
 	assert.Equal(t, LevelInfo, *consoleLogger.LogLevel)
-	assert.Equal(t, *logKeyMask(KeyNone), *consoleLogger.LogKeyMask)
+	require.Equal(t, *logKeyMask(KeyHTTP), *consoleLogger.LogKeyMask)
 
 	cleanup = setTestLogging(LevelDebug, "", KeyDCP, KeySync)
 	assert.Equal(t, LevelDebug, *consoleLogger.LogLevel)

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -661,7 +661,7 @@ func setTestLogging(logLevel LogLevel, caller string, logKeys ...LogKey) (teardo
 	}
 
 	initialLogLevel := LevelInfo
-	initialLogKey := logKeyMask(KeyHTTP)
+	initialLogKey := logKeyMask(KeyNone)
 
 	// Check that a previous invocation has not forgotten to call teardownFn
 	if *consoleLogger.LogLevel != initialLogLevel ||

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -661,7 +661,7 @@ func setTestLogging(logLevel LogLevel, caller string, logKeys ...LogKey) (teardo
 	}
 
 	initialLogLevel := LevelInfo
-	initialLogKey := logKeyMask(KeyNone)
+	initialLogKey := logKeyMask(KeyHTTP)
 
 	// Check that a previous invocation has not forgotten to call teardownFn
 	if *consoleLogger.LogLevel != initialLogLevel ||

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1412,13 +1412,13 @@ func TestDefaultLogging(t *testing.T) {
 
 	require.NoError(t, config.SetupAndValidateLogging(base.TestCtx(t)))
 	assert.Equal(t, base.LevelNone, *base.ConsoleLogLevel())
-	assert.Equal(t, []string{"HTTP"}, base.ConsoleLogKey().EnabledLogKeys())
+	assert.Equal(t, []string{}, base.ConsoleLogKey().EnabledLogKeys())
 
 	// setting just a log key should enable logging
 	config.Logging.Console = &base.ConsoleLoggerConfig{LogKeys: []string{"CRUD"}}
 	require.NoError(t, config.SetupAndValidateLogging(base.TestCtx(t)))
 	assert.Equal(t, base.LevelInfo, *base.ConsoleLogLevel())
-	assert.Equal(t, []string{"CRUD", "HTTP"}, base.ConsoleLogKey().EnabledLogKeys())
+	assert.Equal(t, []string{"CRUD"}, base.ConsoleLogKey().EnabledLogKeys())
 }
 
 func TestSetupServerContext(t *testing.T) {

--- a/rest/handler_test.go
+++ b/rest/handler_test.go
@@ -84,6 +84,7 @@ func TestParseHTTPRangeHeader(t *testing.T) {
 
 func TestHTTPLoggingRedaction(t *testing.T) {
 
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 	base.LongRunningTest(t)
 	rt := NewRestTester(t, nil)
 	defer rt.Close()


### PR DESCRIPTION
Allows not streaming any logs (including HTTP logs) on capella.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2113/
