### PR TITLE
Fixes test without xattrs

### DIFF
--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -184,7 +184,10 @@ func DefaultDbConfig(sc *StartupConfig, useXattrs bool) *DbConfig {
 			dbConfig.ImportPartitions = base.Uint16Ptr(base.GetDefaultImportPartitions(sc.IsServerless()))
 		}
 
+	} else {
+		dbConfig.AutoImport = base.BoolPtr(false)
 	}
+
 	revsLimit := db.DefaultRevsLimitNoConflicts
 	if dbConfig.AllowConflicts != nil && *dbConfig.AllowConflicts {
 		revsLimit = db.DefaultRevsLimitConflicts

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -102,7 +102,7 @@ func DefaultPerDBLogging(bootstrapLoggingCnf base.LoggingConfig) *DbLoggingConfi
 // MergeDatabaseConfigWithDefaults merges the passed in config onto a DefaultDbConfig which results in returned value
 // being populated with defaults when not set
 func MergeDatabaseConfigWithDefaults(sc *StartupConfig, dbConfig *DbConfig) (*DbConfig, error) {
-	defaultDbConfig := DefaultDbConfig(sc)
+	defaultDbConfig := DefaultDbConfig(sc, dbConfig.UseXattrs())
 
 	err := base.ConfigMerge(defaultDbConfig, dbConfig)
 	if err != nil {
@@ -115,11 +115,7 @@ func MergeDatabaseConfigWithDefaults(sc *StartupConfig, dbConfig *DbConfig) (*Db
 // DefaultDbConfig provides a DbConfig with all the default values populated. Used with MergeDatabaseConfigWithDefaults
 // to provide defaults to  include_runtime config endpoints.
 // Note that this does not include unsupported options
-func DefaultDbConfig(sc *StartupConfig) *DbConfig {
-	var partitions *uint16
-	if base.IsEnterpriseEdition() {
-		partitions = base.Uint16Ptr(base.GetDefaultImportPartitions(sc.IsServerless()))
-	}
+func DefaultDbConfig(sc *StartupConfig, useXattrs bool) *DbConfig {
 	dbConfig := DbConfig{
 		BucketConfig:       BucketConfig{},
 		Name:               "",
@@ -127,8 +123,6 @@ func DefaultDbConfig(sc *StartupConfig) *DbConfig {
 		Users:              nil,
 		Roles:              nil,
 		RevsLimit:          nil, // Set this below struct
-		AutoImport:         base.BoolPtr(base.DefaultAutoImport),
-		ImportPartitions:   partitions,
 		ImportFilter:       nil,
 		ImportBackupOldRev: base.BoolPtr(false),
 		EventHandlers:      nil,
@@ -184,6 +178,13 @@ func DefaultDbConfig(sc *StartupConfig) *DbConfig {
 		Logging:                          DefaultPerDBLogging(sc.Logging),
 	}
 
+	if useXattrs {
+		dbConfig.AutoImport = base.BoolPtr(base.DefaultAutoImport)
+		if base.IsEnterpriseEdition() {
+			dbConfig.ImportPartitions = base.Uint16Ptr(base.GetDefaultImportPartitions(sc.IsServerless()))
+		}
+
+	}
 	revsLimit := db.DefaultRevsLimitNoConflicts
 	if dbConfig.AllowConflicts != nil && *dbConfig.AllowConflicts {
 		revsLimit = db.DefaultRevsLimitConflicts

--- a/rest/config_database_test.go
+++ b/rest/config_database_test.go
@@ -17,7 +17,8 @@ import (
 )
 
 func TestDefaultDbConfig(t *testing.T) {
+	useXattrs := true
 	sc := DefaultStartupConfig("")
-	compactIntervalDays := *(DefaultDbConfig(&sc).CompactIntervalDays)
+	compactIntervalDays := *(DefaultDbConfig(&sc, useXattrs).CompactIntervalDays)
 	require.Equal(t, db.DefaultCompactInterval, time.Duration(compactIntervalDays)*time.Hour*24)
 }

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -752,7 +752,7 @@ func TestImportPartitionsServerless(t *testing.T) {
 				RequireStatus(t, resp, http.StatusCreated)
 				dbconf = sc.GetDbConfig("db")
 			} else {
-				dbconf = DefaultDbConfig(sc.Config)
+				dbconf = DefaultDbConfig(sc.Config, rt.GetDatabase().UseXattrs())
 			}
 
 			assert.Equal(t, expectedPartitions, dbconf.ImportPartitions)


### PR DESCRIPTION
- use RestTester.NewDbConfig() to produce a db config that works with SG_TEST_USE_XATTRS=false
- explicitly use NewRestTesterDefaultCollection so the test is going to in the default setting and actually run regularly

From https://jenkins.sgwdev.com/job/weekly-matrix/BACKING_STORE=enterprise-7.2.0,QUERY_PROVIDER=views,SYNC_STORE=inline,label=sgw-amazon-linux2023/89/

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2121/
- [x] `GSI=false,xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2118/