### PR TITLE
CBG-3549 Move retry handling out of BucketSpec

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -124,8 +124,6 @@ type BucketSpec struct {
 	Certpath, Keypath, CACertPath string         // X.509 auth parameters
 	TLSSkipVerify                 bool           // Use insecureSkipVerify when secure scheme (couchbases) is used and cacertpath is undefined
 	KvTLSPort                     int            // Port to use for memcached over TLS.  Required for cbdatasource auth when using TLS
-	MaxNumRetries                 int            // max number of retries before giving up
-	InitialRetrySleepTimeMS       int            // the initial time to sleep in between retry attempts (in millisecond), which will double each retry
 	UseXattrs                     bool           // Whether to use xattrs to store _sync metadata.  Used during view initialization
 	ViewQueryTimeoutSecs          *uint32        // the view query timeout in seconds (default: 75 seconds)
 	MaxConcurrentQueryOps         *int           // maximum number of concurrent query operations (default: DefaultMaxConcurrentQueryOps)
@@ -135,13 +133,12 @@ type BucketSpec struct {
 	DcpBuffer                     int            // gocb dcp buffer size inititialised on the gocb connection string
 }
 
-// Create a RetrySleeper based on the bucket spec properties.  Used to retry bucket operations after transient errors.
-func (spec BucketSpec) RetrySleeper() RetrySleeper {
-	return CreateDoublingSleeperFunc(spec.MaxNumRetries, spec.InitialRetrySleepTimeMS)
-}
+const defaultNumRetries = 10
+const defaultInitialRetryMS = 5
 
-func (spec BucketSpec) MaxRetrySleeper(maxSleepMs int) RetrySleeper {
-	return CreateMaxDoublingSleeperFunc(spec.MaxNumRetries, spec.InitialRetrySleepTimeMS, maxSleepMs)
+// Create a RetrySleeper based on the default properties.  Used to retry bucket operations after transient errors.
+func DefaultRetrySleeper() RetrySleeper {
+	return CreateDoublingSleeperFunc(defaultNumRetries, defaultInitialRetryMS)
 }
 
 func (spec BucketSpec) IsWalrusBucket() bool {

--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -150,7 +150,7 @@ func (c *Collection) SubdocGetRaw(ctx context.Context, k string, subdocKey strin
 		return false, nil, uint64(res.Cas())
 	}
 
-	err, casOut := RetryLoopCas(ctx, "SubdocGetRaw", worker, c.Bucket.Spec.RetrySleeper())
+	err, casOut := RetryLoopCas(ctx, "SubdocGetRaw", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "SubdocGetRaw with key %s and subdocKey %s", UD(k).Redact(), UD(subdocKey).Redact())
 	}
@@ -183,7 +183,7 @@ func (c *Collection) SubdocWrite(ctx context.Context, k string, subdocKey string
 		return false, err, 0
 	}
 
-	err, casOut := RetryLoopCas(ctx, "SubdocWrite", worker, c.Bucket.Spec.RetrySleeper())
+	err, casOut := RetryLoopCas(ctx, "SubdocWrite", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "SubdocWrite with key %s and subdocKey %s", UD(k).Redact(), UD(subdocKey).Redact())
 	}
@@ -272,7 +272,7 @@ func (c *Collection) SubdocGetBodyAndXattr(ctx context.Context, k string, xattrK
 	}
 
 	// Kick off retry loop
-	err, cas = RetryLoopCas(ctx, "SubdocGetBodyAndXattr", worker, c.Bucket.Spec.RetrySleeper())
+	err, cas = RetryLoopCas(ctx, "SubdocGetBodyAndXattr", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "SubdocGetBodyAndXattr %v", UD(k).Redact())
 	}

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -65,7 +65,7 @@ func WriteCasWithXattr(ctx context.Context, store *Collection, k string, xattrKe
 	}
 
 	// Kick off retry loop
-	err, cas = RetryLoopCas(ctx, "WriteCasWithXattr", worker, store.GetSpec().RetrySleeper())
+	err, cas = RetryLoopCas(ctx, "WriteCasWithXattr", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "WriteCasWithXattr with key %v", UD(k).Redact())
 	}
@@ -118,7 +118,7 @@ func UpdateTombstoneXattr(ctx context.Context, store *Collection, k string, xatt
 	}
 
 	// Kick off retry loop
-	err, cas = RetryLoopCas(ctx, "UpdateTombstoneXattr", worker, store.GetSpec().RetrySleeper())
+	err, cas = RetryLoopCas(ctx, "UpdateTombstoneXattr", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "Error during UpdateTombstoneXattr with key %v", UD(k).Redact())
 		return cas, err
@@ -145,7 +145,7 @@ func UpdateTombstoneXattr(ctx context.Context, store *Collection, k string, xatt
 			return false, nil, casOut
 		}
 
-		err, cas = RetryLoopCas(ctx, "UpdateXattrDeleteBodySecondOp", worker, store.GetSpec().RetrySleeper())
+		err, cas = RetryLoopCas(ctx, "UpdateXattrDeleteBodySecondOp", worker, DefaultRetrySleeper())
 		if err != nil {
 			err = pkgerrors.Wrapf(err, "Error during UpdateTombstoneXattr delete op with key %v", UD(k).Redact())
 			return cas, err
@@ -261,7 +261,7 @@ func SetXattr(ctx context.Context, store *Collection, k string, xattrKey string,
 		return false, writeErr, 0
 	}
 
-	err, casOut = RetryLoopCas(ctx, "SetXattr", worker, store.GetSpec().RetrySleeper())
+	err, casOut = RetryLoopCas(ctx, "SetXattr", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "SetXattr with key %v", UD(k).Redact())
 	}
@@ -286,7 +286,7 @@ func RemoveXattr(ctx context.Context, store *Collection, k string, xattrKey stri
 		return false, err, nil
 	}
 
-	err, _ := RetryLoop(ctx, "RemoveXattr", worker, store.GetSpec().RetrySleeper())
+	err, _ := RetryLoop(ctx, "RemoveXattr", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "RemoveXattr with key %v xattr %v", UD(k).Redact(), UD(xattrKey).Redact())
 	}
@@ -311,7 +311,7 @@ func DeleteXattrs(ctx context.Context, store *Collection, k string, xattrKeys ..
 		return false, err, nil
 	}
 
-	err, _ := RetryLoop(ctx, "DeleteXattrs", worker, store.GetSpec().RetrySleeper())
+	err, _ := RetryLoop(ctx, "DeleteXattrs", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "DeleteXattrs with keys %q xattr %v", UD(k).Redact(), UD(strings.Join(xattrKeys, ",")).Redact())
 	}

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -365,9 +365,8 @@ func (lds *LeakyDataStore) GetSpec() BucketSpec {
 	} else {
 		// Return a minimal struct:
 		return BucketSpec{
-			BucketName:    lds.bucket.GetName(),
-			MaxNumRetries: 1,
-			UseXattrs:     true,
+			BucketName: lds.bucket.GetName(),
+			UseXattrs:  true,
 		}
 	}
 }


### PR DESCRIPTION
We no longer have a use case for spec-specific retry handling, and the previous approach made it easy to omit default values.  Move to fixed default values for retry regardless of bucket spec.

CBG-3549

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2123/
