### PR TITLE
CBG-3550 [3.1.2 backport] Move retry handling out of BucketSpec

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -124,8 +124,6 @@ type BucketSpec struct {
 	Certpath, Keypath, CACertPath string         // X.509 auth parameters
 	TLSSkipVerify                 bool           // Use insecureSkipVerify when secure scheme (couchbases) is used and cacertpath is undefined
 	KvTLSPort                     int            // Port to use for memcached over TLS.  Required for cbdatasource auth when using TLS
-	MaxNumRetries                 int            // max number of retries before giving up
-	InitialRetrySleepTimeMS       int            // the initial time to sleep in between retry attempts (in millisecond), which will double each retry
 	UseXattrs                     bool           // Whether to use xattrs to store _sync metadata.  Used during view initialization
 	ViewQueryTimeoutSecs          *uint32        // the view query timeout in seconds (default: 75 seconds)
 	MaxConcurrentQueryOps         *int           // maximum number of concurrent query operations (default: DefaultMaxConcurrentQueryOps)
@@ -135,13 +133,12 @@ type BucketSpec struct {
 	DcpBuffer                     int            // gocb dcp buffer size inititialised on the gocb connection string
 }
 
-// Create a RetrySleeper based on the bucket spec properties.  Used to retry bucket operations after transient errors.
-func (spec BucketSpec) RetrySleeper() RetrySleeper {
-	return CreateDoublingSleeperFunc(spec.MaxNumRetries, spec.InitialRetrySleepTimeMS)
-}
+const defaultNumRetries = 10
+const defaultInitialRetryMS = 5
 
-func (spec BucketSpec) MaxRetrySleeper(maxSleepMs int) RetrySleeper {
-	return CreateMaxDoublingSleeperFunc(spec.MaxNumRetries, spec.InitialRetrySleepTimeMS, maxSleepMs)
+// Create a RetrySleeper based on the default properties.  Used to retry bucket operations after transient errors.
+func DefaultRetrySleeper() RetrySleeper {
+	return CreateDoublingSleeperFunc(defaultNumRetries, defaultInitialRetryMS)
 }
 
 func (spec BucketSpec) IsWalrusBucket() bool {

--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -157,7 +157,7 @@ func (c *Collection) SubdocGetRaw(ctx context.Context, k string, subdocKey strin
 		return false, nil, uint64(res.Cas())
 	}
 
-	err, casOut := RetryLoopCas(ctx, "SubdocGetRaw", worker, c.Bucket.Spec.RetrySleeper())
+	err, casOut := RetryLoopCas(ctx, "SubdocGetRaw", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "SubdocGetRaw with key %s and subdocKey %s", UD(k).Redact(), UD(subdocKey).Redact())
 	}
@@ -190,7 +190,7 @@ func (c *Collection) SubdocWrite(ctx context.Context, k string, subdocKey string
 		return false, err, 0
 	}
 
-	err, casOut := RetryLoopCas(ctx, "SubdocWrite", worker, c.Bucket.Spec.RetrySleeper())
+	err, casOut := RetryLoopCas(ctx, "SubdocWrite", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "SubdocWrite with key %s and subdocKey %s", UD(k).Redact(), UD(subdocKey).Redact())
 	}
@@ -279,7 +279,7 @@ func (c *Collection) SubdocGetBodyAndXattr(ctx context.Context, k string, xattrK
 	}
 
 	// Kick off retry loop
-	err, cas = RetryLoopCas(ctx, "SubdocGetBodyAndXattr", worker, c.Bucket.Spec.RetrySleeper())
+	err, cas = RetryLoopCas(ctx, "SubdocGetBodyAndXattr", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "SubdocGetBodyAndXattr %v", UD(k).Redact())
 	}

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -91,7 +91,7 @@ func WriteCasWithXattr(ctx context.Context, store SubdocXattrStore, k string, xa
 	}
 
 	// Kick off retry loop
-	err, cas = RetryLoopCas(ctx, "WriteCasWithXattr", worker, store.GetSpec().RetrySleeper())
+	err, cas = RetryLoopCas(ctx, "WriteCasWithXattr", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "WriteCasWithXattr with key %v", UD(k).Redact())
 	}
@@ -144,7 +144,7 @@ func UpdateTombstoneXattr(ctx context.Context, store SubdocXattrStore, k string,
 	}
 
 	// Kick off retry loop
-	err, cas = RetryLoopCas(ctx, "UpdateTombstoneXattr", worker, store.GetSpec().RetrySleeper())
+	err, cas = RetryLoopCas(ctx, "UpdateTombstoneXattr", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "Error during UpdateTombstoneXattr with key %v", UD(k).Redact())
 		return cas, err
@@ -171,7 +171,7 @@ func UpdateTombstoneXattr(ctx context.Context, store SubdocXattrStore, k string,
 			return false, nil, casOut
 		}
 
-		err, cas = RetryLoopCas(ctx, "UpdateXattrDeleteBodySecondOp", worker, store.GetSpec().RetrySleeper())
+		err, cas = RetryLoopCas(ctx, "UpdateXattrDeleteBodySecondOp", worker, DefaultRetrySleeper())
 		if err != nil {
 			err = pkgerrors.Wrapf(err, "Error during UpdateTombstoneXattr delete op with key %v", UD(k).Redact())
 			return cas, err
@@ -278,7 +278,7 @@ func SetXattr(ctx context.Context, store SubdocXattrStore, k string, xattrKey st
 		return false, writeErr, 0
 	}
 
-	err, casOut = RetryLoopCas(ctx, "SetXattr", worker, store.GetSpec().RetrySleeper())
+	err, casOut = RetryLoopCas(ctx, "SetXattr", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "SetXattr with key %v", UD(k).Redact())
 	}
@@ -303,7 +303,7 @@ func RemoveXattr(ctx context.Context, store SubdocXattrStore, k string, xattrKey
 		return false, err, nil
 	}
 
-	err, _ := RetryLoop(ctx, "RemoveXattr", worker, store.GetSpec().RetrySleeper())
+	err, _ := RetryLoop(ctx, "RemoveXattr", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "RemoveXattr with key %v xattr %v", UD(k).Redact(), UD(xattrKey).Redact())
 	}
@@ -328,7 +328,7 @@ func DeleteXattrs(ctx context.Context, store SubdocXattrStore, k string, xattrKe
 		return false, err, nil
 	}
 
-	err, _ := RetryLoop(ctx, "DeleteXattrs", worker, store.GetSpec().RetrySleeper())
+	err, _ := RetryLoop(ctx, "DeleteXattrs", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "DeleteXattrs with keys %q xattr %v", UD(k).Redact(), UD(strings.Join(xattrKeys, ",")).Redact())
 	}


### PR DESCRIPTION
Backports CBG-3549 to 3.1.2.
