### PR TITLE
CBG-3516: Release sequences in ranges if allocating a sequence lower than a previously seen sequence

### DIFF
--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1664,7 +1664,7 @@ func TestAssignSequenceReleaseLoop(t *testing.T) {
 	err = db.sequences.datastore.Delete(db.sequences.metaKeys.SyncSeqKey())
 	require.NoError(t, err)
 
-	rev, doc, err = collection.Put(ctx, "doc1", Body{"foo": "buzz", BodyRev: rev})
+	_, doc, err = collection.Put(ctx, "doc1", Body{"foo": "buzz", BodyRev: rev})
 	require.NoError(t, err)
 	require.Greaterf(t, doc.Sequence, endSeq, "Expected doc sequence %d to be greater than end sequence %d", doc.Sequence, endSeq)
 	t.Logf("doc sequence: %d", doc.Sequence)

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -384,7 +384,6 @@ func (s *sequenceAllocator) nextSequenceGreaterThan(ctx context.Context, existin
 
 	err = s.releaseSequences(ctx, sequencesToRelease)
 	if err != nil {
-		s.mutex.Unlock()
 		return 0, err
 	}
 


### PR DESCRIPTION
CBG-3516

Writes a test to reproduce the scenario where the `_sync:seq` doc has been lowered, or we're seeing documents being updated that came from different clusters (with higher sequence numbers)

Existing behaviour was to release sequences all the way from the current sequence up to the new high sequence - one at a time. This PR changes that to release sequences in ranges, wherever possible, but retains the existing functional behaviour.

Added a warning if the sequence gap is much larger than expected (`100 * maxBatchSize`) - there are situations where other SG nodes have reserved a batch of sequences and haven't used them yet.

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2128/
