### PR TITLE
CBG-3553 add bucket.Close() when opening the database

### DIFF
--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -71,11 +71,14 @@ func newSequenceAllocator(ctx context.Context, datastore base.DataStore, dbStats
 
 	// The reserveNotify channel manages communication between the releaseSequenceMonitor goroutine and _reserveSequenceRange invocations.
 	s.reserveNotify = make(chan struct{}, 1)
+	_, err := s.lastSequence(ctx) // just reads latest sequence from bucket
+	if err != nil {
+		return nil, err
+	}
 	go func() {
 		defer base.FatalPanicHandler()
 		s.releaseSequenceMonitor(ctx)
 	}()
-	_, err := s.lastSequence(ctx) // just reads latest sequence from bucket
 	return s, err
 }
 

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -155,7 +155,7 @@ func (s *sequenceAllocator) lastSequence(ctx context.Context) (uint64, error) {
 	s.dbStats.SequenceGetCount.Add(1)
 	last, err := s.getSequence()
 	if err != nil {
-		base.WarnfCtx(ctx, "Error from Get in getSequence(): %v", err)
+		return 0, fmt.Errorf("Couldn't get sequence from bucket: %w", err)
 	}
 	return last, err
 }

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -170,7 +170,7 @@ func (h *handler) handleCreateDB() error {
 			if errors.Is(err, base.ErrAuthError) {
 				return base.HTTPErrorf(http.StatusForbidden, "auth failure using provided bucket credentials for database %s", base.MD(config.Name))
 			}
-			return err
+			return base.HTTPErrorf(http.StatusInternalServerError, "couldn't load database: %v", err)
 		}
 	}
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -498,7 +498,9 @@ func GetBucketSpec(ctx context.Context, config *DatabaseConfig, serverConfig *St
 // lock to see if it's already been added by another process. If so, returns either the
 // existing DatabaseContext or an error based on the useExisting flag.
 // Pass in a bucketFromBucketSpecFn to replace the default ConnectToBucket function. This will cause the failFast argument to be ignored
-func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config DatabaseConfig, options getOrAddDatabaseConfigOptions) (*db.DatabaseContext, error) {
+func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config DatabaseConfig, options getOrAddDatabaseConfigOptions) (dbcontext *db.DatabaseContext, returnedError error) {
+	var bucket base.Bucket
+
 	// Generate bucket spec and validate whether db already exists
 	spec, err := GetBucketSpec(ctx, &config, sc.Config)
 	if err != nil {
@@ -509,6 +511,17 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	if dbName == "" {
 		dbName = spec.BucketName
 	}
+	defer func() {
+		if returnedError != nil {
+			_, dbRegistered := sc.databases_[dbName]
+			if !dbRegistered && dbcontext != nil {
+				dbcontext.Close(ctx) // will close bucket
+			} else if bucket != nil {
+				bucket.Close(ctx)
+			}
+		}
+	}()
+
 	if spec.Server == "" {
 		spec.Server = sc.Config.Bootstrap.Server
 	}
@@ -549,7 +562,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		base.MD(dbName), base.MD(spec.BucketName), base.SD(base.DefaultPool), base.SD(spec.Server))
 
 	// the connectToBucketFn is used for testing seam
-	var bucket base.Bucket
 	if options.connectToBucketFn != nil {
 		// the connectToBucketFn is used for testing seam
 		bucket, err = options.connectToBucketFn(ctx, spec, options.failFast)
@@ -841,7 +853,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 
 	contextOptions.BlipStatsReportingInterval = defaultBytesStatsReportingInterval.Milliseconds()
 	// Create the DB Context
-	dbcontext, err := db.NewDatabaseContext(ctx, dbName, bucket, autoImport, contextOptions)
+	dbcontext, err = db.NewDatabaseContext(ctx, dbName, bucket, autoImport, contextOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -930,7 +930,7 @@ func TestCompactIntervalFromConfig(t *testing.T) {
 }
 
 func TestFailedDatabaseContextBadSyncSeq(t *testing.T) {
-	rt := NewRestTesterPersistentConfig(t)
+	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
 	defer rt.Close()
 
 	dbName := "testdb"

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -928,19 +928,3 @@ func TestCompactIntervalFromConfig(t *testing.T) {
 		})
 	}
 }
-
-func TestFailedDatabaseContextBadSyncSeq(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
-	defer rt.Close()
-
-	dbName := "testdb"
-	metadataKeys := base.NewMetadataKeys(dbName)
-	if base.UnitTestUrlIsWalrus() { // hack until rosmar supports bootstrap config CBG-3271
-		metadataKeys = base.DefaultMetadataKeys
-	}
-	// create invalid non integer sync:seq doc
-	_, err := rt.Bucket().DefaultDataStore().AddRaw(metadataKeys.SyncSeqKey(), 0, []byte(`"00000"`))
-	require.NoError(t, err)
-
-	RequireStatus(t, rt.CreateDatabase(dbName, rt.NewDbConfig()), http.StatusInternalServerError)
-}


### PR DESCRIPTION
- add dbcontext.Close if there's a failure after dbContext is open
- modify non persistent config PUT /db/ config code to return 500 to match error codes on error for persistent config (previously returned 400)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2132/ (minus failure fixed in https://github.com/couchbase/sync_gateway/pull/6546/commits/760ec92fd791c86938e3012196d794855a624268)
