### PR TITLE
CBG-3516 Implement nextSequenceGreaterThan to reduce incr and unused seq traffic

### DIFF
--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -44,8 +44,8 @@ type ChannelCache interface {
 	// Notifies the cache of a principal update.  Updates the cache's high sequence
 	AddPrincipal(change *LogEntry)
 
-	// Notifies the cache of a skipped sequence update. Updates the cache's high sequence
-	AddSkippedSequence(change *LogEntry)
+	// Notifies the cache of an unused sequence update. Updates the cache's high sequence
+	AddUnusedSequence(change *LogEntry)
 
 	// Remove purges the given doc IDs from all channel caches and returns the number of items removed.
 	Remove(ctx context.Context, collectionID uint32, docIDs []string, startTime time.Time) (count int)
@@ -191,8 +191,8 @@ func (c *channelCacheImpl) AddPrincipal(change *LogEntry) {
 	c.updateHighCacheSequence(change.Sequence)
 }
 
-// AddSkipedSequence notifies the cache of a skipped sequence update. Updates the cache's high sequence
-func (c *channelCacheImpl) AddSkippedSequence(change *LogEntry) {
+// Add unused Sequence notifies the cache of an unused sequence update. Updates the cache's high sequence
+func (c *channelCacheImpl) AddUnusedSequence(change *LogEntry) {
 	c.updateHighCacheSequence(change.Sequence)
 }
 

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1664,7 +1664,7 @@ func TestAssignSequenceReleaseLoop(t *testing.T) {
 	err = db.sequences.datastore.Delete(db.sequences.metaKeys.SyncSeqKey())
 	require.NoError(t, err)
 
-	rev, doc, err = collection.Put(ctx, "doc1", Body{"foo": "buzz", BodyRev: rev})
+	_, doc, err = collection.Put(ctx, "doc1", Body{"foo": "buzz", BodyRev: rev})
 	require.NoError(t, err)
 	require.Greaterf(t, doc.Sequence, endSeq, "Expected doc sequence %d to be greater than end sequence %d", doc.Sequence, endSeq)
 	t.Logf("doc sequence: %d", doc.Sequence)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1648,10 +1648,6 @@ func TestAssignSequenceReleaseLoop(t *testing.T) {
 	require.NoError(t, err)
 	t.Logf("doc sequence: %d", doc.Sequence)
 
-	// resetting or lowering sequence isn't supported - you'll end up with duplicate assigned sequences
-	//err = db.sequences.datastore.Delete(db.sequences.metaKeys.SyncSeqKey())
-	//require.NoError(t, err)
-
 	// but we can fiddle with the sequence in the metadata of the doc write to simulate a doc from a different cluster (with a higher sequence)
 	var newSyncData map[string]interface{}
 	sd, err := json.Marshal(doc.SyncData)
@@ -1665,7 +1661,6 @@ func TestAssignSequenceReleaseLoop(t *testing.T) {
 	_, doc, err = collection.Put(ctx, "doc1", Body{"foo": "buzz", BodyRev: rev})
 	require.NoError(t, err)
 	require.Greaterf(t, doc.Sequence, uint64(otherClusterSequenceOffset), "Expected new doc sequence %d to be greater than other cluster's sequence %d", doc.Sequence, otherClusterSequenceOffset)
-	t.Logf("doc sequence: %d", doc.Sequence)
 
 	// wait for the doc to be received
 	err = db.changeCache.waitForSequence(ctx, doc.Sequence, time.Second*30)

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -384,7 +384,6 @@ func (s *sequenceAllocator) nextSequenceGreaterThan(ctx context.Context, existin
 
 	err = s.releaseSequences(ctx, sequencesToRelease)
 	if err != nil {
-		s.mutex.Unlock()
 		return 0, err
 	}
 

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -318,7 +318,9 @@ func TestNextSequenceGreaterThanMultiNode(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 	statsA, err := stats.NewDBStats("A", false, false, false, nil, nil)
+	require.NoError(t, err)
 	statsB, err := stats.NewDBStats("B", false, false, false, nil, nil)
+	require.NoError(t, err)
 	dbStatsA := statsA.DatabaseStats
 	dbStatsB := statsB.DatabaseStats
 

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -235,58 +235,144 @@ func assertNewAllocatorStats(t *testing.T, stats *base.DatabaseStats, incr, rese
 	assert.Equal(t, released, stats.SequenceReleasedCount.Value())
 }
 
-func Test_findSequenceRanges(t *testing.T) {
-	tests := []struct {
-		name      string
-		sequences []uint64
-		expected  []seqRange
-		error     string
-	}{
-		{
-			name:      "empty",
-			sequences: []uint64{},
-			expected:  []seqRange{},
-		},
-		{
-			name:      "single",
-			sequences: []uint64{1},
-			expected:  []seqRange{{1, 1}},
-		},
-		{
-			name:      "single gap",
-			sequences: []uint64{1, 3},
-			expected:  []seqRange{{1, 1}, {3, 3}},
-		},
-		{
-			name:      "single range",
-			sequences: []uint64{1, 2, 3},
-			expected:  []seqRange{{1, 3}},
-		},
-		{
-			name:      "multiple ranges",
-			sequences: []uint64{1, 2, 3, 5, 6, 7, 9, 10, 11},
-			expected:  []seqRange{{1, 3}, {5, 7}, {9, 11}},
-		},
-		{
-			name:      "multiple ranges and singles",
-			sequences: []uint64{1, 2, 3, 5, 7, 9, 10, 11, 13},
-			expected:  []seqRange{{1, 3}, {5, 5}, {7, 7}, {9, 11}, {13, 13}},
-		},
-		{
-			name:      "out of order",
-			sequences: []uint64{1, 2, 5, 4, 3},
-			error:     "input not ordered",
-		},
+func TestNextSequenceGreaterThanSingleNode(t *testing.T) {
+
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	sgw, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err := sgw.NewDBStats("", false, false, false, nil, nil)
+	require.NoError(t, err)
+	testStats := dbstats.Database()
+
+	// Create a sequence allocator without using constructor, to test without a releaseSequenceMonitor
+	// Set sequenceBatchSize=10 to test variations of batching
+	a := &sequenceAllocator{
+		datastore:         bucket.GetSingleDataStore(),
+		dbStats:           testStats,
+		sequenceBatchSize: 10,                      // set initial batch size to 10 to support all test cases
+		reserveNotify:     make(chan struct{}, 50), // Buffered to allow multiple allocations without releaseSequenceMonitor
+		metaKeys:          base.DefaultMetadataKeys,
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			actual, err := findSequenceRanges(tt.sequences)
-			if tt.error == "" {
-				require.NoError(t, err)
-			} else {
-				require.ErrorContains(t, err, tt.error)
-			}
-			assert.Equalf(t, tt.expected, actual, "findSequenceRanges(%v)", tt.sequences)
-		})
+
+	initSequence, err := a.lastSequence(ctx)
+	assert.Equal(t, uint64(0), initSequence)
+	assert.NoError(t, err, "error retrieving last sequence")
+
+	// nextSequenceGreaterThan(0) should perform initial batch allocation of size 10,  and not release any sequences
+	nextSequence, err := a.nextSequenceGreaterThan(ctx, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(1), nextSequence)
+	assertNewAllocatorStats(t, testStats, 1, 10, 1, 0) // incr, reserved, assigned, released counts
+
+	// Calling the same again should use from the existing batch
+	nextSequence, err = a.nextSequenceGreaterThan(ctx, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(2), nextSequence)
+	assertNewAllocatorStats(t, testStats, 1, 10, 2, 0)
+
+	// Test case where greaterThan == s.Last + 1
+	nextSequence, err = a.nextSequenceGreaterThan(ctx, 2)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(3), nextSequence)
+	assertNewAllocatorStats(t, testStats, 1, 10, 3, 0)
+
+	// When requested nextSequenceGreaterThan is > s.Last + 1, we should release previously allocated sequences but
+	// don't require a new incr
+	nextSequence, err = a.nextSequenceGreaterThan(ctx, 5)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(6), nextSequence)
+	assertNewAllocatorStats(t, testStats, 1, 10, 4, 2)
+
+	// Test when requested nextSequenceGreaterThan == s.Max; should release previously allocated sequences and allocate a new batch
+	nextSequence, err = a.nextSequenceGreaterThan(ctx, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(11), nextSequence)
+	assertNewAllocatorStats(t, testStats, 2, 20, 5, 6)
+
+	// Test when requested nextSequenceGreaterThan = s.Max + 1; should release previously allocated sequences AND max+1
+	nextSequence, err = a.nextSequenceGreaterThan(ctx, 21)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(22), nextSequence)
+	assertNewAllocatorStats(t, testStats, 3, 31, 6, 16)
+
+	// Test when requested nextSequenceGreaterThan > s.Max + batch size; should release 9 previously allocated sequences (23-31)
+	// and 19 in the gap to the requested sequence (32-50)
+	nextSequence, err = a.nextSequenceGreaterThan(ctx, 50)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(51), nextSequence)
+	assertNewAllocatorStats(t, testStats, 4, 60, 7, 44)
+
+}
+
+func TestNextSequenceGreaterThanMultiNode(t *testing.T) {
+
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	// Create two sequence allocators without using constructor, to test without a releaseSequenceMonitor
+	// Set sequenceBatchSize=10 to test variations of batching
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	statsA, err := stats.NewDBStats("A", false, false, false, nil, nil)
+	statsB, err := stats.NewDBStats("B", false, false, false, nil, nil)
+	dbStatsA := statsA.DatabaseStats
+	dbStatsB := statsB.DatabaseStats
+
+	require.NoError(t, err)
+	a := &sequenceAllocator{
+		datastore:         bucket.GetSingleDataStore(),
+		dbStats:           dbStatsA,
+		sequenceBatchSize: 10,                      // set initial batch size to 10 to support all test cases
+		reserveNotify:     make(chan struct{}, 50), // Buffered to allow multiple allocations without releaseSequenceMonitor
+		metaKeys:          base.DefaultMetadataKeys,
 	}
+
+	b := &sequenceAllocator{
+		datastore:         bucket.GetSingleDataStore(),
+		dbStats:           dbStatsB,
+		sequenceBatchSize: 10,                      // set initial batch size to 10 to support all test cases
+		reserveNotify:     make(chan struct{}, 50), // Buffered to allow multiple allocations without releaseSequenceMonitor
+		metaKeys:          base.DefaultMetadataKeys,
+	}
+
+	initSequence, err := a.lastSequence(ctx)
+	assert.Equal(t, uint64(0), initSequence)
+	assert.NoError(t, err, "error retrieving last sequence")
+
+	initSequence, err = b.lastSequence(ctx)
+	assert.Equal(t, uint64(0), initSequence)
+	assert.NoError(t, err, "error retrieving last sequence")
+
+	// nextSequenceGreaterThan(0) on A should perform initial batch allocation of size 10 (allocs 1-10),  and not release any sequences
+	nextSequence, err := a.nextSequenceGreaterThan(ctx, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(1), nextSequence)
+	assertNewAllocatorStats(t, dbStatsA, 1, 10, 1, 0) // incr, reserved, assigned, released counts
+
+	// nextSequenceGreaterThan(0) on B should perform initial batch allocation of size 10 (allocs 11-20),  and not release any sequences
+	nextSequence, err = b.nextSequenceGreaterThan(ctx, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(11), nextSequence)
+	assertNewAllocatorStats(t, dbStatsB, 1, 10, 1, 0)
+
+	// calling nextSequenceGreaterThan(15) on B will assign from the existing batch, and release 12-15
+	nextSequence, err = b.nextSequenceGreaterThan(ctx, 15)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(16), nextSequence)
+	assertNewAllocatorStats(t, dbStatsB, 1, 10, 2, 4)
+
+	// calling nextSequenceGreaterThan(15) on A will increment _sync:seq by 5 on it's previously allocated sequence (10).
+	// Since node B has already updated _sync:seq to 20, will result in:
+	//   node A releasing sequences 2-10 from it's existing buffer
+	//   node A allocating and releasing sequences 21-24
+	//   node A adding sequences 25-35 to its buffer, and assigning 25 to the current request
+	nextSequence, err = a.nextSequenceGreaterThan(ctx, 15)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(26), nextSequence)
+	assertNewAllocatorStats(t, dbStatsA, 2, 25, 2, 14)
+
 }


### PR DESCRIPTION
CBG-3516

Adds nextSequenceGreaterThan to the sequenceAllocator.  In cases where the target sequence is greater than the previous max sequence in the allocator, performs a single incr to reach the target sequence, and writes a single unused sequence range document to release the intermediate sequences.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2133/
