### PR TITLE
CBG-3557 [3.1.2 backport] Implement nextSequenceGreaterThan to reduce incr and unused seq traffic

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -575,9 +575,34 @@ func (c *changeCache) releaseUnusedSequence(ctx context.Context, sequence uint64
 	} else {
 		changedChannels.Add(unusedSeq)
 	}
-	c.channelCache.AddSkippedSequence(change)
+	c.channelCache.AddUnusedSequence(change)
 	if c.notifyChange != nil && len(changedChannels) > 0 {
 		c.notifyChange(ctx, changedChannels)
+	}
+}
+
+// releaseUnusedSequenceRange calls processEntry for each sequence in the range, but only issues a single notify.
+func (c *changeCache) releaseUnusedSequenceRange(ctx context.Context, fromSequence uint64, toSequence uint64, timeReceived time.Time) {
+
+	base.InfofCtx(ctx, base.KeyCache, "Received #%d-#%d (unused sequence range)", fromSequence, toSequence)
+
+	unusedSeq := channels.NewID(unusedSeqKey, unusedSeqCollectionID)
+	allChangedChannels := channels.SetOfNoValidate(unusedSeq)
+	for sequence := fromSequence; sequence <= toSequence; sequence++ {
+		change := &LogEntry{
+			Sequence:     sequence,
+			TimeReceived: timeReceived,
+		}
+
+		// Since processEntry may unblock pending sequences, if there were any changed channels we need
+		// to notify any change listeners that are working changes feeds for these channels
+		changedChannels := c.processEntry(ctx, change)
+		allChangedChannels = allChangedChannels.Update(changedChannels)
+		c.channelCache.AddUnusedSequence(change)
+	}
+
+	if c.notifyChange != nil {
+		c.notifyChange(ctx, allChangedChannels)
 	}
 }
 
@@ -601,10 +626,7 @@ func (c *changeCache) processUnusedSequenceRange(ctx context.Context, docID stri
 		return
 	}
 
-	// TODO: There should be a more efficient way to do this
-	for seq := fromSequence; seq <= toSequence; seq++ {
-		c.releaseUnusedSequence(ctx, seq, time.Now())
-	}
+	c.releaseUnusedSequenceRange(ctx, fromSequence, toSequence, time.Now())
 }
 
 func (c *changeCache) processPrincipalDoc(ctx context.Context, docID string, docJSON []byte, isUser bool, timeReceived time.Time) {

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -44,8 +44,8 @@ type ChannelCache interface {
 	// Notifies the cache of a principal update.  Updates the cache's high sequence
 	AddPrincipal(change *LogEntry)
 
-	// Notifies the cache of a skipped sequence update. Updates the cache's high sequence
-	AddSkippedSequence(change *LogEntry)
+	// Notifies the cache of an unused sequence update. Updates the cache's high sequence
+	AddUnusedSequence(change *LogEntry)
 
 	// Remove purges the given doc IDs from all channel caches and returns the number of items removed.
 	Remove(ctx context.Context, collectionID uint32, docIDs []string, startTime time.Time) (count int)
@@ -191,8 +191,8 @@ func (c *channelCacheImpl) AddPrincipal(change *LogEntry) {
 	c.updateHighCacheSequence(change.Sequence)
 }
 
-// AddSkipedSequence notifies the cache of a skipped sequence update. Updates the cache's high sequence
-func (c *channelCacheImpl) AddSkippedSequence(change *LogEntry) {
+// Add unused Sequence notifies the cache of an unused sequence update. Updates the cache's high sequence
+func (c *channelCacheImpl) AddUnusedSequence(change *LogEntry) {
 	c.updateHighCacheSequence(change.Sequence)
 }
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -1546,22 +1546,22 @@ func (db *DatabaseContext) assignSequence(ctx context.Context, docSequence uint6
 			unusedSequences = append(unusedSequences, docSequence)
 		}
 
-		for {
-			var err error
-			if docSequence, err = db.sequences.nextSequence(ctx); err != nil {
+		var err error
+		if docSequence, err = db.sequences.nextSequence(ctx); err != nil {
+			return unusedSequences, err
+		}
+
+		// If the assigned sequence is less than or equal to the previous sequence on the document, release
+		// the assigned sequence and acquire one using nextSequenceGreaterThan
+		if docSequence <= doc.Sequence {
+			if err = db.sequences.releaseSequence(ctx, docSequence); err != nil {
+				base.WarnfCtx(ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", docSequence, err)
+			}
+			docSequence, err = db.sequences.nextSequenceGreaterThan(ctx, doc.Sequence)
+			if err != nil {
 				return unusedSequences, err
 			}
-
-			if docSequence > doc.Sequence {
-				break
-			} else {
-				if err := db.sequences.releaseSequence(ctx, docSequence); err != nil {
-					base.WarnfCtx(ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", docSequence, err)
-				}
-			}
 		}
-		// Could add a db.Sequences.nextSequenceGreaterThan(doc.Sequence) to push the work down into the sequence allocator
-		//  - sequence allocator is responsible for releasing unused sequences, could optimize to do that in bulk if needed
 	}
 
 	doc.Sequence = docSequence


### PR DESCRIPTION
Backports CBG-3516 to 3.1.2.

CBG-3516
