### PR TITLE
CBG-3559: Inherited channels from roles are not checked when running changes feed filtered to a channel

### DIFF
--- a/auth/user.go
+++ b/auth/user.go
@@ -664,18 +664,6 @@ func (user *userImpl) FilterToAvailableCollectionChannels(scope, collection stri
 	return filtered, removed
 }
 
-// getCollectionAccessSeq find the minimum sequence a channel was granted across the user and their associated roles,
-// returning 0 when no access is found for that channel
-func (user *userImpl) getCollectionAccessSeq(scope, collection, channelName string) uint64 {
-	minSeq := user.canSeeCollectionChannelSince(scope, collection, channelName)
-	for _, role := range user.GetRoles() {
-		if seq := role.canSeeCollectionChannelSince(scope, collection, channelName); seq > 0 && (seq < minSeq || minSeq == 0) {
-			minSeq = seq
-		}
-	}
-	return minSeq
-}
-
 func (user *userImpl) GetAddedChannels(channels ch.TimedSet) base.Set {
 	output := base.Set{}
 	for userChannel := range user.inheritedChannels() {

--- a/auth/user.go
+++ b/auth/user.go
@@ -656,8 +656,7 @@ func (user *userImpl) FilterToAvailableCollectionChannels(scope, collection stri
 		if channelName == ch.AllChannelWildcard {
 			return user.InheritedCollectionChannels(scope, collection).Copy(), nil
 		}
-		seq := user.getCollectionAccessSeq(scope, collection, channelName)
-		added := filtered.AddChannel(channelName, seq)
+		added := filtered.AddChannel(channelName, user.canSeeCollectionChannelSince(scope, collection, channelName))
 		if !added {
 			removed = append(removed, channelName)
 		}

--- a/auth/user_collection_access.go
+++ b/auth/user_collection_access.go
@@ -100,3 +100,13 @@ func (user *userImpl) AuthorizeAnyCollectionChannel(scope, collection string, ch
 
 	return user.UnauthError("You are not allowed to see this")
 }
+
+func (user *userImpl) canSeeCollectionChannelSince(scope, collection, channel string) uint64 {
+	minSeq := user.roleImpl.canSeeCollectionChannelSince(scope, collection, channel)
+	for _, role := range user.GetRoles() {
+		if seq := role.canSeeCollectionChannelSince(scope, collection, channel); seq > 0 && (seq < minSeq || minSeq == 0) {
+			minSeq = seq
+		}
+	}
+	return minSeq
+}

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -189,6 +189,71 @@ func TestDocDeletionFromChannel(t *testing.T) {
 	assert.Equal(t, 200, response.Code)
 }
 
+// TestChangesFeedOnInheritedChannelsFromRoles:
+//   - Create a role with access to channel "A"
+//   - Create a user with the role just created
+//   - Put some docs on the database with channel "A" assigned
+//   - Run changes feed as the user with a channel filter on it to channel A
+func TestChangesFeedOnInheritedChannelsFromRoles(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
+	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
+
+	// create role with collection channel access set to channel A
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/role", rest.GetRolePayload(t, "", "", collection, []string{"A"}))
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	// create user and assign the role create above to that user
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/alice", `{"name": "alice", "password": "letmein", "admin_roles": ["role"]}`)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	// Put a some doc on the database with channel A assigned
+	for i := 0; i < 5; i++ {
+		resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+fmt.Sprint(i), `{"source": "rt", "channels":["A"]}`)
+		rest.RequireStatus(t, resp, http.StatusCreated)
+	}
+
+	// Start changes feed as the user filtered to channel A, expect 6 changes (5 docs + user doc)
+	changes, err := rt.WaitForChanges(6, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A", "alice", false)
+	require.NoError(t, err)
+	assert.Equal(t, 6, len(changes.Results))
+}
+
+// TestChangesFeedOnInheritedChannelsFromRolesDefaultCollection:
+//   - Same concept as TestChangesFeedOnInheritedChannelsFromRoles just with use of default collection instead
+//   - Create a role with access to channel "A"
+//   - Create a user with the role just created
+//   - Put some docs on the database with channel "A" assigned
+//   - Run changes feed as the user with a channel filter on it to channel A
+func TestChangesFeedOnInheritedChannelsFromRolesDefaultCollection(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
+
+	rt := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
+	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
+
+	// create role with collection channel access set to channel A
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/role", rest.GetRolePayload(t, "", "", collection, []string{"A"}))
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	// create user and assign the role create above to that user
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/alice", `{"name": "alice", "password": "letmein", "admin_roles": ["role"]}`)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	// Put a some doc on the database with channel A assigned
+	for i := 0; i < 5; i++ {
+		resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+fmt.Sprint(i), `{"source": "rt", "channels":["A"]}`)
+		rest.RequireStatus(t, resp, http.StatusCreated)
+	}
+
+	// Start changes feed as the user filtered to channel A, expect 6 changes (5 docs + user doc)
+	changes, err := rt.WaitForChanges(6, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A", "alice", false)
+	require.NoError(t, err)
+	assert.Equal(t, 6, len(changes.Results))
+}
+
 func TestPostChanges(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)


### PR DESCRIPTION
CBG-3559

Regression found in 3.1+, when filtering running the changes feed with channels specified as a filter. `FilterToAvailableCollectionChannels` does not take into account any inherited channels from roles. If you grant a role access to a channel, then assign that role to a user. Put some docs in the channel assigned to the role then start the changes feed as the user, filtered to the channel granted to the role, you will get the following logging: 
`Channels [ <ud>A</ud> ] request without access by user <ud>alice</ud>`
plus empty changes message. 


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2136/
