### PR TITLE
CBG-3560: [3.1.2] Inherited channels from roles are not checked when running changes feed filtered to a channel

### DIFF
--- a/auth/user_collection_access.go
+++ b/auth/user_collection_access.go
@@ -100,3 +100,13 @@ func (user *userImpl) AuthorizeAnyCollectionChannel(scope, collection string, ch
 
 	return user.UnauthError("You are not allowed to see this")
 }
+
+func (user *userImpl) canSeeCollectionChannelSince(scope, collection, channel string) uint64 {
+	minSeq := user.roleImpl.canSeeCollectionChannelSince(scope, collection, channel)
+	for _, role := range user.GetRoles() {
+		if seq := role.canSeeCollectionChannelSince(scope, collection, channel); seq > 0 && (seq < minSeq || minSeq == 0) {
+			minSeq = seq
+		}
+	}
+	return minSeq
+}


### PR DESCRIPTION
CBG-3560

Regression found in 3.1+, when filtering running the changes feed with channels specified as a filter. FilterToAvailableCollectionChannels does not take into account any inherited channels from roles. If you grant a role access to a channel, then assign that role to a user. Put some docs in the channel assigned to the role then start the changes feed as the user, filtered to the channel granted to the role, you will get the following logging:
Channels [ <ud>A</ud> ] request without access by user <ud>alice</ud>
plus empty changes message.

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration-1.19.5/41/
