### PR TITLE
CBG-3268 replace WaitForRev with WaitForVersion

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2716,11 +2716,12 @@ func TestDocChannelSetPruning(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 
-	revID := rt.CreateDocReturnRev(t, "doc", "", map[string]interface{}{"channels": []string{"a"}})
+	const docID = "doc"
+	version := rt.PutDoc(docID, `{"channels": ["a"]}`)
 
 	for i := 0; i < 10; i++ {
-		revID = rt.CreateDocReturnRev(t, "doc", revID, map[string]interface{}{"channels": []string{}})
-		revID = rt.CreateDocReturnRev(t, "doc", revID, map[string]interface{}{"channels": []string{"a"}})
+		version = rt.UpdateDoc(docID, version, `{"channels": []}`)
+		version = rt.UpdateDoc(docID, version, `{"channels": ["a"]}`)
 	}
 
 	syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc")

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -199,22 +199,18 @@ func TestBlipProveAttachmentV2(t *testing.T) {
 	// Create two docs with the same attachment data on SG - v2 attachments intentionally result in two copies,
 	// CBL will still de-dupe attachments based on digest, so will still try proveAttachmnet for the 2nd.
 	doc1Body := fmt.Sprintf(`{"greetings":[{"hi": "alice"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
-	response := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+doc1ID, doc1Body)
-	RequireStatus(t, response, http.StatusCreated)
-	doc1RevID := RespRevID(t, response)
+	doc1Version := rt.PutDoc(doc1ID, doc1Body)
 
-	data, ok := btc.WaitForRev(doc1ID, doc1RevID)
+	data, ok := btc.WaitForVersion(doc1ID, doc1Version)
 	require.True(t, ok)
 	bodyTextExpected := fmt.Sprintf(`{"greetings":[{"hi":"alice"}],"_attachments":{"%s":{"revpos":1,"length":%d,"stub":true,"digest":"%s"}}}`, attachmentName, len(attachmentData), attachmentDigest)
 	require.JSONEq(t, bodyTextExpected, string(data))
 
 	// create doc2 now that we know the client has the attachment
 	doc2Body := fmt.Sprintf(`{"greetings":[{"howdy": "bob"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
-	response = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+doc2ID, doc2Body)
-	RequireStatus(t, response, http.StatusCreated)
-	doc2RevID := RespRevID(t, response)
+	doc2Version := rt.PutDoc(doc2ID, doc2Body)
 
-	data, ok = btc.WaitForRev(doc2ID, doc2RevID)
+	data, ok = btc.WaitForVersion(doc2ID, doc2Version)
 	require.True(t, ok)
 	bodyTextExpected = fmt.Sprintf(`{"greetings":[{"howdy":"bob"}],"_attachments":{"%s":{"revpos":1,"length":%d,"stub":true,"digest":"%s"}}}`, attachmentName, len(attachmentData), attachmentDigest)
 	require.JSONEq(t, bodyTextExpected, string(data))
@@ -696,12 +692,10 @@ func TestAttachmentComputeStat(t *testing.T) {
 
 	// Create doc revision with attachment on SG.
 	bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-	response := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID, bodyText)
-	assert.Equal(t, http.StatusCreated, response.Code)
+	version := rt.PutDoc(docID, bodyText)
 
 	// Wait for the document to be replicated to client.
-	revId := RespRevID(t, response)
-	data, ok := btc.WaitForRev(docID, revId)
+	data, ok := btc.WaitForVersion(docID, version)
 	assert.True(t, ok)
 	bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
 	require.JSONEq(t, bodyTextExpected, string(data))

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -214,7 +214,7 @@ func TestRevocationScenario1(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
@@ -226,11 +226,11 @@ func TestRevocationScenario1(t *testing.T) {
 	assert.Equal(t, "25", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(80)
@@ -241,7 +241,7 @@ func TestRevocationScenario1(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
@@ -265,14 +265,14 @@ func TestRevocationScenario2(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(50)
 	changes = revocationTester.getChanges(25, 1)
@@ -282,7 +282,7 @@ func TestRevocationScenario2(t *testing.T) {
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(80)
@@ -293,7 +293,7 @@ func TestRevocationScenario2(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
@@ -317,14 +317,14 @@ func TestRevocationScenario3(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 
@@ -334,7 +334,7 @@ func TestRevocationScenario3(t *testing.T) {
 	assert.True(t, changes.Results[0].Revoked)
 
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(80)
@@ -345,7 +345,7 @@ func TestRevocationScenario3(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
@@ -369,18 +369,18 @@ func TestRevocationScenario4(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 
 	revocationTester.fillToSeq(70)
 	changes = revocationTester.getChanges(25, 1)
@@ -397,7 +397,7 @@ func TestRevocationScenario4(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
@@ -421,18 +421,18 @@ func TestRevocationScenario5(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(80)
@@ -443,7 +443,7 @@ func TestRevocationScenario5(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
@@ -467,18 +467,18 @@ func TestRevocationScenario6(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(84)
@@ -491,7 +491,7 @@ func TestRevocationScenario6(t *testing.T) {
 	assert.True(t, changes.Results[0].Revoked)
 
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(90, 0)
@@ -514,24 +514,24 @@ func TestRevocationScenario7(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(100)
 
@@ -561,9 +561,9 @@ func TestRevocationScenario8(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(50)
 	changes = revocationTester.getChanges(5, 0)
@@ -572,13 +572,13 @@ func TestRevocationScenario8(t *testing.T) {
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(50, 0)
@@ -601,9 +601,9 @@ func TestRevocationScenario9(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 
@@ -612,13 +612,13 @@ func TestRevocationScenario9(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(60, 0)
@@ -641,13 +641,13 @@ func TestRevocationScenario10(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 
 	revocationTester.fillToSeq(70)
 	changes = revocationTester.getChanges(5, 0)
@@ -658,7 +658,7 @@ func TestRevocationScenario10(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(70, 0)
@@ -681,13 +681,13 @@ func TestRevocationScenario11(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 
@@ -698,7 +698,7 @@ func TestRevocationScenario11(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(80, 1)
@@ -722,13 +722,13 @@ func TestRevocationScenario12(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(84)
@@ -739,7 +739,7 @@ func TestRevocationScenario12(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(90, 0)
@@ -762,19 +762,19 @@ func TestRevocationScenario13(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(100)
 	changes = revocationTester.getChanges(5, 0)
@@ -801,14 +801,14 @@ func TestRevocationScenario14(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 
 	revocationTester.fillToSeq(25)
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	changes = revocationTester.getChanges(25, 1)
 	assert.Equal(t, "45:3", changes.Last_Seq)
@@ -823,7 +823,7 @@ func TestEnsureRevocationAfterDocMutation(t *testing.T) {
 
 	// Give role access to channel A and give user access to role
 	revocationTester.addRoleChannel("foo", "A")
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 
 	// Skip to seq 4 Create doc channel A
 	revocationTester.fillToSeq(4)
@@ -837,7 +837,7 @@ func TestEnsureRevocationAfterDocMutation(t *testing.T) {
 
 	// Skip to seq 14 then revoke role from user
 	revocationTester.fillToSeq(14)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	// Skip to seq 19 and then update doc foo
 	revocationTester.fillToSeq(19)
@@ -859,7 +859,7 @@ func TestEnsureRevocationUsingDocHistory(t *testing.T) {
 
 	// Give role access to channel A and give user access to role
 	revocationTester.addRoleChannel("foo", "A")
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 
 	// Skip to seq 4 Create doc channel A
 	revocationTester.fillToSeq(4)
@@ -954,7 +954,7 @@ func TestRevocationMutationMovesIntoRevokedChannel(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "A")
 
 	revocationTester.fillToSeq(4)
@@ -967,7 +967,7 @@ func TestRevocationMutationMovesIntoRevokedChannel(t *testing.T) {
 	assert.Len(t, changes.Results, 2)
 	assert.Equal(t, doc2ID, changes.Results[1].ID)
 
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	_ = rt.UpdateDoc(docID, docVersion, `{"channels": ["A"]}`)
 	_ = rt.UpdateDoc(doc2ID, doc2Version, `{"channels": ["A"], "val": "mutate"}`)
 
@@ -986,10 +986,10 @@ func TestRevocationResumeAndLowSeqCheck(t *testing.T) {
 	resp := rt.SendAdminRequest("PUT", "/db/_role/foo2", `{}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "ch1")
 
-	revocationTester.addRole("foo2")
+	revocationTester.addRole("user", "foo2")
 	revocationTester.addRoleChannel("foo2", "ch2")
 
 	revocationTester.fillToSeq(9)
@@ -1040,7 +1040,7 @@ func TestRevocationResumeSameRoleAndLowSeqCheck(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.addRoleChannel("foo", "ch2")
 
@@ -1103,7 +1103,7 @@ func TestRevocationsWithQueryLimit(t *testing.T) {
 	})
 	defer rt.Close()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	revocationTester.fillToSeq(9)
@@ -1113,7 +1113,7 @@ func TestRevocationsWithQueryLimit(t *testing.T) {
 
 	changes := revocationTester.getChanges("0", 4)
 
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	// Run changes once (which has its own wait)
 	sinceVal := changes.Last_Seq
@@ -1145,9 +1145,9 @@ func TestRevocationsWithQueryLimit2Channels(t *testing.T) {
 	})
 	defer rt.Close()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "ch1")
-	revocationTester.addUserChannel("ch2")
+	revocationTester.addUserChannel("user", "ch2")
 
 	revocationTester.fillToSeq(9)
 	_ = rt.PutDoc("doc1", `{"channels": ["ch1", "ch2"]}`)
@@ -1156,7 +1156,7 @@ func TestRevocationsWithQueryLimit2Channels(t *testing.T) {
 
 	changes := revocationTester.getChanges("0", 4)
 
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	_ = changes.Last_Seq
 	// This changes feed would loop if CBG-3273 was still an issue
@@ -1167,7 +1167,7 @@ func TestRevocationsWithQueryLimit2Channels(t *testing.T) {
 	RequireStatus(t, resp, 200)
 
 	// Revoke access to ch2
-	revocationTester.removeUserChannel("ch2")
+	revocationTester.removeUserChannel("user", "ch2")
 	changes = revocationTester.getChanges(0, 7)
 	// Get a doc to ensure no access
 	resp = rt.SendUserRequestWithHeaders("GET", "/{{.keyspace}}/doc1", "", nil, "user", "test")
@@ -1192,7 +1192,7 @@ func TestRevocationsWithQueryLimitChangesLimit(t *testing.T) {
 	})
 	defer rt.Close()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	revocationTester.fillToSeq(9)
@@ -1202,7 +1202,7 @@ func TestRevocationsWithQueryLimitChangesLimit(t *testing.T) {
 
 	changes := revocationTester.getChanges("0", 4)
 
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	waitForUserChangesWithLimit := func(sinceVal interface{}, limit int) ChangesResults {
 		var changesRes ChangesResults
@@ -1247,7 +1247,7 @@ func TestRevocationUserHasDocAccessDocNotFound(t *testing.T) {
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "A")
 
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc", `{"channels": ["A"]}`)
@@ -1280,7 +1280,7 @@ func TestWasDocInChannelAtSeq(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "a")
 	revocationTester.addRoleChannel("foo", "c")
 
@@ -1318,38 +1318,38 @@ func TestChannelGrantedPeriods(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	revocationTester.addUserChannel("a")
+	revocationTester.addUserChannel("user", "a")
 	const docID = "doc"
 	version := rt.PutDoc(docID, `{"channels": ["a"]}`)
 	changes := revocationTester.getChanges(0, 2)
 	assert.Len(t, changes.Results, 2)
 
-	revocationTester.removeUserChannel("a")
+	revocationTester.removeUserChannel("user", "a")
 	version = rt.UpdateDoc(docID, version, `{"mutate": "mutate", "channels": ["a"]}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 
-	revocationTester.addUserChannel("a")
+	revocationTester.addUserChannel("user", "a")
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 
-	revocationTester.removeUserChannel("a")
+	revocationTester.removeUserChannel("user", "a")
 	version = rt.UpdateDoc(docID, version, `{"mutate": "mutate2", "channels": ["a"]}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 
-	revocationTester.addUserChannel("a")
+	revocationTester.addUserChannel("user", "a")
 	version = rt.UpdateDoc(docID, version, `{"mutate": "mutate3", "channels": ["a"]}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "b")
 	version = rt.UpdateDoc(docID, version, `{"channels": ["b"]}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 
 	revocationTester.removeRoleChannel("foo", "b")
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	_ = rt.UpdateDoc(docID, version, `{"mutate": "mutate", "channels": ["b"]}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 }
@@ -1362,7 +1362,7 @@ func TestChannelHistoryPruning(t *testing.T) {
 	c := collection.Name
 	s := collection.ScopeName
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "a")
 
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": ["a"]}`)
@@ -1431,26 +1431,26 @@ func TestChannelRevocationWithContiguousSequences(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	revocationTester.addUserChannel("a")
+	revocationTester.addUserChannel("user", "a")
 	const docID = "doc"
 	version := rt.PutDoc(docID, `{"channels": "a"}`)
 	changes := revocationTester.getChanges(0, 2)
 	assert.Len(t, changes.Results, 2)
 
-	revocationTester.removeUserChannel("a")
+	revocationTester.removeUserChannel("user", "a")
 	version = rt.UpdateDoc(docID, version, `{"mutate": "mutate", "channels": "a"}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 	assert.Equal(t, "doc", changes.Results[0].ID)
 	assert.True(t, changes.Results[0].Revoked)
 
-	revocationTester.addUserChannel("a")
+	revocationTester.addUserChannel("user", "a")
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 	assert.Equal(t, "doc", changes.Results[0].ID)
 	assert.False(t, changes.Results[0].Revoked)
 
-	revocationTester.removeUserChannel("a")
+	revocationTester.removeUserChannel("user", "a")
 	_ = rt.UpdateDoc(docID, version, `{"mutate": "mutate2", "channels": "a"}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
@@ -1533,7 +1533,7 @@ func TestReplicatorRevocations(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "chanA")
 
 	resp := rt2.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "chanA"}`)
@@ -1571,7 +1571,7 @@ func TestReplicatorRevocations(t *testing.T) {
 	resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
 	RequireStatus(t, resp, http.StatusOK)
 
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	require.NoError(t, ar.Start(ctx1))
 	rt1.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
@@ -1596,7 +1596,7 @@ func TestReplicatorRevocationsNoRev(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "chanA")
 
 	const doc1ID = "doc1"
@@ -1634,7 +1634,7 @@ func TestReplicatorRevocationsNoRev(t *testing.T) {
 	resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
 	RequireStatus(t, resp, http.StatusOK)
 
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	_ = rt2.UpdateDoc(doc1ID, doc1Version, `{"channels": "chanA", "mutate": "val"}`)
 
@@ -1661,13 +1661,13 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "chanA")
 
 	resp := rt2.SendAdminRequest("PUT", "/db/_role/foo2", `{}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
-	revocationTester.addRole("foo2")
+	revocationTester.addRole("user", "foo2")
 	revocationTester.addRoleChannel("foo2", "chanB")
 
 	const doc1ID = "doc1"
@@ -1705,7 +1705,7 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 	resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
 	RequireStatus(t, resp, http.StatusOK)
 
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	_ = rt2.UpdateDoc(doc1ID, doc1Version, `{"channels": ["chanA", "chanB"], "mutate": "val"}`)
 
@@ -1753,7 +1753,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
 
-	revocationTester.addRole(revocationTestRole)
+	revocationTester.addRole(revocationTestUser, revocationTestRole)
 	require.NoError(t, rt2.WaitForPendingChanges())
 
 	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
@@ -2237,7 +2237,7 @@ func TestRevocationMessage(t *testing.T) {
 
 	// Add channel to role and role to user
 	revocationTester.addRoleChannel("foo", "A")
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 
 	// Skip to seq 4 and then create doc in channel A
 	revocationTester.fillToSeq(4)
@@ -2250,11 +2250,11 @@ func TestRevocationMessage(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Wait for doc revision to come over
-	_, ok := btc.WaitForBlipRevMessage("doc", version)
+	_, ok := btc.WaitForBlipRevMessage("doc", version.RevID)
 	require.True(t, ok)
 
 	// Remove role from user
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	const doc1ID = "doc1"
 	version = rt.PutDoc(doc1ID, `{"channels": "!"}`)
@@ -2348,7 +2348,7 @@ func TestRevocationNoRev(t *testing.T) {
 
 	// Add channel to role and role to user
 	revocationTester.addRoleChannel("foo", "A")
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 
 	// Skip to seq 4 and then create doc in channel A
 	revocationTester.fillToSeq(4)
@@ -2366,7 +2366,7 @@ func TestRevocationNoRev(t *testing.T) {
 	require.True(t, ok)
 
 	// Remove role from user
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	_ = rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
 
@@ -2442,7 +2442,7 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 
 	// Add channel to role and role to user
 	revocationTester.addRoleChannel("foo", "A")
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 
 	// Skip to seq 4 and then create doc in channel A
 	revocationTester.fillToSeq(4)
@@ -2460,7 +2460,7 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 	require.True(t, ok)
 
 	// Remove role from user
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	_ = rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
 

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -47,20 +47,20 @@ const (
 	revocationTestPassword = "test"
 )
 
-func (tester *ChannelRevocationTester) addRole(role string) {
+func (tester *ChannelRevocationTester) addRole(user, role string) {
 	if tester.roles.Roles == nil {
 		tester.roles.Roles = map[string][]string{}
 	}
 
-	tester.roles.Roles[revocationTestUser] = append(tester.roles.Roles[revocationTestUser], fmt.Sprintf("role:%s", role))
+	tester.roles.Roles[user] = append(tester.roles.Roles[user], fmt.Sprintf("role:%s", role))
 	tester.roleVersion = tester.restTester.UpdateDoc("userRoles", tester.roleVersion, string(mustMarshalJSON(tester.restTester.TB, tester.roles)))
 }
 
-func (tester *ChannelRevocationTester) removeFooRole() {
+func (tester *ChannelRevocationTester) removeRole(user, role string) {
 	delIdx := -1
-	roles := tester.roles.Roles[revocationTestUser]
+	roles := tester.roles.Roles[user]
 	for idx, val := range roles {
-		if val == fmt.Sprintf("role:%s", revocationTestRole) {
+		if val == fmt.Sprintf("role:%s", role) {
 			delIdx = idx
 			break
 		}
@@ -94,18 +94,18 @@ func (tester *ChannelRevocationTester) removeRoleChannel(role, channel string) {
 	tester.roleChannelVersion = tester.restTester.UpdateDoc("roleChannels", tester.roleChannelVersion, string(mustMarshalJSON(tester.restTester.TB, tester.roleChannels)))
 }
 
-func (tester *ChannelRevocationTester) addUserChannel(channel string) {
+func (tester *ChannelRevocationTester) addUserChannel(user, channel string) {
 	if tester.userChannels.Channels == nil {
 		tester.userChannels.Channels = map[string][]string{}
 	}
 
-	tester.userChannels.Channels[revocationTestUser] = append(tester.userChannels.Channels[revocationTestUser], channel)
+	tester.userChannels.Channels[user] = append(tester.userChannels.Channels[user], channel)
 	tester.userChannelVersion = tester.restTester.UpdateDoc("userChannels", tester.userChannelVersion, string(mustMarshalJSON(tester.restTester.TB, tester.userChannels)))
 }
 
-func (tester *ChannelRevocationTester) removeUserChannel(channel string) {
+func (tester *ChannelRevocationTester) removeUserChannel(user string, channel string) {
 	delIdx := -1
-	channelsSlice := tester.userChannels.Channels[revocationTestUser]
+	channelsSlice := tester.userChannels.Channels[user]
 	for idx, val := range channelsSlice {
 		if val == channel {
 			delIdx = idx
@@ -2250,7 +2250,7 @@ func TestRevocationMessage(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Wait for doc revision to come over
-	_, ok := btc.WaitForBlipRevMessage("doc", version.RevID)
+	_, ok := btc.WaitForBlipRevMessage("doc", version)
 	require.True(t, ok)
 
 	// Remove role from user

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -762,6 +762,11 @@ func (cr ChangesResults) RequireDocIDs(t testing.TB, docIDs []string) {
 	}
 }
 
+// requireChangeRevVersion asserts that the given ChangeRev has the expected version for a given entry returned by _changes feed
+func requireChangeRevVersion(t *testing.T, expected DocVersion, changeRev db.ChangeRev) {
+	RequireDocVersionEqual(t, expected, DocVersion{RevID: changeRev["rev"]})
+}
+
 func (rt *RestTester) CreateWaitForChangesRetryWorker(numChangesExpected int, changesURL, username string, useAdminPort bool) (worker base.RetryWorker) {
 
 	waitForChangesWorker := func() (shouldRetry bool, err error, value interface{}) {
@@ -2496,6 +2501,7 @@ func (rt *RestTester) getCollectionsForBLIP() []string {
 			Collection: collection.Name,
 		}.String())
 	}
+	sort.Strings(collections)
 	return collections
 }
 


### PR DESCRIPTION
Replaces `WaitForRev` with `WaitForVersion` to remove rev id assertions. When reviewing this:

- Look for dropped conceptual assertions
- Look for unintentional or unwaited drops in whether the request is user or admin scoped (`PutDoc`, `UpdateDoc`, `DeleteDoc` are admin scoped.
- Make sure there are no dropped `WaitForPendingChanges` or other things that can cause race conditions.

Fails lint CI due to https://github.com/couchbase/sync_gateway/pull/6555

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2138/
