### PR TITLE
Use newer version of golanci-lint to allow using standard library slices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.3
+          cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.0
+          version: v1.55.0
           args: --config=.golangci-strict.yml --timeout=3m
 
   test:

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -13,10 +13,9 @@ package base
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/couchbase/gocb/v2"
 	sgbucket "github.com/couchbase/sg-bucket"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/couchbase/sync_gateway
 
-go 1.19
+go 1.21
 
 require (
 	dario.cat/mergo v1.0.0

--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -11,6 +11,7 @@ package adminapitest
 import (
 	"fmt"
 	"net/http"
+	"slices"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -18,7 +19,6 @@ import (
 	"github.com/couchbase/sync_gateway/rest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 func TestCollectionsSyncImportFunctions(t *testing.T) {

--- a/rest/replicatortest/replicator_collection_test.go
+++ b/rest/replicatortest/replicator_collection_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -22,7 +23,6 @@ import (
 	"github.com/couchbase/sync_gateway/rest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 // TestActiveReplicatorMultiCollection is a test to get as much coverage of collections in ISGR as possible.

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -29,7 +30,6 @@ import (
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/db/functions"
-	"golang.org/x/exp/slices"
 
 	"github.com/couchbase/gocbcore/v10"
 	sgbucket "github.com/couchbase/sg-bucket"


### PR DESCRIPTION
Found in https://github.com/couchbase/sync_gateway/pull/6554
