### PR TITLE
CBG-1966 enable staticcheck

### DIFF
--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -24,7 +24,7 @@ linters:
     #- nakedret # Finds naked returns in functions greater than a specified function length
     #- prealloc # Finds slice declarations that could potentially be preallocated
     #- revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
-    #- staticcheck # (megacheck) Staticcheck is a go vet on steroids, applying a ton of static analysis checks
+    - staticcheck # (megacheck) Staticcheck is a go vet on steroids, applying a ton of static analysis checks
     - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
     - unconvert # Remove unnecessary type conversions
     #- unparam # Reports unused function parameters
@@ -67,7 +67,6 @@ linters:
     - nakedret # Finds naked returns in functions greater than a specified function length
     - prealloc # Finds slice declarations that could potentially be preallocated
     - revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
-    - staticcheck # (megacheck) Staticcheck is a go vet on steroids, applying a ton of static analysis checks
     - structcheck # Finds unused struct fields
     - unparam # Reports unused function parameters
     - varcheck # Finds unused global variables and constants

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -721,7 +721,7 @@ func TestConcurrentUserWrites(t *testing.T) {
 	}
 
 	// Retrieve user to trigger initial calculation of roles, channels
-	user, getErr := auth.GetUser(username)
+	_, getErr := auth.GetUser(username)
 	require.NoError(t, getErr, "Error retrieving user")
 
 	require.NoError(t, auth.SetBcryptCost(DefaultBcryptCost))

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -1255,7 +1255,6 @@ func TestJWTRolesChannels(t *testing.T) {
 				require.Equal(t, base.SetFromArray(login.expectedChannels), user.Channels().AsSet())
 
 				require.Greater(t, user.JWTLastUpdated(), lastUpdateTime)
-				lastUpdateTime = user.JWTLastUpdated()
 			}
 		})
 	}

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -1205,9 +1205,8 @@ func TestJWTRolesChannels(t *testing.T) {
 
 			for i, login := range tc.logins {
 				var (
-					user           User
-					err            error
-					lastUpdateTime time.Time
+					user User
+					err  error
 				)
 				if i == 0 {
 					user, err = auth.NewUser(testUserPrefix+"_"+testSubject, "test", base.SetFromArray(login.explicitChannels))
@@ -1254,7 +1253,6 @@ func TestJWTRolesChannels(t *testing.T) {
 				}
 				require.Equal(t, base.SetFromArray(login.expectedChannels), user.Channels().AsSet())
 
-				require.Greater(t, user.JWTLastUpdated(), lastUpdateTime)
 			}
 		})
 	}

--- a/auth/password_hash_test.go
+++ b/auth/password_hash_test.go
@@ -35,7 +35,6 @@ func BenchmarkBcryptCostTimes(b *testing.B) {
 
 	for i := minCostToTest; i < maxCostToTest; i++ {
 		b.Run(fmt.Sprintf("cost%d", i), func(bn *testing.B) {
-			bn.N = 1
 			_, err := bcrypt.GenerateFromPassword([]byte("hunter2"), i)
 			assert.NoError(bn, err)
 		})

--- a/auth/password_hash_test.go
+++ b/auth/password_hash_test.go
@@ -41,20 +41,24 @@ func BenchmarkBcryptCostTimes(b *testing.B) {
 	}
 }
 
-// TestBcryptDefaultCostTime will ensure that the default bcrypt cost takes at least a 'reasonable' amount of time
-// If this test fails, it suggests maybe we need to think about increasing the default cost...
-func TestBcryptDefaultCostTime(t *testing.T) {
-	// Modest 2.2GHz macbook i7 takes ~80ms at cost 10
-	// Assume server CPUs are ~2x faster
-	minimumDuration := 40 * time.Millisecond
+// TestBcryptCostTimes will output the time it takes to hash a password with each bcrypt cost value
+func TestBcryptCostTimes(t *testing.T) {
+	// Little value in running this regularly. Might be useful for one-off informational purposes
+	t.Skip("Test disabled")
 
-	startTime := time.Now()
-	_, err := bcrypt.GenerateFromPassword([]byte("hunter2"), DefaultBcryptCost)
-	duration := time.Since(startTime)
+	minCostToTest := bcrypt.DefaultCost
+	maxCostToTest := bcrypt.DefaultCost + 5
 
-	t.Logf("bcrypt.GenerateFromPassword with cost %d took: %v", DefaultBcryptCost, duration)
-	assert.NoError(t, err)
-	assert.True(t, minimumDuration < duration)
+	for i := minCostToTest; i < maxCostToTest; i++ {
+		t.Run(fmt.Sprintf("cost%d", i), func(t *testing.T) {
+			startTime := time.Now()
+			_, err := bcrypt.GenerateFromPassword([]byte("hunter2"), i)
+			duration := time.Since(startTime)
+
+			t.Logf("bcrypt.GenerateFromPassword with cost %d took: %v", i, duration)
+			assert.NoError(t, err)
+		})
+	}
 }
 
 func TestSetBcryptCost(t *testing.T) {

--- a/base/collection.go
+++ b/base/collection.go
@@ -63,10 +63,6 @@ func GetGoCBv2Bucket(ctx context.Context, spec BucketSpec) (*GocbV2Bucket, error
 		RetryStrategy:  gocb.NewBestEffortRetryStrategy(nil),
 	}
 
-	if spec.KvPoolSize > 0 {
-		// TODO: Equivalent of kvPoolSize in gocb v2?
-	}
-
 	cluster, err := gocb.Connect(connString, clusterOptions)
 	if err != nil {
 		InfofCtx(ctx, KeyAuth, "Unable to connect to cluster: %v", err)

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -678,11 +678,11 @@ func (meh *sgMgrEventHandlers) OnUnregisterPIndex(pindex *cbgt.PIndex) {
 // OnFeedError is required to trigger reconnection to a feed on a closed connection (EOF).
 // NotifyMgrOnClose will trigger cbgt closing and then attempt to reconnect to the feed, if the manager hasn't
 // been stopped.
-func (meh *sgMgrEventHandlers) OnFeedError(srcType string, r cbgt.Feed, feedErr error) {
+func (meh *sgMgrEventHandlers) OnFeedError(_ string, r cbgt.Feed, feedErr error) {
 
 	// cbgt always passes srcType = SOURCE_GOCBCORE, but we have a wrapped type associated with our indexes - use that instead
 	// for our logging
-	srcType = SOURCE_DCP_SG
+	srcType := SOURCE_DCP_SG
 	var bucketName, bucketUUID string
 	dcpFeed, ok := r.(cbgt.FeedEx)
 	if ok {

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -358,8 +358,7 @@ func dedupeTapEvents(tapEvents []sgbucket.FeedEvent) []sgbucket.FeedEvent {
 	// sequence order as read off the feed.
 	deduped := []sgbucket.FeedEvent{}
 	for _, tapEvent := range tapEvents {
-		key := string(tapEvent.Key)
-		latestTapEventForKey := latestTapEventPerKey[key]
+		latestTapEventForKey := latestTapEventPerKey[string(tapEvent.Key)]
 		if tapEvent.Cas == latestTapEventForKey.Cas {
 			deduped = append(deduped, tapEvent)
 		}

--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -46,7 +46,8 @@ func initExternalLoggers() {
 }
 
 func updateExternalLoggers() {
-	if consoleLogger != nil && consoleLogger.shouldLog(nil, LevelDebug, KeyWalrus) {
+	// use context.Background() since this is called from init or to reset test logging
+	if consoleLogger != nil && consoleLogger.shouldLog(context.Background(), LevelDebug, KeyWalrus) {
 		rosmar.SetLogLevel(rosmar.LevelDebug)
 	} else {
 		rosmar.SetLogLevel(rosmar.LevelInfo)

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -10,8 +10,8 @@ package base
 
 import (
 	"bytes"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"runtime"

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -41,12 +40,6 @@ import (
 // util_test.go, which is only accessible from the base package.
 
 var TestExternalRevStorage = false
-
-func init() {
-
-	// Prevent https://issues.couchbase.com/browse/MB-24237
-	rand.Seed(time.Now().UTC().UnixNano())
-}
 
 type TestBucket struct {
 	Bucket

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -921,4 +922,13 @@ func MoveDocument(t testing.TB, docID string, dst, src DataStore) {
 
 	_, err = src.Remove(docID, srcCAS)
 	require.NoError(t, err)
+}
+
+// FastRandBytes returns a set of random bytes. Uses a low quality random generator.
+func FastRandBytes(t testing.TB, size int) []byte {
+	b := make([]byte, size)
+	// staticcheck wants to use crypto/rand as math/rand is deprecated in go 1.20, but we don't need that for testing
+	_, err := rand.Read(b) // nolint:staticcheck
+	require.NoError(t, err)
+	return b
 }

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -40,10 +40,6 @@ func (apr *ActivePullReplicator) Start(ctx context.Context) error {
 	apr.lock.Lock()
 	defer apr.lock.Unlock()
 
-	if apr == nil {
-		return fmt.Errorf("nil ActivePullReplicator, can't start")
-	}
-
 	if apr.ctx != nil && apr.ctx.Err() == nil {
 		return fmt.Errorf("ActivePullReplicator already running")
 	}
@@ -158,10 +154,6 @@ func (apr *ActivePullReplicator) _subChanges(collectionIdx *int, since string) e
 func (apr *ActivePullReplicator) Complete() {
 	base.TracefCtx(apr.ctx, base.KeyReplicate, "ActivePullReplicator.Complete()")
 	apr.lock.Lock()
-	if apr == nil {
-		apr.lock.Unlock()
-		return
-	}
 	_ = apr.forEachCollection(func(c *activeReplicatorCollection) error {
 		base.TracefCtx(apr.ctx, base.KeyReplicate, "Before calling waitForExpectedSequences in Complete()")
 		if err := c.Checkpointer.waitForExpectedSequences(); err != nil {

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -44,10 +44,6 @@ func (apr *ActivePushReplicator) Start(ctx context.Context) error {
 	apr.lock.Lock()
 	defer apr.lock.Unlock()
 
-	if apr == nil {
-		return fmt.Errorf("nil ActivePushReplicator, can't start")
-	}
-
 	if apr.ctx != nil && apr.ctx.Err() == nil {
 		return fmt.Errorf("ActivePushReplicator already running")
 	}
@@ -111,10 +107,6 @@ func (apr *ActivePushReplicator) _connect() error {
 func (apr *ActivePushReplicator) Complete() {
 	base.TracefCtx(apr.ctx, base.KeyReplicate, "ActivePushReplicator.Complete()")
 	apr.lock.Lock()
-	if apr == nil {
-		apr.lock.Unlock()
-		return
-	}
 
 	// Wait for any pending changes responses to arrive and be processed
 	err := apr._waitForPendingChangesResponse()

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -10,12 +10,12 @@ package db
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
-	"math/rand"
 	"net/http"
 	"strconv"
 	"strings"

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -10,7 +10,6 @@ package db
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -1509,12 +1508,9 @@ func TestLargeAttachments(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	normalAttachment := make([]byte, 15*1024*1024)   // permissible size
-	oversizeAttachment := make([]byte, 25*1024*1024) // memcached would send an E2BIG
-	hugeAttachment := make([]byte, 35*1024*1024)     // memcached would abruptly close our connection
-	_, _ = rand.Read(normalAttachment)
-	_, _ = rand.Read(oversizeAttachment)
-	_, _ = rand.Read(hugeAttachment)
+	normalAttachment := base.FastRandBytes(t, 15*1024*1024)   // permissible size
+	oversizeAttachment := base.FastRandBytes(t, 25*1024*1024) // memcached would send an E2BIG
+	hugeAttachment := base.FastRandBytes(t, 35*1024*1024)     // memcached would abruptly close our connection
 
 	_, _, err := collection.Put(ctx, "testdoc", Body{
 		"_attachments": AttachmentsMeta{

--- a/db/crud.go
+++ b/db/crud.go
@@ -413,10 +413,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 			// db.DbStats.StatsDeltaSync().Add(base.StatKeyDeltaCacheHits, 1)
 			db.dbStats().DeltaSync().DeltaCacheHit.Add(1)
 			return fromRevision.Delta, nil, nil
-		} // else {
-		// TODO: Recurse and merge deltas when gen(revCacheDelta.toRevID) < gen(toRevId)
-		// until then, fall through to generating delta for given rev pair
-		//	}
+		}
 	}
 
 	// Delta is unavailable, but the body is available.

--- a/db/crud.go
+++ b/db/crud.go
@@ -413,10 +413,10 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 			// db.DbStats.StatsDeltaSync().Add(base.StatKeyDeltaCacheHits, 1)
 			db.dbStats().DeltaSync().DeltaCacheHit.Add(1)
 			return fromRevision.Delta, nil, nil
-		} else {
-			// TODO: Recurse and merge deltas when gen(revCacheDelta.toRevID) < gen(toRevId)
-			// until then, fall through to generating delta for given rev pair
-		}
+		} // else {
+		// TODO: Recurse and merge deltas when gen(revCacheDelta.toRevID) < gen(toRevId)
+		// until then, fall through to generating delta for given rev pair
+		//	}
 	}
 
 	// Delta is unavailable, but the body is available.

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1360,6 +1360,7 @@ func TestGet1xRevFromDoc(t *testing.T) {
 	// Get the document body bytes with the tombstone revision rev3, with listRevisions=true
 	// Also validate that the BodyRevisions property is present and correct.
 	bodyBytes, removed, err = collection.get1xRevFromDoc(ctx, doc, rev3, true)
+	require.NoError(t, err)
 	assert.NotEmpty(t, bodyBytes, "Document body bytes should be returned")
 	assert.False(t, removed, "This shouldn't be a removed document")
 	assert.NoError(t, response.Unmarshal(bodyBytes))

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3063,8 +3063,8 @@ func TestGetDatabaseCollectionWithUserDefaultCollection(t *testing.T) {
 			require.NoError(t, err)
 
 			db, err := GetDatabase(dbCtx, nil)
-			defer db.Close(ctx)
 			require.NoError(t, err)
+			defer db.Close(ctx)
 			col, err := db.GetDatabaseCollectionWithUser(testCase.scope, testCase.collection)
 			if testCase.err {
 				require.Error(t, err)

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -803,10 +803,9 @@ func (m *sgReplicateManager) RefreshReplicationCfg(ctx context.Context) error {
 	// Check for replications newly assigned to this node
 	for replicationID, replicationCfg := range configReplications {
 		if replicationCfg.AssignedNode == m.localNodeUUID {
-			replicator, exists := m.activeReplicators[replicationID]
+			_, exists := m.activeReplicators[replicationID]
 			if !exists {
-				var initError error
-				replicator, initError = m.InitializeReplication(replicationCfg)
+				replicator, initError := m.InitializeReplication(replicationCfg)
 				if initError != nil {
 					base.WarnfCtx(m.loggingCtx, "Error initializing replication %s: %v", initError)
 					continue

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -43,7 +43,7 @@ func TestReplicateManagerReplications(t *testing.T) {
 	assert.Equal(t, replication1_id, r.ID)
 
 	// Request non-existent replication
-	r, err = manager.GetReplication("dne")
+	_, err = manager.GetReplication("dne")
 	require.Error(t, err, base.ErrNotFound)
 
 	// Attempt to add existing replication

--- a/main.go
+++ b/main.go
@@ -9,15 +9,8 @@
 package main
 
 import (
-	"math/rand"
-	"time"
-
 	"github.com/couchbase/sync_gateway/rest"
 )
-
-func init() {
-	rand.Seed(time.Now().UTC().UnixNano())
-}
 
 // Simple Sync Gateway launcher tool.
 func main() {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1700,8 +1700,8 @@ func TestLongpollWithWildcard(t *testing.T) {
 	// has a wait counter of zero (no documents writted since the listener was restarted).
 	wg := sync.WaitGroup{}
 	// start changes request
+	wg.Add(1)
 	go func() {
-		wg.Add(1)
 		defer wg.Done()
 		changesJSON := `{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"0"}`
 		changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -264,9 +264,7 @@ func (h *handler) handleDump() error {
 func (h *handler) handleRepair() error {
 
 	// TODO: If repair is re-enabled, it may need to be modified to support xattrs and GSI
-	if true == true {
-		return errors.New("_repair endpoint disabled")
-	}
+	return errors.New("_repair endpoint disabled")
 
 	/*base.InfofCtx(h.ctx(), base.KeyHTTP, "Repair bucket")
 
@@ -305,8 +303,6 @@ func (h *handler) handleRepair() error {
 	return err
 
 	*/
-
-	return nil
 }
 
 // HTTP handler for _dumpchannel

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1431,8 +1431,8 @@ func TestSetupServerContext(t *testing.T) {
 		config.Bootstrap.Password = base.TestClusterPassword()
 		ctx := base.TestCtx(t)
 		sc, err := SetupServerContext(ctx, &config, false)
-		defer sc.Close(ctx)
 		require.NoError(t, err)
+		defer sc.Close(ctx)
 		require.NotNil(t, sc)
 	})
 }

--- a/rest/multipart_test.go
+++ b/rest/multipart_test.go
@@ -13,10 +13,10 @@ package rest
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/rand"
 	"fmt"
 	"io"
 	"log"
-	"math/rand"
 	"mime/multipart"
 	"net/http"
 	"strconv"
@@ -26,6 +26,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWriteMultipartDocument(t *testing.T) {
@@ -163,7 +164,8 @@ func TestWriteJSONPart(t *testing.T) {
 	// a body larger than 300 bytes to test writeJSONPart with compression=true and compression=false
 	mockFakeBody := func() db.Body {
 		bytes := make([]byte, 139)
-		rand.Read(bytes)
+		_, err := rand.Read(bytes)
+		require.NoError(t, err)
 		value := fmt.Sprintf("%x", bytes)
 		return db.Body{"key": "foo", "value": value}
 	}

--- a/rest/multipart_test.go
+++ b/rest/multipart_test.go
@@ -13,7 +13,6 @@ package rest
 import (
 	"bytes"
 	"compress/gzip"
-	"crypto/rand"
 	"fmt"
 	"io"
 	"log"
@@ -26,7 +25,6 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestWriteMultipartDocument(t *testing.T) {
@@ -163,9 +161,7 @@ func TestWriteJSONPart(t *testing.T) {
 	// writeJSONPart toggles compression to false if the incoming body is less than 300 bytes, so creating
 	// a body larger than 300 bytes to test writeJSONPart with compression=true and compression=false
 	mockFakeBody := func() db.Body {
-		bytes := make([]byte, 139)
-		_, err := rand.Read(bytes)
-		require.NoError(t, err)
+		bytes := base.FastRandBytes(t, 139)
 		value := fmt.Sprintf("%x", bytes)
 		return db.Body{"key": "foo", "value": value}
 	}


### PR DESCRIPTION
- remove kvPoolSize empty check (setup in GetGoCBConnString
- replace math/rand with crypto/rand since math/rand.Seed is deprecated since 1.20 for crypto/rand.Seed
- remove random seed on init since go 1.20, which is now builtin, rather than Seed(1)
- remove potential nil checks after we acquire locks in ActiveReplicator
- remove explicit set to benchmark
- check error before defer foo.Close()

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2141/
