### PR TITLE
Drop changeCache.updateStats() lock to read lock

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -81,8 +81,8 @@ type changeCacheStats struct {
 
 func (c *changeCache) updateStats(ctx context.Context) {
 
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 	if c.db == nil {
 		return
 	}


### PR DESCRIPTION
The method doesn't write to any fields on the struct. Doesn't need to hold the full lock.

Avoids contention with the read locks in `getNextSequence()`/`getInitialSequence()`.


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2143/
- [ ] `-race` `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2144/