### PR TITLE
TestRequireResync: Wait for db offline before resyncing

### DIFF
--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -267,6 +267,8 @@ func TestRequireResync(t *testing.T) {
 	resyncPayload, marshalErr := base.JSONMarshal(resyncCollections)
 	require.NoError(t, marshalErr)
 
+	require.NoError(t, rt.WaitForDatabaseState(db2Name, db.DBOffline))
+
 	resp = rt.SendAdminRequest("POST", "/"+db2Name+"/_resync?action=start&regenerate_sequences=true", string(resyncPayload))
 	rest.RequireStatus(t, resp, http.StatusOK)
 


### PR DESCRIPTION
Fix for https://jenkins.sgwdev.com/job/SyncGateway-Integration/2143/testReport/junit/github/com_couchbase_sync_gateway_rest_adminapitest/TestRequireResync/

Test could be in the middle of "Starting" db. Ensure db is back offline before running resync.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `^TestRequireResync$` `x50` `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2146/
