### PR TITLE
CBG-3268 remove RespRevID and prepare for HLV aware testing

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -2320,24 +2320,22 @@ func TestRawTombstone(t *testing.T) {
 	// Create a doc
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID, `{"foo":"bar"}`)
 	rest.RequireStatus(t, resp, http.StatusCreated)
-	revID := rest.RespRevID(t, resp)
+	version := rest.DocVersionFromPutResponse(t, resp)
 
 	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_raw/"+docID, ``)
 	assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 	assert.NotContains(t, string(resp.BodyBytes()), `"_id":"`+docID+`"`)
-	assert.NotContains(t, string(resp.BodyBytes()), `"_rev":"`+revID+`"`)
+	assert.NotContains(t, string(resp.BodyBytes()), `"_rev":"`+version.RevID+`"`)
 	assert.Contains(t, string(resp.BodyBytes()), `"foo":"bar"`)
 	assert.NotContains(t, string(resp.BodyBytes()), `"_deleted":true`)
 
 	// Delete the doc
-	resp = rt.SendAdminRequest(http.MethodDelete, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docID, revID), ``)
-	rest.RequireStatus(t, resp, http.StatusOK)
-	revID = rest.RespRevID(t, resp)
+	deletedVersion := rt.DeleteDocReturnVersion(docID, version)
 
 	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_raw/"+docID, ``)
 	assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 	assert.NotContains(t, string(resp.BodyBytes()), `"_id":"`+docID+`"`)
-	assert.NotContains(t, string(resp.BodyBytes()), `"_rev":"`+revID+`"`)
+	assert.NotContains(t, string(resp.BodyBytes()), `"_rev":"`+deletedVersion.RevID+`"`)
 	assert.NotContains(t, string(resp.BodyBytes()), `"foo":"bar"`)
 	assert.Contains(t, string(resp.BodyBytes()), `"_deleted":true`)
 }
@@ -2808,16 +2806,11 @@ func TestChannelNameSizeWarningUpdateExistingDoc(t *testing.T) {
 
 	// Update doc - should warn
 	chanName := strings.Repeat("B", int(base.DefaultWarnThresholdChannelNameSize)+5)
-	t.Run("Update doc without changing channel", func(t *testing.T) {
-		tr := rt.SendAdminRequest("PUT", "/{{.keyspace}}/replace", `{"chan":"`+chanName+`"}`) // init doc
-		rest.RequireStatus(t, tr, http.StatusCreated)
-
-		ctx := rt.Context()
-		before := rt.ServerContext().Database(ctx, "db").DbStats.Database().WarnChannelNameSizeCount.Value()
-		revId := rest.RespRevID(t, tr)
-		tr = rt.SendAdminRequest("PUT", "/{{.keyspace}}/replace?rev="+revId, `{"chan":"`+chanName+`", "data":"test"}`)
-		rest.RequireStatus(t, tr, http.StatusCreated)
-		after := rt.ServerContext().Database(ctx, "db").DbStats.Database().WarnChannelNameSizeCount.Value()
+	rt.Run("Update doc without changing channel", func(t *testing.T) {
+		version := rt.PutDoc("replace", `{"chan":"`+chanName+`"}`) // init doc
+		before := rt.GetDatabase().DbStats.Database().WarnChannelNameSizeCount.Value()
+		_ = rt.UpdateDoc("replace", version, `{"chan":"`+chanName+`", "data":"test"}`)
+		after := rt.GetDatabase().DbStats.Database().WarnChannelNameSizeCount.Value()
 		assert.Equal(t, before+1, after)
 	})
 }
@@ -2830,19 +2823,14 @@ func TestChannelNameSizeWarningDocChannelUpdate(t *testing.T) {
 
 	channelLength := int(base.DefaultWarnThresholdChannelNameSize) + 5
 	// Update doc channel with creation of a new channel
-	t.Run("Update doc with new channel", func(t *testing.T) {
+	rt.Run("Update doc with new channel", func(t *testing.T) {
 
 		chanName := strings.Repeat("C", channelLength)
-		tr := rt.SendAdminRequest("PUT", "/{{.keyspace}}/replaceNewChannel", `{"chan":"`+chanName+`"}`) // init doc
-		rest.RequireStatus(t, tr, http.StatusCreated)
-
-		ctx := rt.Context()
-		before := rt.ServerContext().Database(ctx, "db").DbStats.Database().WarnChannelNameSizeCount.Value()
-		revId := rest.RespRevID(t, tr)
+		version := rt.PutDoc("replaceNewChannel", `{"chan":"`+chanName+`"}`) // init doc
+		before := rt.GetDatabase().DbStats.Database().WarnChannelNameSizeCount.Value()
 		chanName = strings.Repeat("D", channelLength+5)
-		tr = rt.SendAdminRequest("PUT", "/{{.keyspace}}/replaceNewChannel?rev="+revId, fmt.Sprintf(`{"chan":"`+chanName+`", "data":"test"}`))
-		rest.RequireStatus(t, tr, http.StatusCreated)
-		after := rt.ServerContext().Database(ctx, "db").DbStats.Database().WarnChannelNameSizeCount.Value()
+		_ = rt.UpdateDoc("replaceNewChannel", version, fmt.Sprintf(`{"chan":"`+chanName+`", "data":"test"}`))
+		after := rt.GetDatabase().DbStats.Database().WarnChannelNameSizeCount.Value()
 		assert.Equal(t, before+1, after)
 	})
 }
@@ -2855,17 +2843,12 @@ func TestChannelNameSizeWarningDeleteChannel(t *testing.T) {
 
 	channelLength := int(base.DefaultWarnThresholdChannelNameSize) + 5
 	// Delete channel over max len - no warning
-	t.Run("Delete channel over max length", func(t *testing.T) {
+	rt.Run("Delete channel over max length", func(t *testing.T) {
 		chanName := strings.Repeat("F", channelLength)
-		tr := rt.SendAdminRequest("PUT", "/{{.keyspace}}/deleteme", `{"chan":"`+chanName+`"}`) // init channel
-		rest.RequireStatus(t, tr, http.StatusCreated)
-
-		ctx := rt.Context()
-		before := rt.ServerContext().Database(ctx, "db").DbStats.Database().WarnChannelNameSizeCount.Value()
-		revId := rest.RespRevID(t, tr)
-		tr = rt.SendAdminRequest("DELETE", "/{{.keyspace}}/deleteme?rev="+revId, "")
-		rest.RequireStatus(t, tr, http.StatusOK)
-		after := rt.ServerContext().Database(ctx, "db").DbStats.Database().WarnChannelNameSizeCount.Value()
+		version := rt.PutDoc("deleteme", `{"chan":"`+chanName+`"}`) // init channel
+		before := rt.GetDatabase().DbStats.Database().WarnChannelNameSizeCount.Value()
+		rt.DeleteDoc("deleteme", version)
+		after := rt.GetDatabase().DbStats.Database().WarnChannelNameSizeCount.Value()
 		assert.Equal(t, before, after)
 	})
 }
@@ -4215,9 +4198,7 @@ func TestPutIDRevMatchBody(t *testing.T) {
 	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
 	// Create document to create rev from
-	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc", "{}")
-	rest.RequireStatus(t, resp, 201)
-	rev := rest.RespRevID(t, resp)
+	version := rt.PutDoc("doc", "{}")
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
@@ -4225,12 +4206,12 @@ func TestPutIDRevMatchBody(t *testing.T) {
 			docRev := test.rev
 			docBody := test.docBody
 			if test.docID == "" {
-				docID = "doc" // Used for the rev tests to branch off of
-				docBody = strings.ReplaceAll(docBody, "[REV]", rev)
-				docRev = strings.ReplaceAll(docRev, "[REV]", rev)
+				docID = "doc"                                                 // Used for the rev tests to branch off of
+				docBody = strings.ReplaceAll(docBody, "[REV]", version.RevID) // FIX for HLV?
+				docRev = strings.ReplaceAll(docRev, "[REV]", version.RevID)
 			}
 
-			resp = rt.SendAdminRequest("PUT", fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docID, docRev), docBody)
+			resp := rt.SendAdminRequest("PUT", fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docID, docRev), docBody)
 			if test.expectError {
 				rest.RequireStatus(t, resp, 400)
 				return
@@ -4238,7 +4219,7 @@ func TestPutIDRevMatchBody(t *testing.T) {
 			rest.RequireStatus(t, resp, 201)
 			if test.docID == "" {
 				// Update rev to branch off for next test
-				rev = rest.RespRevID(t, resp)
+				version = rest.DocVersionFromPutResponse(t, resp)
 			}
 		})
 	}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2754,11 +2754,9 @@ func TestTombstoneCompactionAPI(t *testing.T) {
 	rt.GetDatabase().Options.PurgeInterval = &zero
 
 	for i := 0; i < 100; i++ {
-		resp := rt.SendAdminRequest("PUT", fmt.Sprintf("/{{.keyspace}}/doc%d", i), "{}")
-		RequireStatus(t, resp, http.StatusCreated)
-		rev := RespRevID(t, resp)
-		resp = rt.SendAdminRequest("DELETE", fmt.Sprintf("/{{.keyspace}}/doc%d?rev=%s", i, rev), "{}")
-		RequireStatus(t, resp, http.StatusOK)
+		docID := fmt.Sprintf("doc%d", i)
+		version := rt.PutDoc(docID, "{}")
+		rt.DeleteDoc(docID, version)
 	}
 
 	resp := rt.SendAdminRequest("GET", "/{{.db}}/_compact", "")

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1972,7 +1972,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(changes.Results))
 	assert.Equal(t, "doc", changes.Results[0].ID)
-	requireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+	RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
 
 	err = btc.StartOneshotPull()
 	assert.NoError(t, err)
@@ -1985,7 +1985,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(changes.Results))
 	assert.Equal(t, docID, changes.Results[0].ID)
-	requireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+	RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
 
 	err = btc.StartOneshotPull()
 	assert.NoError(t, err)
@@ -2000,11 +2000,11 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, changes.Results, 2)
 	assert.Equal(t, "doc", changes.Results[0].ID)
-	requireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+	RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
 	assert.Equal(t, "3-1bc9dd04c8a257ba28a41eaad90d32de", changes.Results[0].Changes[0]["rev"])
 	assert.False(t, changes.Results[0].Revoked)
 	assert.Equal(t, "docmarker", changes.Results[1].ID)
-	requireChangeRevVersion(t, docMarkerVersion, changes.Results[1].Changes[0])
+	RequireChangeRevVersion(t, docMarkerVersion, changes.Results[1].Changes[0])
 	assert.Equal(t, "1-999bcad4aab47f0a8a24bd9d3598060c", changes.Results[1].Changes[0]["rev"])
 	assert.False(t, changes.Results[1].Revoked)
 
@@ -2082,7 +2082,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(changes.Results))
 	assert.Equal(t, docID, changes.Results[0].ID)
-	requireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+	RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
 
 	err = btc.StartOneshotPull()
 	assert.NoError(t, err)
@@ -2096,7 +2096,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(changes.Results))
 	assert.Equal(t, docID, changes.Results[0].ID)
-	requireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+	RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
 
 	err = btc.StartOneshotPullFiltered("A")
 	assert.NoError(t, err)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -6896,7 +6896,6 @@ func TestLocalWinsConflictResolution(t *testing.T) {
 	for _, test := range conflictResolutionTests {
 		t.Run(test.name, func(t *testing.T) {
 			base.RequireNumTestBuckets(t, 2)
-			base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
 
 			activeRT, remoteRT, remoteURLString, teardown := rest.SetupSGRPeers(t)
 			defer teardown()
@@ -6947,7 +6946,7 @@ func TestLocalWinsConflictResolution(t *testing.T) {
 				localParentVersion = activeRT.PutNewEditsFalse(docID, newLocalVersion, localParentVersion, makeRevBody(test.localMutation.propertyValue, localRevPos, localGen))
 			}
 
-			remoteParentVersion := newLocalVersion
+			remoteParentVersion := newVersion
 			var newRemoteVersion rest.DocVersion
 			for remoteGen := test.initialState.generation + 1; remoteGen <= test.remoteMutation.generation; remoteGen++ {
 				// If deleted=true, tombstone on the last mutation
@@ -6962,7 +6961,7 @@ func TestLocalWinsConflictResolution(t *testing.T) {
 				if test.remoteMutation.attachmentRevPos > 0 {
 					remoteRevPos = test.remoteMutation.attachmentRevPos
 				}
-				_ = remoteRT.PutNewEditsFalse(docID, newRemoteVersion, remoteParentVersion, makeRevBody(test.remoteMutation.propertyValue, remoteRevPos, remoteGen))
+				remoteParentVersion = remoteRT.PutNewEditsFalse(docID, newRemoteVersion, remoteParentVersion, makeRevBody(test.remoteMutation.propertyValue, remoteRevPos, remoteGen))
 			}
 
 			rawResponse = activeRT.SendAdminRequest("GET", "/{{.keyspace}}/_raw/"+docID, "")

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -2102,9 +2102,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	rt2.CreateUser(username, []string{username})
 
 	docID := t.Name() + "rt2doc1"
-	resp := rt2.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID, `{"source":"rt2","channels":["`+username+`"]}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	revID := rest.RespRevID(t, resp)
+	version := rt2.PutDoc(docID, `{"source":"rt2","channels":["`+username+`"]}`)
 
 	remoteDoc, err := rt2.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
@@ -2161,7 +2159,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	doc, err := rt1.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
-	assert.Equal(t, revID, doc.SyncData.CurrentRev)
+	requireDocumentVersion(t, version, doc)
 
 	body, err := doc.GetDeepMutableBody()
 	require.NoError(t, err)
@@ -2596,9 +2594,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	attachment := `"_attachments":{"hi.txt":{"data":"aGk=","content_type":"text/plain"}}`
 
 	docID := t.Name() + "rt2doc1"
-	resp := rt2.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID, `{"source":"rt2","doc_num":1,`+attachment+`,"channels":["alice"]}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	revID := rest.RespRevID(t, resp)
+	version := rt2.PutDoc(docID, `{"source":"rt2","doc_num":1,`+attachment+`,"channels":["alice"]}`)
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
 	srv := httptest.NewServer(rt2.TestPublicHandler())
@@ -2649,7 +2645,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	doc, err := rt1.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
-	assert.Equal(t, revID, doc.SyncData.CurrentRev)
+	requireDocumentVersion(t, version, doc)
 	body, err := doc.GetDeepMutableBody()
 	require.NoError(t, err)
 	assert.Equal(t, "rt2", body["source"])
@@ -2657,9 +2653,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	assert.Equal(t, int64(1), ar.Pull.GetStats().GetAttachment.Value())
 
 	docID = t.Name() + "rt2doc2"
-	resp = rt2.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID, `{"source":"rt2","doc_num":2,`+attachment+`,"channels":["alice"]}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	revID = rest.RespRevID(t, resp)
+	version = rt2.PutDoc(docID, `{"source":"rt2","doc_num":2,`+attachment+`,"channels":["alice"]}`)
 
 	// wait for the new document written to rt2 to arrive at rt1
 	changesResults, err = rt1.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0", "", true)
@@ -2670,7 +2664,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	doc2, err := rt1.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
-	assert.Equal(t, revID, doc2.SyncData.CurrentRev)
+	requireDocumentVersion(t, version, doc2)
 
 	body, err = doc.GetDeepMutableBody()
 	require.NoError(t, err)
@@ -3090,13 +3084,9 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 	// Create first batch of docs
 	docIDPrefix := t.Name() + "doc"
 	for i := 0; i < numRT2DocsInitial; i++ {
-		resp := rt1.SendAdminRequest(http.MethodPut, fmt.Sprintf("/{{.keyspace}}/%s%d", docIDPrefix, i), `{"channels":["alice"]}`)
-		rest.RequireStatus(t, resp, http.StatusCreated)
-		rt1RevID := rest.RespRevID(t, resp)
-		resp = rt2.SendAdminRequest(http.MethodPut, fmt.Sprintf("/{{.keyspace}}/%s%d", docIDPrefix, i), `{"channels":["alice"]}`)
-		rest.RequireStatus(t, resp, http.StatusCreated)
-		rt2RevID := rest.RespRevID(t, resp)
-		require.Equal(t, rt1RevID, rt2RevID)
+		rt1Version := rt1.PutDoc(fmt.Sprintf("%s%d", docIDPrefix, i), `{"channels":["alice"]}`)
+		rt2Version := rt2.PutDoc(fmt.Sprintf("%s%d", docIDPrefix, i), `{"channels":["alice"]}`)
+		rest.RequireDocVersionEqual(t, rt1Version, rt2Version)
 	}
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
@@ -3179,13 +3169,9 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 
 	// Second batch of docs
 	for i := numRT2DocsInitial; i < numRT2DocsTotal; i++ {
-		resp := rt1.SendAdminRequest(http.MethodPut, fmt.Sprintf("/{{.keyspace}}/%s%d", docIDPrefix, i), `{"channels":["alice"]}`)
-		rest.RequireStatus(t, resp, http.StatusCreated)
-		rt1RevID := rest.RespRevID(t, resp)
-		resp = rt2.SendAdminRequest(http.MethodPut, fmt.Sprintf("/{{.keyspace}}/%s%d", docIDPrefix, i), `{"channels":["alice"]}`)
-		rest.RequireStatus(t, resp, http.StatusCreated)
-		rt2RevID := rest.RespRevID(t, resp)
-		require.Equal(t, rt1RevID, rt2RevID)
+		rt1Version := rt1.PutDoc(fmt.Sprintf("%s%d", docIDPrefix, i), `{"channels":["alice"]}`)
+		rt2Version := rt2.PutDoc(fmt.Sprintf("%s%d", docIDPrefix, i), `{"channels":["alice"]}`)
+		rest.RequireDocVersionEqual(t, rt1Version, rt2Version)
 	}
 
 	// Create a new replicator using the same config, which should use the checkpoint set from the first.
@@ -3332,9 +3318,7 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 	ctx1 := rt1.Context()
 
 	docID := t.Name() + "rt1doc1"
-	resp := rt1.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID, `{"source":"rt1","channels":["alice"]}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	revID := rest.RespRevID(t, resp)
+	version := rt1.PutDoc(docID, `{"source":"rt1","channels":["alice"]}`)
 
 	localDoc, err := rt1.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
@@ -3381,7 +3365,7 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 	doc, err := rt2.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
-	assert.Equal(t, revID, doc.SyncData.CurrentRev)
+	requireDocumentVersion(t, version, doc)
 
 	body, err := doc.GetDeepMutableBody()
 	require.NoError(t, err)
@@ -3417,9 +3401,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 	attachment := `"_attachments":{"hi.txt":{"data":"aGk=","content_type":"text/plain"}}`
 
 	docID := t.Name() + "rt1doc1"
-	resp := rt1.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID, `{"source":"rt1","doc_num":1,`+attachment+`,"channels":["alice"]}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	revID := rest.RespRevID(t, resp)
+	version := rt1.PutDoc(docID, `{"source":"rt1","doc_num":1,`+attachment+`,"channels":["alice"]}`)
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
 	srv := httptest.NewServer(rt2.TestPublicHandler())
@@ -3464,7 +3446,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 	doc, err := rt2.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
-	assert.Equal(t, revID, doc.SyncData.CurrentRev)
+	requireDocumentVersion(t, version, doc)
 
 	body, err := doc.GetDeepMutableBody()
 	require.NoError(t, err)
@@ -3473,9 +3455,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 	assert.Equal(t, int64(1), ar.Push.GetStats().HandleGetAttachment.Value())
 
 	docID = t.Name() + "rt1doc2"
-	resp = rt1.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID, `{"source":"rt1","doc_num":2,`+attachment+`,"channels":["alice"]}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	revID = rest.RespRevID(t, resp)
+	version = rt1.PutDoc(docID, `{"source":"rt1","doc_num":2,`+attachment+`,"channels":["alice"]}`)
 
 	// wait for the new document written to rt1 to arrive at rt2
 	changesResults, err = rt2.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0", "", true)
@@ -3486,7 +3466,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 	doc2, err := rt2.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
-	assert.Equal(t, revID, doc2.SyncData.CurrentRev)
+	requireDocumentVersion(t, version, doc2)
 
 	body, err = doc.GetDeepMutableBody()
 	require.NoError(t, err)
@@ -3884,9 +3864,7 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 	ctx1 := rt1.Context()
 
 	docID := t.Name() + "rt1doc1"
-	resp := rt1.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID, `{"source":"rt1","channels":["alice"]}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	revID := rest.RespRevID(t, resp)
+	version := rt1.PutDoc(docID, `{"source":"rt1","channels":["alice"]}`)
 
 	localDoc, err := rt1.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
@@ -3940,7 +3918,7 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 	doc, err := rt2.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
-	assert.Equal(t, revID, doc.SyncData.CurrentRev)
+	requireDocumentVersion(t, version, doc)
 
 	body, err := doc.GetDeepMutableBody()
 	require.NoError(t, err)
@@ -3972,9 +3950,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	rt2.CreateUser(username, []string{username})
 
 	docID := t.Name() + "rt2doc1"
-	resp := rt2.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID, `{"source":"rt2","channels":["alice"]}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	revID := rest.RespRevID(t, resp)
+	version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
 	srv := httptest.NewServer(rt2.TestPublicHandler())
@@ -4027,16 +4003,14 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	doc, err := rt1.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
-	assert.Equal(t, revID, doc.SyncData.CurrentRev)
+	requireDocumentVersion(t, version, doc)
 
 	body, err := doc.GetDeepMutableBody()
 	require.NoError(t, err)
 	assert.Equal(t, "rt2", body["source"])
 
 	// Tombstone the doc in rt2
-	resp = rt2.SendAdminRequest(http.MethodDelete, "/{{.keyspace}}/"+docID+"?rev="+revID, ``)
-	rest.RequireStatus(t, resp, http.StatusOK)
-	revID = rest.RespRevID(t, resp)
+	deletedVersion := rt2.DeleteDocReturnVersion(docID, version)
 
 	// wait for the tombstone written to rt2 to arrive at rt1
 	changesResults, err = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+strconv.FormatUint(doc.Sequence, 10), "", true)
@@ -4048,7 +4022,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.True(t, doc.IsDeleted())
-	assert.Equal(t, revID, doc.SyncData.CurrentRev)
+	requireDocumentVersion(t, deletedVersion, doc)
 }
 
 // TestActiveReplicatorPullPurgeOnRemoval:
@@ -4076,9 +4050,7 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 	rt2.CreateUser(username, []string{username})
 
 	docID := t.Name() + "rt2doc1"
-	resp := rt2.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID, `{"source":"rt2","channels":["alice"]}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	revID := rest.RespRevID(t, resp)
+	version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
 	srv := httptest.NewServer(rt2.TestPublicHandler())
@@ -4128,14 +4100,13 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 	doc, err := rt1.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
-	assert.Equal(t, revID, doc.SyncData.CurrentRev)
+	requireDocumentVersion(t, version, doc)
 
 	body, err := doc.GetDeepMutableBody()
 	require.NoError(t, err)
 	assert.Equal(t, "rt2", body["source"])
 
-	resp = rt2.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID+"?rev="+revID, `{"source":"rt2","channels":["bob"]}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
+	_ = rt2.UpdateDoc(docID, version, `{"source":"rt2","channels":["bob"]}`)
 
 	// wait for the channel removal written to rt2 to arrive at rt1 - we can't monitor _changes, because we've purged, not removed. But we can monitor the associated stat.
 	base.WaitForStat(t, func() int64 {
@@ -4159,77 +4130,77 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 
 	// scenarios
 	conflictResolutionTests := []struct {
-		name                    string
-		localRevisionBody       db.Body
-		localRevID              string
-		remoteRevisionBody      db.Body
-		remoteRevID             string
-		conflictResolver        string
-		expectedLocalBody       db.Body
-		expectedLocalRevID      string
-		expectedTombstonedRevID string
-		expectedResolutionType  db.ConflictResolutionType
-		skipActiveLeafAssertion bool
-		skipBodyAssertion       bool
+		name                      string
+		localRevisionBody         string
+		localVersion              rest.DocVersion
+		remoteRevisionBody        string
+		remoteVersion             rest.DocVersion
+		conflictResolver          string
+		expectedLocalBody         string
+		expectedLocalVersion      rest.DocVersion
+		expectedTombstonedVersion rest.DocVersion
+		expectedResolutionType    db.ConflictResolutionType
+		skipActiveLeafAssertion   bool
+		skipBodyAssertion         bool
 	}{
 		{
 			name:                   "remoteWins",
-			localRevisionBody:      db.Body{"source": "local"},
-			localRevID:             "1-a",
-			remoteRevisionBody:     db.Body{"source": "remote"},
-			remoteRevID:            "1-b",
+			localRevisionBody:      `{"source": "local"}`,
+			localVersion:           rest.NewDocVersionFromFakeRev("1-a"),
+			remoteRevisionBody:     `{"source": "remote"}`,
+			remoteVersion:          rest.NewDocVersionFromFakeRev("1-b"),
 			conflictResolver:       `function(conflict) {return conflict.RemoteDocument;}`,
-			expectedLocalBody:      db.Body{"source": "remote"},
-			expectedLocalRevID:     "1-b",
+			expectedLocalBody:      `{"source": "remote"}`,
+			expectedLocalVersion:   rest.NewDocVersionFromFakeRev("1-b"),
 			expectedResolutionType: db.ConflictResolutionRemote,
 		},
 		{
 			name:               "merge",
-			localRevisionBody:  db.Body{"source": "local"},
-			localRevID:         "1-a",
-			remoteRevisionBody: db.Body{"source": "remote"},
-			remoteRevID:        "1-b",
+			localRevisionBody:  `{"source": "local"}`,
+			localVersion:       rest.NewDocVersionFromFakeRev("1-a"),
+			remoteRevisionBody: `{"source": "remote"}`,
+			remoteVersion:      rest.NewDocVersionFromFakeRev("1-b"),
 			conflictResolver: `function(conflict) {
 					var mergedDoc = new Object();
 					mergedDoc.source = "merged";
 					return mergedDoc;
 				}`,
-			expectedLocalBody:      db.Body{"source": "merged"},
-			expectedLocalRevID:     db.CreateRevIDWithBytes(2, "1-b", []byte(`{"source":"merged"}`)), // rev for merged body, with parent 1-b
+			expectedLocalBody:      `{"source": "merged"}`,
+			expectedLocalVersion:   rest.NewDocVersionFromFakeRev(db.CreateRevIDWithBytes(2, "1-b", []byte(`{"source":"merged"}`))), // rev for merged body, with parent 1-b
 			expectedResolutionType: db.ConflictResolutionMerge,
 		},
 		{
 			name:                   "localWins",
-			localRevisionBody:      db.Body{"source": "local"},
-			localRevID:             "1-a",
-			remoteRevisionBody:     db.Body{"source": "remote"},
-			remoteRevID:            "1-b",
+			localRevisionBody:      `{"source": "local"}`,
+			localVersion:           rest.NewDocVersionFromFakeRev("1-a"),
+			remoteRevisionBody:     `{"source": "remote"}`,
+			remoteVersion:          rest.NewDocVersionFromFakeRev("1-b"),
 			conflictResolver:       `function(conflict) {return conflict.LocalDocument;}`,
-			expectedLocalBody:      db.Body{"source": "local"},
-			expectedLocalRevID:     db.CreateRevIDWithBytes(2, "1-b", []byte(`{"source":"local"}`)), // rev for local body, transposed under parent 1-b
+			expectedLocalBody:      `{"source": "local"}`,
+			expectedLocalVersion:   rest.NewDocVersionFromFakeRev(db.CreateRevIDWithBytes(2, "1-b", []byte(`{"source":"local"}`))), // rev for local body, transposed under parent 1-b
 			expectedResolutionType: db.ConflictResolutionLocal,
 		},
 		{
 			name:                    "twoTombstonesRemoteWin",
-			localRevisionBody:       db.Body{"_deleted": true, "source": "local"},
-			localRevID:              "1-a",
-			remoteRevisionBody:      db.Body{"_deleted": true, "source": "remote"},
-			remoteRevID:             "1-b",
+			localRevisionBody:       `{"_deleted": true, "source": "local"}`,
+			localVersion:            rest.NewDocVersionFromFakeRev("1-a"),
+			remoteRevisionBody:      `{"_deleted": true, "source": "remote"}`,
+			remoteVersion:           rest.NewDocVersionFromFakeRev("1-b"),
 			conflictResolver:        `function(conflict){}`,
-			expectedLocalBody:       db.Body{"source": "remote"},
-			expectedLocalRevID:      "1-b",
+			expectedLocalBody:       `{"source": "remote"}`,
+			expectedLocalVersion:    rest.NewDocVersionFromFakeRev("1-b"),
 			skipActiveLeafAssertion: true,
 			skipBodyAssertion:       base.TestUseXattrs(),
 		},
 		{
 			name:                    "twoTombstonesLocalWin",
-			localRevisionBody:       db.Body{"_deleted": true, "source": "local"},
-			localRevID:              "1-b",
-			remoteRevisionBody:      db.Body{"_deleted": true, "source": "remote"},
-			remoteRevID:             "1-a",
+			localRevisionBody:       `{"_deleted": true, "source": "local"}`,
+			localVersion:            rest.NewDocVersionFromFakeRev("1-b"),
+			remoteRevisionBody:      `{"_deleted": true, "source": "remote"}`,
+			remoteVersion:           rest.NewDocVersionFromFakeRev("1-a"),
 			conflictResolver:        `function(conflict){}`,
-			expectedLocalBody:       db.Body{"source": "local"},
-			expectedLocalRevID:      "1-b",
+			expectedLocalBody:       `{"source": "local"}`,
+			expectedLocalVersion:    rest.NewDocVersionFromFakeRev("1-b"),
 			skipActiveLeafAssertion: true,
 			skipBodyAssertion:       base.TestUseXattrs(),
 		},
@@ -4248,11 +4219,8 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 
 			// Create revision on rt2 (remote)
 			docID := test.name
-			resp, err := rt2.PutDocumentWithRevID(docID, test.remoteRevID, "", test.remoteRevisionBody)
-			assert.NoError(t, err)
-			rest.RequireStatus(t, resp, http.StatusCreated)
-			rt2revID := rest.RespRevID(t, resp)
-			assert.Equal(t, test.remoteRevID, rt2revID)
+			rt2Version := rt2.PutNewEditsFalse(docID, test.remoteVersion, rest.EmptyDocVersion(), test.remoteRevisionBody)
+			rest.RequireDocVersionEqual(t, test.remoteVersion, rt2Version)
 
 			// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
 			srv := httptest.NewServer(rt2.TestPublicHandler())
@@ -4270,11 +4238,8 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			ctx1 := rt1.Context()
 
 			// Create revision on rt1 (local)
-			resp, err = rt1.PutDocumentWithRevID(docID, test.localRevID, "", test.localRevisionBody)
-			assert.NoError(t, err)
-			rest.RequireStatus(t, resp, http.StatusCreated)
-			rt1revID := rest.RespRevID(t, resp)
-			assert.Equal(t, test.localRevID, rt1revID)
+			rt1version := rt1.PutNewEditsFalse(docID, test.localVersion, rest.EmptyDocVersion(), test.localRevisionBody)
+			rest.RequireDocVersionEqual(t, test.localVersion, rt1version)
 
 			customConflictResolver, err := db.NewCustomConflictResolver(ctx1, test.conflictResolver, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err)
@@ -4327,20 +4292,18 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, changesResults.Results, 1)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
-			assert.Equal(t, test.expectedLocalRevID, changesResults.Results[0].Changes[0]["rev"])
+			rest.RequireChangeRevVersion(t, test.expectedLocalVersion, changesResults.Results[0].Changes[0])
 			log.Printf("Changes response is %+v", changesResults)
 
 			doc, err := rt1.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 			require.NoError(t, err)
-			assert.Equal(t, test.expectedLocalRevID, doc.SyncData.CurrentRev)
+			requireDocumentVersion(t, test.expectedLocalVersion, doc)
 
 			// This is skipped for tombstone tests running with xattr as xattr tombstones don't have a body to assert
 			// against
-			ctx := base.TestCtx(t)
 			if !test.skipBodyAssertion {
-				assert.Equal(t, test.expectedLocalBody, doc.Body(ctx))
+				requireBodyEqual(t, test.expectedLocalBody, doc)
 			}
-
 			log.Printf("Doc %s is %+v", docID, doc)
 			for revID, revInfo := range doc.SyncData.History {
 				log.Printf("doc revision [%s]: %+v", revID, revInfo)
@@ -4380,61 +4343,61 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 
 	// scenarios
 	conflictResolutionTests := []struct {
-		name                    string
-		localRevisionBody       []byte
-		localRevID              string
-		remoteRevisionBody      []byte
-		remoteRevID             string
-		commonAncestorRevID     string
-		conflictResolver        string
-		expectedBody            []byte
-		expectedRevID           string
-		expectedTombstonedRevID string
+		name                      string
+		localRevisionBody         string
+		localVersion              rest.DocVersion
+		remoteRevisionBody        string
+		remoteVersion             rest.DocVersion
+		commonAncestorVersion     rest.DocVersion
+		conflictResolver          string
+		expectedBody              string
+		expectedVersion           rest.DocVersion
+		expectedTombstonedVersion string
 	}{
 		{
 			name:               "remoteWins",
-			localRevisionBody:  []byte(`{"source": "local"}`),
-			localRevID:         "1-a",
-			remoteRevisionBody: []byte(`{"source": "remote"}`),
-			remoteRevID:        "1-b",
+			localRevisionBody:  `{"source": "local"}`,
+			localVersion:       rest.NewDocVersionFromFakeRev("1-a"),
+			remoteRevisionBody: `{"source": "remote"}`,
+			remoteVersion:      rest.NewDocVersionFromFakeRev("1-b"),
 			conflictResolver:   `function(conflict) {return conflict.RemoteDocument;}`,
-			expectedBody:       []byte(`{"source": "remote"}`),
-			expectedRevID:      "1-b",
+			expectedBody:       `{"source": "remote"}`,
+			expectedVersion:    rest.NewDocVersionFromFakeRev("1-b"),
 		},
 		{
 			name:               "merge",
-			localRevisionBody:  []byte(`{"source": "local"}`),
-			localRevID:         "1-a",
-			remoteRevisionBody: []byte(`{"source": "remote"}`),
-			remoteRevID:        "1-b",
+			localRevisionBody:  `{"source": "local"}`,
+			localVersion:       rest.NewDocVersionFromFakeRev("1-a"),
+			remoteRevisionBody: `{"source": "remote"}`,
+			remoteVersion:      rest.NewDocVersionFromFakeRev("1-b"),
 			conflictResolver: `function(conflict) {
 							var mergedDoc = new Object();
 							mergedDoc.source = "merged";
 							return mergedDoc;
 						}`,
-			expectedBody:  []byte(`{"source": "merged"}`),
-			expectedRevID: db.CreateRevIDWithBytes(2, "1-b", []byte(`{"source":"merged"}`)), // rev for merged body, with parent 1-b
+			expectedBody:    `{"source": "merged"}`,
+			expectedVersion: rest.NewDocVersionFromFakeRev(db.CreateRevIDWithBytes(2, "1-b", []byte(`{"source":"merged"}`))), // rev for merged body, with parent 1-b
 		},
 		{
 			name:               "localWins",
-			localRevisionBody:  []byte(`{"source": "local"}`),
-			localRevID:         "1-a",
-			remoteRevisionBody: []byte(`{"source": "remote"}`),
-			remoteRevID:        "1-b",
+			localRevisionBody:  `{"source": "local"}`,
+			localVersion:       rest.NewDocVersionFromFakeRev("1-a"),
+			remoteRevisionBody: `{"source": "remote"}`,
+			remoteVersion:      rest.NewDocVersionFromFakeRev("1-b"),
 			conflictResolver:   `function(conflict) {return conflict.LocalDocument;}`,
-			expectedBody:       []byte(`{"source": "local"}`),
-			expectedRevID:      db.CreateRevIDWithBytes(2, "1-b", []byte(`{"source":"local"}`)), // rev for local body, transposed under parent 1-b
+			expectedBody:       `{"source": "local"}`,
+			expectedVersion:    rest.NewDocVersionFromFakeRev(db.CreateRevIDWithBytes(2, "1-b", []byte(`{"source":"local"}`))), // rev for local body, transposed under parent 1-b
 		},
 		{
-			name:                "localWinsRemoteTombstone",
-			localRevisionBody:   []byte(`{"source": "local"}`),
-			localRevID:          "2-a",
-			remoteRevisionBody:  []byte(`{"_deleted": true}`),
-			remoteRevID:         "2-b",
-			commonAncestorRevID: "1-a",
-			conflictResolver:    `function(conflict) {return conflict.LocalDocument;}`,
-			expectedBody:        []byte(`{"source": "local"}`),
-			expectedRevID:       db.CreateRevIDWithBytes(3, "2-b", []byte(`{"source":"local"}`)), // rev for local body, transposed under parent 2-b
+			name:                  "localWinsRemoteTombstone",
+			localRevisionBody:     `{"source": "local"}`,
+			localVersion:          rest.NewDocVersionFromFakeRev("2-a"),
+			remoteRevisionBody:    `{"_deleted": true}`,
+			remoteVersion:         rest.NewDocVersionFromFakeRev("2-b"),
+			commonAncestorVersion: rest.NewDocVersionFromFakeRev("1-a"),
+			conflictResolver:      `function(conflict) {return conflict.LocalDocument;}`,
+			expectedBody:          `{"source": "local"}`,
+			expectedVersion:       rest.NewDocVersionFromFakeRev(db.CreateRevIDWithBytes(3, "2-b", []byte(`{"source":"local"}`))), // rev for local body, transposed under parent 2-b
 		},
 	}
 
@@ -4449,31 +4412,16 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			username := "alice"
 			rt2.CreateUser(username, []string{"*"})
 
-			var localRevisionBody db.Body
-			assert.NoError(t, json.Unmarshal(test.localRevisionBody, &localRevisionBody))
-
-			var remoteRevisionBody db.Body
-			assert.NoError(t, json.Unmarshal(test.remoteRevisionBody, &remoteRevisionBody))
-
-			var expectedLocalBody db.Body
-			assert.NoError(t, json.Unmarshal(test.expectedBody, &expectedLocalBody))
-
 			// Create revision on rt2 (remote)
 			docID := test.name
 
-			if test.commonAncestorRevID != "" {
-				resp, err := rt2.PutDocumentWithRevID(docID, test.commonAncestorRevID, "", remoteRevisionBody)
-				assert.NoError(t, err)
-				rest.RequireStatus(t, resp, http.StatusCreated)
-				rt2revID := rest.RespRevID(t, resp)
-				assert.Equal(t, test.commonAncestorRevID, rt2revID)
+			if !test.commonAncestorVersion.Equal(rest.EmptyDocVersion()) {
+				rt2Version := rt2.PutNewEditsFalse(docID, test.commonAncestorVersion, rest.EmptyDocVersion(), test.remoteRevisionBody)
+				rest.RequireDocVersionEqual(t, test.commonAncestorVersion, rt2Version)
 			}
 
-			resp, err := rt2.PutDocumentWithRevID(docID, test.remoteRevID, test.commonAncestorRevID, remoteRevisionBody)
-			assert.NoError(t, err)
-			rest.RequireStatus(t, resp, http.StatusCreated)
-			rt2revID := rest.RespRevID(t, resp)
-			assert.Equal(t, test.remoteRevID, rt2revID)
+			rt2Version := rt2.PutNewEditsFalse(docID, test.remoteVersion, test.commonAncestorVersion, test.remoteRevisionBody)
+			rest.RequireDocVersionEqual(t, test.remoteVersion, rt2Version)
 
 			remoteDoc, err := rt2.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalSync)
 			require.NoError(t, err)
@@ -4494,19 +4442,13 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			ctx1 := rt1.Context()
 
 			// Create revision on rt1 (local)
-			if test.commonAncestorRevID != "" {
-				resp, err = rt1.PutDocumentWithRevID(docID, test.commonAncestorRevID, "", localRevisionBody)
-				assert.NoError(t, err)
-				rest.RequireStatus(t, resp, http.StatusCreated)
-				rt1revID := rest.RespRevID(t, resp)
-				assert.Equal(t, test.commonAncestorRevID, rt1revID)
+			if !test.commonAncestorVersion.Equal(rest.EmptyDocVersion()) {
+				rt1version := rt1.PutNewEditsFalse(docID, test.commonAncestorVersion, rest.EmptyDocVersion(), test.localRevisionBody)
+				rest.RequireDocVersionEqual(t, test.commonAncestorVersion, rt1version)
 			}
 
-			resp, err = rt1.PutDocumentWithRevID(docID, test.localRevID, test.commonAncestorRevID, localRevisionBody)
-			assert.NoError(t, err)
-			rest.RequireStatus(t, resp, http.StatusCreated)
-			rt1revID := rest.RespRevID(t, resp)
-			assert.Equal(t, test.localRevID, rt1revID)
+			rt1Version := rt1.PutNewEditsFalse(docID, test.localVersion, test.commonAncestorVersion, test.localRevisionBody)
+			rest.RequireDocVersionEqual(t, test.localVersion, rt1Version)
 
 			localDoc, err := rt1.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalSync)
 			require.NoError(t, err)
@@ -4548,7 +4490,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, changesResults.Results, 1)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
-			assert.Equal(t, test.expectedRevID, changesResults.Results[0].Changes[0]["rev"])
+			rest.RequireChangeRevVersion(t, test.expectedVersion, changesResults.Results[0].Changes[0])
 			log.Printf("Changes response is %+v", changesResults)
 
 			rawDocResponse := rt1.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_raw/"+docID, "")
@@ -4559,9 +4501,8 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 
 			doc, err := rt1.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 			require.NoError(t, err)
-			assert.Equal(t, test.expectedRevID, doc.SyncData.CurrentRev)
-			ctx := base.TestCtx(t)
-			assert.Equal(t, expectedLocalBody, doc.Body(ctx))
+			requireDocumentVersion(t, test.expectedVersion, doc)
+			requireBodyEqual(t, test.expectedBody, doc)
 			log.Printf("Doc %s is %+v", docID, doc)
 			log.Printf("Doc %s attachments are %+v", docID, doc.Attachments)
 			for revID, revInfo := range doc.SyncData.History {
@@ -4587,7 +4528,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 
 			// Validate results on the remote (rt2)
 			rt2Since := remoteDoc.Sequence
-			if test.expectedRevID == test.remoteRevID {
+			if test.expectedVersion.Equal(test.remoteVersion) {
 				// no changes should have been pushed back up to rt2, because this rev won.
 				rt2Since = 0
 			}
@@ -4595,13 +4536,13 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, changesResults.Results, 1)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
-			assert.Equal(t, test.expectedRevID, changesResults.Results[0].Changes[0]["rev"])
+			rest.RequireChangeRevVersion(t, test.expectedVersion, changesResults.Results[0].Changes[0])
 			log.Printf("Changes response is %+v", changesResults)
 
 			doc, err = rt2.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 			require.NoError(t, err)
-			assert.Equal(t, test.expectedRevID, doc.SyncData.CurrentRev)
-			assert.Equal(t, expectedLocalBody, doc.Body(ctx))
+			requireDocumentVersion(t, test.expectedVersion, doc)
+			requireBodyEqual(t, test.expectedBody, doc)
 			log.Printf("Remote Doc %s is %+v", docID, doc)
 			log.Printf("Remote Doc %s attachments are %+v", docID, doc.Attachments)
 			for revID, revInfo := range doc.SyncData.History {
@@ -4649,9 +4590,7 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 	ctx1 := rt1.Context()
 
 	docID := t.Name() + "rt1doc1"
-	resp := rt1.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID, `{"source":"rt1","channels":["alice"]}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	revID := rest.RespRevID(t, resp)
+	version := rt1.PutDoc(docID, `{"source":"rt1","channels":["alice"]}`)
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
 	srv := httptest.NewTLSServer(rt2.TestPublicHandler())
@@ -4694,7 +4633,7 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 	doc, err := rt1.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
-	assert.Equal(t, revID, doc.SyncData.CurrentRev)
+	requireDocumentVersion(t, version, doc)
 
 	body, err := doc.GetDeepMutableBody()
 	require.NoError(t, err)
@@ -5392,9 +5331,7 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	ctx1 := rt1.Context()
 
 	rt1docID := t.Name() + "rt1doc1"
-	resp := rt1.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+rt1docID, `{"source":"rt1","channels":["alice"]}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	rt1revID := rest.RespRevID(t, resp)
+	rt1Version := rt1.PutDoc(rt1docID, `{"source":"rt1","channels":["alice"]}`)
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
 	srv := httptest.NewServer(rt2.TestPublicHandler())
@@ -5439,7 +5376,7 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	doc, err := rt2.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), rt1docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
-	assert.Equal(t, rt1revID, doc.SyncData.CurrentRev)
+	requireDocumentVersion(t, rt1Version, doc)
 
 	body, err := doc.GetDeepMutableBody()
 	require.NoError(t, err)
@@ -5447,9 +5384,7 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 
 	// write a doc on rt2 ...
 	rt2docID := t.Name() + "rt2doc1"
-	resp = rt2.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+rt2docID, `{"source":"rt2","channels":["alice"]}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	rt2revID := rest.RespRevID(t, resp)
+	rt2Version := rt2.PutDoc(rt2docID, `{"source":"rt2","channels":["alice"]}`)
 
 	// ... and wait to arrive at rt1
 	changesResults, err = rt1.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0", "", true)
@@ -5461,7 +5396,7 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	doc, err = rt1.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), rt2docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
-	assert.Equal(t, rt2revID, doc.SyncData.CurrentRev)
+	requireDocumentVersion(t, rt2Version, doc)
 
 	body, err = doc.GetDeepMutableBody()
 	require.NoError(t, err)
@@ -5967,35 +5902,31 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 
 	base.LongRunningTest(t)
 
-	createRevID := func(generation int, parentRevID string, body db.Body) string {
+	createVersion := func(generation int, parentRevID string, body db.Body) rest.DocVersion {
 		rev, err := db.CreateRevID(generation, parentRevID, body)
 		require.NoError(t, err, "Error creating revision")
-		return rev
+		return rest.DocVersion{RevID: rev}
 	}
 	docExpiry := time.Now().Local().Add(time.Hour * time.Duration(4)).Format(time.RFC3339)
 
 	// scenarios
 	conflictResolutionTests := []struct {
-		name                string
-		commonAncestorRevID string
-		localRevisionBody   db.Body
-		localRevID          string
-		remoteRevisionBody  db.Body
-		remoteRevID         string
-		conflictResolver    string
-		expectedLocalBody   db.Body
-		expectedLocalRevID  string
+		name                  string
+		commonAncestorVersion rest.DocVersion
+		localRevisionBody     string
+		localVersion          rest.DocVersion
+		remoteRevisionBody    string
+		remoteVersion         rest.DocVersion
+		conflictResolver      string
+		expectedLocalBody     db.Body
+		expectedLocalVersion  rest.DocVersion
 	}{
 		{
-			name: "mergeReadWriteIntlProps",
-			localRevisionBody: db.Body{
-				"source": "local",
-			},
-			localRevID: "1-a",
-			remoteRevisionBody: db.Body{
-				"source": "remote",
-			},
-			remoteRevID: "1-b",
+			name:               "mergeReadWriteIntlProps",
+			localRevisionBody:  `{"source": "local"}`,
+			localVersion:       rest.NewDocVersionFromFakeRev("1-a"),
+			remoteRevisionBody: `{ "source": "remote"}`,
+			remoteVersion:      rest.NewDocVersionFromFakeRev("1-b"),
 			conflictResolver: `function(conflict) {
 				var mergedDoc = new Object();
 				mergedDoc.source = "merged";
@@ -6018,7 +5949,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 				"remoteRevId": "1-b",
 				"source":      "merged",
 			},
-			expectedLocalRevID: createRevID(2, "1-b", db.Body{
+			expectedLocalVersion: createVersion(2, "1-b", db.Body{
 				db.BodyId:     "foo",
 				db.BodyRev:    "2-c",
 				db.BodyExpiry: json.Number("100"),
@@ -6030,23 +5961,11 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 			}),
 		},
 		{
-			name: "mergeReadWriteAttachments",
-			localRevisionBody: map[string]interface{}{
-				db.BodyAttachments: map[string]interface{}{
-					"A": map[string]interface{}{
-						"data": "QQo=",
-					}},
-				"source": "local",
-			},
-			localRevID: "1-a",
-			remoteRevisionBody: map[string]interface{}{
-				db.BodyAttachments: map[string]interface{}{
-					"B": map[string]interface{}{
-						"data": "Qgo=",
-					}},
-				"source": "remote",
-			},
-			remoteRevID: "1-b",
+			name:               "mergeReadWriteAttachments",
+			localRevisionBody:  `{"_attachments": {"A": {"data": "QQo="}}, "source": "local"}`,
+			localVersion:       rest.NewDocVersionFromFakeRev("1-a"),
+			remoteRevisionBody: `{"_attachments": {"B": {"data": "Qgo="}}, "source": "remote"}`,
+			remoteVersion:      rest.NewDocVersionFromFakeRev("1-b"),
 			conflictResolver: `function(conflict) {
 				var mergedDoc = new Object();
 				mergedDoc.source = "merged";
@@ -6066,19 +5985,16 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 			expectedLocalBody: map[string]interface{}{
 				"source": "merged",
 			},
-			expectedLocalRevID: createRevID(2, "1-b", db.Body{
+			expectedLocalVersion: createVersion(2, "1-b", db.Body{
 				"source": "merged",
 			}),
 		},
 		{
-			name: "mergeReadIntlPropsLocalExpiry",
-			localRevisionBody: db.Body{
-				"source":      "local",
-				db.BodyExpiry: docExpiry,
-			},
-			localRevID:         "1-a",
-			remoteRevisionBody: db.Body{"source": "remote"},
-			remoteRevID:        "1-b",
+			name:               "mergeReadIntlPropsLocalExpiry",
+			localRevisionBody:  fmt.Sprintf(`{"source": "local", "_exp": "%s"}`, docExpiry),
+			localVersion:       rest.NewDocVersionFromFakeRev("1-a"),
+			remoteRevisionBody: `{"source": "remote"}`,
+			remoteVersion:      rest.NewDocVersionFromFakeRev("1-b"),
 			conflictResolver: `function(conflict) {
 				var mergedDoc = new Object();
 				mergedDoc.source = "merged";
@@ -6089,22 +6005,17 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 				"localDocExp": docExpiry,
 				"source":      "merged",
 			},
-			expectedLocalRevID: createRevID(2, "1-b", db.Body{
+			expectedLocalVersion: createVersion(2, "1-b", db.Body{
 				"localDocExp": docExpiry,
 				"source":      "merged",
 			}),
 		},
 		{
-			name: "mergeWriteIntlPropsExpiry",
-			localRevisionBody: db.Body{
-				"source":      "local",
-				db.BodyExpiry: docExpiry,
-			},
-			localRevID: "1-a",
-			remoteRevisionBody: db.Body{
-				"source": "remote",
-			},
-			remoteRevID: "1-b",
+			name:               "mergeWriteIntlPropsExpiry",
+			localRevisionBody:  fmt.Sprintf(`{"source": "local", "_exp": "%s"}`, docExpiry),
+			localVersion:       rest.NewDocVersionFromFakeRev("1-a"),
+			remoteRevisionBody: `{"source": "remote"}`,
+			remoteVersion:      rest.NewDocVersionFromFakeRev("1-b"),
 			conflictResolver: fmt.Sprintf(`function(conflict) {
 				var mergedDoc = new Object();
 				mergedDoc.source = "merged";
@@ -6115,23 +6026,18 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 				db.BodyExpiry: docExpiry,
 				"source":      "merged",
 			},
-			expectedLocalRevID: createRevID(2, "1-b", db.Body{
+			expectedLocalVersion: createVersion(2, "1-b", db.Body{
 				db.BodyExpiry: docExpiry,
 				"source":      "merged",
 			}),
 		},
 		{
-			name: "mergeReadIntlPropsDeletedWithLocalTombstone",
-			localRevisionBody: db.Body{
-				"source":       "local",
-				db.BodyDeleted: true,
-			},
-			commonAncestorRevID: "1-a",
-			localRevID:          "2-a",
-			remoteRevisionBody: db.Body{
-				"source": "remote",
-			},
-			remoteRevID: "2-b",
+			name:                  "mergeReadIntlPropsDeletedWithLocalTombstone",
+			localRevisionBody:     `{"source": "local", "_deleted": true}`,
+			commonAncestorVersion: rest.NewDocVersionFromFakeRev("1-a"),
+			localVersion:          rest.NewDocVersionFromFakeRev("2-a"),
+			remoteRevisionBody:    `{"source": "remote"}`,
+			remoteVersion:         rest.NewDocVersionFromFakeRev("2-b"),
 			conflictResolver: `function(conflict) {
 				var mergedDoc = new Object();
 				mergedDoc.source = "merged";
@@ -6142,7 +6048,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 				"localDeleted": true,
 				"source":       "merged",
 			},
-			expectedLocalRevID: createRevID(3, "2-b", db.Body{
+			expectedLocalVersion: createVersion(3, "2-b", db.Body{
 				"localDeleted": true,
 				"source":       "merged",
 			}),
@@ -6152,7 +6058,6 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 	for _, test := range conflictResolutionTests {
 		t.Run(test.name, func(t *testing.T) {
 			base.RequireNumTestBuckets(t, 2)
-			base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 			// Passive
 			rt2 := rest.NewRestTester(t, nil)
@@ -6163,15 +6068,12 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 
 			// Create revision on rt2 (remote)
 			docID := test.name
-			if test.commonAncestorRevID != "" {
-				_, err := rt2.PutDocumentWithRevID(docID, test.commonAncestorRevID, "", test.remoteRevisionBody)
-				assert.NoError(t, err)
+			if !test.commonAncestorVersion.Equal(rest.EmptyDocVersion()) {
+				_ = rt2.PutNewEditsFalse(docID, test.commonAncestorVersion, rest.EmptyDocVersion(), test.remoteRevisionBody)
 			}
-			resp, err := rt2.PutDocumentWithRevID(docID, test.remoteRevID, test.commonAncestorRevID, test.remoteRevisionBody)
-			assert.NoError(t, err)
-			rest.RequireStatus(t, resp, http.StatusCreated)
-			rt2revID := rest.RespRevID(t, resp)
-			assert.Equal(t, test.remoteRevID, rt2revID)
+			fmt.Println("remoteRevisionBody:", test.remoteRevisionBody)
+			rt2Version := rt2.PutNewEditsFalse(docID, test.remoteVersion, test.commonAncestorVersion, test.remoteRevisionBody)
+			rest.RequireDocVersionEqual(t, test.remoteVersion, rt2Version)
 
 			// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
 			srv := httptest.NewServer(rt2.TestPublicHandler())
@@ -6189,15 +6091,13 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 			ctx1 := rt1.Context()
 
 			// Create revision on rt1 (local)
-			if test.commonAncestorRevID != "" {
-				_, err := rt1.PutDocumentWithRevID(docID, test.commonAncestorRevID, "", test.remoteRevisionBody)
+			if !test.commonAncestorVersion.Equal(rest.EmptyDocVersion()) {
+				_ = rt1.PutNewEditsFalse(docID, test.commonAncestorVersion, rest.EmptyDocVersion(), test.remoteRevisionBody)
 				assert.NoError(t, err)
 			}
-			resp, err = rt1.PutDocumentWithRevID(docID, test.localRevID, test.commonAncestorRevID, test.localRevisionBody)
-			assert.NoError(t, err)
-			rest.RequireStatus(t, resp, http.StatusCreated)
-			rt1revID := rest.RespRevID(t, resp)
-			assert.Equal(t, test.localRevID, rt1revID)
+			fmt.Println("localRevisionBody:", test.localRevisionBody)
+			rt1Version := rt1.PutNewEditsFalse(docID, test.localVersion, test.commonAncestorVersion, test.localRevisionBody)
+			rest.RequireDocVersionEqual(t, test.localVersion, rt1Version)
 
 			customConflictResolver, err := db.NewCustomConflictResolver(ctx1, test.conflictResolver, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err)
@@ -6233,12 +6133,12 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, changesResults.Results, 1)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
-			assert.Equal(t, test.expectedLocalRevID, changesResults.Results[0].Changes[0]["rev"])
+			rest.RequireChangeRevVersion(t, test.expectedLocalVersion, changesResults.Results[0].Changes[0])
 			log.Printf("Changes response is %+v", changesResults)
 
 			doc, err := rt1.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 			require.NoError(t, err)
-			assert.Equal(t, test.expectedLocalRevID, doc.SyncData.CurrentRev)
+			requireDocumentVersion(t, test.expectedLocalVersion, doc)
 			ctx := base.TestCtx(t)
 			log.Printf("doc.Body(): %v", doc.Body(ctx))
 			assert.Equal(t, test.expectedLocalBody, doc.Body(ctx))
@@ -6675,7 +6575,7 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 
 			// Create the first revision of the document on rt1.
 			docID := t.Name() + "foo"
-			rt1RevIDCreated := createOrUpdateDoc(t, rt1, docID, "", "foo")
+			rt1VersionCreated := createDoc(rt1, docID, "foo")
 
 			// Create active replicator and start replication.
 			ar, err := db.NewActiveReplicator(ctx1, &config)
@@ -6685,30 +6585,29 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 
 			ctx := base.TestCtx(t)
 			// Wait for the original document revision written to rt1 to arrive at rt2.
-			rt2RevIDCreated := rt1RevIDCreated
+			rt2VersionIDCreated := rt1VersionCreated
 			require.NoError(t, rt2.WaitForCondition(func() bool {
 				doc, _ := rt2.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 				return doc != nil && len(doc.Body(ctx)) > 0
 			}))
-			requireRevID(t, rt2, docID, rt2RevIDCreated)
+			requireVersion(rt2, docID, rt2VersionIDCreated)
 
 			// Stop replication.
 			require.NoError(t, ar.Stop(), "Error stopping replication")
 
 			// Update the document on rt1 to build a revision history.
-			rt1RevIDUpdated := createOrUpdateDoc(t, rt1, docID, rt1RevIDCreated, "bar")
+			rt1VersionUpdated := updateDoc(rt1, docID, rt1VersionCreated, "bar")
 
 			// Tombstone the document on rt1 to mark the tip of the revision history for deletion.
-			resp := rt1.SendAdminRequest(http.MethodDelete, "/{{.keyspace}}/"+docID+"?rev="+rt1RevIDUpdated, ``)
-			rest.RequireStatus(t, resp, http.StatusOK)
+			rt1.DeleteDoc(docID, rt1VersionUpdated)
 
 			// Ensure that the tombstone revision is written to rt1 bucket with an empty body.
 			waitForTombstone(t, rt1, docID)
 
 			// Update the document on rt2 with the specified body values.
-			rt2RevID := rt2RevIDCreated
+			rt2Version := rt1VersionCreated
 			for _, bodyValue := range test.remoteBodyValues {
-				rt2RevID = createOrUpdateDoc(t, rt2, docID, rt2RevID, bodyValue)
+				rt2Version = updateDoc(rt2, docID, rt2Version, bodyValue)
 			}
 
 			// Start replication.
@@ -6720,8 +6619,9 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 			waitForTombstone(t, rt2, docID)
 			waitForTombstone(t, rt1, docID)
 
-			requireRevID(t, rt2, docID, test.expectedRevID)
-			requireRevID(t, rt1, docID, test.expectedRevID)
+			expectedVersion := rest.NewDocVersionFromFakeRev(test.expectedRevID)
+			requireVersion(rt2, docID, expectedVersion)
+			requireVersion(rt1, docID, expectedVersion)
 
 			// Ensure that the document body of the winning tombstone revision written to both
 			// rt1 and rt2 is empty, i.e., An attempt to read the document body of a tombstone
@@ -6831,7 +6731,7 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 
 			// Create the first revision of the document on rt2.
 			docID := test.name + "foo"
-			rt2RevIDCreated := createOrUpdateDoc(t, rt2, docID, "", "foo")
+			rt2VersionCreated := createDoc(rt2, docID, "foo")
 
 			// Create active replicator and start replication.
 			ar, err := db.NewActiveReplicator(ctx1, &config)
@@ -6841,32 +6741,29 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 
 			ctx := base.TestCtx(t)
 			// Wait for the original document revision written to rt2 to arrive at rt1.
-			rt1RevIDCreated := rt2RevIDCreated
+			rt1VersionCreated := rt2VersionCreated
 			require.NoError(t, rt1.WaitForCondition(func() bool {
 				doc, _ := rt1.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
 				return doc != nil && len(doc.Body(ctx)) > 0
 			}))
-			requireRevID(t, rt1, docID, rt1RevIDCreated)
+			requireVersion(rt1, docID, rt1VersionCreated)
 
 			// Stop replication.
 			require.NoError(t, ar.Stop(), "Error stopping replication")
 
 			// Update the document on rt2 to build a revision history.
-			rt2RevIDUpdated := createOrUpdateDoc(t, rt2, docID, rt2RevIDCreated, "bar")
+			rt2VersionUpdated := updateDoc(rt2, docID, rt2VersionCreated, "bar")
 
 			// Tombstone the document on rt2 to mark the tip of the revision history for deletion.
-			resp := rt2.SendAdminRequest(http.MethodDelete, "/{{.keyspace}}/"+docID+"?rev="+rt2RevIDUpdated, ``)
-			rest.RequireStatus(t, resp, http.StatusOK)
-			rt2RevID := rest.RespRevID(t, resp)
-			log.Printf("rt2RevID: %s", rt2RevID)
+			rt2.DeleteDoc(docID, rt2VersionUpdated)
 
 			// Ensure that the tombstone revision is written to rt2 bucket with an empty body.
 			waitForTombstone(t, rt2, docID)
 
 			// Update the document on rt1 with the specified body values.
-			rt1RevID := rt1RevIDCreated
+			rt1Version := rt1VersionCreated
 			for _, bodyValue := range test.localBodyValues {
-				rt1RevID = createOrUpdateDoc(t, rt1, docID, rt1RevID, bodyValue)
+				rt1Version = updateDoc(rt1, docID, rt1Version, bodyValue)
 			}
 
 			// Start replication.
@@ -6878,7 +6775,8 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 			waitForTombstone(t, rt1, docID)
 			waitForTombstone(t, rt2, docID)
 
-			requireRevID(t, rt1, docID, test.expectedRevID)
+			expectedVersion := rest.NewDocVersionFromFakeRev(test.expectedRevID)
+			requireVersion(rt1, docID, expectedVersion)
 			// Wait for conflict resolved doc (tombstone) to be pulled to passive bucket
 			// Then require it is the expected rev
 			require.NoError(t, rt2.WaitForCondition(func() bool {
@@ -7006,13 +6904,11 @@ func TestLocalWinsConflictResolution(t *testing.T) {
 			// Create initial revision(s) on local
 			docID := test.name
 
-			var parentRevID, newRevID string
+			var parentVersion, newVersion rest.DocVersion
 			for gen := 1; gen <= test.initialState.generation; gen++ {
-				newRevID = fmt.Sprintf("%d-initial", gen)
-				resp := activeRT.PutNewEditsFalse(docID, newRevID, parentRevID,
+				newVersion = rest.NewDocVersionFromFakeRev(fmt.Sprintf("%d-initial", gen))
+				parentVersion = activeRT.PutNewEditsFalse(docID, newVersion, parentVersion,
 					makeRevBody(test.initialState.propertyValue, test.initialState.attachmentRevPos, gen))
-				log.Printf("-- Added initial revision: %s", resp.Rev)
-				parentRevID = newRevID
 			}
 
 			// Create replication, wait for initial revision to be replicated
@@ -7020,7 +6916,7 @@ func TestLocalWinsConflictResolution(t *testing.T) {
 			activeRT.CreateReplication(replicationID, remoteURLString, db.ActiveReplicatorTypePushAndPull, nil, true, db.ConflictResolverLocalWins)
 			activeRT.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
-			assert.NoError(t, remoteRT.WaitForRev(docID, newRevID))
+			assert.NoError(t, remoteRT.WaitForVersion(docID, newVersion))
 
 			// Stop the replication
 			response := activeRT.SendAdminRequest("PUT", "/{{.db}}/_replicationStatus/"+replicationID+"?action=stop", "")
@@ -7033,44 +6929,40 @@ func TestLocalWinsConflictResolution(t *testing.T) {
 			log.Printf("-- remote raw pre-update: %s", rawResponse.Body.Bytes())
 
 			// Update local and remote revisions
-			localParentRevID := newRevID
-			var newLocalRevID string
+			localParentVersion := newVersion
+			var newLocalVersion rest.DocVersion
 			for localGen := test.initialState.generation + 1; localGen <= test.localMutation.generation; localGen++ {
 				// If deleted=true, tombstone on the last mutation
 				if test.localMutation.deleted == true && localGen == test.localMutation.generation {
-					activeRT.TombstoneDoc(docID, localParentRevID)
+					activeRT.DeleteDoc(docID, localParentVersion)
 					continue
 				}
 
-				newLocalRevID = fmt.Sprintf("%d-local", localGen)
+				newLocalVersion = rest.NewDocVersionFromFakeRev(fmt.Sprintf("%d-local", localGen))
 				// Local rev pos is greater of initial state revpos and localMutation rev pos
 				localRevPos := test.initialState.attachmentRevPos
 				if test.localMutation.attachmentRevPos > 0 {
 					localRevPos = test.localMutation.attachmentRevPos
 				}
-				resp := activeRT.PutNewEditsFalse(docID, newLocalRevID, localParentRevID, makeRevBody(test.localMutation.propertyValue, localRevPos, localGen))
-				log.Printf("-- Added local revision: %s", resp.Rev)
-				localParentRevID = newLocalRevID
+				localParentVersion = activeRT.PutNewEditsFalse(docID, newLocalVersion, localParentVersion, makeRevBody(test.localMutation.propertyValue, localRevPos, localGen))
 			}
 
-			remoteParentRevID := newRevID
-			var newRemoteRevID string
+			remoteParentVersion := newLocalVersion
+			var newRemoteVersion rest.DocVersion
 			for remoteGen := test.initialState.generation + 1; remoteGen <= test.remoteMutation.generation; remoteGen++ {
 				// If deleted=true, tombstone on the last mutation
 				if test.remoteMutation.deleted == true && remoteGen == test.remoteMutation.generation {
-					remoteRT.TombstoneDoc(docID, remoteParentRevID)
+					remoteRT.DeleteDoc(docID, remoteParentVersion)
 					continue
 				}
-				newRemoteRevID = fmt.Sprintf("%d-remote", remoteGen)
+				newRemoteVersion = rest.NewDocVersionFromFakeRev(fmt.Sprintf("%d-remote", remoteGen))
 
 				// Local rev pos is greater of initial state revpos and remoteMutation rev pos
 				remoteRevPos := test.initialState.attachmentRevPos
 				if test.remoteMutation.attachmentRevPos > 0 {
 					remoteRevPos = test.remoteMutation.attachmentRevPos
 				}
-				resp := remoteRT.PutNewEditsFalse(docID, newRemoteRevID, remoteParentRevID, makeRevBody(test.remoteMutation.propertyValue, remoteRevPos, remoteGen))
-				log.Printf("-- Added remote revision: %s", resp.Rev)
-				remoteParentRevID = newRemoteRevID
+				_ = remoteRT.PutNewEditsFalse(docID, newRemoteVersion, remoteParentVersion, makeRevBody(test.remoteMutation.propertyValue, remoteRevPos, remoteGen))
 			}
 
 			rawResponse = activeRT.SendAdminRequest("GET", "/{{.keyspace}}/_raw/"+docID, "")
@@ -7194,21 +7086,21 @@ func TestReplicatorConflictAttachment(t *testing.T) {
 	testCases := []struct {
 		name                      string
 		conflictResolution        db.ConflictResolverType
-		expectedFinalRev          string
+		expectedFinalVersion      rest.DocVersion
 		expectedRevPos            int
 		expectedAttachmentContent string
 	}{
 		{
 			name:                      "local",
 			conflictResolution:        db.ConflictResolverLocalWins,
-			expectedFinalRev:          "6-3545745ab68aec5b00e745f9e0e3277c",
+			expectedFinalVersion:      rest.NewDocVersionFromFakeRev("6-3545745ab68aec5b00e745f9e0e3277c"),
 			expectedRevPos:            6,
 			expectedAttachmentContent: "hello world",
 		},
 		{
 			name:                      "remote",
 			conflictResolution:        db.ConflictResolverRemoteWins,
-			expectedFinalRev:          "5-remote",
+			expectedFinalVersion:      rest.NewDocVersionFromFakeRev("5-remote"),
 			expectedRevPos:            4,
 			expectedAttachmentContent: "goodbye cruel world",
 		},
@@ -7221,19 +7113,17 @@ func TestReplicatorConflictAttachment(t *testing.T) {
 
 			docID := test.name
 
-			var parentRevID, newRevID string
+			var parentVersion, newVersion rest.DocVersion
 			for gen := 1; gen <= 3; gen++ {
-				newRevID = fmt.Sprintf("%d-initial", gen)
-				resp := activeRT.PutNewEditsFalse(docID, newRevID, parentRevID, "{}")
-				parentRevID = newRevID
-				assert.True(t, resp.Ok)
+				newVersion = rest.NewDocVersionFromFakeRev(fmt.Sprintf("%d-initial", gen))
+				parentVersion = activeRT.PutNewEditsFalse(docID, newVersion, parentVersion, "{}")
 			}
 
 			replicationID := "replication"
 			activeRT.CreateReplication(replicationID, remoteURLString, db.ActiveReplicatorTypePushAndPull, nil, true, test.conflictResolution)
 			activeRT.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
-			assert.NoError(t, remoteRT.WaitForRev(docID, newRevID))
+			assert.NoError(t, remoteRT.WaitForVersion(docID, newVersion))
 
 			response := activeRT.SendAdminRequest("PUT", "/{{.db}}/_replicationStatus/"+replicationID+"?action=stop", "")
 			rest.RequireStatus(t, response, http.StatusOK)
@@ -7242,43 +7132,40 @@ func TestReplicatorConflictAttachment(t *testing.T) {
 			nextGen := 4
 
 			localGen := nextGen
-			localParentRevID := newRevID
-			newLocalRevID := fmt.Sprintf("%d-local", localGen)
-			resp := activeRT.PutNewEditsFalse(docID, newLocalRevID, localParentRevID, `{"_attachments": {"attach": {"data":"aGVsbG8gd29ybGQ="}}}`)
-			assert.True(t, resp.Ok)
-			localParentRevID = newLocalRevID
+			localParentVersion := newVersion
+			newLocalVersion := rest.NewDocVersionFromFakeRev(fmt.Sprintf("%d-local", localGen))
+			_ = activeRT.PutNewEditsFalse(docID, newLocalVersion, localParentVersion, `{"_attachments": {"attach": {"data":"aGVsbG8gd29ybGQ="}}}`)
+			localParentVersion = newLocalVersion
 
 			localGen++
-			newLocalRevID = fmt.Sprintf("%d-local", localGen)
-			resp = activeRT.PutNewEditsFalse(docID, newLocalRevID, localParentRevID, fmt.Sprintf(`{"_attachments": {"attach": {"stub": true, "revpos": %d, "digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`, localGen-1))
-			assert.True(t, resp.Ok)
+			newLocalVersion = rest.NewDocVersionFromFakeRev(fmt.Sprintf("%d-local", localGen))
+			_ = activeRT.PutNewEditsFalse(docID, newLocalVersion, localParentVersion, fmt.Sprintf(`{"_attachments": {"attach": {"stub": true, "revpos": %d, "digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`, localGen-1))
 
 			remoteGen := nextGen
-			remoteParentRevID := newRevID
-			newRemoteRevID := fmt.Sprintf("%d-remote", remoteGen)
-			resp = remoteRT.PutNewEditsFalse(docID, newRemoteRevID, remoteParentRevID, `{"_attachments": {"attach": {"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA=="}}}`)
-			assert.True(t, resp.Ok)
-			remoteParentRevID = newRemoteRevID
+			remoteParentVersion := newVersion
+			newRemoteVersion := rest.NewDocVersionFromFakeRev(fmt.Sprintf("%d-remote", remoteGen))
+			_ = remoteRT.PutNewEditsFalse(docID, newRemoteVersion, remoteParentVersion, `{"_attachments": {"attach": {"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA=="}}}`)
+			remoteParentVersion = newRemoteVersion
 
 			remoteGen++
-			newRemoteRevID = fmt.Sprintf("%d-remote", remoteGen)
-			resp = remoteRT.PutNewEditsFalse(docID, newRemoteRevID, remoteParentRevID, fmt.Sprintf(`{"_attachments": {"attach": {"stub": true, "revpos": %d, "digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}}`, remoteGen-1))
+			newRemoteVersion = rest.NewDocVersionFromFakeRev(fmt.Sprintf("%d-remote", remoteGen))
+			_ = remoteRT.PutNewEditsFalse(docID, newRemoteVersion, remoteParentVersion, fmt.Sprintf(`{"_attachments": {"attach": {"stub": true, "revpos": %d, "digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}}`, remoteGen-1))
 
 			response = activeRT.SendAdminRequest("PUT", "/{{.db}}/_replicationStatus/"+replicationID+"?action=start", "")
 			rest.RequireStatus(t, response, http.StatusOK)
 
-			waitErr := activeRT.WaitForRev(docID, test.expectedFinalRev)
+			waitErr := activeRT.WaitForVersion(docID, test.expectedFinalVersion)
 			assert.NoError(t, waitErr)
-			waitErr = remoteRT.WaitForRev(docID, test.expectedFinalRev)
+			waitErr = remoteRT.WaitForVersion(docID, test.expectedFinalVersion)
 			require.NoError(t, waitErr)
 
 			localDoc := activeRT.GetDocBody(docID)
-			localRevID := localDoc.ExtractRev()
+			localVersion := localDoc.ExtractRev()
 
 			remoteDoc := remoteRT.GetDocBody(docID)
-			remoteRevID := remoteDoc.ExtractRev()
+			remoteVersion := remoteDoc.ExtractRev()
 
-			assert.Equal(t, localRevID, remoteRevID)
+			assert.Equal(t, localVersion, remoteVersion)
 			remoteRevpos := getTestRevpos(t, remoteDoc, "attach")
 			assert.Equal(t, test.expectedRevPos, remoteRevpos)
 
@@ -7403,11 +7290,8 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 	activeCtx := activeRT.Context()
 
 	// Create a document //
-	resp := activeRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/test", `{"field1":"f1_1","field2":"f2_1"}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	revID := rest.RespRevID(t, resp)
-	err := activeRT.WaitForRev("test", revID)
-	require.NoError(t, err)
+	version := activeRT.PutDoc("test", `{"field1":"f1_1","field2":"f2_1"}`)
+	require.NoError(t, activeRT.WaitForVersion("test", version))
 
 	// Set-up replicator //
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
@@ -7435,28 +7319,23 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 	assert.NoError(t, ar.Start(activeCtx))
 
 	// Wait for active to replicate to passive
-	err = passiveRT.WaitForRev("test", revID)
-	require.NoError(t, err)
+	require.NoError(t, passiveRT.WaitForVersion("test", version))
 
 	// Delete active document
-	resp = activeRT.SendAdminRequest(http.MethodDelete, "/{{.keyspace}}/test?rev="+revID, "")
-	rest.RequireStatus(t, resp, http.StatusOK)
-	revID = rest.RespRevID(t, resp)
+	deletedVersion := activeRT.DeleteDocReturnVersion("test", version)
 
 	// Replicate tombstone to passive
 	err = passiveRT.WaitForCondition(func() bool {
-		rawResponse := passiveRT.SendAdminRequest("GET", "/{{.keyspace}}/test?rev="+revID, "")
+		rawResponse := passiveRT.SendAdminRequest("GET", "/{{.keyspace}}/test?rev="+deletedVersion.RevID, "")
 		return rawResponse.Code == 404
 	})
 	require.NoError(t, err)
 
 	// Resurrect tombstoned document
-	resp = activeRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/test?rev="+revID, `{"field2":"f2_2"}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	revID = rest.RespRevID(t, resp)
+	resurrectedVersion := activeRT.UpdateDoc("test", deletedVersion, `{"field2":"f2_2"}`)
 
 	// Replicate resurrection to passive
-	err = passiveRT.WaitForRev("test", revID)
+	err = passiveRT.WaitForVersion("test", resurrectedVersion)
 	assert.NoError(t, err) // If error, problem not fixed
 
 	// Shutdown replicator to close out
@@ -7513,11 +7392,8 @@ func TestUnprocessableDeltas(t *testing.T) {
 	activeCtx := activeRT.Context()
 
 	// Create a document //
-	resp := activeRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/test", `{"field1":"f1_1","field2":"f2_1"}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	revID := rest.RespRevID(t, resp)
-	err := activeRT.WaitForRev("test", revID)
-	require.NoError(t, err)
+	version := activeRT.PutDoc("test", `{"field1":"f1_1","field2":"f2_1"}`)
+	require.NoError(t, activeRT.WaitForVersion("test", version))
 
 	// Set-up replicator //
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
@@ -7545,15 +7421,12 @@ func TestUnprocessableDeltas(t *testing.T) {
 
 	assert.NoError(t, ar.Start(activeCtx))
 
-	err = passiveRT.WaitForRev("test", revID)
-	require.NoError(t, err)
+	require.NoError(t, passiveRT.WaitForVersion("test", version))
 
 	assert.NoError(t, ar.Stop())
 
 	// Make 2nd revision
-	resp = activeRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/test?rev="+revID, `{"field1":"f1_2","field2":"f2_2"}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	revID = rest.RespRevID(t, resp)
+	version2 := activeRT.UpdateDoc("test", version, `{"field1":"f1_2","field2":"f2_2"}`)
 	err = activeRT.WaitForPendingChanges()
 	require.NoError(t, err)
 
@@ -7566,7 +7439,7 @@ func TestUnprocessableDeltas(t *testing.T) {
 
 	assert.NoError(t, ar.Start(activeCtx))
 	// Check if it replicated
-	err = passiveRT.WaitForRev("test", revID)
+	err = passiveRT.WaitForVersion("test", version2)
 	assert.NoError(t, err)
 
 	assert.NoError(t, ar.Stop())
@@ -7602,30 +7475,22 @@ func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 	defer activeRT.Close()
 	activeCtx := activeRT.Context()
 
+	docID := t.Name()
 	// Create the docs //
 	// Doc rev 1
-	resp := activeRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+t.Name(), `{"key":"12","channels": ["rev1chan"]}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	rev1ID := rest.RespRevID(t, resp)
-	err := activeRT.WaitForRev(t.Name(), rev1ID)
-	require.NoError(t, err)
+	version1 := activeRT.PutDoc(docID, `{"key":"12","channels": ["rev1chan"]}`)
+	require.NoError(t, activeRT.WaitForVersion(docID, version1))
 
 	// doc rev 2
-	resp = activeRT.SendAdminRequest(http.MethodPut, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", t.Name(), rev1ID), `{"key":"12","channels":["rev2+3chan"]}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	rev2ID := rest.RespRevID(t, resp)
-	err = activeRT.WaitForRev(t.Name(), rev2ID)
-	require.NoError(t, err)
+	version2 := activeRT.UpdateDoc(docID, version1, `{"key":"12","channels":["rev2+3chan"]}`)
+	require.NoError(t, activeRT.WaitForVersion(docID, version2))
 
 	// Doc rev 3
-	resp = activeRT.SendAdminRequest(http.MethodPut, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", t.Name(), rev2ID), `{"key":"3","channels":["rev2+3chan"]}`)
-	rest.RequireStatus(t, resp, http.StatusCreated)
-	rev3ID := rest.RespRevID(t, resp)
-	err = activeRT.WaitForRev(t.Name(), rev3ID)
-	require.NoError(t, err)
+	version3 := activeRT.UpdateDoc(docID, version2, `{"key":"3","channels":["rev2+3chan"]}`)
+	require.NoError(t, activeRT.WaitForVersion(docID, version3))
 
 	activeRT.GetSingleTestDatabaseCollection().FlushRevisionCacheForTest()
-	err = activeRT.GetSingleDataStore().Delete(fmt.Sprintf("_sync:rev:%s:%d:%s", t.Name(), len(rev2ID), rev2ID))
+	err := activeRT.GetSingleDataStore().Delete(fmt.Sprintf("_sync:rev:%s:%d:%s", t.Name(), len(version2.RevID), version2.RevID))
 	require.NoError(t, err)
 	// Set-up replicator //
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
@@ -8449,4 +8314,10 @@ func TestReplicatorWithCollectionsFailWithoutCollectionsEnabled(t *testing.T) {
 		require.Nil(t, ar)
 	}
 
+}
+
+func requireBodyEqual(t *testing.T, expected string, doc *db.Document) {
+	var expectedBody db.Body
+	require.NoError(t, base.JSONUnmarshal([]byte(expected), &expectedBody))
+	require.Equal(t, expectedBody, doc.Body(base.TestCtx(t)))
 }

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -47,20 +47,20 @@ const (
 	revocationTestPassword = "test"
 )
 
-func (tester *ChannelRevocationTester) addRole(role string) {
+func (tester *ChannelRevocationTester) addRole(user, role string) {
 	if tester.roles.Roles == nil {
 		tester.roles.Roles = map[string][]string{}
 	}
 
-	tester.roles.Roles[revocationTestUser] = append(tester.roles.Roles[revocationTestUser], fmt.Sprintf("role:%s", role))
+	tester.roles.Roles[user] = append(tester.roles.Roles[user], fmt.Sprintf("role:%s", role))
 	tester.roleVersion = tester.restTester.UpdateDoc("userRoles", tester.roleVersion, string(mustMarshalJSON(tester.restTester.TB, tester.roles)))
 }
 
-func (tester *ChannelRevocationTester) removeFooRole() {
+func (tester *ChannelRevocationTester) removeRole(user, role string) {
 	delIdx := -1
-	roles := tester.roles.Roles[revocationTestUser]
+	roles := tester.roles.Roles[user]
 	for idx, val := range roles {
-		if val == fmt.Sprintf("role:%s", revocationTestRole) {
+		if val == fmt.Sprintf("role:%s", role) {
 			delIdx = idx
 			break
 		}
@@ -94,18 +94,18 @@ func (tester *ChannelRevocationTester) removeRoleChannel(role, channel string) {
 	tester.roleChannelVersion = tester.restTester.UpdateDoc("roleChannels", tester.roleChannelVersion, string(mustMarshalJSON(tester.restTester.TB, tester.roleChannels)))
 }
 
-func (tester *ChannelRevocationTester) addUserChannel(channel string) {
+func (tester *ChannelRevocationTester) addUserChannel(user, channel string) {
 	if tester.userChannels.Channels == nil {
 		tester.userChannels.Channels = map[string][]string{}
 	}
 
-	tester.userChannels.Channels[revocationTestUser] = append(tester.userChannels.Channels[revocationTestUser], channel)
+	tester.userChannels.Channels[user] = append(tester.userChannels.Channels[user], channel)
 	tester.userChannelVersion = tester.restTester.UpdateDoc("userChannels", tester.userChannelVersion, string(mustMarshalJSON(tester.restTester.TB, tester.userChannels)))
 }
 
-func (tester *ChannelRevocationTester) removeUserChannel(channel string) {
+func (tester *ChannelRevocationTester) removeUserChannel(user string, channel string) {
 	delIdx := -1
-	channelsSlice := tester.userChannels.Channels[revocationTestUser]
+	channelsSlice := tester.userChannels.Channels[user]
 	for idx, val := range channelsSlice {
 		if val == channel {
 			delIdx = idx
@@ -214,7 +214,7 @@ func TestRevocationScenario1(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
@@ -226,11 +226,11 @@ func TestRevocationScenario1(t *testing.T) {
 	assert.Equal(t, "25", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(80)
@@ -241,7 +241,7 @@ func TestRevocationScenario1(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
@@ -265,14 +265,14 @@ func TestRevocationScenario2(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(50)
 	changes = revocationTester.getChanges(25, 1)
@@ -282,7 +282,7 @@ func TestRevocationScenario2(t *testing.T) {
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(80)
@@ -293,7 +293,7 @@ func TestRevocationScenario2(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
@@ -317,14 +317,14 @@ func TestRevocationScenario3(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 
@@ -334,7 +334,7 @@ func TestRevocationScenario3(t *testing.T) {
 	assert.True(t, changes.Results[0].Revoked)
 
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(80)
@@ -345,7 +345,7 @@ func TestRevocationScenario3(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
@@ -369,18 +369,18 @@ func TestRevocationScenario4(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 
 	revocationTester.fillToSeq(70)
 	changes = revocationTester.getChanges(25, 1)
@@ -397,7 +397,7 @@ func TestRevocationScenario4(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
@@ -421,18 +421,18 @@ func TestRevocationScenario5(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(80)
@@ -443,7 +443,7 @@ func TestRevocationScenario5(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
@@ -467,18 +467,18 @@ func TestRevocationScenario6(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(84)
@@ -491,7 +491,7 @@ func TestRevocationScenario6(t *testing.T) {
 	assert.True(t, changes.Results[0].Revoked)
 
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(90, 0)
@@ -514,24 +514,24 @@ func TestRevocationScenario7(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(100)
 
@@ -561,9 +561,9 @@ func TestRevocationScenario8(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(50)
 	changes = revocationTester.getChanges(5, 0)
@@ -572,13 +572,13 @@ func TestRevocationScenario8(t *testing.T) {
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(50, 0)
@@ -601,9 +601,9 @@ func TestRevocationScenario9(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 
@@ -612,13 +612,13 @@ func TestRevocationScenario9(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(60, 0)
@@ -641,13 +641,13 @@ func TestRevocationScenario10(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 
 	revocationTester.fillToSeq(70)
 	changes = revocationTester.getChanges(5, 0)
@@ -658,7 +658,7 @@ func TestRevocationScenario10(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(70, 0)
@@ -681,13 +681,13 @@ func TestRevocationScenario11(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 
@@ -698,7 +698,7 @@ func TestRevocationScenario11(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(80, 1)
@@ -722,13 +722,13 @@ func TestRevocationScenario12(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(84)
@@ -739,7 +739,7 @@ func TestRevocationScenario12(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(90, 0)
@@ -762,19 +762,19 @@ func TestRevocationScenario13(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(100)
 	changes = revocationTester.getChanges(5, 0)
@@ -801,14 +801,14 @@ func TestRevocationScenario14(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 
 	revocationTester.fillToSeq(25)
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	changes = revocationTester.getChanges(25, 1)
 	assert.Equal(t, "45:3", changes.Last_Seq)
@@ -823,7 +823,7 @@ func TestEnsureRevocationAfterDocMutation(t *testing.T) {
 
 	// Give role access to channel A and give user access to role
 	revocationTester.addRoleChannel("foo", "A")
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 
 	// Skip to seq 4 Create doc channel A
 	revocationTester.fillToSeq(4)
@@ -837,7 +837,7 @@ func TestEnsureRevocationAfterDocMutation(t *testing.T) {
 
 	// Skip to seq 14 then revoke role from user
 	revocationTester.fillToSeq(14)
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	// Skip to seq 19 and then update doc foo
 	revocationTester.fillToSeq(19)
@@ -859,7 +859,7 @@ func TestEnsureRevocationUsingDocHistory(t *testing.T) {
 
 	// Give role access to channel A and give user access to role
 	revocationTester.addRoleChannel("foo", "A")
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 
 	// Skip to seq 4 Create doc channel A
 	revocationTester.fillToSeq(4)
@@ -954,7 +954,7 @@ func TestRevocationMutationMovesIntoRevokedChannel(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "A")
 
 	revocationTester.fillToSeq(4)
@@ -967,7 +967,7 @@ func TestRevocationMutationMovesIntoRevokedChannel(t *testing.T) {
 	assert.Len(t, changes.Results, 2)
 	assert.Equal(t, doc2ID, changes.Results[1].ID)
 
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	_ = rt.UpdateDoc(docID, docVersion, `{"channels": ["A"]}`)
 	_ = rt.UpdateDoc(doc2ID, doc2Version, `{"channels": ["A"], "val": "mutate"}`)
 
@@ -986,10 +986,10 @@ func TestRevocationResumeAndLowSeqCheck(t *testing.T) {
 	resp := rt.SendAdminRequest("PUT", "/db/_role/foo2", `{}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "ch1")
 
-	revocationTester.addRole("foo2")
+	revocationTester.addRole("user", "foo2")
 	revocationTester.addRoleChannel("foo2", "ch2")
 
 	revocationTester.fillToSeq(9)
@@ -1040,7 +1040,7 @@ func TestRevocationResumeSameRoleAndLowSeqCheck(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.addRoleChannel("foo", "ch2")
 
@@ -1103,7 +1103,7 @@ func TestRevocationsWithQueryLimit(t *testing.T) {
 	})
 	defer rt.Close()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	revocationTester.fillToSeq(9)
@@ -1113,7 +1113,7 @@ func TestRevocationsWithQueryLimit(t *testing.T) {
 
 	changes := revocationTester.getChanges("0", 4)
 
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	// Run changes once (which has its own wait)
 	sinceVal := changes.Last_Seq
@@ -1145,9 +1145,9 @@ func TestRevocationsWithQueryLimit2Channels(t *testing.T) {
 	})
 	defer rt.Close()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "ch1")
-	revocationTester.addUserChannel("ch2")
+	revocationTester.addUserChannel("user", "ch2")
 
 	revocationTester.fillToSeq(9)
 	_ = rt.PutDoc("doc1", `{"channels": ["ch1", "ch2"]}`)
@@ -1156,7 +1156,7 @@ func TestRevocationsWithQueryLimit2Channels(t *testing.T) {
 
 	changes := revocationTester.getChanges("0", 4)
 
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	_ = changes.Last_Seq
 	// This changes feed would loop if CBG-3273 was still an issue
@@ -1167,7 +1167,7 @@ func TestRevocationsWithQueryLimit2Channels(t *testing.T) {
 	RequireStatus(t, resp, 200)
 
 	// Revoke access to ch2
-	revocationTester.removeUserChannel("ch2")
+	revocationTester.removeUserChannel("user", "ch2")
 	changes = revocationTester.getChanges(0, 7)
 	// Get a doc to ensure no access
 	resp = rt.SendUserRequestWithHeaders("GET", "/{{.keyspace}}/doc1", "", nil, "user", "test")
@@ -1192,7 +1192,7 @@ func TestRevocationsWithQueryLimitChangesLimit(t *testing.T) {
 	})
 	defer rt.Close()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	revocationTester.fillToSeq(9)
@@ -1202,7 +1202,7 @@ func TestRevocationsWithQueryLimitChangesLimit(t *testing.T) {
 
 	changes := revocationTester.getChanges("0", 4)
 
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	waitForUserChangesWithLimit := func(sinceVal interface{}, limit int) ChangesResults {
 		var changesRes ChangesResults
@@ -1247,7 +1247,7 @@ func TestRevocationUserHasDocAccessDocNotFound(t *testing.T) {
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "A")
 
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc", `{"channels": ["A"]}`)
@@ -1280,7 +1280,7 @@ func TestWasDocInChannelAtSeq(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "a")
 	revocationTester.addRoleChannel("foo", "c")
 
@@ -1318,38 +1318,38 @@ func TestChannelGrantedPeriods(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	revocationTester.addUserChannel("a")
+	revocationTester.addUserChannel("user", "a")
 	const docID = "doc"
 	version := rt.PutDoc(docID, `{"channels": ["a"]}`)
 	changes := revocationTester.getChanges(0, 2)
 	assert.Len(t, changes.Results, 2)
 
-	revocationTester.removeUserChannel("a")
+	revocationTester.removeUserChannel("user", "a")
 	version = rt.UpdateDoc(docID, version, `{"mutate": "mutate", "channels": ["a"]}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 
-	revocationTester.addUserChannel("a")
+	revocationTester.addUserChannel("user", "a")
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 
-	revocationTester.removeUserChannel("a")
+	revocationTester.removeUserChannel("user", "a")
 	version = rt.UpdateDoc(docID, version, `{"mutate": "mutate2", "channels": ["a"]}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 
-	revocationTester.addUserChannel("a")
+	revocationTester.addUserChannel("user", "a")
 	version = rt.UpdateDoc(docID, version, `{"mutate": "mutate3", "channels": ["a"]}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "b")
 	version = rt.UpdateDoc(docID, version, `{"channels": ["b"]}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 
 	revocationTester.removeRoleChannel("foo", "b")
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 	_ = rt.UpdateDoc(docID, version, `{"mutate": "mutate", "channels": ["b"]}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 }
@@ -1362,7 +1362,7 @@ func TestChannelHistoryPruning(t *testing.T) {
 	c := collection.Name
 	s := collection.ScopeName
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "a")
 
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": ["a"]}`)
@@ -1431,26 +1431,26 @@ func TestChannelRevocationWithContiguousSequences(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	revocationTester.addUserChannel("a")
+	revocationTester.addUserChannel("user", "a")
 	const docID = "doc"
 	version := rt.PutDoc(docID, `{"channels": "a"}`)
 	changes := revocationTester.getChanges(0, 2)
 	assert.Len(t, changes.Results, 2)
 
-	revocationTester.removeUserChannel("a")
+	revocationTester.removeUserChannel("user", "a")
 	version = rt.UpdateDoc(docID, version, `{"mutate": "mutate", "channels": "a"}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 	assert.Equal(t, "doc", changes.Results[0].ID)
 	assert.True(t, changes.Results[0].Revoked)
 
-	revocationTester.addUserChannel("a")
+	revocationTester.addUserChannel("user", "a")
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 	assert.Equal(t, "doc", changes.Results[0].ID)
 	assert.False(t, changes.Results[0].Revoked)
 
-	revocationTester.removeUserChannel("a")
+	revocationTester.removeUserChannel("user", "a")
 	_ = rt.UpdateDoc(docID, version, `{"mutate": "mutate2", "channels": "a"}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
@@ -1533,7 +1533,7 @@ func TestReplicatorRevocations(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "chanA")
 
 	resp := rt2.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "chanA"}`)
@@ -1571,7 +1571,7 @@ func TestReplicatorRevocations(t *testing.T) {
 	resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
 	RequireStatus(t, resp, http.StatusOK)
 
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	require.NoError(t, ar.Start(ctx1))
 	rt1.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
@@ -1596,7 +1596,7 @@ func TestReplicatorRevocationsNoRev(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "chanA")
 
 	const doc1ID = "doc1"
@@ -1634,7 +1634,7 @@ func TestReplicatorRevocationsNoRev(t *testing.T) {
 	resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
 	RequireStatus(t, resp, http.StatusOK)
 
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	_ = rt2.UpdateDoc(doc1ID, doc1Version, `{"channels": "chanA", "mutate": "val"}`)
 
@@ -1661,13 +1661,13 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 	revocationTester.addRoleChannel("foo", "chanA")
 
 	resp := rt2.SendAdminRequest("PUT", "/db/_role/foo2", `{}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
-	revocationTester.addRole("foo2")
+	revocationTester.addRole("user", "foo2")
 	revocationTester.addRoleChannel("foo2", "chanB")
 
 	const doc1ID = "doc1"
@@ -1705,7 +1705,7 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 	resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
 	RequireStatus(t, resp, http.StatusOK)
 
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	_ = rt2.UpdateDoc(doc1ID, doc1Version, `{"channels": ["chanA", "chanB"], "mutate": "val"}`)
 
@@ -1753,7 +1753,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
 
-	revocationTester.addRole(revocationTestRole)
+	revocationTester.addRole(revocationTestUser, revocationTestRole)
 	require.NoError(t, rt2.WaitForPendingChanges())
 
 	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
@@ -2237,7 +2237,7 @@ func TestRevocationMessage(t *testing.T) {
 
 	// Add channel to role and role to user
 	revocationTester.addRoleChannel("foo", "A")
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 
 	// Skip to seq 4 and then create doc in channel A
 	revocationTester.fillToSeq(4)
@@ -2254,7 +2254,7 @@ func TestRevocationMessage(t *testing.T) {
 	require.True(t, ok)
 
 	// Remove role from user
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	const doc1ID = "doc1"
 	version = rt.PutDoc(doc1ID, `{"channels": "!"}`)
@@ -2348,7 +2348,7 @@ func TestRevocationNoRev(t *testing.T) {
 
 	// Add channel to role and role to user
 	revocationTester.addRoleChannel("foo", "A")
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 
 	// Skip to seq 4 and then create doc in channel A
 	revocationTester.fillToSeq(4)
@@ -2366,7 +2366,7 @@ func TestRevocationNoRev(t *testing.T) {
 	require.True(t, ok)
 
 	// Remove role from user
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	_ = rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
 
@@ -2442,7 +2442,7 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 
 	// Add channel to role and role to user
 	revocationTester.addRoleChannel("foo", "A")
-	revocationTester.addRole("foo")
+	revocationTester.addRole("user", "foo")
 
 	// Skip to seq 4 and then create doc in channel A
 	revocationTester.fillToSeq(4)
@@ -2460,7 +2460,7 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 	require.True(t, ok)
 
 	// Remove role from user
-	revocationTester.removeFooRole()
+	revocationTester.removeRole("user", "foo")
 
 	_ = rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
 

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -47,20 +47,20 @@ const (
 	revocationTestPassword = "test"
 )
 
-func (tester *ChannelRevocationTester) addRole(user, role string) {
+func (tester *ChannelRevocationTester) addRole(role string) {
 	if tester.roles.Roles == nil {
 		tester.roles.Roles = map[string][]string{}
 	}
 
-	tester.roles.Roles[user] = append(tester.roles.Roles[user], fmt.Sprintf("role:%s", role))
+	tester.roles.Roles[revocationTestUser] = append(tester.roles.Roles[revocationTestUser], fmt.Sprintf("role:%s", role))
 	tester.roleVersion = tester.restTester.UpdateDoc("userRoles", tester.roleVersion, string(mustMarshalJSON(tester.restTester.TB, tester.roles)))
 }
 
-func (tester *ChannelRevocationTester) removeRole(user, role string) {
+func (tester *ChannelRevocationTester) removeFooRole() {
 	delIdx := -1
-	roles := tester.roles.Roles[user]
+	roles := tester.roles.Roles[revocationTestUser]
 	for idx, val := range roles {
-		if val == fmt.Sprintf("role:%s", role) {
+		if val == fmt.Sprintf("role:%s", revocationTestRole) {
 			delIdx = idx
 			break
 		}
@@ -94,18 +94,18 @@ func (tester *ChannelRevocationTester) removeRoleChannel(role, channel string) {
 	tester.roleChannelVersion = tester.restTester.UpdateDoc("roleChannels", tester.roleChannelVersion, string(mustMarshalJSON(tester.restTester.TB, tester.roleChannels)))
 }
 
-func (tester *ChannelRevocationTester) addUserChannel(user, channel string) {
+func (tester *ChannelRevocationTester) addUserChannel(channel string) {
 	if tester.userChannels.Channels == nil {
 		tester.userChannels.Channels = map[string][]string{}
 	}
 
-	tester.userChannels.Channels[user] = append(tester.userChannels.Channels[user], channel)
+	tester.userChannels.Channels[revocationTestUser] = append(tester.userChannels.Channels[revocationTestUser], channel)
 	tester.userChannelVersion = tester.restTester.UpdateDoc("userChannels", tester.userChannelVersion, string(mustMarshalJSON(tester.restTester.TB, tester.userChannels)))
 }
 
-func (tester *ChannelRevocationTester) removeUserChannel(user string, channel string) {
+func (tester *ChannelRevocationTester) removeUserChannel(channel string) {
 	delIdx := -1
-	channelsSlice := tester.userChannels.Channels[user]
+	channelsSlice := tester.userChannels.Channels[revocationTestUser]
 	for idx, val := range channelsSlice {
 		if val == channel {
 			delIdx = idx
@@ -214,7 +214,7 @@ func TestRevocationScenario1(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
@@ -226,11 +226,11 @@ func TestRevocationScenario1(t *testing.T) {
 	assert.Equal(t, "25", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(80)
@@ -241,7 +241,7 @@ func TestRevocationScenario1(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
@@ -265,14 +265,14 @@ func TestRevocationScenario2(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	revocationTester.fillToSeq(50)
 	changes = revocationTester.getChanges(25, 1)
@@ -282,7 +282,7 @@ func TestRevocationScenario2(t *testing.T) {
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(80)
@@ -293,7 +293,7 @@ func TestRevocationScenario2(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
@@ -317,14 +317,14 @@ func TestRevocationScenario3(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 
@@ -334,7 +334,7 @@ func TestRevocationScenario3(t *testing.T) {
 	assert.True(t, changes.Results[0].Revoked)
 
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(80)
@@ -345,7 +345,7 @@ func TestRevocationScenario3(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
@@ -369,18 +369,18 @@ func TestRevocationScenario4(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 
 	revocationTester.fillToSeq(70)
 	changes = revocationTester.getChanges(25, 1)
@@ -397,7 +397,7 @@ func TestRevocationScenario4(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
@@ -421,18 +421,18 @@ func TestRevocationScenario5(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(80)
@@ -443,7 +443,7 @@ func TestRevocationScenario5(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
@@ -467,18 +467,18 @@ func TestRevocationScenario6(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(84)
@@ -491,7 +491,7 @@ func TestRevocationScenario6(t *testing.T) {
 	assert.True(t, changes.Results[0].Revoked)
 
 	revocationTester.fillToSeq(94)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(90, 0)
@@ -514,24 +514,24 @@ func TestRevocationScenario7(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	revocationTester.fillToSeq(100)
 
@@ -561,9 +561,9 @@ func TestRevocationScenario8(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(44)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	revocationTester.fillToSeq(50)
 	changes = revocationTester.getChanges(5, 0)
@@ -572,13 +572,13 @@ func TestRevocationScenario8(t *testing.T) {
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(50, 0)
@@ -601,9 +601,9 @@ func TestRevocationScenario9(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(44)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 
@@ -612,13 +612,13 @@ func TestRevocationScenario9(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(60, 0)
@@ -641,13 +641,13 @@ func TestRevocationScenario10(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(44)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 
 	revocationTester.fillToSeq(70)
 	changes = revocationTester.getChanges(5, 0)
@@ -658,7 +658,7 @@ func TestRevocationScenario10(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(70, 0)
@@ -681,13 +681,13 @@ func TestRevocationScenario11(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(44)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 
@@ -698,7 +698,7 @@ func TestRevocationScenario11(t *testing.T) {
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(80, 1)
@@ -722,13 +722,13 @@ func TestRevocationScenario12(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(44)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(84)
@@ -739,7 +739,7 @@ func TestRevocationScenario12(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(94)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(90, 0)
@@ -762,19 +762,19 @@ func TestRevocationScenario13(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(44)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(64)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
 	revocationTester.fillToSeq(94)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	revocationTester.fillToSeq(100)
 	changes = revocationTester.getChanges(5, 0)
@@ -801,14 +801,14 @@ func TestRevocationScenario14(t *testing.T) {
 	assert.Equal(t, "5", changes.Last_Seq)
 
 	revocationTester.fillToSeq(19)
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 
 	revocationTester.fillToSeq(25)
 	changes = revocationTester.getChanges(5, 1)
 	assert.Equal(t, "20:3", changes.Last_Seq)
 
 	revocationTester.fillToSeq(44)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	changes = revocationTester.getChanges(25, 1)
 	assert.Equal(t, "45:3", changes.Last_Seq)
@@ -823,7 +823,7 @@ func TestEnsureRevocationAfterDocMutation(t *testing.T) {
 
 	// Give role access to channel A and give user access to role
 	revocationTester.addRoleChannel("foo", "A")
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 
 	// Skip to seq 4 Create doc channel A
 	revocationTester.fillToSeq(4)
@@ -837,7 +837,7 @@ func TestEnsureRevocationAfterDocMutation(t *testing.T) {
 
 	// Skip to seq 14 then revoke role from user
 	revocationTester.fillToSeq(14)
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	// Skip to seq 19 and then update doc foo
 	revocationTester.fillToSeq(19)
@@ -859,7 +859,7 @@ func TestEnsureRevocationUsingDocHistory(t *testing.T) {
 
 	// Give role access to channel A and give user access to role
 	revocationTester.addRoleChannel("foo", "A")
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 
 	// Skip to seq 4 Create doc channel A
 	revocationTester.fillToSeq(4)
@@ -954,7 +954,7 @@ func TestRevocationMutationMovesIntoRevokedChannel(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.addRoleChannel("foo", "A")
 
 	revocationTester.fillToSeq(4)
@@ -967,7 +967,7 @@ func TestRevocationMutationMovesIntoRevokedChannel(t *testing.T) {
 	assert.Len(t, changes.Results, 2)
 	assert.Equal(t, doc2ID, changes.Results[1].ID)
 
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 	_ = rt.UpdateDoc(docID, docVersion, `{"channels": ["A"]}`)
 	_ = rt.UpdateDoc(doc2ID, doc2Version, `{"channels": ["A"], "val": "mutate"}`)
 
@@ -986,10 +986,10 @@ func TestRevocationResumeAndLowSeqCheck(t *testing.T) {
 	resp := rt.SendAdminRequest("PUT", "/db/_role/foo2", `{}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.addRoleChannel("foo", "ch1")
 
-	revocationTester.addRole("user", "foo2")
+	revocationTester.addRole("foo2")
 	revocationTester.addRoleChannel("foo2", "ch2")
 
 	revocationTester.fillToSeq(9)
@@ -1040,7 +1040,7 @@ func TestRevocationResumeSameRoleAndLowSeqCheck(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.addRoleChannel("foo", "ch1")
 	revocationTester.addRoleChannel("foo", "ch2")
 
@@ -1103,7 +1103,7 @@ func TestRevocationsWithQueryLimit(t *testing.T) {
 	})
 	defer rt.Close()
 
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	revocationTester.fillToSeq(9)
@@ -1113,7 +1113,7 @@ func TestRevocationsWithQueryLimit(t *testing.T) {
 
 	changes := revocationTester.getChanges("0", 4)
 
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	// Run changes once (which has its own wait)
 	sinceVal := changes.Last_Seq
@@ -1145,9 +1145,9 @@ func TestRevocationsWithQueryLimit2Channels(t *testing.T) {
 	})
 	defer rt.Close()
 
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.addRoleChannel("foo", "ch1")
-	revocationTester.addUserChannel("user", "ch2")
+	revocationTester.addUserChannel("ch2")
 
 	revocationTester.fillToSeq(9)
 	_ = rt.PutDoc("doc1", `{"channels": ["ch1", "ch2"]}`)
@@ -1156,7 +1156,7 @@ func TestRevocationsWithQueryLimit2Channels(t *testing.T) {
 
 	changes := revocationTester.getChanges("0", 4)
 
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	_ = changes.Last_Seq
 	// This changes feed would loop if CBG-3273 was still an issue
@@ -1167,7 +1167,7 @@ func TestRevocationsWithQueryLimit2Channels(t *testing.T) {
 	RequireStatus(t, resp, 200)
 
 	// Revoke access to ch2
-	revocationTester.removeUserChannel("user", "ch2")
+	revocationTester.removeUserChannel("ch2")
 	changes = revocationTester.getChanges(0, 7)
 	// Get a doc to ensure no access
 	resp = rt.SendUserRequestWithHeaders("GET", "/{{.keyspace}}/doc1", "", nil, "user", "test")
@@ -1192,7 +1192,7 @@ func TestRevocationsWithQueryLimitChangesLimit(t *testing.T) {
 	})
 	defer rt.Close()
 
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	revocationTester.fillToSeq(9)
@@ -1202,7 +1202,7 @@ func TestRevocationsWithQueryLimitChangesLimit(t *testing.T) {
 
 	changes := revocationTester.getChanges("0", 4)
 
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	waitForUserChangesWithLimit := func(sinceVal interface{}, limit int) ChangesResults {
 		var changesRes ChangesResults
@@ -1247,7 +1247,7 @@ func TestRevocationUserHasDocAccessDocNotFound(t *testing.T) {
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.addRoleChannel("foo", "A")
 
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc", `{"channels": ["A"]}`)
@@ -1280,7 +1280,7 @@ func TestWasDocInChannelAtSeq(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.addRoleChannel("foo", "a")
 	revocationTester.addRoleChannel("foo", "c")
 
@@ -1318,38 +1318,38 @@ func TestChannelGrantedPeriods(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	revocationTester.addUserChannel("user", "a")
+	revocationTester.addUserChannel("a")
 	const docID = "doc"
 	version := rt.PutDoc(docID, `{"channels": ["a"]}`)
 	changes := revocationTester.getChanges(0, 2)
 	assert.Len(t, changes.Results, 2)
 
-	revocationTester.removeUserChannel("user", "a")
+	revocationTester.removeUserChannel("a")
 	version = rt.UpdateDoc(docID, version, `{"mutate": "mutate", "channels": ["a"]}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 
-	revocationTester.addUserChannel("user", "a")
+	revocationTester.addUserChannel("a")
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 
-	revocationTester.removeUserChannel("user", "a")
+	revocationTester.removeUserChannel("a")
 	version = rt.UpdateDoc(docID, version, `{"mutate": "mutate2", "channels": ["a"]}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 
-	revocationTester.addUserChannel("user", "a")
+	revocationTester.addUserChannel("a")
 	version = rt.UpdateDoc(docID, version, `{"mutate": "mutate3", "channels": ["a"]}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.addRoleChannel("foo", "b")
 	version = rt.UpdateDoc(docID, version, `{"channels": ["b"]}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 
 	revocationTester.removeRoleChannel("foo", "b")
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 	_ = rt.UpdateDoc(docID, version, `{"mutate": "mutate", "channels": ["b"]}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 }
@@ -1362,7 +1362,7 @@ func TestChannelHistoryPruning(t *testing.T) {
 	c := collection.Name
 	s := collection.ScopeName
 
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.addRoleChannel("foo", "a")
 
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": ["a"]}`)
@@ -1431,26 +1431,26 @@ func TestChannelRevocationWithContiguousSequences(t *testing.T) {
 	revocationTester, rt := InitScenario(t, nil)
 	defer rt.Close()
 
-	revocationTester.addUserChannel("user", "a")
+	revocationTester.addUserChannel("a")
 	const docID = "doc"
 	version := rt.PutDoc(docID, `{"channels": "a"}`)
 	changes := revocationTester.getChanges(0, 2)
 	assert.Len(t, changes.Results, 2)
 
-	revocationTester.removeUserChannel("user", "a")
+	revocationTester.removeUserChannel("a")
 	version = rt.UpdateDoc(docID, version, `{"mutate": "mutate", "channels": "a"}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 	assert.Equal(t, "doc", changes.Results[0].ID)
 	assert.True(t, changes.Results[0].Revoked)
 
-	revocationTester.addUserChannel("user", "a")
+	revocationTester.addUserChannel("a")
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
 	assert.Equal(t, "doc", changes.Results[0].ID)
 	assert.False(t, changes.Results[0].Revoked)
 
-	revocationTester.removeUserChannel("user", "a")
+	revocationTester.removeUserChannel("a")
 	_ = rt.UpdateDoc(docID, version, `{"mutate": "mutate2", "channels": "a"}`)
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
@@ -1533,7 +1533,7 @@ func TestReplicatorRevocations(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.addRoleChannel("foo", "chanA")
 
 	resp := rt2.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "chanA"}`)
@@ -1571,7 +1571,7 @@ func TestReplicatorRevocations(t *testing.T) {
 	resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
 	RequireStatus(t, resp, http.StatusOK)
 
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	require.NoError(t, ar.Start(ctx1))
 	rt1.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
@@ -1596,7 +1596,7 @@ func TestReplicatorRevocationsNoRev(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.addRoleChannel("foo", "chanA")
 
 	const doc1ID = "doc1"
@@ -1634,7 +1634,7 @@ func TestReplicatorRevocationsNoRev(t *testing.T) {
 	resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
 	RequireStatus(t, resp, http.StatusOK)
 
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	_ = rt2.UpdateDoc(doc1ID, doc1Version, `{"channels": "chanA", "mutate": "val"}`)
 
@@ -1661,13 +1661,13 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 	revocationTester.addRoleChannel("foo", "chanA")
 
 	resp := rt2.SendAdminRequest("PUT", "/db/_role/foo2", `{}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
-	revocationTester.addRole("user", "foo2")
+	revocationTester.addRole("foo2")
 	revocationTester.addRoleChannel("foo2", "chanB")
 
 	const doc1ID = "doc1"
@@ -1705,7 +1705,7 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 	resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
 	RequireStatus(t, resp, http.StatusOK)
 
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	_ = rt2.UpdateDoc(doc1ID, doc1Version, `{"channels": ["chanA", "chanB"], "mutate": "val"}`)
 
@@ -1753,7 +1753,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
 
-	revocationTester.addRole(revocationTestUser, revocationTestRole)
+	revocationTester.addRole(revocationTestRole)
 	require.NoError(t, rt2.WaitForPendingChanges())
 
 	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
@@ -2237,7 +2237,7 @@ func TestRevocationMessage(t *testing.T) {
 
 	// Add channel to role and role to user
 	revocationTester.addRoleChannel("foo", "A")
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 
 	// Skip to seq 4 and then create doc in channel A
 	revocationTester.fillToSeq(4)
@@ -2254,7 +2254,7 @@ func TestRevocationMessage(t *testing.T) {
 	require.True(t, ok)
 
 	// Remove role from user
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	const doc1ID = "doc1"
 	version = rt.PutDoc(doc1ID, `{"channels": "!"}`)
@@ -2348,7 +2348,7 @@ func TestRevocationNoRev(t *testing.T) {
 
 	// Add channel to role and role to user
 	revocationTester.addRoleChannel("foo", "A")
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 
 	// Skip to seq 4 and then create doc in channel A
 	revocationTester.fillToSeq(4)
@@ -2366,7 +2366,7 @@ func TestRevocationNoRev(t *testing.T) {
 	require.True(t, ok)
 
 	// Remove role from user
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	_ = rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
 
@@ -2442,7 +2442,7 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 
 	// Add channel to role and role to user
 	revocationTester.addRoleChannel("foo", "A")
-	revocationTester.addRole("user", "foo")
+	revocationTester.addRole("foo")
 
 	// Skip to seq 4 and then create doc in channel A
 	revocationTester.fillToSeq(4)
@@ -2460,7 +2460,7 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 	require.True(t, ok)
 
 	// Remove role from user
-	revocationTester.removeRole("user", "foo")
+	revocationTester.removeFooRole()
 
 	_ = rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
 


### PR DESCRIPTION
- Switch uses of explicitly rev checks to `PutDoc` and `UpdateDoc` when appropriate.
- For branching revisions, adapted `PutNewEditsFalse` to allow putting specific versions. Much of this code won't work with HLV, but it seemed easier to port this anyway, and if we do keep this code.
- switch some cases from `t.Run` to `rt.Run` to make assertions not panic

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2147/ ( one test failed, fixed in 2812910)
