### PR TITLE
CBG-3585 log bucket and groupID during config search

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -1467,11 +1467,11 @@ func (sc *ServerContext) migrateV30Configs(ctx context.Context) error {
 			continue
 		}
 
-		base.InfofCtx(ctx, base.KeyConfig, "Found legacy persisted config for database %s - migrating to db registry.", base.MD(dbConfig.Name))
+		base.InfofCtx(ctx, base.KeyConfig, "Found legacy persisted config for database %s in bucket %s, groupID %s - migrating to db registry.", base.MD(dbConfig.Name), base.MD(bucketName), base.MD(groupID))
 		_, insertErr := sc.BootstrapContext.InsertConfig(ctx, bucketName, groupID, &dbConfig)
 		if insertErr != nil {
 			if insertErr == base.ErrAlreadyExists {
-				base.DebugfCtx(ctx, base.KeyConfig, "Found legacy config for database %s, but already exists in registry.", base.MD(dbConfig.Name))
+				base.DebugfCtx(ctx, base.KeyConfig, "Found legacy config for database %s in bucket %s, groupID: %s, but already exists in registry.", base.MD(dbConfig.Name), base.MD(bucketName), base.MD(groupID))
 			} else {
 				base.InfofCtx(ctx, base.KeyConfig, "Unable to persist migrated v3.0 config for bucket %s groupID %s: %s", base.MD(bucketName), base.MD(groupID), insertErr)
 				continue
@@ -1479,7 +1479,7 @@ func (sc *ServerContext) migrateV30Configs(ctx context.Context) error {
 		}
 		removeErr := sc.BootstrapContext.Connection.DeleteMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), legacyCas)
 		if removeErr != nil {
-			base.InfofCtx(ctx, base.KeyConfig, "Failed to remove legacy config for database %s: %s", base.MD(dbConfig.Name), removeErr)
+			base.InfofCtx(ctx, base.KeyConfig, "Failed to remove legacy config for database %s in bucket %s, groupID %s: %s", base.MD(dbConfig.Name), base.MD(bucketName), base.MD(groupID), base.MD(removeErr))
 		}
 	}
 	return nil
@@ -1564,7 +1564,7 @@ func (sc *ServerContext) _fetchDatabase(ctx context.Context, dbName string) (fou
 			cnf.CertPath = sc.Config.Bootstrap.X509CertPath
 			cnf.KeyPath = sc.Config.Bootstrap.X509KeyPath
 		}
-		base.TracefCtx(ctx, base.KeyConfig, "Got config for bucket %q with cas %d", bucket, cas)
+		base.TracefCtx(ctx, base.KeyConfig, "Got database config %s for bucket %q with cas %d and groupID %q", base.MD(dbName), base.MD(bucket), cas, base.MD(sc.Config.Bootstrap.ConfigGroupID))
 		return true, nil
 	}
 
@@ -1686,20 +1686,20 @@ func (sc *ServerContext) FetchConfigs(ctx context.Context, isInitialStartup bool
 	fetchedConfigs := make(map[string]DatabaseConfig, len(buckets))
 	for _, bucket := range buckets {
 
-		base.TracefCtx(ctx, base.KeyConfig, "Checking for configs for group %q from bucket %q", sc.Config.Bootstrap.ConfigGroupID, bucket)
+		base.TracefCtx(ctx, base.KeyConfig, "Checking for configs for group %q from bucket %q", sc.Config.Bootstrap.ConfigGroupID, base.MD(bucket))
 		configs, err := sc.BootstrapContext.GetDatabaseConfigs(ctx, bucket, sc.Config.Bootstrap.ConfigGroupID)
 		if err != nil {
 			// Unexpected error fetching config - SDK has already performed retries, so we'll treat it as a registry removal
 			// this could be due to invalid JSON or some other non-recoverable error.
 			if isInitialStartup {
-				base.WarnfCtx(ctx, "Unable to fetch config for group %q from bucket %q on startup: %v", sc.Config.Bootstrap.ConfigGroupID, bucket, err)
+				base.WarnfCtx(ctx, "Unable to fetch configs for group %q from bucket %q on startup: %v", sc.Config.Bootstrap.ConfigGroupID, base.MD(bucket), err)
 			} else {
-				base.DebugfCtx(ctx, base.KeyConfig, "Unable to fetch config for group %q from bucket %q: %v", sc.Config.Bootstrap.ConfigGroupID, bucket, err)
+				base.DebugfCtx(ctx, base.KeyConfig, "Unable to fetch configs for group %q from bucket %q: %v", sc.Config.Bootstrap.ConfigGroupID, base.MD(bucket), err)
 			}
 			continue
 		}
 		if len(configs) == 0 {
-			base.DebugfCtx(ctx, base.KeyConfig, "Bucket %q did not contain config for group %q", bucket, sc.Config.Bootstrap.ConfigGroupID)
+			base.DebugfCtx(ctx, base.KeyConfig, "Bucket %q did not contain any configs for group %q", base.MD(bucket), sc.Config.Bootstrap.ConfigGroupID)
 			continue
 		}
 		for _, cnf := range configs {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2060,7 +2060,7 @@ func (sc *ServerContext) initializeCouchbaseServerConnections(ctx context.Contex
 		}
 
 		if count > 0 {
-			base.InfofCtx(ctx, base.KeyConfig, "Successfully fetched %d database configs from buckets in cluster", count)
+			base.InfofCtx(ctx, base.KeyConfig, "Successfully fetched %d database configs for group %q from buckets in cluster", count, sc.Config.Bootstrap.ConfigGroupID)
 		} else {
 			base.WarnfCtx(ctx, "Config: No database configs for group %q. Continuing startup to allow REST API database creation", sc.Config.Bootstrap.ConfigGroupID)
 		}
@@ -2083,10 +2083,10 @@ func (sc *ServerContext) initializeCouchbaseServerConnections(ctx context.Contex
 						base.DebugfCtx(ctx, base.KeyConfig, "Fetching configs from buckets in cluster for group %q", sc.Config.Bootstrap.ConfigGroupID)
 						count, err := sc.fetchAndLoadConfigs(ctx, false)
 						if err != nil {
-							base.WarnfCtx(ctx, "Couldn't load configs from bucket when polled: %v", err)
+							base.WarnfCtx(ctx, "Couldn't load configs from bucket for group %q when polled: %v", sc.Config.Bootstrap.ConfigGroupID, err)
 						}
 						if count > 0 {
-							base.InfofCtx(ctx, base.KeyConfig, "Successfully fetched %d database configs from buckets in cluster", count)
+							base.InfofCtx(ctx, base.KeyConfig, "Successfully fetched %d database configs for group %d from buckets in cluster", count, sc.Config.Bootstrap.ConfigGroupID)
 						}
 					}
 				}


### PR DESCRIPTION
This makes it a bit more clear which bucket a config error might come from. I added groupID to these logs as well, since they are logged by some lines in these functions but not all.