### PR TITLE
CBG-2979 remove unused fields and docs for GET /db/

### DIFF
--- a/docs/api/paths/admin/db-.yaml
+++ b/docs/api/paths/admin/db-.yaml
@@ -66,30 +66,6 @@ get:
                 description: Unique server identifier.
                 type: string
                 example: 995618a6a6cc9ac79731bd13240e19b5
-              scopes:
-                description: 'Scopes that are used by the database.'
-                type: object
-                example:
-                  scope1:
-                    collections:
-                      collection1:
-                        update_seq: 123456
-                      collection2:
-                        update_seq: 654321
-                additionalProperties:
-                  description: 'The name of the scope.'
-                  type: object
-                  properties:
-                    collections:
-                      description: 'The set of collections within the scope.'
-                      additionalProperties:
-                        description: 'The name of the collection.'
-                        type: object
-                        properties:
-                          update_seq:
-                            description: 'The last sequence number that was committed to the collection.'
-                            type: integer
-                            example: 123456
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:


### PR DESCRIPTION
sequence numbers are global to all collections, and the scopes parameter was never populated in GET /db

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2156/
